### PR TITLE
Fix and enable TTDevice tests

### DIFF
--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -8,6 +8,7 @@ set(API_TESTS_SRCS
     test_soc_descriptor.cpp
     test_tlb_manager.cpp
     test_software_harvesting.cpp
+    test_tt_device.cpp
 )
 
 add_executable(api_tests ${API_TESTS_SRCS})

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -6,6 +6,7 @@
 #include "gtest/gtest.h"
 #include "l1_address_map.h"
 #include "umd/device/blackhole_implementation.h"
+#include "umd/device/cluster.h"
 #include "umd/device/grayskull_implementation.h"
 #include "umd/device/tt_device/tt_device.h"
 #include "umd/device/wormhole_implementation.h"
@@ -13,16 +14,7 @@
 using namespace tt::umd;
 
 tt_xy_pair get_any_tensix_core(tt::ARCH arch) {
-    switch (arch) {
-        case tt::ARCH::BLACKHOLE:
-            return blackhole::TENSIX_CORES_NOC0[0];
-        case tt::ARCH::WORMHOLE_B0:
-            return wormhole::TENSIX_CORES_NOC0[0];
-        case tt::ARCH::GRAYSKULL:
-            return grayskull::TENSIX_CORES_NOC0[0];
-        default:
-            throw std::runtime_error("Invalid architecture");
-    }
+    return std::make_unique<Cluster>()->get_soc_descriptor(0).get_cores(CoreType::TENSIX)[0];
 }
 
 TEST(ApiTTDeviceTest, BasicTTDeviceIO) {


### PR DESCRIPTION
### Issue

#652 

### Description

Fix and reenable tt device tests. Get unharvested tensix cores that is going to be used for IO in device tests.

### List of the changes

- Get unharvested tensix core
- Enable tt device tests back in CI

### Testing
CI

### API Changes
/