### PR TITLE
Deprecate set_driver_host_address_params

### DIFF
--- a/device/architecture_implementation.h
+++ b/device/architecture_implementation.h
@@ -15,7 +15,7 @@
 #include "device/xy_pair.h"
 #include "device/tt_arch_types.h"
 
-#include "device/tt_device.h"
+struct tt_driver_host_address_params;
 
 namespace tt::umd {
 

--- a/device/architecture_implementation.h
+++ b/device/architecture_implementation.h
@@ -15,6 +15,8 @@
 #include "device/xy_pair.h"
 #include "device/tt_arch_types.h"
 
+#include "device/tt_device.h"
+
 namespace tt::umd {
 
 class architecture_implementation {
@@ -62,6 +64,8 @@ class architecture_implementation {
     virtual tlb_configuration get_tlb_configuration(uint32_t tlb_index) const = 0;
     virtual std::optional<std::tuple<std::uint64_t, std::uint64_t>> describe_tlb(std::int32_t tlb_index) const = 0;
     virtual std::pair<std::uint64_t, std::uint64_t> get_tlb_data(std::uint32_t tlb_index, const tlb_data& data) const = 0;
+
+    virtual tt_driver_host_address_params get_host_address_params() const = 0;
 
     static std::unique_ptr<architecture_implementation> create(tt::ARCH architecture);
 };

--- a/device/blackhole/blackhole_implementation.cpp
+++ b/device/blackhole/blackhole_implementation.cpp
@@ -6,6 +6,8 @@
 
 #include "src/firmware/riscv/blackhole/host_mem_address_map.h"
 
+#include "device/tt_device.h"
+
 namespace tt::umd {
 
 std::tuple<xy_pair, xy_pair> blackhole_implementation::multicast_workaround(xy_pair start, xy_pair end) const {
@@ -76,8 +78,8 @@ std::pair<std::uint64_t, std::uint64_t> blackhole_implementation::get_tlb_data(
 
 }
 
-tt_driver_host_address_params grayskull_implementation::get_host_address_params() {
-    return {blackhole::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, blackhole::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
+tt_driver_host_address_params blackhole_implementation::get_host_address_params() const {
+    return {::blackhole::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, ::blackhole::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
 }
 
 }  // namespace tt::umd

--- a/device/blackhole/blackhole_implementation.cpp
+++ b/device/blackhole/blackhole_implementation.cpp
@@ -4,6 +4,8 @@
 
 #include "blackhole_implementation.h"
 
+#include "src/firmware/riscv/blackhole/host_mem_address_map.h"
+
 namespace tt::umd {
 
 std::tuple<xy_pair, xy_pair> blackhole_implementation::multicast_workaround(xy_pair start, xy_pair end) const {
@@ -72,6 +74,10 @@ std::pair<std::uint64_t, std::uint64_t> blackhole_implementation::get_tlb_data(
         throw std::runtime_error("Invalid TLB index for Blackhole arch");
     }
 
+}
+
+tt_driver_host_address_params grayskull_implementation::get_host_address_params() {
+    return {blackhole::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, blackhole::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
 }
 
 }  // namespace tt::umd

--- a/device/blackhole/blackhole_implementation.h
+++ b/device/blackhole/blackhole_implementation.h
@@ -227,6 +227,9 @@ class blackhole_implementation : public architecture_implementation {
     tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
     std::optional<std::tuple<std::uint64_t, std::uint64_t>> describe_tlb(std::int32_t tlb_index) const override;
     std::pair<std::uint64_t, std::uint64_t> get_tlb_data(std::uint32_t tlb_index, const tlb_data& data) const override;
+
+    tt_driver_host_address_params get_host_address_params() const override;
+
 };
 
 }  // namespace tt::umd

--- a/device/grayskull/grayskull_implementation.cpp
+++ b/device/grayskull/grayskull_implementation.cpp
@@ -4,6 +4,8 @@
 
 #include "grayskull_implementation.h"
 
+#include "src/firmware/riscv/grayskull/host_mem_address_map.h"
+
 namespace tt::umd {
 
 std::tuple<xy_pair, xy_pair> grayskull_implementation::multicast_workaround(xy_pair start, xy_pair end) const {
@@ -79,6 +81,10 @@ std::pair<std::uint64_t, std::uint64_t> grayskull_implementation::get_tlb_data(
     } else {
         throw std::runtime_error("Invalid TLB index for Grayskull arch");
     }
+}
+
+tt_driver_host_address_params grayskull_implementation::get_host_address_params() {
+    return {grayskull::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, grayskull::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
 }
 
 }  // namespace tt::umd

--- a/device/grayskull/grayskull_implementation.cpp
+++ b/device/grayskull/grayskull_implementation.cpp
@@ -6,6 +6,8 @@
 
 #include "src/firmware/riscv/grayskull/host_mem_address_map.h"
 
+#include "device/tt_device.h"
+
 namespace tt::umd {
 
 std::tuple<xy_pair, xy_pair> grayskull_implementation::multicast_workaround(xy_pair start, xy_pair end) const {
@@ -83,8 +85,8 @@ std::pair<std::uint64_t, std::uint64_t> grayskull_implementation::get_tlb_data(
     }
 }
 
-tt_driver_host_address_params grayskull_implementation::get_host_address_params() {
-    return {grayskull::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, grayskull::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
+tt_driver_host_address_params grayskull_implementation::get_host_address_params() const {
+    return {::grayskull::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, ::grayskull::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
 }
 
 }  // namespace tt::umd

--- a/device/grayskull/grayskull_implementation.h
+++ b/device/grayskull/grayskull_implementation.h
@@ -230,6 +230,9 @@ class grayskull_implementation : public architecture_implementation {
     tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
     std::optional<std::tuple<std::uint64_t, std::uint64_t>> describe_tlb(std::int32_t tlb_index) const override;
     std::pair<std::uint64_t, std::uint64_t> get_tlb_data(std::uint32_t tlb_index, const tlb_data& data) const override;
+
+    tt_driver_host_address_params get_host_address_params() const override;
+
 };
 
 }  // namespace tt::umd

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -579,3 +579,5 @@ dynamic_tlb PCIDevice::set_dynamic_tlb_broadcast(unsigned int tlb_index, std::ui
     // Issue a broadcast to cores included in the start (top left) and end (bottom right) grid
     return set_dynamic_tlb(tlb_index, start, end, address, true, harvested_coord_translation, ordering);
 }
+
+tt::umd::architecture_implementation* PCIDevice::get_architecture_implementation() const {return architecture_implementation.get();}

--- a/device/pcie/pci_device.hpp
+++ b/device/pcie/pci_device.hpp
@@ -14,8 +14,8 @@
 
 #include "device/tt_xy_pair.h"
 #include "device/tt_arch_types.h"
-#include "device/architecture_implementation.h"
 #include "device/tt_cluster_descriptor_types.h"
+#include "device/tlb.h"
 
 // TODO: this is used up in tt_silicon_driver.cpp but that logic ought to be
 // lowered into the PCIDevice class since it is specific to PCIe cards.
@@ -28,6 +28,8 @@ static const uint64_t UNROLL_ATU_OFFSET_BAR = 0x1200;
 static const uint64_t BAR0_BH_SIZE = 512 * 1024 * 1024;
 
 constexpr unsigned int c_hang_read_value = 0xffffffffu;
+
+namespace tt::umd { class architecture_implementation; }
 
 struct dynamic_tlb {
     uint64_t bar_offset;        // Offset that address is mapped to, within the PCI BAR.
@@ -161,7 +163,7 @@ public:
     dynamic_tlb set_dynamic_tlb(unsigned int tlb_index, tt_xy_pair target, std::uint64_t address, std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>>& harvested_coord_translation, std::uint64_t ordering = tt::umd::tlb_data::Relaxed);
     dynamic_tlb set_dynamic_tlb_broadcast(unsigned int tlb_index, std::uint64_t address, std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>>& harvested_coord_translation, tt_xy_pair start, tt_xy_pair end, std::uint64_t ordering = tt::umd::tlb_data::Relaxed);
 
-    tt::umd::architecture_implementation* get_architecture_implementation() const { return architecture_implementation.get(); }
+    tt::umd::architecture_implementation* get_architecture_implementation() const;
     void detect_hang_read(uint32_t data_read = c_hang_read_value);
 
 public:

--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -243,6 +243,7 @@ class tt_device
      *
      * @param host_address_params_ All the Host Address space parameters required by UMD.
      */ 
+    [[deprecated("Using unnecessary function.")]]
     virtual void set_driver_host_address_params(const tt_driver_host_address_params& host_address_params_) {
         throw std::runtime_error("---- tt_device::set_driver_host_address_params is not implemented\n");
     }

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -48,6 +48,10 @@
 #include "tt_device.h"
 #include "ioctl.h"
 
+#include "src/firmware/riscv/grayskull/host_mem_address_map.h"
+#include "src/firmware/riscv/wormhole/host_mem_address_map.h"
+#include "src/firmware/riscv/blackhole/host_mem_address_map.h"
+
 using namespace boost::interprocess;
 using namespace tt;
 
@@ -531,6 +535,22 @@ tt_SiliconDevice::tt_SiliconDevice(const std::string &sdesc_path, const std::str
             }
         }
     }
+
+    // Default initialize host_address_params based on detected arch
+    switch(arch_name) {
+        case tt::ARCH::GRAYSKULL:
+            host_address_params = {grayskull::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, grayskull::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
+            break;
+
+        case tt::ARCH::WORMHOLE_B0:
+            host_address_params = {wormhole::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, wormhole::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
+            break;
+
+        case tt::ARCH::BLACKHOLE:
+            host_address_params = {blackhole::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, blackhole::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
+            break;
+    }
+
 }
 
 void tt_SiliconDevice::configure_active_ethernet_cores_for_mmio_device(chip_id_t mmio_chip, const std::unordered_set<tt_xy_pair>& active_eth_cores_per_chip) {

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -48,10 +48,6 @@
 #include "tt_device.h"
 #include "ioctl.h"
 
-#include "src/firmware/riscv/grayskull/host_mem_address_map.h"
-#include "src/firmware/riscv/wormhole/host_mem_address_map.h"
-#include "src/firmware/riscv/blackhole/host_mem_address_map.h"
-
 using namespace boost::interprocess;
 using namespace tt;
 
@@ -537,19 +533,7 @@ tt_SiliconDevice::tt_SiliconDevice(const std::string &sdesc_path, const std::str
     }
 
     // Default initialize host_address_params based on detected arch
-    switch(arch_name) {
-        case tt::ARCH::GRAYSKULL:
-            host_address_params = {grayskull::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, grayskull::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
-            break;
-
-        case tt::ARCH::WORMHOLE_B0:
-            host_address_params = {wormhole::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, wormhole::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
-            break;
-
-        case tt::ARCH::BLACKHOLE:
-            host_address_params = {blackhole::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, blackhole::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
-            break;
-    }
+    host_address_params = architecture_implementation->get_host_address_params();
 
 }
 

--- a/device/wormhole/wormhole_implementation.cpp
+++ b/device/wormhole/wormhole_implementation.cpp
@@ -6,6 +6,8 @@
 
 #include "src/firmware/riscv/wormhole/host_mem_address_map.h"
 
+#include "device/tt_device.h"
+
 namespace tt::umd {
 
 std::tuple<xy_pair, xy_pair> wormhole_implementation::multicast_workaround(xy_pair start, xy_pair end) const {
@@ -91,8 +93,8 @@ std::pair<std::uint64_t, std::uint64_t> wormhole_implementation::get_tlb_data(
     }
 }
 
-tt_driver_host_address_params grayskull_implementation::get_host_address_params() {
-    return {wormhole::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, wormhole::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
+tt_driver_host_address_params wormhole_implementation::get_host_address_params() const {
+    return {::wormhole::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, ::wormhole::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
 }
 
 }  // namespace tt::umd

--- a/device/wormhole/wormhole_implementation.cpp
+++ b/device/wormhole/wormhole_implementation.cpp
@@ -4,6 +4,8 @@
 
 #include "wormhole_implementation.h"
 
+#include "src/firmware/riscv/wormhole/host_mem_address_map.h"
+
 namespace tt::umd {
 
 std::tuple<xy_pair, xy_pair> wormhole_implementation::multicast_workaround(xy_pair start, xy_pair end) const {
@@ -87,6 +89,10 @@ std::pair<std::uint64_t, std::uint64_t> wormhole_implementation::get_tlb_data(
     } else {
         throw std::runtime_error("Invalid TLB index for Wormhole arch");
     }
+}
+
+tt_driver_host_address_params grayskull_implementation::get_host_address_params() {
+    return {wormhole::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, wormhole::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
 }
 
 }  // namespace tt::umd

--- a/device/wormhole/wormhole_implementation.h
+++ b/device/wormhole/wormhole_implementation.h
@@ -264,6 +264,9 @@ class wormhole_implementation : public architecture_implementation {
     tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
     std::optional<std::tuple<std::uint64_t, std::uint64_t>> describe_tlb(std::int32_t tlb_index) const override;
     std::pair<std::uint64_t, std::uint64_t> get_tlb_data(std::uint32_t tlb_index, const tlb_data& data) const override;
+
+    tt_driver_host_address_params get_host_address_params() const override;
+
 };
 
 }  // namespace tt::umd

--- a/src/firmware/riscv/blackhole/host_mem_address_map.h
+++ b/src/firmware/riscv/blackhole/host_mem_address_map.h
@@ -5,6 +5,9 @@
 #include <cstdint>
 #include <stdint.h>
 
+// Remove inline ASAP
+inline namespace blackhole {
+
 namespace host_mem {
 
 struct address_map {
@@ -44,5 +47,6 @@ struct address_map {
     return ALLOCATABLE_QUEUE_REGION_END(channel) - ALLOCATABLE_QUEUE_REGION_START(channel);
   }
 };
+}
 }
 

--- a/src/firmware/riscv/grayskull/host_mem_address_map.h
+++ b/src/firmware/riscv/grayskull/host_mem_address_map.h
@@ -8,6 +8,9 @@
 #include <cstdint>
 #include <stdint.h>
 
+// Remove inline ASAP
+inline namespace grayskull {
+
 namespace host_mem {
 
 struct address_map {
@@ -31,5 +34,6 @@ struct address_map {
   static constexpr std::int32_t NUM_HOST_PERF_QUEUES = 8 * 64;
   static constexpr std::int32_t HOST_PERF_QUEUE_SLOT_SIZE = HOST_PERF_SCRATCH_BUF_SIZE / NUM_HOST_PERF_QUEUES / 32 * 32;
 };
+}
 }
 

--- a/src/firmware/riscv/wormhole/host_mem_address_map.h
+++ b/src/firmware/riscv/wormhole/host_mem_address_map.h
@@ -8,6 +8,9 @@
 #include <cstdint>
 #include <stdint.h>
 
+// Remove inline ASAP
+inline namespace wormhole {
+
 namespace host_mem {
 
 struct address_map {
@@ -31,5 +34,6 @@ struct address_map {
   static constexpr std::int32_t NUM_HOST_PERF_QUEUES = 6 * 64;
   static constexpr std::int32_t HOST_PERF_QUEUE_SLOT_SIZE = HOST_PERF_SCRATCH_BUF_SIZE / NUM_HOST_PERF_QUEUES / 32 * 32;  
 };
+}
 }
 


### PR DESCRIPTION
Deprecate unnecessary API by introducing default initialization for the effected struct, and adding a namespace for the involved constants.

I made the new namespace inline so that existing code wouldn't break either in tests or in tt_metal.