### PR TITLE
Disable ethernet broadcast for all systems with MMIO access to all chips

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -305,8 +305,9 @@ void Cluster::construct_cluster(
 
     create_device(local_chip_ids_, num_host_mem_ch_per_mmio_device, skip_driver_allocs, clean_system_resources);
 
-    // MT: Initial BH - Disable dependency to ethernet firmware
-    if (arch_name == tt::ARCH::BLACKHOLE) {
+    // Disable dependency to ethernet firmware for all BH devices and WH devices with all chips having MMIO (e.g. UBB
+    // Galaxy), do not disable for N150, was seeing some issues in CI
+    if (remote_chip_ids_.empty() and cluster_desc->get_board_type(*local_chip_ids_.begin()) != BoardType::N150) {
         use_ethernet_ordered_writes = false;
         use_ethernet_broadcast = false;
         use_virtual_coords_for_eth_broadcast = false;


### PR DESCRIPTION

### Issue
[(Link to Github issue(s))](https://github.com/tenstorrent/tt-umd/issues/486)

### Description
Ethernet broadcast was getting used for all-mmio system like UBB. This is causing race conditions when opening and closing drivers, since the reset signals are getting broadcasted through ethernet FW but the done check is through MMIO.

### List of the changes
Disable ethernet broadcast for systems with num chips equal to num mmio chips.

### Testing
Tests in Metal on UBB Galaxy

### API Changes
There are no API changes in this PR.
