### PR TITLE
Add basic microbenchmark tests for device read/write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ compile_commands.json
 .cpmcache/
 .vscode/
 *.log
+*.csv

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -82,3 +82,14 @@ if(NOT MASTER_PROJECT)
     set(flatbuffers_include_dir ${flatbuffers_SOURCE_DIR}/include PARENT_SCOPE)
     set(libuv_include_dir ${libuv_SOURCE_DIR}/include PARENT_SCOPE)
 endif()
+
+############################################################################################################################
+# nanobench (for uBenchmarking)
+############################################################################################################################
+if (MASTER_PROJECT)
+    CPMAddPackage(
+        NAME nanobench
+        GITHUB_REPOSITORY martinus/nanobench
+        GIT_TAG v4.3.11
+    )
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ target_include_directories(test_common INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/microbenchmark)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/simulation)
 if($ENV{ARCH_NAME} STREQUAL "wormhole_b0")
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/wormhole)
@@ -15,4 +16,4 @@ else()
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/$ENV{ARCH_NAME})
 endif()
 
-add_custom_target(umd_tests DEPENDS umd_unit_tests simulation_tests)
+add_custom_target(umd_tests DEPENDS umd_unit_tests simulation_tests ubench)

--- a/tests/microbenchmark/CMakeLists.txt
+++ b/tests/microbenchmark/CMakeLists.txt
@@ -1,0 +1,10 @@
+
+set(UBENCH_SRC
+    test_rw_tensix.cpp
+)
+add_executable(ubench ${UBENCH_SRC})
+target_link_libraries(ubench PRIVATE test_common nanobench)
+target_include_directories(ubench PRIVATE ${nanobench_SOURCE_DIR}/src/include)
+set_target_properties(ubench PROPERTIES 
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test/umd/ubenchmarks
+)

--- a/tests/microbenchmark/device_fixture.hpp
+++ b/tests/microbenchmark/device_fixture.hpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: (c) 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <iostream>
+#include <fstream>
+#include <cassert>
+#include <random>
+#include <gtest/gtest.h>
+
+#include "tt_device.h"
+#include "l1_address_map.h"
+#include "device/tt_soc_descriptor.h"
+#include "tests/test_utils/generate_cluster_desc.hpp"
+
+class uBenchmarkFixture : public ::testing::Test {
+    protected:
+    void SetUp() override {
+        // get arch name?
+        results_csv.open("ubench_results.csv", std::ios_base::app);
+
+        auto get_static_tlb_index = [] (tt_xy_pair target) {
+            int flat_index = target.y * 10 + target.x;  // grid_size_x = 10 for GS/WH ????? something is wrong here
+            if (flat_index == 0) {
+                return -1;
+            }
+            return flat_index;
+        };
+        std::set<chip_id_t> target_devices = {0};
+        std::unordered_map<std::string, std::int32_t> dynamic_tlb_config = {{"SMALL_READ_WRITE_TLB", 157}}; // Use both static and dynamic TLBs here
+        uint32_t num_host_mem_ch_per_mmio_device = 1;
+        device = std::make_shared<tt_SiliconDevice>(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), "", target_devices, num_host_mem_ch_per_mmio_device, dynamic_tlb_config, false, true);
+
+        for(int i = 0; i < target_devices.size(); i++) {
+            // Iterate over devices and only setup static TLBs for functional worker cores
+            auto& sdesc = device->get_virtual_soc_descriptors().at(i);
+            for(auto& core : sdesc.workers) {
+                // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE. 
+                device->configure_tlb(i, core, get_static_tlb_index(core), l1_mem::address_map::DATA_BUFFER_SPACE_BASE);
+            }
+        }
+    }
+
+    void TearDown() override {
+        device->close_device();
+        results_csv.close();
+    }
+
+    std::shared_ptr<tt_SiliconDevice> device;
+    std::ofstream results_csv;
+};

--- a/tests/microbenchmark/test_rw_tensix.cpp
+++ b/tests/microbenchmark/test_rw_tensix.cpp
@@ -1,0 +1,94 @@
+
+#include <iostream>
+
+#include "nanobench.h"
+#include "device_fixture.hpp"
+
+std::uint32_t generate_random_address(std::uint32_t max, std::uint32_t min=0) {
+    ankerl::nanobench::Rng gen(80085);
+    std::uniform_int_distribution<> dis(min, max);  // between 0 and 1MB
+    return dis(gen);
+}
+
+TEST_F(uBenchmarkFixture, WriteAllCores32Bytes) {
+    std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7};
+    std::uint64_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
+    std::uint64_t bad_address = 0x30000000;     // this address is not mapped, should trigger fallback write/read path
+
+    ankerl::nanobench::Bench bench_static;
+    ankerl::nanobench::Bench bench_dynamic;
+    for(auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
+        std::stringstream wname;
+        wname << "Write to device core (" << core.x << ", " << core.y << ")";
+        // Write 32 bytes through static tlbs
+        bench_static.title("Write 32 bytes").unit("writes").minEpochIterations(50).output(nullptr).run(wname.str(), [&] {
+            device->write_to_device(vector_to_write, tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
+        });
+        // Write through "fallback/dynamic" tlb
+        bench_dynamic.title("Write 32 bytes fallback").unit("writes").minEpochIterations(50).output(nullptr).run(wname.str(), [&] {
+            device->write_to_device(vector_to_write, tt_cxy_pair(0, core), bad_address, "SMALL_READ_WRITE_TLB");
+        });
+        wname.clear();
+    }
+    bench_static.render(ankerl::nanobench::templates::csv(), results_csv);
+    bench_dynamic.render(ankerl::nanobench::templates::csv(), results_csv);
+}
+
+TEST_F(uBenchmarkFixture, ReadAllCores32Bytes){
+    std::vector<uint32_t> readback_vec = {};
+    std::uint64_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
+    std::uint64_t bad_address = 0x30000000;     // this address is not mapped, should trigger fallback write/read path
+
+    ankerl::nanobench::Bench bench_static;
+    ankerl::nanobench::Bench bench_dynamic;
+    
+    for(auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
+        std::stringstream rname;
+        // Read through static tlbs
+        rname << "Read from device core (" << core.x << ", " << core.y << ")";
+        bench_static.title("Read 32 bytes").unit("reads").minEpochIterations(50).output(nullptr).run(rname.str(), [&] {
+            device->read_from_device(readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
+        });
+        // Read through "fallback/dynamic" tlb
+        bench_dynamic.title("Read 32 bytes fallback").unit("reads").minEpochIterations(50).output(nullptr).run(rname.str(), [&] {
+            device->read_from_device(readback_vec, tt_cxy_pair(0, core), bad_address, 0x20, "SMALL_READ_WRITE_TLB");
+        });
+        rname.clear();
+    }
+    bench_static.render(ankerl::nanobench::templates::csv(), results_csv);
+    bench_dynamic.render(ankerl::nanobench::templates::csv(), results_csv);
+}
+
+TEST_F(uBenchmarkFixture, Write32BytesRandomAddr){
+    std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7};
+    std::uint32_t address;
+
+    ankerl::nanobench::Bench bench;
+    for(auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
+        address = generate_random_address(1<<20); // between 0 and 1MB
+        std::stringstream wname;
+        wname << "Write to device core (" << core.x << ", " << core.y << ") @ address " << std::hex << address;
+        bench.title("Write 32 bytes random address").unit("writes").minEpochIterations(50).output(nullptr).run(wname.str(), [&] {
+            device->write_to_device(vector_to_write, tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
+        });
+        wname.clear();
+    }
+    bench.render(ankerl::nanobench::templates::csv(), results_csv);
+}
+
+TEST_F(uBenchmarkFixture, Read32BytesRandomAddr){
+    std::vector<uint32_t> readback_vec = {};
+    std::uint32_t address;
+
+    ankerl::nanobench::Bench bench;
+    for(auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
+        address = generate_random_address(1<<20); // between 0 and 1MB
+        std::stringstream rname;
+        rname << "Read from device core (" << core.x << ", " << core.y << ") @ address " << std::hex << address;
+        bench.title("Read 32 bytes random address").unit("reads").minEpochIterations(50).output(nullptr).run(rname.str(), [&] {
+            device->read_from_device(readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
+        });
+        rname.clear();
+    }
+    bench.render(ankerl::nanobench::templates::csv(), results_csv);
+}


### PR DESCRIPTION
Using nanobench: https://github.com/martinus/nanobench 

Example of results:
<img width="1018" alt="image" src="https://github.com/user-attachments/assets/536c7111-af7e-4663-be1d-cb6ad034ac85">

`elasped` column shows time taken for each read/write in seconds