### PR TITLE
TTDevice init

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -36,6 +36,10 @@ target_sources(
         simulation/tt_simulation_host.cpp
         tlb.cpp
         tt_cluster_descriptor.cpp
+        tt_device/blackhole_tt_device.cpp
+        tt_device/grayskull_tt_device.cpp
+        tt_device/tt_device.cpp
+        tt_device/wormhole_tt_device.cpp
         tt_silicon_driver_common.cpp
         tt_soc_descriptor.cpp
         grayskull/grayskull_coordinate_manager.cpp

--- a/device/api/umd/device/architecture_implementation.h
+++ b/device/api/umd/device/architecture_implementation.h
@@ -51,6 +51,7 @@ public:
     virtual uint32_t get_mem_large_write_tlb() const = 0;
     virtual uint32_t get_static_tlb_cfg_addr() const = 0;
     virtual uint32_t get_static_tlb_size() const = 0;
+    virtual uint32_t get_read_checking_offset() const = 0;
     virtual uint32_t get_reg_tlb() const = 0;
     virtual uint32_t get_tlb_base_index_16m() const = 0;
     virtual uint32_t get_tensix_soft_reset_addr() const = 0;

--- a/device/api/umd/device/blackhole_implementation.h
+++ b/device/api/umd/device/blackhole_implementation.h
@@ -174,6 +174,8 @@ static constexpr uint32_t TENSIX_SOFT_RESET_ADDR = 0xFFB121B0;
 
 static constexpr uint32_t MSG_TYPE_SETUP_IATU_FOR_PEER_TO_PEER = 0x97;
 
+static const uint32_t BH_NOC_NODE_ID_OFFSET = 0x1FD04044;
+
 static const size_t eth_translated_coordinate_start_x = 20;
 static const size_t eth_translated_coordinate_start_y = 25;
 
@@ -264,6 +266,8 @@ public:
     uint32_t get_static_tlb_cfg_addr() const override { return blackhole::STATIC_TLB_CFG_ADDR; }
 
     uint32_t get_static_tlb_size() const override { return blackhole::STATIC_TLB_SIZE; }
+
+    uint32_t get_read_checking_offset() const override { return blackhole::BH_NOC_NODE_ID_OFFSET; }
 
     uint32_t get_reg_tlb() const override { return blackhole::REG_TLB; }
 

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -819,7 +819,7 @@ public:
     virtual std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id);
     virtual tt_version get_ethernet_fw_version() const;
 
-    TTDevice* get_tt_device(int device_id) const;
+    TTDevice* get_tt_device(chip_id_t device_id) const;
 
     // Destructor
     virtual ~Cluster();
@@ -973,7 +973,9 @@ private:
     std::set<chip_id_t> target_devices_in_cluster = {};
     std::set<chip_id_t> target_remote_chips = {};
     tt::ARCH arch_name;
-    std::unordered_map<chip_id_t, std::unique_ptr<TTDevice>> m_tt_device_map;  // Map of enabled tt devices
+
+    // Map of enabled tt devices
+    std::unordered_map<chip_id_t, std::unique_ptr<TTDevice>> m_tt_device_map;
     std::shared_ptr<tt_ClusterDescriptor> cluster_desc;
 
     // remote eth transfer setup

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -17,9 +17,9 @@
 #include "tt_silicon_driver_common.hpp"
 #include "tt_soc_descriptor.h"
 #include "tt_xy_pair.h"
-#include "umd/device/pci_device.hpp"
 #include "umd/device/tlb.h"
 #include "umd/device/tt_cluster_descriptor_types.h"
+#include "umd/device/tt_device/tt_device.h"
 #include "umd/device/tt_io.hpp"
 
 using TLB_DATA = tt::umd::tlb_data;
@@ -818,8 +818,8 @@ public:
     virtual std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel);
     virtual std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id);
     virtual tt_version get_ethernet_fw_version() const;
-    // TODO: This should be accessible through public API, probably to be moved to tt_device.
-    PCIDevice* get_pci_device(int device_id) const;
+
+    TTDevice* get_tt_device(int device_id) const;
 
     // Destructor
     virtual ~Cluster();
@@ -973,8 +973,7 @@ private:
     std::set<chip_id_t> target_devices_in_cluster = {};
     std::set<chip_id_t> target_remote_chips = {};
     tt::ARCH arch_name;
-    std::unordered_map<chip_id_t, std::unique_ptr<PCIDevice>> m_pci_device_map;  // Map of enabled pci devices
-    int m_num_pci_devices;  // Number of pci devices in system (enabled or disabled)
+    std::unordered_map<chip_id_t, std::unique_ptr<TTDevice>> m_tt_device_map;  // Map of enabled tt devices
     std::shared_ptr<tt_ClusterDescriptor> cluster_desc;
 
     // remote eth transfer setup

--- a/device/api/umd/device/grayskull_implementation.h
+++ b/device/api/umd/device/grayskull_implementation.h
@@ -197,6 +197,8 @@ static constexpr uint32_t ARC_CSM_MAILBOX_SIZE_OFFSET = 0x1FEF84BC;
 
 static constexpr uint32_t TENSIX_SOFT_RESET_ADDR = 0xFFB121B0;
 
+static constexpr uint32_t ARC_SCRATCH_6_OFFSET = 0x1FF30078;
+
 }  // namespace grayskull
 
 class grayskull_implementation : public architecture_implementation {
@@ -266,6 +268,8 @@ public:
     uint32_t get_static_tlb_cfg_addr() const override { return grayskull::STATIC_TLB_CFG_ADDR; }
 
     uint32_t get_static_tlb_size() const override { return grayskull::STATIC_TLB_SIZE; }
+
+    uint32_t get_read_checking_offset() const override { return grayskull::ARC_SCRATCH_6_OFFSET; }
 
     uint32_t get_reg_tlb() const override { return grayskull::REG_TLB; }
 

--- a/device/api/umd/device/tt_device/blackhole_tt_device.h
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.h
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "umd/device/tt_device/tt_device.h"
+
+namespace tt::umd {
+class BlackholeTTDevice : public TTDevice {
+public:
+    BlackholeTTDevice(std::unique_ptr<PCIDevice> pci_device);
+    ~BlackholeTTDevice();
+};
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_device/grayskull_tt_device.h
+++ b/device/api/umd/device/tt_device/grayskull_tt_device.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "umd/device/tt_device/tt_device.h"
+
+namespace tt::umd {
+class GrayskullTTDevice : public TTDevice {
+public:
+    GrayskullTTDevice(std::unique_ptr<PCIDevice> pci_device);
+};
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "umd/device/architecture_implementation.h"
+#include "umd/device/pci_device.hpp"
+
+// TODO: Should be moved to blackhole_architecture_implementation.h
+// See /vendor_ip/synopsys/052021/bh_pcie_ctl_gen5/export/configuration/DWC_pcie_ctl.h
+static const uint64_t UNROLL_ATU_OFFSET_BAR = 0x1200;
+
+// TODO: should be removed from tt_device.h, and put into blackhole_tt_device.h
+// TODO: this is a bit of a hack... something to revisit when we formalize an
+// abstraction for IO.
+// BAR0 size for Blackhole, used to determine whether write block should use BAR0 or BAR4
+static const uint64_t BAR0_BH_SIZE = 512 * 1024 * 1024;
+
+constexpr unsigned int c_hang_read_value = 0xffffffffu;
+
+struct dynamic_tlb {
+    uint64_t bar_offset;      // Offset that address is mapped to, within the PCI BAR.
+    uint64_t remaining_size;  // Bytes remaining between bar_offset and end of the TLB.
+};
+
+namespace tt::umd {
+
+class TTDevice {
+public:
+    /**
+     * Creates a proper TTDevice object for the given PCI device number.
+     */
+    static std::unique_ptr<TTDevice> create(int pci_device_number);
+    TTDevice(std::unique_ptr<PCIDevice> pci_device, std::unique_ptr<architecture_implementation> architecture_impl);
+    virtual ~TTDevice() = default;
+
+    architecture_implementation *get_architecture_implementation();
+    PCIDevice *get_pci_device();
+
+    void detect_hang_read(uint32_t data_read = c_hang_read_value);
+
+    // Note: byte_addr is (mostly but not always) offset into BAR0.  This
+    // interface assumes the caller knows what they are doing - but it's unclear
+    // how to use this interface correctly without knowing details of the chip
+    // and its state.
+    // TODO: build a proper abstraction for IO.  At this level, that is access
+    // to registers in BAR0 (although possibly the right abstraction is to add
+    // methods that perform specific operations as opposed to generic register
+    // read/write methods) and access to segments of BAR0/4 that are mapped to
+    // NOC endpoints.  Probably worth waiting for the KMD to start owning the
+    // resource management aspect of these PCIe->NOC mappings (the "TLBs")
+    // before doing too much work here...
+    void write_block(uint64_t byte_addr, uint64_t num_bytes, const uint8_t *buffer_addr);
+    void read_block(uint64_t byte_addr, uint64_t num_bytes, uint8_t *buffer_addr);
+    void write_regs(volatile uint32_t *dest, const uint32_t *src, uint32_t word_len);
+    void write_regs(uint32_t byte_addr, uint32_t word_len, const void *data);
+    void read_regs(uint32_t byte_addr, uint32_t word_len, void *data);
+
+    // TLB related functions.
+    // TODO: These are architecture specific, and will be moved out of the class.
+    void write_tlb_reg(
+        uint32_t byte_addr, std::uint64_t value_lower, std::uint64_t value_upper, std::uint32_t tlb_cfg_reg_size);
+    dynamic_tlb set_dynamic_tlb(
+        unsigned int tlb_index,
+        tt_xy_pair start,
+        tt_xy_pair end,
+        std::uint64_t address,
+        bool multicast,
+        std::unordered_map<tt_xy_pair, tt_xy_pair> &harvested_coord_translation,
+        std::uint64_t ordering);
+    dynamic_tlb set_dynamic_tlb(
+        unsigned int tlb_index,
+        tt_xy_pair target,
+        std::uint64_t address,
+        std::unordered_map<tt_xy_pair, tt_xy_pair> &harvested_coord_translation,
+        std::uint64_t ordering = tt::umd::tlb_data::Relaxed);
+    dynamic_tlb set_dynamic_tlb_broadcast(
+        unsigned int tlb_index,
+        std::uint64_t address,
+        std::unordered_map<tt_xy_pair, tt_xy_pair> &harvested_coord_translation,
+        tt_xy_pair start,
+        tt_xy_pair end,
+        std::uint64_t ordering = tt::umd::tlb_data::Relaxed);
+
+protected:
+    std::unique_ptr<architecture_implementation> architecture_impl_;
+    std::unique_ptr<PCIDevice> pci_device_;
+    tt::ARCH arch;
+
+    bool is_hardware_hung();
+
+    template <typename T>
+    T *get_register_address(uint32_t register_offset);
+
+    // Custom device memcpy. This is only safe for memory-like regions on the device (Tensix L1, DRAM, ARC CSM).
+    // Both routines assume that misaligned accesses are permitted on host memory.
+    //
+    // 1. AARCH64 device memory does not allow unaligned accesses (including pair loads/stores),
+    // which glibc's memcpy may perform when unrolling. This affects from and to device.
+    // 2. syseng#3487 WH GDDR5 controller has a bug when 1-byte writes are temporarily adjacent
+    // to 2-byte writes. We avoid ever performing a 1-byte write to the device. This only affects to device.
+    void memcpy_to_device(void *dest, const void *src, std::size_t num_bytes);
+    void memcpy_from_device(void *dest, const void *src, std::size_t num_bytes);
+};
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_device/wormhole_tt_device.h
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "umd/device/tt_device/tt_device.h"
+
+namespace tt::umd {
+class WormholeTTDevice : public TTDevice {
+public:
+    WormholeTTDevice(std::unique_ptr<PCIDevice> pci_device);
+};
+}  // namespace tt::umd

--- a/device/api/umd/device/wormhole_implementation.h
+++ b/device/api/umd/device/wormhole_implementation.h
@@ -230,6 +230,8 @@ static constexpr uint32_t ARC_CSM_MAILBOX_SIZE_OFFSET = 0x1FEF84C4;
 
 static constexpr uint32_t TENSIX_SOFT_RESET_ADDR = 0xFFB121B0;
 
+static constexpr uint32_t ARC_SCRATCH_6_OFFSET = 0x1FF30078;
+
 static const size_t tensix_translated_coordinate_start_x = 18;
 static const size_t tensix_translated_coordinate_start_y = 18;
 
@@ -303,6 +305,8 @@ public:
     uint32_t get_mem_large_write_tlb() const override { return wormhole::MEM_LARGE_WRITE_TLB; }
 
     uint32_t get_static_tlb_cfg_addr() const override { return wormhole::STATIC_TLB_CFG_ADDR; }
+
+    uint32_t get_read_checking_offset() const override { return wormhole::ARC_SCRATCH_6_OFFSET; }
 
     uint32_t get_static_tlb_size() const override { return wormhole::STATIC_TLB_SIZE; }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1730,7 +1730,7 @@ void* Cluster::host_dma_address(std::uint64_t offset, chip_id_t src_device_id, u
 }
 
 // Wrapper for throwing more helpful exception when not-enabled pci intf is accessed.
-inline TTDevice* Cluster::get_tt_device(int device_id) const {
+inline TTDevice* Cluster::get_tt_device(chip_id_t device_id) const {
     if (!m_tt_device_map.count(device_id)) {
         throw std::runtime_error(fmt::format("device_id: {} attempted to be accessed, but is not enabled.", device_id));
     }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -229,22 +229,22 @@ void Cluster::create_device(
             logical_device_id);
         int pci_interface_id = logical_to_physical_device_id_map.at(logical_device_id);
 
-        if (!m_pci_device_map.count(logical_device_id)) {
+        if (!m_tt_device_map.count(logical_device_id)) {
             log_debug(
                 LogSiliconDriver,
                 "Opening TT_PCI_INTERFACE_ID {} for netlist target_device_id: {}",
                 pci_interface_id,
                 logical_device_id);
-            m_pci_device_map.insert({logical_device_id, std::make_unique<PCIDevice>(pci_interface_id)});
+            m_tt_device_map.insert({logical_device_id, TTDevice::create(pci_interface_id)});
         }
-        auto dev = m_pci_device_map.at(logical_device_id).get();
+        auto pci_device = m_tt_device_map.at(logical_device_id)->get_pci_device();
 
-        uint16_t pcie_device_id = dev->get_pci_device_id();
-        uint32_t pcie_revision = dev->get_pci_revision();
+        uint16_t pcie_device_id = pci_device->get_pci_device_id();
+        uint32_t pcie_revision = pci_device->get_pci_revision();
         // TODO: get rid of this, it doesn't make any sense.
         int num_host_mem_channels =
             get_available_num_host_mem_channels(num_host_mem_ch_per_mmio_device, pcie_device_id, pcie_revision);
-        if (dev->get_arch() == tt::ARCH::BLACKHOLE && num_host_mem_channels > 1) {
+        if (pci_device->get_arch() == tt::ARCH::BLACKHOLE && num_host_mem_channels > 1) {
             // TODO: Implement support for multiple host channels on BLACKHOLE.
             log_warning(
                 LogSiliconDriver,
@@ -272,7 +272,7 @@ void Cluster::create_device(
                 !(arch_name == tt::ARCH::BLACKHOLE && num_host_mem_channels > 1),
                 "More channels are not yet supported for Blackhole");
             // Same number of host channels per device for now
-            bool hugepages_initialized = m_pci_device_map.at(logical_device_id)->init_hugepage(num_host_mem_channels);
+            bool hugepages_initialized = pci_device->init_hugepage(num_host_mem_channels);
             // Large writes to remote chips require hugepages to be initialized.
             // Conservative assert - end workload if remote chips present but hugepages not initialized (failures caused
             // if using remote only for small transactions)
@@ -281,7 +281,7 @@ void Cluster::create_device(
                     hugepages_initialized,
                     "Hugepages must be successfully initialized if workload contains remote chips!");
             }
-            if (not m_pci_device_map.at(logical_device_id)->get_hugepage_mapping(0).mapping) {
+            if (not pci_device->get_hugepage_mapping(0).mapping) {
                 log_warning(LogSiliconDriver, "No hugepage mapping at device {}.", logical_device_id);
             }
         }
@@ -496,7 +496,6 @@ Cluster::Cluster(
 
     // TODO: this should be fetched through ClusterDescriptor
     auto available_device_ids = detect_available_device_ids();
-    m_num_pci_devices = available_device_ids.size();
 
     int physical_device_id = available_device_ids[0];
     PCIDevice pci_device(physical_device_id);
@@ -511,8 +510,8 @@ Cluster::Cluster(
         log_info(
             LogSiliconDriver,
             "Detected {} PCI device{} : {}",
-            m_num_pci_devices,
-            (m_num_pci_devices > 1) ? "s" : "",
+            available_device_ids.size(),
+            (available_device_ids.size() > 1) ? "s" : "",
             available_device_ids);
         log_debug(LogSiliconDriver, "Passed target devices: {}", target_devices);
     }
@@ -544,7 +543,6 @@ Cluster::Cluster(
 
     // TODO: this should be fetched through ClusterDescriptor
     auto available_device_ids = detect_available_device_ids();
-    m_num_pci_devices = available_device_ids.size();
 
     int physical_device_id = available_device_ids[0];
     PCIDevice pci_device(physical_device_id);
@@ -559,8 +557,8 @@ Cluster::Cluster(
         log_info(
             LogSiliconDriver,
             "Detected {} PCI device{} : {}",
-            m_num_pci_devices,
-            (m_num_pci_devices > 1) ? "s" : "",
+            available_device_ids.size(),
+            (available_device_ids.size() > 1) ? "s" : "",
             available_device_ids);
         log_debug(LogSiliconDriver, "Passed target devices: {}", target_devices);
     }
@@ -589,7 +587,6 @@ Cluster::Cluster(
 
     // TODO: this should be fetched through ClusterDescriptor
     auto available_device_ids = detect_available_device_ids();
-    m_num_pci_devices = available_device_ids.size();
 
     target_devices_in_cluster = target_devices;
     arch_name = tt_SocDescriptor(sdesc_path).arch;
@@ -599,8 +596,8 @@ Cluster::Cluster(
         log_info(
             LogSiliconDriver,
             "Detected {} PCI device{} : {}",
-            m_num_pci_devices,
-            (m_num_pci_devices > 1) ? "s" : "",
+            available_device_ids.size(),
+            (available_device_ids.size() > 1) ? "s" : "",
             available_device_ids);
         log_debug(LogSiliconDriver, "Passed target devices: {}", target_devices);
     }
@@ -736,8 +733,8 @@ void Cluster::perform_harvesting_and_populate_soc_descriptors(
 }
 
 void Cluster::check_pcie_device_initialized(int device_id) {
-    PCIDevice* pci_device = get_pci_device(device_id);
-    tt::ARCH device_arch = pci_device->get_arch();
+    TTDevice* tt_device = get_tt_device(device_id);
+    tt::ARCH device_arch = tt_device->get_pci_device()->get_arch();
     if (arch_name == tt::ARCH::GRAYSKULL) {
         if (device_arch != tt::ARCH::GRAYSKULL) {
             throw std::runtime_error(
@@ -756,7 +753,7 @@ void Cluster::check_pcie_device_initialized(int device_id) {
     } else {
         throw std::runtime_error(fmt::format("Unsupported architecture: {}", get_arch_str(arch_name)));
     }
-    auto architecture_implementation = pci_device->get_architecture_implementation();
+    auto architecture_implementation = tt_device->get_architecture_implementation();
 
     // MT Initial BH - Add check for blackhole once access to ARC registers is setup through TLBs
     if (arch_name != tt::ARCH::BLACKHOLE) {
@@ -896,7 +893,7 @@ void Cluster::translate_to_noc_table_coords(chip_id_t device_id, std::size_t& r,
 void Cluster::initialize_pcie_devices() {
     log_debug(LogSiliconDriver, "Cluster::start");
 
-    for (auto& device_it : m_pci_device_map) {
+    for (auto& device_it : m_tt_device_map) {
         check_pcie_device_initialized(device_it.first);
     }
 
@@ -908,7 +905,7 @@ void Cluster::initialize_pcie_devices() {
 void Cluster::broadcast_pcie_tensix_risc_reset(chip_id_t chip_id, const TensixSoftResetOptions& soft_resets) {
     log_debug(LogSiliconDriver, "Cluster::broadcast_tensix_risc_reset");
 
-    PCIDevice* device = get_pci_device(chip_id);
+    TTDevice* tt_device = get_tt_device(chip_id);
 
     auto valid = soft_resets & ALL_TENSIX_SOFT_RESET;
 
@@ -917,10 +914,10 @@ void Cluster::broadcast_pcie_tensix_risc_reset(chip_id_t chip_id, const TensixSo
         "== For all tensix set soft-reset for {} risc cores.",
         TensixSoftResetOptionsToString(valid).c_str());
 
-    auto architecture_implementation = device->get_architecture_implementation();
+    auto architecture_implementation = tt_device->get_architecture_implementation();
 
     // TODO: this is clumsy and difficult to read
-    auto [soft_reset_reg, _] = device->set_dynamic_tlb_broadcast(
+    auto [soft_reset_reg, _] = tt_device->set_dynamic_tlb_broadcast(
         architecture_implementation->get_reg_tlb(),
         architecture_implementation->get_tensix_soft_reset_addr(),
         harvested_coord_translation.at(chip_id),
@@ -929,13 +926,13 @@ void Cluster::broadcast_pcie_tensix_risc_reset(chip_id_t chip_id, const TensixSo
             architecture_implementation->get_grid_size_x() - 1,
             architecture_implementation->get_grid_size_y() - 1 - num_rows_harvested.at(chip_id)),
         TLB_DATA::Posted);
-    device->write_regs(soft_reset_reg, 1, &valid);
+    tt_device->write_regs(soft_reset_reg, 1, &valid);
     tt_driver_atomics::sfence();
 }
 
 std::set<chip_id_t> Cluster::get_target_mmio_device_ids() {
     if (!all_target_mmio_devices.size()) {
-        for (const auto& it : m_pci_device_map) {
+        for (const auto& it : m_tt_device_map) {
             all_target_mmio_devices.insert(it.first);
         }
     }
@@ -961,7 +958,7 @@ void Cluster::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftRese
     bool target_is_mmio_capable = cluster_desc->is_chip_mmio_capable(target_device);
     if (target_is_mmio_capable) {
         log_assert(
-            m_pci_device_map.find(target_device) != m_pci_device_map.end(),
+            m_tt_device_map.find(target_device) != m_tt_device_map.end(),
             "Could not find MMIO mapped device in devices connected over PCIe");
         send_tensix_risc_reset_to_core(core, soft_resets);
     } else {
@@ -985,7 +982,7 @@ void Cluster::assert_risc_reset_at_core(tt_cxy_pair core) {
     bool target_is_mmio_capable = cluster_desc->is_chip_mmio_capable(target_device);
     if (target_is_mmio_capable) {
         log_assert(
-            m_pci_device_map.find(target_device) != m_pci_device_map.end(),
+            m_tt_device_map.find(target_device) != m_tt_device_map.end(),
             "Could not find MMIO mapped device in devices connected over PCIe");
         send_tensix_risc_reset_to_core(core, TENSIX_ASSERT_SOFT_RESET);
     } else {
@@ -1030,7 +1027,7 @@ std::vector<chip_id_t> Cluster::detect_available_device_ids() {
 
 std::function<void(uint32_t, uint32_t, const uint8_t*)> Cluster::get_fast_pcie_static_tlb_write_callable(
     int device_id) {
-    PCIDevice* dev = get_pci_device(device_id);
+    TTDevice* dev = get_tt_device(device_id);
 
     const auto callable = [dev](uint32_t byte_addr, uint32_t num_bytes, const uint8_t* buffer_addr) {
         dev->write_block(byte_addr, num_bytes, buffer_addr);
@@ -1048,9 +1045,9 @@ tt::Writer Cluster::get_static_tlb_writer(tt_cxy_pair target) {
         throw std::runtime_error("TLBs not initialized");
     }
 
-    auto* dev = get_pci_device(target.chip);
+    auto* dev = get_tt_device(target.chip);
 
-    if (!dev->bar0_wc) {
+    if (!dev->get_pci_device()->bar0_wc) {
         throw std::runtime_error("No write-combined mapping for BAR0");
     }
 
@@ -1062,7 +1059,7 @@ tt::Writer Cluster::get_static_tlb_writer(tt_cxy_pair target) {
     }
 
     auto [tlb_offset, tlb_size] = tlb_data.value();
-    auto* base = reinterpret_cast<uint8_t*>(dev->bar0_wc);
+    auto* base = reinterpret_cast<uint8_t*>(dev->get_pci_device()->bar0_wc);
 
     return tt::Writer(base + tlb_offset, tlb_size);
 }
@@ -1073,7 +1070,7 @@ void Cluster::write_device_memory(
     tt_cxy_pair target,
     uint64_t address,
     const std::string& fallback_tlb) {
-    PCIDevice* dev = get_pci_device(target.chip);
+    TTDevice* dev = get_tt_device(target.chip);
     const uint8_t* buffer_addr = static_cast<const uint8_t*>(mem_ptr);
 
     log_debug(
@@ -1096,7 +1093,7 @@ void Cluster::write_device_memory(
     if (tlb_data.has_value() &&
         address_in_tlb_space(address, size_in_bytes, tlb_index, std::get<1>(tlb_data.value()), target.chip)) {
         auto [tlb_offset, tlb_size] = tlb_data.value();
-        if (dev->bar4_wc != nullptr && tlb_size == BH_4GB_TLB_SIZE) {
+        if (dev->get_pci_device()->bar4_wc != nullptr && tlb_size == BH_4GB_TLB_SIZE) {
             // This is only for Blackhole. If we want to  write to DRAM (BAR4 space), we add offset
             // to which we write so write_block knows it needs to target BAR4
             dev->write_block((tlb_offset + address % tlb_size) + BAR0_BH_SIZE, size_in_bytes, buffer_addr);
@@ -1105,7 +1102,7 @@ void Cluster::write_device_memory(
         }
     } else {
         const auto tlb_index = dynamic_tlb_config.at(fallback_tlb);
-        const scoped_lock<named_mutex> lock(*get_mutex(fallback_tlb, dev->get_device_num()));
+        const scoped_lock<named_mutex> lock(*get_mutex(fallback_tlb, dev->get_pci_device()->get_device_num()));
 
         while (size_in_bytes > 0) {
             auto [mapped_address, tlb_size] = dev->set_dynamic_tlb(
@@ -1135,7 +1132,7 @@ void Cluster::read_device_memory(
         target.y,
         address,
         size_in_bytes);
-    PCIDevice* dev = get_pci_device(target.chip);
+    TTDevice* dev = get_tt_device(target.chip);
 
     uint8_t* buffer_addr = static_cast<uint8_t*>(mem_ptr);
 
@@ -1150,7 +1147,7 @@ void Cluster::read_device_memory(
     if (tlb_data.has_value() &&
         address_in_tlb_space(address, size_in_bytes, tlb_index, std::get<1>(tlb_data.value()), target.chip)) {
         auto [tlb_offset, tlb_size] = tlb_data.value();
-        if (dev->bar4_wc != nullptr && tlb_size == BH_4GB_TLB_SIZE) {
+        if (dev->get_pci_device()->bar4_wc != nullptr && tlb_size == BH_4GB_TLB_SIZE) {
             // This is only for Blackhole. If we want to  read from DRAM (BAR4 space), we add offset
             // from which we read so read_block knows it needs to target BAR4
             dev->read_block((tlb_offset + address % tlb_size) + BAR0_BH_SIZE, size_in_bytes, buffer_addr);
@@ -1160,7 +1157,7 @@ void Cluster::read_device_memory(
         log_debug(LogSiliconDriver, "  read_block called with tlb_offset: {}, tlb_size: {}", tlb_offset, tlb_size);
     } else {
         const auto tlb_index = dynamic_tlb_config.at(fallback_tlb);
-        const scoped_lock<named_mutex> lock(*get_mutex(fallback_tlb, dev->get_device_num()));
+        const scoped_lock<named_mutex> lock(*get_mutex(fallback_tlb, dev->get_pci_device()->get_device_num()));
         log_debug(LogSiliconDriver, "  dynamic tlb_index: {}", tlb_index);
         while (size_in_bytes > 0) {
             auto [mapped_address, tlb_size] = dev->set_dynamic_tlb(
@@ -1184,9 +1181,9 @@ void Cluster::read_buffer(
     void* mem_ptr, std::uint32_t address, std::uint16_t channel, std::uint32_t size_in_bytes, chip_id_t src_device_id) {
     log_assert(src_device_id != -1, "Must provide src_device_id for host_resident read/write");
     log_assert(
-        m_pci_device_map.find(src_device_id) != m_pci_device_map.end(), "read_buffer: Device id is not a MMIO device");
+        m_tt_device_map.find(src_device_id) != m_tt_device_map.end(), "read_buffer: Device id is not a MMIO device");
 
-    hugepage_mapping hugepage_map = m_pci_device_map.at(src_device_id)->get_hugepage_mapping(channel);
+    hugepage_mapping hugepage_map = m_tt_device_map.at(src_device_id)->get_pci_device()->get_hugepage_mapping(channel);
     log_assert(
         hugepage_map.mapping,
         "read_buffer: Hugepages are not allocated for src_device_id: {} ch: {}."
@@ -1209,9 +1206,9 @@ void Cluster::read_buffer(
 void Cluster::write_buffer(
     const void* mem_ptr, std::uint32_t size, std::uint32_t address, std::uint16_t channel, chip_id_t src_device_id) {
     log_assert(
-        m_pci_device_map.find(src_device_id) != m_pci_device_map.end(), "write_buffer: Device id is not a MMIO device");
+        m_tt_device_map.find(src_device_id) != m_tt_device_map.end(), "write_buffer: Device id is not a MMIO device");
 
-    hugepage_mapping hugepage_map = m_pci_device_map.at(src_device_id)->get_hugepage_mapping(channel);
+    hugepage_mapping hugepage_map = m_tt_device_map.at(src_device_id)->get_pci_device()->get_hugepage_mapping(channel);
     log_assert(
         hugepage_map.mapping,
         "write_buffer: Hugepages are not allocated for src_device_id: {} ch: {}."
@@ -1237,19 +1234,19 @@ void Cluster::write_buffer(
 }
 
 uint32_t Cluster::get_power_state_arc_msg(chip_id_t chip_id, tt_DevicePowerState state) {
-    PCIDevice* pci_device = get_pci_device(chip_id);
+    TTDevice* tt_device = get_tt_device(chip_id);
     uint32_t msg = 0xaa00;
     switch (state) {
         case BUSY: {
-            msg |= pci_device->get_architecture_implementation()->get_arc_message_arc_go_busy();
+            msg |= tt_device->get_architecture_implementation()->get_arc_message_arc_go_busy();
             break;
         }
         case LONG_IDLE: {
-            msg |= pci_device->get_architecture_implementation()->get_arc_message_arc_go_long_idle();
+            msg |= tt_device->get_architecture_implementation()->get_arc_message_arc_go_long_idle();
             break;
         }
         case SHORT_IDLE: {
-            msg |= pci_device->get_architecture_implementation()->get_arc_message_arc_go_short_idle();
+            msg |= tt_device->get_architecture_implementation()->get_arc_message_arc_go_short_idle();
             break;
         }
         default:
@@ -1259,7 +1256,7 @@ uint32_t Cluster::get_power_state_arc_msg(chip_id_t chip_id, tt_DevicePowerState
 }
 
 void Cluster::set_pcie_power_state(tt_DevicePowerState state) {
-    for (auto& device_it : m_pci_device_map) {
+    for (auto& device_it : m_tt_device_map) {
         int chip_id = device_it.first;
         uint32_t msg = get_power_state_arc_msg(chip_id, state);
         std::stringstream ss;
@@ -1289,10 +1286,10 @@ int Cluster::get_clock(int logical_device_id) {
 
     uint32_t clock;
     auto mmio_capable_chip_logical = cluster_desc->get_closest_mmio_capable_chip(logical_device_id);
-    PCIDevice* pci_device = get_pci_device(mmio_capable_chip_logical);
+    TTDevice* tt_device = get_tt_device(mmio_capable_chip_logical);
     auto exit_code = arc_msg(
         logical_device_id,
-        0xaa00 | pci_device->get_architecture_implementation()->get_arc_message_get_aiclk(),
+        0xaa00 | tt_device->get_architecture_implementation()->get_arc_message_get_aiclk(),
         true,
         0xFFFF,
         0xFFFF,
@@ -1306,7 +1303,7 @@ int Cluster::get_clock(int logical_device_id) {
 
 std::map<int, int> Cluster::get_clocks() {
     std::map<int, int> clock_freq_map;
-    for (auto& device_it : m_pci_device_map) {
+    for (auto& device_it : m_tt_device_map) {
         int d = device_it.first;
         clock_freq_map.insert({d, get_clock(d)});
     }
@@ -1318,7 +1315,7 @@ Cluster::~Cluster() {
 
     cleanup_shared_host_state();
 
-    m_pci_device_map.clear();
+    m_tt_device_map.clear();
     cluster_desc.reset();
     soc_descriptor_per_chip.clear();
     dynamic_tlb_config.clear();
@@ -1343,9 +1340,9 @@ void Cluster::configure_tlb(
     log_assert(
         ordering == TLB_DATA::Strict || ordering == TLB_DATA::Posted || ordering == TLB_DATA::Relaxed,
         "Invalid ordering specified in Cluster::configure_tlb");
-    PCIDevice* pci_device = get_pci_device(logical_device_id);
-    pci_device->set_dynamic_tlb(tlb_index, core, address, harvested_coord_translation.at(logical_device_id), ordering);
-    auto tlb_size = std::get<1>(pci_device->get_architecture_implementation()->describe_tlb(tlb_index).value());
+    TTDevice* tt_device = get_tt_device(logical_device_id);
+    tt_device->set_dynamic_tlb(tlb_index, core, address, harvested_coord_translation.at(logical_device_id), ordering);
+    auto tlb_size = std::get<1>(tt_device->get_architecture_implementation()->describe_tlb(tlb_index).value());
     if (tlb_config_map.find(logical_device_id) == tlb_config_map.end()) {
         tlb_config_map.insert({logical_device_id, {}});
     }
@@ -1368,12 +1365,12 @@ void Cluster::set_fallback_tlb_ordering_mode(const std::string& fallback_tlb, ui
 // TT<->TT P2P support removed in favor of increased Host memory.
 // TODO: this is in the wrong place, it should be in the PCIDevice.
 void Cluster::init_pcie_iatus() {
-    int num_enabled_devices = m_pci_device_map.size();
+    int num_enabled_devices = m_tt_device_map.size();
     log_debug(LogSiliconDriver, "Cluster::init_pcie_iatus() num_enabled_devices: {}", num_enabled_devices);
 
-    for (auto& src_device_it : m_pci_device_map) {
+    for (auto& src_device_it : m_tt_device_map) {
         int logical_id = src_device_it.first;
-        PCIDevice* src_pci_device = src_device_it.second.get();
+        PCIDevice* src_pci_device = src_device_it.second->get_pci_device();
 
         // TODO: with the IOMMU case, I think we can get away with using just
         // one iATU region for WH.  (On BH, we don't need iATU).  We can only
@@ -1409,43 +1406,47 @@ void Cluster::init_pcie_iatus() {
 
 int Cluster::test_setup_interface() {
     int ret_val = 0;
-    int logical_device_id = m_pci_device_map.begin()->first;
-    PCIDevice* dev = m_pci_device_map.at(logical_device_id).get();
+    int logical_device_id = m_tt_device_map.begin()->first;
+    TTDevice* tt_device = m_tt_device_map.at(logical_device_id).get();
     if (arch_name == tt::ARCH::GRAYSKULL) {
-        uint32_t mapped_reg = dev->set_dynamic_tlb(
-                                     dev->get_architecture_implementation()->get_reg_tlb(),
-                                     tt_xy_pair(0, 0),
-                                     0xffb20108,
-                                     harvested_coord_translation.at(logical_device_id))
+        uint32_t mapped_reg = tt_device
+                                  ->set_dynamic_tlb(
+                                      tt_device->get_architecture_implementation()->get_reg_tlb(),
+                                      tt_xy_pair(0, 0),
+                                      0xffb20108,
+                                      harvested_coord_translation.at(logical_device_id))
                                   .bar_offset;
 
         uint32_t regval = 0;
-        dev->read_regs(mapped_reg, 1, &regval);
+        tt_device->read_regs(mapped_reg, 1, &regval);
         ret_val = (regval != 0xffffffff && ((regval & 0x1) == 1)) ? 0 : 1;
         return ret_val;
     } else if (arch_name == tt::ARCH::WORMHOLE_B0) {
-        uint32_t mapped_reg = dev->set_dynamic_tlb(
-                                     dev->get_architecture_implementation()->get_reg_tlb(),
-                                     tt_xy_pair(1, 0),
-                                     0xffb20108,
-                                     harvested_coord_translation.at(logical_device_id))
+        uint32_t mapped_reg = tt_device
+                                  ->set_dynamic_tlb(
+                                      tt_device->get_architecture_implementation()->get_reg_tlb(),
+                                      tt_xy_pair(1, 0),
+                                      0xffb20108,
+                                      harvested_coord_translation.at(logical_device_id))
                                   .bar_offset;
 
         uint32_t regval = 0;
-        dev->read_regs(mapped_reg, 1, &regval);
+        tt_device->read_regs(mapped_reg, 1, &regval);
         ret_val = (regval != 0xffffffff && (regval == 33)) ? 0 : 1;
         return ret_val;
     } else if (arch_name == tt::ARCH::BLACKHOLE) {
         // MT Inital BH - Try to enable this, but double check "regval == 33"
-        // int ret_val = 0;
-        // PCIDevice *dev = m_pci_device_map.begin()->second->hdev;
 
-        // uint32_t mapped_reg = dev->set_dynamic_tlb(m_pci_device_map.begin()->second,
-        // dev->get_architecture_implementation()->get_reg_tlb(), tt_xy_pair(1, 0), 0xffb20108,
-        // harvested_coord_translation.at(logical_device_id)).bar_offset;
+        // uint32_t mapped_reg = tt_device
+        //                           ->set_dynamic_tlb(
+        //                               tt_device->get_architecture_implementation()->get_reg_tlb(),
+        //                               tt_xy_pair(1, 0),
+        //                               0xffb20108,
+        //                               harvested_coord_translation.at(logical_device_id))
+        //                           .bar_offset;
 
         // uint32_t regval = 0;
-        // read_regs(dev, mapped_reg, 1, &regval);
+        // tt_device->read_regs(dev, mapped_reg, 1, &regval);
         // ret_val = (regval != 0xffffffff && (regval == 33)) ? 0 : 1;
         // return ret_val;
         return 0;
@@ -1455,9 +1456,9 @@ int Cluster::test_setup_interface() {
 }
 
 void Cluster::bar_write32(int logical_device_id, uint32_t addr, uint32_t data) {
-    PCIDevice* dev = get_pci_device(logical_device_id);
+    TTDevice* dev = get_tt_device(logical_device_id);
 
-    if (addr < dev->bar0_uc_offset) {
+    if (addr < dev->get_pci_device()->bar0_uc_offset) {
         dev->write_block(
             addr, sizeof(data), reinterpret_cast<const uint8_t*>(&data));  // do we have to reinterpret_cast?
     } else {
@@ -1466,10 +1467,10 @@ void Cluster::bar_write32(int logical_device_id, uint32_t addr, uint32_t data) {
 }
 
 uint32_t Cluster::bar_read32(int logical_device_id, uint32_t addr) {
-    PCIDevice* dev = get_pci_device(logical_device_id);
+    TTDevice* dev = get_tt_device(logical_device_id);
 
     uint32_t data;
-    if (addr < dev->bar0_uc_offset) {
+    if (addr < dev->get_pci_device()->bar0_uc_offset) {
         dev->read_block(addr, sizeof(data), reinterpret_cast<uint8_t*>(&data));
     } else {
         dev->read_regs(addr, 1, &data);
@@ -1492,12 +1493,12 @@ int Cluster::pcie_arc_msg(
     }
     log_assert(arg0 <= 0xffff and arg1 <= 0xffff, "Only 16 bits allowed in arc_msg args");  // Only 16 bits are allowed
 
-    PCIDevice* pci_device = get_pci_device(logical_device_id);
-    auto architecture_implementation = pci_device->get_architecture_implementation();
+    TTDevice* tt_device = get_tt_device(logical_device_id);
+    auto architecture_implementation = tt_device->get_architecture_implementation();
 
     // Exclusive access for a single process at a time. Based on physical pci interface id.
     std::string msg_type = "ARC_MSG";
-    const scoped_lock<named_mutex> lock(*get_mutex(msg_type, pci_device->get_device_num()));
+    const scoped_lock<named_mutex> lock(*get_mutex(msg_type, tt_device->get_pci_device()->get_device_num()));
     uint32_t fw_arg = arg0 | (arg1 << 16);
     int exit_code = 0;
 
@@ -1550,7 +1551,7 @@ int Cluster::pcie_arc_msg(
         }
     }
 
-    pci_device->detect_hang_read();
+    tt_device->detect_hang_read();
     return exit_code;
 }
 
@@ -1563,8 +1564,9 @@ int Cluster::iatu_configure_peer_region(
         region_id_to_use = 4;  // Hack use region 4 for channel 3..this ensures that we have a smaller chan 3 address
                                // space with the correct start offset
     }
-    PCIDevice* pci_device = get_pci_device(logical_device_id);
-    auto architecture_implementation = pci_device->get_architecture_implementation();
+    TTDevice* tt_device = get_tt_device(logical_device_id);
+    PCIDevice* pci_device = tt_device->get_pci_device();
+    auto architecture_implementation = tt_device->get_architecture_implementation();
 
     // BR: ARC doesn't work yet on Blackhole, so programming ATU directly. Should be removed when arc starts working.
     // TODO: Remove when ARC is implemented on BH.
@@ -1584,39 +1586,39 @@ int Cluster::iatu_configure_peer_region(
         uint64_t iatu_index = 0;
         uint64_t iatu_base = UNROLL_ATU_OFFSET_BAR + iatu_index * 0x200;
 
-        pci_device->write_regs(
+        tt_device->write_regs(
             reinterpret_cast<std::uint32_t*>(static_cast<uint8_t*>(pci_device->bar2_uc) + iatu_base + 0x00),
             &region_ctrl_1,
             1);
-        pci_device->write_regs(
+        tt_device->write_regs(
             reinterpret_cast<std::uint32_t*>(static_cast<uint8_t*>(pci_device->bar2_uc) + iatu_base + 0x04),
             &region_ctrl_2,
             1);
-        pci_device->write_regs(
+        tt_device->write_regs(
             reinterpret_cast<std::uint32_t*>(static_cast<uint8_t*>(pci_device->bar2_uc) + iatu_base + 0x08),
             &base_addr_lo,
             1);
-        pci_device->write_regs(
+        tt_device->write_regs(
             reinterpret_cast<std::uint32_t*>(static_cast<uint8_t*>(pci_device->bar2_uc) + iatu_base + 0x0c),
             &base_addr_hi,
             1);
-        pci_device->write_regs(
+        tt_device->write_regs(
             reinterpret_cast<std::uint32_t*>(static_cast<uint8_t*>(pci_device->bar2_uc) + iatu_base + 0x10),
             &limit_address_lo,
             1);
-        pci_device->write_regs(
+        tt_device->write_regs(
             reinterpret_cast<std::uint32_t*>(static_cast<uint8_t*>(pci_device->bar2_uc) + iatu_base + 0x14),
             &dest_bar_lo,
             1);
-        pci_device->write_regs(
+        tt_device->write_regs(
             reinterpret_cast<std::uint32_t*>(static_cast<uint8_t*>(pci_device->bar2_uc) + iatu_base + 0x18),
             &dest_bar_hi,
             1);
-        pci_device->write_regs(
+        tt_device->write_regs(
             reinterpret_cast<std::uint32_t*>(static_cast<uint8_t*>(pci_device->bar2_uc) + iatu_base + 0x1c),
             &region_ctrl_3,
             1);
-        pci_device->write_regs(
+        tt_device->write_regs(
             reinterpret_cast<std::uint32_t*>(static_cast<uint8_t*>(pci_device->bar2_uc) + iatu_base + 0x20),
             &limit_address_hi,
             1);
@@ -1678,10 +1680,10 @@ uint32_t Cluster::get_harvested_rows(int logical_device_id) {
         harv = std::stoul(harv_override, nullptr, 16);
     } else {
         auto mmio_capable_chip_logical = cluster_desc->get_closest_mmio_capable_chip(logical_device_id);
-        PCIDevice* pci_device = get_pci_device(mmio_capable_chip_logical);
+        TTDevice* tt_device = get_tt_device(mmio_capable_chip_logical);
         int harvesting_msg_code = arc_msg(
             logical_device_id,
-            0xaa00 | pci_device->get_architecture_implementation()->get_arc_message_arc_get_harvesting(),
+            0xaa00 | tt_device->get_architecture_implementation()->get_arc_message_arc_get_harvesting(),
             true,
             0,
             0,
@@ -1719,7 +1721,7 @@ void Cluster::enable_local_ethernet_queue(const chip_id_t& device_id, int timeou
 }
 
 void* Cluster::host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const {
-    hugepage_mapping hugepage_map = m_pci_device_map.at(src_device_id)->get_hugepage_mapping(channel);
+    hugepage_mapping hugepage_map = m_tt_device_map.at(src_device_id)->get_pci_device()->get_hugepage_mapping(channel);
     if (hugepage_map.mapping != nullptr) {
         return static_cast<std::byte*>(hugepage_map.mapping) + offset;
     } else {
@@ -1728,11 +1730,11 @@ void* Cluster::host_dma_address(std::uint64_t offset, chip_id_t src_device_id, u
 }
 
 // Wrapper for throwing more helpful exception when not-enabled pci intf is accessed.
-inline PCIDevice* Cluster::get_pci_device(int device_id) const {
-    if (!m_pci_device_map.count(device_id)) {
+inline TTDevice* Cluster::get_tt_device(int device_id) const {
+    if (!m_tt_device_map.count(device_id)) {
         throw std::runtime_error(fmt::format("device_id: {} attempted to be accessed, but is not enabled.", device_id));
     }
-    return m_pci_device_map.at(device_id).get();
+    return m_tt_device_map.at(device_id).get();
 }
 
 std::shared_ptr<boost::interprocess::named_mutex> Cluster::get_mutex(
@@ -1873,8 +1875,8 @@ void Cluster::write_to_non_mmio_device(
     //                    MUTEX ACQUIRE (NON-MMIO)
     //  do not locate any ethernet core reads/writes before this acquire
     //
-    const scoped_lock<named_mutex> lock(
-        *get_mutex(NON_MMIO_MUTEX_NAME, this->get_pci_device(mmio_capable_chip_logical)->get_device_num()));
+    const scoped_lock<named_mutex> lock(*get_mutex(
+        NON_MMIO_MUTEX_NAME, this->get_tt_device(mmio_capable_chip_logical)->get_pci_device()->get_device_num()));
 
     int& active_core_for_txn =
         non_mmio_transfer_cores_customized ? active_eth_core_idx_per_chip.at(mmio_capable_chip_logical) : active_core;
@@ -2099,8 +2101,8 @@ void Cluster::read_from_non_mmio_device(void* mem_ptr, tt_cxy_pair core, uint64_
     //                    MUTEX ACQUIRE (NON-MMIO)
     //  do not locate any ethernet core reads/writes before this acquire
     //
-    const scoped_lock<named_mutex> lock(
-        *get_mutex(NON_MMIO_MUTEX_NAME, this->get_pci_device(mmio_capable_chip_logical)->get_device_num()));
+    const scoped_lock<named_mutex> lock(*get_mutex(
+        NON_MMIO_MUTEX_NAME, this->get_tt_device(mmio_capable_chip_logical)->get_pci_device()->get_device_num()));
     const tt_cxy_pair remote_transfer_ethernet_core = remote_transfer_ethernet_cores[mmio_capable_chip_logical].at(0);
 
     read_device_memory(
@@ -2526,12 +2528,12 @@ void Cluster::pcie_broadcast_write(
     const std::string& fallback_tlb) {
     // Use the specified TLB to broadcast data to all cores included in the [start, end] grid -> GS Only. Use Ethernet
     // Broadcast for WH.
-    PCIDevice* pci_device = get_pci_device(chip);
+    TTDevice* tt_device = get_tt_device(chip);
     const auto tlb_index = dynamic_tlb_config.at(fallback_tlb);
     const uint8_t* buffer_addr = static_cast<const uint8_t*>(mem_ptr);
-    const scoped_lock<named_mutex> lock(*get_mutex(fallback_tlb, pci_device->get_device_num()));
+    const scoped_lock<named_mutex> lock(*get_mutex(fallback_tlb, tt_device->get_pci_device()->get_device_num()));
     while (size_in_bytes > 0) {
-        auto [mapped_address, tlb_size] = pci_device->set_dynamic_tlb_broadcast(
+        auto [mapped_address, tlb_size] = tt_device->set_dynamic_tlb_broadcast(
             tlb_index,
             addr,
             harvested_coord_translation.at(chip),
@@ -2539,7 +2541,7 @@ void Cluster::pcie_broadcast_write(
             end,
             dynamic_tlb_ordering_modes.at(fallback_tlb));
         uint64_t transfer_size = std::min((uint64_t)size_in_bytes, tlb_size);
-        pci_device->write_block(mapped_address, transfer_size, buffer_addr);
+        tt_device->write_block(mapped_address, transfer_size, buffer_addr);
 
         size_in_bytes -= transfer_size;
         addr += transfer_size;
@@ -2900,7 +2902,7 @@ void Cluster::insert_host_to_device_barrier(
     const std::string& fallback_tlb) {
     // Ensure that this memory barrier is atomic across processes/threads
     const scoped_lock<named_mutex> lock(
-        *get_mutex(MEM_BARRIER_MUTEX_NAME, this->get_pci_device(chip)->get_device_num()));
+        *get_mutex(MEM_BARRIER_MUTEX_NAME, this->get_tt_device(chip)->get_pci_device()->get_device_num()));
     set_membar_flag(chip, cores, tt_MemBarFlag::SET, barrier_addr, fallback_tlb);
     set_membar_flag(chip, cores, tt_MemBarFlag::RESET, barrier_addr, fallback_tlb);
 }
@@ -3011,17 +3013,17 @@ void Cluster::write_to_device(
 
 void Cluster::read_mmio_device_register(
     void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb) {
-    PCIDevice* pci_device = get_pci_device(core.chip);
+    TTDevice* tt_device = get_tt_device(core.chip);
 
     const auto tlb_index = dynamic_tlb_config.at(fallback_tlb);
-    const scoped_lock<named_mutex> lock(*get_mutex(fallback_tlb, pci_device->get_device_num()));
+    const scoped_lock<named_mutex> lock(*get_mutex(fallback_tlb, tt_device->get_pci_device()->get_device_num()));
     log_debug(LogSiliconDriver, "  dynamic tlb_index: {}", tlb_index);
 
     auto [mapped_address, tlb_size] =
-        pci_device->set_dynamic_tlb(tlb_index, core, addr, harvested_coord_translation.at(core.chip), TLB_DATA::Strict);
+        tt_device->set_dynamic_tlb(tlb_index, core, addr, harvested_coord_translation.at(core.chip), TLB_DATA::Strict);
     // Align block to 4bytes if needed.
     auto aligned_buf = tt_4_byte_aligned_buffer(mem_ptr, size);
-    pci_device->read_regs(mapped_address, aligned_buf.block_size / sizeof(std::uint32_t), aligned_buf.local_storage);
+    tt_device->read_regs(mapped_address, aligned_buf.block_size / sizeof(std::uint32_t), aligned_buf.local_storage);
 
     if (aligned_buf.input_size != aligned_buf.block_size) {
         // Copy value from aligned buffer to main buffer.
@@ -3031,21 +3033,21 @@ void Cluster::read_mmio_device_register(
 
 void Cluster::write_mmio_device_register(
     const void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb) {
-    PCIDevice* pci_device = get_pci_device(core.chip);
+    TTDevice* tt_device = get_tt_device(core.chip);
 
     const auto tlb_index = dynamic_tlb_config.at(fallback_tlb);
-    const scoped_lock<named_mutex> lock(*get_mutex(fallback_tlb, pci_device->get_device_num()));
+    const scoped_lock<named_mutex> lock(*get_mutex(fallback_tlb, tt_device->get_pci_device()->get_device_num()));
     log_debug(LogSiliconDriver, "  dynamic tlb_index: {}", tlb_index);
 
     auto [mapped_address, tlb_size] =
-        pci_device->set_dynamic_tlb(tlb_index, core, addr, harvested_coord_translation.at(core.chip), TLB_DATA::Strict);
+        tt_device->set_dynamic_tlb(tlb_index, core, addr, harvested_coord_translation.at(core.chip), TLB_DATA::Strict);
     // Align block to 4bytes if needed.
     auto aligned_buf = tt_4_byte_aligned_buffer(mem_ptr, size);
     if (aligned_buf.input_size != aligned_buf.block_size) {
         // Copy value from main buffer to aligned buffer
         std::memcpy(aligned_buf.local_storage, mem_ptr, size);
     }
-    pci_device->write_regs(mapped_address, aligned_buf.block_size / sizeof(uint32_t), aligned_buf.local_storage);
+    tt_device->write_regs(mapped_address, aligned_buf.block_size / sizeof(uint32_t), aligned_buf.local_storage);
 }
 
 void Cluster::read_from_device(
@@ -3124,7 +3126,7 @@ void Cluster::enable_remote_ethernet_queue(const chip_id_t& chip, int timeout) {
 
 void Cluster::broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOptions& soft_resets) {
     if (arch_name == tt::ARCH::GRAYSKULL) {
-        for (auto& device_it : m_pci_device_map) {
+        for (auto& device_it : m_tt_device_map) {
             broadcast_pcie_tensix_risc_reset(device_it.first, soft_resets);
         }
     } else {
@@ -3201,11 +3203,10 @@ void Cluster::deassert_resets_and_set_power_state() {
     // MT Initial BH - ARC messages not supported in Blackhole
     if (arch_name != tt::ARCH::BLACKHOLE) {
         // Send ARC Messages to deassert RISCV resets
-        for (auto& device_it : m_pci_device_map) {
+        for (auto& device_it : m_tt_device_map) {
             arc_msg(
                 device_it.first,
-                0xaa00 |
-                    device_it.second.get()->get_architecture_implementation()->get_arc_message_deassert_riscv_reset(),
+                0xaa00 | device_it.second->get_architecture_implementation()->get_arc_message_deassert_riscv_reset(),
                 true,
                 0,
                 0);
@@ -3214,10 +3215,10 @@ void Cluster::deassert_resets_and_set_power_state() {
             for (const chip_id_t& chip : target_devices_in_cluster) {
                 if (!cluster_desc->is_chip_mmio_capable(chip)) {
                     auto mmio_capable_chip_logical = cluster_desc->get_closest_mmio_capable_chip(chip);
-                    auto pci_device = get_pci_device(mmio_capable_chip_logical);
+                    auto tt_device = get_tt_device(mmio_capable_chip_logical);
                     remote_arc_msg(
                         chip,
-                        0xaa00 | pci_device->get_architecture_implementation()->get_arc_message_deassert_riscv_reset(),
+                        0xaa00 | tt_device->get_architecture_implementation()->get_arc_message_deassert_riscv_reset(),
                         true,
                         0x0,
                         0x0,
@@ -3332,18 +3333,18 @@ std::uint32_t Cluster::get_num_host_channels(std::uint32_t device_id) {
     log_assert(
         devices.find(device_id) != devices.end(),
         "Querying Host Address parameters for a non-mmio device or a device does not exist.");
-    return m_pci_device_map.at(device_id)->get_num_host_mem_channels();
+    return m_tt_device_map.at(device_id)->get_pci_device()->get_num_host_mem_channels();
 }
 
 std::uint32_t Cluster::get_host_channel_size(std::uint32_t device_id, std::uint32_t channel) {
     log_assert(channel < get_num_host_channels(device_id), "Querying size for a host channel that does not exist.");
-    hugepage_mapping hugepage_map = m_pci_device_map.at(device_id)->get_hugepage_mapping(channel);
+    hugepage_mapping hugepage_map = m_tt_device_map.at(device_id)->get_pci_device()->get_hugepage_mapping(channel);
     log_assert(hugepage_map.mapping_size, "Host channel size can only be queried after the device has been started.");
     return hugepage_map.mapping_size;
 }
 
 std::uint32_t Cluster::get_numa_node_for_pcie_device(std::uint32_t device_id) {
-    return get_pci_device(device_id)->get_numa_node();
+    return get_tt_device(device_id)->get_pci_device()->get_numa_node();
 }
 
 std::uint64_t Cluster::get_pcie_base_addr_from_device(const chip_id_t chip_id) const {

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "umd/device/tt_device/blackhole_tt_device.h"
+
+#include <sys/mman.h>  // for MAP_FAILED
+
+#include "umd/device/blackhole_implementation.h"
+
+namespace tt::umd {
+
+BlackholeTTDevice::BlackholeTTDevice(std::unique_ptr<PCIDevice> pci_device) :
+    TTDevice(std::move(pci_device), std::make_unique<blackhole_implementation>()) {}
+
+BlackholeTTDevice::~BlackholeTTDevice() {
+    if (pci_device_->bar2_uc != nullptr && pci_device_->bar2_uc != MAP_FAILED) {
+        // Disable ATU index 0
+        // TODO: Implement disabling for all indexes, once more host channels are enabled.
+
+        // This is not going to happen if the application crashes, so if it's
+        // essential for correctness then it needs to move to the driver.
+        uint64_t iatu_index = 0;
+        uint64_t iatu_base = UNROLL_ATU_OFFSET_BAR + iatu_index * 0x200;
+        uint32_t region_ctrl_2 = 0 << 31;  // REGION_EN = 0
+
+        volatile uint32_t *dest =
+            reinterpret_cast<uint32_t *>(static_cast<uint8_t *>(pci_device_->bar2_uc) + iatu_base + 0x04);
+        const uint32_t *src = &region_ctrl_2;
+        *dest = *src;
+    }
+}
+}  // namespace tt::umd

--- a/device/tt_device/grayskull_tt_device.cpp
+++ b/device/tt_device/grayskull_tt_device.cpp
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "umd/device/tt_device/grayskull_tt_device.h"
+
+#include "umd/device/grayskull_implementation.h"
+
+namespace tt::umd {
+
+GrayskullTTDevice::GrayskullTTDevice(std::unique_ptr<PCIDevice> pci_device) :
+    TTDevice(std::move(pci_device), std::make_unique<grayskull_implementation>()) {}
+}  // namespace tt::umd

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -1,0 +1,313 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "umd/device/tt_device/tt_device.h"
+
+#include "logger.hpp"
+#include "umd/device/driver_atomics.h"
+#include "umd/device/tt_device/blackhole_tt_device.h"
+#include "umd/device/tt_device/grayskull_tt_device.h"
+#include "umd/device/tt_device/wormhole_tt_device.h"
+
+namespace tt::umd {
+
+TTDevice::TTDevice(
+    std::unique_ptr<PCIDevice> pci_device, std::unique_ptr<architecture_implementation> architecture_impl) :
+    pci_device_(std::move(pci_device)),
+    architecture_impl_(std::move(architecture_impl)),
+    arch(architecture_impl_->get_architecture()) {}
+
+/* static */ std::unique_ptr<TTDevice> TTDevice::create(int pci_device_number) {
+    auto pci_device = std::make_unique<PCIDevice>(pci_device_number);
+
+    switch (pci_device->get_arch()) {
+        case ARCH::GRAYSKULL:
+            return std::make_unique<GrayskullTTDevice>(std::move(pci_device));
+        case ARCH::WORMHOLE_B0:
+            return std::make_unique<WormholeTTDevice>(std::move(pci_device));
+        case ARCH::BLACKHOLE:
+            return std::make_unique<BlackholeTTDevice>(std::move(pci_device));
+        default:
+            return nullptr;
+    }
+}
+
+architecture_implementation *TTDevice::get_architecture_implementation() { return architecture_impl_.get(); }
+
+PCIDevice *TTDevice::get_pci_device() { return pci_device_.get(); }
+
+bool TTDevice::is_hardware_hung() {
+    volatile const void *addr = reinterpret_cast<const char *>(pci_device_->bar0_uc) +
+                                (architecture_impl_->get_arc_reset_scratch_offset() + 6 * 4) -
+                                pci_device_->bar0_uc_offset;
+    std::uint32_t scratch_data = *reinterpret_cast<const volatile std::uint32_t *>(addr);
+
+    return (scratch_data == c_hang_read_value);
+}
+
+void TTDevice::detect_hang_read(std::uint32_t data_read) {
+    if (data_read == c_hang_read_value && is_hardware_hung()) {
+        std::uint32_t scratch_data =
+            *pci_device_->get_register_address<std::uint32_t>(architecture_impl_->get_read_checking_offset());
+
+        throw std::runtime_error("Read 0xffffffff from PCIE: you should reset the board.");
+    }
+}
+
+// This is only needed for the BH workaround in iatu_configure_peer_region since no arc
+void TTDevice::write_regs(volatile uint32_t *dest, const uint32_t *src, uint32_t word_len) {
+    while (word_len-- != 0) {
+        *dest++ = *src++;
+    }
+}
+
+void TTDevice::write_regs(uint32_t byte_addr, uint32_t word_len, const void *data) {
+    volatile uint32_t *dest = pci_device_->get_register_address<uint32_t>(byte_addr);
+    const uint32_t *src = reinterpret_cast<const uint32_t *>(data);
+
+    write_regs(dest, src, word_len);
+}
+
+void TTDevice::read_regs(uint32_t byte_addr, uint32_t word_len, void *data) {
+    const volatile uint32_t *src = pci_device_->get_register_address<uint32_t>(byte_addr);
+    uint32_t *dest = reinterpret_cast<uint32_t *>(data);
+
+    while (word_len-- != 0) {
+        uint32_t temp = *src++;
+        memcpy(dest++, &temp, sizeof(temp));
+    }
+}
+
+void TTDevice::memcpy_to_device(void *dest, const void *src, std::size_t num_bytes) {
+    typedef std::uint32_t copy_t;
+
+    // Start by aligning the destination (device) pointer. If needed, do RMW to fix up the
+    // first partial word.
+    volatile copy_t *dp;
+
+    std::uintptr_t dest_addr = reinterpret_cast<std::uintptr_t>(dest);
+    unsigned int dest_misalignment = dest_addr % sizeof(copy_t);
+
+    if (dest_misalignment != 0) {
+        // Read-modify-write for the first dest element.
+        dp = reinterpret_cast<copy_t *>(dest_addr - dest_misalignment);
+
+        copy_t tmp = *dp;
+
+        auto leading_len = std::min(sizeof(tmp) - dest_misalignment, num_bytes);
+
+        std::memcpy(reinterpret_cast<char *>(&tmp) + dest_misalignment, src, leading_len);
+        num_bytes -= leading_len;
+        src = static_cast<const char *>(src) + leading_len;
+
+        *dp++ = tmp;
+
+    } else {
+        dp = static_cast<copy_t *>(dest);
+    }
+
+    // Copy the destination-aligned middle.
+    const copy_t *sp = static_cast<const copy_t *>(src);
+    std::size_t num_words = num_bytes / sizeof(copy_t);
+
+    for (std::size_t i = 0; i < num_words; i++) {
+        *dp++ = *sp++;
+    }
+
+    // Finally copy any sub-word trailer, again RMW on the destination.
+    auto trailing_len = num_bytes % sizeof(copy_t);
+    if (trailing_len != 0) {
+        copy_t tmp = *dp;
+
+        std::memcpy(&tmp, sp, trailing_len);
+
+        *dp++ = tmp;
+    }
+}
+
+void TTDevice::memcpy_from_device(void *dest, const void *src, std::size_t num_bytes) {
+    typedef std::uint32_t copy_t;
+
+    // Start by aligning the source (device) pointer.
+    const volatile copy_t *sp;
+
+    std::uintptr_t src_addr = reinterpret_cast<std::uintptr_t>(src);
+    unsigned int src_misalignment = src_addr % sizeof(copy_t);
+
+    if (src_misalignment != 0) {
+        sp = reinterpret_cast<copy_t *>(src_addr - src_misalignment);
+
+        copy_t tmp = *sp++;
+
+        auto leading_len = std::min(sizeof(tmp) - src_misalignment, num_bytes);
+        std::memcpy(dest, reinterpret_cast<char *>(&tmp) + src_misalignment, leading_len);
+        num_bytes -= leading_len;
+        dest = static_cast<char *>(dest) + leading_len;
+
+    } else {
+        sp = static_cast<const volatile copy_t *>(src);
+    }
+
+    // Copy the source-aligned middle.
+    copy_t *dp = static_cast<copy_t *>(dest);
+    std::size_t num_words = num_bytes / sizeof(copy_t);
+
+    for (std::size_t i = 0; i < num_words; i++) {
+        *dp++ = *sp++;
+    }
+
+    // Finally copy any sub-word trailer.
+    auto trailing_len = num_bytes % sizeof(copy_t);
+    if (trailing_len != 0) {
+        copy_t tmp = *sp;
+        std::memcpy(dp, &tmp, trailing_len);
+    }
+}
+
+void TTDevice::write_block(uint64_t byte_addr, uint64_t num_bytes, const uint8_t *buffer_addr) {
+    void *dest = nullptr;
+    if (pci_device_->bar4_wc != nullptr && byte_addr >= BAR0_BH_SIZE) {
+        byte_addr -= BAR0_BH_SIZE;
+        dest = reinterpret_cast<uint8_t *>(pci_device_->bar4_wc) + byte_addr;
+    } else {
+        dest = pci_device_->get_register_address<uint8_t>(byte_addr);
+    }
+
+    const void *src = reinterpret_cast<const void *>(buffer_addr);
+    if (arch == tt::ARCH::WORMHOLE_B0) {
+        memcpy_to_device(dest, src, num_bytes);
+    } else {
+        memcpy(dest, src, num_bytes);
+    }
+}
+
+void TTDevice::read_block(uint64_t byte_addr, uint64_t num_bytes, uint8_t *buffer_addr) {
+    void *src = nullptr;
+    if (pci_device_->bar4_wc != nullptr && byte_addr >= BAR0_BH_SIZE) {
+        byte_addr -= BAR0_BH_SIZE;
+        src = reinterpret_cast<uint8_t *>(pci_device_->bar4_wc) + byte_addr;
+    } else {
+        src = pci_device_->get_register_address<uint8_t>(byte_addr);
+    }
+
+    void *dest = reinterpret_cast<void *>(buffer_addr);
+    if (arch == tt::ARCH::WORMHOLE_B0) {
+        memcpy_from_device(dest, src, num_bytes);
+    } else {
+        memcpy(dest, src, num_bytes);
+    }
+
+    if (num_bytes >= sizeof(std::uint32_t)) {
+        detect_hang_read(*reinterpret_cast<std::uint32_t *>(dest));
+    }
+}
+
+void TTDevice::write_tlb_reg(
+    uint32_t byte_addr, uint64_t value_lower, uint64_t value_upper, uint32_t tlb_cfg_reg_size) {
+    log_assert(
+        (tlb_cfg_reg_size == 8) or (tlb_cfg_reg_size == 12),
+        "Tenstorrent hardware supports only 64bit or 96bit TLB config regs");
+
+    volatile uint64_t *dest_qw = pci_device_->get_register_address<uint64_t>(byte_addr);
+    volatile uint32_t *dest_extra_dw = pci_device_->get_register_address<uint32_t>(byte_addr + 8);
+#if defined(__ARM_ARCH) || defined(__riscv)
+    // The store below goes through UC memory on x86, which has implicit ordering constraints with WC accesses.
+    // ARM has no concept of UC memory. This will not allow for implicit ordering of this store wrt other memory
+    // accesses. Insert an explicit full memory barrier for ARM. Do the same for RISC-V.
+    tt_driver_atomics::mfence();
+#endif
+    *dest_qw = value_lower;
+    if (tlb_cfg_reg_size > 8) {
+        uint32_t *p_value_upper = reinterpret_cast<uint32_t *>(&value_upper);
+        *dest_extra_dw = p_value_upper[0];
+    }
+    tt_driver_atomics::mfence();  // Otherwise subsequent WC loads move earlier than the above UC store to the TLB
+                                  // register.
+}
+
+// Get TLB index (from zero), check if it's in 16MB, 2MB or 1MB TLB range, and dynamically program it.
+dynamic_tlb TTDevice::set_dynamic_tlb(
+    unsigned int tlb_index,
+    tt_xy_pair start,
+    tt_xy_pair end,
+    std::uint64_t address,
+    bool multicast,
+    std::unordered_map<tt_xy_pair, tt_xy_pair> &harvested_coord_translation,
+    std::uint64_t ordering) {
+    if (multicast) {
+        std::tie(start, end) = architecture_impl_->multicast_workaround(start, end);
+    }
+
+    log_trace(
+        LogSiliconDriver,
+        "set_dynamic_tlb with arguments: tlb_index = {}, start = ({}, {}), end = ({}, {}), address = 0x{:x}, multicast "
+        "= {}, ordering = {}",
+        tlb_index,
+        start.x,
+        start.y,
+        end.x,
+        end.y,
+        address,
+        multicast,
+        (int)ordering);
+
+    tt::umd::tlb_configuration tlb_config = architecture_impl_->get_tlb_configuration(tlb_index);
+    std::uint32_t TLB_CFG_REG_SIZE_BYTES = architecture_impl_->get_tlb_cfg_reg_size_bytes();
+    auto translated_start_coords = harvested_coord_translation.at(start);
+    auto translated_end_coords = harvested_coord_translation.at(end);
+    uint32_t tlb_address = address / tlb_config.size;
+    uint32_t local_address = address % tlb_config.size;
+    uint64_t tlb_base = tlb_config.base + (tlb_config.size * tlb_config.index_offset);
+    uint32_t tlb_cfg_reg = tlb_config.cfg_addr + (TLB_CFG_REG_SIZE_BYTES * tlb_config.index_offset);
+
+    std::pair<std::uint64_t, std::uint64_t> tlb_data =
+        tt::umd::tlb_data{
+            .local_offset = tlb_address,
+            .x_end = static_cast<uint64_t>(translated_end_coords.x),
+            .y_end = static_cast<uint64_t>(translated_end_coords.y),
+            .x_start = static_cast<uint64_t>(translated_start_coords.x),
+            .y_start = static_cast<uint64_t>(translated_start_coords.y),
+            .mcast = multicast,
+            .ordering = ordering,
+            // TODO #2715: hack for Blackhole A0, will potentially be fixed in B0.
+            // Using the same static vc for reads and writes through TLBs can hang the card. It doesn't even have to be
+            // the same TLB. Dynamic vc should not have this issue. There might be a perf impact with using dynamic vc.
+            .static_vc = (arch == tt::ARCH::BLACKHOLE) ? false : true,
+        }
+            .apply_offset(tlb_config.offset);
+
+    log_debug(
+        LogSiliconDriver,
+        "set_dynamic_tlb() with tlb_index: {} tlb_index_offset: {} dynamic_tlb_size: {}MB tlb_base: 0x{:x} "
+        "tlb_cfg_reg: 0x{:x}",
+        tlb_index,
+        tlb_config.index_offset,
+        tlb_config.size / (1024 * 1024),
+        tlb_base,
+        tlb_cfg_reg);
+    write_tlb_reg(tlb_cfg_reg, tlb_data.first, tlb_data.second, TLB_CFG_REG_SIZE_BYTES);
+
+    return {tlb_base + local_address, tlb_config.size - local_address};
+}
+
+dynamic_tlb TTDevice::set_dynamic_tlb(
+    unsigned int tlb_index,
+    tt_xy_pair target,
+    std::uint64_t address,
+    std::unordered_map<tt_xy_pair, tt_xy_pair> &harvested_coord_translation,
+    std::uint64_t ordering) {
+    return set_dynamic_tlb(tlb_index, tt_xy_pair(0, 0), target, address, false, harvested_coord_translation, ordering);
+}
+
+dynamic_tlb TTDevice::set_dynamic_tlb_broadcast(
+    unsigned int tlb_index,
+    std::uint64_t address,
+    std::unordered_map<tt_xy_pair, tt_xy_pair> &harvested_coord_translation,
+    tt_xy_pair start,
+    tt_xy_pair end,
+    std::uint64_t ordering) {
+    // Issue a broadcast to cores included in the start (top left) and end (bottom right) grid
+    return set_dynamic_tlb(tlb_index, start, end, address, true, harvested_coord_translation, ordering);
+}
+
+}  // namespace tt::umd

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "umd/device/tt_device/wormhole_tt_device.h"
+
+#include "umd/device/wormhole_implementation.h"
+
+namespace tt::umd {
+
+WormholeTTDevice::WormholeTTDevice(std::unique_ptr<PCIDevice> pci_device) :
+    TTDevice(std::move(pci_device), std::make_unique<wormhole_implementation>()) {}
+}  // namespace tt::umd

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -69,8 +69,7 @@ TEST(ApiChipTest, ManualTLBConfiguration) {
             return -1;
         }
         return core.x +
-               core.y *
-                   umd_cluster->get_pci_device(any_mmio_chip)->get_architecture_implementation()->get_grid_size_x();
+               core.y * umd_cluster->get_tt_device(any_mmio_chip)->get_architecture_implementation()->get_grid_size_x();
     };
 
     std::int32_t c_zero_address = 0;


### PR DESCRIPTION
### Issue
Related to #98 

### Description
Initial TTDevice class. It holds PCIDevice and arch implementation.
Gradually, I'd like to move all branches on arch type to be moved from cluster and pci_device to tt_device, and that class to be the only one in the stack which offers different implementation for each arch. According to: https://docs.google.com/drawings/d/1-m1azdsBqMA0A6ATYRMfkhyeuOJuGCEI62N5a96LXj0/edit

### List of the changes
- Create TTDevice class.
- Created arch specific TTDevice classes, which currently don't hold much implementation.
- architecture_implementation is moved to TTDevice, and ~half of PCIDevice is moved. PCIDevice should hold only non-arch specific code, except getting the arch itself. There were only mild, compile related changes in the functions moved from PCIDevice to TTDevice.
- cluster.cpp and tests changed accordingly.
- read_checking_offset moved to architecture_implementation
- Blackhole destructor specific code moved to BlackholeTTDevice from PCIDevice.


### Testing
Existing CI tests should be enough.

### API Changes
There are no API changes in this PR.
But I scheduled post commit tests just to be sure.
- [x] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/12156329972
- [x] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/12156332357
