### PR TITLE
Enable clang for src/ folder

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,2 +1,0 @@
-DisableFormat: true
-SortIncludes: false

--- a/src/firmware/riscv/blackhole/eth_interface.h
+++ b/src/firmware/riscv/blackhole/eth_interface.h
@@ -17,19 +17,19 @@ const uint32_t MAX_CHIP_GRID_SIZE = 128;
 const uint32_t CMD_BUF_SIZE = 4;  // we assume must be 2^N
 
 const uint32_t CMD_BUF_SIZE_MASK = (CMD_BUF_SIZE - 1);
-const uint32_t CMD_BUF_PTR_MASK  = ((CMD_BUF_SIZE << 1) - 1);
+const uint32_t CMD_BUF_PTR_MASK = ((CMD_BUF_SIZE << 1) - 1);
 
 const uint32_t ETH_ROUTING_STRUCT_ADDR = 0x11000;
 const uint32_t ETH_ROUTING_DATA_BUFFER_ADDR = 0x12000;
-//const uint32_t ETH_ROUTING_STRUCT_ADDR = eth_l1_mem::address_map::COMMAND_Q_BASE;
-//const uint32_t ETH_ROUTING_DATA_BUFFER_ADDR = eth_l1_mem::address_map::DATA_BUFFER_BASE;
+// const uint32_t ETH_ROUTING_STRUCT_ADDR = eth_l1_mem::address_map::COMMAND_Q_BASE;
+// const uint32_t ETH_ROUTING_DATA_BUFFER_ADDR = eth_l1_mem::address_map::DATA_BUFFER_BASE;
 
 const uint32_t ROOT_NODE_NOC_X = 9;
 const uint32_t ROOT_NODE_NOC_Y = 0;
 
-const uint32_t CMD_WR_REQ  = (0x1 << 0);
-const uint32_t CMD_WR_ACK  = (0x1 << 1);
-const uint32_t CMD_RD_REQ  = (0x1 << 2);
+const uint32_t CMD_WR_REQ = (0x1 << 0);
+const uint32_t CMD_WR_ACK = (0x1 << 1);
+const uint32_t CMD_RD_REQ = (0x1 << 2);
 const uint32_t CMD_RD_DATA = (0x1 << 3);
 const uint32_t CMD_DATA_BLOCK_DRAM = (0x1 << 4);
 const uint32_t CMD_LAST_DATA_BLOCK_DRAM = (0x1 << 5);
@@ -45,84 +45,94 @@ const uint32_t CMD_MOD = (0x1 << 13);
 
 const uint32_t CMD_ERROR = (0x1 << 30);
 const uint32_t CMD_DEST_UNREACHABLE = (0x1 << 31);
-const uint32_t MAX_BLOCK_SIZE = (0x1 << 10); // Max 1024 bytes
+const uint32_t MAX_BLOCK_SIZE = (0x1 << 10);  // Max 1024 bytes
 
 const uint32_t BROADCAST_HEADER_SIZE_BYTES = 32;
 
 const uint32_t CMD_SIZE_BYTES = 32;
 const uint32_t ETH_RACK_COORD_WIDTH = 8;
 
-//Broadcast header is used to specify which cores in the system are to be excluded from broadcast write.
-//shelf_exclude_mask:
-//                    [Rack_X][7:0], One bit for each shelf on a Rack.
-//                    Excludes entire shelves from broadcast. We support 12 Galaxy racks.
-//                    Rack_X indexes into shelf_exclude_mask[].
-//                    Each of the 8 shelves on a rack can be excluded by setting
-//                    one of the bits in shelf_exclude_mask[Rack_X]
-//                    If (shelf_exclude_mask[Rack_X] >> Rack_Y) & 0x1) is True, that shelf is excluded from broadcast.
-//chip_exclude_mask:
-//                    [31:0], One bit for each chip on the shelf.
-//                    If ((chip_exclude_mask >> (chip_x * 8 + chip_y)) & 0x1) is True, that chip on every shelf is excluded.
-//row_exclude_mask:
-//                    [11:0], One bit for each of the 12 rows in a chip.
-//col_exclude_mask:
-//                    [9:0], One bit for each of the 10 columns in a chip.
-//shelf_visited:      Reserved for firmware internal use. Host must always set to 0 when issuing a broadcast.
+// Broadcast header is used to specify which cores in the system are to be excluded from broadcast write.
+// shelf_exclude_mask:
+//                     [Rack_X][7:0], One bit for each shelf on a Rack.
+//                     Excludes entire shelves from broadcast. We support 12 Galaxy racks.
+//                     Rack_X indexes into shelf_exclude_mask[].
+//                     Each of the 8 shelves on a rack can be excluded by setting
+//                     one of the bits in shelf_exclude_mask[Rack_X]
+//                     If (shelf_exclude_mask[Rack_X] >> Rack_Y) & 0x1) is True, that shelf is excluded from broadcast.
+// chip_exclude_mask:
+//                     [31:0], One bit for each chip on the shelf.
+//                     If ((chip_exclude_mask >> (chip_x * 8 + chip_y)) & 0x1) is True, that chip on every shelf is
+//                     excluded.
+// row_exclude_mask:
+//                     [11:0], One bit for each of the 12 rows in a chip.
+// col_exclude_mask:
+//                     [9:0], One bit for each of the 10 columns in a chip.
+// shelf_visited:      Reserved for firmware internal use. Host must always set to 0 when issuing a broadcast.
 
 typedef struct {
-  uint8_t  shelf_exclude_mask[12];
-  uint32_t chip_exclude_mask;
-  uint16_t row_exclude_mask;
-  uint16_t col_exclude_mask;
-  uint8_t  shelf_visited[12]; // Reserved for Ethernet Routing Firmware use.
+    uint8_t shelf_exclude_mask[12];
+    uint32_t chip_exclude_mask;
+    uint16_t row_exclude_mask;
+    uint16_t col_exclude_mask;
+    uint8_t shelf_visited[12];  // Reserved for Ethernet Routing Firmware use.
 } broadcast_header_t;
+
 static_assert(sizeof(broadcast_header_t) == BROADCAST_HEADER_SIZE_BYTES);
 
 typedef struct {
-  uint64_t sys_addr;
-  uint32_t data;
-  uint32_t flags;
-  uint16_t rack;
-  uint16_t src_resp_buf_index;
-  uint32_t local_buf_index;
-  uint8_t  src_resp_q_id;
-  uint8_t  host_mem_txn_id;
-  uint16_t padding;
-  uint32_t src_addr_tag; //upper 32-bits of request source address.
+    uint64_t sys_addr;
+    uint32_t data;
+    uint32_t flags;
+    uint16_t rack;
+    uint16_t src_resp_buf_index;
+    uint32_t local_buf_index;
+    uint8_t src_resp_q_id;
+    uint8_t host_mem_txn_id;
+    uint16_t padding;
+    uint32_t src_addr_tag;  // upper 32-bits of request source address.
 } routing_cmd_t;
+
 static_assert(sizeof(routing_cmd_t) == CMD_SIZE_BYTES);
 
-
 const uint32_t REMOTE_UPDATE_PTR_SIZE_BYTES = 16;
+
 typedef struct {
-  uint32_t ptr;
-  uint32_t pad[3];
+    uint32_t ptr;
+    uint32_t pad[3];
 } remote_update_ptr_t;
+
 static_assert(sizeof(remote_update_ptr_t) == REMOTE_UPDATE_PTR_SIZE_BYTES);
 
 const uint32_t CMD_COUNTERS_SIZE_BYTES = 32;
+
 typedef struct {
-  uint32_t wr_req;
-  uint32_t wr_resp;
-  uint32_t rd_req;
-  uint32_t rd_resp;
-  uint32_t error;
-  uint32_t pad[3];
+    uint32_t wr_req;
+    uint32_t wr_resp;
+    uint32_t rd_req;
+    uint32_t rd_resp;
+    uint32_t error;
+    uint32_t pad[3];
 } cmd_counters_t;
+
 static_assert(sizeof(cmd_counters_t) == CMD_COUNTERS_SIZE_BYTES);
 
-const uint32_t CMD_Q_SIZE_BYTES = 2*REMOTE_UPDATE_PTR_SIZE_BYTES + CMD_COUNTERS_SIZE_BYTES + CMD_BUF_SIZE*CMD_SIZE_BYTES;
+const uint32_t CMD_Q_SIZE_BYTES =
+    2 * REMOTE_UPDATE_PTR_SIZE_BYTES + CMD_COUNTERS_SIZE_BYTES + CMD_BUF_SIZE * CMD_SIZE_BYTES;
+
 typedef struct {
-  cmd_counters_t cmd_counters;
-  remote_update_ptr_t wrptr;
-  remote_update_ptr_t rdptr;
-  routing_cmd_t cmd[CMD_BUF_SIZE];
+    cmd_counters_t cmd_counters;
+    remote_update_ptr_t wrptr;
+    remote_update_ptr_t rdptr;
+    routing_cmd_t cmd[CMD_BUF_SIZE];
 } cmd_q_t;
+
 static_assert(sizeof(cmd_q_t) == CMD_Q_SIZE_BYTES);
 
-
-//there are 16 64-bit latency counters at the beginning of command q region.
+// there are 16 64-bit latency counters at the beginning of command q region.
 constexpr uint32_t REQUEST_CMD_QUEUE_BASE = ETH_ROUTING_STRUCT_ADDR + 128;
-constexpr uint32_t REQUEST_ROUTING_CMD_QUEUE_BASE = REQUEST_CMD_QUEUE_BASE + sizeof(remote_update_ptr_t) + sizeof(remote_update_ptr_t) + sizeof(cmd_counters_t);
-constexpr uint32_t RESPONSE_CMD_QUEUE_BASE = REQUEST_CMD_QUEUE_BASE + 2*CMD_Q_SIZE_BYTES;
-constexpr uint32_t RESPONSE_ROUTING_CMD_QUEUE_BASE = RESPONSE_CMD_QUEUE_BASE + sizeof(remote_update_ptr_t) + sizeof(remote_update_ptr_t) + sizeof(cmd_counters_t);
+constexpr uint32_t REQUEST_ROUTING_CMD_QUEUE_BASE =
+    REQUEST_CMD_QUEUE_BASE + sizeof(remote_update_ptr_t) + sizeof(remote_update_ptr_t) + sizeof(cmd_counters_t);
+constexpr uint32_t RESPONSE_CMD_QUEUE_BASE = REQUEST_CMD_QUEUE_BASE + 2 * CMD_Q_SIZE_BYTES;
+constexpr uint32_t RESPONSE_ROUTING_CMD_QUEUE_BASE =
+    RESPONSE_CMD_QUEUE_BASE + sizeof(remote_update_ptr_t) + sizeof(remote_update_ptr_t) + sizeof(cmd_counters_t);

--- a/src/firmware/riscv/blackhole/eth_l1_address_map.h
+++ b/src/firmware/riscv/blackhole/eth_l1_address_map.h
@@ -7,56 +7,55 @@
 
 namespace eth_l1_mem {
 
-
 struct address_map {
-  
-  // Sizes
-  static constexpr std::int32_t FIRMWARE_SIZE = 32 * 1024;
-  static constexpr std::int32_t ERISC_BARRIER_SIZE = 0x20; // 32 bytes reserved for Barrier
-  static constexpr std::int32_t COMMAND_Q_SIZE = 4 * 1024;
-  static constexpr std::int32_t DATA_BUFFER_SIZE_HOST = 4 * 1024;
-  static constexpr std::int32_t DATA_BUFFER_SIZE_ETH = 4 * 1024;
-  static constexpr std::int32_t DATA_BUFFER_SIZE_NOC = 16 * 1024;
-  static constexpr std::int32_t DATA_BUFFER_SIZE = 24 * 1024;
-  static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_SIZE = 128;     //
-  static constexpr std::int32_t OVERLAY_BLOB_SIZE = (32 * 1024) - EPOCH_RUNTIME_CONFIG_SIZE;
-  static constexpr std::int32_t OVERLAY_MAX_EXTRA_BLOB_SIZE = (0 * 1024);     
-  static constexpr std::int32_t TILE_HEADER_BUF_SIZE = 32 * 1024;     // 
-  static constexpr std::int32_t NCRISC_L1_EPOCH_Q_SIZE = 32;
-  static constexpr std::int32_t FW_L1_BLOCK_SIZE = OVERLAY_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
-  static constexpr std::int32_t FW_DRAM_BLOCK_SIZE = OVERLAY_BLOB_SIZE + OVERLAY_MAX_EXTRA_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
-  // Base addresses
-  static constexpr std::int32_t FIRMWARE_BASE = 0x9040;
-  static constexpr std::int32_t ERISC_BARRIER_BASE = 0x11FE0;
-  static constexpr std::int32_t L1_EPOCH_Q_BASE = 0x9000; // Epoch Q start in L1.
-  static constexpr std::int32_t L1_DRAM_POLLING_CTRL_BASE = 0x9020;
-  static constexpr std::int32_t COMMAND_Q_BASE = L1_EPOCH_Q_BASE + FIRMWARE_SIZE;
-  static constexpr std::int32_t DATA_BUFFER_BASE = COMMAND_Q_BASE + COMMAND_Q_SIZE;
-  static constexpr std::int32_t TILE_HEADER_BUFFER_BASE = DATA_BUFFER_BASE + DATA_BUFFER_SIZE;
-  static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_BASE = TILE_HEADER_BUFFER_BASE + TILE_HEADER_BUF_SIZE;
-  static constexpr std::int32_t OVERLAY_BLOB_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE;
-  static constexpr std::int32_t DATA_BUFFER_SPACE_BASE = OVERLAY_BLOB_BASE + OVERLAY_BLOB_SIZE;
+    // Sizes
+    static constexpr std::int32_t FIRMWARE_SIZE = 32 * 1024;
+    static constexpr std::int32_t ERISC_BARRIER_SIZE = 0x20;  // 32 bytes reserved for Barrier
+    static constexpr std::int32_t COMMAND_Q_SIZE = 4 * 1024;
+    static constexpr std::int32_t DATA_BUFFER_SIZE_HOST = 4 * 1024;
+    static constexpr std::int32_t DATA_BUFFER_SIZE_ETH = 4 * 1024;
+    static constexpr std::int32_t DATA_BUFFER_SIZE_NOC = 16 * 1024;
+    static constexpr std::int32_t DATA_BUFFER_SIZE = 24 * 1024;
+    static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_SIZE = 128;  //
+    static constexpr std::int32_t OVERLAY_BLOB_SIZE = (32 * 1024) - EPOCH_RUNTIME_CONFIG_SIZE;
+    static constexpr std::int32_t OVERLAY_MAX_EXTRA_BLOB_SIZE = (0 * 1024);
+    static constexpr std::int32_t TILE_HEADER_BUF_SIZE = 32 * 1024;  //
+    static constexpr std::int32_t NCRISC_L1_EPOCH_Q_SIZE = 32;
+    static constexpr std::int32_t FW_L1_BLOCK_SIZE =
+        OVERLAY_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
+    static constexpr std::int32_t FW_DRAM_BLOCK_SIZE =
+        OVERLAY_BLOB_SIZE + OVERLAY_MAX_EXTRA_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
+    // Base addresses
+    static constexpr std::int32_t FIRMWARE_BASE = 0x9040;
+    static constexpr std::int32_t ERISC_BARRIER_BASE = 0x11FE0;
+    static constexpr std::int32_t L1_EPOCH_Q_BASE = 0x9000;  // Epoch Q start in L1.
+    static constexpr std::int32_t L1_DRAM_POLLING_CTRL_BASE = 0x9020;
+    static constexpr std::int32_t COMMAND_Q_BASE = L1_EPOCH_Q_BASE + FIRMWARE_SIZE;
+    static constexpr std::int32_t DATA_BUFFER_BASE = COMMAND_Q_BASE + COMMAND_Q_SIZE;
+    static constexpr std::int32_t TILE_HEADER_BUFFER_BASE = DATA_BUFFER_BASE + DATA_BUFFER_SIZE;
+    static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_BASE = TILE_HEADER_BUFFER_BASE + TILE_HEADER_BUF_SIZE;
+    static constexpr std::int32_t OVERLAY_BLOB_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE;
+    static constexpr std::int32_t DATA_BUFFER_SPACE_BASE = OVERLAY_BLOB_BASE + OVERLAY_BLOB_SIZE;
 
-  static std::int32_t OVERLAY_FULL_BLOB_SIZE() {
-      return OVERLAY_BLOB_SIZE + OVERLAY_MAX_EXTRA_BLOB_SIZE;
-  };
+    static std::int32_t OVERLAY_FULL_BLOB_SIZE() { return OVERLAY_BLOB_SIZE + OVERLAY_MAX_EXTRA_BLOB_SIZE; };
 
-template<std::size_t A, std::size_t B> struct TAssertEquality {
-  static_assert(A==B, "Not equal");
-  static constexpr bool _cResult = (A==B);
+    template <std::size_t A, std::size_t B>
+    struct TAssertEquality {
+        static_assert(A == B, "Not equal");
+        static constexpr bool _cResult = (A == B);
+    };
+
+    static constexpr bool _DATA_BUFFER_SPACE_BASE_CORRECT = TAssertEquality<DATA_BUFFER_SPACE_BASE, 0x28000>::_cResult;
+
+    static constexpr std::int32_t MAX_SIZE = 256 * 1024;
+    static constexpr std::int32_t MAX_L1_LOADING_SIZE = 1 * 256 * 1024;
+
+    static constexpr std::int32_t RISC_LOCAL_MEM_BASE =
+        0xffb00000;  // Actaul local memory address as seen from risc firmware
+                     // As part of the init risc firmware will copy local memory data from
+                     // l1 locations listed above into internal local memory that starts
+                     // at RISC_LOCAL_MEM_BASE address
+
+    static constexpr std::uint32_t FW_VERSION_ADDR = 0x210;
 };
-
-static constexpr bool _DATA_BUFFER_SPACE_BASE_CORRECT = TAssertEquality<DATA_BUFFER_SPACE_BASE, 0x28000>::_cResult;
-
-  static constexpr std::int32_t MAX_SIZE = 256*1024;
-  static constexpr std::int32_t MAX_L1_LOADING_SIZE = 1 * 256 * 1024;  
-  
-  static constexpr std::int32_t RISC_LOCAL_MEM_BASE = 0xffb00000; // Actaul local memory address as seen from risc firmware
-                                                                   // As part of the init risc firmware will copy local memory data from
-                                                                   // l1 locations listed above into internal local memory that starts 
-                                                                   // at RISC_LOCAL_MEM_BASE address
-
-  static constexpr std::uint32_t FW_VERSION_ADDR = 0x210;
-};
-}  // namespace llk
-
+}  // namespace eth_l1_mem

--- a/src/firmware/riscv/blackhole/host_mem_address_map.h
+++ b/src/firmware/riscv/blackhole/host_mem_address_map.h
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
-#include <cstdint>
 #include <stdint.h>
+
+#include <cstdint>
 
 // Remove inline ASAP
 inline namespace blackhole {
@@ -11,42 +12,51 @@ inline namespace blackhole {
 namespace host_mem {
 
 struct address_map {
+    static constexpr std::int32_t NUMBER_OF_CHANNELS = 4;
+    // SYSMEM accessible via DEVICE-to-HOST MMIO
+    static constexpr std::int32_t DEVICE_TO_HOST_MMIO_SIZE_BYTES = 1024 * 1024 * 1024;  // 1GB
+    static constexpr std::int32_t DEVICE_TO_HOST_SCRATCH_SIZE_BYTES_PER_CHANNEL[4] = {
+        128 * 1024 * 1024, 0, 0, 256 * 1024 * 1024};
+    static constexpr std::int32_t DEVICE_TO_HOST_SCRATCH_START_PER_CHANNEL[4] = {
+        DEVICE_TO_HOST_MMIO_SIZE_BYTES - DEVICE_TO_HOST_SCRATCH_SIZE_BYTES_PER_CHANNEL[0],
+        DEVICE_TO_HOST_MMIO_SIZE_BYTES - DEVICE_TO_HOST_SCRATCH_SIZE_BYTES_PER_CHANNEL[1],
+        DEVICE_TO_HOST_MMIO_SIZE_BYTES - DEVICE_TO_HOST_SCRATCH_SIZE_BYTES_PER_CHANNEL[2],
+        DEVICE_TO_HOST_MMIO_SIZE_BYTES - DEVICE_TO_HOST_SCRATCH_SIZE_BYTES_PER_CHANNEL[3]};
 
-  static constexpr std::int32_t NUMBER_OF_CHANNELS = 4;
-  // SYSMEM accessible via DEVICE-to-HOST MMIO
-  static constexpr std::int32_t DEVICE_TO_HOST_MMIO_SIZE_BYTES    = 1024 * 1024 * 1024; // 1GB
-  static constexpr std::int32_t DEVICE_TO_HOST_SCRATCH_SIZE_BYTES_PER_CHANNEL[4] = {128 * 1024 * 1024, 0, 0, 256 * 1024 * 1024};
-  static constexpr std::int32_t DEVICE_TO_HOST_SCRATCH_START_PER_CHANNEL[4] = {DEVICE_TO_HOST_MMIO_SIZE_BYTES - DEVICE_TO_HOST_SCRATCH_SIZE_BYTES_PER_CHANNEL[0], 
-                                                                              DEVICE_TO_HOST_MMIO_SIZE_BYTES - DEVICE_TO_HOST_SCRATCH_SIZE_BYTES_PER_CHANNEL[1],
-                                                                              DEVICE_TO_HOST_MMIO_SIZE_BYTES - DEVICE_TO_HOST_SCRATCH_SIZE_BYTES_PER_CHANNEL[2], 
-                                                                              DEVICE_TO_HOST_MMIO_SIZE_BYTES - DEVICE_TO_HOST_SCRATCH_SIZE_BYTES_PER_CHANNEL[3]};
+    static constexpr std::int32_t DEVICE_TO_HOST_REGION_START = 0;
 
-  static constexpr std::int32_t DEVICE_TO_HOST_REGION_START       = 0;
+    // Ethernet routing region params
+    static constexpr std::int32_t ETH_ROUTING_BLOCK_SIZE = 32 * 1024;
+    static constexpr std::int32_t ETH_ROUTING_BUFFERS_START =
+        DEVICE_TO_HOST_SCRATCH_START_PER_CHANNEL[0];  // Implicit assumption: Eth buffers will be placed on host channel
+                                                      // 0.
+    static constexpr std::int32_t ETH_ROUTING_BUFFERS_SIZE =
+        ETH_ROUTING_BLOCK_SIZE * 16 * 4;  // 16 ethernet cores x 4 buffers/core
 
-  // Ethernet routing region params
-  static constexpr std::int32_t ETH_ROUTING_BLOCK_SIZE = 32 * 1024;
-  static constexpr std::int32_t ETH_ROUTING_BUFFERS_START = DEVICE_TO_HOST_SCRATCH_START_PER_CHANNEL[0]; // Implicit assumption: Eth buffers will be placed on host channel 0.
-  static constexpr std::int32_t ETH_ROUTING_BUFFERS_SIZE = ETH_ROUTING_BLOCK_SIZE * 16 * 4;// 16 ethernet cores x 4 buffers/core
+    // Concurrent perf trace region params
+    static constexpr std::int32_t HOST_PERF_SCRATCH_BUF_START =
+        DEVICE_TO_HOST_SCRATCH_START_PER_CHANNEL[0] +
+        ETH_ROUTING_BUFFERS_SIZE;  // Implicit assumption: Perf buffers will be placed on host channel 0.
+    static constexpr std::int32_t HOST_PERF_SCRATCH_BUF_SIZE = 64 * 1024 * 1024;
+    static constexpr std::int32_t NUM_THREADS_IN_EACH_DEVICE_DUMP = 1;
+    static constexpr std::int32_t NUM_HOST_PERF_QUEUES = 6 * 64;
+    static constexpr std::int32_t HOST_PERF_QUEUE_SLOT_SIZE =
+        HOST_PERF_SCRATCH_BUF_SIZE / NUM_HOST_PERF_QUEUES / 32 * 32;
 
-  // Concurrent perf trace region params
-  static constexpr std::int32_t HOST_PERF_SCRATCH_BUF_START = DEVICE_TO_HOST_SCRATCH_START_PER_CHANNEL[0] + ETH_ROUTING_BUFFERS_SIZE; // Implicit assumption: Perf buffers will be placed on host channel 0.
-  static constexpr std::int32_t HOST_PERF_SCRATCH_BUF_SIZE = 64 * 1024 * 1024;
-  static constexpr std::int32_t NUM_THREADS_IN_EACH_DEVICE_DUMP = 1;
-  static constexpr std::int32_t NUM_HOST_PERF_QUEUES = 6 * 64;
-  static constexpr std::int32_t HOST_PERF_QUEUE_SLOT_SIZE = HOST_PERF_SCRATCH_BUF_SIZE / NUM_HOST_PERF_QUEUES / 32 * 32;  
-  
-  constexpr static std::int32_t ALLOCATABLE_QUEUE_REGION_START(std::int32_t channel) {
-    // queue region starts at the base of host memory region
-    return DEVICE_TO_HOST_REGION_START;
-  }
-  constexpr static std::int32_t ALLOCATABLE_QUEUE_REGION_END(const std::int32_t channel) {
-    // queue region limited to the start of backend reserved scratch region
-    return DEVICE_TO_HOST_REGION_START + DEVICE_TO_HOST_MMIO_SIZE_BYTES - DEVICE_TO_HOST_SCRATCH_SIZE_BYTES_PER_CHANNEL[channel];
-  }
-  constexpr static std::int32_t ALLOCATABLE_QUEUE_REGION_SIZE(const std::int32_t channel) {
-    return ALLOCATABLE_QUEUE_REGION_END(channel) - ALLOCATABLE_QUEUE_REGION_START(channel);
-  }
+    constexpr static std::int32_t ALLOCATABLE_QUEUE_REGION_START(std::int32_t channel) {
+        // queue region starts at the base of host memory region
+        return DEVICE_TO_HOST_REGION_START;
+    }
+
+    constexpr static std::int32_t ALLOCATABLE_QUEUE_REGION_END(const std::int32_t channel) {
+        // queue region limited to the start of backend reserved scratch region
+        return DEVICE_TO_HOST_REGION_START + DEVICE_TO_HOST_MMIO_SIZE_BYTES -
+               DEVICE_TO_HOST_SCRATCH_SIZE_BYTES_PER_CHANNEL[channel];
+    }
+
+    constexpr static std::int32_t ALLOCATABLE_QUEUE_REGION_SIZE(const std::int32_t channel) {
+        return ALLOCATABLE_QUEUE_REGION_END(channel) - ALLOCATABLE_QUEUE_REGION_START(channel);
+    }
 };
-}
-}
-
+}  // namespace host_mem
+}  // namespace blackhole

--- a/src/firmware/riscv/blackhole/l1_address_map.h
+++ b/src/firmware/riscv/blackhole/l1_address_map.h
@@ -11,156 +11,184 @@
 namespace l1_mem {
 
 struct mailbox_type {
-  constexpr static int TRISC0 = 0;
-  constexpr static int TRISC1 = 1;
-  constexpr static int TRISC2 = 2;
-  constexpr static int NCRISC = 3;
-  constexpr static int BRISC  = 4;
+    constexpr static int TRISC0 = 0;
+    constexpr static int TRISC1 = 1;
+    constexpr static int TRISC2 = 2;
+    constexpr static int NCRISC = 3;
+    constexpr static int BRISC = 4;
 };
 
 struct address_map {
-  // Sizes
-  static constexpr std::uint32_t FIRMWARE_SIZE = 20 * 1024;          // 20KB = 7KB + 1KB zeros + 12KB perf buffers
-  static constexpr std::uint32_t L1_BARRIER_SIZE = 0x20; // 32 bytes reserved for L1 Barrier
-  static constexpr std::uint32_t BRISC_FIRMWARE_SIZE = 7*1024 + 512 + 768; // Taking an extra 768B from perf buffer space
-  static constexpr std::uint32_t ZEROS_SIZE = 512;
-  static constexpr std::uint32_t NCRISC_FIRMWARE_SIZE = 32 * 1024;        // 16KB in L0, 16KB in L1
-  static constexpr std::uint32_t TRISC0_SIZE = 20 * 1024;        // 20KB = 16KB + 4KB local memory
-  static constexpr std::uint32_t TRISC1_SIZE = 16 * 1024;        // 16KB = 12KB + 4KB local memory
-  static constexpr std::uint32_t TRISC2_SIZE = 20 * 1024;        // 20KB = 16KB + 4KB local memory
-  static constexpr std::uint32_t TRISC_LOCAL_MEM_SIZE = 4 * 1024;      //
-  static constexpr std::uint32_t NCRISC_LOCAL_MEM_SIZE = 4 * 1024;     //
-  static constexpr std::uint32_t NCRISC_L1_SCRATCH_SIZE = 4 * 1024;     //
-  static constexpr std::uint32_t NCRISC_L1_CODE_SIZE = 16*1024;      // Size of code block that is L1 resident
-  static constexpr std::uint32_t NCRISC_IRAM_CODE_SIZE = 16*1024;    // Size of code block that is IRAM resident
-  static constexpr std::uint32_t NCRISC_DATA_SIZE = 4 * 1024;        // 4KB
-  static constexpr std::uint32_t EPOCH_RUNTIME_CONFIG_SIZE = 128;      //
-  static constexpr std::uint32_t OVERLAY_BLOB_SIZE = (64 * 1024) - EPOCH_RUNTIME_CONFIG_SIZE;
-  static constexpr std::uint32_t TILE_HEADER_BUF_SIZE = 32 * 1024;     //
-  static constexpr std::uint32_t NCRISC_L1_EPOCH_Q_SIZE = 32;
-  static constexpr std::uint32_t FW_L1_BLOCK_SIZE = FIRMWARE_SIZE + NCRISC_FIRMWARE_SIZE + TRISC0_SIZE + TRISC1_SIZE + TRISC2_SIZE + OVERLAY_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
+    // Sizes
+    static constexpr std::uint32_t FIRMWARE_SIZE = 20 * 1024;  // 20KB = 7KB + 1KB zeros + 12KB perf buffers
+    static constexpr std::uint32_t L1_BARRIER_SIZE = 0x20;     // 32 bytes reserved for L1 Barrier
+    static constexpr std::uint32_t BRISC_FIRMWARE_SIZE =
+        7 * 1024 + 512 + 768;  // Taking an extra 768B from perf buffer space
+    static constexpr std::uint32_t ZEROS_SIZE = 512;
+    static constexpr std::uint32_t NCRISC_FIRMWARE_SIZE = 32 * 1024;   // 16KB in L0, 16KB in L1
+    static constexpr std::uint32_t TRISC0_SIZE = 20 * 1024;            // 20KB = 16KB + 4KB local memory
+    static constexpr std::uint32_t TRISC1_SIZE = 16 * 1024;            // 16KB = 12KB + 4KB local memory
+    static constexpr std::uint32_t TRISC2_SIZE = 20 * 1024;            // 20KB = 16KB + 4KB local memory
+    static constexpr std::uint32_t TRISC_LOCAL_MEM_SIZE = 4 * 1024;    //
+    static constexpr std::uint32_t NCRISC_LOCAL_MEM_SIZE = 4 * 1024;   //
+    static constexpr std::uint32_t NCRISC_L1_SCRATCH_SIZE = 4 * 1024;  //
+    static constexpr std::uint32_t NCRISC_L1_CODE_SIZE = 16 * 1024;    // Size of code block that is L1 resident
+    static constexpr std::uint32_t NCRISC_IRAM_CODE_SIZE = 16 * 1024;  // Size of code block that is IRAM resident
+    static constexpr std::uint32_t NCRISC_DATA_SIZE = 4 * 1024;        // 4KB
+    static constexpr std::uint32_t EPOCH_RUNTIME_CONFIG_SIZE = 128;    //
+    static constexpr std::uint32_t OVERLAY_BLOB_SIZE = (64 * 1024) - EPOCH_RUNTIME_CONFIG_SIZE;
+    static constexpr std::uint32_t TILE_HEADER_BUF_SIZE = 32 * 1024;  //
+    static constexpr std::uint32_t NCRISC_L1_EPOCH_Q_SIZE = 32;
+    static constexpr std::uint32_t FW_L1_BLOCK_SIZE = FIRMWARE_SIZE + NCRISC_FIRMWARE_SIZE + TRISC0_SIZE + TRISC1_SIZE +
+                                                      TRISC2_SIZE + OVERLAY_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE +
+                                                      TILE_HEADER_BUF_SIZE;
 
-  // Base addresses
-  static constexpr std::uint32_t FIRMWARE_BASE = 0;
-  static constexpr std::uint32_t L1_BARRIER_BASE = 0x16dfc0;
-  static constexpr std::uint32_t ZEROS_BASE = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE;
-  static constexpr std::uint32_t NCRISC_FIRMWARE_BASE = FIRMWARE_BASE + FIRMWARE_SIZE;
-  static constexpr std::uint32_t NCRISC_L1_CODE_BASE =  NCRISC_FIRMWARE_BASE + NCRISC_IRAM_CODE_SIZE;
-  static constexpr std::uint32_t NCRISC_LOCAL_MEM_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE - NCRISC_LOCAL_MEM_SIZE; // Copy of the local memory
+    // Base addresses
+    static constexpr std::uint32_t FIRMWARE_BASE = 0;
+    static constexpr std::uint32_t L1_BARRIER_BASE = 0x16dfc0;
+    static constexpr std::uint32_t ZEROS_BASE = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE;
+    static constexpr std::uint32_t NCRISC_FIRMWARE_BASE = FIRMWARE_BASE + FIRMWARE_SIZE;
+    static constexpr std::uint32_t NCRISC_L1_CODE_BASE = NCRISC_FIRMWARE_BASE + NCRISC_IRAM_CODE_SIZE;
+    static constexpr std::uint32_t NCRISC_LOCAL_MEM_BASE =
+        NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE - NCRISC_LOCAL_MEM_SIZE;  // Copy of the local memory
 
-  static constexpr std::uint32_t TRISC_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
-  static constexpr std::uint32_t TRISC0_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
-  static constexpr std::uint32_t TRISC0_LOCAL_MEM_BASE = TRISC0_BASE + TRISC0_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::uint32_t TRISC1_BASE = TRISC0_BASE + TRISC0_SIZE;
-  static constexpr std::uint32_t TRISC1_LOCAL_MEM_BASE = TRISC1_BASE + TRISC1_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::uint32_t TRISC2_BASE = TRISC1_BASE + TRISC1_SIZE;
-  static constexpr std::uint32_t TRISC2_LOCAL_MEM_BASE = TRISC2_BASE + TRISC2_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::uint32_t EPOCH_RUNTIME_CONFIG_BASE = TRISC2_BASE + TRISC2_SIZE + TILE_HEADER_BUF_SIZE;
-  static constexpr std::uint32_t OVERLAY_BLOB_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE;
+    static constexpr std::uint32_t TRISC_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
+    static constexpr std::uint32_t TRISC0_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
+    static constexpr std::uint32_t TRISC0_LOCAL_MEM_BASE =
+        TRISC0_BASE + TRISC0_SIZE - TRISC_LOCAL_MEM_SIZE;  // Copy of the local memory
+    static constexpr std::uint32_t TRISC1_BASE = TRISC0_BASE + TRISC0_SIZE;
+    static constexpr std::uint32_t TRISC1_LOCAL_MEM_BASE =
+        TRISC1_BASE + TRISC1_SIZE - TRISC_LOCAL_MEM_SIZE;  // Copy of the local memory
+    static constexpr std::uint32_t TRISC2_BASE = TRISC1_BASE + TRISC1_SIZE;
+    static constexpr std::uint32_t TRISC2_LOCAL_MEM_BASE =
+        TRISC2_BASE + TRISC2_SIZE - TRISC_LOCAL_MEM_SIZE;  // Copy of the local memory
+    static constexpr std::uint32_t EPOCH_RUNTIME_CONFIG_BASE = TRISC2_BASE + TRISC2_SIZE + TILE_HEADER_BUF_SIZE;
+    static constexpr std::uint32_t OVERLAY_BLOB_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE;
 
-  // MT: For Blackhole, this needs to be moved down at the expense of the data buffer
-  static constexpr std::uint32_t NCRISC_L1_RUNTIME_SECTION_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE + OVERLAY_BLOB_SIZE;
-  static constexpr std::uint32_t NCRISC_L1_RUNTIME_SECTION_SIZE = 16*1024;
-  static constexpr std::uint32_t NCRISC_L1_SCRATCH_BASE = NCRISC_L1_RUNTIME_SECTION_BASE + 0x200; // L1 Scratch used by NCRISC sized NCRISC_L1_SCRATCH_SIZE, skip 0x200 because some of the beginning of NCRISC is used .e.g. TEST_MAILBOX
-  static constexpr std::uint32_t NCRISC_L1_CONTEXT_BASE = NCRISC_L1_RUNTIME_SECTION_BASE + 0x20; // If changing make sure to modify src/firmware/riscv/targets/ncrisc/contextASM.S
-  static constexpr std::uint32_t NCRISC_L1_DRAM_POLLING_CTRL_BASE = NCRISC_L1_RUNTIME_SECTION_BASE + 0x40;
-  static constexpr std::uint32_t NCRISC_PERF_QUEUE_HEADER_SIZE = 8 * 8; // Half of this value must be 32B aligned
-  static constexpr std::uint32_t NCRISC_PERF_QUEUE_HEADER_ADDR = NCRISC_L1_RUNTIME_SECTION_BASE + NCRISC_L1_SCRATCH_SIZE; // L1 Performance Buffer used by NCRISC
-  static constexpr std::uint32_t NCRISC_L1_PERF_BUF_BASE = NCRISC_PERF_QUEUE_HEADER_ADDR + NCRISC_PERF_QUEUE_HEADER_SIZE; // L1 Performance Buffer used by NCRISC
-  static constexpr std::uint32_t NCRISC_PERF_BUF_SIZE_LEVEL_0 = 640; // smaller buffer size for limited logging
-  static constexpr std::uint32_t NCRISC_PERF_BUF_SIZE_LEVEL_1 = 4*1024 - NCRISC_PERF_QUEUE_HEADER_SIZE; // NCRISC performance buffer
-  static constexpr std::uint32_t NCRISC_L1_EPOCH_Q_BASE = NCRISC_L1_PERF_BUF_BASE + NCRISC_PERF_BUF_SIZE_LEVEL_1; // Epoch Q start in L1.
+    // MT: For Blackhole, this needs to be moved down at the expense of the data buffer
+    static constexpr std::uint32_t NCRISC_L1_RUNTIME_SECTION_BASE =
+        EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE + OVERLAY_BLOB_SIZE;
+    static constexpr std::uint32_t NCRISC_L1_RUNTIME_SECTION_SIZE = 16 * 1024;
+    static constexpr std::uint32_t NCRISC_L1_SCRATCH_BASE =
+        NCRISC_L1_RUNTIME_SECTION_BASE + 0x200;  // L1 Scratch used by NCRISC sized NCRISC_L1_SCRATCH_SIZE, skip 0x200
+                                                 // because some of the beginning of NCRISC is used .e.g. TEST_MAILBOX
+    static constexpr std::uint32_t NCRISC_L1_CONTEXT_BASE =
+        NCRISC_L1_RUNTIME_SECTION_BASE +
+        0x20;  // If changing make sure to modify src/firmware/riscv/targets/ncrisc/contextASM.S
+    static constexpr std::uint32_t NCRISC_L1_DRAM_POLLING_CTRL_BASE = NCRISC_L1_RUNTIME_SECTION_BASE + 0x40;
+    static constexpr std::uint32_t NCRISC_PERF_QUEUE_HEADER_SIZE = 8 * 8;  // Half of this value must be 32B aligned
+    static constexpr std::uint32_t NCRISC_PERF_QUEUE_HEADER_ADDR =
+        NCRISC_L1_RUNTIME_SECTION_BASE + NCRISC_L1_SCRATCH_SIZE;  // L1 Performance Buffer used by NCRISC
+    static constexpr std::uint32_t NCRISC_L1_PERF_BUF_BASE =
+        NCRISC_PERF_QUEUE_HEADER_ADDR + NCRISC_PERF_QUEUE_HEADER_SIZE;  // L1 Performance Buffer used by NCRISC
+    static constexpr std::uint32_t NCRISC_PERF_BUF_SIZE_LEVEL_0 = 640;  // smaller buffer size for limited logging
+    static constexpr std::uint32_t NCRISC_PERF_BUF_SIZE_LEVEL_1 =
+        4 * 1024 - NCRISC_PERF_QUEUE_HEADER_SIZE;  // NCRISC performance buffer
+    static constexpr std::uint32_t NCRISC_L1_EPOCH_Q_BASE =
+        NCRISC_L1_PERF_BUF_BASE + NCRISC_PERF_BUF_SIZE_LEVEL_1;  // Epoch Q start in L1.
 
-  static constexpr std::uint32_t DATA_BUFFER_SPACE_BASE = NCRISC_L1_RUNTIME_SECTION_BASE + NCRISC_L1_RUNTIME_SECTION_SIZE;
+    static constexpr std::uint32_t DATA_BUFFER_SPACE_BASE =
+        NCRISC_L1_RUNTIME_SECTION_BASE + NCRISC_L1_RUNTIME_SECTION_SIZE;
 
-  static_assert(FIRMWARE_BASE % NOC_ADDRESS_ALIGNMENT == 0, "FIRMWARE_BASE must be aligned to NOC_ADDRESS_ALIGNMENT");
-  static_assert(NCRISC_FIRMWARE_BASE % NOC_ADDRESS_ALIGNMENT == 0, "NCRISC_FIRMWARE_BASE must be aligned to NOC_ADDRESS_ALIGNMENT");
-  static_assert(TRISC0_BASE % NOC_ADDRESS_ALIGNMENT == 0, "TRISC0_BASE must be aligned to NOC_ADDRESS_ALIGNMENT");
-  static_assert(TRISC1_BASE % NOC_ADDRESS_ALIGNMENT == 0, "TROSC1_BASE must be aligned to NOC_ADDRESS_ALIGNMENT");
-  static_assert(TRISC2_BASE % NOC_ADDRESS_ALIGNMENT == 0, "TRISC2_BASE must be aligned to NOC_ADDRESS_ALIGNMENT");
-  static_assert(EPOCH_RUNTIME_CONFIG_BASE % NOC_ADDRESS_ALIGNMENT == 0, "EPOCH_RUNTIME_CONFIG_BASE must be aligned to NOC_ADDRESS_ALIGNMENT");
-  static_assert(OVERLAY_BLOB_BASE % NOC_ADDRESS_ALIGNMENT == 0, "OVERLAY_BLOB_BASE must be aligned to NOC_ADDRESS_ALIGNMENT");
-  static_assert(DATA_BUFFER_SPACE_BASE % NOC_ADDRESS_ALIGNMENT == 0, "DATA_BUFFER_SPACE_BASE must be aligned to NOC_ADDRESS_ALIGNMENT");
-  static_assert(L1_BARRIER_BASE % NOC_ADDRESS_ALIGNMENT == 0, "L1_BARRIER_BASE must be aligned to NOC_ADDRESS_ALIGNMENT");
-  
-  // Trisc Mailboxes
-  static constexpr std::uint32_t TRISC_L1_MAILBOX_OFFSET = 4;
-  static constexpr std::uint32_t BRISC_L1_MAILBOX_OFFSET = 4;
-  static constexpr std::uint32_t NRISC_L1_MAILBOX_OFFSET = 4;
+    static_assert(FIRMWARE_BASE % NOC_ADDRESS_ALIGNMENT == 0, "FIRMWARE_BASE must be aligned to NOC_ADDRESS_ALIGNMENT");
+    static_assert(
+        NCRISC_FIRMWARE_BASE % NOC_ADDRESS_ALIGNMENT == 0,
+        "NCRISC_FIRMWARE_BASE must be aligned to NOC_ADDRESS_ALIGNMENT");
+    static_assert(TRISC0_BASE % NOC_ADDRESS_ALIGNMENT == 0, "TRISC0_BASE must be aligned to NOC_ADDRESS_ALIGNMENT");
+    static_assert(TRISC1_BASE % NOC_ADDRESS_ALIGNMENT == 0, "TROSC1_BASE must be aligned to NOC_ADDRESS_ALIGNMENT");
+    static_assert(TRISC2_BASE % NOC_ADDRESS_ALIGNMENT == 0, "TRISC2_BASE must be aligned to NOC_ADDRESS_ALIGNMENT");
+    static_assert(
+        EPOCH_RUNTIME_CONFIG_BASE % NOC_ADDRESS_ALIGNMENT == 0,
+        "EPOCH_RUNTIME_CONFIG_BASE must be aligned to NOC_ADDRESS_ALIGNMENT");
+    static_assert(
+        OVERLAY_BLOB_BASE % NOC_ADDRESS_ALIGNMENT == 0, "OVERLAY_BLOB_BASE must be aligned to NOC_ADDRESS_ALIGNMENT");
+    static_assert(
+        DATA_BUFFER_SPACE_BASE % NOC_ADDRESS_ALIGNMENT == 0,
+        "DATA_BUFFER_SPACE_BASE must be aligned to NOC_ADDRESS_ALIGNMENT");
+    static_assert(
+        L1_BARRIER_BASE % NOC_ADDRESS_ALIGNMENT == 0, "L1_BARRIER_BASE must be aligned to NOC_ADDRESS_ALIGNMENT");
 
-  static constexpr std::uint32_t TRISC0_MAILBOX_BASE = TRISC0_BASE + TRISC_L1_MAILBOX_OFFSET;
-  static constexpr std::uint32_t TRISC1_MAILBOX_BASE = TRISC1_BASE + TRISC_L1_MAILBOX_OFFSET;
-  static constexpr std::uint32_t TRISC2_MAILBOX_BASE = TRISC2_BASE + TRISC_L1_MAILBOX_OFFSET;
+    // Trisc Mailboxes
+    static constexpr std::uint32_t TRISC_L1_MAILBOX_OFFSET = 4;
+    static constexpr std::uint32_t BRISC_L1_MAILBOX_OFFSET = 4;
+    static constexpr std::uint32_t NRISC_L1_MAILBOX_OFFSET = 4;
 
-  static constexpr std::uint32_t FW_MAILBOX_BASE         = 32;
-  static constexpr std::uint32_t DEBUG_MAILBOX_BUF_BASE  = 112;
+    static constexpr std::uint32_t TRISC0_MAILBOX_BASE = TRISC0_BASE + TRISC_L1_MAILBOX_OFFSET;
+    static constexpr std::uint32_t TRISC1_MAILBOX_BASE = TRISC1_BASE + TRISC_L1_MAILBOX_OFFSET;
+    static constexpr std::uint32_t TRISC2_MAILBOX_BASE = TRISC2_BASE + TRISC_L1_MAILBOX_OFFSET;
 
-  static constexpr std::uint32_t FW_MAILBOX_BUF_SIZE     = 64;
-  static constexpr std::uint32_t DEBUG_MAILBOX_BUF_SIZE  = 64; // For each T0/T1/T2/FW
+    static constexpr std::uint32_t FW_MAILBOX_BASE = 32;
+    static constexpr std::uint32_t DEBUG_MAILBOX_BUF_BASE = 112;
 
-  // Used for TT_LOG
-  static constexpr std::uint32_t TRISC_TT_LOG_MAILBOX_OFFSET = 28;
-  static constexpr std::uint32_t TRISC_TT_LOG_MAILBOX_SIZE = 64;
-  static constexpr std::uint32_t TRISC0_TT_LOG_MAILBOX_BASE = TRISC0_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
-  static constexpr std::uint32_t TRISC1_TT_LOG_MAILBOX_BASE = TRISC1_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
-  static constexpr std::uint32_t TRISC2_TT_LOG_MAILBOX_BASE = TRISC2_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
+    static constexpr std::uint32_t FW_MAILBOX_BUF_SIZE = 64;
+    static constexpr std::uint32_t DEBUG_MAILBOX_BUF_SIZE = 64;  // For each T0/T1/T2/FW
 
-  // Upper 2KB of local space is used as debug buffer
-  static constexpr std::uint32_t DEBUG_BUFFER_SIZE  = 2 * 1024;
-  static constexpr std::uint32_t TRISC0_DEBUG_BUFFER_BASE  = TRISC0_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
-  static constexpr std::uint32_t TRISC1_DEBUG_BUFFER_BASE  = TRISC1_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
-  static constexpr std::uint32_t TRISC2_DEBUG_BUFFER_BASE  = TRISC2_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
+    // Used for TT_LOG
+    static constexpr std::uint32_t TRISC_TT_LOG_MAILBOX_OFFSET = 28;
+    static constexpr std::uint32_t TRISC_TT_LOG_MAILBOX_SIZE = 64;
+    static constexpr std::uint32_t TRISC0_TT_LOG_MAILBOX_BASE = TRISC0_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
+    static constexpr std::uint32_t TRISC1_TT_LOG_MAILBOX_BASE = TRISC1_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
+    static constexpr std::uint32_t TRISC2_TT_LOG_MAILBOX_BASE = TRISC2_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
 
-  static constexpr std::uint32_t MAX_SIZE = 1499136;
-  static constexpr std::uint32_t MAX_L1_LOADING_SIZE = 1 * 1024 * 1024;
+    // Upper 2KB of local space is used as debug buffer
+    static constexpr std::uint32_t DEBUG_BUFFER_SIZE = 2 * 1024;
+    static constexpr std::uint32_t TRISC0_DEBUG_BUFFER_BASE = TRISC0_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
+    static constexpr std::uint32_t TRISC1_DEBUG_BUFFER_BASE = TRISC1_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
+    static constexpr std::uint32_t TRISC2_DEBUG_BUFFER_BASE = TRISC2_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
 
-  static constexpr std::uint32_t RISC_LOCAL_MEM_BASE = 0xffb00000; // Actaul local memory address as seen from risc firmware
-                                                                   // As part of the init risc firmware will copy local memory data from
-                                                                   // l1 locations listed above into internal local memory that starts
-                                                                   // at RISC_LOCAL_MEM_BASE address
+    static constexpr std::uint32_t MAX_SIZE = 1499136;
+    static constexpr std::uint32_t MAX_L1_LOADING_SIZE = 1 * 1024 * 1024;
 
-  static constexpr std::uint32_t NCRISC_IRAM_MEM_BASE = 0xffc00000; // NCRISC instruction RAM base address
-  static constexpr std::uint32_t NCRISC_HAS_IRAM = 0;
+    static constexpr std::uint32_t RISC_LOCAL_MEM_BASE =
+        0xffb00000;  // Actaul local memory address as seen from risc firmware
+                     // As part of the init risc firmware will copy local memory data from
+                     // l1 locations listed above into internal local memory that starts
+                     // at RISC_LOCAL_MEM_BASE address
 
-  // Perf buffer (FIXME - update once location of the perf data buffer is finalized)
-  // Parameter UNPACK_PACK_PERF_BUF_SIZE_LEVEL_1 assumes the following PERF_BUF_SIZE = 12KB - 768
-  static constexpr std::uint32_t PERF_BUF_SIZE = FIRMWARE_SIZE - BRISC_FIRMWARE_SIZE - ZEROS_SIZE;
+    static constexpr std::uint32_t NCRISC_IRAM_MEM_BASE = 0xffc00000;  // NCRISC instruction RAM base address
+    static constexpr std::uint32_t NCRISC_HAS_IRAM = 0;
 
-  // This value must be equal to the sum of all all the subsequent sizes in this section
-  static constexpr std::uint32_t PERF_TOTAL_SETUP_BUFFER_SIZE = 64;
-  // Queue header below is used for the concurrent performance trace
-  static constexpr std::uint32_t PERF_QUEUE_HEADER_SIZE = 16;
-  // Input and output overlay decoupling masks
-  static constexpr std::uint32_t PERF_RISC_MAILBOX_SIZE = 8;
-  // Signal to ncrisc that the performance buffer has been drained.
-  static constexpr std::uint32_t PERF_RESET_PTR_MAILBOX_SIZE = 4;
-  // Signal to all cores within a chip that the epoch comamnd for all cores has been sent;
-  static constexpr std::uint32_t PERF_ANALYZER_COMMAND_START_PTR_SIZE = 8;
-  static constexpr std::uint32_t PERF_ANALYZER_COMMAND_START_VAL_SIZE = 4;
-  static constexpr std::uint32_t PERF_UNUSED_SIZE = 24;
+    // Perf buffer (FIXME - update once location of the perf data buffer is finalized)
+    // Parameter UNPACK_PACK_PERF_BUF_SIZE_LEVEL_1 assumes the following PERF_BUF_SIZE = 12KB - 768
+    static constexpr std::uint32_t PERF_BUF_SIZE = FIRMWARE_SIZE - BRISC_FIRMWARE_SIZE - ZEROS_SIZE;
 
-  static constexpr std::uint32_t MATH_PERF_BUF_SIZE = 64;
-  static constexpr std::uint32_t BRISC_PERF_BUF_SIZE = 640; // Half of this value must be 32B aligned
-  static constexpr std::uint32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_0 = 640; // smaller buffer size for limited logging
-  static constexpr std::uint32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_1 = (12 * 1024 - 768)/2 - MATH_PERF_BUF_SIZE/2 - (PERF_TOTAL_SETUP_BUFFER_SIZE)/2 - BRISC_PERF_BUF_SIZE/2;
+    // This value must be equal to the sum of all all the subsequent sizes in this section
+    static constexpr std::uint32_t PERF_TOTAL_SETUP_BUFFER_SIZE = 64;
+    // Queue header below is used for the concurrent performance trace
+    static constexpr std::uint32_t PERF_QUEUE_HEADER_SIZE = 16;
+    // Input and output overlay decoupling masks
+    static constexpr std::uint32_t PERF_RISC_MAILBOX_SIZE = 8;
+    // Signal to ncrisc that the performance buffer has been drained.
+    static constexpr std::uint32_t PERF_RESET_PTR_MAILBOX_SIZE = 4;
+    // Signal to all cores within a chip that the epoch comamnd for all cores has been sent;
+    static constexpr std::uint32_t PERF_ANALYZER_COMMAND_START_PTR_SIZE = 8;
+    static constexpr std::uint32_t PERF_ANALYZER_COMMAND_START_VAL_SIZE = 4;
+    static constexpr std::uint32_t PERF_UNUSED_SIZE = 24;
 
-  static constexpr std::uint32_t PERF_QUEUE_HEADER_ADDR = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE + ZEROS_SIZE;
-  static constexpr std::uint32_t PERF_RISC_MAILBOX_ADDR = PERF_QUEUE_HEADER_ADDR + PERF_QUEUE_HEADER_SIZE;
-  static constexpr std::uint32_t PERF_RESET_PTR_MAILBOX_ADDR = PERF_RISC_MAILBOX_ADDR + PERF_RISC_MAILBOX_SIZE;
-  static constexpr std::uint32_t PERF_ANALYZER_COMMAND_START_PTR_ADDR = PERF_RESET_PTR_MAILBOX_ADDR + PERF_RESET_PTR_MAILBOX_SIZE;
-  static constexpr std::uint32_t PERF_ANALYZER_COMMAND_START_VAL_ADDR = PERF_ANALYZER_COMMAND_START_PTR_ADDR + PERF_ANALYZER_COMMAND_START_PTR_SIZE;
-  static constexpr std::uint32_t BRISC_PERF_BUF_BASE_ADDR = PERF_ANALYZER_COMMAND_START_VAL_SIZE + PERF_UNUSED_SIZE + PERF_ANALYZER_COMMAND_START_VAL_ADDR;
-  static constexpr std::uint32_t MATH_PERF_BUF_BASE_ADDR = BRISC_PERF_BUF_BASE_ADDR + BRISC_PERF_BUF_SIZE;
-  static constexpr std::uint32_t UNPACK_PACK_PERF_BUF_BASE_ADDR = MATH_PERF_BUF_BASE_ADDR + MATH_PERF_BUF_SIZE;
-  static constexpr std::int32_t PERF_NUM_THREADS = 5;
+    static constexpr std::uint32_t MATH_PERF_BUF_SIZE = 64;
+    static constexpr std::uint32_t BRISC_PERF_BUF_SIZE = 640;                // Half of this value must be 32B aligned
+    static constexpr std::uint32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_0 = 640;  // smaller buffer size for limited logging
+    static constexpr std::uint32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_1 =
+        (12 * 1024 - 768) / 2 - MATH_PERF_BUF_SIZE / 2 - (PERF_TOTAL_SETUP_BUFFER_SIZE) / 2 - BRISC_PERF_BUF_SIZE / 2;
 
-  static constexpr std::uint32_t PERF_QUEUE_PTRS = PERF_QUEUE_HEADER_ADDR;
-  static constexpr std::uint32_t PERF_THREAD_HEADER = PERF_QUEUE_PTRS + 8;
-  static constexpr std::uint32_t PERF_WR_PTR_COPY = PERF_QUEUE_PTRS + 12;
+    static constexpr std::uint32_t PERF_QUEUE_HEADER_ADDR = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE + ZEROS_SIZE;
+    static constexpr std::uint32_t PERF_RISC_MAILBOX_ADDR = PERF_QUEUE_HEADER_ADDR + PERF_QUEUE_HEADER_SIZE;
+    static constexpr std::uint32_t PERF_RESET_PTR_MAILBOX_ADDR = PERF_RISC_MAILBOX_ADDR + PERF_RISC_MAILBOX_SIZE;
+    static constexpr std::uint32_t PERF_ANALYZER_COMMAND_START_PTR_ADDR =
+        PERF_RESET_PTR_MAILBOX_ADDR + PERF_RESET_PTR_MAILBOX_SIZE;
+    static constexpr std::uint32_t PERF_ANALYZER_COMMAND_START_VAL_ADDR =
+        PERF_ANALYZER_COMMAND_START_PTR_ADDR + PERF_ANALYZER_COMMAND_START_PTR_SIZE;
+    static constexpr std::uint32_t BRISC_PERF_BUF_BASE_ADDR =
+        PERF_ANALYZER_COMMAND_START_VAL_SIZE + PERF_UNUSED_SIZE + PERF_ANALYZER_COMMAND_START_VAL_ADDR;
+    static constexpr std::uint32_t MATH_PERF_BUF_BASE_ADDR = BRISC_PERF_BUF_BASE_ADDR + BRISC_PERF_BUF_SIZE;
+    static constexpr std::uint32_t UNPACK_PACK_PERF_BUF_BASE_ADDR = MATH_PERF_BUF_BASE_ADDR + MATH_PERF_BUF_SIZE;
+    static constexpr std::int32_t PERF_NUM_THREADS = 5;
 
-  static constexpr std::uint32_t WALL_CLOCK_L = 0xFFB121F0;
-  static constexpr std::uint32_t WALL_CLOCK_H = 0xFFB121F8;
+    static constexpr std::uint32_t PERF_QUEUE_PTRS = PERF_QUEUE_HEADER_ADDR;
+    static constexpr std::uint32_t PERF_THREAD_HEADER = PERF_QUEUE_PTRS + 8;
+    static constexpr std::uint32_t PERF_WR_PTR_COPY = PERF_QUEUE_PTRS + 12;
 
+    static constexpr std::uint32_t WALL_CLOCK_L = 0xFFB121F0;
+    static constexpr std::uint32_t WALL_CLOCK_H = 0xFFB121F8;
 };
 }  // namespace l1_mem
-

--- a/src/firmware/riscv/grayskull/host_mem_address_map.h
+++ b/src/firmware/riscv/grayskull/host_mem_address_map.h
@@ -5,8 +5,9 @@
  */
 
 #pragma once
-#include <cstdint>
 #include <stdint.h>
+
+#include <cstdint>
 
 // Remove inline ASAP
 inline namespace grayskull {
@@ -14,26 +15,27 @@ inline namespace grayskull {
 namespace host_mem {
 
 struct address_map {
-  
-  // SYSMEM accessible via DEVICE-to-HOST MMIO
+    // SYSMEM accessible via DEVICE-to-HOST MMIO
 
-  static constexpr std::int32_t DEVICE_TO_HOST_MMIO_SIZE_BYTES    = 1024 * 1024 * 1024; // 1GB
-  static constexpr std::int32_t DEVICE_TO_HOST_SCRATCH_SIZE_BYTES = 128 * 1024 * 1024;
-  static constexpr std::int32_t DEVICE_TO_HOST_SCRATCH_START      = DEVICE_TO_HOST_MMIO_SIZE_BYTES - DEVICE_TO_HOST_SCRATCH_SIZE_BYTES;
-  static constexpr std::int32_t DEVICE_TO_HOST_REGION_SIZE_BYTES  = DEVICE_TO_HOST_MMIO_SIZE_BYTES - DEVICE_TO_HOST_SCRATCH_SIZE_BYTES;
-  static constexpr std::int32_t DEVICE_TO_HOST_REGION_START       = 0;
+    static constexpr std::int32_t DEVICE_TO_HOST_MMIO_SIZE_BYTES = 1024 * 1024 * 1024;  // 1GB
+    static constexpr std::int32_t DEVICE_TO_HOST_SCRATCH_SIZE_BYTES = 128 * 1024 * 1024;
+    static constexpr std::int32_t DEVICE_TO_HOST_SCRATCH_START =
+        DEVICE_TO_HOST_MMIO_SIZE_BYTES - DEVICE_TO_HOST_SCRATCH_SIZE_BYTES;
+    static constexpr std::int32_t DEVICE_TO_HOST_REGION_SIZE_BYTES =
+        DEVICE_TO_HOST_MMIO_SIZE_BYTES - DEVICE_TO_HOST_SCRATCH_SIZE_BYTES;
+    static constexpr std::int32_t DEVICE_TO_HOST_REGION_START = 0;
 
-  static constexpr std::int32_t ETH_ROUTING_BLOCK_SIZE = 32 * 1024;
-  static constexpr std::int32_t ETH_ROUTING_BUFFERS_START = DEVICE_TO_HOST_SCRATCH_START;
-  static constexpr std::int32_t ETH_ROUTING_BUFFERS_SIZE = 0;
+    static constexpr std::int32_t ETH_ROUTING_BLOCK_SIZE = 32 * 1024;
+    static constexpr std::int32_t ETH_ROUTING_BUFFERS_START = DEVICE_TO_HOST_SCRATCH_START;
+    static constexpr std::int32_t ETH_ROUTING_BUFFERS_SIZE = 0;
 
-  // Concurrent perf trace parameters
-  static constexpr std::int32_t HOST_PERF_SCRATCH_BUF_START = ETH_ROUTING_BUFFERS_START + ETH_ROUTING_BUFFERS_SIZE;
-  static constexpr std::int32_t HOST_PERF_SCRATCH_BUF_SIZE = 64 * 1024 * 1024;
-  static constexpr std::int32_t NUM_THREADS_IN_EACH_DEVICE_DUMP = 1;
-  static constexpr std::int32_t NUM_HOST_PERF_QUEUES = 8 * 64;
-  static constexpr std::int32_t HOST_PERF_QUEUE_SLOT_SIZE = HOST_PERF_SCRATCH_BUF_SIZE / NUM_HOST_PERF_QUEUES / 32 * 32;
+    // Concurrent perf trace parameters
+    static constexpr std::int32_t HOST_PERF_SCRATCH_BUF_START = ETH_ROUTING_BUFFERS_START + ETH_ROUTING_BUFFERS_SIZE;
+    static constexpr std::int32_t HOST_PERF_SCRATCH_BUF_SIZE = 64 * 1024 * 1024;
+    static constexpr std::int32_t NUM_THREADS_IN_EACH_DEVICE_DUMP = 1;
+    static constexpr std::int32_t NUM_HOST_PERF_QUEUES = 8 * 64;
+    static constexpr std::int32_t HOST_PERF_QUEUE_SLOT_SIZE =
+        HOST_PERF_SCRATCH_BUF_SIZE / NUM_HOST_PERF_QUEUES / 32 * 32;
 };
-}
-}
-
+}  // namespace host_mem
+}  // namespace grayskull

--- a/src/firmware/riscv/grayskull/l1_address_map.h
+++ b/src/firmware/riscv/grayskull/l1_address_map.h
@@ -7,131 +7,149 @@
 #pragma once
 
 #include <cstdint>
+
 namespace l1_mem {
 
 struct mailbox_type {
-  constexpr static int TRISC0 = 0;
-  constexpr static int TRISC1 = 1;
-  constexpr static int TRISC2 = 2;
-  constexpr static int NCRISC = 3;
-  constexpr static int BRISC  = 4;
+    constexpr static int TRISC0 = 0;
+    constexpr static int TRISC1 = 1;
+    constexpr static int TRISC2 = 2;
+    constexpr static int NCRISC = 3;
+    constexpr static int BRISC = 4;
 };
 
 struct address_map {
-  
-  // Sizes
-  static constexpr std::int32_t FIRMWARE_SIZE = 20 * 1024;          // 20KB = 7KB + 1KB zeros + 12KB perf buffers
-  static constexpr std::int32_t BRISC_FIRMWARE_SIZE = 7*1024 + 512 + 768; // Taking an extra 768B from perf buffer space
-  static constexpr std::int32_t ZEROS_SIZE = 512;
-  static constexpr std::int32_t NCRISC_FIRMWARE_SIZE = 32 * 1024; // 16KB in L0, 16KB in L1
-  static constexpr std::int32_t TRISC0_SIZE = 20 * 1024;        // 20KB = 16KB + 4KB local memory
-  static constexpr std::int32_t TRISC1_SIZE = 16 * 1024;        // 16KB = 12KB + 4KB local memory
-  static constexpr std::int32_t TRISC2_SIZE = 20 * 1024;        // 20KB = 16KB + 4KB local memory
-  static constexpr std::int32_t TRISC_LOCAL_MEM_SIZE = 4 * 1024;      // 
-  static constexpr std::int32_t NCRISC_LOCAL_MEM_SIZE = 4 * 1024;     // 
-  static constexpr std::int32_t NCRISC_L1_SCRATCH_SIZE = 4 * 1024;     //
-  static constexpr std::int32_t NCRISC_L1_CODE_SIZE = 16 * 1024;     // Size of code block that is L1 resident
-  static constexpr std::int32_t NCRISC_IRAM_CODE_SIZE = 16*1024;    // Size of code block that is IRAM resident
-  static constexpr std::int32_t NCRISC_DATA_SIZE = 4 * 1024;        // 4KB
-  static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_SIZE = 128;      //
-  static constexpr std::int32_t OVERLAY_BLOB_SIZE = (64 * 1024) - EPOCH_RUNTIME_CONFIG_SIZE;
-  static constexpr std::int32_t TILE_HEADER_BUF_SIZE = 32 * 1024;     // 
-  static constexpr std::int32_t NCRISC_L1_EPOCH_Q_SIZE = 32;
-  static constexpr std::int32_t FW_L1_BLOCK_SIZE = FIRMWARE_SIZE + NCRISC_FIRMWARE_SIZE + TRISC0_SIZE + TRISC1_SIZE + TRISC2_SIZE + OVERLAY_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
+    // Sizes
+    static constexpr std::int32_t FIRMWARE_SIZE = 20 * 1024;  // 20KB = 7KB + 1KB zeros + 12KB perf buffers
+    static constexpr std::int32_t BRISC_FIRMWARE_SIZE =
+        7 * 1024 + 512 + 768;  // Taking an extra 768B from perf buffer space
+    static constexpr std::int32_t ZEROS_SIZE = 512;
+    static constexpr std::int32_t NCRISC_FIRMWARE_SIZE = 32 * 1024;   // 16KB in L0, 16KB in L1
+    static constexpr std::int32_t TRISC0_SIZE = 20 * 1024;            // 20KB = 16KB + 4KB local memory
+    static constexpr std::int32_t TRISC1_SIZE = 16 * 1024;            // 16KB = 12KB + 4KB local memory
+    static constexpr std::int32_t TRISC2_SIZE = 20 * 1024;            // 20KB = 16KB + 4KB local memory
+    static constexpr std::int32_t TRISC_LOCAL_MEM_SIZE = 4 * 1024;    //
+    static constexpr std::int32_t NCRISC_LOCAL_MEM_SIZE = 4 * 1024;   //
+    static constexpr std::int32_t NCRISC_L1_SCRATCH_SIZE = 4 * 1024;  //
+    static constexpr std::int32_t NCRISC_L1_CODE_SIZE = 16 * 1024;    // Size of code block that is L1 resident
+    static constexpr std::int32_t NCRISC_IRAM_CODE_SIZE = 16 * 1024;  // Size of code block that is IRAM resident
+    static constexpr std::int32_t NCRISC_DATA_SIZE = 4 * 1024;        // 4KB
+    static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_SIZE = 128;    //
+    static constexpr std::int32_t OVERLAY_BLOB_SIZE = (64 * 1024) - EPOCH_RUNTIME_CONFIG_SIZE;
+    static constexpr std::int32_t TILE_HEADER_BUF_SIZE = 32 * 1024;  //
+    static constexpr std::int32_t NCRISC_L1_EPOCH_Q_SIZE = 32;
+    static constexpr std::int32_t FW_L1_BLOCK_SIZE = FIRMWARE_SIZE + NCRISC_FIRMWARE_SIZE + TRISC0_SIZE + TRISC1_SIZE +
+                                                     TRISC2_SIZE + OVERLAY_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE +
+                                                     TILE_HEADER_BUF_SIZE;
 
-  // Base addresses
-  static constexpr std::int32_t FIRMWARE_BASE = 0;
-  static constexpr std::int32_t L1_BARRIER_BASE = 0xfffc0;
-  static constexpr std::int32_t ZEROS_BASE = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE;
-  static constexpr std::int32_t NCRISC_FIRMWARE_BASE = FIRMWARE_BASE + FIRMWARE_SIZE;
-  static constexpr std::int32_t NCRISC_L1_CODE_BASE =  NCRISC_FIRMWARE_BASE + NCRISC_IRAM_CODE_SIZE;
-  static constexpr std::int32_t NCRISC_LOCAL_MEM_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE - NCRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::int32_t NCRISC_L1_SCRATCH_BASE = NCRISC_FIRMWARE_BASE + 0x200; // L1 Scratch used by NCRISC sized NCRISC_L1_SCRATCH_SIZE, skip 0x200 because some of the beginning of NCRISC is used .e.g. TEST_MAILBOX
-  static constexpr std::int32_t NCRISC_L1_CONTEXT_BASE = NCRISC_FIRMWARE_BASE + 0x20; // If changing make sure to modify src/firmware/riscv/targets/ncrisc/contextASM.S
-  static constexpr std::int32_t NCRISC_L1_DRAM_POLLING_CTRL_BASE = NCRISC_FIRMWARE_BASE + 0x40;
-  static constexpr std::int32_t NCRISC_PERF_QUEUE_HEADER_SIZE = 8 * 8; // Half of this value must be 32B aligned
-  static constexpr std::int32_t NCRISC_PERF_QUEUE_HEADER_ADDR = NCRISC_FIRMWARE_BASE + NCRISC_L1_SCRATCH_SIZE; // L1 Performance Buffer used by NCRISC
-  static constexpr std::int32_t NCRISC_L1_PERF_BUF_BASE = NCRISC_PERF_QUEUE_HEADER_ADDR + NCRISC_PERF_QUEUE_HEADER_SIZE; // L1 Performance Buffer used by NCRISC
-  static constexpr std::int32_t NCRISC_PERF_BUF_SIZE_LEVEL_0 = 640; // smaller buffer size for limited logging
-  static constexpr std::int32_t NCRISC_PERF_BUF_SIZE_LEVEL_1 = 4*1024 - NCRISC_PERF_QUEUE_HEADER_SIZE; // NCRISC performance buffer
-  static constexpr std::int32_t NCRISC_L1_EPOCH_Q_BASE = NCRISC_L1_PERF_BUF_BASE + NCRISC_PERF_BUF_SIZE_LEVEL_1; // Epoch Q start in L1.
+    // Base addresses
+    static constexpr std::int32_t FIRMWARE_BASE = 0;
+    static constexpr std::int32_t L1_BARRIER_BASE = 0xfffc0;
+    static constexpr std::int32_t ZEROS_BASE = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE;
+    static constexpr std::int32_t NCRISC_FIRMWARE_BASE = FIRMWARE_BASE + FIRMWARE_SIZE;
+    static constexpr std::int32_t NCRISC_L1_CODE_BASE = NCRISC_FIRMWARE_BASE + NCRISC_IRAM_CODE_SIZE;
+    static constexpr std::int32_t NCRISC_LOCAL_MEM_BASE =
+        NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE - NCRISC_LOCAL_MEM_SIZE;  // Copy of the local memory
+    static constexpr std::int32_t NCRISC_L1_SCRATCH_BASE =
+        NCRISC_FIRMWARE_BASE + 0x200;  // L1 Scratch used by NCRISC sized NCRISC_L1_SCRATCH_SIZE, skip 0x200 because
+                                       // some of the beginning of NCRISC is used .e.g. TEST_MAILBOX
+    static constexpr std::int32_t NCRISC_L1_CONTEXT_BASE =
+        NCRISC_FIRMWARE_BASE + 0x20;  // If changing make sure to modify src/firmware/riscv/targets/ncrisc/contextASM.S
+    static constexpr std::int32_t NCRISC_L1_DRAM_POLLING_CTRL_BASE = NCRISC_FIRMWARE_BASE + 0x40;
+    static constexpr std::int32_t NCRISC_PERF_QUEUE_HEADER_SIZE = 8 * 8;  // Half of this value must be 32B aligned
+    static constexpr std::int32_t NCRISC_PERF_QUEUE_HEADER_ADDR =
+        NCRISC_FIRMWARE_BASE + NCRISC_L1_SCRATCH_SIZE;  // L1 Performance Buffer used by NCRISC
+    static constexpr std::int32_t NCRISC_L1_PERF_BUF_BASE =
+        NCRISC_PERF_QUEUE_HEADER_ADDR + NCRISC_PERF_QUEUE_HEADER_SIZE;  // L1 Performance Buffer used by NCRISC
+    static constexpr std::int32_t NCRISC_PERF_BUF_SIZE_LEVEL_0 = 640;   // smaller buffer size for limited logging
+    static constexpr std::int32_t NCRISC_PERF_BUF_SIZE_LEVEL_1 =
+        4 * 1024 - NCRISC_PERF_QUEUE_HEADER_SIZE;  // NCRISC performance buffer
+    static constexpr std::int32_t NCRISC_L1_EPOCH_Q_BASE =
+        NCRISC_L1_PERF_BUF_BASE + NCRISC_PERF_BUF_SIZE_LEVEL_1;  // Epoch Q start in L1.
 
-  static constexpr std::int32_t TRISC_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
-  static constexpr std::int32_t TRISC0_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
-  static constexpr std::int32_t TRISC0_LOCAL_MEM_BASE = TRISC0_BASE + TRISC0_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::int32_t TRISC1_BASE = TRISC0_BASE + TRISC0_SIZE;
-  static constexpr std::int32_t TRISC1_LOCAL_MEM_BASE = TRISC1_BASE + TRISC1_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::int32_t TRISC2_BASE = TRISC1_BASE + TRISC1_SIZE;
-  static constexpr std::int32_t TRISC2_LOCAL_MEM_BASE = TRISC2_BASE + TRISC2_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_BASE = TRISC2_BASE + TRISC2_SIZE + TILE_HEADER_BUF_SIZE;
-  static constexpr std::int32_t OVERLAY_BLOB_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE;
-  static constexpr std::int32_t DATA_BUFFER_SPACE_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE + OVERLAY_BLOB_SIZE;
+    static constexpr std::int32_t TRISC_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
+    static constexpr std::int32_t TRISC0_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
+    static constexpr std::int32_t TRISC0_LOCAL_MEM_BASE =
+        TRISC0_BASE + TRISC0_SIZE - TRISC_LOCAL_MEM_SIZE;  // Copy of the local memory
+    static constexpr std::int32_t TRISC1_BASE = TRISC0_BASE + TRISC0_SIZE;
+    static constexpr std::int32_t TRISC1_LOCAL_MEM_BASE =
+        TRISC1_BASE + TRISC1_SIZE - TRISC_LOCAL_MEM_SIZE;  // Copy of the local memory
+    static constexpr std::int32_t TRISC2_BASE = TRISC1_BASE + TRISC1_SIZE;
+    static constexpr std::int32_t TRISC2_LOCAL_MEM_BASE =
+        TRISC2_BASE + TRISC2_SIZE - TRISC_LOCAL_MEM_SIZE;  // Copy of the local memory
+    static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_BASE = TRISC2_BASE + TRISC2_SIZE + TILE_HEADER_BUF_SIZE;
+    static constexpr std::int32_t OVERLAY_BLOB_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE;
+    static constexpr std::int32_t DATA_BUFFER_SPACE_BASE =
+        EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE + OVERLAY_BLOB_SIZE;
 
-  // Trisc Mailboxes
-  static constexpr std::int32_t TRISC_L1_MAILBOX_OFFSET = 4;
-  static constexpr std::int32_t BRISC_L1_MAILBOX_OFFSET = 4;
-  static constexpr std::int32_t NRISC_L1_MAILBOX_OFFSET = 4;
+    // Trisc Mailboxes
+    static constexpr std::int32_t TRISC_L1_MAILBOX_OFFSET = 4;
+    static constexpr std::int32_t BRISC_L1_MAILBOX_OFFSET = 4;
+    static constexpr std::int32_t NRISC_L1_MAILBOX_OFFSET = 4;
 
-  static constexpr std::int32_t TRISC0_MAILBOX_BASE = TRISC0_BASE + TRISC_L1_MAILBOX_OFFSET;
-  static constexpr std::int32_t TRISC1_MAILBOX_BASE = TRISC1_BASE + TRISC_L1_MAILBOX_OFFSET;
-  static constexpr std::int32_t TRISC2_MAILBOX_BASE = TRISC2_BASE + TRISC_L1_MAILBOX_OFFSET;
+    static constexpr std::int32_t TRISC0_MAILBOX_BASE = TRISC0_BASE + TRISC_L1_MAILBOX_OFFSET;
+    static constexpr std::int32_t TRISC1_MAILBOX_BASE = TRISC1_BASE + TRISC_L1_MAILBOX_OFFSET;
+    static constexpr std::int32_t TRISC2_MAILBOX_BASE = TRISC2_BASE + TRISC_L1_MAILBOX_OFFSET;
 
-  static constexpr std::int32_t FW_MAILBOX_BASE         = 32;
-  static constexpr std::int32_t DEBUG_MAILBOX_BUF_BASE  = 112;
+    static constexpr std::int32_t FW_MAILBOX_BASE = 32;
+    static constexpr std::int32_t DEBUG_MAILBOX_BUF_BASE = 112;
 
-  static constexpr std::int32_t FW_MAILBOX_BUF_SIZE     = 64;
-  static constexpr std::int32_t DEBUG_MAILBOX_BUF_SIZE  = 64; // For each T0/T1/T2/FW
+    static constexpr std::int32_t FW_MAILBOX_BUF_SIZE = 64;
+    static constexpr std::int32_t DEBUG_MAILBOX_BUF_SIZE = 64;  // For each T0/T1/T2/FW
 
-  // Used for TT_LOG
-  static constexpr std::int32_t TRISC_TT_LOG_MAILBOX_OFFSET = 28;
-  static constexpr std::int32_t TRISC_TT_LOG_MAILBOX_SIZE = 64;
-  static constexpr std::int32_t TRISC0_TT_LOG_MAILBOX_BASE = TRISC0_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
-  static constexpr std::int32_t TRISC1_TT_LOG_MAILBOX_BASE = TRISC1_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
-  static constexpr std::int32_t TRISC2_TT_LOG_MAILBOX_BASE = TRISC2_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
- 
-  // Upper 2KB of local space is used as debug buffer
-  static constexpr std::int32_t DEBUG_BUFFER_SIZE  = 2 * 1024;
-  static constexpr std::int32_t TRISC0_DEBUG_BUFFER_BASE  = TRISC0_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
-  static constexpr std::int32_t TRISC1_DEBUG_BUFFER_BASE  = TRISC1_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
-  static constexpr std::int32_t TRISC2_DEBUG_BUFFER_BASE  = TRISC2_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
+    // Used for TT_LOG
+    static constexpr std::int32_t TRISC_TT_LOG_MAILBOX_OFFSET = 28;
+    static constexpr std::int32_t TRISC_TT_LOG_MAILBOX_SIZE = 64;
+    static constexpr std::int32_t TRISC0_TT_LOG_MAILBOX_BASE = TRISC0_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
+    static constexpr std::int32_t TRISC1_TT_LOG_MAILBOX_BASE = TRISC1_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
+    static constexpr std::int32_t TRISC2_TT_LOG_MAILBOX_BASE = TRISC2_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
 
-  static constexpr std::int32_t MAX_SIZE = 1 * 1024 * 1024;  // 1MB
-  static constexpr std::int32_t MAX_L1_LOADING_SIZE = MAX_SIZE;
+    // Upper 2KB of local space is used as debug buffer
+    static constexpr std::int32_t DEBUG_BUFFER_SIZE = 2 * 1024;
+    static constexpr std::int32_t TRISC0_DEBUG_BUFFER_BASE = TRISC0_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
+    static constexpr std::int32_t TRISC1_DEBUG_BUFFER_BASE = TRISC1_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
+    static constexpr std::int32_t TRISC2_DEBUG_BUFFER_BASE = TRISC2_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
 
-  static constexpr std::int32_t RISC_LOCAL_MEM_BASE = 0xffb00000; // Actaul local memory address as seen from risc firmware
-                                                                   // As part of the init risc firmware will copy local memory data from
-                                                                   // l1 locations listed above into internal local memory that starts 
-                                                                   // at RISC_LOCAL_MEM_BASE address
+    static constexpr std::int32_t MAX_SIZE = 1 * 1024 * 1024;  // 1MB
+    static constexpr std::int32_t MAX_L1_LOADING_SIZE = MAX_SIZE;
 
-  static constexpr std::int32_t NCRISC_IRAM_MEM_BASE = 0xffc00000; // NCRISC instruction RAM base address
+    static constexpr std::int32_t RISC_LOCAL_MEM_BASE =
+        0xffb00000;  // Actaul local memory address as seen from risc firmware
+                     // As part of the init risc firmware will copy local memory data from
+                     // l1 locations listed above into internal local memory that starts
+                     // at RISC_LOCAL_MEM_BASE address
 
-  // Perf buffer (FIXME - update once location of the perf data buffer is finalized)
-  // Parameter UNPACK_PACK_PERF_BUF_SIZE_LEVEL_1 assumes the following PERF_BUF_SIZE = 12KB - 768
-  static constexpr std::int32_t PERF_BUF_SIZE = FIRMWARE_SIZE - BRISC_FIRMWARE_SIZE - ZEROS_SIZE;
-  
-  static constexpr std::int32_t PERF_QUEUE_HEADER_SIZE = 16;
-  static constexpr std::int32_t PERF_RISC_MAILBOX_SIZE = 16;
-  static constexpr std::int32_t PERF_UNUSED_SIZE = 32;
-  
-  static constexpr std::int32_t MATH_PERF_BUF_SIZE = 64;
-  static constexpr std::int32_t BRISC_PERF_BUF_SIZE = 640; // Half of this value must be 32B aligned
-  static constexpr std::int32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_0 = 640; // smaller buffer size for limited logging
-  static constexpr std::int32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_1 = (12 * 1024 - 768)/2 - MATH_PERF_BUF_SIZE/2 - (PERF_QUEUE_HEADER_SIZE + PERF_RISC_MAILBOX_SIZE + PERF_UNUSED_SIZE)/2 - BRISC_PERF_BUF_SIZE/2;
-  
-  static constexpr std::int32_t PERF_QUEUE_HEADER_ADDR = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE + ZEROS_SIZE;
-  static constexpr std::int32_t PERF_RISC_MAILBOX_ADDR = PERF_QUEUE_HEADER_ADDR + PERF_QUEUE_HEADER_SIZE;
-  static constexpr std::int32_t BRISC_PERF_BUF_BASE_ADDR = PERF_RISC_MAILBOX_SIZE + PERF_UNUSED_SIZE + PERF_RISC_MAILBOX_ADDR;
-  static constexpr std::int32_t MATH_PERF_BUF_BASE_ADDR = BRISC_PERF_BUF_BASE_ADDR + BRISC_PERF_BUF_SIZE;
-  static constexpr std::int32_t UNPACK_PACK_PERF_BUF_BASE_ADDR = MATH_PERF_BUF_BASE_ADDR + MATH_PERF_BUF_SIZE;
-  static constexpr std::int32_t PERF_NUM_THREADS = 5;
+    static constexpr std::int32_t NCRISC_IRAM_MEM_BASE = 0xffc00000;  // NCRISC instruction RAM base address
 
-  static constexpr std::int32_t PERF_QUEUE_PTRS = PERF_QUEUE_HEADER_ADDR;
-  static constexpr std::int32_t PERF_THREAD_HEADER = PERF_QUEUE_PTRS + 8;
-  static constexpr std::int32_t PERF_WR_PTR_COPY = PERF_QUEUE_PTRS + 12;
+    // Perf buffer (FIXME - update once location of the perf data buffer is finalized)
+    // Parameter UNPACK_PACK_PERF_BUF_SIZE_LEVEL_1 assumes the following PERF_BUF_SIZE = 12KB - 768
+    static constexpr std::int32_t PERF_BUF_SIZE = FIRMWARE_SIZE - BRISC_FIRMWARE_SIZE - ZEROS_SIZE;
 
-  static constexpr std::int32_t WALL_CLOCK_L = 0xFFB121F0;
-  static constexpr std::int32_t WALL_CLOCK_H = 0xFFB121F8;
+    static constexpr std::int32_t PERF_QUEUE_HEADER_SIZE = 16;
+    static constexpr std::int32_t PERF_RISC_MAILBOX_SIZE = 16;
+    static constexpr std::int32_t PERF_UNUSED_SIZE = 32;
 
+    static constexpr std::int32_t MATH_PERF_BUF_SIZE = 64;
+    static constexpr std::int32_t BRISC_PERF_BUF_SIZE = 640;                // Half of this value must be 32B aligned
+    static constexpr std::int32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_0 = 640;  // smaller buffer size for limited logging
+    static constexpr std::int32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_1 =
+        (12 * 1024 - 768) / 2 - MATH_PERF_BUF_SIZE / 2 -
+        (PERF_QUEUE_HEADER_SIZE + PERF_RISC_MAILBOX_SIZE + PERF_UNUSED_SIZE) / 2 - BRISC_PERF_BUF_SIZE / 2;
+
+    static constexpr std::int32_t PERF_QUEUE_HEADER_ADDR = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE + ZEROS_SIZE;
+    static constexpr std::int32_t PERF_RISC_MAILBOX_ADDR = PERF_QUEUE_HEADER_ADDR + PERF_QUEUE_HEADER_SIZE;
+    static constexpr std::int32_t BRISC_PERF_BUF_BASE_ADDR =
+        PERF_RISC_MAILBOX_SIZE + PERF_UNUSED_SIZE + PERF_RISC_MAILBOX_ADDR;
+    static constexpr std::int32_t MATH_PERF_BUF_BASE_ADDR = BRISC_PERF_BUF_BASE_ADDR + BRISC_PERF_BUF_SIZE;
+    static constexpr std::int32_t UNPACK_PACK_PERF_BUF_BASE_ADDR = MATH_PERF_BUF_BASE_ADDR + MATH_PERF_BUF_SIZE;
+    static constexpr std::int32_t PERF_NUM_THREADS = 5;
+
+    static constexpr std::int32_t PERF_QUEUE_PTRS = PERF_QUEUE_HEADER_ADDR;
+    static constexpr std::int32_t PERF_THREAD_HEADER = PERF_QUEUE_PTRS + 8;
+    static constexpr std::int32_t PERF_WR_PTR_COPY = PERF_QUEUE_PTRS + 12;
+
+    static constexpr std::int32_t WALL_CLOCK_L = 0xFFB121F0;
+    static constexpr std::int32_t WALL_CLOCK_H = 0xFFB121F8;
 };
 
 }  // namespace l1_mem

--- a/src/firmware/riscv/wormhole/eth_interface.h
+++ b/src/firmware/riscv/wormhole/eth_interface.h
@@ -20,19 +20,19 @@ const uint32_t MAX_CHIP_GRID_SIZE = 128;
 const uint32_t CMD_BUF_SIZE = 4;  // we assume must be 2^N
 
 const uint32_t CMD_BUF_SIZE_MASK = (CMD_BUF_SIZE - 1);
-const uint32_t CMD_BUF_PTR_MASK  = ((CMD_BUF_SIZE << 1) - 1);
+const uint32_t CMD_BUF_PTR_MASK = ((CMD_BUF_SIZE << 1) - 1);
 
 const uint32_t ETH_ROUTING_STRUCT_ADDR = 0x11000;
 const uint32_t ETH_ROUTING_DATA_BUFFER_ADDR = 0x12000;
-//const uint32_t ETH_ROUTING_STRUCT_ADDR = eth_l1_mem::address_map::COMMAND_Q_BASE;
-//const uint32_t ETH_ROUTING_DATA_BUFFER_ADDR = eth_l1_mem::address_map::DATA_BUFFER_BASE;
+// const uint32_t ETH_ROUTING_STRUCT_ADDR = eth_l1_mem::address_map::COMMAND_Q_BASE;
+// const uint32_t ETH_ROUTING_DATA_BUFFER_ADDR = eth_l1_mem::address_map::DATA_BUFFER_BASE;
 
 const uint32_t ROOT_NODE_NOC_X = 9;
 const uint32_t ROOT_NODE_NOC_Y = 0;
 
-const uint32_t CMD_WR_REQ  = (0x1 << 0);
-const uint32_t CMD_WR_ACK  = (0x1 << 1);
-const uint32_t CMD_RD_REQ  = (0x1 << 2);
+const uint32_t CMD_WR_REQ = (0x1 << 0);
+const uint32_t CMD_WR_ACK = (0x1 << 1);
+const uint32_t CMD_RD_REQ = (0x1 << 2);
 const uint32_t CMD_RD_DATA = (0x1 << 3);
 const uint32_t CMD_DATA_BLOCK_DRAM = (0x1 << 4);
 const uint32_t CMD_LAST_DATA_BLOCK_DRAM = (0x1 << 5);
@@ -46,56 +46,64 @@ const uint32_t CMD_ORDERED = (0x1 << 12);
 
 const uint32_t CMD_DATA_BLOCK_UNAVAILABLE = (0x1 << 30);
 const uint32_t CMD_DEST_UNREACHABLE = (0x1 << 31);
-const uint32_t MAX_BLOCK_SIZE = (0x1 << 10); // Max 1024 bytes
+const uint32_t MAX_BLOCK_SIZE = (0x1 << 10);  // Max 1024 bytes
 
 const uint32_t CMD_SIZE_BYTES = 32;
 const uint32_t ETH_RACK_COORD_WIDTH = 8;
 
 typedef struct {
-  uint64_t sys_addr;
-  uint32_t data;
-  uint32_t flags;
-  uint16_t rack;
-  uint16_t src_resp_buf_index;
-  uint32_t local_buf_index;
-  uint8_t  src_resp_q_id;
-  uint8_t  host_mem_txn_id;
-  uint16_t padding;
-  uint32_t src_addr_tag; //upper 32-bits of request source address.
+    uint64_t sys_addr;
+    uint32_t data;
+    uint32_t flags;
+    uint16_t rack;
+    uint16_t src_resp_buf_index;
+    uint32_t local_buf_index;
+    uint8_t src_resp_q_id;
+    uint8_t host_mem_txn_id;
+    uint16_t padding;
+    uint32_t src_addr_tag;  // upper 32-bits of request source address.
 } routing_cmd_t;
+
 static_assert(sizeof(routing_cmd_t) == CMD_SIZE_BYTES);
 
-
 const uint32_t REMOTE_UPDATE_PTR_SIZE_BYTES = 16;
+
 typedef struct {
-  uint32_t ptr;
-  uint32_t pad[3];
+    uint32_t ptr;
+    uint32_t pad[3];
 } remote_update_ptr_t;
+
 static_assert(sizeof(remote_update_ptr_t) == REMOTE_UPDATE_PTR_SIZE_BYTES);
 
 const uint32_t CMD_COUNTERS_SIZE_BYTES = 32;
+
 typedef struct {
-  uint32_t wr_req;
-  uint32_t wr_resp;
-  uint32_t rd_req;
-  uint32_t rd_resp;
-  uint32_t error;
-  uint32_t pad[3];
+    uint32_t wr_req;
+    uint32_t wr_resp;
+    uint32_t rd_req;
+    uint32_t rd_resp;
+    uint32_t error;
+    uint32_t pad[3];
 } cmd_counters_t;
+
 static_assert(sizeof(cmd_counters_t) == CMD_COUNTERS_SIZE_BYTES);
 
-const uint32_t CMD_Q_SIZE_BYTES = 2*REMOTE_UPDATE_PTR_SIZE_BYTES + CMD_COUNTERS_SIZE_BYTES + CMD_BUF_SIZE*CMD_SIZE_BYTES;
+const uint32_t CMD_Q_SIZE_BYTES =
+    2 * REMOTE_UPDATE_PTR_SIZE_BYTES + CMD_COUNTERS_SIZE_BYTES + CMD_BUF_SIZE * CMD_SIZE_BYTES;
+
 typedef struct {
-  cmd_counters_t cmd_counters;
-  remote_update_ptr_t wrptr;
-  remote_update_ptr_t rdptr;
-  routing_cmd_t cmd[CMD_BUF_SIZE];
+    cmd_counters_t cmd_counters;
+    remote_update_ptr_t wrptr;
+    remote_update_ptr_t rdptr;
+    routing_cmd_t cmd[CMD_BUF_SIZE];
 } cmd_q_t;
+
 static_assert(sizeof(cmd_q_t) == CMD_Q_SIZE_BYTES);
 
-
-//there are 16 64-bit latency counters at the beginning of command q region.
+// there are 16 64-bit latency counters at the beginning of command q region.
 constexpr uint32_t REQUEST_CMD_QUEUE_BASE = ETH_ROUTING_STRUCT_ADDR + 128;
-constexpr uint32_t REQUEST_ROUTING_CMD_QUEUE_BASE = REQUEST_CMD_QUEUE_BASE + sizeof(remote_update_ptr_t) + sizeof(remote_update_ptr_t) + sizeof(cmd_counters_t);
-constexpr uint32_t RESPONSE_CMD_QUEUE_BASE = REQUEST_CMD_QUEUE_BASE + 2*CMD_Q_SIZE_BYTES;
-constexpr uint32_t RESPONSE_ROUTING_CMD_QUEUE_BASE = RESPONSE_CMD_QUEUE_BASE + sizeof(remote_update_ptr_t) + sizeof(remote_update_ptr_t) + sizeof(cmd_counters_t);
+constexpr uint32_t REQUEST_ROUTING_CMD_QUEUE_BASE =
+    REQUEST_CMD_QUEUE_BASE + sizeof(remote_update_ptr_t) + sizeof(remote_update_ptr_t) + sizeof(cmd_counters_t);
+constexpr uint32_t RESPONSE_CMD_QUEUE_BASE = REQUEST_CMD_QUEUE_BASE + 2 * CMD_Q_SIZE_BYTES;
+constexpr uint32_t RESPONSE_ROUTING_CMD_QUEUE_BASE =
+    RESPONSE_CMD_QUEUE_BASE + sizeof(remote_update_ptr_t) + sizeof(remote_update_ptr_t) + sizeof(cmd_counters_t);

--- a/src/firmware/riscv/wormhole/eth_l1_address_map.h
+++ b/src/firmware/riscv/wormhole/eth_l1_address_map.h
@@ -10,54 +10,55 @@
 
 namespace eth_l1_mem {
 
-
 struct address_map {
-  // Sizes
-  static constexpr std::int32_t FIRMWARE_SIZE = 32 * 1024;
-  static constexpr std::int32_t ERISC_BARRIER_SIZE = 0x20; // 32 bytes reserved for Barrier
-  static constexpr std::int32_t COMMAND_Q_SIZE = 4 * 1024;
-  static constexpr std::int32_t DATA_BUFFER_SIZE_HOST = 4 * 1024;
-  static constexpr std::int32_t DATA_BUFFER_SIZE_ETH = 4 * 1024;
-  static constexpr std::int32_t DATA_BUFFER_SIZE_NOC = 16 * 1024;
-  static constexpr std::int32_t DATA_BUFFER_SIZE = 24 * 1024;
-  static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_SIZE = 128;
-  static constexpr std::int32_t OVERLAY_BLOB_SIZE = (32 * 1024) - EPOCH_RUNTIME_CONFIG_SIZE;
-  static constexpr std::int32_t OVERLAY_MAX_EXTRA_BLOB_SIZE = (0 * 1024);
-  static constexpr std::int32_t TILE_HEADER_BUF_SIZE = 32 * 1024;
-  static constexpr std::int32_t NCRISC_L1_EPOCH_Q_SIZE = 32;
-  static constexpr std::int32_t FW_L1_BLOCK_SIZE = OVERLAY_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
-  static constexpr std::int32_t FW_DRAM_BLOCK_SIZE = OVERLAY_BLOB_SIZE + OVERLAY_MAX_EXTRA_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
-  // Base addresses
-  static constexpr std::int32_t FIRMWARE_BASE = 0x9040;
-  static constexpr std::int32_t ERISC_BARRIER_BASE = 0x11FE0;
-  static constexpr std::int32_t L1_EPOCH_Q_BASE = 0x9000; // Epoch Q start in L1.
-  static constexpr std::int32_t L1_DRAM_POLLING_CTRL_BASE = 0x9020;
-  static constexpr std::int32_t COMMAND_Q_BASE = L1_EPOCH_Q_BASE + FIRMWARE_SIZE;
-  static constexpr std::int32_t DATA_BUFFER_BASE = COMMAND_Q_BASE + COMMAND_Q_SIZE;
-  static constexpr std::int32_t TILE_HEADER_BUFFER_BASE = DATA_BUFFER_BASE + DATA_BUFFER_SIZE;
-  static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_BASE = TILE_HEADER_BUFFER_BASE + TILE_HEADER_BUF_SIZE;
-  static constexpr std::int32_t OVERLAY_BLOB_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE;
-  static constexpr std::int32_t DATA_BUFFER_SPACE_BASE = OVERLAY_BLOB_BASE + OVERLAY_BLOB_SIZE;
+    // Sizes
+    static constexpr std::int32_t FIRMWARE_SIZE = 32 * 1024;
+    static constexpr std::int32_t ERISC_BARRIER_SIZE = 0x20;  // 32 bytes reserved for Barrier
+    static constexpr std::int32_t COMMAND_Q_SIZE = 4 * 1024;
+    static constexpr std::int32_t DATA_BUFFER_SIZE_HOST = 4 * 1024;
+    static constexpr std::int32_t DATA_BUFFER_SIZE_ETH = 4 * 1024;
+    static constexpr std::int32_t DATA_BUFFER_SIZE_NOC = 16 * 1024;
+    static constexpr std::int32_t DATA_BUFFER_SIZE = 24 * 1024;
+    static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_SIZE = 128;
+    static constexpr std::int32_t OVERLAY_BLOB_SIZE = (32 * 1024) - EPOCH_RUNTIME_CONFIG_SIZE;
+    static constexpr std::int32_t OVERLAY_MAX_EXTRA_BLOB_SIZE = (0 * 1024);
+    static constexpr std::int32_t TILE_HEADER_BUF_SIZE = 32 * 1024;
+    static constexpr std::int32_t NCRISC_L1_EPOCH_Q_SIZE = 32;
+    static constexpr std::int32_t FW_L1_BLOCK_SIZE =
+        OVERLAY_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
+    static constexpr std::int32_t FW_DRAM_BLOCK_SIZE =
+        OVERLAY_BLOB_SIZE + OVERLAY_MAX_EXTRA_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
+    // Base addresses
+    static constexpr std::int32_t FIRMWARE_BASE = 0x9040;
+    static constexpr std::int32_t ERISC_BARRIER_BASE = 0x11FE0;
+    static constexpr std::int32_t L1_EPOCH_Q_BASE = 0x9000;  // Epoch Q start in L1.
+    static constexpr std::int32_t L1_DRAM_POLLING_CTRL_BASE = 0x9020;
+    static constexpr std::int32_t COMMAND_Q_BASE = L1_EPOCH_Q_BASE + FIRMWARE_SIZE;
+    static constexpr std::int32_t DATA_BUFFER_BASE = COMMAND_Q_BASE + COMMAND_Q_SIZE;
+    static constexpr std::int32_t TILE_HEADER_BUFFER_BASE = DATA_BUFFER_BASE + DATA_BUFFER_SIZE;
+    static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_BASE = TILE_HEADER_BUFFER_BASE + TILE_HEADER_BUF_SIZE;
+    static constexpr std::int32_t OVERLAY_BLOB_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE;
+    static constexpr std::int32_t DATA_BUFFER_SPACE_BASE = OVERLAY_BLOB_BASE + OVERLAY_BLOB_SIZE;
 
-  static std::int32_t OVERLAY_FULL_BLOB_SIZE() {
-      return OVERLAY_BLOB_SIZE + OVERLAY_MAX_EXTRA_BLOB_SIZE;
-  };
+    static std::int32_t OVERLAY_FULL_BLOB_SIZE() { return OVERLAY_BLOB_SIZE + OVERLAY_MAX_EXTRA_BLOB_SIZE; };
 
-template<std::size_t A, std::size_t B> struct TAssertEquality {
-  static_assert(A==B, "Not equal");
-  static constexpr bool _cResult = (A==B);
+    template <std::size_t A, std::size_t B>
+    struct TAssertEquality {
+        static_assert(A == B, "Not equal");
+        static constexpr bool _cResult = (A == B);
+    };
+
+    static constexpr bool _DATA_BUFFER_SPACE_BASE_CORRECT = TAssertEquality<DATA_BUFFER_SPACE_BASE, 0x28000>::_cResult;
+
+    static constexpr std::int32_t MAX_SIZE = 256 * 1024;
+    static constexpr std::int32_t MAX_L1_LOADING_SIZE = 1 * 256 * 1024;
+
+    static constexpr std::int32_t RISC_LOCAL_MEM_BASE =
+        0xffb00000;  // Actaul local memory address as seen from risc firmware
+                     // As part of the init risc firmware will copy local memory data from
+                     // l1 locations listed above into internal local memory that starts
+                     // at RISC_LOCAL_MEM_BASE address
+
+    static constexpr std::uint32_t FW_VERSION_ADDR = 0x210;
 };
-
-static constexpr bool _DATA_BUFFER_SPACE_BASE_CORRECT = TAssertEquality<DATA_BUFFER_SPACE_BASE, 0x28000>::_cResult;
-
-  static constexpr std::int32_t MAX_SIZE = 256*1024;
-  static constexpr std::int32_t MAX_L1_LOADING_SIZE = 1 * 256 * 1024;  
-  
-  static constexpr std::int32_t RISC_LOCAL_MEM_BASE = 0xffb00000; // Actaul local memory address as seen from risc firmware
-                                                                   // As part of the init risc firmware will copy local memory data from
-                                                                   // l1 locations listed above into internal local memory that starts 
-                                                                   // at RISC_LOCAL_MEM_BASE address
-
-  static constexpr std::uint32_t FW_VERSION_ADDR = 0x210;
-};
-}  // namespace llk
+}  // namespace eth_l1_mem

--- a/src/firmware/riscv/wormhole/host_mem_address_map.h
+++ b/src/firmware/riscv/wormhole/host_mem_address_map.h
@@ -5,8 +5,9 @@
  */
 
 #pragma once
-#include <cstdint>
 #include <stdint.h>
+
+#include <cstdint>
 
 // Remove inline ASAP
 inline namespace wormhole {
@@ -14,26 +15,28 @@ inline namespace wormhole {
 namespace host_mem {
 
 struct address_map {
-  
-  // SYSMEM accessible via DEVICE-to-HOST MMIO
+    // SYSMEM accessible via DEVICE-to-HOST MMIO
 
-  static constexpr std::int32_t DEVICE_TO_HOST_MMIO_SIZE_BYTES    = 1024 * 1024 * 1024; // 1GB
-  static constexpr std::int32_t DEVICE_TO_HOST_SCRATCH_SIZE_BYTES = 128 * 1024 * 1024;
-  static constexpr std::int32_t DEVICE_TO_HOST_SCRATCH_START      = DEVICE_TO_HOST_MMIO_SIZE_BYTES - DEVICE_TO_HOST_SCRATCH_SIZE_BYTES;
-  static constexpr std::int32_t DEVICE_TO_HOST_REGION_SIZE_BYTES  = DEVICE_TO_HOST_MMIO_SIZE_BYTES - DEVICE_TO_HOST_SCRATCH_SIZE_BYTES;
-  static constexpr std::int32_t DEVICE_TO_HOST_REGION_START       = 0;
+    static constexpr std::int32_t DEVICE_TO_HOST_MMIO_SIZE_BYTES = 1024 * 1024 * 1024;  // 1GB
+    static constexpr std::int32_t DEVICE_TO_HOST_SCRATCH_SIZE_BYTES = 128 * 1024 * 1024;
+    static constexpr std::int32_t DEVICE_TO_HOST_SCRATCH_START =
+        DEVICE_TO_HOST_MMIO_SIZE_BYTES - DEVICE_TO_HOST_SCRATCH_SIZE_BYTES;
+    static constexpr std::int32_t DEVICE_TO_HOST_REGION_SIZE_BYTES =
+        DEVICE_TO_HOST_MMIO_SIZE_BYTES - DEVICE_TO_HOST_SCRATCH_SIZE_BYTES;
+    static constexpr std::int32_t DEVICE_TO_HOST_REGION_START = 0;
 
-  static constexpr std::int32_t ETH_ROUTING_BLOCK_SIZE = 32 * 1024;
-  static constexpr std::int32_t ETH_ROUTING_BUFFERS_START = DEVICE_TO_HOST_SCRATCH_START;
-  static constexpr std::int32_t ETH_ROUTING_BUFFERS_SIZE = ETH_ROUTING_BLOCK_SIZE * 16 * 4;// 16 ethernet cores x 4 buffers/core
+    static constexpr std::int32_t ETH_ROUTING_BLOCK_SIZE = 32 * 1024;
+    static constexpr std::int32_t ETH_ROUTING_BUFFERS_START = DEVICE_TO_HOST_SCRATCH_START;
+    static constexpr std::int32_t ETH_ROUTING_BUFFERS_SIZE =
+        ETH_ROUTING_BLOCK_SIZE * 16 * 4;  // 16 ethernet cores x 4 buffers/core
 
-  // Concurrent perf trace parameters
-  static constexpr std::int32_t HOST_PERF_SCRATCH_BUF_START = DEVICE_TO_HOST_SCRATCH_START + ETH_ROUTING_BUFFERS_SIZE;
-  static constexpr std::int32_t HOST_PERF_SCRATCH_BUF_SIZE = 64 * 1024 * 1024;
-  static constexpr std::int32_t NUM_THREADS_IN_EACH_DEVICE_DUMP = 1;
-  static constexpr std::int32_t NUM_HOST_PERF_QUEUES = 6 * 64;
-  static constexpr std::int32_t HOST_PERF_QUEUE_SLOT_SIZE = HOST_PERF_SCRATCH_BUF_SIZE / NUM_HOST_PERF_QUEUES / 32 * 32;  
+    // Concurrent perf trace parameters
+    static constexpr std::int32_t HOST_PERF_SCRATCH_BUF_START = DEVICE_TO_HOST_SCRATCH_START + ETH_ROUTING_BUFFERS_SIZE;
+    static constexpr std::int32_t HOST_PERF_SCRATCH_BUF_SIZE = 64 * 1024 * 1024;
+    static constexpr std::int32_t NUM_THREADS_IN_EACH_DEVICE_DUMP = 1;
+    static constexpr std::int32_t NUM_HOST_PERF_QUEUES = 6 * 64;
+    static constexpr std::int32_t HOST_PERF_QUEUE_SLOT_SIZE =
+        HOST_PERF_SCRATCH_BUF_SIZE / NUM_HOST_PERF_QUEUES / 32 * 32;
 };
-}
-}
-
+}  // namespace host_mem
+}  // namespace wormhole

--- a/src/firmware/riscv/wormhole/l1_address_map.h
+++ b/src/firmware/riscv/wormhole/l1_address_map.h
@@ -7,132 +7,150 @@
 #pragma once
 
 #include <cstdint>
+
 namespace l1_mem {
 
 struct mailbox_type {
-  constexpr static int TRISC0 = 0;
-  constexpr static int TRISC1 = 1;
-  constexpr static int TRISC2 = 2;
-  constexpr static int NCRISC = 3;
-  constexpr static int BRISC  = 4;
+    constexpr static int TRISC0 = 0;
+    constexpr static int TRISC1 = 1;
+    constexpr static int TRISC2 = 2;
+    constexpr static int NCRISC = 3;
+    constexpr static int BRISC = 4;
 };
 
 struct address_map {
-  
-  // Sizes
-  static constexpr std::int32_t FIRMWARE_SIZE = 20 * 1024;          // 20KB = 7KB + 1KB zeros + 12KB perf buffers
-  static constexpr std::int32_t L1_BARRIER_SIZE = 0x20; // 32 bytes reserved for L1 Barrier
-  static constexpr std::int32_t BRISC_FIRMWARE_SIZE = 7*1024 + 512 + 768; // Taking an extra 768B from perf buffer space
-  static constexpr std::int32_t ZEROS_SIZE = 512;
-  static constexpr std::int32_t NCRISC_FIRMWARE_SIZE = 32 * 1024; // 16KB in L0, 16KB in L1
-  static constexpr std::int32_t TRISC0_SIZE = 20 * 1024;        // 20KB = 16KB + 4KB local memory
-  static constexpr std::int32_t TRISC1_SIZE = 16 * 1024;        // 16KB = 12KB + 4KB local memory
-  static constexpr std::int32_t TRISC2_SIZE = 20 * 1024;        // 20KB = 16KB + 4KB local memory
-  static constexpr std::int32_t TRISC_LOCAL_MEM_SIZE = 4 * 1024;      // 
-  static constexpr std::int32_t NCRISC_LOCAL_MEM_SIZE = 4 * 1024;     // 
-  static constexpr std::int32_t NCRISC_L1_SCRATCH_SIZE = 4 * 1024;     //
-  static constexpr std::int32_t NCRISC_L1_CODE_SIZE = 16 * 1024;     // Size of code block that is L1 resident
-  static constexpr std::int32_t NCRISC_IRAM_CODE_SIZE = 16*1024;    // Size of code block that is IRAM resident
-  static constexpr std::int32_t NCRISC_DATA_SIZE = 4 * 1024;        // 4KB
-  static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_SIZE = 128;      //
-  static constexpr std::int32_t OVERLAY_BLOB_SIZE = (64 * 1024) - EPOCH_RUNTIME_CONFIG_SIZE;
-  static constexpr std::int32_t TILE_HEADER_BUF_SIZE = 32 * 1024;     // 
-  static constexpr std::int32_t NCRISC_L1_EPOCH_Q_SIZE = 32;
-  static constexpr std::int32_t FW_L1_BLOCK_SIZE = FIRMWARE_SIZE + NCRISC_FIRMWARE_SIZE + TRISC0_SIZE + TRISC1_SIZE + TRISC2_SIZE + OVERLAY_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
+    // Sizes
+    static constexpr std::int32_t FIRMWARE_SIZE = 20 * 1024;  // 20KB = 7KB + 1KB zeros + 12KB perf buffers
+    static constexpr std::int32_t L1_BARRIER_SIZE = 0x20;     // 32 bytes reserved for L1 Barrier
+    static constexpr std::int32_t BRISC_FIRMWARE_SIZE =
+        7 * 1024 + 512 + 768;  // Taking an extra 768B from perf buffer space
+    static constexpr std::int32_t ZEROS_SIZE = 512;
+    static constexpr std::int32_t NCRISC_FIRMWARE_SIZE = 32 * 1024;   // 16KB in L0, 16KB in L1
+    static constexpr std::int32_t TRISC0_SIZE = 20 * 1024;            // 20KB = 16KB + 4KB local memory
+    static constexpr std::int32_t TRISC1_SIZE = 16 * 1024;            // 16KB = 12KB + 4KB local memory
+    static constexpr std::int32_t TRISC2_SIZE = 20 * 1024;            // 20KB = 16KB + 4KB local memory
+    static constexpr std::int32_t TRISC_LOCAL_MEM_SIZE = 4 * 1024;    //
+    static constexpr std::int32_t NCRISC_LOCAL_MEM_SIZE = 4 * 1024;   //
+    static constexpr std::int32_t NCRISC_L1_SCRATCH_SIZE = 4 * 1024;  //
+    static constexpr std::int32_t NCRISC_L1_CODE_SIZE = 16 * 1024;    // Size of code block that is L1 resident
+    static constexpr std::int32_t NCRISC_IRAM_CODE_SIZE = 16 * 1024;  // Size of code block that is IRAM resident
+    static constexpr std::int32_t NCRISC_DATA_SIZE = 4 * 1024;        // 4KB
+    static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_SIZE = 128;    //
+    static constexpr std::int32_t OVERLAY_BLOB_SIZE = (64 * 1024) - EPOCH_RUNTIME_CONFIG_SIZE;
+    static constexpr std::int32_t TILE_HEADER_BUF_SIZE = 32 * 1024;  //
+    static constexpr std::int32_t NCRISC_L1_EPOCH_Q_SIZE = 32;
+    static constexpr std::int32_t FW_L1_BLOCK_SIZE = FIRMWARE_SIZE + NCRISC_FIRMWARE_SIZE + TRISC0_SIZE + TRISC1_SIZE +
+                                                     TRISC2_SIZE + OVERLAY_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE +
+                                                     TILE_HEADER_BUF_SIZE;
 
-  // Base addresses
-  static constexpr std::int32_t FIRMWARE_BASE = 0;
-  static constexpr std::int32_t L1_BARRIER_BASE = 0x16dfc0;
-  static constexpr std::int32_t ZEROS_BASE = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE;
-  static constexpr std::int32_t NCRISC_FIRMWARE_BASE = FIRMWARE_BASE + FIRMWARE_SIZE;
-  static constexpr std::int32_t NCRISC_L1_CODE_BASE =  NCRISC_FIRMWARE_BASE + NCRISC_IRAM_CODE_SIZE;
-  static constexpr std::int32_t NCRISC_LOCAL_MEM_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE - NCRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::int32_t NCRISC_L1_SCRATCH_BASE = NCRISC_FIRMWARE_BASE + 0x200; // L1 Scratch used by NCRISC sized NCRISC_L1_SCRATCH_SIZE, skip 0x200 because some of the beginning of NCRISC is used .e.g. TEST_MAILBOX
-  static constexpr std::int32_t NCRISC_L1_CONTEXT_BASE = NCRISC_FIRMWARE_BASE + 0x20; // If changing make sure to modify src/firmware/riscv/targets/ncrisc/contextASM.S
-  static constexpr std::int32_t NCRISC_L1_DRAM_POLLING_CTRL_BASE = NCRISC_FIRMWARE_BASE + 0x40;
-  static constexpr std::int32_t NCRISC_PERF_QUEUE_HEADER_SIZE = 8 * 8; // Half of this value must be 32B aligned
-  static constexpr std::int32_t NCRISC_PERF_QUEUE_HEADER_ADDR = NCRISC_FIRMWARE_BASE + NCRISC_L1_SCRATCH_SIZE; // L1 Performance Buffer used by NCRISC
-  static constexpr std::int32_t NCRISC_L1_PERF_BUF_BASE = NCRISC_PERF_QUEUE_HEADER_ADDR + NCRISC_PERF_QUEUE_HEADER_SIZE; // L1 Performance Buffer used by NCRISC
-  static constexpr std::int32_t NCRISC_PERF_BUF_SIZE_LEVEL_0 = 640; // smaller buffer size for limited logging
-  static constexpr std::int32_t NCRISC_PERF_BUF_SIZE_LEVEL_1 = 4*1024 - NCRISC_PERF_QUEUE_HEADER_SIZE; // NCRISC performance buffer
-  static constexpr std::int32_t NCRISC_L1_EPOCH_Q_BASE = NCRISC_L1_PERF_BUF_BASE + NCRISC_PERF_BUF_SIZE_LEVEL_1; // Epoch Q start in L1.
+    // Base addresses
+    static constexpr std::int32_t FIRMWARE_BASE = 0;
+    static constexpr std::int32_t L1_BARRIER_BASE = 0x16dfc0;
+    static constexpr std::int32_t ZEROS_BASE = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE;
+    static constexpr std::int32_t NCRISC_FIRMWARE_BASE = FIRMWARE_BASE + FIRMWARE_SIZE;
+    static constexpr std::int32_t NCRISC_L1_CODE_BASE = NCRISC_FIRMWARE_BASE + NCRISC_IRAM_CODE_SIZE;
+    static constexpr std::int32_t NCRISC_LOCAL_MEM_BASE =
+        NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE - NCRISC_LOCAL_MEM_SIZE;  // Copy of the local memory
+    static constexpr std::int32_t NCRISC_L1_SCRATCH_BASE =
+        NCRISC_FIRMWARE_BASE + 0x200;  // L1 Scratch used by NCRISC sized NCRISC_L1_SCRATCH_SIZE, skip 0x200 because
+                                       // some of the beginning of NCRISC is used .e.g. TEST_MAILBOX
+    static constexpr std::int32_t NCRISC_L1_CONTEXT_BASE =
+        NCRISC_FIRMWARE_BASE + 0x20;  // If changing make sure to modify src/firmware/riscv/targets/ncrisc/contextASM.S
+    static constexpr std::int32_t NCRISC_L1_DRAM_POLLING_CTRL_BASE = NCRISC_FIRMWARE_BASE + 0x40;
+    static constexpr std::int32_t NCRISC_PERF_QUEUE_HEADER_SIZE = 8 * 8;  // Half of this value must be 32B aligned
+    static constexpr std::int32_t NCRISC_PERF_QUEUE_HEADER_ADDR =
+        NCRISC_FIRMWARE_BASE + NCRISC_L1_SCRATCH_SIZE;  // L1 Performance Buffer used by NCRISC
+    static constexpr std::int32_t NCRISC_L1_PERF_BUF_BASE =
+        NCRISC_PERF_QUEUE_HEADER_ADDR + NCRISC_PERF_QUEUE_HEADER_SIZE;  // L1 Performance Buffer used by NCRISC
+    static constexpr std::int32_t NCRISC_PERF_BUF_SIZE_LEVEL_0 = 640;   // smaller buffer size for limited logging
+    static constexpr std::int32_t NCRISC_PERF_BUF_SIZE_LEVEL_1 =
+        4 * 1024 - NCRISC_PERF_QUEUE_HEADER_SIZE;  // NCRISC performance buffer
+    static constexpr std::int32_t NCRISC_L1_EPOCH_Q_BASE =
+        NCRISC_L1_PERF_BUF_BASE + NCRISC_PERF_BUF_SIZE_LEVEL_1;  // Epoch Q start in L1.
 
-  static constexpr std::int32_t TRISC_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
-  static constexpr std::int32_t TRISC0_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
-  static constexpr std::int32_t TRISC0_LOCAL_MEM_BASE = TRISC0_BASE + TRISC0_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::int32_t TRISC1_BASE = TRISC0_BASE + TRISC0_SIZE;
-  static constexpr std::int32_t TRISC1_LOCAL_MEM_BASE = TRISC1_BASE + TRISC1_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::int32_t TRISC2_BASE = TRISC1_BASE + TRISC1_SIZE;
-  static constexpr std::int32_t TRISC2_LOCAL_MEM_BASE = TRISC2_BASE + TRISC2_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_BASE = TRISC2_BASE + TRISC2_SIZE + TILE_HEADER_BUF_SIZE;
-  static constexpr std::int32_t OVERLAY_BLOB_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE;
-  static constexpr std::int32_t DATA_BUFFER_SPACE_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE + OVERLAY_BLOB_SIZE;
+    static constexpr std::int32_t TRISC_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
+    static constexpr std::int32_t TRISC0_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
+    static constexpr std::int32_t TRISC0_LOCAL_MEM_BASE =
+        TRISC0_BASE + TRISC0_SIZE - TRISC_LOCAL_MEM_SIZE;  // Copy of the local memory
+    static constexpr std::int32_t TRISC1_BASE = TRISC0_BASE + TRISC0_SIZE;
+    static constexpr std::int32_t TRISC1_LOCAL_MEM_BASE =
+        TRISC1_BASE + TRISC1_SIZE - TRISC_LOCAL_MEM_SIZE;  // Copy of the local memory
+    static constexpr std::int32_t TRISC2_BASE = TRISC1_BASE + TRISC1_SIZE;
+    static constexpr std::int32_t TRISC2_LOCAL_MEM_BASE =
+        TRISC2_BASE + TRISC2_SIZE - TRISC_LOCAL_MEM_SIZE;  // Copy of the local memory
+    static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_BASE = TRISC2_BASE + TRISC2_SIZE + TILE_HEADER_BUF_SIZE;
+    static constexpr std::int32_t OVERLAY_BLOB_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE;
+    static constexpr std::int32_t DATA_BUFFER_SPACE_BASE =
+        EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE + OVERLAY_BLOB_SIZE;
 
-  // Trisc Mailboxes
-  static constexpr std::int32_t TRISC_L1_MAILBOX_OFFSET = 4;
-  static constexpr std::int32_t BRISC_L1_MAILBOX_OFFSET = 4;
-  static constexpr std::int32_t NRISC_L1_MAILBOX_OFFSET = 4;
+    // Trisc Mailboxes
+    static constexpr std::int32_t TRISC_L1_MAILBOX_OFFSET = 4;
+    static constexpr std::int32_t BRISC_L1_MAILBOX_OFFSET = 4;
+    static constexpr std::int32_t NRISC_L1_MAILBOX_OFFSET = 4;
 
-  static constexpr std::int32_t TRISC0_MAILBOX_BASE = TRISC0_BASE + TRISC_L1_MAILBOX_OFFSET;
-  static constexpr std::int32_t TRISC1_MAILBOX_BASE = TRISC1_BASE + TRISC_L1_MAILBOX_OFFSET;
-  static constexpr std::int32_t TRISC2_MAILBOX_BASE = TRISC2_BASE + TRISC_L1_MAILBOX_OFFSET;
+    static constexpr std::int32_t TRISC0_MAILBOX_BASE = TRISC0_BASE + TRISC_L1_MAILBOX_OFFSET;
+    static constexpr std::int32_t TRISC1_MAILBOX_BASE = TRISC1_BASE + TRISC_L1_MAILBOX_OFFSET;
+    static constexpr std::int32_t TRISC2_MAILBOX_BASE = TRISC2_BASE + TRISC_L1_MAILBOX_OFFSET;
 
-  static constexpr std::int32_t FW_MAILBOX_BASE         = 32;
-  static constexpr std::int32_t DEBUG_MAILBOX_BUF_BASE  = 112;
+    static constexpr std::int32_t FW_MAILBOX_BASE = 32;
+    static constexpr std::int32_t DEBUG_MAILBOX_BUF_BASE = 112;
 
-  static constexpr std::int32_t FW_MAILBOX_BUF_SIZE     = 64;
-  static constexpr std::int32_t DEBUG_MAILBOX_BUF_SIZE  = 64; // For each T0/T1/T2/FW
+    static constexpr std::int32_t FW_MAILBOX_BUF_SIZE = 64;
+    static constexpr std::int32_t DEBUG_MAILBOX_BUF_SIZE = 64;  // For each T0/T1/T2/FW
 
-  // Used for TT_LOG
-  static constexpr std::int32_t TRISC_TT_LOG_MAILBOX_OFFSET = 28;
-  static constexpr std::int32_t TRISC_TT_LOG_MAILBOX_SIZE = 64;
-  static constexpr std::int32_t TRISC0_TT_LOG_MAILBOX_BASE = TRISC0_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
-  static constexpr std::int32_t TRISC1_TT_LOG_MAILBOX_BASE = TRISC1_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
-  static constexpr std::int32_t TRISC2_TT_LOG_MAILBOX_BASE = TRISC2_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
- 
-  // Upper 2KB of local space is used as debug buffer
-  static constexpr std::int32_t DEBUG_BUFFER_SIZE  = 2 * 1024;
-  static constexpr std::int32_t TRISC0_DEBUG_BUFFER_BASE  = TRISC0_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
-  static constexpr std::int32_t TRISC1_DEBUG_BUFFER_BASE  = TRISC1_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
-  static constexpr std::int32_t TRISC2_DEBUG_BUFFER_BASE  = TRISC2_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
+    // Used for TT_LOG
+    static constexpr std::int32_t TRISC_TT_LOG_MAILBOX_OFFSET = 28;
+    static constexpr std::int32_t TRISC_TT_LOG_MAILBOX_SIZE = 64;
+    static constexpr std::int32_t TRISC0_TT_LOG_MAILBOX_BASE = TRISC0_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
+    static constexpr std::int32_t TRISC1_TT_LOG_MAILBOX_BASE = TRISC1_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
+    static constexpr std::int32_t TRISC2_TT_LOG_MAILBOX_BASE = TRISC2_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
 
-  static constexpr std::int32_t MAX_SIZE = 1 * 1024 * 1024;  // 1MB
-  static constexpr std::int32_t MAX_L1_LOADING_SIZE = MAX_SIZE;
+    // Upper 2KB of local space is used as debug buffer
+    static constexpr std::int32_t DEBUG_BUFFER_SIZE = 2 * 1024;
+    static constexpr std::int32_t TRISC0_DEBUG_BUFFER_BASE = TRISC0_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
+    static constexpr std::int32_t TRISC1_DEBUG_BUFFER_BASE = TRISC1_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
+    static constexpr std::int32_t TRISC2_DEBUG_BUFFER_BASE = TRISC2_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
 
-  static constexpr std::int32_t RISC_LOCAL_MEM_BASE = 0xffb00000; // Actaul local memory address as seen from risc firmware
-                                                                   // As part of the init risc firmware will copy local memory data from
-                                                                   // l1 locations listed above into internal local memory that starts 
-                                                                   // at RISC_LOCAL_MEM_BASE address
+    static constexpr std::int32_t MAX_SIZE = 1 * 1024 * 1024;  // 1MB
+    static constexpr std::int32_t MAX_L1_LOADING_SIZE = MAX_SIZE;
 
-  static constexpr std::int32_t NCRISC_IRAM_MEM_BASE = 0xffc00000; // NCRISC instruction RAM base address
+    static constexpr std::int32_t RISC_LOCAL_MEM_BASE =
+        0xffb00000;  // Actaul local memory address as seen from risc firmware
+                     // As part of the init risc firmware will copy local memory data from
+                     // l1 locations listed above into internal local memory that starts
+                     // at RISC_LOCAL_MEM_BASE address
 
-  // Perf buffer (FIXME - update once location of the perf data buffer is finalized)
-  // Parameter UNPACK_PACK_PERF_BUF_SIZE_LEVEL_1 assumes the following PERF_BUF_SIZE = 12KB - 768
-  static constexpr std::int32_t PERF_BUF_SIZE = FIRMWARE_SIZE - BRISC_FIRMWARE_SIZE - ZEROS_SIZE;
-  
-  static constexpr std::int32_t PERF_QUEUE_HEADER_SIZE = 16;
-  static constexpr std::int32_t PERF_RISC_MAILBOX_SIZE = 16;
-  static constexpr std::int32_t PERF_UNUSED_SIZE = 32;
-  
-  static constexpr std::int32_t MATH_PERF_BUF_SIZE = 64;
-  static constexpr std::int32_t BRISC_PERF_BUF_SIZE = 640; // Half of this value must be 32B aligned
-  static constexpr std::int32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_0 = 640; // smaller buffer size for limited logging
-  static constexpr std::int32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_1 = (12 * 1024 - 768)/2 - MATH_PERF_BUF_SIZE/2 - (PERF_QUEUE_HEADER_SIZE + PERF_RISC_MAILBOX_SIZE + PERF_UNUSED_SIZE)/2 - BRISC_PERF_BUF_SIZE/2;
-  
-  static constexpr std::int32_t PERF_QUEUE_HEADER_ADDR = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE + ZEROS_SIZE;
-  static constexpr std::int32_t PERF_RISC_MAILBOX_ADDR = PERF_QUEUE_HEADER_ADDR + PERF_QUEUE_HEADER_SIZE;
-  static constexpr std::int32_t BRISC_PERF_BUF_BASE_ADDR = PERF_RISC_MAILBOX_SIZE + PERF_UNUSED_SIZE + PERF_RISC_MAILBOX_ADDR;
-  static constexpr std::int32_t MATH_PERF_BUF_BASE_ADDR = BRISC_PERF_BUF_BASE_ADDR + BRISC_PERF_BUF_SIZE;
-  static constexpr std::int32_t UNPACK_PACK_PERF_BUF_BASE_ADDR = MATH_PERF_BUF_BASE_ADDR + MATH_PERF_BUF_SIZE;
-  static constexpr std::int32_t PERF_NUM_THREADS = 5;
+    static constexpr std::int32_t NCRISC_IRAM_MEM_BASE = 0xffc00000;  // NCRISC instruction RAM base address
 
-  static constexpr std::int32_t PERF_QUEUE_PTRS = PERF_QUEUE_HEADER_ADDR;
-  static constexpr std::int32_t PERF_THREAD_HEADER = PERF_QUEUE_PTRS + 8;
-  static constexpr std::int32_t PERF_WR_PTR_COPY = PERF_QUEUE_PTRS + 12;
+    // Perf buffer (FIXME - update once location of the perf data buffer is finalized)
+    // Parameter UNPACK_PACK_PERF_BUF_SIZE_LEVEL_1 assumes the following PERF_BUF_SIZE = 12KB - 768
+    static constexpr std::int32_t PERF_BUF_SIZE = FIRMWARE_SIZE - BRISC_FIRMWARE_SIZE - ZEROS_SIZE;
 
-  static constexpr std::int32_t WALL_CLOCK_L = 0xFFB121F0;
-  static constexpr std::int32_t WALL_CLOCK_H = 0xFFB121F8;
+    static constexpr std::int32_t PERF_QUEUE_HEADER_SIZE = 16;
+    static constexpr std::int32_t PERF_RISC_MAILBOX_SIZE = 16;
+    static constexpr std::int32_t PERF_UNUSED_SIZE = 32;
 
+    static constexpr std::int32_t MATH_PERF_BUF_SIZE = 64;
+    static constexpr std::int32_t BRISC_PERF_BUF_SIZE = 640;                // Half of this value must be 32B aligned
+    static constexpr std::int32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_0 = 640;  // smaller buffer size for limited logging
+    static constexpr std::int32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_1 =
+        (12 * 1024 - 768) / 2 - MATH_PERF_BUF_SIZE / 2 -
+        (PERF_QUEUE_HEADER_SIZE + PERF_RISC_MAILBOX_SIZE + PERF_UNUSED_SIZE) / 2 - BRISC_PERF_BUF_SIZE / 2;
+
+    static constexpr std::int32_t PERF_QUEUE_HEADER_ADDR = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE + ZEROS_SIZE;
+    static constexpr std::int32_t PERF_RISC_MAILBOX_ADDR = PERF_QUEUE_HEADER_ADDR + PERF_QUEUE_HEADER_SIZE;
+    static constexpr std::int32_t BRISC_PERF_BUF_BASE_ADDR =
+        PERF_RISC_MAILBOX_SIZE + PERF_UNUSED_SIZE + PERF_RISC_MAILBOX_ADDR;
+    static constexpr std::int32_t MATH_PERF_BUF_BASE_ADDR = BRISC_PERF_BUF_BASE_ADDR + BRISC_PERF_BUF_SIZE;
+    static constexpr std::int32_t UNPACK_PACK_PERF_BUF_BASE_ADDR = MATH_PERF_BUF_BASE_ADDR + MATH_PERF_BUF_SIZE;
+    static constexpr std::int32_t PERF_NUM_THREADS = 5;
+
+    static constexpr std::int32_t PERF_QUEUE_PTRS = PERF_QUEUE_HEADER_ADDR;
+    static constexpr std::int32_t PERF_THREAD_HEADER = PERF_QUEUE_PTRS + 8;
+    static constexpr std::int32_t PERF_WR_PTR_COPY = PERF_QUEUE_PTRS + 12;
+
+    static constexpr std::int32_t WALL_CLOCK_L = 0xFFB121F0;
+    static constexpr std::int32_t WALL_CLOCK_H = 0xFFB121F8;
 };
 
 }  // namespace l1_mem


### PR DESCRIPTION
Related to #47 , a follow up from #203

Removed src/.clang-format which disabled formatting in this folder, and ran `pre-commit run --all-files`

If there is something you see that is formatted not in the way you like, please leave a comment, we can add `// clang-format off` to some block to leave custom formatting.