### PR TITLE
Add ChipInfo struct

### DIFF
--- a/device/api/umd/device/tt_device/blackhole_tt_device.h
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.h
@@ -8,6 +8,7 @@
 
 #include <set>
 
+#include "umd/device/blackhole_arc_telemetry_reader.h"
 #include "umd/device/tt_device/tt_device.h"
 
 namespace tt::umd {
@@ -18,8 +19,11 @@ public:
 
     void configure_iatu_region(size_t region, uint64_t base, uint64_t target, size_t size) override;
 
+    ChipInfo get_chip_info() override;
+
 private:
     static constexpr uint64_t ATU_OFFSET_IN_BH_BAR2 = 0x1200;
     std::set<size_t> iatu_regions_;
+    std::unique_ptr<blackhole::BlackholeArcTelemetryReader> telemetry = nullptr;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/grayskull_tt_device.h
+++ b/device/api/umd/device/tt_device/grayskull_tt_device.h
@@ -12,5 +12,7 @@ namespace tt::umd {
 class GrayskullTTDevice : public TTDevice {
 public:
     GrayskullTTDevice(std::unique_ptr<PCIDevice> pci_device);
+
+    ChipInfo get_chip_info() override;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -9,6 +9,7 @@
 #include "umd/device/architecture_implementation.h"
 #include "umd/device/pci_device.hpp"
 #include "umd/device/tt_device/tlb_manager.h"
+#include "umd/device/types/cluster_descriptor_types.h"
 
 // TODO: Should be moved to blackhole_architecture_implementation.h
 // See /vendor_ip/synopsys/052021/bh_pcie_ctl_gen5/export/configuration/DWC_pcie_ctl.h
@@ -127,6 +128,8 @@ public:
      */
     virtual void configure_iatu_region(size_t region, uint64_t base, uint64_t target, size_t size);
 
+    virtual ChipInfo get_chip_info() = 0;
+
 protected:
     std::unique_ptr<PCIDevice> pci_device_;
     std::unique_ptr<architecture_implementation> architecture_impl_;
@@ -151,5 +154,7 @@ protected:
     void create_read_write_mutex();
 
     std::shared_ptr<boost::interprocess::named_mutex> read_write_mutex = nullptr;
+
+    ChipInfo chip_info;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/wormhole_tt_device.h
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.h
@@ -12,5 +12,7 @@ namespace tt::umd {
 class WormholeTTDevice : public TTDevice {
 public:
     WormholeTTDevice(std::unique_ptr<PCIDevice> pci_device);
+
+    ChipInfo get_chip_info() override;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/types/cluster_descriptor_types.h
+++ b/device/api/umd/device/types/cluster_descriptor_types.h
@@ -11,6 +11,8 @@
 #include <cstdint>
 #include <functional>
 
+#include "umd/device/types/harvesting.h"
+
 // Small performant hash combiner taken from boost library.
 // Not using boost::hash_combine due to dependency complications.
 inline void boost_hash_combine(std::size_t &seed, const int value) {
@@ -63,6 +65,18 @@ inline BoardType get_board_type_from_board_id(const uint64_t board_id) {
 
     throw std::runtime_error(fmt::format("No existing board type for board id {}", board_id));
 }
+
+struct ChipUID {
+    uint64_t board_id;
+    uint8_t asic_location;
+};
+
+struct ChipInfo {
+    tt::umd::HarvestingMasks harvesting_masks;
+    BoardType board_type;
+    ChipUID chip_uid;
+    bool noc_translation_enabled;
+};
 
 namespace std {
 template <>

--- a/device/tt_device/grayskull_tt_device.cpp
+++ b/device/tt_device/grayskull_tt_device.cpp
@@ -9,4 +9,9 @@ namespace tt::umd {
 
 GrayskullTTDevice::GrayskullTTDevice(std::unique_ptr<PCIDevice> pci_device) :
     TTDevice(std::move(pci_device), std::make_unique<grayskull_implementation>()) {}
+
+ChipInfo GrayskullTTDevice::get_chip_info() {
+    throw std::runtime_error("Reading ChipInfo is not supported for Grayskull.");
+}
+
 }  // namespace tt::umd

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -9,4 +9,9 @@ namespace tt::umd {
 
 WormholeTTDevice::WormholeTTDevice(std::unique_ptr<PCIDevice> pci_device) :
     TTDevice(std::move(pci_device), std::make_unique<wormhole_implementation>()) {}
+
+ChipInfo WormholeTTDevice::get_chip_info() {
+    throw std::runtime_error("Reading ChipInfo is not supported for Wormhole.");
+}
+
 }  // namespace tt::umd

--- a/tests/blackhole/CMakeLists.txt
+++ b/tests/blackhole/CMakeLists.txt
@@ -2,6 +2,7 @@ set(UNIT_TESTS_BH_SRCS
     test_cluster_bh.cpp
     test_arc_messages_bh.cpp
     test_arc_telemetry_bh.cpp
+    test_chip_info_bh.cpp
 )
 
 add_executable(unit_tests_blackhole ${UNIT_TESTS_BH_SRCS})

--- a/tests/blackhole/test_chip_info_bh.cpp
+++ b/tests/blackhole/test_chip_info_bh.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "gtest/gtest.h"
+#include "umd/device/tt_device/tt_device.h"
+
+using namespace tt::umd;
+
+TEST(BlackholeChipInfo, BasicChipInfo) {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+
+    for (int pci_device_id : pci_device_ids) {
+        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+
+        const ChipInfo chip_info = tt_device->get_chip_info();
+
+        EXPECT_TRUE(chip_info.board_type == BoardType::P100 || chip_info.board_type == BoardType::P150A);
+
+        EXPECT_TRUE(chip_info.chip_uid.asic_location == 0 || chip_info.chip_uid.asic_location == 1);
+    }
+}


### PR DESCRIPTION
### Issue
/

### Description
Tearing apart the PR for blackhole topology into smaller ones.
This PR adds ChipInfo struct which holds all the information needed to construct the Chip on top of TTDevice.

### List of the changes
- Add ChipInfo struct
- Read ChipInfo struct from TTDevice
- Add test

### Testing
Added test. Existing CI

### API Changes
/