### PR TITLE
Remove setup_core_to_tlb_map

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1339,7 +1339,7 @@ void Cluster::configure_tlb(
         tlb_config_map.insert({logical_device_id, {}});
         map_core_to_tlb_per_chip.insert({logical_device_id, {}});
     }
-    log_assert(tlb_config_map.find(tlb_index) == tlb_config_map.end(), "TLB index already configured.");
+    log_assert(tlb_config_map.find(tlb_index) == tlb_config_map.end(), "TLB index already configured {}", tlb_index);
 
     TTDevice* tt_device = get_tt_device(logical_device_id);
     tt_device->set_dynamic_tlb(tlb_index, core, address, harvested_coord_translation.at(logical_device_id), ordering);

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -153,6 +153,31 @@ bool Cluster::address_in_tlb_space(
     return false;
 }
 
+bool Cluster::is_tlb_mapped(tt_cxy_pair target) {
+    if (map_core_to_tlb_per_chip.find(target.chip) == map_core_to_tlb_per_chip.end()) {
+        return false;
+    }
+
+    auto& map_core_to_tlb = map_core_to_tlb_per_chip.at(target.chip);
+    tt_xy_pair target_core = tt_xy_pair(target.x, target.y);
+
+    return map_core_to_tlb.find(target_core) != map_core_to_tlb.end();
+}
+
+bool Cluster::is_tlb_mapped(tt_cxy_pair target, uint64_t address, uint32_t size_in_bytes) {
+    if (!is_tlb_mapped(target)) {
+        return false;
+    }
+
+    auto* dev = get_tt_device(target.chip);
+
+    int32_t tlb_index = map_core_to_tlb_per_chip.at(target.chip).at(tt_xy_pair(target.x, target.y));
+    auto tlb_description = dev->get_architecture_implementation()->describe_tlb(tlb_index);
+
+    return tlb_description.has_value() &&
+           address_in_tlb_space(address, size_in_bytes, tlb_index, std::get<1>(tlb_description.value()), target.chip);
+}
+
 void Cluster::initialize_interprocess_mutexes(int pci_interface_id, bool cleanup_mutexes_in_shm) {
     // These mutexes are intended to be based on physical devices/pci-intf not logical. Set these up ahead of time here
     // (during device init) since its unsafe to modify shared state during multithreaded runtime. cleanup_mutexes_in_shm
@@ -1040,22 +1065,17 @@ tt::Writer Cluster::get_static_tlb_writer(tt_cxy_pair target) {
         throw std::runtime_error(fmt::format("Target not in MMIO chip: {}", target.str()));
     }
 
-    if (!tlbs_init_per_chip[target.chip] || !map_core_to_tlb_per_chip[target.chip]) {
-        throw std::runtime_error("TLBs not initialized");
+    if (!is_tlb_mapped(target)) {
+        throw std::runtime_error(fmt::format("TLBs not initialized for core: {}", target.str()));
     }
 
     auto* dev = get_tt_device(target.chip);
-
     if (!dev->get_pci_device()->bar0_wc) {
         throw std::runtime_error("No write-combined mapping for BAR0");
     }
 
-    auto tlb_index = map_core_to_tlb_per_chip[target.chip](tt_xy_pair(target.x, target.y));
+    auto tlb_index = map_core_to_tlb_per_chip.at(target.chip).at(tt_xy_pair(target.x, target.y));
     auto tlb_data = dev->get_architecture_implementation()->describe_tlb(tlb_index);
-
-    if (!tlb_data.has_value()) {
-        throw std::runtime_error(fmt::format("No TLB mapped to core {}", target.str()));
-    }
 
     auto [tlb_offset, tlb_size] = tlb_data.value();
     auto* base = reinterpret_cast<uint8_t*>(dev->get_pci_device()->bar0_wc);
@@ -1082,16 +1102,10 @@ void Cluster::write_device_memory(
         size_in_bytes,
         small_access);
 
-    std::int32_t tlb_index = 0;
-    std::optional<std::tuple<std::uint64_t, std::uint64_t>> tlb_data = std::nullopt;
-    if (tlbs_init_per_chip[target.chip]) {
-        tlb_index = map_core_to_tlb_per_chip[target.chip](tt_xy_pair(target.x, target.y));
-        tlb_data = dev->get_architecture_implementation()->describe_tlb(tlb_index);
-    }
-
-    if (tlb_data.has_value() &&
-        address_in_tlb_space(address, size_in_bytes, tlb_index, std::get<1>(tlb_data.value()), target.chip)) {
-        auto [tlb_offset, tlb_size] = tlb_data.value();
+    if (is_tlb_mapped(target, address, size_in_bytes)) {
+        auto tlb_description = dev->get_architecture_implementation()->describe_tlb(
+            map_core_to_tlb_per_chip.at(target.chip).at(tt_xy_pair(target.x, target.y)));
+        auto [tlb_offset, tlb_size] = tlb_description.value();
         if (dev->get_pci_device()->bar4_wc != nullptr && tlb_size == BH_4GB_TLB_SIZE) {
             // This is only for Blackhole. If we want to  write to DRAM (BAR4 space), we add offset
             // to which we write so write_block knows it needs to target BAR4
@@ -1132,20 +1146,14 @@ void Cluster::read_device_memory(
         address,
         size_in_bytes);
     TTDevice* dev = get_tt_device(target.chip);
-
     uint8_t* buffer_addr = static_cast<uint8_t*>(mem_ptr);
 
-    std::int32_t tlb_index = 0;
-    std::optional<std::tuple<std::uint64_t, std::uint64_t>> tlb_data = std::nullopt;
-    if (tlbs_init_per_chip[target.chip]) {
-        tlb_index = map_core_to_tlb_per_chip[target.chip](tt_xy_pair(target.x, target.y));
-        tlb_data = dev->get_architecture_implementation()->describe_tlb(tlb_index);
-    }
     log_debug(LogSiliconDriver, "  tlb_index: {}, tlb_data.has_value(): {}", tlb_index, tlb_data.has_value());
 
-    if (tlb_data.has_value() &&
-        address_in_tlb_space(address, size_in_bytes, tlb_index, std::get<1>(tlb_data.value()), target.chip)) {
-        auto [tlb_offset, tlb_size] = tlb_data.value();
+    if (is_tlb_mapped(target, address, size_in_bytes)) {
+        auto tlb_description = dev->get_architecture_implementation()->describe_tlb(
+            map_core_to_tlb_per_chip.at(target.chip).at(tt_xy_pair(target.x, target.y)));
+        auto [tlb_offset, tlb_size] = tlb_description.value();
         if (dev->get_pci_device()->bar4_wc != nullptr && tlb_size == BH_4GB_TLB_SIZE) {
             // This is only for Blackhole. If we want to  read from DRAM (BAR4 space), we add offset
             // from which we read so read_block knows it needs to target BAR4
@@ -1314,15 +1322,12 @@ Cluster::~Cluster() {
 }
 
 std::optional<std::tuple<uint32_t, uint32_t>> Cluster::get_tlb_data_from_target(const tt_cxy_pair& target) {
-    std::int32_t tlb_index = 0;
-    std::optional<std::tuple<std::uint32_t, std::uint32_t>> tlb_data;
-
-    if (tlbs_init_per_chip[target.chip]) {
-        tlb_index = map_core_to_tlb_per_chip[target.chip](tt_xy_pair(target.x, target.y));
-        auto architecture_implementation = tt::umd::architecture_implementation::create(arch_name);
-        tlb_data = architecture_implementation->describe_tlb(tlb_index);
+    if (!is_tlb_mapped(target)) {
+        return std::nullopt;
     }
-    return tlb_data;
+
+    int tlb_index = map_core_to_tlb_per_chip.at(target.chip).at(tt_xy_pair(target.x, target.y));
+    return get_tt_device(target.chip)->get_architecture_implementation()->describe_tlb(tlb_index);
 }
 
 void Cluster::configure_tlb(
@@ -1335,8 +1340,10 @@ void Cluster::configure_tlb(
     auto tlb_size = std::get<1>(tt_device->get_architecture_implementation()->describe_tlb(tlb_index).value());
     if (tlb_config_map.find(logical_device_id) == tlb_config_map.end()) {
         tlb_config_map.insert({logical_device_id, {}});
+        map_core_to_tlb_per_chip.insert({logical_device_id, {}});
     }
-    tlb_config_map[logical_device_id].insert({tlb_index, (address / tlb_size) * tlb_size});
+    tlb_config_map.at(logical_device_id).insert({tlb_index, (address / tlb_size) * tlb_size});
+    map_core_to_tlb_per_chip.at(logical_device_id).insert({core, tlb_index});
 }
 
 void Cluster::set_fallback_tlb_ordering_mode(const std::string& fallback_tlb, uint64_t ordering) {
@@ -3262,12 +3269,6 @@ void Cluster::start_device(const tt_device_params& device_params) {
 void Cluster::close_device() {
     set_power_state(tt_DevicePowerState::LONG_IDLE);
     broadcast_tensix_risc_reset_to_cluster(TENSIX_ASSERT_SOFT_RESET);
-}
-
-void Cluster::setup_core_to_tlb_map(
-    const chip_id_t logical_device_id, std::function<std::int32_t(tt_xy_pair)> mapping_function) {
-    map_core_to_tlb_per_chip[logical_device_id] = mapping_function;
-    tlbs_init_per_chip[logical_device_id] = true;
 }
 
 std::uint32_t Cluster::get_num_dram_channels(std::uint32_t device_id) {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1339,7 +1339,18 @@ void Cluster::configure_tlb(
         tlb_config_map.insert({logical_device_id, {}});
         map_core_to_tlb_per_chip.insert({logical_device_id, {}});
     }
-    log_assert(tlb_config_map.find(tlb_index) != tlb_config_map.end(), "TLB index already configured {}", tlb_index);
+    log_debug(
+        LogSiliconDriver,
+        "Configuring TLB for chip: {} core: {} tlb_index: {} address: {} ordering: {}",
+        logical_device_id,
+        core.str(),
+        tlb_index,
+        address,
+        ordering);
+    log_assert(
+        tlb_config_map.at(logical_device_id).find(tlb_index) == tlb_config_map.at(logical_device_id).end(),
+        "TLB index already configured {}",
+        tlb_index);
 
     TTDevice* tt_device = get_tt_device(logical_device_id);
     tt_device->set_dynamic_tlb(tlb_index, core, address, harvested_coord_translation.at(logical_device_id), ordering);

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1339,7 +1339,7 @@ void Cluster::configure_tlb(
         tlb_config_map.insert({logical_device_id, {}});
         map_core_to_tlb_per_chip.insert({logical_device_id, {}});
     }
-    log_assert(tlb_config_map.find(tlb_index) == tlb_config_map.end(), "TLB index already configured {}", tlb_index);
+    log_assert(tlb_config_map.find(tlb_index) != tlb_config_map.end(), "TLB index already configured {}", tlb_index);
 
     TTDevice* tt_device = get_tt_device(logical_device_id);
     tt_device->set_dynamic_tlb(tlb_index, core, address, harvested_coord_translation.at(logical_device_id), ordering);

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1335,13 +1335,15 @@ void Cluster::configure_tlb(
     log_assert(
         ordering == TLB_DATA::Strict || ordering == TLB_DATA::Posted || ordering == TLB_DATA::Relaxed,
         "Invalid ordering specified in Cluster::configure_tlb");
-    TTDevice* tt_device = get_tt_device(logical_device_id);
-    tt_device->set_dynamic_tlb(tlb_index, core, address, harvested_coord_translation.at(logical_device_id), ordering);
-    auto tlb_size = std::get<1>(tt_device->get_architecture_implementation()->describe_tlb(tlb_index).value());
     if (tlb_config_map.find(logical_device_id) == tlb_config_map.end()) {
         tlb_config_map.insert({logical_device_id, {}});
         map_core_to_tlb_per_chip.insert({logical_device_id, {}});
     }
+    log_assert(tlb_config_map.find(tlb_index) == tlb_config_map.end(), "TLB index already configured.");
+
+    TTDevice* tt_device = get_tt_device(logical_device_id);
+    tt_device->set_dynamic_tlb(tlb_index, core, address, harvested_coord_translation.at(logical_device_id), ordering);
+    auto tlb_size = std::get<1>(tt_device->get_architecture_implementation()->describe_tlb(tlb_index).value());
     tlb_config_map.at(logical_device_id).insert({tlb_index, (address / tlb_size) * tlb_size});
     map_core_to_tlb_per_chip.at(logical_device_id).insert({core, tlb_index});
 }

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -80,8 +80,6 @@ TEST(ApiChipTest, ManualTLBConfiguration) {
         for (tt_xy_pair core : soc_desc.workers) {
             umd_cluster->configure_tlb(mmio_chip, core, get_static_tlb_index(core), c_zero_address);
         }
-
-        umd_cluster->setup_core_to_tlb_map(mmio_chip, get_static_tlb_index);
     }
 
     // Expect not to throw for now configured mmio chip, same one as before.

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -204,7 +204,6 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //             }
 //         }
 //     }
-//     cluster.setup_core_to_tlb_map(get_static_tlb_index_callback);
 
 //     tt_device_params default_params;
 //     cluster.start_device(default_params);
@@ -292,7 +291,6 @@ TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
                 cluster.configure_tlb(
                     i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
             }
-            cluster.setup_core_to_tlb_map(i, get_static_tlb_index_callback);
         }
     }
 
@@ -349,7 +347,6 @@ TEST(SiliconDriverBH, StaticTLB_RW) {
                 cluster.configure_tlb(
                     i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
             }
-            cluster.setup_core_to_tlb_map(i, get_static_tlb_index_callback);
         }
     }
 
@@ -570,7 +567,6 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
             cluster.configure_tlb(i, core, get_static_tlb_index_callback(core), base_addr);
         }
-        cluster.setup_core_to_tlb_map(i, get_static_tlb_index_callback);
     }
 
     tt_device_params default_params;

--- a/tests/grayskull/test_cluster_gs.cpp
+++ b/tests/grayskull/test_cluster_gs.cpp
@@ -9,9 +9,9 @@
 #include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "umd/device/cluster.h"
+#include "umd/device/grayskull_implementation.h"
 #include "umd/device/tt_cluster_descriptor.h"
 #include "umd/device/tt_soc_descriptor.h"
-#include "umd/device/wormhole_implementation.h"
 
 using namespace tt::umd;
 
@@ -95,7 +95,7 @@ TEST(SiliconDriverGS, CustomSocDesc) {
 
 TEST(SiliconDriverGS, HarvestingRuntime) {
     auto get_static_tlb_index = [](tt_xy_pair target) {
-        int flat_index = target.y * tt::umd::wormhole::GRID_SIZE_X + target.x;
+        int flat_index = target.y * tt::umd::grayskull::GRID_SIZE_X + target.x;
         if (flat_index == 0) {
             return -1;
         }
@@ -188,7 +188,7 @@ TEST(SiliconDriverGS, HarvestingRuntime) {
 
 TEST(SiliconDriverGS, StaticTLB_RW) {
     auto get_static_tlb_index = [](tt_xy_pair target) {
-        int flat_index = target.y * tt::umd::wormhole::GRID_SIZE_X + target.x;
+        int flat_index = target.y * tt::umd::grayskull::GRID_SIZE_X + target.x;
         if (flat_index == 0) {
             return -1;
         }
@@ -403,7 +403,7 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
     // Memory barrier flags get sent to address 0 for all channels in this test
 
     auto get_static_tlb_index = [](tt_xy_pair target) {
-        int flat_index = target.y * tt::umd::wormhole::GRID_SIZE_X + target.x;
+        int flat_index = target.y * tt::umd::grayskull::GRID_SIZE_X + target.x;
         if (flat_index == 0) {
             return -1;
         }

--- a/tests/grayskull/test_cluster_gs.cpp
+++ b/tests/grayskull/test_cluster_gs.cpp
@@ -114,7 +114,6 @@ TEST(SiliconDriverGS, HarvestingRuntime) {
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
             cluster.configure_tlb(i, core, get_static_tlb_index(core), l1_mem::address_map::DATA_BUFFER_SPACE_BASE);
         }
-        cluster.setup_core_to_tlb_map(i, get_static_tlb_index);
     }
 
     tt_device_params default_params;
@@ -207,7 +206,6 @@ TEST(SiliconDriverGS, StaticTLB_RW) {
             cluster.configure_tlb(
                 i, core, get_static_tlb_index(core), l1_mem::address_map::DATA_BUFFER_SPACE_BASE, TLB_DATA::Posted);
         }
-        cluster.setup_core_to_tlb_map(i, get_static_tlb_index);
     }
 
     tt_device_params default_params;
@@ -425,7 +423,6 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
             cluster.configure_tlb(i, core, get_static_tlb_index(core), base_addr);
         }
-        cluster.setup_core_to_tlb_map(i, get_static_tlb_index);
     }
 
     tt_device_params default_params;

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -172,7 +172,6 @@ TEST(SiliconDriverWH, HarvestingRuntime) {
             }
         }
     }
-    cluster.setup_core_to_tlb_map(get_static_tlb_index_callback);
 
     tt_device_params default_params;
     cluster.start_device(default_params);
@@ -233,7 +232,6 @@ TEST(SiliconDriverWH, UnalignedStaticTLB_RW) {
                 cluster.configure_tlb(
                     i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
             }
-            cluster.setup_core_to_tlb_map(i, get_static_tlb_index_callback);
         }
     }
 
@@ -289,7 +287,6 @@ TEST(SiliconDriverWH, StaticTLB_RW) {
                 cluster.configure_tlb(
                     i, core, get_static_tlb_index_callback(core), l1_mem::address_map::NCRISC_FIRMWARE_BASE);
             }
-            cluster.setup_core_to_tlb_map(i, get_static_tlb_index_callback);
         }
     }
 
@@ -474,7 +471,6 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
                 // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
                 cluster.configure_tlb(i, core, get_static_tlb_index_callback(core), base_addr);
             }
-            cluster.setup_core_to_tlb_map(i, get_static_tlb_index_callback);
         }
     }
 
@@ -954,7 +950,6 @@ TEST(SiliconDriverWH, LargeAddressTlb) {
     cluster.start_device(tt_device_params{});
 
     auto get_static_tlb_index_callback = [](tt_xy_pair target) { return 0; };
-    cluster.setup_core_to_tlb_map(0, get_static_tlb_index_callback);
 
     // Address of the reset unit in ARC core:
     uint64_t arc_reset_noc = 0x880030000ULL;

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -943,8 +943,8 @@ TEST(SiliconDriverWH, LargeAddressTlb) {
         true,   // clean system resources - yes
         true);  // perform harvesting - yes
 
-    const auto ARC = cluster.get_soc_descriptor(0).arc_cores.at(0);
-    const tt_cxy_pair ARC_CORE(0, ARC.x, ARC.y);
+    const tt_xy_pair ARC_CORE = cluster.get_soc_descriptor(0).arc_cores.at(0);
+    const tt_cxy_pair ARC_CORE_CHIP(0, ARC_CORE.x, ARC_CORE.y);
 
     set_barrier_params(cluster);
     cluster.start_device(tt_device_params{});
@@ -971,10 +971,10 @@ TEST(SiliconDriverWH, LargeAddressTlb) {
     value0 = cluster.bar_read32(0, 0x1ff30060);
 
     // Read the scratch register via the TLB:
-    cluster.read_from_device(&value1, ARC_CORE, addr, sizeof(uint32_t), "LARGE_READ_TLB");
+    cluster.read_from_device(&value1, ARC_CORE_CHIP, addr, sizeof(uint32_t), "LARGE_READ_TLB");
 
     // Read the scratch register via a different TLB, different code path:
-    cluster.read_from_device(&value2, ARC_CORE, addr, sizeof(uint32_t), "REG_TLB");
+    cluster.read_from_device(&value2, ARC_CORE_CHIP, addr, sizeof(uint32_t), "REG_TLB");
 
     // Mask off lower 16 bits; FW changes these dynamically:
     value0 &= 0xffff0000;


### PR DESCRIPTION
### Issue
Related to #44 but also on a path of #351 

### Description
This function in API is a surplus. All the info is already available to the Cluster class through configure_tlb calls.
This is initial PR which changes the API. The following PR won't change the API but will restructure functions internally to introduce TLBManager class.

### List of the changes
- Removed setup_core_to_tlb_map. Fill up the same internal structure through configure_tlb api
- tlbs_init_per_chip is also unnecessary
- Extracted the logic for checking whether static tlb is setup

### Testing
Covered through existing tests.

### API Changes
This PR has API changes:
- [x] tt_metal approved PR pointing to this branch: https://github.com/tenstorrent/tt-metal/pull/16048
- [X] tt_lens doesn't use this API call.
