### PR TITLE
Disable static VC for TLBs for Blackhole

### DIFF
--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -1451,7 +1451,7 @@ dynamic_tlb set_dynamic_tlb(PCIdevice* dev, unsigned int tlb_index, tt_xy_pair s
         .y_start = static_cast<uint64_t>(translated_start_coords.y),
         .mcast = multicast,
         .ordering = ordering,
-        .static_vc = true,
+        .static_vc = false,
     }.apply_offset(tlb_config.offset);
 
     LOG1("set_dynamic_tlb() with tlb_index: %d tlb_index_offset: %d dynamic_tlb_size: %dMB tlb_base: 0x%x tlb_cfg_reg: 0x%x\n", tlb_index, tlb_config.index_offset, tlb_config.size/(1024*1024), tlb_base, tlb_cfg_reg);

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -1451,7 +1451,9 @@ dynamic_tlb set_dynamic_tlb(PCIdevice* dev, unsigned int tlb_index, tt_xy_pair s
         .y_start = static_cast<uint64_t>(translated_start_coords.y),
         .mcast = multicast,
         .ordering = ordering,
-        // TODO: Issue 2715 for blackhole.
+        // TODO #2715: hack for Blackhole A0, will potentially be fixed in B0.
+        // Using the same static vc for reads and writes through TLBs can hang the card. It doesn't even have to be the same TLB.
+        // Dynamic vc should not have this issue. There might be a perf impact with using dynamic vc.
         .static_vc = (dev->hdev->get_arch() == tt::ARCH::BLACKHOLE) ? false : true,
     }.apply_offset(tlb_config.offset);
 

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -1451,7 +1451,8 @@ dynamic_tlb set_dynamic_tlb(PCIdevice* dev, unsigned int tlb_index, tt_xy_pair s
         .y_start = static_cast<uint64_t>(translated_start_coords.y),
         .mcast = multicast,
         .ordering = ordering,
-        .static_vc = false,
+        // TODO: Issue 2715 for blackhole.
+        .static_vc = (dev->hdev->get_arch() == tt::ARCH::BLACKHOLE) ? false : true,
     }.apply_offset(tlb_config.offset);
 
     LOG1("set_dynamic_tlb() with tlb_index: %d tlb_index_offset: %d dynamic_tlb_size: %dMB tlb_base: 0x%x tlb_cfg_reg: 0x%x\n", tlb_index, tlb_config.index_offset, tlb_config.size/(1024*1024), tlb_base, tlb_cfg_reg);


### PR DESCRIPTION
There is a known HW issue that makes this codepath occasionally hang.
I've tested that with this change, we're now not hitting originally reported issues in PyBuda.