### PR TITLE
Minor fix of UMD tests

### DIFF
--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -29,7 +29,7 @@ using Cluster = tt_SiliconDevice;
 // Galaxy
 
 // TODO: This function should not exist, the API itself should be simple enough.
-std::unique_ptr<tt_ClusterDescriptor> get_cluster_desc() {
+std::unique_ptr<tt_ClusterDescriptor> get_cluster_descriptor() {
 
     // TODO: This should not be needed. And could be part of the cluster descriptor probably.
     // Note that cluster descriptor holds logical ids of chips.
@@ -93,7 +93,7 @@ std::unique_ptr<Cluster> get_cluster() {
     // TODO: remove getting manually cluster descriptor from yaml.
     std::string yaml_path = test_utils::GetClusterDescYAML();
     // TODO: Remove the need to do this, allow default constructor to construct with all chips.
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = get_cluster_desc();
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = get_cluster_descriptor();
     std::unordered_set<int> detected_num_chips = cluster_desc->get_all_chips();
 
     // TODO: make this unordered vs set conversion not needed.
@@ -143,7 +143,7 @@ TEST(ApiTest, OpenAllChips) {
 }
 
 TEST(ApiTest, SimpleIOAllChips) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = get_cluster_desc();
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = get_cluster_descriptor();
     std::unique_ptr<Cluster> umd_cluster = get_cluster();
 
     if (umd_cluster == nullptr || umd_cluster->get_all_chips_in_cluster().empty()) {


### PR DESCRIPTION
This was introduced only by two PRs in combination, and only for building tests, thats why I didn't see it before merging.
I intentionally don't want to put get_cluster_desc() function in a common header file, since this function should be going away altogether soon.
#159 and #165 