### PR TITLE
Comment part of Blackhole telemetry test

### DIFF
--- a/tests/blackhole/test_chip_info_bh.cpp
+++ b/tests/blackhole/test_chip_info_bh.cpp
@@ -18,6 +18,7 @@ TEST(BlackholeChipInfo, BasicChipInfo) {
             chip_info.board_type == BoardType::P100 || chip_info.board_type == BoardType::P150 ||
             chip_info.board_type == BoardType::P300);
 
-        EXPECT_TRUE(chip_info.chip_uid.asic_location == 0 || chip_info.chip_uid.asic_location == 1);
+        // TODO: uncomment this when we can read asic location properly from telemetry.
+        // EXPECT_TRUE(chip_info.chip_uid.asic_location == 0 || chip_info.chip_uid.asic_location == 1);
     }
 }


### PR DESCRIPTION
### Issue

Disable part of blackhole telemetry test.

### Description

Comment checking asic location from blackhole telemetry. That  not yet released in fw. PR for when that is introduced is #601 

### List of the changes

- Comment part of the test

### Testing

CI

### API Changes
/