### PR TITLE
Add router_cores and get_core_at

### DIFF
--- a/device/api/umd/device/blackhole_coordinate_manager.h
+++ b/device/api/umd/device/blackhole_coordinate_manager.h
@@ -25,7 +25,8 @@ public:
         const tt_xy_pair& arc_grid_size,
         const std::vector<tt_xy_pair>& arc_cores,
         const tt_xy_pair& pcie_grid_size,
-        const std::vector<tt_xy_pair>& pcie_cores);
+        const std::vector<tt_xy_pair>& pcie_cores,
+        const std::vector<tt_xy_pair>& router_cores);
 
 protected:
     void assert_coordinate_manager_constructor() override;

--- a/device/api/umd/device/blackhole_implementation.h
+++ b/device/api/umd/device/blackhole_implementation.h
@@ -61,7 +61,7 @@ enum class arc_message_type {
 // DEVICE_DATA
 const static tt_xy_pair TENSIX_GRID_SIZE = {14, 10};
 // clang-format off
-const static std::vector<tt_xy_pair> TENSIX_CORES = {{
+const static std::vector<tt_xy_pair> TENSIX_CORES = {
     {1, 2},   {2, 2},  {3, 2},  {4, 2},  {5, 2},  {6, 2},  {7, 2},  {10, 2},  {11, 2},  {12, 2},  {13, 2},  {14, 2},  {15, 2},  {16, 2},
     {1, 3},   {2, 3},  {3, 3},  {4, 3},  {5, 3},  {6, 3},  {7, 3},  {10, 3},  {11, 3},  {12, 3},  {13, 3},  {14, 3},  {15, 3},  {16, 3},
     {1, 4},   {2, 4},  {3, 4},  {4, 4},  {5, 4},  {6, 4},  {7, 4},  {10, 4},  {11, 4},  {12, 4},  {13, 4},  {14, 4},  {15, 4},  {16, 4},
@@ -72,7 +72,7 @@ const static std::vector<tt_xy_pair> TENSIX_CORES = {{
     {1, 9},   {2, 9},  {3, 9},  {4, 9},  {5, 9},  {6, 9},  {7, 9},  {10, 9},  {11, 9},  {12, 9},  {13, 9},  {14, 9},  {15, 9},  {16, 9},
     {1, 10}, {2, 10}, {3, 10}, {4, 10}, {5, 10}, {6, 10}, {7, 10}, {10, 10}, {11, 10}, {12, 10}, {13, 10}, {14, 10}, {15, 10}, {16, 10},
     {1, 11}, {2, 11}, {3, 11}, {4, 11}, {5, 11}, {6, 11}, {7, 11}, {10, 11}, {11, 11}, {12, 11}, {13, 11}, {14, 11}, {15, 11}, {16, 11},
-}};
+};
 // clang-format on
 
 const std::size_t NUM_DRAM_BANKS = 8;
@@ -80,20 +80,36 @@ const std::size_t NUM_NOC_PORTS_PER_DRAM_BANK = 3;
 static const tt_xy_pair DRAM_GRID_SIZE = {NUM_DRAM_BANKS, NUM_NOC_PORTS_PER_DRAM_BANK};
 // clang-format off
 static const std::vector<tt_xy_pair> DRAM_CORES = {
-    {
-        {0, 0},  {0, 1}, {0, 11},
-        {0, 2}, {0, 10},  {0, 3},
-        {0, 9},  {0, 4},  {0, 8},
-        {0, 5},  {0, 7},  {0, 6},
-        {9, 0},  {9, 1}, {9, 11},
-        {9, 2}, {9, 10},  {9, 3},
-        {9, 9},  {9, 4},  {9, 8},
-        {9, 5},  {9, 7},  {9, 6}}};
+    {0, 0},  {0, 1}, {0, 11},
+    {0, 2}, {0, 10},  {0, 3},
+    {0, 9},  {0, 4},  {0, 8},
+    {0, 5},  {0, 7},  {0, 6},
+    {9, 0},  {9, 1}, {9, 11},
+    {9, 2}, {9, 10},  {9, 3},
+    {9, 9},  {9, 4},  {9, 8},
+    {9, 5},  {9, 7},  {9, 6}};
 // clang-format on
-
 // TODO: DRAM locations should be deleted. We keep it for compatibility with
 // the existing code in clients which rely on DRAM_LOCATIONS.
 static const std::vector<tt_xy_pair> DRAM_LOCATIONS = DRAM_CORES;
+
+static const tt_xy_pair ETH_GRID_SIZE = {14, 1};
+static const std::vector<tt_xy_pair> ETH_CORES = {
+    {1, 1},
+    {2, 1},
+    {3, 1},
+    {4, 1},
+    {5, 1},
+    {6, 1},
+    {7, 1},
+    {10, 1},
+    {11, 1},
+    {12, 1},
+    {13, 1},
+    {14, 1},
+    {15, 1},
+    {16, 1}};
+static const std::vector<tt_xy_pair> ETH_LOCATIONS = ETH_CORES;
 
 static const tt_xy_pair ARC_GRID_SIZE = {1, 1};
 static const std::vector<tt_xy_pair> ARC_CORES = {{8, 0}};
@@ -104,23 +120,10 @@ static const std::vector<tt_xy_pair> PCIE_CORES_TYPE2 = {{{2, 0}}};
 static const std::vector<tt_xy_pair> PCI_LOCATIONS = PCIE_CORES_TYPE2;
 static const std::vector<tt_xy_pair> PCIE_CORES_TYPE1 = {{{11, 0}}};
 
-static const tt_xy_pair ETH_GRID_SIZE = {14, 1};
-static const std::vector<tt_xy_pair> ETH_CORES = {
-    {{1, 1},
-     {2, 1},
-     {3, 1},
-     {4, 1},
-     {5, 1},
-     {6, 1},
-     {7, 1},
-     {10, 1},
-     {11, 1},
-     {12, 1},
-     {13, 1},
-     {14, 1},
-     {15, 1},
-     {16, 1}}};
-static const std::vector<tt_xy_pair> ETH_LOCATIONS = ETH_CORES;
+static const std::vector<tt_xy_pair> ROUTER_CORES = {
+    {1, 0},  {2, 0}, {3, 0}, {4, 0}, {5, 0}, {6, 0}, {7, 0}, {10, 0}, {12, 0}, {13, 0}, {14, 0}, {15, 0},
+    {16, 0}, {8, 1}, {8, 2}, {8, 3}, {8, 4}, {8, 5}, {8, 6}, {8, 7},  {8, 8},  {8, 9},  {8, 10}, {8, 11}};
+
 // Return to std::array instead of std::vector once we get std::span support in C++20
 static const std::vector<uint32_t> T6_X_LOCATIONS = {1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13, 14, 15, 16};
 static const std::vector<uint32_t> T6_Y_LOCATIONS = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11};

--- a/device/api/umd/device/coordinate_manager.h
+++ b/device/api/umd/device/coordinate_manager.h
@@ -63,7 +63,8 @@ public:
         tt::ARCH arch, uint32_t tensix_harvesting_logical_layout);
 
     tt::umd::CoreCoord translate_coord_to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system);
-    tt::umd::CoreCoord get_coord_at(const tt_xy_pair& physical_pair, const CoordSystem coord_system);
+    tt::umd::CoreCoord translate_coord_to(
+        const tt_xy_pair core, const CoordSystem input_coord_system, const CoordSystem target_coord_system);
 
     std::vector<tt::umd::CoreCoord> get_cores(const CoreType core_type) const;
     tt_xy_pair get_grid_size(const CoreType core_type) const;
@@ -186,8 +187,13 @@ protected:
      */
     virtual void fill_arc_physical_translated_mapping() = 0;
 
+    // Maps full CoreCoord from any CoordSystem to physical coordinates.
     std::map<tt::umd::CoreCoord, tt_xy_pair> to_physical_map;
+    // Maps physical coordinates given a target CoordSystem to full CoreCoord.
     std::map<std::pair<tt_xy_pair, CoordSystem>, tt::umd::CoreCoord> from_physical_map;
+    // Maps coordinates in the designated CoordSystem to a full CoreCoord at that location holding the right CoreType.
+    // Doesn't include logical CoordSystem.
+    std::map<std::pair<tt_xy_pair, CoordSystem>, tt::umd::CoreCoord> to_core_type_map;
 
     // Whether NOC translation is enabled on chip.
     // This flag affects how Translated coords are calculated. If translation is enabled on the chip, than we can

--- a/device/api/umd/device/coordinate_manager.h
+++ b/device/api/umd/device/coordinate_manager.h
@@ -62,9 +62,9 @@ public:
     static uint32_t shuffle_tensix_harvesting_mask_to_noc0_coords(
         tt::ARCH arch, uint32_t tensix_harvesting_logical_layout);
 
-    tt::umd::CoreCoord translate_coord_to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system);
+    tt::umd::CoreCoord translate_coord_to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const;
     tt::umd::CoreCoord translate_coord_to(
-        const tt_xy_pair core, const CoordSystem input_coord_system, const CoordSystem target_coord_system);
+        const tt_xy_pair core, const CoordSystem input_coord_system, const CoordSystem target_coord_system) const;
 
     std::vector<tt::umd::CoreCoord> get_cores(const CoreType core_type) const;
     tt_xy_pair get_grid_size(const CoreType core_type) const;

--- a/device/api/umd/device/coordinate_manager.h
+++ b/device/api/umd/device/coordinate_manager.h
@@ -17,6 +17,9 @@
 
 class CoordinateManager {
 public:
+    CoordinateManager(CoordinateManager& other) = default;
+    virtual ~CoordinateManager() = default;
+
     /*
      * Creates a Coordinate Manager object.
      * Board type and is_chip_remote are used only for Blackhole, since PCIe cores are different
@@ -37,7 +40,8 @@ public:
         const tt_xy_pair& arc_grid_size,
         const std::vector<tt_xy_pair>& arc_cores,
         const tt_xy_pair& pcie_grid_size,
-        const std::vector<tt_xy_pair>& pcie_cores);
+        const std::vector<tt_xy_pair>& pcie_cores,
+        const std::vector<tt_xy_pair>& router_cores);
 
     static std::shared_ptr<CoordinateManager> create_coordinate_manager(
         tt::ARCH arch,
@@ -49,7 +53,6 @@ public:
         const bool is_chip_remote = false);
 
     static size_t get_num_harvested(const size_t harvesting_mask);
-
     static std::vector<size_t> get_harvested_indices(const size_t harvesting_mask);
 
     // Harvesting mask is reported by hardware in the order of physical layout. This function returns a more suitable
@@ -59,9 +62,8 @@ public:
     static uint32_t shuffle_tensix_harvesting_mask_to_noc0_coords(
         tt::ARCH arch, uint32_t tensix_harvesting_logical_layout);
 
-    CoordinateManager(CoordinateManager& other) = default;
-
     tt::umd::CoreCoord translate_coord_to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system);
+    tt::umd::CoreCoord get_coord_at(const tt_xy_pair& physical_pair, const CoordSystem coord_system);
 
     std::vector<tt::umd::CoreCoord> get_cores(const CoreType core_type) const;
     tt_xy_pair get_grid_size(const CoreType core_type) const;
@@ -69,12 +71,8 @@ public:
     std::vector<tt::umd::CoreCoord> get_harvested_cores(const CoreType core_type) const;
     tt_xy_pair get_harvested_grid_size(const CoreType core_type) const;
 
-    virtual ~CoordinateManager() = default;
-
     size_t get_tensix_harvesting_mask() const;
-
     size_t get_dram_harvesting_mask() const;
-
     size_t get_eth_harvesting_mask() const;
 
 private:
@@ -88,6 +86,7 @@ protected:
      * returned from create-ethernet-map, so each bit is responsible for one row of the actual physical
      * row of the tensix cores on the chip. Harvesting mask is shuffled in constructor to match the NOC
      * layout of the tensix cores.
+     * Router cores don't have a grid size, since they are not layed out in a regular fashion.
      */
     CoordinateManager(
         const bool noc_translation_enabled,
@@ -103,7 +102,8 @@ protected:
         const tt_xy_pair& arc_grid_size,
         const std::vector<tt_xy_pair>& arc_cores,
         const tt_xy_pair& pcie_grid_size,
-        const std::vector<tt_xy_pair>& pcie_cores);
+        const std::vector<tt_xy_pair>& pcie_cores,
+        const std::vector<tt_xy_pair>& router_cores);
 
     void initialize();
 
@@ -114,6 +114,7 @@ protected:
     virtual void translate_eth_coords();
     virtual void translate_arc_coords();
     virtual void translate_pcie_coords();
+    virtual void translate_router_coords();
 
     void identity_map_physical_cores();
     void add_core_translation(const tt::umd::CoreCoord& core_coord, const tt_xy_pair& physical_pair);
@@ -212,4 +213,7 @@ protected:
 
     tt_xy_pair pcie_grid_size;
     const std::vector<tt_xy_pair> pcie_cores;
+
+    // Router cores don't have a grid size, since they are not layed out in a regular fashion.
+    const std::vector<tt_xy_pair> router_cores;
 };

--- a/device/api/umd/device/grayskull_coordinate_manager.h
+++ b/device/api/umd/device/grayskull_coordinate_manager.h
@@ -24,7 +24,8 @@ public:
         const tt_xy_pair& arc_grid_size,
         const std::vector<tt_xy_pair>& arc_cores,
         const tt_xy_pair& pcie_grid_size,
-        const std::vector<tt_xy_pair>& pcie_cores);
+        const std::vector<tt_xy_pair>& pcie_cores,
+        const std::vector<tt_xy_pair>& router_cores);
 
 protected:
     void fill_tensix_physical_translated_mapping() override;

--- a/device/api/umd/device/grayskull_implementation.h
+++ b/device/api/umd/device/grayskull_implementation.h
@@ -105,7 +105,7 @@ enum class arc_message_type {
 
 // DEVICE_DATA
 static const tt_xy_pair TENSIX_GRID_SIZE = {12, 10};
-static const std::vector<tt_xy_pair> TENSIX_CORES = {{
+static const std::vector<tt_xy_pair> TENSIX_CORES = {
     {1, 1},  {2, 1},  {3, 1},  {4, 1},  {5, 1},  {6, 1},  {7, 1},  {8, 1},  {9, 1},  {10, 1},  {11, 1},  {12, 1},
     {1, 2},  {2, 2},  {3, 2},  {4, 2},  {5, 2},  {6, 2},  {7, 2},  {8, 2},  {9, 2},  {10, 2},  {11, 2},  {12, 2},
     {1, 3},  {2, 3},  {3, 3},  {4, 3},  {5, 3},  {6, 3},  {7, 3},  {8, 3},  {9, 3},  {10, 3},  {11, 3},  {12, 3},
@@ -116,26 +116,32 @@ static const std::vector<tt_xy_pair> TENSIX_CORES = {{
     {1, 9},  {2, 9},  {3, 9},  {4, 9},  {5, 9},  {6, 9},  {7, 9},  {8, 9},  {9, 9},  {10, 9},  {11, 9},  {12, 9},
     {1, 10}, {2, 10}, {3, 10}, {4, 10}, {5, 10}, {6, 10}, {7, 10}, {8, 10}, {9, 10}, {10, 10}, {11, 10}, {12, 10},
     {1, 11}, {2, 11}, {3, 11}, {4, 11}, {5, 11}, {6, 11}, {7, 11}, {8, 11}, {9, 11}, {10, 11}, {11, 11}, {12, 11},
-}};
+};
 
 const std::size_t NUM_DRAM_BANKS = 8;
 const std::size_t NUM_NOC_PORTS_PER_DRAM_BANK = 1;
 static const tt_xy_pair DRAM_GRID_SIZE = {NUM_DRAM_BANKS, NUM_NOC_PORTS_PER_DRAM_BANK};
-static const std::vector<tt_xy_pair> DRAM_CORES = {{{1, 0}, {1, 6}, {4, 0}, {4, 6}, {7, 0}, {7, 6}, {10, 0}, {10, 6}}};
-
-static const tt_xy_pair ETH_GRID_SIZE = {0, 0};
-static const std::vector<tt_xy_pair> ETH_CORES = {};
+static const std::vector<tt_xy_pair> DRAM_CORES = {{1, 0}, {1, 6}, {4, 0}, {4, 6}, {7, 0}, {7, 6}, {10, 0}, {10, 6}};
 // TODO: DRAM locations should be deleted. We keep it for compatibility with
 // the existing code in clients which rely on DRAM_LOCATIONS.
 static const std::vector<tt_xy_pair> DRAM_LOCATIONS = DRAM_CORES;
+
+static const tt_xy_pair ETH_GRID_SIZE = {0, 0};
+static const std::vector<tt_xy_pair> ETH_CORES = {};
+static const std::array<xy_pair, 0> ETH_LOCATIONS = {};
+
 static const tt_xy_pair ARC_GRID_SIZE = {1, 1};
-static const std::vector<tt_xy_pair> ARC_CORES = {{{0, 2}}};
+static const std::vector<tt_xy_pair> ARC_CORES = {{0, 2}};
 static const std::vector<tt_xy_pair> ARC_LOCATIONS = ARC_CORES;
 
 static const tt_xy_pair PCIE_GRID_SIZE = {1, 1};
-static const std::vector<tt_xy_pair> PCIE_CORES = {{{0, 4}}};
+static const std::vector<tt_xy_pair> PCIE_CORES = {{0, 4}};
 static const std::vector<tt_xy_pair> PCI_LOCATIONS = PCIE_CORES;
-static const std::array<xy_pair, 0> ETH_LOCATIONS = {};
+
+static const std::vector<tt_xy_pair> ROUTER_CORES = {
+    {0, 0}, {0, 11}, {0, 1}, {0, 10}, {0, 9}, {0, 3},  {0, 8},  {0, 7}, {0, 5}, {0, 6}, {12, 0}, {11, 0}, {2, 0},
+    {3, 0}, {9, 0},  {8, 0}, {5, 0},  {6, 0}, {12, 6}, {11, 6}, {2, 6}, {3, 6}, {9, 6}, {8, 6},  {5, 6},  {6, 6}};
+
 // Return to std::array instead of std::vector once we get std::span support in C++20
 static const std::vector<uint32_t> T6_X_LOCATIONS = {12, 1, 11, 2, 10, 3, 9, 4, 8, 5, 7, 6};
 static const std::vector<uint32_t> T6_Y_LOCATIONS = {11, 1, 10, 2, 9, 3, 8, 4, 7, 5};

--- a/device/api/umd/device/tt_core_coordinates.h
+++ b/device/api/umd/device/tt_core_coordinates.h
@@ -43,7 +43,7 @@ enum class CoordSystem : std::uint8_t {
     TRANSLATED,
 };
 
-static inline std::string to_str(CoreType core_type) {
+static inline std::string to_str(const CoreType core_type) {
     switch (core_type) {
         case CoreType::ARC:
             return "ARC";
@@ -93,7 +93,7 @@ struct CoreCoord : public tt_xy_pair {
     CoreCoord(const size_t x, const size_t y, const CoreType type, const CoordSystem coord_system) :
         tt_xy_pair(x, y), core_type(type), coord_system(coord_system) {}
 
-    CoreCoord(tt_xy_pair core, const CoreType type, const CoordSystem coord_system) :
+    CoreCoord(const tt_xy_pair core, const CoreType type, const CoordSystem coord_system) :
         tt_xy_pair(core), core_type(type), coord_system(coord_system) {}
 
     CoreType core_type;

--- a/device/api/umd/device/tt_core_coordinates.h
+++ b/device/api/umd/device/tt_core_coordinates.h
@@ -70,7 +70,7 @@ static inline std::string to_str(const CoreType core_type) {
     }
 }
 
-static inline std::string to_str(CoordSystem coord_system) {
+static inline std::string to_str(const CoordSystem coord_system) {
     switch (coord_system) {
         case CoordSystem::LOGICAL:
             return "LOGICAL";

--- a/device/api/umd/device/tt_core_coordinates.h
+++ b/device/api/umd/device/tt_core_coordinates.h
@@ -125,11 +125,11 @@ struct CoreCoord : public tt_xy_pair {
         }
         return coord_system < o.coord_system;
     }
-};
 
-static inline std::string to_str(const CoreCoord& core_coord) {
-    return "CoreCoord: (" + std::to_string(core_coord.x) + ", " + std::to_string(core_coord.y) + ", " +
-           to_str(core_coord.core_type) + ", " + to_str(core_coord.coord_system) + ")";
+    std::string to_str() const {
+        return "CoreCoord: (" + std::to_string(x) + ", " + std::to_string(y) + ", " + ::to_str(core_type) + ", " +
+               ::to_str(coord_system) + ")";
+    }
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_core_coordinates.h
+++ b/device/api/umd/device/tt_core_coordinates.h
@@ -43,6 +43,48 @@ enum class CoordSystem : std::uint8_t {
     TRANSLATED,
 };
 
+static inline std::string to_str(CoreType core_type) {
+    switch (core_type) {
+        case CoreType::ARC:
+            return "ARC";
+        case CoreType::DRAM:
+            return "DRAM";
+        case CoreType::ACTIVE_ETH:
+            return "ACTIVE_ETH";
+        case CoreType::IDLE_ETH:
+            return "IDLE_ETH";
+        case CoreType::PCIE:
+            return "PCIE";
+        case CoreType::TENSIX:
+            return "TENSIX";
+        case CoreType::ROUTER_ONLY:
+            return "ROUTER_ONLY";
+        case CoreType::HARVESTED:
+            return "HARVESTED";
+        case CoreType::ETH:
+            return "ETH";
+        case CoreType::WORKER:
+            return "WORKER";
+        default:
+            return "UNKNOWN";
+    }
+}
+
+static inline std::string to_str(CoordSystem coord_system) {
+    switch (coord_system) {
+        case CoordSystem::LOGICAL:
+            return "LOGICAL";
+        case CoordSystem::PHYSICAL:
+            return "PHYSICAL";
+        case CoordSystem::VIRTUAL:
+            return "VIRTUAL";
+        case CoordSystem::TRANSLATED:
+            return "TRANSLATED";
+        default:
+            return "UNKNOWN";
+    }
+}
+
 namespace tt::umd {
 
 struct CoreCoord : public tt_xy_pair {
@@ -50,6 +92,9 @@ struct CoreCoord : public tt_xy_pair {
 
     CoreCoord(const size_t x, const size_t y, const CoreType type, const CoordSystem coord_system) :
         tt_xy_pair(x, y), core_type(type), coord_system(coord_system) {}
+
+    CoreCoord(tt_xy_pair core, const CoreType type, const CoordSystem coord_system) :
+        tt_xy_pair(core), core_type(type), coord_system(coord_system) {}
 
     CoreType core_type;
     CoordSystem coord_system;
@@ -80,6 +125,11 @@ struct CoreCoord : public tt_xy_pair {
         }
         return coord_system < o.coord_system;
     }
+};
+
+static inline std::string to_str(const CoreCoord& core_coord) {
+    return "CoreCoord: (" + std::to_string(core_coord.x) + ", " + std::to_string(core_coord.y) + ", " +
+           to_str(core_coord.core_type) + ", " + to_str(core_coord.coord_system) + ")";
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -102,6 +102,7 @@ public:
     std::unordered_map<tt_xy_pair, int> ethernet_core_channel_map;
     std::vector<std::size_t> trisc_sizes;  // Most of software stack assumes same trisc size for whole chip..
     std::string device_descriptor_file_path = std::string("");
+    std::vector<tt_xy_pair> router_cores;
 
     int overlay_version;
     int unpacker_version;

--- a/device/api/umd/device/wormhole_coordinate_manager.h
+++ b/device/api/umd/device/wormhole_coordinate_manager.h
@@ -25,7 +25,8 @@ public:
         const tt_xy_pair& arc_grid_size,
         const std::vector<tt_xy_pair>& arc_cores,
         const tt_xy_pair& pcie_grid_size,
-        const std::vector<tt_xy_pair>& pcie_cores);
+        const std::vector<tt_xy_pair>& pcie_cores,
+        const std::vector<tt_xy_pair>& router_cores);
 
 protected:
     void fill_tensix_physical_translated_mapping() override;

--- a/device/api/umd/device/wormhole_implementation.h
+++ b/device/api/umd/device/wormhole_implementation.h
@@ -104,7 +104,7 @@ enum class arc_message_type {
 // DEVICE_DATA
 static const tt_xy_pair TENSIX_GRID_SIZE = {8, 10};
 // clang-format off
-static const std::vector<tt_xy_pair> TENSIX_CORES = {{
+static const std::vector<tt_xy_pair> TENSIX_CORES = {
     {1, 1},   {2, 1},  {3, 1},  {4, 1},  {6, 1},  {7, 1},  {8, 1},  {9, 1},
     {1, 2},   {2, 2},  {3, 2},  {4, 2},  {6, 2},  {7, 2},  {8, 2},  {9, 2},
     {1, 3},   {2, 3},  {3, 3},  {4, 3},  {6, 3},  {7, 3},  {8, 3},  {9, 3},
@@ -115,7 +115,7 @@ static const std::vector<tt_xy_pair> TENSIX_CORES = {{
     {1, 9},   {2, 9},  {3, 9},  {4, 9},  {6, 9},  {7, 9},  {8, 9},  {9, 9},
     {1, 10}, {2, 10}, {3, 10}, {4, 10}, {6, 10}, {7, 10}, {8, 10}, {9, 10},
     {1, 11}, {2, 11}, {3, 11}, {4, 11}, {6, 11}, {7, 11}, {8, 11}, {9, 11},
-}};
+};
 // clang-format on
 
 static const std::size_t NUM_DRAM_BANKS = 6;
@@ -123,25 +123,16 @@ static const std::size_t NUM_NOC_PORTS_PER_DRAM_BANK = 3;
 static const tt_xy_pair DRAM_GRID_SIZE = {NUM_DRAM_BANKS, NUM_NOC_PORTS_PER_DRAM_BANK};
 // clang-format off
 static const std::vector<tt_xy_pair> DRAM_CORES = {
-    {{0, 0}, {0, 1}, {0, 11},
-     {0, 5}, {0, 6},  {0, 7},
-     {5, 0}, {5, 1}, {5, 11},
-     {5, 2}, {5, 9}, {5, 10},
-     {5, 3}, {5, 4},  {5, 8},
-     {5, 5}, {5, 6},  {5, 7}}};
+    {0, 0}, {0, 1}, {0, 11},
+    {0, 5}, {0, 6},  {0, 7},
+    {5, 0}, {5, 1}, {5, 11},
+    {5, 2}, {5, 9}, {5, 10},
+    {5, 3}, {5, 4},  {5, 8},
+    {5, 5}, {5, 6},  {5, 7}};
 // clang-format on
-
 // TODO: DRAM locations should be deleted. We keep it for compatibility with
 // the existing code in clients which rely on DRAM_LOCATIONS.
 static const std::vector<tt_xy_pair> DRAM_LOCATIONS = DRAM_CORES;
-
-static const tt_xy_pair ARC_GRID_SIZE = {1, 1};
-static const std::vector<tt_xy_pair> ARC_CORES = {{0, 10}};
-static const std::vector<tt_xy_pair> ARC_LOCATIONS = ARC_CORES;
-
-static const tt_xy_pair PCIE_GRID_SIZE = {1, 1};
-static const std::vector<tt_xy_pair> PCIE_CORES = {{{0, 3}}};
-static const std::vector<tt_xy_pair> PCI_LOCATIONS = PCIE_CORES;
 
 static const tt_xy_pair ETH_GRID_SIZE = {8, 2};
 static const std::vector<tt_xy_pair> ETH_CORES = {
@@ -162,6 +153,17 @@ static const std::vector<tt_xy_pair> ETH_CORES = {
      {8, 6},
      {9, 6}}};
 static const std::vector<tt_xy_pair> ETH_LOCATIONS = ETH_CORES;
+
+static const tt_xy_pair ARC_GRID_SIZE = {1, 1};
+static const std::vector<tt_xy_pair> ARC_CORES = {{0, 10}};
+static const std::vector<tt_xy_pair> ARC_LOCATIONS = ARC_CORES;
+
+static const tt_xy_pair PCIE_GRID_SIZE = {1, 1};
+static const std::vector<tt_xy_pair> PCIE_CORES = {{{0, 3}}};
+static const std::vector<tt_xy_pair> PCI_LOCATIONS = PCIE_CORES;
+
+static const std::vector<tt_xy_pair> ROUTER_CORES = {{0, 2}, {0, 4}, {0, 8}, {0, 9}};
+
 // Return to std::array instead of std::vector once we get std::span support in C++20
 static const std::vector<uint32_t> T6_X_LOCATIONS = {1, 2, 3, 4, 6, 7, 8, 9};
 static const std::vector<uint32_t> T6_Y_LOCATIONS = {1, 2, 3, 4, 5, 7, 8, 9, 10, 11};

--- a/device/blackhole/blackhole_coordinate_manager.cpp
+++ b/device/blackhole/blackhole_coordinate_manager.cpp
@@ -23,7 +23,8 @@ BlackholeCoordinateManager::BlackholeCoordinateManager(
     const tt_xy_pair& arc_grid_size,
     const std::vector<tt_xy_pair>& arc_cores,
     const tt_xy_pair& pcie_grid_size,
-    const std::vector<tt_xy_pair>& pcie_cores) :
+    const std::vector<tt_xy_pair>& pcie_cores,
+    const std::vector<tt_xy_pair>& router_cores) :
     CoordinateManager(
         noc_translation_enabled,
         tensix_grid_size,
@@ -38,7 +39,8 @@ BlackholeCoordinateManager::BlackholeCoordinateManager(
         arc_grid_size,
         arc_cores,
         pcie_grid_size,
-        pcie_cores) {
+        pcie_cores,
+        router_cores) {
     initialize();
 }
 

--- a/device/coordinate_manager.cpp
+++ b/device/coordinate_manager.cpp
@@ -102,12 +102,13 @@ void CoordinateManager::identity_map_physical_cores() {
     }
 }
 
-CoreCoord CoordinateManager::translate_coord_to(const CoreCoord core_coord, const CoordSystem target_coord_system) {
+CoreCoord CoordinateManager::translate_coord_to(
+    const CoreCoord core_coord, const CoordSystem target_coord_system) const {
     return from_physical_map.at({to_physical_map.at(core_coord), target_coord_system});
 }
 
 CoreCoord CoordinateManager::translate_coord_to(
-    const tt_xy_pair core, const CoordSystem input_coord_system, const CoordSystem target_coord_system) {
+    const tt_xy_pair core, const CoordSystem input_coord_system, const CoordSystem target_coord_system) const {
     log_assert(input_coord_system != CoordSystem::LOGICAL, "Coordinate is ambiguous for logical system.");
 
     auto coord_it = to_core_type_map.find({core, input_coord_system});

--- a/device/grayskull/grayskull_coordinate_manager.cpp
+++ b/device/grayskull/grayskull_coordinate_manager.cpp
@@ -22,7 +22,8 @@ GrayskullCoordinateManager::GrayskullCoordinateManager(
     const tt_xy_pair& arc_grid_size,
     const std::vector<tt_xy_pair>& arc_cores,
     const tt_xy_pair& pcie_grid_size,
-    const std::vector<tt_xy_pair>& pcie_cores) :
+    const std::vector<tt_xy_pair>& pcie_cores,
+    const std::vector<tt_xy_pair>& router_cores) :
     CoordinateManager(
         false,
         tensix_grid_size,
@@ -37,7 +38,8 @@ GrayskullCoordinateManager::GrayskullCoordinateManager(
         arc_grid_size,
         arc_cores,
         pcie_grid_size,
-        pcie_cores) {
+        pcie_cores,
+        router_cores) {
     initialize();
 }
 

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -171,6 +171,7 @@ void tt_SocDescriptor::load_core_descriptors_from_device_descriptor(YAML::Node &
         core_descriptor.coord = format_node(core_string);
         core_descriptor.type = CoreType::ROUTER_ONLY;
         cores.insert({core_descriptor.coord, core_descriptor});
+        router_cores.push_back(core_descriptor.coord);
     }
 }
 
@@ -216,7 +217,8 @@ void tt_SocDescriptor::create_coordinate_manager(
         arc_grid_size,
         arc_cores,
         pcie_grid_size,
-        pcie_cores);
+        pcie_cores,
+        router_cores);
     get_cores_and_grid_size_from_coordinate_manager();
 }
 

--- a/device/wormhole/wormhole_coordinate_manager.cpp
+++ b/device/wormhole/wormhole_coordinate_manager.cpp
@@ -21,7 +21,8 @@ WormholeCoordinateManager::WormholeCoordinateManager(
     const tt_xy_pair& arc_grid_size,
     const std::vector<tt_xy_pair>& arc_cores,
     const tt_xy_pair& pcie_grid_size,
-    const std::vector<tt_xy_pair>& pcie_cores) :
+    const std::vector<tt_xy_pair>& pcie_cores,
+    const std::vector<tt_xy_pair>& router_cores) :
     CoordinateManager(
         noc_translation_enabled,
         tensix_grid_size,
@@ -36,7 +37,8 @@ WormholeCoordinateManager::WormholeCoordinateManager(
         arc_grid_size,
         arc_cores,
         pcie_grid_size,
-        pcie_cores) {
+        pcie_cores,
+        router_cores) {
     initialize();
 }
 

--- a/tests/api/test_core_coord_translation_bh.cpp
+++ b/tests/api/test_core_coord_translation_bh.cpp
@@ -661,15 +661,25 @@ TEST(CoordinateManager, CoordinateManagerBlackholeHarvestingShuffle) {
     }
 }
 
-TEST(CoordinateManager, CoordinateManagerBlackholeGettingCoreType) {
+TEST(CoordinateManager, CoordinateManagerBlackholeTranslationWithoutCoreType) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true);
 
-    EXPECT_EQ(coordinate_manager->get_coord_at({0, 0}, CoordSystem::PHYSICAL).core_type, CoreType::DRAM);
-    EXPECT_EQ(coordinate_manager->get_coord_at({0, 0}, CoordSystem::VIRTUAL).core_type, CoreType::DRAM);
-    EXPECT_EQ(coordinate_manager->get_coord_at({2, 2}, CoordSystem::PHYSICAL).core_type, CoreType::TENSIX);
+    EXPECT_EQ(
+        coordinate_manager->translate_coord_to({0, 0}, CoordSystem::PHYSICAL, CoordSystem::PHYSICAL).core_type,
+        CoreType::DRAM);
+    EXPECT_EQ(
+        coordinate_manager->translate_coord_to({0, 0}, CoordSystem::VIRTUAL, CoordSystem::PHYSICAL).core_type,
+        CoreType::DRAM);
+    EXPECT_EQ(
+        coordinate_manager->translate_coord_to({2, 2}, CoordSystem::PHYSICAL, CoordSystem::PHYSICAL).core_type,
+        CoreType::TENSIX);
     // Not allowed for logical coord system.
-    EXPECT_THROW(coordinate_manager->get_coord_at({0, 0}, CoordSystem::LOGICAL), std::runtime_error);
+    EXPECT_THROW(
+        coordinate_manager->translate_coord_to({0, 0}, CoordSystem::LOGICAL, CoordSystem::PHYSICAL),
+        std::runtime_error);
     // Throws if nothing is located at this coordinate.
-    EXPECT_THROW(coordinate_manager->get_coord_at({100, 100}, CoordSystem::PHYSICAL), std::runtime_error);
+    EXPECT_THROW(
+        coordinate_manager->translate_coord_to({100, 100}, CoordSystem::PHYSICAL, CoordSystem::PHYSICAL),
+        std::runtime_error);
 }

--- a/tests/api/test_core_coord_translation_bh.cpp
+++ b/tests/api/test_core_coord_translation_bh.cpp
@@ -660,3 +660,16 @@ TEST(CoordinateManager, CoordinateManagerBlackholeHarvestingShuffle) {
         EXPECT_EQ(harvesting_mask, 1 << i);
     }
 }
+
+TEST(CoordinateManager, CoordinateManagerBlackholeGettingCoreType) {
+    std::shared_ptr<CoordinateManager> coordinate_manager =
+        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE);
+
+    EXPECT_EQ(coordinate_manager->get_coord_at({0, 0}, CoordSystem::PHYSICAL).core_type, CoreType::DRAM);
+    EXPECT_EQ(coordinate_manager->get_coord_at({0, 0}, CoordSystem::VIRTUAL).core_type, CoreType::DRAM);
+    EXPECT_EQ(coordinate_manager->get_coord_at({2, 2}, CoordSystem::PHYSICAL).core_type, CoreType::TENSIX);
+    // Not allowed for logical coord system.
+    EXPECT_THROW(coordinate_manager->get_coord_at({0, 0}, CoordSystem::LOGICAL), std::runtime_error);
+    // Throws if nothing is located at this coordinate.
+    EXPECT_THROW(coordinate_manager->get_coord_at({100, 100}, CoordSystem::PHYSICAL), std::runtime_error);
+}

--- a/tests/api/test_core_coord_translation_gs.cpp
+++ b/tests/api/test_core_coord_translation_gs.cpp
@@ -335,15 +335,25 @@ TEST(CoordinateManager, CoordinateManagerGrayskullHarvestingShuffle) {
     }
 }
 
-TEST(CoordinateManager, CoordinateManagerGrayskullGettingCoreType) {
+TEST(CoordinateManager, CoordinateManagerGrayskullTranslationWithoutCoreType) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL, false);
 
-    EXPECT_EQ(coordinate_manager->get_coord_at({0, 0}, CoordSystem::PHYSICAL).core_type, CoreType::ROUTER_ONLY);
-    EXPECT_EQ(coordinate_manager->get_coord_at({0, 0}, CoordSystem::VIRTUAL).core_type, CoreType::ROUTER_ONLY);
-    EXPECT_EQ(coordinate_manager->get_coord_at({2, 2}, CoordSystem::PHYSICAL).core_type, CoreType::TENSIX);
+    EXPECT_EQ(
+        coordinate_manager->translate_coord_to({0, 0}, CoordSystem::PHYSICAL, CoordSystem::PHYSICAL).core_type,
+        CoreType::ROUTER_ONLY);
+    EXPECT_EQ(
+        coordinate_manager->translate_coord_to({0, 0}, CoordSystem::VIRTUAL, CoordSystem::PHYSICAL).core_type,
+        CoreType::ROUTER_ONLY);
+    EXPECT_EQ(
+        coordinate_manager->translate_coord_to({2, 2}, CoordSystem::PHYSICAL, CoordSystem::PHYSICAL).core_type,
+        CoreType::TENSIX);
     // Not allowed for logical coord system.
-    EXPECT_THROW(coordinate_manager->get_coord_at({0, 0}, CoordSystem::LOGICAL), std::runtime_error);
+    EXPECT_THROW(
+        coordinate_manager->translate_coord_to({0, 0}, CoordSystem::LOGICAL, CoordSystem::PHYSICAL),
+        std::runtime_error);
     // Throws if nothing is located at this coordinate.
-    EXPECT_THROW(coordinate_manager->get_coord_at({100, 100}, CoordSystem::PHYSICAL), std::runtime_error);
+    EXPECT_THROW(
+        coordinate_manager->translate_coord_to({100, 100}, CoordSystem::PHYSICAL, CoordSystem::PHYSICAL),
+        std::runtime_error);
 }

--- a/tests/api/test_core_coord_translation_gs.cpp
+++ b/tests/api/test_core_coord_translation_gs.cpp
@@ -334,3 +334,16 @@ TEST(CoordinateManager, CoordinateManagerGrayskullHarvestingShuffle) {
         EXPECT_EQ(harvesting_mask, 1 << i);
     }
 }
+
+TEST(CoordinateManager, CoordinateManagerGrayskullGettingCoreType) {
+    std::shared_ptr<CoordinateManager> coordinate_manager =
+        CoordinateManager::create_coordinate_manager(tt::ARCH::GRAYSKULL);
+
+    EXPECT_EQ(coordinate_manager->get_coord_at({0, 0}, CoordSystem::PHYSICAL).core_type, CoreType::ROUTER_ONLY);
+    EXPECT_EQ(coordinate_manager->get_coord_at({0, 0}, CoordSystem::VIRTUAL).core_type, CoreType::ROUTER_ONLY);
+    EXPECT_EQ(coordinate_manager->get_coord_at({2, 2}, CoordSystem::PHYSICAL).core_type, CoreType::TENSIX);
+    // Not allowed for logical coord system.
+    EXPECT_THROW(coordinate_manager->get_coord_at({0, 0}, CoordSystem::LOGICAL), std::runtime_error);
+    // Throws if nothing is located at this coordinate.
+    EXPECT_THROW(coordinate_manager->get_coord_at({100, 100}, CoordSystem::PHYSICAL), std::runtime_error);
+}

--- a/tests/api/test_core_coord_translation_wh.cpp
+++ b/tests/api/test_core_coord_translation_wh.cpp
@@ -391,15 +391,25 @@ TEST(CoordinateManager, CoordinateManagerWormholeHarvestingShuffle) {
     }
 }
 
-TEST(CoordinateManager, CoordinateManagerWormholeGettingCoreType) {
+TEST(CoordinateManager, CoordinateManagerWormholeTranslationWithoutCoreType) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true);
 
-    EXPECT_EQ(coordinate_manager->get_coord_at({0, 0}, CoordSystem::PHYSICAL).core_type, CoreType::DRAM);
-    EXPECT_EQ(coordinate_manager->get_coord_at({0, 0}, CoordSystem::VIRTUAL).core_type, CoreType::DRAM);
-    EXPECT_EQ(coordinate_manager->get_coord_at({2, 2}, CoordSystem::PHYSICAL).core_type, CoreType::TENSIX);
+    EXPECT_EQ(
+        coordinate_manager->translate_coord_to({0, 0}, CoordSystem::PHYSICAL, CoordSystem::PHYSICAL).core_type,
+        CoreType::DRAM);
+    EXPECT_EQ(
+        coordinate_manager->translate_coord_to({0, 0}, CoordSystem::VIRTUAL, CoordSystem::PHYSICAL).core_type,
+        CoreType::DRAM);
+    EXPECT_EQ(
+        coordinate_manager->translate_coord_to({2, 2}, CoordSystem::PHYSICAL, CoordSystem::PHYSICAL).core_type,
+        CoreType::TENSIX);
     // Not allowed for logical coord system.
-    EXPECT_THROW(coordinate_manager->get_coord_at({0, 0}, CoordSystem::LOGICAL), std::runtime_error);
+    EXPECT_THROW(
+        coordinate_manager->translate_coord_to({0, 0}, CoordSystem::LOGICAL, CoordSystem::PHYSICAL),
+        std::runtime_error);
     // Throws if nothing is located at this coordinate.
-    EXPECT_THROW(coordinate_manager->get_coord_at({100, 100}, CoordSystem::PHYSICAL), std::runtime_error);
+    EXPECT_THROW(
+        coordinate_manager->translate_coord_to({100, 100}, CoordSystem::PHYSICAL, CoordSystem::PHYSICAL),
+        std::runtime_error);
 }

--- a/tests/api/test_core_coord_translation_wh.cpp
+++ b/tests/api/test_core_coord_translation_wh.cpp
@@ -390,3 +390,16 @@ TEST(CoordinateManager, CoordinateManagerWormholeHarvestingShuffle) {
         EXPECT_EQ(harvesting_mask, 1 << i);
     }
 }
+
+TEST(CoordinateManager, CoordinateManagerWormholeGettingCoreType) {
+    std::shared_ptr<CoordinateManager> coordinate_manager =
+        CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0);
+
+    EXPECT_EQ(coordinate_manager->get_coord_at({0, 0}, CoordSystem::PHYSICAL).core_type, CoreType::DRAM);
+    EXPECT_EQ(coordinate_manager->get_coord_at({0, 0}, CoordSystem::VIRTUAL).core_type, CoreType::DRAM);
+    EXPECT_EQ(coordinate_manager->get_coord_at({2, 2}, CoordSystem::PHYSICAL).core_type, CoreType::TENSIX);
+    // Not allowed for logical coord system.
+    EXPECT_THROW(coordinate_manager->get_coord_at({0, 0}, CoordSystem::LOGICAL), std::runtime_error);
+    // Throws if nothing is located at this coordinate.
+    EXPECT_THROW(coordinate_manager->get_coord_at({100, 100}, CoordSystem::PHYSICAL), std::runtime_error);
+}


### PR DESCRIPTION
### Issue
Somewhat related to #439 

### Description
get_core_at can be a useful API provided by coordinate manager. There are scenarios where we want to learn what is located at a specific core location. This obviously can't be offered for LOGICAL coord system, but for others it is possible.
Since there are also some places in the code which request specifically some cores which might be router_only cores, I've also added router_cores to CoordinateManager and SocDescriptor (see Cluster::test_setup_interface or Cluster::broadcast_pcie_tensix_risc_reset)

### List of the changes
- Add translate_coord_to api which doesn't know what coretype is there
- Add router cores everywhere
- Restructured constants a bit to follow tensix, dram, eth, arc, pci ordering.
- Wrote a test to verify new behavior

### Testing
Added tests which test the new API.

### API Changes
There are no API changes in this PR.
