### PR TITLE
Bump spdlog to unblock us from upgrading fmt

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -103,6 +103,11 @@ function(fetch_dependencies)
     ####################################################################################################################
     # spdlog
     ####################################################################################################################
-    CPMAddPackage(NAME spdlog GITHUB_REPOSITORY gabime/spdlog GIT_TAG v1.14.1 VERSION v1.14.1)
+    CPMAddPackage(
+        NAME spdlog
+        GITHUB_REPOSITORY gabime/spdlog
+        GIT_TAG
+            96a8f6250cbf4e8c76387c614f666710a2fa9bad # Version v 1.15+fmtlib fixes
+    )
 endfunction()
 fetch_dependencies()


### PR DESCRIPTION
### Issue
One step towards https://github.com/tenstorrent/tt-metal/issues/7915

### Description
spdlog uses fmt, but the version we're using uses a function from fmt that is no longer there in the current release of fmt.
spdlog has since added support for newer fmt.  Pull in that update.

### List of the changes
Bump spdlog to the commit that works with current fmt.  Pointed to the hash itself since spdlog hasn't cut a 1.x release since last Nov.

### Testing
Built TT-Metalium locally with this change.

### API Changes
There are no API changes in this PR.