### PR TITLE
Return mutex for arc messages

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1271,6 +1271,10 @@ int Cluster::pcie_arc_msg(
     int timeout,
     uint32_t* return_3,
     uint32_t* return_4) {
+    // Exclusive access for a single process at a time.
+    std::string msg_type = "ARC_MSG";
+    const scoped_lock<named_mutex> lock(*get_mutex(msg_type, logical_device_id));
+
     std::vector<uint32_t> arc_msg_return_values;
 
     if (return_3 != nullptr) {


### PR DESCRIPTION
### Issue

While working on #616 I saw there is a mutex missing for arc messages which I removed in #566. This is not generally but could become if we have two processes sending different arc messages.

### Description

Use the arc message mutex created in cluster during the sending of arc messages

### List of the changes

- Use ARC message mutex in pcie_arc_msg

### Testing

CI

### API Changes
/
