### PR TITLE
Allow passing optional TensixSoftResetOptions to assert risc reset at core API

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -160,11 +160,15 @@ public:
      *
      * @param core Chip and core being targeted.
      */
-    virtual void assert_risc_reset_at_core(tt_cxy_pair core) {
+    virtual void assert_risc_reset_at_core(
+        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET) {
         throw std::runtime_error("---- tt_device::assert_risc_reset_at_core is not implemented\n");
     }
 
-    virtual void assert_risc_reset_at_core(const chip_id_t chip, const tt::umd::CoreCoord core) {
+    virtual void assert_risc_reset_at_core(
+        const chip_id_t chip,
+        const tt::umd::CoreCoord core,
+        const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET) {
         throw std::runtime_error("---- tt_device::assert_risc_reset_at_core is not implemented\n");
     }
 
@@ -636,7 +640,8 @@ public:
         chip_id_t mmio_chip, const std::unordered_set<tt_xy_pair>& active_eth_cores_per_chip);
     virtual void deassert_risc_reset_at_core(
         tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET);
-    virtual void assert_risc_reset_at_core(tt_cxy_pair core);
+    virtual void assert_risc_reset_at_core(
+        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET);
     virtual void write_to_device(
         const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use);
     // TODO: Add CoreCoord API for this function.
@@ -695,7 +700,10 @@ public:
         const chip_id_t chip,
         const tt::umd::CoreCoord core,
         const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET);
-    virtual void assert_risc_reset_at_core(const chip_id_t chip, const tt::umd::CoreCoord core);
+    virtual void assert_risc_reset_at_core(
+        const chip_id_t chip,
+        const tt::umd::CoreCoord core,
+        const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET);
     virtual void write_to_device(
         const void* mem_ptr,
         uint32_t size_in_bytes,

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -26,7 +26,8 @@ public:
     virtual void deassert_risc_reset();
     virtual void deassert_risc_reset_at_core(
         tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET);
-    virtual void assert_risc_reset_at_core(tt_cxy_pair core);
+    virtual void assert_risc_reset_at_core(
+        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET);
     virtual void close_device();
 
     // Runtime Functions

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -966,7 +966,7 @@ void Cluster::deassert_risc_reset_at_core(
     deassert_risc_reset_at_core({(size_t)chip, virtual_coord}, soft_resets);
 }
 
-void Cluster::assert_risc_reset_at_core(tt_cxy_pair core) {
+void Cluster::assert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions& soft_resets) {
     // Get Target Device to query soc descriptor and determine location in cluster
     std::uint32_t target_device = core.chip;
     log_assert(
@@ -980,15 +980,16 @@ void Cluster::assert_risc_reset_at_core(tt_cxy_pair core) {
         "Cannot assert reset on a non-tensix or harvested core");
     bool target_is_mmio_capable = cluster_desc->is_chip_mmio_capable(target_device);
     if (target_is_mmio_capable) {
-        send_tensix_risc_reset_to_core(core, TENSIX_ASSERT_SOFT_RESET);
+        send_tensix_risc_reset_to_core(core, soft_resets);
     } else {
-        send_remote_tensix_risc_reset_to_core(core, TENSIX_ASSERT_SOFT_RESET);
+        send_remote_tensix_risc_reset_to_core(core, soft_resets);
     }
 }
 
-void Cluster::assert_risc_reset_at_core(const chip_id_t chip, const CoreCoord core) {
+void Cluster::assert_risc_reset_at_core(
+    const chip_id_t chip, const CoreCoord core, const TensixSoftResetOptions& soft_resets) {
     const CoreCoord virtual_coord = translate_chip_coord(chip, core, CoordSystem::VIRTUAL);
-    assert_risc_reset_at_core({(size_t)chip, virtual_coord});
+    assert_risc_reset_at_core({(size_t)chip, virtual_coord}, soft_resets);
 }
 
 // Free memory during teardown, and remove (clean/unlock) from any leftover mutexes.

--- a/device/mockup/tt_mockup_device.hpp
+++ b/device/mockup/tt_mockup_device.hpp
@@ -32,7 +32,8 @@ public:
     void deassert_risc_reset_at_core(
         tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET) override {}
 
-    void assert_risc_reset_at_core(tt_cxy_pair core) override {}
+    void assert_risc_reset_at_core(
+        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET) override {}
 
     void close_device() override {}
 

--- a/device/simulation/deprecated/tt_emulation_device.cpp
+++ b/device/simulation/deprecated/tt_emulation_device.cpp
@@ -60,7 +60,7 @@ void tt_emulation_device::deassert_risc_reset_at_core(tt_cxy_pair core, const Te
     tt_zebu_wrapper_inst->tensix_reset_deassert(core.x, core.y);
 }
 
-void tt_emulation_device::assert_risc_reset_at_core(tt_cxy_pair core) {
+void tt_emulation_device::assert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions& soft_resets) {
     tt_zebu_wrapper_inst->tensix_reset_assert(core.x, core.y);
 }
 

--- a/device/simulation/deprecated/tt_emulation_device.h
+++ b/device/simulation/deprecated/tt_emulation_device.h
@@ -33,7 +33,8 @@ public:
     virtual void deassert_risc_reset_at_core(
         tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET);
     virtual void assert_risc_reset();
-    virtual void assert_risc_reset_at_core(tt_cxy_pair core);
+    virtual void assert_risc_reset_at_core(
+        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET);
     virtual void write_to_device(
         std::vector<uint32_t>& vec,
         tt_cxy_pair core,

--- a/device/simulation/deprecated/tt_emulation_stub.cpp
+++ b/device/simulation/deprecated/tt_emulation_stub.cpp
@@ -27,7 +27,7 @@ void tt_emulation_device::assert_risc_reset() {}
 
 void tt_emulation_device::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions& soft_resets) {}
 
-void tt_emulation_device::assert_risc_reset_at_core(tt_cxy_pair core) {}
+void tt_emulation_device::assert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions& soft_resets) {}
 
 void tt_emulation_device::close_device() {}
 

--- a/device/simulation/deprecated/tt_versim_device.cpp
+++ b/device/simulation/deprecated/tt_versim_device.cpp
@@ -173,7 +173,7 @@ void tt_VersimDevice::assert_risc_reset() {
     versim::assert_riscv_reset(*versim);
 }
 
-void tt_VersimDevice::assert_risc_reset_at_core(tt_cxy_pair core) {
+void tt_VersimDevice::assert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions& soft_resets) {
     // This function asserts reset on the full versim device (don't need core level granularity for versim)
     assert_risc_reset();
 }

--- a/device/simulation/deprecated/tt_versim_device.h
+++ b/device/simulation/deprecated/tt_versim_device.h
@@ -45,7 +45,8 @@ public:
     virtual void deassert_risc_reset_at_core(
         tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET);
     virtual void assert_risc_reset();
-    virtual void assert_risc_reset_at_core(tt_cxy_pair core);
+    virtual void assert_risc_reset_at_core(
+        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET);
     virtual void write_to_device(
         std::vector<uint32_t>& vec,
         tt_cxy_pair core,

--- a/device/simulation/deprecated/tt_versim_stub.cpp
+++ b/device/simulation/deprecated/tt_versim_stub.cpp
@@ -96,7 +96,7 @@ void tt_VersimDevice::deassert_risc_reset_at_core(tt_cxy_pair core, const Tensix
 
 void tt_VersimDevice::assert_risc_reset() {}
 
-void tt_VersimDevice::assert_risc_reset_at_core(tt_cxy_pair core) {}
+void tt_VersimDevice::assert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions& soft_resets) {}
 
 void tt_VersimDevice::translate_to_noc_table_coords(chip_id_t device_id, std::size_t& r, std::size_t& c){};
 

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -122,7 +122,7 @@ void tt_SimulationDevice::deassert_risc_reset_at_core(tt_cxy_pair core, const Te
     deassert_risc_reset();
 }
 
-void tt_SimulationDevice::assert_risc_reset_at_core(tt_cxy_pair core) {
+void tt_SimulationDevice::assert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions& soft_resets) {
     log_info(
         tt::LogEmulationDriver,
         "Sending 'assert_risc_reset_at_core'.. (Not implemented, defaulting to 'assert_risc_reset' instead)");


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/307

### Description
Mirror of https://github.com/tenstorrent/tt-umd/pull/292 so we can assert risc reset back to initial state. 

### List of the changes
Added an optional parameter to assert_risc_reset_at_core API

### Testing
Expanded deassert risc reset at core to go through assert sequences as well

### API Changes
This PR has non-breaking API changes
