### PR TITLE
Add API to cluster desc for unique chip id for 6U

### DIFF
--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -51,6 +51,7 @@ protected:
     std::unordered_map<chip_id_t, tt::ARCH> chip_arch = {};
     std::map<ChipUID, chip_id_t> chip_uid_to_chip_id = {};
     std::map<chip_id_t, ChipUID> chip_id_to_chip_uid = {};
+    std::unordered_map<chip_id_t, uint64_t> chip_unique_ids = {};
     std::map<chip_id_t, std::set<uint32_t>> active_eth_channels = {};
     std::map<chip_id_t, std::set<uint32_t>> idle_eth_channels = {};
 
@@ -110,6 +111,7 @@ public:
     const std::unordered_map<chip_id_t, std::uint32_t> &get_harvesting_info() const;
     const std::unordered_map<chip_id_t, bool> &get_noc_translation_table_en() const;
     const std::unordered_map<chip_id_t, eth_coord_t> &get_chip_locations() const;
+    const std::unordered_map<chip_id_t, uint64_t> &get_chip_unique_ids() const;
     const std::
         unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>>
         get_ethernet_connections() const;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -368,6 +368,7 @@ void Cluster::ubb_eth_connections(
                 &remote_chip_id, tt_cxy_pair(chip_id, eth_core.x, eth_core.y), base_addr + (72 * 4), sizeof(uint64_t));
 
             chip_uid_to_local_chip_id.insert({local_chip_id, chip_id});
+            cluster_desc->chip_unique_ids.insert({chip_id, local_chip_id});
 
             channel++;
         }

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -868,6 +868,8 @@ const std::unordered_map<chip_id_t, eth_coord_t> &tt_ClusterDescriptor::get_chip
     return locations;
 }
 
+// Note: this API works only for Wormhole 6U galaxy at the moment.
+// TODO: implement this for Blackhole and old Wormhole configurations.
 const std::unordered_map<chip_id_t, uint64_t> &tt_ClusterDescriptor::get_chip_unique_ids() const {
     return chip_unique_ids;
 }

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -868,6 +868,10 @@ const std::unordered_map<chip_id_t, eth_coord_t> &tt_ClusterDescriptor::get_chip
     return locations;
 }
 
+const std::unordered_map<chip_id_t, uint64_t> &tt_ClusterDescriptor::get_chip_unique_ids() const {
+    return chip_unique_ids;
+}
+
 chip_id_t tt_ClusterDescriptor::get_shelf_local_physical_chip_coords(chip_id_t virtual_coord) {
     log_assert(
         !this->chip_locations.empty(),


### PR DESCRIPTION
### Issue

Add API to cluster desc for unique chip id for 6U

### Description

Add API to cluster desc for unique chip id for 6U. Chip unique id still needs work for old Wormhole configs and Blackhole. Checking this in just for 6U for now since it's helpful for tt-metal folks working on 6U

### List of the changes

- Add struct to cluster descriptor for chip uid
- Add API to get chip uid

### Testing
CI. Manual testing on 6U

### API Changes
/
