### PR TITLE
Remove ADJUST_COMPILER_WARNINGS function

### DIFF
--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -3,13 +3,15 @@ function(FIND_AND_SET_CLANG17)
     find_program(CLANG_17 clang-17)
 
     if(NOT CLANGPP_17 OR NOT CLANG_17)
-        message(FATAL_ERROR "Clang-17 not found. Make sure you have clang-17 and clang++-17 installed and in your PATH")
+        message(
+            FATAL_ERROR
+            "Clang-17 not found. Make sure you have clang-17 and clang++-17 installed and in your PATH"
+        )
     endif()
 
     set(CMAKE_CXX_COMPILER "${CLANGPP_17}" PARENT_SCOPE)
     set(CMAKE_C_COMPILER "${CLANG_17}" PARENT_SCOPE)
 endfunction()
-
 
 function(CHECK_COMPILERS)
     message(STATUS "Checking compilers")
@@ -20,7 +22,14 @@ function(CHECK_COMPILERS)
             CACHE STRING
             "CXX FLAGS for clang"
         )
-        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "17.0.0" OR CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL "18.0.0")
+        if(
+            CMAKE_CXX_COMPILER_VERSION
+                VERSION_LESS
+                "17.0.0"
+            OR CMAKE_CXX_COMPILER_VERSION
+                GREATER_EQUAL
+                "18.0.0"
+        )
             message(WARNING "Only Clang-17 is tested right now")
         endif()
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -30,6 +39,9 @@ function(CHECK_COMPILERS)
             message(WARNING "Only GCC-12 is tested right now")
         endif()
     else()
-        message(FATAL_ERROR "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID} ! Only Clang and GCC are supported")
+        message(
+            FATAL_ERROR
+            "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID} ! Only Clang and GCC are supported"
+        )
     endif()
 endfunction()

--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -33,19 +33,3 @@ function(CHECK_COMPILERS)
         message(FATAL_ERROR "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID} ! Only Clang and GCC are supported")
     endif()
 endfunction()
-
-
-function(ADJUST_COMPILER_WARNINGS)
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        target_compile_options(compiler_warnings INTERFACE
-            -Wsometimes-uninitialized -Wno-c++11-narrowing -Wno-error=local-type-template-args
-            -Wno-delete-non-abstract-non-virtual-dtor -Wno-c99-designator -Wno-shift-op-parentheses -Wno-non-c-typedef-for-linkage
-            -Wno-deprecated-this-capture -Wno-deprecated-volatile -Wno-deprecated-builtins -Wno-deprecated-declarations
-        )
-    else() # GCC
-        target_compile_options(compiler_warnings INTERFACE
-            -Wno-deprecated -Wno-attributes -Wno-stringop-overread -Wno-stringop-overflow -Wno-maybe-uninitialized -Wno-missing-requires
-            -Wno-narrowing -Wno-non-template-friend -Wno-error=non-template-friend
-        )
-    endif()
-endfunction()


### PR DESCRIPTION
This function is not called or needed in this project.

It was copy pasted from tt-metal, and it is causing problems.

Duplicate functions doing different things once they diverge.