### PR TITLE
Implement PCIE harvesting

### DIFF
--- a/device/api/umd/device/blackhole_coordinate_manager.h
+++ b/device/api/umd/device/blackhole_coordinate_manager.h
@@ -35,6 +35,7 @@ protected:
     void translate_tensix_coords() override;
     void translate_dram_coords() override;
     void translate_eth_coords() override;
+    void translate_pcie_coords() override;
 
     void fill_tensix_physical_translated_mapping() override;
     void fill_dram_physical_translated_mapping() override;
@@ -48,6 +49,8 @@ protected:
     std::vector<tt::umd::CoreCoord> get_harvested_dram_cores() const override;
     std::vector<tt::umd::CoreCoord> get_eth_cores() const override;
     std::vector<tt::umd::CoreCoord> get_harvested_eth_cores() const override;
+    std::vector<tt::umd::CoreCoord> get_pcie_cores() const override;
+    std::vector<tt::umd::CoreCoord> get_harvested_pcie_cores() const override;
     tt_xy_pair get_tensix_grid_size() const override;
     tt_xy_pair get_dram_grid_size() const override;
     tt_xy_pair get_harvested_tensix_grid_size() const override;

--- a/device/api/umd/device/blackhole_implementation.h
+++ b/device/api/umd/device/blackhole_implementation.h
@@ -104,7 +104,7 @@ static const tt_xy_pair ARC_GRID_SIZE = {1, 1};
 static const std::vector<tt_xy_pair> ARC_CORES_NOC0 = {{8, 0}};
 static const std::vector<tt_xy_pair> ARC_LOCATIONS = ARC_CORES_NOC0;
 
-static const tt_xy_pair PCIE_GRID_SIZE = {1, 1};
+static const tt_xy_pair PCIE_GRID_SIZE = {2, 1};
 static const std::vector<tt_xy_pair> PCIE_CORES_TYPE2_NOC0 = {{{2, 0}}};
 static const std::vector<tt_xy_pair> PCI_LOCATIONS = PCIE_CORES_TYPE2_NOC0;
 static const std::vector<tt_xy_pair> PCIE_CORES_TYPE1_NOC0 = {{{11, 0}}};
@@ -275,13 +275,6 @@ static const size_t pcie_translated_coordinate_start_y = 24;
 
 static const size_t dram_translated_coordinate_start_x = 17;
 static const size_t dram_translated_coordinate_start_y = 12;
-
-/*
- * Ge the PCIE core that can be used for communication with host
- * based on the board type and asic location of the chip.
- * Information on remote chip is used only if the board type is P300.
- */
-std::vector<tt_xy_pair> get_pcie_cores(const BoardType board_type, const uint8_t asic_location);
 
 }  // namespace blackhole
 

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -999,6 +999,11 @@ private:
         tt_ClusterDescriptor* cluster_desc,
         bool perform_harvesting,
         std::unordered_map<chip_id_t, HarvestingMasks>& simulated_harvesting_masks);
+    uint32_t get_pcie_harvesting_mask(
+        chip_id_t chip_id,
+        tt_ClusterDescriptor* cluster_desc,
+        bool perform_harvesting,
+        std::unordered_map<chip_id_t, HarvestingMasks>& simulated_harvesting_masks);
     void construct_cluster(const uint32_t& num_host_mem_ch_per_mmio_device, const bool create_mock_chips);
     tt_xy_pair translate_to_api_coords(const chip_id_t chip, const tt::umd::CoreCoord core_coord) const;
     // Most of the old APIs accept virtual coordinates, but we communicate with the device through translated

--- a/device/api/umd/device/coordinate_manager.h
+++ b/device/api/umd/device/coordinate_manager.h
@@ -133,6 +133,8 @@ protected:
     virtual std::vector<tt::umd::CoreCoord> get_harvested_dram_cores() const;
     virtual std::vector<tt::umd::CoreCoord> get_eth_cores() const;
     virtual std::vector<tt::umd::CoreCoord> get_harvested_eth_cores() const;
+    virtual std::vector<tt::umd::CoreCoord> get_pcie_cores() const;
+    virtual std::vector<tt::umd::CoreCoord> get_harvested_pcie_cores() const;
     virtual tt_xy_pair get_tensix_grid_size() const;
     virtual tt_xy_pair get_dram_grid_size() const;
     virtual tt_xy_pair get_harvested_tensix_grid_size() const;

--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -82,6 +82,7 @@ protected:
 
     std::map<chip_id_t, uint32_t> dram_harvesting_masks = {};
     std::map<chip_id_t, uint32_t> eth_harvesting_masks = {};
+    std::map<chip_id_t, uint32_t> pcie_harvesting_masks = {};
 
 public:
     /*
@@ -144,4 +145,5 @@ public:
 
     uint32_t get_dram_harvesting_mask(chip_id_t chip_id) const;
     uint32_t get_eth_harvesting_mask(chip_id_t chip_id) const;
+    uint32_t get_pcie_harvesting_mask(chip_id_t chip_id) const;
 };

--- a/device/api/umd/device/types/harvesting.h
+++ b/device/api/umd/device/types/harvesting.h
@@ -14,6 +14,7 @@ struct HarvestingMasks {
     size_t tensix_harvesting_mask = 0;
     size_t dram_harvesting_mask = 0;
     size_t eth_harvesting_mask = 0;
+    size_t pcie_harvesting_mask = 0;
 };
 
 }  // namespace tt::umd

--- a/device/blackhole/blackhole_implementation.cpp
+++ b/device/blackhole/blackhole_implementation.cpp
@@ -115,15 +115,4 @@ uint64_t blackhole_implementation::get_noc_reg_base(
     throw std::runtime_error("Invalid core type or NOC for getting NOC register addr base.");
 }
 
-namespace blackhole {
-std::vector<tt_xy_pair> get_pcie_cores(const BoardType board_type, const uint8_t asic_location) {
-    // Default to type 1 chip.
-    if (board_type == BoardType::UNKNOWN) {
-        return PCIE_CORES_TYPE1_NOC0;
-    }
-    auto chip_type = get_blackhole_chip_type(board_type, asic_location);
-    return chip_type == BlackholeChipType::Type1 ? PCIE_CORES_TYPE1_NOC0 : PCIE_CORES_TYPE2_NOC0;
-}
-}  // namespace blackhole
-
 }  // namespace tt::umd

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -805,6 +805,18 @@ void tt_ClusterDescriptor::load_harvesting_information(YAML::Node &yaml, tt_Clus
             auto harvesting_info = chip_node.second;
             desc.noc_translation_enabled.insert({chip, harvesting_info["noc_translation"].as<bool>()});
             desc.harvesting_masks.insert({chip, harvesting_info["harvest_mask"].as<std::uint32_t>()});
+
+            if (harvesting_info["dram_harvesting_mask"].IsDefined()) {
+                desc.dram_harvesting_masks.insert({chip, harvesting_info["dram_harvesting_mask"].as<std::uint32_t>()});
+            }
+
+            if (harvesting_info["eth_harvesting_mask"].IsDefined()) {
+                desc.eth_harvesting_masks.insert({chip, harvesting_info["eth_harvesting_mask"].as<std::uint32_t>()});
+            }
+
+            if (harvesting_info["pcie_harvesting_mask"].IsDefined()) {
+                desc.pcie_harvesting_masks.insert({chip, harvesting_info["pcie_harvesting_mask"].as<std::uint32_t>()});
+            }
         }
     }
 }
@@ -1008,6 +1020,9 @@ std::string tt_ClusterDescriptor::serialize() const {
         out << YAML::Key << chip << YAML::Value << YAML::BeginMap;
         out << YAML::Key << "noc_translation" << YAML::Value << noc_translation_enabled.at(chip);
         out << YAML::Key << "harvest_mask" << YAML::Value << harvesting_masks.at(chip);
+        out << YAML::Key << "dram_harvesting_mask" << YAML::Value << get_dram_harvesting_mask(chip);
+        out << YAML::Key << "eth_harvesting_mask" << YAML::Value << get_eth_harvesting_mask(chip);
+        out << YAML::Key << "pcie_harvesting_mask" << YAML::Value << get_pcie_harvesting_mask(chip);
         out << YAML::EndMap;
     }
     out << YAML::EndMap;
@@ -1069,6 +1084,15 @@ uint32_t tt_ClusterDescriptor::get_dram_harvesting_mask(chip_id_t chip_id) const
 uint32_t tt_ClusterDescriptor::get_eth_harvesting_mask(chip_id_t chip_id) const {
     auto it = eth_harvesting_masks.find(chip_id);
     if (it == eth_harvesting_masks.end()) {
+        return 0;
+    }
+
+    return it->second;
+}
+
+uint32_t tt_ClusterDescriptor::get_pcie_harvesting_mask(chip_id_t chip_id) const {
+    auto it = pcie_harvesting_masks.find(chip_id);
+    if (it == pcie_harvesting_masks.end()) {
         return 0;
     }
 

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -93,6 +93,21 @@ ChipInfo BlackholeTTDevice::get_chip_info() {
                                                          ? (~telemetry->read_entry(blackhole::TAG_ENABLED_ETH) & 0x3FFF)
                                                          : 0;
 
+    uint32_t pcie_usage = telemetry->read_entry(blackhole::TAG_PCIE_USAGE);
+
+    uint32_t pcie0_usage = pcie_usage & 0x3;
+    uint32_t pcie1_usage = (pcie_usage >> 2) & 0x3;
+
+    const uint32_t pcie_usage_endpoint = 1;
+    chip_info.harvesting_masks.pcie_harvesting_mask = 0;
+    if (pcie0_usage != pcie_usage_endpoint) {
+        chip_info.harvesting_masks.pcie_harvesting_mask |= 0x1;
+    }
+
+    if (pcie1_usage != pcie_usage_endpoint) {
+        chip_info.harvesting_masks.pcie_harvesting_mask |= (1 << 1);
+    }
+
     // TODO: Read asic location of the chip from telemetry when it is available.
     // Until then we have to read it from ETH core, it happens during topology exploration.
     // chip_info.chip_uid.asic_location = telemetry->read_entry(blackhole::TAG_ASIC_LOCATION);

--- a/tests/api/test_core_coord_translation_bh.cpp
+++ b/tests/api/test_core_coord_translation_bh.cpp
@@ -549,11 +549,11 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMPMoreThanOneDRAMBankHarves
 // Test that virtual, physical and translated coordinates are the same for all logical PCIE coordinates.
 TEST(CoordinateManager, CoordinateManagerBlackholePCIETranslationLocal) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, {0, 0, 0}, BoardType::P300, false);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, {0, 0, 0, 0x1}, BoardType::P300, false);
     const tt_xy_pair pcie_grid_size = tt::umd::blackhole::PCIE_GRID_SIZE;
-    const std::vector<tt_xy_pair> pcie_cores = tt::umd::blackhole::PCIE_CORES_TYPE2_NOC0;
+    const std::vector<tt_xy_pair> pcie_cores = tt::umd::blackhole::PCIE_CORES_NOC0;
 
-    for (size_t x = 0; x < pcie_grid_size.x; x++) {
+    for (size_t x = 0; x < pcie_grid_size.x - 1; x++) {
         for (size_t y = 0; y < pcie_grid_size.y; y++) {
             const CoreCoord pcie_logical = CoreCoord(x, y, CoreType::PCIE, CoordSystem::LOGICAL);
             const CoreCoord pcie_virtual = coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::VIRTUAL);
@@ -572,11 +572,11 @@ TEST(CoordinateManager, CoordinateManagerBlackholePCIETranslationLocal) {
 // Test that virtual, physical and translated coordinates are the same for all logical PCIE coordinates.
 TEST(CoordinateManager, CoordinateManagerBlackholePCIETranslationRemote) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true);
+        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, {0, 0, 0, 0x1}, BoardType::P300, false);
     const tt_xy_pair pcie_grid_size = tt::umd::blackhole::PCIE_GRID_SIZE;
-    const std::vector<tt_xy_pair> pcie_cores = tt::umd::blackhole::PCIE_CORES_TYPE1_NOC0;
+    const std::vector<tt_xy_pair> pcie_cores = tt::umd::blackhole::PCIE_CORES_NOC0;
 
-    for (size_t x = 0; x < pcie_grid_size.x; x++) {
+    for (size_t x = 0; x < pcie_grid_size.x - 1; x++) {
         for (size_t y = 0; y < pcie_grid_size.y; y++) {
             const CoreCoord pcie_logical = CoreCoord(x, y, CoreType::PCIE, CoordSystem::LOGICAL);
             const CoreCoord pcie_virtual = coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::VIRTUAL);
@@ -814,7 +814,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeNoc1Noc0Mapping) {
         flatten_vector(tt::umd::blackhole::DRAM_CORES_NOC0), flatten_vector(DRAM_CORES_NOC1), CoreType::DRAM);
     check_noc0_noc1_mapping(tt::umd::blackhole::ETH_CORES_NOC0, ETH_CORES_NOC1, CoreType::ETH);
     check_noc0_noc1_mapping(tt::umd::blackhole::ARC_CORES_NOC0, ARC_CORES_NOC1, CoreType::ARC);
-    check_noc0_noc1_mapping({tt::umd::blackhole::PCIE_CORES_NOC0[1]}, {PCIE_CORES_NOC1[1]}, CoreType::PCIE);
+    check_noc0_noc1_mapping(tt::umd::blackhole::PCIE_CORES_NOC0, PCIE_CORES_NOC1, CoreType::PCIE);
 }
 
 TEST(CoordinateManager, CoordinateManagerBlackholeSecurityTranslation) {

--- a/tests/api/test_noc.cpp
+++ b/tests/api/test_noc.cpp
@@ -61,6 +61,7 @@ TEST(TestNoc, TestNoc0NodeId) {
         check_noc_id_cores(cluster, chip, CoreType::ARC);
 
         check_noc_id_cores(cluster, chip, CoreType::PCIE);
+        check_noc_id_harvested_cores(cluster, chip, CoreType::PCIE);
 
         check_noc_id_cores(cluster, chip, CoreType::SECURITY);
 
@@ -122,6 +123,7 @@ TEST(TestNoc, TestNoc1NodeId) {
         check_noc_id_cores(cluster, chip, CoreType::ARC);
 
         check_noc_id_cores(cluster, chip, CoreType::PCIE);
+        check_noc_id_harvested_cores(cluster, chip, CoreType::PCIE);
 
         check_noc_id_cores(cluster, chip, CoreType::SECURITY);
 

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -415,31 +415,56 @@ TEST(SocDescriptor, NocTranslation) {
 TEST(SocDescriptor, BoardBasedPCIE) {
     // Expect invalid configuration to throw an exception.
     EXPECT_ANY_THROW(tt_SocDescriptor soc_desc(
-        test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"), true, {0, 0, 0}, BoardType::P100, true));
+        test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"), true, {0, 0, 0, 0x2}, BoardType::P100));
     EXPECT_ANY_THROW(tt_SocDescriptor soc_desc(
-        test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"), true, {0, 0, 0}, BoardType::P150, true));
+        test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"), true, {0, 0, 0, 0x1}, BoardType::P150));
     EXPECT_ANY_THROW(tt_SocDescriptor soc_desc(
-        test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"), true, {0, 0, 0}, BoardType::N300, false));
+        test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"), true, {0, 0, 0, 0}, BoardType::P300, 0));
+    EXPECT_ANY_THROW(tt_SocDescriptor soc_desc(
+        test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"), true, {0, 0, 0, 0}, BoardType::P300, 1));
 
-    // Verify expected PCI cores.
-    std::map<std::pair<BoardType, bool>, uint32_t> board_configuration_to_pcie_x_location = {
-        {{BoardType::P100, false}, 11},
-        {{BoardType::P150, false}, 2},
-        {{BoardType::P300, true}, 11},
-        {{BoardType::P300, false}, 2},
-    };
+    {
+        tt_SocDescriptor soc_desc(
+            test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"), true, {0, 0, 0, 0x1}, BoardType::P100);
+        EXPECT_EQ(soc_desc.get_cores(CoreType::PCIE).size(), 1);
+        EXPECT_EQ(soc_desc.get_cores(CoreType::PCIE)[0].x, 11);
+        EXPECT_EQ(soc_desc.get_harvested_cores(CoreType::PCIE).size(), 1);
+        EXPECT_EQ(soc_desc.get_harvested_cores(CoreType::PCIE)[0].x, 2);
+    }
 
-    for (const auto& [board_configuration, expected_pcie_x_location] : board_configuration_to_pcie_x_location) {
+    {
+        tt_SocDescriptor soc_desc(
+            test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"), true, {0, 0, 0, 0x2}, BoardType::P150);
+        EXPECT_EQ(soc_desc.get_cores(CoreType::PCIE).size(), 1);
+        EXPECT_EQ(soc_desc.get_cores(CoreType::PCIE)[0].x, 2);
+        EXPECT_EQ(soc_desc.get_harvested_cores(CoreType::PCIE).size(), 1);
+        EXPECT_EQ(soc_desc.get_harvested_cores(CoreType::PCIE)[0].x, 11);
+    }
+
+    {
         tt_SocDescriptor soc_desc(
             test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"),
             true,
-            {0, 0, 0},
-            board_configuration.first,
-            board_configuration.second);
+            {0, 0, 0, 0x2},
+            BoardType::P300,
+            0);
+        EXPECT_EQ(soc_desc.get_cores(CoreType::PCIE).size(), 1);
+        EXPECT_EQ(soc_desc.get_cores(CoreType::PCIE)[0].x, 2);
+        EXPECT_EQ(soc_desc.get_harvested_cores(CoreType::PCIE).size(), 1);
+        EXPECT_EQ(soc_desc.get_harvested_cores(CoreType::PCIE)[0].x, 11);
+    }
 
-        const std::vector<CoreCoord> pcie_cores = soc_desc.get_cores(CoreType::PCIE);
-        ASSERT_EQ(pcie_cores.size(), 1);
-        EXPECT_EQ(pcie_cores[0].x, expected_pcie_x_location);
+    {
+        tt_SocDescriptor soc_desc(
+            test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"),
+            true,
+            {0, 0, 0, 0x1},
+            BoardType::P300,
+            1);
+        EXPECT_EQ(soc_desc.get_cores(CoreType::PCIE).size(), 1);
+        EXPECT_EQ(soc_desc.get_cores(CoreType::PCIE)[0].x, 11);
+        EXPECT_EQ(soc_desc.get_harvested_cores(CoreType::PCIE).size(), 1);
+        EXPECT_EQ(soc_desc.get_harvested_cores(CoreType::PCIE)[0].x, 2);
     }
 
     // If board type is not provided, just pass through what was described by the soc descriptor.

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -937,3 +937,19 @@ TEST(ClusterBH, TotalNumberOfEthCores) {
 
     EXPECT_EQ(num_eth_cores, num_active_channels + num_idle_channels);
 }
+
+TEST(ClusterBH, PCIECores) {
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+
+    for (chip_id_t chip : cluster->get_target_device_ids()) {
+        const auto& pcie_cores = cluster->get_soc_descriptor(chip).get_cores(CoreType::PCIE);
+
+        EXPECT_EQ(pcie_cores.size(), 1);
+
+        const auto& harvested_pcie_cores = cluster->get_soc_descriptor(chip).get_harvested_cores(CoreType::PCIE);
+
+        EXPECT_EQ(harvested_pcie_cores.size(), 1);
+
+        EXPECT_NE(pcie_cores.at(0).x, harvested_pcie_cores.at(0).x);
+    }
+}


### PR DESCRIPTION
### Issue

#700 

### Description

Implement PCIE harvesting in general. This is needed for Blackhole, but so far we have managed this based on the board type. This PR introduces relying on information from the device on PCIE port config. Even if this information should be 1-1 with board type, it is more reliable to trust the device configuration. 

### List of the changes

- Add pcie harvesting mask
- Add pcie harvesting in coordinate manager
- Remove fuzzy logic based on board type for blackhole
- Update tests
- Fix some tests to pass proper PCIE harvesting mask to structures

### Testing
CI

### API Changes
/