### PR TITLE
Remove ARCH_NAME for tests build

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -24,17 +24,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-group: [
-          {arch: wormhole_b0},
-          {arch: blackhole},
-        ]
         ubuntu-version: [
           'ubuntu-22.04',
           # 'ubuntu-20.04',
         ]
     uses: ./.github/workflows/build-tests.yml
     with:
-      arch: ${{ matrix.test-group.arch}}
       ubuntu-version: ${{ matrix.ubuntu-version}}
       timeout: 15
       build-type: ${{ inputs.build-type || 'Release' }}

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -5,9 +5,6 @@ name: Build Target
 on:
   workflow_call:
     inputs:
-      arch:
-        required: true
-        type: string
       ubuntu-version:
         required: true
         type: string
@@ -20,13 +17,6 @@ on:
         default: Release
   workflow_dispatch:
     inputs:
-      arch:
-        required: true
-        description: 'The architecture to build for'
-        type: choice
-        options:
-          - wormhole_b0
-          - blackhole
       ubuntu-version:
         required: true
         description: 'The version of Ubuntu to build on'
@@ -54,14 +44,11 @@ jobs:
     # Due to parsing bug, fromJSON is used to convert string to number
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
 
-    name: Build umd_tests for ${{ inputs.arch }} on ${{ inputs.ubuntu-version }}
+    name: Build umd_tests on ${{ inputs.ubuntu-version }}
     runs-on: ${{ inputs.ubuntu-version }}
     container:
       image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-version }}:latest
       options: --user root
-
-    env:
-      ARCH_NAME: ${{ inputs.arch }}
 
     steps:
       - uses: actions/checkout@v4
@@ -90,5 +77,5 @@ jobs:
       - name: Upload build artifacts archive
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts-${{ inputs.arch }}-${{ inputs.ubuntu-version }}
+          name: build-artifacts-${{ inputs.ubuntu-version }}
           path: artifact.tar

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,33 +16,6 @@ on:
       timeout:
         required: true
         type: number
-  workflow_dispatch:
-    inputs:
-      arch:
-        required: true
-        description: 'The architecture to build for'
-        type: choice
-        options:
-          - wormhole_b0
-          - blackhole
-      ubuntu-version:
-        required: true
-        description: 'The version of Ubuntu to build on'
-        type: choice
-        options:
-          - ubuntu-22.04
-          - ubuntu-20.04
-      card:
-        required: true
-        description: 'The card to run tests on'
-        type: choice
-        options:
-          - n150
-          - n300
-      timeout:
-        required: true
-        description: 'The timeout for the build job in minutes'
-        type: number
 
 env:
   BUILD_OUTPUT_DIR: ./build
@@ -68,7 +41,6 @@ jobs:
         - /opt/tt_metal_infra/provisioning/provisioning_env:/opt/tt_metal_infra/provisioning/provisioning_env
 
     env:
-      ARCH_NAME: ${{ inputs.arch }}
       LD_LIBRARY_PATH: ./build/lib
 
     steps:
@@ -81,7 +53,7 @@ jobs:
       - name: Use build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: build-artifacts-${{ inputs.arch }}-${{ inputs.ubuntu-version }}
+          name: build-artifacts-${{ inputs.ubuntu-version }}
           path: ./
 
       # This is needed to preserve file permissions

--- a/README.emu.md
+++ b/README.emu.md
@@ -74,8 +74,6 @@ if [ "${APPTAINER_NAME}" == "emulation_rocky8.sif" ]; then
     module load python
     source /opt/rh/gcc-toolset-10/enable     # for gcc 10
 	export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
-
-    export ARCH_NAME=grayskull
 fi
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ cmake -B build -G Ninja
 cmake --build build
 ```
 
-Tests are build separatelly for each architecture.
-Specify the `ARCH_NAME` environment variable as `grayskull`,  `wormhole_b0` or `blackhole` before building.
 You also need to configure cmake to enable tests, hence the need to run cmake configuration step again.
 To build tests:
 ```

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,4 @@
 add_library(firmware INTERFACE)
 add_library(${PROJECT_NAME}::Firmware ALIAS firmware)
 
-target_include_directories(
-    firmware
-    INTERFACE
-        $<$<STREQUAL:$ENV{ARCH_NAME},wormhole_b0>:${CMAKE_CURRENT_SOURCE_DIR}/firmware/riscv/wormhole>
-        $<$<STREQUAL:$ENV{ARCH_NAME},grayskull>:${CMAKE_CURRENT_SOURCE_DIR}/firmware/riscv/grayskull>
-        $<$<STREQUAL:$ENV{ARCH_NAME},blackhole>:${CMAKE_CURRENT_SOURCE_DIR}/firmware/riscv/blackhole>
-        firmware/riscv
-)
+target_include_directories(firmware INTERFACE firmware/riscv)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,3 @@
-# Tests currently depend on ARCH_NAME for compile time include paths
-if(NOT DEFINED ENV{ARCH_NAME})
-    message(FATAL_ERROR "Please set ARCH_NAME to grayskull, wormhole_b0, or blackhole")
-endif(NOT DEFINED ENV{ARCH_NAME})
-
 add_library(test_common INTERFACE)
 target_link_libraries(
     test_common
@@ -59,27 +54,20 @@ if(MASTER_PROJECT)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/microbenchmark)
 endif()
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/api)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/blackhole)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/misc)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/pcie)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/simulation)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/unified)
-if($ENV{ARCH_NAME} STREQUAL "wormhole_b0")
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/wormhole)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/galaxy)
-    add_custom_target(
-        umd_unit_tests
-        DEPENDS
-            unit_tests_wormhole
-            unit_tests_glx
-    )
-else()
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/$ENV{ARCH_NAME})
-endif()
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/wormhole)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/galaxy)
 
 add_custom_target(
     umd_tests
     DEPENDS
-        umd_unit_tests
+        unit_tests_blackhole
+        unit_tests_wormhole
+        unit_tests_glx
         simulation_tests
         test_pcie_device
         api_tests

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -12,7 +12,6 @@
 #include <vector>
 
 #include "fmt/xchar.h"
-#include "l1_address_map.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "umd/device/blackhole_implementation.h"
 #include "umd/device/chip/local_chip.h"
@@ -245,7 +244,8 @@ TEST(ClusterAPI, DynamicTLB_RW) {
 
     std::set<chip_id_t> target_devices = cluster->get_target_device_ids();
     for (const chip_id_t chip : target_devices) {
-        std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
+        // Just make sure to skip L1_BARRIER_BASE
+        std::uint32_t address = 0x100;
         // Write to each core a 100 times at different statically mapped addresses
         const tt_SocDescriptor& soc_desc = cluster->get_soc_descriptor(chip);
         std::vector<CoreCoord> tensix_cores = soc_desc.get_cores(CoreType::TENSIX);

--- a/tests/api/test_mockup_device.cpp
+++ b/tests/api/test_mockup_device.cpp
@@ -16,35 +16,12 @@
 
 namespace test::mockup_device {
 
-std::string get_env_arch_name() {
-    constexpr std::string_view ARCH_NAME_ENV_VAR = "ARCH_NAME";
-    if (const char *arch_name_ptr = std::getenv(ARCH_NAME_ENV_VAR.data())) {
-        return arch_name_ptr;
-    }
-    throw std::runtime_error("Environment variable ARCH_NAME is not set.");
-}
-
-std::string get_soc_descriptor_file(tt::ARCH arch) {
-    // const std::string umd_root = get_umd_root();
-
-    switch (arch) {
-        case tt::ARCH::GRAYSKULL:
-            return test_utils::GetAbsPath("tests/soc_descs/grayskull_10x12.yaml");
-        case tt::ARCH::WORMHOLE_B0:
-            return test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml");
-        case tt::ARCH::BLACKHOLE:
-            return test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml");
-        case tt::ARCH::Invalid:
-            throw std::runtime_error("Invalid arch not supported");
-        default:
-            throw std::runtime_error("Unsupported device architecture");
-    }
-}
-
 TEST(ApiMockupTest, CreateDevice) {
-    const auto arch = tt::arch_from_str(get_env_arch_name());
     std::cout << "Creating mockup device" << std::endl;
-    auto device_driver = std::make_unique<tt_MockupDevice>(get_soc_descriptor_file(arch));
+    for (auto soc_descriptor_file :
+         {"tests/soc_descs/wormhole_b0_8x10.yaml", "tests/soc_descs/blackhole_140_arch.yaml"}) {
+        auto device_driver = std::make_unique<tt_MockupDevice>(test_utils::GetAbsPath(soc_descriptor_file));
+    }
 }
 
 }  // namespace test::mockup_device

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -4,7 +4,6 @@
 #include <thread>
 
 #include "gtest/gtest.h"
-#include "l1_address_map.h"
 #include "umd/device/blackhole_implementation.h"
 #include "umd/device/cluster.h"
 #include "umd/device/grayskull_implementation.h"
@@ -20,7 +19,7 @@ tt_xy_pair get_any_tensix_core(tt::ARCH arch) {
 TEST(ApiTTDeviceTest, BasicTTDeviceIO) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
-    uint64_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
+    uint64_t address = 0x0;
     std::vector<uint32_t> data_write = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     std::vector<uint32_t> data_read(data_write.size(), 0);
 
@@ -58,7 +57,7 @@ TEST(ApiTTDeviceTest, TTDeviceMultipleThreadsIO) {
 
     std::vector<uint32_t> data_write = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
-    const uint64_t address_thread0 = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
+    const uint64_t address_thread0 = 0x0;
     const uint64_t address_thread1 = address_thread0 + data_write.size() * sizeof(uint32_t);
     const uint32_t num_loops = 1000;
 

--- a/tests/blackhole/CMakeLists.txt
+++ b/tests/blackhole/CMakeLists.txt
@@ -15,5 +15,3 @@ set_target_properties(
         OUTPUT_NAME
             unit_tests
 )
-
-add_custom_target(umd_unit_tests DEPENDS unit_tests_blackhole)

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -7,10 +7,10 @@
 #include <memory>
 #include <thread>
 
-#include "eth_l1_address_map.h"
+#include "blackhole/eth_l1_address_map.h"
+#include "blackhole/host_mem_address_map.h"
+#include "blackhole/l1_address_map.h"
 #include "gtest/gtest.h"
-#include "host_mem_address_map.h"
-#include "l1_address_map.h"
 #include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "umd/device/blackhole_implementation.h"

--- a/tests/galaxy/test_umd_concurrent_threads.cpp
+++ b/tests/galaxy/test_umd_concurrent_threads.cpp
@@ -7,16 +7,16 @@
 #include <thread>
 
 #include "common/logger.hpp"
-#include "eth_interface.h"
 #include "gtest/gtest.h"
-#include "host_mem_address_map.h"
-#include "l1_address_map.h"
 #include "test_galaxy_common.h"
 #include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/wormhole/test_wh_common.h"
 #include "umd/device/cluster.h"
 #include "umd/device/tt_cluster_descriptor.h"
+#include "wormhole/eth_interface.h"
+#include "wormhole/host_mem_address_map.h"
+#include "wormhole/l1_address_map.h"
 
 static const std::string SOC_DESC_PATH = "tests/soc_descs/wormhole_b0_8x10.yaml";
 

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -6,16 +6,16 @@
 #include <numeric>
 
 #include "common/logger.hpp"
-#include "eth_interface.h"
 #include "gtest/gtest.h"
-#include "host_mem_address_map.h"
-#include "l1_address_map.h"
 #include "test_galaxy_common.h"
 #include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/wormhole/test_wh_common.h"
 #include "umd/device/cluster.h"
 #include "umd/device/tt_cluster_descriptor.h"
+#include "wormhole/eth_interface.h"
+#include "wormhole/host_mem_address_map.h"
+#include "wormhole/l1_address_map.h"
 
 static const std::string SOC_DESC_PATH = "tests/soc_descs/wormhole_b0_8x10.yaml";
 

--- a/tests/galaxy/test_umd_remote_api_stability.cpp
+++ b/tests/galaxy/test_umd_remote_api_stability.cpp
@@ -8,11 +8,8 @@
 #include <thread>
 
 #include "common/logger.hpp"
-#include "eth_interface.h"
 #include "filesystem"
 #include "gtest/gtest.h"
-#include "host_mem_address_map.h"
-#include "l1_address_map.h"
 #include "tests/galaxy/test_galaxy_common.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/test_utils/stimulus_generators.hpp"
@@ -20,6 +17,9 @@
 #include "umd/device/cluster.h"
 #include "umd/device/tt_cluster_descriptor.h"
 #include "umd/device/tt_soc_descriptor.h"
+#include "wormhole/eth_interface.h"
+#include "wormhole/host_mem_address_map.h"
+#include "wormhole/l1_address_map.h"
 
 namespace tt::umd::test::utils {
 

--- a/tests/microbenchmark/device_fixture.hpp
+++ b/tests/microbenchmark/device_fixture.hpp
@@ -9,7 +9,6 @@
 #include <iostream>
 #include <random>
 
-#include "l1_address_map.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "umd/device/cluster.h"
 #include "umd/device/tt_soc_descriptor.h"

--- a/tests/microbenchmark/test_rw_tensix.cpp
+++ b/tests/microbenchmark/test_rw_tensix.cpp
@@ -18,7 +18,7 @@ std::uint32_t generate_random_address(std::uint32_t max, std::uint32_t min = 0) 
 
 TEST_F(uBenchmarkFixture, WriteAllCores32Bytes) {
     std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7};
-    std::uint64_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
+    std::uint64_t address = 0x100;
     std::uint64_t bad_address = 0x30000000;  // this address is not mapped, should trigger fallback write/read path
 
     ankerl::nanobench::Bench bench_static;
@@ -48,7 +48,7 @@ TEST_F(uBenchmarkFixture, WriteAllCores32Bytes) {
 
 TEST_F(uBenchmarkFixture, ReadAllCores32Bytes) {
     std::vector<uint32_t> readback_vec = {};
-    std::uint64_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
+    std::uint64_t address = 0x100;
     std::uint64_t bad_address = 0x30000000;  // this address is not mapped, should trigger fallback write/read path
 
     ankerl::nanobench::Bench bench_static;

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -4,15 +4,15 @@
 #include <memory>
 #include <thread>
 
-#include "eth_l1_address_map.h"
 #include "gtest/gtest.h"
-#include "host_mem_address_map.h"
-#include "l1_address_map.h"
 #include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "umd/device/cluster.h"
 #include "umd/device/tt_cluster_descriptor.h"
 #include "umd/device/wormhole_implementation.h"
+#include "wormhole/eth_l1_address_map.h"
+#include "wormhole/host_mem_address_map.h"
+#include "wormhole/l1_address_map.h"
 
 using namespace tt::umd;
 

--- a/tests/wormhole/test_remote_communication_wh.cpp
+++ b/tests/wormhole/test_remote_communication_wh.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include "gtest/gtest.h"
-#include "host_mem_address_map.h"
-#include "l1_address_map.h"
 #include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "umd/device/cluster.h"
@@ -11,6 +9,8 @@
 #include "umd/device/tt_cluster_descriptor.h"
 #include "umd/device/types/cluster_types.h"
 #include "umd/device/wormhole_implementation.h"
+#include "wormhole/host_mem_address_map.h"
+#include "wormhole/l1_address_map.h"
 
 using namespace tt::umd;
 

--- a/tests/wormhole/test_umd_remote_api_stability.cpp
+++ b/tests/wormhole/test_umd_remote_api_stability.cpp
@@ -10,17 +10,17 @@
 #include <thread>
 
 #include "common/logger.hpp"
-#include "eth_interface.h"
 #include "filesystem"
 #include "gtest/gtest.h"
-#include "host_mem_address_map.h"
-#include "l1_address_map.h"
 #include "test_wh_common.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/test_utils/stimulus_generators.hpp"
 #include "umd/device/cluster.h"
 #include "umd/device/tt_cluster_descriptor.h"
 #include "umd/device/tt_soc_descriptor.h"
+#include "wormhole/eth_interface.h"
+#include "wormhole/host_mem_address_map.h"
+#include "wormhole/l1_address_map.h"
 
 namespace tt::umd::test::utils {
 class WormholeNebulaX2TestFixture : public WormholeTestFixture {

--- a/tests/wormhole/test_wh_common.h
+++ b/tests/wormhole/test_wh_common.h
@@ -5,12 +5,12 @@
  */
 #pragma once
 
-#include "eth_l1_address_map.h"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/test_utils/stimulus_generators.hpp"
 #include "umd/device/cluster.h"
 #include "umd/device/tt_cluster_descriptor.h"
 #include "umd/device/tt_xy_pair.h"
+#include "wormhole/eth_l1_address_map.h"
 
 constexpr std::uint32_t DRAM_BARRIER_BASE = 0;
 

--- a/tests/wormhole/test_wh_common.h
+++ b/tests/wormhole/test_wh_common.h
@@ -11,6 +11,7 @@
 #include "umd/device/tt_cluster_descriptor.h"
 #include "umd/device/tt_xy_pair.h"
 #include "wormhole/eth_l1_address_map.h"
+#include "wormhole/l1_address_map.h"
 
 constexpr std::uint32_t DRAM_BARRIER_BASE = 0;
 


### PR DESCRIPTION
### Issue
Fixes #270 

### Description
ARCH_NAME removal was done a while back for the lib, but not for tests.
This change now removes ARCH_NAME completely.

### List of the changes
- remove ARCH_NAME and per arch build in github workflows
- remove ARCH_NAME mentions from README
- Remove including firmware/riscv/ARCH_NAME from cmaketests
- Build both bh and wh unit tests
- Alter tests to have specific wormhole or blackhole include instead
- Change addresses in test to use random hardcoded address instead of random constant
- Change mockup test to try both wh and bh


### Testing
CI tests on this PR should be enough.

### API Changes
There are no API changes in this PR.
