### PR TITLE
Enable clang tests/ device/

### DIFF
--- a/device/.clang-format
+++ b/device/.clang-format
@@ -1,2 +1,0 @@
-DisableFormat: true
-SortIncludes: false

--- a/device/architecture_implementation.cpp
+++ b/device/architecture_implementation.cpp
@@ -12,10 +12,14 @@ namespace tt::umd {
 
 std::unique_ptr<architecture_implementation> architecture_implementation::create(tt::ARCH architecture) {
     switch (architecture) {
-        case tt::ARCH::BLACKHOLE: return std::make_unique<blackhole_implementation>();
-        case tt::ARCH::GRAYSKULL: return std::make_unique<grayskull_implementation>();
-        case tt::ARCH::WORMHOLE_B0: return std::make_unique<wormhole_implementation>();
-        default: return nullptr;
+        case tt::ARCH::BLACKHOLE:
+            return std::make_unique<blackhole_implementation>();
+        case tt::ARCH::GRAYSKULL:
+            return std::make_unique<grayskull_implementation>();
+        case tt::ARCH::WORMHOLE_B0:
+            return std::make_unique<wormhole_implementation>();
+        default:
+            return nullptr;
     }
 }
 

--- a/device/architecture_implementation.h
+++ b/device/architecture_implementation.h
@@ -12,8 +12,8 @@
 #include <vector>
 
 #include "device/tlb.h"
-#include "device/xy_pair.h"
 #include "device/tt_arch_types.h"
+#include "device/xy_pair.h"
 
 struct tt_driver_host_address_params;
 struct tt_driver_eth_interface_params;
@@ -22,7 +22,7 @@ struct tt_driver_noc_params;
 namespace tt::umd {
 
 class architecture_implementation {
-   public:
+public:
     virtual ~architecture_implementation() = default;
 
     virtual tt::ARCH get_architecture() const = 0;
@@ -65,7 +65,8 @@ class architecture_implementation {
     virtual std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const = 0;
     virtual tlb_configuration get_tlb_configuration(uint32_t tlb_index) const = 0;
     virtual std::optional<std::tuple<std::uint64_t, std::uint64_t>> describe_tlb(std::int32_t tlb_index) const = 0;
-    virtual std::pair<std::uint64_t, std::uint64_t> get_tlb_data(std::uint32_t tlb_index, const tlb_data& data) const = 0;
+    virtual std::pair<std::uint64_t, std::uint64_t> get_tlb_data(
+        std::uint32_t tlb_index, const tlb_data& data) const = 0;
 
     virtual tt_driver_host_address_params get_host_address_params() const = 0;
     virtual tt_driver_eth_interface_params get_eth_interface_params() const = 0;

--- a/device/blackhole/blackhole_coordinate_manager.h
+++ b/device/blackhole/blackhole_coordinate_manager.h
@@ -9,15 +9,15 @@
 #include "device/coordinate_manager.h"
 
 class BlackholeCoordinateManager : public CoordinateManager {
-
 public:
-    BlackholeCoordinateManager(const tt_xy_pair& worker_grid_size, const std::vector<tt_xy_pair>& workers, std::size_t harvesting_mask)
-        : CoordinateManager(worker_grid_size, workers, harvesting_mask) {}
+    BlackholeCoordinateManager(
+        const tt_xy_pair& worker_grid_size, const std::vector<tt_xy_pair>& workers, std::size_t harvesting_mask) :
+        CoordinateManager(worker_grid_size, workers, harvesting_mask) {}
 
     tt_translated_coords to_translated_coords(tt_logical_coords logical_coords) override;
 
     tt_logical_coords to_logical_coords(tt_translated_coords translated_coords) override;
 
-protected: 
+protected:
     std::set<std::size_t> get_x_coordinates_to_harvest(std::size_t harvesting_mask) override;
 };

--- a/device/blackhole/blackhole_implementation.cpp
+++ b/device/blackhole/blackhole_implementation.cpp
@@ -4,13 +4,12 @@
 
 #include "blackhole_implementation.h"
 
-#include "src/firmware/riscv/blackhole/host_mem_address_map.h"
-#include "src/firmware/riscv/blackhole/eth_interface.h"
-
 #include "device/cluster.h"
+#include "src/firmware/riscv/blackhole/eth_interface.h"
+#include "src/firmware/riscv/blackhole/host_mem_address_map.h"
 
-constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36; // source: noc_parameters.h, common for WH && BH
-constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6; // source: noc_parameters.h, common for WH && BH
+constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h, common for WH && BH
+constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6;  // source: noc_parameters.h, common for WH && BH
 
 namespace tt::umd {
 
@@ -26,10 +25,9 @@ std::tuple<xy_pair, xy_pair> blackhole_implementation::multicast_workaround(xy_p
 }
 
 tlb_configuration blackhole_implementation::get_tlb_configuration(uint32_t tlb_index) const {
-
     // If TLB index is in range for 4GB tlbs (8 TLBs after 202 TLBs for 2MB)
     if (tlb_index >= blackhole::TLB_COUNT_2M && tlb_index < blackhole::TLB_COUNT_2M + blackhole::TLB_COUNT_4G) {
-        return tlb_configuration {
+        return tlb_configuration{
             .size = blackhole::DYNAMIC_TLB_4G_SIZE,
             .base = blackhole::DYNAMIC_TLB_4G_BASE,
             .cfg_addr = blackhole::DYNAMIC_TLB_4G_CFG_ADDR,
@@ -37,7 +35,7 @@ tlb_configuration blackhole_implementation::get_tlb_configuration(uint32_t tlb_i
             .offset = blackhole::TLB_4G_OFFSET,
         };
     }
-    
+
     return tlb_configuration{
         .size = blackhole::DYNAMIC_TLB_2M_SIZE,
         .base = blackhole::DYNAMIC_TLB_2M_BASE,
@@ -73,17 +71,17 @@ std::optional<std::tuple<std::uint64_t, std::uint64_t>> blackhole_implementation
 
 std::pair<std::uint64_t, std::uint64_t> blackhole_implementation::get_tlb_data(
     std::uint32_t tlb_index, const tlb_data& data) const {
-
     if (tlb_index < blackhole::TLB_COUNT_2M) {
         return data.apply_offset(blackhole::TLB_2M_OFFSET);
     } else {
         throw std::runtime_error("Invalid TLB index for Blackhole arch");
     }
-
 }
 
 tt_driver_host_address_params blackhole_implementation::get_host_address_params() const {
-    return {::blackhole::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, ::blackhole::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
+    return {
+        ::blackhole::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE,
+        ::blackhole::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
 }
 
 tt_driver_eth_interface_params blackhole_implementation::get_eth_interface_params() const {

--- a/device/blackhole/blackhole_implementation.h
+++ b/device/blackhole/blackhole_implementation.h
@@ -7,10 +7,10 @@
 #pragma once
 
 #include <array>
+#include <stdexcept>
 
 #include "device/architecture_implementation.h"
 #include "device/tlb.h"
-#include <stdexcept>
 
 namespace tt::umd {
 
@@ -59,30 +59,8 @@ enum class arc_message_type {
 
 // DEVICE_DATA
 static constexpr std::array<xy_pair, 24> DRAM_LOCATIONS = {
-    {{0, 0},
-     {0, 1},
-     {0, 11},
-     {0, 2},
-     {0, 10},
-     {0, 3},
-     {0, 9},
-     {0, 4},
-     {0, 8},
-     {0, 5},
-     {0, 7},
-     {0, 6},
-     {9, 0},
-     {9, 1},
-     {9, 11},
-     {9, 2},
-     {9, 10},
-     {9, 3},
-     {9, 9},
-     {9, 4},
-     {9, 8},
-     {9, 5},
-     {9, 7},
-     {9, 6}}};
+    {{0, 0}, {0, 1}, {0, 11}, {0, 2}, {0, 10}, {0, 3}, {0, 9}, {0, 4}, {0, 8}, {0, 5}, {0, 7}, {0, 6},
+     {9, 0}, {9, 1}, {9, 11}, {9, 2}, {9, 10}, {9, 3}, {9, 9}, {9, 4}, {9, 8}, {9, 5}, {9, 7}, {9, 6}}};
 
 static constexpr std::array<xy_pair, 1> ARC_LOCATIONS = {{{8, 0}}};
 static constexpr std::array<xy_pair, 1> PCI_LOCATIONS = {{{11, 0}}};
@@ -113,14 +91,14 @@ static constexpr uint32_t BROADCAST_TLB_INDEX = 0;     // TODO: Copied from worm
 static constexpr uint32_t STATIC_TLB_CFG_ADDR = 0x1fc00000;
 
 static constexpr uint32_t TLB_COUNT_2M = 202;
-static constexpr uint32_t TLB_BASE_2M = 0; // 0 in BAR0
+static constexpr uint32_t TLB_BASE_2M = 0;  // 0 in BAR0
 static constexpr uint32_t TLB_BASE_INDEX_2M = 0;
 static constexpr uint32_t TLB_2M_SIZE = 2 * 1024 * 1024;
 
 static constexpr uint32_t TLB_CFG_REG_SIZE_BYTES = 12;
 
 static constexpr uint32_t TLB_COUNT_4G = 8;
-static constexpr uint32_t TLB_BASE_4G = 0; // 0 in BAR4
+static constexpr uint32_t TLB_BASE_4G = 0;  // 0 in BAR4
 static constexpr uint32_t TLB_BASE_INDEX_4G = TLB_COUNT_2M;
 static constexpr uint64_t TLB_4G_SIZE = 4ULL * 1024ULL * 1024ULL * 1024ULL;
 static constexpr uint64_t DYNAMIC_TLB_4G_SIZE = TLB_4G_SIZE;
@@ -168,59 +146,108 @@ static constexpr uint32_t MSG_TYPE_SETUP_IATU_FOR_PEER_TO_PEER = 0x97;
 }  // namespace blackhole
 
 class blackhole_implementation : public architecture_implementation {
-   public:
+public:
     tt::ARCH get_architecture() const override { return tt::ARCH::BLACKHOLE; }
+
     uint32_t get_arc_message_arc_get_harvesting() const override {
         return static_cast<uint32_t>(blackhole::arc_message_type::ARC_GET_HARVESTING);
     }
+
     uint32_t get_arc_message_arc_go_busy() const override {
         return static_cast<uint32_t>(blackhole::arc_message_type::ARC_GO_BUSY);
     }
+
     uint32_t get_arc_message_arc_go_long_idle() const override {
         return static_cast<uint32_t>(blackhole::arc_message_type::ARC_GO_LONG_IDLE);
     }
+
     uint32_t get_arc_message_arc_go_short_idle() const override {
         return static_cast<uint32_t>(blackhole::arc_message_type::ARC_GO_SHORT_IDLE);
     }
+
     uint32_t get_arc_message_deassert_riscv_reset() const override {
         return static_cast<uint32_t>(blackhole::arc_message_type::DEASSERT_RISCV_RESET);
     }
+
     uint32_t get_arc_message_get_aiclk() const override {
         return static_cast<uint32_t>(blackhole::arc_message_type::GET_AICLK);
     }
+
     uint32_t get_arc_message_setup_iatu_for_peer_to_peer() const override {
         return static_cast<uint32_t>(blackhole::arc_message_type::SETUP_IATU_FOR_PEER_TO_PEER);
     }
+
     uint32_t get_arc_message_test() const override { return static_cast<uint32_t>(blackhole::arc_message_type::TEST); }
-    uint32_t get_arc_csm_mailbox_offset() const override { throw std::runtime_error("Not supported for Blackhole arch"); return 0; }
+
+    uint32_t get_arc_csm_mailbox_offset() const override {
+        throw std::runtime_error("Not supported for Blackhole arch");
+        return 0;
+    }
+
     uint32_t get_arc_reset_arc_misc_cntl_offset() const override { return blackhole::ARC_RESET_ARC_MISC_CNTL_OFFSET; }
+
     uint32_t get_arc_reset_scratch_offset() const override { return blackhole::ARC_RESET_SCRATCH_OFFSET; }
+
     uint32_t get_dram_channel_0_peer2peer_region_start() const override {
         return blackhole::DRAM_CHANNEL_0_PEER2PEER_REGION_START;
     }
+
     uint32_t get_dram_channel_0_x() const override { return blackhole::DRAM_CHANNEL_0_X; }
+
     uint32_t get_dram_channel_0_y() const override { return blackhole::DRAM_CHANNEL_0_Y; }
+
     uint32_t get_broadcast_tlb_index() const override { return blackhole::BROADCAST_TLB_INDEX; }
+
     uint32_t get_dynamic_tlb_2m_base() const override { return blackhole::DYNAMIC_TLB_2M_BASE; }
+
     uint32_t get_dynamic_tlb_2m_size() const override { return blackhole::DYNAMIC_TLB_2M_SIZE; }
-    uint32_t get_dynamic_tlb_16m_base() const override { throw std::runtime_error("No 16MB TLBs for Blackhole arch"); return 0; }
-    uint32_t get_dynamic_tlb_16m_size() const override { throw std::runtime_error("No 16MB TLBs for Blackhole arch"); return 0; }
-    uint32_t get_dynamic_tlb_16m_cfg_addr() const override { throw std::runtime_error("No 16MB TLBs for Blackhole arch"); return 0; }
+
+    uint32_t get_dynamic_tlb_16m_base() const override {
+        throw std::runtime_error("No 16MB TLBs for Blackhole arch");
+        return 0;
+    }
+
+    uint32_t get_dynamic_tlb_16m_size() const override {
+        throw std::runtime_error("No 16MB TLBs for Blackhole arch");
+        return 0;
+    }
+
+    uint32_t get_dynamic_tlb_16m_cfg_addr() const override {
+        throw std::runtime_error("No 16MB TLBs for Blackhole arch");
+        return 0;
+    }
+
     uint32_t get_mem_large_read_tlb() const override { return blackhole::MEM_LARGE_READ_TLB; }
+
     uint32_t get_mem_large_write_tlb() const override { return blackhole::MEM_LARGE_WRITE_TLB; }
+
     uint32_t get_static_tlb_cfg_addr() const override { return blackhole::STATIC_TLB_CFG_ADDR; }
-    uint32_t get_static_tlb_size() const override { return blackhole::STATIC_TLB_SIZE;  }
+
+    uint32_t get_static_tlb_size() const override { return blackhole::STATIC_TLB_SIZE; }
+
     uint32_t get_reg_tlb() const override { return blackhole::REG_TLB; }
-    uint32_t get_tlb_base_index_16m() const override { throw std::runtime_error("No 16MB TLBs for Blackhole arch"); return 0;  }
+
+    uint32_t get_tlb_base_index_16m() const override {
+        throw std::runtime_error("No 16MB TLBs for Blackhole arch");
+        return 0;
+    }
+
     uint32_t get_tensix_soft_reset_addr() const override { return blackhole::TENSIX_SOFT_RESET_ADDR; }
+
     uint32_t get_grid_size_x() const override { return blackhole::GRID_SIZE_X; }
+
     uint32_t get_grid_size_y() const override { return blackhole::GRID_SIZE_Y; }
+
     uint32_t get_tlb_cfg_reg_size_bytes() const override { return blackhole::TLB_CFG_REG_SIZE_BYTES; }
+
     uint32_t get_small_read_write_tlb() const override { return blackhole::MEM_SMALL_READ_WRITE_TLB; }
+
     const std::vector<uint32_t>& get_harvesting_noc_locations() const override {
         return blackhole::HARVESTING_NOC_LOCATIONS;
     }
+
     const std::vector<uint32_t>& get_t6_x_locations() const override { return blackhole::T6_X_LOCATIONS; }
+
     const std::vector<uint32_t>& get_t6_y_locations() const override { return blackhole::T6_Y_LOCATIONS; }
 
     std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const override;
@@ -231,7 +258,6 @@ class blackhole_implementation : public architecture_implementation {
     tt_driver_host_address_params get_host_address_params() const override;
     tt_driver_eth_interface_params get_eth_interface_params() const override;
     tt_driver_noc_params get_noc_params() const override;
-
 };
 
 }  // namespace tt::umd

--- a/device/cluster.h
+++ b/device/cluster.h
@@ -8,20 +8,19 @@
 #include <cassert>
 #include <cstdint>
 #include <memory>
+#include <set>
 #include <string>
 #include <unordered_set>
 #include <vector>
-#include <set>
 
+#include "device/tlb.h"
+#include "device/tt_cluster_descriptor_types.h"
+#include "device/tt_io.hpp"
+#include "fmt/core.h"
+#include "pcie/pci_device.hpp"
+#include "tt_silicon_driver_common.hpp"
 #include "tt_soc_descriptor.h"
 #include "tt_xy_pair.h"
-#include "tt_silicon_driver_common.hpp"
-#include "device/tt_cluster_descriptor_types.h"
-#include "device/tlb.h"
-#include "device/tt_io.hpp"
-
-#include "pcie/pci_device.hpp"
-#include "fmt/core.h"
 
 using TLB_DATA = tt::umd::tlb_data;
 
@@ -30,29 +29,32 @@ using TLB_DATA = tt::umd::tlb_data;
 tt::ARCH detect_arch(int pci_device_num);
 tt::ARCH detect_arch();
 
-namespace boost::interprocess{
-    class named_mutex;
+namespace boost::interprocess {
+class named_mutex;
 }
 
 class tt_ClusterDescriptor;
 
-enum tt_DevicePowerState {
-    BUSY,
-    SHORT_IDLE,
-    LONG_IDLE
-};
+enum tt_DevicePowerState { BUSY, SHORT_IDLE, LONG_IDLE };
 
 enum tt_MemBarFlag {
     SET = 0xaa,
     RESET = 0xbb,
 };
 
-inline std::ostream &operator <<(std::ostream &os, const tt_DevicePowerState power_state) {
+inline std::ostream& operator<<(std::ostream& os, const tt_DevicePowerState power_state) {
     switch (power_state) {
-        case tt_DevicePowerState::BUSY: os << "Busy"; break;
-        case tt_DevicePowerState::SHORT_IDLE: os << "SHORT_IDLE"; break;
-        case tt_DevicePowerState::LONG_IDLE: os << "LONG_IDLE"; break;
-        default: throw ("Unknown DevicePowerState");
+        case tt_DevicePowerState::BUSY:
+            os << "Busy";
+            break;
+        case tt_DevicePowerState::SHORT_IDLE:
+            os << "SHORT_IDLE";
+            break;
+        case tt_DevicePowerState::LONG_IDLE:
+            os << "LONG_IDLE";
+            break;
+        default:
+            throw("Unknown DevicePowerState");
     }
     return os;
 }
@@ -116,20 +118,22 @@ struct tt_version {
     std::uint16_t major = 0xffff;
     std::uint8_t minor = 0xff;
     std::uint8_t patch = 0xff;
+
     tt_version() {}
+
     tt_version(std::uint16_t major_, std::uint8_t minor_, std::uint8_t patch_) {
         major = major_;
         minor = minor_;
         patch = patch_;
     }
+
     tt_version(std::uint32_t version) {
         major = (version >> 16) & 0xff;
         minor = (version >> 12) & 0xf;
         patch = version & 0xfff;
     }
-    std::string str() const {
-        return fmt::format("{}.{}.{}", major, minor, patch);
-    }
+
+    std::string str() const { return fmt::format("{}.{}.{}", major, minor, patch); }
 };
 
 struct tt_device_params {
@@ -140,29 +144,32 @@ struct tt_device_params {
     bool init_device = true;
     bool early_open_device = false;
     int aiclk = 0;
+
     // The command-line input for vcd_dump_cores can have the following format:
     // {"*-2", "1-*", "*-*", "1-2"}
     // '*' indicates we must dump all the cores in that dimension.
     // This function takes the vector above and unrolles the coords with '*' in one or both dimensions.
     std::vector<std::string> unroll_vcd_dump_cores(tt_xy_pair grid_size) const {
         std::vector<std::string> unrolled_dump_core;
-        for (auto &dump_core: vcd_dump_cores) {
+        for (auto& dump_core : vcd_dump_cores) {
             // If the input is a single *, then dump all cores.
             if (dump_core == "*") {
                 for (size_t x = 0; x < grid_size.x; x++) {
-                for (size_t y = 0; y < grid_size.y; y++) {
-                    std::string current_core_coord = fmt::format("{}-{}", x, y);
-                    if (std::find(std::begin(unrolled_dump_core), std::end(unrolled_dump_core), current_core_coord) == std::end(unrolled_dump_core)) {
-                        unrolled_dump_core.push_back(current_core_coord);
+                    for (size_t y = 0; y < grid_size.y; y++) {
+                        std::string current_core_coord = fmt::format("{}-{}", x, y);
+                        if (std::find(
+                                std::begin(unrolled_dump_core), std::end(unrolled_dump_core), current_core_coord) ==
+                            std::end(unrolled_dump_core)) {
+                            unrolled_dump_core.push_back(current_core_coord);
+                        }
                     }
-                }
                 }
                 continue;
             }
             // Each core coordinate must contain three characters: "core.x-core.y".
             assert(dump_core.size() <= 5);
             size_t delimiter_pos = dump_core.find('-');
-            assert (delimiter_pos != std::string::npos); // y-dim should exist in core coord.
+            assert(delimiter_pos != std::string::npos);  // y-dim should exist in core coord.
 
             std::string core_dim_x = dump_core.substr(0, delimiter_pos);
             size_t core_dim_y_start = delimiter_pos + 1;
@@ -172,7 +179,9 @@ struct tt_device_params {
                 for (size_t x = 0; x < grid_size.x; x++) {
                     for (size_t y = 0; y < grid_size.y; y++) {
                         std::string current_core_coord = fmt::format("{}-{}", x, y);
-                        if (std::find(std::begin(unrolled_dump_core), std::end(unrolled_dump_core), current_core_coord) == std::end(unrolled_dump_core)) {
+                        if (std::find(
+                                std::begin(unrolled_dump_core), std::end(unrolled_dump_core), current_core_coord) ==
+                            std::end(unrolled_dump_core)) {
                             unrolled_dump_core.push_back(current_core_coord);
                         }
                     }
@@ -180,14 +189,16 @@ struct tt_device_params {
             } else if (core_dim_x == "*") {
                 for (size_t x = 0; x < grid_size.x; x++) {
                     std::string current_core_coord = fmt::format("{}-{}", x, core_dim_y);
-                    if (std::find(std::begin(unrolled_dump_core), std::end(unrolled_dump_core), current_core_coord) == std::end(unrolled_dump_core)) {
+                    if (std::find(std::begin(unrolled_dump_core), std::end(unrolled_dump_core), current_core_coord) ==
+                        std::end(unrolled_dump_core)) {
                         unrolled_dump_core.push_back(current_core_coord);
                     }
                 }
             } else if (core_dim_y == "*") {
                 for (size_t y = 0; y < grid_size.y; y++) {
                     std::string current_core_coord = fmt::format("{}-{}", core_dim_x, y);
-                    if (std::find(std::begin(unrolled_dump_core), std::end(unrolled_dump_core), current_core_coord) == std::end(unrolled_dump_core)) {
+                    if (std::find(std::begin(unrolled_dump_core), std::end(unrolled_dump_core), current_core_coord) ==
+                        std::end(unrolled_dump_core)) {
                         unrolled_dump_core.push_back(current_core_coord);
                     }
                 }
@@ -199,10 +210,9 @@ struct tt_device_params {
     }
 
     std::vector<std::string> expand_plusargs() const {
-        std::vector<std::string> all_plusargs {
+        std::vector<std::string> all_plusargs{
             fmt::format("+enable_perf_scoreboard={}", enable_perf_scoreboard),
-            fmt::format("+register_monitor={}", register_monitor)
-        };
+            fmt::format("+register_monitor={}", register_monitor)};
 
         all_plusargs.insert(all_plusargs.end(), plusargs.begin(), plusargs.end());
 
@@ -216,18 +226,18 @@ struct tt_device_params {
  * Exposes a generic interface to callers, providing declarations for virtual functions defined differently for Silicon.
  * Valid usage consists of declaring a tt_device object and initializing it to Silicon backend.
  * Using tt_device itself will throw errors, since its APIs are undefined.
- */ 
-class tt_device
-{
-    public:
+ */
+class tt_device {
+public:
     tt_device();
     virtual ~tt_device();
+
     // Setup/Teardown Functions
     /**
      * Set L1 Address Map parameters used by UMD to communicate with the TT Device.
      *
      * @param l1_address_params_  All the L1 parameters required by UMD
-     */ 
+     */
     virtual void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_) {
         throw std::runtime_error("---- tt_device::set_device_l1_address_params is not implemented\n");
     }
@@ -240,9 +250,9 @@ class tt_device
      * Set Host Address Map parameters used by UMD to communicate with the TT Device (used for remote transactions).
      *
      * @param host_address_params_ All the Host Address space parameters required by UMD.
-     */ 
-    [[deprecated("Using unnecessary function.")]]
-    virtual void set_driver_host_address_params(const tt_driver_host_address_params& host_address_params_) {
+     */
+    [[deprecated("Using unnecessary function.")]] virtual void set_driver_host_address_params(
+        const tt_driver_host_address_params& host_address_params_) {
         throw std::runtime_error("---- tt_device::set_driver_host_address_params is not implemented\n");
     }
 
@@ -250,9 +260,9 @@ class tt_device
      * Set ERISC Firmware parameters used by UMD to communicate with the TT Device (used for remote transactions).
      *
      * @param eth_interface_params_ All the Ethernet Firmware parameters required by UMD.
-     */ 
-    [[deprecated("Using unnecessary function.")]]
-    virtual void set_driver_eth_interface_params(const tt_driver_eth_interface_params& eth_interface_params_) {
+     */
+    [[deprecated("Using unnecessary function.")]] virtual void set_driver_eth_interface_params(
+        const tt_driver_eth_interface_params& eth_interface_params_) {
         throw std::runtime_error("---- tt_device::set_driver_eth_interface_params is not implemented\n");
     }
 
@@ -264,8 +274,13 @@ class tt_device
      * @param tlb_index TLB id that will be programmed.
      * @param address Start address TLB is mapped to.
      * @param ordering Ordering mode for the TLB.
-     */ 
-    virtual void configure_tlb(chip_id_t logical_device_id, tt_xy_pair core, std::int32_t tlb_index, std::int32_t address, uint64_t ordering = TLB_DATA::Relaxed) {
+     */
+    virtual void configure_tlb(
+        chip_id_t logical_device_id,
+        tt_xy_pair core,
+        std::int32_t tlb_index,
+        std::int32_t address,
+        uint64_t ordering = TLB_DATA::Relaxed) {
         throw std::runtime_error("---- tt_device::configure_tlb is not implemented\n");
     }
 
@@ -274,45 +289,51 @@ class tt_device
      *
      * @param fallback_tlb Dynamic TLB being targeted.
      * @param ordering Ordering mode for the TLB.
-     */ 
+     */
     virtual void set_fallback_tlb_ordering_mode(const std::string& fallback_tlb, uint64_t ordering = TLB_DATA::Posted) {
         throw std::runtime_error("---- tt_device::set_fallback_tlb_ordering_mode is not implemented\n");
     }
-    
+
     /**
-     * Give UMD a 1:1 function mapping a core to its appropriate static TLB (currently only support a single TLB per core).
+     * Give UMD a 1:1 function mapping a core to its appropriate static TLB (currently only support a single TLB per
+     * core).
      *
      * @param logical_device_id MMIO chip being targeted.
      * @param mapping_function Function which maps core to TLB index.
      */
-    virtual void setup_core_to_tlb_map(const chip_id_t logical_device_id, std::function<std::int32_t(tt_xy_pair)> mapping_function) {
+    virtual void setup_core_to_tlb_map(
+        const chip_id_t logical_device_id, std::function<std::int32_t(tt_xy_pair)> mapping_function) {
         throw std::runtime_error("---- tt_device::setup_core_to_tlb_map is not implemented\n");
     }
 
     /**
-     * Pass in ethernet cores with active links for a specific MMIO chip. When called, this function will force UMD to use a subset of cores from the active_eth_cores_per_chip set for all host->cluster
-     * non-MMIO transfers. If this function is not called, UMD will use a default set of ethernet core indices for these transfers (0 through 5).
-     * If default behaviour is not desired, this function must be called for all MMIO devices.
+     * Pass in ethernet cores with active links for a specific MMIO chip. When called, this function will force UMD to
+     * use a subset of cores from the active_eth_cores_per_chip set for all host->cluster non-MMIO transfers. If this
+     * function is not called, UMD will use a default set of ethernet core indices for these transfers (0 through 5). If
+     * default behaviour is not desired, this function must be called for all MMIO devices.
      *
      * @param mmio_chip Device being targeted.
      * @param active_eth_cores_per_chip The active ethernet cores for this chip.
      */
-    virtual void configure_active_ethernet_cores_for_mmio_device(chip_id_t mmio_chip, const std::unordered_set<tt_xy_pair>& active_eth_cores_per_chip) {
-        throw std::runtime_error("---- tt_device::configure_active_ethernet_cores_for_mmio_device is not implemented\n");
+    virtual void configure_active_ethernet_cores_for_mmio_device(
+        chip_id_t mmio_chip, const std::unordered_set<tt_xy_pair>& active_eth_cores_per_chip) {
+        throw std::runtime_error(
+            "---- tt_device::configure_active_ethernet_cores_for_mmio_device is not implemented\n");
     }
 
     /**
-     * On Silicon: Assert soft Tensix reset, deassert RiscV reset, set power state to busy (ramp up AICLK), initialize iATUs for PCIe devices and ethernet queues for remote chips.
+     * On Silicon: Assert soft Tensix reset, deassert RiscV reset, set power state to busy (ramp up AICLK), initialize
+     * iATUs for PCIe devices and ethernet queues for remote chips.
      *
      * @param device_params Object specifying initialization configuration.
      */
-    virtual void start_device(const tt_device_params &device_params) {
+    virtual void start_device(const tt_device_params& device_params) {
         throw std::runtime_error("---- tt_device::start_device is not implemented\n");
     }
 
     /**
      * Broadcast deassert soft Tensix Reset to the entire device (to be done after start_device is called).
-     */  
+     */
     virtual void deassert_risc_reset() {
         throw std::runtime_error("---- tt_device::deassert_risc_reset is not implemented\n");
     }
@@ -321,14 +342,15 @@ class tt_device
      * Send a soft deassert reset signal to a single tensix core.
      *
      * @param core Chip and core being targeted.
-     */  
-    virtual void deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets = TENSIX_DEASSERT_SOFT_RESET) {
+     */
+    virtual void deassert_risc_reset_at_core(
+        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET) {
         throw std::runtime_error("---- tt_device::deassert_risc_reset_at_core is not implemented\n");
     }
 
     /**
      * Broadcast assert soft Tensix Reset to the entire device.
-     */  
+     */
     virtual void assert_risc_reset() {
         throw std::runtime_error("---- tt_device::assert_risc_reset is not implemented\n");
     }
@@ -337,7 +359,7 @@ class tt_device
      * Send a soft assert reset signal to a single tensix core.
      *
      * @param core Chip and core being targeted.
-     */  
+     */
     virtual void assert_risc_reset_at_core(tt_cxy_pair core) {
         throw std::runtime_error("---- tt_device::assert_risc_reset_at_core is not implemented\n");
     }
@@ -345,17 +367,15 @@ class tt_device
     /**
      * To be called at the end of a run.
      * Set power state to idle, assert tensix reset at all cores.
-     */  
-    virtual void close_device() {
-        throw std::runtime_error("---- tt_device::close_device is not implemented\n");
-    }
+     */
+    virtual void close_device() { throw std::runtime_error("---- tt_device::close_device is not implemented\n"); }
 
     // Runtime functions
     /**
      * Non-MMIO (ethernet) barrier.
-     * Similar to an mfence for host -> host transfers. Will flush all in-flight ethernet transactions before proceeding with the next one.
-     * This will be applied to all chips in the cluster.
-     */ 
+     * Similar to an mfence for host -> host transfers. Will flush all in-flight ethernet transactions before proceeding
+     * with the next one. This will be applied to all chips in the cluster.
+     */
     virtual void wait_for_non_mmio_flush() {
         throw std::runtime_error("---- tt_device::wait_for_non_mmio_flush is not implemented\n");
     }
@@ -377,12 +397,20 @@ class tt_device
      * @param addr Address to write to.
      * @param tlb_to_use Specifies fallback/dynamic TLB to use.
      */
-    virtual void write_to_device(const void *mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use) {
+    virtual void write_to_device(
+        const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use) {
         // Only implement this for Silicon Backend
         throw std::runtime_error("---- tt_device::write_to_device is not implemented\n");
     }
 
-    virtual void broadcast_write_to_cluster(const void *mem_ptr, uint32_t size_in_bytes, uint64_t address, const std::set<chip_id_t>& chips_to_exclude,  std::set<uint32_t>& rows_to_exclude,  std::set<uint32_t>& columns_to_exclude, const std::string& fallback_tlb) {
+    virtual void broadcast_write_to_cluster(
+        const void* mem_ptr,
+        uint32_t size_in_bytes,
+        uint64_t address,
+        const std::set<chip_id_t>& chips_to_exclude,
+        std::set<uint32_t>& rows_to_exclude,
+        std::set<uint32_t>& columns_to_exclude,
+        const std::string& fallback_tlb) {
         throw std::runtime_error("---- tt_device::broadcast_write_to_cluster is not implemented\n");
     }
 
@@ -395,44 +423,54 @@ class tt_device
      * @param size Number of bytes to read.
      * @param fallback_tlb Specifies fallback/dynamic TLB to use.
      */
-    virtual void read_from_device(void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb) {
+    virtual void read_from_device(
+        void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb) {
         // Only implement this for Silicon Backend
         throw std::runtime_error("---- tt_device::read_from_device is not implemented\n");
     }
 
     /**
      * Write uint32_t vector to specified address and channel on host (defined for Silicon).
-     * 
+     *
      * @param vec Data to write.
      * @param addr Address to write to.
      * @param channel Host channel to target.
      * @param src_device_id Chip to target.
      */
-    virtual void write_to_sysmem(const void* mem_ptr, std::uint32_t size,  uint64_t addr, uint16_t channel, chip_id_t src_device_id) {
+    virtual void write_to_sysmem(
+        const void* mem_ptr, std::uint32_t size, uint64_t addr, uint16_t channel, chip_id_t src_device_id) {
         throw std::runtime_error("---- tt_device::write_to_sysmem is not implemented\n");
     }
-    virtual void read_from_sysmem(void* mem_ptr, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id) {
+
+    virtual void read_from_sysmem(
+        void* mem_ptr, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id) {
         throw std::runtime_error("---- tt_device::read_from_sysmem is not implemented\n");
     }
-    virtual void l1_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {}) {
+
+    virtual void l1_membar(
+        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {}) {
         throw std::runtime_error("---- tt_device::l1_membar is not implemented\n");
     }
-    virtual void dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels = {}) {
+
+    virtual void dram_membar(
+        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels = {}) {
         throw std::runtime_error("---- tt_device::dram_membar is not implemented\n");
     }
-    virtual void dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {}) {
+
+    virtual void dram_membar(
+        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {}) {
         throw std::runtime_error("---- tt_device::dram_membar is not implemented\n");
     }
 
     // Misc. Functions to Query/Set Device State
     /**
-     * Query post harvesting SOC descriptors from UMD in virtual coordinates. 
+     * Query post harvesting SOC descriptors from UMD in virtual coordinates.
      * These descriptors should be used for looking up cores that are passed into UMD APIs.
      */
     virtual std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors() {
         throw std::runtime_error("---- tt_device:get_virtual_soc_descriptors is not implemented\n");
     }
-   
+
     /**
      * Determine if UMD performed harvesting on SOC descriptors.
      */
@@ -440,18 +478,18 @@ class tt_device
         throw std::runtime_error("---- tt_device:using_harvested_soc_descriptors is not implemented\n");
         return 0;
     }
-    
+
     /**
      * Get harvesting masks for all chips/SOC Descriptors in the cluster.
      * Each mask represents a map of enabled (0) and disabled (1) rows on a specific chip (in NOC0 Coordinateds).
-     */ 
+     */
     virtual std::unordered_map<chip_id_t, uint32_t> get_harvesting_masks_for_soc_descriptors() {
         throw std::runtime_error("---- tt_device:get_harvesting_masks_for_soc_descriptors is not implemented\n");
     }
 
     /**
      * Issue message to device, meant to be picked up by ARC firmware.
-     * 
+     *
      * @param logical_device_id Chip to target.
      * @param msg_code Specifies type of ARC message.
      * @param wait_for_done Block until ARC responds.
@@ -460,8 +498,16 @@ class tt_device
      * @param timeout Timeout on ARC.
      * @param return3 Return value from ARC.
      * @param return4 Return value from ARC.
-     */ 
-    virtual int arc_msg(int logical_device_id, uint32_t msg_code, bool wait_for_done = true, uint32_t arg0 = 0, uint32_t arg1 = 0, int timeout=1, uint32_t *return_3 = nullptr, uint32_t *return_4 = nullptr) {
+     */
+    virtual int arc_msg(
+        int logical_device_id,
+        uint32_t msg_code,
+        bool wait_for_done = true,
+        uint32_t arg0 = 0,
+        uint32_t arg1 = 0,
+        int timeout = 1,
+        uint32_t* return_3 = nullptr,
+        uint32_t* return_4 = nullptr) {
         throw std::runtime_error("---- tt_device::arc_msg is not implemented\n");
     }
 
@@ -471,28 +517,28 @@ class tt_device
      * @param device_id Chip to target.
      * @param r Row coordinate.
      * @param c Column coordinate.
-     */ 
-    virtual void translate_to_noc_table_coords(chip_id_t device_id, std::size_t &r, std::size_t &c) {
+     */
+    virtual void translate_to_noc_table_coords(chip_id_t device_id, std::size_t& r, std::size_t& c) {
         throw std::runtime_error("---- tt_device::translate_to_noc_table_coords is not implemented\n");
     }
 
     /**
      * Get the total number of chips in the cluster based on the network descriptor.
-     */ 
+     */
     virtual int get_number_of_chips_in_cluster() {
         throw std::runtime_error("---- tt_device::get_number_of_chips_in_cluster is not implemented\n");
     }
 
     /**
      * Get the logical ids for all chips in the cluster
-     */ 
+     */
     virtual std::unordered_set<chip_id_t> get_all_chips_in_cluster() {
         throw std::runtime_error("---- tt_device::get_all_chips_in_cluster is not implemented\n");
     }
 
     /**
      * Get cluster descriptor object being used in UMD instance.
-     */ 
+     */
     virtual tt_ClusterDescriptor* get_cluster_description() {
         throw std::runtime_error("---- tt_device::get_cluster_description is not implemented\n");
     }
@@ -514,9 +560,9 @@ class tt_device
     /**
      * Get clock frequencies for all MMIO devices targeted by UMD.
      */
-    virtual std::map<int,int> get_clocks() {
+    virtual std::map<int, int> get_clocks() {
         throw std::runtime_error("---- tt_device::get_clocks is not implemented\n");
-        return std::map<int,int>();
+        return std::map<int, int>();
     }
 
     virtual std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id) {
@@ -534,7 +580,7 @@ class tt_device
      * Query number of DRAM channels on a specific device.
      *
      * @param device_id Logical device id to query.
-     */ 
+     */
     virtual std::uint32_t get_num_dram_channels(std::uint32_t device_id) {
         throw std::runtime_error("---- tt_device::get_num_dram_channels is not implemented\n");
         return 0;
@@ -542,10 +588,10 @@ class tt_device
 
     /**
      * Get size for a specific DRAM channel on a device.
-     *    
+     *
      * @param device_id Device to target.
      * @param channel DRAM channel to target.
-     */ 
+     */
     virtual std::uint64_t get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel) {
         throw std::runtime_error("---- tt_device::get_dram_channel_size is not implemented\n");
         return 0;
@@ -555,7 +601,7 @@ class tt_device
      * Query number of Host channels (hugepages) allocated for a specific device.
      *
      * @param device_id Logical device id to target.
-     */ 
+     */
     virtual std::uint32_t get_num_host_channels(std::uint32_t device_id) {
         throw std::runtime_error("---- tt_device::get_num_host_channels is not implemented\n");
         return 0;
@@ -566,20 +612,21 @@ class tt_device
      *
      * @param device_id Logical device id to target.
      * @param channel Logical host channel to target.
-     */ 
+     */
     virtual std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel) {
         throw std::runtime_error("---- tt_device::get_host_channel_size is not implemented\n");
         return 0;
     }
 
     /**
-     * Get absolute address corresponding to a zero based offset into a specific host memory channel for a specific device.
-     *   
+     * Get absolute address corresponding to a zero based offset into a specific host memory channel for a specific
+     * device.
+     *
      * @param offset Offset wrt the start of the channel's address space.
-     * @param src_device_id Device to target. 
+     * @param src_device_id Device to target.
      * @param channel Host memory channel.
      */
-    virtual void *host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const {
+    virtual void* host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const {
         throw std::runtime_error("---- tt_device::host_dma_address is not implemented\n");
         return nullptr;
     }
@@ -588,24 +635,24 @@ class tt_device
         throw std::runtime_error("---- tt_device::get_pcie_base_addr_from_device is not implemented\n");
         return 0;
     }
+
     const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const;
 
     bool performed_harvesting = false;
     std::unordered_map<chip_id_t, uint32_t> harvested_rows_per_target = {};
     bool translation_tables_en = false;
 
-    protected:
+protected:
     std::unordered_map<chip_id_t, tt_SocDescriptor> soc_descriptor_per_chip = {};
 };
 
 namespace tt::umd {
 
 /**
-* Silicon Driver Class, derived from the tt_device class
+ * Silicon Driver Class, derived from the tt_device class
  * Implements APIs to communicate with a physical Tenstorrent Device.
-*/ 
-class Cluster: public tt_device
-{
+ */
+class Cluster : public tt_device {
 public:
     // Constructor
     /**
@@ -619,11 +666,17 @@ public:
      * @param clean_system_resource Specifies if host state from previous runs needs to be cleaned up.
      * @param perform_harvesting Allow the driver to modify the SOC descriptors per chip.
      * @param simulated_harvesting_masks
-     */ 
-    Cluster(const std::string &sdesc_path, const std::string &ndesc_path, const std::set<chip_id_t> &target_devices, 
-                    const uint32_t &num_host_mem_ch_per_mmio_device = 1, const bool skip_driver_allocs = false,
-                    const bool clean_system_resources = false, bool perform_harvesting = true, std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {});
-    
+     */
+    Cluster(
+        const std::string& sdesc_path,
+        const std::string& ndesc_path,
+        const std::set<chip_id_t>& target_devices,
+        const uint32_t& num_host_mem_ch_per_mmio_device = 1,
+        const bool skip_driver_allocs = false,
+        const bool clean_system_resources = false,
+        bool perform_harvesting = true,
+        std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {});
+
     /**
      * Cluster constructor. This constructor should be used to work towards removing all
      * of the params from the constructor of tt_SiliconDevice (to become Cluster).
@@ -633,9 +686,13 @@ public:
      * @param clean_system_resource Specifies if host state from previous runs needs to be cleaned up.
      * @param perform_harvesting Allow the driver to modify the SOC descriptors per chip.
      * @param simulated_harvesting_masks
-     */ 
-    Cluster(const uint32_t &num_host_mem_ch_per_mmio_device = 1, const bool skip_driver_allocs = false,
-                     const bool clean_system_resources = false, bool perform_harvesting = true, std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {});
+     */
+    Cluster(
+        const uint32_t& num_host_mem_ch_per_mmio_device = 1,
+        const bool skip_driver_allocs = false,
+        const bool clean_system_resources = false,
+        bool perform_harvesting = true,
+        std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {});
 
     /**
      * Cluster constructor. This constructor should be used to target specific devices in a cluster.
@@ -646,42 +703,69 @@ public:
      * @param clean_system_resource Specifies if host state from previous runs needs to be cleaned up.
      * @param perform_harvesting Allow the driver to modify the SOC descriptors per chip.
      * @param simulated_harvesting_masks
-     */ 
-    Cluster(const std::set<chip_id_t> &target_devices, const uint32_t &num_host_mem_ch_per_mmio_device = 1, const bool skip_driver_allocs = false,
-            const bool clean_system_resources = false, bool perform_harvesting = true, std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {});
+     */
+    Cluster(
+        const std::set<chip_id_t>& target_devices,
+        const uint32_t& num_host_mem_ch_per_mmio_device = 1,
+        const bool skip_driver_allocs = false,
+        const bool clean_system_resources = false,
+        bool perform_harvesting = true,
+        std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {});
 
-    //Setup/Teardown Functions
+    // Setup/Teardown Functions
     virtual std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors();
     virtual void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_);
     virtual void set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_);
     virtual void set_driver_host_address_params(const tt_driver_host_address_params& host_address_params_);
     virtual void set_driver_eth_interface_params(const tt_driver_eth_interface_params& eth_interface_params_);
-    virtual void configure_tlb(chip_id_t logical_device_id, tt_xy_pair core, std::int32_t tlb_index, std::int32_t address, uint64_t ordering = TLB_DATA::Posted);
+    virtual void configure_tlb(
+        chip_id_t logical_device_id,
+        tt_xy_pair core,
+        std::int32_t tlb_index,
+        std::int32_t address,
+        uint64_t ordering = TLB_DATA::Posted);
     virtual void set_fallback_tlb_ordering_mode(const std::string& fallback_tlb, uint64_t ordering = TLB_DATA::Posted);
-    virtual void setup_core_to_tlb_map(const chip_id_t logical_device_id, std::function<std::int32_t(tt_xy_pair)> mapping_function);
-    virtual void configure_active_ethernet_cores_for_mmio_device(chip_id_t mmio_chip, const std::unordered_set<tt_xy_pair>& active_eth_cores_per_chip);
-    virtual void start_device(const tt_device_params &device_params);
+    virtual void setup_core_to_tlb_map(
+        const chip_id_t logical_device_id, std::function<std::int32_t(tt_xy_pair)> mapping_function);
+    virtual void configure_active_ethernet_cores_for_mmio_device(
+        chip_id_t mmio_chip, const std::unordered_set<tt_xy_pair>& active_eth_cores_per_chip);
+    virtual void start_device(const tt_device_params& device_params);
     virtual void assert_risc_reset();
     virtual void deassert_risc_reset();
-    virtual void deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets = TENSIX_DEASSERT_SOFT_RESET);
+    virtual void deassert_risc_reset_at_core(
+        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET);
     virtual void assert_risc_reset_at_core(tt_cxy_pair core);
     virtual void close_device();
 
     // Runtime Functions
-    virtual void write_to_device(const void *mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use);
-    void broadcast_write_to_cluster(const void *mem_ptr, uint32_t size_in_bytes, uint64_t address, const std::set<chip_id_t>& chips_to_exclude,  std::set<uint32_t>& rows_to_exclude,  std::set<uint32_t>& columns_to_exclude, const std::string& fallback_tlb);
+    virtual void write_to_device(
+        const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use);
+    void broadcast_write_to_cluster(
+        const void* mem_ptr,
+        uint32_t size_in_bytes,
+        uint64_t address,
+        const std::set<chip_id_t>& chips_to_exclude,
+        std::set<uint32_t>& rows_to_exclude,
+        std::set<uint32_t>& columns_to_exclude,
+        const std::string& fallback_tlb);
 
-    virtual void read_from_device(void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
-    virtual void write_to_sysmem(const void* mem_ptr, std::uint32_t size,  uint64_t addr, uint16_t channel, chip_id_t src_device_id);
-    virtual void read_from_sysmem(void* mem_ptr, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id);
+    virtual void read_from_device(
+        void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
+    virtual void write_to_sysmem(
+        const void* mem_ptr, std::uint32_t size, uint64_t addr, uint16_t channel, chip_id_t src_device_id);
+    virtual void read_from_sysmem(
+        void* mem_ptr, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id);
     virtual void wait_for_non_mmio_flush();
     virtual void wait_for_non_mmio_flush(const chip_id_t chip_id);
-    void l1_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
-    void dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels);
-    void dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
+    void l1_membar(
+        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
+    void dram_membar(
+        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels);
+    void dram_membar(
+        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
     // These functions are used by Debuda, so make them public
-    void bar_write32 (int logical_device_id, uint32_t addr, uint32_t data);
-    uint32_t bar_read32 (int logical_device_id, uint32_t addr);
+    void bar_write32(int logical_device_id, uint32_t addr, uint32_t data);
+    uint32_t bar_read32(int logical_device_id, uint32_t addr);
 
     /**
      * If the tlbs are initialized, returns a tuple with the TLB base address and its size
@@ -699,16 +783,24 @@ public:
      * - the mapping is unchanged during the lifetime of the returned object.
      * - the Cluster instance outlives the returned object.
      * - use of the returned object is congruent with the target's TLB setup.
-     *    
+     *
      * @param target The target chip and core to write to.
      */
     tt::Writer get_static_tlb_writer(tt_cxy_pair target);
 
     // Misc. Functions to Query/Set Device State
-    virtual int arc_msg(int logical_device_id, uint32_t msg_code, bool wait_for_done = true, uint32_t arg0 = 0, uint32_t arg1 = 0, int timeout=1, uint32_t *return_3 = nullptr, uint32_t *return_4 = nullptr);
+    virtual int arc_msg(
+        int logical_device_id,
+        uint32_t msg_code,
+        bool wait_for_done = true,
+        uint32_t arg0 = 0,
+        uint32_t arg1 = 0,
+        int timeout = 1,
+        uint32_t* return_3 = nullptr,
+        uint32_t* return_4 = nullptr);
     virtual bool using_harvested_soc_descriptors();
     virtual std::unordered_map<chip_id_t, uint32_t> get_harvesting_masks_for_soc_descriptors();
-    virtual void translate_to_noc_table_coords(chip_id_t device_id, std::size_t &r, std::size_t &c);
+    virtual void translate_to_noc_table_coords(chip_id_t device_id, std::size_t& r, std::size_t& c);
     virtual int get_number_of_chips_in_cluster();
     virtual std::unordered_set<chip_id_t> get_all_chips_in_cluster();
     virtual tt_ClusterDescriptor* get_cluster_description();
@@ -716,13 +808,16 @@ public:
     static std::vector<chip_id_t> detect_available_device_ids();
     virtual std::set<chip_id_t> get_target_mmio_device_ids();
     virtual std::set<chip_id_t> get_target_remote_device_ids();
-    virtual std::map<int,int> get_clocks();
-    virtual void *host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const;
+    virtual std::map<int, int> get_clocks();
+    virtual void* host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const;
     virtual std::uint64_t get_pcie_base_addr_from_device(const chip_id_t chip_id) const;
-    static std::vector<int> extract_rows_to_remove(const tt::ARCH &arch, const int worker_grid_rows, const int harvested_rows);
-    static void remove_worker_row_from_descriptor(tt_SocDescriptor& full_soc_descriptor, const std::vector<int>& row_coordinates_to_remove);
+    static std::vector<int> extract_rows_to_remove(
+        const tt::ARCH& arch, const int worker_grid_rows, const int harvested_rows);
+    static void remove_worker_row_from_descriptor(
+        tt_SocDescriptor& full_soc_descriptor, const std::vector<int>& row_coordinates_to_remove);
     static void harvest_rows_in_soc_descriptor(tt::ARCH arch, tt_SocDescriptor& sdesc, uint32_t harvested_rows);
-    static std::unordered_map<tt_xy_pair, tt_xy_pair> create_harvested_coord_translation(const tt::ARCH arch, bool identity_map);
+    static std::unordered_map<tt_xy_pair, tt_xy_pair> create_harvested_coord_translation(
+        const tt::ARCH arch, bool identity_map);
     std::unordered_map<tt_xy_pair, tt_xy_pair> get_harvested_coord_translation_map(chip_id_t logical_device_id);
     virtual std::uint32_t get_num_dram_channels(std::uint32_t device_id);
     virtual std::uint64_t get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel);
@@ -731,74 +826,153 @@ public:
     virtual std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id);
     virtual tt_version get_ethernet_fw_version() const;
     // TODO: This should be accessible through public API, probably to be moved to tt_device.
-    PCIDevice *get_pci_device(int device_id) const;
+    PCIDevice* get_pci_device(int device_id) const;
 
     // Destructor
-    virtual ~Cluster ();
+    virtual ~Cluster();
 
 private:
     // Helper functions
     // Startup + teardown
-    void create_device(const std::unordered_set<chip_id_t> &target_mmio_device_ids, const uint32_t &num_host_mem_ch_per_mmio_device, const bool skip_driver_allocs, const bool clean_system_resources);
+    void create_device(
+        const std::unordered_set<chip_id_t>& target_mmio_device_ids,
+        const uint32_t& num_host_mem_ch_per_mmio_device,
+        const bool skip_driver_allocs,
+        const bool clean_system_resources);
     void initialize_interprocess_mutexes(int pci_interface_id, bool cleanup_mutexes_in_shm);
     void cleanup_shared_host_state();
     void initialize_pcie_devices();
-    void broadcast_pcie_tensix_risc_reset(chip_id_t chip_id, const TensixSoftResetOptions &cores);
-    void broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOptions &soft_resets);
-    void send_remote_tensix_risc_reset_to_core(const tt_cxy_pair &core, const TensixSoftResetOptions &soft_resets);
-    void send_tensix_risc_reset_to_core(const tt_cxy_pair &core, const TensixSoftResetOptions &soft_resets);
+    void broadcast_pcie_tensix_risc_reset(chip_id_t chip_id, const TensixSoftResetOptions& cores);
+    void broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOptions& soft_resets);
+    void send_remote_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);
+    void send_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);
     void perform_harvesting_and_populate_soc_descriptors(const std::string& sdesc_path, const bool perform_harvesting);
     void populate_cores();
-    void init_pcie_iatus(); // No more p2p support.
+    void init_pcie_iatus();  // No more p2p support.
     void check_pcie_device_initialized(int device_id);
     void set_pcie_power_state(tt_DevicePowerState state);
-    int set_remote_power_state(const chip_id_t &chip, tt_DevicePowerState device_state);
+    int set_remote_power_state(const chip_id_t& chip, tt_DevicePowerState device_state);
     void set_power_state(tt_DevicePowerState state);
     uint32_t get_power_state_arc_msg(chip_id_t chip_id, tt_DevicePowerState state);
     void enable_local_ethernet_queue(const chip_id_t& chip, int timeout);
     void enable_ethernet_queue(int timeout);
     void enable_remote_ethernet_queue(const chip_id_t& chip, int timeout);
     void deassert_resets_and_set_power_state();
-    int iatu_configure_peer_region (int logical_device_id, uint32_t peer_region_id, uint64_t bar_addr_64, uint32_t region_size);
-    uint32_t get_harvested_noc_rows (uint32_t harvesting_mask);
-    uint32_t get_harvested_rows (int logical_device_id);
+    int iatu_configure_peer_region(
+        int logical_device_id, uint32_t peer_region_id, uint64_t bar_addr_64, uint32_t region_size);
+    uint32_t get_harvested_noc_rows(uint32_t harvesting_mask);
+    uint32_t get_harvested_rows(int logical_device_id);
     int get_clock(int logical_device_id);
 
     // Communication Functions
-    void read_buffer(void* mem_ptr, std::uint32_t address, std::uint16_t channel, std::uint32_t size_in_bytes, chip_id_t src_device_id);
-    void write_buffer(const void *mem_ptr, std::uint32_t size, std::uint32_t address, std::uint16_t channel, chip_id_t src_device_id);
-    void write_device_memory(const void *mem_ptr, uint32_t size_in_bytes, tt_cxy_pair target, std::uint32_t address, const std::string& fallback_tlb);
-    void write_to_non_mmio_device(const void *mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t address, bool broadcast = false, std::vector<int> broadcast_header = {});
-    void read_device_memory(void *mem_ptr, tt_cxy_pair target, std::uint32_t address, std::uint32_t size_in_bytes, const std::string& fallback_tlb);
+    void read_buffer(
+        void* mem_ptr,
+        std::uint32_t address,
+        std::uint16_t channel,
+        std::uint32_t size_in_bytes,
+        chip_id_t src_device_id);
+    void write_buffer(
+        const void* mem_ptr, std::uint32_t size, std::uint32_t address, std::uint16_t channel, chip_id_t src_device_id);
+    void write_device_memory(
+        const void* mem_ptr,
+        uint32_t size_in_bytes,
+        tt_cxy_pair target,
+        std::uint32_t address,
+        const std::string& fallback_tlb);
+    void write_to_non_mmio_device(
+        const void* mem_ptr,
+        uint32_t size_in_bytes,
+        tt_cxy_pair core,
+        uint64_t address,
+        bool broadcast = false,
+        std::vector<int> broadcast_header = {});
+    void read_device_memory(
+        void* mem_ptr,
+        tt_cxy_pair target,
+        std::uint32_t address,
+        std::uint32_t size_in_bytes,
+        const std::string& fallback_tlb);
     void read_from_non_mmio_device(void* mem_ptr, tt_cxy_pair core, uint64_t address, uint32_t size_in_bytes);
-    void read_mmio_device_register(void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
-    void write_mmio_device_register(const void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
-    void pcie_broadcast_write(chip_id_t chip, const void* mem_ptr, uint32_t size_in_bytes, std::uint32_t addr, const tt_xy_pair& start, const tt_xy_pair& end, const std::string& fallback_tlb);
-    void ethernet_broadcast_write(const void *mem_ptr, uint32_t size_in_bytes, uint64_t address, const std::set<chip_id_t>& chips_to_exclude, const std::set<uint32_t>& rows_to_exclude, 
-                                  std::set<uint32_t>& cols_to_exclude, const std::string& fallback_tlb, bool use_virtual_coords);
-    void set_membar_flag(const chip_id_t chip, const std::unordered_set<tt_xy_pair>& cores, const uint32_t barrier_value, const uint32_t barrier_addr, const std::string& fallback_tlb);
-    void insert_host_to_device_barrier(const chip_id_t chip, const std::unordered_set<tt_xy_pair>& cores, const uint32_t barrier_addr, const std::string& fallback_tlb);
+    void read_mmio_device_register(
+        void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
+    void write_mmio_device_register(
+        const void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
+    void pcie_broadcast_write(
+        chip_id_t chip,
+        const void* mem_ptr,
+        uint32_t size_in_bytes,
+        std::uint32_t addr,
+        const tt_xy_pair& start,
+        const tt_xy_pair& end,
+        const std::string& fallback_tlb);
+    void ethernet_broadcast_write(
+        const void* mem_ptr,
+        uint32_t size_in_bytes,
+        uint64_t address,
+        const std::set<chip_id_t>& chips_to_exclude,
+        const std::set<uint32_t>& rows_to_exclude,
+        std::set<uint32_t>& cols_to_exclude,
+        const std::string& fallback_tlb,
+        bool use_virtual_coords);
+    void set_membar_flag(
+        const chip_id_t chip,
+        const std::unordered_set<tt_xy_pair>& cores,
+        const uint32_t barrier_value,
+        const uint32_t barrier_addr,
+        const std::string& fallback_tlb);
+    void insert_host_to_device_barrier(
+        const chip_id_t chip,
+        const std::unordered_set<tt_xy_pair>& cores,
+        const uint32_t barrier_addr,
+        const std::string& fallback_tlb);
     void init_membars();
     uint64_t get_sys_addr(uint32_t chip_x, uint32_t chip_y, uint32_t noc_x, uint32_t noc_y, uint64_t offset);
     uint16_t get_sys_rack(uint32_t rack_x, uint32_t rack_y);
     bool is_non_mmio_cmd_q_full(uint32_t curr_wptr, uint32_t curr_rptr);
-    int pcie_arc_msg(int logical_device_id, uint32_t msg_code, bool wait_for_done = true, uint32_t arg0 = 0, uint32_t arg1 = 0, int timeout=1, uint32_t *return_3 = nullptr, uint32_t *return_4 = nullptr);
-    int remote_arc_msg(int logical_device_id, uint32_t msg_code, bool wait_for_done = true, uint32_t arg0 = 0, uint32_t arg1 = 0, int timeout=1, uint32_t *return_3 = nullptr, uint32_t *return_4 = nullptr);
-    bool address_in_tlb_space(uint32_t address, uint32_t size_in_bytes, int32_t tlb_index, uint64_t tlb_size, uint32_t chip);
+    int pcie_arc_msg(
+        int logical_device_id,
+        uint32_t msg_code,
+        bool wait_for_done = true,
+        uint32_t arg0 = 0,
+        uint32_t arg1 = 0,
+        int timeout = 1,
+        uint32_t* return_3 = nullptr,
+        uint32_t* return_4 = nullptr);
+    int remote_arc_msg(
+        int logical_device_id,
+        uint32_t msg_code,
+        bool wait_for_done = true,
+        uint32_t arg0 = 0,
+        uint32_t arg1 = 0,
+        int timeout = 1,
+        uint32_t* return_3 = nullptr,
+        uint32_t* return_4 = nullptr);
+    bool address_in_tlb_space(
+        uint32_t address, uint32_t size_in_bytes, int32_t tlb_index, uint64_t tlb_size, uint32_t chip);
     std::shared_ptr<boost::interprocess::named_mutex> get_mutex(const std::string& tlb_name, int pci_interface_id);
-    virtual uint32_t get_harvested_noc_rows_for_chip(int logical_device_id); // Returns one-hot encoded harvesting mask for PCIe mapped chips
-    void generate_tensix_broadcast_grids_for_grayskull( std::set<std::pair<tt_xy_pair, tt_xy_pair>>& broadcast_grids, std::set<uint32_t>& rows_to_exclude, std::set<uint32_t>& cols_to_exclude);
-    std::unordered_map<chip_id_t, std::vector<std::vector<int>>>&  get_ethernet_broadcast_headers(const std::set<chip_id_t>& chips_to_exclude);
+    virtual uint32_t get_harvested_noc_rows_for_chip(
+        int logical_device_id);  // Returns one-hot encoded harvesting mask for PCIe mapped chips
+    void generate_tensix_broadcast_grids_for_grayskull(
+        std::set<std::pair<tt_xy_pair, tt_xy_pair>>& broadcast_grids,
+        std::set<uint32_t>& rows_to_exclude,
+        std::set<uint32_t>& cols_to_exclude);
+    std::unordered_map<chip_id_t, std::vector<std::vector<int>>>& get_ethernet_broadcast_headers(
+        const std::set<chip_id_t>& chips_to_exclude);
     // Test functions
     void verify_eth_fw();
-    void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t> &fw_versions);
-    int test_setup_interface ();
+    void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions);
+    int test_setup_interface();
 
     // This functions has to be called for local chip, and then it will wait for all connected remote chips to flush.
     void wait_for_connected_non_mmio_flush(chip_id_t chip_id);
 
-    void construct_cluster(const std::string& sdesc_path, const uint32_t &num_host_mem_ch_per_mmio_device, const bool skip_driver_allocs,
-                                     const bool clean_system_resources, bool perform_harvesting, std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks);
+    void construct_cluster(
+        const std::string& sdesc_path,
+        const uint32_t& num_host_mem_ch_per_mmio_device,
+        const bool skip_driver_allocs,
+        const bool clean_system_resources,
+        bool perform_harvesting,
+        std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks);
 
     // State variables
     tt_device_dram_address_params dram_address_params;
@@ -810,22 +984,24 @@ private:
     std::set<chip_id_t> target_devices_in_cluster = {};
     std::set<chip_id_t> target_remote_chips = {};
     tt::ARCH arch_name;
-    std::unordered_map<chip_id_t, std::unique_ptr<PCIDevice>> m_pci_device_map;    // Map of enabled pci devices
-    int m_num_pci_devices;                                      // Number of pci devices in system (enabled or disabled)
+    std::unordered_map<chip_id_t, std::unique_ptr<PCIDevice>> m_pci_device_map;  // Map of enabled pci devices
+    int m_num_pci_devices;  // Number of pci devices in system (enabled or disabled)
     std::shared_ptr<tt_ClusterDescriptor> ndesc;
 
     // remote eth transfer setup
     static constexpr std::uint32_t NUM_ETH_CORES_FOR_NON_MMIO_TRANSFERS = 6;
     static constexpr std::uint32_t NON_EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS = 4;
     static constexpr std::uint32_t NON_EPOCH_ETH_CORES_START_ID = 0;
-    static constexpr std::uint32_t NON_EPOCH_ETH_CORES_MASK = (NON_EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS-1);
+    static constexpr std::uint32_t NON_EPOCH_ETH_CORES_MASK = (NON_EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS - 1);
 
-    static constexpr std::uint32_t EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS = NUM_ETH_CORES_FOR_NON_MMIO_TRANSFERS - NON_EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS;
-    static constexpr std::uint32_t EPOCH_ETH_CORES_START_ID = NON_EPOCH_ETH_CORES_START_ID + NON_EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS;
-    static constexpr std::uint32_t EPOCH_ETH_CORES_MASK = (EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS-1);
+    static constexpr std::uint32_t EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS =
+        NUM_ETH_CORES_FOR_NON_MMIO_TRANSFERS - NON_EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS;
+    static constexpr std::uint32_t EPOCH_ETH_CORES_START_ID =
+        NON_EPOCH_ETH_CORES_START_ID + NON_EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS;
+    static constexpr std::uint32_t EPOCH_ETH_CORES_MASK = (EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS - 1);
 
     int active_core = NON_EPOCH_ETH_CORES_START_ID;
-    std::vector< std::vector<tt_cxy_pair> > remote_transfer_ethernet_cores;
+    std::vector<std::vector<tt_cxy_pair>> remote_transfer_ethernet_cores;
     std::unordered_map<chip_id_t, bool> flush_non_mmio_per_chip = {};
     bool non_mmio_transfer_cores_customized = false;
     std::unordered_map<chip_id_t, int> active_eth_core_idx_per_chip = {};
@@ -850,7 +1026,7 @@ private:
     bool use_ethernet_ordered_writes = true;
     bool use_ethernet_broadcast = true;
     bool use_virtual_coords_for_eth_broadcast = true;
-    tt_version eth_fw_version; // Ethernet FW the driver is interfacing with
+    tt_version eth_fw_version;  // Ethernet FW the driver is interfacing with
     // Named Mutexes
     static constexpr char NON_MMIO_MUTEX_NAME[] = "NON_MMIO";
     static constexpr char ARC_MSG_MUTEX_NAME[] = "ARC_MSG";
@@ -859,13 +1035,13 @@ private:
     static constexpr std::uint32_t SW_VERSION = 0x06060000;
 };
 
-}
+}  // namespace tt::umd
 
-constexpr inline bool operator==(const tt_version &a, const tt_version &b) {
+constexpr inline bool operator==(const tt_version& a, const tt_version& b) {
     return a.major == b.major && a.minor == b.minor && a.patch == b.patch;
 }
 
-constexpr inline bool operator>=(const tt_version &a, const tt_version &b) {
+constexpr inline bool operator>=(const tt_version& a, const tt_version& b) {
     bool fw_major_greater = a.major > b.major;
     bool fw_minor_greater = (a.major == b.major) && (a.minor > b.minor);
     bool patch_greater_or_equal = (a.major == b.major) && (a.minor == b.minor) && (a.patch >= b.patch);

--- a/device/coordinate_manager.cpp
+++ b/device/coordinate_manager.cpp
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "device/coordinate_manager.h"
+
 #include <memory>
+
 #include "coordinate_manager.h"
 #include "grayskull/grayskull_coordinate_manager.h"
 
@@ -71,13 +73,9 @@ void CoordinateManager::clear_harvesting_structures() {
     virtual_y_to_logical_y.clear();
 }
 
-std::set<std::size_t> CoordinateManager::get_x_coordinates_to_harvest(std::size_t harvesting_mask) {
-    return {};
-}
+std::set<std::size_t> CoordinateManager::get_x_coordinates_to_harvest(std::size_t harvesting_mask) { return {}; }
 
-std::set<std::size_t> CoordinateManager::get_y_coordinates_to_harvest(std::size_t harvesting_mask) {
-    return {};
-}
+std::set<std::size_t> CoordinateManager::get_y_coordinates_to_harvest(std::size_t harvesting_mask) { return {}; }
 
 void CoordinateManager::perform_harvesting(std::size_t harvesting_mask) {
     clear_harvesting_structures();
@@ -104,14 +102,16 @@ void CoordinateManager::perform_harvesting(std::size_t harvesting_mask) {
     logical_x_to_virtual_x.resize(grid_size_x - num_harvested_x);
     logical_y_to_virtual_y.resize(grid_size_y - num_harvested_y);
 
-    fill_logical_to_physical_mapping(x_coordinates_to_harvest, y_coordinates_to_harvest, physical_x_unharvested, physical_y_unharvested);
+    fill_logical_to_physical_mapping(
+        x_coordinates_to_harvest, y_coordinates_to_harvest, physical_x_unharvested, physical_y_unharvested);
     fill_logical_to_virtual_mapping(physical_x_unharvested, physical_y_unharvested);
 }
 
 void CoordinateManager::fill_logical_to_physical_mapping(
-    const std::set<size_t>& x_to_harvest, const std::set<size_t>& y_to_harvest,
-    const std::set<size_t>& physical_x_unharvested, const std::set<size_t>& physical_y_unharvested) {
-    
+    const std::set<size_t>& x_to_harvest,
+    const std::set<size_t>& y_to_harvest,
+    const std::set<size_t>& physical_x_unharvested,
+    const std::set<size_t>& physical_y_unharvested) {
     auto physical_y_it = physical_y_unharvested.begin();
     std::size_t logical_y = 0;
     for (size_t y = 0; y < worker_grid_size.y; y++) {
@@ -130,7 +130,7 @@ void CoordinateManager::fill_logical_to_physical_mapping(
 
     auto physical_x_it = physical_x_unharvested.begin();
     std::size_t logical_x = 0;
-    for(std::size_t x = 0; x < worker_grid_size.x; x++) {
+    for (std::size_t x = 0; x < worker_grid_size.x; x++) {
         if (x_to_harvest.find(x) == x_to_harvest.end()) {
             logical_x_to_physical_x[logical_x] = *physical_x_it;
             if (physical_x_to_logical_x.find(*physical_x_it) != physical_x_to_logical_x.end()) {
@@ -145,7 +145,8 @@ void CoordinateManager::fill_logical_to_physical_mapping(
     }
 }
 
-void CoordinateManager::fill_logical_to_virtual_mapping(const std::set<size_t>& physical_x_unharvested, const std::set<size_t>& physical_y_unharvested) {
+void CoordinateManager::fill_logical_to_virtual_mapping(
+    const std::set<size_t>& physical_x_unharvested, const std::set<size_t>& physical_y_unharvested) {
     auto physical_y_it = physical_y_unharvested.begin();
     for (std::size_t y = 0; y < logical_y_to_virtual_y.size(); y++) {
         logical_y_to_virtual_y[y] = *physical_y_it;
@@ -176,7 +177,6 @@ std::unique_ptr<CoordinateManager> CoordinateManager::get_coordinate_manager(
     const tt_xy_pair& worker_grid_size,
     const std::vector<tt_xy_pair>& workers,
     std::size_t harvesting_mask) {
-
     switch (arch) {
         case tt::ARCH::GRAYSKULL:
             return std::make_unique<GrayskullCoordinateManager>(worker_grid_size, workers, harvesting_mask);

--- a/device/coordinate_manager.h
+++ b/device/coordinate_manager.h
@@ -7,17 +7,17 @@
 #pragma once
 
 #include <map>
-#include <vector>
 #include <set>
+#include <vector>
 
-#include "device/tt_xy_pair.h"
 #include "device/tt_arch_types.h"
+#include "device/tt_xy_pair.h"
 
 class CoordinateManager {
-
 public:
-    CoordinateManager(const tt_xy_pair& worker_grid_size, const std::vector<tt_xy_pair>& workers, std::size_t harvesting_mask)
-        : worker_grid_size(worker_grid_size), workers(workers), harvesting_mask(harvesting_mask) {}
+    CoordinateManager(
+        const tt_xy_pair& worker_grid_size, const std::vector<tt_xy_pair>& workers, std::size_t harvesting_mask) :
+        worker_grid_size(worker_grid_size), workers(workers), harvesting_mask(harvesting_mask) {}
 
     virtual void perform_harvesting(std::size_t harvesting_mask);
 
@@ -49,14 +49,17 @@ public:
 
 protected:
     virtual void clear_harvesting_structures();
-    
+
     virtual std::set<std::size_t> get_x_coordinates_to_harvest(std::size_t harvesting_mask);
     virtual std::set<std::size_t> get_y_coordinates_to_harvest(std::size_t harvesting_mask);
 
     virtual void fill_logical_to_physical_mapping(
-        const std::set<size_t>& x_to_harvest, const std::set<size_t>& y_to_harvest,
+        const std::set<size_t>& x_to_harvest,
+        const std::set<size_t>& y_to_harvest,
+        const std::set<size_t>& physical_x_unharvested,
+        const std::set<size_t>& physical_y_unharvested);
+    virtual void fill_logical_to_virtual_mapping(
         const std::set<size_t>& physical_x_unharvested, const std::set<size_t>& physical_y_unharvested);
-    virtual void fill_logical_to_virtual_mapping(const std::set<size_t>& physical_x_unharvested, const std::set<size_t>& physical_y_unharvested);
 
     std::map<std::size_t, std::size_t> physical_y_to_logical_y;
     std::map<std::size_t, std::size_t> physical_x_to_logical_x;

--- a/device/cpuset_lib.cpp
+++ b/device/cpuset_lib.cpp
@@ -2,17 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <algorithm>
-
 #include "cpuset_lib.hpp"
-#include "common/logger.hpp"
-#include <thread>
-#include "device/cluster.h"
+
+#include <algorithm>
 #include <filesystem>
+#include <thread>
+
+#include "common/logger.hpp"
+#include "device/cluster.h"
 #include "fmt/core.h"
+
 namespace tt {
 
 namespace fs = std::filesystem;
+
 namespace cpuset {
 
 /////////////////////////////////////////////////////////////////////////
@@ -21,15 +24,18 @@ namespace cpuset {
 
 // Constructor for singleton class cpu id allocator
 tt_cpuset_allocator::tt_cpuset_allocator() {
-
-    m_pid           = getpid();
-    m_debug         = std::getenv("TT_BACKEND_CPUSET_ALLOCATOR_DEBUG") ? true : false;
+    m_pid = getpid();
+    m_debug = std::getenv("TT_BACKEND_CPUSET_ALLOCATOR_DEBUG") ? true : false;
 
     // Chicken bit to disable this entire feature for debug/comparison.
     bool cpuset_allocator_enable_env = std::getenv("TT_BACKEND_CPUSET_ALLOCATOR_ENABLE") ? true : false;
 
     auto system_tid = std::this_thread::get_id();
-    log_debug(LogSiliconDriver, "Starting tt_cpuset_allocator constructor now for process_id: {} thread_id: {}", m_pid, system_tid);
+    log_debug(
+        LogSiliconDriver,
+        "Starting tt_cpuset_allocator constructor now for process_id: {} thread_id: {}",
+        m_pid,
+        system_tid);
 
     m_enable_cpuset_allocator = true;
 
@@ -38,86 +44,102 @@ tt_cpuset_allocator::tt_cpuset_allocator() {
     m_enable_cpuset_allocator &= init_get_number_of_packages();
     m_enable_cpuset_allocator &= init_find_tt_pci_devices_packages_numanodes();
 
-    if (!cpuset_allocator_enable_env){
+    if (!cpuset_allocator_enable_env) {
         m_enable_cpuset_allocator = false;
-    }else{
+    } else {
+        bool is_cpu_supported = init_is_cpu_model_supported();
 
-        bool is_cpu_supported      = init_is_cpu_model_supported();
-
-        if (is_cpu_supported){
+        if (is_cpu_supported) {
             m_enable_cpuset_allocator &= init_determine_cpuset_allocations();
-        }else{
+        } else {
             m_enable_cpuset_allocator = false;
         }
 
-        log_debug(LogSiliconDriver,"Finished tt_cpuset_allocator constructor now with m_enable_cpuset_allocator: {} for process_id: {} thread_id: {} ", m_enable_cpuset_allocator, m_pid, system_tid);
+        log_debug(
+            LogSiliconDriver,
+            "Finished tt_cpuset_allocator constructor now with m_enable_cpuset_allocator: {} for process_id: {} "
+            "thread_id: {} ",
+            m_enable_cpuset_allocator,
+            m_pid,
+            system_tid);
     }
 }
 
 // Step 1 : Initialize and perform m_topology detection
-bool tt_cpuset_allocator::init_topology_init_and_load(){
-    log_debug(LogSiliconDriver,"Inside tt_cpuset_allocator::topology_init_and_load()");
+bool tt_cpuset_allocator::init_topology_init_and_load() {
+    log_debug(LogSiliconDriver, "Inside tt_cpuset_allocator::topology_init_and_load()");
 
-    if (!m_enable_cpuset_allocator){
+    if (!m_enable_cpuset_allocator) {
         return false;
     }
 
-    if (hwloc_topology_init(&m_topology)){
+    if (hwloc_topology_init(&m_topology)) {
         log_warning(LogSiliconDriver, "Problem initializing topology");
         return false;
     }
 
-    hwloc_topology_set_type_filter(m_topology, HWLOC_OBJ_PCI_DEVICE, HWLOC_TYPE_FILTER_KEEP_ALL); // Need to find PCI devices.
+    hwloc_topology_set_type_filter(
+        m_topology, HWLOC_OBJ_PCI_DEVICE, HWLOC_TYPE_FILTER_KEEP_ALL);  // Need to find PCI devices.
 
-    if (hwloc_topology_load(m_topology)){
+    if (hwloc_topology_load(m_topology)) {
         log_warning(LogSiliconDriver, "Problem loading topology");
         return false;
     }
 
-    return true; // Success
+    return true;  // Success
 }
 
-// Step 2 - Find TT PCI devices in topology by vendor_id to get their PCI bus_id and physical device_id, and package and numamode.
-bool tt_cpuset_allocator::init_find_tt_pci_devices_packages_numanodes(){
-
-    if (!m_enable_cpuset_allocator){
+// Step 2 - Find TT PCI devices in topology by vendor_id to get their PCI bus_id and physical device_id, and package and
+// numamode.
+bool tt_cpuset_allocator::init_find_tt_pci_devices_packages_numanodes() {
+    if (!m_enable_cpuset_allocator) {
         return false;
     }
 
-    log_debug(LogSiliconDriver,"Starting tt_cpuset_allocator::init_find_tt_pci_devices_packages_numanodes()");
+    log_debug(LogSiliconDriver, "Starting tt_cpuset_allocator::init_find_tt_pci_devices_packages_numanodes()");
     m_num_tt_device_by_pci_device_id_map.clear();
 
     hwloc_obj_t pci_device_obj = NULL;
     const std::regex tt_device_re("tenstorrent!([0-9]+)");
 
-    while ((pci_device_obj = hwloc_get_next_pcidev(m_topology, pci_device_obj))){
-
-        if (hwloc_obj_type_is_io(pci_device_obj->type) && (pci_device_obj->attr->pcidev.vendor_id == TENSTORRENT_VENDOR_ID)) {
-
-            std::pair<uint16_t, uint16_t> device_id_revision = std::make_pair(pci_device_obj->attr->pcidev.device_id, pci_device_obj->attr->pcidev.revision);
+    while ((pci_device_obj = hwloc_get_next_pcidev(m_topology, pci_device_obj))) {
+        if (hwloc_obj_type_is_io(pci_device_obj->type) &&
+            (pci_device_obj->attr->pcidev.vendor_id == TENSTORRENT_VENDOR_ID)) {
+            std::pair<uint16_t, uint16_t> device_id_revision =
+                std::make_pair(pci_device_obj->attr->pcidev.device_id, pci_device_obj->attr->pcidev.revision);
             m_num_tt_device_by_pci_device_id_map[device_id_revision] += 1;
 
-            std::string pci_bus_id_str  = get_pci_bus_id(pci_device_obj);
+            std::string pci_bus_id_str = get_pci_bus_id(pci_device_obj);
             std::string pci_device_dir = fmt::format("/sys/bus/pci/devices/{}/tenstorrent/", pci_bus_id_str);
             int physical_device_id = -1;
 
-            log_trace(LogSiliconDriver, "Found TT device with pci_bus_id_str: {} num_devices_by_pci_device_id: {}", pci_bus_id_str, m_num_tt_device_by_pci_device_id_map[device_id_revision]);
+            log_trace(
+                LogSiliconDriver,
+                "Found TT device with pci_bus_id_str: {} num_devices_by_pci_device_id: {}",
+                pci_bus_id_str,
+                m_num_tt_device_by_pci_device_id_map[device_id_revision]);
 
             // First, get the physical_device_id of the device.
-            if (fs::exists(pci_device_dir)){
-                for (const auto &entry : fs::directory_iterator(pci_device_dir)){
+            if (fs::exists(pci_device_dir)) {
+                for (const auto &entry : fs::directory_iterator(pci_device_dir)) {
                     auto entry_str = entry.path().string();
 
-                    if (std::smatch device_match; std::regex_search(entry_str, device_match, tt_device_re) and (stoi(device_match[1]) >= 0)){
+                    if (std::smatch device_match;
+                        std::regex_search(entry_str, device_match, tt_device_re) and (stoi(device_match[1]) >= 0)) {
                         physical_device_id = stoi(device_match[1]);
                         m_all_tt_devices.push_back(physical_device_id);
-                        log_debug(LogSiliconDriver, "Found physical_device_id: {} from file: {}", physical_device_id, entry_str);
+                        log_debug(
+                            LogSiliconDriver,
+                            "Found physical_device_id: {} from file: {}",
+                            physical_device_id,
+                            entry_str);
                         break;
                     }
                 }
 
-                if (physical_device_id == -1){
-                    log_warning(LogSiliconDriver, "Did not find file containing physical_device_id in {}", pci_device_dir);
+                if (physical_device_id == -1) {
+                    log_warning(
+                        LogSiliconDriver, "Did not find file containing physical_device_id in {}", pci_device_dir);
                     return false;
                 }
 
@@ -125,19 +147,23 @@ bool tt_cpuset_allocator::init_find_tt_pci_devices_packages_numanodes(){
 
                 // Next, get the PackageID of the device and update maps.
                 auto package_id = get_package_id_from_device(pci_device_obj, physical_device_id);
-                
-                // This package was not previously seen. Initialize structures tracking the TT Devices mapped to this 
+
+                // This package was not previously seen. Initialize structures tracking the TT Devices mapped to this
                 // package and structures storing the CPU characteristics per package.
                 if (m_package_id_to_devices_map.find(package_id) == m_package_id_to_devices_map.end()) {
                     m_package_id_to_devices_map.insert({package_id, {}});
                     m_package_id_to_num_l3_per_ccx_map.insert({package_id, 0});
                     m_package_id_to_num_ccx_per_ccd_map.insert({package_id, 0});
                 }
-                if (package_id != -1){
+                if (package_id != -1) {
                     m_package_id_to_devices_map.at(package_id).push_back(physical_device_id);
                     m_physical_device_id_to_package_id_map.insert({physical_device_id, package_id});
                 } else {
-                    log_warning(LogSiliconDriver, "Could not find package_id for TT Device (physical_device_id: {} pci_bus_id: {})", physical_device_id, pci_bus_id_str);
+                    log_warning(
+                        LogSiliconDriver,
+                        "Could not find package_id for TT Device (physical_device_id: {} pci_bus_id: {})",
+                        physical_device_id,
+                        pci_bus_id_str);
                     return false;
                 }
 
@@ -145,378 +171,479 @@ bool tt_cpuset_allocator::init_find_tt_pci_devices_packages_numanodes(){
                 auto numa_nodeset = get_numa_nodeset_from_device(pci_device_obj, physical_device_id);
                 m_physical_device_id_to_numa_nodeset_map.insert({physical_device_id, numa_nodeset});
 
-                if (numa_nodeset == 0x0){
-                    log_warning(LogSiliconDriver, "Could not find NumaNodeSet for TT Device (physical_device_id: {} pci_bus_id: {})", physical_device_id, pci_bus_id_str);
+                if (numa_nodeset == 0x0) {
+                    log_warning(
+                        LogSiliconDriver,
+                        "Could not find NumaNodeSet for TT Device (physical_device_id: {} pci_bus_id: {})",
+                        physical_device_id,
+                        pci_bus_id_str);
                     return false;
                 }
 
-                m_physical_device_id_to_cpusets_map.insert({physical_device_id, {}}); // Empty vector.
+                m_physical_device_id_to_cpusets_map.insert({physical_device_id, {}});  // Empty vector.
                 m_num_cpu_cores_allocated_per_tt_device.insert({physical_device_id, 0});
             }
         }
     }
 
-    if (m_all_tt_devices.size() == 0){
-        log_warning(LogSiliconDriver, "Did not find any PCI devices matching Tenstorrent vendor_id 0x{:x}", TENSTORRENT_VENDOR_ID);
+    if (m_all_tt_devices.size() == 0) {
+        log_warning(
+            LogSiliconDriver,
+            "Did not find any PCI devices matching Tenstorrent vendor_id 0x{:x}",
+            TENSTORRENT_VENDOR_ID);
         return false;
     }
 
-    log_debug(LogSiliconDriver,"Finshed tt_cpuset_allocator::init_find_tt_pci_devices_packages_numanodes() found {} devices", m_all_tt_devices.size());
-
+    log_debug(
+        LogSiliconDriver,
+        "Finshed tt_cpuset_allocator::init_find_tt_pci_devices_packages_numanodes() found {} devices",
+        m_all_tt_devices.size());
 
     // Sort these 2 vectors of device_ids before we are done, since discovery can be in any order.
-    for (auto &p: m_package_id_to_devices_map){
+    for (auto &p : m_package_id_to_devices_map) {
         std::sort(p.second.begin(), p.second.end());
     }
 
     std::sort(m_all_tt_devices.begin(), m_all_tt_devices.end());
 
-    return true; // Success
+    return true;  // Success
 }
 
-
 // Step 3 : Detect the number of packages.
-bool tt_cpuset_allocator::init_get_number_of_packages(){
-
-    if (!m_enable_cpuset_allocator){
+bool tt_cpuset_allocator::init_get_number_of_packages() {
+    if (!m_enable_cpuset_allocator) {
         return false;
     }
 
     m_num_packages = hwloc_get_nbobjs_by_type(m_topology, HWLOC_OBJ_PACKAGE);
-    log_debug(LogSiliconDriver,"Found {} CPU packages", m_num_packages);
-    return m_num_packages > 0; // Success
+    log_debug(LogSiliconDriver, "Found {} CPU packages", m_num_packages);
+    return m_num_packages > 0;  // Success
 }
 
 // Step 4 : Return true if all packages are models we want to support. Env-var can be used to ignore this check.
-bool tt_cpuset_allocator::init_is_cpu_model_supported(){
-
-    if (!m_enable_cpuset_allocator){
+bool tt_cpuset_allocator::init_is_cpu_model_supported() {
+    if (!m_enable_cpuset_allocator) {
         return false;
     }
 
-    if (m_num_packages == 0){
-        log_debug(LogSiliconDriver,"init_is_cpu_model_supported(): Found 0 packages, functions run out of order?");
+    if (m_num_packages == 0) {
+        log_debug(LogSiliconDriver, "init_is_cpu_model_supported(): Found 0 packages, functions run out of order?");
         return false;
     }
 
     bool use_any_cpu = std::getenv("TT_BACKEND_CPUSET_ALLOCATOR_SUPPORT_ANY_CPU") ? true : false;
 
-    log_debug(LogSiliconDriver,"Inside tt_cpuset_allocator::check_if_cpu_model_supported()");
+    log_debug(LogSiliconDriver, "Inside tt_cpuset_allocator::check_if_cpu_model_supported()");
 
     // Supported CPU Models for enabling CPUSET Allocator.  Keep the list small to production machines to start.
-    std::vector<std::string> supported_cpu_models = {   "AMD EPYC 7352 24-Core Processor",
-                                                        "AMD EPYC 7532 32-Core Processor"};
+    std::vector<std::string> supported_cpu_models = {
+        "AMD EPYC 7352 24-Core Processor", "AMD EPYC 7532 32-Core Processor"};
 
     // CPU Models that have L3 per CCX and 2 CCX per CCD
-    std::vector<std::string> opt_2ccx_per_ccd_cpu_models = {    "AMD EPYC 7352 24-Core Processor",
-                                                                "AMD EPYC 7532 32-Core Processor"};
-    for(const auto& package: m_package_id_to_devices_map) {
+    std::vector<std::string> opt_2ccx_per_ccd_cpu_models = {
+        "AMD EPYC 7352 24-Core Processor", "AMD EPYC 7532 32-Core Processor"};
+    for (const auto &package : m_package_id_to_devices_map) {
         int package_id = package.first;
         auto package_obj = hwloc_get_obj_by_type(m_topology, HWLOC_OBJ_PACKAGE, package_id);
-        if (m_debug) print_hwloc_object(package_obj, 0, true, true);
+        if (m_debug) {
+            print_hwloc_object(package_obj, 0, true, true);
+        }
 
         std::string pkg_cpu_model = hwloc_obj_get_info_by_name(package_obj, "CPUModel");
 
         // First find out if this CPU is supported by CPUSET Allocator at all.
         bool has_supported_cpu = use_any_cpu ? true : false;
 
-        for (auto &supported_cpu_model : supported_cpu_models){
+        for (auto &supported_cpu_model : supported_cpu_models) {
             has_supported_cpu |= (pkg_cpu_model.find(supported_cpu_model) != std::string::npos);
         }
 
-        log_debug(LogSiliconDriver,"Detected package-id: {} has_supported_cpu: {} for CpuModel: {}", package_id, has_supported_cpu, pkg_cpu_model);
+        log_debug(
+            LogSiliconDriver,
+            "Detected package-id: {} has_supported_cpu: {} for CpuModel: {}",
+            package_id,
+            has_supported_cpu,
+            pkg_cpu_model);
 
-        if (!has_supported_cpu){
+        if (!has_supported_cpu) {
             return false;
         }
 
         // Then, determine if the 2CCX-PER-CCD optimization can be enabled for this CPU Model in the package.
-        for (auto &opt_cpu_model : opt_2ccx_per_ccd_cpu_models){
-            if (pkg_cpu_model.find(opt_cpu_model) != std::string::npos){
+        for (auto &opt_cpu_model : opt_2ccx_per_ccd_cpu_models) {
+            if (pkg_cpu_model.find(opt_cpu_model) != std::string::npos) {
                 m_package_id_to_num_l3_per_ccx_map.at(package_id) = 1;
                 m_package_id_to_num_ccx_per_ccd_map.at(package_id) = 2;
             }
         }
     }
 
-    return true; // Successhwloc
+    return true;  // Successhwloc
 }
 
-
-// Step 5: Get all target allocation objects (ie. L3Cache if IO thread to be allocated per L3Cache cpuset) for a given socket/package.
-bool tt_cpuset_allocator::init_determine_cpuset_allocations(){
-
-    if (!m_enable_cpuset_allocator){
+// Step 5: Get all target allocation objects (ie. L3Cache if IO thread to be allocated per L3Cache cpuset) for a given
+// socket/package.
+bool tt_cpuset_allocator::init_determine_cpuset_allocations() {
+    if (!m_enable_cpuset_allocator) {
         return false;
     }
 
-    log_debug(LogSiliconDriver,"Inside tt_cpuset_allocator::init_determine_cpuset_allocations()");
-    for (const auto& package : m_package_id_to_devices_map) {
+    log_debug(LogSiliconDriver, "Inside tt_cpuset_allocator::init_determine_cpuset_allocations()");
+    for (const auto &package : m_package_id_to_devices_map) {
         int package_id = package.first;
         auto num_tt_devices_for_cpu_package = package.second.size();
 
-        if (num_tt_devices_for_cpu_package == 0){
-            log_debug(LogSiliconDriver, "init_determine_cpuset_allocations() -- no TT devices for package_id: {}, skipping.", package_id);
+        if (num_tt_devices_for_cpu_package == 0) {
+            log_debug(
+                LogSiliconDriver,
+                "init_determine_cpuset_allocations() -- no TT devices for package_id: {}, skipping.",
+                package_id);
             continue;
         }
 
-        log_debug(LogSiliconDriver, "init_determine_cpuset_allocations(). starting to detect allocation slots for package_id: {} ", package_id);
+        log_debug(
+            LogSiliconDriver,
+            "init_determine_cpuset_allocations(). starting to detect allocation slots for package_id: {} ",
+            package_id);
 
         auto package_obj = hwloc_get_obj_by_type(m_topology, HWLOC_OBJ_PACKAGE, package_id);
-        if (m_debug) print_hwloc_object(package_obj, 0, true, true);
+        if (m_debug) {
+            print_hwloc_object(package_obj, 0, true, true);
+        }
 
-        auto num_alloc_slots_in_package = hwloc_get_nbobjs_inside_cpuset_by_type(m_topology, package_obj->cpuset, m_object_per_alloc_slot);
-        if (num_alloc_slots_in_package == 0){
-            log_warning(LogSiliconDriver, "Could not find any of the alloc objects in package_id: {} for this cpu arc", package_id);
+        auto num_alloc_slots_in_package =
+            hwloc_get_nbobjs_inside_cpuset_by_type(m_topology, package_obj->cpuset, m_object_per_alloc_slot);
+        if (num_alloc_slots_in_package == 0) {
+            log_warning(
+                LogSiliconDriver,
+                "Could not find any of the alloc objects in package_id: {} for this cpu arc",
+                package_id);
             return false;
         }
         auto num_alloc_slots_per_tt_device = num_alloc_slots_in_package / num_tt_devices_for_cpu_package;
 
         // Above splits evenly by devices, leaves remainder unused in the example case of 3 devices but 8 slots.
-        log_debug(LogSiliconDriver, "init_determine_cpuset_allocations(). package_id: {} num_alloc_slots_in_package: {} num_tt_devices_for_cpu_package: {} num_alloc_slots_per_tt_device: {}",
-            package_id, num_alloc_slots_in_package, num_tt_devices_for_cpu_package, num_alloc_slots_per_tt_device);
+        log_debug(
+            LogSiliconDriver,
+            "init_determine_cpuset_allocations(). package_id: {} num_alloc_slots_in_package: {} "
+            "num_tt_devices_for_cpu_package: {} num_alloc_slots_per_tt_device: {}",
+            package_id,
+            num_alloc_slots_in_package,
+            num_tt_devices_for_cpu_package,
+            num_alloc_slots_per_tt_device);
 
         int device_idx = 0;
 
-        for (int obj_idx = 0; obj_idx < num_alloc_slots_in_package; obj_idx++){
+        for (int obj_idx = 0; obj_idx < num_alloc_slots_in_package; obj_idx++) {
+            auto obj = hwloc_get_obj_below_by_type(
+                m_topology, HWLOC_OBJ_PACKAGE, package_id, m_object_per_alloc_slot, obj_idx);
 
-            auto obj = hwloc_get_obj_below_by_type(m_topology, HWLOC_OBJ_PACKAGE, package_id, m_object_per_alloc_slot, obj_idx);
-
-            if (obj){
-                if (m_debug) print_hwloc_object(obj, 1, true);
+            if (obj) {
+                if (m_debug) {
+                    print_hwloc_object(obj, 1, true);
+                }
 
                 auto physical_device_id = m_package_id_to_devices_map.at(package_id).at(device_idx);
 
                 // Hack for maximum number of slots per device.
                 // if (m_physical_device_id_to_cpusets_map.at(physical_device_id).size() < 2){
                 m_physical_device_id_to_cpusets_map.at(physical_device_id).push_back(obj->cpuset);
-                int num_cpus = hwloc_get_nbobjs_inside_cpuset_by_type(m_topology,obj->cpuset,HWLOC_OBJ_CORE);
+                int num_cpus = hwloc_get_nbobjs_inside_cpuset_by_type(m_topology, obj->cpuset, HWLOC_OBJ_CORE);
                 m_num_cpu_cores_allocated_per_tt_device.at(physical_device_id) += num_cpus;
                 // }
 
                 // We're distributing allocation objects per package across TT devices, so switch to next one.
-                if (((obj_idx + 1) % num_alloc_slots_per_tt_device) == 0){
-                    device_idx = (device_idx + 1) % num_tt_devices_for_cpu_package; // Loop around if extra slots remain. Assigned to first device for that package.
+                if (((obj_idx + 1) % num_alloc_slots_per_tt_device) == 0) {
+                    device_idx = (device_idx + 1) %
+                                 num_tt_devices_for_cpu_package;  // Loop around if extra slots remain. Assigned to
+                                                                  // first device for that package.
                 }
 
-            }else{
-                log_warning(LogSiliconDriver, "init_determine_cpuset_allocations(). Something went wrong looking for cpuset alloc object under package");
+            } else {
+                log_warning(
+                    LogSiliconDriver,
+                    "init_determine_cpuset_allocations(). Something went wrong looking for cpuset alloc object under "
+                    "package");
                 return false;
             }
         }
 
-        log_debug(LogSiliconDriver, "init_determine_cpuset_allocations(). Done detecting allocation slots for package_id: {} ", package_id);
+        log_debug(
+            LogSiliconDriver,
+            "init_determine_cpuset_allocations(). Done detecting allocation slots for package_id: {} ",
+            package_id);
     }
 
-
     // Summary for Debug purposes.
-    for (auto &physical_device_id : m_all_tt_devices){
-        for (size_t device_alloc_idx=0; device_alloc_idx < m_physical_device_id_to_cpusets_map.at(physical_device_id).size(); device_alloc_idx++){
+    for (auto &physical_device_id : m_all_tt_devices) {
+        for (size_t device_alloc_idx = 0;
+             device_alloc_idx < m_physical_device_id_to_cpusets_map.at(physical_device_id).size();
+             device_alloc_idx++) {
             auto cpuset = m_physical_device_id_to_cpusets_map.at(physical_device_id).at(device_alloc_idx);
             auto pu_ids_vector = get_hwloc_bitmap_vector(cpuset);
             auto num_pu_ids = pu_ids_vector.size();
             auto package_id = m_physical_device_id_to_package_id_map.at(physical_device_id);
-            log_debug(LogSiliconDriver, "Done init_determine_cpuset_allocations(). Summary => for mmio physical_device_id: {} package_id: {} device_alloc_idx: {} picked {} PU's {}", physical_device_id, package_id, device_alloc_idx, num_pu_ids, pu_ids_vector);
+            log_debug(
+                LogSiliconDriver,
+                "Done init_determine_cpuset_allocations(). Summary => for mmio physical_device_id: {} package_id: {} "
+                "device_alloc_idx: {} picked {} PU's {}",
+                physical_device_id,
+                package_id,
+                device_alloc_idx,
+                num_pu_ids,
+                pu_ids_vector);
         }
     }
 
-    return true; // Success
-
+    return true;  // Success
 }
 
 /////////////////////////////////////////////////////////////////////////
 // Runtime Functions ////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////
 
-// Given a physical device_id, determine the right numa nodes associated with it and attempt to membind a previously allocated memory region to it.
-bool tt_cpuset_allocator::bind_area_memory_nodeset(chip_id_t physical_device_id, const void * addr, size_t len){
-
+// Given a physical device_id, determine the right numa nodes associated with it and attempt to membind a previously
+// allocated memory region to it.
+bool tt_cpuset_allocator::bind_area_memory_nodeset(chip_id_t physical_device_id, const void *addr, size_t len) {
     auto tid = std::this_thread::get_id();
-    log_debug(LogSiliconDriver,"bind_area_memory_nodeset(): Going to attempt memory binding of addr/len to NumaNode for physical_device_id: {} (pid: {} tid: {})", physical_device_id, m_pid, tid);
+    log_debug(
+        LogSiliconDriver,
+        "bind_area_memory_nodeset(): Going to attempt memory binding of addr/len to NumaNode for physical_device_id: "
+        "{} (pid: {} tid: {})",
+        physical_device_id,
+        m_pid,
+        tid);
 
-    if (m_physical_device_id_to_numa_nodeset_map.count(physical_device_id) == 0){
-        log_fatal("bind_area_memory_nodeset(): Did not find physical_device_id: {} in numanode_mask map, this is not expected.", physical_device_id);
+    if (m_physical_device_id_to_numa_nodeset_map.count(physical_device_id) == 0) {
+        log_fatal(
+            "bind_area_memory_nodeset(): Did not find physical_device_id: {} in numanode_mask map, this is not "
+            "expected.",
+            physical_device_id);
         return false;
     }
 
     auto target_nodeset = m_physical_device_id_to_numa_nodeset_map.at(physical_device_id);
 
-    if (target_nodeset != 0){
-        if (hwloc_set_area_membind(m_topology, addr, len, target_nodeset, HWLOC_MEMBIND_BIND, HWLOC_MEMBIND_BYNODESET | HWLOC_MEMBIND_STRICT | HWLOC_MEMBIND_MIGRATE) ){
-            log_warning(LogSiliconDriver,"hwloc_set_area_membind(): failed for physical_device_id: {} on NodeSet: {} with errno: {} (pid: {} tid: {})", 
-                physical_device_id, get_hwloc_bitmap_vector(target_nodeset), strerror(errno), m_pid, tid);
+    if (target_nodeset != 0) {
+        if (hwloc_set_area_membind(
+                m_topology,
+                addr,
+                len,
+                target_nodeset,
+                HWLOC_MEMBIND_BIND,
+                HWLOC_MEMBIND_BYNODESET | HWLOC_MEMBIND_STRICT | HWLOC_MEMBIND_MIGRATE)) {
+            log_warning(
+                LogSiliconDriver,
+                "hwloc_set_area_membind(): failed for physical_device_id: {} on NodeSet: {} with errno: {} (pid: {} "
+                "tid: {})",
+                physical_device_id,
+                get_hwloc_bitmap_vector(target_nodeset),
+                strerror(errno),
+                m_pid,
+                tid);
             return false;
-        }else{
-            log_debug(LogSiliconDriver,"hwloc_set_area_membind(): success for physical_device_id: {} on NodeSet: {} (pid: {} tid: {})", physical_device_id, get_hwloc_bitmap_vector(target_nodeset), m_pid, tid);
+        } else {
+            log_debug(
+                LogSiliconDriver,
+                "hwloc_set_area_membind(): success for physical_device_id: {} on NodeSet: {} (pid: {} tid: {})",
+                physical_device_id,
+                get_hwloc_bitmap_vector(target_nodeset),
+                m_pid,
+                tid);
         }
-    }else{
-        log_warning(LogSiliconDriver,"bind_area_memory_nodeset(): Unable to determine TT Device to NumaNode mapping for physical_device_id: {}. Skipping membind.", physical_device_id);
+    } else {
+        log_warning(
+            LogSiliconDriver,
+            "bind_area_memory_nodeset(): Unable to determine TT Device to NumaNode mapping for physical_device_id: {}. "
+            "Skipping membind.",
+            physical_device_id);
         return false;
     }
 
-    return true; // Success
+    return true;  // Success
 }
 
 int tt_cpuset_allocator::_get_num_tt_pci_devices() {
-
     for (auto &d : m_physical_device_id_to_package_id_map) {
         log_trace(LogSiliconDriver, "Found physical_device_id: {} ", d.first);
     }
     return m_physical_device_id_to_package_id_map.size();
 }
 
-
-
-
 /////////////////////////////////////////////////////////////////////////
-//Helper Functions //////////////////////////////////////////////////////
+// Helper Functions //////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////
 
-
-std::string tt_cpuset_allocator::get_pci_bus_id(hwloc_obj_t pci_device_obj){
-
+std::string tt_cpuset_allocator::get_pci_bus_id(hwloc_obj_t pci_device_obj) {
     std::string pci_bus_id_str = "";
 
-    if (hwloc_obj_type_is_io(pci_device_obj->type)) {        
+    if (hwloc_obj_type_is_io(pci_device_obj->type)) {
         auto attrs = pci_device_obj->attr->pcidev;
         pci_bus_id_str = fmt::format("{:04x}:{:02x}:{:02x}.{:01x}", attrs.domain, attrs.bus, attrs.dev, attrs.func);
     }
 
     return pci_bus_id_str;
-
 }
 
-int tt_cpuset_allocator::get_package_id_from_device(hwloc_obj_t pci_device_obj, chip_id_t physical_device_id){
-
+int tt_cpuset_allocator::get_package_id_from_device(hwloc_obj_t pci_device_obj, chip_id_t physical_device_id) {
     auto pci_bus_id_str = m_physical_device_id_to_pci_bus_id_map.at(physical_device_id);
 
-    log_debug(LogSiliconDriver, "Checking TT device (physical_device_id: {} pci_bus_id: {}) to find it's corresponding CPU package", physical_device_id, pci_bus_id_str);
+    log_debug(
+        LogSiliconDriver,
+        "Checking TT device (physical_device_id: {} pci_bus_id: {}) to find it's corresponding CPU package",
+        physical_device_id,
+        pci_bus_id_str);
 
     hwloc_obj_t tmp_obj = hwloc_get_non_io_ancestor_obj(m_topology, pci_device_obj);
     int package_id = -1;
 
     // Keep going up until package/machine hierarchy is found, in case we don't find it right away.
-    while (package_id == -1){
-
-        if ((hwloc_compare_types(tmp_obj->type, HWLOC_OBJ_PACKAGE) == 0) || (hwloc_compare_types(tmp_obj->type, HWLOC_OBJ_MACHINE) == 0)){
-            if (tmp_obj->os_index != (unsigned) -1){
+    while (package_id == -1) {
+        if ((hwloc_compare_types(tmp_obj->type, HWLOC_OBJ_PACKAGE) == 0) ||
+            (hwloc_compare_types(tmp_obj->type, HWLOC_OBJ_MACHINE) == 0)) {
+            if (tmp_obj->os_index != (unsigned)-1) {
                 package_id = tmp_obj->os_index;
-            }else{
-                log_warning(LogSiliconDriver, "Could not find os_index of package or machine object for TT device (physical_device_id: {} pci_bus_id: {})", physical_device_id, pci_bus_id_str);
+            } else {
+                log_warning(
+                    LogSiliconDriver,
+                    "Could not find os_index of package or machine object for TT device (physical_device_id: {} "
+                    "pci_bus_id: {})",
+                    physical_device_id,
+                    pci_bus_id_str);
                 break;
             }
-        }else{
-            if (tmp_obj->parent){
+        } else {
+            if (tmp_obj->parent) {
                 tmp_obj = tmp_obj->parent;
-            }else{
+            } else {
                 break;
             }
         }
     }
 
-    if (m_debug) print_hwloc_object(pci_device_obj, 1, true, true);
-    if (m_debug) print_hwloc_object(tmp_obj, 1, true, true);
+    if (m_debug) {
+        print_hwloc_object(pci_device_obj, 1, true, true);
+    }
+    if (m_debug) {
+        print_hwloc_object(tmp_obj, 1, true, true);
+    }
 
     return package_id;
 }
 
-hwloc_nodeset_t tt_cpuset_allocator::get_numa_nodeset_from_device(hwloc_obj_t pci_device_obj, chip_id_t physical_device_id){
-
+hwloc_nodeset_t tt_cpuset_allocator::get_numa_nodeset_from_device(
+    hwloc_obj_t pci_device_obj, chip_id_t physical_device_id) {
     hwloc_nodeset_t nodeset = 0x0;
 
     // Currently an issue in non-EPYC machines where PCI devices are directly under Machine, and not any NumaNodes.
     // As quick workaround, skip this if there is only single numanode since returning 1 seems fine.
-    if (hwloc_get_nbobjs_by_type(m_topology, HWLOC_OBJ_NUMANODE) == 1){
+    if (hwloc_get_nbobjs_by_type(m_topology, HWLOC_OBJ_NUMANODE) == 1) {
         auto numanode = hwloc_get_obj_by_type(m_topology, HWLOC_OBJ_NUMANODE, 0);
         return numanode->nodeset;
     }
 
     auto pci_bus_id_str = m_physical_device_id_to_pci_bus_id_map.at(physical_device_id);
 
-    log_debug(LogSiliconDriver, "init_detect_tt_device_numanodes(): Checking TT device (physical_device_id: {} pci_bus_id: {}) to find it's corresponding NumaNode.", physical_device_id, pci_bus_id_str);
+    log_debug(
+        LogSiliconDriver,
+        "init_detect_tt_device_numanodes(): Checking TT device (physical_device_id: {} pci_bus_id: {}) to find it's "
+        "corresponding NumaNode.",
+        physical_device_id,
+        pci_bus_id_str);
 
     hwloc_obj_t tmp_obj = pci_device_obj->parent;
-    while (tmp_obj && !tmp_obj->memory_arity){
+    while (tmp_obj && !tmp_obj->memory_arity) {
         tmp_obj = tmp_obj->parent; /* no memory child, walk up */
     }
 
-    if (tmp_obj && tmp_obj->nodeset){
-        log_debug(LogSiliconDriver, "init_detect_tt_device_numanodes(): For TT device (physical_device_id: {} pci_bus_id: {}) found NumaNodeSet: {}", physical_device_id, pci_bus_id_str, get_hwloc_bitmap_vector(tmp_obj->nodeset));
+    if (tmp_obj && tmp_obj->nodeset) {
+        log_debug(
+            LogSiliconDriver,
+            "init_detect_tt_device_numanodes(): For TT device (physical_device_id: {} pci_bus_id: {}) found "
+            "NumaNodeSet: {}",
+            physical_device_id,
+            pci_bus_id_str,
+            get_hwloc_bitmap_vector(tmp_obj->nodeset));
         nodeset = tmp_obj->nodeset;
-    }else{
-        log_warning(LogSiliconDriver, "init_detect_tt_device_numanodes(): Could not determine NumaNodeSet for TT device (physical_device_id: {} pci_bus_id: {})", physical_device_id, pci_bus_id_str);
+    } else {
+        log_warning(
+            LogSiliconDriver,
+            "init_detect_tt_device_numanodes(): Could not determine NumaNodeSet for TT device (physical_device_id: {} "
+            "pci_bus_id: {})",
+            physical_device_id,
+            pci_bus_id_str);
     }
 
     return nodeset;
-
 }
 
 int tt_cpuset_allocator::_get_num_tt_pci_devices_by_pci_device_id(uint16_t device_id, uint16_t revision) {
-
     std::pair<uint16_t, uint16_t> device_id_revision = std::make_pair(device_id, revision);
 
     if (m_num_tt_device_by_pci_device_id_map.find(device_id_revision) != m_num_tt_device_by_pci_device_id_map.end()) {
         return m_num_tt_device_by_pci_device_id_map.at(device_id_revision);
     } else {
-        log_warning(LogSiliconDriver, "Cannot find any TT device with PCI device_id: 0x{:x} and revision: {} in topology.", device_id, revision);
+        log_warning(
+            LogSiliconDriver,
+            "Cannot find any TT device with PCI device_id: 0x{:x} and revision: {} in topology.",
+            device_id,
+            revision);
         return 0;
     }
 }
 
 /////////////////////////////////////////////////////////////////////////
-//Debug Functions ///////////////////////////////////////////////////////
+// Debug Functions ///////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////
 
 // Get all PU ids (or numa nodes) in a vector, for legacy/back-compat/debug purposes.
-std::vector<int> tt_cpuset_allocator::get_hwloc_bitmap_vector(hwloc_bitmap_t &bitmap){
-
+std::vector<int> tt_cpuset_allocator::get_hwloc_bitmap_vector(hwloc_bitmap_t &bitmap) {
     std::vector<int> indices;
     int index;
-    if (bitmap){
-        hwloc_bitmap_foreach_begin(index, bitmap)
-            indices.push_back(index);
+    if (bitmap) {
+        hwloc_bitmap_foreach_begin(index, bitmap) indices.push_back(index);
         hwloc_bitmap_foreach_end();
     }
     return indices;
 }
 
-std::vector<int> tt_cpuset_allocator::get_hwloc_cpuset_vector(hwloc_obj_t &obj){
+std::vector<int> tt_cpuset_allocator::get_hwloc_cpuset_vector(hwloc_obj_t &obj) {
     return get_hwloc_bitmap_vector(obj->cpuset);
 }
 
-std::vector<int> tt_cpuset_allocator::get_hwloc_nodeset_vector(hwloc_obj_t &obj){
+std::vector<int> tt_cpuset_allocator::get_hwloc_nodeset_vector(hwloc_obj_t &obj) {
     return get_hwloc_bitmap_vector(obj->nodeset);
 }
 
-
 // Nicer way to print pu ids as a vector on single line.
-void tt_cpuset_allocator::print_hwloc_cpuset(hwloc_obj_t &obj){
+void tt_cpuset_allocator::print_hwloc_cpuset(hwloc_obj_t &obj) {
     std::cout << " Number: " << hwloc_bitmap_weight(obj->cpuset) << " cpuset_pu_ids: " << get_hwloc_cpuset_vector(obj);
 }
 
-void tt_cpuset_allocator::print_hwloc_nodeset(hwloc_obj_t &obj){
-    std::cout << " Number: " << hwloc_bitmap_weight(obj->nodeset) << " nodeset node_ids: " << get_hwloc_nodeset_vector(obj);
+void tt_cpuset_allocator::print_hwloc_nodeset(hwloc_obj_t &obj) {
+    std::cout << " Number: " << hwloc_bitmap_weight(obj->nodeset)
+              << " nodeset node_ids: " << get_hwloc_nodeset_vector(obj);
 }
 
-void tt_cpuset_allocator::print_hwloc_object(hwloc_obj_t &obj, int depth, bool verbose, bool show_cpuids){
-
+void tt_cpuset_allocator::print_hwloc_object(hwloc_obj_t &obj, int depth, bool verbose, bool show_cpuids) {
     char type[32], attr[1024];
 
     hwloc_obj_type_snprintf(type, sizeof(type), obj, verbose);
-    printf("%*s%s", 2*depth, "", type);
-    if (obj->os_index != (unsigned) -1)
+    printf("%*s%s", 2 * depth, "", type);
+    if (obj->os_index != (unsigned)-1) {
         printf("#%u", obj->os_index);
+    }
     hwloc_obj_attr_snprintf(attr, sizeof(attr), obj, " ", verbose);
 
-    if (*attr)
+    if (*attr) {
         printf("(%s)", attr);
-    if (show_cpuids && obj->cpuset)
+    }
+    if (show_cpuids && obj->cpuset) {
         print_hwloc_cpuset(obj);
+    }
 
     printf("\n");
 }
 
-
 }  // namespace cpuset
 }  // namespace tt
-

--- a/device/cpuset_lib.hpp
+++ b/device/cpuset_lib.hpp
@@ -4,18 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 #pragma once
 
-#include <map>
-#include <vector>
-#include <string>
-#include <mutex>
-#include <thread>
 #include <unistd.h>
 
-#include "device/tt_cluster_descriptor.h" // For chip_id_t
+#include <map>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
 
+#include "device/tt_cluster_descriptor.h"  // For chip_id_t
 #include "hwloc.h"
 
 using tt_cluster_description = tt_ClusterDescriptor;
@@ -27,90 +26,87 @@ namespace cpuset {
 // CPU ID allocator for pinning threads to cpu_ids
 // It's a singleton that should be retrieved via get()
 struct tt_cpuset_allocator {
-    public:
+public:
+    tt_cpuset_allocator(tt_cpuset_allocator const &) = delete;
+    void operator=(tt_cpuset_allocator const &) = delete;
 
-        tt_cpuset_allocator(tt_cpuset_allocator const&)     = delete;
-        void operator=(tt_cpuset_allocator const&)          = delete;
+    // Bind an already allocated memory region to particular numa nodes
+    static bool bind_area_to_memory_nodeset(chip_id_t physical_device_id, const void *addr, size_t len) {
+        auto &instance = tt_cpuset_allocator::get();
+        return instance.bind_area_memory_nodeset(physical_device_id, addr, len);
+    }
 
-        // Bind an already allocated memory region to particular numa nodes
-        static bool bind_area_to_memory_nodeset(chip_id_t physical_device_id, const void * addr, size_t len){
-            auto& instance = tt_cpuset_allocator::get();
-            return instance.bind_area_memory_nodeset(physical_device_id, addr, len);
-        }
+    static int get_num_tt_pci_devices() {
+        auto &instance = tt_cpuset_allocator::get();
+        return instance._get_num_tt_pci_devices();
+    }
 
-        static int get_num_tt_pci_devices(){
-            auto& instance = tt_cpuset_allocator::get();
-            return instance._get_num_tt_pci_devices();
-        }
+    static int get_num_tt_pci_devices_by_pci_device_id(uint16_t device_id, uint16_t revision_id) {
+        auto &instance = tt_cpuset_allocator::get();
+        return instance._get_num_tt_pci_devices_by_pci_device_id(device_id, revision_id);
+    }
 
-        static int get_num_tt_pci_devices_by_pci_device_id(uint16_t device_id, uint16_t revision_id){
-            auto& instance = tt_cpuset_allocator::get();
-            return instance._get_num_tt_pci_devices_by_pci_device_id(device_id, revision_id);
-        }
+private:
+    static tt_cpuset_allocator &get() {
+        static tt_cpuset_allocator instance;
+        return instance;
+    }
 
-    private:
+    tt_cpuset_allocator();
 
-        static tt_cpuset_allocator& get() {
-            static tt_cpuset_allocator instance;
-            return instance;
-        }
+    int TENSTORRENT_VENDOR_ID = 0x1e52;
 
-        tt_cpuset_allocator();
+    bool bind_area_memory_nodeset(chip_id_t physical_device_id, const void *addr, size_t len);
+    int _get_num_tt_pci_devices();
+    int _get_num_tt_pci_devices_by_pci_device_id(uint16_t device_id, uint16_t revision_id);
 
-        int TENSTORRENT_VENDOR_ID = 0x1e52;
+    // Series of init functions, must be called in this order. Seperated out to support
+    // early exit in case of errors.
+    bool init_topology_init_and_load();
+    bool init_find_tt_pci_devices_packages_numanodes();
+    bool init_get_number_of_packages();
+    bool init_is_cpu_model_supported();
+    bool init_determine_cpuset_allocations();
 
-        bool bind_area_memory_nodeset(chip_id_t physical_device_id, const void * addr, size_t len);
-        int _get_num_tt_pci_devices();
-        int _get_num_tt_pci_devices_by_pci_device_id(uint16_t device_id, uint16_t revision_id);
+    // Helper Functions
+    std::string get_pci_bus_id(hwloc_obj_t pci_device_obj);
+    int get_package_id_from_device(hwloc_obj_t pci_device_obj, chip_id_t physical_device_id);
+    hwloc_nodeset_t get_numa_nodeset_from_device(hwloc_obj_t pci_device_obj, chip_id_t physical_device_id);
 
-        // Series of init functions, must be called in this order. Seperated out to support
-        // early exit in case of errors.
-        bool init_topology_init_and_load();
-        bool init_find_tt_pci_devices_packages_numanodes();
-        bool init_get_number_of_packages();
-        bool init_is_cpu_model_supported();
-        bool init_determine_cpuset_allocations();
+    // Debug Functions
+    void print_hwloc_cpuset(hwloc_obj_t &obj);
+    void print_hwloc_nodeset(hwloc_obj_t &obj);
+    void print_hwloc_object(hwloc_obj_t &obj, int depth = 0, bool verbose = false, bool show_cpuids = true);
+    std::vector<int> get_hwloc_bitmap_vector(hwloc_bitmap_t &bitmap);
+    std::vector<int> get_hwloc_cpuset_vector(hwloc_obj_t &obj);
+    std::vector<int> get_hwloc_nodeset_vector(hwloc_obj_t &obj);
+    hwloc_topology_t m_topology;
+    bool m_debug;
+    pid_t m_pid;
 
-        // Helper Functions
-        std::string get_pci_bus_id(hwloc_obj_t pci_device_obj);
-        int get_package_id_from_device(hwloc_obj_t pci_device_obj, chip_id_t physical_device_id);
-        hwloc_nodeset_t get_numa_nodeset_from_device(hwloc_obj_t pci_device_obj, chip_id_t physical_device_id);
+    // Items calculated by parsing system info, used by allocation algorithm:
+    std::map<int, std::vector<int>> m_package_id_to_devices_map;
+    std::map<int, std::string> m_physical_device_id_to_pci_bus_id_map;  // Debug/Info
+    std::map<std::pair<uint16_t, uint16_t>, int> m_num_tt_device_by_pci_device_id_map;
 
-        // Debug Functions
-        void print_hwloc_cpuset(hwloc_obj_t &obj);
-        void print_hwloc_nodeset(hwloc_obj_t &obj);
-        void print_hwloc_object(hwloc_obj_t &obj, int depth = 0, bool verbose = false, bool show_cpuids = true);
-        std::vector<int> get_hwloc_bitmap_vector(hwloc_bitmap_t &bitmap);
-        std::vector<int> get_hwloc_cpuset_vector(hwloc_obj_t &obj);
-        std::vector<int> get_hwloc_nodeset_vector(hwloc_obj_t &obj);
-        hwloc_topology_t m_topology;
-        bool m_debug;
-        pid_t m_pid;
+    std::map<chip_id_t, std::vector<hwloc_cpuset_t>> m_physical_device_id_to_cpusets_map;
+    std::map<chip_id_t, int> m_physical_device_id_to_package_id_map;
 
-        // Items calculated by parsing system info, used by allocation algorithm:
-        std::map<int, std::vector<int>> m_package_id_to_devices_map;
-        std::map<int, std::string> m_physical_device_id_to_pci_bus_id_map; // Debug/Info
-        std::map<std::pair<uint16_t, uint16_t>, int> m_num_tt_device_by_pci_device_id_map;
+    bool m_enable_cpuset_allocator = true;  // Enable feature, otherwise do nothing.
+    int m_num_packages = 0;
+    std::vector<int> m_all_tt_devices = {};
 
-        std::map<chip_id_t, std::vector<hwloc_cpuset_t>> m_physical_device_id_to_cpusets_map;
-        std::map<chip_id_t, int> m_physical_device_id_to_package_id_map;
+    hwloc_obj_type_t m_object_per_alloc_slot = HWLOC_OBJ_L3CACHE;  // Default
 
-        bool m_enable_cpuset_allocator = true; // Enable feature, otherwise do nothing.
-        int m_num_packages = 0;
-        std::vector<int> m_all_tt_devices = {};
+    // For 2CCX-PER-CCD Optimization detection.
+    std::map<int, int> m_package_id_to_num_l3_per_ccx_map;
+    std::map<int, int> m_package_id_to_num_ccx_per_ccd_map;
 
-        hwloc_obj_type_t m_object_per_alloc_slot = HWLOC_OBJ_L3CACHE; // Default
+    // Memory Binding
+    std::map<chip_id_t, hwloc_nodeset_t> m_physical_device_id_to_numa_nodeset_map;
 
-        // For 2CCX-PER-CCD Optimization detection.
-        std::map<int, int> m_package_id_to_num_l3_per_ccx_map;
-        std::map<int, int> m_package_id_to_num_ccx_per_ccd_map;
-
-        // Memory Binding
-        std::map<chip_id_t, hwloc_nodeset_t> m_physical_device_id_to_numa_nodeset_map;
-
-        // Helper for some dynamic multi-threading.
-        std::map<chip_id_t, int> m_num_cpu_cores_allocated_per_tt_device;
-
+    // Helper for some dynamic multi-threading.
+    std::map<chip_id_t, int> m_num_cpu_cores_allocated_per_tt_device;
 };
 
 template <typename T>

--- a/device/driver_atomics.h
+++ b/device/driver_atomics.h
@@ -12,54 +12,44 @@ namespace tt_driver_atomics {
 
 #if defined(__x86_64__) || defined(__i386__)
 // Store-Any barrier.
-static inline __attribute__((always_inline)) void sfence() {
-    _mm_sfence();
-}
+static inline __attribute__((always_inline)) void sfence() { _mm_sfence(); }
+
 // Load-Any barrier.
-static inline __attribute__((always_inline)) void lfence() {
-    _mm_lfence();
-}
+static inline __attribute__((always_inline)) void lfence() { _mm_lfence(); }
+
 // Any-Any barrier.
-static inline __attribute__((always_inline)) void mfence() {
-    _mm_mfence();
-}
+static inline __attribute__((always_inline)) void mfence() { _mm_mfence(); }
 
 #elif defined(__ARM_ARCH)
 
 static inline __attribute__((always_inline)) void sfence() {
     // Full memory barrier (full system). ARM does not have a Store-Any barrier.
     // https://developer.arm.com/documentation/100941/0101/Barriers
-    asm volatile ("DMB SY" : : : "memory");
+    asm volatile("DMB SY" : : : "memory");
 }
 
 static inline __attribute__((always_inline)) void lfence() {
     // Load-Any barrier (full system)
     // https://developer.arm.com/documentation/100941/0101/Barriers
-    asm volatile ("DMB LD" : : : "memory");
+    asm volatile("DMB LD" : : : "memory");
 }
 
 static inline __attribute__((always_inline)) void mfence() {
     // Full memory barrier (full system).
     // https://developer.arm.com/documentation/100941/0101/Barriers
-    asm volatile ("DMB SY" : : : "memory");
+    asm volatile("DMB SY" : : : "memory");
 }
 
 #elif defined(__riscv)
 
-static inline __attribute__((always_inline)) void sfence() {
-    asm volatile ("fence ow, ow" : : : "memory");
-}
+static inline __attribute__((always_inline)) void sfence() { asm volatile("fence ow, ow" : : : "memory"); }
 
-static inline __attribute__((always_inline)) void lfence() {
-    asm volatile ("fence ir, ir" : : : "memory");
-}
+static inline __attribute__((always_inline)) void lfence() { asm volatile("fence ir, ir" : : : "memory"); }
 
-static inline __attribute__((always_inline)) void mfence() {
-    asm volatile ("fence iorw, iorw" : : : "memory");
-}
+static inline __attribute__((always_inline)) void mfence() { asm volatile("fence iorw, iorw" : : : "memory"); }
 
 #else
 #error "Unsupported architecture"
 #endif
 
-} // namespace tt_driver_atomics
+}  // namespace tt_driver_atomics

--- a/device/grayskull/grayskull_coordinate_manager.h
+++ b/device/grayskull/grayskull_coordinate_manager.h
@@ -9,8 +9,8 @@
 #include "device/coordinate_manager.h"
 
 class GrayskullCoordinateManager : public CoordinateManager {
-
 public:
-    GrayskullCoordinateManager(const tt_xy_pair& worker_grid_size, const std::vector<tt_xy_pair>& workers, std::size_t harvesting_mask)
-        : CoordinateManager(worker_grid_size, workers, harvesting_mask) {}
+    GrayskullCoordinateManager(
+        const tt_xy_pair& worker_grid_size, const std::vector<tt_xy_pair>& workers, std::size_t harvesting_mask) :
+        CoordinateManager(worker_grid_size, workers, harvesting_mask) {}
 };

--- a/device/grayskull/grayskull_implementation.cpp
+++ b/device/grayskull/grayskull_implementation.cpp
@@ -4,13 +4,12 @@
 
 #include "grayskull_implementation.h"
 
-#include "src/firmware/riscv/grayskull/host_mem_address_map.h"
-#include "src/firmware/riscv/grayskull/eth_interface.h"
-
 #include "device/cluster.h"
+#include "src/firmware/riscv/grayskull/eth_interface.h"
+#include "src/firmware/riscv/grayskull/host_mem_address_map.h"
 
-constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 32; // source: noc_parameters.h, unique for GS
-constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6; // source: noc_parameters.h, common for GS && WH && BH
+constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 32;   // source: noc_parameters.h, unique for GS
+constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6;  // source: noc_parameters.h, common for GS && WH && BH
 
 namespace tt::umd {
 
@@ -90,7 +89,9 @@ std::pair<std::uint64_t, std::uint64_t> grayskull_implementation::get_tlb_data(
 }
 
 tt_driver_host_address_params grayskull_implementation::get_host_address_params() const {
-    return {::grayskull::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, ::grayskull::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
+    return {
+        ::grayskull::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE,
+        ::grayskull::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
 }
 
 tt_driver_eth_interface_params grayskull_implementation::get_eth_interface_params() const {

--- a/device/grayskull/grayskull_implementation.h
+++ b/device/grayskull/grayskull_implementation.h
@@ -104,7 +104,8 @@ enum class arc_message_type {
 };
 
 // DEVICE_DATA
-static const std::array<xy_pair, 8> DRAM_LOCATIONS = {{{1, 6}, {4, 6}, {7, 6}, {10, 6}, {1, 0}, {4, 0}, {7, 0}, {10, 0}}};
+static const std::array<xy_pair, 8> DRAM_LOCATIONS = {
+    {{1, 6}, {4, 6}, {7, 6}, {10, 6}, {1, 0}, {4, 0}, {7, 0}, {10, 0}}};
 static const std::array<xy_pair, 1> ARC_LOCATIONS = {{{0, 2}}};
 static const std::array<xy_pair, 1> PCI_LOCATIONS = {{{0, 4}}};
 static const std::array<xy_pair, 0> ETH_LOCATIONS = {};
@@ -134,7 +135,8 @@ static constexpr uint32_t STATIC_TLB_CFG_ADDR = 0x1fc00000;
 static constexpr uint32_t TLB_CFG_REG_SIZE_BYTES = 8;
 
 static constexpr uint32_t DYNAMIC_TLB_16M_SIZE = 16 * 1024 * 1024;
-static constexpr uint32_t DYNAMIC_TLB_16M_CFG_ADDR = STATIC_TLB_CFG_ADDR + (TLB_BASE_INDEX_16M * TLB_CFG_REG_SIZE_BYTES);
+static constexpr uint32_t DYNAMIC_TLB_16M_CFG_ADDR =
+    STATIC_TLB_CFG_ADDR + (TLB_BASE_INDEX_16M * TLB_CFG_REG_SIZE_BYTES);
 static constexpr uint32_t DYNAMIC_TLB_16M_BASE = TLB_BASE_16M;
 
 static constexpr uint32_t DYNAMIC_TLB_2M_SIZE = 2 * 1024 * 1024;
@@ -171,59 +173,93 @@ static constexpr uint32_t TENSIX_SOFT_RESET_ADDR = 0xFFB121B0;
 }  // namespace grayskull
 
 class grayskull_implementation : public architecture_implementation {
-   public:
+public:
     tt::ARCH get_architecture() const override { return tt::ARCH::GRAYSKULL; }
+
     uint32_t get_arc_message_arc_get_harvesting() const override {
         return static_cast<uint32_t>(grayskull::arc_message_type::ARC_GET_HARVESTING);
     }
+
     uint32_t get_arc_message_arc_go_busy() const override {
         return static_cast<uint32_t>(grayskull::arc_message_type::ARC_GO_BUSY);
     }
+
     uint32_t get_arc_message_arc_go_long_idle() const override {
         return static_cast<uint32_t>(grayskull::arc_message_type::ARC_GO_LONG_IDLE);
     }
+
     uint32_t get_arc_message_arc_go_short_idle() const override {
         return static_cast<uint32_t>(grayskull::arc_message_type::ARC_GO_SHORT_IDLE);
     }
+
     uint32_t get_arc_message_deassert_riscv_reset() const override {
         return static_cast<uint32_t>(grayskull::arc_message_type::DEASSERT_RISCV_RESET);
     }
+
     uint32_t get_arc_message_get_aiclk() const override {
         return static_cast<uint32_t>(grayskull::arc_message_type::GET_AICLK);
     }
+
     uint32_t get_arc_message_setup_iatu_for_peer_to_peer() const override {
         return static_cast<uint32_t>(grayskull::arc_message_type::SETUP_IATU_FOR_PEER_TO_PEER);
     }
+
     uint32_t get_arc_message_test() const override { return static_cast<uint32_t>(grayskull::arc_message_type::TEST); }
+
     uint32_t get_arc_csm_mailbox_offset() const override { return grayskull::ARC_CSM_MAILBOX_OFFSET; }
+
     uint32_t get_arc_reset_arc_misc_cntl_offset() const override { return grayskull::ARC_RESET_ARC_MISC_CNTL_OFFSET; }
+
     uint32_t get_arc_reset_scratch_offset() const override { return grayskull::ARC_RESET_SCRATCH_OFFSET; }
+
     uint32_t get_dram_channel_0_peer2peer_region_start() const override {
         return grayskull::DRAM_CHANNEL_0_PEER2PEER_REGION_START;
     }
+
     uint32_t get_dram_channel_0_x() const override { return grayskull::DRAM_CHANNEL_0_X; }
+
     uint32_t get_dram_channel_0_y() const override { return grayskull::DRAM_CHANNEL_0_Y; }
+
     uint32_t get_broadcast_tlb_index() const override { return grayskull::BROADCAST_TLB_INDEX; }
+
     uint32_t get_dynamic_tlb_2m_base() const override { return grayskull::DYNAMIC_TLB_2M_BASE; }
+
     uint32_t get_dynamic_tlb_2m_size() const override { return grayskull::DYNAMIC_TLB_2M_SIZE; }
+
     uint32_t get_dynamic_tlb_16m_base() const override { return grayskull::DYNAMIC_TLB_16M_BASE; }
+
     uint32_t get_dynamic_tlb_16m_size() const override { return grayskull::DYNAMIC_TLB_16M_SIZE; }
+
     uint32_t get_dynamic_tlb_16m_cfg_addr() const override { return grayskull::DYNAMIC_TLB_16M_CFG_ADDR; }
+
     uint32_t get_mem_large_read_tlb() const override { return grayskull::MEM_LARGE_READ_TLB; }
+
     uint32_t get_mem_large_write_tlb() const override { return grayskull::MEM_LARGE_WRITE_TLB; }
+
     uint32_t get_static_tlb_cfg_addr() const override { return grayskull::STATIC_TLB_CFG_ADDR; }
+
     uint32_t get_static_tlb_size() const override { return grayskull::STATIC_TLB_SIZE; }
+
     uint32_t get_reg_tlb() const override { return grayskull::REG_TLB; }
+
     uint32_t get_tlb_base_index_16m() const override { return grayskull::TLB_BASE_INDEX_16M; }
+
     uint32_t get_tensix_soft_reset_addr() const override { return grayskull::TENSIX_SOFT_RESET_ADDR; }
+
     uint32_t get_grid_size_x() const override { return grayskull::GRID_SIZE_X; }
+
     uint32_t get_grid_size_y() const override { return grayskull::GRID_SIZE_Y; }
+
     uint32_t get_tlb_cfg_reg_size_bytes() const override { return grayskull::TLB_CFG_REG_SIZE_BYTES; }
+
     uint32_t get_small_read_write_tlb() const override { return grayskull::MEM_SMALL_READ_WRITE_TLB; }
+
     const std::vector<uint32_t>& get_harvesting_noc_locations() const override {
         return grayskull::HARVESTING_NOC_LOCATIONS;
     }
+
     const std::vector<uint32_t>& get_t6_x_locations() const override { return grayskull::T6_X_LOCATIONS; }
+
     const std::vector<uint32_t>& get_t6_y_locations() const override { return grayskull::T6_Y_LOCATIONS; }
 
     std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const override;
@@ -234,7 +270,6 @@ class grayskull_implementation : public architecture_implementation {
     tt_driver_host_address_params get_host_address_params() const override;
     tt_driver_eth_interface_params get_eth_interface_params() const override;
     tt_driver_noc_params get_noc_params() const override;
-
 };
 
 }  // namespace tt::umd

--- a/device/hugepage.cpp
+++ b/device/hugepage.cpp
@@ -6,8 +6,8 @@
 
 #include "hugepage.h"
 
-#include <sys/stat.h> // for umask
-#include <fcntl.h> // for O_RDWR and other constants
+#include <fcntl.h>     // for O_RDWR and other constants
+#include <sys/stat.h>  // for umask
 
 #include "common/logger.hpp"
 #include "device/cpuset_lib.hpp"
@@ -20,13 +20,12 @@ std::string hugepage_dir = hugepage_dir_env ? hugepage_dir_env : "/dev/hugepages
 
 namespace tt::umd {
 
-uint32_t get_num_hugepages(){
-
+uint32_t get_num_hugepages() {
     std::string nr_hugepages_path = "/sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages";
     std::ifstream hugepages_file(nr_hugepages_path);
     uint32_t num_hugepages = 0;
 
-    if(hugepages_file.is_open()) {
+    if (hugepages_file.is_open()) {
         std::string value;
         std::getline(hugepages_file, value);
         num_hugepages = std::stoi(value);
@@ -36,100 +35,121 @@ uint32_t get_num_hugepages(){
     }
 
     return num_hugepages;
-
 }
 
-uint32_t get_available_num_host_mem_channels(const uint32_t num_channels_per_device_target, const uint16_t device_id, const uint16_t revision_id) {
-
+uint32_t get_available_num_host_mem_channels(
+    const uint32_t num_channels_per_device_target, const uint16_t device_id, const uint16_t revision_id) {
     // To minimally support hybrid dev systems with mix of ARCH, get only devices matching current ARCH's device_id.
-    uint32_t total_num_tt_mmio_devices      = tt::cpuset::tt_cpuset_allocator::get_num_tt_pci_devices();
-    uint32_t num_tt_mmio_devices_for_arch   = tt::cpuset::tt_cpuset_allocator::get_num_tt_pci_devices_by_pci_device_id(device_id, revision_id);
-    uint32_t total_hugepages                = get_num_hugepages();
+    uint32_t total_num_tt_mmio_devices = tt::cpuset::tt_cpuset_allocator::get_num_tt_pci_devices();
+    uint32_t num_tt_mmio_devices_for_arch =
+        tt::cpuset::tt_cpuset_allocator::get_num_tt_pci_devices_by_pci_device_id(device_id, revision_id);
+    uint32_t total_hugepages = get_num_hugepages();
 
     // This shouldn't happen on silicon machines.
     if (num_tt_mmio_devices_for_arch == 0) {
-        log_warning(LogSiliconDriver,
+        log_warning(
+            LogSiliconDriver,
             "No TT devices found that match PCI device_id: 0x{:x} revision: {}, returning NumHostMemChannels:0",
-            device_id, revision_id);
+            device_id,
+            revision_id);
         return 0;
     }
 
-    // GS will use P2P + 1 channel, others may support 4 host channels. Apply min of 1 to not completely break setups that were incomplete
-    // ie fewer hugepages than devices, which would partially work previously for some devices.
-    uint32_t num_channels_per_device_available = std::min(num_channels_per_device_target, std::max((uint32_t) 1, total_hugepages / num_tt_mmio_devices_for_arch));
+    // GS will use P2P + 1 channel, others may support 4 host channels. Apply min of 1 to not completely break setups
+    // that were incomplete ie fewer hugepages than devices, which would partially work previously for some devices.
+    uint32_t num_channels_per_device_available =
+        std::min(num_channels_per_device_target, std::max((uint32_t)1, total_hugepages / num_tt_mmio_devices_for_arch));
 
-    // Perform some helpful assertion checks to guard against common pitfalls that would show up as runtime issues later on.
+    // Perform some helpful assertion checks to guard against common pitfalls that would show up as runtime issues later
+    // on.
     if (total_num_tt_mmio_devices > num_tt_mmio_devices_for_arch) {
-        log_warning(LogSiliconDriver,
-            "Hybrid system mixing different TTDevices - this is not well supported. Ensure sufficient Hugepages/HostMemChannels per device.");
+        log_warning(
+            LogSiliconDriver,
+            "Hybrid system mixing different TTDevices - this is not well supported. Ensure sufficient "
+            "Hugepages/HostMemChannels per device.");
     }
 
     if (total_hugepages < num_tt_mmio_devices_for_arch) {
-        log_warning(LogSiliconDriver,
-            "Insufficient NumHugepages: {} should be at least NumMMIODevices: {} for device_id: 0x{:x} revision: {}. NumHostMemChannels would be 0, bumping to 1.",
-            total_hugepages, num_tt_mmio_devices_for_arch, device_id, revision_id);
+        log_warning(
+            LogSiliconDriver,
+            "Insufficient NumHugepages: {} should be at least NumMMIODevices: {} for device_id: 0x{:x} revision: {}. "
+            "NumHostMemChannels would be 0, bumping to 1.",
+            total_hugepages,
+            num_tt_mmio_devices_for_arch,
+            device_id,
+            revision_id);
     }
 
     if (num_channels_per_device_available < num_channels_per_device_target) {
-        log_warning(LogSiliconDriver,
-            "NumHostMemChannels: {} used for device_id: 0x{:x} less than target: {}. Workload will fail if it exceeds NumHostMemChannels. Increase Number of Hugepages.",
-            num_channels_per_device_available, device_id, num_channels_per_device_target);
+        log_warning(
+            LogSiliconDriver,
+            "NumHostMemChannels: {} used for device_id: 0x{:x} less than target: {}. Workload will fail if it exceeds "
+            "NumHostMemChannels. Increase Number of Hugepages.",
+            num_channels_per_device_available,
+            device_id,
+            num_channels_per_device_target);
     }
 
-    log_assert(num_channels_per_device_available <= g_MAX_HOST_MEM_CHANNELS,
+    log_assert(
+        num_channels_per_device_available <= g_MAX_HOST_MEM_CHANNELS,
         "NumHostMemChannels: {} exceeds supported maximum: {}, this is unexpected.",
-        num_channels_per_device_available, g_MAX_HOST_MEM_CHANNELS);
+        num_channels_per_device_available,
+        g_MAX_HOST_MEM_CHANNELS);
 
     return num_channels_per_device_available;
-
 }
 
-std::string find_hugepage_dir(std::size_t pagesize)
-{
-
-    static const std::regex hugetlbfs_mount_re(fmt::format("^(nodev|hugetlbfs) ({}) hugetlbfs ([^ ]+) 0 0$", hugepage_dir));
+std::string find_hugepage_dir(std::size_t pagesize) {
+    static const std::regex hugetlbfs_mount_re(
+        fmt::format("^(nodev|hugetlbfs) ({}) hugetlbfs ([^ ]+) 0 0$", hugepage_dir));
     static const std::regex pagesize_re("(?:^|,)pagesize=([0-9]+)([KMGT])(?:,|$)");
 
     std::ifstream proc_mounts("/proc/mounts");
 
-    for (std::string line; std::getline(proc_mounts, line); )
-    {
-        if (std::smatch mount_match; std::regex_match(line, mount_match, hugetlbfs_mount_re))
-        {
+    for (std::string line; std::getline(proc_mounts, line);) {
+        if (std::smatch mount_match; std::regex_match(line, mount_match, hugetlbfs_mount_re)) {
             std::string options = mount_match[3];
-            if (std::smatch pagesize_match; std::regex_search(options, pagesize_match, pagesize_re))
-            {
+            if (std::smatch pagesize_match; std::regex_search(options, pagesize_match, pagesize_re)) {
                 std::size_t mount_page_size = std::stoull(pagesize_match[1]);
-                switch (pagesize_match[2].str()[0])
-                {
-                    case 'T': mount_page_size <<= 10;
-                    case 'G': mount_page_size <<= 10;
-                    case 'M': mount_page_size <<= 10;
-                    case 'K': mount_page_size <<= 10;
+                switch (pagesize_match[2].str()[0]) {
+                    case 'T':
+                        mount_page_size <<= 10;
+                    case 'G':
+                        mount_page_size <<= 10;
+                    case 'M':
+                        mount_page_size <<= 10;
+                    case 'K':
+                        mount_page_size <<= 10;
                 }
 
-                if (mount_page_size == pagesize)
-                {
+                if (mount_page_size == pagesize) {
                     return mount_match[2];
                 }
             }
         }
     }
 
-    log_warning(LogSiliconDriver, "ttSiliconDevice::find_hugepage_dir: no huge page mount found in /proc/mounts for path: {} with hugepage_size: {}.", hugepage_dir, pagesize);
+    log_warning(
+        LogSiliconDriver,
+        "ttSiliconDevice::find_hugepage_dir: no huge page mount found in /proc/mounts for path: {} with hugepage_size: "
+        "{}.",
+        hugepage_dir,
+        pagesize);
     return std::string();
 }
 
-int open_hugepage_file(const std::string &dir, chip_id_t physical_device_id, uint16_t channel) {
+int open_hugepage_file(const std::string& dir, chip_id_t physical_device_id, uint16_t channel) {
     std::vector<char> filename;
     static const char pipeline_name[] = "tenstorrent";
 
     filename.insert(filename.end(), dir.begin(), dir.end());
-    if (filename.back() != '/') filename.push_back('/');
+    if (filename.back() != '/') {
+        filename.push_back('/');
+    }
 
     // In order to limit number of hugepages while transition from shared hugepage (1 per system) to unique
     // hugepage per device, will share original/shared hugepage filename with physical device 0.
-    if (physical_device_id != 0 || channel != 0){
+    if (physical_device_id != 0 || channel != 0) {
         std::string device_id_str = fmt::format("device_{}_", physical_device_id);
         filename.insert(filename.end(), device_id_str.begin(), device_id_str.end());
     }
@@ -139,20 +159,32 @@ int open_hugepage_file(const std::string &dir, chip_id_t physical_device_id, uin
         filename.insert(filename.end(), channel_id_str.begin(), channel_id_str.end());
     }
 
-    filename.insert(filename.end(), std::begin(pipeline_name), std::end(pipeline_name)); // includes NUL terminator
+    filename.insert(filename.end(), std::begin(pipeline_name), std::end(pipeline_name));  // includes NUL terminator
 
     std::string filename_str(filename.begin(), filename.end());
-    filename_str.erase(std::find(filename_str.begin(), filename_str.end(), '\0'), filename_str.end()); // Erase NULL terminator for printing.
-    log_debug(LogSiliconDriver, "ttSiliconDevice::open_hugepage_file: using filename: {} for physical_device_id: {} channel: {}", filename_str.c_str(), physical_device_id, channel);
+    filename_str.erase(
+        std::find(filename_str.begin(), filename_str.end(), '\0'),
+        filename_str.end());  // Erase NULL terminator for printing.
+    log_debug(
+        LogSiliconDriver,
+        "ttSiliconDevice::open_hugepage_file: using filename: {} for physical_device_id: {} channel: {}",
+        filename_str.c_str(),
+        physical_device_id,
+        channel);
 
     // Save original and set umask to unrestricted.
     auto old_umask = umask(0);
 
-    int fd = open(filename.data(), O_RDWR | O_CREAT | O_CLOEXEC, S_IWUSR | S_IRUSR | S_IWGRP | S_IRGRP | S_IWOTH | S_IROTH );
+    int fd =
+        open(filename.data(), O_RDWR | O_CREAT | O_CLOEXEC, S_IWUSR | S_IRUSR | S_IWGRP | S_IRGRP | S_IWOTH | S_IROTH);
     if (fd == -1 && errno == EACCES) {
-        log_warning(LogSiliconDriver, "ttSiliconDevice::open_hugepage_file could not open filename: {} on first try, unlinking it and retrying.", filename_str);
+        log_warning(
+            LogSiliconDriver,
+            "ttSiliconDevice::open_hugepage_file could not open filename: {} on first try, unlinking it and retrying.",
+            filename_str);
         unlink(filename.data());
-        fd = open(filename.data(), O_RDWR | O_CREAT | O_CLOEXEC, S_IWUSR | S_IRUSR | S_IWGRP | S_IRGRP | S_IWOTH | S_IROTH );
+        fd = open(
+            filename.data(), O_RDWR | O_CREAT | O_CLOEXEC, S_IWUSR | S_IRUSR | S_IWGRP | S_IRGRP | S_IWOTH | S_IROTH);
     }
 
     // Restore original mask
@@ -166,4 +198,4 @@ int open_hugepage_file(const std::string &dir, chip_id_t physical_device_id, uin
     return fd;
 }
 
-} // namespace tt::umd
+}  // namespace tt::umd

--- a/device/hugepage.h
+++ b/device/hugepage.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
-#include "device/tt_cluster_descriptor_types.h"
-
-#include <string>
 #include <cstdint>
+#include <string>
+
+#include "device/tt_cluster_descriptor_types.h"
 
 namespace tt::umd {
 
@@ -17,7 +17,8 @@ namespace tt::umd {
 uint32_t get_num_hugepages();
 
 // Dynamically figure out how many host memory channels (based on hugepages installed) for each device, based on arch.
-uint32_t get_available_num_host_mem_channels(const uint32_t num_channels_per_device_target, const uint16_t device_id, const uint16_t revision_id);
+uint32_t get_available_num_host_mem_channels(
+    const uint32_t num_channels_per_device_target, const uint16_t device_id, const uint16_t revision_id);
 
 // Looks for hugetlbfs inside /proc/mounts matching desired pagesize (typically 1G)
 std::string find_hugepage_dir(std::size_t pagesize);
@@ -27,4 +28,4 @@ std::string find_hugepage_dir(std::size_t pagesize);
 // Today we assume there's only one pipeline running within the system.
 // One hugepage per device such that each device gets unique memory.
 int open_hugepage_file(const std::string &dir, chip_id_t physical_device_id, uint16_t channel);
-}
+}  // namespace tt::umd

--- a/device/ioctl.h
+++ b/device/ioctl.h
@@ -7,151 +7,149 @@
 #ifndef TTDRIVER_IOCTL_H_INCLUDED
 #define TTDRIVER_IOCTL_H_INCLUDED
 
-#include <linux/types.h>
 #include <linux/ioctl.h>
+#include <linux/types.h>
 
 #define TENSTORRENT_DRIVER_VERSION 1
 
 #define TENSTORRENT_IOCTL_MAGIC 0xFA
 
-#define TENSTORRENT_IOCTL_GET_DEVICE_INFO	_IO(TENSTORRENT_IOCTL_MAGIC, 0)
-#define TENSTORRENT_IOCTL_GET_HARVESTING	_IO(TENSTORRENT_IOCTL_MAGIC, 1)
-#define TENSTORRENT_IOCTL_QUERY_MAPPINGS	_IO(TENSTORRENT_IOCTL_MAGIC, 2)
-#define TENSTORRENT_IOCTL_ALLOCATE_DMA_BUF	_IO(TENSTORRENT_IOCTL_MAGIC, 3)
-#define TENSTORRENT_IOCTL_FREE_DMA_BUF		_IO(TENSTORRENT_IOCTL_MAGIC, 4)
-#define TENSTORRENT_IOCTL_GET_DRIVER_INFO	_IO(TENSTORRENT_IOCTL_MAGIC, 5)
-#define TENSTORRENT_IOCTL_RESET_DEVICE		_IO(TENSTORRENT_IOCTL_MAGIC, 6)
-#define TENSTORRENT_IOCTL_PIN_PAGES		_IO(TENSTORRENT_IOCTL_MAGIC, 7)
+#define TENSTORRENT_IOCTL_GET_DEVICE_INFO _IO(TENSTORRENT_IOCTL_MAGIC, 0)
+#define TENSTORRENT_IOCTL_GET_HARVESTING _IO(TENSTORRENT_IOCTL_MAGIC, 1)
+#define TENSTORRENT_IOCTL_QUERY_MAPPINGS _IO(TENSTORRENT_IOCTL_MAGIC, 2)
+#define TENSTORRENT_IOCTL_ALLOCATE_DMA_BUF _IO(TENSTORRENT_IOCTL_MAGIC, 3)
+#define TENSTORRENT_IOCTL_FREE_DMA_BUF _IO(TENSTORRENT_IOCTL_MAGIC, 4)
+#define TENSTORRENT_IOCTL_GET_DRIVER_INFO _IO(TENSTORRENT_IOCTL_MAGIC, 5)
+#define TENSTORRENT_IOCTL_RESET_DEVICE _IO(TENSTORRENT_IOCTL_MAGIC, 6)
+#define TENSTORRENT_IOCTL_PIN_PAGES _IO(TENSTORRENT_IOCTL_MAGIC, 7)
 
 // For tenstorrent_mapping.mapping_id. These are not array indices.
-#define TENSTORRENT_MAPPING_UNUSED		0
-#define TENSTORRENT_MAPPING_RESOURCE0_UC	1
-#define TENSTORRENT_MAPPING_RESOURCE0_WC	2
-#define TENSTORRENT_MAPPING_RESOURCE1_UC	3
-#define TENSTORRENT_MAPPING_RESOURCE1_WC	4
-#define TENSTORRENT_MAPPING_RESOURCE2_UC	5
-#define TENSTORRENT_MAPPING_RESOURCE2_WC	6
+#define TENSTORRENT_MAPPING_UNUSED 0
+#define TENSTORRENT_MAPPING_RESOURCE0_UC 1
+#define TENSTORRENT_MAPPING_RESOURCE0_WC 2
+#define TENSTORRENT_MAPPING_RESOURCE1_UC 3
+#define TENSTORRENT_MAPPING_RESOURCE1_WC 4
+#define TENSTORRENT_MAPPING_RESOURCE2_UC 5
+#define TENSTORRENT_MAPPING_RESOURCE2_WC 6
 
-#define TENSTORRENT_MAX_DMA_BUFS	8
+#define TENSTORRENT_MAX_DMA_BUFS 8
 
 struct tenstorrent_get_device_info_in {
-	__u32 output_size_bytes;
+    __u32 output_size_bytes;
 };
 
 struct tenstorrent_get_device_info_out {
-	__u32 output_size_bytes;
-	__u16 vendor_id;
-	__u16 device_id;
-	__u16 subsystem_vendor_id;
-	__u16 subsystem_id;
-	__u16 bus_dev_fn;	// [0:2] function, [3:7] device, [8:15] bus
-	__u16 max_dma_buf_size_log2;
-	__u16 pci_domain;
+    __u32 output_size_bytes;
+    __u16 vendor_id;
+    __u16 device_id;
+    __u16 subsystem_vendor_id;
+    __u16 subsystem_id;
+    __u16 bus_dev_fn;  // [0:2] function, [3:7] device, [8:15] bus
+    __u16 max_dma_buf_size_log2;
+    __u16 pci_domain;
 };
 
 struct tenstorrent_get_device_info {
-	struct tenstorrent_get_device_info_in in;
-	struct tenstorrent_get_device_info_out out;
+    struct tenstorrent_get_device_info_in in;
+    struct tenstorrent_get_device_info_out out;
 };
 
 struct tenstorrent_query_mappings_in {
-	__u32 output_mapping_count;
-	__u32 reserved;
+    __u32 output_mapping_count;
+    __u32 reserved;
 };
 
 struct tenstorrent_mapping {
-	__u32 mapping_id;
-	__u32 reserved;
-	__u64 mapping_base;
-	__u64 mapping_size;
+    __u32 mapping_id;
+    __u32 reserved;
+    __u64 mapping_base;
+    __u64 mapping_size;
 };
 
 struct tenstorrent_query_mappings_out {
-	struct tenstorrent_mapping mappings[0];
+    struct tenstorrent_mapping mappings[0];
 };
 
 struct tenstorrent_query_mappings {
-	struct tenstorrent_query_mappings_in in;
-	struct tenstorrent_query_mappings_out out;
+    struct tenstorrent_query_mappings_in in;
+    struct tenstorrent_query_mappings_out out;
 };
 
 struct tenstorrent_allocate_dma_buf_in {
-	__u32 requested_size;
-	__u8  buf_index;	// [0,TENSTORRENT_MAX_DMA_BUFS)
-	__u8  reserved0[3];
-	__u64 reserved1[2];
+    __u32 requested_size;
+    __u8 buf_index;  // [0,TENSTORRENT_MAX_DMA_BUFS)
+    __u8 reserved0[3];
+    __u64 reserved1[2];
 };
 
 struct tenstorrent_allocate_dma_buf_out {
-	__u64 physical_address;
-	__u64 mapping_offset;
-	__u32 size;
-	__u32 reserved0;
-	__u64 reserved1[2];
+    __u64 physical_address;
+    __u64 mapping_offset;
+    __u32 size;
+    __u32 reserved0;
+    __u64 reserved1[2];
 };
 
 struct tenstorrent_allocate_dma_buf {
-	struct tenstorrent_allocate_dma_buf_in in;
-	struct tenstorrent_allocate_dma_buf_out out;
+    struct tenstorrent_allocate_dma_buf_in in;
+    struct tenstorrent_allocate_dma_buf_out out;
 };
 
-struct tenstorrent_free_dma_buf_in {
-};
+struct tenstorrent_free_dma_buf_in {};
 
-struct tenstorrent_free_dma_buf_out {
-};
+struct tenstorrent_free_dma_buf_out {};
 
 struct tenstorrent_free_dma_buf {
-	struct tenstorrent_free_dma_buf_in in;
-	struct tenstorrent_free_dma_buf_out out;
+    struct tenstorrent_free_dma_buf_in in;
+    struct tenstorrent_free_dma_buf_out out;
 };
 
 struct tenstorrent_get_driver_info_in {
-	__u32 output_size_bytes;
+    __u32 output_size_bytes;
 };
 
 struct tenstorrent_get_driver_info_out {
-	__u32 output_size_bytes;
-	__u32 driver_version;
+    __u32 output_size_bytes;
+    __u32 driver_version;
 };
 
 struct tenstorrent_get_driver_info {
-	struct tenstorrent_get_driver_info_in in;
-	struct tenstorrent_get_driver_info_out out;
+    struct tenstorrent_get_driver_info_in in;
+    struct tenstorrent_get_driver_info_out out;
 };
 
 struct tenstorrent_reset_device_in {
-	__u32 output_size_bytes;
-	__u32 flags;
+    __u32 output_size_bytes;
+    __u32 flags;
 };
 
 struct tenstorrent_reset_device_out {
-	__u32 output_size_bytes;
-	__u32 result;
+    __u32 output_size_bytes;
+    __u32 result;
 };
 
 struct tenstorrent_reset_device {
-	struct tenstorrent_reset_device_in in;
-	struct tenstorrent_reset_device_out out;
+    struct tenstorrent_reset_device_in in;
+    struct tenstorrent_reset_device_out out;
 };
 
 // tenstorrent_pin_pages_in.flags
 #define TENSTORRENT_PIN_PAGES_CONTIGUOUS 1
 
 struct tenstorrent_pin_pages_in {
-	__u32 output_size_bytes;
-	__u32 flags;
-	__u64 virtual_address;
-	__u64 size;
+    __u32 output_size_bytes;
+    __u32 flags;
+    __u64 virtual_address;
+    __u64 size;
 };
 
 struct tenstorrent_pin_pages_out {
-	__u64 physical_address;
+    __u64 physical_address;
 };
 
 struct tenstorrent_pin_pages {
-	struct tenstorrent_pin_pages_in in;
-	struct tenstorrent_pin_pages_out out;
+    struct tenstorrent_pin_pages_in in;
+    struct tenstorrent_pin_pages_out out;
 };
 
 #endif

--- a/device/ioctl.h
+++ b/device/ioctl.h
@@ -4,152 +4,158 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// clang-format off
+// This file is copied from KMD, so we don't want clang formatting diff.
+
 #ifndef TTDRIVER_IOCTL_H_INCLUDED
 #define TTDRIVER_IOCTL_H_INCLUDED
 
-#include <linux/ioctl.h>
 #include <linux/types.h>
+#include <linux/ioctl.h>
 
 #define TENSTORRENT_DRIVER_VERSION 1
 
 #define TENSTORRENT_IOCTL_MAGIC 0xFA
 
-#define TENSTORRENT_IOCTL_GET_DEVICE_INFO _IO(TENSTORRENT_IOCTL_MAGIC, 0)
-#define TENSTORRENT_IOCTL_GET_HARVESTING _IO(TENSTORRENT_IOCTL_MAGIC, 1)
-#define TENSTORRENT_IOCTL_QUERY_MAPPINGS _IO(TENSTORRENT_IOCTL_MAGIC, 2)
-#define TENSTORRENT_IOCTL_ALLOCATE_DMA_BUF _IO(TENSTORRENT_IOCTL_MAGIC, 3)
-#define TENSTORRENT_IOCTL_FREE_DMA_BUF _IO(TENSTORRENT_IOCTL_MAGIC, 4)
-#define TENSTORRENT_IOCTL_GET_DRIVER_INFO _IO(TENSTORRENT_IOCTL_MAGIC, 5)
-#define TENSTORRENT_IOCTL_RESET_DEVICE _IO(TENSTORRENT_IOCTL_MAGIC, 6)
-#define TENSTORRENT_IOCTL_PIN_PAGES _IO(TENSTORRENT_IOCTL_MAGIC, 7)
+#define TENSTORRENT_IOCTL_GET_DEVICE_INFO	_IO(TENSTORRENT_IOCTL_MAGIC, 0)
+#define TENSTORRENT_IOCTL_GET_HARVESTING	_IO(TENSTORRENT_IOCTL_MAGIC, 1)
+#define TENSTORRENT_IOCTL_QUERY_MAPPINGS	_IO(TENSTORRENT_IOCTL_MAGIC, 2)
+#define TENSTORRENT_IOCTL_ALLOCATE_DMA_BUF	_IO(TENSTORRENT_IOCTL_MAGIC, 3)
+#define TENSTORRENT_IOCTL_FREE_DMA_BUF		_IO(TENSTORRENT_IOCTL_MAGIC, 4)
+#define TENSTORRENT_IOCTL_GET_DRIVER_INFO	_IO(TENSTORRENT_IOCTL_MAGIC, 5)
+#define TENSTORRENT_IOCTL_RESET_DEVICE		_IO(TENSTORRENT_IOCTL_MAGIC, 6)
+#define TENSTORRENT_IOCTL_PIN_PAGES		_IO(TENSTORRENT_IOCTL_MAGIC, 7)
 
 // For tenstorrent_mapping.mapping_id. These are not array indices.
-#define TENSTORRENT_MAPPING_UNUSED 0
-#define TENSTORRENT_MAPPING_RESOURCE0_UC 1
-#define TENSTORRENT_MAPPING_RESOURCE0_WC 2
-#define TENSTORRENT_MAPPING_RESOURCE1_UC 3
-#define TENSTORRENT_MAPPING_RESOURCE1_WC 4
-#define TENSTORRENT_MAPPING_RESOURCE2_UC 5
-#define TENSTORRENT_MAPPING_RESOURCE2_WC 6
+#define TENSTORRENT_MAPPING_UNUSED		0
+#define TENSTORRENT_MAPPING_RESOURCE0_UC	1
+#define TENSTORRENT_MAPPING_RESOURCE0_WC	2
+#define TENSTORRENT_MAPPING_RESOURCE1_UC	3
+#define TENSTORRENT_MAPPING_RESOURCE1_WC	4
+#define TENSTORRENT_MAPPING_RESOURCE2_UC	5
+#define TENSTORRENT_MAPPING_RESOURCE2_WC	6
 
-#define TENSTORRENT_MAX_DMA_BUFS 8
+#define TENSTORRENT_MAX_DMA_BUFS	8
 
 struct tenstorrent_get_device_info_in {
-    __u32 output_size_bytes;
+	__u32 output_size_bytes;
 };
 
 struct tenstorrent_get_device_info_out {
-    __u32 output_size_bytes;
-    __u16 vendor_id;
-    __u16 device_id;
-    __u16 subsystem_vendor_id;
-    __u16 subsystem_id;
-    __u16 bus_dev_fn;  // [0:2] function, [3:7] device, [8:15] bus
-    __u16 max_dma_buf_size_log2;
-    __u16 pci_domain;
+	__u32 output_size_bytes;
+	__u16 vendor_id;
+	__u16 device_id;
+	__u16 subsystem_vendor_id;
+	__u16 subsystem_id;
+	__u16 bus_dev_fn;	// [0:2] function, [3:7] device, [8:15] bus
+	__u16 max_dma_buf_size_log2;
+	__u16 pci_domain;
 };
 
 struct tenstorrent_get_device_info {
-    struct tenstorrent_get_device_info_in in;
-    struct tenstorrent_get_device_info_out out;
+	struct tenstorrent_get_device_info_in in;
+	struct tenstorrent_get_device_info_out out;
 };
 
 struct tenstorrent_query_mappings_in {
-    __u32 output_mapping_count;
-    __u32 reserved;
+	__u32 output_mapping_count;
+	__u32 reserved;
 };
 
 struct tenstorrent_mapping {
-    __u32 mapping_id;
-    __u32 reserved;
-    __u64 mapping_base;
-    __u64 mapping_size;
+	__u32 mapping_id;
+	__u32 reserved;
+	__u64 mapping_base;
+	__u64 mapping_size;
 };
 
 struct tenstorrent_query_mappings_out {
-    struct tenstorrent_mapping mappings[0];
+	struct tenstorrent_mapping mappings[0];
 };
 
 struct tenstorrent_query_mappings {
-    struct tenstorrent_query_mappings_in in;
-    struct tenstorrent_query_mappings_out out;
+	struct tenstorrent_query_mappings_in in;
+	struct tenstorrent_query_mappings_out out;
 };
 
 struct tenstorrent_allocate_dma_buf_in {
-    __u32 requested_size;
-    __u8 buf_index;  // [0,TENSTORRENT_MAX_DMA_BUFS)
-    __u8 reserved0[3];
-    __u64 reserved1[2];
+	__u32 requested_size;
+	__u8  buf_index;	// [0,TENSTORRENT_MAX_DMA_BUFS)
+	__u8  reserved0[3];
+	__u64 reserved1[2];
 };
 
 struct tenstorrent_allocate_dma_buf_out {
-    __u64 physical_address;
-    __u64 mapping_offset;
-    __u32 size;
-    __u32 reserved0;
-    __u64 reserved1[2];
+	__u64 physical_address;
+	__u64 mapping_offset;
+	__u32 size;
+	__u32 reserved0;
+	__u64 reserved1[2];
 };
 
 struct tenstorrent_allocate_dma_buf {
-    struct tenstorrent_allocate_dma_buf_in in;
-    struct tenstorrent_allocate_dma_buf_out out;
+	struct tenstorrent_allocate_dma_buf_in in;
+	struct tenstorrent_allocate_dma_buf_out out;
 };
 
-struct tenstorrent_free_dma_buf_in {};
+struct tenstorrent_free_dma_buf_in {
+};
 
-struct tenstorrent_free_dma_buf_out {};
+struct tenstorrent_free_dma_buf_out {
+};
 
 struct tenstorrent_free_dma_buf {
-    struct tenstorrent_free_dma_buf_in in;
-    struct tenstorrent_free_dma_buf_out out;
+	struct tenstorrent_free_dma_buf_in in;
+	struct tenstorrent_free_dma_buf_out out;
 };
 
 struct tenstorrent_get_driver_info_in {
-    __u32 output_size_bytes;
+	__u32 output_size_bytes;
 };
 
 struct tenstorrent_get_driver_info_out {
-    __u32 output_size_bytes;
-    __u32 driver_version;
+	__u32 output_size_bytes;
+	__u32 driver_version;
 };
 
 struct tenstorrent_get_driver_info {
-    struct tenstorrent_get_driver_info_in in;
-    struct tenstorrent_get_driver_info_out out;
+	struct tenstorrent_get_driver_info_in in;
+	struct tenstorrent_get_driver_info_out out;
 };
 
 struct tenstorrent_reset_device_in {
-    __u32 output_size_bytes;
-    __u32 flags;
+	__u32 output_size_bytes;
+	__u32 flags;
 };
 
 struct tenstorrent_reset_device_out {
-    __u32 output_size_bytes;
-    __u32 result;
+	__u32 output_size_bytes;
+	__u32 result;
 };
 
 struct tenstorrent_reset_device {
-    struct tenstorrent_reset_device_in in;
-    struct tenstorrent_reset_device_out out;
+	struct tenstorrent_reset_device_in in;
+	struct tenstorrent_reset_device_out out;
 };
 
 // tenstorrent_pin_pages_in.flags
 #define TENSTORRENT_PIN_PAGES_CONTIGUOUS 1
 
 struct tenstorrent_pin_pages_in {
-    __u32 output_size_bytes;
-    __u32 flags;
-    __u64 virtual_address;
-    __u64 size;
+	__u32 output_size_bytes;
+	__u32 flags;
+	__u64 virtual_address;
+	__u64 size;
 };
 
 struct tenstorrent_pin_pages_out {
-    __u64 physical_address;
+	__u64 physical_address;
 };
 
 struct tenstorrent_pin_pages {
-    struct tenstorrent_pin_pages_in in;
-    struct tenstorrent_pin_pages_out out;
+	struct tenstorrent_pin_pages_in in;
+	struct tenstorrent_pin_pages_out out;
 };
 
 #endif
+// clang-format on

--- a/device/mockup/tt_mockup_device.hpp
+++ b/device/mockup/tt_mockup_device.hpp
@@ -9,31 +9,42 @@
 #include <cstdint>
 #include <vector>
 
-#include "device/tt_cluster_descriptor.h"
 #include "device/cluster.h"
+#include "device/tt_cluster_descriptor.h"
 
 class tt_MockupDevice : public tt_device {
-   public:
+public:
     tt_MockupDevice(const std::string& sdesc_path) : tt_device() {
         soc_descriptor_per_chip.emplace(0, tt_SocDescriptor(sdesc_path));
         std::set<chip_id_t> target_devices = {0};
     }
+
     virtual ~tt_MockupDevice() {}
 
     // Setup/Teardown Functions
     virtual std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors() override {
         return soc_descriptor_per_chip;
     }
+
     void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_) override {}
+
     void set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_) override {}
+
     void set_driver_host_address_params(const tt_driver_host_address_params& host_address_params_) override {}
-    void set_driver_eth_interface_params(
-        const tt_driver_eth_interface_params& eth_interface_params_) override {}
+
+    void set_driver_eth_interface_params(const tt_driver_eth_interface_params& eth_interface_params_) override {}
+
     void start_device(const tt_device_params& device_params) override {}
+
     void assert_risc_reset() override {}
+
     void deassert_risc_reset() override {}
-    void deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets = TENSIX_DEASSERT_SOFT_RESET) override {}
+
+    void deassert_risc_reset_at_core(
+        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET) override {}
+
     void assert_risc_reset_at_core(tt_cxy_pair core) override {}
+
     void close_device() override {}
 
     // Runtime Functions
@@ -43,10 +54,13 @@ class tt_MockupDevice : public tt_device {
         tt_cxy_pair core,
         uint64_t addr,
         const std::string& tlb_to_use) override {}
+
     void read_from_device(
         void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb) override {}
+
     void write_to_sysmem(
         const void* mem_ptr, std::uint32_t size, uint64_t addr, uint16_t channel, chip_id_t src_device_id) override {}
+
     void read_from_sysmem(
         void* mem_ptr, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id) override {}
 
@@ -54,10 +68,12 @@ class tt_MockupDevice : public tt_device {
         const chip_id_t chip,
         const std::string& fallback_tlb,
         const std::unordered_set<tt_xy_pair>& cores = {}) override {}
+
     void dram_membar(
         const chip_id_t chip,
         const std::string& fallback_tlb,
         const std::unordered_set<uint32_t>& channels = {}) override {}
+
     void dram_membar(
         const chip_id_t chip,
         const std::string& fallback_tlb,
@@ -66,27 +82,35 @@ class tt_MockupDevice : public tt_device {
     void wait_for_non_mmio_flush() override {}
 
     // Misc. Functions to Query/Set Device State
-    std::unordered_map<chip_id_t, uint32_t> get_harvesting_masks_for_soc_descriptors() override {
-        return {{0, 0}};
-    }
+    std::unordered_map<chip_id_t, uint32_t> get_harvesting_masks_for_soc_descriptors() override { return {{0, 0}}; }
+
     static std::vector<chip_id_t> detect_available_device_ids() { return {0}; };
+
     std::set<chip_id_t> get_target_remote_device_ids() override { return target_remote_chips; }
+
     std::map<int, int> get_clocks() override { return {{0, 0}}; }
+
     void* host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const override {
         return nullptr;
     }
+
     std::uint64_t get_pcie_base_addr_from_device(const chip_id_t chip_id) const override { return 0; }
+
     std::uint32_t get_num_dram_channels(std::uint32_t device_id) override {
         return get_soc_descriptor(device_id).get_num_dram_channels();
     };
+
     std::uint64_t get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel) override {
         return get_soc_descriptor(device_id).dram_bank_size;
     }
+
     std::uint32_t get_num_host_channels(std::uint32_t device_id) override { return 1; }
+
     std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel) override { return 0; }
+
     std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id) override { return 0; }
 
-   private:
+private:
     std::vector<tt::ARCH> archs_in_cluster = {};
     std::set<chip_id_t> target_devices_in_cluster = {};
     std::set<chip_id_t> target_remote_chips = {};

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -4,27 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <cstdint>
-#include <cstring> // for memcpy
-#include <vector>
-#include <fcntl.h>  // for ::open
-#include <unistd.h> // for ::close
-#include <sys/ioctl.h> // for ioctl
-#include <sys/mman.h>  // for mmap, munmap
-#include <sys/stat.h> // for fstat
-#include <linux/pci.h> // for PCI_SLOT, PCI_FUNC
-
 #include "pci_device.hpp"
-#include "ioctl.h"
 
-#include "ioctl.h"
-#include "device/tt_arch_types.h"
-#include "device/driver_atomics.h"
-#include "device/architecture_implementation.h"
-#include "device/cpuset_lib.hpp"
-#include "device/hugepage.h"
+#include <fcntl.h>      // for ::open
+#include <linux/pci.h>  // for PCI_SLOT, PCI_FUNC
+#include <sys/ioctl.h>  // for ioctl
+#include <sys/mman.h>   // for mmap, munmap
+#include <sys/stat.h>   // for fstat
+#include <unistd.h>     // for ::close
+
+#include <cstdint>
+#include <cstring>  // for memcpy
+#include <vector>
+
 #include "common/assert.hpp"
 #include "common/logger.hpp"
+#include "device/architecture_implementation.h"
+#include "device/cpuset_lib.hpp"
+#include "device/driver_atomics.h"
+#include "device/hugepage.h"
+#include "device/tt_arch_types.h"
+#include "ioctl.h"
 
 static const uint16_t GS_PCIE_DEVICE_ID = 0xfaca;
 static const uint16_t WH_PCIE_DEVICE_ID = 0x401e;
@@ -32,25 +32,29 @@ static const uint16_t BH_PCIE_DEVICE_ID = 0xb140;
 
 // TODO: we'll have to rethink this when KMD takes control of the inbound PCIe
 // TLB windows and there is no longer a pre-defined WC/UC split.
-static const uint32_t GS_BAR0_WC_MAPPING_SIZE = (156<<20) + (10<<21) + (18<<24);
+static const uint32_t GS_BAR0_WC_MAPPING_SIZE = (156 << 20) + (10 << 21) + (18 << 24);
 
 // Defines the address for WC region. addresses 0 to BH_BAR0_WC_MAPPING_SIZE are in WC, above that are UC
-static const uint32_t BH_BAR0_WC_MAPPING_SIZE = 188<<21;
+static const uint32_t BH_BAR0_WC_MAPPING_SIZE = 188 << 21;
 
 static const uint32_t BH_NOC_NODE_ID_OFFSET = 0x1FD04044;
 static const uint32_t GS_WH_ARC_SCRATCH_6_OFFSET = 0x1FF30078;
 
 // Hugepages must be 1GB in size
-const uint32_t HUGEPAGE_REGION_SIZE = 1 << 30; // 1GB
+const uint32_t HUGEPAGE_REGION_SIZE = 1 << 30;  // 1GB
 
 using namespace tt;
 using namespace tt::umd;
 
 template <typename T>
 static T read_sysfs(const PciDeviceInfo &device_info, const std::string &attribute_name) {
-    const auto sysfs_path = fmt::format("/sys/bus/pci/devices/{:04x}:{:02x}:{:02x}.{:x}/{}",
-                                        device_info.pci_domain, device_info.pci_bus,
-                                        device_info.pci_device, device_info.pci_function, attribute_name);
+    const auto sysfs_path = fmt::format(
+        "/sys/bus/pci/devices/{:04x}:{:02x}:{:02x}.{:x}/{}",
+        device_info.pci_domain,
+        device_info.pci_bus,
+        device_info.pci_device,
+        device_info.pci_function,
+        attribute_name);
     std::ifstream attribute_file(sysfs_path);
     std::string value_str;
     T value;
@@ -75,8 +79,7 @@ static T read_sysfs(const PciDeviceInfo &device_info, const std::string &attribu
     return value;
 }
 
-static PciDeviceInfo read_device_info(int fd)
-{
+static PciDeviceInfo read_device_info(int fd) {
     tenstorrent_get_device_info info{};
     info.in.output_size_bytes = sizeof(info.out);
 
@@ -92,11 +95,11 @@ static PciDeviceInfo read_device_info(int fd)
 }
 
 static tt::ARCH detect_arch(uint32_t pcie_device_id, uint32_t pcie_revision_id) {
-    if (pcie_device_id == GS_PCIE_DEVICE_ID){
+    if (pcie_device_id == GS_PCIE_DEVICE_ID) {
         return tt::ARCH::GRAYSKULL;
-    } else if (pcie_device_id == WH_PCIE_DEVICE_ID && pcie_revision_id == 0x01){
+    } else if (pcie_device_id == WH_PCIE_DEVICE_ID && pcie_revision_id == 0x01) {
         return tt::ARCH::WORMHOLE_B0;
-    } else if (pcie_device_id == BH_PCIE_DEVICE_ID){
+    } else if (pcie_device_id == BH_PCIE_DEVICE_ID) {
         return tt::ARCH::BLACKHOLE;
     } else {
         TT_THROW("Unknown pcie device id that does not match any known architecture: ", pcie_device_id);
@@ -122,28 +125,29 @@ inline void memcpy_to_device(void *dest, const void *src, std::size_t num_bytes)
 
     if (dest_misalignment != 0) {
         // Read-modify-write for the first dest element.
-        dp = reinterpret_cast<copy_t*>(dest_addr - dest_misalignment);
+        dp = reinterpret_cast<copy_t *>(dest_addr - dest_misalignment);
 
         copy_t tmp = *dp;
 
         auto leading_len = std::min(sizeof(tmp) - dest_misalignment, num_bytes);
 
-        std::memcpy(reinterpret_cast<char*>(&tmp) + dest_misalignment, src, leading_len);
+        std::memcpy(reinterpret_cast<char *>(&tmp) + dest_misalignment, src, leading_len);
         num_bytes -= leading_len;
         src = static_cast<const char *>(src) + leading_len;
 
         *dp++ = tmp;
 
     } else {
-        dp = static_cast<copy_t*>(dest);
+        dp = static_cast<copy_t *>(dest);
     }
 
     // Copy the destination-aligned middle.
-    const copy_t *sp = static_cast<const copy_t*>(src);
+    const copy_t *sp = static_cast<const copy_t *>(src);
     std::size_t num_words = num_bytes / sizeof(copy_t);
 
-    for (std::size_t i = 0; i < num_words; i++)
+    for (std::size_t i = 0; i < num_words; i++) {
         *dp++ = *sp++;
+    }
 
     // Finally copy any sub-word trailer, again RMW on the destination.
     auto trailing_len = num_bytes % sizeof(copy_t);
@@ -166,7 +170,7 @@ inline void memcpy_from_device(void *dest, const void *src, std::size_t num_byte
     unsigned int src_misalignment = src_addr % sizeof(copy_t);
 
     if (src_misalignment != 0) {
-        sp = reinterpret_cast<copy_t*>(src_addr - src_misalignment);
+        sp = reinterpret_cast<copy_t *>(src_addr - src_misalignment);
 
         copy_t tmp = *sp++;
 
@@ -176,15 +180,16 @@ inline void memcpy_from_device(void *dest, const void *src, std::size_t num_byte
         dest = static_cast<char *>(dest) + leading_len;
 
     } else {
-        sp = static_cast<const volatile copy_t*>(src);
+        sp = static_cast<const volatile copy_t *>(src);
     }
 
     // Copy the source-aligned middle.
     copy_t *dp = static_cast<copy_t *>(dest);
     std::size_t num_words = num_bytes / sizeof(copy_t);
 
-    for (std::size_t i = 0; i < num_words; i++)
+    for (std::size_t i = 0; i < num_words; i++) {
         *dp++ = *sp++;
+    }
 
     // Finally copy any sub-word trailer.
     auto trailing_len = num_bytes % sizeof(copy_t);
@@ -195,16 +200,15 @@ inline void memcpy_from_device(void *dest, const void *src, std::size_t num_byte
 }
 
 tt::ARCH PciDeviceInfo::get_arch() const {
-    if (this->device_id == GS_PCIE_DEVICE_ID){
+    if (this->device_id == GS_PCIE_DEVICE_ID) {
         return tt::ARCH::GRAYSKULL;
     } else if (this->device_id == WH_PCIE_DEVICE_ID) {
         return tt::ARCH::WORMHOLE_B0;
-    } else if (this->device_id == BH_PCIE_DEVICE_ID){
+    } else if (this->device_id == BH_PCIE_DEVICE_ID) {
         return tt::ARCH::BLACKHOLE;
     }
     return tt::ARCH::Invalid;
 }
-
 
 /* static */ std::vector<int> PCIDevice::enumerate_devices() {
     std::vector<int> device_ids;
@@ -213,7 +217,7 @@ tt::ARCH PciDeviceInfo::get_arch() const {
     if (!std::filesystem::exists(path)) {
         return device_ids;
     }
-    for (const auto& entry : std::filesystem::directory_iterator(path)) {
+    for (const auto &entry : std::filesystem::directory_iterator(path)) {
         std::string filename = entry.path().filename().string();
 
         // TODO: this will skip any device that has a non-numeric name, which
@@ -237,28 +241,29 @@ tt::ARCH PciDeviceInfo::get_arch() const {
 
         try {
             infos[n] = read_device_info(fd);
-        } catch (...) {}
+        } catch (...) {
+        }
 
         close(fd);
     }
     return infos;
 }
 
-PCIDevice::PCIDevice(int pci_device_number, int logical_device_id)
-    : device_path(fmt::format("/dev/tenstorrent/{}", pci_device_number))
-    , pci_device_num(pci_device_number)
-    , logical_id(logical_device_id)
-    , pci_device_file_desc(open(device_path.c_str(), O_RDWR | O_CLOEXEC))
-    , info(read_device_info(pci_device_file_desc))
-    , numa_node(read_sysfs<int>(info, "numa_node"))
-    , revision(read_sysfs<int>(info, "revision"))
-    , arch(detect_arch(info.device_id, revision))
-    , architecture_implementation(tt::umd::architecture_implementation::create(arch))
-{
+PCIDevice::PCIDevice(int pci_device_number, int logical_device_id) :
+    device_path(fmt::format("/dev/tenstorrent/{}", pci_device_number)),
+    pci_device_num(pci_device_number),
+    logical_id(logical_device_id),
+    pci_device_file_desc(open(device_path.c_str(), O_RDWR | O_CLOEXEC)),
+    info(read_device_info(pci_device_file_desc)),
+    numa_node(read_sysfs<int>(info, "numa_node")),
+    revision(read_sysfs<int>(info, "revision")),
+    arch(detect_arch(info.device_id, revision)),
+    architecture_implementation(tt::umd::architecture_implementation::create(arch)) {
     struct {
         tenstorrent_query_mappings query_mappings;
         tenstorrent_mapping mapping_array[8];
     } mappings;
+
     memset(&mappings, 0, sizeof(mappings));
     mappings.query_mappings.in.output_mapping_count = 8;
 
@@ -302,7 +307,9 @@ PCIDevice::PCIDevice(int pci_device_number, int logical_device_id)
             bar4_wc_mapping = mappings.mapping_array[i];
         }
 
-        log_debug(LogSiliconDriver, "BAR mapping id {} base {} size {}",
+        log_debug(
+            LogSiliconDriver,
+            "BAR mapping id {} base {} size {}",
             mappings.mapping_array[i].mapping_id,
             (void *)mappings.mapping_array[i].mapping_base,
             mappings.mapping_array[i].mapping_size);
@@ -317,7 +324,8 @@ PCIDevice::PCIDevice(int pci_device_number, int logical_device_id)
     // Attempt WC mapping first so we can fall back to all-UC if it fails.
     if (bar0_wc_mapping.mapping_id == TENSTORRENT_MAPPING_RESOURCE0_WC) {
         bar0_wc_size = std::min<size_t>(bar0_wc_mapping.mapping_size, wc_mapping_size);
-        bar0_wc = mmap(NULL, bar0_wc_size, PROT_READ | PROT_WRITE, MAP_SHARED, pci_device_file_desc, bar0_wc_mapping.mapping_base);
+        bar0_wc = mmap(
+            NULL, bar0_wc_size, PROT_READ | PROT_WRITE, MAP_SHARED, pci_device_file_desc, bar0_wc_mapping.mapping_base);
         if (bar0_wc == MAP_FAILED) {
             bar0_wc_size = 0;
             bar0_wc = nullptr;
@@ -334,7 +342,13 @@ PCIDevice::PCIDevice(int pci_device_number, int logical_device_id)
         bar0_uc_offset = 0;
     }
 
-    bar0_uc = mmap(NULL, bar0_uc_size, PROT_READ | PROT_WRITE, MAP_SHARED, pci_device_file_desc, bar0_uc_mapping.mapping_base + bar0_uc_offset);
+    bar0_uc = mmap(
+        NULL,
+        bar0_uc_size,
+        PROT_READ | PROT_WRITE,
+        MAP_SHARED,
+        pci_device_file_desc,
+        bar0_uc_mapping.mapping_base + bar0_uc_offset);
 
     if (bar0_uc == MAP_FAILED) {
         throw std::runtime_error(fmt::format("BAR0 UC mapping failed for device {}.", pci_device_num));
@@ -351,22 +365,34 @@ PCIDevice::PCIDevice(int pci_device_number, int logical_device_id)
 
         system_reg_mapping_size = bar4_uc_mapping.mapping_size;
 
-        system_reg_mapping = mmap(NULL, bar4_uc_mapping.mapping_size, PROT_READ | PROT_WRITE, MAP_SHARED, pci_device_file_desc, bar4_uc_mapping.mapping_base);
+        system_reg_mapping = mmap(
+            NULL,
+            bar4_uc_mapping.mapping_size,
+            PROT_READ | PROT_WRITE,
+            MAP_SHARED,
+            pci_device_file_desc,
+            bar4_uc_mapping.mapping_base);
 
         if (system_reg_mapping == MAP_FAILED) {
             throw std::runtime_error(fmt::format("BAR4 UC mapping failed for device {}.", pci_device_num));
         }
 
-        system_reg_start_offset = (512 - 16) * 1024*1024;
-        system_reg_offset_adjust = (512 - 32) * 1024*1024;
-    } else if(arch == tt::ARCH::BLACKHOLE) {
+        system_reg_start_offset = (512 - 16) * 1024 * 1024;
+        system_reg_offset_adjust = (512 - 32) * 1024 * 1024;
+    } else if (arch == tt::ARCH::BLACKHOLE) {
         if (bar2_uc_mapping.mapping_id != TENSTORRENT_MAPPING_RESOURCE1_UC) {
             throw std::runtime_error(fmt::format("Device {} has no BAR2 UC mapping.", pci_device_num));
         }
 
         // Using UnCachable memory mode. This is used for accessing registers on Blackhole.
         bar2_uc_size = bar2_uc_mapping.mapping_size;
-        bar2_uc = mmap(NULL, bar2_uc_mapping.mapping_size, PROT_READ | PROT_WRITE, MAP_SHARED, pci_device_file_desc, bar2_uc_mapping.mapping_base);
+        bar2_uc = mmap(
+            NULL,
+            bar2_uc_mapping.mapping_size,
+            PROT_READ | PROT_WRITE,
+            MAP_SHARED,
+            pci_device_file_desc,
+            bar2_uc_mapping.mapping_base);
 
         if (bar2_uc == MAP_FAILED) {
             throw std::runtime_error(fmt::format("BAR2 UC mapping failed for device {}.", pci_device_num));
@@ -379,7 +405,13 @@ PCIDevice::PCIDevice(int pci_device_number, int logical_device_id)
         // Using Write-Combine memory mode. This is used for accessing DRAM on Blackhole.
         // WC doesn't guarantee write ordering but has better performance.
         bar4_wc_size = bar4_wc_mapping.mapping_size;
-        bar4_wc = mmap(NULL, bar4_wc_mapping.mapping_size, PROT_READ | PROT_WRITE, MAP_SHARED, pci_device_file_desc, bar4_wc_mapping.mapping_base);
+        bar4_wc = mmap(
+            NULL,
+            bar4_wc_mapping.mapping_size,
+            PROT_READ | PROT_WRITE,
+            MAP_SHARED,
+            pci_device_file_desc,
+            bar4_wc_mapping.mapping_base);
 
         if (bar4_wc == MAP_FAILED) {
             throw std::runtime_error(fmt::format("BAR4 WC mapping failed for device {}.", pci_device_num));
@@ -391,7 +423,7 @@ PCIDevice::PCIDevice(int pci_device_number, int logical_device_id)
 }
 
 PCIDevice::~PCIDevice() {
-    for (const auto& hugepage_mapping : hugepage_mapping_per_channel) {
+    for (const auto &hugepage_mapping : hugepage_mapping_per_channel) {
         if (hugepage_mapping.mapping) {
             munmap(hugepage_mapping.mapping, hugepage_mapping.mapping_size);
         }
@@ -405,8 +437,8 @@ PCIDevice::~PCIDevice() {
         // essential for correctness then it needs to move to the driver.
         uint64_t iatu_index = 0;
         uint64_t iatu_base = UNROLL_ATU_OFFSET_BAR + iatu_index * 0x200;
-        uint32_t region_ctrl_2 = 0 << 31; // REGION_EN = 0
-        write_regs(reinterpret_cast<uint32_t*>(static_cast<uint8_t*>(bar2_uc) + iatu_base + 0x04), &region_ctrl_2, 1);
+        uint32_t region_ctrl_2 = 0 << 31;  // REGION_EN = 0
+        write_regs(reinterpret_cast<uint32_t *>(static_cast<uint8_t *>(bar2_uc) + iatu_base + 0x04), &region_ctrl_2, 1);
     }
 
     close(pci_device_file_desc);
@@ -432,8 +464,8 @@ PCIDevice::~PCIDevice() {
     }
 }
 
-template<typename T>
-T* PCIDevice::get_register_address(uint32_t register_offset) {
+template <typename T>
+T *PCIDevice::get_register_address(uint32_t register_offset) {
     // Right now, address can either be exposed register in BAR, or TLB window in BAR0 (BAR4 for Blackhole).
     // Should clarify this interface
     void *reg_mapping;
@@ -446,10 +478,10 @@ T* PCIDevice::get_register_address(uint32_t register_offset) {
         register_offset -= bar0_uc_offset;
         reg_mapping = bar0_uc;
     }
-    return reinterpret_cast<T*>(static_cast<uint8_t*>(reg_mapping) + register_offset);
+    return reinterpret_cast<T *>(static_cast<uint8_t *>(reg_mapping) + register_offset);
 }
 
-void PCIDevice::write_block(uint64_t byte_addr, uint64_t num_bytes, const uint8_t* buffer_addr) {
+void PCIDevice::write_block(uint64_t byte_addr, uint64_t num_bytes, const uint8_t *buffer_addr) {
     void *dest = nullptr;
     if (bar4_wc != nullptr && byte_addr >= BAR0_BH_SIZE) {
         byte_addr -= BAR0_BH_SIZE;
@@ -466,7 +498,7 @@ void PCIDevice::write_block(uint64_t byte_addr, uint64_t num_bytes, const uint8_
     }
 }
 
-void PCIDevice::read_block(uint64_t byte_addr, uint64_t num_bytes, uint8_t* buffer_addr) {
+void PCIDevice::read_block(uint64_t byte_addr, uint64_t num_bytes, uint8_t *buffer_addr) {
     void *src = nullptr;
     if (bar4_wc != nullptr && byte_addr >= BAR0_BH_SIZE) {
         byte_addr -= BAR0_BH_SIZE;
@@ -483,7 +515,7 @@ void PCIDevice::read_block(uint64_t byte_addr, uint64_t num_bytes, uint8_t* buff
     }
 
     if (num_bytes >= sizeof(std::uint32_t)) {
-        detect_hang_read(*reinterpret_cast<std::uint32_t*>(dest));
+        detect_hang_read(*reinterpret_cast<std::uint32_t *>(dest));
     }
 }
 
@@ -496,14 +528,14 @@ void PCIDevice::write_regs(volatile uint32_t *dest, const uint32_t *src, uint32_
 
 void PCIDevice::write_regs(uint32_t byte_addr, uint32_t word_len, const void *data) {
     volatile uint32_t *dest = get_register_address<uint32_t>(byte_addr);
-    const uint32_t *src = reinterpret_cast<const uint32_t*>(data);
+    const uint32_t *src = reinterpret_cast<const uint32_t *>(data);
 
     write_regs(dest, src, word_len);
 }
 
 void PCIDevice::read_regs(uint32_t byte_addr, uint32_t word_len, void *data) {
     const volatile uint32_t *src = get_register_address<uint32_t>(byte_addr);
-    uint32_t *dest = reinterpret_cast<uint32_t*>(data);
+    uint32_t *dest = reinterpret_cast<uint32_t *>(data);
 
     while (word_len-- != 0) {
         uint32_t temp = *src++;
@@ -511,29 +543,34 @@ void PCIDevice::read_regs(uint32_t byte_addr, uint32_t word_len, void *data) {
     }
 }
 
-void PCIDevice::write_tlb_reg(uint32_t byte_addr, uint64_t value_lower, uint64_t value_upper, uint32_t tlb_cfg_reg_size){
-    log_assert((tlb_cfg_reg_size == 8) or (tlb_cfg_reg_size == 12), "Tenstorrent hardware supports only 64bit or 96bit TLB config regs");
+void PCIDevice::write_tlb_reg(
+    uint32_t byte_addr, uint64_t value_lower, uint64_t value_upper, uint32_t tlb_cfg_reg_size) {
+    log_assert(
+        (tlb_cfg_reg_size == 8) or (tlb_cfg_reg_size == 12),
+        "Tenstorrent hardware supports only 64bit or 96bit TLB config regs");
 
     volatile uint64_t *dest_qw = get_register_address<uint64_t>(byte_addr);
-    volatile uint32_t *dest_extra_dw = get_register_address<uint32_t>(byte_addr+8);
+    volatile uint32_t *dest_extra_dw = get_register_address<uint32_t>(byte_addr + 8);
 #if defined(__ARM_ARCH) || defined(__riscv)
     // The store below goes through UC memory on x86, which has implicit ordering constraints with WC accesses.
-    // ARM has no concept of UC memory. This will not allow for implicit ordering of this store wrt other memory accesses.
-    // Insert an explicit full memory barrier for ARM.
-    // Do the same for RISC-V.
+    // ARM has no concept of UC memory. This will not allow for implicit ordering of this store wrt other memory
+    // accesses. Insert an explicit full memory barrier for ARM. Do the same for RISC-V.
     tt_driver_atomics::mfence();
 #endif
     *dest_qw = value_lower;
     if (tlb_cfg_reg_size > 8) {
-        uint32_t* p_value_upper = reinterpret_cast<uint32_t*>(&value_upper);
+        uint32_t *p_value_upper = reinterpret_cast<uint32_t *>(&value_upper);
         *dest_extra_dw = p_value_upper[0];
     }
-    tt_driver_atomics::mfence(); // Otherwise subsequent WC loads move earlier than the above UC store to the TLB register.
+    tt_driver_atomics::mfence();  // Otherwise subsequent WC loads move earlier than the above UC store to the TLB
+                                  // register.
 }
 
 bool PCIDevice::is_hardware_hung() {
-    volatile const void *addr = reinterpret_cast<const char *>(bar0_uc) + (get_architecture_implementation()->get_arc_reset_scratch_offset() + 6 * 4) - bar0_uc_offset;
-    std::uint32_t scratch_data = *reinterpret_cast<const volatile std::uint32_t*>(addr);
+    volatile const void *addr = reinterpret_cast<const char *>(bar0_uc) +
+                                (get_architecture_implementation()->get_arc_reset_scratch_offset() + 6 * 4) -
+                                bar0_uc_offset;
+    std::uint32_t scratch_data = *reinterpret_cast<const volatile std::uint32_t *>(addr);
 
     return (scratch_data == c_hang_read_value);
 }
@@ -547,55 +584,94 @@ void PCIDevice::detect_hang_read(std::uint32_t data_read) {
 }
 
 // Get TLB index (from zero), check if it's in 16MB, 2MB or 1MB TLB range, and dynamically program it.
-dynamic_tlb PCIDevice::set_dynamic_tlb(unsigned int tlb_index, tt_xy_pair start, tt_xy_pair end,
-                            std::uint64_t address, bool multicast, std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>>& harvested_coord_translation, std::uint64_t ordering) {
+dynamic_tlb PCIDevice::set_dynamic_tlb(
+    unsigned int tlb_index,
+    tt_xy_pair start,
+    tt_xy_pair end,
+    std::uint64_t address,
+    bool multicast,
+    std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>> &harvested_coord_translation,
+    std::uint64_t ordering) {
     auto architecture_implementation = get_architecture_implementation();
     if (multicast) {
         std::tie(start, end) = architecture_implementation->multicast_workaround(start, end);
     }
 
-    log_trace(LogSiliconDriver, "set_dynamic_tlb with arguments: tlb_index = {}, start = ({}, {}), end = ({}, {}), address = 0x{:x}, multicast = {}, ordering = {}",
-         tlb_index, start.x, start.y, end.x, end.y, address, multicast, (int)ordering);
+    log_trace(
+        LogSiliconDriver,
+        "set_dynamic_tlb with arguments: tlb_index = {}, start = ({}, {}), end = ({}, {}), address = 0x{:x}, multicast "
+        "= {}, ordering = {}",
+        tlb_index,
+        start.x,
+        start.y,
+        end.x,
+        end.y,
+        address,
+        multicast,
+        (int)ordering);
 
     tt::umd::tlb_configuration tlb_config = architecture_implementation->get_tlb_configuration(tlb_index);
     std::uint32_t TLB_CFG_REG_SIZE_BYTES = architecture_implementation->get_tlb_cfg_reg_size_bytes();
     auto translated_start_coords = harvested_coord_translation.at(logical_id).at(start);
     auto translated_end_coords = harvested_coord_translation.at(logical_id).at(end);
-    uint32_t tlb_address    = address / tlb_config.size;
-    uint32_t local_address   = address % tlb_config.size;
-    uint64_t tlb_base       = tlb_config.base + (tlb_config.size * tlb_config.index_offset);
-    uint32_t tlb_cfg_reg    = tlb_config.cfg_addr + (TLB_CFG_REG_SIZE_BYTES * tlb_config.index_offset);
+    uint32_t tlb_address = address / tlb_config.size;
+    uint32_t local_address = address % tlb_config.size;
+    uint64_t tlb_base = tlb_config.base + (tlb_config.size * tlb_config.index_offset);
+    uint32_t tlb_cfg_reg = tlb_config.cfg_addr + (TLB_CFG_REG_SIZE_BYTES * tlb_config.index_offset);
 
-    std::pair<std::uint64_t, std::uint64_t> tlb_data = tt::umd::tlb_data {
-        .local_offset = tlb_address,
-        .x_end = static_cast<uint64_t>(translated_end_coords.x),
-        .y_end = static_cast<uint64_t>(translated_end_coords.y),
-        .x_start = static_cast<uint64_t>(translated_start_coords.x),
-        .y_start = static_cast<uint64_t>(translated_start_coords.y),
-        .mcast = multicast,
-        .ordering = ordering,
-        // TODO #2715: hack for Blackhole A0, will potentially be fixed in B0.
-        // Using the same static vc for reads and writes through TLBs can hang the card. It doesn't even have to be the same TLB.
-        // Dynamic vc should not have this issue. There might be a perf impact with using dynamic vc.
-        .static_vc = (get_arch() == tt::ARCH::BLACKHOLE) ? false : true,
-    }.apply_offset(tlb_config.offset);
+    std::pair<std::uint64_t, std::uint64_t> tlb_data =
+        tt::umd::tlb_data{
+            .local_offset = tlb_address,
+            .x_end = static_cast<uint64_t>(translated_end_coords.x),
+            .y_end = static_cast<uint64_t>(translated_end_coords.y),
+            .x_start = static_cast<uint64_t>(translated_start_coords.x),
+            .y_start = static_cast<uint64_t>(translated_start_coords.y),
+            .mcast = multicast,
+            .ordering = ordering,
+            // TODO #2715: hack for Blackhole A0, will potentially be fixed in B0.
+            // Using the same static vc for reads and writes through TLBs can hang the card. It doesn't even have to be
+            // the same TLB. Dynamic vc should not have this issue. There might be a perf impact with using dynamic vc.
+            .static_vc = (get_arch() == tt::ARCH::BLACKHOLE) ? false : true,
+        }
+            .apply_offset(tlb_config.offset);
 
-    log_debug(LogSiliconDriver, "set_dynamic_tlb() with tlb_index: {} tlb_index_offset: {} dynamic_tlb_size: {}MB tlb_base: 0x{:x} tlb_cfg_reg: 0x{:x}", tlb_index, tlb_config.index_offset, tlb_config.size/(1024*1024), tlb_base, tlb_cfg_reg);
+    log_debug(
+        LogSiliconDriver,
+        "set_dynamic_tlb() with tlb_index: {} tlb_index_offset: {} dynamic_tlb_size: {}MB tlb_base: 0x{:x} "
+        "tlb_cfg_reg: 0x{:x}",
+        tlb_index,
+        tlb_config.index_offset,
+        tlb_config.size / (1024 * 1024),
+        tlb_base,
+        tlb_cfg_reg);
     write_tlb_reg(tlb_cfg_reg, tlb_data.first, tlb_data.second, TLB_CFG_REG_SIZE_BYTES);
 
-    return { tlb_base + local_address, tlb_config.size - local_address };
+    return {tlb_base + local_address, tlb_config.size - local_address};
 }
 
-dynamic_tlb PCIDevice::set_dynamic_tlb(unsigned int tlb_index, tt_xy_pair target, std::uint64_t address, std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>>& harvested_coord_translation, std::uint64_t ordering) {
+dynamic_tlb PCIDevice::set_dynamic_tlb(
+    unsigned int tlb_index,
+    tt_xy_pair target,
+    std::uint64_t address,
+    std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>> &harvested_coord_translation,
+    std::uint64_t ordering) {
     return set_dynamic_tlb(tlb_index, tt_xy_pair(0, 0), target, address, false, harvested_coord_translation, ordering);
 }
 
-dynamic_tlb PCIDevice::set_dynamic_tlb_broadcast(unsigned int tlb_index, std::uint64_t address, std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>>& harvested_coord_translation, tt_xy_pair start, tt_xy_pair end, std::uint64_t ordering) {
+dynamic_tlb PCIDevice::set_dynamic_tlb_broadcast(
+    unsigned int tlb_index,
+    std::uint64_t address,
+    std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>> &harvested_coord_translation,
+    tt_xy_pair start,
+    tt_xy_pair end,
+    std::uint64_t ordering) {
     // Issue a broadcast to cores included in the start (top left) and end (bottom right) grid
     return set_dynamic_tlb(tlb_index, start, end, address, true, harvested_coord_translation, ordering);
 }
 
-tt::umd::architecture_implementation* PCIDevice::get_architecture_implementation() const {return architecture_implementation.get();}
+tt::umd::architecture_implementation *PCIDevice::get_architecture_implementation() const {
+    return architecture_implementation.get();
+}
 
 bool PCIDevice::init_hugepage(uint32_t num_host_mem_channels) {
     const size_t hugepage_size = HUGEPAGE_REGION_SIZE;
@@ -605,7 +681,10 @@ bool PCIDevice::init_hugepage(uint32_t num_host_mem_channels) {
 
     std::string hugepage_dir = find_hugepage_dir(hugepage_size);
     if (hugepage_dir.empty()) {
-        log_warning(LogSiliconDriver, "ttSiliconDevice::init_hugepage: no huge page mount found for hugepage_size: {}.", hugepage_size);
+        log_warning(
+            LogSiliconDriver,
+            "ttSiliconDevice::init_hugepage: no huge page mount found for hugepage_size: {}.",
+            hugepage_size);
         return false;
     }
 
@@ -615,11 +694,14 @@ bool PCIDevice::init_hugepage(uint32_t num_host_mem_channels) {
 
     // Support for more than 1GB host memory accessible per device, via channels.
     for (int ch = 0; ch < num_host_mem_channels; ch++) {
-
         int hugepage_fd = open_hugepage_file(hugepage_dir, physical_device_id, ch);
         if (hugepage_fd == -1) {
             // Probably a permissions problem.
-            log_warning(LogSiliconDriver, "ttSiliconDevice::init_hugepage: physical_device_id: {} ch: {} creating hugepage mapping file failed.", physical_device_id, ch);
+            log_warning(
+                LogSiliconDriver,
+                "ttSiliconDevice::init_hugepage: physical_device_id: {} ch: {} creating hugepage mapping file failed.",
+                physical_device_id,
+                ch);
             success = false;
             continue;
         }
@@ -630,26 +712,43 @@ bool PCIDevice::init_hugepage(uint32_t num_host_mem_channels) {
             log_warning(LogSiliconDriver, "Error reading hugepage file size after opening.");
         }
 
-        std::byte *mapping = static_cast<std::byte*>(mmap(nullptr, hugepage_size, PROT_READ|PROT_WRITE, MAP_SHARED | MAP_POPULATE, hugepage_fd, 0));
+        std::byte *mapping = static_cast<std::byte *>(
+            mmap(nullptr, hugepage_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, hugepage_fd, 0));
 
         close(hugepage_fd);
 
         if (mapping == MAP_FAILED) {
-            log_warning(LogSiliconDriver, "UMD: Mapping a hugepage failed. (device: {}, {}/{} errno: {}).", physical_device_id, ch, num_host_mem_channels, strerror(errno));
+            log_warning(
+                LogSiliconDriver,
+                "UMD: Mapping a hugepage failed. (device: {}, {}/{} errno: {}).",
+                physical_device_id,
+                ch,
+                num_host_mem_channels,
+                strerror(errno));
             if (hugepage_st.st_size == 0) {
-                log_warning(LogSiliconDriver, "Opened hugepage file has zero size, mapping might've failed due to that. Verify that enough hugepages are provided.");
+                log_warning(
+                    LogSiliconDriver,
+                    "Opened hugepage file has zero size, mapping might've failed due to that. Verify that enough "
+                    "hugepages are provided.");
             }
-            print_file_contents("/proc/cmdline");\
-            print_file_contents("/sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages"); // Hardcoded for 1GB hugepage.
+            print_file_contents("/proc/cmdline");
+            print_file_contents(
+                "/sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages");  // Hardcoded for 1GB hugepage.
             success = false;
             continue;
         }
 
-        // Beter performance if hugepage just allocated (populate flag to prevent lazy alloc) is migrated to same numanode as TT device.
-        if (!tt::cpuset::tt_cpuset_allocator::bind_area_to_memory_nodeset(physical_device_id, mapping, hugepage_size)){
-            log_warning(LogSiliconDriver, "---- ttSiliconDevice::init_hugepage: bind_area_to_memory_nodeset() failed (physical_device_id: {} ch: {}). "
-            "Hugepage allocation is not on NumaNode matching TT Device. Side-Effect is decreased Device->Host perf (Issue #893).",
-            physical_device_id, ch);
+        // Beter performance if hugepage just allocated (populate flag to prevent lazy alloc) is migrated to same
+        // numanode as TT device.
+        if (!tt::cpuset::tt_cpuset_allocator::bind_area_to_memory_nodeset(physical_device_id, mapping, hugepage_size)) {
+            log_warning(
+                LogSiliconDriver,
+                "---- ttSiliconDevice::init_hugepage: bind_area_to_memory_nodeset() failed (physical_device_id: {} ch: "
+                "{}). "
+                "Hugepage allocation is not on NumaNode matching TT Device. Side-Effect is decreased Device->Host perf "
+                "(Issue #893).",
+                physical_device_id,
+                ch);
         }
 
         tenstorrent_pin_pages pin_pages;
@@ -662,7 +761,13 @@ bool PCIDevice::init_hugepage(uint32_t num_host_mem_channels) {
         auto fd = get_fd();
 
         if (ioctl(fd, TENSTORRENT_IOCTL_PIN_PAGES, &pin_pages) == -1) {
-            log_warning(LogSiliconDriver, "---- ttSiliconDevice::init_hugepage: physical_device_id: {} ch: {} TENSTORRENT_IOCTL_PIN_PAGES failed (errno: {}). Common Issue: Requires TTMKD >= 1.11, see following file contents...", physical_device_id, ch, strerror(errno));
+            log_warning(
+                LogSiliconDriver,
+                "---- ttSiliconDevice::init_hugepage: physical_device_id: {} ch: {} TENSTORRENT_IOCTL_PIN_PAGES failed "
+                "(errno: {}). Common Issue: Requires TTMKD >= 1.11, see following file contents...",
+                physical_device_id,
+                ch,
+                strerror(errno));
             munmap(mapping, hugepage_size);
             print_file_contents("/sys/module/tenstorrent/version", "(TTKMD version)");
             print_file_contents("/proc/meminfo");
@@ -673,15 +778,19 @@ bool PCIDevice::init_hugepage(uint32_t num_host_mem_channels) {
 
         hugepage_mapping_per_channel[ch] = {mapping, hugepage_size, pin_pages.out.physical_address};
 
-        log_debug(LogSiliconDriver, "ttSiliconDevice::init_hugepage: physical_device_id: {} ch: {} mapping_size: {} physical address 0x{:x}", physical_device_id, ch, hugepage_size, (unsigned long long)hugepage_mappings.at(device_id).at(ch).physical_address);
+        log_debug(
+            LogSiliconDriver,
+            "ttSiliconDevice::init_hugepage: physical_device_id: {} ch: {} mapping_size: {} physical address 0x{:x}",
+            physical_device_id,
+            ch,
+            hugepage_size,
+            (unsigned long long)hugepage_mappings.at(device_id).at(ch).physical_address);
     }
 
     return success;
 }
 
-int PCIDevice::get_num_host_mem_channels() const {
-    return hugepage_mapping_per_channel.size();
-}
+int PCIDevice::get_num_host_mem_channels() const { return hugepage_mapping_per_channel.size(); }
 
 hugepage_mapping PCIDevice::get_hugepage_mapping(int channel) const {
     if (channel < 0 || hugepage_mapping_per_channel.size() <= channel) {
@@ -691,10 +800,10 @@ hugepage_mapping PCIDevice::get_hugepage_mapping(int channel) const {
     }
 }
 
-void PCIDevice::print_file_contents(std::string filename, std::string hint){
-    if (std::filesystem::exists(filename)){
+void PCIDevice::print_file_contents(std::string filename, std::string hint) {
+    if (std::filesystem::exists(filename)) {
         std::ifstream meminfo(filename);
-        if (meminfo.is_open()){
+        if (meminfo.is_open()) {
             std::cout << std::endl << "File " << filename << " " << hint << " is: " << std::endl;
             std::cout << meminfo.rdbuf();
         }

--- a/device/pcie/pci_device.hpp
+++ b/device/pcie/pci_device.hpp
@@ -12,28 +12,30 @@
 #include <unordered_map>
 #include <vector>
 
-#include "device/tt_xy_pair.h"
+#include "device/tlb.h"
 #include "device/tt_arch_types.h"
 #include "device/tt_cluster_descriptor_types.h"
-#include "device/tlb.h"
+#include "device/tt_xy_pair.h"
 
 // TODO: this is used up in cluster.cpp but that logic ought to be
 // lowered into the PCIDevice class since it is specific to PCIe cards.
 // See /vendor_ip/synopsys/052021/bh_pcie_ctl_gen5/export/configuration/DWC_pcie_ctl.h
 static const uint64_t UNROLL_ATU_OFFSET_BAR = 0x1200;
 
-// TODO: this is a bit of a hack... something to revisit when we formalize an 
+// TODO: this is a bit of a hack... something to revisit when we formalize an
 // abstraction for IO.
 // BAR0 size for Blackhole, used to determine whether write block should use BAR0 or BAR4
 static const uint64_t BAR0_BH_SIZE = 512 * 1024 * 1024;
 
 constexpr unsigned int c_hang_read_value = 0xffffffffu;
 
-namespace tt::umd { class architecture_implementation; }
+namespace tt::umd {
+class architecture_implementation;
+}
 
 struct dynamic_tlb {
-    uint64_t bar_offset;        // Offset that address is mapped to, within the PCI BAR.
-    uint64_t remaining_size;    // Bytes remaining between bar_offset and end of the TLB.
+    uint64_t bar_offset;      // Offset that address is mapped to, within the PCI BAR.
+    uint64_t remaining_size;  // Bytes remaining between bar_offset and end of the TLB.
 };
 
 struct hugepage_mapping {
@@ -42,8 +44,7 @@ struct hugepage_mapping {
     uint64_t physical_address = 0;
 };
 
-struct PciDeviceInfo
-{
+struct PciDeviceInfo {
     uint16_t vendor_id;
     uint16_t device_id;
     uint16_t pci_domain;
@@ -57,14 +58,14 @@ struct PciDeviceInfo
 };
 
 class PCIDevice {
-    const std::string device_path;  // Path to character device: /dev/tenstorrent/N
-    const int pci_device_num;       // N in /dev/tenstorrent/N
-    const int logical_id;           // Unique identifier for each device in entire network topology
-    const int pci_device_file_desc; // Character device file descriptor
-    const PciDeviceInfo info;       // PCI device info
-    const int numa_node;            // -1 if non-NUMA
-    const int revision;             // PCI revision value from sysfs
-    const tt::ARCH arch;            // e.g. Grayskull, Wormhole, Blackhole
+    const std::string device_path;   // Path to character device: /dev/tenstorrent/N
+    const int pci_device_num;        // N in /dev/tenstorrent/N
+    const int logical_id;            // Unique identifier for each device in entire network topology
+    const int pci_device_file_desc;  // Character device file descriptor
+    const PciDeviceInfo info;        // PCI device info
+    const int numa_node;             // -1 if non-NUMA
+    const int revision;              // PCI revision value from sysfs
+    const tt::ARCH arch;             // e.g. Grayskull, Wormhole, Blackhole
     std::unique_ptr<tt::umd::architecture_implementation> architecture_implementation;
 
 public:
@@ -83,7 +84,7 @@ public:
      *
      * Opens the character device file descriptor, reads device information from
      * sysfs, and maps device memory region(s) into the process address space.
-     * 
+     *
      * @param pci_device_number     N in /dev/tenstorrent/N
      * @param logical_device_id     unique identifier for this device in the network topology
      */
@@ -95,8 +96,8 @@ public:
      */
     ~PCIDevice();
 
-    PCIDevice(const PCIDevice&) = delete; // copy
-    void operator=(const PCIDevice&) = delete; // copy assignment
+    PCIDevice(const PCIDevice &) = delete;       // copy
+    void operator=(const PCIDevice &) = delete;  // copy assignment
 
     /**
      * @return PCI device info
@@ -155,21 +156,39 @@ public:
     // NOC endpoints.  Probably worth waiting for the KMD to start owning the
     // resource management aspect of these PCIe->NOC mappings (the "TLBs")
     // before doing too much work here...
-    void write_block(uint64_t byte_addr, uint64_t num_bytes, const uint8_t* buffer_addr);
-    void read_block(uint64_t byte_addr, uint64_t num_bytes, uint8_t* buffer_addr);
+    void write_block(uint64_t byte_addr, uint64_t num_bytes, const uint8_t *buffer_addr);
+    void read_block(uint64_t byte_addr, uint64_t num_bytes, uint8_t *buffer_addr);
     void write_regs(uint32_t byte_addr, uint32_t word_len, const void *data);
     void write_regs(volatile uint32_t *dest, const uint32_t *src, uint32_t word_len);
     void read_regs(uint32_t byte_addr, uint32_t word_len, void *data);
 
     // TLB related functions.
     // TODO: These are architecture specific, and will be moved out of the class.
-    void write_tlb_reg(uint32_t byte_addr, std::uint64_t value_lower, std::uint64_t value_upper, std::uint32_t tlb_cfg_reg_size);
-    dynamic_tlb set_dynamic_tlb(unsigned int tlb_index, tt_xy_pair start, tt_xy_pair end,
-                                std::uint64_t address, bool multicast, std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>>& harvested_coord_translation, std::uint64_t ordering);
-    dynamic_tlb set_dynamic_tlb(unsigned int tlb_index, tt_xy_pair target, std::uint64_t address, std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>>& harvested_coord_translation, std::uint64_t ordering = tt::umd::tlb_data::Relaxed);
-    dynamic_tlb set_dynamic_tlb_broadcast(unsigned int tlb_index, std::uint64_t address, std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>>& harvested_coord_translation, tt_xy_pair start, tt_xy_pair end, std::uint64_t ordering = tt::umd::tlb_data::Relaxed);
+    void write_tlb_reg(
+        uint32_t byte_addr, std::uint64_t value_lower, std::uint64_t value_upper, std::uint32_t tlb_cfg_reg_size);
+    dynamic_tlb set_dynamic_tlb(
+        unsigned int tlb_index,
+        tt_xy_pair start,
+        tt_xy_pair end,
+        std::uint64_t address,
+        bool multicast,
+        std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>> &harvested_coord_translation,
+        std::uint64_t ordering);
+    dynamic_tlb set_dynamic_tlb(
+        unsigned int tlb_index,
+        tt_xy_pair target,
+        std::uint64_t address,
+        std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>> &harvested_coord_translation,
+        std::uint64_t ordering = tt::umd::tlb_data::Relaxed);
+    dynamic_tlb set_dynamic_tlb_broadcast(
+        unsigned int tlb_index,
+        std::uint64_t address,
+        std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>> &harvested_coord_translation,
+        tt_xy_pair start,
+        tt_xy_pair end,
+        std::uint64_t ordering = tt::umd::tlb_data::Relaxed);
 
-    tt::umd::architecture_implementation* get_architecture_implementation() const;
+    tt::umd::architecture_implementation *get_architecture_implementation() const;
     void detect_hang_read(uint32_t data_read = c_hang_read_value);
 
     // TODO: this also probably has more sense to live in the future TTDevice class.
@@ -197,8 +216,8 @@ public:
     // and simplify the code.
     void *system_reg_mapping = nullptr;
     size_t system_reg_mapping_size;
-    uint32_t system_reg_start_offset;  // Registers >= this are system regs, use the mapping.
-    uint32_t system_reg_offset_adjust; // This is the offset of the first reg in the system reg mapping.
+    uint32_t system_reg_start_offset;   // Registers >= this are system regs, use the mapping.
+    uint32_t system_reg_offset_adjust;  // This is the offset of the first reg in the system reg mapping.
 
     uint32_t read_checking_offset;
 
@@ -206,11 +225,10 @@ private:
     bool is_hardware_hung();
 
     template <typename T>
-    T* get_register_address(uint32_t register_offset);
+    T *get_register_address(uint32_t register_offset);
 
     // For debug purposes when various stages fails.
     void print_file_contents(std::string filename, std::string hint = "");
 
     std::vector<hugepage_mapping> hugepage_mapping_per_channel;
 };
-

--- a/device/simulation/deprecated/tt_emulation_device.cpp
+++ b/device/simulation/deprecated/tt_emulation_device.cpp
@@ -3,193 +3,231 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <stdexcept>
+#include "tt_emulation_device.h"
+
 #include <cstring>
+#include <stdexcept>
 
 #include "common/logger.hpp"
 #include "device/tt_cluster_descriptor.h"
-#include "tt_emulation_device.h"
 #include "tt_emu_zemi3_wrapper.h"
 
-
 tt_emulation_device::tt_emulation_device(const std::string& sdesc_path) : tt_device(sdesc_path) {
-  soc_descriptor_per_chip.emplace(0, tt_SocDescriptor(sdesc_path));
-  std::set<chip_id_t> target_devices = {0};
-  // create just a default one, we do not have cluster anyway
-  ndesc = tt_ClusterDescriptor::create_for_grayskull_cluster(target_devices, {});
-  tt_zebu_wrapper_inst = new tt_emu_zemi3_wrapper();
+    soc_descriptor_per_chip.emplace(0, tt_SocDescriptor(sdesc_path));
+    std::set<chip_id_t> target_devices = {0};
+    // create just a default one, we do not have cluster anyway
+    ndesc = tt_ClusterDescriptor::create_for_grayskull_cluster(target_devices, {});
+    tt_zebu_wrapper_inst = new tt_emu_zemi3_wrapper();
 
-  log_info(tt::LogEmulationDriver, "Created Emulation Device ");
+    log_info(tt::LogEmulationDriver, "Created Emulation Device ");
 }
 
 tt_emulation_device::~tt_emulation_device() {
-  ndesc.reset();
-  delete tt_zebu_wrapper_inst;
-  log_info(tt::LogEmulationDriver, "Destroyed Emulation Device ");
+    ndesc.reset();
+    delete tt_zebu_wrapper_inst;
+    log_info(tt::LogEmulationDriver, "Destroyed Emulation Device ");
 }
-  
+
 void tt_emulation_device::write(tt_cxy_pair core, uint64_t addr, const std::vector<uint8_t>& data) {
-  const uint32_t size = static_cast<uint32_t>(data.size());
-  tt_zebu_wrapper_inst->axi_write(0, core.x, core.y, addr, size, data); 
-  log_info(tt::LogEmulationDriver, "Wrote {} bytes to address {:#016x}, core {},{}", size, addr, core.x, core.y);
+    const uint32_t size = static_cast<uint32_t>(data.size());
+    tt_zebu_wrapper_inst->axi_write(0, core.x, core.y, addr, size, data);
+    log_info(tt::LogEmulationDriver, "Wrote {} bytes to address {:#016x}, core {},{}", size, addr, core.x, core.y);
 }
 
 std::vector<uint8_t> tt_emulation_device::read(tt_cxy_pair core, uint64_t addr, uint32_t size) {
-  std::vector<uint8_t> data(size);
-  tt_zebu_wrapper_inst->axi_read(0, core.x, core.y, addr, size, data);
-  log_info(tt::LogEmulationDriver, "Read {} bytes from address {:#016x}", size, addr);
+    std::vector<uint8_t> data(size);
+    tt_zebu_wrapper_inst->axi_read(0, core.x, core.y, addr, size, data);
+    log_info(tt::LogEmulationDriver, "Read {} bytes from address {:#016x}", size, addr);
 
-  return data;
+    return data;
 }
 
-
 void tt_emulation_device::start_device(const tt_device_params& device_params) {
-  tt_zebu_wrapper_inst->zebu_start();
-  tt_zebu_wrapper_inst->zebu_enable_waveform_dump(tt_zebu_wrapper::WAVEFORM_DUMP_QIWC);
-  log_info(tt::LogEmulationDriver, "Started Emulation Device ");
+    tt_zebu_wrapper_inst->zebu_start();
+    tt_zebu_wrapper_inst->zebu_enable_waveform_dump(tt_zebu_wrapper::WAVEFORM_DUMP_QIWC);
+    log_info(tt::LogEmulationDriver, "Started Emulation Device ");
 }
 
 void tt_emulation_device::deassert_risc_reset() {
-  tt_zebu_wrapper_inst->all_tensix_reset_deassert();
-  log_info(tt::LogEmulationDriver, "Deasserted all tensix RISC Reset ");
+    tt_zebu_wrapper_inst->all_tensix_reset_deassert();
+    log_info(tt::LogEmulationDriver, "Deasserted all tensix RISC Reset ");
 }
 
 void tt_emulation_device::assert_risc_reset() {
-  tt_zebu_wrapper_inst->all_tensix_reset_assert();
-  log_info(tt::LogEmulationDriver, "Asserted all tensix RISC Reset ");
+    tt_zebu_wrapper_inst->all_tensix_reset_assert();
+    log_info(tt::LogEmulationDriver, "Asserted all tensix RISC Reset ");
 }
 
-void tt_emulation_device::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets) {
-  tt_zebu_wrapper_inst->tensix_reset_deassert(core.x, core.y);
+void tt_emulation_device::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions& soft_resets) {
+    tt_zebu_wrapper_inst->tensix_reset_deassert(core.x, core.y);
 }
 
 void tt_emulation_device::assert_risc_reset_at_core(tt_cxy_pair core) {
-  tt_zebu_wrapper_inst->tensix_reset_assert(core.x, core.y);
+    tt_zebu_wrapper_inst->tensix_reset_assert(core.x, core.y);
 }
-
-
 
 void tt_emulation_device::close_device() {
     log_info(tt::LogEmulationDriver, "Closing Emulation Device ");
     tt_zebu_wrapper_inst->zebu_finish();
 }
 
-void tt_emulation_device::start(std::vector<std::string> plusargs, std::vector<std::string> dump_cores, bool no_checkers, bool /*init_device*/, bool /*skip_driver_allocs*/
+void tt_emulation_device::start(
+    std::vector<std::string> plusargs,
+    std::vector<std::string> dump_cores,
+    bool no_checkers,
+    bool /*init_device*/,
+    bool /*skip_driver_allocs*/
 ) {
-  log_info(tt::LogEmulationDriver, "Starting Emulation Device ");
+    log_info(tt::LogEmulationDriver, "Starting Emulation Device ");
 }
 
-
-void tt_emulation_device::broadcast_write_to_cluster(const void *mem_ptr, uint32_t size_in_bytes, uint64_t address, const std::set<chip_id_t>& chips_to_exclude, std::set<uint32_t>& rows_to_exclude, std::set<uint32_t>& cols_to_exclude, const std::string& fallback_tlb) {
-  for(const auto& core : get_soc_descriptor(0) -> cores) {
-    // if(cols_to_exclude.find(core.first.x) == cols_to_exclude.end() and rows_to_exclude.find(core.first.y) == rows_to_exclude.end() and core.second.type != CoreType::HARVESTED) {
-    //     write_to_device(mem_ptr, size_in_bytes, tt_cxy_pair(0, core.first.x, core.first.y), address, "");
-    //   }
-    // MT: Iterate through all the worker cores for bcast:
-    // if (get_soc_descriptor(0)->is_worker_core(core.first)) {
-    //   write_to_device(mem_ptr, size_in_bytes, tt_cxy_pair(0, core.first.x, core.first.y), address, "");
-    // }
-    // Emulation only broadcasts to all Tensix cores or all DRAM cores.
-    // differentiate which bcast pattern to use based on exclude columns
-    if (cols_to_exclude.find(0) == cols_to_exclude.end()) {
-      // Detect DRAM bcast
-      if (get_soc_descriptor(0)->is_dram_core(core.first)) {
-        write_to_device(mem_ptr, size_in_bytes, tt_cxy_pair(0, core.first.x, core.first.y), address, "");
-      }
-    } else {
-      if (get_soc_descriptor(0)->is_worker_core(core.first)) {
-        write_to_device(mem_ptr, size_in_bytes, tt_cxy_pair(0, core.first.x, core.first.y), address, "");
-      }
+void tt_emulation_device::broadcast_write_to_cluster(
+    const void* mem_ptr,
+    uint32_t size_in_bytes,
+    uint64_t address,
+    const std::set<chip_id_t>& chips_to_exclude,
+    std::set<uint32_t>& rows_to_exclude,
+    std::set<uint32_t>& cols_to_exclude,
+    const std::string& fallback_tlb) {
+    for (const auto& core : get_soc_descriptor(0)->cores) {
+        // if(cols_to_exclude.find(core.first.x) == cols_to_exclude.end() and rows_to_exclude.find(core.first.y) ==
+        // rows_to_exclude.end() and core.second.type != CoreType::HARVESTED) {
+        //     write_to_device(mem_ptr, size_in_bytes, tt_cxy_pair(0, core.first.x, core.first.y), address, "");
+        //   }
+        // MT: Iterate through all the worker cores for bcast:
+        // if (get_soc_descriptor(0)->is_worker_core(core.first)) {
+        //   write_to_device(mem_ptr, size_in_bytes, tt_cxy_pair(0, core.first.x, core.first.y), address, "");
+        // }
+        // Emulation only broadcasts to all Tensix cores or all DRAM cores.
+        // differentiate which bcast pattern to use based on exclude columns
+        if (cols_to_exclude.find(0) == cols_to_exclude.end()) {
+            // Detect DRAM bcast
+            if (get_soc_descriptor(0)->is_dram_core(core.first)) {
+                write_to_device(mem_ptr, size_in_bytes, tt_cxy_pair(0, core.first.x, core.first.y), address, "");
+            }
+        } else {
+            if (get_soc_descriptor(0)->is_worker_core(core.first)) {
+                write_to_device(mem_ptr, size_in_bytes, tt_cxy_pair(0, core.first.x, core.first.y), address, "");
+            }
+        }
     }
-  }
-} 
-void tt_emulation_device::rolled_write_to_device(std::vector<uint32_t>& base_vec, uint32_t unroll_count, tt_cxy_pair core, uint64_t base_addr, const std::string& tlb_to_use) {
-  std::vector<uint32_t> vec = base_vec;
-  uint32_t byte_increment = 4 * vec.size();
-  for (uint32_t i = 0; i < unroll_count; ++i) {
-    vec[0] = i; // slot id for debug
-    uint64_t offset_addr = base_addr + i * byte_increment;
-    write_to_device(vec, core, offset_addr, tlb_to_use);
-  }
-}
-void tt_emulation_device::write_to_device(const void *mem_ptr, uint32_t size, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use, bool send_epoch_cmd, bool last_send_epoch_cmd, bool ordered_with_prev_remote_write) {
-  log_assert(!(size % 4), "Writes to Emulation Backend should be 4 byte aligned!");
-
-  std::vector<std::uint32_t> mem_vector((uint32_t*)mem_ptr, (uint32_t*)mem_ptr + size / sizeof(uint32_t));
-  write_to_device(mem_vector, core, addr, tlb_to_use, send_epoch_cmd, last_send_epoch_cmd, ordered_with_prev_remote_write);
 }
 
-void tt_emulation_device::write_to_device(std::vector<uint32_t>& vec, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use, bool send_epoch_cmd, bool last_send_epoch_cmd, bool ordered_with_prev_remote_write) {
-
-  std::vector<uint8_t> byte_data(vec.size() * sizeof(uint32_t));
-  std::memcpy(byte_data.data(), vec.data(), byte_data.size());
-
-  write(core, addr, byte_data);
+void tt_emulation_device::rolled_write_to_device(
+    std::vector<uint32_t>& base_vec,
+    uint32_t unroll_count,
+    tt_cxy_pair core,
+    uint64_t base_addr,
+    const std::string& tlb_to_use) {
+    std::vector<uint32_t> vec = base_vec;
+    uint32_t byte_increment = 4 * vec.size();
+    for (uint32_t i = 0; i < unroll_count; ++i) {
+        vec[0] = i;  // slot id for debug
+        uint64_t offset_addr = base_addr + i * byte_increment;
+        write_to_device(vec, core, offset_addr, tlb_to_use);
+    }
 }
 
-void tt_emulation_device::l1_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {
+void tt_emulation_device::write_to_device(
+    const void* mem_ptr,
+    uint32_t size,
+    tt_cxy_pair core,
+    uint64_t addr,
+    const std::string& tlb_to_use,
+    bool send_epoch_cmd,
+    bool last_send_epoch_cmd,
+    bool ordered_with_prev_remote_write) {
+    log_assert(!(size % 4), "Writes to Emulation Backend should be 4 byte aligned!");
+
+    std::vector<std::uint32_t> mem_vector((uint32_t*)mem_ptr, (uint32_t*)mem_ptr + size / sizeof(uint32_t));
+    write_to_device(
+        mem_vector, core, addr, tlb_to_use, send_epoch_cmd, last_send_epoch_cmd, ordered_with_prev_remote_write);
+}
+
+void tt_emulation_device::write_to_device(
+    std::vector<uint32_t>& vec,
+    tt_cxy_pair core,
+    uint64_t addr,
+    const std::string& tlb_to_use,
+    bool send_epoch_cmd,
+    bool last_send_epoch_cmd,
+    bool ordered_with_prev_remote_write) {
+    std::vector<uint8_t> byte_data(vec.size() * sizeof(uint32_t));
+    std::memcpy(byte_data.data(), vec.data(), byte_data.size());
+
+    write(core, addr, byte_data);
+}
+
+void tt_emulation_device::l1_membar(
+    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {
     // Placeholder - implement later - https://yyz-gitlab.local.tenstorrent.com/tenstorrent/open-umd/-/issues/26
 }
 
-void tt_emulation_device::dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {
+void tt_emulation_device::dram_membar(
+    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {
     // Placeholder - implement later - https://yyz-gitlab.local.tenstorrent.com/tenstorrent/open-umd/-/issues/26
 }
 
-void tt_emulation_device::dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels) {
+void tt_emulation_device::dram_membar(
+    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels) {
     // Placeholder - implement later - https://yyz-gitlab.local.tenstorrent.com/tenstorrent/open-umd/-/issues/26
 }
 
+void tt_emulation_device::read_from_device(
+    std::vector<uint32_t>& vec, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& /*tlb_to_use*/) {
+    std::vector<uint8_t> byte_data = read(core, addr, size);
 
+    // Verify that the received byte data can be converted to uint32_t
+    // if (byte_data.size() % sizeof(uint32_t) != 0) {
+    //   throw std::runtime_error("Received byte data size is not a multiple of uint32_t size.");
+    // }
 
-void tt_emulation_device::read_from_device(std::vector<uint32_t>& vec, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& /*tlb_to_use*/) {
-  std::vector<uint8_t> byte_data = read(core, addr, size);
-
-  // Verify that the received byte data can be converted to uint32_t
-  // if (byte_data.size() % sizeof(uint32_t) != 0) {
-  //   throw std::runtime_error("Received byte data size is not a multiple of uint32_t size.");
-  // }
-
-  vec.clear();
-  vec.resize(byte_data.size() / sizeof(uint32_t));
-  std::memcpy(vec.data(), byte_data.data(), byte_data.size());
+    vec.clear();
+    vec.resize(byte_data.size() / sizeof(uint32_t));
+    std::memcpy(vec.data(), byte_data.data(), byte_data.size());
 }
 
 void tt_emulation_device::translate_to_noc_table_coords(chip_id_t device_id, std::size_t& r, std::size_t& c) {
-  // No translation is performed
-  return;
+    // No translation is performed
+    return;
 }
+
 tt_ClusterDescriptor* tt_emulation_device::get_cluster_description() { return ndesc.get(); }
 
 std::set<chip_id_t> tt_emulation_device::get_target_mmio_device_ids() {
-  log_error("LogEmulationDriver: get_target_mmio_device_ids not implemented");
-  return {};
+    log_error("LogEmulationDriver: get_target_mmio_device_ids not implemented");
+    return {};
 }
 
 std::set<chip_id_t> tt_emulation_device::get_target_remote_device_ids() {
-  log_error("LogEmulationDriver: get_target_remote_device_ids not implemented");
-  return {};
+    log_error("LogEmulationDriver: get_target_remote_device_ids not implemented");
+    return {};
 }
 
 void tt_emulation_device::set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_) {
     dram_address_params = dram_address_params_;
 }
+
 int tt_emulation_device::get_number_of_chips_in_cluster() { return detect_number_of_chips(); }
-std::unordered_set<int> tt_emulation_device::get_all_chips_in_cluster() { return { 0 }; }
+
+std::unordered_set<int> tt_emulation_device::get_all_chips_in_cluster() { return {0}; }
+
 int tt_emulation_device::detect_number_of_chips() { return 1; }
 
 bool tt_emulation_device::using_harvested_soc_descriptors() { return false; }
+
 bool tt_emulation_device::noc_translation_en() { return false; }
-std::unordered_map<chip_id_t, uint32_t> tt_emulation_device::get_harvesting_masks_for_soc_descriptors() { return {{0, 0}};}
 
-std::unordered_map<chip_id_t, tt_SocDescriptor>& tt_emulation_device::get_virtual_soc_descriptors() {return soc_descriptor_per_chip;}
-
-std::map<int, int> tt_emulation_device::get_clocks() {
-  return std::map<int, int>();
+std::unordered_map<chip_id_t, uint32_t> tt_emulation_device::get_harvesting_masks_for_soc_descriptors() {
+    return {{0, 0}};
 }
+
+std::unordered_map<chip_id_t, tt_SocDescriptor>& tt_emulation_device::get_virtual_soc_descriptors() {
+    return soc_descriptor_per_chip;
+}
+
+std::map<int, int> tt_emulation_device::get_clocks() { return std::map<int, int>(); }
 
 void tt_emulation_device::set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_) {
-  l1_address_params = l1_address_params_;
+    l1_address_params = l1_address_params_;
 }
-
-
-

--- a/device/simulation/deprecated/tt_emulation_device.h
+++ b/device/simulation/deprecated/tt_emulation_device.h
@@ -9,63 +9,97 @@
 #include <cstdint>
 #include <fstream>
 #include <vector>
+
+#include "cluster.h"
 #include "tt_soc_descriptor.h"
 #include "tt_xy_pair.h"
-#include "cluster.h"
 
 // use forward declaration here so we do not need to include tt_zebu_wrapper.h
 class tt_zebu_wrapper;
 
 class tt_emulation_device : public tt_device {
 public:
-  virtual void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_); // Dont care
-  tt_emulation_device(const std::string& sdesc_path);
-  virtual void start(std::vector<std::string> plusargs, std::vector<std::string> dump_cores, bool no_checkers, bool init_device, bool skip_driver_allocs);
-  virtual void start_device(const tt_device_params& device_params);
-  virtual void close_device();
-  virtual void deassert_risc_reset();
-  virtual void deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets = TENSIX_DEASSERT_SOFT_RESET);
-  virtual void assert_risc_reset();
-  virtual void assert_risc_reset_at_core(tt_cxy_pair core);
-  virtual void write_to_device(std::vector<uint32_t>& vec, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use, bool send_epoch_cmd = false, bool last_send_epoch_cmd = true, bool ordered_with_prev_remote_write = false);
-  virtual void write_to_device(const void *mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use, bool send_epoch_cmd = false, bool last_send_epoch_cmd = true, bool ordered_with_prev_remote_write = false);
-  virtual void broadcast_write_to_cluster(const void *mem_ptr, uint32_t size_in_bytes, uint64_t address, const std::set<chip_id_t>& chips_to_exclude, std::set<uint32_t>& rows_to_exclude, std::set<uint32_t>& columns_to_exclude, const std::string& fallback_tlb);
+    virtual void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_);  // Dont care
+    tt_emulation_device(const std::string& sdesc_path);
+    virtual void start(
+        std::vector<std::string> plusargs,
+        std::vector<std::string> dump_cores,
+        bool no_checkers,
+        bool init_device,
+        bool skip_driver_allocs);
+    virtual void start_device(const tt_device_params& device_params);
+    virtual void close_device();
+    virtual void deassert_risc_reset();
+    virtual void deassert_risc_reset_at_core(
+        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET);
+    virtual void assert_risc_reset();
+    virtual void assert_risc_reset_at_core(tt_cxy_pair core);
+    virtual void write_to_device(
+        std::vector<uint32_t>& vec,
+        tt_cxy_pair core,
+        uint64_t addr,
+        const std::string& tlb_to_use,
+        bool send_epoch_cmd = false,
+        bool last_send_epoch_cmd = true,
+        bool ordered_with_prev_remote_write = false);
+    virtual void write_to_device(
+        const void* mem_ptr,
+        uint32_t size_in_bytes,
+        tt_cxy_pair core,
+        uint64_t addr,
+        const std::string& tlb_to_use,
+        bool send_epoch_cmd = false,
+        bool last_send_epoch_cmd = true,
+        bool ordered_with_prev_remote_write = false);
+    virtual void broadcast_write_to_cluster(
+        const void* mem_ptr,
+        uint32_t size_in_bytes,
+        uint64_t address,
+        const std::set<chip_id_t>& chips_to_exclude,
+        std::set<uint32_t>& rows_to_exclude,
+        std::set<uint32_t>& columns_to_exclude,
+        const std::string& fallback_tlb);
 
-  void l1_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
-  void dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels);
-  void dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
+    void l1_membar(
+        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
+    void dram_membar(
+        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels);
+    void dram_membar(
+        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
 
-  virtual void rolled_write_to_device(std::vector<uint32_t>& base_vec, uint32_t unroll_count, tt_cxy_pair core, uint64_t base_addr, const std::string& tlb_to_use); // See Versim Implementation
-  virtual void read_from_device(std::vector<uint32_t>& vec, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use);
+    virtual void rolled_write_to_device(
+        std::vector<uint32_t>& base_vec,
+        uint32_t unroll_count,
+        tt_cxy_pair core,
+        uint64_t base_addr,
+        const std::string& tlb_to_use);  // See Versim Implementation
+    virtual void read_from_device(
+        std::vector<uint32_t>& vec, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use);
 
-  virtual void translate_to_noc_table_coords(chip_id_t device_id, std::size_t& r, std::size_t& c);
-  virtual bool using_harvested_soc_descriptors();
-  virtual std::unordered_map<chip_id_t, uint32_t> get_harvesting_masks_for_soc_descriptors();
-  virtual std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors();
-  virtual bool noc_translation_en();
-  virtual std::set<chip_id_t> get_target_mmio_device_ids(); 
-  virtual std::set<chip_id_t> get_target_remote_device_ids();
-  virtual ~tt_emulation_device(); 
-  virtual tt_ClusterDescriptor* get_cluster_description();
-  virtual void set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_);
-  virtual int get_number_of_chips_in_cluster(); 
-  virtual std::unordered_set<chip_id_t> get_all_chips_in_cluster(); 
-  static int detect_number_of_chips();  
-  virtual std::map<int, int> get_clocks(); 
+    virtual void translate_to_noc_table_coords(chip_id_t device_id, std::size_t& r, std::size_t& c);
+    virtual bool using_harvested_soc_descriptors();
+    virtual std::unordered_map<chip_id_t, uint32_t> get_harvesting_masks_for_soc_descriptors();
+    virtual std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors();
+    virtual bool noc_translation_en();
+    virtual std::set<chip_id_t> get_target_mmio_device_ids();
+    virtual std::set<chip_id_t> get_target_remote_device_ids();
+    virtual ~tt_emulation_device();
+    virtual tt_ClusterDescriptor* get_cluster_description();
+    virtual void set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_);
+    virtual int get_number_of_chips_in_cluster();
+    virtual std::unordered_set<chip_id_t> get_all_chips_in_cluster();
+    static int detect_number_of_chips();
+    virtual std::map<int, int> get_clocks();
+
 private:
+    tt_device_l1_address_params l1_address_params;
+    std::shared_ptr<tt_ClusterDescriptor> ndesc;
+    tt_device_dram_address_params dram_address_params;
 
-  tt_device_l1_address_params l1_address_params;
-  std::shared_ptr<tt_ClusterDescriptor> ndesc;
-  tt_device_dram_address_params dram_address_params;
-  
-  // zebu wrapper, provides interface to zebu emulator device through axi and command transactors
-  tt_zebu_wrapper *tt_zebu_wrapper_inst = NULL;
+    // zebu wrapper, provides interface to zebu emulator device through axi and command transactors
+    tt_zebu_wrapper* tt_zebu_wrapper_inst = NULL;
 
-
-
-  // These functions implement the "protocol" between the RTL simulation and the UMD
-  void write(tt_cxy_pair core, uint64_t addr, const std::vector<uint8_t>& data);
-  std::vector<uint8_t> read(tt_cxy_pair core, uint64_t addr, uint32_t size);
-  
+    // These functions implement the "protocol" between the RTL simulation and the UMD
+    void write(tt_cxy_pair core, uint64_t addr, const std::vector<uint8_t>& data);
+    std::vector<uint8_t> read(tt_cxy_pair core, uint64_t addr, uint32_t size);
 };
-

--- a/device/simulation/deprecated/tt_emulation_stub.cpp
+++ b/device/simulation/deprecated/tt_emulation_stub.cpp
@@ -3,23 +3,21 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <stdexcept>
 #include <cstring>
+#include <stdexcept>
 
 #include "common/logger.hpp"
 #include "tt_emulation_device.h"
 
 tt_emulation_device::tt_emulation_device(const std::string& sdesc_path) : tt_device(sdesc_path) {
-  throw std::runtime_error("tt_emulation_device() -- Zebu Emulation is not supported in this build\n");
+    throw std::runtime_error("tt_emulation_device() -- Zebu Emulation is not supported in this build\n");
 }
 
-
 tt_emulation_device::~tt_emulation_device() {}
-  
+
 void tt_emulation_device::write(tt_cxy_pair core, uint64_t addr, const std::vector<uint8_t>& data) {}
 
-std::vector<uint8_t> tt_emulation_device::read(tt_cxy_pair core, uint64_t addr, uint32_t size) {return {};}
-
+std::vector<uint8_t> tt_emulation_device::read(tt_cxy_pair core, uint64_t addr, uint32_t size) { return {}; }
 
 void tt_emulation_device::start_device(const tt_device_params& device_params) {}
 
@@ -27,52 +25,99 @@ void tt_emulation_device::deassert_risc_reset() {}
 
 void tt_emulation_device::assert_risc_reset() {}
 
-void tt_emulation_device::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets) {}
+void tt_emulation_device::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions& soft_resets) {}
 
 void tt_emulation_device::assert_risc_reset_at_core(tt_cxy_pair core) {}
 
 void tt_emulation_device::close_device() {}
 
-void tt_emulation_device::start(std::vector<std::string> plusargs, std::vector<std::string> dump_cores, bool no_checkers, bool /*init_device*/, bool /*skip_driver_allocs*/) {}
+void tt_emulation_device::start(
+    std::vector<std::string> plusargs,
+    std::vector<std::string> dump_cores,
+    bool no_checkers,
+    bool /*init_device*/,
+    bool /*skip_driver_allocs*/) {}
 
+void tt_emulation_device::broadcast_write_to_cluster(
+    const void* mem_ptr,
+    uint32_t size_in_bytes,
+    uint64_t address,
+    const std::set<chip_id_t>& chips_to_exclude,
+    std::set<uint32_t>& rows_to_exclude,
+    std::set<uint32_t>& cols_to_exclude,
+    const std::string& fallback_tlb) {}
 
-void tt_emulation_device::broadcast_write_to_cluster(const void *mem_ptr, uint32_t size_in_bytes, uint64_t address, const std::set<chip_id_t>& chips_to_exclude, std::set<uint32_t>& rows_to_exclude, std::set<uint32_t>& cols_to_exclude, const std::string& fallback_tlb) {} 
-void tt_emulation_device::rolled_write_to_device(std::vector<uint32_t>& base_vec, uint32_t unroll_count, tt_cxy_pair core, uint64_t base_addr, const std::string& tlb_to_use) {}
+void tt_emulation_device::rolled_write_to_device(
+    std::vector<uint32_t>& base_vec,
+    uint32_t unroll_count,
+    tt_cxy_pair core,
+    uint64_t base_addr,
+    const std::string& tlb_to_use) {}
 
-void tt_emulation_device::write_to_device(std::vector<uint32_t>& vec, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use, bool send_epoch_cmd, bool last_send_epoch_cmd, bool ordered_with_prev_remote_write) {}
-void tt_emulation_device::write_to_device(const void *mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use, bool send_epoch_cmd, bool last_send_epoch_cmd, bool ordered_with_prev_remote_write) {};
-void tt_emulation_device::read_from_device(std::vector<uint32_t>& vec, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& /*tlb_to_use*/) {}
-void tt_emulation_device::l1_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {}
-void tt_emulation_device::dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {}
-void tt_emulation_device::dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels) {}
+void tt_emulation_device::write_to_device(
+    std::vector<uint32_t>& vec,
+    tt_cxy_pair core,
+    uint64_t addr,
+    const std::string& tlb_to_use,
+    bool send_epoch_cmd,
+    bool last_send_epoch_cmd,
+    bool ordered_with_prev_remote_write) {}
 
+void tt_emulation_device::write_to_device(
+    const void* mem_ptr,
+    uint32_t size_in_bytes,
+    tt_cxy_pair core,
+    uint64_t addr,
+    const std::string& tlb_to_use,
+    bool send_epoch_cmd,
+    bool last_send_epoch_cmd,
+    bool ordered_with_prev_remote_write){};
+
+void tt_emulation_device::read_from_device(
+    std::vector<uint32_t>& vec, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& /*tlb_to_use*/) {}
+
+void tt_emulation_device::l1_membar(
+    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {}
+
+void tt_emulation_device::dram_membar(
+    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {}
+
+void tt_emulation_device::dram_membar(
+    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels) {}
 
 // -------------------------
 // Not sure how to implement these functions below, leaving them blank/default for now
 void tt_emulation_device::translate_to_noc_table_coords(chip_id_t device_id, std::size_t& r, std::size_t& c) {
-  // No translation is performed
-  return;
+    // No translation is performed
+    return;
 }
+
 tt_ClusterDescriptor* tt_emulation_device::get_cluster_description() { return ndesc.get(); }
 
-std::set<chip_id_t> tt_emulation_device::get_target_mmio_device_ids() {return {};}
+std::set<chip_id_t> tt_emulation_device::get_target_mmio_device_ids() { return {}; }
 
-std::set<chip_id_t> tt_emulation_device::get_target_remote_device_ids() {return {};}
+std::set<chip_id_t> tt_emulation_device::get_target_remote_device_ids() { return {}; }
 
 void tt_emulation_device::set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_) {}
+
 int tt_emulation_device::get_number_of_chips_in_cluster() { return detect_number_of_chips(); }
-std::unordered_set<int> tt_emulation_device::get_all_chips_in_cluster() { return { 0 }; }
+
+std::unordered_set<int> tt_emulation_device::get_all_chips_in_cluster() { return {0}; }
+
 int tt_emulation_device::detect_number_of_chips() { return 1; }
 
 bool tt_emulation_device::using_harvested_soc_descriptors() { return false; }
+
 bool tt_emulation_device::noc_translation_en() { return false; }
-std::unordered_map<chip_id_t, uint32_t> tt_emulation_device::get_harvesting_masks_for_soc_descriptors() { return {{0, 0}};}
 
-std::unordered_map<chip_id_t, tt_SocDescriptor>& tt_emulation_device::get_virtual_soc_descriptors() {return soc_descriptor_per_chip;}
+std::unordered_map<chip_id_t, uint32_t> tt_emulation_device::get_harvesting_masks_for_soc_descriptors() {
+    return {{0, 0}};
+}
 
-std::map<int, int> tt_emulation_device::get_clocks() {return std::map<int, int>();}
+std::unordered_map<chip_id_t, tt_SocDescriptor>& tt_emulation_device::get_virtual_soc_descriptors() {
+    return soc_descriptor_per_chip;
+}
+
+std::map<int, int> tt_emulation_device::get_clocks() { return std::map<int, int>(); }
 
 void tt_emulation_device::set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_) {}
-
-
-

--- a/device/simulation/deprecated/tt_versim_device.cpp
+++ b/device/simulation/deprecated/tt_versim_device.cpp
@@ -2,16 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-
-
-#include "cluster.h"
-#include "device/driver_atomics.h"
-#include "common/logger.hpp"
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <vector>
 
+#include "cluster.h"
+#include "common/logger.hpp"
+#include "device/driver_atomics.h"
 #include "yaml-cpp/yaml.h"
 
 // TODO: Remove dependency on command_assembler + soc
@@ -19,63 +17,77 @@
 #include "device/tt_cluster_descriptor.h"
 namespace CA = CommandAssembler;
 
-
-void translate_soc_descriptor_to_ca_soc(CA::Soc &soc, const tt_SocDescriptor soc_descriptor) {
-  for (auto &core : soc_descriptor.cores) {
-    CA::SocNocNode node;
-    CA::xy_pair CA_coord(core.first.x, core.first.y);
-    node.noc_coord = CA_coord;
-    node.memory_size = core.second.l1_size;
-    switch (core.second.type) {
-      case CoreType::ARC: node.arc = true; break;
-      case CoreType::DRAM: {
-        node.dram = true; 
-        #ifdef EN_DRAM_ALIAS
-          node.dram_channel_id = std::get<0>(soc_descriptor.dram_core_channel_map.at(core.first));
-        #endif
-      } break;
-      case CoreType::ETH: node.eth = true; break;
-      case CoreType::PCIE: node.pcie = true; break;
-      case CoreType::WORKER: node.worker = true; break;
-      case CoreType::HARVESTED: node.harvested = true; break;
-      case CoreType::ROUTER_ONLY: node.router_only = true; break;
-      default: std::cout << " Error: Unsupported CoreType type: " << static_cast<int>(core.second.type) << std::endl; break;
+void translate_soc_descriptor_to_ca_soc(CA::Soc& soc, const tt_SocDescriptor soc_descriptor) {
+    for (auto& core : soc_descriptor.cores) {
+        CA::SocNocNode node;
+        CA::xy_pair CA_coord(core.first.x, core.first.y);
+        node.noc_coord = CA_coord;
+        node.memory_size = core.second.l1_size;
+        switch (core.second.type) {
+            case CoreType::ARC:
+                node.arc = true;
+                break;
+            case CoreType::DRAM: {
+                node.dram = true;
+#ifdef EN_DRAM_ALIAS
+                node.dram_channel_id = std::get<0>(soc_descriptor.dram_core_channel_map.at(core.first));
+#endif
+            } break;
+            case CoreType::ETH:
+                node.eth = true;
+                break;
+            case CoreType::PCIE:
+                node.pcie = true;
+                break;
+            case CoreType::WORKER:
+                node.worker = true;
+                break;
+            case CoreType::HARVESTED:
+                node.harvested = true;
+                break;
+            case CoreType::ROUTER_ONLY:
+                node.router_only = true;
+                break;
+            default:
+                std::cout << " Error: Unsupported CoreType type: " << static_cast<int>(core.second.type) << std::endl;
+                break;
+        }
+        soc.SetNodeProperties(node.noc_coord, node);
     }
-    soc.SetNodeProperties(node.noc_coord, node);
-  }
 }
 
 ////////
 // Device Versim
 ////////
 
-#include "device.h"
-#include "sim_interactive.h"
 #include <command_assembler/xy_pair.h>
 
-tt_VersimDevice::tt_VersimDevice(const std::string &sdesc_path, const std::string &ndesc_path) : tt_device(sdesc_path) {
-  soc_descriptor_per_chip.emplace(0, tt_SocDescriptor(sdesc_path));
-  std::set<chip_id_t> target_devices = {0};
-  if (ndesc_path == "") {
-    ndesc = tt_ClusterDescriptor::create_for_grayskull_cluster(target_devices, {});
-  } 
-  else {
-    ndesc = tt_ClusterDescriptor::create_from_yaml(ndesc_path);
-  }
+#include "device.h"
+#include "sim_interactive.h"
+
+tt_VersimDevice::tt_VersimDevice(const std::string& sdesc_path, const std::string& ndesc_path) : tt_device(sdesc_path) {
+    soc_descriptor_per_chip.emplace(0, tt_SocDescriptor(sdesc_path));
+    std::set<chip_id_t> target_devices = {0};
+    if (ndesc_path == "") {
+        ndesc = tt_ClusterDescriptor::create_for_grayskull_cluster(target_devices, {});
+    } else {
+        ndesc = tt_ClusterDescriptor::create_from_yaml(ndesc_path);
+    }
 }
 
-std::unordered_map<chip_id_t, tt_SocDescriptor>& tt_VersimDevice::get_virtual_soc_descriptors() {return soc_descriptor_per_chip;}
-
-tt_ClusterDescriptor* tt_VersimDevice::get_cluster_description() {return ndesc.get();}
-void tt_VersimDevice::start_device(const tt_device_params &device_params) {
-  bool no_checkers = true;
-  std::vector<std::string> dump_cores = device_params.unroll_vcd_dump_cores(get_soc_descriptor(0) -> grid_size);
-  start(device_params.expand_plusargs(), dump_cores, no_checkers, device_params.init_device, false);
+std::unordered_map<chip_id_t, tt_SocDescriptor>& tt_VersimDevice::get_virtual_soc_descriptors() {
+    return soc_descriptor_per_chip;
 }
 
-void tt_VersimDevice::close_device() {
-  stop();
+tt_ClusterDescriptor* tt_VersimDevice::get_cluster_description() { return ndesc.get(); }
+
+void tt_VersimDevice::start_device(const tt_device_params& device_params) {
+    bool no_checkers = true;
+    std::vector<std::string> dump_cores = device_params.unroll_vcd_dump_cores(get_soc_descriptor(0)->grid_size);
+    start(device_params.expand_plusargs(), dump_cores, no_checkers, device_params.init_device, false);
 }
+
+void tt_VersimDevice::close_device() { stop(); }
 
 void tt_VersimDevice::start(
     std::vector<std::string> plusargs,
@@ -83,48 +95,56 @@ void tt_VersimDevice::start(
     bool no_checkers,
     bool /*init_device*/,
     bool /*skip_driver_allocs*/
-    ) {
+) {
+    std::cout << "Start Versim Device " << std::endl;
+    std::string device_descriptor_dir = "./";
 
-     std::cout << "Start Versim Device " << std::endl;
-     std::string device_descriptor_dir = "./";
+    std::optional<std::string> vcd_suffix;
+    if (dump_cores.size() > 0) {
+        vcd_suffix = "core_dump.vcd";
+    }
 
-     std::optional<std::string> vcd_suffix;
-     if (dump_cores.size() > 0) {
-       vcd_suffix = "core_dump.vcd";
-     }
+    std::vector<std::string> vcd_cores;
 
-     std::vector<std::string> vcd_cores;
+    // TODO: For now create a temporary stuff from CA and populate from descriptor before passing back to versim-core
+    // interface. mainly bypasses arch_configs etc from llir.  We can populate soc directly
+    // MT: have to preserve ca_soc_descriptor object since versim references it at runtime
+    CA::xy_pair CA_grid_size(
+        (soc_descriptor_per_chip.begin()->second).grid_size.x, (soc_descriptor_per_chip.begin()->second).grid_size.y);
+    // CA::Soc ca_soc_manager(CA_grid_size);
+    std::unique_ptr<CA::Soc> p_ca_soc_manager_unique = std::make_unique<CA::Soc>(CA_grid_size);
+    translate_soc_descriptor_to_ca_soc(*p_ca_soc_manager_unique, (soc_descriptor_per_chip.begin()->second));
+    // TODO: End
 
-     // TODO: For now create a temporary stuff from CA and populate from descriptor before passing back to versim-core
-     // interface. mainly bypasses arch_configs etc from llir.  We can populate soc directly
-     // MT: have to preserve ca_soc_descriptor object since versim references it at runtime
-     CA::xy_pair CA_grid_size((soc_descriptor_per_chip.begin() -> second).grid_size.x, (soc_descriptor_per_chip.begin() -> second).grid_size.y);
-     // CA::Soc ca_soc_manager(CA_grid_size);
-     std::unique_ptr<CA::Soc> p_ca_soc_manager_unique = std::make_unique<CA::Soc>(CA_grid_size);
-     translate_soc_descriptor_to_ca_soc(*p_ca_soc_manager_unique, (soc_descriptor_per_chip.begin() -> second));
-     // TODO: End
+    std::cout << "Versim Device: turn_on_device ";
+    std::vector<std::uint32_t> trisc_sizes = {
+        static_cast<unsigned int>(l1_address_params.trisc0_size),
+        static_cast<unsigned int>(l1_address_params.trisc1_size),
+        static_cast<unsigned int>(l1_address_params.trisc2_size)};
+    std::unique_ptr<versim::VersimSimulator> versim_unique = versim::turn_on_device(
+        CA_grid_size,
+        *p_ca_soc_manager_unique,
+        plusargs,
+        vcd_suffix,
+        dump_cores,
+        no_checkers,
+        l1_address_params.trisc_base,
+        trisc_sizes);
+    versim = versim_unique.release();
 
-     std::cout << "Versim Device: turn_on_device ";
-     std::vector<std::uint32_t> trisc_sizes = {static_cast<unsigned int>(l1_address_params.trisc0_size), static_cast<unsigned int>(l1_address_params.trisc1_size), static_cast<unsigned int>(l1_address_params.trisc2_size)};
-     std::unique_ptr<versim::VersimSimulator> versim_unique = versim::turn_on_device(CA_grid_size, *p_ca_soc_manager_unique, plusargs, vcd_suffix, dump_cores, no_checkers,
-        l1_address_params.trisc_base, trisc_sizes);
-     versim = versim_unique.release();
+    std::cout << "Versim Device: write info to tvm db " << std::endl;
+    versim::write_info_to_tvm_db(l1_address_params.trisc_base, trisc_sizes);
+    versim::build_and_connect_tvm_phase();
 
-     std::cout << "Versim Device: write info to tvm db " << std::endl;
-     versim::write_info_to_tvm_db(l1_address_params.trisc_base, trisc_sizes);
-     versim::build_and_connect_tvm_phase();
+    versim->spin_threads(*p_ca_soc_manager_unique, false);
+    versim::assert_reset(*versim);
 
-     versim->spin_threads(*p_ca_soc_manager_unique, false);
-     versim::assert_reset(*versim);
+    p_ca_soc_manager = (void*)(p_ca_soc_manager_unique.release());
 
-     p_ca_soc_manager = (void*)(p_ca_soc_manager_unique.release());
-
-     std::cout << "Versim Device: Done start " << std::endl;
+    std::cout << "Versim Device: Done start " << std::endl;
 }
 
-tt_VersimDevice::~tt_VersimDevice () {
-  ndesc.reset();
-}
+tt_VersimDevice::~tt_VersimDevice() { ndesc.reset(); }
 
 // bool tt_VersimDevice::run() {
 //   std::cout << "Versim Device: Run " << std::endl;
@@ -136,165 +156,218 @@ tt_VersimDevice::~tt_VersimDevice () {
 // }
 
 void tt_VersimDevice::deassert_risc_reset() {
-  std::cout << "Versim Device: Deassert risc resets start" << std::endl;
-  versim::handle_resetting_triscs(*versim);
-  std::cout << "Versim Device: Start main loop " << std::endl;
-  versim::startup_versim_main_loop(*versim);
+    std::cout << "Versim Device: Deassert risc resets start" << std::endl;
+    versim::handle_resetting_triscs(*versim);
+    std::cout << "Versim Device: Start main loop " << std::endl;
+    versim::startup_versim_main_loop(*versim);
 }
 
-void tt_VersimDevice::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets) {
-  // This function deasserts reset on the full versim device (don't need core level granularity for versim)
- deassert_risc_reset();
+void tt_VersimDevice::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions& soft_resets) {
+    // This function deasserts reset on the full versim device (don't need core level granularity for versim)
+    deassert_risc_reset();
 }
 
 void tt_VersimDevice::assert_risc_reset() {
-  std::cout << "Pause all the cores" << std::endl;
-  versim::pause(*versim);
+    std::cout << "Pause all the cores" << std::endl;
+    versim::pause(*versim);
 
-  std::cout << "Wait for cores to go to paused state" << std::endl;
-  versim::sleep_wait_for_paused (*versim);
+    std::cout << "Wait for cores to go to paused state" << std::endl;
+    versim::sleep_wait_for_paused(*versim);
 
-  std::cout << "Assert riscv reset" << std::endl;
-  versim::assert_riscv_reset(*versim);
+    std::cout << "Assert riscv reset" << std::endl;
+    versim::assert_riscv_reset(*versim);
 }
 
 void tt_VersimDevice::assert_risc_reset_at_core(tt_cxy_pair core) {
-  // This function asserts reset on the full versim device (don't need core level granularity for versim)
- assert_risc_reset();
+    // This function asserts reset on the full versim device (don't need core level granularity for versim)
+    assert_risc_reset();
 }
 
-void tt_VersimDevice::rolled_write_to_device(std::vector<uint32_t> &vec, uint32_t unroll_count, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use) {
-  uint32_t byte_increment = vec.size() * 4; 
-  for (int i=0; i<unroll_count; i++) {
-      vec[0] = i; // slot id for debug
-      write_to_device(vec, core, addr + i * byte_increment, tlb_to_use);
-  }
+void tt_VersimDevice::rolled_write_to_device(
+    std::vector<uint32_t>& vec, uint32_t unroll_count, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use) {
+    uint32_t byte_increment = vec.size() * 4;
+    for (int i = 0; i < unroll_count; i++) {
+        vec[0] = i;  // slot id for debug
+        write_to_device(vec, core, addr + i * byte_increment, tlb_to_use);
+    }
 }
 
-void tt_VersimDevice::rolled_write_to_device(uint32_t* mem_ptr, uint32_t len, uint32_t unroll_count, tt_cxy_pair core, uint64_t addr, const std::string& fallback_tlb) {
-  std::vector<std::uint32_t> mem_vector(mem_ptr, mem_ptr + len);
-  rolled_write_to_device(mem_vector, unroll_count, core, addr, fallback_tlb);
+void tt_VersimDevice::rolled_write_to_device(
+    uint32_t* mem_ptr,
+    uint32_t len,
+    uint32_t unroll_count,
+    tt_cxy_pair core,
+    uint64_t addr,
+    const std::string& fallback_tlb) {
+    std::vector<std::uint32_t> mem_vector(mem_ptr, mem_ptr + len);
+    rolled_write_to_device(mem_vector, unroll_count, core, addr, fallback_tlb);
 }
 
-void tt_VersimDevice::write_to_device(std::vector<uint32_t> &vec, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use, bool send_epoch_cmd, bool last_send_epoch_cmd, bool ordered_with_prev_remote_write) {
-  
-  log_debug(tt::LogSiliconDriver, "Versim Device ({}): Write vector at target core {}, address: {}", get_sim_time(*versim), core.str(), addr);
+void tt_VersimDevice::write_to_device(
+    std::vector<uint32_t>& vec,
+    tt_cxy_pair core,
+    uint64_t addr,
+    const std::string& tlb_to_use,
+    bool send_epoch_cmd,
+    bool last_send_epoch_cmd,
+    bool ordered_with_prev_remote_write) {
+    log_debug(
+        tt::LogSiliconDriver,
+        "Versim Device ({}): Write vector at target core {}, address: {}",
+        get_sim_time(*versim),
+        core.str(),
+        addr);
 
-  bool aligned_32B = (soc_descriptor_per_chip.begin() -> second).cores.at(core).type == CoreType::DRAM;
-  // MT: Remove these completely
-  CommandAssembler::xy_pair CA_target(core.x, core.y);
-  CommandAssembler::memory CA_tensor_memory(addr, vec);
+    bool aligned_32B = (soc_descriptor_per_chip.begin()->second).cores.at(core).type == CoreType::DRAM;
+    // MT: Remove these completely
+    CommandAssembler::xy_pair CA_target(core.x, core.y);
+    CommandAssembler::memory CA_tensor_memory(addr, vec);
 
-  nuapi::device::write_memory_to_core(*versim, CA_target, CA_tensor_memory);
+    nuapi::device::write_memory_to_core(*versim, CA_target, CA_tensor_memory);
 }
 
-void tt_VersimDevice::write_to_device(const void *mem_ptr, uint32_t size, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use, bool send_epoch_cmd, bool last_send_epoch_cmd, bool ordered_with_prev_remote_write) {
-  log_assert(!(size % 4), "Writes to Versim Backend should be 4 byte aligned!");
+void tt_VersimDevice::write_to_device(
+    const void* mem_ptr,
+    uint32_t size,
+    tt_cxy_pair core,
+    uint64_t addr,
+    const std::string& tlb_to_use,
+    bool send_epoch_cmd,
+    bool last_send_epoch_cmd,
+    bool ordered_with_prev_remote_write) {
+    log_assert(!(size % 4), "Writes to Versim Backend should be 4 byte aligned!");
 
-  std::vector<std::uint32_t> mem_vector((uint32_t*)mem_ptr, (uint32_t*)mem_ptr + size / sizeof(uint32_t));
-  write_to_device(mem_vector, core, addr, tlb_to_use, send_epoch_cmd, last_send_epoch_cmd, ordered_with_prev_remote_write);
+    std::vector<std::uint32_t> mem_vector((uint32_t*)mem_ptr, (uint32_t*)mem_ptr + size / sizeof(uint32_t));
+    write_to_device(
+        mem_vector, core, addr, tlb_to_use, send_epoch_cmd, last_send_epoch_cmd, ordered_with_prev_remote_write);
 }
 
-void tt_VersimDevice::broadcast_write_to_cluster(const void *mem_ptr, uint32_t size_in_bytes, uint64_t address, const std::set<chip_id_t>& chips_to_exclude, std::set<uint32_t>& rows_to_exclude, std::set<uint32_t>& cols_to_exclude, const std::string& fallback_tlb) {
-  for(const auto& core : get_soc_descriptor(0) -> cores) {
-    if(cols_to_exclude.find(core.first.x) == cols_to_exclude.end() and rows_to_exclude.find(core.first.y) == rows_to_exclude.end() and core.second.type != CoreType::HARVESTED) {
-        write_to_device(mem_ptr, size_in_bytes, tt_cxy_pair(0, core.first.x, core.first.y), address, "");
-      }
-  }
+void tt_VersimDevice::broadcast_write_to_cluster(
+    const void* mem_ptr,
+    uint32_t size_in_bytes,
+    uint64_t address,
+    const std::set<chip_id_t>& chips_to_exclude,
+    std::set<uint32_t>& rows_to_exclude,
+    std::set<uint32_t>& cols_to_exclude,
+    const std::string& fallback_tlb) {
+    for (const auto& core : get_soc_descriptor(0)->cores) {
+        if (cols_to_exclude.find(core.first.x) == cols_to_exclude.end() and
+            rows_to_exclude.find(core.first.y) == rows_to_exclude.end() and core.second.type != CoreType::HARVESTED) {
+            write_to_device(mem_ptr, size_in_bytes, tt_cxy_pair(0, core.first.x, core.first.y), address, "");
+        }
+    }
 }
+
 void tt_VersimDevice::wait_for_non_mmio_flush() {
-  // Do nothing, since Versim does not simulate non-mmio mapped chips
+    // Do nothing, since Versim does not simulate non-mmio mapped chips
 }
 
-void tt_VersimDevice::l1_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {
-  tt_driver_atomics::mfence(); // Ensure no reordering of loads/stores around this
+void tt_VersimDevice::l1_membar(
+    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {
+    tt_driver_atomics::mfence();  // Ensure no reordering of loads/stores around this
 }
 
-void tt_VersimDevice::dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels) {
-  tt_driver_atomics::mfence(); // Ensure no reordering of loads/stores around this
+void tt_VersimDevice::dram_membar(
+    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels) {
+    tt_driver_atomics::mfence();  // Ensure no reordering of loads/stores around this
 }
 
-void tt_VersimDevice::dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& dram_cores) {
-  tt_driver_atomics::mfence(); // Ensure no reordering of loads/stores around this
+void tt_VersimDevice::dram_membar(
+    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& dram_cores) {
+    tt_driver_atomics::mfence();  // Ensure no reordering of loads/stores around this
 }
 
-void tt_VersimDevice::read_from_device(std::vector<uint32_t> &vec, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use) {
-  log_debug(tt::LogSiliconDriver, "Versim Device ({}): Read vector from address: {}, with size: {} Bytes", get_sim_time(*versim), addr, size);
+void tt_VersimDevice::read_from_device(
+    std::vector<uint32_t>& vec, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use) {
+    log_debug(
+        tt::LogSiliconDriver,
+        "Versim Device ({}): Read vector from address: {}, with size: {} Bytes",
+        get_sim_time(*versim),
+        addr,
+        size);
 
-  CommandAssembler::xy_pair CA_target(core.x, core.y);
+    CommandAssembler::xy_pair CA_target(core.x, core.y);
 
-  size_t size_in_words = size / 4;
-  auto result = nuapi::device::read_memory_from_core(*versim, CA_target, addr, size_in_words);
-  vec = result;
+    size_t size_in_words = size / 4;
+    auto result = nuapi::device::read_memory_from_core(*versim, CA_target, addr, size_in_words);
+    vec = result;
 }
 
-void tt_VersimDevice::read_from_device(void *mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use) {
-  log_debug(tt::LogSiliconDriver, "Versim Device ({}): Read vector from address: {}, with size: {} Bytes", get_sim_time(*versim), addr, size);
-  log_assert(!(size % 4), "Reads from Versim backend should be 4 byte aligned!");
+void tt_VersimDevice::read_from_device(
+    void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use) {
+    log_debug(
+        tt::LogSiliconDriver,
+        "Versim Device ({}): Read vector from address: {}, with size: {} Bytes",
+        get_sim_time(*versim),
+        addr,
+        size);
+    log_assert(!(size % 4), "Reads from Versim backend should be 4 byte aligned!");
 
-  CommandAssembler::xy_pair CA_target(core.x, core.y);
+    CommandAssembler::xy_pair CA_target(core.x, core.y);
 
-  size_t size_in_words = size / 4;
-  auto result = nuapi::device::read_memory_from_core(*versim, CA_target, addr, size_in_words);
-  memcpy(mem_ptr, result.data(), result.size()*sizeof(uint32_t));
+    size_t size_in_words = size / 4;
+    auto result = nuapi::device::read_memory_from_core(*versim, CA_target, addr, size_in_words);
+    memcpy(mem_ptr, result.data(), result.size() * sizeof(uint32_t));
 }
 
-void tt_VersimDevice::translate_to_noc_table_coords(chip_id_t device_id, std::size_t &r, std::size_t &c) {
-  // No translation is performed
-  return;
+void tt_VersimDevice::translate_to_noc_table_coords(chip_id_t device_id, std::size_t& r, std::size_t& c) {
+    // No translation is performed
+    return;
 }
 
 std::set<chip_id_t> tt_VersimDevice::get_target_mmio_device_ids() {
-  // Must only be used for silicon
-  return {};
+    // Must only be used for silicon
+    return {};
 }
 
 std::set<chip_id_t> tt_VersimDevice::get_target_remote_device_ids() {
-  // Must only be used for silicon
-  return {};
+    // Must only be used for silicon
+    return {};
 }
 
-
-bool versim_check_dram_core_exists(const std::vector<std::vector<tt_xy_pair>> &dram_core_channels, tt_xy_pair target_core) {
+bool versim_check_dram_core_exists(
+    const std::vector<std::vector<tt_xy_pair>>& dram_core_channels, tt_xy_pair target_core) {
     bool dram_core_exists = false;
-    for (const auto &dram_cores_in_channel: dram_core_channels) {
-      for (const auto &dram_core : dram_cores_in_channel) {
-        if (dram_core.x == target_core.x && dram_core.y == target_core.y) {
-            return true;
+    for (const auto& dram_cores_in_channel : dram_core_channels) {
+        for (const auto& dram_core : dram_cores_in_channel) {
+            if (dram_core.x == target_core.x && dram_core.y == target_core.y) {
+                return true;
+            }
         }
-      }
     }
     return false;
 }
 
 int tt_VersimDevice::get_number_of_chips_in_cluster() { return detect_number_of_chips(); }
+
 std::unordered_set<int> tt_VersimDevice::get_all_chips_in_cluster() { return {0}; }
+
 int tt_VersimDevice::detect_number_of_chips() { return 1; }
 
 bool tt_VersimDevice::using_harvested_soc_descriptors() { return false; }
+
 bool tt_VersimDevice::noc_translation_en() { return false; }
-std::unordered_map<chip_id_t, uint32_t> tt_VersimDevice::get_harvesting_masks_for_soc_descriptors() { return {{0, 0}};}
+
+std::unordered_map<chip_id_t, uint32_t> tt_VersimDevice::get_harvesting_masks_for_soc_descriptors() { return {{0, 0}}; }
 
 // Meant to breakout running functions for simulator
 bool tt_VersimDevice::stop() {
-  std::cout << "Versim Device: Stop " << std::endl;
+    std::cout << "Versim Device: Stop " << std::endl;
 
-  versim::turn_off_device(*versim);
-  versim->shutdown();
-  // Force free of all versim cores
-  for (auto x = 0; x < versim->grid_size.x; x++) {
-    for (auto y = 0; y < versim->grid_size.y; y++) {
-      delete versim->core_grid.at(x).at(y);
+    versim::turn_off_device(*versim);
+    versim->shutdown();
+    // Force free of all versim cores
+    for (auto x = 0; x < versim->grid_size.x; x++) {
+        for (auto y = 0; y < versim->grid_size.y; y++) {
+            delete versim->core_grid.at(x).at(y);
+        }
     }
-  }
-  std::cout << "Versim Device: Stop completed " << std::endl;
-  delete versim;
-  return true;
+    std::cout << "Versim Device: Stop completed " << std::endl;
+    delete versim;
+    return true;
 }
 
-std::map<int,int> tt_VersimDevice::get_clocks() {
-  return std::map<int,int>();
-}
+std::map<int, int> tt_VersimDevice::get_clocks() { return std::map<int, int>(); }
 
 void tt_VersimDevice::set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_) {
     l1_address_params = l1_address_params_;
@@ -305,11 +378,11 @@ void tt_VersimDevice::set_device_dram_address_params(const tt_device_dram_addres
 }
 
 std::uint32_t tt_VersimDevice::get_num_dram_channels(std::uint32_t device_id) {
-    return get_soc_descriptor(device_id) -> get_num_dram_channels();
+    return get_soc_descriptor(device_id)->get_num_dram_channels();
 }
 
 std::uint64_t tt_VersimDevice::get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel) {
-    return get_soc_descriptor(device_id) -> dram_bank_size; // Space per channel is identical for now
+    return get_soc_descriptor(device_id)->dram_bank_size;  // Space per channel is identical for now
 }
 
 std::uint32_t tt_VersimDevice::get_num_host_channels(std::uint32_t device_id) {

--- a/device/simulation/deprecated/tt_versim_device.h
+++ b/device/simulation/deprecated/tt_versim_device.h
@@ -11,42 +11,92 @@
 #include "tt_xy_pair.h"
 
 class c_versim_core;
-namespace nuapi {namespace device {template <typename, typename>class Simulator;}}
-namespace versim {
-  struct VersimSimulatorState;
-  using VersimSimulator = nuapi::device::Simulator<c_versim_core *, VersimSimulatorState>;
+
+namespace nuapi {
+namespace device {
+template <typename, typename>
+class Simulator;
 }
+}  // namespace nuapi
+
+namespace versim {
+struct VersimSimulatorState;
+using VersimSimulator = nuapi::device::Simulator<c_versim_core*, VersimSimulatorState>;
+}  // namespace versim
 
 /**
  * @brief Versim Backend Class, derived from the tt_device class
  * Implements APIs to communicate with a simulated (using Verilator) Tenstorrent Device.
-*/ 
-class tt_VersimDevice: public tt_device
-{
-    public:
+ */
+class tt_VersimDevice : public tt_device {
+public:
     virtual void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_);
     virtual void set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_);
-    tt_VersimDevice(const std::string &sdesc_path, const std::string &ndesc_path);
+    tt_VersimDevice(const std::string& sdesc_path, const std::string& ndesc_path);
     virtual std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors();
-    virtual void start(std::vector<std::string> plusargs, std::vector<std::string> dump_cores, bool no_checkers, bool init_device, bool skip_driver_allocs);
-    virtual void start_device(const tt_device_params &device_params);
+    virtual void start(
+        std::vector<std::string> plusargs,
+        std::vector<std::string> dump_cores,
+        bool no_checkers,
+        bool init_device,
+        bool skip_driver_allocs);
+    virtual void start_device(const tt_device_params& device_params);
     virtual void close_device();
     virtual void deassert_risc_reset();
-    virtual void deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets = TENSIX_DEASSERT_SOFT_RESET);
+    virtual void deassert_risc_reset_at_core(
+        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET);
     virtual void assert_risc_reset();
     virtual void assert_risc_reset_at_core(tt_cxy_pair core);
-    virtual void write_to_device(std::vector<uint32_t> &vec, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use, bool send_epoch_cmd = false, bool last_send_epoch_cmd = true, bool ordered_with_prev_remote_write = false);
-    virtual void broadcast_write_to_cluster(const void *mem_ptr, uint32_t size_in_bytes, uint64_t address, const std::set<chip_id_t>& chips_to_exclude, std::set<uint32_t>& rows_to_exclude, std::set<uint32_t>& columns_to_exclude, const std::string& fallback_tlb);
-    virtual void rolled_write_to_device(std::vector<uint32_t> &vec, uint32_t unroll_count, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use);
-    virtual void read_from_device(std::vector<uint32_t> &vec, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use);
-    virtual void rolled_write_to_device(uint32_t* mem_ptr, uint32_t size_in_bytes, uint32_t unroll_count, tt_cxy_pair core, uint64_t addr, const std::string& fallback_tlb);
-    virtual void write_to_device(const void *mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use, bool send_epoch_cmd = false, bool last_send_epoch_cmd = true, bool ordered_with_prev_remote_write = false);
-    virtual void read_from_device(void *mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use); 
+    virtual void write_to_device(
+        std::vector<uint32_t>& vec,
+        tt_cxy_pair core,
+        uint64_t addr,
+        const std::string& tlb_to_use,
+        bool send_epoch_cmd = false,
+        bool last_send_epoch_cmd = true,
+        bool ordered_with_prev_remote_write = false);
+    virtual void broadcast_write_to_cluster(
+        const void* mem_ptr,
+        uint32_t size_in_bytes,
+        uint64_t address,
+        const std::set<chip_id_t>& chips_to_exclude,
+        std::set<uint32_t>& rows_to_exclude,
+        std::set<uint32_t>& columns_to_exclude,
+        const std::string& fallback_tlb);
+    virtual void rolled_write_to_device(
+        std::vector<uint32_t>& vec,
+        uint32_t unroll_count,
+        tt_cxy_pair core,
+        uint64_t addr,
+        const std::string& tlb_to_use);
+    virtual void read_from_device(
+        std::vector<uint32_t>& vec, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use);
+    virtual void rolled_write_to_device(
+        uint32_t* mem_ptr,
+        uint32_t size_in_bytes,
+        uint32_t unroll_count,
+        tt_cxy_pair core,
+        uint64_t addr,
+        const std::string& fallback_tlb);
+    virtual void write_to_device(
+        const void* mem_ptr,
+        uint32_t size_in_bytes,
+        tt_cxy_pair core,
+        uint64_t addr,
+        const std::string& tlb_to_use,
+        bool send_epoch_cmd = false,
+        bool last_send_epoch_cmd = true,
+        bool ordered_with_prev_remote_write = false);
+    virtual void read_from_device(
+        void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use);
     virtual void wait_for_non_mmio_flush();
-    void l1_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
-    void dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels);
-    void dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
-    virtual void translate_to_noc_table_coords(chip_id_t device_id, std::size_t &r, std::size_t &c);
+    void l1_membar(
+        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
+    void dram_membar(
+        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels);
+    void dram_membar(
+        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
+    virtual void translate_to_noc_table_coords(chip_id_t device_id, std::size_t& r, std::size_t& c);
     virtual bool using_harvested_soc_descriptors();
     virtual std::unordered_map<chip_id_t, uint32_t> get_harvesting_masks_for_soc_descriptors();
     virtual bool noc_translation_en();
@@ -57,12 +107,13 @@ class tt_VersimDevice: public tt_device
     virtual int get_number_of_chips_in_cluster();
     virtual std::unordered_set<chip_id_t> get_all_chips_in_cluster();
     static int detect_number_of_chips();
-    virtual std::map<int,int> get_clocks();
+    virtual std::map<int, int> get_clocks();
     virtual std::uint32_t get_num_dram_channels(std::uint32_t device_id);
     virtual std::uint64_t get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel);
     virtual std::uint32_t get_num_host_channels(std::uint32_t device_id);
     virtual std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel);
-    private:
+
+private:
     bool stop();
     tt_device_l1_address_params l1_address_params;
     tt_device_dram_address_params dram_address_params;

--- a/device/simulation/deprecated/tt_versim_stub.cpp
+++ b/device/simulation/deprecated/tt_versim_stub.cpp
@@ -2,19 +2,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-
-#include "cluster.h"
-
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <vector>
 
-tt_VersimDevice::tt_VersimDevice(const std::string &sdesc_path, const std::string &ndesc_path) : tt_device(sdesc_path) {
-  throw std::runtime_error("tt_VersimDevice() -- VERSIM is not supported in this build\n");
+#include "cluster.h"
+
+tt_VersimDevice::tt_VersimDevice(const std::string& sdesc_path, const std::string& ndesc_path) : tt_device(sdesc_path) {
+    throw std::runtime_error("tt_VersimDevice() -- VERSIM is not supported in this build\n");
 }
 
-tt_VersimDevice::~tt_VersimDevice () {}
+tt_VersimDevice::~tt_VersimDevice() {}
 
 std::unordered_map<chip_id_t, tt_SocDescriptor>& tt_VersimDevice::get_virtual_soc_descriptors() {
     throw std::runtime_error("tt_VersimDevice() -- VERSIM is not supported in this build\n");
@@ -22,23 +21,71 @@ std::unordered_map<chip_id_t, tt_SocDescriptor>& tt_VersimDevice::get_virtual_so
 }
 
 int tt_VersimDevice::get_number_of_chips_in_cluster() { return detect_number_of_chips(); }
+
 std::unordered_set<int> tt_VersimDevice::get_all_chips_in_cluster() { return {}; }
+
 int tt_VersimDevice::detect_number_of_chips() { return 0; }
 
-void tt_VersimDevice::start_device(const tt_device_params &device_params) {}
+void tt_VersimDevice::start_device(const tt_device_params& device_params) {}
+
 void tt_VersimDevice::close_device() {}
-void tt_VersimDevice::write_to_device(std::vector<uint32_t> &vec, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use, bool send_epoch_cmd, bool last_send_epoch_cmd, bool ordered_with_prev_remote_write) {}
-void tt_VersimDevice::broadcast_write_to_cluster(const void *mem_ptr, uint32_t size_in_bytes, uint64_t address, const std::set<chip_id_t>& chips_to_exclude, std::set<uint32_t>& rows_to_exclude, std::set<uint32_t>& cols_to_exclude, const std::string& fallback_tlb) {}
-void tt_VersimDevice::read_from_device(std::vector<uint32_t> &vec, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use) {}
-void tt_VersimDevice::rolled_write_to_device(std::vector<uint32_t> &vec, uint32_t unroll_count, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use) {}
-void tt_VersimDevice::write_to_device(const void *mem_ptr, uint32_t len, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use, bool send_epoch_cmd, bool last_send_epoch_cmd, bool ordered_with_prev_remote_write) {}
-void tt_VersimDevice::read_from_device(void *mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use) {}
-void tt_VersimDevice::rolled_write_to_device(uint32_t* mem_ptr, uint32_t len, uint32_t unroll_count, tt_cxy_pair core, uint64_t addr, const std::string& fallback_tlb) {}
+
+void tt_VersimDevice::write_to_device(
+    std::vector<uint32_t>& vec,
+    tt_cxy_pair core,
+    uint64_t addr,
+    const std::string& tlb_to_use,
+    bool send_epoch_cmd,
+    bool last_send_epoch_cmd,
+    bool ordered_with_prev_remote_write) {}
+
+void tt_VersimDevice::broadcast_write_to_cluster(
+    const void* mem_ptr,
+    uint32_t size_in_bytes,
+    uint64_t address,
+    const std::set<chip_id_t>& chips_to_exclude,
+    std::set<uint32_t>& rows_to_exclude,
+    std::set<uint32_t>& cols_to_exclude,
+    const std::string& fallback_tlb) {}
+
+void tt_VersimDevice::read_from_device(
+    std::vector<uint32_t>& vec, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use) {}
+
+void tt_VersimDevice::rolled_write_to_device(
+    std::vector<uint32_t>& vec, uint32_t unroll_count, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use) {
+}
+
+void tt_VersimDevice::write_to_device(
+    const void* mem_ptr,
+    uint32_t len,
+    tt_cxy_pair core,
+    uint64_t addr,
+    const std::string& tlb_to_use,
+    bool send_epoch_cmd,
+    bool last_send_epoch_cmd,
+    bool ordered_with_prev_remote_write) {}
+
+void tt_VersimDevice::read_from_device(
+    void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use) {}
+
+void tt_VersimDevice::rolled_write_to_device(
+    uint32_t* mem_ptr,
+    uint32_t len,
+    uint32_t unroll_count,
+    tt_cxy_pair core,
+    uint64_t addr,
+    const std::string& fallback_tlb) {}
+
 void tt_VersimDevice::wait_for_non_mmio_flush() {}
 
-void tt_VersimDevice::l1_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {}
-void tt_VersimDevice::dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels) {}
-void tt_VersimDevice::dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& dram_cores) {}
+void tt_VersimDevice::l1_membar(
+    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {}
+
+void tt_VersimDevice::dram_membar(
+    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels) {}
+
+void tt_VersimDevice::dram_membar(
+    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& dram_cores) {}
 
 void tt_VersimDevice::start(
     std::vector<std::string> plusargs,
@@ -49,36 +96,48 @@ void tt_VersimDevice::start(
 ) {}
 
 void tt_VersimDevice::deassert_risc_reset() {}
-void tt_VersimDevice::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets) {}
+
+void tt_VersimDevice::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions& soft_resets) {}
+
 void tt_VersimDevice::assert_risc_reset() {}
+
 void tt_VersimDevice::assert_risc_reset_at_core(tt_cxy_pair core) {}
 
-void tt_VersimDevice::translate_to_noc_table_coords(chip_id_t device_id, std::size_t &r, std::size_t &c) {};
+void tt_VersimDevice::translate_to_noc_table_coords(chip_id_t device_id, std::size_t& r, std::size_t& c){};
+
 // void tt_VersimDevice::dump_wall_clock_mailbox(std::string output_path, int device_id) {}
 
-std::set<chip_id_t> tt_VersimDevice::get_target_mmio_device_ids() {return {};}
-std::set<chip_id_t> tt_VersimDevice::get_target_remote_device_ids() {return {};}
+std::set<chip_id_t> tt_VersimDevice::get_target_mmio_device_ids() { return {}; }
+
+std::set<chip_id_t> tt_VersimDevice::get_target_remote_device_ids() { return {}; }
 
 bool versim_check_dram_core_exists(
-    const std::vector<std::vector<tt_xy_pair>> &dram_core_channels, tt_xy_pair target_core) {
-  return false;
+    const std::vector<std::vector<tt_xy_pair>>& dram_core_channels, tt_xy_pair target_core) {
+    return false;
 }
 
 bool tt_VersimDevice::using_harvested_soc_descriptors() { return false; }
+
 bool tt_VersimDevice::noc_translation_en() { return false; }
-std::unordered_map<chip_id_t, uint32_t> tt_VersimDevice::get_harvesting_masks_for_soc_descriptors() { return std::unordered_map<chip_id_t, uint32_t>();}
+
+std::unordered_map<chip_id_t, uint32_t> tt_VersimDevice::get_harvesting_masks_for_soc_descriptors() {
+    return std::unordered_map<chip_id_t, uint32_t>();
+}
 
 bool tt_VersimDevice::stop() { return true; }
 
 void tt_VersimDevice::set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_) {}
+
 void tt_VersimDevice::set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_) {}
 
-std::uint32_t tt_VersimDevice::get_num_dram_channels(std::uint32_t device_id) {return 0;}
-std::uint64_t tt_VersimDevice::get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel) {return 0;}
-std::uint32_t tt_VersimDevice::get_num_host_channels(std::uint32_t device_id) {return 0;}
-std::uint32_t tt_VersimDevice::get_host_channel_size(std::uint32_t device_id, std::uint32_t channel) {return 0;}
+std::uint32_t tt_VersimDevice::get_num_dram_channels(std::uint32_t device_id) { return 0; }
 
-std::map<int,int> tt_VersimDevice::get_clocks() {return std::map<int,int>();}
+std::uint64_t tt_VersimDevice::get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel) { return 0; }
 
-tt_ClusterDescriptor* tt_VersimDevice::get_cluster_description() {return ndesc.get();}
+std::uint32_t tt_VersimDevice::get_num_host_channels(std::uint32_t device_id) { return 0; }
 
+std::uint32_t tt_VersimDevice::get_host_channel_size(std::uint32_t device_id, std::uint32_t channel) { return 0; }
+
+std::map<int, int> tt_VersimDevice::get_clocks() { return std::map<int, int>(); }
+
+tt_ClusterDescriptor* tt_VersimDevice::get_cluster_description() { return ndesc.get(); }

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -4,43 +4,44 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <iostream>
+#include "tt_simulation_device.h"
+
+#include <nng/nng.h>
+#include <uv.h>
+
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <vector>
 
-#include <uv.h>
-#include <nng/nng.h>
-
-#include "common/logger.hpp"
 #include "common/assert.hpp"
+#include "common/logger.hpp"
 #include "device/driver_atomics.h"
 #include "device/tt_cluster_descriptor.h"
-
-#include "tt_simulation_device.h"
 #include "tt_simulation_device_generated.h"
 
-flatbuffers::FlatBufferBuilder create_flatbuffer(DEVICE_COMMAND rw, std::vector<uint32_t> vec, tt_cxy_pair core_, uint64_t addr, uint64_t size_=0){
+flatbuffers::FlatBufferBuilder create_flatbuffer(
+    DEVICE_COMMAND rw, std::vector<uint32_t> vec, tt_cxy_pair core_, uint64_t addr, uint64_t size_ = 0) {
     flatbuffers::FlatBufferBuilder builder;
     auto data = builder.CreateVector(vec);
     auto core = tt_vcs_core(core_.x, core_.y);
-    uint64_t size = size_ == 0 ? size = vec.size()*sizeof(uint32_t) : size = size_;
+    uint64_t size = size_ == 0 ? size = vec.size() * sizeof(uint32_t) : size = size_;
     auto device_cmd = CreateDeviceRequestResponse(builder, rw, data, &core, addr, size);
     builder.Finish(device_cmd);
     return builder;
 }
 
-void print_flatbuffer(const DeviceRequestResponse *buf){    
+void print_flatbuffer(const DeviceRequestResponse* buf) {
     std::vector<uint32_t> data_vec(buf->data()->begin(), buf->data()->end());
     uint64_t addr = buf->address();
     uint32_t size = buf->size();
     tt_cxy_pair core = {0, buf->core()->x(), buf->core()->y()};
-    
+
     std::stringstream ss;
     ss << std::hex << reinterpret_cast<uintptr_t>(addr);
     std::string addr_hex = ss.str();
     log_info(tt::LogEmulationDriver, "{} bytes @ address {} in core ({}, {})", size, addr_hex, core.x, core.y);
-    for(int i = 0; i < data_vec.size(); i++){
+    for (int i = 0; i < data_vec.size(); i++) {
         std::ios_base::fmtflags save = std::cout.flags();
         std::cout << "0x" << std::hex << std::setw(8) << std::setfill('0') << data_vec[i] << " ";
         std::cout.flags(save);
@@ -48,14 +49,14 @@ void print_flatbuffer(const DeviceRequestResponse *buf){
     std::cout << std::endl;
 }
 
-tt_SimulationDevice::tt_SimulationDevice(const std::string &sdesc_path) : tt_device(){
+tt_SimulationDevice::tt_SimulationDevice(const std::string& sdesc_path) : tt_device() {
     log_info(tt::LogEmulationDriver, "Instantiating simulation device");
     soc_descriptor_per_chip.emplace(0, tt_SocDescriptor(sdesc_path));
     std::set<chip_id_t> target_devices = {0};
-    
+
     // Start VCS simulator in a separate process
     TT_ASSERT(std::getenv("TT_REMOTE_EXE"), "TT_REMOTE_EXE not set, please provide path to the VCS binary");
-    uv_loop_t *loop = uv_default_loop();
+    uv_loop_t* loop = uv_default_loop();
     uv_process_t child_p;
     uv_process_options_t child_options = {0};
 
@@ -69,14 +70,12 @@ tt_SimulationDevice::tt_SimulationDevice(const std::string &sdesc_path) : tt_dev
         log_info(tt::LogEmulationDriver, "Simulator process spawned with PID: {}", child_p.pid);
     }
 
-    uv_unref((uv_handle_t *) &child_p);
+    uv_unref((uv_handle_t*)&child_p);
     uv_run(loop, UV_RUN_DEFAULT);
     uv_loop_close(loop);
 }
 
-tt_SimulationDevice::~tt_SimulationDevice() {
-    close_device();
-}
+tt_SimulationDevice::~tt_SimulationDevice() { close_device(); }
 
 // Setup/Teardown Functions
 std::unordered_map<chip_id_t, tt_SocDescriptor>& tt_SimulationDevice::get_virtual_soc_descriptors() {
@@ -99,11 +98,11 @@ void tt_SimulationDevice::set_driver_eth_interface_params(const tt_driver_eth_in
     eth_interface_params = eth_interface_params_;
 }
 
-void tt_SimulationDevice::start_device(const tt_device_params &device_params) {
-    void *buf_ptr = nullptr;
+void tt_SimulationDevice::start_device(const tt_device_params& device_params) {
+    void* buf_ptr = nullptr;
 
     host.start_host();
-    
+
     log_info(tt::LogEmulationDriver, "Waiting for ack msg from remote...");
     size_t buf_size = host.recv_from_device(&buf_ptr);
     auto buf = GetDeviceRequestResponse(buf_ptr);
@@ -114,8 +113,9 @@ void tt_SimulationDevice::start_device(const tt_device_params &device_params) {
 
 void tt_SimulationDevice::assert_risc_reset() {
     log_info(tt::LogEmulationDriver, "Sending assert_risc_reset signal..");
-    auto wr_buffer = create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_ASSERT, std::vector<uint32_t>(1, 0), {0, 0, 0}, 0);
-    uint8_t *wr_buffer_ptr = wr_buffer.GetBufferPointer();
+    auto wr_buffer =
+        create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_ASSERT, std::vector<uint32_t>(1, 0), {0, 0, 0}, 0);
+    uint8_t* wr_buffer_ptr = wr_buffer.GetBufferPointer();
     size_t wr_buffer_size = wr_buffer.GetSize();
 
     print_flatbuffer(GetDeviceRequestResponse(wr_buffer_ptr));
@@ -124,20 +124,25 @@ void tt_SimulationDevice::assert_risc_reset() {
 
 void tt_SimulationDevice::deassert_risc_reset() {
     log_info(tt::LogEmulationDriver, "Sending 'deassert_risc_reset' signal..");
-    auto wr_buffer = create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_DEASSERT, std::vector<uint32_t>(1, 0), {0, 0, 0}, 0);
-    uint8_t *wr_buffer_ptr = wr_buffer.GetBufferPointer();
+    auto wr_buffer =
+        create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_DEASSERT, std::vector<uint32_t>(1, 0), {0, 0, 0}, 0);
+    uint8_t* wr_buffer_ptr = wr_buffer.GetBufferPointer();
     size_t wr_buffer_size = wr_buffer.GetSize();
 
     host.send_to_device(wr_buffer_ptr, wr_buffer_size);
 }
 
-void tt_SimulationDevice::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets) {
-    log_info(tt::LogEmulationDriver, "Sending 'deassert_risc_reset_at_core'.. (Not implemented, defaulting to 'deassert_risc_reset' instead)");
+void tt_SimulationDevice::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions& soft_resets) {
+    log_info(
+        tt::LogEmulationDriver,
+        "Sending 'deassert_risc_reset_at_core'.. (Not implemented, defaulting to 'deassert_risc_reset' instead)");
     deassert_risc_reset();
 }
 
 void tt_SimulationDevice::assert_risc_reset_at_core(tt_cxy_pair core) {
-    log_info(tt::LogEmulationDriver, "Sending 'assert_risc_reset_at_core'.. (Not implemented, defaulting to 'assert_risc_reset' instead)");
+    log_info(
+        tt::LogEmulationDriver,
+        "Sending 'assert_risc_reset_at_core'.. (Not implemented, defaulting to 'assert_risc_reset' instead)");
     assert_risc_reset();
 }
 
@@ -149,19 +154,21 @@ void tt_SimulationDevice::close_device() {
 }
 
 // Runtime Functions
-void tt_SimulationDevice::write_to_device(const void *mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use) {
+void tt_SimulationDevice::write_to_device(
+    const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use) {
     log_info(tt::LogEmulationDriver, "Device writing");
     std::vector<std::uint32_t> data((uint32_t*)mem_ptr, (uint32_t*)mem_ptr + size_in_bytes / sizeof(uint32_t));
     auto wr_buffer = create_flatbuffer(DEVICE_COMMAND_WRITE, data, core, addr);
-    uint8_t *wr_buffer_ptr = wr_buffer.GetBufferPointer();
+    uint8_t* wr_buffer_ptr = wr_buffer.GetBufferPointer();
     size_t wr_buffer_size = wr_buffer.GetSize();
-    
-    print_flatbuffer(GetDeviceRequestResponse(wr_buffer_ptr)); // sanity print
+
+    print_flatbuffer(GetDeviceRequestResponse(wr_buffer_ptr));  // sanity print
     host.send_to_device(wr_buffer_ptr, wr_buffer_size);
 }
 
-void tt_SimulationDevice::read_from_device(void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb) {
-    void *rd_resp;
+void tt_SimulationDevice::read_from_device(
+    void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb) {
+    void* rd_resp;
 
     // Send read request
     auto rd_req_buf = create_flatbuffer(DEVICE_COMMAND_READ, {0}, core, addr, size);
@@ -171,50 +178,49 @@ void tt_SimulationDevice::read_from_device(void* mem_ptr, tt_cxy_pair core, uint
     size_t rd_rsp_sz = host.recv_from_device(&rd_resp);
 
     auto rd_resp_buf = GetDeviceRequestResponse(rd_resp);
-    if (addr != 0x40){
+    if (addr != 0x40) {
         log_info(tt::LogEmulationDriver, "Device reading vec");
-        print_flatbuffer(rd_resp_buf); // 0x40 is host polling device, don't print since it'll spam
+        print_flatbuffer(rd_resp_buf);  // 0x40 is host polling device, don't print since it'll spam
     }
     std::memcpy(mem_ptr, rd_resp_buf->data()->data(), rd_resp_buf->data()->size() * sizeof(uint32_t));
     nng_free(rd_resp, rd_rsp_sz);
 }
 
 void tt_SimulationDevice::wait_for_non_mmio_flush() {}
+
 void tt_SimulationDevice::wait_for_non_mmio_flush(const chip_id_t chip) {}
-void tt_SimulationDevice::l1_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {}
-void tt_SimulationDevice::dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels) {}
-void tt_SimulationDevice::dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {}
+
+void tt_SimulationDevice::l1_membar(
+    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {}
+
+void tt_SimulationDevice::dram_membar(
+    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels) {}
+
+void tt_SimulationDevice::dram_membar(
+    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {}
 
 // Misc. Functions to Query/Set Device State
 std::unordered_map<chip_id_t, uint32_t> tt_SimulationDevice::get_harvesting_masks_for_soc_descriptors() {
     return {{0, 0}};
 }
 
-std::vector<chip_id_t> tt_SimulationDevice::detect_available_device_ids() {
-    return {0};
-}
+std::vector<chip_id_t> tt_SimulationDevice::detect_available_device_ids() { return {0}; }
 
-std::set<chip_id_t> tt_SimulationDevice::get_target_remote_device_ids() {
-    return target_remote_chips;
-}
+std::set<chip_id_t> tt_SimulationDevice::get_target_remote_device_ids() { return target_remote_chips; }
 
-std::map<int,int> tt_SimulationDevice::get_clocks() {
-    return {{0, 0}};
-}
+std::map<int, int> tt_SimulationDevice::get_clocks() { return {{0, 0}}; }
 
-void *tt_SimulationDevice::host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const {
+void* tt_SimulationDevice::host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const {
     return nullptr;
 }
 
 std::uint64_t tt_SimulationDevice::get_pcie_base_addr_from_device(const chip_id_t chip_id) const {
-    if(arch_name == tt::ARCH::WORMHOLE_B0) {
+    if (arch_name == tt::ARCH::WORMHOLE_B0) {
         return 0x800000000;
-    }
-    else if (arch_name == tt::ARCH::BLACKHOLE) {
+    } else if (arch_name == tt::ARCH::BLACKHOLE) {
         // Enable 4th ATU window.
         return 1ULL << 60;
-    }
-    else {
+    } else {
         return 0;
     }
 }
@@ -224,12 +230,11 @@ std::uint32_t tt_SimulationDevice::get_num_dram_channels(std::uint32_t device_id
 }
 
 std::uint64_t tt_SimulationDevice::get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel) {
-    return get_soc_descriptor(device_id).dram_bank_size; // Space per channel is identical for now
+    return get_soc_descriptor(device_id).dram_bank_size;  // Space per channel is identical for now
 }
 
-std::uint32_t tt_SimulationDevice::get_num_host_channels(std::uint32_t device_id) {
-    return 1;
-}
+std::uint32_t tt_SimulationDevice::get_num_host_channels(std::uint32_t device_id) { return 1; }
 
-std::uint32_t tt_SimulationDevice::get_host_channel_size(std::uint32_t device_id, std::uint32_t channel) {return 0;}
-std::uint32_t tt_SimulationDevice::get_numa_node_for_pcie_device(std::uint32_t device_id) {return 0;}
+std::uint32_t tt_SimulationDevice::get_host_channel_size(std::uint32_t device_id, std::uint32_t channel) { return 0; }
+
+std::uint32_t tt_SimulationDevice::get_numa_node_for_pcie_device(std::uint32_t device_id) { return 0; }

--- a/device/simulation/tt_simulation_device.h
+++ b/device/simulation/tt_simulation_device.h
@@ -13,43 +13,49 @@
 #include "device/cluster.h"
 #include "device/simulation/tt_simulation_host.hpp"
 
-class tt_SimulationDevice: public tt_device {
-    public:
-    tt_SimulationDevice(const std::string &sdesc_path);
+class tt_SimulationDevice : public tt_device {
+public:
+    tt_SimulationDevice(const std::string& sdesc_path);
     ~tt_SimulationDevice();
 
     tt_SimulationHost host;
 
-    //Setup/Teardown Functions
+    // Setup/Teardown Functions
     virtual std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors();
     virtual void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_);
     virtual void set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_);
     virtual void set_driver_host_address_params(const tt_driver_host_address_params& host_address_params_);
     virtual void set_driver_eth_interface_params(const tt_driver_eth_interface_params& eth_interface_params_);
-    virtual void start_device(const tt_device_params &device_params);
+    virtual void start_device(const tt_device_params& device_params);
     virtual void assert_risc_reset();
     virtual void deassert_risc_reset();
-    virtual void deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions &soft_resets = TENSIX_DEASSERT_SOFT_RESET);
+    virtual void deassert_risc_reset_at_core(
+        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET);
     virtual void assert_risc_reset_at_core(tt_cxy_pair core);
     virtual void close_device();
 
     // Runtime Functions
-    virtual void write_to_device(const void *mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use);
-    virtual void read_from_device(void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
+    virtual void write_to_device(
+        const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use);
+    virtual void read_from_device(
+        void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
 
     virtual void wait_for_non_mmio_flush();
     virtual void wait_for_non_mmio_flush(const chip_id_t chip);
-    void l1_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
-    void dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels);
-    void dram_membar(const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
+    void l1_membar(
+        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
+    void dram_membar(
+        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels);
+    void dram_membar(
+        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
 
     // Misc. Functions to Query/Set Device State
     // virtual bool using_harvested_soc_descriptors();
     virtual std::unordered_map<chip_id_t, uint32_t> get_harvesting_masks_for_soc_descriptors();
     static std::vector<chip_id_t> detect_available_device_ids();
     virtual std::set<chip_id_t> get_target_remote_device_ids();
-    virtual std::map<int,int> get_clocks();
-    virtual void *host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const;
+    virtual std::map<int, int> get_clocks();
+    virtual void* host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const;
     virtual std::uint64_t get_pcie_base_addr_from_device(const chip_id_t chip_id) const;
     virtual std::uint32_t get_num_dram_channels(std::uint32_t device_id);
     virtual std::uint64_t get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel);
@@ -57,7 +63,7 @@ class tt_SimulationDevice: public tt_device {
     virtual std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel);
     virtual std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id);
 
-    private:
+private:
     // State variables
     tt_device_dram_address_params dram_address_params;
     tt_device_l1_address_params l1_address_params;

--- a/device/simulation/tt_simulation_host.cpp
+++ b/device/simulation/tt_simulation_host.cpp
@@ -2,19 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <typeinfo>
-#include <sstream>
-#include <iomanip>
-#include <filesystem>
-#include <cassert>
-#include <cstdlib>
+#include "tt_simulation_host.hpp"
 
 #include <nng/nng.h>
 #include <nng/protocol/pair1/pair.h>
 
-#include "common/logger.hpp"
+#include <cassert>
+#include <cstdlib>
+#include <filesystem>
+#include <iomanip>
+#include <sstream>
+#include <typeinfo>
+
 #include "common/assert.hpp"
-#include "tt_simulation_host.hpp"
+#include "common/logger.hpp"
 
 tt_SimulationHost::tt_SimulationHost() {
     // Initialize socket and dialer
@@ -64,7 +65,7 @@ void tt_SimulationHost::start_host() {
 void tt_SimulationHost::send_to_device(uint8_t *buf, size_t buf_size) {
     int rv;
     log_debug(tt::LogEmulationDriver, "Sending messsage to remote..");
-    
+
     void *msg = nng_alloc(buf_size);
     std::memcpy(msg, buf, buf_size);
 

--- a/device/simulation/tt_simulation_host.hpp
+++ b/device/simulation/tt_simulation_host.hpp
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: (c) 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-#include <vector>
 #include <cstdint>
 #include <memory>
+#include <vector>
 
 #include "device/tt_xy_pair.h"
 
@@ -20,6 +20,7 @@ public:
     void start_host();
     void send_to_device(uint8_t *buf, size_t buf_size);
     size_t recv_from_device(void **data_ptr);
+
 private:
     std::unique_ptr<nng_socket> host_socket;
     std::unique_ptr<nng_dialer> host_dialer;

--- a/device/tlb.h
+++ b/device/tlb.h
@@ -8,8 +8,8 @@
 
 #include <cstdint>
 #include <optional>
-#include <utility>
 #include <stdexcept>
+#include <utility>
 
 namespace tt::umd {
 
@@ -41,10 +41,10 @@ struct tlb_data {
 
     // Orderings
     static constexpr uint64_t Relaxed = 0;
-    static constexpr uint64_t Strict  = 1;
-    static constexpr uint64_t Posted  = 2;
+    static constexpr uint64_t Strict = 1;
+    static constexpr uint64_t Posted = 2;
 
-    bool check(const tlb_offsets & offset) const;
+    bool check(const tlb_offsets &offset) const;
     std::pair<std::uint64_t, std::uint64_t> apply_offset(const tlb_offsets &offset) const;
 };
 

--- a/device/tt_arch_types.h
+++ b/device/tt_arch_types.h
@@ -17,4 +17,4 @@ enum class ARCH {
     BLACKHOLE = 3,
     Invalid = 0xFF,
 };
-}
+}  // namespace tt

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -2,24 +2,25 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "tt_cluster_descriptor.h"
-#include "libs/create_ethernet_map.h"
 
 #include <fstream>
 #include <memory>
-#include <sstream> 
+#include <sstream>
 
 #include "common/disjoint_set.hpp"
 #include "common/logger.hpp"
+#include "fmt/core.h"
+#include "libs/create_ethernet_map.h"
 #include "yaml-cpp/yaml.h"
 
-#include "fmt/core.h"
-
 using namespace tt;
-bool tt_ClusterDescriptor::ethernet_core_has_active_ethernet_link(chip_id_t local_chip, ethernet_channel_t local_ethernet_channel) const {
+
+bool tt_ClusterDescriptor::ethernet_core_has_active_ethernet_link(
+    chip_id_t local_chip, ethernet_channel_t local_ethernet_channel) const {
     return this->ethernet_connections.find(local_chip) != this->ethernet_connections.end() &&
-           this->ethernet_connections.at(local_chip).find(local_ethernet_channel) != this->ethernet_connections.at(local_chip).end();
+           this->ethernet_connections.at(local_chip).find(local_ethernet_channel) !=
+               this->ethernet_connections.at(local_chip).end();
 }
 
 std::tuple<chip_id_t, ethernet_channel_t> tt_ClusterDescriptor::get_chip_and_channel_of_remote_ethernet_core(
@@ -40,10 +41,14 @@ std::tuple<chip_id_t, ethernet_channel_t> tt_ClusterDescriptor::get_chip_and_cha
     }
 }
 
-// NOTE: It might be worthwhile to precompute this for every pair of directly connected chips, depending on how extensively router needs to use it
-std::vector<std::tuple<ethernet_channel_t, ethernet_channel_t>> tt_ClusterDescriptor::get_directly_connected_ethernet_channels_between_chips(const chip_id_t &first, const chip_id_t &second) const {
+// NOTE: It might be worthwhile to precompute this for every pair of directly connected chips, depending on how
+// extensively router needs to use it
+std::vector<std::tuple<ethernet_channel_t, ethernet_channel_t>>
+tt_ClusterDescriptor::get_directly_connected_ethernet_channels_between_chips(
+    const chip_id_t &first, const chip_id_t &second) const {
     std::vector<std::tuple<ethernet_channel_t, ethernet_channel_t>> directly_connected_channels = {};
-    if (this->enabled_active_chips.find(first) == this->enabled_active_chips.end() || this->enabled_active_chips.find(second) == this->enabled_active_chips.end()) {
+    if (this->enabled_active_chips.find(first) == this->enabled_active_chips.end() ||
+        this->enabled_active_chips.find(second) == this->enabled_active_chips.end()) {
         return {};
     }
 
@@ -60,9 +65,7 @@ bool tt_ClusterDescriptor::is_chip_mmio_capable(const chip_id_t chip_id) const {
     return this->chips_with_mmio.find(chip_id) != this->chips_with_mmio.end();
 }
 
-bool tt_ClusterDescriptor::is_chip_remote(const chip_id_t chip_id) const {
-    return !is_chip_mmio_capable(chip_id);
-}
+bool tt_ClusterDescriptor::is_chip_remote(const chip_id_t chip_id) const { return !is_chip_mmio_capable(chip_id); }
 
 // given two coordinates, finds the number of hops between the two chips
 // it assumes that shelves are connected in x-dim and racks are connected in y-dim
@@ -71,11 +74,21 @@ bool tt_ClusterDescriptor::is_chip_remote(const chip_id_t chip_id) const {
 // then once a chip on the same shelf&rack is found,
 // the distance from this chip to either location_a or location_b is just x&y dim difference.
 // the function returns the total distance of travelled between shelves and racks, plust the x&y dim difference
-int tt_ClusterDescriptor::get_ethernet_link_coord_distance(const eth_coord_t &location_a, const eth_coord_t &location_b) const {
-
-    log_trace(LogSiliconDriver, "get_ethernet_link_coord_distance from ({}, {}, {}, {}, {}) to ({}, {}, {}, {}, {})",
-        location_a.cluster_id, location_a.x, location_a.y, location_a.rack, location_a.shelf,
-        location_b.cluster_id, location_b.x, location_b.y, location_b.rack, location_b.shelf);
+int tt_ClusterDescriptor::get_ethernet_link_coord_distance(
+    const eth_coord_t &location_a, const eth_coord_t &location_b) const {
+    log_trace(
+        LogSiliconDriver,
+        "get_ethernet_link_coord_distance from ({}, {}, {}, {}, {}) to ({}, {}, {}, {}, {})",
+        location_a.cluster_id,
+        location_a.x,
+        location_a.y,
+        location_a.rack,
+        location_a.shelf,
+        location_b.cluster_id,
+        location_b.x,
+        location_b.y,
+        location_b.rack,
+        location_b.shelf);
 
     if (location_a.cluster_id != location_b.cluster_id) {
         return std::numeric_limits<int>::max();
@@ -85,166 +98,242 @@ int tt_ClusterDescriptor::get_ethernet_link_coord_distance(const eth_coord_t &lo
     int y_distance = std::abs(location_a.y - location_b.y);
 
     // move along y-dim to exit from the shelf to go to a higher shelf
-    if(location_b.shelf > location_a.shelf) {
+    if (location_b.shelf > location_a.shelf) {
         // this is already verified where galaxy_shelves_exit_chip_coords_per_y_dim is populated, but just to be safe
-        log_assert(galaxy_shelves_exit_chip_coords_per_y_dim.find(location_a.shelf) != galaxy_shelves_exit_chip_coords_per_y_dim.end(),
+        log_assert(
+            galaxy_shelves_exit_chip_coords_per_y_dim.find(location_a.shelf) !=
+                galaxy_shelves_exit_chip_coords_per_y_dim.end(),
             "Expected shelf-to-shelf connection");
         // this row does not have a shelf-to-shelf connection
-        if(galaxy_shelves_exit_chip_coords_per_y_dim.at(location_a.shelf).find(location_a.y) == galaxy_shelves_exit_chip_coords_per_y_dim.at(location_a.shelf).end()) {
+        if (galaxy_shelves_exit_chip_coords_per_y_dim.at(location_a.shelf).find(location_a.y) ==
+            galaxy_shelves_exit_chip_coords_per_y_dim.at(location_a.shelf).end()) {
             return std::numeric_limits<int>::max();
         }
 
-        const Chip2ChipConnection& shelf_to_shelf_connection = galaxy_shelves_exit_chip_coords_per_y_dim.at(location_a.shelf).at(location_a.y);
-        log_assert(shelf_to_shelf_connection.destination_chip_coords.size(), "Expecting at least one shelf-to-shelf connection, possibly one-to-many");
+        const Chip2ChipConnection &shelf_to_shelf_connection =
+            galaxy_shelves_exit_chip_coords_per_y_dim.at(location_a.shelf).at(location_a.y);
+        log_assert(
+            shelf_to_shelf_connection.destination_chip_coords.size(),
+            "Expecting at least one shelf-to-shelf connection, possibly one-to-many");
 
         // for each shelf-to-shelf connection at location_a.y, find the distance to location_b, take min
         int distance = std::numeric_limits<int>::max();
         eth_coord_t exit_shelf = shelf_to_shelf_connection.source_chip_coord;
-        for(eth_coord_t next_shelf : shelf_to_shelf_connection.destination_chip_coords) {
-
-            log_assert(exit_shelf.y == location_a.y && exit_shelf.shelf == location_a.shelf && exit_shelf.rack == location_a.rack,
+        for (eth_coord_t next_shelf : shelf_to_shelf_connection.destination_chip_coords) {
+            log_assert(
+                exit_shelf.y == location_a.y && exit_shelf.shelf == location_a.shelf &&
+                    exit_shelf.rack == location_a.rack,
                 "Invalid shelf exit coordinates");
 
             // next shelf could be at a different y-dim in nebula->galaxy systems
-            log_assert(next_shelf.shelf == (location_a.shelf+1) && next_shelf.rack == location_a.rack,
+            log_assert(
+                next_shelf.shelf == (location_a.shelf + 1) && next_shelf.rack == location_a.rack,
                 "Invalid shelf entry coordinates");
 
             // hop onto the next shelf and find distance from there
             int distance_to_exit = get_ethernet_link_coord_distance(location_a, exit_shelf);
             int distance_in_next_shelf = get_ethernet_link_coord_distance(next_shelf, location_b);
             // no path found
-            if(distance_to_exit == std::numeric_limits<int>::max() || distance_in_next_shelf == std::numeric_limits<int>::max()) {
+            if (distance_to_exit == std::numeric_limits<int>::max() ||
+                distance_in_next_shelf == std::numeric_limits<int>::max()) {
                 continue;
             }
             distance = std::min(distance, distance_to_exit + distance_in_next_shelf + 1);
         }
-        log_trace(LogSiliconDriver, "\tdistance from ({}, {}, {}, {}) to ({}, {}, {}, {}) is {}",
-            location_a.x, location_a.y, location_a.rack, location_a.shelf,
-            location_b.x, location_b.y, location_b.rack, location_b.shelf, distance);
+        log_trace(
+            LogSiliconDriver,
+            "\tdistance from ({}, {}, {}, {}) to ({}, {}, {}, {}) is {}",
+            location_a.x,
+            location_a.y,
+            location_a.rack,
+            location_a.shelf,
+            location_b.x,
+            location_b.y,
+            location_b.rack,
+            location_b.shelf,
+            distance);
         return distance;
-    }
-    else if(location_a.shelf > location_b.shelf) {
-
+    } else if (location_a.shelf > location_b.shelf) {
         // this is already verified where galaxy_shelves_exit_chip_coords_per_y_dim is populated, but just to be safe
-        log_assert(galaxy_shelves_exit_chip_coords_per_y_dim.find(location_b.shelf) != galaxy_shelves_exit_chip_coords_per_y_dim.end(),
+        log_assert(
+            galaxy_shelves_exit_chip_coords_per_y_dim.find(location_b.shelf) !=
+                galaxy_shelves_exit_chip_coords_per_y_dim.end(),
             "Expected shelf-to-shelf connection");
         // this row does not have a shelf-to-shelf connection
-        if(galaxy_shelves_exit_chip_coords_per_y_dim.at(location_b.shelf).find(location_b.y) == galaxy_shelves_exit_chip_coords_per_y_dim.at(location_b.shelf).end()) {
+        if (galaxy_shelves_exit_chip_coords_per_y_dim.at(location_b.shelf).find(location_b.y) ==
+            galaxy_shelves_exit_chip_coords_per_y_dim.at(location_b.shelf).end()) {
             return std::numeric_limits<int>::max();
         }
 
-        const Chip2ChipConnection& shelf_to_shelf_connection = galaxy_shelves_exit_chip_coords_per_y_dim.at(location_b.shelf).at(location_b.y);
-        log_assert(shelf_to_shelf_connection.destination_chip_coords.size(), "Expecting at least one shelf-to-shelf connection, possibly one-to-many")
+        const Chip2ChipConnection &shelf_to_shelf_connection =
+            galaxy_shelves_exit_chip_coords_per_y_dim.at(location_b.shelf).at(location_b.y);
+        log_assert(
+            shelf_to_shelf_connection.destination_chip_coords.size(),
+            "Expecting at least one shelf-to-shelf connection, possibly one-to-many")
 
-        // for each shelf-to-shelf connection at location_b.y, find the distance to location_a, take min
-        int distance = std::numeric_limits<int>::max();
+            // for each shelf-to-shelf connection at location_b.y, find the distance to location_a, take min
+            int distance = std::numeric_limits<int>::max();
         eth_coord_t exit_shelf = shelf_to_shelf_connection.source_chip_coord;
-        for(eth_coord_t next_shelf : shelf_to_shelf_connection.destination_chip_coords) {
-
-            log_assert(exit_shelf.y == location_b.y && exit_shelf.shelf == location_b.shelf && exit_shelf.rack == location_b.rack,
+        for (eth_coord_t next_shelf : shelf_to_shelf_connection.destination_chip_coords) {
+            log_assert(
+                exit_shelf.y == location_b.y && exit_shelf.shelf == location_b.shelf &&
+                    exit_shelf.rack == location_b.rack,
                 "Invalid shelf exit coordinates");
             // next shelf could be at a different y-dim in nebula->galaxy systems
-            log_assert(next_shelf.shelf == (location_b.shelf+1) && next_shelf.rack == location_b.rack,
+            log_assert(
+                next_shelf.shelf == (location_b.shelf + 1) && next_shelf.rack == location_b.rack,
                 "Invalid shelf entry coordinates");
 
             // hop onto the next shelf and find distance from there
             int distance_to_exit = get_ethernet_link_coord_distance(location_b, exit_shelf);
             int distance_in_next_shelf = get_ethernet_link_coord_distance(next_shelf, location_a);
             // no path found
-            if(distance_to_exit == std::numeric_limits<int>::max() || distance_in_next_shelf == std::numeric_limits<int>::max()) {
+            if (distance_to_exit == std::numeric_limits<int>::max() ||
+                distance_in_next_shelf == std::numeric_limits<int>::max()) {
                 continue;
             }
             distance = std::min(distance, distance_to_exit + distance_in_next_shelf + 1);
         }
-        log_trace(LogSiliconDriver, "\tdistance from ({}, {}, {}, {}) to ({}, {}, {}, {}) is {}",
-            location_a.x, location_a.y, location_a.rack, location_a.shelf,
-            location_b.x, location_b.y, location_b.rack, location_b.shelf, distance);
+        log_trace(
+            LogSiliconDriver,
+            "\tdistance from ({}, {}, {}, {}) to ({}, {}, {}, {}) is {}",
+            location_a.x,
+            location_a.y,
+            location_a.rack,
+            location_a.shelf,
+            location_b.x,
+            location_b.y,
+            location_b.rack,
+            location_b.shelf,
+            distance);
         return distance;
     }
 
     // move along y-dim to exit from the shelf to go to a higher shelf
-    if(location_b.rack > location_a.rack) {
-
+    if (location_b.rack > location_a.rack) {
         // this is already verified where galaxy_racks_exit_chip_coords_per_x_dim is populated, but just to be safe
-        log_assert(galaxy_racks_exit_chip_coords_per_x_dim.find(location_a.rack) != galaxy_racks_exit_chip_coords_per_x_dim.end(),
+        log_assert(
+            galaxy_racks_exit_chip_coords_per_x_dim.find(location_a.rack) !=
+                galaxy_racks_exit_chip_coords_per_x_dim.end(),
             "Expected rack-to-rack connection");
 
         // this row does not have a rack-to-rack connection
-        if(galaxy_racks_exit_chip_coords_per_x_dim.at(location_a.rack).find(location_a.x) == galaxy_racks_exit_chip_coords_per_x_dim.at(location_a.rack).end()) {
+        if (galaxy_racks_exit_chip_coords_per_x_dim.at(location_a.rack).find(location_a.x) ==
+            galaxy_racks_exit_chip_coords_per_x_dim.at(location_a.rack).end()) {
             return std::numeric_limits<int>::max();
         }
 
-        const Chip2ChipConnection& rack_to_rack_connection = galaxy_racks_exit_chip_coords_per_x_dim.at(location_a.rack).at(location_a.x);
-        log_assert(rack_to_rack_connection.destination_chip_coords.size(), "Expecting at least one rack-to-rack connection, possibly one-to-many");
+        const Chip2ChipConnection &rack_to_rack_connection =
+            galaxy_racks_exit_chip_coords_per_x_dim.at(location_a.rack).at(location_a.x);
+        log_assert(
+            rack_to_rack_connection.destination_chip_coords.size(),
+            "Expecting at least one rack-to-rack connection, possibly one-to-many");
 
         // for each rack-to-rack connection at location_a.x, find the distance to location_b, take min
         int distance = std::numeric_limits<int>::max();
         eth_coord_t exit_rack = rack_to_rack_connection.source_chip_coord;
-        for(eth_coord_t next_rack : rack_to_rack_connection.destination_chip_coords) {
-
-            log_assert(exit_rack.x == location_a.x && exit_rack.shelf == location_a.shelf && exit_rack.rack == location_a.rack,
+        for (eth_coord_t next_rack : rack_to_rack_connection.destination_chip_coords) {
+            log_assert(
+                exit_rack.x == location_a.x && exit_rack.shelf == location_a.shelf && exit_rack.rack == location_a.rack,
                 "Invalid rack exit coordinates");
-            log_assert(next_rack.x == location_a.x && next_rack.shelf == location_a.shelf && next_rack.rack == (location_a.rack+1),
+            log_assert(
+                next_rack.x == location_a.x && next_rack.shelf == location_a.shelf &&
+                    next_rack.rack == (location_a.rack + 1),
                 "Invalid rack entry coordinates");
 
             // hop onto the next rack and find distance from there
             int distance_to_exit = get_ethernet_link_coord_distance(location_a, exit_rack);
             int distance_in_next_rack = get_ethernet_link_coord_distance(next_rack, location_b);
             // no path found
-            if (distance_to_exit == std::numeric_limits<int>::max() || distance_in_next_rack == std::numeric_limits<int>::max()) {
+            if (distance_to_exit == std::numeric_limits<int>::max() ||
+                distance_in_next_rack == std::numeric_limits<int>::max()) {
                 continue;
             }
             distance = std::min(distance, distance_to_exit + distance_in_next_rack + 1);
         }
-        log_trace(LogSiliconDriver, "\tdistance from ({}, {}, {}, {}) to ({}, {}, {}, {}) is {}",
-            location_a.x, location_a.y, location_a.rack, location_a.shelf,
-            location_b.x, location_b.y, location_b.rack, location_b.shelf, distance);
+        log_trace(
+            LogSiliconDriver,
+            "\tdistance from ({}, {}, {}, {}) to ({}, {}, {}, {}) is {}",
+            location_a.x,
+            location_a.y,
+            location_a.rack,
+            location_a.shelf,
+            location_b.x,
+            location_b.y,
+            location_b.rack,
+            location_b.shelf,
+            distance);
 
         return distance;
-    }
-    else if(location_a.rack > location_b.rack) {
-
+    } else if (location_a.rack > location_b.rack) {
         // this is already verified where galaxy_racks_exit_chip_coords_per_x_dim is populated, but just to be safe
-        log_assert(galaxy_racks_exit_chip_coords_per_x_dim.find(location_b.rack) != galaxy_racks_exit_chip_coords_per_x_dim.end(),
+        log_assert(
+            galaxy_racks_exit_chip_coords_per_x_dim.find(location_b.rack) !=
+                galaxy_racks_exit_chip_coords_per_x_dim.end(),
             "Expected rack-to-rack connection");
 
         // this row does not have a rack-to-rack connection
-        if(galaxy_racks_exit_chip_coords_per_x_dim.at(location_b.rack).find(location_b.x) == galaxy_racks_exit_chip_coords_per_x_dim.at(location_b.rack).end()) {
+        if (galaxy_racks_exit_chip_coords_per_x_dim.at(location_b.rack).find(location_b.x) ==
+            galaxy_racks_exit_chip_coords_per_x_dim.at(location_b.rack).end()) {
             return std::numeric_limits<int>::max();
         }
 
-        const Chip2ChipConnection& rack_to_rack_connection = galaxy_racks_exit_chip_coords_per_x_dim.at(location_b.rack).at(location_b.x);
-        log_assert(rack_to_rack_connection.destination_chip_coords.size(), "Expecting at least one rack-to-rack connection, possibly one-to-many");
+        const Chip2ChipConnection &rack_to_rack_connection =
+            galaxy_racks_exit_chip_coords_per_x_dim.at(location_b.rack).at(location_b.x);
+        log_assert(
+            rack_to_rack_connection.destination_chip_coords.size(),
+            "Expecting at least one rack-to-rack connection, possibly one-to-many");
 
         // for each rack-to-rack connection at location_a.x, find the distance to location_b, take min
         int distance = std::numeric_limits<int>::max();
         eth_coord_t exit_rack = rack_to_rack_connection.source_chip_coord;
-        for(eth_coord_t next_rack : rack_to_rack_connection.destination_chip_coords) {
-
-            log_assert(exit_rack.x == location_b.x && exit_rack.shelf == location_b.shelf && exit_rack.rack == location_b.rack,
+        for (eth_coord_t next_rack : rack_to_rack_connection.destination_chip_coords) {
+            log_assert(
+                exit_rack.x == location_b.x && exit_rack.shelf == location_b.shelf && exit_rack.rack == location_b.rack,
                 "Invalid rack exit coordinates");
-            log_assert(next_rack.x == location_b.x && next_rack.shelf == location_b.shelf && next_rack.rack == (location_b.rack+1),
+            log_assert(
+                next_rack.x == location_b.x && next_rack.shelf == location_b.shelf &&
+                    next_rack.rack == (location_b.rack + 1),
                 "Invalid rack entry coordinates");
 
             // hop onto the next rack and find distance from there
             int distance_to_exit = get_ethernet_link_coord_distance(location_b, exit_rack);
             int distance_in_next_rack = get_ethernet_link_coord_distance(next_rack, location_a);
             // no path found
-            if (distance_to_exit == std::numeric_limits<int>::max() || distance_in_next_rack == std::numeric_limits<int>::max()) {
+            if (distance_to_exit == std::numeric_limits<int>::max() ||
+                distance_in_next_rack == std::numeric_limits<int>::max()) {
                 continue;
             }
             distance = std::min(distance, distance_to_exit + distance_in_next_rack + 1);
         }
-        log_trace(LogSiliconDriver, "\tdistance from ({}, {}, {}, {}) to ({}, {}, {}, {}) is {}",
-            location_a.x, location_a.y, location_a.rack, location_a.shelf,
-            location_b.x, location_b.y, location_b.rack, location_b.shelf, distance);
+        log_trace(
+            LogSiliconDriver,
+            "\tdistance from ({}, {}, {}, {}) to ({}, {}, {}, {}) is {}",
+            location_a.x,
+            location_a.y,
+            location_a.rack,
+            location_a.shelf,
+            location_b.x,
+            location_b.y,
+            location_b.rack,
+            location_b.shelf,
+            distance);
 
         return distance;
     }
 
-    log_trace(LogSiliconDriver, "\tdistance from ({}, {}, {}, {}) to ({}, {}, {}, {}) is {}",
-        location_a.x, location_a.y, location_a.rack, location_a.shelf,
-        location_b.x, location_b.y, location_b.rack, location_b.shelf, x_distance + y_distance);
+    log_trace(
+        LogSiliconDriver,
+        "\tdistance from ({}, {}, {}, {}) to ({}, {}, {}, {}) is {}",
+        location_a.x,
+        location_a.y,
+        location_a.rack,
+        location_a.shelf,
+        location_b.x,
+        location_b.y,
+        location_b.rack,
+        location_b.shelf,
+        x_distance + y_distance);
 
     // on same shelf/rack, the distance is just x+y difference
     return x_distance + y_distance;
@@ -252,14 +341,13 @@ int tt_ClusterDescriptor::get_ethernet_link_coord_distance(const eth_coord_t &lo
 
 // Returns the closest mmio chip to the given chip
 chip_id_t tt_ClusterDescriptor::get_closest_mmio_capable_chip(const chip_id_t chip) {
-
     log_debug(LogSiliconDriver, "get_closest_mmio_chip to chip{}", chip);
 
     if (this->is_chip_mmio_capable(chip)) {
         return chip;
     }
 
-    if(closest_mmio_chip_cache.find(chip) != closest_mmio_chip_cache.end()) {
+    if (closest_mmio_chip_cache.find(chip) != closest_mmio_chip_cache.end()) {
         return closest_mmio_chip_cache[chip];
     }
 
@@ -271,7 +359,14 @@ chip_id_t tt_ClusterDescriptor::get_closest_mmio_capable_chip(const chip_id_t ch
         const chip_id_t &mmio_chip = pair.first;
         eth_coord_t mmio_eth_coord = this->chip_locations.at(mmio_chip);
 
-        log_debug(LogSiliconDriver, "Checking chip{} at ({}, {}, {}, {})", mmio_chip, mmio_eth_coord.x, mmio_eth_coord.y, mmio_eth_coord.rack, mmio_eth_coord.shelf);
+        log_debug(
+            LogSiliconDriver,
+            "Checking chip{} at ({}, {}, {}, {})",
+            mmio_chip,
+            mmio_eth_coord.x,
+            mmio_eth_coord.y,
+            mmio_eth_coord.rack,
+            mmio_eth_coord.shelf);
 
         int distance = get_ethernet_link_coord_distance(mmio_eth_coord, chip_eth_coord);
         log_debug(LogSiliconDriver, "Distance from chip{} to chip{} is {}", chip, mmio_chip, distance);
@@ -280,7 +375,8 @@ chip_id_t tt_ClusterDescriptor::get_closest_mmio_capable_chip(const chip_id_t ch
             closest_chip = mmio_chip;
         }
     }
-    log_assert(min_distance != std::numeric_limits<int>::max(), "Chip{} is not connected to any MMIO capable chip", chip);
+    log_assert(
+        min_distance != std::numeric_limits<int>::max(), "Chip{} is not connected to any MMIO capable chip", chip);
 
     log_assert(is_chip_mmio_capable(closest_chip), "Closest MMIO chip must be MMIO capable");
 
@@ -294,32 +390,37 @@ chip_id_t tt_ClusterDescriptor::get_closest_mmio_capable_chip(const chip_id_t ch
 std::string tt_ClusterDescriptor::get_cluster_descriptor_file_path() {
     static std::string yaml_path;
     static bool is_initialized = false;
-    if (!is_initialized){
-
+    if (!is_initialized) {
         // Cluster descriptor yaml will be created in a unique temporary directory.
         std::filesystem::path temp_path = std::filesystem::temp_directory_path();
         std::string cluster_path_dir_template = temp_path / "umd_XXXXXX";
         std::filesystem::path cluster_path_dir = mkdtemp(cluster_path_dir_template.data());
         std::filesystem::path cluster_path = cluster_path_dir / "cluster_descriptor.yaml";
-        if (!std::filesystem::exists(cluster_path)){
-            auto val = system ( ("touch " + cluster_path.string()).c_str());
-            if(val != 0) throw std::runtime_error("Cluster Generation Failed!");
+        if (!std::filesystem::exists(cluster_path)) {
+            auto val = system(("touch " + cluster_path.string()).c_str());
+            if (val != 0) {
+                throw std::runtime_error("Cluster Generation Failed!");
+            }
         }
 
-        int val = create_ethernet_map((char*)cluster_path.string().c_str());
-        if(val != 0) throw std::runtime_error("Cluster Generation Failed!");
+        int val = create_ethernet_map((char *)cluster_path.string().c_str());
+        if (val != 0) {
+            throw std::runtime_error("Cluster Generation Failed!");
+        }
         yaml_path = cluster_path.string();
         is_initialized = true;
     }
     return yaml_path;
 }
 
-std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_from_yaml(const std::string &cluster_descriptor_file_path) {
+std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_from_yaml(
+    const std::string &cluster_descriptor_file_path) {
     std::unique_ptr<tt_ClusterDescriptor> desc = std::unique_ptr<tt_ClusterDescriptor>(new tt_ClusterDescriptor());
 
     std::ifstream fdesc(cluster_descriptor_file_path);
     if (fdesc.fail()) {
-        throw std::runtime_error(fmt::format("Error: cluster connectivity descriptor file {} does not exist!", cluster_descriptor_file_path));
+        throw std::runtime_error(fmt::format(
+            "Error: cluster connectivity descriptor file {} does not exist!", cluster_descriptor_file_path));
     }
     fdesc.close();
 
@@ -337,22 +438,31 @@ std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_from_yaml(con
 }
 
 std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_for_grayskull_cluster(
-    const std::set<chip_id_t> &logical_mmio_device_ids,
-    const std::vector<chip_id_t> &physical_mmio_device_ids) {
+    const std::set<chip_id_t> &logical_mmio_device_ids, const std::vector<chip_id_t> &physical_mmio_device_ids) {
     std::unique_ptr<tt_ClusterDescriptor> desc = std::unique_ptr<tt_ClusterDescriptor>(new tt_ClusterDescriptor());
 
     // Some users need not care about physical ids, can provide empty set.
-    auto use_physical_ids                   = physical_mmio_device_ids.size() ? true : false;
-    auto largest_workload_logical_device_id = *logical_mmio_device_ids.rbegin(); // Last element in ordered set.
-    auto num_available_physical_devices     = physical_mmio_device_ids.size();
-    auto required_physical_devices          = largest_workload_logical_device_id + 1;
+    auto use_physical_ids = physical_mmio_device_ids.size() ? true : false;
+    auto largest_workload_logical_device_id = *logical_mmio_device_ids.rbegin();  // Last element in ordered set.
+    auto num_available_physical_devices = physical_mmio_device_ids.size();
+    auto required_physical_devices = largest_workload_logical_device_id + 1;
 
-    log_debug(tt::LogSiliconDriver, "{} - use_physical_ids: {} largest_workload_logical_device_id: {} num_available_physical_devices: {} required_physical_devices: {}",
-        __FUNCTION__, use_physical_ids, largest_workload_logical_device_id, num_available_physical_devices, required_physical_devices);
+    log_debug(
+        tt::LogSiliconDriver,
+        "{} - use_physical_ids: {} largest_workload_logical_device_id: {} num_available_physical_devices: {} "
+        "required_physical_devices: {}",
+        __FUNCTION__,
+        use_physical_ids,
+        largest_workload_logical_device_id,
+        num_available_physical_devices,
+        required_physical_devices);
 
-    log_assert(!use_physical_ids || num_available_physical_devices >= required_physical_devices,
+    log_assert(
+        !use_physical_ids || num_available_physical_devices >= required_physical_devices,
         "Insufficient silicon devices. Workload requires device_id: {} (ie. {} devices) but only {} present",
-        largest_workload_logical_device_id, required_physical_devices, num_available_physical_devices);
+        largest_workload_logical_device_id,
+        required_physical_devices,
+        num_available_physical_devices);
 
     // All Grayskull devices are MMIO mapped so physical_mmio_device_ids correspond to all available devices
     for (auto &logical_id : logical_mmio_device_ids) {
@@ -361,8 +471,10 @@ std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_for_grayskull
         desc->all_chips.insert(logical_id);
         eth_coord_t chip_location{logical_id, 0, 0, 0};
         desc->chip_locations.insert({logical_id, chip_location});
-        desc->coords_to_chip_ids[chip_location.rack][chip_location.shelf][chip_location.y][chip_location.x] = logical_id;
-        log_debug(tt::LogSiliconDriver, "{} - adding logical: {} => physical: {}", __FUNCTION__, logical_id, physical_id);
+        desc->coords_to_chip_ids[chip_location.rack][chip_location.shelf][chip_location.y][chip_location.x] =
+            logical_id;
+        log_debug(
+            tt::LogSiliconDriver, "{} - adding logical: {} => physical: {}", __FUNCTION__, logical_id, physical_id);
     }
 
     desc->enable_all_devices();
@@ -370,7 +482,8 @@ std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_for_grayskull
     return desc;
 }
 
-void tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descriptor(YAML::Node &yaml, tt_ClusterDescriptor &desc) {
+void tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descriptor(
+    YAML::Node &yaml, tt_ClusterDescriptor &desc) {
     log_assert(yaml["ethernet_connections"].IsSequence(), "Invalid YAML");
     for (YAML::Node &connected_endpoints : yaml["ethernet_connections"].as<std::vector<YAML::Node>>()) {
         log_assert(connected_endpoints.IsSequence(), "Invalid YAML");
@@ -403,7 +516,13 @@ void tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descripto
     log_debug(LogSiliconDriver, "Ethernet Connectivity Descriptor:");
     for (const auto &[chip, chan_to_chip_chan_map] : desc.ethernet_connections) {
         for (const auto &[chan, chip_and_chan] : chan_to_chip_chan_map) {
-            log_debug(LogSiliconDriver, "\tchip: {}, chan: {}  <-->  chip: {}, chan: {}", chip, chan, chip_and_chan.x, chip_and_chan.y);
+            log_debug(
+                LogSiliconDriver,
+                "\tchip: {}, chan: {}  <-->  chip: {}, chan: {}",
+                chip,
+                chan,
+                chip_and_chan.x,
+                chip_and_chan.y);
         }
     }
 
@@ -423,52 +542,61 @@ void tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descripto
 }
 
 void tt_ClusterDescriptor::fill_galaxy_connections(tt_ClusterDescriptor &desc) {
-
     int highest_shelf_id = 0;
     int highest_rack_id = 0;
 
     // shelves and racks can be connected at different chip coordinates
-    // determine which chips are connected to the next (i.e. higher id) shelf/rack and what the coordinate of the chip on the other shelf/rack is
-    // this is used in get_ethernet_link_coord_distance to find the distance between two chips
+    // determine which chips are connected to the next (i.e. higher id) shelf/rack and what the coordinate of the chip
+    // on the other shelf/rack is this is used in get_ethernet_link_coord_distance to find the distance between two
+    // chips
     for (const auto &[chip_id, chip_eth_coord] : desc.chip_locations) {
         highest_shelf_id = std::max(highest_shelf_id, chip_eth_coord.shelf);
         highest_rack_id = std::max(highest_rack_id, chip_eth_coord.rack);
         // iterate over all neighbors
-        if(desc.ethernet_connections.find(chip_id) == desc.ethernet_connections.end()) {
-            continue; // chip has no eth connections
+        if (desc.ethernet_connections.find(chip_id) == desc.ethernet_connections.end()) {
+            continue;  // chip has no eth connections
         }
         for (const auto &[chan, chip_and_chan] : desc.ethernet_connections.at(chip_id)) {
             const chip_id_t &neighbor_chip = std::get<0>(chip_and_chan);
             eth_coord_t neighbor_eth_coord = desc.chip_locations.at(neighbor_chip);
             // shelves are connected in x-dim
-            if(neighbor_eth_coord.shelf != chip_eth_coord.shelf) {
-                eth_coord_t higher_shelf_coord = neighbor_eth_coord.shelf > chip_eth_coord.shelf ? neighbor_eth_coord : chip_eth_coord;
-                eth_coord_t lower_shelf_coord = neighbor_eth_coord.shelf < chip_eth_coord.shelf ? neighbor_eth_coord : chip_eth_coord;
+            if (neighbor_eth_coord.shelf != chip_eth_coord.shelf) {
+                eth_coord_t higher_shelf_coord =
+                    neighbor_eth_coord.shelf > chip_eth_coord.shelf ? neighbor_eth_coord : chip_eth_coord;
+                eth_coord_t lower_shelf_coord =
+                    neighbor_eth_coord.shelf < chip_eth_coord.shelf ? neighbor_eth_coord : chip_eth_coord;
                 int lower_shelf_id = lower_shelf_coord.shelf;
                 int lower_shelf_y = lower_shelf_coord.y;
 
-                auto& galaxy_shelf_exit_chip_coords_per_y_dim = desc.galaxy_shelves_exit_chip_coords_per_y_dim[lower_shelf_id];
+                auto &galaxy_shelf_exit_chip_coords_per_y_dim =
+                    desc.galaxy_shelves_exit_chip_coords_per_y_dim[lower_shelf_id];
 
                 log_assert(
-                    galaxy_shelf_exit_chip_coords_per_y_dim.find(lower_shelf_y) == galaxy_shelf_exit_chip_coords_per_y_dim.end() ||
-                    galaxy_shelf_exit_chip_coords_per_y_dim[lower_shelf_y].source_chip_coord == lower_shelf_coord,
+                    galaxy_shelf_exit_chip_coords_per_y_dim.find(lower_shelf_y) ==
+                            galaxy_shelf_exit_chip_coords_per_y_dim.end() ||
+                        galaxy_shelf_exit_chip_coords_per_y_dim[lower_shelf_y].source_chip_coord == lower_shelf_coord,
                     "Expected a single exit chip on each shelf row");
                 galaxy_shelf_exit_chip_coords_per_y_dim[lower_shelf_y].source_chip_coord = lower_shelf_coord;
-                galaxy_shelf_exit_chip_coords_per_y_dim[lower_shelf_y].destination_chip_coords.insert(higher_shelf_coord);
+                galaxy_shelf_exit_chip_coords_per_y_dim[lower_shelf_y].destination_chip_coords.insert(
+                    higher_shelf_coord);
             }
 
             // racks are connected in y-dim
-            if(neighbor_eth_coord.rack != chip_eth_coord.rack) {
-                eth_coord_t higher_rack_coord = neighbor_eth_coord.rack > chip_eth_coord.rack ? neighbor_eth_coord : chip_eth_coord;
-                eth_coord_t lower_rack_coord = neighbor_eth_coord.rack < chip_eth_coord.rack ? neighbor_eth_coord : chip_eth_coord;
+            if (neighbor_eth_coord.rack != chip_eth_coord.rack) {
+                eth_coord_t higher_rack_coord =
+                    neighbor_eth_coord.rack > chip_eth_coord.rack ? neighbor_eth_coord : chip_eth_coord;
+                eth_coord_t lower_rack_coord =
+                    neighbor_eth_coord.rack < chip_eth_coord.rack ? neighbor_eth_coord : chip_eth_coord;
                 int lower_rack_id = lower_rack_coord.rack;
                 int lower_rack_x = lower_rack_coord.x;
 
-                auto& galaxy_rack_exit_chip_coords_per_x_dim = desc.galaxy_racks_exit_chip_coords_per_x_dim[lower_rack_id];
+                auto &galaxy_rack_exit_chip_coords_per_x_dim =
+                    desc.galaxy_racks_exit_chip_coords_per_x_dim[lower_rack_id];
 
                 log_assert(
-                    galaxy_rack_exit_chip_coords_per_x_dim.find(lower_rack_x) == galaxy_rack_exit_chip_coords_per_x_dim.end() ||
-                    galaxy_rack_exit_chip_coords_per_x_dim[lower_rack_x].source_chip_coord == lower_rack_coord,
+                    galaxy_rack_exit_chip_coords_per_x_dim.find(lower_rack_x) ==
+                            galaxy_rack_exit_chip_coords_per_x_dim.end() ||
+                        galaxy_rack_exit_chip_coords_per_x_dim[lower_rack_x].source_chip_coord == lower_rack_coord,
                     "Expected a single exit chip on each rack column");
                 galaxy_rack_exit_chip_coords_per_x_dim[lower_rack_x].source_chip_coord = lower_rack_coord;
                 galaxy_rack_exit_chip_coords_per_x_dim[lower_rack_x].destination_chip_coords.insert(higher_rack_coord);
@@ -479,23 +607,36 @@ void tt_ClusterDescriptor::fill_galaxy_connections(tt_ClusterDescriptor &desc) {
     // verify that every shelf (except the highest in id) is found in galaxy_shelves_exit_chip_coords_per_y_dim
     // this means that we expect the shelves to be connected linearly in a daisy-chain fashion.
     // shelf0->shelf1->shelf2->...->shelfN
-    for(int shelf_id = 0; shelf_id < highest_shelf_id; shelf_id++) {
-        log_assert(desc.galaxy_shelves_exit_chip_coords_per_y_dim.find(shelf_id) != desc.galaxy_shelves_exit_chip_coords_per_y_dim.end(),
-            "Expected shelf {} to be connected to the next shelf", shelf_id);
+    for (int shelf_id = 0; shelf_id < highest_shelf_id; shelf_id++) {
+        log_assert(
+            desc.galaxy_shelves_exit_chip_coords_per_y_dim.find(shelf_id) !=
+                desc.galaxy_shelves_exit_chip_coords_per_y_dim.end(),
+            "Expected shelf {} to be connected to the next shelf",
+            shelf_id);
     }
 
     // this prints the exit chip coordinates for each shelf
     // this is used in get_ethernet_link_coord_distance to find the distance between two chips
     for (const auto &[shelf, shelf_exit_chip_coords_per_y_dim] : desc.galaxy_shelves_exit_chip_coords_per_y_dim) {
         for (const auto &[y_dim, shelf_exit_chip_coords] : shelf_exit_chip_coords_per_y_dim) {
-            log_debug(LogSiliconDriver, "shelf: {} y_dim: {} exit_coord:({}, {}, {}, {})",
-                shelf, y_dim,
-                shelf_exit_chip_coords.source_chip_coord.x, shelf_exit_chip_coords.source_chip_coord.y,
-                shelf_exit_chip_coords.source_chip_coord.rack, shelf_exit_chip_coords.source_chip_coord.shelf);
+            log_debug(
+                LogSiliconDriver,
+                "shelf: {} y_dim: {} exit_coord:({}, {}, {}, {})",
+                shelf,
+                y_dim,
+                shelf_exit_chip_coords.source_chip_coord.x,
+                shelf_exit_chip_coords.source_chip_coord.y,
+                shelf_exit_chip_coords.source_chip_coord.rack,
+                shelf_exit_chip_coords.source_chip_coord.shelf);
             for (const auto &destination_chip_coord : shelf_exit_chip_coords.destination_chip_coords) {
                 // print shelf_exit_chip_coord in the format: (x, y, rack, shelf)
-                log_debug(LogSiliconDriver, "\tdestination_chip_coord: ({}, {}, {}, {})",
-                    destination_chip_coord.x, destination_chip_coord.y, destination_chip_coord.rack, destination_chip_coord.shelf);
+                log_debug(
+                    LogSiliconDriver,
+                    "\tdestination_chip_coord: ({}, {}, {}, {})",
+                    destination_chip_coord.x,
+                    destination_chip_coord.y,
+                    destination_chip_coord.rack,
+                    destination_chip_coord.shelf);
             }
         }
     }
@@ -503,28 +644,41 @@ void tt_ClusterDescriptor::fill_galaxy_connections(tt_ClusterDescriptor &desc) {
     // verify that every rack (except the highest in id) is found in galaxy_racks_exit_chip_coords_per_x_dim
     // this means that we expect the racks to be connected linearly in a daisy-chain fashion.
     // rack0->rack1->rack2->...->rackN
-    for(int rack_id = 0; rack_id < highest_rack_id; rack_id++) {
-        log_assert(desc.galaxy_racks_exit_chip_coords_per_x_dim.find(rack_id) != desc.galaxy_racks_exit_chip_coords_per_x_dim.end(),
-            "Expected rack {} to be connected to the next rack", rack_id);
+    for (int rack_id = 0; rack_id < highest_rack_id; rack_id++) {
+        log_assert(
+            desc.galaxy_racks_exit_chip_coords_per_x_dim.find(rack_id) !=
+                desc.galaxy_racks_exit_chip_coords_per_x_dim.end(),
+            "Expected rack {} to be connected to the next rack",
+            rack_id);
     }
 
     // this prints the exit chip coordinates for each rack
     // this is used in get_ethernet_link_coord_distance to find the distance between two chips
     for (const auto &[rack, rack_exit_chip_coords_per_x_dim] : desc.galaxy_racks_exit_chip_coords_per_x_dim) {
         for (const auto &[x_dim, rack_exit_chip_coords] : rack_exit_chip_coords_per_x_dim) {
-            log_debug(LogSiliconDriver, "rack: {} x_dim: {} exit_coord:({}, {}, {}, {})", rack, x_dim,
-                rack_exit_chip_coords.source_chip_coord.x, rack_exit_chip_coords.source_chip_coord.y,
-                rack_exit_chip_coords.source_chip_coord.rack, rack_exit_chip_coords.source_chip_coord.shelf);
+            log_debug(
+                LogSiliconDriver,
+                "rack: {} x_dim: {} exit_coord:({}, {}, {}, {})",
+                rack,
+                x_dim,
+                rack_exit_chip_coords.source_chip_coord.x,
+                rack_exit_chip_coords.source_chip_coord.y,
+                rack_exit_chip_coords.source_chip_coord.rack,
+                rack_exit_chip_coords.source_chip_coord.shelf);
             for (const auto &destination_chip_coord : rack_exit_chip_coords.destination_chip_coords) {
-                log_debug(LogSiliconDriver, "\tdestination_chip_coord: ({}, {}, {}, {})",
-                    destination_chip_coord.x, destination_chip_coord.y, destination_chip_coord.rack, destination_chip_coord.shelf);
+                log_debug(
+                    LogSiliconDriver,
+                    "\tdestination_chip_coord: ({}, {}, {}, {})",
+                    destination_chip_coord.x,
+                    destination_chip_coord.y,
+                    destination_chip_coord.rack,
+                    destination_chip_coord.shelf);
             }
         }
     }
 }
 
 void tt_ClusterDescriptor::merge_cluster_ids(tt_ClusterDescriptor &desc) {
-    
     DisjointSet<chip_id_t> chip_sets;
     for (const auto &[chip, _] : desc.chip_locations) {
         chip_sets.add_item(chip);
@@ -545,7 +699,6 @@ void tt_ClusterDescriptor::merge_cluster_ids(tt_ClusterDescriptor &desc) {
 }
 
 void tt_ClusterDescriptor::load_chips_from_connectivity_descriptor(YAML::Node &yaml, tt_ClusterDescriptor &desc) {
-
     for (YAML::const_iterator node = yaml["arch"].begin(); node != yaml["arch"].end(); ++node) {
         chip_id_t chip_id = node->first.as<int>();
         desc.all_chips.insert(chip_id);
@@ -561,14 +714,13 @@ void tt_ClusterDescriptor::load_chips_from_connectivity_descriptor(YAML::Node &y
         desc.chip_locations.insert({chip_id, chip_location});
         desc.coords_to_chip_ids[chip_location.rack][chip_location.shelf][chip_location.y][chip_location.x] = chip_id;
     }
-    
-    for(const auto& chip : yaml["chips_with_mmio"]) {
-        if(chip.IsMap()) {
+
+    for (const auto &chip : yaml["chips_with_mmio"]) {
+        if (chip.IsMap()) {
             const auto &chip_map = chip.as<std::map<chip_id_t, chip_id_t>>();
             const auto &chips = chip_map.begin();
             desc.chips_with_mmio.insert({chips->first, chips->second});
-        }
-        else {
+        } else {
             const auto &chip_val = chip.as<int>();
             desc.chips_with_mmio.insert({chip_val, chip_val});
         }
@@ -585,8 +737,8 @@ void tt_ClusterDescriptor::load_chips_from_connectivity_descriptor(YAML::Node &y
             chip_location.shelf);
     }
 
-	if (yaml["boardtype"]) {
-        for (const auto& chip_board_type : yaml["boardtype"].as<std::map<int, std::string>>()) {
+    if (yaml["boardtype"]) {
+        for (const auto &chip_board_type : yaml["boardtype"].as<std::map<int, std::string>>()) {
             auto &chip = chip_board_type.first;
             BoardType board_type;
             if (chip_board_type.second == "n150") {
@@ -597,25 +749,28 @@ void tt_ClusterDescriptor::load_chips_from_connectivity_descriptor(YAML::Node &y
                 board_type = BoardType::GALAXY;
             } else if (chip_board_type.second == "e150") {
                 board_type = BoardType::E150;
-            }
-            else if (chip_board_type.second == "p150A") {
+            } else if (chip_board_type.second == "p150A") {
                 board_type = BoardType::P150A;
             } else {
-                log_warning(LogSiliconDriver, "Unknown board type for chip {}. This might happen because chip is running old firmware. Defaulting to DEFAULT", chip);
+                log_warning(
+                    LogSiliconDriver,
+                    "Unknown board type for chip {}. This might happen because chip is running old firmware. "
+                    "Defaulting to DEFAULT",
+                    chip);
                 board_type = BoardType::DEFAULT;
             }
             desc.chip_board_type.insert({chip, board_type});
         }
     } else {
-        for (const auto& chip: desc.all_chips) {
+        for (const auto &chip : desc.all_chips) {
             desc.chip_board_type.insert({chip, BoardType::DEFAULT});
         }
     }
 }
 
 void tt_ClusterDescriptor::load_harvesting_information(YAML::Node &yaml, tt_ClusterDescriptor &desc) {
-    if(yaml["harvesting"]) {
-        for (const auto& chip_node : yaml["harvesting"].as<std::map<int, YAML::Node>>()) {
+    if (yaml["harvesting"]) {
+        for (const auto &chip_node : yaml["harvesting"].as<std::map<int, YAML::Node>>()) {
             chip_id_t chip = chip_node.first;
             auto harvesting_info = chip_node.second;
             desc.noc_translation_enabled.insert({chip, harvesting_info["noc_translation"].as<bool>()});
@@ -624,9 +779,7 @@ void tt_ClusterDescriptor::load_harvesting_information(YAML::Node &yaml, tt_Clus
     }
 }
 
-void tt_ClusterDescriptor::enable_all_devices() {
-    this->enabled_active_chips = this->all_chips;
-}
+void tt_ClusterDescriptor::enable_all_devices() { this->enabled_active_chips = this->all_chips; }
 
 void tt_ClusterDescriptor::fill_chips_grouped_by_closest_mmio() {
     for (const auto &chip : this->all_chips) {
@@ -636,8 +789,10 @@ void tt_ClusterDescriptor::fill_chips_grouped_by_closest_mmio() {
     }
 }
 
-const std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t> > > tt_ClusterDescriptor::get_ethernet_connections() const {
-    auto eth_connections = std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t> > >();
+const std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>>
+tt_ClusterDescriptor::get_ethernet_connections() const {
+    auto eth_connections = std::
+        unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>>();
 
     for (const auto &[chip, channel_mapping] : this->ethernet_connections) {
         if (this->enabled_active_chips.find(chip) != this->enabled_active_chips.end()) {
@@ -653,7 +808,7 @@ const std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::
     return eth_connections;
 }
 
-const std::unordered_map<chip_id_t, eth_coord_t>& tt_ClusterDescriptor::get_chip_locations() const {
+const std::unordered_map<chip_id_t, eth_coord_t> &tt_ClusterDescriptor::get_chip_locations() const {
     static auto locations = std::unordered_map<chip_id_t, eth_coord_t>();
     if (locations.empty() and !this->chip_locations.empty()) {
         for (auto chip_id : this->enabled_active_chips) {
@@ -665,9 +820,12 @@ const std::unordered_map<chip_id_t, eth_coord_t>& tt_ClusterDescriptor::get_chip
 }
 
 chip_id_t tt_ClusterDescriptor::get_shelf_local_physical_chip_coords(chip_id_t virtual_coord) {
-    log_assert(!this->chip_locations.empty(), "Getting physical chip coordinates is only valid for systems where chips have coordinates");
+    log_assert(
+        !this->chip_locations.empty(),
+        "Getting physical chip coordinates is only valid for systems where chips have coordinates");
     // Physical cooridnates of chip inside a single rack. Calculated based on Galaxy topology.
-    // See: https://yyz-gitlab.local.tenstorrent.com/tenstorrent/budabackend/-/wikis/uploads/23e7a5168f38dfb706f9887fde78cb03/image.png
+    // See:
+    // https://yyz-gitlab.local.tenstorrent.com/tenstorrent/budabackend/-/wikis/uploads/23e7a5168f38dfb706f9887fde78cb03/image.png
     int x = get_chip_locations().at(virtual_coord).x;
     int y = get_chip_locations().at(virtual_coord).y;
     return 8 * x + y;
@@ -686,30 +844,31 @@ const std::unordered_map<chip_id_t, chip_id_t> tt_ClusterDescriptor::get_chips_w
     return chips_map;
 }
 
-const std::unordered_set<chip_id_t>& tt_ClusterDescriptor::get_all_chips() const {
-    return this->enabled_active_chips;
-}
+const std::unordered_set<chip_id_t> &tt_ClusterDescriptor::get_all_chips() const { return this->enabled_active_chips; }
 
-const std::unordered_map<chip_id_t, std::uint32_t>& tt_ClusterDescriptor::get_harvesting_info() const {
+const std::unordered_map<chip_id_t, std::uint32_t> &tt_ClusterDescriptor::get_harvesting_info() const {
     return harvesting_masks;
 }
 
-const std::unordered_map<chip_id_t, bool>& tt_ClusterDescriptor::get_noc_translation_table_en() const {
+const std::unordered_map<chip_id_t, bool> &tt_ClusterDescriptor::get_noc_translation_table_en() const {
     return noc_translation_enabled;
 }
 
 std::size_t tt_ClusterDescriptor::get_number_of_chips() const { return this->enabled_active_chips.size(); }
 
 int tt_ClusterDescriptor::get_ethernet_link_distance(chip_id_t chip_a, chip_id_t chip_b) const {
-    log_assert(!this->chip_locations.empty(), "Getting physical chip coordinates is only valid for systems where chips have coordinates");
+    log_assert(
+        !this->chip_locations.empty(),
+        "Getting physical chip coordinates is only valid for systems where chips have coordinates");
     return this->get_ethernet_link_coord_distance(chip_locations.at(chip_a), chip_locations.at(chip_b));
 }
 
 BoardType tt_ClusterDescriptor::get_board_type(chip_id_t chip_id) const {
-  BoardType board_type = this->chip_board_type.at(chip_id);
-  return board_type;
+    BoardType board_type = this->chip_board_type.at(chip_id);
+    return board_type;
 }
 
-const std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>>& tt_ClusterDescriptor::get_chips_grouped_by_closest_mmio() const {
+const std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> &
+tt_ClusterDescriptor::get_chips_grouped_by_closest_mmio() const {
     return chips_grouped_by_closest_mmio;
 }

--- a/device/tt_cluster_descriptor.h
+++ b/device/tt_cluster_descriptor.h
@@ -4,23 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 #pragma once
 
-#include "device/tt_xy_pair.h"
-
 #include <cstdint>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
-#include <set>
-#include <map>
-#include <tuple>
-#include <string>
 #include <vector>
-#include <memory>
-#include "device/tt_cluster_descriptor_types.h"
 
-namespace YAML { class Node; }
+#include "device/tt_cluster_descriptor_types.h"
+#include "device/tt_xy_pair.h"
+
+namespace YAML {
+class Node;
+}
 
 enum BoardType : uint32_t {
     N150 = 0,
@@ -32,90 +33,93 @@ enum BoardType : uint32_t {
 };
 
 class tt_ClusterDescriptor {
-
 private:
-  int get_ethernet_link_coord_distance(const eth_coord_t &location_a, const eth_coord_t &location_b) const;
+    int get_ethernet_link_coord_distance(const eth_coord_t &location_a, const eth_coord_t &location_b) const;
 
 protected:
+    std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>>
+        ethernet_connections;
+    std::unordered_map<chip_id_t, eth_coord_t> chip_locations;
+    // reverse map: rack/shelf/y/x -> chip_id
+    std::map<int, std::map<int, std::map<int, std::map<int, chip_id_t>>>> coords_to_chip_ids;
+    std::unordered_map<chip_id_t, chip_id_t> chips_with_mmio;
+    std::unordered_set<chip_id_t> all_chips;
+    std::unordered_map<chip_id_t, bool> noc_translation_enabled = {};
+    std::unordered_map<chip_id_t, std::uint32_t> harvesting_masks = {};
+    std::unordered_set<chip_id_t> enabled_active_chips;
+    std::unordered_map<chip_id_t, chip_id_t> closest_mmio_chip_cache = {};
+    std::unordered_map<chip_id_t, BoardType> chip_board_type = {};
+    std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> chips_grouped_by_closest_mmio;
 
-  std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t> > > ethernet_connections;
-  std::unordered_map<chip_id_t, eth_coord_t> chip_locations;
-  // reverse map: rack/shelf/y/x -> chip_id
-  std::map<int, std::map<int, std::map<int, std::map<int, chip_id_t > > > > coords_to_chip_ids;
-  std::unordered_map<chip_id_t, chip_id_t> chips_with_mmio;
-  std::unordered_set<chip_id_t> all_chips;
-  std::unordered_map<chip_id_t, bool> noc_translation_enabled = {};
-  std::unordered_map<chip_id_t, std::uint32_t> harvesting_masks = {};
-  std::unordered_set<chip_id_t> enabled_active_chips;
-  std::unordered_map<chip_id_t, chip_id_t> closest_mmio_chip_cache = {};
-  std::unordered_map<chip_id_t, BoardType> chip_board_type = {};
-  std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> chips_grouped_by_closest_mmio;
+    // one-to-many chip connections
+    struct Chip2ChipConnection {
+        eth_coord_t source_chip_coord;
+        std::unordered_set<eth_coord_t> destination_chip_coords;
+    };
 
-  // one-to-many chip connections
-  struct Chip2ChipConnection {
-    eth_coord_t source_chip_coord;
-    std::unordered_set<eth_coord_t> destination_chip_coords;
-  };
+    // shelf_id -> y dim -> list of chip2chip connections between different shelves
+    // assumption is that on every row of the shelf there is a chip that is connected to the other shelf
+    // there could be one-to-many connections between shelves, i.e. one chip is connected to multiple chips on the other
+    // shelf (in case of nebula->galaxy)
+    std::unordered_map<int, std::unordered_map<int, Chip2ChipConnection>> galaxy_shelves_exit_chip_coords_per_y_dim =
+        {};
+    // rack_id -> x dim -> list of chip2chip connections between different racks
+    // assumption is that on every row of the rack there is a chip that is connected to the other rack
+    std::unordered_map<int, std::unordered_map<int, Chip2ChipConnection>> galaxy_racks_exit_chip_coords_per_x_dim = {};
 
-  // shelf_id -> y dim -> list of chip2chip connections between different shelves
-  // assumption is that on every row of the shelf there is a chip that is connected to the other shelf
-  // there could be one-to-many connections between shelves, i.e. one chip is connected to multiple chips on the other shelf (in case of nebula->galaxy)
-  std::unordered_map<int, std::unordered_map<int, Chip2ChipConnection > > galaxy_shelves_exit_chip_coords_per_y_dim = {};
-  // rack_id -> x dim -> list of chip2chip connections between different racks
-  // assumption is that on every row of the rack there is a chip that is connected to the other rack
-  std::unordered_map<int, std::unordered_map<int, Chip2ChipConnection > > galaxy_racks_exit_chip_coords_per_x_dim = {};
+    static void load_ethernet_connections_from_connectivity_descriptor(YAML::Node &yaml, tt_ClusterDescriptor &desc);
+    static void fill_galaxy_connections(tt_ClusterDescriptor &desc);
+    static void load_chips_from_connectivity_descriptor(YAML::Node &yaml, tt_ClusterDescriptor &desc);
+    static void merge_cluster_ids(tt_ClusterDescriptor &desc);
+    static void load_harvesting_information(YAML::Node &yaml, tt_ClusterDescriptor &desc);
 
-  static void load_ethernet_connections_from_connectivity_descriptor(YAML::Node &yaml, tt_ClusterDescriptor &desc);
-  static void fill_galaxy_connections(tt_ClusterDescriptor &desc);
-  static void load_chips_from_connectivity_descriptor(YAML::Node &yaml, tt_ClusterDescriptor &desc);
-  static void merge_cluster_ids(tt_ClusterDescriptor &desc);
-  static void load_harvesting_information(YAML::Node &yaml, tt_ClusterDescriptor &desc);
-
-  void fill_chips_grouped_by_closest_mmio();
+    void fill_chips_grouped_by_closest_mmio();
 
 public:
-  tt_ClusterDescriptor() = default;
-  tt_ClusterDescriptor(const tt_ClusterDescriptor&) = default;
+    tt_ClusterDescriptor() = default;
+    tt_ClusterDescriptor(const tt_ClusterDescriptor &) = default;
 
-  /*
-   * Returns the pairs of channels that are connected where the first entry in the pair corresponds to the argument ordering when calling the function
-   * An empty result implies that the two chips do not share any direct connection
-   */
-  std::vector<std::tuple<ethernet_channel_t, ethernet_channel_t>> get_directly_connected_ethernet_channels_between_chips(const chip_id_t &first, const chip_id_t &second) const;
-  
-  bool is_chip_mmio_capable(const chip_id_t chip_id) const;
-  bool is_chip_remote(const chip_id_t chip_id) const;
-  chip_id_t get_closest_mmio_capable_chip(const chip_id_t chip);
-  chip_id_t get_shelf_local_physical_chip_coords(chip_id_t virtual_coord);
+    /*
+     * Returns the pairs of channels that are connected where the first entry in the pair corresponds to the argument
+     * ordering when calling the function An empty result implies that the two chips do not share any direct connection
+     */
+    std::vector<std::tuple<ethernet_channel_t, ethernet_channel_t>>
+    get_directly_connected_ethernet_channels_between_chips(const chip_id_t &first, const chip_id_t &second) const;
 
-  // TODO: These following functions will be removed, and ClusterDescriptor will be created without any parameters.
-  // get_cluster_descriptor_file_path will create ethernet map in the background.
-  static std::string get_cluster_descriptor_file_path();
-  static std::unique_ptr<tt_ClusterDescriptor> create_from_yaml(const std::string &cluster_descriptor_file_path);
+    bool is_chip_mmio_capable(const chip_id_t chip_id) const;
+    bool is_chip_remote(const chip_id_t chip_id) const;
+    chip_id_t get_closest_mmio_capable_chip(const chip_id_t chip);
+    chip_id_t get_shelf_local_physical_chip_coords(chip_id_t virtual_coord);
 
-  // TODO: This function is used to create mock cluster descriptor yaml files, for example for simulation.
-  // The name of the function is kept to not gate the changes regarding create-ethernet-map.
-  // It should be renamed to something like create_mock_cluster_descriptor and changed in tt-metal/tt-debuda.
-  static std::unique_ptr<tt_ClusterDescriptor> create_for_grayskull_cluster(
-    const std::set<chip_id_t> &logical_mmio_device_ids,
-    const std::vector<chip_id_t> &physical_mmio_device_ids);
+    // TODO: These following functions will be removed, and ClusterDescriptor will be created without any parameters.
+    // get_cluster_descriptor_file_path will create ethernet map in the background.
+    static std::string get_cluster_descriptor_file_path();
+    static std::unique_ptr<tt_ClusterDescriptor> create_from_yaml(const std::string &cluster_descriptor_file_path);
 
-  const std::unordered_map<chip_id_t, std::uint32_t>& get_harvesting_info() const;
-  const std::unordered_map<chip_id_t, bool>& get_noc_translation_table_en() const;
-  const std::unordered_map<chip_id_t, eth_coord_t>& get_chip_locations() const;
-  const std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t> > > get_ethernet_connections() const;
-  const std::unordered_map<chip_id_t, chip_id_t> get_chips_with_mmio() const;
-  const std::unordered_set<chip_id_t>& get_all_chips() const;
-  const std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>>& get_chips_grouped_by_closest_mmio() const;
-  std::size_t get_number_of_chips() const;
+    // TODO: This function is used to create mock cluster descriptor yaml files, for example for simulation.
+    // The name of the function is kept to not gate the changes regarding create-ethernet-map.
+    // It should be renamed to something like create_mock_cluster_descriptor and changed in tt-metal/tt-debuda.
+    static std::unique_ptr<tt_ClusterDescriptor> create_for_grayskull_cluster(
+        const std::set<chip_id_t> &logical_mmio_device_ids, const std::vector<chip_id_t> &physical_mmio_device_ids);
 
-  int get_ethernet_link_distance(chip_id_t chip_a, chip_id_t chip_b) const;
+    const std::unordered_map<chip_id_t, std::uint32_t> &get_harvesting_info() const;
+    const std::unordered_map<chip_id_t, bool> &get_noc_translation_table_en() const;
+    const std::unordered_map<chip_id_t, eth_coord_t> &get_chip_locations() const;
+    const std::
+        unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>>
+        get_ethernet_connections() const;
+    const std::unordered_map<chip_id_t, chip_id_t> get_chips_with_mmio() const;
+    const std::unordered_set<chip_id_t> &get_all_chips() const;
+    const std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> &get_chips_grouped_by_closest_mmio() const;
+    std::size_t get_number_of_chips() const;
 
-  BoardType get_board_type(chip_id_t chip_id) const;
+    int get_ethernet_link_distance(chip_id_t chip_a, chip_id_t chip_b) const;
 
-  bool ethernet_core_has_active_ethernet_link(chip_id_t local_chip, ethernet_channel_t local_ethernet_channel) const;
-  std::tuple<chip_id_t, ethernet_channel_t> get_chip_and_channel_of_remote_ethernet_core(chip_id_t local_chip, ethernet_channel_t local_ethernet_channel) const;
+    BoardType get_board_type(chip_id_t chip_id) const;
 
-  void enable_all_devices();
+    bool ethernet_core_has_active_ethernet_link(chip_id_t local_chip, ethernet_channel_t local_ethernet_channel) const;
+    std::tuple<chip_id_t, ethernet_channel_t> get_chip_and_channel_of_remote_ethernet_core(
+        chip_id_t local_chip, ethernet_channel_t local_ethernet_channel) const;
 
+    void enable_all_devices();
 };

--- a/device/tt_cluster_descriptor_types.h
+++ b/device/tt_cluster_descriptor_types.h
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#pragma once 
+#pragma once
 
 #include <boost/container_hash/hash.hpp>
-
 #include <functional>
 #include <tuple>
 
 using chip_id_t = int;
 using ethernet_channel_t = int;
+
 struct eth_coord_t {
-    int cluster_id; // This is the same for connected chips.
+    int cluster_id;  // This is the same for connected chips.
     int x;
     int y;
     int rack;
@@ -23,21 +23,23 @@ struct eth_coord_t {
     // in C++20 this should be defined as:
     // constexpr bool operator==(const eth_coord_t &other) const noexcept = default;
     constexpr bool operator==(const eth_coord_t &other) const noexcept {
-        return (cluster_id == other.cluster_id and x == other.x and y == other.y and rack == other.rack and shelf == other.shelf);
+        return (
+            cluster_id == other.cluster_id and x == other.x and y == other.y and rack == other.rack and
+            shelf == other.shelf);
     }
 };
 
 namespace std {
 template <>
 struct hash<eth_coord_t> {
-  std::size_t operator()(eth_coord_t const &c) const {
-    std::size_t seed = 0;
-    boost::hash_combine(seed, c.cluster_id);
-    boost::hash_combine(seed, c.x);
-    boost::hash_combine(seed, c.y);
-    boost::hash_combine(seed, c.rack);
-    boost::hash_combine(seed, c.shelf);
-    return seed;
-  }
+    std::size_t operator()(eth_coord_t const &c) const {
+        std::size_t seed = 0;
+        boost::hash_combine(seed, c.cluster_id);
+        boost::hash_combine(seed, c.x);
+        boost::hash_combine(seed, c.y);
+        boost::hash_combine(seed, c.rack);
+        boost::hash_combine(seed, c.shelf);
+        return seed;
+    }
 };
-}
+}  // namespace std

--- a/device/tt_device.cpp
+++ b/device/tt_device.cpp
@@ -2,30 +2,32 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifdef TT_DEBUG_LOGGING
-#define DEBUG_LOG(str) do { std::cout << str << std::endl; } while( false )
+#define DEBUG_LOG(str)                 \
+    do {                               \
+        std::cout << str << std::endl; \
+    } while (false)
 #else
 #define DEBUG_LOG(str) ((void)0)
 #endif
 
 #include "tt_device.h"
-#include "device/tt_cluster_descriptor_types.h"
-#include <iostream>
+
 #include <fstream>
+#include <iostream>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
+
+#include "device/tt_cluster_descriptor_types.h"
 #include "yaml-cpp/yaml.h"
 
 ////////
 // Device base
 ////////
-tt_device::tt_device() : soc_descriptor_per_chip({}) {
-}
+tt_device::tt_device() : soc_descriptor_per_chip({}) {}
 
-tt_device::~tt_device() {
-}
+tt_device::~tt_device() {}
 
 const tt_SocDescriptor& tt_device::get_soc_descriptor(chip_id_t chip_id) const {
     return soc_descriptor_per_chip.at(chip_id);

--- a/device/tt_io.hpp
+++ b/device/tt_io.hpp
@@ -11,7 +11,7 @@
 namespace tt {
 
 namespace umd {
-    class Cluster;
+class Cluster;
 }
 
 /**
@@ -22,20 +22,18 @@ namespace umd {
  *
  * It is the caller's responsibility to manage the lifetime of Writer objects.
  */
-class Writer
-{
+class Writer {
     friend class tt::umd::Cluster;
 
 public:
     /**
      * @brief Write to a SoC core.
-     * 
+     *
      * @param address must be aligned to the size of T
-     * @param value 
+     * @param value
      */
     template <class T>
-    void write(uint32_t address, T value)
-    {
+    void write(uint32_t address, T value) {
         auto dst = reinterpret_cast<uintptr_t>(base) + address;
 
         if (address >= tlb_size) {
@@ -46,27 +44,23 @@ public:
             throw std::runtime_error("Unaligned write");
         }
 
-        *reinterpret_cast<volatile T*>(dst) = value;
+        *reinterpret_cast<volatile T *>(dst) = value;
     }
 
 private:
     /**
      * @brief tt::umd::Cluster interface to construct a new Writer object.
-     * 
+     *
      * @param base pointer to the base address of a mapped TLB.
      * @param tlb_size size of the mapped TLB.
      */
-    Writer(void *base, size_t tlb_size)
-        : base(base)
-        , tlb_size(tlb_size)
-    {
+    Writer(void *base, size_t tlb_size) : base(base), tlb_size(tlb_size) {
         assert(base);
         assert(tlb_size > 0);
     }
 
-    void *base{ nullptr };
-    size_t tlb_size{ 0 };
+    void *base{nullptr};
+    size_t tlb_size{0};
 };
 
-
-} // namespace tt
+}  // namespace tt

--- a/device/tt_silicon_driver_common.cpp
+++ b/device/tt_silicon_driver_common.cpp
@@ -3,37 +3,37 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "device/tt_silicon_driver_common.hpp"
-#include "tt_xy_pair.h"
+
 #include "cluster.h"
+#include "tt_xy_pair.h"
 
 std::string TensixSoftResetOptionsToString(TensixSoftResetOptions value) {
     std::string output;
 
-    if((value & TensixSoftResetOptions::BRISC) != TensixSoftResetOptions::NONE) {
+    if ((value & TensixSoftResetOptions::BRISC) != TensixSoftResetOptions::NONE) {
         output += "BRISC | ";
     }
-    if((value & TensixSoftResetOptions::TRISC0) != TensixSoftResetOptions::NONE) {
+    if ((value & TensixSoftResetOptions::TRISC0) != TensixSoftResetOptions::NONE) {
         output += "TRISC0 | ";
     }
-    if((value & TensixSoftResetOptions::TRISC1) != TensixSoftResetOptions::NONE) {
+    if ((value & TensixSoftResetOptions::TRISC1) != TensixSoftResetOptions::NONE) {
         output += "TRISC1 | ";
     }
-    if((value & TensixSoftResetOptions::TRISC2) != TensixSoftResetOptions::NONE) {
+    if ((value & TensixSoftResetOptions::TRISC2) != TensixSoftResetOptions::NONE) {
         output += "TRISC2 | ";
     }
-    if((value & TensixSoftResetOptions::NCRISC) != TensixSoftResetOptions::NONE) {
+    if ((value & TensixSoftResetOptions::NCRISC) != TensixSoftResetOptions::NONE) {
         output += "NCRISC | ";
     }
-    if((value & TensixSoftResetOptions::STAGGERED_START) != TensixSoftResetOptions::NONE) {
+    if ((value & TensixSoftResetOptions::STAGGERED_START) != TensixSoftResetOptions::NONE) {
         output += "STAGGERED_START | ";
     }
 
-  if(output.empty()) {
-    output = "UNKNOWN";
-  } else {
-    output.erase(output.end() - 3, output.end());
-  }
+    if (output.empty()) {
+        output = "UNKNOWN";
+    } else {
+        output.erase(output.end() - 3, output.end());
+    }
 
-  return output;
+    return output;
 }
-

--- a/device/tt_silicon_driver_common.hpp
+++ b/device/tt_silicon_driver_common.hpp
@@ -9,53 +9,42 @@
 #include <cstdint>
 #include <string>
 
-enum class TensixSoftResetOptions: std::uint32_t {
+enum class TensixSoftResetOptions : std::uint32_t {
     NONE = 0,
-    BRISC = ((std::uint32_t) 1 << 11),
-    TRISC0 = ((std::uint32_t) 1 << 12),
-    TRISC1 = ((std::uint32_t) 1 << 13),
-    TRISC2 = ((std::uint32_t) 1 << 14),
-    NCRISC = ((std::uint32_t) 1 << 18),
-    STAGGERED_START = ((std::uint32_t) 1 << 31)
+    BRISC = ((std::uint32_t)1 << 11),
+    TRISC0 = ((std::uint32_t)1 << 12),
+    TRISC1 = ((std::uint32_t)1 << 13),
+    TRISC2 = ((std::uint32_t)1 << 14),
+    NCRISC = ((std::uint32_t)1 << 18),
+    STAGGERED_START = ((std::uint32_t)1 << 31)
 };
 
 std::string TensixSoftResetOptionsToString(TensixSoftResetOptions value);
+
 constexpr TensixSoftResetOptions operator|(TensixSoftResetOptions lhs, TensixSoftResetOptions rhs) {
-    return static_cast<TensixSoftResetOptions>(
-        static_cast<uint32_t>(lhs) |
-        static_cast<uint32_t>(rhs)
-    );
+    return static_cast<TensixSoftResetOptions>(static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
 }
 
 constexpr TensixSoftResetOptions operator&(TensixSoftResetOptions lhs, TensixSoftResetOptions rhs) {
-    return static_cast<TensixSoftResetOptions>(
-        static_cast<uint32_t>(lhs) &
-        static_cast<uint32_t>(rhs)
-    );
+    return static_cast<TensixSoftResetOptions>(static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs));
 }
 
 constexpr bool operator!=(TensixSoftResetOptions lhs, TensixSoftResetOptions rhs) {
-    return
-        static_cast<uint32_t>(lhs) !=
-        static_cast<uint32_t>(rhs);
+    return static_cast<uint32_t>(lhs) != static_cast<uint32_t>(rhs);
 }
 
-static constexpr TensixSoftResetOptions ALL_TRISC_SOFT_RESET = TensixSoftResetOptions::TRISC0 |
-                                                           TensixSoftResetOptions::TRISC1 |
-                                                           TensixSoftResetOptions::TRISC2;
+static constexpr TensixSoftResetOptions ALL_TRISC_SOFT_RESET =
+    TensixSoftResetOptions::TRISC0 | TensixSoftResetOptions::TRISC1 | TensixSoftResetOptions::TRISC2;
 
-static constexpr TensixSoftResetOptions ALL_TENSIX_SOFT_RESET = TensixSoftResetOptions::BRISC |
-                                                            TensixSoftResetOptions::NCRISC |
-                                                            TensixSoftResetOptions::STAGGERED_START |
-                                                            ALL_TRISC_SOFT_RESET;
+static constexpr TensixSoftResetOptions ALL_TENSIX_SOFT_RESET =
+    TensixSoftResetOptions::BRISC | TensixSoftResetOptions::NCRISC | TensixSoftResetOptions::STAGGERED_START |
+    ALL_TRISC_SOFT_RESET;
 
-static constexpr TensixSoftResetOptions TENSIX_ASSERT_SOFT_RESET = TensixSoftResetOptions::BRISC |
-                                                               TensixSoftResetOptions::NCRISC |
-                                                               ALL_TRISC_SOFT_RESET;
+static constexpr TensixSoftResetOptions TENSIX_ASSERT_SOFT_RESET =
+    TensixSoftResetOptions::BRISC | TensixSoftResetOptions::NCRISC | ALL_TRISC_SOFT_RESET;
 
-static constexpr TensixSoftResetOptions TENSIX_DEASSERT_SOFT_RESET = TensixSoftResetOptions::NCRISC |
-                                                                 ALL_TRISC_SOFT_RESET |
-                                                                 TensixSoftResetOptions::STAGGERED_START;
+static constexpr TensixSoftResetOptions TENSIX_DEASSERT_SOFT_RESET =
+    TensixSoftResetOptions::NCRISC | ALL_TRISC_SOFT_RESET | TensixSoftResetOptions::STAGGERED_START;
 
-static constexpr TensixSoftResetOptions TENSIX_DEASSERT_SOFT_RESET_NO_STAGGER = TensixSoftResetOptions::NCRISC |
-                                                                                 ALL_TRISC_SOFT_RESET;
+static constexpr TensixSoftResetOptions TENSIX_DEASSERT_SOFT_RESET_NO_STAGGER =
+    TensixSoftResetOptions::NCRISC | ALL_TRISC_SOFT_RESET;

--- a/device/tt_soc_descriptor.h
+++ b/device/tt_soc_descriptor.h
@@ -7,29 +7,25 @@
 #pragma once
 
 #include <cstddef>
-#include <string>
+#include <cstdint>
+#include <iostream>
 #include <map>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
-#include <iostream>
-#include <string>
-#include <cstdint>
-
-#include "tt_xy_pair.h"
-#include "device/tt_arch_types.h"
-
 #include "device/coordinate_manager.h"
-
+#include "device/tt_arch_types.h"
 #include "fmt/core.h"
+#include "tt_xy_pair.h"
 
 namespace YAML {
-    class Node;
+class Node;
 }
 
 std::ostream &operator<<(std::ostream &out, const tt::ARCH &arch_name);
 
-static inline std::string get_arch_str(const tt::ARCH arch_name){
+static inline std::string get_arch_str(const tt::ARCH arch_name) {
     std::string arch_name_str;
 
     if (arch_name == tt::ARCH::GRAYSKULL) {
@@ -45,16 +41,18 @@ static inline std::string get_arch_str(const tt::ARCH arch_name){
     return arch_name_str;
 }
 
-static inline tt::ARCH get_arch_name(const std::string &arch_str){
+static inline tt::ARCH get_arch_name(const std::string &arch_str) {
     tt::ARCH arch;
 
     if ((arch_str == "grayskull") || (arch_str == "GRAYSKULL")) {
         arch = tt::ARCH::GRAYSKULL;
-    } else if ((arch_str == "wormhole") || (arch_str == "WORMHOLE") || (arch_str == "wormhole_b0") || (arch_str == "WORMHOLE_B0")){
+    } else if (
+        (arch_str == "wormhole") || (arch_str == "WORMHOLE") || (arch_str == "wormhole_b0") ||
+        (arch_str == "WORMHOLE_B0")) {
         arch = tt::ARCH::WORMHOLE_B0;
-    } else if ((arch_str == "blackhole") || (arch_str == "BLACKHOLE")){
+    } else if ((arch_str == "blackhole") || (arch_str == "BLACKHOLE")) {
         arch = tt::ARCH::BLACKHOLE;
-    }else {
+    } else {
         throw std::runtime_error(
             fmt::format("At LoadSocDescriptorFromYaml: \"{}\" is not recognized as tt::ARCH.", arch_str));
     }
@@ -69,13 +67,13 @@ tt_xy_pair format_node(std::string str);
 //! SocCore type enumerations
 /*! Superset for all chip generations */
 enum class CoreType {
-  ARC,
-  DRAM,
-  ETH,
-  PCIE,
-  WORKER,
-  HARVESTED,
-  ROUTER_ONLY,
+    ARC,
+    DRAM,
+    ETH,
+    PCIE,
+    WORKER,
+    HARVESTED,
+    ROUTER_ONLY,
 
 };
 
@@ -84,10 +82,10 @@ enum class CoreType {
     Should only contain relevant configuration for SOC
 */
 struct CoreDescriptor {
-  tt_xy_pair coord = tt_xy_pair(0, 0);
-  CoreType type;
+    tt_xy_pair coord = tt_xy_pair(0, 0);
+    CoreType type;
 
-  std::size_t l1_size = 0;
+    std::size_t l1_size = 0;
 };
 
 //! tt_SocDescriptor contains information regarding the SOC configuration targetted.
@@ -95,7 +93,6 @@ struct CoreDescriptor {
     Should only contain relevant configuration for SOC
 */
 class tt_SocDescriptor {
-
 public:
     tt::ARCH arch;
     tt_xy_pair grid_size;
@@ -110,13 +107,15 @@ public:
     std::unordered_map<int, int> worker_log_to_routing_y;
     std::unordered_map<int, int> routing_x_to_worker_x;
     std::unordered_map<int, int> routing_y_to_worker_y;
-    std::vector<std::vector<tt_xy_pair>> dram_cores;  // per channel list of dram cores
+    std::vector<std::vector<tt_xy_pair>> dram_cores;                             // per channel list of dram cores
     std::unordered_map<tt_xy_pair, std::tuple<int, int>> dram_core_channel_map;  // map dram core to chan/subchan
-    std::vector<tt_xy_pair> ethernet_cores;  // ethernet cores (index == channel id)
-    std::unordered_map<tt_xy_pair,int> ethernet_core_channel_map;
+    std::vector<tt_xy_pair> ethernet_cores;                                      // ethernet cores (index == channel id)
+    std::unordered_map<tt_xy_pair, int> ethernet_core_channel_map;
     std::vector<std::size_t> trisc_sizes;  // Most of software stack assumes same trisc size for whole chip..
     std::string device_descriptor_file_path = std::string("");
+
     bool has(tt_xy_pair input) { return cores.find(input) != cores.end(); }
+
     int overlay_version;
     int unpacker_version;
     int dst_size_alignment;
@@ -129,15 +128,15 @@ public:
     int get_num_dram_channels() const;
     bool is_worker_core(const tt_xy_pair &core) const;
     tt_xy_pair get_core_for_dram_channel(int dram_chan, int subchannel) const;
-    bool is_ethernet_core(const tt_xy_pair& core) const;
+    bool is_ethernet_core(const tt_xy_pair &core) const;
 
     // Default constructor. Creates uninitialized object with public access to all of its attributes.
     tt_SocDescriptor() = default;
-    // Constructor used to build object from device descriptor file.    
+    // Constructor used to build object from device descriptor file.
     tt_SocDescriptor(std::string device_descriptor_path, std::size_t harvesting_mask = 0);
 
     // Copy constructor
-    tt_SocDescriptor(const tt_SocDescriptor& other) :
+    tt_SocDescriptor(const tt_SocDescriptor &other) :
         arch(other.arch),
         grid_size(other.grid_size),
         physical_grid_size(other.physical_grid_size),
@@ -167,7 +166,7 @@ public:
         dram_bank_size(other.dram_bank_size) {
         coordinate_manager.reset(new CoordinateManager(*other.coordinate_manager));
     }
-    
+
     // Coordinate conversions.
 
     // Conversions from logical coordinates should be used just for worker cores.
@@ -189,7 +188,7 @@ public:
 
     void perform_harvesting(std::size_t harvesting_mask);
 
-    static std::string get_soc_descriptor_path(tt::ARCH arch); 
+    static std::string get_soc_descriptor_path(tt::ARCH arch);
 
 private:
     void create_coordinate_manager(std::size_t harvesting_mask);

--- a/device/tt_xy_pair.h
+++ b/device/tt_xy_pair.h
@@ -15,44 +15,56 @@ using tt_cxy_pair = tt::umd::cxy_pair;
 
 struct tt_physical_coords : public tt_xy_pair {
     tt_physical_coords() : tt_xy_pair() {}
+
     tt_physical_coords(std::size_t x, std::size_t y) : tt_xy_pair(x, y) {}
 };
 
 struct tt_chip_physical_coords : public tt_cxy_pair {
     tt_chip_physical_coords() : tt_cxy_pair() {}
+
     tt_chip_physical_coords(std::size_t ichip, xy_pair pair) : tt_cxy_pair(ichip, pair) {}
+
     tt_chip_physical_coords(std::size_t ichip, std::size_t x, std::size_t y) : tt_cxy_pair(ichip, x, y) {}
 };
 
 struct tt_logical_coords : public tt_xy_pair {
     tt_logical_coords() : tt_xy_pair() {}
+
     tt_logical_coords(std::size_t x, std::size_t y) : tt_xy_pair(x, y) {}
 };
 
 struct tt_chip_logical_coords : public tt_cxy_pair {
     tt_chip_logical_coords() : tt_cxy_pair() {}
+
     tt_chip_logical_coords(std::size_t ichip, xy_pair pair) : tt_cxy_pair(ichip, pair) {}
+
     tt_chip_logical_coords(std::size_t ichip, std::size_t x, std::size_t y) : tt_cxy_pair(ichip, x, y) {}
 };
 
 struct tt_virtual_coords : public tt_xy_pair {
     tt_virtual_coords() : tt_xy_pair() {}
+
     tt_virtual_coords(std::size_t x, std::size_t y) : tt_xy_pair(x, y) {}
 };
 
 struct tt_chip_virtual_coords : public tt_cxy_pair {
     tt_chip_virtual_coords() : tt_cxy_pair() {}
+
     tt_chip_virtual_coords(std::size_t ichip, xy_pair pair) : tt_cxy_pair(ichip, pair) {}
+
     tt_chip_virtual_coords(std::size_t ichip, std::size_t x, std::size_t y) : tt_cxy_pair(ichip, x, y) {}
 };
 
 struct tt_translated_coords : public tt_xy_pair {
     tt_translated_coords() : tt_xy_pair() {}
+
     tt_translated_coords(std::size_t x, std::size_t y) : tt_xy_pair(x, y) {}
 };
 
 struct tt_chip_translated_coords : public tt_cxy_pair {
     tt_chip_translated_coords() : tt_cxy_pair() {}
+
     tt_chip_translated_coords(std::size_t ichip, xy_pair pair) : tt_cxy_pair(ichip, pair) {}
+
     tt_chip_translated_coords(std::size_t ichip, std::size_t x, std::size_t y) : tt_cxy_pair(ichip, x, y) {}
 };

--- a/device/wormhole/wormhole_coordinate_manager.cpp
+++ b/device/wormhole/wormhole_coordinate_manager.cpp
@@ -19,9 +19,11 @@ std::set<std::size_t> WormholeCoordinateManager::get_y_coordinates_to_harvest(st
 }
 
 tt_translated_coords WormholeCoordinateManager::to_translated_coords(tt_logical_coords logical_coords) {
-    return tt_translated_coords(logical_coords.x + translated_coordinate_start_x, logical_coords.y + translated_coordinate_start_y);
+    return tt_translated_coords(
+        logical_coords.x + translated_coordinate_start_x, logical_coords.y + translated_coordinate_start_y);
 }
 
 tt_logical_coords WormholeCoordinateManager::to_logical_coords(tt_translated_coords translated_coords) {
-    return tt_logical_coords(translated_coords.x - translated_coordinate_start_x, translated_coords.y - translated_coordinate_start_y);
+    return tt_logical_coords(
+        translated_coords.x - translated_coordinate_start_x, translated_coords.y - translated_coordinate_start_y);
 }

--- a/device/wormhole/wormhole_coordinate_manager.h
+++ b/device/wormhole/wormhole_coordinate_manager.h
@@ -9,16 +9,16 @@
 #include "device/coordinate_manager.h"
 
 class WormholeCoordinateManager : public CoordinateManager {
-
 public:
-    WormholeCoordinateManager(const tt_xy_pair& worker_grid_size, const std::vector<tt_xy_pair>& workers, std::size_t harvesting_mask)
-        : CoordinateManager(worker_grid_size, workers, harvesting_mask) {}
+    WormholeCoordinateManager(
+        const tt_xy_pair& worker_grid_size, const std::vector<tt_xy_pair>& workers, std::size_t harvesting_mask) :
+        CoordinateManager(worker_grid_size, workers, harvesting_mask) {}
 
     tt_translated_coords to_translated_coords(tt_logical_coords logical_coords) override;
 
     tt_logical_coords to_logical_coords(tt_translated_coords translated_coords) override;
 
-protected: 
+protected:
     std::set<std::size_t> get_y_coordinates_to_harvest(std::size_t harvesting_mask) override;
 
 private:

--- a/device/wormhole/wormhole_implementation.cpp
+++ b/device/wormhole/wormhole_implementation.cpp
@@ -4,13 +4,12 @@
 
 #include "wormhole_implementation.h"
 
-#include "src/firmware/riscv/wormhole/host_mem_address_map.h"
-#include "src/firmware/riscv/wormhole/eth_interface.h"
-
 #include "device/cluster.h"
+#include "src/firmware/riscv/wormhole/eth_interface.h"
+#include "src/firmware/riscv/wormhole/host_mem_address_map.h"
 
-constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36; // source: noc_parameters.h, common for WH && BH
-constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6; // source: noc_parameters.h, common for WH && BH
+constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h, common for WH && BH
+constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6;  // source: noc_parameters.h, common for WH && BH
 
 namespace tt::umd {
 
@@ -98,7 +97,9 @@ std::pair<std::uint64_t, std::uint64_t> wormhole_implementation::get_tlb_data(
 }
 
 tt_driver_host_address_params wormhole_implementation::get_host_address_params() const {
-    return {::wormhole::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, ::wormhole::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
+    return {
+        ::wormhole::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE,
+        ::wormhole::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
 }
 
 tt_driver_eth_interface_params wormhole_implementation::get_eth_interface_params() const {

--- a/device/wormhole/wormhole_implementation.h
+++ b/device/wormhole/wormhole_implementation.h
@@ -167,7 +167,8 @@ static constexpr uint32_t TLB_BASE_INDEX_16M = TLB_BASE_INDEX_2M + TLB_COUNT_2M;
 static constexpr uint32_t DYNAMIC_TLB_COUNT = 16;
 
 static constexpr uint32_t DYNAMIC_TLB_16M_SIZE = 16 * 1024 * 1024;
-static constexpr uint32_t DYNAMIC_TLB_16M_CFG_ADDR = STATIC_TLB_CFG_ADDR + (TLB_BASE_INDEX_16M * TLB_CFG_REG_SIZE_BYTES);
+static constexpr uint32_t DYNAMIC_TLB_16M_CFG_ADDR =
+    STATIC_TLB_CFG_ADDR + (TLB_BASE_INDEX_16M * TLB_CFG_REG_SIZE_BYTES);
 static constexpr uint32_t DYNAMIC_TLB_16M_BASE = TLB_BASE_16M;
 
 static constexpr uint32_t DYNAMIC_TLB_2M_SIZE = 2 * 1024 * 1024;
@@ -205,59 +206,93 @@ static constexpr uint32_t TENSIX_SOFT_RESET_ADDR = 0xFFB121B0;
 }  // namespace wormhole
 
 class wormhole_implementation : public architecture_implementation {
-   public:
+public:
     tt::ARCH get_architecture() const override { return tt::ARCH::WORMHOLE_B0; }
+
     uint32_t get_arc_message_arc_get_harvesting() const override {
         return static_cast<uint32_t>(wormhole::arc_message_type::ARC_GET_HARVESTING);
     }
+
     uint32_t get_arc_message_arc_go_busy() const override {
         return static_cast<uint32_t>(wormhole::arc_message_type::ARC_GO_BUSY);
     }
+
     uint32_t get_arc_message_arc_go_long_idle() const override {
         return static_cast<uint32_t>(wormhole::arc_message_type::ARC_GO_LONG_IDLE);
     }
+
     uint32_t get_arc_message_arc_go_short_idle() const override {
         return static_cast<uint32_t>(wormhole::arc_message_type::ARC_GO_SHORT_IDLE);
     }
+
     uint32_t get_arc_message_deassert_riscv_reset() const override {
         return static_cast<uint32_t>(wormhole::arc_message_type::DEASSERT_RISCV_RESET);
     }
+
     uint32_t get_arc_message_get_aiclk() const override {
         return static_cast<uint32_t>(wormhole::arc_message_type::GET_AICLK);
     }
+
     uint32_t get_arc_message_setup_iatu_for_peer_to_peer() const override {
         return static_cast<uint32_t>(wormhole::arc_message_type::SETUP_IATU_FOR_PEER_TO_PEER);
     }
+
     uint32_t get_arc_message_test() const override { return static_cast<uint32_t>(wormhole::arc_message_type::TEST); }
+
     uint32_t get_arc_csm_mailbox_offset() const override { return wormhole::ARC_CSM_MAILBOX_OFFSET; }
+
     uint32_t get_arc_reset_arc_misc_cntl_offset() const override { return wormhole::ARC_RESET_ARC_MISC_CNTL_OFFSET; }
+
     uint32_t get_arc_reset_scratch_offset() const override { return wormhole::ARC_RESET_SCRATCH_OFFSET; }
+
     uint32_t get_dram_channel_0_peer2peer_region_start() const override {
         return wormhole::DRAM_CHANNEL_0_PEER2PEER_REGION_START;
     }
+
     uint32_t get_dram_channel_0_x() const override { return wormhole::DRAM_CHANNEL_0_X; }
+
     uint32_t get_dram_channel_0_y() const override { return wormhole::DRAM_CHANNEL_0_Y; }
+
     uint32_t get_broadcast_tlb_index() const override { return wormhole::BROADCAST_TLB_INDEX; }
+
     uint32_t get_dynamic_tlb_2m_base() const override { return wormhole::DYNAMIC_TLB_2M_BASE; }
+
     uint32_t get_dynamic_tlb_2m_size() const override { return wormhole::DYNAMIC_TLB_2M_SIZE; }
+
     uint32_t get_dynamic_tlb_16m_base() const override { return wormhole::DYNAMIC_TLB_16M_BASE; }
+
     uint32_t get_dynamic_tlb_16m_size() const override { return wormhole::DYNAMIC_TLB_16M_SIZE; }
+
     uint32_t get_dynamic_tlb_16m_cfg_addr() const override { return wormhole::DYNAMIC_TLB_16M_CFG_ADDR; }
+
     uint32_t get_mem_large_read_tlb() const override { return wormhole::MEM_LARGE_READ_TLB; }
+
     uint32_t get_mem_large_write_tlb() const override { return wormhole::MEM_LARGE_WRITE_TLB; }
+
     uint32_t get_static_tlb_cfg_addr() const override { return wormhole::STATIC_TLB_CFG_ADDR; }
+
     uint32_t get_static_tlb_size() const override { return wormhole::STATIC_TLB_SIZE; }
+
     uint32_t get_reg_tlb() const override { return wormhole::REG_TLB; }
+
     uint32_t get_tlb_base_index_16m() const override { return wormhole::TLB_BASE_INDEX_16M; }
+
     uint32_t get_tensix_soft_reset_addr() const override { return wormhole::TENSIX_SOFT_RESET_ADDR; }
+
     uint32_t get_grid_size_x() const override { return wormhole::GRID_SIZE_X; }
+
     uint32_t get_grid_size_y() const override { return wormhole::GRID_SIZE_Y; }
+
     uint32_t get_tlb_cfg_reg_size_bytes() const override { return wormhole::TLB_CFG_REG_SIZE_BYTES; }
+
     uint32_t get_small_read_write_tlb() const override { return wormhole::MEM_SMALL_READ_WRITE_TLB; }
+
     const std::vector<uint32_t>& get_harvesting_noc_locations() const override {
         return wormhole::HARVESTING_NOC_LOCATIONS;
     }
+
     const std::vector<uint32_t>& get_t6_x_locations() const override { return wormhole::T6_X_LOCATIONS; }
+
     const std::vector<uint32_t>& get_t6_y_locations() const override { return wormhole::T6_Y_LOCATIONS; }
 
     std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const override;
@@ -268,7 +303,6 @@ class wormhole_implementation : public architecture_implementation {
     tt_driver_host_address_params get_host_address_params() const override;
     tt_driver_eth_interface_params get_eth_interface_params() const override;
     tt_driver_noc_params get_noc_params() const override;
-
 };
 
 }  // namespace tt::umd

--- a/device/xy_pair.cpp
+++ b/device/xy_pair.cpp
@@ -11,6 +11,7 @@
 namespace tt::umd {
 
 std::string xy_pair::str() const { return fmt::format("(x={},y={})", x, y); }
+
 std::string cxy_pair::str() const { return fmt::format("(chip={},x={},y={})", chip, x, y); }
 
 }  // namespace tt::umd

--- a/device/xy_pair.h
+++ b/device/xy_pair.h
@@ -12,6 +12,7 @@ namespace tt::umd {
 
 struct xy_pair {
     constexpr xy_pair() : x{}, y{} {}
+
     constexpr xy_pair(std::size_t x, std::size_t y) : x(x), y(y) {}
 
     std::size_t x;
@@ -30,7 +31,9 @@ constexpr inline bool operator<(const xy_pair &left, const xy_pair &right) {
 
 struct cxy_pair : public xy_pair {
     cxy_pair() : xy_pair{}, chip{} {}
+
     cxy_pair(std::size_t ichip, xy_pair pair) : xy_pair(pair.x, pair.y), chip(ichip) {}
+
     cxy_pair(std::size_t ichip, std::size_t x, std::size_t y) : xy_pair(x, y), chip(ichip) {}
 
     std::size_t chip;

--- a/tests/.clang-format
+++ b/tests/.clang-format
@@ -1,2 +1,0 @@
-DisableFormat: true
-SortIncludes: false

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -5,23 +5,23 @@
 // This file holds Chip specific API examples.
 
 #include <gtest/gtest.h>
-#include "fmt/xchar.h"
 
 #include <algorithm>
 #include <filesystem>
 #include <string>
 #include <vector>
 
+#include "fmt/xchar.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 
 // TODO: change to tt_cluster
+#include "device/architecture_implementation.h"
 #include "device/cluster.h"
 #include "device/tt_cluster_descriptor.h"
-#include "device/architecture_implementation.h"
 
 using namespace tt::umd;
 
-inline tt_cxy_pair get_tensix_chip_core_coord(const std::unique_ptr<Cluster> &umd_cluster) {
+inline tt_cxy_pair get_tensix_chip_core_coord(const std::unique_ptr<Cluster>& umd_cluster) {
     chip_id_t any_mmio_chip = *umd_cluster->get_target_mmio_device_ids().begin();
     const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(any_mmio_chip);
     tt_xy_pair core = soc_desc.workers[0];
@@ -68,16 +68,17 @@ TEST(ApiChipTest, ManualTLBConfiguration) {
         if (!is_worker_core) {
             return -1;
         }
-        return core.x + core.y * umd_cluster->get_pci_device(any_mmio_chip)->get_architecture_implementation()->get_grid_size_x();
+        return core.x +
+               core.y *
+                   umd_cluster->get_pci_device(any_mmio_chip)->get_architecture_implementation()->get_grid_size_x();
     };
 
     std::int32_t c_zero_address = 0;
 
     // Each MMIO chip has it's own set of TLBs, so needs its own configuration.
-    for (chip_id_t mmio_chip: umd_cluster->get_target_mmio_device_ids()) {
-
+    for (chip_id_t mmio_chip : umd_cluster->get_target_mmio_device_ids()) {
         const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(mmio_chip);
-        for (tt_xy_pair core: soc_desc.workers) {
+        for (tt_xy_pair core : soc_desc.workers) {
             umd_cluster->configure_tlb(mmio_chip, core, get_static_tlb_index(core), c_zero_address);
         }
 
@@ -119,7 +120,7 @@ TEST(ApiChipTest, DeassertRiscResetOnCore) {
     if (umd_cluster == nullptr || umd_cluster->get_all_chips_in_cluster().empty()) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
     }
-    
+
     tt_cxy_pair chip_core_coord = get_tensix_chip_core_coord(umd_cluster);
 
     umd_cluster->assert_risc_reset_at_core(chip_core_coord);

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -11,17 +11,16 @@
 #include <string>
 #include <vector>
 
+#include "device/cluster.h"
+#include "device/tt_cluster_descriptor.h"
 #include "fmt/xchar.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 
-#include "device/tt_cluster_descriptor.h"
-#include "device/cluster.h"
-
 // TODO: obviously we need some other way to set this up
+#include "noc/noc_parameters.h"
 #include "src/firmware/riscv/wormhole/eth_l1_address_map.h"
 #include "src/firmware/riscv/wormhole/host_mem_address_map.h"
 #include "src/firmware/riscv/wormhole/l1_address_map.h"
-#include "noc/noc_parameters.h"
 
 using namespace tt::umd;
 
@@ -36,8 +35,7 @@ inline std::unique_ptr<Cluster> get_cluster() {
     if (pci_device_ids.empty()) {
         return nullptr;
     }
-    return std::unique_ptr<Cluster>(
-        new Cluster());
+    return std::unique_ptr<Cluster>(new Cluster());
 }
 
 // TODO: Should not be wormhole specific.
@@ -49,11 +47,9 @@ void setup_wormhole_remote(Cluster* umd_cluster) {
         // Populate address map and NOC parameters that the driver needs for remote transactions
 
         umd_cluster->set_device_l1_address_params(
-            {
-             l1_mem::address_map::L1_BARRIER_BASE,
+            {l1_mem::address_map::L1_BARRIER_BASE,
              eth_l1_mem::address_map::ERISC_BARRIER_BASE,
-             eth_l1_mem::address_map::FW_VERSION_ADDR
-	    });
+             eth_l1_mem::address_map::FW_VERSION_ADDR});
     }
 }
 

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -5,18 +5,16 @@
 #include <gtest/gtest.h>
 
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
-#include "tests/test_utils/generate_cluster_desc.hpp"
 #include "common/disjoint_set.hpp"
-
 #include "device/pcie/pci_device.hpp"
 #include "device/tt_cluster_descriptor.h"
+#include "tests/test_utils/generate_cluster_desc.hpp"
 
 // TODO: Needed for detect_arch, remove when it is part of cluster descriptor.
 #include "device/cluster.h"
-
 
 inline std::unique_ptr<tt_ClusterDescriptor> get_cluster_desc() {
     // TODO: remove getting manually cluster descriptor from yaml.
@@ -45,7 +43,6 @@ TEST(ApiClusterDescriptorTest, DetectArch) {
 }
 
 TEST(ApiClusterDescriptorTest, BasicFunctionality) {
-
     std::unique_ptr<tt_ClusterDescriptor> cluster_desc = get_cluster_desc();
 
     if (cluster_desc == nullptr) {
@@ -57,7 +54,7 @@ TEST(ApiClusterDescriptorTest, BasicFunctionality) {
     std::unordered_map<chip_id_t, eth_coord_t> eth_chip_coords = cluster_desc->get_chip_locations();
     std::unordered_map<chip_id_t, chip_id_t> local_chips_to_pci_device_id = cluster_desc->get_chips_with_mmio();
     std::unordered_set<chip_id_t> local_chips;
-    for (auto [chip, _]: local_chips_to_pci_device_id) {
+    for (auto [chip, _] : local_chips_to_pci_device_id) {
         local_chips.insert(chip);
     }
     std::unordered_set<chip_id_t> remote_chips;
@@ -67,28 +64,30 @@ TEST(ApiClusterDescriptorTest, BasicFunctionality) {
         }
     }
 
-    std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> chips_grouped_by_closest_mmio = cluster_desc->get_chips_grouped_by_closest_mmio();
+    std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> chips_grouped_by_closest_mmio =
+        cluster_desc->get_chips_grouped_by_closest_mmio();
 }
 
 TEST(ApiClusterDescriptorTest, TestAllOfflineClusterDescriptors) {
     for (std::string cluster_desc_yaml : {
-        "blackhole_P150.yaml",
-        "galaxy.yaml",
-        "grayskull_E150.yaml",
-        "grayskull_E300.yaml",
-        "wormhole_2xN300_unconnected.yaml",
-        "wormhole_N150.yaml",
-        "wormhole_N300.yaml",
-    }) {
+             "blackhole_P150.yaml",
+             "galaxy.yaml",
+             "grayskull_E150.yaml",
+             "grayskull_E300.yaml",
+             "wormhole_2xN300_unconnected.yaml",
+             "wormhole_N150.yaml",
+             "wormhole_N300.yaml",
+         }) {
         std::cout << "Testing " << cluster_desc_yaml << std::endl;
-        std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(test_utils::GetAbsPath("tests/api/cluster_descriptor_examples/" + cluster_desc_yaml));
+        std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(
+            test_utils::GetAbsPath("tests/api/cluster_descriptor_examples/" + cluster_desc_yaml));
 
         std::unordered_set<chip_id_t> all_chips = cluster_desc->get_all_chips();
         std::unordered_map<chip_id_t, std::uint32_t> harvesting_for_chips = cluster_desc->get_harvesting_info();
         std::unordered_map<chip_id_t, eth_coord_t> eth_chip_coords = cluster_desc->get_chip_locations();
         std::unordered_map<chip_id_t, chip_id_t> local_chips_to_pci_device_id = cluster_desc->get_chips_with_mmio();
         std::unordered_set<chip_id_t> local_chips;
-        for (auto [chip, _]: local_chips_to_pci_device_id) {
+        for (auto [chip, _] : local_chips_to_pci_device_id) {
             local_chips.insert(chip);
         }
         std::unordered_set<chip_id_t> remote_chips;
@@ -98,12 +97,14 @@ TEST(ApiClusterDescriptorTest, TestAllOfflineClusterDescriptors) {
             }
         }
 
-        std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> chips_grouped_by_closest_mmio = cluster_desc->get_chips_grouped_by_closest_mmio();
+        std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> chips_grouped_by_closest_mmio =
+            cluster_desc->get_chips_grouped_by_closest_mmio();
     }
 }
 
 TEST(ApiClusterDescriptorTest, SeparateClusters) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(test_utils::GetAbsPath("tests/api/cluster_descriptor_examples/wormhole_2xN300_unconnected.yaml"));
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(
+        test_utils::GetAbsPath("tests/api/cluster_descriptor_examples/wormhole_2xN300_unconnected.yaml"));
 
     auto all_chips = cluster_desc->get_all_chips();
     DisjointSet<chip_id_t> chip_clusters;
@@ -112,9 +113,9 @@ TEST(ApiClusterDescriptorTest, SeparateClusters) {
     }
 
     // Merge into clusters of chips.
-    for (auto connection: cluster_desc->get_ethernet_connections()) {
+    for (auto connection : cluster_desc->get_ethernet_connections()) {
         chip_id_t chip = connection.first;
-        for (auto [channel, remote_chip_and_channel]: connection.second) {
+        for (auto [channel, remote_chip_and_channel] : connection.second) {
             chip_id_t remote_chip = std::get<0>(remote_chip_and_channel);
             chip_clusters.merge(chip, remote_chip);
         }

--- a/tests/api/test_mockup_device.cpp
+++ b/tests/api/test_mockup_device.cpp
@@ -25,14 +25,18 @@ std::string get_env_arch_name() {
 }
 
 tt::ARCH get_arch_from_string(const std::string &arch_str) {
-    if (arch_str == "grayskull" || arch_str == "GRAYSKULL")
+    if (arch_str == "grayskull" || arch_str == "GRAYSKULL") {
         return tt::ARCH::GRAYSKULL;
-    if (arch_str == "wormhole_b0" || arch_str == "WORMHOLE_B0")
+    }
+    if (arch_str == "wormhole_b0" || arch_str == "WORMHOLE_B0") {
         return tt::ARCH::WORMHOLE_B0;
-    if (arch_str == "blackhole" || arch_str == "BLACKHOLE")
+    }
+    if (arch_str == "blackhole" || arch_str == "BLACKHOLE") {
         return tt::ARCH::BLACKHOLE;
-    if (arch_str == "Invalid" || arch_str == "INVALID")
+    }
+    if (arch_str == "Invalid" || arch_str == "INVALID") {
         return tt::ARCH::Invalid;
+    }
 
     throw std::runtime_error(arch_str + " is not recognized as tt::ARCH.");
 }
@@ -41,11 +45,16 @@ std::string get_soc_descriptor_file(tt::ARCH arch) {
     // const std::string umd_root = get_umd_root();
 
     switch (arch) {
-        case tt::ARCH::GRAYSKULL: return test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml");
-        case tt::ARCH::WORMHOLE_B0: return  test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml");
-        case tt::ARCH::BLACKHOLE: return  test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml");
-        case tt::ARCH::Invalid: throw std::runtime_error("Invalid arch not supported");
-        default: throw std::runtime_error("Unsupported device architecture");
+        case tt::ARCH::GRAYSKULL:
+            return test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml");
+        case tt::ARCH::WORMHOLE_B0:
+            return test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml");
+        case tt::ARCH::BLACKHOLE:
+            return test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml");
+        case tt::ARCH::Invalid:
+            throw std::runtime_error("Invalid arch not supported");
+        default:
+            throw std::runtime_error("Unsupported device architecture");
     }
 }
 

--- a/tests/api/test_soc_descriptor_bh.cpp
+++ b/tests/api/test_soc_descriptor_bh.cpp
@@ -3,12 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "gtest/gtest.h"
-
 #include "device/tt_soc_descriptor.h"
+#include "gtest/gtest.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/test_utils/soc_desc_test_utils.hpp"
-
 
 // Blackhole workers - x-y annotation
 // functional_workers:
@@ -28,8 +26,8 @@
 // Tests that all physical coordinates are same as all virtual coordinates
 // when there is no harvesting.
 TEST(SocDescriptor, SocDescriptorBHNoHarvesting) {
-
-    tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), 0);
+    tt_SocDescriptor soc_desc =
+        tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), 0);
 
     // We expect full grid size since there is no harvesting.
     tt_xy_pair worker_grid_size = soc_desc.worker_grid_size;
@@ -38,7 +36,7 @@ TEST(SocDescriptor, SocDescriptorBHNoHarvesting) {
             tt_logical_coords logical_coords = tt_logical_coords(x, y);
             tt_virtual_coords virtual_coords = soc_desc.to_virtual_coords(logical_coords);
             tt_physical_coords physical_coords = soc_desc.to_physical_coords(logical_coords);
-            
+
             // Virtual and physical coordinates should be the same.
             EXPECT_EQ(physical_coords, virtual_coords);
         }
@@ -49,7 +47,8 @@ TEST(SocDescriptor, SocDescriptorBHNoHarvesting) {
 // We expect that the top left core will have virtual and physical coordinates (1, 2) and (2, 2) for
 // the logical coordinates if the first row is harvested.
 TEST(SocDescriptor, SocDescriptorBHTopLeftCore) {
-    tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), 1);
+    tt_SocDescriptor soc_desc =
+        tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), 1);
     tt_xy_pair worker_grid_size = soc_desc.worker_grid_size;
 
     tt_logical_coords logical_coords = tt_logical_coords(0, 0);
@@ -65,13 +64,12 @@ TEST(SocDescriptor, SocDescriptorBHTopLeftCore) {
 
 // Test logical to physical coordinate translation.
 // For the full grid of logical coordinates we expect that there are no duplicates of physical coordinates.
-// For the reverse mapping back of physical to logical coordinates we expect that same logical coordinates are returned as from original mapping.
+// For the reverse mapping back of physical to logical coordinates we expect that same logical coordinates are returned
+// as from original mapping.
 TEST(SocDescriptor, SocDescriptorBHLogicalPhysicalMapping) {
-
     const std::size_t max_num_harvested_x = 14;
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"));
     for (std::size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_x); harvesting_mask++) {
-       
         soc_desc.perform_harvesting(harvesting_mask);
 
         std::map<tt_logical_coords, tt_physical_coords> logical_to_physical;
@@ -97,7 +95,7 @@ TEST(SocDescriptor, SocDescriptorBHLogicalPhysicalMapping) {
         for (auto it : logical_to_physical) {
             tt_physical_coords physical_coords = it.second;
             tt_logical_coords logical_coords = soc_desc.to_logical_coords(physical_coords);
-            
+
             // Expect that reverse mapping of physical coordinates gives the same logical coordinates
             // using which we got the physical coordinates.
             EXPECT_EQ(it.first, logical_coords);
@@ -107,13 +105,12 @@ TEST(SocDescriptor, SocDescriptorBHLogicalPhysicalMapping) {
 
 // Test logical to virtual coordinate translation.
 // For the full grid of logical coordinates we expect that there are no duplicates of virtual coordinates.
-// For the reverse mapping back of virtual to logical coordinates we expect that same logical coordinates are returned as from original mapping.
+// For the reverse mapping back of virtual to logical coordinates we expect that same logical coordinates are returned
+// as from original mapping.
 TEST(SocDescriptor, SocDescriptorBHLogicalVirtualMapping) {
-
     const std::size_t max_num_harvested_x = 14;
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"));
     for (std::size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_x); harvesting_mask++) {
-        
         soc_desc.perform_harvesting(harvesting_mask);
 
         std::map<tt_logical_coords, tt_virtual_coords> logical_to_virtual;
@@ -149,13 +146,12 @@ TEST(SocDescriptor, SocDescriptorBHLogicalVirtualMapping) {
 
 // Test logical to translated coordinate translation.
 // For the full grid of logical coordinates we expect that there are no duplicates of translated coordinates.
-// For the reverse mapping back of translated to logical coordinates we expect that same logical coordinates are returned as from original mapping.
+// For the reverse mapping back of translated to logical coordinates we expect that same logical coordinates are
+// returned as from original mapping.
 TEST(SocDescriptor, SocDescriptorBHLogicalTranslatedMapping) {
-
     const std::size_t max_num_harvested_x = 14;
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"));
     for (std::size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_x); harvesting_mask++) {
-        
         soc_desc.perform_harvesting(harvesting_mask);
 
         std::map<tt_logical_coords, tt_translated_coords> logical_to_translated;
@@ -170,7 +166,8 @@ TEST(SocDescriptor, SocDescriptorBHLogicalTranslatedMapping) {
                 tt_translated_coords translated_coords = soc_desc.to_translated_coords(logical_coords);
                 logical_to_translated[logical_coords] = translated_coords;
 
-                // Expect that logical to translated translation is 1-1 mapping. No duplicates for translated coordinates.
+                // Expect that logical to translated translation is 1-1 mapping. No duplicates for translated
+                // coordinates.
                 EXPECT_EQ(translated_coords_set.count(translated_coords), 0);
                 translated_coords_set.insert(translated_coords);
             }
@@ -196,7 +193,7 @@ TEST(SocDescriptor, SocDescriptorBHVirtualEqualTranslated) {
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"));
     for (std::size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_x); harvesting_mask++) {
         soc_desc.perform_harvesting(harvesting_mask);
-        
+
         std::size_t num_harvested_x = test_utils::get_num_harvested(harvesting_mask);
 
         for (std::size_t x = 0; x < soc_desc.worker_grid_size.x - num_harvested_x; x++) {
@@ -209,5 +206,5 @@ TEST(SocDescriptor, SocDescriptorBHVirtualEqualTranslated) {
                 EXPECT_EQ(translated_coords, virtual_coords);
             }
         }
-    } 
+    }
 }

--- a/tests/api/test_soc_descriptor_gs.cpp
+++ b/tests/api/test_soc_descriptor_gs.cpp
@@ -3,9 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "gtest/gtest.h"
-
 #include "device/tt_soc_descriptor.h"
+#include "gtest/gtest.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/test_utils/soc_desc_test_utils.hpp"
 
@@ -27,7 +26,6 @@
 // Tests that all physical coordinates are same as all virtual coordinates
 // when there is no harvesting.
 TEST(SocDescriptor, SocDescriptorGSNoHarvesting) {
-
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"));
 
     // We expect full grid size since there is no harvesting.
@@ -37,7 +35,7 @@ TEST(SocDescriptor, SocDescriptorGSNoHarvesting) {
             tt_logical_coords logical_coords = tt_logical_coords(x, y);
             tt_virtual_coords virtual_coords = soc_desc.to_virtual_coords(logical_coords);
             tt_physical_coords physical_coords = soc_desc.to_physical_coords(logical_coords);
-            
+
             // Virtual and physical coordinates should be the same.
             EXPECT_EQ(physical_coords, virtual_coords);
         }
@@ -48,7 +46,6 @@ TEST(SocDescriptor, SocDescriptorGSNoHarvesting) {
 // We expect that the top left core will have virtual and physical coordinates (1, 1) and (1, 2) for
 // the logical coordinates if the first row is harvested.
 TEST(SocDescriptor, SocDescriptorGSTopLeftCore) {
-
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"));
     tt_xy_pair worker_grid_size = soc_desc.worker_grid_size;
 
@@ -75,7 +72,7 @@ TEST(SocDescriptor, SocDescriptorGSTranslatingCoords) {
             tt_virtual_coords virtual_coords = soc_desc.to_virtual_coords(logical_coords);
             tt_physical_coords physical_coords = soc_desc.to_physical_coords(logical_coords);
             tt_translated_coords translated_coords = soc_desc.to_translated_coords(logical_coords);
-            
+
             // Virtual, physical and translated coordinates should be the same.
             EXPECT_EQ(physical_coords, virtual_coords);
             EXPECT_EQ(physical_coords, translated_coords);
@@ -85,9 +82,9 @@ TEST(SocDescriptor, SocDescriptorGSTranslatingCoords) {
 
 // Test logical to physical coordinate translation.
 // For the full grid of logical coordinates we expect that there are no duplicates of physical coordinates.
-// For the reverse mapping back of physical to logical coordinates we expect that same logical coordinates are returned as from original mapping.
+// For the reverse mapping back of physical to logical coordinates we expect that same logical coordinates are returned
+// as from original mapping.
 TEST(SocDescriptor, SocDescriptorGSLogicalPhysicalMapping) {
-
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"));
 
     std::map<tt_logical_coords, tt_physical_coords> logical_to_physical;
@@ -111,7 +108,7 @@ TEST(SocDescriptor, SocDescriptorGSLogicalPhysicalMapping) {
     for (auto it : logical_to_physical) {
         tt_physical_coords physical_coords = it.second;
         tt_logical_coords logical_coords = soc_desc.to_logical_coords(physical_coords);
-        
+
         // Expect that reverse mapping of physical coordinates gives the same logical coordinates
         // using which we got the physical coordinates.
         EXPECT_EQ(it.first, logical_coords);
@@ -120,9 +117,9 @@ TEST(SocDescriptor, SocDescriptorGSLogicalPhysicalMapping) {
 
 // Test logical to virtual coordinate translation.
 // For the full grid of logical coordinates we expect that there are no duplicates of virtual coordinates.
-// For the reverse mapping back of virtual to logical coordinates we expect that same logical coordinates are returned as from original mapping.
+// For the reverse mapping back of virtual to logical coordinates we expect that same logical coordinates are returned
+// as from original mapping.
 TEST(SocDescriptor, SocDescriptorGSLogicalVirtualMapping) {
-
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"));
 
     std::map<tt_logical_coords, tt_virtual_coords> logical_to_virtual;

--- a/tests/api/test_soc_descriptor_wh.cpp
+++ b/tests/api/test_soc_descriptor_wh.cpp
@@ -3,35 +3,33 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "gtest/gtest.h"
-
 #include "device/tt_soc_descriptor.h"
+#include "gtest/gtest.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/test_utils/soc_desc_test_utils.hpp"
-
 
 // Wormhole workers - x-y annotation
 // functional_workers:
 //   [
-//    1-1,   2-1,   3-1,   4-1,   6-1,   7-1,   8-1,   9-1, 
-//    1-2,   2-2,   3-2,   4-2,   6-2,   7-2,   8-2,   9-2, 
-//    1-3,   2-3,   3-3,   4-3,   6-3,   7-3,   8-3,   9-3, 
-//    1-4,   2-4,   3-4,   4-4,   6-4,   7-4,   8-4,   9-4, 
-//    1-5,   2-5,   3-5,   4-5,   6-5,   7-5,   8-5,   9-5, 
-//    1-7,   2-7,   3-7,   4-7,   6-7,   7-7,   8-7,   9-7, 
-//    1-8,   2-8,   3-8,   4-8,   6-8,   7-8,   8-8,   9-8, 
-//    1-9,   2-9,   3-9,   4-9,   6-9,   7-9,   8-9,   9-9, 
-//    1-10,  2-10,  3-10,  4-10,  6-10,  7-10,  8-10,  9-10, 
-//    1-11,  2-11,  3-11,  4-11,  6-11,  7-11,  8-11,  9-11, 
+//    1-1,   2-1,   3-1,   4-1,   6-1,   7-1,   8-1,   9-1,
+//    1-2,   2-2,   3-2,   4-2,   6-2,   7-2,   8-2,   9-2,
+//    1-3,   2-3,   3-3,   4-3,   6-3,   7-3,   8-3,   9-3,
+//    1-4,   2-4,   3-4,   4-4,   6-4,   7-4,   8-4,   9-4,
+//    1-5,   2-5,   3-5,   4-5,   6-5,   7-5,   8-5,   9-5,
+//    1-7,   2-7,   3-7,   4-7,   6-7,   7-7,   8-7,   9-7,
+//    1-8,   2-8,   3-8,   4-8,   6-8,   7-8,   8-8,   9-8,
+//    1-9,   2-9,   3-9,   4-9,   6-9,   7-9,   8-9,   9-9,
+//    1-10,  2-10,  3-10,  4-10,  6-10,  7-10,  8-10,  9-10,
+//    1-11,  2-11,  3-11,  4-11,  6-11,  7-11,  8-11,  9-11,
 //   ]
 
 // Tests that all physical coordinates are same as all virtual coordinates
 // when there is no harvesting.
 TEST(SocDescriptor, SocDescriptorWHNoHarvesting) {
-
     const std::size_t harvesting_mask = 0;
-    
-    tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), harvesting_mask);
+
+    tt_SocDescriptor soc_desc =
+        tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), harvesting_mask);
 
     // We expect full grid size since there is no harvesting.
     tt_xy_pair worker_grid_size = soc_desc.worker_grid_size;
@@ -51,10 +49,10 @@ TEST(SocDescriptor, SocDescriptorWHNoHarvesting) {
 // We expect that the top left core will have virtual and physical coordinates (1, 1) and (1, 2) for
 // the logical coordinates if the first row is harvested.
 TEST(SocDescriptor, SocDescriptorWHTopLeftCore) {
-
     const std::size_t harvesting_mask = 1;
 
-    tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), harvesting_mask);
+    tt_SocDescriptor soc_desc =
+        tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), harvesting_mask);
     tt_xy_pair worker_grid_size = soc_desc.worker_grid_size;
 
     tt_logical_coords logical_coords = tt_logical_coords(0, 0);
@@ -70,13 +68,12 @@ TEST(SocDescriptor, SocDescriptorWHTopLeftCore) {
 
 // Test logical to physical coordinate translation.
 // For the full grid of logical coordinates we expect that there are no duplicates of physical coordinates.
-// For the reverse mapping back of physical to logical coordinates we expect that same logical coordinates are returned as from original mapping.
+// For the reverse mapping back of physical to logical coordinates we expect that same logical coordinates are returned
+// as from original mapping.
 TEST(SocDescriptor, SocDescriptorWHLogicalPhysicalMapping) {
-
     const std::size_t max_num_harvested_y = 10;
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"));
     for (std::size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_y); harvesting_mask++) {
-
         soc_desc.perform_harvesting(harvesting_mask);
 
         std::map<tt_logical_coords, tt_physical_coords> logical_to_physical;
@@ -96,8 +93,9 @@ TEST(SocDescriptor, SocDescriptorWHLogicalPhysicalMapping) {
                 physical_coords_set.insert(physical_coords);
             }
         }
-        
-        // Expect that the number of physical coordinates is equal to the number of workers minus the number of harvested rows.
+
+        // Expect that the number of physical coordinates is equal to the number of workers minus the number of
+        // harvested rows.
         EXPECT_EQ(physical_coords_set.size(), worker_grid_size.x * (worker_grid_size.y - num_harvested_y));
 
         for (auto it : logical_to_physical) {
@@ -113,13 +111,12 @@ TEST(SocDescriptor, SocDescriptorWHLogicalPhysicalMapping) {
 
 // Test logical to virtual coordinate translation.
 // For the full grid of logical coordinates we expect that there are no duplicates of virtual coordinates.
-// For the reverse mapping back of virtual to logical coordinates we expect that same logical coordinates are returned as from original mapping.
+// For the reverse mapping back of virtual to logical coordinates we expect that same logical coordinates are returned
+// as from original mapping.
 TEST(SocDescriptor, SocDescriptorWHLogicalVirtualMapping) {
-
     const std::size_t max_num_harvested_y = 10;
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"));
     for (std::size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_y); harvesting_mask++) {
-
         soc_desc.perform_harvesting(harvesting_mask);
 
         std::map<tt_logical_coords, tt_virtual_coords> logical_to_virtual;
@@ -153,17 +150,18 @@ TEST(SocDescriptor, SocDescriptorWHLogicalVirtualMapping) {
 
 // Test top left corner translation from logical to translated coordinates.
 TEST(SocDescriptor, SocDescriptorWHLogicalTranslatedTopLeft) {
-
     const std::size_t translated_x_start = 18;
     const std::size_t translated_y_start = 18;
-    const tt_translated_coords expected_translated_coords = tt_translated_coords(translated_x_start, translated_y_start);
+    const tt_translated_coords expected_translated_coords =
+        tt_translated_coords(translated_x_start, translated_y_start);
 
     const std::size_t max_num_harvested_y = 10;
     tt_SocDescriptor soc_desc = tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"));
-    // We go up to numbers less than 2^10 - 1 to test all possible harvesting masks, we don't want to try to convert if everything is harvested.
+    // We go up to numbers less than 2^10 - 1 to test all possible harvesting masks, we don't want to try to convert if
+    // everything is harvested.
     for (std::size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_y) - 1; harvesting_mask++) {
         soc_desc.perform_harvesting(harvesting_mask);
-        
+
         tt_xy_pair worker_grid_size = soc_desc.worker_grid_size;
 
         std::size_t num_harvested_y = test_utils::get_num_harvested(harvesting_mask);

--- a/tests/blackhole/test_bh_common.h
+++ b/tests/blackhole/test_bh_common.h
@@ -3,12 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include "tt_xy_pair.h"
-#include "tt_cluster_descriptor.h"
 #include "cluster.h"
-
-#include "tests/test_utils/stimulus_generators.hpp"
 #include "eth_l1_address_map.h"
+#include "tests/test_utils/stimulus_generators.hpp"
+#include "tt_cluster_descriptor.h"
+#include "tt_xy_pair.h"
 
 using namespace tt::umd;
 
@@ -16,68 +15,68 @@ namespace tt::umd::test::utils {
 
 static void set_params_for_remote_txn(Cluster& device) {
     // Populate address map and NOC parameters that the driver needs for remote transactions
-    device.set_device_l1_address_params({l1_mem::address_map::L1_BARRIER_BASE, eth_l1_mem::address_map::ERISC_BARRIER_BASE, eth_l1_mem::address_map::FW_VERSION_ADDR});
+    device.set_device_l1_address_params(
+        {l1_mem::address_map::L1_BARRIER_BASE,
+         eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+         eth_l1_mem::address_map::FW_VERSION_ADDR});
 }
 
 class BlackholeTestFixture : public ::testing::Test {
- protected:
-  // You can remove any or all of the following functions if their bodies would
-  // be empty.
+protected:
+    // You can remove any or all of the following functions if their bodies would
+    // be empty.
 
-  std::unique_ptr<Cluster> device;
+    std::unique_ptr<Cluster> device;
 
-  BlackholeTestFixture() {
+    BlackholeTestFixture() {}
 
-  }
-
-  ~BlackholeTestFixture() override {
-     // You can do clean-up work that doesn't throw exceptions here.
-  }
-
-  virtual int get_detected_num_chips() = 0;
-  virtual bool is_test_skipped() = 0;
-
-  // If the constructor and destructor are not enough for setting up
-  // and cleaning up each test, you can define the following methods:
-
-  void SetUp() override {
-    // Code here will be called immediately after the constructor (right
-    // before each test).
-
-    if (is_test_skipped()) {
-        GTEST_SKIP() << "Test is skipped due to incorrect number of chips";
+    ~BlackholeTestFixture() override {
+        // You can do clean-up work that doesn't throw exceptions here.
     }
 
-    // std::cout << "Setting Up Test." << std::endl;
-    assert(get_detected_num_chips() > 0);
-    auto devices = std::vector<chip_id_t>(get_detected_num_chips());
-    std::iota(devices.begin(), devices.end(), 0);
-    std::set<chip_id_t> target_devices = {devices.begin(), devices.end()};
-    uint32_t num_host_mem_ch_per_mmio_device = 1;
-    device = std::make_unique<Cluster>(num_host_mem_ch_per_mmio_device, false, true, true);
-    assert(device != nullptr);
-    assert(device->get_cluster_description()->get_number_of_chips() == get_detected_num_chips());
+    virtual int get_detected_num_chips() = 0;
+    virtual bool is_test_skipped() = 0;
 
-    set_params_for_remote_txn(*device);
+    // If the constructor and destructor are not enough for setting up
+    // and cleaning up each test, you can define the following methods:
 
-    tt_device_params default_params;
-    device->start_device(default_params);
+    void SetUp() override {
+        // Code here will be called immediately after the constructor (right
+        // before each test).
 
-    device->deassert_risc_reset();
+        if (is_test_skipped()) {
+            GTEST_SKIP() << "Test is skipped due to incorrect number of chips";
+        }
 
-    device->wait_for_non_mmio_flush();
-  }
+        // std::cout << "Setting Up Test." << std::endl;
+        assert(get_detected_num_chips() > 0);
+        auto devices = std::vector<chip_id_t>(get_detected_num_chips());
+        std::iota(devices.begin(), devices.end(), 0);
+        std::set<chip_id_t> target_devices = {devices.begin(), devices.end()};
+        uint32_t num_host_mem_ch_per_mmio_device = 1;
+        device = std::make_unique<Cluster>(num_host_mem_ch_per_mmio_device, false, true, true);
+        assert(device != nullptr);
+        assert(device->get_cluster_description()->get_number_of_chips() == get_detected_num_chips());
 
-  void TearDown() override {
-    // Code here will be called immediately after each test (right
-    // before the destructor).
+        set_params_for_remote_txn(*device);
 
-    if (!is_test_skipped()) {
-        // std::cout << "Tearing Down Test." << std::endl;
-        device->close_device();
+        tt_device_params default_params;
+        device->start_device(default_params);
+
+        device->deassert_risc_reset();
+
+        device->wait_for_non_mmio_flush();
     }
-  }
 
+    void TearDown() override {
+        // Code here will be called immediately after each test (right
+        // before the destructor).
+
+        if (!is_test_skipped()) {
+            // std::cout << "Tearing Down Test." << std::endl;
+            device->close_device();
+        }
+    }
 };
 
-} // namespace tt::umd::test::utils
+}  // namespace tt::umd::test::utils

--- a/tests/blackhole/test_silicon_driver_bh.cpp
+++ b/tests/blackhole/test_silicon_driver_bh.cpp
@@ -2,30 +2,41 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "gtest/gtest.h"
 #include <cluster.h>
-#include "eth_l1_address_map.h"
-#include "l1_address_map.h"
-#include "host_mem_address_map.h"
-#include <thread>
+
 #include <memory>
+#include <thread>
 
 #include "device/blackhole/blackhole_implementation.h"
 #include "device/tt_cluster_descriptor.h"
-#include "tests/test_utils/generate_cluster_desc.hpp"
+#include "eth_l1_address_map.h"
+#include "gtest/gtest.h"
+#include "host_mem_address_map.h"
+#include "l1_address_map.h"
 #include "tests/test_utils/device_test_utils.hpp"
+#include "tests/test_utils/generate_cluster_desc.hpp"
 
 using namespace tt::umd;
 
 void set_params_for_remote_txn(Cluster& device) {
     // Populate address map and NOC parameters that the driver needs for remote transactions
-    device.set_device_l1_address_params({l1_mem::address_map::L1_BARRIER_BASE, eth_l1_mem::address_map::ERISC_BARRIER_BASE, eth_l1_mem::address_map::FW_VERSION_ADDR});
+    device.set_device_l1_address_params(
+        {l1_mem::address_map::L1_BARRIER_BASE,
+         eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+         eth_l1_mem::address_map::FW_VERSION_ADDR});
 }
 
 std::int32_t get_static_tlb_index(tt_xy_pair target) {
-    bool is_eth_location = std::find(std::begin(tt::umd::blackhole::ETH_LOCATIONS), std::end(tt::umd::blackhole::ETH_LOCATIONS), target) != std::end(tt::umd::blackhole::ETH_LOCATIONS);
-    bool is_tensix_location = std::find(std::begin(tt::umd::blackhole::T6_X_LOCATIONS), std::end(tt::umd::blackhole::T6_X_LOCATIONS), target.x) != std::end(tt::umd::blackhole::T6_X_LOCATIONS) &&
-                            std::find(std::begin(tt::umd::blackhole::T6_Y_LOCATIONS), std::end(tt::umd::blackhole::T6_Y_LOCATIONS), target.y) != std::end(tt::umd::blackhole::T6_Y_LOCATIONS);
+    bool is_eth_location =
+        std::find(std::begin(tt::umd::blackhole::ETH_LOCATIONS), std::end(tt::umd::blackhole::ETH_LOCATIONS), target) !=
+        std::end(tt::umd::blackhole::ETH_LOCATIONS);
+    bool is_tensix_location =
+        std::find(
+            std::begin(tt::umd::blackhole::T6_X_LOCATIONS), std::end(tt::umd::blackhole::T6_X_LOCATIONS), target.x) !=
+            std::end(tt::umd::blackhole::T6_X_LOCATIONS) &&
+        std::find(
+            std::begin(tt::umd::blackhole::T6_Y_LOCATIONS), std::end(tt::umd::blackhole::T6_Y_LOCATIONS), target.y) !=
+            std::end(tt::umd::blackhole::T6_Y_LOCATIONS);
     if (is_eth_location) {
         if (target.y == 6) {
             target.y = 1;
@@ -61,7 +72,8 @@ std::int32_t get_static_tlb_index(tt_xy_pair target) {
 
 std::set<chip_id_t> get_target_devices() {
     std::set<chip_id_t> target_devices;
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq = tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
+        tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
     for (int i = 0; i < cluster_desc_uniq->get_number_of_chips(); i++) {
         target_devices.insert(i);
     }
@@ -73,8 +85,15 @@ TEST(SiliconDriverBH, CreateDestroy) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     tt_device_params default_params;
     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
-    for(int i = 0; i < 50; i++) {
-        Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, false);
+    for (int i = 0; i < 50; i++) {
+        Cluster device = Cluster(
+            test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"),
+            tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+            target_devices,
+            num_host_mem_ch_per_mmio_device,
+            false,
+            true,
+            false);
         set_params_for_remote_txn(device);
         device.start_device(default_params);
         device.deassert_risc_reset();
@@ -85,44 +104,52 @@ TEST(SiliconDriverBH, CreateDestroy) {
 // TEST(SiliconDriverWH, Harvesting) {
 //     std::set<chip_id_t> target_devices = {0, 1};
 //     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 30}, {1, 60}};
-    
+
 //     {
-//         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq = tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
-//         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
-//             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula system";
+//         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
+//         tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path()); if
+//         (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
+//             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
+//             system";
 //         }
 //     }
 
 //     uint32_t num_host_mem_ch_per_mmio_device = 1;
-//     Cluster device = Cluster("./tests/soc_descs/wormhole_b0_8x10.yaml", tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true, simulated_harvesting_masks);
-//     auto sdesc_per_chip = device.get_virtual_soc_descriptors();
+//     Cluster device = Cluster("./tests/soc_descs/wormhole_b0_8x10.yaml",
+//     tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false,
+//     true, true, simulated_harvesting_masks); auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
 //     ASSERT_EQ(device.using_harvested_soc_descriptors(), true) << "Expected Driver to have performed harvesting";
 
 //     for(const auto& chip : sdesc_per_chip) {
-//         ASSERT_EQ(chip.second.workers.size(), 48) << "Expected SOC descriptor with harvesting to have 48 workers for chip" << chip.first;
+//         ASSERT_EQ(chip.second.workers.size(), 48) << "Expected SOC descriptor with harvesting to have 48 workers for
+//         chip" << chip.first;
 //     }
-//     ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(0), 30) << "Expected first chip to have harvesting mask of 30";
-//     ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(1), 60) << "Expected second chip to have harvesting mask of 60";
+//     ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(0), 30) << "Expected first chip to have harvesting
+//     mask of 30"; ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(1), 60) << "Expected second chip to
+//     have harvesting mask of 60";
 // }
 
 // TEST(SiliconDriverWH, CustomSocDesc) {
 //     std::set<chip_id_t> target_devices = {0, 1};
 //     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 30}, {1, 60}};
 //     {
-//         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq = tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
-//         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
-//             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula system";
+//         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
+//         tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path()); if
+//         (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
+//             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
+//             system";
 //         }
 //     }
 
 //     uint32_t num_host_mem_ch_per_mmio_device = 1;
 //     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
-//     Cluster device = Cluster("./tests/soc_descs/wormhole_b0_1x1.yaml", tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, false, simulated_harvesting_masks);
-//     auto sdesc_per_chip = device.get_virtual_soc_descriptors();
-    
-//     ASSERT_EQ(device.using_harvested_soc_descriptors(), false) << "SOC descriptors should not be modified when harvesting is disabled";
-//     for(const auto& chip : sdesc_per_chip) {
+//     Cluster device = Cluster("./tests/soc_descs/wormhole_b0_1x1.yaml",
+//     tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false,
+//     true, false, simulated_harvesting_masks); auto sdesc_per_chip = device.get_virtual_soc_descriptors();
+
+//     ASSERT_EQ(device.using_harvested_soc_descriptors(), false) << "SOC descriptors should not be modified when
+//     harvesting is disabled"; for(const auto& chip : sdesc_per_chip) {
 //         ASSERT_EQ(chip.second.workers.size(), 1) << "Expected 1x1 SOC descriptor to be unmodified by driver";
 //     }
 // }
@@ -136,30 +163,34 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //     std::set<chip_id_t> target_devices = {0, 1};
 //     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 30}, {1, 60}};
 //     {
-//         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq = tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
-//         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
-//             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula system";
+//         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
+//         tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path()); if
+//         (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
+//             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
+//             system";
 //         }
 //     }
 
 //     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    
-//     Cluster device = Cluster("./tests/soc_descs/wormhole_b0_8x10.yaml", tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, true, simulated_harvesting_masks);
-//     set_params_for_remote_txn(device);
-//     auto mmio_devices = device.get_target_mmio_device_ids();
-    
+
+//     Cluster device = Cluster("./tests/soc_descs/wormhole_b0_8x10.yaml",
+//     tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false,
+//     true, true, simulated_harvesting_masks); set_params_for_remote_txn(device); auto mmio_devices =
+//     device.get_target_mmio_device_ids();
+
 //     for(int i = 0; i < target_devices.size(); i++) {
 //         // Iterate over MMIO devices and only setup static TLBs for worker cores
 //         if(std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
 //             auto& sdesc = device.get_virtual_soc_descriptors().at(i);
 //             for(auto& core : sdesc.workers) {
-//                 // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.  
-//                 device.configure_tlb(i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
+//                 // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
+//                 device.configure_tlb(i, core, get_static_tlb_index_callback(core),
+//                 l1_mem::address_map::NCRISC_FIRMWARE_BASE);
 //             }
-//         } 
+//         }
 //     }
 //     device.setup_core_to_tlb_map(get_static_tlb_index_callback);
-    
+
 //     tt_device_params default_params;
 //     device.start_device(default_params);
 //     device.deassert_risc_reset();
@@ -169,26 +200,29 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //     std::vector<uint32_t> readback_vec = {};
 //     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-
 //     for(int i = 0; i < target_devices.size(); i++) {
 //         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
 //         std::uint32_t dynamic_write_address = 0x40000000;
-//         for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
+//         for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped
+//         addresses
 //             for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-//                 device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "");
-//                 device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), dynamic_write_address, "SMALL_READ_WRITE_TLB");
-//                 device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over ethernet were commited
-                
+//                 device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t),
+//                 tt_cxy_pair(i, core), address, ""); device.write_to_device(vector_to_write.data(),
+//                 vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), dynamic_write_address,
+//                 "SMALL_READ_WRITE_TLB"); device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over
+//                 ethernet were commited
+
 //                 test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "");
-//                 test_utils::read_data_from_device(device, dynamic_readback_vec, tt_cxy_pair(i, core), dynamic_write_address, 40, "SMALL_READ_WRITE_TLB");
-//                 ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
-//                 ASSERT_EQ(vector_to_write, dynamic_readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
-//                 device.wait_for_non_mmio_flush();
-                
-//                 device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), dynamic_write_address, "SMALL_READ_WRITE_TLB"); // Clear any written data
-//                 device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, ""); // Clear any written data
-//                 device.wait_for_non_mmio_flush();
-//                 readback_vec = {};
+//                 test_utils::read_data_from_device(device, dynamic_readback_vec, tt_cxy_pair(i, core),
+//                 dynamic_write_address, 40, "SMALL_READ_WRITE_TLB"); ASSERT_EQ(vector_to_write, readback_vec) <<
+//                 "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+//                 ASSERT_EQ(vector_to_write, dynamic_readback_vec) << "Vector read back from core " << core.x << "-" <<
+//                 core.y << "does not match what was written"; device.wait_for_non_mmio_flush();
+
+//                 device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core),
+//                 dynamic_write_address, "SMALL_READ_WRITE_TLB"); // Clear any written data
+//                 device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core),
+//                 address, ""); // Clear any written data device.wait_for_non_mmio_flush(); readback_vec = {};
 //                 dynamic_readback_vec = {};
 //             }
 //             address += 0x20; // Increment by uint32_t size for each write
@@ -199,45 +233,44 @@ TEST(SiliconDriverBH, CreateDestroy) {
 // }
 
 TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
-    auto get_static_tlb_index_callback = [] (tt_xy_pair target) {
-        return get_static_tlb_index(target);
-    };
+    auto get_static_tlb_index_callback = [](tt_xy_pair target) { return get_static_tlb_index(target); };
 
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    
+
     Cluster device = Cluster(num_host_mem_ch_per_mmio_device, false, true, true);
     set_params_for_remote_txn(device);
     auto mmio_devices = device.get_target_mmio_device_ids();
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over MMIO devices and only setup static TLBs for worker cores
-        if(std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
+        if (std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
             auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-            for(auto& core : sdesc.workers) {
-                // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.  
-                device.configure_tlb(i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
+            for (auto& core : sdesc.workers) {
+                // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
+                device.configure_tlb(
+                    i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
             }
             device.setup_core_to_tlb_map(i, get_static_tlb_index_callback);
-        } 
+        }
     }
-    
+
     tt_device_params default_params;
     device.start_device(default_params);
     device.deassert_risc_reset();
 
     std::vector<uint32_t> unaligned_sizes = {3, 14, 21, 255, 362, 430, 1022, 1023, 1025};
-    for(int i = 0; i < target_devices.size(); i++) {
-        for(const auto& size : unaligned_sizes) {
+    for (int i = 0; i < target_devices.size(); i++) {
+        for (const auto& size : unaligned_sizes) {
             std::vector<uint8_t> write_vec(size, 0);
-            for(int i = 0; i < size; i++){
+            for (int i = 0; i < size; i++) {
                 write_vec[i] = size + i;
             }
             std::vector<uint8_t> readback_vec(size, 0);
             std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
-            for(int loop = 0; loop < 50; loop++){
-                for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+            for (int loop = 0; loop < 50; loop++) {
+                for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
                     device.write_to_device(write_vec.data(), size, tt_cxy_pair(i, core), address, "");
                     device.wait_for_non_mmio_flush();
                     device.read_from_device(readback_vec.data(), tt_cxy_pair(i, core), address, size, "");
@@ -251,37 +284,35 @@ TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
                 }
                 address += 0x20;
             }
-
         }
     }
     device.close_device();
 }
 
 TEST(SiliconDriverBH, StaticTLB_RW) {
-    auto get_static_tlb_index_callback = [] (tt_xy_pair target) {
-        return get_static_tlb_index(target);
-    };
+    auto get_static_tlb_index_callback = [](tt_xy_pair target) { return get_static_tlb_index(target); };
 
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    
+
     Cluster device = Cluster(num_host_mem_ch_per_mmio_device, false, true, true);
     set_params_for_remote_txn(device);
     auto mmio_devices = device.get_target_mmio_device_ids();
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over MMIO devices and only setup static TLBs for worker cores
-        if(std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
+        if (std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
             auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-            for(auto& core : sdesc.workers) {
-                // Statically mapping a 2MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.  
-                device.configure_tlb(i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
+            for (auto& core : sdesc.workers) {
+                // Statically mapping a 2MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
+                device.configure_tlb(
+                    i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
             }
             device.setup_core_to_tlb_map(i, get_static_tlb_index_callback);
-        } 
+        }
     }
-    
+
     printf("MT: Static TLBs set\n");
 
     tt_device_params default_params;
@@ -292,27 +323,40 @@ TEST(SiliconDriverBH, StaticTLB_RW) {
     std::vector<uint32_t> readback_vec = {};
     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     // Check functionality of Static TLBs by reading adn writing from statically mapped address space
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
-        for(int loop = 0; loop < 1; loop++){ // Write to each core a 100 times at different statically mapped addresses
-            for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "");
-                device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over ethernet were commited
+        for (int loop = 0; loop < 1;
+             loop++) {  // Write to each core a 100 times at different statically mapped addresses
+            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "");
+                device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
                 test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 device.wait_for_non_mmio_flush();
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB"); // Clear any written data
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");  // Clear any written data
                 device.wait_for_non_mmio_flush();
                 readback_vec = {};
             }
-            address += 0x20; // Increment by uint32_t size for each write
+            address += 0x20;  // Increment by uint32_t size for each write
         }
     }
-    device.close_device();    
+    device.close_device();
 }
 
 TEST(SiliconDriverBH, DynamicTLB_RW) {
-    // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for each transaction
+    // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for
+    // each transaction
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
@@ -329,42 +373,68 @@ TEST(SiliconDriverBH, DynamicTLB_RW) {
     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     std::vector<uint32_t> readback_vec = {};
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
-        for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
-            for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB");
-                device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over ethernet were commited
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "SMALL_READ_WRITE_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+        for (int loop = 0; loop < 100;
+             loop++) {  // Write to each core a 100 times at different statically mapped addresses
+            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
+                device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, 40, "SMALL_READ_WRITE_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 device.wait_for_non_mmio_flush();
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
                 device.wait_for_non_mmio_flush();
                 readback_vec = {};
             }
-            address += 0x20; // Increment by uint32_t size for each write
+            address += 0x20;  // Increment by uint32_t size for each write
         }
     }
     printf("Target Tensix cores completed\n");
-    
+
     // Target DRAM channel 0
     constexpr int NUM_CHANNELS = 8;
     std::vector<uint32_t> dram_vector_to_write = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
     std::uint32_t address = 0x400;
-    for(int i = 0; i < target_devices.size(); i++) {
-        for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
-            for (int ch=0; ch<NUM_CHANNELS; ch++) {
+    for (int i = 0; i < target_devices.size(); i++) {
+        for (int loop = 0; loop < 100;
+             loop++) {  // Write to each core a 100 times at different statically mapped addresses
+            for (int ch = 0; ch < NUM_CHANNELS; ch++) {
                 std::vector<tt_xy_pair> chan = device.get_virtual_soc_descriptors().at(i).dram_cores.at(ch);
                 tt_xy_pair subchan = chan.at(0);
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, subchan), address, "SMALL_READ_WRITE_TLB");
-                device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over ethernet were commited
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, subchan), address, 40, "SMALL_READ_WRITE_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << subchan.x << "-" << subchan.y << "does not match what was written";
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, subchan),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
+                device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, subchan), address, 40, "SMALL_READ_WRITE_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << subchan.x << "-"
+                                                         << subchan.y << "does not match what was written";
                 device.wait_for_non_mmio_flush();
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, subchan), address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, subchan),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
                 device.wait_for_non_mmio_flush();
                 readback_vec = {};
-                address += 0x20; // Increment by uint32_t size for each write
+                address += 0x20;  // Increment by uint32_t size for each write
             }
         }
     }
@@ -381,7 +451,7 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     Cluster device = Cluster(num_host_mem_ch_per_mmio_device, false, true, true);
-    
+
     set_params_for_remote_txn(device);
 
     tt_device_params default_params;
@@ -392,11 +462,18 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
         std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
-        for(int loop = 0; loop < 100; loop++) {
-            for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+        for (int loop = 0; loop < 100; loop++) {
+            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(0, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 readback_vec = {};
             }
             address += 0x20;
@@ -407,12 +484,19 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
         std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = 0x30000000;
-        for(auto& core_ls : device.get_virtual_soc_descriptors().at(0).dram_cores) {
-            for(int loop = 0; loop < 100; loop++) {
-                for(auto& core : core_ls) {
-                    device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
-                    test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
-                    ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+        for (auto& core_ls : device.get_virtual_soc_descriptors().at(0).dram_cores) {
+            for (int loop = 0; loop < 100; loop++) {
+                for (auto& core : core_ls) {
+                    device.write_to_device(
+                        vector_to_write.data(),
+                        vector_to_write.size() * sizeof(std::uint32_t),
+                        tt_cxy_pair(0, core),
+                        address,
+                        "SMALL_READ_WRITE_TLB");
+                    test_utils::read_data_from_device(
+                        device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
+                    ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y
+                                                             << "does not match what was written";
                     readback_vec = {};
                 }
                 address += 0x20;
@@ -427,13 +511,11 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
 
 TEST(SiliconDriverBH, MultiThreadedMemBar) {
     // Have 2 threads read and write from a single device concurrently
-    // All (fairly large) transactions go through a static TLB. 
+    // All (fairly large) transactions go through a static TLB.
     // We want to make sure the memory barrier is thread/process safe.
 
     // Memory barrier flags get sent to address 0 for all channels in this test
-    auto get_static_tlb_index_callback = [] (tt_xy_pair target) {
-        return get_static_tlb_index(target);
-    };
+    auto get_static_tlb_index_callback = [](tt_xy_pair target) { return get_static_tlb_index(target); };
 
     std::set<chip_id_t> target_devices = get_target_devices();
     uint32_t base_addr = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
@@ -441,11 +523,11 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
 
     Cluster device = Cluster(num_host_mem_ch_per_mmio_device, false, true, true);
     set_params_for_remote_txn(device);
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for functional worker cores
         auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-        for(auto& core : sdesc.workers) {
-            // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE. 
+        for (auto& core : sdesc.workers) {
+            // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
             device.configure_tlb(i, core, get_static_tlb_index_callback(core), base_addr);
         }
         device.setup_core_to_tlb_map(i, get_static_tlb_index_callback);
@@ -454,24 +536,41 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     tt_device_params default_params;
     device.start_device(default_params);
     device.deassert_risc_reset();
-    
+
     std::vector<uint32_t> readback_membar_vec = {};
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all workers
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        test_utils::read_data_from_device(
+            device,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            l1_mem::address_map::L1_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all workers
         readback_membar_vec = {};
     }
 
-    for(int chan = 0; chan <  device.get_virtual_soc_descriptors().at(0).get_num_dram_channels(); chan++) {
+    for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(0).get_num_dram_channels(); chan++) {
         auto core = device.get_virtual_soc_descriptors().at(0).get_core_for_dram_channel(chan, 0);
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all DRAM
+        test_utils::read_data_from_device(
+            device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all DRAM
         readback_membar_vec = {};
     }
-    
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all ethernet cores
+
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
+        test_utils::read_data_from_device(
+            device,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0),
+            187);  // Ensure that memory barriers were correctly initialized on all ethernet cores
         readback_membar_vec = {};
     }
 
@@ -481,38 +580,43 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     std::vector<uint32_t> vec2(2560);
     std::vector<uint32_t> zeros(2560, 0);
 
-    for(int i = 0; i < vec1.size(); i++) {
+    for (int i = 0; i < vec1.size(); i++) {
         vec1.at(i) = i;
     }
-    for(int i = 0; i < vec2.size(); i++) {
+    for (int i = 0; i < vec2.size(); i++) {
         vec2.at(i) = vec1.size() + i;
     }
     std::thread th1 = std::thread([&] {
         std::uint32_t address = base_addr;
-        for(int loop = 0; loop < 50; loop++) {
-            for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        for (int loop = 0; loop < 50; loop++) {
+            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
-                device.write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                device.write_to_device(
+                    vec1.data(), vec1.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 device.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 4*vec1.size(), "");
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(0, core), address, 4 * vec1.size(), "");
                 ASSERT_EQ(readback_vec, vec1);
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                device.write_to_device(
+                    zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 readback_vec = {};
             }
-            
         }
     });
 
     std::thread th2 = std::thread([&] {
         std::uint32_t address = base_addr + vec1.size() * 4;
-        for(int loop = 0; loop < 50; loop++) {
-            for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        for (int loop = 0; loop < 50; loop++) {
+            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
-                device.write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                device.write_to_device(
+                    vec2.data(), vec2.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 device.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 4*vec2.size(), "");
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(0, core), address, 4 * vec2.size(), "");
                 ASSERT_EQ(readback_vec, vec2);
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "") ;
+                device.write_to_device(
+                    zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 readback_vec = {};
             }
         }
@@ -521,26 +625,42 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     th1.join();
     th2.join();
 
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers end up in the correct sate for workers
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        test_utils::read_data_from_device(
+            device,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            l1_mem::address_map::L1_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0), 187);  // Ensure that memory barriers end up in the correct sate for workers
         readback_membar_vec = {};
     }
 
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers end up in the correct sate for ethernet cores
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
+        test_utils::read_data_from_device(
+            device,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0),
+            187);  // Ensure that memory barriers end up in the correct sate for ethernet cores
         readback_membar_vec = {};
     }
     device.close_device();
 }
 
-TEST(SiliconDriverBH, DISABLED_BroadcastWrite) { // Cannot broadcast to tensix/ethernet and DRAM simultaneously on Blackhole .. wait_for_non_mmio_flush() is not working as expected?
+TEST(SiliconDriverBH, DISABLED_BroadcastWrite) {  // Cannot broadcast to tensix/ethernet and DRAM simultaneously on
+                                                  // Blackhole .. wait_for_non_mmio_flush() is not working as expected?
     // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    
+
     Cluster device = Cluster(num_host_mem_ch_per_mmio_device, false, true, true);
     set_params_for_remote_txn(device);
     auto mmio_devices = device.get_target_mmio_device_ids();
@@ -555,49 +675,80 @@ TEST(SiliconDriverBH, DISABLED_BroadcastWrite) { // Cannot broadcast to tensix/e
     std::set<uint32_t> rows_to_exclude_for_dram_broadcast = {};
     std::set<uint32_t> cols_to_exclude_for_dram_broadcast = {1, 2, 3, 4, 6, 7, 8, 9};
 
-    for(const auto& size : broadcast_sizes) {
+    for (const auto& size : broadcast_sizes) {
         std::vector<uint32_t> vector_to_write(size);
         std::vector<uint32_t> zeros(size);
         std::vector<uint32_t> readback_vec = {};
-        for(int i = 0; i < size; i++) {
+        for (int i = 0; i < size; i++) {
             vector_to_write[i] = i;
             zeros[i] = 0;
         }
         // Broadcast to Tensix
-        device.broadcast_write_to_cluster(vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude, "LARGE_WRITE_TLB");
-        device.wait_for_non_mmio_flush(); // flush here so we don't simultaneously broadcast to DRAM? 
+        device.broadcast_write_to_cluster(
+            vector_to_write.data(),
+            vector_to_write.size() * 4,
+            address,
+            {},
+            rows_to_exclude,
+            cols_to_exclude,
+            "LARGE_WRITE_TLB");
+        device.wait_for_non_mmio_flush();  // flush here so we don't simultaneously broadcast to DRAM?
         // Broadcast to DRAM
-        device.broadcast_write_to_cluster(vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude_for_dram_broadcast, cols_to_exclude_for_dram_broadcast, "LARGE_WRITE_TLB");
+        device.broadcast_write_to_cluster(
+            vector_to_write.data(),
+            vector_to_write.size() * 4,
+            address,
+            {},
+            rows_to_exclude_for_dram_broadcast,
+            cols_to_exclude_for_dram_broadcast,
+            "LARGE_WRITE_TLB");
         device.wait_for_non_mmio_flush();
 
-        for(const auto i : target_devices) {
-            for(const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                if(rows_to_exclude.find(core.y) != rows_to_exclude.end()) continue;
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was broadcasted";
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+        for (const auto i : target_devices) {
+            for (const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
+                    continue;
+                }
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y
+                                                         << "does not match what was broadcasted";
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
-            for(int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
                 const auto& core = device.get_virtual_soc_descriptors().at(i).get_core_for_dram_channel(chan, 0);
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from DRAM core " << i << " " << core.x << "-" << core.y << " does not match what was broadcasted " << size;
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from DRAM core " << i << " " << core.x << "-" << core.y
+                    << " does not match what was broadcasted " << size;
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
         }
         // Wait for data to be cleared before writing next block
         device.wait_for_non_mmio_flush();
     }
-    device.close_device();    
+    device.close_device();
 }
 
-TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) { // same problem as above..
+TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as above..
     // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    
+
     Cluster device = Cluster(num_host_mem_ch_per_mmio_device, false, true, true);
     set_params_for_remote_txn(device);
     auto mmio_devices = device.get_target_mmio_device_ids();
@@ -605,12 +756,14 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) { // same problem as 
     tt_device_params default_params;
     device.start_device(default_params);
     auto eth_version = device.get_ethernet_fw_version();
-    bool virtual_bcast_supported = (eth_version >= tt_version(6, 8, 0) || eth_version == tt_version(6, 7, 241)) && device.translation_tables_en;
+    bool virtual_bcast_supported =
+        (eth_version >= tt_version(6, 8, 0) || eth_version == tt_version(6, 7, 241)) && device.translation_tables_en;
     if (!virtual_bcast_supported) {
         device.close_device();
-        GTEST_SKIP() << "SiliconDriverWH.VirtualCoordinateBroadcast skipped since ethernet version does not support Virtual Coordinate Broadcast or NOC translation is not enabled";
+        GTEST_SKIP() << "SiliconDriverWH.VirtualCoordinateBroadcast skipped since ethernet version does not support "
+                        "Virtual Coordinate Broadcast or NOC translation is not enabled";
     }
-    
+
     device.deassert_risc_reset();
     std::vector<uint32_t> broadcast_sizes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
     uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
@@ -619,38 +772,69 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) { // same problem as 
     std::set<uint32_t> rows_to_exclude_for_dram_broadcast = {};
     std::set<uint32_t> cols_to_exclude_for_dram_broadcast = {1, 2, 3, 4, 6, 7, 8, 9};
 
-    for(const auto& size : broadcast_sizes) {
+    for (const auto& size : broadcast_sizes) {
         std::vector<uint32_t> vector_to_write(size);
         std::vector<uint32_t> zeros(size);
         std::vector<uint32_t> readback_vec = {};
-        for(int i = 0; i < size; i++) {
+        for (int i = 0; i < size; i++) {
             vector_to_write[i] = i;
             zeros[i] = 0;
         }
         // Broadcast to Tensix
-        device.broadcast_write_to_cluster(vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude, "LARGE_WRITE_TLB");
+        device.broadcast_write_to_cluster(
+            vector_to_write.data(),
+            vector_to_write.size() * 4,
+            address,
+            {},
+            rows_to_exclude,
+            cols_to_exclude,
+            "LARGE_WRITE_TLB");
         // Broadcast to DRAM
-        device.broadcast_write_to_cluster(vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude_for_dram_broadcast, cols_to_exclude_for_dram_broadcast, "LARGE_WRITE_TLB");        
+        device.broadcast_write_to_cluster(
+            vector_to_write.data(),
+            vector_to_write.size() * 4,
+            address,
+            {},
+            rows_to_exclude_for_dram_broadcast,
+            cols_to_exclude_for_dram_broadcast,
+            "LARGE_WRITE_TLB");
         device.wait_for_non_mmio_flush();
 
-        for(const auto i : target_devices) {
-            for(const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                if(rows_to_exclude.find(core.y) != rows_to_exclude.end()) continue;
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was broadcasted";
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+        for (const auto i : target_devices) {
+            for (const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
+                    continue;
+                }
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y
+                                                         << "does not match what was broadcasted";
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
-            for(int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
                 const auto& core = device.get_virtual_soc_descriptors().at(i).get_core_for_dram_channel(chan, 0);
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from DRAM core " << i << " " << core.x << "-" << core.y << " does not match what was broadcasted " << size;
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from DRAM core " << i << " " << core.x << "-" << core.y
+                    << " does not match what was broadcasted " << size;
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
         }
         // Wait for data to be cleared before writing next block
         device.wait_for_non_mmio_flush();
     }
-    device.close_device();    
+    device.close_device();
 }

--- a/tests/blackhole/test_silicon_driver_bh.cpp
+++ b/tests/blackhole/test_silicon_driver_bh.cpp
@@ -107,27 +107,35 @@ TEST(SiliconDriverBH, CreateDestroy) {
 
 //     {
 //         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
-//         tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path()); if
-//         (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
+//             tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
+//         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
 //             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
 //             system";
 //         }
 //     }
 
 //     uint32_t num_host_mem_ch_per_mmio_device = 1;
-//     Cluster device = Cluster("./tests/soc_descs/wormhole_b0_8x10.yaml",
-//     tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false,
-//     true, true, simulated_harvesting_masks); auto sdesc_per_chip = device.get_virtual_soc_descriptors();
+//     Cluster device = Cluster(
+//         "./tests/soc_descs/wormhole_b0_8x10.yaml",
+//         tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+//         target_devices,
+//         num_host_mem_ch_per_mmio_device,
+//         false,
+//         true,
+//         true,
+//         simulated_harvesting_masks);
+//     auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
 //     ASSERT_EQ(device.using_harvested_soc_descriptors(), true) << "Expected Driver to have performed harvesting";
 
-//     for(const auto& chip : sdesc_per_chip) {
-//         ASSERT_EQ(chip.second.workers.size(), 48) << "Expected SOC descriptor with harvesting to have 48 workers for
-//         chip" << chip.first;
+//     for (const auto& chip : sdesc_per_chip) {
+//         ASSERT_EQ(chip.second.workers.size(), 48)
+//             << "Expected SOC descriptor with harvesting to have 48 workers for chip" << chip.first;
 //     }
-//     ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(0), 30) << "Expected first chip to have harvesting
-//     mask of 30"; ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(1), 60) << "Expected second chip to
-//     have harvesting mask of 60";
+//     ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(0), 30)
+//         << "Expected first chip to have harvesting mask of 30";
+//     ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(1), 60)
+//         << "Expected second chip to have harvesting mask of 60";
 // }
 
 // TEST(SiliconDriverWH, CustomSocDesc) {
@@ -135,8 +143,8 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 30}, {1, 60}};
 //     {
 //         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
-//         tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path()); if
-//         (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
+//             tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
+//         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
 //             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
 //             system";
 //         }
@@ -144,28 +152,33 @@ TEST(SiliconDriverBH, CreateDestroy) {
 
 //     uint32_t num_host_mem_ch_per_mmio_device = 1;
 //     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
-//     Cluster device = Cluster("./tests/soc_descs/wormhole_b0_1x1.yaml",
-//     tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false,
-//     true, false, simulated_harvesting_masks); auto sdesc_per_chip = device.get_virtual_soc_descriptors();
+//     Cluster device = Cluster(
+//         "./tests/soc_descs/wormhole_b0_1x1.yaml",
+//         tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+//         target_devices,
+//         num_host_mem_ch_per_mmio_device,
+//         false,
+//         true,
+//         false,
+//         simulated_harvesting_masks);
+//     auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
-//     ASSERT_EQ(device.using_harvested_soc_descriptors(), false) << "SOC descriptors should not be modified when
-//     harvesting is disabled"; for(const auto& chip : sdesc_per_chip) {
+//     ASSERT_EQ(device.using_harvested_soc_descriptors(), false)
+//         << "SOC descriptors should not be modified when harvesting is disabled";
+//     for (const auto& chip : sdesc_per_chip) {
 //         ASSERT_EQ(chip.second.workers.size(), 1) << "Expected 1x1 SOC descriptor to be unmodified by driver";
 //     }
 // }
 
 // TEST(SiliconDriverWH, HarvestingRuntime) {
-
-//     auto get_static_tlb_index_callback = [] (tt_xy_pair target) {
-//         return get_static_tlb_index(target);
-//     };
+//     auto get_static_tlb_index_callback = [](tt_xy_pair target) { return get_static_tlb_index(target); };
 
 //     std::set<chip_id_t> target_devices = {0, 1};
 //     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 30}, {1, 60}};
 //     {
 //         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
-//         tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path()); if
-//         (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
+//             tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
+//         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
 //             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
 //             system";
 //         }
@@ -173,19 +186,26 @@ TEST(SiliconDriverBH, CreateDestroy) {
 
 //     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-//     Cluster device = Cluster("./tests/soc_descs/wormhole_b0_8x10.yaml",
-//     tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false,
-//     true, true, simulated_harvesting_masks); set_params_for_remote_txn(device); auto mmio_devices =
-//     device.get_target_mmio_device_ids();
+//     Cluster device = Cluster(
+//         "./tests/soc_descs/wormhole_b0_8x10.yaml",
+//         tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+//         target_devices,
+//         num_host_mem_ch_per_mmio_device,
+//         false,
+//         true,
+//         true,
+//         simulated_harvesting_masks);
+//     set_params_for_remote_txn(device);
+//     auto mmio_devices = device.get_target_mmio_device_ids();
 
-//     for(int i = 0; i < target_devices.size(); i++) {
+//     for (int i = 0; i < target_devices.size(); i++) {
 //         // Iterate over MMIO devices and only setup static TLBs for worker cores
-//         if(std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
+//         if (std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
 //             auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-//             for(auto& core : sdesc.workers) {
+//             for (auto& core : sdesc.workers) {
 //                 // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
-//                 device.configure_tlb(i, core, get_static_tlb_index_callback(core),
-//                 l1_mem::address_map::NCRISC_FIRMWARE_BASE);
+//                 device.configure_tlb(
+//                     i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
 //             }
 //         }
 //     }
@@ -200,32 +220,57 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //     std::vector<uint32_t> readback_vec = {};
 //     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-//     for(int i = 0; i < target_devices.size(); i++) {
+//     for (int i = 0; i < target_devices.size(); i++) {
 //         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
 //         std::uint32_t dynamic_write_address = 0x40000000;
-//         for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped
-//         addresses
-//             for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-//                 device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t),
-//                 tt_cxy_pair(i, core), address, ""); device.write_to_device(vector_to_write.data(),
-//                 vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), dynamic_write_address,
-//                 "SMALL_READ_WRITE_TLB"); device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over
-//                 ethernet were commited
+//         for (int loop = 0; loop < 100;
+//              loop++) {  // Write to each core a 100 times at different statically mapped addresses
+//             for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+//                 device.write_to_device(
+//                     vector_to_write.data(),
+//                     vector_to_write.size() * sizeof(std::uint32_t),
+//                     tt_cxy_pair(i, core),
+//                     address,
+//                     "");
+//                 device.write_to_device(
+//                     vector_to_write.data(),
+//                     vector_to_write.size() * sizeof(std::uint32_t),
+//                     tt_cxy_pair(i, core),
+//                     dynamic_write_address,
+//                     "SMALL_READ_WRITE_TLB");
+//                 device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 
 //                 test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "");
-//                 test_utils::read_data_from_device(device, dynamic_readback_vec, tt_cxy_pair(i, core),
-//                 dynamic_write_address, 40, "SMALL_READ_WRITE_TLB"); ASSERT_EQ(vector_to_write, readback_vec) <<
-//                 "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
-//                 ASSERT_EQ(vector_to_write, dynamic_readback_vec) << "Vector read back from core " << core.x << "-" <<
-//                 core.y << "does not match what was written"; device.wait_for_non_mmio_flush();
+//                 test_utils::read_data_from_device(
+//                     device,
+//                     dynamic_readback_vec,
+//                     tt_cxy_pair(i, core),
+//                     dynamic_write_address,
+//                     40,
+//                     "SMALL_READ_WRITE_TLB");
+//                 ASSERT_EQ(vector_to_write, readback_vec)
+//                     << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+//                 ASSERT_EQ(vector_to_write, dynamic_readback_vec)
+//                     << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+//                 device.wait_for_non_mmio_flush();
 
-//                 device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core),
-//                 dynamic_write_address, "SMALL_READ_WRITE_TLB"); // Clear any written data
-//                 device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core),
-//                 address, ""); // Clear any written data device.wait_for_non_mmio_flush(); readback_vec = {};
+//                 device.write_to_device(
+//                     zeros.data(),
+//                     zeros.size() * sizeof(std::uint32_t),
+//                     tt_cxy_pair(i, core),
+//                     dynamic_write_address,
+//                     "SMALL_READ_WRITE_TLB");  // Clear any written data
+//                 device.write_to_device(
+//                     zeros.data(),
+//                     zeros.size() * sizeof(std::uint32_t),
+//                     tt_cxy_pair(i, core),
+//                     address,
+//                     "");  // Clear any written data
+//                 device.wait_for_non_mmio_flush();
+//                 readback_vec = {};
 //                 dynamic_readback_vec = {};
 //             }
-//             address += 0x20; // Increment by uint32_t size for each write
+//             address += 0x20;  // Increment by uint32_t size for each write
 //             dynamic_write_address += 0x20;
 //         }
 //     }

--- a/tests/emulation/test_emulation_device.cpp
+++ b/tests/emulation/test_emulation_device.cpp
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "gtest/gtest.h"
-#include "device/tt_soc_descriptor.h"
 #include "device/cluster.h"
 #include "device/tt_emulation_device.h"
+#include "device/tt_soc_descriptor.h"
+#include "gtest/gtest.h"
 
 // DEPRECATED TEST SUITE !!!
 
@@ -22,7 +22,7 @@ TEST(EmulationDeviceGS, BasicEmuTest) {
     uint64_t l1_addr = 0x1000;
     std::vector<uint32_t> wdata(size);
     std::vector<uint32_t> rdata(size);
-    
+
     try {
         device.start_device(default_params);
 
@@ -31,13 +31,23 @@ TEST(EmulationDeviceGS, BasicEmuTest) {
         }
         device.write_to_device(wdata.data(), wdata.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), l1_addr, "l1");
         test_utils::read_data_from_device(device, rdata, tt_cxy_pair(0, core), l1_addr, size, "l1");
-        ASSERT_EQ(wdata, rdata) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+        ASSERT_EQ(wdata, rdata) << "Vector read back from core " << core.x << "-" << core.y
+                                << "does not match what was written";
 
         device.deassert_risc_reset();
-        device.write_to_device(wdata.data(), wdata.size() * sizeof(std::uint32_t), tt_cxy_pair(0, tt_xy_pair(phys_x, phys_y)), l1_addr, "l1");
+        device.write_to_device(
+            wdata.data(),
+            wdata.size() * sizeof(std::uint32_t),
+            tt_cxy_pair(0, tt_xy_pair(phys_x, phys_y)),
+            l1_addr,
+            "l1");
         device.assert_risc_reset();
-        device.write_to_device(wdata.data(), wdata.size() * sizeof(std::uint32_t), tt_cxy_pair(0, tt_xy_pair(phys_x, phys_y)), l1_addr, "l1");
-
+        device.write_to_device(
+            wdata.data(),
+            wdata.size() * sizeof(std::uint32_t),
+            tt_cxy_pair(0, tt_xy_pair(phys_x, phys_y)),
+            l1_addr,
+            "l1");
 
     } catch (const std::exception &e) {
         std::cout << "Error: " << e.what() << std::endl;

--- a/tests/galaxy/test_galaxy_common.cpp
+++ b/tests/galaxy/test_galaxy_common.cpp
@@ -10,9 +10,18 @@ void move_data(
     Cluster& device, tt_multichip_core_addr sender_core, tt_multichip_core_addr receiver_core, uint32_t size) {
     std::vector<uint32_t> readback_vec = {};
     test_utils::read_data_from_device(
-        device, readback_vec, tt_cxy_pair(sender_core.chip, sender_core.core), sender_core.addr, size, "SMALL_READ_WRITE_TLB");
+        device,
+        readback_vec,
+        tt_cxy_pair(sender_core.chip, sender_core.core),
+        sender_core.addr,
+        size,
+        "SMALL_READ_WRITE_TLB");
     device.write_to_device(
-        readback_vec.data(), readback_vec.size() * sizeof(std::uint32_t), tt_cxy_pair(receiver_core.chip, receiver_core.core), receiver_core.addr, "SMALL_READ_WRITE_TLB");
+        readback_vec.data(),
+        readback_vec.size() * sizeof(std::uint32_t),
+        tt_cxy_pair(receiver_core.chip, receiver_core.core),
+        receiver_core.addr,
+        "SMALL_READ_WRITE_TLB");
     device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 
     return;
@@ -25,7 +34,12 @@ void broadcast_data(
     uint32_t size) {
     std::vector<uint32_t> readback_vec = {};
     test_utils::read_data_from_device(
-        device, readback_vec, tt_cxy_pair(sender_core.chip, sender_core.core), sender_core.addr, size, "SMALL_READ_WRITE_TLB");
+        device,
+        readback_vec,
+        tt_cxy_pair(sender_core.chip, sender_core.core),
+        sender_core.addr,
+        size,
+        "SMALL_READ_WRITE_TLB");
     for (const auto& receiver_core : receiver_cores) {
         device.write_to_device(
             readback_vec.data(),

--- a/tests/galaxy/test_galaxy_common.h
+++ b/tests/galaxy/test_galaxy_common.h
@@ -4,18 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 #pragma once
 
 #include <set>
+#include <sstream>
 #include <string>
 #include <tuple>
 #include <vector>
-#include <sstream>
 
 #include "device/cluster.h"
 #include "device/tt_xy_pair.h"
-
 #include "fmt/core.h"
 
 // static const std::string SOC_DESC_PATH = "./tests/soc_descs/wormhole_b0_8x10.yaml";
@@ -24,14 +22,14 @@ using namespace tt::umd;
 
 struct tt_multichip_core_addr {
     tt_multichip_core_addr() : core{}, chip{}, addr{} {}
+
     tt_multichip_core_addr(chip_id_t chip, tt_xy_pair core, std::uint64_t addr) : core(core), chip(chip), addr(addr) {}
 
     tt_xy_pair core;
     chip_id_t chip;
     std::uint64_t addr;
-    std::string str() const {
-        return fmt::format("(chip={},x={},y={},addr=0x{:x})", chip, core.x, core.y, addr);
-    }
+
+    std::string str() const { return fmt::format("(chip={},x={},y={},addr=0x{:x})", chip, core.x, core.y, addr); }
 };
 
 // SIMPLE DATAMOVEMENT API BASED ON UMD

--- a/tests/galaxy/test_umd_concurrent_threads.cpp
+++ b/tests/galaxy/test_umd_concurrent_threads.cpp
@@ -2,22 +2,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <filesystem>
 #include <numeric>
 #include <thread>
-#include <filesystem>
 
-#include "gtest/gtest.h"
-#include "common/logger.hpp"
-#include "tt_cluster_descriptor.h"
 #include "cluster.h"
+#include "common/logger.hpp"
 #include "eth_interface.h"
+#include "gtest/gtest.h"
 #include "host_mem_address_map.h"
 #include "l1_address_map.h"
-
 #include "test_galaxy_common.h"
-#include "tests/wormhole/test_wh_common.h"
-#include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/test_utils/device_test_utils.hpp"
+#include "tests/test_utils/generate_cluster_desc.hpp"
+#include "tests/wormhole/test_wh_common.h"
+#include "tt_cluster_descriptor.h"
 
 static const std::string SOC_DESC_PATH = "tests/soc_descs/wormhole_b0_8x10.yaml";
 
@@ -52,7 +51,12 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
     Cluster device = Cluster(
-        test_utils::GetAbsPath(SOC_DESC_PATH), cluster_desc_path, all_devices, num_host_mem_ch_per_mmio_device, false, true);
+        test_utils::GetAbsPath(SOC_DESC_PATH),
+        cluster_desc_path,
+        all_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
@@ -70,7 +74,12 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (const auto& chip : target_devices_th1) {
             for (auto& core : sdesc_per_chip.at(chip).workers) {
-                device.write_to_device(vector_to_write_th1.data(), vector_to_write_th1.size() * sizeof(std::uint32_t), tt_cxy_pair(chip, core), address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(
+                    vector_to_write_th1.data(),
+                    vector_to_write_th1.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(chip, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
             }
         }
         device.wait_for_non_mmio_flush();
@@ -91,7 +100,12 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (const auto& chip : target_devices_th2) {
             for (auto& core : sdesc_per_chip.at(chip).workers) {
-                device.write_to_device(vector_to_write_th2.data(), vector_to_write_th2.size() * sizeof(std::uint32_t), tt_cxy_pair(chip, core), address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(
+                    vector_to_write_th2.data(),
+                    vector_to_write_th2.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(chip, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
             }
         }
         device.wait_for_non_mmio_flush();
@@ -140,7 +154,12 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
     Cluster device = Cluster(
-        test_utils::GetAbsPath(SOC_DESC_PATH), cluster_desc_path, all_devices, num_host_mem_ch_per_mmio_device, false, true);
+        test_utils::GetAbsPath(SOC_DESC_PATH),
+        cluster_desc_path,
+        all_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
@@ -162,7 +181,12 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
         std::uint32_t address = 0x4000000;
         for (const auto& chip : target_devices_th1) {
             for (auto& core : dram_cores) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(chip, core), address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(chip, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
             }
         }
         device.wait_for_non_mmio_flush();
@@ -182,7 +206,12 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
         std::uint32_t address = 0x5000000;
         for (const auto& chip : target_devices_th2) {
             for (auto& core : sdesc_per_chip.at(chip).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(chip, core), address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(chip, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
             }
         }
         device.wait_for_non_mmio_flush();
@@ -217,7 +246,12 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
     Cluster device = Cluster(
-        test_utils::GetAbsPath(SOC_DESC_PATH), cluster_desc_path, target_devices, num_host_mem_ch_per_mmio_device, false, true);
+        test_utils::GetAbsPath(SOC_DESC_PATH),
+        cluster_desc_path,
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
@@ -239,7 +273,12 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
         chip_id_t mmio_chip = cluster_desc->get_chips_with_mmio().begin()->first;
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = 0x0;
-        device.write_to_device(large_vector.data(), large_vector.size() * sizeof(std::uint32_t), tt_cxy_pair(mmio_chip, tt_xy_pair(0, 0)), address, "SMALL_READ_WRITE_TLB");
+        device.write_to_device(
+            large_vector.data(),
+            large_vector.size() * sizeof(std::uint32_t),
+            tt_cxy_pair(mmio_chip, tt_xy_pair(0, 0)),
+            address,
+            "SMALL_READ_WRITE_TLB");
         test_utils::read_data_from_device(
             device,
             readback_vec,
@@ -257,14 +296,24 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (const auto& chip : target_devices) {
             for (auto& core : sdesc_per_chip.at(chip).workers) {
-                device.write_to_device(small_vector.data(), small_vector.size() * sizeof(std::uint32_t), tt_cxy_pair(chip, core), address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(
+                    small_vector.data(),
+                    small_vector.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(chip, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
             }
         }
         device.wait_for_non_mmio_flush();
         for (const auto& chip : target_devices) {
             for (auto& core : sdesc_per_chip.at(chip).workers) {
                 test_utils::read_data_from_device(
-                    device, readback_vec, tt_cxy_pair(chip, core), address, small_vector.size() * 4, "SMALL_READ_WRITE_TLB");
+                    device,
+                    readback_vec,
+                    tt_cxy_pair(chip, core),
+                    address,
+                    small_vector.size() * 4,
+                    "SMALL_READ_WRITE_TLB");
                 EXPECT_EQ(small_vector, readback_vec)
                     << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 readback_vec = {};

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -2,21 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <numeric>
 #include <filesystem>
+#include <numeric>
 
-#include "gtest/gtest.h"
-#include "common/logger.hpp"
-#include "tt_cluster_descriptor.h"
 #include "cluster.h"
+#include "common/logger.hpp"
 #include "eth_interface.h"
+#include "gtest/gtest.h"
 #include "host_mem_address_map.h"
 #include "l1_address_map.h"
-
 #include "test_galaxy_common.h"
-#include "tests/wormhole/test_wh_common.h"
-#include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/test_utils/device_test_utils.hpp"
+#include "tests/test_utils/generate_cluster_desc.hpp"
+#include "tests/wormhole/test_wh_common.h"
+#include "tt_cluster_descriptor.h"
 
 static const std::string SOC_DESC_PATH = "tests/soc_descs/wormhole_b0_8x10.yaml";
 
@@ -32,7 +31,12 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
     Cluster device = Cluster(
-        test_utils::GetAbsPath(SOC_DESC_PATH), cluster_desc_path, target_devices, num_host_mem_ch_per_mmio_device, false, true);
+        test_utils::GetAbsPath(SOC_DESC_PATH),
+        cluster_desc_path,
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
@@ -64,7 +68,12 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
             for (const auto& core : target_cores) {
                 tt_cxy_pair target_core = tt_cxy_pair(chip, core);
                 auto start = std::chrono::high_resolution_clock::now();
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), target_core, address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    target_core,
+                    address,
+                    "SMALL_READ_WRITE_TLB");
                 device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
                 auto end = std::chrono::high_resolution_clock::now();
                 auto duration = double(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
@@ -72,7 +81,8 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
                 // std::cout << "  chip " << chip << " core " << target_core.str() << " " << duration << std::endl;
 
                 start = std::chrono::high_resolution_clock::now();
-                test_utils::read_data_from_device(device, readback_vec, target_core, address, write_size, "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(
+                    device, readback_vec, target_core, address, write_size, "SMALL_READ_WRITE_TLB");
                 end = std::chrono::high_resolution_clock::now();
                 duration = double(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
                 // std::cout << " read chip " << chip << " core " << target_core.str()<< " " << duration << std::endl;
@@ -145,7 +155,12 @@ void run_data_mover_test(
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
     Cluster device = Cluster(
-        test_utils::GetAbsPath(SOC_DESC_PATH), cluster_desc_path, target_devices, num_host_mem_ch_per_mmio_device, false, true);
+        test_utils::GetAbsPath(SOC_DESC_PATH),
+        cluster_desc_path,
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
 
@@ -162,7 +177,11 @@ void run_data_mover_test(
     std::vector<float> send_bw;
     // Set up data in sender core
     device.write_to_device(
-        vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(sender_core.chip, sender_core.core), sender_core.addr, "SMALL_READ_WRITE_TLB");
+        vector_to_write.data(),
+        vector_to_write.size() * sizeof(std::uint32_t),
+        tt_cxy_pair(sender_core.chip, sender_core.core),
+        sender_core.addr,
+        "SMALL_READ_WRITE_TLB");
     device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 
     // Send data from sender core to receiver core
@@ -261,7 +280,12 @@ void run_data_broadcast_test(
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
     Cluster device = Cluster(
-        test_utils::GetAbsPath(SOC_DESC_PATH), cluster_desc_path, target_devices, num_host_mem_ch_per_mmio_device, false, true);
+        test_utils::GetAbsPath(SOC_DESC_PATH),
+        cluster_desc_path,
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
 
@@ -278,7 +302,11 @@ void run_data_broadcast_test(
     std::vector<float> send_bw;
     //  Set up data in sender core
     device.write_to_device(
-        vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(sender_core.chip, sender_core.core), sender_core.addr, "SMALL_READ_WRITE_TLB");
+        vector_to_write.data(),
+        vector_to_write.size() * sizeof(std::uint32_t),
+        tt_cxy_pair(sender_core.chip, sender_core.core),
+        sender_core.addr,
+        "SMALL_READ_WRITE_TLB");
     device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 
     // Send data from sender core to receiver core

--- a/tests/galaxy/test_umd_remote_api_stability.cpp
+++ b/tests/galaxy/test_umd_remote_api_stability.cpp
@@ -64,19 +64,19 @@ TEST_F(WormholeGalaxyStabilityTestFixture, MixedRemoteTransfers) {
             *this->device,
             100000 * scale_number_of_tests,
             seed,
-
             transfer_type_weights_t{.write = 0.40, .read = 0.4},
-
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 30000),                           // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            // address generator distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),
+            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 30000),
+            // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<int>(2, 4),
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 30000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 30000),
+            // Set to true if you want to emit the command history code to command line
+            false,
             &command_history);
     } catch (...) {
         print_command_history_executable_code(command_history);
@@ -94,19 +94,19 @@ TEST_F(WormholeGalaxyStabilityTestFixture, DISABLED_MultithreadedMixedRemoteTran
             *device,
             50000 * scale_number_of_tests,
             0,
-
             transfer_type_weights_t{.write = 0.50, .read = 0.50},
-
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 30000),                           // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            // address generator distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),
+            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 30000),
+            // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<int>(2, 4),
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 30000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 30000),
+            // Set to true if you want to emit the command history code to command line
+            false,
             nullptr);
     });
     std::thread t2([&]() {
@@ -114,19 +114,19 @@ TEST_F(WormholeGalaxyStabilityTestFixture, DISABLED_MultithreadedMixedRemoteTran
             *device,
             50000 * scale_number_of_tests,
             100,
-
             transfer_type_weights_t{.write = 0.25, .read = 0.50},
-
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 30000),                           // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            // address generator distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),
+            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 30000),
+            // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<int>(2, 4),
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 30000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // READ_SIZE_GENERATOR_T const& read_size_distribution,
+            // Set to true if you want to emit the command history code to command line
+            std::uniform_int_distribution<transfer_size_t>(0x4, 30000),
+            false,
             nullptr);
     });
     std::thread t3([&]() {
@@ -134,19 +134,19 @@ TEST_F(WormholeGalaxyStabilityTestFixture, DISABLED_MultithreadedMixedRemoteTran
             *device,
             50000 * scale_number_of_tests,
             23,
-
             transfer_type_weights_t{.write = 0.5, .read = 0.25},
-
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 30000),                           // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            // address generator distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),
+            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 30000),
+            // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<int>(2, 4),
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 30000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // READ_SIZE_GENERATOR_T const& read_size_distribution,
+            // Set to true if you want to emit the command history code to command line
+            std::uniform_int_distribution<transfer_size_t>(0x4, 30000),
+            false,
             nullptr);
     });
     std::thread t4([&]() {
@@ -154,19 +154,19 @@ TEST_F(WormholeGalaxyStabilityTestFixture, DISABLED_MultithreadedMixedRemoteTran
             *device,
             100000 * scale_number_of_tests,
             99,
-
             transfer_type_weights_t{.write = 0.1, .read = 0.1},
-
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            // address generator distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),
+            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<int>(2, 4),
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // Set to true if you want to emit the command history code to command line
+            false,
             nullptr);
     });
 

--- a/tests/galaxy/test_umd_remote_api_stability.cpp
+++ b/tests/galaxy/test_umd_remote_api_stability.cpp
@@ -7,173 +7,167 @@
 #include <random>
 #include <thread>
 
-#include "tt_cluster_descriptor.h"
 #include "cluster.h"
-
 #include "common/logger.hpp"
 #include "eth_interface.h"
 #include "filesystem"
 #include "gtest/gtest.h"
 #include "host_mem_address_map.h"
 #include "l1_address_map.h"
-#include "tt_soc_descriptor.h"
-
-#include "tests/test_utils/stimulus_generators.hpp"
-#include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/galaxy/test_galaxy_common.h"
+#include "tests/test_utils/generate_cluster_desc.hpp"
+#include "tests/test_utils/stimulus_generators.hpp"
 #include "tests/wormhole/test_wh_common.h"
+#include "tt_cluster_descriptor.h"
+#include "tt_soc_descriptor.h"
 
 namespace tt::umd::test::utils {
 
-
 class WormholeGalaxyStabilityTestFixture : public WormholeTestFixture {
- private:
-  static int detected_num_chips;
-  static bool skip_tests;
+private:
+    static int detected_num_chips;
+    static bool skip_tests;
 
- protected:
+protected:
+    static constexpr int EXPECTED_MIN_CHIPS = 32;
+    static uint32_t scale_number_of_tests;
 
-  static constexpr int EXPECTED_MIN_CHIPS = 32;
-  static uint32_t scale_number_of_tests;
-
-  static void SetUpTestSuite() {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
-    detected_num_chips = cluster_desc->get_number_of_chips();
-    if (detected_num_chips < EXPECTED_MIN_CHIPS) {
-        skip_tests = true;
+    static void SetUpTestSuite() {
+        std::unique_ptr<tt_ClusterDescriptor> cluster_desc =
+            tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
+        detected_num_chips = cluster_desc->get_number_of_chips();
+        if (detected_num_chips < EXPECTED_MIN_CHIPS) {
+            skip_tests = true;
+        }
+        if (char const* scale_number_of_tests_env = std::getenv("SCALE_NUMBER_OF_TESTS")) {
+            scale_number_of_tests = std::atoi(scale_number_of_tests_env);
+        }
     }
-    if(char const* scale_number_of_tests_env = std::getenv("SCALE_NUMBER_OF_TESTS")) {
-        scale_number_of_tests = std::atoi(scale_number_of_tests_env);
-    }
-  }
 
-  virtual int get_detected_num_chips() {
-    return detected_num_chips;
-  }
+    virtual int get_detected_num_chips() { return detected_num_chips; }
 
-  virtual bool is_test_skipped() {
-    return skip_tests;
-  }
-
+    virtual bool is_test_skipped() { return skip_tests; }
 };
-
 
 int WormholeGalaxyStabilityTestFixture::detected_num_chips = -1;
 bool WormholeGalaxyStabilityTestFixture::skip_tests = false;
 uint32_t WormholeGalaxyStabilityTestFixture::scale_number_of_tests = 1;
 
-
 TEST_F(WormholeGalaxyStabilityTestFixture, MixedRemoteTransfers) {
     int seed = 0;
-    
+
     assert(device != nullptr);
-    log_info(LogSiliconDriver,"Started MixedRemoteTransfers");
+    log_info(LogSiliconDriver, "Started MixedRemoteTransfers");
     std::vector<remote_transfer_sample_t> command_history;
     try {
         RunMixedTransfersUniformDistributions(
-            *this->device, 
+            *this->device,
             100000 * scale_number_of_tests,
             seed,
 
             transfer_type_weights_t{.write = 0.40, .read = 0.4},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 30000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 30000),                           // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 30000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 30000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history
-        );
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history);
     } catch (...) {
         print_command_history_executable_code(command_history);
     }
-
 }
 
 TEST_F(WormholeGalaxyStabilityTestFixture, DISABLED_MultithreadedMixedRemoteTransfersMediumSmall) {
     int seed = 0;
 
-    log_info(LogSiliconDriver,"Started MultithreadedMixedRemoteTransfersMediumSmall");
+    log_info(LogSiliconDriver, "Started MultithreadedMixedRemoteTransfersMediumSmall");
 
     assert(device != nullptr);
-    std::thread t1([&](){
+    std::thread t1([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             50000 * scale_number_of_tests,
             0,
 
             transfer_type_weights_t{.write = 0.50, .read = 0.50},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 30000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 30000),                           // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 30000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 30000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            nullptr
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            nullptr);
     });
-    std::thread t2([&](){
+    std::thread t2([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             50000 * scale_number_of_tests,
             100,
 
             transfer_type_weights_t{.write = 0.25, .read = 0.50},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 30000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 30000),                           // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 30000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 30000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            nullptr
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            nullptr);
     });
-    std::thread t3([&](){
+    std::thread t3([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             50000 * scale_number_of_tests,
             23,
 
             transfer_type_weights_t{.write = 0.5, .read = 0.25},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 30000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 30000),                           // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 30000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 30000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            nullptr
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            nullptr);
     });
-    std::thread t4([&](){
+    std::thread t4([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             99,
 
             transfer_type_weights_t{.write = 0.1, .read = 0.1},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            nullptr
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            nullptr);
     });
 
     t1.join();
@@ -182,4 +176,4 @@ TEST_F(WormholeGalaxyStabilityTestFixture, DISABLED_MultithreadedMixedRemoteTran
     t4.join();
 }
 
-} // namespace tt::umd::test::utils
+}  // namespace tt::umd::test::utils

--- a/tests/grayskull/test_silicon_driver.cpp
+++ b/tests/grayskull/test_silicon_driver.cpp
@@ -4,14 +4,14 @@
 
 #include <thread>
 
-#include "gtest/gtest.h"
 #include "cluster.h"
-#include "device/tt_soc_descriptor.h"
 #include "device/tt_cluster_descriptor.h"
+#include "device/tt_soc_descriptor.h"
 #include "device/wormhole/wormhole_implementation.h"
+#include "gtest/gtest.h"
 #include "l1_address_map.h"
-#include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/test_utils/device_test_utils.hpp"
+#include "tests/test_utils/generate_cluster_desc.hpp"
 
 using namespace tt::umd;
 
@@ -19,7 +19,7 @@ TEST(SiliconDriverGS, CreateDestroySequential) {
     std::set<chip_id_t> target_devices = {0};
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     tt_device_params default_params;
-    for(int i = 0; i < 100; i++) {
+    for (int i = 0; i < 100; i++) {
         Cluster device = Cluster(num_host_mem_ch_per_mmio_device, false, true);
         device.start_device(default_params);
         device.deassert_risc_reset();
@@ -33,13 +33,13 @@ TEST(SiliconDriverGS, CreateMultipleInstance) {
     tt_device_params default_params;
     default_params.init_device = false;
     std::unordered_map<int, Cluster*> concurrent_devices = {};
-    for(int i = 0; i < 100; i++) {
+    for (int i = 0; i < 100; i++) {
         concurrent_devices.insert({i, new Cluster(num_host_mem_ch_per_mmio_device, false, true)});
-        concurrent_devices.at(i) -> start_device(default_params);
+        concurrent_devices.at(i)->start_device(default_params);
     }
 
-    for(auto& device : concurrent_devices) {
-        device.second -> close_device();
+    for (auto& device : concurrent_devices) {
+        device.second->close_device();
         delete device.second;
     }
 }
@@ -52,11 +52,15 @@ TEST(SiliconDriverGS, Harvesting) {
     auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     ASSERT_EQ(device.using_harvested_soc_descriptors(), true) << "Expected Driver to have performed harvesting";
-    for(const auto& chip : sdesc_per_chip) {
-        ASSERT_LE(chip.second.workers.size(), 96) << "Expected SOC descriptor with harvesting to have less than or equal to 96 workers for chip " << chip.first;
+    for (const auto& chip : sdesc_per_chip) {
+        ASSERT_LE(chip.second.workers.size(), 96)
+            << "Expected SOC descriptor with harvesting to have less than or equal to 96 workers for chip "
+            << chip.first;
     }
-    ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(0) & simulated_harvesting_masks[0], 6) << "Expected first chip to include simulated harvesting mask of 6";
-    // ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(1), 12) << "Expected second chip to have harvesting mask of 12";
+    ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(0) & simulated_harvesting_masks[0], 6)
+        << "Expected first chip to include simulated harvesting mask of 6";
+    // ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(1), 12) << "Expected second chip to have
+    // harvesting mask of 12";
     device.close_device();
 }
 
@@ -65,16 +69,25 @@ TEST(SiliconDriverGS, CustomSocDesc) {
     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 6}, {1, 12}};
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
-    Cluster device = Cluster(test_utils::GetAbsPath("./tests/soc_descs/grayskull_1x1_arch.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, false, simulated_harvesting_masks);
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("./tests/soc_descs/grayskull_1x1_arch.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        false,
+        simulated_harvesting_masks);
     auto sdesc_per_chip = device.get_virtual_soc_descriptors();
-    ASSERT_EQ(device.using_harvested_soc_descriptors(), false) << "SOC descriptors should not be modified when harvesting is disabled";
-    for(const auto& chip : sdesc_per_chip) {
+    ASSERT_EQ(device.using_harvested_soc_descriptors(), false)
+        << "SOC descriptors should not be modified when harvesting is disabled";
+    for (const auto& chip : sdesc_per_chip) {
         ASSERT_EQ(chip.second.workers.size(), 1) << "Expected 1x1 SOC descriptor to be unmodified by driver";
     }
 }
 
 TEST(SiliconDriverGS, HarvestingRuntime) {
-    auto get_static_tlb_index = [] (tt_xy_pair target) {
+    auto get_static_tlb_index = [](tt_xy_pair target) {
         int flat_index = target.y * tt::umd::wormhole::GRID_SIZE_X + target.x;
         if (flat_index == 0) {
             return -1;
@@ -87,10 +100,10 @@ TEST(SiliconDriverGS, HarvestingRuntime) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     Cluster device = Cluster(num_host_mem_ch_per_mmio_device, false, true, true, simulated_harvesting_masks);
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for functional worker cores
         auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-        for(auto& core : sdesc.workers) {
+        for (auto& core : sdesc.workers) {
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
             device.configure_tlb(i, core, get_static_tlb_index(core), l1_mem::address_map::DATA_BUFFER_SPACE_BASE);
         }
@@ -108,29 +121,59 @@ TEST(SiliconDriverGS, HarvestingRuntime) {
     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     float timeout_in_seconds = 10;
     // Check functionality of Static TLBs by reading adn writing from statically mapped address space
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         std::uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
         std::uint32_t dynamic_write_address = 0x30000000;
-        for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
-            for(auto& core :  device.get_virtual_soc_descriptors().at(i).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "");
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), dynamic_write_address, "SMALL_READ_WRITE_TLB");
+        for (int loop = 0; loop < 100;
+             loop++) {  // Write to each core a 100 times at different statically mapped addresses
+            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "");
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    dynamic_write_address,
+                    "SMALL_READ_WRITE_TLB");
                 auto start_time = std::chrono::high_resolution_clock::now();
-                while(!(vector_to_write == readback_vec)) {
-                    float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start_time).count();
-                    if(wait_duration > timeout_in_seconds) {
+                while (!(vector_to_write == readback_vec)) {
+                    float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(
+                                              std::chrono::high_resolution_clock::now() - start_time)
+                                              .count();
+                    if (wait_duration > timeout_in_seconds) {
                         break;
                     }
                     test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "");
-                    test_utils::read_data_from_device(device, dynamic_readback_vec, tt_cxy_pair(i, core), dynamic_write_address, 40, "SMALL_READ_WRITE_TLB");
+                    test_utils::read_data_from_device(
+                        device,
+                        dynamic_readback_vec,
+                        tt_cxy_pair(i, core),
+                        dynamic_write_address,
+                        40,
+                        "SMALL_READ_WRITE_TLB");
                 }
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB"); // Clear any written data
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), dynamic_write_address, "SMALL_READ_WRITE_TLB"); // Clear any written data
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");  // Clear any written data
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    dynamic_write_address,
+                    "SMALL_READ_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
                 dynamic_readback_vec = {};
             }
-            address += 0x20; // Increment by uint32_t size for each write
+            address += 0x20;  // Increment by uint32_t size for each write
             dynamic_write_address += 0x20;
         }
     }
@@ -138,7 +181,7 @@ TEST(SiliconDriverGS, HarvestingRuntime) {
 }
 
 TEST(SiliconDriverGS, StaticTLB_RW) {
-    auto get_static_tlb_index = [] (tt_xy_pair target) {
+    auto get_static_tlb_index = [](tt_xy_pair target) {
         int flat_index = target.y * tt::umd::wormhole::GRID_SIZE_X + target.x;
         if (flat_index == 0) {
             return -1;
@@ -149,12 +192,13 @@ TEST(SiliconDriverGS, StaticTLB_RW) {
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     Cluster device = Cluster(num_host_mem_ch_per_mmio_device, false, true);
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for worker cores
         auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-        for(auto& core : sdesc.workers) {
+        for (auto& core : sdesc.workers) {
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
-            device.configure_tlb(i, core, get_static_tlb_index(core), l1_mem::address_map::DATA_BUFFER_SPACE_BASE, TLB_DATA::Posted);
+            device.configure_tlb(
+                i, core, get_static_tlb_index(core), l1_mem::address_map::DATA_BUFFER_SPACE_BASE, TLB_DATA::Posted);
         }
         device.setup_core_to_tlb_map(i, get_static_tlb_index);
     }
@@ -168,36 +212,52 @@ TEST(SiliconDriverGS, StaticTLB_RW) {
     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     float timeout_in_seconds = 10;
     // Check functionality of Static TLBs by reading adn writing from statically mapped address space
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         std::uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
-        for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
-            for(auto& core :  device.get_virtual_soc_descriptors().at(i).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "");
+        for (int loop = 0; loop < 100;
+             loop++) {  // Write to each core a 100 times at different statically mapped addresses
+            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "");
                 auto start_time = std::chrono::high_resolution_clock::now();
-                while(!(vector_to_write == readback_vec)) {
-                    float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start_time).count();
-                    if(wait_duration > timeout_in_seconds) {
+                while (!(vector_to_write == readback_vec)) {
+                    float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(
+                                              std::chrono::high_resolution_clock::now() - start_time)
+                                              .count();
+                    if (wait_duration > timeout_in_seconds) {
                         break;
                     }
                     test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "");
                 }
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB"); // Clear any written data
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
-            address += 0x20; // Increment by uint32_t size for each write
+            address += 0x20;  // Increment by uint32_t size for each write
         }
     }
     device.close_device();
 }
 
 TEST(SiliconDriverGS, DynamicTLB_RW) {
-    // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for each transaction
+    // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for
+    // each transaction
     std::set<chip_id_t> target_devices = {0};
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     Cluster device = Cluster(num_host_mem_ch_per_mmio_device, false, true);
-    device.set_fallback_tlb_ordering_mode("SMALL_READ_WRITE_TLB", TLB_DATA::Posted); // Explicitly test API to set fallback tlb ordering mode
+    device.set_fallback_tlb_ordering_mode(
+        "SMALL_READ_WRITE_TLB", TLB_DATA::Posted);  // Explicitly test API to set fallback tlb ordering mode
     tt_device_params default_params;
     device.start_device(default_params);
     device.deassert_risc_reset();
@@ -207,25 +267,40 @@ TEST(SiliconDriverGS, DynamicTLB_RW) {
     std::vector<uint32_t> readback_vec = {};
     float timeout_in_seconds = 10;
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         std::uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
-        for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
-            for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB");
+        for (int loop = 0; loop < 100;
+             loop++) {  // Write to each core a 100 times at different statically mapped addresses
+            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
                 auto start_time = std::chrono::high_resolution_clock::now();
-                while(!(vector_to_write == readback_vec)) {
-                    float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start_time).count();
-                    if(wait_duration > timeout_in_seconds) {
+                while (!(vector_to_write == readback_vec)) {
+                    float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(
+                                              std::chrono::high_resolution_clock::now() - start_time)
+                                              .count();
+                    if (wait_duration > timeout_in_seconds) {
                         break;
                     }
-                    test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "SMALL_READ_WRITE_TLB");
+                    test_utils::read_data_from_device(
+                        device, readback_vec, tt_cxy_pair(i, core), address, 40, "SMALL_READ_WRITE_TLB");
                 }
 
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB"); // Clear any written data
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
-            address += 0x20; // Increment by uint32_t size for each write
+            address += 0x20;  // Increment by uint32_t size for each write
         }
     }
     device.close_device();
@@ -239,7 +314,7 @@ TEST(SiliconDriverGS, MultiThreadedDevice) {
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     Cluster device = Cluster(num_host_mem_ch_per_mmio_device, false, true);
-    
+
     tt_device_params default_params;
     device.start_device(default_params);
     device.deassert_risc_reset();
@@ -249,18 +324,27 @@ TEST(SiliconDriverGS, MultiThreadedDevice) {
         std::vector<uint32_t> readback_vec = {};
         float timeout_in_seconds = 10;
         std::uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
-        for(int loop = 0; loop < 100; loop++) {
-            for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
+        for (int loop = 0; loop < 100; loop++) {
+            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(0, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
                 auto start_time = std::chrono::high_resolution_clock::now();
-                while(!(vector_to_write == readback_vec)) {
-                    float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start_time).count();
-                    if(wait_duration > timeout_in_seconds) {
+                while (!(vector_to_write == readback_vec)) {
+                    float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(
+                                              std::chrono::high_resolution_clock::now() - start_time)
+                                              .count();
+                    if (wait_duration > timeout_in_seconds) {
                         break;
                     }
-                    test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
+                    test_utils::read_data_from_device(
+                        device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
                 }
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 readback_vec = {};
             }
             address += 0x20;
@@ -272,19 +356,28 @@ TEST(SiliconDriverGS, MultiThreadedDevice) {
         std::vector<uint32_t> readback_vec = {};
         float timeout_in_seconds = 10;
         std::uint32_t address = 0x30000000;
-        for(auto& core_ls : device.get_virtual_soc_descriptors().at(0).dram_cores) {
-            for(int loop = 0; loop < 100; loop++) {
-                for(auto& core : core_ls) {
-                    device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
+        for (auto& core_ls : device.get_virtual_soc_descriptors().at(0).dram_cores) {
+            for (int loop = 0; loop < 100; loop++) {
+                for (auto& core : core_ls) {
+                    device.write_to_device(
+                        vector_to_write.data(),
+                        vector_to_write.size() * sizeof(std::uint32_t),
+                        tt_cxy_pair(0, core),
+                        address,
+                        "SMALL_READ_WRITE_TLB");
                     auto start_time = std::chrono::high_resolution_clock::now();
-                    while(!(vector_to_write == readback_vec)) {
-                        float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start_time).count();
-                        if(wait_duration > timeout_in_seconds) {
+                    while (!(vector_to_write == readback_vec)) {
+                        float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(
+                                                  std::chrono::high_resolution_clock::now() - start_time)
+                                                  .count();
+                        if (wait_duration > timeout_in_seconds) {
                             break;
+                        }
+                        test_utils::read_data_from_device(
+                            device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
                     }
-                    test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
-                }
-                    ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+                    ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y
+                                                             << "does not match what was written";
                     readback_vec = {};
                 }
                 address += 0x20;
@@ -297,14 +390,14 @@ TEST(SiliconDriverGS, MultiThreadedDevice) {
     device.close_device();
 }
 
-TEST(SiliconDriverGS, MultiThreadedMemBar) { // this tests takes ~5 mins to run
-    // Have 2 threads read and write from a single device concurrently
-    // All (fairly large) transactions go through a static TLB.
-    // We want to make sure the memory barrier is thread/process safe.
+TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
+                                              // Have 2 threads read and write from a single device concurrently
+                                              // All (fairly large) transactions go through a static TLB.
+                                              // We want to make sure the memory barrier is thread/process safe.
 
     // Memory barrier flags get sent to address 0 for all channels in this test
 
-     auto get_static_tlb_index = [] (tt_xy_pair target) {
+    auto get_static_tlb_index = [](tt_xy_pair target) {
         int flat_index = target.y * tt::umd::wormhole::GRID_SIZE_X + target.x;
         if (flat_index == 0) {
             return -1;
@@ -317,11 +410,11 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) { // this tests takes ~5 mins to run
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
     Cluster device = Cluster(num_host_mem_ch_per_mmio_device, false, true);
-    
-    for(int i = 0; i < target_devices.size(); i++) {
+
+    for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for functional worker cores
         auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-        for(auto& core : sdesc.workers) {
+        for (auto& core : sdesc.workers) {
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
             device.configure_tlb(i, core, get_static_tlb_index(core), base_addr);
         }
@@ -332,22 +425,28 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) { // this tests takes ~5 mins to run
     device.start_device(default_params);
     device.deassert_risc_reset();
     std::vector<uint32_t> readback_membar_vec = {};
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all workers
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        test_utils::read_data_from_device(
+            device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all workers
         readback_membar_vec = {};
     }
 
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all workers
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        test_utils::read_data_from_device(
+            device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all workers
         readback_membar_vec = {};
     }
 
-    for(int chan = 0; chan <  device.get_virtual_soc_descriptors().at(0).get_num_dram_channels(); chan++) {
+    for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(0).get_num_dram_channels(); chan++) {
         auto core = device.get_virtual_soc_descriptors().at(0).get_core_for_dram_channel(chan, 0);
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all DRAM
+        test_utils::read_data_from_device(
+            device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all DRAM
         readback_membar_vec = {};
     }
     // Launch 2 thread accessing different locations of L1 and using memory barrier between write and read
@@ -356,23 +455,26 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) { // this tests takes ~5 mins to run
     std::vector<uint32_t> vec2(25600);
     std::vector<uint32_t> zeros(25600, 0);
 
-    for(int i = 0; i < vec1.size(); i++) {
+    for (int i = 0; i < vec1.size(); i++) {
         vec1.at(i) = i;
     }
-    for(int i = 0; i < vec2.size(); i++) {
+    for (int i = 0; i < vec2.size(); i++) {
         vec2.at(i) = vec1.size() + i;
     }
 
     std::thread th1 = std::thread([&] {
         std::uint32_t address = base_addr;
-        for(int loop = 0; loop < 100; loop++) {
-            for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        for (int loop = 0; loop < 100; loop++) {
+            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
-                device.write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                device.write_to_device(
+                    vec1.data(), vec1.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 device.l1_membar(0, "", {core});
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 4*vec1.size(), "");
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(0, core), address, 4 * vec1.size(), "");
                 ASSERT_EQ(readback_vec, vec1);
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                device.write_to_device(
+                    zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 readback_vec = {};
             }
         }
@@ -380,14 +482,17 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) { // this tests takes ~5 mins to run
 
     std::thread th2 = std::thread([&] {
         std::uint32_t address = base_addr + vec1.size() * 4;
-        for(int loop = 0; loop < 100; loop++) {
-            for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        for (int loop = 0; loop < 100; loop++) {
+            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
-                device.write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                device.write_to_device(
+                    vec2.data(), vec2.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 device.l1_membar(0, "", {core});
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 4*vec2.size(), "");
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(0, core), address, 4 * vec2.size(), "");
                 ASSERT_EQ(readback_vec, vec2);
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "") ;
+                device.write_to_device(
+                    zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 readback_vec = {};
             }
         }
@@ -396,9 +501,10 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) { // this tests takes ~5 mins to run
     th1.join();
     th2.join();
 
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers end up in correct sate workers
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        test_utils::read_data_from_device(
+            device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(readback_membar_vec.at(0), 187);  // Ensure that memory barriers end up in correct sate workers
         readback_membar_vec = {};
     }
 
@@ -409,14 +515,14 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) { // this tests takes ~5 mins to run
  * Copied from Wormhole unit tests.
  */
 TEST(SiliconDriverGS, SysmemTestWithPcie) {
-    Cluster cluster(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"),
-                    "", // test_utils::GetClusterDescYAML(),
-                    {0},
-                    1,  // one "host memory channel", currently a 1G huge page
-                    false, // skip driver allocs - no (don't skip)
-                    true,  // clean system resources - yes
-                    true); // perform harvesting - yes
-
+    Cluster cluster(
+        test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"),
+        "",  // test_utils::GetClusterDescYAML(),
+        {0},
+        1,      // one "host memory channel", currently a 1G huge page
+        false,  // skip driver allocs - no (don't skip)
+        true,   // clean system resources - yes
+        true);  // perform harvesting - yes
 
     cluster.start_device(tt_device_params{});  // no special parameters
 
@@ -432,7 +538,7 @@ TEST(SiliconDriverGS, SysmemTestWithPcie) {
     // Bad API: how big is the buffer?  How do we know it's big enough?
     // Situation today is that there's a 1G hugepage behind it, although this is
     // unclear from the API and may change in the future.
-    uint8_t *sysmem = (uint8_t*)cluster.host_dma_address(0, 0, 0);
+    uint8_t* sysmem = (uint8_t*)cluster.host_dma_address(0, 0, 0);
     ASSERT_NE(sysmem, nullptr);
 
     uint64_t base_address = cluster.get_pcie_base_addr_from_device(mmio_chip_id);

--- a/tests/microbenchmark/device_fixture.hpp
+++ b/tests/microbenchmark/device_fixture.hpp
@@ -2,26 +2,27 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <iostream>
-#include <fstream>
-#include <cassert>
-#include <random>
 #include <gtest/gtest.h>
 
+#include <cassert>
+#include <fstream>
+#include <iostream>
+#include <random>
+
 #include "cluster.h"
-#include "l1_address_map.h"
 #include "device/tt_soc_descriptor.h"
+#include "l1_address_map.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 
 using tt::umd::Cluster;
 
 class uBenchmarkFixture : public ::testing::Test {
-    protected:
+protected:
     void SetUp() override {
         // get arch name?
         results_csv.open("ubench_results.csv", std::ios_base::app);
 
-        auto get_static_tlb_index = [] (tt_xy_pair target) {
+        auto get_static_tlb_index = [](tt_xy_pair target) {
             int flat_index = target.y * 10 + target.x;  // grid_size_x = 10 for GS/WH ????? something is wrong here
             if (flat_index == 0) {
                 return -1;
@@ -30,12 +31,18 @@ class uBenchmarkFixture : public ::testing::Test {
         };
         std::set<chip_id_t> target_devices = {0};
         uint32_t num_host_mem_ch_per_mmio_device = 1;
-        device = std::make_shared<Cluster>(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), "", target_devices, num_host_mem_ch_per_mmio_device, false, true);
+        device = std::make_shared<Cluster>(
+            test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"),
+            "",
+            target_devices,
+            num_host_mem_ch_per_mmio_device,
+            false,
+            true);
 
-        for(int i = 0; i < target_devices.size(); i++) {
+        for (int i = 0; i < target_devices.size(); i++) {
             // Iterate over devices and only setup static TLBs for functional worker cores
             auto& sdesc = device->get_virtual_soc_descriptors().at(i);
-            for(auto& core : sdesc.workers) {
+            for (auto& core : sdesc.workers) {
                 // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
                 device->configure_tlb(i, core, get_static_tlb_index(core), l1_mem::address_map::DATA_BUFFER_SPACE_BASE);
             }

--- a/tests/microbenchmark/test_rw_tensix.cpp
+++ b/tests/microbenchmark/test_rw_tensix.cpp
@@ -6,11 +6,11 @@
 
 #include <iostream>
 
-#include "nanobench.h"
 #include "device_fixture.hpp"
+#include "nanobench.h"
 #include "tests/test_utils/device_test_utils.hpp"
 
-std::uint32_t generate_random_address(std::uint32_t max, std::uint32_t min=0) {
+std::uint32_t generate_random_address(std::uint32_t max, std::uint32_t min = 0) {
     ankerl::nanobench::Rng gen(80085);
     std::uniform_int_distribution<> dis(min, max);  // between 0 and 1MB
     return dis(gen);
@@ -19,81 +19,119 @@ std::uint32_t generate_random_address(std::uint32_t max, std::uint32_t min=0) {
 TEST_F(uBenchmarkFixture, WriteAllCores32Bytes) {
     std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7};
     std::uint64_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
-    std::uint64_t bad_address = 0x30000000;     // this address is not mapped, should trigger fallback write/read path
+    std::uint64_t bad_address = 0x30000000;  // this address is not mapped, should trigger fallback write/read path
 
     ankerl::nanobench::Bench bench_static;
     ankerl::nanobench::Bench bench_dynamic;
-    for(auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
+    for (auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
         std::stringstream wname;
         wname << "Write to device core (" << core.x << ", " << core.y << ")";
         // Write 32 bytes through static tlbs
-        bench_static.title("Write 32 bytes").unit("writes").minEpochIterations(50).output(nullptr).run(wname.str(), [&] {
-            device->write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
-        });
+        bench_static.title("Write 32 bytes")
+            .unit("writes")
+            .minEpochIterations(50)
+            .output(nullptr)
+            .run(wname.str(), [&] {
+                device->write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(0, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
+            });
         // Write through "fallback/dynamic" tlb
-        bench_dynamic.title("Write 32 bytes fallback").unit("writes").minEpochIterations(50).output(nullptr).run(wname.str(), [&] {
-            device->write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), bad_address, "SMALL_READ_WRITE_TLB");
-        });
+        bench_dynamic.title("Write 32 bytes fallback")
+            .unit("writes")
+            .minEpochIterations(50)
+            .output(nullptr)
+            .run(wname.str(), [&] {
+                device->write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(0, core),
+                    bad_address,
+                    "SMALL_READ_WRITE_TLB");
+            });
         wname.clear();
     }
     bench_static.render(ankerl::nanobench::templates::csv(), results_csv);
     bench_dynamic.render(ankerl::nanobench::templates::csv(), results_csv);
 }
 
-TEST_F(uBenchmarkFixture, ReadAllCores32Bytes){
+TEST_F(uBenchmarkFixture, ReadAllCores32Bytes) {
     std::vector<uint32_t> readback_vec = {};
     std::uint64_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
-    std::uint64_t bad_address = 0x30000000;     // this address is not mapped, should trigger fallback write/read path
+    std::uint64_t bad_address = 0x30000000;  // this address is not mapped, should trigger fallback write/read path
 
     ankerl::nanobench::Bench bench_static;
     ankerl::nanobench::Bench bench_dynamic;
-    
-    for(auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
+
+    for (auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
         std::stringstream rname;
         // Read through static tlbs
         rname << "Read from device core (" << core.x << ", " << core.y << ")";
         bench_static.title("Read 32 bytes").unit("reads").minEpochIterations(50).output(nullptr).run(rname.str(), [&] {
-            test_utils::read_data_from_device(*device, readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
+            test_utils::read_data_from_device(
+                *device, readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
         });
         // Read through "fallback/dynamic" tlb
-        bench_dynamic.title("Read 32 bytes fallback").unit("reads").minEpochIterations(50).output(nullptr).run(rname.str(), [&] {
-            test_utils::read_data_from_device(*device, readback_vec, tt_cxy_pair(0, core), bad_address, 0x20, "SMALL_READ_WRITE_TLB");
-        });
+        bench_dynamic.title("Read 32 bytes fallback")
+            .unit("reads")
+            .minEpochIterations(50)
+            .output(nullptr)
+            .run(rname.str(), [&] {
+                test_utils::read_data_from_device(
+                    *device, readback_vec, tt_cxy_pair(0, core), bad_address, 0x20, "SMALL_READ_WRITE_TLB");
+            });
         rname.clear();
     }
     bench_static.render(ankerl::nanobench::templates::csv(), results_csv);
     bench_dynamic.render(ankerl::nanobench::templates::csv(), results_csv);
 }
 
-TEST_F(uBenchmarkFixture, Write32BytesRandomAddr){
+TEST_F(uBenchmarkFixture, Write32BytesRandomAddr) {
     std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7};
     std::uint32_t address;
 
     ankerl::nanobench::Bench bench;
-    for(auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
-        address = generate_random_address(1<<20); // between 0 and 1MB
+    for (auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
+        address = generate_random_address(1 << 20);  // between 0 and 1MB
         std::stringstream wname;
         wname << "Write to device core (" << core.x << ", " << core.y << ") @ address " << std::hex << address;
-        bench.title("Write 32 bytes random address").unit("writes").minEpochIterations(50).output(nullptr).run(wname.str(), [&] {
-            device->write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
-        });
+        bench.title("Write 32 bytes random address")
+            .unit("writes")
+            .minEpochIterations(50)
+            .output(nullptr)
+            .run(wname.str(), [&] {
+                device->write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(0, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
+            });
         wname.clear();
     }
     bench.render(ankerl::nanobench::templates::csv(), results_csv);
 }
 
-TEST_F(uBenchmarkFixture, Read32BytesRandomAddr){
+TEST_F(uBenchmarkFixture, Read32BytesRandomAddr) {
     std::vector<uint32_t> readback_vec = {};
     std::uint32_t address;
 
     ankerl::nanobench::Bench bench;
-    for(auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
-        address = generate_random_address(1<<20); // between 0 and 1MB
+    for (auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
+        address = generate_random_address(1 << 20);  // between 0 and 1MB
         std::stringstream rname;
         rname << "Read from device core (" << core.x << ", " << core.y << ") @ address " << std::hex << address;
-        bench.title("Read 32 bytes random address").unit("reads").minEpochIterations(50).output(nullptr).run(rname.str(), [&] {
-            test_utils::read_data_from_device(*device, readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
-        });
+        bench.title("Read 32 bytes random address")
+            .unit("reads")
+            .minEpochIterations(50)
+            .output(nullptr)
+            .run(rname.str(), [&] {
+                test_utils::read_data_from_device(
+                    *device, readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
+            });
         rname.clear();
     }
     bench.render(ankerl::nanobench::templates::csv(), results_csv);

--- a/tests/pcie/test_pcie_device.cpp
+++ b/tests/pcie/test_pcie_device.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <gtest/gtest.h>
-#include "fmt/xchar.h"
 
 #include <algorithm>
 #include <filesystem>
@@ -13,7 +12,7 @@
 #include <vector>
 
 #include "device/pcie/pci_device.hpp"
-
+#include "fmt/xchar.h"
 
 TEST(PcieDeviceTest, Numa) {
     std::vector<int> nodes;

--- a/tests/simulation/device_fixture.hpp
+++ b/tests/simulation/device_fixture.hpp
@@ -5,15 +5,14 @@
 #pragma once
 
 #include <gtest/gtest.h>
-
-#include "tt_simulation_device.h"
-#include "common/logger.hpp"
-#include "tests/test_utils/generate_cluster_desc.hpp"
-
 #include <nng/nng.h>
+#include <nng/protocol/pair1/pair.h>
 #include <nng/protocol/pipeline0/pull.h>
 #include <nng/protocol/pipeline0/push.h>
-#include <nng/protocol/pair1/pair.h>
+
+#include "common/logger.hpp"
+#include "tests/test_utils/generate_cluster_desc.hpp"
+#include "tt_simulation_device.h"
 
 class SimulationDeviceFixture : public ::testing::Test {
 protected:
@@ -24,9 +23,7 @@ protected:
         device->start_device(default_params);
     }
 
-    static void TearDownTestSuite() {
-        device->close_device();
-    }
+    static void TearDownTestSuite() { device->close_device(); }
 
     static std::unique_ptr<tt_SimulationDevice> device;
 };

--- a/tests/simulation/test_simulation_device.cpp
+++ b/tests/simulation/test_simulation_device.cpp
@@ -3,86 +3,79 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <random>
+
 #include "device_fixture.hpp"
 #include "tests/test_utils/device_test_utils.hpp"
 
-std::vector<uint32_t> generate_data(uint32_t size_in_bytes){
-    size_t size = size_in_bytes/sizeof(uint32_t);
+std::vector<uint32_t> generate_data(uint32_t size_in_bytes) {
+    size_t size = size_in_bytes / sizeof(uint32_t);
     std::vector<uint32_t> data(size);
     std::random_device rd;
     std::mt19937 gen(rd());
     std::uniform_int_distribution<uint32_t> dis(0, 100);
 
-    for(uint32_t i = 0; i < size; i++){
+    for (uint32_t i = 0; i < size; i++) {
         data[i] = dis(gen);
     }
     return data;
 }
 
-class LoopbackAllCoresParam : public SimulationDeviceFixture , 
-                            public ::testing::WithParamInterface<tt_xy_pair> {};
+class LoopbackAllCoresParam : public SimulationDeviceFixture, public ::testing::WithParamInterface<tt_xy_pair> {};
 
 INSTANTIATE_TEST_SUITE_P(
-    LoopbackAllCores,
-    LoopbackAllCoresParam,
-    ::testing::Values(
-        tt_xy_pair{0, 1},
-        tt_xy_pair{1, 1},
-        tt_xy_pair{1, 0}
-    )
-);
+    LoopbackAllCores, LoopbackAllCoresParam, ::testing::Values(tt_xy_pair{0, 1}, tt_xy_pair{1, 1}, tt_xy_pair{1, 0}));
 
-TEST_P(LoopbackAllCoresParam, LoopbackSingleTensix){
-    std::vector<uint32_t> wdata = {1,2,3,4,5};
+TEST_P(LoopbackAllCoresParam, LoopbackSingleTensix) {
+    std::vector<uint32_t> wdata = {1, 2, 3, 4, 5};
     std::vector<uint32_t> rdata(wdata.size(), 0);
     tt_cxy_pair core = {0, GetParam()};
 
-    device->write_to_device(wdata.data(), wdata.size()*sizeof(uint32_t), core, 0x100, "");
-    device->read_from_device(rdata.data(), core, 0x100, rdata.size()*sizeof(uint32_t), "");
-    
+    device->write_to_device(wdata.data(), wdata.size() * sizeof(uint32_t), core, 0x100, "");
+    device->read_from_device(rdata.data(), core, 0x100, rdata.size() * sizeof(uint32_t), "");
+
     ASSERT_EQ(wdata, rdata);
 }
 
-bool loopback_stress_size(std::unique_ptr<tt_SimulationDevice> &device, tt_xy_pair core, uint32_t byte_shift){
+bool loopback_stress_size(std::unique_ptr<tt_SimulationDevice> &device, tt_xy_pair core, uint32_t byte_shift) {
     uint64_t addr = 0x0;
 
     std::vector<uint32_t> wdata = generate_data(1 << byte_shift);
     std::vector<uint32_t> rdata(wdata.size(), 0);
 
-    device->write_to_device(wdata.data(), wdata.size()*sizeof(uint32_t), tt_cxy_pair{0, core}, addr, "");
-    device->read_from_device(rdata.data(), tt_cxy_pair{0, core}, addr, rdata.size()*sizeof(uint32_t), "");
-    
+    device->write_to_device(wdata.data(), wdata.size() * sizeof(uint32_t), tt_cxy_pair{0, core}, addr, "");
+    device->read_from_device(rdata.data(), tt_cxy_pair{0, core}, addr, rdata.size() * sizeof(uint32_t), "");
+
     return wdata == rdata;
 }
 
-TEST_P(LoopbackAllCoresParam, LoopbackStressSize){
+TEST_P(LoopbackAllCoresParam, LoopbackStressSize) {
     tt_xy_pair core = GetParam();
     tt_xy_pair dram = {1, 0};
     if (core == dram) {
-        for (uint32_t i = 2; i <= 30; ++i) {    // 2^30 = 1 GB
+        for (uint32_t i = 2; i <= 30; ++i) {  // 2^30 = 1 GB
             ASSERT_TRUE(loopback_stress_size(device, core, i));
         }
     } else {
-        for (uint32_t i = 2; i <= 20; ++i) {    // 2^20 = 1 MB
+        for (uint32_t i = 2; i <= 20; ++i) {  // 2^20 = 1 MB
             ASSERT_TRUE(loopback_stress_size(device, core, i));
         }
     }
 }
 
-TEST_F(SimulationDeviceFixture, LoopbackTwoTensix){
-    std::vector<uint32_t> wdata1 = {1,2,3,4,5};
-    std::vector<uint32_t> wdata2 = {6,7,8,9,10};
+TEST_F(SimulationDeviceFixture, LoopbackTwoTensix) {
+    std::vector<uint32_t> wdata1 = {1, 2, 3, 4, 5};
+    std::vector<uint32_t> wdata2 = {6, 7, 8, 9, 10};
     std::vector<uint32_t> rdata1(wdata1.size());
     std::vector<uint32_t> rdata2(wdata2.size());
     tt_cxy_pair core1 = {0, 0, 1};
     tt_cxy_pair core2 = {0, 1, 1};
 
-    device->write_to_device(wdata1.data(), wdata1.size()*sizeof(uint32_t),  core1, 0x100, "");
-    device->write_to_device(wdata2.data(), wdata2.size()*sizeof(uint32_t), core2, 0x100, "");
+    device->write_to_device(wdata1.data(), wdata1.size() * sizeof(uint32_t), core1, 0x100, "");
+    device->write_to_device(wdata2.data(), wdata2.size() * sizeof(uint32_t), core2, 0x100, "");
 
-    device->read_from_device(rdata1.data(), core1, 0x100, rdata1.size()*sizeof(uint32_t), "");
-    device->read_from_device(rdata2.data(), core2, 0x100, rdata2.size()*sizeof(uint32_t), "");
-    
+    device->read_from_device(rdata1.data(), core1, 0x100, rdata1.size() * sizeof(uint32_t), "");
+    device->read_from_device(rdata2.data(), core2, 0x100, rdata2.size() * sizeof(uint32_t), "");
+
     ASSERT_EQ(wdata1, rdata1);
     ASSERT_EQ(wdata2, rdata2);
 }

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -15,7 +15,7 @@
 namespace test_utils {
 
 template <typename T>
-static void size_buffer_to_capacity(std::vector<T> &data_buf, std::size_t size_in_bytes) {
+static void size_buffer_to_capacity(std::vector<T>& data_buf, std::size_t size_in_bytes) {
     std::size_t target_size = 0;
     if (size_in_bytes > 0) {
         target_size = ((size_in_bytes - 1) / sizeof(T)) + 1;
@@ -23,22 +23,27 @@ static void size_buffer_to_capacity(std::vector<T> &data_buf, std::size_t size_i
     data_buf.resize(target_size);
 }
 
-static void read_data_from_device(tt_device& device, std::vector<uint32_t> &vec, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& tlb_to_use) {
+static void read_data_from_device(
+    tt_device& device,
+    std::vector<uint32_t>& vec,
+    tt_cxy_pair core,
+    uint64_t addr,
+    uint32_t size,
+    const std::string& tlb_to_use) {
     size_buffer_to_capacity(vec, size);
     device.read_from_device(vec.data(), core, addr, size, tlb_to_use);
 }
 
-inline void fill_with_random_bytes(uint8_t* data, size_t n)
-{
+inline void fill_with_random_bytes(uint8_t* data, size_t n) {
     static std::random_device rd;
     static std::mt19937_64 gen(rd());
     uint64_t* data64 = reinterpret_cast<uint64_t*>(data);
-    std::generate_n(data64, n/8, [&]() { return gen(); });
+    std::generate_n(data64, n / 8, [&]() { return gen(); });
 
     // Handle remaining bytes
-    for (size_t i = (n/8)*8; i < n; ++i) {
+    for (size_t i = (n / 8) * 8; i < n; ++i) {
         data[i] = static_cast<uint8_t>(gen());
     }
 }
 
-}
+}  // namespace test_utils

--- a/tests/test_utils/generate_cluster_desc.hpp
+++ b/tests/test_utils/generate_cluster_desc.hpp
@@ -7,24 +7,26 @@
 #pragma once
 
 #include <filesystem>
-#include <string>
 #include <iostream>
+#include <string>
 
 #include "fmt/core.h"
 
 namespace test_utils {
 
-inline std::string GetAbsPath(std::string path_){
-    // Note that __FILE__ might be resolved at compile time to an absolute or relative address, depending on the compiler.
+inline std::string GetAbsPath(std::string path_) {
+    // Note that __FILE__ might be resolved at compile time to an absolute or relative address, depending on the
+    // compiler.
     std::filesystem::path current_file_path = std::filesystem::path(__FILE__);
     std::filesystem::path umd_root;
     if (current_file_path.is_absolute()) {
         umd_root = current_file_path.parent_path().parent_path().parent_path();
     } else {
-        std::filesystem::path umd_root_relative = std::filesystem::relative(std::filesystem::path(__FILE__).parent_path().parent_path().parent_path(), "../");
+        std::filesystem::path umd_root_relative =
+            std::filesystem::relative(std::filesystem::path(__FILE__).parent_path().parent_path().parent_path(), "../");
         umd_root = std::filesystem::canonical(umd_root_relative);
     }
     std::filesystem::path abs_path = umd_root / path_;
     return abs_path.string();
 }
-} // namespace test_utils
+}  // namespace test_utils

--- a/tests/test_utils/soc_desc_test_utils.hpp
+++ b/tests/test_utils/soc_desc_test_utils.hpp
@@ -15,4 +15,4 @@ static std::size_t get_num_harvested(std::size_t harvesting_mask) {
     return __builtin_popcount(harvesting_mask);
 }
 
-}
+}  // namespace test_utils

--- a/tests/test_utils/stimulus_generators.hpp
+++ b/tests/test_utils/stimulus_generators.hpp
@@ -261,8 +261,8 @@ template <
 
     typename GENERATOR_T = std::mt19937>
 class TestGenerator {
-    using transfer_type_generator_t = DefaultTransferTypeGenerator;  // ConstrainedTemplateTemplateGenerator<RemoteTransferType,
-                                                                     // int, TRANS_TYPE_DISTRIBUTION_T, GENERATOR_T>;
+    // ConstrainedTemplateTemplateGenerator<RemoteTransferType, int, TRANS_TYPE_DISTRIBUTION_T, GENERATOR_T>;
+    using transfer_type_generator_t = DefaultTransferTypeGenerator;
     using write_command_generator_t =
         WriteCommandGenerator<WRITE_DEST_DISTR_T, WRITE_ADDR_DISTR_T, WRITE_SIZE_DISTR_OUT_T, WRITE_SIZE_DISTR_T>;
     using read_command_generator_t =

--- a/tests/test_utils/stimulus_generators.hpp
+++ b/tests/test_utils/stimulus_generators.hpp
@@ -4,18 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
-#include "tt_xy_pair.h"
-#include "tt_cluster_descriptor.h"
-#include "cluster.h"
-
-
+#include <cassert>
 #include <functional>
 #include <iostream>
 #include <map>
 #include <random>
-#include <vector>
 #include <variant>
-#include <cassert>
+#include <vector>
+
+#include "cluster.h"
+#include "tt_cluster_descriptor.h"
+#include "tt_xy_pair.h"
 
 /* Sizes:
  * Distribution (including min/max)
@@ -40,7 +39,6 @@ namespace tt::umd::test::utils {
 
 static const std::string SOC_DESC_PATH = "tests/soc_descs/wormhole_b0_8x10.yaml";
 
-
 enum RemoteTransferType : uint8_t { WRITE = 0, READ };
 
 template <
@@ -50,7 +48,7 @@ template <
     class DISTRIBUTION_T,
     typename GENERATOR_T = std::mt19937>
 class ConstrainedTemplateTemplateGenerator {
-   public:
+public:
     ConstrainedTemplateTemplateGenerator(
         int seed,
         DISTRIBUTION_T<UNCONSTRAINED_SAMPLE_T> const& distribution,
@@ -62,24 +60,17 @@ class ConstrainedTemplateTemplateGenerator {
         return constrain(sample);
     }
 
-   private:
+private:
     GENERATOR_T generator;
     DISTRIBUTION_T<UNCONSTRAINED_SAMPLE_T> distribution;
     std::function<SAMPLE_T(UNCONSTRAINED_SAMPLE_T)> constrain;
 };
 
-
-template <
-    typename SAMPLE_T,
-    typename UNCONSTRAINED_SAMPLE_T,
-    class DISTRIBUTION_T,
-    typename GENERATOR_T = std::mt19937>
+template <typename SAMPLE_T, typename UNCONSTRAINED_SAMPLE_T, class DISTRIBUTION_T, typename GENERATOR_T = std::mt19937>
 class ConstrainedTemplateGenerator {
-   public:
+public:
     ConstrainedTemplateGenerator(
-        int seed,
-        DISTRIBUTION_T const& distribution,
-        std::function<SAMPLE_T(UNCONSTRAINED_SAMPLE_T)> constrain) :
+        int seed, DISTRIBUTION_T const& distribution, std::function<SAMPLE_T(UNCONSTRAINED_SAMPLE_T)> constrain) :
         generator(seed), distribution(distribution), constrain(constrain) {}
 
     SAMPLE_T generate() {
@@ -87,14 +78,14 @@ class ConstrainedTemplateGenerator {
         return constrain(sample);
     }
 
-   private:
+private:
     GENERATOR_T generator;
     DISTRIBUTION_T distribution;
     std::function<SAMPLE_T(UNCONSTRAINED_SAMPLE_T)> constrain;
 };
 
-
-using DefaultTransferTypeGenerator = ConstrainedTemplateTemplateGenerator<RemoteTransferType, int, std::discrete_distribution>;
+using DefaultTransferTypeGenerator =
+    ConstrainedTemplateTemplateGenerator<RemoteTransferType, int, std::discrete_distribution>;
 
 using address_t = uint32_t;
 using destination_t = tt_cxy_pair;
@@ -107,6 +98,7 @@ struct write_transfer_sample_t {
     std::string tlb_to_use;
     // (payload.data(), size, destination, address, tlb_to_use, false, false);
 };
+
 struct read_transfer_sample_t {
     destination_t destination;
     address_t address;
@@ -115,7 +107,8 @@ struct read_transfer_sample_t {
     // (payload.data(), destination, address, size, tlb_to_use);
 };
 
-using remote_transfer_sample_t = std::tuple<RemoteTransferType, std::variant<write_transfer_sample_t, read_transfer_sample_t>>;
+using remote_transfer_sample_t =
+    std::tuple<RemoteTransferType, std::variant<write_transfer_sample_t, read_transfer_sample_t>>;
 
 template <
     template <typename>
@@ -130,7 +123,8 @@ template <
 struct WriteCommandGenerator {
     using destination_generator_t = ConstrainedTemplateTemplateGenerator<destination_t, int, DEST_DISTR_T, GENERATOR_T>;
     using address_generator_t = ConstrainedTemplateTemplateGenerator<address_t, address_t, ADDR_DISTR_T, GENERATOR_T>;
-    using size_generator_t = ConstrainedTemplateTemplateGenerator<transfer_size_t, DISTR_OUT_T, SIZE_DISTR_T, GENERATOR_T>;
+    using size_generator_t =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, DISTR_OUT_T, SIZE_DISTR_T, GENERATOR_T>;
 
     WriteCommandGenerator(
         destination_generator_t const& destination_generator,
@@ -159,7 +153,8 @@ template <
 struct WriteEpochCmdCommandGenerator {
     using destination_generator_t = ConstrainedTemplateTemplateGenerator<destination_t, int, DEST_DISTR_T, GENERATOR_T>;
     using address_generator_t = ConstrainedTemplateTemplateGenerator<address_t, address_t, ADDR_DISTR_T, GENERATOR_T>;
-    using size_generator_t = ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, SIZE_DISTR_T, GENERATOR_T>;
+    using size_generator_t =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, SIZE_DISTR_T, GENERATOR_T>;
     using last_cmd_generator_t = ConstrainedTemplateGenerator<bool, bool, LAST_CMD_DISTR_T, GENERATOR_T>;
     using ordered_generator_t = ConstrainedTemplateGenerator<bool, bool, ORDERED_DISTR_T, GENERATOR_T>;
 
@@ -196,8 +191,10 @@ template <
     typename GENERATOR_T = std::mt19937>
 struct RolledWriteCommandGenerator {
     using destination_generator_t = ConstrainedTemplateTemplateGenerator<destination_t, int, DEST_DISTR_T, GENERATOR_T>;
-    using address_generator_t = ConstrainedTemplateTemplateGenerator<address_t, address_t, SIZE_DISTR_OUT_T, GENERATOR_T>;
-    using size_generator_t = ConstrainedTemplateTemplateGenerator<transfer_size_t, DISTR_SIZE_OUT_T, SIZE_DISTR_T, GENERATOR_T>;
+    using address_generator_t =
+        ConstrainedTemplateTemplateGenerator<address_t, address_t, SIZE_DISTR_OUT_T, GENERATOR_T>;
+    using size_generator_t =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, DISTR_SIZE_OUT_T, SIZE_DISTR_T, GENERATOR_T>;
     using unroll_count_generator_t = ConstrainedTemplateTemplateGenerator<int, int, UNROLL_COUNT_DISTR_T, GENERATOR_T>;
 
     RolledWriteCommandGenerator(
@@ -229,7 +226,8 @@ template <
 struct ReadCommandGenerator {
     using destination_generator_t = ConstrainedTemplateTemplateGenerator<destination_t, int, DEST_DISTR_T, GENERATOR_T>;
     using address_generator_t = ConstrainedTemplateTemplateGenerator<address_t, address_t, ADDR_DISTR_T, GENERATOR_T>;
-    using size_generator_t = ConstrainedTemplateTemplateGenerator<transfer_size_t, DISTR_OUT_T, SIZE_DISTR_T, GENERATOR_T>;
+    using size_generator_t =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, DISTR_OUT_T, SIZE_DISTR_T, GENERATOR_T>;
 
     ReadCommandGenerator(
         destination_generator_t const& destination_generator,
@@ -238,8 +236,6 @@ struct ReadCommandGenerator {
         destination_generator(destination_generator),
         address_generator(address_generator),
         size_generator(size_generator) {}
-
-
 
     destination_generator_t destination_generator;
     address_generator_t address_generator;
@@ -265,12 +261,14 @@ template <
 
     typename GENERATOR_T = std::mt19937>
 class TestGenerator {
-    using transfer_type_generator_t = DefaultTransferTypeGenerator;  // ConstrainedTemplateTemplateGenerator<RemoteTransferType, int,
-                                                                     // TRANS_TYPE_DISTRIBUTION_T, GENERATOR_T>;
-    using write_command_generator_t = WriteCommandGenerator<WRITE_DEST_DISTR_T, WRITE_ADDR_DISTR_T, WRITE_SIZE_DISTR_OUT_T, WRITE_SIZE_DISTR_T>;
-    using read_command_generator_t = ReadCommandGenerator<READ_DEST_DISTR_T,READ_ADDR_DISTR_T, READ_SIZE_DISTR_OUT_T, READ_SIZE_DISTR_T>;
+    using transfer_type_generator_t = DefaultTransferTypeGenerator;  // ConstrainedTemplateTemplateGenerator<RemoteTransferType,
+                                                                     // int, TRANS_TYPE_DISTRIBUTION_T, GENERATOR_T>;
+    using write_command_generator_t =
+        WriteCommandGenerator<WRITE_DEST_DISTR_T, WRITE_ADDR_DISTR_T, WRITE_SIZE_DISTR_OUT_T, WRITE_SIZE_DISTR_T>;
+    using read_command_generator_t =
+        ReadCommandGenerator<READ_DEST_DISTR_T, READ_ADDR_DISTR_T, READ_SIZE_DISTR_OUT_T, READ_SIZE_DISTR_T>;
 
-   public:
+public:
     TestGenerator(
         int seed,
         transfer_type_generator_t const& transfer_type_distribution,
@@ -279,13 +277,10 @@ class TestGenerator {
         generator(seed),
         transfer_type_distribution(transfer_type_distribution),
         write_command_generator(write_command_generator),
-        read_command_generator(read_command_generator)
-    {
-    }
+        read_command_generator(read_command_generator) {}
 
     // Generate a sample (transfer type, size, destination, address) based on custom distributions
     remote_transfer_sample_t generate_sample() {
-
         // Randomly select a transfer type
         RemoteTransferType transfer_type = transfer_type_distribution.generate();
         assert(transfer_type < 4 && transfer_type >= 0);
@@ -294,22 +289,26 @@ class TestGenerator {
                 destination_t const& destination = write_command_generator.destination_generator.generate();
                 address_t const& address = write_command_generator.address_generator.generate();
                 transfer_size_t const& size_in_bytes = write_command_generator.size_generator.generate();
-                return {transfer_type, write_transfer_sample_t{
-                    .destination = destination,
-                    .address = address,
-                    .size_in_bytes = size_in_bytes,
-                    .tlb_to_use = "LARGE_WRITE_TLB"}};
+                return {
+                    transfer_type,
+                    write_transfer_sample_t{
+                        .destination = destination,
+                        .address = address,
+                        .size_in_bytes = size_in_bytes,
+                        .tlb_to_use = "LARGE_WRITE_TLB"}};
             } break;
 
             case RemoteTransferType::READ: {
                 destination_t const& destination = read_command_generator.destination_generator.generate();
                 address_t const& address = read_command_generator.address_generator.generate();
                 transfer_size_t const& size_in_bytes = read_command_generator.size_generator.generate();
-                return {transfer_type, read_transfer_sample_t{
-                    .destination = destination,
-                    .address = address,
-                    .size_in_bytes = size_in_bytes,
-                    .tlb_to_use = "LARGE_READ_TLB"}};
+                return {
+                    transfer_type,
+                    read_transfer_sample_t{
+                        .destination = destination,
+                        .address = address,
+                        .size_in_bytes = size_in_bytes,
+                        .tlb_to_use = "LARGE_READ_TLB"}};
             } break;
 
             default:
@@ -317,7 +316,7 @@ class TestGenerator {
         };
     }
 
-   private:
+private:
     std::mt19937 generator;
 
     transfer_type_generator_t transfer_type_distribution;
@@ -331,15 +330,32 @@ struct transfer_type_weights_t {
     double read;
 };
 
-
-static auto address_aligner = [](address_t addr) -> address_t { addr = (((addr - 1) / 32) + 1) * 32; assert(addr % 32 == 0); return addr;};
-static auto transfer_size_aligner = [](transfer_size_t size) -> transfer_size_t { size = (((size - 1) / 4) + 1) * 4; assert(size > 0); assert(size % 4 == 0); return size; };
-static auto address_aligner_32B = [](transfer_size_t size) -> transfer_size_t { size = (((size - 1) / 32) + 1) * 32; assert(size > 0); return size;};
-static auto size_aligner_32B = [](transfer_size_t size) -> transfer_size_t { size = (((size - 1) / 32) + 1) * 32; assert(size > 0); return size;};
-template<typename T>
+static auto address_aligner = [](address_t addr) -> address_t {
+    addr = (((addr - 1) / 32) + 1) * 32;
+    assert(addr % 32 == 0);
+    return addr;
+};
+static auto transfer_size_aligner = [](transfer_size_t size) -> transfer_size_t {
+    size = (((size - 1) / 4) + 1) * 4;
+    assert(size > 0);
+    assert(size % 4 == 0);
+    return size;
+};
+static auto address_aligner_32B = [](transfer_size_t size) -> transfer_size_t {
+    size = (((size - 1) / 32) + 1) * 32;
+    assert(size > 0);
+    return size;
+};
+static auto size_aligner_32B = [](transfer_size_t size) -> transfer_size_t {
+    size = (((size - 1) / 32) + 1) * 32;
+    assert(size > 0);
+    return size;
+};
+template <typename T>
 static auto passthrough_constrainer = [](T const& t) -> T { return t; };
 
-static inline std::vector<destination_t> generate_core_index_locations(tt_ClusterDescriptor const& cluster_desc, tt_SocDescriptor const& soc_desc) {
+static inline std::vector<destination_t> generate_core_index_locations(
+    tt_ClusterDescriptor const& cluster_desc, tt_SocDescriptor const& soc_desc) {
     std::vector<destination_t> core_index_to_location = {};
 
     for (chip_id_t chip : cluster_desc.get_all_chips()) {
@@ -360,16 +376,19 @@ static void print_command(remote_transfer_sample_t const& command) {
         case RemoteTransferType::WRITE: {
             write_transfer_sample_t const& command_args = std::get<write_transfer_sample_t>(std::get<1>(command));
             std::cout << "Transfer type: WRITE, destination: (c=" << command_args.destination.chip
-                        << ", y=" << command_args.destination.y << ", x=" << command_args.destination.x
-                        << "), address: " << command_args.address << ", size_in_bytes: " << command_args.size_in_bytes << std::endl;
+                      << ", y=" << command_args.destination.y << ", x=" << command_args.destination.x
+                      << "), address: " << command_args.address << ", size_in_bytes: " << command_args.size_in_bytes
+                      << std::endl;
         } break;
         case RemoteTransferType::READ: {
             read_transfer_sample_t const& command_args = std::get<read_transfer_sample_t>(std::get<1>(command));
             std::cout << "Transfer type: READ, destination: (c=" << command_args.destination.chip
-                        << ", y=" << command_args.destination.y << ", x=" << command_args.destination.x
-                        << "), address: " << command_args.address << ", size_in_bytes: " << command_args.size_in_bytes << std::endl;
+                      << ", y=" << command_args.destination.y << ", x=" << command_args.destination.x
+                      << "), address: " << command_args.address << ", size_in_bytes: " << command_args.size_in_bytes
+                      << std::endl;
         } break;
-        default: throw std::runtime_error("Invalid transfer type");
+        default:
+            throw std::runtime_error("Invalid transfer type");
     };
 }
 
@@ -379,12 +398,9 @@ int bytes_to_words(int num_bytes) {
 }
 
 static inline void dispatch_remote_transfer_command(
-    Cluster &driver, 
-    remote_transfer_sample_t const& command, 
-    std::vector<uint32_t> &payload) {
-
+    Cluster& driver, remote_transfer_sample_t const& command, std::vector<uint32_t>& payload) {
     RemoteTransferType transfer_type = std::get<0>(command);
-    auto resize_payload = [](std::vector<uint32_t> &payload, int size_in_bytes) {
+    auto resize_payload = [](std::vector<uint32_t>& payload, int size_in_bytes) {
         payload.resize(bytes_to_words<uint32_t>(size_in_bytes));
     };
 
@@ -392,28 +408,37 @@ static inline void dispatch_remote_transfer_command(
         case RemoteTransferType::WRITE: {
             write_transfer_sample_t const& command_args = std::get<write_transfer_sample_t>(std::get<1>(command));
             assert(command_args.size_in_bytes >= sizeof(uint32_t));
-            resize_payload(payload,command_args.size_in_bytes);
-            driver.write_to_device(payload.data(), bytes_to_words<uint32_t>(command_args.size_in_bytes), command_args.destination, command_args.address, command_args.tlb_to_use);
+            resize_payload(payload, command_args.size_in_bytes);
+            driver.write_to_device(
+                payload.data(),
+                bytes_to_words<uint32_t>(command_args.size_in_bytes),
+                command_args.destination,
+                command_args.address,
+                command_args.tlb_to_use);
         } break;
         case RemoteTransferType::READ: {
             read_transfer_sample_t const& command_args = std::get<read_transfer_sample_t>(std::get<1>(command));
             assert(command_args.size_in_bytes >= sizeof(uint32_t));
-            resize_payload(payload,command_args.size_in_bytes);
-            driver.read_from_device(payload.data(), command_args.destination, command_args.address, command_args.size_in_bytes, command_args.tlb_to_use);
+            resize_payload(payload, command_args.size_in_bytes);
+            driver.read_from_device(
+                payload.data(),
+                command_args.destination,
+                command_args.address,
+                command_args.size_in_bytes,
+                command_args.tlb_to_use);
         } break;
         default:
             throw std::runtime_error("Invalid transfer type");
     };
 }
 
-
 static void print_command_executable_code(remote_transfer_sample_t const& command) {
-
     auto emit_payload_resize_string = [](int size_bytes, int size_word) {
         std::cout << "payload.resize(((" << size_bytes << " - 1) / " << size_word << ") + 1);" << std::endl;
     };
     auto emit_bytes_to_words_len_string = [](std::string const& var_name, int size_in_bytes, int size_word) {
-        std::cout << "int " << var_name << " = (((" << size_in_bytes << " - 1) / " << size_word << ") + 1);" << std::endl;
+        std::cout << "int " << var_name << " = (((" << size_in_bytes << " - 1) / " << size_word << ") + 1);"
+                  << std::endl;
     };
 
     std::cout << "{" << std::endl;
@@ -421,19 +446,25 @@ static void print_command_executable_code(remote_transfer_sample_t const& comman
         case RemoteTransferType::WRITE: {
             write_transfer_sample_t const& command_args = std::get<write_transfer_sample_t>(std::get<1>(command));
             assert(command_args.size_in_bytes >= sizeof(uint32_t));
-            std::cout << "tt_cxy_pair const& destination = tt_cxy_pair(" << command_args.destination.chip << ", " << command_args.destination.x << ", " << command_args.destination.y << ");"  << std::endl;
+            std::cout << "tt_cxy_pair const& destination = tt_cxy_pair(" << command_args.destination.chip << ", "
+                      << command_args.destination.x << ", " << command_args.destination.y << ");" << std::endl;
             std::cout << "assert(" << command_args.size_in_bytes << " >= sizeof(uint32_t));" << std::endl;
             emit_bytes_to_words_len_string("len", command_args.size_in_bytes, sizeof(uint32_t));
             emit_payload_resize_string(command_args.size_in_bytes, sizeof(uint32_t));
-            std::cout << "device->write_to_device(payload.data(), len, destination, " << command_args.address << ", \"" << command_args.tlb_to_use << "\");" << std::endl;
-            // driver.write_to_device(payload.data(), command_args.size, command_args.destination, command_args.address, command_args.tlb_to_use, false, false);
+            std::cout << "device->write_to_device(payload.data(), len, destination, " << command_args.address << ", \""
+                      << command_args.tlb_to_use << "\");" << std::endl;
+            // driver.write_to_device(payload.data(), command_args.size, command_args.destination, command_args.address,
+            // command_args.tlb_to_use, false, false);
         } break;
         case RemoteTransferType::READ: {
             read_transfer_sample_t const& command_args = std::get<read_transfer_sample_t>(std::get<1>(command));
-            std::cout << "tt_cxy_pair const& destination = tt_cxy_pair(" << command_args.destination.chip << ", " << command_args.destination.x << ", " << command_args.destination.y << ");"  << std::endl;
+            std::cout << "tt_cxy_pair const& destination = tt_cxy_pair(" << command_args.destination.chip << ", "
+                      << command_args.destination.x << ", " << command_args.destination.y << ");" << std::endl;
             emit_payload_resize_string(command_args.size_in_bytes, sizeof(uint32_t));
-            std::cout << "device->read_from_device(payload.data(), destination, " << command_args.address << ", " << command_args.size_in_bytes << ", \"" << command_args.tlb_to_use << "\");" << std::endl;
-            // driver.read_from_device(payload.data(), command_args.destination, command_args.address, command_args.size, command_args.tlb_to_use);
+            std::cout << "device->read_from_device(payload.data(), destination, " << command_args.address << ", "
+                      << command_args.size_in_bytes << ", \"" << command_args.tlb_to_use << "\");" << std::endl;
+            // driver.read_from_device(payload.data(), command_args.destination, command_args.address,
+            // command_args.size, command_args.tlb_to_use);
         } break;
         default:
             throw std::runtime_error("Invalid transfer type");
@@ -450,32 +481,36 @@ static void print_command_history_executable_code(std::vector<remote_transfer_sa
     }
 }
 
-
-
-template<
-    template <typename> class WRITE_DEST_DISTR_T, 
-    template <typename> class WRITE_ADDR_DISTR_T, 
+template <
+    template <typename>
+    class WRITE_DEST_DISTR_T,
+    template <typename>
+    class WRITE_ADDR_DISTR_T,
     class WRITE_SIZE_DISTR_OUT_T,
-    template <typename> class WRITE_SIZE_DISTR_T,
+    template <typename>
+    class WRITE_SIZE_DISTR_T,
 
-    template <typename> class READ_DEST_DISTR_T, 
-    template <typename> class READ_ADDR_DISTR_T, 
-    class READ_SIZE_DISTR_OUT_T, 
-    template <typename> class READ_SIZE_DISTR_T
->
+    template <typename>
+    class READ_DEST_DISTR_T,
+    template <typename>
+    class READ_ADDR_DISTR_T,
+    class READ_SIZE_DISTR_OUT_T,
+    template <typename>
+    class READ_SIZE_DISTR_T>
 void RunMixedTransfers(
-    Cluster& device, 
+    Cluster& device,
     int num_samples,
     int seed,
 
     transfer_type_weights_t const& transfer_type_weights,
 
-    WriteCommandGenerator<WRITE_DEST_DISTR_T, WRITE_ADDR_DISTR_T, WRITE_SIZE_DISTR_OUT_T, WRITE_SIZE_DISTR_T> const& write_command_generator,
-    ReadCommandGenerator<READ_DEST_DISTR_T, READ_ADDR_DISTR_T, READ_SIZE_DISTR_OUT_T, READ_SIZE_DISTR_T> const& read_command_generator,
-    
+    WriteCommandGenerator<WRITE_DEST_DISTR_T, WRITE_ADDR_DISTR_T, WRITE_SIZE_DISTR_OUT_T, WRITE_SIZE_DISTR_T> const&
+        write_command_generator,
+    ReadCommandGenerator<READ_DEST_DISTR_T, READ_ADDR_DISTR_T, READ_SIZE_DISTR_OUT_T, READ_SIZE_DISTR_T> const&
+        read_command_generator,
+
     bool record_command_history = false,
-    std::vector<remote_transfer_sample_t> *command_history = nullptr
-) {
+    std::vector<remote_transfer_sample_t>* command_history = nullptr) {
     SCOPED_TRACE("RunMixedTransfers");
     auto test_generator = TestGenerator(
         seed,
@@ -490,7 +525,7 @@ void RunMixedTransfers(
 
     if (record_command_history) {
         assert(command_history != nullptr);
-        assert(command_history->size() == 0); // only support passing in empty command histories
+        assert(command_history->size() == 0);  // only support passing in empty command histories
         command_history->reserve(num_samples);
     }
     std::vector<uint32_t> payload = {};
@@ -513,16 +548,17 @@ void RunMixedTransfers(
     }
 }
 
-
-static ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution> get_default_address_generator(int seed, address_t start, address_t end) {
+static ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>
+get_default_address_generator(int seed, address_t start, address_t end) {
     auto const& address_distribution = std::uniform_int_distribution<address_t>(start, end);
-    return ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(seed + 1, address_distribution, address_aligner);
+    return ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(
+        seed + 1, address_distribution, address_aligner);
 }
 
-
-static ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int_distribution> get_default_full_dram_dest_generator(int seed, Cluster *device) {
+static ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int_distribution>
+get_default_full_dram_dest_generator(int seed, Cluster* device) {
     assert(device != nullptr);
-    tt_ClusterDescriptor *cluster_desc = device->get_cluster_description();
+    tt_ClusterDescriptor* cluster_desc = device->get_cluster_description();
     tt_SocDescriptor const& soc_desc = device->get_virtual_soc_descriptors().at(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
 
@@ -536,19 +572,23 @@ static WriteCommandGenerator<
     std::uniform_int_distribution,
     std::uniform_int_distribution,
     transfer_size_t,
-    std::uniform_int_distribution
-> build_dummy_write_command_generator(Cluster &device) {
-    tt_ClusterDescriptor *cluster_desc = device.get_cluster_description();
+    std::uniform_int_distribution>
+build_dummy_write_command_generator(Cluster& device) {
+    tt_ClusterDescriptor* cluster_desc = device.get_cluster_description();
     tt_SocDescriptor const& soc_desc = device.get_virtual_soc_descriptors().at(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
     auto dest_generator = ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int_distribution>(
         0,
         std::uniform_int_distribution<int>(0, core_index_to_location.size() - 1),
         [core_index_to_location](int dest) -> destination_t { return core_index_to_location.at(dest); });
-    auto addr_generator = ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(0 , std::uniform_int_distribution<address_t>(0,0), address_aligner);
-    auto addr_generator_32B_aligned = ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(0, std::uniform_int_distribution<address_t>(0,0), address_aligner_32B);
-    auto write_size_generator = ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
-        0, std::uniform_int_distribution<address_t>(0,0), transfer_size_aligner);
+    auto addr_generator = ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(
+        0, std::uniform_int_distribution<address_t>(0, 0), address_aligner);
+    auto addr_generator_32B_aligned =
+        ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(
+            0, std::uniform_int_distribution<address_t>(0, 0), address_aligner_32B);
+    auto write_size_generator =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
+            0, std::uniform_int_distribution<address_t>(0, 0), transfer_size_aligner);
 
     return WriteCommandGenerator(dest_generator, addr_generator, write_size_generator);
 }
@@ -557,24 +597,25 @@ static ReadCommandGenerator<
     std::uniform_int_distribution,
     std::uniform_int_distribution,
     transfer_size_t,
-    std::uniform_int_distribution
-> build_dummy_read_command_generator(Cluster &device) {
-    tt_ClusterDescriptor *cluster_desc = device.get_cluster_description();
+    std::uniform_int_distribution>
+build_dummy_read_command_generator(Cluster& device) {
+    tt_ClusterDescriptor* cluster_desc = device.get_cluster_description();
     tt_SocDescriptor const& soc_desc = device.get_virtual_soc_descriptors().at(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
     auto dest_generator = ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int_distribution>(
         0,
         std::uniform_int_distribution<int>(0, core_index_to_location.size() - 1),
         [core_index_to_location](int dest) -> destination_t { return core_index_to_location.at(dest); });
-    auto addr_generator = ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(0, std::uniform_int_distribution<address_t>(0,0), address_aligner);
-    auto read_size_generator = ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
-        0, std::uniform_int_distribution<transfer_size_t>(0,0), transfer_size_aligner);
+    auto addr_generator = ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(
+        0, std::uniform_int_distribution<address_t>(0, 0), address_aligner);
+    auto read_size_generator =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
+            0, std::uniform_int_distribution<transfer_size_t>(0, 0), transfer_size_aligner);
 
     return ReadCommandGenerator(dest_generator, addr_generator, read_size_generator);
-   
 }
 
-template<
+template <
     template <typename>
     class ADDR_GENERATOR_T,
     typename ADDR_DISTR_T,
@@ -583,10 +624,9 @@ template<
     template <typename>
     class READ_SIZE_GENERATOR_T,
     template <typename>
-    class UNROLL_COUNT_GENERATOR_T
->
+    class UNROLL_COUNT_GENERATOR_T>
 void RunMixedTransfersUniformDistributions(
-    Cluster& device, 
+    Cluster& device,
     int num_samples,
     int seed,
 
@@ -597,11 +637,10 @@ void RunMixedTransfersUniformDistributions(
     float percent_not_last_epoch_cmd,
     float percent_not_remote_ordered,
     READ_SIZE_GENERATOR_T<transfer_size_t> const& read_size_distribution,
-    
+
     bool record_command_history = false,
-    std::vector<remote_transfer_sample_t> *command_history = nullptr
-) {
-    tt_ClusterDescriptor *cluster_desc = device.get_cluster_description();
+    std::vector<remote_transfer_sample_t>* command_history = nullptr) {
+    tt_ClusterDescriptor* cluster_desc = device.get_cluster_description();
     tt_SocDescriptor const& soc_desc = device.get_virtual_soc_descriptors().at(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
 
@@ -609,21 +648,30 @@ void RunMixedTransfersUniformDistributions(
         seed,
         std::uniform_int_distribution<int>(0, core_index_to_location.size() - 1),
         [&core_index_to_location](int dest) -> destination_t { return core_index_to_location.at(dest); });
-    auto addr_generator = ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(seed + 1, address_distribution, address_aligner);
-    auto addr_generator_32B_aligned = ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(seed + 1, address_distribution, address_aligner_32B);
-    auto write_size_generator = ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
-        seed + 2, write_size_distribution, transfer_size_aligner);
-    auto read_size_generator = ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
-        seed + 2, read_size_distribution, transfer_size_aligner);
+    auto addr_generator = ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(
+        seed + 1, address_distribution, address_aligner);
+    auto addr_generator_32B_aligned =
+        ConstrainedTemplateTemplateGenerator<address_t, address_t, std::uniform_int_distribution>(
+            seed + 1, address_distribution, address_aligner_32B);
+    auto write_size_generator =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
+            seed + 2, write_size_distribution, transfer_size_aligner);
+    auto read_size_generator =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
+            seed + 2, read_size_distribution, transfer_size_aligner);
     auto last_epoch_cmd_generator = ConstrainedTemplateGenerator<bool, bool, std::bernoulli_distribution>(
-        seed + 3, std::bernoulli_distribution(percent_not_last_epoch_cmd), [](bool last_epoch_cmd) -> bool { return last_epoch_cmd; });
+        seed + 3, std::bernoulli_distribution(percent_not_last_epoch_cmd), [](bool last_epoch_cmd) -> bool {
+            return last_epoch_cmd;
+        });
     auto ordered_generator = ConstrainedTemplateGenerator<bool, bool, std::bernoulli_distribution>(
-        seed + 3, std::bernoulli_distribution(percent_not_remote_ordered), [](bool ordered_with_prev_remote_write) -> bool { return ordered_with_prev_remote_write; });
+        seed + 3,
+        std::bernoulli_distribution(percent_not_remote_ordered),
+        [](bool ordered_with_prev_remote_write) -> bool { return ordered_with_prev_remote_write; });
     auto unroll_count_generator = ConstrainedTemplateTemplateGenerator<int, int, std::uniform_int_distribution>(
         seed + 4, unroll_count_distribution, [](int unroll_count) -> int { return unroll_count; });
 
     RunMixedTransfers(
-        device, 
+        device,
         num_samples,
         seed,
 
@@ -631,12 +679,9 @@ void RunMixedTransfersUniformDistributions(
 
         WriteCommandGenerator(dest_generator, addr_generator, write_size_generator),
         ReadCommandGenerator(dest_generator, addr_generator, read_size_generator),
-        
+
         record_command_history,
-        command_history
-    );
-
+        command_history);
 }
-
 
 }  // namespace tt::umd::test::utils

--- a/tests/unit_test_main.cpp
+++ b/tests/unit_test_main.cpp
@@ -3,10 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "gtest/gtest.h"
-
 #include "gtest_initializer.hpp"
 
 int main(int argc, char **argv) {
-  initialize_gtest(argc, argv);
-  return RUN_ALL_TESTS();
+    initialize_gtest(argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/wormhole/test_silicon_driver_wh.cpp
+++ b/tests/wormhole/test_silicon_driver_wh.cpp
@@ -306,8 +306,8 @@ TEST(SiliconDriverWH, StaticTLB_RW) {
     // Check functionality of Static TLBs by reading adn writing from statically mapped address space
     for (int i = 0; i < target_devices.size(); i++) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
-        for (int loop = 0; loop < 100;
-             loop++) {  // Write to each core a 100 times at different statically mapped addresses
+        // Write to each core a 100 times at different statically mapped addresses
+        for (int loop = 0; loop < 100; loop++) {
             for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
                 device.write_to_device(
                     vector_to_write.data(),
@@ -315,7 +315,8 @@ TEST(SiliconDriverWH, StaticTLB_RW) {
                     tt_cxy_pair(i, core),
                     address,
                     "");
-                device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
+                // Barrier to ensure that all writes over ethernet were commited
+                device.wait_for_non_mmio_flush();
                 test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "");
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
@@ -355,8 +356,8 @@ TEST(SiliconDriverWH, DynamicTLB_RW) {
 
     for (int i = 0; i < target_devices.size(); i++) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
-        for (int loop = 0; loop < 100;
-             loop++) {  // Write to each core a 100 times at different statically mapped addresses
+        // Write to each core a 100 times at different statically mapped addresses
+        for (int loop = 0; loop < 100; loop++) {
             for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
                 device.write_to_device(
                     vector_to_write.data(),
@@ -364,7 +365,8 @@ TEST(SiliconDriverWH, DynamicTLB_RW) {
                     tt_cxy_pair(i, core),
                     address,
                     "SMALL_READ_WRITE_TLB");
-                device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
+                // Barrier to ensure that all writes over ethernet were commited
+                device.wait_for_non_mmio_flush();
                 test_utils::read_data_from_device(
                     device, readback_vec, tt_cxy_pair(i, core), address, 40, "SMALL_READ_WRITE_TLB");
                 ASSERT_EQ(vector_to_write, readback_vec)

--- a/tests/wormhole/test_silicon_driver_wh.cpp
+++ b/tests/wormhole/test_silicon_driver_wh.cpp
@@ -1,32 +1,40 @@
 // SPDX-FileCopyrightText: (c) 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-#include <thread>
 #include <memory>
+#include <thread>
 
-#include "gtest/gtest.h"
 #include "cluster.h"
-#include "eth_l1_address_map.h"
-#include "l1_address_map.h"
-#include "host_mem_address_map.h"
-
 #include "device/tt_cluster_descriptor.h"
 #include "device/wormhole/wormhole_implementation.h"
-#include "tests/test_utils/generate_cluster_desc.hpp"
+#include "eth_l1_address_map.h"
+#include "gtest/gtest.h"
+#include "host_mem_address_map.h"
+#include "l1_address_map.h"
 #include "tests/test_utils/device_test_utils.hpp"
+#include "tests/test_utils/generate_cluster_desc.hpp"
 
 using namespace tt::umd;
 
-
 void set_params_for_remote_txn(Cluster& device) {
     // Populate address map and NOC parameters that the driver needs for remote transactions
-    device.set_device_l1_address_params({l1_mem::address_map::L1_BARRIER_BASE, eth_l1_mem::address_map::ERISC_BARRIER_BASE, eth_l1_mem::address_map::FW_VERSION_ADDR});
+    device.set_device_l1_address_params(
+        {l1_mem::address_map::L1_BARRIER_BASE,
+         eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+         eth_l1_mem::address_map::FW_VERSION_ADDR});
 }
 
 std::int32_t get_static_tlb_index(tt_xy_pair target) {
-    bool is_eth_location = std::find(std::cbegin(tt::umd::wormhole::ETH_LOCATIONS), std::cend(tt::umd::wormhole::ETH_LOCATIONS), target) != std::cend(tt::umd::wormhole::ETH_LOCATIONS);
-    bool is_tensix_location = std::find(std::cbegin(tt::umd::wormhole::T6_X_LOCATIONS), std::cend(tt::umd::wormhole::T6_X_LOCATIONS), target.x) != std::cend(tt::umd::wormhole::T6_X_LOCATIONS) &&
-                            std::find(std::cbegin(tt::umd::wormhole::T6_Y_LOCATIONS), std::cend(tt::umd::wormhole::T6_Y_LOCATIONS), target.y) != std::cend(tt::umd::wormhole::T6_Y_LOCATIONS);
+    bool is_eth_location =
+        std::find(std::cbegin(tt::umd::wormhole::ETH_LOCATIONS), std::cend(tt::umd::wormhole::ETH_LOCATIONS), target) !=
+        std::cend(tt::umd::wormhole::ETH_LOCATIONS);
+    bool is_tensix_location =
+        std::find(
+            std::cbegin(tt::umd::wormhole::T6_X_LOCATIONS), std::cend(tt::umd::wormhole::T6_X_LOCATIONS), target.x) !=
+            std::cend(tt::umd::wormhole::T6_X_LOCATIONS) &&
+        std::find(
+            std::cbegin(tt::umd::wormhole::T6_Y_LOCATIONS), std::cend(tt::umd::wormhole::T6_Y_LOCATIONS), target.y) !=
+            std::cend(tt::umd::wormhole::T6_Y_LOCATIONS);
     if (is_eth_location) {
         if (target.y == 6) {
             target.y = 1;
@@ -65,7 +73,8 @@ std::int32_t get_static_tlb_index(tt_xy_pair target) {
 
 std::set<chip_id_t> get_target_devices() {
     std::set<chip_id_t> target_devices;
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq = tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
+        tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
     for (int i = 0; i < cluster_desc_uniq->get_number_of_chips(); i++) {
         target_devices.insert(i);
     }
@@ -77,8 +86,15 @@ TEST(SiliconDriverWH, CreateDestroy) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     tt_device_params default_params;
     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
-    for(int i = 0; i < 50; i++) {
-        Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_1x1.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, false);
+    for (int i = 0; i < 50; i++) {
+        Cluster device = Cluster(
+            test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_1x1.yaml"),
+            tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+            target_devices,
+            num_host_mem_ch_per_mmio_device,
+            false,
+            true,
+            false);
         set_params_for_remote_txn(device);
         device.start_device(default_params);
         device.deassert_risc_reset();
@@ -97,11 +113,13 @@ TEST(SiliconDriverWH, Harvesting) {
 
     ASSERT_EQ(device.using_harvested_soc_descriptors(), true) << "Expected Driver to have performed harvesting";
 
-    for(const auto& chip : sdesc_per_chip) {
-        ASSERT_EQ(chip.second.workers.size(), 48) << "Expected SOC descriptor with harvesting to have 48 workers for chip" << chip.first;
+    for (const auto& chip : sdesc_per_chip) {
+        ASSERT_EQ(chip.second.workers.size(), 48)
+            << "Expected SOC descriptor with harvesting to have 48 workers for chip" << chip.first;
     }
-    for(int i = 0; i < num_devices; i++){
-        ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(i), simulated_harvesting_masks.at(i)) << "Expecting chip " << i << " to have harvesting mask of " << simulated_harvesting_masks.at(i);
+    for (int i = 0; i < num_devices; i++) {
+        ASSERT_EQ(device.get_harvesting_masks_for_soc_descriptors().at(i), simulated_harvesting_masks.at(i))
+            << "Expecting chip " << i << " to have harvesting mask of " << simulated_harvesting_masks.at(i);
     }
 }
 
@@ -111,11 +129,20 @@ TEST(SiliconDriverWH, CustomSocDesc) {
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
-    Cluster device = Cluster(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_1x1.yaml"), tt_ClusterDescriptor::get_cluster_descriptor_file_path(), target_devices, num_host_mem_ch_per_mmio_device, false, true, false, simulated_harvesting_masks);
+    Cluster device = Cluster(
+        test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_1x1.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true,
+        false,
+        simulated_harvesting_masks);
     auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
-    ASSERT_EQ(device.using_harvested_soc_descriptors(), false) << "SOC descriptors should not be modified when harvesting is disabled";
-    for(const auto& chip : sdesc_per_chip) {
+    ASSERT_EQ(device.using_harvested_soc_descriptors(), false)
+        << "SOC descriptors should not be modified when harvesting is disabled";
+    for (const auto& chip : sdesc_per_chip) {
         ASSERT_EQ(chip.second.workers.size(), 1) << "Expected 1x1 SOC descriptor to be unmodified by driver";
     }
 }
@@ -190,9 +217,7 @@ TEST(SiliconDriverWH, HarvestingRuntime) {
 #endif
 
 TEST(SiliconDriverWH, UnalignedStaticTLB_RW) {
-    auto get_static_tlb_index_callback = [] (tt_xy_pair target) {
-        return get_static_tlb_index(target);
-    };
+    auto get_static_tlb_index_callback = [](tt_xy_pair target) { return get_static_tlb_index(target); };
 
     std::set<chip_id_t> target_devices = get_target_devices();
     int num_devices = target_devices.size();
@@ -202,13 +227,14 @@ TEST(SiliconDriverWH, UnalignedStaticTLB_RW) {
     set_params_for_remote_txn(device);
     auto mmio_devices = device.get_target_mmio_device_ids();
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over MMIO devices and only setup static TLBs for worker cores
-        if(std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
+        if (std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
             auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-            for(auto& core : sdesc.workers) {
+            for (auto& core : sdesc.workers) {
                 // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
-                device.configure_tlb(i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
+                device.configure_tlb(
+                    i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
             }
             device.setup_core_to_tlb_map(i, get_static_tlb_index_callback);
         }
@@ -219,16 +245,16 @@ TEST(SiliconDriverWH, UnalignedStaticTLB_RW) {
     device.deassert_risc_reset();
 
     std::vector<uint32_t> unaligned_sizes = {3, 14, 21, 255, 362, 430, 1022, 1023, 1025};
-    for(int i = 0; i < num_devices; i++) {
-        for(const auto& size : unaligned_sizes) {
+    for (int i = 0; i < num_devices; i++) {
+        for (const auto& size : unaligned_sizes) {
             std::vector<uint8_t> write_vec(size, 0);
-            for(int i = 0; i < size; i++){
+            for (int i = 0; i < size; i++) {
                 write_vec[i] = size + i;
             }
             std::vector<uint8_t> readback_vec(size, 0);
             std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
-            for(int loop = 0; loop < 50; loop++){
-                for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+            for (int loop = 0; loop < 50; loop++) {
+                for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
                     device.write_to_device(write_vec.data(), size, tt_cxy_pair(i, core), address, "");
                     device.wait_for_non_mmio_flush();
                     device.read_from_device(readback_vec.data(), tt_cxy_pair(i, core), address, size, "");
@@ -242,16 +268,13 @@ TEST(SiliconDriverWH, UnalignedStaticTLB_RW) {
                 }
                 address += 0x20;
             }
-
         }
     }
     device.close_device();
 }
 
 TEST(SiliconDriverWH, StaticTLB_RW) {
-    auto get_static_tlb_index_callback = [] (tt_xy_pair target) {
-        return get_static_tlb_index(target);
-    };
+    auto get_static_tlb_index_callback = [](tt_xy_pair target) { return get_static_tlb_index(target); };
 
     std::set<chip_id_t> target_devices = get_target_devices();
 
@@ -260,18 +283,18 @@ TEST(SiliconDriverWH, StaticTLB_RW) {
     set_params_for_remote_txn(device);
     auto mmio_devices = device.get_target_mmio_device_ids();
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over MMIO devices and only setup static TLBs for worker cores
-        if(std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
+        if (std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
             auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-            for(auto& core : sdesc.workers) {
+            for (auto& core : sdesc.workers) {
                 // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
-                device.configure_tlb(i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
+                device.configure_tlb(
+                    i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
             }
             device.setup_core_to_tlb_map(i, get_static_tlb_index_callback);
         }
     }
-
 
     tt_device_params default_params;
     device.start_device(default_params);
@@ -281,27 +304,40 @@ TEST(SiliconDriverWH, StaticTLB_RW) {
     std::vector<uint32_t> readback_vec = {};
     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     // Check functionality of Static TLBs by reading adn writing from statically mapped address space
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
-        for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
-            for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "");
-                device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over ethernet were commited
+        for (int loop = 0; loop < 100;
+             loop++) {  // Write to each core a 100 times at different statically mapped addresses
+            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "");
+                device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
                 test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 device.wait_for_non_mmio_flush();
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB"); // Clear any written data
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");  // Clear any written data
                 device.wait_for_non_mmio_flush();
                 readback_vec = {};
             }
-            address += 0x20; // Increment by uint32_t size for each write
+            address += 0x20;  // Increment by uint32_t size for each write
         }
     }
     device.close_device();
 }
 
 TEST(SiliconDriverWH, DynamicTLB_RW) {
-    // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for each transaction
+    // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for
+    // each transaction
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
@@ -317,20 +353,33 @@ TEST(SiliconDriverWH, DynamicTLB_RW) {
     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     std::vector<uint32_t> readback_vec = {};
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
-        for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
-            for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB");
-                device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over ethernet were commited
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, 40, "SMALL_READ_WRITE_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+        for (int loop = 0; loop < 100;
+             loop++) {  // Write to each core a 100 times at different statically mapped addresses
+            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
+                device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, 40, "SMALL_READ_WRITE_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 device.wait_for_non_mmio_flush();
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "SMALL_READ_WRITE_TLB");
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
                 device.wait_for_non_mmio_flush();
                 readback_vec = {};
             }
-            address += 0x20; // Increment by uint32_t size for each write
+            address += 0x20;  // Increment by uint32_t size for each write
         }
     }
     device.close_device();
@@ -344,7 +393,7 @@ TEST(SiliconDriverWH, MultiThreadedDevice) {
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     Cluster device = Cluster(num_host_mem_ch_per_mmio_device, false, true, true);
-    
+
     set_params_for_remote_txn(device);
 
     tt_device_params default_params;
@@ -355,11 +404,18 @@ TEST(SiliconDriverWH, MultiThreadedDevice) {
         std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
-        for(int loop = 0; loop < 100; loop++) {
-            for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-                device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+        for (int loop = 0; loop < 100; loop++) {
+            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+                device.write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(0, core),
+                    address,
+                    "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 readback_vec = {};
             }
             address += 0x20;
@@ -370,12 +426,19 @@ TEST(SiliconDriverWH, MultiThreadedDevice) {
         std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = 0x30000000;
-        for(auto& core_ls : device.get_virtual_soc_descriptors().at(0).dram_cores) {
-            for(int loop = 0; loop < 100; loop++) {
-                for(auto& core : core_ls) {
-                    device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "SMALL_READ_WRITE_TLB");
-                    test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
-                    ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+        for (auto& core_ls : device.get_virtual_soc_descriptors().at(0).dram_cores) {
+            for (int loop = 0; loop < 100; loop++) {
+                for (auto& core : core_ls) {
+                    device.write_to_device(
+                        vector_to_write.data(),
+                        vector_to_write.size() * sizeof(std::uint32_t),
+                        tt_cxy_pair(0, core),
+                        address,
+                        "SMALL_READ_WRITE_TLB");
+                    test_utils::read_data_from_device(
+                        device, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
+                    ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y
+                                                             << "does not match what was written";
                     readback_vec = {};
                 }
                 address += 0x20;
@@ -394,9 +457,7 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     // We want to make sure the memory barrier is thread/process safe.
 
     // Memory barrier flags get sent to address 0 for all channels in this test
-    auto get_static_tlb_index_callback = [] (tt_xy_pair target) {
-        return get_static_tlb_index(target);
-    };
+    auto get_static_tlb_index_callback = [](tt_xy_pair target) { return get_static_tlb_index(target); };
 
     std::set<chip_id_t> target_devices = get_target_devices();
     uint32_t base_addr = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
@@ -406,11 +467,11 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     set_params_for_remote_txn(device);
     auto mmio_devices = device.get_target_mmio_device_ids();
 
-    for(int i = 0; i < target_devices.size(); i++) {
+    for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for functional worker cores
-        if(std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
+        if (std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
             auto& sdesc = device.get_virtual_soc_descriptors().at(i);
-            for(auto& core : sdesc.workers) {
+            for (auto& core : sdesc.workers) {
                 // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
                 device.configure_tlb(i, core, get_static_tlb_index_callback(core), base_addr);
             }
@@ -423,22 +484,39 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     device.deassert_risc_reset();
 
     std::vector<uint32_t> readback_membar_vec = {};
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all workers
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        test_utils::read_data_from_device(
+            device,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            l1_mem::address_map::L1_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all workers
         readback_membar_vec = {};
     }
 
-    for(int chan = 0; chan <  device.get_virtual_soc_descriptors().at(0).get_num_dram_channels(); chan++) {
+    for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(0).get_num_dram_channels(); chan++) {
         auto core = device.get_virtual_soc_descriptors().at(0).get_core_for_dram_channel(chan, 0);
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all DRAM
+        test_utils::read_data_from_device(
+            device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all DRAM
         readback_membar_vec = {};
     }
 
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers were correctly initialized on all ethernet cores
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
+        test_utils::read_data_from_device(
+            device,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0),
+            187);  // Ensure that memory barriers were correctly initialized on all ethernet cores
         readback_membar_vec = {};
     }
 
@@ -448,38 +526,43 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     std::vector<uint32_t> vec2(2560);
     std::vector<uint32_t> zeros(2560, 0);
 
-    for(int i = 0; i < vec1.size(); i++) {
+    for (int i = 0; i < vec1.size(); i++) {
         vec1.at(i) = i;
     }
-    for(int i = 0; i < vec2.size(); i++) {
+    for (int i = 0; i < vec2.size(); i++) {
         vec2.at(i) = vec1.size() + i;
     }
     std::thread th1 = std::thread([&] {
         std::uint32_t address = base_addr;
-        for(int loop = 0; loop < 50; loop++) {
-            for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        for (int loop = 0; loop < 50; loop++) {
+            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
-                device.write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                device.write_to_device(
+                    vec1.data(), vec1.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 device.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 4*vec1.size(), "");
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(0, core), address, 4 * vec1.size(), "");
                 ASSERT_EQ(readback_vec, vec1);
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                device.write_to_device(
+                    zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 readback_vec = {};
             }
-
         }
     });
 
     std::thread th2 = std::thread([&] {
         std::uint32_t address = base_addr + vec1.size() * 4;
-        for(int loop = 0; loop < 50; loop++) {
-            for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        for (int loop = 0; loop < 50; loop++) {
+            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
-                device.write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                device.write_to_device(
+                    vec2.data(), vec2.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 device.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(0, core), address, 4*vec2.size(), "");
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(0, core), address, 4 * vec2.size(), "");
                 ASSERT_EQ(readback_vec, vec2);
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "") ;
+                device.write_to_device(
+                    zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
                 readback_vec = {};
             }
         }
@@ -488,27 +571,41 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     th1.join();
     th2.join();
 
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers end up in the correct sate for workers
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+        test_utils::read_data_from_device(
+            device,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            l1_mem::address_map::L1_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0), 187);  // Ensure that memory barriers end up in the correct sate for workers
         readback_membar_vec = {};
     }
 
-    for(auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
-        test_utils::read_data_from_device(device, readback_membar_vec, tt_cxy_pair(0, core), eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
-        ASSERT_EQ(readback_membar_vec.at(0), 187); // Ensure that memory barriers end up in the correct sate for ethernet cores
+    for (auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
+        test_utils::read_data_from_device(
+            device,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
+        ASSERT_EQ(
+            readback_membar_vec.at(0),
+            187);  // Ensure that memory barriers end up in the correct sate for ethernet cores
         readback_membar_vec = {};
     }
     device.close_device();
 }
-
 
 TEST(SiliconDriverWH, BroadcastWrite) {
     // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    
+
     Cluster device = Cluster(num_host_mem_ch_per_mmio_device, false, true, true);
     set_params_for_remote_txn(device);
     auto mmio_devices = device.get_target_mmio_device_ids();
@@ -523,33 +620,64 @@ TEST(SiliconDriverWH, BroadcastWrite) {
     std::set<uint32_t> rows_to_exclude_for_dram_broadcast = {};
     std::set<uint32_t> cols_to_exclude_for_dram_broadcast = {1, 2, 3, 4, 6, 7, 8, 9};
 
-    for(const auto& size : broadcast_sizes) {
+    for (const auto& size : broadcast_sizes) {
         std::vector<uint32_t> vector_to_write(size);
         std::vector<uint32_t> zeros(size);
         std::vector<uint32_t> readback_vec = {};
-        for(int i = 0; i < size; i++) {
+        for (int i = 0; i < size; i++) {
             vector_to_write[i] = i;
             zeros[i] = 0;
         }
         // Broadcast to Tensix
-        device.broadcast_write_to_cluster(vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude, "LARGE_WRITE_TLB");
+        device.broadcast_write_to_cluster(
+            vector_to_write.data(),
+            vector_to_write.size() * 4,
+            address,
+            {},
+            rows_to_exclude,
+            cols_to_exclude,
+            "LARGE_WRITE_TLB");
         // Broadcast to DRAM
-        device.broadcast_write_to_cluster(vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude_for_dram_broadcast, cols_to_exclude_for_dram_broadcast, "LARGE_WRITE_TLB");
+        device.broadcast_write_to_cluster(
+            vector_to_write.data(),
+            vector_to_write.size() * 4,
+            address,
+            {},
+            rows_to_exclude_for_dram_broadcast,
+            cols_to_exclude_for_dram_broadcast,
+            "LARGE_WRITE_TLB");
         device.wait_for_non_mmio_flush();
 
-        for(const auto i : target_devices) {
-            for(const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                if(rows_to_exclude.find(core.y) != rows_to_exclude.end()) continue;
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was broadcasted";
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+        for (const auto i : target_devices) {
+            for (const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
+                    continue;
+                }
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y
+                                                         << "does not match what was broadcasted";
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
-            for(int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
                 const auto& core = device.get_virtual_soc_descriptors().at(i).get_core_for_dram_channel(chan, 0);
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from DRAM core " << i << " " << core.x << "-" << core.y << " does not match what was broadcasted " << size;
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from DRAM core " << i << " " << core.x << "-" << core.y
+                    << " does not match what was broadcasted " << size;
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
         }
@@ -564,7 +692,7 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
     std::set<chip_id_t> target_devices = get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    
+
     Cluster device = Cluster(num_host_mem_ch_per_mmio_device, false, true, true);
     set_params_for_remote_txn(device);
     auto mmio_devices = device.get_target_mmio_device_ids();
@@ -572,10 +700,12 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
     tt_device_params default_params;
     device.start_device(default_params);
     auto eth_version = device.get_ethernet_fw_version();
-    bool virtual_bcast_supported = (eth_version >= tt_version(6, 8, 0) || eth_version == tt_version(6, 7, 241)) && device.translation_tables_en;
+    bool virtual_bcast_supported =
+        (eth_version >= tt_version(6, 8, 0) || eth_version == tt_version(6, 7, 241)) && device.translation_tables_en;
     if (!virtual_bcast_supported) {
         device.close_device();
-        GTEST_SKIP() << "SiliconDriverWH.VirtualCoordinateBroadcast skipped since ethernet version does not support Virtual Coordinate Broadcast or NOC translation is not enabled";
+        GTEST_SKIP() << "SiliconDriverWH.VirtualCoordinateBroadcast skipped since ethernet version does not support "
+                        "Virtual Coordinate Broadcast or NOC translation is not enabled";
     }
 
     device.deassert_risc_reset();
@@ -586,33 +716,64 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
     std::set<uint32_t> rows_to_exclude_for_dram_broadcast = {};
     std::set<uint32_t> cols_to_exclude_for_dram_broadcast = {1, 2, 3, 4, 6, 7, 8, 9};
 
-    for(const auto& size : broadcast_sizes) {
+    for (const auto& size : broadcast_sizes) {
         std::vector<uint32_t> vector_to_write(size);
         std::vector<uint32_t> zeros(size);
         std::vector<uint32_t> readback_vec = {};
-        for(int i = 0; i < size; i++) {
+        for (int i = 0; i < size; i++) {
             vector_to_write[i] = i;
             zeros[i] = 0;
         }
         // Broadcast to Tensix
-        device.broadcast_write_to_cluster(vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude, "LARGE_WRITE_TLB");
+        device.broadcast_write_to_cluster(
+            vector_to_write.data(),
+            vector_to_write.size() * 4,
+            address,
+            {},
+            rows_to_exclude,
+            cols_to_exclude,
+            "LARGE_WRITE_TLB");
         // Broadcast to DRAM
-        device.broadcast_write_to_cluster(vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude_for_dram_broadcast, cols_to_exclude_for_dram_broadcast, "LARGE_WRITE_TLB");
+        device.broadcast_write_to_cluster(
+            vector_to_write.data(),
+            vector_to_write.size() * 4,
+            address,
+            {},
+            rows_to_exclude_for_dram_broadcast,
+            cols_to_exclude_for_dram_broadcast,
+            "LARGE_WRITE_TLB");
         device.wait_for_non_mmio_flush();
 
-        for(const auto i : target_devices) {
-            for(const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
-                if(rows_to_exclude.find(core.y) != rows_to_exclude.end()) continue;
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y << "does not match what was broadcasted";
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+        for (const auto i : target_devices) {
+            for (const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
+                    continue;
+                }
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y
+                                                         << "does not match what was broadcasted";
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
-            for(int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
                 const auto& core = device.get_virtual_soc_descriptors().at(i).get_core_for_dram_channel(chan, 0);
-                test_utils::read_data_from_device(device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
-                ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from DRAM core " << i << " " << core.x << "-" << core.y << " does not match what was broadcasted " << size;
-                device.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "LARGE_WRITE_TLB"); // Clear any written data
+                test_utils::read_data_from_device(
+                    device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from DRAM core " << i << " " << core.x << "-" << core.y
+                    << " does not match what was broadcasted " << size;
+                device.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    tt_cxy_pair(i, core),
+                    address,
+                    "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
         }
@@ -621,7 +782,6 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
     }
     device.close_device();
 }
-
 
 /**
  * This is a basic DMA test -- not using the PCIe controller's DMA engine, but
@@ -647,10 +807,11 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
 TEST(SiliconDriverWH, SysmemTestWithPcie) {
     auto target_devices = get_target_devices();
 
-    Cluster cluster(1,  // one "host memory channel", currently a 1G huge page
-                            false, // skip driver allocs - no (don't skip)
-                            true,  // clean system resources - yes
-                            true); // perform harvesting - yes
+    Cluster cluster(
+        1,      // one "host memory channel", currently a 1G huge page
+        false,  // skip driver allocs - no (don't skip)
+        true,   // clean system resources - yes
+        true);  // perform harvesting - yes
 
     set_params_for_remote_txn(cluster);
     cluster.start_device(tt_device_params{});  // no special parameters
@@ -667,7 +828,7 @@ TEST(SiliconDriverWH, SysmemTestWithPcie) {
     // Bad API: how big is the buffer?  How do we know it's big enough?
     // Situation today is that there's a 1G hugepage behind it, although this is
     // unclear from the API and may change in the future.
-    uint8_t *sysmem = (uint8_t*)cluster.host_dma_address(0, 0, 0);
+    uint8_t* sysmem = (uint8_t*)cluster.host_dma_address(0, 0, 0);
     ASSERT_NE(sysmem, nullptr);
 
     // This is the address inside the Wormhole PCIe block that is mapped to the
@@ -710,13 +871,14 @@ TEST(SiliconDriverWH, RandomSysmemTestWithPcie) {
     const size_t num_channels = 2;  // ideally 4, but CI seems to have 2...
     auto target_devices = get_target_devices();
 
-    Cluster cluster(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"),
-                    tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
-                    target_devices,
-                    num_channels,
-                    false, // skip driver allocs - no (don't skip)
-                    true,  // clean system resources - yes
-                    true); // perform harvesting - yes
+    Cluster cluster(
+        test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"),
+        tt_ClusterDescriptor::get_cluster_descriptor_file_path(),
+        target_devices,
+        num_channels,
+        false,  // skip driver allocs - no (don't skip)
+        true,   // clean system resources - yes
+        true);  // perform harvesting - yes
 
     set_params_for_remote_txn(cluster);
     cluster.start_device(tt_device_params{});  // no special parameters
@@ -725,7 +887,7 @@ TEST(SiliconDriverWH, RandomSysmemTestWithPcie) {
     const auto PCIE = cluster.get_soc_descriptor(mmio_chip_id).pcie_cores.at(0);
     const tt_cxy_pair PCIE_CORE(mmio_chip_id, PCIE.x, PCIE.y);
     const size_t ONE_GIG = 1 << 30;
-    const size_t num_tests = 0x20000;   // runs in a reasonable amount of time
+    const size_t num_tests = 0x20000;  // runs in a reasonable amount of time
 
     // PCIe core is at (x=0, y=3) on Wormhole NOC0.
     ASSERT_EQ(PCIE.x, 0);
@@ -735,13 +897,13 @@ TEST(SiliconDriverWH, RandomSysmemTestWithPcie) {
     auto generate_aligned_address = [&](uint64_t lo, uint64_t hi) -> uint64_t {
         static std::random_device rd;
         static std::mt19937_64 gen(rd());
-        std::uniform_int_distribution<uint64_t> dis(lo/ALIGNMENT, hi/ALIGNMENT);
+        std::uniform_int_distribution<uint64_t> dis(lo / ALIGNMENT, hi / ALIGNMENT);
         return dis(gen) * ALIGNMENT;
     };
 
     uint64_t base_address = cluster.get_pcie_base_addr_from_device(mmio_chip_id);
     for (size_t channel = 0; channel < num_channels; ++channel) {
-        uint8_t *sysmem = (uint8_t*)cluster.host_dma_address(0, 0, channel);
+        uint8_t* sysmem = (uint8_t*)cluster.host_dma_address(0, 0, channel);
         ASSERT_NE(sysmem, nullptr);
 
         test_utils::fill_with_random_bytes(sysmem, ONE_GIG);
@@ -774,4 +936,3 @@ TEST(SiliconDriverWH, RandomSysmemTestWithPcie) {
         }
     }
 }
-

--- a/tests/wormhole/test_umd_remote_api_stability.cpp
+++ b/tests/wormhole/test_umd_remote_api_stability.cpp
@@ -65,19 +65,19 @@ TEST_F(WormholeNebulaX2TestFixture, MixedRemoteTransfersMediumSmall) {
             *device,
             100000 * scale_number_of_tests,
             0,
-
             transfer_type_weights_t{.write = 0.25, .read = 0.25},
-
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            // address generator distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),
+            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<int>(2, 4),
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // Set to true if you want to emit the command history code to command line
+            false,
             &command_history);
     } catch (...) {
         print_command_history_executable_code(command_history);
@@ -99,19 +99,19 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersMediumSmall
             *device,
             100000 * scale_number_of_tests,
             0,
-
             transfer_type_weights_t{.write = 0.50, .read = 0.50},
-
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            // address generator distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),
+            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<int>(2, 4),
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // Set to true if you want to emit the command history code to command line
+            false,
             &command_history0);
     });
     std::thread t2([&]() {
@@ -119,19 +119,19 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersMediumSmall
             *device,
             100000 * scale_number_of_tests,
             100,
-
             transfer_type_weights_t{.write = 0.25, .read = 0.50},
-
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            // address generator distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),
+            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<int>(2, 4),
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // Set to true if you want to emit the command history code to command line
+            false,
             &command_history1);
     });
     std::thread t3([&]() {
@@ -139,19 +139,19 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersMediumSmall
             *device,
             100000 * scale_number_of_tests,
             23,
-
             transfer_type_weights_t{.write = 0.5, .read = 0.25},
-
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            // address generator distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),
+            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<int>(2, 4),
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // Set to true if you want to emit the command history code to command line
+            false,
             &command_history2);
     });
     std::thread t4([&]() {
@@ -159,19 +159,19 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersMediumSmall
             *device,
             100000 * scale_number_of_tests,
             99,
-
             transfer_type_weights_t{.write = 1.0, .read = 0.0},
-
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            // address generator distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),
+            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<int>(2, 4),
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // Set to true if you want to emit the command history code to command line
+            false,
             &command_history3);
     });
 
@@ -193,19 +193,19 @@ TEST_F(WormholeNebulaX2TestFixture, MixedRemoteTransfersLarge) {
             *device,
             10000 * scale_number_of_tests,
             0,
-
             transfer_type_weights_t{.write = 0.15, .read = 0.15},
-
-            std::uniform_int_distribution<address_t>(0x10000, 0x200000),  // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 300000),                          // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            // address generator distribution
+            std::uniform_int_distribution<address_t>(0x10000, 0x200000),
+            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 300000),
+            // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<int>(2, 4),
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 300000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // READ_SIZE_GENERATOR_T const& read_size_distribution,
+            // Set to true if you want to emit the command history code to command line
+            std::uniform_int_distribution<transfer_size_t>(0x4, 300000),
+            false,
             &command_history);
     } catch (...) {
         print_command_history_executable_code(command_history);
@@ -233,13 +233,11 @@ TEST_F(WormholeNebulaX2TestFixture, WritesOnlyNormalDistributionMean10kStd3kMinS
             *device,
             10000 * scale_number_of_tests,
             0,
-
             transfer_type_weights_t{.write = 1., .read = 0.},
-
             WriteCommandGenerator(dest_generator, address_generator, write_size_generator),
             build_dummy_read_command_generator(*device),
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // Set to true if you want to emit the command history code to command line
+            false,
             &command_history);
     } catch (...) {
         print_command_history_executable_code(command_history);
@@ -261,19 +259,19 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLMS) {
             *device,
             100000 * scale_number_of_tests,
             0,
-
             transfer_type_weights_t{.write = 0.50, .read = 0.50},
-
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(
-                4, 300000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            // address generator distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),
+            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(4, 300000),
+            // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<int>(2, 4),
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // Set to true if you want to emit the command history code to command line
+            false,
             &command_history0);
     });
     std::thread t2([&]() {
@@ -281,19 +279,19 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLMS) {
             *device,
             100000 * scale_number_of_tests,
             100,
-
             transfer_type_weights_t{.write = 0.25, .read = 0.50},
-
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            // address generator distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),
+            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<int>(2, 4),
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // Set to true if you want to emit the command history code to command line
+            false,
             &command_history1);
     });
     std::thread t3([&]() {
@@ -301,19 +299,19 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLMS) {
             *device,
             100000 * scale_number_of_tests,
             23,
-
             transfer_type_weights_t{.write = 0.5, .read = 0.25},
-
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            // address generator distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),
+            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<int>(2, 4),
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // Set to true if you want to emit the command history code to command line
+            false,
             &command_history2);
     });
     std::thread t4([&]() {
@@ -321,19 +319,19 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLMS) {
             *device,
             100000 * scale_number_of_tests,
             99,
-
             transfer_type_weights_t{.write = 1.0, .read = 0.0},
-
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            // address generator distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),
+            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<int>(2, 4),
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(
-                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(0x4, 3000),
+            // Set to true if you want to emit the command history code to command line
+            false,
             &command_history3);
     });
 
@@ -373,13 +371,11 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLargeWrites
             *device,
             10000 * scale_number_of_tests,
             0,
-
             transfer_type_weights_t{.write = 1., .read = 0.},
-
             WriteCommandGenerator(dest_generator, address_generator, write_size_generator),
             build_dummy_read_command_generator(*device),
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // Set to true if you want to emit the command history code to command line
+            false,
             &command_history0);
     });
     std::thread write_cmds_thread2([&]() {
@@ -387,13 +383,11 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLargeWrites
             *device,
             10000 * scale_number_of_tests,
             0,
-
             transfer_type_weights_t{.write = 1., .read = 0.},
-
             WriteCommandGenerator(dest_generator, address_generator, write_size_generator),
             build_dummy_read_command_generator(*device),
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // Set to true if you want to emit the command history code to command line
+            false,
             &command_history0);
     });
     std::thread read_cmd_threads1([&]() {
@@ -401,13 +395,11 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLargeWrites
             *device,
             10000 * scale_number_of_tests,
             0,
-
             transfer_type_weights_t{.write = 0, .read = 1.},
-
             build_dummy_write_command_generator(*device),
             ReadCommandGenerator(dest_generator, address_generator, read_size_generator),
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // Set to true if you want to emit the command history code to command line
+            false,
             &command_history0);
     });
     std::thread read_cmd_threads2([&]() {
@@ -415,13 +407,11 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLargeWrites
             *device,
             10000 * scale_number_of_tests,
             0,
-
             transfer_type_weights_t{.write = 0, .read = 1.},
-
             build_dummy_write_command_generator(*device),
             ReadCommandGenerator(dest_generator, address_generator, read_size_generator),
-
-            false,  // Set to true if you want to emit the command history code to command line
+            // Set to true if you want to emit the command history code to command line
+            false,
             &command_history0);
     });
 

--- a/tests/wormhole/test_umd_remote_api_stability.cpp
+++ b/tests/wormhole/test_umd_remote_api_stability.cpp
@@ -2,58 +2,51 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <chrono>
 #include <cstdint>
+#include <ctime>
 #include <numeric>
 #include <random>
 #include <thread>
 
-#include "tt_cluster_descriptor.h"
 #include "cluster.h"
-
 #include "common/logger.hpp"
 #include "eth_interface.h"
 #include "filesystem"
 #include "gtest/gtest.h"
 #include "host_mem_address_map.h"
 #include "l1_address_map.h"
-#include "tt_soc_descriptor.h"
-
-#include "tests/test_utils/stimulus_generators.hpp"
-#include "tests/test_utils/generate_cluster_desc.hpp"
 #include "test_wh_common.h"
-
-#include <chrono>
-#include <ctime>
+#include "tests/test_utils/generate_cluster_desc.hpp"
+#include "tests/test_utils/stimulus_generators.hpp"
+#include "tt_cluster_descriptor.h"
+#include "tt_soc_descriptor.h"
 
 namespace tt::umd::test::utils {
 class WormholeNebulaX2TestFixture : public WormholeTestFixture {
- private:
-  static int detected_num_chips;
-  static bool skip_tests;
+private:
+    static int detected_num_chips;
+    static bool skip_tests;
 
- protected: 
+protected:
+    static constexpr int EXPECTED_NUM_CHIPS = 2;
+    static uint32_t scale_number_of_tests;
 
-  static constexpr int EXPECTED_NUM_CHIPS = 2;
-  static uint32_t scale_number_of_tests;
-
-  static void SetUpTestSuite() {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
-    detected_num_chips = cluster_desc->get_number_of_chips();
-    if (detected_num_chips != EXPECTED_NUM_CHIPS) {
-        skip_tests = true;
+    static void SetUpTestSuite() {
+        std::unique_ptr<tt_ClusterDescriptor> cluster_desc =
+            tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
+        detected_num_chips = cluster_desc->get_number_of_chips();
+        if (detected_num_chips != EXPECTED_NUM_CHIPS) {
+            skip_tests = true;
+        }
+        if (char const* scale_number_of_tests_env = std::getenv("SCALE_NUMBER_OF_TESTS")) {
+            scale_number_of_tests = std::atoi(scale_number_of_tests_env);
+        }
     }
-    if(char const* scale_number_of_tests_env = std::getenv("SCALE_NUMBER_OF_TESTS")) {
-        scale_number_of_tests = std::atoi(scale_number_of_tests_env);
-    }
-  }
 
-  virtual int get_detected_num_chips() {
-    return detected_num_chips;
-  }
+    virtual int get_detected_num_chips() { return detected_num_chips; }
 
-  virtual bool is_test_skipped() {
-    return skip_tests;
-  }
+    virtual bool is_test_skipped() { return skip_tests; }
 };
 
 int WormholeNebulaX2TestFixture::detected_num_chips = -1;
@@ -63,28 +56,29 @@ uint32_t WormholeNebulaX2TestFixture::scale_number_of_tests = 1;
 TEST_F(WormholeNebulaX2TestFixture, MixedRemoteTransfersMediumSmall) {
     int seed = 0;
 
-    log_info(LogSiliconDriver,"Started MixedRemoteTransfersMediumSmall");
+    log_info(LogSiliconDriver, "Started MixedRemoteTransfersMediumSmall");
 
     std::vector<remote_transfer_sample_t> command_history;
     try {
         assert(device != nullptr);
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             0,
 
             transfer_type_weights_t{.write = 0.25, .read = 0.25},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history
-        );
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history);
     } catch (...) {
         print_command_history_executable_code(command_history);
     }
@@ -93,88 +87,92 @@ TEST_F(WormholeNebulaX2TestFixture, MixedRemoteTransfersMediumSmall) {
 TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersMediumSmall) {
     int seed = 0;
 
-    log_info(LogSiliconDriver,"Started MultithreadedMixedRemoteTransfersMediumSmall");
+    log_info(LogSiliconDriver, "Started MultithreadedMixedRemoteTransfersMediumSmall");
 
     assert(device != nullptr);
     std::vector<remote_transfer_sample_t> command_history0;
     std::vector<remote_transfer_sample_t> command_history1;
     std::vector<remote_transfer_sample_t> command_history2;
     std::vector<remote_transfer_sample_t> command_history3;
-    std::thread t1([&](){
+    std::thread t1([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             0,
 
             transfer_type_weights_t{.write = 0.50, .read = 0.50},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history0
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history0);
     });
-    std::thread t2([&](){
+    std::thread t2([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             100,
 
             transfer_type_weights_t{.write = 0.25, .read = 0.50},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history1
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history1);
     });
-    std::thread t3([&](){
+    std::thread t3([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             23,
 
             transfer_type_weights_t{.write = 0.5, .read = 0.25},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history2
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history2);
     });
-    std::thread t4([&](){
+    std::thread t4([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             99,
 
             transfer_type_weights_t{.write = 1.0, .read = 0.0},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history3
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history3);
     });
 
     t1.join();
@@ -186,52 +184,53 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersMediumSmall
 TEST_F(WormholeNebulaX2TestFixture, MixedRemoteTransfersLarge) {
     int seed = 0;
 
-    log_info(LogSiliconDriver,"Started MixedRemoteTransfersLarge");
+    log_info(LogSiliconDriver, "Started MixedRemoteTransfersLarge");
 
     assert(device != nullptr);
     std::vector<remote_transfer_sample_t> command_history;
     try {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             10000 * scale_number_of_tests,
             0,
 
             transfer_type_weights_t{.write = 0.15, .read = 0.15},
 
-            std::uniform_int_distribution<address_t>(0x10000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 300000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x10000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 300000),                          // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 300000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 300000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history
-        );
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history);
     } catch (...) {
         print_command_history_executable_code(command_history);
     }
-
 }
 
 TEST_F(WormholeNebulaX2TestFixture, WritesOnlyNormalDistributionMean10kStd3kMinSizeTruncate4) {
     int seed = 0;
 
-    log_info(LogSiliconDriver,"Started WritesOnlyNormalDistributionMean10kStd3kMinSizeTruncate4");
+    log_info(LogSiliconDriver, "Started WritesOnlyNormalDistributionMean10kStd3kMinSizeTruncate4");
 
     assert(device != nullptr);
     std::vector<remote_transfer_sample_t> command_history;
 
     auto write_size_generator = ConstrainedTemplateTemplateGenerator<transfer_size_t, double, std::normal_distribution>(
-        seed, std::normal_distribution<>(10000, 3000), [](double x) -> transfer_size_t { return size_aligner_32B(static_cast<transfer_size_t>((x >= 4) ? x : 4)); });
-    
+        seed, std::normal_distribution<>(10000, 3000), [](double x) -> transfer_size_t {
+            return size_aligner_32B(static_cast<transfer_size_t>((x >= 4) ? x : 4));
+        });
 
     auto dest_generator = get_default_full_dram_dest_generator(seed, device.get());
     auto address_generator = get_default_address_generator(seed, 0x100000, 0x5000000);
 
     try {
         RunMixedTransfers(
-            *device, 
+            *device,
             10000 * scale_number_of_tests,
             0,
 
@@ -240,100 +239,102 @@ TEST_F(WormholeNebulaX2TestFixture, WritesOnlyNormalDistributionMean10kStd3kMinS
             WriteCommandGenerator(dest_generator, address_generator, write_size_generator),
             build_dummy_read_command_generator(*device),
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history
-        );
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history);
     } catch (...) {
         print_command_history_executable_code(command_history);
     }
-
 }
 
 TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLMS) {
     int seed = 0;
 
-    log_info(LogSiliconDriver,"Started MultithreadedMixedRemoteTransfersLMS");
+    log_info(LogSiliconDriver, "Started MultithreadedMixedRemoteTransfersLMS");
 
     assert(device != nullptr);
     std::vector<remote_transfer_sample_t> command_history0;
     std::vector<remote_transfer_sample_t> command_history1;
     std::vector<remote_transfer_sample_t> command_history2;
     std::vector<remote_transfer_sample_t> command_history3;
-    std::thread t1([&](){
+    std::thread t1([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             0,
 
             transfer_type_weights_t{.write = 0.50, .read = 0.50},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(4, 300000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                4, 300000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history0
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history0);
     });
-    std::thread t2([&](){
+    std::thread t2([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             100,
 
             transfer_type_weights_t{.write = 0.25, .read = 0.50},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history1
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history1);
     });
-    std::thread t3([&](){
+    std::thread t3([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             23,
 
             transfer_type_weights_t{.write = 0.5, .read = 0.25},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history2
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history2);
     });
-    std::thread t4([&](){
+    std::thread t4([&]() {
         RunMixedTransfersUniformDistributions(
-            *device, 
+            *device,
             100000 * scale_number_of_tests,
             99,
 
             transfer_type_weights_t{.write = 1.0, .read = 0.0},
 
-            std::uniform_int_distribution<address_t>(0x100000, 0x200000), // address generator distribution
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //WRITE_SIZE_GENERATOR_T const& write_size_distribution,
-            std::uniform_int_distribution<int>(2, 4), //UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
+            std::uniform_int_distribution<address_t>(0x100000, 0x200000),  // address generator distribution
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),                            // WRITE_SIZE_GENERATOR_T const& write_size_distribution,
+            std::uniform_int_distribution<int>(2, 4),  // UNROLL_COUNT_GENERATOR_T const& unroll_count_distribution
             0.75,
             0.75,
-            std::uniform_int_distribution<transfer_size_t>(0x4, 3000), //READ_SIZE_GENERATOR_T const& read_size_distribution,
+            std::uniform_int_distribution<transfer_size_t>(
+                0x4, 3000),  // READ_SIZE_GENERATOR_T const& read_size_distribution,
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history3
-        );    
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history3);
     });
 
     t1.join();
@@ -345,21 +346,29 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLMS) {
 TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLargeWritesSmallReads) {
     int seed = 0;
 
-    log_info(LogSiliconDriver,"Started MultithreadedMixedRemoteTransfersLargeWritesSmallReads");
+    log_info(LogSiliconDriver, "Started MultithreadedMixedRemoteTransfersLargeWritesSmallReads");
 
     assert(device != nullptr);
     std::vector<remote_transfer_sample_t> command_history0;
     std::vector<remote_transfer_sample_t> command_history1;
 
-    auto write_size_generator = ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
-        seed, std::uniform_int_distribution<transfer_size_t>(1000000, 30000000), [](transfer_size_t x) -> transfer_size_t { return size_aligner_32B(static_cast<transfer_size_t>((x >= 4) ? x : 4)); });
-    auto read_size_generator = ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
-        seed, std::uniform_int_distribution<transfer_size_t>(16, 4096), [](transfer_size_t x) -> transfer_size_t { return size_aligner_32B(static_cast<transfer_size_t>((x >= 4) ? x : 4)); });
+    auto write_size_generator =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
+            seed,
+            std::uniform_int_distribution<transfer_size_t>(1000000, 30000000),
+            [](transfer_size_t x) -> transfer_size_t {
+                return size_aligner_32B(static_cast<transfer_size_t>((x >= 4) ? x : 4));
+            });
+    auto read_size_generator =
+        ConstrainedTemplateTemplateGenerator<transfer_size_t, transfer_size_t, std::uniform_int_distribution>(
+            seed, std::uniform_int_distribution<transfer_size_t>(16, 4096), [](transfer_size_t x) -> transfer_size_t {
+                return size_aligner_32B(static_cast<transfer_size_t>((x >= 4) ? x : 4));
+            });
 
     auto dest_generator = get_default_full_dram_dest_generator(seed, device.get());
     auto address_generator = get_default_address_generator(seed, 0x100000, 0x5000000);
 
-    std::thread write_cmds_thread1([&](){
+    std::thread write_cmds_thread1([&]() {
         RunMixedTransfers(
             *device,
             10000 * scale_number_of_tests,
@@ -370,11 +379,10 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLargeWrites
             WriteCommandGenerator(dest_generator, address_generator, write_size_generator),
             build_dummy_read_command_generator(*device),
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history0
-        );
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history0);
     });
-    std::thread write_cmds_thread2([&](){
+    std::thread write_cmds_thread2([&]() {
         RunMixedTransfers(
             *device,
             10000 * scale_number_of_tests,
@@ -385,11 +393,10 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLargeWrites
             WriteCommandGenerator(dest_generator, address_generator, write_size_generator),
             build_dummy_read_command_generator(*device),
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history0
-        );
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history0);
     });
-    std::thread read_cmd_threads1([&](){
+    std::thread read_cmd_threads1([&]() {
         RunMixedTransfers(
             *device,
             10000 * scale_number_of_tests,
@@ -400,11 +407,10 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLargeWrites
             build_dummy_write_command_generator(*device),
             ReadCommandGenerator(dest_generator, address_generator, read_size_generator),
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history0
-        );
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history0);
     });
-    std::thread read_cmd_threads2([&](){
+    std::thread read_cmd_threads2([&]() {
         RunMixedTransfers(
             *device,
             10000 * scale_number_of_tests,
@@ -415,15 +421,13 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLargeWrites
             build_dummy_write_command_generator(*device),
             ReadCommandGenerator(dest_generator, address_generator, read_size_generator),
 
-            false, // Set to true if you want to emit the command history code to command line
-            &command_history0
-        );
+            false,  // Set to true if you want to emit the command history code to command line
+            &command_history0);
     });
 
     write_cmds_thread1.join();
     write_cmds_thread2.join();
     read_cmd_threads1.join();
     read_cmd_threads2.join();
-
 }
-} // namespace tt::umd::test::utils
+}  // namespace tt::umd::test::utils

--- a/tests/wormhole/test_wh_common.h
+++ b/tests/wormhole/test_wh_common.h
@@ -5,80 +5,79 @@
  */
 #pragma once
 
-#include "tt_cluster_descriptor.h"
 #include "cluster.h"
-#include "tt_xy_pair.h"
 #include "eth_l1_address_map.h"
-
-#include "tests/test_utils/stimulus_generators.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
+#include "tests/test_utils/stimulus_generators.hpp"
+#include "tt_cluster_descriptor.h"
+#include "tt_xy_pair.h"
 
 namespace tt::umd::test::utils {
 
 static void set_params_for_remote_txn(Cluster& device) {
     // Populate address map and NOC parameters that the driver needs for remote transactions
-    device.set_device_l1_address_params({l1_mem::address_map::L1_BARRIER_BASE, eth_l1_mem::address_map::ERISC_BARRIER_BASE, eth_l1_mem::address_map::FW_VERSION_ADDR});
+    device.set_device_l1_address_params(
+        {l1_mem::address_map::L1_BARRIER_BASE,
+         eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+         eth_l1_mem::address_map::FW_VERSION_ADDR});
 }
 
 class WormholeTestFixture : public ::testing::Test {
- protected:
-  // You can remove any or all of the following functions if their bodies would
-  // be empty.
+protected:
+    // You can remove any or all of the following functions if their bodies would
+    // be empty.
 
-  std::unique_ptr<Cluster> device;
+    std::unique_ptr<Cluster> device;
 
-  WormholeTestFixture() {
+    WormholeTestFixture() {}
 
-  }
-
-  ~WormholeTestFixture() override {
-     // You can do clean-up work that doesn't throw exceptions here.
-  }
-
-  virtual int get_detected_num_chips() = 0;
-  virtual bool is_test_skipped() = 0;
-
-  // If the constructor and destructor are not enough for setting up
-  // and cleaning up each test, you can define the following methods:
-
-  void SetUp() override {
-    // Code here will be called immediately after the constructor (right
-    // before each test).
-
-    if (is_test_skipped()) {
-        GTEST_SKIP() << "Test is skipped due to incorrect number of chips";
+    ~WormholeTestFixture() override {
+        // You can do clean-up work that doesn't throw exceptions here.
     }
 
-    // std::cout << "Setting Up Test." << std::endl;
-    assert(get_detected_num_chips() > 0);
-    auto devices = std::vector<chip_id_t>(get_detected_num_chips());
-    std::iota(devices.begin(), devices.end(), 0);
-    std::set<chip_id_t> target_devices = {devices.begin(), devices.end()};
-    uint32_t num_host_mem_ch_per_mmio_device = 1;
-    device = std::make_unique<Cluster>(num_host_mem_ch_per_mmio_device, false, true, true);
-    assert(device != nullptr);
-    assert(device->get_cluster_description()->get_number_of_chips() == get_detected_num_chips());
+    virtual int get_detected_num_chips() = 0;
+    virtual bool is_test_skipped() = 0;
 
-    set_params_for_remote_txn(*device);
+    // If the constructor and destructor are not enough for setting up
+    // and cleaning up each test, you can define the following methods:
 
-    tt_device_params default_params;
-    device->start_device(default_params);
+    void SetUp() override {
+        // Code here will be called immediately after the constructor (right
+        // before each test).
 
-    device->deassert_risc_reset();
+        if (is_test_skipped()) {
+            GTEST_SKIP() << "Test is skipped due to incorrect number of chips";
+        }
 
-    device->wait_for_non_mmio_flush();
-  }
+        // std::cout << "Setting Up Test." << std::endl;
+        assert(get_detected_num_chips() > 0);
+        auto devices = std::vector<chip_id_t>(get_detected_num_chips());
+        std::iota(devices.begin(), devices.end(), 0);
+        std::set<chip_id_t> target_devices = {devices.begin(), devices.end()};
+        uint32_t num_host_mem_ch_per_mmio_device = 1;
+        device = std::make_unique<Cluster>(num_host_mem_ch_per_mmio_device, false, true, true);
+        assert(device != nullptr);
+        assert(device->get_cluster_description()->get_number_of_chips() == get_detected_num_chips());
 
-  void TearDown() override {
-    // Code here will be called immediately after each test (right
-    // before the destructor).
+        set_params_for_remote_txn(*device);
 
-    if (!is_test_skipped()) {
-        // std::cout << "Tearing Down Test." << std::endl;
-        device->close_device();
+        tt_device_params default_params;
+        device->start_device(default_params);
+
+        device->deassert_risc_reset();
+
+        device->wait_for_non_mmio_flush();
     }
-  }
 
+    void TearDown() override {
+        // Code here will be called immediately after each test (right
+        // before the destructor).
+
+        if (!is_test_skipped()) {
+            // std::cout << "Tearing Down Test." << std::endl;
+            device->close_device();
+        }
+    }
 };
 
-} // namespace tt::umd::test::utils
+}  // namespace tt::umd::test::utils

--- a/tests/wormhole/test_wh_common.h
+++ b/tests/wormhole/test_wh_common.h
@@ -49,7 +49,6 @@ protected:
             GTEST_SKIP() << "Test is skipped due to incorrect number of chips";
         }
 
-        // std::cout << "Setting Up Test." << std::endl;
         assert(get_detected_num_chips() > 0);
         auto devices = std::vector<chip_id_t>(get_detected_num_chips());
         std::iota(devices.begin(), devices.end(), 0);
@@ -74,7 +73,6 @@ protected:
         // before the destructor).
 
         if (!is_test_skipped()) {
-            // std::cout << "Tearing Down Test." << std::endl;
             device->close_device();
         }
     }


### PR DESCRIPTION
### Issue
Related to https://github.com/tenstorrent/tt-umd/issues/47 , a follow up from https://github.com/tenstorrent/tt-umd/pull/203

### Description
Enabling clang practically repo-wide

### List of the changes
- Removed device/.clang-format and tests/.clang-format which were previously disabling it.
- Left over src/.clang-format, since these are copied files from external repo.
- Ran `pre-commit run --all-files`

### Testing
Code builds.

### API Changes
There are no API changes in this PR.
