### PR TITLE
Replace snprintf and string concat with fmt::format

### DIFF
--- a/device/cpuset_lib.cpp
+++ b/device/cpuset_lib.cpp
@@ -379,7 +379,7 @@ std::string tt_cpuset_allocator::get_pci_bus_id(hwloc_obj_t pci_device_obj){
 
     if (hwloc_obj_type_is_io(pci_device_obj->type)) {        
         auto attrs = pci_device_obj->attr->pcidev;
-        pci_bus_id_str = fmt::format("{:04x}{:02x}{:02x}{:01x}", attrs.domain, attrs.bus, attrs.dev, attrs.func);
+        pci_bus_id_str = fmt::format("{:04x}:{:02x}:{:02x}.{:01x}", attrs.domain, attrs.bus, attrs.dev, attrs.func);
     }
 
     return pci_bus_id_str;

--- a/device/cpuset_lib.cpp
+++ b/device/cpuset_lib.cpp
@@ -9,6 +9,7 @@
 #include <thread>
 #include "device/tt_device.h"
 #include <filesystem>
+#include "fmt/core.h"
 namespace tt {
 
 namespace fs = std::filesystem;
@@ -97,7 +98,7 @@ bool tt_cpuset_allocator::init_find_tt_pci_devices_packages_numanodes(){
             m_num_tt_device_by_pci_device_id_map[device_id_revision] += 1;
 
             std::string pci_bus_id_str  = get_pci_bus_id(pci_device_obj);
-            std::string pci_device_dir  = "/sys/bus/pci/devices/" + pci_bus_id_str + "/tenstorrent/";
+            std::string pci_device_dir = fmt::format("/sys/bus/pci/devices/{}/tenstorrent/", pci_bus_id_str);
             int physical_device_id = -1;
 
             log_trace(LogSiliconDriver, "Found TT device with pci_bus_id_str: {} num_devices_by_pci_device_id: {}", pci_bus_id_str, m_num_tt_device_by_pci_device_id_map[device_id_revision]);
@@ -376,11 +377,9 @@ std::string tt_cpuset_allocator::get_pci_bus_id(hwloc_obj_t pci_device_obj){
 
     std::string pci_bus_id_str = "";
 
-    if (hwloc_obj_type_is_io(pci_device_obj->type)) {
-        char pci_bus_id[14];
+    if (hwloc_obj_type_is_io(pci_device_obj->type)) {        
         auto attrs = pci_device_obj->attr->pcidev;
-        snprintf(pci_bus_id, sizeof(pci_bus_id), "%04x:%02x:%02x.%01x", attrs.domain, attrs.bus, attrs.dev, attrs.func);
-        pci_bus_id_str = (std::string) pci_bus_id;
+        pci_bus_id_str = fmt::format("{:04x}{:02x}{:02x}{:01x}", attrs.domain, attrs.bus, attrs.dev, attrs.func);
     }
 
     return pci_bus_id_str;

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -150,7 +150,7 @@ void PCIDevice::setup_device() {
     mappings.query_mappings.in.output_mapping_count = 8;
 
     if (ioctl(device_fd, TENSTORRENT_IOCTL_QUERY_MAPPINGS, &mappings.query_mappings) == -1) {
-        throw std::runtime_error(std::string("Query mappings failed on device ") + std::to_string(device_id) + ".");
+        throw std::runtime_error(fmt::format("Query mappings failed on device {}.", device_id));
     }
 
     // Mapping resource to BAR
@@ -203,7 +203,7 @@ void PCIDevice::setup_device() {
     }
 
     if (bar0_uc_mapping.mapping_id != TENSTORRENT_MAPPING_RESOURCE0_UC) {
-        throw std::runtime_error(std::string("Device ") + std::to_string(device_id) + " has no BAR0 UC mapping.");
+        throw std::runtime_error(fmt::format("Device {} has no BAR0 UC mapping.", device_id));
     }
 
     auto wc_mapping_size = arch == tt::ARCH::BLACKHOLE ? BH_BAR0_WC_MAPPING_SIZE : GS_BAR0_WC_MAPPING_SIZE;
@@ -231,7 +231,7 @@ void PCIDevice::setup_device() {
     bar0_uc = mmap(NULL, bar0_uc_size, PROT_READ | PROT_WRITE, MAP_SHARED, device_fd, bar0_uc_mapping.mapping_base + bar0_uc_offset);
 
     if (bar0_uc == MAP_FAILED) {
-        throw std::runtime_error(std::string("BAR0 UC memory mapping failed for device ") + std::to_string(device_id) + ".");
+        throw std::runtime_error(fmt::format("BAR0 UC mapping failed for device {}.", device_id));
     }
 
     if (!bar0_wc) {
@@ -240,7 +240,7 @@ void PCIDevice::setup_device() {
 
     if (arch == tt::ARCH::WORMHOLE_B0) {
         if (bar4_uc_mapping.mapping_id != TENSTORRENT_MAPPING_RESOURCE2_UC) {
-            throw std::runtime_error(std::string("Device ") + std::to_string(device_id) + " has no BAR4 UC mapping.");
+            throw std::runtime_error(fmt::format("Device {} has no BAR4 UC mapping.", device_id));
         }
 
         system_reg_mapping_size = bar4_uc_mapping.mapping_size;
@@ -248,14 +248,14 @@ void PCIDevice::setup_device() {
         system_reg_mapping = mmap(NULL, bar4_uc_mapping.mapping_size, PROT_READ | PROT_WRITE, MAP_SHARED, device_fd, bar4_uc_mapping.mapping_base);
 
         if (system_reg_mapping == MAP_FAILED) {
-            throw std::runtime_error(std::string("BAR4 UC memory mapping failed for device ") + std::to_string(device_id) + ".");
+            throw std::runtime_error(fmt::format("BAR4 UC mapping failed for device {}.", device_id));
         }
 
         system_reg_start_offset = (512 - 16) * 1024*1024;
         system_reg_offset_adjust = (512 - 32) * 1024*1024;
     } else if(arch == tt::ARCH::BLACKHOLE) {
         if (bar2_uc_mapping.mapping_id != TENSTORRENT_MAPPING_RESOURCE1_UC) {
-            throw std::runtime_error(std::string("Device ") + std::to_string(device_id) + " has no BAR2 UC mapping.");
+            throw std::runtime_error(fmt::format("Device {} has no BAR2 UC mapping.", device_id));
         }
 
         // Using UnCachable memory mode. This is used for accessing registers on Blackhole.
@@ -263,11 +263,11 @@ void PCIDevice::setup_device() {
         bar2_uc = mmap(NULL, bar2_uc_mapping.mapping_size, PROT_READ | PROT_WRITE, MAP_SHARED, device_fd, bar2_uc_mapping.mapping_base);
 
         if (bar2_uc == MAP_FAILED) {
-            throw std::runtime_error(std::string("BAR2 UC memory mapping failed for device ") + std::to_string(device_id) + ".");
+            throw std::runtime_error(fmt::format("BAR2 UC mapping failed for device {}.", device_id));
         }
 
         if (bar4_wc_mapping.mapping_id != TENSTORRENT_MAPPING_RESOURCE2_WC) {
-            throw std::runtime_error(std::string("Device ") + std::to_string(device_id) + " has no BAR4 WC mapping.");
+            throw std::runtime_error(fmt::format("Device {} has no BAR4 WC mapping.", device_id));
         }
 
         // Using Write-Combine memory mode. This is used for accessing DRAM on Blackhole.
@@ -276,7 +276,7 @@ void PCIDevice::setup_device() {
         bar4_wc = mmap(NULL, bar4_wc_mapping.mapping_size, PROT_READ | PROT_WRITE, MAP_SHARED, device_fd, bar4_wc_mapping.mapping_base);
 
         if (bar4_wc == MAP_FAILED) {
-            throw std::runtime_error(std::string("BAR4 WC memory mapping failed for device ") + std::to_string(device_id) + ".");
+            throw std::runtime_error(fmt::format("BAR4 WC mapping failed for device {}.", device_id));
         }
     }
 
@@ -332,7 +332,7 @@ void PCIDevice::open_hugepage_per_host_mem_ch(uint32_t num_host_mem_channels) {
         log_debug(LogSiliconDriver, "Opening device_fd_per_host_ch device index: {} ch: {} (num_host_mem_channels: {})", device_id, ch, num_host_mem_channels);
         int device_fd_for_host_mem = find_device(device_id);
         if (device_fd_for_host_mem == -1) {
-            throw std::runtime_error(std::string("Failed opening a host memory device handle for device ") + std::to_string(device_id));
+            throw std::runtime_error(fmt::format("Failed opening a host memory device handle for device {}.", device_id));
         }
         device_fd_per_host_ch.push_back(device_fd_for_host_mem);
     }

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -12,6 +12,8 @@
 #include "common/logger.hpp"
 #include "yaml-cpp/yaml.h"
 
+#include "fmt/core.h"
+
 using namespace tt;
 bool tt_ClusterDescriptor::ethernet_core_has_active_ethernet_link(chip_id_t local_chip, ethernet_channel_t local_ethernet_channel) const {
     return this->ethernet_connections.find(local_chip) != this->ethernet_connections.end() &&
@@ -297,7 +299,7 @@ std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_from_yaml(con
 
     std::ifstream fdesc(cluster_descriptor_file_path);
     if (fdesc.fail()) {
-        throw std::runtime_error("Error: cluster connectivity descriptor file " + cluster_descriptor_file_path + " does not exist!");
+        throw std::runtime_error(fmt::format("Error: cluster connectivity descriptor file {} does not exist!", cluster_descriptor_file_path));
     }
     fdesc.close();
 

--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -21,6 +21,7 @@
 #include "device/tt_io.hpp"
 
 #include "pcie/pci_device.hpp"
+#include "fmt/core.h"
 
 using TLB_DATA = tt::umd::tlb_data;
 
@@ -126,7 +127,7 @@ struct tt_version {
         patch = version & 0xfff;
     }
     std::string str() const {
-        return std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(patch);
+        return fmt::format("{}.{}.{}", major, minor, patch);
     }
 };
 
@@ -149,7 +150,7 @@ struct tt_device_params {
             if (dump_core == "*") {
                 for (size_t x = 0; x < grid_size.x; x++) {
                 for (size_t y = 0; y < grid_size.y; y++) {
-                    std::string current_core_coord(std::to_string(x) + "-" + std::to_string(y));
+                    std::string current_core_coord = fmt::format("{}-{}", x, y);
                     if (std::find(std::begin(unrolled_dump_core), std::end(unrolled_dump_core), current_core_coord) == std::end(unrolled_dump_core)) {
                         unrolled_dump_core.push_back(current_core_coord);
                     }
@@ -169,7 +170,7 @@ struct tt_device_params {
             if (core_dim_x == "*" && core_dim_y == "*") {
                 for (size_t x = 0; x < grid_size.x; x++) {
                     for (size_t y = 0; y < grid_size.y; y++) {
-                        std::string current_core_coord(std::to_string(x) + "-" + std::to_string(y));
+                        std::string current_core_coord = fmt::format("{}-{}", x, y);
                         if (std::find(std::begin(unrolled_dump_core), std::end(unrolled_dump_core), current_core_coord) == std::end(unrolled_dump_core)) {
                             unrolled_dump_core.push_back(current_core_coord);
                         }
@@ -177,14 +178,14 @@ struct tt_device_params {
                 }
             } else if (core_dim_x == "*") {
                 for (size_t x = 0; x < grid_size.x; x++) {
-                    std::string current_core_coord(std::to_string(x) + "-" + core_dim_y);
+                    std::string current_core_coord = fmt::format("{}-{}", x, core_dim_y);
                     if (std::find(std::begin(unrolled_dump_core), std::end(unrolled_dump_core), current_core_coord) == std::end(unrolled_dump_core)) {
                         unrolled_dump_core.push_back(current_core_coord);
                     }
                 }
             } else if (core_dim_y == "*") {
                 for (size_t y = 0; y < grid_size.y; y++) {
-                    std::string current_core_coord(core_dim_x + "-" + std::to_string(y));
+                    std::string current_core_coord = fmt::format("{}-{}", core_dim_x, y);
                     if (std::find(std::begin(unrolled_dump_core), std::end(unrolled_dump_core), current_core_coord) == std::end(unrolled_dump_core)) {
                         unrolled_dump_core.push_back(current_core_coord);
                     }
@@ -198,8 +199,8 @@ struct tt_device_params {
 
     std::vector<std::string> expand_plusargs() const {
         std::vector<std::string> all_plusargs {
-            "+enable_perf_scoreboard=" + std::to_string(enable_perf_scoreboard),
-            "+register_monitor=" + std::to_string(register_monitor)
+            fmt::format("+enable_perf_scoreboard={}", enable_perf_scoreboard),
+            fmt::format("+register_monitor={}", register_monitor)
         };
 
         all_plusargs.insert(all_plusargs.end(), plusargs.begin(), plusargs.end());

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -465,7 +465,7 @@ void tt_SiliconDevice::initialize_interprocess_mutexes(int pci_interface_id, boo
     }
 
     // Initialize ARC core mutex
-    mutex_name = "ARC_MSG" + std::to_string(pci_interface_id);
+    mutex_name = fmt::format("ARC_MSG{}", pci_interface_id);
     if (cleanup_mutexes_in_shm) named_mutex::remove(mutex_name.c_str());
     hardware_resource_mutex_map[mutex_name] = std::make_shared<named_mutex>(open_or_create, mutex_name.c_str(), unrestricted_permissions);
 
@@ -835,21 +835,21 @@ void tt_SiliconDevice::check_pcie_device_initialized(int device_id) {
     tt::ARCH device_arch = pci_device->get_arch();
     if (arch_name == tt::ARCH::GRAYSKULL) {
         if (device_arch != tt::ARCH::GRAYSKULL) {
-            throw std::runtime_error("Attempted to run grayskull configured tt_device on " + get_arch_str(device_arch));
+            throw std::runtime_error(fmt::format("Attempted to run grayskull configured tt_device on {}", get_arch_str(device_arch)));
         }
     }
     else if (arch_name == tt::ARCH::WORMHOLE || arch_name == tt::ARCH::WORMHOLE_B0) {
         if (device_arch != tt::ARCH::WORMHOLE && device_arch != tt::ARCH::WORMHOLE_B0) {
-            throw std::runtime_error("Attempted to run wormhole configured tt_device on " + get_arch_str(device_arch));
+            throw std::runtime_error(fmt::format("Attempted to run wormhole configured tt_device on {}", get_arch_str(device_arch)));
         }
     }
     else if (arch_name == tt::ARCH::BLACKHOLE) {
         if (device_arch != tt::ARCH::BLACKHOLE) {
-            throw std::runtime_error("Attempted to run blackhole configured tt_device on " + get_arch_str(device_arch));
+            throw std::runtime_error(fmt::format("Attempted to run blackhole configured tt_device on {}", get_arch_str(device_arch)));
         }
     }
     else {
-        throw std::runtime_error("Unsupported architecture: " + get_arch_str(arch_name));
+        throw std::runtime_error(fmt::format("Unsupported architecture: {}", get_arch_str(arch_name)));
     }
     auto architecture_implementation = pci_device->get_architecture_implementation();
 
@@ -862,11 +862,12 @@ void tt_SiliconDevice::check_pcie_device_initialized(int device_id) {
         uint32_t arc_msg_return = arc_msg(device_id, 0xaa00 | architecture_implementation->get_arc_message_test(), true, arg, 0, 1, &bar_read_again);
         if (arc_msg_return != 0 || bar_read_again != arg + 1) {
             auto postcode = bar_read32(device_id, architecture_implementation->get_arc_reset_scratch_offset());
-            throw std::runtime_error("Device is not initialized: arc_fw postcode: " + std::to_string(postcode)
-            + " arc_msg_return: " + std::to_string(arc_msg_return)
-            + " arg: " + std::to_string(arg)
-            + " bar_read_initial: " + std::to_string(bar_read_initial)
-            + " bar_read_again: " + std::to_string(bar_read_again));
+            throw std::runtime_error(fmt::format("Device is not initialized: arc_fw postcode: {} arc_msg_return: {} arg: {} bar_read_initial: {} bar_read_again: {}",
+                                                 postcode,
+                                                 arc_msg_return,
+                                                 arg,
+                                                 bar_read_initial,
+                                                 bar_read_again));
         }
     }
 
@@ -1085,7 +1086,7 @@ std::function<void(uint32_t, uint32_t, const uint8_t*)> tt_SiliconDevice::get_fa
 
 tt::Writer tt_SiliconDevice::get_static_tlb_writer(tt_cxy_pair target) {
     if (!ndesc->is_chip_mmio_capable(target.chip)) {
-        throw std::runtime_error("Target not in MMIO chip: " + target.str());
+        throw std::runtime_error(fmt::format("Target not in MMIO chip: {}", target.str()));
     }
 
     if (!tlbs_init || !map_core_to_tlb) {
@@ -1102,7 +1103,7 @@ tt::Writer tt_SiliconDevice::get_static_tlb_writer(tt_cxy_pair target) {
     auto tlb_data = dev->get_architecture_implementation()->describe_tlb(tlb_index);
 
     if (!tlb_data.has_value()) {
-        throw std::runtime_error("No TLB mapped to core " + target.str());
+        throw std::runtime_error(fmt::format("No TLB mapped to core {}", target.str()));
     }
 
     auto [tlb_offset, tlb_size] = tlb_data.value();
@@ -1209,9 +1210,10 @@ void tt_SiliconDevice::read_buffer(
     if(hugepage_mapping.at(src_device_id).at(channel)) {
       user_scratchspace = static_cast<char*>(hugepage_mapping.at(src_device_id).at(channel)) + (address & HUGEPAGE_MAP_MASK);
     } else {
-      std::string err_msg = "write_buffer: Hugepages are not allocated for src_device_id: " + std::to_string(src_device_id) + " ch: " + std::to_string(channel);
-      err_msg += " - Ensure sufficient number of Hugepages installed per device (1 per host mem ch, per device)";
-      throw std::runtime_error(err_msg);
+        throw std::runtime_error(fmt::format("write_buffer: Hugepages are not allocated for src_device_id: {} ch: {}."
+                                             " - Ensure sufficient number of Hugepages installed per device (1 per host mem ch, per device)",
+                                             src_device_id,
+                                             channel));
     }
 
     LOG1("---- tt_SiliconDevice::read_buffer (src_device_id: %d, ch: %d) from 0x%lx\n",  src_device_id, channel, user_scratchspace);
@@ -1236,8 +1238,9 @@ void tt_SiliconDevice::write_buffer(
         size);
       user_scratchspace = static_cast<char*>(hugepage_mapping.at(src_device_id).at(channel)) + (address & HUGEPAGE_MAP_MASK);
     } else {
-      std::string err_msg = "write_buffer: Hugepage are not allocated for src_device_id: " + std::to_string(src_device_id) + " ch: " + std::to_string(channel);
-      throw std::runtime_error(err_msg);
+        throw std::runtime_error(fmt::format("write_buffer: Hugepage are not allocated for src_device_id: {} ch: {}",
+                                             src_device_id,
+                                             channel));
     }
     memcpy(user_scratchspace, mem_ptr, size);
 }
@@ -1273,8 +1276,7 @@ void tt_SiliconDevice::set_pcie_power_state(tt_DevicePowerState state) {
         ss << state;
         auto exit_code = arc_msg(d, 0xaa00 | msg, true, 0, 0);
         if (exit_code != 0) {
-            throw std::runtime_error(
-                "Failed to set power state to " + ss.str() + " with exit code " + std::to_string(exit_code));
+            throw std::runtime_error(fmt::format("Failed to set power state to {} with exit code {}", ss.str(), exit_code));
         }
     }
 }
@@ -1297,7 +1299,7 @@ int tt_SiliconDevice::get_clock(int logical_device_id) {
     PCIDevice* pci_device = get_pci_device(mmio_capable_chip_logical);
     auto exit_code = arc_msg(logical_device_id, 0xaa00 | pci_device->get_architecture_implementation()->get_arc_message_get_aiclk(), true, 0xFFFF, 0xFFFF, 1, &clock);
     if (exit_code != 0) {
-        throw std::runtime_error("Failed to get aiclk value with exit code " + std::to_string(exit_code));
+        throw std::runtime_error(fmt::format("Failed to get aiclk value with exit code {}", exit_code));
     }
     return clock;
 }
@@ -1388,8 +1390,7 @@ void tt_SiliconDevice::init_pcie_iatus() {
                 }
                 host_channel_size.at(src_pci_device -> logical_id).push_back(region_size);
             } else {
-                std::string err_msg = "init_pcie_iatus: Hugepages are not allocated for src_pci_id: " + std::to_string(src_pci_id) + " ch: " + std::to_string(channel_id);
-                throw std::runtime_error(err_msg);
+                throw std::runtime_error(fmt::format("init_pcie_iatus: Hugepages are not allocated for src_pci_id: {} ch: {}", src_pci_id, channel_id));
             }
         }
     }
@@ -1399,7 +1400,7 @@ void tt_SiliconDevice::init_pcie_iatus() {
 std::string find_hugepage_dir(std::size_t pagesize)
 {
 
-    static const std::regex hugetlbfs_mount_re("^(nodev|hugetlbfs) (" + hugepage_dir + ") hugetlbfs ([^ ]+) 0 0$");
+    static const std::regex hugetlbfs_mount_re(fmt::format("^(nodev|hugetlbfs) () hugetlbfs ([^ ]+) 0 0$", hugepage_dir));
     static const std::regex pagesize_re("(?:^|,)pagesize=([0-9]+)([KMGT])(?:,|$)");
 
     std::ifstream proc_mounts("/proc/mounts");
@@ -1446,12 +1447,12 @@ int tt_SiliconDevice::open_hugepage_file(const std::string &dir, chip_id_t physi
     // In order to limit number of hugepages while transition from shared hugepage (1 per system) to unique
     // hugepage per device, will share original/shared hugepage filename with physical device 0.
     if (physical_device_id != 0 || channel != 0){
-        std::string device_id_str = "device_" + std::to_string((int)physical_device_id) + "_";
+        std::string device_id_str = fmt::format("device_{}_channel_{}_", physical_device_id, channel);
         filename.insert(filename.end(), device_id_str.begin(), device_id_str.end());
     }
 
     if (channel != 0) {
-        std::string channel_id_str = "channel_" + std::to_string(channel) + "_";
+        std::string channel_id_str = fmt::format("channel_{}_", channel);
         filename.insert(filename.end(), channel_id_str.begin(), channel_id_str.end());
     }
 
@@ -1609,7 +1610,7 @@ int tt_SiliconDevice::test_setup_interface () {
         return 0;
     }
     else {
-        throw std::runtime_error("Unsupported architecture: " + get_arch_str(arch_name));
+        throw std::runtime_error(fmt::format("Unsupported architecture: {}", get_arch_str(arch_name)));
     }
 }
 
@@ -1670,7 +1671,7 @@ int tt_SiliconDevice::pcie_arc_msg(int logical_device_id, uint32_t msg_code, boo
         auto start = std::chrono::system_clock::now();
         while (true) {
             if (std::chrono::system_clock::now() - start > timeout_seconds) {
-                throw std::runtime_error("Timed out after waiting " + std::to_string(timeout) + " seconds for device " + std::to_string(logical_device_id) + " ARC to respond");
+                throw std::runtime_error(fmt::format("Timed out after waiting {} seconds for device {} ARC to respond", timeout, logical_device_id));
             }
 
             status = bar_read32(logical_device_id, architecture_implementation->get_arc_reset_scratch_offset() + 5 * 4);
@@ -1801,7 +1802,7 @@ void tt_SiliconDevice::enable_local_ethernet_queue(const chip_id_t &device_id, i
     auto start = std::chrono::system_clock::now();
     while (msg_success != 1) {
         if (std::chrono::system_clock::now() - start > timeout_seconds) {
-            throw std::runtime_error("Timed out after waiting " + std::to_string(timeout) + " seconds for DRAM to finish training");
+            throw std::runtime_error(fmt::format("Timed out after waiting {} seconds for for DRAM to finish training", timeout));
         }
 
         if (arc_msg(device_id, 0xaa58, true, 0xFFFF, 0xFFFF, 1, &msg_success) == MSG_ERROR_REPLY) {
@@ -1821,7 +1822,7 @@ void *tt_SiliconDevice::host_dma_address(std::uint64_t offset, chip_id_t src_dev
 // Wrapper for throwing more helpful exception when not-enabled pci intf is accessed.
 inline PCIDevice* tt_SiliconDevice::get_pci_device(int device_id) const {
     if (!m_pci_device_map.count(device_id)){
-        throw std::runtime_error(std::string("device_id: " + std::to_string(device_id) + " attempted to be accessed, but is not enabled."));
+        throw std::runtime_error(fmt::format("device_id: {} attempted to be accessed, but is not enabled.", device_id));
     }
     return m_pci_device_map.at(device_id).get();
 }
@@ -2631,7 +2632,7 @@ int tt_SiliconDevice::remote_arc_msg(int chip, uint32_t msg_code, bool wait_for_
             if (std::chrono::system_clock::now() - start > timeout_seconds) {
                 std::stringstream ss;
                 ss << std::hex << msg_code;
-                throw std::runtime_error("Timed out after waiting " + std::to_string(timeout) + " seconds for device " + std::to_string(chip) + " ARC to respond to message 0x" +  ss.str());
+                throw std::runtime_error(fmt::format("Timed out after waiting {} seconds for device {} ARC to respond to message 0x{}", timeout, chip, ss.str()));
             }
 
             uint32_t status = 0;
@@ -2880,7 +2881,7 @@ void tt_SiliconDevice::enable_remote_ethernet_queue(const chip_id_t& chip, int t
     auto start = std::chrono::system_clock::now();
     while (msg_success != 1) {
         if (std::chrono::system_clock::now() - start > timeout_seconds) {
-            throw std::runtime_error("Timed out after waiting " + std::to_string(timeout) + " seconds for DRAM to finish training");
+            throw std::runtime_error(fmt::format("Timed out after waiting {} seconds for DRAM to finish training", timeout));
         }
         int msg_rt = remote_arc_msg(chip, 0xaa58, true, 0xFFFF, 0xFFFF, 1, &msg_success, NULL);
         if (msg_rt == MSG_ERROR_REPLY) {

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -1400,7 +1400,7 @@ void tt_SiliconDevice::init_pcie_iatus() {
 std::string find_hugepage_dir(std::size_t pagesize)
 {
 
-    static const std::regex hugetlbfs_mount_re(fmt::format("^(nodev|hugetlbfs) () hugetlbfs ([^ ]+) 0 0$", hugepage_dir));
+    static const std::regex hugetlbfs_mount_re(fmt::format("^(nodev|hugetlbfs) ({}) hugetlbfs ([^ ]+) 0 0$", hugepage_dir));
     static const std::regex pagesize_re("(?:^|,)pagesize=([0-9]+)([KMGT])(?:,|$)");
 
     std::ifstream proc_mounts("/proc/mounts");

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -12,9 +12,11 @@
 #include <string>
 #include <unordered_set>
 
+#include "fmt/core.h"
+
 // #include "l1_address_map.h"
 
-std::string format_node(tt_xy_pair xy) { return std::to_string(xy.x) + "-" + std::to_string(xy.y); }
+std::string format_node(tt_xy_pair xy) { return fmt::format("{}-{}", xy.x, xy.y); }
 
 tt_xy_pair format_node(std::string str) {
   int x_coord;
@@ -26,7 +28,7 @@ tt_xy_pair format_node(std::string str) {
     x_coord = std::stoi(x_y_pair[1]);
     y_coord = std::stoi(x_y_pair[2]);
   } else {
-    throw std::runtime_error("Could not parse the core id: " + str);
+    throw std::runtime_error(fmt::format("Could not parse the core id: {}", str));
   }
 
   tt_xy_pair xy(x_coord, y_coord);
@@ -167,7 +169,7 @@ void tt_SocDescriptor::load_core_descriptors_from_device_descriptor(YAML::Node &
 tt_SocDescriptor::tt_SocDescriptor(std::string device_descriptor_path) {
     std::ifstream fdesc(device_descriptor_path);
     if (fdesc.fail()) {
-        throw std::runtime_error("Error: device descriptor file " + device_descriptor_path + " does not exist!");
+        throw std::runtime_error(fmt::format("Error: device descriptor file {} does not exist!", device_descriptor_path));
     }
     fdesc.close();
 

--- a/device/tt_soc_descriptor.h
+++ b/device/tt_soc_descriptor.h
@@ -19,6 +19,9 @@
 #include "tt_xy_pair.h"
 #include "device/tt_arch_types.h"
 
+
+#include "fmt/core.h"
+
 namespace YAML {
     class Node;
 }
@@ -60,7 +63,7 @@ static inline tt::ARCH get_arch_name(const std::string &arch_str){
         arch = tt::ARCH::BLACKHOLE;
     }else {
         throw std::runtime_error(
-            "At LoadSocDescriptorFromYaml: \"" + arch_str + "\" is not recognized as tt::ARCH.");
+            fmt::format("At LoadSocDescriptorFromYaml: \"{}\" is not recognized as tt::ARCH.", arch_str));
     }
 
     return arch;

--- a/device/xy_pair.h
+++ b/device/xy_pair.h
@@ -8,6 +8,8 @@
 
 #include <string>
 
+#include "fmt/core.h"
+
 namespace tt::umd {
 
 struct xy_pair {
@@ -17,7 +19,7 @@ struct xy_pair {
     std::size_t x;
     std::size_t y;
 
-    std::string str() const { return "(x=" + std::to_string(x) + ",y=" + std::to_string(y) + ")"; }
+    std::string str() const { return fmt::format("(x={},y={})", x, y); }
 };
 
 constexpr inline bool operator==(const xy_pair &a, const xy_pair &b) { return a.x == b.x && a.y == b.y; }
@@ -36,7 +38,7 @@ struct cxy_pair : public xy_pair {
     std::size_t chip;
 
     std::string str() const {
-        return "(chip=" + std::to_string(chip) + ",x=" + std::to_string(x) + ",y=" + std::to_string(y) + ")";
+        return fmt::format("(chip={},x={},y={})", chip, x, y);
     }
 };
 

--- a/tests/galaxy/test_galaxy_common.h
+++ b/tests/galaxy/test_galaxy_common.h
@@ -16,6 +16,8 @@
 #include "device/tt_device.h"
 #include "device/tt_xy_pair.h"
 
+#include "fmt/core.h"
+
 // static const std::string SOC_DESC_PATH = "./tests/soc_descs/wormhole_b0_8x10.yaml";
 
 using chip_id_t = int;
@@ -29,10 +31,7 @@ struct tt_multichip_core_addr {
     chip_id_t chip;
     std::uint64_t addr;
     std::string str() const {
-        std::stringstream ss;
-        ss << std::hex << addr << std::dec;
-        return "(chip=" + std::to_string(chip) + ",x=" + std::to_string(core.x) + ",y=" + std::to_string(core.y) +
-               ",addr=0x" + ss.str() + ")";
+        return fmt::format("(chip={},x={},y={},addr=0x{:x})", chip, core.x, core.y, addr);
     }
 };
 

--- a/tests/test_utils/generate_cluster_desc.cpp
+++ b/tests/test_utils/generate_cluster_desc.cpp
@@ -20,7 +20,7 @@ fs::path generate_cluster_desc_yaml() {
 
     fs::path eth_fpath = fs::path ( __FILE__ ).parent_path().parent_path().parent_path();
     eth_fpath /= "device/bin/silicon/x86/create-ethernet-map";
-    std::string cmd = eth_fpath.string() + " " + umd_path.string();
+    std::string cmd = fmt::format("{} {}", eth_fpath.string(), umd_path.string());
     int val = system(cmd.c_str());
     if(val != 0) throw std::runtime_error("Cluster Generation Failed!");
 

--- a/tests/test_utils/generate_cluster_desc.hpp
+++ b/tests/test_utils/generate_cluster_desc.hpp
@@ -10,6 +10,8 @@
 #include <string>
 #include <iostream>
 
+#include "fmt/core.h"
+
 namespace test_utils {
 
 inline std::string GetAbsPath(std::string path_){
@@ -42,7 +44,7 @@ inline std::string GetClusterDescYAML(){
         // Generates the cluster descriptor in the CWD
 
         std::filesystem::path eth_fpath = umd_path / "device/bin/silicon/x86/create-ethernet-map";
-        std::string cmd = eth_fpath.string() + " " + cluster_path.string();
+        std::string cmd = fmt::format("{} {}", eth_fpath.string(), cluster_path.string());
         int val = system(cmd.c_str());
         if(val != 0) throw std::runtime_error("Cluster Generation Failed!");
         yaml_path = cluster_path.string();


### PR DESCRIPTION
Fixes #54

### Note

`hwloc` object has `snprintf` function for that specific type, which is builtin, so that is not changed in the PR