### PR TITLE
Implement Cluster CoreCoord API

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -866,6 +866,8 @@ private:
         const bool clean_system_resources,
         bool perform_harvesting,
         std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks);
+    tt::umd::CoreCoord translate_chip_coord(
+        const chip_id_t chip, const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const;
 
     // State variables
     tt_device_dram_address_params dram_address_params;

--- a/device/api/umd/device/coordinate_manager.h
+++ b/device/api/umd/device/coordinate_manager.h
@@ -40,7 +40,7 @@ public:
 
     CoordinateManager(CoordinateManager& other) = default;
 
-    tt::umd::CoreCoord to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system);
+    tt::umd::CoreCoord translate_coord_to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system);
 
     std::vector<tt::umd::CoreCoord> get_cores(const CoreType core_type) const;
     tt_xy_pair get_grid_size(const CoreType core_type) const;

--- a/device/api/umd/device/tt_core_coordinates.h
+++ b/device/api/umd/device/tt_core_coordinates.h
@@ -83,3 +83,10 @@ struct CoreCoord : public tt_xy_pair {
 };
 
 }  // namespace tt::umd
+
+namespace std {
+template <>
+struct hash<tt::umd::CoreCoord> {
+    size_t operator()(const tt::umd::CoreCoord& core_coord) const;
+};
+}  // namespace std

--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -90,7 +90,7 @@ public:
         harvested_grid_size_map(other.harvested_grid_size_map) {}
 
     // CoreCoord conversions.
-    tt::umd::CoreCoord to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const;
+    tt::umd::CoreCoord translate_coord_to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const;
 
     static std::string get_soc_descriptor_path(tt::ARCH arch);
 

--- a/device/blackhole/blackhole_coordinate_manager.cpp
+++ b/device/blackhole/blackhole_coordinate_manager.cpp
@@ -38,6 +38,9 @@ BlackholeCoordinateManager::BlackholeCoordinateManager(
 }
 
 void BlackholeCoordinateManager::translate_tensix_coords() {
+    if (CoordinateManager::get_num_harvested(tensix_harvesting_mask) > tensix_grid_size.x) {
+        tensix_harvesting_mask = 0;
+    }
     size_t num_harvested_x = CoordinateManager::get_num_harvested(tensix_harvesting_mask);
     size_t grid_size_x = tensix_grid_size.x;
     size_t grid_size_y = tensix_grid_size.y;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -590,11 +590,8 @@ Cluster::Cluster(
             "Target device {} not present in current cluster!",
             chip_id);
 
-        // Note that initially soc_descriptors are not harvested, but will be harvested later if perform_harvesting is
-        // true.
-        // TODO: This should be changed, harvesting should be done in tt_socdescriptor's constructor and not as part of
-        // cluster class.
-        tt_SocDescriptor soc_desc = tt_SocDescriptor(sdesc_path);
+        size_t tensix_harvesting_mask = cluster_desc->get_harvesting_info().at(chip_id);
+        tt_SocDescriptor soc_desc = tt_SocDescriptor(sdesc_path, tensix_harvesting_mask);
         log_assert(
             cluster_desc->get_arch(chip_id) == soc_desc.arch,
             "Passed soc descriptor has {} arch, but for chip id {} has arch {}",

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -690,7 +690,7 @@ void Cluster::configure_active_ethernet_cores_for_mmio_device(
     const tt_SocDescriptor& soc_desc = get_soc_descriptor(mmio_chip);
     for (const auto& core : active_eth_cores_per_chip) {
         CoreCoord virtual_coord = soc_desc.translate_coord_to(core, CoordSystem::VIRTUAL);
-        active_eth_cores_xy.insert(tt_xy_pair(virtual_coord.x, virtual_coord.y));
+        active_eth_cores_xy.insert(virtual_coord);
     }
 
     configure_active_ethernet_cores_for_mmio_device(mmio_chip, active_eth_cores_xy);
@@ -1011,12 +1011,8 @@ void Cluster::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftRese
 
 void Cluster::deassert_risc_reset_at_core(
     const chip_id_t chip, const CoreCoord core, const TensixSoftResetOptions& soft_resets) {
-    tt_cxy_pair virtual_core;
-    virtual_core.chip = chip;
     const CoreCoord virtual_coord = get_soc_descriptor(chip).translate_coord_to(core, CoordSystem::VIRTUAL);
-    virtual_core.x = virtual_coord.x;
-    virtual_core.y = virtual_coord.y;
-    deassert_risc_reset_at_core(virtual_core, soft_resets);
+    deassert_risc_reset_at_core({(size_t)chip, virtual_coord}, soft_resets);
 }
 
 void Cluster::assert_risc_reset_at_core(tt_cxy_pair core) {
@@ -1040,12 +1036,8 @@ void Cluster::assert_risc_reset_at_core(tt_cxy_pair core) {
 }
 
 void Cluster::assert_risc_reset_at_core(const chip_id_t chip, const CoreCoord core) {
-    tt_cxy_pair virtual_core;
-    virtual_core.chip = chip;
     const CoreCoord virtual_coord = get_soc_descriptor(chip).translate_coord_to(core, CoordSystem::VIRTUAL);
-    virtual_core.x = virtual_coord.x;
-    virtual_core.y = virtual_coord.y;
-    assert_risc_reset_at_core(virtual_core);
+    assert_risc_reset_at_core({(size_t)chip, virtual_coord});
 }
 
 // Free memory during teardown, and remove (clean/unlock) from any leftover mutexes.
@@ -1111,12 +1103,8 @@ tt::Writer Cluster::get_static_tlb_writer(tt_cxy_pair target) {
 }
 
 tt::Writer Cluster::get_static_tlb_writer(const chip_id_t chip, const CoreCoord target) {
-    tt_cxy_pair virtual_core;
-    virtual_core.chip = chip;
     const CoreCoord virtual_coord = get_soc_descriptor(chip).translate_coord_to(target, CoordSystem::VIRTUAL);
-    virtual_core.x = virtual_coord.x;
-    virtual_core.y = virtual_coord.y;
-    return get_static_tlb_writer(virtual_core);
+    return get_static_tlb_writer({(size_t)chip, virtual_coord});
 }
 
 void Cluster::write_device_memory(
@@ -1365,12 +1353,8 @@ std::optional<std::tuple<uint32_t, uint32_t>> Cluster::get_tlb_data_from_target(
 }
 
 std::optional<std::tuple<uint32_t, uint32_t>> Cluster::get_tlb_data_from_target(const chip_id_t chip, CoreCoord core) {
-    tt_cxy_pair virtual_core;
-    virtual_core.chip = chip;
     const CoreCoord virtual_coord = get_soc_descriptor(chip).translate_coord_to(core, CoordSystem::VIRTUAL);
-    virtual_core.x = virtual_coord.x;
-    virtual_core.y = virtual_coord.y;
-    return get_tlb_data_from_target(virtual_core);
+    return get_tlb_data_from_target({(size_t)chip, virtual_coord});
 }
 
 void Cluster::configure_tlb(
@@ -1405,12 +1389,9 @@ void Cluster::configure_tlb(
 
 void Cluster::configure_tlb(
     chip_id_t logical_device_id, tt::umd::CoreCoord core, int32_t tlb_index, uint64_t address, uint64_t ordering) {
-    tt_xy_pair virtual_core;
     const CoreCoord virtual_coord =
         get_soc_descriptor(logical_device_id).translate_coord_to(core, CoordSystem::VIRTUAL);
-    virtual_core.x = virtual_coord.x;
-    virtual_core.y = virtual_coord.y;
-    configure_tlb(logical_device_id, virtual_core, tlb_index, address, ordering);
+    configure_tlb(logical_device_id, {virtual_coord.x, virtual_coord.y}, tlb_index, address, ordering);
 }
 
 void Cluster::set_fallback_tlb_ordering_mode(const std::string& fallback_tlb, uint64_t ordering) {
@@ -3074,12 +3055,8 @@ void Cluster::write_to_device(
     CoreCoord core,
     uint64_t addr,
     const std::string& tlb_to_use) {
-    tt_cxy_pair virtual_core;
-    virtual_core.chip = chip;
     CoreCoord virtual_coord = get_soc_descriptor(chip).translate_coord_to(core, CoordSystem::VIRTUAL);
-    virtual_core.x = virtual_coord.x;
-    virtual_core.y = virtual_coord.y;
-    write_to_device(mem_ptr, size_in_bytes, virtual_core, addr, tlb_to_use);
+    write_to_device(mem_ptr, size_in_bytes, {(size_t)chip, virtual_coord}, addr, tlb_to_use);
 }
 
 void Cluster::read_mmio_device_register(
@@ -3143,12 +3120,8 @@ void Cluster::read_from_device(
 
 void Cluster::read_from_device(
     void* mem_ptr, chip_id_t chip, CoreCoord core, uint64_t addr, uint32_t size, const std::string& fallback_tlb) {
-    tt_cxy_pair virtual_core;
-    virtual_core.chip = chip;
     CoreCoord virtual_coord = get_soc_descriptor(chip).translate_coord_to(core, CoordSystem::VIRTUAL);
-    virtual_core.x = virtual_coord.x;
-    virtual_core.y = virtual_coord.y;
-    read_from_device(mem_ptr, virtual_core, addr, size, fallback_tlb);
+    read_from_device(mem_ptr, {(size_t)chip, virtual_coord}, addr, size, fallback_tlb);
 }
 
 int Cluster::arc_msg(

--- a/device/coordinate_manager.cpp
+++ b/device/coordinate_manager.cpp
@@ -86,6 +86,9 @@ CoreCoord CoordinateManager::translate_coord_to(const CoreCoord core_coord, cons
 }
 
 void CoordinateManager::translate_tensix_coords() {
+    if (CoordinateManager::get_num_harvested(tensix_harvesting_mask) > tensix_grid_size.y) {
+        tensix_harvesting_mask = 0;
+    }
     size_t num_harvested_y = CoordinateManager::get_num_harvested(tensix_harvesting_mask);
     size_t grid_size_x = tensix_grid_size.x;
     size_t grid_size_y = tensix_grid_size.y;

--- a/device/coordinate_manager.cpp
+++ b/device/coordinate_manager.cpp
@@ -81,7 +81,7 @@ void CoordinateManager::identity_map_physical_cores() {
     }
 }
 
-CoreCoord CoordinateManager::to(const CoreCoord core_coord, const CoordSystem coord_system) {
+CoreCoord CoordinateManager::translate_coord_to(const CoreCoord core_coord, const CoordSystem coord_system) {
     return from_physical_map.at({to_physical_map.at(core_coord), coord_system});
 }
 

--- a/device/tt_core_coordinates.cpp
+++ b/device/tt_core_coordinates.cpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/tt_core_coordinates.h"
+
+namespace std {
+std::size_t operator()(const CoreCoord& core_coord) const {
+    size_t seed = 0;
+    seed = std::hash<size_t>{}(core_coord.x) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    seed = std::hash<size_t>{}(core_coord.y) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    seed = std::hash<CoreType>{}(core_coord.core_type) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    seed = std::hash<CoordSystem>{}(core_coord.coord_system) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    return seed;
+}
+}  // namespace std

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -211,8 +211,9 @@ void tt_SocDescriptor::create_coordinate_manager(
     get_cores_and_grid_size_from_coordinate_manager();
 }
 
-tt::umd::CoreCoord tt_SocDescriptor::to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const {
-    return coordinate_manager->to(core_coord, coord_system);
+tt::umd::CoreCoord tt_SocDescriptor::translate_coord_to(
+    const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const {
+    return coordinate_manager->translate_coord_to(core_coord, coord_system);
 }
 
 tt_SocDescriptor::tt_SocDescriptor(
@@ -269,7 +270,7 @@ tt_xy_pair tt_SocDescriptor::get_core_for_dram_channel(int dram_chan, int subcha
 
 CoreCoord tt_SocDescriptor::get_dram_core_for_channel(int dram_chan, int subchannel) const {
     const CoreCoord logical_dram_coord = CoreCoord(dram_chan, subchannel, CoreType::DRAM, CoordSystem::LOGICAL);
-    return to(logical_dram_coord, CoordSystem::PHYSICAL);
+    return translate_coord_to(logical_dram_coord, CoordSystem::PHYSICAL);
 }
 
 bool tt_SocDescriptor::is_ethernet_core(const tt_xy_pair &core) const {

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "fmt/xchar.h"
+#include "l1_address_map.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "umd/device/chip/local_chip.h"
 #include "umd/device/chip/mock_chip.h"
@@ -101,37 +102,25 @@ TEST(ApiClusterTest, SimpleIOAllChips) {
     for (auto chip_id : umd_cluster->get_target_device_ids()) {
         const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(chip_id);
 
-        // TODO: figure out if core locations should contain chip_id
-        tt_xy_pair any_core = soc_desc.workers[0];
-        tt_cxy_pair any_core_global(chip_id, any_core);
-
-        if (cluster_desc->is_chip_remote(chip_id) && soc_desc.arch != tt::ARCH::WORMHOLE_B0) {
-            std::cout << "Skipping remote chip " << chip_id << " because it is not a wormhole_b0 chip." << std::endl;
-            continue;
-        }
+        CoreCoord any_core = soc_desc.get_cores(CoreType::TENSIX)[0];
 
         std::cout << "Writing to chip " << chip_id << " core " << any_core.str() << std::endl;
 
-        umd_cluster->write_to_device(data.data(), data_size, any_core_global, 0, "LARGE_WRITE_TLB");
+        umd_cluster->write_to_device(data.data(), data_size, chip_id, any_core, 0, "LARGE_WRITE_TLB");
+
+        umd_cluster->wait_for_non_mmio_flush(chip_id);
     }
 
     // Now read back the data.
     for (auto chip_id : umd_cluster->get_target_device_ids()) {
         const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(chip_id);
 
-        // TODO: figure out if core locations should contain chip_id
-        tt_xy_pair any_core = soc_desc.workers[0];
-        tt_cxy_pair any_core_global(chip_id, any_core);
-
-        if (cluster_desc->is_chip_remote(chip_id) && soc_desc.arch != tt::ARCH::WORMHOLE_B0) {
-            std::cout << "Skipping remote chip " << chip_id << " because it is not a wormhole_b0 chip." << std::endl;
-            continue;
-        }
+        CoreCoord any_core = soc_desc.get_cores(CoreType::TENSIX)[0];
 
         std::cout << "Reading from chip " << chip_id << " core " << any_core.str() << std::endl;
 
         std::vector<uint8_t> readback_data(data_size, 0);
-        umd_cluster->read_from_device(readback_data.data(), any_core_global, 0, data_size, "LARGE_READ_TLB");
+        umd_cluster->read_from_device(readback_data.data(), chip_id, any_core, 0, data_size, "LARGE_READ_TLB");
 
         ASSERT_EQ(data, readback_data);
     }
@@ -156,9 +145,7 @@ TEST(ApiClusterTest, RemoteFlush) {
     for (auto chip_id : umd_cluster->get_target_remote_device_ids()) {
         const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(chip_id);
 
-        // TODO: figure out if core locations should contain chip_id
-        tt_xy_pair any_core = soc_desc.workers[0];
-        tt_cxy_pair any_core_global(chip_id, any_core);
+        const CoreCoord any_core = soc_desc.get_cores(CoreType::TENSIX)[0];
 
         if (!cluster_desc->is_chip_remote(chip_id)) {
             std::cout << "Chip " << chip_id << " skipped because it is not a remote chip." << std::endl;
@@ -171,31 +158,17 @@ TEST(ApiClusterTest, RemoteFlush) {
         }
 
         std::cout << "Writing to chip " << chip_id << " core " << any_core.str() << std::endl;
-        umd_cluster->write_to_device(data.data(), data_size, any_core_global, 0, "LARGE_WRITE_TLB");
+        umd_cluster->write_to_device(data.data(), data_size, chip_id, any_core, 0, "LARGE_WRITE_TLB");
 
         std::cout << "Waiting for remote chip flush " << chip_id << std::endl;
         umd_cluster->wait_for_non_mmio_flush(chip_id);
 
-        std::cout << "Waiting again for flush " << chip_id << ", should be no-op" << std::endl;
-        umd_cluster->wait_for_non_mmio_flush(chip_id);
+        std::cout << "Reading from chip " << chip_id << " core " << any_core.str() << std::endl;
+        std::vector<uint8_t> readback_data(data_size, 0);
+        umd_cluster->read_from_device(readback_data.data(), chip_id, any_core, 0, data_size, "LARGE_READ_TLB");
+
+        ASSERT_EQ(data, readback_data);
     }
-
-    chip_id_t any_remote_chip = *umd_cluster->get_target_remote_device_ids().begin();
-    const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(any_remote_chip);
-    tt_xy_pair any_core = soc_desc.workers[0];
-    tt_cxy_pair any_core_global(any_remote_chip, any_core);
-    if (soc_desc.arch != tt::ARCH::WORMHOLE_B0) {
-        std::cout << "Skipping whole cluster wait because it is not a wormhole_b0 chip." << std::endl;
-        return;
-    }
-    std::cout << "Writing to chip " << any_remote_chip << " core " << any_core.str() << std::endl;
-    umd_cluster->write_to_device(data.data(), data_size, any_core_global, 0, "LARGE_WRITE_TLB");
-
-    std::cout << "Testing whole cluster wait for remote chip flush." << std::endl;
-    umd_cluster->wait_for_non_mmio_flush();
-
-    std::cout << "Testing whole cluster wait for remote chip flush again, should be no-op." << std::endl;
-    umd_cluster->wait_for_non_mmio_flush();
 }
 
 TEST(ApiClusterTest, SimpleIOSpecificChips) {
@@ -223,38 +196,80 @@ TEST(ApiClusterTest, SimpleIOSpecificChips) {
     for (auto chip_id : umd_cluster->get_target_device_ids()) {
         const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(chip_id);
 
-        // TODO: figure out if core locations should contain chip_id
-        tt_xy_pair any_core = soc_desc.workers[0];
-        tt_cxy_pair any_core_global(chip_id, any_core);
-
-        if (cluster_desc->is_chip_remote(chip_id) && soc_desc.arch != tt::ARCH::WORMHOLE_B0) {
-            std::cout << "Skipping remote chip " << chip_id << " because it is not a wormhole_b0 chip." << std::endl;
-            continue;
-        }
+        const CoreCoord any_core = soc_desc.get_cores(CoreType::TENSIX)[0];
 
         std::cout << "Writing to chip " << chip_id << " core " << any_core.str() << std::endl;
 
-        umd_cluster->write_to_device(data.data(), data_size, any_core_global, 0, "LARGE_WRITE_TLB");
+        umd_cluster->write_to_device(data.data(), data_size, chip_id, any_core, 0, "LARGE_WRITE_TLB");
+
+        umd_cluster->wait_for_non_mmio_flush(chip_id);
     }
 
     // Now read back the data.
     for (auto chip_id : umd_cluster->get_target_device_ids()) {
         const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(chip_id);
 
-        // TODO: figure out if core locations should contain chip_id
-        tt_xy_pair any_core = soc_desc.workers[0];
-        tt_cxy_pair any_core_global(chip_id, any_core);
-
-        if (cluster_desc->is_chip_remote(chip_id) && soc_desc.arch != tt::ARCH::WORMHOLE_B0) {
-            std::cout << "Skipping remote chip " << chip_id << " because it is not a wormhole_b0 chip." << std::endl;
-            continue;
-        }
+        const CoreCoord any_core = soc_desc.get_cores(CoreType::TENSIX)[0];
 
         std::cout << "Reading from chip " << chip_id << " core " << any_core.str() << std::endl;
 
         std::vector<uint8_t> readback_data(data_size, 0);
-        umd_cluster->read_from_device(readback_data.data(), any_core_global, 0, data_size, "LARGE_READ_TLB");
+        umd_cluster->read_from_device(readback_data.data(), chip_id, any_core, 0, data_size, "LARGE_READ_TLB");
 
         ASSERT_EQ(data, readback_data);
     }
+}
+
+TEST(ClusterAPI, DynamicTLB_RW) {
+    // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for
+    // each transaction
+
+    std::unique_ptr<Cluster> cluster = get_cluster();
+
+    tt_device_params default_params;
+    cluster->start_device(default_params);
+    cluster->deassert_risc_reset();
+
+    std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    std::vector<uint32_t> readback_vec = zeros;
+
+    static const uint32_t num_loops = 100;
+
+    std::set<chip_id_t> target_devices = cluster->get_target_device_ids();
+    for (const chip_id_t chip : target_devices) {
+        std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
+        // Write to each core a 100 times at different statically mapped addresses
+        const tt_SocDescriptor& soc_desc = cluster->get_soc_descriptor(chip);
+        std::vector<CoreCoord> tensix_cores = soc_desc.get_cores(CoreType::TENSIX);
+        for (int loop = 0; loop < num_loops; loop++) {
+            for (auto& core : tensix_cores) {
+                cluster->write_to_device(
+                    vector_to_write.data(),
+                    vector_to_write.size() * sizeof(std::uint32_t),
+                    chip,
+                    core,
+                    address,
+                    "SMALL_READ_WRITE_TLB");
+
+                // Barrier to ensure that all writes over ethernet were commited
+                cluster->wait_for_non_mmio_flush();
+                cluster->read_from_device(readback_vec.data(), chip, core, address, 40, "SMALL_READ_WRITE_TLB");
+
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
+
+                cluster->wait_for_non_mmio_flush();
+
+                cluster->write_to_device(
+                    zeros.data(), zeros.size() * sizeof(std::uint32_t), chip, core, address, "SMALL_READ_WRITE_TLB");
+
+                cluster->wait_for_non_mmio_flush();
+
+                readback_vec = zeros;
+            }
+            address += 0x20;  // Increment by uint32_t size for each write
+        }
+    }
+    cluster->close_device();
 }

--- a/tests/api/test_core_coord_translation_bh.cpp
+++ b/tests/api/test_core_coord_translation_bh.cpp
@@ -20,8 +20,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeNoHarvesting) {
     for (size_t x = 0; x < tensix_grid_size.x; x++) {
         for (size_t y = 0; y < tensix_grid_size.y; y++) {
             CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-            CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
-            CoreCoord physical_coords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+            CoreCoord virtual_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
+            CoreCoord physical_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
 
             // Virtual and physical coordinates should be the same.
             EXPECT_EQ(physical_coords.x, virtual_coords.x);
@@ -43,11 +43,11 @@ TEST(CoordinateManager, CoordinateManagerBlackholeTopLeftCore) {
     CoreCoord logical_coords = CoreCoord(0, 0, CoreType::TENSIX, CoordSystem::LOGICAL);
 
     // Always expect same virtual coordinate for (0, 0) logical coordinate.
-    CoreCoord virtual_cords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+    CoreCoord virtual_cords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
     EXPECT_EQ(virtual_cords, CoreCoord(1, 2, CoreType::TENSIX, CoordSystem::VIRTUAL));
 
     // This depends on harvesting mask. So expected physical coord is specific to this test and Blackhole arch.
-    CoreCoord physical_cords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+    CoreCoord physical_cords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
     EXPECT_EQ(physical_cords, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::PHYSICAL));
 }
 
@@ -71,7 +71,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeLogicalPhysicalMapping) {
         for (size_t x = 0; x < tensix_grid_size.x - num_harvested_x; x++) {
             for (size_t y = 0; y < tensix_grid_size.y; y++) {
                 CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-                CoreCoord physical_coords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+                CoreCoord physical_coords =
+                    coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
                 logical_to_physical[logical_coords] = physical_coords;
 
                 // Expect that logical to physical translation is 1-1 mapping. No duplicates for physical coordinates.
@@ -84,7 +85,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeLogicalPhysicalMapping) {
 
         for (auto it : logical_to_physical) {
             CoreCoord physical_coords = it.second;
-            CoreCoord logical_coords = coordinate_manager->to(physical_coords, CoordSystem::LOGICAL);
+            CoreCoord logical_coords = coordinate_manager->translate_coord_to(physical_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of physical coordinates gives the same logical coordinates
             // using which we got the physical coordinates.
@@ -113,7 +114,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeLogicalVirtualMapping) {
         for (size_t x = 0; x < tensix_grid_size.x - num_harvested_x; x++) {
             for (size_t y = 0; y < tensix_grid_size.y; y++) {
                 CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-                CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+                CoreCoord virtual_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
                 logical_to_virtual[logical_coords] = virtual_coords;
 
                 // Expect that logical to virtual translation is 1-1 mapping. No duplicates for virtual coordinates.
@@ -126,7 +127,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeLogicalVirtualMapping) {
 
         for (auto it : logical_to_virtual) {
             CoreCoord virtual_coords = it.second;
-            CoreCoord logical_coords = coordinate_manager->to(virtual_coords, CoordSystem::LOGICAL);
+            CoreCoord logical_coords = coordinate_manager->translate_coord_to(virtual_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of virtual coordinates gives the same logical coordinates
             // using which we got the virtual coordinates.
@@ -155,7 +156,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeLogicalTranslatedMapping) {
         for (size_t x = 0; x < tensix_grid_size.x - num_harvested_x; x++) {
             for (size_t y = 0; y < tensix_grid_size.y; y++) {
                 CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-                CoreCoord translated_coords = coordinate_manager->to(logical_coords, CoordSystem::TRANSLATED);
+                CoreCoord translated_coords =
+                    coordinate_manager->translate_coord_to(logical_coords, CoordSystem::TRANSLATED);
                 logical_to_translated[logical_coords] = translated_coords;
 
                 // Expect that logical to translated translation is 1-1 mapping. No duplicates for translated
@@ -169,7 +171,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeLogicalTranslatedMapping) {
 
         for (auto it : logical_to_translated) {
             CoreCoord translated_coords = it.second;
-            CoreCoord logical_coords = coordinate_manager->to(translated_coords, CoordSystem::LOGICAL);
+            CoreCoord logical_coords = coordinate_manager->translate_coord_to(translated_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of translated coordinates gives the same logical coordinates
             // using which we got the translated coordinates.
@@ -192,8 +194,9 @@ TEST(CoordinateManager, CoordinateManagerBlackholeVirtualEqualTranslated) {
         for (size_t x = 0; x < tt::umd::blackhole::TENSIX_GRID_SIZE.x - num_harvested_x; x++) {
             for (size_t y = 0; y < tt::umd::blackhole::TENSIX_GRID_SIZE.y; y++) {
                 CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-                CoreCoord translated_coords = coordinate_manager->to(logical_coords, CoordSystem::TRANSLATED);
-                CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+                CoreCoord translated_coords =
+                    coordinate_manager->translate_coord_to(logical_coords, CoordSystem::TRANSLATED);
+                CoreCoord virtual_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
 
                 // Expect that translated coordinates are same as virtual coordinates.
                 EXPECT_EQ(translated_coords.x, virtual_coords.x);
@@ -221,11 +224,13 @@ TEST(CoordinateManager, CoordinateManagerBlackholeTransltedMappingHarvested) {
     for (size_t cnt = 0; cnt < num_harvested_x * tensix_grid_size.y; cnt++) {
         CoreCoord physical_core =
             CoreCoord(tensix_cores[index].x, tensix_cores[index].y, CoreType::TENSIX, CoordSystem::PHYSICAL);
-        const CoreCoord translated_core = coordinate_manager->to(physical_core, CoordSystem::TRANSLATED);
+        const CoreCoord translated_core =
+            coordinate_manager->translate_coord_to(physical_core, CoordSystem::TRANSLATED);
 
         const CoreCoord virtual_core = CoreCoord(
             tensix_cores[virtual_index].x, tensix_cores[virtual_index].y, CoreType::TENSIX, CoordSystem::VIRTUAL);
-        const CoreCoord translated_core_from_virtual = coordinate_manager->to(virtual_core, CoordSystem::TRANSLATED);
+        const CoreCoord translated_core_from_virtual =
+            coordinate_manager->translate_coord_to(virtual_core, CoordSystem::TRANSLATED);
 
         EXPECT_EQ(translated_core, translated_core_from_virtual);
 
@@ -267,7 +272,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMNoHarvesting) {
                 CoreType::DRAM,
                 CoordSystem::PHYSICAL);
 
-            const CoreCoord dram_physical = coordinate_manager->to(dram_logical, CoordSystem::PHYSICAL);
+            const CoreCoord dram_physical = coordinate_manager->translate_coord_to(dram_logical, CoordSystem::PHYSICAL);
 
             EXPECT_EQ(dram_physical, expected_physical);
         }
@@ -282,7 +287,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMTopLeft) {
     const CoreCoord top_left_dram_logical = CoreCoord(0, 0, CoreType::DRAM, CoordSystem::LOGICAL);
     const CoreCoord expected_top_left_physical = CoreCoord(0, 2, CoreType::DRAM, CoordSystem::PHYSICAL);
 
-    const CoreCoord top_left_physical = coordinate_manager->to(top_left_dram_logical, CoordSystem::PHYSICAL);
+    const CoreCoord top_left_physical =
+        coordinate_manager->translate_coord_to(top_left_dram_logical, CoordSystem::PHYSICAL);
 
     EXPECT_EQ(top_left_physical, expected_top_left_physical);
 }
@@ -313,7 +319,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMLogicalPhysicalMapping) {
         for (size_t x = 0; x < num_dram_banks - num_banks_harvested; x++) {
             for (size_t y = 0; y < num_noc_ports_per_bank; y++) {
                 const CoreCoord logical_coords = CoreCoord(x, y, CoreType::DRAM, CoordSystem::LOGICAL);
-                const CoreCoord physical_coords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+                const CoreCoord physical_coords =
+                    coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
                 logical_to_physical[logical_coords] = physical_coords;
 
                 // Expect that logical to physical translation is 1-1 mapping. No duplicates for physical coordinates.
@@ -326,7 +333,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMLogicalPhysicalMapping) {
 
         for (auto it : logical_to_physical) {
             const CoreCoord physical_coords = it.second;
-            const CoreCoord logical_coords = coordinate_manager->to(physical_coords, CoordSystem::LOGICAL);
+            const CoreCoord logical_coords =
+                coordinate_manager->translate_coord_to(physical_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of physical coordinates gives the same logical coordinates
             // using which we got the physical coordinates.
@@ -360,7 +368,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMLogicalVirtualMapping) {
         for (size_t x = 0; x < num_dram_banks - num_harvested_banks; x++) {
             for (size_t y = 0; y < num_noc_ports_per_bank; y++) {
                 CoreCoord logical_coords = CoreCoord(x, y, CoreType::DRAM, CoordSystem::LOGICAL);
-                CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+                CoreCoord virtual_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
                 logical_to_virtual[logical_coords] = virtual_coords;
 
                 // Expect that logical to virtual translation is 1-1 mapping. No duplicates for virtual coordinates.
@@ -371,7 +379,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMLogicalVirtualMapping) {
 
         for (auto it : logical_to_virtual) {
             CoreCoord virtual_coords = it.second;
-            CoreCoord logical_coords = coordinate_manager->to(virtual_coords, CoordSystem::LOGICAL);
+            CoreCoord logical_coords = coordinate_manager->translate_coord_to(virtual_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of virtual coordinates gives the same logical coordinates
             // using which we got the virtual coordinates.
@@ -402,7 +410,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMTranslatedMapping) {
         for (size_t x = 0; x < num_dram_banks - num_harvested_banks; x++) {
             for (size_t y = 0; y < num_noc_ports_per_bank; y++) {
                 const CoreCoord logical_coords = CoreCoord(x, y, CoreType::DRAM, CoordSystem::LOGICAL);
-                const CoreCoord translated_coords = coordinate_manager->to(logical_coords, CoordSystem::TRANSLATED);
+                const CoreCoord translated_coords =
+                    coordinate_manager->translate_coord_to(logical_coords, CoordSystem::TRANSLATED);
 
                 EXPECT_GE(translated_coords.x, tt::umd::blackhole::dram_translated_coordinate_start_x);
                 EXPECT_GE(translated_coords.y, tt::umd::blackhole::dram_translated_coordinate_start_y);
@@ -418,7 +427,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMTranslatedMapping) {
 
         for (auto it : logical_to_translated) {
             const CoreCoord translated_coords = it.second;
-            const CoreCoord logical_coords = coordinate_manager->to(translated_coords, CoordSystem::LOGICAL);
+            const CoreCoord logical_coords =
+                coordinate_manager->translate_coord_to(translated_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of translated coordinates gives the same logical coordinates
             // using which we got the translated coordinates.
@@ -452,14 +462,15 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMVirtualPhysicalMapping) {
         const tt_xy_pair virtual_pair = dram_cores[virtual_index + noc_port];
 
         CoreCoord physical_core = CoreCoord(physical_pair.x, physical_pair.y, CoreType::DRAM, CoordSystem::PHYSICAL);
-        CoreCoord virtual_from_physical = coordinate_manager->to(physical_core, CoordSystem::VIRTUAL);
+        CoreCoord virtual_from_physical = coordinate_manager->translate_coord_to(physical_core, CoordSystem::VIRTUAL);
 
         CoreCoord virtual_core = CoreCoord(virtual_pair.x, virtual_pair.y, CoreType::DRAM, CoordSystem::VIRTUAL);
 
         EXPECT_EQ(virtual_from_physical, virtual_core);
 
-        CoreCoord translated_core = coordinate_manager->to(physical_core, CoordSystem::TRANSLATED);
-        CoreCoord translated_from_virtual = coordinate_manager->to(virtual_core, CoordSystem::TRANSLATED);
+        CoreCoord translated_core = coordinate_manager->translate_coord_to(physical_core, CoordSystem::TRANSLATED);
+        CoreCoord translated_from_virtual =
+            coordinate_manager->translate_coord_to(virtual_core, CoordSystem::TRANSLATED);
 
         EXPECT_EQ(translated_core, translated_from_virtual);
 
@@ -493,8 +504,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholePCIETranslation) {
     for (size_t x = 0; x < pcie_grid_size.x; x++) {
         for (size_t y = 0; y < pcie_grid_size.y; y++) {
             const CoreCoord arc_logical = CoreCoord(x, y, CoreType::PCIE, CoordSystem::LOGICAL);
-            const CoreCoord arc_virtual = coordinate_manager->to(arc_logical, CoordSystem::VIRTUAL);
-            const CoreCoord arc_physical = coordinate_manager->to(arc_logical, CoordSystem::PHYSICAL);
+            const CoreCoord arc_virtual = coordinate_manager->translate_coord_to(arc_logical, CoordSystem::VIRTUAL);
+            const CoreCoord arc_physical = coordinate_manager->translate_coord_to(arc_logical, CoordSystem::PHYSICAL);
 
             EXPECT_EQ(arc_virtual.x, arc_physical.x);
             EXPECT_EQ(arc_virtual.y, arc_physical.y);
@@ -511,9 +522,10 @@ TEST(CoordinateManager, CoordinateManagerBlackholeARCTranslation) {
     for (size_t x = 0; x < arc_grid_size.x; x++) {
         for (size_t y = 0; y < arc_grid_size.y; y++) {
             const CoreCoord arc_logical = CoreCoord(x, y, CoreType::ARC, CoordSystem::LOGICAL);
-            const CoreCoord arc_virtual = coordinate_manager->to(arc_logical, CoordSystem::VIRTUAL);
-            const CoreCoord arc_physical = coordinate_manager->to(arc_logical, CoordSystem::PHYSICAL);
-            const CoreCoord arc_translated = coordinate_manager->to(arc_logical, CoordSystem::TRANSLATED);
+            const CoreCoord arc_virtual = coordinate_manager->translate_coord_to(arc_logical, CoordSystem::VIRTUAL);
+            const CoreCoord arc_physical = coordinate_manager->translate_coord_to(arc_logical, CoordSystem::PHYSICAL);
+            const CoreCoord arc_translated =
+                coordinate_manager->translate_coord_to(arc_logical, CoordSystem::TRANSLATED);
 
             EXPECT_EQ(arc_virtual.x, arc_physical.x);
             EXPECT_EQ(arc_virtual.y, arc_physical.y);
@@ -536,9 +548,10 @@ TEST(CoordinateManager, CoordinateManagerBlackholeETHTranslation) {
     for (size_t x = 0; x < eth_grid_size.x; x++) {
         for (size_t y = 0; y < eth_grid_size.y; y++) {
             const CoreCoord eth_logical = CoreCoord(x, y, CoreType::ETH, CoordSystem::LOGICAL);
-            const CoreCoord eth_virtual = coordinate_manager->to(eth_logical, CoordSystem::VIRTUAL);
-            const CoreCoord eth_physical = coordinate_manager->to(eth_logical, CoordSystem::PHYSICAL);
-            const CoreCoord eth_translated = coordinate_manager->to(eth_logical, CoordSystem::TRANSLATED);
+            const CoreCoord eth_virtual = coordinate_manager->translate_coord_to(eth_logical, CoordSystem::VIRTUAL);
+            const CoreCoord eth_physical = coordinate_manager->translate_coord_to(eth_logical, CoordSystem::PHYSICAL);
+            const CoreCoord eth_translated =
+                coordinate_manager->translate_coord_to(eth_logical, CoordSystem::TRANSLATED);
 
             EXPECT_EQ(eth_virtual.x, eth_physical.x);
             EXPECT_EQ(eth_virtual.y, eth_physical.y);

--- a/tests/api/test_core_coord_translation_gs.cpp
+++ b/tests/api/test_core_coord_translation_gs.cpp
@@ -20,8 +20,8 @@ TEST(CoordinateManager, CoordinateManagerGrayskullNoHarvesting) {
     for (size_t x = 0; x < tensix_grid_size.x; x++) {
         for (size_t y = 0; y < tensix_grid_size.y; y++) {
             CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-            CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
-            CoreCoord physical_coords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+            CoreCoord virtual_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
+            CoreCoord physical_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
 
             // Virtual and physical coordinates should be the same.
             EXPECT_EQ(physical_coords.x, virtual_coords.x);
@@ -40,11 +40,11 @@ TEST(CoordinateManager, CoordinateManagerGrayskullTopLeftCore) {
     CoreCoord logical_coords = CoreCoord(0, 0, CoreType::TENSIX, CoordSystem::LOGICAL);
 
     // Always expect same virtual coordinate for (0, 0) logical coordinate.
-    CoreCoord virtual_cords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+    CoreCoord virtual_cords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
     EXPECT_EQ(virtual_cords, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL));
 
     // This depends on harvesting mask. So expected physical coord is specific to this test and Wormhole arch.
-    CoreCoord physical_cords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+    CoreCoord physical_cords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
     EXPECT_EQ(physical_cords, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::PHYSICAL));
 }
 
@@ -60,11 +60,11 @@ TEST(CoordinateManager, CoordinateManagerGrayskullTopLeftCoreHarvesting) {
     CoreCoord logical_coords = CoreCoord(0, 0, CoreType::TENSIX, CoordSystem::LOGICAL);
 
     // Always expect same virtual coordinate for (0, 0) logical coordinate.
-    CoreCoord virtual_cords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+    CoreCoord virtual_cords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
     EXPECT_EQ(virtual_cords, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL));
 
     // This depends on harvesting mask. So expected physical coord is specific to this test and Wormhole arch.
-    CoreCoord physical_cords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+    CoreCoord physical_cords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
     EXPECT_EQ(physical_cords, CoreCoord(1, 2, CoreType::TENSIX, CoordSystem::PHYSICAL));
 }
 
@@ -78,9 +78,10 @@ TEST(CoordinateManager, CoordinateManagerGrayskullTranslatingCoords) {
     for (size_t x = 0; x < tensix_grid_size.x; x++) {
         for (size_t y = 0; y < tensix_grid_size.y; y++) {
             CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-            CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
-            CoreCoord physical_coords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
-            CoreCoord translated_coords = coordinate_manager->to(logical_coords, CoordSystem::TRANSLATED);
+            CoreCoord virtual_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
+            CoreCoord physical_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
+            CoreCoord translated_coords =
+                coordinate_manager->translate_coord_to(logical_coords, CoordSystem::TRANSLATED);
 
             // Virtual, physical and translated coordinates should be the same.
             EXPECT_EQ(physical_coords.x, virtual_coords.x);
@@ -112,7 +113,8 @@ TEST(CoordinateManager, CoordinateManagerGrayskullLogicalPhysicalMapping) {
         for (size_t x = 0; x < tensix_grid_size.x; x++) {
             for (size_t y = 0; y < tensix_grid_size.y - num_harvested_y; y++) {
                 CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-                CoreCoord physical_coords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+                CoreCoord physical_coords =
+                    coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
                 logical_to_physical[logical_coords] = physical_coords;
 
                 // Expect that logical to physical translation is 1-1 mapping. No duplicates for physical coordinates.
@@ -127,7 +129,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullLogicalPhysicalMapping) {
 
         for (auto it : logical_to_physical) {
             CoreCoord physical_coords = it.second;
-            CoreCoord logical_coords = coordinate_manager->to(physical_coords, CoordSystem::LOGICAL);
+            CoreCoord logical_coords = coordinate_manager->translate_coord_to(physical_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of physical coordinates gives the same logical coordinates
             // using which we got the physical coordinates.
@@ -156,7 +158,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullLogicalVirtualMapping) {
         for (size_t x = 0; x < tensix_grid_size.x; x++) {
             for (size_t y = 0; y < tensix_grid_size.y - num_harvested_y; y++) {
                 CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-                CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+                CoreCoord virtual_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
                 logical_to_virtual[logical_coords] = virtual_coords;
 
                 // Expect that logical to virtual translation is 1-1 mapping. No duplicates for virtual coordinates.
@@ -167,7 +169,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullLogicalVirtualMapping) {
 
         for (auto it : logical_to_virtual) {
             CoreCoord virtual_coords = it.second;
-            CoreCoord logical_coords = coordinate_manager->to(virtual_coords, CoordSystem::LOGICAL);
+            CoreCoord logical_coords = coordinate_manager->translate_coord_to(virtual_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of virtual coordinates gives the same logical coordinates
             // using which we got the virtual coordinates.
@@ -193,7 +195,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullPhysicalHarvestedMapping) {
     for (size_t index = 0; index < num_harvested * tensix_grid_size.x; index++) {
         const CoreCoord physical_core =
             CoreCoord(tensix_cores[index].x, tensix_cores[index].y, CoreType::TENSIX, CoordSystem::PHYSICAL);
-        const CoreCoord virtual_core = coordinate_manager->to(physical_core, CoordSystem::VIRTUAL);
+        const CoreCoord virtual_core = coordinate_manager->translate_coord_to(physical_core, CoordSystem::VIRTUAL);
 
         EXPECT_EQ(virtual_core.x, tensix_cores[virtual_index].x);
         EXPECT_EQ(virtual_core.y, tensix_cores[virtual_index].y);
@@ -219,11 +221,13 @@ TEST(CoordinateManager, CoordinateManagerGrayskullPhysicalTranslatedHarvestedMap
     for (size_t index = 0; index < num_harvested * tensix_grid_size.x; index++) {
         const CoreCoord physical_core =
             CoreCoord(tensix_cores[index].x, tensix_cores[index].y, CoreType::TENSIX, CoordSystem::PHYSICAL);
-        const CoreCoord translated_core = coordinate_manager->to(physical_core, CoordSystem::TRANSLATED);
+        const CoreCoord translated_core =
+            coordinate_manager->translate_coord_to(physical_core, CoordSystem::TRANSLATED);
 
         const CoreCoord virtual_core = CoreCoord(
             tensix_cores[virtual_index].x, tensix_cores[virtual_index].y, CoreType::TENSIX, CoordSystem::VIRTUAL);
-        const CoreCoord translated_core_from_virtual = coordinate_manager->to(virtual_core, CoordSystem::TRANSLATED);
+        const CoreCoord translated_core_from_virtual =
+            coordinate_manager->translate_coord_to(virtual_core, CoordSystem::TRANSLATED);
 
         EXPECT_EQ(translated_core, translated_core_from_virtual);
 
@@ -248,7 +252,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullDRAMNoHarvesting) {
         const CoreCoord expected_physical =
             CoreCoord(dram_cores[dram_bank].x, dram_cores[dram_bank].y, CoreType::DRAM, CoordSystem::PHYSICAL);
 
-        const CoreCoord dram_physical = coordinate_manager->to(dram_logical, CoordSystem::PHYSICAL);
+        const CoreCoord dram_physical = coordinate_manager->translate_coord_to(dram_logical, CoordSystem::PHYSICAL);
 
         EXPECT_EQ(dram_physical, expected_physical);
     }
@@ -263,9 +267,10 @@ TEST(CoordinateManager, CoordinateManagerGrayskullPCIETranslation) {
     for (size_t x = 0; x < pcie_grid_size.x; x++) {
         for (size_t y = 0; y < pcie_grid_size.y; y++) {
             const CoreCoord pcie_logical = CoreCoord(x, y, CoreType::PCIE, CoordSystem::LOGICAL);
-            const CoreCoord pcie_virtual = coordinate_manager->to(pcie_logical, CoordSystem::VIRTUAL);
-            const CoreCoord pcie_physical = coordinate_manager->to(pcie_logical, CoordSystem::PHYSICAL);
-            const CoreCoord pcie_translated = coordinate_manager->to(pcie_logical, CoordSystem::TRANSLATED);
+            const CoreCoord pcie_virtual = coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::VIRTUAL);
+            const CoreCoord pcie_physical = coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::PHYSICAL);
+            const CoreCoord pcie_translated =
+                coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::TRANSLATED);
 
             EXPECT_EQ(pcie_virtual.x, pcie_physical.x);
             EXPECT_EQ(pcie_virtual.y, pcie_physical.y);
@@ -285,9 +290,10 @@ TEST(CoordinateManager, CoordinateManagerGrayskullARCTranslation) {
     for (size_t x = 0; x < arc_grid_size.x; x++) {
         for (size_t y = 0; y < arc_grid_size.y; y++) {
             const CoreCoord arc_logical = CoreCoord(x, y, CoreType::ARC, CoordSystem::LOGICAL);
-            const CoreCoord arc_virtual = coordinate_manager->to(arc_logical, CoordSystem::VIRTUAL);
-            const CoreCoord arc_physical = coordinate_manager->to(arc_logical, CoordSystem::PHYSICAL);
-            const CoreCoord arc_translated = coordinate_manager->to(arc_logical, CoordSystem::TRANSLATED);
+            const CoreCoord arc_virtual = coordinate_manager->translate_coord_to(arc_logical, CoordSystem::VIRTUAL);
+            const CoreCoord arc_physical = coordinate_manager->translate_coord_to(arc_logical, CoordSystem::PHYSICAL);
+            const CoreCoord arc_translated =
+                coordinate_manager->translate_coord_to(arc_logical, CoordSystem::TRANSLATED);
 
             EXPECT_EQ(arc_virtual.x, arc_physical.x);
             EXPECT_EQ(arc_virtual.y, arc_physical.y);

--- a/tests/api/test_core_coord_translation_wh.cpp
+++ b/tests/api/test_core_coord_translation_wh.cpp
@@ -13,18 +13,18 @@ using namespace tt::umd;
 // Tests that all physical coordinates are same as all virtual coordinates
 // when there is no harvesting.
 TEST(CoordinateManager, CoordinateManagerWormholeNoHarvesting) {
-    const size_t harvesting_mask = 0;
-
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, 0, 0);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0);
 
     // We expect full grid size since there is no harvesting.
     tt_xy_pair tensix_grid_size = tt::umd::wormhole::TENSIX_GRID_SIZE;
     for (size_t x = 0; x < tensix_grid_size.x; x++) {
         for (size_t y = 0; y < tensix_grid_size.y; y++) {
             const CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-            const CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
-            const CoreCoord physical_coords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+            const CoreCoord virtual_coords =
+                coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
+            const CoreCoord physical_coords =
+                coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
 
             // Virtual and physical coordinates should be the same.
             EXPECT_EQ(physical_coords.x, virtual_coords.x);
@@ -47,11 +47,11 @@ TEST(CoordinateManager, CoordinateManagerWormholeTopLeftCore) {
     CoreCoord logical_coords = CoreCoord(0, 0, CoreType::TENSIX, CoordSystem::LOGICAL);
 
     // Always expect same virtual coordinate for (0, 0) logical coordinate.
-    CoreCoord virtual_cords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+    CoreCoord virtual_cords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
     EXPECT_EQ(virtual_cords, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL));
 
     // This depends on harvesting mask. So expected physical coord is specific to this test and Wormhole arch.
-    CoreCoord physical_cords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+    CoreCoord physical_cords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
     EXPECT_EQ(physical_cords, CoreCoord(1, 2, CoreType::TENSIX, CoordSystem::PHYSICAL));
 }
 
@@ -75,7 +75,8 @@ TEST(CoordinateManager, CoordinateManagerWormholeLogicalPhysicalMapping) {
         for (size_t x = 0; x < tensix_grid_size.x; x++) {
             for (size_t y = 0; y < tensix_grid_size.y - num_harvested_y; y++) {
                 CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-                CoreCoord physical_coords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+                CoreCoord physical_coords =
+                    coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
                 logical_to_physical[logical_coords] = physical_coords;
 
                 // Expect that logical to physical translation is 1-1 mapping. No duplicates for physical coordinates.
@@ -90,7 +91,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeLogicalPhysicalMapping) {
 
         for (auto it : logical_to_physical) {
             CoreCoord physical_coords = it.second;
-            CoreCoord logical_coords = coordinate_manager->to(physical_coords, CoordSystem::LOGICAL);
+            CoreCoord logical_coords = coordinate_manager->translate_coord_to(physical_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of physical coordinates gives the same logical coordinates
             // using which we got the physical coordinates.
@@ -119,7 +120,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeLogicalVirtualMapping) {
         for (size_t x = 0; x < tensix_grid_size.x; x++) {
             for (size_t y = 0; y < tensix_grid_size.y - num_harvested_y; y++) {
                 CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-                CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+                CoreCoord virtual_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
                 logical_to_virtual[logical_coords] = virtual_coords;
 
                 // Expect that logical to virtual translation is 1-1 mapping. No duplicates for virtual coordinates.
@@ -130,7 +131,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeLogicalVirtualMapping) {
 
         for (auto it : logical_to_virtual) {
             CoreCoord virtual_coords = it.second;
-            CoreCoord logical_coords = coordinate_manager->to(virtual_coords, CoordSystem::LOGICAL);
+            CoreCoord logical_coords = coordinate_manager->translate_coord_to(virtual_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of virtual coordinates gives the same logical coordinates
             // using which we got the virtual coordinates.
@@ -159,12 +160,15 @@ TEST(CoordinateManager, CoordinateManagerWormholeLogicalTranslatedTopLeft) {
         size_t num_harvested_y = CoordinateManager::get_num_harvested(harvesting_mask);
 
         CoreCoord logical_coords = CoreCoord(0, 0, CoreType::TENSIX, CoordSystem::LOGICAL);
-        CoreCoord physical_coords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
-        CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+        CoreCoord physical_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
+        CoreCoord virtual_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
 
-        CoreCoord translated_from_logical = coordinate_manager->to(logical_coords, CoordSystem::TRANSLATED);
-        CoreCoord translated_from_physical = coordinate_manager->to(physical_coords, CoordSystem::TRANSLATED);
-        CoreCoord translated_from_virtual = coordinate_manager->to(virtual_coords, CoordSystem::TRANSLATED);
+        CoreCoord translated_from_logical =
+            coordinate_manager->translate_coord_to(logical_coords, CoordSystem::TRANSLATED);
+        CoreCoord translated_from_physical =
+            coordinate_manager->translate_coord_to(physical_coords, CoordSystem::TRANSLATED);
+        CoreCoord translated_from_virtual =
+            coordinate_manager->translate_coord_to(virtual_coords, CoordSystem::TRANSLATED);
 
         EXPECT_EQ(translated_from_logical, expected_translated_coords);
         EXPECT_EQ(translated_from_physical, expected_translated_coords);
@@ -189,7 +193,7 @@ TEST(CoordinateManager, CoordinateManagerWormholePhysicalVirtualHarvestedMapping
     for (size_t index = 0; index < num_harvested * tensix_grid_size.x; index++) {
         const CoreCoord physical_core =
             CoreCoord(tensix_cores[index].x, tensix_cores[index].y, CoreType::TENSIX, CoordSystem::PHYSICAL);
-        const CoreCoord virtual_core = coordinate_manager->to(physical_core, CoordSystem::VIRTUAL);
+        const CoreCoord virtual_core = coordinate_manager->translate_coord_to(physical_core, CoordSystem::VIRTUAL);
 
         EXPECT_EQ(virtual_core.x, tensix_cores[virtual_index].x);
         EXPECT_EQ(virtual_core.y, tensix_cores[virtual_index].y);
@@ -221,11 +225,13 @@ TEST(CoordinateManager, CoordinateManagerWormholePhysicalTranslatedHarvestedMapp
     for (size_t index = 0; index < num_harvested * tensix_grid_size.x; index++) {
         const CoreCoord physical_core =
             CoreCoord(tensix_cores[index].x, tensix_cores[index].y, CoreType::TENSIX, CoordSystem::PHYSICAL);
-        const CoreCoord translated_core = coordinate_manager->to(physical_core, CoordSystem::TRANSLATED);
+        const CoreCoord translated_core =
+            coordinate_manager->translate_coord_to(physical_core, CoordSystem::TRANSLATED);
 
         const CoreCoord virtual_core = CoreCoord(
             tensix_cores[virtual_index].x, tensix_cores[virtual_index].y, CoreType::TENSIX, CoordSystem::VIRTUAL);
-        const CoreCoord translated_core_from_virtual = coordinate_manager->to(virtual_core, CoordSystem::TRANSLATED);
+        const CoreCoord translated_core_from_virtual =
+            coordinate_manager->translate_coord_to(virtual_core, CoordSystem::TRANSLATED);
 
         EXPECT_EQ(translated_core, translated_core_from_virtual);
 
@@ -263,7 +269,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeDRAMNoHarvesting) {
                 CoreType::DRAM,
                 CoordSystem::PHYSICAL);
 
-            const CoreCoord dram_physical = coordinate_manager->to(dram_logical, CoordSystem::PHYSICAL);
+            const CoreCoord dram_physical = coordinate_manager->translate_coord_to(dram_logical, CoordSystem::PHYSICAL);
 
             EXPECT_EQ(dram_physical, expected_physical);
         }
@@ -280,8 +286,8 @@ TEST(CoordinateManager, CoordinateManagerWormholeETHPhysicalEqualVirtual) {
     for (size_t x = 0; x < eth_grid_size.x; x++) {
         for (size_t y = 0; y < eth_grid_size.y; y++) {
             const CoreCoord eth_logical = CoreCoord(x, y, CoreType::ETH, CoordSystem::LOGICAL);
-            const CoreCoord eth_virtual = coordinate_manager->to(eth_logical, CoordSystem::VIRTUAL);
-            const CoreCoord eth_physical = coordinate_manager->to(eth_logical, CoordSystem::PHYSICAL);
+            const CoreCoord eth_virtual = coordinate_manager->translate_coord_to(eth_logical, CoordSystem::VIRTUAL);
+            const CoreCoord eth_physical = coordinate_manager->translate_coord_to(eth_logical, CoordSystem::PHYSICAL);
 
             EXPECT_EQ(eth_virtual.x, eth_physical.x);
             EXPECT_EQ(eth_virtual.y, eth_physical.y);
@@ -298,7 +304,8 @@ TEST(CoordinateManager, CoordinateManagerWormholeETHLogicalToTranslated) {
     for (size_t x = 0; x < eth_grid_size.x; x++) {
         for (size_t y = 0; y < eth_grid_size.y; y++) {
             const CoreCoord eth_logical = CoreCoord(x, y, CoreType::ETH, CoordSystem::LOGICAL);
-            const CoreCoord eth_translated = coordinate_manager->to(eth_logical, CoordSystem::TRANSLATED);
+            const CoreCoord eth_translated =
+                coordinate_manager->translate_coord_to(eth_logical, CoordSystem::TRANSLATED);
 
             EXPECT_EQ(eth_translated.x, x + 18);
             EXPECT_EQ(eth_translated.y, y + 16);
@@ -315,9 +322,10 @@ TEST(CoordinateManager, CoordinateManagerWormholeARCTranslation) {
     for (size_t x = 0; x < arc_grid_size.x; x++) {
         for (size_t y = 0; y < arc_grid_size.y; y++) {
             const CoreCoord arc_logical = CoreCoord(x, y, CoreType::ARC, CoordSystem::LOGICAL);
-            const CoreCoord arc_virtual = coordinate_manager->to(arc_logical, CoordSystem::VIRTUAL);
-            const CoreCoord arc_physical = coordinate_manager->to(arc_logical, CoordSystem::PHYSICAL);
-            const CoreCoord arc_translated = coordinate_manager->to(arc_logical, CoordSystem::TRANSLATED);
+            const CoreCoord arc_virtual = coordinate_manager->translate_coord_to(arc_logical, CoordSystem::VIRTUAL);
+            const CoreCoord arc_physical = coordinate_manager->translate_coord_to(arc_logical, CoordSystem::PHYSICAL);
+            const CoreCoord arc_translated =
+                coordinate_manager->translate_coord_to(arc_logical, CoordSystem::TRANSLATED);
 
             EXPECT_EQ(arc_virtual.x, arc_physical.x);
             EXPECT_EQ(arc_virtual.y, arc_physical.y);
@@ -337,9 +345,10 @@ TEST(CoordinateManager, CoordinateManagerWormholePCIETranslation) {
     for (size_t x = 0; x < pcie_grid_size.x; x++) {
         for (size_t y = 0; y < pcie_grid_size.y; y++) {
             const CoreCoord pcie_logical = CoreCoord(x, y, CoreType::PCIE, CoordSystem::LOGICAL);
-            const CoreCoord pcie_virtual = coordinate_manager->to(pcie_logical, CoordSystem::VIRTUAL);
-            const CoreCoord pcie_physical = coordinate_manager->to(pcie_logical, CoordSystem::PHYSICAL);
-            const CoreCoord pcie_translated = coordinate_manager->to(pcie_logical, CoordSystem::TRANSLATED);
+            const CoreCoord pcie_virtual = coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::VIRTUAL);
+            const CoreCoord pcie_physical = coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::PHYSICAL);
+            const CoreCoord pcie_translated =
+                coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::TRANSLATED);
 
             EXPECT_EQ(pcie_virtual.x, pcie_physical.x);
             EXPECT_EQ(pcie_virtual.y, pcie_physical.y);

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -112,8 +112,8 @@ TEST(SocDescriptor, SocDescriptorWormholeETHLogicalToPhysical) {
     for (size_t y = 0; y < eth_grid_size.y; y++) {
         for (size_t x = 0; x < eth_grid_size.x; x++) {
             const CoreCoord eth_logical = CoreCoord(x, y, CoreType::ETH, CoordSystem::LOGICAL);
-            const CoreCoord eth_physical = soc_desc.to(eth_logical, CoordSystem::PHYSICAL);
-            const CoreCoord eth_virtual = soc_desc.to(eth_logical, CoordSystem::VIRTUAL);
+            const CoreCoord eth_physical = soc_desc.translate_coord_to(eth_logical, CoordSystem::PHYSICAL);
+            const CoreCoord eth_virtual = soc_desc.translate_coord_to(eth_logical, CoordSystem::VIRTUAL);
 
             EXPECT_EQ(eth_physical.x, wormhole_eth_cores[index].x);
             EXPECT_EQ(eth_physical.y, wormhole_eth_cores[index].y);
@@ -216,9 +216,9 @@ TEST(SocDescriptor, CustomSocDescriptor) {
     tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_simulation_1x2.yaml"), 0, 0);
 
     const CoreCoord tensix_core_01 = CoreCoord(0, 1, CoreType::TENSIX, CoordSystem::PHYSICAL);
-    const CoreCoord tensix_core_01_virtual = soc_desc.to(tensix_core_01, CoordSystem::VIRTUAL);
-    const CoreCoord tensix_core_01_logical = soc_desc.to(tensix_core_01, CoordSystem::LOGICAL);
-    const CoreCoord tensix_core_01_translated = soc_desc.to(tensix_core_01, CoordSystem::TRANSLATED);
+    const CoreCoord tensix_core_01_virtual = soc_desc.translate_coord_to(tensix_core_01, CoordSystem::VIRTUAL);
+    const CoreCoord tensix_core_01_logical = soc_desc.translate_coord_to(tensix_core_01, CoordSystem::LOGICAL);
+    const CoreCoord tensix_core_01_translated = soc_desc.translate_coord_to(tensix_core_01, CoordSystem::TRANSLATED);
 
     EXPECT_EQ(tensix_core_01_virtual.x, tensix_core_01.x);
     EXPECT_EQ(tensix_core_01_virtual.y, tensix_core_01.y);
@@ -230,9 +230,9 @@ TEST(SocDescriptor, CustomSocDescriptor) {
     EXPECT_EQ(tensix_core_01_logical.y, 0);
 
     const CoreCoord tensix_core_11 = CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::PHYSICAL);
-    const CoreCoord tensix_core_11_virtual = soc_desc.to(tensix_core_11, CoordSystem::VIRTUAL);
-    const CoreCoord tensix_core_11_logical = soc_desc.to(tensix_core_11, CoordSystem::LOGICAL);
-    const CoreCoord tensix_core_11_translated = soc_desc.to(tensix_core_11, CoordSystem::TRANSLATED);
+    const CoreCoord tensix_core_11_virtual = soc_desc.translate_coord_to(tensix_core_11, CoordSystem::VIRTUAL);
+    const CoreCoord tensix_core_11_logical = soc_desc.translate_coord_to(tensix_core_11, CoordSystem::LOGICAL);
+    const CoreCoord tensix_core_11_translated = soc_desc.translate_coord_to(tensix_core_11, CoordSystem::TRANSLATED);
 
     EXPECT_EQ(tensix_core_11_virtual.x, tensix_core_11.x);
     EXPECT_EQ(tensix_core_11_virtual.y, tensix_core_11.y);
@@ -253,9 +253,9 @@ TEST(SocDescriptor, CustomSocDescriptor) {
     EXPECT_TRUE(harvested_tensix_cores.empty());
 
     const CoreCoord dram_core_10 = CoreCoord(1, 0, CoreType::DRAM, CoordSystem::PHYSICAL);
-    const CoreCoord dram_core_10_virtual = soc_desc.to(dram_core_10, CoordSystem::VIRTUAL);
-    const CoreCoord dram_core_10_logical = soc_desc.to(dram_core_10, CoordSystem::LOGICAL);
-    const CoreCoord dram_core_10_translated = soc_desc.to(dram_core_10, CoordSystem::TRANSLATED);
+    const CoreCoord dram_core_10_virtual = soc_desc.translate_coord_to(dram_core_10, CoordSystem::VIRTUAL);
+    const CoreCoord dram_core_10_logical = soc_desc.translate_coord_to(dram_core_10, CoordSystem::LOGICAL);
+    const CoreCoord dram_core_10_translated = soc_desc.translate_coord_to(dram_core_10, CoordSystem::TRANSLATED);
 
     EXPECT_EQ(dram_core_10_virtual.x, dram_core_10.x);
     EXPECT_EQ(dram_core_10_virtual.y, dram_core_10.y);


### PR DESCRIPTION
### Issue

https://github.com/tenstorrent/tt-umd/issues/220)

### Description

Provide Cluster API with CoreCoord. Every function that was expecting virtual coordinates has the same function just with CoreCoord structure. Old API is still there just to not break tt-metal and tt-lens at the moment. When the clients have switched to the new API we can delete the old one. In the meantime, internals of Cluster can be redesigned in parallel with client work on switching to new API. So this should be a two phase change. This is the first one where the new API is added, and when clients have switched to the new API second phase will be deleting the old API 

### List of the changes

- Separate Cluster API into 3 groups (something we want to keep, to delete and new API)
- Add API with CoreCoord
- Change API tests to use the new API

### Testing

UMD unit tests

### API Changes

Old API is still there, so no API changes at the moment
