### PR TITLE
Introduce close device to Chip

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -30,6 +30,7 @@ public:
     virtual ~Chip() = default;
 
     virtual void start_device() = 0;
+    virtual void close_device() = 0;
 
     tt_SocDescriptor& get_soc_descriptor();
 

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -24,6 +24,7 @@ public:
     bool is_mmio_capable() const override;
 
     void start_device() override;
+    void close_device() override;
 
     TTDevice* get_tt_device() override;
     SysmemManager* get_sysmem_manager() override;

--- a/device/api/umd/device/chip/mock_chip.h
+++ b/device/api/umd/device/chip/mock_chip.h
@@ -15,6 +15,7 @@ public:
     bool is_mmio_capable() const override;
 
     void start_device() override;
+    void close_device() override;
 
     void write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) override;
     void read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) override;

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -21,6 +21,7 @@ public:
     bool is_mmio_capable() const override;
 
     void start_device() override;
+    void close_device() override;
 
     void write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) override;
     void read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) override;

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -134,6 +134,8 @@ void LocalChip::start_device() {
     initialize_membars();
 }
 
+void LocalChip::close_device(){};
+
 void LocalChip::wait_eth_cores_training(const uint32_t timeout_ms) {
     if (get_tt_device()->get_arch() != tt::ARCH::BLACKHOLE) {
         return;

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -14,6 +14,8 @@ bool MockChip::is_mmio_capable() const { return false; }
 
 void MockChip::start_device() {}
 
+void MockChip::close_device() {}
+
 void MockChip::write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) {}
 
 void MockChip::read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) {}

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -26,6 +26,8 @@ bool RemoteChip::is_mmio_capable() const { return false; }
 
 void RemoteChip::start_device() {}
 
+void RemoteChip::close_device() {}
+
 void RemoteChip::write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) {
     auto translated_core = translate_chip_coord_virtual_to_translated(core);
     remote_communication_->write_to_non_mmio(eth_chip_location_, translated_core, src, l1_dest, size);

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1233,6 +1233,9 @@ void Cluster::start_device(const tt_device_params& device_params) {
 }
 
 void Cluster::close_device() {
+    for (auto chip_id : all_chip_ids_) {
+        get_chip(chip_id)->close_device();
+    }
     set_power_state(tt_DevicePowerState::LONG_IDLE);
     broadcast_tensix_risc_reset_to_cluster(TENSIX_ASSERT_SOFT_RESET);
 }


### PR DESCRIPTION
### Issue
On a path of #250 

### Description
Introduce close_device() which will gain more content in the following period.

### List of the changes
- Add close_device to chip.h
- Implement it trivially in derived classes

### Testing
Client CIs

### API Changes
There are API changes in the whole PR stack which ends with : https://github.com/tenstorrent/tt-umd/pull/800
I'll merge the whole stack once the whole stack is approved, and then merge the changes in the clients.
Relevant links to CIs and PRs in clients are in the referenced PR
