### PR TITLE
Soc descriptor API with CoreCoord

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -34,6 +34,7 @@ env:
   DEPS_OUTPUT_DIR: ./build/_deps
   TEST_OUTPUT_DIR: ./build/test
   CLUSTER_DESCRIPTORS_DIR: ./tests/api/cluster_descriptor_examples
+  SOC_DESCRIPTORS_DIR: ./tests/soc_descs
 
 jobs:
   build:
@@ -77,7 +78,8 @@ jobs:
           tar cvf artifact.tar ${{ env.TEST_OUTPUT_DIR }} \
           ${{ env.LIB_OUTPUT_DIR }} \
           ${{ env.DEPS_OUTPUT_DIR }} \
-          ${{ env.CLUSTER_DESCRIPTORS_DIR }}
+          ${{ env.CLUSTER_DESCRIPTORS_DIR }} \
+          ${{ env.SOC_DESCRIPTORS_DIR }}
 
       - name: Upload build artifacts archive
         uses: actions/upload-artifact@v4

--- a/device/api/umd/device/blackhole_coordinate_manager.h
+++ b/device/api/umd/device/blackhole_coordinate_manager.h
@@ -34,6 +34,15 @@ protected:
     void fill_pcie_physical_translated_mapping() override;
     void fill_dram_physical_translated_mapping() override;
 
+    std::vector<tt::umd::CoreCoord> get_tensix_cores() const override;
+    std::vector<tt::umd::CoreCoord> get_harvested_tensix_cores() const override;
+    std::vector<tt::umd::CoreCoord> get_dram_cores() const override;
+    std::vector<tt::umd::CoreCoord> get_harvested_dram_cores() const override;
+    tt_xy_pair get_tensix_grid_size() const override;
+    tt_xy_pair get_dram_grid_size() const override;
+    tt_xy_pair get_harvested_tensix_grid_size() const override;
+    tt_xy_pair get_harvested_dram_grid_size() const override;
+
 private:
     void map_column_of_dram_banks(const size_t start_bank, const size_t end_bank, const size_t x_coord);
 };

--- a/device/api/umd/device/coordinate_manager.h
+++ b/device/api/umd/device/coordinate_manager.h
@@ -42,6 +42,12 @@ public:
 
     tt::umd::CoreCoord to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system);
 
+    std::vector<tt::umd::CoreCoord> get_cores(const CoreType core_type) const;
+    tt_xy_pair get_grid_size(const CoreType core_type) const;
+
+    std::vector<tt::umd::CoreCoord> get_harvested_cores(const CoreType core_type) const;
+    tt_xy_pair get_harvested_grid_size(const CoreType core_type) const;
+
     virtual ~CoordinateManager() = default;
 
     size_t get_tensix_harvesting_mask() const;
@@ -51,6 +57,9 @@ public:
 private:
     static void assert_create_coordinate_manager(
         const tt::ARCH arch, const size_t tensix_harvesting_mask, const size_t dram_harvesting_mask);
+
+    const std::vector<tt_xy_pair>& get_physical_pairs(const CoreType core_type) const;
+    std::vector<tt::umd::CoreCoord> get_all_physical_cores(const CoreType core_type) const;
 
 protected:
     /*
@@ -86,6 +95,15 @@ protected:
 
     void identity_map_physical_cores();
     void add_core_translation(const tt::umd::CoreCoord& core_coord, const tt_xy_pair& physical_pair);
+
+    virtual std::vector<tt::umd::CoreCoord> get_tensix_cores() const;
+    virtual std::vector<tt::umd::CoreCoord> get_harvested_tensix_cores() const;
+    virtual std::vector<tt::umd::CoreCoord> get_dram_cores() const;
+    virtual std::vector<tt::umd::CoreCoord> get_harvested_dram_cores() const;
+    virtual tt_xy_pair get_tensix_grid_size() const;
+    virtual tt_xy_pair get_dram_grid_size() const;
+    virtual tt_xy_pair get_harvested_tensix_grid_size() const;
+    virtual tt_xy_pair get_harvested_dram_grid_size() const;
 
     /*
      * Fills the logical to translated mapping for the tensix cores.
@@ -134,23 +152,21 @@ protected:
     std::map<tt::umd::CoreCoord, tt_xy_pair> to_physical_map;
     std::map<std::pair<tt_xy_pair, CoordSystem>, tt::umd::CoreCoord> from_physical_map;
 
-    const tt_xy_pair tensix_grid_size;
-    const std::vector<tt_xy_pair>& tensix_cores;
+    tt_xy_pair tensix_grid_size;
+    const std::vector<tt_xy_pair> tensix_cores;
     size_t tensix_harvesting_mask;
     const size_t physical_layout_tensix_harvesting_mask;
 
-    const tt_xy_pair dram_grid_size;
-    const std::vector<tt_xy_pair>& dram_cores;
+    tt_xy_pair dram_grid_size;
+    const std::vector<tt_xy_pair> dram_cores;
     size_t dram_harvesting_mask;
 
-    const tt_xy_pair eth_grid_size;
-    const std::vector<tt_xy_pair>& eth_cores;
+    tt_xy_pair eth_grid_size;
+    const std::vector<tt_xy_pair> eth_cores;
 
-    const tt_xy_pair arc_grid_size;
-    const std::vector<tt_xy_pair>& arc_cores;
+    tt_xy_pair arc_grid_size;
+    const std::vector<tt_xy_pair> arc_cores;
 
-    const tt_xy_pair pcie_grid_size;
-    const std::vector<tt_xy_pair>& pcie_cores;
+    tt_xy_pair pcie_grid_size;
+    const std::vector<tt_xy_pair> pcie_cores;
 };
-
-// friend

--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -46,42 +46,6 @@ struct CoreDescriptor {
 */
 class tt_SocDescriptor {
 public:
-    tt::ARCH arch;
-    tt_xy_pair grid_size;
-    tt_xy_pair physical_grid_size;
-    tt_xy_pair worker_grid_size;
-    std::unordered_map<tt_xy_pair, CoreDescriptor> cores;
-    std::vector<tt_xy_pair> arc_cores;
-    std::vector<tt_xy_pair> workers;
-    std::vector<tt_xy_pair> harvested_workers;
-    std::vector<tt_xy_pair> pcie_cores;
-    std::unordered_map<int, int> worker_log_to_routing_x;
-    std::unordered_map<int, int> worker_log_to_routing_y;
-    std::unordered_map<int, int> routing_x_to_worker_x;
-    std::unordered_map<int, int> routing_y_to_worker_y;
-    std::vector<std::vector<tt_xy_pair>> dram_cores;                             // per channel list of dram cores
-    std::unordered_map<tt_xy_pair, std::tuple<int, int>> dram_core_channel_map;  // map dram core to chan/subchan
-    std::vector<tt_xy_pair> ethernet_cores;                                      // ethernet cores (index == channel id)
-    std::unordered_map<tt_xy_pair, int> ethernet_core_channel_map;
-    std::vector<std::size_t> trisc_sizes;  // Most of software stack assumes same trisc size for whole chip..
-    std::string device_descriptor_file_path = std::string("");
-
-    bool has(tt_xy_pair input) { return cores.find(input) != cores.end(); }
-
-    int overlay_version;
-    int unpacker_version;
-    int dst_size_alignment;
-    int packer_version;
-    int worker_l1_size;
-    int eth_l1_size;
-    bool noc_translation_id_enabled;
-    uint64_t dram_bank_size;
-
-    int get_num_dram_channels() const;
-    bool is_worker_core(const tt_xy_pair &core) const;
-    tt_xy_pair get_core_for_dram_channel(int dram_chan, int subchannel) const;
-    bool is_ethernet_core(const tt_xy_pair &core) const;
-
     // Default constructor. Creates uninitialized object with public access to all of its attributes.
     tt_SocDescriptor() = default;
     // Constructor used to build object from device descriptor file.
@@ -119,22 +83,78 @@ public:
         eth_l1_size(other.eth_l1_size),
         noc_translation_id_enabled(other.noc_translation_id_enabled),
         dram_bank_size(other.dram_bank_size),
-        coordinate_manager(other.coordinate_manager) {}
+        coordinate_manager(other.coordinate_manager),
+        cores_map(other.cores_map),
+        grid_size_map(other.grid_size_map),
+        harvested_cores_map(other.harvested_cores_map),
+        harvested_grid_size_map(other.harvested_grid_size_map) {}
 
     // CoreCoord conversions.
-    tt::umd::CoreCoord to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system);
+    tt::umd::CoreCoord to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const;
 
     static std::string get_soc_descriptor_path(tt::ARCH arch);
+
+    std::vector<tt::umd::CoreCoord> get_cores(const CoreType core_type) const;
+    std::vector<tt::umd::CoreCoord> get_harvested_cores(const CoreType core_type) const;
+    tt_xy_pair get_grid_size(const CoreType core_type) const;
+    tt_xy_pair get_harvested_grid_size(const CoreType core_type) const;
+
+    int get_num_dram_channels() const;
+
+    bool is_worker_core(const tt_xy_pair &core) const;
+
+    tt_xy_pair get_core_for_dram_channel(int dram_chan, int subchannel) const;
+
+    tt::umd::CoreCoord get_dram_core_for_channel(int dram_chan, int subchannel) const;
+    tt::umd::CoreCoord get_dram_core(uint32_t dram_chan, uint32_t subchannel) const;
+
+    bool is_ethernet_core(const tt_xy_pair &core) const;
+
+    tt::ARCH arch;
+    tt_xy_pair grid_size;
+    tt_xy_pair physical_grid_size;
+    tt_xy_pair worker_grid_size;
+    std::unordered_map<tt_xy_pair, CoreDescriptor> cores;
+    std::vector<tt_xy_pair> arc_cores;
+    std::vector<tt_xy_pair> workers;
+    std::vector<tt_xy_pair> harvested_workers;
+    std::vector<tt_xy_pair> pcie_cores;
+    std::unordered_map<int, int> worker_log_to_routing_x;
+    std::unordered_map<int, int> worker_log_to_routing_y;
+    std::unordered_map<int, int> routing_x_to_worker_x;
+    std::unordered_map<int, int> routing_y_to_worker_y;
+    std::vector<std::vector<tt_xy_pair>> dram_cores;                             // per channel list of dram cores
+    std::unordered_map<tt_xy_pair, std::tuple<int, int>> dram_core_channel_map;  // map dram core to chan/subchan
+    std::vector<tt_xy_pair> ethernet_cores;                                      // ethernet cores (index == channel id)
+    std::unordered_map<tt_xy_pair, int> ethernet_core_channel_map;
+    std::vector<std::size_t> trisc_sizes;  // Most of software stack assumes same trisc size for whole chip..
+    std::string device_descriptor_file_path = std::string("");
+
+    int overlay_version;
+    int unpacker_version;
+    int dst_size_alignment;
+    int packer_version;
+    int worker_l1_size;
+    int eth_l1_size;
+    bool noc_translation_id_enabled;
+    uint64_t dram_bank_size;
 
 private:
     void create_coordinate_manager(const std::size_t tensix_harvesting_mask, const std::size_t dram_harvesting_mask);
     void load_core_descriptors_from_device_descriptor(YAML::Node &device_descriptor_yaml);
     void load_soc_features_from_device_descriptor(YAML::Node &device_descriptor_yaml);
+    void get_cores_and_grid_size_from_coordinate_manager();
+
+    static tt_xy_pair calculate_grid_size(const std::vector<tt_xy_pair> &cores);
 
     // TODO: change this to unique pointer as soon as copying of tt_SocDescriptor
     // is not needed anymore. Soc descriptor and coordinate manager should be
     // created once per chip.
     std::shared_ptr<CoordinateManager> coordinate_manager = nullptr;
+    std::map<CoreType, std::vector<tt::umd::CoreCoord>> cores_map;
+    std::map<CoreType, tt_xy_pair> grid_size_map;
+    std::map<CoreType, std::vector<tt::umd::CoreCoord>> harvested_cores_map;
+    std::map<CoreType, tt_xy_pair> harvested_grid_size_map;
 };
 
 // Allocates a new soc descriptor on the heap. Returns an owning pointer.

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -6,6 +6,7 @@ set(API_TESTS_SRCS
     test_core_coord_translation_wh.cpp
     test_core_coord_translation_bh.cpp
     test_mockup_device.cpp
+    test_soc_descriptor.cpp
 )
 
 add_executable(api_tests ${API_TESTS_SRCS})

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -1,0 +1,241 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "gtest/gtest.h"
+#include "tests/test_utils/generate_cluster_desc.hpp"
+#include "umd/device/blackhole_implementation.h"
+#include "umd/device/grayskull_implementation.h"
+#include "umd/device/tt_soc_descriptor.h"
+#include "umd/device/wormhole_implementation.h"
+
+using namespace tt::umd;
+
+// Test soc descriptor API for Wormhole when there is no harvesting.
+TEST(SocDescriptor, SocDescriptorGrayskullNoHarvesting) {
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"));
+
+    const std::vector<tt_xy_pair> grayskull_tensix_cores = tt::umd::grayskull::TENSIX_CORES;
+
+    ASSERT_EQ(soc_desc.get_num_dram_channels(), tt::umd::grayskull::NUM_DRAM_BANKS);
+
+    for (const tt_xy_pair& tensix_core : grayskull_tensix_cores) {
+        ASSERT_TRUE(soc_desc.is_worker_core(tensix_core));
+        ASSERT_FALSE(soc_desc.is_ethernet_core(tensix_core));
+    }
+
+    ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::TENSIX).empty());
+    ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::DRAM).empty());
+}
+
+// Test soc descriptor API for Grayskull when there is tensix harvesting.
+TEST(SocDescriptor, SocDescriptorGrayskullOneRowHarvesting) {
+    const tt_xy_pair grayskull_tensix_grid_size = tt::umd::grayskull::TENSIX_GRID_SIZE;
+    const std::vector<tt_xy_pair> grayskull_tensix_cores = tt::umd::grayskull::TENSIX_CORES;
+    const size_t harvesting_mask = (1 << tt::umd::grayskull::LOGICAL_HARVESTING_LAYOUT[0]);
+
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), harvesting_mask);
+
+    const std::vector<CoreCoord> tensix_cores = soc_desc.get_cores(CoreType::TENSIX);
+
+    ASSERT_EQ(tensix_cores.size(), grayskull_tensix_grid_size.x * (grayskull_tensix_grid_size.y - 1));
+
+    size_t index = grayskull_tensix_grid_size.x;
+
+    for (size_t core_index = 0; core_index < tensix_cores.size(); core_index++) {
+        ASSERT_EQ(tensix_cores[core_index].x, grayskull_tensix_cores[index].x);
+        ASSERT_EQ(tensix_cores[core_index].y, grayskull_tensix_cores[index].y);
+        index++;
+    }
+
+    const std::vector<CoreCoord> harvested_cores = soc_desc.get_harvested_cores(CoreType::TENSIX);
+
+    ASSERT_FALSE(harvested_cores.empty());
+
+    ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::DRAM).empty());
+}
+
+// Test soc descriptor API for Wormhole when there is no harvesting.
+TEST(SocDescriptor, SocDescriptorWormholeNoHarvesting) {
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"));
+
+    const std::vector<tt_xy_pair> wormhole_tensix_cores = tt::umd::wormhole::TENSIX_CORES;
+
+    ASSERT_EQ(soc_desc.get_num_dram_channels(), tt::umd::wormhole::NUM_DRAM_BANKS);
+
+    for (const tt_xy_pair& tensix_core : wormhole_tensix_cores) {
+        ASSERT_TRUE(soc_desc.is_worker_core(tensix_core));
+        ASSERT_FALSE(soc_desc.is_ethernet_core(tensix_core));
+    }
+
+    ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::TENSIX).empty());
+    ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::DRAM).empty());
+}
+
+// Test soc descriptor API for Wormhole when there is tensix harvesting.
+TEST(SocDescriptor, SocDescriptorWormholeOneRowHarvesting) {
+    const tt_xy_pair wormhole_tensix_grid_size = tt::umd::wormhole::TENSIX_GRID_SIZE;
+    const std::vector<tt_xy_pair> wormhole_tensix_cores = tt::umd::wormhole::TENSIX_CORES;
+    const size_t harvesting_mask = (1 << tt::umd::wormhole::LOGICAL_HARVESTING_LAYOUT[0]);
+
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), harvesting_mask);
+
+    const std::vector<CoreCoord> tensix_cores = soc_desc.get_cores(CoreType::TENSIX);
+
+    ASSERT_EQ(tensix_cores.size(), wormhole_tensix_grid_size.x * (wormhole_tensix_grid_size.y - 1));
+
+    size_t index = wormhole_tensix_grid_size.x;
+
+    for (size_t core_index = 0; core_index < tensix_cores.size(); core_index++) {
+        ASSERT_EQ(tensix_cores[core_index].x, wormhole_tensix_cores[index].x);
+        ASSERT_EQ(tensix_cores[core_index].y, wormhole_tensix_cores[index].y);
+        index++;
+    }
+
+    const std::vector<CoreCoord> harvested_cores = soc_desc.get_harvested_cores(CoreType::TENSIX);
+
+    ASSERT_FALSE(harvested_cores.empty());
+
+    ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::DRAM).empty());
+}
+
+// Test soc descriptor API for Blackhole when there is no harvesting.
+TEST(SocDescriptor, SocDescriptorBlackholeNoHarvesting) {
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"));
+
+    const std::vector<tt_xy_pair> blackhole_tensix_cores = tt::umd::blackhole::TENSIX_CORES;
+
+    ASSERT_EQ(soc_desc.get_num_dram_channels(), tt::umd::blackhole::NUM_DRAM_BANKS);
+
+    for (const tt_xy_pair& tensix_core : blackhole_tensix_cores) {
+        ASSERT_TRUE(soc_desc.is_worker_core(tensix_core));
+        ASSERT_FALSE(soc_desc.is_ethernet_core(tensix_core));
+    }
+
+    ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::TENSIX).empty());
+    ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::DRAM).empty());
+}
+
+// Test soc descriptor API for Blackhole when there is tensix harvesting.
+TEST(SocDescriptor, SocDescriptorBlackholeOneRowHarvesting) {
+    const tt_xy_pair blackhole_tensix_grid_size = tt::umd::blackhole::TENSIX_GRID_SIZE;
+    const std::vector<tt_xy_pair> blackhole_tensix_cores = tt::umd::blackhole::TENSIX_CORES;
+
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), 1);
+
+    const std::vector<CoreCoord> tensix_cores = soc_desc.get_cores(CoreType::TENSIX);
+
+    ASSERT_EQ(tensix_cores.size(), (blackhole_tensix_grid_size.x - 1) * blackhole_tensix_grid_size.y);
+
+    size_t index = 1;
+
+    for (size_t core_index = 0; core_index < tensix_cores.size(); core_index++) {
+        ASSERT_EQ(tensix_cores[core_index].x, blackhole_tensix_cores[index].x);
+        ASSERT_EQ(tensix_cores[core_index].y, blackhole_tensix_cores[index].y);
+        index++;
+        if (index % blackhole_tensix_grid_size.x == 0) {
+            index++;
+        }
+    }
+
+    const std::vector<CoreCoord> harvested_cores = soc_desc.get_harvested_cores(CoreType::TENSIX);
+
+    ASSERT_FALSE(harvested_cores.empty());
+
+    ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::DRAM).empty());
+}
+
+// Test soc descriptor API for Blackhole when there is DRAM harvesting.
+TEST(SocDescriptor, SocDescriptorBlackholeDRAMHarvesting) {
+    const tt_xy_pair blackhole_tensix_grid_size = tt::umd::blackhole::TENSIX_GRID_SIZE;
+    const std::vector<tt_xy_pair> blackhole_tensix_cores = tt::umd::blackhole::TENSIX_CORES;
+    const std::vector<tt_xy_pair> blackhole_dram_cores = tt::umd::blackhole::DRAM_CORES;
+    const size_t num_dram_banks = tt::umd::blackhole::NUM_DRAM_BANKS;
+    const size_t num_noc_ports_per_bank = tt::umd::blackhole::NUM_NOC_PORTS_PER_DRAM_BANK;
+
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), 0, 1);
+
+    const std::vector<CoreCoord> tensix_cores = soc_desc.get_cores(CoreType::TENSIX);
+
+    ASSERT_EQ(tensix_cores.size(), blackhole_tensix_grid_size.x * blackhole_tensix_grid_size.y);
+
+    size_t index = 0;
+    for (size_t core_index = 0; core_index < tensix_cores.size(); core_index++) {
+        ASSERT_EQ(tensix_cores[core_index].x, blackhole_tensix_cores[index].x);
+        ASSERT_EQ(tensix_cores[core_index].y, blackhole_tensix_cores[index].y);
+        index++;
+    }
+
+    ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::TENSIX).empty());
+
+    const std::vector<CoreCoord> dram_cores = soc_desc.get_cores(CoreType::DRAM);
+
+    ASSERT_EQ(dram_cores.size(), (num_dram_banks - 1) * num_noc_ports_per_bank);
+
+    const std::vector<CoreCoord> harvested_dram_cores = soc_desc.get_harvested_cores(CoreType::DRAM);
+
+    ASSERT_EQ(harvested_dram_cores.size(), num_noc_ports_per_bank);
+
+    for (size_t core_index = 0; core_index < num_noc_ports_per_bank; core_index++) {
+        ASSERT_EQ(harvested_dram_cores[core_index].x, blackhole_dram_cores[core_index].x);
+        ASSERT_EQ(harvested_dram_cores[core_index].y, blackhole_dram_cores[core_index].y);
+    }
+}
+
+TEST(SocDescriptor, CustomSocDescriptor) {
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_simulation_1x2.yaml"), 0, 0);
+
+    const CoreCoord tensix_core_01 = CoreCoord(0, 1, CoreType::TENSIX, CoordSystem::PHYSICAL);
+    const CoreCoord tensix_core_01_virtual = soc_desc.to(tensix_core_01, CoordSystem::VIRTUAL);
+    const CoreCoord tensix_core_01_logical = soc_desc.to(tensix_core_01, CoordSystem::LOGICAL);
+    const CoreCoord tensix_core_01_translated = soc_desc.to(tensix_core_01, CoordSystem::TRANSLATED);
+
+    EXPECT_EQ(tensix_core_01_virtual.x, tensix_core_01.x);
+    EXPECT_EQ(tensix_core_01_virtual.y, tensix_core_01.y);
+
+    EXPECT_EQ(tensix_core_01_virtual.x, tensix_core_01_translated.x);
+    EXPECT_EQ(tensix_core_01_virtual.y, tensix_core_01_translated.y);
+
+    EXPECT_EQ(tensix_core_01_logical.x, 0);
+    EXPECT_EQ(tensix_core_01_logical.y, 0);
+
+    const CoreCoord tensix_core_11 = CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::PHYSICAL);
+    const CoreCoord tensix_core_11_virtual = soc_desc.to(tensix_core_11, CoordSystem::VIRTUAL);
+    const CoreCoord tensix_core_11_logical = soc_desc.to(tensix_core_11, CoordSystem::LOGICAL);
+    const CoreCoord tensix_core_11_translated = soc_desc.to(tensix_core_11, CoordSystem::TRANSLATED);
+
+    EXPECT_EQ(tensix_core_11_virtual.x, tensix_core_11.x);
+    EXPECT_EQ(tensix_core_11_virtual.y, tensix_core_11.y);
+
+    EXPECT_EQ(tensix_core_11_virtual.x, tensix_core_11_translated.x);
+    EXPECT_EQ(tensix_core_11_virtual.y, tensix_core_11_translated.y);
+
+    EXPECT_EQ(tensix_core_11_logical.x, 1);
+    EXPECT_EQ(tensix_core_11_logical.y, 0);
+
+    std::vector<CoreCoord> cores = soc_desc.get_cores(CoreType::TENSIX);
+    EXPECT_EQ(cores.size(), 2);
+
+    EXPECT_EQ(cores[0], tensix_core_01);
+    EXPECT_EQ(cores[1], tensix_core_11);
+
+    std::vector<CoreCoord> harvested_tensix_cores = soc_desc.get_harvested_cores(CoreType::TENSIX);
+    EXPECT_TRUE(harvested_tensix_cores.empty());
+
+    const CoreCoord dram_core_10 = CoreCoord(1, 0, CoreType::DRAM, CoordSystem::PHYSICAL);
+    const CoreCoord dram_core_10_virtual = soc_desc.to(dram_core_10, CoordSystem::VIRTUAL);
+    const CoreCoord dram_core_10_logical = soc_desc.to(dram_core_10, CoordSystem::LOGICAL);
+    const CoreCoord dram_core_10_translated = soc_desc.to(dram_core_10, CoordSystem::TRANSLATED);
+
+    EXPECT_EQ(dram_core_10_virtual.x, dram_core_10.x);
+    EXPECT_EQ(dram_core_10_virtual.y, dram_core_10.y);
+
+    EXPECT_EQ(dram_core_10.x, dram_core_10_translated.x);
+    EXPECT_EQ(dram_core_10.y, dram_core_10_translated.y);
+
+    EXPECT_EQ(dram_core_10_logical.x, 0);
+    EXPECT_EQ(dram_core_10_logical.y, 0);
+
+    EXPECT_EQ(soc_desc.get_num_dram_channels(), 1);
+}

--- a/tests/soc_descs/blackhole_simulation_1x2.yaml
+++ b/tests/soc_descs/blackhole_simulation_1x2.yaml
@@ -1,0 +1,55 @@
+grid:
+  x_size: 2
+  y_size: 2
+
+arc:
+  []
+
+pcie:
+  []
+
+dram:
+  [[1-0]]
+
+dram_preferred_eth_endpoint:
+  [ 1-0 ]
+
+dram_preferred_worker_endpoint:
+  [ 1-0 ]
+
+dram_address_offsets:
+  [ 0 ]
+
+eth:
+  []
+
+functional_workers:
+  [0-1, 1-1]
+
+harvested_workers:
+  []
+
+router_only:
+  [0-0]
+
+worker_l1_size:
+  1499136
+
+dram_bank_size:
+  1073741824
+
+eth_l1_size:
+  0
+
+arch_name: BLACKHOLE
+
+features:
+  unpacker:
+    version: 1
+    inline_srca_trans_without_srca_trans_instr: False
+  math:
+    dst_size_alignment: 32768
+  packer:
+    version: 1
+  overlay:
+    version: 1


### PR DESCRIPTION
### Issue

/

### Description

Integrate CoreCoord struct into tt_SocDescriptor class

### List of the changes

- Expose new API with CoreCoord through Soc descriptor 
- Test custom soc descriptor
- Implement functions to get cores and grid size
- Implement functions to get harvested cores and grid size

### Testing

Unit test

### API Changes

No API changes. API is the same, implementations have changed 
