### PR TITLE
Blackhole tests CoreCoord API

### DIFF
--- a/device/api/umd/device/tt_core_coordinates.h
+++ b/device/api/umd/device/tt_core_coordinates.h
@@ -126,7 +126,7 @@ struct CoreCoord : public tt_xy_pair {
         return coord_system < o.coord_system;
     }
 
-    std::string to_str() const {
+    std::string str() const {
         return "CoreCoord: (" + std::to_string(x) + ", " + std::to_string(y) + ", " + ::to_str(core_type) + ", " +
                ::to_str(coord_system) + ")";
     }

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -308,7 +308,7 @@ TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
             std::vector<uint8_t> readback_vec(size, 0);
             std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
             for (int loop = 0; loop < 50; loop++) {
-                for (CoreCoord core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
+                for (const CoreCoord& core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
                     cluster.write_to_device(write_vec.data(), size, i, core, address, "");
                     cluster.wait_for_non_mmio_flush();
                     cluster.read_from_device(readback_vec.data(), i, core, address, size, "");
@@ -342,7 +342,7 @@ TEST(SiliconDriverBH, StaticTLB_RW) {
         // Iterate over MMIO devices and only setup static TLBs for worker cores
         if (std::find(mmio_devices.begin(), mmio_devices.end(), i) != mmio_devices.end()) {
             auto& sdesc = cluster.get_soc_descriptor(i);
-            for (CoreCoord core : sdesc.get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
                 // Statically mapping a 2MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
                 cluster.configure_tlb(
                     i,
@@ -366,7 +366,7 @@ TEST(SiliconDriverBH, StaticTLB_RW) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (int loop = 0; loop < 1;
              loop++) {  // Write to each core a 100 times at different statically mapped addresses
-            for (CoreCoord core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
                 cluster.write_to_device(
                     vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), i, core, address, "");
                 cluster.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
@@ -411,7 +411,7 @@ TEST(SiliconDriverBH, DynamicTLB_RW) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (int loop = 0; loop < 100;
              loop++) {  // Write to each core a 100 times at different statically mapped addresses
-            for (CoreCoord core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
                 cluster.write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
@@ -489,7 +489,7 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (int loop = 0; loop < 100; loop++) {
-            for (CoreCoord core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 cluster.write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
@@ -512,7 +512,7 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
         std::uint32_t address = 0x30000000;
         for (std::vector<CoreCoord> core_ls : cluster.get_soc_descriptor(0).get_dram_cores()) {
             for (int loop = 0; loop < 100; loop++) {
-                for (CoreCoord core : core_ls) {
+                for (const CoreCoord& core : core_ls) {
                     cluster.write_to_device(
                         vector_to_write.data(),
                         vector_to_write.size() * sizeof(std::uint32_t),
@@ -553,7 +553,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for functional worker cores
         auto& sdesc = cluster.get_soc_descriptor(i);
-        for (CoreCoord core : sdesc.get_cores(CoreType::TENSIX)) {
+        for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
             cluster.configure_tlb(
                 i,
@@ -567,7 +567,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     cluster.start_device(default_params);
 
     std::vector<uint32_t> readback_membar_vec = {};
-    for (CoreCoord core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
+    for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
         test_utils::read_data_from_device(
             cluster, readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(
@@ -583,7 +583,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
         readback_membar_vec = {};
     }
 
-    for (CoreCoord core : cluster.get_soc_descriptor(0).get_cores(CoreType::ETH)) {
+    for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::ETH)) {
         test_utils::read_data_from_device(
             cluster,
             readback_membar_vec,
@@ -613,7 +613,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     std::thread th1 = std::thread([&] {
         std::uint32_t address = base_addr;
         for (int loop = 0; loop < 50; loop++) {
-            for (CoreCoord core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 std::vector<uint32_t> readback_vec = {};
                 cluster.write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), 0, core, address, "");
                 cluster.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
@@ -628,7 +628,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     std::thread th2 = std::thread([&] {
         std::uint32_t address = base_addr + vec1.size() * 4;
         for (int loop = 0; loop < 50; loop++) {
-            for (CoreCoord core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 std::vector<uint32_t> readback_vec = {};
                 cluster.write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), 0, core, address, "");
                 cluster.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
@@ -643,7 +643,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     th1.join();
     th2.join();
 
-    for (CoreCoord core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
+    for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
         test_utils::read_data_from_device(
             cluster, readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(
@@ -651,7 +651,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
         readback_membar_vec = {};
     }
 
-    for (CoreCoord core : cluster.get_soc_descriptor(0).get_cores(CoreType::ETH)) {
+    for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::ETH)) {
         test_utils::read_data_from_device(
             cluster,
             readback_membar_vec,
@@ -718,7 +718,7 @@ TEST(SiliconDriverBH, DISABLED_BroadcastWrite) {  // Cannot broadcast to tensix/
         cluster.wait_for_non_mmio_flush();
 
         for (const auto i : target_devices) {
-            for (const CoreCoord core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
                 if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
                     continue;
                 }
@@ -812,7 +812,7 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as
         cluster.wait_for_non_mmio_flush();
 
         for (const auto i : target_devices) {
-            for (const CoreCoord core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
                 if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
                     continue;
                 }


### PR DESCRIPTION
### Issue
Contributing to #439

### Description
Switch blackhole tests to use the new API using CoreCoords

### List of the changes
- Changed .workers to .get_cores(CoreType::TENSIX)
- Changed calls for read/write to accept CoreCoords
- get_core_for_dram_channel to get_dram_core_for_channel
- get cores for other types
- Using CoreCoord constants instead of tt_xy_pair

### Testing
Manual run on a blackhole machine confirms these tests still work.
Unit tests have been failing prior to this PR, and this PR doesn't seem to introduce a new failure.

### API Changes
There are no API changes in this PR.
