### PR TITLE
Fix warning for grayskull boards

### DIFF
--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -25,12 +25,14 @@ class Node;
 }
 
 enum BoardType : uint32_t {
-    N150 = 0,
-    N300 = 1,
-    E150 = 2,
-    P150A = 3,
-    GALAXY = 4,
-    UNKNOWN = 5,
+    E75 = 0,
+    E150 = 1,
+    E300 = 2,
+    N150 = 3,
+    N300 = 4,
+    P150A = 5,
+    GALAXY = 6,
+    UNKNOWN = 7,
 };
 
 class tt_ClusterDescriptor {

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -737,16 +737,20 @@ void tt_ClusterDescriptor::load_chips_from_connectivity_descriptor(YAML::Node &y
         for (const auto &chip_board_type : yaml["boardtype"].as<std::map<int, std::string>>()) {
             auto &chip = chip_board_type.first;
             BoardType board_type;
-            if (chip_board_type.second == "n150") {
+            if (chip_board_type.second == "e75") {
+                board_type = BoardType::E75;
+            } else if (chip_board_type.second == "e150") {
+                board_type = BoardType::E150;
+            } else if (chip_board_type.second == "e300") {
+                board_type = BoardType::E300;
+            } else if (chip_board_type.second == "n150") {
                 board_type = BoardType::N150;
             } else if (chip_board_type.second == "n300") {
                 board_type = BoardType::N300;
-            } else if (chip_board_type.second == "GALAXY") {
-                board_type = BoardType::GALAXY;
-            } else if (chip_board_type.second == "e150") {
-                board_type = BoardType::E150;
             } else if (chip_board_type.second == "p150A") {
                 board_type = BoardType::P150A;
+            } else if (chip_board_type.second == "GALAXY") {
+                board_type = BoardType::GALAXY;
             } else {
                 log_warning(
                     LogSiliconDriver,

--- a/tests/api/cluster_descriptor_examples/grayskull_e75.yaml
+++ b/tests/api/cluster_descriptor_examples/grayskull_e75.yaml
@@ -1,0 +1,23 @@
+arch: {
+   0: Grayskull,
+}
+
+chips: {
+}
+
+ethernet_connections: [
+]
+
+chips_with_mmio: [
+   0: 0,
+]
+
+# harvest_mask is the bit indicating which tensix row is harvested. So bit 0 = first tensix row; bit 1 = second tensix row etc...
+harvesting: {
+   0: {noc_translation: false, harvest_mask: 0},
+}
+
+# This value will be null if the boardtype is unknown, should never happen in practice but to be defensive it would be useful to throw an error on this case.
+boardtype: {
+   0: e75,
+}

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -75,6 +75,7 @@ TEST(ApiClusterDescriptorTest, TestAllOfflineClusterDescriptors) {
     for (std::string cluster_desc_yaml : {
              "blackhole_P150.yaml",
              "galaxy.yaml",
+             "grayskull_e75.yaml",
              "grayskull_E150.yaml",
              "grayskull_E300.yaml",
              "wormhole_2xN300_unconnected.yaml",


### PR DESCRIPTION
### Issue

Fixing metal issue https://github.com/tenstorrent/tt-metal/issues/15296

### Description

Recognize e75 and e150 in cluster descriptor

### List of the changes

Add e75 and e150 to board type enum

### Testing

CI

### API Changes
No API changes but below is metal PR that is going to bump umd
- [x] tt_metal approved PR pointing to this branch: https://github.com/tenstorrent/tt-metal/pull/16126