### PR TITLE
Remove set_driver_*_params and set_device_*_params

### DIFF
--- a/device/api/umd/device/architecture_implementation.h
+++ b/device/api/umd/device/architecture_implementation.h
@@ -16,6 +16,7 @@
 #include "umd/device/types/arch.h"
 #include "umd/device/types/xy_pair.h"
 
+struct tt_device_l1_address_params;
 struct tt_driver_host_address_params;
 struct tt_driver_eth_interface_params;
 struct tt_driver_noc_params;
@@ -70,6 +71,7 @@ public:
     virtual std::pair<std::uint64_t, std::uint64_t> get_tlb_data(
         std::uint32_t tlb_index, const tlb_data& data) const = 0;
 
+    virtual tt_device_l1_address_params get_l1_address_params() const = 0;
     virtual tt_driver_host_address_params get_host_address_params() const = 0;
     virtual tt_driver_eth_interface_params get_eth_interface_params() const = 0;
     virtual tt_driver_noc_params get_noc_params() const = 0;

--- a/device/api/umd/device/blackhole_implementation.h
+++ b/device/api/umd/device/blackhole_implementation.h
@@ -309,6 +309,7 @@ public:
     std::optional<std::tuple<std::uint64_t, std::uint64_t>> describe_tlb(std::int32_t tlb_index) const override;
     std::pair<std::uint64_t, std::uint64_t> get_tlb_data(std::uint32_t tlb_index, const tlb_data& data) const override;
 
+    tt_device_l1_address_params get_l1_address_params() const override;
     tt_driver_host_address_params get_host_address_params() const override;
     tt_driver_eth_interface_params get_eth_interface_params() const override;
     tt_driver_noc_params get_noc_params() const override;

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -47,36 +47,12 @@ public:
 
     // Setup/Teardown Functions
     /**
-     * Set L1 Address Map parameters used by UMD to communicate with the TT Device.
+     * Set Barrier Address Map parameters used by UMD to communicate with the TT Device.
      *
-     * @param l1_address_params_  All the L1 parameters required by UMD
+     * @param barrier_address_params_  All the barrier parameters required by UMD
      */
-    virtual void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_) {
-        throw std::runtime_error("---- tt_device::set_device_l1_address_params is not implemented\n");
-    }
-
-    virtual void set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_) {
-        throw std::runtime_error("---- tt_device::set_device_dram_address_params is not implemented\n");
-    }
-
-    /**
-     * Set Host Address Map parameters used by UMD to communicate with the TT Device (used for remote transactions).
-     *
-     * @param host_address_params_ All the Host Address space parameters required by UMD.
-     */
-    [[deprecated("Using unnecessary function.")]] virtual void set_driver_host_address_params(
-        const tt_driver_host_address_params& host_address_params_) {
-        throw std::runtime_error("---- tt_device::set_driver_host_address_params is not implemented\n");
-    }
-
-    /**
-     * Set ERISC Firmware parameters used by UMD to communicate with the TT Device (used for remote transactions).
-     *
-     * @param eth_interface_params_ All the Ethernet Firmware parameters required by UMD.
-     */
-    [[deprecated("Using unnecessary function.")]] virtual void set_driver_eth_interface_params(
-        const tt_driver_eth_interface_params& eth_interface_params_) {
-        throw std::runtime_error("---- tt_device::set_driver_eth_interface_params is not implemented\n");
+    virtual void set_barrier_address_params(const barrier_address_params& barrier_address_params_) {
+        throw std::runtime_error("---- tt_device::set_barrier_address_params is not implemented\n");
     }
 
     /**
@@ -561,10 +537,7 @@ public:
     static std::unique_ptr<Cluster> create_mock_cluster();
 
     // Setup/Teardown Functions
-    virtual void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_);
-    virtual void set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_);
-    virtual void set_driver_host_address_params(const tt_driver_host_address_params& host_address_params_);
-    virtual void set_driver_eth_interface_params(const tt_driver_eth_interface_params& eth_interface_params_);
+    virtual void set_barrier_address_params(const barrier_address_params& barrier_address_params_);
     virtual void configure_tlb(
         chip_id_t logical_device_id,
         tt_xy_pair core,

--- a/device/api/umd/device/grayskull_implementation.h
+++ b/device/api/umd/device/grayskull_implementation.h
@@ -299,6 +299,7 @@ public:
     std::optional<std::tuple<std::uint64_t, std::uint64_t>> describe_tlb(std::int32_t tlb_index) const override;
     std::pair<std::uint64_t, std::uint64_t> get_tlb_data(std::uint32_t tlb_index, const tlb_data& data) const override;
 
+    tt_device_l1_address_params get_l1_address_params() const override;
     tt_driver_host_address_params get_host_address_params() const override;
     tt_driver_eth_interface_params get_eth_interface_params() const override;
     tt_driver_noc_params get_noc_params() const override;

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -20,10 +20,7 @@ public:
 
     tt_SimulationHost host;
 
-    virtual void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_);
-    virtual void set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_);
-    virtual void set_driver_host_address_params(const tt_driver_host_address_params& host_address_params_);
-    virtual void set_driver_eth_interface_params(const tt_driver_eth_interface_params& eth_interface_params_);
+    virtual void set_barrier_address_params(const barrier_address_params& barrier_address_params_);
     virtual void start_device(const tt_device_params& device_params);
     virtual void assert_risc_reset();
     virtual void deassert_risc_reset();
@@ -63,11 +60,7 @@ public:
 
 private:
     // State variables
-    tt_device_dram_address_params dram_address_params;
-    tt_device_l1_address_params l1_address_params;
-    tt_driver_host_address_params host_address_params;
     tt_driver_noc_params noc_params;
-    tt_driver_eth_interface_params eth_interface_params;
     std::vector<tt::ARCH> archs_in_cluster = {};
     std::set<chip_id_t> target_devices_in_cluster = {};
     std::set<chip_id_t> target_remote_chips = {};

--- a/device/api/umd/device/types/cluster_types.h
+++ b/device/api/umd/device/types/cluster_types.h
@@ -35,6 +35,12 @@ inline std::ostream& operator<<(std::ostream& os, const tt_DevicePowerState powe
     return os;
 }
 
+struct barrier_address_params {
+    std::uint32_t tensix_l1_barrier_base = 0;
+    std::uint32_t eth_l1_barrier_base = 0;
+    std::uint32_t dram_barrier_base = 0;
+};
+
 struct tt_device_dram_address_params {
     std::uint32_t DRAM_BARRIER_BASE = 0;
 };

--- a/device/api/umd/device/wormhole_implementation.h
+++ b/device/api/umd/device/wormhole_implementation.h
@@ -333,6 +333,7 @@ public:
     std::optional<std::tuple<std::uint64_t, std::uint64_t>> describe_tlb(std::int32_t tlb_index) const override;
     std::pair<std::uint64_t, std::uint64_t> get_tlb_data(std::uint32_t tlb_index, const tlb_data& data) const override;
 
+    tt_device_l1_address_params get_l1_address_params() const override;
     tt_driver_host_address_params get_host_address_params() const override;
     tt_driver_eth_interface_params get_eth_interface_params() const override;
     tt_driver_noc_params get_noc_params() const override;

--- a/device/blackhole/blackhole_implementation.cpp
+++ b/device/blackhole/blackhole_implementation.cpp
@@ -5,7 +5,9 @@
 #include "umd/device/blackhole_implementation.h"
 
 #include "blackhole/eth_interface.h"
+#include "blackhole/eth_l1_address_map.h"
 #include "blackhole/host_mem_address_map.h"
+#include "blackhole/l1_address_map.h"
 #include "umd/device/cluster.h"
 
 constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h, common for WH && BH
@@ -76,6 +78,15 @@ std::pair<std::uint64_t, std::uint64_t> blackhole_implementation::get_tlb_data(
     } else {
         throw std::runtime_error("Invalid TLB index for Blackhole arch");
     }
+}
+
+tt_device_l1_address_params blackhole_implementation::get_l1_address_params() const {
+    // L1 barrier base and erisc barrier base should be explicitly set by the client.
+    // Setting some default values here, but it should be ultimately overridden by the client.
+    return {
+        ::l1_mem::address_map::L1_BARRIER_BASE,
+        ::eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+        ::eth_l1_mem::address_map::FW_VERSION_ADDR};
 }
 
 tt_driver_host_address_params blackhole_implementation::get_host_address_params() const {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -472,6 +472,12 @@ void Cluster::construct_cluster(
         }
     }
 
+    // Default initialize l1_address_params based on detected arch
+    l1_address_params = architecture_implementation->get_l1_address_params();
+
+    // Default initialize dram_address_params.
+    dram_address_params = {0u};
+
     // Default initialize host_address_params based on detected arch
     host_address_params = architecture_implementation->get_host_address_params();
 
@@ -3305,22 +3311,6 @@ void Cluster::close_device() {
     broadcast_tensix_risc_reset_to_cluster(TENSIX_ASSERT_SOFT_RESET);
 }
 
-void Cluster::set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_) {
-    l1_address_params = l1_address_params_;
-}
-
-void Cluster::set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_) {
-    dram_address_params = dram_address_params_;
-}
-
-void Cluster::set_driver_host_address_params(const tt_driver_host_address_params& host_address_params_) {
-    host_address_params = host_address_params_;
-}
-
-void Cluster::set_driver_eth_interface_params(const tt_driver_eth_interface_params& eth_interface_params_) {
-    eth_interface_params = eth_interface_params_;
-}
-
 void Cluster::setup_core_to_tlb_map(
     const chip_id_t logical_device_id, std::function<std::int32_t(tt_xy_pair)> mapping_function) {
     map_core_to_tlb_per_chip[logical_device_id] = mapping_function;
@@ -3377,6 +3367,12 @@ tt_version Cluster::get_ethernet_fw_version() const {
         eth_fw_version.major != 0xffff and eth_fw_version.minor != 0xff and eth_fw_version.patch != 0xff,
         "Device must be started before querying Ethernet FW version.");
     return eth_fw_version;
+}
+
+void Cluster::set_barrier_address_params(const barrier_address_params& barrier_address_params_) {
+    l1_address_params.tensix_l1_barrier_base = barrier_address_params_.tensix_l1_barrier_base;
+    l1_address_params.eth_l1_barrier_base = barrier_address_params_.eth_l1_barrier_base;
+    dram_address_params.DRAM_BARRIER_BASE = barrier_address_params_.dram_barrier_base;
 }
 
 }  // namespace tt::umd

--- a/device/grayskull/grayskull_implementation.cpp
+++ b/device/grayskull/grayskull_implementation.cpp
@@ -6,6 +6,7 @@
 
 #include "grayskull/eth_interface.h"
 #include "grayskull/host_mem_address_map.h"
+#include "grayskull/l1_address_map.h"
 #include "umd/device/cluster.h"
 
 constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 32;   // source: noc_parameters.h, unique for GS
@@ -86,6 +87,13 @@ std::pair<std::uint64_t, std::uint64_t> grayskull_implementation::get_tlb_data(
     } else {
         throw std::runtime_error("Invalid TLB index for Grayskull arch");
     }
+}
+
+tt_device_l1_address_params grayskull_implementation::get_l1_address_params() const {
+    // L1 barrier base should be explicitly set by the client.
+    // Setting some default value here, but it should be ultimately overridden by the client.
+    // Grayskull doesn't have ethernet cores, so no eth params are set here.
+    return {::l1_mem::address_map::L1_BARRIER_BASE, 0, 0};
 }
 
 tt_driver_host_address_params grayskull_implementation::get_host_address_params() const {

--- a/device/mockup/tt_mockup_device.hpp
+++ b/device/mockup/tt_mockup_device.hpp
@@ -21,13 +21,7 @@ public:
 
     virtual ~tt_MockupDevice() {}
 
-    void set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_) override {}
-
-    void set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_) override {}
-
-    void set_driver_host_address_params(const tt_driver_host_address_params& host_address_params_) override {}
-
-    void set_driver_eth_interface_params(const tt_driver_eth_interface_params& eth_interface_params_) override {}
+    void set_barrier_address_params(const barrier_address_params& barrier_address_params_) override {}
 
     void start_device(const tt_device_params& device_params) override {}
 

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -79,21 +79,7 @@ tt_SimulationDevice::tt_SimulationDevice(const std::string& sdesc_path) : tt_dev
 
 tt_SimulationDevice::~tt_SimulationDevice() { close_device(); }
 
-void tt_SimulationDevice::set_device_l1_address_params(const tt_device_l1_address_params& l1_address_params_) {
-    l1_address_params = l1_address_params_;
-}
-
-void tt_SimulationDevice::set_device_dram_address_params(const tt_device_dram_address_params& dram_address_params_) {
-    dram_address_params = dram_address_params_;
-}
-
-void tt_SimulationDevice::set_driver_host_address_params(const tt_driver_host_address_params& host_address_params_) {
-    host_address_params = host_address_params_;
-}
-
-void tt_SimulationDevice::set_driver_eth_interface_params(const tt_driver_eth_interface_params& eth_interface_params_) {
-    eth_interface_params = eth_interface_params_;
-}
+void tt_SimulationDevice::set_barrier_address_params(const barrier_address_params& barrier_address_params_) {}
 
 void tt_SimulationDevice::start_device(const tt_device_params& device_params) {
     void* buf_ptr = nullptr;

--- a/device/wormhole/wormhole_implementation.cpp
+++ b/device/wormhole/wormhole_implementation.cpp
@@ -6,7 +6,9 @@
 
 #include "umd/device/cluster.h"
 #include "wormhole/eth_interface.h"
+#include "wormhole/eth_l1_address_map.h"
 #include "wormhole/host_mem_address_map.h"
+#include "wormhole/l1_address_map.h"
 
 constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h, common for WH && BH
 constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6;  // source: noc_parameters.h, common for WH && BH
@@ -94,6 +96,15 @@ std::pair<std::uint64_t, std::uint64_t> wormhole_implementation::get_tlb_data(
     } else {
         throw std::runtime_error("Invalid TLB index for Wormhole arch");
     }
+}
+
+tt_device_l1_address_params wormhole_implementation::get_l1_address_params() const {
+    // L1 barrier base and erisc barrier base should be explicitly set by the client.
+    // Setting some default values here, but it should be ultimately overridden by the client.
+    return {
+        ::l1_mem::address_map::L1_BARRIER_BASE,
+        ::eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+        ::eth_l1_mem::address_map::FW_VERSION_ADDR};
 }
 
 tt_driver_host_address_params wormhole_implementation::get_host_address_params() const {

--- a/tests/blackhole/test_bh_common.h
+++ b/tests/blackhole/test_bh_common.h
@@ -11,14 +11,14 @@
 
 using namespace tt::umd;
 
+constexpr std::uint32_t DRAM_BARRIER_BASE = 0;
+
 namespace tt::umd::test::utils {
 
-static void set_params_for_remote_txn(Cluster& cluster) {
-    // Populate address map and NOC parameters that the driver needs for remote transactions
-    cluster.set_device_l1_address_params(
-        {l1_mem::address_map::L1_BARRIER_BASE,
-         eth_l1_mem::address_map::ERISC_BARRIER_BASE,
-         eth_l1_mem::address_map::FW_VERSION_ADDR});
+static void set_barrier_params(Cluster& cluster) {
+    // Populate address map and NOC parameters that the driver needs for memory barriers and remote transactions.
+    cluster.set_barrier_address_params(
+        {l1_mem::address_map::L1_BARRIER_BASE, eth_l1_mem::address_map::ERISC_BARRIER_BASE, DRAM_BARRIER_BASE});
 }
 
 class BlackholeTestFixture : public ::testing::Test {
@@ -58,7 +58,7 @@ protected:
         assert(cluster != nullptr);
         assert(cluster->get_cluster_description()->get_number_of_chips() == get_detected_num_chips());
 
-        set_params_for_remote_txn(*cluster);
+        set_barrier_params(*cluster);
 
         tt_device_params default_params;
         cluster->start_device(default_params);

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -18,12 +18,12 @@
 
 using namespace tt::umd;
 
-void set_params_for_remote_txn(Cluster& cluster) {
-    // Populate address map and NOC parameters that the driver needs for remote transactions
-    cluster.set_device_l1_address_params(
-        {l1_mem::address_map::L1_BARRIER_BASE,
-         eth_l1_mem::address_map::ERISC_BARRIER_BASE,
-         eth_l1_mem::address_map::FW_VERSION_ADDR});
+constexpr std::uint32_t DRAM_BARRIER_BASE = 0;
+
+static void set_barrier_params(Cluster& cluster) {
+    // Populate address map and NOC parameters that the driver needs for memory barriers and remote transactions.
+    cluster.set_barrier_address_params(
+        {l1_mem::address_map::L1_BARRIER_BASE, eth_l1_mem::address_map::ERISC_BARRIER_BASE, DRAM_BARRIER_BASE});
 }
 
 std::int32_t get_static_tlb_index(tt_xy_pair target) {
@@ -92,7 +92,7 @@ TEST(SiliconDriverBH, CreateDestroy) {
             false,
             true,
             false);
-        set_params_for_remote_txn(cluster);
+        set_barrier_params(cluster);
         cluster.start_device(default_params);
         cluster.deassert_risc_reset();
         cluster.close_device();
@@ -190,7 +190,7 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //         true,
 //         true,
 //         simulated_harvesting_masks);
-//     set_params_for_remote_txn(cluster);
+//     set_barrier_params(cluster);
 //     auto mmio_devices = cluster.get_target_mmio_device_ids();
 
 //     for (int i = 0; i < target_devices.size(); i++) {
@@ -280,7 +280,7 @@ TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
     Cluster cluster = Cluster(num_host_mem_ch_per_mmio_device, false, true, true);
-    set_params_for_remote_txn(cluster);
+    set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
 
     for (int i = 0; i < target_devices.size(); i++) {
@@ -337,7 +337,7 @@ TEST(SiliconDriverBH, StaticTLB_RW) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
     Cluster cluster = Cluster(num_host_mem_ch_per_mmio_device, false, true, true);
-    set_params_for_remote_txn(cluster);
+    set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
 
     for (int i = 0; i < target_devices.size(); i++) {
@@ -402,7 +402,7 @@ TEST(SiliconDriverBH, DynamicTLB_RW) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     Cluster cluster = Cluster(num_host_mem_ch_per_mmio_device, false, true, true);
 
-    set_params_for_remote_txn(cluster);
+    set_barrier_params(cluster);
 
     tt_device_params default_params;
     cluster.start_device(default_params);
@@ -492,7 +492,7 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     Cluster cluster = Cluster(num_host_mem_ch_per_mmio_device, false, true, true);
 
-    set_params_for_remote_txn(cluster);
+    set_barrier_params(cluster);
 
     tt_device_params default_params;
     cluster.start_device(default_params);
@@ -562,7 +562,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
     Cluster cluster = Cluster(num_host_mem_ch_per_mmio_device, false, true, true);
-    set_params_for_remote_txn(cluster);
+    set_barrier_params(cluster);
     for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for functional worker cores
         auto& sdesc = cluster.get_soc_descriptor(i);
@@ -702,7 +702,7 @@ TEST(SiliconDriverBH, DISABLED_BroadcastWrite) {  // Cannot broadcast to tensix/
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
     Cluster cluster = Cluster(num_host_mem_ch_per_mmio_device, false, true, true);
-    set_params_for_remote_txn(cluster);
+    set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
 
     tt_device_params default_params;
@@ -790,7 +790,7 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
     Cluster cluster = Cluster(num_host_mem_ch_per_mmio_device, false, true, true);
-    set_params_for_remote_txn(cluster);
+    set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
 
     tt_device_params default_params;
@@ -891,7 +891,7 @@ TEST(SiliconDriverBH, SysmemTestWithPcie) {
         true,   // clean system resources - yes
         true);  // perform harvesting - yes
 
-    set_params_for_remote_txn(cluster);
+    set_barrier_params(cluster);
     cluster.start_device(tt_device_params{});  // no special parameters
 
     const chip_id_t mmio_chip_id = 0;
@@ -962,7 +962,7 @@ TEST(SiliconDriverBH, RandomSysmemTestWithPcie) {
         true,   // clean system resources - yes
         true);  // perform harvesting - yes
 
-    set_params_for_remote_txn(cluster);
+    set_barrier_params(cluster);
     cluster.start_device(tt_device_params{});  // no special parameters
 
     const chip_id_t mmio_chip_id = 0;

--- a/tests/galaxy/test_umd_concurrent_threads.cpp
+++ b/tests/galaxy/test_umd_concurrent_threads.cpp
@@ -53,7 +53,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
         Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), all_devices, num_host_mem_ch_per_mmio_device, false, true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
-    tt::umd::test::utils::set_params_for_remote_txn(device);
+    tt::umd::test::utils::set_barrier_params(device);
 
     tt_device_params default_params;
     device.start_device(default_params);
@@ -150,7 +150,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
         Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), all_devices, num_host_mem_ch_per_mmio_device, false, true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
-    tt::umd::test::utils::set_params_for_remote_txn(device);
+    tt::umd::test::utils::set_barrier_params(device);
 
     tt_device_params default_params;
     device.start_device(default_params);
@@ -236,7 +236,7 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
         Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), target_devices, num_host_mem_ch_per_mmio_device, false, true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
-    tt::umd::test::utils::set_params_for_remote_txn(device);
+    tt::umd::test::utils::set_barrier_params(device);
 
     tt_device_params default_params;
     device.start_device(default_params);

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -33,7 +33,7 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
         Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), target_devices, num_host_mem_ch_per_mmio_device, false, true);
     const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
-    tt::umd::test::utils::set_params_for_remote_txn(device);
+    tt::umd::test::utils::set_barrier_params(device);
 
     tt_device_params default_params;
     device.start_device(default_params);
@@ -150,7 +150,7 @@ void run_data_mover_test(
     Cluster device =
         Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), target_devices, num_host_mem_ch_per_mmio_device, false, true);
 
-    tt::umd::test::utils::set_params_for_remote_txn(device);
+    tt::umd::test::utils::set_barrier_params(device);
 
     tt_device_params default_params;
     device.start_device(default_params);
@@ -269,7 +269,7 @@ void run_data_broadcast_test(
     Cluster device =
         Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), target_devices, num_host_mem_ch_per_mmio_device, false, true);
 
-    tt::umd::test::utils::set_params_for_remote_txn(device);
+    tt::umd::test::utils::set_barrier_params(device);
 
     tt_device_params default_params;
     device.start_device(default_params);

--- a/tests/grayskull/test_cluster_gs.cpp
+++ b/tests/grayskull/test_cluster_gs.cpp
@@ -15,6 +15,14 @@
 
 using namespace tt::umd;
 
+constexpr std::uint32_t DRAM_BARRIER_BASE = 0;
+
+static void set_barrier_params(Cluster& cluster) {
+    // Populate address map and NOC parameters that the driver needs for memory barriers.
+    // Grayskull doesn't have ETH, so we don't need to populate the ETH barrier address.
+    cluster.set_barrier_address_params({l1_mem::address_map::L1_BARRIER_BASE, 0u, DRAM_BARRIER_BASE});
+}
+
 TEST(SiliconDriverGS, CreateDestroySequential) {
     std::set<chip_id_t> target_devices = {0};
     uint32_t num_host_mem_ch_per_mmio_device = 1;
@@ -426,7 +434,12 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
     std::vector<uint32_t> readback_membar_vec = {};
     for (auto& core : cluster.get_soc_descriptor(0).workers) {
         test_utils::read_data_from_device(
-            cluster, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
+            cluster,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            l1_mem::address_map::L1_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all workers
         readback_membar_vec = {};
@@ -434,7 +447,12 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
 
     for (auto& core : cluster.get_soc_descriptor(0).workers) {
         test_utils::read_data_from_device(
-            cluster, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
+            cluster,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            l1_mem::address_map::L1_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all workers
         readback_membar_vec = {};
@@ -443,7 +461,7 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
     for (int chan = 0; chan < cluster.get_soc_descriptor(0).get_num_dram_channels(); chan++) {
         auto core = cluster.get_soc_descriptor(0).get_core_for_dram_channel(chan, 0);
         test_utils::read_data_from_device(
-            cluster, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
+            cluster, readback_membar_vec, tt_cxy_pair(0, core), DRAM_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all DRAM
         readback_membar_vec = {};
@@ -502,7 +520,12 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
 
     for (auto& core : cluster.get_soc_descriptor(0).workers) {
         test_utils::read_data_from_device(
-            cluster, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
+            cluster,
+            readback_membar_vec,
+            tt_cxy_pair(0, core),
+            l1_mem::address_map::L1_BARRIER_BASE,
+            4,
+            "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(readback_membar_vec.at(0), 187);  // Ensure that memory barriers end up in correct sate workers
         readback_membar_vec = {};
     }

--- a/tests/wormhole/test_wh_common.h
+++ b/tests/wormhole/test_wh_common.h
@@ -12,14 +12,14 @@
 #include "umd/device/tt_cluster_descriptor.h"
 #include "umd/device/tt_xy_pair.h"
 
+constexpr std::uint32_t DRAM_BARRIER_BASE = 0;
+
 namespace tt::umd::test::utils {
 
-static void set_params_for_remote_txn(Cluster& cluster) {
-    // Populate address map and NOC parameters that the driver needs for remote transactions
-    cluster.set_device_l1_address_params(
-        {l1_mem::address_map::L1_BARRIER_BASE,
-         eth_l1_mem::address_map::ERISC_BARRIER_BASE,
-         eth_l1_mem::address_map::FW_VERSION_ADDR});
+static void set_barrier_params(Cluster& cluster) {
+    // Populate address map and NOC parameters that the driver needs for memory barriers and remote transactions.
+    cluster.set_barrier_address_params(
+        {l1_mem::address_map::L1_BARRIER_BASE, eth_l1_mem::address_map::ERISC_BARRIER_BASE, DRAM_BARRIER_BASE});
 }
 
 class WormholeTestFixture : public ::testing::Test {
@@ -58,7 +58,7 @@ protected:
         assert(cluster != nullptr);
         assert(cluster->get_cluster_description()->get_number_of_chips() == get_detected_num_chips());
 
-        set_params_for_remote_txn(*cluster);
+        set_barrier_params(*cluster);
 
         tt_device_params default_params;
         cluster->start_device(default_params);


### PR DESCRIPTION
### Issue
Fixes #106 

### Description
Part of this was done previously in https://github.com/tenstorrent/tt-umd/pull/260 https://github.com/tenstorrent/tt-umd/pull/261 and https://github.com/tenstorrent/tt-umd/pull/234

### List of the changes
- Added default l1_address_params and dram_address_params
- Remove set_device_l1_address_params, set_device_dram_address_params, set_driver_host_address_params, set_driver_eth_interface_params
- Remove unnecessary code from tests

### Testing
CI tests, but more importantly CI tests on the related tt_metal PR.

### API Changes
This PR has API changes:
- [x] tt_metal approved PR pointing to this branch: https://github.com/tenstorrent/tt-metal/pull/15908
- [X] No breaking changes in tt_debuda
