### PR TITLE
Fix a WH unit test

### DIFF
--- a/tests/wormhole/test_silicon_driver_wh.cpp
+++ b/tests/wormhole/test_silicon_driver_wh.cpp
@@ -698,6 +698,9 @@ TEST(SiliconDriverWH, SysmemTestWithPcie) {
                             true,  // clean system resources - yes
                             true); // perform harvesting - yes
 
+    set_params_for_remote_txn(device);
+    device.start_device(tt_device_params{});  // no special parameters
+
     // PCIe core is at (x=0, y=3) on Wormhole NOC0.
     const size_t PCIE_X = 0;    // NOC0
     const size_t PCIE_Y = 3;    // NOC0


### PR DESCRIPTION
tt_SiliconDevice instances can exist in an invalid state.  This test was relying on hardware state configured by previous tests.  It would fail if executed on its own.