### PR TITLE
Remove assert for Blackhole arc messages

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -2851,7 +2851,6 @@ int Cluster::arc_msg(
     int timeout,
     uint32_t* return_3,
     uint32_t* return_4) {
-    log_assert(arch_name != tt::ARCH::BLACKHOLE, "ARC messages not supported in Blackhole");
     if (cluster_desc->is_chip_mmio_capable(logical_device_id)) {
         return pcie_arc_msg(logical_device_id, msg_code, wait_for_done, arg0, arg1, timeout, return_3, return_4);
     } else {


### PR DESCRIPTION
### Issue

Remove assert for Blackhole ARC messages to enable custom use of arc_msg interface. This path is not used by UMD so we didn't see this, but someone would want to use this interface in a custom way. tt-exalens test was failing

### Description

Remove assert for BH

### List of the changes

- Remove assert for BH

### Testing

CI + tt-exalens tests pass

### API Changes
/
