### PR TITLE
Fix address types

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1379,7 +1379,7 @@ std::optional<std::tuple<uint32_t, uint32_t>> Cluster::get_tlb_data_from_target(
 }
 
 void Cluster::configure_tlb(
-    chip_id_t logical_device_id, tt_xy_pair core, std::int32_t tlb_index, std::int32_t address, uint64_t ordering) {
+    chip_id_t logical_device_id, tt_xy_pair core, int32_t tlb_index, uint64_t address, uint64_t ordering) {
     log_assert(
         ordering == TLB_DATA::Strict || ordering == TLB_DATA::Posted || ordering == TLB_DATA::Relaxed,
         "Invalid ordering specified in Cluster::configure_tlb");

--- a/device/cluster.h
+++ b/device/cluster.h
@@ -278,8 +278,8 @@ public:
     virtual void configure_tlb(
         chip_id_t logical_device_id,
         tt_xy_pair core,
-        std::int32_t tlb_index,
-        std::int32_t address,
+        int32_t tlb_index,
+        uint64_t address,
         uint64_t ordering = TLB_DATA::Relaxed) {
         throw std::runtime_error("---- tt_device::configure_tlb is not implemented\n");
     }
@@ -721,8 +721,8 @@ public:
     virtual void configure_tlb(
         chip_id_t logical_device_id,
         tt_xy_pair core,
-        std::int32_t tlb_index,
-        std::int32_t address,
+        int32_t tlb_index,
+        uint64_t address,
         uint64_t ordering = TLB_DATA::Posted);
     virtual void set_fallback_tlb_ordering_mode(const std::string& fallback_tlb, uint64_t ordering = TLB_DATA::Posted);
     virtual void setup_core_to_tlb_map(

--- a/device/cluster.h
+++ b/device/cluster.h
@@ -877,7 +877,7 @@ private:
         const void* mem_ptr,
         uint32_t size_in_bytes,
         tt_cxy_pair target,
-        std::uint32_t address,
+        uint64_t address,
         const std::string& fallback_tlb);
     void write_to_non_mmio_device(
         const void* mem_ptr,
@@ -887,11 +887,7 @@ private:
         bool broadcast = false,
         std::vector<int> broadcast_header = {});
     void read_device_memory(
-        void* mem_ptr,
-        tt_cxy_pair target,
-        std::uint32_t address,
-        std::uint32_t size_in_bytes,
-        const std::string& fallback_tlb);
+        void* mem_ptr, tt_cxy_pair target, uint64_t address, uint32_t size_in_bytes, const std::string& fallback_tlb);
     void read_from_non_mmio_device(void* mem_ptr, tt_cxy_pair core, uint64_t address, uint32_t size_in_bytes);
     void read_mmio_device_register(
         void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
@@ -948,7 +944,7 @@ private:
         uint32_t* return_3 = nullptr,
         uint32_t* return_4 = nullptr);
     bool address_in_tlb_space(
-        uint32_t address, uint32_t size_in_bytes, int32_t tlb_index, uint64_t tlb_size, uint32_t chip);
+        uint64_t address, uint32_t size_in_bytes, int32_t tlb_index, uint64_t tlb_size, uint32_t chip);
     std::shared_ptr<boost::interprocess::named_mutex> get_mutex(const std::string& tlb_name, int pci_interface_id);
     virtual uint32_t get_harvested_noc_rows_for_chip(
         int logical_device_id);  // Returns one-hot encoded harvesting mask for PCIe mapped chips
@@ -1012,7 +1008,7 @@ private:
     std::unordered_map<chip_id_t, std::unordered_set<tt_xy_pair>> workers_per_chip = {};
     std::unordered_set<tt_xy_pair> eth_cores = {};
     std::unordered_set<tt_xy_pair> dram_cores = {};
-    std::map<chip_id_t, std::unordered_map<std::int32_t, std::int32_t>> tlb_config_map = {};
+    std::map<chip_id_t, std::unordered_map<int32_t, uint64_t>> tlb_config_map = {};
     std::set<chip_id_t> all_target_mmio_devices;
 
     // Note that these maps holds only entries for local PCIe chips.

--- a/src/firmware/riscv/blackhole/eth_l1_address_map.h
+++ b/src/firmware/riscv/blackhole/eth_l1_address_map.h
@@ -9,35 +9,35 @@ namespace eth_l1_mem {
 
 
 struct address_map {
-  
-  // Sizes
-  static constexpr std::int32_t FIRMWARE_SIZE = 32 * 1024;
-  static constexpr std::int32_t ERISC_BARRIER_SIZE = 0x20; // 32 bytes reserved for Barrier
-  static constexpr std::int32_t COMMAND_Q_SIZE = 4 * 1024;
-  static constexpr std::int32_t DATA_BUFFER_SIZE_HOST = 4 * 1024;
-  static constexpr std::int32_t DATA_BUFFER_SIZE_ETH = 4 * 1024;
-  static constexpr std::int32_t DATA_BUFFER_SIZE_NOC = 16 * 1024;
-  static constexpr std::int32_t DATA_BUFFER_SIZE = 24 * 1024;
-  static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_SIZE = 128;     //
-  static constexpr std::int32_t OVERLAY_BLOB_SIZE = (32 * 1024) - EPOCH_RUNTIME_CONFIG_SIZE;
-  static constexpr std::int32_t OVERLAY_MAX_EXTRA_BLOB_SIZE = (0 * 1024);     
-  static constexpr std::int32_t TILE_HEADER_BUF_SIZE = 32 * 1024;     // 
-  static constexpr std::int32_t NCRISC_L1_EPOCH_Q_SIZE = 32;
-  static constexpr std::int32_t FW_L1_BLOCK_SIZE = OVERLAY_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
-  static constexpr std::int32_t FW_DRAM_BLOCK_SIZE = OVERLAY_BLOB_SIZE + OVERLAY_MAX_EXTRA_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
-  // Base addresses
-  static constexpr std::int32_t FIRMWARE_BASE = 0x9040;
-  static constexpr std::int32_t ERISC_BARRIER_BASE = 0x11FE0;
-  static constexpr std::int32_t L1_EPOCH_Q_BASE = 0x9000; // Epoch Q start in L1.
-  static constexpr std::int32_t L1_DRAM_POLLING_CTRL_BASE = 0x9020;
-  static constexpr std::int32_t COMMAND_Q_BASE = L1_EPOCH_Q_BASE + FIRMWARE_SIZE;
-  static constexpr std::int32_t DATA_BUFFER_BASE = COMMAND_Q_BASE + COMMAND_Q_SIZE;
-  static constexpr std::int32_t TILE_HEADER_BUFFER_BASE = DATA_BUFFER_BASE + DATA_BUFFER_SIZE;
-  static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_BASE = TILE_HEADER_BUFFER_BASE + TILE_HEADER_BUF_SIZE;
-  static constexpr std::int32_t OVERLAY_BLOB_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE;
-  static constexpr std::int32_t DATA_BUFFER_SPACE_BASE = OVERLAY_BLOB_BASE + OVERLAY_BLOB_SIZE;
 
-  static std::int32_t OVERLAY_FULL_BLOB_SIZE() {
+  // Sizes
+  static constexpr uint32_t FIRMWARE_SIZE = 32 * 1024;
+  static constexpr uint32_t ERISC_BARRIER_SIZE = 0x20; // 32 bytes reserved for Barrier
+  static constexpr uint32_t COMMAND_Q_SIZE = 4 * 1024;
+  static constexpr uint32_t DATA_BUFFER_SIZE_HOST = 4 * 1024;
+  static constexpr uint32_t DATA_BUFFER_SIZE_ETH = 4 * 1024;
+  static constexpr uint32_t DATA_BUFFER_SIZE_NOC = 16 * 1024;
+  static constexpr uint32_t DATA_BUFFER_SIZE = 24 * 1024;
+  static constexpr uint32_t EPOCH_RUNTIME_CONFIG_SIZE = 128;     //
+  static constexpr uint32_t OVERLAY_BLOB_SIZE = (32 * 1024) - EPOCH_RUNTIME_CONFIG_SIZE;
+  static constexpr uint32_t OVERLAY_MAX_EXTRA_BLOB_SIZE = (0 * 1024);
+  static constexpr uint32_t TILE_HEADER_BUF_SIZE = 32 * 1024;     //
+  static constexpr uint32_t NCRISC_L1_EPOCH_Q_SIZE = 32;
+  static constexpr uint32_t FW_L1_BLOCK_SIZE = OVERLAY_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
+  static constexpr uint32_t FW_DRAM_BLOCK_SIZE = OVERLAY_BLOB_SIZE + OVERLAY_MAX_EXTRA_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
+  // Base addresses
+  static constexpr uint32_t FIRMWARE_BASE = 0x9040;
+  static constexpr uint32_t ERISC_BARRIER_BASE = 0x11FE0;
+  static constexpr uint32_t L1_EPOCH_Q_BASE = 0x9000; // Epoch Q start in L1.
+  static constexpr uint32_t L1_DRAM_POLLING_CTRL_BASE = 0x9020;
+  static constexpr uint32_t COMMAND_Q_BASE = L1_EPOCH_Q_BASE + FIRMWARE_SIZE;
+  static constexpr uint32_t DATA_BUFFER_BASE = COMMAND_Q_BASE + COMMAND_Q_SIZE;
+  static constexpr uint32_t TILE_HEADER_BUFFER_BASE = DATA_BUFFER_BASE + DATA_BUFFER_SIZE;
+  static constexpr uint32_t EPOCH_RUNTIME_CONFIG_BASE = TILE_HEADER_BUFFER_BASE + TILE_HEADER_BUF_SIZE;
+  static constexpr uint32_t OVERLAY_BLOB_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE;
+  static constexpr uint32_t DATA_BUFFER_SPACE_BASE = OVERLAY_BLOB_BASE + OVERLAY_BLOB_SIZE;
+
+  static uint32_t OVERLAY_FULL_BLOB_SIZE() {
       return OVERLAY_BLOB_SIZE + OVERLAY_MAX_EXTRA_BLOB_SIZE;
   };
 
@@ -48,15 +48,15 @@ template<std::size_t A, std::size_t B> struct TAssertEquality {
 
 static constexpr bool _DATA_BUFFER_SPACE_BASE_CORRECT = TAssertEquality<DATA_BUFFER_SPACE_BASE, 0x28000>::_cResult;
 
-  static constexpr std::int32_t MAX_SIZE = 256*1024;
-  static constexpr std::int32_t MAX_L1_LOADING_SIZE = 1 * 256 * 1024;  
-  
-  static constexpr std::int32_t RISC_LOCAL_MEM_BASE = 0xffb00000; // Actaul local memory address as seen from risc firmware
+  static constexpr uint32_t MAX_SIZE = 256*1024;
+  static constexpr uint32_t MAX_L1_LOADING_SIZE = 1 * 256 * 1024;
+
+  static constexpr uint32_t RISC_LOCAL_MEM_BASE = 0xffb00000; // Actaul local memory address as seen from risc firmware
                                                                    // As part of the init risc firmware will copy local memory data from
-                                                                   // l1 locations listed above into internal local memory that starts 
+                                                                   // l1 locations listed above into internal local memory that starts
                                                                    // at RISC_LOCAL_MEM_BASE address
 
-  static constexpr std::uint32_t FW_VERSION_ADDR = 0x210;
+  static constexpr uint32_t FW_VERSION_ADDR = 0x210;
 };
 }  // namespace llk
 

--- a/src/firmware/riscv/grayskull/l1_address_map.h
+++ b/src/firmware/riscv/grayskull/l1_address_map.h
@@ -18,119 +18,119 @@ struct mailbox_type {
 };
 
 struct address_map {
-  
+
   // Sizes
-  static constexpr std::int32_t FIRMWARE_SIZE = 20 * 1024;          // 20KB = 7KB + 1KB zeros + 12KB perf buffers
-  static constexpr std::int32_t BRISC_FIRMWARE_SIZE = 7*1024 + 512 + 768; // Taking an extra 768B from perf buffer space
-  static constexpr std::int32_t ZEROS_SIZE = 512;
-  static constexpr std::int32_t NCRISC_FIRMWARE_SIZE = 32 * 1024; // 16KB in L0, 16KB in L1
-  static constexpr std::int32_t TRISC0_SIZE = 20 * 1024;        // 20KB = 16KB + 4KB local memory
-  static constexpr std::int32_t TRISC1_SIZE = 16 * 1024;        // 16KB = 12KB + 4KB local memory
-  static constexpr std::int32_t TRISC2_SIZE = 20 * 1024;        // 20KB = 16KB + 4KB local memory
-  static constexpr std::int32_t TRISC_LOCAL_MEM_SIZE = 4 * 1024;      // 
-  static constexpr std::int32_t NCRISC_LOCAL_MEM_SIZE = 4 * 1024;     // 
-  static constexpr std::int32_t NCRISC_L1_SCRATCH_SIZE = 4 * 1024;     //
-  static constexpr std::int32_t NCRISC_L1_CODE_SIZE = 16 * 1024;     // Size of code block that is L1 resident
-  static constexpr std::int32_t NCRISC_IRAM_CODE_SIZE = 16*1024;    // Size of code block that is IRAM resident
-  static constexpr std::int32_t NCRISC_DATA_SIZE = 4 * 1024;        // 4KB
-  static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_SIZE = 128;      //
-  static constexpr std::int32_t OVERLAY_BLOB_SIZE = (64 * 1024) - EPOCH_RUNTIME_CONFIG_SIZE;
-  static constexpr std::int32_t TILE_HEADER_BUF_SIZE = 32 * 1024;     // 
-  static constexpr std::int32_t NCRISC_L1_EPOCH_Q_SIZE = 32;
-  static constexpr std::int32_t FW_L1_BLOCK_SIZE = FIRMWARE_SIZE + NCRISC_FIRMWARE_SIZE + TRISC0_SIZE + TRISC1_SIZE + TRISC2_SIZE + OVERLAY_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
+  static constexpr uint32_t FIRMWARE_SIZE = 20 * 1024;          // 20KB = 7KB + 1KB zeros + 12KB perf buffers
+  static constexpr uint32_t BRISC_FIRMWARE_SIZE = 7*1024 + 512 + 768; // Taking an extra 768B from perf buffer space
+  static constexpr uint32_t ZEROS_SIZE = 512;
+  static constexpr uint32_t NCRISC_FIRMWARE_SIZE = 32 * 1024; // 16KB in L0, 16KB in L1
+  static constexpr uint32_t TRISC0_SIZE = 20 * 1024;        // 20KB = 16KB + 4KB local memory
+  static constexpr uint32_t TRISC1_SIZE = 16 * 1024;        // 16KB = 12KB + 4KB local memory
+  static constexpr uint32_t TRISC2_SIZE = 20 * 1024;        // 20KB = 16KB + 4KB local memory
+  static constexpr uint32_t TRISC_LOCAL_MEM_SIZE = 4 * 1024;      //
+  static constexpr uint32_t NCRISC_LOCAL_MEM_SIZE = 4 * 1024;     //
+  static constexpr uint32_t NCRISC_L1_SCRATCH_SIZE = 4 * 1024;     //
+  static constexpr uint32_t NCRISC_L1_CODE_SIZE = 16 * 1024;     // Size of code block that is L1 resident
+  static constexpr uint32_t NCRISC_IRAM_CODE_SIZE = 16*1024;    // Size of code block that is IRAM resident
+  static constexpr uint32_t NCRISC_DATA_SIZE = 4 * 1024;        // 4KB
+  static constexpr uint32_t EPOCH_RUNTIME_CONFIG_SIZE = 128;      //
+  static constexpr uint32_t OVERLAY_BLOB_SIZE = (64 * 1024) - EPOCH_RUNTIME_CONFIG_SIZE;
+  static constexpr uint32_t TILE_HEADER_BUF_SIZE = 32 * 1024;     //
+  static constexpr uint32_t NCRISC_L1_EPOCH_Q_SIZE = 32;
+  static constexpr uint32_t FW_L1_BLOCK_SIZE = FIRMWARE_SIZE + NCRISC_FIRMWARE_SIZE + TRISC0_SIZE + TRISC1_SIZE + TRISC2_SIZE + OVERLAY_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
 
   // Base addresses
-  static constexpr std::int32_t FIRMWARE_BASE = 0;
-  static constexpr std::int32_t L1_BARRIER_BASE = 0xfffc0;
-  static constexpr std::int32_t ZEROS_BASE = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE;
-  static constexpr std::int32_t NCRISC_FIRMWARE_BASE = FIRMWARE_BASE + FIRMWARE_SIZE;
-  static constexpr std::int32_t NCRISC_L1_CODE_BASE =  NCRISC_FIRMWARE_BASE + NCRISC_IRAM_CODE_SIZE;
-  static constexpr std::int32_t NCRISC_LOCAL_MEM_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE - NCRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::int32_t NCRISC_L1_SCRATCH_BASE = NCRISC_FIRMWARE_BASE + 0x200; // L1 Scratch used by NCRISC sized NCRISC_L1_SCRATCH_SIZE, skip 0x200 because some of the beginning of NCRISC is used .e.g. TEST_MAILBOX
-  static constexpr std::int32_t NCRISC_L1_CONTEXT_BASE = NCRISC_FIRMWARE_BASE + 0x20; // If changing make sure to modify src/firmware/riscv/targets/ncrisc/contextASM.S
-  static constexpr std::int32_t NCRISC_L1_DRAM_POLLING_CTRL_BASE = NCRISC_FIRMWARE_BASE + 0x40;
-  static constexpr std::int32_t NCRISC_PERF_QUEUE_HEADER_SIZE = 8 * 8; // Half of this value must be 32B aligned
-  static constexpr std::int32_t NCRISC_PERF_QUEUE_HEADER_ADDR = NCRISC_FIRMWARE_BASE + NCRISC_L1_SCRATCH_SIZE; // L1 Performance Buffer used by NCRISC
-  static constexpr std::int32_t NCRISC_L1_PERF_BUF_BASE = NCRISC_PERF_QUEUE_HEADER_ADDR + NCRISC_PERF_QUEUE_HEADER_SIZE; // L1 Performance Buffer used by NCRISC
-  static constexpr std::int32_t NCRISC_PERF_BUF_SIZE_LEVEL_0 = 640; // smaller buffer size for limited logging
-  static constexpr std::int32_t NCRISC_PERF_BUF_SIZE_LEVEL_1 = 4*1024 - NCRISC_PERF_QUEUE_HEADER_SIZE; // NCRISC performance buffer
-  static constexpr std::int32_t NCRISC_L1_EPOCH_Q_BASE = NCRISC_L1_PERF_BUF_BASE + NCRISC_PERF_BUF_SIZE_LEVEL_1; // Epoch Q start in L1.
+  static constexpr uint32_t FIRMWARE_BASE = 0;
+  static constexpr uint32_t L1_BARRIER_BASE = 0xfffc0;
+  static constexpr uint32_t ZEROS_BASE = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE;
+  static constexpr uint32_t NCRISC_FIRMWARE_BASE = FIRMWARE_BASE + FIRMWARE_SIZE;
+  static constexpr uint32_t NCRISC_L1_CODE_BASE =  NCRISC_FIRMWARE_BASE + NCRISC_IRAM_CODE_SIZE;
+  static constexpr uint32_t NCRISC_LOCAL_MEM_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE - NCRISC_LOCAL_MEM_SIZE; // Copy of the local memory
+  static constexpr uint32_t NCRISC_L1_SCRATCH_BASE = NCRISC_FIRMWARE_BASE + 0x200; // L1 Scratch used by NCRISC sized NCRISC_L1_SCRATCH_SIZE, skip 0x200 because some of the beginning of NCRISC is used .e.g. TEST_MAILBOX
+  static constexpr uint32_t NCRISC_L1_CONTEXT_BASE = NCRISC_FIRMWARE_BASE + 0x20; // If changing make sure to modify src/firmware/riscv/targets/ncrisc/contextASM.S
+  static constexpr uint32_t NCRISC_L1_DRAM_POLLING_CTRL_BASE = NCRISC_FIRMWARE_BASE + 0x40;
+  static constexpr uint32_t NCRISC_PERF_QUEUE_HEADER_SIZE = 8 * 8; // Half of this value must be 32B aligned
+  static constexpr uint32_t NCRISC_PERF_QUEUE_HEADER_ADDR = NCRISC_FIRMWARE_BASE + NCRISC_L1_SCRATCH_SIZE; // L1 Performance Buffer used by NCRISC
+  static constexpr uint32_t NCRISC_L1_PERF_BUF_BASE = NCRISC_PERF_QUEUE_HEADER_ADDR + NCRISC_PERF_QUEUE_HEADER_SIZE; // L1 Performance Buffer used by NCRISC
+  static constexpr uint32_t NCRISC_PERF_BUF_SIZE_LEVEL_0 = 640; // smaller buffer size for limited logging
+  static constexpr uint32_t NCRISC_PERF_BUF_SIZE_LEVEL_1 = 4*1024 - NCRISC_PERF_QUEUE_HEADER_SIZE; // NCRISC performance buffer
+  static constexpr uint32_t NCRISC_L1_EPOCH_Q_BASE = NCRISC_L1_PERF_BUF_BASE + NCRISC_PERF_BUF_SIZE_LEVEL_1; // Epoch Q start in L1.
 
-  static constexpr std::int32_t TRISC_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
-  static constexpr std::int32_t TRISC0_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
-  static constexpr std::int32_t TRISC0_LOCAL_MEM_BASE = TRISC0_BASE + TRISC0_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::int32_t TRISC1_BASE = TRISC0_BASE + TRISC0_SIZE;
-  static constexpr std::int32_t TRISC1_LOCAL_MEM_BASE = TRISC1_BASE + TRISC1_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::int32_t TRISC2_BASE = TRISC1_BASE + TRISC1_SIZE;
-  static constexpr std::int32_t TRISC2_LOCAL_MEM_BASE = TRISC2_BASE + TRISC2_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_BASE = TRISC2_BASE + TRISC2_SIZE + TILE_HEADER_BUF_SIZE;
-  static constexpr std::int32_t OVERLAY_BLOB_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE;
-  static constexpr std::int32_t DATA_BUFFER_SPACE_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE + OVERLAY_BLOB_SIZE;
+  static constexpr uint32_t TRISC_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
+  static constexpr uint32_t TRISC0_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
+  static constexpr uint32_t TRISC0_LOCAL_MEM_BASE = TRISC0_BASE + TRISC0_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
+  static constexpr uint32_t TRISC1_BASE = TRISC0_BASE + TRISC0_SIZE;
+  static constexpr uint32_t TRISC1_LOCAL_MEM_BASE = TRISC1_BASE + TRISC1_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
+  static constexpr uint32_t TRISC2_BASE = TRISC1_BASE + TRISC1_SIZE;
+  static constexpr uint32_t TRISC2_LOCAL_MEM_BASE = TRISC2_BASE + TRISC2_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
+  static constexpr uint32_t EPOCH_RUNTIME_CONFIG_BASE = TRISC2_BASE + TRISC2_SIZE + TILE_HEADER_BUF_SIZE;
+  static constexpr uint32_t OVERLAY_BLOB_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE;
+  static constexpr uint32_t DATA_BUFFER_SPACE_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE + OVERLAY_BLOB_SIZE;
 
   // Trisc Mailboxes
-  static constexpr std::int32_t TRISC_L1_MAILBOX_OFFSET = 4;
-  static constexpr std::int32_t BRISC_L1_MAILBOX_OFFSET = 4;
-  static constexpr std::int32_t NRISC_L1_MAILBOX_OFFSET = 4;
+  static constexpr uint32_t TRISC_L1_MAILBOX_OFFSET = 4;
+  static constexpr uint32_t BRISC_L1_MAILBOX_OFFSET = 4;
+  static constexpr uint32_t NRISC_L1_MAILBOX_OFFSET = 4;
 
-  static constexpr std::int32_t TRISC0_MAILBOX_BASE = TRISC0_BASE + TRISC_L1_MAILBOX_OFFSET;
-  static constexpr std::int32_t TRISC1_MAILBOX_BASE = TRISC1_BASE + TRISC_L1_MAILBOX_OFFSET;
-  static constexpr std::int32_t TRISC2_MAILBOX_BASE = TRISC2_BASE + TRISC_L1_MAILBOX_OFFSET;
+  static constexpr uint32_t TRISC0_MAILBOX_BASE = TRISC0_BASE + TRISC_L1_MAILBOX_OFFSET;
+  static constexpr uint32_t TRISC1_MAILBOX_BASE = TRISC1_BASE + TRISC_L1_MAILBOX_OFFSET;
+  static constexpr uint32_t TRISC2_MAILBOX_BASE = TRISC2_BASE + TRISC_L1_MAILBOX_OFFSET;
 
-  static constexpr std::int32_t FW_MAILBOX_BASE         = 32;
-  static constexpr std::int32_t DEBUG_MAILBOX_BUF_BASE  = 112;
+  static constexpr uint32_t FW_MAILBOX_BASE         = 32;
+  static constexpr uint32_t DEBUG_MAILBOX_BUF_BASE  = 112;
 
-  static constexpr std::int32_t FW_MAILBOX_BUF_SIZE     = 64;
-  static constexpr std::int32_t DEBUG_MAILBOX_BUF_SIZE  = 64; // For each T0/T1/T2/FW
+  static constexpr uint32_t FW_MAILBOX_BUF_SIZE     = 64;
+  static constexpr uint32_t DEBUG_MAILBOX_BUF_SIZE  = 64; // For each T0/T1/T2/FW
 
   // Used for TT_LOG
-  static constexpr std::int32_t TRISC_TT_LOG_MAILBOX_OFFSET = 28;
-  static constexpr std::int32_t TRISC_TT_LOG_MAILBOX_SIZE = 64;
-  static constexpr std::int32_t TRISC0_TT_LOG_MAILBOX_BASE = TRISC0_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
-  static constexpr std::int32_t TRISC1_TT_LOG_MAILBOX_BASE = TRISC1_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
-  static constexpr std::int32_t TRISC2_TT_LOG_MAILBOX_BASE = TRISC2_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
- 
+  static constexpr uint32_t TRISC_TT_LOG_MAILBOX_OFFSET = 28;
+  static constexpr uint32_t TRISC_TT_LOG_MAILBOX_SIZE = 64;
+  static constexpr uint32_t TRISC0_TT_LOG_MAILBOX_BASE = TRISC0_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
+  static constexpr uint32_t TRISC1_TT_LOG_MAILBOX_BASE = TRISC1_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
+  static constexpr uint32_t TRISC2_TT_LOG_MAILBOX_BASE = TRISC2_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
+
   // Upper 2KB of local space is used as debug buffer
-  static constexpr std::int32_t DEBUG_BUFFER_SIZE  = 2 * 1024;
-  static constexpr std::int32_t TRISC0_DEBUG_BUFFER_BASE  = TRISC0_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
-  static constexpr std::int32_t TRISC1_DEBUG_BUFFER_BASE  = TRISC1_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
-  static constexpr std::int32_t TRISC2_DEBUG_BUFFER_BASE  = TRISC2_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
+  static constexpr uint32_t DEBUG_BUFFER_SIZE  = 2 * 1024;
+  static constexpr uint32_t TRISC0_DEBUG_BUFFER_BASE  = TRISC0_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
+  static constexpr uint32_t TRISC1_DEBUG_BUFFER_BASE  = TRISC1_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
+  static constexpr uint32_t TRISC2_DEBUG_BUFFER_BASE  = TRISC2_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
 
-  static constexpr std::int32_t MAX_SIZE = 1 * 1024 * 1024;  // 1MB
-  static constexpr std::int32_t MAX_L1_LOADING_SIZE = MAX_SIZE;
+  static constexpr uint32_t MAX_SIZE = 1 * 1024 * 1024;  // 1MB
+  static constexpr uint32_t MAX_L1_LOADING_SIZE = MAX_SIZE;
 
-  static constexpr std::int32_t RISC_LOCAL_MEM_BASE = 0xffb00000; // Actaul local memory address as seen from risc firmware
+  static constexpr uint32_t RISC_LOCAL_MEM_BASE = 0xffb00000; // Actaul local memory address as seen from risc firmware
                                                                    // As part of the init risc firmware will copy local memory data from
-                                                                   // l1 locations listed above into internal local memory that starts 
+                                                                   // l1 locations listed above into internal local memory that starts
                                                                    // at RISC_LOCAL_MEM_BASE address
 
-  static constexpr std::int32_t NCRISC_IRAM_MEM_BASE = 0xffc00000; // NCRISC instruction RAM base address
+  static constexpr uint32_t NCRISC_IRAM_MEM_BASE = 0xffc00000; // NCRISC instruction RAM base address
 
   // Perf buffer (FIXME - update once location of the perf data buffer is finalized)
   // Parameter UNPACK_PACK_PERF_BUF_SIZE_LEVEL_1 assumes the following PERF_BUF_SIZE = 12KB - 768
-  static constexpr std::int32_t PERF_BUF_SIZE = FIRMWARE_SIZE - BRISC_FIRMWARE_SIZE - ZEROS_SIZE;
-  
-  static constexpr std::int32_t PERF_QUEUE_HEADER_SIZE = 16;
-  static constexpr std::int32_t PERF_RISC_MAILBOX_SIZE = 16;
-  static constexpr std::int32_t PERF_UNUSED_SIZE = 32;
-  
-  static constexpr std::int32_t MATH_PERF_BUF_SIZE = 64;
-  static constexpr std::int32_t BRISC_PERF_BUF_SIZE = 640; // Half of this value must be 32B aligned
-  static constexpr std::int32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_0 = 640; // smaller buffer size for limited logging
-  static constexpr std::int32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_1 = (12 * 1024 - 768)/2 - MATH_PERF_BUF_SIZE/2 - (PERF_QUEUE_HEADER_SIZE + PERF_RISC_MAILBOX_SIZE + PERF_UNUSED_SIZE)/2 - BRISC_PERF_BUF_SIZE/2;
-  
-  static constexpr std::int32_t PERF_QUEUE_HEADER_ADDR = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE + ZEROS_SIZE;
-  static constexpr std::int32_t PERF_RISC_MAILBOX_ADDR = PERF_QUEUE_HEADER_ADDR + PERF_QUEUE_HEADER_SIZE;
-  static constexpr std::int32_t BRISC_PERF_BUF_BASE_ADDR = PERF_RISC_MAILBOX_SIZE + PERF_UNUSED_SIZE + PERF_RISC_MAILBOX_ADDR;
-  static constexpr std::int32_t MATH_PERF_BUF_BASE_ADDR = BRISC_PERF_BUF_BASE_ADDR + BRISC_PERF_BUF_SIZE;
-  static constexpr std::int32_t UNPACK_PACK_PERF_BUF_BASE_ADDR = MATH_PERF_BUF_BASE_ADDR + MATH_PERF_BUF_SIZE;
-  static constexpr std::int32_t PERF_NUM_THREADS = 5;
+  static constexpr uint32_t PERF_BUF_SIZE = FIRMWARE_SIZE - BRISC_FIRMWARE_SIZE - ZEROS_SIZE;
 
-  static constexpr std::int32_t PERF_QUEUE_PTRS = PERF_QUEUE_HEADER_ADDR;
-  static constexpr std::int32_t PERF_THREAD_HEADER = PERF_QUEUE_PTRS + 8;
-  static constexpr std::int32_t PERF_WR_PTR_COPY = PERF_QUEUE_PTRS + 12;
+  static constexpr uint32_t PERF_QUEUE_HEADER_SIZE = 16;
+  static constexpr uint32_t PERF_RISC_MAILBOX_SIZE = 16;
+  static constexpr uint32_t PERF_UNUSED_SIZE = 32;
 
-  static constexpr std::int32_t WALL_CLOCK_L = 0xFFB121F0;
-  static constexpr std::int32_t WALL_CLOCK_H = 0xFFB121F8;
+  static constexpr uint32_t MATH_PERF_BUF_SIZE = 64;
+  static constexpr uint32_t BRISC_PERF_BUF_SIZE = 640; // Half of this value must be 32B aligned
+  static constexpr uint32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_0 = 640; // smaller buffer size for limited logging
+  static constexpr uint32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_1 = (12 * 1024 - 768)/2 - MATH_PERF_BUF_SIZE/2 - (PERF_QUEUE_HEADER_SIZE + PERF_RISC_MAILBOX_SIZE + PERF_UNUSED_SIZE)/2 - BRISC_PERF_BUF_SIZE/2;
+
+  static constexpr uint32_t PERF_QUEUE_HEADER_ADDR = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE + ZEROS_SIZE;
+  static constexpr uint32_t PERF_RISC_MAILBOX_ADDR = PERF_QUEUE_HEADER_ADDR + PERF_QUEUE_HEADER_SIZE;
+  static constexpr uint32_t BRISC_PERF_BUF_BASE_ADDR = PERF_RISC_MAILBOX_SIZE + PERF_UNUSED_SIZE + PERF_RISC_MAILBOX_ADDR;
+  static constexpr uint32_t MATH_PERF_BUF_BASE_ADDR = BRISC_PERF_BUF_BASE_ADDR + BRISC_PERF_BUF_SIZE;
+  static constexpr uint32_t UNPACK_PACK_PERF_BUF_BASE_ADDR = MATH_PERF_BUF_BASE_ADDR + MATH_PERF_BUF_SIZE;
+  static constexpr uint32_t PERF_NUM_THREADS = 5;
+
+  static constexpr uint32_t PERF_QUEUE_PTRS = PERF_QUEUE_HEADER_ADDR;
+  static constexpr uint32_t PERF_THREAD_HEADER = PERF_QUEUE_PTRS + 8;
+  static constexpr uint32_t PERF_WR_PTR_COPY = PERF_QUEUE_PTRS + 12;
+
+  static constexpr uint32_t WALL_CLOCK_L = 0xFFB121F0;
+  static constexpr uint32_t WALL_CLOCK_H = 0xFFB121F8;
 
 };
 

--- a/src/firmware/riscv/wormhole/l1_address_map.h
+++ b/src/firmware/riscv/wormhole/l1_address_map.h
@@ -18,120 +18,120 @@ struct mailbox_type {
 };
 
 struct address_map {
-  
+
   // Sizes
-  static constexpr std::int32_t FIRMWARE_SIZE = 20 * 1024;          // 20KB = 7KB + 1KB zeros + 12KB perf buffers
-  static constexpr std::int32_t L1_BARRIER_SIZE = 0x20; // 32 bytes reserved for L1 Barrier
-  static constexpr std::int32_t BRISC_FIRMWARE_SIZE = 7*1024 + 512 + 768; // Taking an extra 768B from perf buffer space
-  static constexpr std::int32_t ZEROS_SIZE = 512;
-  static constexpr std::int32_t NCRISC_FIRMWARE_SIZE = 32 * 1024; // 16KB in L0, 16KB in L1
-  static constexpr std::int32_t TRISC0_SIZE = 20 * 1024;        // 20KB = 16KB + 4KB local memory
-  static constexpr std::int32_t TRISC1_SIZE = 16 * 1024;        // 16KB = 12KB + 4KB local memory
-  static constexpr std::int32_t TRISC2_SIZE = 20 * 1024;        // 20KB = 16KB + 4KB local memory
-  static constexpr std::int32_t TRISC_LOCAL_MEM_SIZE = 4 * 1024;      // 
-  static constexpr std::int32_t NCRISC_LOCAL_MEM_SIZE = 4 * 1024;     // 
-  static constexpr std::int32_t NCRISC_L1_SCRATCH_SIZE = 4 * 1024;     //
-  static constexpr std::int32_t NCRISC_L1_CODE_SIZE = 16 * 1024;     // Size of code block that is L1 resident
-  static constexpr std::int32_t NCRISC_IRAM_CODE_SIZE = 16*1024;    // Size of code block that is IRAM resident
-  static constexpr std::int32_t NCRISC_DATA_SIZE = 4 * 1024;        // 4KB
-  static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_SIZE = 128;      //
-  static constexpr std::int32_t OVERLAY_BLOB_SIZE = (64 * 1024) - EPOCH_RUNTIME_CONFIG_SIZE;
-  static constexpr std::int32_t TILE_HEADER_BUF_SIZE = 32 * 1024;     // 
-  static constexpr std::int32_t NCRISC_L1_EPOCH_Q_SIZE = 32;
-  static constexpr std::int32_t FW_L1_BLOCK_SIZE = FIRMWARE_SIZE + NCRISC_FIRMWARE_SIZE + TRISC0_SIZE + TRISC1_SIZE + TRISC2_SIZE + OVERLAY_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
+  static constexpr uint32_t FIRMWARE_SIZE = 20 * 1024;          // 20KB = 7KB + 1KB zeros + 12KB perf buffers
+  static constexpr uint32_t L1_BARRIER_SIZE = 0x20; // 32 bytes reserved for L1 Barrier
+  static constexpr uint32_t BRISC_FIRMWARE_SIZE = 7*1024 + 512 + 768; // Taking an extra 768B from perf buffer space
+  static constexpr uint32_t ZEROS_SIZE = 512;
+  static constexpr uint32_t NCRISC_FIRMWARE_SIZE = 32 * 1024; // 16KB in L0, 16KB in L1
+  static constexpr uint32_t TRISC0_SIZE = 20 * 1024;        // 20KB = 16KB + 4KB local memory
+  static constexpr uint32_t TRISC1_SIZE = 16 * 1024;        // 16KB = 12KB + 4KB local memory
+  static constexpr uint32_t TRISC2_SIZE = 20 * 1024;        // 20KB = 16KB + 4KB local memory
+  static constexpr uint32_t TRISC_LOCAL_MEM_SIZE = 4 * 1024;      //
+  static constexpr uint32_t NCRISC_LOCAL_MEM_SIZE = 4 * 1024;     //
+  static constexpr uint32_t NCRISC_L1_SCRATCH_SIZE = 4 * 1024;     //
+  static constexpr uint32_t NCRISC_L1_CODE_SIZE = 16 * 1024;     // Size of code block that is L1 resident
+  static constexpr uint32_t NCRISC_IRAM_CODE_SIZE = 16*1024;    // Size of code block that is IRAM resident
+  static constexpr uint32_t NCRISC_DATA_SIZE = 4 * 1024;        // 4KB
+  static constexpr uint32_t EPOCH_RUNTIME_CONFIG_SIZE = 128;      //
+  static constexpr uint32_t OVERLAY_BLOB_SIZE = (64 * 1024) - EPOCH_RUNTIME_CONFIG_SIZE;
+  static constexpr uint32_t TILE_HEADER_BUF_SIZE = 32 * 1024;     //
+  static constexpr uint32_t NCRISC_L1_EPOCH_Q_SIZE = 32;
+  static constexpr uint32_t FW_L1_BLOCK_SIZE = FIRMWARE_SIZE + NCRISC_FIRMWARE_SIZE + TRISC0_SIZE + TRISC1_SIZE + TRISC2_SIZE + OVERLAY_BLOB_SIZE + EPOCH_RUNTIME_CONFIG_SIZE + TILE_HEADER_BUF_SIZE;
 
   // Base addresses
-  static constexpr std::int32_t FIRMWARE_BASE = 0;
-  static constexpr std::int32_t L1_BARRIER_BASE = 0x16dfc0;
-  static constexpr std::int32_t ZEROS_BASE = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE;
-  static constexpr std::int32_t NCRISC_FIRMWARE_BASE = FIRMWARE_BASE + FIRMWARE_SIZE;
-  static constexpr std::int32_t NCRISC_L1_CODE_BASE =  NCRISC_FIRMWARE_BASE + NCRISC_IRAM_CODE_SIZE;
-  static constexpr std::int32_t NCRISC_LOCAL_MEM_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE - NCRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::int32_t NCRISC_L1_SCRATCH_BASE = NCRISC_FIRMWARE_BASE + 0x200; // L1 Scratch used by NCRISC sized NCRISC_L1_SCRATCH_SIZE, skip 0x200 because some of the beginning of NCRISC is used .e.g. TEST_MAILBOX
-  static constexpr std::int32_t NCRISC_L1_CONTEXT_BASE = NCRISC_FIRMWARE_BASE + 0x20; // If changing make sure to modify src/firmware/riscv/targets/ncrisc/contextASM.S
-  static constexpr std::int32_t NCRISC_L1_DRAM_POLLING_CTRL_BASE = NCRISC_FIRMWARE_BASE + 0x40;
-  static constexpr std::int32_t NCRISC_PERF_QUEUE_HEADER_SIZE = 8 * 8; // Half of this value must be 32B aligned
-  static constexpr std::int32_t NCRISC_PERF_QUEUE_HEADER_ADDR = NCRISC_FIRMWARE_BASE + NCRISC_L1_SCRATCH_SIZE; // L1 Performance Buffer used by NCRISC
-  static constexpr std::int32_t NCRISC_L1_PERF_BUF_BASE = NCRISC_PERF_QUEUE_HEADER_ADDR + NCRISC_PERF_QUEUE_HEADER_SIZE; // L1 Performance Buffer used by NCRISC
-  static constexpr std::int32_t NCRISC_PERF_BUF_SIZE_LEVEL_0 = 640; // smaller buffer size for limited logging
-  static constexpr std::int32_t NCRISC_PERF_BUF_SIZE_LEVEL_1 = 4*1024 - NCRISC_PERF_QUEUE_HEADER_SIZE; // NCRISC performance buffer
-  static constexpr std::int32_t NCRISC_L1_EPOCH_Q_BASE = NCRISC_L1_PERF_BUF_BASE + NCRISC_PERF_BUF_SIZE_LEVEL_1; // Epoch Q start in L1.
+  static constexpr uint32_t FIRMWARE_BASE = 0;
+  static constexpr uint32_t L1_BARRIER_BASE = 0x16dfc0;
+  static constexpr uint32_t ZEROS_BASE = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE;
+  static constexpr uint32_t NCRISC_FIRMWARE_BASE = FIRMWARE_BASE + FIRMWARE_SIZE;
+  static constexpr uint32_t NCRISC_L1_CODE_BASE =  NCRISC_FIRMWARE_BASE + NCRISC_IRAM_CODE_SIZE;
+  static constexpr uint32_t NCRISC_LOCAL_MEM_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE - NCRISC_LOCAL_MEM_SIZE; // Copy of the local memory
+  static constexpr uint32_t NCRISC_L1_SCRATCH_BASE = NCRISC_FIRMWARE_BASE + 0x200; // L1 Scratch used by NCRISC sized NCRISC_L1_SCRATCH_SIZE, skip 0x200 because some of the beginning of NCRISC is used .e.g. TEST_MAILBOX
+  static constexpr uint32_t NCRISC_L1_CONTEXT_BASE = NCRISC_FIRMWARE_BASE + 0x20; // If changing make sure to modify src/firmware/riscv/targets/ncrisc/contextASM.S
+  static constexpr uint32_t NCRISC_L1_DRAM_POLLING_CTRL_BASE = NCRISC_FIRMWARE_BASE + 0x40;
+  static constexpr uint32_t NCRISC_PERF_QUEUE_HEADER_SIZE = 8 * 8; // Half of this value must be 32B aligned
+  static constexpr uint32_t NCRISC_PERF_QUEUE_HEADER_ADDR = NCRISC_FIRMWARE_BASE + NCRISC_L1_SCRATCH_SIZE; // L1 Performance Buffer used by NCRISC
+  static constexpr uint32_t NCRISC_L1_PERF_BUF_BASE = NCRISC_PERF_QUEUE_HEADER_ADDR + NCRISC_PERF_QUEUE_HEADER_SIZE; // L1 Performance Buffer used by NCRISC
+  static constexpr uint32_t NCRISC_PERF_BUF_SIZE_LEVEL_0 = 640; // smaller buffer size for limited logging
+  static constexpr uint32_t NCRISC_PERF_BUF_SIZE_LEVEL_1 = 4*1024 - NCRISC_PERF_QUEUE_HEADER_SIZE; // NCRISC performance buffer
+  static constexpr uint32_t NCRISC_L1_EPOCH_Q_BASE = NCRISC_L1_PERF_BUF_BASE + NCRISC_PERF_BUF_SIZE_LEVEL_1; // Epoch Q start in L1.
 
-  static constexpr std::int32_t TRISC_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
-  static constexpr std::int32_t TRISC0_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
-  static constexpr std::int32_t TRISC0_LOCAL_MEM_BASE = TRISC0_BASE + TRISC0_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::int32_t TRISC1_BASE = TRISC0_BASE + TRISC0_SIZE;
-  static constexpr std::int32_t TRISC1_LOCAL_MEM_BASE = TRISC1_BASE + TRISC1_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::int32_t TRISC2_BASE = TRISC1_BASE + TRISC1_SIZE;
-  static constexpr std::int32_t TRISC2_LOCAL_MEM_BASE = TRISC2_BASE + TRISC2_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
-  static constexpr std::int32_t EPOCH_RUNTIME_CONFIG_BASE = TRISC2_BASE + TRISC2_SIZE + TILE_HEADER_BUF_SIZE;
-  static constexpr std::int32_t OVERLAY_BLOB_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE;
-  static constexpr std::int32_t DATA_BUFFER_SPACE_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE + OVERLAY_BLOB_SIZE;
+  static constexpr uint32_t TRISC_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
+  static constexpr uint32_t TRISC0_BASE = NCRISC_FIRMWARE_BASE + NCRISC_FIRMWARE_SIZE;
+  static constexpr uint32_t TRISC0_LOCAL_MEM_BASE = TRISC0_BASE + TRISC0_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
+  static constexpr uint32_t TRISC1_BASE = TRISC0_BASE + TRISC0_SIZE;
+  static constexpr uint32_t TRISC1_LOCAL_MEM_BASE = TRISC1_BASE + TRISC1_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
+  static constexpr uint32_t TRISC2_BASE = TRISC1_BASE + TRISC1_SIZE;
+  static constexpr uint32_t TRISC2_LOCAL_MEM_BASE = TRISC2_BASE + TRISC2_SIZE - TRISC_LOCAL_MEM_SIZE; // Copy of the local memory
+  static constexpr uint32_t EPOCH_RUNTIME_CONFIG_BASE = TRISC2_BASE + TRISC2_SIZE + TILE_HEADER_BUF_SIZE;
+  static constexpr uint32_t OVERLAY_BLOB_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE;
+  static constexpr uint32_t DATA_BUFFER_SPACE_BASE = EPOCH_RUNTIME_CONFIG_BASE + EPOCH_RUNTIME_CONFIG_SIZE + OVERLAY_BLOB_SIZE;
 
   // Trisc Mailboxes
-  static constexpr std::int32_t TRISC_L1_MAILBOX_OFFSET = 4;
-  static constexpr std::int32_t BRISC_L1_MAILBOX_OFFSET = 4;
-  static constexpr std::int32_t NRISC_L1_MAILBOX_OFFSET = 4;
+  static constexpr uint32_t TRISC_L1_MAILBOX_OFFSET = 4;
+  static constexpr uint32_t BRISC_L1_MAILBOX_OFFSET = 4;
+  static constexpr uint32_t NRISC_L1_MAILBOX_OFFSET = 4;
 
-  static constexpr std::int32_t TRISC0_MAILBOX_BASE = TRISC0_BASE + TRISC_L1_MAILBOX_OFFSET;
-  static constexpr std::int32_t TRISC1_MAILBOX_BASE = TRISC1_BASE + TRISC_L1_MAILBOX_OFFSET;
-  static constexpr std::int32_t TRISC2_MAILBOX_BASE = TRISC2_BASE + TRISC_L1_MAILBOX_OFFSET;
+  static constexpr uint32_t TRISC0_MAILBOX_BASE = TRISC0_BASE + TRISC_L1_MAILBOX_OFFSET;
+  static constexpr uint32_t TRISC1_MAILBOX_BASE = TRISC1_BASE + TRISC_L1_MAILBOX_OFFSET;
+  static constexpr uint32_t TRISC2_MAILBOX_BASE = TRISC2_BASE + TRISC_L1_MAILBOX_OFFSET;
 
-  static constexpr std::int32_t FW_MAILBOX_BASE         = 32;
-  static constexpr std::int32_t DEBUG_MAILBOX_BUF_BASE  = 112;
+  static constexpr uint32_t FW_MAILBOX_BASE         = 32;
+  static constexpr uint32_t DEBUG_MAILBOX_BUF_BASE  = 112;
 
-  static constexpr std::int32_t FW_MAILBOX_BUF_SIZE     = 64;
-  static constexpr std::int32_t DEBUG_MAILBOX_BUF_SIZE  = 64; // For each T0/T1/T2/FW
+  static constexpr uint32_t FW_MAILBOX_BUF_SIZE     = 64;
+  static constexpr uint32_t DEBUG_MAILBOX_BUF_SIZE  = 64; // For each T0/T1/T2/FW
 
   // Used for TT_LOG
-  static constexpr std::int32_t TRISC_TT_LOG_MAILBOX_OFFSET = 28;
-  static constexpr std::int32_t TRISC_TT_LOG_MAILBOX_SIZE = 64;
-  static constexpr std::int32_t TRISC0_TT_LOG_MAILBOX_BASE = TRISC0_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
-  static constexpr std::int32_t TRISC1_TT_LOG_MAILBOX_BASE = TRISC1_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
-  static constexpr std::int32_t TRISC2_TT_LOG_MAILBOX_BASE = TRISC2_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
- 
+  static constexpr uint32_t TRISC_TT_LOG_MAILBOX_OFFSET = 28;
+  static constexpr uint32_t TRISC_TT_LOG_MAILBOX_SIZE = 64;
+  static constexpr uint32_t TRISC0_TT_LOG_MAILBOX_BASE = TRISC0_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
+  static constexpr uint32_t TRISC1_TT_LOG_MAILBOX_BASE = TRISC1_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
+  static constexpr uint32_t TRISC2_TT_LOG_MAILBOX_BASE = TRISC2_MAILBOX_BASE + TRISC_TT_LOG_MAILBOX_OFFSET;
+
   // Upper 2KB of local space is used as debug buffer
-  static constexpr std::int32_t DEBUG_BUFFER_SIZE  = 2 * 1024;
-  static constexpr std::int32_t TRISC0_DEBUG_BUFFER_BASE  = TRISC0_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
-  static constexpr std::int32_t TRISC1_DEBUG_BUFFER_BASE  = TRISC1_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
-  static constexpr std::int32_t TRISC2_DEBUG_BUFFER_BASE  = TRISC2_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
+  static constexpr uint32_t DEBUG_BUFFER_SIZE  = 2 * 1024;
+  static constexpr uint32_t TRISC0_DEBUG_BUFFER_BASE  = TRISC0_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
+  static constexpr uint32_t TRISC1_DEBUG_BUFFER_BASE  = TRISC1_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
+  static constexpr uint32_t TRISC2_DEBUG_BUFFER_BASE  = TRISC2_LOCAL_MEM_BASE + DEBUG_BUFFER_SIZE;
 
-  static constexpr std::int32_t MAX_SIZE = 1 * 1024 * 1024;  // 1MB
-  static constexpr std::int32_t MAX_L1_LOADING_SIZE = MAX_SIZE;
+  static constexpr uint32_t MAX_SIZE = 1 * 1024 * 1024;  // 1MB
+  static constexpr uint32_t MAX_L1_LOADING_SIZE = MAX_SIZE;
 
-  static constexpr std::int32_t RISC_LOCAL_MEM_BASE = 0xffb00000; // Actaul local memory address as seen from risc firmware
+  static constexpr uint32_t RISC_LOCAL_MEM_BASE = 0xffb00000; // Actaul local memory address as seen from risc firmware
                                                                    // As part of the init risc firmware will copy local memory data from
-                                                                   // l1 locations listed above into internal local memory that starts 
+                                                                   // l1 locations listed above into internal local memory that starts
                                                                    // at RISC_LOCAL_MEM_BASE address
 
-  static constexpr std::int32_t NCRISC_IRAM_MEM_BASE = 0xffc00000; // NCRISC instruction RAM base address
+  static constexpr uint32_t NCRISC_IRAM_MEM_BASE = 0xffc00000; // NCRISC instruction RAM base address
 
   // Perf buffer (FIXME - update once location of the perf data buffer is finalized)
   // Parameter UNPACK_PACK_PERF_BUF_SIZE_LEVEL_1 assumes the following PERF_BUF_SIZE = 12KB - 768
-  static constexpr std::int32_t PERF_BUF_SIZE = FIRMWARE_SIZE - BRISC_FIRMWARE_SIZE - ZEROS_SIZE;
-  
-  static constexpr std::int32_t PERF_QUEUE_HEADER_SIZE = 16;
-  static constexpr std::int32_t PERF_RISC_MAILBOX_SIZE = 16;
-  static constexpr std::int32_t PERF_UNUSED_SIZE = 32;
-  
-  static constexpr std::int32_t MATH_PERF_BUF_SIZE = 64;
-  static constexpr std::int32_t BRISC_PERF_BUF_SIZE = 640; // Half of this value must be 32B aligned
-  static constexpr std::int32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_0 = 640; // smaller buffer size for limited logging
-  static constexpr std::int32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_1 = (12 * 1024 - 768)/2 - MATH_PERF_BUF_SIZE/2 - (PERF_QUEUE_HEADER_SIZE + PERF_RISC_MAILBOX_SIZE + PERF_UNUSED_SIZE)/2 - BRISC_PERF_BUF_SIZE/2;
-  
-  static constexpr std::int32_t PERF_QUEUE_HEADER_ADDR = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE + ZEROS_SIZE;
-  static constexpr std::int32_t PERF_RISC_MAILBOX_ADDR = PERF_QUEUE_HEADER_ADDR + PERF_QUEUE_HEADER_SIZE;
-  static constexpr std::int32_t BRISC_PERF_BUF_BASE_ADDR = PERF_RISC_MAILBOX_SIZE + PERF_UNUSED_SIZE + PERF_RISC_MAILBOX_ADDR;
-  static constexpr std::int32_t MATH_PERF_BUF_BASE_ADDR = BRISC_PERF_BUF_BASE_ADDR + BRISC_PERF_BUF_SIZE;
-  static constexpr std::int32_t UNPACK_PACK_PERF_BUF_BASE_ADDR = MATH_PERF_BUF_BASE_ADDR + MATH_PERF_BUF_SIZE;
-  static constexpr std::int32_t PERF_NUM_THREADS = 5;
+  static constexpr uint32_t PERF_BUF_SIZE = FIRMWARE_SIZE - BRISC_FIRMWARE_SIZE - ZEROS_SIZE;
 
-  static constexpr std::int32_t PERF_QUEUE_PTRS = PERF_QUEUE_HEADER_ADDR;
-  static constexpr std::int32_t PERF_THREAD_HEADER = PERF_QUEUE_PTRS + 8;
-  static constexpr std::int32_t PERF_WR_PTR_COPY = PERF_QUEUE_PTRS + 12;
+  static constexpr uint32_t PERF_QUEUE_HEADER_SIZE = 16;
+  static constexpr uint32_t PERF_RISC_MAILBOX_SIZE = 16;
+  static constexpr uint32_t PERF_UNUSED_SIZE = 32;
 
-  static constexpr std::int32_t WALL_CLOCK_L = 0xFFB121F0;
-  static constexpr std::int32_t WALL_CLOCK_H = 0xFFB121F8;
+  static constexpr uint32_t MATH_PERF_BUF_SIZE = 64;
+  static constexpr uint32_t BRISC_PERF_BUF_SIZE = 640; // Half of this value must be 32B aligned
+  static constexpr uint32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_0 = 640; // smaller buffer size for limited logging
+  static constexpr uint32_t UNPACK_PACK_PERF_BUF_SIZE_LEVEL_1 = (12 * 1024 - 768)/2 - MATH_PERF_BUF_SIZE/2 - (PERF_QUEUE_HEADER_SIZE + PERF_RISC_MAILBOX_SIZE + PERF_UNUSED_SIZE)/2 - BRISC_PERF_BUF_SIZE/2;
+
+  static constexpr uint32_t PERF_QUEUE_HEADER_ADDR = FIRMWARE_BASE + BRISC_FIRMWARE_SIZE + ZEROS_SIZE;
+  static constexpr uint32_t PERF_RISC_MAILBOX_ADDR = PERF_QUEUE_HEADER_ADDR + PERF_QUEUE_HEADER_SIZE;
+  static constexpr uint32_t BRISC_PERF_BUF_BASE_ADDR = PERF_RISC_MAILBOX_SIZE + PERF_UNUSED_SIZE + PERF_RISC_MAILBOX_ADDR;
+  static constexpr uint32_t MATH_PERF_BUF_BASE_ADDR = BRISC_PERF_BUF_BASE_ADDR + BRISC_PERF_BUF_SIZE;
+  static constexpr uint32_t UNPACK_PACK_PERF_BUF_BASE_ADDR = MATH_PERF_BUF_BASE_ADDR + MATH_PERF_BUF_SIZE;
+  static constexpr uint32_t PERF_NUM_THREADS = 5;
+
+  static constexpr uint32_t PERF_QUEUE_PTRS = PERF_QUEUE_HEADER_ADDR;
+  static constexpr uint32_t PERF_THREAD_HEADER = PERF_QUEUE_PTRS + 8;
+  static constexpr uint32_t PERF_WR_PTR_COPY = PERF_QUEUE_PTRS + 12;
+
+  static constexpr uint32_t WALL_CLOCK_L = 0xFFB121F0;
+  static constexpr uint32_t WALL_CLOCK_H = 0xFFB121F8;
 
 };
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/303

### Description
Using signed integer for address is wrong and can cause bugs due to sign extension since UMD represents addresses as uint64_t internally.  32 bits is unnecessarily restrictive (there are address spaces in the chips that reach beyond 0x7fffffff that I might want to configure a static window for).

### List of the changes
* Use uint64_t instead of int32_t in `configure_tlb` method
* Convert sizes/constants in some header files from int32_t to uint32_t
* Remove unnecessary `std::` prefixing

### Testing
CI

### API Changes
This PR has API changes, but it shouldn't break anything.
