### PR TITLE
Remove logical_id from pci_device

### DIFF
--- a/device/api/umd/device/pci_device.hpp
+++ b/device/api/umd/device/pci_device.hpp
@@ -66,7 +66,6 @@ using tt::umd::semver_t;
 class PCIDevice {
     const std::string device_path;   // Path to character device: /dev/tenstorrent/N
     const int pci_device_num;        // N in /dev/tenstorrent/N
-    const int logical_id;            // Unique identifier for each device in entire network topology
     const int pci_device_file_desc;  // Character device file descriptor
     const PciDeviceInfo info;        // PCI device info
     const int numa_node;             // -1 if non-NUMA
@@ -93,9 +92,8 @@ public:
      * sysfs, and maps device memory region(s) into the process address space.
      *
      * @param pci_device_number     N in /dev/tenstorrent/N
-     * @param logical_device_id     unique identifier for this device in the network topology
      */
-    PCIDevice(int pci_device_number, int logical_device_id = 0);
+    PCIDevice(int pci_device_number);
 
     /**
      * PCIDevice destructor.
@@ -128,13 +126,6 @@ public:
      * TODO: target for removal; upper layers should not care about this.
      */
     int get_device_num() const { return pci_device_num; }
-
-    /**
-     * @return unique integer for each device in entire network topology
-     * TODO: target for removal; upper layers shouldn't to pass this in here. It
-     * is unused by this class.
-     */
-    int get_logical_id() const { return logical_id; }
 
     /**
      * @return PCI device id
@@ -179,18 +170,18 @@ public:
         tt_xy_pair end,
         std::uint64_t address,
         bool multicast,
-        std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>> &harvested_coord_translation,
+        std::unordered_map<tt_xy_pair, tt_xy_pair> &harvested_coord_translation,
         std::uint64_t ordering);
     dynamic_tlb set_dynamic_tlb(
         unsigned int tlb_index,
         tt_xy_pair target,
         std::uint64_t address,
-        std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>> &harvested_coord_translation,
+        std::unordered_map<tt_xy_pair, tt_xy_pair> &harvested_coord_translation,
         std::uint64_t ordering = tt::umd::tlb_data::Relaxed);
     dynamic_tlb set_dynamic_tlb_broadcast(
         unsigned int tlb_index,
         std::uint64_t address,
-        std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>> &harvested_coord_translation,
+        std::unordered_map<tt_xy_pair, tt_xy_pair> &harvested_coord_translation,
         tt_xy_pair start,
         tt_xy_pair end,
         std::uint64_t ordering = tt::umd::tlb_data::Relaxed);

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -258,10 +258,9 @@ tt::ARCH PciDeviceInfo::get_arch() const {
     return infos;
 }
 
-PCIDevice::PCIDevice(int pci_device_number, int logical_device_id) :
+PCIDevice::PCIDevice(int pci_device_number) :
     device_path(fmt::format("/dev/tenstorrent/{}", pci_device_number)),
     pci_device_num(pci_device_number),
-    logical_id(logical_device_id),
     pci_device_file_desc(open(device_path.c_str(), O_RDWR | O_CLOEXEC)),
     info(read_device_info(pci_device_file_desc)),
     numa_node(read_sysfs<int>(info, "numa_node", -1)),  // default to -1 if not found
@@ -602,7 +601,7 @@ dynamic_tlb PCIDevice::set_dynamic_tlb(
     tt_xy_pair end,
     std::uint64_t address,
     bool multicast,
-    std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>> &harvested_coord_translation,
+    std::unordered_map<tt_xy_pair, tt_xy_pair> &harvested_coord_translation,
     std::uint64_t ordering) {
     auto architecture_implementation = get_architecture_implementation();
     if (multicast) {
@@ -624,8 +623,8 @@ dynamic_tlb PCIDevice::set_dynamic_tlb(
 
     tt::umd::tlb_configuration tlb_config = architecture_implementation->get_tlb_configuration(tlb_index);
     std::uint32_t TLB_CFG_REG_SIZE_BYTES = architecture_implementation->get_tlb_cfg_reg_size_bytes();
-    auto translated_start_coords = harvested_coord_translation.at(logical_id).at(start);
-    auto translated_end_coords = harvested_coord_translation.at(logical_id).at(end);
+    auto translated_start_coords = harvested_coord_translation.at(start);
+    auto translated_end_coords = harvested_coord_translation.at(end);
     uint32_t tlb_address = address / tlb_config.size;
     uint32_t local_address = address % tlb_config.size;
     uint64_t tlb_base = tlb_config.base + (tlb_config.size * tlb_config.index_offset);
@@ -665,7 +664,7 @@ dynamic_tlb PCIDevice::set_dynamic_tlb(
     unsigned int tlb_index,
     tt_xy_pair target,
     std::uint64_t address,
-    std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>> &harvested_coord_translation,
+    std::unordered_map<tt_xy_pair, tt_xy_pair> &harvested_coord_translation,
     std::uint64_t ordering) {
     return set_dynamic_tlb(tlb_index, tt_xy_pair(0, 0), target, address, false, harvested_coord_translation, ordering);
 }
@@ -673,7 +672,7 @@ dynamic_tlb PCIDevice::set_dynamic_tlb(
 dynamic_tlb PCIDevice::set_dynamic_tlb_broadcast(
     unsigned int tlb_index,
     std::uint64_t address,
-    std::unordered_map<chip_id_t, std::unordered_map<tt_xy_pair, tt_xy_pair>> &harvested_coord_translation,
+    std::unordered_map<tt_xy_pair, tt_xy_pair> &harvested_coord_translation,
     tt_xy_pair start,
     tt_xy_pair end,
     std::uint64_t ordering) {
@@ -688,7 +687,6 @@ tt::umd::architecture_implementation *PCIDevice::get_architecture_implementation
 bool PCIDevice::init_hugepage(uint32_t num_host_mem_channels) {
     const size_t hugepage_size = HUGEPAGE_REGION_SIZE;
 
-    // Convert from logical (device_id in netlist) to physical device_id (in case of virtualization)
     auto physical_device_id = get_device_num();
 
     std::string hugepage_dir = find_hugepage_dir(hugepage_size);


### PR DESCRIPTION
### Issue
Related to #137

### Description
logical_id should not exist in PCIDevice. Logical id is the notion of the current runtime. PCIDevice only cares about physical card connected to the

### List of the changes
- Remove logical_id from PCIDevice constructor
- Pass harvested info only for this device, not whole map.

### Testing
Code builds

### API Changes
There are no API changes in this PR.
