### PR TITLE
Ensure fmt is used as a static library

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -145,7 +145,7 @@ target_link_libraries(
         hwloc
         rt
         spdlog::spdlog_header_only
-        fmt::fmt-header-only
+        fmt::fmt
         yaml-cpp::yaml-cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/${CMAKE_SYSTEM_PROCESSOR}/libcreate_ethernet_map.a
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ target_link_libraries(
         gtest_main
         gtest
         pthread
-        fmt::fmt-header-only
+        fmt::fmt
         $<$<BOOL:${TT_UMD_BUILD_SIMULATION}>:nng>
 )
 target_include_directories(

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -102,7 +102,14 @@ endif()
 # fmt : https://github.com/fmtlib/fmt
 ###################################################################################################################
 
-CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 11.1.4)
+CPMAddPackage(
+    NAME fmt
+    GITHUB_REPOSITORY fmtlib/fmt
+    GIT_TAG 11.1.4
+    OPTIONS
+        "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
+        "BUILD_SHARED_LIBS OFF"
+)
 
 ###################################################################################################################
 # nanobench (for uBenchmarking)


### PR DESCRIPTION
### Description
I would like our usage of fmt, to use the static library target to save on compilation time.

### List of the changes
Ensure fmt is built as a static library.
Use `fmt::fmt` target, instead of the header only target.

### Testing
CI is my test bed.

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
