### PR TITLE
#12405: Refactor to use strong types

### DIFF
--- a/device/cpuset_lib.cpp
+++ b/device/cpuset_lib.cpp
@@ -126,7 +126,7 @@ bool tt_cpuset_allocator::init_find_tt_pci_devices_packages_numanodes(){
 
             std::string pci_bus_id_str  = get_pci_bus_id(pci_device_obj);
             std::string pci_device_dir  = "/sys/bus/pci/devices/" + pci_bus_id_str + "/tenstorrent/";
-            int physical_device_id = -1;
+            auto physical_device_id = umd::chip_id::none;
 
             log_trace(LogSiliconDriver, "Found TT device with pci_bus_id_str: {} num_devices_by_pci_device_id: {}", pci_bus_id_str, m_num_tt_device_by_pci_device_id_map[device_id_revision]);
 
@@ -136,14 +136,14 @@ bool tt_cpuset_allocator::init_find_tt_pci_devices_packages_numanodes(){
                     auto entry_str = entry.path().string();
 
                     if (std::smatch device_match; std::regex_search(entry_str, device_match, tt_device_re) and (stoi(device_match[1]) >= 0)){
-                        physical_device_id = stoi(device_match[1]);
+                        physical_device_id = umd::chip_id{stoi(device_match[1])};
                         m_all_tt_devices.push_back(physical_device_id);
                         log_debug(LogSiliconDriver, "Found physical_device_id: {} from file: {}", physical_device_id, entry_str);
                         break;
                     }
                 }
 
-                if (physical_device_id == -1){
+                if (physical_device_id == umd::chip_id::none){
                     log_warning(LogSiliconDriver, "Did not find file containing physical_device_id in {}", pci_device_dir);
                     return false;
                 }

--- a/device/cpuset_lib.hpp
+++ b/device/cpuset_lib.hpp
@@ -128,8 +128,8 @@ struct tt_cpuset_allocator {
         std::unordered_map<chip_id_t, chip_id_t> m_logical_to_physical_mmio_device_id_map;
 
         // Items calculated by parsing system info, used by allocation algorithm:
-        std::map<int, std::vector<int>> m_package_id_to_devices_map;
-        std::map<int, std::string> m_physical_device_id_to_pci_bus_id_map; // Debug/Info
+        std::map<int, std::vector<umd::chip_id>> m_package_id_to_devices_map;
+        std::map<umd::chip_id, std::string> m_physical_device_id_to_pci_bus_id_map; // Debug/Info
         std::map<std::pair<uint16_t, uint16_t>, int> m_num_tt_device_by_pci_device_id_map;
 
         std::map<chip_id_t, std::vector<hwloc_cpuset_t>> m_physical_device_id_to_cpusets_map;
@@ -139,7 +139,7 @@ struct tt_cpuset_allocator {
 
         bool m_enable_cpuset_allocator = true; // Enable feature, otherwise do nothing.
         int m_num_packages = 0;
-        std::vector<int> m_all_tt_devices = {};
+        std::vector<umd::chip_id> m_all_tt_devices = {};
 
         hwloc_obj_type_t m_object_per_alloc_slot = HWLOC_OBJ_L3CACHE; // Default
 

--- a/device/kmdif.h
+++ b/device/kmdif.h
@@ -20,10 +20,16 @@ struct DMAbuffer {
 
 struct TTDevice;
 
+namespace tt::umd {
+
+enum class chip_id : int;
+
+}  // namespace tt::umd
+
 struct PCIdevice  {
-	unsigned int id = 0;
+	tt::umd::chip_id id{0};
 	TTDevice *hdev = nullptr;
-    unsigned int logical_id;
+    tt::umd::chip_id logical_id;
     std::uint16_t vendor_id;
     std::uint16_t device_id;
     std::uint16_t subsystem_vendor_id;

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -89,22 +89,11 @@ bool tt_ClusterDescriptor::is_chip_mmio_capable(const chip_id_t &chip_id) const 
 int tt_ClusterDescriptor::get_ethernet_link_coord_distance(const eth_coord_t &location_a, const eth_coord_t &location_b) const {
 
     log_trace(LogSiliconDriver, "get_ethernet_link_coord_distance from ({}, {}, {}, {}) to ({}, {}, {}, {})",
-        std::get<0>(location_a), std::get<1>(location_a), std::get<2>(location_a), std::get<3>(location_a),
-        std::get<0>(location_b), std::get<1>(location_b), std::get<2>(location_b), std::get<3>(location_b));
+        location_a.x, location_a.y, location_a.shelf, location_a.rack,
+        location_b.x, location_b.y, location_b.shelf, location_b.rack);
 
-    // eth_coord_t: x, y, rack, shelf
-
-    int x_a = std::get<0>(location_a);
-    int x_b = std::get<0>(location_b);
-
-    int y_a = std::get<1>(location_a);
-    int y_b = std::get<1>(location_b);
-
-    int shelf_a = std::get<3>(location_a);
-    int shelf_b = std::get<3>(location_b);
-
-    int rack_a = std::get<2>(location_a);
-    int rack_b = std::get<2>(location_b);
+    auto [x_a, y_a, shelf_a, rack_a] = location_a;
+    auto [x_b, y_b, shelf_b, rack_b] = location_b;
 
     int x_distance = std::abs(x_a - x_b);
     int y_distance = std::abs(y_a - y_b);
@@ -127,11 +116,11 @@ int tt_ClusterDescriptor::get_ethernet_link_coord_distance(const eth_coord_t &lo
         eth_coord_t exit_shelf = shelf_to_shelf_connection.source_chip_coord;
         for(eth_coord_t next_shelf : shelf_to_shelf_connection.destination_chip_coords) {
 
-            log_assert(std::get<1>(exit_shelf) == y_a && std::get<3>(exit_shelf) == shelf_a && std::get<2>(exit_shelf) == rack_a,
+            log_assert(exit_shelf.y == y_a && exit_shelf.shelf == shelf_a && exit_shelf.rack == rack_a,
                 "Invalid shelf exit coordinates");
 
             // next shelf could be at a different y-dim in nebula->galaxy systems
-            log_assert(std::get<3>(next_shelf) == (shelf_a+1) && std::get<2>(next_shelf) == rack_a,
+            log_assert(next_shelf.shelf == (shelf_a+1) && next_shelf.rack == rack_a,
                 "Invalid shelf entry coordinates");
 
             // hop onto the next shelf and find distance from there
@@ -144,8 +133,8 @@ int tt_ClusterDescriptor::get_ethernet_link_coord_distance(const eth_coord_t &lo
             distance = std::min(distance, distance_to_exit + distance_in_next_shelf + 1);
         }
         log_trace(LogSiliconDriver, "\tdistance from ({}, {}, {}, {}) to ({}, {}, {}, {}) is {}",
-            std::get<0>(location_a), std::get<1>(location_a), std::get<2>(location_a), std::get<3>(location_a),
-            std::get<0>(location_b), std::get<1>(location_b), std::get<2>(location_b), std::get<3>(location_b), distance);
+            location_a.x, location_a.y, location_a.rack, location_a.shelf,
+            location_b.x, location_b.y, location_b.rack, location_b.shelf, distance);
         return distance;
     }
     else if(shelf_a > shelf_b) {
@@ -166,10 +155,10 @@ int tt_ClusterDescriptor::get_ethernet_link_coord_distance(const eth_coord_t &lo
         eth_coord_t exit_shelf = shelf_to_shelf_connection.source_chip_coord;
         for(eth_coord_t next_shelf : shelf_to_shelf_connection.destination_chip_coords) {
 
-            log_assert(std::get<1>(exit_shelf) == y_b && std::get<3>(exit_shelf) == shelf_b && std::get<2>(exit_shelf) == rack_b,
+            log_assert(exit_shelf.y == y_b && exit_shelf.shelf == shelf_b && exit_shelf.rack == rack_b,
                 "Invalid shelf exit coordinates");
             // next shelf could be at a different y-dim in nebula->galaxy systems
-            log_assert(std::get<3>(next_shelf) == (shelf_b+1) && std::get<2>(next_shelf) == rack_b,
+            log_assert(next_shelf.shelf == (shelf_b+1) && next_shelf.rack == rack_b,
                 "Invalid shelf entry coordinates");
 
             // hop onto the next shelf and find distance from there
@@ -182,8 +171,8 @@ int tt_ClusterDescriptor::get_ethernet_link_coord_distance(const eth_coord_t &lo
             distance = std::min(distance, distance_to_exit + distance_in_next_shelf + 1);
         }
         log_trace(LogSiliconDriver, "\tdistance from ({}, {}, {}, {}) to ({}, {}, {}, {}) is {}",
-            std::get<0>(location_a), std::get<1>(location_a), std::get<2>(location_a), std::get<3>(location_a),
-            std::get<0>(location_b), std::get<1>(location_b), std::get<2>(location_b), std::get<3>(location_b), distance);
+            location_a.x, location_a.y, location_a.rack, location_a.shelf,
+            location_b.x, location_b.y, location_b.rack, location_b.shelf, distance);
         return distance;
     }
 
@@ -207,9 +196,9 @@ int tt_ClusterDescriptor::get_ethernet_link_coord_distance(const eth_coord_t &lo
         eth_coord_t exit_rack = rack_to_rack_connection.source_chip_coord;
         for(eth_coord_t next_rack : rack_to_rack_connection.destination_chip_coords) {
 
-            log_assert(std::get<0>(exit_rack) == x_a && std::get<3>(exit_rack) == shelf_a && std::get<2>(exit_rack) == rack_a,
+            log_assert(exit_rack.x == x_a && exit_rack.shelf == shelf_a && exit_rack.rack == rack_a,
                 "Invalid rack exit coordinates");
-            log_assert(std::get<0>(next_rack) == x_a && std::get<3>(next_rack) == shelf_a && std::get<2>(next_rack) == (rack_a+1),
+            log_assert(next_rack.x == x_a && next_rack.shelf == shelf_a && next_rack.rack == (rack_a+1),
                 "Invalid rack entry coordinates");
 
             // hop onto the next rack and find distance from there
@@ -222,8 +211,8 @@ int tt_ClusterDescriptor::get_ethernet_link_coord_distance(const eth_coord_t &lo
             distance = std::min(distance, distance_to_exit + distance_in_next_rack + 1);
         }
         log_trace(LogSiliconDriver, "\tdistance from ({}, {}, {}, {}) to ({}, {}, {}, {}) is {}",
-            std::get<0>(location_a), std::get<1>(location_a), std::get<2>(location_a), std::get<3>(location_a),
-            std::get<0>(location_b), std::get<1>(location_b), std::get<2>(location_b), std::get<3>(location_b), distance);
+            location_a.x, location_a.y, location_a.rack, location_a.shelf,
+            location_b.x, location_b.y, location_b.rack, location_b.shelf, distance);
 
         return distance;
     }
@@ -246,9 +235,9 @@ int tt_ClusterDescriptor::get_ethernet_link_coord_distance(const eth_coord_t &lo
         eth_coord_t exit_rack = rack_to_rack_connection.source_chip_coord;
         for(eth_coord_t next_rack : rack_to_rack_connection.destination_chip_coords) {
 
-            log_assert(std::get<0>(exit_rack) == x_b && std::get<3>(exit_rack) == shelf_b && std::get<2>(exit_rack) == rack_b,
+            log_assert(exit_rack.x == x_b && exit_rack.shelf == shelf_b && exit_rack.rack == rack_b,
                 "Invalid rack exit coordinates");
-            log_assert(std::get<0>(next_rack) == x_b && std::get<3>(next_rack) == shelf_b && std::get<2>(next_rack) == (rack_b+1),
+            log_assert(next_rack.x == x_b && next_rack.shelf == shelf_b && next_rack.rack == (rack_b+1),
                 "Invalid rack entry coordinates");
 
             // hop onto the next rack and find distance from there
@@ -261,15 +250,15 @@ int tt_ClusterDescriptor::get_ethernet_link_coord_distance(const eth_coord_t &lo
             distance = std::min(distance, distance_to_exit + distance_in_next_rack + 1);
         }
         log_trace(LogSiliconDriver, "\tdistance from ({}, {}, {}, {}) to ({}, {}, {}, {}) is {}",
-            std::get<0>(location_a), std::get<1>(location_a), std::get<2>(location_a), std::get<3>(location_a),
-            std::get<0>(location_b), std::get<1>(location_b), std::get<2>(location_b), std::get<3>(location_b), distance);
+            location_a.x, location_a.y, location_a.rack, location_a.shelf,
+            location_b.x, location_b.y, location_b.rack, location_b.shelf, distance);
 
         return distance;
     }
 
     log_trace(LogSiliconDriver, "\tdistance from ({}, {}, {}, {}) to ({}, {}, {}, {}) is {}",
-        std::get<0>(location_a), std::get<1>(location_a), std::get<2>(location_a), std::get<3>(location_a),
-        std::get<0>(location_b), std::get<1>(location_b), std::get<2>(location_b), std::get<3>(location_b), x_distance + y_distance);
+        location_a.x, location_a.y, location_a.rack, location_a.shelf,
+        location_b.x, location_b.y, location_b.rack, location_b.shelf, x_distance + y_distance);
 
     // on same shelf/rack, the distance is just x+y difference
     return x_distance + y_distance;
@@ -296,7 +285,7 @@ chip_id_t tt_ClusterDescriptor::get_closest_mmio_capable_chip(const chip_id_t &c
         const chip_id_t &mmio_chip = pair.first;
         eth_coord_t mmio_eth_coord = this->chip_locations.at(mmio_chip);
 
-        log_debug(LogSiliconDriver, "Checking chip{} at ({}, {}, {}, {})", mmio_chip, std::get<0>(mmio_eth_coord), std::get<1>(mmio_eth_coord), std::get<2>(mmio_eth_coord), std::get<3>(mmio_eth_coord));
+        log_debug(LogSiliconDriver, "Checking chip{} at ({}, {}, {}, {})", mmio_chip, mmio_eth_coord.x, mmio_eth_coord.y, mmio_eth_coord.rack, mmio_eth_coord.shelf);
 
         int distance = get_ethernet_link_coord_distance(mmio_eth_coord, chip_eth_coord);
         if (distance < min_distance) {
@@ -342,7 +331,7 @@ std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_for_grayskull
     auto use_physical_ids                   = physical_mmio_device_ids.size() ? true : false;
     auto largest_workload_logical_device_id = *logical_mmio_device_ids.rbegin(); // Last element in ordered set.
     auto num_available_physical_devices     = physical_mmio_device_ids.size();
-    auto required_physical_devices          = largest_workload_logical_device_id + 1;
+    auto required_physical_devices          = static_cast<int>(largest_workload_logical_device_id) + 1;
 
     log_debug(tt::LogSiliconDriver, "{} - use_physical_ids: {} largest_workload_logical_device_id: {} num_available_physical_devices: {} required_physical_devices: {}",
         __FUNCTION__, use_physical_ids, largest_workload_logical_device_id, num_available_physical_devices, required_physical_devices);
@@ -353,12 +342,12 @@ std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_for_grayskull
 
     // All Grayskull devices are MMIO mapped so physical_mmio_device_ids correspond to all available devices
     for (auto &logical_id : logical_mmio_device_ids) {
-        auto physical_id = use_physical_ids ? physical_mmio_device_ids.at(logical_id) : -1;
+        auto physical_id = use_physical_ids ? physical_mmio_device_ids.at(static_cast<int>(logical_id)) : umd::chip_id::none;
         desc->chips_with_mmio.insert({logical_id, physical_id});
         desc->all_chips.insert(logical_id);
-        eth_coord_t chip_location{logical_id, 0, 0, 0};
+        eth_coord_t chip_location{static_cast<int>(logical_id), 0, 0, 0};
         desc->chip_locations.insert({logical_id, chip_location});
-        desc->coords_to_chip_ids[std::get<2>(chip_location)][std::get<3>(chip_location)][std::get<1>(chip_location)][std::get<0>(chip_location)] = logical_id;
+        desc->coords_to_chip_ids[chip_location.rack][chip_location.shelf][chip_location.y][chip_location.x] = logical_id;
         log_debug(tt::LogSiliconDriver, "{} - adding logical: {} => physical: {}", __FUNCTION__, logical_id, physical_id);
     }
 
@@ -383,10 +372,10 @@ void tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descripto
         std::vector<YAML::Node> endpoints = connected_endpoints.as<std::vector<YAML::Node>>();
         log_assert(endpoints.size() == 2, "Currently ethernet cores can only connect to one other ethernet endpoint");
 
-        int chip_0 = endpoints.at(0)["chip"].as<int>();
-        int channel_0 = endpoints.at(0)["chan"].as<int>();
-        int chip_1 = endpoints.at(1)["chip"].as<int>();
-        int channel_1 = endpoints.at(1)["chan"].as<int>();
+        const umd::chip_id chip_0{endpoints.at(0)["chip"].as<int>()};
+        const umd::ethernet_channel channel_0{endpoints.at(0)["chan"].as<int>()};
+        const umd::chip_id chip_1{endpoints.at(1)["chip"].as<int>()};
+        const umd::ethernet_channel channel_1{endpoints.at(1)["chan"].as<int>()};
         if (desc.ethernet_connections[chip_0].find(channel_0) != desc.ethernet_connections[chip_0].end()) {
             log_assert(
                 (std::get<0>(desc.ethernet_connections[chip_0][channel_0]) == chip_1) &&
@@ -419,7 +408,7 @@ void tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descripto
             for (const auto &[row, row_chip_map] : shelf_chip_map) {
                 std::stringstream row_chips;
                 for (const auto &[col, chip_id] : row_chip_map) {
-                    row_chips << chip_id << "\t";
+                    row_chips << static_cast<int>(chip_id) << "\t";
                 }
                 log_debug(LogSiliconDriver, "\t\t{}", row_chips.str());
             }
@@ -433,8 +422,8 @@ void tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descripto
     // determine which chips are connected to the next (i.e. higher id) shelf/rack and what the coordinate of the chip on the other shelf/rack is
     // this is used in get_ethernet_link_coord_distance to find the distance between two chips
     for (const auto &[chip_id, chip_eth_coord] : desc.chip_locations) {
-        highest_shelf_id = std::max(highest_shelf_id, std::get<3>(chip_eth_coord));
-        highest_rack_id = std::max(highest_rack_id, std::get<2>(chip_eth_coord));
+        highest_shelf_id = std::max(highest_shelf_id, chip_eth_coord.shelf);
+        highest_rack_id = std::max(highest_rack_id, chip_eth_coord.rack);
         // iterate over all neighbors
         if(desc.ethernet_connections.find(chip_id) == desc.ethernet_connections.end()) {
             continue; // chip has no eth connections
@@ -443,11 +432,11 @@ void tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descripto
             const chip_id_t &neighbor_chip = std::get<0>(chip_and_chan);
             eth_coord_t neighbor_eth_coord = desc.chip_locations.at(neighbor_chip);
             // shelves are connected in x-dim
-            if(std::get<3>(neighbor_eth_coord) != std::get<3>(chip_eth_coord)) {
-                eth_coord_t higher_shelf_coord = std::get<3>(neighbor_eth_coord) > std::get<3>(chip_eth_coord) ? neighbor_eth_coord : chip_eth_coord;
-                eth_coord_t lower_shelf_coord = std::get<3>(neighbor_eth_coord) < std::get<3>(chip_eth_coord) ? neighbor_eth_coord : chip_eth_coord;
-                int lower_shelf_id = std::get<3>(lower_shelf_coord);
-                int lower_shelf_y = std::get<1>(lower_shelf_coord);
+            if(neighbor_eth_coord.shelf != chip_eth_coord.shelf) {
+                eth_coord_t higher_shelf_coord = neighbor_eth_coord.shelf > chip_eth_coord.shelf ? neighbor_eth_coord : chip_eth_coord;
+                eth_coord_t lower_shelf_coord = neighbor_eth_coord.shelf < chip_eth_coord.shelf ? neighbor_eth_coord : chip_eth_coord;
+                int lower_shelf_id = lower_shelf_coord.shelf;
+                int lower_shelf_y = lower_shelf_coord.y;
 
                 auto& galaxy_shelf_exit_chip_coords_per_y_dim = desc.galaxy_shelves_exit_chip_coords_per_y_dim[lower_shelf_id];
 
@@ -460,11 +449,11 @@ void tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descripto
             }
 
             // racks are connected in y-dim
-            if(std::get<2>(neighbor_eth_coord) != std::get<2>(chip_eth_coord)) {
-                eth_coord_t higher_rack_coord = std::get<2>(neighbor_eth_coord) > std::get<2>(chip_eth_coord) ? neighbor_eth_coord : chip_eth_coord;
-                eth_coord_t lower_rack_coord = std::get<2>(neighbor_eth_coord) < std::get<2>(chip_eth_coord) ? neighbor_eth_coord : chip_eth_coord;
-                int lower_rack_id = std::get<2>(lower_rack_coord);
-                int lower_rack_x = std::get<0>(lower_rack_coord);
+            if(neighbor_eth_coord.rack != chip_eth_coord.rack) {
+                eth_coord_t higher_rack_coord = neighbor_eth_coord.rack > chip_eth_coord.rack ? neighbor_eth_coord : chip_eth_coord;
+                eth_coord_t lower_rack_coord = neighbor_eth_coord.rack < chip_eth_coord.rack ? neighbor_eth_coord : chip_eth_coord;
+                int lower_rack_id = lower_rack_coord.rack;
+                int lower_rack_x = lower_rack_coord.x;
 
                 auto& galaxy_rack_exit_chip_coords_per_x_dim = desc.galaxy_racks_exit_chip_coords_per_x_dim[lower_rack_id];
 
@@ -527,25 +516,25 @@ void tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descripto
 
 void tt_ClusterDescriptor::load_chips_from_connectivity_descriptor(YAML::Node &yaml, tt_ClusterDescriptor &desc) {
     for (YAML::const_iterator node = yaml["chips"].begin(); node != yaml["chips"].end(); ++node) {
-        chip_id_t chip_id = node->first.as<int>();
+        const umd::chip_id chip_id{node->first.as<int>()};
         std::vector<int> chip_rack_coords = node->second.as<std::vector<int>>();
         log_assert(chip_rack_coords.size() == 4, "Galaxy (x, y, rack, shelf) coords must be size 4");
         eth_coord_t chip_location{
             chip_rack_coords.at(0), chip_rack_coords.at(1), chip_rack_coords.at(2), chip_rack_coords.at(3)};
         
         desc.chip_locations.insert({chip_id, chip_location});
-        desc.coords_to_chip_ids[std::get<2>(chip_location)][std::get<3>(chip_location)][std::get<1>(chip_location)][std::get<0>(chip_location)] = chip_id;
+        desc.coords_to_chip_ids[chip_location.rack][chip_location.shelf][chip_location.y][chip_location.x] = chip_id;
         desc.all_chips.insert(chip_id);
     }
     
     for(const auto& chip : yaml["chips_with_mmio"]) {
         if(chip.IsMap()) {
-            const auto &chip_map = chip.as<std::map<chip_id_t, chip_id_t>>();
+            const auto &chip_map = chip.as<std::map<int, int>>();
             const auto &chips = chip_map.begin();
-            desc.chips_with_mmio.insert({chips->first, chips->second});
+            desc.chips_with_mmio.insert({umd::chip_id{chips->first}, umd::chip_id{chips->second}});
         }
         else {
-            const auto &chip_val = chip.as<int>();
+            const umd::chip_id chip_val{chip.as<int>()};
             desc.chips_with_mmio.insert({chip_val, chip_val});
         }
     }
@@ -555,15 +544,15 @@ void tt_ClusterDescriptor::load_chips_from_connectivity_descriptor(YAML::Node &y
             LogSiliconDriver,
             "\tchip: {},  EthCoord(x={}, y={}, rack={}, shelf={})",
             chip_id,
-            std::get<0>(chip_location),
-            std::get<1>(chip_location),
-            std::get<2>(chip_location),
-            std::get<3>(chip_location));
+            chip_location.x,
+            chip_location.y,
+            chip_location.rack,
+            chip_location.shelf);
     }
 
 		if (yaml["boardtype"]) {
         for (const auto& chip_board_type : yaml["boardtype"].as<std::map<int, std::string>>()) {
-            auto &chip = chip_board_type.first;
+            umd::chip_id chip{chip_board_type.first};
             BoardType board_type;
             if (chip_board_type.second == "n150") {
                 board_type = BoardType::N150;
@@ -586,7 +575,7 @@ void tt_ClusterDescriptor::load_chips_from_connectivity_descriptor(YAML::Node &y
 void tt_ClusterDescriptor::load_harvesting_information(YAML::Node &yaml, tt_ClusterDescriptor &desc) {
     if(yaml["harvesting"]) {
         for (const auto& chip_node : yaml["harvesting"].as<std::map<int, YAML::Node>>()) {
-            chip_id_t chip = chip_node.first;
+            chip_id_t chip{chip_node.first};
             auto harvesting_info = chip_node.second;
             desc.noc_translation_enabled.insert({chip, harvesting_info["noc_translation"].as<bool>()});
             desc.harvesting_masks.insert({chip, harvesting_info["harvest_mask"].as<std::uint32_t>()});
@@ -641,9 +630,8 @@ std::unordered_map<chip_id_t, eth_coord_t> tt_ClusterDescriptor::get_chip_locati
 chip_id_t tt_ClusterDescriptor::get_shelf_local_physical_chip_coords(chip_id_t virtual_coord) {
     // Physical cooridnates of chip inside a single rack. Calculated based on Galaxy topology.
     // See: https://yyz-gitlab.local.tenstorrent.com/tenstorrent/budabackend/-/wikis/uploads/23e7a5168f38dfb706f9887fde78cb03/image.png
-    int x = std::get<0>(get_chip_locations().at(virtual_coord));
-    int y = std::get<1>(get_chip_locations().at(virtual_coord));
-    return 8 * x + y;
+    const auto chip_location = get_chip_locations().at(virtual_coord);
+    return umd::chip_id{8 * chip_location.x + chip_location.y};
 }
 
 // Return map, but filter by enabled active chips.

--- a/device/tt_cluster_descriptor_types.h
+++ b/device/tt_cluster_descriptor_types.h
@@ -4,24 +4,63 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#pragma once 
+#pragma once
 
-#include <tuple>
+#include <fmt/format.h>
 
-using chip_id_t = int;
-using ethernet_channel_t = int;
-using eth_coord_t = std::tuple<int, int, int, int>;  // x, y, rack, shelf
+#include <functional>
+#include <type_traits>
 
-namespace std {
-template <>
-struct hash<eth_coord_t> {
-  std::size_t operator()(eth_coord_t const &c) const {
-    std::size_t seed = 0;
-    seed = std::hash<std::size_t>()(std::get<0>(c)) << 48 | 
-          std::hash<std::size_t>()(std::get<1>(c)) << 32 |
-          std::hash<std::size_t>()(std::get<2>(c)) << 16 |
-          std::hash<std::size_t>()(std::get<3>(c));
-    return seed;
-  }
+
+namespace tt::umd {
+
+enum class chip_id : int {
+    none = -1,
 };
-}
+
+enum class ethernet_channel : int {};
+
+struct eth_coord {
+    int x;
+    int y;
+    int rack;
+    int shelf;
+
+    // in C++20 this should be defined as:
+    // constexpr bool operator==(const eth_coord &other) const noexcept = default;
+    constexpr bool operator==(const eth_coord &other) const noexcept {
+        return (x == other.x and y == other.y and rack == other.rack and shelf == other.shelf);
+    }
+};
+
+}  // namespace tt::umd
+
+using chip_id_t = tt::umd::chip_id;
+using ethernet_channel_t = tt::umd::ethernet_channel;
+using eth_coord_t = tt::umd::eth_coord;
+
+template <>
+struct fmt::formatter<tt::umd::chip_id> {
+   private:
+    using underlying_type = std::underlying_type_t<tt::umd::chip_id>;
+
+    fmt::formatter<underlying_type> underlying_formatter;
+
+   public:
+    constexpr fmt::format_parse_context::iterator parse(fmt::format_parse_context &ctx) {
+        return underlying_formatter.parse(ctx);
+    }
+
+    constexpr fmt::format_context::iterator format(const tt::umd::chip_id value, fmt::format_context &ctx) const {
+        return underlying_formatter.format(static_cast<underlying_type>(value), ctx);
+    } 
+};
+
+template <>
+struct std::hash<tt::umd::eth_coord> {
+    std::size_t operator()(tt::umd::eth_coord const &c) const {
+        constexpr std::hash<std::size_t> hash{};
+        const std::size_t seed = hash(c.x) << 48 | hash(c.y) << 32 | c.rack << 16 | c.shelf;
+        return seed;
+    }
+};

--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -561,20 +561,19 @@ class tt_device
      * @brief Get clock frequencies for all MMIO devices targeted by UMD
      * \returns Map of logical chip id to clock frequency (for MMIO chips only)
     */
-    virtual std::map<int,int> get_clocks() {
+    virtual std::map<tt::umd::chip_id,int> get_clocks() {
         throw std::runtime_error("---- tt_device::get_clocks is not implemented\n");
-        return std::map<int,int>();
     }
 
     /**
      * @brief Get the PCIe speed for a specific device based on link width and link speed
      * \returns Bandwidth in Gbps
      */
-    virtual std::uint32_t get_pcie_speed(std::uint32_t device_id) {
+    virtual std::uint32_t get_pcie_speed(tt::umd::chip_id device_id) {
         return 8 * 16;  // default to x8 at 16 GT/s
     }
 
-    virtual std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id) {
+    virtual std::uint32_t get_numa_node_for_pcie_device(tt::umd::chip_id device_id) {
         throw std::runtime_error("---- tt_device::get_numa_node_for_pcie_device is not implemented\n");
     }
 
@@ -594,7 +593,7 @@ class tt_device
      * \returns Total memory allocated on host for a specific device
      * 
     */ 
-    virtual uint32_t dma_allocation_size(chip_id_t src_device_id = -1) {
+    virtual uint32_t dma_allocation_size(chip_id_t src_device_id = tt::umd::chip_id::none) {
         throw std::runtime_error("---- tt_device::dma_allocation_size is not implemented\n");
         return 0;
     }
@@ -614,7 +613,7 @@ class tt_device
      * \param device_id Logical device id to query
      * \returns Number of DRAM channels on device
     */ 
-    virtual std::uint32_t get_num_dram_channels(std::uint32_t device_id) {
+    virtual std::uint32_t get_num_dram_channels(tt::umd::chip_id device_id) {
         throw std::runtime_error("---- tt_device::get_num_dram_channels is not implemented\n");
         return 0;
     }
@@ -624,7 +623,7 @@ class tt_device
      * \param channel Logical channel id (taken from soc descriptor) for which the size will be queried
      * \returns Size of specific DRAM channel
     */ 
-    virtual std::uint64_t get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel) {
+    virtual std::uint64_t get_dram_channel_size(tt::umd::chip_id device_id, std::uint32_t channel) {
         throw std::runtime_error("---- tt_device::get_dram_channel_size is not implemented\n");
         return 0;
     }
@@ -634,7 +633,7 @@ class tt_device
      * \param device_id Logical device id to query
      * \returns Number of Host channels allocated for device
     */ 
-    virtual std::uint32_t get_num_host_channels(std::uint32_t device_id) {
+    virtual std::uint32_t get_num_host_channels(tt::umd::chip_id device_id) {
         throw std::runtime_error("---- tt_device::get_num_host_channels is not implemented\n");
         return 0;
     }
@@ -645,7 +644,7 @@ class tt_device
      * \param channel Logical Host channel id for which the accessible  size will be queried
      * \returns Device accessible size of specific Host channel
     */ 
-    virtual std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel) {
+    virtual std::uint32_t get_host_channel_size(tt::umd::chip_id device_id, std::uint32_t channel) {
         throw std::runtime_error("---- tt_device::get_host_channel_size is not implemented\n");
         return 0;
     }
@@ -723,7 +722,7 @@ class tt_VersimDevice: public tt_device
     virtual int get_number_of_chips_in_cluster();
     virtual std::unordered_set<chip_id_t> get_all_chips_in_cluster();
     static int detect_number_of_chips();
-    virtual std::map<int,int> get_clocks();
+    virtual std::map<tt::umd::chip_id,int> get_clocks();
     virtual std::uint32_t get_num_dram_channels(std::uint32_t device_id);
     virtual std::uint64_t get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel);
     virtual std::uint32_t get_num_host_channels(std::uint32_t device_id);
@@ -800,8 +799,8 @@ class tt_SiliconDevice: public tt_device
     void dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels);
     void dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
     // These functions are used by Debuda, so make them public
-    void bar_write32 (int logical_device_id, uint32_t addr, uint32_t data);
-    uint32_t bar_read32 (int logical_device_id, uint32_t addr);
+    void bar_write32 (tt::umd::chip_id logical_device_id, uint32_t addr, uint32_t data);
+    uint32_t bar_read32 (tt::umd::chip_id logical_device_id, uint32_t addr);
     /**
      * @brief If the tlbs are initialized, returns a tuple with the TLB base address and its size
     */
@@ -809,7 +808,7 @@ class tt_SiliconDevice: public tt_device
     /**
      * @brief This API allows you to write directly to device memory that is addressable by a static TLB
     */
-    std::function<void(uint32_t, uint32_t, const uint8_t*, uint32_t)> get_fast_pcie_static_tlb_write_callable(int device_id);
+    std::function<void(uint32_t, uint32_t, const uint8_t*, uint32_t)> get_fast_pcie_static_tlb_write_callable(tt::umd::chip_id device_id);
 
     /**
      * @brief Provide fast write access to a statically-mapped TLB.
@@ -829,7 +828,7 @@ class tt_SiliconDevice: public tt_device
     */
     uint32_t get_m_dma_buf_size() const;
     // Misc. Functions to Query/Set Device State
-    virtual int arc_msg(int logical_device_id, uint32_t msg_code, bool wait_for_done = true, uint32_t arg0 = 0, uint32_t arg1 = 0, int timeout=1, uint32_t *return_3 = nullptr, uint32_t *return_4 = nullptr);
+    virtual int arc_msg(tt::umd::chip_id logical_device_id, uint32_t msg_code, bool wait_for_done = true, uint32_t arg0 = 0, uint32_t arg1 = 0, int timeout=1, uint32_t *return_3 = nullptr, uint32_t *return_4 = nullptr);
     virtual bool using_harvested_soc_descriptors();
     virtual std::unordered_map<chip_id_t, uint32_t> get_harvesting_masks_for_soc_descriptors();
     virtual bool noc_translation_en();
@@ -842,8 +841,8 @@ class tt_SiliconDevice: public tt_device
     static std::unordered_map<chip_id_t, chip_id_t> get_logical_to_physical_mmio_device_id_map(std::vector<chip_id_t> physical_device_ids);
     virtual std::set<chip_id_t> get_target_mmio_device_ids();
     virtual std::set<chip_id_t> get_target_remote_device_ids();
-    virtual std::map<int,int> get_clocks();
-    virtual uint32_t dma_allocation_size(chip_id_t src_device_id = -1);
+    virtual std::map<tt::umd::chip_id,int> get_clocks();
+    virtual uint32_t dma_allocation_size(chip_id_t src_device_id = tt::umd::chip_id::none);
     virtual void *channel_address(std::uint32_t offset, const tt_cxy_pair& target);
     virtual void *host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const;
     virtual std::uint64_t get_pcie_base_addr_from_device() const;
@@ -853,12 +852,12 @@ class tt_SiliconDevice: public tt_device
     static std::unordered_map<tt_xy_pair, tt_xy_pair> create_harvested_coord_translation(const tt::ARCH arch, bool identity_map);
     static std::unordered_map<chip_id_t, uint32_t> get_harvesting_masks_from_harvested_rows(std::unordered_map<chip_id_t, std::vector<uint32_t>> harvested_rows); 
     std::unordered_map<tt_xy_pair, tt_xy_pair> get_harvested_coord_translation_map(chip_id_t logical_device_id);
-    virtual std::uint32_t get_num_dram_channels(std::uint32_t device_id);
-    virtual std::uint64_t get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel);
-    virtual std::uint32_t get_num_host_channels(std::uint32_t device_id);
-    virtual std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel);
-    virtual std::uint32_t get_pcie_speed(std::uint32_t device_id);
-    virtual std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id);
+    virtual std::uint32_t get_num_dram_channels(tt::umd::chip_id device_id);
+    virtual std::uint64_t get_dram_channel_size(tt::umd::chip_id device_id, std::uint32_t channel);
+    virtual std::uint32_t get_num_host_channels(tt::umd::chip_id device_id);
+    virtual std::uint32_t get_host_channel_size(tt::umd::chip_id device_id, std::uint32_t channel);
+    virtual std::uint32_t get_pcie_speed(tt::umd::chip_id device_id);
+    virtual std::uint32_t get_numa_node_for_pcie_device(tt::umd::chip_id device_id);
     virtual tt_version get_ethernet_fw_version() const;
 
     // Destructor
@@ -868,7 +867,7 @@ class tt_SiliconDevice: public tt_device
     // Helper functions
     // Startup + teardown
     void create_device(const std::unordered_set<chip_id_t> &target_mmio_device_ids, const uint32_t &num_host_mem_ch_per_mmio_device, const bool skip_driver_allocs, const bool clean_system_resources);
-    void initialize_interprocess_mutexes(int pci_interface_id, bool cleanup_mutexes_in_shm);
+    void initialize_interprocess_mutexes(tt::umd::chip_id pci_interface_id, bool cleanup_mutexes_in_shm);
     void cleanup_shared_host_state();
     void initialize_pcie_devices();
     void broadcast_pcie_tensix_risc_reset(struct PCIdevice *device, const TensixSoftResetOptions &cores);
@@ -881,7 +880,7 @@ class tt_SiliconDevice: public tt_device
     void init_pcie_iatus_no_p2p();
     bool init_hugepage(chip_id_t device_id);
     bool init_dmabuf(chip_id_t device_id);
-    void check_pcie_device_initialized(int device_id);
+    void check_pcie_device_initialized(tt::umd::chip_id device_id);
     bool init_dma_turbo_buf(struct PCIdevice* pci_device);
     bool uninit_dma_turbo_buf(struct PCIdevice* pci_device);
     static std::map<chip_id_t, std::string> get_physical_device_id_to_bus_id_map(std::vector<chip_id_t> physical_device_ids);
@@ -894,10 +893,10 @@ class tt_SiliconDevice: public tt_device
     void enable_remote_ethernet_queue(const chip_id_t& chip, int timeout);
     void deassert_resets_and_set_power_state();
     int open_hugepage_file(const std::string &dir, chip_id_t device_id, uint16_t channel);
-    int iatu_configure_peer_region (int logical_device_id, uint32_t peer_region_id, uint64_t bar_addr_64, uint32_t region_size);
+    int iatu_configure_peer_region (tt::umd::chip_id logical_device_id, uint32_t peer_region_id, uint64_t bar_addr_64, uint32_t region_size);
     uint32_t get_harvested_noc_rows (uint32_t harvesting_mask);
-    uint32_t get_harvested_rows (int logical_device_id);
-    int get_clock(int logical_device_id);
+    uint32_t get_harvested_rows (tt::umd::chip_id logical_device_id);
+    int get_clock(tt::umd::chip_id logical_device_id);
 
     // Communication Functions
     void read_dma_buffer(void* mem_ptr, std::uint32_t address, std::uint16_t channel, std::uint32_t size_in_bytes, chip_id_t src_device_id);
@@ -919,17 +918,17 @@ class tt_SiliconDevice: public tt_device
     uint64_t get_sys_addr(uint32_t chip_x, uint32_t chip_y, uint32_t noc_x, uint32_t noc_y, uint64_t offset);
     uint16_t get_sys_rack(uint32_t rack_x, uint32_t rack_y);
     bool is_non_mmio_cmd_q_full(uint32_t curr_wptr, uint32_t curr_rptr);
-    int pcie_arc_msg(int logical_device_id, uint32_t msg_code, bool wait_for_done = true, uint32_t arg0 = 0, uint32_t arg1 = 0, int timeout=1, uint32_t *return_3 = nullptr, uint32_t *return_4 = nullptr);
-    int remote_arc_msg(int logical_device_id, uint32_t msg_code, bool wait_for_done = true, uint32_t arg0 = 0, uint32_t arg1 = 0, int timeout=1, uint32_t *return_3 = nullptr, uint32_t *return_4 = nullptr);
-    bool address_in_tlb_space(uint32_t address, uint32_t size_in_bytes, int32_t tlb_index, uint64_t tlb_size, uint32_t chip);
-    struct PCIdevice* get_pci_device(int pci_intf_id) const;
-    std::shared_ptr<boost::interprocess::named_mutex> get_mutex(const std::string& tlb_name, int pci_interface_id);
-    virtual uint32_t get_harvested_noc_rows_for_chip(int logical_device_id); // Returns one-hot encoded harvesting mask for PCIe mapped chips
+    int pcie_arc_msg(tt::umd::chip_id logical_device_id, uint32_t msg_code, bool wait_for_done = true, uint32_t arg0 = 0, uint32_t arg1 = 0, int timeout=1, uint32_t *return_3 = nullptr, uint32_t *return_4 = nullptr);
+    int remote_arc_msg(tt::umd::chip_id logical_device_id, uint32_t msg_code, bool wait_for_done = true, uint32_t arg0 = 0, uint32_t arg1 = 0, int timeout=1, uint32_t *return_3 = nullptr, uint32_t *return_4 = nullptr);
+    bool address_in_tlb_space(uint32_t address, uint32_t size_in_bytes, int32_t tlb_index, uint64_t tlb_size, tt::umd::chip_id chip);
+    struct PCIdevice* get_pci_device(tt::umd::chip_id pci_intf_id) const;
+    std::shared_ptr<boost::interprocess::named_mutex> get_mutex(const std::string& tlb_name, tt::umd::chip_id pci_interface_id);
+    virtual uint32_t get_harvested_noc_rows_for_chip(tt::umd::chip_id logical_device_id); // Returns one-hot encoded harvesting mask for PCIe mapped chips
     void generate_tensix_broadcast_grids_for_grayskull( std::set<std::pair<tt_xy_pair, tt_xy_pair>>& broadcast_grids, std::set<uint32_t>& rows_to_exclude, std::set<uint32_t>& cols_to_exclude);
     std::unordered_map<chip_id_t, std::vector<std::vector<int>>>&  get_ethernet_broadcast_headers(const std::set<chip_id_t>& chips_to_exclude);
     // Test functions
     void verify_eth_fw();
-    void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t> &fw_versions);
+    void verify_sw_fw_versions(tt::umd::chip_id device_id, std::uint32_t sw_version, std::vector<std::uint32_t> &fw_versions);
     int test_pcie_tlb_setup (struct PCIdevice* pci_device);
     int test_setup_interface ();
     int test_broadcast (int logical_device_id);
@@ -1007,7 +1006,7 @@ class tt_SiliconDevice: public tt_device
     static constexpr std::uint32_t SW_VERSION = 0x06060000;
 };
 
-tt::ARCH detect_arch(uint16_t device_id = 0);
+tt::ARCH detect_arch(tt::umd::chip_id device_id = {});
 
 uint32_t get_num_hugepages();
 

--- a/device/xy_pair.h
+++ b/device/xy_pair.h
@@ -10,6 +10,8 @@
 
 namespace tt::umd {
 
+enum class chip_id : int;
+
 struct xy_pair {
     constexpr xy_pair() : x{}, y{} {}
     constexpr xy_pair(std::size_t x, std::size_t y) : x(x), y(y) {}
@@ -30,13 +32,13 @@ constexpr inline bool operator<(const xy_pair &left, const xy_pair &right) {
 
 struct cxy_pair : public xy_pair {
     cxy_pair() : xy_pair{}, chip{} {}
-    cxy_pair(std::size_t ichip, xy_pair pair) : xy_pair(pair.x, pair.y), chip(ichip) {}
-    cxy_pair(std::size_t ichip, std::size_t x, std::size_t y) : xy_pair(x, y), chip(ichip) {}
+    cxy_pair(chip_id ichip, xy_pair pair) : xy_pair(pair.x, pair.y), chip(ichip) {}
+    cxy_pair(chip_id ichip, std::size_t x, std::size_t y) : xy_pair(x, y), chip(ichip) {}
 
-    std::size_t chip;
+    chip_id chip;
 
     std::string str() const {
-        return "(chip=" + std::to_string(chip) + ",x=" + std::to_string(x) + ",y=" + std::to_string(y) + ")";
+        return "(chip=" + std::to_string(static_cast<std::size_t>(chip)) + ",x=" + std::to_string(x) + ",y=" + std::to_string(y) + ")";
     }
 };
 
@@ -70,7 +72,7 @@ template <>
 struct hash<tt::umd::cxy_pair> {
     std::size_t operator()(tt::umd::cxy_pair const &o) const {
         std::size_t seed = 0;
-        seed = std::hash<std::size_t>()(o.chip) ^ (std::hash<std::size_t>()(o.x) << 1) ^
+        seed = std::hash<std::size_t>()(static_cast<std::size_t>(o.chip)) ^ (std::hash<std::size_t>()(o.x) << 1) ^
                (std::hash<std::size_t>()(o.y) << 2);
         return seed;
     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/12405

### Problem description
Aliases of integral types are being used interchangeably with the integral types, allowing for erroneous implicit conversions.

### What's changed
Refactor to use enum class and make any intentional conversions explicit.