### PR TITLE
Remove serialize from Cluster

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -782,10 +782,6 @@ public:
 
     static std::unique_ptr<tt_ClusterDescriptor> create_cluster_descriptor(std::string sdesc_path = "");
 
-    static std::string serialize();
-
-    static std::filesystem::path serialize_to_file(const std::filesystem::path& dest_file = "");
-
     // Destructor
     virtual ~Cluster();
 

--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -142,10 +142,10 @@ public:
 
     void enable_all_devices();
 
+    // Serialize the cluster descriptor to a YAML string, or directly to a file.
+    // A default file in /tmp directory will be used if no path is passed.
     std::string serialize() const;
-
-    void serialize_to_file(const std::filesystem::path &dest_file) const;
-
+    std::filesystem::path serialize_to_file(const std::filesystem::path &dest_file = "") const;
     static std::filesystem::path get_default_cluster_descriptor_file_path();
 
     std::set<uint32_t> get_active_eth_channels(chip_id_t chip_id);

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1422,15 +1422,4 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
     return desc;
 }
 
-std::string Cluster::serialize() { return Cluster::create_cluster_descriptor()->serialize(); }
-
-std::filesystem::path Cluster::serialize_to_file(const std::filesystem::path& dest_file) {
-    std::filesystem::path file_path = dest_file;
-    if (file_path.empty()) {
-        file_path = tt_ClusterDescriptor::get_default_cluster_descriptor_file_path();
-    }
-    Cluster::create_cluster_descriptor()->serialize_to_file(file_path);
-    return file_path;
-}
-
 }  // namespace tt::umd

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -1052,10 +1052,15 @@ std::string tt_ClusterDescriptor::serialize() const {
     return out.c_str();
 }
 
-void tt_ClusterDescriptor::serialize_to_file(const std::filesystem::path &dest_file) const {
+std::filesystem::path tt_ClusterDescriptor::serialize_to_file(const std::filesystem::path &dest_file) const {
+    std::filesystem::path file_path = dest_file;
+    if (file_path.empty()) {
+        file_path = get_default_cluster_descriptor_file_path();
+    }
     std::ofstream file(dest_file);
     file << serialize();
     file.close();
+    return file_path;
 }
 
 std::filesystem::path tt_ClusterDescriptor::get_default_cluster_descriptor_file_path() {

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -1057,7 +1057,7 @@ std::filesystem::path tt_ClusterDescriptor::serialize_to_file(const std::filesys
     if (file_path.empty()) {
         file_path = get_default_cluster_descriptor_file_path();
     }
-    std::ofstream file(dest_file);
+    std::ofstream file(file_path);
     file << serialize();
     file.close();
     return file_path;

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -64,9 +64,15 @@ TEST(ApiClusterTest, DifferentConstructors) {
 
     // 4. Constructor taking cluster descriptor based on which to create cluster.
     // This could be cluster descriptor cached from previous runtime, or with some custom modifications.
-    std::filesystem::path cluster_path = tt::umd::Cluster::serialize_to_file();
+    // You can just create a cluster descriptor and serialize it to file, or fetch a cluster descriptor from already
+    // created Cluster class.
+    std::filesystem::path cluster_path1 = tt::umd::Cluster::create_cluster_descriptor()->serialize_to_file();
+    umd_cluster = std::make_unique<Cluster>();
+    std::filesystem::path cluster_path2 = umd_cluster->get_cluster_description()->serialize_to_file();
+    umd_cluster = nullptr;
+
     umd_cluster = std::make_unique<Cluster>(ClusterOptions{
-        .cluster_descriptor = tt_ClusterDescriptor::create_from_yaml(cluster_path),
+        .cluster_descriptor = tt_ClusterDescriptor::create_from_yaml(cluster_path1),
     });
     umd_cluster = nullptr;
 

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -211,7 +211,7 @@ TEST(ApiClusterDescriptorTest, PrintClusterDescriptor) {
     // For wormhole we still use create-ethernet-map.
     std::filesystem::path cluster_path;
     if (tt_device->get_arch() == tt::ARCH::BLACKHOLE || tt_device->get_board_type() == BoardType::UBB) {
-        cluster_path = tt::umd::Cluster::serialize_to_file();
+        cluster_path = tt::umd::Cluster::create_cluster_descriptor()->serialize_to_file();
     } else {
         cluster_path = tt_ClusterDescriptor::get_cluster_descriptor_file_path();
     }

--- a/tools/topology.cpp
+++ b/tools/topology.cpp
@@ -27,7 +27,7 @@ int main(int argc, char *argv[]) {
         cluster_descriptor_path = result["path"].as<std::string>();
     }
 
-    std::string output_path = Cluster::serialize_to_file(cluster_descriptor_path);
+    std::string output_path = tt::umd::Cluster::create_cluster_descriptor()->serialize_to_file(cluster_descriptor_path);
     log_info(tt::LogSiliconDriver, "Cluster descriptor serialized to {}", output_path);
     return 0;
 }


### PR DESCRIPTION
### Issue
On a path of #250 

### Description
serialize in Cluster is unnecessary.

### List of the changes
- Remove serialize and serialize_to_file from Cluster
- Change the tests accordingly
- Slightly changed tt_ClusterDescriptor::serialize_to_file in case of no path provided

### Testing
Client CIs

### API Changes
There are API changes in the whole PR stack which ends with : https://github.com/tenstorrent/tt-umd/pull/800
I'll merge the whole stack once the whole stack is approved, and then merge the changes in the clients.
Relevant links to CIs and PRs in clients are in the referenced PR
