### PR TITLE
Harvesting mask NOC layout

### DIFF
--- a/device/api/umd/device/blackhole_implementation.h
+++ b/device/api/umd/device/blackhole_implementation.h
@@ -122,7 +122,8 @@ static const std::vector<tt_xy_pair> ETH_LOCATIONS = ETH_CORES;
 // Return to std::array instead of std::vector once we get std::span support in C++20
 static const std::vector<uint32_t> T6_X_LOCATIONS = {1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13, 14, 15, 16};
 static const std::vector<uint32_t> T6_Y_LOCATIONS = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
-static const std::vector<uint32_t> HARVESTING_NOC_LOCATIONS = {};
+static const std::vector<uint32_t> HARVESTING_NOC_LOCATIONS = {1, 16, 2, 15, 3, 14, 4, 13, 5, 12, 6, 11, 7, 10};
+static const std::vector<uint32_t> LOGICAL_HARVESTING_LAYOUT = {0, 2, 4, 6, 8, 10, 12, 13, 11, 9, 7, 5, 3, 1};
 
 static constexpr uint32_t STATIC_TLB_SIZE = 1024 * 1024;  // TODO: Copied from wormhole. Need to verify.
 

--- a/device/api/umd/device/coordinate_manager.h
+++ b/device/api/umd/device/coordinate_manager.h
@@ -44,11 +44,22 @@ public:
 
     virtual ~CoordinateManager() = default;
 
+    size_t get_tensix_harvesting_mask() const;
+
+    size_t get_dram_harvesting_mask() const;
+
 private:
     static void assert_create_coordinate_manager(
         const tt::ARCH arch, const size_t tensix_harvesting_mask, const size_t dram_harvesting_mask);
 
 protected:
+    /*
+     * Constructor for Coordinate Manager.
+     * Tensix harvesting mask is supposed to be passed as original harvesting mask that is
+     * returned from create-ethernet-map, so each bit is responsible for one row of the actual physical
+     * row of the tensix cores on the chip. Harvesting mask is shuffled in constructor to match the NOC
+     * layout of the tensix cores.
+     */
     CoordinateManager(
         const tt_xy_pair& tensix_grid_size,
         const std::vector<tt_xy_pair>& tensix_cores,
@@ -64,6 +75,8 @@ protected:
         const std::vector<tt_xy_pair>& pcie_cores);
 
     void initialize();
+
+    virtual void shuffle_tensix_harvesting_mask(const std::vector<uint32_t>& harvesting_locations);
 
     virtual void translate_tensix_coords();
     virtual void translate_dram_coords();
@@ -124,6 +137,7 @@ protected:
     const tt_xy_pair tensix_grid_size;
     const std::vector<tt_xy_pair>& tensix_cores;
     size_t tensix_harvesting_mask;
+    const size_t physical_layout_tensix_harvesting_mask;
 
     const tt_xy_pair dram_grid_size;
     const std::vector<tt_xy_pair>& dram_cores;

--- a/device/api/umd/device/grayskull_implementation.h
+++ b/device/api/umd/device/grayskull_implementation.h
@@ -140,6 +140,7 @@ static const std::array<xy_pair, 0> ETH_LOCATIONS = {};
 static const std::vector<uint32_t> T6_X_LOCATIONS = {12, 1, 11, 2, 10, 3, 9, 4, 8, 5, 7, 6};
 static const std::vector<uint32_t> T6_Y_LOCATIONS = {11, 1, 10, 2, 9, 3, 8, 4, 7, 5};
 static const std::vector<uint32_t> HARVESTING_NOC_LOCATIONS = {5, 7, 4, 8, 3, 9, 2, 10, 1, 11};
+static const std::vector<uint32_t> LOGICAL_HARVESTING_LAYOUT = {8, 6, 4, 2, 0, 1, 3, 5, 7, 9};
 
 static constexpr uint32_t STATIC_TLB_SIZE = 1024 * 1024;
 

--- a/device/api/umd/device/wormhole_implementation.h
+++ b/device/api/umd/device/wormhole_implementation.h
@@ -166,6 +166,7 @@ static const std::vector<tt_xy_pair> ETH_LOCATIONS = ETH_CORES;
 static const std::vector<uint32_t> T6_X_LOCATIONS = {1, 2, 3, 4, 6, 7, 8, 9};
 static const std::vector<uint32_t> T6_Y_LOCATIONS = {1, 2, 3, 4, 5, 7, 8, 9, 10, 11};
 static const std::vector<uint32_t> HARVESTING_NOC_LOCATIONS = {11, 1, 10, 2, 9, 3, 8, 4, 7, 5};
+static const std::vector<uint32_t> LOGICAL_HARVESTING_LAYOUT = {1, 3, 5, 7, 9, 8, 6, 4, 2, 0};
 
 static constexpr uint32_t STATIC_TLB_SIZE = 1024 * 1024;
 

--- a/device/blackhole/blackhole_coordinate_manager.cpp
+++ b/device/blackhole/blackhole_coordinate_manager.cpp
@@ -33,6 +33,7 @@ BlackholeCoordinateManager::BlackholeCoordinateManager(
         arc_cores,
         pcie_grid_size,
         pcie_cores) {
+    this->shuffle_tensix_harvesting_mask(blackhole::HARVESTING_NOC_LOCATIONS);
     initialize();
 }
 

--- a/device/grayskull/grayskull_coordinate_manager.cpp
+++ b/device/grayskull/grayskull_coordinate_manager.cpp
@@ -33,6 +33,7 @@ GrayskullCoordinateManager::GrayskullCoordinateManager(
         arc_cores,
         pcie_grid_size,
         pcie_cores) {
+    this->shuffle_tensix_harvesting_mask(grayskull::HARVESTING_NOC_LOCATIONS);
     initialize();
 }
 

--- a/device/wormhole/wormhole_coordinate_manager.cpp
+++ b/device/wormhole/wormhole_coordinate_manager.cpp
@@ -33,6 +33,7 @@ WormholeCoordinateManager::WormholeCoordinateManager(
         arc_cores,
         pcie_grid_size,
         pcie_cores) {
+    this->shuffle_tensix_harvesting_mask(wormhole::HARVESTING_NOC_LOCATIONS);
     initialize();
 }
 


### PR DESCRIPTION
### Issue
/ 

### Description

Harvesting mask targets tensix rows based on the physical chip layout. So far I have assumed it is NOC layout. This PR is fixing that.

### List of the changes

- Impement shuffling of harvesting mask bits to be be in sync with NOC layout in all cordinate managers 

### Testing

Unit tests.

### API Changes

No API changes
