### PR TITLE
Coordinate manager ETH mapping fix

### DIFF
--- a/device/coordinate_manager.cpp
+++ b/device/coordinate_manager.cpp
@@ -317,8 +317,7 @@ void CoordinateManager::translate_router_coords() {
 
 void CoordinateManager::fill_eth_default_physical_translated_mapping() {
     for (size_t eth_channel = 0; eth_channel < num_eth_channels; eth_channel++) {
-        CoreCoord logical_coord = CoreCoord(0, eth_channel, CoreType::ETH, CoordSystem::LOGICAL);
-        const tt_xy_pair physical_pair = to_physical_map[logical_coord];
+        const tt_xy_pair physical_pair = eth_cores[eth_channel];
         const size_t translated_x = physical_pair.x;
         const size_t translated_y = physical_pair.y;
 

--- a/tests/api/test_core_coord_translation_bh.cpp
+++ b/tests/api/test_core_coord_translation_bh.cpp
@@ -687,3 +687,17 @@ TEST(CoordinateManager, CoordinateManagerBlackholeTranslationWithoutCoreType) {
         coordinate_manager->translate_coord_to({100, 100}, CoordSystem::PHYSICAL, CoordSystem::PHYSICAL),
         std::runtime_error);
 }
+
+TEST(CoordinateManager, CoordinateManagerBlackholeETHNoNocTranslationMapping) {
+    std::shared_ptr<CoordinateManager> coordinate_manager =
+        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, false);
+
+    const std::vector<tt_xy_pair> eth_pairs = tt::umd::blackhole::ETH_CORES;
+    for (const tt_xy_pair& eth_pair : eth_pairs) {
+        const CoreCoord eth_core = CoreCoord(eth_pair.x, eth_pair.y, CoreType::ETH, CoordSystem::PHYSICAL);
+        const CoreCoord eth_translated = coordinate_manager->translate_coord_to(eth_core, CoordSystem::TRANSLATED);
+
+        EXPECT_EQ(eth_translated.x, eth_pair.x);
+        EXPECT_EQ(eth_translated.y, eth_pair.y);
+    }
+}


### PR DESCRIPTION
### Issue

Metal blackhole post commit was failing because ETH cores were not properly mapped to translated when noc translation was disabled.

### Description

Map ETH cores properly 1:1 physical translated on Blackhole when noc translation is disabled.

### List of the changes

- Map ETH cores 1:1 physical-translated

### Testing

CI

### API Changes
/ 
