### PR TITLE
Introduce a PCIe DMA API; add a basic WH implementation

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -50,6 +50,10 @@ public:
     virtual void read_from_device(
         tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size, const std::string& fallback_tlb);
 
+    // Will only ever work for LocalChip.
+    virtual void dma_write_to_device(const void* src, size_t size, tt_xy_pair core, uint64_t addr);
+    virtual void dma_read_from_device(void* dst, size_t size, tt_xy_pair core, uint64_t addr);
+
     virtual void write_to_device_reg(
         tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size, const std::string& fallback_tlb);
     virtual void read_from_device_reg(

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -46,6 +46,9 @@ public:
     void read_from_device(
         tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size, const std::string& fallback_tlb) override;
 
+    void dma_write_to_device(const void* src, size_t size, tt_xy_pair core, uint64_t addr) override;
+    void dma_read_from_device(void* dst, size_t size, tt_xy_pair core, uint64_t addr) override;
+
     void write_to_device_reg(
         tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size, const std::string& fallback_tlb) override;
     void read_from_device_reg(

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -331,6 +331,30 @@ public:
     }
 
     /**
+     * Use PCIe DMA to write device memory (L1 or DRAM).
+     *
+     * @param src Source data address.
+     * @param size Size in bytes.
+     * @param chip Chip to target; must be local, i.e. attached via PCIe.
+     * @param core Core to target.
+     * @param addr Address to write to.
+     */
+    virtual void dma_write_to_device(
+        const void* src, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) = 0;
+
+    /**
+     * Use PCIe DMA to read device memory (L1 or DRAM).
+     *
+     * @param src Source data address.
+     * @param size Size in bytes.
+     * @param chip Chip to target; must be local, i.e. attached via PCIe.
+     * @param core Core to target.
+     * @param addr Address to read from.
+     */
+    virtual void dma_read_from_device(
+        void* dst, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) = 0;
+
+    /**
      * Write data to specified address and channel on host (defined for Silicon).
      * This API is used to write to the host memory location that is made available to the device through
      * initialization. During the initialization the user should be able to specify how many "channels" are available to
@@ -856,6 +880,9 @@ public:
         const std::string& fallback_tlb = "LARGE_READ_TLB");
     virtual void read_from_device_reg(
         void* mem_ptr, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr, uint32_t size);
+    virtual void dma_write_to_device(
+        const void* src, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr);
+    virtual void dma_read_from_device(void* dst, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr);
     std::optional<std::tuple<uint32_t, uint32_t>> get_tlb_data_from_target(
         const chip_id_t chip, const tt::umd::CoreCoord core);
     tlb_configuration get_tlb_configuration(const chip_id_t chip, const tt::umd::CoreCoord core);

--- a/device/api/umd/device/pci_device.hpp
+++ b/device/api/umd/device/pci_device.hpp
@@ -38,6 +38,15 @@ struct PciDeviceInfo {
 // Do we want to put everything into this file into tt::umd namespace?
 using tt::umd::semver_t;
 
+struct DmaBuffer {
+    uint8_t *buffer{nullptr};
+    uint8_t *completion{nullptr};
+    size_t size{0};
+
+    uint32_t buffer_pa{0};
+    uint32_t completion_pa{0};
+};
+
 class PCIDevice {
     const std::string device_path;   // Path to character device: /dev/tenstorrent/N
     const int pci_device_num;        // N in /dev/tenstorrent/N
@@ -48,6 +57,7 @@ class PCIDevice {
     const tt::ARCH arch;             // e.g. Grayskull, Wormhole, Blackhole
     const semver_t kmd_version;      // KMD version
     const bool iommu_enabled;        // Whether the system is protected from this device by an IOMMU
+    DmaBuffer dma_buffer{};
 
 public:
     /**
@@ -143,6 +153,13 @@ public:
      * @return uint64_t PA (no IOMMU) or IOVA (with IOMMU) for use by the device
      */
     uint64_t map_for_dma(void *buffer, size_t size);
+
+    /**
+     * Access the device's DMA buffer.  This buffer is not guaranteed to exist.
+     * It is the caller's responsibility to check if the buffer is valid and to
+     * chunk the desired transfer size to fit within it.
+     */
+    DmaBuffer &get_dma_buffer() { return dma_buffer; }
 
 public:
     // TODO: we can and should make all of these private.

--- a/device/api/umd/device/pci_device.hpp
+++ b/device/api/umd/device/pci_device.hpp
@@ -39,12 +39,12 @@ struct PciDeviceInfo {
 using tt::umd::semver_t;
 
 struct DmaBuffer {
-    uint8_t *buffer{nullptr};
-    uint8_t *completion{nullptr};
-    size_t size{0};
+    uint8_t *buffer = nullptr;
+    uint8_t *completion = nullptr;
+    size_t size = 0;
 
-    uint32_t buffer_pa{0};
-    uint32_t completion_pa{0};
+    uint32_t buffer_pa = 0;
+    uint32_t completion_pa = 0;
 };
 
 class PCIDevice {

--- a/device/api/umd/device/tt_device/blackhole_tt_device.h
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.h
@@ -31,6 +31,9 @@ public:
 
     BoardType get_board_type() override;
 
+    void dma_d2h(void *dst, uint32_t src, size_t size) override;
+    void dma_h2d(uint32_t dst, const void *src, size_t size) override;
+
 private:
     static constexpr uint64_t ATU_OFFSET_IN_BH_BAR2 = 0x1200;
     std::set<size_t> iatu_regions_;

--- a/device/api/umd/device/tt_device/grayskull_tt_device.h
+++ b/device/api/umd/device/tt_device/grayskull_tt_device.h
@@ -16,5 +16,8 @@ public:
     ChipInfo get_chip_info() override;
 
     BoardType get_board_type() override;
+
+    void dma_d2h(void *dst, uint32_t src, size_t size) override;
+    void dma_h2d(uint32_t dst, const void *src, size_t size) override;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -73,6 +73,26 @@ public:
     void write_regs(uint32_t byte_addr, uint32_t word_len, const void *data);
     void read_regs(uint32_t byte_addr, uint32_t word_len, void *data);
 
+    /**
+     * DMA transfer from device to host.
+     *
+     * @param dst destination buffer
+     * @param src AXI address corresponding to inbound PCIe TLB window; src % 4 == 0
+     * @param size number of bytes
+     * @throws std::runtime_error if the DMA transfer fails
+     */
+    virtual void dma_d2h(void *dst, uint32_t src, size_t size) = 0;
+
+    /**
+     * DMA transfer from host to device.
+     *
+     * @param dst AXI address corresponding to inbound PCIe TLB window; dst % 4 == 0
+     * @param src source buffer
+     * @param size number of bytes
+     * @throws std::runtime_error if the DMA transfer fails
+     */
+    virtual void dma_h2d(uint32_t dst, const void *src, size_t size) = 0;
+
     // Read/write functions that always use same TLB entry. This is not supposed to be used
     // on any code path that is performance critical. It is used to read/write the data needed
     // to get the information to form cluster of chips, or just use base TTDevice functions.

--- a/device/api/umd/device/tt_device/wormhole_tt_device.h
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "umd/device/tt_device/tt_device.h"
 
 namespace tt::umd {
@@ -26,5 +28,13 @@ public:
     BoardType get_board_type() override;
 
     std::vector<DramTrainingStatus> get_dram_training_status() override;
+
+    void dma_d2h(void *dst, uint32_t src, size_t size) override;
+    void dma_h2d(uint32_t dst, const void *src, size_t size) override;
+
+private:
+    // Enforce single-threaded access, even though there are more serious issues
+    // surrounding resource management as it relates to DMA.
+    std::mutex dma_mutex_;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -74,6 +74,14 @@ public:
         uint32_t size,
         const std::string& fallback_tlb);
 
+    void dma_write_to_device(const void* src, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) {
+        throw std::runtime_error("DMA write not supported in simulation mode.");
+    }
+
+    void dma_read_from_device(void* dst, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) {
+        throw std::runtime_error("DMA read not supported in simulation mode.");
+    }
+
     virtual void wait_for_non_mmio_flush();
     virtual void wait_for_non_mmio_flush(const chip_id_t chip);
     void l1_membar(

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -89,6 +89,14 @@ void Chip::read_from_device(
     throw std::runtime_error("Chip::read_from_device is not available for this chip.");
 }
 
+void Chip::dma_write_to_device(const void* src, size_t size, tt_xy_pair core, uint64_t addr) {
+    throw std::runtime_error("Chip::dma_write_to_device is not available for this chip.");
+}
+
+void Chip::dma_read_from_device(void* dst, size_t size, tt_xy_pair core, uint64_t addr) {
+    throw std::runtime_error("Chip::dma_read_from_device is not available for this chip.");
+}
+
 void Chip::write_to_device_reg(
     tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size, const std::string& fallback_tlb) {
     throw std::runtime_error("Chip::write_to_device_reg is not available for this chip.");

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -240,11 +240,49 @@ void LocalChip::read_from_device(
 }
 
 void LocalChip::dma_write_to_device(const void* src, size_t size, tt_xy_pair core, uint64_t addr) {
-    // TODO
+    static const std::string tlb_name = "LARGE_WRITE_TLB";
+    const uint8_t* buffer = static_cast<const uint8_t*>(src);
+    auto tlb_index = tlb_manager_->dynamic_tlb_config_.at(tlb_name);
+    auto ordering = tlb_manager_->dynamic_tlb_ordering_modes_.at(tlb_name);
+    PCIDevice* pci_device = tt_device_->get_pci_device();
+    size_t dmabuf_size = pci_device->get_dma_buffer().size;
+
+    core = translate_chip_coord_virtual_to_translated(core);
+
+    auto lock = acquire_mutex(tlb_name, pci_device->get_device_num());
+    while (size > 0) {
+        auto [axi_address, tlb_size] = tt_device_->set_dynamic_tlb(tlb_index, core, addr, ordering);
+        size_t transfer_size = std::min({size, tlb_size, dmabuf_size});
+
+        tt_device_->dma_h2d(axi_address, buffer, transfer_size);
+
+        size -= transfer_size;
+        addr += transfer_size;
+        buffer += transfer_size;
+    }
 }
 
 void LocalChip::dma_read_from_device(void* dst, size_t size, tt_xy_pair core, uint64_t addr) {
-    // TODO
+    static const std::string tlb_name = "LARGE_READ_TLB";
+    uint8_t* buffer = static_cast<uint8_t*>(dst);
+    auto tlb_index = tlb_manager_->dynamic_tlb_config_.at(tlb_name);
+    auto ordering = tlb_manager_->dynamic_tlb_ordering_modes_.at(tlb_name);
+    PCIDevice* pci_device = tt_device_->get_pci_device();
+    size_t dmabuf_size = pci_device->get_dma_buffer().size;
+
+    core = translate_chip_coord_virtual_to_translated(core);
+
+    auto lock = acquire_mutex(tlb_name, pci_device->get_device_num());
+    while (size > 0) {
+        auto [axi_address, tlb_size] = tt_device_->set_dynamic_tlb(tlb_index, core, addr, ordering);
+        size_t transfer_size = std::min({size, tlb_size, dmabuf_size});
+
+        tt_device_->dma_d2h(buffer, axi_address, transfer_size);
+
+        size -= transfer_size;
+        addr += transfer_size;
+        buffer += transfer_size;
+    }
 }
 
 void LocalChip::write_to_device_reg(

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -239,6 +239,14 @@ void LocalChip::read_from_device(
     }
 }
 
+void LocalChip::dma_write_to_device(const void* src, size_t size, tt_xy_pair core, uint64_t addr) {
+    // TODO
+}
+
+void LocalChip::dma_read_from_device(void* dst, size_t size, tt_xy_pair core, uint64_t addr) {
+    // TODO
+}
+
 void LocalChip::write_to_device_reg(
     tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size, const std::string& fallback_tlb) {
     if (size % sizeof(uint32_t) != 0) {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1628,10 +1628,16 @@ void Cluster::write_to_device(
     write_to_device(mem_ptr, size_in_bytes, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, tlb_to_use);
 }
 
+
 void Cluster::write_to_device_reg(
     const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, CoreCoord core, uint64_t addr) {
     write_to_device(mem_ptr, size_in_bytes, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, "REG_TLB");
 }
+
+void Cluster::dma_write_to_device(
+    const void* src, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) {}
+
+void Cluster::dma_read_from_device(void* dst, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) {}
 
 void Cluster::read_mmio_device_register(
     void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb) {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1628,16 +1628,21 @@ void Cluster::write_to_device(
     write_to_device(mem_ptr, size_in_bytes, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, tlb_to_use);
 }
 
-
 void Cluster::write_to_device_reg(
     const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, CoreCoord core, uint64_t addr) {
     write_to_device(mem_ptr, size_in_bytes, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, "REG_TLB");
 }
 
 void Cluster::dma_write_to_device(
-    const void* src, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) {}
+    const void* src, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) {
+    auto api_coords = translate_to_api_coords(chip, core);
+    get_local_chip(chip)->dma_write_to_device(src, size, api_coords, addr);
+}
 
-void Cluster::dma_read_from_device(void* dst, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) {}
+void Cluster::dma_read_from_device(void* dst, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) {
+    auto api_coords = translate_to_api_coords(chip, core);
+    get_local_chip(chip)->dma_read_from_device(dst, size, api_coords, addr);
+}
 
 void Cluster::read_mmio_device_register(
     void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb) {

--- a/device/mockup/tt_mockup_device.hpp
+++ b/device/mockup/tt_mockup_device.hpp
@@ -73,6 +73,12 @@ public:
         uint32_t size,
         const std::string& fallback_tlb) override {}
 
+    void dma_write_to_device(
+        const void* src, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) override {}
+
+    void dma_read_from_device(void* dst, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) override {
+    }
+
     void write_to_sysmem(
         const void* mem_ptr, std::uint32_t size, uint64_t addr, uint16_t channel, chip_id_t src_device_id) override {}
 

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -176,4 +176,12 @@ BoardType BlackholeTTDevice::get_board_type() {
         (telemetry->read_entry(blackhole::TAG_BOARD_ID_LOW)));
 }
 
+void BlackholeTTDevice::dma_d2h(void *dst, uint32_t src, size_t size) {
+    throw std::runtime_error("D2H DMA is not supported on Blackhole.");
+}
+
+void BlackholeTTDevice::dma_h2d(uint32_t dst, const void *src, size_t size) {
+    throw std::runtime_error("H2D DMA is not supported on Blackhole.");
+}
+
 }  // namespace tt::umd

--- a/device/tt_device/grayskull_tt_device.cpp
+++ b/device/tt_device/grayskull_tt_device.cpp
@@ -20,4 +20,12 @@ BoardType GrayskullTTDevice::get_board_type() {
         "TTDevice is deleted.");
 }
 
+void GrayskullTTDevice::dma_d2h(void *dst, uint32_t src, size_t size) {
+    throw std::runtime_error("D2H DMA is not supported on Grayskull.");
+}
+
+void GrayskullTTDevice::dma_h2d(uint32_t dst, const void *src, size_t size) {
+    throw std::runtime_error("H2D DMA is not supported on Grayskull.");
+}
+
 }  // namespace tt::umd

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -1001,10 +1001,10 @@ TEST(SiliconDriverWH, DMA1) {
 
     cluster.start_device(tt_device_params{});
 
-    size_t dram_count = cluster.get_num_dram_channels(chip);
+    auto& soc_descriptor = cluster.get_soc_descriptor(chip);
+    size_t dram_count = soc_descriptor.get_num_dram_channels();
     std::vector<CoreCoord> dram_cores;
     for (size_t i = 0; i < dram_count; ++i) {
-        auto& soc_descriptor = cluster.get_soc_descriptor(chip);
         dram_cores.push_back(soc_descriptor.get_dram_core_for_channel(i, 0, CoordSystem::NOC0));
     }
 
@@ -1067,10 +1067,10 @@ TEST(SiliconDriverWH, DMA2) {
     set_barrier_params(cluster);
     cluster.start_device(tt_device_params{});
 
-    size_t dram_count = cluster.get_num_dram_channels(chip);
+    auto& soc_descriptor = cluster.get_soc_descriptor(chip);
+    size_t dram_count = soc_descriptor.get_num_dram_channels();
     std::vector<CoreCoord> dram_cores;
     for (size_t i = 0; i < dram_count; ++i) {
-        auto& soc_descriptor = cluster.get_soc_descriptor(chip);
         dram_cores.push_back(soc_descriptor.get_dram_core_for_channel(i, 0, CoordSystem::NOC0));
     }
 

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -1100,7 +1100,6 @@ TEST(SiliconDriverWH, DMA2) {
 
         // First, write a different random pattern to a random address on each DRAM core.
         for (const auto& core : dram_cores) {
-
             // Generate random size and address.
             size_t size = size_dist(rng) & ~0x3ULL;
             uint64_t addr = addr_dist(rng) & ~0x3ULL;
@@ -1146,7 +1145,6 @@ TEST(SiliconDriverWH, DMA2) {
 
         // First, write a different random pattern to a random address on each DRAM core.
         for (const auto& dram_core : dram_cores) {
-
             // Generate random size and address.
             size_t size = size_dist(rng) & ~0x3ULL;
             uint64_t addr = addr_dist(rng) & ~0x3ULL;


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/85

### Description
Introduces APIs and an initial implementation for PCIe DMA transfers targeting Wormhole devices.  This aims to provide applications with a high-throughput mechanism for reading chip memory, addressing the performance limitations of MMIO reads (observed in the 3-4 MiB/s range).

The implementation uses polling via a completion flag in host memory, as driver-level interrupt support is not yet available.  It relies on an intermediate DMA buffer allocated by the driver.

### List of the changes
* Add PCIe DMA methods to `Cluster`, `Chip`, and `TTDevice` interfaces.
* Implement low-level DMA register programming and polling logic in `WormholeTTDevice`.
* Implement DMA transfer coordination (TLB management, chunking) in `LocalChip`.
* Add DMA buffer allocation and management to `PCIDevice`.
* Add simulation and mockup stubs for DMA methods.
* Add placeholder implementations for Grayskull and Blackhole `TTDevice` classes.
* Add unit tests for Wormhole DMA functionality.

### Testing
* Added unit tests covering fixed-size and randomized DMA transfers.
* Verified functionality manually on my WH dev systems.

### API Changes
Adds new public API methods for DMA transfers (`dma_write_to_device`, `dma_read_from_device` in the `Cluster` interface).  This is a non-breaking change; existing APIs are unaffected.