### PR TITLE
Rename P150A to P150

### DIFF
--- a/device/api/umd/device/types/cluster_descriptor_types.h
+++ b/device/api/umd/device/types/cluster_descriptor_types.h
@@ -45,7 +45,7 @@ enum BoardType : uint32_t {
     N150,
     N300,
     P100,
-    P150A,
+    P150,
     P300,
     GALAXY,
     UNKNOWN,
@@ -60,7 +60,7 @@ inline BoardType get_board_type_from_board_id(const uint64_t board_id) {
     } else if (upi == 0x43) {
         return BoardType::P100;
     } else if (upi == 0x40 || upi == 0x41) {
-        return BoardType::P150A;
+        return BoardType::P150;
     }
 
     throw std::runtime_error(fmt::format("No existing board type for board id {}", board_id));

--- a/device/blackhole/blackhole_implementation.cpp
+++ b/device/blackhole/blackhole_implementation.cpp
@@ -115,7 +115,7 @@ std::vector<tt_xy_pair> get_pcie_cores(const BoardType board_type, const bool is
 
     if (board_type == BoardType::UNKNOWN || board_type == BoardType::P100) {
         return PCIE_CORES_TYPE1;
-    } else if (board_type == BoardType::P150A) {
+    } else if (board_type == BoardType::P150) {
         return PCIE_CORES_TYPE2;
     } else if (board_type == BoardType::P300) {
         return is_chip_remote ? PCIE_CORES_TYPE1 : PCIE_CORES_TYPE2;

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -752,7 +752,7 @@ void tt_ClusterDescriptor::load_chips_from_connectivity_descriptor(YAML::Node &y
                 board_type = BoardType::N300;
             } else if (chip_board_type.second == "p100") {
                 board_type = BoardType::P100;
-            } else if (chip_board_type.second == "p150A") {
+            } else if (chip_board_type.second == "p150A" || chip_board_type.second == "p150") {
                 board_type = BoardType::P150;
             } else if (chip_board_type.second == "p300") {
                 board_type = BoardType::P300;

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -454,7 +454,7 @@ std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_mock_cluster(
             board_type = BoardType::N150;
             break;
         case tt::ARCH::BLACKHOLE:
-            board_type = BoardType::P150A;
+            board_type = BoardType::P150;
             break;
         default:
             board_type = BoardType::UNKNOWN;
@@ -753,7 +753,7 @@ void tt_ClusterDescriptor::load_chips_from_connectivity_descriptor(YAML::Node &y
             } else if (chip_board_type.second == "p100") {
                 board_type = BoardType::P100;
             } else if (chip_board_type.second == "p150A") {
-                board_type = BoardType::P150A;
+                board_type = BoardType::P150;
             } else if (chip_board_type.second == "p300") {
                 board_type = BoardType::P300;
             } else if (chip_board_type.second == "GALAXY") {

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -291,7 +291,7 @@ std::string tt_SocDescriptor::get_soc_descriptor_path(
             if (board_type == BoardType::P100 || board_type == BoardType::UNKNOWN) {
                 // TODO: this path needs to be changed to point to soc descriptors outside of tests directory.
                 return tt::umd::utils::get_abs_path("tests/soc_descs/blackhole_140_arch_no_eth.yaml");
-            } else if (board_type == BoardType::P150A) {
+            } else if (board_type == BoardType::P150) {
                 // TODO: this path needs to be changed to point to soc descriptors outside of tests directory.
                 return tt::umd::utils::get_abs_path("tests/soc_descs/blackhole_140_arch_type2.yaml");
             } else if (board_type == BoardType::P300) {

--- a/tests/blackhole/test_chip_info_bh.cpp
+++ b/tests/blackhole/test_chip_info_bh.cpp
@@ -14,7 +14,7 @@ TEST(BlackholeChipInfo, BasicChipInfo) {
 
         const ChipInfo chip_info = tt_device->get_chip_info();
 
-        EXPECT_TRUE(chip_info.board_type == BoardType::P100 || chip_info.board_type == BoardType::P150A);
+        EXPECT_TRUE(chip_info.board_type == BoardType::P100 || chip_info.board_type == BoardType::P150);
 
         EXPECT_TRUE(chip_info.chip_uid.asic_location == 0 || chip_info.chip_uid.asic_location == 1);
     }


### PR DESCRIPTION
### Issue

/

### Description

Rename P150A board type to P150. Board type naming should not be dependent on type of cooling or other stuff.

### List of the changes

- Rename P150A to P150

### Testing

CI

### API Changes

Metal uses P150A, will change it 

- [ ] tt-metal PR - ?