### PR TITLE
Offer membars without fallback_tlbs in API

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -380,6 +380,18 @@ public:
     }
 
     /**
+     * Tensix L1 memory barrier.
+     * This should be called when the client wants to ensure that all transactions on the L1 of the specified cores have
+     * completed.
+     *
+     * @param chip Chip to target.
+     * @param cores Cores being targeted.
+     */
+    virtual void l1_membar(const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores = {}) {
+        throw std::runtime_error("---- tt_device::l1_membar is not implemented\n");
+    }
+
+    /**
      * DRAM memory barrier.
      * This should be called when the client wants to ensure that all transactions on the specified dram bank have
      * completed.
@@ -398,6 +410,18 @@ public:
      * This should be called when the client wants to ensure that all transactions on the specified dram bank have
      * completed.
      *
+     * @param chip Chip to target.
+     * @param channels Channels being targeted.
+     */
+    virtual void dram_membar(const chip_id_t chip, const std::unordered_set<uint32_t>& channels = {}) {
+        throw std::runtime_error("---- tt_device::dram_membar is not implemented\n");
+    }
+
+    /**
+     * DRAM memory barrier.
+     * This should be called when the client wants to ensure that all transactions on the specified dram bank have
+     * completed.
+     *
      * @param chip Chip being targeted.
      * @param flackback_tlb Specifies fallback/dynamic TLB to use.
      * @param cores Cores being targeted.
@@ -406,6 +430,18 @@ public:
         const chip_id_t chip,
         const std::string& fallback_tlb,
         const std::unordered_set<tt::umd::CoreCoord>& cores = {}) {
+        throw std::runtime_error("---- tt_device::dram_membar is not implemented\n");
+    }
+
+    /**
+     * DRAM memory barrier.
+     * This should be called when the client wants to ensure that all transactions on the specified dram bank have
+     * completed.
+     *
+     * @param chip Chip being targeted.
+     * @param cores Cores being targeted.
+     */
+    virtual void dram_membar(const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores = {}) {
         throw std::runtime_error("---- tt_device::dram_membar is not implemented\n");
     }
 
@@ -665,8 +701,6 @@ public:
         void* mem_ptr, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id);
     virtual void wait_for_non_mmio_flush();
     virtual void wait_for_non_mmio_flush(const chip_id_t chip_id);
-    void dram_membar(
-        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels);
 
     /**
      * Write data to specified address on the BAR space of the device.
@@ -878,8 +912,13 @@ public:
         chip_id_t mmio_chip, const std::unordered_set<CoreCoord>& active_eth_cores_per_chip);
     void l1_membar(
         const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<CoreCoord>& cores = {});
+    void l1_membar(const chip_id_t chip, const std::unordered_set<CoreCoord>& cores = {});
     void dram_membar(
         const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<CoreCoord>& cores = {});
+    void dram_membar(const chip_id_t chip, const std::unordered_set<CoreCoord>& cores = {});
+    void dram_membar(
+        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels);
+    void dram_membar(const chip_id_t chip, const std::unordered_set<uint32_t>& channels);
     void set_power_state(tt_DevicePowerState state);
 
     static std::unique_ptr<tt_ClusterDescriptor> create_cluster_descriptor(std::string sdesc_path = "");

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1985,6 +1985,10 @@ void Cluster::l1_membar(
     }
 }
 
+void Cluster::l1_membar(const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores) {
+    l1_membar(chip, "LARGE_WRITE_TLB", cores);
+}
+
 void Cluster::dram_membar(
     const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt::umd::CoreCoord>& cores) {
     std::unordered_set<tt_xy_pair> cores_xy;
@@ -2008,6 +2012,10 @@ void Cluster::dram_membar(
     }
 }
 
+void Cluster::dram_membar(const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores) {
+    dram_membar(chip, "LARGE_WRITE_TLB", cores);
+}
+
 void Cluster::dram_membar(
     const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels) {
     if (cluster_desc->is_chip_mmio_capable(chip)) {
@@ -2029,6 +2037,10 @@ void Cluster::dram_membar(
     } else {
         wait_for_non_mmio_flush();
     }
+}
+
+void Cluster::dram_membar(const chip_id_t chip, const std::unordered_set<uint32_t>& channels) {
+    dram_membar(chip, "LARGE_WRITE_TLB", channels);
 }
 
 void Cluster::write_to_device(


### PR DESCRIPTION
### Issue
On a path of #737 

### Description
With these changes we can now offer whole api free of fallback_tlbs to tt_metal, and when it changes to the new API we can remove fallback_tlb on our end.

### List of the changes
- l1_membar and dram_membar versions without fallback_tlb

### Testing
No testing

### API Changes
There are API changes in this PR, to be switched to in the clients
