### PR TITLE
Add cmake install

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -20,8 +20,7 @@ target_link_libraries(umd_device
     PUBLIC yaml-cpp::yaml-cpp umd_common_directories nng uv compiler_flags
     PRIVATE hwloc rt Boost::interprocess fmt
 )
-target_include_directories(umd_device
-    PRIVATE
+target_include_directories(umd_device PUBLIC
     ${flatbuffers_SOURCE_DIR}/include
     ${nanomsg_SOURCE_DIR}/include
     ${libuv_SOURCE_DIR}/include

--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -20,7 +20,8 @@ target_link_libraries(umd_device
     PUBLIC yaml-cpp::yaml-cpp umd_common_directories nng uv compiler_flags
     PRIVATE hwloc rt Boost::interprocess fmt
 )
-target_include_directories(umd_device PUBLIC
+target_include_directories(umd_device
+    PRIVATE
     ${flatbuffers_SOURCE_DIR}/include
     ${nanomsg_SOURCE_DIR}/include
     ${libuv_SOURCE_DIR}/include
@@ -29,4 +30,18 @@ set_target_properties(umd_device PROPERTIES
     OUTPUT_NAME device
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
     POSITION_INDEPENDENT_CODE ON
+)
+
+include(GNUInstallDirs)
+
+install(TARGETS umd_device
+    EXPORT umdTargets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT dev
+)
+
+install(EXPORT umdTargets
+    FILE umdTargets.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/umd
 )

--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -33,14 +33,14 @@ set_target_properties(umd_device PROPERTIES
 
 include(GNUInstallDirs)
 
+# EXPORT umdTargets
 install(TARGETS umd_device
-    EXPORT umdTargets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     COMPONENT dev
 )
 
-install(EXPORT umdTargets
-    FILE umdTargets.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/umd
-)
+#install(EXPORT umdTargets
+#    FILE umdTargets.cmake
+#    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/umd
+#)


### PR DESCRIPTION
At some point...

We should be able to run cmake --install

The library should be in an export set, but doing that currently causes error due to poor separation of public and private dependencies / include paths.

This is a stepping stone to find_package(umd).