### PR TITLE
Revert "Abolish get_available_num_host_mem_channels"

### DIFF
--- a/device/api/umd/device/hugepage.h
+++ b/device/api/umd/device/hugepage.h
@@ -16,6 +16,10 @@ namespace tt::umd {
 // Get number of 1GB host hugepages installed.
 uint32_t get_num_hugepages();
 
+// Dynamically figure out how many host memory channels (based on hugepages installed) for each device, based on arch.
+uint32_t get_available_num_host_mem_channels(
+    const uint32_t num_channels_per_device_target, const uint16_t device_id, const uint16_t revision_id);
+
 // Looks for hugetlbfs inside /proc/mounts matching desired pagesize (typically 1G)
 std::string find_hugepage_dir(std::size_t pagesize);
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -240,7 +240,14 @@ void Cluster::create_device(
         }
         auto pci_device = m_tt_device_map.at(logical_device_id)->get_pci_device();
 
-        int num_host_mem_channels = num_host_mem_ch_per_mmio_device;
+        uint16_t pcie_device_id = pci_device->get_pci_device_id();
+        uint32_t pcie_revision = pci_device->get_pci_revision();
+        // TODO: get rid of this, it doesn't make any sense.
+        // Update: I did get rid of it and it broke Metal CI, which is passing
+        // tests that ask for more hugepages than exist.  That's wrong, but it
+        // isn't fixed yet, so until then...
+        int num_host_mem_channels =
+            get_available_num_host_mem_channels(num_host_mem_ch_per_mmio_device, pcie_device_id, pcie_revision);
 
         log_debug(
             LogSiliconDriver,

--- a/device/hugepage.cpp
+++ b/device/hugepage.cpp
@@ -37,6 +37,68 @@ uint32_t get_num_hugepages() {
     return num_hugepages;
 }
 
+uint32_t get_available_num_host_mem_channels(
+    const uint32_t num_channels_per_device_target, const uint16_t device_id, const uint16_t revision_id) {
+    // To minimally support hybrid dev systems with mix of ARCH, get only devices matching current ARCH's device_id.
+    uint32_t total_num_tt_mmio_devices = tt::cpuset::tt_cpuset_allocator::get_num_tt_pci_devices();
+    uint32_t num_tt_mmio_devices_for_arch =
+        tt::cpuset::tt_cpuset_allocator::get_num_tt_pci_devices_by_pci_device_id(device_id, revision_id);
+    uint32_t total_hugepages = get_num_hugepages();
+
+    // This shouldn't happen on silicon machines.
+    if (num_tt_mmio_devices_for_arch == 0) {
+        log_warning(
+            LogSiliconDriver,
+            "No TT devices found that match PCI device_id: 0x{:x} revision: {}, returning NumHostMemChannels:0",
+            device_id,
+            revision_id);
+        return 0;
+    }
+
+    // GS will use P2P + 1 channel, others may support 4 host channels. Apply min of 1 to not completely break setups
+    // that were incomplete ie fewer hugepages than devices, which would partially work previously for some devices.
+    uint32_t num_channels_per_device_available =
+        std::min(num_channels_per_device_target, std::max((uint32_t)1, total_hugepages / num_tt_mmio_devices_for_arch));
+
+    // Perform some helpful assertion checks to guard against common pitfalls that would show up as runtime issues later
+    // on.
+    if (total_num_tt_mmio_devices > num_tt_mmio_devices_for_arch) {
+        log_warning(
+            LogSiliconDriver,
+            "Hybrid system mixing different TTDevices - this is not well supported. Ensure sufficient "
+            "Hugepages/HostMemChannels per device.");
+    }
+
+    if (total_hugepages < num_tt_mmio_devices_for_arch) {
+        log_warning(
+            LogSiliconDriver,
+            "Insufficient NumHugepages: {} should be at least NumMMIODevices: {} for device_id: 0x{:x} revision: {}. "
+            "NumHostMemChannels would be 0, bumping to 1.",
+            total_hugepages,
+            num_tt_mmio_devices_for_arch,
+            device_id,
+            revision_id);
+    }
+
+    if (num_channels_per_device_available < num_channels_per_device_target) {
+        log_warning(
+            LogSiliconDriver,
+            "NumHostMemChannels: {} used for device_id: 0x{:x} less than target: {}. Workload will fail if it exceeds "
+            "NumHostMemChannels. Increase Number of Hugepages.",
+            num_channels_per_device_available,
+            device_id,
+            num_channels_per_device_target);
+    }
+
+    log_assert(
+        num_channels_per_device_available <= g_MAX_HOST_MEM_CHANNELS,
+        "NumHostMemChannels: {} exceeds supported maximum: {}, this is unexpected.",
+        num_channels_per_device_available,
+        g_MAX_HOST_MEM_CHANNELS);
+
+    return num_channels_per_device_available;
+}
+
 std::string find_hugepage_dir(std::size_t pagesize) {
     static const std::regex hugetlbfs_mount_re(
         fmt::format("^(nodev|hugetlbfs) ({}) hugetlbfs ([^ ]+) 0 0$", hugepage_dir));


### PR DESCRIPTION
Reverts commit 3210bd959bc75e5e2d97b30631bbb606585a48e5 from https://github.com/tenstorrent/tt-umd/pull/393.

### Issue
Metal CI failure tracked in https://github.com/tenstorrent/tt-metal/issues/15675

### Description
The reverted commit removed logic that allowed applications to request more hugepages than available to UMD.  Previously, UMD would issue a warning in such cases.  However, this created a potential safety issue since applications had no visibility into partial hugepage allocation (e.g., requesting 4 pages but receiving only 2).

This situation could lead to:
- Host software segfaults when accessing unmapped pages
- More critically, device software could potentially corrupt host physical address space by writing to nonexistent pages

While the original change (making excessive hugepage requests a fatal error) improved safety, particularly in conjunction with IOMMU enablement, it caused failures in Metal CI tests that (possibly unintentionally?) request more hugepages than available.  This revert is a temporary measure until the Metal CI tests can be updated.


### List of the changes
* Revert 3210bd959bc75e5e2d97b30631bbb606585a48e5
* Update comment documentation

### Testing
CI

### API Changes
There are no API changes in this PR.

