### PR TITLE
BH Static TLB changes for worker cores

### DIFF
--- a/device/architecture_implementation.h
+++ b/device/architecture_implementation.h
@@ -37,6 +37,8 @@ class architecture_implementation {
     virtual uint32_t get_dram_channel_0_x() const = 0;
     virtual uint32_t get_dram_channel_0_y() const = 0;
     virtual uint32_t get_broadcast_tlb_index() const = 0;
+    virtual uint32_t get_dynamic_tlb_2m_base() const = 0;
+    virtual uint32_t get_dynamic_tlb_2m_size() const = 0;
     virtual uint32_t get_dynamic_tlb_16m_base() const = 0;
     virtual uint32_t get_dynamic_tlb_16m_size() const = 0;
     virtual uint32_t get_dynamic_tlb_16m_cfg_addr() const = 0;

--- a/device/blackhole_implementation.h
+++ b/device/blackhole_implementation.h
@@ -105,6 +105,8 @@ static constexpr uint32_t TLB_BASE_2M = 0;
 static constexpr uint32_t TLB_BASE_INDEX_2M = 0;
 static constexpr uint32_t TLB_2M_SIZE = 2 * 1024 * 1024;
 
+static constexpr uint32_t DYNAMIC_TLB_COUNT = 16;
+
 static constexpr uint32_t TLB_CFG_REG_SIZE_BYTES = 12;
 static constexpr uint32_t DYNAMIC_TLB_2M_SIZE = 2 * 1024 * 1024;
 static constexpr uint32_t DYNAMIC_TLB_2M_CFG_ADDR = STATIC_TLB_CFG_ADDR + (TLB_BASE_INDEX_2M * TLB_CFG_REG_SIZE_BYTES);
@@ -121,7 +123,7 @@ static constexpr unsigned int MEM_SMALL_READ_WRITE_TLB = TLB_BASE_INDEX_2M + 194
 static constexpr uint32_t DYNAMIC_TLB_BASE_INDEX = TLB_BASE_INDEX_2M + 190;
 
 static constexpr uint32_t DRAM_CHANNEL_0_X = 0;
-static constexpr uint32_t DRAM_CHANNEL_0_Y = 0;
+static constexpr uint32_t DRAM_CHANNEL_0_Y = 1;
 static constexpr uint32_t DRAM_CHANNEL_0_PEER2PEER_REGION_START = 0x30000000;  // This is the last 256MB of DRAM
 
 static constexpr uint32_t GRID_SIZE_X = 17;
@@ -178,13 +180,15 @@ class blackhole_implementation : public architecture_implementation {
     uint32_t get_dram_channel_0_x() const override { return blackhole::DRAM_CHANNEL_0_X; }
     uint32_t get_dram_channel_0_y() const override { return blackhole::DRAM_CHANNEL_0_Y; }
     uint32_t get_broadcast_tlb_index() const override { return blackhole::BROADCAST_TLB_INDEX; }
+    uint32_t get_dynamic_tlb_2m_base() const override { return blackhole::DYNAMIC_TLB_2M_BASE; }
+    uint32_t get_dynamic_tlb_2m_size() const override { return blackhole::DYNAMIC_TLB_2M_SIZE; }
     uint32_t get_dynamic_tlb_16m_base() const override { throw std::runtime_error("No 16MB TLBs for Blackhole arch"); return 0; }
     uint32_t get_dynamic_tlb_16m_size() const override { throw std::runtime_error("No 16MB TLBs for Blackhole arch"); return 0; }
     uint32_t get_dynamic_tlb_16m_cfg_addr() const override { throw std::runtime_error("No 16MB TLBs for Blackhole arch"); return 0; }
     uint32_t get_mem_large_read_tlb() const override { return blackhole::MEM_LARGE_READ_TLB; }
     uint32_t get_mem_large_write_tlb() const override { return blackhole::MEM_LARGE_WRITE_TLB; }
-    uint32_t get_static_tlb_cfg_addr() const override { throw std::runtime_error("No static TLBs for Blackhole arch"); return 0; }
-    uint32_t get_static_tlb_size() const override { throw std::runtime_error("No static TLBs for Blackhole arch"); return 0;  }
+    uint32_t get_static_tlb_cfg_addr() const override { return blackhole::STATIC_TLB_CFG_ADDR; }
+    uint32_t get_static_tlb_size() const override { return blackhole::STATIC_TLB_SIZE;  }
     uint32_t get_reg_tlb() const override { return blackhole::REG_TLB; }
     uint32_t get_tlb_base_index_16m() const override { throw std::runtime_error("No 16MB TLBs for Blackhole arch"); return 0;  }
     uint32_t get_tensix_soft_reset_addr() const override { return blackhole::TENSIX_SOFT_RESET_ADDR; }

--- a/device/blackhole_implementation.h
+++ b/device/blackhole_implementation.h
@@ -115,12 +115,12 @@ static constexpr uint32_t DYNAMIC_TLB_2M_BASE = TLB_BASE_2M;
 // REG_TLB for dynamic writes to registers. They are aligned with the kernel driver's WC/UC split.  But kernel driver
 // uses different TLB's for these.
 // Revisit for BH
-
 static constexpr unsigned int REG_TLB = TLB_BASE_INDEX_2M + 191;
-static constexpr unsigned int MEM_LARGE_WRITE_TLB = TLB_BASE_INDEX_2M + 192;
-static constexpr unsigned int MEM_LARGE_READ_TLB = TLB_BASE_INDEX_2M + 193;
-static constexpr unsigned int MEM_SMALL_READ_WRITE_TLB = TLB_BASE_INDEX_2M + 194;
-static constexpr uint32_t DYNAMIC_TLB_BASE_INDEX = TLB_BASE_INDEX_2M + 190;
+
+static constexpr uint32_t DYNAMIC_TLB_BASE_INDEX = TLB_BASE_INDEX_2M + 180;
+static constexpr unsigned int MEM_LARGE_WRITE_TLB = TLB_BASE_INDEX_2M + 181;
+static constexpr unsigned int MEM_LARGE_READ_TLB = TLB_BASE_INDEX_2M + 182;
+static constexpr unsigned int MEM_SMALL_READ_WRITE_TLB = TLB_BASE_INDEX_2M + 183;
 
 static constexpr uint32_t DRAM_CHANNEL_0_X = 0;
 static constexpr uint32_t DRAM_CHANNEL_0_Y = 1;

--- a/device/grayskull_implementation.h
+++ b/device/grayskull_implementation.h
@@ -205,6 +205,8 @@ class grayskull_implementation : public architecture_implementation {
     uint32_t get_dram_channel_0_x() const override { return grayskull::DRAM_CHANNEL_0_X; }
     uint32_t get_dram_channel_0_y() const override { return grayskull::DRAM_CHANNEL_0_Y; }
     uint32_t get_broadcast_tlb_index() const override { return grayskull::BROADCAST_TLB_INDEX; }
+    uint32_t get_dynamic_tlb_2m_base() const override { return grayskull::DYNAMIC_TLB_2M_BASE; }
+    uint32_t get_dynamic_tlb_2m_size() const override { return grayskull::DYNAMIC_TLB_2M_SIZE; }
     uint32_t get_dynamic_tlb_16m_base() const override { return grayskull::DYNAMIC_TLB_16M_BASE; }
     uint32_t get_dynamic_tlb_16m_size() const override { return grayskull::DYNAMIC_TLB_16M_SIZE; }
     uint32_t get_dynamic_tlb_16m_cfg_addr() const override { return grayskull::DYNAMIC_TLB_16M_CFG_ADDR; }

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -3063,8 +3063,8 @@ void *tt_SiliconDevice::channel_0_address(std::uint32_t offset, std::uint32_t de
     // Temporary hack for blackhole bringup.
     if (arch_name == tt::ARCH::BLACKHOLE) {
         // Use 195th 2MB TLB onwards.
-        // TLBs up to 195 are used as static or fallback TLBs.
-        const std::uint32_t TLB_CH0_START = 195;
+        // TLBs up to 184 are used as static or fallback TLBs.
+        const std::uint32_t TLB_CH0_START = 184;
         bar0_offset = offset - architecture_implementation->get_dram_channel_0_peer2peer_region_start()
                         + architecture_implementation->get_dynamic_tlb_2m_base() + (TLB_CH0_START * architecture_implementation->get_dynamic_tlb_2m_size());
 

--- a/device/wormhole_implementation.h
+++ b/device/wormhole_implementation.h
@@ -238,6 +238,8 @@ class wormhole_implementation : public architecture_implementation {
     uint32_t get_dram_channel_0_x() const override { return wormhole::DRAM_CHANNEL_0_X; }
     uint32_t get_dram_channel_0_y() const override { return wormhole::DRAM_CHANNEL_0_Y; }
     uint32_t get_broadcast_tlb_index() const override { return wormhole::BROADCAST_TLB_INDEX; }
+    uint32_t get_dynamic_tlb_2m_base() const override { return wormhole::DYNAMIC_TLB_2M_BASE; }
+    uint32_t get_dynamic_tlb_2m_size() const override { return wormhole::DYNAMIC_TLB_2M_SIZE; }
     uint32_t get_dynamic_tlb_16m_base() const override { return wormhole::DYNAMIC_TLB_16M_BASE; }
     uint32_t get_dynamic_tlb_16m_size() const override { return wormhole::DYNAMIC_TLB_16M_SIZE; }
     uint32_t get_dynamic_tlb_16m_cfg_addr() const override { return wormhole::DYNAMIC_TLB_16M_CFG_ADDR; }


### PR DESCRIPTION
Part of larger effort on Budabackend to bring up and test Blackhole.

This PR adds Blackhole specific functions for TLBs. It also removes assertions for usage of static TLBs for Blackhole, which were added during initial Blackhole bringup.

[Issue on BBE for core static TLBs](https://yyz-gitlab.local.tenstorrent.com/tenstorrent/budabackend/-/issues/2653)