### PR TITLE
Add a test for reading NOC1 noc node id register

### DIFF
--- a/device/api/umd/device/blackhole_implementation.h
+++ b/device/api/umd/device/blackhole_implementation.h
@@ -240,6 +240,7 @@ constexpr std::array<std::pair<CoreType, uint64_t>, 5> NOC1_CONTROL_REG_ADDR_BAS
      {CoreType::PCIE, 0xFFFFFFFFFF000000ULL},
      {CoreType::ARC, 0xFFFFFFFFFF000000ULL}}};
 static const uint64_t NOC_NODE_ID_OFFSET = 0x44;
+
 static const size_t eth_translated_coordinate_start_x = 20;
 static const size_t eth_translated_coordinate_start_y = 25;
 

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -308,9 +308,21 @@ void LocalChip::read_from_device_reg(
 
 tt_xy_pair LocalChip::translate_chip_coord_virtual_to_translated(const tt_xy_pair core) const {
     CoreCoord core_coord = soc_descriptor_.get_coord_at(core, CoordSystem::VIRTUAL);
-    auto translated_coord =
-        soc_descriptor_.translate_coord_to(core_coord, umd_use_noc1 ? CoordSystem::PHYSICAL : CoordSystem::TRANSLATED);
-    return translated_coord;
+    if (soc_descriptor_.noc_translation_enabled) {
+        if (soc_descriptor_.arch == tt::ARCH::BLACKHOLE) {
+            if (core_coord.core_type == CoreType::TENSIX || !umd_use_noc1) {
+                return soc_descriptor_.translate_coord_to(core_coord, CoordSystem::TRANSLATED);
+            } else {
+                return soc_descriptor_.translate_coord_to(core_coord, CoordSystem::NOC1);
+            }
+        } else {
+            return soc_descriptor_.translate_coord_to(
+                core_coord, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::TRANSLATED);
+        }
+    } else {
+        return soc_descriptor_.translate_coord_to(
+            core_coord, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::TRANSLATED);
+    }
 }
 
 void LocalChip::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& active_eth_cores_per_chip) {

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -308,6 +308,10 @@ void LocalChip::read_from_device_reg(
 
 tt_xy_pair LocalChip::translate_chip_coord_virtual_to_translated(const tt_xy_pair core) const {
     CoreCoord core_coord = soc_descriptor_.get_coord_at(core, CoordSystem::VIRTUAL);
+    // Since NOC1 and translated coordinate space overlaps for Tensix cores on Blackhole,
+    // Tensix cores are always used in translated space. Other cores are used either in
+    // NOC1 or translated space depending on the umd_use_noc1 flag.
+    // On Wormhole Tensix can use NOC1 space if umd_use_noc1 is set to true.
     if (soc_descriptor_.noc_translation_enabled) {
         if (soc_descriptor_.arch == tt::ARCH::BLACKHOLE) {
             if (core_coord.core_type == CoreType::TENSIX || !umd_use_noc1) {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -2707,9 +2707,21 @@ tt_xy_pair Cluster::translate_to_api_coords(const chip_id_t chip, const tt::umd:
 
 tt_xy_pair Cluster::translate_chip_coord_virtual_to_translated(const chip_id_t chip_id, const tt_xy_pair core) const {
     CoreCoord core_coord = get_soc_descriptor(chip_id).get_coord_at(core, CoordSystem::VIRTUAL);
-    auto translated_coord = get_soc_descriptor(chip_id).translate_coord_to(
-        core_coord, umd_use_noc1 ? CoordSystem::PHYSICAL : CoordSystem::TRANSLATED);
-    return translated_coord;
+    if (get_soc_descriptor(chip_id).noc_translation_enabled) {
+        if (get_soc_descriptor(chip_id).arch == tt::ARCH::BLACKHOLE) {
+            if (core_coord.core_type == CoreType::TENSIX || !umd_use_noc1) {
+                return get_soc_descriptor(chip_id).translate_coord_to(core_coord, CoordSystem::TRANSLATED);
+            } else {
+                return get_soc_descriptor(chip_id).translate_coord_to(core_coord, CoordSystem::NOC1);
+            }
+        } else {
+            return get_soc_descriptor(chip_id).translate_coord_to(
+                core_coord, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::TRANSLATED);
+        }
+    } else {
+        return get_soc_descriptor(chip_id).translate_coord_to(
+            core_coord, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::TRANSLATED);
+    }
 }
 
 std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(std::string sdesc_path) {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -2707,6 +2707,10 @@ tt_xy_pair Cluster::translate_to_api_coords(const chip_id_t chip, const tt::umd:
 
 tt_xy_pair Cluster::translate_chip_coord_virtual_to_translated(const chip_id_t chip_id, const tt_xy_pair core) const {
     CoreCoord core_coord = get_soc_descriptor(chip_id).get_coord_at(core, CoordSystem::VIRTUAL);
+    // Since NOC1 and translated coordinate space overlaps for Tensix cores on Blackhole,
+    // Tensix cores are always used in translated space. Other cores are used either in
+    // NOC1 or translated space depending on the umd_use_noc1 flag.
+    // On Wormhole Tensix can use NOC1 space if umd_use_noc1 is set to true.
     if (get_soc_descriptor(chip_id).noc_translation_enabled) {
         if (get_soc_descriptor(chip_id).arch == tt::ARCH::BLACKHOLE) {
             if (core_coord.core_type == CoreType::TENSIX || !umd_use_noc1) {

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -10,6 +10,7 @@ set(API_TESTS_SRCS
     test_software_harvesting.cpp
     test_sysmem_manager.cpp
     test_tt_device.cpp
+    test_noc.cpp
 )
 
 add_executable(api_tests ${API_TESTS_SRCS})

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -339,63 +339,6 @@ TEST(TestCluster, TestClusterLogicalETHChannelsConnectivity) {
     }
 }
 
-TEST(TestCluster, TestClusterNocId) {
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
-
-    auto read_noc_id_reg = [&](std::unique_ptr<Cluster>& cluster, chip_id_t chip, CoreCoord core) {
-        const uint64_t noc_node_id_offset = 0x2C;
-        const uint64_t noc_node_id_reg_addr =
-            cluster->get_tt_device(0)->get_architecture_implementation()->get_noc_reg_base(core.core_type, 0) +
-            cluster->get_tt_device(0)->get_architecture_implementation()->get_noc_node_id_offset();
-        uint32_t noc_node_id_val;
-        cluster->read_from_device(
-            &noc_node_id_val, chip, core, noc_node_id_reg_addr, sizeof(noc_node_id_val), "REG_TLB");
-        uint32_t x = noc_node_id_val & 0x3F;
-        uint32_t y = (noc_node_id_val >> 6) & 0x3F;
-        return tt_xy_pair(x, y);
-    };
-
-    auto check_noc_id_cores = [read_noc_id_reg](std::unique_ptr<Cluster>& cluster, chip_id_t chip, CoreType core_type) {
-        const std::vector<CoreCoord>& cores = cluster->get_soc_descriptor(chip).get_cores(core_type);
-        for (const CoreCoord& core : cores) {
-            const auto [x, y] = read_noc_id_reg(cluster, chip, core);
-            EXPECT_EQ(core.x, x);
-            EXPECT_EQ(core.y, y);
-        }
-    };
-
-    auto check_noc_id_harvested_cores = [read_noc_id_reg](
-                                            std::unique_ptr<Cluster>& cluster, chip_id_t chip, CoreType core_type) {
-        const std::vector<CoreCoord>& cores = cluster->get_soc_descriptor(chip).get_harvested_cores(core_type);
-        for (const CoreCoord& core : cores) {
-            const auto [x, y] = read_noc_id_reg(cluster, chip, core);
-            EXPECT_EQ(core.x, x);
-            EXPECT_EQ(core.y, y);
-        }
-    };
-
-    tt::ARCH arch = cluster->get_cluster_description()->get_arch(0);
-
-    for (chip_id_t chip : cluster->get_target_device_ids()) {
-        check_noc_id_cores(cluster, chip, CoreType::TENSIX);
-        check_noc_id_harvested_cores(cluster, chip, CoreType::TENSIX);
-
-        check_noc_id_cores(cluster, chip, CoreType::ETH);
-        check_noc_id_harvested_cores(cluster, chip, CoreType::ETH);
-
-        if (arch == tt::ARCH::BLACKHOLE) {
-            check_noc_id_cores(cluster, chip, CoreType::DRAM);
-            check_noc_id_harvested_cores(cluster, chip, CoreType::DRAM);
-        }
-
-        check_noc_id_cores(cluster, chip, CoreType::ARC);
-
-        check_noc_id_cores(cluster, chip, CoreType::PCIE);
-
-        // TODO: add readouts for router cores.
-    }
-}
-
 TEST(TestCluster, TestClusterAICLKControl) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 

--- a/tests/api/test_noc.cpp
+++ b/tests/api/test_noc.cpp
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// This file holds Cluster specific API examples.
+
+#include <gtest/gtest.h>
+
+#include "umd/device/cluster.h"
+#include "umd/device/tt_cluster_descriptor.h"
+
+using namespace tt::umd;
+
+TEST(TestCluster, TestClusterNoc0Id) {
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+
+    auto read_noc_id_reg = [&](std::unique_ptr<Cluster>& cluster, chip_id_t chip, CoreCoord core) {
+        const uint64_t noc_node_id_reg_addr =
+            cluster->get_tt_device(0)->get_architecture_implementation()->get_noc_reg_base(core.core_type, 0) +
+            cluster->get_tt_device(0)->get_architecture_implementation()->get_noc_node_id_offset();
+        uint32_t noc_node_id_val;
+        cluster->read_from_device(
+            &noc_node_id_val, chip, core, noc_node_id_reg_addr, sizeof(noc_node_id_val), "REG_TLB");
+        uint32_t x = noc_node_id_val & 0x3F;
+        uint32_t y = (noc_node_id_val >> 6) & 0x3F;
+        return tt_xy_pair(x, y);
+    };
+
+    auto check_noc_id_cores = [read_noc_id_reg](std::unique_ptr<Cluster>& cluster, chip_id_t chip, CoreType core_type) {
+        const std::vector<CoreCoord>& cores = cluster->get_soc_descriptor(chip).get_cores(core_type);
+        for (const CoreCoord& core : cores) {
+            const auto [x, y] = read_noc_id_reg(cluster, chip, core);
+            EXPECT_EQ(core.x, x);
+            EXPECT_EQ(core.y, y);
+        }
+    };
+
+    auto check_noc_id_harvested_cores = [read_noc_id_reg](
+                                            std::unique_ptr<Cluster>& cluster, chip_id_t chip, CoreType core_type) {
+        const std::vector<CoreCoord>& cores = cluster->get_soc_descriptor(chip).get_harvested_cores(core_type);
+        for (const CoreCoord& core : cores) {
+            const auto [x, y] = read_noc_id_reg(cluster, chip, core);
+            EXPECT_EQ(core.x, x);
+            EXPECT_EQ(core.y, y);
+        }
+    };
+
+    tt::ARCH arch = cluster->get_cluster_description()->get_arch(0);
+
+    for (chip_id_t chip : cluster->get_target_device_ids()) {
+        check_noc_id_cores(cluster, chip, CoreType::TENSIX);
+        check_noc_id_harvested_cores(cluster, chip, CoreType::TENSIX);
+
+        check_noc_id_cores(cluster, chip, CoreType::ETH);
+        check_noc_id_harvested_cores(cluster, chip, CoreType::ETH);
+
+        if (arch == tt::ARCH::BLACKHOLE) {
+            check_noc_id_cores(cluster, chip, CoreType::DRAM);
+            check_noc_id_harvested_cores(cluster, chip, CoreType::DRAM);
+        }
+
+        check_noc_id_cores(cluster, chip, CoreType::ARC);
+
+        check_noc_id_cores(cluster, chip, CoreType::PCIE);
+
+        // TODO: add readouts for router cores.
+    }
+}
+
+TEST(TestCluster, TestClusterNoc1Id) {
+    TTDevice::use_noc1(true);
+
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+
+    auto read_noc_id_reg = [&](std::unique_ptr<Cluster>& cluster, chip_id_t chip, CoreCoord core) {
+        const uint64_t noc_node_id_reg_addr =
+            cluster->get_tt_device(0)->get_architecture_implementation()->get_noc_reg_base(core.core_type, 1) +
+            cluster->get_tt_device(0)->get_architecture_implementation()->get_noc_node_id_offset();
+        uint32_t noc_node_id_val;
+        cluster->read_from_device(
+            &noc_node_id_val, chip, core, noc_node_id_reg_addr, sizeof(noc_node_id_val), "REG_TLB");
+        uint32_t x = noc_node_id_val & 0x3F;
+        uint32_t y = (noc_node_id_val >> 6) & 0x3F;
+        return tt_xy_pair(x, y);
+    };
+
+    auto check_noc_id_cores = [read_noc_id_reg](std::unique_ptr<Cluster>& cluster, chip_id_t chip, CoreType core_type) {
+        const std::vector<CoreCoord>& cores = cluster->get_soc_descriptor(chip).get_cores(core_type, CoordSystem::NOC1);
+        for (const CoreCoord& core : cores) {
+            const auto [x, y] = read_noc_id_reg(cluster, chip, core);
+            EXPECT_EQ(core.x, x);
+            EXPECT_EQ(core.y, y);
+        }
+    };
+
+    auto check_noc_id_harvested_cores = [read_noc_id_reg](
+                                            std::unique_ptr<Cluster>& cluster, chip_id_t chip, CoreType core_type) {
+        const std::vector<CoreCoord>& cores =
+            cluster->get_soc_descriptor(chip).get_harvested_cores(core_type, CoordSystem::NOC1);
+        for (const CoreCoord& core : cores) {
+            const auto [x, y] = read_noc_id_reg(cluster, chip, core);
+            EXPECT_EQ(core.x, x);
+            EXPECT_EQ(core.y, y);
+        }
+    };
+
+    tt::ARCH arch = cluster->get_cluster_description()->get_arch(0);
+
+    // TODO: add reads from remote chips as well. NOC1 traffic is not working
+    // for remote read/writes on wormhole remote chips.
+    for (chip_id_t chip : cluster->get_target_mmio_device_ids()) {
+        check_noc_id_cores(cluster, chip, CoreType::TENSIX);
+        check_noc_id_harvested_cores(cluster, chip, CoreType::TENSIX);
+
+        check_noc_id_cores(cluster, chip, CoreType::ETH);
+        check_noc_id_harvested_cores(cluster, chip, CoreType::ETH);
+
+        if (arch == tt::ARCH::BLACKHOLE) {
+            check_noc_id_cores(cluster, chip, CoreType::DRAM);
+            check_noc_id_harvested_cores(cluster, chip, CoreType::DRAM);
+        }
+
+        check_noc_id_cores(cluster, chip, CoreType::ARC);
+
+        check_noc_id_cores(cluster, chip, CoreType::PCIE);
+
+        // TODO: add readouts for router cores.
+    }
+
+    TTDevice::use_noc1(false);
+}


### PR DESCRIPTION
### Issue

Read NOC_NODE_ID register using NOC1 and for NOC1 

### Description

Add a test that reads noc node id register for noc1 coordinates and using noc1. 

### List of the changes

- Add a test for reading noc1 noc node id reg
- Fix translation of coordinates, there was a potential bug when using NOC1

### Testing

CI

### API Changes
/