### PR TITLE
Remove get_virtual_soc_descriptors

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -496,16 +496,6 @@ public:
         throw std::runtime_error("---- tt_device::dram_membar is not implemented\n");
     }
 
-    // Misc. Functions to Query/Set Device State
-    /**
-     * Query post harvesting SOC descriptors from UMD in virtual coordinates.
-     * It should just return the SoCDescriptors that were created during construction.
-     * These descriptors should be used for looking up cores that are passed into UMD APIs.
-     */
-    virtual std::unordered_map<chip_id_t, tt_SocDescriptor> get_virtual_soc_descriptors() {
-        return soc_descriptor_per_chip;
-    }
-
     /**
      * Determine if UMD performed harvesting on SOC descriptors. Returns false if there is no harvesting for the
      * devices.
@@ -677,16 +667,12 @@ public:
      * @param chip_id Chip to get soc descriptor for.
      */
     virtual const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const {
-        return soc_descriptor_per_chip.at(chip_id);
+        throw std::runtime_error("---- tt_device::get_soc_descriptor is not implemented\n");
     }
 
     bool performed_harvesting = false;
     std::unordered_map<chip_id_t, uint32_t> harvested_rows_per_target = {};
     bool translation_tables_en = false;
-
-protected:
-    // TODO: Remove this once get_virtual_soc_descriptors can be removed.
-    std::unordered_map<chip_id_t, tt_SocDescriptor> soc_descriptor_per_chip = {};
 };
 
 namespace tt::umd {
@@ -907,7 +893,6 @@ public:
     // Existing API we want to remove. UMD is transitioning to use CoreCoord instead of tt_xy_pair.
     // This set of functions is supposed to be removed one the transition for clients (tt-metal, tt-lens) is complete.
     // TODO: remove this set of functions once the transition for clients is completed.
-    std::unordered_map<chip_id_t, tt_SocDescriptor> get_virtual_soc_descriptors();
     virtual void configure_tlb(
         chip_id_t logical_device_id,
         tt_xy_pair core,

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -78,6 +78,7 @@ public:
     virtual std::uint32_t get_num_host_channels(std::uint32_t device_id);
     virtual std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel);
     virtual std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id);
+    virtual const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const;
 
 private:
     // State variables
@@ -87,4 +88,5 @@ private:
     std::set<chip_id_t> target_remote_chips = {};
     tt::ARCH arch_name;
     std::shared_ptr<tt_ClusterDescriptor> cluster_descriptor;
+    std::unordered_map<chip_id_t, tt_SocDescriptor> soc_descriptor_per_chip = {};
 };

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -136,14 +136,6 @@ const tt_SocDescriptor& Cluster::get_soc_descriptor(chip_id_t chip_id) const {
     return chips_.at(chip_id)->get_soc_descriptor();
 }
 
-std::unordered_map<chip_id_t, tt_SocDescriptor> Cluster::get_virtual_soc_descriptors() {
-    std::unordered_map<chip_id_t, tt_SocDescriptor> soc_descs;
-    for (const auto& chip : chips_) {
-        soc_descs[chip.first] = chip.second->get_soc_descriptor();
-    }
-    return soc_descs;
-}
-
 void Cluster::initialize_interprocess_mutexes(int logical_device_id, bool cleanup_mutexes_in_shm) {
     // These mutexes are intended to be based on physical devices/pci-intf not logical. Set these up ahead of time here
     // (during device init) since its unsafe to modify shared state during multithreaded runtime. cleanup_mutexes_in_shm
@@ -294,11 +286,6 @@ void Cluster::construct_cluster(
         log_info(LogSiliconDriver, "Detected PCI devices: {}", available_device_ids);
         log_info(
             LogSiliconDriver, "Using local chip ids: {} and remote chip ids {}", local_chip_ids_, remote_chip_ids_);
-    }
-
-    // Prefill the soc_descriptor_per_chip
-    for (const auto& [chip_id, chip] : chips_) {
-        soc_descriptor_per_chip.emplace(chip_id, chip->get_soc_descriptor());
     }
 
     perform_harvesting_on_sdesc = perform_harvesting;

--- a/device/mockup/tt_mockup_device.hpp
+++ b/device/mockup/tt_mockup_device.hpp
@@ -104,9 +104,14 @@ public:
 
     std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id) override { return 0; }
 
+    const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const override {
+        return soc_descriptor_per_chip.at(chip_id);
+    };
+
 private:
     std::vector<tt::ARCH> archs_in_cluster = {};
     std::set<chip_id_t> target_devices_in_cluster = {};
     std::set<chip_id_t> target_remote_chips = {};
     std::shared_ptr<tt_ClusterDescriptor> cluster_descriptor;
+    std::unordered_map<chip_id_t, tt_SocDescriptor> soc_descriptor_per_chip = {};
 };

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -238,3 +238,7 @@ std::uint32_t tt_SimulationDevice::get_num_host_channels(std::uint32_t device_id
 std::uint32_t tt_SimulationDevice::get_host_channel_size(std::uint32_t device_id, std::uint32_t channel) { return 0; }
 
 std::uint32_t tt_SimulationDevice::get_numa_node_for_pcie_device(std::uint32_t device_id) { return 0; }
+
+const tt_SocDescriptor& tt_SimulationDevice::get_soc_descriptor(chip_id_t chip_id) const {
+    return soc_descriptor_per_chip.at(chip_id);
+};

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -120,7 +120,6 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //         true,
 //         true,
 //         simulated_harvesting_masks);
-//     auto sdesc_per_chip = cluster.get_virtual_soc_descriptors();
 
 //     ASSERT_EQ(cluster.using_harvested_soc_descriptors(), true) << "Expected Driver to have performed harvesting";
 
@@ -156,7 +155,6 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //         true,
 //         false,
 //         simulated_harvesting_masks);
-//     auto sdesc_per_chip = cluster.get_virtual_soc_descriptors();
 
 //     ASSERT_EQ(cluster.using_harvested_soc_descriptors(), false)
 //         << "SOC descriptors should not be modified when harvesting is disabled";

--- a/tests/galaxy/test_umd_concurrent_threads.cpp
+++ b/tests/galaxy/test_umd_concurrent_threads.cpp
@@ -51,7 +51,6 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
 
     Cluster device =
         Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), all_devices, num_host_mem_ch_per_mmio_device, false, true);
-    const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_barrier_params(device);
 
@@ -67,7 +66,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
         std::uint32_t write_size = vector_to_write_th1.size() * 4;
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (const auto& chip : target_devices_th1) {
-            for (const CoreCoord& core : sdesc_per_chip.at(chip).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
                 device.write_to_device(
                     vector_to_write_th1.data(),
                     vector_to_write_th1.size() * sizeof(std::uint32_t),
@@ -79,7 +78,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
         }
         device.wait_for_non_mmio_flush();
         for (auto& chip : target_devices_th1) {
-            for (const CoreCoord& core : sdesc_per_chip.at(chip).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
                 test_utils::read_data_from_device(
                     device, readback_vec, chip, core, address, write_size, "SMALL_READ_WRITE_TLB");
                 EXPECT_EQ(vector_to_write_th1, readback_vec)
@@ -94,7 +93,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
         std::uint32_t write_size = vector_to_write_th2.size() * 4;
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (const auto& chip : target_devices_th2) {
-            for (const CoreCoord& core : sdesc_per_chip.at(chip).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
                 device.write_to_device(
                     vector_to_write_th2.data(),
                     vector_to_write_th2.size() * sizeof(std::uint32_t),
@@ -106,7 +105,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
         }
         device.wait_for_non_mmio_flush();
         for (const auto& chip : target_devices_th2) {
-            for (const CoreCoord& core : sdesc_per_chip.at(chip).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
                 test_utils::read_data_from_device(
                     device, readback_vec, chip, core, address, write_size, "SMALL_READ_WRITE_TLB");
                 EXPECT_EQ(vector_to_write_th2, readback_vec)
@@ -150,7 +149,6 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
 
     Cluster device =
         Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), all_devices, num_host_mem_ch_per_mmio_device, false, true);
-    const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_barrier_params(device);
 
@@ -166,7 +164,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = 0x4000000;
         for (const auto& chip : target_devices_th1) {
-            for (const CoreCoord& core : sdesc_per_chip.at(0).get_cores(CoreType::DRAM)) {
+            for (const CoreCoord& core : device.get_soc_descriptor(0).get_cores(CoreType::DRAM)) {
                 device.write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
@@ -178,7 +176,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
         }
         device.wait_for_non_mmio_flush();
         for (const auto& chip : target_devices_th1) {
-            for (const CoreCoord& core : sdesc_per_chip.at(0).get_cores(CoreType::DRAM)) {
+            for (const CoreCoord& core : device.get_soc_descriptor(0).get_cores(CoreType::DRAM)) {
                 test_utils::read_data_from_device(
                     device, readback_vec, chip, core, address, write_size, "SMALL_READ_WRITE_TLB");
                 EXPECT_EQ(vector_to_write, readback_vec)
@@ -192,7 +190,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = 0x5000000;
         for (const auto& chip : target_devices_th2) {
-            for (const CoreCoord& core : sdesc_per_chip.at(chip).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
                 device.write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
@@ -204,7 +202,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
         }
         device.wait_for_non_mmio_flush();
         for (const auto& chip : target_devices_th2) {
-            for (const CoreCoord& core : sdesc_per_chip.at(chip).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
                 test_utils::read_data_from_device(
                     device, readback_vec, chip, core, address, write_size, "SMALL_READ_WRITE_TLB");
                 EXPECT_EQ(vector_to_write, readback_vec)
@@ -234,7 +232,6 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
 
     Cluster device =
         Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), target_devices, num_host_mem_ch_per_mmio_device, false, true);
-    const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_barrier_params(device);
 
@@ -274,7 +271,7 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (const auto& chip : target_devices) {
-            for (const CoreCoord& core : sdesc_per_chip.at(chip).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
                 device.write_to_device(
                     small_vector.data(),
                     small_vector.size() * sizeof(std::uint32_t),
@@ -286,7 +283,7 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
         }
         device.wait_for_non_mmio_flush();
         for (const auto& chip : target_devices) {
-            for (const CoreCoord& core : sdesc_per_chip.at(chip).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
                 test_utils::read_data_from_device(
                     device, readback_vec, chip, core, address, small_vector.size() * 4, "SMALL_READ_WRITE_TLB");
                 EXPECT_EQ(small_vector, readback_vec)

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -31,7 +31,6 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
 
     Cluster device =
         Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), target_devices, num_host_mem_ch_per_mmio_device, false, true);
-    const auto sdesc_per_chip = device.get_virtual_soc_descriptors();
 
     tt::umd::test::utils::set_barrier_params(device);
 
@@ -53,9 +52,9 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
         for (int loop = 0; loop < 10; loop++) {
             std::vector<CoreCoord> target_cores;
             if (dram_write) {
-                target_cores = sdesc_per_chip.at(chip).get_cores(CoreType::DRAM);
+                target_cores = device.get_soc_descriptor(chip).get_cores(CoreType::DRAM);
             } else {
-                target_cores = sdesc_per_chip.at(chip).get_cores(CoreType::TENSIX);
+                target_cores = device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX);
             }
             for (const CoreCoord& core : target_cores) {
                 auto start = std::chrono::high_resolution_clock::now();

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -120,7 +120,7 @@ TEST(SiliconDriverWH, Harvesting) {
 
     for (const auto& chip : cluster.get_target_device_ids()) {
         ASSERT_LE(cluster.get_soc_descriptor(chip).get_cores(CoreType::TENSIX).size(), 48)
-            << "Expected SOC descriptor with harvesting to have 48 workers or less for chip" << chip.first;
+            << "Expected SOC descriptor with harvesting to have 48 workers or less for chip " << chip;
     }
     for (int i = 0; i < num_devices; i++) {
         // harvesting info stored in soc descriptor is in logical coordinates.

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -106,7 +106,6 @@ TEST(SiliconDriverWH, Harvesting) {
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     Cluster cluster = Cluster(num_host_mem_ch_per_mmio_device, false, true, true, simulated_harvesting_masks);
-    auto sdesc_per_chip = cluster.get_virtual_soc_descriptors();
 
     // Real harvesting info on this system will be forcefully included in the harvesting mask.
     std::unordered_map<chip_id_t, std::uint32_t> harvesting_info =
@@ -119,8 +118,8 @@ TEST(SiliconDriverWH, Harvesting) {
 
     ASSERT_EQ(cluster.using_harvested_soc_descriptors(), true) << "Expected Driver to have performed harvesting";
 
-    for (const auto& chip : sdesc_per_chip) {
-        ASSERT_LE(chip.second.get_cores(CoreType::TENSIX).size(), 48)
+    for (const auto& chip : cluster.get_target_device_ids()) {
+        ASSERT_LE(cluster.get_soc_descriptor(chip).get_cores(CoreType::TENSIX).size(), 48)
             << "Expected SOC descriptor with harvesting to have 48 workers or less for chip" << chip.first;
     }
     for (int i = 0; i < num_devices; i++) {
@@ -158,12 +157,11 @@ TEST(SiliconDriverWH, CustomSocDesc) {
         true,
         false,
         simulated_harvesting_masks);
-    auto sdesc_per_chip = cluster.get_virtual_soc_descriptors();
 
     ASSERT_EQ(cluster.using_harvested_soc_descriptors(), false)
         << "SOC descriptors should not be modified when harvesting is disabled";
-    for (const auto& chip : sdesc_per_chip) {
-        ASSERT_EQ(chip.second.get_cores(CoreType::TENSIX).size(), 1)
+    for (const auto& chip : cluster.get_target_device_ids()) {
+        ASSERT_EQ(cluster.get_soc_descriptor(chip).get_cores(CoreType::TENSIX).size(), 1)
             << "Expected 1x1 SOC descriptor to be unmodified by driver";
     }
 }


### PR DESCRIPTION
### Issue
Part of https://github.com/tenstorrent/tt-umd/issues/248

### Description
This map usage is removed from tt-metal.
Alternative is to get_target_device_ids and then get_soc_descriptor()

### List of the changes
- Removed get_virtual_soc_descriptors
- Added specific get_soc_descriptor to mockup and simulation
- Change all relevant usages

### Testing
Existing CI tests

### API Changes
There will be no breaking API changes after this one is merged: https://github.com/tenstorrent/tt-metal/pull/17645
