### PR TITLE
Rename get_mutex to acquire_lock

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -55,8 +55,8 @@ public:
         tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size, const std::string& fallback_tlb);
 
     // TODO: To be removed once all usages are moved inside local chip.
-    virtual std::unique_lock<boost::interprocess::named_mutex> get_mutex(std::string mutex_name, int pci_device_id);
-    virtual std::unique_lock<boost::interprocess::named_mutex> get_mutex(MutexType mutex_type, int pci_device_id);
+    virtual std::unique_lock<boost::interprocess::named_mutex> acquire_lock(std::string mutex_name, int pci_device_id);
+    virtual std::unique_lock<boost::interprocess::named_mutex> acquire_lock(MutexType mutex_type, int pci_device_id);
 
     virtual void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores);
     // TODO: To be removed once all the usages are moved inside the class.

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -50,8 +50,8 @@ public:
     void read_from_device_reg(
         tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size, const std::string& fallback_tlb) override;
 
-    std::unique_lock<boost::interprocess::named_mutex> get_mutex(std::string mutex_name, int pci_device_id) override;
-    std::unique_lock<boost::interprocess::named_mutex> get_mutex(MutexType mutex_type, int pci_device_id) override;
+    std::unique_lock<boost::interprocess::named_mutex> acquire_lock(std::string mutex_name, int pci_device_id) override;
+    std::unique_lock<boost::interprocess::named_mutex> acquire_lock(MutexType mutex_type, int pci_device_id) override;
 
 private:
     std::unique_ptr<TTDevice> tt_device_;

--- a/device/api/umd/device/lock_manager.h
+++ b/device/api/umd/device/lock_manager.h
@@ -38,22 +38,22 @@ public:
     // This set of functions is used to manage mutexes which are system wide and not chip specific.
     void initialize_mutex(MutexType mutex_type, const bool clear_mutex);
     void clear_mutex(MutexType mutex_type);
-    std::unique_lock<boost::interprocess::named_mutex> get_mutex(MutexType mutex_type);
+    std::unique_lock<boost::interprocess::named_mutex> acquire_lock(MutexType mutex_type);
 
     // This set of functions is used to manage mutexes which are chip specific.
     void initialize_mutex(MutexType mutex_type, int pci_device_id, const bool clear_mutex);
     void clear_mutex(MutexType mutex_type, int pci_device_id);
-    std::unique_lock<boost::interprocess::named_mutex> get_mutex(MutexType mutex_type, int pci_device_id);
+    std::unique_lock<boost::interprocess::named_mutex> acquire_lock(MutexType mutex_type, int pci_device_id);
 
     // This set of functions is used to manage mutexes which are chip specific. This variant accepts custom mutex name.
     void initialize_mutex(std::string mutex_prefix, int pci_device_id, const bool clear_mutex);
     void clear_mutex(std::string mutex_prefix, int pci_device_id);
-    std::unique_lock<boost::interprocess::named_mutex> get_mutex(std::string mutex_prefix, int pci_device_id);
+    std::unique_lock<boost::interprocess::named_mutex> acquire_lock(std::string mutex_prefix, int pci_device_id);
 
 private:
     void initialize_mutex_internal(const std::string& mutex_name, const bool clear_mutex);
     void clear_mutex_internal(const std::string& mutex_name);
-    std::unique_lock<boost::interprocess::named_mutex> get_mutex_internal(const std::string& mutex_name);
+    std::unique_lock<boost::interprocess::named_mutex> acquire_lock_internal(const std::string& mutex_name);
 
     // Const map of mutex names for each of the types listed in the enum.
     static const std::unordered_map<MutexType, std::string> MutexTypeToString;

--- a/device/blackhole/blackhole_arc_messenger.cpp
+++ b/device/blackhole/blackhole_arc_messenger.cpp
@@ -18,7 +18,7 @@ BlackholeArcMessenger::BlackholeArcMessenger(TTDevice* tt_device) : ArcMessenger
 
 uint32_t BlackholeArcMessenger::send_message(
     const uint32_t msg_code, std::vector<uint32_t>& return_values, uint16_t arg0, uint16_t arg1, uint32_t timeout_ms) {
-    auto lock = lock_manager.get_mutex(MutexType::ARC_MSG, tt_device->get_pci_device()->get_device_num());
+    auto lock = lock_manager.acquire_lock(MutexType::ARC_MSG, tt_device->get_pci_device()->get_device_num());
     return blackhole_arc_msg_queue->send_message((ArcMessageType)msg_code, arg0, arg1, timeout_ms);
 }
 

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -116,11 +116,11 @@ std::vector<CoreCoord> Chip::get_remote_transfer_ethernet_cores() {
     throw std::runtime_error("Chip::get_remote_transfer_ethernet_cores is not available for this chip.");
 }
 
-std::unique_lock<boost::interprocess::named_mutex> Chip::get_mutex(std::string mutex_name, int pci_device_id) {
-    throw std::runtime_error("LockManager::get_mutex is not available for this chip.");
+std::unique_lock<boost::interprocess::named_mutex> Chip::acquire_lock(std::string mutex_name, int pci_device_id) {
+    throw std::runtime_error("LockManager::acquire_lock is not available for this chip.");
 }
 
-std::unique_lock<boost::interprocess::named_mutex> Chip::get_mutex(MutexType mutex_type, int pci_device_id) {
-    throw std::runtime_error("LockManager::get_mutex is not available for this chip.");
+std::unique_lock<boost::interprocess::named_mutex> Chip::acquire_lock(MutexType mutex_type, int pci_device_id) {
+    throw std::runtime_error("LockManager::acquire_lock is not available for this chip.");
 }
 }  // namespace tt::umd

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -203,7 +203,7 @@ void LocalChip::write_to_device(
         }
     } else {
         const auto tlb_index = tlb_manager_->dynamic_tlb_config_.at(fallback_tlb);
-        auto lock = get_mutex(fallback_tlb, tt_device_->get_pci_device()->get_device_num());
+        auto lock = acquire_lock(fallback_tlb, tt_device_->get_pci_device()->get_device_num());
 
         while (size > 0) {
             auto [mapped_address, tlb_size] = tt_device_->set_dynamic_tlb(
@@ -251,7 +251,7 @@ void LocalChip::read_from_device(
             tlb_description.size);
     } else {
         const auto tlb_index = tlb_manager_->dynamic_tlb_config_.at(fallback_tlb);
-        auto lock = get_mutex(fallback_tlb, tt_device_->get_pci_device()->get_device_num());
+        auto lock = acquire_lock(fallback_tlb, tt_device_->get_pci_device()->get_device_num());
         log_debug(LogSiliconDriver, "  dynamic tlb_index: {}", tlb_index);
         while (size > 0) {
             auto [mapped_address, tlb_size] = tt_device_->set_dynamic_tlb(
@@ -273,7 +273,7 @@ void LocalChip::read_from_device(
 void LocalChip::write_to_device_reg(
     tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size, const std::string& fallback_tlb) {
     const auto tlb_index = tlb_manager_->dynamic_tlb_config_.at(fallback_tlb);
-    auto lock = lock_manager_.get_mutex(fallback_tlb, tt_device_->get_pci_device()->get_device_num());
+    auto lock = lock_manager_.acquire_lock(fallback_tlb, tt_device_->get_pci_device()->get_device_num());
     log_debug(LogSiliconDriver, "  dynamic tlb_index: {}", tlb_index);
 
     auto [mapped_address, tlb_size] = tt_device_->set_dynamic_tlb(
@@ -290,7 +290,7 @@ void LocalChip::write_to_device_reg(
 void LocalChip::read_from_device_reg(
     tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size, const std::string& fallback_tlb) {
     const auto tlb_index = tlb_manager_->dynamic_tlb_config_.at(fallback_tlb);
-    auto lock = lock_manager_.get_mutex(fallback_tlb, tt_device_->get_pci_device()->get_device_num());
+    auto lock = lock_manager_.acquire_lock(fallback_tlb, tt_device_->get_pci_device()->get_device_num());
     log_debug(LogSiliconDriver, "  dynamic tlb_index: {}", tlb_index);
 
     auto [mapped_address, tlb_size] = tt_device_->set_dynamic_tlb(
@@ -350,11 +350,11 @@ int LocalChip::get_active_eth_core_idx() { return active_eth_core_idx; }
 
 std::vector<CoreCoord> LocalChip::get_remote_transfer_ethernet_cores() { return remote_transfer_eth_cores_; }
 
-std::unique_lock<boost::interprocess::named_mutex> LocalChip::get_mutex(std::string mutex_name, int pci_device_id) {
-    return lock_manager_.get_mutex(mutex_name, pci_device_id);
+std::unique_lock<boost::interprocess::named_mutex> LocalChip::acquire_lock(std::string mutex_name, int pci_device_id) {
+    return lock_manager_.acquire_lock(mutex_name, pci_device_id);
 }
 
-std::unique_lock<boost::interprocess::named_mutex> LocalChip::get_mutex(MutexType mutex_type, int pci_device_id) {
-    return lock_manager_.get_mutex(mutex_type, pci_device_id);
+std::unique_lock<boost::interprocess::named_mutex> LocalChip::acquire_lock(MutexType mutex_type, int pci_device_id) {
+    return lock_manager_.acquire_lock(mutex_type, pci_device_id);
 }
 }  // namespace tt::umd

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1246,7 +1246,7 @@ void Cluster::write_to_non_mmio_device(
     //
     auto lock =
         get_local_chip(mmio_capable_chip_logical)
-            ->get_mutex(
+            ->acquire_lock(
                 MutexType::NON_MMIO, get_tt_device(mmio_capable_chip_logical)->get_pci_device()->get_device_num());
     tt_cxy_pair remote_transfer_ethernet_core = tt_cxy_pair(
         mmio_capable_chip_logical, get_local_chip(mmio_capable_chip_logical)->get_remote_transfer_ethernet_core());
@@ -1481,7 +1481,7 @@ void Cluster::read_from_non_mmio_device(void* mem_ptr, tt_cxy_pair core, uint64_
     //
     auto lock =
         get_local_chip(mmio_capable_chip_logical)
-            ->get_mutex(
+            ->acquire_lock(
                 MutexType::NON_MMIO, get_tt_device(mmio_capable_chip_logical)->get_pci_device()->get_device_num());
     const tt_cxy_pair remote_transfer_ethernet_core = tt_cxy_pair(
         mmio_capable_chip_logical, get_local_chip(mmio_capable_chip_logical)->get_remote_transfer_ethernet_core());
@@ -2230,7 +2230,7 @@ void Cluster::insert_host_to_device_barrier(
     const uint32_t barrier_addr,
     const std::string& fallback_tlb) {
     // Ensure that this memory barrier is atomic across processes/threads
-    auto lock = get_local_chip(chip)->get_mutex(
+    auto lock = get_local_chip(chip)->acquire_lock(
         MutexType::MEM_BARRIER, get_tt_device(chip)->get_pci_device()->get_device_num());
     set_membar_flag(chip, cores, tt_MemBarFlag::SET, barrier_addr, fallback_tlb);
     set_membar_flag(chip, cores, tt_MemBarFlag::RESET, barrier_addr, fallback_tlb);
@@ -2741,7 +2741,7 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(std::st
             lock_manager.initialize_mutex(MutexType::CREATE_ETH_MAP, false);
             std::unique_ptr<tt_ClusterDescriptor> cluster_desc = nullptr;
             {
-                auto lock = lock_manager.get_mutex(MutexType::CREATE_ETH_MAP);
+                auto lock = lock_manager.acquire_lock(MutexType::CREATE_ETH_MAP);
                 cluster_desc = tt_ClusterDescriptor::create();
             }
             lock_manager.clear_mutex(MutexType::CREATE_ETH_MAP);

--- a/device/lock_manager.cpp
+++ b/device/lock_manager.cpp
@@ -38,8 +38,8 @@ void LockManager::initialize_mutex(MutexType mutex_type, const bool clear_mutex)
 
 void LockManager::clear_mutex(MutexType mutex_type) { clear_mutex_internal(MutexTypeToString.at(mutex_type)); }
 
-std::unique_lock<named_mutex> LockManager::get_mutex(MutexType mutex_type) {
-    return get_mutex_internal(MutexTypeToString.at(mutex_type));
+std::unique_lock<named_mutex> LockManager::acquire_lock(MutexType mutex_type) {
+    return acquire_lock_internal(MutexTypeToString.at(mutex_type));
 }
 
 void LockManager::initialize_mutex(MutexType mutex_type, int pci_device_id, const bool clear_mutex) {
@@ -52,9 +52,9 @@ void LockManager::clear_mutex(MutexType mutex_type, int pci_device_id) {
     clear_mutex_internal(mutex_name);
 }
 
-std::unique_lock<named_mutex> LockManager::get_mutex(MutexType mutex_type, int pci_device_id) {
+std::unique_lock<named_mutex> LockManager::acquire_lock(MutexType mutex_type, int pci_device_id) {
     std::string mutex_name = MutexTypeToString.at(mutex_type) + std::to_string(pci_device_id);
-    return get_mutex_internal(mutex_name);
+    return acquire_lock_internal(mutex_name);
 }
 
 void LockManager::initialize_mutex(std::string mutex_prefix, int pci_device_id, const bool clear_mutex) {
@@ -67,9 +67,9 @@ void LockManager::clear_mutex(std::string mutex_prefix, int pci_device_id) {
     clear_mutex_internal(mutex_name);
 }
 
-std::unique_lock<named_mutex> LockManager::get_mutex(std::string mutex_prefix, int pci_device_id) {
+std::unique_lock<named_mutex> LockManager::acquire_lock(std::string mutex_prefix, int pci_device_id) {
     std::string mutex_name = mutex_prefix + std::to_string(pci_device_id);
-    return get_mutex_internal(mutex_name);
+    return acquire_lock_internal(mutex_name);
 }
 
 void LockManager::initialize_mutex_internal(const std::string& mutex_name, const bool clear_mutex) {
@@ -104,7 +104,7 @@ void LockManager::clear_mutex_internal(const std::string& mutex_name) {
     named_mutex::remove(mutex_name.c_str());
 }
 
-std::unique_lock<named_mutex> LockManager::get_mutex_internal(const std::string& mutex_name) {
+std::unique_lock<named_mutex> LockManager::acquire_lock_internal(const std::string& mutex_name) {
     if (mutexes.find(mutex_name) == mutexes.end()) {
         throw std::runtime_error("Mutex not initialized: " + mutex_name);
     }

--- a/device/remote_communication.cpp
+++ b/device/remote_communication.cpp
@@ -77,7 +77,7 @@ void RemoteCommunication::read_non_mmio(
     //                    MUTEX ACQUIRE (NON-MMIO)
     //  do not locate any ethernet core reads/writes before this acquire
     //
-    auto lock = lock_manager.get_mutex(MutexType::NON_MMIO, tt_device->get_pci_device()->get_device_num());
+    auto lock = lock_manager.acquire_lock(MutexType::NON_MMIO, tt_device->get_pci_device()->get_device_num());
 
     const tt_xy_pair remote_transfer_ethernet_core = eth_core;
 
@@ -312,7 +312,7 @@ void RemoteCommunication::write_to_non_mmio(
     //  do not locate any ethernet core reads/writes before this acquire
     //
 
-    auto lock = lock_manager.get_mutex(MutexType::NON_MMIO, tt_device->get_pci_device()->get_device_num());
+    auto lock = lock_manager.acquire_lock(MutexType::NON_MMIO, tt_device->get_pci_device()->get_device_num());
 
     int active_core_for_txn = 0;
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -217,7 +217,7 @@ void TTDevice::read_block(uint64_t byte_addr, uint64_t num_bytes, uint8_t *buffe
 }
 
 void TTDevice::read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
-    auto lock = lock_manager.get_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num());
+    auto lock = lock_manager.acquire_lock(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num());
     uint8_t *buffer_addr = static_cast<uint8_t *>(mem_ptr);
     const uint32_t tlb_index = get_architecture_implementation()->get_small_read_write_tlb();
     while (size > 0) {
@@ -232,7 +232,7 @@ void TTDevice::read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, u
 }
 
 void TTDevice::write_to_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
-    auto lock = lock_manager.get_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num());
+    auto lock = lock_manager.acquire_lock(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num());
     uint8_t *buffer_addr = static_cast<uint8_t *>(mem_ptr);
     const uint32_t tlb_index = get_architecture_implementation()->get_small_read_write_tlb();
 

--- a/device/wormhole/wormhole_arc_messenger.cpp
+++ b/device/wormhole/wormhole_arc_messenger.cpp
@@ -24,7 +24,7 @@ uint32_t WormholeArcMessenger::send_message(
 
     log_assert(arg0 <= 0xffff and arg1 <= 0xffff, "Only 16 bits allowed in arc_msg args");
 
-    auto lock = lock_manager.get_mutex(MutexType::ARC_MSG, tt_device->get_pci_device()->get_device_num());
+    auto lock = lock_manager.acquire_lock(MutexType::ARC_MSG, tt_device->get_pci_device()->get_device_num());
 
     auto architecture_implementation = tt_device->get_architecture_implementation();
 


### PR DESCRIPTION
### Issue
No issue, raised in #679 

### Description
Rename to better communicate what this API actually does.

### List of the changes
- get_mutex to acquire_lock everywhere

### Testing
No testing

### API Changes
There are no API changes in this PR.
