### PR TITLE
Synchronize Cluster and TTDevice IO

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -53,6 +53,7 @@ target_sources(
         blackhole/blackhole_arc_messenger.cpp
         blackhole/blackhole_arc_message_queue.cpp
         xy_pair.cpp
+        umd_utils.cpp
         ${FBS_GENERATED_HEADER}
 )
 

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -12,6 +12,7 @@
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <vector>
 
@@ -1185,8 +1186,8 @@ private:
     bool use_virtual_coords_for_eth_broadcast = true;
     tt_version eth_fw_version;  // Ethernet FW the driver is interfacing with
     // Named Mutexes
-    static constexpr char NON_MMIO_MUTEX_NAME[] = "NON_MMIO";
-    static constexpr char MEM_BARRIER_MUTEX_NAME[] = "MEM_BAR";
+    static constexpr std::string_view NON_MMIO_MUTEX_NAME = "NON_MMIO";
+    static constexpr std::string_view MEM_BARRIER_MUTEX_NAME = "MEM_BAR";
     // ERISC FW Version Required by UMD
     static constexpr std::uint32_t SW_VERSION = 0x06060000;
 };

--- a/device/api/umd/device/umd_utils.h
+++ b/device/api/umd/device/umd_utils.h
@@ -6,9 +6,14 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 
-#include "umd/device/types/xy_pair.h"
+#include "umd/device/tt_xy_pair.h"
+
+namespace boost::interprocess {
+class named_mutex;
+}
 
 static inline std::vector<tt_xy_pair> flatten_vector(const std::vector<std::vector<tt_xy_pair>>& vector_of_vectors) {
     std::vector<tt_xy_pair> flat_vector;
@@ -17,3 +22,8 @@ static inline std::vector<tt_xy_pair> flatten_vector(const std::vector<std::vect
     }
     return flat_vector;
 }
+
+std::shared_ptr<boost::interprocess::named_mutex> initialize_mutex(
+    const std::string& mutex_name, const bool clear_mutex);
+
+void clear_mutex(const std::string& mutex_name);

--- a/device/arc_messenger.cpp
+++ b/device/arc_messenger.cpp
@@ -10,6 +10,7 @@
 
 #include "umd/device/blackhole_arc_messenger.h"
 #include "umd/device/tt_device/tt_device.h"
+#include "umd/device/umd_utils.h"
 #include "umd/device/wormhole_arc_messenger.h"
 
 using namespace boost::interprocess;
@@ -39,18 +40,13 @@ uint32_t ArcMessenger::send_message(const uint32_t msg_code, uint16_t arg0, uint
 }
 
 void ArcMessenger::initialize_arc_msg_mutex() {
-    permissions unrestricted_permissions;
-    unrestricted_permissions.set_unrestricted();
-    std::string mutex_name =
-        std::string(ArcMessenger::MUTEX_NAME) + std::to_string(tt_device->get_pci_device()->get_device_num());
-    arc_msg_mutex = std::make_shared<named_mutex>(open_or_create, mutex_name.c_str(), unrestricted_permissions);
+    arc_msg_mutex = initialize_mutex(
+        std::string(ArcMessenger::MUTEX_NAME) + std::to_string(tt_device->get_pci_device()->get_device_num()), false);
 }
 
 void ArcMessenger::clean_arc_msg_mutex() {
-    std::string mutex_name =
-        std::string(ArcMessenger::MUTEX_NAME) + std::to_string(tt_device->get_pci_device()->get_device_num());
     arc_msg_mutex.reset();
-    named_mutex::remove(mutex_name.c_str());
+    clear_mutex(std::string(ArcMessenger::MUTEX_NAME) + std::to_string(tt_device->get_pci_device()->get_device_num()));
 }
 
 ArcMessenger::~ArcMessenger() { clean_arc_msg_mutex(); }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -150,38 +150,26 @@ void Cluster::initialize_interprocess_mutexes(int logical_device_id, bool cleanu
 
     // Store old mask and clear processes umask
     auto old_umask = umask(0);
-    permissions unrestricted_permissions;
-    unrestricted_permissions.set_unrestricted();
     std::string mutex_name = "";
+
+    uint32_t pci_device_id = get_tt_device(logical_device_id)->get_pci_device()->get_device_num();
 
     // Initialize Dynamic TLB mutexes
     for (auto& tlb : get_tlb_manager(logical_device_id)->dynamic_tlb_config_) {
-        mutex_name = tlb.first + std::to_string(logical_device_id);
-        if (cleanup_mutexes_in_shm) {
-            named_mutex::remove(mutex_name.c_str());
-        }
-        hardware_resource_mutex_map[mutex_name] =
-            std::make_shared<named_mutex>(open_or_create, mutex_name.c_str(), unrestricted_permissions);
+        mutex_name = tlb.first + std::to_string(pci_device_id);
+        hardware_resource_mutex_map[mutex_name] = initialize_mutex(mutex_name, cleanup_mutexes_in_shm);
     }
 
     if (arch_name == tt::ARCH::WORMHOLE_B0) {
-        mutex_name = NON_MMIO_MUTEX_NAME + std::to_string(logical_device_id);
         // Initialize non-MMIO mutexes for WH devices regardless of number of chips, since these may be used for
         // ethernet broadcast
-        if (cleanup_mutexes_in_shm) {
-            named_mutex::remove(mutex_name.c_str());
-        }
-        hardware_resource_mutex_map[mutex_name] =
-            std::make_shared<named_mutex>(open_or_create, mutex_name.c_str(), unrestricted_permissions);
+        mutex_name = std::string(NON_MMIO_MUTEX_NAME) + std::to_string(pci_device_id);
+        hardware_resource_mutex_map[mutex_name] = initialize_mutex(mutex_name, cleanup_mutexes_in_shm);
     }
 
     // Initialize interprocess mutexes to make host -> device memory barriers atomic
-    mutex_name = MEM_BARRIER_MUTEX_NAME + std::to_string(logical_device_id);
-    if (cleanup_mutexes_in_shm) {
-        named_mutex::remove(mutex_name.c_str());
-    }
-    hardware_resource_mutex_map[mutex_name] =
-        std::make_shared<named_mutex>(open_or_create, mutex_name.c_str(), unrestricted_permissions);
+    mutex_name = std::string(MEM_BARRIER_MUTEX_NAME) + std::to_string(pci_device_id);
+    hardware_resource_mutex_map[mutex_name] = initialize_mutex(mutex_name, cleanup_mutexes_in_shm);
 
     // Restore old mask
     umask(old_umask);
@@ -1386,7 +1374,8 @@ inline TLBManager* Cluster::get_tlb_manager(chip_id_t device_id) const {
 
 std::shared_ptr<boost::interprocess::named_mutex> Cluster::get_mutex(
     const std::string& tlb_name, int logical_device_id) {
-    std::string mutex_name = tlb_name + std::to_string(logical_device_id);
+    std::string mutex_name =
+        tlb_name + std::to_string(get_tt_device(logical_device_id)->get_pci_device()->get_device_num());
     return hardware_resource_mutex_map.at(mutex_name);
 }
 
@@ -1538,7 +1527,7 @@ void Cluster::write_to_non_mmio_device(
     //                    MUTEX ACQUIRE (NON-MMIO)
     //  do not locate any ethernet core reads/writes before this acquire
     //
-    const scoped_lock<named_mutex> lock(*get_mutex(NON_MMIO_MUTEX_NAME, mmio_capable_chip_logical));
+    const scoped_lock<named_mutex> lock(*get_mutex(std::string(NON_MMIO_MUTEX_NAME), mmio_capable_chip_logical));
 
     int& active_core_for_txn =
         non_mmio_transfer_cores_customized ? active_eth_core_idx_per_chip.at(mmio_capable_chip_logical) : active_core;
@@ -1775,7 +1764,7 @@ void Cluster::read_from_non_mmio_device(void* mem_ptr, tt_cxy_pair core, uint64_
     //                    MUTEX ACQUIRE (NON-MMIO)
     //  do not locate any ethernet core reads/writes before this acquire
     //
-    const scoped_lock<named_mutex> lock(*get_mutex(NON_MMIO_MUTEX_NAME, mmio_capable_chip_logical));
+    const scoped_lock<named_mutex> lock(*get_mutex(std::string(NON_MMIO_MUTEX_NAME), mmio_capable_chip_logical));
     const tt_cxy_pair remote_transfer_ethernet_core = remote_transfer_ethernet_cores[mmio_capable_chip_logical].at(0);
 
     read_device_memory(
@@ -2546,7 +2535,7 @@ void Cluster::insert_host_to_device_barrier(
     const uint32_t barrier_addr,
     const std::string& fallback_tlb) {
     // Ensure that this memory barrier is atomic across processes/threads
-    const scoped_lock<named_mutex> lock(*get_mutex(MEM_BARRIER_MUTEX_NAME, chip));
+    const scoped_lock<named_mutex> lock(*get_mutex(std::string(MEM_BARRIER_MUTEX_NAME), chip));
     set_membar_flag(chip, cores, tt_MemBarFlag::SET, barrier_addr, fallback_tlb);
     set_membar_flag(chip, cores, tt_MemBarFlag::RESET, barrier_addr, fallback_tlb);
 }

--- a/device/umd_utils.cpp
+++ b/device/umd_utils.cpp
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "umd/device/umd_utils.h"
+
+#include <boost/interprocess/permissions.hpp>
+#include <boost/interprocess/sync/named_mutex.hpp>
+
+using namespace boost::interprocess;
+
+std::shared_ptr<named_mutex> initialize_mutex(const std::string& mutex_name, const bool clear_mutex) {
+    if (clear_mutex) {
+        named_mutex::remove(mutex_name.c_str());
+    }
+    permissions unrestricted_permissions;
+    unrestricted_permissions.set_unrestricted();
+    return std::make_shared<named_mutex>(open_or_create, mutex_name.c_str(), unrestricted_permissions);
+}
+
+void clear_mutex(const std::string& mutex_name) { named_mutex::remove(mutex_name.c_str()); }

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -9,6 +9,7 @@ set(API_TESTS_SRCS
     test_tlb_manager.cpp
     test_tt_device.cpp
     test_software_harvesting.cpp
+    test_multiprocess.cpp
 )
 
 add_executable(api_tests ${API_TESTS_SRCS})

--- a/tests/api/test_multiprocess.cpp
+++ b/tests/api/test_multiprocess.cpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <thread>
+
+#include "l1_address_map.h"
+#include "umd/device/cluster.h"
+
+using namespace tt::umd;
+
+TEST(MultiprocessUMD, ClusterAndTTDeviceTest) {
+    const uint64_t address_thread0 = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
+    const uint64_t address_thread1 = address_thread0 + 0x100;
+    const uint32_t num_loops = 1000;
+
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+
+    for (chip_id_t chip : cluster->get_target_mmio_device_ids()) {
+        TTDevice* tt_device = cluster->get_tt_device(chip);
+
+        CoreCoord tensix_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)[0];
+
+        std::thread thread0([&]() {
+            std::vector<uint32_t> data_write_t0 = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+            std::vector<uint32_t> data_read(data_write_t0.size(), 0);
+            for (uint32_t loop = 0; loop < num_loops; loop++) {
+                tt_device->write_to_device(
+                    data_write_t0.data(), tensix_core, address_thread0, data_write_t0.size() * sizeof(uint32_t));
+
+                tt_device->read_from_device(
+                    data_read.data(), tensix_core, address_thread0, data_read.size() * sizeof(uint32_t));
+
+                ASSERT_EQ(data_write_t0, data_read);
+
+                data_read = std::vector<uint32_t>(data_write_t0.size(), 0);
+            }
+        });
+
+        std::thread thread1([&]() {
+            std::vector<uint32_t> data_write_t1 = {11, 22, 33, 44, 55, 66, 77, 88, 99, 100};
+            std::vector<uint32_t> data_read(data_write_t1.size(), 0);
+            for (uint32_t loop = 0; loop < num_loops; loop++) {
+                cluster->write_to_device(
+                    data_write_t1.data(),
+                    data_write_t1.size() * sizeof(uint32_t),
+                    chip,
+                    tensix_core,
+                    address_thread1,
+                    "SMALL_READ_WRITE_TLB");
+
+                cluster->read_from_device(
+                    data_read.data(),
+                    chip,
+                    tensix_core,
+                    address_thread1,
+                    data_read.size() * sizeof(uint32_t),
+                    "SMALL_READ_WRITE_TLB");
+
+                ASSERT_EQ(data_write_t1, data_read);
+
+                data_read = std::vector<uint32_t>(data_write_t1.size(), 0);
+            }
+        });
+
+        thread0.join();
+        thread1.join();
+    }
+}


### PR DESCRIPTION
### Issue

Part of the effort #555

### Description

Synchronize IO for Cluster and TTDevice class. TTDevice has mutex for accessing small_read_write_tlb as well as Cluster so these two are in sync over the same mutex now. Mutex has to have PCI device num concat to the TLB name in order to be able to have the same one in TTDevice (TTDevice has no logical chip id or anything similar)

### List of the changes

- Have TLB mutexes be with PCI device id instead of logical device id
- Common code for creating mutexes
- Add a test

### Testing

CI. Added test for syncing TTDevice and Cluster doing IO over small read write tlb

### API Changes
/
