### PR TITLE
Fix parsing of new cluster desc format

### DIFF
--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -502,7 +502,11 @@ void tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descripto
         log_assert(connected_endpoints.IsSequence(), "Invalid YAML");
 
         std::vector<YAML::Node> endpoints = connected_endpoints.as<std::vector<YAML::Node>>();
-        log_assert(endpoints.size() == 2, "Currently ethernet cores can only connect to one other ethernet endpoint");
+        log_assert(
+            endpoints.size() <= 3,
+            "Ethernet connections in YAML should always contatin information on connected endpoints and optionally "
+            "information on whether "
+            "routing is enabled.");
 
         int chip_0 = endpoints.at(0)["chip"].as<int>();
         int channel_0 = endpoints.at(0)["chan"].as<int>();

--- a/tests/api/cluster_descriptor_examples/wormhole_N300_routing_info.yaml
+++ b/tests/api/cluster_descriptor_examples/wormhole_N300_routing_info.yaml
@@ -1,0 +1,30 @@
+arch: {
+   0: Wormhole,
+   1: Wormhole,
+}
+
+chips: {
+   0: [0,0,0,0],
+   1: [1,0,0,0],
+}
+
+ethernet_connections: [
+   [{chip: 0, chan: 8}, {chip: 1, chan: 0}, {routing_enabled: true}],
+   [{chip: 0, chan: 9}, {chip: 1, chan: 1}, {routing_enabled: true}],
+]
+
+chips_with_mmio: [
+   0: 0,
+]
+
+# harvest_mask is the bit indicating which tensix row is harvested. So bit 0 = first tensix row; bit 1 = second tensix row etc...
+harvesting: {
+   0: {noc_translation: true, harvest_mask: 65},
+   1: {noc_translation: true, harvest_mask: 5},
+}
+
+# This value will be null if the boardtype is unknown, should never happen in practice but to be defensive it would be useful to throw an error on this case.
+boardtype: {
+   0: n300,
+   1: n300,
+}

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -5,9 +5,6 @@
 #include <gtest/gtest.h>
 
 #include <fstream>
-#include <string>
-#include <unordered_map>
-#include <vector>
 
 #include "disjoint_set.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
@@ -84,6 +81,7 @@ TEST(ApiClusterDescriptorTest, TestAllOfflineClusterDescriptors) {
              "wormhole_2xN300_unconnected.yaml",
              "wormhole_N150.yaml",
              "wormhole_N300.yaml",
+             "wormhole_N300_routing_info.yaml",
          }) {
         std::cout << "Testing " << cluster_desc_yaml << std::endl;
         std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(


### PR DESCRIPTION
### Issue

Fix parsing of new cluster descriptor format introduced by #610 

### Description

Add guard to not fail when cluster descriptor has routing enabled information

### List of the changes

- Allow ethernet connections to have 3 fields
- Add example cluster descriptor

### Testing

CI. New cluster descriptor was added as part of the test

### API Changes
/
