### PR TITLE
Fix Metal build: put detect_arch() back

### DIFF
--- a/device/pcie/pci_device.hpp
+++ b/device/pcie/pci_device.hpp
@@ -8,8 +8,9 @@
 
 #include <cstdint>
 #include <cstdio>
-#include <vector>
+#include <map>
 #include <unordered_map>
+#include <vector>
 
 #include "device/tt_xy_pair.h"
 #include "device/tt_arch_types.h"
@@ -41,13 +42,17 @@ struct PciDeviceInfo
     uint16_t pci_bus;
     uint16_t pci_device;
     uint16_t pci_function;
+
+    tt::ARCH get_arch() const;
+    // TODO: does it make sense to move attributes that we can read from sysfs
+    // onto this struct as methods?  e.g. current_link_width etc.
 };
 
 class PCIDevice {
     const std::string device_path;  // Path to character device: /dev/tenstorrent/N
-    const int pci_device_num;           // N in /dev/tenstorrent/N
+    const int pci_device_num;       // N in /dev/tenstorrent/N
     const int logical_id;           // Unique identifier for each device in entire network topology
-    const int pci_device_file_desc;                   // Character device file descriptor
+    const int pci_device_file_desc; // Character device file descriptor
     const PciDeviceInfo info;       // PCI device info
     const int numa_node;            // -1 if non-NUMA
     const int revision;             // PCI revision value from sysfs
@@ -59,6 +64,11 @@ public:
      * @return a list of integers corresponding to character devices in /dev/tenstorrent/
      */
     static std::vector<int> enumerate_devices();
+
+    /**
+     * @return a map of PCI device numbers (/dev/tenstorrent/N) to PciDeviceInfo
+     */
+    static std::map<int, PciDeviceInfo> enumerate_devices_info();
 
     /**
      * PCI device constructor.

--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -25,6 +25,9 @@
 
 using TLB_DATA = tt::umd::tlb_data;
 
+// TODO: Remove this - it's here for Metal backwards compatibility.
+// Implementation is in tt_silicon_driver.cpp.
+tt::ARCH detect_arch(int pci_device_num);
 
 namespace boost::interprocess{
     class named_mutex;

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -66,6 +66,27 @@ std::string hugepage_dir = hugepage_dir_env ? hugepage_dir_env : "/dev/hugepages
 // TLB size for DRAM on blackhole - 4GB
 const uint64_t BH_4GB_TLB_SIZE = 4ULL * 1024 * 1024 * 1024;
 
+// Metal uses this function to determine the architecture of the first PCIe chip
+// and then verifies that all subsequent chips are of the same architecture.  It
+// looks like Metal is doing this because we don't provide any other way... When
+// we are further along in our refactoring efforts and `tt_device` is more of a
+// Cluster abstraction, we should provide Metal with interfaces for:
+//      1. Checking that all chips are of the same architecture (we may not care
+//         about this, but the application might).
+//      2. Getting the architecture of a specific chip.
+// Until then... I'm putting this function back so that Metal will still build
+// next time someone bumps its UMD submodule version.
+tt::ARCH detect_arch(int pci_device_num) {
+    const auto devices_info = PCIDevice::enumerate_devices_info();
+    const auto it = devices_info.find(pci_device_num);
+    if (it == devices_info.end()) {
+        return tt::ARCH::Invalid;
+    }
+
+    const auto info = it->second;
+    return info.get_arch();
+}
+
 template <typename T>
 void size_buffer_to_capacity(std::vector<T> &data_buf, std::size_t size_in_bytes) {
     std::size_t target_size = 0;


### PR DESCRIPTION
This family of functions was removed during a refactor.  Metal is relying on one of them.  This change reintroduces it.

Fixes https://github.com/tenstorrent/tt-umd/issues/171