### PR TITLE
Move configure_iatu_region from Cluster

### DIFF
--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -96,6 +96,7 @@ private:
 
     void check_pcie_device_initialized();
     int test_setup_interface();
+    void init_pcie_iatus();
 
 protected:
     void wait_eth_cores_training(const uint32_t timeout_ms = 60000) override;

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -920,14 +920,11 @@ private:
     void broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOptions& soft_resets);
     void send_remote_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);
     void send_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);
-    void init_pcie_iatus();  // No more p2p support.
     void set_pcie_power_state(tt_DevicePowerState state);
     int set_remote_power_state(const chip_id_t& chip, tt_DevicePowerState device_state);
     uint32_t get_power_state_arc_msg(chip_id_t chip_id, tt_DevicePowerState state);
     void enable_ethernet_queue(int timeout);
     void deassert_resets_and_set_power_state();
-    int iatu_configure_peer_region(
-        int logical_device_id, uint32_t peer_region_id, uint64_t bar_addr_64, uint32_t region_size);
     int get_clock(int logical_device_id);
     void wait_for_aiclk_value(tt_DevicePowerState power_state, const uint32_t timeout_ms = 5000);
 

--- a/device/api/umd/device/tt_device/blackhole_tt_device.h
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.h
@@ -17,7 +17,7 @@ public:
     BlackholeTTDevice(std::unique_ptr<PCIDevice> pci_device);
     ~BlackholeTTDevice();
 
-    void configure_iatu_region(size_t region, uint64_t base, uint64_t target, size_t size) override;
+    void configure_iatu_region(size_t region, uint64_t target, size_t region_size) override;
 
     ChipInfo get_chip_info() override;
 

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -138,16 +138,15 @@ public:
      * either 1GB hugepages or a compatible scheme.
      *
      * @param region iATU region index (0-15)
-     * @param base region * (1 << 30)
      * @param target DMA address (PA or IOVA) to map to
-     * @param size size of the mapping window; must be (1 << 30)
+     * @param region_size size of the mapping window; must be (1 << 30)
      *
      * NOTE: Programming the iATU from userspace is architecturally incorrect:
      * - iATU should be managed by KMD to ensure proper cleanup on process exit
      * - Multiple processes can corrupt each other's iATU configurations
      * We should fix this!
      */
-    virtual void configure_iatu_region(size_t region, uint64_t base, uint64_t target, size_t size);
+    virtual void configure_iatu_region(size_t region, uint64_t target, size_t region_size);
 
     virtual ChipInfo get_chip_info() = 0;
 

--- a/device/api/umd/device/tt_device/wormhole_tt_device.h
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.h
@@ -15,6 +15,8 @@ class WormholeTTDevice : public TTDevice {
 public:
     WormholeTTDevice(std::unique_ptr<PCIDevice> pci_device);
 
+    void configure_iatu_region(size_t region, uint64_t target, size_t region_size) override;
+
     void wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms = 1000) override;
 
     ChipInfo get_chip_info() override;

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -342,12 +342,7 @@ dynamic_tlb TTDevice::set_dynamic_tlb_broadcast(
     return set_dynamic_tlb(tlb_index, start, end, address, true, ordering);
 }
 
-void TTDevice::configure_iatu_region(size_t region, uint64_t base, uint64_t target, size_t size) {
-    // TODO: The code to do this is still up in cluster.cpp.  It should be moved
-    // here, but a prerequisite is to have an ARC messaging interface at this
-    // (TTDevice) level... it too is still up in cluster.cpp.
-    //
-    // For now, just throw an exception.
+void TTDevice::configure_iatu_region(size_t region, uint64_t target, size_t region_size) {
     throw std::runtime_error("configure_iatu_region is not implemented for this device");
 }
 

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "umd/device/tt_device/wormhole_tt_device.h"
 
+#include "logger.hpp"
 #include "umd/device/types/wormhole_dram.h"
 #include "umd/device/types/wormhole_telemetry.h"
 #include "umd/device/wormhole_implementation.h"
@@ -104,6 +105,36 @@ std::vector<DramTrainingStatus> WormholeTTDevice::get_dram_training_status() {
     }
 
     return dram_training_status;
+}
+
+void WormholeTTDevice::configure_iatu_region(size_t region, uint64_t target, size_t region_size) {
+    uint32_t dest_bar_lo = target & 0xffffffff;
+    uint32_t dest_bar_hi = (target >> 32) & 0xffffffff;
+    std::uint32_t region_id_to_use = region;
+
+    // TODO: stop doing this.  It's related to HUGEPAGE_CHANNEL_3_SIZE_LIMIT.
+    if (region == 3) {
+        region_id_to_use = 4;  // Hack use region 4 for channel 3..this ensures that we have a smaller chan 3 address
+                               // space with the correct start offset
+    }
+
+    bar_write32(architecture_impl_->get_arc_csm_mailbox_offset() + 0 * 4, region_id_to_use);
+    bar_write32(architecture_impl_->get_arc_csm_mailbox_offset() + 1 * 4, dest_bar_lo);
+    bar_write32(architecture_impl_->get_arc_csm_mailbox_offset() + 2 * 4, dest_bar_hi);
+    bar_write32(architecture_impl_->get_arc_csm_mailbox_offset() + 3 * 4, region_size);
+    arc_messenger_->send_message(
+        wormhole::ARC_MSG_COMMON_PREFIX | architecture_impl_->get_arc_message_setup_iatu_for_peer_to_peer(), 0, 0);
+
+    // Print what just happened
+    uint32_t peer_region_start = region_id_to_use * region_size;
+    uint32_t peer_region_end = (region_id_to_use + 1) * region_size - 1;
+    log_debug(
+        LogSiliconDriver,
+        "    [region id {}] NOC to PCI address range 0x{:x}-0x{:x} mapped to addr 0x{:x}",
+        region,
+        peer_region_start,
+        peer_region_end,
+        target);
 }
 
 // TODO: This is a temporary implementation, and ought to be replaced with a


### PR DESCRIPTION
### Issue
On a path to #248 but also #142 

### Description
Move iatu configuration to tt_device, and also its calling to local_chip

### List of the changes
- Merged bh and wh declarations for configure_iatu_region
- Moved wh's definition for configure_iatu_region to tt_device
- Moved init_pcie_iatus  to local_chip and Calling this from start_device

### Testing
No additional testing

### API Changes
There are no API changes in this PR.
