### PR TITLE
Non silicon chips are local chips

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -602,7 +602,8 @@ private:
     // Startup + teardown
     void create_device(
         const std::set<chip_id_t>& target_mmio_device_ids,
-        const uint32_t& num_host_mem_ch_per_mmio_device, const ChipType& chip_type);
+        const uint32_t& num_host_mem_ch_per_mmio_device,
+        const ChipType& chip_type);
     void broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOptions& soft_resets);
     void send_remote_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);
     void send_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -602,8 +602,7 @@ private:
     // Startup + teardown
     void create_device(
         const std::set<chip_id_t>& target_mmio_device_ids,
-        const uint32_t& num_host_mem_ch_per_mmio_device,
-        const bool create_mock_chips);
+        const uint32_t& num_host_mem_ch_per_mmio_device, const ChipType& chip_type);
     void broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOptions& soft_resets);
     void send_remote_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);
     void send_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);
@@ -655,7 +654,7 @@ private:
         HarvestingMasks& simulated_harvesting_masks);
     uint32_t get_tensix_harvesting_mask(
         chip_id_t chip_id, tt_ClusterDescriptor* cluster_desc, HarvestingMasks& simulated_harvesting_masks);
-    void construct_cluster(const uint32_t& num_host_mem_ch_per_mmio_device, const bool create_mock_chips);
+    void construct_cluster(const uint32_t& num_host_mem_ch_per_mmio_device, const ChipType& chip_type);
     tt_xy_pair translate_to_api_coords(const chip_id_t chip, const tt::umd::CoreCoord core_coord) const;
     // Most of the old APIs accept virtual coordinates, but we communicate with the device through translated
     // coordinates. This is an internal helper function, until we switch the API to accept translated coordinates.

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -647,7 +647,7 @@ private:
         bool perform_harvesting,
         HarvestingMasks& simulated_harvesting_masks);
 
-    void add_chip(chip_id_t chip_id, std::unique_ptr<Chip> chip);
+    void add_chip(const chip_id_t& chip_id, const ChipType& chip_type, std::unique_ptr<Chip> chip);
     HarvestingMasks get_harvesting_masks(
         chip_id_t chip_id,
         tt_ClusterDescriptor* cluster_desc,

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -102,14 +102,14 @@ const tt_SocDescriptor& Cluster::get_soc_descriptor(chip_id_t chip_id) const {
 void Cluster::create_device(
     const std::set<chip_id_t>& target_mmio_device_ids,
     const uint32_t& num_host_mem_ch_per_mmio_device,
-    const bool create_mock_chips) {
+    const ChipType& chip_type) {
     log_debug(LogSiliconDriver, "Cluster::Cluster");
 
     // Don't buffer stdout.
     setbuf(stdout, NULL);
 
     for (const chip_id_t& logical_device_id : target_mmio_device_ids) {
-        if (!create_mock_chips) {
+        if (chip_type == ChipType::SILICON) {
             bool hugepages_initialized =
                 (get_local_chip(logical_device_id)->get_sysmem_manager()->get_hugepage_mapping(0).mapping != nullptr);
             // Large writes to remote chips require hugepages to be initialized.
@@ -127,11 +127,11 @@ void Cluster::create_device(
     }
 }
 
-void Cluster::construct_cluster(const uint32_t& num_host_mem_ch_per_mmio_device, const bool create_mock_chips) {
+void Cluster::construct_cluster(const uint32_t& num_host_mem_ch_per_mmio_device, const ChipType& chip_type) {
     // TODO: work on removing this member altogether. Currently assumes all have the same arch.
     arch_name = chips_.empty() ? tt::ARCH::Invalid : chips_.begin()->second->get_soc_descriptor().arch;
 
-    if (!create_mock_chips) {
+    if (chip_type == ChipType::SILICON) {
         std::vector<int> pci_ids;
         for (const auto& [logical_id, pci_id] : cluster_desc->get_chips_with_mmio()) {
             pci_ids.push_back(pci_id);
@@ -141,7 +141,7 @@ void Cluster::construct_cluster(const uint32_t& num_host_mem_ch_per_mmio_device,
             LogSiliconDriver, "Using local chip ids: {} and remote chip ids {}", local_chip_ids_, remote_chip_ids_);
     }
 
-    create_device(local_chip_ids_, num_host_mem_ch_per_mmio_device, create_mock_chips);
+    create_device(local_chip_ids_, num_host_mem_ch_per_mmio_device, chip_type);
 
     // Disable dependency to ethernet firmware for all BH devices and WH devices with all chips having MMIO (e.g. UBB
     // Galaxy, or P300).
@@ -415,7 +415,7 @@ Cluster::Cluster(ClusterOptions options) {
                 options.simulator_directory));
     }
 
-    construct_cluster(options.num_host_mem_ch_per_mmio_device, options.chip_type != ChipType::SILICON);
+    construct_cluster(options.num_host_mem_ch_per_mmio_device, options.chip_type);
 }
 
 void Cluster::configure_active_ethernet_cores_for_mmio_device(

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -235,13 +235,14 @@ tt_SocDescriptor Cluster::construct_soc_descriptor(
     }
 }
 
-void Cluster::add_chip(chip_id_t chip_id, std::unique_ptr<Chip> chip) {
+void Cluster::add_chip(const chip_id_t& chip_id, const ChipType& chip_type, std::unique_ptr<Chip> chip) {
     log_assert(
         chips_.find(chip_id) == chips_.end(),
         "Chip with id {} already exists in cluster. Cannot add another chip with the same id.",
         chip_id);
     all_chip_ids_.insert(chip_id);
-    if (cluster_desc->is_chip_mmio_capable(chip_id)) {
+    // All non silicon chip types are considered local chips.
+    if (chip_type != ChipType::SILICON || cluster_desc->is_chip_mmio_capable(chip_id)) {
         local_chip_ids_.insert(chip_id);
     } else {
         remote_chip_ids_.insert(chip_id);
@@ -404,6 +405,7 @@ Cluster::Cluster(ClusterOptions options) {
 
         add_chip(
             chip_id,
+            options.chip_type,
             construct_chip_from_cluster(
                 chip_id,
                 options.chip_type,


### PR DESCRIPTION
### Issue
On a path of #250 

### Description
Simulation chips have been mistakenly put into remote chips, which made tests fail.

### List of the changes
- Change bool create_mock_chips to ChipType chip_type
- Set simulator and mock chips as local chips.

### Testing
Client CIs

### API Changes
There are API changes in the whole PR stack which ends with : https://github.com/tenstorrent/tt-umd/pull/838
I'll merge the whole stack once the whole stack is approved, and then merge the changes in the clients.
Relevant links to CIs and PRs in clients are in the referenced PR

