### PR TITLE
Implement TTDevice get_board_type

### DIFF
--- a/device/api/umd/device/tt_device/blackhole_tt_device.h
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.h
@@ -25,6 +25,8 @@ public:
 
     uint32_t get_clock() override;
 
+    BoardType get_board_type() override;
+
 private:
     static constexpr uint64_t ATU_OFFSET_IN_BH_BAR2 = 0x1200;
     std::set<size_t> iatu_regions_;

--- a/device/api/umd/device/tt_device/grayskull_tt_device.h
+++ b/device/api/umd/device/tt_device/grayskull_tt_device.h
@@ -14,5 +14,7 @@ public:
     GrayskullTTDevice(std::unique_ptr<PCIDevice> pci_device);
 
     ChipInfo get_chip_info() override;
+
+    BoardType get_board_type() override;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -141,6 +141,8 @@ public:
 
     virtual uint32_t get_clock();
 
+    virtual BoardType get_board_type();
+
 protected:
     std::unique_ptr<PCIDevice> pci_device_;
     std::unique_ptr<architecture_implementation> architecture_impl_;

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -141,7 +141,7 @@ public:
 
     virtual uint32_t get_clock();
 
-    virtual BoardType get_board_type();
+    virtual BoardType get_board_type() = 0;
 
 protected:
     std::unique_ptr<PCIDevice> pci_device_;

--- a/device/api/umd/device/tt_device/wormhole_tt_device.h
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.h
@@ -16,5 +16,7 @@ public:
     ChipInfo get_chip_info() override;
 
     uint32_t get_clock() override;
+
+    BoardType get_board_type() override;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/types/cluster_descriptor_types.h
+++ b/device/api/umd/device/types/cluster_descriptor_types.h
@@ -112,7 +112,6 @@ inline BlackholeChipType get_blackhole_chip_type(const BoardType board_type, con
     }
 }
 
-// TODO: add Wormhole and Grayskull board types to this function
 inline BoardType get_board_type_from_board_id(const uint64_t board_id) {
     uint64_t upi = (board_id >> 36) & 0xFFFFF;
 

--- a/device/api/umd/device/types/cluster_descriptor_types.h
+++ b/device/api/umd/device/types/cluster_descriptor_types.h
@@ -124,6 +124,12 @@ inline BoardType get_board_type_from_board_id(const uint64_t board_id) {
         return BoardType::P150;
     } else if (upi == 0x44 || upi == 0x45 || upi == 0x46) {
         return BoardType::P300;
+    } else if (upi == 0x14) {
+        return BoardType::N300;
+    } else if (upi == 0x18) {
+        return BoardType::N150;
+    } else if (upi == 0xB) {
+        return BoardType::GALAXY;
     }
 
     throw std::runtime_error(fmt::format("No existing board type for board id {}", board_id));

--- a/device/api/umd/device/wormhole_implementation.h
+++ b/device/api/umd/device/wormhole_implementation.h
@@ -90,6 +90,7 @@ static constexpr auto TLB_16M_OFFSET = tlb_offsets{
 
 enum class arc_message_type {
     NOP = 0x11,  // Do nothing
+    GET_SMBUS_TELEMETRY_ADDR = 0x2C,
     GET_AICLK = 0x34,
     ARC_GO_BUSY = 0x52,
     ARC_GO_SHORT_IDLE = 0x53,

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -150,4 +150,10 @@ uint32_t BlackholeTTDevice::get_clock() {
     throw std::runtime_error("AICLK telemetry not available for Blackhole device.");
 }
 
+BoardType BlackholeTTDevice::get_board_type() {
+    return get_board_type_from_board_id(
+        ((uint64_t)telemetry->read_entry(blackhole::TAG_BOARD_ID_HIGH) << 32) |
+        (telemetry->read_entry(blackhole::TAG_BOARD_ID_LOW)));
+}
+
 }  // namespace tt::umd

--- a/device/tt_device/grayskull_tt_device.cpp
+++ b/device/tt_device/grayskull_tt_device.cpp
@@ -14,4 +14,10 @@ ChipInfo GrayskullTTDevice::get_chip_info() {
     throw std::runtime_error("Reading ChipInfo is not supported for Grayskull.");
 }
 
+BoardType GrayskullTTDevice::get_board_type() {
+    throw std::runtime_error(
+        "Base TTDevice class does not have get_board_type implemented. Move this to abstract function once Grayskull "
+        "TTDevice is deleted.");
+}
+
 }  // namespace tt::umd

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -379,10 +379,4 @@ uint32_t TTDevice::get_clock() {
         "TTDevice is deleted.");
 }
 
-BoardType TTDevice::get_board_type() {
-    throw std::runtime_error(
-        "Base TTDevice class does not have get_board_type implemented. Move this to abstract function once Grayskull "
-        "TTDevice is deleted.");
-}
-
 }  // namespace tt::umd

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -379,4 +379,10 @@ uint32_t TTDevice::get_clock() {
         "TTDevice is deleted.");
 }
 
+BoardType TTDevice::get_board_type() {
+    throw std::runtime_error(
+        "Base TTDevice class does not have get_board_type implemented. Move this to abstract function once Grayskull "
+        "TTDevice is deleted.");
+}
+
 }  // namespace tt::umd

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -34,7 +34,12 @@ BoardType WormholeTTDevice::get_board_type() {
     ::std::vector<uint32_t> arc_msg_return_values = {0};
     static const uint32_t timeout_ms = 1000;
     uint32_t exit_code = get_arc_messenger()->send_message(
-        tt::umd::wormhole::ARC_MSG_COMMON_PREFIX | 0x2C, arc_msg_return_values, 0, 0, timeout_ms);
+        tt::umd::wormhole::ARC_MSG_COMMON_PREFIX |
+            (uint32_t)tt::umd::wormhole::arc_message_type::GET_SMBUS_TELEMETRY_ADDR,
+        arc_msg_return_values,
+        0,
+        0,
+        timeout_ms);
 
     static constexpr uint64_t noc_telemetry_offset = 0x810000000;
     uint64_t telemetry_struct_offset = arc_msg_return_values[0] + noc_telemetry_offset;
@@ -42,8 +47,10 @@ BoardType WormholeTTDevice::get_board_type() {
     uint32_t board_id_lo;
     uint32_t board_id_hi;
     tt_xy_pair arc_core = tt::umd::wormhole::ARC_CORES[0];
-    read_from_device(&board_id_hi, arc_core, telemetry_struct_offset + 16, sizeof(uint32_t));
-    read_from_device(&board_id_lo, arc_core, telemetry_struct_offset + 20, sizeof(uint32_t));
+    static uint64_t board_id_hi_telemetry_offset = 16;
+    static uint64_t board_id_lo_telemetry_offset = 20;
+    read_from_device(&board_id_hi, arc_core, telemetry_struct_offset + board_id_hi_telemetry_offset, sizeof(uint32_t));
+    read_from_device(&board_id_lo, arc_core, telemetry_struct_offset + board_id_lo_telemetry_offset, sizeof(uint32_t));
 
     return get_board_type_from_board_id(((uint64_t)board_id_hi << 32) | board_id_lo);
 }

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -30,4 +30,22 @@ uint32_t WormholeTTDevice::get_clock() {
     return arc_msg_return_values[0];
 }
 
+BoardType WormholeTTDevice::get_board_type() {
+    ::std::vector<uint32_t> arc_msg_return_values = {0};
+    static const uint32_t timeout_ms = 1000;
+    uint32_t exit_code = get_arc_messenger()->send_message(
+        tt::umd::wormhole::ARC_MSG_COMMON_PREFIX | 0x2C, arc_msg_return_values, 0, 0, timeout_ms);
+
+    static constexpr uint64_t noc_telemetry_offset = 0x810000000;
+    uint64_t telemetry_struct_offset = arc_msg_return_values[0] + noc_telemetry_offset;
+
+    uint32_t board_id_lo;
+    uint32_t board_id_hi;
+    tt_xy_pair arc_core = tt::umd::wormhole::ARC_CORES[0];
+    read_from_device(&board_id_hi, arc_core, telemetry_struct_offset + 16, sizeof(uint32_t));
+    read_from_device(&board_id_lo, arc_core, telemetry_struct_offset + 20, sizeof(uint32_t));
+
+    return get_board_type_from_board_id(((uint64_t)board_id_hi << 32) | board_id_lo);
+}
+
 }  // namespace tt::umd

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -23,7 +23,7 @@ tt_xy_pair get_any_tensix_core(tt::ARCH arch) {
     }
 }
 
-TEST(TTDeviceTest, BasicTTDeviceIO) {
+TEST(ApiTTDeviceTest, BasicTTDeviceIO) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     uint64_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
@@ -42,5 +42,18 @@ TEST(TTDeviceTest, BasicTTDeviceIO) {
         ASSERT_EQ(data_write, data_read);
 
         data_read = std::vector<uint32_t>(data_write.size(), 0);
+    }
+}
+
+TEST(ApiTTDeviceTest, TTDeviceGetBoardType) {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+    for (int pci_device_id : pci_device_ids) {
+        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+
+        BoardType board_type = tt_device->get_board_type();
+
+        EXPECT_TRUE(
+            board_type == BoardType::N150 || board_type == BoardType::N300 || board_type == BoardType::P100 ||
+            board_type == BoardType::P150 || board_type == BoardType::P300 || board_type == BoardType::GALAXY);
     }
 }


### PR DESCRIPTION
### Issue

Add getting board type from TTDevice object. This will become more important when we fully want to implement create-ethernet-map from scratch. I find it useful during my UBB work so wanted to put it out as separate PR.

### Description

Add getting board type from TTDevice object. This info is read from Wormhole telemetry. Format of the board_id is same as for Blackhole so board type can deduced from upi.

### List of the changes

- Add get_board_type function to TTDevice
- Add recognizing all board types based on upi

### Testing

CI + additional test

### API Changes
/
