### PR TITLE
Remove cxy version of some Cluster functions

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -708,10 +708,6 @@ public:
         int32_t tlb_index,
         uint64_t address,
         uint64_t ordering = TLB_DATA::Posted);
-    virtual void deassert_risc_reset_at_core(
-        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET);
-    virtual void assert_risc_reset_at_core(
-        tt_cxy_pair core, const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET);
     // TODO: Add CoreCoord API for this function.
     void broadcast_write_to_cluster(
         const void* mem_ptr,
@@ -722,16 +718,6 @@ public:
         std::set<uint32_t>& columns_to_exclude);
 
     /**
-     * If the tlbs are initialized, returns a tuple with the TLB base address and its size
-     */
-    std::optional<std::tuple<uint32_t, uint32_t>> get_tlb_data_from_target(const tt_cxy_pair& target);
-
-    /**
-     * Returns a struct with the TLB configuration, or throws an exception if the target does not have a static TLB.
-     */
-    tlb_configuration get_tlb_configuration(const tt_cxy_pair& target);
-
-    /**
      * Provide fast write access to a statically-mapped TLB.
      * It is the caller's responsibility to ensure that
      * - the target has a static TLB mapping configured.
@@ -739,9 +725,10 @@ public:
      * - the Cluster instance outlives the returned object.
      * - use of the returned object is congruent with the target's TLB setup.
      *
-     * @param target The target chip and core to write to.
+     * @param chip The target chip to write to.
+     * @param target The target core to write to.
      */
-    tt::Writer get_static_tlb_writer(tt_cxy_pair target);
+    tt::Writer get_static_tlb_writer(const chip_id_t chip, const tt::umd::CoreCoord target);
 
     // New API. UMD is transitioning to use CoreCoord instead of tt_xy_pair.
     // This is new set of functions that should be used once the transition for clients (tt-metal, tt-lens) is complete.
@@ -769,10 +756,7 @@ public:
     virtual void dma_write_to_device(
         const void* src, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr);
     virtual void dma_read_from_device(void* dst, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr);
-    std::optional<std::tuple<uint32_t, uint32_t>> get_tlb_data_from_target(
-        const chip_id_t chip, const tt::umd::CoreCoord core);
     tlb_configuration get_tlb_configuration(const chip_id_t chip, const tt::umd::CoreCoord core);
-    tt::Writer get_static_tlb_writer(const chip_id_t chip, const tt::umd::CoreCoord target);
     virtual void configure_active_ethernet_cores_for_mmio_device(
         chip_id_t mmio_chip, const std::unordered_set<CoreCoord>& active_eth_cores_per_chip);
     void l1_membar(const chip_id_t chip, const std::unordered_set<CoreCoord>& cores = {});

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -68,7 +68,7 @@ TEST(ApiChipTest, ManualTLBConfiguration) {
     }
 
     // Expect not to throw for now configured mmio chip, same one as before.
-    EXPECT_NO_THROW(umd_cluster->get_static_tlb_writer(tt_cxy_pair(any_mmio_chip, core)));
+    EXPECT_NO_THROW(umd_cluster->get_static_tlb_writer(any_mmio_chip, core));
 
     // Expect to throw for non worker cores.
     CoreCoord dram_core = soc_desc.get_dram_cores()[0][0];
@@ -76,7 +76,7 @@ TEST(ApiChipTest, ManualTLBConfiguration) {
     auto eth_cores = soc_desc.get_cores(CoreType::ETH);
     if (!eth_cores.empty()) {
         CoreCoord eth_core = eth_cores[0];
-        EXPECT_THROW(umd_cluster->get_static_tlb_writer(tt_cxy_pair(any_mmio_chip, eth_core)), std::runtime_error);
+        EXPECT_THROW(umd_cluster->get_static_tlb_writer(any_mmio_chip, eth_core), std::runtime_error);
     }
 }
 


### PR DESCRIPTION
### Issue
On a path of #250 
Finally solves #602 

### Description
Clean up a couple of functions in Cluster api

### List of the changes
- Remove de/assert_risc_reset_at_core versions that accepted cxy_pair instead of CoreCoord, and changed their implementation slightly
- Remove get_tlb_data_from_target API, unnecessary
- Keep only CoreCoord version of get_tlb_configuration
- Minor change in one test

### Testing
Client CIs

### API Changes
There are API changes in the whole PR stack which ends with : https://github.com/tenstorrent/tt-umd/pull/800
I'll merge the whole stack once the whole stack is approved, and then merge the changes in the clients.
Relevant links to CIs and PRs in clients are in the referenced PR
