### PR TITLE
No ARCH_NAME in CI building umd_device

### DIFF
--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -1,0 +1,53 @@
+# Builds umd_device.
+# Build is performed on all supported OS versions.
+name: Build Target
+
+on:
+  workflow_call:
+    inputs:
+      timeout:
+        required: true
+        type: number
+  workflow_dispatch:
+    inputs:
+      timeout:
+        required: true
+        description: 'The timeout for the build job in minutes'
+        type: number
+      
+env:
+  BUILD_TARGET: umd_device
+  BUILD_OUTPUT_DIR: ./build
+  LIB_OUTPUT_DIR: ./build/lib
+  DEPS_OUTPUT_DIR: ./build/_deps
+  TEST_OUTPUT_DIR: ./build/test
+  CREATE_MAP_BINARIES_DIR: ./device/bin/silicon
+
+jobs:
+  build:
+    timeout-minutes: ${{ inputs.timeout }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [
+          {runs-on: ubuntu-22.04, docker-image: tt-umd-ci-ubuntu-22.04},
+          {runs-on: ubuntu-20.04, docker-image: tt-umd-ci-ubuntu-20.04},
+        ]
+
+    name: Build ${{ env.BUILD_TARGET }} for any arch on ${{ matrix.build.runs-on }}
+    runs-on: ${{ matrix.build.runs-on }}
+    container:
+      image: ghcr.io/${{ github.repository }}/${{ matrix.build.docker-image }}:latest
+      options: --user root
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Build ${{ env.BUILD_TARGET }}
+      run: |
+        echo "Compiling the code..."
+        cmake -B ${{ env.BUILD_OUTPUT_DIR }} -G Ninja
+        cmake --build ${{ env.BUILD_OUTPUT_DIR }} --target ${{ env.BUILD_TARGET }}
+        echo "Compile complete."

--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -34,7 +34,7 @@ jobs:
           {runs-on: ubuntu-20.04, docker-image: tt-umd-ci-ubuntu-20.04},
         ]
 
-    name: Build ${{ env.BUILD_TARGET }} for any arch on ${{ matrix.build.runs-on }}
+    name: Build umd_device for any arch on ${{ matrix.build.runs-on }}
     runs-on: ${{ matrix.build.runs-on }}
     container:
       image: ghcr.io/${{ github.repository }}/${{ matrix.build.docker-image }}:latest

--- a/.github/workflows/build-target.yml
+++ b/.github/workflows/build-target.yml
@@ -28,6 +28,7 @@ on:
           - grayskull
           - wormhole_b0
           - blackhole
+          - ""
       timeout:
         required: true
         description: 'The timeout for the build job in minutes'
@@ -70,13 +71,16 @@ jobs:
       image: ghcr.io/${{ github.repository }}/${{ matrix.build.docker-image }}:latest
       options: --user root
 
-    env:
-      ARCH_NAME: ${{ inputs.arch }}
-
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+
+    - name: Set ARCH_NAME if not empty
+      run: |
+        if [[ -n "${{ inputs.arch }}" ]]; then
+          echo "ARCH_NAME=${{ inputs.arch }}" >> $GITHUB_ENV
+        fi
 
     - name: Build ${{ inputs.build-target }}
       run: |

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -46,7 +46,7 @@ jobs:
           {runs-on: ubuntu-20.04, docker-image: tt-umd-ci-ubuntu-20.04},
         ]
 
-    name: Build ${{ env.BUILD_TARGET }} for ${{ inputs.arch }} on ${{ matrix.build.runs-on }}
+    name: Build umd_tests for ${{ inputs.arch }} on ${{ matrix.build.runs-on }}
     runs-on: ${{ matrix.build.runs-on }}
     container:
       image: ghcr.io/${{ github.repository }}/${{ matrix.build.docker-image }}:latest

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -1,4 +1,4 @@
-# Builds requested target and uploads its artifact if requested.
+# Builds umd_tests.
 # Build is performed on the specified architecture and on all supported OS versions.
 name: Build Target
 
@@ -11,13 +11,6 @@ on:
       timeout:
         required: true
         type: number
-      build-target:
-        required: true
-        type: string
-      upload-artifacts:
-        required: false
-        type: boolean
-        default: false
   workflow_dispatch:
     inputs:
       arch:
@@ -28,26 +21,14 @@ on:
           - grayskull
           - wormhole_b0
           - blackhole
-          - ""
       timeout:
         required: true
         description: 'The timeout for the build job in minutes'
         type: number
-      build-target:
-        required: true
-        description: 'The target to build'
-        type: choice
-        options:
-          - umd_device
-          - umd_tests
-      upload-artifacts:
-        required: false
-        description: 'Whether to upload artifacts'
-        type: boolean
-        default: false
       
 
 env:
+  BUILD_TARGET: umd_tests
   BUILD_OUTPUT_DIR: ./build
   LIB_OUTPUT_DIR: ./build/lib
   DEPS_OUTPUT_DIR: ./build/_deps
@@ -65,39 +46,34 @@ jobs:
           {runs-on: ubuntu-20.04, docker-image: tt-umd-ci-ubuntu-20.04},
         ]
 
-    name: Build ${{ inputs.build-target }} for ${{ inputs.arch }} on ${{ matrix.build.runs-on }}
+    name: Build ${{ env.BUILD_TARGET }} for ${{ inputs.arch }} on ${{ matrix.build.runs-on }}
     runs-on: ${{ matrix.build.runs-on }}
     container:
       image: ghcr.io/${{ github.repository }}/${{ matrix.build.docker-image }}:latest
       options: --user root
+
+    env:
+      ARCH_NAME: ${{ inputs.arch }}
 
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
 
-    - name: Set ARCH_NAME if not empty
-      run: |
-        if [[ -n "${{ inputs.arch }}" ]]; then
-          echo "ARCH_NAME=${{ inputs.arch }}" >> $GITHUB_ENV
-        fi
-
-    - name: Build ${{ inputs.build-target }}
+    - name: Build ${{ env.BUILD_TARGET }}
       run: |
         echo "Compiling the code..."
         cmake -B ${{ env.BUILD_OUTPUT_DIR }} -G Ninja -DTT_UMD_BUILD_TESTS=ON
-        cmake --build ${{ env.BUILD_OUTPUT_DIR }} --target ${{ inputs.build-target }}
+        cmake --build ${{ env.BUILD_OUTPUT_DIR }} --target ${{ env.BUILD_TARGET }}
         echo "Compile complete."
 
     # This is needed to preserve file permissions
     # https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss
     - name: Tar build, test and run artifacts
-      if: ${{ inputs.upload-artifacts }}
       shell: bash
       run: tar cvf artifact.tar ${{ env.TEST_OUTPUT_DIR }} ${{ env.LIB_OUTPUT_DIR }} ${{ env.DEPS_OUTPUT_DIR }} ${{ env.CREATE_MAP_BINARIES_DIR }}
 
     - name: Upload build artifacts archive
-      if: ${{ inputs.upload-artifacts }}
       uses: actions/upload-artifact@v4
       with:
         name: build-artifacts-${{ inputs.arch }}-${{ matrix.build.runs-on }}

--- a/.github/workflows/on-pr-opt.yml
+++ b/.github/workflows/on-pr-opt.yml
@@ -18,12 +18,10 @@ jobs:
           { arch: wormhole_b0 },
           # { arch: blackhole },
         ]
-    uses: ./.github/workflows/build-target.yml
+    uses: ./.github/workflows/build-tests.yml
     with:
       arch: ${{ matrix.test-group.arch }}
       timeout: 10
-      build-target: umd_tests
-      upload-artifacts: true
 
   test-all:
     secrets: inherit

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -9,16 +9,8 @@ on:
 jobs:
   build-all:
     secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: grayskull },
-          { arch: wormhole_b0 },
-          { arch: blackhole },
-        ]
     uses: ./.github/workflows/build-target.yml
     with:
-      arch: ${{ matrix.test-group.arch }}
+      arch: ""
       timeout: 10
       build-target: umd_device

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   build-all:
     secrets: inherit
-    uses: ./.github/workflows/build-target.yml
+    uses: ./.github/workflows/build-device.yml
     with:
-      arch: ""
       timeout: 10
-      build-target: umd_device

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ sudo apt install -y libhwloc-dev
 
 ## Build flow
 We are transitioning away from Make. The main libraries and tests should now be built with CMake.
-Specify the `ARCH_NAME` environment variable as `grayskull` or `wormhole_b0` before building.
+The device lib is built once for all supported architectures (grayskull, wormhole and blackhole).
 
 To build `libdevice.so`: 
 ```
@@ -18,8 +18,12 @@ ninja -C build
 ninja umd_device -C build
 ```
 
+Tests are build separatelly for each architecture.
+Specify the `ARCH_NAME` environment variable as `grayskull`,  `wormhole_b0` or `blackhole` before building.
+You also need to configure cmake to enable tests, hence the need to run cmake configuration step again.
 To build tests:
 ```
+cmake -B build -G Ninja -DTT_UMD_BUILD_TESTS=ON
 ninja umd_tests -C build
 ```
 


### PR DESCRIPTION
A continuation to #87 , to reflect the current state in our CI.
Related to #86 and a part of #51 .

There is now enough difference between building umd_device and umd_tests to warrant separate files, since umd_tests still requires ARCH_NAME and umd_device does not. This way it looks clearer.