### PR TITLE
Blackhole ETH id mapping fix

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -40,6 +40,7 @@
 #include "api/umd/device/tt_core_coordinates.h"
 #include "logger.hpp"
 #include "umd/device/architecture_implementation.h"
+#include "umd/device/blackhole_implementation.h"
 #include "umd/device/chip/local_chip.h"
 #include "umd/device/chip/mock_chip.h"
 #include "umd/device/chip/remote_chip.h"
@@ -3238,7 +3239,6 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
         }
     }
 
-    std::map<chip_id_t, std::map<size_t, size_t>> map_eth_id_to_logical_core;
     for (auto& it : chips) {
         const chip_id_t chip_id = it.first;
         const std::unique_ptr<Chip>& chip = it.second;
@@ -3254,18 +3254,6 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
         desc->harvesting_masks.insert({chip_id, chip->get_chip_info().harvesting_masks.tensix_harvesting_mask});
         desc->dram_harvesting_masks.insert({chip_id, chip->get_chip_info().harvesting_masks.dram_harvesting_mask});
         desc->eth_harvesting_masks.insert({chip_id, chip->get_chip_info().harvesting_masks.eth_harvesting_mask});
-
-        const std::vector<CoreCoord> eth_cores = chip->get_soc_descriptor().get_cores(CoreType::ETH);
-        for (size_t eth_channel = 0; eth_channel < eth_cores.size(); eth_channel++) {
-            tt_xy_pair physical_pair = eth_cores[eth_channel];
-
-            // ETH id corresponds to the index of the pair in ETH_CORES array.
-            size_t eth_id =
-                std::find(tt::umd::blackhole::ETH_CORES.begin(), tt::umd::blackhole::ETH_CORES.end(), physical_pair) -
-                tt::umd::blackhole::ETH_CORES.begin();
-
-            map_eth_id_to_logical_core[chip_id][eth_id] = eth_channel;
-        }
     }
 
     if (chips.begin()->second->get_tt_device()->get_arch() == tt::ARCH::BLACKHOLE) {
@@ -3306,11 +3294,15 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
                             chip_id,
                             remote_info.get_chip_uid().board_id);
                     } else {
+                        const CoreCoord logical_remote_coord = chips.at(remote_chip_id.value())
+                                                                   ->get_soc_descriptor()
+                                                                   .translate_coord_to(
+                                                                       blackhole::ETH_CORES[remote_info.eth_id],
+                                                                       CoordSystem::PHYSICAL,
+                                                                       CoordSystem::LOGICAL);
                         // Adding a connection only one way, the other chip should add it another way.
-                        desc->ethernet_connections[local_chip_id]
-                                                  [map_eth_id_to_logical_core[local_chip_id][local_info.eth_id]] = {
-                            remote_chip_id.value(),
-                            map_eth_id_to_logical_core[remote_chip_id.value()][remote_info.eth_id]};
+                        desc->ethernet_connections[local_chip_id][eth_channel] = {
+                            remote_chip_id.value(), logical_remote_coord.y};
                     }
                 } else if (boot_results.eth_status.port_status == blackhole::port_status_e::PORT_DOWN) {
                     // active eth core, just with link being down.

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -3331,38 +3331,6 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
         ubb_eth_connections(chips, desc);
     }
 
-    // This is a way to verify that cluster descriptor does not have logical eth connections
-    // that has the value bigger than number of non-harvested ETH cores for the chip.
-    for (auto& [local_chip_id, eth_connections] : desc->ethernet_connections) {
-        size_t local_chip_eth_cores_size =
-            chips.at(local_chip_id)->get_soc_descriptor().get_cores(CoreType::ETH).size();
-
-        for (auto& [local_eth, connection] : eth_connections) {
-            auto [remote_chip_id, remote_eth] = connection;
-            // chip_id_t remote_chip_id = connection.first;
-            // size_t remote_eth = connection.second;
-
-            size_t remote_chip_eth_cores_size =
-                chips.at(remote_chip_id)->get_soc_descriptor().get_cores(CoreType::ETH).size();
-
-            if (local_eth >= local_chip_eth_cores_size) {
-                throw std::runtime_error(fmt::format(
-                    "ETH channel {} on chip {} has higher channel number than number of non-harvested ETH cores - {}.",
-                    local_eth,
-                    local_chip_id,
-                    local_chip_eth_cores_size));
-            }
-
-            if (remote_eth >= remote_chip_eth_cores_size) {
-                throw std::runtime_error(fmt::format(
-                    "ETH channel {} on chip {} has higher channel number than number of non-harvested ETH cores - {}.",
-                    remote_eth,
-                    remote_chip_id,
-                    remote_chip_eth_cores_size));
-            }
-        }
-    }
-
     desc->enable_all_devices();
 
     desc->fill_chips_grouped_by_closest_mmio();

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -3341,10 +3341,6 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
 
     // This is a way to verify that cluster descriptor does not have logical eth connections
     // that has the value bigger than number of non-harvested ETH cores for the chip.
-
-    // iterate over
-    // std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>>
-    //     ethernet_connections;
     for (auto& [local_chip_id, eth_connections] : desc->ethernet_connections) {
         size_t local_chip_eth_cores_size =
             chips.at(local_chip_id)->get_soc_descriptor().get_cores(CoreType::ETH).size();


### PR DESCRIPTION
### Issue

#588 ETH id from ETH core is not considering harvesting, and we would want to have logical ETH channels which consider harvesting in cluster descriptor. We put ETH id from the core in the cluster descriptor, so now considering harvesting as well

### Description

Add mapping of ETH id from the core to the logical ETH channel to know which logical channel to put in the cluster descriptor instead od ETH id from ETH core.

### List of the changes

- Add mapping of ETH id from ETH core to logical eth channel
- Add logical eth channels to cluster descriptor
- Add verification that there is no higher ETH logical channel that number of channels

### Testing
CI + ran locally to check the mapping

### API Changes
/