### PR TITLE
Support multiple unconnected clusters

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -46,8 +46,8 @@ function(fetch_dependencies)
     # boost::interprocess
     ############################################################################################################################
     include(${PROJECT_SOURCE_DIR}/cmake/fetch_boost.cmake)
+    fetch_boost_library(container_hash)
     fetch_boost_library(interprocess)
-    fetch_boost_library(functional)
 
     ############################################################################################################################
     # Nanomsg

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -47,6 +47,7 @@ function(fetch_dependencies)
     ############################################################################################################################
     include(${PROJECT_SOURCE_DIR}/cmake/fetch_boost.cmake)
     fetch_boost_library(interprocess)
+    fetch_boost_library(functional)
 
     ############################################################################################################################
     # Nanomsg

--- a/common/disjoint_set.hpp
+++ b/common/disjoint_set.hpp
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <unordered_map>
+#include <unordered_set>
+
+// A standard disjoint set data structure to track connected components.
+template <typename T>
+class DisjointSet {
+public:
+    void add_item(T item) { parent[item] = item; }
+
+    int get_set(T item) {
+        while (parent[item] != item) {
+            item = parent[item];
+        }
+        return item;
+    }
+
+    void merge(T item1, T item2) {
+        T set1 = get_set(item1);
+        T set2 = get_set(item2);
+        parent[set1] = set2;
+    }
+
+    bool are_same_set(T item1, T item2) { return get_set(item1) == get_set(item2); }
+
+    int get_num_sets() {
+        std::unordered_set<T> sets;
+        for (auto [item, _] : parent) {
+            sets.insert(get_set(item));
+        }
+        return sets.size();
+    }
+
+private:
+    std::unordered_map<T, T> parent;
+};

--- a/device/tt_cluster_descriptor.h
+++ b/device/tt_cluster_descriptor.h
@@ -66,7 +66,9 @@ class tt_ClusterDescriptor {
   std::unordered_map<int, std::unordered_map<int, Chip2ChipConnection > > galaxy_racks_exit_chip_coords_per_x_dim = {};
 
   static void load_ethernet_connections_from_connectivity_descriptor(YAML::Node &yaml, tt_ClusterDescriptor &desc);
+  static void fill_galaxy_connections(tt_ClusterDescriptor &desc);
   static void load_chips_from_connectivity_descriptor(YAML::Node &yaml, tt_ClusterDescriptor &desc);
+  static void merge_cluster_ids(tt_ClusterDescriptor &desc);
   static void load_harvesting_information(YAML::Node &yaml, tt_ClusterDescriptor &desc);
 
   void fill_chips_grouped_by_closest_mmio();

--- a/device/tt_cluster_descriptor_types.h
+++ b/device/tt_cluster_descriptor_types.h
@@ -6,22 +6,37 @@
 
 #pragma once 
 
+#include <boost/container_hash/hash.hpp>
+
 #include <functional>
 #include <tuple>
 
 using chip_id_t = int;
 using ethernet_channel_t = int;
-using eth_coord_t = std::tuple<int, int, int, int>;  // x, y, rack, shelf
+struct eth_coord_t {
+    int cluster_id; // This is the same for connected chips.
+    int x;
+    int y;
+    int rack;
+    int shelf;
+
+    // in C++20 this should be defined as:
+    // constexpr bool operator==(const eth_coord_t &other) const noexcept = default;
+    constexpr bool operator==(const eth_coord_t &other) const noexcept {
+        return (x == other.x and y == other.y and rack == other.rack and shelf == other.shelf);
+    }
+};
 
 namespace std {
 template <>
 struct hash<eth_coord_t> {
   std::size_t operator()(eth_coord_t const &c) const {
     std::size_t seed = 0;
-    seed = std::hash<std::size_t>()(std::get<0>(c)) << 48 | 
-          std::hash<std::size_t>()(std::get<1>(c)) << 32 |
-          std::hash<std::size_t>()(std::get<2>(c)) << 16 |
-          std::hash<std::size_t>()(std::get<3>(c));
+    boost::hash_combine(seed, c.cluster_id);
+    boost::hash_combine(seed, c.x);
+    boost::hash_combine(seed, c.y);
+    boost::hash_combine(seed, c.rack);
+    boost::hash_combine(seed, c.shelf);
     return seed;
   }
 };

--- a/device/tt_cluster_descriptor_types.h
+++ b/device/tt_cluster_descriptor_types.h
@@ -23,7 +23,7 @@ struct eth_coord_t {
     // in C++20 this should be defined as:
     // constexpr bool operator==(const eth_coord_t &other) const noexcept = default;
     constexpr bool operator==(const eth_coord_t &other) const noexcept {
-        return (x == other.x and y == other.y and rack == other.rack and shelf == other.shelf);
+        return (cluster_id == other.cluster_id and x == other.x and y == other.y and rack == other.rack and shelf == other.shelf);
     }
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(
         gtest
         pthread
         fmt::fmt-header-only
+        Boost::container_hash
 )
 target_include_directories(
     test_common

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -102,13 +102,7 @@ TEST(ApiClusterDescriptorTest, TestAllOfflineClusterDescriptors) {
     }
 }
 
-
-// This tests fails on a machine with multiple cards.
-// It works as long as all the devices that are discoverable are connected through ethernet.
-// Our ClusterDescriptor doesn't have a notion of multiple unconnected clusters of cards.
 TEST(ApiClusterDescriptorTest, SeparateClusters) {
-    // GTEST_SKIP() << "Skipping test which documents non functional feature.";
-
     std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(test_utils::GetAbsPath("tests/api/cluster_descriptor_examples/wormhole_2xN300_unconnected.yaml"));
 
     auto all_chips = cluster_desc->get_all_chips();

--- a/tests/galaxy/test_galaxy_common.h
+++ b/tests/galaxy/test_galaxy_common.h
@@ -22,9 +22,6 @@
 
 using namespace tt::umd;
 
-using chip_id_t = int;
-using ethernet_channel_t = int;
-using eth_coord_t = std::tuple<int, int, int, int>;  // x, y, rack, shelf
 struct tt_multichip_core_addr {
     tt_multichip_core_addr() : core{}, chip{}, addr{} {}
     tt_multichip_core_addr(chip_id_t chip, tt_xy_pair core, std::uint64_t addr) : core(core), chip(chip), addr(addr) {}


### PR DESCRIPTION
### Issue
Fixes tenstorrent/tt-umd#226 
Unblocks systems with multiple blackhole cards requested by @abhullar-tt 
Makes situation in https://github.com/tenstorrent/tt-metal/issues/15101 better.

### Description
I'm not fully certain if this was the only required change needed to support multiple unconnected clusters. There was a clear issue due to way eth coords were handled, which is fixed. Not sure if there is some other assumption somewhere else in the driver.

### List of the changes
- Changed eth_coord_t to a struct. Made changes throughout the code accordingly. This somewhat deprecates tenstorrent/tt-umd#46 
- Added cluster_id to eth_coord struct, which designates which connected graph component a chip belongs to.
- Filling up cluster_id as part of construction.
- Split filling ethernet coordinates and galaxy shelf related structures.
- If cluster_id doesn't match, the get_eth_distance function will return limits::max().

### Testing
Uncommented previously skipped test, which was failing for one of the example cluster descriptors.

### API Changes
There are no API changes in this PR.
