### PR TITLE
Fix blackhole NOC1 translation bugs

### DIFF
--- a/device/api/umd/device/blackhole_arc_message_queue.h
+++ b/device/api/umd/device/blackhole_arc_message_queue.h
@@ -46,7 +46,7 @@ private:
 
 public:
     BlackholeArcMessageQueue(
-        TTDevice* tt_device, const uint64_t base_address, const uint64_t size, const CoreCoord arc_core);
+        TTDevice* tt_device, const uint64_t base_address, const uint64_t size, const tt_xy_pair arc_core);
 
     /*
      * Send ARC message. The call of send_message is blocking, timeout is to be implemented.
@@ -73,7 +73,7 @@ private:
     const uint64_t base_address;
     const uint64_t size;
     TTDevice* tt_device;
-    const CoreCoord arc_core;
+    const tt_xy_pair arc_core;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/blackhole_arc_telemetry_reader.h
+++ b/device/api/umd/device/blackhole_arc_telemetry_reader.h
@@ -44,11 +44,7 @@ private:
     std::map<uint32_t, uint32_t> telemetry_offset;
 
     // During initialization of telemetry, if the NOC0 is hung then we need to read the telemetry values from NOC1.
-    const tt_xy_pair arc_core =
-        !umd_use_noc1 ? tt::umd::blackhole::ARC_CORES_NOC0[0]
-                      : tt_xy_pair(
-                            tt::umd::blackhole::NOC0_X_TO_NOC1_X[tt::umd::blackhole::ARC_CORES_NOC0[0].x],
-                            tt::umd::blackhole::NOC0_Y_TO_NOC1_Y[tt::umd::blackhole::ARC_CORES_NOC0[0].y]);
+    const tt_xy_pair arc_core;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/blackhole_implementation.h
+++ b/device/api/umd/device/blackhole_implementation.h
@@ -276,6 +276,10 @@ static const size_t pcie_translated_coordinate_start_y = 24;
 static const size_t dram_translated_coordinate_start_x = 17;
 static const size_t dram_translated_coordinate_start_y = 12;
 
+// Return arc core pair that can be used to access ARC core on the device. This depends on information
+// whether NOC translation is enabled and if we want to use NOC0 or NOC1.
+tt_xy_pair get_arc_core(const bool noc_translation_enabled, const bool umd_use_noc1);
+
 }  // namespace blackhole
 
 class blackhole_implementation : public architecture_implementation {

--- a/device/api/umd/device/tt_device/blackhole_tt_device.h
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.h
@@ -19,8 +19,6 @@ public:
 
     void configure_iatu_region(size_t region, uint64_t target, size_t region_size) override;
 
-    ChipInfo get_chip_info() override;
-
     void wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms = 1000) override;
 
     uint32_t get_clock() override;
@@ -31,6 +29,8 @@ public:
 
     BoardType get_board_type() override;
 
+    bool get_noc_translation_enabled() override;
+
     void dma_d2h(void *dst, uint32_t src, size_t size) override;
 
     void dma_h2d(uint32_t dst, const void *src, size_t size) override;
@@ -40,6 +40,8 @@ public:
     void dma_d2h_zero_copy(void *dst, uint32_t src, size_t size) override;
 
     std::vector<DramTrainingStatus> get_dram_training_status() override;
+
+    ChipInfo get_chip_info() override;
 
 private:
     static constexpr uint64_t ATU_OFFSET_IN_BH_BAR2 = 0x1200;

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -188,6 +188,8 @@ public:
 
     virtual BoardType get_board_type() = 0;
 
+    virtual bool get_noc_translation_enabled() = 0;
+
     // TODO: find a way to expose this in a better way, probably through getting telemetry reader and reading the
     // required fields. Returns the information whether DRAM training status is available and the status value.
     virtual std::vector<DramTrainingStatus> get_dram_training_status();
@@ -214,6 +216,8 @@ protected:
     // to 2-byte writes. We avoid ever performing a 1-byte write to the device. This only affects to device.
     void memcpy_to_device(void *dest, const void *src, std::size_t num_bytes);
     void memcpy_from_device(void *dest, const void *src, std::size_t num_bytes);
+
+    virtual void init_tt_device();
 
     ChipInfo chip_info;
 };

--- a/device/api/umd/device/tt_device/wormhole_tt_device.h
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.h
@@ -19,8 +19,6 @@ public:
 
     void wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms = 1000) override;
 
-    ChipInfo get_chip_info() override;
-
     uint32_t get_clock() override;
 
     uint32_t get_max_clock_freq() override;
@@ -28,6 +26,8 @@ public:
     uint32_t get_min_clock_freq() override;
 
     BoardType get_board_type() override;
+
+    bool get_noc_translation_enabled() override;
 
     std::vector<DramTrainingStatus> get_dram_training_status() override;
 
@@ -38,6 +38,8 @@ public:
     void dma_h2d_zero_copy(uint32_t dst, const void *src, size_t size) override;
 
     void dma_d2h_zero_copy(void *dst, uint32_t src, size_t size) override;
+
+    ChipInfo get_chip_info() override;
 
 private:
     void dma_d2h_transfer(void *dst, uint32_t src, size_t size);

--- a/device/blackhole/blackhole_arc_message_queue.cpp
+++ b/device/blackhole/blackhole_arc_message_queue.cpp
@@ -7,10 +7,12 @@
 
 #include "umd/device/tt_device/tt_device.h"
 
+extern bool umd_use_noc1;
+
 namespace tt::umd {
 
 BlackholeArcMessageQueue::BlackholeArcMessageQueue(
-    TTDevice* tt_device, const uint64_t base_address, const uint64_t size, const CoreCoord arc_core) :
+    TTDevice* tt_device, const uint64_t base_address, const uint64_t size, const tt_xy_pair arc_core) :
     base_address(base_address), size(size), tt_device(tt_device), arc_core(arc_core) {}
 
 void BlackholeArcMessageQueue::read_words(uint32_t* data, size_t num_words, size_t offset) {
@@ -114,7 +116,8 @@ uint32_t BlackholeArcMessageQueue::send_message(
 
 std::unique_ptr<BlackholeArcMessageQueue> BlackholeArcMessageQueue::get_blackhole_arc_message_queue(
     TTDevice* tt_device, const size_t queue_index) {
-    const CoreCoord arc_core = CoreCoord(8, 0, CoreType::ARC, CoordSystem::PHYSICAL);
+    const tt_xy_pair arc_core =
+        tt::umd::blackhole::get_arc_core(tt_device->get_noc_translation_enabled(), umd_use_noc1);
 
     uint32_t queue_control_block_addr;
     tt_device->read_from_device(&queue_control_block_addr, arc_core, blackhole::SCRATCH_RAM_11, sizeof(uint32_t));

--- a/device/blackhole/blackhole_implementation.cpp
+++ b/device/blackhole/blackhole_implementation.cpp
@@ -115,4 +115,14 @@ uint64_t blackhole_implementation::get_noc_reg_base(
     throw std::runtime_error("Invalid core type or NOC for getting NOC register addr base.");
 }
 
+namespace blackhole {
+tt_xy_pair get_arc_core(const bool noc_translation_enabled, const bool umd_use_noc1) {
+    return (noc_translation_enabled || !umd_use_noc1)
+               ? tt::umd::blackhole::ARC_CORES_NOC0[0]
+               : tt_xy_pair(
+                     tt::umd::blackhole::NOC0_X_TO_NOC1_X[tt::umd::blackhole::ARC_CORES_NOC0[0].x],
+                     tt::umd::blackhole::NOC0_Y_TO_NOC1_Y[tt::umd::blackhole::ARC_CORES_NOC0[0].y]);
+}
+}  // namespace blackhole
+
 }  // namespace tt::umd

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -394,11 +394,7 @@ tt_xy_pair LocalChip::translate_chip_coord_virtual_to_translated(const tt_xy_pai
     // On Wormhole Tensix can use NOC1 space if umd_use_noc1 is set to true.
     if (soc_descriptor_.noc_translation_enabled) {
         if (soc_descriptor_.arch == tt::ARCH::BLACKHOLE) {
-            if (core_coord.core_type == CoreType::TENSIX || !umd_use_noc1) {
-                return soc_descriptor_.translate_coord_to(core_coord, CoordSystem::TRANSLATED);
-            } else {
-                return soc_descriptor_.translate_coord_to(core_coord, CoordSystem::NOC1);
-            }
+            return soc_descriptor_.translate_coord_to(core_coord, CoordSystem::TRANSLATED);
         } else {
             return soc_descriptor_.translate_coord_to(
                 core_coord, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::TRANSLATED);

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -12,7 +12,9 @@
 namespace tt::umd {
 
 BlackholeTTDevice::BlackholeTTDevice(std::unique_ptr<PCIDevice> pci_device) :
-    TTDevice(std::move(pci_device), std::make_unique<blackhole_implementation>()) {}
+    TTDevice(std::move(pci_device), std::make_unique<blackhole_implementation>()) {
+    init_tt_device();
+}
 
 BlackholeTTDevice::~BlackholeTTDevice() {
     // Turn off iATU for the regions we programmed.  This won't happen if the
@@ -82,7 +84,20 @@ void BlackholeTTDevice::configure_iatu_region(size_t region, uint64_t target, si
         target);
 }
 
+bool BlackholeTTDevice::get_noc_translation_enabled() {
+    const uint64_t addr = blackhole::NIU_CFG_NOC0_BAR_ADDR;
+    uint32_t niu_cfg;
+    if (addr < get_pci_device()->bar0_uc_offset) {
+        read_block(addr, sizeof(niu_cfg), reinterpret_cast<uint8_t *>(&niu_cfg));
+    } else {
+        read_regs(addr, 1, &niu_cfg);
+    }
+
+    return ((niu_cfg >> 14) & 0x1) != 0;
+}
+
 ChipInfo BlackholeTTDevice::get_chip_info() {
+    ChipInfo chip_info;
     chip_info.harvesting_masks.tensix_harvesting_mask =
         telemetry->is_entry_available(blackhole::TAG_ENABLED_TENSIX_COL)
             ? (~telemetry->read_entry(blackhole::TAG_ENABLED_TENSIX_COL) & 0x3FFF)
@@ -114,15 +129,7 @@ ChipInfo BlackholeTTDevice::get_chip_info() {
     // Until then we have to read it from ETH core, it happens during topology exploration.
     // chip_info.chip_uid.asic_location = telemetry->read_entry(blackhole::TAG_ASIC_LOCATION);
 
-    const uint64_t addr = blackhole::NIU_CFG_NOC0_BAR_ADDR;
-    uint32_t niu_cfg;
-    if (addr < get_pci_device()->bar0_uc_offset) {
-        read_block(addr, sizeof(niu_cfg), reinterpret_cast<uint8_t *>(&niu_cfg));
-    } else {
-        read_regs(addr, 1, &niu_cfg);
-    }
-
-    chip_info.noc_translation_enabled = ((niu_cfg >> 14) & 0x1) != 0;
+    chip_info.noc_translation_enabled = get_noc_translation_enabled();
 
     // It is expected that these entries are always available.
     chip_info.chip_uid.board_id = ((uint64_t)telemetry->read_entry(blackhole::TAG_BOARD_ID_HIGH) << 32) |

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -22,6 +22,9 @@ TTDevice::TTDevice(
     architecture_impl_(std::move(architecture_impl)),
     arch(architecture_impl_->get_architecture()) {
     lock_manager.initialize_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num());
+}
+
+void TTDevice::init_tt_device() {
     arc_messenger_ = ArcMessenger::create_arc_messenger(this);
     telemetry = ArcTelemetryReader::create_arc_telemetry_reader(this);
 }
@@ -279,7 +282,8 @@ dynamic_tlb TTDevice::set_dynamic_tlb(
 
     log_trace(
         LogSiliconDriver,
-        "set_dynamic_tlb with arguments: tlb_index = {}, start = ({}, {}), end = ({}, {}), address = 0x{:x}, multicast "
+        "set_dynamic_tlb with arguments: tlb_index = {}, start = ({}, {}), end = ({}, {}), address = 0x{:x}, "
+        "multicast "
         "= {}, ordering = {}",
         tlb_index,
         start.x,
@@ -308,8 +312,9 @@ dynamic_tlb TTDevice::set_dynamic_tlb(
             .mcast = multicast,
             .ordering = ordering,
             // TODO #2715: hack for Blackhole A0, will potentially be fixed in B0.
-            // Using the same static vc for reads and writes through TLBs can hang the card. It doesn't even have to be
-            // the same TLB. Dynamic vc should not have this issue. There might be a perf impact with using dynamic vc.
+            // Using the same static vc for reads and writes through TLBs can hang the card. It doesn't even have to
+            // be the same TLB. Dynamic vc should not have this issue. There might be a perf impact with using
+            // dynamic vc.
             .static_vc = (arch == tt::ARCH::BLACKHOLE) ? false : true,
         }
             .apply_offset(tlb_config.offset);

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -14,19 +14,22 @@ static constexpr uint32_t DMA_TIMEOUT_MS = 10000;  // 10 seconds
 namespace tt::umd {
 
 WormholeTTDevice::WormholeTTDevice(std::unique_ptr<PCIDevice> pci_device) :
-    TTDevice(std::move(pci_device), std::make_unique<wormhole_implementation>()) {}
+    TTDevice(std::move(pci_device), std::make_unique<wormhole_implementation>()) {
+    init_tt_device();
+}
 
-ChipInfo WormholeTTDevice::get_chip_info() {
-    ChipInfo chip_info;
-
+bool WormholeTTDevice::get_noc_translation_enabled() {
     uint32_t niu_cfg;
     const tt_xy_pair dram_core = {0, 0};
     const uint64_t niu_cfg_addr = 0x1000A0000 + 0x100;
     read_from_device(&niu_cfg, dram_core, niu_cfg_addr, sizeof(uint32_t));
 
-    bool noc_translation_enabled = (niu_cfg & (1 << 14)) != 0;
+    return (niu_cfg & (1 << 14)) != 0;
+}
 
-    chip_info.noc_translation_enabled = noc_translation_enabled;
+ChipInfo WormholeTTDevice::get_chip_info() {
+    ChipInfo chip_info;
+    chip_info.noc_translation_enabled = get_noc_translation_enabled();
 
     std::vector<uint32_t> arc_msg_return_values = {0};
     const uint32_t timeout_ms = 1000;


### PR DESCRIPTION
### Issue

#776 

### Description

FIx readout of NOC1 node id for Blackhole on new 80.18 firmware. Telemetry reader and arc messenger were relying on predefined coordinates for ARC core, which may not always be true based on noc translation enabled and/or usage of NOC1. Additionally, mapping of ETH coordinates in NOC1 pre translated space is not the same as for NOC0 pre-translated space. Disable the readouts for NOC node id test for NOC1.

### List of the changes

- Dynamic choice of ARC core coordinates based on noc translation enabled and noc1 usage
- get_noc_translation_enabled for TTDevice
- Reenable NOC1 node id test
- Disable part for harvested ETH cores readouts

### Testing

CI

### API Changes
/
