### PR TITLE
Remove unsupported ARCHS

### DIFF
--- a/device/architecture_implementation.cpp
+++ b/device/architecture_implementation.cpp
@@ -14,7 +14,6 @@ std::unique_ptr<architecture_implementation> architecture_implementation::create
     switch (architecture) {
         case tt::ARCH::BLACKHOLE: return std::make_unique<blackhole_implementation>();
         case tt::ARCH::GRAYSKULL: return std::make_unique<grayskull_implementation>();
-        case tt::ARCH::WORMHOLE:
         case tt::ARCH::WORMHOLE_B0: return std::make_unique<wormhole_implementation>();
         default: return nullptr;
     }

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -87,11 +87,6 @@ static tt::ARCH detect_arch(uint32_t pcie_device_id, uint32_t pcie_revision_id) 
         return tt::ARCH::GRAYSKULL;
     } else if (pcie_device_id == WH_PCIE_DEVICE_ID && pcie_revision_id == 0x01){
         return tt::ARCH::WORMHOLE_B0;
-    } else if (pcie_device_id == WH_PCIE_DEVICE_ID){
-        // TODO: did we ship any of these?  I've never seen one.  Can we stop
-        // having an ARCH for it if they don't exist?
-        TT_THROW("Wormhole is not supported. Please use Wormhole B0 instead.");
-        return tt::ARCH::WORMHOLE;
     } else if (pcie_device_id == BH_PCIE_DEVICE_ID){
         return tt::ARCH::BLACKHOLE;
     } else {

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -182,7 +182,7 @@ void *tt_SimulationDevice::host_dma_address(std::uint64_t offset, chip_id_t src_
 }
 
 std::uint64_t tt_SimulationDevice::get_pcie_base_addr_from_device(const chip_id_t chip_id) const {
-    if(arch_name == tt::ARCH::WORMHOLE or arch_name == tt::ARCH::WORMHOLE_B0) {
+    if(arch_name == tt::ARCH::WORMHOLE_B0) {
         return 0x800000000;
     }
     else if (arch_name == tt::ARCH::BLACKHOLE) {

--- a/device/tt_arch_types.h
+++ b/device/tt_arch_types.h
@@ -12,10 +12,8 @@ namespace tt {
  * @brief ARCH Enums
  */
 enum class ARCH {
-    JAWBRIDGE = 0,
     GRAYSKULL = 1,
-    WORMHOLE = 2,
-    WORMHOLE_B0 = 3,
+    WORMHOLE_B0 = 2,
     BLACKHOLE = 4,
     Invalid = 0xFF,
 };

--- a/device/tt_arch_types.h
+++ b/device/tt_arch_types.h
@@ -14,7 +14,7 @@ namespace tt {
 enum class ARCH {
     GRAYSKULL = 1,
     WORMHOLE_B0 = 2,
-    BLACKHOLE = 4,
+    BLACKHOLE = 3,
     Invalid = 0xFF,
 };
 }

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -216,16 +216,12 @@ bool tt_SocDescriptor::is_ethernet_core(const tt_xy_pair &core) const {
 }
 
 std::ostream &operator<<(std::ostream &out, const tt::ARCH &arch_name) {
-    if (arch_name == tt::ARCH::JAWBRIDGE) {
-        out << "jawbridge";
-    } else if (arch_name == tt::ARCH::Invalid) {
+    if (arch_name == tt::ARCH::Invalid) {
         out << "none";
     } else if (arch_name == tt::ARCH::GRAYSKULL) {
         out << "grayskull";
-    } else if (arch_name == tt::ARCH::WORMHOLE) {
-        out << "wormhole";
     } else if (arch_name == tt::ARCH::WORMHOLE_B0) {
-        out << "wormhole_b0";
+        out << "wormhole";
     } else if (arch_name == tt::ARCH::BLACKHOLE) {
         out << "blackhole"; //Just how many ARCH-to-string functions do we plan to have, anyway?
     } else {

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -221,7 +221,7 @@ std::ostream &operator<<(std::ostream &out, const tt::ARCH &arch_name) {
     } else if (arch_name == tt::ARCH::GRAYSKULL) {
         out << "grayskull";
     } else if (arch_name == tt::ARCH::WORMHOLE_B0) {
-        out << "wormhole";
+        out << "wormhole_b0";
     } else if (arch_name == tt::ARCH::BLACKHOLE) {
         out << "blackhole"; //Just how many ARCH-to-string functions do we plan to have, anyway?
     } else {

--- a/device/tt_soc_descriptor.h
+++ b/device/tt_soc_descriptor.h
@@ -34,7 +34,7 @@ static inline std::string get_arch_str(const tt::ARCH arch_name){
     if (arch_name == tt::ARCH::GRAYSKULL) {
         arch_name_str = "grayskull";
     } else if (arch_name == tt::ARCH::WORMHOLE_B0) {
-        arch_name_str = "wormhole";
+        arch_name_str = "wormhole_b0";
     } else if (arch_name == tt::ARCH::BLACKHOLE) {
         arch_name_str = "blackhole";
     } else {

--- a/device/tt_soc_descriptor.h
+++ b/device/tt_soc_descriptor.h
@@ -31,14 +31,10 @@ std::ostream &operator<<(std::ostream &out, const tt::ARCH &arch_name);
 static inline std::string get_arch_str(const tt::ARCH arch_name){
     std::string arch_name_str;
 
-    if (arch_name == tt::ARCH::JAWBRIDGE) {
-        arch_name_str = "jawbridge";
-    } else if (arch_name == tt::ARCH::GRAYSKULL) {
+    if (arch_name == tt::ARCH::GRAYSKULL) {
         arch_name_str = "grayskull";
-    } else if (arch_name == tt::ARCH::WORMHOLE) {
-        arch_name_str = "wormhole";
     } else if (arch_name == tt::ARCH::WORMHOLE_B0) {
-        arch_name_str = "wormhole_b0";
+        arch_name_str = "wormhole";
     } else if (arch_name == tt::ARCH::BLACKHOLE) {
         arch_name_str = "blackhole";
     } else {
@@ -51,13 +47,9 @@ static inline std::string get_arch_str(const tt::ARCH arch_name){
 static inline tt::ARCH get_arch_name(const std::string &arch_str){
     tt::ARCH arch;
 
-    if ((arch_str == "jawbridge") || (arch_str == "JAWBRIDGE")) {
-        arch = tt::ARCH::JAWBRIDGE;
-    } else if ((arch_str == "grayskull") || (arch_str == "GRAYSKULL")) {
+    if ((arch_str == "grayskull") || (arch_str == "GRAYSKULL")) {
         arch = tt::ARCH::GRAYSKULL;
-    } else if ((arch_str == "wormhole") || (arch_str == "WORMHOLE")){
-        arch = tt::ARCH::WORMHOLE;
-    } else if ((arch_str == "wormhole_b0") || (arch_str == "WORMHOLE_B0")){
+    } else if ((arch_str == "wormhole") || (arch_str == "WORMHOLE") || (arch_str == "wormhole_b0") || (arch_str == "WORMHOLE_B0")){
         arch = tt::ARCH::WORMHOLE_B0;
     } else if ((arch_str == "blackhole") || (arch_str == "BLACKHOLE")){
         arch = tt::ARCH::BLACKHOLE;

--- a/device/wormhole/wormhole_implementation.h
+++ b/device/wormhole/wormhole_implementation.h
@@ -206,7 +206,7 @@ static constexpr uint32_t TENSIX_SOFT_RESET_ADDR = 0xFFB121B0;
 
 class wormhole_implementation : public architecture_implementation {
    public:
-    tt::ARCH get_architecture() const override { return tt::ARCH::WORMHOLE; }
+    tt::ARCH get_architecture() const override { return tt::ARCH::WORMHOLE_B0; }
     uint32_t get_arc_message_arc_get_harvesting() const override {
         return static_cast<uint32_t>(wormhole::arc_message_type::ARC_GET_HARVESTING);
     }

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -94,7 +94,7 @@ inline std::unique_ptr<Cluster> get_cluster() {
     std::string soc_path;
     if (device_arch == tt::ARCH::GRAYSKULL) {
         soc_path = test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml");
-    } else if (device_arch == tt::ARCH::WORMHOLE || device_arch == tt::ARCH::WORMHOLE_B0) {
+    } else if (device_arch == tt::ARCH::WORMHOLE_B0) {
         soc_path = test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml");
     } else if (device_arch == tt::ARCH::BLACKHOLE) {
         soc_path = test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml");

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -106,7 +106,7 @@ inline std::unique_ptr<Cluster> get_cluster() {
     std::string soc_path;
     if (device_arch == tt::ARCH::GRAYSKULL) {
         soc_path = test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml");
-    } else if (device_arch == tt::ARCH::WORMHOLE || device_arch == tt::ARCH::WORMHOLE_B0) {
+    } else if (device_arch == tt::ARCH::WORMHOLE_B0) {
         soc_path = test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml");
     } else if (device_arch == tt::ARCH::BLACKHOLE) {
         soc_path = test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml");


### PR DESCRIPTION
FIx https://github.com/tenstorrent/tt-umd/issues/158

Won't switch to `WORMHOLE` instead of `WORMHOLE_B0` for now, it needs a lot of changes in tt-metal (directory organization, I need to find who is responsible for this in tt-metal)

### TODO

- [x] Remove from draft when `pjanevski/remove_architecture_enum` is merged
- [x] Attach tt-metal branch with required changes. Other commits need to be uplifted first - https://github.com/tenstorrent/tt-metal/tree/pjanevski/bump_umd_archs

### Follow up 

Rename `wormhole` to `wormhole_b0` - https://github.com/tenstorrent/tt-umd/issues/211