### PR TITLE
Move PCIDevice functions to PCIDevice class

### DIFF
--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -524,7 +524,7 @@ dynamic_tlb PCIDevice::set_dynamic_tlb(unsigned int tlb_index, tt_xy_pair start,
     auto translated_start_coords = harvested_coord_translation.at(logical_id).at(start);
     auto translated_end_coords = harvested_coord_translation.at(logical_id).at(end);
     uint32_t tlb_address    = address / tlb_config.size;
-    uint32_t local_offset   = address % tlb_config.size;
+    uint32_t local_address   = address % tlb_config.size;
     uint64_t tlb_base       = tlb_config.base + (tlb_config.size * tlb_config.index_offset);
     uint32_t tlb_cfg_reg    = tlb_config.cfg_addr + (TLB_CFG_REG_SIZE_BYTES * tlb_config.index_offset);
 
@@ -543,10 +543,9 @@ dynamic_tlb PCIDevice::set_dynamic_tlb(unsigned int tlb_index, tt_xy_pair start,
     }.apply_offset(tlb_config.offset);
 
     log_debug(LogSiliconDriver, "set_dynamic_tlb() with tlb_index: {} tlb_index_offset: {} dynamic_tlb_size: {}MB tlb_base: 0x{:x} tlb_cfg_reg: 0x{:x}", tlb_index, tlb_config.index_offset, tlb_config.size/(1024*1024), tlb_base, tlb_cfg_reg);
-    // write_regs(dev -> hdev, tlb_cfg_reg, 2, &tlb_data);
     write_tlb_reg(tlb_cfg_reg, tlb_data.first, tlb_data.second, TLB_CFG_REG_SIZE_BYTES);
 
-    return { tlb_base + local_offset, tlb_config.size - local_offset };
+    return { tlb_base + local_address, tlb_config.size - local_address };
 }
 
 dynamic_tlb PCIDevice::set_dynamic_tlb(unsigned int tlb_index, tt_xy_pair target, std::uint64_t address, std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>>& harvested_coord_translation, std::uint64_t ordering) {

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -507,3 +507,53 @@ void PCIDevice::detect_hang_read(std::uint32_t data_read) {
         throw std::runtime_error("Read 0xffffffff from PCIE: you should reset the board.");
     }
 }
+
+// Get TLB index (from zero), check if it's in 16MB, 2MB or 1MB TLB range, and dynamically program it.
+dynamic_tlb PCIDevice::set_dynamic_tlb(unsigned int tlb_index, tt_xy_pair start, tt_xy_pair end,
+                            std::uint64_t address, bool multicast, std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>>& harvested_coord_translation, std::uint64_t ordering) {
+    auto architecture_implementation = get_architecture_implementation();
+    if (multicast) {
+        std::tie(start, end) = architecture_implementation->multicast_workaround(start, end);
+    }
+
+    log_trace(LogSiliconDriver, "set_dynamic_tlb with arguments: tlb_index = {}, start = ({}, {}), end = ({}, {}), address = 0x{:x}, multicast = {}, ordering = {}",
+         tlb_index, start.x, start.y, end.x, end.y, address, multicast, (int)ordering);
+
+    tt::umd::tlb_configuration tlb_config = architecture_implementation->get_tlb_configuration(tlb_index);
+    std::uint32_t TLB_CFG_REG_SIZE_BYTES = architecture_implementation->get_tlb_cfg_reg_size_bytes();
+    auto translated_start_coords = harvested_coord_translation.at(logical_id).at(start);
+    auto translated_end_coords = harvested_coord_translation.at(logical_id).at(end);
+    uint32_t tlb_address    = address / tlb_config.size;
+    uint32_t local_offset   = address % tlb_config.size;
+    uint64_t tlb_base       = tlb_config.base + (tlb_config.size * tlb_config.index_offset);
+    uint32_t tlb_cfg_reg    = tlb_config.cfg_addr + (TLB_CFG_REG_SIZE_BYTES * tlb_config.index_offset);
+
+    std::pair<std::uint64_t, std::uint64_t> tlb_data = tt::umd::tlb_data {
+        .local_offset = tlb_address,
+        .x_end = static_cast<uint64_t>(translated_end_coords.x),
+        .y_end = static_cast<uint64_t>(translated_end_coords.y),
+        .x_start = static_cast<uint64_t>(translated_start_coords.x),
+        .y_start = static_cast<uint64_t>(translated_start_coords.y),
+        .mcast = multicast,
+        .ordering = ordering,
+        // TODO #2715: hack for Blackhole A0, will potentially be fixed in B0.
+        // Using the same static vc for reads and writes through TLBs can hang the card. It doesn't even have to be the same TLB.
+        // Dynamic vc should not have this issue. There might be a perf impact with using dynamic vc.
+        .static_vc = (get_arch() == tt::ARCH::BLACKHOLE) ? false : true,
+    }.apply_offset(tlb_config.offset);
+
+    log_debug(LogSiliconDriver, "set_dynamic_tlb() with tlb_index: {} tlb_index_offset: {} dynamic_tlb_size: {}MB tlb_base: 0x{:x} tlb_cfg_reg: 0x{:x}", tlb_index, tlb_config.index_offset, tlb_config.size/(1024*1024), tlb_base, tlb_cfg_reg);
+    // write_regs(dev -> hdev, tlb_cfg_reg, 2, &tlb_data);
+    write_tlb_reg(tlb_cfg_reg, tlb_data.first, tlb_data.second, TLB_CFG_REG_SIZE_BYTES);
+
+    return { tlb_base + local_offset, tlb_config.size - local_offset };
+}
+
+dynamic_tlb PCIDevice::set_dynamic_tlb(unsigned int tlb_index, tt_xy_pair target, std::uint64_t address, std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>>& harvested_coord_translation, std::uint64_t ordering) {
+    return set_dynamic_tlb(tlb_index, tt_xy_pair(0, 0), target, address, false, harvested_coord_translation, ordering);
+}
+
+dynamic_tlb PCIDevice::set_dynamic_tlb_broadcast(unsigned int tlb_index, std::uint64_t address, std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>>& harvested_coord_translation, tt_xy_pair start, tt_xy_pair end, std::uint64_t ordering) {
+    // Issue a broadcast to cores included in the start (top left) and end (bottom right) grid
+    return set_dynamic_tlb(tlb_index, start, end, address, true, harvested_coord_translation, ordering);
+}

--- a/device/pcie/pci_device.hpp
+++ b/device/pcie/pci_device.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 #include <unordered_map>
 
+#include "device/tt_xy_pair.h"
 #include "device/tt_arch_types.h"
 #include "device/architecture_implementation.h"
 #include "device/tt_cluster_descriptor_types.h"

--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -702,7 +702,7 @@ class tt_SiliconDevice: public tt_device
     void initialize_interprocess_mutexes(int pci_interface_id, bool cleanup_mutexes_in_shm);
     void cleanup_shared_host_state();
     void initialize_pcie_devices();
-    void broadcast_pcie_tensix_risc_reset(PCIDevice *device, const TensixSoftResetOptions &cores);
+    void broadcast_pcie_tensix_risc_reset(chip_id_t chip_id, const TensixSoftResetOptions &cores);
     void broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOptions &soft_resets);
     void send_remote_tensix_risc_reset_to_core(const tt_cxy_pair &core, const TensixSoftResetOptions &soft_resets);
     void send_tensix_risc_reset_to_core(const tt_cxy_pair &core, const TensixSoftResetOptions &soft_resets);
@@ -714,7 +714,7 @@ class tt_SiliconDevice: public tt_device
     void set_pcie_power_state(tt_DevicePowerState state);
     int set_remote_power_state(const chip_id_t &chip, tt_DevicePowerState device_state);
     void set_power_state(tt_DevicePowerState state);
-    uint32_t get_power_state_arc_msg(PCIDevice *pci_device, tt_DevicePowerState state);
+    uint32_t get_power_state_arc_msg(chip_id_t chip_id, tt_DevicePowerState state);
     void enable_local_ethernet_queue(const chip_id_t& chip, int timeout);
     void enable_ethernet_queue(int timeout);
     void enable_remote_ethernet_queue(const chip_id_t& chip, int timeout);

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -172,10 +172,6 @@ bool is_char_dev(const dirent *ent, const char *parent_dir) {
 #include <fstream>
 #include <iomanip>
 
-struct dynamic_tlb {
-    uint64_t bar_offset;        // Offset that address is mapped to, within the PCI BAR.
-    uint64_t remaining_size;    // Bytes remaining between bar_offset and end of the TLB.
-};
 
 struct routing_cmd_t {
     uint64_t sys_addr;
@@ -221,69 +217,6 @@ namespace {
             }
         }
     };
-}
-// Get TLB index (from zero), check if it's in 16MB, 2MB or 1MB TLB range, and dynamically program it.
-dynamic_tlb set_dynamic_tlb(
-    PCIDevice* dev,
-    unsigned int tlb_index,
-    tt_xy_pair start,
-    tt_xy_pair end,
-    std::uint64_t address,
-    bool multicast,
-    std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>>& harvested_coord_translation,
-    std::uint64_t ordering)
-{
-    auto architecture_implementation = dev->get_architecture_implementation();
-
-    // TODO(Joel): the PCIDevice should not really be carring this around - this
-    // is one of two places that extracts it from the PCIDevice.  Since KMD will
-    // eventually take over the TLB programming, this can get removed later on.
-    auto logical_id = dev->get_logical_id();
-
-    if (multicast) {
-        std::tie(start, end) = architecture_implementation->multicast_workaround(start, end);
-    }
-
-    log_trace(LogSiliconDriver, "set_dynamic_tlb with arguments: tlb_index = {}, start = ({}, {}), end = ({}, {}), address = 0x{:x}, multicast = {}, ordering = {}",
-         tlb_index, start.x, start.y, end.x, end.y, address, multicast, (int)ordering);
-
-    tt::umd::tlb_configuration tlb_config = architecture_implementation->get_tlb_configuration(tlb_index);
-    std::uint32_t TLB_CFG_REG_SIZE_BYTES = architecture_implementation->get_tlb_cfg_reg_size_bytes();
-    auto translated_start_coords = harvested_coord_translation.at(logical_id).at(start);
-    auto translated_end_coords = harvested_coord_translation.at(logical_id).at(end);
-    uint32_t tlb_address    = address / tlb_config.size;
-    uint32_t local_offset   = address % tlb_config.size;
-    uint64_t tlb_base       = tlb_config.base + (tlb_config.size * tlb_config.index_offset);
-    uint32_t tlb_cfg_reg    = tlb_config.cfg_addr + (TLB_CFG_REG_SIZE_BYTES * tlb_config.index_offset);
-
-    std::pair<std::uint64_t, std::uint64_t> tlb_data = TLB_DATA {
-        .local_offset = tlb_address,
-        .x_end = static_cast<uint64_t>(translated_end_coords.x),
-        .y_end = static_cast<uint64_t>(translated_end_coords.y),
-        .x_start = static_cast<uint64_t>(translated_start_coords.x),
-        .y_start = static_cast<uint64_t>(translated_start_coords.y),
-        .mcast = multicast,
-        .ordering = ordering,
-        // TODO #2715: hack for Blackhole A0, will potentially be fixed in B0.
-        // Using the same static vc for reads and writes through TLBs can hang the card. It doesn't even have to be the same TLB.
-        // Dynamic vc should not have this issue. There might be a perf impact with using dynamic vc.
-        .static_vc = (dev->get_arch() == tt::ARCH::BLACKHOLE) ? false : true,
-    }.apply_offset(tlb_config.offset);
-
-    log_debug(LogSiliconDriver, "set_dynamic_tlb() with tlb_index: {} tlb_index_offset: {} dynamic_tlb_size: {}MB tlb_base: 0x{:x} tlb_cfg_reg: 0x{:x}", tlb_index, tlb_config.index_offset, tlb_config.size/(1024*1024), tlb_base, tlb_cfg_reg);
-    // write_regs(dev -> hdev, tlb_cfg_reg, 2, &tlb_data);
-    dev->write_tlb_reg(tlb_cfg_reg, tlb_data.first, tlb_data.second, TLB_CFG_REG_SIZE_BYTES);
-
-    return { tlb_base + local_offset, tlb_config.size - local_offset };
-}
-
-dynamic_tlb set_dynamic_tlb(PCIDevice *dev, unsigned int tlb_index, tt_xy_pair target, std::uint64_t address, std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>>& harvested_coord_translation, std::uint64_t ordering = TLB_DATA::Relaxed) {
-    return set_dynamic_tlb(dev, tlb_index, tt_xy_pair(0, 0), target, address, false, harvested_coord_translation, ordering);
-}
-
-dynamic_tlb set_dynamic_tlb_broadcast(PCIDevice *dev, unsigned int tlb_index, std::uint64_t address, std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>>& harvested_coord_translation, tt_xy_pair start, tt_xy_pair end, std::uint64_t ordering = TLB_DATA::Relaxed) {
-    // Issue a broadcast to cores included in the start (top left) and end (bottom right) grid
-    return set_dynamic_tlb(dev, tlb_index, start, end, address, true, harvested_coord_translation, ordering);
 }
 
 bool tt_SiliconDevice::address_in_tlb_space(uint32_t address, uint32_t size_in_bytes, int32_t tlb_index, uint64_t tlb_size, std::uint32_t chip) {
@@ -824,8 +757,10 @@ void tt_SiliconDevice::initialize_pcie_devices() {
     init_membars();
 }
 
-void tt_SiliconDevice::broadcast_pcie_tensix_risc_reset(PCIDevice *device, const TensixSoftResetOptions &soft_resets) {
+void tt_SiliconDevice::broadcast_pcie_tensix_risc_reset(chip_id_t chip_id, const TensixSoftResetOptions &soft_resets) {
     log_debug(LogSiliconDriver, "tt_SiliconDevice::broadcast_tensix_risc_reset");
+
+    PCIDevice* device = get_pci_device(chip_id);
 
     auto valid = soft_resets & ALL_TENSIX_SOFT_RESET;
     auto logical_id = device->get_logical_id();
@@ -835,8 +770,7 @@ void tt_SiliconDevice::broadcast_pcie_tensix_risc_reset(PCIDevice *device, const
     auto architecture_implementation = device->get_architecture_implementation();
 
     // TODO: this is clumsy and difficult to read
-    auto [soft_reset_reg, _] = set_dynamic_tlb_broadcast(
-        device,
+    auto [soft_reset_reg, _] = device->set_dynamic_tlb_broadcast(
         architecture_implementation->get_reg_tlb(),
         architecture_implementation->get_tensix_soft_reset_addr(),
         harvested_coord_translation,
@@ -1001,7 +935,7 @@ void tt_SiliconDevice::write_device_memory(const void *mem_ptr, uint32_t size_in
 
         while(size_in_bytes > 0) {
 
-            auto [mapped_address, tlb_size] = set_dynamic_tlb(dev, tlb_index, target, address, harvested_coord_translation, dynamic_tlb_ordering_modes.at(fallback_tlb));
+            auto [mapped_address, tlb_size] = dev->set_dynamic_tlb(tlb_index, target, address, harvested_coord_translation, dynamic_tlb_ordering_modes.at(fallback_tlb));
             uint32_t transfer_size = std::min((uint64_t)size_in_bytes, tlb_size);
             dev->write_block(mapped_address, transfer_size, buffer_addr);
 
@@ -1044,7 +978,7 @@ void tt_SiliconDevice::read_device_memory(void *mem_ptr, tt_cxy_pair target, std
         log_debug(LogSiliconDriver, "  dynamic tlb_index: {}", tlb_index);
         while(size_in_bytes > 0) {
 
-            auto [mapped_address, tlb_size] = set_dynamic_tlb(dev, tlb_index, target, address, harvested_coord_translation, dynamic_tlb_ordering_modes.at(fallback_tlb));
+            auto [mapped_address, tlb_size] = dev->set_dynamic_tlb(tlb_index, target, address, harvested_coord_translation, dynamic_tlb_ordering_modes.at(fallback_tlb));
             uint32_t transfer_size = std::min((uint64_t)size_in_bytes, tlb_size);
             dev->read_block(mapped_address, transfer_size, buffer_addr);
 
@@ -1106,7 +1040,8 @@ void tt_SiliconDevice::write_buffer(
 }
 
 
-uint32_t tt_SiliconDevice::get_power_state_arc_msg(PCIDevice* pci_device, tt_DevicePowerState state) {
+uint32_t tt_SiliconDevice::get_power_state_arc_msg(chip_id_t chip_id, tt_DevicePowerState state) {
+    PCIDevice* pci_device = get_pci_device(chip_id);
     uint32_t msg = 0xaa00;
     switch (state) {
         case BUSY: {
@@ -1129,12 +1064,11 @@ uint32_t tt_SiliconDevice::get_power_state_arc_msg(PCIDevice* pci_device, tt_Dev
 void tt_SiliconDevice::set_pcie_power_state(tt_DevicePowerState state) {
 
     for (auto &device_it : m_pci_device_map){
-        int d = device_it.first;
-        auto pci_device = device_it.second.get();
-        uint32_t msg = get_power_state_arc_msg(pci_device, state);
+        int chip_id = device_it.first;
+        uint32_t msg = get_power_state_arc_msg(chip_id, state);
         std::stringstream ss;
         ss << state;
-        auto exit_code = arc_msg(d, 0xaa00 | msg, true, 0, 0);
+        auto exit_code = arc_msg(chip_id, 0xaa00 | msg, true, 0, 0);
         if (exit_code != 0) {
             throw std::runtime_error(fmt::format("Failed to set power state to {} with exit code {}", ss.str(), exit_code));
         }
@@ -1215,7 +1149,7 @@ std::optional<std::tuple<uint32_t, uint32_t>> tt_SiliconDevice::get_tlb_data_fro
 void tt_SiliconDevice::configure_tlb(chip_id_t logical_device_id, tt_xy_pair core, std::int32_t tlb_index, std::int32_t address, uint64_t ordering) {
     log_assert(ordering == TLB_DATA::Strict || ordering == TLB_DATA::Posted || ordering == TLB_DATA::Relaxed, "Invalid ordering specified in tt_SiliconDevice::configure_tlb");
     PCIDevice *pci_device = get_pci_device(logical_device_id);
-    set_dynamic_tlb(pci_device, tlb_index, core, address, harvested_coord_translation, ordering);
+    pci_device->set_dynamic_tlb(tlb_index, core, address, harvested_coord_translation, ordering);
     auto tlb_size = std::get<1>(pci_device->get_architecture_implementation()->describe_tlb(tlb_index).value());
     if(tlb_config_map.find(logical_device_id) == tlb_config_map.end()) tlb_config_map.insert({logical_device_id, {}});
     tlb_config_map[logical_device_id].insert({tlb_index, (address / tlb_size) * tlb_size});
@@ -1438,7 +1372,7 @@ int tt_SiliconDevice::test_setup_interface () {
         int ret_val = 0;
         PCIDevice *dev = m_pci_device_map.begin()->second.get();
 
-        uint32_t mapped_reg = set_dynamic_tlb(dev, dev->get_architecture_implementation()->get_reg_tlb(), tt_xy_pair(0, 0), 0xffb20108, harvested_coord_translation).bar_offset;
+        uint32_t mapped_reg = dev->set_dynamic_tlb(dev->get_architecture_implementation()->get_reg_tlb(), tt_xy_pair(0, 0), 0xffb20108, harvested_coord_translation).bar_offset;
 
         uint32_t regval = 0;
         dev->read_regs(mapped_reg, 1, &regval);
@@ -1449,7 +1383,7 @@ int tt_SiliconDevice::test_setup_interface () {
         int ret_val = 0;
         PCIDevice *dev = m_pci_device_map.begin()->second.get();
 
-        uint32_t mapped_reg = set_dynamic_tlb(dev, dev->get_architecture_implementation()->get_reg_tlb(), tt_xy_pair(1, 0), 0xffb20108, harvested_coord_translation).bar_offset;
+        uint32_t mapped_reg = dev->set_dynamic_tlb(dev->get_architecture_implementation()->get_reg_tlb(), tt_xy_pair(1, 0), 0xffb20108, harvested_coord_translation).bar_offset;
 
         uint32_t regval = 0;
         dev->read_regs(mapped_reg, 1, &regval);
@@ -1461,7 +1395,7 @@ int tt_SiliconDevice::test_setup_interface () {
         // int ret_val = 0;
         // PCIDevice *dev = m_pci_device_map.begin()->second->hdev;
 
-        // uint32_t mapped_reg = set_dynamic_tlb(m_pci_device_map.begin()->second, dev->get_architecture_implementation()->get_reg_tlb(), tt_xy_pair(1, 0), 0xffb20108, harvested_coord_translation).bar_offset;
+        // uint32_t mapped_reg = dev->set_dynamic_tlb(m_pci_device_map.begin()->second, dev->get_architecture_implementation()->get_reg_tlb(), tt_xy_pair(1, 0), 0xffb20108, harvested_coord_translation).bar_offset;
 
         // uint32_t regval = 0;
         // read_regs(dev, mapped_reg, 1, &regval);
@@ -2291,7 +2225,7 @@ void tt_SiliconDevice::pcie_broadcast_write(chip_id_t chip, const void* mem_ptr,
     const uint8_t* buffer_addr = static_cast<const uint8_t*>(mem_ptr);
     const scoped_lock<named_mutex> lock(*get_mutex(fallback_tlb, pci_device->get_device_num()));
     while(size_in_bytes > 0) {
-        auto [mapped_address, tlb_size] = set_dynamic_tlb_broadcast(pci_device, tlb_index, addr, harvested_coord_translation, start, end, dynamic_tlb_ordering_modes.at(fallback_tlb));
+        auto [mapped_address, tlb_size] = pci_device->set_dynamic_tlb_broadcast(tlb_index, addr, harvested_coord_translation, start, end, dynamic_tlb_ordering_modes.at(fallback_tlb));
         uint64_t transfer_size = std::min((uint64_t)size_in_bytes, tlb_size);
         pci_device->write_block(mapped_address, transfer_size, buffer_addr);
 
@@ -2658,7 +2592,7 @@ void tt_SiliconDevice::read_mmio_device_register(void* mem_ptr, tt_cxy_pair core
     const scoped_lock<named_mutex> lock(*get_mutex(fallback_tlb, pci_device->get_device_num()));
     log_debug(LogSiliconDriver, "  dynamic tlb_index: {}", tlb_index);
 
-    auto [mapped_address, tlb_size] = set_dynamic_tlb(pci_device, tlb_index, core, addr, harvested_coord_translation, TLB_DATA::Strict);
+    auto [mapped_address, tlb_size] = pci_device->set_dynamic_tlb(tlb_index, core, addr, harvested_coord_translation, TLB_DATA::Strict);
     // Align block to 4bytes if needed. 
     auto aligned_buf = tt_4_byte_aligned_buffer(mem_ptr, size);
     pci_device->read_regs(mapped_address, aligned_buf.block_size / sizeof(std::uint32_t), aligned_buf.local_storage);
@@ -2677,7 +2611,7 @@ void tt_SiliconDevice::write_mmio_device_register(const void* mem_ptr, tt_cxy_pa
     const scoped_lock<named_mutex> lock(*get_mutex(fallback_tlb, pci_device->get_device_num()));
     log_debug(LogSiliconDriver, "  dynamic tlb_index: {}", tlb_index);
 
-    auto [mapped_address, tlb_size] = set_dynamic_tlb(pci_device, tlb_index, core, addr, harvested_coord_translation, TLB_DATA::Strict);
+    auto [mapped_address, tlb_size] = pci_device->set_dynamic_tlb(tlb_index, core, addr, harvested_coord_translation, TLB_DATA::Strict);
     // Align block to 4bytes if needed. 
     auto aligned_buf = tt_4_byte_aligned_buffer(mem_ptr, size);
     if(aligned_buf.input_size != aligned_buf.block_size) {
@@ -2729,8 +2663,7 @@ void tt_SiliconDevice::send_remote_tensix_risc_reset_to_core(const tt_cxy_pair &
 
 int tt_SiliconDevice::set_remote_power_state(const chip_id_t &chip, tt_DevicePowerState device_state) {
     auto mmio_capable_chip_logical = ndesc->get_closest_mmio_capable_chip(chip);
-    PCIDevice *pci_device = get_pci_device(mmio_capable_chip_logical);
-    return remote_arc_msg(chip, get_power_state_arc_msg(pci_device, device_state), true, 0, 0, 1, NULL, NULL);
+    return remote_arc_msg(chip, get_power_state_arc_msg(mmio_capable_chip_logical, device_state), true, 0, 0, 1, NULL, NULL);
 }
 
 
@@ -2753,7 +2686,7 @@ void tt_SiliconDevice::enable_remote_ethernet_queue(const chip_id_t& chip, int t
 void tt_SiliconDevice::broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOptions &soft_resets) {
     if(arch_name == tt::ARCH::GRAYSKULL) {
         for (auto &device_it : m_pci_device_map) {
-            broadcast_pcie_tensix_risc_reset(device_it.second.get(), soft_resets);
+            broadcast_pcie_tensix_risc_reset(device_it.first, soft_resets);
         }
     }
     else {


### PR DESCRIPTION
Some of the functions which clearly accept PCIDevice pointer were located in tt_silicon_driver, but they obviously should be part of the PCIDevice class.
Those same functions are also arch specific, so they'll probably be moved to new class TTDevice according to https://docs.google.com/drawings/d/1-m1azdsBqMA0A6ATYRMfkhyeuOJuGCEI62N5a96LXj0/edit

I've also changed two functions, broadcast_pcie_tensix_risc_reset and get_power_state_arc_msg to accept chip_id rather than PCIDevice pointer. These were private members, so no API change.

Related to #142 