### PR TITLE
Fix UMD unit tests on 80.15 fw bundle

### DIFF
--- a/device/api/umd/device/types/blackhole_telemetry.h
+++ b/device/api/umd/device/types/blackhole_telemetry.h
@@ -10,7 +10,10 @@ namespace tt::umd {
 
 namespace blackhole {
 
-constexpr uint8_t NUMBER_TELEMETRY_TAGS = 38;
+// TODO: this is resized to push the release of the 80.15 firmware version.
+// Rewrite the Blackhole telemetry class to support any tag or if the spec for Blackhole
+// becomes fixed just set this number to the proper size.
+constexpr uint8_t NUMBER_TELEMETRY_TAGS = 64;
 
 constexpr uint8_t TAG_BOARD_ID_HIGH = 1;
 constexpr uint8_t TAG_BOARD_ID_LOW = 2;


### PR DESCRIPTION
### Issue

UMD unit tests were failing on new firmware release 80.15.

### Description

Resize the telemetry table tag array to fit all the new tags in the firmware. The new tags are out of the original spec so resizing to 64 in order to have room for some additional if needed. Follow up issue to size this properly or just support any tag value is #544 

### List of the changes

- Resize the telemetry tag table

### Testing

Flashed the new fw and ran CI

### API Changes
/
