### PR TITLE
Clang-format in CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,147 +1,26 @@
----
-Language:        Cpp
-# BasedOnStyle:  Google
-AccessModifierOffset: -1
+BasedOnStyle: Google
+ColumnLimit: 120
+IndentWidth: 4
+
+# This will make access modifiers (public/protected/private) sit on the same indentation as `class` keyword
+AccessModifierOffset: -4
+
+# Arguments, parameters and construction initializer are broken as following:
+# - Try to fit everything into single line (controlled by ColumnLimit).
+# - If it doesn't fit, break immediately after open bracket (in case of arguments and parameters)
+#   or after colon in case of constructor initializers.
+# - Try to fit everything else into the second line.
+# - If it doesn't fit in second line, then each argument, parameter or initializer will sit in its own line.
 AlignAfterOpenBracket: AlwaysBreak
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
-AlignEscapedNewlines: Left
-AlignOperands:   true
-AlignTrailingComments: true
-AllowShortBlocksOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: true
-AllowShortFunctionsOnASingleLine: All
-AllowShortLoopsOnASingleLine: true
-AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false
 BinPackParameters: false
-BraceWrapping:
-# AfterCaseLabel:  false
-  AfterClass:      false
-  AfterControlStatement: false
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
-  AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  AfterExternBlock: false
-  BeforeCatch:     false
-  BeforeElse:      false
-  IndentBraces:    false
-  SplitEmptyFunction: true
-  SplitEmptyRecord: true
-  SplitEmptyNamespace: true
-BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Attach
-BreakBeforeInheritanceComma: false
-BreakInheritanceList: BeforeColon
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
-BreakConstructorInitializers: AfterColon
-BreakAfterJavaFieldAnnotations: false
-BreakStringLiterals: true
-ColumnLimit:     120
-CommentPragmas:  '^ IWYU pragma:'
-CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
-DerivePointerAlignment: true
-DisableFormat:   false
-ExperimentalAutoDetectBinPacking: false
-FixNamespaceComments: true
-ForEachMacros:
-  - foreach
-  - Q_FOREACH
-  - BOOST_FOREACH
-IncludeBlocks:   Regroup
-IncludeCategories:
-  - Regex:           '^<ext/.*\.h>'
-    Priority:        2
-  - Regex:           '^<.*\.h>'
-    Priority:        1
-  - Regex:           '^<.*'
-    Priority:        2
-  - Regex:           '.*'
-    Priority:        3
-IncludeIsMainRegex: '([-_](test|unittest))?$'
-IndentCaseLabels: true
-IndentPPDirectives: None
-IndentWidth:     4
-IndentWrappedFunctionNames: false
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false
-MacroBlockBegin: ''
-MacroBlockEnd:   ''
-MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
-ObjCBinPackProtocolList: Never
-ObjCBlockIndentWidth: 2
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: true
-PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 1
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyBreakTemplateDeclaration: 10
-PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 200
-PointerAlignment: Right
-RawStringFormats:
-  - Language:        Cpp
-    Delimiters:
-      - cc
-      - CC
-      - cpp
-      - Cpp
-      - CPP
-      - 'c++'
-      - 'C++'
-    CanonicalDelimiter: ''
-    BasedOnStyle:    google
-  - Language:        TextProto
-    Delimiters:
-      - pb
-      - PB
-      - proto
-      - PROTO
-    EnclosingFunctions:
-      - EqualsProto
-      - EquivToProto
-      - PARSE_PARTIAL_TEXT_PROTO
-      - PARSE_TEST_PROTO
-      - PARSE_TEXT_PROTO
-      - ParseTextOrDie
-      - ParseTextProtoOrDie
-    CanonicalDelimiter: ''
-    BasedOnStyle:    google
-ReflowComments:  true
-SortIncludes:    true
-SortUsingDeclarations: true
-SpaceAfterCStyleCast: false
-SpaceAfterTemplateKeyword: true
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeCpp11BracedList: false
-SpaceBeforeCtorInitializerColon: true
-SpaceBeforeInheritanceColon: true
-SpaceBeforeParens: ControlStatements
-SpaceBeforeRangeBasedForLoopColon: true
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 2
-SpacesInAngles:  false
-SpacesInContainerLiterals: true
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
-Standard:        Cpp11
-TabWidth:        4
-UseTab:          Never
-...
 
+# When constructor initializers exist in the constructor definition, leave the colon as last thing on the original
+# line instead of putting it on the next line.
+BreakConstructorInitializers: AfterColon
+
+# Disallow single statements after if/else/for/while/do without curly braces.
+InsertBraces: true
+
+# Separate definition blocks, including classes, structs, enums, and functions.
+SeparateDefinitionBlocks: Always

--- a/.github/clang_format_repo.sh
+++ b/.github/clang_format_repo.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# A couple of notes about the command below:
+# If we omitted \( and \), the -not filter would've been applied only on -name '*.h', since it has
+# higher precedence than -or.
+# -print0 will separate each file will null character when printing the result.
+# -z in sort tells it to expect null separator between items. Items are sorted just for prettier log.
+# -0 in xargs tells it to expect null separator between items, each passed to clang-format.
+# -t will print out commands being executed, for prettier log and easier debug.
+# -n1 limits the number of items to pass to clang-format to 1. This is also just for easier debugging,
+# since clang-format can also accept multiple files.
+#
+echo "Running clang-format version $(clang-format --version) on all files in the repository."
+find . \( -name '*.cpp' -or -name '*.h' -or -name '*.hpp' \) \
+    -not -path "./.cpmcache/*" \
+    -not -path "./build/*" -print0 | \
+    sort -z | \
+    xargs -0 -t -n1 clang-format -i -style=file

--- a/.github/workflows/lint-clang.yml
+++ b/.github/workflows/lint-clang.yml
@@ -1,0 +1,26 @@
+# Runs clang-format on all cpp and h files in the repository.
+name: Build Target
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build:
+    timeout-minutes: 10
+    # It is unnecessary to run this job on multiple OS versions.
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/${{ github.repository }}/tt-umd-ci-ubuntu-22.04:latest
+      options: --user root
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # The git diff will have non-zero exit code if clang-format changes any files.
+      - name: Run clang-format
+        run: |
+          .github/clang_format_repo.sh
+          git diff --exit-code

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -7,6 +7,10 @@ on:
     branches: [ "main" ]
 
 jobs:
+  lint-clang:
+    secrets: inherit
+    uses: ./.github/workflows/lint-clang.yml
+
   build-all:
     secrets: inherit
     uses: ./.github/workflows/build-device.yml

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -6,6 +6,10 @@ on:
     branches: [ "main" ]
 
 jobs:
+  lint-clang:
+    secrets: inherit
+    uses: ./.github/workflows/lint-clang.yml
+
   build-all:
     secrets: inherit
     uses: ./.github/workflows/build-device.yml

--- a/.vscode/default.settings.json
+++ b/.vscode/default.settings.json
@@ -1,0 +1,7 @@
+{
+    "[cpp]": {
+        "editor.formatOnSave": true,
+    },
+    "C_Cpp.clang_format_fallbackStyle": "Google",
+    "C_Cpp.clang_format_style": "file",
+}

--- a/README.md
+++ b/README.md
@@ -49,3 +49,29 @@ You can then use `libdevice.so` by linking against the `umd_device` target wheve
 ```
 target_link_libraries(tt_metal PUBLIC umd_device)
 ```
+
+# Formatting C++ code with clang-format
+
+## Installing clang-format
+
+If you're using an IRD docker, clang-format 19 should be already available.
+If you don't have clang-format in your working environment, follow the instructions
+on [llvm website](https://apt.llvm.org/) for installing it.
+
+## Formatting files
+
+If working with VSCode, you can copy the provided default settings:
+```bash
+cp .vscode/default.settings.json .vscode/settings.json
+```
+
+From now on, c++ files will be formatted on save (given that clang-format is available).
+
+If you want to format the whole repo, you can use this script:
+```bash
+.github/clang-format-repo.sh
+```
+
+## Git pre-commit hook
+
+TBD

--- a/common/assert.hpp
+++ b/common/assert.hpp
@@ -6,9 +6,10 @@
 
 #pragma once
 
-#include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
+
+#include <iostream>
 #include <sstream>
 #include <vector>
 
@@ -18,6 +19,7 @@ namespace tt {
 template <typename A, typename B>
 struct OStreamJoin {
     OStreamJoin(A const& a, B const& b, char const* delim = " ") : a(a), b(b), delim(delim) {}
+
     A const& a;
     B const& b;
     char const* delim;
@@ -41,7 +43,8 @@ void tt_assert_message(std::ostream& os, T const& t, Ts const&... ts) {
 }
 
 template <typename... Ts>
-[[ noreturn ]] void tt_throw(char const* file, int line, const std::string& assert_type, char const* condition_str, Ts const&... messages) {
+[[noreturn]] void tt_throw(
+    char const* file, int line, const std::string& assert_type, char const* condition_str, Ts const&... messages) {
     std::stringstream trace_message_ss = {};
     trace_message_ss << assert_type << " @ " << file << ":" << line << ": " << condition_str << std::endl;
     if constexpr (sizeof...(messages) > 0) {
@@ -53,11 +56,16 @@ template <typename... Ts>
     trace_message_ss << std::flush;
     LoggerDevice::get().flush();
     throw std::runtime_error(trace_message_ss.str());
-
 }
 
 template <typename... Ts>
-void tt_assert(char const* file, int line, const std::string& assert_type, bool condition, char const* condition_str, Ts const&... messages) {
+void tt_assert(
+    char const* file,
+    int line,
+    const std::string& assert_type,
+    bool condition,
+    char const* condition_str,
+    Ts const&... messages) {
     if (not condition) {
         ::tt::assert::tt_throw(file, line, assert_type, condition_str, messages...);
     }
@@ -65,5 +73,6 @@ void tt_assert(char const* file, int line, const std::string& assert_type, bool 
 
 }  // namespace tt::assert
 
-#define TT_ASSERT(condition, ...) ::tt::assert::tt_assert(__FILE__, __LINE__, "TT_ASSERT", (condition), #condition,      ##__VA_ARGS__)
-#define TT_THROW(...)             ::tt::assert::tt_throw(__FILE__, __LINE__, "TT_THROW",     "tt::exception", ##__VA_ARGS__)
+#define TT_ASSERT(condition, ...) \
+    ::tt::assert::tt_assert(__FILE__, __LINE__, "TT_ASSERT", (condition), #condition, ##__VA_ARGS__)
+#define TT_THROW(...) ::tt::assert::tt_throw(__FILE__, __LINE__, "TT_THROW", "tt::exception", ##__VA_ARGS__)

--- a/common/backtrace.hpp
+++ b/common/backtrace.hpp
@@ -3,10 +3,10 @@
 #include <cxxabi.h>
 #include <execinfo.h>
 
+#include <csignal>
 #include <iostream>
 #include <sstream>
 #include <vector>
-#include <csignal>
 
 namespace tt::assert {
 
@@ -33,7 +33,7 @@ static std::string demangle(const char *str) {
  * @param[in] size Maximum number of return layers
  * @param[in] skip Skip the number of layers at the top of the stack
  */
-inline std::vector<std::string> backtrace(int size = 64, int skip = 1, void* caller_address = nullptr) {
+inline std::vector<std::string> backtrace(int size = 64, int skip = 1, void *caller_address = nullptr) {
     std::vector<std::string> bt;
     void **array = (void **)malloc((sizeof(void *) * size));
     if (caller_address != nullptr) {
@@ -60,7 +60,8 @@ inline std::vector<std::string> backtrace(int size = 64, int skip = 1, void* cal
  * @param[in] skip Skip the number of layers at the top of the stack
  * @param[in] prefix Output before stack information
  */
-inline std::string backtrace_to_string(int size = 64, int skip = 2, const std::string &prefix = "", void* caller_address = nullptr) {
+inline std::string backtrace_to_string(
+    int size = 64, int skip = 2, const std::string &prefix = "", void *caller_address = nullptr) {
     std::vector<std::string> bt = backtrace(size, skip, caller_address);
     std::stringstream ss;
     for (size_t i = 0; i < bt.size(); ++i) {

--- a/common/gtest_initializer.hpp
+++ b/common/gtest_initializer.hpp
@@ -10,26 +10,21 @@
 #include "gtest/gtest.h"
 
 namespace testing {
-    // Testing flag verbose can be accessed with GTEST_FLAG(verbose), and set with macro GTEST_VERBOSE=1
-    bool verbose = testing::internal::BoolFromGTestEnv("verbose", false);
-}
+// Testing flag verbose can be accessed with GTEST_FLAG(verbose), and set with macro GTEST_VERBOSE=1
+bool verbose = testing::internal::BoolFromGTestEnv("verbose", false);
+}  // namespace testing
 
 // GoogleTest event listener which only prints test suite name, how many tests are run, and failed tests.
-class SilentEventListener : public testing::TestEventListener
-{
+class SilentEventListener : public testing::TestEventListener {
 public:
     explicit SilentEventListener(testing::TestEventListener* default_event_listener) :
-        m_default_event_listener(default_event_listener)
-    {
-    }
+        m_default_event_listener(default_event_listener) {}
 
-    virtual void OnTestProgramStart(const testing::UnitTest& unit_test) override
-    {
+    virtual void OnTestProgramStart(const testing::UnitTest& unit_test) override {
         m_default_event_listener->OnTestProgramStart(unit_test);
     }
 
-    virtual void OnTestIterationStart(const testing::UnitTest& unit_test, int iteration) override
-    {
+    virtual void OnTestIterationStart(const testing::UnitTest& unit_test, int iteration) override {
         m_default_event_listener->OnTestIterationStart(unit_test, iteration);
     }
 
@@ -43,14 +38,12 @@ public:
 
     virtual void OnTestEnd(const testing::TestInfo& test_info) override {}
 
-    virtual void OnTestSuiteEnd(const testing::TestSuite& test_suite) override
-    {
+    virtual void OnTestSuiteEnd(const testing::TestSuite& test_suite) override {
         m_default_event_listener->OnTestSuiteEnd(test_suite);
     }
 
 #ifndef GTEST_REMOVE_LEGACY_TEST_CASEAPI_
-    virtual void OnTestCaseEnd(const testing::TestCase& test_case)
-    {
+    virtual void OnTestCaseEnd(const testing::TestCase& test_case) {
         m_default_event_listener->OnTestCaseEnd(test_case);
     }
 #endif  // GTEST_REMOVE_LEGACY_TEST_CASEAPI_
@@ -59,13 +52,11 @@ public:
 
     virtual void OnEnvironmentsTearDownEnd(const testing::UnitTest& unit_test) override {}
 
-    virtual void OnTestIterationEnd(const testing::UnitTest& unit_test, int iteration) override
-    {
+    virtual void OnTestIterationEnd(const testing::UnitTest& unit_test, int iteration) override {
         m_default_event_listener->OnTestIterationEnd(unit_test, iteration);
     }
 
-    virtual void OnTestProgramEnd(const testing::UnitTest& unit_test) override
-    {
+    virtual void OnTestProgramEnd(const testing::UnitTest& unit_test) override {
         m_default_event_listener->OnTestProgramEnd(unit_test);
         // Separating test outputs for different projects.
         std::cout << std::endl;
@@ -75,8 +66,7 @@ private:
     std::unique_ptr<testing::TestEventListener> m_default_event_listener;
 };
 
-void initialize_gtest(int argc, char **argv)
-{
+void initialize_gtest(int argc, char** argv) {
     // Default gtest initializer
     testing::InitGoogleTest(&argc, argv);
     bool overwrite_env = false;

--- a/common/logger.hpp
+++ b/common/logger.hpp
@@ -20,22 +20,22 @@
 #include <pybind11/iostream.h>
 #endif
 
+#include "common/backtrace.hpp"
 #include "fmt/color.h"
 #include "fmt/core.h"
 #include "fmt/ostream.h"
-#include "fmt/std.h"
 #include "fmt/ranges.h"
-
-#include "common/backtrace.hpp"
+#include "fmt/std.h"
 
 namespace tt {
 
-#define LOGGER_TYPES_DEVICE   \
-    X(Always) \
-    X(SiliconDriver)   \
-    X(EmulationDriver) \
+#define LOGGER_TYPES_DEVICE \
+    X(Always)               \
+    X(SiliconDriver)        \
+    X(EmulationDriver)
 
 enum LogTypeDevice : uint32_t {
+
 // clang-format off
 #define X(a) Log ## a,
     LOGGER_TYPES_DEVICE
@@ -46,8 +46,9 @@ enum LogTypeDevice : uint32_t {
 static_assert(LogTypeDevice_Count < 64, "Exceeded number of log types");
 
 #pragma GCC visibility push(hidden)
+
 class LoggerDevice {
-   public:
+public:
     static constexpr char const* type_names[LogTypeDevice_Count] = {
     // clang-format off
 #define X(a) #a,
@@ -133,7 +134,7 @@ class LoggerDevice {
 
     void flush() { *fd << std::flush; }
 
-   private:
+private:
     LoggerDevice() {
         static char const* env = std::getenv("LOGGER_TYPES");
         if (env) {
@@ -146,8 +147,7 @@ class LoggerDevice {
                     mask_index++;
                 }
             }
-        }
-        else {
+        } else {
             mask = 0xFFFFFFFFFFFFFFFF;
         }
 
@@ -158,8 +158,7 @@ class LoggerDevice {
                 level_str.begin(), level_str.end(), level_str.begin(), [](unsigned char c) { return std::toupper(c); });
             std::underlying_type_t<Level> level_index = 0;
             for (char const* level_name : level_names) {
-                if (level_str == level_name)
-                {
+                if (level_str == level_name) {
                     min_level = static_cast<Level>(level_index);
                 }
                 level_index++;
@@ -168,11 +167,9 @@ class LoggerDevice {
 
 #if !defined(UTILS_LOGGER_PYTHON_OSTREAM_REDIRECT) || (UTILS_LOGGER_PYTHON_OSTREAM_REDIRECT == 0)
         static char const* file_env = std::getenv("LOGGER_FILE");
-        if (file_env)
-        {
+        if (file_env) {
             log_file.open(file_env);
-            if (log_file.is_open())
-            {
+            if (log_file.is_open()) {
                 fd = &log_file;
             }
         }
@@ -196,7 +193,6 @@ class LoggerDevice {
     std::ofstream log_file;
     std::ostream* fd = &std::cout;
     std::uint64_t mask = (1 << LogAlways);
-    
 };
 
 #pragma GCC visibility pop
@@ -207,66 +203,62 @@ template <typename... Args>
 static void log_trace_(LogTypeDevice type, std::string const& src_info, char const* fmt, Args&&... args) {
     LoggerDevice::get().log_level_type(LoggerDevice::Level::Trace, type, fmt, src_info, std::forward<Args>(args)...);
 }
-} // namespace tt
+}  // namespace tt
 
-#define log_custom(level, type, str, ...) \
-    { \
-        if (static_cast<std::underlying_type_t<tt::LoggerDevice::Level>>(level) >= static_cast<std::underlying_type_t<tt::LoggerDevice::Level>>(tt::LoggerDevice::get().min_level)) { \
-            tt::LoggerDevice::get().log_level_type(level, type, str, ## __VA_ARGS__); \
-        } \
+#define log_custom(level, type, str, ...)                                                                      \
+    {                                                                                                          \
+        if (static_cast<std::underlying_type_t<tt::LoggerDevice::Level>>(level) >=                             \
+            static_cast<std::underlying_type_t<tt::LoggerDevice::Level>>(tt::LoggerDevice::get().min_level)) { \
+            tt::LoggerDevice::get().log_level_type(level, type, str, ##__VA_ARGS__);                           \
+        }                                                                                                      \
     }
 
 #define log_info(type, str, ...) \
-    { \
-        log_custom(tt::LoggerDevice::Level::Info, type, str, ## __VA_ARGS__); \
-    }
+    { log_custom(tt::LoggerDevice::Level::Info, type, str, ##__VA_ARGS__); }
 
 #define log_warning(type, str, ...) \
-    { \
-        log_custom(tt::LoggerDevice::Level::Warning, type, str, ## __VA_ARGS__); \
-    }
-    
+    { log_custom(tt::LoggerDevice::Level::Warning, type, str, ##__VA_ARGS__); }
+
 #define log_error(str, ...) \
-    { \
-        log_custom(tt::LoggerDevice::Level::Error, tt::LogAlways, str, ## __VA_ARGS__); \
+    { log_custom(tt::LoggerDevice::Level::Error, tt::LogAlways, str, ##__VA_ARGS__); }
+
+#define log_fatal(str, ...)                                                                                         \
+    {                                                                                                               \
+        log_custom(tt::LoggerDevice::Level::Fatal, tt::LogAlways, str, ##__VA_ARGS__);                              \
+        tt::LoggerDevice::get().flush();                                                                            \
+        throw std::runtime_error(                                                                                   \
+            fmt::format(str, ##__VA_ARGS__) + "\nbacktrace:\n" + tt::assert::backtrace_to_string(100, 1, " --- ")); \
     }
 
-#define log_fatal(str, ...)                                                      \
-    {                                                                            \
-        log_custom(tt::LoggerDevice::Level::Fatal, tt::LogAlways, str, ##__VA_ARGS__); \
-        tt::LoggerDevice::get().flush();                                               \
-        throw std::runtime_error(fmt::format(str,  ## __VA_ARGS__) + "\nbacktrace:\n" + tt::assert::backtrace_to_string(100, 1, " --- ")); \
-    }
-
-#define log_assert(cond, str, ...) \
-    { \
-        if (!(cond)) { \
-            log_custom(tt::LoggerDevice::Level::Fatal, tt::LogAlways, str, ## __VA_ARGS__); \
-            tt::LoggerDevice::get().flush(); \
-            throw std::runtime_error(fmt::format(str, ## __VA_ARGS__) + "\nbacktrace:\n" + tt::assert::backtrace_to_string(100, 1, " --- ")); \
-        } \
+#define log_assert(cond, str, ...)                                                         \
+    {                                                                                      \
+        if (!(cond)) {                                                                     \
+            log_custom(tt::LoggerDevice::Level::Fatal, tt::LogAlways, str, ##__VA_ARGS__); \
+            tt::LoggerDevice::get().flush();                                               \
+            throw std::runtime_error(                                                      \
+                fmt::format(str, ##__VA_ARGS__) + "\nbacktrace:\n" +                       \
+                tt::assert::backtrace_to_string(100, 1, " --- "));                         \
+        }                                                                                  \
     }
 
 #ifdef TT_DEBUG_LOGGING
 
 #define log_debug(type, str, ...) \
-    { \
-        log_custom(tt::LoggerDevice::Level::Debug, type, str, ## __VA_ARGS__); \
-    }
+    { log_custom(tt::LoggerDevice::Level::Debug, type, str, ##__VA_ARGS__); }
 
-#define log_trace(type, ...) \
-    { \
-        if (static_cast<std::underlying_type_t<tt::LoggerDevice::Level>>(tt::LoggerDevice::Level::Trace) >= static_cast<std::underlying_type_t<tt::LoggerDevice::Level>>(LoggerDevice::get().min_level)) { \
-            tt::log_trace_(type, fmt::format(fmt::fg(fmt::color::green), "{}:{}", __FILE__, __LINE__), "{} - " __VA_ARGS__); \
-        } \
+#define log_trace(type, ...)                                                                                      \
+    {                                                                                                             \
+        if (static_cast<std::underlying_type_t<tt::LoggerDevice::Level>>(tt::LoggerDevice::Level::Trace) >=       \
+            static_cast<std::underlying_type_t<tt::LoggerDevice::Level>>(LoggerDevice::get().min_level)) {        \
+            tt::log_trace_(                                                                                       \
+                type, fmt::format(fmt::fg(fmt::color::green), "{}:{}", __FILE__, __LINE__), "{} - " __VA_ARGS__); \
+        }                                                                                                         \
     }
 
 #define log_profile(str, ...) \
-    { \
-        log_custom(tt::LoggerDevice::Level::Profile, tt::LogProfile, str, ## __VA_ARGS__); \
-    }
+    { log_custom(tt::LoggerDevice::Level::Profile, tt::LogProfile, str, ##__VA_ARGS__); }
 
-#else 
+#else
 
 #define log_trace(...) ((void)0)
 #define log_debug(...) ((void)0)

--- a/device/.clang-format
+++ b/device/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: false

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: false

--- a/tests/.clang-format
+++ b/tests/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: false


### PR DESCRIPTION
From this PR, our CI will start enforcing clang-formatted code.
There is a .github/clang_format_repo.sh script available, which can also be used offline to format your files.

I've taken this script and part of .clang-format from budabackend, where I did previous effort on enabling clang. For more info, you can see https://yyz-gitlab.local.tenstorrent.com/tenstorrent/budabackend/-/issues/2660

See this for the difference between the old .clang-format and the new one. Note that most of the rules in the old one are default GoogleStyle rules. https://yyz-gitlab.local.tenstorrent.com/tenstorrent/budabackend/-/issues/2660#difference-between-clang-rules

The only difference from the agreed .clang-format from budabackend is whether braces are split into newline or not. I know that this can become a heated argument in this company :)

I intentionally disabled formatting for most of the code to reduce impact of this PR. Will introduce formatted code gradually in the following PRs. I only enabled it in couple of files in common/ directory.

These are the changes that would be implemented at the moment: https://github.com/tenstorrent/tt-umd/commit/304f102721518c8f593bd7f02a1cbca8e0c7a22c

TBD: Add instructions in README how to add this as a post commit check.