### PR TITLE
No ARCH_NAME in CI building umd_device - on push job

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -8,19 +8,9 @@ on:
 jobs:
   build-all:
     secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: grayskull },
-          { arch: wormhole_b0 },
-          { arch: blackhole },
-        ]
-    uses: ./.github/workflows/build-target.yml
+    uses: ./.github/workflows/build-device.yml
     with:
-      arch: ${{ matrix.test-group.arch }}
       timeout: 10
-      build-target: umd_device
 
   build-tests:
     secrets: inherit
@@ -33,12 +23,10 @@ jobs:
           { arch: wormhole_b0 },
           # { arch: blackhole },
         ]
-    uses: ./.github/workflows/build-target.yml
+    uses: ./.github/workflows/build-tests.yml
     with:
       arch: ${{ matrix.test-group.arch }}
       timeout: 10
-      build-target: umd_tests
-      upload-artifacts: true
 
   test-all:
     secrets: inherit


### PR DESCRIPTION
Forgot to change this workflow, which gets activated only on push. 
I've actually now manually ran it on this branch to verify it works: https://github.com/tenstorrent/tt-umd/actions/runs/11102792536