### PR TITLE
Disable tests that are intermittently failing

### DIFF
--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -137,46 +137,48 @@ TEST(ApiChipTest, DeassertRiscResetOnCore) {
 
 // This tests puts a specific core into reset and then specifies a legal deassert value
 // It reads back the risc reset reg to validate
-TEST(ApiChipTest, SpecifyLegalDeassertRiscResetOnCore) {
-    std::unique_ptr<Cluster> umd_cluster = get_cluster();
+// TOOD issue#362
+// TEST(ApiChipTest, SpecifyLegalDeassertRiscResetOnCore) {
+//     std::unique_ptr<Cluster> umd_cluster = get_cluster();
 
-    if (umd_cluster == nullptr || umd_cluster->get_all_chips_in_cluster().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
+//     if (umd_cluster == nullptr || umd_cluster->get_all_chips_in_cluster().empty()) {
+//         GTEST_SKIP() << "No chips present on the system. Skipping test.";
+//     }
 
-    tt_cxy_pair chip_core_coord = get_tensix_chip_core_coord(umd_cluster);
+//     tt_cxy_pair chip_core_coord = get_tensix_chip_core_coord(umd_cluster);
 
-    umd_cluster->assert_risc_reset_at_core(chip_core_coord);
-    TensixSoftResetOptions deassert_val = ALL_TRISC_SOFT_RESET | TensixSoftResetOptions::STAGGERED_START;
-    umd_cluster->deassert_risc_reset_at_core(chip_core_coord, deassert_val);
-    umd_cluster->l1_membar(chip_core_coord.chip, "LARGE_WRITE_TLB");
+//     umd_cluster->assert_risc_reset_at_core(chip_core_coord);
+//     TensixSoftResetOptions deassert_val = ALL_TRISC_SOFT_RESET | TensixSoftResetOptions::STAGGERED_START;
+//     umd_cluster->deassert_risc_reset_at_core(chip_core_coord, deassert_val);
+//     umd_cluster->l1_membar(chip_core_coord.chip, "LARGE_WRITE_TLB");
 
-    uint32_t soft_reset_reg_addr = 0xFFB121B0;
-    uint32_t risc_reset_val;
-    umd_cluster->read_from_device(&risc_reset_val, chip_core_coord, soft_reset_reg_addr, sizeof(uint32_t), "REG_TLB");
-    EXPECT_EQ(static_cast<uint32_t>(deassert_val), risc_reset_val);
-}
+//     uint32_t soft_reset_reg_addr = 0xFFB121B0;
+//     uint32_t risc_reset_val;
+//     umd_cluster->read_from_device(&risc_reset_val, chip_core_coord, soft_reset_reg_addr, sizeof(uint32_t),
+//     "REG_TLB"); EXPECT_EQ(static_cast<uint32_t>(deassert_val), risc_reset_val);
+// }
 
 // // This tests puts a specific core into reset and then specifies an illegal deassert value
 // // It reads back the risc reset reg to validate that reset reg is in a legal state
-TEST(ApiChipTest, SpecifyIllegalDeassertRiscResetOnCore) {
-    std::unique_ptr<Cluster> umd_cluster = get_cluster();
+// TOOD issue#362
+// TEST(ApiChipTest, SpecifyIllegalDeassertRiscResetOnCore) {
+//     std::unique_ptr<Cluster> umd_cluster = get_cluster();
 
-    if (umd_cluster == nullptr || umd_cluster->get_all_chips_in_cluster().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
+//     if (umd_cluster == nullptr || umd_cluster->get_all_chips_in_cluster().empty()) {
+//         GTEST_SKIP() << "No chips present on the system. Skipping test.";
+//     }
 
-    tt_cxy_pair chip_core_coord = get_tensix_chip_core_coord(umd_cluster);
+//     tt_cxy_pair chip_core_coord = get_tensix_chip_core_coord(umd_cluster);
 
-    umd_cluster->assert_risc_reset_at_core(chip_core_coord);
+//     umd_cluster->assert_risc_reset_at_core(chip_core_coord);
 
-    TensixSoftResetOptions deassert_val = static_cast<TensixSoftResetOptions>(0xDEADBEEF);
-    umd_cluster->deassert_risc_reset_at_core(chip_core_coord, deassert_val);
-    umd_cluster->l1_membar(chip_core_coord.chip, "LARGE_WRITE_TLB");
+//     TensixSoftResetOptions deassert_val = static_cast<TensixSoftResetOptions>(0xDEADBEEF);
+//     umd_cluster->deassert_risc_reset_at_core(chip_core_coord, deassert_val);
+//     umd_cluster->l1_membar(chip_core_coord.chip, "LARGE_WRITE_TLB");
 
-    uint32_t soft_reset_reg_addr = 0xFFB121B0;
-    uint32_t risc_reset_val;
-    umd_cluster->read_from_device(&risc_reset_val, chip_core_coord, soft_reset_reg_addr, sizeof(uint32_t), "REG_TLB");
-    uint32_t expected_deassert_val = static_cast<uint32_t>(deassert_val & ALL_TENSIX_SOFT_RESET);
-    EXPECT_EQ(risc_reset_val, expected_deassert_val);
-}
+//     uint32_t soft_reset_reg_addr = 0xFFB121B0;
+//     uint32_t risc_reset_val;
+//     umd_cluster->read_from_device(&risc_reset_val, chip_core_coord, soft_reset_reg_addr, sizeof(uint32_t),
+//     "REG_TLB"); uint32_t expected_deassert_val = static_cast<uint32_t>(deassert_val & ALL_TENSIX_SOFT_RESET);
+//     EXPECT_EQ(risc_reset_val, expected_deassert_val);
+// }


### PR DESCRIPTION
### Issue
Related to #362 #363 #364 

### Description
These tests have been intermittently failing on tt_metal CI and UMD CI. See linked issues for more information

### List of the changes
- Comment out the tests and leave issue numbers in code.

### Testing
No testing

### API Changes
There are no API changes in this PR.
