### PR TITLE
Initial Chip class

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -24,6 +24,10 @@ target_sources(
     device
     PRIVATE
         architecture_implementation.cpp
+        chip/chip.cpp
+        chip/local_chip.cpp
+        chip/mock_chip.cpp
+        chip/remote_chip.cpp
         cluster.cpp
         coordinate_manager.cpp
         cpuset_lib.cpp

--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -14,17 +14,15 @@ namespace tt::umd {
 // An abstract class that represents a chip.
 class Chip {
 public:
-    Chip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor);
+    Chip(tt_SocDescriptor soc_descriptor);
 
     virtual ~Chip() = default;
 
-    chip_id_t get_chip_id() const;
     tt_SocDescriptor& get_soc_descriptor();
 
     virtual bool is_mmio_capable() const = 0;
 
 private:
-    chip_id_t chip_id_;
     tt_SocDescriptor soc_descriptor_;
 };
 

--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -21,6 +21,8 @@ public:
     chip_id_t get_chip_id() const;
     tt_SocDescriptor& get_soc_descriptor();
 
+    virtual bool is_mmio_capable() const = 0;
+
 private:
     chip_id_t chip_id_;
     tt_SocDescriptor soc_descriptor_;

--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "umd/device/tt_cluster_descriptor_types.h"
+#include "umd/device/tt_soc_descriptor.h"
+
+namespace tt::umd {
+
+// An abstract class that represents a chip.
+class Chip {
+public:
+    Chip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor);
+
+    virtual ~Chip() = default;
+
+    chip_id_t get_chip_id() const;
+    tt_SocDescriptor& get_soc_descriptor();
+
+private:
+    chip_id_t chip_id_;
+    tt_SocDescriptor soc_descriptor_;
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include "umd/device/tt_cluster_descriptor_types.h"
 #include "umd/device/tt_soc_descriptor.h"
+#include "umd/device/types/cluster_descriptor_types.h"
 
 namespace tt::umd {
 

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "umd/device/chip/chip.h"
+
+namespace tt::umd {
+class LocalChip : public Chip {
+public:
+    LocalChip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor);
+};
+}  // namespace tt::umd

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -12,5 +12,6 @@ namespace tt::umd {
 class LocalChip : public Chip {
 public:
     LocalChip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor);
+    bool is_mmio_capable() const override;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -11,7 +11,7 @@
 namespace tt::umd {
 class LocalChip : public Chip {
 public:
-    LocalChip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor);
+    LocalChip(tt_SocDescriptor soc_descriptor);
     bool is_mmio_capable() const override;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/chip/mock_chip.h
+++ b/device/api/umd/device/chip/mock_chip.h
@@ -12,5 +12,6 @@ namespace tt::umd {
 class MockChip : public Chip {
 public:
     MockChip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor);
+    bool is_mmio_capable() const override;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/chip/mock_chip.h
+++ b/device/api/umd/device/chip/mock_chip.h
@@ -11,7 +11,7 @@
 namespace tt::umd {
 class MockChip : public Chip {
 public:
-    MockChip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor);
+    MockChip(tt_SocDescriptor soc_descriptor);
     bool is_mmio_capable() const override;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/chip/mock_chip.h
+++ b/device/api/umd/device/chip/mock_chip.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "umd/device/chip/chip.h"
+
+namespace tt::umd {
+class MockChip : public Chip {
+public:
+    MockChip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor);
+};
+}  // namespace tt::umd

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -11,7 +11,7 @@
 namespace tt::umd {
 class RemoteChip : public Chip {
 public:
-    RemoteChip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor);
+    RemoteChip(tt_SocDescriptor soc_descriptor);
     bool is_mmio_capable() const override;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "umd/device/chip/chip.h"
+
+namespace tt::umd {
+class RemoteChip : public Chip {
+public:
+    RemoteChip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor);
+};
+}  // namespace tt::umd

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -12,5 +12,6 @@ namespace tt::umd {
 class RemoteChip : public Chip {
 public:
     RemoteChip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor);
+    bool is_mmio_capable() const override;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -479,7 +479,8 @@ public:
      * @param skip_driver_allocs
      * @param clean_system_resource Specifies if host state from previous runs needs to be cleaned up.
      * @param perform_harvesting Allow the driver to modify the SOC descriptors per chip.
-     * @param simulated_harvesting_masks
+     * @param simulated_harvesting_masks Manually specify additional harvesting masks for the devices in the cluster.
+     * The ones defined by the devices itself have to be used, they will be merged with the ones passed here.
      */
     Cluster(
         const uint32_t& num_host_mem_ch_per_mmio_device = 1,
@@ -490,14 +491,15 @@ public:
 
     /**
      * Cluster constructor.
-     * This constructor can be used to target specific devices on the system.
+     * This constructor can be used to target only specific devices on the system.
      *
      * @param target_devices Devices to target.
      * @param num_host_mem_ch_per_mmio_device Requested number of host channels (hugepages).
      * @param skip_driver_allocs
      * @param clean_system_resource Specifies if host state from previous runs needs to be cleaned up.
      * @param perform_harvesting Allow the driver to modify the SOC descriptors per chip.
-     * @param simulated_harvesting_masks
+     * @param simulated_harvesting_masks Manually specify additional harvesting masks for the devices in the cluster.
+     * The ones defined by the devices itself have to be used, they will be merged with the ones passed here.
      */
     Cluster(
         const std::set<chip_id_t>& target_devices,
@@ -511,14 +513,16 @@ public:
      * Cluster constructor.
      * This constructor can be used with custom soc descriptors for the devices on the system.
      *
-     * @param sdesc_path SOC descriptor yaml path specifying single chip. This represents default architecture and will
-     * be harvested according to the devices present in the cluster.
+     * @param sdesc_path SOC descriptor yaml path specifying single chip. The passed soc descriptor will be used as a
+     * default device description for devices in the cluster, but each chip will be harvested according to the
+     * harvesting info of the devices in the cluster.
      * @param target_devices Devices to target.
      * @param num_host_mem_ch_per_mmio_device Requested number of host channels (hugepages).
      * @param skip_driver_allocs
      * @param clean_system_resource Specifies if host state from previous runs needs to be cleaned up.
      * @param perform_harvesting Allow the driver to modify the SOC descriptors per chip.
-     * @param simulated_harvesting_masks
+     * @param simulated_harvesting_masks Manually specify additional harvesting masks for the devices in the cluster.
+     * The ones defined by the devices itself have to be used, they will be merged with the ones passed here.
      */
     Cluster(
         const std::string& sdesc_path,

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -280,7 +280,7 @@ public:
      * Query post harvesting SOC descriptors from UMD in virtual coordinates.
      * These descriptors should be used for looking up cores that are passed into UMD APIs.
      */
-    virtual std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors() {
+    virtual std::unordered_map<chip_id_t, tt_SocDescriptor> get_virtual_soc_descriptors() {
         return soc_descriptor_per_chip;
     }
 
@@ -677,7 +677,7 @@ public:
 
     const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const;
     // TODO: This function should be removed.
-    std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors();
+    std::unordered_map<chip_id_t, tt_SocDescriptor> get_virtual_soc_descriptors();
 
     // Destructor
     virtual ~Cluster();

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -449,7 +449,7 @@ public:
         return 0;
     }
 
-    virtual const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) {
+    virtual const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const {
         return soc_descriptor_per_chip.at(chip_id);
     }
 
@@ -676,6 +676,8 @@ public:
     TTDevice* get_tt_device(chip_id_t device_id) const;
 
     const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const;
+    // TODO: This function should be removed.
+    std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors();
 
     // Destructor
     virtual ~Cluster();

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -42,8 +42,8 @@ class tt_ClusterDescriptor;
  */
 class tt_device {
 public:
-    tt_device();
-    virtual ~tt_device();
+    tt_device(){};
+    virtual ~tt_device(){};
 
     // Setup/Teardown Functions
     /**
@@ -281,7 +281,7 @@ public:
      * These descriptors should be used for looking up cores that are passed into UMD APIs.
      */
     virtual std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors() {
-        throw std::runtime_error("---- tt_device:get_virtual_soc_descriptors is not implemented\n");
+        return soc_descriptor_per_chip;
     }
 
     /**
@@ -449,11 +449,17 @@ public:
         return 0;
     }
 
-    virtual const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const = 0;
+    virtual const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) {
+        return soc_descriptor_per_chip.at(chip_id);
+    }
 
     bool performed_harvesting = false;
     std::unordered_map<chip_id_t, uint32_t> harvested_rows_per_target = {};
     bool translation_tables_en = false;
+
+protected:
+    // TODO: Remove this once get_virtual_soc_descriptors can be removed.
+    std::unordered_map<chip_id_t, tt_SocDescriptor> soc_descriptor_per_chip = {};
 };
 
 namespace tt::umd {
@@ -550,7 +556,6 @@ public:
     static std::unique_ptr<Cluster> create_mock_cluster();
 
     // Setup/Teardown Functions
-    virtual std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors();
     virtual void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_);
     virtual void set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_);
     virtual void set_driver_host_address_params(const tt_driver_host_address_params& host_address_params_);
@@ -827,8 +832,6 @@ private:
     // Map of enabled tt devices
     std::unordered_map<chip_id_t, std::unique_ptr<TTDevice>> m_tt_device_map;
     std::shared_ptr<tt_ClusterDescriptor> cluster_desc;
-    // TODO: See if this can be removed.
-    std::unordered_map<chip_id_t, tt_SocDescriptor> soc_desc_map;
 
     // remote eth transfer setup
     static constexpr std::uint32_t NUM_ETH_CORES_FOR_NON_MMIO_TRANSFERS = 6;

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -449,7 +449,7 @@ public:
         return 0;
     }
 
-    virtual const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const;
+    virtual const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const = 0;
 
     bool performed_harvesting = false;
     std::unordered_map<chip_id_t, uint32_t> harvested_rows_per_target = {};
@@ -520,10 +520,10 @@ public:
         bool perform_harvesting = true,
         std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {});
 
-    // /**
-    //  * Cluster constructor which creates a cluster for Mock chips.
-    //  */
-    // static std::unique_ptr<Cluster> create_mock_cluster();
+    /**
+     * Cluster constructor which creates a cluster for Mock chips.
+     */
+    static std::unique_ptr<Cluster> create_mock_cluster();
 
     // /**
     //  * Helper function to construct a chip from info found in cluster descriptor.
@@ -658,6 +658,12 @@ public:
     virtual ~Cluster();
 
 private:
+    /**
+     * Construct empty cluster, for the purposes of creating a mock cluster.
+     * Note that the argument is not used, but is required to differentiate from the other constructor.
+     */
+    Cluster(bool mock);
+
     // Helper functions
     // Startup + teardown
     void create_device(
@@ -788,7 +794,7 @@ private:
     // This functions has to be called for local chip, and then it will wait for all connected remote chips to flush.
     void wait_for_connected_non_mmio_flush(chip_id_t chip_id);
 
-    void add_chip(chip_id_t chip_id, tt_SocDescriptor& soc_desc, bool is_mmio_capable);
+    void add_chip(chip_id_t chip_id, std::unique_ptr<Chip> chip);
     void construct_cluster(
         const uint32_t& num_host_mem_ch_per_mmio_device,
         const bool skip_driver_allocs,
@@ -812,6 +818,8 @@ private:
     // Map of enabled tt devices
     std::unordered_map<chip_id_t, std::unique_ptr<TTDevice>> m_tt_device_map;
     std::shared_ptr<tt_ClusterDescriptor> cluster_desc;
+    // TODO: See if this can be removed.
+    std::unordered_map<chip_id_t, tt_SocDescriptor> soc_desc_map;
 
     // remote eth transfer setup
     static constexpr std::uint32_t NUM_ETH_CORES_FOR_NON_MMIO_TRANSFERS = 6;

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -511,7 +511,8 @@ public:
      * Cluster constructor.
      * This constructor can be used with custom soc descriptors for the devices on the system.
      *
-     * @param soc_desc SOC descriptor specifying single chip.
+     * @param sdesc_path SOC descriptor yaml path specifying single chip. This represents default architecture and will
+     * be harvested according to the devices present in the cluster.
      * @param target_devices Devices to target.
      * @param num_host_mem_ch_per_mmio_device Requested number of host channels (hugepages).
      * @param skip_driver_allocs
@@ -520,7 +521,7 @@ public:
      * @param simulated_harvesting_masks
      */
     Cluster(
-        tt_SocDescriptor soc_desc,
+        const std::string& sdesc_path,
         const std::set<chip_id_t>& target_devices,
         const uint32_t& num_host_mem_ch_per_mmio_device = 1,
         const bool skip_driver_allocs = false,

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -20,6 +20,8 @@ public:
 
     tt_SimulationHost host;
 
+    const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const;
+
     // Setup/Teardown Functions
     virtual std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors();
     virtual void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_);
@@ -62,6 +64,9 @@ public:
     virtual std::uint32_t get_num_host_channels(std::uint32_t device_id);
     virtual std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel);
     virtual std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id);
+
+protected:
+    std::unordered_map<chip_id_t, tt_SocDescriptor> soc_descriptor_per_chip = {};
 
 private:
     // State variables

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -20,10 +20,6 @@ public:
 
     tt_SimulationHost host;
 
-    const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const;
-
-    // Setup/Teardown Functions
-    virtual std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors();
     virtual void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_);
     virtual void set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_);
     virtual void set_driver_host_address_params(const tt_driver_host_address_params& host_address_params_);
@@ -64,9 +60,6 @@ public:
     virtual std::uint32_t get_num_host_channels(std::uint32_t device_id);
     virtual std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel);
     virtual std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id);
-
-protected:
-    std::unordered_map<chip_id_t, tt_SocDescriptor> soc_descriptor_per_chip = {};
 
 private:
     // State variables

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "umd/device/chip/chip.h"
+
+namespace tt::umd {
+
+Chip::Chip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor) : chip_id_(chip_id), soc_descriptor_(soc_descriptor) {}
+
+chip_id_t Chip::get_chip_id() const { return chip_id_; }
+
+tt_SocDescriptor& Chip::get_soc_descriptor() { return soc_descriptor_; }
+
+}  // namespace tt::umd

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -8,9 +8,7 @@
 
 namespace tt::umd {
 
-Chip::Chip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor) : chip_id_(chip_id), soc_descriptor_(soc_descriptor) {}
-
-chip_id_t Chip::get_chip_id() const { return chip_id_; }
+Chip::Chip(tt_SocDescriptor soc_descriptor) : soc_descriptor_(soc_descriptor) {}
 
 tt_SocDescriptor& Chip::get_soc_descriptor() { return soc_descriptor_; }
 

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "umd/device/chip/local_chip.h"
+
+namespace tt::umd {
+
+LocalChip::LocalChip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor) : Chip(chip_id, soc_descriptor) {}
+
+}  // namespace tt::umd

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -10,4 +10,5 @@ namespace tt::umd {
 
 LocalChip::LocalChip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor) : Chip(chip_id, soc_descriptor) {}
 
+bool LocalChip::is_mmio_capable() const { return true; }
 }  // namespace tt::umd

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -8,7 +8,7 @@
 
 namespace tt::umd {
 
-LocalChip::LocalChip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor) : Chip(chip_id, soc_descriptor) {}
+LocalChip::LocalChip(tt_SocDescriptor soc_descriptor) : Chip(soc_descriptor) {}
 
 bool LocalChip::is_mmio_capable() const { return true; }
 }  // namespace tt::umd

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -8,7 +8,7 @@
 
 namespace tt::umd {
 
-MockChip::MockChip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor) : Chip(chip_id, soc_descriptor) {}
+MockChip::MockChip(tt_SocDescriptor soc_descriptor) : Chip(soc_descriptor) {}
 
 bool MockChip::is_mmio_capable() const { return true; }
 }  // namespace tt::umd

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -10,4 +10,5 @@ namespace tt::umd {
 
 MockChip::MockChip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor) : Chip(chip_id, soc_descriptor) {}
 
+bool MockChip::is_mmio_capable() const { return true; }
 }  // namespace tt::umd

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "umd/device/chip/mock_chip.h"
+
+namespace tt::umd {
+
+MockChip::MockChip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor) : Chip(chip_id, soc_descriptor) {}
+
+}  // namespace tt::umd

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "umd/device/chip/remote_chip.h"
+
+namespace tt::umd {
+
+RemoteChip::RemoteChip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor) : Chip(chip_id, soc_descriptor) {}
+
+}  // namespace tt::umd

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -10,4 +10,5 @@ namespace tt::umd {
 
 RemoteChip::RemoteChip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor) : Chip(chip_id, soc_descriptor) {}
 
+bool RemoteChip::is_mmio_capable() const { return false; }
 }  // namespace tt::umd

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -8,7 +8,7 @@
 
 namespace tt::umd {
 
-RemoteChip::RemoteChip(chip_id_t chip_id, tt_SocDescriptor soc_descriptor) : Chip(chip_id, soc_descriptor) {}
+RemoteChip::RemoteChip(tt_SocDescriptor soc_descriptor) : Chip(soc_descriptor) {}
 
 bool RemoteChip::is_mmio_capable() const { return false; }
 }  // namespace tt::umd

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -501,6 +501,10 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(chip_id_t chip_id, tt
 }
 
 void Cluster::add_chip(chip_id_t chip_id, std::unique_ptr<Chip> chip) {
+    log_assert(
+        chips_.find(chip_id) == chips_.end(),
+        "Chip with id {} already exists in cluster. Cannot add another chip with the same id.",
+        chip_id);
     target_devices_in_cluster.insert(chip_id);
     if (chip->is_mmio_capable()) {
         all_target_mmio_devices.insert(chip_id);

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -566,7 +566,7 @@ Cluster::Cluster(
 }
 
 Cluster::Cluster(
-    tt_SocDescriptor soc_desc,
+    const std::string& sdesc_path,
     const std::set<chip_id_t>& target_devices,
     const uint32_t& num_host_mem_ch_per_mmio_device,
     const bool skip_driver_allocs,
@@ -580,6 +580,8 @@ Cluster::Cluster(
             cluster_desc->get_all_chips().find(chip_id) != cluster_desc->get_all_chips().end(),
             "Target device {} not present in current cluster!",
             chip_id);
+
+        tt_SocDescriptor soc_desc = tt_SocDescriptor(sdesc_path, cluster_desc->get_harvesting_info().at(chip_id));
         log_assert(
             cluster_desc->get_arch(chip_id) == soc_desc.arch,
             "Passed soc descriptor has {} arch, but for chip id {} has arch {}",

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -585,9 +585,9 @@ Cluster::Cluster(
         log_assert(
             cluster_desc->get_arch(chip_id) == soc_desc.arch,
             "Passed soc descriptor has {} arch, but for chip id {} has arch {}",
-            get_arch_str(soc_desc.arch),
+            arch_to_str(soc_desc.arch),
             chip_id,
-            get_arch_str(cluster_desc->get_arch(chip_id)));
+            arch_to_str(cluster_desc->get_arch(chip_id)));
         add_chip(chip_id, construct_chip_from_cluster(chip_id, cluster_desc.get(), soc_desc));
     }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -71,12 +71,6 @@ void size_buffer_to_capacity(std::vector<T>& data_buf, std::size_t size_in_bytes
     data_buf.resize(target_size);
 }
 
-// TODO: To be removed when tt_device is removed
-
-tt_device::tt_device() {}
-
-tt_device::~tt_device() {}
-
 // --------------------------------------------------------------------------------------------------------------
 // --------------------------------------------------------------------------------------------------------------
 // --------------------------------------------------------------------------------------------------------------
@@ -150,8 +144,6 @@ bool Cluster::address_in_tlb_space(
     }
     return false;
 }
-
-std::unordered_map<chip_id_t, tt_SocDescriptor>& Cluster::get_virtual_soc_descriptors() { return soc_desc_map; }
 
 void Cluster::initialize_interprocess_mutexes(int pci_interface_id, bool cleanup_mutexes_in_shm) {
     // These mutexes are intended to be based on physical devices/pci-intf not logical. Set these up ahead of time here
@@ -332,9 +324,9 @@ void Cluster::construct_cluster(
             target_remote_chips);
     }
 
-    // Prefill the soc_desc_map
+    // Prefill the soc_descriptor_per_chip
     for (const auto& [chip_id, chip] : chips_) {
-        soc_desc_map.emplace(chip_id, chip->get_soc_descriptor());
+        soc_descriptor_per_chip.emplace(chip_id, chip->get_soc_descriptor());
     }
 
     perform_harvesting_on_sdesc = perform_harvesting;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -39,6 +39,7 @@
 #include "logger.hpp"
 #include "umd/device/architecture_implementation.h"
 #include "umd/device/chip/local_chip.h"
+#include "umd/device/chip/mock_chip.h"
 #include "umd/device/chip/remote_chip.h"
 #include "umd/device/driver_atomics.h"
 #include "umd/device/hugepage.h"
@@ -139,19 +140,6 @@ const tt_SocDescriptor& Cluster::get_soc_descriptor(chip_id_t chip_id) const {
     return chips_.at(chip_id)->get_soc_descriptor();
 }
 
-// std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
-//     chip_id_t logical_device_id, tt_ClusterDescriptor* cluster_desc) {
-//     if (cluster_desc == nullptr) {
-//         cluster_desc = tt_ClusterDescriptor::create();
-//     }
-
-//     if (cluster_desc->is_chip_mmio_capable(logical_device_id)) {
-//         return std::make_unique<LocalChip>(logical_device_id, cluster_desc);
-//     } else {
-//         return std::make_unique<RemoteChip>(logical_device_id, cluster_desc);
-//     }
-// }
-
 bool Cluster::address_in_tlb_space(
     uint64_t address, uint32_t size_in_bytes, int32_t tlb_index, uint64_t tlb_size, std::uint32_t chip) {
     const auto& tlb_map = tlb_config_map.at(chip);
@@ -163,13 +151,7 @@ bool Cluster::address_in_tlb_space(
     return false;
 }
 
-std::unordered_map<chip_id_t, tt_SocDescriptor>& Cluster::get_virtual_soc_descriptors() {
-    std::unordered_map<chip_id_t, tt_SocDescriptor> soc_desc_map;
-    for (const auto& [chip_id, chip] : chips_) {
-        soc_desc_map.emplace(chip_id, chip->get_soc_descriptor());
-    }
-    return soc_desc_map;
-}
+std::unordered_map<chip_id_t, tt_SocDescriptor>& Cluster::get_virtual_soc_descriptors() { return soc_desc_map; }
 
 void Cluster::initialize_interprocess_mutexes(int pci_interface_id, bool cleanup_mutexes_in_shm) {
     // These mutexes are intended to be based on physical devices/pci-intf not logical. Set these up ahead of time here
@@ -350,6 +332,11 @@ void Cluster::construct_cluster(
             target_remote_chips);
     }
 
+    // Prefill the soc_desc_map
+    for (const auto& [chip_id, chip] : chips_) {
+        soc_desc_map.emplace(chip_id, chip->get_soc_descriptor());
+    }
+
     perform_harvesting_on_sdesc = perform_harvesting;
 
     // It is mandatory for all devices to have these TLBs set aside, as the driver needs them to issue remote reads and
@@ -504,14 +491,11 @@ void Cluster::construct_cluster(
     noc_params = architecture_implementation->get_noc_params();
 }
 
-void Cluster::add_chip(chip_id_t chip_id, tt_SocDescriptor& soc_desc, bool is_mmio_capable) {
-    std::unique_ptr<Chip> chip;
+void Cluster::add_chip(chip_id_t chip_id, std::unique_ptr<Chip> chip) {
     target_devices_in_cluster.insert(chip_id);
-    if (is_mmio_capable) {
-        chip = std::make_unique<LocalChip>(soc_desc);
+    if (chip->is_mmio_capable()) {
         all_target_mmio_devices.insert(chip_id);
     } else {
-        chip = std::make_unique<RemoteChip>(soc_desc);
         target_remote_chips.insert(chip_id);
     }
     chips_.emplace(chip_id, std::move(chip));
@@ -522,8 +506,7 @@ Cluster::Cluster(
     const bool skip_driver_allocs,
     const bool clean_system_resources,
     bool perform_harvesting,
-    std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks) :
-    tt_device() {
+    std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks) {
     cluster_desc = tt_ClusterDescriptor::create();
 
     for (auto& chip_id : cluster_desc->get_all_chips()) {
@@ -531,12 +514,15 @@ Cluster::Cluster(
         std::string soc_desc_path = tt_SocDescriptor::get_soc_descriptor_path(arch);
         uint32_t harvesting_info = cluster_desc->get_harvesting_info().at(chip_id);
         tt_SocDescriptor soc_desc = tt_SocDescriptor(soc_desc_path, harvesting_info);
-        bool is_chip_mmio_capable = cluster_desc->is_chip_mmio_capable(chip_id);
-        add_chip(chip_id, soc_desc, is_chip_mmio_capable);
+        if (cluster_desc->is_chip_mmio_capable(chip_id)) {
+            add_chip(chip_id, std::make_unique<LocalChip>(soc_desc));
+        } else {
+            add_chip(chip_id, std::make_unique<RemoteChip>(soc_desc));
+        }
     }
 
     // TODO: work on removing this member altogether. Currently assumes all have the same arch.
-    arch_name = chips_.begin()->second->get()->get_soc_descriptor().arch;
+    arch_name = chips_.begin()->second->get_soc_descriptor().arch;
 
     construct_cluster(
         num_host_mem_ch_per_mmio_device,
@@ -552,8 +538,7 @@ Cluster::Cluster(
     const bool skip_driver_allocs,
     const bool clean_system_resources,
     bool perform_harvesting,
-    std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks) :
-    tt_device() {
+    std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks) {
     cluster_desc = tt_ClusterDescriptor::create();
 
     for (auto& chip_id : target_devices) {
@@ -565,12 +550,15 @@ Cluster::Cluster(
         std::string soc_desc_path = tt_SocDescriptor::get_soc_descriptor_path(arch);
         uint32_t harvesting_info = cluster_desc->get_harvesting_info().at(chip_id);
         tt_SocDescriptor soc_desc = tt_SocDescriptor(soc_desc_path, harvesting_info);
-        bool is_chip_mmio_capable = cluster_desc->is_chip_mmio_capable(chip_id);
-        add_chip(chip_id, soc_desc, is_chip_mmio_capable);
+        if (cluster_desc->is_chip_mmio_capable(chip_id)) {
+            add_chip(chip_id, std::make_unique<LocalChip>(soc_desc));
+        } else {
+            add_chip(chip_id, std::make_unique<RemoteChip>(soc_desc));
+        }
     }
 
     // TODO: work on removing this member altogether. Currently assumes all have the same arch.
-    arch_name = chips_.begin()->second->get()->get_soc_descriptor().arch;
+    arch_name = chips_.begin()->second->get_soc_descriptor().arch;
 
     construct_cluster(
         num_host_mem_ch_per_mmio_device,
@@ -587,8 +575,7 @@ Cluster::Cluster(
     const bool skip_driver_allocs,
     const bool clean_system_resources,
     bool perform_harvesting,
-    std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks) :
-    tt_device() {
+    std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks) {
     cluster_desc = tt_ClusterDescriptor::create();
 
     for (auto& chip_id : target_devices) {
@@ -599,15 +586,18 @@ Cluster::Cluster(
         log_assert(
             cluster_desc->get_arch(chip_id) == soc_desc.arch,
             "Passed soc descriptor has {} arch, but for chip id {} has arch {}",
-            soc_desc.arch,
+            get_arch_str(soc_desc.arch),
             chip_id,
-            cluster_desc->get_arch(chip_id));
-        bool is_chip_mmio_capable = cluster_desc->is_chip_mmio_capable(chip_id);
-        add_chip(chip_id, soc_desc, is_chip_mmio_capable);
+            get_arch_str(cluster_desc->get_arch(chip_id)));
+        if (cluster_desc->is_chip_mmio_capable(chip_id)) {
+            add_chip(chip_id, std::make_unique<LocalChip>(soc_desc));
+        } else {
+            add_chip(chip_id, std::make_unique<RemoteChip>(soc_desc));
+        }
     }
 
     // TODO: work on removing this member altogether. Currently assumes all have the same arch.
-    arch_name = chips_.begin()->second->get()->get_soc_descriptor().arch;
+    arch_name = chips_.begin()->second->get_soc_descriptor().arch;
 
     construct_cluster(
         num_host_mem_ch_per_mmio_device,
@@ -615,6 +605,22 @@ Cluster::Cluster(
         clean_system_resources,
         perform_harvesting,
         simulated_harvesting_masks);
+}
+
+Cluster::Cluster(bool mock) {}
+
+/* static */ std::unique_ptr<Cluster> Cluster::create_mock_cluster() {
+    // TBD how this would look like for simulated cluster.
+    std::unique_ptr<Cluster> cluster = std::unique_ptr<Cluster>(new Cluster(true));
+    // Arbitrary arch used for mock cluster.
+    cluster->arch_name = tt::ARCH::WORMHOLE_B0;
+    chip_id_t mock_chip_id = 0;
+    cluster->cluster_desc = tt_ClusterDescriptor::create_mock_cluster({mock_chip_id}, cluster->arch_name);
+    tt_SocDescriptor soc_desc = tt_SocDescriptor(tt_SocDescriptor::get_soc_descriptor_path(cluster->arch_name));
+    cluster->add_chip(mock_chip_id, std::make_unique<MockChip>(soc_desc));
+
+    cluster->construct_cluster(1, true, true, false, {});
+    return cluster;
 }
 
 void Cluster::configure_active_ethernet_cores_for_mmio_device(

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -134,14 +134,12 @@ const tt_SocDescriptor& Cluster::get_soc_descriptor(chip_id_t chip_id) const {
     return chips_.at(chip_id)->get_soc_descriptor();
 }
 
-std::unordered_map<chip_id_t, tt_SocDescriptor>& Cluster::get_virtual_soc_descriptors() {
-    // Refresh map of soc descriptors before returning it.
-    // TODO: This function should not exist.
-    soc_descriptor_per_chip.clear();
+std::unordered_map<chip_id_t, tt_SocDescriptor> Cluster::get_virtual_soc_descriptors() {
+    std::unordered_map<chip_id_t, tt_SocDescriptor> soc_descs;
     for (const auto& chip : chips_) {
-        soc_descriptor_per_chip[chip.first] = chip.second->get_soc_descriptor();
+        soc_descs[chip.first] = chip.second->get_soc_descriptor();
     }
-    return soc_descriptor_per_chip;
+    return soc_descs;
 }
 
 bool Cluster::address_in_tlb_space(

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -646,7 +646,10 @@ Cluster::Cluster(
 /* static */ std::unique_ptr<Cluster> Cluster::create_mock_cluster() {
     // TBD how this would look like for simulated cluster.
     // Arbitrary arch used for mock cluster.
-    tt::ARCH arch = tt::ARCH::WORMHOLE_B0;
+    // Note that this arch currently has an impact on some stuff in Cluster class, based on the produced cluster
+    // descriptor on the system. This should not be true in the future when we start taking stuff in Cluster from Chip
+    // rather than ClusterDescriptor.
+    tt::ARCH arch = tt::ARCH::GRAYSKULL;
     chip_id_t mock_chip_id = 0;
     tt_SocDescriptor soc_desc = tt_SocDescriptor(tt_SocDescriptor::get_soc_descriptor_path(arch));
     std::unique_ptr<Chip> chip = std::make_unique<MockChip>(soc_desc);

--- a/device/mockup/tt_mockup_device.hpp
+++ b/device/mockup/tt_mockup_device.hpp
@@ -21,15 +21,6 @@ public:
 
     virtual ~tt_MockupDevice() {}
 
-    const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const override {
-        return soc_descriptor_per_chip.at(0);
-    }
-
-    // Setup/Teardown Functions
-    virtual std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors() override {
-        return soc_descriptor_per_chip;
-    }
-
     void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_) override {}
 
     void set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_) override {}
@@ -113,9 +104,6 @@ public:
     std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel) override { return 0; }
 
     std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id) override { return 0; }
-
-protected:
-    std::unordered_map<chip_id_t, tt_SocDescriptor> soc_descriptor_per_chip = {};
 
 private:
     std::vector<tt::ARCH> archs_in_cluster = {};

--- a/device/mockup/tt_mockup_device.hpp
+++ b/device/mockup/tt_mockup_device.hpp
@@ -21,7 +21,9 @@ public:
 
     virtual ~tt_MockupDevice() {}
 
-    const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const override;
+    const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const override {
+        return soc_descriptor_per_chip.at(0);
+    }
 
     // Setup/Teardown Functions
     virtual std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors() override {

--- a/device/mockup/tt_mockup_device.hpp
+++ b/device/mockup/tt_mockup_device.hpp
@@ -21,6 +21,8 @@ public:
 
     virtual ~tt_MockupDevice() {}
 
+    const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const override;
+
     // Setup/Teardown Functions
     virtual std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors() override {
         return soc_descriptor_per_chip;
@@ -109,6 +111,9 @@ public:
     std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel) override { return 0; }
 
     std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id) override { return 0; }
+
+protected:
+    std::unordered_map<chip_id_t, tt_SocDescriptor> soc_descriptor_per_chip = {};
 
 private:
     std::vector<tt::ARCH> archs_in_cluster = {};

--- a/device/simulation/deprecated/tt_emulation_device.cpp
+++ b/device/simulation/deprecated/tt_emulation_device.cpp
@@ -26,10 +26,6 @@ tt_emulation_device::~tt_emulation_device() {
     log_info(tt::LogEmulationDriver, "Destroyed Emulation Device ");
 }
 
-const tt_SocDescriptor& tt_emulation_device::get_soc_descriptor(chip_id_t chip_id) const {
-    return soc_descriptor_per_chip.at(chip_id);
-}
-
 void tt_emulation_device::write(tt_cxy_pair core, uint64_t addr, const std::vector<uint8_t>& data) {
     const uint32_t size = static_cast<uint32_t>(data.size());
     tt_zebu_wrapper_inst->axi_write(0, core.x, core.y, addr, size, data);
@@ -222,10 +218,6 @@ bool tt_emulation_device::noc_translation_en() { return false; }
 
 std::unordered_map<chip_id_t, uint32_t> tt_emulation_device::get_harvesting_masks_for_soc_descriptors() {
     return {{0, 0}};
-}
-
-std::unordered_map<chip_id_t, tt_SocDescriptor>& tt_emulation_device::get_virtual_soc_descriptors() {
-    return soc_descriptor_per_chip;
 }
 
 std::map<int, int> tt_emulation_device::get_clocks() { return std::map<int, int>(); }

--- a/device/simulation/deprecated/tt_emulation_device.cpp
+++ b/device/simulation/deprecated/tt_emulation_device.cpp
@@ -26,6 +26,10 @@ tt_emulation_device::~tt_emulation_device() {
     log_info(tt::LogEmulationDriver, "Destroyed Emulation Device ");
 }
 
+const tt_SocDescriptor& tt_emulation_device::get_soc_descriptor(chip_id_t chip_id) const {
+    return soc_descriptor_per_chip.at(chip_id);
+}
+
 void tt_emulation_device::write(tt_cxy_pair core, uint64_t addr, const std::vector<uint8_t>& data) {
     const uint32_t size = static_cast<uint32_t>(data.size());
     tt_zebu_wrapper_inst->axi_write(0, core.x, core.y, addr, size, data);

--- a/device/simulation/deprecated/tt_emulation_device.h
+++ b/device/simulation/deprecated/tt_emulation_device.h
@@ -19,8 +19,6 @@ class tt_zebu_wrapper;
 
 class tt_emulation_device : public tt_device {
 public:
-    const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const;
-
     virtual void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_);  // Dont care
     tt_emulation_device(const std::string& sdesc_path);
     virtual void start(
@@ -92,9 +90,6 @@ public:
     virtual std::unordered_set<chip_id_t> get_all_chips_in_cluster();
     static int detect_number_of_chips();
     virtual std::map<int, int> get_clocks();
-
-protected:
-    std::unordered_map<chip_id_t, tt_SocDescriptor> soc_descriptor_per_chip = {};
 
 private:
     tt_device_l1_address_params l1_address_params;

--- a/device/simulation/deprecated/tt_emulation_device.h
+++ b/device/simulation/deprecated/tt_emulation_device.h
@@ -19,6 +19,8 @@ class tt_zebu_wrapper;
 
 class tt_emulation_device : public tt_device {
 public:
+    const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const;
+
     virtual void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_);  // Dont care
     tt_emulation_device(const std::string& sdesc_path);
     virtual void start(
@@ -90,6 +92,9 @@ public:
     virtual std::unordered_set<chip_id_t> get_all_chips_in_cluster();
     static int detect_number_of_chips();
     virtual std::map<int, int> get_clocks();
+
+protected:
+    std::unordered_map<chip_id_t, tt_SocDescriptor> soc_descriptor_per_chip = {};
 
 private:
     tt_device_l1_address_params l1_address_params;

--- a/device/simulation/deprecated/tt_emulation_device.h
+++ b/device/simulation/deprecated/tt_emulation_device.h
@@ -79,7 +79,6 @@ public:
     virtual void translate_to_noc_table_coords(chip_id_t device_id, std::size_t& r, std::size_t& c);
     virtual bool using_harvested_soc_descriptors();
     virtual std::unordered_map<chip_id_t, uint32_t> get_harvesting_masks_for_soc_descriptors();
-    virtual std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors();
     virtual bool noc_translation_en();
     virtual std::set<chip_id_t> get_target_mmio_device_ids();
     virtual std::set<chip_id_t> get_target_remote_device_ids();

--- a/device/simulation/deprecated/tt_emulation_stub.cpp
+++ b/device/simulation/deprecated/tt_emulation_stub.cpp
@@ -114,10 +114,6 @@ std::unordered_map<chip_id_t, uint32_t> tt_emulation_device::get_harvesting_mask
     return {{0, 0}};
 }
 
-std::unordered_map<chip_id_t, tt_SocDescriptor>& tt_emulation_device::get_virtual_soc_descriptors() {
-    return soc_descriptor_per_chip;
-}
-
 std::map<int, int> tt_emulation_device::get_clocks() { return std::map<int, int>(); }
 
 void tt_emulation_device::set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_) {}

--- a/device/simulation/deprecated/tt_versim_device.cpp
+++ b/device/simulation/deprecated/tt_versim_device.cpp
@@ -74,14 +74,6 @@ tt_VersimDevice::tt_VersimDevice(const std::string& sdesc_path, const std::strin
     }
 }
 
-const tt_SocDescriptor& Cluster::get_soc_descriptor(chip_id_t chip_id) const {
-    return soc_descriptor_per_chip.at(chip_id);
-}
-
-std::unordered_map<chip_id_t, tt_SocDescriptor>& tt_VersimDevice::get_virtual_soc_descriptors() {
-    return soc_descriptor_per_chip;
-}
-
 tt_ClusterDescriptor* tt_VersimDevice::get_cluster_description() { return cluster_descriptor.get(); }
 
 void tt_VersimDevice::start_device(const tt_device_params& device_params) {

--- a/device/simulation/deprecated/tt_versim_device.cpp
+++ b/device/simulation/deprecated/tt_versim_device.cpp
@@ -74,6 +74,10 @@ tt_VersimDevice::tt_VersimDevice(const std::string& sdesc_path, const std::strin
     }
 }
 
+const tt_SocDescriptor& Cluster::get_soc_descriptor(chip_id_t chip_id) const {
+    return soc_descriptor_per_chip.at(chip_id);
+}
+
 std::unordered_map<chip_id_t, tt_SocDescriptor>& tt_VersimDevice::get_virtual_soc_descriptors() {
     return soc_descriptor_per_chip;
 }

--- a/device/simulation/deprecated/tt_versim_device.h
+++ b/device/simulation/deprecated/tt_versim_device.h
@@ -30,6 +30,8 @@ using VersimSimulator = nuapi::device::Simulator<c_versim_core*, VersimSimulator
  */
 class tt_VersimDevice : public tt_device {
 public:
+    const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const;
+
     virtual void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_);
     virtual void set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_);
     tt_VersimDevice(const std::string& sdesc_path, const std::string& ndesc_path);
@@ -112,6 +114,9 @@ public:
     virtual std::uint64_t get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel);
     virtual std::uint32_t get_num_host_channels(std::uint32_t device_id);
     virtual std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel);
+
+protected:
+    std::unordered_map<chip_id_t, tt_SocDescriptor> soc_descriptor_per_chip = {};
 
 private:
     bool stop();

--- a/device/simulation/deprecated/tt_versim_device.h
+++ b/device/simulation/deprecated/tt_versim_device.h
@@ -30,12 +30,9 @@ using VersimSimulator = nuapi::device::Simulator<c_versim_core*, VersimSimulator
  */
 class tt_VersimDevice : public tt_device {
 public:
-    const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const;
-
     virtual void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_);
     virtual void set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_);
     tt_VersimDevice(const std::string& sdesc_path, const std::string& ndesc_path);
-    virtual std::unordered_map<chip_id_t, tt_SocDescriptor>& get_virtual_soc_descriptors();
     virtual void start(
         std::vector<std::string> plusargs,
         std::vector<std::string> dump_cores,
@@ -114,9 +111,6 @@ public:
     virtual std::uint64_t get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel);
     virtual std::uint32_t get_num_host_channels(std::uint32_t device_id);
     virtual std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel);
-
-protected:
-    std::unordered_map<chip_id_t, tt_SocDescriptor> soc_descriptor_per_chip = {};
 
 private:
     bool stop();

--- a/device/simulation/deprecated/tt_versim_stub.cpp
+++ b/device/simulation/deprecated/tt_versim_stub.cpp
@@ -15,11 +15,6 @@ tt_VersimDevice::tt_VersimDevice(const std::string& sdesc_path, const std::strin
 
 tt_VersimDevice::~tt_VersimDevice() {}
 
-std::unordered_map<chip_id_t, tt_SocDescriptor>& tt_VersimDevice::get_virtual_soc_descriptors() {
-    throw std::runtime_error("tt_VersimDevice() -- VERSIM is not supported in this build\n");
-    return soc_descriptor_per_chip;
-}
-
 int tt_VersimDevice::get_number_of_chips_in_cluster() { return detect_number_of_chips(); }
 
 std::unordered_set<int> tt_VersimDevice::get_all_chips_in_cluster() { return {}; }

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -79,15 +79,6 @@ tt_SimulationDevice::tt_SimulationDevice(const std::string& sdesc_path) : tt_dev
 
 tt_SimulationDevice::~tt_SimulationDevice() { close_device(); }
 
-const tt_SocDescriptor& tt_SimulationDevice::get_soc_descriptor(chip_id_t chip_id) const {
-    return soc_descriptor_per_chip.at(chip_id);
-}
-
-// Setup/Teardown Functions
-std::unordered_map<chip_id_t, tt_SocDescriptor>& tt_SimulationDevice::get_virtual_soc_descriptors() {
-    return soc_descriptor_per_chip;
-}
-
 void tt_SimulationDevice::set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_) {
     l1_address_params = l1_address_params_;
 }

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -79,6 +79,10 @@ tt_SimulationDevice::tt_SimulationDevice(const std::string& sdesc_path) : tt_dev
 
 tt_SimulationDevice::~tt_SimulationDevice() { close_device(); }
 
+const tt_SocDescriptor& tt_SimulationDevice::get_soc_descriptor(chip_id_t chip_id) const {
+    return soc_descriptor_per_chip.at(chip_id);
+}
+
 // Setup/Teardown Functions
 std::unordered_map<chip_id_t, tt_SocDescriptor>& tt_SimulationDevice::get_virtual_soc_descriptors() {
     return soc_descriptor_per_chip;

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -72,29 +72,47 @@ TEST(ApiClusterTest, DifferentConstructors) {
     umd_cluster = nullptr;
 
     // 2. Constructor which allows choosing a subset of Chips to open.
-    std::set<chip_id_t> target_devices = {0};
+    chip_id_t logical_device_id = 0;
+    std::set<chip_id_t> target_devices = {logical_device_id};
     umd_cluster = std::make_unique<Cluster>(target_devices);
     umd_cluster = nullptr;
 
-    // 3.1. First chip will be created using helper function from the cluster
-    std::unique_ptr<Chip> chip1 = Cluster::construct_chip_from_cluster(0);
-    // If creating multiple chips, it might we worth to create a cluster descriptor, and pass it to all calls.
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create();
-    chip1 = Cluster::construct_chip_from_cluster(0, cluster_desc.get());
-
-    // 3.2. Second chip is manually created with custom soc descriptor.
-    tt::ARCH device_arch = detect_arch();
+    // 3. Constructor taking a custom soc descriptor in addition.
+    tt::ARCH device_arch = tt_ClusterDescriptor::detect_arch(logical_device_id);
     // You can add a custom soc descriptor here.
     std::string sdesc_path = tt_SocDescriptor::get_soc_descriptor_path(device_arch);
     int harvesting_mask = 0;
     tt_SocDescriptor soc_desc = tt_SocDescriptor(sdesc_path, harvesting_mask);
-    std::unique_ptr<Chip> chip2 = std::make_unique<LocalChip>(0, soc_desc);
+    umd_cluster = std::make_unique<Cluster>(soc_desc, target_devices);
 
-    // 3.3. Third chip is a mock chip.
-    std::unique_ptr<Chip> chip3 = std::make_unique<MockChip>();
+    // // ?????
+    // // 5.1. First chip will be created using helper function from the cluster
+    // std::unique_ptr<Chip> chip1 = Cluster::construct_chip_from_cluster(0);
+    // // If creating multiple chips, it might we worth to create a cluster descriptor, and pass it to all calls.
+    // std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create();
+    // chip_id_t logical_device_id = 0;
+    // chip1 = Cluster::construct_chip_from_cluster(logical_device_id, cluster_desc.get());
 
-    // 3. Constructor taking a custom set of Chips.
-    umd_cluster = std::make_unique<Cluster>({chip1, chip2, chip3});
+    // // 3.2. Second chip is manually created with custom soc descriptor.
+    // tt::ARCH device_arch = cluster_desc->get_arch(logical_device_id);
+    // // You can add a custom soc descriptor here.
+    // std::string sdesc_path = tt_SocDescriptor::get_soc_descriptor_path(device_arch);
+    // int harvesting_mask = 0;
+    // tt_SocDescriptor soc_desc = tt_SocDescriptor(sdesc_path, harvesting_mask);
+    // // We have to reuse the same chip1 since we can't open the same chip twice.
+    // chip1 = nullptr;
+    // chip1 = std::make_unique<LocalChip>(logical_device_id, soc_desc);
+
+    // // 3.3. Third chip is a mock chip.
+    // chip_id_t second_logical_id = 1;
+    // // We can create with a custom soc descriptor.
+    // std::unique_ptr<Chip> chip2 =
+    //     std::make_unique<MockChip>(second_logical_id,
+    //     tt_SocDescriptor::get_soc_descriptor_path(tt::ARCH::WORMHOLE_B0));
+
+    // // 3. Constructor taking a custom set of Chips.
+    // // Mark Experimental.
+    // umd_cluster = std::make_unique<Cluster>({chip1, chip2});
 }
 
 TEST(ApiClusterTest, SimpleIOAllChips) {

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -81,9 +81,7 @@ TEST(ApiClusterTest, DifferentConstructors) {
     tt::ARCH device_arch = tt_ClusterDescriptor::detect_arch(logical_device_id);
     // You can add a custom soc descriptor here.
     std::string sdesc_path = tt_SocDescriptor::get_soc_descriptor_path(device_arch);
-    int harvesting_mask = 0;
-    tt_SocDescriptor soc_desc = tt_SocDescriptor(sdesc_path, harvesting_mask);
-    umd_cluster = std::make_unique<Cluster>(soc_desc, target_devices);
+    umd_cluster = std::make_unique<Cluster>(sdesc_path, target_devices);
     umd_cluster = nullptr;
 
     // 4. Constructor for creating a cluster with mock chip.

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -89,37 +89,6 @@ TEST(ApiClusterTest, DifferentConstructors) {
     // 4. Constructor for creating a cluster with mock chip.
     umd_cluster = Cluster::create_mock_cluster();
     umd_cluster = nullptr;
-
-    // // ?????
-    // // 5.1. First chip will be created using helper function from the cluster
-    // std::unique_ptr<Chip> chip1 = Cluster::construct_chip_from_cluster(0);
-    // // If creating multiple chips, it might we worth to create a cluster descriptor, and pass it to all calls.
-    // std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create();
-    // chip_id_t logical_device_id = 0;
-    // chip1 = Cluster::construct_chip_from_cluster(logical_device_id, cluster_desc.get());
-
-    // // 3.2. Second chip is manually created with custom soc descriptor.
-    // tt::ARCH device_arch = cluster_desc->get_arch(logical_device_id);
-    // // You can add a custom soc descriptor here.
-    // std::string sdesc_path = tt_SocDescriptor::get_soc_descriptor_path(device_arch);
-    // int harvesting_mask = 0;
-    // tt_SocDescriptor soc_desc = tt_SocDescriptor(sdesc_path, harvesting_mask);
-    // // We have to reuse the same chip1 since we can't open the same chip twice.
-    // chip1 = nullptr;
-    // chip1 = std::make_unique<LocalChip>(soc_desc);
-
-    // // 3.3. Third chip is a mock chip.
-    // chip_id_t second_logical_id = 1;
-    // // We can create with a custom soc descriptor.
-    // std::unique_ptr<Chip> chip2 =
-    //     std::make_unique<MockChip>(tt_SocDescriptor::get_soc_descriptor_path(tt::ARCH::WORMHOLE_B0));
-
-    // // 3. Constructor taking a custom set of Chips.
-    // // Mark Experimental.
-    // umd_cluster = std::make_unique<Cluster>({chip1, chip2});
-
-    // umd_cluster = std::make_unique<Cluster>(
-    //     {std::make_unique<MockChip>(tt_SocDescriptor::get_soc_descriptor_path(tt::ARCH::WORMHOLE_B0))});
 }
 
 TEST(ApiClusterTest, SimpleIOAllChips) {

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -13,6 +13,8 @@
 
 #include "fmt/xchar.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
+#include "umd/device/chip/local_chip.h"
+#include "umd/device/chip/mock_chip.h"
 #include "umd/device/cluster.h"
 #include "umd/device/tt_cluster_descriptor.h"
 
@@ -55,6 +57,45 @@ void setup_wormhole_remote(Cluster* umd_cluster) {
 
 // This test should be one line only.
 TEST(ApiClusterTest, OpenAllChips) { std::unique_ptr<Cluster> umd_cluster = get_cluster(); }
+
+TEST(ApiClusterTest, DifferentConstructors) {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+    // TODO: Make this test work on a host system without any tt devices.
+    if (pci_device_ids.empty()) {
+        GTEST_SKIP() << "No chips present on the system. Skipping test.";
+    }
+
+    std::unique_ptr<Cluster> umd_cluster;
+
+    // 1. Simplest constructor. Creates Cluster with all the chips available
+    umd_cluster = std::make_unique<Cluster>();
+    umd_cluster = nullptr;
+
+    // 2. Constructor which allows choosing a subset of Chips to open.
+    std::set<chip_id_t> target_devices = {0};
+    umd_cluster = std::make_unique<Cluster>(target_devices);
+    umd_cluster = nullptr;
+
+    // 3.1. First chip will be created using helper function from the cluster
+    std::unique_ptr<Chip> chip1 = Cluster::construct_chip_from_cluster(0);
+    // If creating multiple chips, it might we worth to create a cluster descriptor, and pass it to all calls.
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create();
+    chip1 = Cluster::construct_chip_from_cluster(0, cluster_desc.get());
+
+    // 3.2. Second chip is manually created with custom soc descriptor.
+    tt::ARCH device_arch = detect_arch();
+    // You can add a custom soc descriptor here.
+    std::string sdesc_path = tt_SocDescriptor::get_soc_descriptor_path(device_arch);
+    int harvesting_mask = 0;
+    tt_SocDescriptor soc_desc = tt_SocDescriptor(sdesc_path, harvesting_mask);
+    std::unique_ptr<Chip> chip2 = std::make_unique<LocalChip>(0, soc_desc);
+
+    // 3.3. Third chip is a mock chip.
+    std::unique_ptr<Chip> chip3 = std::make_unique<MockChip>();
+
+    // 3. Constructor taking a custom set of Chips.
+    umd_cluster = std::make_unique<Cluster>({chip1, chip2, chip3});
+}
 
 TEST(ApiClusterTest, SimpleIOAllChips) {
     std::unique_ptr<Cluster> umd_cluster = get_cluster();

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -84,6 +84,11 @@ TEST(ApiClusterTest, DifferentConstructors) {
     int harvesting_mask = 0;
     tt_SocDescriptor soc_desc = tt_SocDescriptor(sdesc_path, harvesting_mask);
     umd_cluster = std::make_unique<Cluster>(soc_desc, target_devices);
+    umd_cluster = nullptr;
+
+    // 4. Constructor for creating a cluster with mock chip.
+    umd_cluster = Cluster::create_mock_cluster();
+    umd_cluster = nullptr;
 
     // // ?????
     // // 5.1. First chip will be created using helper function from the cluster
@@ -101,18 +106,20 @@ TEST(ApiClusterTest, DifferentConstructors) {
     // tt_SocDescriptor soc_desc = tt_SocDescriptor(sdesc_path, harvesting_mask);
     // // We have to reuse the same chip1 since we can't open the same chip twice.
     // chip1 = nullptr;
-    // chip1 = std::make_unique<LocalChip>(logical_device_id, soc_desc);
+    // chip1 = std::make_unique<LocalChip>(soc_desc);
 
     // // 3.3. Third chip is a mock chip.
     // chip_id_t second_logical_id = 1;
     // // We can create with a custom soc descriptor.
     // std::unique_ptr<Chip> chip2 =
-    //     std::make_unique<MockChip>(second_logical_id,
-    //     tt_SocDescriptor::get_soc_descriptor_path(tt::ARCH::WORMHOLE_B0));
+    //     std::make_unique<MockChip>(tt_SocDescriptor::get_soc_descriptor_path(tt::ARCH::WORMHOLE_B0));
 
     // // 3. Constructor taking a custom set of Chips.
     // // Mark Experimental.
     // umd_cluster = std::make_unique<Cluster>({chip1, chip2});
+
+    // umd_cluster = std::make_unique<Cluster>(
+    //     {std::make_unique<MockChip>(tt_SocDescriptor::get_soc_descriptor_path(tt::ARCH::WORMHOLE_B0))});
 }
 
 TEST(ApiClusterTest, SimpleIOAllChips) {
@@ -240,7 +247,7 @@ TEST(ApiClusterTest, SimpleIOSpecificChips) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
     }
 
-    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>(0);
+    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>(0u);
 
     const tt_ClusterDescriptor* cluster_desc = umd_cluster->get_cluster_description();
 

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -67,7 +67,7 @@ TEST(ApiClusterTest, DifferentConstructors) {
 
     std::unique_ptr<Cluster> umd_cluster;
 
-    // 1. Simplest constructor. Creates Cluster with all the chips available
+    // 1. Simplest constructor. Creates Cluster with all the chips available.
     umd_cluster = std::make_unique<Cluster>();
     umd_cluster = nullptr;
 

--- a/tests/blackhole/test_silicon_driver_bh.cpp
+++ b/tests/blackhole/test_silicon_driver_bh.cpp
@@ -196,7 +196,7 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //     for (int i = 0; i < target_devices.size(); i++) {
 //         // Iterate over MMIO devices and only setup static TLBs for worker cores
 //         if (std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
-//             auto& sdesc = device.get_virtual_soc_descriptors().at(i);
+//             auto& sdesc = device.get_soc_descriptor(i);
 //             for (auto& core : sdesc.workers) {
 //                 // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
 //                 device.configure_tlb(
@@ -220,7 +220,7 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //         std::uint32_t dynamic_write_address = 0x40000000;
 //         for (int loop = 0; loop < 100;
 //              loop++) {  // Write to each core a 100 times at different statically mapped addresses
-//             for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+//             for (auto& core : device.get_soc_descriptor(i).workers) {
 //                 device.write_to_device(
 //                     vector_to_write.data(),
 //                     vector_to_write.size() * sizeof(std::uint32_t),
@@ -286,7 +286,7 @@ TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
     for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over MMIO devices and only setup static TLBs for worker cores
         if (std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
-            auto& sdesc = device.get_virtual_soc_descriptors().at(i);
+            auto& sdesc = device.get_soc_descriptor(i);
             for (auto& core : sdesc.workers) {
                 // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
                 device.configure_tlb(
@@ -310,7 +310,7 @@ TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
             std::vector<uint8_t> readback_vec(size, 0);
             std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
             for (int loop = 0; loop < 50; loop++) {
-                for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                for (auto& core : device.get_soc_descriptor(i).workers) {
                     device.write_to_device(write_vec.data(), size, tt_cxy_pair(i, core), address, "");
                     device.wait_for_non_mmio_flush();
                     device.read_from_device(readback_vec.data(), tt_cxy_pair(i, core), address, size, "");
@@ -343,7 +343,7 @@ TEST(SiliconDriverBH, StaticTLB_RW) {
     for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over MMIO devices and only setup static TLBs for worker cores
         if (std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
-            auto& sdesc = device.get_virtual_soc_descriptors().at(i);
+            auto& sdesc = device.get_soc_descriptor(i);
             for (auto& core : sdesc.workers) {
                 // Statically mapping a 2MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
                 device.configure_tlb(
@@ -367,7 +367,7 @@ TEST(SiliconDriverBH, StaticTLB_RW) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (int loop = 0; loop < 1;
              loop++) {  // Write to each core a 100 times at different statically mapped addresses
-            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+            for (auto& core : device.get_soc_descriptor(i).workers) {
                 device.write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
@@ -417,7 +417,7 @@ TEST(SiliconDriverBH, DynamicTLB_RW) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (int loop = 0; loop < 100;
              loop++) {  // Write to each core a 100 times at different statically mapped addresses
-            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+            for (auto& core : device.get_soc_descriptor(i).workers) {
                 device.write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
@@ -452,7 +452,7 @@ TEST(SiliconDriverBH, DynamicTLB_RW) {
         for (int loop = 0; loop < 100;
              loop++) {  // Write to each core a 100 times at different statically mapped addresses
             for (int ch = 0; ch < NUM_CHANNELS; ch++) {
-                std::vector<tt_xy_pair> chan = device.get_virtual_soc_descriptors().at(i).dram_cores.at(ch);
+                std::vector<tt_xy_pair> chan = device.get_soc_descriptor(i).dram_cores.at(ch);
                 tt_xy_pair subchan = chan.at(0);
                 device.write_to_device(
                     vector_to_write.data(),
@@ -503,7 +503,7 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (int loop = 0; loop < 100; loop++) {
-            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+            for (auto& core : device.get_soc_descriptor(0).workers) {
                 device.write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
@@ -524,7 +524,7 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
         std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = 0x30000000;
-        for (auto& core_ls : device.get_virtual_soc_descriptors().at(0).dram_cores) {
+        for (auto& core_ls : device.get_soc_descriptor(0).dram_cores) {
             for (int loop = 0; loop < 100; loop++) {
                 for (auto& core : core_ls) {
                     device.write_to_device(
@@ -565,7 +565,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     set_params_for_remote_txn(device);
     for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for functional worker cores
-        auto& sdesc = device.get_virtual_soc_descriptors().at(i);
+        auto& sdesc = device.get_soc_descriptor(i);
         for (auto& core : sdesc.workers) {
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
             device.configure_tlb(i, core, get_static_tlb_index_callback(core), base_addr);
@@ -578,7 +578,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     device.deassert_risc_reset();
 
     std::vector<uint32_t> readback_membar_vec = {};
-    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+    for (auto& core : device.get_soc_descriptor(0).workers) {
         test_utils::read_data_from_device(
             device,
             readback_membar_vec,
@@ -591,8 +591,8 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
         readback_membar_vec = {};
     }
 
-    for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(0).get_num_dram_channels(); chan++) {
-        auto core = device.get_virtual_soc_descriptors().at(0).get_core_for_dram_channel(chan, 0);
+    for (int chan = 0; chan < device.get_soc_descriptor(0).get_num_dram_channels(); chan++) {
+        auto core = device.get_soc_descriptor(0).get_core_for_dram_channel(chan, 0);
         test_utils::read_data_from_device(
             device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(
@@ -600,7 +600,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
         readback_membar_vec = {};
     }
 
-    for (auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
+    for (auto& core : device.get_soc_descriptor(0).ethernet_cores) {
         test_utils::read_data_from_device(
             device,
             readback_membar_vec,
@@ -629,7 +629,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     std::thread th1 = std::thread([&] {
         std::uint32_t address = base_addr;
         for (int loop = 0; loop < 50; loop++) {
-            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+            for (auto& core : device.get_soc_descriptor(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
                 device.write_to_device(
                     vec1.data(), vec1.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
@@ -647,7 +647,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     std::thread th2 = std::thread([&] {
         std::uint32_t address = base_addr + vec1.size() * 4;
         for (int loop = 0; loop < 50; loop++) {
-            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+            for (auto& core : device.get_soc_descriptor(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
                 device.write_to_device(
                     vec2.data(), vec2.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
@@ -665,7 +665,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     th1.join();
     th2.join();
 
-    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+    for (auto& core : device.get_soc_descriptor(0).workers) {
         test_utils::read_data_from_device(
             device,
             readback_membar_vec,
@@ -678,7 +678,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
         readback_membar_vec = {};
     }
 
-    for (auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
+    for (auto& core : device.get_soc_descriptor(0).ethernet_cores) {
         test_utils::read_data_from_device(
             device,
             readback_membar_vec,
@@ -745,7 +745,7 @@ TEST(SiliconDriverBH, DISABLED_BroadcastWrite) {  // Cannot broadcast to tensix/
         device.wait_for_non_mmio_flush();
 
         for (const auto i : target_devices) {
-            for (const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+            for (const auto& core : device.get_soc_descriptor(i).workers) {
                 if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
                     continue;
                 }
@@ -761,8 +761,8 @@ TEST(SiliconDriverBH, DISABLED_BroadcastWrite) {  // Cannot broadcast to tensix/
                     "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
-            for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
-                const auto& core = device.get_virtual_soc_descriptors().at(i).get_core_for_dram_channel(chan, 0);
+            for (int chan = 0; chan < device.get_soc_descriptor(i).get_num_dram_channels(); chan++) {
+                const auto& core = device.get_soc_descriptor(i).get_core_for_dram_channel(chan, 0);
                 test_utils::read_data_from_device(
                     device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
                 ASSERT_EQ(vector_to_write, readback_vec)
@@ -841,7 +841,7 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as
         device.wait_for_non_mmio_flush();
 
         for (const auto i : target_devices) {
-            for (const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+            for (const auto& core : device.get_soc_descriptor(i).workers) {
                 if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
                     continue;
                 }
@@ -857,8 +857,8 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as
                     "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
-            for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
-                const auto& core = device.get_virtual_soc_descriptors().at(i).get_core_for_dram_channel(chan, 0);
+            for (int chan = 0; chan < device.get_soc_descriptor(i).get_num_dram_channels(); chan++) {
+                const auto& core = device.get_soc_descriptor(i).get_core_for_dram_channel(chan, 0);
                 test_utils::read_data_from_device(
                     device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
                 ASSERT_EQ(vector_to_write, readback_vec)

--- a/tests/galaxy/test_umd_concurrent_threads.cpp
+++ b/tests/galaxy/test_umd_concurrent_threads.cpp
@@ -49,12 +49,8 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device = Cluster(
-        tt_SocDescriptor(test_utils::GetAbsPath(SOC_DESC_PATH)),
-        all_devices,
-        num_host_mem_ch_per_mmio_device,
-        false,
-        true);
+    Cluster device =
+        Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), all_devices, num_host_mem_ch_per_mmio_device, false, true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
@@ -150,12 +146,8 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device = Cluster(
-        tt_SocDescriptor(test_utils::GetAbsPath(SOC_DESC_PATH)),
-        all_devices,
-        num_host_mem_ch_per_mmio_device,
-        false,
-        true);
+    Cluster device =
+        Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), all_devices, num_host_mem_ch_per_mmio_device, false, true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
@@ -240,12 +232,8 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device = Cluster(
-        tt_SocDescriptor(test_utils::GetAbsPath(SOC_DESC_PATH)),
-        target_devices,
-        num_host_mem_ch_per_mmio_device,
-        false,
-        true);
+    Cluster device =
+        Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), target_devices, num_host_mem_ch_per_mmio_device, false, true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_params_for_remote_txn(device);

--- a/tests/galaxy/test_umd_concurrent_threads.cpp
+++ b/tests/galaxy/test_umd_concurrent_threads.cpp
@@ -49,8 +49,12 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device =
-        Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), all_devices, num_host_mem_ch_per_mmio_device, false, true);
+    Cluster device = Cluster(
+        tt_SocDescriptor(test_utils::GetAbsPath(SOC_DESC_PATH)),
+        all_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
@@ -146,8 +150,12 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device =
-        Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), all_devices, num_host_mem_ch_per_mmio_device, false, true);
+    Cluster device = Cluster(
+        tt_SocDescriptor(test_utils::GetAbsPath(SOC_DESC_PATH)),
+        all_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
@@ -232,8 +240,12 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device =
-        Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), target_devices, num_host_mem_ch_per_mmio_device, false, true);
+    Cluster device = Cluster(
+        tt_SocDescriptor(test_utils::GetAbsPath(SOC_DESC_PATH)),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_params_for_remote_txn(device);

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -29,8 +29,12 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device =
-        Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), target_devices, num_host_mem_ch_per_mmio_device, false, true);
+    Cluster device = Cluster(
+        tt_SocDescriptor(test_utils::GetAbsPath(SOC_DESC_PATH)),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
@@ -147,8 +151,12 @@ void run_data_mover_test(
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device =
-        Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), target_devices, num_host_mem_ch_per_mmio_device, false, true);
+    Cluster device = Cluster(
+        tt_SocDescriptor(test_utils::GetAbsPath(SOC_DESC_PATH)),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
 
@@ -266,8 +274,12 @@ void run_data_broadcast_test(
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device =
-        Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), target_devices, num_host_mem_ch_per_mmio_device, false, true);
+    Cluster device = Cluster(
+        tt_SocDescriptor(test_utils::GetAbsPath(SOC_DESC_PATH)),
+        target_devices,
+        num_host_mem_ch_per_mmio_device,
+        false,
+        true);
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
 

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -29,12 +29,8 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device = Cluster(
-        tt_SocDescriptor(test_utils::GetAbsPath(SOC_DESC_PATH)),
-        target_devices,
-        num_host_mem_ch_per_mmio_device,
-        false,
-        true);
+    Cluster device =
+        Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), target_devices, num_host_mem_ch_per_mmio_device, false, true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
@@ -151,12 +147,8 @@ void run_data_mover_test(
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device = Cluster(
-        tt_SocDescriptor(test_utils::GetAbsPath(SOC_DESC_PATH)),
-        target_devices,
-        num_host_mem_ch_per_mmio_device,
-        false,
-        true);
+    Cluster device =
+        Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), target_devices, num_host_mem_ch_per_mmio_device, false, true);
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
 
@@ -274,12 +266,8 @@ void run_data_broadcast_test(
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device = Cluster(
-        tt_SocDescriptor(test_utils::GetAbsPath(SOC_DESC_PATH)),
-        target_devices,
-        num_host_mem_ch_per_mmio_device,
-        false,
-        true);
+    Cluster device =
+        Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), target_devices, num_host_mem_ch_per_mmio_device, false, true);
 
     tt::umd::test::utils::set_params_for_remote_txn(device);
 

--- a/tests/grayskull/test_silicon_driver.cpp
+++ b/tests/grayskull/test_silicon_driver.cpp
@@ -101,7 +101,7 @@ TEST(SiliconDriverGS, HarvestingRuntime) {
 
     for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for functional worker cores
-        auto& sdesc = device.get_virtual_soc_descriptors().at(i);
+        auto& sdesc = device.get_soc_descriptor(i);
         for (auto& core : sdesc.workers) {
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
             device.configure_tlb(i, core, get_static_tlb_index(core), l1_mem::address_map::DATA_BUFFER_SPACE_BASE);
@@ -125,7 +125,7 @@ TEST(SiliconDriverGS, HarvestingRuntime) {
         std::uint32_t dynamic_write_address = 0x30000000;
         for (int loop = 0; loop < 100;
              loop++) {  // Write to each core a 100 times at different statically mapped addresses
-            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+            for (auto& core : device.get_soc_descriptor(i).workers) {
                 device.write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
@@ -193,7 +193,7 @@ TEST(SiliconDriverGS, StaticTLB_RW) {
     Cluster device = Cluster(num_host_mem_ch_per_mmio_device, false, true);
     for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for worker cores
-        auto& sdesc = device.get_virtual_soc_descriptors().at(i);
+        auto& sdesc = device.get_soc_descriptor(i);
         for (auto& core : sdesc.workers) {
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
             device.configure_tlb(
@@ -215,7 +215,7 @@ TEST(SiliconDriverGS, StaticTLB_RW) {
         std::uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
         for (int loop = 0; loop < 100;
              loop++) {  // Write to each core a 100 times at different statically mapped addresses
-            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+            for (auto& core : device.get_soc_descriptor(i).workers) {
                 device.write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
@@ -270,7 +270,7 @@ TEST(SiliconDriverGS, DynamicTLB_RW) {
         std::uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
         for (int loop = 0; loop < 100;
              loop++) {  // Write to each core a 100 times at different statically mapped addresses
-            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+            for (auto& core : device.get_soc_descriptor(i).workers) {
                 device.write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
@@ -324,7 +324,7 @@ TEST(SiliconDriverGS, MultiThreadedDevice) {
         float timeout_in_seconds = 10;
         std::uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
         for (int loop = 0; loop < 100; loop++) {
-            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+            for (auto& core : device.get_soc_descriptor(0).workers) {
                 device.write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
@@ -355,7 +355,7 @@ TEST(SiliconDriverGS, MultiThreadedDevice) {
         std::vector<uint32_t> readback_vec = {};
         float timeout_in_seconds = 10;
         std::uint32_t address = 0x30000000;
-        for (auto& core_ls : device.get_virtual_soc_descriptors().at(0).dram_cores) {
+        for (auto& core_ls : device.get_soc_descriptor(0).dram_cores) {
             for (int loop = 0; loop < 100; loop++) {
                 for (auto& core : core_ls) {
                     device.write_to_device(
@@ -412,7 +412,7 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
 
     for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for functional worker cores
-        auto& sdesc = device.get_virtual_soc_descriptors().at(i);
+        auto& sdesc = device.get_soc_descriptor(i);
         for (auto& core : sdesc.workers) {
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
             device.configure_tlb(i, core, get_static_tlb_index(core), base_addr);
@@ -424,7 +424,7 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
     device.start_device(default_params);
     device.deassert_risc_reset();
     std::vector<uint32_t> readback_membar_vec = {};
-    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+    for (auto& core : device.get_soc_descriptor(0).workers) {
         test_utils::read_data_from_device(
             device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(
@@ -432,7 +432,7 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
         readback_membar_vec = {};
     }
 
-    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+    for (auto& core : device.get_soc_descriptor(0).workers) {
         test_utils::read_data_from_device(
             device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(
@@ -440,8 +440,8 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
         readback_membar_vec = {};
     }
 
-    for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(0).get_num_dram_channels(); chan++) {
-        auto core = device.get_virtual_soc_descriptors().at(0).get_core_for_dram_channel(chan, 0);
+    for (int chan = 0; chan < device.get_soc_descriptor(0).get_num_dram_channels(); chan++) {
+        auto core = device.get_soc_descriptor(0).get_core_for_dram_channel(chan, 0);
         test_utils::read_data_from_device(
             device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(
@@ -464,7 +464,7 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
     std::thread th1 = std::thread([&] {
         std::uint32_t address = base_addr;
         for (int loop = 0; loop < 100; loop++) {
-            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+            for (auto& core : device.get_soc_descriptor(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
                 device.write_to_device(
                     vec1.data(), vec1.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
@@ -482,7 +482,7 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
     std::thread th2 = std::thread([&] {
         std::uint32_t address = base_addr + vec1.size() * 4;
         for (int loop = 0; loop < 100; loop++) {
-            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+            for (auto& core : device.get_soc_descriptor(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
                 device.write_to_device(
                     vec2.data(), vec2.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
@@ -500,7 +500,7 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
     th1.join();
     th2.join();
 
-    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+    for (auto& core : device.get_soc_descriptor(0).workers) {
         test_utils::read_data_from_device(
             device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(readback_membar_vec.at(0), 187);  // Ensure that memory barriers end up in correct sate workers

--- a/tests/microbenchmark/device_fixture.hpp
+++ b/tests/microbenchmark/device_fixture.hpp
@@ -40,7 +40,7 @@ protected:
 
         for (int i = 0; i < target_devices.size(); i++) {
             // Iterate over devices and only setup static TLBs for functional worker cores
-            auto& sdesc = device->get_virtual_soc_descriptors().at(i);
+            auto& sdesc = device->get_soc_descriptor(i);
             for (auto& core : sdesc.workers) {
                 // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
                 device->configure_tlb(i, core, get_static_tlb_index(core), l1_mem::address_map::DATA_BUFFER_SPACE_BASE);

--- a/tests/microbenchmark/test_rw_tensix.cpp
+++ b/tests/microbenchmark/test_rw_tensix.cpp
@@ -23,7 +23,7 @@ TEST_F(uBenchmarkFixture, WriteAllCores32Bytes) {
 
     ankerl::nanobench::Bench bench_static;
     ankerl::nanobench::Bench bench_dynamic;
-    for (auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
+    for (auto& core : device->get_soc_descriptor(0).workers) {
         std::stringstream wname;
         wname << "Write to device core (" << core.x << ", " << core.y << ")";
         // Write 32 bytes through static tlbs
@@ -66,13 +66,13 @@ TEST_F(uBenchmarkFixture, ReadAllCores32Bytes) {
     ankerl::nanobench::Bench bench_static;
     ankerl::nanobench::Bench bench_dynamic;
 
-    for (auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
+    for (auto& core : device->get_soc_descriptor(0)
         std::stringstream rname;
         // Read through static tlbs
         rname << "Read from device core (" << core.x << ", " << core.y << ")";
         bench_static.title("Read 32 bytes").unit("reads").minEpochIterations(50).output(nullptr).run(rname.str(), [&] {
-            test_utils::read_data_from_device(
-                *device, readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
+        test_utils::read_data_from_device(
+            *device, readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
         });
         // Read through "fallback/dynamic" tlb
         bench_dynamic.title("Read 32 bytes fallback")
@@ -80,13 +80,14 @@ TEST_F(uBenchmarkFixture, ReadAllCores32Bytes) {
             .minEpochIterations(50)
             .output(nullptr)
             .run(rname.str(), [&] {
-                test_utils::read_data_from_device(
-                    *device, readback_vec, tt_cxy_pair(0, core), bad_address, 0x20, "SMALL_READ_WRITE_TLB");
+        test_utils::read_data_from_device(
+            *device, readback_vec, tt_cxy_pair(0, core), bad_address, 0x20, "SMALL_READ_WRITE_TLB");
             });
         rname.clear();
-    }
-    bench_static.render(ankerl::nanobench::templates::csv(), results_csv);
-    bench_dynamic.render(ankerl::nanobench::templates::csv(), results_csv);
+}
+
+bench_static.render(ankerl::nanobench::templates::csv(), results_csv);
+bench_dynamic.render(ankerl::nanobench::templates::csv(), results_csv);
 }
 
 TEST_F(uBenchmarkFixture, Write32BytesRandomAddr) {
@@ -94,7 +95,7 @@ TEST_F(uBenchmarkFixture, Write32BytesRandomAddr) {
     std::uint32_t address;
 
     ankerl::nanobench::Bench bench;
-    for (auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
+    for (auto& core : device->get_soc_descriptor(0)
         address = generate_random_address(1 << 20);  // between 0 and 1MB
         std::stringstream wname;
         wname << "Write to device core (" << core.x << ", " << core.y << ") @ address " << std::hex << address;
@@ -103,16 +104,17 @@ TEST_F(uBenchmarkFixture, Write32BytesRandomAddr) {
             .minEpochIterations(50)
             .output(nullptr)
             .run(wname.str(), [&] {
-                device->write_to_device(
-                    vector_to_write.data(),
-                    vector_to_write.size() * sizeof(std::uint32_t),
-                    tt_cxy_pair(0, core),
-                    address,
-                    "SMALL_READ_WRITE_TLB");
+        device->write_to_device(
+            vector_to_write.data(),
+            vector_to_write.size() * sizeof(std::uint32_t),
+            tt_cxy_pair(0, core),
+            address,
+            "SMALL_READ_WRITE_TLB");
             });
         wname.clear();
-    }
-    bench.render(ankerl::nanobench::templates::csv(), results_csv);
+}
+
+bench.render(ankerl::nanobench::templates::csv(), results_csv);
 }
 
 TEST_F(uBenchmarkFixture, Read32BytesRandomAddr) {
@@ -120,7 +122,7 @@ TEST_F(uBenchmarkFixture, Read32BytesRandomAddr) {
     std::uint32_t address;
 
     ankerl::nanobench::Bench bench;
-    for (auto& core : device->get_virtual_soc_descriptors().at(0).workers) {
+    for (auto& core : device->get_soc_descriptor(0)
         address = generate_random_address(1 << 20);  // between 0 and 1MB
         std::stringstream rname;
         rname << "Read from device core (" << core.x << ", " << core.y << ") @ address " << std::hex << address;
@@ -129,10 +131,11 @@ TEST_F(uBenchmarkFixture, Read32BytesRandomAddr) {
             .minEpochIterations(50)
             .output(nullptr)
             .run(rname.str(), [&] {
-                test_utils::read_data_from_device(
-                    *device, readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
+        test_utils::read_data_from_device(
+            *device, readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
             });
         rname.clear();
-    }
-    bench.render(ankerl::nanobench::templates::csv(), results_csv);
+}
+
+bench.render(ankerl::nanobench::templates::csv(), results_csv);
 }

--- a/tests/test_utils/stimulus_generators.hpp
+++ b/tests/test_utils/stimulus_generators.hpp
@@ -559,7 +559,7 @@ static ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int
 get_default_full_dram_dest_generator(int seed, Cluster* device) {
     assert(device != nullptr);
     tt_ClusterDescriptor* cluster_desc = device->get_cluster_description();
-    tt_SocDescriptor const& soc_desc = device->get_virtual_soc_descriptors().at(0);
+    tt_SocDescriptor const& soc_desc = device->get_soc_descriptor(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
 
     return ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int_distribution>(
@@ -575,7 +575,7 @@ static WriteCommandGenerator<
     std::uniform_int_distribution>
 build_dummy_write_command_generator(Cluster& device) {
     tt_ClusterDescriptor* cluster_desc = device.get_cluster_description();
-    tt_SocDescriptor const& soc_desc = device.get_virtual_soc_descriptors().at(0);
+    tt_SocDescriptor const& soc_desc = device.get_soc_descriptor(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
     auto dest_generator = ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int_distribution>(
         0,
@@ -600,7 +600,7 @@ static ReadCommandGenerator<
     std::uniform_int_distribution>
 build_dummy_read_command_generator(Cluster& device) {
     tt_ClusterDescriptor* cluster_desc = device.get_cluster_description();
-    tt_SocDescriptor const& soc_desc = device.get_virtual_soc_descriptors().at(0);
+    tt_SocDescriptor const& soc_desc = device.get_soc_descriptor(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
     auto dest_generator = ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int_distribution>(
         0,
@@ -641,7 +641,7 @@ void RunMixedTransfersUniformDistributions(
     bool record_command_history = false,
     std::vector<remote_transfer_sample_t>* command_history = nullptr) {
     tt_ClusterDescriptor* cluster_desc = device.get_cluster_description();
-    tt_SocDescriptor const& soc_desc = device.get_virtual_soc_descriptors().at(0);
+    tt_SocDescriptor const& soc_desc = device.get_soc_descriptor(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
 
     auto dest_generator = ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int_distribution>(

--- a/tests/wormhole/test_silicon_driver_wh.cpp
+++ b/tests/wormhole/test_silicon_driver_wh.cpp
@@ -87,7 +87,7 @@ TEST(SiliconDriverWH, CreateDestroy) {
     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
     for (int i = 0; i < 50; i++) {
         Cluster device = Cluster(
-            test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_1x1.yaml"),
+            tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_1x1.yaml")),
             target_devices,
             num_host_mem_ch_per_mmio_device,
             false,
@@ -128,7 +128,7 @@ TEST(SiliconDriverWH, CustomSocDesc) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
     Cluster device = Cluster(
-        test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_1x1.yaml"),
+        tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_1x1.yaml")),
         target_devices,
         num_host_mem_ch_per_mmio_device,
         false,

--- a/tests/wormhole/test_silicon_driver_wh.cpp
+++ b/tests/wormhole/test_silicon_driver_wh.cpp
@@ -165,7 +165,7 @@ TEST(SiliconDriverWH, HarvestingRuntime) {
     for(int i = 0; i < target_devices.size(); i++) {
         // Iterate over MMIO devices and only setup static TLBs for worker cores
         if(std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
-            auto& sdesc = device.get_virtual_soc_descriptors().at(i);
+            auto& sdesc = device.get_soc_descriptor(i);
             for(auto& core : sdesc.workers) {
                 // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
                 device.configure_tlb(i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
@@ -188,7 +188,7 @@ TEST(SiliconDriverWH, HarvestingRuntime) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         std::uint32_t dynamic_write_address = 0x40000000;
         for(int loop = 0; loop < 100; loop++){ // Write to each core a 100 times at different statically mapped addresses
-            for(auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+            for(auto& core : device.get_soc_descriptor(i).workers) {
                 device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), address, "");
                 device.write_to_device(vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), tt_cxy_pair(i, core), dynamic_write_address, "SMALL_READ_WRITE_TLB");
                 device.wait_for_non_mmio_flush(); // Barrier to ensure that all writes over ethernet were commited
@@ -227,7 +227,7 @@ TEST(SiliconDriverWH, UnalignedStaticTLB_RW) {
     for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over MMIO devices and only setup static TLBs for worker cores
         if (std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
-            auto& sdesc = device.get_virtual_soc_descriptors().at(i);
+            auto& sdesc = device.get_soc_descriptor(i);
             for (auto& core : sdesc.workers) {
                 // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
                 device.configure_tlb(
@@ -251,7 +251,7 @@ TEST(SiliconDriverWH, UnalignedStaticTLB_RW) {
             std::vector<uint8_t> readback_vec(size, 0);
             std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
             for (int loop = 0; loop < 50; loop++) {
-                for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+                for (auto& core : device.get_soc_descriptor(i).workers) {
                     device.write_to_device(write_vec.data(), size, tt_cxy_pair(i, core), address, "");
                     device.wait_for_non_mmio_flush();
                     device.read_from_device(readback_vec.data(), tt_cxy_pair(i, core), address, size, "");
@@ -283,7 +283,7 @@ TEST(SiliconDriverWH, StaticTLB_RW) {
     for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over MMIO devices and only setup static TLBs for worker cores
         if (std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
-            auto& sdesc = device.get_virtual_soc_descriptors().at(i);
+            auto& sdesc = device.get_soc_descriptor(i);
             for (auto& core : sdesc.workers) {
                 // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
                 device.configure_tlb(
@@ -305,7 +305,7 @@ TEST(SiliconDriverWH, StaticTLB_RW) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         // Write to each core a 100 times at different statically mapped addresses
         for (int loop = 0; loop < 100; loop++) {
-            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+            for (auto& core : device.get_soc_descriptor(i).workers) {
                 device.write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
@@ -355,7 +355,7 @@ TEST(SiliconDriverWH, DynamicTLB_RW) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         // Write to each core a 100 times at different statically mapped addresses
         for (int loop = 0; loop < 100; loop++) {
-            for (auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+            for (auto& core : device.get_soc_descriptor(i).workers) {
                 device.write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
@@ -404,7 +404,7 @@ TEST(SiliconDriverWH, MultiThreadedDevice) {
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (int loop = 0; loop < 100; loop++) {
-            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+            for (auto& core : device.get_soc_descriptor(0).workers) {
                 device.write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
@@ -425,7 +425,7 @@ TEST(SiliconDriverWH, MultiThreadedDevice) {
         std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = 0x30000000;
-        for (auto& core_ls : device.get_virtual_soc_descriptors().at(0).dram_cores) {
+        for (auto& core_ls : device.get_soc_descriptor(0).dram_cores) {
             for (int loop = 0; loop < 100; loop++) {
                 for (auto& core : core_ls) {
                     device.write_to_device(
@@ -469,7 +469,7 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for functional worker cores
         if (std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
-            auto& sdesc = device.get_virtual_soc_descriptors().at(i);
+            auto& sdesc = device.get_soc_descriptor(i);
             for (auto& core : sdesc.workers) {
                 // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
                 device.configure_tlb(i, core, get_static_tlb_index_callback(core), base_addr);
@@ -483,7 +483,7 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     device.deassert_risc_reset();
 
     std::vector<uint32_t> readback_membar_vec = {};
-    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+    for (auto& core : device.get_soc_descriptor(0).workers) {
         test_utils::read_data_from_device(
             device,
             readback_membar_vec,
@@ -496,8 +496,8 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
         readback_membar_vec = {};
     }
 
-    for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(0).get_num_dram_channels(); chan++) {
-        auto core = device.get_virtual_soc_descriptors().at(0).get_core_for_dram_channel(chan, 0);
+    for (int chan = 0; chan < device.get_soc_descriptor(0).get_num_dram_channels(); chan++) {
+        auto core = device.get_soc_descriptor(0).get_core_for_dram_channel(chan, 0);
         test_utils::read_data_from_device(
             device, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(
@@ -505,7 +505,7 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
         readback_membar_vec = {};
     }
 
-    for (auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
+    for (auto& core : device.get_soc_descriptor(0).ethernet_cores) {
         test_utils::read_data_from_device(
             device,
             readback_membar_vec,
@@ -534,7 +534,7 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     std::thread th1 = std::thread([&] {
         std::uint32_t address = base_addr;
         for (int loop = 0; loop < 50; loop++) {
-            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+            for (auto& core : device.get_soc_descriptor(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
                 device.write_to_device(
                     vec1.data(), vec1.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
@@ -552,7 +552,7 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     std::thread th2 = std::thread([&] {
         std::uint32_t address = base_addr + vec1.size() * 4;
         for (int loop = 0; loop < 50; loop++) {
-            for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+            for (auto& core : device.get_soc_descriptor(0).workers) {
                 std::vector<uint32_t> readback_vec = {};
                 device.write_to_device(
                     vec2.data(), vec2.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
@@ -570,7 +570,7 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     th1.join();
     th2.join();
 
-    for (auto& core : device.get_virtual_soc_descriptors().at(0).workers) {
+    for (auto& core : device.get_soc_descriptor(0).workers) {
         test_utils::read_data_from_device(
             device,
             readback_membar_vec,
@@ -583,7 +583,7 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
         readback_membar_vec = {};
     }
 
-    for (auto& core : device.get_virtual_soc_descriptors().at(0).ethernet_cores) {
+    for (auto& core : device.get_soc_descriptor(0).ethernet_cores) {
         test_utils::read_data_from_device(
             device,
             readback_membar_vec,
@@ -648,7 +648,7 @@ TEST(SiliconDriverWH, BroadcastWrite) {
         device.wait_for_non_mmio_flush();
 
         for (const auto i : target_devices) {
-            for (const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+            for (const auto& core : device.get_soc_descriptor(i).workers) {
                 if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
                     continue;
                 }
@@ -664,8 +664,8 @@ TEST(SiliconDriverWH, BroadcastWrite) {
                     "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
-            for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
-                const auto& core = device.get_virtual_soc_descriptors().at(i).get_core_for_dram_channel(chan, 0);
+            for (int chan = 0; chan < device.get_soc_descriptor(i).get_num_dram_channels(); chan++) {
+                const auto& core = device.get_soc_descriptor(i).get_core_for_dram_channel(chan, 0);
                 test_utils::read_data_from_device(
                     device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
                 ASSERT_EQ(vector_to_write, readback_vec)
@@ -744,7 +744,7 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
         device.wait_for_non_mmio_flush();
 
         for (const auto i : target_devices) {
-            for (const auto& core : device.get_virtual_soc_descriptors().at(i).workers) {
+            for (const auto& core : device.get_soc_descriptor(i).workers) {
                 if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
                     continue;
                 }
@@ -760,8 +760,8 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
                     "LARGE_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
             }
-            for (int chan = 0; chan < device.get_virtual_soc_descriptors().at(i).get_num_dram_channels(); chan++) {
-                const auto& core = device.get_virtual_soc_descriptors().at(i).get_core_for_dram_channel(chan, 0);
+            for (int chan = 0; chan < device.get_soc_descriptor(i).get_num_dram_channels(); chan++) {
+                const auto& core = device.get_soc_descriptor(i).get_core_for_dram_channel(chan, 0);
                 test_utils::read_data_from_device(
                     device, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
                 ASSERT_EQ(vector_to_write, readback_vec)

--- a/tests/wormhole/test_silicon_driver_wh.cpp
+++ b/tests/wormhole/test_silicon_driver_wh.cpp
@@ -87,7 +87,7 @@ TEST(SiliconDriverWH, CreateDestroy) {
     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
     for (int i = 0; i < 50; i++) {
         Cluster device = Cluster(
-            tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_1x1.yaml")),
+            test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_1x1.yaml"),
             target_devices,
             num_host_mem_ch_per_mmio_device,
             false,
@@ -128,7 +128,7 @@ TEST(SiliconDriverWH, CustomSocDesc) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
     Cluster device = Cluster(
-        tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_1x1.yaml")),
+        test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_1x1.yaml"),
         target_devices,
         num_host_mem_ch_per_mmio_device,
         false,


### PR DESCRIPTION
### Issue
First PR towards #248 

### Description
First in set of changes to introduce Chip abstraction class according to the plan https://docs.google.com/drawings/d/1-m1azdsBqMA0A6ATYRMfkhyeuOJuGCEI62N5a96LXj0/edit
This change also required minor rethinking of some parts of how Cluster is constructed (this took much time to figure out).

### List of the changes
- Added Chip class, and derived Local, Remote, and Mock classes. Local will be created for mmio chips, Remote for non-mmio. Mock chip is now only a placeholder, to show the Cluster constructor API changes, but it should merge with existing MockupDevice. Chip is an abstract class.
- Chip classes for now only hold soc descriptors and nothing else. Further PRs will gradually move out logic from Cluster to Chip.
- get_soc_descriptor and soc_descriptor_per_chip were moved around to conform to the new reality
- This was reverted after offline discussion: (Cluster constructor which takes soc descriptor was changed so that it takes tt_SocDescriptor object rather than yaml file. This is because the object also holds harvesting information.)
- Added another Cluster constructor which takes a set of chips. This is an experimental one, and users should know what they're doing and they can break the code easily.
- Previously mentioned new constructor was used to offer Cluster::create_mock_cluster which is a helper function to build you a cluster with mock chip.
- Wrote a test which showcases different constructor usages, which was a leftover from #277 

### Testing
Existing tests should prove no functional changes in this PR.

### API Changes
This PR has no API changes.
