### PR TITLE
Remove RD/WR device/sysmem API with vector argument

### DIFF
--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -366,20 +366,9 @@ class tt_device
         // Only implement this for Silicon Backend
         throw std::runtime_error("---- tt_device::write_to_device is not implemented\n");
     }
+
     virtual void broadcast_write_to_cluster(const void *mem_ptr, uint32_t size_in_bytes, uint64_t address, const std::set<chip_id_t>& chips_to_exclude,  std::set<uint32_t>& rows_to_exclude,  std::set<uint32_t>& columns_to_exclude, const std::string& fallback_tlb) {
         throw std::runtime_error("---- tt_device::broadcast_write_to_cluster is not implemented\n");
-    }
-
-    /**
-     * Write uint32_t vector to specified device, core and address (defined for Silicon).
-     *
-     * @param vec Data to write.
-     * @param core Chip and core being targeted.
-     * @param addr Address to write to.
-     * @param tlb_to_use Specifies fallback/dynamic TLB to use.
-     */
-    virtual void write_to_device(std::vector<uint32_t> &vec, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use) {
-        throw std::runtime_error("---- tt_device::write_to_device is not implemented\n");
     }
 
     /**
@@ -397,19 +386,6 @@ class tt_device
     }
 
     /**
-     * Read a uint32_t vector from a specified device, core and address to host memory (defined for Silicon).
-     *
-     * @param vec Vector to fill with data.
-     * @param core Chip and core to target.
-     * @param addr Address to read from.
-     * @param size Number of bytes to read.
-     * @param fallback_tlb Specifies fallback/dynamic TLB to use.
-    */
-    virtual void read_from_device(std::vector<uint32_t> &vec, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use) {
-        throw std::runtime_error("---- tt_device::read_from_device is not implemented\n");
-    }
-
-    /**
      * Write uint32_t vector to specified address and channel on host (defined for Silicon).
      * 
      * @param vec Data to write.
@@ -417,24 +393,8 @@ class tt_device
      * @param channel Host channel to target.
      * @param src_device_id Chip to target.
      */
-    virtual void write_to_sysmem(std::vector<uint32_t>& vec, uint64_t addr, uint16_t channel, chip_id_t src_device_id) {
-        throw std::runtime_error("---- tt_device::write_to_sysmem is not implemented\n");
-    }
-
     virtual void write_to_sysmem(const void* mem_ptr, std::uint32_t size,  uint64_t addr, uint16_t channel, chip_id_t src_device_id) {
         throw std::runtime_error("---- tt_device::write_to_sysmem is not implemented\n");
-    }
-    /**
-     * Read uint32_t vector from specified address and channel on host (defined for Silicon).
-     *
-     * @param vec Vector to fill with data.
-     * @param addr Address to read from.
-     * @param channel Host channel to read data from.
-     * @param size Number of bytes to read.
-     * @param src_device_id Chip being targeted.
-     */
-    virtual void read_from_sysmem(std::vector<uint32_t> &vec, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id) {
-        throw std::runtime_error("---- tt_device::read_from_sysmem is not implemented\n");
     }
     virtual void read_from_sysmem(void* mem_ptr, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id) {
         throw std::runtime_error("---- tt_device::read_from_sysmem is not implemented\n");
@@ -670,14 +630,10 @@ class tt_SiliconDevice: public tt_device
 
     // Runtime Functions
     virtual void write_to_device(const void *mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use);
-    virtual void write_to_device(std::vector<uint32_t> &vec, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use);
     void broadcast_write_to_cluster(const void *mem_ptr, uint32_t size_in_bytes, uint64_t address, const std::set<chip_id_t>& chips_to_exclude,  std::set<uint32_t>& rows_to_exclude,  std::set<uint32_t>& columns_to_exclude, const std::string& fallback_tlb);
 
     virtual void read_from_device(void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
-    virtual void read_from_device(std::vector<uint32_t> &vec, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use);
-    virtual void write_to_sysmem(std::vector<uint32_t>& vec, uint64_t addr, uint16_t channel, chip_id_t src_device_id);
     virtual void write_to_sysmem(const void* mem_ptr, std::uint32_t size,  uint64_t addr, uint16_t channel, chip_id_t src_device_id);
-    virtual void read_from_sysmem(std::vector<uint32_t> &vec, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id);
     virtual void read_from_sysmem(void* mem_ptr, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id);
     virtual void wait_for_non_mmio_flush();
     void l1_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -2243,6 +2243,7 @@ void tt_SiliconDevice::read_from_non_mmio_device(void* mem_ptr, tt_cxy_pair core
             } else {
                 // Read 4 byte aligned block from device/sysmem
                 if (use_dram) {
+                    size_buffer_to_capacity(data_block, block_size);
                     read_from_sysmem(data_block.data(), host_dram_block_addr, host_dram_channel, block_size, mmio_capable_chip_logical);
                 } else {
                     uint32_t buf_address = eth_interface_params.eth_routing_data_buffer_addr + resp_rd_ptr * max_block_size;

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -2023,7 +2023,7 @@ void tt_SiliconDevice::write_to_non_mmio_device(
                     write_to_sysmem(broadcast_header.data(), broadcast_header.size() * sizeof(uint32_t), host_dram_block_addr, host_dram_channel, mmio_capable_chip_logical);
                 }
                 // Write payload to sysmem
-                write_to_sysmem(data_block, host_dram_block_addr + BROADCAST_HEADER_SIZE * broadcast, host_dram_channel, mmio_capable_chip_logical);
+                write_to_sysmem(data_block.data(), data_block.size() * DATA_WORD_SIZE, host_dram_block_addr + BROADCAST_HEADER_SIZE * broadcast, host_dram_channel, mmio_capable_chip_logical);
 
             } else {
                 uint32_t buf_address = eth_interface_params.eth_routing_data_buffer_addr + req_wr_ptr * max_block_size;
@@ -2243,7 +2243,7 @@ void tt_SiliconDevice::read_from_non_mmio_device(void* mem_ptr, tt_cxy_pair core
             } else {
                 // Read 4 byte aligned block from device/sysmem
                 if (use_dram) {
-                    read_from_sysmem(data_block, host_dram_block_addr, host_dram_channel, block_size, mmio_capable_chip_logical);
+                    read_from_sysmem(data_block.data(), host_dram_block_addr, host_dram_channel, block_size, mmio_capable_chip_logical);
                 } else {
                     uint32_t buf_address = eth_interface_params.eth_routing_data_buffer_addr + resp_rd_ptr * max_block_size;
                     size_buffer_to_capacity(data_block, block_size);
@@ -2659,16 +2659,9 @@ int tt_SiliconDevice::remote_arc_msg(int chip, uint32_t msg_code, bool wait_for_
 void tt_SiliconDevice::write_to_sysmem(const void* mem_ptr, std::uint32_t size,  uint64_t addr, uint16_t channel, chip_id_t src_device_id) {
     write_buffer(mem_ptr, size, addr, channel, src_device_id);
 }
-void tt_SiliconDevice::write_to_sysmem(std::vector<uint32_t>& vec, uint64_t addr, uint16_t channel, chip_id_t src_device_id) {
-    write_buffer(vec.data(), vec.size() * sizeof(uint32_t), addr, channel, src_device_id);
-}
 
 void tt_SiliconDevice::read_from_sysmem(void* mem_ptr, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id) {
     read_buffer(mem_ptr, addr, channel, size, src_device_id);
-}
-void tt_SiliconDevice::read_from_sysmem(std::vector<uint32_t> &vec, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id) {
-    size_buffer_to_capacity(vec, size);
-    read_buffer(vec.data(), addr, channel, size, src_device_id);
 }
 
 void tt_SiliconDevice::set_membar_flag(const chip_id_t chip, const std::unordered_set<tt_xy_pair>& cores, const uint32_t barrier_value, const uint32_t barrier_addr, const std::string& fallback_tlb) {
@@ -2676,15 +2669,15 @@ void tt_SiliconDevice::set_membar_flag(const chip_id_t chip, const std::unordere
     std::unordered_set<tt_xy_pair> cores_synced = {};
     std::vector<uint32_t> barrier_val_vec = {barrier_value};
     for (const auto& core : cores) {
-        write_to_device(barrier_val_vec, tt_cxy_pair(chip, core), barrier_addr, fallback_tlb);
+        write_to_device(barrier_val_vec.data(), barrier_val_vec.size() * sizeof(uint32_t), tt_cxy_pair(chip, core), barrier_addr, fallback_tlb);
     }
     tt_driver_atomics::sfence(); // Ensure that all writes in the Host WC buffer are flushed
     while (cores_synced.size() != cores.size()) {
         for(const auto& core : cores) {
             if (cores_synced.find(core) == cores_synced.end()) {
-                std::vector<uint32_t> readback_vec = {};
-                read_from_device(readback_vec, tt_cxy_pair(chip, core), barrier_addr, sizeof(std::uint32_t), fallback_tlb);
-                if (readback_vec.at(0) == barrier_value) {
+                uint32_t readback_val;
+                read_from_device(&readback_val, tt_cxy_pair(chip, core), barrier_addr, sizeof(std::uint32_t), fallback_tlb);
+                if (readback_val == barrier_value) {
                     cores_synced.insert(core);
                 }
                 else {
@@ -2797,11 +2790,6 @@ void tt_SiliconDevice::write_to_device(const void *mem_ptr, uint32_t size, tt_cx
     }
 }
 
-void tt_SiliconDevice::write_to_device(std::vector<uint32_t> &vec, tt_cxy_pair core, uint64_t addr, const std::string& fallback_tlb) {
-    // Overloaded device writer that accepts a vector
-    write_to_device(vec.data(), vec.size() * sizeof(uint32_t), core, addr, fallback_tlb);
-}
-
 void tt_SiliconDevice::read_mmio_device_register(void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb) {
     PCIDevice *pci_device = get_pci_device(core.chip);
 
@@ -2853,12 +2841,6 @@ void tt_SiliconDevice::read_from_device(void* mem_ptr, tt_cxy_pair core, uint64_
         read_from_non_mmio_device(mem_ptr, core, addr, size);
     }
 }
-
-void tt_SiliconDevice::read_from_device(std::vector<uint32_t> &vec, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb) {
-    size_buffer_to_capacity(vec, size);
-    read_from_device(vec.data(), core, addr, size, fallback_tlb);
-}
-
 
 int tt_SiliconDevice::arc_msg(int logical_device_id, uint32_t msg_code, bool wait_for_done, uint32_t arg0, uint32_t arg1, int timeout, uint32_t *return_3, uint32_t *return_4) {
     log_assert(arch_name != tt::ARCH::BLACKHOLE, "ARC messages not supported in Blackhole");
@@ -3003,11 +2985,11 @@ void tt_SiliconDevice::deassert_resets_and_set_power_state() {
 
 void tt_SiliconDevice::verify_eth_fw() {
     for(const auto& chip : target_devices_in_cluster) {
-        std::vector<uint32_t> mem_vector;
+        uint32_t fw_version;
         std::vector<uint32_t> fw_versions;
         for (tt_xy_pair &eth_core : get_soc_descriptor(chip).ethernet_cores) {
-            read_from_device(mem_vector, tt_cxy_pair(chip, eth_core), l1_address_params.fw_version_addr, sizeof(uint32_t), "LARGE_READ_TLB");
-            fw_versions.push_back(mem_vector.at(0));
+            read_from_device(&fw_version, tt_cxy_pair(chip, eth_core), l1_address_params.fw_version_addr, sizeof(uint32_t), "LARGE_READ_TLB");
+            fw_versions.push_back(fw_version);
         }
         verify_sw_fw_versions(chip, SW_VERSION, fw_versions);
         eth_fw_version = tt_version(fw_versions.at(0));

--- a/tests/blackhole/test_silicon_driver_bh.cpp
+++ b/tests/blackhole/test_silicon_driver_bh.cpp
@@ -15,6 +15,7 @@
 #include "device/blackhole/blackhole_implementation.h"
 #include "device/tt_cluster_descriptor.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
+#include "tests/test_utils/device_test_utils.hpp"
 
 void set_params_for_remote_txn(tt_SiliconDevice& device) {
     // Populate address map and NOC parameters that the driver needs for remote transactions
@@ -188,18 +189,18 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //         std::uint32_t dynamic_write_address = 0x40000000;
 //         for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
 //             for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-//                 device.write_to_device(vector_to_write, tt_cxy_pair(i, core), address, "");
-//                 device.write_to_device(vector_to_write, tt_cxy_pair(i, core), dynamic_write_address, "SMALL_READ_WRITE_TLB");
+//                 device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "");
+//                 device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), dynamic_write_address, "SMALL_READ_WRITE_TLB");
 //                 device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over ethernet were commited
                 
-//                 device.read_from_device(readback_vec, tt_cxy_pair(i, core), address, 40, "");
-//                 device.read_from_device(dynamic_readback_vec, tt_cxy_pair(i, core), dynamic_write_address, 40, "SMALL_READ_WRITE_TLB");
+//                 test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "");
+//                 test_utils::read_data_from_device(device, dynamic_readback_vec, tt_cxy_pair(i, core), dynamic_write_address, 40, "SMALL_READ_WRITE_TLB");
 //                 ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
 //                 ASSERT_EQ(vector_to_write, dynamic_readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
 //                 device.wait_for_non_mmio_flush();
                 
-//                 device.write_to_device(zeros, tt_cxy_pair(i, core), dynamic_write_address, "SMALL_READ_WRITE_TLB"); // Clear any written data
-//                 device.write_to_device(zeros, tt_cxy_pair(i, core), address, ""); // Clear any written data
+//                 device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), dynamic_write_address, "SMALL_READ_WRITE_TLB"); // Clear any written data
+//                 device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, ""); // Clear any written data
 //                 device.wait_for_non_mmio_flush();
 //                 readback_vec = {};
 //                 dynamic_readback_vec = {};
@@ -256,7 +257,7 @@ TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
                 for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
                     device.write_to_device(write_vec.data(), size, tt_cxy_pair(i, core), address, "");
                     device.wait_for_non_mmio_flush();
-                    device.read_from_device(readback_vec.data(), tt_cxy_pair(i, core), address, size, "");
+                    test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, size, "");
                     ASSERT_EQ(readback_vec, write_vec);
                     readback_vec = std::vector<uint8_t>(size, 0);
                     device.write_to_sysmem(write_vec.data(), size, 0, 0, 0);
@@ -315,12 +316,12 @@ TEST(SiliconDriverBH, StaticTLB_RW) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for(int loop = 0; loop < 1; loop++){ // Write to each core a 100 times at different statically mapped addresses
             for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                device.write_to_device(vector_to_write, tt_cxy_pair(i, core), address, "");
+                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "");
                 device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over ethernet were commited
-                device.read_from_device(readback_vec, tt_cxy_pair(i, core), address, 40, "");
+                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "");
                 ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 device.wait_for_non_mmio_flush();
-                device.write_to_device(zeros, tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB"); // Clear any written data
+                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB"); // Clear any written data
                 device.wait_for_non_mmio_flush();
                 readback_vec = {};
             }
@@ -354,12 +355,12 @@ TEST(SiliconDriverBH, DynamicTLB_RW) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
             for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                device.write_to_device(vector_to_write, tt_cxy_pair(i, core), address, "DYNAMIC_TLB_BASE_INDEX");
+                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "DYNAMIC_TLB_BASE_INDEX");
                 device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over ethernet were commited
-                device.read_from_device(readback_vec, tt_cxy_pair(i, core), address, 40, "DYNAMIC_TLB_BASE_INDEX");
+                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "DYNAMIC_TLB_BASE_INDEX");
                 ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 device.wait_for_non_mmio_flush();
-                device.write_to_device(zeros, tt_cxy_pair(i, core), address, "DYNAMIC_TLB_BASE_INDEX");
+                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "DYNAMIC_TLB_BASE_INDEX");
                 device.wait_for_non_mmio_flush();
                 readback_vec = {};
             }
@@ -377,12 +378,12 @@ TEST(SiliconDriverBH, DynamicTLB_RW) {
             for (int ch=0; ch<NUM_CHANNELS; ch++) {
                 std::vector<tt_xy_pair> chan = device.get_virtual_soc_descriptors().at(i).dram_cores.at(ch);
                 tt_xy_pair subchan = chan.at(0);
-                device.write_to_device(vector_to_write, tt_cxy_pair(i, subchan), address, "DYNAMIC_TLB_BASE_INDEX");
+                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, subchan), address, "DYNAMIC_TLB_BASE_INDEX");
                 device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over ethernet were commited
-                device.read_from_device(readback_vec, tt_cxy_pair(i, subchan), address, 40, "DYNAMIC_TLB_BASE_INDEX");
+                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, subchan), address, 40, "DYNAMIC_TLB_BASE_INDEX");
                 ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << subchan.x << "-" << subchan.y << "does not match what was written";
                 device.wait_for_non_mmio_flush();
-                device.write_to_device(zeros, tt_cxy_pair(i, subchan), address, "DYNAMIC_TLB_BASE_INDEX");
+                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, subchan), address, "DYNAMIC_TLB_BASE_INDEX");
                 device.wait_for_non_mmio_flush();
                 readback_vec = {};
                 address += 0x20; // Increment by uint32_t size for each write
@@ -417,8 +418,8 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for(int loop = 0; loop < 100; loop++) {
             for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-                device.write_to_device(vector_to_write, tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
-                device.read_from_device(readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
                 ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 readback_vec = {};
             }
@@ -433,8 +434,8 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
         for(auto& core_ls : device.get_virtual_soc_descriptors().at(0).dram_cores) {
             for(int loop = 0; loop < 100; loop++) {
                 for(auto& core : core_ls) {
-                    device.write_to_device(vector_to_write, tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
-                    device.read_from_device(readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
+                    device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
+                    test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
                     ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                     readback_vec = {};
                 }
@@ -482,20 +483,20 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     
     std::vector<uint32_t> readback_membar_vec = {};
     for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-        device.read_from_device(readback_membar_vec, tt_cxy_pair(0, core), l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
+        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all workers
         readback_membar_vec = {};
     }
 
     for(int chan = 0; chan <  device.get_virtual_soc_descriptors().at(0).get_num_dram_channels(); chan++) {
         auto core = device.get_virtual_soc_descriptors().at(0).get_core_for_dram_channel(chan, 0);
-        device.read_from_device(readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
+        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all DRAM
         readback_membar_vec = {};
     }
     
     for(auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
-        device.read_from_device(readback_membar_vec, tt_cxy_pair(0, core), eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
+        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all ethernet cores
         readback_membar_vec = {};
     }
@@ -517,11 +518,11 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
         for(int loop = 0; loop < 50; loop++) {
             for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
-                device.write_to_device(vec1, tt_cxy_pair(0, core), address, "");
+                device.write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 device.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
-                device.read_from_device(readback_vec, tt_cxy_pair(0, core), address, 4*vec1.size(), "");
+                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 4*vec1.size(), "");
                 ASSERT_EQ(readback_vec, vec1);
-                device.write_to_device(zeros, tt_cxy_pair(0, core), address, "");
+                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 readback_vec = {};
             }
             
@@ -533,11 +534,11 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
         for(int loop = 0; loop < 50; loop++) {
             for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
-                device.write_to_device(vec2, tt_cxy_pair(0, core), address, "");
+                device.write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 device.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
-                device.read_from_device(readback_vec, tt_cxy_pair(0, core), address, 4*vec2.size(), "");
+                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 4*vec2.size(), "");
                 ASSERT_EQ(readback_vec, vec2);
-                device.write_to_device(zeros, tt_cxy_pair(0, core), address, "") ;
+                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "") ;
                 readback_vec = {};
             }
         }
@@ -547,13 +548,13 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     th2.join();
 
     for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-        device.read_from_device(readback_membar_vec, tt_cxy_pair(0, core), l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
+        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers end up in the correct sate for workers
         readback_membar_vec = {};
     }
 
     for(auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
-        device.read_from_device(readback_membar_vec, tt_cxy_pair(0, core), eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
+        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers end up in the correct sate for ethernet cores
         readback_membar_vec = {};
     }
@@ -599,16 +600,16 @@ TEST(SiliconDriverBH, DISABLED_BroadcastWrite) { // Cannot broadcast to tensix/e
         for(const auto i : target_devices) {
             for(const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
                 if(rows_to_exclude.find(core.y) != rows_to_exclude.end()) continue;
-                device.read_from_device(readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
                 ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was broadcasted";
-                device.write_to_device(zeros, tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
                 readback_vec = {};
             }
             for(int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
                 const auto& core = device.get_virtual_soc_descriptors().at(i).get_core_for_dram_channel(chan, 0);
-                device.read_from_device(readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
                 ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from DRAM core " << i << " " << core.x << "-" << core.y << " does not match what was broadcasted " << size;
-                device.write_to_device(zeros, tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
                 readback_vec = {};
             }
         }
@@ -663,16 +664,16 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) { // same problem as 
         for(const auto i : target_devices) {
             for(const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
                 if(rows_to_exclude.find(core.y) != rows_to_exclude.end()) continue;
-                device.read_from_device(readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
                 ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was broadcasted";
-                device.write_to_device(zeros, tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
                 readback_vec = {};
             }
             for(int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
                 const auto& core = device.get_virtual_soc_descriptors().at(i).get_core_for_dram_channel(chan, 0);
-                device.read_from_device(readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
                 ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from DRAM core " << i << " " << core.x << "-" << core.y << " does not match what was broadcasted " << size;
-                device.write_to_device(zeros, tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
                 readback_vec = {};
             }
         }

--- a/tests/blackhole/test_silicon_driver_bh.cpp
+++ b/tests/blackhole/test_silicon_driver_bh.cpp
@@ -257,7 +257,7 @@ TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
                 for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
                     device.write_to_device(write_vec.data(), size, tt_cxy_pair(i, core), address, "");
                     device.wait_for_non_mmio_flush();
-                    test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, size, "");
+                    device.read_from_device(readback_vec.data(), tt_cxy_pair(i, core), address, size, "");
                     ASSERT_EQ(readback_vec, write_vec);
                     readback_vec = std::vector<uint8_t>(size, 0);
                     device.write_to_sysmem(write_vec.data(), size, 0, 0, 0);
@@ -273,7 +273,6 @@ TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
     }
     device.close_device();
 }
-
 
 TEST(SiliconDriverBH, StaticTLB_RW) {
     auto get_static_tlb_index_callback = [] (tt_xy_pair target) {

--- a/tests/emulation/test_emulation_device.cpp
+++ b/tests/emulation/test_emulation_device.cpp
@@ -24,14 +24,14 @@ TEST(EmulationDeviceGS, BasicEmuTest) {
         for (auto &byte : wdata) {
             byte = rand();
         }
-        device.write_to_device(wdata, tt_cxy_pair(0, core), l1_addr, "l1");
-        device.read_from_device(rdata, tt_cxy_pair(0, core), l1_addr, size, "l1");
+        device.write_to_device(wdata.data(), wdata.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), l1_addr, "l1");
+        test_utils::read_data_from_device(device, rdata, tt_cxy_pair(0, core), l1_addr, size, "l1");
         ASSERT_EQ(wdata, rdata) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
 
         device.deassert_risc_reset();
-        device.write_to_device(wdata, tt_cxy_pair(0, tt_xy_pair(phys_x, phys_y)), l1_addr, "l1");
+        device.write_to_device(wdata.data(), wdata.size() * sizeof(std::uint32_t), tt_cxy_pair(0, tt_xy_pair(phys_x, phys_y)), l1_addr, "l1");
         device.assert_risc_reset();
-        device.write_to_device(wdata, tt_cxy_pair(0, tt_xy_pair(phys_x, phys_y)), l1_addr, "l1");
+        device.write_to_device(wdata.data(), wdata.size() * sizeof(std::uint32_t), tt_cxy_pair(0, tt_xy_pair(phys_x, phys_y)), l1_addr, "l1");
 
 
     } catch (const std::exception &e) {

--- a/tests/galaxy/test_galaxy_common.cpp
+++ b/tests/galaxy/test_galaxy_common.cpp
@@ -3,13 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "test_galaxy_common.h"
+
+#include "tests/test_utils/device_test_utils.hpp"
+
 void move_data(
     tt_SiliconDevice& device, tt_multichip_core_addr sender_core, tt_multichip_core_addr receiver_core, uint32_t size) {
     std::vector<uint32_t> readback_vec = {};
-    device.read_from_device(
-        readback_vec, tt_cxy_pair(sender_core.chip, sender_core.core), sender_core.addr, size, "SMALL_READ_WRITE_TLB");
+    test_utils::read_data_from_device(
+        device, readback_vec, tt_cxy_pair(sender_core.chip, sender_core.core), sender_core.addr, size, "SMALL_READ_WRITE_TLB");
     device.write_to_device(
-        readback_vec, tt_cxy_pair(receiver_core.chip, receiver_core.core), receiver_core.addr, "SMALL_READ_WRITE_TLB");
+        readback_vec.data(), readback_vec.size() * sizeof(std::uint32_t), tt_cxy_pair(receiver_core.chip, receiver_core.core), receiver_core.addr, "SMALL_READ_WRITE_TLB");
     device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 
     return;
@@ -21,11 +24,12 @@ void broadcast_data(
     std::vector<tt_multichip_core_addr> receiver_cores,
     uint32_t size) {
     std::vector<uint32_t> readback_vec = {};
-    device.read_from_device(
-        readback_vec, tt_cxy_pair(sender_core.chip, sender_core.core), sender_core.addr, size, "SMALL_READ_WRITE_TLB");
+    test_utils::read_data_from_device(
+        device, readback_vec, tt_cxy_pair(sender_core.chip, sender_core.core), sender_core.addr, size, "SMALL_READ_WRITE_TLB");
     for (const auto& receiver_core : receiver_cores) {
         device.write_to_device(
-            readback_vec,
+            readback_vec.data(),
+            readback_vec.size() * sizeof(std::uint32_t),
             tt_cxy_pair(receiver_core.chip, receiver_core.core),
             receiver_core.addr,
             "SMALL_READ_WRITE_TLB");

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -16,6 +16,7 @@
 #include "test_galaxy_common.h"
 #include "tests/wormhole/test_wh_common.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
+#include "tests/test_utils/device_test_utils.hpp"
 
 static const std::string SOC_DESC_PATH = "tests/soc_descs/wormhole_b0_8x10.yaml";
 
@@ -65,7 +66,7 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
             for (const auto& core : target_cores) {
                 tt_cxy_pair target_core = tt_cxy_pair(chip, core);
                 auto start = std::chrono::high_resolution_clock::now();
-                device.write_to_device(vector_to_write, target_core, address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), target_core, address, "SMALL_READ_WRITE_TLB");
                 device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
                 auto end = std::chrono::high_resolution_clock::now();
                 auto duration = double(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
@@ -73,7 +74,7 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
                 // std::cout << "  chip " << chip << " core " << target_core.str() << " " << duration << std::endl;
 
                 start = std::chrono::high_resolution_clock::now();
-                device.read_from_device(readback_vec, target_core, address, write_size, "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(device, readback_vec, target_core, address, write_size, "SMALL_READ_WRITE_TLB");
                 end = std::chrono::high_resolution_clock::now();
                 duration = double(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
                 // std::cout << " read chip " << chip << " core " << target_core.str()<< " " << duration << std::endl;
@@ -165,7 +166,7 @@ void run_data_mover_test(
     std::vector<float> send_bw;
     // Set up data in sender core
     device.write_to_device(
-        vector_to_write, tt_cxy_pair(sender_core.chip, sender_core.core), sender_core.addr, "SMALL_READ_WRITE_TLB");
+        vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(sender_core.chip, sender_core.core), sender_core.addr, "SMALL_READ_WRITE_TLB");
     device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 
     // Send data from sender core to receiver core
@@ -177,7 +178,8 @@ void run_data_mover_test(
     // std::cout << "move data duration "<< duration << std::endl;
 
     // Verify data is correct in receiver core
-    device.read_from_device(
+    test_utils::read_data_from_device(
+        device,
         readback_vec,
         tt_cxy_pair(receiver_core.chip, receiver_core.core),
         receiver_core.addr,
@@ -282,7 +284,7 @@ void run_data_broadcast_test(
     std::vector<float> send_bw;
     //  Set up data in sender core
     device.write_to_device(
-        vector_to_write, tt_cxy_pair(sender_core.chip, sender_core.core), sender_core.addr, "SMALL_READ_WRITE_TLB");
+        vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(sender_core.chip, sender_core.core), sender_core.addr, "SMALL_READ_WRITE_TLB");
     device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 
     // Send data from sender core to receiver core
@@ -295,7 +297,8 @@ void run_data_broadcast_test(
 
     // Verify data is correct in receiver core
     for (const auto& receiver_core : receiver_cores) {
-        device.read_from_device(
+        test_utils::read_data_from_device(
+            device,
             readback_vec,
             tt_cxy_pair(receiver_core.chip, receiver_core.core),
             receiver_core.addr,

--- a/tests/galaxy/test_umd_remote_api_stability.cpp
+++ b/tests/galaxy/test_umd_remote_api_stability.cpp
@@ -23,7 +23,6 @@
 #include "tests/galaxy/test_galaxy_common.h"
 #include "tests/wormhole/test_wh_common.h"
 
-
 namespace tt::umd::test::utils {
 
 

--- a/tests/microbenchmark/test_rw_tensix.cpp
+++ b/tests/microbenchmark/test_rw_tensix.cpp
@@ -3,6 +3,7 @@
 
 #include "nanobench.h"
 #include "device_fixture.hpp"
+#include "tests/test_utils/device_test_utils.hpp"
 
 std::uint32_t generate_random_address(std::uint32_t max, std::uint32_t min=0) {
     ankerl::nanobench::Rng gen(80085);
@@ -22,11 +23,11 @@ TEST_F(uBenchmarkFixture, WriteAllCores32Bytes) {
         wname << "Write to device core (" << core.x << ", " << core.y << ")";
         // Write 32 bytes through static tlbs
         bench_static.title("Write 32 bytes").unit("writes").minEpochIterations(50).output(nullptr).run(wname.str(), [&] {
-            device->write_to_device(vector_to_write, tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
+            device->write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
         });
         // Write through "fallback/dynamic" tlb
         bench_dynamic.title("Write 32 bytes fallback").unit("writes").minEpochIterations(50).output(nullptr).run(wname.str(), [&] {
-            device->write_to_device(vector_to_write, tt_cxy_pair(0, core), bad_address, "SMALL_READ_WRITE_TLB");
+            device->write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), bad_address, "SMALL_READ_WRITE_TLB");
         });
         wname.clear();
     }
@@ -47,11 +48,11 @@ TEST_F(uBenchmarkFixture, ReadAllCores32Bytes){
         // Read through static tlbs
         rname << "Read from device core (" << core.x << ", " << core.y << ")";
         bench_static.title("Read 32 bytes").unit("reads").minEpochIterations(50).output(nullptr).run(rname.str(), [&] {
-            device->read_from_device(readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
+            test_utils::read_data_from_device(*device, readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
         });
         // Read through "fallback/dynamic" tlb
         bench_dynamic.title("Read 32 bytes fallback").unit("reads").minEpochIterations(50).output(nullptr).run(rname.str(), [&] {
-            device->read_from_device(readback_vec, tt_cxy_pair(0, core), bad_address, 0x20, "SMALL_READ_WRITE_TLB");
+            test_utils::read_data_from_device(*device, readback_vec.data(), tt_cxy_pair(0, core), bad_address, 0x20, "SMALL_READ_WRITE_TLB");
         });
         rname.clear();
     }
@@ -69,7 +70,7 @@ TEST_F(uBenchmarkFixture, Write32BytesRandomAddr){
         std::stringstream wname;
         wname << "Write to device core (" << core.x << ", " << core.y << ") @ address " << std::hex << address;
         bench.title("Write 32 bytes random address").unit("writes").minEpochIterations(50).output(nullptr).run(wname.str(), [&] {
-            device->write_to_device(vector_to_write, tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
+            device->write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
         });
         wname.clear();
     }
@@ -86,7 +87,7 @@ TEST_F(uBenchmarkFixture, Read32BytesRandomAddr){
         std::stringstream rname;
         rname << "Read from device core (" << core.x << ", " << core.y << ") @ address " << std::hex << address;
         bench.title("Read 32 bytes random address").unit("reads").minEpochIterations(50).output(nullptr).run(rname.str(), [&] {
-            device->read_from_device(readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
+            test_utils::read_data_from_device(*device, readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
         });
         rname.clear();
     }

--- a/tests/simulation/test_simulation_device.cpp
+++ b/tests/simulation/test_simulation_device.cpp
@@ -4,6 +4,7 @@
 
 #include <random>
 #include "device_fixture.hpp"
+#include "tests/test_utils/device_test_utils.hpp"
 
 std::vector<uint32_t> generate_data(uint32_t size_in_bytes){
     size_t size = size_in_bytes/sizeof(uint32_t);
@@ -37,7 +38,7 @@ TEST_P(LoopbackAllCoresParam, LoopbackSingleTensix){
     tt_cxy_pair core = {0, GetParam()};
 
     device->write_to_device(wdata.data(), wdata.size()*sizeof(uint32_t), core, 0x100, "");
-    device->read_from_device(rdata.data(), core, 0x100, wdata.size()*sizeof(uint32_t), "");
+    test_utils::read_data_from_device(*device, rdata, core, 0x100, wdata.size()*sizeof(uint32_t), "");
     
     ASSERT_EQ(wdata, rdata);
 }
@@ -49,7 +50,7 @@ bool loopback_stress_size(std::unique_ptr<tt_SimulationDevice> &device, tt_xy_pa
     std::vector<uint32_t> rdata(wdata.size(), 0);
 
     device->write_to_device(wdata.data(), wdata.size()*sizeof(uint32_t), tt_cxy_pair{0, core}, addr, "");
-    device->read_from_device(rdata.data(), tt_cxy_pair{0, core}, addr, wdata.size()*sizeof(uint32_t), "");
+    test_utils::read_data_from_device(*device, rdata, tt_cxy_pair{0, core}, addr, wdata.size()*sizeof(uint32_t), "");
     
     return wdata == rdata;
 }
@@ -79,8 +80,8 @@ TEST_F(SimulationDeviceFixture, LoopbackTwoTensix){
     device->write_to_device(wdata1.data(), wdata1.size()*sizeof(uint32_t),  core1, 0x100, "");
     device->write_to_device(wdata2.data(), wdata2.size()*sizeof(uint32_t), core2, 0x100, "");
 
-    device->read_from_device(rdata1.data(), core1, 0x100, wdata1.size()*sizeof(uint32_t), "");
-    device->read_from_device(rdata2.data(), core2, 0x100, wdata2.size()*sizeof(uint32_t), "");
+    test_utils::read_data_from_device(*device, rdata1, core1, 0x100, wdata1.size()*sizeof(uint32_t), "");
+    test_utils::read_data_from_device(*device, rdata2, core2, 0x100, wdata2.size()*sizeof(uint32_t), "");
     
     ASSERT_EQ(wdata1, rdata1);
     ASSERT_EQ(wdata2, rdata2);

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include <string>
+
+#include "tt_device.h"
+
+namespace test_utils {
+
+template <typename T>
+static void size_buffer_to_capacity(std::vector<T> &data_buf, std::size_t size_in_bytes) {
+    std::size_t target_size = 0;
+    if (size_in_bytes > 0) {
+        target_size = ((size_in_bytes - 1) / sizeof(T)) + 1;
+    }
+    data_buf.resize(target_size);
+}
+
+static void read_data_from_device(tt_device& device, std::vector<uint32_t> &vec, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use) {
+    size_buffer_to_capacity(vec, size);
+    device.read_from_device(vec.data(), core, addr, size, tlb_to_use);
+}
+
+}


### PR DESCRIPTION
Fixes #67

Remove API for read and write to device/sysmem which has `std::vector ` as an argument. Use only functions that have `void*` as an argument. Change calls inside `tt_silicon_driver` which were using `std::vector` variant

TODO

- [x] Investigate whether tt-metal was using API with `std::vector` arguement. Change this if needed before bumping UMD -> tt-metal was just using `void*` interface