### PR TITLE
Read NOC0 node id to confirm core coordinates

### DIFF
--- a/device/api/umd/device/blackhole_implementation.h
+++ b/device/api/umd/device/blackhole_implementation.h
@@ -272,6 +272,9 @@ static constexpr uint32_t TENSIX_L1_SIZE = 1499136;
 static constexpr uint32_t ETH_L1_SIZE = 262144;
 static constexpr uint64_t DRAM_BANK_SIZE = 4294967296;
 
+static constexpr uint64_t NOC_CONTROL_REG_ADDR_BASE = 0xFFB20000;
+static constexpr uint64_t NOC_NODE_ID_OFFSET = 0x44;
+
 static const size_t eth_translated_coordinate_start_x = 20;
 static const size_t eth_translated_coordinate_start_y = 25;
 

--- a/device/api/umd/device/wormhole_implementation.h
+++ b/device/api/umd/device/wormhole_implementation.h
@@ -290,6 +290,14 @@ static constexpr uint32_t TENSIX_L1_SIZE = 1499136;
 static constexpr uint32_t ETH_L1_SIZE = 262144;
 static constexpr uint64_t DRAM_BANK_SIZE = 2147483648;
 
+static constexpr uint64_t NOC_CONTROL_REG_ADDR_BASE = 0xFFB20000;
+static constexpr uint64_t NOC_NODE_ID_OFFSET = 0x2C;
+// Constants copied from noc_parameters.h which is removed from UMD.
+// TODO: think about bringing these files back to UMD for tests.
+static const uint32_t NOC_CFG_OFFSET = 0x100;
+static const uint32_t NOC_REG_WORD_SIZE = 4;
+static const uint32_t NOC_CFG_NOC_ID_LOGICAL = 0xE;
+
 static const size_t tensix_translated_coordinate_start_x = 18;
 static const size_t tensix_translated_coordinate_start_y = 18;
 

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -14,10 +14,12 @@
 #include "fmt/xchar.h"
 #include "l1_address_map.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
+#include "umd/device/blackhole_implementation.h"
 #include "umd/device/chip/local_chip.h"
 #include "umd/device/chip/mock_chip.h"
 #include "umd/device/cluster.h"
 #include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/wormhole_implementation.h"
 
 // TODO: obviously we need some other way to set this up
 #include "noc/noc_parameters.h"
@@ -333,5 +335,82 @@ TEST(TestCluster, TestClusterLogicalETHChannelsConnectivity) {
             EXPECT_TRUE(channel < num_channels_local_chip);
             EXPECT_TRUE(remote_channel < num_channels_remote_chip);
         }
+    }
+}
+
+TEST(TestCluster, TestClusterNocId) {
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+
+    // Setup memory barrier addresses.
+    // Some default values are set during construction of UMD, but you can override them.
+    cluster->set_barrier_address_params({L1_BARRIER_BASE, ETH_BARRIER_BASE, DRAM_BARRIER_BASE});
+
+    tt::ARCH arch = cluster->get_cluster_description()->get_arch(0);
+
+    // All chips in the cluster have the same noc_translation_enabled value.
+    bool noc_translation_enabled = cluster->get_cluster_description()->get_noc_translation_table_en().at(0);
+
+    uint64_t noc_node_id_reg_addr = 0;
+    if (arch == tt::ARCH::WORMHOLE_B0) {
+        if (noc_translation_enabled) {
+            noc_node_id_reg_addr = tt::umd::wormhole::NOC_CONTROL_REG_ADDR_BASE + tt::umd::wormhole::NOC_CFG_OFFSET +
+                                   tt::umd::wormhole::NOC_REG_WORD_SIZE * tt::umd::wormhole::NOC_CFG_NOC_ID_LOGICAL;
+        } else {
+            noc_node_id_reg_addr = tt::umd::wormhole::NOC_CONTROL_REG_ADDR_BASE + tt::umd::wormhole::NOC_NODE_ID_OFFSET;
+        }
+    } else if (arch == tt::ARCH::BLACKHOLE) {
+        noc_node_id_reg_addr = tt::umd::blackhole::NOC_CONTROL_REG_ADDR_BASE + tt::umd::blackhole::NOC_NODE_ID_OFFSET;
+    }
+
+    auto check_noc_id_cores = [noc_node_id_reg_addr](
+                                  std::unique_ptr<Cluster>& cluster, chip_id_t chip, CoreType core_type) {
+        const std::vector<CoreCoord>& cores = cluster->get_soc_descriptor(chip).get_cores(core_type);
+        for (const CoreCoord& core : cores) {
+            uint32_t noc_node_id_val;
+            cluster->read_from_device(
+                &noc_node_id_val, chip, core, noc_node_id_reg_addr, sizeof(noc_node_id_val), "REG_TLB");
+            uint32_t x = noc_node_id_val & 0x3F;
+            uint32_t y = (noc_node_id_val >> 6) & 0x3F;
+            CoreCoord translated_coord =
+                cluster->get_soc_descriptor(chip).translate_coord_to(core, CoordSystem::TRANSLATED);
+            EXPECT_EQ(translated_coord.x, x);
+            EXPECT_EQ(translated_coord.y, y);
+        }
+    };
+
+    auto check_noc_id_harvested_cores = [noc_node_id_reg_addr](
+                                            std::unique_ptr<Cluster>& cluster, chip_id_t chip, CoreType core_type) {
+        const std::vector<CoreCoord>& cores = cluster->get_soc_descriptor(chip).get_harvested_cores(core_type);
+        for (const CoreCoord& core : cores) {
+            uint32_t noc_node_id_val;
+            cluster->read_from_device(
+                &noc_node_id_val, chip, core, noc_node_id_reg_addr, sizeof(noc_node_id_val), "REG_TLB");
+            uint32_t x = noc_node_id_val & 0x3F;
+            uint32_t y = (noc_node_id_val >> 6) & 0x3F;
+            CoreCoord translated_coord =
+                cluster->get_soc_descriptor(chip).translate_coord_to(core, CoordSystem::TRANSLATED);
+            EXPECT_EQ(translated_coord.x, x);
+            EXPECT_EQ(translated_coord.y, y);
+        }
+    };
+
+    for (chip_id_t chip : cluster->get_target_device_ids()) {
+        check_noc_id_cores(cluster, chip, CoreType::TENSIX);
+        check_noc_id_harvested_cores(cluster, chip, CoreType::TENSIX);
+
+        check_noc_id_cores(cluster, chip, CoreType::ETH);
+        check_noc_id_harvested_cores(cluster, chip, CoreType::ETH);
+
+        // TODO: figure out how to read this information on Wormhole.
+        if (arch == tt::ARCH::BLACKHOLE) {
+            check_noc_id_cores(cluster, chip, CoreType::DRAM);
+            check_noc_id_harvested_cores(cluster, chip, CoreType::DRAM);
+        }
+
+        // TODO: figure out how to read this information on WH and BH.
+        // check_noc_id_cores(cluster, chip, CoreType::ARC);
+
+        // TODO: figure out why this hangs the chip both on WH and BH.
+        // check_noc_id_cores(cluster, chip, CoreType::PCIE);
     }
 }


### PR DESCRIPTION
### Issue

/

### Description

Add a test to read NOC node id register from different core types. This is a good test to confirm core coordinates from soc descriptor.

### List of the changes

- Add a test
- Add constants for BH and WH noc node id register
- Figure out how to read the information for all the cores

### Testing

CI + added test

### API Changes
/
