### PR TITLE
Integrate ArcMessenger into Cluster code path

### DIFF
--- a/device/api/umd/device/arc_messenger.h
+++ b/device/api/umd/device/arc_messenger.h
@@ -5,9 +5,13 @@
  */
 #pragma once
 
-#include "umd/device/tt_device/tt_device.h"
+#include <cstdint>
+#include <memory>
+#include <vector>
 
 namespace tt::umd {
+
+class TTDevice;
 
 class ArcMessenger {
 public:

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "umd/device/arc_messenger.h"
 #include "umd/device/architecture_implementation.h"
 #include "umd/device/pci_device.hpp"
 #include "umd/device/tt_device/tlb_manager.h"
@@ -31,6 +32,7 @@ struct dynamic_tlb {
 namespace tt::umd {
 
 class TLBManager;
+class ArcMessenger;
 
 class TTDevice {
 public:
@@ -135,11 +137,14 @@ public:
 
     uint32_t bar_read32(uint32_t addr);
 
+    ArcMessenger *get_arc_messenger() const;
+
 protected:
     std::unique_ptr<PCIDevice> pci_device_;
     std::unique_ptr<architecture_implementation> architecture_impl_;
     std::unique_ptr<TLBManager> tlb_manager_;
     tt::ARCH arch;
+    std::unique_ptr<ArcMessenger> arc_messenger_;
 
     bool is_hardware_hung();
 

--- a/device/arc_messenger.cpp
+++ b/device/arc_messenger.cpp
@@ -6,6 +6,7 @@
 #include "umd/device/arc_messenger.h"
 
 #include "umd/device/blackhole_arc_messenger.h"
+#include "umd/device/tt_device/tt_device.h"
 #include "umd/device/wormhole_arc_messenger.h"
 
 namespace tt::umd {

--- a/device/blackhole/blackhole_arc_messenger.cpp
+++ b/device/blackhole/blackhole_arc_messenger.cpp
@@ -5,6 +5,8 @@
  */
 #include "umd/device/blackhole_arc_messenger.h"
 
+#include "umd/device/tt_device/tt_device.h"
+
 namespace tt::umd {
 
 BlackholeArcMessenger::BlackholeArcMessenger(TTDevice* tt_device) : ArcMessenger(tt_device) {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1210,70 +1210,28 @@ int Cluster::pcie_arc_msg(
     int timeout,
     uint32_t* return_3,
     uint32_t* return_4) {
-    if ((msg_code & 0xff00) != 0xaa00) {
-        log_error("Malformed message. msg_code is 0x{:x} but should be 0xaa..", msg_code);
-    }
-    log_assert(arg0 <= 0xffff and arg1 <= 0xffff, "Only 16 bits allowed in arc_msg args");  // Only 16 bits are allowed
+    std::vector<uint32_t> arc_msg_return_values;
 
-    TTDevice* tt_device = get_tt_device(logical_device_id);
-    auto architecture_implementation = tt_device->get_architecture_implementation();
-
-    // Exclusive access for a single process at a time. Based on physical pci interface id.
-    std::string msg_type = "ARC_MSG";
-    const scoped_lock<named_mutex> lock(*get_mutex(msg_type, logical_device_id));
-    uint32_t fw_arg = arg0 | (arg1 << 16);
-    int exit_code = 0;
-
-    bar_write32(logical_device_id, architecture_implementation->get_arc_reset_scratch_offset() + 3 * 4, fw_arg);
-    bar_write32(logical_device_id, architecture_implementation->get_arc_reset_scratch_offset() + 5 * 4, msg_code);
-
-    uint32_t misc = bar_read32(logical_device_id, architecture_implementation->get_arc_reset_arc_misc_cntl_offset());
-    if (misc & (1 << 16)) {
-        log_error("trigger_fw_int failed on device {}", logical_device_id);
-        return 1;
-    } else {
-        bar_write32(
-            logical_device_id, architecture_implementation->get_arc_reset_arc_misc_cntl_offset(), misc | (1 << 16));
+    if (return_3 != nullptr) {
+        arc_msg_return_values.push_back(0);
     }
 
-    if (wait_for_done) {
-        uint32_t status = 0xbadbad;
-        auto timeout_seconds = std::chrono::seconds(timeout);
-        auto start = std::chrono::system_clock::now();
-        while (true) {
-            if (std::chrono::system_clock::now() - start > timeout_seconds) {
-                throw std::runtime_error(fmt::format(
-                    "Timed out after waiting {} seconds for device {} ARC to respond", timeout, logical_device_id));
-            }
-
-            status = bar_read32(logical_device_id, architecture_implementation->get_arc_reset_scratch_offset() + 5 * 4);
-
-            if ((status & 0xffff) == (msg_code & 0xff)) {
-                if (return_3 != nullptr) {
-                    *return_3 = bar_read32(
-                        logical_device_id, architecture_implementation->get_arc_reset_scratch_offset() + 3 * 4);
-                }
-
-                if (return_4 != nullptr) {
-                    *return_4 = bar_read32(
-                        logical_device_id, architecture_implementation->get_arc_reset_scratch_offset() + 4 * 4);
-                }
-
-                exit_code = (status & 0xffff0000) >> 16;
-                break;
-            } else if (status == MSG_ERROR_REPLY) {
-                log_warning(
-                    LogSiliconDriver,
-                    "On device {}, message code 0x{:x} not recognized by FW",
-                    logical_device_id,
-                    msg_code);
-                exit_code = MSG_ERROR_REPLY;
-                break;
-            }
-        }
+    if (return_4 != nullptr) {
+        arc_msg_return_values.push_back(0);
     }
 
-    tt_device->detect_hang_read();
+    uint32_t exit_code = get_tt_device(logical_device_id)
+                             ->get_arc_messenger()
+                             ->send_message(msg_code, arc_msg_return_values, arg0, arg1, timeout);
+
+    if (return_3 != nullptr) {
+        *return_3 = arc_msg_return_values[0];
+    }
+
+    if (return_4 != nullptr) {
+        *return_4 = arc_msg_return_values[1];
+    }
+
     return exit_code;
 }
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -4,6 +4,7 @@
 #include "umd/device/tt_device/tt_device.h"
 
 #include "logger.hpp"
+#include "umd/device/arc_messenger.h"
 #include "umd/device/driver_atomics.h"
 #include "umd/device/tt_device/blackhole_tt_device.h"
 #include "umd/device/tt_device/grayskull_tt_device.h"
@@ -21,7 +22,8 @@ TTDevice::TTDevice(
     pci_device_(std::move(pci_device)),
     architecture_impl_(std::move(architecture_impl)),
     tlb_manager_(std::make_unique<TLBManager>(this)),
-    arch(architecture_impl_->get_architecture()) {}
+    arch(architecture_impl_->get_architecture()),
+    arc_messenger_(ArcMessenger::create_arc_messenger(this)) {}
 
 /* static */ std::unique_ptr<TTDevice> TTDevice::create(int pci_device_number) {
     auto pci_device = std::make_unique<PCIDevice>(pci_device_number);
@@ -368,5 +370,7 @@ uint32_t TTDevice::bar_read32(uint32_t addr) {
     }
     return data;
 }
+
+tt::umd::ArcMessenger *TTDevice::get_arc_messenger() const { return arc_messenger_.get(); }
 
 }  // namespace tt::umd

--- a/device/wormhole/wormhole_arc_messenger.cpp
+++ b/device/wormhole/wormhole_arc_messenger.cpp
@@ -5,9 +5,8 @@
  */
 #include "umd/device/wormhole_arc_messenger.h"
 
-#include <iostream>
-
 #include "logger.hpp"
+#include "umd/device/tt_device/tt_device.h"
 #include "umd/device/wormhole_implementation.h"
 
 namespace tt::umd {


### PR DESCRIPTION
### Issue

#549 

### Description

Integrate ARC messenger class introduced by #548 to Cluster code path

### List of the changes

- Add ArcMessenger to TTDevice class
- Call ArcMessenger from TTDevice each time PCIe arc message is needed

### Testing
CI

### API Changes
/