### PR TITLE
get_pcie_base_addr_from_device per chip

### DIFF
--- a/device/mockup/tt_mockup_device.hpp
+++ b/device/mockup/tt_mockup_device.hpp
@@ -87,7 +87,7 @@ class tt_MockupDevice : public tt_device {
     void* host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const override {
         return nullptr;
     }
-    std::uint64_t get_pcie_base_addr_from_device() const override { return 0; }
+    std::uint64_t get_pcie_base_addr_from_device(const chip_id_t chip_id) const override { return 0; }
     std::uint32_t get_num_dram_channels(std::uint32_t device_id) override {
         return get_soc_descriptor(device_id)->get_num_dram_channels();
     };

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -181,7 +181,7 @@ void *tt_SimulationDevice::host_dma_address(std::uint64_t offset, chip_id_t src_
     return nullptr;
 }
 
-std::uint64_t tt_SimulationDevice::get_pcie_base_addr_from_device() const {
+std::uint64_t tt_SimulationDevice::get_pcie_base_addr_from_device(const chip_id_t chip_id) const {
     if(arch_name == tt::ARCH::WORMHOLE or arch_name == tt::ARCH::WORMHOLE_B0) {
         return 0x800000000;
     }

--- a/device/simulation/tt_simulation_device.h
+++ b/device/simulation/tt_simulation_device.h
@@ -56,7 +56,7 @@ class tt_SimulationDevice: public tt_device {
     virtual std::set<chip_id_t> get_target_remote_device_ids();
     virtual std::map<int,int> get_clocks();
     virtual void *host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const;
-    virtual std::uint64_t get_pcie_base_addr_from_device() const;
+    virtual std::uint64_t get_pcie_base_addr_from_device(const chip_id_t chip_id) const;
     virtual std::uint32_t get_num_dram_channels(std::uint32_t device_id);
     virtual std::uint64_t get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel);
     virtual std::uint32_t get_num_host_channels(std::uint32_t device_id);

--- a/device/tt_device.cpp
+++ b/device/tt_device.cpp
@@ -27,6 +27,6 @@ tt_device::tt_device(const std::string& sdesc_path) : soc_descriptor_per_chip({}
 tt_device::~tt_device() {
 }
 
-const tt_SocDescriptor& tt_device::get_soc_descriptor(chip_id_t chip_id){
+const tt_SocDescriptor& tt_device::get_soc_descriptor(chip_id_t chip_id) const {
     return soc_descriptor_per_chip.at(chip_id);
 }

--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -584,11 +584,11 @@ class tt_device
         return nullptr;
     }
 
-    virtual std::uint64_t get_pcie_base_addr_from_device() const {
+    virtual std::uint64_t get_pcie_base_addr_from_device(const chip_id_t chip_id) const {
         throw std::runtime_error("---- tt_device::get_pcie_base_addr_from_device is not implemented\n");
         return 0;
     }
-    const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id);
+    const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const;
 
     bool performed_harvesting = false;
     std::unordered_map<chip_id_t, uint32_t> harvested_rows_per_target = {};
@@ -693,7 +693,7 @@ class tt_SiliconDevice: public tt_device
     virtual std::set<chip_id_t> get_target_remote_device_ids();
     virtual std::map<int,int> get_clocks();
     virtual void *host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const;
-    virtual std::uint64_t get_pcie_base_addr_from_device() const;
+    virtual std::uint64_t get_pcie_base_addr_from_device(const chip_id_t chip_id) const;
     static std::vector<int> extract_rows_to_remove(const tt::ARCH &arch, const int worker_grid_rows, const int harvested_rows);
     static void remove_worker_row_from_descriptor(tt_SocDescriptor& full_soc_descriptor, const std::vector<int>& row_coordinates_to_remove);
     static void harvest_rows_in_soc_descriptor(tt::ARCH arch, tt_SocDescriptor& sdesc, uint32_t harvested_rows);

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -2939,11 +2939,13 @@ std::uint32_t tt_SiliconDevice::get_numa_node_for_pcie_device(std::uint32_t devi
     return get_pci_device(device_id)->get_numa_node();
 }
 
-std::uint64_t tt_SiliconDevice::get_pcie_base_addr_from_device() const {
-    if(arch_name == tt::ARCH::WORMHOLE or arch_name == tt::ARCH::WORMHOLE_B0) {
+std::uint64_t tt_SiliconDevice::get_pcie_base_addr_from_device(const chip_id_t chip_id) const {
+    // TODO: Should probably be lowered to TTDevice.
+    tt::ARCH arch = get_soc_descriptor(chip_id).arch;
+    if(arch == tt::ARCH::WORMHOLE or arch == tt::ARCH::WORMHOLE_B0) {
         return 0x800000000;
     }
-    else if (arch_name == tt::ARCH::BLACKHOLE) {
+    else if (arch == tt::ARCH::BLACKHOLE) {
         // Enable 4th ATU window.
         return 1ULL << 60;
     }

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -161,3 +161,12 @@ TEST(ApiChipTest, ManualTLBConfiguration) {
         EXPECT_THROW(umd_cluster->get_static_tlb_writer(tt_cxy_pair(any_mmio_chip, eth_core)), std::runtime_error);
     }
 }
+
+// TODO: Move to test_chip
+TEST(ApiChipTest, SimpleAPIShowcase) {
+    std::unique_ptr<Cluster> umd_cluster = get_cluster();
+    chip_id_t chip_id = *umd_cluster->get_all_chips_in_cluster().begin();
+
+    // TODO: In future, will be accessed through tt::umd::Chip api.
+    umd_cluster->get_pcie_base_addr_from_device(chip_id);
+}

--- a/tests/wormhole/test_silicon_driver_wh.cpp
+++ b/tests/wormhole/test_silicon_driver_wh.cpp
@@ -680,9 +680,10 @@ TEST(SiliconDriverWH, SysmemTestWithPcie) {
     device.start_device(tt_device_params{});  // no special parameters
 
     // PCIe core is at (x=0, y=3) on Wormhole NOC0.
+    const chip_id_t mmio_chip_id = 0;
     const size_t PCIE_X = 0;    // NOC0
     const size_t PCIE_Y = 3;    // NOC0
-    const tt_cxy_pair PCIE_CORE(0, PCIE_X, PCIE_Y);
+    const tt_cxy_pair PCIE_CORE(mmio_chip_id, PCIE_X, PCIE_Y);
     const size_t test_size_bytes = 0x4000;  // Arbitrarilly chosen, but small size so the test runs quickly.
 
     // Bad API: how big is the buffer?  How do we know it's big enough?
@@ -694,7 +695,7 @@ TEST(SiliconDriverWH, SysmemTestWithPcie) {
     // This is the address inside the Wormhole PCIe block that is mapped to the
     // system bus.  In Wormhole, this is a fixed address, 0x8'0000'0000.
     // The driver should have mapped this address to the bottom of sysmem.
-    uint64_t base_address = device.get_pcie_base_addr_from_device();
+    uint64_t base_address = device.get_pcie_base_addr_from_device(mmio_chip_id);
 
     // Buffer that we will use to read sysmem into, then write sysmem from.
     std::vector<uint8_t> buffer(test_size_bytes, 0x0);


### PR DESCRIPTION
This attribute is tied to a chip. Although it could be argued that currently we only support a cluster of chips of same architecture, therefore this would be the same for all chips in a single cluster.
Still, this makes sense and further unblocks supporting multiple architectures in a single cluster/driver. It will also allow it to be lowered to TTDevice class which will is arch specific (currently architecture_implementation).

Related to #157 , contributes to #154 .

- Breaks existing usages of get_pcie_base_addr_from_device
- tt_metal corresponding PR: https://github.com/tenstorrent/tt-metal/pull/13949
- tt_debuda change: Not used