### PR TITLE
A CMake target for firmware headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ message(STATUS "UMD build type: ${CMAKE_BUILD_TYPE}")
 include(dependencies)
 
 add_subdirectory(device)
+add_subdirectory(src)
 
 option(TT_UMD_BUILD_TESTS "Enables build of tt_umd tests" OFF)
 if(TT_UMD_BUILD_TESTS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(firmware INTERFACE)
+add_library(${PROJECT_NAME}::Firmware ALIAS firmware)
+
+target_include_directories(
+    firmware
+    INTERFACE
+        $<$<STREQUAL:$ENV{ARCH_NAME},wormhole_b0>:${CMAKE_CURRENT_SOURCE_DIR}/firmware/riscv/wormhole>
+        $<$<STREQUAL:$ENV{ARCH_NAME},grayskull>:${CMAKE_CURRENT_SOURCE_DIR}/firmware/riscv/grayskull>
+        $<$<STREQUAL:$ENV{ARCH_NAME},blackhole>:${CMAKE_CURRENT_SOURCE_DIR}/firmware/riscv/blackhole>
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,8 @@ add_library(test_common INTERFACE)
 target_link_libraries(
     test_common
     INTERFACE
-        umd_device
+        umd::device
+        umd::Firmware
         gtest_main
         gtest
         pthread
@@ -19,31 +20,6 @@ target_include_directories(
         ${PROJECT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}
 )
-if($ENV{ARCH_NAME} STREQUAL "grayskull")
-    message(STATUS "UMD: Building for Grayskull")
-    target_include_directories(
-        test_common
-        INTERFACE
-            ${PROJECT_SOURCE_DIR}/device/grayskull
-            ${PROJECT_SOURCE_DIR}/src/firmware/riscv/grayskull
-    )
-elseif($ENV{ARCH_NAME} STREQUAL "wormhole_b0")
-    message(STATUS "UMD: Building for Wormhole")
-    target_include_directories(
-        test_common
-        INTERFACE
-            ${PROJECT_SOURCE_DIR}/device/wormhole
-            ${PROJECT_SOURCE_DIR}/src/firmware/riscv/wormhole
-    )
-elseif($ENV{ARCH_NAME} STREQUAL "blackhole")
-    message(STATUS "UMD: Building for Blackhole")
-    target_include_directories(
-        test_common
-        INTERFACE
-            ${PROJECT_SOURCE_DIR}/device/blackhole
-            ${PROJECT_SOURCE_DIR}/src/firmware/riscv/blackhole
-    )
-endif()
 
 if(MASTER_PROJECT)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/microbenchmark)


### PR DESCRIPTION
 Create a target to encapsulate firmware
    
 Bonus: this pushes ARCH_NAME down closer to the source where it can be abstracted away more easily.