### PR TITLE
Minor fix get_num_host_channels

### DIFF
--- a/.github/workflows/on-pr-opt.yml
+++ b/.github/workflows/on-pr-opt.yml
@@ -20,7 +20,7 @@ jobs:
     uses: ./.github/workflows/build-tests.yml
     with:
       arch: ${{ matrix.test-group.arch}}
-      timeout: 10
+      timeout: 15
 
   test-all:
     secrets: inherit

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -11,7 +11,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/build-device.yml
     with:
-      timeout: 10
+      timeout: 15
 
   pre-commit:
     name: Run Pre-commit Hooks and Propose Fixes

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -10,7 +10,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/build-device.yml
     with:
-      timeout: 10
+      timeout: 15
 
   build-tests:
     secrets: inherit
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/build-tests.yml
     with:
       arch: ${{ matrix.test-group.arch }}
-      timeout: 10
+      timeout: 15
 
   test-all:
     secrets: inherit

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -2923,7 +2923,8 @@ std::uint64_t tt_SiliconDevice::get_dram_channel_size(std::uint32_t device_id, s
 }
 
 std::uint32_t tt_SiliconDevice::get_num_host_channels(std::uint32_t device_id) {
-    log_assert(all_target_mmio_devices.find(device_id) != all_target_mmio_devices.end(), "Querying Host Address parameters for a non-mmio device or a device does not exist.");
+    auto devices = get_target_mmio_device_ids();
+    log_assert(devices.find(device_id) != devices.end(), "Querying Host Address parameters for a non-mmio device or a device does not exist.");
     return m_num_host_mem_channels; // Same number of host channels per device for now
 }
 

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -176,8 +176,9 @@ TEST(ApiChipTest, ManualTLBConfiguration) {
 // TODO: Move to test_chip
 TEST(ApiChipTest, SimpleAPIShowcase) {
     std::unique_ptr<Cluster> umd_cluster = get_cluster();
-    chip_id_t chip_id = *umd_cluster->get_all_chips_in_cluster().begin();
+    chip_id_t chip_id = *umd_cluster->get_target_mmio_device_ids().begin();
 
     // TODO: In future, will be accessed through tt::umd::Chip api.
     umd_cluster->get_pcie_base_addr_from_device(chip_id);
+    umd_cluster->get_num_host_channels(chip_id);
 }

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -176,7 +176,7 @@ TEST(ApiChipTest, ManualTLBConfiguration) {
 // TODO: Move to test_chip
 TEST(ApiChipTest, SimpleAPIShowcase) {
     std::unique_ptr<Cluster> umd_cluster = get_cluster();
-    chip_id_t chip_id = *umd_cluster->get_target_mmio_device_ids().begin();
+    chip_id_t chip_id = umd_cluster->get_cluster_description()->get_chips_with_mmio().begin()->first;
 
     // TODO: In future, will be accessed through tt::umd::Chip api.
     umd_cluster->get_pcie_base_addr_from_device(chip_id);


### PR DESCRIPTION
This is a minor fix, so now all access to all_target_mmio_devices goes through get_target_mmio_device_ids().

It previously worked correctly as long as any function called get_target_mmio_device_ids() first which would fill up the all_target_mmio_devices.
For whatever reason this now doesn't happen in tt_metal tests: https://github.com/tenstorrent/tt-metal/actions/runs/11626089648/job/32377175304

I wrote a test to verify that this fails with current code, and then fixed the issue. You can see the tests failed after the second commit.

Seems like our build can occasionally be slower, increasing timeout slightly.