### PR TITLE
Replace log_assert with runtime error

### DIFF
--- a/device/blackhole/blackhole_coordinate_manager.cpp
+++ b/device/blackhole/blackhole_coordinate_manager.cpp
@@ -39,9 +39,9 @@ BlackholeCoordinateManager::BlackholeCoordinateManager(
 }
 
 void BlackholeCoordinateManager::assert_coordinate_manager_constructor() {
-    log_assert(
-        get_num_harvested(harvesting_masks.dram_harvesting_mask) <= 1,
-        "Only one DRAM bank can be harvested on Blackhole");
+    if (get_num_harvested(harvesting_masks.dram_harvesting_mask) > 1) {
+        throw std::runtime_error("Only one DRAM bank can be harvested on Blackhole");
+    }
 
     // TODO: assert that exactly 2 or all 14 (P100) ETH cores are harvested for Blackhole. This is
     // going to be true both for all Blackhole products.

--- a/device/blackhole/blackhole_implementation.cpp
+++ b/device/blackhole/blackhole_implementation.cpp
@@ -108,7 +108,9 @@ tt_driver_noc_params blackhole_implementation::get_noc_params() const {
 namespace blackhole {
 std::vector<tt_xy_pair> get_pcie_cores(const BoardType board_type, const bool is_chip_remote) {
     if (is_chip_remote) {
-        log_assert(board_type == BoardType::P300, "Remote chip is supported only for Blackhole P300 board.");
+        if (board_type != BoardType::P300) {
+            throw std::runtime_error("Remote chip is supported only for Blackhole P300 board.");
+        }
     }
 
     if (board_type == BoardType::UNKNOWN || board_type == BoardType::P100) {

--- a/device/grayskull/grayskull_coordinate_manager.cpp
+++ b/device/grayskull/grayskull_coordinate_manager.cpp
@@ -38,21 +38,21 @@ GrayskullCoordinateManager::GrayskullCoordinateManager(
 }
 
 void GrayskullCoordinateManager::fill_tensix_physical_translated_mapping() {
-    log_assert(false, "NOC translation is not supported for Grayskull.");
+    throw std::runtime_error("NOC translation is not supported for Grayskull.");
 }
 
 void GrayskullCoordinateManager::fill_eth_physical_translated_mapping() {
-    log_assert(false, "NOC translation is not supported for Grayskull.");
+    throw std::runtime_error("NOC translation is not supported for Grayskull.");
 }
 
 void GrayskullCoordinateManager::fill_dram_physical_translated_mapping() {
-    log_assert(false, "NOC translation is not supported for Grayskull.");
+    throw std::runtime_error("NOC translation is not supported for Grayskull.");
 }
 
 void GrayskullCoordinateManager::fill_pcie_physical_translated_mapping() {
-    log_assert(false, "NOC translation is not supported for Grayskull.");
+    throw std::runtime_error("NOC translation is not supported for Grayskull.");
 }
 
 void GrayskullCoordinateManager::fill_arc_physical_translated_mapping() {
-    log_assert(false, "NOC translation is not supported for Grayskull.");
+    throw std::runtime_error("NOC translation is not supported for Grayskull.");
 }

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -366,7 +366,9 @@ std::vector<tt::umd::CoreCoord> tt_SocDescriptor::get_cores(
 
 std::vector<tt::umd::CoreCoord> tt_SocDescriptor::get_harvested_cores(
     const CoreType core_type, const CoordSystem coord_system) const {
-    log_assert(coord_system != CoordSystem::LOGICAL, "Harvested cores are not supported for logical coordinates");
+    if (coord_system == CoordSystem::LOGICAL) {
+        throw std::runtime_error("Harvested cores are not supported for logical coordinates");
+    }
     auto harvested_cores_map_it = harvested_cores_map.find(core_type);
     if (coord_system != CoordSystem::PHYSICAL) {
         return translate_coordinates(harvested_cores_map_it->second, coord_system);


### PR DESCRIPTION
### Issue

tt-lens users have seen fatal prints because of log_assert. This PR changes log_assert with exception, plus some other log_assert that we introduced. Other log_assert calls are going to go away by redesign or we are going to make separate exceptions later on. Follow up issues linked below

### Description

Replace log_assert calls with throwing of runtime error

### List of the changes

Same as description

### Testing
CI

### API Changes
/

### TODO

- [x] Add follow up issues - https://github.com/tenstorrent/tt-umd/issues/517