### PR TITLE
Fix undefined behavior bug

### DIFF
--- a/device/tlb.cpp
+++ b/device/tlb.cpp
@@ -7,15 +7,16 @@
 namespace tt::umd {
 
 bool tlb_data::check(const tlb_offsets &offset) const {
-    return local_offset > ((1 << (offset.x_end - offset.local_offset)) - 1) |
-           x_end > ((1 << (offset.y_end - offset.x_end)) - 1) | y_end > ((1 << (offset.x_start - offset.y_end)) - 1) |
-           x_start > ((1 << (offset.y_start - offset.x_start)) - 1) |
-           y_start > ((1 << (offset.noc_sel - offset.y_start)) - 1) |
-           noc_sel > ((1 << (offset.mcast - offset.noc_sel)) - 1) |
-           mcast > ((1 << (offset.ordering - offset.mcast)) - 1) |
-           ordering > ((1 << (offset.linked - offset.ordering)) - 1) |
-           linked > ((1 << (offset.static_vc - offset.linked)) - 1) |
-           static_vc > ((1 << (offset.static_vc_end - offset.static_vc)) - 1);
+    return local_offset > ((1ULL << (offset.x_end - offset.local_offset)) - 1) |
+           x_end > ((1ULL << (offset.y_end - offset.x_end)) - 1) |
+           y_end > ((1ULL << (offset.x_start - offset.y_end)) - 1) |
+           x_start > ((1ULL << (offset.y_start - offset.x_start)) - 1) |
+           y_start > ((1ULL << (offset.noc_sel - offset.y_start)) - 1) |
+           noc_sel > ((1ULL << (offset.mcast - offset.noc_sel)) - 1) |
+           mcast > ((1ULL << (offset.ordering - offset.mcast)) - 1) |
+           ordering > ((1ULL << (offset.linked - offset.ordering)) - 1) |
+           linked > ((1ULL << (offset.static_vc - offset.linked)) - 1) |
+           static_vc > ((1ULL << (offset.static_vc_end - offset.static_vc)) - 1);
 }
 
 // Helper lambda to handle bit packing


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/376

### Description
The literal `1` has type `int`.  The left shift operation is undefined when the result can not be represented in the left operand type.

### List of the changes
* Use a 64 bit 1.

### Testing
N/A

### API Changes
N/A
