### PR TITLE
Make nng private and static

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -56,7 +56,6 @@ function(fetch_dependencies)
         GITHUB_REPOSITORY nanomsg/nng
         GIT_TAG v1.8.0
         OPTIONS
-            "BUILD_SHARED_LIBS ON"
             "NNG_TESTS OFF"
             "NNG_TOOLS OFF"
     )

--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -41,15 +41,14 @@ target_include_directories(
 )
 
 # flatbuffers is public - exposed to tt_metal by tt_simulation_device_generated.h
-# nng is public - exposed to tt_metal by tt_simulation_host.hpp
 target_link_libraries(
     device
     PUBLIC
-        nng
         flatbuffers
         uv
     PRIVATE
         hwloc
+        nng
         rt
         Boost::interprocess
         fmt::fmt-header-only


### PR DESCRIPTION
### Issue
NA

### Description
libnng.so is no longer a public dependency as of this PR: https://github.com/tenstorrent/tt-umd/pull/224
Additionally, given that it is only consumed here it would be advantageous to statically link it.
Why?
So we don't have to:
- Install it
- Package it in a debian
- Bundle it in a ttnn python wheel ... etc ... 

### List of the changes
Build nng as static
Make it private linkage

### Testing
Hoping CI is good enough

### API Changes
There are no API changes in this PR.
