### PR TITLE
Add physical <-> translated mapping for all BH pcie cores

### DIFF
--- a/device/blackhole/blackhole_coordinate_manager.cpp
+++ b/device/blackhole/blackhole_coordinate_manager.cpp
@@ -221,17 +221,20 @@ void BlackholeCoordinateManager::fill_eth_physical_translated_mapping() {
 }
 
 void BlackholeCoordinateManager::fill_pcie_physical_translated_mapping() {
-    CoreCoord logical_coord = CoreCoord(0, 0, CoreType::PCIE, CoordSystem::LOGICAL);
+    for (size_t x = 0; x < pcie_grid_size.x; x++) {
+        for (size_t y = 0; y < pcie_grid_size.y; y++) {
+            CoreCoord logical_coord = CoreCoord(x, y, CoreType::PCIE, CoordSystem::LOGICAL);
+            const tt_xy_pair physical_pair = to_physical_map[logical_coord];
 
-    const tt_xy_pair physical_pair = to_physical_map[logical_coord];
+            CoreCoord translated_coord = CoreCoord(
+                blackhole::pcie_translated_coordinate_start_x,
+                blackhole::pcie_translated_coordinate_start_y,
+                CoreType::PCIE,
+                CoordSystem::TRANSLATED);
 
-    CoreCoord translated_coord = CoreCoord(
-        blackhole::pcie_translated_coordinate_start_x,
-        blackhole::pcie_translated_coordinate_start_y,
-        CoreType::PCIE,
-        CoordSystem::TRANSLATED);
-
-    add_core_translation(translated_coord, physical_pair);
+            add_core_translation(translated_coord, physical_pair);
+        }
+    }
 }
 
 void BlackholeCoordinateManager::fill_arc_physical_translated_mapping() {


### PR DESCRIPTION
### Issue
N/A

### Description
In Metal the BH soc descriptor lists both potential physical PCIe cores (2,0) and (11,0) but later picks which physical (noc0) PCIe core to use for the board type. 

When switching to translated coordinates Metal tests were failing to translate (11,0) because the BH coordinate manager assumes only 1 PCIe core 

### List of the changes
Update physical <-> translated mapping for BH to iterate over all PCIe cores. 

### Testing
- Tested on Metal branch `abhullar/bh-virtual`
