### PR TITLE
Revert "Move remote eth core choice to local_chip (#667)"

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include <unordered_set>
-
 #include "umd/device/lock_manager.h"
 #include "umd/device/tt_soc_descriptor.h"
 #include "umd/device/types/cluster_descriptor_types.h"
@@ -57,13 +55,6 @@ public:
     // TODO: To be removed once all usages are moved inside local chip.
     virtual std::unique_lock<boost::interprocess::named_mutex> get_mutex(std::string mutex_name, int pci_device_id);
     virtual std::unique_lock<boost::interprocess::named_mutex> get_mutex(MutexType mutex_type, int pci_device_id);
-
-    virtual void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores);
-    // TODO: To be removed once all the usages are moved inside the class.
-    virtual tt_xy_pair get_remote_transfer_ethernet_core();
-    virtual void update_active_eth_core_idx();
-    virtual int get_active_eth_core_idx();
-    virtual std::vector<CoreCoord> get_remote_transfer_ethernet_cores();
 
     // TODO: This should be private, once enough stuff is moved inside chip.
     // Probably also moved to LocalChip.

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -30,13 +30,6 @@ public:
     SysmemManager* get_sysmem_manager() override;
     TLBManager* get_tlb_manager() override;
 
-    void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) override;
-    // TODO: To be removed once all the usages are moved inside the class.
-    tt_xy_pair get_remote_transfer_ethernet_core() override;
-    void update_active_eth_core_idx() override;
-    int get_active_eth_core_idx() override;
-    std::vector<CoreCoord> get_remote_transfer_ethernet_cores() override;
-
     void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) override;
     void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) override;
 
@@ -58,9 +51,6 @@ private:
     std::unique_ptr<SysmemManager> sysmem_manager_;
     std::unique_ptr<TLBManager> tlb_manager_;
     LockManager lock_manager_;
-
-    std::vector<CoreCoord> remote_transfer_eth_cores_;
-    int active_eth_core_idx = 0;
 
     void initialize_local_chip(int num_host_mem_channels = 0, const bool clear_mutex = false);
     void initialize_tlb_manager();

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -1020,7 +1020,23 @@ private:
 
     std::shared_ptr<tt_ClusterDescriptor> cluster_desc;
 
+    // remote eth transfer setup
+    static constexpr std::uint32_t NUM_ETH_CORES_FOR_NON_MMIO_TRANSFERS = 6;
+    static constexpr std::uint32_t NON_EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS = 4;
+    static constexpr std::uint32_t NON_EPOCH_ETH_CORES_START_ID = 0;
+    static constexpr std::uint32_t NON_EPOCH_ETH_CORES_MASK = (NON_EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS - 1);
+
+    static constexpr std::uint32_t EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS =
+        NUM_ETH_CORES_FOR_NON_MMIO_TRANSFERS - NON_EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS;
+    static constexpr std::uint32_t EPOCH_ETH_CORES_START_ID =
+        NON_EPOCH_ETH_CORES_START_ID + NON_EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS;
+    static constexpr std::uint32_t EPOCH_ETH_CORES_MASK = (EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS - 1);
+
+    int active_core = NON_EPOCH_ETH_CORES_START_ID;
+    std::vector<std::vector<tt_cxy_pair>> remote_transfer_ethernet_cores;
     std::unordered_map<chip_id_t, bool> flush_non_mmio_per_chip = {};
+    bool non_mmio_transfer_cores_customized = false;
+    std::unordered_map<chip_id_t, int> active_eth_core_idx_per_chip = {};
     std::unordered_map<chip_id_t, std::unordered_set<tt_xy_pair>> workers_per_chip = {};
     std::unordered_set<tt_xy_pair> eth_cores = {};
     std::unordered_set<tt_xy_pair> dram_cores = {};

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -99,26 +99,6 @@ void Chip::read_from_device_reg(
     throw std::runtime_error("Chip::read_from_device_reg is not available for this chip.");
 }
 
-void Chip::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) {
-    throw std::runtime_error("Chip::set_remote_transfer_ethernet_cores is not available for this chip.");
-}
-
-tt_xy_pair Chip::get_remote_transfer_ethernet_core() {
-    throw std::runtime_error("Chip::get_remote_transfer_ethernet_core is not available for this chip.");
-}
-
-void Chip::update_active_eth_core_idx() {
-    throw std::runtime_error("Chip::update_active_eth_core_idx is not available for this chip.");
-}
-
-int Chip::get_active_eth_core_idx() {
-    throw std::runtime_error("Chip::active_eth_core_idx is not available for this chip.");
-}
-
-std::vector<CoreCoord> Chip::get_remote_transfer_ethernet_cores() {
-    throw std::runtime_error("Chip::get_remote_transfer_ethernet_cores is not available for this chip.");
-}
-
 std::unique_lock<boost::interprocess::named_mutex> Chip::get_mutex(std::string mutex_name, int pci_device_id) {
     throw std::runtime_error("LockManager::get_mutex is not available for this chip.");
 }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -157,6 +157,23 @@ void Cluster::construct_cluster(const uint32_t& num_host_mem_ch_per_mmio_device,
     }
 
     populate_cores();
+
+    // MT: Initial BH - skip this for BH
+    if (arch_name == tt::ARCH::WORMHOLE_B0) {
+        remote_transfer_ethernet_cores.resize(local_chip_ids_.size());
+        for (const auto& logical_mmio_chip_id : local_chip_ids_) {
+            const tt_SocDescriptor& soc_desc = get_soc_descriptor(logical_mmio_chip_id);
+            // 4-5 is for send_epoch_commands, 0-3 are for everything else
+            for (std::uint32_t i = 0; i < NUM_ETH_CORES_FOR_NON_MMIO_TRANSFERS; i++) {
+                if (remote_transfer_ethernet_cores.size() <= logical_mmio_chip_id) {
+                    remote_transfer_ethernet_cores.resize(logical_mmio_chip_id + 1);
+                }
+                CoreCoord ethernet_core = soc_desc.get_eth_core_for_channel(i, CoordSystem::VIRTUAL);
+                remote_transfer_ethernet_cores.at(logical_mmio_chip_id)
+                    .push_back(tt_cxy_pair(logical_mmio_chip_id, ethernet_core));
+            }
+        }
+    }
 }
 
 std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
@@ -524,7 +541,33 @@ Cluster::Cluster(
 
 void Cluster::configure_active_ethernet_cores_for_mmio_device(
     chip_id_t mmio_chip, const std::unordered_set<CoreCoord>& active_eth_cores_per_chip) {
-    get_local_chip(mmio_chip)->set_remote_transfer_ethernet_cores(active_eth_cores_per_chip);
+    // Makes UMD aware of which ethernet cores have active links.
+    // Based on this information, UMD determines which ethernet cores can be used for host->cluster non-MMIO transfers.
+    // This overrides the default ethernet cores tagged for host to cluster routing in the constructor and must be
+    // called for all MMIO devices, if default behaviour is not desired.
+    auto& soc_desc = get_soc_descriptor(mmio_chip);
+    log_assert(soc_desc.arch == tt::ARCH::WORMHOLE_B0, "{} can only be called for Wormhole arch", __FUNCTION__);
+    // Cores 0, 1, 6, 7 are only available if in the active set
+    static std::unordered_set<CoreCoord> eth_cores_available_if_active = {
+        soc_desc.get_eth_core_for_channel(0, CoordSystem::VIRTUAL),
+        soc_desc.get_eth_core_for_channel(1, CoordSystem::VIRTUAL),
+        soc_desc.get_eth_core_for_channel(6, CoordSystem::VIRTUAL),
+        soc_desc.get_eth_core_for_channel(7, CoordSystem::VIRTUAL)};
+    // Eth cores 8 and 9 are always available
+    std::vector<tt_cxy_pair> non_mmio_access_cores_for_chip = {
+        {(size_t)mmio_chip, soc_desc.get_eth_core_for_channel(8, CoordSystem::VIRTUAL)},
+        {(size_t)mmio_chip, soc_desc.get_eth_core_for_channel(9, CoordSystem::VIRTUAL)}};
+    for (const auto& active_eth_core : active_eth_cores_per_chip) {
+        const auto virtual_active_eth_core =
+            get_soc_descriptor(mmio_chip).translate_coord_to(active_eth_core, CoordSystem::VIRTUAL);
+        if (eth_cores_available_if_active.find(virtual_active_eth_core) != eth_cores_available_if_active.end()) {
+            non_mmio_access_cores_for_chip.push_back(tt_cxy_pair(mmio_chip, virtual_active_eth_core));
+        }
+    }
+
+    remote_transfer_ethernet_cores[mmio_chip] = non_mmio_access_cores_for_chip;
+    active_eth_core_idx_per_chip.insert({mmio_chip, 0});
+    non_mmio_transfer_cores_customized = true;
 }
 
 void Cluster::populate_cores() {
@@ -1209,6 +1252,12 @@ void Cluster::write_to_non_mmio_device(
     }
     flush_non_mmio_per_chip[cluster_desc->get_closest_mmio_capable_chip(core.chip)] = true;
 
+    if (non_mmio_transfer_cores_customized) {
+        log_assert(
+            active_eth_core_idx_per_chip.find(mmio_capable_chip_logical) != active_eth_core_idx_per_chip.end(),
+            "Ethernet Cores for Host to Cluster communication were not initialized for all MMIO devices.");
+    }
+
     using data_word_t = uint32_t;
     constexpr int DATA_WORD_SIZE = sizeof(data_word_t);
     constexpr int BROADCAST_HEADER_SIZE = sizeof(data_word_t) * 8;  // Broadcast header is 8 words
@@ -1253,8 +1302,11 @@ void Cluster::write_to_non_mmio_device(
         get_local_chip(mmio_capable_chip_logical)
             ->get_mutex(
                 MutexType::NON_MMIO, get_tt_device(mmio_capable_chip_logical)->get_pci_device()->get_device_num());
-    tt_cxy_pair remote_transfer_ethernet_core = tt_cxy_pair(
-        mmio_capable_chip_logical, get_local_chip(mmio_capable_chip_logical)->get_remote_transfer_ethernet_core());
+
+    int& active_core_for_txn =
+        non_mmio_transfer_cores_customized ? active_eth_core_idx_per_chip.at(mmio_capable_chip_logical) : active_core;
+    tt_cxy_pair remote_transfer_ethernet_core =
+        remote_transfer_ethernet_cores.at(mmio_capable_chip_logical)[active_core_for_txn];
 
     erisc_command.resize(sizeof(routing_cmd_t) / DATA_WORD_SIZE);
     new_cmd = (routing_cmd_t*)&erisc_command[0];
@@ -1264,6 +1316,7 @@ void Cluster::write_to_non_mmio_device(
         eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
         eth_interface_params.remote_update_ptr_size_bytes * 2,
         read_tlb);
+    uint32_t full_count = 0;
     uint32_t offset = 0;
     uint32_t block_size;
 
@@ -1282,6 +1335,7 @@ void Cluster::write_to_non_mmio_device(
                 read_tlb);
             full = is_non_mmio_cmd_q_full(
                 chips_.at(mmio_capable_chip_logical)->eth_interface_params, erisc_q_ptrs[0], erisc_q_rptr[0]);
+            full_count++;
         }
         // full = true;
         //  set full only if this command will make the q full.
@@ -1320,9 +1374,7 @@ void Cluster::write_to_non_mmio_device(
 
         uint32_t host_dram_block_addr =
             host_address_params.eth_routing_buffers_start +
-            (get_local_chip(mmio_capable_chip_logical)->get_active_eth_core_idx() * eth_interface_params.cmd_buf_size +
-             req_wr_ptr) *
-                max_block_size;
+            (active_core_for_txn * eth_interface_params.cmd_buf_size + req_wr_ptr) * max_block_size;
         uint16_t host_dram_channel = 0;  // This needs to be 0, since WH can only map ETH buffers to chan 0.
 
         if (req_flags & eth_interface_params.cmd_data_block) {
@@ -1425,10 +1477,15 @@ void Cluster::write_to_non_mmio_device(
                 chips_.at(mmio_capable_chip_logical)->eth_interface_params,
                 (erisc_q_ptrs[0]) & eth_interface_params.cmd_buf_ptr_mask,
                 erisc_q_rptr[0])) {
-            get_local_chip(mmio_capable_chip_logical)->update_active_eth_core_idx();
-            remote_transfer_ethernet_core = tt_cxy_pair(
-                mmio_capable_chip_logical,
-                get_local_chip(mmio_capable_chip_logical)->get_remote_transfer_ethernet_core());
+            active_core_for_txn++;
+            uint32_t update_mask_for_chip = remote_transfer_ethernet_cores[mmio_capable_chip_logical].size() - 1;
+            active_core_for_txn =
+                non_mmio_transfer_cores_customized
+                    ? (active_core_for_txn & update_mask_for_chip)
+                    : ((active_core_for_txn & NON_EPOCH_ETH_CORES_MASK) + NON_EPOCH_ETH_CORES_START_ID);
+            // active_core = (active_core & NON_EPOCH_ETH_CORES_MASK) + NON_EPOCH_ETH_CORES_START_ID;
+            remote_transfer_ethernet_core =
+                remote_transfer_ethernet_cores.at(mmio_capable_chip_logical)[active_core_for_txn];
             read_device_memory(
                 erisc_q_ptrs.data(),
                 remote_transfer_ethernet_core,
@@ -1488,8 +1545,7 @@ void Cluster::read_from_non_mmio_device(void* mem_ptr, tt_cxy_pair core, uint64_
         get_local_chip(mmio_capable_chip_logical)
             ->get_mutex(
                 MutexType::NON_MMIO, get_tt_device(mmio_capable_chip_logical)->get_pci_device()->get_device_num());
-    const tt_cxy_pair remote_transfer_ethernet_core = tt_cxy_pair(
-        mmio_capable_chip_logical, get_local_chip(mmio_capable_chip_logical)->get_remote_transfer_ethernet_core());
+    const tt_cxy_pair remote_transfer_ethernet_core = remote_transfer_ethernet_cores[mmio_capable_chip_logical].at(0);
 
     read_device_memory(
         erisc_q_ptrs.data(),
@@ -1723,8 +1779,7 @@ void Cluster::wait_for_connected_non_mmio_flush(const chip_id_t chip_id) {
                 std::vector<uint32_t>(eth_interface_params.remote_update_ptr_size_bytes * 2 / sizeof(uint32_t));
 
             // wait for all queues to be empty.
-            for (tt_xy_pair& xy : get_local_chip(chip_id)->get_remote_transfer_ethernet_cores()) {
-                tt_cxy_pair cxy = tt_cxy_pair(chip_id, xy);
+            for (tt_cxy_pair& cxy : remote_transfer_ethernet_cores.at(chip_id)) {
                 do {
                     read_device_memory(
                         erisc_q_ptrs.data(),
@@ -1735,8 +1790,7 @@ void Cluster::wait_for_connected_non_mmio_flush(const chip_id_t chip_id) {
                 } while (erisc_q_ptrs[0] != erisc_q_ptrs[4]);
             }
             // wait for all write responses to come back.
-            for (tt_xy_pair& xy : get_local_chip(chip_id)->get_remote_transfer_ethernet_cores()) {
-                tt_cxy_pair cxy = tt_cxy_pair(chip_id, xy);
+            for (tt_cxy_pair& cxy : remote_transfer_ethernet_cores.at(chip_id)) {
                 do {
                     read_device_memory(
                         erisc_txn_counters.data(), cxy, eth_interface_params.request_cmd_queue_base, 8, read_tlb);

--- a/device/remote_communication.cpp
+++ b/device/remote_communication.cpp
@@ -271,7 +271,10 @@ void RemoteCommunication::write_to_non_mmio(
     uint32_t size_in_bytes,
     eth_coord_t target_chip,
     const tt_xy_pair eth_core) {
+    static constexpr std::uint32_t NUM_ETH_CORES_FOR_NON_MMIO_TRANSFERS = 6;
     static constexpr std::uint32_t NON_EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS = 4;
+    static constexpr std::uint32_t NON_EPOCH_ETH_CORES_START_ID = 0;
+    static constexpr std::uint32_t NON_EPOCH_ETH_CORES_MASK = (NON_EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS - 1);
 
     using data_word_t = uint32_t;
     constexpr int DATA_WORD_SIZE = sizeof(data_word_t);
@@ -314,6 +317,7 @@ void RemoteCommunication::write_to_non_mmio(
 
     auto lock = lock_manager.get_mutex(MutexType::NON_MMIO, tt_device->get_pci_device()->get_device_num());
 
+    bool non_mmio_transfer_cores_customized = false;
     int active_core_for_txn = 0;
 
     tt_xy_pair remote_transfer_ethernet_core = eth_core;
@@ -448,7 +452,16 @@ void RemoteCommunication::write_to_non_mmio(
 
         if (is_non_mmio_cmd_q_full(
                 eth_interface_params, (erisc_q_ptrs[0]) & eth_interface_params.cmd_buf_ptr_mask, erisc_q_rptr[0])) {
-            active_core_for_txn = (active_core_for_txn + 1) % NON_EPOCH_ETH_CORES_FOR_NON_MMIO_TRANSFERS;
+            active_core_for_txn++;
+            // uint32_t update_mask_for_chip = remote_transfer_ethernet_cores[mmio_capable_chip_logical].size() - 1;
+            uint32_t update_mask_for_chip = 1;
+            active_core_for_txn =
+                non_mmio_transfer_cores_customized
+                    ? (active_core_for_txn & update_mask_for_chip)
+                    : ((active_core_for_txn & NON_EPOCH_ETH_CORES_MASK) + NON_EPOCH_ETH_CORES_START_ID);
+            // active_core = (active_core & NON_EPOCH_ETH_CORES_MASK) + NON_EPOCH_ETH_CORES_START_ID;
+            // remote_transfer_ethernet_core =
+            //     remote_transfer_ethernet_cores.at(mmio_capable_chip_logical)[active_core_for_txn];
             remote_transfer_ethernet_core = eth_core;
             tt_device->read_from_device(
                 erisc_q_ptrs.data(),


### PR DESCRIPTION
This reverts commit 0c92c0298a87f4ac533074323f160361a099e6dc.

### Issue
Solves #712 

### Description
Haven't investigated yet why this happens, but will when I create this change again.

### List of the changes
- Reverted offending TG change using git revert command

### Testing
Relevant thread where testing process was explained: https://github.com/tenstorrent/tt-umd/pull/709#discussion_r2033695669

I ran TG on fix #709 without this commit, and it passed: https://github.com/tenstorrent/tt-metal/actions/runs/14354669406

### API Changes
There are no API changes in this PR.
