### PR TITLE
TTDevice read/write

### DIFF
--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -27,6 +27,10 @@ struct dynamic_tlb {
     uint64_t remaining_size;  // Bytes remaining between bar_offset and end of the TLB.
 };
 
+namespace boost::interprocess {
+class named_mutex;
+}
+
 namespace tt::umd {
 
 class TLBManager;
@@ -64,6 +68,8 @@ public:
     void write_regs(volatile uint32_t *dest, const uint32_t *src, uint32_t word_len);
     void write_regs(uint32_t byte_addr, uint32_t word_len, const void *data);
     void read_regs(uint32_t byte_addr, uint32_t word_len, void *data);
+    void read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
+    void write_to_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
 
     // TLB related functions.
     // TODO: These are architecture specific, and will be moved out of the class.
@@ -137,5 +143,9 @@ protected:
     // to 2-byte writes. We avoid ever performing a 1-byte write to the device. This only affects to device.
     void memcpy_to_device(void *dest, const void *src, std::size_t num_bytes);
     void memcpy_from_device(void *dest, const void *src, std::size_t num_bytes);
+
+    void create_read_write_mutex();
+
+    std::shared_ptr<boost::interprocess::named_mutex> read_write_mutex = nullptr;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -68,6 +68,10 @@ public:
     void write_regs(volatile uint32_t *dest, const uint32_t *src, uint32_t word_len);
     void write_regs(uint32_t byte_addr, uint32_t word_len, const void *data);
     void read_regs(uint32_t byte_addr, uint32_t word_len, void *data);
+
+    // Read/write functions that always use same TLB entry. This is not supposed to be used
+    // on any code path that is performance critical. It is used to read/write the data needed
+    // to get the information to form cluster of chips, or just use base TTDevice functions.
     void read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
     void write_to_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
 

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -8,6 +8,7 @@ set(API_TESTS_SRCS
     test_mockup_device.cpp
     test_soc_descriptor.cpp
     test_tlb_manager.cpp
+    test_tt_device.cpp
 )
 
 add_executable(api_tests ${API_TESTS_SRCS})

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "gtest/gtest.h"
+#include "l1_address_map.h"
+#include "umd/device/blackhole_implementation.h"
+#include "umd/device/grayskull_implementation.h"
+#include "umd/device/tt_device/tt_device.h"
+#include "umd/device/wormhole_implementation.h"
+
+using namespace tt::umd;
+
+tt_xy_pair get_any_tensix_core(tt::ARCH arch) {
+    switch (arch) {
+        case tt::ARCH::BLACKHOLE:
+            return blackhole::TENSIX_CORES[0];
+        case tt::ARCH::WORMHOLE_B0:
+            return wormhole::TENSIX_CORES[0];
+        case tt::ARCH::GRAYSKULL:
+            return grayskull::TENSIX_CORES[0];
+        default:
+            throw std::runtime_error("Invalid architecture");
+    }
+}
+
+TEST(TTDeviceTest, BasicTTDeviceIO) {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+
+    uint64_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
+    std::vector<uint32_t> data_write = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    std::vector<uint32_t> data_read(data_write.size(), 0);
+
+    for (int pci_device_id : pci_device_ids) {
+        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+
+        tt_xy_pair tensix_core = get_any_tensix_core(tt_device->get_arch());
+
+        tt_device->write_to_device(data_write.data(), tensix_core, address, data_write.size() * sizeof(uint32_t));
+
+        tt_device->read_from_device(data_read.data(), tensix_core, address, data_read.size() * sizeof(uint32_t));
+
+        ASSERT_EQ(data_write, data_read);
+
+        data_read = std::vector<uint32_t>(data_write.size(), 0);
+    }
+}


### PR DESCRIPTION
### Issue
/

### Description
Tearing apart everything that is needed for blackhole topology discovery into smaller PRs. This PR adds r/w functions to TTDevice. TTDevice is always taking the same TLB in order to do read/write. This path in the future can go through KMD or just take and release any TLB provided by KMD. This is needed to read some basic info about the chip when we don't have chip class. This work is pushing towards proper layering (create cluster bottom up)

### List of the changes
- Add read_from_device to TTDevice
- Add write_to_device to TTDevice
- Add test

### Testing
Added test for basic IO. Existing CI

### API Changes
/
