### PR TITLE
Telemetry tool

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -10,6 +10,17 @@ target_link_libraries(
         cxxopts::cxxopts
 )
 
+add_executable(telemetry telemetry.cpp)
+target_link_libraries(telemetry PRIVATE tools_common)
+set_target_properties(
+    telemetry
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${CMAKE_BINARY_DIR}/tools/umd/
+        OUTPUT_NAME
+            telemetry
+)
+
 add_executable(topology topology.cpp)
 target_link_libraries(topology PRIVATE tools_common)
 set_target_properties(
@@ -21,4 +32,9 @@ set_target_properties(
             topology
 )
 
-add_custom_target(umd_tools DEPENDS topology)
+add_custom_target(
+    umd_tools
+    DEPENDS
+        telemetry
+        topology
+)

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,33 @@
+# Tools
+
+## Build flow
+
+In general, see the common build instructions in the main [README](../README.md)
+
+Short instructions for building tools:
+```
+cmake -B build -G Ninja
+cmake --build build --target umd_tools
+```
+
+## Topology tool
+
+The topology tool can be used to generate cluster descriptor which describes system topology of tenstorrent devices.
+It shows information such as pci connected chips, remote chips, ethernet connections, harvesting, etc.
+
+You can run the following for more information:
+```
+./build/tools/umd/topology --help
+```
+
+## Telemetry tool
+
+The telemetry tool can be used to read telemetry from ARC. You can provide which pci chips should be polled, the frequency of polling and which telemetry to read.
+It has a special mode where it can read some important factors for Wormhole device.
+
+If you want to save the values, you can also pass an output file to write to.
+
+You can run the following for more information:
+```
+./build/tools/umd/telemetry --help
+```

--- a/tools/telemetry.cpp
+++ b/tools/telemetry.cpp
@@ -17,9 +17,9 @@
 using namespace tt::umd;
 
 std::string run_default_telemetry(int pci_device, ArcTelemetryReader* telemetry_reader) {
-    uint32_t aiclk_fmax = telemetry_reader->read_entry(wormhole::TAG_AICLK);
-    uint32_t aiclk_current = aiclk_fmax & 0xFFFF;
-    // uint32_t aiclk_fmax = aiclk_fmax >> 16;
+    // Holds information about the max AICLK value and the current one.
+    uint32_t aiclk_info = telemetry_reader->read_entry(wormhole::TAG_AICLK);
+    uint32_t aiclk_current = aiclk_info & 0xFFFF;
     uint32_t vcore = telemetry_reader->read_entry(wormhole::TAG_VCORE);
     uint32_t tdp = telemetry_reader->read_entry(wormhole::TAG_TDP) & 0xFFFF;
     uint32_t asic_temperature = telemetry_reader->read_entry(wormhole::TAG_ASIC_TEMPERATURE);
@@ -42,7 +42,8 @@ int main(int argc, char* argv[]) {
         cxxopts::value<std::vector<std::string>>())(
         "t,tag",
         "Telemetry tag to read. If set to -1, will run default telemetry mode which works only for WH and reads aiclk, "
-        "power, temperature and vcore",
+        "power, temperature and vcore. See device/api/umd/device/types/wormhole_telemetry.h (or blackhole_telemetry.h) "
+        "for all available tags.",
         cxxopts::value<int>()->default_value("-1"))(
         "f,freq", "Frequency of polling in microseconds.", cxxopts::value<int>()->default_value("1000"))(
         "o,outfile",

--- a/tools/telemetry.cpp
+++ b/tools/telemetry.cpp
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include <chrono>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "logger.hpp"
+#include "umd/device/arc_telemetry_reader.h"
+#include "umd/device/types/wormhole_telemetry.h"
+
+using namespace tt::umd;
+
+void run_default_telemetry(int pci_device, ArcTelemetryReader* telemetry_reader) {
+    uint32_t aiclk_fmax = telemetry_reader->read_entry(wormhole::TAG_AICLK);
+    uint32_t aiclk_current = aiclk_fmax & 0xFFFF;
+    // uint32_t aiclk_fmax = aiclk_fmax >> 16;
+    uint32_t vcore = telemetry_reader->read_entry(wormhole::TAG_VCORE);
+    uint32_t tdp = telemetry_reader->read_entry(wormhole::TAG_TDP) & 0xFFFF;
+    uint32_t asic_temperature = telemetry_reader->read_entry(wormhole::TAG_ASIC_TEMPERATURE);
+    uint32_t current_temperature = (asic_temperature & 0xFFFF) / 16.0;
+
+    log_info(
+        tt::LogSiliconDriver,
+        "Device id {} - AICLK: {} VCore: {} TDP: {} Temp: {}",
+        pci_device,
+        aiclk_current,
+        vcore,
+        tdp,
+        current_temperature);
+}
+
+std::vector<std::string> split(const std::string& str, char delim) {
+    std::vector<std::string> tokens;
+    std::stringstream ss(str);
+    std::string token;
+
+    while (std::getline(ss, token, delim)) {
+        tokens.push_back(token);
+    }
+
+    return tokens;
+}
+
+int main(int argc, char* argv[]) {
+    if (argc == 2 && std::string(argv[1]) == "help") {
+        std::cerr << "Usage: telemetry <telemetry_tag> <frequency_ms> <device_ids>" << std::endl;
+        std::cerr << "Example: telemetry 0,1,2,3 4 2" << std::endl;
+        std::cerr << "First argument is the list of device ids. For example 0,1,2,3. This refer to pci_ids"
+                  << std::endl;
+        std::cerr << "Second argument is the telemetry tag value. See all values in "
+                     "device/api/umd/device/types/wormhole_telemetry.h or blackhole_telemetry.h"
+                  << std::endl;
+        std::cerr << "Third argument is the frequency of pooling the telemetry in milliseconds" << std::endl;
+        return 1;
+    }
+
+    int frequency_ms = 1;
+    if (argc >= 4) {
+        frequency_ms = std::stoi(argv[3]);
+    }
+    int telemetry_tag = -1;
+    if (argc >= 3) {
+        telemetry_tag = std::stoi(argv[2]);
+    }
+
+    std::vector<int> discovered_pci_device_ids = PCIDevice::enumerate_devices();
+    std::vector<int> pci_device_ids;
+    if (argc >= 2) {
+        auto device_ids_str = split(argv[1], ',');
+
+        for (auto& device_id_str : device_ids_str) {
+            int device_id = std::stoi(device_id_str);
+            if (std::find(discovered_pci_device_ids.begin(), discovered_pci_device_ids.end(), device_id) ==
+                discovered_pci_device_ids.end()) {
+                std::cerr << "Device ID with pci id " << device_id << " not found in the system." << std::endl;
+                // Ignore this device id and continue.
+            } else {
+                pci_device_ids.push_back(device_id);
+            }
+        }
+    } else {
+        pci_device_ids = discovered_pci_device_ids;
+    }
+
+    std::vector<std::pair<int, std::unique_ptr<ArcTelemetryReader>>> telemetry_readers;
+    std::vector<std::unique_ptr<TTDevice>> tt_devices;
+    for (int pci_device_id : pci_device_ids) {
+        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        std::unique_ptr<ArcTelemetryReader> arc_telemetry_reader =
+            ArcTelemetryReader::create_arc_telemetry_reader(tt_device.get());
+        tt_devices.push_back(std::move(tt_device));
+        telemetry_readers.push_back(std::make_pair(pci_device_id, std::move(arc_telemetry_reader)));
+    }
+
+    while (true) {
+        auto start_time = std::chrono::steady_clock::now();
+        for (int i = 0; i < telemetry_readers.size(); i++) {
+            int device_id = telemetry_readers.at(i).first;
+            auto& telemetry_reader = telemetry_readers.at(i).second;
+
+            if (telemetry_tag == -1) {
+                run_default_telemetry(device_id, telemetry_reader.get());
+            } else {
+                uint32_t telemetry_value = telemetry_reader->read_entry(telemetry_tag);
+                log_info(tt::LogSiliconDriver, "Device id {} - Telemetry value: 0x{:x}", device_id, telemetry_value);
+            }
+        }
+
+        auto end_time = std::chrono::steady_clock::now();
+        auto time_passed = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time).count();
+        uint64_t time_to_wait = frequency_ms * 1000 - time_passed;
+        if (time_to_wait > 0) {
+            std::this_thread::sleep_for(std::chrono::microseconds(time_to_wait));
+        }
+    }
+
+    return 0;
+}

--- a/tools/telemetry.cpp
+++ b/tools/telemetry.cpp
@@ -25,7 +25,7 @@ void run_default_telemetry(int pci_device, ArcTelemetryReader* telemetry_reader)
 
     log_info(
         tt::LogSiliconDriver,
-        "Device id {} - AICLK: {} VCore: {} TDP: {} Temp: {}",
+        "Device id {} - AICLK: {} VCore: {} Power: {} Temp: {}",
         pci_device,
         aiclk_current,
         vcore,


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/788
Also, this was directly needed by ihamerTT

### Description
Added telemetry tool. You can filter the pci devices, request telemetry for any tag, and setup frequency of pooling.

### List of the changes
- Add telemetry tool
- Default behavior is that it is reading aiclk, vcore, temp
- If tag is selected it will pool on a tag
- Frequency in ms is adjustable

### Testing
Manually ran the tool to touch all codepaths on a WH card

### API Changes
There are no API changes in this PR.
