### PR TITLE
Implement ARC telemetry reader class

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -48,6 +48,8 @@ target_sources(
         tt_soc_descriptor.cpp
         wormhole/wormhole_coordinate_manager.cpp
         blackhole/blackhole_coordinate_manager.cpp
+        arc_telemetry_reader.cpp
+        wormhole/wormhole_arc_telemetry_reader.cpp
         blackhole/blackhole_arc_telemetry_reader.cpp
         arc_messenger.cpp
         wormhole/wormhole_arc_messenger.cpp

--- a/device/api/umd/device/arc_telemetry_reader.h
+++ b/device/api/umd/device/arc_telemetry_reader.h
@@ -11,8 +11,6 @@ namespace tt::umd {
 
 class ArcTelemetryReader {
 public:
-    ArcTelemetryReader(TTDevice* tt_device);
-
     virtual ~ArcTelemetryReader() = default;
 
     virtual uint32_t read_entry(const uint8_t telemetry_tag) = 0;
@@ -22,6 +20,8 @@ public:
     static std::unique_ptr<ArcTelemetryReader> create_arc_telemetry_reader(TTDevice* tt_device);
 
 protected:
+    ArcTelemetryReader(TTDevice* tt_device);
+
     TTDevice* tt_device;
 };
 

--- a/device/api/umd/device/arc_telemetry_reader.h
+++ b/device/api/umd/device/arc_telemetry_reader.h
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "umd/device/tt_device/tt_device.h"
+
+namespace tt::umd {
+
+class ArcTelemetryReader {
+public:
+    ArcTelemetryReader(TTDevice* tt_device);
+
+    virtual ~ArcTelemetryReader() = default;
+
+    virtual uint32_t read_entry(const uint8_t telemetry_tag) = 0;
+
+    virtual bool is_entry_available(const uint8_t telemetry_tag) = 0;
+
+    static std::unique_ptr<ArcTelemetryReader> create_arc_telemetry_reader(TTDevice* tt_device);
+
+protected:
+    TTDevice* tt_device;
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/blackhole_arc_telemetry_reader.h
+++ b/device/api/umd/device/blackhole_arc_telemetry_reader.h
@@ -5,10 +5,8 @@
  */
 #pragma once
 
+#include "umd/device/arc_telemetry_reader.h"
 #include "umd/device/blackhole_implementation.h"
-#include "umd/device/tt_core_coordinates.h"
-#include "umd/device/tt_device/tt_device.h"
-#include "umd/device/types/blackhole_telemetry.h"
 
 extern bool umd_use_noc1;
 
@@ -16,13 +14,13 @@ namespace tt::umd {
 
 namespace blackhole {
 
-class BlackholeArcTelemetryReader {
+class BlackholeArcTelemetryReader : public ArcTelemetryReader {
 public:
     BlackholeArcTelemetryReader(TTDevice* tt_device);
 
-    uint32_t read_entry(const uint8_t telemetry_tag);
+    uint32_t read_entry(const uint8_t telemetry_tag) override;
 
-    bool is_entry_available(const uint8_t telemetry_tag);
+    bool is_entry_available(const uint8_t telemetry_tag) override;
 
 private:
     void initialize_telemetry();

--- a/device/api/umd/device/blackhole_arc_telemetry_reader.h
+++ b/device/api/umd/device/blackhole_arc_telemetry_reader.h
@@ -25,8 +25,6 @@ public:
 private:
     void initialize_telemetry();
 
-    TTDevice* tt_device;
-
     // Address of the telemetry table struct on ARC core.
     uint32_t telemetry_table_addr;
 

--- a/device/api/umd/device/tt_device/blackhole_tt_device.h
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.h
@@ -30,6 +30,5 @@ public:
 private:
     static constexpr uint64_t ATU_OFFSET_IN_BH_BAR2 = 0x1200;
     std::set<size_t> iatu_regions_;
-    std::unique_ptr<blackhole::BlackholeArcTelemetryReader> telemetry = nullptr;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -9,6 +9,7 @@
 #include <string_view>
 
 #include "umd/device/arc_messenger.h"
+#include "umd/device/arc_telemetry_reader.h"
 #include "umd/device/architecture_implementation.h"
 #include "umd/device/chip_helpers/tlb_manager.h"
 #include "umd/device/pci_device.hpp"
@@ -38,6 +39,7 @@ class named_mutex;
 namespace tt::umd {
 
 class ArcMessenger;
+class ArcTelemetryReader;
 
 class TTDevice {
 public:
@@ -153,6 +155,7 @@ protected:
     tt::ARCH arch;
     std::unique_ptr<ArcMessenger> arc_messenger_ = nullptr;
     LockManager lock_manager;
+    std::unique_ptr<ArcTelemetryReader> telemetry = nullptr;
 
     bool is_hardware_hung();
 

--- a/device/api/umd/device/types/wormhole_telemetry.h
+++ b/device/api/umd/device/types/wormhole_telemetry.h
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+namespace tt::umd {
+
+namespace wormhole {
+
+static const uint32_t TELEMETRY_NUMBER_OF_TAGS = 50;
+
+constexpr uint8_t TAG_ENUM_VERSION = 0;
+constexpr uint8_t TAG_DEVICE_ID = 1;
+constexpr uint8_t TAG_ASIC_RO = 2;
+constexpr uint8_t TAG_ASIC_IDD = 3;
+constexpr uint8_t TAG_BOARD_ID_HIGH = 4;
+constexpr uint8_t TAG_BOARD_ID_LOW = 5;
+constexpr uint8_t TAG_ARC0_FW_VERSION = 6;
+constexpr uint8_t TAG_ARC1_FW_VERSION = 7;
+constexpr uint8_t TAG_ARC2_FW_VERSION = 8;
+constexpr uint8_t TAG_ARC3_FW_VERSION = 9;
+constexpr uint8_t TAG_SPIBOOTROM_FW_VERSION = 10;
+constexpr uint8_t TAG_ETH_FW_VERSION = 11;
+constexpr uint8_t TAG_M3_BL_FW_VERSION = 12;
+constexpr uint8_t TAG_M3_APP_FW_VERSION = 13;
+constexpr uint8_t TAG_DDR_STATUS = 14;
+constexpr uint8_t TAG_ETH_STATUS0 = 15;
+constexpr uint8_t TAG_ETH_STATUS1 = 16;
+constexpr uint8_t TAG_PCIE_STATUS = 17;
+constexpr uint8_t TAG_FAULTS = 18;
+constexpr uint8_t TAG_ARC0_HEALTH = 19;
+constexpr uint8_t TAG_ARC1_HEALTH = 20;
+constexpr uint8_t TAG_ARC2_HEALTH = 21;
+constexpr uint8_t TAG_ARC3_HEALTH = 22;
+constexpr uint8_t TAG_FAN_SPEED = 23;
+constexpr uint8_t TAG_AICLK = 24;
+constexpr uint8_t TAG_AXICLK = 25;
+constexpr uint8_t TAG_ARCCLK = 26;
+constexpr uint8_t TAG_THROTTLER = 27;
+constexpr uint8_t TAG_VCORE = 28;
+constexpr uint8_t TAG_ASIC_TEMPERATURE = 29;
+constexpr uint8_t TAG_VREG_TEMPERATURE = 30;
+constexpr uint8_t TAG_BOARD_TEMPERATURE = 31;
+constexpr uint8_t TAG_TDP = 32;
+constexpr uint8_t TAG_TDC = 33;
+constexpr uint8_t TAG_VDD_LIMITS = 34;
+constexpr uint8_t TAG_THM_LIMITS = 35;
+constexpr uint8_t TAG_WH_FW_DATE = 36;
+constexpr uint8_t TAG_ASIC_TMON0 = 37;
+constexpr uint8_t TAG_ASIC_TMON1 = 38;
+constexpr uint8_t TAG_MVDDQ_POWER = 39;
+constexpr uint8_t TAG_GDDR_TRAIN_TEMP0 = 40;
+constexpr uint8_t TAG_GDDR_TRAIN_TEMP1 = 41;
+constexpr uint8_t TAG_BOOT_DATE = 42;
+constexpr uint8_t TAG_RT_SECONDS = 43;
+constexpr uint8_t TAG_ETH_DEBUG_STATUS0 = 44;
+constexpr uint8_t TAG_ETH_DEBUG_STATUS1 = 45;
+constexpr uint8_t TAG_TT_FLASH_VERSION = 46;
+constexpr uint8_t TAG_ETH_LOOPBACK_STATUS = 47;
+constexpr uint8_t TAG_ETH_LIVE_STATUS = 48;
+constexpr uint8_t TAG_FW_BUNDLE_VERSION = 49;
+
+}  // namespace wormhole
+
+}  // namespace tt::umd

--- a/device/api/umd/device/wormhole_arc_telemetry_reader.h
+++ b/device/api/umd/device/wormhole_arc_telemetry_reader.h
@@ -28,8 +28,6 @@ private:
 
     void verify_telemetry();
 
-    std::unique_ptr<ArcMessenger> arc_messenger;
-
     uint64_t telemetry_base_noc_addr;
 
     // During initialization of telemetry, if the NOC0 is hung then we need to read the telemetry values from NOC1.

--- a/device/api/umd/device/wormhole_arc_telemetry_reader.h
+++ b/device/api/umd/device/wormhole_arc_telemetry_reader.h
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "umd/device/arc_messenger.h"
+#include "umd/device/arc_telemetry_reader.h"
+#include "umd/device/wormhole_implementation.h"
+
+extern bool umd_use_noc1;
+
+namespace tt::umd {
+
+namespace wormhole {
+
+class WormholeArcTelemetryReader : public ArcTelemetryReader {
+public:
+    WormholeArcTelemetryReader(TTDevice* tt_device);
+
+    uint32_t read_entry(const uint8_t telemetry_tag) override;
+
+    bool is_entry_available(const uint8_t telemetry_tag) override;
+
+private:
+    void initialize_telemetry();
+
+    void verify_telemetry();
+
+    std::unique_ptr<ArcMessenger> arc_messenger;
+
+    uint64_t telemetry_base_noc_addr;
+
+    // During initialization of telemetry, if the NOC0 is hung then we need to read the telemetry values from NOC1.
+    const tt_xy_pair arc_core = !umd_use_noc1
+                                    ? tt::umd::wormhole::ARC_CORES_NOC0[0]
+                                    : tt_xy_pair(
+                                          tt::umd::wormhole::NOC0_X_TO_NOC1_X[tt::umd::wormhole::ARC_CORES_NOC0[0].x],
+                                          tt::umd::wormhole::NOC0_Y_TO_NOC1_Y[tt::umd::wormhole::ARC_CORES_NOC0[0].y]);
+};
+
+}  // namespace wormhole
+
+}  // namespace tt::umd

--- a/device/arc_telemetry_reader.cpp
+++ b/device/arc_telemetry_reader.cpp
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "umd/device/arc_telemetry_reader.h"
+
+#include "umd/device/blackhole_arc_telemetry_reader.h"
+#include "umd/device/wormhole_arc_telemetry_reader.h"
+
+namespace tt::umd {
+
+ArcTelemetryReader::ArcTelemetryReader(TTDevice* tt_device) : tt_device(tt_device) {}
+
+std::unique_ptr<ArcTelemetryReader> ArcTelemetryReader::create_arc_telemetry_reader(TTDevice* tt_device) {
+    switch (tt_device->get_arch()) {
+        case tt::ARCH::WORMHOLE_B0:
+            return std::make_unique<wormhole::WormholeArcTelemetryReader>(tt_device);
+        case tt::ARCH::BLACKHOLE:
+            return std::make_unique<blackhole::BlackholeArcTelemetryReader>(tt_device);
+        default:
+            throw std::runtime_error("Unsupported architecture for creating Arc telemetry reader.");
+    }
+}
+
+}  // namespace tt::umd

--- a/device/blackhole/blackhole_arc_telemetry_reader.cpp
+++ b/device/blackhole/blackhole_arc_telemetry_reader.cpp
@@ -7,11 +7,13 @@
 
 #include <fmt/core.h>
 
+#include "umd/device/types/blackhole_telemetry.h"
+
 namespace tt::umd {
 
 namespace blackhole {
 
-BlackholeArcTelemetryReader::BlackholeArcTelemetryReader(TTDevice* tt_device) : tt_device(tt_device) {
+BlackholeArcTelemetryReader::BlackholeArcTelemetryReader(TTDevice* tt_device) : ArcTelemetryReader(tt_device) {
     initialize_telemetry();
 }
 

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -12,9 +12,7 @@
 namespace tt::umd {
 
 BlackholeTTDevice::BlackholeTTDevice(std::unique_ptr<PCIDevice> pci_device) :
-    TTDevice(std::move(pci_device), std::make_unique<blackhole_implementation>()) {
-    telemetry = std::make_unique<blackhole::BlackholeArcTelemetryReader>(this);
-}
+    TTDevice(std::move(pci_device), std::make_unique<blackhole_implementation>()) {}
 
 BlackholeTTDevice::~BlackholeTTDevice() {
     // Turn off iATU for the regions we programmed.  This won't happen if the

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -26,6 +26,7 @@ TTDevice::TTDevice(
     arch(architecture_impl_->get_architecture()) {
     lock_manager.initialize_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num(), false);
     arc_messenger_ = ArcMessenger::create_arc_messenger(this);
+    telemetry = ArcTelemetryReader::create_arc_telemetry_reader(this);
 }
 
 /* static */ std::unique_ptr<TTDevice> TTDevice::create(int pci_device_number) {

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "umd/device/tt_device/wormhole_tt_device.h"
 
+#include "umd/device/types/wormhole_telemetry.h"
 #include "umd/device/wormhole_implementation.h"
 
 namespace tt::umd {
@@ -62,27 +63,8 @@ uint32_t WormholeTTDevice::get_clock() {
 }
 
 BoardType WormholeTTDevice::get_board_type() {
-    ::std::vector<uint32_t> arc_msg_return_values = {0};
-    static const uint32_t timeout_ms = 1000;
-    uint32_t exit_code = get_arc_messenger()->send_message(
-        tt::umd::wormhole::ARC_MSG_COMMON_PREFIX |
-            (uint32_t)tt::umd::wormhole::arc_message_type::GET_SMBUS_TELEMETRY_ADDR,
-        arc_msg_return_values,
-        0,
-        0,
-        timeout_ms);
-
-    tt_xy_pair arc_core = tt::umd::wormhole::ARC_CORES_NOC0[0];
-    static constexpr uint64_t noc_telemetry_offset = 0x810000000;
-    uint64_t telemetry_struct_offset = arc_msg_return_values[0] + noc_telemetry_offset;
-
-    uint32_t board_id_lo;
-    uint32_t board_id_hi;
-    static uint64_t board_id_hi_telemetry_offset = 16;
-    static uint64_t board_id_lo_telemetry_offset = 20;
-    read_from_device(&board_id_hi, arc_core, telemetry_struct_offset + board_id_hi_telemetry_offset, sizeof(uint32_t));
-    read_from_device(&board_id_lo, arc_core, telemetry_struct_offset + board_id_lo_telemetry_offset, sizeof(uint32_t));
-
+    uint32_t board_id_lo = telemetry->read_entry(tt::umd::wormhole::TAG_BOARD_ID_LOW);
+    uint32_t board_id_hi = telemetry->read_entry(tt::umd::wormhole::TAG_BOARD_ID_HIGH);
     return get_board_type_from_board_id(((uint64_t)board_id_hi << 32) | board_id_lo);
 }
 

--- a/device/wormhole/wormhole_arc_telemetry_reader.cpp
+++ b/device/wormhole/wormhole_arc_telemetry_reader.cpp
@@ -11,15 +11,14 @@ namespace tt::umd {
 
 namespace wormhole {
 
-WormholeArcTelemetryReader::WormholeArcTelemetryReader(TTDevice* tt_device) :
-    ArcTelemetryReader(tt_device), arc_messenger(ArcMessenger::create_arc_messenger(tt_device)) {
+WormholeArcTelemetryReader::WormholeArcTelemetryReader(TTDevice* tt_device) : ArcTelemetryReader(tt_device) {
     initialize_telemetry();
 }
 
 void WormholeArcTelemetryReader::initialize_telemetry() {
     std::vector<uint32_t> arc_msg_return_values = {0};
     static const uint32_t timeout_ms = 1000;
-    uint32_t exit_code = arc_messenger->send_message(
+    uint32_t exit_code = tt_device->get_arc_messenger()->send_message(
         tt::umd::wormhole::ARC_MSG_COMMON_PREFIX |
             (uint32_t)tt::umd::wormhole::arc_message_type::GET_SMBUS_TELEMETRY_ADDR,
         arc_msg_return_values,

--- a/device/wormhole/wormhole_arc_telemetry_reader.cpp
+++ b/device/wormhole/wormhole_arc_telemetry_reader.cpp
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "umd/device/wormhole_arc_telemetry_reader.h"
+
+#include "umd/device/types/wormhole_telemetry.h"
+
+namespace tt::umd {
+
+namespace wormhole {
+
+WormholeArcTelemetryReader::WormholeArcTelemetryReader(TTDevice* tt_device) :
+    ArcTelemetryReader(tt_device), arc_messenger(ArcMessenger::create_arc_messenger(tt_device)) {
+    initialize_telemetry();
+}
+
+void WormholeArcTelemetryReader::initialize_telemetry() {
+    std::vector<uint32_t> arc_msg_return_values = {0};
+    static const uint32_t timeout_ms = 1000;
+    uint32_t exit_code = arc_messenger->send_message(
+        tt::umd::wormhole::ARC_MSG_COMMON_PREFIX |
+            (uint32_t)tt::umd::wormhole::arc_message_type::GET_SMBUS_TELEMETRY_ADDR,
+        arc_msg_return_values,
+        0,
+        0,
+        timeout_ms);
+
+    static constexpr uint64_t noc_telemetry_offset = 0x810000000;
+    telemetry_base_noc_addr = arc_msg_return_values[0] + noc_telemetry_offset;
+    verify_telemetry();
+}
+
+void WormholeArcTelemetryReader::verify_telemetry() {
+    uint32_t vendor_id = read_entry(tt::umd::wormhole::TAG_DEVICE_ID);
+    constexpr uint32_t tt_vendor_id = 0x1e52;
+    if ((vendor_id & 0xFFFF) != tt_vendor_id) {
+        throw std::runtime_error(
+            fmt::format("Tenstorrent vendor ID mismatch. Expected: 0x{:x}, Got: 0x{:x}", tt_vendor_id, vendor_id));
+    }
+}
+
+uint32_t WormholeArcTelemetryReader::read_entry(const uint8_t telemetry_tag) {
+    if (!is_entry_available(telemetry_tag)) {
+        throw std::runtime_error(fmt::format(
+            "Telemetry entry {} not available. You can use is_entry_available() to check if the entry is available.",
+            telemetry_tag));
+    }
+
+    uint32_t telemetry_value;
+    tt_device->read_from_device(
+        &telemetry_value, arc_core, telemetry_base_noc_addr + telemetry_tag * sizeof(uint32_t), sizeof(uint32_t));
+
+    return telemetry_value;
+}
+
+bool WormholeArcTelemetryReader::is_entry_available(const uint8_t telemetry_tag) {
+    return telemetry_tag >= 0 && telemetry_tag < tt::umd::wormhole::TELEMETRY_NUMBER_OF_TAGS;
+}
+
+}  // namespace wormhole
+}  // namespace tt::umd

--- a/tests/blackhole/test_arc_telemetry_bh.cpp
+++ b/tests/blackhole/test_arc_telemetry_bh.cpp
@@ -34,7 +34,7 @@ TEST(BlackholeTelemetry, BlackholeTelemetryEntryAvailable) {
         EXPECT_TRUE(blackhole_arc_telemetry_reader->is_entry_available(blackhole::TAG_BOARD_ID_HIGH));
         EXPECT_TRUE(blackhole_arc_telemetry_reader->is_entry_available(blackhole::TAG_BOARD_ID_LOW));
 
-        // Blackhole tag table is still not finalized, but we are probably never going to have 1000 tags.
-        EXPECT_FALSE(blackhole_arc_telemetry_reader->is_entry_available(1000));
+        // Blackhole tag table is still not finalized, but we are probably never going to have 200 tags.
+        EXPECT_FALSE(blackhole_arc_telemetry_reader->is_entry_available(200));
     }
 }

--- a/tests/blackhole/test_arc_telemetry_bh.cpp
+++ b/tests/blackhole/test_arc_telemetry_bh.cpp
@@ -22,3 +22,19 @@ TEST(BlackholeTelemetry, BasicBlackholeTelemetry) {
         EXPECT_NO_THROW(get_board_type_from_board_id(board_id));
     }
 }
+
+TEST(BlackholeTelemetry, BlackholeTelemetryEntryAvailable) {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+
+    for (int pci_device_id : pci_device_ids) {
+        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<ArcTelemetryReader> blackhole_arc_telemetry_reader =
+            ArcTelemetryReader::create_arc_telemetry_reader(tt_device.get());
+
+        EXPECT_TRUE(blackhole_arc_telemetry_reader->is_entry_available(blackhole::TAG_BOARD_ID_HIGH));
+        EXPECT_TRUE(blackhole_arc_telemetry_reader->is_entry_available(blackhole::TAG_BOARD_ID_LOW));
+
+        // Blackhole tag table is still not finalized, but we are probably never going to have 1000 tags.
+        EXPECT_FALSE(blackhole_arc_telemetry_reader->is_entry_available(1000));
+    }
+}

--- a/tests/wormhole/CMakeLists.txt
+++ b/tests/wormhole/CMakeLists.txt
@@ -3,6 +3,7 @@ set(UNIT_TESTS_WH_SRCS
     test_umd_remote_api_stability.cpp
     test_arc_messages_wh.cpp
     test_remote_communication_wh.cpp
+    test_arc_telemetry_wh.cpp
 )
 
 add_executable(unit_tests_wormhole ${UNIT_TESTS_WH_SRCS})

--- a/tests/wormhole/test_arc_telemetry_wh.cpp
+++ b/tests/wormhole/test_arc_telemetry_wh.cpp
@@ -22,3 +22,19 @@ TEST(WormholeTelemetry, BasicWormholeTelemetry) {
         EXPECT_NO_THROW(get_board_type_from_board_id(board_id));
     }
 }
+
+TEST(WormholeTelemetry, WormholeTelemetryEntryAvailable) {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+
+    for (int pci_device_id : pci_device_ids) {
+        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<ArcTelemetryReader> telemetry =
+            ArcTelemetryReader::create_arc_telemetry_reader(tt_device.get());
+
+        for (uint32_t telem_tag = 0; telem_tag < wormhole::TELEMETRY_NUMBER_OF_TAGS; telem_tag++) {
+            EXPECT_TRUE(telemetry->is_entry_available(telem_tag));
+        }
+
+        EXPECT_FALSE(telemetry->is_entry_available(wormhole::TELEMETRY_NUMBER_OF_TAGS));
+    }
+}

--- a/tests/wormhole/test_arc_telemetry_wh.cpp
+++ b/tests/wormhole/test_arc_telemetry_wh.cpp
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "gtest/gtest.h"
 #include "umd/device/arc_telemetry_reader.h"
-#include "umd/device/types/blackhole_telemetry.h"
+#include "umd/device/types/wormhole_telemetry.h"
 
 using namespace tt::umd;
 
-TEST(BlackholeTelemetry, BasicBlackholeTelemetry) {
+TEST(WormholeTelemetry, BasicWormholeTelemetry) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     for (int pci_device_id : pci_device_ids) {
@@ -15,8 +15,8 @@ TEST(BlackholeTelemetry, BasicBlackholeTelemetry) {
         std::unique_ptr<ArcTelemetryReader> blackhole_arc_telemetry_reader =
             ArcTelemetryReader::create_arc_telemetry_reader(tt_device.get());
 
-        uint32_t board_id_high = blackhole_arc_telemetry_reader->read_entry(blackhole::TAG_BOARD_ID_HIGH);
-        uint32_t board_id_low = blackhole_arc_telemetry_reader->read_entry(blackhole::TAG_BOARD_ID_LOW);
+        uint32_t board_id_high = blackhole_arc_telemetry_reader->read_entry(wormhole::TAG_BOARD_ID_HIGH);
+        uint32_t board_id_low = blackhole_arc_telemetry_reader->read_entry(wormhole::TAG_BOARD_ID_LOW);
 
         const uint64_t board_id = ((uint64_t)board_id_high << 32) | (board_id_low);
         EXPECT_NO_THROW(get_board_type_from_board_id(board_id));


### PR DESCRIPTION
### Issue

#508 

### Description

Implement telemetry reader class. This class should hide the details of reading the telemetry on Wormhole and Blackhole. It provides simple API to check whether some tag is present in the telemetry and read the appropriate tag value. 

### List of the changes

- Implement base telemetry reader class
- Derive wh and bh telemetry readers and move logic to these classes
- Use telemetry reader class wherever it is needed to read the telemetry
- Add tags for Wormhole telemetry

### Testing

CI. A lot of tests are going through telemetry to get basic info about the device so that is a good test in itself. Additional tests added for each architecture 

### API Changes
/