### PR TITLE
Remove fallback_tlb from all tests

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -286,7 +286,7 @@ public:
         const std::set<chip_id_t>& chips_to_exclude,
         std::set<uint32_t>& rows_to_exclude,
         std::set<uint32_t>& columns_to_exclude,
-        const std::string& fallback_tlb) {
+        const std::string& fallback_tlb = "LARGE_WRITE_TLB") {
         throw std::runtime_error("---- tt_device::broadcast_write_to_cluster is not implemented\n");
     }
 
@@ -820,7 +820,7 @@ public:
         const std::set<chip_id_t>& chips_to_exclude,
         std::set<uint32_t>& rows_to_exclude,
         std::set<uint32_t>& columns_to_exclude,
-        const std::string& fallback_tlb);
+        const std::string& fallback_tlb = "LARGE_WRITE_TLB");
     virtual void read_from_device(
         void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
 

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -63,7 +63,7 @@ public:
         chip_id_t chip,
         tt::umd::CoreCoord core,
         uint64_t addr,
-        const std::string& tlb_to_use);
+        const std::string& tlb_to_use = "LARGE_WRITE_TLB");
     virtual void read_from_device(
         void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
     virtual void read_from_device(
@@ -72,7 +72,7 @@ public:
         tt::umd::CoreCoord core,
         uint64_t addr,
         uint32_t size,
-        const std::string& fallback_tlb);
+        const std::string& fallback_tlb = "LARGE_READ_TLB");
 
     void dma_write_to_device(const void* src, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) {
         throw std::runtime_error("DMA write not supported in simulation mode.");

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -108,9 +108,9 @@ TEST(ApiChipTest, SimpleAPIShowcase) {
 //     tt_cxy_pair chip_core_coord = get_tensix_chip_core_coord(umd_cluster);
 
 //     umd_cluster->assert_risc_reset_at_core(chip_core_coord);
-//     umd_cluster->l1_membar(chip_core_coord.chip, "LARGE_WRITE_TLB");
+//     umd_cluster->l1_membar(chip_core_coord.chip);
 //     umd_cluster->deassert_risc_reset_at_core(chip_core_coord);
-//     umd_cluster->l1_membar(chip_core_coord.chip, "LARGE_WRITE_TLB");
+//     umd_cluster->l1_membar(chip_core_coord.chip);
 
 //     uint32_t soft_reset_reg_addr = 0xFFB121B0;
 //     uint32_t expected_risc_reset_val = static_cast<uint32_t>(TENSIX_DEASSERT_SOFT_RESET);
@@ -133,7 +133,7 @@ TEST(ApiChipTest, SimpleAPIShowcase) {
 //     umd_cluster->assert_risc_reset_at_core(chip_core_coord);
 //     TensixSoftResetOptions deassert_val = ALL_TRISC_SOFT_RESET | TensixSoftResetOptions::STAGGERED_START;
 //     umd_cluster->deassert_risc_reset_at_core(chip_core_coord, deassert_val);
-//     umd_cluster->l1_membar(chip_core_coord.chip, "LARGE_WRITE_TLB");
+//     umd_cluster->l1_membar(chip_core_coord.chip);
 
 //     uint32_t soft_reset_reg_addr = 0xFFB121B0;
 //     uint32_t risc_reset_val;
@@ -156,7 +156,7 @@ TEST(ApiChipTest, SimpleAPIShowcase) {
 
 //     TensixSoftResetOptions deassert_val = static_cast<TensixSoftResetOptions>(0xDEADBEEF);
 //     umd_cluster->deassert_risc_reset_at_core(chip_core_coord, deassert_val);
-//     umd_cluster->l1_membar(chip_core_coord.chip, "LARGE_WRITE_TLB");
+//     umd_cluster->l1_membar(chip_core_coord.chip);
 
 //     uint32_t soft_reset_reg_addr = 0xFFB121B0;
 //     uint32_t risc_reset_val;

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -93,7 +93,7 @@ TEST(ApiClusterTest, SimpleIOAllChips) {
 
         std::cout << "Writing to chip " << chip_id << " core " << any_core.str() << std::endl;
 
-        umd_cluster->write_to_device(data.data(), data_size, chip_id, any_core, 0, "LARGE_WRITE_TLB");
+        umd_cluster->write_to_device(data.data(), data_size, chip_id, any_core, 0);
 
         umd_cluster->wait_for_non_mmio_flush(chip_id);
     }
@@ -107,7 +107,7 @@ TEST(ApiClusterTest, SimpleIOAllChips) {
         std::cout << "Reading from chip " << chip_id << " core " << any_core.str() << std::endl;
 
         std::vector<uint8_t> readback_data(data_size, 0);
-        umd_cluster->read_from_device(readback_data.data(), chip_id, any_core, 0, data_size, "LARGE_READ_TLB");
+        umd_cluster->read_from_device(readback_data.data(), chip_id, any_core, 0, data_size);
 
         ASSERT_EQ(data, readback_data);
     }
@@ -141,14 +141,14 @@ TEST(ApiClusterTest, RemoteFlush) {
         }
 
         std::cout << "Writing to chip " << chip_id << " core " << any_core.str() << std::endl;
-        umd_cluster->write_to_device(data.data(), data_size, chip_id, any_core, 0, "LARGE_WRITE_TLB");
+        umd_cluster->write_to_device(data.data(), data_size, chip_id, any_core, 0);
 
         std::cout << "Waiting for remote chip flush " << chip_id << std::endl;
         umd_cluster->wait_for_non_mmio_flush(chip_id);
 
         std::cout << "Reading from chip " << chip_id << " core " << any_core.str() << std::endl;
         std::vector<uint8_t> readback_data(data_size, 0);
-        umd_cluster->read_from_device(readback_data.data(), chip_id, any_core, 0, data_size, "LARGE_READ_TLB");
+        umd_cluster->read_from_device(readback_data.data(), chip_id, any_core, 0, data_size);
 
         ASSERT_EQ(data, readback_data);
     }
@@ -184,7 +184,7 @@ TEST(ApiClusterTest, SimpleIOSpecificChips) {
 
         std::cout << "Writing to chip " << chip_id << " core " << any_core.str() << std::endl;
 
-        umd_cluster->write_to_device(data.data(), data_size, chip_id, any_core, 0, "LARGE_WRITE_TLB");
+        umd_cluster->write_to_device(data.data(), data_size, chip_id, any_core, 0);
 
         umd_cluster->wait_for_non_mmio_flush(chip_id);
     }
@@ -198,7 +198,7 @@ TEST(ApiClusterTest, SimpleIOSpecificChips) {
         std::cout << "Reading from chip " << chip_id << " core " << any_core.str() << std::endl;
 
         std::vector<uint8_t> readback_data(data_size, 0);
-        umd_cluster->read_from_device(readback_data.data(), chip_id, any_core, 0, data_size, "LARGE_READ_TLB");
+        umd_cluster->read_from_device(readback_data.data(), chip_id, any_core, 0, data_size);
 
         ASSERT_EQ(data, readback_data);
     }
@@ -229,24 +229,18 @@ TEST(ClusterAPI, DynamicTLB_RW) {
         for (int loop = 0; loop < num_loops; loop++) {
             for (auto& core : tensix_cores) {
                 cluster->write_to_device(
-                    vector_to_write.data(),
-                    vector_to_write.size() * sizeof(std::uint32_t),
-                    chip,
-                    core,
-                    address,
-                    "SMALL_READ_WRITE_TLB");
+                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), chip, core, address);
 
                 // Barrier to ensure that all writes over ethernet were commited
                 cluster->wait_for_non_mmio_flush();
-                cluster->read_from_device(readback_vec.data(), chip, core, address, 40, "SMALL_READ_WRITE_TLB");
+                cluster->read_from_device(readback_vec.data(), chip, core, address, 40);
 
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
 
                 cluster->wait_for_non_mmio_flush();
 
-                cluster->write_to_device(
-                    zeros.data(), zeros.size() * sizeof(std::uint32_t), chip, core, address, "SMALL_READ_WRITE_TLB");
+                cluster->write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip, core, address);
 
                 cluster->wait_for_non_mmio_flush();
 
@@ -362,21 +356,19 @@ TEST(TestCluster, ReadWriteL1) {
         CoreCoord tensix_core = cluster->get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)[0];
 
         // Zero out L1.
-        cluster->write_to_device(zero_data.data(), zero_data.size(), chip_id, tensix_core, 0, "SMALL_READ_WRITE_TLB");
+        cluster->write_to_device(zero_data.data(), zero_data.size(), chip_id, tensix_core, 0);
 
         cluster->wait_for_non_mmio_flush(chip_id);
 
-        cluster->read_from_device(
-            readback_data.data(), chip_id, tensix_core, 0, tensix_l1_size, "SMALL_READ_WRITE_TLB");
+        cluster->read_from_device(readback_data.data(), chip_id, tensix_core, 0, tensix_l1_size);
 
         EXPECT_EQ(zero_data, readback_data);
 
-        cluster->write_to_device(data.data(), data.size(), chip_id, tensix_core, 0, "SMALL_READ_WRITE_TLB");
+        cluster->write_to_device(data.data(), data.size(), chip_id, tensix_core, 0);
 
         cluster->wait_for_non_mmio_flush(chip_id);
 
-        cluster->read_from_device(
-            readback_data.data(), chip_id, tensix_core, 0, tensix_l1_size, "SMALL_READ_WRITE_TLB");
+        cluster->read_from_device(readback_data.data(), chip_id, tensix_core, 0, tensix_l1_size);
 
         EXPECT_EQ(data, readback_data);
     }

--- a/tests/api/test_noc.cpp
+++ b/tests/api/test_noc.cpp
@@ -20,8 +20,7 @@ TEST(TestNoc, TestNoc0NodeId) {
             cluster->get_tt_device(0)->get_architecture_implementation()->get_noc_reg_base(core.core_type, 0) +
             cluster->get_tt_device(0)->get_architecture_implementation()->get_noc_node_id_offset();
         uint32_t noc_node_id_val;
-        cluster->read_from_device(
-            &noc_node_id_val, chip, core, noc_node_id_reg_addr, sizeof(noc_node_id_val), "REG_TLB");
+        cluster->read_from_device_reg(&noc_node_id_val, chip, core, noc_node_id_reg_addr, sizeof(noc_node_id_val));
         uint32_t x = noc_node_id_val & 0x3F;
         uint32_t y = (noc_node_id_val >> 6) & 0x3F;
         return tt_xy_pair(x, y);
@@ -81,8 +80,7 @@ TEST(TestNoc, TestNoc1NodeId) {
             cluster->get_tt_device(0)->get_architecture_implementation()->get_noc_reg_base(core.core_type, 1) +
             cluster->get_tt_device(0)->get_architecture_implementation()->get_noc_node_id_offset();
         uint32_t noc_node_id_val;
-        cluster->read_from_device(
-            &noc_node_id_val, chip, core, noc_node_id_reg_addr, sizeof(noc_node_id_val), "REG_TLB");
+        cluster->read_from_device_reg(&noc_node_id_val, chip, core, noc_node_id_reg_addr, sizeof(noc_node_id_val));
         uint32_t x = noc_node_id_val & 0x3F;
         uint32_t y = (noc_node_id_val >> 6) & 0x3F;
         return tt_xy_pair(x, y);

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -173,18 +173,16 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //                     vector_to_write.data(),
 //                     vector_to_write.size() * sizeof(std::uint32_t),
 //                     tt_cxy_pair(i, core),
-//                     dynamic_write_address,
-//                     "SMALL_READ_WRITE_TLB");
+//                     dynamic_write_address);
 //                 cluster.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 
-//                 test_utils::read_data_from_device(cluster, readback_vec, tt_cxy_pair(i, core), address, 40, "");
+//                 test_utils::read_data_from_device(cluster, readback_vec, tt_cxy_pair(i, core), address, 40);
 //                 test_utils::read_data_from_device(
 //                     cluster,
 //                     dynamic_readback_vec,
 //                     tt_cxy_pair(i, core),
 //                     dynamic_write_address,
-//                     40,
-//                     "SMALL_READ_WRITE_TLB");
+//                     40);
 //                 ASSERT_EQ(vector_to_write, readback_vec)
 //                     << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
 //                 ASSERT_EQ(vector_to_write, dynamic_readback_vec)
@@ -195,8 +193,7 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //                     zeros.data(),
 //                     zeros.size() * sizeof(std::uint32_t),
 //                     tt_cxy_pair(i, core),
-//                     dynamic_write_address,
-//                     "SMALL_READ_WRITE_TLB");  // Clear any written data
+//                     dynamic_write_address);  // Clear any written data
 //                 cluster.write_to_device(
 //                     zeros.data(),
 //                     zeros.size() * sizeof(std::uint32_t),
@@ -254,9 +251,9 @@ TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
             std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
             for (int loop = 0; loop < 50; loop++) {
                 for (const CoreCoord& core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
-                    cluster.write_to_device(write_vec.data(), size, i, core, address, "");
+                    cluster.write_to_device(write_vec.data(), size, i, core, address);
                     cluster.wait_for_non_mmio_flush();
-                    cluster.read_from_device(readback_vec.data(), i, core, address, size, "");
+                    cluster.read_from_device(readback_vec.data(), i, core, address, size);
                     ASSERT_EQ(readback_vec, write_vec);
                     readback_vec = std::vector<uint8_t>(size, 0);
                     cluster.write_to_sysmem(write_vec.data(), size, 0, 0, 0);
@@ -313,9 +310,9 @@ TEST(SiliconDriverBH, StaticTLB_RW) {
              loop++) {  // Write to each core a 100 times at different statically mapped addresses
             for (const CoreCoord& core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
                 cluster.write_to_device(
-                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), i, core, address, "");
+                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), i, core, address);
                 cluster.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
-                test_utils::read_data_from_device(cluster, readback_vec, i, core, address, 40, "");
+                test_utils::read_data_from_device(cluster, readback_vec, i, core, address, 40);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.str() << " does not match what was written";
                 cluster.wait_for_non_mmio_flush();
@@ -324,8 +321,7 @@ TEST(SiliconDriverBH, StaticTLB_RW) {
                     zeros.size() * sizeof(std::uint32_t),
                     i,
                     core,
-                    address,
-                    "SMALL_READ_WRITE_TLB");  // Clear any written data
+                    address);  // Clear any written data
                 cluster.wait_for_non_mmio_flush();
                 readback_vec = {};
             }
@@ -358,19 +354,13 @@ TEST(SiliconDriverBH, DynamicTLB_RW) {
              loop++) {  // Write to each core a 100 times at different statically mapped addresses
             for (const CoreCoord& core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
                 cluster.write_to_device(
-                    vector_to_write.data(),
-                    vector_to_write.size() * sizeof(std::uint32_t),
-                    i,
-                    core,
-                    address,
-                    "SMALL_READ_WRITE_TLB");
+                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), i, core, address);
                 cluster.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
-                test_utils::read_data_from_device(cluster, readback_vec, i, core, address, 40, "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(cluster, readback_vec, i, core, address, 40);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.str() << " does not match what was written";
                 cluster.wait_for_non_mmio_flush();
-                cluster.write_to_device(
-                    zeros.data(), zeros.size() * sizeof(std::uint32_t), i, core, address, "SMALL_READ_WRITE_TLB");
+                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), i, core, address);
                 cluster.wait_for_non_mmio_flush();
                 readback_vec = {};
             }
@@ -390,20 +380,13 @@ TEST(SiliconDriverBH, DynamicTLB_RW) {
                 std::vector<CoreCoord> chan = cluster.get_soc_descriptor(i).get_dram_cores().at(ch);
                 CoreCoord subchan = chan.at(0);
                 cluster.write_to_device(
-                    vector_to_write.data(),
-                    vector_to_write.size() * sizeof(std::uint32_t),
-                    i,
-                    subchan,
-                    address,
-                    "SMALL_READ_WRITE_TLB");
+                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), i, subchan, address);
                 cluster.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
-                test_utils::read_data_from_device(
-                    cluster, readback_vec, i, subchan, address, 40, "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(cluster, readback_vec, i, subchan, address, 40);
                 ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from core " << subchan.x << "-"
                                                          << subchan.y << "does not match what was written";
                 cluster.wait_for_non_mmio_flush();
-                cluster.write_to_device(
-                    zeros.data(), zeros.size() * sizeof(std::uint32_t), i, subchan, address, "SMALL_READ_WRITE_TLB");
+                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), i, subchan, address);
                 cluster.wait_for_non_mmio_flush();
                 readback_vec = {};
                 address += 0x20;  // Increment by uint32_t size for each write
@@ -436,13 +419,8 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
         for (int loop = 0; loop < 100; loop++) {
             for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 cluster.write_to_device(
-                    vector_to_write.data(),
-                    vector_to_write.size() * sizeof(std::uint32_t),
-                    0,
-                    core,
-                    address,
-                    "SMALL_READ_WRITE_TLB");
-                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 40, "SMALL_READ_WRITE_TLB");
+                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), 0, core, address);
+                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 40);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.str() << " does not match what was written";
                 readback_vec = {};
@@ -459,14 +437,8 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
             for (int loop = 0; loop < 100; loop++) {
                 for (const CoreCoord& core : core_ls) {
                     cluster.write_to_device(
-                        vector_to_write.data(),
-                        vector_to_write.size() * sizeof(std::uint32_t),
-                        0,
-                        core,
-                        address,
-                        "SMALL_READ_WRITE_TLB");
-                    test_utils::read_data_from_device(
-                        cluster, readback_vec, 0, core, address, 40, "SMALL_READ_WRITE_TLB");
+                        vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), 0, core, address);
+                    test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 40);
                     ASSERT_EQ(vector_to_write, readback_vec)
                         << "Vector read back from core " << core.str() << " does not match what was written";
                     readback_vec = {};
@@ -514,7 +486,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     std::vector<uint32_t> readback_membar_vec = {};
     for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
         test_utils::read_data_from_device(
-            cluster, readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
+            cluster, readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all workers
         readback_membar_vec = {};
@@ -522,7 +494,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
 
     for (int chan = 0; chan < cluster.get_soc_descriptor(0).get_num_dram_channels(); chan++) {
         CoreCoord core = cluster.get_soc_descriptor(0).get_dram_core_for_channel(chan, 0, CoordSystem::VIRTUAL);
-        test_utils::read_data_from_device(cluster, readback_membar_vec, 0, core, 0, 4, "SMALL_READ_WRITE_TLB");
+        test_utils::read_data_from_device(cluster, readback_membar_vec, 0, core, 0, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all DRAM
         readback_membar_vec = {};
@@ -530,13 +502,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
 
     for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::ETH)) {
         test_utils::read_data_from_device(
-            cluster,
-            readback_membar_vec,
-            0,
-            core,
-            eth_l1_mem::address_map::ERISC_BARRIER_BASE,
-            4,
-            "SMALL_READ_WRITE_TLB");
+            cluster, readback_membar_vec, 0, core, eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0),
             187);  // Ensure that memory barriers were correctly initialized on all ethernet cores
@@ -560,11 +526,11 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
         for (int loop = 0; loop < 50; loop++) {
             for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 std::vector<uint32_t> readback_vec = {};
-                cluster.write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), 0, core, address, "");
-                cluster.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
-                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec1.size(), "");
+                cluster.write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), 0, core, address);
+                cluster.l1_membar(0, {core});
+                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec1.size());
                 ASSERT_EQ(readback_vec, vec1);
-                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address, "");
+                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address);
                 readback_vec = {};
             }
         }
@@ -575,11 +541,11 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
         for (int loop = 0; loop < 50; loop++) {
             for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 std::vector<uint32_t> readback_vec = {};
-                cluster.write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), 0, core, address, "");
-                cluster.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
-                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec2.size(), "");
+                cluster.write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), 0, core, address);
+                cluster.l1_membar(0, {core});
+                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec2.size());
                 ASSERT_EQ(readback_vec, vec2);
-                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address, "");
+                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address);
                 readback_vec = {};
             }
         }
@@ -590,7 +556,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
 
     for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
         test_utils::read_data_from_device(
-            cluster, readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
+            cluster, readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers end up in the correct sate for workers
         readback_membar_vec = {};
@@ -598,13 +564,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
 
     for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::ETH)) {
         test_utils::read_data_from_device(
-            cluster,
-            readback_membar_vec,
-            0,
-            core,
-            eth_l1_mem::address_map::ERISC_BARRIER_BASE,
-            4,
-            "SMALL_READ_WRITE_TLB");
+            cluster, readback_membar_vec, 0, core, eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0),
             187);  // Ensure that memory barriers end up in the correct sate for ethernet cores
@@ -643,13 +603,7 @@ TEST(SiliconDriverBH, DISABLED_BroadcastWrite) {  // Cannot broadcast to tensix/
         }
         // Broadcast to Tensix
         cluster.broadcast_write_to_cluster(
-            vector_to_write.data(),
-            vector_to_write.size() * 4,
-            address,
-            {},
-            rows_to_exclude,
-            cols_to_exclude,
-            "LARGE_WRITE_TLB");
+            vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude);
         cluster.wait_for_non_mmio_flush();  // flush here so we don't simultaneously broadcast to DRAM?
         // Broadcast to DRAM
         cluster.broadcast_write_to_cluster(
@@ -658,8 +612,7 @@ TEST(SiliconDriverBH, DISABLED_BroadcastWrite) {  // Cannot broadcast to tensix/
             address,
             {},
             rows_to_exclude_for_dram_broadcast,
-            cols_to_exclude_for_dram_broadcast,
-            "LARGE_WRITE_TLB");
+            cols_to_exclude_for_dram_broadcast);
         cluster.wait_for_non_mmio_flush();
 
         for (const auto i : target_devices) {
@@ -667,31 +620,29 @@ TEST(SiliconDriverBH, DISABLED_BroadcastWrite) {  // Cannot broadcast to tensix/
                 if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
                     continue;
                 }
-                test_utils::read_data_from_device(
-                    cluster, readback_vec, i, core, address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                test_utils::read_data_from_device(cluster, readback_vec, i, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.str() << " does not match what was broadcasted";
                 cluster.write_to_device(
                     zeros.data(),
                     zeros.size() * sizeof(std::uint32_t),
-                    tt_cxy_pair(i, core),
-                    address,
-                    "LARGE_WRITE_TLB");  // Clear any written data
+                    i,
+                    core,
+                    address);  // Clear any written data
                 readback_vec = {};
             }
             for (int chan = 0; chan < cluster.get_soc_descriptor(i).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
                     cluster.get_soc_descriptor(i).get_dram_core_for_channel(chan, 0, CoordSystem::VIRTUAL);
-                test_utils::read_data_from_device(
-                    cluster, readback_vec, i, core, address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                test_utils::read_data_from_device(cluster, readback_vec, i, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from DRAM core " << i << " " << core.str()
                                                          << " does not match what was broadcasted " << size;
                 cluster.write_to_device(
                     zeros.data(),
                     zeros.size() * sizeof(std::uint32_t),
-                    tt_cxy_pair(i, core),
-                    address,
-                    "LARGE_WRITE_TLB");  // Clear any written data
+                    i,
+                    core,
+                    address);  // Clear any written data
                 readback_vec = {};
             }
         }
@@ -739,13 +690,7 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as
         }
         // Broadcast to Tensix
         cluster.broadcast_write_to_cluster(
-            vector_to_write.data(),
-            vector_to_write.size() * 4,
-            address,
-            {},
-            rows_to_exclude,
-            cols_to_exclude,
-            "LARGE_WRITE_TLB");
+            vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude);
         // Broadcast to DRAM
         cluster.broadcast_write_to_cluster(
             vector_to_write.data(),
@@ -753,8 +698,7 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as
             address,
             {},
             rows_to_exclude_for_dram_broadcast,
-            cols_to_exclude_for_dram_broadcast,
-            "LARGE_WRITE_TLB");
+            cols_to_exclude_for_dram_broadcast);
         cluster.wait_for_non_mmio_flush();
 
         for (const auto i : target_devices) {
@@ -762,8 +706,7 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as
                 if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
                     continue;
                 }
-                test_utils::read_data_from_device(
-                    cluster, readback_vec, i, core, address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                test_utils::read_data_from_device(cluster, readback_vec, i, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.str() << " does not match what was broadcasted";
                 cluster.write_to_device(
@@ -771,15 +714,13 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as
                     zeros.size() * sizeof(std::uint32_t),
                     i,
                     core,
-                    address,
-                    "LARGE_WRITE_TLB");  // Clear any written data
+                    address);  // Clear any written data
                 readback_vec = {};
             }
             for (int chan = 0; chan < cluster.get_soc_descriptor(i).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
                     cluster.get_soc_descriptor(i).get_dram_core_for_channel(chan, 0, CoordSystem::VIRTUAL);
-                test_utils::read_data_from_device(
-                    cluster, readback_vec, i, core, address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                test_utils::read_data_from_device(cluster, readback_vec, i, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from DRAM core " << i << " " << core.str()
                                                          << " does not match what was broadcasted " << size;
                 cluster.write_to_device(
@@ -787,8 +728,7 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as
                     zeros.size() * sizeof(std::uint32_t),
                     i,
                     core,
-                    address,
-                    "LARGE_WRITE_TLB");  // Clear any written data
+                    address);  // Clear any written data
                 readback_vec = {};
             }
         }
@@ -917,7 +857,7 @@ TEST(SiliconDriverBH, RandomSysmemTestWithPcie) {
             ASSERT_EQ(address % ALIGNMENT, 0) << "Address not properly aligned";
 
             uint32_t value = 0;
-            cluster.read_from_device(&value, mmio_chip_id, pcie_core, noc_addr, sizeof(uint32_t), "LARGE_READ_TLB");
+            cluster.read_from_device(&value, mmio_chip_id, pcie_core, noc_addr, sizeof(uint32_t));
 
             uint32_t expected = *reinterpret_cast<uint32_t*>(&sysmem[sysmem_address]);
             ASSERT_EQ(value, expected) << fmt::format("Mismatch at address {:#x}", address);

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -755,7 +755,6 @@ TEST(SiliconDriverBH, SysmemTestWithPcie) {
 
     const chip_id_t mmio_chip_id = 0;
     const auto PCIE = cluster.get_soc_descriptor(mmio_chip_id).get_cores(CoreType::PCIE).at(0);
-    const tt_cxy_pair PCIE_CORE(mmio_chip_id, PCIE.x, PCIE.y);
     const size_t test_size_bytes = 0x4000;  // Arbitrarilly chosen, but small size so the test runs quickly.
 
     uint8_t* sysmem = (uint8_t*)cluster.host_dma_address(0, 0, 0);
@@ -770,7 +769,7 @@ TEST(SiliconDriverBH, SysmemTestWithPcie) {
     test_utils::fill_with_random_bytes(sysmem, test_size_bytes);
 
     // Step 2: Read sysmem into buffer.
-    cluster.read_from_device(&buffer[0], PCIE_CORE, base_address, buffer.size(), "REG_TLB");
+    cluster.read_from_device(&buffer[0], mmio_chip_id, PCIE, base_address, buffer.size());
 
     // Step 3: Verify that buffer matches sysmem.
     ASSERT_EQ(buffer, std::vector<uint8_t>(sysmem, sysmem + test_size_bytes));
@@ -779,12 +778,12 @@ TEST(SiliconDriverBH, SysmemTestWithPcie) {
     test_utils::fill_with_random_bytes(&buffer[0], test_size_bytes);
 
     // Step 5: Write buffer into sysmem, overwriting what was there.
-    cluster.write_to_device(&buffer[0], buffer.size(), PCIE_CORE, base_address, "REG_TLB");
+    cluster.write_to_device(&buffer[0], buffer.size(), mmio_chip_id, PCIE, base_address);
 
     // Step 5b: Read back sysmem into a throwaway buffer.  The intent is to
     // ensure the write has completed before we check sysmem against buffer.
     std::vector<uint8_t> throwaway(test_size_bytes, 0x0);
-    cluster.read_from_device(&throwaway[0], PCIE_CORE, base_address, throwaway.size(), "REG_TLB");
+    cluster.read_from_device(&throwaway[0], mmio_chip_id, PCIE, base_address, throwaway.size());
 
     // Step 6: Verify that sysmem matches buffer.
     ASSERT_EQ(buffer, std::vector<uint8_t>(sysmem, sysmem + test_size_bytes));

--- a/tests/galaxy/test_galaxy_common.cpp
+++ b/tests/galaxy/test_galaxy_common.cpp
@@ -15,15 +15,13 @@ void move_data(
         sender_core.chip,
         device.get_soc_descriptor(sender_core.chip).get_coord_at(sender_core.core, CoordSystem::VIRTUAL),
         sender_core.addr,
-        size,
-        "SMALL_READ_WRITE_TLB");
+        size);
     device.write_to_device(
         readback_vec.data(),
         readback_vec.size() * sizeof(std::uint32_t),
         receiver_core.chip,
         device.get_soc_descriptor(receiver_core.chip).get_coord_at(receiver_core.core, CoordSystem::VIRTUAL),
-        receiver_core.addr,
-        "SMALL_READ_WRITE_TLB");
+        receiver_core.addr);
     device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 
     return;
@@ -41,16 +39,14 @@ void broadcast_data(
         sender_core.chip,
         device.get_soc_descriptor(sender_core.chip).get_coord_at(sender_core.core, CoordSystem::VIRTUAL),
         sender_core.addr,
-        size,
-        "SMALL_READ_WRITE_TLB");
+        size);
     for (const auto& receiver_core : receiver_cores) {
         device.write_to_device(
             readback_vec.data(),
             readback_vec.size() * sizeof(std::uint32_t),
             receiver_core.chip,
             device.get_soc_descriptor(receiver_core.chip).get_coord_at(receiver_core.core, CoordSystem::VIRTUAL),
-            receiver_core.addr,
-            "SMALL_READ_WRITE_TLB");
+            receiver_core.addr);
     }
     device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 

--- a/tests/galaxy/test_umd_concurrent_threads.cpp
+++ b/tests/galaxy/test_umd_concurrent_threads.cpp
@@ -72,15 +72,13 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
                     vector_to_write_th1.size() * sizeof(std::uint32_t),
                     chip,
                     core,
-                    address,
-                    "SMALL_READ_WRITE_TLB");
+                    address);
             }
         }
         device.wait_for_non_mmio_flush();
         for (auto& chip : target_devices_th1) {
             for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
-                test_utils::read_data_from_device(
-                    device, readback_vec, chip, core, address, write_size, "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(device, readback_vec, chip, core, address, write_size);
                 EXPECT_EQ(vector_to_write_th1, readback_vec)
                     << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 readback_vec = {};
@@ -99,15 +97,13 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
                     vector_to_write_th2.size() * sizeof(std::uint32_t),
                     chip,
                     core,
-                    address,
-                    "SMALL_READ_WRITE_TLB");
+                    address);
             }
         }
         device.wait_for_non_mmio_flush();
         for (const auto& chip : target_devices_th2) {
             for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
-                test_utils::read_data_from_device(
-                    device, readback_vec, chip, core, address, write_size, "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(device, readback_vec, chip, core, address, write_size);
                 EXPECT_EQ(vector_to_write_th2, readback_vec)
                     << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 readback_vec = {};
@@ -166,19 +162,13 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
         for (const auto& chip : target_devices_th1) {
             for (const CoreCoord& core : device.get_soc_descriptor(0).get_cores(CoreType::DRAM)) {
                 device.write_to_device(
-                    vector_to_write.data(),
-                    vector_to_write.size() * sizeof(std::uint32_t),
-                    chip,
-                    core,
-                    address,
-                    "SMALL_READ_WRITE_TLB");
+                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), chip, core, address);
             }
         }
         device.wait_for_non_mmio_flush();
         for (const auto& chip : target_devices_th1) {
             for (const CoreCoord& core : device.get_soc_descriptor(0).get_cores(CoreType::DRAM)) {
-                test_utils::read_data_from_device(
-                    device, readback_vec, chip, core, address, write_size, "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(device, readback_vec, chip, core, address, write_size);
                 EXPECT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from dram core " << core.str() << " does not match what was written";
                 readback_vec = {};
@@ -192,19 +182,13 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
         for (const auto& chip : target_devices_th2) {
             for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
                 device.write_to_device(
-                    vector_to_write.data(),
-                    vector_to_write.size() * sizeof(std::uint32_t),
-                    chip,
-                    core,
-                    address,
-                    "SMALL_READ_WRITE_TLB");
+                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), chip, core, address);
             }
         }
         device.wait_for_non_mmio_flush();
         for (const auto& chip : target_devices_th2) {
             for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
-                test_utils::read_data_from_device(
-                    device, readback_vec, chip, core, address, write_size, "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(device, readback_vec, chip, core, address, write_size);
                 EXPECT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from dram core " << core.str() << " does not match what was written";
                 readback_vec = {};
@@ -252,16 +236,14 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
             large_vector.size() * sizeof(std::uint32_t),
             mmio_chip,
             CoreCoord(0, 0, CoreType::DRAM, CoordSystem::PHYSICAL),
-            address,
-            "SMALL_READ_WRITE_TLB");
+            address);
         test_utils::read_data_from_device(
             device,
             readback_vec,
             mmio_chip,
             CoreCoord(0, 0, CoreType::DRAM, CoordSystem::PHYSICAL),
             address,
-            large_vector.size() * 4,
-            "SMALL_READ_WRITE_TLB");
+            large_vector.size() * 4);
         EXPECT_EQ(large_vector, readback_vec) << "Vector read back from dram core "
                                               << "0-0"
                                               << "does not match what was written";
@@ -273,19 +255,13 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
         for (const auto& chip : target_devices) {
             for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
                 device.write_to_device(
-                    small_vector.data(),
-                    small_vector.size() * sizeof(std::uint32_t),
-                    chip,
-                    core,
-                    address,
-                    "SMALL_READ_WRITE_TLB");
+                    small_vector.data(), small_vector.size() * sizeof(std::uint32_t), chip, core, address);
             }
         }
         device.wait_for_non_mmio_flush();
         for (const auto& chip : target_devices) {
             for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
-                test_utils::read_data_from_device(
-                    device, readback_vec, chip, core, address, small_vector.size() * 4, "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(device, readback_vec, chip, core, address, small_vector.size() * 4);
                 EXPECT_EQ(small_vector, readback_vec)
                     << "Vector read back from core " << core.str() << " does not match what was written";
                 readback_vec = {};

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -59,12 +59,7 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
             for (const CoreCoord& core : target_cores) {
                 auto start = std::chrono::high_resolution_clock::now();
                 device.write_to_device(
-                    vector_to_write.data(),
-                    vector_to_write.size() * sizeof(std::uint32_t),
-                    chip,
-                    core,
-                    address,
-                    "SMALL_READ_WRITE_TLB");
+                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), chip, core, address);
                 device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
                 auto end = std::chrono::high_resolution_clock::now();
                 auto duration = double(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
@@ -72,8 +67,7 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
                 // std::cout << "  chip " << chip << " core " << target_core.str() << " " << duration << std::endl;
 
                 start = std::chrono::high_resolution_clock::now();
-                test_utils::read_data_from_device(
-                    device, readback_vec, chip, core, address, write_size, "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(device, readback_vec, chip, core, address, write_size);
                 end = std::chrono::high_resolution_clock::now();
                 duration = double(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
                 // std::cout << " read chip " << chip << " core " << target_core.str()<< " " << duration << std::endl;
@@ -166,8 +160,7 @@ void run_data_mover_test(
         vector_to_write.size() * sizeof(std::uint32_t),
         sender_core.chip,
         sender_core.core,
-        sender_core.addr,
-        "SMALL_READ_WRITE_TLB");
+        sender_core.addr);
     device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 
     // Send data from sender core to receiver core
@@ -180,13 +173,7 @@ void run_data_mover_test(
 
     // Verify data is correct in receiver core
     test_utils::read_data_from_device(
-        device,
-        readback_vec,
-        receiver_core.chip,
-        receiver_core.core,
-        receiver_core.addr,
-        write_size,
-        "SMALL_READ_WRITE_TLB");
+        device, readback_vec, receiver_core.chip, receiver_core.core, receiver_core.addr, write_size);
     EXPECT_EQ(vector_to_write, readback_vec)
         << "Vector read back from core " << receiver_core.str() << " does not match what was written";
 
@@ -287,8 +274,7 @@ void run_data_broadcast_test(
         vector_to_write.size() * sizeof(std::uint32_t),
         sender_core.chip,
         sender_core.core,
-        sender_core.addr,
-        "SMALL_READ_WRITE_TLB");
+        sender_core.addr);
     device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 
     // Send data from sender core to receiver core
@@ -302,13 +288,7 @@ void run_data_broadcast_test(
     // Verify data is correct in receiver core
     for (const auto& receiver_core : receiver_cores) {
         test_utils::read_data_from_device(
-            device,
-            readback_vec,
-            receiver_core.chip,
-            receiver_core.core,
-            receiver_core.addr,
-            write_size,
-            "SMALL_READ_WRITE_TLB");
+            device, readback_vec, receiver_core.chip, receiver_core.core, receiver_core.addr, write_size);
         EXPECT_EQ(vector_to_write, readback_vec)
             << "Vector read back from core " << receiver_core.str() << " does not match what was written";
         readback_vec = {};

--- a/tests/microbenchmark/test_rw_tensix.cpp
+++ b/tests/microbenchmark/test_rw_tensix.cpp
@@ -33,12 +33,7 @@ TEST_F(uBenchmarkFixture, WriteAllCores32Bytes) {
             .output(nullptr)
             .run(wname.str(), [&] {
                 device->write_to_device(
-                    vector_to_write.data(),
-                    vector_to_write.size() * sizeof(std::uint32_t),
-                    0,
-                    core_coord,
-                    bad_address,
-                    "SMALL_READ_WRITE_TLB");
+                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), 0, core_coord, bad_address);
             });
         wname.clear();
     }
@@ -62,8 +57,7 @@ TEST_F(uBenchmarkFixture, ReadAllCores32Bytes) {
             .minEpochIterations(50)
             .output(nullptr)
             .run(rname.str(), [&] {
-                test_utils::read_data_from_device(
-                    *device, readback_vec, 0, core_coord, bad_address, 0x20, "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(*device, readback_vec, 0, core_coord, bad_address, 0x20);
             });
         rname.clear();
     }
@@ -88,12 +82,7 @@ TEST_F(uBenchmarkFixture, Write32BytesRandomAddr) {
             .output(nullptr)
             .run(wname.str(), [&] {
                 device->write_to_device(
-                    vector_to_write.data(),
-                    vector_to_write.size() * sizeof(std::uint32_t),
-                    0,
-                    core_coord,
-                    address,
-                    "SMALL_READ_WRITE_TLB");
+                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), 0, core_coord, address);
             });
         wname.clear();
     }
@@ -116,8 +105,7 @@ TEST_F(uBenchmarkFixture, Read32BytesRandomAddr) {
             .minEpochIterations(50)
             .output(nullptr)
             .run(rname.str(), [&] {
-                test_utils::read_data_from_device(
-                    *device, readback_vec, 0, core_coord, address, 0x20, "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(*device, readback_vec, 0, core_coord, address, 0x20);
             });
         rname.clear();
     }

--- a/tests/simulation/test_simulation_device.cpp
+++ b/tests/simulation/test_simulation_device.cpp
@@ -20,37 +20,43 @@ std::vector<uint32_t> generate_data(uint32_t size_in_bytes) {
     return data;
 }
 
-class LoopbackAllCoresParam : public SimulationDeviceFixture, public ::testing::WithParamInterface<tt_xy_pair> {};
+class LoopbackAllCoresParam : public SimulationDeviceFixture,
+                              public ::testing::WithParamInterface<tt::umd::CoreCoord> {};
 
 INSTANTIATE_TEST_SUITE_P(
-    LoopbackAllCores, LoopbackAllCoresParam, ::testing::Values(tt_xy_pair{0, 1}, tt_xy_pair{1, 1}, tt_xy_pair{1, 0}));
+    LoopbackAllCores,
+    LoopbackAllCoresParam,
+    ::testing::Values(
+        tt::umd::CoreCoord{0, 1, CoreType::TENSIX, CoordSystem::VIRTUAL},
+        tt::umd::CoreCoord{1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL},
+        tt::umd::CoreCoord{1, 0, CoreType::DRAM, CoordSystem::VIRTUAL}));
 
 TEST_P(LoopbackAllCoresParam, LoopbackSingleTensix) {
     std::vector<uint32_t> wdata = {1, 2, 3, 4, 5};
     std::vector<uint32_t> rdata(wdata.size(), 0);
-    tt_cxy_pair core = {0, GetParam()};
+    tt::umd::CoreCoord core = GetParam();
 
-    device->write_to_device(wdata.data(), wdata.size() * sizeof(uint32_t), core, 0x100, "");
-    device->read_from_device(rdata.data(), core, 0x100, rdata.size() * sizeof(uint32_t), "");
+    device->write_to_device(wdata.data(), wdata.size() * sizeof(uint32_t), 0, core, 0x100);
+    device->read_from_device(rdata.data(), 0, core, 0x100, rdata.size() * sizeof(uint32_t));
 
     ASSERT_EQ(wdata, rdata);
 }
 
-bool loopback_stress_size(std::unique_ptr<tt_SimulationDevice> &device, tt_xy_pair core, uint32_t byte_shift) {
+bool loopback_stress_size(std::unique_ptr<tt_SimulationDevice> &device, tt::umd::CoreCoord core, uint32_t byte_shift) {
     uint64_t addr = 0x0;
 
     std::vector<uint32_t> wdata = generate_data(1 << byte_shift);
     std::vector<uint32_t> rdata(wdata.size(), 0);
 
-    device->write_to_device(wdata.data(), wdata.size() * sizeof(uint32_t), tt_cxy_pair{0, core}, addr, "");
-    device->read_from_device(rdata.data(), tt_cxy_pair{0, core}, addr, rdata.size() * sizeof(uint32_t), "");
+    device->write_to_device(wdata.data(), wdata.size() * sizeof(uint32_t), 0, core, addr);
+    device->read_from_device(rdata.data(), 0, core, addr, rdata.size() * sizeof(uint32_t));
 
     return wdata == rdata;
 }
 
 TEST_P(LoopbackAllCoresParam, LoopbackStressSize) {
-    tt_xy_pair core = GetParam();
-    tt_xy_pair dram = {1, 0};
+    tt::umd::CoreCoord core = GetParam();
+    tt::umd::CoreCoord dram = {1, 0, CoreType::DRAM, CoordSystem::VIRTUAL};
     if (core == dram) {
         for (uint32_t i = 2; i <= 30; ++i) {  // 2^30 = 1 GB
             ASSERT_TRUE(loopback_stress_size(device, core, i));
@@ -67,14 +73,14 @@ TEST_F(SimulationDeviceFixture, LoopbackTwoTensix) {
     std::vector<uint32_t> wdata2 = {6, 7, 8, 9, 10};
     std::vector<uint32_t> rdata1(wdata1.size());
     std::vector<uint32_t> rdata2(wdata2.size());
-    tt_cxy_pair core1 = {0, 0, 1};
-    tt_cxy_pair core2 = {0, 1, 1};
+    tt::umd::CoreCoord core1 = {0, 1, CoreType::TENSIX, CoordSystem::VIRTUAL};
+    tt::umd::CoreCoord core2 = {1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL};
 
-    device->write_to_device(wdata1.data(), wdata1.size() * sizeof(uint32_t), core1, 0x100, "");
-    device->write_to_device(wdata2.data(), wdata2.size() * sizeof(uint32_t), core2, 0x100, "");
+    device->write_to_device(wdata1.data(), wdata1.size() * sizeof(uint32_t), 0, core1, 0x100);
+    device->write_to_device(wdata2.data(), wdata2.size() * sizeof(uint32_t), 0, core2, 0x100);
 
-    device->read_from_device(rdata1.data(), core1, 0x100, rdata1.size() * sizeof(uint32_t), "");
-    device->read_from_device(rdata2.data(), core2, 0x100, rdata2.size() * sizeof(uint32_t), "");
+    device->read_from_device(rdata1.data(), 0, core1, 0x100, rdata1.size() * sizeof(uint32_t));
+    device->read_from_device(rdata2.data(), 0, core2, 0x100, rdata2.size() * sizeof(uint32_t));
 
     ASSERT_EQ(wdata1, rdata1);
     ASSERT_EQ(wdata2, rdata2);

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -30,10 +30,9 @@ static void read_data_from_device(
     chip_id_t chip_id,
     tt::umd::CoreCoord core,
     uint64_t addr,
-    uint32_t size,
-    const std::string& tlb_to_use) {
+    uint32_t size) {
     size_buffer_to_capacity(vec, size);
-    device.read_from_device(vec.data(), chip_id, core, addr, size, tlb_to_use);
+    device.read_from_device(vec.data(), chip_id, core, addr, size);
 }
 
 inline void fill_with_random_bytes(uint8_t* data, size_t n) {

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -168,19 +168,17 @@ TEST(SiliconDriverWH, HarvestingRuntime) {
              loop++) {  // Write to each core a 100 times at different statically mapped addresses
             for (const CoreCoord& core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
                 cluster.write_to_device(
-                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), i, core, address, "");
+                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), i, core, address);
                 cluster.write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
                     i,
                     core,
-                    dynamic_write_address,
-                    "SMALL_READ_WRITE_TLB");
+                    dynamic_write_address);
                 cluster.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 
-                test_utils::read_data_from_device(cluster, readback_vec, i, core, address, 40, "");
-                test_utils::read_data_from_device(
-                    cluster, dynamic_readback_vec, i, core, dynamic_write_address, 40, "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(cluster, readback_vec, i, core, address, 40);
+                test_utils::read_data_from_device(cluster, dynamic_readback_vec, i, core, dynamic_write_address, 40);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.str() << " does not match what was written";
                 ASSERT_EQ(vector_to_write, dynamic_readback_vec)
@@ -192,15 +190,13 @@ TEST(SiliconDriverWH, HarvestingRuntime) {
                     zeros.size() * sizeof(std::uint32_t),
                     i,
                     core,
-                    dynamic_write_address,
-                    "SMALL_READ_WRITE_TLB");  // Clear any written data
+                    dynamic_write_address);  // Clear any written data
                 cluster.write_to_device(
                     zeros.data(),
                     zeros.size() * sizeof(std::uint32_t),
                     i,
                     core,
-                    address,
-                    "");  // Clear any written data
+                    address);  // Clear any written data
                 cluster.wait_for_non_mmio_flush();
                 readback_vec = {};
                 dynamic_readback_vec = {};
@@ -252,9 +248,9 @@ TEST(SiliconDriverWH, UnalignedStaticTLB_RW) {
             std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
             for (int loop = 0; loop < 50; loop++) {
                 for (const CoreCoord& core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
-                    cluster.write_to_device(write_vec.data(), size, i, core, address, "");
+                    cluster.write_to_device(write_vec.data(), size, i, core, address);
                     cluster.wait_for_non_mmio_flush();
-                    cluster.read_from_device(readback_vec.data(), i, core, address, size, "");
+                    cluster.read_from_device(readback_vec.data(), i, core, address, size);
                     ASSERT_EQ(readback_vec, write_vec);
                     readback_vec = std::vector<uint8_t>(size, 0);
                     cluster.write_to_sysmem(write_vec.data(), size, 0, 0, 0);
@@ -308,10 +304,10 @@ TEST(SiliconDriverWH, StaticTLB_RW) {
         for (int loop = 0; loop < 100; loop++) {
             for (const CoreCoord& core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
                 cluster.write_to_device(
-                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), i, core, address, "");
+                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), i, core, address);
                 // Barrier to ensure that all writes over ethernet were commited
                 cluster.wait_for_non_mmio_flush();
-                test_utils::read_data_from_device(cluster, readback_vec, i, core, address, 40, "");
+                test_utils::read_data_from_device(cluster, readback_vec, i, core, address, 40);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.str() << " does not match what was written";
                 cluster.wait_for_non_mmio_flush();
@@ -320,8 +316,7 @@ TEST(SiliconDriverWH, StaticTLB_RW) {
                     zeros.size() * sizeof(std::uint32_t),
                     i,
                     core,
-                    address,
-                    "SMALL_READ_WRITE_TLB");  // Clear any written data
+                    address);  // Clear any written data
                 cluster.wait_for_non_mmio_flush();
                 readback_vec = {};
             }
@@ -354,20 +349,14 @@ TEST(SiliconDriverWH, DynamicTLB_RW) {
         for (int loop = 0; loop < 100; loop++) {
             for (const CoreCoord& core : cluster.get_soc_descriptor(i).get_cores(CoreType::TENSIX)) {
                 cluster.write_to_device(
-                    vector_to_write.data(),
-                    vector_to_write.size() * sizeof(std::uint32_t),
-                    i,
-                    core,
-                    address,
-                    "SMALL_READ_WRITE_TLB");
+                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), i, core, address);
                 // Barrier to ensure that all writes over ethernet were commited
                 cluster.wait_for_non_mmio_flush();
-                test_utils::read_data_from_device(cluster, readback_vec, i, core, address, 40, "SMALL_READ_WRITE_TLB");
+                test_utils::read_data_from_device(cluster, readback_vec, i, core, address, 40);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.str() << " does not match what was written";
                 cluster.wait_for_non_mmio_flush();
-                cluster.write_to_device(
-                    zeros.data(), zeros.size() * sizeof(std::uint32_t), i, core, address, "SMALL_READ_WRITE_TLB");
+                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), i, core, address);
                 cluster.wait_for_non_mmio_flush();
                 readback_vec = {};
             }
@@ -398,13 +387,8 @@ TEST(SiliconDriverWH, MultiThreadedDevice) {
         for (int loop = 0; loop < 100; loop++) {
             for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 cluster.write_to_device(
-                    vector_to_write.data(),
-                    vector_to_write.size() * sizeof(std::uint32_t),
-                    0,
-                    core,
-                    address,
-                    "SMALL_READ_WRITE_TLB");
-                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 40, "SMALL_READ_WRITE_TLB");
+                    vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), 0, core, address);
+                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 40);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.str() << " does not match what was written";
                 readback_vec = {};
@@ -421,14 +405,8 @@ TEST(SiliconDriverWH, MultiThreadedDevice) {
             for (int loop = 0; loop < 100; loop++) {
                 for (const CoreCoord& core : core_ls) {
                     cluster.write_to_device(
-                        vector_to_write.data(),
-                        vector_to_write.size() * sizeof(std::uint32_t),
-                        0,
-                        core,
-                        address,
-                        "SMALL_READ_WRITE_TLB");
-                    test_utils::read_data_from_device(
-                        cluster, readback_vec, 0, core, address, 40, "SMALL_READ_WRITE_TLB");
+                        vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), 0, core, address);
+                    test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 40);
                     ASSERT_EQ(vector_to_write, readback_vec)
                         << "Vector read back from core " << core.str() << " does not match what was written";
                     readback_vec = {};
@@ -480,7 +458,7 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     std::vector<uint32_t> readback_membar_vec = {};
     for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
         test_utils::read_data_from_device(
-            cluster, readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
+            cluster, readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all workers
         readback_membar_vec = {};
@@ -488,7 +466,7 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
 
     for (int chan = 0; chan < cluster.get_soc_descriptor(0).get_num_dram_channels(); chan++) {
         CoreCoord core = cluster.get_soc_descriptor(0).get_dram_core_for_channel(chan, 0, CoordSystem::VIRTUAL);
-        test_utils::read_data_from_device(cluster, readback_membar_vec, 0, core, 0, 4, "SMALL_READ_WRITE_TLB");
+        test_utils::read_data_from_device(cluster, readback_membar_vec, 0, core, 0, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all DRAM
         readback_membar_vec = {};
@@ -496,13 +474,7 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
 
     for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::ETH)) {
         test_utils::read_data_from_device(
-            cluster,
-            readback_membar_vec,
-            0,
-            core,
-            eth_l1_mem::address_map::ERISC_BARRIER_BASE,
-            4,
-            "SMALL_READ_WRITE_TLB");
+            cluster, readback_membar_vec, 0, core, eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0),
             187);  // Ensure that memory barriers were correctly initialized on all ethernet cores
@@ -526,11 +498,11 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
         for (int loop = 0; loop < 50; loop++) {
             for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 std::vector<uint32_t> readback_vec = {};
-                cluster.write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), 0, core, address, "");
-                cluster.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
-                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec1.size(), "");
+                cluster.write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), 0, core, address);
+                cluster.l1_membar(0, {core});
+                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec1.size());
                 ASSERT_EQ(readback_vec, vec1);
-                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address, "");
+                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address);
                 readback_vec = {};
             }
         }
@@ -541,11 +513,11 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
         for (int loop = 0; loop < 50; loop++) {
             for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 std::vector<uint32_t> readback_vec = {};
-                cluster.write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), 0, core, address, "");
-                cluster.l1_membar(0, "SMALL_READ_WRITE_TLB", {core});
-                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec2.size(), "");
+                cluster.write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), 0, core, address);
+                cluster.l1_membar(0, {core});
+                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec2.size());
                 ASSERT_EQ(readback_vec, vec2);
-                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address, "");
+                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address);
                 readback_vec = {};
             }
         }
@@ -556,7 +528,7 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
 
     for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
         test_utils::read_data_from_device(
-            cluster, readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4, "SMALL_READ_WRITE_TLB");
+            cluster, readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers end up in the correct sate for workers
         readback_membar_vec = {};
@@ -564,13 +536,7 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
 
     for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::ETH)) {
         test_utils::read_data_from_device(
-            cluster,
-            readback_membar_vec,
-            0,
-            core,
-            eth_l1_mem::address_map::ERISC_BARRIER_BASE,
-            4,
-            "SMALL_READ_WRITE_TLB");
+            cluster, readback_membar_vec, 0, core, eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0),
             187);  // Ensure that memory barriers end up in the correct sate for ethernet cores
@@ -608,13 +574,7 @@ TEST(SiliconDriverWH, BroadcastWrite) {
         }
         // Broadcast to Tensix
         cluster.broadcast_write_to_cluster(
-            vector_to_write.data(),
-            vector_to_write.size() * 4,
-            address,
-            {},
-            rows_to_exclude,
-            cols_to_exclude,
-            "LARGE_WRITE_TLB");
+            vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude);
         // Broadcast to DRAM
         cluster.broadcast_write_to_cluster(
             vector_to_write.data(),
@@ -622,8 +582,7 @@ TEST(SiliconDriverWH, BroadcastWrite) {
             address,
             {},
             rows_to_exclude_for_dram_broadcast,
-            cols_to_exclude_for_dram_broadcast,
-            "LARGE_WRITE_TLB");
+            cols_to_exclude_for_dram_broadcast);
         cluster.wait_for_non_mmio_flush();
 
         for (const auto i : target_devices) {
@@ -631,8 +590,7 @@ TEST(SiliconDriverWH, BroadcastWrite) {
                 if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
                     continue;
                 }
-                test_utils::read_data_from_device(
-                    cluster, readback_vec, i, core, address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                test_utils::read_data_from_device(cluster, readback_vec, i, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.str() << " does not match what was broadcasted";
                 cluster.write_to_device(
@@ -640,15 +598,13 @@ TEST(SiliconDriverWH, BroadcastWrite) {
                     zeros.size() * sizeof(std::uint32_t),
                     i,
                     core,
-                    address,
-                    "LARGE_WRITE_TLB");  // Clear any written data
+                    address);  // Clear any written data
                 readback_vec = {};
             }
             for (int chan = 0; chan < cluster.get_soc_descriptor(i).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
                     cluster.get_soc_descriptor(i).get_dram_core_for_channel(chan, 0, CoordSystem::VIRTUAL);
-                test_utils::read_data_from_device(
-                    cluster, readback_vec, i, core, address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                test_utils::read_data_from_device(cluster, readback_vec, i, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from DRAM core " << i << " " << core.str()
                                                          << " does not match what was broadcasted " << size;
                 cluster.write_to_device(
@@ -656,8 +612,7 @@ TEST(SiliconDriverWH, BroadcastWrite) {
                     zeros.size() * sizeof(std::uint32_t),
                     i,
                     core,
-                    address,
-                    "LARGE_WRITE_TLB");  // Clear any written data
+                    address);  // Clear any written data
                 readback_vec = {};
             }
         }
@@ -705,13 +660,7 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
         }
         // Broadcast to Tensix
         cluster.broadcast_write_to_cluster(
-            vector_to_write.data(),
-            vector_to_write.size() * 4,
-            address,
-            {},
-            rows_to_exclude,
-            cols_to_exclude,
-            "LARGE_WRITE_TLB");
+            vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude);
         // Broadcast to DRAM
         cluster.broadcast_write_to_cluster(
             vector_to_write.data(),
@@ -719,8 +668,7 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
             address,
             {},
             rows_to_exclude_for_dram_broadcast,
-            cols_to_exclude_for_dram_broadcast,
-            "LARGE_WRITE_TLB");
+            cols_to_exclude_for_dram_broadcast);
         cluster.wait_for_non_mmio_flush();
 
         for (const auto i : target_devices) {
@@ -732,8 +680,7 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
                 if (rows_to_exclude.find(virtual_core.y) != rows_to_exclude.end()) {
                     continue;
                 }
-                test_utils::read_data_from_device(
-                    cluster, readback_vec, i, core, address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                test_utils::read_data_from_device(cluster, readback_vec, i, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.str() << " does not match what was broadcasted";
                 cluster.write_to_device(
@@ -741,15 +688,13 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
                     zeros.size() * sizeof(std::uint32_t),
                     i,
                     core,
-                    address,
-                    "LARGE_WRITE_TLB");  // Clear any written data
+                    address);  // Clear any written data
                 readback_vec = {};
             }
             for (int chan = 0; chan < cluster.get_soc_descriptor(i).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
                     cluster.get_soc_descriptor(i).get_dram_core_for_channel(chan, 0, CoordSystem::VIRTUAL);
-                test_utils::read_data_from_device(
-                    cluster, readback_vec, i, core, address, vector_to_write.size() * 4, "LARGE_READ_TLB");
+                test_utils::read_data_from_device(cluster, readback_vec, i, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(vector_to_write, readback_vec) << "Vector read back from DRAM core " << i << " " << core.str()
                                                          << " does not match what was broadcasted " << size;
                 cluster.write_to_device(
@@ -757,8 +702,7 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
                     zeros.size() * sizeof(std::uint32_t),
                     i,
                     core,
-                    address,
-                    "LARGE_WRITE_TLB");  // Clear any written data
+                    address);  // Clear any written data
                 readback_vec = {};
             }
         }
@@ -869,7 +813,6 @@ TEST(SiliconDriverWH, RandomSysmemTestWithPcie) {
 
     const chip_id_t mmio_chip_id = 0;
     const auto PCIE = cluster.get_soc_descriptor(mmio_chip_id).get_cores(CoreType::PCIE).at(0);
-    const tt_cxy_pair PCIE_CORE(mmio_chip_id, PCIE.x, PCIE.y);
     const size_t ONE_GIG = 1 << 30;
     const size_t num_tests = 0x20000;  // runs in a reasonable amount of time
 
@@ -913,7 +856,7 @@ TEST(SiliconDriverWH, RandomSysmemTestWithPcie) {
             ASSERT_EQ(address % ALIGNMENT, 0) << "Address not properly aligned";
 
             uint32_t value = 0;
-            cluster.read_from_device(&value, PCIE_CORE, noc_addr, sizeof(uint32_t), "LARGE_READ_TLB");
+            cluster.read_from_device(&value, mmio_chip_id, PCIE, noc_addr, sizeof(uint32_t));
 
             uint32_t expected = *reinterpret_cast<uint32_t*>(&sysmem[sysmem_address]);
             ASSERT_EQ(value, expected) << fmt::format("Mismatch at address {:#x}", address);
@@ -932,8 +875,7 @@ TEST(SiliconDriverWH, LargeAddressTlb) {
         true,   // clean system resources - yes
         true);  // perform harvesting - yes
 
-    const tt_xy_pair ARC_CORE = cluster.get_soc_descriptor(0).get_cores(CoreType::ARC).at(0);
-    const tt_cxy_pair ARC_CORE_CHIP(0, ARC_CORE.x, ARC_CORE.y);
+    const CoreCoord ARC_CORE = cluster.get_soc_descriptor(0).get_cores(CoreType::ARC).at(0);
 
     set_barrier_params(cluster);
     cluster.start_device(tt_device_params{});
@@ -960,10 +902,10 @@ TEST(SiliconDriverWH, LargeAddressTlb) {
     value0 = cluster.get_chip(0)->get_tt_device()->bar_read32(0x1ff30060);
 
     // Read the scratch register via the TLB:
-    cluster.read_from_device(&value1, ARC_CORE_CHIP, addr, sizeof(uint32_t), "LARGE_READ_TLB");
+    cluster.read_from_device(&value1, 0, ARC_CORE, addr, sizeof(uint32_t));
 
     // Read the scratch register via a different TLB, different code path:
-    cluster.read_from_device(&value2, ARC_CORE_CHIP, addr, sizeof(uint32_t), "REG_TLB");
+    cluster.read_from_device(&value2, 0, ARC_CORE, addr, sizeof(uint32_t));
 
     // Mask off lower 16 bits; FW changes these dynamically:
     value0 &= 0xffff0000;
@@ -1155,7 +1097,7 @@ TEST(SiliconDriverWH, DMA2) {
 
             // Perform the DMA write.
             auto now = std::chrono::steady_clock::now();
-            cluster.write_to_device(pattern.data(), pattern.size(), chip, dram_core, addr, "LARGE_WRITE_TLB");
+            cluster.write_to_device(pattern.data(), pattern.size(), chip, dram_core, addr);
             auto end = std::chrono::steady_clock::now();
             auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
             print_speed("MMIO: Host -> Device", pattern.size(), ns);

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -747,7 +747,6 @@ TEST(SiliconDriverWH, SysmemTestWithPcie) {
 
     const chip_id_t mmio_chip_id = 0;
     const auto PCIE = cluster.get_soc_descriptor(mmio_chip_id).get_cores(CoreType::PCIE).at(0);
-    const tt_cxy_pair PCIE_CORE(mmio_chip_id, PCIE.x, PCIE.y);
     const size_t test_size_bytes = 0x4000;  // Arbitrarilly chosen, but small size so the test runs quickly.
 
     // PCIe core is at (x=0, y=3) on Wormhole NOC0.
@@ -772,7 +771,7 @@ TEST(SiliconDriverWH, SysmemTestWithPcie) {
     test_utils::fill_with_random_bytes(sysmem, test_size_bytes);
 
     // Step 2: Read sysmem into buffer.
-    cluster.read_from_device(&buffer[0], PCIE_CORE, base_address, buffer.size(), "REG_TLB");
+    cluster.read_from_device(&buffer[0], mmio_chip_id, PCIE, base_address, buffer.size());
 
     // Step 3: Verify that buffer matches sysmem.
     ASSERT_EQ(buffer, std::vector<uint8_t>(sysmem, sysmem + test_size_bytes));
@@ -781,12 +780,12 @@ TEST(SiliconDriverWH, SysmemTestWithPcie) {
     test_utils::fill_with_random_bytes(&buffer[0], test_size_bytes);
 
     // Step 5: Write buffer into sysmem, overwriting what was there.
-    cluster.write_to_device(&buffer[0], buffer.size(), PCIE_CORE, base_address, "REG_TLB");
+    cluster.write_to_device(&buffer[0], buffer.size(), mmio_chip_id, PCIE, base_address);
 
     // Step 5b: Read back sysmem into a throwaway buffer.  The intent is to
     // ensure the write has completed before we check sysmem against buffer.
     std::vector<uint8_t> throwaway(test_size_bytes, 0x0);
-    cluster.read_from_device(&throwaway[0], PCIE_CORE, base_address, throwaway.size(), "REG_TLB");
+    cluster.read_from_device(&throwaway[0], mmio_chip_id, PCIE, base_address, throwaway.size());
 
     // Step 6: Verify that sysmem matches buffer.
     ASSERT_EQ(buffer, std::vector<uint8_t>(sysmem, sysmem + test_size_bytes));

--- a/tests/wormhole/test_remote_communication_wh.cpp
+++ b/tests/wormhole/test_remote_communication_wh.cpp
@@ -57,12 +57,7 @@ TEST(RemoteCommunicationWormhole, BasicRemoteCommunicationIO) {
                 data_to_write.size() * sizeof(uint32_t));
 
             cluster->write_to_device(
-                data_to_write.data(),
-                data_to_write.size() * sizeof(uint32_t),
-                remote_chip_id,
-                core,
-                address1,
-                "SMALL_READ_WRITE_TLB");
+                data_to_write.data(), data_to_write.size() * sizeof(uint32_t), remote_chip_id, core, address1);
 
             remote_comm->wait_for_non_mmio_flush();
 
@@ -79,12 +74,7 @@ TEST(RemoteCommunicationWormhole, BasicRemoteCommunicationIO) {
             data_read = std::vector<uint32_t>(10, 0);
 
             cluster->read_from_device(
-                data_read.data(),
-                remote_chip_id,
-                core,
-                address0,
-                data_read.size() * sizeof(uint32_t),
-                "SMALL_READ_WRITE_TLB");
+                data_read.data(), remote_chip_id, core, address0, data_read.size() * sizeof(uint32_t));
 
             ASSERT_EQ(data_to_write, data_read)
                 << "Vector read back from core " << core.str() << " does not match what was written";


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/737

### Description
Removing fallback_tlbs from all tests, all calls to UMD api

### List of the changes
- Remove all fallback_tlbs from test when write/read to device and membars
- Changed simulation tests to use CoreCoord
- Added membar to multiprocess tests where needed.

### Testing
Existing CI tests

### API Changes
There are no API changes in this PR.
