### PR TITLE
Fix simulation test

### DIFF
--- a/tests/simulation/test_simulation_device.cpp
+++ b/tests/simulation/test_simulation_device.cpp
@@ -20,21 +20,16 @@ std::vector<uint32_t> generate_data(uint32_t size_in_bytes) {
     return data;
 }
 
-class LoopbackAllCoresParam : public SimulationDeviceFixture,
-                              public ::testing::WithParamInterface<tt::umd::CoreCoord> {};
+class LoopbackAllCoresParam : public SimulationDeviceFixture, public ::testing::WithParamInterface<tt_xy_pair> {};
 
 INSTANTIATE_TEST_SUITE_P(
-    LoopbackAllCores,
-    LoopbackAllCoresParam,
-    ::testing::Values(
-        tt::umd::CoreCoord{0, 1, CoreType::TENSIX, CoordSystem::VIRTUAL},
-        tt::umd::CoreCoord{1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL},
-        tt::umd::CoreCoord{1, 0, CoreType::DRAM, CoordSystem::VIRTUAL}));
+    LoopbackAllCores, LoopbackAllCoresParam, ::testing::Values(tt_xy_pair{0, 1}, tt_xy_pair{1, 1}, tt_xy_pair{1, 0}));
 
 TEST_P(LoopbackAllCoresParam, LoopbackSingleTensix) {
     std::vector<uint32_t> wdata = {1, 2, 3, 4, 5};
     std::vector<uint32_t> rdata(wdata.size(), 0);
-    tt::umd::CoreCoord core = GetParam();
+    auto &soc_desc = device->get_soc_descriptor(0);
+    tt::umd::CoreCoord core = soc_desc.get_coord_at(GetParam(), CoordSystem::VIRTUAL);
 
     device->write_to_device(wdata.data(), wdata.size() * sizeof(uint32_t), 0, core, 0x100);
     device->read_from_device(rdata.data(), 0, core, 0x100, rdata.size() * sizeof(uint32_t));
@@ -55,8 +50,9 @@ bool loopback_stress_size(std::unique_ptr<tt_SimulationDevice> &device, tt::umd:
 }
 
 TEST_P(LoopbackAllCoresParam, LoopbackStressSize) {
-    tt::umd::CoreCoord core = GetParam();
-    tt::umd::CoreCoord dram = {1, 0, CoreType::DRAM, CoordSystem::VIRTUAL};
+    auto &soc_desc = device->get_soc_descriptor(0);
+    tt::umd::CoreCoord core = soc_desc.get_coord_at(GetParam(), CoordSystem::VIRTUAL);
+    tt::umd::CoreCoord dram = soc_desc.get_coord_at({1, 0}, CoordSystem::VIRTUAL);
     if (core == dram) {
         for (uint32_t i = 2; i <= 30; ++i) {  // 2^30 = 1 GB
             ASSERT_TRUE(loopback_stress_size(device, core, i));
@@ -69,12 +65,13 @@ TEST_P(LoopbackAllCoresParam, LoopbackStressSize) {
 }
 
 TEST_F(SimulationDeviceFixture, LoopbackTwoTensix) {
+    auto &soc_desc = device->get_soc_descriptor(0);
     std::vector<uint32_t> wdata1 = {1, 2, 3, 4, 5};
     std::vector<uint32_t> wdata2 = {6, 7, 8, 9, 10};
     std::vector<uint32_t> rdata1(wdata1.size());
     std::vector<uint32_t> rdata2(wdata2.size());
-    tt::umd::CoreCoord core1 = {0, 1, CoreType::TENSIX, CoordSystem::VIRTUAL};
-    tt::umd::CoreCoord core2 = {1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL};
+    tt::umd::CoreCoord core1 = soc_desc.get_coord_at({0, 1}, CoordSystem::VIRTUAL);
+    tt::umd::CoreCoord core2 = soc_desc.get_coord_at({1, 1}, CoordSystem::VIRTUAL);
 
     device->write_to_device(wdata1.data(), wdata1.size() * sizeof(uint32_t), 0, core1, 0x100);
     device->write_to_device(wdata2.data(), wdata2.size() * sizeof(uint32_t), 0, core2, 0x100);


### PR DESCRIPTION
### Issue
Broken in #763

### Description
Seems like tensix and dram placement is not the same everywhere, so this can break simulator based on soc descriptor.

### List of the changes
- Revert testing values from CoreCoord to tt_xy_pair. The code will now find what is at that place.

### Testing
Manual testing by dzivanovicTT

### API Changes
There are no API changes in this PR.
