### PR TITLE
noc_translation_enabled uninitialized fix

### DIFF
--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -125,7 +125,6 @@ public:
     int packer_version;
     int worker_l1_size;
     int eth_l1_size;
-    bool noc_translation_id_enabled;
     uint64_t dram_bank_size;
 
     // Passed through constructor.

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -3066,7 +3066,7 @@ void Cluster::verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std
     // Temporarily enable this feature for 6.7.241 as well for testing.
     use_virtual_coords_for_eth_broadcast &=
         (fw_first_eth_core >= tt_version(6, 8, 0) || fw_first_eth_core == tt_version(6, 7, 241)) &&
-        get_soc_descriptor(device_id).noc_translation_id_enabled;
+        get_soc_descriptor(device_id).noc_translation_enabled;
 }
 
 void Cluster::start_device(const tt_device_params& device_params) {

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -715,7 +715,7 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as
     cluster.start_device(default_params);
     auto eth_version = cluster.get_ethernet_fw_version();
     bool virtual_bcast_supported = (eth_version >= tt_version(6, 8, 0) || eth_version == tt_version(6, 7, 241)) &&
-                                   cluster.get_soc_descriptor(*target_devices.begin()).noc_translation_id_enabled;
+                                   cluster.get_soc_descriptor(*target_devices.begin()).noc_translation_enabled;
     if (!virtual_bcast_supported) {
         cluster.close_device();
         GTEST_SKIP() << "SiliconDriverWH.VirtualCoordinateBroadcast skipped since ethernet version does not support "

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -682,7 +682,7 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
     cluster.start_device(default_params);
     auto eth_version = cluster.get_ethernet_fw_version();
     bool virtual_bcast_supported = (eth_version >= tt_version(6, 8, 0) || eth_version == tt_version(6, 7, 241)) &&
-                                   cluster.get_soc_descriptor(*target_devices.begin()).noc_translation_id_enabled;
+                                   cluster.get_soc_descriptor(*target_devices.begin()).noc_translation_enabled;
     if (!virtual_bcast_supported) {
         cluster.close_device();
         GTEST_SKIP() << "SiliconDriverWH.VirtualCoordinateBroadcast skipped since ethernet version does not support "


### PR DESCRIPTION
### Issue
This arised as an issue in https://github.com/tenstorrent/tt-umd/pull/626

### Description
Setting this variable was silently removed in https://github.com/tenstorrent/tt-umd/pull/609, but it was still read across the code. Reading uninitialized variable gives undefined value. What's interesting is that printing this value gave "32" even though it is a bool.
I was previously aware that we have two ways of reading noc_translation_enabled, one through cluster_descriptor (or during cluster topology discovery), and another through soc_descriptor, but haven't consolidated them. Referenced PR removed this reading from soc_descriptor, because it is not even present at any soc descriptor, so this change was fine.

### List of the changes
- Removes noc_translation_id_enabled
- Move usages to noc_translation_enabled

### Testing
For some strange reason, only https://github.com/tenstorrent/tt-umd/pull/626 surfaced this issue. I ran the test before this change and after the change, manually, and the failure doesn't appear anymore. Note that the failure is not deterministic, you have to run it ~10 times to check if it will fail anytime or not.

### API Changes
There are no API changes in this PR.
