### PR TITLE
Fix PCI harvesting for P100 board

### DIFF
--- a/device/blackhole/blackhole_coordinate_manager.cpp
+++ b/device/blackhole/blackhole_coordinate_manager.cpp
@@ -206,6 +206,13 @@ void BlackholeCoordinateManager::translate_pcie_coords() {
             for (size_t y = 0; y < pcie_grid_size.y; y++) {
                 const tt_xy_pair& pcie_core = pcie_cores[x * pcie_grid_size.y + y];
 
+                CoreCoord virtual_coord = CoreCoord(pcie_core.x, pcie_core.y, CoreType::PCIE, CoordSystem::VIRTUAL);
+                add_core_translation(virtual_coord, pcie_core);
+            }
+        } else {
+            for (size_t y = 0; y < pcie_grid_size.y; y++) {
+                const tt_xy_pair& pcie_core = pcie_cores[x * pcie_grid_size.y + y];
+
                 CoreCoord logical_coord = CoreCoord(logical_x, y, CoreType::PCIE, CoordSystem::LOGICAL);
                 add_core_translation(logical_coord, pcie_core);
 
@@ -213,13 +220,6 @@ void BlackholeCoordinateManager::translate_pcie_coords() {
                 add_core_translation(virtual_coord, pcie_core);
             }
             logical_x++;
-        } else {
-            for (size_t y = 0; y < pcie_grid_size.y; y++) {
-                const tt_xy_pair& pcie_core = pcie_cores[x * pcie_grid_size.y + y];
-
-                CoreCoord virtual_coord = CoreCoord(pcie_core.x, pcie_core.y, CoreType::PCIE, CoordSystem::VIRTUAL);
-                add_core_translation(virtual_coord, pcie_core);
-            }
         }
     }
 

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -83,10 +83,12 @@ void tt_SocDescriptor::create_coordinate_manager(const BoardType board_type, con
         }
     }
 
+    // TODO: P100 has two types of boards, each using different PCI core.
+    // Either have two separate enums or completely remove the check here.
     // PCIE harvesting mask 0x1 corresponds to (2, 0) and 0x2 corresponds to (11, 0).
-    if (board_type == BoardType::P100 && harvesting_masks.pcie_harvesting_mask != 0x1) {
-        throw std::runtime_error("P100 card should always have PCIE core (2, 0) harvested.");
-    }
+    // if (board_type == BoardType::P100 && harvesting_masks.pcie_harvesting_mask != 0x1) {
+    //     throw std::runtime_error("P100 card should always have PCIE core (2, 0) harvested.");
+    // }
 
     if (board_type == BoardType::P150 && harvesting_masks.pcie_harvesting_mask != 0x2) {
         throw std::runtime_error("P150 card should always have PCIE core (11, 0) harvested.");

--- a/tests/api/test_core_coord_translation_bh.cpp
+++ b/tests/api/test_core_coord_translation_bh.cpp
@@ -550,46 +550,34 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMPMoreThanOneDRAMBankHarves
 TEST(CoordinateManager, CoordinateManagerBlackholePCIETranslationLocal) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, {0, 0, 0, 0x1}, BoardType::P300, false);
-    const tt_xy_pair pcie_grid_size = tt::umd::blackhole::PCIE_GRID_SIZE;
-    const std::vector<tt_xy_pair> pcie_cores = tt::umd::blackhole::PCIE_CORES_NOC0;
+    const tt_xy_pair pcie_core = {11, 0};
 
-    for (size_t x = 0; x < pcie_grid_size.x - 1; x++) {
-        for (size_t y = 0; y < pcie_grid_size.y; y++) {
-            const CoreCoord pcie_logical = CoreCoord(x, y, CoreType::PCIE, CoordSystem::LOGICAL);
-            const CoreCoord pcie_virtual = coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::VIRTUAL);
-            const CoreCoord pcie_physical = coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::PHYSICAL);
-            const tt_xy_pair pcie_core = pcie_cores[y * pcie_grid_size.x + x];
+    const CoreCoord pcie_logical = CoreCoord(0, 0, CoreType::PCIE, CoordSystem::LOGICAL);
+    const CoreCoord pcie_virtual = coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::VIRTUAL);
+    const CoreCoord pcie_physical = coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::PHYSICAL);
 
-            EXPECT_EQ(pcie_virtual.x, pcie_physical.x);
-            EXPECT_EQ(pcie_virtual.y, pcie_physical.y);
+    EXPECT_EQ(pcie_virtual.x, pcie_physical.x);
+    EXPECT_EQ(pcie_virtual.y, pcie_physical.y);
 
-            EXPECT_EQ(pcie_core.x, pcie_physical.x);
-            EXPECT_EQ(pcie_core.y, pcie_physical.y);
-        }
-    }
+    EXPECT_EQ(pcie_core.x, pcie_physical.x);
+    EXPECT_EQ(pcie_core.y, pcie_physical.y);
 }
 
 // Test that virtual, physical and translated coordinates are the same for all logical PCIE coordinates.
 TEST(CoordinateManager, CoordinateManagerBlackholePCIETranslationRemote) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
-        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, {0, 0, 0, 0x1}, BoardType::P300, false);
-    const tt_xy_pair pcie_grid_size = tt::umd::blackhole::PCIE_GRID_SIZE;
-    const std::vector<tt_xy_pair> pcie_cores = tt::umd::blackhole::PCIE_CORES_NOC0;
+        CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, {0, 0, 0, 0x2}, BoardType::P300, false);
+    const tt_xy_pair pcie_core = {2, 0};
 
-    for (size_t x = 0; x < pcie_grid_size.x - 1; x++) {
-        for (size_t y = 0; y < pcie_grid_size.y; y++) {
-            const CoreCoord pcie_logical = CoreCoord(x, y, CoreType::PCIE, CoordSystem::LOGICAL);
-            const CoreCoord pcie_virtual = coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::VIRTUAL);
-            const CoreCoord pcie_physical = coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::PHYSICAL);
-            const tt_xy_pair pcie_core = pcie_cores[y * pcie_grid_size.x + x];
+    const CoreCoord pcie_logical = CoreCoord(0, 0, CoreType::PCIE, CoordSystem::LOGICAL);
+    const CoreCoord pcie_virtual = coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::VIRTUAL);
+    const CoreCoord pcie_physical = coordinate_manager->translate_coord_to(pcie_logical, CoordSystem::PHYSICAL);
 
-            EXPECT_EQ(pcie_virtual.x, pcie_physical.x);
-            EXPECT_EQ(pcie_virtual.y, pcie_physical.y);
+    EXPECT_EQ(pcie_virtual.x, pcie_physical.x);
+    EXPECT_EQ(pcie_virtual.y, pcie_physical.y);
 
-            EXPECT_EQ(pcie_core.x, pcie_physical.x);
-            EXPECT_EQ(pcie_core.y, pcie_physical.y);
-        }
-    }
+    EXPECT_EQ(pcie_core.x, pcie_physical.x);
+    EXPECT_EQ(pcie_core.y, pcie_physical.y);
 }
 
 // Test that virtual, physical and translated coordinates are the same for all logical ARC coordinates.

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -415,8 +415,6 @@ TEST(SocDescriptor, NocTranslation) {
 TEST(SocDescriptor, BoardBasedPCIE) {
     // Expect invalid configuration to throw an exception.
     EXPECT_ANY_THROW(tt_SocDescriptor soc_desc(
-        test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"), true, {0, 0, 0, 0x2}, BoardType::P100));
-    EXPECT_ANY_THROW(tt_SocDescriptor soc_desc(
         test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"), true, {0, 0, 0, 0x1}, BoardType::P150));
     EXPECT_ANY_THROW(tt_SocDescriptor soc_desc(
         test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch.yaml"), true, {0, 0, 0, 0}, BoardType::P300, 0));


### PR DESCRIPTION
### Issue

#769 

### Description

We have two types of P100 cards. They use different PCI cores on Blackhole so we can't rely on the check that used PCI core is always going to be the same. This PR removes the check from soc descriptor and changes some tests. 

### List of the changes

- Remove the check for harvested PCI core on P100
- Fix reverse logic for PCI harvesting in coordinate manager
- Change the tests to test the change

### Testing
CI. Change was manually tested on P100 and P100A boards to verify that tests pass.

### API Changes
/