### PR TITLE
Blackhole 4GB tlbs

### DIFF
--- a/device/architecture_implementation.h
+++ b/device/architecture_implementation.h
@@ -37,6 +37,8 @@ class architecture_implementation {
     virtual uint32_t get_dram_channel_0_x() const = 0;
     virtual uint32_t get_dram_channel_0_y() const = 0;
     virtual uint32_t get_broadcast_tlb_index() const = 0;
+    virtual uint32_t get_dynamic_tlb_2m_base() const = 0;
+    virtual uint32_t get_dynamic_tlb_2m_size() const = 0;
     virtual uint32_t get_dynamic_tlb_16m_base() const = 0;
     virtual uint32_t get_dynamic_tlb_16m_size() const = 0;
     virtual uint32_t get_dynamic_tlb_16m_cfg_addr() const = 0;

--- a/device/architecture_implementation.h
+++ b/device/architecture_implementation.h
@@ -59,7 +59,7 @@ class architecture_implementation {
 
     virtual std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const = 0;
     virtual tlb_configuration get_tlb_configuration(uint32_t tlb_index) const = 0;
-    virtual std::optional<std::tuple<std::uint32_t, std::uint32_t>> describe_tlb(std::int32_t tlb_index) const = 0;
+    virtual std::optional<std::tuple<std::uint64_t, std::uint64_t>> describe_tlb(std::int32_t tlb_index) const = 0;
     virtual std::pair<std::uint64_t, std::uint64_t> get_tlb_data(std::uint32_t tlb_index, const tlb_data& data) const = 0;
 
     static std::unique_ptr<architecture_implementation> create(architecture architecture);

--- a/device/blackhole_implementation.h
+++ b/device/blackhole_implementation.h
@@ -105,6 +105,8 @@ static constexpr uint32_t TLB_BASE_2M = 0;
 static constexpr uint32_t TLB_BASE_INDEX_2M = 0;
 static constexpr uint32_t TLB_2M_SIZE = 2 * 1024 * 1024;
 
+static constexpr uint32_t DYNAMIC_TLB_COUNT = 16;
+
 static constexpr uint32_t TLB_CFG_REG_SIZE_BYTES = 12;
 static constexpr uint32_t DYNAMIC_TLB_2M_SIZE = 2 * 1024 * 1024;
 static constexpr uint32_t DYNAMIC_TLB_2M_CFG_ADDR = STATIC_TLB_CFG_ADDR + (TLB_BASE_INDEX_2M * TLB_CFG_REG_SIZE_BYTES);
@@ -121,7 +123,7 @@ static constexpr unsigned int MEM_SMALL_READ_WRITE_TLB = TLB_BASE_INDEX_2M + 194
 static constexpr uint32_t DYNAMIC_TLB_BASE_INDEX = TLB_BASE_INDEX_2M + 190;
 
 static constexpr uint32_t DRAM_CHANNEL_0_X = 0;
-static constexpr uint32_t DRAM_CHANNEL_0_Y = 0;
+static constexpr uint32_t DRAM_CHANNEL_0_Y = 1;
 static constexpr uint32_t DRAM_CHANNEL_0_PEER2PEER_REGION_START = 0x30000000;  // This is the last 256MB of DRAM
 
 static constexpr uint32_t GRID_SIZE_X = 17;
@@ -178,13 +180,15 @@ class blackhole_implementation : public architecture_implementation {
     uint32_t get_dram_channel_0_x() const override { return blackhole::DRAM_CHANNEL_0_X; }
     uint32_t get_dram_channel_0_y() const override { return blackhole::DRAM_CHANNEL_0_Y; }
     uint32_t get_broadcast_tlb_index() const override { return blackhole::BROADCAST_TLB_INDEX; }
+    uint32_t get_dynamic_tlb_2m_base() const override { return blackhole::DYNAMIC_TLB_2M_BASE; }
+    uint32_t get_dynamic_tlb_2m_size() const override { return blackhole::DYNAMIC_TLB_2M_SIZE; }
     uint32_t get_dynamic_tlb_16m_base() const override { throw std::runtime_error("No 16MB TLBs for Blackhole arch"); return 0; }
     uint32_t get_dynamic_tlb_16m_size() const override { throw std::runtime_error("No 16MB TLBs for Blackhole arch"); return 0; }
     uint32_t get_dynamic_tlb_16m_cfg_addr() const override { throw std::runtime_error("No 16MB TLBs for Blackhole arch"); return 0; }
     uint32_t get_mem_large_read_tlb() const override { return blackhole::MEM_LARGE_READ_TLB; }
     uint32_t get_mem_large_write_tlb() const override { return blackhole::MEM_LARGE_WRITE_TLB; }
-    uint32_t get_static_tlb_cfg_addr() const override { throw std::runtime_error("No static TLBs for Blackhole arch"); return 0; }
-    uint32_t get_static_tlb_size() const override { throw std::runtime_error("No static TLBs for Blackhole arch"); return 0;  }
+    uint32_t get_static_tlb_cfg_addr() const override { return blackhole::STATIC_TLB_CFG_ADDR; }
+    uint32_t get_static_tlb_size() const override { return blackhole::STATIC_TLB_SIZE;  }
     uint32_t get_reg_tlb() const override { return blackhole::REG_TLB; }
     uint32_t get_tlb_base_index_16m() const override { throw std::runtime_error("No 16MB TLBs for Blackhole arch"); return 0;  }
     uint32_t get_tensix_soft_reset_addr() const override { return blackhole::TENSIX_SOFT_RESET_ADDR; }

--- a/device/blackhole_implementation.h
+++ b/device/blackhole_implementation.h
@@ -30,6 +30,19 @@ static constexpr auto TLB_2M_OFFSET = tlb_offsets{
     // missing .stream_header
     .static_vc_end = 75};
 
+static constexpr auto TLB_4G_OFFSET = tlb_offsets{
+    .local_offset = 0,
+    .x_end = 32,
+    .y_end = 38,
+    .x_start = 44,
+    .y_start = 50,
+    .noc_sel = 56,
+    .mcast = 58,
+    .ordering = 59,
+    .linked = 61,
+    .static_vc = 62,
+    // missing .stream_header
+    .static_vc_end = 64};
 
 enum class arc_message_type {
     NOP = 0x11,  // Do nothing
@@ -70,6 +83,33 @@ static constexpr std::array<xy_pair, 24> DRAM_LOCATIONS = {
      {9, 9},
      {9, 10},
      {9, 11}}};
+
+static constexpr std::array<xy_pair, 24> DRAM_LOCATIONS_4GB = {
+    {{0, 0},
+     {0, 1},
+     {0, 11},
+     {0, 2},
+     {0, 10},
+     {0, 3},
+     {0, 9},
+     {0, 4},
+     {0, 8},
+     {0, 5},
+     {0, 7},
+     {0, 6},
+     {9, 0},
+     {9, 1},
+     {9, 11},
+     {9, 2},
+     {9, 10},
+     {9, 3},
+     {9, 9},
+     {9, 4},
+     {9, 8},
+     {9, 5},
+     {9, 7},
+     {9, 6}}};
+
 static constexpr std::array<xy_pair, 1> ARC_LOCATIONS = {{{8, 0}}};
 static constexpr std::array<xy_pair, 1> PCI_LOCATIONS = {{{11, 0}}};
 static constexpr std::array<xy_pair, 14> ETH_LOCATIONS = {
@@ -101,13 +141,24 @@ static constexpr uint32_t BROADCAST_TLB_INDEX = 0;     // TODO: Copied from worm
 static constexpr uint32_t STATIC_TLB_CFG_ADDR = 0x1fc00000;
 
 static constexpr uint32_t TLB_COUNT_2M = 202;
-static constexpr uint32_t TLB_BASE_2M = 0;
+static constexpr uint32_t TLB_BASE_2M = 0; // 0 in BAR0
 static constexpr uint32_t TLB_BASE_INDEX_2M = 0;
 static constexpr uint32_t TLB_2M_SIZE = 2 * 1024 * 1024;
 
+static constexpr uint32_t TLB_CFG_REG_SIZE_BYTES = 12;
+
+// TODO(pjanevski): put 4G tlb constants into separate groups
+static constexpr uint32_t TLB_COUNT_4G = 8;
+static constexpr uint32_t TLB_BASE_4G = 0; // 0 in BAR4
+static constexpr uint32_t TLB_BASE_INDEX_4G = TLB_COUNT_2M;
+static constexpr uint64_t TLB_4G_SIZE = 4ULL * 1024ULL * 1024ULL * 1024ULL;
+static constexpr uint64_t DYNAMIC_TLB_4G_SIZE = TLB_4G_SIZE;
+static constexpr uint32_t DYNAMIC_TLB_4G_CFG_ADDR = STATIC_TLB_CFG_ADDR + (TLB_BASE_INDEX_4G * TLB_CFG_REG_SIZE_BYTES);
+static constexpr uint32_t DYNAMIC_TLB_4G_BASE = TLB_BASE_4G;
+// TODO(pjanevski): end of 4G tlb constants
+
 static constexpr uint32_t DYNAMIC_TLB_COUNT = 16;
 
-static constexpr uint32_t TLB_CFG_REG_SIZE_BYTES = 12;
 static constexpr uint32_t DYNAMIC_TLB_2M_SIZE = 2 * 1024 * 1024;
 static constexpr uint32_t DYNAMIC_TLB_2M_CFG_ADDR = STATIC_TLB_CFG_ADDR + (TLB_BASE_INDEX_2M * TLB_CFG_REG_SIZE_BYTES);
 static constexpr uint32_t DYNAMIC_TLB_2M_BASE = TLB_BASE_2M;
@@ -203,7 +254,7 @@ class blackhole_implementation : public architecture_implementation {
 
     std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const override;
     tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
-    std::optional<std::tuple<std::uint32_t, std::uint32_t>> describe_tlb(std::int32_t tlb_index) const override;
+    std::optional<std::tuple<std::uint64_t, std::uint64_t>> describe_tlb(std::int32_t tlb_index) const override;
     std::pair<std::uint64_t, std::uint64_t> get_tlb_data(std::uint32_t tlb_index, const tlb_data& data) const override;
 };
 

--- a/device/grayskull_implementation.cpp
+++ b/device/grayskull_implementation.cpp
@@ -38,7 +38,7 @@ tlb_configuration grayskull_implementation::get_tlb_configuration(uint32_t tlb_i
     }
 }
 
-std::optional<std::tuple<std::uint32_t, std::uint32_t>> grayskull_implementation::describe_tlb(
+std::optional<std::tuple<std::uint64_t, std::uint64_t>> grayskull_implementation::describe_tlb(
     std::int32_t tlb_index) const {
     std::uint32_t TLB_COUNT_1M = 156;
     std::uint32_t TLB_COUNT_2M = 10;

--- a/device/grayskull_implementation.h
+++ b/device/grayskull_implementation.h
@@ -205,6 +205,8 @@ class grayskull_implementation : public architecture_implementation {
     uint32_t get_dram_channel_0_x() const override { return grayskull::DRAM_CHANNEL_0_X; }
     uint32_t get_dram_channel_0_y() const override { return grayskull::DRAM_CHANNEL_0_Y; }
     uint32_t get_broadcast_tlb_index() const override { return grayskull::BROADCAST_TLB_INDEX; }
+    uint32_t get_dynamic_tlb_2m_base() const override { return grayskull::DYNAMIC_TLB_2M_BASE; }
+    uint32_t get_dynamic_tlb_2m_size() const override { return grayskull::DYNAMIC_TLB_2M_SIZE; }
     uint32_t get_dynamic_tlb_16m_base() const override { return grayskull::DYNAMIC_TLB_16M_BASE; }
     uint32_t get_dynamic_tlb_16m_size() const override { return grayskull::DYNAMIC_TLB_16M_SIZE; }
     uint32_t get_dynamic_tlb_16m_cfg_addr() const override { return grayskull::DYNAMIC_TLB_16M_CFG_ADDR; }

--- a/device/grayskull_implementation.h
+++ b/device/grayskull_implementation.h
@@ -228,7 +228,7 @@ class grayskull_implementation : public architecture_implementation {
 
     std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const override;
     tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
-    std::optional<std::tuple<std::uint32_t, std::uint32_t>> describe_tlb(std::int32_t tlb_index) const override;
+    std::optional<std::tuple<std::uint64_t, std::uint64_t>> describe_tlb(std::int32_t tlb_index) const override;
     std::pair<std::uint64_t, std::uint64_t> get_tlb_data(std::uint32_t tlb_index, const tlb_data& data) const override;
 };
 

--- a/device/tlb.h
+++ b/device/tlb.h
@@ -49,7 +49,7 @@ struct tlb_data {
 };
 
 struct tlb_configuration {
-    uint32_t size;
+    uint64_t size;
     uint32_t base;
     uint32_t cfg_addr;
     uint32_t index_offset;

--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -921,7 +921,7 @@ class tt_SiliconDevice: public tt_device
     bool is_non_mmio_cmd_q_full(uint32_t curr_wptr, uint32_t curr_rptr);
     int pcie_arc_msg(int logical_device_id, uint32_t msg_code, bool wait_for_done = true, uint32_t arg0 = 0, uint32_t arg1 = 0, int timeout=1, uint32_t *return_3 = nullptr, uint32_t *return_4 = nullptr);
     int remote_arc_msg(int logical_device_id, uint32_t msg_code, bool wait_for_done = true, uint32_t arg0 = 0, uint32_t arg1 = 0, int timeout=1, uint32_t *return_3 = nullptr, uint32_t *return_4 = nullptr);
-    bool address_in_tlb_space(uint32_t address, uint32_t size_in_bytes, int32_t tlb_index, uint32_t tlb_size, uint32_t chip);
+    bool address_in_tlb_space(uint32_t address, uint32_t size_in_bytes, int32_t tlb_index, uint64_t tlb_size, uint32_t chip);
     struct PCIdevice* get_pci_device(int pci_intf_id) const;
     std::shared_ptr<boost::interprocess::named_mutex> get_mutex(const std::string& tlb_name, int pci_interface_id);
     virtual uint32_t get_harvested_noc_rows_for_chip(int logical_device_id); // Returns one-hot encoded harvesting mask for PCIe mapped chips

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -177,6 +177,9 @@ struct TTDeviceBase
     std::vector<DMAbuffer> dma_buffer_mappings;
 
     std::uint32_t read_checking_offset;
+
+    void* bar4_mapping = nullptr;
+    std::uint64_t bar4_mapping_size;
 };
 
 struct TTDevice : TTDeviceBase
@@ -531,6 +534,28 @@ void TTDevice::do_open() {
 
         this->system_reg_start_offset = (512 - 16) * 1024*1024;
         this->system_reg_offset_adjust = (512 - 32) * 1024*1024;
+    } else if(is_blackhole(device_info.out)) {
+
+        if (bar2_uc_mapping.mapping_id != TENSTORRENT_MAPPING_RESOURCE2_UC) {
+            throw std::runtime_error(std::string("Device ") + std::to_string(index) + " has no BAR4 UC mapping.");
+        }
+
+        // WC mapping
+        // this->bar4_mapping_size = bar2_wc_mapping.mapping_size;
+        // this->bar4_mapping = mmap(NULL, bar2_wc_mapping.mapping_size, PROT_READ | PROT_WRITE, MAP_SHARED, device_fd, bar2_wc_mapping.mapping_base);
+
+        // if (this->bar4_mapping == MAP_FAILED) {
+        //     throw std::runtime_error(std::string("BAR4 WC memory mapping failed for device ") + std::to_string(index) + ".");
+        // }
+
+        // UC mapping
+        this->bar4_mapping_size = bar2_uc_mapping.mapping_size;
+        this->bar4_mapping = mmap(NULL, bar2_uc_mapping.mapping_size, PROT_READ | PROT_WRITE, MAP_SHARED, device_fd, bar2_uc_mapping.mapping_base);
+        
+        if (this->bar4_mapping == MAP_FAILED) {
+            throw std::runtime_error(std::string("BAR4 UC memory mapping failed for device ") + std::to_string(index) + ".");
+        }
+       
     }
     pci_domain = device_info.out.pci_domain;
     pci_bus = device_info.out.bus_dev_fn >> 8;
@@ -976,7 +1001,7 @@ void memcpy_from_device(void *dest, const void *src, std::size_t num_bytes) {
     }
 }
 
-void read_block(TTDevice *dev, uint32_t byte_addr, uint32_t num_bytes, uint8_t* buffer_addr, uint32_t dma_buf_size) {
+void read_block(TTDevice *dev, uint64_t byte_addr, uint64_t num_bytes, uint8_t* buffer_addr, uint32_t dma_buf_size) {
     if (num_bytes >= g_DMA_BLOCK_SIZE_READ_THRESHOLD_BYTES && g_DMA_BLOCK_SIZE_READ_THRESHOLD_BYTES > 0) {
         record_access ("read_block_a", byte_addr, num_bytes, true, false, true, true); // addr, size, turbo, write, block, endline
 
@@ -998,7 +1023,12 @@ void read_block(TTDevice *dev, uint32_t byte_addr, uint32_t num_bytes, uint8_t* 
     record_access("read_block_b", byte_addr, num_bytes, false, false, true, false); // addr, size, turbo, write, block, endline
 
     void *reg_mapping;
-    if (dev->system_reg_mapping != nullptr && byte_addr >= dev->system_reg_start_offset) {
+    const uint64_t bar0_size = 512 * 1024 * 1024;
+    if (byte_addr >= bar0_size) {
+        byte_addr -= bar0_size;
+        reg_mapping = dev->bar4_mapping;
+    }
+    else if (dev->system_reg_mapping != nullptr && byte_addr >= dev->system_reg_start_offset) {
         byte_addr -= dev->system_reg_offset_adjust;
         reg_mapping = dev->system_reg_mapping;
     } else if (dev->bar0_wc != dev->bar0_uc && byte_addr < dev->bar0_wc_size) {
@@ -1032,10 +1062,10 @@ void read_block(TTDevice *dev, uint32_t byte_addr, uint32_t num_bytes, uint8_t* 
     if (num_bytes >= sizeof(std::uint32_t)) {
         detect_ffffffff_read(dev, *reinterpret_cast<std::uint32_t*>(dest));
     }
-    print_buffer (buffer_addr, std::min(g_NUM_BYTES_TO_PRINT, num_bytes), true);
+    print_buffer (buffer_addr, std::min((uint64_t)g_NUM_BYTES_TO_PRINT, num_bytes), true);
 }
 
-void write_block(TTDevice *dev, uint32_t byte_addr, uint32_t num_bytes, const uint8_t* buffer_addr, uint32_t dma_buf_size) {
+void write_block(TTDevice *dev, uint64_t byte_addr, uint64_t num_bytes, const uint8_t* buffer_addr, uint32_t dma_buf_size) {
     if (num_bytes >= g_DMA_BLOCK_SIZE_WRITE_THRESHOLD_BYTES && g_DMA_BLOCK_SIZE_WRITE_THRESHOLD_BYTES > 0) {
         record_access ("write_block_a", byte_addr, num_bytes, true, true, true, true); // addr, size, turbo, write, block, endline
 
@@ -1057,7 +1087,12 @@ void write_block(TTDevice *dev, uint32_t byte_addr, uint32_t num_bytes, const ui
     record_access("write_block_b", byte_addr, num_bytes, false, true, true, false); // addr, size, turbo, write, block, endline
 
     void *reg_mapping;
-    if (dev->system_reg_mapping != nullptr && byte_addr >= dev->system_reg_start_offset) {
+    const uint64_t bar0_size = 512 * 1024 * 1024;
+    if (byte_addr >= bar0_size) {
+        byte_addr -= bar0_size;
+        reg_mapping = dev->bar4_mapping;
+    }
+    else if (dev->system_reg_mapping != nullptr && byte_addr >= dev->system_reg_start_offset) {
         byte_addr -= dev->system_reg_offset_adjust;
         reg_mapping = dev->system_reg_mapping;
     } else if (dev->bar0_wc != dev->bar0_uc && byte_addr < dev->bar0_wc_size) {
@@ -1086,7 +1121,7 @@ void write_block(TTDevice *dev, uint32_t byte_addr, uint32_t num_bytes, const ui
      memcpy(dest, src, num_bytes);
 #endif
 #endif
-    print_buffer (buffer_addr, std::min(g_NUM_BYTES_TO_PRINT, num_bytes), true);
+    print_buffer (buffer_addr, std::min((uint64_t)g_NUM_BYTES_TO_PRINT, num_bytes), true);
 }
 
 void read_checking_enable(bool enable = true) {
@@ -1277,8 +1312,8 @@ void print_device_info (struct PCIdevice &d) {
 #include <iomanip>
 
 struct dynamic_tlb {
-    uint32_t bar_offset;        // Offset that address is mapped to, within the PCI BAR.
-    uint32_t remaining_size;    // Bytes remaining between bar_offset and end of the TLB.
+    uint64_t bar_offset;        // Offset that address is mapped to, within the PCI BAR.
+    uint64_t remaining_size;    // Bytes remaining between bar_offset and end of the TLB.
 };
 
 struct routing_cmd_t {
@@ -1343,7 +1378,7 @@ dynamic_tlb set_dynamic_tlb(PCIdevice* dev, unsigned int tlb_index, tt_xy_pair s
     auto translated_end_coords = harvested_coord_translation.at(dev -> logical_id).at(end);
     uint32_t tlb_address    = address / tlb_config.size;
     uint32_t local_offset   = address % tlb_config.size;
-    uint32_t tlb_base       = tlb_config.base + (tlb_config.size * tlb_config.index_offset);
+    uint64_t tlb_base       = tlb_config.base + (tlb_config.size * tlb_config.index_offset);
     uint32_t tlb_cfg_reg    = tlb_config.cfg_addr + (TLB_CFG_REG_SIZE_BYTES * tlb_config.index_offset);
 
     std::pair<std::uint64_t, std::uint64_t> tlb_data = TLB_DATA {
@@ -1357,13 +1392,12 @@ dynamic_tlb set_dynamic_tlb(PCIdevice* dev, unsigned int tlb_index, tt_xy_pair s
         .static_vc = true,
     }.apply_offset(tlb_config.offset);
 
-    LOG1 ("set_dynamic_tlb() with tlb_index: %d tlb_index_offset: %d dynamic_tlb_size: %dMB tlb_base: 0x%x tlb_cfg_reg: 0x%x\n", tlb_index, tlb_config.index_offset, tlb_config.size/(1024*1024), tlb_base, tlb_cfg_reg);
-    //write_regs(dev -> hdev, tlb_cfg_reg, 2, &tlb_data);
+    LOG1("set_dynamic_tlb() with tlb_index: %d tlb_index_offset: %d dynamic_tlb_size: %dMB tlb_base: 0x%x tlb_cfg_reg: 0x%x\n", tlb_index, tlb_config.index_offset, tlb_config.size/(1024*1024), tlb_base, tlb_cfg_reg);
+    // write_regs(dev -> hdev, tlb_cfg_reg, 2, &tlb_data);
     write_tlb_reg(dev->hdev, tlb_cfg_reg, tlb_data.first, tlb_data.second, TLB_CFG_REG_SIZE_BYTES);
 
     return { tlb_base + local_offset, tlb_config.size - local_offset };
 }
-
 
 dynamic_tlb set_dynamic_tlb(PCIdevice *dev, unsigned int tlb_index, tt_xy_pair target, std::uint64_t address, std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>>& harvested_coord_translation, std::uint64_t ordering = TLB_DATA::Relaxed) {
     return set_dynamic_tlb(dev, tlb_index, tt_xy_pair(0, 0), target, address, false, harvested_coord_translation, ordering);
@@ -1375,7 +1409,7 @@ dynamic_tlb set_dynamic_tlb_broadcast(PCIdevice *dev, unsigned int tlb_index, st
                             address, true, harvested_coord_translation, ordering);
 }
 
-bool tt_SiliconDevice::address_in_tlb_space(uint32_t address, uint32_t size_in_bytes, int32_t tlb_index, uint32_t tlb_size, std::uint32_t chip) {
+bool tt_SiliconDevice::address_in_tlb_space(uint32_t address, uint32_t size_in_bytes, int32_t tlb_index, uint64_t tlb_size, std::uint32_t chip) {
     return ((tlb_config_map.at(chip).find(tlb_index) != tlb_config_map.at(chip).end()) && address >= tlb_config_map.at(chip).at(tlb_index) && (address + size_in_bytes <= tlb_config_map.at(chip).at(tlb_index) + tlb_size));
 }
 
@@ -2140,16 +2174,21 @@ void tt_SiliconDevice::write_device_memory(const void *mem_ptr, uint32_t size_in
     //     target.chip, target.x, target.y, address, size_in_bytes, small_access);
 
     std::int32_t tlb_index = 0;
-    std::optional<std::tuple<std::uint32_t, std::uint32_t>> tlb_data = std::nullopt;
+    std::optional<std::tuple<std::uint64_t, std::uint64_t>> tlb_data = std::nullopt;
     if(tlbs_init) {
         tlb_index = map_core_to_tlb(tt_xy_pair(target.x, target.y));
         tlb_data = dev->get_architecture_implementation()->describe_tlb(tlb_index);
     }
 
     if (tlb_data.has_value() && address_in_tlb_space(address, size_in_bytes, tlb_index, std::get<1>(tlb_data.value()), target.chip)) {
-        // log_assert(arch_name != tt::ARCH::BLACKHOLE, "Pre-initialized TLBs not supported in BH");
         auto [tlb_offset, tlb_size] = tlb_data.value();
-        write_block(dev, tlb_offset + address % tlb_size, size_in_bytes, buffer_addr, m_dma_buf_size);
+        const uint64_t tlb_2m_size = 512 * 1024 * 1024;
+        if (tlb_size > tlb_2m_size) {
+            uint64_t bar4_offset = tlb_offset + address % tlb_size;
+            write_block(dev, (tlb_offset + address % tlb_size) + tlb_2m_size, size_in_bytes, buffer_addr, m_dma_buf_size);
+        } else {
+            write_block(dev, tlb_offset + address % tlb_size, size_in_bytes, buffer_addr, m_dma_buf_size);
+        }
     } else {
         const auto tlb_index = dynamic_tlb_config.at(fallback_tlb);
         const scoped_lock<named_mutex> lock(*get_mutex(fallback_tlb, pci_device -> id));
@@ -2157,7 +2196,7 @@ void tt_SiliconDevice::write_device_memory(const void *mem_ptr, uint32_t size_in
         while(size_in_bytes > 0) {
 
             auto [mapped_address, tlb_size] = set_dynamic_tlb(pci_device, tlb_index, target, address, harvested_coord_translation, dynamic_tlb_ordering_modes.at(fallback_tlb));
-            uint32_t transfer_size = std::min(size_in_bytes, tlb_size);
+            uint32_t transfer_size = std::min((uint64_t)size_in_bytes, tlb_size);
             write_block(dev, mapped_address, transfer_size, buffer_addr, m_dma_buf_size);
 
             size_in_bytes -= transfer_size;
@@ -2177,7 +2216,7 @@ void tt_SiliconDevice::read_device_memory(void *mem_ptr, tt_cxy_pair target, std
     uint8_t* buffer_addr = static_cast<uint8_t*>(mem_ptr);
 
     std::int32_t tlb_index = 0;
-    std::optional<std::tuple<std::uint32_t, std::uint32_t>> tlb_data = std::nullopt;
+    std::optional<std::tuple<std::uint64_t, std::uint64_t>> tlb_data = std::nullopt;
     if(tlbs_init) {
         tlb_index = map_core_to_tlb(tt_xy_pair(target.x, target.y));
         tlb_data = dev->get_architecture_implementation()->describe_tlb(tlb_index);
@@ -2186,7 +2225,12 @@ void tt_SiliconDevice::read_device_memory(void *mem_ptr, tt_cxy_pair target, std
 
     if (tlb_data.has_value()  && address_in_tlb_space(address, size_in_bytes, tlb_index, std::get<1>(tlb_data.value()), target.chip)) {
         auto [tlb_offset, tlb_size] = tlb_data.value();
-        read_block(dev, tlb_offset + address % tlb_size, size_in_bytes, buffer_addr, m_dma_buf_size);
+        const uint64_t tlb_2m_size = 512 * 1024 * 1024;
+        if (tlb_size > tlb_2m_size) {
+            read_block(dev, (tlb_offset + address % tlb_size) + tlb_2m_size, size_in_bytes, buffer_addr, m_dma_buf_size);
+        } else {
+            read_block(dev, tlb_offset + address % tlb_size, size_in_bytes, buffer_addr, m_dma_buf_size);
+        }
         LOG1 ("  read_block called with tlb_offset: %d, tlb_size: %d\n", tlb_offset, tlb_size);
     } else {
         const auto tlb_index = dynamic_tlb_config.at(fallback_tlb);
@@ -2195,7 +2239,7 @@ void tt_SiliconDevice::read_device_memory(void *mem_ptr, tt_cxy_pair target, std
         while(size_in_bytes > 0) {
 
             auto [mapped_address, tlb_size] = set_dynamic_tlb(pci_device, tlb_index, target, address, harvested_coord_translation, dynamic_tlb_ordering_modes.at(fallback_tlb));
-            uint32_t transfer_size = std::min(size_in_bytes, tlb_size);
+            uint32_t transfer_size = std::min((uint64_t)size_in_bytes, tlb_size);
             read_block(dev, mapped_address, transfer_size, buffer_addr, m_dma_buf_size);
 
             size_in_bytes -= transfer_size;
@@ -3310,7 +3354,7 @@ void tt_SiliconDevice::write_to_non_mmio_device(
             block_size = (block_size + alignment_mask) & ~alignment_mask;
         }
         // For 4 byte aligned data, transfer_size always == block_size. For unaligned data, transfer_size < block_size in the last block
-        uint32_t transfer_size = std::min(block_size, size_in_bytes - offset); // Host side data size that needs to be copied
+        uint64_t transfer_size = std::min(block_size, size_in_bytes - offset); // Host side data size that needs to be copied
         // Use block mode for broadcast
         uint32_t req_flags = (broadcast || (block_size > DATA_WORD_SIZE)) ? (eth_interface_params.CMD_DATA_BLOCK | eth_interface_params.CMD_WR_REQ | timestamp) : eth_interface_params.CMD_WR_REQ;
         uint32_t resp_flags = block_size > DATA_WORD_SIZE ? (eth_interface_params.CMD_DATA_BLOCK | eth_interface_params.CMD_WR_ACK) : eth_interface_params.CMD_WR_ACK;
@@ -4021,7 +4065,7 @@ void tt_SiliconDevice::pcie_broadcast_write(chip_id_t chip, const void* mem_ptr,
     const scoped_lock<named_mutex> lock(*get_mutex(fallback_tlb, pci_device -> id));
     while(size_in_bytes > 0) {
         auto [mapped_address, tlb_size] = set_dynamic_tlb_broadcast(pci_device, tlb_index, addr, harvested_coord_translation, start, end, dynamic_tlb_ordering_modes.at(fallback_tlb));
-        uint32_t transfer_size = std::min(size_in_bytes, tlb_size);
+        uint64_t transfer_size = std::min((uint64_t)size_in_bytes, tlb_size);
         write_block(dev, mapped_address, transfer_size, buffer_addr, m_dma_buf_size);
 
         size_in_bytes -= transfer_size;

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -2142,13 +2142,12 @@ void tt_SiliconDevice::write_device_memory(const void *mem_ptr, uint32_t size_in
     std::int32_t tlb_index = 0;
     std::optional<std::tuple<std::uint32_t, std::uint32_t>> tlb_data = std::nullopt;
     if(tlbs_init) {
-        log_assert(arch_name != tt::ARCH::BLACKHOLE, "Pre-initialized TLBs not supported in BH");
         tlb_index = map_core_to_tlb(tt_xy_pair(target.x, target.y));
         tlb_data = dev->get_architecture_implementation()->describe_tlb(tlb_index);
     }
 
     if (tlb_data.has_value() && address_in_tlb_space(address, size_in_bytes, tlb_index, std::get<1>(tlb_data.value()), target.chip)) {
-        log_assert(arch_name != tt::ARCH::BLACKHOLE, "Pre-initialized TLBs not supported in BH");
+        // log_assert(arch_name != tt::ARCH::BLACKHOLE, "Pre-initialized TLBs not supported in BH");
         auto [tlb_offset, tlb_size] = tlb_data.value();
         write_block(dev, tlb_offset + address % tlb_size, size_in_bytes, buffer_addr, m_dma_buf_size);
     } else {
@@ -2180,14 +2179,12 @@ void tt_SiliconDevice::read_device_memory(void *mem_ptr, tt_cxy_pair target, std
     std::int32_t tlb_index = 0;
     std::optional<std::tuple<std::uint32_t, std::uint32_t>> tlb_data = std::nullopt;
     if(tlbs_init) {
-        log_assert(arch_name != tt::ARCH::BLACKHOLE, "Pre-initialized TLBs not supported in BH");
         tlb_index = map_core_to_tlb(tt_xy_pair(target.x, target.y));
         tlb_data = dev->get_architecture_implementation()->describe_tlb(tlb_index);
     }
     LOG1("  tlb_index: %d, tlb_data.has_value(): %d\n", tlb_index, tlb_data.has_value());
 
     if (tlb_data.has_value()  && address_in_tlb_space(address, size_in_bytes, tlb_index, std::get<1>(tlb_data.value()), target.chip)) {
-        log_assert(arch_name != tt::ARCH::BLACKHOLE, "Pre-initialized TLBs not supported in BH");    // MT: Use only dynamic TLBs and never program static
         auto [tlb_offset, tlb_size] = tlb_data.value();
         read_block(dev, tlb_offset + address % tlb_size, size_in_bytes, buffer_addr, m_dma_buf_size);
         LOG1 ("  read_block called with tlb_offset: %d, tlb_size: %d\n", tlb_offset, tlb_size);
@@ -3063,8 +3060,21 @@ void *tt_SiliconDevice::channel_0_address(std::uint32_t offset, std::uint32_t de
     log_assert(ndesc->is_chip_mmio_capable(device_id), "Cannot call channel_0_address for non-MMIO device");
     struct PCIdevice* pci_device = get_pci_device(device_id);
     auto architecture_implementation = pci_device->hdev->get_architecture_implementation();
-    std::uint64_t bar0_offset = offset - architecture_implementation->get_dram_channel_0_peer2peer_region_start()
-                                + architecture_implementation->get_dynamic_tlb_16m_base() + architecture_implementation->get_dynamic_tlb_16m_size();
+    std::uint64_t bar0_offset;
+
+    // Temporary hack for blackhole bringup.
+    if (arch_name == tt::ARCH::BLACKHOLE) {
+
+        // Use 195th 2MB TLB onwards.
+        const std::uint32_t TLB_CH0_START = 195;
+        bar0_offset = offset - architecture_implementation->get_dram_channel_0_peer2peer_region_start()
+                        + architecture_implementation->get_dynamic_tlb_2m_base() + (TLB_CH0_START * architecture_implementation->get_dynamic_tlb_2m_size());
+
+    } else {
+        // This hard-codes that we use 16MB TLB #1 onwards for the mapping. See tt_SiliconDevice::init_pcie_tlb.
+        bar0_offset = offset - architecture_implementation->get_dram_channel_0_peer2peer_region_start()
+                        + architecture_implementation->get_dynamic_tlb_16m_base() + architecture_implementation->get_dynamic_tlb_16m_size();
+    }
 
     return static_cast<std::byte*>(pci_device->hdev->bar0_wc) + bar0_offset;
 }

--- a/device/wormhole_implementation.cpp
+++ b/device/wormhole_implementation.cpp
@@ -43,7 +43,7 @@ tlb_configuration wormhole_implementation::get_tlb_configuration(uint32_t tlb_in
     }
 }
 
-std::optional<std::tuple<std::uint32_t, std::uint32_t>> wormhole_implementation::describe_tlb(
+std::optional<std::tuple<std::uint64_t, std::uint64_t>> wormhole_implementation::describe_tlb(
     std::int32_t tlb_index) const {
     std::uint32_t TLB_COUNT_1M = 156;
     std::uint32_t TLB_COUNT_2M = 10;

--- a/device/wormhole_implementation.h
+++ b/device/wormhole_implementation.h
@@ -238,6 +238,8 @@ class wormhole_implementation : public architecture_implementation {
     uint32_t get_dram_channel_0_x() const override { return wormhole::DRAM_CHANNEL_0_X; }
     uint32_t get_dram_channel_0_y() const override { return wormhole::DRAM_CHANNEL_0_Y; }
     uint32_t get_broadcast_tlb_index() const override { return wormhole::BROADCAST_TLB_INDEX; }
+    uint32_t get_dynamic_tlb_2m_base() const override { return wormhole::DYNAMIC_TLB_2M_BASE; }
+    uint32_t get_dynamic_tlb_2m_size() const override { return wormhole::DYNAMIC_TLB_2M_SIZE; }
     uint32_t get_dynamic_tlb_16m_base() const override { return wormhole::DYNAMIC_TLB_16M_BASE; }
     uint32_t get_dynamic_tlb_16m_size() const override { return wormhole::DYNAMIC_TLB_16M_SIZE; }
     uint32_t get_dynamic_tlb_16m_cfg_addr() const override { return wormhole::DYNAMIC_TLB_16M_CFG_ADDR; }

--- a/device/wormhole_implementation.h
+++ b/device/wormhole_implementation.h
@@ -261,7 +261,7 @@ class wormhole_implementation : public architecture_implementation {
 
     std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const override;
     tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
-    std::optional<std::tuple<std::uint32_t, std::uint32_t>> describe_tlb(std::int32_t tlb_index) const override;
+    std::optional<std::tuple<std::uint64_t, std::uint64_t>> describe_tlb(std::int32_t tlb_index) const override;
     std::pair<std::uint64_t, std::uint64_t> get_tlb_data(std::uint32_t tlb_index, const tlb_data& data) const override;
 };
 


### PR DESCRIPTION
**Keeping this PR in draft until [*](https://github.com/tenstorrent/tt-umd/pull/10) is merged. Target branch is the branch on that PR to follow changes more easily, I will switch the target branch later on to main*

### Problem

Part of larger effort on Budabackend to bring up and test Blackhole

Blackhole has 32GB BAR4 space which is used for DRAM access (4GB per channel). 8 more TLBs are mapped in BAR0 after the TLBs for 2MB device access. Using this our access to DRAM should be faster because now we don't need to access it in chunks of 2MB or 16MB like in Grayskull and Wormhole

### Solution

This MR enables usage of BAR4, mapping BAR4 segment in runtime virtual memory, and makes sure that every access to DRAM goes through BAR4 segment. Access to DRAM in `write_device_memory` and `read_device_memory` should now happen only through the BAR4 space.

### Testing

Change is tested manually, by verifying that every access to DRAM is done through the BAR4 segment. [Commit that verifies the change](https://github.com/tenstorrent/tt-umd/commit/05eb06c82d89709f453343f6ae6a3112c01a639f) is on scratchpad branch, we probably don't want to merge this