### PR TITLE
Move deassert_risc_resets to Chip class

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -69,6 +69,7 @@ public:
 
     virtual void send_tensix_risc_reset(tt_xy_pair core, const TensixSoftResetOptions& soft_resets);
     virtual void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets);
+    virtual void deassert_risc_resets() = 0;
 
     virtual int get_clock() = 0;
     virtual int get_numa_node();

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -63,6 +63,7 @@ public:
     void dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
     void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
 
+    void deassert_risc_resets() override;
     int get_clock() override;
     int get_numa_node() override;
 

--- a/device/api/umd/device/chip/mock_chip.h
+++ b/device/api/umd/device/chip/mock_chip.h
@@ -33,6 +33,7 @@ public:
     void dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
     void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
 
+    void deassert_risc_resets() override;
     int get_clock() override;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -41,6 +41,7 @@ public:
     void dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
     void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
 
+    void deassert_risc_resets() override;
     int get_clock() override;
 
 private:

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -58,6 +58,7 @@ public:
 
     void send_tensix_risc_reset(tt_xy_pair core, const TensixSoftResetOptions& soft_resets) override;
     void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) override;
+    void deassert_risc_resets() override;
 
     int get_clock() override;
 

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -747,6 +747,17 @@ void LocalChip::dram_membar(const std::unordered_set<uint32_t>& channels) {
     dram_membar(dram_cores_to_sync);
 }
 
+void LocalChip::deassert_risc_resets() {
+    if (soc_descriptor_.arch != tt::ARCH::BLACKHOLE) {
+        arc_msg(
+            wormhole::ARC_MSG_COMMON_PREFIX |
+                tt_device_->get_architecture_implementation()->get_arc_message_deassert_riscv_reset(),
+            true,
+            0,
+            0);
+    }
+}
+
 int LocalChip::get_clock() { return tt_device_->get_clock(); }
 
 int LocalChip::get_numa_node() { return tt_device_->get_pci_device()->get_numa_node(); }

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -37,5 +37,7 @@ void MockChip::dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) 
 
 void MockChip::dram_membar(const std::unordered_set<uint32_t>& channels) {}
 
+void MockChip::deassert_risc_resets() {}
+
 int MockChip::get_clock() { return 0; }
 }  // namespace tt::umd

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -148,6 +148,8 @@ void RemoteChip::dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores
 
 void RemoteChip::dram_membar(const std::unordered_set<uint32_t>& channels) { wait_for_non_mmio_flush(); }
 
+void RemoteChip::deassert_risc_resets() { local_chip_->deassert_risc_resets(); }
+
 int RemoteChip::get_clock() { return local_chip_->get_clock(); }
 
 }  // namespace tt::umd

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -184,6 +184,8 @@ void tt_SimulationDevice::dram_membar(const std::unordered_set<uint32_t>& channe
 
 void tt_SimulationDevice::dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) {}
 
+void tt_SimulationDevice::deassert_risc_resets() {}
+
 int tt_SimulationDevice::get_clock() { return 0; }
 
 int tt_SimulationDevice::arc_msg(


### PR DESCRIPTION
### Issue
On a path of #250 

### Description
Move deassert_risc_resets implementation to Chip class.
Motivation was that code in cluster.cpp was assuming that local chips had tt_device and sysmem_manager, which is not true for Simulation chip. Moving this to Chip allows for custom implementation.
Minor fix for eth_fw_version

### List of the changes
- Move deassert_risc_resets to Chip.
- Implementation for both local and remote chips turned out to be the same, just the remote chip was calling it's local chip function.
- Allow eth_fw_version to be empty. We didn't have a wormhole chip without eth previously, now we have through Simulation

### Testing
Client CIs

### API Changes
There are API changes in the whole PR stack which ends with : https://github.com/tenstorrent/tt-umd/pull/838
I'll merge the whole stack once the whole stack is approved, and then merge the changes in the clients.
Relevant links to CIs and PRs in clients are in the referenced PR

