### PR TITLE
Implement TTDevice get clock

### DIFF
--- a/device/api/umd/device/tt_device/blackhole_tt_device.h
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.h
@@ -23,7 +23,7 @@ public:
 
     void wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms = 1000) override;
 
-    uint32_t get_clock();
+    uint32_t get_clock() override;
 
 private:
     static constexpr uint64_t ATU_OFFSET_IN_BH_BAR2 = 0x1200;

--- a/device/api/umd/device/tt_device/blackhole_tt_device.h
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.h
@@ -23,6 +23,8 @@ public:
 
     void wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms = 1000) override;
 
+    uint32_t get_clock();
+
 private:
     static constexpr uint64_t ATU_OFFSET_IN_BH_BAR2 = 0x1200;
     std::set<size_t> iatu_regions_;

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -139,6 +139,8 @@ public:
 
     ArcMessenger *get_arc_messenger() const;
 
+    virtual uint32_t get_clock();
+
 protected:
     std::unique_ptr<PCIDevice> pci_device_;
     std::unique_ptr<architecture_implementation> architecture_impl_;

--- a/device/api/umd/device/tt_device/wormhole_tt_device.h
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.h
@@ -14,5 +14,7 @@ public:
     WormholeTTDevice(std::unique_ptr<PCIDevice> pci_device);
 
     ChipInfo get_chip_info() override;
+
+    uint32_t get_clock() override;
 };
 }  // namespace tt::umd

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -990,35 +990,8 @@ void Cluster::set_pcie_power_state(tt_DevicePowerState state) {
 }
 
 int Cluster::get_clock(int logical_device_id) {
-    // TODO: remove this once ARC messages work.
-    // This is currently used only for testing and bringing up Blackhole on Buda.
-    if (arch_name == tt::ARCH::BLACKHOLE) {
-        char* clk_env_var = getenv("TT_SILICON_DRIVER_AICLK");
-        if (clk_env_var != nullptr) {
-            log_warning(
-                LogSiliconDriver,
-                "ARC messages are not enabled on Blackhole. "
-                "Using AICLK value from environment variable TT_SILICON_DRIVER_AICLK: {}",
-                clk_env_var);
-            return std::stoi(clk_env_var);
-        }
-    }
-
-    uint32_t clock;
     auto mmio_capable_chip_logical = cluster_desc->get_closest_mmio_capable_chip(logical_device_id);
-    TTDevice* tt_device = get_tt_device(mmio_capable_chip_logical);
-    auto exit_code = arc_msg(
-        logical_device_id,
-        0xaa00 | tt_device->get_architecture_implementation()->get_arc_message_get_aiclk(),
-        true,
-        0xFFFF,
-        0xFFFF,
-        1,
-        &clock);
-    if (exit_code != 0) {
-        throw std::runtime_error(fmt::format("Failed to get aiclk value with exit code {}", exit_code));
-    }
-    return clock;
+    return get_tt_device(mmio_capable_chip_logical)->get_clock();
 }
 
 std::map<int, int> Cluster::get_clocks() {

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -142,4 +142,12 @@ void BlackholeTTDevice::wait_arc_core_start(const tt_xy_pair arc_core, const uin
     }
 }
 
+uint32_t BlackholeTTDevice::get_clock() {
+    if (telemetry->is_entry_available(blackhole::TAG_AICLK)) {
+        return telemetry->read_entry(blackhole::TAG_AICLK);
+    }
+
+    throw std::runtime_error("AICLK telemetry not available for Blackhole device.");
+}
+
 }  // namespace tt::umd

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -373,4 +373,10 @@ uint32_t TTDevice::bar_read32(uint32_t addr) {
 
 tt::umd::ArcMessenger *TTDevice::get_arc_messenger() const { return arc_messenger_.get(); }
 
+uint32_t TTDevice::get_clock() {
+    throw std::runtime_error(
+        "Base TTDevice class does not have get_clock implemented. Move this to abstract function once Grayskull "
+        "TTDevice is deleted.");
+}
+
 }  // namespace tt::umd

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -14,4 +14,20 @@ ChipInfo WormholeTTDevice::get_chip_info() {
     throw std::runtime_error("Reading ChipInfo is not supported for Wormhole.");
 }
 
+uint32_t WormholeTTDevice::get_clock() {
+    const uint32_t timeouts_ms = 1000;
+    // There is one return value from AICLK ARC message.
+    std::vector<uint32_t> arc_msg_return_values = {0};
+    auto exit_code = get_arc_messenger()->send_message(
+        tt::umd::wormhole::ARC_MSG_COMMON_PREFIX | get_architecture_implementation()->get_arc_message_get_aiclk(),
+        arc_msg_return_values,
+        0xFFFF,
+        0xFFFF,
+        timeouts_ms);
+    if (exit_code != 0) {
+        throw std::runtime_error(fmt::format("Failed to get AICLK value with exit code {}", exit_code));
+    }
+    return arc_msg_return_values[0];
+}
+
 }  // namespace tt::umd

--- a/tests/wormhole/test_arc_messages_wh.cpp
+++ b/tests/wormhole/test_arc_messages_wh.cpp
@@ -52,15 +52,9 @@ TEST(WormholeArcMessages, WormholeArcMessagesAICLK) {
 
         std::this_thread::sleep_for(std::chrono::milliseconds(ms_sleep));
 
-        std::vector<uint32_t> arc_msg_return_values = {0};
-        response = arc_messenger->send_message(
-            tt::umd::wormhole::ARC_MSG_COMMON_PREFIX |
-                tt_device->get_architecture_implementation()->get_arc_message_get_aiclk(),
-            arc_msg_return_values,
-            0,
-            0);
+        uint32_t aiclk = tt_device->get_clock();
 
-        EXPECT_EQ(arc_msg_return_values[0], tt::umd::wormhole::AICLK_BUSY_VAL);
+        EXPECT_EQ(aiclk, tt::umd::wormhole::AICLK_BUSY_VAL);
 
         response = arc_messenger->send_message(
             tt::umd::wormhole::ARC_MSG_COMMON_PREFIX |
@@ -70,14 +64,8 @@ TEST(WormholeArcMessages, WormholeArcMessagesAICLK) {
 
         std::this_thread::sleep_for(std::chrono::milliseconds(ms_sleep));
 
-        arc_msg_return_values = {0};
-        response = arc_messenger->send_message(
-            tt::umd::wormhole::ARC_MSG_COMMON_PREFIX |
-                tt_device->get_architecture_implementation()->get_arc_message_get_aiclk(),
-            arc_msg_return_values,
-            0,
-            0);
+        aiclk = tt_device->get_clock();
 
-        EXPECT_EQ(arc_msg_return_values[0], tt::umd::wormhole::AICLK_IDLE_VAL);
+        EXPECT_EQ(aiclk, tt::umd::wormhole::AICLK_IDLE_VAL);
     }
 }


### PR DESCRIPTION
### Issue

Expose readouts of AICLK through TTDevice. Metal uses Cluster get_clocks which should work both for Blackhole and Wormhole.

### Description

get_clocks in Cluster should work for all architectures. Hide get_clock for each device behind TTDevice. 

### List of the changes

- Implement TTDevice get_clock
- Change Cluster get_clock to call TTDevice get_clock
- Change tests to use TTDevice get_clock

### Testing
CI

### API Changes
/