### PR TITLE
Fix ARC timeout message bug

### DIFF
--- a/device/api/umd/device/arc_messenger.h
+++ b/device/api/umd/device/arc_messenger.h
@@ -37,7 +37,7 @@ public:
      * @param return_values Return values from the ARC message.
      * @param arg0 arg0 for the message.
      * @param arg1 arg1 for the message.
-     * @param timeout_ms Timeout in milliseconds.
+     * @param timeout_ms Timeout in milliseconds; 0 to wait indefinitely.
      * @return Success code of the ARC message.
      */
     virtual uint32_t send_message(
@@ -54,7 +54,7 @@ public:
      * @param msg_code ARC messsage type.
      * @param arg0 arg0 for the message.
      * @param arg1 arg1 for the message.
-     * @param timeout_ms Timeout in milliseconds.
+     * @param timeout_ms Timeout in milliseconds; 0 to wait indefinitely.
      * @return Success code of the ARC message.
      */
     uint32_t send_message(const uint32_t msg_code, uint16_t arg0 = 0, uint16_t arg1 = 0, uint32_t timeout_ms = 1000);

--- a/device/api/umd/device/blackhole_arc_message_queue.h
+++ b/device/api/umd/device/blackhole_arc_message_queue.h
@@ -58,9 +58,9 @@ public:
         TTDevice* tt_device, const size_t queue_index);
 
 private:
-    void push_request(std::array<uint32_t, BlackholeArcMessageQueue::entry_len>& request);
+    void push_request(std::array<uint32_t, BlackholeArcMessageQueue::entry_len>& request, uint32_t timeout_ms);
 
-    std::array<uint32_t, entry_len> pop_response();
+    std::array<uint32_t, entry_len> pop_response(uint32_t timeout_ms);
 
     void read_words(uint32_t* data, size_t num_words, size_t offset);
 

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -385,7 +385,7 @@ public:
      * @param wait_for_done Block until ARC responds.
      * @param arg0 Message related argument.
      * @param arg1 Message related argument.
-     * @param timeout Timeout on ARC.
+     * @param timeout_ms Timeout in milliseconds.
      * @param return3 Return value from ARC.
      * @param return4 Return value from ARC.
      */
@@ -395,7 +395,7 @@ public:
         bool wait_for_done = true,
         uint32_t arg0 = 0,
         uint32_t arg1 = 0,
-        int timeout = 1,
+        uint32_t timeout_ms = 1000,
         uint32_t* return_3 = nullptr,
         uint32_t* return_4 = nullptr) {
         throw std::runtime_error("---- tt_device::arc_msg is not implemented\n");
@@ -662,7 +662,7 @@ public:
         bool wait_for_done = true,
         uint32_t arg0 = 0,
         uint32_t arg1 = 0,
-        int timeout = 1,
+        uint32_t timeout_ms = 1000,
         uint32_t* return_3 = nullptr,
         uint32_t* return_4 = nullptr);
     virtual tt_ClusterDescriptor* get_cluster_description();
@@ -922,7 +922,7 @@ private:
         bool wait_for_done = true,
         uint32_t arg0 = 0,
         uint32_t arg1 = 0,
-        int timeout = 1,
+        uint32_t timeout_ms = 1000,
         uint32_t* return_3 = nullptr,
         uint32_t* return_4 = nullptr);
     int remote_arc_msg(
@@ -931,7 +931,7 @@ private:
         bool wait_for_done = true,
         uint32_t arg0 = 0,
         uint32_t arg1 = 0,
-        int timeout = 1,
+        uint32_t timeout_ms = 1000,
         uint32_t* return_3 = nullptr,
         uint32_t* return_4 = nullptr);
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -570,7 +570,13 @@ void Cluster::check_pcie_device_initialized(int device_id) {
         uint32_t arg = bar_read_initial == 500 ? 325 : 500;
         uint32_t bar_read_again;
         uint32_t arc_msg_return = arc_msg(
-            device_id, 0xaa00 | architecture_implementation->get_arc_message_test(), true, arg, 0, 1, &bar_read_again);
+            device_id,
+            0xaa00 | architecture_implementation->get_arc_message_test(),
+            true,
+            arg,
+            0,
+            1000,
+            &bar_read_again);
         if (arc_msg_return != 0 || bar_read_again != arg + 1) {
             auto postcode = bar_read32(device_id, architecture_implementation->get_arc_reset_scratch_offset());
             throw std::runtime_error(fmt::format(
@@ -958,7 +964,7 @@ int Cluster::pcie_arc_msg(
     bool wait_for_done,
     uint32_t arg0,
     uint32_t arg1,
-    int timeout,
+    uint32_t timeout_ms,
     uint32_t* return_3,
     uint32_t* return_4) {
     std::vector<uint32_t> arc_msg_return_values;
@@ -972,7 +978,7 @@ int Cluster::pcie_arc_msg(
 
     uint32_t exit_code = get_tt_device(logical_device_id)
                              ->get_arc_messenger()
-                             ->send_message(msg_code, arc_msg_return_values, arg0, arg1, timeout);
+                             ->send_message(msg_code, arc_msg_return_values, arg0, arg1, timeout_ms);
 
     if (return_3 != nullptr) {
         *return_3 = arc_msg_return_values[0];
@@ -1071,7 +1077,7 @@ uint32_t Cluster::get_harvested_rows(int logical_device_id) {
             true,
             0,
             0,
-            1,
+            1000,
             &harv);
         log_assert(
             harvesting_msg_code != MSG_ERROR_REPLY, "Failed to read harvested rows from device {}", logical_device_id);
@@ -1098,7 +1104,7 @@ void Cluster::enable_local_ethernet_queue(const chip_id_t& device_id, int timeou
                 fmt::format("Timed out after waiting {} seconds for for DRAM to finish training", timeout));
         }
 
-        if (arc_msg(device_id, 0xaa58, true, 0xFFFF, 0xFFFF, 1, &msg_success) == MSG_ERROR_REPLY) {
+        if (arc_msg(device_id, 0xaa58, true, 0xFFFF, 0xFFFF, 1000, &msg_success) == MSG_ERROR_REPLY) {
             break;
         }
     }
@@ -2103,7 +2109,7 @@ int Cluster::remote_arc_msg(
     bool wait_for_done,
     uint32_t arg0,
     uint32_t arg1,
-    int timeout,
+    uint32_t timeout_ms,
     uint32_t* return_3,
     uint32_t* return_4) {
     constexpr uint64_t ARC_RESET_SCRATCH_ADDR = 0x880030060;
@@ -2137,15 +2143,16 @@ int Cluster::remote_arc_msg(
 
     if (wait_for_done) {
         uint32_t status = 0xbadbad;
-        auto timeout_seconds = std::chrono::seconds(timeout);
-        auto start = std::chrono::system_clock::now();
+        auto start = std::chrono::steady_clock::now();
         while (true) {
-            if (std::chrono::system_clock::now() - start > timeout_seconds) {
+            auto now = std::chrono::steady_clock::now();
+            auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count();
+            if (elapsed_ms > timeout_ms && timeout_ms != 0) {
                 std::stringstream ss;
                 ss << std::hex << msg_code;
                 throw std::runtime_error(fmt::format(
-                    "Timed out after waiting {} seconds for device {} ARC to respond to message 0x{}",
-                    timeout,
+                    "Timed out after waiting {} ms for device {} ARC to respond to message 0x{}",
+                    timeout_ms,
                     chip,
                     ss.str()));
             }
@@ -2412,13 +2419,13 @@ int Cluster::arc_msg(
     bool wait_for_done,
     uint32_t arg0,
     uint32_t arg1,
-    int timeout,
+    uint32_t timeout_ms,
     uint32_t* return_3,
     uint32_t* return_4) {
     if (cluster_desc->is_chip_mmio_capable(logical_device_id)) {
-        return pcie_arc_msg(logical_device_id, msg_code, wait_for_done, arg0, arg1, timeout, return_3, return_4);
+        return pcie_arc_msg(logical_device_id, msg_code, wait_for_done, arg0, arg1, timeout_ms, return_3, return_4);
     } else {
-        return remote_arc_msg(logical_device_id, msg_code, wait_for_done, arg0, arg1, timeout, return_3, return_4);
+        return remote_arc_msg(logical_device_id, msg_code, wait_for_done, arg0, arg1, timeout_ms, return_3, return_4);
     }
 }
 

--- a/device/mockup/tt_mockup_device.hpp
+++ b/device/mockup/tt_mockup_device.hpp
@@ -100,7 +100,7 @@ public:
         bool wait_for_done = true,
         uint32_t arg0 = 0,
         uint32_t arg1 = 0,
-        int timeout = 1,
+        uint32_t timeout_ms = 1000,
         uint32_t* return_3 = nullptr,
         uint32_t* return_4 = nullptr) override {
         return 0;

--- a/device/wormhole/wormhole_arc_messenger.cpp
+++ b/device/wormhole/wormhole_arc_messenger.cpp
@@ -53,8 +53,8 @@ uint32_t WormholeArcMessenger::send_message(
     while (true) {
         auto end = std::chrono::system_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-        if (duration.count() > timeout_ms) {
-            throw std::runtime_error(fmt::format("Timed out after waiting {} seconds for ARC to respond", timeout_ms));
+        if (duration.count() > timeout_ms && timeout_ms != 0) {
+            throw std::runtime_error(fmt::format("Timed out after waiting {} ms for ARC to respond", timeout_ms));
         }
 
         status = tt_device->bar_read32(


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/695

### Description
Fixes an incongruity between Cluster and ArcMessenger with respect to timeout units.  Adds timeout functionality to BlackholeArcMessageQueue. 

### List of the changes
1. Cluster: change arc_msg timeout from seconds to ms to match lower-level implementation
2. ArcMessenger: clarify arc_messenger timeout documentation
3. Correct an error message and support indefinite wait in WormholeArcMessenger
4. Add timeout support to BlackholeArcMessageQueue

### Testing
Manual

### API Changes
This PR has API changes, but should not break anything.