### PR TITLE
Fix flatc tt_metal build 

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -75,8 +75,6 @@ function(fetch_dependencies)
             "FLATBUFFERS_STRICT_MODE ON"
     )
 
-    set(FLATC_EXE ${flatbuffers_BINARY_DIR}/flatc PARENT_SCOPE)
-
     ###################################################################################################################
     # libuv (for process management)
     ###################################################################################################################

--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -7,7 +7,7 @@ add_custom_command(
     OUTPUT
         ${FBS_GENERATED_HEADER}
     COMMAND
-        ${FLATC_EXE}
+        flatc
     ARGS
         --cpp -o "${CMAKE_CURRENT_BINARY_DIR}/" ${FBS_FILE}
     DEPENDS


### PR DESCRIPTION
### Issue
Fix issue after #358 

### Description
This change creates problems on clang-tidy run on tt_metal.

### List of the changes
- Reverted part of change from referenced PR

### Testing
Both bellow branches and runs have detect_arch commit reverted on UMD, and have "don't run clang-tidy" commit reverted on tt_metal
All post commit run on tt_metal prior to change: https://github.com/tenstorrent/tt-metal/actions/runs/12177536236
All post commit run on tt_metal after change:  https://github.com/tenstorrent/tt-metal/actions/runs/12177582506

### API Changes
There are no API changes in this PR.

Note that "build client" job failure is expected due to this PR not being checked in: https://github.com/tenstorrent/tt-metal/pull/15564
