### PR TITLE
Change Grayskull tests to new api

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -897,8 +897,7 @@ private:
         std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks);
 
     // Helper function for translating chip coordinates.
-    tt::umd::CoreCoord translate_chip_coord(
-        const chip_id_t chip, const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const;
+    tt_xy_pair translate_to_api_coords(const chip_id_t chip, const tt::umd::CoreCoord core_coord) const;
 
     // State variables
     std::vector<tt::ARCH> archs_in_cluster = {};

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -675,8 +675,7 @@ void Cluster::configure_active_ethernet_cores_for_mmio_device(
     const std::unordered_set<CoreCoord>& active_eth_cores_per_chip, chip_id_t mmio_chip) {
     std::unordered_set<tt_xy_pair> active_eth_cores_xy;
     for (const auto& core : active_eth_cores_per_chip) {
-        CoreCoord virtual_coord = translate_chip_coord(mmio_chip, core, CoordSystem::VIRTUAL);
-        active_eth_cores_xy.insert(virtual_coord);
+        active_eth_cores_xy.insert(translate_to_api_coords(mmio_chip, core));
     }
 
     configure_active_ethernet_cores_for_mmio_device(mmio_chip, active_eth_cores_xy);
@@ -997,8 +996,7 @@ void Cluster::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftRese
 
 void Cluster::deassert_risc_reset_at_core(
     const chip_id_t chip, const CoreCoord core, const TensixSoftResetOptions& soft_resets) {
-    const CoreCoord virtual_coord = translate_chip_coord(chip, core, CoordSystem::VIRTUAL);
-    deassert_risc_reset_at_core({(size_t)chip, virtual_coord}, soft_resets);
+    deassert_risc_reset_at_core({(size_t)chip, translate_to_api_coords(chip, core)}, soft_resets);
 }
 
 void Cluster::assert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions& soft_resets) {
@@ -1023,8 +1021,7 @@ void Cluster::assert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetO
 
 void Cluster::assert_risc_reset_at_core(
     const chip_id_t chip, const CoreCoord core, const TensixSoftResetOptions& soft_resets) {
-    const CoreCoord virtual_coord = translate_chip_coord(chip, core, CoordSystem::VIRTUAL);
-    assert_risc_reset_at_core({(size_t)chip, virtual_coord}, soft_resets);
+    assert_risc_reset_at_core({(size_t)chip, translate_to_api_coords(chip, core)}, soft_resets);
 }
 
 // Free memory during teardown, and remove (clean/unlock) from any leftover mutexes.
@@ -1071,8 +1068,7 @@ tt::Writer Cluster::get_static_tlb_writer(tt_cxy_pair target) {
 }
 
 tt::Writer Cluster::get_static_tlb_writer(const chip_id_t chip, const CoreCoord target) {
-    const CoreCoord virtual_coord = translate_chip_coord(chip, target, CoordSystem::VIRTUAL);
-    return get_static_tlb_writer({(size_t)chip, virtual_coord});
+    return get_static_tlb_writer({(size_t)chip, translate_to_api_coords(chip, target)});
 }
 
 void Cluster::write_device_memory(
@@ -1324,13 +1320,11 @@ tlb_configuration Cluster::get_tlb_configuration(const tt_cxy_pair& target) {
 }
 
 std::optional<std::tuple<uint32_t, uint32_t>> Cluster::get_tlb_data_from_target(const chip_id_t chip, CoreCoord core) {
-    const CoreCoord virtual_coord = translate_chip_coord(chip, core, CoordSystem::VIRTUAL);
-    return get_tlb_data_from_target({(size_t)chip, virtual_coord});
+    return get_tlb_data_from_target({(size_t)chip, translate_to_api_coords(chip, core)});
 }
 
 tlb_configuration Cluster::get_tlb_configuration(const chip_id_t chip, CoreCoord core) {
-    const CoreCoord virtual_coord = translate_chip_coord(chip, core, CoordSystem::VIRTUAL);
-    return get_tlb_configuration({(size_t)chip, virtual_coord});
+    return get_tlb_configuration({(size_t)chip, translate_to_api_coords(chip, core)});
 }
 
 void Cluster::configure_tlb(
@@ -1341,8 +1335,7 @@ void Cluster::configure_tlb(
 
 void Cluster::configure_tlb(
     chip_id_t logical_device_id, tt::umd::CoreCoord core, int32_t tlb_index, uint64_t address, uint64_t ordering) {
-    const CoreCoord virtual_coord = translate_chip_coord(logical_device_id, core, CoordSystem::VIRTUAL);
-    configure_tlb(logical_device_id, {virtual_coord.x, virtual_coord.y}, tlb_index, address, ordering);
+    configure_tlb(logical_device_id, translate_to_api_coords(logical_device_id, core), tlb_index, address, ordering);
 }
 
 void Cluster::set_fallback_tlb_ordering_mode(const std::string& fallback_tlb, uint64_t ordering) {
@@ -2959,8 +2952,7 @@ void Cluster::l1_membar(
     const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores, const std::string& fallback_tlb) {
     std::unordered_set<tt_xy_pair> cores_xy;
     for (const auto& core : cores) {
-        const CoreCoord virtual_core = translate_chip_coord(chip, core, CoordSystem::VIRTUAL);
-        cores_xy.insert({virtual_core.x, virtual_core.y});
+        cores_xy.insert(translate_to_api_coords(chip, core));
     }
     l1_membar(chip, fallback_tlb, cores_xy);
 }
@@ -2988,8 +2980,7 @@ void Cluster::dram_membar(
     const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores, const std::string& fallback_tlb) {
     std::unordered_set<tt_xy_pair> cores_xy;
     for (const auto& core : cores) {
-        const CoreCoord virtual_core = translate_chip_coord(chip, core, CoordSystem::VIRTUAL);
-        cores_xy.insert({virtual_core.x, virtual_core.y});
+        cores_xy.insert(translate_to_api_coords(chip, core));
     }
     dram_membar(chip, fallback_tlb, cores_xy);
 }
@@ -3041,8 +3032,7 @@ void Cluster::write_to_device(
     CoreCoord core,
     uint64_t addr,
     const std::string& tlb_to_use) {
-    CoreCoord virtual_coord = translate_chip_coord(chip, core, CoordSystem::VIRTUAL);
-    write_to_device(mem_ptr, size_in_bytes, {(size_t)chip, virtual_coord}, addr, tlb_to_use);
+    write_to_device(mem_ptr, size_in_bytes, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, tlb_to_use);
 }
 
 void Cluster::read_mmio_device_register(
@@ -3106,8 +3096,7 @@ void Cluster::read_from_device(
 
 void Cluster::read_from_device(
     void* mem_ptr, chip_id_t chip, CoreCoord core, uint64_t addr, uint32_t size, const std::string& fallback_tlb) {
-    CoreCoord virtual_coord = translate_chip_coord(chip, core, CoordSystem::VIRTUAL);
-    read_from_device(mem_ptr, {(size_t)chip, virtual_coord}, addr, size, fallback_tlb);
+    read_from_device(mem_ptr, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, size, fallback_tlb);
 }
 
 int Cluster::arc_msg(
@@ -3393,8 +3382,10 @@ void Cluster::set_barrier_address_params(const barrier_address_params& barrier_a
     }
 }
 
-tt::umd::CoreCoord Cluster::translate_chip_coord(
-    const chip_id_t chip, const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const {
+// TODO: This is a temporary function while we're switching between the old and the new API.
+// Eventually, this function should be so small it would be obvioud to remove.
+tt_xy_pair Cluster::translate_to_api_coords(const chip_id_t chip, const tt::umd::CoreCoord core_coord) const {
+    CoordSystem coord_system = arch_name == tt::ARCH::GRAYSKULL ? CoordSystem::PHYSICAL : CoordSystem::VIRTUAL;
     return get_soc_descriptor(chip).translate_coord_to(core_coord, coord_system);
 }
 

--- a/tests/grayskull/test_cluster_gs.cpp
+++ b/tests/grayskull/test_cluster_gs.cpp
@@ -52,30 +52,30 @@ TEST(SiliconDriverGS, CreateMultipleInstance) {
 }
 
 TEST(SiliconDriverGS, Harvesting) {
-    std::set<chip_id_t> target_devices = {0};
     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 6}, {1, 12}};
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     Cluster cluster = Cluster(num_host_mem_ch_per_mmio_device, false, true, true, simulated_harvesting_masks);
-    auto sdesc_per_chip = cluster.get_virtual_soc_descriptors();
 
-    ASSERT_EQ(cluster.using_harvested_soc_descriptors(), true) << "Expected Driver to have performed harvesting";
-    for (const auto& chip : sdesc_per_chip) {
-        ASSERT_LE(chip.second.workers.size(), 96)
-            << "Expected SOC descriptor with harvesting to have less than or equal to 96 workers for chip "
-            << chip.first;
+    for (const auto& chip_id : cluster.get_target_device_ids()) {
+        auto soc_desc = cluster.get_soc_descriptor(chip_id);
+        ASSERT_NE(soc_desc.get_harvested_grid_size(CoreType::TENSIX), tt_xy_pair(0, 0))
+            << "Expected Driver to have performed harvesting";
+        ASSERT_LE(soc_desc.get_cores(CoreType::TENSIX).size(), 96)
+            << "Expected SOC descriptor with harvesting to have less than or equal to 96 workers for chip " << chip_id;
+
+        // harvesting info stored in soc descriptor is in logical coordinates.
+        ASSERT_EQ(
+            soc_desc.tensix_harvesting_mask & simulated_harvesting_masks.at(chip_id),
+            simulated_harvesting_masks.at(chip_id))
+            << "Expected first chip to include simulated harvesting mask of 6";
+        // get_harvesting_masks_for_soc_descriptors will return harvesting info in noc0 coordinates.
+        simulated_harvesting_masks.at(chip_id) = CoordinateManager::shuffle_tensix_harvesting_mask_to_noc0_coords(
+            tt::ARCH::GRAYSKULL, simulated_harvesting_masks.at(chip_id));
+        ASSERT_EQ(
+            cluster.get_harvesting_masks_for_soc_descriptors().at(chip_id) & simulated_harvesting_masks.at(chip_id),
+            simulated_harvesting_masks.at(chip_id))
+            << "Expected first chip to include simulated harvesting mask of 6";
     }
-    // harvesting info stored in soc descriptor is in logical coordinates.
-    ASSERT_EQ(
-        cluster.get_soc_descriptor(0).tensix_harvesting_mask & simulated_harvesting_masks[0],
-        simulated_harvesting_masks[0])
-        << "Expected first chip to include simulated harvesting mask of 6";
-    // get_harvesting_masks_for_soc_descriptors will return harvesting info in noc0 coordinates.
-    simulated_harvesting_masks[0] = CoordinateManager::shuffle_tensix_harvesting_mask_to_noc0_coords(
-        tt::ARCH::GRAYSKULL, simulated_harvesting_masks[0]);
-    ASSERT_EQ(
-        cluster.get_harvesting_masks_for_soc_descriptors().at(0) & simulated_harvesting_masks[0],
-        simulated_harvesting_masks[0])
-        << "Expected first chip to include simulated harvesting mask of 6";
     cluster.close_device();
 }
 
@@ -83,7 +83,7 @@ TEST(SiliconDriverGS, CustomSocDesc) {
     std::set<chip_id_t> target_devices = {0};
     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 6}, {1, 12}};
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
+    // Initialize the driver with a 1x1 descriptor and explicitly do not perform harvesting
     Cluster cluster = Cluster(
         test_utils::GetAbsPath("./tests/soc_descs/grayskull_1x1_arch.yaml"),
         target_devices,
@@ -92,11 +92,12 @@ TEST(SiliconDriverGS, CustomSocDesc) {
         true,
         false,
         simulated_harvesting_masks);
-    auto sdesc_per_chip = cluster.get_virtual_soc_descriptors();
-    ASSERT_EQ(cluster.using_harvested_soc_descriptors(), false)
-        << "SOC descriptors should not be modified when harvesting is disabled";
-    for (const auto& chip : sdesc_per_chip) {
-        ASSERT_EQ(chip.second.workers.size(), 1) << "Expected 1x1 SOC descriptor to be unmodified by driver";
+    for (const auto& chip_id : cluster.get_target_device_ids()) {
+        auto soc_desc = cluster.get_soc_descriptor(chip_id);
+        ASSERT_NE(soc_desc.get_harvested_grid_size(CoreType::TENSIX), tt_xy_pair(0, 0))
+            << "SOC descriptors should not be modified when harvesting is disabled";
+        ASSERT_EQ(soc_desc.get_cores(CoreType::TENSIX).size(), 1)
+            << "Expected 1x1 SOC descriptor to be unmodified by driver";
     }
 }
 
@@ -117,7 +118,7 @@ TEST(SiliconDriverGS, HarvestingRuntime) {
     for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for functional worker cores
         auto& sdesc = cluster.get_soc_descriptor(i);
-        for (auto& core : sdesc.workers) {
+        for (auto& core : sdesc.get_cores(CoreType::TENSIX)) {
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
             cluster.configure_tlb(i, core, get_static_tlb_index(core), l1_mem::address_map::DATA_BUFFER_SPACE_BASE);
         }
@@ -138,17 +139,14 @@ TEST(SiliconDriverGS, HarvestingRuntime) {
         std::uint32_t dynamic_write_address = 0x30000000;
         for (int loop = 0; loop < 100;
              loop++) {  // Write to each core a 100 times at different statically mapped addresses
-            for (auto& core : cluster.get_soc_descriptor(i).workers) {
+            for (auto& core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
+                cluster.write_to_device(
+                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), i, core, address, "");
                 cluster.write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
-                    tt_cxy_pair(i, core),
-                    address,
-                    "");
-                cluster.write_to_device(
-                    vector_to_write.data(),
-                    vector_to_write.size() * sizeof(std::uint32_t),
-                    tt_cxy_pair(i, core),
+                    i,
+                    core,
                     dynamic_write_address,
                     "SMALL_READ_WRITE_TLB");
                 auto start_time = std::chrono::high_resolution_clock::now();
@@ -159,27 +157,24 @@ TEST(SiliconDriverGS, HarvestingRuntime) {
                     if (wait_duration > timeout_in_seconds) {
                         break;
                     }
-                    test_utils::read_data_from_device(cluster, readback_vec, tt_cxy_pair(i, core), address, 40, "");
+                    test_utils::read_data_from_device(cluster, readback_vec, i, core, address, 40, "");
                     test_utils::read_data_from_device(
-                        cluster,
-                        dynamic_readback_vec,
-                        tt_cxy_pair(i, core),
-                        dynamic_write_address,
-                        40,
-                        "SMALL_READ_WRITE_TLB");
+                        cluster, dynamic_readback_vec, i, core, dynamic_write_address, 40, "SMALL_READ_WRITE_TLB");
                 }
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 cluster.write_to_device(
                     zeros.data(),
                     zeros.size() * sizeof(std::uint32_t),
-                    tt_cxy_pair(i, core),
+                    i,
+                    core,
                     address,
                     "SMALL_READ_WRITE_TLB");  // Clear any written data
                 cluster.write_to_device(
                     zeros.data(),
                     zeros.size() * sizeof(std::uint32_t),
-                    tt_cxy_pair(i, core),
+                    i,
+                    core,
                     dynamic_write_address,
                     "SMALL_READ_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
@@ -207,7 +202,7 @@ TEST(SiliconDriverGS, StaticTLB_RW) {
     for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for worker cores
         auto& sdesc = cluster.get_soc_descriptor(i);
-        for (auto& core : sdesc.workers) {
+        for (auto& core : sdesc.get_cores(CoreType::TENSIX)) {
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
             cluster.configure_tlb(
                 i, core, get_static_tlb_index(core), l1_mem::address_map::DATA_BUFFER_SPACE_BASE, TLB_DATA::Posted);
@@ -226,13 +221,9 @@ TEST(SiliconDriverGS, StaticTLB_RW) {
         std::uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
         for (int loop = 0; loop < 100;
              loop++) {  // Write to each core a 100 times at different statically mapped addresses
-            for (auto& core : cluster.get_soc_descriptor(i).workers) {
+            for (auto& core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
                 cluster.write_to_device(
-                    vector_to_write.data(),
-                    vector_to_write.size() * sizeof(std::uint32_t),
-                    tt_cxy_pair(i, core),
-                    address,
-                    "");
+                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), i, core, address, "");
                 auto start_time = std::chrono::high_resolution_clock::now();
                 while (!(vector_to_write == readback_vec)) {
                     float wait_duration = std::chrono::duration_cast<std::chrono::seconds>(
@@ -241,14 +232,15 @@ TEST(SiliconDriverGS, StaticTLB_RW) {
                     if (wait_duration > timeout_in_seconds) {
                         break;
                     }
-                    test_utils::read_data_from_device(cluster, readback_vec, tt_cxy_pair(i, core), address, 40, "");
+                    test_utils::read_data_from_device(cluster, readback_vec, i, core, address, 40, "");
                 }
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 cluster.write_to_device(
                     zeros.data(),
                     zeros.size() * sizeof(std::uint32_t),
-                    tt_cxy_pair(i, core),
+                    i,
+                    core,
                     address,
                     "SMALL_READ_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
@@ -280,11 +272,12 @@ TEST(SiliconDriverGS, DynamicTLB_RW) {
         std::uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
         for (int loop = 0; loop < 100;
              loop++) {  // Write to each core a 100 times at different statically mapped addresses
-            for (auto& core : cluster.get_soc_descriptor(i).workers) {
+            for (auto& core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
                 cluster.write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
-                    tt_cxy_pair(i, core),
+                    i,
+                    core,
                     address,
                     "SMALL_READ_WRITE_TLB");
                 auto start_time = std::chrono::high_resolution_clock::now();
@@ -304,7 +297,8 @@ TEST(SiliconDriverGS, DynamicTLB_RW) {
                 cluster.write_to_device(
                     zeros.data(),
                     zeros.size() * sizeof(std::uint32_t),
-                    tt_cxy_pair(i, core),
+                    i,
+                    core,
                     address,
                     "SMALL_READ_WRITE_TLB");  // Clear any written data
                 readback_vec = {};
@@ -333,11 +327,12 @@ TEST(SiliconDriverGS, MultiThreadedDevice) {
         float timeout_in_seconds = 10;
         std::uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
         for (int loop = 0; loop < 100; loop++) {
-            for (auto& core : cluster.get_soc_descriptor(0).workers) {
+            for (auto& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 cluster.write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
-                    tt_cxy_pair(0, core),
+                    0,
+                    core,
                     address,
                     "SMALL_READ_WRITE_TLB");
                 auto start_time = std::chrono::high_resolution_clock::now();
@@ -349,7 +344,7 @@ TEST(SiliconDriverGS, MultiThreadedDevice) {
                         break;
                     }
                     test_utils::read_data_from_device(
-                        cluster, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
+                        cluster, readback_vec, 0, core, address, 40, "SMALL_READ_WRITE_TLB");
                 }
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
@@ -364,13 +359,14 @@ TEST(SiliconDriverGS, MultiThreadedDevice) {
         std::vector<uint32_t> readback_vec = {};
         float timeout_in_seconds = 10;
         std::uint32_t address = 0x30000000;
-        for (auto& core_ls : cluster.get_soc_descriptor(0).dram_cores) {
+        for (auto& core_ls : cluster.get_soc_descriptor(0).get_dram_cores()) {
             for (int loop = 0; loop < 100; loop++) {
                 for (auto& core : core_ls) {
                     cluster.write_to_device(
                         vector_to_write.data(),
                         vector_to_write.size() * sizeof(std::uint32_t),
-                        tt_cxy_pair(0, core),
+                        0,
+                        core,
                         address,
                         "SMALL_READ_WRITE_TLB");
                     auto start_time = std::chrono::high_resolution_clock::now();
@@ -382,7 +378,7 @@ TEST(SiliconDriverGS, MultiThreadedDevice) {
                             break;
                         }
                         test_utils::read_data_from_device(
-                            cluster, readback_vec, tt_cxy_pair(0, core), address, 40, "SMALL_READ_WRITE_TLB");
+                            cluster, readback_vec, 0, core, address, 40, "SMALL_READ_WRITE_TLB");
                     }
                     ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << core.x << "-" << core.y
                                                              << "does not match what was written";
@@ -422,7 +418,7 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
     for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for functional worker cores
         auto& sdesc = cluster.get_soc_descriptor(i);
-        for (auto& core : sdesc.workers) {
+        for (auto& core : sdesc.get_cores(CoreType::TENSIX)) {
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
             cluster.configure_tlb(i, core, get_static_tlb_index(core), base_addr);
         }
@@ -431,36 +427,26 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
     tt_device_params default_params;
     cluster.start_device(default_params);
     std::vector<uint32_t> readback_membar_vec = {};
-    for (auto& core : cluster.get_soc_descriptor(0).workers) {
+    for (auto& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
         test_utils::read_data_from_device(
-            cluster,
-            readback_membar_vec,
-            tt_cxy_pair(0, core),
-            l1_mem::address_map::L1_BARRIER_BASE,
-            4,
-            "SMALL_READ_WRITE_TLB");
+            cluster, readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all workers
         readback_membar_vec = {};
     }
 
-    for (auto& core : cluster.get_soc_descriptor(0).workers) {
+    for (auto& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
         test_utils::read_data_from_device(
-            cluster,
-            readback_membar_vec,
-            tt_cxy_pair(0, core),
-            l1_mem::address_map::L1_BARRIER_BASE,
-            4,
-            "SMALL_READ_WRITE_TLB");
+            cluster, readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all workers
         readback_membar_vec = {};
     }
 
     for (int chan = 0; chan < cluster.get_soc_descriptor(0).get_num_dram_channels(); chan++) {
-        auto core = cluster.get_soc_descriptor(0).get_core_for_dram_channel(chan, 0);
+        auto core = cluster.get_soc_descriptor(0).get_dram_core_for_channel(chan, 0);
         test_utils::read_data_from_device(
-            cluster, readback_membar_vec, tt_cxy_pair(0, core), DRAM_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
+            cluster, readback_membar_vec, 0, core, DRAM_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all DRAM
         readback_membar_vec = {};
@@ -481,16 +467,13 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
     std::thread th1 = std::thread([&] {
         std::uint32_t address = base_addr;
         for (int loop = 0; loop < 100; loop++) {
-            for (auto& core : cluster.get_soc_descriptor(0).workers) {
+            for (auto& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 std::vector<uint32_t> readback_vec = {};
-                cluster.write_to_device(
-                    vec1.data(), vec1.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                cluster.write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), 0, core, address, "");
                 cluster.l1_membar(0, "", {core});
-                test_utils::read_data_from_device(
-                    cluster, readback_vec, tt_cxy_pair(0, core), address, 4 * vec1.size(), "");
+                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec1.size(), "");
                 ASSERT_EQ(readback_vec, vec1);
-                cluster.write_to_device(
-                    zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address, "");
                 readback_vec = {};
             }
         }
@@ -499,16 +482,13 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
     std::thread th2 = std::thread([&] {
         std::uint32_t address = base_addr + vec1.size() * 4;
         for (int loop = 0; loop < 100; loop++) {
-            for (auto& core : cluster.get_soc_descriptor(0).workers) {
+            for (auto& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 std::vector<uint32_t> readback_vec = {};
-                cluster.write_to_device(
-                    vec2.data(), vec2.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                cluster.write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), 0, core, address, "");
                 cluster.l1_membar(0, "", {core});
-                test_utils::read_data_from_device(
-                    cluster, readback_vec, tt_cxy_pair(0, core), address, 4 * vec2.size(), "");
+                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec2.size(), "");
                 ASSERT_EQ(readback_vec, vec2);
-                cluster.write_to_device(
-                    zeros.data(), zeros.size() * sizeof(std::uint32_t), tt_cxy_pair(0, core), address, "");
+                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address, "");
                 readback_vec = {};
             }
         }
@@ -517,14 +497,9 @@ TEST(SiliconDriverGS, MultiThreadedMemBar) {  // this tests takes ~5 mins to run
     th1.join();
     th2.join();
 
-    for (auto& core : cluster.get_soc_descriptor(0).workers) {
+    for (auto& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
         test_utils::read_data_from_device(
-            cluster,
-            readback_membar_vec,
-            tt_cxy_pair(0, core),
-            l1_mem::address_map::L1_BARRIER_BASE,
-            4,
-            "SMALL_READ_WRITE_TLB");
+            cluster, readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(readback_membar_vec.at(0), 187);  // Ensure that memory barriers end up in correct sate workers
         readback_membar_vec = {};
     }
@@ -547,8 +522,7 @@ TEST(SiliconDriverGS, SysmemTestWithPcie) {
     cluster.start_device(tt_device_params{});  // no special parameters
 
     const chip_id_t mmio_chip_id = 0;
-    const auto PCIE = cluster.get_soc_descriptor(mmio_chip_id).pcie_cores.at(0);
-    const tt_cxy_pair PCIE_CORE(mmio_chip_id, PCIE.x, PCIE.y);
+    const auto PCIE = cluster.get_soc_descriptor(mmio_chip_id).get_cores(CoreType::PCIE).at(0);
     const size_t test_size_bytes = 0x4000;  // Arbitrarilly chosen, but small size so the test runs quickly.
 
     // PCIe core is at (x=0, y=4) on Grayskull NOC0.
@@ -570,7 +544,7 @@ TEST(SiliconDriverGS, SysmemTestWithPcie) {
     test_utils::fill_with_random_bytes(sysmem, test_size_bytes);
 
     // Step 2: Read sysmem into buffer.
-    cluster.read_from_device(&buffer[0], PCIE_CORE, base_address, buffer.size(), "REG_TLB");
+    cluster.read_from_device(&buffer[0], mmio_chip_id, PCIE, base_address, buffer.size(), "REG_TLB");
 
     // Step 3: Verify that buffer matches sysmem.
     ASSERT_EQ(buffer, std::vector<uint8_t>(sysmem, sysmem + test_size_bytes));
@@ -579,12 +553,12 @@ TEST(SiliconDriverGS, SysmemTestWithPcie) {
     test_utils::fill_with_random_bytes(&buffer[0], test_size_bytes);
 
     // Step 5: Write buffer into sysmem, overwriting what was there.
-    cluster.write_to_device(&buffer[0], buffer.size(), PCIE_CORE, base_address, "REG_TLB");
+    cluster.write_to_device(&buffer[0], buffer.size(), mmio_chip_id, PCIE, base_address, "REG_TLB");
 
     // Step 5b: Read back sysmem into a throwaway buffer.  The intent is to
     // ensure the write has completed before we check sysmem against buffer.
     std::vector<uint8_t> throwaway(test_size_bytes, 0x0);
-    cluster.read_from_device(&throwaway[0], PCIE_CORE, base_address, throwaway.size(), "REG_TLB");
+    cluster.read_from_device(&throwaway[0], mmio_chip_id, PCIE, base_address, throwaway.size(), "REG_TLB");
 
     // Step 6: Verify that sysmem matches buffer.
     ASSERT_EQ(buffer, std::vector<uint8_t>(sysmem, sysmem + test_size_bytes));

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -34,6 +34,18 @@ static void read_data_from_device(
     device.read_from_device(vec.data(), core, addr, size, tlb_to_use);
 }
 
+static void read_data_from_device(
+    tt_device& device,
+    std::vector<uint32_t>& vec,
+    chip_id_t chip_id,
+    tt::umd::CoreCoord core,
+    uint64_t addr,
+    uint32_t size,
+    const std::string& tlb_to_use) {
+    size_buffer_to_capacity(vec, size);
+    device.read_from_device(vec.data(), chip_id, core, addr, size, tlb_to_use);
+}
+
 inline void fill_with_random_bytes(uint8_t* data, size_t n) {
     static std::random_device rd;
     static std::mt19937_64 gen(rd());


### PR DESCRIPTION
### Issue


### Description
Motivation was that Pavle and me recently realised that Grayskull actually used physical coords in the API. We thought Virtual coords were used consistently.

### List of the changes
- Grayskull tests use .get_cores instead of .workers
- using_harvested_soc_descriptors was changed to new api as well
- .dram_cores was changed to new api

### Testing
Existing CI grayskull tests

### API Changes
There are no API changes in this PR.
