### PR TITLE
Move set_power_state to Chip class

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -71,6 +71,7 @@ public:
     virtual void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets);
     virtual void deassert_risc_resets() = 0;
 
+    virtual void set_power_state(tt_DevicePowerState state) = 0;
     virtual int get_clock() = 0;
     virtual int get_numa_node();
 

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -64,6 +64,7 @@ public:
     void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
 
     void deassert_risc_resets() override;
+    void set_power_state(tt_DevicePowerState state) override;
     int get_clock() override;
     int get_numa_node() override;
 
@@ -106,6 +107,10 @@ private:
     void set_membar_flag(
         const std::vector<CoreCoord>& cores, const uint32_t barrier_value, const uint32_t barrier_addr);
     void insert_host_to_device_barrier(const std::vector<CoreCoord>& cores, const uint32_t barrier_addr);
+
+    void wait_for_aiclk_value(tt_DevicePowerState power_state, const uint32_t timeout_ms = 5000);
+
+    uint32_t get_power_state_arc_msg(tt_DevicePowerState state);
 
 protected:
     void wait_eth_cores_training(const uint32_t timeout_ms = 60000) override;

--- a/device/api/umd/device/chip/mock_chip.h
+++ b/device/api/umd/device/chip/mock_chip.h
@@ -34,6 +34,7 @@ public:
     void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
 
     void deassert_risc_resets() override;
+    void set_power_state(tt_DevicePowerState state) override;
     int get_clock() override;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -42,6 +42,7 @@ public:
     void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
 
     void deassert_risc_resets() override;
+    void set_power_state(tt_DevicePowerState state) override;
     int get_clock() override;
 
 private:

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -607,13 +607,10 @@ private:
     void broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOptions& soft_resets);
     void send_remote_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);
     void send_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);
-    void set_pcie_power_state(tt_DevicePowerState state);
-    int set_remote_power_state(const chip_id_t& chip, tt_DevicePowerState device_state);
     uint32_t get_power_state_arc_msg(chip_id_t chip_id, tt_DevicePowerState state);
     void enable_ethernet_queue(int timeout);
     void deassert_resets_and_set_power_state();
     int get_clock(int logical_device_id);
-    void wait_for_aiclk_value(tt_DevicePowerState power_state, const uint32_t timeout_ms = 5000);
 
     // Communication Functions
     void ethernet_broadcast_write(

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -60,6 +60,7 @@ public:
     void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) override;
     void deassert_risc_resets() override;
 
+    void set_power_state(tt_DevicePowerState state) override;
     int get_clock() override;
 
     int arc_msg(

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -760,11 +760,11 @@ void LocalChip::deassert_risc_resets() {
 }
 
 void LocalChip::set_power_state(tt_DevicePowerState state) {
-    int exit_code;
-    if (soc_descriptor_.arch != tt::ARCH::BLACKHOLE) {
+    int exit_code = 0;
+    if (soc_descriptor_.arch == tt::ARCH::WORMHOLE_B0) {
         uint32_t msg = get_power_state_arc_msg(state);
         exit_code = arc_msg(wormhole::ARC_MSG_COMMON_PREFIX | msg, true, 0, 0);
-    } else {
+    } else if (soc_descriptor_.arch == tt::ARCH::BLACKHOLE) {
         if (state == tt_DevicePowerState::BUSY) {
             exit_code = tt_device_->get_arc_messenger()->send_message(
                 (uint32_t)tt::umd::blackhole::ArcMessageType::AICLK_GO_BUSY);

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -11,6 +11,7 @@
 #include "umd/device/chip_helpers/tlb_manager.h"
 #include "umd/device/driver_atomics.h"
 #include "umd/device/tt_device/tt_device.h"
+#include "umd/device/types/blackhole_arc.h"
 #include "umd/device/types/blackhole_eth.h"
 #include "umd/device/wormhole_implementation.h"
 
@@ -756,6 +757,72 @@ void LocalChip::deassert_risc_resets() {
             0,
             0);
     }
+}
+
+void LocalChip::set_power_state(tt_DevicePowerState state) {
+    int exit_code;
+    if (soc_descriptor_.arch != tt::ARCH::BLACKHOLE) {
+        uint32_t msg = get_power_state_arc_msg(state);
+        exit_code = arc_msg(wormhole::ARC_MSG_COMMON_PREFIX | msg, true, 0, 0);
+    } else {
+        if (state == tt_DevicePowerState::BUSY) {
+            exit_code = tt_device_->get_arc_messenger()->send_message(
+                (uint32_t)tt::umd::blackhole::ArcMessageType::AICLK_GO_BUSY);
+        } else {
+            exit_code = tt_device_->get_arc_messenger()->send_message(
+                (uint32_t)tt::umd::blackhole::ArcMessageType::AICLK_GO_LONG_IDLE);
+        }
+    }
+    log_assert(exit_code == 0, "Failed to set power state to {} with exit code: {}", (int)state, exit_code);
+
+    wait_for_aiclk_value(state);
+}
+
+void LocalChip::wait_for_aiclk_value(tt_DevicePowerState power_state, const uint32_t timeout_ms) {
+    auto start = std::chrono::system_clock::now();
+    uint32_t target_aiclk = 0;
+    if (power_state == tt_DevicePowerState::BUSY) {
+        target_aiclk = tt_device_->get_max_clock_freq();
+    } else if (power_state == tt_DevicePowerState::LONG_IDLE) {
+        target_aiclk = tt_device_->get_min_clock_freq();
+    }
+    uint32_t aiclk = tt_device_->get_clock();
+    while (aiclk != target_aiclk) {
+        auto end = std::chrono::system_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+        if (duration.count() > timeout_ms) {
+            log_warning(
+                LogSiliconDriver,
+                "Waiting for AICLK value to settle failed on timeout after {}. Expected to see {}, last value "
+                "observed {}",
+                timeout_ms,
+                target_aiclk,
+                aiclk);
+            return;
+        }
+        aiclk = tt_device_->get_clock();
+    }
+}
+
+uint32_t LocalChip::get_power_state_arc_msg(tt_DevicePowerState state) {
+    uint32_t msg = wormhole::ARC_MSG_COMMON_PREFIX;
+    switch (state) {
+        case BUSY: {
+            msg |= architecture_implementation::create(soc_descriptor_.arch)->get_arc_message_arc_go_busy();
+            break;
+        }
+        case LONG_IDLE: {
+            msg |= architecture_implementation::create(soc_descriptor_.arch)->get_arc_message_arc_go_long_idle();
+            break;
+        }
+        case SHORT_IDLE: {
+            msg |= architecture_implementation::create(soc_descriptor_.arch)->get_arc_message_arc_go_short_idle();
+            break;
+        }
+        default:
+            throw std::runtime_error("Unrecognized power state.");
+    }
+    return msg;
 }
 
 int LocalChip::get_clock() { return tt_device_->get_clock(); }

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -39,5 +39,7 @@ void MockChip::dram_membar(const std::unordered_set<uint32_t>& channels) {}
 
 void MockChip::deassert_risc_resets() {}
 
+void MockChip::set_power_state(tt_DevicePowerState state) {}
+
 int MockChip::get_clock() { return 0; }
 }  // namespace tt::umd

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -150,6 +150,8 @@ void RemoteChip::dram_membar(const std::unordered_set<uint32_t>& channels) { wai
 
 void RemoteChip::deassert_risc_resets() { local_chip_->deassert_risc_resets(); }
 
+void RemoteChip::set_power_state(tt_DevicePowerState state) { local_chip_->set_power_state(state); }
+
 int RemoteChip::get_clock() { return local_chip_->get_clock(); }
 
 }  // namespace tt::umd

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -186,6 +186,8 @@ void tt_SimulationDevice::dram_membar(const std::unordered_set<tt::umd::CoreCoor
 
 void tt_SimulationDevice::deassert_risc_resets() {}
 
+void tt_SimulationDevice::set_power_state(tt_DevicePowerState state) {}
+
 int tt_SimulationDevice::get_clock() { return 0; }
 
 int tt_SimulationDevice::arc_msg(
@@ -196,5 +198,6 @@ int tt_SimulationDevice::arc_msg(
     uint32_t timeout_ms,
     uint32_t* return_3,
     uint32_t* return_4) {
+    *return_3 = 1;
     return 0;
 }


### PR DESCRIPTION
### Issue
Last change for #250

The previous changes in the stack of changes leading to this one:
https://github.com/tenstorrent/tt-umd/pull/725
https://github.com/tenstorrent/tt-umd/pull/801
https://github.com/tenstorrent/tt-umd/pull/802
https://github.com/tenstorrent/tt-umd/pull/803
https://github.com/tenstorrent/tt-umd/pull/804
https://github.com/tenstorrent/tt-umd/pull/805
https://github.com/tenstorrent/tt-umd/pull/806
https://github.com/tenstorrent/tt-umd/pull/807
https://github.com/tenstorrent/tt-umd/pull/808
https://github.com/tenstorrent/tt-umd/pull/809
https://github.com/tenstorrent/tt-umd/pull/810
https://github.com/tenstorrent/tt-umd/pull/811
https://github.com/tenstorrent/tt-umd/pull/800
https://github.com/tenstorrent/tt-umd/pull/835
https://github.com/tenstorrent/tt-umd/pull/839
https://github.com/tenstorrent/tt-umd/pull/840
https://github.com/tenstorrent/tt-umd/pull/838


### Description
Move set_power_state and all accompanying functions to Chip class

### List of the changes
- Move wait_for_aiclk_value and get_power_state_arc_msg to LocalChip
- Moved implementation for set_power_state to LocalChip and RemoteChip. The implementation was the same, just the chip being targeted was different
- Remove inline from a couple of functions - this wasn't needed, and the build started mysteriously failing due to it.

### Testing
Client CIs

### API Changes
This is the tip of the stack of PRs with breaking API changes.
I'll merge the whole stack once the whole stack is approved, and then merge the changes in the clients
- [x] tt_metal approved PR pointing to this branch: https://github.com/tenstorrent/tt-metal/pull/21269
- [x] tt_debuda approved PR pointing to this branch: https://github.com/tenstorrent/tt-exalens/pull/342
- [x] tt_umd_simulators CI run: https://yyz-gitlab.local.tenstorrent.com/tenstorrent/tt-umd-simulators/-/pipelines/558107