### PR TITLE
Create cluster descriptor yaml in hidden folder

### DIFF
--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -303,8 +303,10 @@ std::string tt_ClusterDescriptor::get_cluster_descriptor_file_path() {
     static std::string yaml_path;
     static bool is_initialized = false;
     if (!is_initialized){
-        // Cluster descriptor path will be created in the working directory.        
-        std::filesystem::path cluster_path = std::filesystem::path("cluster_descriptor.yaml");
+        // Cluster descriptor path will be created in the working directory.
+        std::filesystem::path cluster_path_dir = std::filesystem::path(".umd");
+        std::filesystem::create_directories( cluster_path_dir );  
+        std::filesystem::path cluster_path = cluster_path_dir / "cluster_descriptor.yaml";
         if (!std::filesystem::exists(cluster_path)){
             auto val = system ( ("touch " + cluster_path.string()).c_str());
             if(val != 0) throw std::runtime_error("Cluster Generation Failed!");

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -303,9 +303,11 @@ std::string tt_ClusterDescriptor::get_cluster_descriptor_file_path() {
     static std::string yaml_path;
     static bool is_initialized = false;
     if (!is_initialized){
-        // Cluster descriptor path will be created in the working directory.
-        std::filesystem::path cluster_path_dir = std::filesystem::path(".umd");
-        std::filesystem::create_directories( cluster_path_dir );  
+
+        // Cluster descriptor yaml will be created in a unique temporary directory.
+        std::filesystem::path temp_path = std::filesystem::temp_directory_path();
+        std::string cluster_path_dir_template = temp_path / "umd_XXXXXX";
+        std::filesystem::path cluster_path_dir = mkdtemp(cluster_path_dir_template.data());
         std::filesystem::path cluster_path = cluster_path_dir / "cluster_descriptor.yaml";
         if (!std::filesystem::exists(cluster_path)){
             auto val = system ( ("touch " + cluster_path.string()).c_str());


### PR DESCRIPTION
### Issue
Fixes #298 

### Description
After #245 the default location of cluster_descriptor.yaml creation has changed. There were some comments from metal and debuda team around this. Mainly, this file is not hidden anymore.
On the suggestion from @tt-vjovanovic , I've changed the code to create this file in OS provided temporary directory.

### List of the changes
- Put newly created cluster_descriptor.yaml in a temp folder. This won't be relative to working dir anymore.

### Testing
CI tests touch this codepath

### API Changes
There are no API changes in this PR.
