### PR TITLE
Implement recognizing Blackhole p150c board type

### DIFF
--- a/device/api/umd/device/types/cluster_descriptor_types.h
+++ b/device/api/umd/device/types/cluster_descriptor_types.h
@@ -120,7 +120,7 @@ inline BoardType get_board_type_from_board_id(const uint64_t board_id) {
         return BoardType::P100;
     } else if (upi == 0x43) {
         return BoardType::P100;
-    } else if (upi == 0x40 || upi == 0x41) {
+    } else if (upi == 0x40 || upi == 0x41 || upi == 0x42) {
         return BoardType::P150;
     }
 

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -752,7 +752,9 @@ void tt_ClusterDescriptor::load_chips_from_connectivity_descriptor(YAML::Node &y
                 board_type = BoardType::N300;
             } else if (chip_board_type.second == "p100") {
                 board_type = BoardType::P100;
-            } else if (chip_board_type.second == "p150A" || chip_board_type.second == "p150") {
+            } else if (
+                chip_board_type.second == "p150" || chip_board_type.second == "p150A" ||
+                chip_board_type.second == "p150C") {
                 board_type = BoardType::P150;
             } else if (chip_board_type.second == "p300") {
                 board_type = BoardType::P300;


### PR DESCRIPTION
### Issue

Add p150c to be recognizable as board type from upi. Not sure if we have p150c for testing but to be ready if UMD is tested on p150c board.

### Description

Implement recognizing Blackhole p150c board type

### List of the changes

- Add upi for p150c 
- Add recognizing p150c from cluster descriptor

### Testing

CI

### API Changes
/
