### PR TITLE
Add support for P300 board type

### DIFF
--- a/device/api/umd/device/types/cluster_descriptor_types.h
+++ b/device/api/umd/device/types/cluster_descriptor_types.h
@@ -122,6 +122,8 @@ inline BoardType get_board_type_from_board_id(const uint64_t board_id) {
         return BoardType::P100;
     } else if (upi == 0x40 || upi == 0x41 || upi == 0x42) {
         return BoardType::P150;
+    } else if (upi == 0x44 || upi == 0x45 || upi == 0x46) {
+        return BoardType::P300;
     }
 
     throw std::runtime_error(fmt::format("No existing board type for board id {}", board_id));

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -776,7 +776,9 @@ void tt_ClusterDescriptor::load_chips_from_connectivity_descriptor(YAML::Node &y
                 chip_board_type.second == "p150" || chip_board_type.second == "p150A" ||
                 chip_board_type.second == "p150C") {
                 board_type = BoardType::P150;
-            } else if (chip_board_type.second == "p300") {
+            } else if (
+                chip_board_type.second == "p300" || chip_board_type.second == "p300A" ||
+                chip_board_type.second == "p300C") {
                 board_type = BoardType::P300;
             } else if (chip_board_type.second == "GALAXY") {
                 board_type = BoardType::GALAXY;


### PR DESCRIPTION
### Issue

Add support for recognizing P300 board type.

### Description

Add recognizing P300 board type from board upi.

### List of the changes

- Add recognizing P300 board type from upi
- Add recognizing P300 from cluster descriptor yaml

### Testing

CI. This is to enable testing on P300 silicon

### API Changes
/
