### PR TITLE
Support using system flatbuffers

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -4,13 +4,17 @@ if(TT_UMD_BUILD_SIMULATION)
     set(FBS_FILE ${PROJECT_SOURCE_DIR}/device/simulation/tt_simulation_device.fbs)
     get_filename_component(FBS_FILE_NAME ${FBS_FILE} NAME_WLE)
     set(FBS_GENERATED_HEADER "${CMAKE_CURRENT_BINARY_DIR}/${FBS_FILE_NAME}_generated.h")
+    set(FBS_DEPENDS "")
+    if(TARGET flatc)
+        set(FBS_DEPENDS flatc)
+    endif()
     add_custom_command(
         OUTPUT
             ${FBS_GENERATED_HEADER}
         COMMAND
             flatc --cpp -o "${CMAKE_CURRENT_BINARY_DIR}" ${FBS_FILE}
         DEPENDS
-            flatc
+            ${FBS_DEPENDS}
             ${FBS_FILE}
         COMMENT "Generating FlatBuffers header ${FBS_GENERATED_HEADER}"
         VERBATIM

--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -152,7 +152,7 @@ if(TT_UMD_BUILD_SIMULATION)
     target_link_libraries(
         device
         PRIVATE
-            flatbuffers
+            flatbuffers::flatbuffers
             nng
             uv_a
     )

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -73,8 +73,8 @@ if(TT_UMD_BUILD_SIMULATION)
             "FLATBUFFERS_SKIP_MONSTER_EXTRA ON"
             "FLATBUFFERS_STRICT_MODE ON"
     )
-    if(flatbuffers_ADDED AND NOT TARGET flatbuffers::flatbuffers AND TARGET FlatBuffers::FlatBuffers)
-        add_library(flatbuffers::flatbuffers ALIAS FlatBuffers::FlatBuffers)
+    if(flatbuffers_ADDED AND NOT TARGET flatbuffers::flatbuffers AND TARGET flatbuffers)
+        add_library(flatbuffers::flatbuffers ALIAS flatbuffers)
     endif()
 endif()
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -73,7 +73,8 @@ if(TT_UMD_BUILD_SIMULATION)
             "FLATBUFFERS_SKIP_MONSTER_EXTRA ON"
             "FLATBUFFERS_STRICT_MODE ON"
     )
-    if(flatbuffers_ADDED)
+
+    if(NOT TARGET flatbuffers::flatbuffers)
         message(
             INFO
             "CPM Added flatbuffers, creating ALIAS flatbuffers::flatbuffers"

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -73,7 +73,8 @@ if(TT_UMD_BUILD_SIMULATION)
             "FLATBUFFERS_SKIP_MONSTER_EXTRA ON"
             "FLATBUFFERS_STRICT_MODE ON"
     )
-    if(flatbuffers_ADDED AND NOT TARGET flatbuffers::flatbuffers AND TARGET flatbuffers)
+    if(flatbuffers_ADDED)
+	message(INFO "CPM Added flatbuffers, creating ALIAS flatbuffers::flatbuffers")
         add_library(flatbuffers::flatbuffers ALIAS flatbuffers)
     endif()
 endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -74,7 +74,10 @@ if(TT_UMD_BUILD_SIMULATION)
             "FLATBUFFERS_STRICT_MODE ON"
     )
     if(flatbuffers_ADDED)
-	message(INFO "CPM Added flatbuffers, creating ALIAS flatbuffers::flatbuffers")
+        message(
+            INFO
+            "CPM Added flatbuffers, creating ALIAS flatbuffers::flatbuffers"
+        )
         add_library(flatbuffers::flatbuffers ALIAS flatbuffers)
     endif()
 endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -73,6 +73,10 @@ if(TT_UMD_BUILD_SIMULATION)
             "FLATBUFFERS_SKIP_MONSTER_EXTRA ON"
             "FLATBUFFERS_STRICT_MODE ON"
     )
+    if(flatbuffers_ADDED)
+        if(NOT TARGET flatbuffers::flatbuffers AND TARGET FlatBuffers::FlatBuffers)
+	    add_library(flatbuffers::flatbuffers ALIAS FlatBuffers::FlatBuffers)
+    endif()
 endif()
 
 ###################################################################################################################

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -73,9 +73,8 @@ if(TT_UMD_BUILD_SIMULATION)
             "FLATBUFFERS_SKIP_MONSTER_EXTRA ON"
             "FLATBUFFERS_STRICT_MODE ON"
     )
-    if(flatbuffers_ADDED)
-        if(NOT TARGET flatbuffers::flatbuffers AND TARGET FlatBuffers::FlatBuffers)
-	    add_library(flatbuffers::flatbuffers ALIAS FlatBuffers::FlatBuffers)
+    if(flatbuffers_ADDED AND NOT TARGET flatbuffers::flatbuffers AND TARGET FlatBuffers::FlatBuffers)
+        add_library(flatbuffers::flatbuffers ALIAS FlatBuffers::FlatBuffers)
     endif()
 endif()
 


### PR DESCRIPTION
### Description
The current setup assumes that we are always building flatbuffers together with UMD.
However, that may not always be the case.
For example, someone may want to force usage of system packages to save on compile time.

### List of the changes
- flatc target is only a dependency when using locally built flatbuffers
- use the target name `flatbuffers::flatbuffers` when linking. flatbuffers CMake is a little janky.

### Testing
CI

### API Changes
There are no API changes in this PR.
