### PR TITLE
Api tests CoreCoord API

### DIFF
--- a/device/api/umd/device/tt_core_coordinates.h
+++ b/device/api/umd/device/tt_core_coordinates.h
@@ -126,7 +126,7 @@ struct CoreCoord : public tt_xy_pair {
         return coord_system < o.coord_system;
     }
 
-    std::string to_str() const {
+    std::string str() const {
         return "CoreCoord: (" + std::to_string(x) + ", " + std::to_string(y) + ", " + ::to_str(core_type) + ", " +
                ::to_str(coord_system) + ")";
     }

--- a/device/simulation/deprecated/tt_emulation_device.cpp
+++ b/device/simulation/deprecated/tt_emulation_device.cpp
@@ -87,7 +87,7 @@ void tt_emulation_device::broadcast_write_to_cluster(
     std::set<uint32_t>& rows_to_exclude,
     std::set<uint32_t>& cols_to_exclude,
     const std::string& fallback_tlb) {
-    for (const auto& core : get_soc_descriptor(0)->cores) {
+    for (const auto& core : get_soc_descriptor(0)->get_all_cores()) {
         // if(cols_to_exclude.find(core.first.x) == cols_to_exclude.end() and rows_to_exclude.find(core.first.y) ==
         // rows_to_exclude.end() and core.second.type != CoreType::HARVESTED) {
         //     write_to_device(mem_ptr, size_in_bytes, tt_cxy_pair(0, core.first.x, core.first.y), address, "");
@@ -100,11 +100,11 @@ void tt_emulation_device::broadcast_write_to_cluster(
         // differentiate which bcast pattern to use based on exclude columns
         if (cols_to_exclude.find(0) == cols_to_exclude.end()) {
             // Detect DRAM bcast
-            if (get_soc_descriptor(0)->is_dram_core(core.first)) {
+            if (core.core_type == CoreType::DRAM) {
                 write_to_device(mem_ptr, size_in_bytes, tt_cxy_pair(0, core.first.x, core.first.y), address, "");
             }
         } else {
-            if (get_soc_descriptor(0)->is_worker_core(core.first)) {
+            if (core.core_type == CoreType::TENSIX) {
                 write_to_device(mem_ptr, size_in_bytes, tt_cxy_pair(0, core.first.x, core.first.y), address, "");
             }
         }

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -21,12 +21,12 @@
 
 using namespace tt::umd;
 
-inline tt_cxy_pair get_tensix_chip_core_coord(const std::unique_ptr<Cluster>& umd_cluster) {
-    chip_id_t any_mmio_chip = *umd_cluster->get_target_mmio_device_ids().begin();
-    const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(any_mmio_chip);
-    tt_xy_pair core = soc_desc.workers[0];
-    return tt_cxy_pair(any_mmio_chip, core);
-}
+// inline tt_cxy_pair get_tensix_chip_core_coord(const std::unique_ptr<Cluster>& umd_cluster) {
+//     chip_id_t any_mmio_chip = *umd_cluster->get_target_mmio_device_ids().begin();
+//     const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(any_mmio_chip);
+//     tt_xy_pair core = soc_desc.workers[0];
+//     return tt_cxy_pair(any_mmio_chip, core);
+// }
 
 inline std::unique_ptr<Cluster> get_cluster() {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
@@ -50,26 +50,26 @@ TEST(ApiChipTest, ManualTLBConfiguration) {
     if (!remote_chips.empty()) {
         chip_id_t any_remote_chip = *remote_chips.begin();
         const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(any_remote_chip);
-        tt_xy_pair core = soc_desc.workers[0];
-        EXPECT_THROW(umd_cluster->get_static_tlb_writer(tt_cxy_pair(any_remote_chip, core)), std::runtime_error);
+        CoreCoord core = soc_desc.get_cores(CoreType::TENSIX)[0];
+        EXPECT_THROW(umd_cluster->get_static_tlb_writer(any_remote_chip, core), std::runtime_error);
     }
 
     // Expect to throw for non configured mmio chip.
     chip_id_t any_mmio_chip = *umd_cluster->get_target_mmio_device_ids().begin();
     const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(any_mmio_chip);
-    tt_xy_pair core = soc_desc.workers[0];
-    EXPECT_THROW(umd_cluster->get_static_tlb_writer(tt_cxy_pair(any_mmio_chip, core)), std::runtime_error);
+    CoreCoord core = soc_desc.get_cores(CoreType::TENSIX)[0];
+    EXPECT_THROW(umd_cluster->get_static_tlb_writer(any_mmio_chip, core), std::runtime_error);
 
     // TODO: This should be part of TTDevice interface, not Cluster or Chip.
     // Configure TLBs.
-    std::function<int(tt_xy_pair)> get_static_tlb_index = [&](tt_xy_pair core) -> int {
+    std::function<int(CoreCoord)> get_static_tlb_index = [&](CoreCoord core) -> int {
         // TODO: Make this per arch.
-        bool is_worker_core = soc_desc.is_worker_core(core);
-        if (!is_worker_core) {
+        if (core.core_type != CoreType::TENSIX) {
             return -1;
         }
-        return core.x +
-               core.y * umd_cluster->get_tt_device(any_mmio_chip)->get_architecture_implementation()->get_grid_size_x();
+        // LOGICAL system needs to be used for the correct calculation of tlb_index.
+        core = umd_cluster->get_soc_descriptor(any_mmio_chip).translate_coord_to(core, CoordSystem::LOGICAL);
+        return core.x + core.y * umd_cluster->get_soc_descriptor(any_mmio_chip).get_grid_size(CoreType::TENSIX).x;
     };
 
     std::int32_t c_zero_address = 0;
@@ -77,7 +77,7 @@ TEST(ApiChipTest, ManualTLBConfiguration) {
     // Each MMIO chip has it's own set of TLBs, so needs its own configuration.
     for (chip_id_t mmio_chip : umd_cluster->get_target_mmio_device_ids()) {
         const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(mmio_chip);
-        for (tt_xy_pair core : soc_desc.workers) {
+        for (CoreCoord core : soc_desc.get_cores(CoreType::TENSIX)) {
             umd_cluster->configure_tlb(mmio_chip, core, get_static_tlb_index(core), c_zero_address);
         }
     }
@@ -86,10 +86,11 @@ TEST(ApiChipTest, ManualTLBConfiguration) {
     EXPECT_NO_THROW(umd_cluster->get_static_tlb_writer(tt_cxy_pair(any_mmio_chip, core)));
 
     // Expect to throw for non worker cores.
-    tt_xy_pair dram_core = soc_desc.dram_cores[0][0];
-    EXPECT_THROW(umd_cluster->get_static_tlb_writer(tt_cxy_pair(any_mmio_chip, dram_core)), std::runtime_error);
-    if (!soc_desc.ethernet_cores.empty()) {
-        tt_xy_pair eth_core = soc_desc.ethernet_cores[0];
+    CoreCoord dram_core = soc_desc.get_dram_cores()[0][0];
+    EXPECT_THROW(umd_cluster->get_static_tlb_writer(any_mmio_chip, dram_core), std::runtime_error);
+    auto eth_cores = soc_desc.get_cores(CoreType::ETH);
+    if (!eth_cores.empty()) {
+        CoreCoord eth_core = eth_cores[0];
         EXPECT_THROW(umd_cluster->get_static_tlb_writer(tt_cxy_pair(any_mmio_chip, eth_core)), std::runtime_error);
     }
 }

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -12,7 +12,7 @@
 
 using namespace tt::umd;
 
-// Test soc descriptor API for Wormhole when there is no harvesting.
+// Test soc descriptor API for Grayskull when there is no harvesting.
 TEST(SocDescriptor, SocDescriptorGrayskullNoHarvesting) {
     tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml"), false);
 
@@ -21,8 +21,8 @@ TEST(SocDescriptor, SocDescriptorGrayskullNoHarvesting) {
     ASSERT_EQ(soc_desc.get_num_dram_channels(), tt::umd::grayskull::NUM_DRAM_BANKS);
 
     for (const tt_xy_pair& tensix_core : grayskull_tensix_cores) {
-        ASSERT_TRUE(soc_desc.is_worker_core(tensix_core));
-        ASSERT_FALSE(soc_desc.is_ethernet_core(tensix_core));
+        CoreCoord core_coord = soc_desc.get_coord_at(tensix_core, CoordSystem::PHYSICAL);
+        ASSERT_TRUE(core_coord.core_type == CoreType::TENSIX);
     }
 
     ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::TENSIX).empty());
@@ -84,8 +84,8 @@ TEST(SocDescriptor, SocDescriptorWormholeNoHarvesting) {
     ASSERT_EQ(soc_desc.get_num_dram_channels(), tt::umd::wormhole::NUM_DRAM_BANKS);
 
     for (const tt_xy_pair& tensix_core : wormhole_tensix_cores) {
-        ASSERT_TRUE(soc_desc.is_worker_core(tensix_core));
-        ASSERT_FALSE(soc_desc.is_ethernet_core(tensix_core));
+        CoreCoord core_coord = soc_desc.get_coord_at(tensix_core, CoordSystem::PHYSICAL);
+        ASSERT_TRUE(core_coord.core_type == CoreType::TENSIX);
     }
 
     ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::TENSIX).empty());
@@ -216,8 +216,8 @@ TEST(SocDescriptor, SocDescriptorBlackholeNoHarvesting) {
     ASSERT_EQ(soc_desc.get_num_dram_channels(), tt::umd::blackhole::NUM_DRAM_BANKS);
 
     for (const tt_xy_pair& tensix_core : blackhole_tensix_cores) {
-        ASSERT_TRUE(soc_desc.is_worker_core(tensix_core));
-        ASSERT_FALSE(soc_desc.is_ethernet_core(tensix_core));
+        CoreCoord core_coord = soc_desc.get_coord_at(tensix_core, CoordSystem::PHYSICAL);
+        ASSERT_TRUE(core_coord.core_type == CoreType::TENSIX);
     }
 
     ASSERT_TRUE(soc_desc.get_harvested_cores(CoreType::TENSIX).empty());

--- a/tests/test_utils/stimulus_generators.hpp
+++ b/tests/test_utils/stimulus_generators.hpp
@@ -359,10 +359,8 @@ static inline std::vector<destination_t> generate_core_index_locations(
     std::vector<destination_t> core_index_to_location = {};
 
     for (chip_id_t chip : cluster_desc.get_all_chips()) {
-        for (auto const& dram_channel_cores : soc_desc.dram_cores) {
-            for (tt_xy_pair const& dram_core : dram_channel_cores) {
-                core_index_to_location.push_back({static_cast<std::size_t>(chip), dram_core.x, dram_core.y});
-            }
+        for (const CoreCoord dram_core : soc_desc.get_cores(CoreType::DRAM)) {
+            core_index_to_location.push_back(destination_t(chip, dram_core));
         }
     }
 


### PR DESCRIPTION
### Issue
Contributing to #439

### Description
Switch miscellaneous and api tests to use the new API using CoreCoords

### List of the changes
- Changed .workers to .get_cores(CoreType::TENSIX)
- Changed calls for read/write to accept CoreCoords
- get_core_for_dram_channel to get_dram_core_for_channel
- get cores for other types
- Using CoreCoord constants instead of tt_xy_pair
- Remove is_worker_core and is_dram_core usage

### Testing
Existing CI tests

### API Changes
There are no API changes in this PR.
