### PR TITLE
Fix: enforce alignment for register access

### DIFF
--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -14,32 +14,6 @@
 
 extern bool umd_use_noc1;
 
-struct tt_4_byte_aligned_buffer {
-    // Stores a 4 byte aligned buffer
-    // If the input buffer is already 4 byte aligned, this is a nop
-    std::uint32_t* local_storage = nullptr;
-    std::uint32_t input_size = 0;
-    std::uint32_t block_size = 0;
-
-    tt_4_byte_aligned_buffer(const void* mem_ptr, uint32_t size_in_bytes) {
-        input_size = size_in_bytes;
-        local_storage = (uint32_t*)mem_ptr;
-        uint32_t alignment_mask = sizeof(uint32_t) - 1;
-        uint32_t aligned_size = (size_in_bytes + alignment_mask) & ~alignment_mask;
-
-        if (size_in_bytes < aligned_size) {
-            local_storage = new uint32_t[aligned_size / sizeof(uint32_t)];
-        }
-        block_size = aligned_size;
-    }
-
-    ~tt_4_byte_aligned_buffer() {
-        if (block_size > input_size) {
-            delete[] local_storage;
-        }
-    }
-};
-
 namespace tt::umd {
 
 // TLB size for DRAM on blackhole - 4GB
@@ -265,37 +239,40 @@ void LocalChip::read_from_device(
 
 void LocalChip::write_to_device_reg(
     tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size, const std::string& fallback_tlb) {
+    if (size % sizeof(uint32_t) != 0) {
+        throw std::runtime_error("Size must be a multiple of 4 bytes");
+    }
+
+    if (reg_dest % sizeof(uint32_t) != 0) {
+        throw std::runtime_error("Register address must be 4-byte aligned");
+    }
+
     const auto tlb_index = tlb_manager_->dynamic_tlb_config_.at(fallback_tlb);
     auto lock = lock_manager_.acquire_mutex(fallback_tlb, tt_device_->get_pci_device()->get_device_num());
     log_debug(LogSiliconDriver, "  dynamic tlb_index: {}", tlb_index);
 
     auto [mapped_address, tlb_size] = tt_device_->set_dynamic_tlb(
         tlb_index, translate_chip_coord_virtual_to_translated(core), reg_dest, tt::umd::tlb_data::Strict);
-    // Align block to 4bytes if needed.
-    auto aligned_buf = tt_4_byte_aligned_buffer(src, size);
-    if (aligned_buf.input_size != aligned_buf.block_size) {
-        // Copy value from main buffer to aligned buffer
-        std::memcpy(aligned_buf.local_storage, src, size);
-    }
-    tt_device_->write_regs(mapped_address, aligned_buf.block_size / sizeof(uint32_t), aligned_buf.local_storage);
+    tt_device_->write_regs(mapped_address, size / sizeof(uint32_t), src);
 }
 
 void LocalChip::read_from_device_reg(
     tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size, const std::string& fallback_tlb) {
+    if (size % sizeof(uint32_t) != 0) {
+        throw std::runtime_error("Size must be a multiple of 4 bytes");
+    }
+
+    if (reg_src % sizeof(uint32_t) != 0) {
+        throw std::runtime_error("Register address must be 4-byte aligned");
+    }
+
     const auto tlb_index = tlb_manager_->dynamic_tlb_config_.at(fallback_tlb);
     auto lock = lock_manager_.acquire_mutex(fallback_tlb, tt_device_->get_pci_device()->get_device_num());
     log_debug(LogSiliconDriver, "  dynamic tlb_index: {}", tlb_index);
 
     auto [mapped_address, tlb_size] = tt_device_->set_dynamic_tlb(
         tlb_index, translate_chip_coord_virtual_to_translated(core), reg_src, tt::umd::tlb_data::Strict);
-    // Align block to 4bytes if needed.
-    auto aligned_buf = tt_4_byte_aligned_buffer(dest, size);
-    tt_device_->read_regs(mapped_address, aligned_buf.block_size / sizeof(std::uint32_t), aligned_buf.local_storage);
-
-    if (aligned_buf.input_size != aligned_buf.block_size) {
-        // Copy value from aligned buffer to main buffer.
-        std::memcpy(dest, aligned_buf.local_storage, size);
-    }
+    tt_device_->read_regs(mapped_address, size / sizeof(uint32_t), dest);
 }
 
 tt_xy_pair LocalChip::translate_chip_coord_virtual_to_translated(const tt_xy_pair core) const {


### PR DESCRIPTION
Remove the complex and bugged tt_4_byte_aligned_buffer class.  This fixes a bug where uninitialized padding bytes could be written to registers if the original size was not a multiple of 4.

Add strict checks to ensure that register access is 4-byte aligned and in a multiple of 4 bytes.