### PR TITLE
Fix BH address translation

### DIFF
--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -602,7 +602,7 @@ class tt_device
     /** 
      * Get the address for the MMIO mapped region on Channel (as seen from host memory)
      * \param offset Address in DRAM
-     * \param device_id logical id for MMIO device being queried FIXME
+     * \param target chip-x-y struct specifying device and core of target DRAM
      * \returns Host interpretation of MMIO mapped channel 0 address 
      */ 
     virtual void *channel_address(std::uint32_t offset, const tt_cxy_pair& target) {

--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -602,10 +602,10 @@ class tt_device
     /** 
      * Get the address for the MMIO mapped region on Channel (as seen from host memory)
      * \param offset Address in DRAM
-     * \param device_id logical id for MMIO device being queried
+     * \param device_id logical id for MMIO device being queried FIXME
      * \returns Host interpretation of MMIO mapped channel 0 address 
      */ 
-    virtual void *channel_0_address(std::uint32_t offset, std::uint32_t device_id) const {
+    virtual void *channel_address(std::uint32_t offset, std::uint32_t device_id, const tt_cxy_pair& target) {
         throw std::runtime_error("---- tt_device::channel_0_address is not implemented\n");
         return nullptr;
     }
@@ -844,7 +844,7 @@ class tt_SiliconDevice: public tt_device
     virtual std::set<chip_id_t> get_target_remote_device_ids();
     virtual std::map<int,int> get_clocks();
     virtual uint32_t dma_allocation_size(chip_id_t src_device_id = -1);
-    virtual void *channel_0_address(std::uint32_t offset, std::uint32_t device_id) const;
+    virtual void *channel_address(std::uint32_t offset, std::uint32_t device_id, const tt_cxy_pair& target) override;
     virtual void *host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const;
     virtual std::uint64_t get_pcie_base_addr_from_device() const;
     static std::vector<int> extract_rows_to_remove(const tt::ARCH &arch, const int worker_grid_rows, const int harvested_rows);

--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -606,7 +606,7 @@ class tt_device
      * \returns Host interpretation of MMIO mapped channel 0 address 
      */ 
     virtual void *channel_address(std::uint32_t offset, const tt_cxy_pair& target) {
-        throw std::runtime_error("---- tt_device::channel_0_address is not implemented\n");
+        throw std::runtime_error("---- tt_device::channel_address is not implemented\n");
         return nullptr;
     }
     /**

--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -605,7 +605,7 @@ class tt_device
      * \param device_id logical id for MMIO device being queried FIXME
      * \returns Host interpretation of MMIO mapped channel 0 address 
      */ 
-    virtual void *channel_address(std::uint32_t offset, std::uint32_t device_id, const tt_cxy_pair& target) {
+    virtual void *channel_address(std::uint32_t offset, const tt_cxy_pair& target) {
         throw std::runtime_error("---- tt_device::channel_0_address is not implemented\n");
         return nullptr;
     }
@@ -844,7 +844,7 @@ class tt_SiliconDevice: public tt_device
     virtual std::set<chip_id_t> get_target_remote_device_ids();
     virtual std::map<int,int> get_clocks();
     virtual uint32_t dma_allocation_size(chip_id_t src_device_id = -1);
-    virtual void *channel_address(std::uint32_t offset, std::uint32_t device_id, const tt_cxy_pair& target) override;
+    virtual void *channel_address(std::uint32_t offset, const tt_cxy_pair& target) override;
     virtual void *host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const;
     virtual std::uint64_t get_pcie_base_addr_from_device() const;
     static std::vector<int> extract_rows_to_remove(const tt::ARCH &arch, const int worker_grid_rows, const int harvested_rows);

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -3218,11 +3218,11 @@ void *tt_SiliconDevice::channel_address(std::uint32_t offset, const tt_cxy_pair&
     // Temporary hack for blackhole bringup.
     if (arch_name == tt::ARCH::BLACKHOLE) {
         // We use BAR4 segment for mapping for Blackhole.
-        log_assert(tlbs_init, "tlb not init.");
+        log_assert(tlbs_init, "TLBs were not initialized.");
         std::int32_t tlb_index = map_core_to_tlb(tt_xy_pair(target.x, target.y));
         auto [tlb_offset, tlb_size] = pci_device->hdev->get_architecture_implementation()->describe_tlb(tlb_index).value();
 
-        log_assert(pci_device->hdev->bar4_wc != nullptr && tlb_size == BH_4GB_TLB_SIZE, "bar4 not initialized, or tlbs not initialized properly.");
+        log_assert(pci_device->hdev->bar4_wc != nullptr && tlb_size == BH_4GB_TLB_SIZE, "BAR4 not initialized, or TLBs not initialized properly.");
         return static_cast<std::byte*>(pci_device->hdev->bar4_wc) + tlb_offset + offset;
     } else {
         // This hard-codes that we use 16MB TLB #1 onwards for the mapping.

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -3209,8 +3209,7 @@ void tt_SiliconDevice::enable_local_ethernet_queue(const chip_id_t &device_id, i
     }
 }
 
-
-void *tt_SiliconDevice::channel_0_address(std::uint32_t offset, std::uint32_t device_id) const {
+void *tt_SiliconDevice::channel_address(std::uint32_t offset, std::uint32_t device_id, const tt_cxy_pair& target) {
     log_assert(ndesc->is_chip_mmio_capable(device_id), "Cannot call channel_0_address for non-MMIO device");
     struct PCIdevice* pci_device = get_pci_device(device_id);
     auto architecture_implementation = pci_device->hdev->get_architecture_implementation();
@@ -3219,7 +3218,12 @@ void *tt_SiliconDevice::channel_0_address(std::uint32_t offset, std::uint32_t de
     // Temporary hack for blackhole bringup.
     if (arch_name == tt::ARCH::BLACKHOLE) {
         // We use BAR4 segment for mapping for Blackhole.
-        return static_cast<std::byte*>(pci_device->hdev->bar4_wc) + offset;
+        log_assert(tlbs_init, "tlb not init.");
+        std::int32_t tlb_index = map_core_to_tlb(tt_xy_pair(target.x, target.y));
+        auto [tlb_offset, tlb_size] = pci_device->hdev->get_architecture_implementation()->describe_tlb(tlb_index).value();
+
+        log_assert(pci_device->hdev->bar4_wc != nullptr && tlb_size == BH_4GB_TLB_SIZE, "bar4 not initialized, or tlbs not initialized properly.");
+        return static_cast<std::byte*>(pci_device->hdev->bar4_wc) + tlb_offset + offset;
     } else {
         // This hard-codes that we use 16MB TLB #1 onwards for the mapping.
         bar0_offset = offset - architecture_implementation->get_dram_channel_0_peer2peer_region_start()

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -3210,7 +3210,7 @@ void tt_SiliconDevice::enable_local_ethernet_queue(const chip_id_t &device_id, i
 }
 
 void *tt_SiliconDevice::channel_address(std::uint32_t offset, const tt_cxy_pair& target) {
-    log_assert(ndesc->is_chip_mmio_capable(target.chip), "Cannot call channel_0_address for non-MMIO device");
+    log_assert(ndesc->is_chip_mmio_capable(target.chip), "Cannot call channel_address for non-MMIO device");
     struct PCIdevice* pci_device = get_pci_device(target.chip);
     auto architecture_implementation = pci_device->hdev->get_architecture_implementation();
     std::uint64_t bar0_offset;

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -3209,9 +3209,9 @@ void tt_SiliconDevice::enable_local_ethernet_queue(const chip_id_t &device_id, i
     }
 }
 
-void *tt_SiliconDevice::channel_address(std::uint32_t offset, std::uint32_t device_id, const tt_cxy_pair& target) {
-    log_assert(ndesc->is_chip_mmio_capable(device_id), "Cannot call channel_0_address for non-MMIO device");
-    struct PCIdevice* pci_device = get_pci_device(device_id);
+void *tt_SiliconDevice::channel_address(std::uint32_t offset, const tt_cxy_pair& target) {
+    log_assert(ndesc->is_chip_mmio_capable(target.chip), "Cannot call channel_0_address for non-MMIO device");
+    struct PCIdevice* pci_device = get_pci_device(target.chip);
     auto architecture_implementation = pci_device->hdev->get_architecture_implementation();
     std::uint64_t bar0_offset;
 


### PR DESCRIPTION
The codepath hitting channel_address (former channel_0_address, but renamed to reduce confusion) is used by Buda when writing to these queues in DRAM.
Previous generations of chips didn't use static tlbs for channels other than 0. Now, BAR4 on BH allows us to map whole DRAM, hence a modification is needed to this function.

This change was integrated in BudaBackend and tested with accompanying BBE changes.