### PR TITLE
Add NOC node id check for more cores

### DIFF
--- a/device/api/umd/device/architecture_implementation.h
+++ b/device/api/umd/device/architecture_implementation.h
@@ -11,6 +11,7 @@
 #include <tuple>
 #include <vector>
 
+#include "umd/device/tt_core_coordinates.h"
 #include "umd/device/tt_xy_pair.h"
 #include "umd/device/types/arch.h"
 #include "umd/device/types/tlb.h"
@@ -81,6 +82,9 @@ public:
     virtual tt_driver_noc_params get_noc_params() const = 0;
 
     static std::unique_ptr<architecture_implementation> create(tt::ARCH architecture);
+
+    virtual uint64_t get_noc_reg_base(
+        const CoreType core_type, const uint32_t noc, const uint32_t noc_port = 0) const = 0;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/architecture_implementation.h
+++ b/device/api/umd/device/architecture_implementation.h
@@ -83,6 +83,7 @@ public:
 
     static std::unique_ptr<architecture_implementation> create(tt::ARCH architecture);
 
+    virtual uint64_t get_noc_node_id_offset() const = 0;
     virtual uint64_t get_noc_reg_base(
         const CoreType core_type, const uint32_t noc, const uint32_t noc_port = 0) const = 0;
 };

--- a/device/api/umd/device/blackhole_implementation.h
+++ b/device/api/umd/device/blackhole_implementation.h
@@ -374,6 +374,8 @@ public:
     tt_driver_eth_interface_params get_eth_interface_params() const override;
     tt_driver_noc_params get_noc_params() const override;
 
+    virtual uint64_t get_noc_node_id_offset() const override { return 0x44; }
+
     uint64_t get_noc_reg_base(const CoreType core_type, const uint32_t noc, const uint32_t noc_port = 0) const override;
 };
 

--- a/device/api/umd/device/blackhole_implementation.h
+++ b/device/api/umd/device/blackhole_implementation.h
@@ -227,6 +227,19 @@ static constexpr uint32_t TENSIX_L1_SIZE = 1499136;
 static constexpr uint32_t ETH_L1_SIZE = 262144;
 static constexpr uint64_t DRAM_BANK_SIZE = 4294967296;
 
+constexpr std::array<std::pair<CoreType, uint64_t>, 5> NOC0_CONTROL_REG_ADDR_BASE_MAP = {
+    {{CoreType::TENSIX, 0xFFB20000},
+     {CoreType::ETH, 0xFFB20000},
+     {CoreType::DRAM, 0xFFB20000},
+     {CoreType::PCIE, 0xFFFFFFFFFF000000ULL},
+     {CoreType::ARC, 0xFFFFFFFFFF000000ULL}}};
+constexpr std::array<std::pair<CoreType, uint64_t>, 5> NOC1_CONTROL_REG_ADDR_BASE_MAP = {
+    {{CoreType::TENSIX, 0xFFB30000},
+     {CoreType::ETH, 0xFFB30000},
+     {CoreType::DRAM, 0xFFB30000},
+     {CoreType::PCIE, 0xFFFFFFFFFF000000ULL},
+     {CoreType::ARC, 0xFFFFFFFFFF000000ULL}}};
+static const uint64_t NOC_NODE_ID_OFFSET = 0x44;
 static const size_t eth_translated_coordinate_start_x = 20;
 static const size_t eth_translated_coordinate_start_y = 25;
 
@@ -374,7 +387,7 @@ public:
     tt_driver_eth_interface_params get_eth_interface_params() const override;
     tt_driver_noc_params get_noc_params() const override;
 
-    virtual uint64_t get_noc_node_id_offset() const override { return 0x44; }
+    virtual uint64_t get_noc_node_id_offset() const override { return blackhole::NOC_NODE_ID_OFFSET; }
 
     uint64_t get_noc_reg_base(const CoreType core_type, const uint32_t noc, const uint32_t noc_port = 0) const override;
 };

--- a/device/api/umd/device/blackhole_implementation.h
+++ b/device/api/umd/device/blackhole_implementation.h
@@ -227,9 +227,6 @@ static constexpr uint32_t TENSIX_L1_SIZE = 1499136;
 static constexpr uint32_t ETH_L1_SIZE = 262144;
 static constexpr uint64_t DRAM_BANK_SIZE = 4294967296;
 
-static constexpr uint64_t NOC_CONTROL_REG_ADDR_BASE = 0xFFB20000;
-static constexpr uint64_t NOC_NODE_ID_OFFSET = 0x44;
-
 static const size_t eth_translated_coordinate_start_x = 20;
 static const size_t eth_translated_coordinate_start_y = 25;
 
@@ -376,6 +373,8 @@ public:
     tt_driver_host_address_params get_host_address_params() const override;
     tt_driver_eth_interface_params get_eth_interface_params() const override;
     tt_driver_noc_params get_noc_params() const override;
+
+    uint64_t get_noc_reg_base(const CoreType core_type, const uint32_t noc, const uint32_t noc_port = 0) const override;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/grayskull_implementation.h
+++ b/device/api/umd/device/grayskull_implementation.h
@@ -324,6 +324,11 @@ public:
     tt_driver_host_address_params get_host_address_params() const override;
     tt_driver_eth_interface_params get_eth_interface_params() const override;
     tt_driver_noc_params get_noc_params() const override;
+
+    uint64_t get_noc_reg_base(
+        const CoreType core_type, const uint32_t noc, const uint32_t dram_channel = 0) const override {
+        return 0;
+    }
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/grayskull_implementation.h
+++ b/device/api/umd/device/grayskull_implementation.h
@@ -325,6 +325,10 @@ public:
     tt_driver_eth_interface_params get_eth_interface_params() const override;
     tt_driver_noc_params get_noc_params() const override;
 
+    // This functions don't return proper values for grayskull. It will be deleted once
+    // we can fully delete grayskull_implementation.
+    virtual uint64_t get_noc_node_id_offset() const override { return 0; }
+
     uint64_t get_noc_reg_base(
         const CoreType core_type, const uint32_t noc, const uint32_t dram_channel = 0) const override {
         return 0;

--- a/device/api/umd/device/wormhole_implementation.h
+++ b/device/api/umd/device/wormhole_implementation.h
@@ -375,6 +375,8 @@ public:
     tt_driver_eth_interface_params get_eth_interface_params() const override;
     tt_driver_noc_params get_noc_params() const override;
 
+    virtual uint64_t get_noc_node_id_offset() const override { return 0x2C; }
+
     uint64_t get_noc_reg_base(const CoreType core_type, const uint32_t noc, const uint32_t noc_port = 0) const override;
 };
 

--- a/device/api/umd/device/wormhole_implementation.h
+++ b/device/api/umd/device/wormhole_implementation.h
@@ -251,6 +251,20 @@ static constexpr uint32_t TENSIX_L1_SIZE = 1499136;
 static constexpr uint32_t ETH_L1_SIZE = 262144;
 static constexpr uint64_t DRAM_BANK_SIZE = 2147483648;
 
+constexpr std::array<std::pair<CoreType, uint64_t>, 5> NOC0_CONTROL_REG_ADDR_BASE_MAP = {
+    {{CoreType::TENSIX, 0xFFB20000},
+     {CoreType::ETH, 0xFFB20000},
+     {CoreType::DRAM, 0x100080000},
+     {CoreType::PCIE, 0xFFFB20000},
+     {CoreType::ARC, 0xFFFB20000}}};
+constexpr std::array<std::pair<CoreType, uint64_t>, 5> NOC1_CONTROL_REG_ADDR_BASE_MAP = {
+    {{CoreType::TENSIX, 0xFFB30000},
+     {CoreType::ETH, 0xFFB30000},
+     {CoreType::DRAM, 0x100088000},
+     {CoreType::PCIE, 0xFFFB30000},
+     {CoreType::ARC, 0xFFFB30000}}};
+static const uint64_t NOC_NODE_ID_OFFSET = 0x2C;
+
 static const size_t tensix_translated_coordinate_start_x = 18;
 static const size_t tensix_translated_coordinate_start_y = 18;
 
@@ -375,7 +389,7 @@ public:
     tt_driver_eth_interface_params get_eth_interface_params() const override;
     tt_driver_noc_params get_noc_params() const override;
 
-    virtual uint64_t get_noc_node_id_offset() const override { return 0x2C; }
+    virtual uint64_t get_noc_node_id_offset() const override { return wormhole::NOC_NODE_ID_OFFSET; }
 
     uint64_t get_noc_reg_base(const CoreType core_type, const uint32_t noc, const uint32_t noc_port = 0) const override;
 };

--- a/device/api/umd/device/wormhole_implementation.h
+++ b/device/api/umd/device/wormhole_implementation.h
@@ -251,14 +251,6 @@ static constexpr uint32_t TENSIX_L1_SIZE = 1499136;
 static constexpr uint32_t ETH_L1_SIZE = 262144;
 static constexpr uint64_t DRAM_BANK_SIZE = 2147483648;
 
-static constexpr uint64_t NOC_CONTROL_REG_ADDR_BASE = 0xFFB20000;
-static constexpr uint64_t NOC_NODE_ID_OFFSET = 0x2C;
-// Constants copied from noc_parameters.h which is removed from UMD.
-// TODO: think about bringing these files back to UMD for tests.
-static const uint32_t NOC_CFG_OFFSET = 0x100;
-static const uint32_t NOC_REG_WORD_SIZE = 4;
-static const uint32_t NOC_CFG_NOC_ID_LOGICAL = 0xE;
-
 static const size_t tensix_translated_coordinate_start_x = 18;
 static const size_t tensix_translated_coordinate_start_y = 18;
 
@@ -382,6 +374,8 @@ public:
     tt_driver_host_address_params get_host_address_params() const override;
     tt_driver_eth_interface_params get_eth_interface_params() const override;
     tt_driver_noc_params get_noc_params() const override;
+
+    uint64_t get_noc_reg_base(const CoreType core_type, const uint32_t noc, const uint32_t noc_port = 0) const override;
 };
 
 }  // namespace tt::umd

--- a/device/blackhole/blackhole_implementation.cpp
+++ b/device/blackhole/blackhole_implementation.cpp
@@ -96,6 +96,39 @@ tt_driver_noc_params blackhole_implementation::get_noc_params() const {
     return {NOC_ADDR_LOCAL_BITS, NOC_ADDR_NODE_ID_BITS};
 }
 
+uint64_t blackhole_implementation::get_noc_reg_base(
+    const CoreType core_type, const uint32_t noc, const uint32_t noc_port) const {
+    switch (core_type) {
+        case CoreType::TENSIX:
+        case CoreType::ETH: {
+            if (noc == 0) {
+                return 0xFFB20000;
+            } else {
+                return 0xFFB30000;
+            }
+        }
+        case CoreType::DRAM: {
+            // TODO: add noc_port parameter to this function.
+            if (noc == 0) {
+                return 0xFFB20000;
+            } else {
+                return 0xFFB30000;
+            }
+        }
+        case CoreType::ARC:
+        case CoreType::PCIE: {
+            if (noc == 0) {
+                return 0xFFFFFFFFFF000000ULL;
+            } else {
+                return 0xFFFFFFFFFF000000ULL;
+            }
+        }
+        default: {
+            throw std::runtime_error("Invalid core type for getting NOC register addr base.");
+        }
+    }
+}
+
 namespace blackhole {
 std::vector<tt_xy_pair> get_pcie_cores(const BoardType board_type, const uint8_t asic_location) {
     // Default to type 1 chip.
@@ -105,6 +138,7 @@ std::vector<tt_xy_pair> get_pcie_cores(const BoardType board_type, const uint8_t
     auto chip_type = get_blackhole_chip_type(board_type, asic_location);
     return chip_type == BlackholeChipType::Type1 ? PCIE_CORES_TYPE1_NOC0 : PCIE_CORES_TYPE2_NOC0;
 }
+
 }  // namespace blackhole
 
 }  // namespace tt::umd

--- a/device/blackhole/blackhole_implementation.cpp
+++ b/device/blackhole/blackhole_implementation.cpp
@@ -98,35 +98,50 @@ tt_driver_noc_params blackhole_implementation::get_noc_params() const {
 
 uint64_t blackhole_implementation::get_noc_reg_base(
     const CoreType core_type, const uint32_t noc, const uint32_t noc_port) const {
-    switch (core_type) {
-        case CoreType::TENSIX:
-        case CoreType::ETH: {
-            if (noc == 0) {
-                return 0xFFB20000;
-            } else {
-                return 0xFFB30000;
+    if (noc == 0) {
+        for (const auto& noc_pair : blackhole::NOC0_CONTROL_REG_ADDR_BASE_MAP) {
+            if (noc_pair.first == core_type) {
+                return noc_pair.second;
             }
         }
-        case CoreType::DRAM: {
-            // TODO: add noc_port parameter to this function.
-            if (noc == 0) {
-                return 0xFFB20000;
-            } else {
-                return 0xFFB30000;
+    } else {
+        for (const auto& noc_pair : blackhole::NOC1_CONTROL_REG_ADDR_BASE_MAP) {
+            if (noc_pair.first == core_type) {
+                return noc_pair.second;
             }
-        }
-        case CoreType::ARC:
-        case CoreType::PCIE: {
-            if (noc == 0) {
-                return 0xFFFFFFFFFF000000ULL;
-            } else {
-                return 0xFFFFFFFFFF000000ULL;
-            }
-        }
-        default: {
-            throw std::runtime_error("Invalid core type for getting NOC register addr base.");
         }
     }
+
+    throw std::runtime_error("Invalid core type or NOC for getting NOC register addr base.");
+    // switch (core_type) {
+    //     case CoreType::TENSIX:
+    //     case CoreType::ETH: {
+    //         if (noc == 0) {
+    //             return 0xFFB20000;
+    //         } else {
+    //             return 0xFFB30000;
+    //         }
+    //     }
+    //     case CoreType::DRAM: {
+    //         // TODO: add noc_port parameter to this function.
+    //         if (noc == 0) {
+    //             return 0xFFB20000;
+    //         } else {
+    //             return 0xFFB30000;
+    //         }
+    //     }
+    //     case CoreType::ARC:
+    //     case CoreType::PCIE: {
+    //         if (noc == 0) {
+    //             return 0xFFFFFFFFFF000000ULL;
+    //         } else {
+    //             return 0xFFFFFFFFFF000000ULL;
+    //         }
+    //     }
+    //     default: {
+    //         throw std::runtime_error("Invalid core type for getting NOC register addr base.");
+    //     }
+    // }
 }
 
 namespace blackhole {

--- a/device/blackhole/blackhole_implementation.cpp
+++ b/device/blackhole/blackhole_implementation.cpp
@@ -113,35 +113,6 @@ uint64_t blackhole_implementation::get_noc_reg_base(
     }
 
     throw std::runtime_error("Invalid core type or NOC for getting NOC register addr base.");
-    // switch (core_type) {
-    //     case CoreType::TENSIX:
-    //     case CoreType::ETH: {
-    //         if (noc == 0) {
-    //             return 0xFFB20000;
-    //         } else {
-    //             return 0xFFB30000;
-    //         }
-    //     }
-    //     case CoreType::DRAM: {
-    //         // TODO: add noc_port parameter to this function.
-    //         if (noc == 0) {
-    //             return 0xFFB20000;
-    //         } else {
-    //             return 0xFFB30000;
-    //         }
-    //     }
-    //     case CoreType::ARC:
-    //     case CoreType::PCIE: {
-    //         if (noc == 0) {
-    //             return 0xFFFFFFFFFF000000ULL;
-    //         } else {
-    //             return 0xFFFFFFFFFF000000ULL;
-    //         }
-    //     }
-    //     default: {
-    //         throw std::runtime_error("Invalid core type for getting NOC register addr base.");
-    //     }
-    // }
 }
 
 namespace blackhole {
@@ -153,7 +124,6 @@ std::vector<tt_xy_pair> get_pcie_cores(const BoardType board_type, const uint8_t
     auto chip_type = get_blackhole_chip_type(board_type, asic_location);
     return chip_type == BlackholeChipType::Type1 ? PCIE_CORES_TYPE1_NOC0 : PCIE_CORES_TYPE2_NOC0;
 }
-
 }  // namespace blackhole
 
 }  // namespace tt::umd

--- a/device/wormhole/wormhole_implementation.cpp
+++ b/device/wormhole/wormhole_implementation.cpp
@@ -4,6 +4,8 @@
 
 #include "umd/device/wormhole_implementation.h"
 
+#include <stdexcept>
+
 #include "umd/device/cluster.h"
 #include "wormhole/eth_interface.h"
 #include "wormhole/eth_l1_address_map.h"
@@ -100,6 +102,38 @@ tt_driver_eth_interface_params wormhole_implementation::get_eth_interface_params
 
 tt_driver_noc_params wormhole_implementation::get_noc_params() const {
     return {NOC_ADDR_LOCAL_BITS, NOC_ADDR_NODE_ID_BITS};
+}
+
+uint64_t wormhole_implementation::get_noc_reg_base(
+    const CoreType core_type, const uint32_t noc, const uint32_t noc_port) const {
+    switch (core_type) {
+        case CoreType::TENSIX:
+        case CoreType::ETH: {
+            if (noc == 0) {
+                return 0xFFB20000;
+            } else {
+                return 0xFFB30000;
+            }
+        }
+        case CoreType::DRAM: {
+            if (noc == 0) {
+                return 0x100080000 + noc_port * 0x10000;
+            } else {
+                return 0x100088000 + noc_port * 0x10000;
+            }
+        }
+        case CoreType::ARC:
+        case CoreType::PCIE: {
+            if (noc == 0) {
+                return 0xFFFB20000;
+            } else {
+                return 0xFFFB30000;
+            }
+        }
+        default: {
+            throw std::runtime_error("Invalid core type for getting NOC register addr base.");
+        }
+    }
 }
 
 }  // namespace tt::umd

--- a/device/wormhole/wormhole_implementation.cpp
+++ b/device/wormhole/wormhole_implementation.cpp
@@ -104,36 +104,24 @@ tt_driver_noc_params wormhole_implementation::get_noc_params() const {
     return {NOC_ADDR_LOCAL_BITS, NOC_ADDR_NODE_ID_BITS};
 }
 
+// TODO: integrate noc_port for DRAM core type inside the function.
 uint64_t wormhole_implementation::get_noc_reg_base(
     const CoreType core_type, const uint32_t noc, const uint32_t noc_port) const {
-    switch (core_type) {
-        case CoreType::TENSIX:
-        case CoreType::ETH: {
-            if (noc == 0) {
-                return 0xFFB20000;
-            } else {
-                return 0xFFB30000;
+    if (noc == 0) {
+        for (const auto& noc_pair : wormhole::NOC0_CONTROL_REG_ADDR_BASE_MAP) {
+            if (noc_pair.first == core_type) {
+                return noc_pair.second;
             }
         }
-        case CoreType::DRAM: {
-            if (noc == 0) {
-                return 0x100080000 + noc_port * 0x10000;
-            } else {
-                return 0x100088000 + noc_port * 0x10000;
+    } else {
+        for (const auto& noc_pair : wormhole::NOC1_CONTROL_REG_ADDR_BASE_MAP) {
+            if (noc_pair.first == core_type) {
+                return noc_pair.second;
             }
-        }
-        case CoreType::ARC:
-        case CoreType::PCIE: {
-            if (noc == 0) {
-                return 0xFFFB20000;
-            } else {
-                return 0xFFFB30000;
-            }
-        }
-        default: {
-            throw std::runtime_error("Invalid core type for getting NOC register addr base.");
         }
     }
+
+    throw std::runtime_error("Invalid core type or NOC for getting NOC register addr base.");
 }
 
 }  // namespace tt::umd

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -342,28 +342,11 @@ TEST(TestCluster, TestClusterLogicalETHChannelsConnectivity) {
 TEST(TestCluster, TestClusterNocId) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
-    // Setup memory barrier addresses.
-    // Some default values are set during construction of UMD, but you can override them.
-    cluster->set_barrier_address_params({L1_BARRIER_BASE, ETH_BARRIER_BASE, DRAM_BARRIER_BASE});
-
-    tt::ARCH arch = cluster->get_cluster_description()->get_arch(0);
-
-    // All chips in the cluster have the same noc_translation_enabled value.
-    bool noc_translation_enabled = cluster->get_cluster_description()->get_noc_translation_table_en().at(0);
-
-    uint64_t noc_node_id_reg_addr = 0;
-    if (arch == tt::ARCH::WORMHOLE_B0) {
-        if (noc_translation_enabled) {
-            noc_node_id_reg_addr = tt::umd::wormhole::NOC_CONTROL_REG_ADDR_BASE + tt::umd::wormhole::NOC_CFG_OFFSET +
-                                   tt::umd::wormhole::NOC_REG_WORD_SIZE * tt::umd::wormhole::NOC_CFG_NOC_ID_LOGICAL;
-        } else {
-            noc_node_id_reg_addr = tt::umd::wormhole::NOC_CONTROL_REG_ADDR_BASE + tt::umd::wormhole::NOC_NODE_ID_OFFSET;
-        }
-    } else if (arch == tt::ARCH::BLACKHOLE) {
-        noc_node_id_reg_addr = tt::umd::blackhole::NOC_CONTROL_REG_ADDR_BASE + tt::umd::blackhole::NOC_NODE_ID_OFFSET;
-    }
-
-    auto read_noc_id_reg = [noc_node_id_reg_addr](std::unique_ptr<Cluster>& cluster, chip_id_t chip, CoreCoord core) {
+    auto read_noc_id_reg = [&](std::unique_ptr<Cluster>& cluster, chip_id_t chip, CoreCoord core) {
+        const uint64_t noc_node_id_offset = 0x2C;
+        const uint64_t noc_node_id_reg_addr =
+            cluster->get_tt_device(0)->get_architecture_implementation()->get_noc_reg_base(core.core_type, 0) +
+            noc_node_id_offset;
         uint32_t noc_node_id_val;
         cluster->read_from_device(
             &noc_node_id_val, chip, core, noc_node_id_reg_addr, sizeof(noc_node_id_val), "REG_TLB");
@@ -376,10 +359,8 @@ TEST(TestCluster, TestClusterNocId) {
         const std::vector<CoreCoord>& cores = cluster->get_soc_descriptor(chip).get_cores(core_type);
         for (const CoreCoord& core : cores) {
             const auto [x, y] = read_noc_id_reg(cluster, chip, core);
-            CoreCoord translated_coord =
-                cluster->get_soc_descriptor(chip).translate_coord_to(core, CoordSystem::TRANSLATED);
-            EXPECT_EQ(translated_coord.x, x);
-            EXPECT_EQ(translated_coord.y, y);
+            EXPECT_EQ(core.x, x);
+            EXPECT_EQ(core.y, y);
         }
     };
 
@@ -388,12 +369,12 @@ TEST(TestCluster, TestClusterNocId) {
         const std::vector<CoreCoord>& cores = cluster->get_soc_descriptor(chip).get_harvested_cores(core_type);
         for (const CoreCoord& core : cores) {
             const auto [x, y] = read_noc_id_reg(cluster, chip, core);
-            CoreCoord translated_coord =
-                cluster->get_soc_descriptor(chip).translate_coord_to(core, CoordSystem::TRANSLATED);
-            EXPECT_EQ(translated_coord.x, x);
-            EXPECT_EQ(translated_coord.y, y);
+            EXPECT_EQ(core.x, x);
+            EXPECT_EQ(core.y, y);
         }
     };
+
+    tt::ARCH arch = cluster->get_cluster_description()->get_arch(0);
 
     for (chip_id_t chip : cluster->get_target_device_ids()) {
         check_noc_id_cores(cluster, chip, CoreType::TENSIX);
@@ -402,17 +383,14 @@ TEST(TestCluster, TestClusterNocId) {
         check_noc_id_cores(cluster, chip, CoreType::ETH);
         check_noc_id_harvested_cores(cluster, chip, CoreType::ETH);
 
-        // TODO: figure out how to read this information on Wormhole.
         if (arch == tt::ARCH::BLACKHOLE) {
             check_noc_id_cores(cluster, chip, CoreType::DRAM);
             check_noc_id_harvested_cores(cluster, chip, CoreType::DRAM);
         }
 
-        // TODO: figure out how to read this information on WH and BH.
-        // check_noc_id_cores(cluster, chip, CoreType::ARC);
+        check_noc_id_cores(cluster, chip, CoreType::ARC);
 
-        // TODO: figure out why this hangs the chip both on WH and BH.
-        // check_noc_id_cores(cluster, chip, CoreType::PCIE);
+        check_noc_id_cores(cluster, chip, CoreType::PCIE);
     }
 }
 

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -346,7 +346,7 @@ TEST(TestCluster, TestClusterNocId) {
         const uint64_t noc_node_id_offset = 0x2C;
         const uint64_t noc_node_id_reg_addr =
             cluster->get_tt_device(0)->get_architecture_implementation()->get_noc_reg_base(core.core_type, 0) +
-            noc_node_id_offset;
+            cluster->get_tt_device(0)->get_architecture_implementation()->get_noc_node_id_offset();
         uint32_t noc_node_id_val;
         cluster->read_from_device(
             &noc_node_id_val, chip, core, noc_node_id_reg_addr, sizeof(noc_node_id_val), "REG_TLB");
@@ -391,6 +391,8 @@ TEST(TestCluster, TestClusterNocId) {
         check_noc_id_cores(cluster, chip, CoreType::ARC);
 
         check_noc_id_cores(cluster, chip, CoreType::PCIE);
+
+        // TODO: add readouts for router cores.
     }
 }
 


### PR DESCRIPTION
### Issue

big part of #630 

### Description

Add functions to get base address of more core types. Update the NOC0 test. NOC1 test in #684 should be updated accordingly.

### List of the changes

- Add function to get base NOC register addr for all core types
- Add function to get noc node id offset per arch
- Update the NOC0 test
- Enable readouts from more core types

### Testing

CI

### API Changes
/