### PR TITLE
init

### DIFF
--- a/device/api/umd/device/architecture_implementation.h
+++ b/device/api/umd/device/architecture_implementation.h
@@ -67,7 +67,6 @@ public:
 
     virtual std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const = 0;
     virtual tlb_configuration get_tlb_configuration(uint32_t tlb_index) const = 0;
-    virtual std::optional<std::tuple<std::uint64_t, std::uint64_t>> describe_tlb(std::int32_t tlb_index) const = 0;
     virtual std::pair<std::uint64_t, std::uint64_t> get_tlb_data(
         std::uint32_t tlb_index, const tlb_data& data) const = 0;
 

--- a/device/api/umd/device/blackhole_implementation.h
+++ b/device/api/umd/device/blackhole_implementation.h
@@ -306,7 +306,6 @@ public:
 
     std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const override;
     tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
-    std::optional<std::tuple<std::uint64_t, std::uint64_t>> describe_tlb(std::int32_t tlb_index) const override;
     std::pair<std::uint64_t, std::uint64_t> get_tlb_data(std::uint32_t tlb_index, const tlb_data& data) const override;
 
     tt_device_l1_address_params get_l1_address_params() const override;

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -562,7 +562,7 @@ public:
     /**
      * If the tlbs are initialized, returns a tuple with the TLB base address and its size
      */
-    std::optional<std::tuple<uint32_t, uint32_t>> get_tlb_data_from_target(const tt_cxy_pair& target);
+    tlb_configuration get_tlb_data_from_target(const tt_cxy_pair& target);
     /**
      * This API allows you to write directly to device memory that is addressable by a static TLB
      */

--- a/device/api/umd/device/grayskull_implementation.h
+++ b/device/api/umd/device/grayskull_implementation.h
@@ -296,7 +296,6 @@ public:
 
     std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const override;
     tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
-    std::optional<std::tuple<std::uint64_t, std::uint64_t>> describe_tlb(std::int32_t tlb_index) const override;
     std::pair<std::uint64_t, std::uint64_t> get_tlb_data(std::uint32_t tlb_index, const tlb_data& data) const override;
 
     tt_device_l1_address_params get_l1_address_params() const override;

--- a/device/api/umd/device/tlb.h
+++ b/device/api/umd/device/tlb.h
@@ -50,9 +50,10 @@ struct tlb_data {
 
 struct tlb_configuration {
     uint64_t size;
-    uint32_t base;
-    uint32_t cfg_addr;
-    uint32_t index_offset;
+    uint64_t base;
+    uint64_t cfg_addr;
+    uint64_t index_offset;
+    uint64_t tlb_offset;
     tlb_offsets offset;
 };
 

--- a/device/api/umd/device/wormhole_implementation.h
+++ b/device/api/umd/device/wormhole_implementation.h
@@ -330,7 +330,6 @@ public:
 
     std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const override;
     tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
-    std::optional<std::tuple<std::uint64_t, std::uint64_t>> describe_tlb(std::int32_t tlb_index) const override;
     std::pair<std::uint64_t, std::uint64_t> get_tlb_data(std::uint32_t tlb_index, const tlb_data& data) const override;
 
     tt_device_l1_address_params get_l1_address_params() const override;

--- a/device/blackhole/blackhole_implementation.cpp
+++ b/device/blackhole/blackhole_implementation.cpp
@@ -34,6 +34,8 @@ tlb_configuration blackhole_implementation::get_tlb_configuration(uint32_t tlb_i
             .base = blackhole::DYNAMIC_TLB_4G_BASE,
             .cfg_addr = blackhole::DYNAMIC_TLB_4G_CFG_ADDR,
             .index_offset = tlb_index - blackhole::TLB_BASE_INDEX_4G,
+            .tlb_offset = blackhole::DYNAMIC_TLB_4G_BASE +
+                          (tlb_index - blackhole::TLB_BASE_INDEX_4G) * blackhole::DYNAMIC_TLB_4G_SIZE,
             .offset = blackhole::TLB_4G_OFFSET,
         };
     }
@@ -43,32 +45,10 @@ tlb_configuration blackhole_implementation::get_tlb_configuration(uint32_t tlb_i
         .base = blackhole::DYNAMIC_TLB_2M_BASE,
         .cfg_addr = blackhole::DYNAMIC_TLB_2M_CFG_ADDR,
         .index_offset = tlb_index - blackhole::TLB_BASE_INDEX_2M,
+        .tlb_offset = blackhole::DYNAMIC_TLB_2M_BASE +
+                      (tlb_index - blackhole::TLB_BASE_INDEX_2M) * blackhole::DYNAMIC_TLB_2M_SIZE,
         .offset = blackhole::TLB_2M_OFFSET,
     };
-}
-
-std::optional<std::tuple<std::uint64_t, std::uint64_t>> blackhole_implementation::describe_tlb(
-    std::int32_t tlb_index) const {
-    std::uint32_t TLB_COUNT_2M = 202;
-
-    std::uint32_t TLB_BASE_2M = 0;
-    if (tlb_index < 0) {
-        return std::nullopt;
-    }
-
-    if (tlb_index >= TLB_COUNT_2M && tlb_index < TLB_COUNT_2M + blackhole::TLB_COUNT_4G) {
-        auto tlb_offset = tlb_index - TLB_COUNT_2M;
-        auto size = blackhole::TLB_4G_SIZE;
-        return std::tuple(blackhole::TLB_BASE_4G + tlb_offset * size, size);
-    }
-
-    if (tlb_index >= 0 && tlb_index < TLB_COUNT_2M) {
-        auto tlb_offset = tlb_index;
-        auto size = 1 << 21;
-        return std::tuple(TLB_BASE_2M + tlb_offset * size, size);
-    }
-
-    return std::nullopt;
 }
 
 std::pair<std::uint64_t, std::uint64_t> blackhole_implementation::get_tlb_data(

--- a/device/grayskull/grayskull_implementation.cpp
+++ b/device/grayskull/grayskull_implementation.cpp
@@ -25,6 +25,8 @@ tlb_configuration grayskull_implementation::get_tlb_configuration(uint32_t tlb_i
             .base = grayskull::DYNAMIC_TLB_16M_BASE,
             .cfg_addr = grayskull::DYNAMIC_TLB_16M_CFG_ADDR,
             .index_offset = tlb_index - grayskull::TLB_BASE_INDEX_16M,
+            .tlb_offset = grayskull::DYNAMIC_TLB_16M_BASE +
+                          (tlb_index - grayskull::TLB_BASE_INDEX_16M) * grayskull::DYNAMIC_TLB_16M_SIZE,
             .offset = grayskull::TLB_16M_OFFSET,
         };
     } else if (tlb_index >= grayskull::TLB_BASE_INDEX_2M) {
@@ -33,6 +35,8 @@ tlb_configuration grayskull_implementation::get_tlb_configuration(uint32_t tlb_i
             .base = grayskull::DYNAMIC_TLB_2M_BASE,
             .cfg_addr = grayskull::DYNAMIC_TLB_2M_CFG_ADDR,
             .index_offset = tlb_index - grayskull::TLB_BASE_INDEX_2M,
+            .tlb_offset = grayskull::DYNAMIC_TLB_2M_BASE +
+                          (tlb_index - grayskull::TLB_BASE_INDEX_2M) * grayskull::DYNAMIC_TLB_2M_SIZE,
             .offset = grayskull::TLB_2M_OFFSET,
         };
     } else {
@@ -41,39 +45,11 @@ tlb_configuration grayskull_implementation::get_tlb_configuration(uint32_t tlb_i
             .base = grayskull::DYNAMIC_TLB_1M_BASE,
             .cfg_addr = grayskull::DYNAMIC_TLB_1M_CFG_ADDR,
             .index_offset = tlb_index - grayskull::TLB_BASE_INDEX_1M,
+            .tlb_offset = grayskull::DYNAMIC_TLB_1M_BASE +
+                          (tlb_index - grayskull::TLB_BASE_INDEX_1M) * grayskull::DYNAMIC_TLB_1M_SIZE,
             .offset = grayskull::TLB_1M_OFFSET,
         };
     }
-}
-
-std::optional<std::tuple<std::uint64_t, std::uint64_t>> grayskull_implementation::describe_tlb(
-    std::int32_t tlb_index) const {
-    std::uint32_t TLB_COUNT_1M = 156;
-    std::uint32_t TLB_COUNT_2M = 10;
-    std::uint32_t TLB_COUNT_16M = 20;
-
-    std::uint32_t TLB_BASE_1M = 0;
-    std::uint32_t TLB_BASE_2M = TLB_COUNT_1M * (1 << 20);
-    std::uint32_t TLB_BASE_16M = TLB_BASE_2M + TLB_COUNT_2M * (1 << 21);
-
-    if (tlb_index < 0) {
-        return std::nullopt;
-    }
-
-    if (tlb_index >= 0 && tlb_index < TLB_COUNT_1M) {
-        std::uint32_t size = 1 << 20;
-        return std::tuple(TLB_BASE_1M + size * tlb_index, size);
-    } else if (tlb_index >= 0 && tlb_index < TLB_COUNT_1M + TLB_COUNT_2M) {
-        auto tlb_offset = tlb_index - TLB_COUNT_1M;
-        auto size = 1 << 21;
-        return std::tuple(TLB_BASE_2M + tlb_offset * size, size);
-    } else if (tlb_index >= 0 and tlb_index < TLB_COUNT_1M + TLB_COUNT_2M + TLB_COUNT_16M) {
-        auto tlb_offset = tlb_index - (TLB_COUNT_1M + TLB_COUNT_2M);
-        auto size = 1 << 24;
-        return std::tuple(TLB_BASE_16M + tlb_offset * size, size);
-    }
-
-    return std::nullopt;
 }
 
 std::pair<std::uint64_t, std::uint64_t> grayskull_implementation::get_tlb_data(

--- a/device/wormhole/wormhole_implementation.cpp
+++ b/device/wormhole/wormhole_implementation.cpp
@@ -31,6 +31,8 @@ tlb_configuration wormhole_implementation::get_tlb_configuration(uint32_t tlb_in
             .base = wormhole::DYNAMIC_TLB_16M_BASE,
             .cfg_addr = wormhole::DYNAMIC_TLB_16M_CFG_ADDR,
             .index_offset = tlb_index - wormhole::TLB_BASE_INDEX_16M,
+            .tlb_offset = wormhole::DYNAMIC_TLB_16M_BASE +
+                          (tlb_index - wormhole::TLB_BASE_INDEX_16M) * wormhole::DYNAMIC_TLB_16M_SIZE,
             .offset = wormhole::TLB_16M_OFFSET,
         };
     } else if (tlb_index >= wormhole::TLB_BASE_INDEX_2M) {
@@ -39,6 +41,8 @@ tlb_configuration wormhole_implementation::get_tlb_configuration(uint32_t tlb_in
             .base = wormhole::DYNAMIC_TLB_2M_BASE,
             .cfg_addr = wormhole::DYNAMIC_TLB_2M_CFG_ADDR,
             .index_offset = tlb_index - wormhole::TLB_BASE_INDEX_2M,
+            .tlb_offset = wormhole::DYNAMIC_TLB_2M_BASE +
+                          (tlb_index - wormhole::TLB_BASE_INDEX_2M) * wormhole::DYNAMIC_TLB_2M_SIZE,
             .offset = wormhole::TLB_2M_OFFSET,
         };
     } else {
@@ -47,38 +51,11 @@ tlb_configuration wormhole_implementation::get_tlb_configuration(uint32_t tlb_in
             .base = wormhole::DYNAMIC_TLB_1M_BASE,
             .cfg_addr = wormhole::DYNAMIC_TLB_1M_CFG_ADDR,
             .index_offset = tlb_index - wormhole::TLB_BASE_INDEX_1M,
+            .tlb_offset = wormhole::DYNAMIC_TLB_1M_BASE +
+                          (tlb_index - wormhole::TLB_BASE_INDEX_1M) * wormhole::DYNAMIC_TLB_1M_SIZE,
             .offset = wormhole::TLB_1M_OFFSET,
         };
     }
-}
-
-std::optional<std::tuple<std::uint64_t, std::uint64_t>> wormhole_implementation::describe_tlb(
-    std::int32_t tlb_index) const {
-    std::uint32_t TLB_COUNT_1M = 156;
-    std::uint32_t TLB_COUNT_2M = 10;
-    std::uint32_t TLB_COUNT_16M = 20;
-
-    std::uint32_t TLB_BASE_1M = 0;
-    std::uint32_t TLB_BASE_2M = TLB_COUNT_1M * (1 << 20);
-    std::uint32_t TLB_BASE_16M = TLB_BASE_2M + TLB_COUNT_2M * (1 << 21);
-    if (tlb_index < 0) {
-        return std::nullopt;
-    }
-
-    if (tlb_index >= 0 && tlb_index < TLB_COUNT_1M) {
-        std::uint32_t size = 1 << 20;
-        return std::tuple(TLB_BASE_1M + size * tlb_index, size);
-    } else if (tlb_index >= 0 && tlb_index < TLB_COUNT_1M + TLB_COUNT_2M) {
-        auto tlb_offset = tlb_index - TLB_COUNT_1M;
-        auto size = 1 << 21;
-        return std::tuple(TLB_BASE_2M + tlb_offset * size, size);
-    } else if (tlb_index >= 0 and tlb_index < TLB_COUNT_1M + TLB_COUNT_2M + TLB_COUNT_16M) {
-        auto tlb_offset = tlb_index - (TLB_COUNT_1M + TLB_COUNT_2M);
-        auto size = 1 << 24;
-        return std::tuple(TLB_BASE_16M + tlb_offset * size, size);
-    }
-
-    return std::nullopt;
 }
 
 std::pair<std::uint64_t, std::uint64_t> wormhole_implementation::get_tlb_data(


### PR DESCRIPTION
### Issue
Related to #417 

### Description
Seems like we've had a redundant get_tlb_configuration and describe_tlb functions. I also noted that sometimes we downcasted 64bit address to 32bit, so this should solve those problems if they were even present.

### List of the changes
- Removed describe_tlb everywhere
- Changed describe_tlb calls with get_tlb_configuration
- API now returns tlb_configuration type.

### Testing
Existing CI tests

### API Changes
This PR has API changes:
- [ ] tt_metal approved PR pointing to this branch: link
- [ ] tt_lens doesn't use this API call.
