### PR TITLE
Remove cluster descriptor API from public

### DIFF
--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -78,6 +78,8 @@ protected:
 
     void fill_chips_grouped_by_closest_mmio();
 
+    static std::unique_ptr<tt_ClusterDescriptor> create();
+
     std::map<chip_id_t, uint32_t> dram_harvesting_masks = {};
     std::map<chip_id_t, uint32_t> eth_harvesting_masks = {};
 
@@ -98,7 +100,6 @@ public:
     // get_cluster_descriptor_file_path will create ethernet map in the background.
     static std::string get_cluster_descriptor_file_path();
     static std::unique_ptr<tt_ClusterDescriptor> create_from_yaml(const std::string &cluster_descriptor_file_path);
-    static std::unique_ptr<tt_ClusterDescriptor> create();
     static tt::ARCH detect_arch(const chip_id_t chip_id);
 
     // This function is used to create mock cluster descriptor yaml files, for example for simulation.

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -10,11 +10,14 @@
 
 #include "disjoint_set.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
+#include "umd/device/cluster.h"
 #include "umd/device/pci_device.hpp"
 #include "umd/device/tt_cluster_descriptor.h"
 
+using namespace tt::umd;
+
 TEST(ApiClusterDescriptorTest, DetectArch) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create();
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
 
     if (cluster_desc->get_number_of_chips() == 0) {
         // Expect it to be invalid if no devices are found.
@@ -46,7 +49,7 @@ TEST(ApiClusterDescriptorTest, DetectArch) {
 }
 
 TEST(ApiClusterDescriptorTest, BasicFunctionality) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create();
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
 
     if (cluster_desc == nullptr) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -72,7 +72,7 @@ std::int32_t get_static_tlb_index(tt_xy_pair target) {
 
 std::set<chip_id_t> get_target_devices() {
     std::set<chip_id_t> target_devices;
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq = tt_ClusterDescriptor::create();
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq = Cluster::create_cluster_descriptor();
     for (int i = 0; i < cluster_desc_uniq->get_number_of_chips(); i++) {
         target_devices.insert(i);
     }
@@ -104,7 +104,7 @@ TEST(SiliconDriverBH, CreateDestroy) {
 
 //     {
 //         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
-//             tt_ClusterDescriptor::create();
+//             Cluster::create_cluster_descriptor();
 //         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
 //             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
 //             system";
@@ -136,7 +136,7 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 30}, {1, 60}};
 //     {
 //         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
-//             tt_ClusterDescriptor::create();
+//             Cluster::create_cluster_descriptor();
 //         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
 //             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
 //             system";
@@ -166,7 +166,7 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 30}, {1, 60}};
 //     {
 //         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
-//             tt_ClusterDescriptor::create();
+//             Cluster::create_cluster_descriptor();
 //         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
 //             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
 //             system";

--- a/tests/galaxy/test_umd_concurrent_threads.cpp
+++ b/tests/galaxy/test_umd_concurrent_threads.cpp
@@ -24,7 +24,7 @@ static const std::string SOC_DESC_PATH = "tests/soc_descs/wormhole_b0_8x10.yaml"
 TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
     // Galaxy Setup
 
-    std::shared_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create();
+    std::shared_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
     std::set<chip_id_t> target_devices_th1 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
     std::set<chip_id_t> target_devices_th2 = {17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32};
     std::set<chip_id_t> all_devices = {};
@@ -122,7 +122,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
 
 TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
     // Galaxy Setup
-    std::shared_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create();
+    std::shared_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
     std::set<chip_id_t> target_devices_th1 = {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32};
     std::set<chip_id_t> target_devices_th2 = {1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31};
     std::set<chip_id_t> all_devices = {};
@@ -219,7 +219,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
 
 TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
     // Galaxy Setup
-    std::shared_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create();
+    std::shared_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
     std::set<chip_id_t> target_devices = {0, 1, 2, 3, 4, 5, 6, 7, 8};
     for (const auto& chip : target_devices) {
         // Verify that selected chips are in the cluster

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -21,7 +21,7 @@ static const std::string SOC_DESC_PATH = "tests/soc_descs/wormhole_b0_8x10.yaml"
 
 void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
     // Galaxy Setup
-    std::shared_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create();
+    std::shared_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
     std::set<chip_id_t> target_devices = {};
     for (const auto& chip : cluster_desc->get_all_chips()) {
         target_devices.insert(chip);
@@ -127,7 +127,7 @@ TEST(GalaxyBasicReadWrite, LargeRemoteDramBlockReadWrite) { run_remote_read_writ
 void run_data_mover_test(
     uint32_t vector_size, tt_multichip_core_addr sender_core, tt_multichip_core_addr receiver_core) {
     // Galaxy Setup
-    std::shared_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create();
+    std::shared_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
     std::set<chip_id_t> target_devices = {};
     for (const auto& chip : cluster_desc->get_all_chips()) {
         target_devices.insert(chip);
@@ -246,7 +246,7 @@ TEST(GalaxyDataMovement, TwoChipMoveData4) {
 void run_data_broadcast_test(
     uint32_t vector_size, tt_multichip_core_addr sender_core, std::vector<tt_multichip_core_addr> receiver_cores) {
     // Galaxy Setup
-    std::shared_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create();
+    std::shared_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
     std::set<chip_id_t> target_devices = {};
     for (const auto& chip : cluster_desc->get_all_chips()) {
         target_devices.insert(chip);

--- a/tests/galaxy/test_umd_remote_api_stability.cpp
+++ b/tests/galaxy/test_umd_remote_api_stability.cpp
@@ -33,7 +33,7 @@ protected:
     static uint32_t scale_number_of_tests;
 
     static void SetUpTestSuite() {
-        std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create();
+        std::unique_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
         detected_num_chips = cluster_desc->get_number_of_chips();
         if (detected_num_chips < EXPECTED_MIN_CHIPS) {
             skip_tests = true;

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -73,7 +73,7 @@ std::int32_t get_static_tlb_index(tt_xy_pair target) {
 
 std::set<chip_id_t> get_target_devices() {
     std::set<chip_id_t> target_devices;
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq = tt_ClusterDescriptor::create();
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq = Cluster::create_cluster_descriptor();
     for (int i = 0; i < cluster_desc_uniq->get_number_of_chips(); i++) {
         target_devices.insert(i);
     }

--- a/tests/wormhole/test_umd_remote_api_stability.cpp
+++ b/tests/wormhole/test_umd_remote_api_stability.cpp
@@ -33,7 +33,7 @@ protected:
     static uint32_t scale_number_of_tests;
 
     static void SetUpTestSuite() {
-        std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create();
+        std::unique_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
         detected_num_chips = cluster_desc->get_number_of_chips();
         if (detected_num_chips != EXPECTED_NUM_CHIPS) {
             skip_tests = true;


### PR DESCRIPTION
### Issue

Cluster descriptor create API always calls create-ethernet-map. This lib does not work for BH, UBB...This API should be moved from public and all calls should go through `Cluster::create_cluster_descriptor.`

### Description

Only public accessible API for creating cluster descriptor from silicon should be `Cluster::create_cluster_descriptor`. Make all tests use this API and remove create-ethernet-map call from public API.

### List of the changes

- Move `tt_ClusterDescriptor::create()` from public
- Make tests use Cluster API

### Testing
CI

### API Changes

`tt_ClusterDescriptor::create()` is not public anymore - switch all clients to `Cluster::create_cluster_descriptor()`

- [ ]  tt_metal PR - ?