### PR TITLE
Disable tt_device tests

### DIFF
--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -7,7 +7,6 @@ set(API_TESTS_SRCS
     test_mockup_device.cpp
     test_soc_descriptor.cpp
     test_tlb_manager.cpp
-    test_tt_device.cpp
     test_software_harvesting.cpp
 )
 


### PR DESCRIPTION
### Issue
Mitigates #652 until a proper fix is made

### Description
test_tt_device might access harvested tensix cores which can hang the card, or presumably crash the system.

### List of the changes
- Remove test_tt_device.cpp from the cmaketests

### Testing
I've checked that ApiTTDeviceTest is not in the list of tests ran on this PR

### API Changes
There are no API changes in this PR.
