### PR TITLE
Use components to group installed pieces

### DIFF
--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -19,6 +19,7 @@ install(
         ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
         ${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+    COMPONENT umd-dev
 )
 
 set(CPACK_PACKAGE_NAME "${PROJECT_NAME}-dev")

--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -53,12 +53,59 @@ target_sources(
         ${FBS_GENERATED_HEADER}
 )
 
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
+    target_sources(
+        device
+        PUBLIC
+            FILE_SET api
+            TYPE HEADERS
+            BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/api
+            FILES
+                api/umd/device/architecture_implementation.h
+                api/umd/device/blackhole_arc_message_queue.h
+                api/umd/device/blackhole_coordinate_manager.h
+                api/umd/device/blackhole_implementation.h
+                api/umd/device/chip/chip.h
+                api/umd/device/chip/local_chip.h
+                api/umd/device/chip/mock_chip.h
+                api/umd/device/chip/remote_chip.h
+                api/umd/device/cluster.h
+                api/umd/device/coordinate_manager.h
+                api/umd/device/device_api_metal.h
+                api/umd/device/driver_atomics.h
+                api/umd/device/grayskull_coordinate_manager.h
+                api/umd/device/grayskull_implementation.h
+                api/umd/device/hugepage.h
+                api/umd/device/pci_device.hpp
+                api/umd/device/semver.hpp
+                api/umd/device/tt_cluster_descriptor.h
+                api/umd/device/tt_core_coordinates.h
+                api/umd/device/tt_device/blackhole_tt_device.h
+                api/umd/device/tt_device/grayskull_tt_device.h
+                api/umd/device/tt_device/tlb_manager.h
+                api/umd/device/tt_device/tt_device.h
+                api/umd/device/tt_device/wormhole_tt_device.h
+                api/umd/device/tt_io.hpp
+                api/umd/device/tt_silicon_driver_common.hpp
+                api/umd/device/tt_simulation_device.h
+                api/umd/device/tt_simulation_host.hpp
+                api/umd/device/tt_soc_descriptor.h
+                api/umd/device/tt_xy_pair.h
+                api/umd/device/types/arch.h
+                api/umd/device/types/blackhole_arc.h
+                api/umd/device/types/cluster_descriptor_types.h
+                api/umd/device/types/cluster_types.h
+                api/umd/device/types/tlb.h
+                api/umd/device/types/xy_pair.h
+                api/umd/device/wormhole_coordinate_manager.h
+                api/umd/device/wormhole_implementation.h
+    )
+endif()
+
 target_include_directories(
     device
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/device>
     PRIVATE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
@@ -83,23 +130,29 @@ target_link_libraries(
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/${CMAKE_SYSTEM_PROCESSOR}/libcreate_ethernet_map.a
 )
 
-install(
-    TARGETS
-        device
-    EXPORT ${PROJECT_NAME}Targets
-    ARCHIVE
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        COMPONENT dev
-)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
+    install(
+        TARGETS
+            device
+        EXPORT ${PROJECT_NAME}Targets
+        ARCHIVE
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT umd-runtime
+        FILE_SET
+        api
+            COMPONENT umd-dev
+    )
 
-install(
-    EXPORT ${PROJECT_NAME}Targets
-    FILE ${PROJECT_NAME}Targets.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
-    NAMESPACE ${PROJECT_NAME}::
-)
+    install(
+        EXPORT ${PROJECT_NAME}Targets
+        FILE ${PROJECT_NAME}Targets.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+        NAMESPACE ${PROJECT_NAME}::
+        COMPONENT umd-dev
+    )
+endif()
 
 # Add a custom command to copy the library to build/lib
 add_custom_command(


### PR DESCRIPTION
### Issue
One step towards https://github.com/tenstorrent/tt-metal/issues/7915

### Description
Best practice is to put installed pieces into components.  And for them to be named uniquely to the project.  That way any consuming project can choose where to redirect each piece.
Any install items without a component go into "Unspecified".  And once two things land in the same component they're lumped together.  Separate components may be placed together by choice.

### List of the changes
* Created a FILE_SET for the public API to be installed
* Removed the INSTALL_INTERFACE directives; these are populated based on where the FILE_SET is told to be installed to.
  * This may be done by the consuming project, if they wish, and the include dir will be adjusted accordingly at install time
* Distinguished between files needed at runtime vs. those required only for SDK development.

### Testing
Built and packaged in TT-Metalium (on a hacked up branch; TT-Metalium has lots of work to do, too).

### API Changes
There are no API changes in this PR.
