### PR TITLE
Derive SimulationDevice from Chip

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -73,6 +73,7 @@ if(TT_UMD_BUILD_SIMULATION)
             simulation/tt_simulation_host.cpp
             ${FBS_GENERATED_HEADER}
     )
+    target_compile_definitions(device PRIVATE TT_UMD_BUILD_SIMULATION)
 endif()
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -578,6 +578,8 @@ struct ClusterOptions {
     // type is SILICON, the constructor will throw if cluster_descriptor configuration shows chips which don't exist on
     // the system.
     std::unique_ptr<tt_ClusterDescriptor> cluster_descriptor = nullptr;
+    // This parameter is used only for SIMULATION chip type.
+    std::filesystem::path simulator_directory = "";
 };
 
 /**
@@ -908,7 +910,8 @@ private:
         const ChipType& chip_type,
         tt_ClusterDescriptor* cluster_desc,
         tt_SocDescriptor& soc_desc,
-        int num_host_mem_channels);
+        int num_host_mem_channels,
+        const std::filesystem::path& simulator_directory);
     tt_SocDescriptor construct_soc_descriptor(
         const std::string& soc_desc_path,
         chip_id_t chip_id,

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -10,6 +10,7 @@
 #include <filesystem>
 #include <vector>
 
+#include "umd/device/chip/chip.h"
 #include "umd/device/cluster.h"
 #include "umd/device/tt_simulation_host.hpp"
 
@@ -28,7 +29,7 @@ private:
     tt_SocDescriptor soc_descriptor;
 };
 
-class tt_SimulationDevice : public tt_device {
+class tt_SimulationDevice : public tt::umd::Chip {
 public:
     tt_SimulationDevice(const std::filesystem::path& simulator_directory) :
         tt_SimulationDevice(tt_SimulationDeviceInit(simulator_directory)) {}
@@ -38,60 +39,32 @@ public:
 
     tt_SimulationHost host;
 
-    virtual void set_barrier_address_params(const barrier_address_params& barrier_address_params_);
-    virtual void start_device(const tt_device_params& device_params);
-    virtual void assert_risc_reset();
-    virtual void deassert_risc_reset();
+    void start_device() override;
+    void close_device() override;
 
-    virtual void deassert_risc_reset_at_core(
-        const chip_id_t chip,
-        const tt::umd::CoreCoord core,
-        const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET);
-    virtual void assert_risc_reset_at_core(
-        const chip_id_t chip,
-        const tt::umd::CoreCoord core,
-        const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET);
+    bool is_mmio_capable() const override { return false; }
 
-    virtual void close_device();
+    // All tt_xy_pair cores in this class are defined in VIRTUAL coords.
+    void write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) override;
+    void read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) override;
 
-    // Runtime Functions
-    virtual void write_to_device(const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr);
-    virtual void write_to_device(
-        const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr);
-    virtual void read_from_device(void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size);
-    virtual void read_from_device(void* mem_ptr, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr, uint32_t size);
+    void wait_for_non_mmio_flush() override;
 
-    void dma_write_to_device(const void* src, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) {
-        throw std::runtime_error("DMA write not supported in simulation mode.");
-    }
+    void l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
+    void dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
+    void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
 
-    void dma_read_from_device(void* dst, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) {
-        throw std::runtime_error("DMA read not supported in simulation mode.");
-    }
+    void send_tensix_risc_reset(tt_xy_pair core, const TensixSoftResetOptions& soft_resets) override;
+    void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) override;
 
-    virtual void wait_for_non_mmio_flush();
-    virtual void wait_for_non_mmio_flush(const chip_id_t chip);
-    void l1_membar(const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores = {});
-    void dram_membar(const chip_id_t chip, const std::unordered_set<uint32_t>& channels);
-    void dram_membar(const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores = {});
-
-    // Misc. Functions to Query/Set Device State
-    static std::vector<chip_id_t> detect_available_device_ids();
-    virtual std::set<chip_id_t> get_target_device_ids();
-    virtual std::set<chip_id_t> get_target_mmio_device_ids();
-    virtual std::set<chip_id_t> get_target_remote_device_ids();
-    virtual std::map<int, int> get_clocks();
-    virtual void* host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const;
-    virtual std::uint64_t get_pcie_base_addr_from_device(const chip_id_t chip_id) const;
-    virtual std::uint32_t get_num_host_channels(std::uint32_t device_id);
-    virtual std::uint32_t get_host_channel_size(std::uint32_t device_id, std::uint32_t channel);
-    virtual std::uint32_t get_numa_node_for_pcie_device(std::uint32_t device_id);
-    virtual const tt_SocDescriptor& get_soc_descriptor(chip_id_t chip_id) const;
-
-    virtual void configure_active_ethernet_cores_for_mmio_device(
-        chip_id_t mmio_chip, const std::unordered_set<tt::umd::CoreCoord>& active_eth_cores_per_chip);
-
-    tt_xy_pair translate_to_api_coords(const chip_id_t chip, const tt::umd::CoreCoord core_coord) const;
+    int arc_msg(
+        uint32_t msg_code,
+        bool wait_for_done = true,
+        uint32_t arg0 = 0,
+        uint32_t arg1 = 0,
+        uint32_t timeout_ms = 1000,
+        uint32_t* return_3 = nullptr,
+        uint32_t* return_4 = nullptr) override;
 
 private:
     // State variables

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -161,8 +161,14 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
         return std::make_unique<MockChip>(soc_desc);
     }
     if (chip_type == ChipType::SIMULATION) {
+#ifdef TT_UMD_BUILD_SIMULATION
         // Note that passed soc descriptor is ignored in favor of soc descriptor from simulator_directory.
         return std::make_unique<tt_SimulationDevice>(simulator_directory);
+#else
+        throw std::runtime_error(
+            "Simulation device is not supported in this build. Set '-DTT_UMD_BUILD_SIMULATION=ON' during cmake "
+            "configuration to enable simulation device.");
+#endif
     }
 
     if (cluster_desc->is_chip_mmio_capable(chip_id)) {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -47,6 +47,7 @@
 #include "umd/device/topology_utils.h"
 #include "umd/device/tt_cluster_descriptor.h"
 #include "umd/device/tt_core_coordinates.h"
+#include "umd/device/tt_simulation_device.h"
 #include "umd/device/tt_soc_descriptor.h"
 #include "umd/device/types/arch.h"
 #include "umd/device/types/blackhole_arc.h"
@@ -154,13 +155,14 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     const ChipType& chip_type,
     tt_ClusterDescriptor* cluster_desc,
     tt_SocDescriptor& soc_desc,
-    int num_host_mem_channels) {
+    int num_host_mem_channels,
+    const std::filesystem::path& simulator_directory) {
     if (chip_type == ChipType::MOCK) {
         return std::make_unique<MockChip>(soc_desc);
     }
     if (chip_type == ChipType::SIMULATION) {
-        // TBD in following PRs
-        throw std::runtime_error("Simulation chip type is not supported yet.");
+        // Note that passed soc descriptor is ignored in favor of soc descriptor from simulator_directory.
+        return std::make_unique<tt_SimulationDevice>(simulator_directory);
     }
 
     if (cluster_desc->is_chip_mmio_capable(chip_id)) {
@@ -247,7 +249,12 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
         chip_board_type,
         asic_location);
     return construct_chip_from_cluster(
-        chip_id, create_mock_chip ? ChipType::MOCK : ChipType::SILICON, cluster_desc, soc_desc, num_host_mem_channels);
+        chip_id,
+        create_mock_chip ? ChipType::MOCK : ChipType::SILICON,
+        cluster_desc,
+        soc_desc,
+        num_host_mem_channels,
+        "");
 }
 
 std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
@@ -270,7 +277,12 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
         chip_board_type,
         asic_location);
     return construct_chip_from_cluster(
-        chip_id, create_mock_chip ? ChipType::MOCK : ChipType::SILICON, cluster_desc, soc_desc, num_host_mem_channels);
+        chip_id,
+        create_mock_chip ? ChipType::MOCK : ChipType::SILICON,
+        cluster_desc,
+        soc_desc,
+        num_host_mem_channels,
+        "");
 }
 
 void Cluster::add_chip(chip_id_t chip_id, std::unique_ptr<Chip> chip) {
@@ -443,7 +455,12 @@ Cluster::Cluster(ClusterOptions options) {
         add_chip(
             chip_id,
             construct_chip_from_cluster(
-                chip_id, options.chip_type, cluster_desc.get(), soc_desc, options.num_host_mem_ch_per_mmio_device));
+                chip_id,
+                options.chip_type,
+                cluster_desc.get(),
+                soc_desc,
+                options.num_host_mem_ch_per_mmio_device,
+                options.simulator_directory));
     }
 
     construct_cluster(options.num_host_mem_ch_per_mmio_device, options.chip_type != ChipType::SILICON);

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -19,7 +19,7 @@
 #include "umd/device/driver_atomics.h"
 
 flatbuffers::FlatBufferBuilder create_flatbuffer(
-    DEVICE_COMMAND rw, std::vector<uint32_t> vec, tt_cxy_pair core_, uint64_t addr, uint64_t size_ = 0) {
+    DEVICE_COMMAND rw, std::vector<uint32_t> vec, tt_xy_pair core_, uint64_t addr, uint64_t size_ = 0) {
     flatbuffers::FlatBufferBuilder builder;
     auto data = builder.CreateVector(vec);
     auto core = tt_vcs_core(core_.x, core_.y);
@@ -33,7 +33,7 @@ void print_flatbuffer(const DeviceRequestResponse* buf) {
     std::vector<uint32_t> data_vec(buf->data()->begin(), buf->data()->end());
     uint64_t addr = buf->address();
     uint32_t size = buf->size();
-    tt_cxy_pair core = {0, buf->core()->x(), buf->core()->y()};
+    tt_xy_pair core = {buf->core()->x(), buf->core()->y()};
 
     std::stringstream ss;
     ss << std::hex << reinterpret_cast<uintptr_t>(addr);
@@ -52,7 +52,7 @@ void print_flatbuffer(const DeviceRequestResponse* buf) {
 tt_SimulationDeviceInit::tt_SimulationDeviceInit(const std::filesystem::path& simulator_directory) :
     simulator_directory(simulator_directory), soc_descriptor(simulator_directory / "soc_descriptor.yaml", false) {}
 
-tt_SimulationDevice::tt_SimulationDevice(const tt_SimulationDeviceInit& init) : tt_device() {
+tt_SimulationDevice::tt_SimulationDevice(const tt_SimulationDeviceInit& init) : Chip(init.get_soc_descriptor()) {
     log_info(tt::LogEmulationDriver, "Instantiating simulation device");
     soc_descriptor_per_chip.emplace(0, init.get_soc_descriptor());
     arch_name = init.get_arch_name();
@@ -85,9 +85,7 @@ tt_SimulationDevice::tt_SimulationDevice(const tt_SimulationDeviceInit& init) : 
 
 tt_SimulationDevice::~tt_SimulationDevice() { close_device(); }
 
-void tt_SimulationDevice::set_barrier_address_params(const barrier_address_params& barrier_address_params_) {}
-
-void tt_SimulationDevice::start_device(const tt_device_params& device_params) {
+void tt_SimulationDevice::start_device() {
     void* buf_ptr = nullptr;
 
     host.start_host();
@@ -100,62 +98,55 @@ void tt_SimulationDevice::start_device(const tt_device_params& device_params) {
     nng_free(buf_ptr, buf_size);
 }
 
-void tt_SimulationDevice::assert_risc_reset() {
-    log_info(tt::LogEmulationDriver, "Sending assert_risc_reset signal..");
-    auto wr_buffer =
-        create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_ASSERT, std::vector<uint32_t>(1, 0), {0, 0, 0}, 0);
-    uint8_t* wr_buffer_ptr = wr_buffer.GetBufferPointer();
-    size_t wr_buffer_size = wr_buffer.GetSize();
-
-    print_flatbuffer(GetDeviceRequestResponse(wr_buffer_ptr));
-    host.send_to_device(wr_buffer_ptr, wr_buffer_size);
-}
-
-void tt_SimulationDevice::deassert_risc_reset() {
-    log_info(tt::LogEmulationDriver, "Sending 'deassert_risc_reset' signal..");
-    auto wr_buffer =
-        create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_DEASSERT, std::vector<uint32_t>(1, 0), {0, 0, 0}, 0);
-    uint8_t* wr_buffer_ptr = wr_buffer.GetBufferPointer();
-    size_t wr_buffer_size = wr_buffer.GetSize();
-
-    host.send_to_device(wr_buffer_ptr, wr_buffer_size);
-}
-
-void tt_SimulationDevice::deassert_risc_reset_at_core(
-    const chip_id_t chip, const tt::umd::CoreCoord core, const TensixSoftResetOptions& soft_resets) {
+void tt_SimulationDevice::send_tensix_risc_reset(tt_xy_pair core, const TensixSoftResetOptions& soft_resets) {
     log_info(
         tt::LogEmulationDriver,
-        "Sending 'deassert_risc_reset_at_core'.. (Not implemented, defaulting to 'deassert_risc_reset' instead)");
-    deassert_risc_reset();
+        "Sending 'send_tensix_risc_reset' for core.. (Not implemented, defaulting to 'send_tensix_risc_reset' "
+        "instead)");
+    send_tensix_risc_reset(soft_resets);
 }
 
-void tt_SimulationDevice::assert_risc_reset_at_core(
-    const chip_id_t chip, const tt::umd::CoreCoord core, const TensixSoftResetOptions& soft_resets) {
-    log_info(
-        tt::LogEmulationDriver,
-        "Sending 'assert_risc_reset_at_core'.. (Not implemented, defaulting to 'assert_risc_reset' instead)");
-    assert_risc_reset();
+void tt_SimulationDevice::send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) {
+    if (soft_resets == TENSIX_ASSERT_SOFT_RESET) {
+        log_info(tt::LogEmulationDriver, "Sending assert_risc_reset signal..");
+        auto wr_buffer =
+            create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_ASSERT, std::vector<uint32_t>(1, 0), {0, 0}, 0);
+        uint8_t* wr_buffer_ptr = wr_buffer.GetBufferPointer();
+        size_t wr_buffer_size = wr_buffer.GetSize();
+
+        print_flatbuffer(GetDeviceRequestResponse(wr_buffer_ptr));
+        host.send_to_device(wr_buffer_ptr, wr_buffer_size);
+    } else if (soft_resets == TENSIX_DEASSERT_SOFT_RESET) {
+        log_info(tt::LogEmulationDriver, "Sending 'deassert_risc_reset' signal..");
+        auto wr_buffer =
+            create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_DEASSERT, std::vector<uint32_t>(1, 0), {0, 0}, 0);
+        uint8_t* wr_buffer_ptr = wr_buffer.GetBufferPointer();
+        size_t wr_buffer_size = wr_buffer.GetSize();
+
+        host.send_to_device(wr_buffer_ptr, wr_buffer_size);
+    } else {
+        TT_THROW("Invalid soft reset option.");
+    }
 }
 
 void tt_SimulationDevice::close_device() {
     // disconnect from remote connection
     log_info(tt::LogEmulationDriver, "Sending exit signal to remote...");
-    auto builder = create_flatbuffer(DEVICE_COMMAND_EXIT, std::vector<uint32_t>(1, 0), {0, 0, 0}, 0);
+    auto builder = create_flatbuffer(DEVICE_COMMAND_EXIT, std::vector<uint32_t>(1, 0), {0, 0}, 0);
     host.send_to_device(builder.GetBufferPointer(), builder.GetSize());
 }
 
 // Runtime Functions
-void tt_SimulationDevice::write_to_device(
-    const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr) {
+void tt_SimulationDevice::write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) {
     log_info(
         tt::LogEmulationDriver,
-        "Device writing {} bytes to addr {} in core ({}, {})",
-        size_in_bytes,
-        addr,
+        "Device writing {} bytes to l1_dest {} in core ({}, {})",
+        size,
+        l1_dest,
         core.x,
         core.y);
-    std::vector<std::uint32_t> data((uint32_t*)mem_ptr, (uint32_t*)mem_ptr + size_in_bytes / sizeof(uint32_t));
-    auto wr_buffer = create_flatbuffer(DEVICE_COMMAND_WRITE, data, core, addr);
+    std::vector<std::uint32_t> data((uint32_t*)src, (uint32_t*)src + size / sizeof(uint32_t));
+    auto wr_buffer = create_flatbuffer(DEVICE_COMMAND_WRITE, data, core, l1_dest);
     uint8_t* wr_buffer_ptr = wr_buffer.GetBufferPointer();
     size_t wr_buffer_size = wr_buffer.GetSize();
 
@@ -163,16 +154,11 @@ void tt_SimulationDevice::write_to_device(
     host.send_to_device(wr_buffer_ptr, wr_buffer_size);
 }
 
-void tt_SimulationDevice::write_to_device(
-    const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) {
-    write_to_device(mem_ptr, size_in_bytes, {(size_t)chip, translate_to_api_coords(chip, core)}, addr);
-}
-
-void tt_SimulationDevice::read_from_device(void* mem_ptr, tt_cxy_pair core, uint64_t addr, uint32_t size) {
+void tt_SimulationDevice::read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) {
     void* rd_resp;
 
     // Send read request
-    auto rd_req_buf = create_flatbuffer(DEVICE_COMMAND_READ, {0}, core, addr, size);
+    auto rd_req_buf = create_flatbuffer(DEVICE_COMMAND_READ, {0}, core, l1_src, size);
     host.send_to_device(rd_req_buf.GetBufferPointer(), rd_req_buf.GetSize());
 
     // Get read response
@@ -184,67 +170,25 @@ void tt_SimulationDevice::read_from_device(void* mem_ptr, tt_cxy_pair core, uint
     log_debug(tt::LogEmulationDriver, "Device reading vec");
     print_flatbuffer(rd_resp_buf);
 
-    std::memcpy(mem_ptr, rd_resp_buf->data()->data(), rd_resp_buf->data()->size() * sizeof(uint32_t));
+    std::memcpy(dest, rd_resp_buf->data()->data(), rd_resp_buf->data()->size() * sizeof(uint32_t));
     nng_free(rd_resp, rd_rsp_sz);
-}
-
-void tt_SimulationDevice::read_from_device(
-    void* mem_ptr, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr, uint32_t size) {
-    read_from_device(mem_ptr, {(size_t)chip, translate_to_api_coords(chip, core)}, addr, size);
 }
 
 void tt_SimulationDevice::wait_for_non_mmio_flush() {}
 
-void tt_SimulationDevice::wait_for_non_mmio_flush(const chip_id_t chip) {}
+void tt_SimulationDevice::l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) {}
 
-void tt_SimulationDevice::l1_membar(const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores) {}
+void tt_SimulationDevice::dram_membar(const std::unordered_set<uint32_t>& channels) {}
 
-void tt_SimulationDevice::dram_membar(const chip_id_t chip, const std::unordered_set<uint32_t>& channels) {}
+void tt_SimulationDevice::dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) {}
 
-void tt_SimulationDevice::dram_membar(const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores) {}
-
-// Misc. Functions to Query/Set Device State
-std::vector<chip_id_t> tt_SimulationDevice::detect_available_device_ids() { return {0}; }
-
-std::set<chip_id_t> tt_SimulationDevice::get_target_device_ids() { return target_devices_in_cluster; }
-
-std::set<chip_id_t> tt_SimulationDevice::get_target_mmio_device_ids() { return target_devices_in_cluster; }
-
-std::set<chip_id_t> tt_SimulationDevice::get_target_remote_device_ids() { return target_remote_chips; }
-
-std::map<int, int> tt_SimulationDevice::get_clocks() { return {{0, 0}}; }
-
-void* tt_SimulationDevice::host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const {
-    return nullptr;
-}
-
-std::uint64_t tt_SimulationDevice::get_pcie_base_addr_from_device(const chip_id_t chip_id) const {
-    if (arch_name == tt::ARCH::WORMHOLE_B0) {
-        return 0x800000000;
-    } else if (arch_name == tt::ARCH::BLACKHOLE) {
-        // Enable 4th ATU window.
-        return 1ULL << 60;
-    } else {
-        return 0;
-    }
-}
-
-std::uint32_t tt_SimulationDevice::get_num_host_channels(std::uint32_t device_id) { return 1; }
-
-std::uint32_t tt_SimulationDevice::get_host_channel_size(std::uint32_t device_id, std::uint32_t channel) { return 0; }
-
-std::uint32_t tt_SimulationDevice::get_numa_node_for_pcie_device(std::uint32_t device_id) { return 0; }
-
-const tt_SocDescriptor& tt_SimulationDevice::get_soc_descriptor(chip_id_t chip_id) const {
-    return soc_descriptor_per_chip.at(chip_id);
-};
-
-void tt_SimulationDevice::configure_active_ethernet_cores_for_mmio_device(
-    chip_id_t mmio_chip, const std::unordered_set<tt::umd::CoreCoord>& active_eth_cores_per_chip) {}
-
-// TODO: This is a temporary function while we're switching between the old and the new API.
-// Eventually, this function should be so small it would be obvioud to remove.
-tt_xy_pair tt_SimulationDevice::translate_to_api_coords(
-    const chip_id_t chip, const tt::umd::CoreCoord core_coord) const {
-    return get_soc_descriptor(chip).translate_coord_to(core_coord, CoordSystem::VIRTUAL);
+int tt_SimulationDevice::arc_msg(
+    uint32_t msg_code,
+    bool wait_for_done,
+    uint32_t arg0,
+    uint32_t arg1,
+    uint32_t timeout_ms,
+    uint32_t* return_3,
+    uint32_t* return_4) {
+    return 0;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,9 +70,12 @@ add_custom_target(
         unit_tests_blackhole
         unit_tests_wormhole
         unit_tests_glx
-        simulation_tests
         test_pcie_device
         api_tests
         umd_misc_tests
         unified_tests
 )
+
+if(TT_UMD_BUILD_SIMULATION)
+    add_dependencies(umd_tests simulation_tests)
+endif()

--- a/tests/simulation/device_fixture.hpp
+++ b/tests/simulation/device_fixture.hpp
@@ -19,15 +19,14 @@
 class SimulationDeviceFixture : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        // default_params and yaml path are both dummy and won't change test behavior
-        tt_device_params default_params;
+        // yaml path is dummy and won't change test behavior
         const char* simulator_path = getenv("TT_UMD_SIMULATOR");
         if (simulator_path == nullptr) {
             throw std::runtime_error(
                 "You need to define TT_UMD_SIMULATOR that will point to simulator path. eg. build/versim-wormhole-b0");
         }
         device = std::make_unique<tt_SimulationDevice>(simulator_path);
-        device->start_device(default_params);
+        device->start_device();
     }
 
     static void TearDownTestSuite() { device->close_device(); }

--- a/tests/simulation/test_simulation_device.cpp
+++ b/tests/simulation/test_simulation_device.cpp
@@ -28,7 +28,7 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(LoopbackAllCoresParam, LoopbackSingleTensix) {
     std::vector<uint32_t> wdata = {1, 2, 3, 4, 5};
     std::vector<uint32_t> rdata(wdata.size(), 0);
-    auto &soc_desc = device->get_soc_descriptor(0);
+    auto &soc_desc = device->get_soc_descriptor();
     tt::umd::CoreCoord core = soc_desc.get_coord_at(GetParam(), CoordSystem::VIRTUAL);
 
     device->write_to_device(core, wdata.data(), 0x100, wdata.size() * sizeof(uint32_t));
@@ -50,7 +50,7 @@ bool loopback_stress_size(std::unique_ptr<tt_SimulationDevice> &device, tt::umd:
 }
 
 TEST_P(LoopbackAllCoresParam, LoopbackStressSize) {
-    auto &soc_desc = device->get_soc_descriptor(0);
+    auto &soc_desc = device->get_soc_descriptor();
     tt::umd::CoreCoord core = soc_desc.get_coord_at(GetParam(), CoordSystem::VIRTUAL);
     tt::umd::CoreCoord dram = soc_desc.get_coord_at({1, 0}, CoordSystem::VIRTUAL);
     if (core == dram) {
@@ -65,7 +65,7 @@ TEST_P(LoopbackAllCoresParam, LoopbackStressSize) {
 }
 
 TEST_F(SimulationDeviceFixture, LoopbackTwoTensix) {
-    auto &soc_desc = device->get_soc_descriptor(0);
+    auto &soc_desc = device->get_soc_descriptor();
     std::vector<uint32_t> wdata1 = {1, 2, 3, 4, 5};
     std::vector<uint32_t> wdata2 = {6, 7, 8, 9, 10};
     std::vector<uint32_t> rdata1(wdata1.size());

--- a/tests/simulation/test_simulation_device.cpp
+++ b/tests/simulation/test_simulation_device.cpp
@@ -31,8 +31,8 @@ TEST_P(LoopbackAllCoresParam, LoopbackSingleTensix) {
     auto &soc_desc = device->get_soc_descriptor(0);
     tt::umd::CoreCoord core = soc_desc.get_coord_at(GetParam(), CoordSystem::VIRTUAL);
 
-    device->write_to_device(wdata.data(), wdata.size() * sizeof(uint32_t), 0, core, 0x100);
-    device->read_from_device(rdata.data(), 0, core, 0x100, rdata.size() * sizeof(uint32_t));
+    device->write_to_device(core, wdata.data(), 0x100, wdata.size() * sizeof(uint32_t));
+    device->read_from_device(core, rdata.data(), 0x100, rdata.size() * sizeof(uint32_t));
 
     ASSERT_EQ(wdata, rdata);
 }
@@ -43,8 +43,8 @@ bool loopback_stress_size(std::unique_ptr<tt_SimulationDevice> &device, tt::umd:
     std::vector<uint32_t> wdata = generate_data(1 << byte_shift);
     std::vector<uint32_t> rdata(wdata.size(), 0);
 
-    device->write_to_device(wdata.data(), wdata.size() * sizeof(uint32_t), 0, core, addr);
-    device->read_from_device(rdata.data(), 0, core, addr, rdata.size() * sizeof(uint32_t));
+    device->write_to_device(core, wdata.data(), addr, wdata.size() * sizeof(uint32_t));
+    device->read_from_device(core, rdata.data(), addr, rdata.size() * sizeof(uint32_t));
 
     return wdata == rdata;
 }
@@ -73,11 +73,11 @@ TEST_F(SimulationDeviceFixture, LoopbackTwoTensix) {
     tt::umd::CoreCoord core1 = soc_desc.get_coord_at({0, 1}, CoordSystem::VIRTUAL);
     tt::umd::CoreCoord core2 = soc_desc.get_coord_at({1, 1}, CoordSystem::VIRTUAL);
 
-    device->write_to_device(wdata1.data(), wdata1.size() * sizeof(uint32_t), 0, core1, 0x100);
-    device->write_to_device(wdata2.data(), wdata2.size() * sizeof(uint32_t), 0, core2, 0x100);
+    device->write_to_device(core1, wdata1.data(), 0x100, wdata1.size() * sizeof(uint32_t));
+    device->write_to_device(core2, wdata2.data(), 0x100, wdata2.size() * sizeof(uint32_t));
 
-    device->read_from_device(rdata1.data(), 0, core1, 0x100, rdata1.size() * sizeof(uint32_t));
-    device->read_from_device(rdata2.data(), 0, core2, 0x100, rdata2.size() * sizeof(uint32_t));
+    device->read_from_device(core1, rdata1.data(), 0x100, rdata1.size() * sizeof(uint32_t));
+    device->read_from_device(core2, rdata2.data(), 0x100, rdata2.size() * sizeof(uint32_t));
 
     ASSERT_EQ(wdata1, rdata1);
     ASSERT_EQ(wdata2, rdata2);


### PR DESCRIPTION
### Issue
On a path of #250 
Solves #249

### Description
Implement SimulationDevice as Chip as oppossed to tt_device.
Simulation should be created from the Cluster from now on.

### List of the changes
- Change : public tt_device to : public Chip
- Introduce simulator_directory option in ClusterOptions and propagate it.
- Change SimulationDevice header so that it matches what's in the Chip.
- Change slightly implementation in SimulationDevice so it matches the new API, the implementation is not actually changed that much.
- Change simulation tests since the API changed.

### Testing
Client CIs

### API Changes
There are API changes in the whole PR stack which ends with : https://github.com/tenstorrent/tt-umd/pull/800
I'll merge the whole stack once the whole stack is approved, and then merge the changes in the clients.
Relevant links to CIs and PRs in clients are in the referenced PR
