### PR TITLE
P100 board type

### DIFF
--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -25,14 +25,15 @@ class Node;
 }
 
 enum BoardType : uint32_t {
-    E75 = 0,
-    E150 = 1,
-    E300 = 2,
-    N150 = 3,
-    N300 = 4,
-    P150A = 5,
-    GALAXY = 6,
-    UNKNOWN = 7,
+    E75,
+    E150,
+    E300,
+    N150,
+    N300,
+    P100,
+    P150A,
+    GALAXY,
+    UNKNOWN,
 };
 
 class tt_ClusterDescriptor {

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -747,6 +747,8 @@ void tt_ClusterDescriptor::load_chips_from_connectivity_descriptor(YAML::Node &y
                 board_type = BoardType::N150;
             } else if (chip_board_type.second == "n300") {
                 board_type = BoardType::N300;
+            } else if (chip_board_type.second == "p100") {
+                board_type = BoardType::P100;
             } else if (chip_board_type.second == "p150A") {
                 board_type = BoardType::P150A;
             } else if (chip_board_type.second == "GALAXY") {

--- a/tests/api/cluster_descriptor_examples/blackhole_P100.yaml
+++ b/tests/api/cluster_descriptor_examples/blackhole_P100.yaml
@@ -19,5 +19,5 @@ harvesting: {
 
 # This value will be null if the boardtype is unknown, should never happen in practice but to be defensive it would be useful to throw an error on this case.
 boardtype: {
-   0: null,
+   0: p100,
 }

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -73,7 +73,7 @@ TEST(ApiClusterDescriptorTest, BasicFunctionality) {
 
 TEST(ApiClusterDescriptorTest, TestAllOfflineClusterDescriptors) {
     for (std::string cluster_desc_yaml : {
-             "blackhole_P150.yaml",
+             "blackhole_P100.yaml",
              "galaxy.yaml",
              "grayskull_e75.yaml",
              "grayskull_E150.yaml",


### PR DESCRIPTION
### Issue

/

### Description
Add P100 board type

### List of the changes
Add P100 board type. Cluster descriptors on P100 have board type set now 

### Testing
CI

### API Changes
/
