### PR TITLE
Fix Blackhole coordinate translation

### DIFF
--- a/device/api/umd/device/blackhole_coordinate_manager.h
+++ b/device/api/umd/device/blackhole_coordinate_manager.h
@@ -57,5 +57,9 @@ protected:
     tt_xy_pair get_harvested_dram_grid_size() const override;
 
 private:
-    void map_column_of_dram_banks(const size_t start_bank, const size_t end_bank, const size_t x_coord);
+    void map_dram_banks(
+        const size_t start_bank,
+        const size_t end_bank,
+        const size_t x_coord,
+        const size_t y_coord_start = tt::umd::blackhole::dram_translated_coordinate_start_y);
 };

--- a/device/blackhole/blackhole_coordinate_manager.cpp
+++ b/device/blackhole/blackhole_coordinate_manager.cpp
@@ -382,6 +382,7 @@ void BlackholeCoordinateManager::fill_dram_physical_translated_mapping() {
         map_dram_banks(
             mirror_west_bank + 1,
             blackhole::NUM_DRAM_BANKS / 2,
+            blackhole::dram_translated_coordinate_start_x,
             blackhole::dram_translated_coordinate_start_y + mirror_west_bank * blackhole::NUM_NOC_PORTS_PER_DRAM_BANK);
 
         map_dram_banks(

--- a/device/blackhole/blackhole_coordinate_manager.cpp
+++ b/device/blackhole/blackhole_coordinate_manager.cpp
@@ -68,7 +68,7 @@ void BlackholeCoordinateManager::translate_tensix_coords() {
     size_t grid_size_y = tensix_grid_size.y;
 
     size_t logical_x = 0;
-    size_t x_index = grid_size_x - num_harvested_x;
+    size_t x_index = grid_size_x - 1;
     for (size_t x = 0; x < grid_size_x; x++) {
         if (harvesting_masks.tensix_harvesting_mask & (1 << x)) {
             for (size_t y = 0; y < grid_size_y; y++) {
@@ -80,7 +80,7 @@ void BlackholeCoordinateManager::translate_tensix_coords() {
 
                 add_core_translation(virtual_coord, physical_core);
             }
-            x_index++;
+            x_index--;
         } else {
             for (size_t y = 0; y < grid_size_y; y++) {
                 const tt_xy_pair& tensix_core = tensix_cores[x + y * grid_size_x];
@@ -299,9 +299,9 @@ void BlackholeCoordinateManager::fill_arc_physical_translated_mapping() {
     fill_arc_default_physical_translated_mapping();
 }
 
-void BlackholeCoordinateManager::map_column_of_dram_banks(
-    const size_t start_bank, const size_t end_bank, const size_t x_coord) {
-    size_t translated_y = blackhole::dram_translated_coordinate_start_y;
+void BlackholeCoordinateManager::map_dram_banks(
+    const size_t start_bank, const size_t end_bank, const size_t x_coord, const size_t y_coord) {
+    size_t translated_y = y_coord;
     for (size_t bank = start_bank; bank < end_bank; bank++) {
         for (size_t port = 0; port < blackhole::NUM_NOC_PORTS_PER_DRAM_BANK; port++) {
             CoreCoord logical_coord = CoreCoord(bank, port, CoreType::DRAM, CoordSystem::LOGICAL);
@@ -340,8 +340,8 @@ void BlackholeCoordinateManager::fill_dram_physical_translated_mapping() {
         CoordinateManager::get_harvested_indices(harvesting_masks.dram_harvesting_mask);
 
     if (harvested_banks.empty()) {
-        map_column_of_dram_banks(0, blackhole::NUM_DRAM_BANKS / 2, blackhole::dram_translated_coordinate_start_x);
-        map_column_of_dram_banks(
+        map_dram_banks(0, blackhole::NUM_DRAM_BANKS / 2, blackhole::dram_translated_coordinate_start_x);
+        map_dram_banks(
             blackhole::NUM_DRAM_BANKS / 2,
             blackhole::NUM_DRAM_BANKS,
             blackhole::dram_translated_coordinate_start_x + 1);
@@ -351,17 +351,48 @@ void BlackholeCoordinateManager::fill_dram_physical_translated_mapping() {
     const size_t harvested_bank = harvested_banks[0];
 
     if (harvested_bank < blackhole::NUM_DRAM_BANKS / 2) {
-        const size_t mirror_east_bank = harvested_bank + blackhole::NUM_DRAM_BANKS / 2;
-        map_column_of_dram_banks(
-            0, blackhole::NUM_DRAM_BANKS / 2 - 1, blackhole::dram_translated_coordinate_start_x + 1);
-        map_column_of_dram_banks(
-            blackhole::NUM_DRAM_BANKS / 2 - 1,
+        const size_t mirror_east_bank = harvested_bank + blackhole::NUM_DRAM_BANKS / 2 - 1;
+
+        // Map west column of DRAM banks.
+        map_dram_banks(0, blackhole::NUM_DRAM_BANKS / 2 - 1, blackhole::dram_translated_coordinate_start_x + 1);
+
+        // Map east column of DRAM banks.
+        map_dram_banks(
+            blackhole::NUM_DRAM_BANKS / 2 - 1, mirror_east_bank, blackhole::dram_translated_coordinate_start_x);
+
+        map_dram_banks(
+            mirror_east_bank + 1,
             blackhole::NUM_DRAM_BANKS - 1,
-            blackhole::dram_translated_coordinate_start_x);
+            blackhole::dram_translated_coordinate_start_x,
+            blackhole::dram_translated_coordinate_start_y +
+                (mirror_east_bank - (blackhole::NUM_DRAM_BANKS / 2 - 1)) * blackhole::NUM_NOC_PORTS_PER_DRAM_BANK);
+
+        map_dram_banks(
+            mirror_east_bank,
+            mirror_east_bank + 1,
+            blackhole::dram_translated_coordinate_start_x,
+            blackhole::dram_translated_coordinate_start_y +
+                (blackhole::NUM_DRAM_BANKS / 2 - 1) * blackhole::NUM_NOC_PORTS_PER_DRAM_BANK);
     } else {
         const size_t mirror_west_bank = harvested_bank - blackhole::NUM_DRAM_BANKS / 2;
-        map_column_of_dram_banks(0, blackhole::NUM_DRAM_BANKS / 2, blackhole::dram_translated_coordinate_start_x);
-        map_column_of_dram_banks(
+
+        // Map west column of DRAM banks.
+        map_dram_banks(0, mirror_west_bank, blackhole::dram_translated_coordinate_start_x);
+
+        map_dram_banks(
+            mirror_west_bank + 1,
+            blackhole::NUM_DRAM_BANKS / 2,
+            blackhole::dram_translated_coordinate_start_y + mirror_west_bank * blackhole::NUM_NOC_PORTS_PER_DRAM_BANK);
+
+        map_dram_banks(
+            mirror_west_bank,
+            mirror_west_bank + 1,
+            blackhole::dram_translated_coordinate_start_x,
+            blackhole::dram_translated_coordinate_start_y +
+                (blackhole::NUM_DRAM_BANKS / 2 - 1) * blackhole::NUM_NOC_PORTS_PER_DRAM_BANK);
+
+        // Map east column of DRAM banks.
+        map_dram_banks(
             blackhole::NUM_DRAM_BANKS / 2,
             blackhole::NUM_DRAM_BANKS - 1,
             blackhole::dram_translated_coordinate_start_x + 1);

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -90,6 +90,7 @@ ChipInfo BlackholeTTDevice::get_chip_info() {
     chip_info.harvesting_masks.dram_harvesting_mask = telemetry->is_entry_available(blackhole::TAG_ENABLED_GDDR)
                                                           ? (~telemetry->read_entry(blackhole::TAG_ENABLED_GDDR) & 0xFF)
                                                           : 0;
+
     chip_info.harvesting_masks.eth_harvesting_mask = telemetry->is_entry_available(blackhole::TAG_ENABLED_ETH)
                                                          ? (~telemetry->read_entry(blackhole::TAG_ENABLED_ETH) & 0x3FFF)
                                                          : 0;

--- a/tests/api/test_core_coord_translation_bh.cpp
+++ b/tests/api/test_core_coord_translation_bh.cpp
@@ -273,13 +273,15 @@ TEST(CoordinateManager, CoordinateManagerBlackholeTensixTranslatedMappingHarvest
     size_t virtual_index = tensix_grid_size.x - num_harvested_x;
 
     const CoreCoord tensix_column0 = CoreCoord(1, 2, CoreType::TENSIX, CoordSystem::NOC0);
-    const CoreCoord translated_column0 = coordinate_manager->translate_coord_to(tensix_column0, CoordSystem::TRANSLATED);
+    const CoreCoord translated_column0 =
+        coordinate_manager->translate_coord_to(tensix_column0, CoordSystem::TRANSLATED);
 
     EXPECT_EQ(translated_column0.x, 16);
     EXPECT_EQ(translated_column0.y, 2);
 
     const CoreCoord tensix_column1 = CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::NOC0);
-    const CoreCoord translated_column1 = coordinate_manager->translate_coord_to(tensix_column1, CoordSystem::TRANSLATED);
+    const CoreCoord translated_column1 =
+        coordinate_manager->translate_coord_to(tensix_column1, CoordSystem::TRANSLATED);
 
     EXPECT_EQ(translated_column1.x, 15);
     EXPECT_EQ(translated_column1.y, 2);

--- a/tests/api/test_core_coord_translation_bh.cpp
+++ b/tests/api/test_core_coord_translation_bh.cpp
@@ -259,7 +259,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeVirtualEqualTranslated) {
 }
 
 // Test mapping of the coordinates for harvested DRAM bank.
-TEST(CoordinateManager, CoordinateManagerBlackholeTransltedMappingHarvested) {
+TEST(CoordinateManager, CoordinateManagerBlackholeTensixTranslatedMappingHarvested) {
     const size_t tensix_harvesting_mask = (1 << 0) | (1 << 1);
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, {tensix_harvesting_mask});
@@ -272,35 +272,17 @@ TEST(CoordinateManager, CoordinateManagerBlackholeTransltedMappingHarvested) {
     size_t index = 0;
     size_t virtual_index = tensix_grid_size.x - num_harvested_x;
 
-    for (size_t cnt = 0; cnt < num_harvested_x * tensix_grid_size.y; cnt++) {
-        CoreCoord physical_core =
-            CoreCoord(tensix_cores[index].x, tensix_cores[index].y, CoreType::TENSIX, CoordSystem::PHYSICAL);
-        const CoreCoord translated_core =
-            coordinate_manager->translate_coord_to(physical_core, CoordSystem::TRANSLATED);
+    const CoreCoord tensix_column0 = CoreCoord(1, 2, CoreType::TENSIX, CoordSystem::NOC0);
+    const CoreCoord translated_column0 = coordinate_manager->translate_coord_to(tensix_column0, CoordSystem::TRANSLATED);
 
-        const CoreCoord virtual_core = CoreCoord(
-            tensix_cores[virtual_index].x, tensix_cores[virtual_index].y, CoreType::TENSIX, CoordSystem::VIRTUAL);
-        const CoreCoord translated_core_from_virtual =
-            coordinate_manager->translate_coord_to(virtual_core, CoordSystem::TRANSLATED);
+    EXPECT_EQ(translated_column0.x, 16);
+    EXPECT_EQ(translated_column0.y, 2);
 
-        EXPECT_EQ(translated_core, translated_core_from_virtual);
+    const CoreCoord tensix_column1 = CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::NOC0);
+    const CoreCoord translated_column1 = coordinate_manager->translate_coord_to(tensix_column1, CoordSystem::TRANSLATED);
 
-        EXPECT_EQ(translated_core.x, tensix_cores[virtual_index].x);
-        EXPECT_EQ(translated_core.y, tensix_cores[virtual_index].y);
-
-        index += tensix_grid_size.x;
-        virtual_index += tensix_grid_size.x;
-
-        if (index >= tensix_cores.size()) {
-            index = index % tensix_cores.size();
-            index++;
-        }
-
-        if (virtual_index >= tensix_cores.size()) {
-            virtual_index = virtual_index % tensix_cores.size();
-            virtual_index++;
-        }
-    }
+    EXPECT_EQ(translated_column1.x, 15);
+    EXPECT_EQ(translated_column1.y, 2);
 }
 
 // Test mapping of DRAM coordinates from logical to physical. When there is no DRAM harvesting, logical


### PR DESCRIPTION
### Issue

#784 

### Description

Fix mapping of coordinates to translated space when NOC translation is enabled on Blackhole. There were 2 problems

- There is a "bug" in syseng firmware 80.18 where harvested tensix columns are mapped in reverse from NOC layout order to last few columns in translated space
- UMD bug for mapping DRAM banks to translated space. Mirroring west/east banks were not mapped properly. It was working only when last bank in the column (3 or 7) was harvested

Both bugs were uncovered by NOC0 node id test. It now passes

### List of the changes

- Map tensix columns in reverse to translated space
- Add a test to confirm this
- Fix bug for mapping DRAM banks to translated space

### Testing

CI. Additional test to confirm reverse mapping of tensix cores. NOC0 node id test is very good in uncovering these issues it now passes

### API Changes
/
