### PR TITLE
Moved membar code to Chip

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -59,6 +59,10 @@ public:
 
     virtual void wait_for_non_mmio_flush();
 
+    virtual void l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) = 0;
+    virtual void dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) = 0;
+    virtual void dram_membar(const std::unordered_set<uint32_t>& channels = {}) = 0;
+
     // TODO: To be removed once all usages are moved inside local chip.
     virtual std::unique_lock<RobustMutex> acquire_mutex(std::string mutex_name, int pci_device_id);
     virtual std::unique_lock<RobustMutex> acquire_mutex(MutexType mutex_type, int pci_device_id);

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -59,6 +59,10 @@ public:
     void set_flush_non_mmio(bool flush_non_mmio);
     bool get_flush_non_mmio() const;
 
+    void l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
+    void dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
+    void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
+
     std::unique_lock<RobustMutex> acquire_mutex(std::string mutex_name, int pci_device_id) override;
     std::unique_lock<RobustMutex> acquire_mutex(MutexType mutex_type, int pci_device_id) override;
 
@@ -87,12 +91,17 @@ private:
     void initialize_tlb_manager();
     void initialize_default_chip_mutexes(const bool clear_mutex);
     void initialize_default_remote_transfer_ethernet_cores();
+    void initialize_membars();
 
     tt_xy_pair translate_chip_coord_virtual_to_translated(const tt_xy_pair core) const;
 
     void check_pcie_device_initialized();
     int test_setup_interface();
     void init_pcie_iatus();
+
+    void set_membar_flag(
+        const std::vector<CoreCoord>& cores, const uint32_t barrier_value, const uint32_t barrier_addr);
+    void insert_host_to_device_barrier(const std::vector<CoreCoord>& cores, const uint32_t barrier_addr);
 
 protected:
     void wait_eth_cores_training(const uint32_t timeout_ms = 60000) override;

--- a/device/api/umd/device/chip/mock_chip.h
+++ b/device/api/umd/device/chip/mock_chip.h
@@ -24,5 +24,9 @@ public:
         uint32_t timeout_ms,
         uint32_t* return_3,
         uint32_t* return_4) override;
+
+    void l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
+    void dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
+    void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -33,6 +33,10 @@ public:
         uint32_t* return_3 = nullptr,
         uint32_t* return_4 = nullptr) override;
 
+    void l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
+    void dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
+    void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
+
 private:
     tt_xy_pair translate_chip_coord_virtual_to_translated(const tt_xy_pair core);
 

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -836,7 +836,6 @@ private:
         const std::set<chip_id_t>& target_mmio_device_ids,
         const uint32_t& num_host_mem_ch_per_mmio_device,
         const bool create_mock_chips);
-    void initialize_pcie_devices();
     void broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOptions& soft_resets);
     void send_remote_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);
     void send_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);
@@ -869,14 +868,6 @@ private:
         const std::set<uint32_t>& rows_to_exclude,
         std::set<uint32_t>& cols_to_exclude,
         bool use_virtual_coords);
-    void set_membar_flag(
-        const chip_id_t chip,
-        const std::vector<CoreCoord>& cores,
-        const uint32_t barrier_value,
-        const uint32_t barrier_addr);
-    void insert_host_to_device_barrier(
-        const chip_id_t chip, const std::vector<CoreCoord>& cores, const uint32_t barrier_addr);
-    void init_membars();
 
     std::unordered_map<chip_id_t, std::vector<std::vector<int>>>& get_ethernet_broadcast_headers(
         const std::set<chip_id_t>& chips_to_exclude);

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -9,6 +9,7 @@
 #include "logger.hpp"
 #include "umd/device/blackhole_implementation.h"
 #include "umd/device/chip_helpers/tlb_manager.h"
+#include "umd/device/driver_atomics.h"
 #include "umd/device/tt_device/tt_device.h"
 #include "umd/device/types/blackhole_eth.h"
 #include "umd/device/wormhole_implementation.h"
@@ -101,6 +102,23 @@ void LocalChip::initialize_default_chip_mutexes(const bool clear_mutex) {
 
     // Initialize interprocess mutexes to make host -> device memory barriers atomic
     lock_manager_.initialize_mutex(MutexType::MEM_BARRIER, pci_device_id, clear_mutex);
+}
+
+void LocalChip::initialize_membars() {
+    set_membar_flag(
+        soc_descriptor_.get_cores(CoreType::TENSIX, CoordSystem::VIRTUAL),
+        tt_MemBarFlag::RESET,
+        l1_address_params.tensix_l1_barrier_base);
+    set_membar_flag(
+        soc_descriptor_.get_cores(CoreType::ETH, CoordSystem::VIRTUAL),
+        tt_MemBarFlag::RESET,
+        l1_address_params.eth_l1_barrier_base);
+
+    std::vector<CoreCoord> dram_cores_vector = {};
+    for (std::uint32_t dram_idx = 0; dram_idx < soc_descriptor_.get_num_dram_channels(); dram_idx++) {
+        dram_cores_vector.push_back(soc_descriptor_.get_dram_core_for_channel(dram_idx, 0, CoordSystem::VIRTUAL));
+    }
+    set_membar_flag(dram_cores_vector, tt_MemBarFlag::RESET, dram_address_params.DRAM_BARRIER_BASE);
 }
 
 TTDevice* LocalChip::get_tt_device() { return tt_device_.get(); }
@@ -611,6 +629,99 @@ void LocalChip::init_pcie_iatus() {
         }
         tt_device_->configure_iatu_region(channel, hugepage_map.physical_address, region_size);
     }
+}
+
+void LocalChip::set_membar_flag(
+    const std::vector<CoreCoord>& cores, const uint32_t barrier_value, const uint32_t barrier_addr) {
+    tt_driver_atomics::sfence();  // Ensure that writes before this do not get reordered
+    std::unordered_set<CoreCoord> cores_synced = {};
+    std::vector<uint32_t> barrier_val_vec = {barrier_value};
+    for (const auto& core : cores) {
+        write_to_device(core, barrier_val_vec.data(), barrier_addr, barrier_val_vec.size() * sizeof(uint32_t));
+    }
+    tt_driver_atomics::sfence();  // Ensure that all writes in the Host WC buffer are flushed
+    while (cores_synced.size() != cores.size()) {
+        for (const auto& core : cores) {
+            if (cores_synced.find(core) == cores_synced.end()) {
+                uint32_t readback_val;
+                read_from_device(core, &readback_val, barrier_addr, sizeof(std::uint32_t));
+                if (readback_val == barrier_value) {
+                    cores_synced.insert(core);
+                } else {
+                    log_trace(
+                        LogSiliconDriver,
+                        "Waiting for core {} to recieve mem bar flag {} in function",
+                        core.str(),
+                        barrier_value);
+                }
+            }
+        }
+    }
+    // Ensure that reads or writes after this do not get reordered.
+    // Reordering can cause races where data gets transferred before the barrier has returned
+    tt_driver_atomics::mfence();
+}
+
+void LocalChip::insert_host_to_device_barrier(const std::vector<CoreCoord>& cores, const uint32_t barrier_addr) {
+    // Ensure that this memory barrier is atomic across processes/threads
+    auto lock = lock_manager_.acquire_mutex(MutexType::MEM_BARRIER, tt_device_->get_pci_device()->get_device_num());
+    set_membar_flag(cores, tt_MemBarFlag::SET, barrier_addr);
+    set_membar_flag(cores, tt_MemBarFlag::RESET, barrier_addr);
+}
+
+void LocalChip::l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) {
+    const auto& all_workers = soc_descriptor_.get_cores(CoreType::TENSIX, CoordSystem::VIRTUAL);
+    const auto& all_eth = soc_descriptor_.get_cores(CoreType::ETH, CoordSystem::VIRTUAL);
+
+    if (cores.size()) {
+        // Insert barrier on specific cores with L1
+        std::vector<CoreCoord> workers_to_sync = {};
+        std::vector<CoreCoord> eth_to_sync = {};
+
+        for (const auto& core : cores) {
+            auto core_from_soc = soc_descriptor_.get_coord_at(core, core.coord_system);
+            if (core_from_soc.core_type == CoreType::TENSIX) {
+                workers_to_sync.push_back(core);
+            } else if (core_from_soc.core_type == CoreType::ETH) {
+                eth_to_sync.push_back(core);
+            } else {
+                log_fatal("Can only insert an L1 Memory barrier on Tensix or Ethernet cores.");
+            }
+        }
+        insert_host_to_device_barrier(workers_to_sync, l1_address_params.tensix_l1_barrier_base);
+        insert_host_to_device_barrier(eth_to_sync, l1_address_params.eth_l1_barrier_base);
+    } else {
+        // Insert barrier on all cores with L1
+        insert_host_to_device_barrier(all_workers, l1_address_params.tensix_l1_barrier_base);
+        insert_host_to_device_barrier(all_eth, l1_address_params.eth_l1_barrier_base);
+    }
+}
+
+void LocalChip::dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) {
+    if (cores.size()) {
+        for (const auto& core : cores) {
+            log_assert(
+                soc_descriptor_.get_coord_at(core, core.coord_system).core_type == CoreType::DRAM,
+                "Can only insert a DRAM Memory barrier on DRAM cores.");
+        }
+        std::vector<CoreCoord> dram_cores_vector = std::vector<CoreCoord>(cores.begin(), cores.end());
+        insert_host_to_device_barrier(dram_cores_vector, dram_address_params.DRAM_BARRIER_BASE);
+    } else {
+        // Insert Barrier on all DRAM Cores
+        std::vector<CoreCoord> dram_cores_vector = {};
+        for (std::uint32_t dram_idx = 0; dram_idx < soc_descriptor_.get_num_dram_channels(); dram_idx++) {
+            dram_cores_vector.push_back(soc_descriptor_.get_dram_core_for_channel(dram_idx, 0, CoordSystem::VIRTUAL));
+        }
+        insert_host_to_device_barrier(dram_cores_vector, dram_address_params.DRAM_BARRIER_BASE);
+    }
+}
+
+void LocalChip::dram_membar(const std::unordered_set<uint32_t>& channels) {
+    std::unordered_set<CoreCoord> dram_cores_to_sync = {};
+    for (const auto& chan : channels) {
+        dram_cores_to_sync.insert(soc_descriptor_.get_dram_core_for_channel(chan, 0, CoordSystem::VIRTUAL));
+    }
+    dram_membar(dram_cores_to_sync);
 }
 
 }  // namespace tt::umd

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -132,6 +132,7 @@ bool LocalChip::is_mmio_capable() const { return true; }
 void LocalChip::start_device() {
     check_pcie_device_initialized();
     init_pcie_iatus();
+    initialize_membars();
 }
 
 void LocalChip::wait_eth_cores_training(const uint32_t timeout_ms) {

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -24,4 +24,10 @@ int MockChip::arc_msg(
     uint32_t* return_4) {
     return 0;
 }
+
+void MockChip::l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) {}
+
+void MockChip::dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) {}
+
+void MockChip::dram_membar(const std::unordered_set<uint32_t>& channels) {}
 }  // namespace tt::umd

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -137,4 +137,10 @@ int RemoteChip::arc_msg(
     return exit_code;
 }
 
+void RemoteChip::l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) { wait_for_non_mmio_flush(); }
+
+void RemoteChip::dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) { wait_for_non_mmio_flush(); }
+
+void RemoteChip::dram_membar(const std::unordered_set<uint32_t>& channels) { wait_for_non_mmio_flush(); }
+
 }  // namespace tt::umd

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -530,15 +530,6 @@ void Cluster::configure_active_ethernet_cores_for_mmio_device(
     get_local_chip(mmio_chip)->set_remote_transfer_ethernet_cores(active_eth_cores_per_chip);
 }
 
-void Cluster::initialize_pcie_devices() {
-    log_debug(LogSiliconDriver, "Cluster::start");
-
-    for (auto chip_id : all_chip_ids_) {
-        get_chip(chip_id)->start_device();
-    }
-    // TBD after rebase remove this function
-}
-
 std::set<chip_id_t> Cluster::get_target_device_ids() { return all_chip_ids_; }
 
 std::set<chip_id_t> Cluster::get_target_mmio_device_ids() { return local_chip_ids_; }
@@ -1335,7 +1326,10 @@ void Cluster::verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std
 
 void Cluster::start_device(const tt_device_params& device_params) {
     if (device_params.init_device) {
-        initialize_pcie_devices();
+        for (auto chip_id : all_chip_ids_) {
+            get_chip(chip_id)->start_device();
+        }
+
         // MT Initial BH - Ethernet firmware not present in Blackhole
         if (arch_name == tt::ARCH::WORMHOLE_B0) {
             verify_eth_fw();


### PR DESCRIPTION
### Issue
Part of #248 

### Description
Moving membar related code to Chip

### List of the changes
- Move code for l1_membar and dram_membar to Chip. RemoteChip implementation is to wait for flush, LocalChip is the same as from the Cluster
- initialize_membars is moved, it is called when we start_device()

### Testing
No additional testing

### API Changes
There are no API changes in this PR.
