### PR TITLE
Coordinate manager maps redesign

### DIFF
--- a/device/api/umd/device/blackhole_coordinate_manager.h
+++ b/device/api/umd/device/blackhole_coordinate_manager.h
@@ -29,10 +29,10 @@ protected:
     void translate_dram_coords() override;
     void translate_tensix_coords() override;
 
-    void fill_tensix_logical_to_translated() override;
-    void fill_eth_logical_to_translated() override;
-    void fill_pcie_logical_to_translated() override;
-    void fill_dram_logical_to_translated() override;
+    void fill_tensix_physical_translated_mapping() override;
+    void fill_eth_physical_translated_mapping() override;
+    void fill_pcie_physical_translated_mapping() override;
+    void fill_dram_physical_translated_mapping() override;
 
 private:
     void map_column_of_dram_banks(const size_t start_bank, const size_t end_bank, const size_t x_coord);

--- a/device/api/umd/device/coordinate_manager.h
+++ b/device/api/umd/device/coordinate_manager.h
@@ -63,6 +63,8 @@ protected:
         const tt_xy_pair& pcie_grid_size,
         const std::vector<tt_xy_pair>& pcie_cores);
 
+    void initialize();
+
     virtual void translate_tensix_coords();
     virtual void translate_dram_coords();
     virtual void translate_eth_coords();
@@ -136,3 +138,5 @@ protected:
     const tt_xy_pair pcie_grid_size;
     const std::vector<tt_xy_pair>& pcie_cores;
 };
+
+// friend

--- a/device/api/umd/device/coordinate_manager.h
+++ b/device/api/umd/device/coordinate_manager.h
@@ -16,20 +16,6 @@
 
 class CoordinateManager {
 public:
-    CoordinateManager(
-        const tt_xy_pair& tensix_grid_size,
-        const std::vector<tt_xy_pair>& tensix_cores,
-        const size_t tensix_harvesting_mask,
-        const tt_xy_pair& dram_grid_size,
-        const std::vector<tt_xy_pair>& dram_cores,
-        const size_t dram_harvesting_mask,
-        const tt_xy_pair& eth_grid_size,
-        const std::vector<tt_xy_pair>& eth_cores,
-        const tt_xy_pair& arc_grid_size,
-        const std::vector<tt_xy_pair>& arc_cores,
-        const tt_xy_pair& pcie_grid_size,
-        const std::vector<tt_xy_pair>& pcie_cores);
-
     static std::shared_ptr<CoordinateManager> create_coordinate_manager(
         tt::ARCH arch,
         const tt_xy_pair& tensix_grid_size,
@@ -59,20 +45,32 @@ public:
     virtual ~CoordinateManager() = default;
 
 private:
-    tt::umd::CoreCoord to_physical(const tt::umd::CoreCoord core_coord);
-    tt::umd::CoreCoord to_logical(const tt::umd::CoreCoord core_coord);
-    tt::umd::CoreCoord to_virtual(const tt::umd::CoreCoord core_coord);
-    tt::umd::CoreCoord to_translated(const tt::umd::CoreCoord core_coord);
-
     static void assert_create_coordinate_manager(
         const tt::ARCH arch, const size_t tensix_harvesting_mask, const size_t dram_harvesting_mask);
 
 protected:
+    CoordinateManager(
+        const tt_xy_pair& tensix_grid_size,
+        const std::vector<tt_xy_pair>& tensix_cores,
+        const size_t tensix_harvesting_mask,
+        const tt_xy_pair& dram_grid_size,
+        const std::vector<tt_xy_pair>& dram_cores,
+        const size_t dram_harvesting_mask,
+        const tt_xy_pair& eth_grid_size,
+        const std::vector<tt_xy_pair>& eth_cores,
+        const tt_xy_pair& arc_grid_size,
+        const std::vector<tt_xy_pair>& arc_cores,
+        const tt_xy_pair& pcie_grid_size,
+        const std::vector<tt_xy_pair>& pcie_cores);
+
     virtual void translate_tensix_coords();
     virtual void translate_dram_coords();
     virtual void translate_eth_coords();
     virtual void translate_arc_coords();
     virtual void translate_pcie_coords();
+
+    void identity_map_physical_cores();
+    void add_core_translation(const tt::umd::CoreCoord& core_coord, const tt_xy_pair& physical_pair);
 
     /*
      * Fills the logical to translated mapping for the tensix cores.
@@ -81,90 +79,45 @@ protected:
      * should override this method. Wormhole and Blackhole coordinate managers
      * override this method to implement different mapping.
      */
-    virtual void fill_tensix_logical_to_translated();
+    virtual void fill_tensix_physical_translated_mapping();
 
     /*
-     * Fills the logical to translated mapping for the ethernet cores.
+     * Fills the physical to translated mapping for the ethernet cores.
      * By default, translated coordinates are the same as physical coordinates.
      * Derived coordinate managers that need to implement different mapping
      * should override this method. Wormhole and Blackhole coordinate managers
      * override this method to implement different mapping.
      */
-    virtual void fill_eth_logical_to_translated();
+    virtual void fill_eth_physical_translated_mapping();
 
     /*
-     * Fills the logical to translated mapping for the DRAM cores.
+     * Fills the physical to translated mapping for the DRAM cores.
      * By default, translated coordinates are the same as physical coordinates.
      * Derived coordinate managers that need to implement different mapping
      * should override this method. Blackhole coordinate manager overrides
      * this method to implement different mapping.
      */
-    virtual void fill_dram_logical_to_translated();
+    virtual void fill_dram_physical_translated_mapping();
 
     /*
-     * Fills the logical to translated mapping for the PCIE cores.
+     * Fills the physical to translated mapping for the PCIE cores.
      * By default, translated coordinates are the same as physical coordinates.
      * Derived coordinate managers that need to implement different mapping
      * should override this method. Blackhole coordinate manager overrides
      * this method to implement different mapping.
      */
-    virtual void fill_pcie_logical_to_translated();
+    virtual void fill_pcie_physical_translated_mapping();
 
     /*
-     * Fills the logical to translated mapping for the ARC cores.
+     * Fills the physical to translated mapping for the ARC cores.
      * By default, translated coordinates are the same as physical coordinates.
      * Derived coordinate managers that need to implement different mapping
      * should override this method.
      */
-    virtual void fill_arc_logical_to_translated();
+    virtual void fill_arc_physical_translated_mapping();
 
-    std::map<tt_xy_pair, tt::umd::CoreCoord> tensix_logical_to_translated;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> tensix_logical_to_virtual;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> tensix_logical_to_physical;
-
-    std::map<tt_xy_pair, tt::umd::CoreCoord> tensix_physical_to_logical;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> tensix_virtual_to_logical;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> tensix_translated_to_logical;
-
-    std::map<tt_xy_pair, tt::umd::CoreCoord> dram_logical_to_translated;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> dram_logical_to_virtual;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> dram_logical_to_physical;
-
-    std::map<tt_xy_pair, tt::umd::CoreCoord> dram_physical_to_logical;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> dram_virtual_to_logical;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> dram_translated_to_logical;
-
-    std::map<tt_xy_pair, tt::umd::CoreCoord> eth_logical_to_translated;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> eth_logical_to_virtual;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> eth_logical_to_physical;
-
-    std::map<tt_xy_pair, tt::umd::CoreCoord> eth_physical_to_logical;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> eth_virtual_to_logical;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> eth_translated_to_logical;
-
-    std::map<tt_xy_pair, tt::umd::CoreCoord> arc_logical_to_translated;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> arc_logical_to_virtual;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> arc_logical_to_physical;
-
-    std::map<tt_xy_pair, tt::umd::CoreCoord> arc_physical_to_logical;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> arc_virtual_to_logical;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> arc_translated_to_logical;
-
-    std::map<tt_xy_pair, tt::umd::CoreCoord> pcie_logical_to_translated;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> pcie_logical_to_virtual;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> pcie_logical_to_physical;
-
-    std::map<tt_xy_pair, tt::umd::CoreCoord> pcie_physical_to_logical;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> pcie_virtual_to_logical;
-    std::map<tt_xy_pair, tt::umd::CoreCoord> pcie_translated_to_logical;
-
-    std::map<tt_xy_pair, tt::umd::CoreCoord>& get_logical_to_translated(CoreType core_type);
-    std::map<tt_xy_pair, tt::umd::CoreCoord>& get_logical_to_virtual(CoreType core_type);
-    std::map<tt_xy_pair, tt::umd::CoreCoord>& get_logical_to_physical(CoreType core_type);
-
-    std::map<tt_xy_pair, tt::umd::CoreCoord>& get_physical_to_logical(CoreType core_type);
-    std::map<tt_xy_pair, tt::umd::CoreCoord>& get_virtual_to_logical(CoreType core_type);
-    std::map<tt_xy_pair, tt::umd::CoreCoord>& get_translated_to_logical(CoreType core_type);
+    std::map<tt::umd::CoreCoord, tt_xy_pair> to_physical_map;
+    std::map<std::pair<tt_xy_pair, CoordSystem>, tt::umd::CoreCoord> from_physical_map;
 
     const tt_xy_pair tensix_grid_size;
     const std::vector<tt_xy_pair>& tensix_cores;

--- a/device/api/umd/device/grayskull_coordinate_manager.h
+++ b/device/api/umd/device/grayskull_coordinate_manager.h
@@ -26,5 +26,5 @@ public:
         const std::vector<tt_xy_pair>& pcie_cores);
 
 protected:
-    void fill_eth_logical_to_translated() override;
+    void fill_eth_physical_translated_mapping() override;
 };

--- a/device/api/umd/device/tt_core_coordinates.h
+++ b/device/api/umd/device/tt_core_coordinates.h
@@ -58,6 +58,28 @@ struct CoreCoord : public tt_xy_pair {
         return this->x == other.x && this->y == other.y && this->core_type == other.core_type &&
                this->coord_system == other.coord_system;
     }
+
+    bool operator<(const CoreCoord& o) const {
+        if (x < o.x) {
+            return true;
+        }
+        if (x > o.x) {
+            return false;
+        }
+        if (y < o.y) {
+            return true;
+        }
+        if (y > o.y) {
+            return false;
+        }
+        if (core_type < o.core_type) {
+            return true;
+        }
+        if (core_type > o.core_type) {
+            return false;
+        }
+        return coord_system < o.coord_system;
+    }
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/wormhole_coordinate_manager.h
+++ b/device/api/umd/device/wormhole_coordinate_manager.h
@@ -26,6 +26,6 @@ public:
         const std::vector<tt_xy_pair>& pcie_cores);
 
 protected:
-    void fill_tensix_logical_to_translated() override;
-    void fill_eth_logical_to_translated() override;
+    void fill_tensix_physical_translated_mapping() override;
+    void fill_eth_physical_translated_mapping() override;
 };

--- a/device/blackhole/blackhole_coordinate_manager.cpp
+++ b/device/blackhole/blackhole_coordinate_manager.cpp
@@ -33,6 +33,7 @@ BlackholeCoordinateManager::BlackholeCoordinateManager(
         arc_cores,
         pcie_grid_size,
         pcie_cores) {
+    this->identity_map_physical_cores();
     this->translate_tensix_coords();
     this->translate_dram_coords();
     this->translate_eth_coords();
@@ -41,103 +42,131 @@ BlackholeCoordinateManager::BlackholeCoordinateManager(
 }
 
 void BlackholeCoordinateManager::translate_tensix_coords() {
-    size_t num_harvested_x = __builtin_popcount(tensix_harvesting_mask);
+    size_t num_harvested_x = CoordinateManager::get_num_harvested(tensix_harvesting_mask);
     size_t grid_size_x = tensix_grid_size.x;
     size_t grid_size_y = tensix_grid_size.y;
 
     size_t logical_x = 0;
+    size_t x_index = grid_size_x - num_harvested_x;
     for (size_t x = 0; x < grid_size_x; x++) {
-        if (!(tensix_harvesting_mask & (1 << x))) {
+        if (tensix_harvesting_mask & (1 << x)) {
+            size_t y_index = 0;
+            for (size_t y = 0; y < grid_size_y; y++) {
+                const tt_xy_pair& physical_core = tensix_cores[x + y * grid_size_x];
+                const tt_xy_pair& virtual_core = tensix_cores[x_index + y_index * grid_size_x];
+
+                CoreCoord virtual_coord =
+                    CoreCoord(virtual_core.x, virtual_core.y, CoreType::TENSIX, CoordSystem::VIRTUAL);
+
+                add_core_translation(virtual_coord, physical_core);
+
+                y_index++;
+            }
+            x_index++;
+        } else {
             for (size_t y = 0; y < grid_size_y; y++) {
                 const tt_xy_pair& tensix_core = tensix_cores[x + y * grid_size_x];
-                tensix_logical_to_physical[{logical_x, y}] =
-                    CoreCoord(tensix_core.x, tensix_core.y, CoreType::TENSIX, CoordSystem::PHYSICAL);
-                tensix_physical_to_logical[tensix_core] =
-                    CoreCoord(logical_x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
+                const tt_xy_pair& virtual_core = tensix_cores[logical_x + y * grid_size_x];
+
+                CoreCoord logical_coord = CoreCoord(logical_x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
+                add_core_translation(logical_coord, tensix_core);
+
+                CoreCoord virtual_coord =
+                    CoreCoord(virtual_core.x, virtual_core.y, CoreType::TENSIX, CoordSystem::VIRTUAL);
+                add_core_translation(virtual_coord, tensix_core);
             }
             logical_x++;
         }
     }
 
-    for (size_t x = 0; x < grid_size_x - num_harvested_x; x++) {
-        for (size_t y = 0; y < grid_size_y; y++) {
-            const tt_xy_pair& tensix_core = tensix_cores[x + y * grid_size_x];
-            tensix_logical_to_virtual[{x, y}] =
-                CoreCoord(tensix_core.x, tensix_core.y, CoreType::TENSIX, CoordSystem::VIRTUAL);
-            tensix_virtual_to_logical[tensix_core] = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-        }
-    }
-
-    fill_tensix_logical_to_translated();
+    fill_tensix_physical_translated_mapping();
 }
 
-void BlackholeCoordinateManager::fill_tensix_logical_to_translated() {
-    const size_t num_harvested_x = __builtin_popcount(tensix_harvesting_mask);
-    const size_t grid_size_x = tensix_grid_size.x;
-    const size_t grid_size_y = tensix_grid_size.y;
+void BlackholeCoordinateManager::fill_tensix_physical_translated_mapping() {
+    for (const tt_xy_pair& physical_core : tensix_cores) {
+        const CoreCoord virtual_coord = from_physical_map.at({physical_core, CoordSystem::VIRTUAL});
+        const CoreCoord translated_coord =
+            CoreCoord(virtual_coord.x, virtual_coord.y, CoreType::TENSIX, CoordSystem::TRANSLATED);
 
-    for (size_t x = 0; x < grid_size_x - num_harvested_x; x++) {
-        for (size_t y = 0; y < grid_size_y; y++) {
-            const CoreCoord virtual_coord = tensix_logical_to_virtual[{x, y}];
-            const size_t translated_x = virtual_coord.x;
-            const size_t translated_y = virtual_coord.y;
-            tensix_logical_to_translated[{x, y}] =
-                CoreCoord(translated_x, translated_y, CoreType::TENSIX, CoordSystem::TRANSLATED);
-            tensix_translated_to_logical[{translated_x, translated_y}] =
-                CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-        }
+        add_core_translation(translated_coord, physical_core);
     }
 }
 
 void BlackholeCoordinateManager::translate_dram_coords() {
-    size_t num_harvested_banks = __builtin_popcount(dram_harvesting_mask);
-
-    for (size_t x = 0; x < dram_grid_size.x - num_harvested_banks; x++) {
-        for (size_t y = 0; y < dram_grid_size.y; y++) {
-            const tt_xy_pair& dram_core = dram_cores[x * dram_grid_size.y + y];
-            dram_logical_to_virtual[{x, y}] = CoreCoord(dram_core.x, dram_core.y, CoreType::DRAM, CoordSystem::VIRTUAL);
-            dram_virtual_to_logical[dram_core] = CoreCoord(x, y, CoreType::DRAM, CoordSystem::LOGICAL);
-        }
-    }
+    size_t num_harvested_banks = CoordinateManager::get_num_harvested(dram_harvesting_mask);
 
     size_t logical_x = 0;
     for (size_t x = 0; x < dram_grid_size.x; x++) {
         if (!(dram_harvesting_mask & (1 << x))) {
             for (size_t y = 0; y < dram_grid_size.y; y++) {
                 const tt_xy_pair& dram_core = dram_cores[x * dram_grid_size.y + y];
-                dram_logical_to_physical[{logical_x, y}] =
-                    CoreCoord(dram_core.x, dram_core.y, CoreType::DRAM, CoordSystem::PHYSICAL);
-                dram_physical_to_logical[dram_core] = CoreCoord(logical_x, y, CoreType::DRAM, CoordSystem::LOGICAL);
+
+                CoreCoord logical_coord = CoreCoord(logical_x, y, CoreType::DRAM, CoordSystem::LOGICAL);
+
+                add_core_translation(logical_coord, dram_core);
             }
             logical_x++;
         }
     }
 
-    fill_dram_logical_to_translated();
+    for (size_t x = 0; x < dram_grid_size.x - num_harvested_banks; x++) {
+        for (size_t y = 0; y < dram_grid_size.y; y++) {
+            const tt_xy_pair& dram_core = dram_cores[x * dram_grid_size.y + y];
+            CoreCoord dram_logical = CoreCoord(x, y, CoreType::DRAM, CoordSystem::LOGICAL);
+            CoreCoord dram_virtual = CoreCoord(dram_core.x, dram_core.y, CoreType::DRAM, CoordSystem::VIRTUAL);
+
+            const tt_xy_pair physical_pair = to_physical_map[dram_logical];
+
+            add_core_translation(dram_virtual, physical_pair);
+        }
+    }
+
+    size_t harvested_index = (dram_grid_size.x - num_harvested_banks) * dram_grid_size.y;
+    for (size_t x = 0; x < dram_grid_size.x; x++) {
+        if (dram_harvesting_mask & (1 << x)) {
+            for (size_t y = 0; y < dram_grid_size.y; y++) {
+                const tt_xy_pair& dram_core = dram_cores[x * dram_grid_size.y + y];
+                const tt_xy_pair& virtual_core = dram_cores[harvested_index++];
+
+                CoreCoord virtual_coord =
+                    CoreCoord(virtual_core.x, virtual_core.y, CoreType::DRAM, CoordSystem::VIRTUAL);
+
+                add_core_translation(virtual_coord, dram_core);
+            }
+        }
+    }
+
+    fill_dram_physical_translated_mapping();
 }
 
-void BlackholeCoordinateManager::fill_eth_logical_to_translated() {
+void BlackholeCoordinateManager::fill_eth_physical_translated_mapping() {
     for (size_t x = 0; x < eth_grid_size.x; x++) {
         for (size_t y = 0; y < eth_grid_size.y; y++) {
             const size_t translated_x = x + blackhole::eth_translated_coordinate_start_x;
             const size_t translated_y = y + blackhole::eth_translated_coordinate_start_y;
-            eth_logical_to_translated[{x, y}] =
-                CoreCoord(translated_x, translated_y, CoreType::ETH, CoordSystem::TRANSLATED);
-            eth_translated_to_logical[{translated_x, translated_y}] =
-                CoreCoord(x, y, CoreType::ETH, CoordSystem::LOGICAL);
+
+            CoreCoord logical_coord = CoreCoord(x, y, CoreType::ETH, CoordSystem::LOGICAL);
+            const tt_xy_pair physical_pair = to_physical_map[logical_coord];
+
+            CoreCoord translated_coord = CoreCoord(translated_x, translated_y, CoreType::ETH, CoordSystem::TRANSLATED);
+
+            add_core_translation(translated_coord, physical_pair);
         }
     }
 }
 
-void BlackholeCoordinateManager::fill_pcie_logical_to_translated() {
-    pcie_logical_to_translated[{0, 0}] = CoreCoord(
+void BlackholeCoordinateManager::fill_pcie_physical_translated_mapping() {
+    CoreCoord logical_coord = CoreCoord(0, 0, CoreType::PCIE, CoordSystem::LOGICAL);
+
+    const tt_xy_pair physical_pair = to_physical_map[logical_coord];
+
+    CoreCoord translated_coord = CoreCoord(
         blackhole::pcie_translated_coordinate_start_x,
         blackhole::pcie_translated_coordinate_start_y,
         CoreType::PCIE,
         CoordSystem::TRANSLATED);
-    pcie_translated_to_logical[{
-        blackhole::pcie_translated_coordinate_start_x, blackhole::pcie_translated_coordinate_start_y}] =
-        CoreCoord(0, 0, CoreType::PCIE, CoordSystem::LOGICAL);
+
+    add_core_translation(translated_coord, physical_pair);
 }
 
 void BlackholeCoordinateManager::map_column_of_dram_banks(
@@ -145,16 +174,19 @@ void BlackholeCoordinateManager::map_column_of_dram_banks(
     size_t translated_y = blackhole::dram_translated_coordinate_start_y;
     for (size_t bank = start_bank; bank < end_bank; bank++) {
         for (size_t port = 0; port < blackhole::NUM_NOC_PORTS_PER_DRAM_BANK; port++) {
-            dram_logical_to_translated[{bank, port}] =
-                CoreCoord(x_coord, translated_y, CoreType::DRAM, CoordSystem::TRANSLATED);
-            dram_translated_to_logical[{x_coord, translated_y}] =
-                CoreCoord(bank, port, CoreType::DRAM, CoordSystem::LOGICAL);
+            CoreCoord logical_coord = CoreCoord(bank, port, CoreType::DRAM, CoordSystem::LOGICAL);
+            const tt_xy_pair physical_pair = to_physical_map[logical_coord];
+
+            CoreCoord translated_coord = CoreCoord(x_coord, translated_y, CoreType::DRAM, CoordSystem::TRANSLATED);
+
+            add_core_translation(translated_coord, physical_pair);
+
             translated_y++;
         }
     }
 }
 
-void BlackholeCoordinateManager::fill_dram_logical_to_translated() {
+void BlackholeCoordinateManager::fill_dram_physical_translated_mapping() {
     const std::vector<size_t> harvested_banks = CoordinateManager::get_harvested_indices(dram_harvesting_mask);
 
     if (harvested_banks.empty()) {
@@ -183,5 +215,29 @@ void BlackholeCoordinateManager::fill_dram_logical_to_translated() {
             blackhole::NUM_DRAM_BANKS / 2,
             blackhole::NUM_DRAM_BANKS - 1,
             blackhole::dram_translated_coordinate_start_x + 1);
+    }
+
+    const size_t virtual_index = (dram_grid_size.x - 1) * dram_grid_size.y;
+    const size_t physical_index = harvested_bank * dram_grid_size.y;
+
+    const size_t harvested_bank_translated_x = blackhole::dram_translated_coordinate_start_x + 1;
+    const size_t harvested_bank_translated_y =
+        blackhole::dram_translated_coordinate_start_y + (dram_grid_size.x / 2 - 1) * dram_grid_size.y;
+
+    for (size_t noc_port = 0; noc_port < dram_grid_size.y; noc_port++) {
+        const tt_xy_pair& physical_core = dram_cores[physical_index + noc_port];
+        const tt_xy_pair& virtual_core = dram_cores[virtual_index + noc_port];
+
+        CoreCoord virtual_coord = CoreCoord(virtual_core.x, virtual_core.y, CoreType::DRAM, CoordSystem::VIRTUAL);
+
+        add_core_translation(virtual_coord, physical_core);
+
+        CoreCoord translated_coord = CoreCoord(
+            harvested_bank_translated_x,
+            harvested_bank_translated_y + noc_port,
+            CoreType::DRAM,
+            CoordSystem::TRANSLATED);
+
+        add_core_translation(translated_coord, physical_core);
     }
 }

--- a/device/blackhole/blackhole_coordinate_manager.cpp
+++ b/device/blackhole/blackhole_coordinate_manager.cpp
@@ -33,12 +33,7 @@ BlackholeCoordinateManager::BlackholeCoordinateManager(
         arc_cores,
         pcie_grid_size,
         pcie_cores) {
-    this->identity_map_physical_cores();
-    this->translate_tensix_coords();
-    this->translate_dram_coords();
-    this->translate_eth_coords();
-    this->translate_arc_coords();
-    this->translate_pcie_coords();
+    initialize();
 }
 
 void BlackholeCoordinateManager::translate_tensix_coords() {
@@ -50,17 +45,14 @@ void BlackholeCoordinateManager::translate_tensix_coords() {
     size_t x_index = grid_size_x - num_harvested_x;
     for (size_t x = 0; x < grid_size_x; x++) {
         if (tensix_harvesting_mask & (1 << x)) {
-            size_t y_index = 0;
             for (size_t y = 0; y < grid_size_y; y++) {
                 const tt_xy_pair& physical_core = tensix_cores[x + y * grid_size_x];
-                const tt_xy_pair& virtual_core = tensix_cores[x_index + y_index * grid_size_x];
+                const tt_xy_pair& virtual_core = tensix_cores[x_index + y * grid_size_x];
 
                 CoreCoord virtual_coord =
                     CoreCoord(virtual_core.x, virtual_core.y, CoreType::TENSIX, CoordSystem::VIRTUAL);
 
                 add_core_translation(virtual_coord, physical_core);
-
-                y_index++;
             }
             x_index++;
         } else {

--- a/device/coordinate_manager.cpp
+++ b/device/coordinate_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: (c) 2023 Tenstorrent Inc.
+ * SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -38,252 +38,109 @@ CoordinateManager::CoordinateManager(
     pcie_grid_size(pcie_grid_size),
     pcie_cores(pcie_cores) {}
 
-std::map<tt_xy_pair, CoreCoord>& CoordinateManager::get_logical_to_translated(CoreType core_type) {
-    switch (core_type) {
-        case CoreType::TENSIX:
-            return tensix_logical_to_translated;
-        case CoreType::DRAM:
-            return dram_logical_to_translated;
-        case CoreType::ACTIVE_ETH:
-        case CoreType::IDLE_ETH:
-        case CoreType::ETH:
-            return eth_logical_to_translated;
-        case CoreType::ARC:
-            return arc_logical_to_translated;
-        case CoreType::PCIE:
-            return pcie_logical_to_translated;
-        default:
-            throw std::runtime_error("Core type is not supported for getting logical to translated mapping");
-    }
+void CoordinateManager::add_core_translation(const CoreCoord& core_coord, const tt_xy_pair& physical_pair) {
+    to_physical_map.insert({core_coord, physical_pair});
+    from_physical_map.insert({{{physical_pair.x, physical_pair.y}, core_coord.coord_system}, core_coord});
 }
 
-std::map<tt_xy_pair, CoreCoord>& CoordinateManager::get_logical_to_virtual(CoreType core_type) {
-    switch (core_type) {
-        case CoreType::TENSIX:
-            return tensix_logical_to_virtual;
-        case CoreType::DRAM:
-            return dram_logical_to_virtual;
-        case CoreType::ACTIVE_ETH:
-        case CoreType::IDLE_ETH:
-        case CoreType::ETH:
-            return eth_logical_to_virtual;
-        case CoreType::ARC:
-            return arc_logical_to_virtual;
-        case CoreType::PCIE:
-            return pcie_logical_to_virtual;
-        default:
-            throw std::runtime_error("Core type is not supported for getting logical to virtual mapping");
+void CoordinateManager::identity_map_physical_cores() {
+    for (auto& core : tensix_cores) {
+        const CoreCoord core_coord = CoreCoord(core.x, core.y, CoreType::TENSIX, CoordSystem::PHYSICAL);
+        add_core_translation(core_coord, core);
     }
-}
 
-std::map<tt_xy_pair, CoreCoord>& CoordinateManager::get_logical_to_physical(CoreType core_type) {
-    switch (core_type) {
-        case CoreType::TENSIX:
-            return tensix_logical_to_physical;
-        case CoreType::DRAM:
-            return dram_logical_to_physical;
-        case CoreType::ACTIVE_ETH:
-        case CoreType::IDLE_ETH:
-        case CoreType::ETH:
-            return eth_logical_to_physical;
-        case CoreType::ARC:
-            return arc_logical_to_physical;
-        case CoreType::PCIE:
-            return pcie_logical_to_physical;
-        default:
-            throw std::runtime_error("Core type is not supported for getting logical to physical mapping");
+    for (auto& core : dram_cores) {
+        const CoreCoord core_coord = CoreCoord(core.x, core.y, CoreType::DRAM, CoordSystem::PHYSICAL);
+        add_core_translation(core_coord, core);
     }
-}
 
-std::map<tt_xy_pair, CoreCoord>& CoordinateManager::get_physical_to_logical(CoreType core_type) {
-    switch (core_type) {
-        case CoreType::TENSIX:
-            return tensix_physical_to_logical;
-        case CoreType::DRAM:
-            return dram_physical_to_logical;
-        case CoreType::ACTIVE_ETH:
-        case CoreType::IDLE_ETH:
-        case CoreType::ETH:
-            return eth_physical_to_logical;
-        case CoreType::ARC:
-            return arc_physical_to_logical;
-        case CoreType::PCIE:
-            return pcie_physical_to_logical;
-        default:
-            throw std::runtime_error("Core type is not supported for getting physical to logical mapping");
+    for (auto& core : eth_cores) {
+        const CoreCoord core_coord = CoreCoord(core.x, core.y, CoreType::ETH, CoordSystem::PHYSICAL);
+        add_core_translation(core_coord, core);
     }
-}
 
-std::map<tt_xy_pair, CoreCoord>& CoordinateManager::get_virtual_to_logical(CoreType core_type) {
-    switch (core_type) {
-        case CoreType::TENSIX:
-            return tensix_virtual_to_logical;
-        case CoreType::DRAM:
-            return dram_virtual_to_logical;
-        case CoreType::ACTIVE_ETH:
-        case CoreType::IDLE_ETH:
-        case CoreType::ETH:
-            return eth_virtual_to_logical;
-        case CoreType::ARC:
-            return arc_virtual_to_logical;
-        case CoreType::PCIE:
-            return pcie_virtual_to_logical;
-        default:
-            throw std::runtime_error("Core type is not supported for getting virtual to logical mapping");
+    for (auto& core : arc_cores) {
+        const CoreCoord core_coord = CoreCoord(core.x, core.y, CoreType::ARC, CoordSystem::PHYSICAL);
+        add_core_translation(core_coord, core);
     }
-}
 
-std::map<tt_xy_pair, CoreCoord>& CoordinateManager::get_translated_to_logical(CoreType core_type) {
-    switch (core_type) {
-        case CoreType::TENSIX:
-            return tensix_translated_to_logical;
-        case CoreType::DRAM:
-            return dram_translated_to_logical;
-        case CoreType::ACTIVE_ETH:
-        case CoreType::IDLE_ETH:
-        case CoreType::ETH:
-            return eth_translated_to_logical;
-        case CoreType::ARC:
-            return arc_translated_to_logical;
-        case CoreType::PCIE:
-            return pcie_translated_to_logical;
-        default:
-            throw std::runtime_error("Core type is not supported for getting translated to logical mapping");
-    }
-}
-
-CoreCoord CoordinateManager::to_physical(const CoreCoord core_coord) {
-    switch (core_coord.coord_system) {
-        case CoordSystem::PHYSICAL:
-            return core_coord;
-        case CoordSystem::VIRTUAL:
-        case CoordSystem::TRANSLATED:
-            return to_physical(to_logical(core_coord));
-        case CoordSystem::LOGICAL: {
-            auto& logical_mapping = get_logical_to_physical(core_coord.core_type);
-            return logical_mapping[{core_coord.x, core_coord.y}];
-        }
-        default:
-            throw std::runtime_error(
-                "Unexpected CoordSystem value " + std::to_string((uint8_t)core_coord.coord_system));
-    }
-}
-
-CoreCoord CoordinateManager::to_virtual(const CoreCoord core_coord) {
-    switch (core_coord.coord_system) {
-        case CoordSystem::TRANSLATED:
-        case CoordSystem::PHYSICAL:
-            return to_virtual(to_logical(core_coord));
-        case CoordSystem::VIRTUAL:
-            return core_coord;
-        case CoordSystem::LOGICAL: {
-            auto& logical_mapping = get_logical_to_virtual(core_coord.core_type);
-            return logical_mapping[{core_coord.x, core_coord.y}];
-        }
-        default:
-            throw std::runtime_error(
-                "Unexpected CoordSystem value " + std::to_string((uint8_t)core_coord.coord_system));
-    }
-}
-
-CoreCoord CoordinateManager::to_logical(const CoreCoord core_coord) {
-    switch (core_coord.coord_system) {
-        case CoordSystem::LOGICAL:
-            return core_coord;
-        case CoordSystem::PHYSICAL: {
-            auto& physical_mapping = get_physical_to_logical(core_coord.core_type);
-            return physical_mapping[{core_coord.x, core_coord.y}];
-        }
-        case CoordSystem::VIRTUAL: {
-            auto& virtual_mapping = get_virtual_to_logical(core_coord.core_type);
-            return virtual_mapping[{core_coord.x, core_coord.y}];
-        }
-        case CoordSystem::TRANSLATED: {
-            auto& translated_mapping = get_translated_to_logical(core_coord.core_type);
-            return translated_mapping[{core_coord.x, core_coord.y}];
-        }
-        default:
-            throw std::runtime_error(
-                "Unexpected CoordSystem value " + std::to_string((uint8_t)core_coord.coord_system));
-    }
-}
-
-CoreCoord CoordinateManager::to_translated(const CoreCoord core_coord) {
-    switch (core_coord.coord_system) {
-        case CoordSystem::PHYSICAL:
-        case CoordSystem::VIRTUAL:
-            return to_translated(to_logical(core_coord));
-        case CoordSystem::TRANSLATED:
-            return core_coord;
-        case CoordSystem::LOGICAL: {
-            auto& logical_mapping = get_logical_to_translated(core_coord.core_type);
-            return logical_mapping[{core_coord.x, core_coord.y}];
-        }
-        default:
-            throw std::runtime_error(
-                "Unexpected CoordSystem value " + std::to_string((uint8_t)core_coord.coord_system));
+    for (auto& core : pcie_cores) {
+        const CoreCoord core_coord = CoreCoord(core.x, core.y, CoreType::PCIE, CoordSystem::PHYSICAL);
+        add_core_translation(core_coord, core);
     }
 }
 
 CoreCoord CoordinateManager::to(const CoreCoord core_coord, const CoordSystem coord_system) {
-    switch (coord_system) {
-        case CoordSystem::LOGICAL:
-            return to_logical(core_coord);
-        case CoordSystem::PHYSICAL:
-            return to_physical(core_coord);
-        case CoordSystem::VIRTUAL:
-            return to_virtual(core_coord);
-        case CoordSystem::TRANSLATED:
-            return to_translated(core_coord);
-        default:
-            throw std::runtime_error(
-                "Unexpected CoordSystem value " + std::to_string((uint8_t)core_coord.coord_system));
-    }
+    return from_physical_map.at({to_physical_map.at(core_coord), coord_system});
 }
 
 void CoordinateManager::translate_tensix_coords() {
-    size_t num_harvested_y = __builtin_popcount(tensix_harvesting_mask);
+    size_t num_harvested_y = CoordinateManager::get_num_harvested(tensix_harvesting_mask);
     size_t grid_size_x = tensix_grid_size.x;
     size_t grid_size_y = tensix_grid_size.y;
 
     size_t logical_y = 0;
+    size_t harvested_index = (grid_size_y - num_harvested_y) * grid_size_x;
     for (size_t y = 0; y < grid_size_y; y++) {
-        if (!(tensix_harvesting_mask & (1 << y))) {
+        if (tensix_harvesting_mask & (1 << y)) {
+            for (size_t x = 0; x < grid_size_x; x++) {
+                const tt_xy_pair& physical_core = tensix_cores[y * grid_size_x + x];
+                const tt_xy_pair& virtual_core = tensix_cores[harvested_index++];
+
+                CoreCoord virtual_coord =
+                    CoreCoord(virtual_core.x, virtual_core.y, CoreType::TENSIX, CoordSystem::VIRTUAL);
+
+                add_core_translation(virtual_coord, physical_core);
+            }
+        } else {
             for (size_t x = 0; x < grid_size_x; x++) {
                 const tt_xy_pair& tensix_core = tensix_cores[y * grid_size_x + x];
-                tensix_logical_to_physical[{x, logical_y}] =
-                    CoreCoord(tensix_core.x, tensix_core.y, CoreType::TENSIX, CoordSystem::PHYSICAL);
-                tensix_physical_to_logical[tensix_core] =
-                    CoreCoord(x, logical_y, CoreType::TENSIX, CoordSystem::LOGICAL);
+                const tt_xy_pair& virtual_core = tensix_cores[logical_y * grid_size_x + x];
+
+                CoreCoord logical_coord = CoreCoord(x, logical_y, CoreType::TENSIX, CoordSystem::LOGICAL);
+                add_core_translation(logical_coord, tensix_core);
+
+                CoreCoord virtual_coord =
+                    CoreCoord(virtual_core.x, virtual_core.y, CoreType::TENSIX, CoordSystem::VIRTUAL);
+                add_core_translation(virtual_coord, tensix_core);
             }
             logical_y++;
         }
     }
 
-    for (size_t y = 0; y < grid_size_y - num_harvested_y; y++) {
-        for (size_t x = 0; x < grid_size_x; x++) {
-            const tt_xy_pair& tensix_core = tensix_cores[y * grid_size_x + x];
-            tensix_logical_to_virtual[{x, y}] =
-                CoreCoord(tensix_core.x, tensix_core.y, CoreType::TENSIX, CoordSystem::VIRTUAL);
-            tensix_virtual_to_logical[tensix_core] = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-        }
-    }
-
-    fill_tensix_logical_to_translated();
+    fill_tensix_physical_translated_mapping();
 }
 
-void CoordinateManager::fill_tensix_logical_to_translated() {
-    size_t num_harvested_y = __builtin_popcount(tensix_harvesting_mask);
+void CoordinateManager::fill_tensix_physical_translated_mapping() {
+    size_t num_harvested_y = CoordinateManager::get_num_harvested(tensix_harvesting_mask);
 
     for (size_t x = 0; x < tensix_grid_size.x; x++) {
         for (size_t y = 0; y < tensix_grid_size.y - num_harvested_y; y++) {
-            const CoreCoord physical_coord = tensix_logical_to_physical[{x, y}];
-            const size_t translated_x = physical_coord.x;
-            const size_t translated_y = physical_coord.y;
-            tensix_logical_to_translated[{x, y}] =
+            CoreCoord logical_coord = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
+            const tt_xy_pair physical_pair = to_physical_map[logical_coord];
+            const size_t translated_x = physical_pair.x;
+            const size_t translated_y = physical_pair.y;
+
+            CoreCoord translated_coord =
                 CoreCoord(translated_x, translated_y, CoreType::TENSIX, CoordSystem::TRANSLATED);
-            tensix_translated_to_logical[tt_xy_pair(translated_x, translated_y)] =
-                CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
+
+            add_core_translation(translated_coord, physical_pair);
+        }
+    }
+
+    size_t harvested_index = (tensix_grid_size.y - num_harvested_y) * tensix_grid_size.x;
+    for (size_t y = 0; y < tensix_grid_size.y; y++) {
+        if (tensix_harvesting_mask & (1 << y)) {
+            for (size_t x = 0; x < tensix_grid_size.x; x++) {
+                const tt_xy_pair& physical_core = tensix_cores[y * tensix_grid_size.x + x];
+                const size_t translated_x = physical_core.x;
+                const size_t translated_y = physical_core.y;
+
+                CoreCoord translated_coord =
+                    CoreCoord(translated_x, translated_y, CoreType::TENSIX, CoordSystem::TRANSLATED);
+
+                add_core_translation(translated_coord, physical_core);
+            }
         }
     }
 }
@@ -292,120 +149,121 @@ void CoordinateManager::translate_dram_coords() {
     for (size_t x = 0; x < dram_grid_size.x; x++) {
         for (size_t y = 0; y < dram_grid_size.y; y++) {
             const tt_xy_pair dram_core = dram_cores[x * dram_grid_size.y + y];
-            dram_logical_to_virtual[{x, y}] = CoreCoord(dram_core.x, dram_core.y, CoreType::DRAM, CoordSystem::VIRTUAL);
-            dram_virtual_to_logical[dram_core] = CoreCoord(x, y, CoreType::DRAM, CoordSystem::LOGICAL);
 
-            dram_logical_to_physical[{x, y}] =
-                CoreCoord(dram_core.x, dram_core.y, CoreType::DRAM, CoordSystem::PHYSICAL);
-            dram_physical_to_logical[dram_core] = CoreCoord(x, y, CoreType::DRAM, CoordSystem::LOGICAL);
+            CoreCoord logical_coord = CoreCoord(x, y, CoreType::DRAM, CoordSystem::LOGICAL);
+            CoreCoord virtual_coord = CoreCoord(dram_core.x, dram_core.y, CoreType::DRAM, CoordSystem::VIRTUAL);
+
+            add_core_translation(logical_coord, dram_core);
+            add_core_translation(virtual_coord, dram_core);
         }
     }
 
-    fill_dram_logical_to_translated();
+    fill_dram_physical_translated_mapping();
 }
 
 void CoordinateManager::translate_eth_coords() {
     for (size_t x = 0; x < eth_grid_size.x; x++) {
         for (size_t y = 0; y < eth_grid_size.y; y++) {
             const tt_xy_pair eth_core = eth_cores[x * eth_grid_size.y + y];
-            eth_logical_to_virtual[{x, y}] = CoreCoord(eth_core.x, eth_core.y, CoreType::ETH, CoordSystem::VIRTUAL);
-            eth_virtual_to_logical[eth_core] = CoreCoord(x, y, CoreType::ETH, CoordSystem::LOGICAL);
 
-            eth_logical_to_physical[{x, y}] = CoreCoord(eth_core.x, eth_core.y, CoreType::ETH, CoordSystem::PHYSICAL);
-            eth_physical_to_logical[eth_core] = CoreCoord(x, y, CoreType::ETH, CoordSystem::LOGICAL);
+            CoreCoord logical_coord = CoreCoord(x, y, CoreType::ETH, CoordSystem::LOGICAL);
+            CoreCoord virtual_coord = CoreCoord(eth_core.x, eth_core.y, CoreType::ETH, CoordSystem::VIRTUAL);
+
+            add_core_translation(logical_coord, eth_core);
+            add_core_translation(virtual_coord, eth_core);
         }
     }
 
-    fill_eth_logical_to_translated();
+    fill_eth_physical_translated_mapping();
 }
 
 void CoordinateManager::translate_arc_coords() {
     for (size_t x = 0; x < arc_grid_size.x; x++) {
         for (size_t y = 0; y < arc_grid_size.y; y++) {
             const tt_xy_pair arc_core = arc_cores[x * arc_grid_size.y + y];
-            arc_logical_to_virtual[{x, y}] = CoreCoord(arc_core.x, arc_core.y, CoreType::ARC, CoordSystem::VIRTUAL);
-            arc_virtual_to_logical[arc_core] = CoreCoord(x, y, CoreType::ARC, CoordSystem::LOGICAL);
 
-            arc_logical_to_physical[{x, y}] = CoreCoord(arc_core.x, arc_core.y, CoreType::ARC, CoordSystem::PHYSICAL);
-            arc_physical_to_logical[arc_core] = CoreCoord(x, y, CoreType::ARC, CoordSystem::LOGICAL);
+            CoreCoord logical_coord = CoreCoord(x, y, CoreType::ARC, CoordSystem::LOGICAL);
+            CoreCoord virtual_coord = CoreCoord(arc_core.x, arc_core.y, CoreType::ARC, CoordSystem::VIRTUAL);
 
-            arc_logical_to_translated[{x, y}] =
-                CoreCoord(arc_core.x, arc_core.y, CoreType::ARC, CoordSystem::TRANSLATED);
-            arc_translated_to_logical[arc_core] = CoreCoord(x, y, CoreType::ARC, CoordSystem::LOGICAL);
+            add_core_translation(logical_coord, arc_core);
+            add_core_translation(virtual_coord, arc_core);
         }
     }
 
-    fill_arc_logical_to_translated();
+    fill_arc_physical_translated_mapping();
 }
 
 void CoordinateManager::translate_pcie_coords() {
     for (size_t x = 0; x < pcie_grid_size.x; x++) {
         for (size_t y = 0; y < pcie_grid_size.y; y++) {
             const tt_xy_pair pcie_core = pcie_cores[x * pcie_grid_size.y + y];
-            pcie_logical_to_virtual[{x, y}] = CoreCoord(pcie_core.x, pcie_core.y, CoreType::PCIE, CoordSystem::VIRTUAL);
-            pcie_virtual_to_logical[pcie_core] = CoreCoord(x, y, CoreType::PCIE, CoordSystem::LOGICAL);
+            CoreCoord logical_coord = CoreCoord(x, y, CoreType::PCIE, CoordSystem::LOGICAL);
+            CoreCoord virtual_coord = CoreCoord(pcie_core.x, pcie_core.y, CoreType::PCIE, CoordSystem::VIRTUAL);
 
-            pcie_logical_to_physical[{x, y}] =
-                CoreCoord(pcie_core.x, pcie_core.y, CoreType::PCIE, CoordSystem::PHYSICAL);
-            pcie_physical_to_logical[pcie_core] = CoreCoord(x, y, CoreType::PCIE, CoordSystem::LOGICAL);
+            add_core_translation(logical_coord, pcie_core);
+            add_core_translation(virtual_coord, pcie_core);
         }
     }
 
-    fill_pcie_logical_to_translated();
+    fill_pcie_physical_translated_mapping();
 }
 
-void CoordinateManager::fill_eth_logical_to_translated() {
+void CoordinateManager::fill_eth_physical_translated_mapping() {
     for (size_t x = 0; x < eth_grid_size.x; x++) {
         for (size_t y = 0; y < eth_grid_size.y; y++) {
-            const CoreCoord physical_coord = eth_logical_to_physical[{x, y}];
-            const size_t translated_x = physical_coord.x;
-            const size_t translated_y = physical_coord.y;
-            eth_logical_to_translated[{x, y}] =
-                CoreCoord(translated_x, translated_y, CoreType::ETH, CoordSystem::TRANSLATED);
-            eth_translated_to_logical[{translated_x, translated_y}] =
-                CoreCoord(x, y, CoreType::ETH, CoordSystem::LOGICAL);
+            CoreCoord logical_coord = CoreCoord(x, y, CoreType::ETH, CoordSystem::LOGICAL);
+            const tt_xy_pair physical_pair = to_physical_map[logical_coord];
+            const size_t translated_x = physical_pair.x;
+            const size_t translated_y = physical_pair.y;
+
+            CoreCoord translated_coord = CoreCoord(translated_x, translated_y, CoreType::ETH, CoordSystem::TRANSLATED);
+
+            add_core_translation(translated_coord, physical_pair);
         }
     }
 }
 
-void CoordinateManager::fill_dram_logical_to_translated() {
+void CoordinateManager::fill_dram_physical_translated_mapping() {
     for (size_t x = 0; x < dram_grid_size.x; x++) {
         for (size_t y = 0; y < dram_grid_size.y; y++) {
-            const CoreCoord physical_coord = dram_logical_to_physical[{x, y}];
-            const size_t translated_x = physical_coord.x;
-            const size_t translated_y = physical_coord.y;
-            dram_logical_to_translated[{x, y}] =
-                CoreCoord(translated_x, translated_y, CoreType::DRAM, CoordSystem::TRANSLATED);
-            dram_translated_to_logical[{translated_x, translated_y}] =
-                CoreCoord(x, y, CoreType::DRAM, CoordSystem::LOGICAL);
+            CoreCoord logical_coord = CoreCoord(x, y, CoreType::DRAM, CoordSystem::LOGICAL);
+            const tt_xy_pair physical_pair = to_physical_map[logical_coord];
+            const size_t translated_x = physical_pair.x;
+            const size_t translated_y = physical_pair.y;
+
+            CoreCoord translated_coord = CoreCoord(translated_x, translated_y, CoreType::DRAM, CoordSystem::TRANSLATED);
+
+            add_core_translation(translated_coord, physical_pair);
         }
     }
 }
 
-void CoordinateManager::fill_pcie_logical_to_translated() {
+void CoordinateManager::fill_pcie_physical_translated_mapping() {
     for (size_t x = 0; x < pcie_grid_size.x; x++) {
         for (size_t y = 0; y < pcie_grid_size.y; y++) {
-            const CoreCoord physical_coord = pcie_logical_to_physical[{x, y}];
-            const size_t translated_x = physical_coord.x;
-            const size_t translated_y = physical_coord.y;
-            pcie_logical_to_translated[{x, y}] =
-                CoreCoord(translated_x, translated_y, CoreType::PCIE, CoordSystem::TRANSLATED);
-            pcie_translated_to_logical[{translated_x, translated_y}] =
-                CoreCoord(x, y, CoreType::PCIE, CoordSystem::LOGICAL);
+            CoreCoord logical_coord = CoreCoord(x, y, CoreType::PCIE, CoordSystem::LOGICAL);
+            const tt_xy_pair physical_pair = to_physical_map[logical_coord];
+            const size_t translated_x = physical_pair.x;
+            const size_t translated_y = physical_pair.y;
+
+            CoreCoord translated_coord = CoreCoord(translated_x, translated_y, CoreType::PCIE, CoordSystem::TRANSLATED);
+
+            add_core_translation(translated_coord, physical_pair);
         }
     }
 }
 
-void CoordinateManager::fill_arc_logical_to_translated() {
+void CoordinateManager::fill_arc_physical_translated_mapping() {
     for (size_t x = 0; x < arc_grid_size.x; x++) {
         for (size_t y = 0; y < arc_grid_size.y; y++) {
-            const CoreCoord physical_coord = arc_logical_to_physical[{x, y}];
-            const size_t translated_x = physical_coord.x;
-            const size_t translated_y = physical_coord.y;
-            arc_logical_to_translated[{x, y}] =
-                CoreCoord(translated_x, translated_y, CoreType::ARC, CoordSystem::TRANSLATED);
-            arc_translated_to_logical[{translated_x, translated_y}] =
-                CoreCoord(x, y, CoreType::ARC, CoordSystem::LOGICAL);
+            CoreCoord logical_coord = CoreCoord(x, y, CoreType::ARC, CoordSystem::LOGICAL);
+            const tt_xy_pair physical_pair = to_physical_map[logical_coord];
+            const size_t translated_x = physical_pair.x;
+            const size_t translated_y = physical_pair.y;
+
+            CoreCoord translated_coord = CoreCoord(translated_x, translated_y, CoreType::ARC, CoordSystem::TRANSLATED);
+
+            add_core_translation(translated_coord, physical_pair);
         }
     }
 }
@@ -538,9 +396,9 @@ std::shared_ptr<CoordinateManager> CoordinateManager::create_coordinate_manager(
                 pcie_cores);
         case tt::ARCH::Invalid:
             throw std::runtime_error("Invalid architecture for creating coordinate manager");
+        default:
+            throw std::runtime_error("Unexpected ARCH value " + std::to_string((int)arch));
     }
-
-    throw std::runtime_error("Invalid architecture for creating coordinate manager");
 }
 
 size_t CoordinateManager::get_num_harvested(const size_t harvesting_mask) {

--- a/device/coordinate_manager.cpp
+++ b/device/coordinate_manager.cpp
@@ -38,6 +38,15 @@ CoordinateManager::CoordinateManager(
     pcie_grid_size(pcie_grid_size),
     pcie_cores(pcie_cores) {}
 
+void CoordinateManager::initialize() {
+    this->identity_map_physical_cores();
+    this->translate_tensix_coords();
+    this->translate_dram_coords();
+    this->translate_eth_coords();
+    this->translate_arc_coords();
+    this->translate_pcie_coords();
+}
+
 void CoordinateManager::add_core_translation(const CoreCoord& core_coord, const tt_xy_pair& physical_pair) {
     to_physical_map.insert({core_coord, physical_pair});
     from_physical_map.insert({{{physical_pair.x, physical_pair.y}, core_coord.coord_system}, core_coord});
@@ -108,7 +117,7 @@ void CoordinateManager::translate_tensix_coords() {
         }
     }
 
-    fill_tensix_physical_translated_mapping();
+    this->fill_tensix_physical_translated_mapping();
 }
 
 void CoordinateManager::fill_tensix_physical_translated_mapping() {

--- a/device/grayskull/grayskull_coordinate_manager.cpp
+++ b/device/grayskull/grayskull_coordinate_manager.cpp
@@ -33,12 +33,7 @@ GrayskullCoordinateManager::GrayskullCoordinateManager(
         arc_cores,
         pcie_grid_size,
         pcie_cores) {
-    this->identity_map_physical_cores();
-    this->translate_tensix_coords();
-    this->translate_dram_coords();
-    this->translate_eth_coords();
-    this->translate_arc_coords();
-    this->translate_pcie_coords();
+    initialize();
 }
 
 void GrayskullCoordinateManager::fill_eth_physical_translated_mapping() {

--- a/device/grayskull/grayskull_coordinate_manager.cpp
+++ b/device/grayskull/grayskull_coordinate_manager.cpp
@@ -33,6 +33,7 @@ GrayskullCoordinateManager::GrayskullCoordinateManager(
         arc_cores,
         pcie_grid_size,
         pcie_cores) {
+    this->identity_map_physical_cores();
     this->translate_tensix_coords();
     this->translate_dram_coords();
     this->translate_eth_coords();
@@ -40,16 +41,17 @@ GrayskullCoordinateManager::GrayskullCoordinateManager(
     this->translate_pcie_coords();
 }
 
-void GrayskullCoordinateManager::fill_eth_logical_to_translated() {
+void GrayskullCoordinateManager::fill_eth_physical_translated_mapping() {
     for (size_t x = 0; x < eth_grid_size.x; x++) {
         for (size_t y = 0; y < eth_grid_size.y; y++) {
-            const CoreCoord physical_coord = eth_logical_to_physical[{x, y}];
-            const size_t translated_x = physical_coord.x;
-            const size_t translated_y = physical_coord.y;
-            eth_logical_to_translated[{x, y}] =
-                CoreCoord(translated_x, translated_y, CoreType::ETH, CoordSystem::TRANSLATED);
-            eth_translated_to_logical[{translated_x, translated_y}] =
-                CoreCoord(x, y, CoreType::ETH, CoordSystem::LOGICAL);
+            CoreCoord logical_coord = CoreCoord(x, y, CoreType::ETH, CoordSystem::LOGICAL);
+            const tt_xy_pair physical_pair = to_physical_map[logical_coord];
+            const size_t translated_x = physical_pair.x;
+            const size_t translated_y = physical_pair.y;
+
+            CoreCoord translated_coord = CoreCoord(translated_x, translated_y, CoreType::ETH, CoordSystem::TRANSLATED);
+
+            add_core_translation(translated_coord, physical_pair);
         }
     }
 }

--- a/device/wormhole/wormhole_coordinate_manager.cpp
+++ b/device/wormhole/wormhole_coordinate_manager.cpp
@@ -33,12 +33,7 @@ WormholeCoordinateManager::WormholeCoordinateManager(
         arc_cores,
         pcie_grid_size,
         pcie_cores) {
-    this->identity_map_physical_cores();
-    this->translate_tensix_coords();
-    this->translate_dram_coords();
-    this->translate_eth_coords();
-    this->translate_arc_coords();
-    this->translate_pcie_coords();
+    initialize();
 }
 
 void WormholeCoordinateManager::fill_tensix_physical_translated_mapping() {

--- a/tests/api/test_core_coord_translation_gs.cpp
+++ b/tests/api/test_core_coord_translation_gs.cpp
@@ -174,6 +174,62 @@ TEST(CoordinateManager, CoordinateManagerGrayskullLogicalVirtualMapping) {
     }
 }
 
+// Test that harvested physical coordinates map to the last row of the virtual coordinates.
+TEST(CoordinateManager, CoordinateManagerWormholePhysicalGrayskullHarvestedMapping) {
+    // Harvest first and second NOC layout row.
+    const size_t harvesting_mask = 3;
+    const size_t num_harvested = CoordinateManager::get_num_harvested(harvesting_mask);
+    std::shared_ptr<CoordinateManager> coordinate_manager =
+        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, 3);
+
+    const std::vector<tt_xy_pair> tensix_cores = tt::umd::grayskull::TENSIX_CORES;
+    const tt_xy_pair tensix_grid_size = tt::umd::grayskull::TENSIX_GRID_SIZE;
+
+    size_t virtual_index = (tensix_grid_size.y - num_harvested) * tensix_grid_size.x;
+
+    for (size_t index = 0; index < num_harvested * tensix_grid_size.x; index++) {
+        const CoreCoord physical_core =
+            CoreCoord(tensix_cores[index].x, tensix_cores[index].y, CoreType::TENSIX, CoordSystem::PHYSICAL);
+        const CoreCoord virtual_core = coordinate_manager->to(physical_core, CoordSystem::VIRTUAL);
+
+        EXPECT_EQ(virtual_core.x, tensix_cores[virtual_index].x);
+        EXPECT_EQ(virtual_core.y, tensix_cores[virtual_index].y);
+
+        virtual_index++;
+    }
+}
+
+// Test that harvested physical coordinates map to the last row of the virtual coordinates.
+TEST(CoordinateManager, CoordinateManagerGrayskullPhysicalTranslatedHarvestedMapping) {
+    // Harvest first and second NOC layout row.
+    const size_t harvesting_mask = 3;
+    const size_t num_harvested = CoordinateManager::get_num_harvested(harvesting_mask);
+    std::shared_ptr<CoordinateManager> coordinate_manager =
+        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, 3);
+
+    const std::vector<tt_xy_pair> tensix_cores = tt::umd::grayskull::TENSIX_CORES;
+    const tt_xy_pair tensix_grid_size = tt::umd::grayskull::TENSIX_GRID_SIZE;
+
+    size_t virtual_index = (tensix_grid_size.y - num_harvested) * tensix_grid_size.x;
+
+    for (size_t index = 0; index < num_harvested * tensix_grid_size.x; index++) {
+        const CoreCoord physical_core =
+            CoreCoord(tensix_cores[index].x, tensix_cores[index].y, CoreType::TENSIX, CoordSystem::PHYSICAL);
+        const CoreCoord translated_core = coordinate_manager->to(physical_core, CoordSystem::TRANSLATED);
+
+        const CoreCoord virtual_core = CoreCoord(
+            tensix_cores[virtual_index].x, tensix_cores[virtual_index].y, CoreType::TENSIX, CoordSystem::VIRTUAL);
+        const CoreCoord translated_core_from_virtual = coordinate_manager->to(virtual_core, CoordSystem::TRANSLATED);
+
+        EXPECT_EQ(translated_core, translated_core_from_virtual);
+
+        EXPECT_EQ(physical_core.x, translated_core.x);
+        EXPECT_EQ(physical_core.y, translated_core.y);
+
+        virtual_index++;
+    }
+}
+
 // Test mapping of DRAM coordinates from logical to physical. We have no DRAM harvesting on Grayskull,
 // so logical coordinates should cover all physical coordinates.
 TEST(CoordinateManager, CoordinateManagerGrayskullDRAMNoHarvesting) {


### PR DESCRIPTION
### Issue

Some parts of https://github.com/tenstorrent/tt-umd/issues/355

### Description

Redesign maps of the Coordinate Manager class. Instead of per core type maps, we use one map now for all core types. Virtual to physical to translated mappings are now implemented for harvested coordinates as well. We may want to use those cores sometimes so in order to support proper reading/writing to these cores. Now all translations are going throug the physical (NOC0) coordinate system, since soc descriptors are in physical coordinate system, and each core has those coordinates.

### List of the changes

- Remove per core type map
- Add one map for all cores
- Implement translation for harvested tensix cores
- Implement translation for harvested dram cores

### Testing

Existing unit tests, added more

### API Changes

No API changes