### PR TITLE
CPM: Don't download boost

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -42,23 +42,6 @@ function(fetch_dependencies)
     endif()
 
     ###################################################################################################################
-    # boost::interprocess
-    ###################################################################################################################
-    CPMAddPackage(
-        NAME Boost
-        VERSION 1.86.0
-        URL
-            https://github.com/boostorg/boost/releases/download/boost-1.86.0/boost-1.86.0-cmake.tar.xz
-            URL_HASH
-            SHA256=2c5ec5edcdff47ff55e27ed9560b0a0b94b07bd07ed9928b476150e16b0efc57
-        OPTIONS
-            "BOOST_ENABLE_CMAKE ON"
-            "BOOST_SKIP_INSTALL_RULES ON"
-            "BUILD_SHARED_LIBS OFF"
-            "BOOST_INCLUDE_LIBRARIES interprocess"
-    )
-
-    ###################################################################################################################
     # Nanomsg
     ###################################################################################################################
     CPMAddPackage(

--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -133,7 +133,6 @@ target_link_libraries(
         nng
         rt
         uv_a
-        Boost::interprocess
         spdlog::spdlog_header_only
         fmt::fmt-header-only
         yaml-cpp::yaml-cpp


### PR DESCRIPTION
https://github.com/tenstorrent/tt-umd/pull/693 removed UMD use of boost::interprocess.
Fixes #681 

This PR stops UMD from downloading 91M of boost on every CMake configuration.  It is no longer needed.