### PR TITLE
Fix target_devices not used

### DIFF
--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -117,7 +117,7 @@ public:
         get_ethernet_connections() const;
     const std::unordered_map<chip_id_t, chip_id_t> get_chips_with_mmio() const;
     const std::unordered_set<chip_id_t> &get_all_chips() const;
-    const std::vector<chip_id_t> get_all_chips_local_first() const;
+    const std::vector<chip_id_t> get_chips_local_first(std::unordered_set<chip_id_t> chips) const;
     const std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> &get_chips_grouped_by_closest_mmio() const;
     std::size_t get_number_of_chips() const;
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -418,7 +418,7 @@ Cluster::Cluster(
     std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks) {
     cluster_desc = Cluster::create_cluster_descriptor();
 
-    for (auto& chip_id : cluster_desc->get_all_chips_local_first()) {
+    for (auto& chip_id : cluster_desc->get_chips_local_first(cluster_desc->get_all_chips())) {
         add_chip(
             chip_id,
             construct_chip_from_cluster(
@@ -443,7 +443,8 @@ Cluster::Cluster(
     std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks) {
     cluster_desc = Cluster::create_cluster_descriptor();
 
-    for (auto& chip_id : cluster_desc->get_all_chips_local_first()) {
+    std::unordered_set<chip_id_t> target_devices_set(target_devices.begin(), target_devices.end());
+    for (auto& chip_id : cluster_desc->get_chips_local_first(target_devices_set)) {
         log_assert(
             cluster_desc->get_all_chips().find(chip_id) != cluster_desc->get_all_chips().end(),
             "Target device {} not present in current cluster!",
@@ -473,7 +474,8 @@ Cluster::Cluster(
     std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks) {
     cluster_desc = Cluster::create_cluster_descriptor(sdesc_path);
 
-    for (auto& chip_id : cluster_desc->get_all_chips_local_first()) {
+    std::unordered_set<chip_id_t> target_devices_set(target_devices.begin(), target_devices.end());
+    for (auto& chip_id : cluster_desc->get_chips_local_first(target_devices_set)) {
         log_assert(
             cluster_desc->get_all_chips().find(chip_id) != cluster_desc->get_all_chips().end(),
             "Target device {} not present in current cluster!",
@@ -509,7 +511,7 @@ Cluster::Cluster(
     std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks) {
     cluster_desc = std::move(cluster_descriptor);
 
-    for (auto& chip_id : cluster_desc->get_all_chips_local_first()) {
+    for (auto& chip_id : cluster_desc->get_chips_local_first(cluster_desc->get_all_chips())) {
         add_chip(
             chip_id,
             construct_chip_from_cluster(

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -901,19 +901,19 @@ const std::unordered_map<chip_id_t, chip_id_t> tt_ClusterDescriptor::get_chips_w
 
 const std::unordered_set<chip_id_t> &tt_ClusterDescriptor::get_all_chips() const { return this->enabled_active_chips; }
 
-const std::vector<chip_id_t> tt_ClusterDescriptor::get_all_chips_local_first() const {
-    std::vector<chip_id_t> all_chips_local_first;
-    for (const auto &chip : get_all_chips()) {
+const std::vector<chip_id_t> tt_ClusterDescriptor::get_chips_local_first(std::unordered_set<chip_id_t> chips) const {
+    std::vector<chip_id_t> chips_local_first;
+    for (const auto &chip : chips) {
         if (is_chip_mmio_capable(chip)) {
-            all_chips_local_first.push_back(chip);
+            chips_local_first.push_back(chip);
         }
     }
-    for (const auto &chip : get_all_chips()) {
+    for (const auto &chip : chips) {
         if (is_chip_remote(chip)) {
-            all_chips_local_first.push_back(chip);
+            chips_local_first.push_back(chip);
         }
     }
-    return all_chips_local_first;
+    return chips_local_first;
 }
 
 const std::unordered_map<chip_id_t, std::uint32_t> &tt_ClusterDescriptor::get_harvesting_info() const {

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -51,6 +51,7 @@ TEST(ApiClusterTest, DifferentConstructors) {
         target_devices = {logical_device_id};
     }
     umd_cluster = std::make_unique<Cluster>(target_devices);
+    EXPECT_EQ(umd_cluster->get_target_device_ids().size(), target_devices.size());
     umd_cluster = nullptr;
 
     if (chips_available) {


### PR DESCRIPTION
### Issue
No issue

### Description
Previous PR silently removed using target_devices: #682, get it back

### List of the changes
- Don't ignore target_devices

### Testing
CI tests, added a test which verifies only the target  devices were openned.

### API Changes
There are no API changes in this PR.
