### PR TITLE
Add API for fast writes to static TLBs

### DIFF
--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -18,6 +18,7 @@
 #include "tt_silicon_driver_common.hpp"
 #include "device/tt_cluster_descriptor_types.h"
 #include "device/tlb.h"
+#include "device/tt_io.hpp"
 
 using TLB_OFFSETS = tt::umd::tlb_offsets;
 using TLB_DATA = tt::umd::tlb_data;
@@ -809,6 +810,20 @@ class tt_SiliconDevice: public tt_device
      * @brief This API allows you to write directly to device memory that is addressable by a static TLB
     */
     std::function<void(uint32_t, uint32_t, const uint8_t*, uint32_t)> get_fast_pcie_static_tlb_write_callable(int device_id);
+
+    /**
+     * @brief Provide fast write access to a statically-mapped TLB.
+     * It is the caller's responsibility to ensure that
+     * - the target has a static TLB mapping configured.
+     * - the mapping is unchanged during the lifetime of the returned object.
+     * - the tt_SiliconDevice instance outlives the returned object.
+     * - use of the returned object is congruent with the target's TLB setup.
+     * @param target The target chip and core to write to.
+     * @throws std::runtime_error on error.
+     * @returns a Writer instance that can be used to write to the target.
+     */
+    tt::Writer get_static_tlb_writer(tt_cxy_pair target);
+
     /**
      * @brief Returns the DMA buf size 
     */

--- a/device/tt_io.hpp
+++ b/device/tt_io.hpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+#include <stdexcept>
+
+class tt_SiliconDevice;
+
+namespace tt {
+
+/**
+ * @brief Provides write access to a SoC core via a statically-mapped TLB.
+ *
+ * TLB refers to the aperture within the device BAR that is mapped to a NOC
+ * endpoint (i.e. an (X, Y) location + address) within the chip.
+ *
+ * It is the caller's responsibility to manage the lifetime of Writer objects.
+ */
+class Writer
+{
+    friend class ::tt_SiliconDevice;
+
+public:
+    /**
+     * @brief Write to a SoC core.
+     * 
+     * @param address must be aligned to the size of T
+     * @param value 
+     */
+    template <class T>
+    void write(uint32_t address, T value)
+    {
+        auto dst = reinterpret_cast<uintptr_t>(base) + address;
+
+        if (address >= tlb_size) {
+            throw std::runtime_error("Address out of bounds for TLB");
+        }
+
+        if (alignof(T) > 1 && (dst & (alignof(T) - 1))) {
+            throw std::runtime_error("Unaligned write");
+        }
+
+        *reinterpret_cast<volatile T*>(dst) = value;
+    }
+
+private:
+    /**
+     * @brief tt_SiliconDriver interface to construct a new Writer object.
+     * 
+     * @param base pointer to the base address of a mapped TLB.
+     * @param tlb_size size of the mapped TLB.
+     */
+    Writer(void *base, size_t tlb_size)
+        : base(base)
+        , tlb_size(tlb_size)
+    {
+        assert(base);
+        assert(tlb_size > 0);
+    }
+
+    void *base{ nullptr };
+    size_t tlb_size{ 0 };
+};
+
+
+} // namespace tt


### PR DESCRIPTION
Existing code paths for performing such a write suffer from limitations: The "REG_TLB" path reconfigures a single 16M TLB and performs multiple hash table lookups (costing on the order of hundreds of nanoseconds each) prior to performing the write (on the order of tens of nanoseconds). The non "REG_TLB" path can take two directions: use of an alternate 16M TLB (incurring the same performance penalty) or use of a statically-mapped TLB (if such a mapping exists). These paths contain read-modify-write logic which may result in unexpected system behavior.

This change adds an API where the cost for hash table lookups is paid up-front. The intent is for callers requiring fast write access to a specific core to create and maintain a Writer object using this new API.