### PR TITLE
Make read KMD version public

### DIFF
--- a/device/api/umd/device/pci_device.hpp
+++ b/device/api/umd/device/pci_device.hpp
@@ -161,6 +161,11 @@ public:
      */
     DmaBuffer &get_dma_buffer() { return dma_buffer; }
 
+    /**
+     * Read KMD version installed on the system.
+     */
+    static semver_t read_kmd_version();
+
 public:
     // TODO: we can and should make all of these private.
     void *bar0_uc = nullptr;
@@ -202,7 +207,4 @@ public:
         }
         return reinterpret_cast<T *>(static_cast<uint8_t *>(reg_mapping) + register_offset);
     }
-
-private:
-    semver_t read_kmd_version();
 };

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -174,7 +174,7 @@ PCIDevice::PCIDevice(int pci_device_number) :
     numa_node(read_sysfs<int>(info, "numa_node", -1)),  // default to -1 if not found
     revision(read_sysfs<int>(info, "revision")),
     arch(info.get_arch()),
-    kmd_version(read_kmd_version()),
+    kmd_version(PCIDevice::read_kmd_version()),
     iommu_enabled(detect_iommu(info)) {
     if (iommu_enabled && kmd_version < kmd_ver_for_iommu) {
         TT_THROW("Running with IOMMU support requires KMD version {} or newer", kmd_ver_for_iommu.to_string());


### PR DESCRIPTION
### Issue

Motivated by #733 , in order to protect the feature based on KMD version

### Description

Make reading KMD version information public. Make function static since it's not tied to specific PCI device, rather the system

### List of the changes

- Make function read_kmd_version public
- Make function static
- Change usages accordingly

### Testing
CI

### API Changes
/
