### PR TITLE
Revert "Make uv and nng private and static (#323)"

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -56,6 +56,7 @@ function(fetch_dependencies)
         GITHUB_REPOSITORY nanomsg/nng
         GIT_TAG v1.8.0
         OPTIONS
+            "BUILD_SHARED_LIBS ON"
             "NNG_TESTS OFF"
             "NNG_TOOLS OFF"
     )
@@ -96,14 +97,7 @@ function(fetch_dependencies)
     ############################################################################################################################
     # libuv (for process management)
     ############################################################################################################################
-    CPMAddPackage(
-        NAME libuv
-        GITHUB_REPOSITORY libuv/libuv
-        GIT_TAG v1.48.0
-        OPTIONS
-            "LIBUV_BUILD_TESTS OFF"
-            "LIBUV_BUILD_SHARED OFF"
-    )
+    CPMAddPackage(NAME libuv GITHUB_REPOSITORY libuv/libuv GIT_TAG v1.48.0 OPTIONS "LIBUV_BUILD_TESTS OFF")
 
     ############################################################################################################################
     # fmt : https://github.com/fmtlib/fmt

--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -41,15 +41,16 @@ target_include_directories(
 )
 
 # flatbuffers is public - exposed to tt_metal by tt_simulation_device_generated.h
+# nng is public - exposed to tt_metal by tt_simulation_host.hpp
 target_link_libraries(
     device
     PUBLIC
+        nng
         flatbuffers
+        uv
     PRIVATE
         hwloc
-        nng
         rt
-        uv_a
         Boost::interprocess
         fmt::fmt-header-only
         yaml-cpp::yaml-cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,6 @@ target_link_libraries(
         gtest
         pthread
         fmt::fmt-header-only
-        nng
 )
 target_include_directories(
     test_common


### PR DESCRIPTION
This reverts commit 0a41bf5d0db7f49de4e12b193cf0246f825d68f6.

### Issue
No issue

### Description
This change broke tt-metal build.
post commit workflow failing: https://github.com/tenstorrent/tt-metal/actions/runs/12031721201
post commit workflow on this branch: https://github.com/tenstorrent/tt-metal/actions/runs/12032379476/job/33545486354
blackhole post-commit failing: https://github.com/tenstorrent/tt-metal/actions/runs/12031811999
blackhole post-commit on this branch: https://github.com/tenstorrent/tt-metal/actions/runs/12032509241

### List of the changes
- git revert 0a41bf5d0db7f49de4e12b193cf0246f825d68f6

### Testing
see description

### API Changes
-