### PR TITLE
Use bar_read32 and bar_write32 from TTDevice

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -630,23 +630,6 @@ public:
         const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels);
 
     /**
-     * Write data to specified address on the BAR space of the device.
-     *
-     * @param logical_device_id Device to target.
-     * @param addr Address to write to.
-     * @param data Data to write.
-     */
-    void bar_write32(int logical_device_id, uint32_t addr, uint32_t data);
-
-    /**
-     * Read data from specified address on the BAR space of the device.
-     *
-     * @param logical_device_id Device to target.
-     * @param addr Address to read from.
-     */
-    uint32_t bar_read32(int logical_device_id, uint32_t addr);
-
-    /**
      * This API allows you to write directly to device memory that is addressable by a static TLB.
      */
     std::function<void(uint32_t, uint32_t, const uint8_t*)> get_fast_pcie_static_tlb_write_callable(int device_id);

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -598,7 +598,7 @@ void Cluster::check_pcie_device_initialized(int device_id) {
     if (arch_name != tt::ARCH::BLACKHOLE) {
         log_debug(LogSiliconDriver, "== Check if device_id: {} is initialized", device_id);
         uint32_t bar_read_initial =
-            bar_read32(device_id, architecture_implementation->get_arc_reset_scratch_offset() + 3 * 4);
+            tt_device->bar_read32(architecture_implementation->get_arc_reset_scratch_offset() + 3 * 4);
         uint32_t arg = bar_read_initial == 500 ? 325 : 500;
         uint32_t bar_read_again;
         uint32_t arc_msg_return = arc_msg(
@@ -610,7 +610,7 @@ void Cluster::check_pcie_device_initialized(int device_id) {
             1000,
             &bar_read_again);
         if (arc_msg_return != 0 || bar_read_again != arg + 1) {
-            auto postcode = bar_read32(device_id, architecture_implementation->get_arc_reset_scratch_offset());
+            auto postcode = tt_device->bar_read32(architecture_implementation->get_arc_reset_scratch_offset());
             throw std::runtime_error(fmt::format(
                 "Device is not initialized: arc_fw postcode: {} arc_msg_return: {} arg: {} bar_read_initial: {} "
                 "bar_read_again: {}",
@@ -954,29 +954,6 @@ int Cluster::test_setup_interface() {
     }
 }
 
-void Cluster::bar_write32(int logical_device_id, uint32_t addr, uint32_t data) {
-    TTDevice* dev = get_tt_device(logical_device_id);
-
-    if (addr < dev->get_pci_device()->bar0_uc_offset) {
-        dev->write_block(
-            addr, sizeof(data), reinterpret_cast<const uint8_t*>(&data));  // do we have to reinterpret_cast?
-    } else {
-        dev->write_regs(addr, 1, &data);
-    }
-}
-
-uint32_t Cluster::bar_read32(int logical_device_id, uint32_t addr) {
-    TTDevice* dev = get_tt_device(logical_device_id);
-
-    uint32_t data;
-    if (addr < dev->get_pci_device()->bar0_uc_offset) {
-        dev->read_block(addr, sizeof(data), reinterpret_cast<uint8_t*>(&data));
-    } else {
-        dev->read_regs(addr, 1, &data);
-    }
-    return data;
-}
-
 // Returns 0 if everything was OK
 int Cluster::pcie_arc_msg(
     int logical_device_id,
@@ -1035,10 +1012,10 @@ int Cluster::iatu_configure_peer_region(
     PCIDevice* pci_device = tt_device->get_pci_device();
     auto architecture_implementation = tt_device->get_architecture_implementation();
 
-    bar_write32(logical_device_id, architecture_implementation->get_arc_csm_mailbox_offset() + 0 * 4, region_id_to_use);
-    bar_write32(logical_device_id, architecture_implementation->get_arc_csm_mailbox_offset() + 1 * 4, dest_bar_lo);
-    bar_write32(logical_device_id, architecture_implementation->get_arc_csm_mailbox_offset() + 2 * 4, dest_bar_hi);
-    bar_write32(logical_device_id, architecture_implementation->get_arc_csm_mailbox_offset() + 3 * 4, region_size);
+    tt_device->bar_write32(architecture_implementation->get_arc_csm_mailbox_offset() + 0 * 4, region_id_to_use);
+    tt_device->bar_write32(architecture_implementation->get_arc_csm_mailbox_offset() + 1 * 4, dest_bar_lo);
+    tt_device->bar_write32(architecture_implementation->get_arc_csm_mailbox_offset() + 2 * 4, dest_bar_hi);
+    tt_device->bar_write32(architecture_implementation->get_arc_csm_mailbox_offset() + 3 * 4, region_size);
     arc_msg(
         logical_device_id,
         0xaa00 | architecture_implementation->get_arc_message_setup_iatu_for_peer_to_peer(),

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -957,7 +957,7 @@ TEST(SiliconDriverWH, LargeAddressTlb) {
     uint32_t value2 = 0;
 
     // Read the scratch register via BAR0:
-    value0 = cluster.get_local_chip(0)->get_tt_device()->bar_read32(0x1ff30060);
+    value0 = cluster.get_chip(0)->get_tt_device()->bar_read32(0x1ff30060);
 
     // Read the scratch register via the TLB:
     cluster.read_from_device(&value1, ARC_CORE_CHIP, addr, sizeof(uint32_t), "LARGE_READ_TLB");

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -957,7 +957,7 @@ TEST(SiliconDriverWH, LargeAddressTlb) {
     uint32_t value2 = 0;
 
     // Read the scratch register via BAR0:
-    value0 = cluster.bar_read32(0, 0x1ff30060);
+    value0 = cluster.get_local_chip(0)->get_tt_device()->bar_read32(0x1ff30060);
 
     // Read the scratch register via the TLB:
     cluster.read_from_device(&value1, ARC_CORE_CHIP, addr, sizeof(uint32_t), "LARGE_READ_TLB");


### PR DESCRIPTION
### Issue
Part of https://github.com/tenstorrent/tt-umd/issues/142

### Description
Remove the bar_ functions from Cluster. They have the same implementation in tt_device already.

### List of the changes
- Remove bar_read32 and bar_write32
- Switch to tt_device implementation

### Testing
Existing CI tests pass

### API Changes
There are no API changes in this PR.
