### PR TITLE
Fix NUMA node detection

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -90,8 +90,11 @@ jobs:
       shell: bash
       run: tar xvf artifact.tar
 
-    - name: Run UMD unit tests
+    - name: Run arch-specific UMD unit tests
       run: |
         ${{ env.TEST_OUTPUT_DIR }}/umd/${{ inputs.arch }}/unit_tests
+    - name: Run additional UMD tests
+      run: |
+        ${{ env.TEST_OUTPUT_DIR }}/umd/test_pcie_device/test_pcie_device
 
 

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -156,6 +156,24 @@ inline void memcpy_from_device(void *dest, const void *src, std::size_t num_byte
 // --------------------------------------------------------------------------------------------------------------
 // --------------------------------------------------------------------------------------------------------------
 
+/* static */ std::vector<int> PCIDevice::enumerate_devices() {
+    std::vector<int> device_ids;
+    std::string path = "/dev/tenstorrent/";
+
+    for (const auto& entry : std::filesystem::directory_iterator(path)) {
+        std::string filename = entry.path().filename().string();
+
+        // TODO: this will skip any device that has a non-numeric name, which
+        // is probably what we want longer-term (i.e. a UUID or something).
+        if (std::all_of(filename.begin(), filename.end(), ::isdigit)) {
+            device_ids.push_back(std::stoi(filename));
+        }
+    }
+
+    std::sort(device_ids.begin(), device_ids.end());
+    return device_ids;
+}
+
 PCIDevice::PCIDevice(int device_id, int logical_device_id) {
     // TODO: use C++ constructor to do everything
     // TODO: make public member vars const

--- a/device/pcie/pci_device.hpp
+++ b/device/pcie/pci_device.hpp
@@ -35,6 +35,11 @@ struct PciDeviceInfo
 
 class PCIDevice {
 public:
+    /**
+     * Return a list of integers corresponding to character devices in /dev/tenstorrent/
+     */
+    static std::vector<int> enumerate_devices();
+
     PCIDevice(int device_id, int logical_device_id);
     ~PCIDevice();
     PCIDevice(const PCIDevice&) = delete; // copy

--- a/device/pcie/pci_device.hpp
+++ b/device/pcie/pci_device.hpp
@@ -23,14 +23,25 @@ static const uint64_t UNROLL_ATU_OFFSET_BAR = 0x1200;
 // BAR0 size for Blackhole, used to determine whether write block should use BAR0 or BAR4
 const uint64_t BAR0_BH_SIZE = 512 * 1024 * 1024;
 
+struct PciDeviceInfo
+{
+    uint16_t vendor_id;
+    uint16_t device_id;
+    uint16_t pci_domain;
+    uint16_t pci_bus;
+    uint16_t pci_device;
+    uint16_t pci_function;
+};
 
 class PCIDevice {
 public:
     PCIDevice(int device_id, int logical_device_id);
     ~PCIDevice();
     PCIDevice(const PCIDevice&) = delete; // copy
-    void operator = (const PCIDevice&) = delete; // copy assignment
-    
+    void operator=(const PCIDevice&) = delete; // copy assignment
+
+    const PciDeviceInfo get_device_info() const { return info; }
+
     void write_block(uint64_t byte_addr, uint64_t num_bytes, const uint8_t* buffer_addr);
     void read_block(uint64_t byte_addr, uint64_t num_bytes, uint8_t* buffer_addr);
     void write_regs(uint32_t byte_addr, uint32_t word_len, const void *data);
@@ -39,15 +50,16 @@ public:
     void write_tlb_reg(uint32_t byte_addr, std::uint64_t value_lower, std::uint64_t value_upper, std::uint32_t tlb_cfg_reg_size);
 
     void open_hugepage_per_host_mem_ch(uint32_t num_host_mem_channels);
-    bool reset_board();
     tt::umd::architecture_implementation* get_architecture_implementation() const { return architecture_implementation.get(); }
 
-    int device_id;
-    int logical_id;
+    PciDeviceInfo info;
+
+    int device_id;  // N in /dev/tenstorrent/N
+    int logical_id; // TODO: does not belong in here
     int device_fd = -1;
 
     // PCIe device info
-    std::uint32_t numa_node;
+    int numa_node;
     std::uint32_t pcie_device_id;
     std::uint32_t pcie_revision_id;
 
@@ -94,6 +106,7 @@ private:
 
     tt::ARCH arch;
     std::unique_ptr<tt::umd::architecture_implementation> architecture_implementation;
+
 };
 
 tt::ARCH detect_arch(int device_id=0);

--- a/device/pcie/utils.hpp
+++ b/device/pcie/utils.hpp
@@ -47,7 +47,7 @@ tenstorrent_get_device_info get_pcie_device_info(int device_fd) {
 std::uint32_t get_pcie_info(int device_id, const std::string &info_needed) {
     // Get PCIe device info through iotcl
     int device_fd = find_device(device_id);
-    static const tenstorrent_get_device_info device_info = get_pcie_device_info(device_fd);
+    auto device_info = get_pcie_device_info(device_fd);
 
     if(info_needed == "pcie_device_id"){
         return device_info.out.device_id;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ target_include_directories(test_common INTERFACE
 
 if (MASTER_PROJECT)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/microbenchmark)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/pcie)
 endif()
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/simulation)
 if($ENV{ARCH_NAME} STREQUAL "wormhole_b0")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,8 +31,8 @@ target_include_directories(test_common INTERFACE
 
 if (MASTER_PROJECT)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/microbenchmark)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/pcie)
 endif()
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/pcie)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/simulation)
 if($ENV{ARCH_NAME} STREQUAL "wormhole_b0")
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/wormhole)
@@ -42,4 +42,4 @@ else()
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/$ENV{ARCH_NAME})
 endif()
 
-add_custom_target(umd_tests DEPENDS umd_unit_tests simulation_tests)
+add_custom_target(umd_tests DEPENDS umd_unit_tests simulation_tests test_pcie_device)

--- a/tests/pcie/CMakeLists.txt
+++ b/tests/pcie/CMakeLists.txt
@@ -2,4 +2,5 @@ add_executable(test_pcie_device test_pcie_device.cpp)
 target_link_libraries(test_pcie_device PRIVATE test_common)
 set_target_properties(test_pcie_device PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test/umd/test_pcie_device
+    OUTPUT_NAME test_pcie_device
 )

--- a/tests/pcie/CMakeLists.txt
+++ b/tests/pcie/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(test_pcie_device test_pcie_device.cpp)
+target_link_libraries(test_pcie_device PRIVATE test_common)
+set_target_properties(test_pcie_device PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test/umd/test_pcie_device
+)

--- a/tests/pcie/test_pcie_device.cpp
+++ b/tests/pcie/test_pcie_device.cpp
@@ -1,5 +1,6 @@
 
 #include <gtest/gtest.h>
+#include "fmt/xchar.h"
 
 #include <algorithm>
 #include <filesystem>
@@ -27,7 +28,8 @@ TEST(PcieDeviceTest, Numa) {
         bool all_non_negative = std::all_of(nodes.begin(), nodes.end(), [](int node) { return node >= 0; });
 
         EXPECT_TRUE(all_negative_one || all_non_negative)
-            << "NUMA nodes should either all be -1 (non-NUMA system) or all be non-negative (NUMA system)";
+            << "NUMA nodes should either all be -1 (non-NUMA system) or all be non-negative (NUMA system)"
+            << " but got: " << fmt::format("{}", fmt::join(nodes, ", "));
     } else {
         SUCCEED() << "No PCIe devices were enumerated";
     }

--- a/tests/pcie/test_pcie_device.cpp
+++ b/tests/pcie/test_pcie_device.cpp
@@ -1,0 +1,52 @@
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "device/pcie/pci_device.hpp"
+
+static std::vector<int> simple_pcie_device_enumeration()
+{
+    std::vector<int> device_ids;
+    std::string path = "/dev/tenstorrent/";
+
+    for (const auto& entry : std::filesystem::directory_iterator(path)) {
+        std::string filename = entry.path().filename().string();
+
+        // TODO: this will skip any device that has a non-numeric name, which
+        // is probably what we want longer-term (i.e. a UUID or something).
+        if (std::all_of(filename.begin(), filename.end(), ::isdigit)) {
+            device_ids.push_back(std::stoi(filename));
+        }
+    }
+
+    std::sort(device_ids.begin(), device_ids.end());
+    return device_ids;
+}
+
+TEST(PcieDeviceTest, Numa) {
+    std::vector<int> nodes;
+
+    for (auto device_id : simple_pcie_device_enumeration()) {
+        PCIDevice device(device_id, 0);
+        nodes.push_back(device.numa_node);
+    }
+
+    // Acceptable outcomes:
+    // 1. all of them are -1 (not a NUMA system)
+    // 2. all of them are >= 0 (NUMA system)
+    // 3. empty vector (no devices enumerated)
+
+    if (!nodes.empty()) {
+        bool all_negative_one = std::all_of(nodes.begin(), nodes.end(), [](int node) { return node == -1; });
+        bool all_non_negative = std::all_of(nodes.begin(), nodes.end(), [](int node) { return node >= 0; });
+
+        EXPECT_TRUE(all_negative_one || all_non_negative)
+            << "NUMA nodes should either all be -1 (non-NUMA system) or all be non-negative (NUMA system)";
+    } else {
+        SUCCEED() << "No PCIe devices were enumerated";
+    }
+}

--- a/tests/pcie/test_pcie_device.cpp
+++ b/tests/pcie/test_pcie_device.cpp
@@ -8,29 +8,11 @@
 
 #include "device/pcie/pci_device.hpp"
 
-static std::vector<int> simple_pcie_device_enumeration()
-{
-    std::vector<int> device_ids;
-    std::string path = "/dev/tenstorrent/";
-
-    for (const auto& entry : std::filesystem::directory_iterator(path)) {
-        std::string filename = entry.path().filename().string();
-
-        // TODO: this will skip any device that has a non-numeric name, which
-        // is probably what we want longer-term (i.e. a UUID or something).
-        if (std::all_of(filename.begin(), filename.end(), ::isdigit)) {
-            device_ids.push_back(std::stoi(filename));
-        }
-    }
-
-    std::sort(device_ids.begin(), device_ids.end());
-    return device_ids;
-}
 
 TEST(PcieDeviceTest, Numa) {
     std::vector<int> nodes;
 
-    for (auto device_id : simple_pcie_device_enumeration()) {
+    for (auto device_id : PCIDevice::enumerate_devices()) {
         PCIDevice device(device_id, 0);
         nodes.push_back(device.numa_node);
     }


### PR DESCRIPTION
https://github.com/tenstorrent/tt-umd/issues/134

1. Fix implicit assumption that every accelerator is of the same type (GS/WH/BH)
2. Remove some use of PCIDevice::logical_id from tt_silicon_driver.cpp
3. Add NUMA node detection to PCIDevice class
4. Add a PCIDevice class test harness (+ test for NUMA node detection)