### PR TITLE
Add mutex to TTDevice for read and write

### DIFF
--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <string_view>
+
 #include "umd/device/arc_messenger.h"
 #include "umd/device/architecture_implementation.h"
 #include "umd/device/pci_device.hpp"
@@ -177,9 +179,6 @@ private:
 
     std::shared_ptr<boost::interprocess::named_mutex> read_write_mutex = nullptr;
 
-    // Name of the mutex is SMALL_READ_WRITE_TLB because we need to be able to
-    // sync this TTDevice mutex with Cluster mutex for this same TLB. So final name
-    // of the mutex will be SMALL_READ_WRITE_TLB{pci_device_id} both in Cluster and TTDevice.
-    static constexpr char MUTEX_NAME[] = "SMALL_READ_WRITE_TLB";
+    static constexpr std::string_view MUTEX_NAME = "TT_SMALL_READ_WRITE_TLB";
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -179,6 +179,6 @@ private:
 
     std::shared_ptr<boost::interprocess::named_mutex> read_write_mutex = nullptr;
 
-    static constexpr std::string_view MUTEX_NAME = "TT_SMALL_READ_WRITE_TLB";
+    static constexpr std::string_view MUTEX_NAME = "SMALL_READ_WRITE_TLB";
 };
 }  // namespace tt::umd

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -392,14 +392,13 @@ uint32_t TTDevice::get_clock() {
 void TTDevice::initialize_tt_device_mutex() {
     permissions unrestricted_permissions;
     unrestricted_permissions.set_unrestricted();
-    std::string mutex_name = TTDevice::MUTEX_NAME + std::to_string(get_pci_device()->get_device_num());
+    std::string mutex_name = std::string(TTDevice::MUTEX_NAME) + std::to_string(get_pci_device()->get_device_num());
     read_write_mutex = std::make_shared<named_mutex>(open_or_create, mutex_name.c_str(), unrestricted_permissions);
 }
 
 void TTDevice::clean_tt_device_mutex() {
-    std::string mutex_name = TTDevice::MUTEX_NAME + std::to_string(get_pci_device()->get_device_num());
+    std::string mutex_name = std::string(TTDevice::MUTEX_NAME) + std::to_string(get_pci_device()->get_device_num());
     read_write_mutex.reset();
-    read_write_mutex = nullptr;
     named_mutex::remove(mutex_name.c_str());
 }
 

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+#include <thread>
+
 #include "gtest/gtest.h"
 #include "l1_address_map.h"
 #include "umd/device/blackhole_implementation.h"
@@ -56,5 +58,54 @@ TEST(ApiTTDeviceTest, TTDeviceGetBoardType) {
             board_type == BoardType::N150 || board_type == BoardType::N300 || board_type == BoardType::P100 ||
             board_type == BoardType::P150 || board_type == BoardType::P300 || board_type == BoardType::GALAXY ||
             board_type == BoardType::UBB);
+    }
+}
+
+TEST(ApiTTDeviceTest, TTDeviceMultipleThreadsIO) {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+
+    std::vector<uint32_t> data_write = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+
+    const uint64_t address_thread0 = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
+    const uint64_t address_thread1 = address_thread0 + data_write.size() * sizeof(uint32_t);
+    const uint32_t num_loops = 1000;
+
+    for (int pci_device_id : pci_device_ids) {
+        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+
+        tt_xy_pair tensix_core = get_any_tensix_core(tt_device->get_arch());
+
+        std::thread thread0([&]() {
+            std::vector<uint32_t> data_read(data_write.size(), 0);
+            for (uint32_t loop = 0; loop < num_loops; loop++) {
+                tt_device->write_to_device(
+                    data_write.data(), tensix_core, address_thread0, data_write.size() * sizeof(uint32_t));
+
+                tt_device->read_from_device(
+                    data_read.data(), tensix_core, address_thread0, data_read.size() * sizeof(uint32_t));
+
+                ASSERT_EQ(data_write, data_read);
+
+                data_read = std::vector<uint32_t>(data_write.size(), 0);
+            }
+        });
+
+        std::thread thread1([&]() {
+            std::vector<uint32_t> data_read(data_write.size(), 0);
+            for (uint32_t loop = 0; loop < num_loops; loop++) {
+                tt_device->write_to_device(
+                    data_write.data(), tensix_core, address_thread1, data_write.size() * sizeof(uint32_t));
+
+                tt_device->read_from_device(
+                    data_read.data(), tensix_core, address_thread1, data_read.size() * sizeof(uint32_t));
+
+                ASSERT_EQ(data_write, data_read);
+
+                data_read = std::vector<uint32_t>(data_write.size(), 0);
+            }
+        });
+
+        thread0.join();
+        thread1.join();
     }
 }


### PR DESCRIPTION
### Issue

Part of the effort towards #523 

### Description

Add mutex for read/writes for TTDevice based on the underlying PCI device

### List of the changes

- Add mutex for TTDevice read/writes io
- Add a multithreaded test

### Testing

CI + additional multithreaded test for TTDevice io

### API Changes
/
