### PR TITLE
Remove override which raises an error due to inconsistent usage

### DIFF
--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -844,7 +844,7 @@ class tt_SiliconDevice: public tt_device
     virtual std::set<chip_id_t> get_target_remote_device_ids();
     virtual std::map<int,int> get_clocks();
     virtual uint32_t dma_allocation_size(chip_id_t src_device_id = -1);
-    virtual void *channel_address(std::uint32_t offset, const tt_cxy_pair& target) override;
+    virtual void *channel_address(std::uint32_t offset, const tt_cxy_pair& target);
     virtual void *host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const;
     virtual std::uint64_t get_pcie_base_addr_from_device() const;
     static std::vector<int> extract_rows_to_remove(const tt::ARCH &arch, const int worker_grid_rows, const int harvested_rows);


### PR DESCRIPTION
A compiler in budabackend on CI raises issue due to inconsistent use of override (i.e., by the rule in clang, override should be used either everywhere or nowhere). The last PR broke this pattern: https://github.com/tenstorrent/tt-umd/pull/19. Reverting the override keyword.

I've tested now that the build in budabackend CI passes