### PR TITLE
hid simulation device thus flat buffers from public headers

### DIFF
--- a/device/device_api_metal.h
+++ b/device/device_api_metal.h
@@ -8,4 +8,3 @@
 #include "device/tt_device.h"
 #include "device/driver_atomics.h"
 #include "device/tt_emulation_device.h"
-#include "device/simulation/tt_simulation_device.h"


### PR DESCRIPTION
See https://github.com/tenstorrent/tt-metal/issues/11640 for details.

This PR hides flatbuffers from public UMD headers so 3rd party projects can compile successfully without matching the exact version of flatbuffers used by UMD/TTNN. This is impossible for some projects (ex: GGML)

If ok, this PR can be merged and pulled into tt-metal AFTER https://github.com/tenstorrent/tt-metal/pull/11641 is merged