### PR TITLE
Build all when building tt_metal

### DIFF
--- a/.github/workflows/build-clients.yml
+++ b/.github/workflows/build-clients.yml
@@ -7,7 +7,7 @@ on:
         required: true
         description: 'The timeout for the job in minutes'
         type: number
-        default: 30
+        default: 90
   pull_request:
     branches: ["main"]
   push:
@@ -17,7 +17,7 @@ jobs:
   build-tt-metal:
     # Due to parsing bug, fromJSON is used to convert string to number.
     # In pull_request or push events, the input context is not available, stating the default again here.
-    timeout-minutes: ${{ fromJSON(inputs.timeout || '30') }}
+    timeout-minutes: ${{ fromJSON(inputs.timeout || '90') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-clients.yml
+++ b/.github/workflows/build-clients.yml
@@ -53,4 +53,4 @@ jobs:
           export ARCH_NAME=${{ matrix.arch_name }}
           export TT_METAL_HOME=$(pwd)
           export PYTHONPATH=$(pwd)
-          ./build_metal.sh
+          ./build_metal.sh --build-all --enable-ccache --enable-profiler


### PR DESCRIPTION
### Issue
No issue

### Description
Build more stuff during "build client" workflow, to match what is done in tt_metal ci.

### List of the changes
- Added build options --build-all --enable-ccache --enable-profiler

### Testing
CI test

### API Changes
There are no API changes in this PR.
