### PR TITLE
Fix tests to use non-harvested cores

### DIFF
--- a/tests/api/test_tlb_manager.cpp
+++ b/tests/api/test_tlb_manager.cpp
@@ -64,12 +64,15 @@ TEST(ApiTLBManager, ManualTLBConfiguration) {
     std::int32_t c_zero_address = 0;
 
     for (CoreCoord core : soc_desc.get_cores(CoreType::TENSIX)) {
-        tlb_manager->configure_tlb(core, core, get_static_tlb_index(core), c_zero_address, tlb_data::Relaxed);
+        auto virtual_core = soc_desc.translate_coord_to(core, CoordSystem::VIRTUAL);
+        auto translated_core = soc_desc.translate_coord_to(core, CoordSystem::TRANSLATED);
+        tlb_manager->configure_tlb(
+            virtual_core, translated_core, get_static_tlb_index(core), c_zero_address, tlb_data::Relaxed);
     }
 
     // So now that we have configured TLBs we can use it to interface with the TTDevice.
-    auto any_worker_core = soc_desc.get_cores(CoreType::TENSIX)[0];
-    tlb_configuration tlb_description = tlb_manager->get_tlb_configuration(any_worker_core);
+    auto any_worker_virtual_core = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::VIRTUAL)[0];
+    tlb_configuration tlb_description = tlb_manager->get_tlb_configuration(any_worker_virtual_core);
 
     // TODO: Maybe accept tlb_index only?
     uint64_t address_l1_to_write = 0;
@@ -79,6 +82,6 @@ TEST(ApiTLBManager, ManualTLBConfiguration) {
 
     // Another way to write to the TLB.
     // TODO: This should be converted to AbstractIO writer.
-    tt::Writer writer = tlb_manager->get_static_tlb_writer(any_worker_core);
+    tt::Writer writer = tlb_manager->get_static_tlb_writer(any_worker_virtual_core);
     writer.write(address_l1_to_write, buffer_to_write[0]);
 }

--- a/tests/api/test_tlb_manager.cpp
+++ b/tests/api/test_tlb_manager.cpp
@@ -29,8 +29,10 @@ TEST(ApiTLBManager, ManualTLBConfiguration) {
     }
 
     std::unique_ptr<TLBManager> tlb_manager = std::make_unique<TLBManager>(tt_device.get());
-    tt_SocDescriptor soc_desc = tt_SocDescriptor(
-        tt_SocDescriptor::get_soc_descriptor_path(tt_device->get_arch()), tt_device->get_arch() != tt::ARCH::GRAYSKULL);
+    ChipInfo chip_info = tt_device->get_chip_info();
+
+    tt_SocDescriptor soc_desc(
+        tt_device->get_arch(), chip_info.noc_translation_enabled, chip_info.harvesting_masks, chip_info.board_type);
 
     // TODO: This should be part of TTDevice interface, not Cluster or Chip.
     // Configure TLBs.

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -27,7 +27,7 @@ TEST(ApiTTDeviceTest, BasicTTDeviceIO) {
         tt_SocDescriptor soc_desc(
             tt_device->get_arch(), chip_info.noc_translation_enabled, chip_info.harvesting_masks, chip_info.board_type);
 
-        tt_xy_pair tensix_core = soc_desc.get_cores(CoreType::TENSIX)[0];
+        tt_xy_pair tensix_core = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
 
         tt_device->write_to_device(data_write.data(), tensix_core, address, data_write.size() * sizeof(uint32_t));
 
@@ -70,7 +70,7 @@ TEST(ApiTTDeviceTest, TTDeviceMultipleThreadsIO) {
         tt_SocDescriptor soc_desc(
             tt_device->get_arch(), chip_info.noc_translation_enabled, chip_info.harvesting_masks, chip_info.board_type);
 
-        tt_xy_pair tensix_core = soc_desc.get_cores(CoreType::TENSIX)[0];
+        tt_xy_pair tensix_core = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
 
         std::thread thread0([&]() {
             std::vector<uint32_t> data_read(data_write.size(), 0);

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -12,10 +12,6 @@
 
 using namespace tt::umd;
 
-tt_xy_pair get_any_tensix_core(tt::ARCH arch) {
-    return std::make_unique<Cluster>()->get_soc_descriptor(0).get_cores(CoreType::TENSIX)[0];
-}
-
 TEST(ApiTTDeviceTest, BasicTTDeviceIO) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
@@ -26,7 +22,12 @@ TEST(ApiTTDeviceTest, BasicTTDeviceIO) {
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
 
-        tt_xy_pair tensix_core = get_any_tensix_core(tt_device->get_arch());
+        ChipInfo chip_info = tt_device->get_chip_info();
+
+        tt_SocDescriptor soc_desc(
+            tt_device->get_arch(), chip_info.noc_translation_enabled, chip_info.harvesting_masks, chip_info.board_type);
+
+        tt_xy_pair tensix_core = soc_desc.get_cores(CoreType::TENSIX)[0];
 
         tt_device->write_to_device(data_write.data(), tensix_core, address, data_write.size() * sizeof(uint32_t));
 
@@ -64,7 +65,12 @@ TEST(ApiTTDeviceTest, TTDeviceMultipleThreadsIO) {
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
 
-        tt_xy_pair tensix_core = get_any_tensix_core(tt_device->get_arch());
+        ChipInfo chip_info = tt_device->get_chip_info();
+
+        tt_SocDescriptor soc_desc(
+            tt_device->get_arch(), chip_info.noc_translation_enabled, chip_info.harvesting_masks, chip_info.board_type);
+
+        tt_xy_pair tensix_core = soc_desc.get_cores(CoreType::TENSIX)[0];
 
         std::thread thread0([&]() {
             std::vector<uint32_t> data_read(data_write.size(), 0);


### PR DESCRIPTION
### Issue

#697 

### Description

Fix TLBManager and TTDevice test to always use non-harvested tensix cores.

### List of the changes

- Fix tests to use non-harvested cores

### Testing

CI

### API Changes
/
