### PR TITLE
Move assert/deassert at core to Chip

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -8,6 +8,7 @@
 
 #include <unordered_set>
 
+#include "umd/device/tt_silicon_driver_common.hpp"
 #include "umd/device/tt_soc_descriptor.h"
 #include "umd/device/types/cluster_descriptor_types.h"
 #include "umd/device/types/cluster_types.h"
@@ -45,7 +46,7 @@ public:
     virtual void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size);
     virtual void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size);
 
-    // Both write and read cores are defined in VIRTUAL coords.
+    // All tt_xy_pair cores in this class are defined in VIRTUAL coords.
     virtual void write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) = 0;
     virtual void read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) = 0;
     virtual void write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size) = 0;
@@ -56,6 +57,8 @@ public:
     virtual void dma_read_from_device(void* dst, size_t size, tt_xy_pair core, uint64_t addr);
 
     virtual void wait_for_non_mmio_flush();
+
+    virtual void send_tensix_risc_reset(tt_xy_pair core, const TensixSoftResetOptions& soft_resets);
 
     // TODO: To be removed once all usages are moved inside local chip.
     virtual std::unique_lock<RobustMutex> acquire_mutex(std::string mutex_name, int pci_device_id);

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -8,6 +8,7 @@
 
 #include "logger.hpp"
 #include "umd/device/architecture_implementation.h"
+#include "umd/device/driver_atomics.h"
 
 namespace tt::umd {
 
@@ -140,4 +141,10 @@ void Chip::enable_ethernet_queue(int timeout_s) {
     }
 }
 
+void Chip::send_tensix_risc_reset(tt_xy_pair core, const TensixSoftResetOptions& soft_resets) {
+    auto valid = soft_resets & ALL_TENSIX_SOFT_RESET;
+    uint32_t valid_val = (std::underlying_type<TensixSoftResetOptions>::type)valid;
+    write_to_device_reg(core, &valid_val, 0xFFB121B0, sizeof(uint32_t));
+    tt_driver_atomics::sfence();
+}
 }  // namespace tt::umd

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -559,13 +559,7 @@ void Cluster::deassert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftRese
     log_assert(
         core_coord.core_type == CoreType::TENSIX || core_coord.core_type == CoreType::ETH,
         "Cannot deassert reset on a non-tensix or harvested core");
-    bool target_is_mmio_capable = cluster_desc->is_chip_mmio_capable(target_device);
-    if (target_is_mmio_capable) {
-        send_tensix_risc_reset_to_core(core, soft_resets);
-    } else {
-        log_assert(arch_name != tt::ARCH::BLACKHOLE, "Can't issue access to remote core in BH");
-        send_remote_tensix_risc_reset_to_core(core, soft_resets);
-    }
+    get_chip(core.chip)->send_tensix_risc_reset(core, soft_resets);
 }
 
 void Cluster::deassert_risc_reset_at_core(
@@ -580,12 +574,7 @@ void Cluster::assert_risc_reset_at_core(tt_cxy_pair core, const TensixSoftResetO
     log_assert(
         core_coord.core_type == CoreType::TENSIX || core_coord.core_type == CoreType::ETH,
         "Cannot assert reset on a non-tensix or harvested core");
-    bool target_is_mmio_capable = cluster_desc->is_chip_mmio_capable(target_device);
-    if (target_is_mmio_capable) {
-        send_tensix_risc_reset_to_core(core, soft_resets);
-    } else {
-        send_remote_tensix_risc_reset_to_core(core, soft_resets);
-    }
+    get_chip(core.chip)->send_tensix_risc_reset(core, soft_resets);
 }
 
 void Cluster::assert_risc_reset_at_core(
@@ -1234,23 +1223,6 @@ int Cluster::arc_msg(
     uint32_t* return_3,
     uint32_t* return_4) {
     return get_chip(logical_device_id)->arc_msg(msg_code, wait_for_done, arg0, arg1, timeout_ms, return_3, return_4);
-}
-
-void Cluster::send_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets) {
-    auto valid = soft_resets & ALL_TENSIX_SOFT_RESET;
-    uint32_t valid_val = (std::underlying_type<TensixSoftResetOptions>::type)valid;
-    CoreCoord virtual_core = get_soc_descriptor(core.chip).get_coord_at(core, CoordSystem::VIRTUAL);
-    write_to_device_reg(&valid_val, sizeof(uint32_t), core.chip, virtual_core, 0xFFB121B0);
-    tt_driver_atomics::sfence();
-}
-
-void Cluster::send_remote_tensix_risc_reset_to_core(
-    const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets) {
-    auto valid = soft_resets & ALL_TENSIX_SOFT_RESET;
-    uint32_t valid_val = (std::underlying_type<TensixSoftResetOptions>::type)valid;
-    CoreCoord virtual_core = get_soc_descriptor(core.chip).get_coord_at(core, CoordSystem::VIRTUAL);
-    write_to_device(&valid_val, sizeof(uint32_t), core.chip, virtual_core, 0xFFB121B0);
-    tt_driver_atomics::sfence();
 }
 
 int Cluster::set_remote_power_state(const chip_id_t& chip, tt_DevicePowerState device_state) {


### PR DESCRIPTION
### Issue
One of the last changes of #248

### Description
Moving assert/deassert code to chip.
Note that I haven't moved any broadcast related stuff including cluster wide asserts

### List of the changes
- Moved send_tensix_risc_reset_to_core to chip.cpp. Note that the implementation was actually the same between local and remote, just remote functions were used (which are now consolidated in Chip::read/write

### Testing
No tests

### API Changes
There are no API changes in this PR.
