### PR TITLE
Enable clang for tests/ folder

### DIFF
--- a/tests/.clang-format
+++ b/tests/.clang-format
@@ -1,2 +1,0 @@
-DisableFormat: true
-SortIncludes: false

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -11,17 +11,16 @@
 #include <string>
 #include <vector>
 
+#include "device/cluster.h"
+#include "device/tt_cluster_descriptor.h"
 #include "fmt/xchar.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 
-#include "device/tt_cluster_descriptor.h"
-#include "device/cluster.h"
-
 // TODO: obviously we need some other way to set this up
+#include "noc/noc_parameters.h"
 #include "src/firmware/riscv/wormhole/eth_l1_address_map.h"
 #include "src/firmware/riscv/wormhole/host_mem_address_map.h"
 #include "src/firmware/riscv/wormhole/l1_address_map.h"
-#include "noc/noc_parameters.h"
 
 using namespace tt::umd;
 
@@ -103,11 +102,9 @@ void setup_wormhole_remote(Cluster* umd_cluster) {
         // Populate address map and NOC parameters that the driver needs for remote transactions
 
         umd_cluster->set_device_l1_address_params(
-            {
-             l1_mem::address_map::L1_BARRIER_BASE,
+            {l1_mem::address_map::L1_BARRIER_BASE,
              eth_l1_mem::address_map::ERISC_BARRIER_BASE,
-             eth_l1_mem::address_map::FW_VERSION_ADDR
-	    });
+             eth_l1_mem::address_map::FW_VERSION_ADDR});
     }
 }
 

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -5,18 +5,16 @@
 #include <gtest/gtest.h>
 
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
-#include "tests/test_utils/generate_cluster_desc.hpp"
 #include "common/disjoint_set.hpp"
-
 #include "device/pcie/pci_device.hpp"
 #include "device/tt_cluster_descriptor.h"
+#include "tests/test_utils/generate_cluster_desc.hpp"
 
 // TODO: Needed for detect_arch, remove when it is part of cluster descriptor.
 #include "device/cluster.h"
-
 
 inline std::unique_ptr<tt_ClusterDescriptor> get_cluster_desc() {
     // TODO: remove getting manually cluster descriptor from yaml.
@@ -45,7 +43,6 @@ TEST(ApiClusterDescriptorTest, DetectArch) {
 }
 
 TEST(ApiClusterDescriptorTest, BasicFunctionality) {
-
     std::unique_ptr<tt_ClusterDescriptor> cluster_desc = get_cluster_desc();
 
     if (cluster_desc == nullptr) {
@@ -57,7 +54,7 @@ TEST(ApiClusterDescriptorTest, BasicFunctionality) {
     std::unordered_map<chip_id_t, eth_coord_t> eth_chip_coords = cluster_desc->get_chip_locations();
     std::unordered_map<chip_id_t, chip_id_t> local_chips_to_pci_device_id = cluster_desc->get_chips_with_mmio();
     std::unordered_set<chip_id_t> local_chips;
-    for (auto [chip, _]: local_chips_to_pci_device_id) {
+    for (auto [chip, _] : local_chips_to_pci_device_id) {
         local_chips.insert(chip);
     }
     std::unordered_set<chip_id_t> remote_chips;
@@ -67,28 +64,30 @@ TEST(ApiClusterDescriptorTest, BasicFunctionality) {
         }
     }
 
-    std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> chips_grouped_by_closest_mmio = cluster_desc->get_chips_grouped_by_closest_mmio();
+    std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> chips_grouped_by_closest_mmio =
+        cluster_desc->get_chips_grouped_by_closest_mmio();
 }
 
 TEST(ApiClusterDescriptorTest, TestAllOfflineClusterDescriptors) {
     for (std::string cluster_desc_yaml : {
-        "blackhole_P150.yaml",
-        "galaxy.yaml",
-        "grayskull_E150.yaml",
-        "grayskull_E300.yaml",
-        "wormhole_2xN300_unconnected.yaml",
-        "wormhole_N150.yaml",
-        "wormhole_N300.yaml",
-    }) {
+             "blackhole_P150.yaml",
+             "galaxy.yaml",
+             "grayskull_E150.yaml",
+             "grayskull_E300.yaml",
+             "wormhole_2xN300_unconnected.yaml",
+             "wormhole_N150.yaml",
+             "wormhole_N300.yaml",
+         }) {
         std::cout << "Testing " << cluster_desc_yaml << std::endl;
-        std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(test_utils::GetAbsPath("tests/api/cluster_descriptor_examples/" + cluster_desc_yaml));
+        std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(
+            test_utils::GetAbsPath("tests/api/cluster_descriptor_examples/" + cluster_desc_yaml));
 
         std::unordered_set<chip_id_t> all_chips = cluster_desc->get_all_chips();
         std::unordered_map<chip_id_t, std::uint32_t> harvesting_for_chips = cluster_desc->get_harvesting_info();
         std::unordered_map<chip_id_t, eth_coord_t> eth_chip_coords = cluster_desc->get_chip_locations();
         std::unordered_map<chip_id_t, chip_id_t> local_chips_to_pci_device_id = cluster_desc->get_chips_with_mmio();
         std::unordered_set<chip_id_t> local_chips;
-        for (auto [chip, _]: local_chips_to_pci_device_id) {
+        for (auto [chip, _] : local_chips_to_pci_device_id) {
             local_chips.insert(chip);
         }
         std::unordered_set<chip_id_t> remote_chips;
@@ -98,12 +97,14 @@ TEST(ApiClusterDescriptorTest, TestAllOfflineClusterDescriptors) {
             }
         }
 
-        std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> chips_grouped_by_closest_mmio = cluster_desc->get_chips_grouped_by_closest_mmio();
+        std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> chips_grouped_by_closest_mmio =
+            cluster_desc->get_chips_grouped_by_closest_mmio();
     }
 }
 
 TEST(ApiClusterDescriptorTest, SeparateClusters) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(test_utils::GetAbsPath("tests/api/cluster_descriptor_examples/wormhole_2xN300_unconnected.yaml"));
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(
+        test_utils::GetAbsPath("tests/api/cluster_descriptor_examples/wormhole_2xN300_unconnected.yaml"));
 
     auto all_chips = cluster_desc->get_all_chips();
     DisjointSet<chip_id_t> chip_clusters;
@@ -112,9 +113,9 @@ TEST(ApiClusterDescriptorTest, SeparateClusters) {
     }
 
     // Merge into clusters of chips.
-    for (auto connection: cluster_desc->get_ethernet_connections()) {
+    for (auto connection : cluster_desc->get_ethernet_connections()) {
         chip_id_t chip = connection.first;
-        for (auto [channel, remote_chip_and_channel]: connection.second) {
+        for (auto [channel, remote_chip_and_channel] : connection.second) {
             chip_id_t remote_chip = std::get<0>(remote_chip_and_channel);
             chip_clusters.merge(chip, remote_chip);
         }

--- a/tests/api/test_mockup_device.cpp
+++ b/tests/api/test_mockup_device.cpp
@@ -25,14 +25,18 @@ std::string get_env_arch_name() {
 }
 
 tt::ARCH get_arch_from_string(const std::string &arch_str) {
-    if (arch_str == "grayskull" || arch_str == "GRAYSKULL")
+    if (arch_str == "grayskull" || arch_str == "GRAYSKULL") {
         return tt::ARCH::GRAYSKULL;
-    if (arch_str == "wormhole_b0" || arch_str == "WORMHOLE_B0")
+    }
+    if (arch_str == "wormhole_b0" || arch_str == "WORMHOLE_B0") {
         return tt::ARCH::WORMHOLE_B0;
-    if (arch_str == "blackhole" || arch_str == "BLACKHOLE")
+    }
+    if (arch_str == "blackhole" || arch_str == "BLACKHOLE") {
         return tt::ARCH::BLACKHOLE;
-    if (arch_str == "Invalid" || arch_str == "INVALID")
+    }
+    if (arch_str == "Invalid" || arch_str == "INVALID") {
         return tt::ARCH::Invalid;
+    }
 
     throw std::runtime_error(arch_str + " is not recognized as tt::ARCH.");
 }
@@ -41,11 +45,16 @@ std::string get_soc_descriptor_file(tt::ARCH arch) {
     // const std::string umd_root = get_umd_root();
 
     switch (arch) {
-        case tt::ARCH::GRAYSKULL: return test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml");
-        case tt::ARCH::WORMHOLE_B0: return  test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml");
-        case tt::ARCH::BLACKHOLE: return  test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml");
-        case tt::ARCH::Invalid: throw std::runtime_error("Invalid arch not supported");
-        default: throw std::runtime_error("Unsupported device architecture");
+        case tt::ARCH::GRAYSKULL:
+            return test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml");
+        case tt::ARCH::WORMHOLE_B0:
+            return test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml");
+        case tt::ARCH::BLACKHOLE:
+            return test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml");
+        case tt::ARCH::Invalid:
+            throw std::runtime_error("Invalid arch not supported");
+        default:
+            throw std::runtime_error("Unsupported device architecture");
     }
 }
 

--- a/tests/api/test_soc_descriptor_bh.cpp
+++ b/tests/api/test_soc_descriptor_bh.cpp
@@ -3,12 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "gtest/gtest.h"
-
 #include "device/tt_soc_descriptor.h"
+#include "gtest/gtest.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/test_utils/soc_desc_test_utils.hpp"
-
 
 // Blackhole workers - x-y annotation
 // functional_workers:
@@ -28,8 +26,8 @@
 // Tests that all physical coordinates are same as all virtual coordinates
 // when there is no harvesting.
 TEST(SocDescriptor, SocDescriptorBHNoHarvesting) {
-
-    tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), 0);
+    tt_SocDescriptor soc_desc =
+        tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), 0);
 
     // We expect full grid size since there is no harvesting.
     tt_xy_pair worker_grid_size = soc_desc.worker_grid_size;
@@ -38,7 +36,7 @@ TEST(SocDescriptor, SocDescriptorBHNoHarvesting) {
             tt_logical_coords logical_coords = tt_logical_coords(x, y);
             tt_virtual_coords virtual_coords = soc_desc.to_virtual_coords(logical_coords);
             tt_physical_coords physical_coords = soc_desc.to_physical_coords(logical_coords);
-            
+
             // Virtual and physical coordinates should be the same.
             EXPECT_EQ(physical_coords, virtual_coords);
         }
@@ -49,7 +47,8 @@ TEST(SocDescriptor, SocDescriptorBHNoHarvesting) {
 // We expect that the top left core will have virtual and physical coordinates (1, 2) and (2, 2) for
 // the logical coordinates if the first row is harvested.
 TEST(SocDescriptor, SocDescriptorBHTopLeftCore) {
-    tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), 1);
+    tt_SocDescriptor soc_desc =
+        tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), 1);
     tt_xy_pair worker_grid_size = soc_desc.worker_grid_size;
 
     tt_logical_coords logical_coords = tt_logical_coords(0, 0);
@@ -65,13 +64,12 @@ TEST(SocDescriptor, SocDescriptorBHTopLeftCore) {
 
 // Test logical to physical coordinate translation.
 // For the full grid of logical coordinates we expect that there are no duplicates of physical coordinates.
-// For the reverse mapping back of physical to logical coordinates we expect that same logical coordinates are returned as from original mapping.
+// For the reverse mapping back of physical to logical coordinates we expect that same logical coordinates are returned
+// as from original mapping.
 TEST(SocDescriptor, SocDescriptorBHLogicalPhysicalMapping) {
-
     const std::size_t max_num_harvested_x = 14;
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"));
     for (std::size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_x); harvesting_mask++) {
-       
         soc_desc.perform_harvesting(harvesting_mask);
 
         std::map<tt_logical_coords, tt_physical_coords> logical_to_physical;
@@ -97,7 +95,7 @@ TEST(SocDescriptor, SocDescriptorBHLogicalPhysicalMapping) {
         for (auto it : logical_to_physical) {
             tt_physical_coords physical_coords = it.second;
             tt_logical_coords logical_coords = soc_desc.to_logical_coords(physical_coords);
-            
+
             // Expect that reverse mapping of physical coordinates gives the same logical coordinates
             // using which we got the physical coordinates.
             EXPECT_EQ(it.first, logical_coords);
@@ -107,13 +105,12 @@ TEST(SocDescriptor, SocDescriptorBHLogicalPhysicalMapping) {
 
 // Test logical to virtual coordinate translation.
 // For the full grid of logical coordinates we expect that there are no duplicates of virtual coordinates.
-// For the reverse mapping back of virtual to logical coordinates we expect that same logical coordinates are returned as from original mapping.
+// For the reverse mapping back of virtual to logical coordinates we expect that same logical coordinates are returned
+// as from original mapping.
 TEST(SocDescriptor, SocDescriptorBHLogicalVirtualMapping) {
-
     const std::size_t max_num_harvested_x = 14;
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"));
     for (std::size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_x); harvesting_mask++) {
-        
         soc_desc.perform_harvesting(harvesting_mask);
 
         std::map<tt_logical_coords, tt_virtual_coords> logical_to_virtual;
@@ -149,13 +146,12 @@ TEST(SocDescriptor, SocDescriptorBHLogicalVirtualMapping) {
 
 // Test logical to translated coordinate translation.
 // For the full grid of logical coordinates we expect that there are no duplicates of translated coordinates.
-// For the reverse mapping back of translated to logical coordinates we expect that same logical coordinates are returned as from original mapping.
+// For the reverse mapping back of translated to logical coordinates we expect that same logical coordinates are
+// returned as from original mapping.
 TEST(SocDescriptor, SocDescriptorBHLogicalTranslatedMapping) {
-
     const std::size_t max_num_harvested_x = 14;
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"));
     for (std::size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_x); harvesting_mask++) {
-        
         soc_desc.perform_harvesting(harvesting_mask);
 
         std::map<tt_logical_coords, tt_translated_coords> logical_to_translated;
@@ -170,7 +166,8 @@ TEST(SocDescriptor, SocDescriptorBHLogicalTranslatedMapping) {
                 tt_translated_coords translated_coords = soc_desc.to_translated_coords(logical_coords);
                 logical_to_translated[logical_coords] = translated_coords;
 
-                // Expect that logical to translated translation is 1-1 mapping. No duplicates for translated coordinates.
+                // Expect that logical to translated translation is 1-1 mapping. No duplicates for translated
+                // coordinates.
                 EXPECT_EQ(translated_coords_set.count(translated_coords), 0);
                 translated_coords_set.insert(translated_coords);
             }
@@ -196,7 +193,7 @@ TEST(SocDescriptor, SocDescriptorBHVirtualEqualTranslated) {
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"));
     for (std::size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_x); harvesting_mask++) {
         soc_desc.perform_harvesting(harvesting_mask);
-        
+
         std::size_t num_harvested_x = test_utils::get_num_harvested(harvesting_mask);
 
         for (std::size_t x = 0; x < soc_desc.worker_grid_size.x - num_harvested_x; x++) {
@@ -209,5 +206,5 @@ TEST(SocDescriptor, SocDescriptorBHVirtualEqualTranslated) {
                 EXPECT_EQ(translated_coords, virtual_coords);
             }
         }
-    } 
+    }
 }

--- a/tests/api/test_soc_descriptor_gs.cpp
+++ b/tests/api/test_soc_descriptor_gs.cpp
@@ -3,9 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "gtest/gtest.h"
-
 #include "device/tt_soc_descriptor.h"
+#include "gtest/gtest.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/test_utils/soc_desc_test_utils.hpp"
 
@@ -27,7 +26,6 @@
 // Tests that all physical coordinates are same as all virtual coordinates
 // when there is no harvesting.
 TEST(SocDescriptor, SocDescriptorGSNoHarvesting) {
-
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"));
 
     // We expect full grid size since there is no harvesting.
@@ -37,7 +35,7 @@ TEST(SocDescriptor, SocDescriptorGSNoHarvesting) {
             tt_logical_coords logical_coords = tt_logical_coords(x, y);
             tt_virtual_coords virtual_coords = soc_desc.to_virtual_coords(logical_coords);
             tt_physical_coords physical_coords = soc_desc.to_physical_coords(logical_coords);
-            
+
             // Virtual and physical coordinates should be the same.
             EXPECT_EQ(physical_coords, virtual_coords);
         }
@@ -48,7 +46,6 @@ TEST(SocDescriptor, SocDescriptorGSNoHarvesting) {
 // We expect that the top left core will have virtual and physical coordinates (1, 1) and (1, 2) for
 // the logical coordinates if the first row is harvested.
 TEST(SocDescriptor, SocDescriptorGSTopLeftCore) {
-
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"));
     tt_xy_pair worker_grid_size = soc_desc.worker_grid_size;
 
@@ -75,7 +72,7 @@ TEST(SocDescriptor, SocDescriptorGSTranslatingCoords) {
             tt_virtual_coords virtual_coords = soc_desc.to_virtual_coords(logical_coords);
             tt_physical_coords physical_coords = soc_desc.to_physical_coords(logical_coords);
             tt_translated_coords translated_coords = soc_desc.to_translated_coords(logical_coords);
-            
+
             // Virtual, physical and translated coordinates should be the same.
             EXPECT_EQ(physical_coords, virtual_coords);
             EXPECT_EQ(physical_coords, translated_coords);
@@ -85,9 +82,9 @@ TEST(SocDescriptor, SocDescriptorGSTranslatingCoords) {
 
 // Test logical to physical coordinate translation.
 // For the full grid of logical coordinates we expect that there are no duplicates of physical coordinates.
-// For the reverse mapping back of physical to logical coordinates we expect that same logical coordinates are returned as from original mapping.
+// For the reverse mapping back of physical to logical coordinates we expect that same logical coordinates are returned
+// as from original mapping.
 TEST(SocDescriptor, SocDescriptorGSLogicalPhysicalMapping) {
-
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"));
 
     std::map<tt_logical_coords, tt_physical_coords> logical_to_physical;
@@ -111,7 +108,7 @@ TEST(SocDescriptor, SocDescriptorGSLogicalPhysicalMapping) {
     for (auto it : logical_to_physical) {
         tt_physical_coords physical_coords = it.second;
         tt_logical_coords logical_coords = soc_desc.to_logical_coords(physical_coords);
-        
+
         // Expect that reverse mapping of physical coordinates gives the same logical coordinates
         // using which we got the physical coordinates.
         EXPECT_EQ(it.first, logical_coords);
@@ -120,9 +117,9 @@ TEST(SocDescriptor, SocDescriptorGSLogicalPhysicalMapping) {
 
 // Test logical to virtual coordinate translation.
 // For the full grid of logical coordinates we expect that there are no duplicates of virtual coordinates.
-// For the reverse mapping back of virtual to logical coordinates we expect that same logical coordinates are returned as from original mapping.
+// For the reverse mapping back of virtual to logical coordinates we expect that same logical coordinates are returned
+// as from original mapping.
 TEST(SocDescriptor, SocDescriptorGSLogicalVirtualMapping) {
-
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"));
 
     std::map<tt_logical_coords, tt_virtual_coords> logical_to_virtual;

--- a/tests/api/test_soc_descriptor_wh.cpp
+++ b/tests/api/test_soc_descriptor_wh.cpp
@@ -3,35 +3,33 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "gtest/gtest.h"
-
 #include "device/tt_soc_descriptor.h"
+#include "gtest/gtest.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/test_utils/soc_desc_test_utils.hpp"
-
 
 // Wormhole workers - x-y annotation
 // functional_workers:
 //   [
-//    1-1,   2-1,   3-1,   4-1,   6-1,   7-1,   8-1,   9-1, 
-//    1-2,   2-2,   3-2,   4-2,   6-2,   7-2,   8-2,   9-2, 
-//    1-3,   2-3,   3-3,   4-3,   6-3,   7-3,   8-3,   9-3, 
-//    1-4,   2-4,   3-4,   4-4,   6-4,   7-4,   8-4,   9-4, 
-//    1-5,   2-5,   3-5,   4-5,   6-5,   7-5,   8-5,   9-5, 
-//    1-7,   2-7,   3-7,   4-7,   6-7,   7-7,   8-7,   9-7, 
-//    1-8,   2-8,   3-8,   4-8,   6-8,   7-8,   8-8,   9-8, 
-//    1-9,   2-9,   3-9,   4-9,   6-9,   7-9,   8-9,   9-9, 
-//    1-10,  2-10,  3-10,  4-10,  6-10,  7-10,  8-10,  9-10, 
-//    1-11,  2-11,  3-11,  4-11,  6-11,  7-11,  8-11,  9-11, 
+//    1-1,   2-1,   3-1,   4-1,   6-1,   7-1,   8-1,   9-1,
+//    1-2,   2-2,   3-2,   4-2,   6-2,   7-2,   8-2,   9-2,
+//    1-3,   2-3,   3-3,   4-3,   6-3,   7-3,   8-3,   9-3,
+//    1-4,   2-4,   3-4,   4-4,   6-4,   7-4,   8-4,   9-4,
+//    1-5,   2-5,   3-5,   4-5,   6-5,   7-5,   8-5,   9-5,
+//    1-7,   2-7,   3-7,   4-7,   6-7,   7-7,   8-7,   9-7,
+//    1-8,   2-8,   3-8,   4-8,   6-8,   7-8,   8-8,   9-8,
+//    1-9,   2-9,   3-9,   4-9,   6-9,   7-9,   8-9,   9-9,
+//    1-10,  2-10,  3-10,  4-10,  6-10,  7-10,  8-10,  9-10,
+//    1-11,  2-11,  3-11,  4-11,  6-11,  7-11,  8-11,  9-11,
 //   ]
 
 // Tests that all physical coordinates are same as all virtual coordinates
 // when there is no harvesting.
 TEST(SocDescriptor, SocDescriptorWHNoHarvesting) {
-
     const std::size_t harvesting_mask = 0;
-    
-    tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), harvesting_mask);
+
+    tt_SocDescriptor soc_desc =
+        tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), harvesting_mask);
 
     // We expect full grid size since there is no harvesting.
     tt_xy_pair worker_grid_size = soc_desc.worker_grid_size;
@@ -51,10 +49,10 @@ TEST(SocDescriptor, SocDescriptorWHNoHarvesting) {
 // We expect that the top left core will have virtual and physical coordinates (1, 1) and (1, 2) for
 // the logical coordinates if the first row is harvested.
 TEST(SocDescriptor, SocDescriptorWHTopLeftCore) {
-
     const std::size_t harvesting_mask = 1;
 
-    tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), harvesting_mask);
+    tt_SocDescriptor soc_desc =
+        tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), harvesting_mask);
     tt_xy_pair worker_grid_size = soc_desc.worker_grid_size;
 
     tt_logical_coords logical_coords = tt_logical_coords(0, 0);
@@ -70,13 +68,12 @@ TEST(SocDescriptor, SocDescriptorWHTopLeftCore) {
 
 // Test logical to physical coordinate translation.
 // For the full grid of logical coordinates we expect that there are no duplicates of physical coordinates.
-// For the reverse mapping back of physical to logical coordinates we expect that same logical coordinates are returned as from original mapping.
+// For the reverse mapping back of physical to logical coordinates we expect that same logical coordinates are returned
+// as from original mapping.
 TEST(SocDescriptor, SocDescriptorWHLogicalPhysicalMapping) {
-
     const std::size_t max_num_harvested_y = 10;
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"));
     for (std::size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_y); harvesting_mask++) {
-
         soc_desc.perform_harvesting(harvesting_mask);
 
         std::map<tt_logical_coords, tt_physical_coords> logical_to_physical;
@@ -96,8 +93,9 @@ TEST(SocDescriptor, SocDescriptorWHLogicalPhysicalMapping) {
                 physical_coords_set.insert(physical_coords);
             }
         }
-        
-        // Expect that the number of physical coordinates is equal to the number of workers minus the number of harvested rows.
+
+        // Expect that the number of physical coordinates is equal to the number of workers minus the number of
+        // harvested rows.
         EXPECT_EQ(physical_coords_set.size(), worker_grid_size.x * (worker_grid_size.y - num_harvested_y));
 
         for (auto it : logical_to_physical) {
@@ -113,13 +111,12 @@ TEST(SocDescriptor, SocDescriptorWHLogicalPhysicalMapping) {
 
 // Test logical to virtual coordinate translation.
 // For the full grid of logical coordinates we expect that there are no duplicates of virtual coordinates.
-// For the reverse mapping back of virtual to logical coordinates we expect that same logical coordinates are returned as from original mapping.
+// For the reverse mapping back of virtual to logical coordinates we expect that same logical coordinates are returned
+// as from original mapping.
 TEST(SocDescriptor, SocDescriptorWHLogicalVirtualMapping) {
-
     const std::size_t max_num_harvested_y = 10;
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"));
     for (std::size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_y); harvesting_mask++) {
-
         soc_desc.perform_harvesting(harvesting_mask);
 
         std::map<tt_logical_coords, tt_virtual_coords> logical_to_virtual;
@@ -153,17 +150,18 @@ TEST(SocDescriptor, SocDescriptorWHLogicalVirtualMapping) {
 
 // Test top left corner translation from logical to translated coordinates.
 TEST(SocDescriptor, SocDescriptorWHLogicalTranslatedTopLeft) {
-
     const std::size_t translated_x_start = 18;
     const std::size_t translated_y_start = 18;
-    const tt_translated_coords expected_translated_coords = tt_translated_coords(translated_x_start, translated_y_start);
+    const tt_translated_coords expected_translated_coords =
+        tt_translated_coords(translated_x_start, translated_y_start);
 
     const std::size_t max_num_harvested_y = 10;
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"));
-    // We go up to numbers less than 2^10 - 1 to test all possible harvesting masks, we don't want to try to convert if everything is harvested.
+    // We go up to numbers less than 2^10 - 1 to test all possible harvesting masks, we don't want to try to convert if
+    // everything is harvested.
     for (std::size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_y) - 1; harvesting_mask++) {
         soc_desc.perform_harvesting(harvesting_mask);
-        
+
         tt_xy_pair worker_grid_size = soc_desc.worker_grid_size;
 
         std::size_t num_harvested_y = test_utils::get_num_harvested(harvesting_mask);

--- a/tests/blackhole/test_bh_common.h
+++ b/tests/blackhole/test_bh_common.h
@@ -3,12 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include "tt_xy_pair.h"
-#include "tt_cluster_descriptor.h"
 #include "cluster.h"
-
-#include "tests/test_utils/stimulus_generators.hpp"
 #include "eth_l1_address_map.h"
+#include "tests/test_utils/stimulus_generators.hpp"
+#include "tt_cluster_descriptor.h"
+#include "tt_xy_pair.h"
 
 using namespace tt::umd;
 
@@ -16,68 +15,75 @@ namespace tt::umd::test::utils {
 
 static void set_params_for_remote_txn(Cluster& device) {
     // Populate address map and NOC parameters that the driver needs for remote transactions
-    device.set_device_l1_address_params({l1_mem::address_map::L1_BARRIER_BASE, eth_l1_mem::address_map::ERISC_BARRIER_BASE, eth_l1_mem::address_map::FW_VERSION_ADDR});
+    device.set_device_l1_address_params(
+        {l1_mem::address_map::L1_BARRIER_BASE,
+         eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+         eth_l1_mem::address_map::FW_VERSION_ADDR});
 }
 
 class BlackholeTestFixture : public ::testing::Test {
- protected:
-  // You can remove any or all of the following functions if their bodies would
-  // be empty.
+protected:
+    // You can remove any or all of the following functions if their bodies would
+    // be empty.
 
-  std::unique_ptr<Cluster> device;
+    std::unique_ptr<Cluster> device;
 
-  BlackholeTestFixture() {
+    BlackholeTestFixture() {}
 
-  }
-
-  ~BlackholeTestFixture() override {
-     // You can do clean-up work that doesn't throw exceptions here.
-  }
-
-  virtual int get_detected_num_chips() = 0;
-  virtual bool is_test_skipped() = 0;
-
-  // If the constructor and destructor are not enough for setting up
-  // and cleaning up each test, you can define the following methods:
-
-  void SetUp() override {
-    // Code here will be called immediately after the constructor (right
-    // before each test).
-
-    if (is_test_skipped()) {
-        GTEST_SKIP() << "Test is skipped due to incorrect number of chips";
+    ~BlackholeTestFixture() override {
+        // You can do clean-up work that doesn't throw exceptions here.
     }
 
-    // std::cout << "Setting Up Test." << std::endl;
-    assert(get_detected_num_chips() > 0);
-    auto devices = std::vector<chip_id_t>(get_detected_num_chips());
-    std::iota(devices.begin(), devices.end(), 0);
-    std::set<chip_id_t> target_devices = {devices.begin(), devices.end()};
-    uint32_t num_host_mem_ch_per_mmio_device = 1;
-    device = std::make_unique<Cluster>(test_utils::GetAbsPath(SOC_DESC_PATH), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true);
-    assert(device != nullptr);
-    assert(device->get_cluster_description()->get_number_of_chips() == get_detected_num_chips());
+    virtual int get_detected_num_chips() = 0;
+    virtual bool is_test_skipped() = 0;
 
-    set_params_for_remote_txn(*device);
+    // If the constructor and destructor are not enough for setting up
+    // and cleaning up each test, you can define the following methods:
 
-    tt_device_params default_params;
-    device->start_device(default_params);
+    void SetUp() override {
+        // Code here will be called immediately after the constructor (right
+        // before each test).
 
-    device->deassert_risc_reset();
+        if (is_test_skipped()) {
+            GTEST_SKIP() << "Test is skipped due to incorrect number of chips";
+        }
 
-    device->wait_for_non_mmio_flush();
-  }
+        // std::cout << "Setting Up Test." << std::endl;
+        assert(get_detected_num_chips() > 0);
+        auto devices = std::vector<chip_id_t>(get_detected_num_chips());
+        std::iota(devices.begin(), devices.end(), 0);
+        std::set<chip_id_t> target_devices = {devices.begin(), devices.end()};
+        uint32_t num_host_mem_ch_per_mmio_device = 1;
+        device = std::make_unique<Cluster>(
+            test_utils::GetAbsPath(SOC_DESC_PATH),
+            tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+            target_devices,
+            num_host_mem_ch_per_mmio_device,
+            false,
+            true,
+            true);
+        assert(device != nullptr);
+        assert(device->get_cluster_description()->get_number_of_chips() == get_detected_num_chips());
 
-  void TearDown() override {
-    // Code here will be called immediately after each test (right
-    // before the destructor).
+        set_params_for_remote_txn(*device);
 
-    if (!is_test_skipped()) {
-        // std::cout << "Tearing Down Test." << std::endl;
-        device->close_device();
+        tt_device_params default_params;
+        device->start_device(default_params);
+
+        device->deassert_risc_reset();
+
+        device->wait_for_non_mmio_flush();
     }
-  }
 
+    void TearDown() override {
+        // Code here will be called immediately after each test (right
+        // before the destructor).
+
+        if (!is_test_skipped()) {
+            // std::cout << "Tearing Down Test." << std::endl;
+            device->close_device();
+        }
+    }
 };
 
-} // namespace tt::umd::test::utils
+}  // namespace tt::umd::test::utils

--- a/tests/blackhole/test_silicon_driver_bh.cpp
+++ b/tests/blackhole/test_silicon_driver_bh.cpp
@@ -2,30 +2,41 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "gtest/gtest.h"
 #include <cluster.h>
-#include "eth_l1_address_map.h"
-#include "l1_address_map.h"
-#include "host_mem_address_map.h"
-#include <thread>
+
 #include <memory>
+#include <thread>
 
 #include "device/blackhole/blackhole_implementation.h"
 #include "device/tt_cluster_descriptor.h"
-#include "tests/test_utils/generate_cluster_desc.hpp"
+#include "eth_l1_address_map.h"
+#include "gtest/gtest.h"
+#include "host_mem_address_map.h"
+#include "l1_address_map.h"
 #include "tests/test_utils/device_test_utils.hpp"
+#include "tests/test_utils/generate_cluster_desc.hpp"
 
 using namespace tt::umd;
 
 void set_params_for_remote_txn(Cluster& device) {
     // Populate address map and NOC parameters that the driver needs for remote transactions
-    device.set_device_l1_address_params({l1_mem::address_map::L1_BARRIER_BASE, eth_l1_mem::address_map::ERISC_BARRIER_BASE, eth_l1_mem::address_map::FW_VERSION_ADDR});
+    device.set_device_l1_address_params(
+        {l1_mem::address_map::L1_BARRIER_BASE,
+         eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+         eth_l1_mem::address_map::FW_VERSION_ADDR});
 }
 
 std::int32_t get_static_tlb_index(tt_xy_pair target) {
-    bool is_eth_location = std::find(std::begin(tt::umd::blackhole::ETH_LOCATIONS), std::end(tt::umd::blackhole::ETH_LOCATIONS), target) != std::end(tt::umd::blackhole::ETH_LOCATIONS);
-    bool is_tensix_location = std::find(std::begin(tt::umd::blackhole::T6_X_LOCATIONS), std::end(tt::umd::blackhole::T6_X_LOCATIONS), target.x) != std::end(tt::umd::blackhole::T6_X_LOCATIONS) &&
-                            std::find(std::begin(tt::umd::blackhole::T6_Y_LOCATIONS), std::end(tt::umd::blackhole::T6_Y_LOCATIONS), target.y) != std::end(tt::umd::blackhole::T6_Y_LOCATIONS);
+    bool is_eth_location =
+        std::find(std::begin(tt::umd::blackhole::ETH_LOCATIONS), std::end(tt::umd::blackhole::ETH_LOCATIONS), target) !=
+        std::end(tt::umd::blackhole::ETH_LOCATIONS);
+    bool is_tensix_location =
+        std::find(
+            std::begin(tt::umd::blackhole::T6_X_LOCATIONS), std::end(tt::umd::blackhole::T6_X_LOCATIONS), target.x) !=
+            std::end(tt::umd::blackhole::T6_X_LOCATIONS) &&
+        std::find(
+            std::begin(tt::umd::blackhole::T6_Y_LOCATIONS), std::end(tt::umd::blackhole::T6_Y_LOCATIONS), target.y) !=
+            std::end(tt::umd::blackhole::T6_Y_LOCATIONS);
     if (is_eth_location) {
         if (target.y == 6) {
             target.y = 1;
@@ -61,7 +72,8 @@ std::int32_t get_static_tlb_index(tt_xy_pair target) {
 
 std::set<chip_id_t> get_target_devices() {
     std::set<chip_id_t> target_devices;
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq = tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
+        tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
     for (int i = 0; i < cluster_desc_uniq->get_number_of_chips(); i++) {
         target_devices.insert(i);
     }
@@ -73,8 +85,15 @@ TEST(SiliconDriverBH, CreateDestroy) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     tt_device_params default_params;
     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
-    for(int i = 0; i < 50; i++) {
-        Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, false);
+    for (int i = 0; i < 50; i++) {
+        Cluster device = Cluster(
+            test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"),
+            tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+            target_devices,
+            num_host_mem_ch_per_mmio_device,
+            false,
+            true,
+            false);
         set_params_for_remote_txn(device);
         device.start_device(default_params);
         device.deassert_risc_reset();
@@ -85,44 +104,52 @@ TEST(SiliconDriverBH, CreateDestroy) {
 // TEST(SiliconDriverWH, Harvesting) {
 //     std::set<chip_id_t> target_devices = {0, 1};
 //     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 30}, {1, 60}};
-    
+
 //     {
-//         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq = tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
-//         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
-//             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula system";
+//         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
+//         tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path()); if
+//         (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
+//             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
+//             system";
 //         }
 //     }
 
 //     uint32_t num_host_mem_ch_per_mmio_device = 1;
-//     Cluster device = Cluster("./tests/soc_descs/wormhole_b0_8x10.yaml", tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true, simulated_harvesting_masks);
-//     auto sdesc_per_chip = device.get_virtual_soc_descriptors();
+//     Cluster device = Cluster("./tests/soc_descs/wormhole_b0_8x10.yaml",
+//     tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false,
+//     true, true, simulated_harvesting_masks); auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
 //     ASSERT_EQ(device.using_harvested_soc_descriptors(), true) << "Expected Driver to have performed harvesting";
 
 //     for(const auto& chip : sdesc_per_chip) {
-//         ASSERT_EQ(chip.second.workers.size(), 48) << "Expected SOC descriptor with harvesting to have 48 workers for chip" << chip.first;
+//         ASSERT_EQ(chip.second.workers.size(), 48) << "Expected SOC descriptor with harvesting to have 48 workers for
+//         chip" << chip.first;
 //     }
-//     ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(0), 30) << "Expected first chip to have harvesting mask of 30";
-//     ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(1), 60) << "Expected second chip to have harvesting mask of 60";
+//     ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(0), 30) << "Expected first chip to have harvesting
+//     mask of 30"; ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(1), 60) << "Expected second chip to
+//     have harvesting mask of 60";
 // }
 
 // TEST(SiliconDriverWH, CustomSocDesc) {
 //     std::set<chip_id_t> target_devices = {0, 1};
 //     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 30}, {1, 60}};
 //     {
-//         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq = tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
-//         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
-//             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula system";
+//         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
+//         tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path()); if
+//         (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
+//             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
+//             system";
 //         }
 //     }
 
 //     uint32_t num_host_mem_ch_per_mmio_device = 1;
 //     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
-//     Cluster device = Cluster("./tests/soc_descs/wormhole_b0_1x1.yaml", tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, false, simulated_harvesting_masks);
-//     auto sdesc_per_chip = device.get_virtual_soc_descriptors();
-    
-//     ASSERT_EQ(device.using_harvested_soc_descriptors(), false) << "SOC descriptors should not be modified when harvesting is disabled";
-//     for(const auto& chip : sdesc_per_chip) {
+//     Cluster device = Cluster("./tests/soc_descs/wormhole_b0_1x1.yaml",
+//     tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false,
+//     true, false, simulated_harvesting_masks); auto sdesc_per_chip = device.get_virtual_soc_descriptors();
+
+//     ASSERT_EQ(device.using_harvested_soc_descriptors(), false) << "SOC descriptors should not be modified when
+//     harvesting is disabled"; for(const auto& chip : sdesc_per_chip) {
 //         ASSERT_EQ(chip.second.workers.size(), 1) << "Expected 1x1 SOC descriptor to be unmodified by driver";
 //     }
 // }
@@ -136,30 +163,34 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //     std::set<chip_id_t> target_devices = {0, 1};
 //     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 30}, {1, 60}};
 //     {
-//         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq = tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
-//         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
-//             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula system";
+//         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
+//         tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path()); if
+//         (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
+//             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
+//             system";
 //         }
 //     }
 
 //     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    
-//     Cluster device = Cluster("./tests/soc_descs/wormhole_b0_8x10.yaml", tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true, simulated_harvesting_masks);
-//     set_params_for_remote_txn(device);
-//     auto mmio_devices = device.get_target_mmio_device_ids();
-    
+
+//     Cluster device = Cluster("./tests/soc_descs/wormhole_b0_8x10.yaml",
+//     tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false,
+//     true, true, simulated_harvesting_masks); set_params_for_remote_txn(device); auto mmio_devices =
+//     device.get_target_mmio_device_ids();
+
 //     for(int i = 0; i < target_devices.size(); i++) {
 //         // Iterate over MMIO devices and only setup static TLBs for worker cores
 //         if(std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
 //             auto& sdesc = device.get_virtual_soc_descriptors().at(i);
 //             for(auto& core : sdesc.workers) {
-//                 // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.  
-//                 device.configure_tlb(i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
+//                 // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
+//                 device.configure_tlb(i, core, get_static_tlb_index_callback(core),
+//                 l1_mem::address_map::NCRISC_FIRMWARE_BASE);
 //             }
-//         } 
+//         }
 //     }
 //     device.setup_core_to_tlb_map(get_static_tlb_index_callback);
-    
+
 //     tt_device_params default_params;
 //     device.start_device(default_params);
 //     device.deassert_risc_reset();
@@ -169,26 +200,29 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //     std::vector<uint32_t> readback_vec = {};
 //     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-
 //     for(int i = 0; i < target_devices.size(); i++) {
 //         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
 //         std::uint32_t dynamic_write_address = 0x40000000;
-//         for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
+//         for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped
+//         addresses
 //             for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-//                 device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "");
-//                 device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), dynamic_write_address, "SMALL_READ_WRITE_TLB");
-//                 device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over ethernet were commited
-                
+//                 device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t),
+//                 tt_cxy_pair(i, core), address, ""); device.write_to_device(vector_to_write.data(),
+//                 vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), dynamic_write_address,
+//                 "SMALL_READ_WRITE_TLB"); device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over
+//                 ethernet were commited
+
 //                 test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "");
-//                 test_utils::read_data_from_device(device, dynamic_readback_vec, tt_cxy_pair(i, core), dynamic_write_address, 40, "SMALL_READ_WRITE_TLB");
-//                 ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
-//                 ASSERT_EQ(vector_to_write, dynamic_readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
-//                 device.wait_for_non_mmio_flush();
-                
-//                 device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), dynamic_write_address, "SMALL_READ_WRITE_TLB"); // Clear any written data
-//                 device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, ""); // Clear any written data
-//                 device.wait_for_non_mmio_flush();
-//                 readback_vec = {};
+//                 test_utils::read_data_from_device(device, dynamic_readback_vec, tt_cxy_pair(i, core),
+//                 dynamic_write_address, 40, "SMALL_READ_WRITE_TLB"); ASSERT_EQ(vector_to_write, readback_vec) <<
+//                 "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+//                 ASSERT_EQ(vector_to_write, dynamic_readback_vec) << "Vector read back from core " << core.x << "-" <<
+//                 core.y << "does not match what was written"; device.wait_for_non_mmio_flush();
+
+//                 device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core),
+//                 dynamic_write_address, "SMALL_READ_WRITE_TLB"); // Clear any written data
+//                 device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core),
+//                 address, ""); // Clear any written data device.wait_for_non_mmio_flush(); readback_vec = {};
 //                 dynamic_readback_vec = {};
 //             }
 //             address += 0x20; // Increment by uint32_t size for each write
@@ -199,45 +233,51 @@ TEST(SiliconDriverBH, CreateDestroy) {
 // }
 
 TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
-    auto get_static_tlb_index_callback = [] (tt_xy_pair target) {
-        return get_static_tlb_index(target);
-    };
+    auto get_static_tlb_index_callback = [](tt_xy_pair target) { return get_static_tlb_index(target); };
 
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true);
+
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        true);
     set_params_for_remote_txn(device);
     auto mmio_devices = device.get_target_mmio_device_ids();
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over MMIO devices and only setup static TLBs for worker cores
-        if(std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
+        if (std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
             auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-            for(auto& core : sdesc.workers) {
-                // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.  
-                device.configure_tlb(i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
+            for (auto& core : sdesc.workers) {
+                // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
+                device.configure_tlb(
+                    i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
             }
             device.setup_core_to_tlb_map(i, get_static_tlb_index_callback);
-        } 
+        }
     }
-    
+
     tt_device_params default_params;
     device.start_device(default_params);
     device.deassert_risc_reset();
 
     std::vector<uint32_t> unaligned_sizes = {3, 14, 21, 255, 362, 430, 1022, 1023, 1025};
-    for(int i = 0; i < target_devices.size(); i++) {
-        for(const auto& size : unaligned_sizes) {
+    for (int i = 0; i < target_devices.size(); i++) {
+        for (const auto& size : unaligned_sizes) {
             std::vector<uint8_t> write_vec(size, 0);
-            for(int i = 0; i < size; i++){
+            for (int i = 0; i < size; i++) {
                 write_vec[i] = size + i;
             }
             std::vector<uint8_t> readback_vec(size, 0);
             std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
-            for(int loop = 0; loop < 50; loop++){
-                for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+            for (int loop = 0; loop < 50; loop++) {
+                for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
                     device.write_to_device(write_vec.data(), size, tt_cxy_pair(i, core), address, "");
                     device.wait_for_non_mmio_flush();
                     device.read_from_device(readback_vec.data(), tt_cxy_pair(i, core), address, size, "");
@@ -251,37 +291,42 @@ TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
                 }
                 address += 0x20;
             }
-
         }
     }
     device.close_device();
 }
 
 TEST(SiliconDriverBH, StaticTLB_RW) {
-    auto get_static_tlb_index_callback = [] (tt_xy_pair target) {
-        return get_static_tlb_index(target);
-    };
+    auto get_static_tlb_index_callback = [](tt_xy_pair target) { return get_static_tlb_index(target); };
 
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true);
+
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        true);
     set_params_for_remote_txn(device);
     auto mmio_devices = device.get_target_mmio_device_ids();
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over MMIO devices and only setup static TLBs for worker cores
-        if(std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
+        if (std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
             auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-            for(auto& core : sdesc.workers) {
-                // Statically mapping a 2MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.  
-                device.configure_tlb(i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
+            for (auto& core : sdesc.workers) {
+                // Statically mapping a 2MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
+                device.configure_tlb(
+                    i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
             }
             device.setup_core_to_tlb_map(i, get_static_tlb_index_callback);
-        } 
+        }
     }
-    
+
     printf("MT: Static TLBs set\n");
 
     tt_device_params default_params;
@@ -292,31 +337,51 @@ TEST(SiliconDriverBH, StaticTLB_RW) {
     std::vector<uint32_t> readback_vec = {};
     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     // Check functionality of Static TLBs by reading adn writing from statically mapped address space
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
-        for(int loop = 0; loop < 1; loop++){ // Write to each core a 100 times at different statically mapped addresses
-            for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "");
-                device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over ethernet were commited
+        for (int loop = 0; loop < 1;
+             loop++) {  // Write to each core a 100 times at different statically mapped addresses
+            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "");
+                device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
                 test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 device.wait_for_non_mmio_flush();
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB"); // Clear any written data
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");  // Clear any written data
                 device.wait_for_non_mmio_flush();
                 readback_vec = {};
             }
-            address += 0x20; // Increment by uint32_t size for each write
+            address += 0x20;  // Increment by uint32_t size for each write
         }
     }
-    device.close_device();    
+    device.close_device();
 }
 
 TEST(SiliconDriverBH, DynamicTLB_RW) {
-    // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for each transaction
+    // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for
+    // each transaction
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true);
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        true);
 
     set_params_for_remote_txn(device);
 
@@ -329,42 +394,68 @@ TEST(SiliconDriverBH, DynamicTLB_RW) {
     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     std::vector<uint32_t> readback_vec = {};
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
-        for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
-            for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB");
-                device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over ethernet were commited
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "SMALL_READ_WRITE_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+        for (int loop = 0; loop < 100;
+             loop++) {  // Write to each core a 100 times at different statically mapped addresses
+            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
+                device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, 40, "SMALL_READ_WRITE_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 device.wait_for_non_mmio_flush();
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
                 device.wait_for_non_mmio_flush();
                 readback_vec = {};
             }
-            address += 0x20; // Increment by uint32_t size for each write
+            address += 0x20;  // Increment by uint32_t size for each write
         }
     }
     printf("Target Tensix cores completed\n");
-    
+
     // Target DRAM channel 0
     constexpr int NUM_CHANNELS = 8;
     std::vector<uint32_t> dram_vector_to_write = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
     std::uint32_t address = 0x400;
-    for(int i = 0; i < target_devices.size(); i++) {
-        for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
-            for (int ch=0; ch<NUM_CHANNELS; ch++) {
+    for (int i = 0; i < target_devices.size(); i++) {
+        for (int loop = 0; loop < 100;
+             loop++) {  // Write to each core a 100 times at different statically mapped addresses
+            for (int ch = 0; ch < NUM_CHANNELS; ch++) {
                 std::vector<tt_xy_pair> chan = device.get_virtual_soc_descriptors().at(i).dram_cores.at(ch);
                 tt_xy_pair subchan = chan.at(0);
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, subchan), address, "SMALL_READ_WRITE_TLB");
-                device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over ethernet were commited
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, subchan), address, 40, "SMALL_READ_WRITE_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << subchan.x << "-" << subchan.y << "does not match what was written";
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, subchan),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
+                device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, subchan), address, 40, "SMALL_READ_WRITE_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << subchan.x << "-"
+                                                         << subchan.y << "does not match what was written";
                 device.wait_for_non_mmio_flush();
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, subchan), address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, subchan),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
                 device.wait_for_non_mmio_flush();
                 readback_vec = {};
-                address += 0x20; // Increment by uint32_t size for each write
+                address += 0x20;  // Increment by uint32_t size for each write
             }
         }
     }
@@ -380,8 +471,15 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true);
-    
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        true);
+
     set_params_for_remote_txn(device);
 
     tt_device_params default_params;
@@ -392,11 +490,18 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
         std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
-        for(int loop = 0; loop < 100; loop++) {
-            for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+        for (int loop = 0; loop < 100; loop++) {
+            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(0, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 readback_vec = {};
             }
             address += 0x20;
@@ -407,12 +512,19 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
         std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = 0x30000000;
-        for(auto& core_ls : device.get_virtual_soc_descriptors().at(0).dram_cores) {
-            for(int loop = 0; loop < 100; loop++) {
-                for(auto& core : core_ls) {
-                    device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
-                    test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
-                    ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+        for (auto& core_ls : device.get_virtual_soc_descriptors().at(0).dram_cores) {
+            for (int loop = 0; loop < 100; loop++) {
+                for (auto& core : core_ls) {
+                    device.write_to_device(
+                        vector_to_write.data(),
+                        vector_to_write.size() * sizeof(std::uint32_t),
+                        tt_cxy_pair(0, core),
+                        address,
+                        "SMALL_READ_WRITE_TLB");
+                    test_utils::read_data_from_device(
+                        device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
+                    ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y
+                                                             << "does not match what was written";
                     readback_vec = {};
                 }
                 address += 0x20;
@@ -427,25 +539,30 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
 
 TEST(SiliconDriverBH, MultiThreadedMemBar) {
     // Have 2 threads read and write from a single device concurrently
-    // All (fairly large) transactions go through a static TLB. 
+    // All (fairly large) transactions go through a static TLB.
     // We want to make sure the memory barrier is thread/process safe.
 
     // Memory barrier flags get sent to address 0 for all channels in this test
-    auto get_static_tlb_index_callback = [] (tt_xy_pair target) {
-        return get_static_tlb_index(target);
-    };
+    auto get_static_tlb_index_callback = [](tt_xy_pair target) { return get_static_tlb_index(target); };
 
     std::set<chip_id_t> target_devices = get_target_devices();
     uint32_t base_addr = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true);
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        true);
     set_params_for_remote_txn(device);
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for functional worker cores
         auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-        for(auto& core : sdesc.workers) {
-            // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE. 
+        for (auto& core : sdesc.workers) {
+            // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
             device.configure_tlb(i, core, get_static_tlb_index_callback(core), base_addr);
         }
         device.setup_core_to_tlb_map(i, get_static_tlb_index_callback);
@@ -454,24 +571,41 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     tt_device_params default_params;
     device.start_device(default_params);
     device.deassert_risc_reset();
-    
+
     std::vector<uint32_t> readback_membar_vec = {};
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all workers
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        test_utils::read_data_from_device(
+            device,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            l1_mem::address_map::L1_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all workers
         readback_membar_vec = {};
     }
 
-    for(int chan = 0; chan <  device.get_virtual_soc_descriptors().at(0).get_num_dram_channels(); chan++) {
+    for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(0).get_num_dram_channels(); chan++) {
         auto core = device.get_virtual_soc_descriptors().at(0).get_core_for_dram_channel(chan, 0);
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all DRAM
+        test_utils::read_data_from_device(
+            device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all DRAM
         readback_membar_vec = {};
     }
-    
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all ethernet cores
+
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
+        test_utils::read_data_from_device(
+            device,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0),
+            187);  // Ensure that memory barriers were correctly initialized on all ethernet cores
         readback_membar_vec = {};
     }
 
@@ -481,38 +615,43 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     std::vector<uint32_t> vec2(2560);
     std::vector<uint32_t> zeros(2560, 0);
 
-    for(int i = 0; i < vec1.size(); i++) {
+    for (int i = 0; i < vec1.size(); i++) {
         vec1.at(i) = i;
     }
-    for(int i = 0; i < vec2.size(); i++) {
+    for (int i = 0; i < vec2.size(); i++) {
         vec2.at(i) = vec1.size() + i;
     }
     std::thread th1 = std::thread([&] {
         std::uint32_t address = base_addr;
-        for(int loop = 0; loop < 50; loop++) {
-            for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        for (int loop = 0; loop < 50; loop++) {
+            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
-                device.write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                device.write_to_device(
+                    vec1.data(), vec1.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 device.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 4*vec1.size(), "");
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(0, core), address, 4 * vec1.size(), "");
                 ASSERT_EQ(readback_vec, vec1);
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                device.write_to_device(
+                    zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 readback_vec = {};
             }
-            
         }
     });
 
     std::thread th2 = std::thread([&] {
         std::uint32_t address = base_addr + vec1.size() * 4;
-        for(int loop = 0; loop < 50; loop++) {
-            for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        for (int loop = 0; loop < 50; loop++) {
+            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
-                device.write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                device.write_to_device(
+                    vec2.data(), vec2.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 device.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 4*vec2.size(), "");
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(0, core), address, 4 * vec2.size(), "");
                 ASSERT_EQ(readback_vec, vec2);
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "") ;
+                device.write_to_device(
+                    zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 readback_vec = {};
             }
         }
@@ -521,27 +660,50 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     th1.join();
     th2.join();
 
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers end up in the correct sate for workers
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        test_utils::read_data_from_device(
+            device,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            l1_mem::address_map::L1_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0), 187);  // Ensure that memory barriers end up in the correct sate for workers
         readback_membar_vec = {};
     }
 
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers end up in the correct sate for ethernet cores
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
+        test_utils::read_data_from_device(
+            device,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0),
+            187);  // Ensure that memory barriers end up in the correct sate for ethernet cores
         readback_membar_vec = {};
     }
     device.close_device();
 }
 
-TEST(SiliconDriverBH, DISABLED_BroadcastWrite) { // Cannot broadcast to tensix/ethernet and DRAM simultaneously on Blackhole .. wait_for_non_mmio_flush() is not working as expected?
+TEST(SiliconDriverBH, DISABLED_BroadcastWrite) {  // Cannot broadcast to tensix/ethernet and DRAM simultaneously on
+                                                  // Blackhole .. wait_for_non_mmio_flush() is not working as expected?
     // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true);
+
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        true);
     set_params_for_remote_txn(device);
     auto mmio_devices = device.get_target_mmio_device_ids();
 
@@ -555,62 +717,102 @@ TEST(SiliconDriverBH, DISABLED_BroadcastWrite) { // Cannot broadcast to tensix/e
     std::set<uint32_t> rows_to_exclude_for_dram_broadcast = {};
     std::set<uint32_t> cols_to_exclude_for_dram_broadcast = {1, 2, 3, 4, 6, 7, 8, 9};
 
-    for(const auto& size : broadcast_sizes) {
+    for (const auto& size : broadcast_sizes) {
         std::vector<uint32_t> vector_to_write(size);
         std::vector<uint32_t> zeros(size);
         std::vector<uint32_t> readback_vec = {};
-        for(int i = 0; i < size; i++) {
+        for (int i = 0; i < size; i++) {
             vector_to_write[i] = i;
             zeros[i] = 0;
         }
         // Broadcast to Tensix
-        device.broadcast_write_to_cluster(vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude, "LARGE_WRITE_TLB");
-        device.wait_for_non_mmio_flush(); // flush here so we don't simultaneously broadcast to DRAM? 
+        device.broadcast_write_to_cluster(
+            vector_to_write.data(),
+            vector_to_write.size() * 4,
+            address,
+            {},
+            rows_to_exclude,
+            cols_to_exclude,
+            "LARGE_WRITE_TLB");
+        device.wait_for_non_mmio_flush();  // flush here so we don't simultaneously broadcast to DRAM?
         // Broadcast to DRAM
-        device.broadcast_write_to_cluster(vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude_for_dram_broadcast, cols_to_exclude_for_dram_broadcast, "LARGE_WRITE_TLB");
+        device.broadcast_write_to_cluster(
+            vector_to_write.data(),
+            vector_to_write.size() * 4,
+            address,
+            {},
+            rows_to_exclude_for_dram_broadcast,
+            cols_to_exclude_for_dram_broadcast,
+            "LARGE_WRITE_TLB");
         device.wait_for_non_mmio_flush();
 
-        for(const auto i : target_devices) {
-            for(const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                if(rows_to_exclude.find(core.y) != rows_to_exclude.end()) continue;
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was broadcasted";
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+        for (const auto i : target_devices) {
+            for (const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
+                    continue;
+                }
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y
+                                                         << "does not match what was broadcasted";
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
-            for(int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
                 const auto& core = device.get_virtual_soc_descriptors().at(i).get_core_for_dram_channel(chan, 0);
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from DRAM core " << i << " " << core.x << "-" << core.y << " does not match what was broadcasted " << size;
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from DRAM core " << i << " " << core.x << "-" << core.y
+                    << " does not match what was broadcasted " << size;
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
         }
         // Wait for data to be cleared before writing next block
         device.wait_for_non_mmio_flush();
     }
-    device.close_device();    
+    device.close_device();
 }
 
-TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) { // same problem as above..
+TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as above..
     // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true);
+
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        true);
     set_params_for_remote_txn(device);
     auto mmio_devices = device.get_target_mmio_device_ids();
 
     tt_device_params default_params;
     device.start_device(default_params);
     auto eth_version = device.get_ethernet_fw_version();
-    bool virtual_bcast_supported = (eth_version >= tt_version(6, 8, 0) || eth_version == tt_version(6, 7, 241)) && device.translation_tables_en;
+    bool virtual_bcast_supported =
+        (eth_version >= tt_version(6, 8, 0) || eth_version == tt_version(6, 7, 241)) && device.translation_tables_en;
     if (!virtual_bcast_supported) {
         device.close_device();
-        GTEST_SKIP() << "SiliconDriverWH.VirtualCoordinateBroadcast skipped since ethernet version does not support Virtual Coordinate Broadcast or NOC translation is not enabled";
+        GTEST_SKIP() << "SiliconDriverWH.VirtualCoordinateBroadcast skipped since ethernet version does not support "
+                        "Virtual Coordinate Broadcast or NOC translation is not enabled";
     }
-    
+
     device.deassert_risc_reset();
     std::vector<uint32_t> broadcast_sizes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
     uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
@@ -619,38 +821,69 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) { // same problem as 
     std::set<uint32_t> rows_to_exclude_for_dram_broadcast = {};
     std::set<uint32_t> cols_to_exclude_for_dram_broadcast = {1, 2, 3, 4, 6, 7, 8, 9};
 
-    for(const auto& size : broadcast_sizes) {
+    for (const auto& size : broadcast_sizes) {
         std::vector<uint32_t> vector_to_write(size);
         std::vector<uint32_t> zeros(size);
         std::vector<uint32_t> readback_vec = {};
-        for(int i = 0; i < size; i++) {
+        for (int i = 0; i < size; i++) {
             vector_to_write[i] = i;
             zeros[i] = 0;
         }
         // Broadcast to Tensix
-        device.broadcast_write_to_cluster(vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude, "LARGE_WRITE_TLB");
+        device.broadcast_write_to_cluster(
+            vector_to_write.data(),
+            vector_to_write.size() * 4,
+            address,
+            {},
+            rows_to_exclude,
+            cols_to_exclude,
+            "LARGE_WRITE_TLB");
         // Broadcast to DRAM
-        device.broadcast_write_to_cluster(vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude_for_dram_broadcast, cols_to_exclude_for_dram_broadcast, "LARGE_WRITE_TLB");        
+        device.broadcast_write_to_cluster(
+            vector_to_write.data(),
+            vector_to_write.size() * 4,
+            address,
+            {},
+            rows_to_exclude_for_dram_broadcast,
+            cols_to_exclude_for_dram_broadcast,
+            "LARGE_WRITE_TLB");
         device.wait_for_non_mmio_flush();
 
-        for(const auto i : target_devices) {
-            for(const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                if(rows_to_exclude.find(core.y) != rows_to_exclude.end()) continue;
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was broadcasted";
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+        for (const auto i : target_devices) {
+            for (const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
+                    continue;
+                }
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y
+                                                         << "does not match what was broadcasted";
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
-            for(int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
                 const auto& core = device.get_virtual_soc_descriptors().at(i).get_core_for_dram_channel(chan, 0);
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from DRAM core " << i << " " << core.x << "-" << core.y << " does not match what was broadcasted " << size;
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from DRAM core " << i << " " << core.x << "-" << core.y
+                    << " does not match what was broadcasted " << size;
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
         }
         // Wait for data to be cleared before writing next block
         device.wait_for_non_mmio_flush();
     }
-    device.close_device();    
+    device.close_device();
 }

--- a/tests/emulation/test_emulation_device.cpp
+++ b/tests/emulation/test_emulation_device.cpp
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "gtest/gtest.h"
-#include "device/tt_soc_descriptor.h"
 #include "device/cluster.h"
 #include "device/tt_emulation_device.h"
+#include "device/tt_soc_descriptor.h"
+#include "gtest/gtest.h"
 
 // DEPRECATED TEST SUITE !!!
 
@@ -22,7 +22,7 @@ TEST(EmulationDeviceGS, BasicEmuTest) {
     uint64_t l1_addr = 0x1000;
     std::vector<uint32_t> wdata(size);
     std::vector<uint32_t> rdata(size);
-    
+
     try {
         device.start_device(default_params);
 
@@ -31,13 +31,23 @@ TEST(EmulationDeviceGS, BasicEmuTest) {
         }
         device.write_to_device(wdata.data(), wdata.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), l1_addr, "l1");
         test_utils::read_data_from_device(device, rdata, tt_cxy_pair(0, core), l1_addr, size, "l1");
-        ASSERT_EQ(wdata, rdata) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+        ASSERT_EQ(wdata, rdata) << "Vector read back from core " << core.x << "-" << core.y
+                                << "does not match what was written";
 
         device.deassert_risc_reset();
-        device.write_to_device(wdata.data(), wdata.size() * sizeof(std::uint32_t), tt_cxy_pair(0, tt_xy_pair(phys_x, phys_y)), l1_addr, "l1");
+        device.write_to_device(
+            wdata.data(),
+            wdata.size() * sizeof(std::uint32_t),
+            tt_cxy_pair(0, tt_xy_pair(phys_x, phys_y)),
+            l1_addr,
+            "l1");
         device.assert_risc_reset();
-        device.write_to_device(wdata.data(), wdata.size() * sizeof(std::uint32_t), tt_cxy_pair(0, tt_xy_pair(phys_x, phys_y)), l1_addr, "l1");
-
+        device.write_to_device(
+            wdata.data(),
+            wdata.size() * sizeof(std::uint32_t),
+            tt_cxy_pair(0, tt_xy_pair(phys_x, phys_y)),
+            l1_addr,
+            "l1");
 
     } catch (const std::exception &e) {
         std::cout << "Error: " << e.what() << std::endl;

--- a/tests/galaxy/test_galaxy_common.cpp
+++ b/tests/galaxy/test_galaxy_common.cpp
@@ -10,9 +10,18 @@ void move_data(
     Cluster& device, tt_multichip_core_addr sender_core, tt_multichip_core_addr receiver_core, uint32_t size) {
     std::vector<uint32_t> readback_vec = {};
     test_utils::read_data_from_device(
-        device, readback_vec, tt_cxy_pair(sender_core.chip, sender_core.core), sender_core.addr, size, "SMALL_READ_WRITE_TLB");
+        device,
+        readback_vec,
+        tt_cxy_pair(sender_core.chip, sender_core.core),
+        sender_core.addr,
+        size,
+        "SMALL_READ_WRITE_TLB");
     device.write_to_device(
-        readback_vec.data(), readback_vec.size() * sizeof(std::uint32_t), tt_cxy_pair(receiver_core.chip, receiver_core.core), receiver_core.addr, "SMALL_READ_WRITE_TLB");
+        readback_vec.data(),
+        readback_vec.size() * sizeof(std::uint32_t),
+        tt_cxy_pair(receiver_core.chip, receiver_core.core),
+        receiver_core.addr,
+        "SMALL_READ_WRITE_TLB");
     device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 
     return;
@@ -25,7 +34,12 @@ void broadcast_data(
     uint32_t size) {
     std::vector<uint32_t> readback_vec = {};
     test_utils::read_data_from_device(
-        device, readback_vec, tt_cxy_pair(sender_core.chip, sender_core.core), sender_core.addr, size, "SMALL_READ_WRITE_TLB");
+        device,
+        readback_vec,
+        tt_cxy_pair(sender_core.chip, sender_core.core),
+        sender_core.addr,
+        size,
+        "SMALL_READ_WRITE_TLB");
     for (const auto& receiver_core : receiver_cores) {
         device.write_to_device(
             readback_vec.data(),

--- a/tests/galaxy/test_galaxy_common.h
+++ b/tests/galaxy/test_galaxy_common.h
@@ -4,18 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 #pragma once
 
 #include <set>
+#include <sstream>
 #include <string>
 #include <tuple>
 #include <vector>
-#include <sstream>
 
 #include "device/cluster.h"
 #include "device/tt_xy_pair.h"
-
 #include "fmt/core.h"
 
 // static const std::string SOC_DESC_PATH = "./tests/soc_descs/wormhole_b0_8x10.yaml";
@@ -24,14 +22,14 @@ using namespace tt::umd;
 
 struct tt_multichip_core_addr {
     tt_multichip_core_addr() : core{}, chip{}, addr{} {}
+
     tt_multichip_core_addr(chip_id_t chip, tt_xy_pair core, std::uint64_t addr) : core(core), chip(chip), addr(addr) {}
 
     tt_xy_pair core;
     chip_id_t chip;
     std::uint64_t addr;
-    std::string str() const {
-        return fmt::format("(chip={},x={},y={},addr=0x{:x})", chip, core.x, core.y, addr);
-    }
+
+    std::string str() const { return fmt::format("(chip={},x={},y={},addr=0x{:x})", chip, core.x, core.y, addr); }
 };
 
 // SIMPLE DATAMOVEMENT API BASED ON UMD

--- a/tests/galaxy/test_umd_concurrent_threads.cpp
+++ b/tests/galaxy/test_umd_concurrent_threads.cpp
@@ -2,22 +2,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <filesystem>
 #include <numeric>
 #include <thread>
-#include <filesystem>
 
-#include "gtest/gtest.h"
-#include "common/logger.hpp"
-#include "tt_cluster_descriptor.h"
 #include "cluster.h"
+#include "common/logger.hpp"
 #include "eth_interface.h"
+#include "gtest/gtest.h"
 #include "host_mem_address_map.h"
 #include "l1_address_map.h"
-
 #include "test_galaxy_common.h"
-#include "tests/wormhole/test_wh_common.h"
-#include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/test_utils/device_test_utils.hpp"
+#include "tests/test_utils/generate_cluster_desc.hpp"
+#include "tests/wormhole/test_wh_common.h"
+#include "tt_cluster_descriptor.h"
 
 static const std::string SOC_DESC_PATH = "tests/soc_descs/wormhole_b0_8x10.yaml";
 
@@ -52,7 +51,12 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
     Cluster device = Cluster(
-        test_utils::GetAbsPath(SOC_DESC_PATH), cluster_desc_path, all_devices, num_host_mem_ch_per_mmio_device, false, true);
+        test_utils::GetAbsPath(SOC_DESC_PATH),
+        cluster_desc_path,
+        all_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
@@ -70,7 +74,12 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (const auto& chip : target_devices_th1) {
             for (auto& core : sdesc_per_chip.at(chip).workers) {
-                device.write_to_device(vector_to_write_th1.data(), vector_to_write_th1.size() * sizeof(std::uint32_t), tt_cxy_pair(chip, core), address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(
+                    vector_to_write_th1.data(),
+                    vector_to_write_th1.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(chip, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
             }
         }
         device.wait_for_non_mmio_flush();
@@ -91,7 +100,12 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (const auto& chip : target_devices_th2) {
             for (auto& core : sdesc_per_chip.at(chip).workers) {
-                device.write_to_device(vector_to_write_th2.data(), vector_to_write_th2.size() * sizeof(std::uint32_t), tt_cxy_pair(chip, core), address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(
+                    vector_to_write_th2.data(),
+                    vector_to_write_th2.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(chip, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
             }
         }
         device.wait_for_non_mmio_flush();
@@ -140,7 +154,12 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
     Cluster device = Cluster(
-        test_utils::GetAbsPath(SOC_DESC_PATH), cluster_desc_path, all_devices, num_host_mem_ch_per_mmio_device, false, true);
+        test_utils::GetAbsPath(SOC_DESC_PATH),
+        cluster_desc_path,
+        all_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
@@ -162,7 +181,12 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
         std::uint32_t address = 0x4000000;
         for (const auto& chip : target_devices_th1) {
             for (auto& core : dram_cores) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(chip, core), address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(chip, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
             }
         }
         device.wait_for_non_mmio_flush();
@@ -182,7 +206,12 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
         std::uint32_t address = 0x5000000;
         for (const auto& chip : target_devices_th2) {
             for (auto& core : sdesc_per_chip.at(chip).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(chip, core), address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(chip, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
             }
         }
         device.wait_for_non_mmio_flush();
@@ -217,7 +246,12 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
     Cluster device = Cluster(
-        test_utils::GetAbsPath(SOC_DESC_PATH), cluster_desc_path, target_devices, num_host_mem_ch_per_mmio_device, false, true);
+        test_utils::GetAbsPath(SOC_DESC_PATH),
+        cluster_desc_path,
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
@@ -239,7 +273,12 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
         chip_id_t mmio_chip = cluster_desc->get_chips_with_mmio().begin()->first;
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = 0x0;
-        device.write_to_device(large_vector.data(), large_vector.size() * sizeof(std::uint32_t), tt_cxy_pair(mmio_chip, tt_xy_pair(0, 0)), address, "SMALL_READ_WRITE_TLB");
+        device.write_to_device(
+            large_vector.data(),
+            large_vector.size() * sizeof(std::uint32_t),
+            tt_cxy_pair(mmio_chip, tt_xy_pair(0, 0)),
+            address,
+            "SMALL_READ_WRITE_TLB");
         test_utils::read_data_from_device(
             device,
             readback_vec,
@@ -257,14 +296,24 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (const auto& chip : target_devices) {
             for (auto& core : sdesc_per_chip.at(chip).workers) {
-                device.write_to_device(small_vector.data(), small_vector.size() * sizeof(std::uint32_t), tt_cxy_pair(chip, core), address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(
+                    small_vector.data(),
+                    small_vector.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(chip, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
             }
         }
         device.wait_for_non_mmio_flush();
         for (const auto& chip : target_devices) {
             for (auto& core : sdesc_per_chip.at(chip).workers) {
                 test_utils::read_data_from_device(
-                    device, readback_vec, tt_cxy_pair(chip, core), address, small_vector.size() * 4, "SMALL_READ_WRITE_TLB");
+                    device,
+                    readback_vec,
+                    tt_cxy_pair(chip, core),
+                    address,
+                    small_vector.size() * 4,
+                    "SMALL_READ_WRITE_TLB");
                 EXPECT_EQ(small_vector, readback_vec)
                     << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 readback_vec = {};

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -2,21 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <numeric>
 #include <filesystem>
+#include <numeric>
 
-#include "gtest/gtest.h"
-#include "common/logger.hpp"
-#include "tt_cluster_descriptor.h"
 #include "cluster.h"
+#include "common/logger.hpp"
 #include "eth_interface.h"
+#include "gtest/gtest.h"
 #include "host_mem_address_map.h"
 #include "l1_address_map.h"
-
 #include "test_galaxy_common.h"
-#include "tests/wormhole/test_wh_common.h"
-#include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/test_utils/device_test_utils.hpp"
+#include "tests/test_utils/generate_cluster_desc.hpp"
+#include "tests/wormhole/test_wh_common.h"
+#include "tt_cluster_descriptor.h"
 
 static const std::string SOC_DESC_PATH = "tests/soc_descs/wormhole_b0_8x10.yaml";
 
@@ -32,7 +31,12 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
     Cluster device = Cluster(
-        test_utils::GetAbsPath(SOC_DESC_PATH), cluster_desc_path, target_devices, num_host_mem_ch_per_mmio_device, false, true);
+        test_utils::GetAbsPath(SOC_DESC_PATH),
+        cluster_desc_path,
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
@@ -64,7 +68,12 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
             for (const auto& core : target_cores) {
                 tt_cxy_pair target_core = tt_cxy_pair(chip, core);
                 auto start = std::chrono::high_resolution_clock::now();
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), target_core, address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    target_core,
+                    address,
+                    "SMALL_READ_WRITE_TLB");
                 device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
                 auto end = std::chrono::high_resolution_clock::now();
                 auto duration = double(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
@@ -72,7 +81,8 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
                 // std::cout << "  chip " << chip << " core " << target_core.str() << " " << duration << std::endl;
 
                 start = std::chrono::high_resolution_clock::now();
-                test_utils::read_data_from_device(device, readback_vec, target_core, address, write_size, "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(
+                    device, readback_vec, target_core, address, write_size, "SMALL_READ_WRITE_TLB");
                 end = std::chrono::high_resolution_clock::now();
                 duration = double(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
                 // std::cout << " read chip " << chip << " core " << target_core.str()<< " " << duration << std::endl;
@@ -145,7 +155,12 @@ void run_data_mover_test(
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
     Cluster device = Cluster(
-        test_utils::GetAbsPath(SOC_DESC_PATH), cluster_desc_path, target_devices, num_host_mem_ch_per_mmio_device, false, true);
+        test_utils::GetAbsPath(SOC_DESC_PATH),
+        cluster_desc_path,
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
 
@@ -162,7 +177,11 @@ void run_data_mover_test(
     std::vector<float> send_bw;
     // Set up data in sender core
     device.write_to_device(
-        vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(sender_core.chip, sender_core.core), sender_core.addr, "SMALL_READ_WRITE_TLB");
+        vector_to_write.data(),
+        vector_to_write.size() * sizeof(std::uint32_t),
+        tt_cxy_pair(sender_core.chip, sender_core.core),
+        sender_core.addr,
+        "SMALL_READ_WRITE_TLB");
     device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 
     // Send data from sender core to receiver core
@@ -261,7 +280,12 @@ void run_data_broadcast_test(
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
     Cluster device = Cluster(
-        test_utils::GetAbsPath(SOC_DESC_PATH), cluster_desc_path, target_devices, num_host_mem_ch_per_mmio_device, false, true);
+        test_utils::GetAbsPath(SOC_DESC_PATH),
+        cluster_desc_path,
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
 
@@ -278,7 +302,11 @@ void run_data_broadcast_test(
     std::vector<float> send_bw;
     //  Set up data in sender core
     device.write_to_device(
-        vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(sender_core.chip, sender_core.core), sender_core.addr, "SMALL_READ_WRITE_TLB");
+        vector_to_write.data(),
+        vector_to_write.size() * sizeof(std::uint32_t),
+        tt_cxy_pair(sender_core.chip, sender_core.core),
+        sender_core.addr,
+        "SMALL_READ_WRITE_TLB");
     device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 
     // Send data from sender core to receiver core

--- a/tests/galaxy/test_umd_remote_api_stability.cpp
+++ b/tests/galaxy/test_umd_remote_api_stability.cpp
@@ -7,173 +7,167 @@
 #include <random>
 #include <thread>
 
-#include "tt_cluster_descriptor.h"
 #include "cluster.h"
-
 #include "common/logger.hpp"
 #include "eth_interface.h"
 #include "filesystem"
 #include "gtest/gtest.h"
 #include "host_mem_address_map.h"
 #include "l1_address_map.h"
-#include "tt_soc_descriptor.h"
-
-#include "tests/test_utils/stimulus_generators.hpp"
-#include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/galaxy/test_galaxy_common.h"
+#include "tests/test_utils/generate_cluster_desc.hpp"
+#include "tests/test_utils/stimulus_generators.hpp"
 #include "tests/wormhole/test_wh_common.h"
+#include "tt_cluster_descriptor.h"
+#include "tt_soc_descriptor.h"
 
 namespace tt::umd::test::utils {
 
-
 class WormholeGalaxyStabilityTestFixture : public WormholeTestFixture {
- private:
-  static int detected_num_chips;
-  static bool skip_tests;
+private:
+    static int detected_num_chips;
+    static bool skip_tests;
 
- protected:
+protected:
+    static constexpr int EXPECTED_MIN_CHIPS = 32;
+    static uint32_t scale_number_of_tests;
 
-  static constexpr int EXPECTED_MIN_CHIPS = 32;
-  static uint32_t scale_number_of_tests;
-
-  static void SetUpTestSuite() {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
-    detected_num_chips = cluster_desc->get_number_of_chips();
-    if (detected_num_chips < EXPECTED_MIN_CHIPS) {
-        skip_tests = true;
+    static void SetUpTestSuite() {
+        std::unique_ptr<tt_ClusterDescriptor> cluster_desc =
+            tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
+        detected_num_chips = cluster_desc->get_number_of_chips();
+        if (detected_num_chips < EXPECTED_MIN_CHIPS) {
+            skip_tests = true;
+        }
+        if (char const* scale_number_of_tests_env = std::getenv("SCALE_NUMBER_OF_TESTS")) {
+            scale_number_of_tests = std::atoi(scale_number_of_tests_env);
+        }
     }
-    if(char const* scale_number_of_tests_env = std::getenv("SCALE_NUMBER_OF_TESTS")) {
-        scale_number_of_tests = std::atoi(scale_number_of_tests_env);
-    }
-  }
 
-  virtual int get_detected_num_chips() {
-    return detected_num_chips;
-  }
+    virtual int get_detected_num_chips() { return detected_num_chips; }
 
-  virtual bool is_test_skipped() {
-    return skip_tests;
-  }
-
+    virtual bool is_test_skipped() { return skip_tests; }
 };
-
 
 int WormholeGalaxyStabilityTestFixture::detected_num_chips = -1;
 bool WormholeGalaxyStabilityTestFixture::skip_tests = false;
 uint32_t WormholeGalaxyStabilityTestFixture::scale_number_of_tests = 1;
 
-
 TEST_F(WormholeGalaxyStabilityTestFixture, MixedRemoteTransfers) {
     int seed = 0;
-    
+
     assert(device != nullptr);
-    log_info(LogSiliconDriver,"Started MixedRemoteTransfers");
+    log_info(LogSiliconDriver, "Started MixedRemoteTransfers");
     std::vector<remote_transfer_sample_t> command_history;
     try {
         RunMixedTransfersUniformDistributions(
-            *this->device, 
+            *this->device,
             100000 * scale_number_of_tests,
             seed,
 
             transfer_type_weights_t{.write = 0.40, .read = 0.4},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 30000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 30000),                           // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 30000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 30000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history
-        );
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history);
     } catch (...) {
         print_command_history_executable_code(command_history);
     }
-
 }
 
 TEST_F(WormholeGalaxyStabilityTestFixture, DISABLED_MultithreadedMixedRemoteTransfersMediumSmall) {
     int seed = 0;
 
-    log_info(LogSiliconDriver,"Started MultithreadedMixedRemoteTransfersMediumSmall");
+    log_info(LogSiliconDriver, "Started MultithreadedMixedRemoteTransfersMediumSmall");
 
     assert(device != nullptr);
-    std::thread t1([&](){
+    std::thread t1([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             50000 * scale_number_of_tests,
             0,
 
             transfer_type_weights_t{.write = 0.50, .read = 0.50},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 30000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 30000),                           // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 30000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 30000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            nullptr
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            nullptr);
     });
-    std::thread t2([&](){
+    std::thread t2([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             50000 * scale_number_of_tests,
             100,
 
             transfer_type_weights_t{.write = 0.25, .read = 0.50},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 30000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 30000),                           // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 30000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 30000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            nullptr
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            nullptr);
     });
-    std::thread t3([&](){
+    std::thread t3([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             50000 * scale_number_of_tests,
             23,
 
             transfer_type_weights_t{.write = 0.5, .read = 0.25},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 30000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 30000),                           // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 30000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 30000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            nullptr
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            nullptr);
     });
-    std::thread t4([&](){
+    std::thread t4([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             99,
 
             transfer_type_weights_t{.write = 0.1, .read = 0.1},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            nullptr
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            nullptr);
     });
 
     t1.join();
@@ -182,4 +176,4 @@ TEST_F(WormholeGalaxyStabilityTestFixture, DISABLED_MultithreadedMixedRemoteTran
     t4.join();
 }
 
-} // namespace tt::umd::test::utils
+}  // namespace tt::umd::test::utils

--- a/tests/grayskull/test_silicon_driver.cpp
+++ b/tests/grayskull/test_silicon_driver.cpp
@@ -4,14 +4,14 @@
 
 #include <thread>
 
-#include "gtest/gtest.h"
 #include "cluster.h"
-#include "device/tt_soc_descriptor.h"
 #include "device/tt_cluster_descriptor.h"
+#include "device/tt_soc_descriptor.h"
 #include "device/wormhole/wormhole_implementation.h"
+#include "gtest/gtest.h"
 #include "l1_address_map.h"
-#include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/test_utils/device_test_utils.hpp"
+#include "tests/test_utils/generate_cluster_desc.hpp"
 
 using namespace tt::umd;
 
@@ -19,8 +19,14 @@ TEST(SiliconDriverGS, CreateDestroySequential) {
     std::set<chip_id_t> target_devices = {0};
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     tt_device_params default_params;
-    for(int i = 0; i < 100; i++) {
-        Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true);
+    for (int i = 0; i < 100; i++) {
+        Cluster device = Cluster(
+            test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"),
+            tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+            target_devices,
+            num_host_mem_ch_per_mmio_device,
+            false,
+            true);
         device.start_device(default_params);
         device.deassert_risc_reset();
         device.close_device();
@@ -33,13 +39,21 @@ TEST(SiliconDriverGS, CreateMultipleInstance) {
     tt_device_params default_params;
     default_params.init_device = false;
     std::unordered_map<int, Cluster*> concurrent_devices = {};
-    for(int i = 0; i < 100; i++) {
-        concurrent_devices.insert({i, new Cluster(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true)});
-        concurrent_devices.at(i) -> start_device(default_params);
+    for (int i = 0; i < 100; i++) {
+        concurrent_devices.insert(
+            {i,
+             new Cluster(
+                 test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"),
+                 tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+                 target_devices,
+                 num_host_mem_ch_per_mmio_device,
+                 false,
+                 true)});
+        concurrent_devices.at(i)->start_device(default_params);
     }
 
-    for(auto& device : concurrent_devices) {
-        device.second -> close_device();
+    for (auto& device : concurrent_devices) {
+        device.second->close_device();
         delete device.second;
     }
 }
@@ -48,15 +62,27 @@ TEST(SiliconDriverGS, Harvesting) {
     std::set<chip_id_t> target_devices = {0};
     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 6}, {1, 12}};
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true, simulated_harvesting_masks);
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        true,
+        simulated_harvesting_masks);
     auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     ASSERT_EQ(device.using_harvested_soc_descriptors(), true) << "Expected Driver to have performed harvesting";
-    for(const auto& chip : sdesc_per_chip) {
-        ASSERT_LE(chip.second.workers.size(), 96) << "Expected SOC descriptor with harvesting to have less than or equal to 96 workers for chip " << chip.first;
+    for (const auto& chip : sdesc_per_chip) {
+        ASSERT_LE(chip.second.workers.size(), 96)
+            << "Expected SOC descriptor with harvesting to have less than or equal to 96 workers for chip "
+            << chip.first;
     }
-    ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(0) & simulated_harvesting_masks[0], 6) << "Expected first chip to include simulated harvesting mask of 6";
-    // ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(1), 12) << "Expected second chip to have harvesting mask of 12";
+    ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(0) & simulated_harvesting_masks[0], 6)
+        << "Expected first chip to include simulated harvesting mask of 6";
+    // ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(1), 12) << "Expected second chip to have
+    // harvesting mask of 12";
     device.close_device();
 }
 
@@ -65,16 +91,25 @@ TEST(SiliconDriverGS, CustomSocDesc) {
     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 6}, {1, 12}};
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
-    Cluster device = Cluster(test_utils::GetAbsPath("./tests/soc_descs/grayskull_1x1_arch.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, false, simulated_harvesting_masks);
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("./tests/soc_descs/grayskull_1x1_arch.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        false,
+        simulated_harvesting_masks);
     auto sdesc_per_chip = device.get_virtual_soc_descriptors();
-    ASSERT_EQ(device.using_harvested_soc_descriptors(), false) << "SOC descriptors should not be modified when harvesting is disabled";
-    for(const auto& chip : sdesc_per_chip) {
+    ASSERT_EQ(device.using_harvested_soc_descriptors(), false)
+        << "SOC descriptors should not be modified when harvesting is disabled";
+    for (const auto& chip : sdesc_per_chip) {
         ASSERT_EQ(chip.second.workers.size(), 1) << "Expected 1x1 SOC descriptor to be unmodified by driver";
     }
 }
 
 TEST(SiliconDriverGS, HarvestingRuntime) {
-    auto get_static_tlb_index = [] (tt_xy_pair target) {
+    auto get_static_tlb_index = [](tt_xy_pair target) {
         int flat_index = target.y * tt::umd::wormhole::GRID_SIZE_X + target.x;
         if (flat_index == 0) {
             return -1;
@@ -85,12 +120,20 @@ TEST(SiliconDriverGS, HarvestingRuntime) {
     std::set<chip_id_t> target_devices = {0};
     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 6}, {1, 12}};
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true, simulated_harvesting_masks);
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        true,
+        simulated_harvesting_masks);
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for functional worker cores
         auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-        for(auto& core : sdesc.workers) {
+        for (auto& core : sdesc.workers) {
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
             device.configure_tlb(i, core, get_static_tlb_index(core), l1_mem::address_map::DATA_BUFFER_SPACE_BASE);
         }
@@ -108,29 +151,59 @@ TEST(SiliconDriverGS, HarvestingRuntime) {
     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     float timeout_in_seconds = 10;
     // Check functionality of Static TLBs by reading adn writing from statically mapped address space
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         std::uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
         std::uint32_t dynamic_write_address = 0x30000000;
-        for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
-            for(auto& core :  device.get_virtual_soc_descriptors().at(i).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "");
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), dynamic_write_address, "SMALL_READ_WRITE_TLB");
+        for (int loop = 0; loop < 100;
+             loop++) {  // Write to each core a 100 times at different statically mapped addresses
+            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "");
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    dynamic_write_address,
+                    "SMALL_READ_WRITE_TLB");
                 auto start_time = std::chrono::high_resolution_clock::now();
-                while(!(vector_to_write == readback_vec)) {
-                    float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start_time).count();
-                    if(wait_duration > timeout_in_seconds) {
+                while (!(vector_to_write == readback_vec)) {
+                    float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(
+                                              std::chrono::high_resolution_clock::now() - start_time)
+                                              .count();
+                    if (wait_duration > timeout_in_seconds) {
                         break;
                     }
                     test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "");
-                    test_utils::read_data_from_device(device, dynamic_readback_vec, tt_cxy_pair(i, core), dynamic_write_address, 40, "SMALL_READ_WRITE_TLB");
+                    test_utils::read_data_from_device(
+                        device,
+                        dynamic_readback_vec,
+                        tt_cxy_pair(i, core),
+                        dynamic_write_address,
+                        40,
+                        "SMALL_READ_WRITE_TLB");
                 }
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB"); // Clear any written data
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), dynamic_write_address, "SMALL_READ_WRITE_TLB"); // Clear any written data
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");  // Clear any written data
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    dynamic_write_address,
+                    "SMALL_READ_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
                 dynamic_readback_vec = {};
             }
-            address += 0x20; // Increment by uint32_t size for each write
+            address += 0x20;  // Increment by uint32_t size for each write
             dynamic_write_address += 0x20;
         }
     }
@@ -138,7 +211,7 @@ TEST(SiliconDriverGS, HarvestingRuntime) {
 }
 
 TEST(SiliconDriverGS, StaticTLB_RW) {
-    auto get_static_tlb_index = [] (tt_xy_pair target) {
+    auto get_static_tlb_index = [](tt_xy_pair target) {
         int flat_index = target.y * tt::umd::wormhole::GRID_SIZE_X + target.x;
         if (flat_index == 0) {
             return -1;
@@ -148,13 +221,20 @@ TEST(SiliconDriverGS, StaticTLB_RW) {
     std::set<chip_id_t> target_devices = {0};
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true);
-    for(int i = 0; i < target_devices.size(); i++) {
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
+    for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for worker cores
         auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-        for(auto& core : sdesc.workers) {
+        for (auto& core : sdesc.workers) {
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
-            device.configure_tlb(i, core, get_static_tlb_index(core), l1_mem::address_map::DATA_BUFFER_SPACE_BASE, TLB_DATA::Posted);
+            device.configure_tlb(
+                i, core, get_static_tlb_index(core), l1_mem::address_map::DATA_BUFFER_SPACE_BASE, TLB_DATA::Posted);
         }
         device.setup_core_to_tlb_map(i, get_static_tlb_index);
     }
@@ -168,36 +248,58 @@ TEST(SiliconDriverGS, StaticTLB_RW) {
     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     float timeout_in_seconds = 10;
     // Check functionality of Static TLBs by reading adn writing from statically mapped address space
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         std::uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
-        for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
-            for(auto& core :  device.get_virtual_soc_descriptors().at(i).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "");
+        for (int loop = 0; loop < 100;
+             loop++) {  // Write to each core a 100 times at different statically mapped addresses
+            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "");
                 auto start_time = std::chrono::high_resolution_clock::now();
-                while(!(vector_to_write == readback_vec)) {
-                    float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start_time).count();
-                    if(wait_duration > timeout_in_seconds) {
+                while (!(vector_to_write == readback_vec)) {
+                    float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(
+                                              std::chrono::high_resolution_clock::now() - start_time)
+                                              .count();
+                    if (wait_duration > timeout_in_seconds) {
                         break;
                     }
                     test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "");
                 }
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB"); // Clear any written data
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
-            address += 0x20; // Increment by uint32_t size for each write
+            address += 0x20;  // Increment by uint32_t size for each write
         }
     }
     device.close_device();
 }
 
 TEST(SiliconDriverGS, DynamicTLB_RW) {
-    // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for each transaction
+    // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for
+    // each transaction
     std::set<chip_id_t> target_devices = {0};
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true);
-    device.set_fallback_tlb_ordering_mode("SMALL_READ_WRITE_TLB", TLB_DATA::Posted); // Explicitly test API to set fallback tlb ordering mode
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
+    device.set_fallback_tlb_ordering_mode(
+        "SMALL_READ_WRITE_TLB", TLB_DATA::Posted);  // Explicitly test API to set fallback tlb ordering mode
     tt_device_params default_params;
     device.start_device(default_params);
     device.deassert_risc_reset();
@@ -207,25 +309,40 @@ TEST(SiliconDriverGS, DynamicTLB_RW) {
     std::vector<uint32_t> readback_vec = {};
     float timeout_in_seconds = 10;
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         std::uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
-        for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
-            for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB");
+        for (int loop = 0; loop < 100;
+             loop++) {  // Write to each core a 100 times at different statically mapped addresses
+            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
                 auto start_time = std::chrono::high_resolution_clock::now();
-                while(!(vector_to_write == readback_vec)) {
-                    float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start_time).count();
-                    if(wait_duration > timeout_in_seconds) {
+                while (!(vector_to_write == readback_vec)) {
+                    float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(
+                                              std::chrono::high_resolution_clock::now() - start_time)
+                                              .count();
+                    if (wait_duration > timeout_in_seconds) {
                         break;
                     }
-                    test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "SMALL_READ_WRITE_TLB");
+                    test_utils::read_data_from_device(
+                        device, readback_vec, tt_cxy_pair(i, core), address, 40, "SMALL_READ_WRITE_TLB");
                 }
 
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB"); // Clear any written data
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
-            address += 0x20; // Increment by uint32_t size for each write
+            address += 0x20;  // Increment by uint32_t size for each write
         }
     }
     device.close_device();
@@ -238,7 +355,13 @@ TEST(SiliconDriverGS, MultiThreadedDevice) {
     std::set<chip_id_t> target_devices = {0};
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true);
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
     tt_device_params default_params;
     device.start_device(default_params);
     device.deassert_risc_reset();
@@ -248,18 +371,27 @@ TEST(SiliconDriverGS, MultiThreadedDevice) {
         std::vector<uint32_t> readback_vec = {};
         float timeout_in_seconds = 10;
         std::uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
-        for(int loop = 0; loop < 100; loop++) {
-            for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
+        for (int loop = 0; loop < 100; loop++) {
+            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(0, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
                 auto start_time = std::chrono::high_resolution_clock::now();
-                while(!(vector_to_write == readback_vec)) {
-                    float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start_time).count();
-                    if(wait_duration > timeout_in_seconds) {
+                while (!(vector_to_write == readback_vec)) {
+                    float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(
+                                              std::chrono::high_resolution_clock::now() - start_time)
+                                              .count();
+                    if (wait_duration > timeout_in_seconds) {
                         break;
                     }
-                    test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
+                    test_utils::read_data_from_device(
+                        device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
                 }
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 readback_vec = {};
             }
             address += 0x20;
@@ -271,19 +403,28 @@ TEST(SiliconDriverGS, MultiThreadedDevice) {
         std::vector<uint32_t> readback_vec = {};
         float timeout_in_seconds = 10;
         std::uint32_t address = 0x30000000;
-        for(auto& core_ls : device.get_virtual_soc_descriptors().at(0).dram_cores) {
-            for(int loop = 0; loop < 100; loop++) {
-                for(auto& core : core_ls) {
-                    device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
+        for (auto& core_ls : device.get_virtual_soc_descriptors().at(0).dram_cores) {
+            for (int loop = 0; loop < 100; loop++) {
+                for (auto& core : core_ls) {
+                    device.write_to_device(
+                        vector_to_write.data(),
+                        vector_to_write.size() * sizeof(std::uint32_t),
+                        tt_cxy_pair(0, core),
+                        address,
+                        "SMALL_READ_WRITE_TLB");
                     auto start_time = std::chrono::high_resolution_clock::now();
-                    while(!(vector_to_write == readback_vec)) {
-                        float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start_time).count();
-                        if(wait_duration > timeout_in_seconds) {
+                    while (!(vector_to_write == readback_vec)) {
+                        float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(
+                                                  std::chrono::high_resolution_clock::now() - start_time)
+                                                  .count();
+                        if (wait_duration > timeout_in_seconds) {
                             break;
+                        }
+                        test_utils::read_data_from_device(
+                            device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
                     }
-                    test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
-                }
-                    ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+                    ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y
+                                                             << "does not match what was written";
                     readback_vec = {};
                 }
                 address += 0x20;
@@ -296,14 +437,14 @@ TEST(SiliconDriverGS, MultiThreadedDevice) {
     device.close_device();
 }
 
-TEST(SiliconDriverGS, MultiThreadedMemBar) { // this tests takes ~5 mins to run
-    // Have 2 threads read and write from a single device concurrently
-    // All (fairly large) transactions go through a static TLB.
-    // We want to make sure the memory barrier is thread/process safe.
+TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
+                                              // Have 2 threads read and write from a single device concurrently
+                                              // All (fairly large) transactions go through a static TLB.
+                                              // We want to make sure the memory barrier is thread/process safe.
 
     // Memory barrier flags get sent to address 0 for all channels in this test
 
-     auto get_static_tlb_index = [] (tt_xy_pair target) {
+    auto get_static_tlb_index = [](tt_xy_pair target) {
         int flat_index = target.y * tt::umd::wormhole::GRID_SIZE_X + target.x;
         if (flat_index == 0) {
             return -1;
@@ -315,12 +456,18 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) { // this tests takes ~5 mins to run
     uint32_t base_addr = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true);
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for functional worker cores
         auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-        for(auto& core : sdesc.workers) {
+        for (auto& core : sdesc.workers) {
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
             device.configure_tlb(i, core, get_static_tlb_index(core), base_addr);
         }
@@ -331,22 +478,28 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) { // this tests takes ~5 mins to run
     device.start_device(default_params);
     device.deassert_risc_reset();
     std::vector<uint32_t> readback_membar_vec = {};
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all workers
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        test_utils::read_data_from_device(
+            device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all workers
         readback_membar_vec = {};
     }
 
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all workers
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        test_utils::read_data_from_device(
+            device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all workers
         readback_membar_vec = {};
     }
 
-    for(int chan = 0; chan <  device.get_virtual_soc_descriptors().at(0).get_num_dram_channels(); chan++) {
+    for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(0).get_num_dram_channels(); chan++) {
         auto core = device.get_virtual_soc_descriptors().at(0).get_core_for_dram_channel(chan, 0);
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all DRAM
+        test_utils::read_data_from_device(
+            device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all DRAM
         readback_membar_vec = {};
     }
     // Launch 2 thread accessing different locations of L1 and using memory barrier between write and read
@@ -355,23 +508,26 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) { // this tests takes ~5 mins to run
     std::vector<uint32_t> vec2(25600);
     std::vector<uint32_t> zeros(25600, 0);
 
-    for(int i = 0; i < vec1.size(); i++) {
+    for (int i = 0; i < vec1.size(); i++) {
         vec1.at(i) = i;
     }
-    for(int i = 0; i < vec2.size(); i++) {
+    for (int i = 0; i < vec2.size(); i++) {
         vec2.at(i) = vec1.size() + i;
     }
 
     std::thread th1 = std::thread([&] {
         std::uint32_t address = base_addr;
-        for(int loop = 0; loop < 100; loop++) {
-            for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        for (int loop = 0; loop < 100; loop++) {
+            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
-                device.write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                device.write_to_device(
+                    vec1.data(), vec1.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 device.l1_membar(0, "", {core});
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 4*vec1.size(), "");
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(0, core), address, 4 * vec1.size(), "");
                 ASSERT_EQ(readback_vec, vec1);
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                device.write_to_device(
+                    zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 readback_vec = {};
             }
         }
@@ -379,14 +535,17 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) { // this tests takes ~5 mins to run
 
     std::thread th2 = std::thread([&] {
         std::uint32_t address = base_addr + vec1.size() * 4;
-        for(int loop = 0; loop < 100; loop++) {
-            for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        for (int loop = 0; loop < 100; loop++) {
+            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
-                device.write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                device.write_to_device(
+                    vec2.data(), vec2.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 device.l1_membar(0, "", {core});
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 4*vec2.size(), "");
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(0, core), address, 4 * vec2.size(), "");
                 ASSERT_EQ(readback_vec, vec2);
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "") ;
+                device.write_to_device(
+                    zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 readback_vec = {};
             }
         }
@@ -395,9 +554,10 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) { // this tests takes ~5 mins to run
     th1.join();
     th2.join();
 
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers end up in correct sate workers
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        test_utils::read_data_from_device(
+            device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(readback_membar_vec.at(0), 187);  // Ensure that memory barriers end up in correct sate workers
         readback_membar_vec = {};
     }
 
@@ -408,14 +568,14 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) { // this tests takes ~5 mins to run
  * Copied from Wormhole unit tests.
  */
 TEST(SiliconDriverGS, SysmemTestWithPcie) {
-    Cluster cluster(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"),
-                    "", // test_utils::GetClusterDescYAML(),
-                    {0},
-                    1,  // one "host memory channel", currently a 1G huge page
-                    false, // skip driver allocs - no (don't skip)
-                    true,  // clean system resources - yes
-                    true); // perform harvesting - yes
-
+    Cluster cluster(
+        test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"),
+        "",  // test_utils::GetClusterDescYAML(),
+        {0},
+        1,      // one "host memory channel", currently a 1G huge page
+        false,  // skip driver allocs - no (don't skip)
+        true,   // clean system resources - yes
+        true);  // perform harvesting - yes
 
     cluster.start_device(tt_device_params{});  // no special parameters
 
@@ -431,7 +591,7 @@ TEST(SiliconDriverGS, SysmemTestWithPcie) {
     // Bad API: how big is the buffer?  How do we know it's big enough?
     // Situation today is that there's a 1G hugepage behind it, although this is
     // unclear from the API and may change in the future.
-    uint8_t *sysmem = (uint8_t*)cluster.host_dma_address(0, 0, 0);
+    uint8_t* sysmem = (uint8_t*)cluster.host_dma_address(0, 0, 0);
     ASSERT_NE(sysmem, nullptr);
 
     uint64_t base_address = cluster.get_pcie_base_addr_from_device(mmio_chip_id);

--- a/tests/microbenchmark/device_fixture.hpp
+++ b/tests/microbenchmark/device_fixture.hpp
@@ -2,26 +2,27 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <iostream>
-#include <fstream>
-#include <cassert>
-#include <random>
 #include <gtest/gtest.h>
 
+#include <cassert>
+#include <fstream>
+#include <iostream>
+#include <random>
+
 #include "cluster.h"
-#include "l1_address_map.h"
 #include "device/tt_soc_descriptor.h"
+#include "l1_address_map.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 
 using tt::umd::Cluster;
 
 class uBenchmarkFixture : public ::testing::Test {
-    protected:
+protected:
     void SetUp() override {
         // get arch name?
         results_csv.open("ubench_results.csv", std::ios_base::app);
 
-        auto get_static_tlb_index = [] (tt_xy_pair target) {
+        auto get_static_tlb_index = [](tt_xy_pair target) {
             int flat_index = target.y * 10 + target.x;  // grid_size_x = 10 for GS/WH ????? something is wrong here
             if (flat_index == 0) {
                 return -1;
@@ -30,12 +31,18 @@ class uBenchmarkFixture : public ::testing::Test {
         };
         std::set<chip_id_t> target_devices = {0};
         uint32_t num_host_mem_ch_per_mmio_device = 1;
-        device = std::make_shared<Cluster>(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), "", target_devices, num_host_mem_ch_per_mmio_device, false, true);
+        device = std::make_shared<Cluster>(
+            test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"),
+            "",
+            target_devices,
+            num_host_mem_ch_per_mmio_device,
+            false,
+            true);
 
-        for(int i = 0; i < target_devices.size(); i++) {
+        for (int i = 0; i < target_devices.size(); i++) {
             // Iterate over devices and only setup static TLBs for functional worker cores
             auto& sdesc = device->get_virtual_soc_descriptors().at(i);
-            for(auto& core : sdesc.workers) {
+            for (auto& core : sdesc.workers) {
                 // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
                 device->configure_tlb(i, core, get_static_tlb_index(core), l1_mem::address_map::DATA_BUFFER_SPACE_BASE);
             }

--- a/tests/microbenchmark/test_rw_tensix.cpp
+++ b/tests/microbenchmark/test_rw_tensix.cpp
@@ -6,11 +6,11 @@
 
 #include <iostream>
 
-#include "nanobench.h"
 #include "device_fixture.hpp"
+#include "nanobench.h"
 #include "tests/test_utils/device_test_utils.hpp"
 
-std::uint32_t generate_random_address(std::uint32_t max, std::uint32_t min=0) {
+std::uint32_t generate_random_address(std::uint32_t max, std::uint32_t min = 0) {
     ankerl::nanobench::Rng gen(80085);
     std::uniform_int_distribution<> dis(min, max);  // between 0 and 1MB
     return dis(gen);
@@ -19,81 +19,119 @@ std::uint32_t generate_random_address(std::uint32_t max, std::uint32_t min=0) {
 TEST_F(uBenchmarkFixture, WriteAllCores32Bytes) {
     std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7};
     std::uint64_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
-    std::uint64_t bad_address = 0x30000000;     // this address is not mapped, should trigger fallback write/read path
+    std::uint64_t bad_address = 0x30000000;  // this address is not mapped, should trigger fallback write/read path
 
     ankerl::nanobench::Bench bench_static;
     ankerl::nanobench::Bench bench_dynamic;
-    for(auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
+    for (auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
         std::stringstream wname;
         wname << "Write to device core (" << core.x << ", " << core.y << ")";
         // Write 32 bytes through static tlbs
-        bench_static.title("Write 32 bytes").unit("writes").minEpochIterations(50).output(nullptr).run(wname.str(), [&] {
-            device->write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
-        });
+        bench_static.title("Write 32 bytes")
+            .unit("writes")
+            .minEpochIterations(50)
+            .output(nullptr)
+            .run(wname.str(), [&] {
+                device->write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(0, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
+            });
         // Write through "fallback/dynamic" tlb
-        bench_dynamic.title("Write 32 bytes fallback").unit("writes").minEpochIterations(50).output(nullptr).run(wname.str(), [&] {
-            device->write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), bad_address, "SMALL_READ_WRITE_TLB");
-        });
+        bench_dynamic.title("Write 32 bytes fallback")
+            .unit("writes")
+            .minEpochIterations(50)
+            .output(nullptr)
+            .run(wname.str(), [&] {
+                device->write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(0, core),
+                    bad_address,
+                    "SMALL_READ_WRITE_TLB");
+            });
         wname.clear();
     }
     bench_static.render(ankerl::nanobench::templates::csv(), results_csv);
     bench_dynamic.render(ankerl::nanobench::templates::csv(), results_csv);
 }
 
-TEST_F(uBenchmarkFixture, ReadAllCores32Bytes){
+TEST_F(uBenchmarkFixture, ReadAllCores32Bytes) {
     std::vector<uint32_t> readback_vec = {};
     std::uint64_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
-    std::uint64_t bad_address = 0x30000000;     // this address is not mapped, should trigger fallback write/read path
+    std::uint64_t bad_address = 0x30000000;  // this address is not mapped, should trigger fallback write/read path
 
     ankerl::nanobench::Bench bench_static;
     ankerl::nanobench::Bench bench_dynamic;
-    
-    for(auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
+
+    for (auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
         std::stringstream rname;
         // Read through static tlbs
         rname << "Read from device core (" << core.x << ", " << core.y << ")";
         bench_static.title("Read 32 bytes").unit("reads").minEpochIterations(50).output(nullptr).run(rname.str(), [&] {
-            test_utils::read_data_from_device(*device, readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
+            test_utils::read_data_from_device(
+                *device, readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
         });
         // Read through "fallback/dynamic" tlb
-        bench_dynamic.title("Read 32 bytes fallback").unit("reads").minEpochIterations(50).output(nullptr).run(rname.str(), [&] {
-            test_utils::read_data_from_device(*device, readback_vec, tt_cxy_pair(0, core), bad_address, 0x20, "SMALL_READ_WRITE_TLB");
-        });
+        bench_dynamic.title("Read 32 bytes fallback")
+            .unit("reads")
+            .minEpochIterations(50)
+            .output(nullptr)
+            .run(rname.str(), [&] {
+                test_utils::read_data_from_device(
+                    *device, readback_vec, tt_cxy_pair(0, core), bad_address, 0x20, "SMALL_READ_WRITE_TLB");
+            });
         rname.clear();
     }
     bench_static.render(ankerl::nanobench::templates::csv(), results_csv);
     bench_dynamic.render(ankerl::nanobench::templates::csv(), results_csv);
 }
 
-TEST_F(uBenchmarkFixture, Write32BytesRandomAddr){
+TEST_F(uBenchmarkFixture, Write32BytesRandomAddr) {
     std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7};
     std::uint32_t address;
 
     ankerl::nanobench::Bench bench;
-    for(auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
-        address = generate_random_address(1<<20); // between 0 and 1MB
+    for (auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
+        address = generate_random_address(1 << 20);  // between 0 and 1MB
         std::stringstream wname;
         wname << "Write to device core (" << core.x << ", " << core.y << ") @ address " << std::hex << address;
-        bench.title("Write 32 bytes random address").unit("writes").minEpochIterations(50).output(nullptr).run(wname.str(), [&] {
-            device->write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
-        });
+        bench.title("Write 32 bytes random address")
+            .unit("writes")
+            .minEpochIterations(50)
+            .output(nullptr)
+            .run(wname.str(), [&] {
+                device->write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(0, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
+            });
         wname.clear();
     }
     bench.render(ankerl::nanobench::templates::csv(), results_csv);
 }
 
-TEST_F(uBenchmarkFixture, Read32BytesRandomAddr){
+TEST_F(uBenchmarkFixture, Read32BytesRandomAddr) {
     std::vector<uint32_t> readback_vec = {};
     std::uint32_t address;
 
     ankerl::nanobench::Bench bench;
-    for(auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
-        address = generate_random_address(1<<20); // between 0 and 1MB
+    for (auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
+        address = generate_random_address(1 << 20);  // between 0 and 1MB
         std::stringstream rname;
         rname << "Read from device core (" << core.x << ", " << core.y << ") @ address " << std::hex << address;
-        bench.title("Read 32 bytes random address").unit("reads").minEpochIterations(50).output(nullptr).run(rname.str(), [&] {
-            test_utils::read_data_from_device(*device, readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
-        });
+        bench.title("Read 32 bytes random address")
+            .unit("reads")
+            .minEpochIterations(50)
+            .output(nullptr)
+            .run(rname.str(), [&] {
+                test_utils::read_data_from_device(
+                    *device, readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
+            });
         rname.clear();
     }
     bench.render(ankerl::nanobench::templates::csv(), results_csv);

--- a/tests/pcie/test_pcie_device.cpp
+++ b/tests/pcie/test_pcie_device.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <gtest/gtest.h>
-#include "fmt/xchar.h"
 
 #include <algorithm>
 #include <filesystem>
@@ -13,7 +12,7 @@
 #include <vector>
 
 #include "device/pcie/pci_device.hpp"
-
+#include "fmt/xchar.h"
 
 TEST(PcieDeviceTest, Numa) {
     std::vector<int> nodes;

--- a/tests/simulation/device_fixture.hpp
+++ b/tests/simulation/device_fixture.hpp
@@ -5,15 +5,14 @@
 #pragma once
 
 #include <gtest/gtest.h>
-
-#include "tt_simulation_device.h"
-#include "common/logger.hpp"
-#include "tests/test_utils/generate_cluster_desc.hpp"
-
 #include <nng/nng.h>
+#include <nng/protocol/pair1/pair.h>
 #include <nng/protocol/pipeline0/pull.h>
 #include <nng/protocol/pipeline0/push.h>
-#include <nng/protocol/pair1/pair.h>
+
+#include "common/logger.hpp"
+#include "tests/test_utils/generate_cluster_desc.hpp"
+#include "tt_simulation_device.h"
 
 class SimulationDeviceFixture : public ::testing::Test {
 protected:
@@ -24,9 +23,7 @@ protected:
         device->start_device(default_params);
     }
 
-    static void TearDownTestSuite() {
-        device->close_device();
-    }
+    static void TearDownTestSuite() { device->close_device(); }
 
     static std::unique_ptr<tt_SimulationDevice> device;
 };

--- a/tests/simulation/test_simulation_device.cpp
+++ b/tests/simulation/test_simulation_device.cpp
@@ -3,86 +3,79 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <random>
+
 #include "device_fixture.hpp"
 #include "tests/test_utils/device_test_utils.hpp"
 
-std::vector<uint32_t> generate_data(uint32_t size_in_bytes){
-    size_t size = size_in_bytes/sizeof(uint32_t);
+std::vector<uint32_t> generate_data(uint32_t size_in_bytes) {
+    size_t size = size_in_bytes / sizeof(uint32_t);
     std::vector<uint32_t> data(size);
     std::random_device rd;
     std::mt19937 gen(rd());
     std::uniform_int_distribution<uint32_t> dis(0, 100);
 
-    for(uint32_t i = 0; i < size; i++){
+    for (uint32_t i = 0; i < size; i++) {
         data[i] = dis(gen);
     }
     return data;
 }
 
-class LoopbackAllCoresParam : public SimulationDeviceFixture , 
-                            public ::testing::WithParamInterface<tt_xy_pair> {};
+class LoopbackAllCoresParam : public SimulationDeviceFixture, public ::testing::WithParamInterface<tt_xy_pair> {};
 
 INSTANTIATE_TEST_SUITE_P(
-    LoopbackAllCores,
-    LoopbackAllCoresParam,
-    ::testing::Values(
-        tt_xy_pair{0, 1},
-        tt_xy_pair{1, 1},
-        tt_xy_pair{1, 0}
-    )
-);
+    LoopbackAllCores, LoopbackAllCoresParam, ::testing::Values(tt_xy_pair{0, 1}, tt_xy_pair{1, 1}, tt_xy_pair{1, 0}));
 
-TEST_P(LoopbackAllCoresParam, LoopbackSingleTensix){
-    std::vector<uint32_t> wdata = {1,2,3,4,5};
+TEST_P(LoopbackAllCoresParam, LoopbackSingleTensix) {
+    std::vector<uint32_t> wdata = {1, 2, 3, 4, 5};
     std::vector<uint32_t> rdata(wdata.size(), 0);
     tt_cxy_pair core = {0, GetParam()};
 
-    device->write_to_device(wdata.data(), wdata.size()*sizeof(uint32_t), core, 0x100, "");
-    device->read_from_device(rdata.data(), core, 0x100, rdata.size()*sizeof(uint32_t), "");
-    
+    device->write_to_device(wdata.data(), wdata.size() * sizeof(uint32_t), core, 0x100, "");
+    device->read_from_device(rdata.data(), core, 0x100, rdata.size() * sizeof(uint32_t), "");
+
     ASSERT_EQ(wdata, rdata);
 }
 
-bool loopback_stress_size(std::unique_ptr<tt_SimulationDevice> &device, tt_xy_pair core, uint32_t byte_shift){
+bool loopback_stress_size(std::unique_ptr<tt_SimulationDevice> &device, tt_xy_pair core, uint32_t byte_shift) {
     uint64_t addr = 0x0;
 
     std::vector<uint32_t> wdata = generate_data(1 << byte_shift);
     std::vector<uint32_t> rdata(wdata.size(), 0);
 
-    device->write_to_device(wdata.data(), wdata.size()*sizeof(uint32_t), tt_cxy_pair{0, core}, addr, "");
-    device->read_from_device(rdata.data(), tt_cxy_pair{0, core}, addr, rdata.size()*sizeof(uint32_t), "");
-    
+    device->write_to_device(wdata.data(), wdata.size() * sizeof(uint32_t), tt_cxy_pair{0, core}, addr, "");
+    device->read_from_device(rdata.data(), tt_cxy_pair{0, core}, addr, rdata.size() * sizeof(uint32_t), "");
+
     return wdata == rdata;
 }
 
-TEST_P(LoopbackAllCoresParam, LoopbackStressSize){
+TEST_P(LoopbackAllCoresParam, LoopbackStressSize) {
     tt_xy_pair core = GetParam();
     tt_xy_pair dram = {1, 0};
     if (core == dram) {
-        for (uint32_t i = 2; i <= 30; ++i) {    // 2^30 = 1 GB
+        for (uint32_t i = 2; i <= 30; ++i) {  // 2^30 = 1 GB
             ASSERT_TRUE(loopback_stress_size(device, core, i));
         }
     } else {
-        for (uint32_t i = 2; i <= 20; ++i) {    // 2^20 = 1 MB
+        for (uint32_t i = 2; i <= 20; ++i) {  // 2^20 = 1 MB
             ASSERT_TRUE(loopback_stress_size(device, core, i));
         }
     }
 }
 
-TEST_F(SimulationDeviceFixture, LoopbackTwoTensix){
-    std::vector<uint32_t> wdata1 = {1,2,3,4,5};
-    std::vector<uint32_t> wdata2 = {6,7,8,9,10};
+TEST_F(SimulationDeviceFixture, LoopbackTwoTensix) {
+    std::vector<uint32_t> wdata1 = {1, 2, 3, 4, 5};
+    std::vector<uint32_t> wdata2 = {6, 7, 8, 9, 10};
     std::vector<uint32_t> rdata1(wdata1.size());
     std::vector<uint32_t> rdata2(wdata2.size());
     tt_cxy_pair core1 = {0, 0, 1};
     tt_cxy_pair core2 = {0, 1, 1};
 
-    device->write_to_device(wdata1.data(), wdata1.size()*sizeof(uint32_t),  core1, 0x100, "");
-    device->write_to_device(wdata2.data(), wdata2.size()*sizeof(uint32_t), core2, 0x100, "");
+    device->write_to_device(wdata1.data(), wdata1.size() * sizeof(uint32_t), core1, 0x100, "");
+    device->write_to_device(wdata2.data(), wdata2.size() * sizeof(uint32_t), core2, 0x100, "");
 
-    device->read_from_device(rdata1.data(), core1, 0x100, rdata1.size()*sizeof(uint32_t), "");
-    device->read_from_device(rdata2.data(), core2, 0x100, rdata2.size()*sizeof(uint32_t), "");
-    
+    device->read_from_device(rdata1.data(), core1, 0x100, rdata1.size() * sizeof(uint32_t), "");
+    device->read_from_device(rdata2.data(), core2, 0x100, rdata2.size() * sizeof(uint32_t), "");
+
     ASSERT_EQ(wdata1, rdata1);
     ASSERT_EQ(wdata2, rdata2);
 }

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -15,7 +15,7 @@
 namespace test_utils {
 
 template <typename T>
-static void size_buffer_to_capacity(std::vector<T> &data_buf, std::size_t size_in_bytes) {
+static void size_buffer_to_capacity(std::vector<T>& data_buf, std::size_t size_in_bytes) {
     std::size_t target_size = 0;
     if (size_in_bytes > 0) {
         target_size = ((size_in_bytes - 1) / sizeof(T)) + 1;
@@ -23,22 +23,27 @@ static void size_buffer_to_capacity(std::vector<T> &data_buf, std::size_t size_i
     data_buf.resize(target_size);
 }
 
-static void read_data_from_device(tt_device& device, std::vector<uint32_t> &vec, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use) {
+static void read_data_from_device(
+    tt_device& device,
+    std::vector<uint32_t>& vec,
+    tt_cxy_pair core,
+    uint64_t addr,
+    uint32_t size,
+    const std::string& tlb_to_use) {
     size_buffer_to_capacity(vec, size);
     device.read_from_device(vec.data(), core, addr, size, tlb_to_use);
 }
 
-inline void fill_with_random_bytes(uint8_t* data, size_t n)
-{
+inline void fill_with_random_bytes(uint8_t* data, size_t n) {
     static std::random_device rd;
     static std::mt19937_64 gen(rd());
     uint64_t* data64 = reinterpret_cast<uint64_t*>(data);
-    std::generate_n(data64, n/8, [&]() { return gen(); });
+    std::generate_n(data64, n / 8, [&]() { return gen(); });
 
     // Handle remaining bytes
-    for (size_t i = (n/8)*8; i < n; ++i) {
+    for (size_t i = (n / 8) * 8; i < n; ++i) {
         data[i] = static_cast<uint8_t>(gen());
     }
 }
 
-}
+}  // namespace test_utils

--- a/tests/test_utils/generate_cluster_desc.hpp
+++ b/tests/test_utils/generate_cluster_desc.hpp
@@ -7,24 +7,26 @@
 #pragma once
 
 #include <filesystem>
-#include <string>
 #include <iostream>
+#include <string>
 
 #include "fmt/core.h"
 
 namespace test_utils {
 
-inline std::string GetAbsPath(std::string path_){
-    // Note that __FILE__ might be resolved at compile time to an absolute or relative address, depending on the compiler.
+inline std::string GetAbsPath(std::string path_) {
+    // Note that __FILE__ might be resolved at compile time to an absolute or relative address, depending on the
+    // compiler.
     std::filesystem::path current_file_path = std::filesystem::path(__FILE__);
     std::filesystem::path umd_root;
     if (current_file_path.is_absolute()) {
         umd_root = current_file_path.parent_path().parent_path().parent_path();
     } else {
-        std::filesystem::path umd_root_relative = std::filesystem::relative(std::filesystem::path(__FILE__).parent_path().parent_path().parent_path(), "../");
+        std::filesystem::path umd_root_relative =
+            std::filesystem::relative(std::filesystem::path(__FILE__).parent_path().parent_path().parent_path(), "../");
         umd_root = std::filesystem::canonical(umd_root_relative);
     }
     std::filesystem::path abs_path = umd_root / path_;
     return abs_path.string();
 }
-} // namespace test_utils
+}  // namespace test_utils

--- a/tests/test_utils/soc_desc_test_utils.hpp
+++ b/tests/test_utils/soc_desc_test_utils.hpp
@@ -15,4 +15,4 @@ static std::size_t get_num_harvested(std::size_t harvesting_mask) {
     return __builtin_popcount(harvesting_mask);
 }
 
-}
+}  // namespace test_utils

--- a/tests/test_utils/stimulus_generators.hpp
+++ b/tests/test_utils/stimulus_generators.hpp
@@ -4,18 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
-#include "tt_xy_pair.h"
-#include "tt_cluster_descriptor.h"
-#include "cluster.h"
-
-
+#include <cassert>
 #include <functional>
 #include <iostream>
 #include <map>
 #include <random>
-#include <vector>
 #include <variant>
-#include <cassert>
+#include <vector>
+
+#include "cluster.h"
+#include "tt_cluster_descriptor.h"
+#include "tt_xy_pair.h"
 
 /* Sizes:
  * Distribution (including min/max)
@@ -40,7 +39,6 @@ namespace tt::umd::test::utils {
 
 static const std::string SOC_DESC_PATH = "tests/soc_descs/wormhole_b0_8x10.yaml";
 
-
 enum RemoteTransferType : uint8_t { WRITE = 0, READ };
 
 template <
@@ -50,7 +48,7 @@ template <
     class DISTRIBUTION_T,
     typename GENERATOR_T = std::mt19937>
 class ConstrainedTemplateTemplateGenerator {
-   public:
+public:
     ConstrainedTemplateTemplateGenerator(
         int seed,
         DISTRIBUTION_T<UNCONSTRAINED_SAMPLE_T> const& distribution,
@@ -62,24 +60,17 @@ class ConstrainedTemplateTemplateGenerator {
         return constrain(sample);
     }
 
-   private:
+private:
     GENERATOR_T generator;
     DISTRIBUTION_T<UNCONSTRAINED_SAMPLE_T> distribution;
     std::function<SAMPLE_T(UNCONSTRAINED_SAMPLE_T)> constrain;
 };
 
-
-template <
-    typename SAMPLE_T,
-    typename UNCONSTRAINED_SAMPLE_T,
-    class DISTRIBUTION_T,
-    typename GENERATOR_T = std::mt19937>
+template <typename SAMPLE_T, typename UNCONSTRAINED_SAMPLE_T, class DISTRIBUTION_T, typename GENERATOR_T = std::mt19937>
 class ConstrainedTemplateGenerator {
-   public:
+public:
     ConstrainedTemplateGenerator(
-        int seed,
-        DISTRIBUTION_T const& distribution,
-        std::function<SAMPLE_T(UNCONSTRAINED_SAMPLE_T)> constrain) :
+        int seed, DISTRIBUTION_T const& distribution, std::function<SAMPLE_T(UNCONSTRAINED_SAMPLE_T)> constrain) :
         generator(seed), distribution(distribution), constrain(constrain) {}
 
     SAMPLE_T generate() {
@@ -87,14 +78,14 @@ class ConstrainedTemplateGenerator {
         return constrain(sample);
     }
 
-   private:
+private:
     GENERATOR_T generator;
     DISTRIBUTION_T distribution;
     std::function<SAMPLE_T(UNCONSTRAINED_SAMPLE_T)> constrain;
 };
 
-
-using DefaultTransferTypeGenerator = ConstrainedTemplateTemplateGenerator<RemoteTransferType, int, std::discrete_distribution>;
+using DefaultTransferTypeGenerator =
+    ConstrainedTemplateTemplateGenerator<RemoteTransferType, int, std::discrete_distribution>;
 
 using address_t = uint32_t;
 using destination_t = tt_cxy_pair;
@@ -107,6 +98,7 @@ struct write_transfer_sample_t {
     std::string tlb_to_use;
     // (payload.data(), size, destination, address, tlb_to_use, false, false);
 };
+
 struct read_transfer_sample_t {
     destination_t destination;
     address_t address;
@@ -115,7 +107,8 @@ struct read_transfer_sample_t {
     // (payload.data(), destination, address, size, tlb_to_use);
 };
 
-using remote_transfer_sample_t = std::tuple<RemoteTransferType, std::variant<write_transfer_sample_t, read_transfer_sample_t>>;
+using remote_transfer_sample_t =
+    std::tuple<RemoteTransferType, std::variant<write_transfer_sample_t, read_transfer_sample_t>>;
 
 template <
     template <typename>
@@ -130,7 +123,8 @@ template <
 struct WriteCommandGenerator {
     using destination_generator_t = ConstrainedTemplateTemplateGenerator<destination_t, int, DEST_DISTR_T, GENERATOR_T>;
     using address_generator_t = ConstrainedTemplateTemplateGenerator<address_t, address_t, ADDR_DISTR_T, GENERATOR_T>;
-    using size_generator_t = ConstrainedTemplateTemplateGenerator<transfer_size_t, DISTR_OUT_T, SIZE_DISTR_T, GENERATOR_T>;
+    using size_generator_t =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, DISTR_OUT_T, SIZE_DISTR_T, GENERATOR_T>;
 
     WriteCommandGenerator(
         destination_generator_t const& destination_generator,
@@ -159,7 +153,8 @@ template <
 struct WriteEpochCmdCommandGenerator {
     using destination_generator_t = ConstrainedTemplateTemplateGenerator<destination_t, int, DEST_DISTR_T, GENERATOR_T>;
     using address_generator_t = ConstrainedTemplateTemplateGenerator<address_t, address_t, ADDR_DISTR_T, GENERATOR_T>;
-    using size_generator_t = ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, SIZE_DISTR_T, GENERATOR_T>;
+    using size_generator_t =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, SIZE_DISTR_T, GENERATOR_T>;
     using last_cmd_generator_t = ConstrainedTemplateGenerator<bool, bool, LAST_CMD_DISTR_T, GENERATOR_T>;
     using ordered_generator_t = ConstrainedTemplateGenerator<bool, bool, ORDERED_DISTR_T, GENERATOR_T>;
 
@@ -196,8 +191,10 @@ template <
     typename GENERATOR_T = std::mt19937>
 struct RolledWriteCommandGenerator {
     using destination_generator_t = ConstrainedTemplateTemplateGenerator<destination_t, int, DEST_DISTR_T, GENERATOR_T>;
-    using address_generator_t = ConstrainedTemplateTemplateGenerator<address_t, address_t, SIZE_DISTR_OUT_T, GENERATOR_T>;
-    using size_generator_t = ConstrainedTemplateTemplateGenerator<transfer_size_t, DISTR_SIZE_OUT_T, SIZE_DISTR_T, GENERATOR_T>;
+    using address_generator_t =
+        ConstrainedTemplateTemplateGenerator<address_t, address_t, SIZE_DISTR_OUT_T, GENERATOR_T>;
+    using size_generator_t =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, DISTR_SIZE_OUT_T, SIZE_DISTR_T, GENERATOR_T>;
     using unroll_count_generator_t = ConstrainedTemplateTemplateGenerator<int, int, UNROLL_COUNT_DISTR_T, GENERATOR_T>;
 
     RolledWriteCommandGenerator(
@@ -229,7 +226,8 @@ template <
 struct ReadCommandGenerator {
     using destination_generator_t = ConstrainedTemplateTemplateGenerator<destination_t, int, DEST_DISTR_T, GENERATOR_T>;
     using address_generator_t = ConstrainedTemplateTemplateGenerator<address_t, address_t, ADDR_DISTR_T, GENERATOR_T>;
-    using size_generator_t = ConstrainedTemplateTemplateGenerator<transfer_size_t, DISTR_OUT_T, SIZE_DISTR_T, GENERATOR_T>;
+    using size_generator_t =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, DISTR_OUT_T, SIZE_DISTR_T, GENERATOR_T>;
 
     ReadCommandGenerator(
         destination_generator_t const& destination_generator,
@@ -238,8 +236,6 @@ struct ReadCommandGenerator {
         destination_generator(destination_generator),
         address_generator(address_generator),
         size_generator(size_generator) {}
-
-
 
     destination_generator_t destination_generator;
     address_generator_t address_generator;
@@ -265,12 +261,14 @@ template <
 
     typename GENERATOR_T = std::mt19937>
 class TestGenerator {
-    using transfer_type_generator_t = DefaultTransferTypeGenerator;  // ConstrainedTemplateTemplateGenerator<RemoteTransferType, int,
-                                                                     // TRANS_TYPE_DISTRIBUTION_T, GENERATOR_T>;
-    using write_command_generator_t = WriteCommandGenerator<WRITE_DEST_DISTR_T, WRITE_ADDR_DISTR_T, WRITE_SIZE_DISTR_OUT_T, WRITE_SIZE_DISTR_T>;
-    using read_command_generator_t = ReadCommandGenerator<READ_DEST_DISTR_T,READ_ADDR_DISTR_T, READ_SIZE_DISTR_OUT_T, READ_SIZE_DISTR_T>;
+    using transfer_type_generator_t = DefaultTransferTypeGenerator;  // ConstrainedTemplateTemplateGenerator<RemoteTransferType,
+                                                                     // int, TRANS_TYPE_DISTRIBUTION_T, GENERATOR_T>;
+    using write_command_generator_t =
+        WriteCommandGenerator<WRITE_DEST_DISTR_T, WRITE_ADDR_DISTR_T, WRITE_SIZE_DISTR_OUT_T, WRITE_SIZE_DISTR_T>;
+    using read_command_generator_t =
+        ReadCommandGenerator<READ_DEST_DISTR_T, READ_ADDR_DISTR_T, READ_SIZE_DISTR_OUT_T, READ_SIZE_DISTR_T>;
 
-   public:
+public:
     TestGenerator(
         int seed,
         transfer_type_generator_t const& transfer_type_distribution,
@@ -279,13 +277,10 @@ class TestGenerator {
         generator(seed),
         transfer_type_distribution(transfer_type_distribution),
         write_command_generator(write_command_generator),
-        read_command_generator(read_command_generator)
-    {
-    }
+        read_command_generator(read_command_generator) {}
 
     // Generate a sample (transfer type, size, destination, address) based on custom distributions
     remote_transfer_sample_t generate_sample() {
-
         // Randomly select a transfer type
         RemoteTransferType transfer_type = transfer_type_distribution.generate();
         assert(transfer_type < 4 && transfer_type >= 0);
@@ -294,22 +289,26 @@ class TestGenerator {
                 destination_t const& destination = write_command_generator.destination_generator.generate();
                 address_t const& address = write_command_generator.address_generator.generate();
                 transfer_size_t const& size_in_bytes = write_command_generator.size_generator.generate();
-                return {transfer_type, write_transfer_sample_t{
-                    .destination = destination,
-                    .address = address,
-                    .size_in_bytes = size_in_bytes,
-                    .tlb_to_use = "LARGE_WRITE_TLB"}};
+                return {
+                    transfer_type,
+                    write_transfer_sample_t{
+                        .destination = destination,
+                        .address = address,
+                        .size_in_bytes = size_in_bytes,
+                        .tlb_to_use = "LARGE_WRITE_TLB"}};
             } break;
 
             case RemoteTransferType::READ: {
                 destination_t const& destination = read_command_generator.destination_generator.generate();
                 address_t const& address = read_command_generator.address_generator.generate();
                 transfer_size_t const& size_in_bytes = read_command_generator.size_generator.generate();
-                return {transfer_type, read_transfer_sample_t{
-                    .destination = destination,
-                    .address = address,
-                    .size_in_bytes = size_in_bytes,
-                    .tlb_to_use = "LARGE_READ_TLB"}};
+                return {
+                    transfer_type,
+                    read_transfer_sample_t{
+                        .destination = destination,
+                        .address = address,
+                        .size_in_bytes = size_in_bytes,
+                        .tlb_to_use = "LARGE_READ_TLB"}};
             } break;
 
             default:
@@ -317,7 +316,7 @@ class TestGenerator {
         };
     }
 
-   private:
+private:
     std::mt19937 generator;
 
     transfer_type_generator_t transfer_type_distribution;
@@ -331,15 +330,32 @@ struct transfer_type_weights_t {
     double read;
 };
 
-
-static auto address_aligner = [](address_t addr) -> address_t { addr = (((addr - 1) / 32) + 1) * 32; assert(addr % 32 == 0); return addr;};
-static auto transfer_size_aligner = [](transfer_size_t size) -> transfer_size_t { size = (((size - 1) / 4) + 1) * 4; assert(size > 0); assert(size % 4 == 0); return size; };
-static auto address_aligner_32B = [](transfer_size_t size) -> transfer_size_t { size = (((size - 1) / 32) + 1) * 32; assert(size > 0); return size;};
-static auto size_aligner_32B = [](transfer_size_t size) -> transfer_size_t { size = (((size - 1) / 32) + 1) * 32; assert(size > 0); return size;};
-template<typename T>
+static auto address_aligner = [](address_t addr) -> address_t {
+    addr = (((addr - 1) / 32) + 1) * 32;
+    assert(addr % 32 == 0);
+    return addr;
+};
+static auto transfer_size_aligner = [](transfer_size_t size) -> transfer_size_t {
+    size = (((size - 1) / 4) + 1) * 4;
+    assert(size > 0);
+    assert(size % 4 == 0);
+    return size;
+};
+static auto address_aligner_32B = [](transfer_size_t size) -> transfer_size_t {
+    size = (((size - 1) / 32) + 1) * 32;
+    assert(size > 0);
+    return size;
+};
+static auto size_aligner_32B = [](transfer_size_t size) -> transfer_size_t {
+    size = (((size - 1) / 32) + 1) * 32;
+    assert(size > 0);
+    return size;
+};
+template <typename T>
 static auto passthrough_constrainer = [](T const& t) -> T { return t; };
 
-static inline std::vector<destination_t> generate_core_index_locations(tt_ClusterDescriptor const& cluster_desc, tt_SocDescriptor const& soc_desc) {
+static inline std::vector<destination_t> generate_core_index_locations(
+    tt_ClusterDescriptor const& cluster_desc, tt_SocDescriptor const& soc_desc) {
     std::vector<destination_t> core_index_to_location = {};
 
     for (chip_id_t chip : cluster_desc.get_all_chips()) {
@@ -360,16 +376,19 @@ static void print_command(remote_transfer_sample_t const& command) {
         case RemoteTransferType::WRITE: {
             write_transfer_sample_t const& command_args = std::get<write_transfer_sample_t>(std::get<1>(command));
             std::cout << "Transfer type: WRITE, destination: (c=" << command_args.destination.chip
-                        << ", y=" << command_args.destination.y << ", x=" << command_args.destination.x
-                        << "), address: " << command_args.address << ", size_in_bytes: " << command_args.size_in_bytes << std::endl;
+                      << ", y=" << command_args.destination.y << ", x=" << command_args.destination.x
+                      << "), address: " << command_args.address << ", size_in_bytes: " << command_args.size_in_bytes
+                      << std::endl;
         } break;
         case RemoteTransferType::READ: {
             read_transfer_sample_t const& command_args = std::get<read_transfer_sample_t>(std::get<1>(command));
             std::cout << "Transfer type: READ, destination: (c=" << command_args.destination.chip
-                        << ", y=" << command_args.destination.y << ", x=" << command_args.destination.x
-                        << "), address: " << command_args.address << ", size_in_bytes: " << command_args.size_in_bytes << std::endl;
+                      << ", y=" << command_args.destination.y << ", x=" << command_args.destination.x
+                      << "), address: " << command_args.address << ", size_in_bytes: " << command_args.size_in_bytes
+                      << std::endl;
         } break;
-        default: throw std::runtime_error("Invalid transfer type");
+        default:
+            throw std::runtime_error("Invalid transfer type");
     };
 }
 
@@ -379,12 +398,9 @@ int bytes_to_words(int num_bytes) {
 }
 
 static inline void dispatch_remote_transfer_command(
-    Cluster &driver, 
-    remote_transfer_sample_t const& command, 
-    std::vector<uint32_t> &payload) {
-
+    Cluster& driver, remote_transfer_sample_t const& command, std::vector<uint32_t>& payload) {
     RemoteTransferType transfer_type = std::get<0>(command);
-    auto resize_payload = [](std::vector<uint32_t> &payload, int size_in_bytes) {
+    auto resize_payload = [](std::vector<uint32_t>& payload, int size_in_bytes) {
         payload.resize(bytes_to_words<uint32_t>(size_in_bytes));
     };
 
@@ -392,28 +408,37 @@ static inline void dispatch_remote_transfer_command(
         case RemoteTransferType::WRITE: {
             write_transfer_sample_t const& command_args = std::get<write_transfer_sample_t>(std::get<1>(command));
             assert(command_args.size_in_bytes >= sizeof(uint32_t));
-            resize_payload(payload,command_args.size_in_bytes);
-            driver.write_to_device(payload.data(), bytes_to_words<uint32_t>(command_args.size_in_bytes), command_args.destination, command_args.address, command_args.tlb_to_use);
+            resize_payload(payload, command_args.size_in_bytes);
+            driver.write_to_device(
+                payload.data(),
+                bytes_to_words<uint32_t>(command_args.size_in_bytes),
+                command_args.destination,
+                command_args.address,
+                command_args.tlb_to_use);
         } break;
         case RemoteTransferType::READ: {
             read_transfer_sample_t const& command_args = std::get<read_transfer_sample_t>(std::get<1>(command));
             assert(command_args.size_in_bytes >= sizeof(uint32_t));
-            resize_payload(payload,command_args.size_in_bytes);
-            driver.read_from_device(payload.data(), command_args.destination, command_args.address, command_args.size_in_bytes, command_args.tlb_to_use);
+            resize_payload(payload, command_args.size_in_bytes);
+            driver.read_from_device(
+                payload.data(),
+                command_args.destination,
+                command_args.address,
+                command_args.size_in_bytes,
+                command_args.tlb_to_use);
         } break;
         default:
             throw std::runtime_error("Invalid transfer type");
     };
 }
 
-
 static void print_command_executable_code(remote_transfer_sample_t const& command) {
-
     auto emit_payload_resize_string = [](int size_bytes, int size_word) {
         std::cout << "payload.resize(((" << size_bytes << " - 1) / " << size_word << ") + 1);" << std::endl;
     };
     auto emit_bytes_to_words_len_string = [](std::string const& var_name, int size_in_bytes, int size_word) {
-        std::cout << "int " << var_name << " = (((" << size_in_bytes << " - 1) / " << size_word << ") + 1);" << std::endl;
+        std::cout << "int " << var_name << " = (((" << size_in_bytes << " - 1) / " << size_word << ") + 1);"
+                  << std::endl;
     };
 
     std::cout << "{" << std::endl;
@@ -421,19 +446,25 @@ static void print_command_executable_code(remote_transfer_sample_t const& comman
         case RemoteTransferType::WRITE: {
             write_transfer_sample_t const& command_args = std::get<write_transfer_sample_t>(std::get<1>(command));
             assert(command_args.size_in_bytes >= sizeof(uint32_t));
-            std::cout << "tt_cxy_pair const& destination = tt_cxy_pair(" << command_args.destination.chip << ", " << command_args.destination.x << ", " << command_args.destination.y << ");"  << std::endl;
+            std::cout << "tt_cxy_pair const& destination = tt_cxy_pair(" << command_args.destination.chip << ", "
+                      << command_args.destination.x << ", " << command_args.destination.y << ");" << std::endl;
             std::cout << "assert(" << command_args.size_in_bytes << " >= sizeof(uint32_t));" << std::endl;
             emit_bytes_to_words_len_string("len", command_args.size_in_bytes, sizeof(uint32_t));
             emit_payload_resize_string(command_args.size_in_bytes, sizeof(uint32_t));
-            std::cout << "device->write_to_device(payload.data(), len, destination, " << command_args.address << ", \"" << command_args.tlb_to_use << "\");" << std::endl;
-            // driver.write_to_device(payload.data(), command_args.size, command_args.destination, command_args.address, command_args.tlb_to_use, false, false);
+            std::cout << "device->write_to_device(payload.data(), len, destination, " << command_args.address << ", \""
+                      << command_args.tlb_to_use << "\");" << std::endl;
+            // driver.write_to_device(payload.data(), command_args.size, command_args.destination, command_args.address,
+            // command_args.tlb_to_use, false, false);
         } break;
         case RemoteTransferType::READ: {
             read_transfer_sample_t const& command_args = std::get<read_transfer_sample_t>(std::get<1>(command));
-            std::cout << "tt_cxy_pair const& destination = tt_cxy_pair(" << command_args.destination.chip << ", " << command_args.destination.x << ", " << command_args.destination.y << ");"  << std::endl;
+            std::cout << "tt_cxy_pair const& destination = tt_cxy_pair(" << command_args.destination.chip << ", "
+                      << command_args.destination.x << ", " << command_args.destination.y << ");" << std::endl;
             emit_payload_resize_string(command_args.size_in_bytes, sizeof(uint32_t));
-            std::cout << "device->read_from_device(payload.data(), destination, " << command_args.address << ", " << command_args.size_in_bytes << ", \"" << command_args.tlb_to_use << "\");" << std::endl;
-            // driver.read_from_device(payload.data(), command_args.destination, command_args.address, command_args.size, command_args.tlb_to_use);
+            std::cout << "device->read_from_device(payload.data(), destination, " << command_args.address << ", "
+                      << command_args.size_in_bytes << ", \"" << command_args.tlb_to_use << "\");" << std::endl;
+            // driver.read_from_device(payload.data(), command_args.destination, command_args.address,
+            // command_args.size, command_args.tlb_to_use);
         } break;
         default:
             throw std::runtime_error("Invalid transfer type");
@@ -450,32 +481,36 @@ static void print_command_history_executable_code(std::vector<remote_transfer_sa
     }
 }
 
-
-
-template<
-    template <typename> class WRITE_DEST_DISTR_T, 
-    template <typename> class WRITE_ADDR_DISTR_T, 
+template <
+    template <typename>
+    class WRITE_DEST_DISTR_T,
+    template <typename>
+    class WRITE_ADDR_DISTR_T,
     class WRITE_SIZE_DISTR_OUT_T,
-    template <typename> class WRITE_SIZE_DISTR_T,
+    template <typename>
+    class WRITE_SIZE_DISTR_T,
 
-    template <typename> class READ_DEST_DISTR_T, 
-    template <typename> class READ_ADDR_DISTR_T, 
-    class READ_SIZE_DISTR_OUT_T, 
-    template <typename> class READ_SIZE_DISTR_T
->
+    template <typename>
+    class READ_DEST_DISTR_T,
+    template <typename>
+    class READ_ADDR_DISTR_T,
+    class READ_SIZE_DISTR_OUT_T,
+    template <typename>
+    class READ_SIZE_DISTR_T>
 void RunMixedTransfers(
-    Cluster& device, 
+    Cluster& device,
     int num_samples,
     int seed,
 
     transfer_type_weights_t const& transfer_type_weights,
 
-    WriteCommandGenerator<WRITE_DEST_DISTR_T, WRITE_ADDR_DISTR_T, WRITE_SIZE_DISTR_OUT_T, WRITE_SIZE_DISTR_T> const& write_command_generator,
-    ReadCommandGenerator<READ_DEST_DISTR_T, READ_ADDR_DISTR_T, READ_SIZE_DISTR_OUT_T, READ_SIZE_DISTR_T> const& read_command_generator,
-    
+    WriteCommandGenerator<WRITE_DEST_DISTR_T, WRITE_ADDR_DISTR_T, WRITE_SIZE_DISTR_OUT_T, WRITE_SIZE_DISTR_T> const&
+        write_command_generator,
+    ReadCommandGenerator<READ_DEST_DISTR_T, READ_ADDR_DISTR_T, READ_SIZE_DISTR_OUT_T, READ_SIZE_DISTR_T> const&
+        read_command_generator,
+
     bool record_command_history = false,
-    std::vector<remote_transfer_sample_t> *command_history = nullptr
-) {
+    std::vector<remote_transfer_sample_t>* command_history = nullptr) {
     SCOPED_TRACE("RunMixedTransfers");
     auto test_generator = TestGenerator(
         seed,
@@ -490,7 +525,7 @@ void RunMixedTransfers(
 
     if (record_command_history) {
         assert(command_history != nullptr);
-        assert(command_history->size() == 0); // only support passing in empty command histories
+        assert(command_history->size() == 0);  // only support passing in empty command histories
         command_history->reserve(num_samples);
     }
     std::vector<uint32_t> payload = {};
@@ -513,16 +548,17 @@ void RunMixedTransfers(
     }
 }
 
-
-static ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution> get_default_address_generator(int seed, address_t start, address_t end) {
+static ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>
+get_default_address_generator(int seed, address_t start, address_t end) {
     auto const& address_distribution = std::uniform_int_distribution<address_t>(start, end);
-    return ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(seed + 1, address_distribution, address_aligner);
+    return ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(
+        seed + 1, address_distribution, address_aligner);
 }
 
-
-static ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int_distribution> get_default_full_dram_dest_generator(int seed, Cluster *device) {
+static ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int_distribution>
+get_default_full_dram_dest_generator(int seed, Cluster* device) {
     assert(device != nullptr);
-    tt_ClusterDescriptor *cluster_desc = device->get_cluster_description();
+    tt_ClusterDescriptor* cluster_desc = device->get_cluster_description();
     tt_SocDescriptor const& soc_desc = device->get_virtual_soc_descriptors().at(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
 
@@ -536,19 +572,23 @@ static WriteCommandGenerator<
     std::uniform_int_distribution,
     std::uniform_int_distribution,
     transfer_size_t,
-    std::uniform_int_distribution
-> build_dummy_write_command_generator(Cluster &device) {
-    tt_ClusterDescriptor *cluster_desc = device.get_cluster_description();
+    std::uniform_int_distribution>
+build_dummy_write_command_generator(Cluster& device) {
+    tt_ClusterDescriptor* cluster_desc = device.get_cluster_description();
     tt_SocDescriptor const& soc_desc = device.get_virtual_soc_descriptors().at(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
     auto dest_generator = ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int_distribution>(
         0,
         std::uniform_int_distribution<int>(0, core_index_to_location.size() - 1),
         [core_index_to_location](int dest) -> destination_t { return core_index_to_location.at(dest); });
-    auto addr_generator = ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(0 , std::uniform_int_distribution<address_t>(0,0), address_aligner);
-    auto addr_generator_32B_aligned = ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(0, std::uniform_int_distribution<address_t>(0,0), address_aligner_32B);
-    auto write_size_generator = ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
-        0, std::uniform_int_distribution<address_t>(0,0), transfer_size_aligner);
+    auto addr_generator = ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(
+        0, std::uniform_int_distribution<address_t>(0, 0), address_aligner);
+    auto addr_generator_32B_aligned =
+        ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(
+            0, std::uniform_int_distribution<address_t>(0, 0), address_aligner_32B);
+    auto write_size_generator =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
+            0, std::uniform_int_distribution<address_t>(0, 0), transfer_size_aligner);
 
     return WriteCommandGenerator(dest_generator, addr_generator, write_size_generator);
 }
@@ -557,24 +597,25 @@ static ReadCommandGenerator<
     std::uniform_int_distribution,
     std::uniform_int_distribution,
     transfer_size_t,
-    std::uniform_int_distribution
-> build_dummy_read_command_generator(Cluster &device) {
-    tt_ClusterDescriptor *cluster_desc = device.get_cluster_description();
+    std::uniform_int_distribution>
+build_dummy_read_command_generator(Cluster& device) {
+    tt_ClusterDescriptor* cluster_desc = device.get_cluster_description();
     tt_SocDescriptor const& soc_desc = device.get_virtual_soc_descriptors().at(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
     auto dest_generator = ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int_distribution>(
         0,
         std::uniform_int_distribution<int>(0, core_index_to_location.size() - 1),
         [core_index_to_location](int dest) -> destination_t { return core_index_to_location.at(dest); });
-    auto addr_generator = ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(0, std::uniform_int_distribution<address_t>(0,0), address_aligner);
-    auto read_size_generator = ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
-        0, std::uniform_int_distribution<transfer_size_t>(0,0), transfer_size_aligner);
+    auto addr_generator = ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(
+        0, std::uniform_int_distribution<address_t>(0, 0), address_aligner);
+    auto read_size_generator =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
+            0, std::uniform_int_distribution<transfer_size_t>(0, 0), transfer_size_aligner);
 
     return ReadCommandGenerator(dest_generator, addr_generator, read_size_generator);
-   
 }
 
-template<
+template <
     template <typename>
     class ADDR_GENERATOR_T,
     typename ADDR_DISTR_T,
@@ -583,10 +624,9 @@ template<
     template <typename>
     class READ_SIZE_GENERATOR_T,
     template <typename>
-    class UNROLL_COUNT_GENERATOR_T
->
+    class UNROLL_COUNT_GENERATOR_T>
 void RunMixedTransfersUniformDistributions(
-    Cluster& device, 
+    Cluster& device,
     int num_samples,
     int seed,
 
@@ -597,11 +637,10 @@ void RunMixedTransfersUniformDistributions(
     float percent_not_last_epoch_cmd,
     float percent_not_remote_ordered,
     READ_SIZE_GENERATOR_T<transfer_size_t> const& read_size_distribution,
-    
+
     bool record_command_history = false,
-    std::vector<remote_transfer_sample_t> *command_history = nullptr
-) {
-    tt_ClusterDescriptor *cluster_desc = device.get_cluster_description();
+    std::vector<remote_transfer_sample_t>* command_history = nullptr) {
+    tt_ClusterDescriptor* cluster_desc = device.get_cluster_description();
     tt_SocDescriptor const& soc_desc = device.get_virtual_soc_descriptors().at(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
 
@@ -609,21 +648,30 @@ void RunMixedTransfersUniformDistributions(
         seed,
         std::uniform_int_distribution<int>(0, core_index_to_location.size() - 1),
         [&core_index_to_location](int dest) -> destination_t { return core_index_to_location.at(dest); });
-    auto addr_generator = ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(seed + 1, address_distribution, address_aligner);
-    auto addr_generator_32B_aligned = ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(seed + 1, address_distribution, address_aligner_32B);
-    auto write_size_generator = ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
-        seed + 2, write_size_distribution, transfer_size_aligner);
-    auto read_size_generator = ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
-        seed + 2, read_size_distribution, transfer_size_aligner);
+    auto addr_generator = ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(
+        seed + 1, address_distribution, address_aligner);
+    auto addr_generator_32B_aligned =
+        ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(
+            seed + 1, address_distribution, address_aligner_32B);
+    auto write_size_generator =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
+            seed + 2, write_size_distribution, transfer_size_aligner);
+    auto read_size_generator =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
+            seed + 2, read_size_distribution, transfer_size_aligner);
     auto last_epoch_cmd_generator = ConstrainedTemplateGenerator<bool, bool, std::bernoulli_distribution>(
-        seed + 3, std::bernoulli_distribution(percent_not_last_epoch_cmd), [](bool last_epoch_cmd) -> bool { return last_epoch_cmd; });
+        seed + 3, std::bernoulli_distribution(percent_not_last_epoch_cmd), [](bool last_epoch_cmd) -> bool {
+            return last_epoch_cmd;
+        });
     auto ordered_generator = ConstrainedTemplateGenerator<bool, bool, std::bernoulli_distribution>(
-        seed + 3, std::bernoulli_distribution(percent_not_remote_ordered), [](bool ordered_with_prev_remote_write) -> bool { return ordered_with_prev_remote_write; });
+        seed + 3,
+        std::bernoulli_distribution(percent_not_remote_ordered),
+        [](bool ordered_with_prev_remote_write) -> bool { return ordered_with_prev_remote_write; });
     auto unroll_count_generator = ConstrainedTemplateTemplateGenerator<int, int, std::uniform_int_distribution>(
         seed + 4, unroll_count_distribution, [](int unroll_count) -> int { return unroll_count; });
 
     RunMixedTransfers(
-        device, 
+        device,
         num_samples,
         seed,
 
@@ -631,12 +679,9 @@ void RunMixedTransfersUniformDistributions(
 
         WriteCommandGenerator(dest_generator, addr_generator, write_size_generator),
         ReadCommandGenerator(dest_generator, addr_generator, read_size_generator),
-        
+
         record_command_history,
-        command_history
-    );
-
+        command_history);
 }
-
 
 }  // namespace tt::umd::test::utils

--- a/tests/unit_test_main.cpp
+++ b/tests/unit_test_main.cpp
@@ -3,10 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "gtest/gtest.h"
-
 #include "gtest_initializer.hpp"
 
 int main(int argc, char **argv) {
-  initialize_gtest(argc, argv);
-  return RUN_ALL_TESTS();
+    initialize_gtest(argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/wormhole/test_silicon_driver_wh.cpp
+++ b/tests/wormhole/test_silicon_driver_wh.cpp
@@ -1,32 +1,40 @@
 // SPDX-FileCopyrightText: (c) 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-#include <thread>
 #include <memory>
+#include <thread>
 
-#include "gtest/gtest.h"
 #include "cluster.h"
-#include "eth_l1_address_map.h"
-#include "l1_address_map.h"
-#include "host_mem_address_map.h"
-
 #include "device/tt_cluster_descriptor.h"
 #include "device/wormhole/wormhole_implementation.h"
-#include "tests/test_utils/generate_cluster_desc.hpp"
+#include "eth_l1_address_map.h"
+#include "gtest/gtest.h"
+#include "host_mem_address_map.h"
+#include "l1_address_map.h"
 #include "tests/test_utils/device_test_utils.hpp"
+#include "tests/test_utils/generate_cluster_desc.hpp"
 
 using namespace tt::umd;
 
-
 void set_params_for_remote_txn(Cluster& device) {
     // Populate address map and NOC parameters that the driver needs for remote transactions
-    device.set_device_l1_address_params({l1_mem::address_map::L1_BARRIER_BASE, eth_l1_mem::address_map::ERISC_BARRIER_BASE, eth_l1_mem::address_map::FW_VERSION_ADDR});
+    device.set_device_l1_address_params(
+        {l1_mem::address_map::L1_BARRIER_BASE,
+         eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+         eth_l1_mem::address_map::FW_VERSION_ADDR});
 }
 
 std::int32_t get_static_tlb_index(tt_xy_pair target) {
-    bool is_eth_location = std::find(std::cbegin(tt::umd::wormhole::ETH_LOCATIONS), std::cend(tt::umd::wormhole::ETH_LOCATIONS), target) != std::cend(tt::umd::wormhole::ETH_LOCATIONS);
-    bool is_tensix_location = std::find(std::cbegin(tt::umd::wormhole::T6_X_LOCATIONS), std::cend(tt::umd::wormhole::T6_X_LOCATIONS), target.x) != std::cend(tt::umd::wormhole::T6_X_LOCATIONS) &&
-                            std::find(std::cbegin(tt::umd::wormhole::T6_Y_LOCATIONS), std::cend(tt::umd::wormhole::T6_Y_LOCATIONS), target.y) != std::cend(tt::umd::wormhole::T6_Y_LOCATIONS);
+    bool is_eth_location =
+        std::find(std::cbegin(tt::umd::wormhole::ETH_LOCATIONS), std::cend(tt::umd::wormhole::ETH_LOCATIONS), target) !=
+        std::cend(tt::umd::wormhole::ETH_LOCATIONS);
+    bool is_tensix_location =
+        std::find(
+            std::cbegin(tt::umd::wormhole::T6_X_LOCATIONS), std::cend(tt::umd::wormhole::T6_X_LOCATIONS), target.x) !=
+            std::cend(tt::umd::wormhole::T6_X_LOCATIONS) &&
+        std::find(
+            std::cbegin(tt::umd::wormhole::T6_Y_LOCATIONS), std::cend(tt::umd::wormhole::T6_Y_LOCATIONS), target.y) !=
+            std::cend(tt::umd::wormhole::T6_Y_LOCATIONS);
     if (is_eth_location) {
         if (target.y == 6) {
             target.y = 1;
@@ -65,7 +73,8 @@ std::int32_t get_static_tlb_index(tt_xy_pair target) {
 
 std::set<chip_id_t> get_target_devices() {
     std::set<chip_id_t> target_devices;
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq = tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
+        tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
     for (int i = 0; i < cluster_desc_uniq->get_number_of_chips(); i++) {
         target_devices.insert(i);
     }
@@ -77,8 +86,15 @@ TEST(SiliconDriverWH, CreateDestroy) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     tt_device_params default_params;
     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
-    for(int i = 0; i < 50; i++) {
-        Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_1x1.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, false);
+    for (int i = 0; i < 50; i++) {
+        Cluster device = Cluster(
+            test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_1x1.yaml"),
+            tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+            target_devices,
+            num_host_mem_ch_per_mmio_device,
+            false,
+            true,
+            false);
         set_params_for_remote_txn(device);
         device.start_device(default_params);
         device.deassert_risc_reset();
@@ -92,16 +108,26 @@ TEST(SiliconDriverWH, Harvesting) {
     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 30}, {1, 60}};
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true, simulated_harvesting_masks);
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        true,
+        simulated_harvesting_masks);
     auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     ASSERT_EQ(device.using_harvested_soc_descriptors(), true) << "Expected Driver to have performed harvesting";
 
-    for(const auto& chip : sdesc_per_chip) {
-        ASSERT_EQ(chip.second.workers.size(), 48) << "Expected SOC descriptor with harvesting to have 48 workers for chip" << chip.first;
+    for (const auto& chip : sdesc_per_chip) {
+        ASSERT_EQ(chip.second.workers.size(), 48)
+            << "Expected SOC descriptor with harvesting to have 48 workers for chip" << chip.first;
     }
-    for(int i = 0; i < num_devices; i++){
-        ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(i), simulated_harvesting_masks.at(i)) << "Expecting chip " << i << " to have harvesting mask of " << simulated_harvesting_masks.at(i);
+    for (int i = 0; i < num_devices; i++) {
+        ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(i), simulated_harvesting_masks.at(i))
+            << "Expecting chip " << i << " to have harvesting mask of " << simulated_harvesting_masks.at(i);
     }
 }
 
@@ -111,11 +137,20 @@ TEST(SiliconDriverWH, CustomSocDesc) {
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_1x1.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, false, simulated_harvesting_masks);
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_1x1.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        false,
+        simulated_harvesting_masks);
     auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
-    ASSERT_EQ(device.using_harvested_soc_descriptors(), false) << "SOC descriptors should not be modified when harvesting is disabled";
-    for(const auto& chip : sdesc_per_chip) {
+    ASSERT_EQ(device.using_harvested_soc_descriptors(), false)
+        << "SOC descriptors should not be modified when harvesting is disabled";
+    for (const auto& chip : sdesc_per_chip) {
         ASSERT_EQ(chip.second.workers.size(), 1) << "Expected 1x1 SOC descriptor to be unmodified by driver";
     }
 }
@@ -190,25 +225,31 @@ TEST(SiliconDriverWH, HarvestingRuntime) {
 #endif
 
 TEST(SiliconDriverWH, UnalignedStaticTLB_RW) {
-    auto get_static_tlb_index_callback = [] (tt_xy_pair target) {
-        return get_static_tlb_index(target);
-    };
+    auto get_static_tlb_index_callback = [](tt_xy_pair target) { return get_static_tlb_index(target); };
 
     std::set<chip_id_t> target_devices = get_target_devices();
     int num_devices = target_devices.size();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true);
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        true);
     set_params_for_remote_txn(device);
     auto mmio_devices = device.get_target_mmio_device_ids();
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over MMIO devices and only setup static TLBs for worker cores
-        if(std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
+        if (std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
             auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-            for(auto& core : sdesc.workers) {
+            for (auto& core : sdesc.workers) {
                 // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
-                device.configure_tlb(i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
+                device.configure_tlb(
+                    i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
             }
             device.setup_core_to_tlb_map(i, get_static_tlb_index_callback);
         }
@@ -219,16 +260,16 @@ TEST(SiliconDriverWH, UnalignedStaticTLB_RW) {
     device.deassert_risc_reset();
 
     std::vector<uint32_t> unaligned_sizes = {3, 14, 21, 255, 362, 430, 1022, 1023, 1025};
-    for(int i = 0; i < num_devices; i++) {
-        for(const auto& size : unaligned_sizes) {
+    for (int i = 0; i < num_devices; i++) {
+        for (const auto& size : unaligned_sizes) {
             std::vector<uint8_t> write_vec(size, 0);
-            for(int i = 0; i < size; i++){
+            for (int i = 0; i < size; i++) {
                 write_vec[i] = size + i;
             }
             std::vector<uint8_t> readback_vec(size, 0);
             std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
-            for(int loop = 0; loop < 50; loop++){
-                for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+            for (int loop = 0; loop < 50; loop++) {
+                for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
                     device.write_to_device(write_vec.data(), size, tt_cxy_pair(i, core), address, "");
                     device.wait_for_non_mmio_flush();
                     device.read_from_device(readback_vec.data(), tt_cxy_pair(i, core), address, size, "");
@@ -242,36 +283,40 @@ TEST(SiliconDriverWH, UnalignedStaticTLB_RW) {
                 }
                 address += 0x20;
             }
-
         }
     }
     device.close_device();
 }
 
 TEST(SiliconDriverWH, StaticTLB_RW) {
-    auto get_static_tlb_index_callback = [] (tt_xy_pair target) {
-        return get_static_tlb_index(target);
-    };
+    auto get_static_tlb_index_callback = [](tt_xy_pair target) { return get_static_tlb_index(target); };
 
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true);
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        true);
     set_params_for_remote_txn(device);
     auto mmio_devices = device.get_target_mmio_device_ids();
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over MMIO devices and only setup static TLBs for worker cores
-        if(std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
+        if (std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
             auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-            for(auto& core : sdesc.workers) {
+            for (auto& core : sdesc.workers) {
                 // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
-                device.configure_tlb(i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
+                device.configure_tlb(
+                    i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
             }
             device.setup_core_to_tlb_map(i, get_static_tlb_index_callback);
         }
     }
-
 
     tt_device_params default_params;
     device.start_device(default_params);
@@ -281,31 +326,51 @@ TEST(SiliconDriverWH, StaticTLB_RW) {
     std::vector<uint32_t> readback_vec = {};
     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     // Check functionality of Static TLBs by reading adn writing from statically mapped address space
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
-        for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
-            for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "");
-                device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over ethernet were commited
+        for (int loop = 0; loop < 100;
+             loop++) {  // Write to each core a 100 times at different statically mapped addresses
+            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "");
+                device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
                 test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 device.wait_for_non_mmio_flush();
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB"); // Clear any written data
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");  // Clear any written data
                 device.wait_for_non_mmio_flush();
                 readback_vec = {};
             }
-            address += 0x20; // Increment by uint32_t size for each write
+            address += 0x20;  // Increment by uint32_t size for each write
         }
     }
     device.close_device();
 }
 
 TEST(SiliconDriverWH, DynamicTLB_RW) {
-    // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for each transaction
+    // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for
+    // each transaction
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"),  tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true);
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        true);
 
     set_params_for_remote_txn(device);
 
@@ -317,20 +382,33 @@ TEST(SiliconDriverWH, DynamicTLB_RW) {
     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     std::vector<uint32_t> readback_vec = {};
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
-        for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
-            for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB");
-                device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over ethernet were commited
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "SMALL_READ_WRITE_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+        for (int loop = 0; loop < 100;
+             loop++) {  // Write to each core a 100 times at different statically mapped addresses
+            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
+                device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, 40, "SMALL_READ_WRITE_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 device.wait_for_non_mmio_flush();
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
                 device.wait_for_non_mmio_flush();
                 readback_vec = {};
             }
-            address += 0x20; // Increment by uint32_t size for each write
+            address += 0x20;  // Increment by uint32_t size for each write
         }
     }
     device.close_device();
@@ -343,7 +421,14 @@ TEST(SiliconDriverWH, MultiThreadedDevice) {
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true);
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        true);
     set_params_for_remote_txn(device);
 
     tt_device_params default_params;
@@ -354,11 +439,18 @@ TEST(SiliconDriverWH, MultiThreadedDevice) {
         std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
-        for(int loop = 0; loop < 100; loop++) {
-            for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+        for (int loop = 0; loop < 100; loop++) {
+            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(0, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 readback_vec = {};
             }
             address += 0x20;
@@ -369,12 +461,19 @@ TEST(SiliconDriverWH, MultiThreadedDevice) {
         std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = 0x30000000;
-        for(auto& core_ls : device.get_virtual_soc_descriptors().at(0).dram_cores) {
-            for(int loop = 0; loop < 100; loop++) {
-                for(auto& core : core_ls) {
-                    device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
-                    test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
-                    ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+        for (auto& core_ls : device.get_virtual_soc_descriptors().at(0).dram_cores) {
+            for (int loop = 0; loop < 100; loop++) {
+                for (auto& core : core_ls) {
+                    device.write_to_device(
+                        vector_to_write.data(),
+                        vector_to_write.size() * sizeof(std::uint32_t),
+                        tt_cxy_pair(0, core),
+                        address,
+                        "SMALL_READ_WRITE_TLB");
+                    test_utils::read_data_from_device(
+                        device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
+                    ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y
+                                                             << "does not match what was written";
                     readback_vec = {};
                 }
                 address += 0x20;
@@ -393,23 +492,28 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     // We want to make sure the memory barrier is thread/process safe.
 
     // Memory barrier flags get sent to address 0 for all channels in this test
-    auto get_static_tlb_index_callback = [] (tt_xy_pair target) {
-        return get_static_tlb_index(target);
-    };
+    auto get_static_tlb_index_callback = [](tt_xy_pair target) { return get_static_tlb_index(target); };
 
     std::set<chip_id_t> target_devices = get_target_devices();
     uint32_t base_addr = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true);
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        true);
     set_params_for_remote_txn(device);
     auto mmio_devices = device.get_target_mmio_device_ids();
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for functional worker cores
-        if(std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
+        if (std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
             auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-            for(auto& core : sdesc.workers) {
+            for (auto& core : sdesc.workers) {
                 // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
                 device.configure_tlb(i, core, get_static_tlb_index_callback(core), base_addr);
             }
@@ -422,22 +526,39 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     device.deassert_risc_reset();
 
     std::vector<uint32_t> readback_membar_vec = {};
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all workers
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        test_utils::read_data_from_device(
+            device,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            l1_mem::address_map::L1_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all workers
         readback_membar_vec = {};
     }
 
-    for(int chan = 0; chan <  device.get_virtual_soc_descriptors().at(0).get_num_dram_channels(); chan++) {
+    for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(0).get_num_dram_channels(); chan++) {
         auto core = device.get_virtual_soc_descriptors().at(0).get_core_for_dram_channel(chan, 0);
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all DRAM
+        test_utils::read_data_from_device(
+            device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all DRAM
         readback_membar_vec = {};
     }
 
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all ethernet cores
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
+        test_utils::read_data_from_device(
+            device,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0),
+            187);  // Ensure that memory barriers were correctly initialized on all ethernet cores
         readback_membar_vec = {};
     }
 
@@ -447,38 +568,43 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     std::vector<uint32_t> vec2(2560);
     std::vector<uint32_t> zeros(2560, 0);
 
-    for(int i = 0; i < vec1.size(); i++) {
+    for (int i = 0; i < vec1.size(); i++) {
         vec1.at(i) = i;
     }
-    for(int i = 0; i < vec2.size(); i++) {
+    for (int i = 0; i < vec2.size(); i++) {
         vec2.at(i) = vec1.size() + i;
     }
     std::thread th1 = std::thread([&] {
         std::uint32_t address = base_addr;
-        for(int loop = 0; loop < 50; loop++) {
-            for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        for (int loop = 0; loop < 50; loop++) {
+            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
-                device.write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                device.write_to_device(
+                    vec1.data(), vec1.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 device.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 4*vec1.size(), "");
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(0, core), address, 4 * vec1.size(), "");
                 ASSERT_EQ(readback_vec, vec1);
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                device.write_to_device(
+                    zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 readback_vec = {};
             }
-
         }
     });
 
     std::thread th2 = std::thread([&] {
         std::uint32_t address = base_addr + vec1.size() * 4;
-        for(int loop = 0; loop < 50; loop++) {
-            for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        for (int loop = 0; loop < 50; loop++) {
+            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
-                device.write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                device.write_to_device(
+                    vec2.data(), vec2.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 device.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 4*vec2.size(), "");
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(0, core), address, 4 * vec2.size(), "");
                 ASSERT_EQ(readback_vec, vec2);
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "") ;
+                device.write_to_device(
+                    zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 readback_vec = {};
             }
         }
@@ -487,27 +613,48 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     th1.join();
     th2.join();
 
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers end up in the correct sate for workers
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        test_utils::read_data_from_device(
+            device,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            l1_mem::address_map::L1_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0), 187);  // Ensure that memory barriers end up in the correct sate for workers
         readback_membar_vec = {};
     }
 
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers end up in the correct sate for ethernet cores
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
+        test_utils::read_data_from_device(
+            device,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0),
+            187);  // Ensure that memory barriers end up in the correct sate for ethernet cores
         readback_membar_vec = {};
     }
     device.close_device();
 }
-
 
 TEST(SiliconDriverWH, BroadcastWrite) {
     // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true);
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        true);
     set_params_for_remote_txn(device);
     auto mmio_devices = device.get_target_mmio_device_ids();
 
@@ -521,33 +668,64 @@ TEST(SiliconDriverWH, BroadcastWrite) {
     std::set<uint32_t> rows_to_exclude_for_dram_broadcast = {};
     std::set<uint32_t> cols_to_exclude_for_dram_broadcast = {1, 2, 3, 4, 6, 7, 8, 9};
 
-    for(const auto& size : broadcast_sizes) {
+    for (const auto& size : broadcast_sizes) {
         std::vector<uint32_t> vector_to_write(size);
         std::vector<uint32_t> zeros(size);
         std::vector<uint32_t> readback_vec = {};
-        for(int i = 0; i < size; i++) {
+        for (int i = 0; i < size; i++) {
             vector_to_write[i] = i;
             zeros[i] = 0;
         }
         // Broadcast to Tensix
-        device.broadcast_write_to_cluster(vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude, "LARGE_WRITE_TLB");
+        device.broadcast_write_to_cluster(
+            vector_to_write.data(),
+            vector_to_write.size() * 4,
+            address,
+            {},
+            rows_to_exclude,
+            cols_to_exclude,
+            "LARGE_WRITE_TLB");
         // Broadcast to DRAM
-        device.broadcast_write_to_cluster(vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude_for_dram_broadcast, cols_to_exclude_for_dram_broadcast, "LARGE_WRITE_TLB");
+        device.broadcast_write_to_cluster(
+            vector_to_write.data(),
+            vector_to_write.size() * 4,
+            address,
+            {},
+            rows_to_exclude_for_dram_broadcast,
+            cols_to_exclude_for_dram_broadcast,
+            "LARGE_WRITE_TLB");
         device.wait_for_non_mmio_flush();
 
-        for(const auto i : target_devices) {
-            for(const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                if(rows_to_exclude.find(core.y) != rows_to_exclude.end()) continue;
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was broadcasted";
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+        for (const auto i : target_devices) {
+            for (const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
+                    continue;
+                }
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y
+                                                         << "does not match what was broadcasted";
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
-            for(int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
                 const auto& core = device.get_virtual_soc_descriptors().at(i).get_core_for_dram_channel(chan, 0);
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from DRAM core " << i << " " << core.x << "-" << core.y << " does not match what was broadcasted " << size;
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from DRAM core " << i << " " << core.x << "-" << core.y
+                    << " does not match what was broadcasted " << size;
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
         }
@@ -562,17 +740,26 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true);
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        true);
     set_params_for_remote_txn(device);
     auto mmio_devices = device.get_target_mmio_device_ids();
 
     tt_device_params default_params;
     device.start_device(default_params);
     auto eth_version = device.get_ethernet_fw_version();
-    bool virtual_bcast_supported = (eth_version >= tt_version(6, 8, 0) || eth_version == tt_version(6, 7, 241)) && device.translation_tables_en;
+    bool virtual_bcast_supported =
+        (eth_version >= tt_version(6, 8, 0) || eth_version == tt_version(6, 7, 241)) && device.translation_tables_en;
     if (!virtual_bcast_supported) {
         device.close_device();
-        GTEST_SKIP() << "SiliconDriverWH.VirtualCoordinateBroadcast skipped since ethernet version does not support Virtual Coordinate Broadcast or NOC translation is not enabled";
+        GTEST_SKIP() << "SiliconDriverWH.VirtualCoordinateBroadcast skipped since ethernet version does not support "
+                        "Virtual Coordinate Broadcast or NOC translation is not enabled";
     }
 
     device.deassert_risc_reset();
@@ -583,33 +770,64 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
     std::set<uint32_t> rows_to_exclude_for_dram_broadcast = {};
     std::set<uint32_t> cols_to_exclude_for_dram_broadcast = {1, 2, 3, 4, 6, 7, 8, 9};
 
-    for(const auto& size : broadcast_sizes) {
+    for (const auto& size : broadcast_sizes) {
         std::vector<uint32_t> vector_to_write(size);
         std::vector<uint32_t> zeros(size);
         std::vector<uint32_t> readback_vec = {};
-        for(int i = 0; i < size; i++) {
+        for (int i = 0; i < size; i++) {
             vector_to_write[i] = i;
             zeros[i] = 0;
         }
         // Broadcast to Tensix
-        device.broadcast_write_to_cluster(vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude, "LARGE_WRITE_TLB");
+        device.broadcast_write_to_cluster(
+            vector_to_write.data(),
+            vector_to_write.size() * 4,
+            address,
+            {},
+            rows_to_exclude,
+            cols_to_exclude,
+            "LARGE_WRITE_TLB");
         // Broadcast to DRAM
-        device.broadcast_write_to_cluster(vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude_for_dram_broadcast, cols_to_exclude_for_dram_broadcast, "LARGE_WRITE_TLB");
+        device.broadcast_write_to_cluster(
+            vector_to_write.data(),
+            vector_to_write.size() * 4,
+            address,
+            {},
+            rows_to_exclude_for_dram_broadcast,
+            cols_to_exclude_for_dram_broadcast,
+            "LARGE_WRITE_TLB");
         device.wait_for_non_mmio_flush();
 
-        for(const auto i : target_devices) {
-            for(const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                if(rows_to_exclude.find(core.y) != rows_to_exclude.end()) continue;
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was broadcasted";
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+        for (const auto i : target_devices) {
+            for (const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
+                    continue;
+                }
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y
+                                                         << "does not match what was broadcasted";
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
-            for(int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
                 const auto& core = device.get_virtual_soc_descriptors().at(i).get_core_for_dram_channel(chan, 0);
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from DRAM core " << i << " " << core.x << "-" << core.y << " does not match what was broadcasted " << size;
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from DRAM core " << i << " " << core.x << "-" << core.y
+                    << " does not match what was broadcasted " << size;
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
         }
@@ -618,7 +836,6 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
     }
     device.close_device();
 }
-
 
 /**
  * This is a basic DMA test -- not using the PCIe controller's DMA engine, but
@@ -644,13 +861,14 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
 TEST(SiliconDriverWH, SysmemTestWithPcie) {
     auto target_devices = get_target_devices();
 
-    Cluster cluster(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"),
-                    tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
-                    target_devices,
-                    1,  // one "host memory channel", currently a 1G huge page
-                    false, // skip driver allocs - no (don't skip)
-                    true,  // clean system resources - yes
-                    true); // perform harvesting - yes
+    Cluster cluster(
+        test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        1,      // one "host memory channel", currently a 1G huge page
+        false,  // skip driver allocs - no (don't skip)
+        true,   // clean system resources - yes
+        true);  // perform harvesting - yes
 
     set_params_for_remote_txn(cluster);
     cluster.start_device(tt_device_params{});  // no special parameters
@@ -667,7 +885,7 @@ TEST(SiliconDriverWH, SysmemTestWithPcie) {
     // Bad API: how big is the buffer?  How do we know it's big enough?
     // Situation today is that there's a 1G hugepage behind it, although this is
     // unclear from the API and may change in the future.
-    uint8_t *sysmem = (uint8_t*)cluster.host_dma_address(0, 0, 0);
+    uint8_t* sysmem = (uint8_t*)cluster.host_dma_address(0, 0, 0);
     ASSERT_NE(sysmem, nullptr);
 
     // This is the address inside the Wormhole PCIe block that is mapped to the
@@ -710,13 +928,14 @@ TEST(SiliconDriverWH, RandomSysmemTestWithPcie) {
     const size_t num_channels = 2;  // ideally 4, but CI seems to have 2...
     auto target_devices = get_target_devices();
 
-    Cluster cluster(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"),
-                    tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
-                    target_devices,
-                    num_channels,
-                    false, // skip driver allocs - no (don't skip)
-                    true,  // clean system resources - yes
-                    true); // perform harvesting - yes
+    Cluster cluster(
+        test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_channels,
+        false,  // skip driver allocs - no (don't skip)
+        true,   // clean system resources - yes
+        true);  // perform harvesting - yes
 
     set_params_for_remote_txn(cluster);
     cluster.start_device(tt_device_params{});  // no special parameters
@@ -725,7 +944,7 @@ TEST(SiliconDriverWH, RandomSysmemTestWithPcie) {
     const auto PCIE = cluster.get_soc_descriptor(mmio_chip_id).pcie_cores.at(0);
     const tt_cxy_pair PCIE_CORE(mmio_chip_id, PCIE.x, PCIE.y);
     const size_t ONE_GIG = 1 << 30;
-    const size_t num_tests = 0x20000;   // runs in a reasonable amount of time
+    const size_t num_tests = 0x20000;  // runs in a reasonable amount of time
 
     // PCIe core is at (x=0, y=3) on Wormhole NOC0.
     ASSERT_EQ(PCIE.x, 0);
@@ -735,13 +954,13 @@ TEST(SiliconDriverWH, RandomSysmemTestWithPcie) {
     auto generate_aligned_address = [&](uint64_t lo, uint64_t hi) -> uint64_t {
         static std::random_device rd;
         static std::mt19937_64 gen(rd());
-        std::uniform_int_distribution<uint64_t> dis(lo/ALIGNMENT, hi/ALIGNMENT);
+        std::uniform_int_distribution<uint64_t> dis(lo / ALIGNMENT, hi / ALIGNMENT);
         return dis(gen) * ALIGNMENT;
     };
 
     uint64_t base_address = cluster.get_pcie_base_addr_from_device(mmio_chip_id);
     for (size_t channel = 0; channel < num_channels; ++channel) {
-        uint8_t *sysmem = (uint8_t*)cluster.host_dma_address(0, 0, channel);
+        uint8_t* sysmem = (uint8_t*)cluster.host_dma_address(0, 0, channel);
         ASSERT_NE(sysmem, nullptr);
 
         test_utils::fill_with_random_bytes(sysmem, ONE_GIG);
@@ -774,4 +993,3 @@ TEST(SiliconDriverWH, RandomSysmemTestWithPcie) {
         }
     }
 }
-

--- a/tests/wormhole/test_umd_remote_api_stability.cpp
+++ b/tests/wormhole/test_umd_remote_api_stability.cpp
@@ -2,58 +2,51 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <chrono>
 #include <cstdint>
+#include <ctime>
 #include <numeric>
 #include <random>
 #include <thread>
 
-#include "tt_cluster_descriptor.h"
 #include "cluster.h"
-
 #include "common/logger.hpp"
 #include "eth_interface.h"
 #include "filesystem"
 #include "gtest/gtest.h"
 #include "host_mem_address_map.h"
 #include "l1_address_map.h"
-#include "tt_soc_descriptor.h"
-
-#include "tests/test_utils/stimulus_generators.hpp"
-#include "tests/test_utils/generate_cluster_desc.hpp"
 #include "test_wh_common.h"
-
-#include <chrono>
-#include <ctime>
+#include "tests/test_utils/generate_cluster_desc.hpp"
+#include "tests/test_utils/stimulus_generators.hpp"
+#include "tt_cluster_descriptor.h"
+#include "tt_soc_descriptor.h"
 
 namespace tt::umd::test::utils {
 class WormholeNebulaX2TestFixture : public WormholeTestFixture {
- private:
-  static int detected_num_chips;
-  static bool skip_tests;
+private:
+    static int detected_num_chips;
+    static bool skip_tests;
 
- protected: 
+protected:
+    static constexpr int EXPECTED_NUM_CHIPS = 2;
+    static uint32_t scale_number_of_tests;
 
-  static constexpr int EXPECTED_NUM_CHIPS = 2;
-  static uint32_t scale_number_of_tests;
-
-  static void SetUpTestSuite() {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
-    detected_num_chips = cluster_desc->get_number_of_chips();
-    if (detected_num_chips != EXPECTED_NUM_CHIPS) {
-        skip_tests = true;
+    static void SetUpTestSuite() {
+        std::unique_ptr<tt_ClusterDescriptor> cluster_desc =
+            tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
+        detected_num_chips = cluster_desc->get_number_of_chips();
+        if (detected_num_chips != EXPECTED_NUM_CHIPS) {
+            skip_tests = true;
+        }
+        if (char const* scale_number_of_tests_env = std::getenv("SCALE_NUMBER_OF_TESTS")) {
+            scale_number_of_tests = std::atoi(scale_number_of_tests_env);
+        }
     }
-    if(char const* scale_number_of_tests_env = std::getenv("SCALE_NUMBER_OF_TESTS")) {
-        scale_number_of_tests = std::atoi(scale_number_of_tests_env);
-    }
-  }
 
-  virtual int get_detected_num_chips() {
-    return detected_num_chips;
-  }
+    virtual int get_detected_num_chips() { return detected_num_chips; }
 
-  virtual bool is_test_skipped() {
-    return skip_tests;
-  }
+    virtual bool is_test_skipped() { return skip_tests; }
 };
 
 int WormholeNebulaX2TestFixture::detected_num_chips = -1;
@@ -63,28 +56,29 @@ uint32_t WormholeNebulaX2TestFixture::scale_number_of_tests = 1;
 TEST_F(WormholeNebulaX2TestFixture, MixedRemoteTransfersMediumSmall) {
     int seed = 0;
 
-    log_info(LogSiliconDriver,"Started MixedRemoteTransfersMediumSmall");
+    log_info(LogSiliconDriver, "Started MixedRemoteTransfersMediumSmall");
 
     std::vector<remote_transfer_sample_t> command_history;
     try {
         assert(device != nullptr);
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             0,
 
             transfer_type_weights_t{.write = 0.25, .read = 0.25},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history
-        );
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history);
     } catch (...) {
         print_command_history_executable_code(command_history);
     }
@@ -93,88 +87,92 @@ TEST_F(WormholeNebulaX2TestFixture, MixedRemoteTransfersMediumSmall) {
 TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersMediumSmall) {
     int seed = 0;
 
-    log_info(LogSiliconDriver,"Started MultithreadedMixedRemoteTransfersMediumSmall");
+    log_info(LogSiliconDriver, "Started MultithreadedMixedRemoteTransfersMediumSmall");
 
     assert(device != nullptr);
     std::vector<remote_transfer_sample_t> command_history0;
     std::vector<remote_transfer_sample_t> command_history1;
     std::vector<remote_transfer_sample_t> command_history2;
     std::vector<remote_transfer_sample_t> command_history3;
-    std::thread t1([&](){
+    std::thread t1([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             0,
 
             transfer_type_weights_t{.write = 0.50, .read = 0.50},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history0
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history0);
     });
-    std::thread t2([&](){
+    std::thread t2([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             100,
 
             transfer_type_weights_t{.write = 0.25, .read = 0.50},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history1
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history1);
     });
-    std::thread t3([&](){
+    std::thread t3([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             23,
 
             transfer_type_weights_t{.write = 0.5, .read = 0.25},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history2
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history2);
     });
-    std::thread t4([&](){
+    std::thread t4([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             99,
 
             transfer_type_weights_t{.write = 1.0, .read = 0.0},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history3
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history3);
     });
 
     t1.join();
@@ -186,52 +184,53 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersMediumSmall
 TEST_F(WormholeNebulaX2TestFixture, MixedRemoteTransfersLarge) {
     int seed = 0;
 
-    log_info(LogSiliconDriver,"Started MixedRemoteTransfersLarge");
+    log_info(LogSiliconDriver, "Started MixedRemoteTransfersLarge");
 
     assert(device != nullptr);
     std::vector<remote_transfer_sample_t> command_history;
     try {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             10000 * scale_number_of_tests,
             0,
 
             transfer_type_weights_t{.write = 0.15, .read = 0.15},
 
-            std::uniform_int_distribution<address_t>(0x10000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 300000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x10000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 300000),                          // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 300000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 300000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history
-        );
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history);
     } catch (...) {
         print_command_history_executable_code(command_history);
     }
-
 }
 
 TEST_F(WormholeNebulaX2TestFixture, WritesOnlyNormalDistributionMean10kStd3kMinSizeTruncate4) {
     int seed = 0;
 
-    log_info(LogSiliconDriver,"Started WritesOnlyNormalDistributionMean10kStd3kMinSizeTruncate4");
+    log_info(LogSiliconDriver, "Started WritesOnlyNormalDistributionMean10kStd3kMinSizeTruncate4");
 
     assert(device != nullptr);
     std::vector<remote_transfer_sample_t> command_history;
 
     auto write_size_generator = ConstrainedTemplateTemplateGenerator<transfer_size_t, double, std::normal_distribution>(
-        seed, std::normal_distribution<>(10000, 3000), [](double x) -> transfer_size_t { return size_aligner_32B(static_cast<transfer_size_t>((x >= 4) ? x : 4)); });
-    
+        seed, std::normal_distribution<>(10000, 3000), [](double x) -> transfer_size_t {
+            return size_aligner_32B(static_cast<transfer_size_t>((x >= 4) ? x : 4));
+        });
 
     auto dest_generator = get_default_full_dram_dest_generator(seed, device.get());
     auto address_generator = get_default_address_generator(seed, 0x100000, 0x5000000);
 
     try {
         RunMixedTransfers(
-            *device, 
+            *device,
             10000 * scale_number_of_tests,
             0,
 
@@ -240,100 +239,102 @@ TEST_F(WormholeNebulaX2TestFixture, WritesOnlyNormalDistributionMean10kStd3kMinS
             WriteCommandGenerator(dest_generator, address_generator, write_size_generator),
             build_dummy_read_command_generator(*device),
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history
-        );
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history);
     } catch (...) {
         print_command_history_executable_code(command_history);
     }
-
 }
 
 TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLMS) {
     int seed = 0;
 
-    log_info(LogSiliconDriver,"Started MultithreadedMixedRemoteTransfersLMS");
+    log_info(LogSiliconDriver, "Started MultithreadedMixedRemoteTransfersLMS");
 
     assert(device != nullptr);
     std::vector<remote_transfer_sample_t> command_history0;
     std::vector<remote_transfer_sample_t> command_history1;
     std::vector<remote_transfer_sample_t> command_history2;
     std::vector<remote_transfer_sample_t> command_history3;
-    std::thread t1([&](){
+    std::thread t1([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             0,
 
             transfer_type_weights_t{.write = 0.50, .read = 0.50},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(4, 300000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                4, 300000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history0
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history0);
     });
-    std::thread t2([&](){
+    std::thread t2([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             100,
 
             transfer_type_weights_t{.write = 0.25, .read = 0.50},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history1
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history1);
     });
-    std::thread t3([&](){
+    std::thread t3([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             23,
 
             transfer_type_weights_t{.write = 0.5, .read = 0.25},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history2
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history2);
     });
-    std::thread t4([&](){
+    std::thread t4([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             99,
 
             transfer_type_weights_t{.write = 1.0, .read = 0.0},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history3
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history3);
     });
 
     t1.join();
@@ -345,21 +346,29 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLMS) {
 TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLargeWritesSmallReads) {
     int seed = 0;
 
-    log_info(LogSiliconDriver,"Started MultithreadedMixedRemoteTransfersLargeWritesSmallReads");
+    log_info(LogSiliconDriver, "Started MultithreadedMixedRemoteTransfersLargeWritesSmallReads");
 
     assert(device != nullptr);
     std::vector<remote_transfer_sample_t> command_history0;
     std::vector<remote_transfer_sample_t> command_history1;
 
-    auto write_size_generator = ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
-        seed, std::uniform_int_distribution<transfer_size_t>(1000000, 30000000), [](transfer_size_t x) -> transfer_size_t { return size_aligner_32B(static_cast<transfer_size_t>((x >= 4) ? x : 4)); });
-    auto read_size_generator = ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
-        seed, std::uniform_int_distribution<transfer_size_t>(16, 4096), [](transfer_size_t x) -> transfer_size_t { return size_aligner_32B(static_cast<transfer_size_t>((x >= 4) ? x : 4)); });
+    auto write_size_generator =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
+            seed,
+            std::uniform_int_distribution<transfer_size_t>(1000000, 30000000),
+            [](transfer_size_t x) -> transfer_size_t {
+                return size_aligner_32B(static_cast<transfer_size_t>((x >= 4) ? x : 4));
+            });
+    auto read_size_generator =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
+            seed, std::uniform_int_distribution<transfer_size_t>(16, 4096), [](transfer_size_t x) -> transfer_size_t {
+                return size_aligner_32B(static_cast<transfer_size_t>((x >= 4) ? x : 4));
+            });
 
     auto dest_generator = get_default_full_dram_dest_generator(seed, device.get());
     auto address_generator = get_default_address_generator(seed, 0x100000, 0x5000000);
 
-    std::thread write_cmds_thread1([&](){
+    std::thread write_cmds_thread1([&]() {
         RunMixedTransfers(
             *device,
             10000 * scale_number_of_tests,
@@ -370,11 +379,10 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLargeWrites
             WriteCommandGenerator(dest_generator, address_generator, write_size_generator),
             build_dummy_read_command_generator(*device),
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history0
-        );
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history0);
     });
-    std::thread write_cmds_thread2([&](){
+    std::thread write_cmds_thread2([&]() {
         RunMixedTransfers(
             *device,
             10000 * scale_number_of_tests,
@@ -385,11 +393,10 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLargeWrites
             WriteCommandGenerator(dest_generator, address_generator, write_size_generator),
             build_dummy_read_command_generator(*device),
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history0
-        );
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history0);
     });
-    std::thread read_cmd_threads1([&](){
+    std::thread read_cmd_threads1([&]() {
         RunMixedTransfers(
             *device,
             10000 * scale_number_of_tests,
@@ -400,11 +407,10 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLargeWrites
             build_dummy_write_command_generator(*device),
             ReadCommandGenerator(dest_generator, address_generator, read_size_generator),
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history0
-        );
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history0);
     });
-    std::thread read_cmd_threads2([&](){
+    std::thread read_cmd_threads2([&]() {
         RunMixedTransfers(
             *device,
             10000 * scale_number_of_tests,
@@ -415,15 +421,13 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLargeWrites
             build_dummy_write_command_generator(*device),
             ReadCommandGenerator(dest_generator, address_generator, read_size_generator),
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history0
-        );
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history0);
     });
 
     write_cmds_thread1.join();
     write_cmds_thread2.join();
     read_cmd_threads1.join();
     read_cmd_threads2.join();
-
 }
-} // namespace tt::umd::test::utils
+}  // namespace tt::umd::test::utils

--- a/tests/wormhole/test_wh_common.h
+++ b/tests/wormhole/test_wh_common.h
@@ -5,80 +5,86 @@
  */
 #pragma once
 
-#include "tt_cluster_descriptor.h"
 #include "cluster.h"
-#include "tt_xy_pair.h"
 #include "eth_l1_address_map.h"
-
-#include "tests/test_utils/stimulus_generators.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
+#include "tests/test_utils/stimulus_generators.hpp"
+#include "tt_cluster_descriptor.h"
+#include "tt_xy_pair.h"
 
 namespace tt::umd::test::utils {
 
 static void set_params_for_remote_txn(Cluster& device) {
     // Populate address map and NOC parameters that the driver needs for remote transactions
-    device.set_device_l1_address_params({l1_mem::address_map::L1_BARRIER_BASE, eth_l1_mem::address_map::ERISC_BARRIER_BASE, eth_l1_mem::address_map::FW_VERSION_ADDR});
+    device.set_device_l1_address_params(
+        {l1_mem::address_map::L1_BARRIER_BASE,
+         eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+         eth_l1_mem::address_map::FW_VERSION_ADDR});
 }
 
 class WormholeTestFixture : public ::testing::Test {
- protected:
-  // You can remove any or all of the following functions if their bodies would
-  // be empty.
+protected:
+    // You can remove any or all of the following functions if their bodies would
+    // be empty.
 
-  std::unique_ptr<Cluster> device;
+    std::unique_ptr<Cluster> device;
 
-  WormholeTestFixture() {
+    WormholeTestFixture() {}
 
-  }
-
-  ~WormholeTestFixture() override {
-     // You can do clean-up work that doesn't throw exceptions here.
-  }
-
-  virtual int get_detected_num_chips() = 0;
-  virtual bool is_test_skipped() = 0;
-
-  // If the constructor and destructor are not enough for setting up
-  // and cleaning up each test, you can define the following methods:
-
-  void SetUp() override {
-    // Code here will be called immediately after the constructor (right
-    // before each test).
-
-    if (is_test_skipped()) {
-        GTEST_SKIP() << "Test is skipped due to incorrect number of chips";
+    ~WormholeTestFixture() override {
+        // You can do clean-up work that doesn't throw exceptions here.
     }
 
-    // std::cout << "Setting Up Test." << std::endl;
-    assert(get_detected_num_chips() > 0);
-    auto devices = std::vector<chip_id_t>(get_detected_num_chips());
-    std::iota(devices.begin(), devices.end(), 0);
-    std::set<chip_id_t> target_devices = {devices.begin(), devices.end()};
-    uint32_t num_host_mem_ch_per_mmio_device = 1;
-    device = std::make_unique<Cluster>(test_utils::GetAbsPath(SOC_DESC_PATH), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true);
-    assert(device != nullptr);
-    assert(device->get_cluster_description()->get_number_of_chips() == get_detected_num_chips());
+    virtual int get_detected_num_chips() = 0;
+    virtual bool is_test_skipped() = 0;
 
-    set_params_for_remote_txn(*device);
+    // If the constructor and destructor are not enough for setting up
+    // and cleaning up each test, you can define the following methods:
 
-    tt_device_params default_params;
-    device->start_device(default_params);
+    void SetUp() override {
+        // Code here will be called immediately after the constructor (right
+        // before each test).
 
-    device->deassert_risc_reset();
+        if (is_test_skipped()) {
+            GTEST_SKIP() << "Test is skipped due to incorrect number of chips";
+        }
 
-    device->wait_for_non_mmio_flush();
-  }
+        // std::cout << "Setting Up Test." << std::endl;
+        assert(get_detected_num_chips() > 0);
+        auto devices = std::vector<chip_id_t>(get_detected_num_chips());
+        std::iota(devices.begin(), devices.end(), 0);
+        std::set<chip_id_t> target_devices = {devices.begin(), devices.end()};
+        uint32_t num_host_mem_ch_per_mmio_device = 1;
+        device = std::make_unique<Cluster>(
+            test_utils::GetAbsPath(SOC_DESC_PATH),
+            tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+            target_devices,
+            num_host_mem_ch_per_mmio_device,
+            false,
+            true,
+            true);
+        assert(device != nullptr);
+        assert(device->get_cluster_description()->get_number_of_chips() == get_detected_num_chips());
 
-  void TearDown() override {
-    // Code here will be called immediately after each test (right
-    // before the destructor).
+        set_params_for_remote_txn(*device);
 
-    if (!is_test_skipped()) {
-        // std::cout << "Tearing Down Test." << std::endl;
-        device->close_device();
+        tt_device_params default_params;
+        device->start_device(default_params);
+
+        device->deassert_risc_reset();
+
+        device->wait_for_non_mmio_flush();
     }
-  }
 
+    void TearDown() override {
+        // Code here will be called immediately after each test (right
+        // before the destructor).
+
+        if (!is_test_skipped()) {
+            // std::cout << "Tearing Down Test." << std::endl;
+            device->close_device();
+        }
+    }
 };
 
-} // namespace tt::umd::test::utils
+}  // namespace tt::umd::test::utils


### PR DESCRIPTION
Related to #47 , a follow up from #203

Removed tests/.clang-format which disabled formatting in this folder, and ran `pre-commit run --all-files`

If there is something you see that is formatted not in the way you like, please leave a comment, we can add `// clang-format off` to some block to leave custom formatting.