### PR TITLE
Fix eth_coord hash dependency

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -46,7 +46,6 @@ function(fetch_dependencies)
     # boost::interprocess
     ############################################################################################################################
     include(${PROJECT_SOURCE_DIR}/cmake/fetch_boost.cmake)
-    fetch_boost_library(container_hash)
     fetch_boost_library(interprocess)
 
     ############################################################################################################################

--- a/device/tt_cluster_descriptor_types.h
+++ b/device/tt_cluster_descriptor_types.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <boost/container_hash/hash.hpp>
 #include <functional>
 #include <tuple>
 
@@ -29,16 +28,22 @@ struct eth_coord_t {
     }
 };
 
+// Small performant hash combiner taken from boost library.
+// Not using boost::hash_combine due to dependency complications.
+inline void boost_hash_combine(std::size_t &seed, const int value) {
+    seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
 namespace std {
 template <>
 struct hash<eth_coord_t> {
     std::size_t operator()(eth_coord_t const &c) const {
         std::size_t seed = 0;
-        boost::hash_combine(seed, c.cluster_id);
-        boost::hash_combine(seed, c.x);
-        boost::hash_combine(seed, c.y);
-        boost::hash_combine(seed, c.rack);
-        boost::hash_combine(seed, c.shelf);
+        boost_hash_combine(seed, c.cluster_id);
+        boost_hash_combine(seed, c.x);
+        boost_hash_combine(seed, c.y);
+        boost_hash_combine(seed, c.rack);
+        boost_hash_combine(seed, c.shelf);
         return seed;
     }
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,6 @@ target_link_libraries(
         gtest
         pthread
         fmt::fmt-header-only
-        Boost::container_hash
 )
 target_include_directories(
     test_common


### PR DESCRIPTION
### Issue
A follow up of #306 

### Description
Adding a new boost dependency complicates things. The code, as is currently on main, won't build in tt_metal.

### List of the changes
- Remove boost dependency, and use one liner hash function

### Testing
No testing

### API Changes
There are no API changes in this PR.
