### PR TITLE
Fix bug building UMD as submodule

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -71,14 +71,14 @@ CPMAddPackage(
 function(GENERATE_FBS_HEADER FBS_FILE)
     get_filename_component(FBS_FILE_NAME ${FBS_FILE} NAME)
     get_filename_component(FBS_FILE_DIR ${FBS_FILE} DIRECTORY)
-    set(FBS_GENERATED_HEADER "${PROJECT_BINARY_DIR}/${FBS_FILE_NAME}_generated.h")
+    set(FBS_GENERATED_HEADER "${CMAKE_CURRENT_BINARY_DIR}/${FBS_FILE_NAME}_generated.h")
     add_custom_command(
         OUTPUT
             ${FBS_GENERATED_HEADER}
         COMMAND
             flatc
         ARGS
-            --cpp -o "${PROJECT_BINARY_DIR}/" ${FBS_FILE}
+            --cpp -o "${CMAKE_CURRENT_BINARY_DIR}/" ${FBS_FILE}
         DEPENDS
             flatc
             ${FBS_FILE}

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -71,14 +71,14 @@ CPMAddPackage(
 function(GENERATE_FBS_HEADER FBS_FILE)
     get_filename_component(FBS_FILE_NAME ${FBS_FILE} NAME)
     get_filename_component(FBS_FILE_DIR ${FBS_FILE} DIRECTORY)
-    set(FBS_GENERATED_HEADER "${CMAKE_BINARY_DIR}/${FBS_FILE_NAME}_generated.h")
+    set(FBS_GENERATED_HEADER "${PROJECT_BINARY_DIR}/${FBS_FILE_NAME}_generated.h")
     add_custom_command(
         OUTPUT
             ${FBS_GENERATED_HEADER}
         COMMAND
             flatc
         ARGS
-            --cpp -o "${CMAKE_BINARY_DIR}/" ${FBS_FILE}
+            --cpp -o "${PROJECT_BINARY_DIR}/" ${FBS_FILE}
         DEPENDS
             flatc
             ${FBS_FILE}

--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/device>
     PRIVATE
-        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
 )
 
 # flatbuffers is public - exposed to tt_metal by tt_simulation_device_generated.h


### PR DESCRIPTION
Include path is given to device library as PROJECT_BINARY_DIR

Function uses CMAKE_BINARY_DIR.

This causes problems when building UMD as a submodule.