### PR TITLE
Wait for Blackhole DRAM training

### DIFF
--- a/device/api/umd/device/tt_device/blackhole_tt_device.h
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.h
@@ -32,7 +32,10 @@ public:
     BoardType get_board_type() override;
 
     void dma_d2h(void *dst, uint32_t src, size_t size) override;
+
     void dma_h2d(uint32_t dst, const void *src, size_t size) override;
+
+    std::vector<DramTrainingStatus> get_dram_training_status() override;
 
 private:
     static constexpr uint64_t ATU_OFFSET_IN_BH_BAR2 = 0x1200;

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -428,10 +428,6 @@ std::unique_lock<RobustMutex> LocalChip::acquire_mutex(MutexType mutex_type, int
 }
 
 void LocalChip::wait_dram_cores_training(const uint32_t timeout_ms) {
-    if (get_tt_device()->get_arch() == tt::ARCH::BLACKHOLE) {
-        return;
-    }
-
     TTDevice* tt_device = get_tt_device();
 
     auto start = std::chrono::system_clock::now();

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -90,6 +90,7 @@ ChipInfo BlackholeTTDevice::get_chip_info() {
     chip_info.harvesting_masks.dram_harvesting_mask = telemetry->is_entry_available(blackhole::TAG_ENABLED_GDDR)
                                                           ? (~telemetry->read_entry(blackhole::TAG_ENABLED_GDDR) & 0xFF)
                                                           : 0;
+
     chip_info.harvesting_masks.eth_harvesting_mask = telemetry->is_entry_available(blackhole::TAG_ENABLED_ETH)
                                                          ? (~telemetry->read_entry(blackhole::TAG_ENABLED_ETH) & 0x3FFF)
                                                          : 0;
@@ -201,12 +202,12 @@ std::vector<DramTrainingStatus> BlackholeTTDevice::get_dram_training_status() {
     // errors. If some channel is harvested the bits are always going to be zero.
     for (uint32_t dram_channel = 0; dram_channel < num_dram_channels; dram_channel++) {
         if (telemetry_data & (1 << (2 * dram_channel))) {
-            dram_training_status.push_back(DramTrainingStatus::FAIL);
+            dram_training_status.push_back(DramTrainingStatus::SUCCESS);
             continue;
         }
 
         if (telemetry_data & (1 << (2 * dram_channel + 1))) {
-            dram_training_status.push_back(DramTrainingStatus::SUCCESS);
+            dram_training_status.push_back(DramTrainingStatus::FAIL);
             continue;
         }
 

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -185,4 +185,35 @@ void BlackholeTTDevice::dma_h2d(uint32_t dst, const void *src, size_t size) {
     throw std::runtime_error("H2D DMA is not supported on Blackhole.");
 }
 
+std::vector<DramTrainingStatus> BlackholeTTDevice::get_dram_training_status() {
+    if (!telemetry->is_entry_available(tt::umd::blackhole::TAG_DDR_STATUS)) {
+        return {};
+    }
+
+    uint32_t telemetry_data = telemetry->read_entry(tt::umd::blackhole::TAG_DDR_STATUS);
+    std::vector<DramTrainingStatus> dram_training_status;
+    const uint32_t num_dram_channels = blackhole::NUM_DRAM_BANKS;
+    // Format of the dram training status is as follows:
+    // Each channel gets two bits in the 32-bit value (16 bits used). The lower bits are for lower channels.
+    // Lower of the two bits is for training error and higher of the two bits is for training status.
+    // Example: 0b 00 00 00 00 00 00 01 10
+    // would mean that only channel 0 is trained, channel 1 has the error and other are not trained and don't have
+    // errors. If some channel is harvested the bits are always going to be zero.
+    for (uint32_t dram_channel = 0; dram_channel < num_dram_channels; dram_channel++) {
+        if (telemetry_data & (1 << (2 * dram_channel))) {
+            dram_training_status.push_back(DramTrainingStatus::FAIL);
+            continue;
+        }
+
+        if (telemetry_data & (1 << (2 * dram_channel + 1))) {
+            dram_training_status.push_back(DramTrainingStatus::SUCCESS);
+            continue;
+        }
+
+        dram_training_status.push_back(DramTrainingStatus::IN_PROGRESS);
+    }
+
+    return dram_training_status;
+}
+
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue

#478 

Note: the PR is probably going to timeout on Blackhole CI until the fw from the syseng is released, so reviewers can do the review without me checking this in, to be ready when the fw is released.

### Description

Implement waiting for DRAM training on Blackhole. Format of the data provided by syseng to sw is described in https://tenstorrent.atlassian.net/browse/SYS-1241. This PR integrates the wait in our code according to the proposed ticket design.

### List of the changes

- Add function to wait for DRAM cores
- Implement the proposed design from the ticket
- Add functions to TTDevice that expose DRAM training info

### Testing
CI

### API Changes
/