### PR TITLE
Move several minor functions to Chip class

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -44,6 +44,8 @@ public:
     virtual SysmemManager* get_sysmem_manager();
     virtual TLBManager* get_tlb_manager();
 
+    virtual int get_num_host_channels();
+    virtual int get_host_channel_size(std::uint32_t channel);
     virtual void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size);
     virtual void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size);
 
@@ -57,6 +59,8 @@ public:
     virtual void dma_write_to_device(const void* src, size_t size, tt_xy_pair core, uint64_t addr);
     virtual void dma_read_from_device(void* dst, size_t size, tt_xy_pair core, uint64_t addr);
 
+    virtual std::function<void(uint32_t, uint32_t, const uint8_t*)> get_fast_pcie_static_tlb_write_callable();
+
     virtual void wait_for_non_mmio_flush();
 
     virtual void l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) = 0;
@@ -65,6 +69,9 @@ public:
 
     virtual void send_tensix_risc_reset(tt_xy_pair core, const TensixSoftResetOptions& soft_resets);
     virtual void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets);
+
+    virtual int get_clock() = 0;
+    virtual int get_numa_node();
 
     virtual int arc_msg(
         uint32_t msg_code,

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -37,6 +37,8 @@ public:
     int get_active_eth_core_idx();
     std::vector<CoreCoord> get_remote_transfer_ethernet_cores();
 
+    int get_num_host_channels() override;
+    int get_host_channel_size(std::uint32_t channel) override;
     void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) override;
     void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) override;
 
@@ -48,6 +50,8 @@ public:
     void dma_write_to_device(const void* src, size_t size, tt_xy_pair core, uint64_t addr) override;
     void dma_read_from_device(void* dst, size_t size, tt_xy_pair core, uint64_t addr) override;
 
+    std::function<void(uint32_t, uint32_t, const uint8_t*)> get_fast_pcie_static_tlb_write_callable() override;
+
     void ethernet_broadcast_write(
         const void* src, uint64_t core_dest, uint32_t size, std::vector<int> broadcast_header);
 
@@ -58,6 +62,9 @@ public:
     void l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
     void dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
     void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
+
+    int get_clock() override;
+    int get_numa_node() override;
 
     std::unique_lock<RobustMutex> acquire_mutex(std::string mutex_name, int pci_device_id);
     std::unique_lock<RobustMutex> acquire_mutex(MutexType mutex_type, int pci_device_id);

--- a/device/api/umd/device/chip/mock_chip.h
+++ b/device/api/umd/device/chip/mock_chip.h
@@ -32,5 +32,7 @@ public:
     void l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
     void dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
     void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
+
+    int get_clock() override;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -41,10 +41,13 @@ public:
     void dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
     void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
 
+    int get_clock() override;
+
 private:
     tt_xy_pair translate_chip_coord_virtual_to_translated(const tt_xy_pair core);
 
     eth_coord_t eth_chip_location_;
     std::unique_ptr<RemoteCommunication> remote_communication_;
+    LocalChip* local_chip_;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -44,6 +44,8 @@ public:
 
     bool is_mmio_capable() const override { return false; }
 
+    void set_remote_transfer_ethernet_cores(const std::unordered_set<tt::umd::CoreCoord>& cores) override;
+
     // All tt_xy_pair cores in this class are defined in VIRTUAL coords.
     void write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) override;
     void read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) override;
@@ -56,6 +58,8 @@ public:
 
     void send_tensix_risc_reset(tt_xy_pair core, const TensixSoftResetOptions& soft_resets) override;
     void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) override;
+
+    int get_clock() override;
 
     int arc_msg(
         uint32_t msg_code,

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -73,6 +73,10 @@ TLBManager* Chip::get_tlb_manager() {
         "Chip::get_tlb_manager is not available for this chip, it is only available for LocalChips.");
 }
 
+int Chip::get_num_host_channels() { return 0; }
+
+int Chip::get_host_channel_size(std::uint32_t channel) { return 0; }
+
 void Chip::write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) {
     throw std::runtime_error("Chip::write_to_sysmem is not available for this chip.");
 }
@@ -97,6 +101,10 @@ void Chip::dma_read_from_device(void* dst, size_t size, tt_xy_pair core, uint64_
     throw std::runtime_error("Chip::dma_read_from_device is not available for this chip.");
 }
 
+std::function<void(uint32_t, uint32_t, const uint8_t*)> Chip::get_fast_pcie_static_tlb_write_callable() {
+    throw std::runtime_error("Chip::get_fast_pcie_static_tlb_write_callable is not available for this chip.");
+}
+
 void Chip::wait_for_non_mmio_flush() {
     throw std::runtime_error("Chip::wait_for_non_mmio_flush is not available for this chip.");
 }
@@ -104,6 +112,8 @@ void Chip::wait_for_non_mmio_flush() {
 void Chip::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) {
     throw std::runtime_error("Chip::set_remote_transfer_ethernet_cores is not available for this chip.");
 }
+
+int Chip::get_numa_node() { throw std::runtime_error("Chip::get_numa_node is not available for this chip."); }
 
 void Chip::wait_dram_cores_training(const uint32_t timeout_ms) {}
 

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -75,7 +75,9 @@ TLBManager* Chip::get_tlb_manager() {
 
 int Chip::get_num_host_channels() { return 0; }
 
-int Chip::get_host_channel_size(std::uint32_t channel) { return 0; }
+int Chip::get_host_channel_size(std::uint32_t channel) {
+    throw std::runtime_error("There are no host channels available.");
+}
 
 void Chip::write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) {
     throw std::runtime_error("Chip::write_to_sysmem is not available for this chip.");

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -36,4 +36,6 @@ void MockChip::l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) {}
 void MockChip::dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) {}
 
 void MockChip::dram_membar(const std::unordered_set<uint32_t>& channels) {}
+
+int MockChip::get_clock() { return 0; }
 }  // namespace tt::umd

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -16,7 +16,8 @@ namespace tt::umd {
 RemoteChip::RemoteChip(tt_SocDescriptor soc_descriptor, eth_coord_t eth_chip_location, LocalChip* local_chip) :
     Chip(soc_descriptor),
     eth_chip_location_(eth_chip_location),
-    remote_communication_(std::make_unique<RemoteCommunication>(local_chip)) {
+    remote_communication_(std::make_unique<RemoteCommunication>(local_chip)),
+    local_chip_(local_chip) {
     log_assert(soc_descriptor_.arch != tt::ARCH::BLACKHOLE, "Non-MMIO targets not supported in Blackhole");
 }
 
@@ -146,5 +147,7 @@ void RemoteChip::l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) 
 void RemoteChip::dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) { wait_for_non_mmio_flush(); }
 
 void RemoteChip::dram_membar(const std::unordered_set<uint32_t>& channels) { wait_for_non_mmio_flush(); }
+
+int RemoteChip::get_clock() { return local_chip_->get_clock(); }
 
 }  // namespace tt::umd

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -136,6 +136,8 @@ void tt_SimulationDevice::close_device() {
     host.send_to_device(builder.GetBufferPointer(), builder.GetSize());
 }
 
+void tt_SimulationDevice::set_remote_transfer_ethernet_cores(const std::unordered_set<tt::umd::CoreCoord>& cores) {}
+
 // Runtime Functions
 void tt_SimulationDevice::write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) {
     log_info(
@@ -181,6 +183,8 @@ void tt_SimulationDevice::l1_membar(const std::unordered_set<tt::umd::CoreCoord>
 void tt_SimulationDevice::dram_membar(const std::unordered_set<uint32_t>& channels) {}
 
 void tt_SimulationDevice::dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) {}
+
+int tt_SimulationDevice::get_clock() { return 0; }
 
 int tt_SimulationDevice::arc_msg(
     uint32_t msg_code,


### PR DESCRIPTION
### Issue
On a path of #250 

### Description
Move several minor function's implementation to Chip class.
Motivation was that code in cluster.cpp was assuming that local chips had tt_device and sysmem_manager, which is not true for Simulation chip. Moving this to Chip allows for custom implementation.

### List of the changes
- Move get_num_host_channels, get_host_channel_size, get_fast_pcie_static_tlb_write_callable, get_clock, get_numa_node to Chip
-  Removed this from Cluster
- All implementations were very simple, so not much changes, just moving code around.
- Keep LocalChip in Remote to be able to call its functions

### Testing
Client CIs

### API Changes
There are API changes in the whole PR stack which ends with : https://github.com/tenstorrent/tt-umd/pull/838
I'll merge the whole stack once the whole stack is approved, and then merge the changes in the clients.
Relevant links to CIs and PRs in clients are in the referenced PR

