### PR TITLE
Move check_pcie_device to Chip

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -28,6 +28,8 @@ public:
 
     virtual ~Chip() = default;
 
+    virtual void start_device() = 0;
+
     tt_SocDescriptor& get_soc_descriptor();
 
     virtual bool is_mmio_capable() const = 0;

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -27,6 +27,8 @@ public:
 
     bool is_mmio_capable() const override;
 
+    void start_device() override;
+
     TTDevice* get_tt_device() override;
     SysmemManager* get_sysmem_manager() override;
     TLBManager* get_tlb_manager() override;
@@ -91,6 +93,9 @@ private:
     void initialize_default_remote_transfer_ethernet_cores();
 
     tt_xy_pair translate_chip_coord_virtual_to_translated(const tt_xy_pair core) const;
+
+    void check_pcie_device_initialized();
+    int test_setup_interface();
 
 protected:
     void wait_eth_cores_training(const uint32_t timeout_ms = 60000) override;

--- a/device/api/umd/device/chip/mock_chip.h
+++ b/device/api/umd/device/chip/mock_chip.h
@@ -14,6 +14,8 @@ public:
     MockChip(tt_SocDescriptor soc_descriptor);
     bool is_mmio_capable() const override;
 
+    void start_device() override;
+
     int arc_msg(
         uint32_t msg_code,
         bool wait_for_done,

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -17,6 +17,8 @@ public:
     RemoteChip(tt_SocDescriptor soc_descriptor, eth_coord_t eth_chip_location, LocalChip* local_chip);
     bool is_mmio_capable() const override;
 
+    void start_device() override;
+
     void write_to_device(
         tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size, const std::string& fallback_tlb) override;
     void read_from_device(

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -921,7 +921,6 @@ private:
     void send_remote_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);
     void send_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);
     void init_pcie_iatus();  // No more p2p support.
-    void check_pcie_device_initialized(int device_id);
     void set_pcie_power_state(tt_DevicePowerState state);
     int set_remote_power_state(const chip_id_t& chip, tt_DevicePowerState device_state);
     uint32_t get_power_state_arc_msg(chip_id_t chip_id, tt_DevicePowerState state);
@@ -980,7 +979,6 @@ private:
     // Test functions
     void verify_eth_fw();
     void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions);
-    int test_setup_interface();
 
     // Helper functions for constructing the chips from the cluster descriptor.
     std::unique_ptr<Chip> construct_chip_from_cluster(

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -11,6 +11,7 @@
 #include "umd/device/chip_helpers/tlb_manager.h"
 #include "umd/device/tt_device/tt_device.h"
 #include "umd/device/types/blackhole_eth.h"
+#include "umd/device/wormhole_implementation.h"
 
 extern bool umd_use_noc1;
 
@@ -106,6 +107,8 @@ SysmemManager* LocalChip::get_sysmem_manager() { return sysmem_manager_.get(); }
 TLBManager* LocalChip::get_tlb_manager() { return tlb_manager_.get(); }
 
 bool LocalChip::is_mmio_capable() const { return true; }
+
+void LocalChip::start_device() { check_pcie_device_initialized(); }
 
 void LocalChip::wait_eth_cores_training(const uint32_t timeout_ms) {
     if (get_tt_device()->get_arch() != tt::ARCH::BLACKHOLE) {
@@ -495,6 +498,72 @@ int LocalChip::arc_msg(
     }
 
     return exit_code;
+}
+
+void LocalChip::check_pcie_device_initialized() {
+    auto architecture_implementation = tt_device_->get_architecture_implementation();
+
+    // MT Initial BH - Add check for blackhole once access to ARC registers is setup through TLBs
+    if (soc_descriptor_.arch != tt::ARCH::BLACKHOLE) {
+        log_debug(LogSiliconDriver, "== Check if device_id: {} is initialized", device_id);
+        uint32_t bar_read_initial =
+            tt_device_->bar_read32(architecture_implementation->get_arc_reset_scratch_offset() + 3 * 4);
+        uint32_t arg = bar_read_initial == 500 ? 325 : 500;
+        uint32_t bar_read_again;
+        uint32_t arc_msg_return =
+            arc_msg(wormhole::ARC_MSG_COMMON_PREFIX | architecture_implementation->get_arc_message_test(), true, arg, 0, 1000, &bar_read_again);
+        if (arc_msg_return != 0 || bar_read_again != arg + 1) {
+            auto postcode = tt_device_->bar_read32(architecture_implementation->get_arc_reset_scratch_offset());
+            throw std::runtime_error(fmt::format(
+                "Device is not initialized: arc_fw postcode: {} arc_msg_return: {} arg: {} bar_read_initial: {} "
+                "bar_read_again: {}",
+                postcode,
+                arc_msg_return,
+                arg,
+                bar_read_initial,
+                bar_read_again));
+        }
+    }
+
+    if (test_setup_interface()) {
+        throw std::runtime_error(
+            "Device is incorrectly initialized. If this is a harvested Wormhole machine, it is likely that NOC "
+            "Translation Tables are not enabled on device. These need to be enabled for the silicon driver to run.");
+    }
+}
+
+int LocalChip::test_setup_interface() {
+    int ret_val = 0;
+    if (soc_descriptor_.arch == tt::ARCH::WORMHOLE_B0) {
+        uint32_t mapped_reg = tt_device_
+                                  ->set_dynamic_tlb(
+                                      tt_device_->get_architecture_implementation()->get_reg_tlb(),
+                                      translate_chip_coord_virtual_to_translated(tt_xy_pair(1, 0)),
+                                      0xffb20108)
+                                  .bar_offset;
+
+        uint32_t regval = 0;
+        tt_device_->read_regs(mapped_reg, 1, &regval);
+        ret_val = (regval != HANG_READ_VALUE && (regval == 33)) ? 0 : 1;
+        return ret_val;
+    } else if (soc_descriptor_.arch == tt::ARCH::BLACKHOLE) {
+        // MT Inital BH - Try to enable this, but double check "regval == 33"
+
+        // uint32_t mapped_reg = tt_device_
+        //                           ->set_dynamic_tlb(
+        //                               tt_device_->get_architecture_implementation()->get_reg_tlb(),
+        //                               translate_chip_coord_virtual_to_translated(tt_xy_pair(1, 0)),
+        //                               0xffb20108)
+        //                           .bar_offset;
+
+        // uint32_t regval = 0;
+        // tt_device_->read_regs(dev, mapped_reg, 1, &regval);
+        // ret_val = (regval != HANG_READ_VALUE && (regval == 33)) ? 0 : 1;
+        // return ret_val;
+        return 0;
+    } else {
+        throw std::runtime_error(fmt::format("Unsupported architecture: {}", arch_to_str(soc_descriptor_.arch)));
+    }
 }
 
 }  // namespace tt::umd

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -12,6 +12,8 @@ MockChip::MockChip(tt_SocDescriptor soc_descriptor) : Chip(soc_descriptor) {}
 
 bool MockChip::is_mmio_capable() const { return false; }
 
+void MockChip::start_device() {}
+
 int MockChip::arc_msg(
     uint32_t msg_code,
     bool wait_for_done,

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -20,6 +20,8 @@ RemoteChip::RemoteChip(tt_SocDescriptor soc_descriptor, eth_coord_t eth_chip_loc
 
 bool RemoteChip::is_mmio_capable() const { return false; }
 
+void RemoteChip::start_device() {}
+
 void RemoteChip::write_to_device(
     tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size, const std::string& fallback_tlb) {
     // TODO: Fallback TLB is ignored for now, but it will be removed soon from the signature.

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -532,63 +532,11 @@ void Cluster::configure_active_ethernet_cores_for_mmio_device(
     get_local_chip(mmio_chip)->set_remote_transfer_ethernet_cores(active_eth_cores_per_chip);
 }
 
-void Cluster::check_pcie_device_initialized(int device_id) {
-    TTDevice* tt_device = get_tt_device(device_id);
-    tt::ARCH device_arch = tt_device->get_pci_device()->get_arch();
-    if (arch_name == tt::ARCH::WORMHOLE_B0) {
-        if (device_arch != tt::ARCH::WORMHOLE_B0) {
-            throw std::runtime_error(
-                fmt::format("Attempted to run wormhole configured tt_device on {}", arch_to_str(device_arch)));
-        }
-    } else if (arch_name == tt::ARCH::BLACKHOLE) {
-        if (device_arch != tt::ARCH::BLACKHOLE) {
-            throw std::runtime_error(
-                fmt::format("Attempted to run blackhole configured tt_device on {}", arch_to_str(device_arch)));
-        }
-    } else {
-        throw std::runtime_error(fmt::format("Unsupported architecture: {}", arch_to_str(arch_name)));
-    }
-    auto architecture_implementation = tt_device->get_architecture_implementation();
-
-    // MT Initial BH - Add check for blackhole once access to ARC registers is setup through TLBs
-    if (arch_name != tt::ARCH::BLACKHOLE) {
-        log_debug(LogSiliconDriver, "== Check if device_id: {} is initialized", device_id);
-        uint32_t bar_read_initial =
-            tt_device->bar_read32(architecture_implementation->get_arc_reset_scratch_offset() + 3 * 4);
-        uint32_t arg = bar_read_initial == 500 ? 325 : 500;
-        uint32_t bar_read_again;
-        uint32_t arc_msg_return = get_chip(device_id)->arc_msg(
-            wormhole::ARC_MSG_COMMON_PREFIX | architecture_implementation->get_arc_message_test(),
-            true,
-            arg,
-            0,
-            1000,
-            &bar_read_again);
-        if (arc_msg_return != 0 || bar_read_again != arg + 1) {
-            auto postcode = tt_device->bar_read32(architecture_implementation->get_arc_reset_scratch_offset());
-            throw std::runtime_error(fmt::format(
-                "Device is not initialized: arc_fw postcode: {} arc_msg_return: {} arg: {} bar_read_initial: {} "
-                "bar_read_again: {}",
-                postcode,
-                arc_msg_return,
-                arg,
-                bar_read_initial,
-                bar_read_again));
-        }
-    }
-
-    if (test_setup_interface()) {
-        throw std::runtime_error(
-            "Device is incorrectly initialized. If this is a harvested Wormhole machine, it is likely that NOC "
-            "Translation Tables are not enabled on device. These need to be enabled for the silicon driver to run.");
-    }
-}
-
 void Cluster::initialize_pcie_devices() {
     log_debug(LogSiliconDriver, "Cluster::start");
 
-    for (auto chip_id : local_chip_ids_) {
-        check_pcie_device_initialized(chip_id);
+    for (auto chip_id : all_chip_ids_) {
+        get_chip(chip_id)->start_device();
     }
 
     init_pcie_iatus();
@@ -857,42 +805,6 @@ void Cluster::init_pcie_iatus() {
                 iatu_configure_peer_region(chip_id, channel, hugepage_map.physical_address, region_size);
             }
         }
-    }
-}
-
-int Cluster::test_setup_interface() {
-    int ret_val = 0;
-    int chip_id = *local_chip_ids_.begin();
-    TTDevice* tt_device = get_tt_device(chip_id);
-    if (arch_name == tt::ARCH::WORMHOLE_B0) {
-        uint32_t mapped_reg = tt_device
-                                  ->set_dynamic_tlb(
-                                      tt_device->get_architecture_implementation()->get_reg_tlb(),
-                                      translate_chip_coord_virtual_to_translated(chip_id, tt_xy_pair(1, 0)),
-                                      0xffb20108)
-                                  .bar_offset;
-
-        uint32_t regval = 0;
-        tt_device->read_regs(mapped_reg, 1, &regval);
-        ret_val = (regval != HANG_READ_VALUE && (regval == 33)) ? 0 : 1;
-        return ret_val;
-    } else if (arch_name == tt::ARCH::BLACKHOLE) {
-        // MT Inital BH - Try to enable this, but double check "regval == 33"
-
-        // uint32_t mapped_reg = tt_device
-        //                           ->set_dynamic_tlb(
-        //                               tt_device->get_architecture_implementation()->get_reg_tlb(),
-        //                               translate_chip_coord_virtual_to_translated(chip_id, tt_xy_pair(1, 0)),
-        //                               0xffb20108)
-        //                           .bar_offset;
-
-        // uint32_t regval = 0;
-        // tt_device->read_regs(dev, mapped_reg, 1, &regval);
-        // ret_val = (regval != HANG_READ_VALUE && (regval == 33)) ? 0 : 1;
-        // return ret_val;
-        return 0;
-    } else {
-        throw std::runtime_error(fmt::format("Unsupported architecture: {}", arch_to_str(arch_name)));
     }
 }
 


### PR DESCRIPTION
### Issue
On a path of #248

### Description
Moving check pcie_device to local chip

### List of the changes
- Moved check_pcie_device_initialized and test_setup_interface to local_chip
- Started the "start_device" function in Chip, which should hold all the code from cluster start_device

### Testing
No additional testing

### API Changes
There are no API changes in this PR.
