### PR TITLE
Fix Blackhole unit test

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -17,7 +17,6 @@
 
 #include "fmt/core.h"
 #include "tt_silicon_driver_common.hpp"
-#include "umd/device/blackhole_arc_message_queue.h"
 #include "umd/device/chip/chip.h"
 #include "umd/device/tt_device/tt_device.h"
 #include "umd/device/tt_io.hpp"
@@ -1160,8 +1159,6 @@ private:
 
     std::shared_ptr<tt_ClusterDescriptor> cluster_desc;
 
-    std::unique_ptr<tt::umd::BlackholeArcMessageQueue> bh_arc_msg_queue = nullptr;
-
     // remote eth transfer setup
     static constexpr std::uint32_t NUM_ETH_CORES_FOR_NON_MMIO_TRANSFERS = 6;
     static constexpr std::uint32_t NON_EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS = 4;
@@ -1183,7 +1180,6 @@ private:
     std::unordered_map<chip_id_t, std::unordered_set<tt_xy_pair>> workers_per_chip = {};
     std::unordered_set<tt_xy_pair> eth_cores = {};
     std::unordered_set<tt_xy_pair> dram_cores = {};
-    std::unordered_map<chip_id_t, std::unique_ptr<BlackholeArcMessageQueue>> bh_arc_msg_queues = {};
 
     std::map<std::set<chip_id_t>, std::unordered_map<chip_id_t, std::vector<std::vector<int>>>> bcast_header_cache = {};
     bool perform_harvesting_on_sdesc = false;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -2941,13 +2941,18 @@ void Cluster::set_power_state(tt_DevicePowerState device_state) {
             }
         }
     } else {
+        uint32_t exit_code;
         for (auto& chip : all_chip_ids_) {
-            std::unique_ptr<BlackholeArcMessageQueue>& bh_arc_msg_queue = bh_arc_msg_queues.at(chip);
-
             if (device_state == tt_DevicePowerState::BUSY) {
-                bh_arc_msg_queue->send_message(tt::umd::blackhole::ArcMessageType::AICLK_GO_BUSY);
+                exit_code = get_tt_device(chip)->get_arc_messenger()->send_message(
+                    (uint32_t)tt::umd::blackhole::ArcMessageType::AICLK_GO_BUSY);
             } else {
-                bh_arc_msg_queue->send_message(tt::umd::blackhole::ArcMessageType::AICLK_GO_LONG_IDLE);
+                exit_code = get_tt_device(chip)->get_arc_messenger()->send_message(
+                    (uint32_t)tt::umd::blackhole::ArcMessageType::AICLK_GO_LONG_IDLE);
+            }
+
+            if (exit_code != 0) {
+                throw std::runtime_error(fmt::format("Setting power state for chip {} failed.", chip));
             }
         }
     }

--- a/tests/blackhole/test_arc_messages_bh.cpp
+++ b/tests/blackhole/test_arc_messages_bh.cpp
@@ -8,6 +8,7 @@
 #include "umd/device/arc_messenger.h"
 #include "umd/device/blackhole_arc_telemetry_reader.h"
 #include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/types/blackhole_arc.h"
 
 using namespace tt::umd;
 
@@ -21,7 +22,7 @@ TEST(BlackholeArcMessages, BlackholeArcMessagesBasic) {
 
         const uint32_t num_loops = 100;
         for (int i = 0; i < num_loops; i++) {
-            uint32_t response = bh_arc_messenger->send_message((uint32_t)ArcMessageType::TEST);
+            uint32_t response = bh_arc_messenger->send_message((uint32_t)blackhole::ArcMessageType::TEST);
             ASSERT_EQ(response, 0);
         }
     }
@@ -37,7 +38,7 @@ TEST(BlackholeArcMessages, BlackholeArcMessageHigherAIClock) {
 
         std::unique_ptr<ArcMessenger> bh_arc_messenger = ArcMessenger::create_arc_messenger(tt_device.get());
 
-        uint32_t response = bh_arc_messenger->send_message((uint32_t)ArcMessageType::AICLK_GO_BUSY);
+        uint32_t response = bh_arc_messenger->send_message((uint32_t)blackhole::ArcMessageType::AICLK_GO_BUSY);
 
         // Wait for telemetry to update AICLK.
         std::this_thread::sleep_for(std::chrono::milliseconds(ms_sleep));
@@ -46,7 +47,7 @@ TEST(BlackholeArcMessages, BlackholeArcMessageHigherAIClock) {
 
         EXPECT_EQ(aiclk, blackhole::AICLK_BUSY_VAL);
 
-        response = bh_arc_messenger->send_message((uint32_t)ArcMessageType::AICLK_GO_LONG_IDLE);
+        response = bh_arc_messenger->send_message((uint32_t)blackhole::ArcMessageType::AICLK_GO_LONG_IDLE);
 
         // Wait for telemetry to update AICLK.
         std::this_thread::sleep_for(std::chrono::milliseconds(ms_sleep));


### PR DESCRIPTION
### Issue

#549 introduced a bug where Blackhole arc messenger queues were deleted, but Arc messenger was not integrated for setting power state

### Description

Use TTDevice Arc messenger to set power properly on Blackhole.

### List of the changes

- Remove Blackhole Arc messenger queues
- Use TTDevice arc messenger

### Testing

Running tests locally uncovered the problem since p150 CI is broken. Ran tests locally to confirm again.

### API Changes
/
