### PR TITLE
ClusterDescriptor chips grouped by closest mmio

### DIFF
--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -313,7 +313,7 @@ std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_from_yaml(con
     tt_ClusterDescriptor::load_harvesting_information(yaml, *desc);
     desc->enable_all_devices();
 
-    fill_chips_grouped_by_closest_mmio();
+    desc->fill_chips_grouped_by_closest_mmio();
 
     return desc;
 }
@@ -655,6 +655,6 @@ BoardType tt_ClusterDescriptor::get_board_type(chip_id_t chip_id) const {
   return board_type;
 }
 
-std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> tt_ClusterDescriptor::get_chips_grouped_by_closest_mmio() {
+std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> tt_ClusterDescriptor::get_chips_grouped_by_closest_mmio() const {
     return chips_grouped_by_closest_mmio;
 }

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -313,6 +313,8 @@ std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_from_yaml(con
     tt_ClusterDescriptor::load_harvesting_information(yaml, *desc);
     desc->enable_all_devices();
 
+    fill_chips_grouped_by_closest_mmio();
+
     return desc;
 }
 
@@ -573,6 +575,14 @@ void tt_ClusterDescriptor::enable_all_devices() {
     this->enabled_active_chips = this->all_chips;
 }
 
+void tt_ClusterDescriptor::fill_chips_grouped_by_closest_mmio() {
+    for (const auto &chip : this->all_chips) {
+        // This will also fill up the closest_mmio_chip_cache
+        chip_id_t closest_mmio_chip = get_closest_mmio_capable_chip(chip);
+        this->chips_grouped_by_closest_mmio[closest_mmio_chip].insert(chip);
+    }
+}
+
 std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t> > > tt_ClusterDescriptor::get_ethernet_connections() const {
     auto eth_connections = std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t> > >();
 
@@ -643,4 +653,8 @@ int tt_ClusterDescriptor::get_ethernet_link_distance(chip_id_t chip_a, chip_id_t
 BoardType tt_ClusterDescriptor::get_board_type(chip_id_t chip_id) const {
   BoardType board_type = this->chip_board_type.at(chip_id);
   return board_type;
+}
+
+std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> tt_ClusterDescriptor::get_chips_grouped_by_closest_mmio() {
+    return chips_grouped_by_closest_mmio;
 }

--- a/device/tt_cluster_descriptor.h
+++ b/device/tt_cluster_descriptor.h
@@ -47,6 +47,7 @@ class tt_ClusterDescriptor {
   std::unordered_set<chip_id_t> enabled_active_chips;
   std::unordered_map<chip_id_t, chip_id_t> closest_mmio_chip_cache = {};
   std::unordered_map<chip_id_t, BoardType> chip_board_type = {};
+  std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> chips_grouped_by_closest_mmio;
 
   // one-to-many chip connections
   struct Chip2ChipConnection {
@@ -65,6 +66,8 @@ class tt_ClusterDescriptor {
   static void load_ethernet_connections_from_connectivity_descriptor(YAML::Node &yaml, tt_ClusterDescriptor &desc);
   static void load_chips_from_connectivity_descriptor(YAML::Node &yaml, tt_ClusterDescriptor &desc);
   static void load_harvesting_information(YAML::Node &yaml, tt_ClusterDescriptor &desc);
+
+  void fill_chips_grouped_by_closest_mmio();
 
  public:
   tt_ClusterDescriptor() = default;
@@ -92,6 +95,7 @@ class tt_ClusterDescriptor {
   std::unordered_map<chip_id_t, chip_id_t> get_chips_with_mmio() const;
   std::unordered_set<chip_id_t> get_all_chips() const;
   std::size_t get_number_of_chips() const;
+  std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> get_chips_grouped_by_closest_mmio() const;
 
   int get_ethernet_link_distance(chip_id_t chip_a, chip_id_t chip_b) const;
 

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -65,6 +65,8 @@ TEST(ApiClusterDescriptorTest, BasicFunctionality) {
             remote_chips.insert(chip);
         }
     }
+
+    std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> chips_grouped_by_closest_mmio = cluster_desc->get_chips_grouped_by_closest_mmio();
 }
 
 // A standard disjoint set data structure to track connected components.


### PR DESCRIPTION
This map might be needed by the client, as it is currently needed by tt_metal at https://github.com/tenstorrent/tt-metal/blob/main/tt_metal/llrt/tt_cluster.hpp#L280.
This implements it directly in tt_clusterdescriptor. And fills it up in the same way as tt_metal.
Added to API tests as well.