### PR TITLE
TTDevice get max and min AICLK

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -871,8 +871,7 @@ private:
     uint32_t get_harvested_noc_rows(uint32_t harvesting_mask);
     uint32_t get_harvested_rows(int logical_device_id);
     int get_clock(int logical_device_id);
-    void wait_for_aiclk_value(const uint32_t aiclk_val, const uint32_t timeout_ms = 5000);
-    static uint32_t get_target_aiclk_value(tt::ARCH arch, tt_DevicePowerState device_state);
+    void wait_for_aiclk_value(tt_DevicePowerState power_state, const uint32_t timeout_ms = 5000);
 
     // Communication Functions
     void write_device_memory(

--- a/device/api/umd/device/tt_device/blackhole_tt_device.h
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.h
@@ -25,6 +25,10 @@ public:
 
     uint32_t get_clock() override;
 
+    uint32_t get_max_clock_freq() override;
+
+    uint32_t get_min_clock_freq() override;
+
     BoardType get_board_type() override;
 
 private:

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -147,6 +147,10 @@ public:
 
     virtual uint32_t get_clock();
 
+    virtual uint32_t get_max_clock_freq();
+
+    virtual uint32_t get_min_clock_freq();
+
     virtual BoardType get_board_type() = 0;
 
     // TODO: find a way to expose this in a better way, probably through getting telemetry reader and reading the

--- a/device/api/umd/device/tt_device/wormhole_tt_device.h
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.h
@@ -19,6 +19,10 @@ public:
 
     uint32_t get_clock() override;
 
+    uint32_t get_max_clock_freq() override;
+
+    uint32_t get_min_clock_freq() override;
+
     BoardType get_board_type() override;
 
     std::vector<DramTrainingStatus> get_dram_training_status() override;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -763,7 +763,7 @@ std::map<int, int> Cluster::get_clocks() {
 void Cluster::wait_for_aiclk_value(tt_DevicePowerState power_state, const uint32_t timeout_ms) {
     auto start = std::chrono::system_clock::now();
     for (auto& chip_id : local_chip_ids_) {
-        uint32_t target_aiclk;
+        uint32_t target_aiclk = 0;
         if (power_state == tt_DevicePowerState::BUSY) {
             target_aiclk = get_tt_device(chip_id)->get_max_clock_freq();
         } else if (power_state == tt_DevicePowerState::LONG_IDLE) {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -760,29 +760,17 @@ std::map<int, int> Cluster::get_clocks() {
     return clock_freq_map;
 }
 
-uint32_t Cluster::get_target_aiclk_value(tt::ARCH arch, tt_DevicePowerState device_state) {
-    if (arch == tt::ARCH::WORMHOLE_B0) {
-        if (device_state == tt_DevicePowerState::BUSY) {
-            return tt::umd::wormhole::AICLK_BUSY_VAL;
-        } else if (device_state == tt_DevicePowerState::LONG_IDLE) {
-            return tt::umd::wormhole::AICLK_IDLE_VAL;
-        }
-    } else if (arch == tt::ARCH::BLACKHOLE) {
-        if (device_state == tt_DevicePowerState::BUSY) {
-            return tt::umd::blackhole::AICLK_BUSY_VAL;
-        } else if (device_state == tt_DevicePowerState::LONG_IDLE) {
-            return tt::umd::blackhole::AICLK_IDLE_VAL;
-        }
-    }
-
-    throw std::runtime_error("Unsupported architecture for getting AICLK value.");
-}
-
-void Cluster::wait_for_aiclk_value(const uint32_t aiclk_val, const uint32_t timeout_ms) {
+void Cluster::wait_for_aiclk_value(tt_DevicePowerState power_state, const uint32_t timeout_ms) {
     auto start = std::chrono::system_clock::now();
     for (auto& chip_id : local_chip_ids_) {
+        uint32_t target_aiclk;
+        if (power_state == tt_DevicePowerState::BUSY) {
+            target_aiclk = get_tt_device(chip_id)->get_max_clock_freq();
+        } else if (power_state == tt_DevicePowerState::LONG_IDLE) {
+            target_aiclk = get_tt_device(chip_id)->get_min_clock_freq();
+        }
         uint32_t aiclk = get_clock(chip_id);
-        while (aiclk != aiclk_val) {
+        while (aiclk != target_aiclk) {
             auto end = std::chrono::system_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
             if (duration.count() > timeout_ms) {
@@ -2514,7 +2502,7 @@ void Cluster::set_power_state(tt_DevicePowerState device_state) {
             }
         }
     }
-    wait_for_aiclk_value(Cluster::get_target_aiclk_value(arch_name, device_state));
+    wait_for_aiclk_value(device_state);
 }
 
 void Cluster::enable_ethernet_queue(int timeout) {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -2435,7 +2435,7 @@ void Cluster::send_remote_tensix_risc_reset_to_core(
 int Cluster::set_remote_power_state(const chip_id_t& chip, tt_DevicePowerState device_state) {
     auto mmio_capable_chip_logical = cluster_desc->get_closest_mmio_capable_chip(chip);
     return remote_arc_msg(
-        chip, get_power_state_arc_msg(mmio_capable_chip_logical, device_state), true, 0, 0, 1, NULL, NULL);
+        chip, get_power_state_arc_msg(mmio_capable_chip_logical, device_state), true, 0, 0, 1000, NULL, NULL);
 }
 
 void Cluster::enable_remote_ethernet_queue(const chip_id_t& chip, int timeout) {
@@ -2447,7 +2447,7 @@ void Cluster::enable_remote_ethernet_queue(const chip_id_t& chip, int timeout) {
             throw std::runtime_error(
                 fmt::format("Timed out after waiting {} seconds for DRAM to finish training", timeout));
         }
-        int msg_rt = remote_arc_msg(chip, 0xaa58, true, 0xFFFF, 0xFFFF, 1, &msg_success, NULL);
+        int msg_rt = remote_arc_msg(chip, 0xaa58, true, 0xFFFF, 0xFFFF, 1000, &msg_success, NULL);
         if (msg_rt == MSG_ERROR_REPLY) {
             break;
         }
@@ -2555,7 +2555,7 @@ void Cluster::deassert_resets_and_set_power_state() {
                         true,
                         0x0,
                         0x0,
-                        1,
+                        1000,
                         NULL,
                         NULL);
                 }

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -149,6 +149,12 @@ uint32_t BlackholeTTDevice::get_clock() {
     throw std::runtime_error("AICLK telemetry not available for Blackhole device.");
 }
 
+// TODO: figure out if Blackhole has the information on maximum possible
+// clock frequency. For now, we are using the maximum possible value.
+uint32_t BlackholeTTDevice::get_max_clock_freq() { return tt::umd::blackhole::AICLK_BUSY_VAL; }
+
+uint32_t BlackholeTTDevice::get_min_clock_freq() { return tt::umd::blackhole::AICLK_IDLE_VAL; }
+
 BoardType BlackholeTTDevice::get_board_type() {
     return get_board_type_from_board_id(
         ((uint64_t)telemetry->read_entry(blackhole::TAG_BOARD_ID_HIGH) << 32) |

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -383,6 +383,18 @@ uint32_t TTDevice::get_clock() {
         "TTDevice is deleted.");
 }
 
+uint32_t TTDevice::get_max_clock_freq() {
+    throw std::runtime_error(
+        "Base TTDevice class does not have get_max_clock_freq implemented. Move this to abstract function once "
+        "Grayskull TTDevice is deleted.");
+}
+
+uint32_t TTDevice::get_min_clock_freq() {
+    throw std::runtime_error(
+        "Base TTDevice class does not have get_min_clock_freq implemented. Move this to abstract function once "
+        "Grayskull TTDevice is deleted.");
+}
+
 TTDevice::~TTDevice() { lock_manager.clear_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num()); }
 
 std::vector<DramTrainingStatus> TTDevice::get_dram_training_status() { return {}; }

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -65,6 +65,13 @@ uint32_t WormholeTTDevice::get_clock() {
     return arc_msg_return_values[0];
 }
 
+uint32_t WormholeTTDevice::get_max_clock_freq() {
+    uint32_t aiclk_telemetry = telemetry->read_entry(tt::umd::wormhole::TAG_AICLK);
+    return (aiclk_telemetry >> 16) & 0xFFFF;
+}
+
+uint32_t WormholeTTDevice::get_min_clock_freq() { return tt::umd::wormhole::AICLK_IDLE_VAL; }
+
 BoardType WormholeTTDevice::get_board_type() {
     uint32_t board_id_lo = telemetry->read_entry(tt::umd::wormhole::TAG_BOARD_ID_LOW);
     uint32_t board_id_hi = telemetry->read_entry(tt::umd::wormhole::TAG_BOARD_ID_HIGH);

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -355,15 +355,19 @@ TEST(TestCluster, TestClusterAICLKControl) {
 
     cluster->set_power_state(tt_DevicePowerState::BUSY);
 
-    auto clocks = cluster->get_clocks();
-    for (auto& clock : clocks) {
-        EXPECT_EQ(clock.second, go_busy_aiclk_val);
+    // TODO: check this for Wormhole as well if we can somehow hardcode set of values to check for
+    // go busy AICLK. It won't always be the same for Wormhole.
+    if (arch == tt::ARCH::BLACKHOLE) {
+        auto clocks_busy = cluster->get_clocks();
+        for (auto& clock : clocks_busy) {
+            EXPECT_EQ(clock.second, go_busy_aiclk_val);
+        }
     }
 
     cluster->set_power_state(tt_DevicePowerState::LONG_IDLE);
 
-    clocks = cluster->get_clocks();
-    for (auto& clock : clocks) {
+    auto clocks_idle = cluster->get_clocks();
+    for (auto& clock : clocks_idle) {
         EXPECT_EQ(clock.second, go_idle_aiclk_val);
     }
 }


### PR DESCRIPTION
### Issue

AICLK go busy value is not always going to be the same, but we can read the maximum possible value on the device. So instead of waiting for 1000 on Wormhole, wait on the maximum for the specified device.

Aftermath of https://github.com/tenstorrent/tt-umd/pull/663 and https://github.com/tenstorrent/tt-umd/pull/698

### Description

Add functions to get maximum and minimum possible AICLK from TTDevice. Wait on those values when changing power state.

### List of the changes

- Add function for getting maximum AICLK from device
- Add function for getting minimum AICLK from device
- Wait on those values when setting power state
- Change test for Wormhole since we can't hardcode value now
- Fix remote arc message timeout

### Testing
CI

### API Changes
/
