### PR TITLE
Change compiler to clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,27 @@
 cmake_minimum_required(VERSION 3.16)
-project(umd_device)
+
+include(cmake/compilers.cmake)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+if (DEFINED ENV{CMAKE_C_COMPILER} AND DEFINED ENV{CMAKE_CXX_COMPILER})
+    message(STATUS "Setting C and C++ compiler from environment variables")
+    set(CMAKE_C_COMPILER $ENV{CMAKE_C_COMPILER})
+    set(CMAKE_CXX_COMPILER $ENV{CMAKE_CXX_COMPILER})
+endif()
+
+if (CMAKE_CXX_COMPILER AND CMAKE_C_COMPILER)
+    message(STATUS "Using specifed C++ compiler: ${CMAKE_CXX_COMPILER}")
+    message(STATUS "Using specifed C compiler: ${CMAKE_C_COMPILER}")
+else()
+    message(STATUS "No C or C++ compiler specified, defaulting to Clang-17")
+    FIND_AND_SET_CLANG17()
+endif()
+
+project(umd_device)
+
+CHECK_COMPILERS()
 
 set(MASTER_PROJECT OFF)
 if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -1,0 +1,46 @@
+function(FIND_AND_SET_CLANG17)
+    find_program(CLANGPP_17 clang++-17)
+    find_program(CLANG_17 clang-17)
+
+    if(NOT CLANGPP_17 OR NOT CLANG_17)
+        message(FATAL_ERROR "Clang-17 not found. Make sure you have clang-17 and clang++-17 installed and in your PATH")
+    endif()
+
+    set(CMAKE_CXX_COMPILER "${CLANGPP_17}" PARENT_SCOPE)
+    set(CMAKE_C_COMPILER "${CLANG_17}" PARENT_SCOPE)
+endfunction()
+
+
+function(CHECK_COMPILERS)
+    message(STATUS "Checking compilers")
+
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "17.0.0" OR CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL "18.0.0")
+            message(WARNING "Only Clang-17 is tested right now")
+        endif()
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "12.0.0")
+            message(FATAL_ERROR "GCC-12 or higher is required")
+        elseif(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL "13.0.0")
+            message(WARNING "Only GCC-12 is tested right now")
+        endif()
+    else()
+        message(FATAL_ERROR "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID} ! Only Clang and GCC are supported")
+    endif()
+endfunction()
+
+
+function(ADJUST_COMPILER_WARNINGS)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        target_compile_options(compiler_warnings INTERFACE
+            -Wsometimes-uninitialized -Wno-c++11-narrowing -Wno-error=local-type-template-args
+            -Wno-delete-non-abstract-non-virtual-dtor -Wno-c99-designator -Wno-shift-op-parentheses -Wno-non-c-typedef-for-linkage
+            -Wno-deprecated-this-capture -Wno-deprecated-volatile -Wno-deprecated-builtins -Wno-deprecated-declarations
+        )
+    else() # GCC-12 or higher
+        target_compile_options(compiler_warnings INTERFACE
+            -Wno-deprecated -Wno-attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-maybe-uninitialized -Wno-missing-requires
+            -Wno-narrowing -Wno-non-template-friend -Wno-error=non-template-friend
+        )
+    endif()
+endfunction()


### PR DESCRIPTION
Related to #45 
tt-metal uses clang compiler.
This configuration was copied from metal's CMakeLists.txt.
The irds that we're using for tt-metal already have this setup, so it shouldn't disrupt anyone.
I've already installed clang-17 in #70, so CI will still work with this switch.