### PR TITLE
[Harvesting] simulated_harvesting_masks passed to tt_SocDescriptor

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -855,8 +855,17 @@ private:
     void wait_for_connected_non_mmio_flush(chip_id_t chip_id);
     std::unique_ptr<Chip> construct_chip_from_cluster(
         chip_id_t chip_id, tt_ClusterDescriptor* cluster_desc, tt_SocDescriptor& soc_desc);
-    std::unique_ptr<Chip> construct_chip_from_cluster(chip_id_t logical_device_id, tt_ClusterDescriptor* cluster_desc);
+    std::unique_ptr<Chip> construct_chip_from_cluster(
+        chip_id_t logical_device_id,
+        tt_ClusterDescriptor* cluster_desc,
+        bool perform_harvesting,
+        uint32_t simulated_tensix_harvesting);
     void add_chip(chip_id_t chip_id, std::unique_ptr<Chip> chip);
+    uint32_t get_tensix_harvesting_mask(
+        chip_id_t chip_id,
+        tt_ClusterDescriptor* cluster_desc,
+        bool perform_harvesting,
+        uint32_t simulated_tensix_harvesting);
     void construct_cluster(
         const uint32_t& num_host_mem_ch_per_mmio_device,
         const bool skip_driver_allocs,

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -859,13 +859,13 @@ private:
         chip_id_t logical_device_id,
         tt_ClusterDescriptor* cluster_desc,
         bool perform_harvesting,
-        uint32_t simulated_tensix_harvesting);
+        std::unordered_map<chip_id_t, uint32_t>& simulated_harvesting_masks);
     void add_chip(chip_id_t chip_id, std::unique_ptr<Chip> chip);
     uint32_t get_tensix_harvesting_mask(
         chip_id_t chip_id,
         tt_ClusterDescriptor* cluster_desc,
         bool perform_harvesting,
-        uint32_t simulated_tensix_harvesting);
+        std::unordered_map<chip_id_t, uint32_t>& simulated_harvesting_masks);
     void construct_cluster(
         const uint32_t& num_host_mem_ch_per_mmio_device,
         const bool skip_driver_allocs,

--- a/device/api/umd/device/coordinate_manager.h
+++ b/device/api/umd/device/coordinate_manager.h
@@ -42,6 +42,13 @@ public:
 
     static std::vector<size_t> get_harvested_indices(const size_t harvesting_mask);
 
+    // Harvesting mask is reported by hardware in the order of physical layout. This function returns a more suitable
+    // representation in logical order: Bit 0 being set means the first row in NOC0 coords is harvested.
+    static uint32_t shuffle_tensix_harvesting_mask(tt::ARCH arch, uint32_t tensix_harvesting_physical_layout);
+    // TODO: This function should be removed once the corresponding API is removed from Cluster.
+    static uint32_t shuffle_tensix_harvesting_mask_to_noc0_coords(
+        tt::ARCH arch, uint32_t tensix_harvesting_logical_layout);
+
     CoordinateManager(CoordinateManager& other) = default;
 
     tt::umd::CoreCoord translate_coord_to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system);
@@ -90,8 +97,6 @@ protected:
     void initialize();
 
     virtual void assert_coordinate_manager_constructor();
-
-    virtual void shuffle_tensix_harvesting_mask(const std::vector<uint32_t>& harvesting_locations);
 
     virtual void translate_tensix_coords();
     virtual void translate_dram_coords();

--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -140,6 +140,7 @@ public:
     int eth_l1_size;
     bool noc_translation_id_enabled;
     uint64_t dram_bank_size;
+    uint32_t tensix_harvesting_mask;
 
 private:
     void create_coordinate_manager(

--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -55,40 +55,6 @@ public:
         const size_t dram_harvesting_mask = 0,
         const size_t eth_harvesting_mask = 0);
 
-    // Copy constructor
-    tt_SocDescriptor(const tt_SocDescriptor &other) :
-        arch(other.arch),
-        grid_size(other.grid_size),
-        worker_grid_size(other.worker_grid_size),
-        cores(other.cores),
-        arc_cores(other.arc_cores),
-        workers(other.workers),
-        harvested_workers(other.harvested_workers),
-        pcie_cores(other.pcie_cores),
-        worker_log_to_routing_x(other.worker_log_to_routing_x),
-        worker_log_to_routing_y(other.worker_log_to_routing_y),
-        routing_x_to_worker_x(other.routing_x_to_worker_x),
-        routing_y_to_worker_y(other.routing_y_to_worker_y),
-        dram_cores(other.dram_cores),
-        dram_core_channel_map(other.dram_core_channel_map),
-        ethernet_cores(other.ethernet_cores),
-        ethernet_core_channel_map(other.ethernet_core_channel_map),
-        trisc_sizes(other.trisc_sizes),
-        device_descriptor_file_path(other.device_descriptor_file_path),
-        overlay_version(other.overlay_version),
-        unpacker_version(other.unpacker_version),
-        dst_size_alignment(other.dst_size_alignment),
-        packer_version(other.packer_version),
-        worker_l1_size(other.worker_l1_size),
-        eth_l1_size(other.eth_l1_size),
-        noc_translation_id_enabled(other.noc_translation_id_enabled),
-        dram_bank_size(other.dram_bank_size),
-        coordinate_manager(other.coordinate_manager),
-        cores_map(other.cores_map),
-        grid_size_map(other.grid_size_map),
-        harvested_cores_map(other.harvested_cores_map),
-        harvested_grid_size_map(other.harvested_grid_size_map) {}
-
     // CoreCoord conversions.
     tt::umd::CoreCoord translate_coord_to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const;
 

--- a/device/blackhole/blackhole_coordinate_manager.cpp
+++ b/device/blackhole/blackhole_coordinate_manager.cpp
@@ -37,7 +37,6 @@ BlackholeCoordinateManager::BlackholeCoordinateManager(
         arc_cores,
         pcie_grid_size,
         pcie_cores) {
-    this->shuffle_tensix_harvesting_mask(blackhole::HARVESTING_NOC_LOCATIONS);
     initialize();
 }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -524,8 +524,6 @@ Cluster::Cluster(
         add_chip(
             chip_id,
             construct_chip_from_cluster(chip_id, cluster_desc.get(), perform_harvesting, simulated_harvesting_masks));
-        // log_info(LogSiliconDriver, "Added chip {} to cluster with harvesting {}.",
-        // chips_.at(chip_id)->get_soc_descriptor().tensix_harvesting_mask);
     }
 
     // TODO: work on removing this member altogether. Currently assumes all have the same arch.

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -501,6 +501,14 @@ uint32_t Cluster::get_tensix_harvesting_mask(
             chip_id,
             tensix_harvesting_mask);
     }
+    log_debug(
+        LogSiliconDriver,
+        "Harvesting mask for chip {} is {} (physical layout: {}, logical: {}, simulated harvesting mask: {}).",
+        chip_id,
+        tensix_harvesting_mask | simulated_harvesting_mask,
+        tensix_harvesting_mask_physical_layout,
+        tensix_harvesting_mask,
+        simulated_harvesting_mask);
     return tensix_harvesting_mask | simulated_harvesting_mask;
 }
 
@@ -516,6 +524,8 @@ Cluster::Cluster(
         add_chip(
             chip_id,
             construct_chip_from_cluster(chip_id, cluster_desc.get(), perform_harvesting, simulated_harvesting_masks));
+        // log_info(LogSiliconDriver, "Added chip {} to cluster with harvesting {}.",
+        // chips_.at(chip_id)->get_soc_descriptor().tensix_harvesting_mask);
     }
 
     // TODO: work on removing this member altogether. Currently assumes all have the same arch.

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -456,11 +456,11 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     chip_id_t chip_id,
     tt_ClusterDescriptor* cluster_desc,
     bool perform_harvesting,
-    uint32_t simulated_tensix_harvesting) {
+    std::unordered_map<chip_id_t, uint32_t>& simulated_harvesting_masks) {
     tt::ARCH arch = cluster_desc->get_arch(chip_id);
     std::string soc_desc_path = tt_SocDescriptor::get_soc_descriptor_path(arch);
     uint32_t tensix_harvesting_mask =
-        get_tensix_harvesting_mask(chip_id, cluster_desc, perform_harvesting, simulated_tensix_harvesting);
+        get_tensix_harvesting_mask(chip_id, cluster_desc, perform_harvesting, simulated_harvesting_masks);
     tt_SocDescriptor soc_desc = tt_SocDescriptor(soc_desc_path, tensix_harvesting_mask);
     return construct_chip_from_cluster(chip_id, cluster_desc, soc_desc);
 }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -267,14 +267,13 @@ void Cluster::create_device(
 bool Cluster::using_harvested_soc_descriptors() { return perform_harvesting_on_sdesc && performed_harvesting; }
 
 std::unordered_map<chip_id_t, uint32_t> Cluster::get_harvesting_masks_for_soc_descriptors() {
-    if (using_harvested_soc_descriptors()) {
-        return harvested_rows_per_target;
+    std::unordered_map<chip_id_t, uint32_t> harvesting_masks = {};
+    for (const auto& [chip_id, chip] : chips_) {
+        uint32_t noc0_harvesting_mask = CoordinateManager::shuffle_tensix_harvesting_mask_to_noc0_coords(
+            chip->get_soc_descriptor().arch, chip->get_soc_descriptor().tensix_harvesting_mask);
+        harvesting_masks.insert({chip_id, noc0_harvesting_mask});
     }
-    std::unordered_map<chip_id_t, uint32_t> default_harvesting_masks = {};
-    for (const auto chip : all_chip_ids_) {
-        default_harvesting_masks.insert({chip, 0});
-    }
-    return default_harvesting_masks;
+    return harvesting_masks;
 }
 
 void Cluster::construct_cluster(
@@ -488,7 +487,9 @@ uint32_t Cluster::get_tensix_harvesting_mask(
         log_info(LogSiliconDriver, "Skipping harvesting for chip {}.", chip_id);
         return 0;
     }
-    uint32_t tensix_harvesting_mask = cluster_desc->get_harvesting_info().at(chip_id);
+    uint32_t tensix_harvesting_mask_physical_layout = cluster_desc->get_harvesting_info().at(chip_id);
+    uint32_t tensix_harvesting_mask = CoordinateManager::shuffle_tensix_harvesting_mask(
+        cluster_desc->get_arch(chip_id), tensix_harvesting_mask_physical_layout);
     uint32_t simulated_harvesting_mask = (simulated_harvesting_masks.find(chip_id) != simulated_harvesting_masks.end())
                                              ? simulated_harvesting_masks.at(chip_id)
                                              : 0;

--- a/device/grayskull/grayskull_coordinate_manager.cpp
+++ b/device/grayskull/grayskull_coordinate_manager.cpp
@@ -35,7 +35,6 @@ GrayskullCoordinateManager::GrayskullCoordinateManager(
         arc_cores,
         pcie_grid_size,
         pcie_cores) {
-    this->shuffle_tensix_harvesting_mask(grayskull::HARVESTING_NOC_LOCATIONS);
     initialize();
 }
 

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -222,7 +222,8 @@ tt_SocDescriptor::tt_SocDescriptor(
     std::string device_descriptor_path,
     const size_t tensix_harvesting_mask,
     const size_t dram_harvesting_mask,
-    const size_t eth_harvesting_mask) {
+    const size_t eth_harvesting_mask) :
+    tensix_harvesting_mask(tensix_harvesting_mask) {
     std::ifstream fdesc(device_descriptor_path);
     if (fdesc.fail()) {
         throw std::runtime_error(

--- a/device/wormhole/wormhole_coordinate_manager.cpp
+++ b/device/wormhole/wormhole_coordinate_manager.cpp
@@ -35,7 +35,6 @@ WormholeCoordinateManager::WormholeCoordinateManager(
         arc_cores,
         pcie_grid_size,
         pcie_cores) {
-    this->shuffle_tensix_harvesting_mask(wormhole::HARVESTING_NOC_LOCATIONS);
     initialize();
 }
 

--- a/tests/api/test_core_coord_translation_bh.cpp
+++ b/tests/api/test_core_coord_translation_bh.cpp
@@ -35,7 +35,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeNoHarvesting) {
 // the logical coordinates if the first row is harvested.
 TEST(CoordinateManager, CoordinateManagerBlackholeTopLeftCore) {
     // This is targeting first row of Tensix cores on NOC layout.
-    const size_t harvesting_mask = (1 << tt::umd::blackhole::LOGICAL_HARVESTING_LAYOUT[0]);
+    const size_t harvesting_mask = (1 << 0);
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, harvesting_mask);
     tt_xy_pair tensix_grid_size = tt::umd::blackhole::TENSIX_GRID_SIZE;
@@ -208,8 +208,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeVirtualEqualTranslated) {
 
 // Test mapping of the coordinates for harvested DRAM bank.
 TEST(CoordinateManager, CoordinateManagerBlackholeTransltedMappingHarvested) {
-    const size_t harvesting_mask = (1 << tt::umd::blackhole::LOGICAL_HARVESTING_LAYOUT[0]) |
-                                   (1 << tt::umd::blackhole::LOGICAL_HARVESTING_LAYOUT[1]);
+    const size_t harvesting_mask = (1 << 0) | (1 << 1);
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, harvesting_mask);
 
@@ -619,5 +618,16 @@ TEST(CoordinateManager, CoordinateManagerBlackholePhysicalLayoutTensixHarvesting
             CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, harvesting_mask);
 
         EXPECT_EQ(coordinate_manager->get_tensix_harvesting_mask(), harvesting_mask);
+    }
+}
+
+// Test whether we properly shuffle the harvesting mask based on the physical layout of the chip.
+TEST(CoordinateManager, CoordinateManagerBlackholeHarvestingShuffle) {
+    for (size_t i = 0; i < tt::umd::blackhole::LOGICAL_HARVESTING_LAYOUT.size(); i++) {
+        const size_t harvesting_mask_physical_layout = (1 << tt::umd::blackhole::LOGICAL_HARVESTING_LAYOUT[i]);
+        const size_t harvesting_mask =
+            CoordinateManager::shuffle_tensix_harvesting_mask(tt::ARCH::BLACKHOLE, harvesting_mask_physical_layout);
+
+        EXPECT_EQ(harvesting_mask, 1 << i);
     }
 }

--- a/tests/api/test_core_coord_translation_gs.cpp
+++ b/tests/api/test_core_coord_translation_gs.cpp
@@ -53,7 +53,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullTopLeftCore) {
 // the logical coordinates if the first row is harvested.
 TEST(CoordinateManager, CoordinateManagerGrayskullTopLeftCoreHarvesting) {
     // This is targeting first row of Tensix cores on NOC layout.
-    const size_t harvesting_mask = (1 << tt::umd::grayskull::LOGICAL_HARVESTING_LAYOUT[0]);
+    const size_t harvesting_mask = (1 << 0);
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, harvesting_mask);
 
@@ -181,8 +181,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullLogicalVirtualMapping) {
 // Test that harvested physical coordinates map to the last row of the virtual coordinates.
 TEST(CoordinateManager, CoordinateManagerGrayskullPhysicalHarvestedMapping) {
     // Harvest first and second NOC layout row.
-    const size_t harvesting_mask = (1 << tt::umd::grayskull::LOGICAL_HARVESTING_LAYOUT[0]) |
-                                   (1 << tt::umd::grayskull::LOGICAL_HARVESTING_LAYOUT[1]);
+    const size_t harvesting_mask = (1 << 0) | (1 << 1);
     const size_t num_harvested = CoordinateManager::get_num_harvested(harvesting_mask);
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, harvesting_mask);
@@ -207,8 +206,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullPhysicalHarvestedMapping) {
 // Test that harvested physical coordinates map to the last row of the virtual coordinates.
 TEST(CoordinateManager, CoordinateManagerGrayskullPhysicalTranslatedHarvestedMapping) {
     // Harvest first and second NOC layout row.
-    const size_t harvesting_mask = (1 << tt::umd::grayskull::LOGICAL_HARVESTING_LAYOUT[0]) |
-                                   (1 << tt::umd::grayskull::LOGICAL_HARVESTING_LAYOUT[1]);
+    const size_t harvesting_mask = (1 << 0) | (1 << 1);
     const size_t num_harvested = CoordinateManager::get_num_harvested(harvesting_mask);
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, harvesting_mask);
@@ -323,5 +321,16 @@ TEST(CoordinateManager, CoordinateManagerGrayskullPhysicalLayoutTensixHarvesting
             CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, harvesting_mask);
 
         EXPECT_EQ(coordinate_manager->get_tensix_harvesting_mask(), harvesting_mask);
+    }
+}
+
+// Test whether we properly shuffle the harvesting mask based on the physical layout of the chip.
+TEST(CoordinateManager, CoordinateManagerGrayskullHarvestingShuffle) {
+    for (size_t i = 0; i < tt::umd::grayskull::LOGICAL_HARVESTING_LAYOUT.size(); i++) {
+        const size_t harvesting_mask_physical_layout = (1 << tt::umd::grayskull::LOGICAL_HARVESTING_LAYOUT[i]);
+        const size_t harvesting_mask =
+            CoordinateManager::shuffle_tensix_harvesting_mask(tt::ARCH::GRAYSKULL, harvesting_mask_physical_layout);
+
+        EXPECT_EQ(harvesting_mask, 1 << i);
     }
 }

--- a/tests/api/test_core_coord_translation_wh.cpp
+++ b/tests/api/test_core_coord_translation_wh.cpp
@@ -38,7 +38,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeNoHarvesting) {
 // the logical coordinates if the first row is harvested.
 TEST(CoordinateManager, CoordinateManagerWormholeTopLeftCore) {
     // This harvesting mask if targeting first row in NOC layout.
-    const size_t harvesting_mask = (1 << tt::umd::wormhole::LOGICAL_HARVESTING_LAYOUT[0]);
+    const size_t harvesting_mask = (1 << 0);
 
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, harvesting_mask);
@@ -179,8 +179,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeLogicalTranslatedTopLeft) {
 // Test that harvested physical coordinates map to the last row of the virtual coordinates.
 TEST(CoordinateManager, CoordinateManagerWormholePhysicalVirtualHarvestedMapping) {
     // Harvest first and second NOC layout row.
-    const size_t harvesting_mask =
-        (1 << tt::umd::wormhole::LOGICAL_HARVESTING_LAYOUT[0]) | (1 << tt::umd::wormhole::LOGICAL_HARVESTING_LAYOUT[1]);
+    const size_t harvesting_mask = (1 << 0) | (1 << 1);
     const size_t num_harvested = CoordinateManager::get_num_harvested(harvesting_mask);
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, harvesting_mask);
@@ -205,8 +204,7 @@ TEST(CoordinateManager, CoordinateManagerWormholePhysicalVirtualHarvestedMapping
 // Test that harvested physical coordinates map to the last row of the virtual coordinates.
 TEST(CoordinateManager, CoordinateManagerWormholePhysicalTranslatedHarvestedMapping) {
     // Harvest first and second NOC layout row.
-    const size_t harvesting_mask =
-        (1 << tt::umd::wormhole::LOGICAL_HARVESTING_LAYOUT[0]) | (1 << tt::umd::wormhole::LOGICAL_HARVESTING_LAYOUT[1]);
+    const size_t harvesting_mask = (1 << 0) | (1 << 1);
     const size_t num_harvested = CoordinateManager::get_num_harvested(harvesting_mask);
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, harvesting_mask);
@@ -378,5 +376,16 @@ TEST(CoordinateManager, CoordinateManagerWormholePhysicalLayoutTensixHarvestingM
             CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, harvesting_mask);
 
         EXPECT_EQ(coordinate_manager->get_tensix_harvesting_mask(), harvesting_mask);
+    }
+}
+
+// Test whether we properly shuffle the harvesting mask based on the physical layout of the chip.
+TEST(CoordinateManager, CoordinateManagerWormholeHarvestingShuffle) {
+    for (size_t i = 0; i < tt::umd::wormhole::LOGICAL_HARVESTING_LAYOUT.size(); i++) {
+        const size_t harvesting_mask_physical_layout = (1 << tt::umd::wormhole::LOGICAL_HARVESTING_LAYOUT[i]);
+        const size_t harvesting_mask =
+            CoordinateManager::shuffle_tensix_harvesting_mask(tt::ARCH::WORMHOLE_B0, harvesting_mask_physical_layout);
+
+        EXPECT_EQ(harvesting_mask, 1 << i);
     }
 }

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -33,7 +33,7 @@ TEST(SocDescriptor, SocDescriptorGrayskullNoHarvesting) {
 TEST(SocDescriptor, SocDescriptorGrayskullOneRowHarvesting) {
     const tt_xy_pair grayskull_tensix_grid_size = tt::umd::grayskull::TENSIX_GRID_SIZE;
     const std::vector<tt_xy_pair> grayskull_tensix_cores = tt::umd::grayskull::TENSIX_CORES;
-    const size_t harvesting_mask = (1 << tt::umd::grayskull::LOGICAL_HARVESTING_LAYOUT[0]);
+    const size_t harvesting_mask = (1 << 0);
 
     tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), harvesting_mask);
 
@@ -101,7 +101,7 @@ TEST(SocDescriptor, SocDescriptorWormholeDRAM) {
 TEST(SocDescriptor, SocDescriptorWormholeOneRowHarvesting) {
     const tt_xy_pair wormhole_tensix_grid_size = tt::umd::wormhole::TENSIX_GRID_SIZE;
     const std::vector<tt_xy_pair> wormhole_tensix_cores = tt::umd::wormhole::TENSIX_CORES;
-    const size_t harvesting_mask = (1 << tt::umd::wormhole::LOGICAL_HARVESTING_LAYOUT[0]);
+    const size_t harvesting_mask = (1 << 0);
 
     tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), harvesting_mask);
 

--- a/tests/grayskull/test_cluster_gs.cpp
+++ b/tests/grayskull/test_cluster_gs.cpp
@@ -64,10 +64,18 @@ TEST(SiliconDriverGS, Harvesting) {
             << "Expected SOC descriptor with harvesting to have less than or equal to 96 workers for chip "
             << chip.first;
     }
-    ASSERT_EQ(cluster.get_harvesting_masks_for_soc_descriptors().at(0) & simulated_harvesting_masks[0], 6)
+    // harvesting info stored in soc descriptor is in logical coordinates.
+    ASSERT_EQ(
+        cluster.get_soc_descriptor(0).tensix_harvesting_mask & simulated_harvesting_masks[0],
+        simulated_harvesting_masks[0])
         << "Expected first chip to include simulated harvesting mask of 6";
-    // ASSERT_EQ(cluster.get_harvesting_masks_for_soc_descriptors().at(1), 12) << "Expected second chip to have
-    // harvesting mask of 12";
+    // get_harvesting_masks_for_soc_descriptors will return harvesting info in noc0 coordinates.
+    simulated_harvesting_masks[0] = CoordinateManager::shuffle_tensix_harvesting_mask_to_noc0_coords(
+        tt::ARCH::GRAYSKULL, simulated_harvesting_masks[0]);
+    ASSERT_EQ(
+        cluster.get_harvesting_masks_for_soc_descriptors().at(0) & simulated_harvesting_masks[0],
+        simulated_harvesting_masks[0])
+        << "Expected first chip to include simulated harvesting mask of 6";
     cluster.close_device();
 }
 


### PR DESCRIPTION
### Issue
Related to #439 

### Description
First of the changes preparing removal of harvesting logic inside Cluster.
perform_harvesting, and simulated_harvesting_masks arguments are now added to affect tt_SocDescriptor.
Had to remove logic converting harvesting_mask from physical layout coords to logical coords out of the CoordinateManager constructor.

### List of the changes
- perform_harvesting now affects harvesting in tt_SocDescriptor
- simulated_harvesting_masks are now used for harvesting in tt_SocDescriptor
- get_tensix_harvesting_mask is a helper function which does both of these
- shuffle_tensix_harvesting_mask is now a static public function, which should be called prior to calling CoordinateManager
- CoordinateManager now accepts harvesting in logical coords.
- Due to deprecated get_harvesting_masks_for_soc_descriptors, there is an additional shuffle_tensix_harvesting_mask_to_noc0_coords which does the required translation.
- tt_SocDescriptor removed copy constructor, since it is already a default one.
- Other functions changed accordingly to pass this arguments

### Testing
- Changed call to get_harvesting_masks_for_soc_descriptors, so it is tested with the new flow, through harvesting provided by socdescriptor class
- Added HarvestingShuffle tests in all arch tests

### API Changes
There are no API changes in this PR.
