### PR TITLE
Introduce send_tensix_risc_reset to Chip

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -64,6 +64,7 @@ public:
     virtual void dram_membar(const std::unordered_set<uint32_t>& channels = {}) = 0;
 
     virtual void send_tensix_risc_reset(tt_xy_pair core, const TensixSoftResetOptions& soft_resets);
+    virtual void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets);
 
     virtual int arc_msg(
         uint32_t msg_code,

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -131,4 +131,10 @@ void Chip::send_tensix_risc_reset(tt_xy_pair core, const TensixSoftResetOptions&
     write_to_device_reg(core, &valid_val, 0xFFB121B0, sizeof(uint32_t));
     tt_driver_atomics::sfence();
 }
+
+void Chip::send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) {
+    for (const CoreCoord core : soc_descriptor_.get_all_cores(CoordSystem::VIRTUAL)) {
+        send_tensix_risc_reset(core, soft_resets);
+    }
+}
 }  // namespace tt::umd

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -133,7 +133,7 @@ void Chip::send_tensix_risc_reset(tt_xy_pair core, const TensixSoftResetOptions&
 }
 
 void Chip::send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) {
-    for (const CoreCoord core : soc_descriptor_.get_all_cores(CoordSystem::VIRTUAL)) {
+    for (const CoreCoord core : soc_descriptor_.get_cores(CoreType::TENSIX, CoordSystem::VIRTUAL)) {
         send_tensix_risc_reset(core, soft_resets);
     }
 }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1086,6 +1086,14 @@ void Cluster::broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOption
         // Nowhere to broadcast to.
         return;
     }
+    // If ethernet broadcast is not supported, do it one by one.
+    if (!use_ethernet_broadcast) {
+        for (auto& chip_id : all_chip_ids_) {
+            get_chip(chip_id)->send_tensix_risc_reset(soft_resets);
+        }
+        return;
+    }
+
     auto valid = soft_resets & ALL_TENSIX_SOFT_RESET;
     uint32_t valid_val = (std::underlying_type<TensixSoftResetOptions>::type)valid;
     std::set<chip_id_t> chips_to_exclude = {};


### PR DESCRIPTION
### Issue
On a path of #250 

### Description
Introduce an API which sends risc_reset signal to all cores on a chip.
Motivation for this change was that before this change, if we tried to use Mock/Simulation chip, the code would still go through the flow of trying to setup ethernet broadcast for broadcasting tensix reset, and then collapse to write_to_device_reg in case broadcast is not enabled. This change makes this happen a bit earlier, at the beginning of the broadcast_tensix_risc_reset_to_cluster function

### List of the changes
- Introduce send_tensix_risc_reset, which sends to all cores.
- Call send_tensix_risc_reset if broadcast is not enabled in broadcast_tensix_risc_reset_to_cluster

### Testing
Client CIs

### API Changes
There are API changes in the whole PR stack which ends with : https://github.com/tenstorrent/tt-umd/pull/800
I'll merge the whole stack once the whole stack is approved, and then merge the changes in the clients.
Relevant links to CIs and PRs in clients are in the referenced PR
