### PR TITLE
#86: Remove ARCH_NAME dependency for libdevice.so

### DIFF
--- a/.github/workflows/build-target.yml
+++ b/.github/workflows/build-target.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Build ${{ inputs.build-target }}
       run: |
         echo "Compiling the code..."
-        cmake -B ${{ env.BUILD_OUTPUT_DIR }} -G Ninja
+        cmake -B ${{ env.BUILD_OUTPUT_DIR }} -G Ninja -DTT_UMD_BUILD_TESTS=ON
         cmake --build ${{ env.BUILD_OUTPUT_DIR }} --target ${{ inputs.build-target }}
         echo "Compile complete."
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,6 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/device)
 
 option(TT_UMD_BUILD_TESTS "Enables build of tt_umd tests" OFF)
 if(TT_UMD_BUILD_TESTS)
-    add_subdirectory(tests)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/tests)
 endif(TT_UMD_BUILD_TESTS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,28 +97,10 @@ include(${PROJECT_SOURCE_DIR}/cmake/dependencies.cmake)
 add_library(umd_common_directories INTERFACE)
 target_include_directories(umd_common_directories INTERFACE ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/device ${PROJECT_SOURCE_DIR}/third_party/fmt/include)
 
-if(NOT DEFINED ENV{ARCH_NAME})
-    message(FATAL_ERROR "Please set ARCH_NAME to grayskull, wormhole_b0, or blackhole")
-elseif($ENV{ARCH_NAME} STREQUAL "grayskull")
-    message(STATUS "UMD: Building for Grayskull")
-    target_include_directories(umd_common_directories INTERFACE 
-        ${PROJECT_SOURCE_DIR}/device/grayskull 
-        ${PROJECT_SOURCE_DIR}/src/firmware/riscv/grayskull
-    )
-elseif($ENV{ARCH_NAME} STREQUAL "wormhole_b0")
-    message(STATUS "UMD: Building for Wormhole")
-    target_include_directories(umd_common_directories INTERFACE 
-        ${PROJECT_SOURCE_DIR}/device/wormhole 
-        ${PROJECT_SOURCE_DIR}/src/firmware/riscv/wormhole
-    )
-elseif($ENV{ARCH_NAME} STREQUAL "blackhole")
-    message(STATUS "UMD: Building for Blackhole")
-    target_include_directories(umd_common_directories INTERFACE 
-        ${PROJECT_SOURCE_DIR}/device/blackhole 
-        ${PROJECT_SOURCE_DIR}/src/firmware/riscv/blackhole
-    )
-endif()
-
 add_subdirectory(${PROJECT_SOURCE_DIR}/device)
-add_subdirectory(${PROJECT_SOURCE_DIR}/tests EXCLUDE_FROM_ALL)
+
+option(TT_UMD_BUILD_TESTS "Enables build of tt_umd tests" OFF)
+if(TT_UMD_BUILD_TESTS)
+    add_subdirectory(tests)
+endif(TT_UMD_BUILD_TESTS)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,27 @@
 
+# Tests currently depend on ARCH_NAME for compile time include paths
+if(NOT DEFINED ENV{ARCH_NAME})
+    message(FATAL_ERROR "Please set ARCH_NAME to grayskull, wormhole_b0, or blackhole")
+elseif($ENV{ARCH_NAME} STREQUAL "grayskull")
+    message(STATUS "UMD: Building for Grayskull")
+    target_include_directories(umd_common_directories INTERFACE
+        ${PROJECT_SOURCE_DIR}/device/grayskull
+        ${PROJECT_SOURCE_DIR}/src/firmware/riscv/grayskull
+    )
+elseif($ENV{ARCH_NAME} STREQUAL "wormhole_b0")
+    message(STATUS "UMD: Building for Wormhole")
+    target_include_directories(umd_common_directories INTERFACE
+        ${PROJECT_SOURCE_DIR}/device/wormhole
+        ${PROJECT_SOURCE_DIR}/src/firmware/riscv/wormhole
+    )
+elseif($ENV{ARCH_NAME} STREQUAL "blackhole")
+    message(STATUS "UMD: Building for Blackhole")
+    target_include_directories(umd_common_directories INTERFACE
+        ${PROJECT_SOURCE_DIR}/device/blackhole
+        ${PROJECT_SOURCE_DIR}/src/firmware/riscv/blackhole
+    )
+endif()
+
 add_library(test_common INTERFACE)
 target_link_libraries(test_common INTERFACE umd_device gtest_main gtest pthread)
 target_include_directories(test_common INTERFACE 


### PR DESCRIPTION
Closes #86 

Updated CI workflows to pass `-DTT_UMD_BUILD_TESTS=ON`