### PR TITLE
Remove Cluster harvesting and Soc descriptor private

### DIFF
--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -64,8 +64,6 @@ public:
         const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
 
     // Misc. Functions to Query/Set Device State
-    // virtual bool using_harvested_soc_descriptors();
-    virtual std::unordered_map<chip_id_t, uint32_t> get_harvesting_masks_for_soc_descriptors();
     static std::vector<chip_id_t> detect_available_device_ids();
     virtual std::set<chip_id_t> get_target_device_ids();
     virtual std::set<chip_id_t> get_target_mmio_device_ids();

--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -86,8 +86,6 @@ public:
     uint32_t get_num_eth_channels() const;
     uint32_t get_num_harvested_eth_channels() const;
 
-    tt_xy_pair get_core_for_dram_channel(int dram_chan, int subchannel) const;
-
     // LOGICAL coordinates for DRAM and ETH are tightly coupled with channels, so this code is very similar to what
     // would translate_coord_to do for a coord with LOGICAL coords.
     tt::umd::CoreCoord get_dram_core_for_channel(
@@ -97,23 +95,8 @@ public:
 
     tt::ARCH arch;
     tt_xy_pair grid_size;
-    tt_xy_pair worker_grid_size;
-    std::unordered_map<tt_xy_pair, CoreDescriptor> cores;
-    std::vector<tt_xy_pair> arc_cores;
-    std::vector<tt_xy_pair> workers;
-    std::vector<tt_xy_pair> harvested_workers;
-    std::vector<tt_xy_pair> pcie_cores;
-    std::unordered_map<int, int> worker_log_to_routing_x;
-    std::unordered_map<int, int> worker_log_to_routing_y;
-    std::unordered_map<int, int> routing_x_to_worker_x;
-    std::unordered_map<int, int> routing_y_to_worker_y;
-    std::vector<std::vector<tt_xy_pair>> dram_cores;                             // per channel list of dram cores
-    std::unordered_map<tt_xy_pair, std::tuple<int, int>> dram_core_channel_map;  // map dram core to chan/subchan
-    std::vector<tt_xy_pair> ethernet_cores;                                      // ethernet cores (index == channel id)
-    std::unordered_map<tt_xy_pair, int> ethernet_core_channel_map;
     std::vector<std::size_t> trisc_sizes;  // Most of software stack assumes same trisc size for whole chip..
     std::string device_descriptor_file_path = std::string("");
-    std::vector<tt_xy_pair> router_cores;
 
     int overlay_version;
     int unpacker_version;
@@ -123,14 +106,13 @@ public:
     int eth_l1_size;
     bool noc_translation_id_enabled;
     uint64_t dram_bank_size;
+
+    // Passed through constructor.
+    bool noc_translation_enabled;
     tt::umd::HarvestingMasks harvesting_masks;
 
 private:
-    void create_coordinate_manager(
-        const bool noc_translation_enabled,
-        const tt::umd::HarvestingMasks harvesting_masks,
-        const BoardType board_type,
-        const uint8_t asic_location);
+    void create_coordinate_manager(const BoardType board_type, const uint8_t asic_location);
     void load_core_descriptors_from_device_descriptor(YAML::Node &device_descriptor_yaml);
     void load_soc_features_from_device_descriptor(YAML::Node &device_descriptor_yaml);
     void get_cores_and_grid_size_from_coordinate_manager();
@@ -138,6 +120,19 @@ private:
     static tt_xy_pair calculate_grid_size(const std::vector<tt_xy_pair> &cores);
     std::vector<tt::umd::CoreCoord> translate_coordinates(
         const std::vector<tt::umd::CoreCoord> &physical_cores, const CoordSystem coord_system) const;
+
+    // Internal structures, read from yaml.
+    tt_xy_pair worker_grid_size;
+    std::unordered_map<tt_xy_pair, CoreDescriptor> cores;
+    std::vector<tt_xy_pair> arc_cores;
+    std::vector<tt_xy_pair> workers;
+    std::vector<tt_xy_pair> harvested_workers;
+    std::vector<tt_xy_pair> pcie_cores;
+    std::vector<std::vector<tt_xy_pair>> dram_cores;                             // per channel list of dram cores
+    std::unordered_map<tt_xy_pair, std::tuple<int, int>> dram_core_channel_map;  // map dram core to chan/subchan
+    std::vector<tt_xy_pair> ethernet_cores;                                      // ethernet cores (index == channel id)
+    std::unordered_map<tt_xy_pair, int> ethernet_core_channel_map;
+    std::vector<tt_xy_pair> router_cores;
 
     // TODO: change this to unique pointer as soon as copying of tt_SocDescriptor
     // is not needed anymore. Soc descriptor and coordinate manager should be

--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -95,6 +95,7 @@ public:
 
     tt::ARCH arch;
     tt_xy_pair grid_size;
+    tt_xy_pair worker_grid_size;
     std::vector<std::size_t> trisc_sizes;  // Most of software stack assumes same trisc size for whole chip..
     std::string device_descriptor_file_path = std::string("");
 
@@ -122,7 +123,6 @@ private:
         const std::vector<tt::umd::CoreCoord> &physical_cores, const CoordSystem coord_system) const;
 
     // Internal structures, read from yaml.
-    tt_xy_pair worker_grid_size;
     std::unordered_map<tt_xy_pair, CoreDescriptor> cores;
     std::vector<tt_xy_pair> arc_cores;
     std::vector<tt_xy_pair> workers;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -252,46 +252,25 @@ void Cluster::create_device(
                 log_warning(LogSiliconDriver, "No hugepage mapping at device {}.", logical_device_id);
             }
         }
-
-        // translation layer for harvested coords. Default is identity map
-        harvested_coord_translation.insert({logical_device_id, create_harvested_coord_translation(arch_name, true)});
     }
 
     for (const chip_id_t& chip : all_chip_ids_) {
-        // Initialize identity mapping for Non-MMIO chips as well
         if (!cluster_desc->is_chip_mmio_capable(chip)) {
-            harvested_coord_translation.insert({chip, create_harvested_coord_translation(arch_name, true)});
             flush_non_mmio_per_chip[chip] = false;
         }
     }
 }
 
-bool Cluster::using_harvested_soc_descriptors() { return perform_harvesting_on_sdesc && performed_harvesting; }
-
-std::unordered_map<chip_id_t, uint32_t> Cluster::get_harvesting_masks_for_soc_descriptors() {
-    std::unordered_map<chip_id_t, uint32_t> harvesting_masks = {};
-    for (const auto& [chip_id, chip] : chips_) {
-        uint32_t noc0_harvesting_mask = CoordinateManager::shuffle_tensix_harvesting_mask_to_noc0_coords(
-            chip->get_soc_descriptor().arch, chip->get_soc_descriptor().harvesting_masks.tensix_harvesting_mask);
-        harvesting_masks.insert({chip_id, noc0_harvesting_mask});
-    }
-    return harvesting_masks;
-}
-
 void Cluster::construct_cluster(
     const uint32_t& num_host_mem_ch_per_mmio_device,
     const bool create_mock_chips,
-    const bool clean_system_resources,
-    bool perform_harvesting,
-    std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks) {
+    const bool clean_system_resources) {
     if (!create_mock_chips) {
         auto available_device_ids = detect_available_device_ids();
         log_info(LogSiliconDriver, "Detected PCI devices: {}", available_device_ids);
         log_info(
             LogSiliconDriver, "Using local chip ids: {} and remote chip ids {}", local_chip_ids_, remote_chip_ids_);
     }
-
-    perform_harvesting_on_sdesc = perform_harvesting;
 
     create_device(local_chip_ids_, num_host_mem_ch_per_mmio_device, create_mock_chips, clean_system_resources);
 
@@ -303,114 +282,6 @@ void Cluster::construct_cluster(
         use_virtual_coords_for_eth_broadcast = false;
     }
 
-    if (arch_name == tt::ARCH::WORMHOLE_B0) {
-        const auto& harvesting_masks = cluster_desc->get_harvesting_info();
-        const auto& noc_translation_enabled = cluster_desc->get_noc_translation_table_en();
-
-        translation_tables_en = false;
-        for (auto& masks : harvesting_masks) {
-            if (all_chip_ids_.find(masks.first) != all_chip_ids_.end()) {
-                harvested_rows_per_target[masks.first] = get_harvested_noc_rows(masks.second);
-                noc_translation_enabled_for_chip[masks.first] = noc_translation_enabled.at(masks.first);
-                num_rows_harvested.insert({masks.first, std::bitset<32>(masks.second).count()});
-                if (harvested_rows_per_target[masks.first]) {
-                    performed_harvesting = true;
-                }
-            }
-        }
-        if (noc_translation_enabled_for_chip.size() > 0) {
-            auto const consistent_translation_table_state = [&](std::pair<chip_id_t, bool> const& i) {
-                return noc_translation_enabled_for_chip.begin()->second == i.second;
-            };
-
-            bool translation_tables_match_on_all_chips = std::all_of(
-                noc_translation_enabled_for_chip.begin(),
-                noc_translation_enabled_for_chip.end(),
-                consistent_translation_table_state);
-            log_assert(
-                translation_tables_match_on_all_chips,
-                "Cluster uses NOC translation tables inconsistently across chips.");
-            translation_tables_en = noc_translation_enabled_for_chip.begin()->second;
-        }
-
-        if (translation_tables_en) {
-            harvested_coord_translation.clear();
-            for (const chip_id_t& chip : all_chip_ids_) {
-                harvested_coord_translation.insert({chip, create_harvested_coord_translation(arch_name, false)});
-            }
-        }
-        log_assert(
-            performed_harvesting ? translation_tables_en : true,
-            "Using a harvested WH cluster with NOC translation disabled.");
-    } else if (arch_name == tt::ARCH::BLACKHOLE) {
-        // Default harvesting info for Blackhole, describing no harvesting
-        for (auto chip_id = all_chip_ids_.begin(); chip_id != all_chip_ids_.end(); chip_id++) {
-            harvested_rows_per_target[*chip_id] = 0;   // get_harvested_noc_rows_for_chip(*chip_id);
-            num_rows_harvested.insert({*chip_id, 0});  // Only set for broadcast TLB to get RISCS out of reset. We want
-                                                       // all rows to have a reset signal sent.
-            if (harvested_rows_per_target[*chip_id]) {
-                performed_harvesting = true;
-            }
-        }
-    } else if (arch_name == tt::ARCH::GRAYSKULL) {
-        // Multichip harvesting is supported for GS.
-        for (auto chip_id = all_chip_ids_.begin(); chip_id != all_chip_ids_.end(); chip_id++) {
-            if (create_mock_chips) {
-                harvested_rows_per_target[*chip_id] =
-                    get_harvested_noc_rows((uint32_t)(cluster_desc->get_harvesting_info().at(*chip_id)));
-            } else {
-                harvested_rows_per_target[*chip_id] = get_harvested_noc_rows_for_chip(*chip_id);
-            }
-            num_rows_harvested.insert({*chip_id, 0});  // Only set for broadcast TLB to get RISCS out of reset. We want
-                                                       // all rows to have a reset signal sent.
-            if (harvested_rows_per_target[*chip_id]) {
-                performed_harvesting = true;
-            }
-        }
-    }
-
-    if (simulated_harvesting_masks.size()) {
-        performed_harvesting = true;
-        for (auto device_id = all_chip_ids_.begin(); device_id != all_chip_ids_.end(); device_id++) {
-            log_assert(
-                simulated_harvesting_masks.find(*device_id) != simulated_harvesting_masks.end(),
-                "Could not find harvesting mask for device_id {}",
-                *device_id);
-            if (arch_name == tt::ARCH::GRAYSKULL) {
-                if ((simulated_harvesting_masks.at(*device_id).tensix_harvesting_mask &
-                     harvested_rows_per_target[*device_id]) != harvested_rows_per_target[*device_id]) {
-                    log_warning(
-                        LogSiliconDriver,
-                        "Simulated harvesting config for device {} does not include the actual harvesting config. "
-                        "Simulated harvesting mask will be added to the real harvesting mask. Actual Harvested Rows : "
-                        "{}    Simulated Harvested Rows : {}",
-                        *device_id,
-                        harvested_rows_per_target[*device_id],
-                        simulated_harvesting_masks.at(*device_id).tensix_harvesting_mask);
-                }
-                simulated_harvesting_masks.at(*device_id).tensix_harvesting_mask |=
-                    harvested_rows_per_target[*device_id];
-            } else if (arch_name == tt::ARCH::WORMHOLE_B0) {
-                log_assert(
-                    std::bitset<32>(simulated_harvesting_masks.at(*device_id).tensix_harvesting_mask).count() >=
-                        std::bitset<32>(harvested_rows_per_target[*device_id]).count(),
-                    "Simulated Harvesting for WH must contain at least as many rows as the actual harvesting config. "
-                    "Actual Harvested Rows : {}  Simulated Harvested Rows : {}",
-                    harvested_rows_per_target[*device_id],
-                    simulated_harvesting_masks.at(*device_id).tensix_harvesting_mask);
-                num_rows_harvested.at(*device_id) =
-                    std::bitset<32>(simulated_harvesting_masks.at(*device_id).tensix_harvesting_mask).count();
-                log_assert(
-                    performed_harvesting ? translation_tables_en : true,
-                    "Using a harvested WH cluster with NOC translation disabled.");
-            }
-            harvested_rows_per_target[*device_id] = simulated_harvesting_masks.at(*device_id).tensix_harvesting_mask;
-        }
-    }
-
-    if (perform_harvesting) {
-        perform_harvesting_on_soc_descriptors();
-    }
     populate_cores();
 
     // MT: Initial BH - skip this for BH
@@ -586,9 +457,7 @@ Cluster::Cluster(
     construct_cluster(
         num_host_mem_ch_per_mmio_device,
         create_mock_chips,
-        clean_system_resources,
-        perform_harvesting,
-        simulated_harvesting_masks);
+        clean_system_resources);
 }
 
 Cluster::Cluster(
@@ -617,9 +486,7 @@ Cluster::Cluster(
     construct_cluster(
         num_host_mem_ch_per_mmio_device,
         create_mock_chips,
-        clean_system_resources,
-        perform_harvesting,
-        simulated_harvesting_masks);
+        clean_system_resources);
 }
 
 Cluster::Cluster(
@@ -660,9 +527,7 @@ Cluster::Cluster(
     construct_cluster(
         num_host_mem_ch_per_mmio_device,
         create_mock_chips,
-        clean_system_resources,
-        perform_harvesting,
-        simulated_harvesting_masks);
+        clean_system_resources);
 }
 
 Cluster::Cluster(
@@ -687,9 +552,7 @@ Cluster::Cluster(
     construct_cluster(
         num_host_mem_ch_per_mmio_device,
         create_mock_chips,
-        clean_system_resources,
-        perform_harvesting,
-        simulated_harvesting_masks);
+        clean_system_resources);
 }
 
 void Cluster::configure_active_ethernet_cores_for_mmio_device(
@@ -748,77 +611,6 @@ void Cluster::populate_cores() {
     }
 }
 
-std::vector<int> Cluster::extract_rows_to_remove(
-    const tt::ARCH& arch, const int worker_grid_rows, const int harvested_rows) {
-    // Check if harvesting config is legal for GS and WH
-    log_assert(
-        !((harvested_rows & 1) || (harvested_rows & 64) || (harvested_rows & 0xFFFFF000)),
-        "For grayskull and wormhole, only rows 1-5 and 7-11 can be harvested");
-    std::vector<int> row_coordinates_to_remove;
-    int row_coordinate = 0;
-    int tmp = harvested_rows;
-    while (tmp) {
-        if (tmp & 1) {
-            row_coordinates_to_remove.push_back(row_coordinate);
-        }
-
-        tmp = tmp >> 1;
-        row_coordinate++;
-    }
-    if (arch == tt::ARCH::WORMHOLE_B0) {
-        // For Wormhole, we always remove the last few rows in the SOC descriptor in case of harvesting
-        for (int i = 0; i < row_coordinates_to_remove.size(); i++) {
-            row_coordinates_to_remove[i] = worker_grid_rows - i;
-        }
-    }
-    return row_coordinates_to_remove;
-}
-
-void Cluster::remove_worker_row_from_descriptor(
-    tt_SocDescriptor& full_soc_descriptor, const std::vector<int>& row_coordinates_to_remove) {
-    std::vector<tt_xy_pair> workers_to_keep;
-    for (auto worker = (full_soc_descriptor.workers).begin(); worker != (full_soc_descriptor.workers).end(); worker++) {
-        if (find(row_coordinates_to_remove.begin(), row_coordinates_to_remove.end(), (*worker).y) ==
-            row_coordinates_to_remove.end()) {
-            workers_to_keep.push_back(*worker);
-        } else {
-            (full_soc_descriptor.harvested_workers).push_back(*worker);
-            full_soc_descriptor.cores.at(*worker).type = CoreType::HARVESTED;
-        }
-    }
-    full_soc_descriptor.workers = workers_to_keep;
-    (full_soc_descriptor.worker_grid_size).y -= row_coordinates_to_remove.size();
-    full_soc_descriptor.routing_y_to_worker_y = {};
-    full_soc_descriptor.worker_log_to_routing_y = {};
-
-    std::set<int> modified_y_coords = {};
-
-    for (const auto& core : full_soc_descriptor.workers) {
-        modified_y_coords.insert(core.y);
-    }
-    int logical_y_coord = 0;
-    for (const auto& y_coord : modified_y_coords) {
-        full_soc_descriptor.routing_y_to_worker_y.insert({y_coord, logical_y_coord});
-        full_soc_descriptor.worker_log_to_routing_y.insert({logical_y_coord, y_coord});
-        logical_y_coord++;
-    }
-}
-
-void Cluster::harvest_rows_in_soc_descriptor(tt::ARCH arch, tt_SocDescriptor& sdesc, uint32_t harvested_rows) {
-    std::uint32_t max_row_to_remove =
-        (*std::max_element((sdesc.workers).begin(), (sdesc.workers).end(), [](const auto& a, const auto& b) {
-            return a.y < b.y;
-        })).y;
-    std::vector<int> row_coordinates_to_remove = extract_rows_to_remove(arch, max_row_to_remove, harvested_rows);
-    remove_worker_row_from_descriptor(sdesc, row_coordinates_to_remove);
-}
-
-void Cluster::perform_harvesting_on_soc_descriptors() {
-    for (const auto& chip : harvested_rows_per_target) {
-        harvest_rows_in_soc_descriptor(arch_name, chips_.at(chip.first)->get_soc_descriptor(), chip.second);
-    }
-}
-
 void Cluster::check_pcie_device_initialized(int device_id) {
     TTDevice* tt_device = get_tt_device(device_id);
     tt::ARCH device_arch = tt_device->get_pci_device()->get_arch();
@@ -871,113 +663,6 @@ void Cluster::check_pcie_device_initialized(int device_id) {
     }
 }
 
-std::unordered_map<tt_xy_pair, tt_xy_pair> Cluster::create_harvested_coord_translation(
-    const tt::ARCH arch, bool identity_map) {
-    log_assert(
-        identity_map ? true : (arch != tt::ARCH::GRAYSKULL), "NOC Translation can only be performed for WH devices");
-    std::unordered_map<tt_xy_pair, tt_xy_pair> translation_table = {};
-
-    tt_xy_pair grid_size;
-    std::vector<uint32_t> T6_x = {};
-    std::vector<uint32_t> T6_y = {};
-    std::vector<tt_xy_pair> ethernet = {};
-    // Store device specific data for GS and WH depending on arch
-    if (arch == tt::ARCH::GRAYSKULL) {
-        grid_size = tt_xy_pair(13, 12);
-        T6_x = {12, 1, 11, 2, 10, 3, 9, 4, 8, 5, 7, 6};
-        T6_y = {11, 1, 10, 2, 9, 3, 8, 4, 7, 5};
-    } else if (arch == tt::ARCH::BLACKHOLE) {
-        grid_size = tt_xy_pair(17, 12);
-        T6_x = {16, 1, 15, 2, 14, 3, 13, 4, 12, 5, 11, 6, 10, 7};
-        T6_y = {11, 2, 10, 3, 9, 4, 8, 5, 7, 6};
-    } else {
-        grid_size = tt_xy_pair(10, 12);
-        T6_x = {1, 2, 3, 4, 6, 7, 8, 9};
-        T6_y = {1, 2, 3, 4, 5, 7, 8, 9, 10, 11};
-        // clang-format off
-        ethernet = {{1, 0}, {2, 0}, {3, 0}, {4, 0}, {6, 0}, {7, 0}, {8, 0}, {9, 0},
-                    {1, 6}, {2, 6}, {3, 6}, {4, 6}, {6, 6}, {7, 6}, {8, 6}, {9, 6}};
-        // clang-format on
-    }
-
-    if (identity_map) {
-        // When device is initialized, assume no harvesting and create an identity map for cores
-        // This flow is always used for GS, since there is no hardware harvesting
-        for (int x = 0; x < grid_size.x; x++) {
-            for (int y = 0; y < grid_size.y; y++) {
-                tt_xy_pair curr_core = tt_xy_pair(x, y);
-                translation_table.insert({curr_core, curr_core});
-            }
-        }
-        return translation_table;
-    }
-
-    // If this function is called with identity_map = false, we have perform NOC translation
-    // This can only happen for WH devices
-    // Setup coord translation for workers. Map all worker cores
-    for (int x = 0; x < grid_size.x; x++) {
-        for (int y = 0; y < grid_size.y; y++) {
-            tt_xy_pair curr_core = tt_xy_pair(x, y);
-
-            if (std::find(T6_x.begin(), T6_x.end(), x) != T6_x.end() &&
-                std::find(T6_y.begin(), T6_y.end(), y) != T6_y.end()) {
-                // This is a worker core. Apply translation for WH.
-                tt_xy_pair harvested_worker;
-                if (x >= 1 && x <= 4) {
-                    harvested_worker.x = x + 17;
-                } else if (x <= 9 && x > 5) {
-                    harvested_worker.x = x + 16;
-                } else {
-                    log_assert(false, "Invalid WH worker x coord {} when creating translation tables.", x);
-                }
-
-                if (y >= 1 && y <= 5) {
-                    harvested_worker.y = y + 17;
-                } else if (y <= 11 && y > 6) {
-                    harvested_worker.y = y + 16;
-                } else {
-                    log_assert(false, "Invalid WH worker y coord {} when creating translation tables.", y);
-                }
-                translation_table.insert({curr_core, harvested_worker});
-            }
-
-            else if (std::find(ethernet.begin(), ethernet.end(), curr_core) != ethernet.end()) {
-                // This is an eth core. Apply translation for WH.
-                tt_xy_pair harvested_eth_core;
-                if (x >= 1 && x <= 4) {
-                    harvested_eth_core.x = x + 17;
-                } else if (x <= 9 && x > 5) {
-                    harvested_eth_core.x = x + 16;
-                } else {
-                    log_assert(false, "Invalid WH eth_core x coord {} when creating translation tables.", x);
-                }
-
-                if (y == 0) {
-                    harvested_eth_core.y = y + 16;
-                } else if (y == 6) {
-                    harvested_eth_core.y = y + 11;
-                } else {
-                    log_assert(false, "Invalid WH eth_core y coord {} when creating translation tables.", y);
-                }
-                translation_table.insert({curr_core, harvested_eth_core});
-            }
-
-            else {
-                // All other cores for WH are not translated in case of harvesting.
-                translation_table.insert({curr_core, curr_core});
-            }
-        }
-    }
-    return translation_table;
-}
-
-void Cluster::translate_to_noc_table_coords(chip_id_t device_id, std::size_t& r, std::size_t& c) {
-    tt_xy_pair translated_coords = translate_chip_coord_virtual_to_translated(device_id, {c, r});
-
-    c = translated_coords.x;
-    r = translated_coords.y;
-}
-
 void Cluster::initialize_pcie_devices() {
     log_debug(LogSiliconDriver, "Cluster::start");
 
@@ -1005,6 +690,9 @@ void Cluster::broadcast_pcie_tensix_risc_reset(chip_id_t chip_id, const TensixSo
 
     auto architecture_implementation = tt_device->get_architecture_implementation();
 
+    std::cout << " REMOVE MEEEE, BUT HARVESTED GRID IS "
+              << get_soc_descriptor(chip_id).get_harvested_grid_size(CoreType::TENSIX).str() << std::endl;
+
     // TODO: this is clumsy and difficult to read
     auto [soft_reset_reg, _] = tt_device->set_dynamic_tlb_broadcast(
         architecture_implementation->get_reg_tlb(),
@@ -1012,7 +700,8 @@ void Cluster::broadcast_pcie_tensix_risc_reset(chip_id_t chip_id, const TensixSo
         tt_xy_pair(0, 0),
         tt_xy_pair(
             architecture_implementation->get_grid_size_x() - 1,
-            architecture_implementation->get_grid_size_y() - 1 - num_rows_harvested.at(chip_id)),
+            architecture_implementation->get_grid_size_y() - 1 -
+                get_soc_descriptor(chip_id).get_harvested_grid_size(CoreType::TENSIX).y),
         TLB_DATA::Posted);
     tt_device->write_regs(soft_reset_reg, 1, &valid);
     tt_driver_atomics::sfence();
@@ -1874,7 +1563,7 @@ void Cluster::write_to_non_mmio_device(
     std::string write_tlb = "LARGE_WRITE_TLB";
     std::string read_tlb = "LARGE_READ_TLB";
     std::string empty_tlb = "";
-    translate_to_noc_table_coords(core.chip, core.y, core.x);
+    translate_chip_coord_virtual_to_translated(core.chip, core);
     std::vector<std::uint32_t> erisc_command;
     std::vector<std::uint32_t> erisc_q_rptr = std::vector<uint32_t>(1);
     std::vector<std::uint32_t> erisc_q_ptrs =
@@ -2103,7 +1792,7 @@ void Cluster::read_from_non_mmio_device(void* mem_ptr, tt_cxy_pair core, uint64_
     std::string write_tlb = "LARGE_WRITE_TLB";
     std::string read_tlb = "LARGE_READ_TLB";
     std::string empty_tlb = "";
-    translate_to_noc_table_coords(core.chip, core.y, core.x);
+    translate_chip_coord_virtual_to_translated(core.chip, core);
 
     const auto& mmio_capable_chip_logical = cluster_desc->get_closest_mmio_capable_chip(core.chip);
     const eth_coord_t target_chip = cluster_desc->get_chip_locations().at(core.chip);
@@ -3349,7 +3038,7 @@ void Cluster::verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std
     // Temporarily enable this feature for 6.7.241 as well for testing.
     use_virtual_coords_for_eth_broadcast &=
         (fw_first_eth_core >= tt_version(6, 8, 0) || fw_first_eth_core == tt_version(6, 7, 241)) &&
-        translation_tables_en;
+        get_soc_descriptor(device_id).noc_translation_id_enabled;
 }
 
 void Cluster::start_device(const tt_device_params& device_params) {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1546,7 +1546,11 @@ void Cluster::write_to_non_mmio_device(
     std::string write_tlb = "LARGE_WRITE_TLB";
     std::string read_tlb = "LARGE_READ_TLB";
     std::string empty_tlb = "";
-    translate_chip_coord_virtual_to_translated(core.chip, core);
+
+    tt_xy_pair translated_core = translate_chip_coord_virtual_to_translated(core.chip, core);
+    core.x = translated_core.x;
+    core.y = translated_core.y;
+
     std::vector<std::uint32_t> erisc_command;
     std::vector<std::uint32_t> erisc_q_rptr = std::vector<uint32_t>(1);
     std::vector<std::uint32_t> erisc_q_ptrs =
@@ -1775,7 +1779,10 @@ void Cluster::read_from_non_mmio_device(void* mem_ptr, tt_cxy_pair core, uint64_
     std::string write_tlb = "LARGE_WRITE_TLB";
     std::string read_tlb = "LARGE_READ_TLB";
     std::string empty_tlb = "";
-    translate_chip_coord_virtual_to_translated(core.chip, core);
+
+    tt_xy_pair translated_core = translate_chip_coord_virtual_to_translated(core.chip, core);
+    core.x = translated_core.x;
+    core.y = translated_core.y;
 
     const auto& mmio_capable_chip_logical = cluster_desc->get_closest_mmio_capable_chip(core.chip);
     const eth_coord_t target_chip = cluster_desc->get_chip_locations().at(core.chip);

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -262,9 +262,7 @@ void Cluster::create_device(
 }
 
 void Cluster::construct_cluster(
-    const uint32_t& num_host_mem_ch_per_mmio_device,
-    const bool create_mock_chips,
-    const bool clean_system_resources) {
+    const uint32_t& num_host_mem_ch_per_mmio_device, const bool create_mock_chips, const bool clean_system_resources) {
     if (!create_mock_chips) {
         auto available_device_ids = detect_available_device_ids();
         log_info(LogSiliconDriver, "Detected PCI devices: {}", available_device_ids);
@@ -454,10 +452,7 @@ Cluster::Cluster(
     // TODO: work on removing this member altogether. Currently assumes all have the same arch.
     arch_name = chips_.begin()->second->get_soc_descriptor().arch;
 
-    construct_cluster(
-        num_host_mem_ch_per_mmio_device,
-        create_mock_chips,
-        clean_system_resources);
+    construct_cluster(num_host_mem_ch_per_mmio_device, create_mock_chips, clean_system_resources);
 }
 
 Cluster::Cluster(
@@ -483,10 +478,7 @@ Cluster::Cluster(
     // TODO: work on removing this member altogether. Currently assumes all have the same arch.
     arch_name = chips_.begin()->second->get_soc_descriptor().arch;
 
-    construct_cluster(
-        num_host_mem_ch_per_mmio_device,
-        create_mock_chips,
-        clean_system_resources);
+    construct_cluster(num_host_mem_ch_per_mmio_device, create_mock_chips, clean_system_resources);
 }
 
 Cluster::Cluster(
@@ -524,10 +516,7 @@ Cluster::Cluster(
     // TODO: work on removing this member altogether. Currently assumes all have the same arch.
     arch_name = chips_.begin()->second->get_soc_descriptor().arch;
 
-    construct_cluster(
-        num_host_mem_ch_per_mmio_device,
-        create_mock_chips,
-        clean_system_resources);
+    construct_cluster(num_host_mem_ch_per_mmio_device, create_mock_chips, clean_system_resources);
 }
 
 Cluster::Cluster(
@@ -549,10 +538,7 @@ Cluster::Cluster(
     // TODO: work on removing this member altogether. Currently assumes all have the same arch.
     arch_name = chips_.begin()->second->get_soc_descriptor().arch;
 
-    construct_cluster(
-        num_host_mem_ch_per_mmio_device,
-        create_mock_chips,
-        clean_system_resources);
+    construct_cluster(num_host_mem_ch_per_mmio_device, create_mock_chips, clean_system_resources);
 }
 
 void Cluster::configure_active_ethernet_cores_for_mmio_device(

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -676,9 +676,6 @@ void Cluster::broadcast_pcie_tensix_risc_reset(chip_id_t chip_id, const TensixSo
 
     auto architecture_implementation = tt_device->get_architecture_implementation();
 
-    std::cout << " REMOVE MEEEE, BUT HARVESTED GRID IS "
-              << get_soc_descriptor(chip_id).get_harvested_grid_size(CoreType::TENSIX).str() << std::endl;
-
     // TODO: this is clumsy and difficult to read
     auto [soft_reset_reg, _] = tt_device->set_dynamic_tlb_broadcast(
         architecture_implementation->get_reg_tlb(),

--- a/device/mockup/tt_mockup_device.hpp
+++ b/device/mockup/tt_mockup_device.hpp
@@ -72,8 +72,6 @@ public:
     void wait_for_non_mmio_flush() override {}
 
     // Misc. Functions to Query/Set Device State
-    std::unordered_map<chip_id_t, uint32_t> get_harvesting_masks_for_soc_descriptors() override { return {{0, 0}}; }
-
     static std::vector<chip_id_t> detect_available_device_ids() { return {0}; };
 
     std::set<chip_id_t> get_target_device_ids() override { return target_devices_in_cluster; }

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -196,10 +196,6 @@ void tt_SimulationDevice::dram_membar(
     const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {}
 
 // Misc. Functions to Query/Set Device State
-std::unordered_map<chip_id_t, uint32_t> tt_SimulationDevice::get_harvesting_masks_for_soc_descriptors() {
-    return {{0, 0}};
-}
-
 std::vector<chip_id_t> tt_SimulationDevice::detect_available_device_ids() { return {0}; }
 
 std::set<chip_id_t> tt_SimulationDevice::get_target_device_ids() { return target_devices_in_cluster; }

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -130,8 +130,6 @@ void tt_SocDescriptor::load_core_descriptors_from_device_descriptor(YAML::Node &
     std::vector<std::string> worker_cores = device_descriptor_yaml["functional_workers"].as<std::vector<std::string>>();
     std::set<int> worker_routing_coords_x;
     std::set<int> worker_routing_coords_y;
-    std::unordered_map<int, int> routing_coord_worker_x;
-    std::unordered_map<int, int> routing_coord_worker_y;
     for (const auto &core_string : worker_cores) {
         CoreDescriptor core_descriptor;
         core_descriptor.coord = format_node(core_string);
@@ -143,21 +141,7 @@ void tt_SocDescriptor::load_core_descriptors_from_device_descriptor(YAML::Node &
         worker_routing_coords_y.insert(core_descriptor.coord.y);
     }
 
-    int func_x_start = 0;
-    int func_y_start = 0;
-    std::set<int>::iterator it;
-    for (it = worker_routing_coords_x.begin(); it != worker_routing_coords_x.end(); ++it) {
-        worker_log_to_routing_x[func_x_start] = *it;
-        routing_x_to_worker_x[*it] = func_x_start;
-        func_x_start++;
-    }
-    for (it = worker_routing_coords_y.begin(); it != worker_routing_coords_y.end(); ++it) {
-        worker_log_to_routing_y[func_y_start] = *it;
-        routing_y_to_worker_y[*it] = func_y_start;
-        func_y_start++;
-    }
-
-    worker_grid_size = tt_xy_pair(func_x_start, func_y_start);
+    worker_grid_size = tt_xy_pair(worker_routing_coords_x.size(), worker_routing_coords_y.size());
 
     auto harvested_cores = device_descriptor_yaml["harvested_workers"].as<std::vector<std::string>>();
     for (const auto &core_string : harvested_cores) {
@@ -186,11 +170,7 @@ tt_xy_pair tt_SocDescriptor::calculate_grid_size(const std::vector<tt_xy_pair> &
     return {x.size(), y.size()};
 }
 
-void tt_SocDescriptor::create_coordinate_manager(
-    const bool noc_translation_enabled,
-    const HarvestingMasks harvesting_masks,
-    const BoardType board_type,
-    const uint8_t asic_location) {
+void tt_SocDescriptor::create_coordinate_manager(const BoardType board_type, const uint8_t asic_location) {
     const tt_xy_pair dram_grid_size = tt_xy_pair(dram_cores.size(), dram_cores.empty() ? 0 : dram_cores[0].size());
     const tt_xy_pair arc_grid_size = tt_SocDescriptor::calculate_grid_size(arc_cores);
     tt_xy_pair pcie_grid_size = tt_SocDescriptor::calculate_grid_size(pcie_cores);
@@ -262,7 +242,7 @@ tt_SocDescriptor::tt_SocDescriptor(
     const HarvestingMasks harvesting_masks,
     const BoardType board_type,
     const uint8_t asic_location) :
-    harvesting_masks(harvesting_masks) {
+    noc_translation_enabled(noc_translation_enabled), harvesting_masks(harvesting_masks) {
     std::ifstream fdesc(device_descriptor_path);
     if (fdesc.fail()) {
         throw std::runtime_error(
@@ -281,7 +261,7 @@ tt_SocDescriptor::tt_SocDescriptor(
     arch_name_value = trim(arch_name_value);
     arch = tt::arch_from_str(arch_name_value);
     load_soc_features_from_device_descriptor(device_descriptor_yaml);
-    create_coordinate_manager(noc_translation_enabled, harvesting_masks, board_type, asic_location);
+    create_coordinate_manager(board_type, asic_location);
 }
 
 int tt_SocDescriptor::get_num_dram_channels() const {
@@ -292,10 +272,6 @@ int tt_SocDescriptor::get_num_dram_channels() const {
         }
     }
     return num_channels;
-}
-
-tt_xy_pair tt_SocDescriptor::get_core_for_dram_channel(int dram_chan, int subchannel) const {
-    return this->dram_cores.at(dram_chan).at(subchannel);
 }
 
 CoreCoord tt_SocDescriptor::get_dram_core_for_channel(

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -121,8 +121,6 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //         true,
 //         simulated_harvesting_masks);
 
-//     ASSERT_EQ(cluster.using_harvested_soc_descriptors(), true) << "Expected Driver to have performed harvesting";
-
 //     for (const auto& chip : sdesc_per_chip) {
 //         ASSERT_EQ(chip.second.workers.size(), 48)
 //             << "Expected SOC descriptor with harvesting to have 48 workers for chip" << chip.first;
@@ -156,8 +154,6 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //         false,
 //         simulated_harvesting_masks);
 
-//     ASSERT_EQ(cluster.using_harvested_soc_descriptors(), false)
-//         << "SOC descriptors should not be modified when harvesting is disabled";
 //     for (const auto& chip : sdesc_per_chip) {
 //         ASSERT_EQ(chip.second.workers.size(), 1) << "Expected 1x1 SOC descriptor to be unmodified by driver";
 //     }
@@ -767,8 +763,8 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as
     tt_device_params default_params;
     cluster.start_device(default_params);
     auto eth_version = cluster.get_ethernet_fw_version();
-    bool virtual_bcast_supported =
-        (eth_version >= tt_version(6, 8, 0) || eth_version == tt_version(6, 7, 241)) && cluster.translation_tables_en;
+    bool virtual_bcast_supported = (eth_version >= tt_version(6, 8, 0) || eth_version == tt_version(6, 7, 241)) &&
+                                   cluster.get_soc_descriptor(*target_devices.begin()).noc_translation_id_enabled;
     if (!virtual_bcast_supported) {
         cluster.close_device();
         GTEST_SKIP() << "SiliconDriverWH.VirtualCoordinateBroadcast skipped since ethernet version does not support "

--- a/tests/grayskull/test_cluster_gs.cpp
+++ b/tests/grayskull/test_cluster_gs.cpp
@@ -69,15 +69,6 @@ TEST(SiliconDriverGS, Harvesting) {
                 simulated_harvesting_masks.at(chip_id).tensix_harvesting_mask,
             simulated_harvesting_masks.at(chip_id).tensix_harvesting_mask)
             << "Expected first chip to include simulated harvesting mask of 6";
-        // get_harvesting_masks_for_soc_descriptors will return harvesting info in noc0 coordinates.
-        simulated_harvesting_masks.at(chip_id).tensix_harvesting_mask =
-            CoordinateManager::shuffle_tensix_harvesting_mask_to_noc0_coords(
-                tt::ARCH::GRAYSKULL, simulated_harvesting_masks.at(chip_id).tensix_harvesting_mask);
-        ASSERT_EQ(
-            cluster.get_harvesting_masks_for_soc_descriptors().at(chip_id) &
-                simulated_harvesting_masks.at(chip_id).tensix_harvesting_mask,
-            simulated_harvesting_masks.at(chip_id).tensix_harvesting_mask)
-            << "Expected first chip to include simulated harvesting mask of 6";
     }
     cluster.close_device();
 }

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -122,9 +122,9 @@ TEST(SiliconDriverWH, Harvesting) {
         simulated_harvesting_masks[i].tensix_harvesting_mask |= harvesting_mask_logical;
     }
 
-    for (const auto& chip : sdesc_per_chip) {
-        ASSERT_LE(chip.second.get_cores(CoreType::TENSIX).size(), 48)
-            << "Expected SOC descriptor with harvesting to have 48 workers or less for chip " << chip.first;
+    for (const auto& chip : cluster.get_target_device_ids()) {
+        ASSERT_EQ(cluster.get_soc_descriptor(chip).get_cores(CoreType::TENSIX).size(), 48)
+            << "Expected SOC descriptor with harvesting to have 48 workers or less for chip " << chip;
     }
     for (int i = 0; i < num_devices; i++) {
         // harvesting info stored in soc descriptor is in logical coordinates.

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -123,7 +123,7 @@ TEST(SiliconDriverWH, Harvesting) {
     }
 
     for (const auto& chip : cluster.get_target_device_ids()) {
-        ASSERT_LT(cluster.get_soc_descriptor(chip).get_cores(CoreType::TENSIX).size(), 48)
+        ASSERT_LE(cluster.get_soc_descriptor(chip).get_cores(CoreType::TENSIX).size(), 48)
             << "Expected SOC descriptor with harvesting to have 48 workers or less for chip " << chip;
     }
     for (int i = 0; i < num_devices; i++) {

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -123,7 +123,7 @@ TEST(SiliconDriverWH, Harvesting) {
     }
 
     for (const auto& chip : cluster.get_target_device_ids()) {
-        ASSERT_EQ(cluster.get_soc_descriptor(chip).get_cores(CoreType::TENSIX).size(), 48)
+        ASSERT_LT(cluster.get_soc_descriptor(chip).get_cores(CoreType::TENSIX).size(), 48)
             << "Expected SOC descriptor with harvesting to have 48 workers or less for chip " << chip;
     }
     for (int i = 0; i < num_devices; i++) {


### PR DESCRIPTION
### Issue
Last one for #439 

### Description
Finally removing old harvesting code. All the tt_metal's usages have been moved to the new soc_descriptor and core_coordinate_manager apis.

### List of the changes
- Remove using_harvested_soc_descriptors, get_harvesting_masks_for_soc_descriptors and translate_to_noc_table_coords functions, and performed_harvesting, harvested_rows_per_target, translation_tables_en from the public cluster API
- Remove harvesting code from Cluster with many internal functions
- move old soc_descriptor structures to be private.
- Adjust tests accordingly
- Added noc_translation public member to soc_descriptor. Verify that the one passed through constructor and through soc_descriptor matches. This code should be improved.

### Testing
Code builds

### API Changes
There are no breaking API changes in this PR.
Related metal PRs prior to this change:
https://github.com/tenstorrent/tt-metal/pull/17003
https://github.com/tenstorrent/tt-metal/pull/17306
https://github.com/tenstorrent/tt-metal/pull/17543
https://github.com/tenstorrent/tt-metal/pull/17620
https://github.com/tenstorrent/tt-metal/pull/17642
https://github.com/tenstorrent/tt-metal/pull/17645
https://github.com/tenstorrent/tt-metal/pull/17674
https://github.com/tenstorrent/tt-metal/pull/17678
https://github.com/tenstorrent/tt-metal/pull/17707
https://github.com/tenstorrent/tt-metal/pull/18352

