### PR TITLE
Allow optional soft reset option to be passed into deassert_risc_reset_at_core

### DIFF
--- a/device/mockup/tt_mockup_device.hpp
+++ b/device/mockup/tt_mockup_device.hpp
@@ -32,7 +32,7 @@ class tt_MockupDevice : public tt_device {
     void start_device(const tt_device_params& device_params) override {}
     void assert_risc_reset() override {}
     void deassert_risc_reset() override {}
-    void deassert_risc_reset_at_core(tt_cxy_pair core) override {}
+    void deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets = TENSIX_DEASSERT_SOFT_RESET) override {}
     void assert_risc_reset_at_core(tt_cxy_pair core) override {}
     void close_device() override {}
 

--- a/device/simulation/deprecated/tt_emulation_device.cpp
+++ b/device/simulation/deprecated/tt_emulation_device.cpp
@@ -59,7 +59,7 @@ void tt_emulation_device::assert_risc_reset() {
   log_info(tt::LogEmulationDriver, "Asserted all tensix RISC Reset ");
 }
 
-void tt_emulation_device::deassert_risc_reset_at_core(tt_cxy_pair core) {
+void tt_emulation_device::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets) {
   tt_zebu_wrapper_inst->tensix_reset_deassert(core.x, core.y);
 }
 

--- a/device/simulation/deprecated/tt_emulation_device.h
+++ b/device/simulation/deprecated/tt_emulation_device.h
@@ -24,7 +24,7 @@ public:
   virtual void start_device(const tt_device_params& device_params);
   virtual void close_device();
   virtual void deassert_risc_reset();
-  virtual void deassert_risc_reset_at_core(tt_cxy_pair core);
+  virtual void deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets = TENSIX_DEASSERT_SOFT_RESET);
   virtual void assert_risc_reset();
   virtual void assert_risc_reset_at_core(tt_cxy_pair core);
   virtual void write_to_device(std::vector<uint32_t>& vec, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use, bool send_epoch_cmd = false, bool last_send_epoch_cmd = true, bool ordered_with_prev_remote_write = false);

--- a/device/simulation/deprecated/tt_emulation_stub.cpp
+++ b/device/simulation/deprecated/tt_emulation_stub.cpp
@@ -27,7 +27,7 @@ void tt_emulation_device::deassert_risc_reset() {}
 
 void tt_emulation_device::assert_risc_reset() {}
 
-void tt_emulation_device::deassert_risc_reset_at_core(tt_cxy_pair core) {}
+void tt_emulation_device::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets) {}
 
 void tt_emulation_device::assert_risc_reset_at_core(tt_cxy_pair core) {}
 

--- a/device/simulation/deprecated/tt_versim_device.cpp
+++ b/device/simulation/deprecated/tt_versim_device.cpp
@@ -142,7 +142,7 @@ void tt_VersimDevice::deassert_risc_reset() {
   versim::startup_versim_main_loop(*versim);
 }
 
-void tt_VersimDevice::deassert_risc_reset_at_core(tt_cxy_pair core) {
+void tt_VersimDevice::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets) {
   // This function deasserts reset on the full versim device (don't need core level granularity for versim)
  deassert_risc_reset();
 }

--- a/device/simulation/deprecated/tt_versim_device.h
+++ b/device/simulation/deprecated/tt_versim_device.h
@@ -32,7 +32,7 @@ class tt_VersimDevice: public tt_device
     virtual void start_device(const tt_device_params &device_params);
     virtual void close_device();
     virtual void deassert_risc_reset();
-    virtual void deassert_risc_reset_at_core(tt_cxy_pair core);
+    virtual void deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets = TENSIX_DEASSERT_SOFT_RESET);
     virtual void assert_risc_reset();
     virtual void assert_risc_reset_at_core(tt_cxy_pair core);
     virtual void write_to_device(std::vector<uint32_t> &vec, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use, bool send_epoch_cmd = false, bool last_send_epoch_cmd = true, bool ordered_with_prev_remote_write = false);

--- a/device/simulation/deprecated/tt_versim_stub.cpp
+++ b/device/simulation/deprecated/tt_versim_stub.cpp
@@ -49,7 +49,7 @@ void tt_VersimDevice::start(
 ) {}
 
 void tt_VersimDevice::deassert_risc_reset() {}
-void tt_VersimDevice::deassert_risc_reset_at_core(tt_cxy_pair core) {}
+void tt_VersimDevice::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets) {}
 void tt_VersimDevice::assert_risc_reset() {}
 void tt_VersimDevice::assert_risc_reset_at_core(tt_cxy_pair core) {}
 

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -131,7 +131,7 @@ void tt_SimulationDevice::deassert_risc_reset() {
     host.send_to_device(wr_buffer_ptr, wr_buffer_size);
 }
 
-void tt_SimulationDevice::deassert_risc_reset_at_core(tt_cxy_pair core) {
+void tt_SimulationDevice::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets) {
     log_info(tt::LogEmulationDriver, "Sending 'deassert_risc_reset_at_core'.. (Not implemented, defaulting to 'deassert_risc_reset' instead)");
     deassert_risc_reset();
 }

--- a/device/simulation/tt_simulation_device.h
+++ b/device/simulation/tt_simulation_device.h
@@ -29,7 +29,7 @@ class tt_SimulationDevice: public tt_device {
     virtual void start_device(const tt_device_params &device_params);
     virtual void assert_risc_reset();
     virtual void deassert_risc_reset();
-    virtual void deassert_risc_reset_at_core(tt_cxy_pair core);
+    virtual void deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets = TENSIX_DEASSERT_SOFT_RESET);
     virtual void assert_risc_reset_at_core(tt_cxy_pair core);
     virtual void close_device();
 

--- a/device/tt_device.h
+++ b/device/tt_device.h
@@ -321,7 +321,7 @@ class tt_device
      *
      * @param core Chip and core being targeted.
      */  
-    virtual void deassert_risc_reset_at_core(tt_cxy_pair core) {
+    virtual void deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets = TENSIX_DEASSERT_SOFT_RESET) {
         throw std::runtime_error("---- tt_device::deassert_risc_reset_at_core is not implemented\n");
     }
 
@@ -634,7 +634,7 @@ class tt_SiliconDevice: public tt_device
     virtual void start_device(const tt_device_params &device_params);
     virtual void assert_risc_reset();
     virtual void deassert_risc_reset();
-    virtual void deassert_risc_reset_at_core(tt_cxy_pair core);
+    virtual void deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets = TENSIX_DEASSERT_SOFT_RESET);
     virtual void assert_risc_reset_at_core(tt_cxy_pair core);
     virtual void close_device();
 

--- a/device/tt_silicon_driver.cpp
+++ b/device/tt_silicon_driver.cpp
@@ -741,7 +741,7 @@ void tt_SiliconDevice::deassert_risc_reset() {
     broadcast_tensix_risc_reset_to_cluster(TENSIX_DEASSERT_SOFT_RESET);
 }
 
-void tt_SiliconDevice::deassert_risc_reset_at_core(tt_cxy_pair core) {
+void tt_SiliconDevice::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets) {
     std::uint32_t target_device = core.chip; // Get Target Device to query soc descriptor and determine location in cluster
     log_assert(std::find(get_soc_descriptor(target_device).workers.begin(), get_soc_descriptor(target_device).workers.end(), core) != get_soc_descriptor(target_device).workers.end() ||
                std::find(get_soc_descriptor(target_device).ethernet_cores.begin(), get_soc_descriptor(target_device).ethernet_cores.end(), core) != get_soc_descriptor(target_device).ethernet_cores.end(),
@@ -749,11 +749,11 @@ void tt_SiliconDevice::deassert_risc_reset_at_core(tt_cxy_pair core) {
     bool target_is_mmio_capable = ndesc -> is_chip_mmio_capable(target_device);
     if(target_is_mmio_capable) {
         log_assert(m_pci_device_map.find(target_device) != m_pci_device_map.end(), "Could not find MMIO mapped device in devices connected over PCIe");
-        send_tensix_risc_reset_to_core(core, TENSIX_DEASSERT_SOFT_RESET);
+        send_tensix_risc_reset_to_core(core, soft_resets);
     }
     else {
         log_assert(arch_name != tt::ARCH::BLACKHOLE, "Can't issue access to remote core in BH");
-        send_remote_tensix_risc_reset_to_core(core, TENSIX_DEASSERT_SOFT_RESET);
+        send_remote_tensix_risc_reset_to_core(core, soft_resets);
     }
 }
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/287

### Description
Metal needed ability to deassert only the second risc on BH ethernet cores 

### List of the changes
Added an optional parameter to deassert_risc_reset_at_core API

### Testing
Will be opening up a PR in Metal on top of this branch and will run post commit and BH post commit. 
[Metal post commit](https://github.com/tenstorrent/tt-metal/pull/14945)
[Metal Blackhole post commit](https://github.com/tenstorrent/tt-metal/actions/runs/11788328309)

### API Changes
This PR has non-breaking API changes:
- [ ] [tt_metal approved PR pointing to this branch](https://github.com/tenstorrent/tt-metal/pull/14945)
- [ ] tt_debuda approved PR pointing to this branch: link -- is this needed if it is not breaking?
