### PR TITLE
Disable AICLK tests for busy value

### DIFF
--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -317,11 +317,9 @@ TEST(TestCluster, TestClusterAICLKControl) {
 
     auto clocks_busy = cluster->get_clocks();
     for (auto& clock : clocks_busy) {
-        // TODO: check this for Wormhole as well if we can somehow hardcode set of values to check for
-        // go busy AICLK. It won't always be the same for Wormhole.
-        if (cluster->get_cluster_description()->get_arch(clock.first) == tt::ARCH::BLACKHOLE) {
-            EXPECT_EQ(clock.second, get_expected_clock_val(clock.first, true));
-        }
+        // TODO #781: Figure out a proper mechanism to detect the right value. For now just check that Busy value is
+        // larger than Idle value.
+        EXPECT_LT(clock.second, get_expected_clock_val(clock.first, false));
     }
 
     cluster->set_power_state(tt_DevicePowerState::LONG_IDLE);

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -319,7 +319,7 @@ TEST(TestCluster, TestClusterAICLKControl) {
     for (auto& clock : clocks_busy) {
         // TODO #781: Figure out a proper mechanism to detect the right value. For now just check that Busy value is
         // larger than Idle value.
-        EXPECT_LT(clock.second, get_expected_clock_val(clock.first, false));
+        EXPECT_GT(clock.second, get_expected_clock_val(clock.first, false));
     }
 
     cluster->set_power_state(tt_DevicePowerState::LONG_IDLE);

--- a/tests/blackhole/test_arc_messages_bh.cpp
+++ b/tests/blackhole/test_arc_messages_bh.cpp
@@ -46,7 +46,7 @@ TEST(BlackholeArcMessages, BlackholeArcMessageHigherAIClock) {
         uint32_t aiclk = tt_device->get_clock();
 
         // TODO #781: For now expect only that busy val is something larger than idle val.
-        EXPECT_LT(aiclk, blackhole::AICLK_IDLE_VAL);
+        EXPECT_GT(aiclk, blackhole::AICLK_IDLE_VAL);
 
         response = bh_arc_messenger->send_message((uint32_t)blackhole::ArcMessageType::AICLK_GO_LONG_IDLE);
 

--- a/tests/blackhole/test_arc_messages_bh.cpp
+++ b/tests/blackhole/test_arc_messages_bh.cpp
@@ -45,7 +45,8 @@ TEST(BlackholeArcMessages, BlackholeArcMessageHigherAIClock) {
 
         uint32_t aiclk = tt_device->get_clock();
 
-        EXPECT_EQ(aiclk, blackhole::AICLK_BUSY_VAL);
+        // TODO #781: For now expect only that busy val is something larger than idle val.
+        EXPECT_LT(aiclk, blackhole::AICLK_IDLE_VAL);
 
         response = bh_arc_messenger->send_message((uint32_t)blackhole::ArcMessageType::AICLK_GO_LONG_IDLE);
 

--- a/tests/wormhole/test_arc_messages_wh.cpp
+++ b/tests/wormhole/test_arc_messages_wh.cpp
@@ -54,7 +54,8 @@ TEST(WormholeArcMessages, WormholeArcMessagesAICLK) {
 
         uint32_t aiclk = tt_device->get_clock();
 
-        EXPECT_EQ(aiclk, tt::umd::wormhole::AICLK_BUSY_VAL);
+        // TODO #781: For now expect only that busy val is something larger than idle val.
+        EXPECT_LT(aiclk, tt::umd::wormhole::AICLK_IDLE_VAL);
 
         response = arc_messenger->send_message(
             tt::umd::wormhole::ARC_MSG_COMMON_PREFIX |

--- a/tests/wormhole/test_arc_messages_wh.cpp
+++ b/tests/wormhole/test_arc_messages_wh.cpp
@@ -55,7 +55,7 @@ TEST(WormholeArcMessages, WormholeArcMessagesAICLK) {
         uint32_t aiclk = tt_device->get_clock();
 
         // TODO #781: For now expect only that busy val is something larger than idle val.
-        EXPECT_LT(aiclk, tt::umd::wormhole::AICLK_IDLE_VAL);
+        EXPECT_GT(aiclk, tt::umd::wormhole::AICLK_IDLE_VAL);
 
         response = arc_messenger->send_message(
             tt::umd::wormhole::ARC_MSG_COMMON_PREFIX |


### PR DESCRIPTION
### Issue
Related to #781

### Description
Until we figure out a proper mechanism, we shouldn't fail if we don't see the exact hardcoded busy value for aiclk.

### List of the changes
- Changed all tests that expected BUSY_VAL to instead expect larget than IDLE_VAL

### Testing
CI tests

### API Changes
There are no API changes in this PR.
