### PR TITLE
wait_for_non_mmio_flush per chip

### DIFF
--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -155,6 +155,7 @@ void tt_SimulationDevice::read_from_sysmem(std::vector<uint32_t> &vec, uint64_t 
 void tt_SimulationDevice::read_from_sysmem(void* mem_ptr, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id) {}
 
 void tt_SimulationDevice::wait_for_non_mmio_flush() {}
+void tt_SimulationDevice::wait_for_non_mmio_flush(const chip_id_t chip) {}
 void tt_SimulationDevice::l1_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {}
 void tt_SimulationDevice::dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels) {}
 void tt_SimulationDevice::dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {}

--- a/device/simulation/tt_simulation_device.h
+++ b/device/simulation/tt_simulation_device.h
@@ -42,7 +42,8 @@ class tt_SimulationDevice: public tt_device {
     virtual void read_from_sysmem(std::vector<uint32_t> &vec, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id);
     virtual void read_from_sysmem(void* mem_ptr, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id);
     
-    virtual void wait_for_non_mmio_flush(); //
+    virtual void wait_for_non_mmio_flush();
+    virtual void wait_for_non_mmio_flush(const chip_id_t chip);
     void l1_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
     void dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels);
     void dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});

--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -362,7 +362,7 @@ class tt_device
      * Non-MMIO (ethernet) barrier.
      * This function should be called for a remote chip. If called for local chip, it will be a no-op.
      */
-    virtual void wait_for_non_mmio_flush(chip_id_t chip_id) {
+    virtual void wait_for_non_mmio_flush(const chip_id_t chip_id) {
         throw std::runtime_error("---- tt_device::wait_for_non_mmio_flush is not implemented\n");
     }
 
@@ -649,7 +649,7 @@ class tt_SiliconDevice: public tt_device
     virtual void write_to_sysmem(const void* mem_ptr, std::uint32_t size,  uint64_t addr, uint16_t channel, chip_id_t src_device_id);
     virtual void read_from_sysmem(void* mem_ptr, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id);
     virtual void wait_for_non_mmio_flush();
-    virtual void wait_for_non_mmio_flush(chip_id_t chip_id);
+    virtual void wait_for_non_mmio_flush(const chip_id_t chip_id);
     void l1_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
     void dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels);
     void dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});

--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -352,8 +352,17 @@ class tt_device
     /**
      * Non-MMIO (ethernet) barrier.
      * Similar to an mfence for host -> host transfers. Will flush all in-flight ethernet transactions before proceeding with the next one.
+     * This will be applied to all chips in the cluster.
      */ 
     virtual void wait_for_non_mmio_flush() {
+        throw std::runtime_error("---- tt_device::wait_for_non_mmio_flush is not implemented\n");
+    }
+
+    /**
+     * Non-MMIO (ethernet) barrier.
+     * This function should be called for a remote chip. If called for local chip, it will be a no-op.
+     */
+    virtual void wait_for_non_mmio_flush(chip_id_t chip_id) {
         throw std::runtime_error("---- tt_device::wait_for_non_mmio_flush is not implemented\n");
     }
 
@@ -640,6 +649,7 @@ class tt_SiliconDevice: public tt_device
     virtual void write_to_sysmem(const void* mem_ptr, std::uint32_t size,  uint64_t addr, uint16_t channel, chip_id_t src_device_id);
     virtual void read_from_sysmem(void* mem_ptr, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id);
     virtual void wait_for_non_mmio_flush();
+    virtual void wait_for_non_mmio_flush(chip_id_t chip_id);
     void l1_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
     void dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels);
     void dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
@@ -759,6 +769,9 @@ class tt_SiliconDevice: public tt_device
     void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t> &fw_versions);
     int test_setup_interface ();
 
+    // This functions has to be called for local chip, and then it will wait for all connected remote chips to flush.
+    void wait_for_connected_non_mmio_flush(chip_id_t chip_id);
+
     // State variables
     tt_device_dram_address_params dram_address_params;
     tt_device_l1_address_params l1_address_params;
@@ -784,7 +797,7 @@ class tt_SiliconDevice: public tt_device
 
     int active_core = NON_EPOCH_ETH_CORES_START_ID;
     std::vector< std::vector<tt_cxy_pair> > remote_transfer_ethernet_cores;
-    bool flush_non_mmio = false;
+    std::unordered_map<chip_id_t, bool> flush_non_mmio_per_chip = {};
     bool non_mmio_transfer_cores_customized = false;
     std::unordered_map<chip_id_t, int> active_eth_core_idx_per_chip = {};
     std::unordered_map<chip_id_t, bool> noc_translation_enabled_for_chip = {};

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -351,11 +351,8 @@ void tt_SiliconDevice::create_device(const std::unordered_set<chip_id_t> &target
         // Initialize identity mapping for Non-MMIO chips as well
         if(!ndesc -> is_chip_mmio_capable(chip)) {
             harvested_coord_translation.insert({chip, create_harvested_coord_translation(arch_name, true)});
+            flush_non_mmio_per_chip[chip] = false;
         }
-    }
-
-    for (const chip_id_t &logical_device_id : target_remote_chips) {
-        flush_non_mmio_per_chip[logical_device_id] = false;
     }
 }
 
@@ -1748,6 +1745,7 @@ void tt_SiliconDevice::write_to_non_mmio_device(
     else {
         mmio_capable_chip_logical = ndesc->get_closest_mmio_capable_chip(core.chip);
     }
+    flush_non_mmio_per_chip[ndesc->get_closest_mmio_capable_chip(core.chip)] = true;
 
     if (non_mmio_transfer_cores_customized) {
         log_assert(active_eth_core_idx_per_chip.find(mmio_capable_chip_logical) != active_eth_core_idx_per_chip.end(), "Ethernet Cores for Host to Cluster communication were not initialized for all MMIO devices.");
@@ -1775,7 +1773,6 @@ void tt_SiliconDevice::write_to_non_mmio_device(
     bool use_dram;
     uint32_t max_block_size;
 
-    flush_non_mmio_per_chip[core.chip] = true;
     // Broadcast requires block writes to host dram
     use_dram = broadcast || (size_in_bytes > 256 * DATA_WORD_SIZE);
     max_block_size = use_dram ? host_address_params.eth_routing_block_size : eth_interface_params.max_block_size;
@@ -2094,56 +2091,54 @@ void tt_SiliconDevice::read_from_non_mmio_device(void* mem_ptr, tt_cxy_pair core
 }
 
 void tt_SiliconDevice::wait_for_connected_non_mmio_flush(const chip_id_t chip_id) {
-    log_assert(arch_name != tt::ARCH::BLACKHOLE, "Non-MMIO flush not supported in Blackhole");
-    std::string read_tlb = "LARGE_READ_TLB";
-    auto chips_with_mmio = this->get_target_mmio_device_ids();
+    if(flush_non_mmio_per_chip[chip_id]) {
+        log_assert(arch_name != tt::ARCH::BLACKHOLE, "Non-MMIO flush not supported in Blackhole");
+        std::string read_tlb = "LARGE_READ_TLB";
+        auto chips_with_mmio = this->get_target_mmio_device_ids();
 
-    if (chips_with_mmio.find(chip_id) == chips_with_mmio.end()) {
-        log_debug(LogSiliconDriver, "Chip {} is not an MMIO chip, skipping wait_for_connected_non_mmio_flush", chip_id);
-        return;
-    }
-
-    if (arch_name == tt::ARCH::WORMHOLE || arch_name == tt::ARCH::WORMHOLE_B0) {
-        std::vector<std::uint32_t> erisc_txn_counters = std::vector<uint32_t>(2);
-        std::vector<std::uint32_t> erisc_q_ptrs = std::vector<uint32_t>(eth_interface_params.remote_update_ptr_size_bytes*2 / sizeof(uint32_t));
-
-        //wait for all queues to be empty.
-        for (tt_cxy_pair &cxy : remote_transfer_ethernet_cores.at(chip_id)) {
-            do {
-                read_device_memory(erisc_q_ptrs.data(), cxy, eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes, eth_interface_params.remote_update_ptr_size_bytes*2, read_tlb);
-            } while (erisc_q_ptrs[0] != erisc_q_ptrs[4]);
+        if (chips_with_mmio.find(chip_id) == chips_with_mmio.end()) {
+            log_debug(LogSiliconDriver, "Chip {} is not an MMIO chip, skipping wait_for_connected_non_mmio_flush", chip_id);
+            return;
         }
-        //wait for all write responses to come back.
-        for (tt_cxy_pair &cxy : remote_transfer_ethernet_cores.at(chip_id)) {
-            do {
-                read_device_memory(erisc_txn_counters.data(), cxy, eth_interface_params.request_cmd_queue_base, 8, read_tlb);
-            } while (erisc_txn_counters[0] != erisc_txn_counters[1]);
+
+        if (arch_name == tt::ARCH::WORMHOLE || arch_name == tt::ARCH::WORMHOLE_B0) {
+            std::vector<std::uint32_t> erisc_txn_counters = std::vector<uint32_t>(2);
+            std::vector<std::uint32_t> erisc_q_ptrs = std::vector<uint32_t>(eth_interface_params.remote_update_ptr_size_bytes*2 / sizeof(uint32_t));
+
+            //wait for all queues to be empty.
+            for (tt_cxy_pair &cxy : remote_transfer_ethernet_cores.at(chip_id)) {
+                do {
+                    read_device_memory(erisc_q_ptrs.data(), cxy, eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes, eth_interface_params.remote_update_ptr_size_bytes*2, read_tlb);
+                } while (erisc_q_ptrs[0] != erisc_q_ptrs[4]);
+            }
+            //wait for all write responses to come back.
+            for (tt_cxy_pair &cxy : remote_transfer_ethernet_cores.at(chip_id)) {
+                do {
+                    read_device_memory(erisc_txn_counters.data(), cxy, eth_interface_params.request_cmd_queue_base, 8, read_tlb);
+                } while (erisc_txn_counters[0] != erisc_txn_counters[1]);
+            }
         }
+        flush_non_mmio_per_chip[chip_id] = false;
     }
 }
 
 
 void tt_SiliconDevice::wait_for_non_mmio_flush(const chip_id_t chip_id) {
-    if(flush_non_mmio_per_chip[chip_id]) {
-        log_assert(arch_name != tt::ARCH::BLACKHOLE, "Non-MMIO flush not supported in Blackhole");
-        std::string read_tlb = "LARGE_READ_TLB";
+    log_assert(arch_name != tt::ARCH::BLACKHOLE, "Non-MMIO flush not supported in Blackhole");
+    std::string read_tlb = "LARGE_READ_TLB";
 
-        auto remote_chips = this->get_target_remote_device_ids();
-        if (remote_chips.find(chip_id) == remote_chips.end()) {
-            log_debug(LogSiliconDriver, "Chip {} is not a remote chip, skipping wait_for_non_mmio_flush", chip_id);
-            return;
-        }
-
-        chip_id_t mmio_connected_chip = ndesc->get_closest_mmio_capable_chip(chip_id);
-        wait_for_connected_non_mmio_flush(mmio_connected_chip);
-
-        flush_non_mmio_per_chip[chip_id] = false;
+    if (!this->ndesc->is_chip_remote(chip_id)) {
+        log_debug(LogSiliconDriver, "Chip {} is not a remote chip, skipping wait_for_non_mmio_flush", chip_id);
+        return;
     }
+
+    chip_id_t mmio_connected_chip = ndesc->get_closest_mmio_capable_chip(chip_id);
+    wait_for_connected_non_mmio_flush(mmio_connected_chip);
 }
 
 void tt_SiliconDevice::wait_for_non_mmio_flush() {
-    for (auto& chip_id : get_target_remote_device_ids()) {
-        wait_for_non_mmio_flush(chip_id);
+    for (auto& chip_id : get_target_mmio_device_ids()) {
+        wait_for_connected_non_mmio_flush(chip_id);
     }
 }
 

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -2093,7 +2093,7 @@ void tt_SiliconDevice::read_from_non_mmio_device(void* mem_ptr, tt_cxy_pair core
 
 }
 
-void tt_SiliconDevice::wait_for_connected_non_mmio_flush(chip_id_t chip_id) {
+void tt_SiliconDevice::wait_for_connected_non_mmio_flush(const chip_id_t chip_id) {
     log_assert(arch_name != tt::ARCH::BLACKHOLE, "Non-MMIO flush not supported in Blackhole");
     std::string read_tlb = "LARGE_READ_TLB";
     auto chips_with_mmio = this->get_target_mmio_device_ids();
@@ -2123,7 +2123,7 @@ void tt_SiliconDevice::wait_for_connected_non_mmio_flush(chip_id_t chip_id) {
 }
 
 
-void tt_SiliconDevice::wait_for_non_mmio_flush(chip_id_t chip_id) {
+void tt_SiliconDevice::wait_for_non_mmio_flush(const chip_id_t chip_id) {
     if(flush_non_mmio_per_chip[chip_id]) {
         log_assert(arch_name != tt::ARCH::BLACKHOLE, "Non-MMIO flush not supported in Blackhole");
         std::string read_tlb = "LARGE_READ_TLB";

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -199,3 +199,64 @@ TEST(ApiTest, SimpleIOAllChips) {
         ASSERT_EQ(data, readback_data);
     }
 }
+
+TEST(ApiTest, RemoteFlush) {
+
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = get_cluster_desc();
+    std::unique_ptr<Cluster> umd_cluster = get_cluster();
+
+    if (umd_cluster == nullptr || umd_cluster->get_all_chips_in_cluster().empty()) {
+        std::cout << "No chips found. Skipping test." << std::endl;
+        return;
+    }
+
+    size_t data_size = 1024;
+    std::vector<uint8_t> data(data_size, 0);
+
+    // TODO: this should be part of constructor if it is mandatory.
+    setup_wormhole_remote(umd_cluster.get());
+
+    for (auto chip_id : umd_cluster->get_target_remote_device_ids()) {
+        tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(chip_id);
+
+        // TODO: figure out if core locations should contain chip_id
+        tt_xy_pair any_core = soc_desc.workers[0];
+        tt_cxy_pair any_core_global (chip_id, any_core);
+
+        if (!cluster_desc->is_chip_remote(chip_id)) {
+            std::cout << "Chip " << chip_id << " skipped because it is not a remote chip." << std::endl;
+            continue;
+        }
+
+        if (soc_desc.arch != tt::ARCH::WORMHOLE_B0) {
+            std::cout << "Skipping remote chip " << chip_id << " because it is not a wormhole_b0 chip." << std::endl;
+            continue;
+        }
+
+        std::cout << "Writing to chip " << chip_id << " core " << any_core.str() << std::endl;
+        umd_cluster->write_to_device(data.data(), data_size, any_core_global, 0, "LARGE_WRITE_TLB");
+
+        std::cout << "Waiting for remote chip flush " << chip_id << std::endl;
+        umd_cluster->wait_for_non_mmio_flush(chip_id);
+
+        std::cout << "Waiting again for flush " << chip_id << ", should be no-op" << std::endl;
+        umd_cluster->wait_for_non_mmio_flush(chip_id);
+    }
+
+    chip_id_t any_remote_chip = *umd_cluster->get_target_remote_device_ids().begin();
+    tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(any_remote_chip);
+    tt_xy_pair any_core = soc_desc.workers[0];
+    tt_cxy_pair any_core_global (any_remote_chip, any_core);
+    if (soc_desc.arch != tt::ARCH::WORMHOLE_B0) {
+        std::cout << "Skipping whole cluster wait because it is not a wormhole_b0 chip." << std::endl;
+        return;
+    }
+    std::cout << "Writing to chip " << any_remote_chip << " core " << any_core.str() << std::endl;
+    umd_cluster->write_to_device(data.data(), data_size, any_core_global, 0, "LARGE_WRITE_TLB");    
+
+    std::cout << "Testing whole cluster wait for remote chip flush." << std::endl;
+    umd_cluster->wait_for_non_mmio_flush();
+
+    std::cout << "Testing whole cluster wait for remote chip flush again, should be no-op." << std::endl;
+    umd_cluster->wait_for_non_mmio_flush();
+}

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -202,7 +202,7 @@ TEST(ApiTest, SimpleIOAllChips) {
 
 TEST(ApiTest, RemoteFlush) {
 
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = get_cluster_desc();
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = get_cluster_descriptor();
     std::unique_ptr<Cluster> umd_cluster = get_cluster();
 
     if (umd_cluster == nullptr || umd_cluster->get_all_chips_in_cluster().empty()) {
@@ -217,7 +217,7 @@ TEST(ApiTest, RemoteFlush) {
     setup_wormhole_remote(umd_cluster.get());
 
     for (auto chip_id : umd_cluster->get_target_remote_device_ids()) {
-        tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(chip_id);
+        const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(chip_id);
 
         // TODO: figure out if core locations should contain chip_id
         tt_xy_pair any_core = soc_desc.workers[0];
@@ -244,7 +244,7 @@ TEST(ApiTest, RemoteFlush) {
     }
 
     chip_id_t any_remote_chip = *umd_cluster->get_target_remote_device_ids().begin();
-    tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(any_remote_chip);
+    const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(any_remote_chip);
     tt_xy_pair any_core = soc_desc.workers[0];
     tt_cxy_pair any_core_global (any_remote_chip, any_core);
     if (soc_desc.arch != tt::ARCH::WORMHOLE_B0) {

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -29,7 +29,7 @@ using Cluster = tt_SiliconDevice;
 // Galaxy
 
 // TODO: This function should not exist, the API itself should be simple enough.
-std::unique_ptr<tt_ClusterDescriptor> get_cluster_descriptor() {
+inline std::unique_ptr<tt_ClusterDescriptor> get_cluster_desc() {
 
     // TODO: This should not be needed. And could be part of the cluster descriptor probably.
     // Note that cluster descriptor holds logical ids of chips.
@@ -66,7 +66,7 @@ std::unique_ptr<tt_ClusterDescriptor> get_cluster_descriptor() {
 }
 
 // TODO: This function should not exist, the API itself should be simple enough.
-std::unique_ptr<Cluster> get_cluster() {
+inline std::unique_ptr<Cluster> get_cluster() {
 
     // TODO: This should not be needed. And could be part of the cluster descriptor probably.
     // Note that cluster descriptor holds logical ids of chips.
@@ -93,7 +93,7 @@ std::unique_ptr<Cluster> get_cluster() {
     // TODO: remove getting manually cluster descriptor from yaml.
     std::string yaml_path = test_utils::GetClusterDescYAML();
     // TODO: Remove the need to do this, allow default constructor to construct with all chips.
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = get_cluster_descriptor();
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = get_cluster_desc();
     std::unordered_set<int> detected_num_chips = cluster_desc->get_all_chips();
 
     // TODO: make this unordered vs set conversion not needed.
@@ -138,12 +138,12 @@ void setup_wormhole_remote(Cluster* umd_cluster) {
 }
 
 // This test should be one line only.
-TEST(ApiTest, OpenAllChips) {
+TEST(ApiClusterTest, OpenAllChips) {
     std::unique_ptr<Cluster> umd_cluster = get_cluster();
 }
 
-TEST(ApiTest, SimpleIOAllChips) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = get_cluster_descriptor();
+TEST(ApiClusterTest, SimpleIOAllChips) {
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = get_cluster_desc();
     std::unique_ptr<Cluster> umd_cluster = get_cluster();
 
     if (umd_cluster == nullptr || umd_cluster->get_all_chips_in_cluster().empty()) {
@@ -200,9 +200,9 @@ TEST(ApiTest, SimpleIOAllChips) {
     }
 }
 
-TEST(ApiTest, RemoteFlush) {
+TEST(ApiClusterTest, RemoteFlush) {
 
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = get_cluster_descriptor();
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = get_cluster_desc();
     std::unique_ptr<Cluster> umd_cluster = get_cluster();
 
     if (umd_cluster == nullptr || umd_cluster->get_all_chips_in_cluster().empty()) {

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -11,7 +11,7 @@
 #include "device/tt_cluster_descriptor.h"
 
 
-std::unique_ptr<tt_ClusterDescriptor> get_cluster_desc() {
+inline std::unique_ptr<tt_ClusterDescriptor> get_cluster_desc() {
 
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
     std::set<int> pci_device_ids_set (pci_device_ids.begin(), pci_device_ids.end());


### PR DESCRIPTION
wait_for_non_mmio_flush should be per chip_id. It is used like this in tt_metal, but API doesn't offer it per chip.
This is related to #157 and preparing UMD for changes in tt_metal.

Also related to #154 since I've added a test which shows how this flush is used.

- Does not break existing workflows
- tt_metal corresponding PR: https://github.com/tenstorrent/tt-metal/pull/13949
- tt_debuda change: Not used