### PR TITLE
Cluster CoreCoord API

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -1193,7 +1193,8 @@ private:
         const bool clean_system_resources,
         bool perform_harvesting,
         std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks);
-    // Helper functions for translating chip coordinates.
+    // TODO: These functions should be removed once the transition to CoreCoord is complete.
+    CoordSystem get_coord_system_used() const;
     tt_xy_pair translate_to_api_coords(const chip_id_t chip, const tt::umd::CoreCoord core_coord) const;
     // Most of the old APIs accept virtual coordinates, but we communicate with the device through translated
     // coordinates. This is an internal helper function, until we switch the API to accept translated coordinates.

--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -89,8 +89,9 @@ public:
 
     tt_xy_pair get_core_for_dram_channel(int dram_chan, int subchannel) const;
 
+    // Effectively translates between LOGICAL and VIRTUAL coordinates for DRAM and ETH cores.
     tt::umd::CoreCoord get_dram_core_for_channel(int dram_chan, int subchannel) const;
-    tt::umd::CoreCoord get_dram_core(uint32_t dram_chan, uint32_t subchannel) const;
+    tt::umd::CoreCoord get_eth_core_for_channel(int eth_chan) const;
 
     bool is_ethernet_core(const tt_xy_pair &core) const;
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -428,9 +428,9 @@ void Cluster::construct_cluster(
                 if (remote_transfer_ethernet_cores.size() <= logical_mmio_chip_id) {
                     remote_transfer_ethernet_cores.resize(logical_mmio_chip_id + 1);
                 }
+                CoreCoord ethernet_core = soc_desc.get_eth_core_for_channel(i);
                 remote_transfer_ethernet_cores.at(logical_mmio_chip_id)
-                    .push_back(tt_cxy_pair(
-                        logical_mmio_chip_id, soc_desc.ethernet_cores.at(i).x, soc_desc.ethernet_cores.at(i).y));
+                    .push_back(tt_cxy_pair(logical_mmio_chip_id, ethernet_core));
             }
         }
     }
@@ -699,17 +699,18 @@ void Cluster::configure_active_ethernet_cores_for_mmio_device(
     // Based on this information, UMD determines which ethernet cores can be used for host->cluster non-MMIO transfers.
     // This overrides the default ethernet cores tagged for host to cluster routing in the constructor and must be
     // called for all MMIO devices, if default behaviour is not desired.
-    log_assert(
-        get_soc_descriptor(mmio_chip).arch == tt::ARCH::WORMHOLE_B0,
-        "{} can only be called for Wormhole arch",
-        __FUNCTION__);
-    auto& eth_cores = get_soc_descriptor(mmio_chip).ethernet_cores;
+    auto& soc_desc = get_soc_descriptor(mmio_chip);
+    log_assert(soc_desc.arch == tt::ARCH::WORMHOLE_B0, "{} can only be called for Wormhole arch", __FUNCTION__);
     // Cores 0, 1, 6, 7 are only available if in the active set
     static std::unordered_set<tt_xy_pair> eth_cores_available_if_active = {
-        eth_cores.at(0), eth_cores.at(1), eth_cores.at(6), eth_cores.at(7)};
+        soc_desc.get_eth_core_for_channel(0),
+        soc_desc.get_eth_core_for_channel(1),
+        soc_desc.get_eth_core_for_channel(6),
+        soc_desc.get_eth_core_for_channel(7)};
     // Eth cores 8 and 9 are always available
     std::vector<tt_cxy_pair> non_mmio_access_cores_for_chip = {
-        tt_cxy_pair(mmio_chip, eth_cores.at(8)), tt_cxy_pair(mmio_chip, eth_cores.at(9))};
+        {(size_t)mmio_chip, soc_desc.get_eth_core_for_channel(8)},
+        {(size_t)mmio_chip, soc_desc.get_eth_core_for_channel(9)}};
     for (const auto& active_eth_core : active_eth_cores_per_chip) {
         if (eth_cores_available_if_active.find(active_eth_core) != eth_cores_available_if_active.end()) {
             non_mmio_access_cores_for_chip.push_back(tt_cxy_pair(mmio_chip, active_eth_core));
@@ -735,12 +736,13 @@ void Cluster::populate_cores() {
     std::uint32_t count = 0;
     for (const auto& [chip_id, chip] : chips_) {
         auto& soc_desc = chip->get_soc_descriptor();
-        workers_per_chip.insert(
-            {chip_id, std::unordered_set<tt_xy_pair>(soc_desc.workers.begin(), soc_desc.workers.end())});
+        auto workers = soc_desc.get_cores(CoreType::TENSIX, get_coord_system_used());
+        workers_per_chip.insert({chip_id, std::unordered_set<tt_xy_pair>(workers.begin(), workers.end())});
         if (count == 0) {
-            eth_cores = std::unordered_set<tt_xy_pair>(soc_desc.ethernet_cores.begin(), soc_desc.ethernet_cores.end());
+            auto ethernet_cores = soc_desc.get_cores(CoreType::ETH, get_coord_system_used());
+            eth_cores = std::unordered_set<tt_xy_pair>(ethernet_cores.begin(), ethernet_cores.end());
             for (std::uint32_t dram_idx = 0; dram_idx < soc_desc.get_num_dram_channels(); dram_idx++) {
-                dram_cores.insert(soc_desc.get_core_for_dram_channel(dram_idx, 0));
+                dram_cores.insert(soc_desc.get_dram_core_for_channel(dram_idx, 0));
             }
         }
         count++;
@@ -1027,14 +1029,9 @@ void Cluster::deassert_risc_reset() { broadcast_tensix_risc_reset_to_cluster(TEN
 void Cluster::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions& soft_resets) {
     // Get Target Device to query soc descriptor and determine location in cluster
     std::uint32_t target_device = core.chip;
+    CoreCoord core_coord = get_soc_descriptor(target_device).get_coord_at(core, get_coord_system_used());
     log_assert(
-        std::find(
-            get_soc_descriptor(target_device).workers.begin(), get_soc_descriptor(target_device).workers.end(), core) !=
-                get_soc_descriptor(target_device).workers.end() ||
-            std::find(
-                get_soc_descriptor(target_device).ethernet_cores.begin(),
-                get_soc_descriptor(target_device).ethernet_cores.end(),
-                core) != get_soc_descriptor(target_device).ethernet_cores.end(),
+        core_coord.core_type == CoreType::TENSIX || core_coord.core_type == CoreType::ETH,
         "Cannot deassert reset on a non-tensix or harvested core");
     bool target_is_mmio_capable = cluster_desc->is_chip_mmio_capable(target_device);
     if (target_is_mmio_capable) {
@@ -1053,14 +1050,9 @@ void Cluster::deassert_risc_reset_at_core(
 void Cluster::assert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions& soft_resets) {
     // Get Target Device to query soc descriptor and determine location in cluster
     std::uint32_t target_device = core.chip;
+    CoreCoord core_coord = get_soc_descriptor(target_device).get_coord_at(core, get_coord_system_used());
     log_assert(
-        std::find(
-            get_soc_descriptor(target_device).workers.begin(), get_soc_descriptor(target_device).workers.end(), core) !=
-                get_soc_descriptor(target_device).workers.end() ||
-            std::find(
-                get_soc_descriptor(target_device).ethernet_cores.begin(),
-                get_soc_descriptor(target_device).ethernet_cores.end(),
-                core) != get_soc_descriptor(target_device).ethernet_cores.end(),
+        core_coord.core_type == CoreType::TENSIX || core_coord.core_type == CoreType::ETH,
         "Cannot assert reset on a non-tensix or harvested core");
     bool target_is_mmio_capable = cluster_desc->is_chip_mmio_capable(target_device);
     if (target_is_mmio_capable) {
@@ -2652,12 +2644,10 @@ void Cluster::ethernet_broadcast_write(
             if (chips_to_exclude.find(chip) != chips_to_exclude.end()) {
                 continue;
             }
-            for (const auto& core : get_soc_descriptor(chip).cores) {
-                if (cols_to_exclude.find(core.first.x) == cols_to_exclude.end() and
-                    rows_to_exclude.find(core.first.y) == rows_to_exclude.end() and
-                    core.second.type != CoreType::HARVESTED) {
-                    write_to_device(
-                        mem_ptr, size_in_bytes, tt_cxy_pair(chip, core.first.x, core.first.y), address, fallback_tlb);
+            for (const CoreCoord core : get_soc_descriptor(chip).get_all_cores(get_coord_system_used())) {
+                if (cols_to_exclude.find(core.x) == cols_to_exclude.end() &&
+                    rows_to_exclude.find(core.y) == rows_to_exclude.end()) {
+                    write_to_device(mem_ptr, size_in_bytes, chip, core, address, fallback_tlb);
                 }
             }
         }
@@ -2818,7 +2808,7 @@ int Cluster::remote_arc_msg(
     constexpr uint64_t ARC_RESET_SCRATCH_ADDR = 0x880030060;
     constexpr uint64_t ARC_RESET_MISC_CNTL_ADDR = 0x880030100;
 
-    auto core = tt_cxy_pair(chip, get_soc_descriptor(chip).arc_cores.at(0));
+    auto core = tt_cxy_pair(chip, get_soc_descriptor(chip).get_cores(CoreType::ARC).at(0));
 
     if ((msg_code & 0xff00) != 0xaa00) {
         log_error("Malformed message. msg_code is 0x{:x} but should be 0xaa..", msg_code);
@@ -3046,7 +3036,7 @@ void Cluster::dram_membar(
         if (channels.size()) {
             std::unordered_set<tt_xy_pair> dram_cores_to_sync = {};
             for (const auto& chan : channels) {
-                dram_cores_to_sync.insert(get_soc_descriptor(chip).get_core_for_dram_channel(chan, 0));
+                dram_cores_to_sync.insert(get_soc_descriptor(chip).get_dram_core_for_channel(chan, 0));
             }
             insert_host_to_device_barrier(
                 chip, dram_cores_to_sync, dram_address_params.DRAM_BARRIER_BASE, fallback_tlb);
@@ -3071,7 +3061,7 @@ void Cluster::write_to_device(
     } else {
         log_assert(arch_name != tt::ARCH::BLACKHOLE, "Non-MMIO targets not supported in Blackhole");
         log_assert(
-            (get_soc_descriptor(core.chip).ethernet_cores).size() > 0 && chips_.size() > 1,
+            (get_soc_descriptor(core.chip).get_cores(CoreType::ETH)).size() > 0 && chips_.size() > 1,
             "Cannot issue ethernet writes to a single chip cluster!");
         write_to_non_mmio_device(mem_ptr, size, core, addr);
     }
@@ -3140,7 +3130,7 @@ void Cluster::read_from_device(
             arch_name != tt::ARCH::BLACKHOLE,
             "Non-MMIO targets not supported in Blackhole");  // MT: Use only dynamic TLBs and never program static
         log_assert(
-            (get_soc_descriptor(core.chip).ethernet_cores).size() > 0 && chips_.size() > 1,
+            (get_soc_descriptor(core.chip).get_cores(CoreType::TENSIX)).size() > 0 && chips_.size() > 1,
             "Cannot issue ethernet reads from a single chip cluster!");
         read_from_non_mmio_device(mem_ptr, core, addr, size);
     }
@@ -3320,10 +3310,11 @@ void Cluster::verify_eth_fw() {
     for (const auto& chip : all_chip_ids_) {
         uint32_t fw_version;
         std::vector<uint32_t> fw_versions;
-        for (const tt_xy_pair& eth_core : get_soc_descriptor(chip).ethernet_cores) {
+        for (const CoreCoord eth_core : get_soc_descriptor(chip).get_cores(CoreType::ETH)) {
             read_from_device(
                 &fw_version,
-                tt_cxy_pair(chip, eth_core),
+                chip,
+                eth_core,
                 chips_.at(chip)->l1_address_params.fw_version_addr,
                 sizeof(uint32_t),
                 "LARGE_READ_TLB");
@@ -3437,8 +3428,11 @@ void Cluster::set_barrier_address_params(const barrier_address_params& barrier_a
 // TODO: This is a temporary function while we're switching between the old and the new API.
 // Eventually, this function should be so small it would be obvioud to remove.
 tt_xy_pair Cluster::translate_to_api_coords(const chip_id_t chip, const tt::umd::CoreCoord core_coord) const {
-    CoordSystem coord_system = arch_name == tt::ARCH::GRAYSKULL ? CoordSystem::PHYSICAL : CoordSystem::VIRTUAL;
-    return get_soc_descriptor(chip).translate_coord_to(core_coord, coord_system);
+    return get_soc_descriptor(chip).translate_coord_to(core_coord, get_coord_system_used());
+}
+
+CoordSystem Cluster::get_coord_system_used() const {
+    return arch_name == tt::ARCH::GRAYSKULL ? CoordSystem::PHYSICAL : CoordSystem::VIRTUAL;
 }
 
 tt_xy_pair Cluster::translate_chip_coord_virtual_to_translated(const chip_id_t chip_id, const tt_xy_pair core) const {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -3426,19 +3426,18 @@ void Cluster::set_barrier_address_params(const barrier_address_params& barrier_a
     }
 }
 
+CoordSystem Cluster::get_coord_system_used() const {
+    return arch_name == tt::ARCH::GRAYSKULL ? CoordSystem::PHYSICAL : CoordSystem::VIRTUAL;
+}
+
 // TODO: This is a temporary function while we're switching between the old and the new API.
 // Eventually, this function should be so small it would be obvioud to remove.
 tt_xy_pair Cluster::translate_to_api_coords(const chip_id_t chip, const tt::umd::CoreCoord core_coord) const {
     return get_soc_descriptor(chip).translate_coord_to(core_coord, get_coord_system_used());
 }
 
-CoordSystem Cluster::get_coord_system_used() const {
-    return arch_name == tt::ARCH::GRAYSKULL ? CoordSystem::PHYSICAL : CoordSystem::VIRTUAL;
-}
-
 tt_xy_pair Cluster::translate_chip_coord_virtual_to_translated(const chip_id_t chip_id, const tt_xy_pair core) const {
-    CoordSystem coord_system = arch_name == tt::ARCH::GRAYSKULL ? CoordSystem::PHYSICAL : CoordSystem::VIRTUAL;
-    CoreCoord core_coord = get_soc_descriptor(chip_id).get_coord_at(core, coord_system);
+    CoreCoord core_coord = get_soc_descriptor(chip_id).get_coord_at(core, get_coord_system_used());
     auto translated_coord = get_soc_descriptor(chip_id).translate_coord_to(core_coord, CoordSystem::TRANSLATED);
     return translated_coord;
 }

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -275,7 +275,12 @@ tt_xy_pair tt_SocDescriptor::get_core_for_dram_channel(int dram_chan, int subcha
 
 CoreCoord tt_SocDescriptor::get_dram_core_for_channel(int dram_chan, int subchannel) const {
     const CoreCoord logical_dram_coord = CoreCoord(dram_chan, subchannel, CoreType::DRAM, CoordSystem::LOGICAL);
-    return translate_coord_to(logical_dram_coord, CoordSystem::PHYSICAL);
+    return translate_coord_to(logical_dram_coord, CoordSystem::VIRTUAL);
+}
+
+CoreCoord tt_SocDescriptor::get_eth_core_for_channel(int eth_chan) const {
+    const CoreCoord logical_eth_coord = CoreCoord(0, eth_chan, CoreType::ETH, CoordSystem::LOGICAL);
+    return translate_coord_to(logical_eth_coord, CoordSystem::VIRTUAL);
 }
 
 bool tt_SocDescriptor::is_ethernet_core(const tt_xy_pair &core) const {


### PR DESCRIPTION
### Issue
Contributing to #439

### Description
Switch cluster to use the new API using CoreCoords. Except the part of the code which will be removed (remove_worker_row_from_descriptor)

### List of the changes
- Changed .workers to .get_cores(CoreType::TENSIX)
- Changed calls for read/write to accept CoreCoords
- get_core_for_dram_channel to get_dram_core_for_channel
- get cores for other types
- Using CoreCoord constants instead of tt_xy_pair
- Remove is_worker_core and is_dram_core usage
- Added get_eth_core_for_channel

### Testing
Existing CI tests

### API Changes
There are no API changes in this PR.
