### PR TITLE
Serialize cluster into yaml

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -690,7 +690,7 @@ public:
      * Simplest form, creates a cluster of all available devices on the system.
      *
      * @param num_host_mem_ch_per_mmio_device Requested number of host channels (hugepages).
-     * @param skip_driver_allocs
+     * @param create_mock_chips Create mock chips for the devices in the cluster descriptor.
      * @param clean_system_resource Specifies if host state from previous runs needs to be cleaned up.
      * @param perform_harvesting Allow the driver to modify the SOC descriptors per chip.
      * @param simulated_harvesting_masks Manually specify additional harvesting masks for the devices in the cluster.
@@ -699,11 +699,10 @@ public:
      */
     Cluster(
         const uint32_t& num_host_mem_ch_per_mmio_device = 1,
-        const bool skip_driver_allocs = false,
+        const bool create_mock_chips = false,
         const bool clean_system_resources = false,
         bool perform_harvesting = true,
-        std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {},
-        const bool create_mock_chips = false);
+        std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {});
 
     /**
      * Cluster constructor.
@@ -711,21 +710,19 @@ public:
      *
      * @param target_devices Devices to target.
      * @param num_host_mem_ch_per_mmio_device Requested number of host channels (hugepages).
-     * @param skip_driver_allocs
+     * @param create_mock_chips Create mock chips for the devices in the cluster descriptor.
      * @param clean_system_resource Specifies if host state from previous runs needs to be cleaned up.
      * @param perform_harvesting Allow the driver to modify the SOC descriptors per chip.
      * @param simulated_harvesting_masks Manually specify additional harvesting masks for the devices in the cluster.
      * The ones defined by the devices itself have to be used, they will be merged with the ones passed here.
-     * @param create_mock_chips Create mock chips for the devices in the cluster descriptor.
      */
     Cluster(
         const std::set<chip_id_t>& target_devices,
         const uint32_t& num_host_mem_ch_per_mmio_device = 1,
-        const bool skip_driver_allocs = false,
+        const bool create_mock_chips = false,
         const bool clean_system_resources = false,
         bool perform_harvesting = true,
-        std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {},
-        const bool create_mock_chips = false);
+        std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {});
 
     /**
      * Cluster constructor.
@@ -736,22 +733,20 @@ public:
      * harvesting info of the devices in the cluster.
      * @param target_devices Devices to target.
      * @param num_host_mem_ch_per_mmio_device Requested number of host channels (hugepages).
-     * @param skip_driver_allocs
+     * @param create_mock_chips Create mock chips for the devices in the cluster descriptor.
      * @param clean_system_resource Specifies if host state from previous runs needs to be cleaned up.
      * @param perform_harvesting Allow the driver to modify the SOC descriptors per chip.
      * @param simulated_harvesting_masks Manually specify additional harvesting masks for the devices in the cluster.
      * The ones defined by the devices itself have to be used, they will be merged with the ones passed here.
-     * @param create_mock_chips Create mock chips for the devices in the cluster descriptor.
      */
     Cluster(
         const std::string& sdesc_path,
         const std::set<chip_id_t>& target_devices,
         const uint32_t& num_host_mem_ch_per_mmio_device = 1,
-        const bool skip_driver_allocs = false,
+        const bool create_mock_chips = false,
         const bool clean_system_resources = false,
         bool perform_harvesting = true,
-        std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {},
-        const bool create_mock_chips = false);
+        std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {});
 
     /**
      * Cluster constructor.
@@ -761,21 +756,19 @@ public:
      *
      * @param cluster_descriptor Cluster descriptor object based on which Cluster is going to be created.
      * @param num_host_mem_ch_per_mmio_device Requested number of host channels (hugepages).
-     * @param skip_driver_allocs
+     * @param create_mock_chips Create mock chips for the devices in the cluster descriptor.
      * @param clean_system_resource Specifies if host state from previous runs needs to be cleaned up.
      * @param perform_harvesting Allow the driver to modify the SOC descriptors per chip.
      * @param simulated_harvesting_masks Manually specify additional harvesting masks for the devices in the cluster.
      * The ones defined by the devices itself have to be used, they will be merged with the ones passed here.
-     * @param create_mock_chips Create mock chips for the devices in the cluster descriptor.
      */
     Cluster(
         std::unique_ptr<tt_ClusterDescriptor> cluster_descriptor,
         const uint32_t& num_host_mem_ch_per_mmio_device = 1,
-        const bool skip_driver_allocs = false,
+        const bool create_mock_chips = false,
         const bool clean_system_resources = false,
         bool perform_harvesting = true,
-        std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {},
-        const bool create_mock_chips = false);
+        std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {});
 
     // Existing API we want to keep. UMD is transitioning to use CoreCoord instead of tt_xy_pair.
     // This set of function shouldn't be removed even after the transition.
@@ -1014,7 +1007,7 @@ private:
     void create_device(
         const std::set<chip_id_t>& target_mmio_device_ids,
         const uint32_t& num_host_mem_ch_per_mmio_device,
-        const bool skip_driver_allocs,
+        const bool create_mock_chips,
         const bool clean_system_resources);
     void initialize_interprocess_mutexes(int logical_device_id, bool cleanup_mutexes_in_shm);
     void cleanup_shared_host_state();
@@ -1188,7 +1181,7 @@ private:
         std::unordered_map<chip_id_t, HarvestingMasks>& simulated_harvesting_masks);
     void construct_cluster(
         const uint32_t& num_host_mem_ch_per_mmio_device,
-        const bool skip_driver_allocs,
+        const bool create_mock_chips,
         const bool clean_system_resources,
         bool perform_harvesting,
         std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks);

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -700,7 +700,8 @@ public:
         const bool skip_driver_allocs = false,
         const bool clean_system_resources = false,
         bool perform_harvesting = true,
-        std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {});
+        std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {},
+        const bool create_mock_chips = false);
 
     /**
      * Cluster constructor.
@@ -720,7 +721,8 @@ public:
         const bool skip_driver_allocs = false,
         const bool clean_system_resources = false,
         bool perform_harvesting = true,
-        std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {});
+        std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {},
+        const bool create_mock_chips = false);
 
     /**
      * Cluster constructor.
@@ -744,34 +746,17 @@ public:
         const bool skip_driver_allocs = false,
         const bool clean_system_resources = false,
         bool perform_harvesting = true,
-        std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {});
+        std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {},
+        const bool create_mock_chips = false);
 
-    /**
-     * Cluster constructor.
-     * This constructor offers maximal flexibility, allowing the user to pass manually created Chips.
-     * The user has to know what they are doing.
-     * TODO: Could fail if logical_ids not match the ones in cluster descriptor, while Cluster still uses cluster
-     * descriptor.
-     *
-     * @param chips Map of logical device ids to Chip instances.
-     * @param num_host_mem_ch_per_mmio_device Requested number of host channels (hugepages).
-     * @param skip_driver_allocs
-     * @param clean_system_resource Specifies if host state from previous runs needs to be cleaned up.
-     * @param perform_harvesting Allow the driver to modify the SOC descriptors per chip.
-     * @param simulated_harvesting_masks
-     */
     Cluster(
-        std::unordered_map<chip_id_t, std::unique_ptr<Chip>>& chips,
+        std::unique_ptr<tt_ClusterDescriptor> cluster_descriptor,
         const uint32_t& num_host_mem_ch_per_mmio_device = 1,
         const bool skip_driver_allocs = false,
         const bool clean_system_resources = false,
         bool perform_harvesting = true,
-        std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {});
-
-    /**
-     * Cluster constructor which creates a cluster with Mock chips.
-     */
-    static std::unique_ptr<Cluster> create_mock_cluster();
+        std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {},
+        const bool create_mock_chips = false);
 
     // Existing API we want to keep. UMD is transitioning to use CoreCoord instead of tt_xy_pair.
     // This set of function shouldn't be removed even after the transition.
@@ -996,6 +981,9 @@ public:
         const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores, const std::string& fallback_tlb);
 
     static std::unique_ptr<tt_ClusterDescriptor> create_cluster_descriptor();
+
+    static std::string serialize();
+
     // Destructor
     virtual ~Cluster();
 
@@ -1137,18 +1125,23 @@ private:
 
     // Helper functions for constructing the chips from the cluster descriptor.
     std::unique_ptr<Chip> construct_chip_from_cluster(
-        chip_id_t chip_id, tt_ClusterDescriptor* cluster_desc, tt_SocDescriptor& soc_desc);
+        chip_id_t chip_id,
+        tt_ClusterDescriptor* cluster_desc,
+        tt_SocDescriptor& soc_desc,
+        const bool create_mock_chip = false);
     std::unique_ptr<Chip> construct_chip_from_cluster(
         const std::string& soc_desc_path,
         chip_id_t chip_id,
         tt_ClusterDescriptor* cluster_desc,
         bool perform_harvesting,
-        std::unordered_map<chip_id_t, HarvestingMasks>& simulated_harvesting_masks);
+        std::unordered_map<chip_id_t, HarvestingMasks>& simulated_harvesting_masks,
+        const bool create_mock_chip = false);
     std::unique_ptr<Chip> construct_chip_from_cluster(
         chip_id_t logical_device_id,
         tt_ClusterDescriptor* cluster_desc,
         bool perform_harvesting,
-        std::unordered_map<chip_id_t, HarvestingMasks>& simulated_harvesting_masks);
+        std::unordered_map<chip_id_t, HarvestingMasks>& simulated_harvesting_masks,
+        const bool create_mock_chip = false);
     void add_chip(chip_id_t chip_id, std::unique_ptr<Chip> chip);
     HarvestingMasks get_harvesting_masks(
         chip_id_t chip_id,

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -7,6 +7,7 @@
 #pragma once
 #include <cassert>
 #include <cstdint>
+#include <filesystem>
 #include <memory>
 #include <set>
 #include <stdexcept>
@@ -694,6 +695,7 @@ public:
      * @param perform_harvesting Allow the driver to modify the SOC descriptors per chip.
      * @param simulated_harvesting_masks Manually specify additional harvesting masks for the devices in the cluster.
      * The ones defined by the devices itself have to be used, they will be merged with the ones passed here.
+     * @param create_mock_chips Create mock chips for the devices in the cluster descriptor.
      */
     Cluster(
         const uint32_t& num_host_mem_ch_per_mmio_device = 1,
@@ -714,6 +716,7 @@ public:
      * @param perform_harvesting Allow the driver to modify the SOC descriptors per chip.
      * @param simulated_harvesting_masks Manually specify additional harvesting masks for the devices in the cluster.
      * The ones defined by the devices itself have to be used, they will be merged with the ones passed here.
+     * @param create_mock_chips Create mock chips for the devices in the cluster descriptor.
      */
     Cluster(
         const std::set<chip_id_t>& target_devices,
@@ -738,6 +741,7 @@ public:
      * @param perform_harvesting Allow the driver to modify the SOC descriptors per chip.
      * @param simulated_harvesting_masks Manually specify additional harvesting masks for the devices in the cluster.
      * The ones defined by the devices itself have to be used, they will be merged with the ones passed here.
+     * @param create_mock_chips Create mock chips for the devices in the cluster descriptor.
      */
     Cluster(
         const std::string& sdesc_path,
@@ -749,6 +753,21 @@ public:
         std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {},
         const bool create_mock_chips = false);
 
+    /**
+     * Cluster constructor.
+     * This constructor can be used with custom cluster descriptor. If the cluster descriptor does not match the
+     * actual devices on the system, the constructor will throw an exception. If create_mock_chips is set to true,
+     * the constructor will create mock chips for the devices in the cluster descriptor.
+     *
+     * @param cluster_descriptor Cluster descriptor object based on which Cluster is going to be created.
+     * @param num_host_mem_ch_per_mmio_device Requested number of host channels (hugepages).
+     * @param skip_driver_allocs
+     * @param clean_system_resource Specifies if host state from previous runs needs to be cleaned up.
+     * @param perform_harvesting Allow the driver to modify the SOC descriptors per chip.
+     * @param simulated_harvesting_masks Manually specify additional harvesting masks for the devices in the cluster.
+     * The ones defined by the devices itself have to be used, they will be merged with the ones passed here.
+     * @param create_mock_chips Create mock chips for the devices in the cluster descriptor.
+     */
     Cluster(
         std::unique_ptr<tt_ClusterDescriptor> cluster_descriptor,
         const uint32_t& num_host_mem_ch_per_mmio_device = 1,
@@ -983,6 +1002,8 @@ public:
     static std::unique_ptr<tt_ClusterDescriptor> create_cluster_descriptor();
 
     static std::string serialize();
+
+    static std::filesystem::path serialize_to_file();
 
     // Destructor
     virtual ~Cluster();

--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -123,5 +123,7 @@ public:
 
     void enable_all_devices();
 
-    std::string serialize();
+    std::string serialize() const;
+
+    std::filesystem::path serialize_to_file() const;
 };

--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -122,4 +122,6 @@ public:
         chip_id_t local_chip, ethernet_channel_t local_ethernet_channel) const;
 
     void enable_all_devices();
+
+    std::string serialize();
 };

--- a/device/api/umd/device/types/cluster_descriptor_types.h
+++ b/device/api/umd/device/types/cluster_descriptor_types.h
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <functional>
 
+#include "fmt/core.h"
 #include "umd/device/types/harvesting.h"
 
 // Small performant hash combiner taken from boost library.
@@ -50,6 +51,33 @@ enum BoardType : uint32_t {
     GALAXY,
     UNKNOWN,
 };
+
+inline std::string board_type_to_string(const BoardType board_type) {
+    switch (board_type) {
+        case BoardType::E75:
+            return "e75";
+        case BoardType::E150:
+            return "e150";
+        case BoardType::E300:
+            return "e300";
+        case BoardType::N150:
+            return "n150";
+        case BoardType::N300:
+            return "n300";
+        case BoardType::P100:
+            return "p100";
+        case BoardType::P150A:
+            return "p150";
+        case BoardType::P300:
+            return "p300";
+        case BoardType::GALAXY:
+            return "galaxy";
+        case BoardType::UNKNOWN:
+            return "unknown";
+    }
+
+    throw std::runtime_error("Unknown board type passed for conversion to string.");
+}
 
 // TODO: add Wormhole and Grayskull board types to this function
 inline BoardType get_board_type_from_board_id(const uint64_t board_id) {

--- a/device/api/umd/device/types/cluster_descriptor_types.h
+++ b/device/api/umd/device/types/cluster_descriptor_types.h
@@ -66,7 +66,7 @@ inline std::string board_type_to_string(const BoardType board_type) {
             return "n300";
         case BoardType::P100:
             return "p100";
-        case BoardType::P150A:
+        case BoardType::P150:
             return "p150";
         case BoardType::P300:
             return "p300";

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -451,7 +451,7 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
         get_harvesting_masks(chip_id, cluster_desc, perform_harvesting, simulated_harvesting_masks);
     tt_SocDescriptor soc_desc =
         tt_SocDescriptor(soc_desc_path, cluster_desc->get_noc_translation_table_en().at(chip_id), harvesting_masks);
-    return construct_chip_from_cluster(chip_id, cluster_desc, soc_desc);
+    return construct_chip_from_cluster(chip_id, cluster_desc, soc_desc, create_mock_chip);
 }
 
 std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
@@ -464,7 +464,7 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     const BoardType chip_board_type = cluster_desc->get_board_type(chip_id);
     std::string soc_desc_path = tt_SocDescriptor::get_soc_descriptor_path(arch, chip_board_type);
     return construct_chip_from_cluster(
-        soc_desc_path, chip_id, cluster_desc, perform_harvesting, simulated_harvesting_masks);
+        soc_desc_path, chip_id, cluster_desc, perform_harvesting, simulated_harvesting_masks, create_mock_chip);
 }
 
 void Cluster::add_chip(chip_id_t chip_id, std::unique_ptr<Chip> chip) {
@@ -3541,5 +3541,7 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
 }
 
 std::string Cluster::serialize() { return Cluster::create_cluster_descriptor()->serialize(); }
+
+std::filesystem::path Cluster::serialize_to_file() { return Cluster::create_cluster_descriptor()->serialize_to_file(); }
 
 }  // namespace tt::umd

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -904,7 +904,7 @@ tt_ClusterDescriptor::get_chips_grouped_by_closest_mmio() const {
 
 chip_id_t tt_ClusterDescriptor::get_chip_id(const ChipUID &chip_uid) const { return chip_uid_to_chip_id.at(chip_uid); }
 
-std::string tt_ClusterDescriptor::serialize() {
+std::string tt_ClusterDescriptor::serialize() const {
     YAML::Emitter out;
 
     out << YAML::BeginMap;
@@ -964,13 +964,16 @@ std::string tt_ClusterDescriptor::serialize() {
 
     out << YAML::EndMap;
 
-    // Output YAML to file
+    return out.c_str();
+}
+
+std::filesystem::path tt_ClusterDescriptor::serialize_to_file() const {
     std::filesystem::path temp_path = std::filesystem::temp_directory_path();
     std::string cluster_path_dir_template = temp_path / "umd_XXXXXX";
     std::filesystem::path cluster_path_dir = mkdtemp(cluster_path_dir_template.data());
     std::filesystem::path cluster_path = cluster_path_dir / "cluster_descriptor.yaml";
     std::ofstream file(cluster_path);
-    file << out.c_str();
+    file << serialize();
     file.close();
 
     return cluster_path;

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -789,6 +789,13 @@ void tt_ClusterDescriptor::load_harvesting_information(YAML::Node &yaml, tt_Clus
 void tt_ClusterDescriptor::enable_all_devices() { this->enabled_active_chips = this->all_chips; }
 
 void tt_ClusterDescriptor::fill_chips_grouped_by_closest_mmio() {
+    // TODO: remote ethernet coordinates if new eth fw is ported for back Wormhole.
+    // For newer topologies every chip will have a direct connection to MMIO chip, so there won't be
+    // ethernet coordinates, represented by chip locations, to calculate the closest MMIO chip.
+    if (this->chip_locations.empty()) {
+        return;
+    }
+
     for (const auto &chip : this->all_chips) {
         // This will also fill up the closest_mmio_chip_cache
         chip_id_t closest_mmio_chip = get_closest_mmio_capable_chip(chip);
@@ -896,3 +903,75 @@ tt_ClusterDescriptor::get_chips_grouped_by_closest_mmio() const {
 }
 
 chip_id_t tt_ClusterDescriptor::get_chip_id(const ChipUID &chip_uid) const { return chip_uid_to_chip_id.at(chip_uid); }
+
+std::string tt_ClusterDescriptor::serialize() {
+    YAML::Emitter out;
+
+    out << YAML::BeginMap;
+
+    // Section: arch
+    out << YAML::Key << "arch" << YAML::Value << YAML::BeginMap;
+    for (const auto &[chip_id, arch] : chip_arch) {
+        out << YAML::Key << chip_id << YAML::Value << tt::arch_to_str(arch);
+    }
+    out << YAML::EndMap;
+
+    // Section: ethernet_connections
+    out << YAML::Key << "ethernet_connections" << YAML::Value << YAML::BeginSeq;
+    std::set<std::pair<chip_id_t, int>> serialized_connections;
+    for (const auto &[src_chip, channels] : ethernet_connections) {
+        for (const auto &[src_chan, dest] : channels) {
+            if (serialized_connections.find({src_chip, src_chan}) != serialized_connections.end()) {
+                continue;
+            }
+            auto [dest_chip, dest_chan] = dest;
+            serialized_connections.insert({dest_chip, dest_chan});
+            out << YAML::BeginSeq;
+            out << YAML::BeginMap << YAML::Key << "chip" << YAML::Value << src_chip << YAML::Key << "chan"
+                << YAML::Value << src_chan << YAML::EndMap;
+            out << YAML::BeginMap << YAML::Key << "chip" << YAML::Value << dest_chip << YAML::Key << "chan"
+                << YAML::Value << dest_chan << YAML::EndMap;
+            out << YAML::EndSeq;
+        }
+    }
+
+    out << YAML::EndSeq;
+
+    // Section: chips_with_mmio
+    out << YAML::Key << "chips_with_mmio" << YAML::Value << YAML::BeginSeq;
+    for (const auto &chip_with_mmio : chips_with_mmio) {
+        out << YAML::BeginMap << YAML::Key << chip_with_mmio.first << YAML::Value << chip_with_mmio.second
+            << YAML::EndMap;
+    }
+    out << YAML::EndSeq;
+
+    // Section: harvesting
+    out << YAML::Key << "harvesting" << YAML::Value << YAML::BeginMap;
+    for (const int &chip : all_chips) {
+        out << YAML::Key << chip << YAML::Value << YAML::BeginMap;
+        out << YAML::Key << "noc_translation" << YAML::Value << noc_translation_enabled.at(chip);
+        out << YAML::Key << "harvest_mask" << YAML::Value << harvesting_masks.at(chip);
+        out << YAML::EndMap;
+    }
+    out << YAML::EndMap;
+
+    // Section: boardtype
+    out << YAML::Key << "boardtype" << YAML::Value << YAML::BeginMap;
+    for (const int &chip : all_chips) {
+        out << YAML::Key << chip << YAML::Value << board_type_to_string(chip_board_type.at(chip));
+    }
+    out << YAML::EndMap;
+
+    out << YAML::EndMap;
+
+    // Output YAML to file
+    std::filesystem::path temp_path = std::filesystem::temp_directory_path();
+    std::string cluster_path_dir_template = temp_path / "umd_XXXXXX";
+    std::filesystem::path cluster_path_dir = mkdtemp(cluster_path_dir_template.data());
+    std::filesystem::path cluster_path = cluster_path_dir / "cluster_descriptor.yaml";
+    std::ofstream file(cluster_path);
+    file << out.c_str();
+    file.close();
+
+    return cluster_path;
+}

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -70,13 +70,6 @@ TEST(ApiClusterTest, DifferentConstructors) {
     std::string sdesc_path = tt_SocDescriptor::get_soc_descriptor_path(device_arch, BoardType::UNKNOWN);
     umd_cluster = std::make_unique<Cluster>(sdesc_path, target_devices);
     umd_cluster = nullptr;
-
-    // TODO: This doesn't work at the moment.
-    // It will start working when we move enough stuff to the chips. At the moment this was disabled, it was mostly due
-    // to harvesting info.
-    // // 4. Constructor for creating a cluster with mock chip.
-    // umd_cluster = Cluster::create_mock_cluster();
-    // umd_cluster = nullptr;
 }
 
 TEST(ApiClusterTest, SimpleIOAllChips) {
@@ -277,4 +270,11 @@ TEST(ClusterAPI, DynamicTLB_RW) {
         }
     }
     cluster->close_device();
+}
+
+TEST(ClusterAPI, TestClusterSerialize) {
+    std::string cluster_path = tt::umd::Cluster::serialize();
+    std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {};
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(
+        tt_ClusterDescriptor::create_from_yaml(cluster_path), 1, false, false, true, simulated_harvesting_masks, true);
 }

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -76,7 +76,7 @@ TEST(ApiClusterTest, DifferentConstructors) {
     std::filesystem::path cluster_path = tt::umd::Cluster::serialize_to_file();
     std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {};
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(
-        tt_ClusterDescriptor::create_from_yaml(cluster_path), 1, false, false, true, simulated_harvesting_masks, true);
+        tt_ClusterDescriptor::create_from_yaml(cluster_path), 1, true, false, true, simulated_harvesting_masks);
 }
 
 TEST(ApiClusterTest, SimpleIOAllChips) {

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -70,6 +70,13 @@ TEST(ApiClusterTest, DifferentConstructors) {
     std::string sdesc_path = tt_SocDescriptor::get_soc_descriptor_path(device_arch, BoardType::UNKNOWN);
     umd_cluster = std::make_unique<Cluster>(sdesc_path, target_devices);
     umd_cluster = nullptr;
+
+    // 4. Constructor taking cluster descriptor based on which to create cluster.
+    // Create mock chips is set to true in order to create mock chips for the devices in the cluster descriptor.
+    std::filesystem::path cluster_path = tt::umd::Cluster::serialize_to_file();
+    std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {};
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(
+        tt_ClusterDescriptor::create_from_yaml(cluster_path), 1, false, false, true, simulated_harvesting_masks, true);
 }
 
 TEST(ApiClusterTest, SimpleIOAllChips) {
@@ -270,11 +277,4 @@ TEST(ClusterAPI, DynamicTLB_RW) {
         }
     }
     cluster->close_device();
-}
-
-TEST(ClusterAPI, TestClusterSerialize) {
-    std::string cluster_path = tt::umd::Cluster::serialize();
-    std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {};
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(
-        tt_ClusterDescriptor::create_from_yaml(cluster_path), 1, false, false, true, simulated_harvesting_masks, true);
 }


### PR DESCRIPTION
### Issue

Solving part of #431 

### Description

Add a function to serialize cluster to the yaml (reverse of what we were doing so far). Add flag to all Cluster constructors to create mock chips inside Cluster if user wants that. Expose this (de)serializing through the API as mentioned in the issue above. Output yaml look like (note the styling difference than original, but in YAML world it is the same)

```
arch:
  1: wormhole_b0
  0: wormhole_b0
ethernet_connections:
  -
    - chip: 1
      chan: 1
    - chip: 0
      chan: 9
  -
    - chip: 1
      chan: 0
    - chip: 0
      chan: 8
chips_with_mmio:
  - 0: 0
harvesting:
  1:
    noc_translation: true
    harvest_mask: 513
  0:
    noc_translation: true
    harvest_mask: 129
boardtype:
  1: n300
  0: n300 
```

### List of the changes

- Add serialize function to Cluster (public)
- Add serialize function cluste descriptor (not public)
- Add flag to all Cluster constructors to create mock chips
- Add a test

### Testing
CI + new test

### API Changes

Added create_mock_chips to Cluster constuctors, but changes not needed in UMD clients.