### PR TITLE
Add options to enable compilation with sanitizers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build*
 compile_commands.json
 .cache/**
 .cpmcache/
+.envrc
 .vscode/
 *.log
 *.csv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,57 @@ if(MASTER_PROJECT)
         set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Release build is the default" FORCE)
     endif()
 
+    option(ENABLE_ASAN "Enable build with AddressSanitizer" OFF)
+    message(STATUS "Build with ASAN: ${ENABLE_ASAN}")
+
+    set(SANITIZER_ENABLED ${ENABLE_ASAN})
+
+    option(ENABLE_MSAN "Enable build with MemorySanitizer" OFF)
+    message(STATUS "Build with MSAN: ${ENABLE_MSAN}")
+
+    if(SANITIZER_ENABLED AND ENABLE_MSAN)
+        message(FATAL_ERROR "Multiple sanitizers are not supported")
+    elseif(ENABLE_MSAN)
+        set(SANITIZER_ENABLED ${ENABLE_MSAN})
+    endif()
+
+    option(ENABLE_TSAN "Enable build with ThreadSanitizer" OFF)
+    message(STATUS "Build with TSAN: ${ENABLE_TSAN}")
+
+    if(SANITIZER_ENABLED AND ENABLE_TSAN)
+        message(FATAL_ERROR "Multiple sanitizers are not supported")
+    elseif(ENABLE_TSAN)
+        set(SANITIZER_ENABLED ${ENABLE_TSAN})
+    endif()
+
+    option(ENABLE_UBSAN "Enable build with UndefinedBehaviorSanitizer" OFF)
+    message(STATUS "Build with UBSAN: ${ENABLE_UBSAN}")
+
+    if(SANITIZER_ENABLED AND ENABLE_UBSAN)
+        message(FATAL_ERROR "Multiple sanitizers are not supported")
+    endif()
+
+    unset(SANITIZER_ENABLED)
+
     add_library(compiler_flags INTERFACE)
-    target_compile_options(compiler_flags INTERFACE -DFMT_HEADER_ONLY)
+    target_compile_options(
+        compiler_flags
+        INTERFACE -DFMT_HEADER_ONLY
+                $<$<BOOL:${ENABLE_ASAN}>:-fsanitize=address>
+                $<$<BOOL:${ENABLE_MSAN}>:-fsanitize=memory>
+                $<$<BOOL:${ENABLE_TSAN}>:-fsanitize=thread>
+                $<$<BOOL:${ENABLE_UBSAN}>:-fsanitize=undefined>)
+
+    add_library(linker_flags INTERFACE)
+    target_link_options(
+        linker_flags
+        INTERFACE
+        $<$<BOOL:${ENABLE_ASAN}>:-fsanitize=address>
+        $<$<BOOL:${ENABLE_MSAN}>:-fsanitize=memory>
+        $<$<BOOL:${ENABLE_TSAN}>:-fsanitize=thread>
+        $<$<BOOL:${ENABLE_UBSAN}>:-fsanitize=undefined>)
+
+    target_link_libraries(compiler_flags INTERFACE linker_flags)
 endif()
 message(STATUS "UMD build type: ${CMAKE_BUILD_TYPE}")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11453

### Problem description
We want the ability to compile C++ with sanitizers to verify code's safety

### What's changed
This pull request adds options for MemorySanitizer, ThreadSanitizer, and UndefinedBehaviorSanitizer to CMake and ensures that they're mutually exclusive during configuration.