### PR TITLE
Remove harvesting from Cluster v2

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -306,14 +306,6 @@ public:
     }
 
     /**
-     * Determine if UMD performed harvesting on SOC descriptors.
-     */
-    virtual bool using_harvested_soc_descriptors() {
-        throw std::runtime_error("---- tt_device:using_harvested_soc_descriptors is not implemented\n");
-        return 0;
-    }
-
-    /**
      * Get harvesting masks for all chips/SOC Descriptors in the cluster.
      * Each mask represents a map of enabled (0) and disabled (1) rows on a specific chip (in NOC0 Coordinateds).
      */
@@ -673,7 +665,6 @@ public:
      * @param target The target chip and core to write to.
      */
     tt::Writer get_static_tlb_writer(tt_cxy_pair target);
-    virtual bool using_harvested_soc_descriptors();
     virtual void translate_to_noc_table_coords(chip_id_t device_id, std::size_t& r, std::size_t& c);
     static std::vector<int> extract_rows_to_remove(
         const tt::ARCH& arch, const int worker_grid_rows, const int harvested_rows);

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -45,7 +45,6 @@ public:
         const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
 
     // Misc. Functions to Query/Set Device State
-    // virtual bool using_harvested_soc_descriptors();
     virtual std::unordered_map<chip_id_t, uint32_t> get_harvesting_masks_for_soc_descriptors();
     static std::vector<chip_id_t> detect_available_device_ids();
     virtual std::set<chip_id_t> get_target_remote_device_ids();

--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -141,6 +141,9 @@ public:
     bool noc_translation_id_enabled;
     uint64_t dram_bank_size;
 
+    // TODO: Consider removing this once it is not being used anymore by metal_socdescriptor.
+    size_t tensix_harvesting_mask;
+
 private:
     void create_coordinate_manager(
         const size_t tensix_harvesting_mask, const size_t dram_harvesting_mask, const size_t eth_harvesting_mask);

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -264,17 +264,12 @@ void Cluster::create_device(
     }
 }
 
-bool Cluster::using_harvested_soc_descriptors() { return perform_harvesting_on_sdesc && performed_harvesting; }
-
 std::unordered_map<chip_id_t, uint32_t> Cluster::get_harvesting_masks_for_soc_descriptors() {
-    if (using_harvested_soc_descriptors()) {
-        return harvested_rows_per_target;
+    std::unordered_map<chip_id_t, uint32_t> harvesting_masks = {};
+    for (const auto& [chip_id, chip] : chips_) {
+        harvesting_masks.insert({chip_id, chip->get_soc_descriptor().tensix_harvesting_mask});
     }
-    std::unordered_map<chip_id_t, uint32_t> default_harvesting_masks = {};
-    for (const auto chip : all_chip_ids_) {
-        default_harvesting_masks.insert({chip, 0});
-    }
-    return default_harvesting_masks;
+    return harvesting_masks;
 }
 
 void Cluster::construct_cluster(

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -222,7 +222,8 @@ tt_SocDescriptor::tt_SocDescriptor(
     std::string device_descriptor_path,
     const size_t tensix_harvesting_mask,
     const size_t dram_harvesting_mask,
-    const size_t eth_harvesting_mask) {
+    const size_t eth_harvesting_mask) :
+    tensix_harvesting_mask(tensix_harvesting_mask) {
     std::ifstream fdesc(device_descriptor_path);
     if (fdesc.fail()) {
         throw std::runtime_error(

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -122,8 +122,6 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //         simulated_harvesting_masks);
 //     auto sdesc_per_chip = cluster.get_virtual_soc_descriptors();
 
-//     ASSERT_EQ(cluster.using_harvested_soc_descriptors(), true) << "Expected Driver to have performed harvesting";
-
 //     for (const auto& chip : sdesc_per_chip) {
 //         ASSERT_EQ(chip.second.workers.size(), 48)
 //             << "Expected SOC descriptor with harvesting to have 48 workers for chip" << chip.first;
@@ -158,8 +156,6 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //         simulated_harvesting_masks);
 //     auto sdesc_per_chip = cluster.get_virtual_soc_descriptors();
 
-//     ASSERT_EQ(cluster.using_harvested_soc_descriptors(), false)
-//         << "SOC descriptors should not be modified when harvesting is disabled";
 //     for (const auto& chip : sdesc_per_chip) {
 //         ASSERT_EQ(chip.second.workers.size(), 1) << "Expected 1x1 SOC descriptor to be unmodified by driver";
 //     }

--- a/tests/grayskull/test_cluster_gs.cpp
+++ b/tests/grayskull/test_cluster_gs.cpp
@@ -58,7 +58,6 @@ TEST(SiliconDriverGS, Harvesting) {
     Cluster cluster = Cluster(num_host_mem_ch_per_mmio_device, false, true, true, simulated_harvesting_masks);
     auto sdesc_per_chip = cluster.get_virtual_soc_descriptors();
 
-    ASSERT_EQ(cluster.using_harvested_soc_descriptors(), true) << "Expected Driver to have performed harvesting";
     for (const auto& chip : sdesc_per_chip) {
         ASSERT_LE(chip.second.workers.size(), 96)
             << "Expected SOC descriptor with harvesting to have less than or equal to 96 workers for chip "
@@ -85,8 +84,6 @@ TEST(SiliconDriverGS, CustomSocDesc) {
         false,
         simulated_harvesting_masks);
     auto sdesc_per_chip = cluster.get_virtual_soc_descriptors();
-    ASSERT_EQ(cluster.using_harvested_soc_descriptors(), false)
-        << "SOC descriptors should not be modified when harvesting is disabled";
     for (const auto& chip : sdesc_per_chip) {
         ASSERT_EQ(chip.second.workers.size(), 1) << "Expected 1x1 SOC descriptor to be unmodified by driver";
     }

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -108,8 +108,6 @@ TEST(SiliconDriverWH, Harvesting) {
     Cluster cluster = Cluster(num_host_mem_ch_per_mmio_device, false, true, true, simulated_harvesting_masks);
     auto sdesc_per_chip = cluster.get_virtual_soc_descriptors();
 
-    ASSERT_EQ(cluster.using_harvested_soc_descriptors(), true) << "Expected Driver to have performed harvesting";
-
     for (const auto& chip : sdesc_per_chip) {
         ASSERT_EQ(chip.second.workers.size(), 48)
             << "Expected SOC descriptor with harvesting to have 48 workers for chip" << chip.first;
@@ -136,8 +134,6 @@ TEST(SiliconDriverWH, CustomSocDesc) {
         simulated_harvesting_masks);
     auto sdesc_per_chip = cluster.get_virtual_soc_descriptors();
 
-    ASSERT_EQ(cluster.using_harvested_soc_descriptors(), false)
-        << "SOC descriptors should not be modified when harvesting is disabled";
     for (const auto& chip : sdesc_per_chip) {
         ASSERT_EQ(chip.second.workers.size(), 1) << "Expected 1x1 SOC descriptor to be unmodified by driver";
     }


### PR DESCRIPTION
### Issue
Related to #439 

### Description
(Add freeform description.)

### List of the changes
- Removed unnecessary using_harvested_soc_descriptors
- Change get_harvesting_masks_for_soc_descriptors to get harvesting from tt_SocDescriptor

### Testing
(Comment on CI testing or Manual testing touching this change.)

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
