### PR TITLE
Fix tests for harvested BH

### DIFF
--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -24,7 +24,8 @@ LocalChip::LocalChip(std::string sdesc_path, std::unique_ptr<TTDevice> tt_device
         tt_SocDescriptor(
             sdesc_path,
             tt_device->get_chip_info().noc_translation_enabled,
-            tt_device->get_chip_info().harvesting_masks)),
+            tt_device->get_chip_info().harvesting_masks,
+            tt_device->get_chip_info().board_type)),
     tt_device_(std::move(tt_device)) {
     initialize_local_chip();
 }

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -114,8 +114,9 @@ ChipInfo BlackholeTTDevice::get_chip_info() {
 
     chip_info.board_type = get_board_type_from_board_id(chip_info.chip_uid.board_id);
 
+    // TODO: likely not needed anymore. Firware on P100 will give 0 for TAG_ENABLED_ETH
     if (chip_info.board_type == BoardType::P100) {
-        chip_info.harvesting_masks.eth_harvesting_mask = 0;
+        chip_info.harvesting_masks.eth_harvesting_mask = 0x3FFF;
     }
 
     return chip_info;

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -265,13 +265,7 @@ tt_SocDescriptor::tt_SocDescriptor(
 }
 
 int tt_SocDescriptor::get_num_dram_channels() const {
-    int num_channels = 0;
-    for (auto &dram_core : dram_cores) {
-        if (dram_core.size() > 0) {
-            num_channels++;
-        }
-    }
-    return num_channels;
+    return get_grid_size(CoreType::DRAM).x;
 }
 
 CoreCoord tt_SocDescriptor::get_dram_core_for_channel(

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -264,9 +264,7 @@ tt_SocDescriptor::tt_SocDescriptor(
     create_coordinate_manager(board_type, asic_location);
 }
 
-int tt_SocDescriptor::get_num_dram_channels() const {
-    return get_grid_size(CoreType::DRAM).x;
-}
+int tt_SocDescriptor::get_num_dram_channels() const { return get_grid_size(CoreType::DRAM).x; }
 
 CoreCoord tt_SocDescriptor::get_dram_core_for_channel(
     int dram_chan, int subchannel, const CoordSystem coord_system) const {

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -91,7 +91,7 @@ TEST(SiliconDriverBH, CreateDestroy) {
             num_host_mem_ch_per_mmio_device,
             false,
             true,
-            false);
+            true);
         set_barrier_params(cluster);
         cluster.start_device(default_params);
         cluster.close_device();
@@ -429,10 +429,10 @@ TEST(SiliconDriverBH, DynamicTLB_RW) {
     printf("Target Tensix cores completed\n");
 
     // Target DRAM channel 0
-    constexpr int NUM_CHANNELS = 8;
     std::vector<uint32_t> dram_vector_to_write = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
     std::uint32_t address = 0x400;
     for (int i = 0; i < target_devices.size(); i++) {
+        int NUM_CHANNELS = cluster.get_soc_descriptor(i).get_num_dram_channels();
         for (int loop = 0; loop < 100;
              loop++) {  // Write to each core a 100 times at different statically mapped addresses
             for (int ch = 0; ch < NUM_CHANNELS; ch++) {
@@ -610,7 +610,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
             for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 std::vector<uint32_t> readback_vec = {};
                 cluster.write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), 0, core, address, "");
-                cluster.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
+                cluster.l1_membar(0, {core}, "SMALL_READ_WRITE_TLB");
                 test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec1.size(), "");
                 ASSERT_EQ(readback_vec, vec1);
                 cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address, "");
@@ -625,7 +625,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
             for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 std::vector<uint32_t> readback_vec = {};
                 cluster.write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), 0, core, address, "");
-                cluster.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
+                cluster.l1_membar(0, {core}, "SMALL_READ_WRITE_TLB");
                 test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec2.size(), "");
                 ASSERT_EQ(readback_vec, vec2);
                 cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address, "");

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -86,7 +86,7 @@ TEST(SiliconDriverBH, CreateDestroy) {
     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
     for (int i = 0; i < 50; i++) {
         Cluster cluster = Cluster(
-            test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"),
+            test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"),
             target_devices,
             num_host_mem_ch_per_mmio_device,
             false,
@@ -903,7 +903,7 @@ static bool is_iommu_available() {
     const size_t num_channels = 1;
     auto target_devices = get_target_devices();
     Cluster cluster(
-        test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"),
+        test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"),
         target_devices,
         num_channels,
         false,  // skip driver allocs - no (don't skip)


### PR DESCRIPTION
### Issue
Finishes #576 

### Description
Fixed a couple of items

### List of the changes
- (Didn't lead to this specific issue) Pass board type to soc descriptor
- Hardcode eth harvesting to all harvested instead of none harvested for P100
- get_num_dram_channels took size of old structure which is unharvested, switched to new structure
- (Didn't lead to this specific issue) Switch all blackhole_140_arch_no_eth to blackhole_140_arch.yaml
- Enable harvesting in CreateDestroy test. This works for WH with false, since it uses a soc descriptor which is 1x1. If we ended up on a card which has 1st row harvested, these test would probably fail for WH
- Fix hardcoded dram num channels somewhere in the tests
- Switch l1_membar to use new umd API which uses CoreCoord api

### Testing
Manually tested on yyz-lab-125. Obviously the CI tests should still pass.

### API Changes
There are no API changes in this PR.
