### PR TITLE
Fixing BlackholeArcTelemetryReader to use noc1 coordinate when umd_use_noc1 is specified

### DIFF
--- a/device/api/umd/device/blackhole_arc_telemetry_reader.h
+++ b/device/api/umd/device/blackhole_arc_telemetry_reader.h
@@ -50,7 +50,7 @@ private:
     bool telemetry_entry_available[NUMBER_TELEMETRY_TAGS];
     uint32_t telemetry_offset[NUMBER_TELEMETRY_TAGS];
 
-    const tt_xy_pair arc_core = !umd_use_noc1 ? tt::umd::blackhole::ARC_CORES[0] : tt_xy_pair(8,11);
+    const tt_xy_pair arc_core = !umd_use_noc1 ? tt::umd::blackhole::ARC_CORES[0] : tt_xy_pair(8, 11);
 };
 
 }  // namespace blackhole

--- a/device/api/umd/device/blackhole_arc_telemetry_reader.h
+++ b/device/api/umd/device/blackhole_arc_telemetry_reader.h
@@ -10,6 +10,8 @@
 #include "umd/device/tt_device/tt_device.h"
 #include "umd/device/types/blackhole_telemetry.h"
 
+extern bool umd_use_noc1;
+
 namespace tt::umd {
 
 namespace blackhole {
@@ -48,7 +50,7 @@ private:
     bool telemetry_entry_available[NUMBER_TELEMETRY_TAGS];
     uint32_t telemetry_offset[NUMBER_TELEMETRY_TAGS];
 
-    const tt_xy_pair arc_core = tt::umd::blackhole::ARC_CORES[0];
+    const tt_xy_pair arc_core = !umd_use_noc1 ? tt::umd::blackhole::ARC_CORES[0] : tt_xy_pair(8,11);
 };
 
 }  // namespace blackhole

--- a/device/api/umd/device/blackhole_arc_telemetry_reader.h
+++ b/device/api/umd/device/blackhole_arc_telemetry_reader.h
@@ -50,7 +50,8 @@ private:
     bool telemetry_entry_available[NUMBER_TELEMETRY_TAGS];
     uint32_t telemetry_offset[NUMBER_TELEMETRY_TAGS];
 
-    const tt_xy_pair arc_core = !umd_use_noc1 ? tt::umd::blackhole::ARC_CORES[0] : tt_xy_pair(8, 11);
+    const tt_xy_pair arc_core =
+        !umd_use_noc1 ? tt::umd::blackhole::ARC_CORES[0] : tt_xy_pair(8, 11);  // ARC coordinates in NOC1 are 8-11
 };
 
 }  // namespace blackhole


### PR DESCRIPTION
With this change, starting `tt-lens` with noc1 should work even after noc0 is corrupted.