### PR TITLE
Showcase usage of eth connectivity api's

### DIFF
--- a/device/api/umd/device/architecture_implementation.h
+++ b/device/api/umd/device/architecture_implementation.h
@@ -50,6 +50,7 @@ public:
     virtual uint32_t get_dynamic_tlb_16m_cfg_addr() const = 0;
     virtual uint32_t get_mem_large_read_tlb() const = 0;
     virtual uint32_t get_mem_large_write_tlb() const = 0;
+    virtual uint32_t get_num_eth_channels() const = 0;
     virtual uint32_t get_static_tlb_cfg_addr() const = 0;
     virtual uint32_t get_static_tlb_size() const = 0;
     virtual uint32_t get_read_checking_offset() const = 0;

--- a/device/api/umd/device/blackhole_implementation.h
+++ b/device/api/umd/device/blackhole_implementation.h
@@ -308,6 +308,8 @@ public:
 
     uint32_t get_mem_large_write_tlb() const override { return blackhole::MEM_LARGE_WRITE_TLB; }
 
+    uint32_t get_num_eth_channels() const override { return blackhole::NUM_ETH_CHANNELS; }
+
     uint32_t get_static_tlb_cfg_addr() const override { return blackhole::STATIC_TLB_CFG_ADDR; }
 
     uint32_t get_static_tlb_size() const override { return blackhole::STATIC_TLB_SIZE; }

--- a/device/api/umd/device/grayskull_implementation.h
+++ b/device/api/umd/device/grayskull_implementation.h
@@ -272,6 +272,8 @@ public:
 
     uint32_t get_mem_large_write_tlb() const override { return grayskull::MEM_LARGE_WRITE_TLB; }
 
+    uint32_t get_num_eth_channels() const override { return 0; }
+
     uint32_t get_static_tlb_cfg_addr() const override { return grayskull::STATIC_TLB_CFG_ADDR; }
 
     uint32_t get_static_tlb_size() const override { return grayskull::STATIC_TLB_SIZE; }

--- a/device/api/umd/device/wormhole_implementation.h
+++ b/device/api/umd/device/wormhole_implementation.h
@@ -311,6 +311,8 @@ public:
 
     uint32_t get_mem_large_write_tlb() const override { return wormhole::MEM_LARGE_WRITE_TLB; }
 
+    uint32_t get_num_eth_channels() const override { return wormhole::NUM_ETH_CHANNELS; }
+
     uint32_t get_static_tlb_cfg_addr() const override { return wormhole::STATIC_TLB_CFG_ADDR; }
 
     uint32_t get_read_checking_offset() const override { return wormhole::ARC_SCRATCH_6_OFFSET; }

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -8,6 +8,8 @@
 #include <memory>
 #include <sstream>
 
+#include "api/umd/device/blackhole_implementation.h"
+#include "api/umd/device/wormhole_implementation.h"
 #include "disjoint_set.hpp"
 #include "fmt/core.h"
 #include "libs/create_ethernet_map.h"
@@ -485,9 +487,8 @@ void tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descripto
 
     // Preload idle eth channels.
     for (const auto &chip : desc.all_chips) {
-        int num_channels = desc.chip_arch.at(chip) == tt::ARCH::BLACKHOLE
-                               ? 14
-                               : (desc.chip_arch.at(chip) == tt::ARCH::WORMHOLE_B0 ? 16 : 0);
+        int num_channels =
+            tt::umd::architecture_implementation::create(desc.chip_arch.at(chip))->get_num_eth_channels();
         for (int i = 0; i < num_channels; i++) {
             desc.idle_eth_channels[chip].insert(i);
         }

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -487,7 +487,9 @@ void tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descripto
 
     // Preload idle eth channels.
     for (const auto &chip : desc.all_chips) {
-        int num_harvested_channels = CoordinateManager::get_num_harvested(desc.eth_harvesting_masks.at(chip));
+        int num_harvested_channels = desc.eth_harvesting_masks.empty()
+                                         ? 0
+                                         : CoordinateManager::get_num_harvested(desc.eth_harvesting_masks.at(chip));
         int num_channels =
             tt::umd::architecture_implementation::create(desc.chip_arch.at(chip))->get_num_eth_channels() -
             num_harvested_channels;

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -428,10 +428,10 @@ std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_from_yaml(
 
     YAML::Node yaml = YAML::LoadFile(cluster_descriptor_file_path);
     tt_ClusterDescriptor::load_chips_from_connectivity_descriptor(yaml, *desc);
+    tt_ClusterDescriptor::load_harvesting_information(yaml, *desc);
     tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descriptor(yaml, *desc);
     tt_ClusterDescriptor::merge_cluster_ids(*desc);
     tt_ClusterDescriptor::fill_galaxy_connections(*desc);
-    tt_ClusterDescriptor::load_harvesting_information(yaml, *desc);
     desc->enable_all_devices();
 
     desc->fill_chips_grouped_by_closest_mmio();
@@ -487,8 +487,10 @@ void tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descripto
 
     // Preload idle eth channels.
     for (const auto &chip : desc.all_chips) {
+        int num_harvested_channels = CoordinateManager::get_num_harvested(desc.eth_harvesting_masks.at(chip));
         int num_channels =
-            tt::umd::architecture_implementation::create(desc.chip_arch.at(chip))->get_num_eth_channels();
+            tt::umd::architecture_implementation::create(desc.chip_arch.at(chip))->get_num_eth_channels() -
+            num_harvested_channels;
         for (int i = 0; i < num_channels; i++) {
             desc.idle_eth_channels[chip].insert(i);
         }

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -183,4 +183,17 @@ TEST(ApiClusterDescriptorTest, EthernetConnectivity) {
                       << std::endl;
         }
     }
+
+    for (auto chip : cluster_desc->get_all_chips()) {
+        std::cout << "Chip " << chip << " has the following active ethernet channels: ";
+        for (auto eth_chan : cluster_desc->get_active_eth_channels(chip)) {
+            std::cout << eth_chan << " ";
+        }
+        std::cout << std::endl;
+        std::cout << " and following idle ethernet channels: ";
+        for (auto eth_chan : cluster_desc->get_idle_eth_channels(chip)) {
+            std::cout << eth_chan << " ";
+        }
+        std::cout << std::endl;
+    }
 }

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -168,7 +168,10 @@ TEST(ApiClusterDescriptorTest, EthernetConnectivity) {
 
     for (auto chip : cluster_desc->get_all_chips()) {
         // Wormhole has 16 and Blackhole has 14 ethernet channels.
-        for (int eth_chan = 0; eth_chan < 16; eth_chan++) {
+        for (int eth_chan = 0;
+             eth_chan <
+             tt::umd::architecture_implementation::create(cluster_desc->get_arch(chip))->get_num_eth_channels();
+             eth_chan++) {
             bool has_active_link = cluster_desc->ethernet_core_has_active_ethernet_link(chip, eth_chan);
             std::cout << "Chip " << chip << " channel " << eth_chan << " has active link: " << has_active_link
                       << std::endl;


### PR DESCRIPTION
### Issue
Related to #431 

### Description
Consolidating required APIs in an api code example test

### List of the changes
- Added test
- Fill active/idle eth channels from .yaml file as well.

### Testing
CI

### API Changes
There are no API changes in this PR.
