### PR TITLE
Privatize flatbuffers

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -67,9 +67,8 @@ target_include_directories(
 # flatbuffers is public - exposed to tt_metal by tt_simulation_device_generated.h
 target_link_libraries(
     device
-    PUBLIC
-        flatbuffers
     PRIVATE
+        flatbuffers
         umd::Common
         umd::Firmware
         hwloc


### PR DESCRIPTION
### Issue
One step towards https://github.com/tenstorrent/tt-metal/issues/7915

### Description
As far as I can tell, this dependency does not spill publicly.
* Grep'ing the `api/` dir comes up empty for 'flatbuffer'.
* The generated header is private.
* The code still builds with it kept private.

### List of the changes
Kept `flatbuffers` internal to `device`, no longer publishing it as part of the API.

### Testing
Compiled locally.

### API Changes
There are no API changes in this PR.
