### PR TITLE
Read Blackhole asic locaiton from telemetry

### DIFF
--- a/device/api/umd/device/types/blackhole_telemetry.h
+++ b/device/api/umd/device/types/blackhole_telemetry.h
@@ -49,6 +49,10 @@ constexpr uint8_t TAG_ENABLED_GDDR = 36;
 constexpr uint8_t TAG_ENABLED_L2CPU = 37;
 constexpr uint8_t TAG_PCIE_USAGE = 38;
 
+// TODO: set proper value to the tag for ASIC location
+// when it is released in the CMFW.
+constexpr uint8_t TAG_ASIC_LOCATION = 0;
+
 }  // namespace blackhole
 
 }  // namespace tt::umd

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -3208,34 +3208,8 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
         return desc;
     }
 
-    for (auto& it : chips) {
-        const chip_id_t chip_id = it.first;
-        const std::unique_ptr<Chip>& chip = it.second;
-
-        // TODO: Use the line below when we can read asic location from the Blackhole telemetry.
-        // Until then we have to read it from ETH core.
-        // desc->add_chip_uid(chip_id, chip->get_chip_info().chip_uid);
-
-        // TODO: Remove this when we can read asic location from the Blackhole telemetry.
-        // Until then we have to read it from ETH core.
-        const std::vector<CoreCoord> eth_cores = chip->get_soc_descriptor().get_cores(CoreType::ETH);
-        for (size_t eth_channel = 0; eth_channel < eth_cores.size(); eth_channel++) {
-            const CoreCoord& eth_core = eth_cores[eth_channel];
-            TTDevice* tt_device = chip->get_tt_device();
-            blackhole::boot_results_t boot_results;
-
-            tt_device->read_from_device(
-                (uint8_t*)&boot_results,
-                tt_xy_pair(eth_core.x, eth_core.y),
-                blackhole::BOOT_RESULTS_ADDR,
-                sizeof(boot_results));
-
-            // We can read the asic location only from active ETH cores.
-            if (boot_results.eth_status.port_status == blackhole::port_status_e::PORT_UP) {
-                const blackhole::chip_info_t& local_info = boot_results.local_info;
-                desc->add_chip_uid(chip_id, ChipUID{chip->get_chip_info().chip_uid.board_id, local_info.asic_location});
-            }
-        }
+    for (auto& [chip_id, chip] : chips) {
+        desc->add_chip_uid(chip_id, chip->get_chip_info().chip_uid);
     }
 
     for (auto& it : chips) {

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -95,9 +95,7 @@ ChipInfo BlackholeTTDevice::get_chip_info() {
                                                          ? (~telemetry->read_entry(blackhole::TAG_ENABLED_ETH) & 0x3FFF)
                                                          : 0;
 
-    // TODO: Read asic location of the chip from telemetry when it is available.
-    // Until then we have to read it from ETH core, it happens during topology exploration.
-    // chip_info.chip_uid.asic_location = telemetry->read_entry(blackhole::TAG_ASIC_LOCATION);
+    chip_info.chip_uid.asic_location = telemetry->read_entry(blackhole::TAG_ASIC_LOCATION);
 
     const uint64_t addr = blackhole::NIU_CFG_NOC0_BAR_ADDR;
     uint32_t niu_cfg;


### PR DESCRIPTION
### Issue

#587. Note that this PR is gated by firmware that has this feature implemented

### Description

Read asic location from CMFW telemetry rather than reading it from ETH core.

### List of the changes

- Read asic location from CMFW telemetry
- Delete reading it from ETH cores

### Testing

CI

### API Changes
/
