### PR TITLE
[Harvesting] Changed harvested_coord_translation to CoordinateManager translation

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -1195,7 +1195,7 @@ private:
         std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks);
     // Helper functions for translating chip coordinates.
     tt_xy_pair translate_to_api_coords(const chip_id_t chip, const tt::umd::CoreCoord core_coord) const;
-    // Most of the old APIs accept virtual coordinates, but we communicate with the device through translate
+    // Most of the old APIs accept virtual coordinates, but we communicate with the device through translated
     // coordinates. This is an internal helper function, until we switch the API to accept translated coordinates.
     tt_xy_pair translate_chip_coord_virtual_to_translated(const chip_id_t chip_id, const tt_xy_pair core) const;
 

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -1193,8 +1193,11 @@ private:
         const bool clean_system_resources,
         bool perform_harvesting,
         std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks);
-    // Helper function for translating chip coordinates.
+    // Helper functions for translating chip coordinates.
     tt_xy_pair translate_to_api_coords(const chip_id_t chip, const tt::umd::CoreCoord core_coord) const;
+    // Most of the old APIs accept virtual coordinates, but we communicate with the device through translate
+    // coordinates. This is an internal helper function, until we switch the API to accept translated coordinates.
+    tt_xy_pair translate_chip_coord_virtual_to_translated(const chip_id_t chip_id, const tt_xy_pair core) const;
 
     // State variables
     std::vector<tt::ARCH> archs_in_cluster = {};

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -3444,7 +3444,8 @@ tt_xy_pair Cluster::translate_to_api_coords(const chip_id_t chip, const tt::umd:
 }
 
 tt_xy_pair Cluster::translate_chip_coord_virtual_to_translated(const chip_id_t chip_id, const tt_xy_pair core) const {
-    return translate_chip_coord(chip_id, {core, CoreType::TENSIX, CoordSystem::VIRTUAL}, CoordSystem::TRANSLATED);
+    CoreCoord virtual_coord = get_soc_descriptor(chip_id).get_coord_at(core, CoordSystem::VIRTUAL);
+    return (tt_xy_pair)translate_chip_coord(chip_id, virtual_coord, CoordSystem::TRANSLATED);
 }
 
 }  // namespace tt::umd

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -3444,8 +3444,10 @@ tt_xy_pair Cluster::translate_to_api_coords(const chip_id_t chip, const tt::umd:
 }
 
 tt_xy_pair Cluster::translate_chip_coord_virtual_to_translated(const chip_id_t chip_id, const tt_xy_pair core) const {
-    CoreCoord virtual_coord = get_soc_descriptor(chip_id).get_coord_at(core, CoordSystem::VIRTUAL);
-    return (tt_xy_pair)translate_chip_coord(chip_id, virtual_coord, CoordSystem::TRANSLATED);
+    CoordSystem coord_system = arch_name == tt::ARCH::GRAYSKULL ? CoordSystem::PHYSICAL : CoordSystem::VIRTUAL;
+    CoreCoord core_coord = get_soc_descriptor(chip_id).get_coord_at(core, coord_system);
+    auto translated_coord = get_soc_descriptor(chip_id).translate_coord_to(core_coord, CoordSystem::TRANSLATED);
+    return translated_coord;
 }
 
 }  // namespace tt::umd

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1007,12 +1007,10 @@ void Cluster::broadcast_pcie_tensix_risc_reset(chip_id_t chip_id, const TensixSo
     auto [soft_reset_reg, _] = tt_device->set_dynamic_tlb_broadcast(
         architecture_implementation->get_reg_tlb(),
         architecture_implementation->get_tensix_soft_reset_addr(),
-        translate_chip_coord_virtual_to_translated(chip_id, tt_xy_pair(0, 0)),
-        translate_chip_coord_virtual_to_translated(
-            chip_id,
-            tt_xy_pair(
-                architecture_implementation->get_grid_size_x() - 1,
-                architecture_implementation->get_grid_size_y() - 1 - num_rows_harvested.at(chip_id))),
+        harvested_coord_translation.at(chip_id).at(tt_xy_pair(0, 0)),
+        harvested_coord_translation.at(chip_id).at(tt_xy_pair(
+            architecture_implementation->get_grid_size_x() - 1,
+            architecture_implementation->get_grid_size_y() - 1 - num_rows_harvested.at(chip_id))),
         TLB_DATA::Posted);
     tt_device->write_regs(soft_reset_reg, 1, &valid);
     tt_driver_atomics::sfence();


### PR DESCRIPTION
### Issue
Related to #439 

### Description
Almost the last step which allows harvesting code to be removed from cluster

### List of the changes
Remove harvested_coord_translation in favour of core coordinates api.

### Testing
Existing tests

### API Changes
There are no API changes in this PR.
