### PR TITLE
Reduce CI load

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -19,9 +19,14 @@ jobs:
           {arch: wormhole_b0},
           {arch: blackhole},
         ]
+        ubuntu-version: [
+          'ubuntu-22.04',
+          'ubuntu-20.04',
+        ]
     uses: ./.github/workflows/build-tests.yml
     with:
       arch: ${{ matrix.test-group.arch}}
+      ubuntu-version: ${{ matrix.ubuntu-version}}
       timeout: 15
 
   test-all:
@@ -39,8 +44,14 @@ jobs:
           # Enable once we have functional cards.
           # {arch: blackhole},
         ]
+        ubuntu-version: [
+          # Running tests on ubuntu-20.04 should be sufficient. Reduce load on CI.
+          # 'ubuntu-22.04',
+          'ubuntu-20.04',
+        ]
     uses: ./.github/workflows/run-tests.yml
     with:
       arch: ${{ matrix.test-group.arch}}
+      ubuntu-version: ${{ matrix.ubuntu-version}}
       card: ${{ matrix.test-group.card}}
       timeout: ${{ matrix.test-group.timeout}}

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -8,6 +8,9 @@ on:
       arch:
         required: true
         type: string
+      ubuntu-version:
+        required: true
+        type: string
       timeout:
         required: true
         type: number
@@ -21,6 +24,13 @@ on:
           - grayskull
           - wormhole_b0
           - blackhole
+      ubuntu-version:
+        required: true
+        description: 'The version of Ubuntu to build on'
+        type: choice
+        options:
+          - ubuntu-22.04
+          - ubuntu-20.04
       timeout:
         required: true
         description: 'The timeout for the build job in minutes'
@@ -40,18 +50,11 @@ jobs:
   build:
     # Due to parsing bug, fromJSON is used to convert string to number
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
-    strategy:
-      fail-fast: false
-      matrix:
-        build: [
-          {runs-on: ubuntu-22.04, docker-image: tt-umd-ci-ubuntu-22.04},
-          {runs-on: ubuntu-20.04, docker-image: tt-umd-ci-ubuntu-20.04},
-        ]
 
-    name: Build umd_tests for ${{ inputs.arch }} on ${{ matrix.build.runs-on }}
-    runs-on: ${{ matrix.build.runs-on }}
+    name: Build umd_tests for ${{ inputs.arch }} on ${{ inputs.ubuntu-version }}
+    runs-on: ${{ inputs.ubuntu-version }}
     container:
-      image: ghcr.io/${{ github.repository }}/${{ matrix.build.docker-image }}:latest
+      image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-version }}:latest
       options: --user root
 
     env:
@@ -84,5 +87,5 @@ jobs:
       - name: Upload build artifacts archive
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts-${{ inputs.arch }}-${{ matrix.build.runs-on }}
+          name: build-artifacts-${{ inputs.arch }}-${{ inputs.ubuntu-version }}
           path: artifact.tar

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,6 +7,9 @@ on:
       arch:
         required: true
         type: string
+      ubuntu-version:
+        required: true
+        type: string
       card:
         required: true
         type: string
@@ -23,6 +26,13 @@ on:
           - grayskull
           - wormhole_b0
           - blackhole
+      ubuntu-version:
+        required: true
+        description: 'The version of Ubuntu to build on'
+        type: choice
+        options:
+          - ubuntu-22.04
+          - ubuntu-20.04
       card:
         required: true
         description: 'The card to run tests on'
@@ -47,20 +57,13 @@ jobs:
   test:
     # Due to parsing bug, fromJSON is used to convert string to number
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
-    strategy:
-      fail-fast: false
-      matrix:
-        build: [
-          {runs-on: ubuntu-22.04, docker-image: tt-umd-ci-ubuntu-22.04},
-          {runs-on: ubuntu-20.04, docker-image: tt-umd-ci-ubuntu-20.04},
-        ]
 
-    name: Run tests for ${{ inputs.arch }} on ${{ inputs.card }} on ${{ matrix.build.runs-on }}
+    name: Run tests for ${{ inputs.arch }} on ${{ inputs.card }} on ${{ inputs.ubuntu-version }}
     runs-on:
       - self-hosted
       - ${{ inputs.card }}
     container:
-      image: ghcr.io/${{ github.repository }}/${{ matrix.build.docker-image }}:latest
+      image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-version }}:latest
       options: --user root --device /dev/tenstorrent/0
       volumes:
         - /dev/hugepages:/dev/hugepages
@@ -83,7 +86,7 @@ jobs:
       - name: Use build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: build-artifacts-${{ inputs.arch }}-${{ matrix.build.runs-on }}
+          name: build-artifacts-${{ inputs.arch }}-${{ inputs.ubuntu-version }}
           path: ./
 
       # This is needed to preserve file permissions


### PR DESCRIPTION
### Issue
No issue

### Description
We are running same tests on both versions of ubuntu.
There is no need to think that tests would fall on one of the version and not the other, and we never saw this case. I still intentionally left building on ubuntu 22 though.
I chose ubuntu-20 since this is the same one as used in tt-metal.

### List of the changes
- Changed build-tests and run-tests to accept ubuntu version argument
- Added required ubuntu versions in build_and_run tests. Build on both 20 and 22, run tests only on 20.
- I'll also add these tests as required for PRs after this PR.

### Testing
CI tests on this PR

### API Changes
There are no API changes in this PR.
