### PR TITLE
Add API for fast 32-bit writes to static TLBs

### DIFF
--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -19,6 +19,8 @@
 #include "device/tt_cluster_descriptor_types.h"
 #include "device/tlb.h"
 
+#include "device/tt_io.hpp"
+
 using TLB_OFFSETS = tt::umd::tlb_offsets;
 using TLB_DATA = tt::umd::tlb_data;
 
@@ -807,16 +809,16 @@ class tt_SiliconDevice: public tt_device
     std::function<void(uint32_t, uint32_t, const uint8_t*, uint32_t)> get_fast_pcie_static_tlb_write_callable(int device_id);
 
     /**
-     * @brief Provides fast four-byte write access to a statically-mapped TLB.
+     * @brief Provides fast write access to a statically-mapped TLB.
      * It is the caller's responsibility to ensure that:
      * - the target has a static TLB mapping configured.
-     * - the mapping is unchanged during the lifetime of the returned function.
-     * - the tt_SiliconDevice instance outlives the returned function.
+     * - the mapping is unchanged during the lifetime of the returned object.
+     * - the tt_SiliconDevice instance outlives the returned object.
      * @param target The target chip and core to write to.
      * @throws std::runtime_error on error.
-     * @returns a function with signature `void write32(uint32_t addr, uint32_t data)`
+     * @returns a Writer instance that can be used to write to the target.
      */
-    std::function<void(uint32_t /*addr*/, uint32_t /*val*/)> get_static_tlb_write32_callable(tt_cxy_pair target);
+    tt::Writer get_static_tlb_write_callable(tt_cxy_pair target);
 
     /**
      * @brief Returns the DMA buf size 

--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -805,6 +805,19 @@ class tt_SiliconDevice: public tt_device
      * @brief This API allows you to write directly to device memory that is addressable by a static TLB
     */
     std::function<void(uint32_t, uint32_t, const uint8_t*, uint32_t)> get_fast_pcie_static_tlb_write_callable(int device_id);
+
+    /**
+     * @brief Provides fast four-byte write access to a statically-mapped TLB.
+     * It is the caller's responsibility to ensure that:
+     * - the target has a static TLB mapping configured.
+     * - the mapping is unchanged during the lifetime of the returned function.
+     * - the tt_SiliconDevice instance outlives the returned function.
+     * @param target The target chip and core to write to.
+     * @throws std::runtime_error on error.
+     * @returns a function with signature `void write32(uint32_t addr, uint32_t data)`
+     */
+    std::function<void(uint32_t /*addr*/, uint32_t /*val*/)> get_static_tlb_write32_callable(tt_cxy_pair target);
+
     /**
      * @brief Returns the DMA buf size 
     */

--- a/device/tt_io.hpp
+++ b/device/tt_io.hpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+#include <stdexcept>
+
+class tt_SiliconDevice;
+
+namespace tt {
+
+class Writer
+{
+    friend class ::tt_SiliconDevice;
+
+public:
+    template <class T>
+    void write(uint32_t address, T value)
+    {
+        auto dst = reinterpret_cast<uintptr_t>(base) + address;
+
+        if (address >= tlb_size) {
+            throw std::runtime_error("Address out of bounds for TLB");
+        }
+
+        if (alignof(T) > 1 && (dst & (alignof(T) - 1))) {
+            throw std::runtime_error("Unaligned write");
+        }
+
+        *reinterpret_cast<volatile T*>(dst) = value;
+    }
+
+private:
+    /**
+     * @brief Provides write access to a SoC core via a statically-mapped TLB.
+     * 
+     * @param base 
+     * @param range 
+     */
+    Writer(void *base, size_t tlb_size)
+        : base(base)
+        , tlb_size(tlb_size)
+    {
+        assert(base);
+        assert(tlb_size > 0);
+    }
+
+    void *base{ nullptr };
+    size_t tlb_size{ 0 };
+};
+
+
+} // namespace tt

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -2085,6 +2085,44 @@ std::function<void(uint32_t, uint32_t, const uint8_t*, uint32_t)> tt_SiliconDevi
     return callable;
 }
 
+std::function<void(uint32_t, uint32_t)> tt_SiliconDevice::get_static_tlb_write32_callable(tt_cxy_pair target) {
+    if (!ndesc->is_chip_mmio_capable(target.chip)) {
+        throw std::runtime_error("Target not in MMIO chip: " + target.str());
+    }
+
+    if (!tlbs_init || !map_core_to_tlb) {
+        throw std::runtime_error("TLBs not initialized");
+    }
+
+    auto *pci_device = get_pci_device(target.chip);
+    auto *dev = pci_device->hdev;
+    auto tlb_index = map_core_to_tlb(tt_xy_pair(target.x, target.y));
+    auto tlb_data = dev->get_architecture_implementation()->describe_tlb(tlb_index);
+
+    if (!tlb_data.has_value()) {
+        throw std::runtime_error("No TLB mapped to core " + target.str());
+    }
+
+    if (!dev->bar0_wc) {
+        throw std::runtime_error("No write-combined mapping for BAR0");
+    }
+
+    const auto callable = [dev, tlb_data](uint32_t address, uint32_t value) {
+        auto [tlb_offset, tlb_size] = tlb_data.value();
+
+        if (address >= tlb_size) {
+            throw std::runtime_error("Address out of bounds for TLB");
+        }
+
+        auto *wc = reinterpret_cast<uint8_t *>(dev->bar0_wc);
+        auto *ptr = reinterpret_cast<volatile uint32_t *>(wc + tlb_offset + address);
+        *ptr = value;
+        tt_driver_atomics::sfence();
+    };
+
+    return callable;
+}
+
 void tt_SiliconDevice::write_device_memory(const void *mem_ptr, uint32_t size_in_bytes, tt_cxy_pair target, std::uint32_t address, const std::string& fallback_tlb) {
     struct PCIdevice* pci_device = get_pci_device(target.chip);
     TTDevice *dev = pci_device->hdev;


### PR DESCRIPTION
Existing code paths for performing such a write suffer from limitations: The "REG_TLB" path reconfigures a single 16M TLB and performs multiple hash table lookups (costing on the order of hundreds of nanoseconds each) prior to performing the write (on the order of tens of nanoseconds).  The non "REG_TLB" path can take two directions: use of an alternate 16M TLB (incurring the same performance penalty) or use of a statically-mapped TLB (if such a mapping exists).  These paths contain read-modify-write logic which may result in unexpected system behavior.

This change adds a mechanism that is patterned after the existing `get_fast_pcie_static_tlb_write_callable` API.  The intent is for callers requiring fast 32-bit write access to a specific core to create and maintain a write32 function using this new API.  The API is designed so that the resulting function can be called in a hot path.