### PR TITLE
Introduce get_chip and get_local_chip

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -846,6 +846,20 @@ public:
     TLBManager* get_tlb_manager(chip_id_t device_id) const;
 
     /**
+     * Get Chip for specified logical device id.
+     *
+     * @param device_id Device to target.
+     */
+    Chip* get_chip(chip_id_t device_id) const;
+
+    /**
+     * Get Chip for specified logical device id, verify it is local.
+     *
+     * @param device_id Device to target.
+     */
+    Chip* get_local_chip(chip_id_t device_id) const;
+
+    /**
      * Get Soc descriptor for specified logical device id.
      *
      * @param device_id Device to target.


### PR DESCRIPTION
### Issue
#248 

### Description
Just a minor change in how chip and local chip are fetched.
Makes it more explicit for where are local chips expected.

### List of the changes
- Introduce get_chip() and get_local_chip() which just asserts that this is a local chip.

### Testing
Existing CI, but not a big change that needs much testing.

### API Changes
There are no API changes in this PR.
