### PR TITLE
Remove unused Cluster functions

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -684,16 +684,6 @@ public:
     virtual tt_ClusterDescriptor* get_cluster_description();
 
     /**
-     * Get number of MMIO chips detected on the system.
-     */
-    static int detect_number_of_chips();
-
-    /**
-     * Get vector of available MMIO device ids on the system.
-     */
-    static std::vector<chip_id_t> detect_available_device_ids();
-
-    /**
      * Get set of chip ids for all chips in the cluster.
      */
     virtual std::set<chip_id_t> get_target_device_ids();
@@ -893,7 +883,6 @@ private:
     void deassert_resets_and_set_power_state();
     int iatu_configure_peer_region(
         int logical_device_id, uint32_t peer_region_id, uint64_t bar_addr_64, uint32_t region_size);
-    uint32_t get_harvested_noc_rows(uint32_t harvesting_mask);
     int get_clock(int logical_device_id);
     void wait_for_aiclk_value(tt_DevicePowerState power_state, const uint32_t timeout_ms = 5000);
 
@@ -1025,7 +1014,6 @@ private:
         std::unique_ptr<tt_ClusterDescriptor>& cluster_desc);
 
     // State variables
-    std::vector<tt::ARCH> archs_in_cluster = {};
     std::set<chip_id_t> all_chip_ids_ = {};
     std::set<chip_id_t> remote_chip_ids_ = {};
     std::set<chip_id_t> local_chip_ids_ = {};
@@ -1039,8 +1027,6 @@ private:
     std::unordered_set<tt_xy_pair> dram_cores = {};
 
     std::map<std::set<chip_id_t>, std::unordered_map<chip_id_t, std::vector<std::vector<int>>>> bcast_header_cache = {};
-    bool perform_harvesting_on_sdesc = false;
-    bool use_ethernet_ordered_writes = true;
     bool use_ethernet_broadcast = true;
     bool use_virtual_coords_for_eth_broadcast = true;
     tt_version eth_fw_version;  // Ethernet FW the driver is interfacing with

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -487,25 +487,6 @@ public:
     }
 
     /**
-     * Query number of DRAM channels on a specific device.
-     *
-     * @param device_id Logical device id to query.
-     */
-    virtual std::uint32_t get_num_dram_channels(std::uint32_t device_id) {
-        throw std::runtime_error("---- tt_device::get_num_dram_channels is not implemented\n");
-    }
-
-    /**
-     * Get size for a specific DRAM channel on a device.
-     *
-     * @param device_id Device to target.
-     * @param channel DRAM channel to target.
-     */
-    virtual std::uint64_t get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel) {
-        throw std::runtime_error("---- tt_device::get_dram_channel_size is not implemented\n");
-    }
-
-    /**
      * Query number of memory channels on Host device allocated for a specific device during initialization.
      *
      * @param device_id Logical device id to target.
@@ -730,8 +711,6 @@ public:
     virtual std::map<int, int> get_clocks();
     virtual void* host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const;
     virtual std::uint64_t get_pcie_base_addr_from_device(const chip_id_t chip_id) const;
-    virtual std::uint32_t get_num_dram_channels(std::uint32_t device_id);
-    virtual std::uint64_t get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel);
     virtual std::uint32_t get_num_host_channels(std::uint32_t device_id);
     virtual std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel);
     virtual std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id);
@@ -915,7 +894,6 @@ private:
     int iatu_configure_peer_region(
         int logical_device_id, uint32_t peer_region_id, uint64_t bar_addr_64, uint32_t region_size);
     uint32_t get_harvested_noc_rows(uint32_t harvesting_mask);
-    uint32_t get_harvested_rows(int logical_device_id);
     int get_clock(int logical_device_id);
     void wait_for_aiclk_value(tt_DevicePowerState power_state, const uint32_t timeout_ms = 5000);
 
@@ -980,8 +958,6 @@ private:
         uint32_t* return_3 = nullptr,
         uint32_t* return_4 = nullptr);
 
-    virtual uint32_t get_harvested_noc_rows_for_chip(
-        int logical_device_id);  // Returns one-hot encoded harvesting mask for PCIe mapped chips
     std::unordered_map<chip_id_t, std::vector<std::vector<int>>>& get_ethernet_broadcast_headers(
         const std::set<chip_id_t>& chips_to_exclude);
     // Test functions

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -108,7 +108,6 @@ public:
 private:
     // State variables
     tt_driver_noc_params noc_params;
-    std::vector<tt::ARCH> archs_in_cluster = {};
     std::set<chip_id_t> target_devices_in_cluster = {};
     std::set<chip_id_t> target_remote_chips = {};
     tt::ARCH arch_name;

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -95,8 +95,6 @@ public:
     virtual std::map<int, int> get_clocks();
     virtual void* host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const;
     virtual std::uint64_t get_pcie_base_addr_from_device(const chip_id_t chip_id) const;
-    virtual std::uint32_t get_num_dram_channels(std::uint32_t device_id);
-    virtual std::uint64_t get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel);
     virtual std::uint32_t get_num_host_channels(std::uint32_t device_id);
     virtual std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel);
     virtual std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id);

--- a/device/mockup/tt_mockup_device.hpp
+++ b/device/mockup/tt_mockup_device.hpp
@@ -134,11 +134,7 @@ public:
         return soc_descriptor_per_chip.at(chip_id);
     };
 
-    // Misc. Functions to Query/Set Device State
-    static std::vector<chip_id_t> detect_available_device_ids() { return {0}; }
-
 private:
-    std::vector<tt::ARCH> archs_in_cluster = {};
     std::set<chip_id_t> target_devices_in_cluster = {};
     std::set<chip_id_t> target_remote_chips = {};
     std::shared_ptr<tt_ClusterDescriptor> cluster_descriptor;

--- a/device/mockup/tt_mockup_device.hpp
+++ b/device/mockup/tt_mockup_device.hpp
@@ -120,14 +120,6 @@ public:
 
     tt_version get_ethernet_fw_version() const override { return {0, 0, 0}; }
 
-    std::uint32_t get_num_dram_channels(std::uint32_t device_id) override {
-        return get_soc_descriptor(device_id).get_num_dram_channels();
-    };
-
-    std::uint64_t get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel) override {
-        return get_soc_descriptor(device_id).dram_bank_size;
-    }
-
     std::uint32_t get_num_host_channels(std::uint32_t device_id) override { return 1; }
 
     std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel) override { return 0; }

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -243,14 +243,6 @@ std::uint64_t tt_SimulationDevice::get_pcie_base_addr_from_device(const chip_id_
     }
 }
 
-std::uint32_t tt_SimulationDevice::get_num_dram_channels(std::uint32_t device_id) {
-    return get_soc_descriptor(device_id).get_num_dram_channels();
-}
-
-std::uint64_t tt_SimulationDevice::get_dram_channel_size(std::uint32_t device_id, std::uint32_t channel) {
-    return get_soc_descriptor(device_id).dram_bank_size;  // Space per channel is identical for now
-}
-
 std::uint32_t tt_SimulationDevice::get_num_host_channels(std::uint32_t device_id) { return 1; }
 
 std::uint32_t tt_SimulationDevice::get_host_channel_size(std::uint32_t device_id, std::uint32_t channel) { return 0; }


### PR DESCRIPTION
### Issue
Freeing up some code on a path to #248 

### Description
I've reviewed all the functions and cleared up some leftover dead code.

### List of the changes
- Removed get_num_dram_channels and get_dram_channel_size, this is obtained from soc descriptor in tt_metal
- Removed detect_number_of_chips and detect_available_device_ids, this is obtained from cluster descriptor in tt_metal. Only simulation_device::detect_available_device_ids is used but hardcoded to {0}
- Removed leftover dead code get_harvested_noc_rows, get_harvested_rows and get_harvested_noc_rows_for_chip
- Removed unused variables archs_in_cluster, perform_harvesting_on_sdesc and use_ethernet_ordered_writes

### Testing
Code builds

### API Changes
There are no breaking API changes in this PR.
