### PR TITLE
Move arc_msg to Chip

### DIFF
--- a/device/api/umd/device/architecture_implementation.h
+++ b/device/api/umd/device/architecture_implementation.h
@@ -24,6 +24,8 @@ struct tt_driver_noc_params;
 
 namespace tt::umd {
 
+static const uint32_t HANG_READ_VALUE = 0xFFFFFFFFu;
+
 class architecture_implementation {
 public:
     virtual ~architecture_implementation() = default;

--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -67,12 +67,12 @@ public:
 
     virtual int arc_msg(
         uint32_t msg_code,
-        bool wait_for_done,
-        uint32_t arg0,
-        uint32_t arg1,
-        uint32_t timeout_ms,
-        uint32_t* return_3,
-        uint32_t* return_4) = 0;
+        bool wait_for_done = true,
+        uint32_t arg0 = 0,
+        uint32_t arg1 = 0,
+        uint32_t timeout_ms = 1000,
+        uint32_t* return_3 = nullptr,
+        uint32_t* return_4 = nullptr) = 0;
 
     virtual void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores);
     // TODO: To be removed once all the usages are moved inside the class.

--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -65,12 +65,24 @@ public:
     virtual std::unique_lock<RobustMutex> acquire_mutex(std::string mutex_name, int pci_device_id);
     virtual std::unique_lock<RobustMutex> acquire_mutex(MutexType mutex_type, int pci_device_id);
 
+    virtual int arc_msg(
+        uint32_t msg_code,
+        bool wait_for_done,
+        uint32_t arg0,
+        uint32_t arg1,
+        uint32_t timeout_ms,
+        uint32_t* return_3,
+        uint32_t* return_4) = 0;
+
     virtual void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores);
     // TODO: To be removed once all the usages are moved inside the class.
     virtual tt_xy_pair get_remote_transfer_ethernet_core();
     virtual void update_active_eth_core_idx();
     virtual int get_active_eth_core_idx();
     virtual std::vector<CoreCoord> get_remote_transfer_ethernet_cores();
+
+    // TODO: To be moved to private implementation once methods are moved to chip
+    void enable_ethernet_queue(int timeout_s);
 
     // TODO: This should be private, once enough stuff is moved inside chip.
     // Probably also moved to LocalChip.

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -66,12 +66,12 @@ public:
 
     int arc_msg(
         uint32_t msg_code,
-        bool wait_for_done,
-        uint32_t arg0,
-        uint32_t arg1,
-        uint32_t timeout_ms,
-        uint32_t* return_3,
-        uint32_t* return_4) override;
+        bool wait_for_done = true,
+        uint32_t arg0 = 0,
+        uint32_t arg1 = 0,
+        uint32_t timeout_ms = 1000,
+        uint32_t* return_3 = nullptr,
+        uint32_t* return_4 = nullptr) override;
 
 private:
     std::unique_ptr<TTDevice> tt_device_;

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -64,6 +64,15 @@ public:
     std::unique_lock<RobustMutex> acquire_mutex(std::string mutex_name, int pci_device_id) override;
     std::unique_lock<RobustMutex> acquire_mutex(MutexType mutex_type, int pci_device_id) override;
 
+    int arc_msg(
+        uint32_t msg_code,
+        bool wait_for_done,
+        uint32_t arg0,
+        uint32_t arg1,
+        uint32_t timeout_ms,
+        uint32_t* return_3,
+        uint32_t* return_4) override;
+
 private:
     std::unique_ptr<TTDevice> tt_device_;
     std::unique_ptr<SysmemManager> sysmem_manager_;

--- a/device/api/umd/device/chip/mock_chip.h
+++ b/device/api/umd/device/chip/mock_chip.h
@@ -13,5 +13,14 @@ class MockChip : public Chip {
 public:
     MockChip(tt_SocDescriptor soc_descriptor);
     bool is_mmio_capable() const override;
+
+    int arc_msg(
+        uint32_t msg_code,
+        bool wait_for_done,
+        uint32_t arg0,
+        uint32_t arg1,
+        uint32_t timeout_ms,
+        uint32_t* return_3,
+        uint32_t* return_4) override;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -26,12 +26,12 @@ public:
 
     int arc_msg(
         uint32_t msg_code,
-        bool wait_for_done,
-        uint32_t arg0,
-        uint32_t arg1,
-        uint32_t timeout_ms,
-        uint32_t* return_3,
-        uint32_t* return_4) override;
+        bool wait_for_done = true,
+        uint32_t arg0 = 0,
+        uint32_t arg1 = 0,
+        uint32_t timeout_ms = 1000,
+        uint32_t* return_3 = nullptr,
+        uint32_t* return_4 = nullptr) override;
 
 private:
     tt_xy_pair translate_chip_coord_virtual_to_translated(const tt_xy_pair core);

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -24,6 +24,15 @@ public:
 
     void wait_for_non_mmio_flush() override;
 
+    int arc_msg(
+        uint32_t msg_code,
+        bool wait_for_done,
+        uint32_t arg0,
+        uint32_t arg1,
+        uint32_t timeout_ms,
+        uint32_t* return_3,
+        uint32_t* return_4) override;
+
 private:
     tt_xy_pair translate_chip_coord_virtual_to_translated(const tt_xy_pair core);
 

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -925,9 +925,7 @@ private:
     void set_pcie_power_state(tt_DevicePowerState state);
     int set_remote_power_state(const chip_id_t& chip, tt_DevicePowerState device_state);
     uint32_t get_power_state_arc_msg(chip_id_t chip_id, tt_DevicePowerState state);
-    void enable_local_ethernet_queue(const chip_id_t& chip, int timeout);
     void enable_ethernet_queue(int timeout);
-    void enable_remote_ethernet_queue(const chip_id_t& chip, int timeout);
     void deassert_resets_and_set_power_state();
     int iatu_configure_peer_region(
         int logical_device_id, uint32_t peer_region_id, uint64_t bar_addr_64, uint32_t region_size);
@@ -976,24 +974,6 @@ private:
         const uint32_t barrier_addr,
         const std::string& fallback_tlb);
     void init_membars();
-    int pcie_arc_msg(
-        int logical_device_id,
-        uint32_t msg_code,
-        bool wait_for_done = true,
-        uint32_t arg0 = 0,
-        uint32_t arg1 = 0,
-        uint32_t timeout_ms = 1000,
-        uint32_t* return_3 = nullptr,
-        uint32_t* return_4 = nullptr);
-    int remote_arc_msg(
-        int logical_device_id,
-        uint32_t msg_code,
-        bool wait_for_done = true,
-        uint32_t arg0 = 0,
-        uint32_t arg1 = 0,
-        uint32_t timeout_ms = 1000,
-        uint32_t* return_3 = nullptr,
-        uint32_t* return_4 = nullptr);
 
     std::unordered_map<chip_id_t, std::vector<std::vector<int>>>& get_ethernet_broadcast_headers(
         const std::set<chip_id_t>& chips_to_exclude);

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -25,8 +25,6 @@ static const uint64_t UNROLL_ATU_OFFSET_BAR = 0x1200;
 // BAR0 size for Blackhole, used to determine whether write block should use BAR0 or BAR4
 static const uint64_t BAR0_BH_SIZE = 512 * 1024 * 1024;
 
-constexpr unsigned int c_hang_read_value = 0xffffffffu;
-
 struct dynamic_tlb {
     uint64_t bar_offset;      // Offset that address is mapped to, within the PCI BAR.
     uint64_t remaining_size;  // Bytes remaining between bar_offset and end of the TLB.
@@ -54,7 +52,7 @@ public:
 
     tt::ARCH get_arch();
 
-    void detect_hang_read(uint32_t data_read = c_hang_read_value);
+    void detect_hang_read(uint32_t data_read = HANG_READ_VALUE);
 
     // Note: byte_addr is (mostly but not always) offset into BAR0.  This
     // interface assumes the caller knows what they are doing - but it's unclear

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -154,7 +154,7 @@ void Chip::enable_ethernet_queue(int timeout_s) {
             throw std::runtime_error(
                 fmt::format("Timed out after waiting {} seconds for for DRAM to finish training", timeout_s));
         }
-        if (arc_msg(0xaa58, true, 0xFFFF, 0xFFFF, 1000, &msg_success, nullptr) == HANG_READ_VALUE) {
+        if (arc_msg(0xaa58, true, 0xFFFF, 0xFFFF, 1000, &msg_success) == HANG_READ_VALUE) {
             break;
         }
     }

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -466,4 +466,35 @@ void LocalChip::wait_dram_cores_training(const uint32_t timeout_ms) {
     }
 }
 
+int LocalChip::arc_msg(
+    uint32_t msg_code,
+    bool wait_for_done,
+    uint32_t arg0,
+    uint32_t arg1,
+    uint32_t timeout_ms,
+    uint32_t* return_3,
+    uint32_t* return_4) {
+    std::vector<uint32_t> arc_msg_return_values;
+    if (return_3 != nullptr) {
+        arc_msg_return_values.push_back(0);
+    }
+
+    if (return_4 != nullptr) {
+        arc_msg_return_values.push_back(0);
+    }
+
+    uint32_t exit_code =
+        get_tt_device()->get_arc_messenger()->send_message(msg_code, arc_msg_return_values, arg0, arg1, timeout_ms);
+
+    if (return_3 != nullptr) {
+        *return_3 = arc_msg_return_values[0];
+    }
+
+    if (return_4 != nullptr) {
+        *return_4 = arc_msg_return_values[1];
+    }
+
+    return exit_code;
+}
+
 }  // namespace tt::umd

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -11,4 +11,15 @@ namespace tt::umd {
 MockChip::MockChip(tt_SocDescriptor soc_descriptor) : Chip(soc_descriptor) {}
 
 bool MockChip::is_mmio_capable() const { return false; }
+
+int MockChip::arc_msg(
+    uint32_t msg_code,
+    bool wait_for_done,
+    uint32_t arg0,
+    uint32_t arg1,
+    uint32_t timeout_ms,
+    uint32_t* return_3,
+    uint32_t* return_4) {
+    return 0;
+}
 }  // namespace tt::umd

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -63,4 +63,78 @@ void RemoteChip::wait_for_non_mmio_flush() {
     remote_communication_->wait_for_non_mmio_flush();
 }
 
+int RemoteChip::arc_msg(
+    uint32_t msg_code,
+    bool wait_for_done,
+    uint32_t arg0,
+    uint32_t arg1,
+    uint32_t timeout_ms,
+    uint32_t* return_3,
+    uint32_t* return_4) {
+    constexpr uint64_t ARC_RESET_SCRATCH_ADDR = 0x880030060;
+    constexpr uint64_t ARC_RESET_MISC_CNTL_ADDR = 0x880030100;
+
+    auto arc_core = soc_descriptor_.get_cores(CoreType::ARC).at(0);
+
+    if ((msg_code & 0xff00) != 0xaa00) {
+        log_error("Malformed message. msg_code is 0x{:x} but should be 0xaa..", msg_code);
+    }
+    log_assert(arg0 <= 0xffff and arg1 <= 0xffff, "Only 16 bits allowed in arc_msg args");  // Only 16 bits are allowed
+
+    uint32_t fw_arg = arg0 | (arg1 << 16);
+    int exit_code = 0;
+
+    { write_to_device(arc_core, &fw_arg, ARC_RESET_SCRATCH_ADDR + 3 * 4, sizeof(fw_arg), ""); }
+
+    { write_to_device(arc_core, &msg_code, ARC_RESET_SCRATCH_ADDR + 5 * 4, sizeof(fw_arg), ""); }
+
+    wait_for_non_mmio_flush();
+    uint32_t misc = 0;
+
+    read_from_device(arc_core, &misc, ARC_RESET_MISC_CNTL_ADDR, 4, "");
+
+    if (misc & (1 << 16)) {
+        log_error("trigger_fw_int failed on device");
+        return 1;
+    } else {
+        misc |= (1 << 16);
+        write_to_device(arc_core, &misc, ARC_RESET_MISC_CNTL_ADDR, sizeof(misc), "");
+    }
+
+    if (wait_for_done) {
+        uint32_t status = 0xbadbad;
+        auto start = std::chrono::steady_clock::now();
+        while (true) {
+            auto now = std::chrono::steady_clock::now();
+            auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count();
+            if (elapsed_ms > timeout_ms && timeout_ms != 0) {
+                std::stringstream ss;
+                ss << std::hex << msg_code;
+                throw std::runtime_error(fmt::format(
+                    "Timed out after waiting {} ms for device ARC to respond to message 0x{}", timeout_ms, ss.str()));
+            }
+
+            uint32_t status = 0;
+            read_from_device(arc_core, &status, ARC_RESET_SCRATCH_ADDR + 5 * 4, sizeof(status), "");
+            if ((status & 0xffff) == (msg_code & 0xff)) {
+                if (return_3 != nullptr) {
+                    read_from_device(arc_core, return_3, ARC_RESET_SCRATCH_ADDR + 3 * 4, sizeof(uint32_t), "");
+                }
+
+                if (return_4 != nullptr) {
+                    read_from_device(arc_core, return_4, ARC_RESET_SCRATCH_ADDR + 4 * 4, sizeof(uint32_t), "");
+                }
+
+                exit_code = (status & 0xffff0000) >> 16;
+                break;
+            } else if (status == HANG_READ_VALUE) {
+                log_warning(LogSiliconDriver, "Message code 0x{:x} not recognized by FW", msg_code);
+                exit_code = HANG_READ_VALUE;
+                break;
+            }
+        }
+    }
+    return exit_code;
+}
+
 }  // namespace tt::umd

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -54,11 +54,11 @@ bool TTDevice::is_hardware_hung() {
                                 pci_device_->bar0_uc_offset;
     std::uint32_t scratch_data = *reinterpret_cast<const volatile std::uint32_t *>(addr);
 
-    return (scratch_data == c_hang_read_value);
+    return (scratch_data == HANG_READ_VALUE);
 }
 
 void TTDevice::detect_hang_read(std::uint32_t data_read) {
-    if (data_read == c_hang_read_value && is_hardware_hung()) {
+    if (data_read == HANG_READ_VALUE && is_hardware_hung()) {
         std::uint32_t scratch_data =
             *pci_device_->get_register_address<std::uint32_t>(architecture_impl_->get_read_checking_offset());
 

--- a/device/wormhole/wormhole_arc_messenger.cpp
+++ b/device/wormhole/wormhole_arc_messenger.cpp
@@ -15,7 +15,7 @@ WormholeArcMessenger::WormholeArcMessenger(TTDevice* tt_device) : ArcMessenger(t
 
 uint32_t WormholeArcMessenger::send_message(
     const uint32_t msg_code, std::vector<uint32_t>& return_values, uint16_t arg0, uint16_t arg1, uint32_t timeout_ms) {
-    if ((msg_code & 0xff00) != 0xaa00) {
+    if ((msg_code & 0xff00) != wormhole::ARC_MSG_COMMON_PREFIX) {
         log_error("Malformed message. msg_code is 0x{:x} but should be 0xaa..", msg_code);
     }
 

--- a/device/wormhole/wormhole_arc_messenger.cpp
+++ b/device/wormhole/wormhole_arc_messenger.cpp
@@ -15,7 +15,6 @@ WormholeArcMessenger::WormholeArcMessenger(TTDevice* tt_device) : ArcMessenger(t
 
 uint32_t WormholeArcMessenger::send_message(
     const uint32_t msg_code, std::vector<uint32_t>& return_values, uint16_t arg0, uint16_t arg1, uint32_t timeout_ms) {
-    static const uint32_t MSG_ERROR_REPLY = 0xFFFFFFFF;
     if ((msg_code & 0xff00) != 0xaa00) {
         log_error("Malformed message. msg_code is 0x{:x} but should be 0xaa..", msg_code);
     }
@@ -74,9 +73,9 @@ uint32_t WormholeArcMessenger::send_message(
 
             exit_code = (status & 0xffff0000) >> 16;
             break;
-        } else if (status == MSG_ERROR_REPLY) {
+        } else if (status == HANG_READ_VALUE) {
             log_warning(LogSiliconDriver, "On device {}, message code 0x{:x} not recognized by FW", 0, msg_code);
-            exit_code = MSG_ERROR_REPLY;
+            exit_code = HANG_READ_VALUE;
             break;
         }
     }


### PR DESCRIPTION
### Issue
Part of #248

### Description
As a next step, moving arc_msg to Chip classes.

### List of the changes
- Moved pcie_arc_msg to LocalChip::arc_msg, and from remote_arc_msg to RemoteChip::arc_msg
- Moved enable_local_ethernet_queue and enable_remote_ethernet_queue into Chip::enable_ethernet_queue, since it was the same implementation for both local and remote chips.
- Define HANG_READ_VALUE in architecture_implementation.h to be available to all

### Testing
Existing CI tests

### API Changes
There are no API changes in this PR.
