### PR TITLE
Disable two BH tests

### DIFF
--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -865,6 +865,9 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as
     cluster.close_device();
 }
 
+// This is broken on P150 because it's getting the wrong PCIe coordinate.
+// Disabling these tests until this is addressed.
+#if 0
 /**
  * Copied from the Wormhole test.
  */
@@ -992,3 +995,4 @@ TEST(SiliconDriverBH, RandomSysmemTestWithPcie) {
         }
     }
 }
+#endif


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/433

### Description
P100 and P150 use different PCIe blocks to connect to the host.  The tests rely on SOC descriptor which specifies the wrong coordinate for P150.  This causes system instability.

### List of the changes
* Disable the two tests until the issue can be fixed properly

### Testing
N/A

### API Changes
There are no API changes in this PR.
