### PR TITLE
Add mutex to ArcMessenger class

### DIFF
--- a/device/api/umd/device/arc_messenger.h
+++ b/device/api/umd/device/arc_messenger.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <string_view>
 #include <vector>
 
 namespace boost::interprocess {

--- a/device/api/umd/device/arc_messenger.h
+++ b/device/api/umd/device/arc_messenger.h
@@ -9,6 +9,10 @@
 #include <memory>
 #include <vector>
 
+namespace boost::interprocess {
+class named_mutex;
+}
+
 namespace tt::umd {
 
 class TTDevice;
@@ -52,7 +56,7 @@ public:
      */
     uint32_t send_message(const uint32_t msg_code, uint16_t arg0 = 0, uint16_t arg1 = 0, uint32_t timeout_ms = 1000);
 
-    virtual ~ArcMessenger() = default;
+    virtual ~ArcMessenger();
 
 protected:
     /**
@@ -63,5 +67,13 @@ protected:
     ArcMessenger(TTDevice* tt_device);
 
     TTDevice* tt_device;
+
+    std::shared_ptr<boost::interprocess::named_mutex> arc_msg_mutex = nullptr;
+
+    static constexpr char MUTEX_NAME[] = "ARC_MSG";
+
+private:
+    void initialize_arc_msg_mutex();
+    void clean_arc_msg_mutex();
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/arc_messenger.h
+++ b/device/api/umd/device/arc_messenger.h
@@ -70,10 +70,11 @@ protected:
 
     std::shared_ptr<boost::interprocess::named_mutex> arc_msg_mutex = nullptr;
 
-    static constexpr char MUTEX_NAME[] = "ARC_MSG";
+    static constexpr std::string_view MUTEX_NAME = "TT_ARC_MSG";
 
 private:
     void initialize_arc_msg_mutex();
     void clean_arc_msg_mutex();
 };
+
 }  // namespace tt::umd

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -1189,7 +1189,6 @@ private:
     tt_version eth_fw_version;  // Ethernet FW the driver is interfacing with
     // Named Mutexes
     static constexpr char NON_MMIO_MUTEX_NAME[] = "NON_MMIO";
-    static constexpr char ARC_MSG_MUTEX_NAME[] = "ARC_MSG";
     static constexpr char MEM_BARRIER_MUTEX_NAME[] = "MEM_BAR";
     // ERISC FW Version Required by UMD
     static constexpr std::uint32_t SW_VERSION = 0x06060000;

--- a/device/arc_messenger.cpp
+++ b/device/arc_messenger.cpp
@@ -41,14 +41,15 @@ uint32_t ArcMessenger::send_message(const uint32_t msg_code, uint16_t arg0, uint
 void ArcMessenger::initialize_arc_msg_mutex() {
     permissions unrestricted_permissions;
     unrestricted_permissions.set_unrestricted();
-    std::string mutex_name = ArcMessenger::MUTEX_NAME + std::to_string(tt_device->get_pci_device()->get_device_num());
+    std::string mutex_name =
+        std::string(ArcMessenger::MUTEX_NAME) + std::to_string(tt_device->get_pci_device()->get_device_num());
     arc_msg_mutex = std::make_shared<named_mutex>(open_or_create, mutex_name.c_str(), unrestricted_permissions);
 }
 
 void ArcMessenger::clean_arc_msg_mutex() {
-    std::string mutex_name = ArcMessenger::MUTEX_NAME + std::to_string(tt_device->get_pci_device()->get_device_num());
+    std::string mutex_name =
+        std::string(ArcMessenger::MUTEX_NAME) + std::to_string(tt_device->get_pci_device()->get_device_num());
     arc_msg_mutex.reset();
-    arc_msg_mutex = nullptr;
     named_mutex::remove(mutex_name.c_str());
 }
 

--- a/device/arc_messenger.cpp
+++ b/device/arc_messenger.cpp
@@ -5,9 +5,14 @@
  */
 #include "umd/device/arc_messenger.h"
 
+#include <boost/interprocess/permissions.hpp>
+#include <boost/interprocess/sync/named_mutex.hpp>
+
 #include "umd/device/blackhole_arc_messenger.h"
 #include "umd/device/tt_device/tt_device.h"
 #include "umd/device/wormhole_arc_messenger.h"
+
+using namespace boost::interprocess;
 
 namespace tt::umd {
 
@@ -26,11 +31,27 @@ std::unique_ptr<ArcMessenger> ArcMessenger::create_arc_messenger(TTDevice* tt_de
     }
 }
 
-ArcMessenger::ArcMessenger(TTDevice* tt_device) : tt_device(tt_device) {}
+ArcMessenger::ArcMessenger(TTDevice* tt_device) : tt_device(tt_device) { initialize_arc_msg_mutex(); }
 
 uint32_t ArcMessenger::send_message(const uint32_t msg_code, uint16_t arg0, uint16_t arg1, uint32_t timeout_ms) {
     std::vector<uint32_t> return_values;
     return send_message(msg_code, return_values, arg0, arg1, timeout_ms);
 }
+
+void ArcMessenger::initialize_arc_msg_mutex() {
+    permissions unrestricted_permissions;
+    unrestricted_permissions.set_unrestricted();
+    std::string mutex_name = ArcMessenger::MUTEX_NAME + std::to_string(tt_device->get_pci_device()->get_device_num());
+    arc_msg_mutex = std::make_shared<named_mutex>(open_or_create, mutex_name.c_str(), unrestricted_permissions);
+}
+
+void ArcMessenger::clean_arc_msg_mutex() {
+    std::string mutex_name = ArcMessenger::MUTEX_NAME + std::to_string(tt_device->get_pci_device()->get_device_num());
+    arc_msg_mutex.reset();
+    arc_msg_mutex = nullptr;
+    named_mutex::remove(mutex_name.c_str());
+}
+
+ArcMessenger::~ArcMessenger() { clean_arc_msg_mutex(); }
 
 }  // namespace tt::umd

--- a/device/blackhole/blackhole_arc_messenger.cpp
+++ b/device/blackhole/blackhole_arc_messenger.cpp
@@ -5,7 +5,12 @@
  */
 #include "umd/device/blackhole_arc_messenger.h"
 
+#include <boost/interprocess/sync/named_mutex.hpp>
+#include <boost/interprocess/sync/scoped_lock.hpp>
+
 #include "umd/device/tt_device/tt_device.h"
+
+using namespace boost::interprocess;
 
 namespace tt::umd {
 
@@ -16,6 +21,7 @@ BlackholeArcMessenger::BlackholeArcMessenger(TTDevice* tt_device) : ArcMessenger
 
 uint32_t BlackholeArcMessenger::send_message(
     const uint32_t msg_code, std::vector<uint32_t>& return_values, uint16_t arg0, uint16_t arg1, uint32_t timeout_ms) {
+    const scoped_lock<named_mutex> lock(*arc_msg_mutex);
     return blackhole_arc_msg_queue->send_message((ArcMessageType)msg_code, arg0, arg1, timeout_ms);
 }
 

--- a/device/wormhole/wormhole_arc_messenger.cpp
+++ b/device/wormhole/wormhole_arc_messenger.cpp
@@ -5,9 +5,14 @@
  */
 #include "umd/device/wormhole_arc_messenger.h"
 
+#include <boost/interprocess/sync/named_mutex.hpp>
+#include <boost/interprocess/sync/scoped_lock.hpp>
+
 #include "logger.hpp"
 #include "umd/device/tt_device/tt_device.h"
 #include "umd/device/wormhole_implementation.h"
+
+using namespace boost::interprocess;
 
 namespace tt::umd {
 
@@ -21,6 +26,8 @@ uint32_t WormholeArcMessenger::send_message(
     }
 
     log_assert(arg0 <= 0xffff and arg1 <= 0xffff, "Only 16 bits allowed in arc_msg args");
+
+    const scoped_lock<named_mutex> lock(*arc_msg_mutex);
 
     auto architecture_implementation = tt_device->get_architecture_implementation();
 

--- a/tests/blackhole/test_arc_messages_bh.cpp
+++ b/tests/blackhole/test_arc_messages_bh.cpp
@@ -66,7 +66,7 @@ TEST(BlackholeArcMessages, MultipleThreadsArcMessages) {
     for (uint32_t chip_id : cluster->get_target_mmio_device_ids()) {
         TTDevice* tt_device = cluster->get_tt_device(chip_id);
 
-        std::thread thread0([tt_device, harvesting_mask_cluster_desc]() {
+        std::thread thread0([&]() {
             std::unique_ptr<ArcMessenger> arc_messenger = ArcMessenger::create_arc_messenger(tt_device);
 
             for (uint32_t loop = 0; loop < num_loops; loop++) {
@@ -75,7 +75,7 @@ TEST(BlackholeArcMessages, MultipleThreadsArcMessages) {
             }
         });
 
-        std::thread thread1([tt_device, harvesting_mask_cluster_desc]() {
+        std::thread thread1([&]() {
             std::unique_ptr<ArcMessenger> arc_messenger = ArcMessenger::create_arc_messenger(tt_device);
 
             for (uint32_t loop = 0; loop < num_loops; loop++) {

--- a/tests/wormhole/test_arc_messages_wh.cpp
+++ b/tests/wormhole/test_arc_messages_wh.cpp
@@ -69,3 +69,50 @@ TEST(WormholeArcMessages, WormholeArcMessagesAICLK) {
         EXPECT_EQ(aiclk, tt::umd::wormhole::AICLK_IDLE_VAL);
     }
 }
+
+TEST(WormholeArcMessages, MultipleThreadsArcMessages) {
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+
+    const uint32_t num_loops = 1000;
+
+    for (uint32_t chip_id : cluster->get_target_mmio_device_ids()) {
+        TTDevice* tt_device = cluster->get_tt_device(chip_id);
+
+        uint32_t harvesting_mask_cluster_desc = cluster->get_cluster_description()->get_harvesting_info().at(chip_id);
+
+        std::thread thread0([tt_device, harvesting_mask_cluster_desc]() {
+            std::unique_ptr<ArcMessenger> arc_messenger = ArcMessenger::create_arc_messenger(tt_device);
+
+            for (uint32_t loop = 0; loop < num_loops; loop++) {
+                std::vector<uint32_t> arc_msg_return_values = {0};
+                uint32_t response = arc_messenger->send_message(
+                    tt::umd::wormhole::ARC_MSG_COMMON_PREFIX |
+                        tt_device->get_architecture_implementation()->get_arc_message_arc_get_harvesting(),
+                    arc_msg_return_values,
+                    0,
+                    0);
+
+                EXPECT_EQ(arc_msg_return_values[0], harvesting_mask_cluster_desc);
+            }
+        });
+
+        std::thread thread1([tt_device, harvesting_mask_cluster_desc]() {
+            std::unique_ptr<ArcMessenger> arc_messenger = ArcMessenger::create_arc_messenger(tt_device);
+
+            for (uint32_t loop = 0; loop < num_loops; loop++) {
+                std::vector<uint32_t> arc_msg_return_values = {0};
+                uint32_t response = arc_messenger->send_message(
+                    tt::umd::wormhole::ARC_MSG_COMMON_PREFIX |
+                        tt_device->get_architecture_implementation()->get_arc_message_arc_get_harvesting(),
+                    arc_msg_return_values,
+                    0,
+                    0);
+
+                EXPECT_EQ(arc_msg_return_values[0], harvesting_mask_cluster_desc);
+            }
+        });
+
+        thread0.join();
+        thread1.join();
+    }
+}

--- a/tests/wormhole/test_arc_messages_wh.cpp
+++ b/tests/wormhole/test_arc_messages_wh.cpp
@@ -80,7 +80,7 @@ TEST(WormholeArcMessages, MultipleThreadsArcMessages) {
 
         uint32_t harvesting_mask_cluster_desc = cluster->get_cluster_description()->get_harvesting_info().at(chip_id);
 
-        std::thread thread0([tt_device, harvesting_mask_cluster_desc]() {
+        std::thread thread0([&]() {
             std::unique_ptr<ArcMessenger> arc_messenger = ArcMessenger::create_arc_messenger(tt_device);
 
             for (uint32_t loop = 0; loop < num_loops; loop++) {
@@ -96,7 +96,7 @@ TEST(WormholeArcMessages, MultipleThreadsArcMessages) {
             }
         });
 
-        std::thread thread1([tt_device, harvesting_mask_cluster_desc]() {
+        std::thread thread1([&]() {
             std::unique_ptr<ArcMessenger> arc_messenger = ArcMessenger::create_arc_messenger(tt_device);
 
             for (uint32_t loop = 0; loop < num_loops; loop++) {


### PR DESCRIPTION
### Issue

#622 returned mutex for ARC messages to Cluster. This PR moves it to dedicated Arc messenger class

### Description

Move ARC message mutex to arc messenger class

### List of the changes

Move ARC message mutex to arc messenger class

### Testing

CI + additional test added

### API Changes
/
