### PR TITLE
Allow GCC 9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Required Ubuntu dependencies:
 sudo apt install -y libhwloc-dev cmake ninja-build
 ```
 
+Suggested third-party dependency is Clang 17:
+```
+wget https://apt.llvm.org/llvm.sh
+chmod u+x llvm.sh
+sudo ./llvm.sh 17
+```
+
 ## Build flow
 
 To build `libdevice.so`: 
@@ -25,6 +32,12 @@ To build tests:
 ```
 cmake -B build -G Ninja -DTT_UMD_BUILD_TESTS=ON
 ninja umd_tests -C build
+```
+
+To build with GCC, set these environment variables before invoking `cmake`:
+```
+export CMAKE_C_COMPILER=/usr/bin/gcc
+export CMAKE_CXX_COMPILER=/usr/bin/g++
 ```
 
 ## As a submodule/external project

--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -20,7 +20,7 @@ function(CHECK_COMPILERS)
         endif()
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "12.0.0")
-            message(FATAL_ERROR "GCC-12 or higher is required")
+            message(WARNING "GCC-12 or higher is suggested")
         elseif(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL "13.0.0")
             message(WARNING "Only GCC-12 is tested right now")
         endif()
@@ -37,7 +37,7 @@ function(ADJUST_COMPILER_WARNINGS)
             -Wno-delete-non-abstract-non-virtual-dtor -Wno-c99-designator -Wno-shift-op-parentheses -Wno-non-c-typedef-for-linkage
             -Wno-deprecated-this-capture -Wno-deprecated-volatile -Wno-deprecated-builtins -Wno-deprecated-declarations
         )
-    else() # GCC-12 or higher
+    else() # GCC
         target_compile_options(compiler_warnings INTERFACE
             -Wno-deprecated -Wno-attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-maybe-uninitialized -Wno-missing-requires
             -Wno-narrowing -Wno-non-template-friend -Wno-error=non-template-friend


### PR DESCRIPTION
This change allows UMD to be built and debugged with the distribution-provided tools under Ubuntu 20.04.  This requires CMAKE_C_COMPILER and CMAKE_CXX_COMPILER environment variables to be set to gcc and g++, respectively.  Without them, the build will still default to using a third-party compiler which the user must have installed.