### PR TITLE
Get DRAM cores grouped by bank

### DIFF
--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -99,6 +99,9 @@ public:
     tt_xy_pair get_grid_size(const CoreType core_type) const;
     tt_xy_pair get_harvested_grid_size(const CoreType core_type) const;
 
+    std::vector<std::vector<tt::umd::CoreCoord>> get_dram_cores() const;
+    std::vector<std::vector<tt::umd::CoreCoord>> get_harvested_dram_cores() const;
+
     int get_num_dram_channels() const;
 
     bool is_worker_core(const tt_xy_pair &core) const;
@@ -155,6 +158,11 @@ private:
     std::map<CoreType, tt_xy_pair> grid_size_map;
     std::map<CoreType, std::vector<tt::umd::CoreCoord>> harvested_cores_map;
     std::map<CoreType, tt_xy_pair> harvested_grid_size_map;
+
+    // DRAM cores are kept in additional vector struct since one DRAM bank
+    // has multiple NOC endpoints, so some UMD clients prefer vector of vectors returned.
+    std::vector<std::vector<tt::umd::CoreCoord>> dram_cores_core_coord;
+    std::vector<std::vector<tt::umd::CoreCoord>> harvested_dram_cores_core_coord;
 };
 
 // Allocates a new soc descriptor on the heap. Returns an owning pointer.

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -314,6 +314,27 @@ void tt_SocDescriptor::get_cores_and_grid_size_from_coordinate_manager() {
 
     harvested_cores_map.insert({CoreType::DRAM, coordinate_manager->get_harvested_cores(CoreType::DRAM)});
     harvested_grid_size_map.insert({CoreType::DRAM, coordinate_manager->get_harvested_grid_size(CoreType::DRAM)});
+
+    const std::vector<CoreCoord> dram_cores = cores_map.at(CoreType::DRAM);
+    const tt_xy_pair dram_grid_size = grid_size_map.at(CoreType::DRAM);
+
+    dram_cores_core_coord.resize(dram_grid_size.x);
+    for (size_t bank = 0; bank < dram_grid_size.x; bank++) {
+        for (size_t noc_port = 0; noc_port < dram_grid_size.y; noc_port++) {
+            dram_cores_core_coord[bank].push_back(dram_cores[bank * dram_grid_size.y + noc_port]);
+        }
+    }
+
+    const std::vector<CoreCoord> harvested_dram_cores = harvested_cores_map.at(CoreType::DRAM);
+    const tt_xy_pair harvested_dram_grid_size = harvested_grid_size_map.at(CoreType::DRAM);
+
+    harvested_dram_cores_core_coord.resize(harvested_dram_grid_size.x);
+    for (size_t bank = 0; bank < harvested_dram_grid_size.x; bank++) {
+        for (size_t noc_port = 0; noc_port < harvested_dram_grid_size.y; noc_port++) {
+            harvested_dram_cores_core_coord[bank].push_back(
+                harvested_dram_cores[bank * harvested_dram_grid_size.y + noc_port]);
+        }
+    }
 }
 
 std::vector<tt::umd::CoreCoord> tt_SocDescriptor::get_cores(const CoreType core_type) const {
@@ -342,4 +363,10 @@ tt_xy_pair tt_SocDescriptor::get_harvested_grid_size(const CoreType core_type) c
         return {0, 0};
     }
     return harvested_grid_size_map.at(core_type);
+}
+
+std::vector<std::vector<CoreCoord>> tt_SocDescriptor::get_dram_cores() const { return dram_cores_core_coord; }
+
+std::vector<std::vector<CoreCoord>> tt_SocDescriptor::get_harvested_dram_cores() const {
+    return harvested_dram_cores_core_coord;
 }

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -224,6 +224,12 @@ TEST(ClusterAPI, DynamicTLB_RW) {
     // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for
     // each transaction
 
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+    // TODO: Make this test work on a host system without any tt devices.
+    if (pci_device_ids.empty()) {
+        GTEST_SKIP() << "No chips present on the system. Skipping test.";
+    }
+
     std::unique_ptr<Cluster> cluster = get_cluster();
 
     tt_device_params default_params;

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -56,6 +56,18 @@ TEST(SocDescriptor, SocDescriptorGrayskullOneRowHarvesting) {
     ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::DRAM).empty());
 }
 
+// Test soc descriptor API for getting DRAM cores.
+TEST(SocDescriptor, SocDescriptorGrayskullDRAM) {
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"));
+
+    const std::vector<std::vector<CoreCoord>> dram_cores = soc_desc.get_dram_cores();
+
+    ASSERT_EQ(dram_cores.size(), tt::umd::grayskull::NUM_DRAM_BANKS);
+    for (auto& vec : dram_cores) {
+        ASSERT_EQ(vec.size(), tt::umd::grayskull::NUM_NOC_PORTS_PER_DRAM_BANK);
+    }
+}
+
 // Test soc descriptor API for Wormhole when there is no harvesting.
 TEST(SocDescriptor, SocDescriptorWormholeNoHarvesting) {
     tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"));
@@ -71,6 +83,18 @@ TEST(SocDescriptor, SocDescriptorWormholeNoHarvesting) {
 
     ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::TENSIX).empty());
     ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::DRAM).empty());
+}
+
+// Test soc descriptor API for getting DRAM cores.
+TEST(SocDescriptor, SocDescriptorWormholeDRAM) {
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"));
+
+    const std::vector<std::vector<CoreCoord>> dram_cores = soc_desc.get_dram_cores();
+
+    ASSERT_EQ(dram_cores.size(), tt::umd::wormhole::NUM_DRAM_BANKS);
+    for (auto& vec : dram_cores) {
+        ASSERT_EQ(vec.size(), tt::umd::wormhole::NUM_NOC_PORTS_PER_DRAM_BANK);
+    }
 }
 
 // Test soc descriptor API for Wormhole when there is tensix harvesting.
@@ -173,6 +197,18 @@ TEST(SocDescriptor, SocDescriptorBlackholeOneRowHarvesting) {
     ASSERT_FALSE(harvested_cores.empty());
 
     ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::DRAM).empty());
+}
+
+// Test soc descriptor API for getting DRAM cores.
+TEST(SocDescriptor, SocDescriptorBlackholeDRAM) {
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"));
+
+    const std::vector<std::vector<CoreCoord>> dram_cores = soc_desc.get_dram_cores();
+
+    ASSERT_EQ(dram_cores.size(), tt::umd::blackhole::NUM_DRAM_BANKS);
+    for (auto& vec : dram_cores) {
+        ASSERT_EQ(vec.size(), tt::umd::blackhole::NUM_NOC_PORTS_PER_DRAM_BANK);
+    }
 }
 
 // Test soc descriptor API for Blackhole when there is DRAM harvesting.


### PR DESCRIPTION
### Issue

/

### Description

Get DRAM cores grouped by bank

### List of the changes

- Get DRAM cores grouped by bank
- Nit change: make one of the cluster tests skip on the machine without cards

### Testing
CI

### API Changes

Api added, no need to uplift