### PR TITLE
Fix compilation with GCC 12/13

### DIFF
--- a/device/tt_cluster_descriptor.h
+++ b/device/tt_cluster_descriptor.h
@@ -9,6 +9,7 @@
 
 #include "device/tt_xy_pair.h"
 
+#include <cstdint>
 #include <unordered_map>
 #include <unordered_set>
 #include <set>

--- a/device/tt_soc_descriptor.h
+++ b/device/tt_soc_descriptor.h
@@ -14,6 +14,7 @@
 
 #include <iostream>
 #include <string>
+#include <cstdint>
 
 #include "tt_xy_pair.h"
 #include "device/tt_arch_types.h"


### PR DESCRIPTION
See title - there were forgotten `#include`'s of C++ standard library headers which break compilation with recent versions of GCC.