### PR TITLE
Convert fatal numanode log to warning

### DIFF
--- a/device/cpuset_lib.cpp
+++ b/device/cpuset_lib.cpp
@@ -416,7 +416,8 @@ bool tt_cpuset_allocator::bind_area_memory_nodeset(chip_id_t physical_device_id,
         tid);
 
     if (m_physical_device_id_to_numa_nodeset_map.count(physical_device_id) == 0) {
-        log_fatal(
+        log_warning(
+            LogSiliconDriver,
             "bind_area_memory_nodeset(): Did not find physical_device_id: {} in numanode_mask map, this is not "
             "expected.",
             physical_device_id);


### PR DESCRIPTION
### Issue
Issue reported directly.

### Description
Given that this is the only left log_fatal in this file, I'd say it should be safe to convert it to warning. If numa node detection and binding fails, the driver can still continue execution

### List of the changes
- Change log_fatal to log_warning

### Testing
No testing

### API Changes
There are no API changes in this PR.
