### PR TITLE
Fix UMD multiprocess runs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -78,9 +78,6 @@ jobs:
         run: |
           ${{ env.TEST_OUTPUT_DIR }}/umd/misc/umd_misc_tests
 
-      # TODO: Re-enable unified tests in CI once we solve the bugs
-      # we are seeing in the tests. Issues are tracked in issue
-      # https://github.com/tenstorrent/tt-umd/issues/654
-      # - name: Run unified tests
-      #   run: |
-      #     ${{ env.TEST_OUTPUT_DIR }}/umd/unified/unified_tests
+      - name: Run unified tests
+        run: |
+          ${{ env.TEST_OUTPUT_DIR }}/umd/unified/unified_tests

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -14,11 +14,7 @@ namespace tt::umd {
 
 class LocalChip : public Chip {
 public:
-    LocalChip(
-        tt_SocDescriptor soc_descriptor,
-        int pci_device_id,
-        int num_host_mem_channels = 0,
-        const bool clear_mutex = false);
+    LocalChip(tt_SocDescriptor soc_descriptor, int pci_device_id, int num_host_mem_channels = 0);
 
     LocalChip(std::string sdesc_path, std::unique_ptr<TTDevice> tt_device);
 
@@ -47,9 +43,9 @@ private:
     std::unique_ptr<TLBManager> tlb_manager_;
     LockManager lock_manager;
 
-    void initialize_local_chip(int num_host_mem_channels = 0, const bool clear_mutex = false);
+    void initialize_local_chip(int num_host_mem_channels = 0);
     void initialize_tlb_manager();
-    void initialize_default_chip_mutexes(const bool clear_mutex);
+    void initialize_default_chip_mutexes();
 
     tt_xy_pair translate_chip_coord_virtual_to_translated(const tt_xy_pair core) const;
 

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -1090,7 +1090,6 @@ private:
         tt_ClusterDescriptor* cluster_desc,
         tt_SocDescriptor& soc_desc,
         int num_host_mem_channels,
-        const bool clean_system_resources,
         const bool create_mock_chip = false);
     std::unique_ptr<Chip> construct_chip_from_cluster(
         const std::string& soc_desc_path,
@@ -1099,7 +1098,6 @@ private:
         bool perform_harvesting,
         std::unordered_map<chip_id_t, HarvestingMasks>& simulated_harvesting_masks,
         int num_host_mem_channels,
-        const bool clean_system_resources,
         const bool create_mock_chip = false);
     std::unique_ptr<Chip> construct_chip_from_cluster(
         chip_id_t logical_device_id,
@@ -1107,7 +1105,6 @@ private:
         bool perform_harvesting,
         std::unordered_map<chip_id_t, HarvestingMasks>& simulated_harvesting_masks,
         int num_host_mem_channels,
-        const bool clean_system_resources,
         const bool create_mock_chip = false);
     void add_chip(chip_id_t chip_id, std::unique_ptr<Chip> chip);
     HarvestingMasks get_harvesting_masks(

--- a/device/api/umd/device/lock_manager.h
+++ b/device/api/umd/device/lock_manager.h
@@ -33,25 +33,24 @@ enum class MutexType {
 class LockManager {
 public:
     LockManager();
-    ~LockManager();
 
     // This set of functions is used to manage mutexes which are system wide and not chip specific.
-    void initialize_mutex(MutexType mutex_type, const bool clear_mutex);
+    void initialize_mutex(MutexType mutex_type);
     void clear_mutex(MutexType mutex_type);
     std::unique_lock<boost::interprocess::named_mutex> get_mutex(MutexType mutex_type);
 
     // This set of functions is used to manage mutexes which are chip specific.
-    void initialize_mutex(MutexType mutex_type, int pci_device_id, const bool clear_mutex);
+    void initialize_mutex(MutexType mutex_type, int pci_device_id);
     void clear_mutex(MutexType mutex_type, int pci_device_id);
     std::unique_lock<boost::interprocess::named_mutex> get_mutex(MutexType mutex_type, int pci_device_id);
 
     // This set of functions is used to manage mutexes which are chip specific. This variant accepts custom mutex name.
-    void initialize_mutex(std::string mutex_prefix, int pci_device_id, const bool clear_mutex);
+    void initialize_mutex(std::string mutex_prefix, int pci_device_id);
     void clear_mutex(std::string mutex_prefix, int pci_device_id);
     std::unique_lock<boost::interprocess::named_mutex> get_mutex(std::string mutex_prefix, int pci_device_id);
 
 private:
-    void initialize_mutex_internal(const std::string& mutex_name, const bool clear_mutex);
+    void initialize_mutex_internal(const std::string& mutex_name);
     void clear_mutex_internal(const std::string& mutex_name);
     std::unique_lock<boost::interprocess::named_mutex> get_mutex_internal(const std::string& mutex_name);
 

--- a/device/arc_messenger.cpp
+++ b/device/arc_messenger.cpp
@@ -30,7 +30,7 @@ std::unique_ptr<ArcMessenger> ArcMessenger::create_arc_messenger(TTDevice* tt_de
 }
 
 ArcMessenger::ArcMessenger(TTDevice* tt_device) : tt_device(tt_device) {
-    lock_manager.initialize_mutex(MutexType::ARC_MSG, tt_device->get_pci_device()->get_device_num(), false);
+    lock_manager.initialize_mutex(MutexType::ARC_MSG, tt_device->get_pci_device()->get_device_num());
 }
 
 uint32_t ArcMessenger::send_message(const uint32_t msg_code, uint16_t arg0, uint16_t arg1, uint32_t timeout_ms) {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -209,7 +209,6 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     tt_ClusterDescriptor* cluster_desc,
     tt_SocDescriptor& soc_desc,
     int num_host_mem_channels,
-    const bool clean_system_resources,
     const bool create_mock_chip) {
     if (create_mock_chip) {
         return std::make_unique<MockChip>(soc_desc);
@@ -217,7 +216,7 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
 
     if (cluster_desc->is_chip_mmio_capable(chip_id)) {
         return std::make_unique<LocalChip>(
-            soc_desc, cluster_desc->get_chips_with_mmio().at(chip_id), num_host_mem_channels, clean_system_resources);
+            soc_desc, cluster_desc->get_chips_with_mmio().at(chip_id), num_host_mem_channels);
     } else {
         return std::make_unique<RemoteChip>(soc_desc);
     }
@@ -230,7 +229,6 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     bool perform_harvesting,
     std::unordered_map<chip_id_t, HarvestingMasks>& simulated_harvesting_masks,
     int num_host_mem_channels,
-    const bool clean_system_resources,
     const bool create_mock_chip) {
     HarvestingMasks harvesting_masks =
         get_harvesting_masks(chip_id, cluster_desc, perform_harvesting, simulated_harvesting_masks);
@@ -243,8 +241,7 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
         harvesting_masks,
         chip_board_type,
         asic_location);
-    return construct_chip_from_cluster(
-        chip_id, cluster_desc, soc_desc, num_host_mem_channels, clean_system_resources, create_mock_chip);
+    return construct_chip_from_cluster(chip_id, cluster_desc, soc_desc, num_host_mem_channels, create_mock_chip);
 }
 
 std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
@@ -253,7 +250,6 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     bool perform_harvesting,
     std::unordered_map<chip_id_t, HarvestingMasks>& simulated_harvesting_masks,
     int num_host_mem_channels,
-    const bool clean_system_resources,
     const bool create_mock_chip) {
     tt::ARCH arch = cluster_desc->get_arch(chip_id);
     HarvestingMasks harvesting_masks =
@@ -267,8 +263,7 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
         harvesting_masks,
         chip_board_type,
         asic_location);
-    return construct_chip_from_cluster(
-        chip_id, cluster_desc, soc_desc, num_host_mem_channels, clean_system_resources, create_mock_chip);
+    return construct_chip_from_cluster(chip_id, cluster_desc, soc_desc, num_host_mem_channels, create_mock_chip);
 }
 
 void Cluster::add_chip(chip_id_t chip_id, std::unique_ptr<Chip> chip) {
@@ -457,7 +452,6 @@ Cluster::Cluster(
                 perform_harvesting,
                 simulated_harvesting_masks,
                 num_host_mem_ch_per_mmio_device,
-                clean_system_resources,
                 create_mock_chips));
     }
 
@@ -489,7 +483,6 @@ Cluster::Cluster(
                 perform_harvesting,
                 simulated_harvesting_masks,
                 num_host_mem_ch_per_mmio_device,
-                clean_system_resources,
                 create_mock_chips));
     }
 
@@ -523,7 +516,6 @@ Cluster::Cluster(
                 perform_harvesting,
                 simulated_harvesting_masks,
                 num_host_mem_ch_per_mmio_device,
-                clean_system_resources,
                 create_mock_chips));
         log_assert(
             cluster_desc->get_arch(chip_id) == get_chip(chip_id)->get_soc_descriptor().arch,
@@ -557,7 +549,6 @@ Cluster::Cluster(
                 perform_harvesting,
                 simulated_harvesting_masks,
                 num_host_mem_ch_per_mmio_device,
-                clean_system_resources,
                 create_mock_chips));
     }
 

--- a/device/remote_communication.cpp
+++ b/device/remote_communication.cpp
@@ -34,7 +34,7 @@ struct routing_cmd_t {
 namespace tt::umd {
 
 RemoteCommunication::RemoteCommunication(TTDevice* tt_device) : tt_device(tt_device) {
-    lock_manager.initialize_mutex(MutexType::NON_MMIO, tt_device->get_pci_device()->get_device_num(), false);
+    lock_manager.initialize_mutex(MutexType::NON_MMIO, tt_device->get_pci_device()->get_device_num());
 }
 
 RemoteCommunication::~RemoteCommunication() {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -24,7 +24,7 @@ TTDevice::TTDevice(
     pci_device_(std::move(pci_device)),
     architecture_impl_(std::move(architecture_impl)),
     arch(architecture_impl_->get_architecture()) {
-    lock_manager.initialize_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num(), false);
+    lock_manager.initialize_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num());
     arc_messenger_ = ArcMessenger::create_arc_messenger(this);
     telemetry = ArcTelemetryReader::create_arc_telemetry_reader(this);
 }

--- a/tests/unified/multiprocess.cpp
+++ b/tests/unified/multiprocess.cpp
@@ -11,7 +11,7 @@
 
 using namespace tt::umd;
 
-constexpr int NUM_PARALLEL = 4;
+constexpr int NUM_PARALLEL = 10;
 constexpr int NUM_LOOPS = 1000;
 
 // We want to test IO in parallel in each thread.


### PR DESCRIPTION
### Issue

#654 

### Description

Fix multiprocess tests flakiness. Destructors of various classes were deleting shared mutexes so the lock failed silently and race conditions were happening. This PR deletes any removal of mutexes.

### List of the changes

- Remove deletion of mutexes
- Remove clear_mutex var from functions
- Bump threads to 10 in multiprocess tests
- Enable multiprocess tests

### Testing
CI

### API Changes
/
