### PR TITLE
Implement new constructor accepting ClusterOptions

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -19,6 +19,7 @@
 #include "fmt/core.h"
 #include "tt_silicon_driver_common.hpp"
 #include "umd/device/chip/chip.h"
+#include "umd/device/tt_cluster_descriptor.h"
 #include "umd/device/tt_device/tt_device.h"
 #include "umd/device/tt_io.hpp"
 #include "umd/device/types/arch.h"

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -545,7 +545,7 @@ class RemoteChip;
 // Chip type to create under the Cluster class.
 //  - Silicon means that the chips under cluster will be connected to actual physical devices connected to the system.
 //  - Simulation is used for simulation runs.
-//  - Mock is used for testing purposes, which mocks all calls.
+//  - Mock is used for testing purposes, implementation of all functions is empty.
 enum ChipType {
     SILICON,
     SIMULATION,

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -589,7 +589,7 @@ public:
      * Cluster constructor. Construct chips per passed options.
      * @param options See documentation of ClusterOptions for explanation of specific arguments.
      */
-    Cluster(ClusterOptions options = {});
+    Cluster(ClusterOptions options);
 
     // TODO: The following constructors will be removed.
     /**

--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cstdint>
+#include <filesystem>
 #include <map>
 #include <memory>
 #include <set>
@@ -17,7 +18,6 @@
 #include <vector>
 
 #include "umd/device/chip/chip.h"
-#include "umd/device/cluster.h"
 #include "umd/device/topology_discovery.h"
 #include "umd/device/tt_xy_pair.h"
 #include "umd/device/types/arch.h"
@@ -25,6 +25,10 @@
 
 namespace YAML {
 class Node;
+}
+
+namespace tt::umd {
+class Cluster;
 }
 
 class tt_ClusterDescriptor {

--- a/device/api/umd/device/types/harvesting.h
+++ b/device/api/umd/device/types/harvesting.h
@@ -15,6 +15,14 @@ struct HarvestingMasks {
     size_t dram_harvesting_mask = 0;
     size_t eth_harvesting_mask = 0;
     size_t pcie_harvesting_mask = 0;
+
+    HarvestingMasks operator|(const HarvestingMasks& other) const {
+        return HarvestingMasks{
+            .tensix_harvesting_mask = this->tensix_harvesting_mask | other.tensix_harvesting_mask,
+            .dram_harvesting_mask = this->dram_harvesting_mask | other.dram_harvesting_mask,
+            .eth_harvesting_mask = this->eth_harvesting_mask | other.eth_harvesting_mask,
+            .pcie_harvesting_mask = this->pcie_harvesting_mask | other.pcie_harvesting_mask};
+    }
 };
 
 }  // namespace tt::umd

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -904,6 +904,12 @@ const std::unordered_set<chip_id_t> &tt_ClusterDescriptor::get_all_chips() const
 const std::vector<chip_id_t> tt_ClusterDescriptor::get_chips_local_first(std::unordered_set<chip_id_t> chips) const {
     std::vector<chip_id_t> chips_local_first;
     for (const auto &chip : chips) {
+        log_assert(
+            this->chip_locations.find(chip) != this->chip_locations.end(),
+            "Chip {} not found in cluster descriptor.",
+            chip);
+    }
+    for (const auto &chip : chips) {
         if (is_chip_mmio_capable(chip)) {
             chips_local_first.push_back(chip);
         }

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -905,7 +905,7 @@ const std::vector<chip_id_t> tt_ClusterDescriptor::get_chips_local_first(std::un
     std::vector<chip_id_t> chips_local_first;
     for (const auto &chip : chips) {
         log_assert(
-            this->chip_locations.find(chip) != this->chip_locations.end(),
+            this->enabled_active_chips.find(chip) != this->enabled_active_chips.end(),
             "Chip {} not found in cluster descriptor.",
             chip);
     }

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -8,6 +8,7 @@
 
 #include "disjoint_set.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
+#include "umd/device/cluster.h"
 #include "umd/device/pci_device.hpp"
 #include "umd/device/tt_cluster_descriptor.h"
 

--- a/tests/api/test_software_harvesting.cpp
+++ b/tests/api/test_software_harvesting.cpp
@@ -15,7 +15,7 @@
 using namespace tt::umd;
 
 TEST(SoftwareHarvesting, TensixSoftwareHarvestingAllChips) {
-    std::set<chip_id_t> target_devices = test_utils::get_target_devices();
+    std::unordered_set<chip_id_t> target_devices = test_utils::get_target_devices();
 
     int num_devices = target_devices.size();
     std::unordered_map<chip_id_t, HarvestingMasks> software_harvesting_masks;
@@ -25,8 +25,11 @@ TEST(SoftwareHarvesting, TensixSoftwareHarvestingAllChips) {
     }
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    std::unique_ptr<Cluster> cluster =
-        std::make_unique<Cluster>(num_host_mem_ch_per_mmio_device, false, true, software_harvesting_masks);
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
+        .simulated_harvesting_masks_per_chip = software_harvesting_masks,
+        .target_devices = target_devices,
+    });
 
     for (const chip_id_t& chip : cluster->get_target_device_ids()) {
         tt::ARCH arch = cluster->get_cluster_description()->get_arch(chip);

--- a/tests/blackhole/test_arc_messages_bh.cpp
+++ b/tests/blackhole/test_arc_messages_bh.cpp
@@ -7,7 +7,7 @@
 #include "gtest/gtest.h"
 #include "umd/device/arc_messenger.h"
 #include "umd/device/blackhole_arc_telemetry_reader.h"
-#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/cluster.h"
 #include "umd/device/types/blackhole_arc.h"
 
 using namespace tt::umd;

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -71,11 +71,14 @@ std::int32_t get_static_tlb_index(tt_xy_pair target) {
 }
 
 TEST(SiliconDriverBH, CreateDestroy) {
-    std::set<chip_id_t> target_devices = test_utils::get_target_devices();
+    std::unordered_set<chip_id_t> target_devices = test_utils::get_target_devices();
     uint32_t num_host_mem_ch_per_mmio_device = 1;
     tt_device_params default_params;
     for (int i = 0; i < 50; i++) {
-        Cluster cluster = Cluster(target_devices, num_host_mem_ch_per_mmio_device, false, true);
+        Cluster cluster = Cluster(ClusterOptions{
+            .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
+            .target_devices = target_devices,
+        });
         set_barrier_params(cluster);
         cluster.start_device(default_params);
         cluster.close_device();
@@ -212,11 +215,13 @@ TEST(SiliconDriverBH, CreateDestroy) {
 TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
     auto get_static_tlb_index_callback = [](tt_xy_pair target) { return get_static_tlb_index(target); };
 
-    std::set<chip_id_t> target_devices = test_utils::get_target_devices();
+    std::unordered_set<chip_id_t> target_devices = test_utils::get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster cluster = Cluster(num_host_mem_ch_per_mmio_device, false, true);
+    Cluster cluster = Cluster(ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
+    });
     set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
 
@@ -270,11 +275,13 @@ TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
 TEST(SiliconDriverBH, StaticTLB_RW) {
     auto get_static_tlb_index_callback = [](tt_xy_pair target) { return get_static_tlb_index(target); };
 
-    std::set<chip_id_t> target_devices = test_utils::get_target_devices();
+    std::unordered_set<chip_id_t> target_devices = test_utils::get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster cluster = Cluster(num_host_mem_ch_per_mmio_device, false, true);
+    Cluster cluster = Cluster(ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
+    });
     set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
 
@@ -332,10 +339,12 @@ TEST(SiliconDriverBH, StaticTLB_RW) {
 TEST(SiliconDriverBH, DynamicTLB_RW) {
     // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for
     // each transaction
-    std::set<chip_id_t> target_devices = test_utils::get_target_devices();
+    std::unordered_set<chip_id_t> target_devices = test_utils::get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    Cluster cluster = Cluster(num_host_mem_ch_per_mmio_device, false, true);
+    Cluster cluster = Cluster(ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
+    });
 
     set_barrier_params(cluster);
 
@@ -400,10 +409,12 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
     // Have 2 threads read and write from a single device concurrently
     // All transactions go through a single Dynamic TLB. We want to make sure this is thread/process safe
 
-    std::set<chip_id_t> target_devices = test_utils::get_target_devices();
+    std::unordered_set<chip_id_t> target_devices = test_utils::get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
-    Cluster cluster = Cluster(num_host_mem_ch_per_mmio_device, false, true);
+    Cluster cluster = Cluster(ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
+    });
 
     set_barrier_params(cluster);
 
@@ -459,11 +470,13 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     // Memory barrier flags get sent to address 0 for all channels in this test
     auto get_static_tlb_index_callback = [](tt_xy_pair target) { return get_static_tlb_index(target); };
 
-    std::set<chip_id_t> target_devices = test_utils::get_target_devices();
+    std::unordered_set<chip_id_t> target_devices = test_utils::get_target_devices();
     uint32_t base_addr = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster cluster = Cluster(num_host_mem_ch_per_mmio_device, false, true);
+    Cluster cluster = Cluster(ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
+    });
     set_barrier_params(cluster);
     for (int i = 0; i < target_devices.size(); i++) {
         // Iterate over devices and only setup static TLBs for functional worker cores
@@ -574,11 +587,13 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
 TEST(SiliconDriverBH, DISABLED_BroadcastWrite) {  // Cannot broadcast to tensix/ethernet and DRAM simultaneously on
                                                   // Blackhole .. wait_for_non_mmio_flush() is not working as expected?
     // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly
-    std::set<chip_id_t> target_devices = test_utils::get_target_devices();
+    std::unordered_set<chip_id_t> target_devices = test_utils::get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster cluster = Cluster(num_host_mem_ch_per_mmio_device, false, true);
+    Cluster cluster = Cluster(ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
+    });
     set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
 
@@ -652,11 +667,13 @@ TEST(SiliconDriverBH, DISABLED_BroadcastWrite) {  // Cannot broadcast to tensix/
 
 TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as above..
     // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly
-    std::set<chip_id_t> target_devices = test_utils::get_target_devices();
+    std::unordered_set<chip_id_t> target_devices = test_utils::get_target_devices();
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster cluster = Cluster(num_host_mem_ch_per_mmio_device, false, true);
+    Cluster cluster = Cluster(ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
+    });
     set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
 
@@ -742,10 +759,10 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as
 TEST(SiliconDriverBH, SysmemTestWithPcie) {
     auto target_devices = test_utils::get_target_devices();
 
-    Cluster cluster(
-        1,      // one "host memory channel",
-        false,  // skip driver allocs - no (don't skip)
-        true);  // perform harvesting - yes
+    Cluster cluster(ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = 1,  // one "host memory channel",
+        .perform_harvesting = true,
+    });
 
     set_barrier_params(cluster);
     cluster.start_device(tt_device_params{});  // no special parameters
@@ -787,13 +804,13 @@ TEST(SiliconDriverBH, SysmemTestWithPcie) {
 }
 
 static bool is_iommu_available() {
-    const size_t num_channels = 1;
+    const uint32_t num_channels = 1;
     auto target_devices = test_utils::get_target_devices();
-    Cluster cluster(
-        target_devices,
-        num_channels,
-        false,  // skip driver allocs - no (don't skip)
-        true);  // perform harvesting - yes
+    Cluster cluster(ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = num_channels,
+        .perform_harvesting = true,
+        .target_devices = target_devices,
+    });
     return cluster.get_tt_device(0)->get_pci_device()->is_iommu_enabled();
 }
 
@@ -804,14 +821,14 @@ static bool is_iommu_available() {
 TEST(SiliconDriverBH, RandomSysmemTestWithPcie) {
     // How many hugepages will Blackhole CI systems allocate?  Hopefully zero,
     // and they'll have IOMMU instead.  But if not, let's assume 2.
-    const size_t num_channels = is_iommu_available() ? 4 : 2;
+    const uint32_t num_channels = is_iommu_available() ? 4 : 2;
     auto target_devices = test_utils::get_target_devices();
 
-    Cluster cluster(
-        target_devices,
-        num_channels,
-        false,  // skip driver allocs - no (don't skip)
-        true);  // perform harvesting - yes
+    Cluster cluster(ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = num_channels,
+        .perform_harvesting = true,
+        .target_devices = target_devices,
+    });
 
     set_barrier_params(cluster);
     cluster.start_device(tt_device_params{});  // no special parameters

--- a/tests/galaxy/test_umd_concurrent_threads.cpp
+++ b/tests/galaxy/test_umd_concurrent_threads.cpp
@@ -27,7 +27,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
     std::shared_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
     std::set<chip_id_t> target_devices_th1 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
     std::set<chip_id_t> target_devices_th2 = {17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32};
-    std::set<chip_id_t> all_devices = {};
+    std::unordered_set<chip_id_t> all_devices = {};
     std::set_union(
         target_devices_th1.begin(),
         target_devices_th1.end(),
@@ -49,8 +49,12 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device =
-        Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), all_devices, num_host_mem_ch_per_mmio_device, false, true);
+    Cluster device(ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
+        .perform_harvesting = true,
+        .sdesc_path = test_utils::GetAbsPath(SOC_DESC_PATH),
+        .target_devices = all_devices,
+    });
 
     tt::umd::test::utils::set_barrier_params(device);
 
@@ -121,7 +125,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
     std::shared_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
     std::set<chip_id_t> target_devices_th1 = {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32};
     std::set<chip_id_t> target_devices_th2 = {1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31};
-    std::set<chip_id_t> all_devices = {};
+    std::unordered_set<chip_id_t> all_devices = {};
     std::set_union(
         std::begin(target_devices_th1),
         std::end(target_devices_th1),
@@ -143,8 +147,12 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device =
-        Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), all_devices, num_host_mem_ch_per_mmio_device, false, true);
+    Cluster device(ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
+        .perform_harvesting = true,
+        .sdesc_path = test_utils::GetAbsPath(SOC_DESC_PATH),
+        .target_devices = all_devices,
+    });
 
     tt::umd::test::utils::set_barrier_params(device);
 
@@ -204,7 +212,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
 TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
     // Galaxy Setup
     std::shared_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
-    std::set<chip_id_t> target_devices = {0, 1, 2, 3, 4, 5, 6, 7, 8};
+    std::unordered_set<chip_id_t> target_devices = {0, 1, 2, 3, 4, 5, 6, 7, 8};
     for (const auto& chip : target_devices) {
         // Verify that selected chips are in the cluster
         auto it = std::find(cluster_desc->get_all_chips().begin(), cluster_desc->get_all_chips().end(), chip);
@@ -214,8 +222,12 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device =
-        Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), target_devices, num_host_mem_ch_per_mmio_device, false, true);
+    Cluster device(ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
+        .perform_harvesting = true,
+        .sdesc_path = test_utils::GetAbsPath(SOC_DESC_PATH),
+        .target_devices = target_devices,
+    });
 
     tt::umd::test::utils::set_barrier_params(device);
 

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -22,15 +22,19 @@ static const std::string SOC_DESC_PATH = "tests/soc_descs/wormhole_b0_8x10.yaml"
 void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
     // Galaxy Setup
     std::shared_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
-    std::set<chip_id_t> target_devices = {};
+    std::unordered_set<chip_id_t> target_devices = {};
     for (const auto& chip : cluster_desc->get_all_chips()) {
         target_devices.insert(chip);
     }
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device =
-        Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), target_devices, num_host_mem_ch_per_mmio_device, false, true);
+    Cluster device(ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
+        .perform_harvesting = true,
+        .sdesc_path = test_utils::GetAbsPath(SOC_DESC_PATH),
+        .target_devices = target_devices,
+    });
 
     tt::umd::test::utils::set_barrier_params(device);
 
@@ -122,7 +126,7 @@ void run_data_mover_test(
     uint32_t vector_size, tt_multichip_core_addr sender_core, tt_multichip_core_addr receiver_core) {
     // Galaxy Setup
     std::shared_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
-    std::set<chip_id_t> target_devices = {};
+    std::unordered_set<chip_id_t> target_devices = {};
     for (const auto& chip : cluster_desc->get_all_chips()) {
         target_devices.insert(chip);
     }
@@ -138,8 +142,12 @@ void run_data_mover_test(
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device =
-        Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), target_devices, num_host_mem_ch_per_mmio_device, false, true);
+    Cluster device(ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
+        .perform_harvesting = true,
+        .sdesc_path = test_utils::GetAbsPath(SOC_DESC_PATH),
+        .target_devices = target_devices,
+    });
 
     tt::umd::test::utils::set_barrier_params(device);
 
@@ -234,7 +242,7 @@ void run_data_broadcast_test(
     uint32_t vector_size, tt_multichip_core_addr sender_core, std::vector<tt_multichip_core_addr> receiver_cores) {
     // Galaxy Setup
     std::shared_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
-    std::set<chip_id_t> target_devices = {};
+    std::unordered_set<chip_id_t> target_devices = {};
     for (const auto& chip : cluster_desc->get_all_chips()) {
         target_devices.insert(chip);
     }
@@ -252,8 +260,12 @@ void run_data_broadcast_test(
 
     uint32_t num_host_mem_ch_per_mmio_device = 1;
 
-    Cluster device =
-        Cluster(test_utils::GetAbsPath(SOC_DESC_PATH), target_devices, num_host_mem_ch_per_mmio_device, false, true);
+    Cluster device(ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
+        .perform_harvesting = true,
+        .sdesc_path = test_utils::GetAbsPath(SOC_DESC_PATH),
+        .target_devices = target_devices,
+    });
 
     tt::umd::test::utils::set_barrier_params(device);
 

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -47,8 +47,8 @@ inline void fill_with_random_bytes(uint8_t* data, size_t n) {
     }
 }
 
-static std::set<chip_id_t> get_target_devices() {
-    std::set<chip_id_t> target_devices;
+static std::unordered_set<chip_id_t> get_target_devices() {
+    std::unordered_set<chip_id_t> target_devices;
     std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq = tt::umd::Cluster::create_cluster_descriptor();
     for (int i = 0; i < cluster_desc_uniq->get_number_of_chips(); i++) {
         target_devices.insert(i);

--- a/tests/wormhole/test_wh_common.h
+++ b/tests/wormhole/test_wh_common.h
@@ -55,7 +55,10 @@ protected:
         std::iota(devices.begin(), devices.end(), 0);
         std::set<chip_id_t> target_devices = {devices.begin(), devices.end()};
         uint32_t num_host_mem_ch_per_mmio_device = 1;
-        cluster = std::make_unique<Cluster>(num_host_mem_ch_per_mmio_device, false, true);
+        cluster = std::make_unique<Cluster>(ClusterOptions{
+            .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
+            .perform_harvesting = true,
+        });
         assert(cluster != nullptr);
         assert(cluster->get_cluster_description()->get_number_of_chips() == get_detected_num_chips());
 


### PR DESCRIPTION
### Issue
On a path of #250 

### Description
Introduce new Cluster constructor, which accepts ClusterOptions. Motivation was that our number of constructors was exploding. This one allows changing any one of the options in isolation, or in any combination.

### List of the changes
- Introduce ChipType enum for chip_type argument, so we know which kind of cluster to create.
- Introduce ClusterOptions which should provide options to the constructor
- Changed create_mock_chip usage to go through ChipType
- New construct_soc_descriptor which seems like a better way to separate responsibilities. The second two construct_chip_from_cluster are marked as deprecated (removed in following PRs)
- Implement the new constructor, which should also service Chip and Simulation chips now.
- get_chips_local_first now also verifies chips are present in the cluster.
- target_devices in ClusterOptions are now unordered_set compared to a set in other constructors
- Changed all tests to use the new ClusterOptions constructor. Note that many of the values are default ones, and this is cleaned up in one of the following PRs

### Testing
Client CIs

### API Changes
There are API changes in the whole PR stack which ends with : https://github.com/tenstorrent/tt-umd/pull/800
I'll merge the whole stack once the whole stack is approved, and then merge the changes in the clients.
Relevant links to CIs and PRs in clients are in the referenced PR
