### PR TITLE
Remove surplus read/write cluster functions

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -45,17 +45,15 @@ public:
     virtual void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size);
     virtual void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size);
 
-    // TODO: Currently works only for Local and not for Remote.
     // Both write and read cores are defined in VIRTUAL coords.
-    virtual void write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size);
-    virtual void read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size);
+    virtual void write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) = 0;
+    virtual void read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) = 0;
+    virtual void write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size) = 0;
+    virtual void read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size) = 0;
 
     // Will only ever work for LocalChip.
     virtual void dma_write_to_device(const void* src, size_t size, tt_xy_pair core, uint64_t addr);
     virtual void dma_read_from_device(void* dst, size_t size, tt_xy_pair core, uint64_t addr);
-
-    virtual void write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size);
-    virtual void read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size);
 
     virtual void wait_for_non_mmio_flush();
 

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -45,12 +45,11 @@ public:
 
     void write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) override;
     void read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) override;
+    void write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size) override;
+    void read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size) override;
 
     void dma_write_to_device(const void* src, size_t size, tt_xy_pair core, uint64_t addr) override;
     void dma_read_from_device(void* dst, size_t size, tt_xy_pair core, uint64_t addr) override;
-
-    void write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size) override;
-    void read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size) override;
 
     void ethernet_broadcast_write(
         const void* src, uint64_t core_dest, uint32_t size, std::vector<int> broadcast_header);

--- a/device/api/umd/device/chip/mock_chip.h
+++ b/device/api/umd/device/chip/mock_chip.h
@@ -16,6 +16,12 @@ public:
 
     void start_device() override;
 
+    void write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) override;
+    void read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) override;
+
+    void write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size) override;
+    void read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size) override;
+
     int arc_msg(
         uint32_t msg_code,
         bool wait_for_done,

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -22,6 +22,9 @@ public:
     void write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) override;
     void read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) override;
 
+    void write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size) override;
+    void read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size) override;
+
     void wait_for_non_mmio_flush() override;
 
     int arc_msg(

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -750,7 +750,6 @@ public:
         tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET);
     virtual void assert_risc_reset_at_core(
         tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET);
-    virtual void write_to_device(const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr);
     // TODO: Add CoreCoord API for this function.
     void broadcast_write_to_cluster(
         const void* mem_ptr,
@@ -759,7 +758,6 @@ public:
         const std::set<chip_id_t>& chips_to_exclude,
         std::set<uint32_t>& rows_to_exclude,
         std::set<uint32_t>& columns_to_exclude);
-    virtual void read_from_device(void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size);
 
     /**
      * If the tlbs are initialized, returns a tuple with the TLB base address and its size
@@ -849,18 +847,6 @@ private:
     void wait_for_aiclk_value(tt_DevicePowerState power_state, const uint32_t timeout_ms = 5000);
 
     // Communication Functions
-    void write_device_memory(const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair target, uint64_t address);
-    void write_to_non_mmio_device(
-        const void* mem_ptr,
-        uint32_t size_in_bytes,
-        tt_cxy_pair core,
-        uint64_t address,
-        bool broadcast = false,
-        std::vector<int> broadcast_header = {});
-    void read_device_memory(void* mem_ptr, tt_cxy_pair target, uint64_t address, uint32_t size_in_bytes);
-    void read_from_non_mmio_device(void* mem_ptr, tt_cxy_pair core, uint64_t address, uint32_t size_in_bytes);
-    void read_mmio_device_register(void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size);
-    void write_mmio_device_register(const void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size);
     void ethernet_broadcast_write(
         const void* mem_ptr,
         uint32_t size_in_bytes,

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -80,28 +80,12 @@ void Chip::read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, u
     throw std::runtime_error("Chip::read_from_sysmem is not available for this chip.");
 }
 
-void Chip::write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) {
-    throw std::runtime_error("Chip::write_to_device is not available for this chip.");
-}
-
-void Chip::read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) {
-    throw std::runtime_error("Chip::read_from_device is not available for this chip.");
-}
-
 void Chip::dma_write_to_device(const void* src, size_t size, tt_xy_pair core, uint64_t addr) {
     throw std::runtime_error("Chip::dma_write_to_device is not available for this chip.");
 }
 
 void Chip::dma_read_from_device(void* dst, size_t size, tt_xy_pair core, uint64_t addr) {
     throw std::runtime_error("Chip::dma_read_from_device is not available for this chip.");
-}
-
-void Chip::write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size) {
-    throw std::runtime_error("Chip::write_to_device_reg is not available for this chip.");
-}
-
-void Chip::read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size) {
-    throw std::runtime_error("Chip::read_from_device_reg is not available for this chip.");
 }
 
 void Chip::wait_for_non_mmio_flush() {

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -14,6 +14,14 @@ bool MockChip::is_mmio_capable() const { return false; }
 
 void MockChip::start_device() {}
 
+void MockChip::write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) {}
+
+void MockChip::read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) {}
+
+void MockChip::write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size) {}
+
+void MockChip::read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size) {}
+
 int MockChip::arc_msg(
     uint32_t msg_code,
     bool wait_for_done,

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -34,6 +34,14 @@ void RemoteChip::read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, 
     remote_communication_->read_non_mmio(eth_chip_location_, translated_core, dest, l1_src, size);
 }
 
+void RemoteChip::write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size) {
+    write_to_device(core, src, reg_dest, size);
+}
+
+void RemoteChip::read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size) {
+    read_from_device(core, dest, reg_src, size);
+}
+
 // TODO: This translation should go away when we start using CoreCoord everywhere.
 tt_xy_pair RemoteChip::translate_chip_coord_virtual_to_translated(const tt_xy_pair core) {
     CoreCoord core_coord = get_soc_descriptor().get_coord_at(core, CoordSystem::VIRTUAL);

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -612,10 +612,6 @@ tt::Writer Cluster::get_static_tlb_writer(const chip_id_t chip, const CoreCoord 
     return get_static_tlb_writer({(size_t)chip, translate_to_api_coords(chip, target)});
 }
 
-void Cluster::read_device_memory(void* mem_ptr, tt_cxy_pair target, uint64_t address, uint32_t size_in_bytes) {
-    get_local_chip(target.chip)->read_from_device({target.x, target.y}, mem_ptr, address, size_in_bytes);
-}
-
 uint32_t Cluster::get_power_state_arc_msg(chip_id_t chip_id, tt_DevicePowerState state) {
     TTDevice* tt_device = get_tt_device(chip_id);
     uint32_t msg = wormhole::ARC_MSG_COMMON_PREFIX;
@@ -760,24 +756,6 @@ inline RemoteChip* Cluster::get_remote_chip(chip_id_t device_id) const {
     log_assert(
         remote_chip_ids_.find(device_id) != remote_chip_ids_.end(), "Device id {} is not a remote chip.", device_id);
     return dynamic_cast<RemoteChip*>(get_chip(device_id));
-}
-
-void Cluster::write_to_non_mmio_device(
-    const void* mem_ptr,
-    uint32_t size_in_bytes,
-    tt_cxy_pair core,
-    uint64_t address,
-    bool broadcast,
-    std::vector<int> broadcast_header) {
-    if (broadcast) {
-        get_local_chip(core.chip)->ethernet_broadcast_write(mem_ptr, address, size_in_bytes, broadcast_header);
-    } else {
-        get_remote_chip(core.chip)->write_to_device(core, mem_ptr, address, size_in_bytes);
-    }
-}
-
-void Cluster::read_from_non_mmio_device(void* mem_ptr, tt_cxy_pair core, uint64_t address, uint32_t size_in_bytes) {
-    get_remote_chip(core.chip)->read_from_device(core, mem_ptr, address, size_in_bytes);
 }
 
 void Cluster::wait_for_non_mmio_flush(const chip_id_t chip_id) { get_chip(chip_id)->wait_for_non_mmio_flush(); }
@@ -938,9 +916,7 @@ void Cluster::ethernet_broadcast_write(
                 header.at(4) = use_virtual_coords * 0x8000;  // Reset row/col exclusion masks
                 header.at(4) |= row_exclusion_mask;
                 header.at(4) |= col_exclusion_mask;
-                // Write Target: x-y endpoint is a don't care. Initialize to tt_xy_pair(1, 1)
-                write_to_non_mmio_device(
-                    mem_ptr, size_in_bytes, tt_cxy_pair(mmio_group.first, tt_xy_pair(1, 1)), address, true, header);
+                get_local_chip(mmio_group.first)->ethernet_broadcast_write(mem_ptr, address, size_in_bytes, header);
             }
         }
     } else {
@@ -1215,32 +1191,14 @@ void Cluster::dram_membar(const chip_id_t chip, const std::unordered_set<uint32_
     dram_membar(chip, dram_cores_to_sync);
 }
 
-void Cluster::write_to_device(const void* mem_ptr, uint32_t size, tt_cxy_pair core, uint64_t addr) {
-    bool target_is_mmio_capable = cluster_desc->is_chip_mmio_capable(core.chip);
-    if (target_is_mmio_capable) {
-        get_local_chip(core.chip)->write_to_device({core.x, core.y}, mem_ptr, addr, size);
-    } else {
-        log_assert(arch_name != tt::ARCH::BLACKHOLE, "Non-MMIO targets not supported in Blackhole");
-        log_assert(
-            (get_soc_descriptor(core.chip).get_cores(CoreType::ETH)).size() > 0 && chips_.size() > 1,
-            "Cannot issue ethernet writes to a single chip cluster!");
-        write_to_non_mmio_device(mem_ptr, size, core, addr);
-    }
-}
-
 void Cluster::write_to_device(
     const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, CoreCoord core, uint64_t addr) {
-    write_to_device(mem_ptr, size_in_bytes, {(size_t)chip, translate_to_api_coords(chip, core)}, addr);
+    get_chip(chip)->write_to_device(translate_to_api_coords(chip, core), mem_ptr, addr, size_in_bytes);
 }
 
 void Cluster::write_to_device_reg(
     const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, CoreCoord core, uint64_t addr) {
-    bool target_is_mmio_capable = cluster_desc->is_chip_mmio_capable(chip);
-    if (target_is_mmio_capable) {
-        write_mmio_device_register(mem_ptr, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, size_in_bytes);
-    } else {
-        write_to_non_mmio_device(mem_ptr, size_in_bytes, {(size_t)chip, translate_to_api_coords(chip, core)}, addr);
-    }
+    get_local_chip(chip)->write_to_device_reg(translate_to_api_coords(chip, core), mem_ptr, addr, size_in_bytes);
 }
 
 void Cluster::dma_write_to_device(
@@ -1254,40 +1212,12 @@ void Cluster::dma_read_from_device(void* dst, size_t size, chip_id_t chip, tt::u
     get_local_chip(chip)->dma_read_from_device(dst, size, api_coords, addr);
 }
 
-void Cluster::read_mmio_device_register(void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size) {
-    get_local_chip(core.chip)->read_from_device_reg(core, mem_ptr, addr, size);
-}
-
-void Cluster::write_mmio_device_register(const void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size) {
-    get_local_chip(core.chip)->write_to_device_reg(core, mem_ptr, addr, size);
-}
-
-void Cluster::read_from_device(void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size) {
-    bool target_is_mmio_capable = cluster_desc->is_chip_mmio_capable(core.chip);
-    if (target_is_mmio_capable) {
-        read_device_memory(mem_ptr, core, addr, size);
-    } else {
-        log_assert(
-            arch_name != tt::ARCH::BLACKHOLE,
-            "Non-MMIO targets not supported in Blackhole");  // MT: Use only dynamic TLBs and never program static
-        log_assert(
-            (get_soc_descriptor(core.chip).get_cores(CoreType::TENSIX)).size() > 0 && chips_.size() > 1,
-            "Cannot issue ethernet reads from a single chip cluster!");
-        read_from_non_mmio_device(mem_ptr, core, addr, size);
-    }
-}
-
 void Cluster::read_from_device(void* mem_ptr, chip_id_t chip, CoreCoord core, uint64_t addr, uint32_t size) {
-    read_from_device(mem_ptr, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, size);
+    get_chip(chip)->read_from_device(translate_to_api_coords(chip, core), mem_ptr, addr, size);
 }
 
 void Cluster::read_from_device_reg(void* mem_ptr, chip_id_t chip, CoreCoord core, uint64_t addr, uint32_t size) {
-    bool target_is_mmio_capable = cluster_desc->is_chip_mmio_capable(chip);
-    if (target_is_mmio_capable) {
-        read_mmio_device_register(mem_ptr, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, size);
-    } else {
-        read_from_non_mmio_device(mem_ptr, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, size);
-    }
+    get_local_chip(chip)->read_from_device_reg(translate_to_api_coords(chip, core), mem_ptr, addr, size);
 }
 
 int Cluster::arc_msg(
@@ -1314,7 +1244,8 @@ void Cluster::send_remote_tensix_risc_reset_to_core(
     const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets) {
     auto valid = soft_resets & ALL_TENSIX_SOFT_RESET;
     uint32_t valid_val = (std::underlying_type<TensixSoftResetOptions>::type)valid;
-    write_to_non_mmio_device(&valid_val, sizeof(uint32_t), core, 0xFFB121B0);
+    write_to_device(
+        &valid_val, sizeof(uint32_t), core.chip, {core, CoreType::TENSIX, CoordSystem::VIRTUAL}, 0xFFB121B0);
     tt_driver_atomics::sfence();
 }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1198,7 +1198,7 @@ void Cluster::write_to_device(
 
 void Cluster::write_to_device_reg(
     const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, CoreCoord core, uint64_t addr) {
-    get_local_chip(chip)->write_to_device_reg(translate_to_api_coords(chip, core), mem_ptr, addr, size_in_bytes);
+    get_chip(chip)->write_to_device_reg(translate_to_api_coords(chip, core), mem_ptr, addr, size_in_bytes);
 }
 
 void Cluster::dma_write_to_device(
@@ -1217,7 +1217,7 @@ void Cluster::read_from_device(void* mem_ptr, chip_id_t chip, CoreCoord core, ui
 }
 
 void Cluster::read_from_device_reg(void* mem_ptr, chip_id_t chip, CoreCoord core, uint64_t addr, uint32_t size) {
-    get_local_chip(chip)->read_from_device_reg(translate_to_api_coords(chip, core), mem_ptr, addr, size);
+    get_chip(chip)->read_from_device_reg(translate_to_api_coords(chip, core), mem_ptr, addr, size);
 }
 
 int Cluster::arc_msg(


### PR DESCRIPTION
### Issue
Related to #248 and after #737 

### Description
After some cleanups in read/write path, finally cleanup surplus functions from cluster.

### List of the changes
- Removed read/write device_memory functions
- Removed read_write non_mmio_device functions
- Removed read/write functions which accept xy_pair cores.
- Changed the code in cluster.cpp slightly to adapt.
- One codepath which used write_to_non_mmio_device which used broadcast, changed the call to explicitly call broadcast on local _chip

### Testing
No additional testing

### API Changes
There are no external API changes in this PR.
