### PR TITLE
Print cluster descriptor in contents

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -91,6 +91,10 @@ jobs:
         shell: bash
         run: tar xvf artifact.tar
 
+      - name: Run API tests
+        run: |
+          ${{ env.TEST_OUTPUT_DIR }}/umd/api/api_tests
+
       - name: Run arch-specific UMD unit tests
         run: |
           ${{ env.TEST_OUTPUT_DIR }}/umd/${{ inputs.arch }}/unit_tests
@@ -98,10 +102,6 @@ jobs:
       - name: Run PCI tests
         run: |
           ${{ env.TEST_OUTPUT_DIR }}/umd/test_pcie_device/test_pcie_device
-
-      - name: Run API tests
-        run: |
-          ${{ env.TEST_OUTPUT_DIR }}/umd/api/api_tests
 
       - name: Run MISC tests
         run: |

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -4,10 +4,10 @@
 
 #include <gtest/gtest.h>
 
+#include <fstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <fstream>
 
 #include "disjoint_set.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
@@ -222,8 +222,7 @@ TEST(ApiClusterDescriptorTest, PrintClusterDescriptor) {
 
     std::cout << "Cluster descriptor file path: " << cluster_path << std::endl;
     std::cout << "Contents:" << std::endl;
-    std::ifstream
-        file(cluster_path);  // open the file
+    std::ifstream file(cluster_path);  // open the file
     std::string line;
     while (std::getline(file, line)) {
         std::cout << line << std::endl;

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -202,3 +202,17 @@ TEST(ApiClusterDescriptorTest, EthernetConnectivity) {
         std::cout << std::endl;
     }
 }
+
+TEST(ApiClusterDescriptorTest, PrintClusterDescriptor) {
+    std::filesystem::path cluster_path = tt::umd::Cluster::serialize_to_file();
+
+    std::cout << "Cluster descriptor file path: " << cluster_path << std::endl;
+    std::cout << "Contents:" << std::endl;
+    std::ifstream
+        file(cluster_path);  // open the file
+    std::string line;
+    while (std::getline(file, line)) {
+        std::cout << line << std::endl;
+    }
+    file.close();
+}

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <fstream>
 
 #include "disjoint_set.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"


### PR DESCRIPTION
### Issue
No issue, but inspired by #610 

### Description
Adding cluster descriptor output in our tests, just for easier debugging.

### List of the changes
- Print serialized generated cluster descriptor in case of BH and UBB
- Print cluster descriptor generated by CEM in other cases
- Changed the order so that API tests are executed first

### Testing
- CI on this PR

### API Changes
There are no API changes in this PR.
