### PR TITLE
Remove harvest_coord_translation from broadcast_pcie_tensix_risc_reset

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -991,6 +991,7 @@ void Cluster::initialize_pcie_devices() {
 
 void Cluster::broadcast_pcie_tensix_risc_reset(chip_id_t chip_id, const TensixSoftResetOptions& soft_resets) {
     log_debug(LogSiliconDriver, "Cluster::broadcast_tensix_risc_reset");
+    log_assert(arch_name == tt::ARCH::GRAYSKULL, "broadcast_pcie_tensix_risc_reset works only for Grayskull.");
 
     TTDevice* tt_device = get_tt_device(chip_id);
 
@@ -1007,10 +1008,10 @@ void Cluster::broadcast_pcie_tensix_risc_reset(chip_id_t chip_id, const TensixSo
     auto [soft_reset_reg, _] = tt_device->set_dynamic_tlb_broadcast(
         architecture_implementation->get_reg_tlb(),
         architecture_implementation->get_tensix_soft_reset_addr(),
-        harvested_coord_translation.at(chip_id).at(tt_xy_pair(0, 0)),
-        harvested_coord_translation.at(chip_id).at(tt_xy_pair(
+        tt_xy_pair(0, 0),
+        tt_xy_pair(
             architecture_implementation->get_grid_size_x() - 1,
-            architecture_implementation->get_grid_size_y() - 1 - num_rows_harvested.at(chip_id))),
+            architecture_implementation->get_grid_size_y() - 1 - num_rows_harvested.at(chip_id)),
         TLB_DATA::Posted);
     tt_device->write_regs(soft_reset_reg, 1, &valid);
     tt_driver_atomics::sfence();


### PR DESCRIPTION
### Issue
Related to #439 

### Description
Left this for another since I wasn't sure about the changes, left it out of #445 
Looks like this is only called for grayskull, so identity map is used.

### List of the changes
- Remove going through harvest_coord_translation, since it is identity map
- Added assert to guard only grayskull usage.

### Testing
Existing CI tests.

### API Changes
There are no API changes in this PR.
