### PR TITLE
Fix default translation for TRANSLATED BH coords

### DIFF
--- a/device/api/umd/device/coordinate_manager.h
+++ b/device/api/umd/device/coordinate_manager.h
@@ -135,7 +135,7 @@ protected:
     virtual std::vector<tt::umd::CoreCoord> get_harvested_eth_cores() const;
     virtual std::vector<tt::umd::CoreCoord> get_pcie_cores() const;
     virtual std::vector<tt::umd::CoreCoord> get_harvested_pcie_cores() const;
-    virtual tt_xy_pair get_tensix_grid_size() const;
+    virtual tt_xy_pair get_tensix_grid_size() const = 0;
     virtual tt_xy_pair get_dram_grid_size() const;
     virtual tt_xy_pair get_harvested_tensix_grid_size() const;
     virtual tt_xy_pair get_harvested_dram_grid_size() const;

--- a/device/api/umd/device/wormhole_coordinate_manager.h
+++ b/device/api/umd/device/wormhole_coordinate_manager.h
@@ -35,4 +35,6 @@ protected:
     void fill_eth_physical_translated_mapping() override;
     void fill_pcie_physical_translated_mapping() override;
     void fill_arc_physical_translated_mapping() override;
+
+    tt_xy_pair get_tensix_grid_size() const override;
 };

--- a/device/coordinate_manager.cpp
+++ b/device/coordinate_manager.cpp
@@ -215,16 +215,7 @@ void CoordinateManager::translate_tensix_coords() {
 void CoordinateManager::fill_tensix_default_physical_translated_mapping() {
     tt_xy_pair tensix_grid_unharvested = get_grid_size(CoreType::TENSIX);
 
-    for (CoreCoord physical_core : get_tensix_cores()) {
-        const size_t translated_x = physical_core.x;
-        const size_t translated_y = physical_core.y;
-
-        CoreCoord translated_coord = CoreCoord(translated_x, translated_y, CoreType::TENSIX, CoordSystem::TRANSLATED);
-
-        add_core_translation(translated_coord, (tt_xy_pair)physical_core);
-    }
-
-    for (CoreCoord physical_core : get_harvested_tensix_cores()) {
+    for (CoreCoord physical_core : tensix_cores) {
         const size_t translated_x = physical_core.x;
         const size_t translated_y = physical_core.y;
 

--- a/device/coordinate_manager.cpp
+++ b/device/coordinate_manager.cpp
@@ -215,13 +215,9 @@ void CoordinateManager::translate_tensix_coords() {
 void CoordinateManager::fill_tensix_default_physical_translated_mapping() {
     tt_xy_pair tensix_grid_unharvested = get_grid_size(CoreType::TENSIX);
 
-    for (CoreCoord physical_core : tensix_cores) {
-        const size_t translated_x = physical_core.x;
-        const size_t translated_y = physical_core.y;
-
-        CoreCoord translated_coord = CoreCoord(translated_x, translated_y, CoreType::TENSIX, CoordSystem::TRANSLATED);
-
-        add_core_translation(translated_coord, (tt_xy_pair)physical_core);
+    for (tt_xy_pair physical_core : tensix_cores) {
+        CoreCoord translated_coord = CoreCoord(physical_core, CoreType::TENSIX, CoordSystem::TRANSLATED);
+        add_core_translation(translated_coord, physical_core);
     }
 }
 

--- a/device/coordinate_manager.cpp
+++ b/device/coordinate_manager.cpp
@@ -219,8 +219,7 @@ void CoordinateManager::fill_tensix_default_physical_translated_mapping() {
         const size_t translated_x = physical_core.x;
         const size_t translated_y = physical_core.y;
 
-        CoreCoord translated_coord =
-            CoreCoord(translated_x, translated_y, CoreType::TENSIX, CoordSystem::TRANSLATED);
+        CoreCoord translated_coord = CoreCoord(translated_x, translated_y, CoreType::TENSIX, CoordSystem::TRANSLATED);
 
         add_core_translation(translated_coord, (tt_xy_pair)physical_core);
     }
@@ -229,8 +228,7 @@ void CoordinateManager::fill_tensix_default_physical_translated_mapping() {
         const size_t translated_x = physical_core.x;
         const size_t translated_y = physical_core.y;
 
-        CoreCoord translated_coord =
-            CoreCoord(translated_x, translated_y, CoreType::TENSIX, CoordSystem::TRANSLATED);
+        CoreCoord translated_coord = CoreCoord(translated_x, translated_y, CoreType::TENSIX, CoordSystem::TRANSLATED);
 
         add_core_translation(translated_coord, (tt_xy_pair)physical_core);
     }

--- a/device/coordinate_manager.cpp
+++ b/device/coordinate_manager.cpp
@@ -213,36 +213,26 @@ void CoordinateManager::translate_tensix_coords() {
 }
 
 void CoordinateManager::fill_tensix_default_physical_translated_mapping() {
-    size_t num_harvested_y = CoordinateManager::get_num_harvested(harvesting_masks.tensix_harvesting_mask);
+    tt_xy_pair tensix_grid_unharvested = get_grid_size(CoreType::TENSIX);
 
-    for (size_t x = 0; x < tensix_grid_size.x; x++) {
-        for (size_t y = 0; y < tensix_grid_size.y - num_harvested_y; y++) {
-            CoreCoord logical_coord = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
-            const tt_xy_pair physical_pair = to_physical_map[logical_coord];
-            const size_t translated_x = physical_pair.x;
-            const size_t translated_y = physical_pair.y;
+    for (CoreCoord physical_core : get_tensix_cores()) {
+        const size_t translated_x = physical_core.x;
+        const size_t translated_y = physical_core.y;
 
-            CoreCoord translated_coord =
-                CoreCoord(translated_x, translated_y, CoreType::TENSIX, CoordSystem::TRANSLATED);
+        CoreCoord translated_coord =
+            CoreCoord(translated_x, translated_y, CoreType::TENSIX, CoordSystem::TRANSLATED);
 
-            add_core_translation(translated_coord, physical_pair);
-        }
+        add_core_translation(translated_coord, (tt_xy_pair)physical_core);
     }
 
-    size_t harvested_index = (tensix_grid_size.y - num_harvested_y) * tensix_grid_size.x;
-    for (size_t y = 0; y < tensix_grid_size.y; y++) {
-        if (harvesting_masks.tensix_harvesting_mask & (1 << y)) {
-            for (size_t x = 0; x < tensix_grid_size.x; x++) {
-                const tt_xy_pair& physical_core = tensix_cores[y * tensix_grid_size.x + x];
-                const size_t translated_x = physical_core.x;
-                const size_t translated_y = physical_core.y;
+    for (CoreCoord physical_core : get_harvested_tensix_cores()) {
+        const size_t translated_x = physical_core.x;
+        const size_t translated_y = physical_core.y;
 
-                CoreCoord translated_coord =
-                    CoreCoord(translated_x, translated_y, CoreType::TENSIX, CoordSystem::TRANSLATED);
+        CoreCoord translated_coord =
+            CoreCoord(translated_x, translated_y, CoreType::TENSIX, CoordSystem::TRANSLATED);
 
-                add_core_translation(translated_coord, physical_core);
-            }
-        }
+        add_core_translation(translated_coord, (tt_xy_pair)physical_core);
     }
 }
 
@@ -551,12 +541,6 @@ std::vector<tt::umd::CoreCoord> CoordinateManager::get_cores(const CoreType core
         default:
             throw std::runtime_error("Core type is not supported for getting cores");
     }
-}
-
-tt_xy_pair CoordinateManager::get_tensix_grid_size() const {
-    return {
-        tensix_grid_size.x,
-        tensix_grid_size.y - CoordinateManager::get_num_harvested(harvesting_masks.tensix_harvesting_mask)};
 }
 
 tt_xy_pair CoordinateManager::get_dram_grid_size() const { return dram_grid_size; }

--- a/device/wormhole/wormhole_coordinate_manager.cpp
+++ b/device/wormhole/wormhole_coordinate_manager.cpp
@@ -114,3 +114,9 @@ void WormholeCoordinateManager::fill_arc_physical_translated_mapping() {
     // ARC cores are not translated in Wormhole.
     fill_arc_default_physical_translated_mapping();
 }
+
+tt_xy_pair WormholeCoordinateManager::get_tensix_grid_size() const {
+    return {
+        tensix_grid_size.x,
+        tensix_grid_size.y - CoordinateManager::get_num_harvested(harvesting_masks.tensix_harvesting_mask)};
+}


### PR DESCRIPTION
### Issue
No issue

### Description
Surfaced through https://github.com/tenstorrent/tt-umd/pull/747
Default translation is wrong for tensix for blackhole when noc translation is not enabled.

### List of the changes
- make get_grid_size pure virtual
- change default translate tensix implementation to include bh case when columns are harvested.

### Testing
We're missing translation tests for when noc translation is not enabled.
Manually ran this code on 747 change

### API Changes
There are no API changes in this PR.
