### PR TITLE
Add DRAM and ETH harvesting info to cluster desc

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -1122,16 +1122,14 @@ private:
         tt_ClusterDescriptor* cluster_desc,
         bool perform_harvesting,
         std::unordered_map<chip_id_t, HarvestingMasks>& simulated_harvesting_masks);
-    // TODO: this function returns only software harvesting mask for DRAM.
-    // Combine this with silicon harvesting mask once gathering silicon harvesting mask is implemented.
     uint32_t get_dram_harvesting_mask(
         chip_id_t chip_id,
+        tt_ClusterDescriptor* cluster_desc,
         bool perform_harvesting,
         std::unordered_map<chip_id_t, HarvestingMasks>& simulated_harvesting_masks);
-    // TODO: this function returns only software harvesting mask for ETH.
-    // Combine this with silicon harvesting mask once gathering silicon harvesting mask is implemented.
     uint32_t get_eth_harvesting_mask(
         chip_id_t chip_id,
+        tt_ClusterDescriptor* cluster_desc,
         bool perform_harvesting,
         std::unordered_map<chip_id_t, HarvestingMasks>& simulated_harvesting_masks);
     void construct_cluster(

--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -78,6 +78,9 @@ protected:
 
     void fill_chips_grouped_by_closest_mmio();
 
+    std::map<chip_id_t, uint32_t> dram_harvesting_masks = {};
+    std::map<chip_id_t, uint32_t> eth_harvesting_masks = {};
+
 public:
     /*
      * Returns the pairs of channels that are connected where the first entry in the pair corresponds to the argument
@@ -134,4 +137,7 @@ public:
 
     std::set<uint32_t> get_active_eth_channels(chip_id_t chip_id);
     std::set<uint32_t> get_idle_eth_channels(chip_id_t chip_id);
+
+    uint32_t get_dram_harvesting_mask(chip_id_t chip_id) const;
+    uint32_t get_eth_harvesting_mask(chip_id_t chip_id) const;
 };

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -1017,3 +1017,21 @@ std::set<uint32_t> tt_ClusterDescriptor::get_idle_eth_channels(chip_id_t chip_id
 
     return it->second;
 }
+
+uint32_t tt_ClusterDescriptor::get_dram_harvesting_mask(chip_id_t chip_id) const {
+    auto it = dram_harvesting_masks.find(chip_id);
+    if (it == dram_harvesting_masks.end()) {
+        return 0;
+    }
+
+    return it->second;
+}
+
+uint32_t tt_ClusterDescriptor::get_eth_harvesting_mask(chip_id_t chip_id) const {
+    auto it = eth_harvesting_masks.find(chip_id);
+    if (it == eth_harvesting_masks.end()) {
+        return 0;
+    }
+
+    return it->second;
+}


### PR DESCRIPTION
### Issue

Fix 80.15 fw unit tests on P150 card.

### Description

We didn't store DRAM and ETH harvesting masks inside cluster descriptor so Chips were getting created with incorrect harvesting masks. 

### List of the changes

- Store DRAM and ETH harvesting mask into cluster desc
- Read the information while creating the chips

### Testing

CI, failing test is passing

### API Changes
/
