### PR TITLE
Remove grayskull download of noc parameters

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,7 +23,6 @@ target_include_directories(
 # It can slow down reconfigures
 # Here we skip downloading repeatedly
 set(ARCHS
-    grayskull
     wormhole
     blackhole
 )


### PR DESCRIPTION
### Description
File was removed from tt-metal main

```
CMake Error at tt_metal/third_party/umd/tests/CMakeLists.txt:47 (message):
  Failed to download
  https://raw.githubusercontent.com/tenstorrent/tt-metal/refs/heads/main/tt_metal/hw/inc/grayskull/noc/noc_parameters.h


-- Configuring incomplete, errors occurred!
Error: Process completed with exit code 1.
```

### List of the changes
Delete grayskull for noc parameters download, because the file doesn't exist anymore.

### Testing
CI is my testbed

### API Changes
There are no API changes in this PR.
