### PR TITLE
Remove unused Chip APIs

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -64,10 +64,6 @@ public:
 
     virtual void send_tensix_risc_reset(tt_xy_pair core, const TensixSoftResetOptions& soft_resets);
 
-    // TODO: To be removed once all usages are moved inside local chip.
-    virtual std::unique_lock<RobustMutex> acquire_mutex(std::string mutex_name, int pci_device_id);
-    virtual std::unique_lock<RobustMutex> acquire_mutex(MutexType mutex_type, int pci_device_id);
-
     virtual int arc_msg(
         uint32_t msg_code,
         bool wait_for_done = true,
@@ -78,11 +74,6 @@ public:
         uint32_t* return_4 = nullptr) = 0;
 
     virtual void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores);
-    // TODO: To be removed once all the usages are moved inside the class.
-    virtual tt_xy_pair get_remote_transfer_ethernet_core();
-    virtual void update_active_eth_core_idx();
-    virtual int get_active_eth_core_idx();
-    virtual std::vector<CoreCoord> get_remote_transfer_ethernet_cores();
 
     // TODO: To be moved to private implementation once methods are moved to chip
     void enable_ethernet_queue(int timeout_s);

--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -49,8 +49,8 @@ public:
     // All tt_xy_pair cores in this class are defined in VIRTUAL coords.
     virtual void write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) = 0;
     virtual void read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) = 0;
-    virtual void write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size) = 0;
-    virtual void read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size) = 0;
+    virtual void write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size);
+    virtual void read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size);
 
     // Will only ever work for LocalChip.
     virtual void dma_write_to_device(const void* src, size_t size, tt_xy_pair core, uint64_t addr);

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -30,11 +30,11 @@ public:
     TLBManager* get_tlb_manager() override;
 
     void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) override;
-    // TODO: To be removed once all the usages are moved inside the class.
-    tt_xy_pair get_remote_transfer_ethernet_core() override;
-    void update_active_eth_core_idx() override;
-    int get_active_eth_core_idx() override;
-    std::vector<CoreCoord> get_remote_transfer_ethernet_cores() override;
+    // TODO: Figure out if this should remain public or used another way.
+    tt_xy_pair get_remote_transfer_ethernet_core();
+    void update_active_eth_core_idx();
+    int get_active_eth_core_idx();
+    std::vector<CoreCoord> get_remote_transfer_ethernet_cores();
 
     void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) override;
     void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) override;
@@ -58,8 +58,8 @@ public:
     void dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
     void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
 
-    std::unique_lock<RobustMutex> acquire_mutex(std::string mutex_name, int pci_device_id) override;
-    std::unique_lock<RobustMutex> acquire_mutex(MutexType mutex_type, int pci_device_id) override;
+    std::unique_lock<RobustMutex> acquire_mutex(std::string mutex_name, int pci_device_id);
+    std::unique_lock<RobustMutex> acquire_mutex(MutexType mutex_type, int pci_device_id);
 
     int arc_msg(
         uint32_t msg_code,

--- a/device/api/umd/device/chip/mock_chip.h
+++ b/device/api/umd/device/chip/mock_chip.h
@@ -19,9 +19,6 @@ public:
     void write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) override;
     void read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) override;
 
-    void write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size) override;
-    void read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size) override;
-
     int arc_msg(
         uint32_t msg_code,
         bool wait_for_done,

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -25,9 +25,6 @@ public:
     void write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) override;
     void read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) override;
 
-    void write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size) override;
-    void read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size) override;
-
     void wait_for_non_mmio_flush() override;
 
     int arc_msg(

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -97,30 +97,6 @@ void Chip::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord
     throw std::runtime_error("Chip::set_remote_transfer_ethernet_cores is not available for this chip.");
 }
 
-tt_xy_pair Chip::get_remote_transfer_ethernet_core() {
-    throw std::runtime_error("Chip::get_remote_transfer_ethernet_core is not available for this chip.");
-}
-
-void Chip::update_active_eth_core_idx() {
-    throw std::runtime_error("Chip::update_active_eth_core_idx is not available for this chip.");
-}
-
-int Chip::get_active_eth_core_idx() {
-    throw std::runtime_error("Chip::active_eth_core_idx is not available for this chip.");
-}
-
-std::vector<CoreCoord> Chip::get_remote_transfer_ethernet_cores() {
-    throw std::runtime_error("Chip::get_remote_transfer_ethernet_cores is not available for this chip.");
-}
-
-std::unique_lock<RobustMutex> Chip::acquire_mutex(std::string mutex_name, int pci_device_id) {
-    throw std::runtime_error("LockManager::acquire_mutex is not available for this chip.");
-}
-
-std::unique_lock<RobustMutex> Chip::acquire_mutex(MutexType mutex_type, int pci_device_id) {
-    throw std::runtime_error("LockManager::acquire_mutex is not available for this chip.");
-}
-
 void Chip::wait_dram_cores_training(const uint32_t timeout_ms) {}
 
 void Chip::enable_ethernet_queue(int timeout_s) {

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -81,6 +81,14 @@ void Chip::read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, u
     throw std::runtime_error("Chip::read_from_sysmem is not available for this chip.");
 }
 
+void Chip::write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size) {
+    write_to_device(core, src, reg_dest, size);
+}
+
+void Chip::read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size) {
+    read_from_device(core, dest, reg_src, size);
+}
+
 void Chip::dma_write_to_device(const void* src, size_t size, tt_xy_pair core, uint64_t addr) {
     throw std::runtime_error("Chip::dma_write_to_device is not available for this chip.");
 }

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -18,10 +18,6 @@ void MockChip::write_to_device(tt_xy_pair core, const void* src, uint64_t l1_des
 
 void MockChip::read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) {}
 
-void MockChip::write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size) {}
-
-void MockChip::read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size) {}
-
 int MockChip::arc_msg(
     uint32_t msg_code,
     bool wait_for_done,

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -36,14 +36,6 @@ void RemoteChip::read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, 
     remote_communication_->read_non_mmio(eth_chip_location_, translated_core, dest, l1_src, size);
 }
 
-void RemoteChip::write_to_device_reg(tt_xy_pair core, const void* src, uint64_t reg_dest, uint32_t size) {
-    write_to_device(core, src, reg_dest, size);
-}
-
-void RemoteChip::read_from_device_reg(tt_xy_pair core, void* dest, uint64_t reg_src, uint32_t size) {
-    read_from_device(core, dest, reg_src, size);
-}
-
 // TODO: This translation should go away when we start using CoreCoord everywhere.
 tt_xy_pair RemoteChip::translate_chip_coord_virtual_to_translated(const tt_xy_pair core) {
     CoreCoord core_coord = get_soc_descriptor().get_coord_at(core, CoordSystem::VIRTUAL);


### PR DESCRIPTION
### Issue
On a path of #250 

### Description
Remove some unused APIs from Chip to make the transition easier.

### List of the changes
- Remove acquire_mutex from Chip API, as it is not needed in Cluster anymore
- Remove remote transfer eth core related Chip API, as it is not needed in Cluster anymore
- Move read/write _reg functions to Chip with the default implementation of using the non _reg variants. This was formerly in RemoteChip

### Testing
Client CIs

### API Changes
There are API changes in the whole PR stack which ends with : https://github.com/tenstorrent/tt-umd/pull/800
I'll merge the whole stack once the whole stack is approved, and then merge the changes in the clients.
Relevant links to CIs and PRs in clients are in the referenced PR
