### PR TITLE
Implement changes to run tests on P300

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -3211,7 +3211,33 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
     for (auto& it : chips) {
         const chip_id_t chip_id = it.first;
         const std::unique_ptr<Chip>& chip = it.second;
-        desc->add_chip_uid(chip_id, chip->get_chip_info().chip_uid);
+        // desc->add_chip_uid(chip_id, chip->get_chip_info().chip_uid);
+
+        const std::vector<CoreCoord> eth_cores = chip->get_soc_descriptor().get_cores(CoreType::ETH);
+
+        for (size_t eth_channel = 0; eth_channel < eth_cores.size(); eth_channel++) {
+            const CoreCoord& eth_core = eth_cores[eth_channel];
+            TTDevice* tt_device = chip->get_tt_device();
+            blackhole::boot_results_t boot_results;
+
+            tt_device->read_from_device(
+                (uint8_t*)&boot_results,
+                tt_xy_pair(eth_core.x, eth_core.y),
+                blackhole::BOOT_RESULTS_ADDR,
+                sizeof(boot_results));
+
+            if (boot_results.eth_status.port_status == blackhole::port_status_e::PORT_UP) {
+                // active eth core
+                desc->active_eth_channels[chip_id].insert(eth_channel);
+                log_debug(LogSiliconDriver, "Eth core ({}, {}) on chip {} is active", eth_core.x, eth_core.y, chip_id);
+                const blackhole::chip_info_t& local_info = boot_results.local_info;
+                const blackhole::chip_info_t& remote_info = boot_results.remote_info;
+
+                uint8_t al = local_info.asic_location;
+
+                desc->add_chip_uid(chip_id, ChipUID{chip->get_chip_info().chip_uid.board_id, al});
+            }
+        }
     }
 
     for (auto& it : chips) {

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -95,8 +95,9 @@ ChipInfo BlackholeTTDevice::get_chip_info() {
                                                          ? (~telemetry->read_entry(blackhole::TAG_ENABLED_ETH) & 0x3FFF)
                                                          : 0;
 
-    // It is expected that this entry is always available.
-    chip_info.chip_uid.asic_location = telemetry->read_entry(blackhole::TAG_ASIC_ID);
+    // TODO: Read asic location of the chip from telemetry when it is available.
+    // Until then we have to read it from ETH core, it happens during topology exploration.
+    // chip_info.chip_uid.asic_location = telemetry->read_entry(blackhole::TAG_ASIC_LOCATION);
 
     const uint64_t addr = blackhole::NIU_CFG_NOC0_BAR_ADDR;
     uint32_t niu_cfg;

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -55,20 +55,23 @@ TEST(ApiChipTest, ManualTLBConfiguration) {
 
     // TODO: This should be part of TTDevice interface, not Cluster or Chip.
     // Configure TLBs.
+    chip_id_t mmio_chip_for_tlb_config = any_mmio_chip;
     std::function<int(CoreCoord)> get_static_tlb_index = [&](CoreCoord core) -> int {
         // TODO: Make this per arch.
         if (core.core_type != CoreType::TENSIX) {
             return -1;
         }
         // LOGICAL system needs to be used for the correct calculation of tlb_index.
-        core = umd_cluster->get_soc_descriptor(any_mmio_chip).translate_coord_to(core, CoordSystem::LOGICAL);
-        return core.x + core.y * umd_cluster->get_soc_descriptor(any_mmio_chip).get_grid_size(CoreType::TENSIX).x;
+        core = umd_cluster->get_soc_descriptor(mmio_chip_for_tlb_config).translate_coord_to(core, CoordSystem::LOGICAL);
+        return core.x +
+               core.y * umd_cluster->get_soc_descriptor(mmio_chip_for_tlb_config).get_grid_size(CoreType::TENSIX).x;
     };
 
     std::int32_t c_zero_address = 0;
 
     // Each MMIO chip has it's own set of TLBs, so needs its own configuration.
     for (chip_id_t mmio_chip : umd_cluster->get_target_mmio_device_ids()) {
+        mmio_chip_for_tlb_config = mmio_chip;
         const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(mmio_chip);
         for (CoreCoord core : soc_desc.get_cores(CoreType::TENSIX)) {
             umd_cluster->configure_tlb(mmio_chip, core, get_static_tlb_index(core), c_zero_address);

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -278,3 +278,28 @@ TEST(ClusterAPI, DynamicTLB_RW) {
     }
     cluster->close_device();
 }
+
+TEST(TestCluster, PrintAllChipsAllCores) {
+    std::unique_ptr<Cluster> umd_cluster = get_cluster();
+
+    for (chip_id_t chip : umd_cluster->get_target_device_ids()) {
+        std::cout << "Chip " << chip << std::endl;
+
+        const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(chip);
+
+        const std::vector<CoreCoord>& tensix_cores = soc_desc.get_cores(CoreType::TENSIX);
+        for (const CoreCoord& core : tensix_cores) {
+            std::cout << "Tensix core " << core.str() << std::endl;
+        }
+
+        const std::vector<CoreCoord>& dram_cores = soc_desc.get_cores(CoreType::DRAM);
+        for (const CoreCoord& core : dram_cores) {
+            std::cout << "DRAM core " << core.str() << std::endl;
+        }
+
+        const std::vector<CoreCoord>& eth_cores = soc_desc.get_cores(CoreType::ETH);
+        for (const CoreCoord& core : eth_cores) {
+            std::cout << "ETH core " << core.str() << std::endl;
+        }
+    }
+}

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -10,14 +10,13 @@
 
 #include "disjoint_set.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
-#include "umd/device/cluster.h"
 #include "umd/device/pci_device.hpp"
 #include "umd/device/tt_cluster_descriptor.h"
 
 using namespace tt::umd;
 
 TEST(ApiClusterDescriptorTest, DetectArch) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
 
     if (cluster_desc->get_number_of_chips() == 0) {
         // Expect it to be invalid if no devices are found.
@@ -49,7 +48,7 @@ TEST(ApiClusterDescriptorTest, DetectArch) {
 }
 
 TEST(ApiClusterDescriptorTest, BasicFunctionality) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
 
     if (cluster_desc == nullptr) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";

--- a/tests/blackhole/test_chip_info_bh.cpp
+++ b/tests/blackhole/test_chip_info_bh.cpp
@@ -14,7 +14,9 @@ TEST(BlackholeChipInfo, BasicChipInfo) {
 
         const ChipInfo chip_info = tt_device->get_chip_info();
 
-        EXPECT_TRUE(chip_info.board_type == BoardType::P100 || chip_info.board_type == BoardType::P150);
+        EXPECT_TRUE(
+            chip_info.board_type == BoardType::P100 || chip_info.board_type == BoardType::P150 ||
+            chip_info.board_type == BoardType::P300);
 
         EXPECT_TRUE(chip_info.chip_uid.asic_location == 0 || chip_info.chip_uid.asic_location == 1);
     }

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -72,7 +72,7 @@ std::int32_t get_static_tlb_index(tt_xy_pair target) {
 
 std::set<chip_id_t> get_target_devices() {
     std::set<chip_id_t> target_devices;
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq = Cluster::create_cluster_descriptor();
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq = tt::umd::Cluster::create_cluster_descriptor();
     for (int i = 0; i < cluster_desc_uniq->get_number_of_chips(); i++) {
         target_devices.insert(i);
     }
@@ -104,7 +104,7 @@ TEST(SiliconDriverBH, CreateDestroy) {
 
 //     {
 //         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
-//             Cluster::create_cluster_descriptor();
+//             tt::umd::Cluster::create_cluster_descriptor();
 //         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
 //             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
 //             system";
@@ -136,7 +136,7 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 30}, {1, 60}};
 //     {
 //         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
-//             Cluster::create_cluster_descriptor();
+//             tt::umd::Cluster::create_cluster_descriptor();
 //         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
 //             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
 //             system";
@@ -166,7 +166,7 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 30}, {1, 60}};
 //     {
 //         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
-//             Cluster::create_cluster_descriptor();
+//             tt::umd::Cluster::create_cluster_descriptor();
 //         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
 //             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
 //             system";


### PR DESCRIPTION
### Issue

Run UMD unit tests on P300 board. This boards still have experimental fw so not available on CI but we ran to prevent any problems when Metal starts using it.

### Description

Few fixes were needed to get UMD unit tests running properly. Asic location must for now be read from ETH cores, instead of the telemetry. Syseng folks are going to patch this in some of the upcoming fw releases. Second one was badly written test that is fixed now.

### List of the changes

- Read asic location from active ETH core
- Fix badly written test
- Dont' call tt_ClusterDescriptor create-ethernet-map in Blackhole tests

### Testing

UMD unit tests pass on P300 locally. 

### API Changes
/