### PR TITLE
Updates for BH connectivity 

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -51,7 +51,7 @@ private:
 protected:
     void wait_chip_to_be_ready();
 
-    virtual void wait_eth_cores_training(const uint32_t timeout_ms = 5000);
+    virtual void wait_eth_cores_training(const uint32_t timeout_ms = 60000);
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -28,6 +28,6 @@ private:
     void initialize_tlb_manager();
 
 protected:
-    void wait_eth_cores_training(const uint32_t timeout_ms = 5000) override;
+    void wait_eth_cores_training(const uint32_t timeout_ms = 60000) override;
 };
 }  // namespace tt::umd


### PR DESCRIPTION
…
### Issue
N/A

### Description
 Syseng confirmed that eth port status would be in `PORT_UNKNOWN` while training so update check for eth training to wait for eth to move out of this state. 

### List of the changes
- Update timeout for eth to finish training to be 60s 
- Wait for eths to move out of `PORT_UNKNOWN`

### Testing
Testing this on `abhullar/bh-p150` in Metal on bh-32