### PR TITLE
Minor cluster.h change

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -512,7 +512,6 @@ public:
      */
     virtual bool using_harvested_soc_descriptors() {
         throw std::runtime_error("---- tt_device:using_harvested_soc_descriptors is not implemented\n");
-        return 0;
     }
 
     /**
@@ -568,6 +567,13 @@ public:
     }
 
     /**
+     * Get set of chip ids for all chips in the cluster.
+     */
+    virtual std::set<chip_id_t> get_target_device_ids() {
+        throw std::runtime_error("---- tt_device::get_target_device_ids is not implemented\n");
+    }
+
+    /**
      * Get all logical ids for all local chips targeted by UMD.
      */
     virtual std::set<chip_id_t> get_target_mmio_device_ids() {
@@ -587,7 +593,6 @@ public:
      */
     virtual std::map<int, int> get_clocks() {
         throw std::runtime_error("---- tt_device::get_clocks is not implemented\n");
-        return std::map<int, int>();
     }
 
     /**
@@ -614,7 +619,6 @@ public:
      */
     virtual std::uint32_t get_num_dram_channels(std::uint32_t device_id) {
         throw std::runtime_error("---- tt_device::get_num_dram_channels is not implemented\n");
-        return 0;
     }
 
     /**
@@ -625,7 +629,6 @@ public:
      */
     virtual std::uint64_t get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel) {
         throw std::runtime_error("---- tt_device::get_dram_channel_size is not implemented\n");
-        return 0;
     }
 
     /**
@@ -635,7 +638,6 @@ public:
      */
     virtual std::uint32_t get_num_host_channels(std::uint32_t device_id) {
         throw std::runtime_error("---- tt_device::get_num_host_channels is not implemented\n");
-        return 0;
     }
 
     /**
@@ -646,7 +648,6 @@ public:
      */
     virtual std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel) {
         throw std::runtime_error("---- tt_device::get_host_channel_size is not implemented\n");
-        return 0;
     }
 
     /**
@@ -659,7 +660,6 @@ public:
      */
     virtual void* host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const {
         throw std::runtime_error("---- tt_device::host_dma_address is not implemented\n");
-        return nullptr;
     }
 
     /**
@@ -669,7 +669,6 @@ public:
      */
     virtual std::uint64_t get_pcie_base_addr_from_device(const chip_id_t chip_id) const {
         throw std::runtime_error("---- tt_device::get_pcie_base_addr_from_device is not implemented\n");
-        return 0;
     }
 
     /**
@@ -852,6 +851,11 @@ public:
     static std::vector<chip_id_t> detect_available_device_ids();
 
     /**
+     * Get set of chip ids for all chips in the cluster.
+     */
+    virtual std::set<chip_id_t> get_target_device_ids();
+
+    /**
      * Get vector of chip ids for MMIO devices in the cluster.
      */
     virtual std::set<chip_id_t> get_target_mmio_device_ids();
@@ -860,11 +864,6 @@ public:
      * Get vector of chip ids for remote devices in the cluster.
      */
     virtual std::set<chip_id_t> get_target_remote_device_ids();
-
-    /**
-     * Get set of chip ids for all chips in the cluster.
-     */
-    virtual std::set<chip_id_t> get_target_device_ids();
 
     virtual std::map<int, int> get_clocks();
     virtual void* host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const;

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -67,6 +67,8 @@ public:
     // virtual bool using_harvested_soc_descriptors();
     virtual std::unordered_map<chip_id_t, uint32_t> get_harvesting_masks_for_soc_descriptors();
     static std::vector<chip_id_t> detect_available_device_ids();
+    virtual std::set<chip_id_t> get_target_device_ids();
+    virtual std::set<chip_id_t> get_target_mmio_device_ids();
     virtual std::set<chip_id_t> get_target_remote_device_ids();
     virtual std::map<int, int> get_clocks();
     virtual void* host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1019,9 +1019,11 @@ void Cluster::broadcast_pcie_tensix_risc_reset(chip_id_t chip_id, const TensixSo
     tt_driver_atomics::sfence();
 }
 
+std::set<chip_id_t> Cluster::get_target_device_ids() { return all_chip_ids_; }
+
 std::set<chip_id_t> Cluster::get_target_mmio_device_ids() { return local_chip_ids_; }
 
-std::set<chip_id_t> Cluster::get_target_device_ids() { return all_chip_ids_; }
+std::set<chip_id_t> Cluster::get_target_remote_device_ids() { return remote_chip_ids_; }
 
 void Cluster::assert_risc_reset() { broadcast_tensix_risc_reset_to_cluster(TENSIX_ASSERT_SOFT_RESET); }
 
@@ -3265,8 +3267,6 @@ void Cluster::enable_ethernet_queue(int timeout) {
         }
     }
 }
-
-std::set<chip_id_t> Cluster::get_target_remote_device_ids() { return remote_chip_ids_; }
 
 void Cluster::deassert_resets_and_set_power_state() {
     // Assert tensix resets on all chips in cluster

--- a/device/mockup/tt_mockup_device.hpp
+++ b/device/mockup/tt_mockup_device.hpp
@@ -16,7 +16,7 @@ class tt_MockupDevice : public tt_device {
 public:
     tt_MockupDevice(const std::string& sdesc_path) : tt_device() {
         soc_descriptor_per_chip.emplace(0, tt_SocDescriptor(sdesc_path, false));
-        std::set<chip_id_t> target_devices = {0};
+        target_devices_in_cluster = {0};
     }
 
     virtual ~tt_MockupDevice() {}
@@ -75,6 +75,10 @@ public:
     std::unordered_map<chip_id_t, uint32_t> get_harvesting_masks_for_soc_descriptors() override { return {{0, 0}}; }
 
     static std::vector<chip_id_t> detect_available_device_ids() { return {0}; };
+
+    std::set<chip_id_t> get_target_device_ids() { return target_devices_in_cluster; }
+
+    std::set<chip_id_t> get_target_mmio_device_ids() { return target_devices_in_cluster; }
 
     std::set<chip_id_t> get_target_remote_device_ids() override { return target_remote_chips; }
 

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -56,7 +56,7 @@ tt_SimulationDevice::tt_SimulationDevice(const tt_SimulationDeviceInit& init) : 
     log_info(tt::LogEmulationDriver, "Instantiating simulation device");
     soc_descriptor_per_chip.emplace(0, init.get_soc_descriptor());
     arch_name = init.get_arch_name();
-    std::set<chip_id_t> target_devices = {0};
+    target_devices_in_cluster = {0};
 
     // Start VCS simulator in a separate process
     std::filesystem::path simulator_path = init.get_simulator_path();
@@ -201,6 +201,10 @@ std::unordered_map<chip_id_t, uint32_t> tt_SimulationDevice::get_harvesting_mask
 }
 
 std::vector<chip_id_t> tt_SimulationDevice::detect_available_device_ids() { return {0}; }
+
+std::set<chip_id_t> tt_SimulationDevice::get_target_device_ids() { return target_devices_in_cluster; }
+
+std::set<chip_id_t> tt_SimulationDevice::get_target_mmio_device_ids() { return target_devices_in_cluster; }
 
 std::set<chip_id_t> tt_SimulationDevice::get_target_remote_device_ids() { return target_remote_chips; }
 


### PR DESCRIPTION
### Issue
Related to #439

### Description
Minor API changes.

### List of the changes
- Added missing get_target_device_ids to tt_device API. This includes both local and remote chips. This is not necessarily the same set returned by cluster descriptor
- Remove return values after throw, unnecessary
- Change mockup and simulation accordingly

### Testing
No testing

### API Changes
There are no breaking API changes in this PR.
