### PR TITLE
Add bare metal CI runs

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -47,6 +47,7 @@ jobs:
           {arch: wormhole_b0, card: tt-beta-ubuntu-2204-n300-large-stable, timeout: 15},
           # TODO: Re-enable when we have a stable card.
           # {arch: blackhole, card: p150, timeout: 15},
+          {arch: baremetal, card: ubuntu-22.04, timeout: 15},
         ]
         ubuntu-version: [
           # Running tests on ubuntu-22.04 should be sufficient. Reduce load on CI.

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - ${{ inputs.card }}
     container:
       image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-version }}:latest
-      options: --user root --device /dev/tenstorrent/0
+      options: --user root ${{ inputs.arch != 'baremetal' && '--device /dev/tenstorrent/0' || '' }}
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -67,6 +67,7 @@ jobs:
           ${{ env.TEST_OUTPUT_DIR }}/umd/api/api_tests
 
       - name: Run arch-specific UMD unit tests
+        if: ${{ inputs.arch != 'baremetal' }}
         run: |
           ${{ env.TEST_OUTPUT_DIR }}/umd/${{ inputs.arch }}/unit_tests
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -2560,7 +2560,9 @@ void Cluster::set_power_state(tt_DevicePowerState device_state) {
             }
         }
     }
-    wait_for_aiclk_value(Cluster::get_target_aiclk_value(arch_name, device_state));
+    if (!all_chip_ids_.empty()) {
+        wait_for_aiclk_value(Cluster::get_target_aiclk_value(arch_name, device_state));
+    }
 }
 
 void Cluster::enable_ethernet_queue(int timeout) {

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -21,20 +21,11 @@
 
 using namespace tt::umd;
 
-inline std::unique_ptr<Cluster> get_cluster() {
-    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    // TODO: Make this test work on a host system without any tt devices.
-    if (pci_device_ids.empty()) {
-        return nullptr;
-    }
-    return std::unique_ptr<Cluster>(new Cluster());
-}
-
 // TODO: Once default auto TLB setup is in, check it is setup properly.
 TEST(ApiChipTest, ManualTLBConfiguration) {
-    std::unique_ptr<Cluster> umd_cluster = get_cluster();
+    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
 
-    if (umd_cluster == nullptr || umd_cluster->get_target_device_ids().empty()) {
+    if (umd_cluster->get_target_device_ids().empty()) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
     }
 
@@ -91,9 +82,9 @@ TEST(ApiChipTest, ManualTLBConfiguration) {
 
 // TODO: Move to test_chip
 TEST(ApiChipTest, SimpleAPIShowcase) {
-    std::unique_ptr<Cluster> umd_cluster = get_cluster();
+    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
 
-    if (umd_cluster == nullptr || umd_cluster->get_target_device_ids().empty()) {
+    if (umd_cluster->get_target_device_ids().empty()) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
     }
 
@@ -108,7 +99,7 @@ TEST(ApiChipTest, SimpleAPIShowcase) {
 // // This tests puts a specific core into reset and then deasserts it using default deassert value
 // // It reads back the risc reset reg to validate
 // TEST(ApiChipTest, DeassertRiscResetOnCore) {
-//     std::unique_ptr<Cluster> umd_cluster = get_cluster();
+//     std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
 
 //     if (umd_cluster == nullptr || umd_cluster->get_target_device_ids().empty()) {
 //         GTEST_SKIP() << "No chips present on the system. Skipping test.";
@@ -131,7 +122,7 @@ TEST(ApiChipTest, SimpleAPIShowcase) {
 // // This tests puts a specific core into reset and then specifies a legal deassert value
 // // It reads back the risc reset reg to validate
 // TEST(ApiChipTest, SpecifyLegalDeassertRiscResetOnCore) {
-//     std::unique_ptr<Cluster> umd_cluster = get_cluster();
+//     std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
 
 //     if (umd_cluster == nullptr || umd_cluster->get_target_device_ids().empty()) {
 //         GTEST_SKIP() << "No chips present on the system. Skipping test.";
@@ -153,7 +144,7 @@ TEST(ApiChipTest, SimpleAPIShowcase) {
 // // // This tests puts a specific core into reset and then specifies an illegal deassert value
 // // // It reads back the risc reset reg to validate that reset reg is in a legal state
 // TEST(ApiChipTest, SpecifyIllegalDeassertRiscResetOnCore) {
-//     std::unique_ptr<Cluster> umd_cluster = get_cluster();
+//     std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
 
 //     if (umd_cluster == nullptr || umd_cluster->get_target_device_ids().empty()) {
 //         GTEST_SKIP() << "No chips present on the system. Skipping test.";

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -308,28 +308,27 @@ TEST(TestCluster, TestClusterLogicalETHChannelsConnectivity) {
 TEST(TestCluster, TestClusterAICLKControl) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
-    uint32_t go_busy_aiclk_val;
-    uint32_t go_idle_aiclk_val;
-    tt::ARCH arch = cluster->get_cluster_description()->get_arch(0);
-    if (arch == tt::ARCH::WORMHOLE_B0) {
-        go_busy_aiclk_val = tt::umd::wormhole::AICLK_BUSY_VAL;
-        go_idle_aiclk_val = tt::umd::wormhole::AICLK_IDLE_VAL;
-    } else if (arch == tt::ARCH::BLACKHOLE) {
-        go_busy_aiclk_val = tt::umd::blackhole::AICLK_BUSY_VAL;
-        go_idle_aiclk_val = tt::umd::blackhole::AICLK_IDLE_VAL;
-    }
+    auto get_expected_clock_val = [&cluster](chip_id_t chip_id, bool busy) {
+        tt::ARCH arch = cluster->get_cluster_description()->get_arch(chip_id);
+        if (arch == tt::ARCH::WORMHOLE_B0) {
+            return busy ? tt::umd::wormhole::AICLK_BUSY_VAL : tt::umd::wormhole::AICLK_IDLE_VAL;
+        } else if (arch == tt::ARCH::BLACKHOLE) {
+            return busy ? tt::umd::blackhole::AICLK_BUSY_VAL : tt::umd::blackhole::AICLK_IDLE_VAL;
+        }
+        return 0u;
+    };
 
     cluster->set_power_state(tt_DevicePowerState::BUSY);
 
     auto clocks = cluster->get_clocks();
     for (auto& clock : clocks) {
-        EXPECT_EQ(clock.second, go_busy_aiclk_val);
+        EXPECT_EQ(clock.second, get_expected_clock_val(clock.first, true));
     }
 
     cluster->set_power_state(tt_DevicePowerState::LONG_IDLE);
 
     clocks = cluster->get_clocks();
     for (auto& clock : clocks) {
-        EXPECT_EQ(clock.second, go_idle_aiclk_val);
+        EXPECT_EQ(clock.second, get_expected_clock_val(clock.first, false));
     }
 }

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -33,43 +33,34 @@ constexpr std::uint32_t L1_BARRIER_BASE = 12;
 constexpr std::uint32_t ETH_BARRIER_BASE = 256 * 1024 - 32;
 constexpr std::uint32_t DRAM_BARRIER_BASE = 0;
 
-inline std::unique_ptr<Cluster> get_cluster() {
-    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    // TODO: Make this test work on a host system without any tt devices.
-    if (pci_device_ids.empty()) {
-        return nullptr;
-    }
-    return std::unique_ptr<Cluster>(new Cluster());
-}
-
 // This test should be one line only.
-TEST(ApiClusterTest, OpenAllChips) { std::unique_ptr<Cluster> umd_cluster = get_cluster(); }
+TEST(ApiClusterTest, OpenAllChips) { std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>(); }
 
 TEST(ApiClusterTest, DifferentConstructors) {
-    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    // TODO: Make this test work on a host system without any tt devices.
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
-
     std::unique_ptr<Cluster> umd_cluster;
 
     // 1. Simplest constructor. Creates Cluster with all the chips available.
     umd_cluster = std::make_unique<Cluster>();
+    bool chips_available = !umd_cluster->get_target_device_ids().empty();
     umd_cluster = nullptr;
 
     // 2. Constructor which allows choosing a subset of Chips to open.
     chip_id_t logical_device_id = 0;
-    std::set<chip_id_t> target_devices = {logical_device_id};
+    std::set<chip_id_t> target_devices = {};
+    if (chips_available) {
+        target_devices = {logical_device_id};
+    }
     umd_cluster = std::make_unique<Cluster>(target_devices);
     umd_cluster = nullptr;
 
-    // 3. Constructor taking a custom soc descriptor in addition.
-    tt::ARCH device_arch = Cluster::create_cluster_descriptor()->get_arch(logical_device_id);
-    // You can add a custom soc descriptor here.
-    std::string sdesc_path = tt_SocDescriptor::get_soc_descriptor_path(device_arch);
-    umd_cluster = std::make_unique<Cluster>(sdesc_path, target_devices);
-    umd_cluster = nullptr;
+    if (chips_available) {
+        // 3. Constructor taking a custom soc descriptor in addition.
+        tt::ARCH device_arch = Cluster::create_cluster_descriptor()->get_arch(logical_device_id);
+        // You can add a custom soc descriptor here.
+        std::string sdesc_path = tt_SocDescriptor::get_soc_descriptor_path(device_arch);
+        umd_cluster = std::make_unique<Cluster>(sdesc_path, target_devices);
+        umd_cluster = nullptr;
+    }
 
     // 4. Constructor taking cluster descriptor based on which to create cluster.
     // Create mock chips is set to true in order to create mock chips for the devices in the cluster descriptor.
@@ -80,11 +71,7 @@ TEST(ApiClusterTest, DifferentConstructors) {
 }
 
 TEST(ApiClusterTest, SimpleIOAllChips) {
-    std::unique_ptr<Cluster> umd_cluster = get_cluster();
-
-    if (umd_cluster == nullptr || umd_cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
+    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
 
     const tt_ClusterDescriptor* cluster_desc = umd_cluster->get_cluster_description();
 
@@ -127,11 +114,7 @@ TEST(ApiClusterTest, SimpleIOAllChips) {
 }
 
 TEST(ApiClusterTest, RemoteFlush) {
-    std::unique_ptr<Cluster> umd_cluster = get_cluster();
-
-    if (umd_cluster == nullptr || umd_cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
+    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
 
     const tt_ClusterDescriptor* cluster_desc = umd_cluster->get_cluster_description();
 
@@ -172,14 +155,14 @@ TEST(ApiClusterTest, RemoteFlush) {
 }
 
 TEST(ApiClusterTest, SimpleIOSpecificChips) {
-    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    // TODO: Make this test work on a host system without any tt devices.
-    if (pci_device_ids.empty()) {
+    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
+
+    if (umd_cluster->get_target_device_ids().empty()) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
     }
 
     std::set<chip_id_t> target_devices = {0};
-    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>(target_devices);
+    umd_cluster = std::make_unique<Cluster>(target_devices);
 
     const tt_ClusterDescriptor* cluster_desc = umd_cluster->get_cluster_description();
 
@@ -225,13 +208,7 @@ TEST(ClusterAPI, DynamicTLB_RW) {
     // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for
     // each transaction
 
-    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    // TODO: Make this test work on a host system without any tt devices.
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
-
-    std::unique_ptr<Cluster> cluster = get_cluster();
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
     tt_device_params default_params;
     cluster->start_device(default_params);
@@ -282,13 +259,7 @@ TEST(ClusterAPI, DynamicTLB_RW) {
 }
 
 TEST(TestCluster, PrintAllChipsAllCores) {
-    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    // TODO: Make this test work on a host system without any tt devices.
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
-
-    std::unique_ptr<Cluster> umd_cluster = get_cluster();
+    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
 
     for (chip_id_t chip : umd_cluster->get_target_device_ids()) {
         std::cout << "Chip " << chip << std::endl;
@@ -316,11 +287,6 @@ TEST(TestCluster, PrintAllChipsAllCores) {
 // chip. This is needed because of eth id readouts for Blackhole that don't take harvesting into
 // acount. This test verifies that both for Wormhole and Blackhole.
 TEST(TestCluster, TestClusterLogicalETHChannelsConnectivity) {
-    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    // TODO: Make this test work on a host system without any tt devices.
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
     tt_ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
@@ -341,6 +307,10 @@ TEST(TestCluster, TestClusterLogicalETHChannelsConnectivity) {
 
 TEST(TestCluster, TestClusterNocId) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+
+    if (cluster->get_target_device_ids().empty()) {
+        GTEST_SKIP() << "No chips present on the system. Skipping test.";
+    }
 
     auto read_noc_id_reg = [&](std::unique_ptr<Cluster>& cluster, chip_id_t chip, CoreCoord core) {
         const uint64_t noc_node_id_offset = 0x2C;

--- a/tests/api/test_noc.cpp
+++ b/tests/api/test_noc.cpp
@@ -45,8 +45,6 @@ TEST(TestCluster, TestClusterNoc0Id) {
         }
     };
 
-    tt::ARCH arch = cluster->get_cluster_description()->get_arch(0);
-
     for (chip_id_t chip : cluster->get_target_device_ids()) {
         check_noc_id_cores(cluster, chip, CoreType::TENSIX);
         check_noc_id_harvested_cores(cluster, chip, CoreType::TENSIX);
@@ -54,7 +52,7 @@ TEST(TestCluster, TestClusterNoc0Id) {
         check_noc_id_cores(cluster, chip, CoreType::ETH);
         check_noc_id_harvested_cores(cluster, chip, CoreType::ETH);
 
-        if (arch == tt::ARCH::BLACKHOLE) {
+        if (cluster->get_cluster_description()->get_arch(chip) == tt::ARCH::BLACKHOLE) {
             check_noc_id_cores(cluster, chip, CoreType::DRAM);
             check_noc_id_harvested_cores(cluster, chip, CoreType::DRAM);
         }
@@ -104,8 +102,6 @@ TEST(TestCluster, TestClusterNoc1Id) {
         }
     };
 
-    tt::ARCH arch = cluster->get_cluster_description()->get_arch(0);
-
     // TODO: add reads from remote chips as well. NOC1 traffic is not working
     // for remote read/writes on wormhole remote chips.
     for (chip_id_t chip : cluster->get_target_mmio_device_ids()) {
@@ -115,7 +111,7 @@ TEST(TestCluster, TestClusterNoc1Id) {
         check_noc_id_cores(cluster, chip, CoreType::ETH);
         check_noc_id_harvested_cores(cluster, chip, CoreType::ETH);
 
-        if (arch == tt::ARCH::BLACKHOLE) {
+        if (cluster->get_cluster_description()->get_arch(chip) == tt::ARCH::BLACKHOLE) {
             check_noc_id_cores(cluster, chip, CoreType::DRAM);
             check_noc_id_harvested_cores(cluster, chip, CoreType::DRAM);
         }

--- a/tests/api/test_software_harvesting.cpp
+++ b/tests/api/test_software_harvesting.cpp
@@ -15,12 +15,6 @@
 using namespace tt::umd;
 
 TEST(SoftwareHarvesting, TensixSoftwareHarvestingAllChips) {
-    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    // TODO: Make this test work on a host system without any tt devices.
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
-
     std::set<chip_id_t> target_devices = test_utils::get_target_devices();
 
     int num_devices = target_devices.size();
@@ -34,18 +28,17 @@ TEST(SoftwareHarvesting, TensixSoftwareHarvestingAllChips) {
     std::unique_ptr<Cluster> cluster =
         std::make_unique<Cluster>(num_host_mem_ch_per_mmio_device, false, true, true, software_harvesting_masks);
 
-    tt::ARCH arch = cluster->get_cluster_description()->get_arch(0);
-
-    uint32_t upper_limit_num_cores;
-    if (arch == tt::ARCH::WORMHOLE_B0) {
-        // At least 2 rows are expected to be harvested.
-        upper_limit_num_cores = 64;
-    } else if (arch == tt::ARCH::BLACKHOLE) {
-        // At least 2 columns are expected to be harvested.
-        upper_limit_num_cores = 120;
-    }
-
     for (const chip_id_t& chip : cluster->get_target_device_ids()) {
+        tt::ARCH arch = cluster->get_cluster_description()->get_arch(chip);
+
+        uint32_t upper_limit_num_cores;
+        if (arch == tt::ARCH::WORMHOLE_B0) {
+            // At least 2 rows are expected to be harvested.
+            upper_limit_num_cores = 64;
+        } else if (arch == tt::ARCH::BLACKHOLE) {
+            // At least 2 columns are expected to be harvested.
+            upper_limit_num_cores = 120;
+        }
         ASSERT_LE(cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX).size(), upper_limit_num_cores);
     }
 

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include "gtest/gtest.h"
+#include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/chip_helpers/sysmem_manager.h"
 
 using namespace tt::umd;
@@ -10,32 +11,33 @@ const uint32_t HUGEPAGE_REGION_SIZE = 1 << 30;  // 1GB
 
 TEST(ApiSysmemManager, BasicIO) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
+
+    for (int pci_device_id : pci_device_ids) {
+        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+
+        std::unique_ptr<SysmemManager> sysmem = std::make_unique<SysmemManager>(tt_device.get());
+
+        // Initializes system memory with one channel.
+        sysmem->init_hugepage(1);
+
+        // Simple write and read test.
+        std::vector<uint32_t> data_write = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        sysmem->write_to_sysmem(0, data_write.data(), 0, data_write.size() * sizeof(uint32_t));
+
+        std::vector<uint32_t> data_read = std::vector<uint32_t>(data_write.size(), 0);
+        sysmem->read_from_sysmem(0, data_read.data(), 0, data_read.size() * sizeof(uint32_t));
+
+        EXPECT_EQ(data_write, data_read);
+
+        // Channel 1 is not setup, so this should throw an exception.
+        EXPECT_THROW(
+            sysmem->write_to_sysmem(1, data_write.data(), 0, data_write.size() * sizeof(uint32_t)), std::runtime_error);
+
+        // When we write over the limit, the address is wrapped around the hugepage size
+        sysmem->write_to_sysmem(
+            0, data_write.data(), HUGEPAGE_REGION_SIZE + 0x100, data_write.size() * sizeof(uint32_t));
+        data_read = std::vector<uint32_t>(data_write.size(), 0);
+        sysmem->read_from_sysmem(0, data_read.data(), 0x100, data_read.size() * sizeof(uint32_t));
+        EXPECT_EQ(data_write, data_read);
     }
-    std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_ids[0]);
-
-    std::unique_ptr<SysmemManager> sysmem = std::make_unique<SysmemManager>(tt_device.get());
-
-    // Initializes system memory with one channel.
-    sysmem->init_hugepage(1);
-
-    // Simple write and read test.
-    std::vector<uint32_t> data_write = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    sysmem->write_to_sysmem(0, data_write.data(), 0, data_write.size() * sizeof(uint32_t));
-
-    std::vector<uint32_t> data_read = std::vector<uint32_t>(data_write.size(), 0);
-    sysmem->read_from_sysmem(0, data_read.data(), 0, data_read.size() * sizeof(uint32_t));
-
-    EXPECT_EQ(data_write, data_read);
-
-    // Channel 1 is not setup, so this should throw an exception.
-    EXPECT_THROW(
-        sysmem->write_to_sysmem(1, data_write.data(), 0, data_write.size() * sizeof(uint32_t)), std::runtime_error);
-
-    // When we write over the limit, the address is wrapped around the hugepage size
-    sysmem->write_to_sysmem(0, data_write.data(), HUGEPAGE_REGION_SIZE + 0x100, data_write.size() * sizeof(uint32_t));
-    data_read = std::vector<uint32_t>(data_write.size(), 0);
-    sysmem->read_from_sysmem(0, data_read.data(), 0x100, data_read.size() * sizeof(uint32_t));
-    EXPECT_EQ(data_write, data_read);
 }

--- a/tests/api/test_tlb_manager.cpp
+++ b/tests/api/test_tlb_manager.cpp
@@ -77,3 +77,4 @@ TEST(ApiTLBManager, ManualTLBConfiguration) {
         tt::Writer writer = tlb_manager->get_static_tlb_writer(any_worker_virtual_core);
         writer.write(address_l1_to_write, buffer_to_write[0]);
     }
+}

--- a/tests/api/test_tlb_manager.cpp
+++ b/tests/api/test_tlb_manager.cpp
@@ -6,77 +6,71 @@
 
 #include <gtest/gtest.h>
 
+#include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/tt_device/tt_device.h"
 #include "umd/device/tt_io.hpp"
 #include "umd/device/tt_soc_descriptor.h"
 
 using namespace tt::umd;
 
-std::unique_ptr<TTDevice> get_tt_device() {
-    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    if (pci_device_ids.empty()) {
-        return nullptr;
-    }
-    return TTDevice::create(pci_device_ids[0]);
-}
-
 // TODO: Once default auto TLB setup is in, check it is setup properly.
 TEST(ApiTLBManager, ManualTLBConfiguration) {
-    std::unique_ptr<TTDevice> tt_device = get_tt_device();
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
-    if (tt_device == nullptr) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
+    for (int pci_device_id : pci_device_ids) {
+        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
 
-    std::unique_ptr<TLBManager> tlb_manager = std::make_unique<TLBManager>(tt_device.get());
-    tt_SocDescriptor soc_desc = tt_SocDescriptor(
-        tt_SocDescriptor::get_soc_descriptor_path(tt_device->get_arch()), tt_device->get_arch() != tt::ARCH::GRAYSKULL);
+        std::unique_ptr<TLBManager> tlb_manager = std::make_unique<TLBManager>(tt_device.get());
+        tt_SocDescriptor soc_desc = tt_SocDescriptor(
+            tt_SocDescriptor::get_soc_descriptor_path(tt_device->get_arch()),
+            tt_device->get_arch() != tt::ARCH::GRAYSKULL);
 
-    // TODO: This should be part of TTDevice interface, not Cluster or Chip.
-    // Configure TLBs.
-    std::function<int(CoreCoord)> get_static_tlb_index = [&](CoreCoord core) -> int {
-        // TODO: Make this per arch.
-        if (core.core_type != CoreType::TENSIX) {
-            return -1;
+        // TODO: This should be part of TTDevice interface, not Cluster or Chip.
+        // Configure TLBs.
+        std::function<int(CoreCoord)> get_static_tlb_index = [&](CoreCoord core) -> int {
+            // TODO: Make this per arch.
+            if (core.core_type != CoreType::TENSIX) {
+                return -1;
+            }
+            core = soc_desc.translate_coord_to(core, CoordSystem::LOGICAL);
+            auto tlb_index = core.x + core.y * soc_desc.get_grid_size(CoreType::TENSIX).x;
+
+            auto tlb_1m_base_and_count = tt_device->get_architecture_implementation()->get_tlb_1m_base_and_count();
+            auto tlb_2m_base_and_count = tt_device->get_architecture_implementation()->get_tlb_2m_base_and_count();
+
+            // Use either 1mb or 2mb tlbs.
+            if (tlb_1m_base_and_count.second > 0) {
+                // Expect that tlb index is within the number of 1mb TLBs.
+                EXPECT_TRUE(tlb_index < tlb_1m_base_and_count.second);
+                tlb_index += tlb_1m_base_and_count.first;
+            } else {
+                // Expect that tlb index is within the number of 1mb TLBs.
+                EXPECT_TRUE(tlb_index < tlb_2m_base_and_count.second);
+                tlb_index += tlb_2m_base_and_count.first;
+            }
+
+            return tlb_index;
+        };
+
+        std::int32_t c_zero_address = 0;
+
+        for (CoreCoord core : soc_desc.get_cores(CoreType::TENSIX)) {
+            tlb_manager->configure_tlb(core, core, get_static_tlb_index(core), c_zero_address, tlb_data::Relaxed);
         }
-        core = soc_desc.translate_coord_to(core, CoordSystem::LOGICAL);
-        auto tlb_index = core.x + core.y * soc_desc.get_grid_size(CoreType::TENSIX).x;
 
-        auto tlb_1m_base_and_count = tt_device->get_architecture_implementation()->get_tlb_1m_base_and_count();
-        auto tlb_2m_base_and_count = tt_device->get_architecture_implementation()->get_tlb_2m_base_and_count();
+        // So now that we have configured TLBs we can use it to interface with the TTDevice.
+        auto any_worker_core = soc_desc.get_cores(CoreType::TENSIX)[0];
+        tlb_configuration tlb_description = tlb_manager->get_tlb_configuration(any_worker_core);
 
-        // Use either 1mb or 2mb tlbs.
-        if (tlb_1m_base_and_count.second > 0) {
-            // Expect that tlb index is within the number of 1mb TLBs.
-            EXPECT_TRUE(tlb_index < tlb_1m_base_and_count.second);
-            tlb_index += tlb_1m_base_and_count.first;
-        } else {
-            // Expect that tlb index is within the number of 1mb TLBs.
-            EXPECT_TRUE(tlb_index < tlb_2m_base_and_count.second);
-            tlb_index += tlb_2m_base_and_count.first;
-        }
+        // TODO: Maybe accept tlb_index only?
+        uint64_t address_l1_to_write = 0;
+        std::vector<uint8_t> buffer_to_write = {0x01, 0x02, 0x03, 0x04};
+        tt_device->write_block(
+            tlb_description.tlb_offset + address_l1_to_write, buffer_to_write.size(), buffer_to_write.data());
 
-        return tlb_index;
-    };
-
-    std::int32_t c_zero_address = 0;
-
-    for (CoreCoord core : soc_desc.get_cores(CoreType::TENSIX)) {
-        tlb_manager->configure_tlb(core, core, get_static_tlb_index(core), c_zero_address, tlb_data::Relaxed);
+        // Another way to write to the TLB.
+        // TODO: This should be converted to AbstractIO writer.
+        tt::Writer writer = tlb_manager->get_static_tlb_writer(any_worker_core);
+        writer.write(address_l1_to_write, buffer_to_write[0]);
     }
-
-    // So now that we have configured TLBs we can use it to interface with the TTDevice.
-    auto any_worker_core = soc_desc.get_cores(CoreType::TENSIX)[0];
-    tlb_configuration tlb_description = tlb_manager->get_tlb_configuration(any_worker_core);
-
-    // TODO: Maybe accept tlb_index only?
-    uint64_t address_l1_to_write = 0;
-    std::vector<uint8_t> buffer_to_write = {0x01, 0x02, 0x03, 0x04};
-    tt_device->write_block(
-        tlb_description.tlb_offset + address_l1_to_write, buffer_to_write.size(), buffer_to_write.data());
-
-    // Another way to write to the TLB.
-    // TODO: This should be converted to AbstractIO writer.
-    tt::Writer writer = tlb_manager->get_static_tlb_writer(any_worker_core);
-    writer.write(address_l1_to_write, buffer_to_write[0]);
 }

--- a/tests/unified/multiprocess.cpp
+++ b/tests/unified/multiprocess.cpp
@@ -60,7 +60,7 @@ TEST(Multiprocess, MultipleClusters) {
     std::vector<std::unique_ptr<Cluster>> clusters;
     for (int i = 0; i < NUM_PARALLEL; i++) {
         std::cout << "Creating cluster " << i << std::endl;
-        clusters.push_back(std::unique_ptr<Cluster>(new Cluster()));
+        clusters.push_back(std::make_unique<Cluster>());
     }
     for (int i = 0; i < NUM_PARALLEL; i++) {
         std::cout << "Running IO for cluster " << i << std::endl;
@@ -71,7 +71,7 @@ TEST(Multiprocess, MultipleClusters) {
 
 // Multiple threads use single cluster for IO.
 TEST(Multiprocess, MultipleThreadsSingleCluster) {
-    std::unique_ptr<Cluster> cluster = std::unique_ptr<Cluster>(new Cluster());
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     std::vector<std::thread> threads;
     for (int i = 0; i < NUM_PARALLEL; i++) {
         threads.push_back(std::thread([&, i] {
@@ -91,7 +91,7 @@ TEST(Multiprocess, MultipleThreadsMultipleClustersCreation) {
     for (int i = 0; i < NUM_PARALLEL; i++) {
         threads.push_back(std::thread([&, i] {
             std::cout << "Create cluster " << i << std::endl;
-            std::unique_ptr<Cluster> cluster = std::unique_ptr<Cluster>(new Cluster());
+            std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
             cluster = nullptr;
         }));
     }
@@ -106,7 +106,7 @@ TEST(Multiprocess, MultipleThreadsMultipleClustersRunning) {
     for (int i = 0; i < NUM_PARALLEL; i++) {
         threads.push_back(std::thread([&, i] {
             std::cout << "Creating cluster " << i << std::endl;
-            std::unique_ptr<Cluster> cluster = std::unique_ptr<Cluster>(new Cluster());
+            std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
             std::cout << "Running IO for cluster " << i << std::endl;
             test_read_write_all_tensix_cores(cluster.get(), i);
             std::cout << "Finished IO for cluster " << i << std::endl;
@@ -127,7 +127,7 @@ TEST(Multiprocess, WorkloadVSMonitor) {
 
     auto workload_thread = std::thread([&] {
         std::cout << "Creating workload cluster" << std::endl;
-        std::unique_ptr<Cluster> cluster = std::unique_ptr<Cluster>(new Cluster());
+        std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
         std::cout << "Running IO for workload cluster" << std::endl;
         test_read_write_all_tensix_cores(cluster.get(), 0);
         std::cout << "Finished IO for workload cluster" << std::endl;
@@ -135,7 +135,7 @@ TEST(Multiprocess, WorkloadVSMonitor) {
 
     auto monitor_thread = std::thread([&] {
         std::cout << "Creating monitor cluster" << std::endl;
-        std::unique_ptr<Cluster> cluster = std::unique_ptr<Cluster>(new Cluster());
+        std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
         std::cout << "Running only reads for monitor cluster" << std::endl;
         for (int loop = 0; loop < NUM_LOOPS; loop++) {
             uint32_t example_read;
@@ -192,7 +192,7 @@ TEST(Multiprocess, LongLivedMonitor) {
 
     for (int i = 0; i < NUM_PARALLEL; i++) {
         std::cout << "Creating cluster " << i << std::endl;
-        std::unique_ptr<Cluster> cluster = std::unique_ptr<Cluster>(new Cluster());
+        std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
         std::cout << "Running IO for cluster " << i << std::endl;
         test_read_write_all_tensix_cores(cluster.get(), i);
         std::cout << "Finished IO for cluster " << i << std::endl;


### PR DESCRIPTION
### Issue
No issue, but slightly related to #571 since I want to introduce offline unit tests
In the meantime, this issue popped up which this PR fixes: https://github.com/tenstorrent/tt-metal/issues/18087

### Description
Add baremetal machine to CI for running tests, and fix all issues with creating Cluster object on a system without chips.

### List of the changes
- add baremetal to workflow
- Fix Cluster so it doesn't throw if no chips are present
- Alter tests to skip/don't skip based on if chips are present.

### Testing
CI tests

### API Changes
There are no API changes in this PR.
