### PR TITLE
Print hugepage 0 size warning only if mapping fails

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,9 @@
 ### List of the changes
 (Itemized list of all the changes.)
 
+### Testing
+(Comment on CI testing or Manual testing touching this change.)
+
 ### API Changes
 (When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
 (Then merge this PR, change the client PRs to point to UMD main, and then merge them.)

--- a/device/hugepage.cpp
+++ b/device/hugepage.cpp
@@ -6,7 +6,7 @@
 
 #include "hugepage.h"
 
-#include <sys/stat.h> // for umask, fstat
+#include <sys/stat.h> // for umask
 #include <fcntl.h> // for O_RDWR and other constants
 
 #include "common/logger.hpp"
@@ -153,16 +153,6 @@ int open_hugepage_file(const std::string &dir, chip_id_t physical_device_id, uin
         log_warning(LogSiliconDriver, "ttSiliconDevice::open_hugepage_file could not open filename: {} on first try, unlinking it and retrying.", filename_str);
         unlink(filename.data());
         fd = open(filename.data(), O_RDWR | O_CREAT | O_CLOEXEC, S_IWUSR | S_IRUSR | S_IWGRP | S_IRGRP | S_IWOTH | S_IROTH );
-    }
-
-    // Verify opened file size.
-    struct stat st;
-    if (fstat(fd, &st) == -1) {
-        log_warning(LogSiliconDriver, "Error reading file size after opening: {}", filename_str);
-    } else {
-        if (st.st_size == 0) {
-            log_warning(LogSiliconDriver, "Opened hugepage file has zero size, mapping it might fail: {}. Verify that enough hugepages are provided.", filename_str);
-        }
     }
 
     // Restore original mask


### PR DESCRIPTION
### Issue
Fixes https://github.com/tenstorrent/tt-umd/issues/275

### Description
Aftermath of #168 . Added a warning by design. This was being printed even if everything worked correctly, but hugepage file was created for the first time.

### List of the changes
- Moved warning not to printed everytime but only in case of mapping failure.
- Minor PR template addition to motivate people to comment on testing

### Testing
Manually tested on t3008 machine that if no hugepages are available this warning is printed. Also tested this warning is not printed if everything works but is first hugepage setup.

### API Changes
There are no API changes in this PR.
