### PR TITLE
Move read/write to device to Chip

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -41,6 +41,12 @@ public:
     virtual void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size);
     virtual void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size);
 
+    // TODO: Currently works only for Local and not for Remote.
+    virtual void write_to_device(
+        tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size, const std::string& fallback_tlb);
+    virtual void read_from_device(
+        tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size, const std::string& fallback_tlb);
+
     // TODO: To be removed once all usages are moved inside local chip.
     virtual std::unique_lock<boost::interprocess::named_mutex> get_mutex(std::string mutex_name, int pci_device_id);
     virtual std::unique_lock<boost::interprocess::named_mutex> get_mutex(MutexType mutex_type, int pci_device_id);
@@ -53,17 +59,16 @@ public:
     tt_driver_noc_params noc_params;
     tt_driver_eth_interface_params eth_interface_params;
 
-private:
+protected:
+    void wait_chip_to_be_ready();
+
+    virtual void wait_eth_cores_training(const uint32_t timeout_ms = 60000);
+
     void set_default_params(ARCH arch);
 
     ChipInfo chip_info_;
 
     tt_SocDescriptor soc_descriptor_;
-
-protected:
-    void wait_chip_to_be_ready();
-
-    virtual void wait_eth_cores_training(const uint32_t timeout_ms = 60000);
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -33,6 +33,11 @@ public:
     void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) override;
     void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) override;
 
+    void write_to_device(
+        tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size, const std::string& fallback_tlb) override;
+    void read_from_device(
+        tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size, const std::string& fallback_tlb) override;
+
     std::unique_lock<boost::interprocess::named_mutex> get_mutex(std::string mutex_name, int pci_device_id) override;
     std::unique_lock<boost::interprocess::named_mutex> get_mutex(MutexType mutex_type, int pci_device_id) override;
 
@@ -45,6 +50,8 @@ private:
     void initialize_local_chip(int num_host_mem_channels = 0, const bool clear_mutex = false);
     void initialize_tlb_manager();
     void initialize_default_chip_mutexes(const bool clear_mutex);
+
+    tt_xy_pair translate_chip_coord_virtual_to_translated(const tt_xy_pair core) const;
 
 protected:
     void wait_eth_cores_training(const uint32_t timeout_ms = 60000) override;

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -76,6 +76,16 @@ void Chip::read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, u
     throw std::runtime_error("Chip::read_from_sysmem is not available for this chip.");
 }
 
+void Chip::write_to_device(
+    tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size, const std::string& fallback_tlb) {
+    throw std::runtime_error("Chip::write_to_device is not available for this chip.");
+}
+
+void Chip::read_from_device(
+    tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size, const std::string& fallback_tlb) {
+    throw std::runtime_error("Chip::read_from_device is not available for this chip.");
+}
+
 std::unique_lock<boost::interprocess::named_mutex> Chip::get_mutex(std::string mutex_name, int pci_device_id) {
     throw std::runtime_error("LockManager::get_mutex is not available for this chip.");
 }


### PR DESCRIPTION
### Issue
Contributing towards #248

### Description
Move local chip communication from Cluster to Chip

### List of the changes
- Moved read/write device to LocalChip
- Set some members in chip protected instead of private

### Testing
Existing CI tests

### API Changes
There are no API changes in this PR.
