### PR TITLE
Simplify tests using default constructor values

### DIFF
--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -228,8 +228,7 @@ TEST(ClusterAPI, DynamicTLB_RW) {
 
     static const uint32_t num_loops = 100;
 
-    std::set<chip_id_t> target_devices = cluster->get_target_device_ids();
-    for (const chip_id_t chip : target_devices) {
+    for (const chip_id_t chip : cluster->get_target_device_ids()) {
         // Just make sure to skip L1_BARRIER_BASE
         std::uint32_t address = 0x100;
         // Write to each core a 100 times at different statically mapped addresses

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -44,42 +44,38 @@ TEST(ApiClusterTest, DifferentConstructors) {
     bool chips_available = !umd_cluster->get_target_device_ids().empty();
     umd_cluster = nullptr;
 
-    // 2. Constructor which allows choosing a subset of Chips to open.
-    chip_id_t logical_device_id = 0;
-    std::unordered_set<chip_id_t> target_devices = {};
     if (chips_available) {
-        target_devices = {logical_device_id};
-    }
-    umd_cluster = std::make_unique<Cluster>(ClusterOptions{
-        .target_devices = target_devices,
-    });
-    EXPECT_EQ(umd_cluster->get_target_device_ids().size(), target_devices.size());
-    umd_cluster = nullptr;
+        // 2. Constructor which allows choosing a subset of Chips to open.
+        umd_cluster = std::make_unique<Cluster>(ClusterOptions{
+            .target_devices = {0},
+        });
+        EXPECT_EQ(umd_cluster->get_target_device_ids().size(), 1);
+        umd_cluster = nullptr;
 
-    if (chips_available) {
         // 3. Constructor taking a custom soc descriptor in addition.
-        tt::ARCH device_arch = Cluster::create_cluster_descriptor()->get_arch(logical_device_id);
+        tt::ARCH device_arch = Cluster::create_cluster_descriptor()->get_arch(0);
         // You can add a custom soc descriptor here.
         std::string sdesc_path = tt_SocDescriptor::get_soc_descriptor_path(device_arch);
         umd_cluster = std::make_unique<Cluster>(ClusterOptions{
             .sdesc_path = sdesc_path,
-            .target_devices = target_devices,
         });
         umd_cluster = nullptr;
     }
 
     // 4. Constructor taking cluster descriptor based on which to create cluster.
-    // Create mock chips is set to true in order to create mock chips for the devices in the cluster descriptor.
+    // This could be cluster descriptor cached from previous runtime, or with some custom modifications.
     std::filesystem::path cluster_path = tt::umd::Cluster::serialize_to_file();
-    std::unordered_map<chip_id_t, HarvestingMasks> simulated_harvesting_masks = {};
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{
-        .chip_type = ChipType::MOCK,
-        .num_host_mem_ch_per_mmio_device = 1,
-        .perform_harvesting = true,
-        .simulated_harvesting_masks_per_chip = simulated_harvesting_masks,
+    umd_cluster = std::make_unique<Cluster>(ClusterOptions{
         .cluster_descriptor = tt_ClusterDescriptor::create_from_yaml(cluster_path),
-
     });
+    umd_cluster = nullptr;
+
+    // 5. Create mock chips is set to true in order to create mock chips for the devices in the cluster descriptor.
+    umd_cluster = std::make_unique<Cluster>(ClusterOptions{
+        .chip_type = ChipType::MOCK,
+        .target_devices = {0},
+    });
+    umd_cluster = nullptr;
 }
 
 TEST(ApiClusterTest, SimpleIOAllChips) {

--- a/tests/api/test_software_harvesting.cpp
+++ b/tests/api/test_software_harvesting.cpp
@@ -15,20 +15,8 @@
 using namespace tt::umd;
 
 TEST(SoftwareHarvesting, TensixSoftwareHarvestingAllChips) {
-    std::unordered_set<chip_id_t> target_devices = test_utils::get_target_devices();
-
-    int num_devices = target_devices.size();
-    std::unordered_map<chip_id_t, HarvestingMasks> software_harvesting_masks;
-
-    for (auto chip : target_devices) {
-        software_harvesting_masks[chip] = {0x3, 0, 0};
-    }
-
-    uint32_t num_host_mem_ch_per_mmio_device = 1;
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{
-        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
-        .simulated_harvesting_masks_per_chip = software_harvesting_masks,
-        .target_devices = target_devices,
+        .simulated_harvesting_masks = {0x3, 0, 0},
     });
 
     for (const chip_id_t& chip : cluster->get_target_device_ids()) {
@@ -46,9 +34,6 @@ TEST(SoftwareHarvesting, TensixSoftwareHarvestingAllChips) {
     }
 
     for (const chip_id_t& chip : cluster->get_target_device_ids()) {
-        EXPECT_TRUE(
-            (software_harvesting_masks.at(chip).tensix_harvesting_mask &
-             cluster->get_soc_descriptor(chip).harvesting_masks.tensix_harvesting_mask) ==
-            software_harvesting_masks.at(chip).tensix_harvesting_mask);
+        EXPECT_TRUE((0x3 & cluster->get_soc_descriptor(chip).harvesting_masks.tensix_harvesting_mask) == 0x3);
     }
 }

--- a/tests/galaxy/test_umd_concurrent_threads.cpp
+++ b/tests/galaxy/test_umd_concurrent_threads.cpp
@@ -18,8 +18,6 @@
 #include "wormhole/host_mem_address_map.h"
 #include "wormhole/l1_address_map.h"
 
-static const std::string SOC_DESC_PATH = "tests/soc_descs/wormhole_b0_8x10.yaml";
-
 // Have 2 threads read and write to all cores on the Galaxy
 TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
     // Galaxy Setup
@@ -47,12 +45,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
             << "Target chip on thread 2 " << chip << " is not in the Galaxy cluster";
     }
 
-    uint32_t num_host_mem_ch_per_mmio_device = 1;
-
     Cluster device(ClusterOptions{
-        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
-        .perform_harvesting = true,
-        .sdesc_path = test_utils::GetAbsPath(SOC_DESC_PATH),
         .target_devices = all_devices,
     });
 
@@ -145,12 +138,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
             << "Target chip on thread 2 " << chip << " is not in the Galaxy cluster";
     }
 
-    uint32_t num_host_mem_ch_per_mmio_device = 1;
-
     Cluster device(ClusterOptions{
-        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
-        .perform_harvesting = true,
-        .sdesc_path = test_utils::GetAbsPath(SOC_DESC_PATH),
         .target_devices = all_devices,
     });
 
@@ -220,12 +208,7 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
             << "Target chip " << chip << " is not in the Galaxy cluster";
     }
 
-    uint32_t num_host_mem_ch_per_mmio_device = 1;
-
     Cluster device(ClusterOptions{
-        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
-        .perform_harvesting = true,
-        .sdesc_path = test_utils::GetAbsPath(SOC_DESC_PATH),
         .target_devices = target_devices,
     });
 

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -17,24 +17,8 @@
 #include "wormhole/host_mem_address_map.h"
 #include "wormhole/l1_address_map.h"
 
-static const std::string SOC_DESC_PATH = "tests/soc_descs/wormhole_b0_8x10.yaml";
-
 void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
-    // Galaxy Setup
-    std::shared_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
-    std::unordered_set<chip_id_t> target_devices = {};
-    for (const auto& chip : cluster_desc->get_all_chips()) {
-        target_devices.insert(chip);
-    }
-
-    uint32_t num_host_mem_ch_per_mmio_device = 1;
-
-    Cluster device(ClusterOptions{
-        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
-        .perform_harvesting = true,
-        .sdesc_path = test_utils::GetAbsPath(SOC_DESC_PATH),
-        .target_devices = target_devices,
-    });
+    Cluster device;
 
     tt::umd::test::utils::set_barrier_params(device);
 
@@ -50,7 +34,7 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
 
     std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
 
-    for (const auto& chip : target_devices) {
+    for (const auto& chip : device.get_target_device_ids()) {
         std::vector<float> write_bw;
         std::vector<float> read_bw;
         for (int loop = 0; loop < 10; loop++) {
@@ -124,12 +108,8 @@ TEST(GalaxyBasicReadWrite, LargeRemoteDramBlockReadWrite) { run_remote_read_writ
 
 void run_data_mover_test(
     uint32_t vector_size, tt_multichip_core_addr sender_core, tt_multichip_core_addr receiver_core) {
-    // Galaxy Setup
-    std::shared_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
-    std::unordered_set<chip_id_t> target_devices = {};
-    for (const auto& chip : cluster_desc->get_all_chips()) {
-        target_devices.insert(chip);
-    }
+    Cluster device;
+    auto target_devices = device.get_target_device_ids();
 
     // Verify that sender chip and receiver chip are in the cluster
     auto it = std::find(target_devices.begin(), target_devices.end(), sender_core.chip);
@@ -139,15 +119,6 @@ void run_data_mover_test(
     it = std::find(target_devices.begin(), target_devices.end(), receiver_core.chip);
     ASSERT_TRUE(it != target_devices.end())
         << "Receiver core is on chip " << sender_core.chip << " which is not in the Galaxy cluster";
-
-    uint32_t num_host_mem_ch_per_mmio_device = 1;
-
-    Cluster device(ClusterOptions{
-        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
-        .perform_harvesting = true,
-        .sdesc_path = test_utils::GetAbsPath(SOC_DESC_PATH),
-        .target_devices = target_devices,
-    });
 
     tt::umd::test::utils::set_barrier_params(device);
 
@@ -240,12 +211,8 @@ TEST(GalaxyDataMovement, TwoChipMoveData4) {
 
 void run_data_broadcast_test(
     uint32_t vector_size, tt_multichip_core_addr sender_core, std::vector<tt_multichip_core_addr> receiver_cores) {
-    // Galaxy Setup
-    std::shared_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
-    std::unordered_set<chip_id_t> target_devices = {};
-    for (const auto& chip : cluster_desc->get_all_chips()) {
-        target_devices.insert(chip);
-    }
+    Cluster device;
+    auto target_devices = device.get_target_device_ids();
 
     // Verify that sender chip and receiver chip are in the cluster
     auto it = std::find(target_devices.begin(), target_devices.end(), sender_core.chip);
@@ -257,15 +224,6 @@ void run_data_broadcast_test(
         ASSERT_TRUE(it != target_devices.end())
             << "Receiver core is on chip " << sender_core.chip << " which is not in the Galaxy cluster";
     }
-
-    uint32_t num_host_mem_ch_per_mmio_device = 1;
-
-    Cluster device(ClusterOptions{
-        .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
-        .perform_harvesting = true,
-        .sdesc_path = test_utils::GetAbsPath(SOC_DESC_PATH),
-        .target_devices = target_devices,
-    });
 
     tt::umd::test::utils::set_barrier_params(device);
 
@@ -317,7 +275,7 @@ void run_data_broadcast_test(
 
 // L1 to L1 single chip
 TEST(GalaxyDataMovement, BroadcastData1) {
-    tt_SocDescriptor sdesc(test_utils::GetAbsPath(SOC_DESC_PATH), true);
+    tt_SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, true);
 
     tt_multichip_core_addr sender_core(4, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
     std::vector<tt_multichip_core_addr> receiver_cores;
@@ -330,7 +288,7 @@ TEST(GalaxyDataMovement, BroadcastData1) {
 
 // L1 to L1 multi chip
 TEST(GalaxyDataMovement, BroadcastData2) {
-    tt_SocDescriptor sdesc(test_utils::GetAbsPath(SOC_DESC_PATH), true);
+    tt_SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, true);
 
     tt_multichip_core_addr sender_core(12, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
     std::vector<tt_multichip_core_addr> receiver_cores;
@@ -372,7 +330,7 @@ TEST(GalaxyDataMovement, BroadcastData2) {
 
 // Dram to L1
 TEST(GalaxyDataMovement, BroadcastData3) {
-    tt_SocDescriptor sdesc(test_utils::GetAbsPath(SOC_DESC_PATH), true);
+    tt_SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, true);
 
     tt_multichip_core_addr sender_core(10, CoreCoord(0, 0, CoreType::DRAM, CoordSystem::VIRTUAL), 0x20000);
     std::vector<tt_multichip_core_addr> receiver_cores;
@@ -390,7 +348,7 @@ TEST(GalaxyDataMovement, BroadcastData3) {
 
 // L1 to Dram
 TEST(GalaxyDataMovement, BroadcastData4) {
-    tt_SocDescriptor sdesc(test_utils::GetAbsPath(SOC_DESC_PATH), true);
+    tt_SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, true);
 
     tt_multichip_core_addr sender_core(17, CoreCoord(8, 8, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x20000);
     std::vector<tt_multichip_core_addr> receiver_cores;
@@ -407,7 +365,7 @@ TEST(GalaxyDataMovement, BroadcastData4) {
 
 // Dram to Dram
 TEST(GalaxyDataMovement, BroadcastData5) {
-    tt_SocDescriptor sdesc(test_utils::GetAbsPath(SOC_DESC_PATH), true);
+    tt_SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, true);
 
     tt_multichip_core_addr sender_core(31, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x20000);
     std::vector<tt_multichip_core_addr> receiver_cores;

--- a/tests/microbenchmark/device_fixture.hpp
+++ b/tests/microbenchmark/device_fixture.hpp
@@ -29,7 +29,6 @@ protected:
             return flat_index;
         };
         std::set<chip_id_t> target_devices = {0};
-        uint32_t num_host_mem_ch_per_mmio_device = 1;
         device = std::make_shared<Cluster>(target_devices);
     }
 

--- a/tests/microbenchmark/device_fixture.hpp
+++ b/tests/microbenchmark/device_fixture.hpp
@@ -13,8 +13,6 @@
 #include "umd/device/cluster.h"
 #include "umd/device/tt_soc_descriptor.h"
 
-using tt::umd::Cluster;
-
 class uBenchmarkFixture : public ::testing::Test {
 protected:
     void SetUp() override {
@@ -28,7 +26,7 @@ protected:
             }
             return flat_index;
         };
-        device = std::make_shared<Cluster>(ClusterOptions{.target_devices = {0}});
+        device = std::make_shared<tt::umd::Cluster>(tt::umd::ClusterOptions{.target_devices = {0}});
     }
 
     void TearDown() override {
@@ -36,6 +34,6 @@ protected:
         results_csv.close();
     }
 
-    std::shared_ptr<Cluster> device;
+    std::shared_ptr<tt::umd::Cluster> device;
     std::ofstream results_csv;
 };

--- a/tests/microbenchmark/device_fixture.hpp
+++ b/tests/microbenchmark/device_fixture.hpp
@@ -28,8 +28,7 @@ protected:
             }
             return flat_index;
         };
-        std::set<chip_id_t> target_devices = {0};
-        device = std::make_shared<Cluster>(target_devices);
+        device = std::make_shared<Cluster>(ClusterOptions{.target_devices = {0}});
     }
 
     void TearDown() override {

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -47,13 +47,4 @@ inline void fill_with_random_bytes(uint8_t* data, size_t n) {
     }
 }
 
-static std::unordered_set<chip_id_t> get_target_devices() {
-    std::unordered_set<chip_id_t> target_devices;
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq = tt::umd::Cluster::create_cluster_descriptor();
-    for (int i = 0; i < cluster_desc_uniq->get_number_of_chips(); i++) {
-        target_devices.insert(i);
-    }
-    return target_devices;
-}
-
 }  // namespace test_utils

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -91,7 +91,7 @@ TEST(SiliconDriverWH, CreateDestroy) {
 
 TEST(SiliconDriverWH, CustomSocDesc) {
     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
-    Cluster cluster = Cluster(ClusterOptions{
+    Cluster cluster(ClusterOptions{
         .perform_harvesting = false,
         .simulated_harvesting_masks = {60, 0, 0},
         .simulated_harvesting_masks_per_chip = {{0, {30, 0, 0}}, {1, {60, 0, 0}}},
@@ -106,7 +106,7 @@ TEST(SiliconDriverWH, CustomSocDesc) {
 TEST(SiliconDriverWH, HarvestingRuntime) {
     auto get_static_tlb_index_callback = [](tt_xy_pair target) { return get_static_tlb_index(target); };
 
-    Cluster cluster = Cluster(ClusterOptions{
+    Cluster cluster(ClusterOptions{
         .simulated_harvesting_masks = {60, 0, 0},
         .simulated_harvesting_masks_per_chip = {{0, {30, 0, 0}}, {1, {60, 0, 0}}},
     });
@@ -741,7 +741,7 @@ TEST(SiliconDriverWH, SysmemTestWithPcie) {
 TEST(SiliconDriverWH, RandomSysmemTestWithPcie) {
     const uint32_t num_channels = 2;  // ideally 4, but CI seems to have 2...
 
-    Cluster cluster = Cluster(ClusterOptions{
+    Cluster cluster(ClusterOptions{
         .num_host_mem_ch_per_mmio_device = num_channels,
     });
 

--- a/tests/wormhole/test_wh_common.h
+++ b/tests/wormhole/test_wh_common.h
@@ -54,11 +54,7 @@ protected:
         auto devices = std::vector<chip_id_t>(get_detected_num_chips());
         std::iota(devices.begin(), devices.end(), 0);
         std::set<chip_id_t> target_devices = {devices.begin(), devices.end()};
-        uint32_t num_host_mem_ch_per_mmio_device = 1;
-        cluster = std::make_unique<Cluster>(ClusterOptions{
-            .num_host_mem_ch_per_mmio_device = num_host_mem_ch_per_mmio_device,
-            .perform_harvesting = true,
-        });
+        cluster = std::make_unique<Cluster>();
         assert(cluster != nullptr);
         assert(cluster->get_cluster_description()->get_number_of_chips() == get_detected_num_chips());
 

--- a/tests/wormhole/test_wh_common.h
+++ b/tests/wormhole/test_wh_common.h
@@ -50,10 +50,6 @@ protected:
             GTEST_SKIP() << "Test is skipped due to incorrect number of chips";
         }
 
-        assert(get_detected_num_chips() > 0);
-        auto devices = std::vector<chip_id_t>(get_detected_num_chips());
-        std::iota(devices.begin(), devices.end(), 0);
-        std::set<chip_id_t> target_devices = {devices.begin(), devices.end()};
         cluster = std::make_unique<Cluster>();
         assert(cluster != nullptr);
         assert(cluster->get_cluster_description()->get_number_of_chips() == get_detected_num_chips());


### PR DESCRIPTION
### Issue
On a path of #250 

### Description
Simplify tests, take advantage of default values.

### List of the changes
- Changed much code in tests.
- Removed .target_devices argument whenever whole cluster was expected
- Removed num_channels and perform_harvesting when they have default values.
- Changed DifferentConstructors tests a bit, added a new option

### Testing
Client CIs

### API Changes
There are API changes in the whole PR stack which ends with : https://github.com/tenstorrent/tt-umd/pull/800
I'll merge the whole stack once the whole stack is approved, and then merge the changes in the clients.
Relevant links to CIs and PRs in clients are in the referenced PR
