### PR TITLE
Remove unused APIs

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -121,28 +121,13 @@ public:
      * use a subset of cores from the active_eth_cores_per_chip set for all host->cluster non-MMIO transfers. If this
      * function is not called, UMD will use a default set of ethernet core indices for these transfers (0 through 5). If
      * default behaviour is not desired, this function must be called for all MMIO devices.
-     *
-     * @param mmio_chip Device being targeted.
-     * @param active_eth_cores_per_chip The active ethernet cores for this chip.
-     */
-    virtual void configure_active_ethernet_cores_for_mmio_device(
-        chip_id_t mmio_chip, const std::unordered_set<tt_xy_pair>& active_eth_cores_per_chip) {
-        throw std::runtime_error(
-            "---- tt_device::configure_active_ethernet_cores_for_mmio_device is not implemented\n");
-    }
-
-    /**
-     * Pass in ethernet cores with active links for a specific MMIO chip. When called, this function will force UMD to
-     * use a subset of cores from the active_eth_cores_per_chip set for all host->cluster non-MMIO transfers. If this
-     * function is not called, UMD will use a default set of ethernet core indices for these transfers (0 through 5). If
-     * default behaviour is not desired, this function must be called for all MMIO devices.
      * This API is going to be deprecated when all UMD clients transition to CoreCoord API.
      *
-     * @param active_eth_cores_per_chip The active ethernet cores for this chip.
      * @param mmio_chip Device being targeted.
+     * @param active_eth_cores_per_chip The active ethernet cores for this chip.
      */
     virtual void configure_active_ethernet_cores_for_mmio_device(
-        const std::unordered_set<tt::umd::CoreCoord>& active_eth_cores_per_chip, chip_id_t mmio_chip) {
+        chip_id_t mmio_chip, const std::unordered_set<tt::umd::CoreCoord>& active_eth_cores_per_chip) {
         throw std::runtime_error(
             "---- tt_device::configure_active_ethernet_cores_for_mmio_device is not implemented\n");
     }
@@ -176,20 +161,6 @@ public:
      * Send a BRISC soft deassert reset signal to a single tensix core.
      * Similar to the broadcast deassert_risc_reset API function, but done only on a single core.
      *
-     * This API is going to be deprecated when all UMD clients transition to CoreCoord API.
-     *
-     * @param core Chip and Core to target.
-     * @param soft_resets Specifies which RISCV cores on Tensix to deassert.
-     */
-    virtual void deassert_risc_reset_at_core(
-        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET) {
-        throw std::runtime_error("---- tt_device::deassert_risc_reset_at_core is not implemented\n");
-    }
-
-    /**
-     * Send a BRISC soft deassert reset signal to a single tensix core.
-     * Similar to the broadcast deassert_risc_reset API function, but done only on a single core.
-     *
      * @param chip Chip to target.
      * @param core Core to target.
      * @param soft_resets Specifies which RISCV cores on Tensix to deassert.
@@ -208,21 +179,6 @@ public:
      */
     virtual void assert_risc_reset() {
         throw std::runtime_error("---- tt_device::assert_risc_reset is not implemented\n");
-    }
-
-    /**
-     * Send a BRISC soft assert reset signal to a single tensix core.
-     * It writes to TENSIX register SOFT_RESET, the address of
-     * which is architecture dependant. Please consult the desired architecture specs to find the exact address
-     *
-     * This API is going to be deprecated when all UMD clients transition to CoreCoord API.
-     *
-     * @param core Chip and Core to target.
-     * @param soft_resets Specifies which RISCV cores on Tensix to deassert.
-     */
-    virtual void assert_risc_reset_at_core(
-        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET) {
-        throw std::runtime_error("---- tt_device::assert_risc_reset_at_core is not implemented\n");
     }
 
     /**
@@ -277,25 +233,6 @@ public:
      * This API is used for writing to both TENSIX and DRAM cores. The internal SocDescriptor can be used to determine
      * which type of the core is being targeted.
      *
-     * This API is going to be deprecated when all UMD clients transition to CoreCoord API.
-     *
-     * @param mem_ptr Source data address.
-     * @param size_in_bytes Source data size.
-     * @param core Device and Core to target.
-     * @param addr Address to write to.
-     * @param tlb_to_use Specifies fallback/dynamic TLB to use.
-     */
-    virtual void write_to_device(
-        const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use) {
-        // Only implement this for Silicon Backend
-        throw std::runtime_error("---- tt_device::write_to_device is not implemented\n");
-    }
-
-    /**
-     * Write uint32_t data (as specified by ptr + len pair) to specified device, core and address (defined for Silicon).
-     * This API is used for writing to both TENSIX and DRAM cores. The internal SocDescriptor can be used to determine
-     * which type of the core is being targeted.
-     *
      * @param mem_ptr Source data address.
      * @param size_in_bytes Source data size.
      * @param chip Chip to target.
@@ -337,25 +274,6 @@ public:
         std::set<uint32_t>& columns_to_exclude,
         const std::string& fallback_tlb) {
         throw std::runtime_error("---- tt_device::broadcast_write_to_cluster is not implemented\n");
-    }
-
-    /**
-     * Read uint32_t data from a specified device, core and address to host memory (defined for Silicon).
-     * This API is used for reading from both TENSIX and DRAM cores. The internal SocDescriptor can be used to determine
-     * which type of the core is being targeted.
-     *
-     * This API is going to be deprecated when all UMD clients transition to CoreCoord API.
-     *
-     * @param mem_ptr Data pointer to read the data into.
-     * @param core Chip and Core to target.
-     * @param addr Address to read from.
-     * @param size Number of bytes to read.
-     * @param fallback_tlb Specifies fallback/dynamic TLB to use.
-     */
-    virtual void read_from_device(
-        void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb) {
-        // Only implement this for Silicon Backend
-        throw std::runtime_error("---- tt_device::read_from_device is not implemented\n");
     }
 
     /**
@@ -418,28 +336,14 @@ public:
      * This should be called when the client wants to ensure that all transactions on the L1 of the specified cores have
      * completed.
      *
-     * This API is going to be deprecated when all UMD clients transition to CoreCoord API.
-     *
      * @param chip Chip to target.
      * @param flackback_tlb Specifies fallback/dynamic TLB to use.
      * @param cores Cores being targeted.
      */
     virtual void l1_membar(
-        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {}) {
-        throw std::runtime_error("---- tt_device::l1_membar is not implemented\n");
-    }
-
-    /**
-     * Tensix L1 memory barrier.
-     * This should be called when the client wants to ensure that all transactions on the L1 of the specified cores have
-     * completed.
-     *
-     * @param chip Chip to target.
-     * @param cores Cores being targeted.
-     * @param flackback_tlb Specifies fallback/dynamic TLB to use.
-     */
-    virtual void l1_membar(
-        const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores, const std::string& fallback_tlb) {
+        const chip_id_t chip,
+        const std::string& fallback_tlb,
+        const std::unordered_set<tt::umd::CoreCoord>& cores = {}) {
         throw std::runtime_error("---- tt_device::l1_membar is not implemented\n");
     }
 
@@ -462,28 +366,14 @@ public:
      * This should be called when the client wants to ensure that all transactions on the specified dram bank have
      * completed.
      *
-     * This API is going to be deprecated when all UMD clients transition to CoreCoord API.
-     *
-     * @param chip Chip to target.
-     * @param flackback_tlb Specifies fallback/dynamic TLB to use.
-     * @param cores Cores being targeted.
-     */
-    virtual void dram_membar(
-        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {}) {
-        throw std::runtime_error("---- tt_device::dram_membar is not implemented\n");
-    }
-
-    /**
-     * DRAM memory barrier.
-     * This should be called when the client wants to ensure that all transactions on the specified dram bank have
-     * completed.
-     *
      * @param chip Chip being targeted.
-     * @param cores Cores being targeted.
      * @param flackback_tlb Specifies fallback/dynamic TLB to use.
+     * @param cores Cores being targeted.
      */
     virtual void dram_membar(
-        const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores, const std::string& fallback_tlb) {
+        const chip_id_t chip,
+        const std::string& fallback_tlb,
+        const std::unordered_set<tt::umd::CoreCoord>& cores = {}) {
         throw std::runtime_error("---- tt_device::dram_membar is not implemented\n");
     }
 
@@ -864,8 +754,6 @@ public:
         int32_t tlb_index,
         uint64_t address,
         uint64_t ordering = TLB_DATA::Posted);
-    virtual void configure_active_ethernet_cores_for_mmio_device(
-        chip_id_t mmio_chip, const std::unordered_set<tt_xy_pair>& active_eth_cores_per_chip);
     virtual void deassert_risc_reset_at_core(
         tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET);
     virtual void assert_risc_reset_at_core(
@@ -883,10 +771,6 @@ public:
         const std::string& fallback_tlb);
     virtual void read_from_device(
         void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
-    void l1_membar(
-        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
-    void dram_membar(
-        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
 
     /**
      * If the tlbs are initialized, returns a tuple with the TLB base address and its size
@@ -945,11 +829,11 @@ public:
     tlb_configuration get_tlb_configuration(const chip_id_t chip, const tt::umd::CoreCoord core);
     tt::Writer get_static_tlb_writer(const chip_id_t chip, const tt::umd::CoreCoord target);
     virtual void configure_active_ethernet_cores_for_mmio_device(
-        const std::unordered_set<tt::umd::CoreCoord>& active_eth_cores_per_chip, chip_id_t mmio_chip);
-    virtual void l1_membar(
-        const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores, const std::string& fallback_tlb);
-    virtual void dram_membar(
-        const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores, const std::string& fallback_tlb);
+        chip_id_t mmio_chip, const std::unordered_set<CoreCoord>& active_eth_cores_per_chip);
+    void l1_membar(
+        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<CoreCoord>& cores = {});
+    void dram_membar(
+        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<CoreCoord>& cores = {});
 
     static std::unique_ptr<tt_ClusterDescriptor> create_cluster_descriptor(std::string sdesc_path = "");
 

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -117,16 +117,6 @@ public:
     }
 
     /**
-     * Set ordering mode for dynamic/fallback TLBs (passed into driver constructor).
-     *
-     * @param fallback_tlb Dynamic TLB being targeted.
-     * @param ordering Ordering mode for the TLB.
-     */
-    virtual void set_fallback_tlb_ordering_mode(const std::string& fallback_tlb, uint64_t ordering = TLB_DATA::Posted) {
-        throw std::runtime_error("---- tt_device::set_fallback_tlb_ordering_mode is not implemented\n");
-    }
-
-    /**
      * Pass in ethernet cores with active links for a specific MMIO chip. When called, this function will force UMD to
      * use a subset of cores from the active_eth_cores_per_chip set for all host->cluster non-MMIO transfers. If this
      * function is not called, UMD will use a default set of ethernet core indices for these transfers (0 through 5). If
@@ -740,7 +730,6 @@ public:
     // This set of function shouldn't be removed even after the transition.
     // TODO: regroup the functions from this set into setup/teardown, runtime, and misc functions.
     virtual void set_barrier_address_params(const barrier_address_params& barrier_address_params_);
-    virtual void set_fallback_tlb_ordering_mode(const std::string& fallback_tlb, uint64_t ordering = TLB_DATA::Posted);
     virtual void start_device(const tt_device_params& device_params);
     virtual void assert_risc_reset();
     virtual void deassert_risc_reset();
@@ -1020,14 +1009,6 @@ private:
         void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
     void write_mmio_device_register(
         const void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
-    void pcie_broadcast_write(
-        chip_id_t chip,
-        const void* mem_ptr,
-        uint32_t size_in_bytes,
-        std::uint32_t addr,
-        const tt_xy_pair& start,
-        const tt_xy_pair& end,
-        const std::string& fallback_tlb);
     void ethernet_broadcast_write(
         const void* mem_ptr,
         uint32_t size_in_bytes,

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -42,10 +42,6 @@ public:
     virtual void start_device(const tt_device_params& device_params);
     virtual void assert_risc_reset();
     virtual void deassert_risc_reset();
-    virtual void deassert_risc_reset_at_core(
-        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET);
-    virtual void assert_risc_reset_at_core(
-        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET);
 
     virtual void deassert_risc_reset_at_core(
         const chip_id_t chip,
@@ -81,11 +77,15 @@ public:
     virtual void wait_for_non_mmio_flush();
     virtual void wait_for_non_mmio_flush(const chip_id_t chip);
     void l1_membar(
-        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
+        const chip_id_t chip,
+        const std::string& fallback_tlb,
+        const std::unordered_set<tt::umd::CoreCoord>& cores = {});
     void dram_membar(
         const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels);
     void dram_membar(
-        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores = {});
+        const chip_id_t chip,
+        const std::string& fallback_tlb,
+        const std::unordered_set<tt::umd::CoreCoord>& cores = {});
 
     // Misc. Functions to Query/Set Device State
     static std::vector<chip_id_t> detect_available_device_ids();
@@ -103,9 +103,7 @@ public:
     virtual const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const;
 
     virtual void configure_active_ethernet_cores_for_mmio_device(
-        chip_id_t mmio_chip, const std::unordered_set<tt_xy_pair>& active_eth_cores_per_chip);
-    virtual void configure_active_ethernet_cores_for_mmio_device(
-        const std::unordered_set<tt::umd::CoreCoord>& active_eth_cores_per_chip, chip_id_t mmio_chip);
+        chip_id_t mmio_chip, const std::unordered_set<tt::umd::CoreCoord>& active_eth_cores_per_chip);
 
     tt_xy_pair translate_to_api_coords(const chip_id_t chip, const tt::umd::CoreCoord core_coord) const;
 

--- a/device/mockup/tt_mockup_device.hpp
+++ b/device/mockup/tt_mockup_device.hpp
@@ -23,6 +23,9 @@ public:
 
     void set_barrier_address_params(const barrier_address_params& barrier_address_params_) override {}
 
+    void configure_active_ethernet_cores_for_mmio_device(
+        chip_id_t mmio_chip, const std::unordered_set<tt::umd::CoreCoord>& active_eth_cores_per_chip) override {}
+
     void start_device(const tt_device_params& device_params) override {}
 
     void assert_risc_reset() override {}
@@ -30,23 +33,45 @@ public:
     void deassert_risc_reset() override {}
 
     void deassert_risc_reset_at_core(
-        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET) override {}
+        const chip_id_t chip,
+        const tt::umd::CoreCoord core,
+        const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET) override {}
 
     void assert_risc_reset_at_core(
-        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET) override {}
+        const chip_id_t chip,
+        const tt::umd::CoreCoord core,
+        const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET) override {}
 
     void close_device() override {}
 
-    // Runtime Functions
+    void wait_for_non_mmio_flush() override {}
+
+    void wait_for_non_mmio_flush(const chip_id_t chip_id) override {}
+
     void write_to_device(
         const void* mem_ptr,
         uint32_t size_in_bytes,
-        tt_cxy_pair core,
+        chip_id_t chip,
+        tt::umd::CoreCoord core,
         uint64_t addr,
         const std::string& tlb_to_use) override {}
 
+    void broadcast_write_to_cluster(
+        const void* mem_ptr,
+        uint32_t size_in_bytes,
+        uint64_t address,
+        const std::set<chip_id_t>& chips_to_exclude,
+        std::set<uint32_t>& rows_to_exclude,
+        std::set<uint32_t>& columns_to_exclude,
+        const std::string& fallback_tlb) override {}
+
     void read_from_device(
-        void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb) override {}
+        void* mem_ptr,
+        chip_id_t chip,
+        tt::umd::CoreCoord core,
+        uint64_t addr,
+        uint32_t size,
+        const std::string& fallback_tlb) override {}
 
     void write_to_sysmem(
         const void* mem_ptr, std::uint32_t size, uint64_t addr, uint16_t channel, chip_id_t src_device_id) override {}
@@ -57,7 +82,7 @@ public:
     void l1_membar(
         const chip_id_t chip,
         const std::string& fallback_tlb,
-        const std::unordered_set<tt_xy_pair>& cores = {}) override {}
+        const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override {}
 
     void dram_membar(
         const chip_id_t chip,
@@ -67,12 +92,21 @@ public:
     void dram_membar(
         const chip_id_t chip,
         const std::string& fallback_tlb,
-        const std::unordered_set<tt_xy_pair>& cores = {}) override {}
+        const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override {}
 
-    void wait_for_non_mmio_flush() override {}
+    int arc_msg(
+        int logical_device_id,
+        uint32_t msg_code,
+        bool wait_for_done = true,
+        uint32_t arg0 = 0,
+        uint32_t arg1 = 0,
+        int timeout = 1,
+        uint32_t* return_3 = nullptr,
+        uint32_t* return_4 = nullptr) override {
+        return 0;
+    }
 
-    // Misc. Functions to Query/Set Device State
-    static std::vector<chip_id_t> detect_available_device_ids() { return {0}; };
+    tt_ClusterDescriptor* get_cluster_description() override { return cluster_descriptor.get(); }
 
     std::set<chip_id_t> get_target_device_ids() override { return target_devices_in_cluster; }
 
@@ -82,11 +116,9 @@ public:
 
     std::map<int, int> get_clocks() override { return {{0, 0}}; }
 
-    void* host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const override {
-        return nullptr;
-    }
+    std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id) override { return 0; }
 
-    std::uint64_t get_pcie_base_addr_from_device(const chip_id_t chip_id) const override { return 0; }
+    tt_version get_ethernet_fw_version() const override { return {0, 0, 0}; }
 
     std::uint32_t get_num_dram_channels(std::uint32_t device_id) override {
         return get_soc_descriptor(device_id).get_num_dram_channels();
@@ -100,11 +132,18 @@ public:
 
     std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel) override { return 0; }
 
-    std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id) override { return 0; }
+    void* host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const override {
+        return nullptr;
+    }
+
+    std::uint64_t get_pcie_base_addr_from_device(const chip_id_t chip_id) const override { return 0; }
 
     const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const override {
         return soc_descriptor_per_chip.at(chip_id);
     };
+
+    // Misc. Functions to Query/Set Device State
+    static std::vector<chip_id_t> detect_available_device_ids() { return {0}; }
 
 private:
     std::vector<tt::ARCH> archs_in_cluster = {};

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -121,28 +121,20 @@ void tt_SimulationDevice::deassert_risc_reset() {
     host.send_to_device(wr_buffer_ptr, wr_buffer_size);
 }
 
-void tt_SimulationDevice::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions& soft_resets) {
+void tt_SimulationDevice::deassert_risc_reset_at_core(
+    const chip_id_t chip, const tt::umd::CoreCoord core, const TensixSoftResetOptions& soft_resets) {
     log_info(
         tt::LogEmulationDriver,
         "Sending 'deassert_risc_reset_at_core'.. (Not implemented, defaulting to 'deassert_risc_reset' instead)");
     deassert_risc_reset();
 }
 
-void tt_SimulationDevice::assert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetOptions& soft_resets) {
+void tt_SimulationDevice::assert_risc_reset_at_core(
+    const chip_id_t chip, const tt::umd::CoreCoord core, const TensixSoftResetOptions& soft_resets) {
     log_info(
         tt::LogEmulationDriver,
         "Sending 'assert_risc_reset_at_core'.. (Not implemented, defaulting to 'assert_risc_reset' instead)");
     assert_risc_reset();
-}
-
-void tt_SimulationDevice::deassert_risc_reset_at_core(
-    const chip_id_t chip, const tt::umd::CoreCoord core, const TensixSoftResetOptions& soft_resets) {
-    deassert_risc_reset_at_core({(size_t)chip, translate_to_api_coords(chip, core)}, soft_resets);
-}
-
-void tt_SimulationDevice::assert_risc_reset_at_core(
-    const chip_id_t chip, const tt::umd::CoreCoord core, const TensixSoftResetOptions& soft_resets) {
-    assert_risc_reset_at_core({(size_t)chip, translate_to_api_coords(chip, core)}, soft_resets);
 }
 
 void tt_SimulationDevice::close_device() {
@@ -217,13 +209,13 @@ void tt_SimulationDevice::wait_for_non_mmio_flush() {}
 void tt_SimulationDevice::wait_for_non_mmio_flush(const chip_id_t chip) {}
 
 void tt_SimulationDevice::l1_membar(
-    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {}
+    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt::umd::CoreCoord>& cores) {}
 
 void tt_SimulationDevice::dram_membar(
     const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels) {}
 
 void tt_SimulationDevice::dram_membar(
-    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt_xy_pair>& cores) {}
+    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt::umd::CoreCoord>& cores) {}
 
 // Misc. Functions to Query/Set Device State
 std::vector<chip_id_t> tt_SimulationDevice::detect_available_device_ids() { return {0}; }
@@ -270,10 +262,7 @@ const tt_SocDescriptor& tt_SimulationDevice::get_soc_descriptor(chip_id_t chip_i
 };
 
 void tt_SimulationDevice::configure_active_ethernet_cores_for_mmio_device(
-    chip_id_t mmio_chip, const std::unordered_set<tt_xy_pair>& active_eth_cores_per_chip) {}
-
-void tt_SimulationDevice::configure_active_ethernet_cores_for_mmio_device(
-    const std::unordered_set<tt::umd::CoreCoord>& active_eth_cores_per_chip, chip_id_t mmio_chip) {}
+    chip_id_t mmio_chip, const std::unordered_set<tt::umd::CoreCoord>& active_eth_cores_per_chip) {}
 
 // TODO: This is a temporary function while we're switching between the old and the new API.
 // Eventually, this function should be so small it would be obvioud to remove.

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -561,7 +561,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
             for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 std::vector<uint32_t> readback_vec = {};
                 cluster.write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), 0, core, address, "");
-                cluster.l1_membar(0, {core}, "SMALL_READ_WRITE_TLB");
+                cluster.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
                 test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec1.size(), "");
                 ASSERT_EQ(readback_vec, vec1);
                 cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address, "");
@@ -576,7 +576,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
             for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 std::vector<uint32_t> readback_vec = {};
                 cluster.write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), 0, core, address, "");
-                cluster.l1_membar(0, {core}, "SMALL_READ_WRITE_TLB");
+                cluster.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
                 test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec2.size(), "");
                 ASSERT_EQ(readback_vec, vec2);
                 cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address, "");
@@ -668,7 +668,7 @@ TEST(SiliconDriverBH, DISABLED_BroadcastWrite) {  // Cannot broadcast to tensix/
                     continue;
                 }
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, tt_cxy_pair(i, core), address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                    cluster, readback_vec, i, core, address, vector_to_write.size() * 4, "LARGE_READ_TLB");
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.str() << " does not match what was broadcasted";
                 cluster.write_to_device(

--- a/tests/galaxy/test_galaxy_common.cpp
+++ b/tests/galaxy/test_galaxy_common.cpp
@@ -12,14 +12,16 @@ void move_data(
     test_utils::read_data_from_device(
         device,
         readback_vec,
-        tt_cxy_pair(sender_core.chip, sender_core.core),
+        sender_core.chip,
+        device.get_soc_descriptor(sender_core.chip).get_coord_at(sender_core.core, CoordSystem::VIRTUAL),
         sender_core.addr,
         size,
         "SMALL_READ_WRITE_TLB");
     device.write_to_device(
         readback_vec.data(),
         readback_vec.size() * sizeof(std::uint32_t),
-        tt_cxy_pair(receiver_core.chip, receiver_core.core),
+        receiver_core.chip,
+        device.get_soc_descriptor(receiver_core.chip).get_coord_at(receiver_core.core, CoordSystem::VIRTUAL),
         receiver_core.addr,
         "SMALL_READ_WRITE_TLB");
     device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
@@ -36,7 +38,8 @@ void broadcast_data(
     test_utils::read_data_from_device(
         device,
         readback_vec,
-        tt_cxy_pair(sender_core.chip, sender_core.core),
+        sender_core.chip,
+        device.get_soc_descriptor(sender_core.chip).get_coord_at(sender_core.core, CoordSystem::VIRTUAL),
         sender_core.addr,
         size,
         "SMALL_READ_WRITE_TLB");
@@ -44,7 +47,8 @@ void broadcast_data(
         device.write_to_device(
             readback_vec.data(),
             readback_vec.size() * sizeof(std::uint32_t),
-            tt_cxy_pair(receiver_core.chip, receiver_core.core),
+            receiver_core.chip,
+            device.get_soc_descriptor(receiver_core.chip).get_coord_at(receiver_core.core, CoordSystem::VIRTUAL),
             receiver_core.addr,
             "SMALL_READ_WRITE_TLB");
     }

--- a/tests/microbenchmark/test_rw_tensix.cpp
+++ b/tests/microbenchmark/test_rw_tensix.cpp
@@ -64,7 +64,7 @@ TEST_F(uBenchmarkFixture, ReadAllCores32Bytes) {
             .output(nullptr)
             .run(rname.str(), [&] {
                 test_utils::read_data_from_device(
-                    *device, readback_vec, tt_cxy_pair(0, core), bad_address, 0x20, "SMALL_READ_WRITE_TLB");
+                    *device, readback_vec, 0, core, bad_address, 0x20, "SMALL_READ_WRITE_TLB");
             });
         rname.clear();
     }

--- a/tests/microbenchmark/test_rw_tensix.cpp
+++ b/tests/microbenchmark/test_rw_tensix.cpp
@@ -36,7 +36,7 @@ TEST_F(uBenchmarkFixture, WriteAllCores32Bytes) {
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
                     0,
-                    core,
+                    core_coord,
                     bad_address,
                     "SMALL_READ_WRITE_TLB");
             });
@@ -91,7 +91,7 @@ TEST_F(uBenchmarkFixture, Write32BytesRandomAddr) {
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
                     0,
-                    core,
+                    core_coord,
                     address,
                     "SMALL_READ_WRITE_TLB");
             });
@@ -107,17 +107,17 @@ TEST_F(uBenchmarkFixture, Read32BytesRandomAddr) {
 
     ankerl::nanobench::Bench bench;
     for (auto& core_coord : device->get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
-        tt_xy_pair core = {core_coord.x, core_coord.y};
         address = generate_random_address(1 << 20);  // between 0 and 1MB
         std::stringstream rname;
-        rname << "Read from device core (" << core.x << ", " << core.y << ") @ address " << std::hex << address;
+        rname << "Read from device core (" << core_coord.x << ", " << core_coord.y << ") @ address " << std::hex
+              << address;
         bench.title("Read 32 bytes random address")
             .unit("reads")
             .minEpochIterations(50)
             .output(nullptr)
             .run(rname.str(), [&] {
                 test_utils::read_data_from_device(
-                    *device, readback_vec, tt_cxy_pair(0, core), address, 0x20, "SMALL_READ_WRITE_TLB");
+                    *device, readback_vec, 0, core_coord, address, 0x20, "SMALL_READ_WRITE_TLB");
             });
         rname.clear();
     }

--- a/tests/microbenchmark/test_rw_tensix.cpp
+++ b/tests/microbenchmark/test_rw_tensix.cpp
@@ -24,9 +24,8 @@ TEST_F(uBenchmarkFixture, WriteAllCores32Bytes) {
     ankerl::nanobench::Bench bench_static;
     ankerl::nanobench::Bench bench_dynamic;
     for (auto& core_coord : device->get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
-        tt_xy_pair core = {core_coord.x, core_coord.y};
         std::stringstream wname;
-        wname << "Write to device core (" << core.x << ", " << core.y << ")";
+        wname << "Write to device core (" << core_coord.x << ", " << core_coord.y << ")";
         // Write through "fallback/dynamic" tlb
         bench_dynamic.title("Write 32 bytes fallback")
             .unit("writes")
@@ -36,7 +35,8 @@ TEST_F(uBenchmarkFixture, WriteAllCores32Bytes) {
                 device->write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
-                    tt_cxy_pair(0, core),
+                    0,
+                    core,
                     bad_address,
                     "SMALL_READ_WRITE_TLB");
             });
@@ -55,7 +55,6 @@ TEST_F(uBenchmarkFixture, ReadAllCores32Bytes) {
     ankerl::nanobench::Bench bench_dynamic;
 
     for (auto& core_coord : device->get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
-        tt_xy_pair core = {core_coord.x, core_coord.y};
         std::stringstream rname;
         // Read through "fallback/dynamic" tlb
         bench_dynamic.title("Read 32 bytes fallback")
@@ -64,7 +63,7 @@ TEST_F(uBenchmarkFixture, ReadAllCores32Bytes) {
             .output(nullptr)
             .run(rname.str(), [&] {
                 test_utils::read_data_from_device(
-                    *device, readback_vec, 0, core, bad_address, 0x20, "SMALL_READ_WRITE_TLB");
+                    *device, readback_vec, 0, core_coord, bad_address, 0x20, "SMALL_READ_WRITE_TLB");
             });
         rname.clear();
     }
@@ -79,10 +78,10 @@ TEST_F(uBenchmarkFixture, Write32BytesRandomAddr) {
 
     ankerl::nanobench::Bench bench;
     for (auto& core_coord : device->get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
-        tt_xy_pair core = {core_coord.x, core_coord.y};
         address = generate_random_address(1 << 20);  // between 0 and 1MB
         std::stringstream wname;
-        wname << "Write to device core (" << core.x << ", " << core.y << ") @ address " << std::hex << address;
+        wname << "Write to device core (" << core_coord.x << ", " << core_coord.y << ") @ address " << std::hex
+              << address;
         bench.title("Write 32 bytes random address")
             .unit("writes")
             .minEpochIterations(50)
@@ -91,7 +90,8 @@ TEST_F(uBenchmarkFixture, Write32BytesRandomAddr) {
                 device->write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
-                    tt_cxy_pair(0, core),
+                    0,
+                    core,
                     address,
                     "SMALL_READ_WRITE_TLB");
             });

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -27,17 +27,6 @@ static void size_buffer_to_capacity(std::vector<T>& data_buf, std::size_t size_i
 static void read_data_from_device(
     tt_device& device,
     std::vector<uint32_t>& vec,
-    tt_cxy_pair core,
-    uint64_t addr,
-    uint32_t size,
-    const std::string& tlb_to_use) {
-    size_buffer_to_capacity(vec, size);
-    device.read_from_device(vec.data(), core, addr, size, tlb_to_use);
-}
-
-static void read_data_from_device(
-    tt_device& device,
-    std::vector<uint32_t>& vec,
     chip_id_t chip_id,
     tt::umd::CoreCoord core,
     uint64_t addr,

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -488,8 +488,7 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
 
     for (int chan = 0; chan < cluster.get_soc_descriptor(0).get_num_dram_channels(); chan++) {
         CoreCoord core = cluster.get_soc_descriptor(0).get_dram_core_for_channel(chan, 0, CoordSystem::VIRTUAL);
-        test_utils::read_data_from_device(
-            cluster, readback_membar_vec, tt_cxy_pair(0, core), 0, 4, "SMALL_READ_WRITE_TLB");
+        test_utils::read_data_from_device(cluster, readback_membar_vec, 0, core, 0, 4, "SMALL_READ_WRITE_TLB");
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all DRAM
         readback_membar_vec = {};
@@ -528,7 +527,7 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
             for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 std::vector<uint32_t> readback_vec = {};
                 cluster.write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), 0, core, address, "");
-                cluster.l1_membar(0, {core}, "SMALL_READ_WRITE_TLB");
+                cluster.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
                 test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec1.size(), "");
                 ASSERT_EQ(readback_vec, vec1);
                 cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address, "");
@@ -543,7 +542,7 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
             for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 std::vector<uint32_t> readback_vec = {};
                 cluster.write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), 0, core, address, "");
-                cluster.l1_membar(0, {core}, "SMALL_READ_WRITE_TLB");
+                cluster.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
                 test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec2.size(), "");
                 ASSERT_EQ(readback_vec, vec2);
                 cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address, "");


### PR DESCRIPTION
### Issue
On a way of #248 , but also contributing slightly to #567 

### Description
Remove old unused API.

### List of the changes
- Removed set_fallback_tlb_ordering_mode, this is unused and also this is hardware detail, should be contained in UMD
- Removed pcie_broadcast_write, this was only for Grayskull
- Removed one version and changed the other version's order of arguments. Since these functions accepted vectors, the order of arguments had to be different. I've removed the tt_xy_pair versions, and rearranged the CoreCoord versions to maintain the original order.  I verified for these members that the code in tt_metal is still valid. Since I removed the old variants, I've also rearranged the code a bit internally in cluster.cpp. Following functions: configure_active_ethernet_cores_for_mmio_device, l1_membar, dram_membar.
- Removed old versions with tt_xy_pair, tt_metal already switched to CoreCoord ones: deassert_risc_reset_at_core, assert_risc_reset_at_core, write_to_device, read_from_device
- Adjusted tt_SimulationDevice accordingly
- Adjusted MockupDevice accordingly, and fixed prior missing functions
- Minor fixes in tests. There was a push previously to move tests to new API, but some old usages slipped through, that's why this part of the change wasn't that large

### Testing
CI on this PR
All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/14227798358
And metal build passes

### API Changes
There are API changes in this PR, but the job for building tt_metal shows there aren't any breaking changes.
