### PR TITLE
Implement dynamic Blackhole telemetry

### DIFF
--- a/device/api/umd/device/blackhole_arc_telemetry_reader.h
+++ b/device/api/umd/device/blackhole_arc_telemetry_reader.h
@@ -46,9 +46,8 @@ private:
     // Address of the telemetry data on ARC core.
     uint32_t telemetry_values_addr;
 
-    uint32_t telemetry_values[NUMBER_TELEMETRY_TAGS];
-    bool telemetry_entry_available[NUMBER_TELEMETRY_TAGS];
-    uint32_t telemetry_offset[NUMBER_TELEMETRY_TAGS];
+    std::map<uint32_t, uint32_t> telemetry_values;
+    std::map<uint32_t, uint32_t> telemetry_offset;
 
     const tt_xy_pair arc_core =
         !umd_use_noc1 ? tt::umd::blackhole::ARC_CORES[0] : tt_xy_pair(8, 11);  // ARC coordinates in NOC1 are 8-11

--- a/device/api/umd/device/types/blackhole_telemetry.h
+++ b/device/api/umd/device/types/blackhole_telemetry.h
@@ -10,11 +10,6 @@ namespace tt::umd {
 
 namespace blackhole {
 
-// TODO: this is resized to push the release of the 80.15 firmware version.
-// Rewrite the Blackhole telemetry class to support any tag or if the spec for Blackhole
-// becomes fixed just set this number to the proper size.
-constexpr uint8_t NUMBER_TELEMETRY_TAGS = 64;
-
 constexpr uint8_t TAG_BOARD_ID_HIGH = 1;
 constexpr uint8_t TAG_BOARD_ID_LOW = 2;
 constexpr uint8_t TAG_ASIC_ID = 3;


### PR DESCRIPTION
### Issue

#544 

### Description

Array of Blackhole tags has been statically allocated so far. Since Blackhole telemetry will change further and expand number of tags, implement telemetry to support any tag that is read from the ARC core. This should prevent bugs that we had during 80.15 fw release.

### List of the changes

- Remove limit on number of tags
- Change arrays to maps for telemetry values and offsets

### Testing

CI (every BH test goes through the telemetry)

### API Changes
/