### PR TITLE
[Harvesting] noc_translation_enabled added to tt_SocDescriptor

### DIFF
--- a/device/api/umd/device/blackhole_coordinate_manager.h
+++ b/device/api/umd/device/blackhole_coordinate_manager.h
@@ -12,6 +12,7 @@
 class BlackholeCoordinateManager : public CoordinateManager {
 public:
     BlackholeCoordinateManager(
+        const bool noc_translation_enabled,
         const tt_xy_pair& tensix_grid_size,
         const std::vector<tt_xy_pair>& tensix_cores,
         const size_t tensix_harvesting_mask,
@@ -29,14 +30,15 @@ public:
 protected:
     void assert_coordinate_manager_constructor() override;
 
-    void translate_dram_coords() override;
     void translate_tensix_coords() override;
+    void translate_dram_coords() override;
     void translate_eth_coords() override;
 
     void fill_tensix_physical_translated_mapping() override;
+    void fill_dram_physical_translated_mapping() override;
     void fill_eth_physical_translated_mapping() override;
     void fill_pcie_physical_translated_mapping() override;
-    void fill_dram_physical_translated_mapping() override;
+    void fill_arc_physical_translated_mapping() override;
 
     std::vector<tt::umd::CoreCoord> get_tensix_cores() const override;
     std::vector<tt::umd::CoreCoord> get_harvested_tensix_cores() const override;

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -868,8 +868,16 @@ private:
 
     // This functions has to be called for local chip, and then it will wait for all connected remote chips to flush.
     void wait_for_connected_non_mmio_flush(chip_id_t chip_id);
+
+    // Helper functions for constructing the chips from the cluster descriptor.
     std::unique_ptr<Chip> construct_chip_from_cluster(
         chip_id_t chip_id, tt_ClusterDescriptor* cluster_desc, tt_SocDescriptor& soc_desc);
+    std::unique_ptr<Chip> construct_chip_from_cluster(
+        const std::string& soc_desc_path,
+        chip_id_t chip_id,
+        tt_ClusterDescriptor* cluster_desc,
+        bool perform_harvesting,
+        std::unordered_map<chip_id_t, uint32_t>& simulated_harvesting_masks);
     std::unique_ptr<Chip> construct_chip_from_cluster(
         chip_id_t logical_device_id,
         tt_ClusterDescriptor* cluster_desc,
@@ -887,6 +895,8 @@ private:
         const bool clean_system_resources,
         bool perform_harvesting,
         std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks);
+
+    // Helper function for translating chip coordinates.
     tt::umd::CoreCoord translate_chip_coord(
         const chip_id_t chip, const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const;
 

--- a/device/api/umd/device/coordinate_manager.h
+++ b/device/api/umd/device/coordinate_manager.h
@@ -188,10 +188,10 @@ protected:
     std::map<tt::umd::CoreCoord, tt_xy_pair> to_physical_map;
     std::map<std::pair<tt_xy_pair, CoordSystem>, tt::umd::CoreCoord> from_physical_map;
 
-    // Whether NOC translation is enabled.
-    // Effectivelly, when this is enabled, we can interface NOC with Virtual coordinates (on wormhole, translated by
-    // some constant). If not, Physical should be used. This will be implemented through Translated coordinates, so the
-    // user can always use those to interface with NOC.
+    // Whether NOC translation is enabled on chip.
+    // This flag affects how Translated coords are calculated. If translation is enabled on the chip, than we can
+    // interface it with a coordinate system which abstracts away harvested cores. If it is not enabled, then we need to
+    // interface it with noc0 coordinates.
     bool noc_translation_enabled;
 
     tt_xy_pair tensix_grid_size;

--- a/device/api/umd/device/grayskull_coordinate_manager.h
+++ b/device/api/umd/device/grayskull_coordinate_manager.h
@@ -27,5 +27,9 @@ public:
         const std::vector<tt_xy_pair>& pcie_cores);
 
 protected:
+    void fill_tensix_physical_translated_mapping() override;
     void fill_eth_physical_translated_mapping() override;
+    void fill_dram_physical_translated_mapping() override;
+    void fill_pcie_physical_translated_mapping() override;
+    void fill_arc_physical_translated_mapping() override;
 };

--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -52,6 +52,7 @@ public:
     // Constructor used to build object from device descriptor file.
     tt_SocDescriptor(
         std::string device_descriptor_path,
+        const bool noc_translation_enabled,
         const size_t tensix_harvesting_mask = 0,
         const size_t dram_harvesting_mask = 0,
         const size_t eth_harvesting_mask = 0);
@@ -114,7 +115,10 @@ public:
 
 private:
     void create_coordinate_manager(
-        const size_t tensix_harvesting_mask, const size_t dram_harvesting_mask, const size_t eth_harvesting_mask);
+        const bool noc_translation_enabled,
+        const size_t tensix_harvesting_mask,
+        const size_t dram_harvesting_mask,
+        const size_t eth_harvesting_mask);
     void load_core_descriptors_from_device_descriptor(YAML::Node &device_descriptor_yaml);
     void load_soc_features_from_device_descriptor(YAML::Node &device_descriptor_yaml);
     void get_cores_and_grid_size_from_coordinate_manager();

--- a/device/api/umd/device/wormhole_coordinate_manager.h
+++ b/device/api/umd/device/wormhole_coordinate_manager.h
@@ -12,6 +12,7 @@
 class WormholeCoordinateManager : public CoordinateManager {
 public:
     WormholeCoordinateManager(
+        const bool noc_translation_enabled,
         const tt_xy_pair& tensix_grid_size,
         const std::vector<tt_xy_pair>& tensix_cores,
         const size_t tensix_harvesting_mask,
@@ -28,5 +29,8 @@ public:
 
 protected:
     void fill_tensix_physical_translated_mapping() override;
+    void fill_dram_physical_translated_mapping() override;
     void fill_eth_physical_translated_mapping() override;
+    void fill_pcie_physical_translated_mapping() override;
+    void fill_arc_physical_translated_mapping() override;
 };

--- a/device/blackhole/blackhole_coordinate_manager.cpp
+++ b/device/blackhole/blackhole_coordinate_manager.cpp
@@ -10,6 +10,7 @@
 using namespace tt::umd;
 
 BlackholeCoordinateManager::BlackholeCoordinateManager(
+    const bool noc_translation_enabled,
     const tt_xy_pair& tensix_grid_size,
     const std::vector<tt_xy_pair>& tensix_cores,
     const size_t tensix_harvesting_mask,
@@ -24,6 +25,7 @@ BlackholeCoordinateManager::BlackholeCoordinateManager(
     const tt_xy_pair& pcie_grid_size,
     const std::vector<tt_xy_pair>& pcie_cores) :
     CoordinateManager(
+        noc_translation_enabled,
         tensix_grid_size,
         tensix_cores,
         tensix_harvesting_mask,
@@ -89,7 +91,11 @@ void BlackholeCoordinateManager::translate_tensix_coords() {
         }
     }
 
-    fill_tensix_physical_translated_mapping();
+    if (noc_translation_enabled) {
+        fill_tensix_physical_translated_mapping();
+    } else {
+        fill_tensix_default_physical_translated_mapping();
+    }
 }
 
 void BlackholeCoordinateManager::fill_tensix_physical_translated_mapping() {
@@ -146,7 +152,11 @@ void BlackholeCoordinateManager::translate_dram_coords() {
         }
     }
 
-    fill_dram_physical_translated_mapping();
+    if (noc_translation_enabled) {
+        fill_dram_physical_translated_mapping();
+    } else {
+        fill_dram_default_physical_translated_mapping();
+    }
 }
 
 void BlackholeCoordinateManager::translate_eth_coords() {
@@ -184,7 +194,11 @@ void BlackholeCoordinateManager::translate_eth_coords() {
         }
     }
 
-    fill_eth_physical_translated_mapping();
+    if (noc_translation_enabled) {
+        fill_eth_physical_translated_mapping();
+    } else {
+        fill_eth_default_physical_translated_mapping();
+    }
 }
 
 void BlackholeCoordinateManager::fill_eth_physical_translated_mapping() {
@@ -229,6 +243,11 @@ void BlackholeCoordinateManager::fill_pcie_physical_translated_mapping() {
         CoordSystem::TRANSLATED);
 
     add_core_translation(translated_coord, physical_pair);
+}
+
+void BlackholeCoordinateManager::fill_arc_physical_translated_mapping() {
+    // ARC cores are not translated in Blackhole.
+    fill_arc_default_physical_translated_mapping();
 }
 
 void BlackholeCoordinateManager::map_column_of_dram_banks(

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -441,9 +441,6 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     tt_ClusterDescriptor* cluster_desc,
     bool perform_harvesting,
     std::unordered_map<chip_id_t, uint32_t>& simulated_harvesting_masks) {
-    tt::ARCH arch = cluster_desc->get_arch(chip_id);
-    const BoardType chip_board_type = cluster_desc->get_board_type(chip_id);
-    std::string soc_desc_path = tt_SocDescriptor::get_soc_descriptor_path(arch, chip_board_type);
     uint32_t tensix_harvesting_mask =
         get_tensix_harvesting_mask(chip_id, cluster_desc, perform_harvesting, simulated_harvesting_masks);
     tt_SocDescriptor soc_desc = tt_SocDescriptor(
@@ -457,7 +454,8 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     bool perform_harvesting,
     std::unordered_map<chip_id_t, uint32_t>& simulated_harvesting_masks) {
     tt::ARCH arch = cluster_desc->get_arch(chip_id);
-    std::string soc_desc_path = tt_SocDescriptor::get_soc_descriptor_path(arch);
+    const BoardType chip_board_type = cluster_desc->get_board_type(chip_id);
+    std::string soc_desc_path = tt_SocDescriptor::get_soc_descriptor_path(arch, chip_board_type);
     return construct_chip_from_cluster(
         soc_desc_path, chip_id, cluster_desc, perform_harvesting, simulated_harvesting_masks);
 }
@@ -636,7 +634,8 @@ Cluster::Cluster(
     // rather than ClusterDescriptor.
     tt::ARCH arch = tt::ARCH::GRAYSKULL;
     chip_id_t mock_chip_id = 0;
-    tt_SocDescriptor soc_desc = tt_SocDescriptor(tt_SocDescriptor::get_soc_descriptor_path(arch, BoardType::UNKNOWN), false);
+    tt_SocDescriptor soc_desc =
+        tt_SocDescriptor(tt_SocDescriptor::get_soc_descriptor_path(arch, BoardType::UNKNOWN), false);
     std::unique_ptr<Chip> chip = std::make_unique<MockChip>(soc_desc);
 
     std::unordered_map<chip_id_t, std::unique_ptr<Chip>> chips;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -436,6 +436,7 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
 }
 
 std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
+    const std::string& soc_desc_path,
     chip_id_t chip_id,
     tt_ClusterDescriptor* cluster_desc,
     bool perform_harvesting,
@@ -445,8 +446,20 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     std::string soc_desc_path = tt_SocDescriptor::get_soc_descriptor_path(arch, chip_board_type);
     uint32_t tensix_harvesting_mask =
         get_tensix_harvesting_mask(chip_id, cluster_desc, perform_harvesting, simulated_harvesting_masks);
-    tt_SocDescriptor soc_desc = tt_SocDescriptor(soc_desc_path, tensix_harvesting_mask);
+    tt_SocDescriptor soc_desc = tt_SocDescriptor(
+        soc_desc_path, cluster_desc->get_noc_translation_table_en().at(chip_id), tensix_harvesting_mask);
     return construct_chip_from_cluster(chip_id, cluster_desc, soc_desc);
+}
+
+std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
+    chip_id_t chip_id,
+    tt_ClusterDescriptor* cluster_desc,
+    bool perform_harvesting,
+    std::unordered_map<chip_id_t, uint32_t>& simulated_harvesting_masks) {
+    tt::ARCH arch = cluster_desc->get_arch(chip_id);
+    std::string soc_desc_path = tt_SocDescriptor::get_soc_descriptor_path(arch);
+    return construct_chip_from_cluster(
+        soc_desc_path, chip_id, cluster_desc, perform_harvesting, simulated_harvesting_masks);
 }
 
 void Cluster::add_chip(chip_id_t chip_id, std::unique_ptr<Chip> chip) {
@@ -567,16 +580,16 @@ Cluster::Cluster(
             cluster_desc->get_all_chips().find(chip_id) != cluster_desc->get_all_chips().end(),
             "Target device {} not present in current cluster!",
             chip_id);
-        size_t tensix_harvesting_mask =
-            get_tensix_harvesting_mask(chip_id, cluster_desc.get(), perform_harvesting, simulated_harvesting_masks);
-        tt_SocDescriptor soc_desc = tt_SocDescriptor(sdesc_path, tensix_harvesting_mask);
+        add_chip(
+            chip_id,
+            construct_chip_from_cluster(
+                sdesc_path, chip_id, cluster_desc.get(), perform_harvesting, simulated_harvesting_masks));
         log_assert(
-            cluster_desc->get_arch(chip_id) == soc_desc.arch,
+            cluster_desc->get_arch(chip_id) == chips_.at(chip_id)->get_soc_descriptor().arch,
             "Passed soc descriptor has {} arch, but for chip id {} has arch {}",
-            arch_to_str(soc_desc.arch),
+            arch_to_str(chips_.at(chip_id)->get_soc_descriptor().arch),
             chip_id,
             arch_to_str(cluster_desc->get_arch(chip_id)));
-        add_chip(chip_id, construct_chip_from_cluster(chip_id, cluster_desc.get(), soc_desc));
     }
 
     // TODO: work on removing this member altogether. Currently assumes all have the same arch.
@@ -623,7 +636,7 @@ Cluster::Cluster(
     // rather than ClusterDescriptor.
     tt::ARCH arch = tt::ARCH::GRAYSKULL;
     chip_id_t mock_chip_id = 0;
-    tt_SocDescriptor soc_desc = tt_SocDescriptor(tt_SocDescriptor::get_soc_descriptor_path(arch, BoardType::UNKNOWN));
+    tt_SocDescriptor soc_desc = tt_SocDescriptor(tt_SocDescriptor::get_soc_descriptor_path(arch, BoardType::UNKNOWN), false);
     std::unique_ptr<Chip> chip = std::make_unique<MockChip>(soc_desc);
 
     std::unordered_map<chip_id_t, std::unique_ptr<Chip>> chips;

--- a/device/grayskull/grayskull_coordinate_manager.cpp
+++ b/device/grayskull/grayskull_coordinate_manager.cpp
@@ -5,6 +5,8 @@
  */
 #include "umd/device/grayskull_coordinate_manager.h"
 
+#include "logger.hpp"
+
 using namespace tt::umd;
 
 GrayskullCoordinateManager::GrayskullCoordinateManager(
@@ -22,6 +24,7 @@ GrayskullCoordinateManager::GrayskullCoordinateManager(
     const tt_xy_pair& pcie_grid_size,
     const std::vector<tt_xy_pair>& pcie_cores) :
     CoordinateManager(
+        false,
         tensix_grid_size,
         tensix_cores,
         tensix_harvesting_mask,
@@ -38,17 +41,22 @@ GrayskullCoordinateManager::GrayskullCoordinateManager(
     initialize();
 }
 
+void GrayskullCoordinateManager::fill_tensix_physical_translated_mapping() {
+    log_assert(false, "NOC translation is not supported for Grayskull.");
+}
+
 void GrayskullCoordinateManager::fill_eth_physical_translated_mapping() {
-    for (size_t x = 0; x < eth_grid_size.x; x++) {
-        for (size_t y = 0; y < eth_grid_size.y; y++) {
-            CoreCoord logical_coord = CoreCoord(x, y, CoreType::ETH, CoordSystem::LOGICAL);
-            const tt_xy_pair physical_pair = to_physical_map[logical_coord];
-            const size_t translated_x = physical_pair.x;
-            const size_t translated_y = physical_pair.y;
+    log_assert(false, "NOC translation is not supported for Grayskull.");
+}
 
-            CoreCoord translated_coord = CoreCoord(translated_x, translated_y, CoreType::ETH, CoordSystem::TRANSLATED);
+void GrayskullCoordinateManager::fill_dram_physical_translated_mapping() {
+    log_assert(false, "NOC translation is not supported for Grayskull.");
+}
 
-            add_core_translation(translated_coord, physical_pair);
-        }
-    }
+void GrayskullCoordinateManager::fill_pcie_physical_translated_mapping() {
+    log_assert(false, "NOC translation is not supported for Grayskull.");
+}
+
+void GrayskullCoordinateManager::fill_arc_physical_translated_mapping() {
+    log_assert(false, "NOC translation is not supported for Grayskull.");
 }

--- a/device/mockup/tt_mockup_device.hpp
+++ b/device/mockup/tt_mockup_device.hpp
@@ -15,7 +15,7 @@
 class tt_MockupDevice : public tt_device {
 public:
     tt_MockupDevice(const std::string& sdesc_path) : tt_device() {
-        soc_descriptor_per_chip.emplace(0, tt_SocDescriptor(sdesc_path));
+        soc_descriptor_per_chip.emplace(0, tt_SocDescriptor(sdesc_path, false));
         std::set<chip_id_t> target_devices = {0};
     }
 

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -53,7 +53,7 @@ void print_flatbuffer(const DeviceRequestResponse* buf) {
 
 tt_SimulationDevice::tt_SimulationDevice(const std::string& sdesc_path) : tt_device() {
     log_info(tt::LogEmulationDriver, "Instantiating simulation device");
-    soc_descriptor_per_chip.emplace(0, tt_SocDescriptor(sdesc_path));
+    soc_descriptor_per_chip.emplace(0, tt_SocDescriptor(sdesc_path, false));
     std::set<chip_id_t> target_devices = {0};
 
     // Start VCS simulator in a separate process

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -61,6 +61,8 @@ inline std::string &trim(std::string &s, const char *t = ws) { return ltrim(rtri
 
 void tt_SocDescriptor::load_soc_features_from_device_descriptor(YAML::Node &device_descriptor_yaml) {
     overlay_version = device_descriptor_yaml["features"]["overlay"]["version"].as<int>();
+    // TODO: Check whether this is a valid value, and whether it is used.
+    // Also check if this is the same thing as noc_translation in cluster descriptor.
     noc_translation_id_enabled =
         device_descriptor_yaml["features"]["noc"] && device_descriptor_yaml["features"]["noc"]["translation_id_enabled"]
             ? device_descriptor_yaml["features"]["noc"]["translation_id_enabled"].as<bool>()

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -183,7 +183,10 @@ tt_xy_pair tt_SocDescriptor::calculate_grid_size(const std::vector<tt_xy_pair> &
 }
 
 void tt_SocDescriptor::create_coordinate_manager(
-    const size_t tensix_harvesting_mask, const size_t dram_harvesting_mask, const size_t eth_harvesting_mask) {
+    const bool noc_translation_enabled,
+    const size_t tensix_harvesting_mask,
+    const size_t dram_harvesting_mask,
+    const size_t eth_harvesting_mask) {
     const tt_xy_pair dram_grid_size = tt_xy_pair(dram_cores.size(), dram_cores.empty() ? 0 : dram_cores[0].size());
     const tt_xy_pair arc_grid_size = tt_SocDescriptor::calculate_grid_size(arc_cores);
     const tt_xy_pair pcie_grid_size = tt_SocDescriptor::calculate_grid_size(pcie_cores);
@@ -198,6 +201,7 @@ void tt_SocDescriptor::create_coordinate_manager(
 
     coordinate_manager = CoordinateManager::create_coordinate_manager(
         arch,
+        noc_translation_enabled,
         worker_grid_size,
         workers,
         tensix_harvesting_mask,
@@ -221,6 +225,7 @@ tt::umd::CoreCoord tt_SocDescriptor::translate_coord_to(
 
 tt_SocDescriptor::tt_SocDescriptor(
     std::string device_descriptor_path,
+    const bool noc_translation_enabled,
     const size_t tensix_harvesting_mask,
     const size_t dram_harvesting_mask,
     const size_t eth_harvesting_mask) :
@@ -243,7 +248,8 @@ tt_SocDescriptor::tt_SocDescriptor(
     arch_name_value = trim(arch_name_value);
     arch = tt::arch_from_str(arch_name_value);
     load_soc_features_from_device_descriptor(device_descriptor_yaml);
-    create_coordinate_manager(tensix_harvesting_mask, dram_harvesting_mask, eth_harvesting_mask);
+    create_coordinate_manager(
+        noc_translation_enabled, tensix_harvesting_mask, dram_harvesting_mask, eth_harvesting_mask);
 }
 
 int tt_SocDescriptor::get_num_dram_channels() const {

--- a/device/wormhole/wormhole_coordinate_manager.cpp
+++ b/device/wormhole/wormhole_coordinate_manager.cpp
@@ -8,6 +8,7 @@
 using namespace tt::umd;
 
 WormholeCoordinateManager::WormholeCoordinateManager(
+    const bool noc_translation_enabled,
     const tt_xy_pair& tensix_grid_size,
     const std::vector<tt_xy_pair>& tensix_cores,
     const size_t tensix_harvesting_mask,
@@ -22,6 +23,7 @@ WormholeCoordinateManager::WormholeCoordinateManager(
     const tt_xy_pair& pcie_grid_size,
     const std::vector<tt_xy_pair>& pcie_cores) :
     CoordinateManager(
+        noc_translation_enabled,
         tensix_grid_size,
         tensix_cores,
         tensix_harvesting_mask,
@@ -72,6 +74,11 @@ void WormholeCoordinateManager::fill_tensix_physical_translated_mapping() {
     }
 }
 
+void WormholeCoordinateManager::fill_dram_physical_translated_mapping() {
+    // DRAM cores are not translated in Wormhole.
+    fill_dram_default_physical_translated_mapping();
+}
+
 void WormholeCoordinateManager::fill_eth_physical_translated_mapping() {
     for (size_t x = 0; x < eth_grid_size.x; x++) {
         for (size_t y = 0; y < eth_grid_size.y; y++) {
@@ -84,4 +91,14 @@ void WormholeCoordinateManager::fill_eth_physical_translated_mapping() {
             add_core_translation(translated_coord, physical_pair);
         }
     }
+}
+
+void WormholeCoordinateManager::fill_pcie_physical_translated_mapping() {
+    // PCIE cores are not translated in Wormhole.
+    fill_pcie_default_physical_translated_mapping();
+}
+
+void WormholeCoordinateManager::fill_arc_physical_translated_mapping() {
+    // ARC cores are not translated in Wormhole.
+    fill_arc_default_physical_translated_mapping();
 }

--- a/tests/api/test_core_coord_translation_bh.cpp
+++ b/tests/api/test_core_coord_translation_bh.cpp
@@ -13,7 +13,7 @@ using namespace tt::umd;
 // when there is no harvesting.
 TEST(CoordinateManager, CoordinateManagerBlackholeNoHarvesting) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true);
 
     // We expect full grid size since there is no harvesting.
     tt_xy_pair tensix_grid_size = tt::umd::blackhole::TENSIX_GRID_SIZE;
@@ -37,7 +37,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeTopLeftCore) {
     // This is targeting first row of Tensix cores on NOC layout.
     const size_t harvesting_mask = (1 << 0);
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, harvesting_mask);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, harvesting_mask);
     tt_xy_pair tensix_grid_size = tt::umd::blackhole::TENSIX_GRID_SIZE;
 
     CoreCoord logical_coords = CoreCoord(0, 0, CoreType::TENSIX, CoordSystem::LOGICAL);
@@ -60,7 +60,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeLogicalPhysicalMapping) {
 
     for (size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_x); harvesting_mask++) {
         std::shared_ptr<CoordinateManager> coordinate_manager =
-            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, harvesting_mask);
+            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, harvesting_mask);
 
         std::map<CoreCoord, CoreCoord> logical_to_physical;
         std::set<CoreCoord> physical_coords_set;
@@ -103,7 +103,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeLogicalVirtualMapping) {
 
     for (size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_x); harvesting_mask++) {
         std::shared_ptr<CoordinateManager> coordinate_manager =
-            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, harvesting_mask);
+            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, harvesting_mask);
 
         std::map<CoreCoord, CoreCoord> logical_to_virtual;
         std::set<CoreCoord> virtual_coords_set;
@@ -145,7 +145,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeLogicalTranslatedMapping) {
 
     for (size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_x); harvesting_mask++) {
         std::shared_ptr<CoordinateManager> coordinate_manager =
-            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, harvesting_mask);
+            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, harvesting_mask);
 
         std::map<CoreCoord, CoreCoord> logical_to_translated;
         std::set<CoreCoord> translated_coords_set;
@@ -187,7 +187,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeVirtualEqualTranslated) {
 
     for (size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_x); harvesting_mask++) {
         std::shared_ptr<CoordinateManager> coordinate_manager =
-            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, harvesting_mask);
+            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, harvesting_mask);
 
         size_t num_harvested_x = CoordinateManager::get_num_harvested(harvesting_mask);
 
@@ -210,7 +210,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeVirtualEqualTranslated) {
 TEST(CoordinateManager, CoordinateManagerBlackholeTransltedMappingHarvested) {
     const size_t harvesting_mask = (1 << 0) | (1 << 1);
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, harvesting_mask);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, harvesting_mask);
 
     const tt_xy_pair tensix_grid_size = tt::umd::blackhole::TENSIX_GRID_SIZE;
     const std::vector<tt_xy_pair> tensix_cores = tt::umd::blackhole::TENSIX_CORES;
@@ -255,7 +255,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeTransltedMappingHarvested) {
 // coordinates should cover all physical coordinates.
 TEST(CoordinateManager, CoordinateManagerBlackholeDRAMNoHarvesting) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true);
 
     const size_t num_dram_banks = tt::umd::blackhole::NUM_DRAM_BANKS;
     const size_t num_noc_ports_per_bank = tt::umd::blackhole::NUM_NOC_PORTS_PER_DRAM_BANK;
@@ -281,7 +281,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMNoHarvesting) {
 // Test top left corner translation from logical to physical coordinates.
 TEST(CoordinateManager, CoordinateManagerBlackholeDRAMTopLeft) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, 0, 1);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, 0, 1);
 
     const CoreCoord top_left_dram_logical = CoreCoord(0, 0, CoreType::DRAM, CoordSystem::LOGICAL);
     const CoreCoord expected_top_left_physical = CoreCoord(0, 2, CoreType::DRAM, CoordSystem::PHYSICAL);
@@ -308,7 +308,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMLogicalPhysicalMapping) {
         }
 
         std::shared_ptr<CoordinateManager> coordinate_manager =
-            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, 0, harvesting_mask);
+            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, 0, harvesting_mask);
 
         std::map<CoreCoord, CoreCoord> logical_to_physical;
         std::set<CoreCoord> physical_coords_set;
@@ -357,7 +357,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMLogicalVirtualMapping) {
         }
 
         std::shared_ptr<CoordinateManager> coordinate_manager =
-            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, 0, harvesting_mask);
+            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, 0, harvesting_mask);
 
         std::map<CoreCoord, CoreCoord> logical_to_virtual;
         std::set<CoreCoord> virtual_coords_set;
@@ -399,7 +399,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMTranslatedMapping) {
         }
 
         std::shared_ptr<CoordinateManager> coordinate_manager =
-            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, 0, harvesting_mask);
+            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, 0, harvesting_mask);
 
         std::map<CoreCoord, CoreCoord> logical_to_translated;
         std::set<CoreCoord> translated_coord_set;
@@ -447,7 +447,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMVirtualPhysicalMapping) {
     const size_t dram_harvesting_mask = 1;
 
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, 0, dram_harvesting_mask);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, 0, dram_harvesting_mask);
 
     const size_t physical_index = 0;
     const size_t virtual_index = (num_dram_banks - 1) * num_noc_ports_per_bank;
@@ -490,14 +490,15 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMPMoreThanOneDRAMBankHarves
         }
 
         EXPECT_THROW(
-            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, 0, harvesting_mask), std::runtime_error);
+            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, 0, harvesting_mask),
+            std::runtime_error);
     }
 }
 
 // Test that virtual, physical and translated coordinates are the same for all logical PCIE coordinates.
 TEST(CoordinateManager, CoordinateManagerBlackholePCIETranslationLocal) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, 0, 0, 0, BoardType::P300, false);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, 0, 0, 0, BoardType::P300, false);
     const tt_xy_pair pcie_grid_size = tt::umd::blackhole::PCIE_GRID_SIZE;
     const std::vector<tt_xy_pair> pcie_cores = tt::umd::blackhole::PCIE_CORES_TYPE2;
 
@@ -520,7 +521,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholePCIETranslationLocal) {
 // Test that virtual, physical and translated coordinates are the same for all logical PCIE coordinates.
 TEST(CoordinateManager, CoordinateManagerBlackholePCIETranslationRemote) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, 0, 0, 0, BoardType::P300, true);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true);
     const tt_xy_pair pcie_grid_size = tt::umd::blackhole::PCIE_GRID_SIZE;
     const std::vector<tt_xy_pair> pcie_cores = tt::umd::blackhole::PCIE_CORES_TYPE1;
 
@@ -543,7 +544,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholePCIETranslationRemote) {
 // Test that virtual, physical and translated coordinates are the same for all logical ARC coordinates.
 TEST(CoordinateManager, CoordinateManagerBlackholeARCTranslation) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true);
     const tt_xy_pair arc_grid_size = tt::umd::blackhole::ARC_GRID_SIZE;
 
     for (size_t x = 0; x < arc_grid_size.x; x++) {
@@ -566,7 +567,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeARCTranslation) {
 // Test ethernet coordinate translation.
 TEST(CoordinateManager, CoordinateManagerBlackholeETHTranslation) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true);
     const tt_xy_pair eth_grid_size = tt::umd::blackhole::ETH_GRID_SIZE;
 
     const size_t eth_translated_coordinate_start_x = 20;
@@ -601,7 +602,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeETHHarvesting) {
         }
 
         std::shared_ptr<CoordinateManager> coordinate_manager =
-            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, 0, 0, harvesting_mask);
+            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, 0, 0, harvesting_mask);
 
         size_t index = 0;
 
@@ -643,7 +644,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholePhysicalLayoutTensixHarvesting
 
     for (size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_x); harvesting_mask++) {
         std::shared_ptr<CoordinateManager> coordinate_manager =
-            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, harvesting_mask);
+            CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, harvesting_mask);
 
         EXPECT_EQ(coordinate_manager->get_tensix_harvesting_mask(), harvesting_mask);
     }

--- a/tests/api/test_core_coord_translation_gs.cpp
+++ b/tests/api/test_core_coord_translation_gs.cpp
@@ -13,7 +13,7 @@ using namespace tt::umd;
 // when there is no harvesting.
 TEST(CoordinateManager, CoordinateManagerGrayskullNoHarvesting) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, false);
 
     // We expect full grid size since there is no harvesting.
     tt_xy_pair tensix_grid_size = tt::umd::grayskull::TENSIX_GRID_SIZE;
@@ -35,7 +35,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullNoHarvesting) {
 // the logical coordinates if the first row is harvested.
 TEST(CoordinateManager, CoordinateManagerGrayskullTopLeftCore) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, false);
 
     CoreCoord logical_coords = CoreCoord(0, 0, CoreType::TENSIX, CoordSystem::LOGICAL);
 
@@ -55,7 +55,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullTopLeftCoreHarvesting) {
     // This is targeting first row of Tensix cores on NOC layout.
     const size_t harvesting_mask = (1 << 0);
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, harvesting_mask);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, false, harvesting_mask);
 
     CoreCoord logical_coords = CoreCoord(0, 0, CoreType::TENSIX, CoordSystem::LOGICAL);
 
@@ -72,7 +72,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullTopLeftCoreHarvesting) {
 // We always expect that physical, virtual and translated coordinates are the same.
 TEST(CoordinateManager, CoordinateManagerGrayskullTranslatingCoords) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, false);
     tt_xy_pair tensix_grid_size = tt::umd::grayskull::TENSIX_GRID_SIZE;
 
     for (size_t x = 0; x < tensix_grid_size.x; x++) {
@@ -103,7 +103,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullLogicalPhysicalMapping) {
 
     for (size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_y); harvesting_mask++) {
         std::shared_ptr<CoordinateManager> coordinate_manager =
-            CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, harvesting_mask);
+            CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, false, harvesting_mask);
 
         std::map<CoreCoord, CoreCoord> logical_to_physical;
         std::set<CoreCoord> physical_coords_set;
@@ -148,7 +148,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullLogicalVirtualMapping) {
 
     for (size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_y); harvesting_mask++) {
         std::shared_ptr<CoordinateManager> coordinate_manager =
-            CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, harvesting_mask);
+            CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, false, harvesting_mask);
 
         std::map<CoreCoord, CoreCoord> logical_to_virtual;
         std::set<CoreCoord> virtual_coords_set;
@@ -184,7 +184,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullPhysicalHarvestedMapping) {
     const size_t harvesting_mask = (1 << 0) | (1 << 1);
     const size_t num_harvested = CoordinateManager::get_num_harvested(harvesting_mask);
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, harvesting_mask);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, false, harvesting_mask);
 
     const std::vector<tt_xy_pair> tensix_cores = tt::umd::grayskull::TENSIX_CORES;
     const tt_xy_pair tensix_grid_size = tt::umd::grayskull::TENSIX_GRID_SIZE;
@@ -209,7 +209,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullPhysicalTranslatedHarvestedMap
     const size_t harvesting_mask = (1 << 0) | (1 << 1);
     const size_t num_harvested = CoordinateManager::get_num_harvested(harvesting_mask);
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, harvesting_mask);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, false, harvesting_mask);
 
     const std::vector<tt_xy_pair> tensix_cores = tt::umd::grayskull::TENSIX_CORES;
     const tt_xy_pair tensix_grid_size = tt::umd::grayskull::TENSIX_GRID_SIZE;
@@ -240,7 +240,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullPhysicalTranslatedHarvestedMap
 // so logical coordinates should cover all physical coordinates.
 TEST(CoordinateManager, CoordinateManagerGrayskullDRAMNoHarvesting) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, false);
 
     const size_t num_dram_banks = tt::umd::grayskull::NUM_DRAM_BANKS;
     const std::vector<tt_xy_pair>& dram_cores = tt::umd::grayskull::DRAM_CORES;
@@ -259,7 +259,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullDRAMNoHarvesting) {
 // Test that virtual, physical and translated coordinates are the same for all logical PCIE coordinates.
 TEST(CoordinateManager, CoordinateManagerGrayskullPCIETranslation) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, false);
     const tt_xy_pair pcie_grid_size = tt::umd::grayskull::PCIE_GRID_SIZE;
 
     for (size_t x = 0; x < pcie_grid_size.x; x++) {
@@ -282,7 +282,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullPCIETranslation) {
 // Test that virtual, physical and translated coordinates are the same for all logical ARC coordinates.
 TEST(CoordinateManager, CoordinateManagerGrayskullARCTranslation) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, false);
     const tt_xy_pair arc_grid_size = tt::umd::grayskull::ARC_GRID_SIZE;
 
     for (size_t x = 0; x < arc_grid_size.x; x++) {
@@ -304,12 +304,12 @@ TEST(CoordinateManager, CoordinateManagerGrayskullARCTranslation) {
 
 // Test that we assert properly if DRAM harvesting mask is non-zero for Grayskull.
 TEST(CoordinateManager, CoordinateManagerGrayskullDRAMHarvestingAssert) {
-    EXPECT_THROW(CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, 0, 1), std::runtime_error);
+    EXPECT_THROW(CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, false, 0, 1), std::runtime_error);
 }
 
 // Test that we assert properly if ETH harvesting mask is non-zero for Grayskull.
 TEST(CoordinateManager, CoordinateManagerGrayskullETHHarvestingAssert) {
-    EXPECT_THROW(CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, 0, 0, 1), std::runtime_error);
+    EXPECT_THROW(CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, false, 0, 0, 1), std::runtime_error);
 }
 
 // Test that we properly get harvesting mask that is based on the physical layout of the chip.
@@ -318,7 +318,7 @@ TEST(CoordinateManager, CoordinateManagerGrayskullPhysicalLayoutTensixHarvesting
 
     for (size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_y); harvesting_mask++) {
         std::shared_ptr<CoordinateManager> coordinate_manager =
-            CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, harvesting_mask);
+            CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, false, harvesting_mask);
 
         EXPECT_EQ(coordinate_manager->get_tensix_harvesting_mask(), harvesting_mask);
     }

--- a/tests/api/test_core_coord_translation_wh.cpp
+++ b/tests/api/test_core_coord_translation_wh.cpp
@@ -14,7 +14,7 @@ using namespace tt::umd;
 // when there is no harvesting.
 TEST(CoordinateManager, CoordinateManagerWormholeNoHarvesting) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true);
 
     // We expect full grid size since there is no harvesting.
     tt_xy_pair tensix_grid_size = tt::umd::wormhole::TENSIX_GRID_SIZE;
@@ -41,7 +41,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeTopLeftCore) {
     const size_t harvesting_mask = (1 << 0);
 
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, harvesting_mask);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true, harvesting_mask);
     tt_xy_pair tensix_grid_size = tt::umd::wormhole::TENSIX_GRID_SIZE;
 
     CoreCoord logical_coords = CoreCoord(0, 0, CoreType::TENSIX, CoordSystem::LOGICAL);
@@ -64,7 +64,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeLogicalPhysicalMapping) {
 
     for (size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_y); harvesting_mask++) {
         std::shared_ptr<CoordinateManager> coordinate_manager =
-            CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, harvesting_mask);
+            CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true, harvesting_mask);
 
         std::map<CoreCoord, CoreCoord> logical_to_physical;
         std::set<CoreCoord> physical_coords_set;
@@ -109,7 +109,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeLogicalVirtualMapping) {
 
     for (size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_y); harvesting_mask++) {
         std::shared_ptr<CoordinateManager> coordinate_manager =
-            CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, harvesting_mask);
+            CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true, harvesting_mask);
 
         std::map<CoreCoord, CoreCoord> logical_to_virtual;
         std::set<CoreCoord> virtual_coords_set;
@@ -153,7 +153,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeLogicalTranslatedTopLeft) {
     // if everything is harvested.
     for (size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_y) - 1; harvesting_mask++) {
         std::shared_ptr<CoordinateManager> coordinate_manager =
-            CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, harvesting_mask);
+            CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true, harvesting_mask);
 
         tt_xy_pair tensix_grid_size = tt::umd::wormhole::TENSIX_GRID_SIZE;
 
@@ -182,7 +182,7 @@ TEST(CoordinateManager, CoordinateManagerWormholePhysicalVirtualHarvestedMapping
     const size_t harvesting_mask = (1 << 0) | (1 << 1);
     const size_t num_harvested = CoordinateManager::get_num_harvested(harvesting_mask);
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, harvesting_mask);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true, harvesting_mask);
 
     const std::vector<tt_xy_pair> tensix_cores = tt::umd::wormhole::TENSIX_CORES;
     const tt_xy_pair tensix_grid_size = tt::umd::wormhole::TENSIX_GRID_SIZE;
@@ -207,7 +207,7 @@ TEST(CoordinateManager, CoordinateManagerWormholePhysicalTranslatedHarvestedMapp
     const size_t harvesting_mask = (1 << 0) | (1 << 1);
     const size_t num_harvested = CoordinateManager::get_num_harvested(harvesting_mask);
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, harvesting_mask);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true, harvesting_mask);
 
     const std::vector<tt_xy_pair> tensix_cores = tt::umd::wormhole::TENSIX_CORES;
     const tt_xy_pair tensix_grid_size = tt::umd::wormhole::TENSIX_GRID_SIZE;
@@ -251,7 +251,7 @@ TEST(CoordinateManager, CoordinateManagerWormholePhysicalTranslatedHarvestedMapp
 // so logical coordinates should cover all physical coordinates.
 TEST(CoordinateManager, CoordinateManagerWormholeDRAMNoHarvesting) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true);
 
     const size_t num_dram_banks = tt::umd::wormhole::NUM_DRAM_BANKS;
     const size_t num_noc_ports_per_bank = tt::umd::wormhole::NUM_NOC_PORTS_PER_DRAM_BANK;
@@ -278,7 +278,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeDRAMNoHarvesting) {
 // harvesting.
 TEST(CoordinateManager, CoordinateManagerWormholeETHPhysicalEqualVirtual) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true);
     const tt_xy_pair eth_grid_size = tt::umd::wormhole::ETH_GRID_SIZE;
 
     for (size_t x = 0; x < eth_grid_size.x; x++) {
@@ -296,7 +296,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeETHPhysicalEqualVirtual) {
 // Test translation of logical to translated ethernet coordinates.
 TEST(CoordinateManager, CoordinateManagerWormholeETHLogicalToTranslated) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true);
     const tt_xy_pair eth_grid_size = tt::umd::wormhole::ETH_GRID_SIZE;
 
     for (size_t x = 0; x < eth_grid_size.x; x++) {
@@ -314,7 +314,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeETHLogicalToTranslated) {
 // Test that virtual, physical and translated coordinates are the same for all logical coordinates.
 TEST(CoordinateManager, CoordinateManagerWormholeARCTranslation) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true);
     const tt_xy_pair arc_grid_size = tt::umd::wormhole::ARC_GRID_SIZE;
 
     for (size_t x = 0; x < arc_grid_size.x; x++) {
@@ -337,7 +337,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeARCTranslation) {
 // Test that virtual, physical and translated coordinates are the same for all logical PCIE coordinates.
 TEST(CoordinateManager, CoordinateManagerWormholePCIETranslation) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true);
     const tt_xy_pair pcie_grid_size = tt::umd::wormhole::PCIE_GRID_SIZE;
 
     for (size_t x = 0; x < pcie_grid_size.x; x++) {
@@ -359,12 +359,13 @@ TEST(CoordinateManager, CoordinateManagerWormholePCIETranslation) {
 
 // Test that we assert properly if DRAM harvesting mask is non-zero for Wormhole.
 TEST(CoordinateManager, CoordinateManagerWormholeDRAMHarvestingAssert) {
-    EXPECT_THROW(CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, 0, 1), std::runtime_error);
+    EXPECT_THROW(CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true, 0, 1), std::runtime_error);
 }
 
 // Test that we assert properly if ETH harvesting mask is non-zero for Wormhole.
 TEST(CoordinateManager, CoordinateManagerWormholeETHHarvestingAssert) {
-    EXPECT_THROW(CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, 0, 0, 1), std::runtime_error);
+    EXPECT_THROW(
+        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true, 0, 0, 1), std::runtime_error);
 }
 
 // Test that we properly get harvesting mask that is based on the physical layout of the chip.
@@ -373,7 +374,7 @@ TEST(CoordinateManager, CoordinateManagerWormholePhysicalLayoutTensixHarvestingM
 
     for (size_t harvesting_mask = 0; harvesting_mask < (1 << max_num_harvested_y); harvesting_mask++) {
         std::shared_ptr<CoordinateManager> coordinate_manager =
-            CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, harvesting_mask);
+            CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true, harvesting_mask);
 
         EXPECT_EQ(coordinate_manager->get_tensix_harvesting_mask(), harvesting_mask);
     }

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -344,7 +344,7 @@ TEST(SocDescriptor, CustomSocDescriptor) {
 }
 
 TEST(SocDescriptor, SocDescriptorGrayskullMultipleCoordinateSystems) {
-    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"));
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), false);
 
     const std::vector<tt_xy_pair> cores_physical = tt::umd::grayskull::TENSIX_CORES;
 
@@ -369,7 +369,7 @@ TEST(SocDescriptor, SocDescriptorGrayskullMultipleCoordinateSystems) {
 }
 
 TEST(SocDescriptor, SocDescriptorWormholeMultipleCoordinateSystems) {
-    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"));
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), true);
 
     const std::vector<tt_xy_pair> cores_physical = tt::umd::wormhole::TENSIX_CORES;
 
@@ -394,7 +394,7 @@ TEST(SocDescriptor, SocDescriptorWormholeMultipleCoordinateSystems) {
 }
 
 TEST(SocDescriptor, SocDescriptorBlackholeMultipleCoordinateSystems) {
-    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"));
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), true);
 
     const std::vector<tt_xy_pair> cores_physical = tt::umd::blackhole::TENSIX_CORES;
 
@@ -419,7 +419,7 @@ TEST(SocDescriptor, SocDescriptorBlackholeMultipleCoordinateSystems) {
 }
 
 TEST(SocDescriptor, SocDescriptorGrayskullNoLogicalForHarvestedCores) {
-    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), 1);
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), false, 1);
 
     EXPECT_THROW(soc_desc.get_harvested_cores(CoreType::TENSIX, CoordSystem::LOGICAL), std::runtime_error);
 
@@ -429,7 +429,7 @@ TEST(SocDescriptor, SocDescriptorGrayskullNoLogicalForHarvestedCores) {
 }
 
 TEST(SocDescriptor, SocDescriptorWormholeNoLogicalForHarvestedCores) {
-    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), 1);
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), true, 1);
 
     EXPECT_THROW(soc_desc.get_harvested_cores(CoreType::TENSIX, CoordSystem::LOGICAL), std::runtime_error);
 
@@ -439,7 +439,7 @@ TEST(SocDescriptor, SocDescriptorWormholeNoLogicalForHarvestedCores) {
 }
 
 TEST(SocDescriptor, SocDescriptorBlackholeNoLogicalForHarvestedCores) {
-    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"), 1);
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"), true, 1);
 
     EXPECT_THROW(soc_desc.get_harvested_cores(CoreType::TENSIX, CoordSystem::LOGICAL), std::runtime_error);
 

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -14,7 +14,7 @@ using namespace tt::umd;
 
 // Test soc descriptor API for Wormhole when there is no harvesting.
 TEST(SocDescriptor, SocDescriptorGrayskullNoHarvesting) {
-    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"));
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), false);
 
     const std::vector<tt_xy_pair> grayskull_tensix_cores = tt::umd::grayskull::TENSIX_CORES;
 
@@ -35,7 +35,7 @@ TEST(SocDescriptor, SocDescriptorGrayskullOneRowHarvesting) {
     const std::vector<tt_xy_pair> grayskull_tensix_cores = tt::umd::grayskull::TENSIX_CORES;
     const size_t harvesting_mask = (1 << 0);
 
-    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), harvesting_mask);
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), false, harvesting_mask);
 
     const std::vector<CoreCoord> tensix_cores = soc_desc.get_cores(CoreType::TENSIX);
 
@@ -58,7 +58,7 @@ TEST(SocDescriptor, SocDescriptorGrayskullOneRowHarvesting) {
 
 // Test soc descriptor API for getting DRAM cores.
 TEST(SocDescriptor, SocDescriptorGrayskullDRAM) {
-    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"));
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), false);
 
     const std::vector<std::vector<CoreCoord>> dram_cores = soc_desc.get_dram_cores();
 
@@ -70,7 +70,7 @@ TEST(SocDescriptor, SocDescriptorGrayskullDRAM) {
 
 // Test soc descriptor API for Wormhole when there is no harvesting.
 TEST(SocDescriptor, SocDescriptorWormholeNoHarvesting) {
-    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"));
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), true);
 
     const std::vector<tt_xy_pair> wormhole_tensix_cores = tt::umd::wormhole::TENSIX_CORES;
 
@@ -87,7 +87,7 @@ TEST(SocDescriptor, SocDescriptorWormholeNoHarvesting) {
 
 // Test soc descriptor API for getting DRAM cores.
 TEST(SocDescriptor, SocDescriptorWormholeDRAM) {
-    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"));
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), true);
 
     const std::vector<std::vector<CoreCoord>> dram_cores = soc_desc.get_dram_cores();
 
@@ -103,7 +103,7 @@ TEST(SocDescriptor, SocDescriptorWormholeOneRowHarvesting) {
     const std::vector<tt_xy_pair> wormhole_tensix_cores = tt::umd::wormhole::TENSIX_CORES;
     const size_t harvesting_mask = (1 << 0);
 
-    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), harvesting_mask);
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), true, harvesting_mask);
 
     const std::vector<CoreCoord> tensix_cores = soc_desc.get_cores(CoreType::TENSIX);
 
@@ -126,7 +126,7 @@ TEST(SocDescriptor, SocDescriptorWormholeOneRowHarvesting) {
 
 // Test ETH translation from logical to physical coordinates.
 TEST(SocDescriptor, SocDescriptorWormholeETHLogicalToPhysical) {
-    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"));
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), true);
 
     const std::vector<tt_xy_pair>& wormhole_eth_cores = tt::umd::wormhole::ETH_CORES;
     const tt_xy_pair eth_grid_size = soc_desc.get_grid_size(CoreType::ETH);
@@ -165,7 +165,7 @@ TEST(SocDescriptor, SocDescriptorBlackholeETHHarvesting) {
         }
 
         tt_SocDescriptor soc_desc(
-            test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_local.yaml"), 0, 0, eth_harvesting_mask);
+            test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_local.yaml"), true, 0, 0, eth_harvesting_mask);
 
         const std::vector<CoreCoord> eth_cores = soc_desc.get_cores(CoreType::ETH);
 
@@ -193,7 +193,7 @@ TEST(SocDescriptor, SocDescriptorBlackholeETHHarvesting) {
 
 // Test soc descriptor API for Blackhole when there is no harvesting.
 TEST(SocDescriptor, SocDescriptorBlackholeNoHarvesting) {
-    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"));
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), true);
 
     const std::vector<tt_xy_pair> blackhole_tensix_cores = tt::umd::blackhole::TENSIX_CORES;
 
@@ -213,7 +213,7 @@ TEST(SocDescriptor, SocDescriptorBlackholeOneRowHarvesting) {
     const tt_xy_pair blackhole_tensix_grid_size = tt::umd::blackhole::TENSIX_GRID_SIZE;
     const std::vector<tt_xy_pair> blackhole_tensix_cores = tt::umd::blackhole::TENSIX_CORES;
 
-    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), 1);
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), true, 1);
 
     const std::vector<CoreCoord> tensix_cores = soc_desc.get_cores(CoreType::TENSIX);
 
@@ -239,7 +239,7 @@ TEST(SocDescriptor, SocDescriptorBlackholeOneRowHarvesting) {
 
 // Test soc descriptor API for getting DRAM cores.
 TEST(SocDescriptor, SocDescriptorBlackholeDRAM) {
-    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"));
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), true);
 
     const std::vector<std::vector<CoreCoord>> dram_cores = soc_desc.get_dram_cores();
 
@@ -257,7 +257,7 @@ TEST(SocDescriptor, SocDescriptorBlackholeDRAMHarvesting) {
     const size_t num_dram_banks = tt::umd::blackhole::NUM_DRAM_BANKS;
     const size_t num_noc_ports_per_bank = tt::umd::blackhole::NUM_NOC_PORTS_PER_DRAM_BANK;
 
-    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), 0, 1);
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), true, 0, 1);
 
     const std::vector<CoreCoord> tensix_cores = soc_desc.get_cores(CoreType::TENSIX);
 
@@ -287,7 +287,7 @@ TEST(SocDescriptor, SocDescriptorBlackholeDRAMHarvesting) {
 }
 
 TEST(SocDescriptor, CustomSocDescriptor) {
-    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_simulation_1x2.yaml"), 0, 0);
+    tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_simulation_1x2.yaml"), true, 0, 0);
 
     const CoreCoord tensix_core_01 = CoreCoord(0, 1, CoreType::TENSIX, CoordSystem::PHYSICAL);
     const CoreCoord tensix_core_01_virtual = soc_desc.translate_coord_to(tensix_core_01, CoordSystem::VIRTUAL);
@@ -446,4 +446,29 @@ TEST(SocDescriptor, SocDescriptorBlackholeNoLogicalForHarvestedCores) {
     EXPECT_THROW(soc_desc.get_harvested_cores(CoreType::DRAM, CoordSystem::LOGICAL), std::runtime_error);
 
     EXPECT_THROW(soc_desc.get_harvested_cores(CoreType::ETH, CoordSystem::LOGICAL), std::runtime_error);
+}
+
+TEST(SocDescriptor, NocTranslation) {
+    // Test when noc translation is disabled.
+    {
+        tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), false, 1);
+
+        const CoreCoord tensix_core = CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::PHYSICAL);
+        const CoreCoord tensix_core_virtual = soc_desc.translate_coord_to(tensix_core, CoordSystem::VIRTUAL);
+        const CoreCoord tensix_core_translated = soc_desc.translate_coord_to(tensix_core, CoordSystem::TRANSLATED);
+
+        EXPECT_EQ((tt_xy_pair)tensix_core_translated, (tt_xy_pair)tensix_core);
+        EXPECT_NE((tt_xy_pair)tensix_core_translated, (tt_xy_pair)tensix_core_virtual);
+    }
+    // Test when noc translation is enabled.
+    {
+        tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), true, 1);
+
+        const CoreCoord tensix_core = CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::PHYSICAL);
+        const CoreCoord tensix_core_virtual = soc_desc.translate_coord_to(tensix_core, CoordSystem::VIRTUAL);
+        const CoreCoord tensix_core_translated = soc_desc.translate_coord_to(tensix_core, CoordSystem::TRANSLATED);
+
+        EXPECT_NE((tt_xy_pair)tensix_core_translated, (tt_xy_pair)tensix_core);
+        EXPECT_EQ((tt_xy_pair)tensix_core_translated, (tt_xy_pair)tensix_core_virtual);
+    }
 }

--- a/tests/api/test_tlb_manager.cpp
+++ b/tests/api/test_tlb_manager.cpp
@@ -29,7 +29,8 @@ TEST(ApiTLBManager, ManualTLBConfiguration) {
     }
 
     TLBManager* tlb_manager = tt_device->get_tlb_manager();
-    tt_SocDescriptor soc_desc = tt_SocDescriptor::get_soc_descriptor_path(tt_device->get_arch());
+    tt_SocDescriptor soc_desc = tt_SocDescriptor(
+        tt_SocDescriptor::get_soc_descriptor_path(tt_device->get_arch()), tt_device->get_arch() != tt::ARCH::GRAYSKULL);
 
     // TODO: This should be part of TTDevice interface, not Cluster or Chip.
     // Configure TLBs.

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -324,7 +324,7 @@ void run_data_broadcast_test(
 
 // L1 to L1 single chip
 TEST(GalaxyDataMovement, BroadcastData1) {
-    tt_SocDescriptor sdesc(test_utils::GetAbsPath(SOC_DESC_PATH));
+    tt_SocDescriptor sdesc(test_utils::GetAbsPath(SOC_DESC_PATH), true);
 
     tt_multichip_core_addr sender_core(4, tt_xy_pair(1, 1), 0x5000);
     std::vector<tt_multichip_core_addr> receiver_cores;
@@ -337,7 +337,7 @@ TEST(GalaxyDataMovement, BroadcastData1) {
 
 // L1 to L1 multi chip
 TEST(GalaxyDataMovement, BroadcastData2) {
-    tt_SocDescriptor sdesc(test_utils::GetAbsPath(SOC_DESC_PATH));
+    tt_SocDescriptor sdesc(test_utils::GetAbsPath(SOC_DESC_PATH), true);
 
     tt_multichip_core_addr sender_core(12, tt_xy_pair(1, 1), 0x5000);
     std::vector<tt_multichip_core_addr> receiver_cores;
@@ -363,7 +363,7 @@ TEST(GalaxyDataMovement, BroadcastData2) {
 
 // Dram to L1
 TEST(GalaxyDataMovement, BroadcastData3) {
-    tt_SocDescriptor sdesc(test_utils::GetAbsPath(SOC_DESC_PATH));
+    tt_SocDescriptor sdesc(test_utils::GetAbsPath(SOC_DESC_PATH), true);
 
     tt_multichip_core_addr sender_core(10, tt_xy_pair(0, 0), 0x20000);
     std::vector<tt_multichip_core_addr> receiver_cores;
@@ -377,7 +377,7 @@ TEST(GalaxyDataMovement, BroadcastData3) {
 
 // L1 to Dram
 TEST(GalaxyDataMovement, BroadcastData4) {
-    tt_SocDescriptor sdesc(test_utils::GetAbsPath(SOC_DESC_PATH));
+    tt_SocDescriptor sdesc(test_utils::GetAbsPath(SOC_DESC_PATH), true);
 
     tt_multichip_core_addr sender_core(17, tt_xy_pair(8, 8), 0x20000);
     std::vector<tt_multichip_core_addr> receiver_cores;
@@ -393,7 +393,7 @@ TEST(GalaxyDataMovement, BroadcastData4) {
 
 // Dram to Dram
 TEST(GalaxyDataMovement, BroadcastData5) {
-    tt_SocDescriptor sdesc(test_utils::GetAbsPath(SOC_DESC_PATH));
+    tt_SocDescriptor sdesc(test_utils::GetAbsPath(SOC_DESC_PATH), true);
 
     tt_multichip_core_addr sender_core(31, tt_xy_pair(2, 2), 0x20000);
     std::vector<tt_multichip_core_addr> receiver_cores;


### PR DESCRIPTION
### Issue
Related to #439 

### Description
The last missing feature of Coordinate Manager is noc_translation enabled feature. If this is disabled, translated coords will be same as physical coords.

### List of the changes
- Add bool noc_translation_enabled to CoordinateManager constructor
- Added default versions of translate-physical mapping, which do identity mapping.
- Added a test to test if this flag works
- The translation flag is now required, so added it explicitly to tests where needed.

### Testing
Added another test, existing CI tests.

### API Changes
There are no API changes in this PR.
