### PR TITLE
Remove TTDevice mutex

### DIFF
--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -28,10 +28,6 @@ struct dynamic_tlb {
     uint64_t remaining_size;  // Bytes remaining between bar_offset and end of the TLB.
 };
 
-namespace boost::interprocess {
-class named_mutex;
-}
-
 namespace tt::umd {
 
 class TLBManager;
@@ -150,10 +146,6 @@ protected:
     // to 2-byte writes. We avoid ever performing a 1-byte write to the device. This only affects to device.
     void memcpy_to_device(void *dest, const void *src, std::size_t num_bytes);
     void memcpy_from_device(void *dest, const void *src, std::size_t num_bytes);
-
-    void create_read_write_mutex();
-
-    std::shared_ptr<boost::interprocess::named_mutex> read_write_mutex = nullptr;
 
     ChipInfo chip_info;
 };

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -3,17 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "umd/device/tt_device/tt_device.h"
 
-#include <boost/interprocess/permissions.hpp>
-#include <boost/interprocess/sync/named_mutex.hpp>
-#include <boost/interprocess/sync/scoped_lock.hpp>
-
 #include "logger.hpp"
 #include "umd/device/driver_atomics.h"
 #include "umd/device/tt_device/blackhole_tt_device.h"
 #include "umd/device/tt_device/grayskull_tt_device.h"
 #include "umd/device/tt_device/wormhole_tt_device.h"
-
-using namespace boost::interprocess;
 
 namespace tt::umd {
 
@@ -22,9 +16,7 @@ TTDevice::TTDevice(
     pci_device_(std::move(pci_device)),
     architecture_impl_(std::move(architecture_impl)),
     tlb_manager_(std::make_unique<TLBManager>(this)),
-    arch(architecture_impl_->get_architecture()) {
-    create_read_write_mutex();
-}
+    arch(architecture_impl_->get_architecture()) {}
 
 /* static */ std::unique_ptr<TTDevice> TTDevice::create(int pci_device_number) {
     auto pci_device = std::make_unique<PCIDevice>(pci_device_number);
@@ -216,7 +208,6 @@ void TTDevice::read_block(uint64_t byte_addr, uint64_t num_bytes, uint8_t *buffe
 }
 
 void TTDevice::read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
-    const scoped_lock<named_mutex> lock(*read_write_mutex);
     uint8_t *buffer_addr = static_cast<uint8_t *>(mem_ptr);
     const uint32_t tlb_index = get_architecture_implementation()->get_small_read_write_tlb();
     while (size > 0) {
@@ -231,10 +222,8 @@ void TTDevice::read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, u
 }
 
 void TTDevice::write_to_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
-    const scoped_lock<named_mutex> lock(*read_write_mutex);
     uint8_t *buffer_addr = static_cast<uint8_t *>(mem_ptr);
     const uint32_t tlb_index = get_architecture_implementation()->get_small_read_write_tlb();
-    // const scoped_lock<named_mutex> lock(*get_mutex(fallback_tlb, target.chip));
 
     while (size > 0) {
         auto [mapped_address, tlb_size] = set_dynamic_tlb(tlb_index, core, addr, tt::umd::tlb_data::Strict);
@@ -350,12 +339,6 @@ void TTDevice::configure_iatu_region(size_t region, uint64_t base, uint64_t targ
     //
     // For now, just throw an exception.
     throw std::runtime_error("configure_iatu_region is not implemented for this device");
-}
-
-void TTDevice::create_read_write_mutex() {
-    permissions unrestricted_permissions;
-    unrestricted_permissions.set_unrestricted();
-    read_write_mutex = std::make_shared<named_mutex>(open_or_create, "read_write_mutex", unrestricted_permissions);
 }
 
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue

Metal folks reported issue https://github.com/tenstorrent/tt-metal/issues/17763 - handling mutex for sync on TTDevice read/write. Removing it for now since UMD is not using this code path in concurrent way. Opened issue #523 to fix this properly

### Description

Remove mutex for TTdevice read/write sync

### List of the changes

- Remove mutex for TTDevice read/write sync

### Testing

CI

### API Changes
/