### PR TITLE
Update build-clients.yml for metal packaging

### DIFF
--- a/.github/workflows/build-clients.yml
+++ b/.github/workflows/build-clients.yml
@@ -36,6 +36,8 @@ jobs:
           path: tt-metal
           repository: tenstorrent/tt-metal
           submodules: recursive
+          fetch-depth: 500 # Need enough history for `git describe`
+          fetch-tags: true # Need tags for `git describe`
 
       - name: Checkout UMD
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description
```
CMake Error at /usr/share/cmake-4.0/Modules/WriteBasicConfigVersionFile.cmake:43 (message):
  No VERSION specified for WRITE_BASIC_CONFIG_VERSION_FILE()
Call Stack (most recent call first):
  /usr/share/cmake-4.0/Modules/CMakePackageConfigHelpers.cmake:407 (write_basic_config_version_file)
  cmake/packaging.cmake:45 (write_basic_package_version_file)
  CMakeLists.txt:313 (include)
```

### List of the changes
Fetch enough history, and tags, for git describe. Metal versioning depends on git describe.

### Testing
CI is my test bed.

### API Changes
There are no API changes in this PR.