### PR TITLE
Get coord type and get all cores

### DIFF
--- a/device/api/umd/device/coordinate_manager.h
+++ b/device/api/umd/device/coordinate_manager.h
@@ -62,6 +62,7 @@ public:
         tt::ARCH arch, uint32_t tensix_harvesting_logical_layout);
 
     tt::umd::CoreCoord translate_coord_to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const;
+    CoreType get_coord_type(const tt_xy_pair core, const CoordSystem coord_system) const;
     tt::umd::CoreCoord translate_coord_to(
         const tt_xy_pair core, const CoordSystem input_coord_system, const CoordSystem target_coord_system) const;
 

--- a/device/api/umd/device/coordinate_manager.h
+++ b/device/api/umd/device/coordinate_manager.h
@@ -62,7 +62,7 @@ public:
         tt::ARCH arch, uint32_t tensix_harvesting_logical_layout);
 
     tt::umd::CoreCoord translate_coord_to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const;
-    CoreType get_coord_type(const tt_xy_pair core, const CoordSystem coord_system) const;
+    tt::umd::CoreCoord get_coord_at(const tt_xy_pair core, const CoordSystem coord_system) const;
     tt::umd::CoreCoord translate_coord_to(
         const tt_xy_pair core, const CoordSystem input_coord_system, const CoordSystem target_coord_system) const;
 

--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -72,6 +72,10 @@ public:
         const CoreType core_type, const CoordSystem coord_system = CoordSystem::PHYSICAL) const;
     std::vector<tt::umd::CoreCoord> get_harvested_cores(
         const CoreType core_type, const CoordSystem coord_system = CoordSystem::PHYSICAL) const;
+    std::vector<tt::umd::CoreCoord> get_all_cores(const CoordSystem coord_system = CoordSystem::PHYSICAL) const;
+    std::vector<tt::umd::CoreCoord> get_all_harvested_cores(
+        const CoordSystem coord_system = CoordSystem::PHYSICAL) const;
+
     tt_xy_pair get_grid_size(const CoreType core_type) const;
     tt_xy_pair get_harvested_grid_size(const CoreType core_type) const;
 

--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -59,7 +59,7 @@ public:
 
     // CoreCoord conversions.
     tt::umd::CoreCoord translate_coord_to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const;
-    CoreType get_coord_type(const tt_xy_pair core, const CoordSystem coord_system) const;
+    tt::umd::CoreCoord get_coord_at(const tt_xy_pair core, const CoordSystem coord_system) const;
     tt::umd::CoreCoord translate_coord_to(
         const tt_xy_pair core_location,
         const CoordSystem input_coord_system,

--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -59,6 +59,7 @@ public:
 
     // CoreCoord conversions.
     tt::umd::CoreCoord translate_coord_to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const;
+    CoreType get_coord_type(const tt_xy_pair core, const CoordSystem coord_system) const;
     tt::umd::CoreCoord translate_coord_to(
         const tt_xy_pair core_location,
         const CoordSystem input_coord_system,

--- a/device/coordinate_manager.cpp
+++ b/device/coordinate_manager.cpp
@@ -126,19 +126,23 @@ CoreCoord CoordinateManager::translate_coord_to(
     return coord_it->second;
 }
 
-CoreCoord CoordinateManager::translate_coord_to(
-    const tt_xy_pair core, const CoordSystem input_coord_system, const CoordSystem target_coord_system) const {
-    log_assert(input_coord_system != CoordSystem::LOGICAL, "Coordinate is ambiguous for logical system.");
+CoreType CoordinateManager::get_coord_type(const tt_xy_pair core, const CoordSystem coord_system) const {
+    log_assert(coord_system != CoordSystem::LOGICAL, "Coordinate is ambiguous for logical system.");
 
-    auto coord_it = to_core_type_map.find({core, input_coord_system});
+    auto coord_it = to_core_type_map.find({core, coord_system});
     log_assert(
         coord_it != to_core_type_map.end(),
         "No core type found for system {} at location: ({}, {})",
-        to_str(input_coord_system),
+        to_str(coord_system),
         core.x,
         core.y);
+    return coord_it->second.core_type;
+}
 
-    return translate_coord_to(coord_it->second, target_coord_system);
+CoreCoord CoordinateManager::translate_coord_to(
+    const tt_xy_pair core, const CoordSystem input_coord_system, const CoordSystem target_coord_system) const {
+    CoreCoord core_coord(core, get_coord_type(core, input_coord_system), input_coord_system);
+    return translate_coord_to(core_coord, target_coord_system);
 }
 
 void CoordinateManager::translate_tensix_coords() {

--- a/device/coordinate_manager.cpp
+++ b/device/coordinate_manager.cpp
@@ -126,7 +126,7 @@ CoreCoord CoordinateManager::translate_coord_to(
     return coord_it->second;
 }
 
-CoreType CoordinateManager::get_coord_type(const tt_xy_pair core, const CoordSystem coord_system) const {
+CoreCoord CoordinateManager::get_coord_at(const tt_xy_pair core, const CoordSystem coord_system) const {
     log_assert(coord_system != CoordSystem::LOGICAL, "Coordinate is ambiguous for logical system.");
 
     auto coord_it = to_core_type_map.find({core, coord_system});
@@ -136,12 +136,12 @@ CoreType CoordinateManager::get_coord_type(const tt_xy_pair core, const CoordSys
         to_str(coord_system),
         core.x,
         core.y);
-    return coord_it->second.core_type;
+    return coord_it->second;
 }
 
 CoreCoord CoordinateManager::translate_coord_to(
     const tt_xy_pair core, const CoordSystem input_coord_system, const CoordSystem target_coord_system) const {
-    CoreCoord core_coord(core, get_coord_type(core, input_coord_system), input_coord_system);
+    CoreCoord core_coord = get_coord_at(core, input_coord_system);
     return translate_coord_to(core_coord, target_coord_system);
 }
 

--- a/device/coordinate_manager.cpp
+++ b/device/coordinate_manager.cpp
@@ -428,6 +428,8 @@ const std::vector<tt_xy_pair>& CoordinateManager::get_physical_pairs(const CoreT
             return arc_cores;
         case CoreType::PCIE:
             return pcie_cores;
+        case CoreType::ROUTER_ONLY:
+            return router_cores;
         default:
             throw std::runtime_error("Core type is not supported for getting physical pairs");
     }
@@ -492,9 +494,9 @@ std::vector<tt::umd::CoreCoord> CoordinateManager::get_cores(const CoreType core
         case CoreType::ETH:
             return get_eth_cores();
         case CoreType::ARC:
-            return get_all_physical_cores(CoreType::ARC);
         case CoreType::PCIE:
-            return get_all_physical_cores(CoreType::PCIE);
+        case CoreType::ROUTER_ONLY:
+            return get_all_physical_cores(core_type);
         default:
             throw std::runtime_error("Core type is not supported for getting cores");
     }
@@ -531,6 +533,7 @@ std::vector<tt::umd::CoreCoord> CoordinateManager::get_harvested_cores(const Cor
             return get_harvested_eth_cores();
         case CoreType::ARC:
         case CoreType::PCIE:
+        case CoreType::ROUTER_ONLY:
             return {};
         default:
             throw std::runtime_error("Core type is not supported for getting harvested cores");

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -225,8 +225,8 @@ tt::umd::CoreCoord tt_SocDescriptor::translate_coord_to(
     return coordinate_manager->translate_coord_to(core_coord, coord_system);
 }
 
-CoreType tt_SocDescriptor::get_coord_type(const tt_xy_pair core, const CoordSystem coord_system) const {
-    return coordinate_manager->get_coord_type(core, coord_system);
+tt::umd::CoreCoord tt_SocDescriptor::get_coord_at(const tt_xy_pair core, const CoordSystem coord_system) const {
+    return coordinate_manager->get_coord_at(core, coord_system);
 }
 
 tt::umd::CoreCoord tt_SocDescriptor::translate_coord_to(

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -225,6 +225,10 @@ tt::umd::CoreCoord tt_SocDescriptor::translate_coord_to(
     return coordinate_manager->translate_coord_to(core_coord, coord_system);
 }
 
+CoreType tt_SocDescriptor::get_coord_type(const tt_xy_pair core, const CoordSystem coord_system) const {
+    return coordinate_manager->get_coord_type(core, coord_system);
+}
+
 tt::umd::CoreCoord tt_SocDescriptor::translate_coord_to(
     const tt_xy_pair core_location, const CoordSystem input_coord_system, const CoordSystem target_coord_system) const {
     return coordinate_manager->translate_coord_to(core_location, input_coord_system, target_coord_system);

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -27,6 +27,8 @@ TEST(SocDescriptor, SocDescriptorGrayskullNoHarvesting) {
 
     ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::TENSIX).empty());
     ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::DRAM).empty());
+    ASSERT_EQ(soc_desc.get_all_cores().size(), grayskull::GRID_SIZE_X * grayskull::GRID_SIZE_Y);
+    ASSERT_EQ(soc_desc.get_all_harvested_cores().size(), 0);
 }
 
 // Test soc descriptor API for Grayskull when there is tensix harvesting.
@@ -54,6 +56,11 @@ TEST(SocDescriptor, SocDescriptorGrayskullOneRowHarvesting) {
     ASSERT_FALSE(harvested_cores.empty());
 
     ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::DRAM).empty());
+
+    ASSERT_EQ(
+        soc_desc.get_all_cores().size(),
+        grayskull::GRID_SIZE_X * grayskull::GRID_SIZE_Y - grayskull::TENSIX_GRID_SIZE.x);
+    ASSERT_EQ(soc_desc.get_all_harvested_cores().size(), grayskull::TENSIX_GRID_SIZE.x);
 }
 
 // Test soc descriptor API for getting DRAM cores.
@@ -83,6 +90,8 @@ TEST(SocDescriptor, SocDescriptorWormholeNoHarvesting) {
 
     ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::TENSIX).empty());
     ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::DRAM).empty());
+    ASSERT_EQ(soc_desc.get_all_cores().size(), wormhole::GRID_SIZE_X * wormhole::GRID_SIZE_Y);
+    ASSERT_EQ(soc_desc.get_all_harvested_cores().size(), 0);
 }
 
 // Test soc descriptor API for getting DRAM cores.
@@ -122,6 +131,10 @@ TEST(SocDescriptor, SocDescriptorWormholeOneRowHarvesting) {
     ASSERT_FALSE(harvested_cores.empty());
 
     ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::DRAM).empty());
+
+    ASSERT_EQ(
+        soc_desc.get_all_cores().size(), wormhole::GRID_SIZE_X * wormhole::GRID_SIZE_Y - wormhole::TENSIX_GRID_SIZE.x);
+    ASSERT_EQ(soc_desc.get_all_harvested_cores().size(), wormhole::TENSIX_GRID_SIZE.x);
 }
 
 // Test ETH translation from logical to physical coordinates.
@@ -167,6 +180,9 @@ TEST(SocDescriptor, SocDescriptorBlackholeETHHarvesting) {
 
         const std::vector<CoreCoord> eth_cores = soc_desc.get_cores(CoreType::ETH);
 
+        ASSERT_EQ(soc_desc.get_all_cores().size(), blackhole::GRID_SIZE_X * blackhole::GRID_SIZE_Y - 2);
+        ASSERT_EQ(soc_desc.get_all_harvested_cores().size(), 2);
+
         EXPECT_EQ(eth_cores.size(), num_eth_channels - num_harvested_eth_cores);
 
         const std::vector<CoreCoord> harvested_eth_cores = soc_desc.get_harvested_cores(CoreType::ETH);
@@ -204,6 +220,8 @@ TEST(SocDescriptor, SocDescriptorBlackholeNoHarvesting) {
 
     ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::TENSIX).empty());
     ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::DRAM).empty());
+    ASSERT_EQ(soc_desc.get_all_cores().size(), blackhole::GRID_SIZE_X * blackhole::GRID_SIZE_Y);
+    ASSERT_EQ(soc_desc.get_all_harvested_cores().size(), 0);
 }
 
 // Test soc descriptor API for Blackhole when there is tensix harvesting.
@@ -233,6 +251,11 @@ TEST(SocDescriptor, SocDescriptorBlackholeOneRowHarvesting) {
     ASSERT_FALSE(harvested_cores.empty());
 
     ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::DRAM).empty());
+
+    ASSERT_EQ(
+        soc_desc.get_all_cores().size(),
+        blackhole::GRID_SIZE_X * blackhole::GRID_SIZE_Y - blackhole::TENSIX_GRID_SIZE.y);
+    ASSERT_EQ(soc_desc.get_all_harvested_cores().size(), blackhole::TENSIX_GRID_SIZE.y);
 }
 
 // Test soc descriptor API for getting DRAM cores.
@@ -269,6 +292,8 @@ TEST(SocDescriptor, SocDescriptorBlackholeDRAMHarvesting) {
     }
 
     ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::TENSIX).empty());
+    ASSERT_EQ(soc_desc.get_all_cores().size(), blackhole::GRID_SIZE_X * blackhole::GRID_SIZE_Y - 3);
+    ASSERT_EQ(soc_desc.get_all_harvested_cores().size(), 3);
 
     const std::vector<CoreCoord> dram_cores = soc_desc.get_cores(CoreType::DRAM);
 


### PR DESCRIPTION
### Issue
Heading towards https://github.com/tenstorrent/tt-umd/issues/439

### Description
Added some APIs needed by tt_metal for switching to new UMD API using CoreCoords.

### List of the changes
- Added get_coord_type, and made translate_coord_to going through it
- Added get_all_cores and get_all_harvested_cores to soc descriptor
- Added ROUTER_ONLY cores to cores_map, so it is available in get_cores api.
- Rewrote cores_map addition to be more compact.
- Added tests for get_all_cores

### Testing
(Comment on CI testing or Manual testing touching this change.)

### API Changes
There are no API changes in this PR.
