### PR TITLE
Log fixes

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -934,8 +934,6 @@ void Cluster::read_device_memory(
     TTDevice* dev = get_tt_device(target.chip);
     uint8_t* buffer_addr = static_cast<uint8_t*>(mem_ptr);
 
-    log_debug(LogSiliconDriver, "  tlb_index: {}, tlb_data.has_value(): {}", tlb_index, tlb_data.has_value());
-
     if (get_tlb_manager(target.chip)->is_tlb_mapped({target.x, target.y}, address, size_in_bytes)) {
         tlb_configuration tlb_description = get_tlb_manager(target.chip)->get_tlb_configuration({target.x, target.y});
         if (dev->get_pci_device()->bar4_wc != nullptr && tlb_description.size == BH_4GB_TLB_SIZE) {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -231,12 +231,11 @@ void Cluster::create_device(
             log_debug(
                 LogSiliconDriver,
                 "Using {} Hugepages/NumHostMemChannels for PCIDevice (logical_device_id: {} pci_interface_id: {} "
-                "device_id: 0x{:x} revision: {})",
+                "device_id: 0x{:x})",
                 num_host_mem_channels,
                 logical_device_id,
                 pci_device->get_device_num(),
-                pci_device->get_device_num(),
-                pci_device->revision_id);
+                pci_device->get_device_num());
 
             // TODO: This will be moved to a dedicated Locking class.
             initialize_interprocess_mutexes(logical_device_id, clean_system_resources);

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -881,13 +881,12 @@ void Cluster::write_device_memory(
 
     log_debug(
         LogSiliconDriver,
-        "Cluster::write_device_memory to chip:{} {}-{} at 0x{:x} size_in_bytes: {} small_access: {}",
+        "Cluster::write_device_memory to chip:{} {}-{} at 0x{:x} size_in_bytes: {}",
         target.chip,
         target.x,
         target.y,
         address,
-        size_in_bytes,
-        small_access);
+        size_in_bytes);
 
     if (get_tlb_manager(target.chip)->is_tlb_mapped({target.x, target.y}, address, size_in_bytes)) {
         tlb_configuration tlb_description = get_tlb_manager(target.chip)->get_tlb_configuration({target.x, target.y});

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -489,7 +489,7 @@ bool PCIDevice::init_hugepage(uint32_t num_host_mem_channels) {
             physical_device_id,
             ch,
             hugepage_size,
-            (unsigned long long)hugepage_mappings.at(device_id).at(ch).physical_address);
+            pin_pages.out.physical_address);
     }
 
     return success;

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -173,8 +173,8 @@ int tt_ClusterDescriptor::get_ethernet_link_coord_distance(
             shelf_to_shelf_connection.destination_chip_coords.size(),
             "Expecting at least one shelf-to-shelf connection, possibly one-to-many");
 
-            // for each shelf-to-shelf connection at location_b.y, find the distance to location_a, take min
-            int distance = std::numeric_limits<int>::max();
+        // for each shelf-to-shelf connection at location_b.y, find the distance to location_a, take min
+        int distance = std::numeric_limits<int>::max();
         eth_coord_t exit_shelf = shelf_to_shelf_connection.source_chip_coord;
         for (eth_coord_t next_shelf : shelf_to_shelf_connection.destination_chip_coords) {
             log_assert(

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -171,7 +171,7 @@ int tt_ClusterDescriptor::get_ethernet_link_coord_distance(
             galaxy_shelves_exit_chip_coords_per_y_dim.at(location_b.shelf).at(location_b.y);
         log_assert(
             shelf_to_shelf_connection.destination_chip_coords.size(),
-            "Expecting at least one shelf-to-shelf connection, possibly one-to-many")
+            "Expecting at least one shelf-to-shelf connection, possibly one-to-many");
 
             // for each shelf-to-shelf connection at location_b.y, find the distance to location_a, take min
             int distance = std::numeric_limits<int>::max();

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -530,6 +530,8 @@ void tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descripto
         desc.idle_eth_channels[chip_1].erase(channel_1);
     }
 
+    // std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>> ethernet_connections;
+
     log_debug(LogSiliconDriver, "Ethernet Connectivity Descriptor:");
     for (const auto &[chip, chan_to_chip_chan_map] : desc.ethernet_connections) {
         for (const auto &[chan, chip_and_chan] : chan_to_chip_chan_map) {
@@ -538,8 +540,8 @@ void tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descripto
                 "\tchip: {}, chan: {}  <-->  chip: {}, chan: {}",
                 chip,
                 chan,
-                chip_and_chan.x,
-                chip_and_chan.y);
+                std::get<0>(chip_and_chan),
+                std::get<1>(chip_and_chan));
         }
     }
 

--- a/device/tt_device/tlb_manager.cpp
+++ b/device/tt_device/tlb_manager.cpp
@@ -25,7 +25,7 @@ void TLBManager::configure_tlb(
     log_debug(
         LogSiliconDriver,
         "Configuring TLB for chip: {} core: {} tlb_index: {} address: {} ordering: {}",
-        logical_device_id,
+        tt_device_->get_pci_device()->get_device_num(),
         core.str(),
         tlb_index,
         address,


### PR DESCRIPTION
Some code doesn't build if TT_DEBUG_LOGGING is defined.  This fixes or removes broken log statements.