### PR TITLE
Remove cores structs from Cluster

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -902,7 +902,6 @@ private:
     void broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOptions& soft_resets);
     void send_remote_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);
     void send_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);
-    void populate_cores();
     void init_pcie_iatus();  // No more p2p support.
     void check_pcie_device_initialized(int device_id);
     void set_pcie_power_state(tt_DevicePowerState state);
@@ -951,13 +950,13 @@ private:
         bool use_virtual_coords);
     void set_membar_flag(
         const chip_id_t chip,
-        const std::unordered_set<tt_xy_pair>& cores,
+        const std::vector<CoreCoord>& cores,
         const uint32_t barrier_value,
         const uint32_t barrier_addr,
         const std::string& fallback_tlb);
     void insert_host_to_device_barrier(
         const chip_id_t chip,
-        const std::unordered_set<tt_xy_pair>& cores,
+        const std::vector<CoreCoord>& cores,
         const uint32_t barrier_addr,
         const std::string& fallback_tlb);
     void init_membars();
@@ -1057,10 +1056,6 @@ private:
     tt::ARCH arch_name;
 
     std::shared_ptr<tt_ClusterDescriptor> cluster_desc;
-
-    std::unordered_map<chip_id_t, std::unordered_set<tt_xy_pair>> workers_per_chip = {};
-    std::unordered_set<tt_xy_pair> eth_cores = {};
-    std::unordered_set<tt_xy_pair> dram_cores = {};
 
     std::map<std::set<chip_id_t>, std::unordered_map<chip_id_t, std::vector<std::vector<int>>>> bcast_header_cache = {};
     bool perform_harvesting_on_sdesc = false;


### PR DESCRIPTION
### Issue
Part of #248 

### Description
These structures are a surplus in cluster.h, they shouldn't exist

### List of the changes
- Deleted eth_cores, dram_cores, worker_cores. Removed populate_cores which filled them
- Changed all usages of said cores to different forms of soc_desc.get_cores()
- Changed set_membar and insert_host_to_device_barrier to accept vector instead of set, to better conform with get_cores().
- Changed set_membar and insert_host_to_device_barrier to accept CoreCoords instead of xy_pair
- Changed the code throughout these functions to allow for the changes mentioned.

### Testing
Existing CI tests

### API Changes
There are no API changes in this PR.
