### PR TITLE
Move wait_for_non_mmio_flush to RemoteChip and RemoteCommunication

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -55,6 +55,8 @@ public:
     virtual void read_from_device_reg(
         tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size, const std::string& fallback_tlb);
 
+    virtual void wait_for_non_mmio_flush();
+
     // TODO: To be removed once all usages are moved inside local chip.
     virtual std::unique_lock<RobustMutex> acquire_mutex(std::string mutex_name, int pci_device_id);
     virtual std::unique_lock<RobustMutex> acquire_mutex(MutexType mutex_type, int pci_device_id);

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -50,6 +50,10 @@ public:
     void read_from_device_reg(
         tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size, const std::string& fallback_tlb) override;
 
+    void wait_for_non_mmio_flush() override;
+    void set_flush_non_mmio(bool flush_non_mmio);
+    bool get_flush_non_mmio() const;
+
     std::unique_lock<RobustMutex> acquire_mutex(std::string mutex_name, int pci_device_id) override;
     std::unique_lock<RobustMutex> acquire_mutex(MutexType mutex_type, int pci_device_id) override;
 
@@ -61,6 +65,7 @@ private:
 
     std::vector<CoreCoord> remote_transfer_eth_cores_;
     int active_eth_core_idx = 0;
+    bool flush_non_mmio_ = false;
 
     void initialize_local_chip(int num_host_mem_channels = 0, const bool clear_mutex = false);
     void initialize_tlb_manager();

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -20,6 +20,8 @@ public:
     void read_from_device(
         tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size, const std::string& fallback_tlb) override;
 
+    void wait_for_non_mmio_flush() override;
+
 private:
     tt_xy_pair translate_chip_coord_virtual_to_translated(const tt_xy_pair core);
 

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -993,9 +993,6 @@ private:
     void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions);
     int test_setup_interface();
 
-    // This functions has to be called for local chip, and then it will wait for all connected remote chips to flush.
-    void wait_for_connected_non_mmio_flush(chip_id_t chip_id);
-
     // Helper functions for constructing the chips from the cluster descriptor.
     std::unique_ptr<Chip> construct_chip_from_cluster(
         chip_id_t chip_id,
@@ -1065,7 +1062,6 @@ private:
 
     std::shared_ptr<tt_ClusterDescriptor> cluster_desc;
 
-    std::unordered_map<chip_id_t, bool> flush_non_mmio_per_chip = {};
     std::unordered_map<chip_id_t, std::unordered_set<tt_xy_pair>> workers_per_chip = {};
     std::unordered_set<tt_xy_pair> eth_cores = {};
     std::unordered_set<tt_xy_pair> dram_cores = {};

--- a/device/api/umd/device/remote_communication.h
+++ b/device/api/umd/device/remote_communication.h
@@ -28,7 +28,7 @@ public:
         eth_coord_t target_chip,
         const tt_xy_pair eth_core);
 
-    void wait_for_non_mmio_flush(std::vector<tt_xy_pair> remote_transfer_eth_cores);
+    void wait_for_non_mmio_flush();
 
 private:
     LocalChip* local_chip_;

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -99,6 +99,10 @@ void Chip::read_from_device_reg(
     throw std::runtime_error("Chip::read_from_device_reg is not available for this chip.");
 }
 
+void Chip::wait_for_non_mmio_flush() {
+    throw std::runtime_error("Chip::wait_for_non_mmio_flush is not available for this chip.");
+}
+
 void Chip::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) {
     throw std::runtime_error("Chip::set_remote_transfer_ethernet_cores is not available for this chip.");
 }

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -276,6 +276,14 @@ void LocalChip::read_from_device_reg(
     tt_device_->read_regs(mapped_address, size / sizeof(uint32_t), dest);
 }
 
+void LocalChip::wait_for_non_mmio_flush() {
+    // This is a local chip, so no need to flush remote communication.
+}
+
+void LocalChip::set_flush_non_mmio(bool flush_non_mmio) { flush_non_mmio_ = flush_non_mmio; }
+
+bool LocalChip::get_flush_non_mmio() const { return flush_non_mmio_; }
+
 tt_xy_pair LocalChip::translate_chip_coord_virtual_to_translated(const tt_xy_pair core) const {
     CoreCoord core_coord = soc_descriptor_.get_coord_at(core, CoordSystem::VIRTUAL);
     // Since NOC1 and translated coordinate space overlaps for Tensix cores on Blackhole,

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -6,6 +6,7 @@
 
 #include "umd/device/chip/remote_chip.h"
 
+#include "logger.hpp"
 #include "umd/device/chip/local_chip.h"
 
 extern bool umd_use_noc1;
@@ -49,4 +50,10 @@ tt_xy_pair RemoteChip::translate_chip_coord_virtual_to_translated(const tt_xy_pa
             core_coord, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::TRANSLATED);
     }
 }
+
+void RemoteChip::wait_for_non_mmio_flush() {
+    log_assert(soc_descriptor_.arch != tt::ARCH::BLACKHOLE, "Non-MMIO flush not supported in Blackhole");
+    remote_communication_->wait_for_non_mmio_flush();
+}
+
 }  // namespace tt::umd

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1439,7 +1439,7 @@ void Cluster::read_from_non_mmio_device(void* mem_ptr, tt_cxy_pair core, uint64_
     get_remote_chip(core.chip)->read_from_device(core, mem_ptr, address, size_in_bytes, "");
 }
 
-void Cluster::wait_for_non_mmio_flush(const chip_id_t chip_id) { get_remote_chip(chip_id)->wait_for_non_mmio_flush(); }
+void Cluster::wait_for_non_mmio_flush(const chip_id_t chip_id) { get_chip(chip_id)->wait_for_non_mmio_flush(); }
 
 void Cluster::wait_for_non_mmio_flush() {
     for (auto& [chip_id, chip] : chips_) {

--- a/tests/wormhole/test_remote_communication_wh.cpp
+++ b/tests/wormhole/test_remote_communication_wh.cpp
@@ -65,7 +65,7 @@ TEST(RemoteCommunicationWormhole, BasicRemoteCommunicationIO) {
                 address1,
                 "SMALL_READ_WRITE_TLB");
 
-            remote_comm->wait_for_non_mmio_flush(active_eth_cores);
+            remote_comm->wait_for_non_mmio_flush();
 
             remote_comm->read_non_mmio(
                 remote_eth_coord,


### PR DESCRIPTION
### Issue
On a way to #248

### Description
Next one after #682 , before moving write_non_mmio

### List of the changes
- flush_non_mmio_per_chip moved from Cluster to LocalChip
- wait_for_non_mmio_flush implementation moved to RemoteCommunication. This API is also surfaced in RemoteChip
- Changed cluster.h calls to accommodate new API

### Testing
Existing CI tests

### API Changes
There are no API changes in this PR.
