### PR TITLE
Disable multiprocess tests in CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -106,6 +106,9 @@ jobs:
         run: |
           ${{ env.TEST_OUTPUT_DIR }}/umd/misc/umd_misc_tests
 
-      - name: Run unified tests
-        run: |
-          ${{ env.TEST_OUTPUT_DIR }}/umd/unified/unified_tests
+      # TODO: Re-enable unified tests in CI once we solve the bugs
+      # we are seeing in the tests. Issues are tracked in issue
+      # https://github.com/tenstorrent/tt-umd/issues/654
+      # - name: Run unified tests
+      #   run: |
+      #     ${{ env.TEST_OUTPUT_DIR }}/umd/unified/unified_tests


### PR DESCRIPTION
### Issue

Disable multiprocess tests in CI to not block other PRs until all the issues in #654 are fixed

### Description

Disable multiprocess tests in CI

### List of the changes

Disable multiprocess tests in CI

### Testing

CI

### API Changes
/
