### PR TITLE
Hide simulation device/host impl details

### DIFF
--- a/device/simulation/tt_simulation_device.h
+++ b/device/simulation/tt_simulation_device.h
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "device/tt_device.h"
-#include "tt_simulation_device_generated.h"
 #include "device/simulation/tt_simulation_host.hpp"
 
 class tt_SimulationDevice: public tt_device {
@@ -69,7 +68,4 @@ class tt_SimulationDevice: public tt_device {
     std::set<chip_id_t> target_remote_chips = {};
     tt::ARCH arch_name;
     std::shared_ptr<tt_ClusterDescriptor> ndesc;
-
-    flatbuffers::FlatBufferBuilder create_flatbuffer(DEVICE_COMMAND rw, std::vector<uint32_t> vec, tt_cxy_pair core_, uint64_t addr, uint64_t size_=0);
-    void print_flatbuffer(const DeviceRequestResponse *buf);
 };

--- a/device/simulation/tt_simulation_host.cpp
+++ b/device/simulation/tt_simulation_host.cpp
@@ -9,11 +9,18 @@
 #include <cassert>
 #include <cstdlib>
 
+#include <nng/nng.h>
+#include <nng/protocol/pair1/pair.h>
+
 #include "common/logger.hpp"
 #include "common/assert.hpp"
 #include "tt_simulation_host.hpp"
 
 tt_SimulationHost::tt_SimulationHost() {
+    // Initialize socket and dialer
+    host_socket = std::make_unique<nng_socket>();
+    host_dialer = std::make_unique<nng_dialer>();
+
     // Get current date time string
     std::time_t time = std::time(nullptr);
     std::tm local_time = *std::localtime(&time);
@@ -32,21 +39,21 @@ tt_SimulationHost::tt_SimulationHost() {
 
     // Open socket and create dialer
     log_info(tt::LogEmulationDriver, "Dialing: {}", nng_socket_addr);
-    nng_pair1_open(&host_socket);
-    int rv = nng_dialer_create(&host_dialer, host_socket, nng_socket_addr);
+    nng_pair1_open(host_socket.get());
+    int rv = nng_dialer_create(host_dialer.get(), *host_socket, nng_socket_addr);
     TT_ASSERT(rv == 0, "Failed to create dialer: {} {}", nng_strerror(rv), nng_socket_addr);
 }
 
 tt_SimulationHost::~tt_SimulationHost() {
-    nng_dialer_close(host_dialer);
-    nng_close(host_socket);
+    nng_dialer_close(*host_dialer);
+    nng_close(*host_socket);
 }
 
 void tt_SimulationHost::start_host() {
     // Establish connection with remote VCS simulator
     int rv;
     do {
-        rv = nng_dialer_start(host_dialer, 0);
+        rv = nng_dialer_start(*host_dialer, 0);
         if (rv != 0) {
             log_info(tt::LogEmulationDriver, "Waiting for remote: {}", nng_strerror(rv));
             std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -61,7 +68,7 @@ void tt_SimulationHost::send_to_device(uint8_t *buf, size_t buf_size) {
     void *msg = nng_alloc(buf_size);
     std::memcpy(msg, buf, buf_size);
 
-    rv = nng_send(host_socket, msg, buf_size, NNG_FLAG_ALLOC);
+    rv = nng_send(*host_socket, msg, buf_size, NNG_FLAG_ALLOC);
     log_debug(tt::LogEmulationDriver, "Message sent.");
     if (rv != 0) {
         log_info(tt::LogEmulationDriver, "Failed to send message to remote: {}", nng_strerror(rv));
@@ -72,7 +79,7 @@ size_t tt_SimulationHost::recv_from_device(void **data_ptr) {
     int rv;
     size_t data_size;
     log_debug(tt::LogEmulationDriver, "Receiving messsage from remote..");
-    rv = nng_recv(host_socket, data_ptr, &data_size, NNG_FLAG_ALLOC);
+    rv = nng_recv(*host_socket, data_ptr, &data_size, NNG_FLAG_ALLOC);
     log_debug(tt::LogEmulationDriver, "Message received.");
     if (rv != 0) {
         log_info(tt::LogEmulationDriver, "Failed to receive message from remote: {}", nng_strerror(rv));

--- a/device/simulation/tt_simulation_host.hpp
+++ b/device/simulation/tt_simulation_host.hpp
@@ -3,13 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <vector>
 #include <cstdint>
-
-#include <nng/nng.h>
-#include <nng/protocol/pair1/pair.h>
+#include <memory>
 
 #include "device/tt_xy_pair.h"
 
 #define NNG_SOCKET_PREFIX "ipc:///tmp/"
+
+typedef struct nng_socket_s nng_socket;
+typedef struct nng_dialer_s nng_dialer;
 
 class tt_SimulationHost {
 public:
@@ -20,6 +21,6 @@ public:
     void send_to_device(uint8_t *buf, size_t buf_size);
     size_t recv_from_device(void **data_ptr);
 private:
-    nng_socket host_socket;
-    nng_dialer host_dialer;
+    std::unique_ptr<nng_socket> host_socket;
+    std::unique_ptr<nng_dialer> host_dialer;
 };

--- a/tests/simulation/device_fixture.hpp
+++ b/tests/simulation/device_fixture.hpp
@@ -8,6 +8,7 @@
 
 #include "tt_simulation_device.h"
 #include "common/logger.hpp"
+#include "tests/test_utils/generate_cluster_desc.hpp"
 
 #include <nng/nng.h>
 #include <nng/protocol/pipeline0/pull.h>
@@ -17,8 +18,9 @@
 class SimulationDeviceFixture : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
+        // default_params and yaml path are both dummy and won't change test behavior
         tt_device_params default_params;
-        device = std::make_unique<tt_SimulationDevice>("");
+        device = std::make_unique<tt_SimulationDevice>(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"));
         device->start_device(default_params);
     }
 


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-umd/issues/187

Changes include: 
- Forward declare `nng_socket` and `nng_dialer`, changing them into pointers and propagating this change to not expose `nng.h` in `tt_simulation_host.hpp`
- remove `create_flatbuffer` and `print_flatbuffer` as a member function in `tt_simulation_device` so now no need to expose flatbuffers in `tt_simulation_device.hpp`
- hijacked a quick simulation test fix onto this PR