### PR TITLE
Move read_from_non_mmio_device to RemoteChip

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -44,6 +44,7 @@ public:
     virtual void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size);
 
     // TODO: Currently works only for Local and not for Remote.
+    // Both write and read cores are defined in VIRTUAL coords.
     virtual void write_to_device(
         tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size, const std::string& fallback_tlb);
     virtual void read_from_device(

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -21,6 +21,8 @@ public:
         tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size, const std::string& fallback_tlb) override;
 
 private:
+    tt_xy_pair translate_chip_coord_virtual_to_translated(const tt_xy_pair core);
+
     eth_coord_t eth_chip_location_;
     std::unique_ptr<RemoteCommunication> remote_communication_;
 };

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -7,11 +7,21 @@
 #pragma once
 
 #include "umd/device/chip/chip.h"
+#include "umd/device/remote_communication.h"
 
 namespace tt::umd {
+class LocalChip;
+
 class RemoteChip : public Chip {
 public:
-    RemoteChip(tt_SocDescriptor soc_descriptor);
+    RemoteChip(tt_SocDescriptor soc_descriptor, eth_coord_t eth_chip_location, LocalChip* local_chip);
     bool is_mmio_capable() const override;
+
+    void read_from_device(
+        tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size, const std::string& fallback_tlb) override;
+
+private:
+    eth_coord_t eth_chip_location_;
+    std::unique_ptr<RemoteCommunication> remote_communication_;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -521,6 +521,9 @@ public:
 
 namespace tt::umd {
 
+class LocalChip;
+class RemoteChip;
+
 /**
  * Silicon Driver Class, derived from the tt_device class
  * Implements APIs to communicate with a physical Tenstorrent Device.
@@ -732,7 +735,14 @@ public:
      *
      * @param device_id Device to target.
      */
-    Chip* get_local_chip(chip_id_t device_id) const;
+    LocalChip* get_local_chip(chip_id_t device_id) const;
+
+    /**
+     * Get Chip for specified logical device id, verify it is remote.
+     *
+     * @param device_id Device to target.
+     */
+    RemoteChip* get_remote_chip(chip_id_t device_id) const;
 
     /**
      * Get Soc descriptor for specified logical device id.

--- a/device/api/umd/device/remote_communication.h
+++ b/device/api/umd/device/remote_communication.h
@@ -16,6 +16,7 @@ public:
     RemoteCommunication(LocalChip* local_chip);
     virtual ~RemoteCommunication();
 
+    // Target core should be in translated coords.
     void read_non_mmio(
         eth_coord_t target_chip, tt_xy_pair target_core, void* dest, uint64_t core_src, uint32_t size_in_bytes);
 

--- a/device/api/umd/device/remote_communication.h
+++ b/device/api/umd/device/remote_communication.h
@@ -9,18 +9,15 @@
 
 namespace tt::umd {
 
+class LocalChip;
+
 class RemoteCommunication {
 public:
-    RemoteCommunication(TTDevice* tt_device);
+    RemoteCommunication(LocalChip* local_chip);
     virtual ~RemoteCommunication();
 
     void read_non_mmio(
-        uint8_t* mem_ptr,
-        tt_xy_pair core,
-        uint64_t address,
-        uint32_t size_in_bytes,
-        eth_coord_t target_chip,
-        const tt_xy_pair eth_core);
+        eth_coord_t target_chip, tt_xy_pair target_core, void* dest, uint64_t core_src, uint32_t size_in_bytes);
 
     void write_to_non_mmio(
         uint8_t* mem_ptr,
@@ -33,8 +30,7 @@ public:
     void wait_for_non_mmio_flush(std::vector<tt_xy_pair> remote_transfer_eth_cores);
 
 private:
-    TTDevice* tt_device;
-    LockManager lock_manager;
+    LocalChip* local_chip_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -114,7 +114,7 @@ public:
         get_ethernet_connections() const;
     const std::unordered_map<chip_id_t, chip_id_t> get_chips_with_mmio() const;
     const std::unordered_set<chip_id_t> &get_all_chips() const;
-    const std::vector<chip_id_t> &get_all_chips_local_first() const;
+    const std::vector<chip_id_t> get_all_chips_local_first() const;
     const std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> &get_chips_grouped_by_closest_mmio() const;
     std::size_t get_number_of_chips() const;
 

--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -114,6 +114,7 @@ public:
         get_ethernet_connections() const;
     const std::unordered_map<chip_id_t, chip_id_t> get_chips_with_mmio() const;
     const std::unordered_set<chip_id_t> &get_all_chips() const;
+    const std::vector<chip_id_t> &get_all_chips_local_first() const;
     const std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> &get_chips_grouped_by_closest_mmio() const;
     std::size_t get_number_of_chips() const;
 

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -20,6 +20,8 @@ bool RemoteChip::is_mmio_capable() const { return false; }
 void RemoteChip::read_from_device(
     tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size, const std::string& fallback_tlb) {
     // TODO: Fallback TLB is ignored for now, but it will be removed soon from the signature.
-    remote_communication_->read_non_mmio(eth_chip_location_, core, dest, l1_src, size);
+    // TODO: This translation should go away when we start using CoreCoord everywhere.
+    auto translated_core = get_soc_descriptor().translate_coord_to(core, CoordSystem::VIRTUAL, CoordSystem::TRANSLATED);
+    remote_communication_->read_non_mmio(eth_chip_location_, translated_core, dest, l1_src, size);
 }
 }  // namespace tt::umd

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -6,9 +6,20 @@
 
 #include "umd/device/chip/remote_chip.h"
 
+#include "umd/device/chip/local_chip.h"
+
 namespace tt::umd {
 
-RemoteChip::RemoteChip(tt_SocDescriptor soc_descriptor) : Chip(soc_descriptor) {}
+RemoteChip::RemoteChip(tt_SocDescriptor soc_descriptor, eth_coord_t eth_chip_location, LocalChip* local_chip) :
+    Chip(soc_descriptor),
+    eth_chip_location_(eth_chip_location),
+    remote_communication_(std::make_unique<RemoteCommunication>(local_chip)) {}
 
 bool RemoteChip::is_mmio_capable() const { return false; }
+
+void RemoteChip::read_from_device(
+    tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size, const std::string& fallback_tlb) {
+    // TODO: Fallback TLB is ignored for now, but it will be removed soon from the signature.
+    remote_communication_->read_non_mmio(eth_chip_location_, core, dest, l1_src, size);
+}
 }  // namespace tt::umd

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -8,6 +8,8 @@
 
 #include "umd/device/chip/local_chip.h"
 
+extern bool umd_use_noc1;
+
 namespace tt::umd {
 
 RemoteChip::RemoteChip(tt_SocDescriptor soc_descriptor, eth_coord_t eth_chip_location, LocalChip* local_chip) :
@@ -20,8 +22,31 @@ bool RemoteChip::is_mmio_capable() const { return false; }
 void RemoteChip::read_from_device(
     tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size, const std::string& fallback_tlb) {
     // TODO: Fallback TLB is ignored for now, but it will be removed soon from the signature.
-    // TODO: This translation should go away when we start using CoreCoord everywhere.
-    auto translated_core = get_soc_descriptor().translate_coord_to(core, CoordSystem::VIRTUAL, CoordSystem::TRANSLATED);
+    auto translated_core = translate_chip_coord_virtual_to_translated(core);
     remote_communication_->read_non_mmio(eth_chip_location_, translated_core, dest, l1_src, size);
+}
+
+// TODO: This translation should go away when we start using CoreCoord everywhere.
+tt_xy_pair RemoteChip::translate_chip_coord_virtual_to_translated(const tt_xy_pair core) {
+    CoreCoord core_coord = get_soc_descriptor().get_coord_at(core, CoordSystem::VIRTUAL);
+    // Since NOC1 and translated coordinate space overlaps for Tensix cores on Blackhole,
+    // Tensix cores are always used in translated space. Other cores are used either in
+    // NOC1 or translated space depending on the umd_use_noc1 flag.
+    // On Wormhole Tensix can use NOC1 space if umd_use_noc1 is set to true.
+    if (get_soc_descriptor().noc_translation_enabled) {
+        if (get_soc_descriptor().arch == tt::ARCH::BLACKHOLE) {
+            if (core_coord.core_type == CoreType::TENSIX || !umd_use_noc1) {
+                return get_soc_descriptor().translate_coord_to(core_coord, CoordSystem::TRANSLATED);
+            } else {
+                return get_soc_descriptor().translate_coord_to(core_coord, CoordSystem::NOC1);
+            }
+        } else {
+            return get_soc_descriptor().translate_coord_to(
+                core_coord, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::TRANSLATED);
+        }
+    } else {
+        return get_soc_descriptor().translate_coord_to(
+            core_coord, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::TRANSLATED);
+    }
 }
 }  // namespace tt::umd

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -175,6 +175,9 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
         return std::make_unique<LocalChip>(
             soc_desc, cluster_desc->get_chips_with_mmio().at(chip_id), num_host_mem_channels, clean_system_resources);
     } else {
+        if (cluster_desc->get_arch(chip_id) != tt::ARCH::WORMHOLE_B0) {
+            throw std::runtime_error("Remote chips are supported only for wormhole.");
+        }
         return std::make_unique<RemoteChip>(
             soc_desc,
             cluster_desc->get_chip_locations().at(chip_id),
@@ -407,19 +410,7 @@ Cluster::Cluster(
     std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks) {
     cluster_desc = Cluster::create_cluster_descriptor();
 
-    std::vector<chip_id_t> all_chips_local_first;
-    for (const auto& chip : cluster_desc->get_all_chips()) {
-        if (cluster_desc->is_chip_mmio_capable(chip)) {
-            all_chips_local_first.push_back(chip);
-        }
-    }
-    for (const auto& chip : cluster_desc->get_all_chips()) {
-        if (cluster_desc->is_chip_remote(chip)) {
-            all_chips_local_first.push_back(chip);
-        }
-    }
-
-    for (auto& chip_id : all_chips_local_first) {
+    for (auto& chip_id : cluster_desc->get_all_chips_local_first()) {
         add_chip(
             chip_id,
             construct_chip_from_cluster(
@@ -444,19 +435,7 @@ Cluster::Cluster(
     std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks) {
     cluster_desc = Cluster::create_cluster_descriptor();
 
-    std::vector<chip_id_t> all_chips_local_first;
-    for (const auto& chip : target_devices) {
-        if (cluster_desc->is_chip_mmio_capable(chip)) {
-            all_chips_local_first.push_back(chip);
-        }
-    }
-    for (const auto& chip : target_devices) {
-        if (cluster_desc->is_chip_remote(chip)) {
-            all_chips_local_first.push_back(chip);
-        }
-    }
-
-    for (auto& chip_id : all_chips_local_first) {
+    for (auto& chip_id : cluster_desc->get_all_chips_local_first()) {
         log_assert(
             cluster_desc->get_all_chips().find(chip_id) != cluster_desc->get_all_chips().end(),
             "Target device {} not present in current cluster!",
@@ -486,19 +465,7 @@ Cluster::Cluster(
     std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks) {
     cluster_desc = Cluster::create_cluster_descriptor(sdesc_path);
 
-    std::vector<chip_id_t> all_chips_local_first;
-    for (const auto& chip : target_devices) {
-        if (cluster_desc->is_chip_mmio_capable(chip)) {
-            all_chips_local_first.push_back(chip);
-        }
-    }
-    for (const auto& chip : target_devices) {
-        if (cluster_desc->is_chip_remote(chip)) {
-            all_chips_local_first.push_back(chip);
-        }
-    }
-
-    for (auto& chip_id : all_chips_local_first) {
+    for (auto& chip_id : cluster_desc->get_all_chips_local_first()) {
         log_assert(
             cluster_desc->get_all_chips().find(chip_id) != cluster_desc->get_all_chips().end(),
             "Target device {} not present in current cluster!",
@@ -534,19 +501,7 @@ Cluster::Cluster(
     std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks) {
     cluster_desc = std::move(cluster_descriptor);
 
-    std::vector<chip_id_t> all_chips_local_first;
-    for (const auto& chip : cluster_desc->get_all_chips()) {
-        if (cluster_desc->is_chip_mmio_capable(chip)) {
-            all_chips_local_first.push_back(chip);
-        }
-    }
-    for (const auto& chip : cluster_desc->get_all_chips()) {
-        if (cluster_desc->is_chip_remote(chip)) {
-            all_chips_local_first.push_back(chip);
-        }
-    }
-
-    for (auto& chip_id : all_chips_local_first) {
+    for (auto& chip_id : cluster_desc->get_all_chips_local_first()) {
         add_chip(
             chip_id,
             construct_chip_from_cluster(

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -407,7 +407,19 @@ Cluster::Cluster(
     std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks) {
     cluster_desc = Cluster::create_cluster_descriptor();
 
-    for (auto& chip_id : cluster_desc->get_all_chips()) {
+    std::vector<chip_id_t> all_chips_local_first;
+    for (const auto& chip : cluster_desc->get_all_chips()) {
+        if (cluster_desc->is_chip_mmio_capable(chip)) {
+            all_chips_local_first.push_back(chip);
+        }
+    }
+    for (const auto& chip : cluster_desc->get_all_chips()) {
+        if (cluster_desc->is_chip_remote(chip)) {
+            all_chips_local_first.push_back(chip);
+        }
+    }
+
+    for (auto& chip_id : all_chips_local_first) {
         add_chip(
             chip_id,
             construct_chip_from_cluster(
@@ -432,7 +444,19 @@ Cluster::Cluster(
     std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks) {
     cluster_desc = Cluster::create_cluster_descriptor();
 
-    for (auto& chip_id : target_devices) {
+    std::vector<chip_id_t> all_chips_local_first;
+    for (const auto& chip : target_devices) {
+        if (cluster_desc->is_chip_mmio_capable(chip)) {
+            all_chips_local_first.push_back(chip);
+        }
+    }
+    for (const auto& chip : target_devices) {
+        if (cluster_desc->is_chip_remote(chip)) {
+            all_chips_local_first.push_back(chip);
+        }
+    }
+
+    for (auto& chip_id : all_chips_local_first) {
         log_assert(
             cluster_desc->get_all_chips().find(chip_id) != cluster_desc->get_all_chips().end(),
             "Target device {} not present in current cluster!",
@@ -462,7 +486,19 @@ Cluster::Cluster(
     std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks) {
     cluster_desc = Cluster::create_cluster_descriptor(sdesc_path);
 
-    for (auto& chip_id : target_devices) {
+    std::vector<chip_id_t> all_chips_local_first;
+    for (const auto& chip : target_devices) {
+        if (cluster_desc->is_chip_mmio_capable(chip)) {
+            all_chips_local_first.push_back(chip);
+        }
+    }
+    for (const auto& chip : target_devices) {
+        if (cluster_desc->is_chip_remote(chip)) {
+            all_chips_local_first.push_back(chip);
+        }
+    }
+
+    for (auto& chip_id : all_chips_local_first) {
         log_assert(
             cluster_desc->get_all_chips().find(chip_id) != cluster_desc->get_all_chips().end(),
             "Target device {} not present in current cluster!",
@@ -498,7 +534,19 @@ Cluster::Cluster(
     std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks) {
     cluster_desc = std::move(cluster_descriptor);
 
-    for (auto& chip_id : cluster_desc->get_all_chips()) {
+    std::vector<chip_id_t> all_chips_local_first;
+    for (const auto& chip : cluster_desc->get_all_chips()) {
+        if (cluster_desc->is_chip_mmio_capable(chip)) {
+            all_chips_local_first.push_back(chip);
+        }
+    }
+    for (const auto& chip : cluster_desc->get_all_chips()) {
+        if (cluster_desc->is_chip_remote(chip)) {
+            all_chips_local_first.push_back(chip);
+        }
+    }
+
+    for (auto& chip_id : all_chips_local_first) {
         add_chip(
             chip_id,
             construct_chip_from_cluster(

--- a/device/remote_communication.cpp
+++ b/device/remote_communication.cpp
@@ -6,6 +6,7 @@
 #include "umd/device/remote_communication.h"
 
 #include "logger.hpp"
+#include "umd/device/chip/local_chip.h"
 #include "umd/device/driver_atomics.h"
 #include "umd/device/topology_utils.h"
 #include "umd/device/umd_utils.h"
@@ -35,31 +36,27 @@ struct routing_cmd_t {
 
 namespace tt::umd {
 
-RemoteCommunication::RemoteCommunication(TTDevice* tt_device) : tt_device(tt_device) {
-    lock_manager.initialize_mutex(MutexType::NON_MMIO, tt_device->get_pci_device()->get_device_num(), false);
-}
+RemoteCommunication::RemoteCommunication(LocalChip* local_chip) : local_chip_(local_chip) {}
 
-RemoteCommunication::~RemoteCommunication() {
-    lock_manager.clear_mutex(MutexType::NON_MMIO, tt_device->get_pci_device()->get_device_num());
-}
+RemoteCommunication::~RemoteCommunication() {}
 
 void RemoteCommunication::read_non_mmio(
-    uint8_t* mem_ptr,
-    tt_xy_pair core,
-    uint64_t address,
-    uint32_t size_in_bytes,
-    eth_coord_t target_chip,
-    const tt_xy_pair eth_core) {
+    eth_coord_t target_chip, tt_xy_pair target_core, void* dest, uint64_t core_src, uint32_t size_in_bytes) {
     using data_word_t = uint32_t;
     constexpr int DATA_WORD_SIZE = sizeof(data_word_t);
+    std::string write_tlb = "LARGE_WRITE_TLB";
+    std::string read_tlb = "LARGE_READ_TLB";
+    std::string empty_tlb = "";
 
-    tt_xy_pair translated_core = core;
-    core.x = translated_core.x;
-    core.y = translated_core.y;
+    auto translated_coord = local_chip_->get_soc_descriptor().translate_coord_to(
+        target_core, CoordSystem::VIRTUAL, umd_use_noc1 ? CoordSystem::PHYSICAL : CoordSystem::TRANSLATED);
+    target_core.x = translated_coord.x;
+    target_core.y = translated_coord.y;
 
-    auto host_address_params = tt_device->get_architecture_implementation()->get_host_address_params();
-    auto eth_interface_params = tt_device->get_architecture_implementation()->get_eth_interface_params();
-    auto noc_params = tt_device->get_architecture_implementation()->get_noc_params();
+    // TODO: To be removed when this is moved to Chip classes.
+    auto host_address_params = local_chip_->host_address_params;
+    auto eth_interface_params = local_chip_->eth_interface_params;
+    auto noc_params = local_chip_->noc_params;
 
     std::vector<std::uint32_t> erisc_command;
     std::vector<std::uint32_t> erisc_q_rptr;
@@ -78,33 +75,36 @@ void RemoteCommunication::read_non_mmio(
     //                    MUTEX ACQUIRE (NON-MMIO)
     //  do not locate any ethernet core reads/writes before this acquire
     //
-    auto lock = lock_manager.acquire_mutex(MutexType::NON_MMIO, tt_device->get_pci_device()->get_device_num());
+    auto lock =
+        local_chip_->acquire_mutex(MutexType::NON_MMIO, local_chip_->get_tt_device()->get_pci_device()->get_device_num());
 
-    const tt_xy_pair remote_transfer_ethernet_core = eth_core;
+    const tt_xy_pair remote_transfer_ethernet_core = local_chip_->get_remote_transfer_ethernet_core();
 
-    tt_device->read_from_device(
+    local_chip_->read_from_device(
+        remote_transfer_ethernet_core,
         erisc_q_ptrs.data(),
-        remote_transfer_ethernet_core,
         eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
-        eth_interface_params.remote_update_ptr_size_bytes * 2);
-    tt_device->read_from_device(
+        eth_interface_params.remote_update_ptr_size_bytes * 2,
+        read_tlb);
+    local_chip_->read_from_device(
+        remote_transfer_ethernet_core,
         erisc_resp_q_wptr.data(),
-        remote_transfer_ethernet_core,
         eth_interface_params.response_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
-        DATA_WORD_SIZE);
-    tt_device->read_from_device(
-        erisc_resp_q_rptr.data(),
+        DATA_WORD_SIZE,
+        read_tlb);
+    local_chip_->read_from_device(
         remote_transfer_ethernet_core,
+        erisc_resp_q_rptr.data(),
         eth_interface_params.response_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes +
             eth_interface_params.remote_update_ptr_size_bytes,
-        DATA_WORD_SIZE);
+        DATA_WORD_SIZE,
+        read_tlb);
 
     bool full = is_non_mmio_cmd_q_full(eth_interface_params, erisc_q_ptrs[0], erisc_q_ptrs[4]);
     erisc_q_rptr.resize(1);
     erisc_q_rptr[0] = erisc_q_ptrs[4];
 
-    // bool use_dram;
-    bool use_dram = false;
+    bool use_dram;
     uint32_t max_block_size;
 
     use_dram = size_in_bytes > 1024;
@@ -116,18 +116,19 @@ void RemoteCommunication::read_non_mmio(
 
     while (offset < size_in_bytes) {
         while (full) {
-            tt_device->read_from_device(
-                erisc_q_rptr.data(),
+            local_chip_->read_from_device(
                 remote_transfer_ethernet_core,
+                erisc_q_rptr.data(),
                 eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes +
                     eth_interface_params.remote_update_ptr_size_bytes,
-                DATA_WORD_SIZE);
+                DATA_WORD_SIZE,
+                read_tlb);
             full = is_non_mmio_cmd_q_full(eth_interface_params, erisc_q_ptrs[0], erisc_q_rptr[0]);
         }
 
         uint32_t req_wr_ptr = erisc_q_ptrs[0] & eth_interface_params.cmd_buf_size_mask;
-        if ((address + offset) & 0x1F) {  // address not 32-byte aligned
-            block_size = DATA_WORD_SIZE;  // 4 byte aligned block
+        if ((core_src + offset) & 0x1F) {  // address not 32-byte aligned
+            block_size = DATA_WORD_SIZE;   // 4 byte aligned block
         } else {
             block_size = offset + max_block_size > size_in_bytes ? size_in_bytes - offset : max_block_size;
             // Align up to 4 bytes.
@@ -151,9 +152,10 @@ void RemoteCommunication::read_non_mmio(
 
         // Send the read request
         log_assert(
-            (req_flags == eth_interface_params.cmd_rd_req) || (((address + offset) & 0x1F) == 0),
+            (req_flags == eth_interface_params.cmd_rd_req) || (((core_src + offset) & 0x1F) == 0),
             "Block mode offset must be 32-byte aligned.");  // Block mode offset must be 32-byte aligned.
-        new_cmd->sys_addr = get_sys_addr(noc_params, target_chip.x, target_chip.y, core.x, core.y, address + offset);
+        new_cmd->sys_addr =
+            get_sys_addr(noc_params, target_chip.x, target_chip.y, target_core.x, target_core.y, core_src + offset);
         new_cmd->rack = get_sys_rack(eth_interface_params, target_chip.rack, target_chip.shelf);
         new_cmd->data = block_size;
         new_cmd->flags = req_flags;
@@ -161,22 +163,25 @@ void RemoteCommunication::read_non_mmio(
         if (use_dram) {
             new_cmd->src_addr_tag = host_dram_block_addr;
         }
-        tt_device->write_to_device(
-            erisc_command.data(),
+        local_chip_->write_to_device(
             remote_transfer_ethernet_core,
+            erisc_command.data(),
             eth_interface_params.request_routing_cmd_queue_base + (sizeof(routing_cmd_t) * req_wr_ptr),
-            erisc_command.size() * DATA_WORD_SIZE);
+            erisc_command.size() * DATA_WORD_SIZE,
+            write_tlb);
+        ;
         tt_driver_atomics::sfence();
 
         erisc_q_ptrs[0] = (erisc_q_ptrs[0] + 1) & eth_interface_params.cmd_buf_ptr_mask;
         std::vector<std::uint32_t> erisc_q_wptr;
         erisc_q_wptr.resize(1);
         erisc_q_wptr[0] = erisc_q_ptrs[0];
-        tt_device->write_to_device(
-            erisc_q_wptr.data(),
+        local_chip_->write_to_device(
             remote_transfer_ethernet_core,
+            erisc_q_wptr.data(),
             eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
-            erisc_q_wptr.size() * DATA_WORD_SIZE);
+            erisc_q_wptr.size() * DATA_WORD_SIZE,
+            write_tlb);
         tt_driver_atomics::sfence();
         // If there is more data to read and this command will make the q full, set full to 1.
         // otherwise full stays false so that we do not poll the rd pointer in next iteration.
@@ -184,16 +189,17 @@ void RemoteCommunication::read_non_mmio(
         // to poll rd pointer in every iteration.
 
         if (is_non_mmio_cmd_q_full(eth_interface_params, (erisc_q_ptrs[0]), erisc_q_rptr[0])) {
-            tt_device->read_from_device(
-                erisc_q_ptrs.data(),
+            local_chip_->read_from_device(
                 remote_transfer_ethernet_core,
+                erisc_q_ptrs.data(),
                 eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
-                eth_interface_params.remote_update_ptr_size_bytes * 2);
+                eth_interface_params.remote_update_ptr_size_bytes * 2,
+                read_tlb);
             full = is_non_mmio_cmd_q_full(eth_interface_params, erisc_q_ptrs[0], erisc_q_ptrs[4]);
             erisc_q_rptr[0] = erisc_q_ptrs[4];
         }
 
-        // Wait for read request completion and extract the data into the `mem_ptr`
+        // Wait for read request completion and extract the data into the `dest`
 
         // erisc firmware will:
         // 1. clear response flags
@@ -204,21 +210,23 @@ void RemoteCommunication::read_non_mmio(
         // So we have to wait for wrptr to advance, then wait for flags to be nonzero, then read data.
 
         do {
-            tt_device->read_from_device(
-                erisc_resp_q_wptr.data(),
+            local_chip_->read_from_device(
                 remote_transfer_ethernet_core,
+                erisc_resp_q_wptr.data(),
                 eth_interface_params.response_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
-                DATA_WORD_SIZE);
+                DATA_WORD_SIZE,
+                read_tlb);
         } while (erisc_resp_q_rptr[0] == erisc_resp_q_wptr[0]);
         tt_driver_atomics::lfence();
         uint32_t flags_offset = 12 + sizeof(routing_cmd_t) * resp_rd_ptr;
         std::vector<std::uint32_t> erisc_resp_flags = std::vector<uint32_t>(1);
         do {
-            tt_device->read_from_device(
-                erisc_resp_flags.data(),
+            local_chip_->read_from_device(
                 remote_transfer_ethernet_core,
+                erisc_resp_flags.data(),
                 eth_interface_params.response_routing_cmd_queue_base + flags_offset,
-                DATA_WORD_SIZE);
+                DATA_WORD_SIZE,
+                read_tlb);
         } while (erisc_resp_flags[0] == 0);
 
         if (erisc_resp_flags[0] == resp_flags) {
@@ -226,39 +234,50 @@ void RemoteCommunication::read_non_mmio(
             uint32_t data_offset = 8 + sizeof(routing_cmd_t) * resp_rd_ptr;
             if (block_size == DATA_WORD_SIZE) {
                 std::vector<std::uint32_t> erisc_resp_data = std::vector<uint32_t>(1);
-                tt_device->read_from_device(
-                    erisc_resp_data.data(),
+                local_chip_->read_from_device(
                     remote_transfer_ethernet_core,
+                    erisc_resp_data.data(),
                     eth_interface_params.response_routing_cmd_queue_base + data_offset,
-                    DATA_WORD_SIZE);
+                    DATA_WORD_SIZE,
+                    read_tlb);
                 if (size_in_bytes - offset < 4) {
                     // Handle misaligned (4 bytes) data at the end of the block.
                     // Only read remaining bytes into the host buffer, instead of reading the full uint32_t
-                    std::memcpy((uint8_t*)mem_ptr + offset, erisc_resp_data.data(), size_in_bytes - offset);
+                    std::memcpy((uint8_t*)dest + offset, erisc_resp_data.data(), size_in_bytes - offset);
                 } else {
-                    *((uint32_t*)mem_ptr + offset / DATA_WORD_SIZE) = erisc_resp_data[0];
+                    *((uint32_t*)dest + offset / DATA_WORD_SIZE) = erisc_resp_data[0];
                 }
             } else {
-                uint32_t buf_address = eth_interface_params.eth_routing_data_buffer_addr + resp_rd_ptr * max_block_size;
-                size_buffer_to_capacity(data_block, block_size);
-                tt_device->read_from_device(data_block.data(), remote_transfer_ethernet_core, buf_address, block_size);
-                // assert(mem_ptr.size() - (offset/DATA_WORD_SIZE) >= (block_size * DATA_WORD_SIZE));
+                // Read 4 byte aligned block from device/sysmem
+                if (use_dram) {
+                    size_buffer_to_capacity(data_block, block_size);
+                    local_chip_->read_from_sysmem(
+                        host_dram_channel, data_block.data(), host_dram_block_addr, block_size);
+                } else {
+                    uint32_t buf_address =
+                        eth_interface_params.eth_routing_data_buffer_addr + resp_rd_ptr * max_block_size;
+                    size_buffer_to_capacity(data_block, block_size);
+                    local_chip_->read_from_device(
+                        remote_transfer_ethernet_core, data_block.data(), buf_address, block_size, read_tlb);
+                }
+                // assert(dest.size() - (offset/DATA_WORD_SIZE) >= (block_size * DATA_WORD_SIZE));
                 log_assert(
                     (data_block.size() * DATA_WORD_SIZE) >= block_size,
                     "Incorrect data size read back from sysmem/device");
                 // Account for misalignment by skipping any padding bytes in the copied data_block
-                memcpy((uint8_t*)mem_ptr + offset, data_block.data(), std::min(block_size, size_in_bytes - offset));
+                memcpy((uint8_t*)dest + offset, data_block.data(), std::min(block_size, size_in_bytes - offset));
             }
         }
 
         // Finally increment the rdptr for the response command q
         erisc_resp_q_rptr[0] = (erisc_resp_q_rptr[0] + 1) & eth_interface_params.cmd_buf_ptr_mask;
-        tt_device->write_to_device(
-            erisc_resp_q_rptr.data(),
+        local_chip_->write_to_device(
             remote_transfer_ethernet_core,
+            erisc_resp_q_rptr.data(),
             eth_interface_params.response_cmd_queue_base + sizeof(remote_update_ptr_t) +
                 eth_interface_params.cmd_counters_size_bytes,
-            erisc_resp_q_rptr.size() * DATA_WORD_SIZE);
+            erisc_resp_q_rptr.size() * DATA_WORD_SIZE,
+            write_tlb);
         tt_driver_atomics::sfence();
         log_assert(erisc_resp_flags[0] == resp_flags, "Unexpected ERISC Response Flags.");
 
@@ -279,9 +298,11 @@ void RemoteCommunication::write_to_non_mmio(
     constexpr int DATA_WORD_SIZE = sizeof(data_word_t);
     constexpr int BROADCAST_HEADER_SIZE = sizeof(data_word_t) * 8;  // Broadcast header is 8 words
 
-    auto host_address_params = tt_device->get_architecture_implementation()->get_host_address_params();
-    auto eth_interface_params = tt_device->get_architecture_implementation()->get_eth_interface_params();
-    auto noc_params = tt_device->get_architecture_implementation()->get_noc_params();
+    auto host_address_params =
+        local_chip_->get_tt_device()->get_architecture_implementation()->get_host_address_params();
+    auto eth_interface_params =
+        local_chip_->get_tt_device()->get_architecture_implementation()->get_eth_interface_params();
+    auto noc_params = local_chip_->get_tt_device()->get_architecture_implementation()->get_noc_params();
 
     tt_xy_pair translated_core = core;
     core.x = translated_core.x;
@@ -314,7 +335,8 @@ void RemoteCommunication::write_to_non_mmio(
     //  do not locate any ethernet core reads/writes before this acquire
     //
 
-    auto lock = lock_manager.acquire_mutex(MutexType::NON_MMIO, tt_device->get_pci_device()->get_device_num());
+    auto lock =
+        local_chip_->acquire_mutex(MutexType::NON_MMIO, local_chip_->get_tt_device()->get_pci_device()->get_device_num());
 
     int active_core_for_txn = 0;
 
@@ -322,7 +344,7 @@ void RemoteCommunication::write_to_non_mmio(
 
     erisc_command.resize(sizeof(routing_cmd_t) / DATA_WORD_SIZE);
     new_cmd = (routing_cmd_t*)&erisc_command[0];
-    tt_device->read_from_device(
+    local_chip_->get_tt_device()->read_from_device(
         erisc_q_ptrs.data(),
         remote_transfer_ethernet_core,
         eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
@@ -336,7 +358,7 @@ void RemoteCommunication::write_to_non_mmio(
     erisc_q_rptr[0] = erisc_q_ptrs[4];
     while (offset < size_in_bytes) {
         while (full) {
-            tt_device->read_from_device(
+            local_chip_->get_tt_device()->read_from_device(
                 erisc_q_rptr.data(),
                 remote_transfer_ethernet_core,
                 eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes +
@@ -392,7 +414,7 @@ void RemoteCommunication::write_to_non_mmio(
                 uint32_t buf_address = eth_interface_params.eth_routing_data_buffer_addr + req_wr_ptr * max_block_size;
                 size_buffer_to_capacity(data_block, block_size);
                 memcpy(&data_block[0], (uint8_t*)mem_ptr + offset, transfer_size);
-                tt_device->write_to_device(
+                local_chip_->get_tt_device()->write_to_device(
                     data_block.data(), remote_transfer_ethernet_core, buf_address, data_block.size() * DATA_WORD_SIZE);
             }
             tt_driver_atomics::sfence();
@@ -424,7 +446,7 @@ void RemoteCommunication::write_to_non_mmio(
         if (use_dram) {
             new_cmd->src_addr_tag = host_dram_block_addr;
         }
-        tt_device->write_to_device(
+        local_chip_->get_tt_device()->write_to_device(
             erisc_command.data(),
             remote_transfer_ethernet_core,
             eth_interface_params.request_routing_cmd_queue_base + (sizeof(routing_cmd_t) * req_wr_ptr),
@@ -435,7 +457,7 @@ void RemoteCommunication::write_to_non_mmio(
         std::vector<std::uint32_t> erisc_q_wptr;
         erisc_q_wptr.resize(1);
         erisc_q_wptr[0] = erisc_q_ptrs[0];
-        tt_device->write_to_device(
+        local_chip_->get_tt_device()->write_to_device(
             erisc_q_wptr.data(),
             remote_transfer_ethernet_core,
             eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
@@ -453,7 +475,7 @@ void RemoteCommunication::write_to_non_mmio(
                 eth_interface_params, (erisc_q_ptrs[0]) & eth_interface_params.cmd_buf_ptr_mask, erisc_q_rptr[0])) {
             active_core_for_txn = (active_core_for_txn + 1) % NON_EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS;
             remote_transfer_ethernet_core = eth_core;
-            tt_device->read_from_device(
+            local_chip_->get_tt_device()->read_from_device(
                 erisc_q_ptrs.data(),
                 remote_transfer_ethernet_core,
                 eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
@@ -465,7 +487,8 @@ void RemoteCommunication::write_to_non_mmio(
 }
 
 void RemoteCommunication::wait_for_non_mmio_flush(std::vector<tt_xy_pair> remote_transfer_eth_cores) {
-    auto eth_interface_params = tt_device->get_architecture_implementation()->get_eth_interface_params();
+    auto eth_interface_params =
+        local_chip_->get_tt_device()->get_architecture_implementation()->get_eth_interface_params();
 
     std::vector<std::uint32_t> erisc_txn_counters = std::vector<uint32_t>(2);
     std::vector<std::uint32_t> erisc_q_ptrs =
@@ -475,7 +498,7 @@ void RemoteCommunication::wait_for_non_mmio_flush(std::vector<tt_xy_pair> remote
     std::vector<tt_xy_pair> active_eth_cores = remote_transfer_eth_cores;
     for (tt_xy_pair& eth_core : active_eth_cores) {
         do {
-            tt_device->read_from_device(
+            local_chip_->get_tt_device()->read_from_device(
                 erisc_q_ptrs.data(),
                 eth_core,
                 eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
@@ -485,7 +508,7 @@ void RemoteCommunication::wait_for_non_mmio_flush(std::vector<tt_xy_pair> remote
     // wait for all write responses to come back.
     for (tt_xy_pair& eth_core : active_eth_cores) {
         do {
-            tt_device->read_from_device(
+            local_chip_->get_tt_device()->read_from_device(
                 erisc_txn_counters.data(), eth_core, eth_interface_params.request_cmd_queue_base, 8);
         } while (erisc_txn_counters[0] != erisc_txn_counters[1]);
     }

--- a/device/remote_communication.cpp
+++ b/device/remote_communication.cpp
@@ -70,8 +70,8 @@ void RemoteCommunication::read_non_mmio(
     //                    MUTEX ACQUIRE (NON-MMIO)
     //  do not locate any ethernet core reads/writes before this acquire
     //
-    auto lock =
-        local_chip_->acquire_mutex(MutexType::NON_MMIO, local_chip_->get_tt_device()->get_pci_device()->get_device_num());
+    auto lock = local_chip_->acquire_mutex(
+        MutexType::NON_MMIO, local_chip_->get_tt_device()->get_pci_device()->get_device_num());
 
     const tt_xy_pair remote_transfer_ethernet_core = local_chip_->get_remote_transfer_ethernet_core();
 
@@ -330,8 +330,8 @@ void RemoteCommunication::write_to_non_mmio(
     //  do not locate any ethernet core reads/writes before this acquire
     //
 
-    auto lock =
-        local_chip_->acquire_mutex(MutexType::NON_MMIO, local_chip_->get_tt_device()->get_pci_device()->get_device_num());
+    auto lock = local_chip_->acquire_mutex(
+        MutexType::NON_MMIO, local_chip_->get_tt_device()->get_pci_device()->get_device_num());
 
     int active_core_for_txn = 0;
 

--- a/device/remote_communication.cpp
+++ b/device/remote_communication.cpp
@@ -48,11 +48,6 @@ void RemoteCommunication::read_non_mmio(
     std::string read_tlb = "LARGE_READ_TLB";
     std::string empty_tlb = "";
 
-    auto translated_coord = local_chip_->get_soc_descriptor().translate_coord_to(
-        target_core, CoordSystem::VIRTUAL, umd_use_noc1 ? CoordSystem::PHYSICAL : CoordSystem::TRANSLATED);
-    target_core.x = translated_coord.x;
-    target_core.y = translated_coord.y;
-
     // TODO: To be removed when this is moved to Chip classes.
     auto host_address_params = local_chip_->host_address_params;
     auto eth_interface_params = local_chip_->eth_interface_params;

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -883,7 +883,7 @@ const std::unordered_map<chip_id_t, chip_id_t> tt_ClusterDescriptor::get_chips_w
 
 const std::unordered_set<chip_id_t> &tt_ClusterDescriptor::get_all_chips() const { return this->enabled_active_chips; }
 
-const std::vector<chip_id_t> &tt_ClusterDescriptor::get_all_chips_local_first() const {
+const std::vector<chip_id_t> tt_ClusterDescriptor::get_all_chips_local_first() const {
     std::vector<chip_id_t> all_chips_local_first;
     for (const auto &chip : get_all_chips()) {
         if (is_chip_mmio_capable(chip)) {

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -883,6 +883,21 @@ const std::unordered_map<chip_id_t, chip_id_t> tt_ClusterDescriptor::get_chips_w
 
 const std::unordered_set<chip_id_t> &tt_ClusterDescriptor::get_all_chips() const { return this->enabled_active_chips; }
 
+const std::vector<chip_id_t> &tt_ClusterDescriptor::get_all_chips_local_first() const {
+    std::vector<chip_id_t> all_chips_local_first;
+    for (const auto &chip : get_all_chips()) {
+        if (is_chip_mmio_capable(chip)) {
+            all_chips_local_first.push_back(chip);
+        }
+    }
+    for (const auto &chip : get_all_chips()) {
+        if (is_chip_remote(chip)) {
+            all_chips_local_first.push_back(chip);
+        }
+    }
+    return all_chips_local_first;
+}
+
 const std::unordered_map<chip_id_t, std::uint32_t> &tt_ClusterDescriptor::get_harvesting_info() const {
     return harvesting_masks;
 }

--- a/tests/wormhole/test_remote_communication_wh.cpp
+++ b/tests/wormhole/test_remote_communication_wh.cpp
@@ -24,7 +24,7 @@ TEST(RemoteCommunicationWormhole, BasicRemoteCommunicationIO) {
 
     chip_id_t mmio_chip_id = *cluster->get_target_mmio_device_ids().begin();
     std::unique_ptr<RemoteCommunication> remote_comm =
-        std::make_unique<RemoteCommunication>(cluster->get_tt_device(mmio_chip_id));
+        std::make_unique<RemoteCommunication>(cluster->get_local_chip(mmio_chip_id));
 
     tt_ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
 
@@ -66,12 +66,7 @@ TEST(RemoteCommunicationWormhole, BasicRemoteCommunicationIO) {
             remote_comm->wait_for_non_mmio_flush(active_eth_cores);
 
             remote_comm->read_non_mmio(
-                (uint8_t*)data_read.data(),
-                core,
-                address1,
-                data_read.size() * sizeof(uint32_t),
-                remote_eth_coord,
-                active_eth_cores.at(0));
+                remote_eth_coord, core, (uint8_t*)data_read.data(), address1, data_read.size() * sizeof(uint32_t));
 
             ASSERT_EQ(data_to_write, data_read)
                 << "Vector read back from core " << core.str() << " does not match what was written";

--- a/tests/wormhole/test_remote_communication_wh.cpp
+++ b/tests/wormhole/test_remote_communication_wh.cpp
@@ -47,9 +47,11 @@ TEST(RemoteCommunicationWormhole, BasicRemoteCommunicationIO) {
         eth_coord_t remote_eth_coord = cluster_desc->get_chip_locations().at(remote_chip_id);
 
         for (const CoreCoord& core : cluster->get_soc_descriptor(remote_chip_id).get_cores(CoreType::TENSIX)) {
+            CoreCoord translated_core =
+                cluster->get_soc_descriptor(remote_chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
             remote_comm->write_to_non_mmio(
                 (uint8_t*)data_to_write.data(),
-                core,
+                translated_core,
                 address0,
                 data_to_write.size() * sizeof(uint32_t),
                 remote_eth_coord,
@@ -66,7 +68,11 @@ TEST(RemoteCommunicationWormhole, BasicRemoteCommunicationIO) {
             remote_comm->wait_for_non_mmio_flush(active_eth_cores);
 
             remote_comm->read_non_mmio(
-                remote_eth_coord, core, (uint8_t*)data_read.data(), address1, data_read.size() * sizeof(uint32_t));
+                remote_eth_coord,
+                translated_core,
+                (uint8_t*)data_read.data(),
+                address1,
+                data_read.size() * sizeof(uint32_t));
 
             ASSERT_EQ(data_to_write, data_read)
                 << "Vector read back from core " << core.str() << " does not match what was written";


### PR DESCRIPTION
### Issue
On a path of #248

### Description
In this PR, remote read communication is moved to RemoteChip.
There's work on:
1. Initial changes to accommodate RemoteChip to even do what's needed
2. Actual move of read and write to RemoteChip
3. Additional complexities due to a fact that remote write can be done on a LocalChip in case of ethernet broadcast.

1+2+3 seemed too much for a PR, so instead I did just 1+2 by moving only the read part, and 2+3 will be done in a next part where I'll move the write part.

### List of the changes
- RemoteCommunication now accepts LocalChip instead of TTDevice
- Copied the read code from cluster.cpp instead of existing RemoteCommunication's hacked read code
- In RemoteCommunication::write_non_mmio I did slight changes due to now having LocalChip instead of TTDevice and LockManager.
- It only made sense that get_local_chip and get_remote_chip actually return the right classes. I tried other options but I liked this one the most. In any case, those two calls should not be used a lot (in the final code where everywthing is moved to chip classes). Added get_remote_chip call.
- RemoteChip can now do a read through read_from_device, same api as is for LocalChip. This will get unified in Cluster in some of the following PRs. Also, fallback_tlbs will be removed in some of the following PRs
- Slightly changed the order of arguments in read_non_mmio so that first the target is given, then addresses, then size. Note that eth core used is not passed anymore, but it is fetched from the local_chip_. This change was actually done in https://github.com/tenstorrent/tt-umd/pull/667

### Testing
Existing CI tests.
Also tt_metal tests, since I'm uncertain on the scope of our remote tests:

### API Changes
There are no API changes in this PR.
