### PR TITLE
Cleanup leftover PCIDevice methods from tt_silicon_driver

### DIFF
--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -23,8 +23,6 @@
 #include "common/assert.hpp"
 #include "common/logger.hpp"
 
-constexpr unsigned int c_hang_read_value = 0xffffffffu;
-
 static PciDeviceInfo read_device_info(int fd)
 {
     tenstorrent_get_device_info info{};

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -512,11 +512,3 @@ void PCIDevice::detect_ffffffff_read(std::uint32_t data_read) {
         throw std::runtime_error("Read 0xffffffff from PCIE: you should reset the board.");
     }
 }
-
-void PCIDevice::resume_after_device_reset() {
-    setup_device();
-}
-
-void PCIDevice::suspend_before_device_reset() {
-    close_device();
-}

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -12,6 +12,8 @@
 #include <sys/ioctl.h> // for ioctl
 #include <sys/mman.h>  // for mmap, munmap
 #include <linux/pci.h> // for PCI_SLOT, PCI_FUNC
+#include <spawn.h> // for posix_spawn
+#include <wait.h> // for waitpid
 
 #include "pci_device.hpp"
 #include "utils.hpp"
@@ -448,6 +450,10 @@ void PCIDevice::read_block(uint64_t byte_addr, uint64_t num_bytes, uint8_t* buff
     } else {
         memcpy(dest, src, num_bytes);
     }
+
+    if (num_bytes >= sizeof(std::uint32_t)) {
+        detect_ffffffff_read(*reinterpret_cast<std::uint32_t*>(dest));
+    }
 }
 
 // This is only needed for the BH workaround in iatu_configure_peer_region since no arc
@@ -492,4 +498,85 @@ void PCIDevice::write_tlb_reg(uint32_t byte_addr, std::uint64_t value_lower, std
         *dest_extra_dw = p_value_upper[0];
     }
     tt_driver_atomics::mfence(); // Otherwise subsequent WC loads move earlier than the above UC store to the TLB register.
+}
+
+
+bool PCIDevice::is_hardware_hung() {
+    volatile const void *addr = reinterpret_cast<const char *>(bar0_uc) + (get_architecture_implementation()->get_arc_reset_scratch_offset() + 6 * 4) - bar0_uc_offset;
+    std::uint32_t scratch_data = *reinterpret_cast<const volatile std::uint32_t*>(addr);
+
+    return (scratch_data == 0xffffffffu);
+}
+
+bool PCIDevice::reset_by_sysfs() {
+
+    const char *virtual_env = getenv("VIRTUAL_ENV");
+    if (virtual_env == nullptr)
+        return false;
+
+    std::string reset_helper_path = virtual_env;
+    reset_helper_path += "/bin/reset-helper";
+
+    // TBD fix this after #141 is resolved
+    std::string busid = std::to_string(pci_bus);
+
+    suspend_before_device_reset();
+
+    char *argv[3];
+    argv[0] = const_cast<char*>(reset_helper_path.c_str());
+    argv[1] = const_cast<char*>(busid.c_str());
+    argv[2] = nullptr;
+
+    pid_t reset_helper_pid;
+    if (posix_spawn(&reset_helper_pid, reset_helper_path.c_str(), nullptr, nullptr, argv, environ) != 0)
+        return false;
+
+    siginfo_t reset_helper_status;
+    if (waitid(P_PID, reset_helper_pid, &reset_helper_status, WEXITED) != 0)
+        return false;
+
+    if (reset_helper_status.si_status != 0)
+        return false;
+
+    resume_after_device_reset();
+
+    return true;
+}
+
+bool PCIDevice::reset_by_ioctl() {
+    struct tenstorrent_reset_device reset_device;
+    memset(&reset_device, 0, sizeof(reset_device));
+
+    reset_device.in.output_size_bytes = sizeof(reset_device.out);
+    reset_device.in.flags = 0;
+
+    if (ioctl(device_fd, TENSTORRENT_IOCTL_RESET_DEVICE, &reset_device) == -1) {
+        return false;
+    }
+
+    return (reset_device.out.result == 0);
+}
+
+bool PCIDevice::auto_reset_board() {
+    return ((reset_by_ioctl() || reset_by_sysfs()) && !is_hardware_hung());
+}
+
+void PCIDevice::detect_ffffffff_read(std::uint32_t data_read) {
+    if (data_read == 0xffffffffu && is_hardware_hung()) {
+        std::uint32_t scratch_data = *get_register_address<std::uint32_t>(read_checking_offset);
+
+        if (auto_reset_board()) {
+            throw std::runtime_error("Read 0xffffffff from PCIE: auto-reset succeeded.");
+        } else {
+            throw std::runtime_error("Read 0xffffffff from PCIE: you should reset the board.");
+        }
+    }
+}
+
+void PCIDevice::resume_after_device_reset() {
+    setup_device();
+}
+
+void PCIDevice::suspend_before_device_reset() {
+    close_device();
 }

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -12,8 +12,6 @@
 #include <sys/ioctl.h> // for ioctl
 #include <sys/mman.h>  // for mmap, munmap
 #include <linux/pci.h> // for PCI_SLOT, PCI_FUNC
-#include <spawn.h> // for posix_spawn
-#include <wait.h> // for waitpid
 
 #include "pci_device.hpp"
 #include "utils.hpp"

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -517,8 +517,7 @@ bool PCIDevice::reset_by_sysfs() {
     std::string reset_helper_path = virtual_env;
     reset_helper_path += "/bin/reset-helper";
 
-    // TBD fix this after #141 is resolved
-    std::string busid = std::to_string(pci_bus);
+    std::string busid = std::to_string(info.pci_bus);
 
     suspend_before_device_reset();
 

--- a/device/pcie/pci_device.hpp
+++ b/device/pcie/pci_device.hpp
@@ -103,9 +103,6 @@ private:
     void setup_device();
     void close_device();
 
-    void resume_after_device_reset();
-    void suspend_before_device_reset();
-
     bool is_hardware_hung();
 
     template <typename T>

--- a/device/pcie/pci_device.hpp
+++ b/device/pcie/pci_device.hpp
@@ -97,7 +97,7 @@ public:
 
     tt::ARCH get_arch() const;
 
-    void detect_ffffffff_read(std::uint32_t data_read = 0xffffffffu);
+    void detect_hang_read(std::uint32_t data_read = 0xffffffffu);
     
 private:
     void setup_device();

--- a/device/pcie/pci_device.hpp
+++ b/device/pcie/pci_device.hpp
@@ -23,6 +23,7 @@ static const uint64_t UNROLL_ATU_OFFSET_BAR = 0x1200;
 // BAR0 size for Blackhole, used to determine whether write block should use BAR0 or BAR4
 const uint64_t BAR0_BH_SIZE = 512 * 1024 * 1024;
 
+constexpr unsigned int c_hang_read_value = 0xffffffffu;
 struct PciDeviceInfo
 {
     uint16_t vendor_id;
@@ -97,7 +98,7 @@ public:
 
     tt::ARCH get_arch() const;
 
-    void detect_hang_read(std::uint32_t data_read = 0xffffffffu);
+    void detect_hang_read(std::uint32_t data_read = c_hang_read_value);
     
 private:
     void setup_device();

--- a/device/pcie/pci_device.hpp
+++ b/device/pcie/pci_device.hpp
@@ -93,18 +93,24 @@ public:
     std::uint32_t system_reg_start_offset;  // Registers >= this are system regs, use the mapping.
     std::uint32_t system_reg_offset_adjust; // This is the offset of the first reg in the system reg mapping.
 
-    // int sysfs_config_fd = -1;    // not used
     std::uint32_t read_checking_offset;
 
     tt::ARCH get_arch() const;
+
+    void detect_ffffffff_read(std::uint32_t data_read = 0xffffffffu);
     
 private:
     void setup_device();
     void close_device();
-    // void drop();
 
-    // bool reset_by_sysfs();
-    // bool reset_by_ioctl();
+    void resume_after_device_reset();
+    void suspend_before_device_reset();
+
+    bool is_hardware_hung();
+
+    bool reset_by_sysfs();
+    bool reset_by_ioctl();
+    bool auto_reset_board();
 
     template <typename T>
     T* get_register_address(std::uint32_t register_offset);

--- a/device/pcie/pci_device.hpp
+++ b/device/pcie/pci_device.hpp
@@ -108,10 +108,6 @@ private:
 
     bool is_hardware_hung();
 
-    bool reset_by_sysfs();
-    bool reset_by_ioctl();
-    bool auto_reset_board();
-
     template <typename T>
     T* get_register_address(std::uint32_t register_offset);
 

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -1531,7 +1531,7 @@ int tt_SiliconDevice::pcie_arc_msg(int logical_device_id, uint32_t msg_code, boo
         }
     }
 
-    pci_device->detect_ffffffff_read();
+    pci_device->detect_hang_read();
     return exit_code;
 }
 

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -35,8 +35,6 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <dirent.h>
-#include <spawn.h>
-#include <wait.h>
 #include <errno.h>
 
 #include "yaml-cpp/yaml.h"
@@ -164,94 +162,8 @@ bool is_char_dev(const dirent *ent, const char *parent_dir) {
     }
 }
 
-// leaving this in for now, TODO clean up
-#if 0
-bool is_hardware_hung(const PCIDevice *dev) {
-    volatile const void *addr = reinterpret_cast<const char *>(dev->bar0_uc) + (dev->get_architecture_implementation()->get_arc_reset_scratch_offset() + 6 * 4) - dev->bar0_uc_offset;
-    std::uint32_t scratch_data = *reinterpret_cast<const volatile std::uint32_t*>(addr);
 
-    return (scratch_data == 0xffffffffu);
-}
 
-bool reset_by_sysfs(PCIDevice *dev) {
-
-    const char *virtual_env = getenv("VIRTUAL_ENV");
-    if (virtual_env == nullptr)
-        return false;
-
-    std::string reset_helper_path = virtual_env;
-    reset_helper_path += "/bin/reset-helper";
-
-    std::string busid = std::to_string(dev->pci_bus);
-
-    dev->suspend_before_device_reset();
-
-    char *argv[3];
-    argv[0] = const_cast<char*>(reset_helper_path.c_str());
-    argv[1] = const_cast<char*>(busid.c_str());
-    argv[2] = nullptr;
-
-    pid_t reset_helper_pid;
-    if (posix_spawn(&reset_helper_pid, reset_helper_path.c_str(), nullptr, nullptr, argv, environ) != 0)
-        return false;
-
-    siginfo_t reset_helper_status;
-    if (waitid(P_PID, reset_helper_pid, &reset_helper_status, WEXITED) != 0)
-        return false;
-
-    if (reset_helper_status.si_status != 0)
-        return false;
-
-    dev->resume_after_device_reset();
-
-    return true;
-}
-
-bool reset_by_ioctl(PCIDevice *dev) {
-    struct tenstorrent_reset_device reset_device;
-    memset(&reset_device, 0, sizeof(reset_device));
-
-    reset_device.in.output_size_bytes = sizeof(reset_device.out);
-    reset_device.in.flags = 0;
-
-    if (ioctl(dev->device_fd, TENSTORRENT_IOCTL_RESET_DEVICE, &reset_device) == -1) {
-        return false;
-    }
-
-    return (reset_device.out.result == 0);
-}
-
-bool auto_reset_board(PCIDevice *dev) {
-    return ((reset_by_ioctl(dev) || reset_by_sysfs(dev)) && !is_hardware_hung(dev));
-}
-
-void detect_ffffffff_read(PCIDevice *dev, std::uint32_t data_read = 0xffffffffu) {
-    if (data_read == 0xffffffffu && is_hardware_hung(dev)) {
-        std::uint32_t scratch_data = *register_address<std::uint32_t>(dev, dev->read_checking_offset);
-
-        if (auto_reset_board(dev)) {
-            throw std::runtime_error("Read 0xffffffff from PCIE: auto-reset succeeded.");
-        } else {
-            throw std::runtime_error("Read 0xffffffff from PCIE: you should reset the board.");
-        }
-    }
-}
-
-inline void record_access (const char* where, uint32_t addr, uint32_t size, bool turbo, bool write, bool block, bool endline) {
-    log_trace(LogSiliconDriver, "{} PCI_ACCESS {} 0x{:x}  {} bytes {} {}{}", where, write ? "WR" : "RD", addr, size, turbo ? "TU" : "  ", block ? "BLK" : "   ", endline ? "\n" : "" );
-}
-
-inline void print_buffer (const void* buffer_addr, uint32_t len_bytes = 16, bool endline = true) {
-    // Prints each byte in a buffer
-    uint8_t *b = (uint8_t *)(buffer_addr);
-    for (uint32_t i = 0; i < len_bytes; i++) {
-        log_trace(LogSiliconDriver, "    [0x{:x}] = 0x{:x} ({}) ", i, b[i], b[i]);
-    }
-    if (endline) {
-        log_trace(LogSiliconDriver, "\n");
-    }
-}
-#endif
 // --------------------------------------------------------------------------------------------------------------
 // --------------------------------------------------------------------------------------------------------------
 // --------------------------------------------------------------------------------------------------------------
@@ -1619,7 +1531,7 @@ int tt_SiliconDevice::pcie_arc_msg(int logical_device_id, uint32_t msg_code, boo
         }
     }
 
-    // detect_ffffffff_read(pci_device);
+    pci_device->detect_ffffffff_read();
     return exit_code;
 }
 


### PR DESCRIPTION
A couple of methods were commented out with detecting hanged device disabled after #64 
This PR reintroduces it back, and moves all this PCIDevice related functions to that class.