### PR TITLE
Rename function for coord translation

### DIFF
--- a/device/api/umd/device/coordinate_manager.h
+++ b/device/api/umd/device/coordinate_manager.h
@@ -40,7 +40,7 @@ public:
 
     CoordinateManager(CoordinateManager& other) = default;
 
-    tt::umd::CoreCoord to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system);
+    tt::umd::CoreCoord translate_coord_to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system);
 
     std::vector<tt::umd::CoreCoord> get_cores(const CoreType core_type) const;
     tt_xy_pair get_grid_size(const CoreType core_type) const;

--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -90,7 +90,7 @@ public:
         harvested_grid_size_map(other.harvested_grid_size_map) {}
 
     // CoreCoord conversions.
-    tt::umd::CoreCoord to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const;
+    tt::umd::CoreCoord translate_coord_to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const;
 
     static std::string get_soc_descriptor_path(tt::ARCH arch);
 

--- a/device/coordinate_manager.cpp
+++ b/device/coordinate_manager.cpp
@@ -81,7 +81,7 @@ void CoordinateManager::identity_map_physical_cores() {
     }
 }
 
-CoreCoord CoordinateManager::to(const CoreCoord core_coord, const CoordSystem coord_system) {
+CoreCoord CoordinateManager::translate_coord_to(const CoreCoord core_coord, const CoordSystem coord_system) {
     return from_physical_map.at({to_physical_map.at(core_coord), coord_system});
 }
 

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -211,8 +211,9 @@ void tt_SocDescriptor::create_coordinate_manager(
     get_cores_and_grid_size_from_coordinate_manager();
 }
 
-tt::umd::CoreCoord tt_SocDescriptor::to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const {
-    return coordinate_manager->to(core_coord, coord_system);
+tt::umd::CoreCoord tt_SocDescriptor::translate_coord_to(
+    const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const {
+    return coordinate_manager->translate_coord_to(core_coord, coord_system);
 }
 
 tt_SocDescriptor::tt_SocDescriptor(
@@ -269,7 +270,7 @@ tt_xy_pair tt_SocDescriptor::get_core_for_dram_channel(int dram_chan, int subcha
 
 CoreCoord tt_SocDescriptor::get_dram_core_for_channel(int dram_chan, int subchannel) const {
     const CoreCoord logical_dram_coord = CoreCoord(dram_chan, subchannel, CoreType::DRAM, CoordSystem::LOGICAL);
-    return to(logical_dram_coord, CoordSystem::PHYSICAL);
+    return translate_coord_to(logical_dram_coord, CoordSystem::PHYSICAL);
 }
 
 bool tt_SocDescriptor::is_ethernet_core(const tt_xy_pair &core) const {

--- a/tests/api/test_core_coord_translation_bh.cpp
+++ b/tests/api/test_core_coord_translation_bh.cpp
@@ -20,8 +20,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeNoHarvesting) {
     for (size_t x = 0; x < tensix_grid_size.x; x++) {
         for (size_t y = 0; y < tensix_grid_size.y; y++) {
             CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-            CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
-            CoreCoord physical_coords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+            CoreCoord virtual_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
+            CoreCoord physical_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
 
             // Virtual and physical coordinates should be the same.
             EXPECT_EQ(physical_coords.x, virtual_coords.x);
@@ -43,11 +43,11 @@ TEST(CoordinateManager, CoordinateManagerBlackholeTopLeftCore) {
     CoreCoord logical_coords = CoreCoord(0, 0, CoreType::TENSIX, CoordSystem::LOGICAL);
 
     // Always expect same virtual coordinate for (0, 0) logical coordinate.
-    CoreCoord virtual_cords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+    CoreCoord virtual_cords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
     EXPECT_EQ(virtual_cords, CoreCoord(1, 2, CoreType::TENSIX, CoordSystem::VIRTUAL));
 
     // This depends on harvesting mask. So expected physical coord is specific to this test and Blackhole arch.
-    CoreCoord physical_cords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+    CoreCoord physical_cords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
     EXPECT_EQ(physical_cords, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::PHYSICAL));
 }
 
@@ -71,7 +71,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeLogicalPhysicalMapping) {
         for (size_t x = 0; x < tensix_grid_size.x - num_harvested_x; x++) {
             for (size_t y = 0; y < tensix_grid_size.y; y++) {
                 CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-                CoreCoord physical_coords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+                CoreCoord physical_coords =
+                    coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
                 logical_to_physical[logical_coords] = physical_coords;
 
                 // Expect that logical to physical translation is 1-1 mapping. No duplicates for physical coordinates.
@@ -84,7 +85,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeLogicalPhysicalMapping) {
 
         for (auto it : logical_to_physical) {
             CoreCoord physical_coords = it.second;
-            CoreCoord logical_coords = coordinate_manager->to(physical_coords, CoordSystem::LOGICAL);
+            CoreCoord logical_coords = coordinate_manager->translate_coord_to(physical_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of physical coordinates gives the same logical coordinates
             // using which we got the physical coordinates.
@@ -113,7 +114,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeLogicalVirtualMapping) {
         for (size_t x = 0; x < tensix_grid_size.x - num_harvested_x; x++) {
             for (size_t y = 0; y < tensix_grid_size.y; y++) {
                 CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-                CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+                CoreCoord virtual_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
                 logical_to_virtual[logical_coords] = virtual_coords;
 
                 // Expect that logical to virtual translation is 1-1 mapping. No duplicates for virtual coordinates.
@@ -126,7 +127,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeLogicalVirtualMapping) {
 
         for (auto it : logical_to_virtual) {
             CoreCoord virtual_coords = it.second;
-            CoreCoord logical_coords = coordinate_manager->to(virtual_coords, CoordSystem::LOGICAL);
+            CoreCoord logical_coords = coordinate_manager->translate_coord_to(virtual_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of virtual coordinates gives the same logical coordinates
             // using which we got the virtual coordinates.
@@ -155,7 +156,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeLogicalTranslatedMapping) {
         for (size_t x = 0; x < tensix_grid_size.x - num_harvested_x; x++) {
             for (size_t y = 0; y < tensix_grid_size.y; y++) {
                 CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-                CoreCoord translated_coords = coordinate_manager->to(logical_coords, CoordSystem::TRANSLATED);
+                CoreCoord translated_coords =
+                    coordinate_manager->translate_coord_to(logical_coords, CoordSystem::TRANSLATED);
                 logical_to_translated[logical_coords] = translated_coords;
 
                 // Expect that logical to translated translation is 1-1 mapping. No duplicates for translated
@@ -169,7 +171,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeLogicalTranslatedMapping) {
 
         for (auto it : logical_to_translated) {
             CoreCoord translated_coords = it.second;
-            CoreCoord logical_coords = coordinate_manager->to(translated_coords, CoordSystem::LOGICAL);
+            CoreCoord logical_coords = coordinate_manager->translate_coord_to(translated_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of translated coordinates gives the same logical coordinates
             // using which we got the translated coordinates.
@@ -192,8 +194,9 @@ TEST(CoordinateManager, CoordinateManagerBlackholeVirtualEqualTranslated) {
         for (size_t x = 0; x < tt::umd::blackhole::TENSIX_GRID_SIZE.x - num_harvested_x; x++) {
             for (size_t y = 0; y < tt::umd::blackhole::TENSIX_GRID_SIZE.y; y++) {
                 CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-                CoreCoord translated_coords = coordinate_manager->to(logical_coords, CoordSystem::TRANSLATED);
-                CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+                CoreCoord translated_coords =
+                    coordinate_manager->translate_coord_to(logical_coords, CoordSystem::TRANSLATED);
+                CoreCoord virtual_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
 
                 // Expect that translated coordinates are same as virtual coordinates.
                 EXPECT_EQ(translated_coords.x, virtual_coords.x);
@@ -221,11 +224,13 @@ TEST(CoordinateManager, CoordinateManagerBlackholeTransltedMappingHarvested) {
     for (size_t cnt = 0; cnt < num_harvested_x * tensix_grid_size.y; cnt++) {
         CoreCoord physical_core =
             CoreCoord(tensix_cores[index].x, tensix_cores[index].y, CoreType::TENSIX, CoordSystem::PHYSICAL);
-        const CoreCoord translated_core = coordinate_manager->to(physical_core, CoordSystem::TRANSLATED);
+        const CoreCoord translated_core =
+            coordinate_manager->translate_coord_to(physical_core, CoordSystem::TRANSLATED);
 
         const CoreCoord virtual_core = CoreCoord(
             tensix_cores[virtual_index].x, tensix_cores[virtual_index].y, CoreType::TENSIX, CoordSystem::VIRTUAL);
-        const CoreCoord translated_core_from_virtual = coordinate_manager->to(virtual_core, CoordSystem::TRANSLATED);
+        const CoreCoord translated_core_from_virtual =
+            coordinate_manager->translate_coord_to(virtual_core, CoordSystem::TRANSLATED);
 
         EXPECT_EQ(translated_core, translated_core_from_virtual);
 
@@ -267,7 +272,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMNoHarvesting) {
                 CoreType::DRAM,
                 CoordSystem::PHYSICAL);
 
-            const CoreCoord dram_physical = coordinate_manager->to(dram_logical, CoordSystem::PHYSICAL);
+            const CoreCoord dram_physical = coordinate_manager->translate_coord_to(dram_logical, CoordSystem::PHYSICAL);
 
             EXPECT_EQ(dram_physical, expected_physical);
         }
@@ -282,7 +287,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMTopLeft) {
     const CoreCoord top_left_dram_logical = CoreCoord(0, 0, CoreType::DRAM, CoordSystem::LOGICAL);
     const CoreCoord expected_top_left_physical = CoreCoord(0, 2, CoreType::DRAM, CoordSystem::PHYSICAL);
 
-    const CoreCoord top_left_physical = coordinate_manager->to(top_left_dram_logical, CoordSystem::PHYSICAL);
+    const CoreCoord top_left_physical =
+        coordinate_manager->translate_coord_to(top_left_dram_logical, CoordSystem::PHYSICAL);
 
     EXPECT_EQ(top_left_physical, expected_top_left_physical);
 }
@@ -313,7 +319,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMLogicalPhysicalMapping) {
         for (size_t x = 0; x < num_dram_banks - num_banks_harvested; x++) {
             for (size_t y = 0; y < num_noc_ports_per_bank; y++) {
                 const CoreCoord logical_coords = CoreCoord(x, y, CoreType::DRAM, CoordSystem::LOGICAL);
-                const CoreCoord physical_coords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+                const CoreCoord physical_coords =
+                    coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
                 logical_to_physical[logical_coords] = physical_coords;
 
                 // Expect that logical to physical translation is 1-1 mapping. No duplicates for physical coordinates.
@@ -326,7 +333,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMLogicalPhysicalMapping) {
 
         for (auto it : logical_to_physical) {
             const CoreCoord physical_coords = it.second;
-            const CoreCoord logical_coords = coordinate_manager->to(physical_coords, CoordSystem::LOGICAL);
+            const CoreCoord logical_coords =
+                coordinate_manager->translate_coord_to(physical_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of physical coordinates gives the same logical coordinates
             // using which we got the physical coordinates.
@@ -360,7 +368,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMLogicalVirtualMapping) {
         for (size_t x = 0; x < num_dram_banks - num_harvested_banks; x++) {
             for (size_t y = 0; y < num_noc_ports_per_bank; y++) {
                 CoreCoord logical_coords = CoreCoord(x, y, CoreType::DRAM, CoordSystem::LOGICAL);
-                CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+                CoreCoord virtual_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
                 logical_to_virtual[logical_coords] = virtual_coords;
 
                 // Expect that logical to virtual translation is 1-1 mapping. No duplicates for virtual coordinates.
@@ -371,7 +379,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMLogicalVirtualMapping) {
 
         for (auto it : logical_to_virtual) {
             CoreCoord virtual_coords = it.second;
-            CoreCoord logical_coords = coordinate_manager->to(virtual_coords, CoordSystem::LOGICAL);
+            CoreCoord logical_coords = coordinate_manager->translate_coord_to(virtual_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of virtual coordinates gives the same logical coordinates
             // using which we got the virtual coordinates.
@@ -402,7 +410,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMTranslatedMapping) {
         for (size_t x = 0; x < num_dram_banks - num_harvested_banks; x++) {
             for (size_t y = 0; y < num_noc_ports_per_bank; y++) {
                 const CoreCoord logical_coords = CoreCoord(x, y, CoreType::DRAM, CoordSystem::LOGICAL);
-                const CoreCoord translated_coords = coordinate_manager->to(logical_coords, CoordSystem::TRANSLATED);
+                const CoreCoord translated_coords =
+                    coordinate_manager->translate_coord_to(logical_coords, CoordSystem::TRANSLATED);
 
                 EXPECT_GE(translated_coords.x, tt::umd::blackhole::dram_translated_coordinate_start_x);
                 EXPECT_GE(translated_coords.y, tt::umd::blackhole::dram_translated_coordinate_start_y);
@@ -418,7 +427,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMTranslatedMapping) {
 
         for (auto it : logical_to_translated) {
             const CoreCoord translated_coords = it.second;
-            const CoreCoord logical_coords = coordinate_manager->to(translated_coords, CoordSystem::LOGICAL);
+            const CoreCoord logical_coords =
+                coordinate_manager->translate_coord_to(translated_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of translated coordinates gives the same logical coordinates
             // using which we got the translated coordinates.
@@ -452,14 +462,15 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMVirtualPhysicalMapping) {
         const tt_xy_pair virtual_pair = dram_cores[virtual_index + noc_port];
 
         CoreCoord physical_core = CoreCoord(physical_pair.x, physical_pair.y, CoreType::DRAM, CoordSystem::PHYSICAL);
-        CoreCoord virtual_from_physical = coordinate_manager->to(physical_core, CoordSystem::VIRTUAL);
+        CoreCoord virtual_from_physical = coordinate_manager->translate_coord_to(physical_core, CoordSystem::VIRTUAL);
 
         CoreCoord virtual_core = CoreCoord(virtual_pair.x, virtual_pair.y, CoreType::DRAM, CoordSystem::VIRTUAL);
 
         EXPECT_EQ(virtual_from_physical, virtual_core);
 
-        CoreCoord translated_core = coordinate_manager->to(physical_core, CoordSystem::TRANSLATED);
-        CoreCoord translated_from_virtual = coordinate_manager->to(virtual_core, CoordSystem::TRANSLATED);
+        CoreCoord translated_core = coordinate_manager->translate_coord_to(physical_core, CoordSystem::TRANSLATED);
+        CoreCoord translated_from_virtual =
+            coordinate_manager->translate_coord_to(virtual_core, CoordSystem::TRANSLATED);
 
         EXPECT_EQ(translated_core, translated_from_virtual);
 
@@ -493,8 +504,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholePCIETranslation) {
     for (size_t x = 0; x < pcie_grid_size.x; x++) {
         for (size_t y = 0; y < pcie_grid_size.y; y++) {
             const CoreCoord arc_logical = CoreCoord(x, y, CoreType::PCIE, CoordSystem::LOGICAL);
-            const CoreCoord arc_virtual = coordinate_manager->to(arc_logical, CoordSystem::VIRTUAL);
-            const CoreCoord arc_physical = coordinate_manager->to(arc_logical, CoordSystem::PHYSICAL);
+            const CoreCoord arc_virtual = coordinate_manager->translate_coord_to(arc_logical, CoordSystem::VIRTUAL);
+            const CoreCoord arc_physical = coordinate_manager->translate_coord_to(arc_logical, CoordSystem::PHYSICAL);
 
             EXPECT_EQ(arc_virtual.x, arc_physical.x);
             EXPECT_EQ(arc_virtual.y, arc_physical.y);
@@ -511,9 +522,10 @@ TEST(CoordinateManager, CoordinateManagerBlackholeARCTranslation) {
     for (size_t x = 0; x < arc_grid_size.x; x++) {
         for (size_t y = 0; y < arc_grid_size.y; y++) {
             const CoreCoord arc_logical = CoreCoord(x, y, CoreType::ARC, CoordSystem::LOGICAL);
-            const CoreCoord arc_virtual = coordinate_manager->to(arc_logical, CoordSystem::VIRTUAL);
-            const CoreCoord arc_physical = coordinate_manager->to(arc_logical, CoordSystem::PHYSICAL);
-            const CoreCoord arc_translated = coordinate_manager->to(arc_logical, CoordSystem::TRANSLATED);
+            const CoreCoord arc_virtual = coordinate_manager->translate_coord_to(arc_logical, CoordSystem::VIRTUAL);
+            const CoreCoord arc_physical = coordinate_manager->translate_coord_to(arc_logical, CoordSystem::PHYSICAL);
+            const CoreCoord arc_translated =
+                coordinate_manager->translate_coord_to(arc_logical, CoordSystem::TRANSLATED);
 
             EXPECT_EQ(arc_virtual.x, arc_physical.x);
             EXPECT_EQ(arc_virtual.y, arc_physical.y);
@@ -536,9 +548,10 @@ TEST(CoordinateManager, CoordinateManagerBlackholeETHTranslation) {
     for (size_t x = 0; x < eth_grid_size.x; x++) {
         for (size_t y = 0; y < eth_grid_size.y; y++) {
             const CoreCoord eth_logical = CoreCoord(x, y, CoreType::ETH, CoordSystem::LOGICAL);
-            const CoreCoord eth_virtual = coordinate_manager->to(eth_logical, CoordSystem::VIRTUAL);
-            const CoreCoord eth_physical = coordinate_manager->to(eth_logical, CoordSystem::PHYSICAL);
-            const CoreCoord eth_translated = coordinate_manager->to(eth_logical, CoordSystem::TRANSLATED);
+            const CoreCoord eth_virtual = coordinate_manager->translate_coord_to(eth_logical, CoordSystem::VIRTUAL);
+            const CoreCoord eth_physical = coordinate_manager->translate_coord_to(eth_logical, CoordSystem::PHYSICAL);
+            const CoreCoord eth_translated =
+                coordinate_manager->translate_coord_to(eth_logical, CoordSystem::TRANSLATED);
 
             EXPECT_EQ(eth_virtual.x, eth_physical.x);
             EXPECT_EQ(eth_virtual.y, eth_physical.y);

--- a/tests/api/test_core_coord_translation_gs.cpp
+++ b/tests/api/test_core_coord_translation_gs.cpp
@@ -20,8 +20,8 @@ TEST(CoordinateManager, CoordinateManagerGrayskullNoHarvesting) {
     for (size_t x = 0; x < tensix_grid_size.x; x++) {
         for (size_t y = 0; y < tensix_grid_size.y; y++) {
             CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-            CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
-            CoreCoord physical_coords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+            CoreCoord virtual_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
+            CoreCoord physical_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
 
             // Virtual and physical coordinates should be the same.
             EXPECT_EQ(physical_coords.x, virtual_coords.x);
@@ -40,11 +40,11 @@ TEST(CoordinateManager, CoordinateManagerGrayskullTopLeftCore) {
     CoreCoord logical_coords = CoreCoord(0, 0, CoreType::TENSIX, CoordSystem::LOGICAL);
 
     // Always expect same virtual coordinate for (0, 0) logical coordinate.
-    CoreCoord virtual_cords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+    CoreCoord virtual_cords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
     EXPECT_EQ(virtual_cords, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL));
 
     // This depends on harvesting mask. So expected physical coord is specific to this test and Wormhole arch.
-    CoreCoord physical_cords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+    CoreCoord physical_cords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
     EXPECT_EQ(physical_cords, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::PHYSICAL));
 }
 
@@ -60,11 +60,11 @@ TEST(CoordinateManager, CoordinateManagerGrayskullTopLeftCoreHarvesting) {
     CoreCoord logical_coords = CoreCoord(0, 0, CoreType::TENSIX, CoordSystem::LOGICAL);
 
     // Always expect same virtual coordinate for (0, 0) logical coordinate.
-    CoreCoord virtual_cords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+    CoreCoord virtual_cords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
     EXPECT_EQ(virtual_cords, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL));
 
     // This depends on harvesting mask. So expected physical coord is specific to this test and Wormhole arch.
-    CoreCoord physical_cords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+    CoreCoord physical_cords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
     EXPECT_EQ(physical_cords, CoreCoord(1, 2, CoreType::TENSIX, CoordSystem::PHYSICAL));
 }
 
@@ -78,9 +78,10 @@ TEST(CoordinateManager, CoordinateManagerGrayskullTranslatingCoords) {
     for (size_t x = 0; x < tensix_grid_size.x; x++) {
         for (size_t y = 0; y < tensix_grid_size.y; y++) {
             CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-            CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
-            CoreCoord physical_coords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
-            CoreCoord translated_coords = coordinate_manager->to(logical_coords, CoordSystem::TRANSLATED);
+            CoreCoord virtual_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
+            CoreCoord physical_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
+            CoreCoord translated_coords =
+                coordinate_manager->translate_coord_to(logical_coords, CoordSystem::TRANSLATED);
 
             // Virtual, physical and translated coordinates should be the same.
             EXPECT_EQ(physical_coords.x, virtual_coords.x);
@@ -112,7 +113,8 @@ TEST(CoordinateManager, CoordinateManagerGrayskullLogicalPhysicalMapping) {
         for (size_t x = 0; x < tensix_grid_size.x; x++) {
             for (size_t y = 0; y < tensix_grid_size.y - num_harvested_y; y++) {
                 CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-                CoreCoord physical_coords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+                CoreCoord physical_coords =
+                    coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
                 logical_to_physical[logical_coords] = physical_coords;
 
                 // Expect that logical to physical translation is 1-1 mapping. No duplicates for physical coordinates.
@@ -127,7 +129,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullLogicalPhysicalMapping) {
 
         for (auto it : logical_to_physical) {
             CoreCoord physical_coords = it.second;
-            CoreCoord logical_coords = coordinate_manager->to(physical_coords, CoordSystem::LOGICAL);
+            CoreCoord logical_coords = coordinate_manager->translate_coord_to(physical_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of physical coordinates gives the same logical coordinates
             // using which we got the physical coordinates.
@@ -156,7 +158,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullLogicalVirtualMapping) {
         for (size_t x = 0; x < tensix_grid_size.x; x++) {
             for (size_t y = 0; y < tensix_grid_size.y - num_harvested_y; y++) {
                 CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-                CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+                CoreCoord virtual_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
                 logical_to_virtual[logical_coords] = virtual_coords;
 
                 // Expect that logical to virtual translation is 1-1 mapping. No duplicates for virtual coordinates.
@@ -167,7 +169,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullLogicalVirtualMapping) {
 
         for (auto it : logical_to_virtual) {
             CoreCoord virtual_coords = it.second;
-            CoreCoord logical_coords = coordinate_manager->to(virtual_coords, CoordSystem::LOGICAL);
+            CoreCoord logical_coords = coordinate_manager->translate_coord_to(virtual_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of virtual coordinates gives the same logical coordinates
             // using which we got the virtual coordinates.
@@ -193,7 +195,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullPhysicalHarvestedMapping) {
     for (size_t index = 0; index < num_harvested * tensix_grid_size.x; index++) {
         const CoreCoord physical_core =
             CoreCoord(tensix_cores[index].x, tensix_cores[index].y, CoreType::TENSIX, CoordSystem::PHYSICAL);
-        const CoreCoord virtual_core = coordinate_manager->to(physical_core, CoordSystem::VIRTUAL);
+        const CoreCoord virtual_core = coordinate_manager->translate_coord_to(physical_core, CoordSystem::VIRTUAL);
 
         EXPECT_EQ(virtual_core.x, tensix_cores[virtual_index].x);
         EXPECT_EQ(virtual_core.y, tensix_cores[virtual_index].y);
@@ -219,11 +221,13 @@ TEST(CoordinateManager, CoordinateManagerGrayskullPhysicalTranslatedHarvestedMap
     for (size_t index = 0; index < num_harvested * tensix_grid_size.x; index++) {
         const CoreCoord physical_core =
             CoreCoord(tensix_cores[index].x, tensix_cores[index].y, CoreType::TENSIX, CoordSystem::PHYSICAL);
-        const CoreCoord translated_core = coordinate_manager->to(physical_core, CoordSystem::TRANSLATED);
+        const CoreCoord translated_core =
+            coordinate_manager->translate_coord_to(physical_core, CoordSystem::TRANSLATED);
 
         const CoreCoord virtual_core = CoreCoord(
             tensix_cores[virtual_index].x, tensix_cores[virtual_index].y, CoreType::TENSIX, CoordSystem::VIRTUAL);
-        const CoreCoord translated_core_from_virtual = coordinate_manager->to(virtual_core, CoordSystem::TRANSLATED);
+        const CoreCoord translated_core_from_virtual =
+            coordinate_manager->translate_coord_to(virtual_core, CoordSystem::TRANSLATED);
 
         EXPECT_EQ(translated_core, translated_core_from_virtual);
 
@@ -248,7 +252,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullDRAMNoHarvesting) {
         const CoreCoord expected_physical =
             CoreCoord(dram_cores[dram_bank].x, dram_cores[dram_bank].y, CoreType::DRAM, CoordSystem::PHYSICAL);
 
-        const CoreCoord dram_physical = coordinate_manager->to(dram_logical, CoordSystem::PHYSICAL);
+        const CoreCoord dram_physical = coordinate_manager->translate_coord_to(dram_logical, CoordSystem::PHYSICAL);
 
         EXPECT_EQ(dram_physical, expected_physical);
     }
@@ -263,9 +267,10 @@ TEST(CoordinateManager, CoordinateManagerGrayskullPCIETranslation) {
     for (size_t x = 0; x < pcie_grid_size.x; x++) {
         for (size_t y = 0; y < pcie_grid_size.y; y++) {
             const CoreCoord pcie_logical = CoreCoord(x, y, CoreType::PCIE, CoordSystem::LOGICAL);
-            const CoreCoord pcie_virtual = coordinate_manager->to(pcie_logical, CoordSystem::VIRTUAL);
-            const CoreCoord pcie_physical = coordinate_manager->to(pcie_logical, CoordSystem::PHYSICAL);
-            const CoreCoord pcie_translated = coordinate_manager->to(pcie_logical, CoordSystem::TRANSLATED);
+            const CoreCoord pcie_virtual = coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::VIRTUAL);
+            const CoreCoord pcie_physical = coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::PHYSICAL);
+            const CoreCoord pcie_translated =
+                coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::TRANSLATED);
 
             EXPECT_EQ(pcie_virtual.x, pcie_physical.x);
             EXPECT_EQ(pcie_virtual.y, pcie_physical.y);
@@ -285,9 +290,10 @@ TEST(CoordinateManager, CoordinateManagerGrayskullARCTranslation) {
     for (size_t x = 0; x < arc_grid_size.x; x++) {
         for (size_t y = 0; y < arc_grid_size.y; y++) {
             const CoreCoord arc_logical = CoreCoord(x, y, CoreType::ARC, CoordSystem::LOGICAL);
-            const CoreCoord arc_virtual = coordinate_manager->to(arc_logical, CoordSystem::VIRTUAL);
-            const CoreCoord arc_physical = coordinate_manager->to(arc_logical, CoordSystem::PHYSICAL);
-            const CoreCoord arc_translated = coordinate_manager->to(arc_logical, CoordSystem::TRANSLATED);
+            const CoreCoord arc_virtual = coordinate_manager->translate_coord_to(arc_logical, CoordSystem::VIRTUAL);
+            const CoreCoord arc_physical = coordinate_manager->translate_coord_to(arc_logical, CoordSystem::PHYSICAL);
+            const CoreCoord arc_translated =
+                coordinate_manager->translate_coord_to(arc_logical, CoordSystem::TRANSLATED);
 
             EXPECT_EQ(arc_virtual.x, arc_physical.x);
             EXPECT_EQ(arc_virtual.y, arc_physical.y);

--- a/tests/api/test_core_coord_translation_wh.cpp
+++ b/tests/api/test_core_coord_translation_wh.cpp
@@ -23,8 +23,10 @@ TEST(CoordinateManager, CoordinateManagerWormholeNoHarvesting) {
     for (size_t x = 0; x < tensix_grid_size.x; x++) {
         for (size_t y = 0; y < tensix_grid_size.y; y++) {
             const CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-            const CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
-            const CoreCoord physical_coords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+            const CoreCoord virtual_coords =
+                coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
+            const CoreCoord physical_coords =
+                coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
 
             // Virtual and physical coordinates should be the same.
             EXPECT_EQ(physical_coords.x, virtual_coords.x);
@@ -47,11 +49,11 @@ TEST(CoordinateManager, CoordinateManagerWormholeTopLeftCore) {
     CoreCoord logical_coords = CoreCoord(0, 0, CoreType::TENSIX, CoordSystem::LOGICAL);
 
     // Always expect same virtual coordinate for (0, 0) logical coordinate.
-    CoreCoord virtual_cords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+    CoreCoord virtual_cords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
     EXPECT_EQ(virtual_cords, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL));
 
     // This depends on harvesting mask. So expected physical coord is specific to this test and Wormhole arch.
-    CoreCoord physical_cords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+    CoreCoord physical_cords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
     EXPECT_EQ(physical_cords, CoreCoord(1, 2, CoreType::TENSIX, CoordSystem::PHYSICAL));
 }
 
@@ -75,7 +77,8 @@ TEST(CoordinateManager, CoordinateManagerWormholeLogicalPhysicalMapping) {
         for (size_t x = 0; x < tensix_grid_size.x; x++) {
             for (size_t y = 0; y < tensix_grid_size.y - num_harvested_y; y++) {
                 CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-                CoreCoord physical_coords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
+                CoreCoord physical_coords =
+                    coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
                 logical_to_physical[logical_coords] = physical_coords;
 
                 // Expect that logical to physical translation is 1-1 mapping. No duplicates for physical coordinates.
@@ -90,7 +93,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeLogicalPhysicalMapping) {
 
         for (auto it : logical_to_physical) {
             CoreCoord physical_coords = it.second;
-            CoreCoord logical_coords = coordinate_manager->to(physical_coords, CoordSystem::LOGICAL);
+            CoreCoord logical_coords = coordinate_manager->translate_coord_to(physical_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of physical coordinates gives the same logical coordinates
             // using which we got the physical coordinates.
@@ -119,7 +122,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeLogicalVirtualMapping) {
         for (size_t x = 0; x < tensix_grid_size.x; x++) {
             for (size_t y = 0; y < tensix_grid_size.y - num_harvested_y; y++) {
                 CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-                CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+                CoreCoord virtual_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
                 logical_to_virtual[logical_coords] = virtual_coords;
 
                 // Expect that logical to virtual translation is 1-1 mapping. No duplicates for virtual coordinates.
@@ -130,7 +133,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeLogicalVirtualMapping) {
 
         for (auto it : logical_to_virtual) {
             CoreCoord virtual_coords = it.second;
-            CoreCoord logical_coords = coordinate_manager->to(virtual_coords, CoordSystem::LOGICAL);
+            CoreCoord logical_coords = coordinate_manager->translate_coord_to(virtual_coords, CoordSystem::LOGICAL);
 
             // Expect that reverse mapping of virtual coordinates gives the same logical coordinates
             // using which we got the virtual coordinates.
@@ -159,12 +162,15 @@ TEST(CoordinateManager, CoordinateManagerWormholeLogicalTranslatedTopLeft) {
         size_t num_harvested_y = CoordinateManager::get_num_harvested(harvesting_mask);
 
         CoreCoord logical_coords = CoreCoord(0, 0, CoreType::TENSIX, CoordSystem::LOGICAL);
-        CoreCoord physical_coords = coordinate_manager->to(logical_coords, CoordSystem::PHYSICAL);
-        CoreCoord virtual_coords = coordinate_manager->to(logical_coords, CoordSystem::VIRTUAL);
+        CoreCoord physical_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::PHYSICAL);
+        CoreCoord virtual_coords = coordinate_manager->translate_coord_to(logical_coords, CoordSystem::VIRTUAL);
 
-        CoreCoord translated_from_logical = coordinate_manager->to(logical_coords, CoordSystem::TRANSLATED);
-        CoreCoord translated_from_physical = coordinate_manager->to(physical_coords, CoordSystem::TRANSLATED);
-        CoreCoord translated_from_virtual = coordinate_manager->to(virtual_coords, CoordSystem::TRANSLATED);
+        CoreCoord translated_from_logical =
+            coordinate_manager->translate_coord_to(logical_coords, CoordSystem::TRANSLATED);
+        CoreCoord translated_from_physical =
+            coordinate_manager->translate_coord_to(physical_coords, CoordSystem::TRANSLATED);
+        CoreCoord translated_from_virtual =
+            coordinate_manager->translate_coord_to(virtual_coords, CoordSystem::TRANSLATED);
 
         EXPECT_EQ(translated_from_logical, expected_translated_coords);
         EXPECT_EQ(translated_from_physical, expected_translated_coords);
@@ -189,7 +195,7 @@ TEST(CoordinateManager, CoordinateManagerWormholePhysicalVirtualHarvestedMapping
     for (size_t index = 0; index < num_harvested * tensix_grid_size.x; index++) {
         const CoreCoord physical_core =
             CoreCoord(tensix_cores[index].x, tensix_cores[index].y, CoreType::TENSIX, CoordSystem::PHYSICAL);
-        const CoreCoord virtual_core = coordinate_manager->to(physical_core, CoordSystem::VIRTUAL);
+        const CoreCoord virtual_core = coordinate_manager->translate_coord_to(physical_core, CoordSystem::VIRTUAL);
 
         EXPECT_EQ(virtual_core.x, tensix_cores[virtual_index].x);
         EXPECT_EQ(virtual_core.y, tensix_cores[virtual_index].y);
@@ -221,11 +227,13 @@ TEST(CoordinateManager, CoordinateManagerWormholePhysicalTranslatedHarvestedMapp
     for (size_t index = 0; index < num_harvested * tensix_grid_size.x; index++) {
         const CoreCoord physical_core =
             CoreCoord(tensix_cores[index].x, tensix_cores[index].y, CoreType::TENSIX, CoordSystem::PHYSICAL);
-        const CoreCoord translated_core = coordinate_manager->to(physical_core, CoordSystem::TRANSLATED);
+        const CoreCoord translated_core =
+            coordinate_manager->translate_coord_to(physical_core, CoordSystem::TRANSLATED);
 
         const CoreCoord virtual_core = CoreCoord(
             tensix_cores[virtual_index].x, tensix_cores[virtual_index].y, CoreType::TENSIX, CoordSystem::VIRTUAL);
-        const CoreCoord translated_core_from_virtual = coordinate_manager->to(virtual_core, CoordSystem::TRANSLATED);
+        const CoreCoord translated_core_from_virtual =
+            coordinate_manager->translate_coord_to(virtual_core, CoordSystem::TRANSLATED);
 
         EXPECT_EQ(translated_core, translated_core_from_virtual);
 
@@ -263,7 +271,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeDRAMNoHarvesting) {
                 CoreType::DRAM,
                 CoordSystem::PHYSICAL);
 
-            const CoreCoord dram_physical = coordinate_manager->to(dram_logical, CoordSystem::PHYSICAL);
+            const CoreCoord dram_physical = coordinate_manager->translate_coord_to(dram_logical, CoordSystem::PHYSICAL);
 
             EXPECT_EQ(dram_physical, expected_physical);
         }
@@ -280,8 +288,8 @@ TEST(CoordinateManager, CoordinateManagerWormholeETHPhysicalEqualVirtual) {
     for (size_t x = 0; x < eth_grid_size.x; x++) {
         for (size_t y = 0; y < eth_grid_size.y; y++) {
             const CoreCoord eth_logical = CoreCoord(x, y, CoreType::ETH, CoordSystem::LOGICAL);
-            const CoreCoord eth_virtual = coordinate_manager->to(eth_logical, CoordSystem::VIRTUAL);
-            const CoreCoord eth_physical = coordinate_manager->to(eth_logical, CoordSystem::PHYSICAL);
+            const CoreCoord eth_virtual = coordinate_manager->translate_coord_to(eth_logical, CoordSystem::VIRTUAL);
+            const CoreCoord eth_physical = coordinate_manager->translate_coord_to(eth_logical, CoordSystem::PHYSICAL);
 
             EXPECT_EQ(eth_virtual.x, eth_physical.x);
             EXPECT_EQ(eth_virtual.y, eth_physical.y);
@@ -298,7 +306,8 @@ TEST(CoordinateManager, CoordinateManagerWormholeETHLogicalToTranslated) {
     for (size_t x = 0; x < eth_grid_size.x; x++) {
         for (size_t y = 0; y < eth_grid_size.y; y++) {
             const CoreCoord eth_logical = CoreCoord(x, y, CoreType::ETH, CoordSystem::LOGICAL);
-            const CoreCoord eth_translated = coordinate_manager->to(eth_logical, CoordSystem::TRANSLATED);
+            const CoreCoord eth_translated =
+                coordinate_manager->translate_coord_to(eth_logical, CoordSystem::TRANSLATED);
 
             EXPECT_EQ(eth_translated.x, x + 18);
             EXPECT_EQ(eth_translated.y, y + 16);
@@ -315,9 +324,10 @@ TEST(CoordinateManager, CoordinateManagerWormholeARCTranslation) {
     for (size_t x = 0; x < arc_grid_size.x; x++) {
         for (size_t y = 0; y < arc_grid_size.y; y++) {
             const CoreCoord arc_logical = CoreCoord(x, y, CoreType::ARC, CoordSystem::LOGICAL);
-            const CoreCoord arc_virtual = coordinate_manager->to(arc_logical, CoordSystem::VIRTUAL);
-            const CoreCoord arc_physical = coordinate_manager->to(arc_logical, CoordSystem::PHYSICAL);
-            const CoreCoord arc_translated = coordinate_manager->to(arc_logical, CoordSystem::TRANSLATED);
+            const CoreCoord arc_virtual = coordinate_manager->translate_coord_to(arc_logical, CoordSystem::VIRTUAL);
+            const CoreCoord arc_physical = coordinate_manager->translate_coord_to(arc_logical, CoordSystem::PHYSICAL);
+            const CoreCoord arc_translated =
+                coordinate_manager->translate_coord_to(arc_logical, CoordSystem::TRANSLATED);
 
             EXPECT_EQ(arc_virtual.x, arc_physical.x);
             EXPECT_EQ(arc_virtual.y, arc_physical.y);
@@ -337,9 +347,10 @@ TEST(CoordinateManager, CoordinateManagerWormholePCIETranslation) {
     for (size_t x = 0; x < pcie_grid_size.x; x++) {
         for (size_t y = 0; y < pcie_grid_size.y; y++) {
             const CoreCoord pcie_logical = CoreCoord(x, y, CoreType::PCIE, CoordSystem::LOGICAL);
-            const CoreCoord pcie_virtual = coordinate_manager->to(pcie_logical, CoordSystem::VIRTUAL);
-            const CoreCoord pcie_physical = coordinate_manager->to(pcie_logical, CoordSystem::PHYSICAL);
-            const CoreCoord pcie_translated = coordinate_manager->to(pcie_logical, CoordSystem::TRANSLATED);
+            const CoreCoord pcie_virtual = coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::VIRTUAL);
+            const CoreCoord pcie_physical = coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::PHYSICAL);
+            const CoreCoord pcie_translated =
+                coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::TRANSLATED);
 
             EXPECT_EQ(pcie_virtual.x, pcie_physical.x);
             EXPECT_EQ(pcie_virtual.y, pcie_physical.y);

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -112,8 +112,8 @@ TEST(SocDescriptor, SocDescriptorWormholeETHLogicalToPhysical) {
     for (size_t y = 0; y < eth_grid_size.y; y++) {
         for (size_t x = 0; x < eth_grid_size.x; x++) {
             const CoreCoord eth_logical = CoreCoord(x, y, CoreType::ETH, CoordSystem::LOGICAL);
-            const CoreCoord eth_physical = soc_desc.to(eth_logical, CoordSystem::PHYSICAL);
-            const CoreCoord eth_virtual = soc_desc.to(eth_logical, CoordSystem::VIRTUAL);
+            const CoreCoord eth_physical = soc_desc.translate_coord_to(eth_logical, CoordSystem::PHYSICAL);
+            const CoreCoord eth_virtual = soc_desc.translate_coord_to(eth_logical, CoordSystem::VIRTUAL);
 
             EXPECT_EQ(eth_physical.x, wormhole_eth_cores[index].x);
             EXPECT_EQ(eth_physical.y, wormhole_eth_cores[index].y);
@@ -216,9 +216,9 @@ TEST(SocDescriptor, CustomSocDescriptor) {
     tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_simulation_1x2.yaml"), 0, 0);
 
     const CoreCoord tensix_core_01 = CoreCoord(0, 1, CoreType::TENSIX, CoordSystem::PHYSICAL);
-    const CoreCoord tensix_core_01_virtual = soc_desc.to(tensix_core_01, CoordSystem::VIRTUAL);
-    const CoreCoord tensix_core_01_logical = soc_desc.to(tensix_core_01, CoordSystem::LOGICAL);
-    const CoreCoord tensix_core_01_translated = soc_desc.to(tensix_core_01, CoordSystem::TRANSLATED);
+    const CoreCoord tensix_core_01_virtual = soc_desc.translate_coord_to(tensix_core_01, CoordSystem::VIRTUAL);
+    const CoreCoord tensix_core_01_logical = soc_desc.translate_coord_to(tensix_core_01, CoordSystem::LOGICAL);
+    const CoreCoord tensix_core_01_translated = soc_desc.translate_coord_to(tensix_core_01, CoordSystem::TRANSLATED);
 
     EXPECT_EQ(tensix_core_01_virtual.x, tensix_core_01.x);
     EXPECT_EQ(tensix_core_01_virtual.y, tensix_core_01.y);
@@ -230,9 +230,9 @@ TEST(SocDescriptor, CustomSocDescriptor) {
     EXPECT_EQ(tensix_core_01_logical.y, 0);
 
     const CoreCoord tensix_core_11 = CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::PHYSICAL);
-    const CoreCoord tensix_core_11_virtual = soc_desc.to(tensix_core_11, CoordSystem::VIRTUAL);
-    const CoreCoord tensix_core_11_logical = soc_desc.to(tensix_core_11, CoordSystem::LOGICAL);
-    const CoreCoord tensix_core_11_translated = soc_desc.to(tensix_core_11, CoordSystem::TRANSLATED);
+    const CoreCoord tensix_core_11_virtual = soc_desc.translate_coord_to(tensix_core_11, CoordSystem::VIRTUAL);
+    const CoreCoord tensix_core_11_logical = soc_desc.translate_coord_to(tensix_core_11, CoordSystem::LOGICAL);
+    const CoreCoord tensix_core_11_translated = soc_desc.translate_coord_to(tensix_core_11, CoordSystem::TRANSLATED);
 
     EXPECT_EQ(tensix_core_11_virtual.x, tensix_core_11.x);
     EXPECT_EQ(tensix_core_11_virtual.y, tensix_core_11.y);
@@ -253,9 +253,9 @@ TEST(SocDescriptor, CustomSocDescriptor) {
     EXPECT_TRUE(harvested_tensix_cores.empty());
 
     const CoreCoord dram_core_10 = CoreCoord(1, 0, CoreType::DRAM, CoordSystem::PHYSICAL);
-    const CoreCoord dram_core_10_virtual = soc_desc.to(dram_core_10, CoordSystem::VIRTUAL);
-    const CoreCoord dram_core_10_logical = soc_desc.to(dram_core_10, CoordSystem::LOGICAL);
-    const CoreCoord dram_core_10_translated = soc_desc.to(dram_core_10, CoordSystem::TRANSLATED);
+    const CoreCoord dram_core_10_virtual = soc_desc.translate_coord_to(dram_core_10, CoordSystem::VIRTUAL);
+    const CoreCoord dram_core_10_logical = soc_desc.translate_coord_to(dram_core_10, CoordSystem::LOGICAL);
+    const CoreCoord dram_core_10_translated = soc_desc.translate_coord_to(dram_core_10, CoordSystem::TRANSLATED);
 
     EXPECT_EQ(dram_core_10_virtual.x, dram_core_10.x);
     EXPECT_EQ(dram_core_10_virtual.y, dram_core_10.y);


### PR DESCRIPTION
### Issue

/

### Description

Rename function for coordinate translation

### List of the changes

/

### Testing


### API Changes

Metal is not using this, tt-lens should be changed

- [ ]  tt_debuda approved PR pointing to this branch: link
