### PR TITLE
GCC CI build

### DIFF
--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -31,15 +31,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [
+        image: [
           {runs-on: ubuntu-22.04, docker-image: tt-umd-ci-ubuntu-22.04},
           {runs-on: ubuntu-20.04, docker-image: tt-umd-ci-ubuntu-20.04},
         ]
+        compiler: [gcc, clang]
 
-    name: Build device for any arch on ${{ matrix.build.runs-on }}
-    runs-on: ${{ matrix.build.runs-on }}
+    name: Build device for any arch on ${{ matrix.image.runs-on }}
+    runs-on: ${{ matrix.image.runs-on }}
     container:
-      image: ghcr.io/${{ github.repository }}/${{ matrix.build.docker-image }}:latest
+      image: ghcr.io/${{ github.repository }}/${{ matrix.image.docker-image }}:latest
       options: --user root
 
     steps:
@@ -47,6 +48,12 @@ jobs:
         with:
           submodules: recursive
           lfs: 'true'
+
+      - name: Set GCC compiler
+        if: ${{ matrix.compiler == 'gcc' }}
+        run: |
+          export CMAKE_C_COMPILER=/usr/bin/gcc
+          export CMAKE_CXX_COMPILER=/usr/bin/g++
 
       - name: Build ${{ env.BUILD_TARGET }}
         run: |


### PR DESCRIPTION
### Issue
Fixes #136

### Description
Add GCC build to CI. Motivation was a question in #382 

### List of the changes
- Added GCC build to CI
- Not added for building tests (not to explode the number of jobs too much. These jobs will be merged once we remove the need to setup ARCH_NAME explicitly

### Testing
CI tests on this PR should be different

### API Changes
There are no API changes in this PR.
