### PR TITLE
Remove fallback tlb from API

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -47,19 +47,15 @@ public:
 
     // TODO: Currently works only for Local and not for Remote.
     // Both write and read cores are defined in VIRTUAL coords.
-    virtual void write_to_device(
-        tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size, const std::string& fallback_tlb);
-    virtual void read_from_device(
-        tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size, const std::string& fallback_tlb);
+    virtual void write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size);
+    virtual void read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size);
 
     // Will only ever work for LocalChip.
     virtual void dma_write_to_device(const void* src, size_t size, tt_xy_pair core, uint64_t addr);
     virtual void dma_read_from_device(void* dst, size_t size, tt_xy_pair core, uint64_t addr);
 
-    virtual void write_to_device_reg(
-        tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size, const std::string& fallback_tlb);
-    virtual void read_from_device_reg(
-        tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size, const std::string& fallback_tlb);
+    virtual void write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size);
+    virtual void read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size);
 
     virtual void wait_for_non_mmio_flush();
 

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -43,18 +43,14 @@ public:
     void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) override;
     void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) override;
 
-    void write_to_device(
-        tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size, const std::string& fallback_tlb) override;
-    void read_from_device(
-        tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size, const std::string& fallback_tlb) override;
+    void write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) override;
+    void read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) override;
 
     void dma_write_to_device(const void* src, size_t size, tt_xy_pair core, uint64_t addr) override;
     void dma_read_from_device(void* dst, size_t size, tt_xy_pair core, uint64_t addr) override;
 
-    void write_to_device_reg(
-        tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size, const std::string& fallback_tlb) override;
-    void read_from_device_reg(
-        tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size, const std::string& fallback_tlb) override;
+    void write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size) override;
+    void read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size) override;
 
     void ethernet_broadcast_write(
         const void* src, uint64_t core_dest, uint32_t size, std::vector<int> broadcast_header);

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -19,10 +19,8 @@ public:
 
     void start_device() override;
 
-    void write_to_device(
-        tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size, const std::string& fallback_tlb) override;
-    void read_from_device(
-        tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size, const std::string& fallback_tlb) override;
+    void write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) override;
+    void read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) override;
 
     void wait_for_non_mmio_flush() override;
 

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -234,15 +234,9 @@ public:
      * @param chip Chip to target.
      * @param core Core to target.
      * @param addr Address to write to.
-     * @param tlb_to_use Specifies fallback/dynamic TLB to use.
      */
     virtual void write_to_device(
-        const void* mem_ptr,
-        uint32_t size_in_bytes,
-        chip_id_t chip,
-        tt::umd::CoreCoord core,
-        uint64_t addr,
-        const std::string& tlb_to_use = "LARGE_WRITE_TLB") {
+        const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) {
         throw std::runtime_error("---- tt_device::write_to_device is not implemented\n");
     }
 
@@ -277,7 +271,6 @@ public:
      * @param chips_to_exclude Chips to exclude from the broadcast.
      * @param rows_to_exclude  NOC0 rows to exclude from the broadcast.
      * @param columns_to_exclude NOC0 columns to exclude from the broadcast.
-     * @param fallback_tlb Specifies fallback/dynamic TLB to use.
      */
     virtual void broadcast_write_to_cluster(
         const void* mem_ptr,
@@ -285,8 +278,7 @@ public:
         uint64_t address,
         const std::set<chip_id_t>& chips_to_exclude,
         std::set<uint32_t>& rows_to_exclude,
-        std::set<uint32_t>& columns_to_exclude,
-        const std::string& fallback_tlb = "LARGE_WRITE_TLB") {
+        std::set<uint32_t>& columns_to_exclude) {
         throw std::runtime_error("---- tt_device::broadcast_write_to_cluster is not implemented\n");
     }
 
@@ -300,15 +292,9 @@ public:
      * @param core Core to target.
      * @param addr Address to read from.
      * @param size Number of bytes to read.
-     * @param fallback_tlb Specifies fallback/dynamic TLB to use.
      */
     virtual void read_from_device(
-        void* mem_ptr,
-        chip_id_t chip,
-        tt::umd::CoreCoord core,
-        uint64_t addr,
-        uint32_t size,
-        const std::string& fallback_tlb = "LARGE_READ_TLB") {
+        void* mem_ptr, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr, uint32_t size) {
         throw std::runtime_error("---- tt_device::read_from_device is not implemented\n");
     }
 
@@ -393,22 +379,6 @@ public:
      * completed.
      *
      * @param chip Chip to target.
-     * @param flackback_tlb Specifies fallback/dynamic TLB to use.
-     * @param cores Cores being targeted.
-     */
-    virtual void l1_membar(
-        const chip_id_t chip,
-        const std::string& fallback_tlb,
-        const std::unordered_set<tt::umd::CoreCoord>& cores = {}) {
-        throw std::runtime_error("---- tt_device::l1_membar is not implemented\n");
-    }
-
-    /**
-     * Tensix L1 memory barrier.
-     * This should be called when the client wants to ensure that all transactions on the L1 of the specified cores have
-     * completed.
-     *
-     * @param chip Chip to target.
      * @param cores Cores being targeted.
      */
     virtual void l1_membar(const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores = {}) {
@@ -421,39 +391,9 @@ public:
      * completed.
      *
      * @param chip Chip to target.
-     * @param flackback_tlb Specifies fallback/dynamic TLB to use.
-     * @param channels Channels being targeted.
-     */
-    virtual void dram_membar(
-        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels = {}) {
-        throw std::runtime_error("---- tt_device::dram_membar is not implemented\n");
-    }
-
-    /**
-     * DRAM memory barrier.
-     * This should be called when the client wants to ensure that all transactions on the specified dram bank have
-     * completed.
-     *
-     * @param chip Chip to target.
      * @param channels Channels being targeted.
      */
     virtual void dram_membar(const chip_id_t chip, const std::unordered_set<uint32_t>& channels = {}) {
-        throw std::runtime_error("---- tt_device::dram_membar is not implemented\n");
-    }
-
-    /**
-     * DRAM memory barrier.
-     * This should be called when the client wants to ensure that all transactions on the specified dram bank have
-     * completed.
-     *
-     * @param chip Chip being targeted.
-     * @param flackback_tlb Specifies fallback/dynamic TLB to use.
-     * @param cores Cores being targeted.
-     */
-    virtual void dram_membar(
-        const chip_id_t chip,
-        const std::string& fallback_tlb,
-        const std::unordered_set<tt::umd::CoreCoord>& cores = {}) {
         throw std::runtime_error("---- tt_device::dram_membar is not implemented\n");
     }
 
@@ -810,8 +750,7 @@ public:
         tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET);
     virtual void assert_risc_reset_at_core(
         tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET);
-    virtual void write_to_device(
-        const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use);
+    virtual void write_to_device(const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr);
     // TODO: Add CoreCoord API for this function.
     void broadcast_write_to_cluster(
         const void* mem_ptr,
@@ -819,10 +758,8 @@ public:
         uint64_t address,
         const std::set<chip_id_t>& chips_to_exclude,
         std::set<uint32_t>& rows_to_exclude,
-        std::set<uint32_t>& columns_to_exclude,
-        const std::string& fallback_tlb = "LARGE_WRITE_TLB");
-    virtual void read_from_device(
-        void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
+        std::set<uint32_t>& columns_to_exclude);
+    virtual void read_from_device(void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size);
 
     /**
      * If the tlbs are initialized, returns a tuple with the TLB base address and its size
@@ -863,21 +800,10 @@ public:
         const tt::umd::CoreCoord core,
         const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET);
     virtual void write_to_device(
-        const void* mem_ptr,
-        uint32_t size_in_bytes,
-        chip_id_t chip,
-        tt::umd::CoreCoord core,
-        uint64_t addr,
-        const std::string& tlb_to_use = "LARGE_WRITE_TLB");
+        const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr);
     virtual void write_to_device_reg(
         const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr);
-    virtual void read_from_device(
-        void* mem_ptr,
-        chip_id_t chip,
-        tt::umd::CoreCoord core,
-        uint64_t addr,
-        uint32_t size,
-        const std::string& fallback_tlb = "LARGE_READ_TLB");
+    virtual void read_from_device(void* mem_ptr, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr, uint32_t size);
     virtual void read_from_device_reg(
         void* mem_ptr, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr, uint32_t size);
     virtual void dma_write_to_device(
@@ -889,14 +815,8 @@ public:
     tt::Writer get_static_tlb_writer(const chip_id_t chip, const tt::umd::CoreCoord target);
     virtual void configure_active_ethernet_cores_for_mmio_device(
         chip_id_t mmio_chip, const std::unordered_set<CoreCoord>& active_eth_cores_per_chip);
-    void l1_membar(
-        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<CoreCoord>& cores = {});
     void l1_membar(const chip_id_t chip, const std::unordered_set<CoreCoord>& cores = {});
-    void dram_membar(
-        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<CoreCoord>& cores = {});
     void dram_membar(const chip_id_t chip, const std::unordered_set<CoreCoord>& cores = {});
-    void dram_membar(
-        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels);
     void dram_membar(const chip_id_t chip, const std::unordered_set<uint32_t>& channels);
     void set_power_state(tt_DevicePowerState state);
 
@@ -929,12 +849,7 @@ private:
     void wait_for_aiclk_value(tt_DevicePowerState power_state, const uint32_t timeout_ms = 5000);
 
     // Communication Functions
-    void write_device_memory(
-        const void* mem_ptr,
-        uint32_t size_in_bytes,
-        tt_cxy_pair target,
-        uint64_t address,
-        const std::string& fallback_tlb);
+    void write_device_memory(const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair target, uint64_t address);
     void write_to_non_mmio_device(
         const void* mem_ptr,
         uint32_t size_in_bytes,
@@ -942,13 +857,10 @@ private:
         uint64_t address,
         bool broadcast = false,
         std::vector<int> broadcast_header = {});
-    void read_device_memory(
-        void* mem_ptr, tt_cxy_pair target, uint64_t address, uint32_t size_in_bytes, const std::string& fallback_tlb);
+    void read_device_memory(void* mem_ptr, tt_cxy_pair target, uint64_t address, uint32_t size_in_bytes);
     void read_from_non_mmio_device(void* mem_ptr, tt_cxy_pair core, uint64_t address, uint32_t size_in_bytes);
-    void read_mmio_device_register(
-        void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
-    void write_mmio_device_register(
-        const void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
+    void read_mmio_device_register(void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size);
+    void write_mmio_device_register(const void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size);
     void ethernet_broadcast_write(
         const void* mem_ptr,
         uint32_t size_in_bytes,
@@ -956,19 +868,14 @@ private:
         const std::set<chip_id_t>& chips_to_exclude,
         const std::set<uint32_t>& rows_to_exclude,
         std::set<uint32_t>& cols_to_exclude,
-        const std::string& fallback_tlb,
         bool use_virtual_coords);
     void set_membar_flag(
         const chip_id_t chip,
         const std::vector<CoreCoord>& cores,
         const uint32_t barrier_value,
-        const uint32_t barrier_addr,
-        const std::string& fallback_tlb);
+        const uint32_t barrier_addr);
     void insert_host_to_device_barrier(
-        const chip_id_t chip,
-        const std::vector<CoreCoord>& cores,
-        const uint32_t barrier_addr,
-        const std::string& fallback_tlb);
+        const chip_id_t chip, const std::vector<CoreCoord>& cores, const uint32_t barrier_addr);
     void init_membars();
 
     std::unordered_map<chip_id_t, std::vector<std::vector<int>>>& get_ethernet_broadcast_headers(

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -55,24 +55,11 @@ public:
     virtual void close_device();
 
     // Runtime Functions
+    virtual void write_to_device(const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr);
     virtual void write_to_device(
-        const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use);
-    virtual void write_to_device(
-        const void* mem_ptr,
-        uint32_t size_in_bytes,
-        chip_id_t chip,
-        tt::umd::CoreCoord core,
-        uint64_t addr,
-        const std::string& tlb_to_use = "LARGE_WRITE_TLB");
-    virtual void read_from_device(
-        void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb);
-    virtual void read_from_device(
-        void* mem_ptr,
-        chip_id_t chip,
-        tt::umd::CoreCoord core,
-        uint64_t addr,
-        uint32_t size,
-        const std::string& fallback_tlb = "LARGE_READ_TLB");
+        const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr);
+    virtual void read_from_device(void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size);
+    virtual void read_from_device(void* mem_ptr, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr, uint32_t size);
 
     void dma_write_to_device(const void* src, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) {
         throw std::runtime_error("DMA write not supported in simulation mode.");
@@ -84,16 +71,9 @@ public:
 
     virtual void wait_for_non_mmio_flush();
     virtual void wait_for_non_mmio_flush(const chip_id_t chip);
-    void l1_membar(
-        const chip_id_t chip,
-        const std::string& fallback_tlb,
-        const std::unordered_set<tt::umd::CoreCoord>& cores = {});
-    void dram_membar(
-        const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels);
-    void dram_membar(
-        const chip_id_t chip,
-        const std::string& fallback_tlb,
-        const std::unordered_set<tt::umd::CoreCoord>& cores = {});
+    void l1_membar(const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores = {});
+    void dram_membar(const chip_id_t chip, const std::unordered_set<uint32_t>& channels);
+    void dram_membar(const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores = {});
 
     // Misc. Functions to Query/Set Device State
     static std::vector<chip_id_t> detect_available_device_ids();

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -80,13 +80,11 @@ void Chip::read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, u
     throw std::runtime_error("Chip::read_from_sysmem is not available for this chip.");
 }
 
-void Chip::write_to_device(
-    tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size, const std::string& fallback_tlb) {
+void Chip::write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) {
     throw std::runtime_error("Chip::write_to_device is not available for this chip.");
 }
 
-void Chip::read_from_device(
-    tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size, const std::string& fallback_tlb) {
+void Chip::read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) {
     throw std::runtime_error("Chip::read_from_device is not available for this chip.");
 }
 
@@ -98,13 +96,11 @@ void Chip::dma_read_from_device(void* dst, size_t size, tt_xy_pair core, uint64_
     throw std::runtime_error("Chip::dma_read_from_device is not available for this chip.");
 }
 
-void Chip::write_to_device_reg(
-    tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size, const std::string& fallback_tlb) {
+void Chip::write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size) {
     throw std::runtime_error("Chip::write_to_device_reg is not available for this chip.");
 }
 
-void Chip::read_from_device_reg(
-    tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size, const std::string& fallback_tlb) {
+void Chip::read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size) {
     throw std::runtime_error("Chip::read_from_device_reg is not available for this chip.");
 }
 

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -156,8 +156,7 @@ void LocalChip::read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_s
     sysmem_manager_->read_from_sysmem(channel, dest, sysmem_src, size);
 }
 
-void LocalChip::write_to_device(
-    tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size, const std::string& fallback_tlb) {
+void LocalChip::write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) {
     const uint8_t* buffer_addr = static_cast<const uint8_t*>(src);
 
     log_debug(
@@ -180,6 +179,7 @@ void LocalChip::write_to_device(
             tt_device_->write_block(tlb_description.tlb_offset + l1_dest % tlb_description.size, size, buffer_addr);
         }
     } else {
+        std::string fallback_tlb = "LARGE_WRITE_TLB";
         const auto tlb_index = tlb_manager_->dynamic_tlb_config_.at(fallback_tlb);
         auto lock = acquire_mutex(fallback_tlb, tt_device_->get_pci_device()->get_device_num());
 
@@ -200,8 +200,7 @@ void LocalChip::write_to_device(
     }
 }
 
-void LocalChip::read_from_device(
-    tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size, const std::string& fallback_tlb) {
+void LocalChip::read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) {
     log_debug(
         LogSiliconDriver,
         "Chip::read_from_device from pci device {} core {}-{} at 0x{:x} size: {}",
@@ -228,6 +227,7 @@ void LocalChip::read_from_device(
             tlb_description.tlb_offset,
             tlb_description.size);
     } else {
+        std::string fallback_tlb = "LARGE_READ_TLB";
         const auto tlb_index = tlb_manager_->dynamic_tlb_config_.at(fallback_tlb);
         auto lock = acquire_mutex(fallback_tlb, tt_device_->get_pci_device()->get_device_num());
         log_debug(LogSiliconDriver, "  dynamic tlb_index: {}", tlb_index);
@@ -294,8 +294,7 @@ void LocalChip::dma_read_from_device(void* dst, size_t size, tt_xy_pair core, ui
     }
 }
 
-void LocalChip::write_to_device_reg(
-    tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size, const std::string& fallback_tlb) {
+void LocalChip::write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size) {
     if (size % sizeof(uint32_t) != 0) {
         throw std::runtime_error("Size must be a multiple of 4 bytes");
     }
@@ -304,6 +303,7 @@ void LocalChip::write_to_device_reg(
         throw std::runtime_error("Register address must be 4-byte aligned");
     }
 
+    std::string fallback_tlb = "REG_TLB";
     const auto tlb_index = tlb_manager_->dynamic_tlb_config_.at(fallback_tlb);
     auto lock = lock_manager_.acquire_mutex(fallback_tlb, tt_device_->get_pci_device()->get_device_num());
     log_debug(LogSiliconDriver, "  dynamic tlb_index: {}", tlb_index);
@@ -313,8 +313,7 @@ void LocalChip::write_to_device_reg(
     tt_device_->write_regs(mapped_address, size / sizeof(uint32_t), src);
 }
 
-void LocalChip::read_from_device_reg(
-    tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size, const std::string& fallback_tlb) {
+void LocalChip::read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size) {
     if (size % sizeof(uint32_t) != 0) {
         throw std::runtime_error("Size must be a multiple of 4 bytes");
     }
@@ -323,6 +322,7 @@ void LocalChip::read_from_device_reg(
         throw std::runtime_error("Register address must be 4-byte aligned");
     }
 
+    std::string fallback_tlb = "REG_TLB";
     const auto tlb_index = tlb_manager_->dynamic_tlb_config_.at(fallback_tlb);
     auto lock = lock_manager_.acquire_mutex(fallback_tlb, tt_device_->get_pci_device()->get_device_num());
     log_debug(LogSiliconDriver, "  dynamic tlb_index: {}", tlb_index);

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -16,21 +16,21 @@ namespace tt::umd {
 RemoteChip::RemoteChip(tt_SocDescriptor soc_descriptor, eth_coord_t eth_chip_location, LocalChip* local_chip) :
     Chip(soc_descriptor),
     eth_chip_location_(eth_chip_location),
-    remote_communication_(std::make_unique<RemoteCommunication>(local_chip)) {}
+    remote_communication_(std::make_unique<RemoteCommunication>(local_chip)) {
+    log_assert(soc_descriptor_.arch != tt::ARCH::BLACKHOLE, "Non-MMIO targets not supported in Blackhole");
+}
 
 bool RemoteChip::is_mmio_capable() const { return false; }
 
 void RemoteChip::start_device() {}
 
-void RemoteChip::write_to_device(
-    tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size, const std::string& fallback_tlb) {
+void RemoteChip::write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) {
     // TODO: Fallback TLB is ignored for now, but it will be removed soon from the signature.
     auto translated_core = translate_chip_coord_virtual_to_translated(core);
     remote_communication_->write_to_non_mmio(eth_chip_location_, translated_core, src, l1_dest, size);
 }
 
-void RemoteChip::read_from_device(
-    tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size, const std::string& fallback_tlb) {
+void RemoteChip::read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) {
     // TODO: Fallback TLB is ignored for now, but it will be removed soon from the signature.
     auto translated_core = translate_chip_coord_virtual_to_translated(core);
     remote_communication_->read_non_mmio(eth_chip_location_, translated_core, dest, l1_src, size);

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -25,13 +25,11 @@ bool RemoteChip::is_mmio_capable() const { return false; }
 void RemoteChip::start_device() {}
 
 void RemoteChip::write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) {
-    // TODO: Fallback TLB is ignored for now, but it will be removed soon from the signature.
     auto translated_core = translate_chip_coord_virtual_to_translated(core);
     remote_communication_->write_to_non_mmio(eth_chip_location_, translated_core, src, l1_dest, size);
 }
 
 void RemoteChip::read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) {
-    // TODO: Fallback TLB is ignored for now, but it will be removed soon from the signature.
     auto translated_core = translate_chip_coord_virtual_to_translated(core);
     remote_communication_->read_non_mmio(eth_chip_location_, translated_core, dest, l1_src, size);
 }

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -84,21 +84,21 @@ int RemoteChip::arc_msg(
     uint32_t fw_arg = arg0 | (arg1 << 16);
     int exit_code = 0;
 
-    { write_to_device(arc_core, &fw_arg, ARC_RESET_SCRATCH_ADDR + 3 * 4, sizeof(fw_arg), ""); }
+    { write_to_device(arc_core, &fw_arg, ARC_RESET_SCRATCH_ADDR + 3 * 4, sizeof(fw_arg)); }
 
-    { write_to_device(arc_core, &msg_code, ARC_RESET_SCRATCH_ADDR + 5 * 4, sizeof(fw_arg), ""); }
+    { write_to_device(arc_core, &msg_code, ARC_RESET_SCRATCH_ADDR + 5 * 4, sizeof(fw_arg)); }
 
     wait_for_non_mmio_flush();
     uint32_t misc = 0;
 
-    read_from_device(arc_core, &misc, ARC_RESET_MISC_CNTL_ADDR, 4, "");
+    read_from_device(arc_core, &misc, ARC_RESET_MISC_CNTL_ADDR, 4);
 
     if (misc & (1 << 16)) {
         log_error("trigger_fw_int failed on device");
         return 1;
     } else {
         misc |= (1 << 16);
-        write_to_device(arc_core, &misc, ARC_RESET_MISC_CNTL_ADDR, sizeof(misc), "");
+        write_to_device(arc_core, &misc, ARC_RESET_MISC_CNTL_ADDR, sizeof(misc));
     }
 
     if (wait_for_done) {
@@ -115,14 +115,14 @@ int RemoteChip::arc_msg(
             }
 
             uint32_t status = 0;
-            read_from_device(arc_core, &status, ARC_RESET_SCRATCH_ADDR + 5 * 4, sizeof(status), "");
+            read_from_device(arc_core, &status, ARC_RESET_SCRATCH_ADDR + 5 * 4, sizeof(status));
             if ((status & 0xffff) == (msg_code & 0xff)) {
                 if (return_3 != nullptr) {
-                    read_from_device(arc_core, return_3, ARC_RESET_SCRATCH_ADDR + 3 * 4, sizeof(uint32_t), "");
+                    read_from_device(arc_core, return_3, ARC_RESET_SCRATCH_ADDR + 3 * 4, sizeof(uint32_t));
                 }
 
                 if (return_4 != nullptr) {
-                    read_from_device(arc_core, return_4, ARC_RESET_SCRATCH_ADDR + 4 * 4, sizeof(uint32_t), "");
+                    read_from_device(arc_core, return_4, ARC_RESET_SCRATCH_ADDR + 4 * 4, sizeof(uint32_t));
                 }
 
                 exit_code = (status & 0xffff0000) >> 16;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1230,7 +1230,7 @@ void Cluster::write_to_device(const void* mem_ptr, uint32_t size, tt_cxy_pair co
 
 void Cluster::write_to_device(
     const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, CoreCoord core, uint64_t addr) {
-    get_local_chip(chip)->write_to_device(translate_to_api_coords(chip, core), mem_ptr, addr, size_in_bytes);
+    write_to_device(mem_ptr, size_in_bytes, {(size_t)chip, translate_to_api_coords(chip, core)}, addr);
 }
 
 void Cluster::write_to_device_reg(

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1235,7 +1235,12 @@ void Cluster::write_to_device(
 
 void Cluster::write_to_device_reg(
     const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, CoreCoord core, uint64_t addr) {
-    write_mmio_device_register(mem_ptr, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, size_in_bytes);
+    bool target_is_mmio_capable = cluster_desc->is_chip_mmio_capable(chip);
+    if (target_is_mmio_capable) {
+        write_mmio_device_register(mem_ptr, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, size_in_bytes);
+    } else {
+        write_to_non_mmio_device(mem_ptr, size_in_bytes, {(size_t)chip, translate_to_api_coords(chip, core)}, addr);
+    }
 }
 
 void Cluster::dma_write_to_device(
@@ -1277,7 +1282,12 @@ void Cluster::read_from_device(void* mem_ptr, chip_id_t chip, CoreCoord core, ui
 }
 
 void Cluster::read_from_device_reg(void* mem_ptr, chip_id_t chip, CoreCoord core, uint64_t addr, uint32_t size) {
-    read_mmio_device_register(mem_ptr, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, size);
+    bool target_is_mmio_capable = cluster_desc->is_chip_mmio_capable(chip);
+    if (target_is_mmio_capable) {
+        read_mmio_device_register(mem_ptr, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, size);
+    } else {
+        read_from_non_mmio_device(mem_ptr, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, size);
+    }
 }
 
 int Cluster::arc_msg(

--- a/device/mockup/tt_mockup_device.hpp
+++ b/device/mockup/tt_mockup_device.hpp
@@ -49,12 +49,7 @@ public:
     void wait_for_non_mmio_flush(const chip_id_t chip_id) override {}
 
     void write_to_device(
-        const void* mem_ptr,
-        uint32_t size_in_bytes,
-        chip_id_t chip,
-        tt::umd::CoreCoord core,
-        uint64_t addr,
-        const std::string& tlb_to_use) override {}
+        const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) override {}
 
     void broadcast_write_to_cluster(
         const void* mem_ptr,
@@ -62,16 +57,10 @@ public:
         uint64_t address,
         const std::set<chip_id_t>& chips_to_exclude,
         std::set<uint32_t>& rows_to_exclude,
-        std::set<uint32_t>& columns_to_exclude,
-        const std::string& fallback_tlb) override {}
+        std::set<uint32_t>& columns_to_exclude) override {}
 
     void read_from_device(
-        void* mem_ptr,
-        chip_id_t chip,
-        tt::umd::CoreCoord core,
-        uint64_t addr,
-        uint32_t size,
-        const std::string& fallback_tlb) override {}
+        void* mem_ptr, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr, uint32_t size) override {}
 
     void dma_write_to_device(
         const void* src, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) override {}
@@ -85,20 +74,11 @@ public:
     void read_from_sysmem(
         void* mem_ptr, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id) override {}
 
-    void l1_membar(
-        const chip_id_t chip,
-        const std::string& fallback_tlb,
-        const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override {}
+    void l1_membar(const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override {}
 
-    void dram_membar(
-        const chip_id_t chip,
-        const std::string& fallback_tlb,
-        const std::unordered_set<uint32_t>& channels = {}) override {}
+    void dram_membar(const chip_id_t chip, const std::unordered_set<uint32_t>& channels = {}) override {}
 
-    void dram_membar(
-        const chip_id_t chip,
-        const std::string& fallback_tlb,
-        const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override {}
+    void dram_membar(const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override {}
 
     int arc_msg(
         int logical_device_id,

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -146,7 +146,7 @@ void tt_SimulationDevice::close_device() {
 
 // Runtime Functions
 void tt_SimulationDevice::write_to_device(
-    const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, const std::string& tlb_to_use) {
+    const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr) {
     log_info(
         tt::LogEmulationDriver,
         "Device writing {} bytes to addr {} in core ({}, {})",
@@ -164,17 +164,11 @@ void tt_SimulationDevice::write_to_device(
 }
 
 void tt_SimulationDevice::write_to_device(
-    const void* mem_ptr,
-    uint32_t size_in_bytes,
-    chip_id_t chip,
-    tt::umd::CoreCoord core,
-    uint64_t addr,
-    const std::string& tlb_to_use) {
-    write_to_device(mem_ptr, size_in_bytes, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, tlb_to_use);
+    const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) {
+    write_to_device(mem_ptr, size_in_bytes, {(size_t)chip, translate_to_api_coords(chip, core)}, addr);
 }
 
-void tt_SimulationDevice::read_from_device(
-    void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size, const std::string& fallback_tlb) {
+void tt_SimulationDevice::read_from_device(void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size) {
     void* rd_resp;
 
     // Send read request
@@ -195,27 +189,19 @@ void tt_SimulationDevice::read_from_device(
 }
 
 void tt_SimulationDevice::read_from_device(
-    void* mem_ptr,
-    chip_id_t chip,
-    tt::umd::CoreCoord core,
-    uint64_t addr,
-    uint32_t size,
-    const std::string& fallback_tlb) {
-    read_from_device(mem_ptr, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, size, fallback_tlb);
+    void* mem_ptr, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr, uint32_t size) {
+    read_from_device(mem_ptr, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, size);
 }
 
 void tt_SimulationDevice::wait_for_non_mmio_flush() {}
 
 void tt_SimulationDevice::wait_for_non_mmio_flush(const chip_id_t chip) {}
 
-void tt_SimulationDevice::l1_membar(
-    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt::umd::CoreCoord>& cores) {}
+void tt_SimulationDevice::l1_membar(const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores) {}
 
-void tt_SimulationDevice::dram_membar(
-    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<uint32_t>& channels) {}
+void tt_SimulationDevice::dram_membar(const chip_id_t chip, const std::unordered_set<uint32_t>& channels) {}
 
-void tt_SimulationDevice::dram_membar(
-    const chip_id_t chip, const std::string& fallback_tlb, const std::unordered_set<tt::umd::CoreCoord>& cores) {}
+void tt_SimulationDevice::dram_membar(const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores) {}
 
 // Misc. Functions to Query/Set Device State
 std::vector<chip_id_t> tt_SimulationDevice::detect_available_device_ids() { return {0}; }


### PR DESCRIPTION
### Issue
#737 

### Description
Further efforts in removing fallback_tlbs from API

### List of the changes
- Remove from read/write APIs and membars
- Also for simulation and mock
- Remove fallback_tlbs from all calls
- read/write _reg functions now don't go through read/write device, but to read/write mmio directly.
- The REG_TLB path has been removed from read/write to device functions.
- TLBs are hardcoded inside local chip class.

### Testing
No additional testing

### API Changes
There are API changes  which remove fallback_tlbs, but metal should be prepared for it
- tt_exalens approved PR https://github.com/tenstorrent/tt-exalens/pull/336
