### PR TITLE
Fix Metal build: put detect_arch() back v2

### DIFF
--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -28,6 +28,7 @@ using TLB_DATA = tt::umd::tlb_data;
 // TODO: Remove this - it's here for Metal backwards compatibility.
 // Implementation is in tt_silicon_driver.cpp.
 tt::ARCH detect_arch(int pci_device_num);
+tt::ARCH detect_arch();
 
 namespace boost::interprocess{
     class named_mutex;

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -66,6 +66,7 @@ std::string hugepage_dir = hugepage_dir_env ? hugepage_dir_env : "/dev/hugepages
 // TLB size for DRAM on blackhole - 4GB
 const uint64_t BH_4GB_TLB_SIZE = 4ULL * 1024 * 1024 * 1024;
 
+// TODO: Remove in favor of cluster descriptor method, when it becomes available.
 // Metal uses this function to determine the architecture of the first PCIe chip
 // and then verifies that all subsequent chips are of the same architecture.  It
 // looks like Metal is doing this because we don't provide any other way... When
@@ -87,6 +88,7 @@ tt::ARCH detect_arch(int pci_device_num) {
     return info.get_arch();
 }
 
+// TODO: Remove in favor of cluster descriptor method, when it becomes available.
 // There is also a function which just wants to get any architecture, since it
 // presumably already checked that all archs are the same.
 tt::ARCH detect_arch() {

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -87,6 +87,16 @@ tt::ARCH detect_arch(int pci_device_num) {
     return info.get_arch();
 }
 
+// There is also a function which just wants to get any architecture, since it
+// presumably already checked that all archs are the same.
+tt::ARCH detect_arch() {
+    const auto devices_info = PCIDevice::enumerate_devices_info();
+    if (devices_info.empty()) {
+        return tt::ARCH::Invalid;
+    }
+    return devices_info.begin()->second.get_arch();
+}
+
 template <typename T>
 void size_buffer_to_capacity(std::vector<T> &data_buf, std::size_t size_in_bytes) {
     std::size_t target_size = 0;

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -10,7 +10,7 @@
 #include "device/pcie/pci_device.hpp"
 #include "device/tt_cluster_descriptor.h"
 
-// Needed for detect_arch, remove when it is part of cluster descriptor.
+// TODO: Needed for detect_arch, remove when it is part of cluster descriptor.
 #include "device/tt_device.h"
 
 

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -59,6 +59,9 @@ TEST(ApiTest, DetectArch) {
         // TODO: This should be the only available API, previous call should be routed to this one to get any arch.
         tt::ARCH arch2 = detect_arch(PCIDevice::enumerate_devices()[0]);
         EXPECT_NE(arch2, tt::ARCH::Invalid);
+
+        // In our current setup, we expect all arch to be the same.
+        EXPECT_EQ(arch, arch2);
     }
 }
 

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -10,6 +10,9 @@
 #include "device/pcie/pci_device.hpp"
 #include "device/tt_cluster_descriptor.h"
 
+// Needed for detect_arch, remove when it is part of cluster descriptor.
+#include "device/tt_device.h"
+
 
 std::unique_ptr<tt_ClusterDescriptor> get_cluster_desc() {
 
@@ -41,6 +44,22 @@ std::unique_ptr<tt_ClusterDescriptor> get_cluster_desc() {
     }
 
     return cluster_desc;
+}
+
+TEST(ApiTest, DetectArch) {
+    // TODO: This should be part of cluster descriptor. It is currently used like this from tt_metal.
+    tt::ARCH arch = detect_arch();
+
+    // Expect it to be invalid if no devices are found.
+    if (PCIDevice::enumerate_devices().empty()) {
+        EXPECT_EQ(arch, tt::ARCH::Invalid);
+    } else {
+        EXPECT_NE(arch, tt::ARCH::Invalid);
+
+        // TODO: This should be the only available API, previous call should be routed to this one to get any arch.
+        tt::ARCH arch2 = detect_arch(PCIDevice::enumerate_devices()[0]);
+        EXPECT_NE(arch2, tt::ARCH::Invalid);
+    }
 }
 
 TEST(ApiClusterDescriptorTest, BasicFunctionality) {


### PR DESCRIPTION
I've rushed into merging Joel's change #175
Seems like there were two detect_arch() calls which were needed. 
This time I've manually verified that tt_metal builds with UMD on this branch.

I've also added an API test to document this usage, which should be changed, probably to tt::umd::ClusterDescriptor::get_arch(chip_id) or something similar

Fixes #171 