### PR TITLE
Implement blackhole telemetry

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -49,6 +49,7 @@ target_sources(
         wormhole/wormhole_coordinate_manager.cpp
         blackhole/blackhole_coordinate_manager.cpp
         blackhole/blackhole_arc_message_queue.cpp
+        blackhole/blackhole_arc_telemetry_reader.cpp
         xy_pair.cpp
         ${FBS_GENERATED_HEADER}
 )

--- a/device/api/umd/device/blackhole_arc_telemetry_reader.h
+++ b/device/api/umd/device/blackhole_arc_telemetry_reader.h
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "umd/device/blackhole_implementation.h"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/tt_device/tt_device.h"
+#include "umd/device/types/blackhole_telemetry.h"
+
+namespace tt::umd {
+
+namespace blackhole {
+
+class BlackholeArcTelemetryReader {
+public:
+    BlackholeArcTelemetryReader(TTDevice* tt_device);
+
+    uint32_t read_entry(const uint8_t telemetry_tag);
+
+    bool is_entry_available(const uint8_t telemetry_tag);
+
+private:
+    void initialize_telemetry();
+
+    TTDevice* tt_device;
+
+    // Address of the telemetry table struct on ARC core.
+    uint32_t telemetry_table_addr;
+
+    // Number of entries in the telemetry table.
+    uint32_t entry_count;
+
+    // Address of the telemetry data on ARC core.
+    uint32_t telemetry_values_addr;
+
+    uint32_t telemetry_values[NUMBER_TELEMETRY_TAGS];
+    bool telemetry_entry_available[NUMBER_TELEMETRY_TAGS];
+    uint32_t telemetry_offset[NUMBER_TELEMETRY_TAGS];
+
+    const tt_xy_pair arc_core = tt::umd::blackhole::ARC_CORES[0];
+};
+
+}  // namespace blackhole
+
+}  // namespace tt::umd

--- a/device/api/umd/device/blackhole_arc_telemetry_reader.h
+++ b/device/api/umd/device/blackhole_arc_telemetry_reader.h
@@ -33,6 +33,14 @@ private:
     // Number of entries in the telemetry table.
     uint32_t entry_count;
 
+    // After entry_count the telemetry contains entry_count structs of TelemetryTagEntry.
+    // Each struct contains tag and offset. Tag represents what is represented by the value.
+    // Offset is the index of the telemetry value in the telemetry_values array.
+    struct TelemetryTagEntry {
+        uint16_t tag;
+        uint16_t offset;
+    };
+
     // Address of the telemetry data on ARC core.
     uint32_t telemetry_values_addr;
 

--- a/device/api/umd/device/blackhole_implementation.h
+++ b/device/api/umd/device/blackhole_implementation.h
@@ -204,6 +204,9 @@ constexpr uint32_t ARC_FW_INT_VAL = 65536;
 
 constexpr uint32_t ARC_MSG_RESPONSE_OK_LIMIT = 240;
 
+static const uint32_t SCRATCH_RAM_12 = 0x80030430;
+static const uint32_t SCRATCH_RAM_13 = 0x80030434;
+
 static const size_t eth_translated_coordinate_start_x = 20;
 static const size_t eth_translated_coordinate_start_y = 25;
 

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -75,12 +75,6 @@ public:
     void read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
     void write_to_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
 
-    // Read/write functions that always use same TLB entry. This is not supposed to be used
-    // on any code path that is performance critical. It is used to read/write the data needed
-    // to get the information to form cluster of chips, or just use base TTDevice functions.
-    void read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
-    void write_to_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
-
     // TLB related functions.
     // TODO: These are architecture specific, and will be moved out of the class.
     void write_tlb_reg(

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -68,6 +68,8 @@ public:
     void write_regs(volatile uint32_t *dest, const uint32_t *src, uint32_t word_len);
     void write_regs(uint32_t byte_addr, uint32_t word_len, const void *data);
     void read_regs(uint32_t byte_addr, uint32_t word_len, void *data);
+    void read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
+    void write_to_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
 
     // Read/write functions that always use same TLB entry. This is not supposed to be used
     // on any code path that is performance critical. It is used to read/write the data needed

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -68,6 +68,10 @@ public:
     void write_regs(volatile uint32_t *dest, const uint32_t *src, uint32_t word_len);
     void write_regs(uint32_t byte_addr, uint32_t word_len, const void *data);
     void read_regs(uint32_t byte_addr, uint32_t word_len, void *data);
+
+    // Read/write functions that always use same TLB entry. This is not supposed to be used
+    // on any code path that is performance critical. It is used to read/write the data needed
+    // to get the information to form cluster of chips, or just use base TTDevice functions.
     void read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
     void write_to_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
 

--- a/device/api/umd/device/types/blackhole_telemetry.h
+++ b/device/api/umd/device/types/blackhole_telemetry.h
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+namespace tt::umd {
+
+namespace blackhole {
+
+constexpr uint8_t NUMBER_TELEMETRY_TAGS = 38;
+
+constexpr uint8_t TAG_BOARD_ID_HIGH = 1;
+constexpr uint8_t TAG_BOARD_ID_LOW = 2;
+constexpr uint8_t TAG_ASIC_ID = 3;
+constexpr uint8_t TAG_HARVESTING_STATE = 4;
+constexpr uint8_t TAG_UPDATE_TELEM_SPEED = 5;
+constexpr uint8_t TAG_VCORE = 6;
+constexpr uint8_t TAG_TDP = 7;
+constexpr uint8_t TAG_TDC = 8;
+constexpr uint8_t TAG_VDD_LIMITS = 9;
+constexpr uint8_t TAG_THM_LIMITS = 10;
+constexpr uint8_t TAG_ASIC_TEMPERATURE = 11;
+constexpr uint8_t TAG_VREG_TEMPERATURE = 12;
+constexpr uint8_t TAG_BOARD_TEMPERATURE = 13;
+constexpr uint8_t TAG_AICLK = 14;
+constexpr uint8_t TAG_AXICLK = 15;
+constexpr uint8_t TAG_ARCCLK = 16;
+constexpr uint8_t TAG_L2CPUCLK0 = 17;
+constexpr uint8_t TAG_L2CPUCLK1 = 18;
+constexpr uint8_t TAG_L2CPUCLK2 = 19;
+constexpr uint8_t TAG_L2CPUCLK3 = 20;
+constexpr uint8_t TAG_ETH_LIVE_STATUS = 21;
+constexpr uint8_t TAG_DDR_STATUS = 22;
+constexpr uint8_t TAG_DDR_SPEED = 23;
+constexpr uint8_t TAG_ETH_FW_VERSION = 24;
+constexpr uint8_t TAG_DDR_FW_VERSION = 25;
+constexpr uint8_t TAG_BM_APP_FW_VERSION = 26;
+constexpr uint8_t TAG_BM_BL_FW_VERSION = 27;
+constexpr uint8_t TAG_FLASH_BUNDLE_VERSION = 28;
+constexpr uint8_t TAG_CM_FW_VERSION = 29;
+constexpr uint8_t TAG_L2CPU_FW_VERSION = 30;
+constexpr uint8_t TAG_FAN_SPEED = 31;
+constexpr uint8_t TAG_TIMER_HEARTBEAT = 32;
+constexpr uint8_t TAG_TELEM_ENUM_COUNT = 33;
+constexpr uint8_t TAG_ENABLED_TENSIX_COL = 34;
+constexpr uint8_t TAG_ENABLED_ETH = 35;
+constexpr uint8_t TAG_ENABLED_GDDR = 36;
+constexpr uint8_t TAG_ENABLED_L2CPU = 37;
+constexpr uint8_t TAG_PCIE_USAGE = 38;
+
+struct telemetry_entry {
+    uint16_t tag;
+    uint16_t offset;
+};
+
+// telemetry_table struct is going to be represented as a BlackholeArctelemetryReader class.
+// It is not possible to statically create this struct becase number of entries is not know at compile time.
+// struct telemetry_table {
+//   uint32_t version;
+//   uint32_t entry_count;
+//   struct telemetry_entry tag_table[TELEM_ENUM_COUNT];
+//   uint32_t telemetry[TELEM_ENUM_COUNT];
+// };
+
+}  // namespace blackhole
+
+}  // namespace tt::umd

--- a/device/api/umd/device/types/blackhole_telemetry.h
+++ b/device/api/umd/device/types/blackhole_telemetry.h
@@ -51,20 +51,6 @@ constexpr uint8_t TAG_ENABLED_GDDR = 36;
 constexpr uint8_t TAG_ENABLED_L2CPU = 37;
 constexpr uint8_t TAG_PCIE_USAGE = 38;
 
-struct telemetry_entry {
-    uint16_t tag;
-    uint16_t offset;
-};
-
-// telemetry_table struct is going to be represented as a BlackholeArctelemetryReader class.
-// It is not possible to statically create this struct becase number of entries is not know at compile time.
-// struct telemetry_table {
-//   uint32_t version;
-//   uint32_t entry_count;
-//   struct telemetry_entry tag_table[TELEM_ENUM_COUNT];
-//   uint32_t telemetry[TELEM_ENUM_COUNT];
-// };
-
 }  // namespace blackhole
 
 }  // namespace tt::umd

--- a/device/api/umd/device/types/cluster_descriptor_types.h
+++ b/device/api/umd/device/types/cluster_descriptor_types.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <fmt/core.h>
+
 #include <cstdint>
 #include <functional>
 
@@ -46,6 +48,21 @@ enum BoardType : uint32_t {
     GALAXY,
     UNKNOWN,
 };
+
+// TODO: add Wormhole and Grayskull board types to this function
+inline BoardType get_board_type_from_board_id(const uint64_t board_id) {
+    uint64_t upi = (board_id >> 36) & 0xFFFFF;
+
+    if (upi == 0x36) {
+        return BoardType::P100;
+    } else if (upi == 0x43) {
+        return BoardType::P100;
+    } else if (upi == 0x40 || upi == 0x41) {
+        return BoardType::P150A;
+    }
+
+    throw std::runtime_error(fmt::format("No existing board type for board id {}", board_id));
+}
 
 namespace std {
 template <>

--- a/device/blackhole/blackhole_arc_telemetry_reader.cpp
+++ b/device/blackhole/blackhole_arc_telemetry_reader.cpp
@@ -1,0 +1,93 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "umd/device/blackhole_arc_telemetry_reader.h"
+
+#include <fmt/core.h>
+
+namespace tt::umd {
+
+namespace blackhole {
+
+BlackholeArcTelemetryReader::BlackholeArcTelemetryReader(TTDevice* tt_device) : tt_device(tt_device) {
+    initialize_telemetry();
+}
+
+void BlackholeArcTelemetryReader::initialize_telemetry() {
+    for (uint8_t i = 0; i < NUMBER_TELEMETRY_TAGS; i++) {
+        telemetry_entry_available[i] = false;
+    }
+
+    tt_device->read_from_device(
+        &telemetry_table_addr,
+        BlackholeArcTelemetryReader::arc_core,
+        tt::umd::blackhole::SCRATCH_RAM_13,
+        sizeof(uint32_t));
+
+    tt_device->read_from_device(
+        &entry_count, BlackholeArcTelemetryReader::arc_core, telemetry_table_addr + sizeof(uint32_t), sizeof(uint32_t));
+
+    tt_device->read_from_device(
+        &telemetry_values_addr,
+        BlackholeArcTelemetryReader::arc_core,
+        tt::umd::blackhole::SCRATCH_RAM_12,
+        sizeof(uint32_t));
+
+    // We offset the tag_table_address by 2 * sizeof(uint32_t) to skip the first two uint32_t values,
+    // which are version and entry count. For representaiton look at blackhole_telemetry.h
+    uint32_t tag_table_address = telemetry_table_addr + 2 * sizeof(uint32_t);
+    std::vector<blackhole::telemetry_entry> telemetry_tag_entries(entry_count);
+    tt_device->read_from_device(
+        telemetry_tag_entries.data(),
+        BlackholeArcTelemetryReader::arc_core,
+        tag_table_address,
+        entry_count * sizeof(blackhole::telemetry_entry));
+
+    std::vector<uint32_t> telemetry_data(entry_count);
+    tt_device->read_from_device(
+        telemetry_data.data(),
+        BlackholeArcTelemetryReader::arc_core,
+        telemetry_values_addr,
+        entry_count * sizeof(uint32_t));
+
+    for (const blackhole::telemetry_entry& tag_entry : telemetry_tag_entries) {
+        const uint16_t tag_val = tag_entry.tag;
+        const uint16_t offset_val = tag_entry.offset;
+
+        telemetry_values[tag_val - 1] = telemetry_data[offset_val];
+        telemetry_entry_available[tag_val - 1] = true;
+        telemetry_offset[tag_val - 1] = offset_val;
+    }
+}
+
+uint32_t BlackholeArcTelemetryReader::read_entry(const uint8_t telemetry_tag) {
+    if (telemetry_tag == 0 || telemetry_tag > NUMBER_TELEMETRY_TAGS) {
+        throw std::runtime_error(fmt::format("Invalid telemtry tag {}", telemetry_tag));
+    }
+
+    if (!telemetry_entry_available[telemetry_tag - 1]) {
+        throw std::runtime_error(fmt::format(
+            "Telemetry entry {} not available. You can use is_entry_available() to check if the entry is available.",
+            telemetry_tag));
+    }
+
+    const uint32_t offset = telemetry_offset[telemetry_tag - 1];
+    uint32_t telemetry_val;
+    tt_device->read_from_device(
+        &telemetry_val,
+        BlackholeArcTelemetryReader::arc_core,
+        telemetry_values_addr + offset * sizeof(uint32_t),
+        sizeof(uint32_t));
+
+    telemetry_values[telemetry_tag - 1] = telemetry_val;
+    return telemetry_values[telemetry_tag - 1];
+}
+
+bool BlackholeArcTelemetryReader::is_entry_available(const uint8_t telemetry_tag) {
+    return telemetry_entry_available[telemetry_tag - 1];
+}
+
+}  // namespace blackhole
+}  // namespace tt::umd

--- a/device/blackhole/blackhole_arc_telemetry_reader.cpp
+++ b/device/blackhole/blackhole_arc_telemetry_reader.cpp
@@ -38,12 +38,12 @@ void BlackholeArcTelemetryReader::initialize_telemetry() {
     // We offset the tag_table_address by 2 * sizeof(uint32_t) to skip the first two uint32_t values,
     // which are version and entry count. For representaiton look at blackhole_telemetry.h
     uint32_t tag_table_address = telemetry_table_addr + 2 * sizeof(uint32_t);
-    std::vector<blackhole::telemetry_entry> telemetry_tag_entries(entry_count);
+    std::vector<TelemetryTagEntry> telemetry_tag_entries(entry_count);
     tt_device->read_from_device(
         telemetry_tag_entries.data(),
         BlackholeArcTelemetryReader::arc_core,
         tag_table_address,
-        entry_count * sizeof(blackhole::telemetry_entry));
+        entry_count * sizeof(TelemetryTagEntry));
 
     std::vector<uint32_t> telemetry_data(entry_count);
     tt_device->read_from_device(
@@ -52,7 +52,7 @@ void BlackholeArcTelemetryReader::initialize_telemetry() {
         telemetry_values_addr,
         entry_count * sizeof(uint32_t));
 
-    for (const blackhole::telemetry_entry& tag_entry : telemetry_tag_entries) {
+    for (const TelemetryTagEntry& tag_entry : telemetry_tag_entries) {
         const uint16_t tag_val = tag_entry.tag;
         const uint16_t offset_val = tag_entry.offset;
 

--- a/tests/blackhole/CMakeLists.txt
+++ b/tests/blackhole/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(UNIT_TESTS_BH_SRCS
     test_cluster_bh.cpp
     test_arc_messages_bh.cpp
+    test_arc_telemetry_bh.cpp
 )
 
 add_executable(unit_tests_blackhole ${UNIT_TESTS_BH_SRCS})

--- a/tests/blackhole/test_arc_telemetry_bh.cpp
+++ b/tests/blackhole/test_arc_telemetry_bh.cpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "gtest/gtest.h"
+#include "umd/device/blackhole_arc_telemetry_reader.h"
+
+using namespace tt::umd;
+
+TEST(BlackholeTelemetry, BasicBlackholeTelemetry) {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+
+    for (int pci_device_id : pci_device_ids) {
+        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<blackhole::BlackholeArcTelemetryReader> blackhole_arc_telemetry_reader =
+            std::make_unique<blackhole::BlackholeArcTelemetryReader>(tt_device.get());
+
+        uint32_t board_id_high = blackhole_arc_telemetry_reader->read_entry(blackhole::TAG_BOARD_ID_HIGH);
+        uint32_t board_id_low = blackhole_arc_telemetry_reader->read_entry(blackhole::TAG_BOARD_ID_LOW);
+
+        const uint64_t board_id = ((uint64_t)board_id_high << 32) | (board_id_low);
+        EXPECT_NO_THROW(get_board_type_from_board_id(board_id));
+    }
+}


### PR DESCRIPTION
### Issue

#94 - this should close the issue

### Description
Tearing apart things for work towards Blackhole topology. 
Implement telemetry reading for Blackhole. RW are going through TTDevice, could be switched to go through Chip in the future, although this is not something that should be on a perf path. Telemetry reading is not same for Wormhole. We can generalize this class and derive ARCH specific things in the future if we ever implement Wormhole telemetry from source.

### List of the changes
- Create BlackholeArcTelemetryReader that provides the API for reading of blackhole telemetry
- Add test

### Testing
Added test for BH telemetry. Existing CI

### API Changes
/
