### PR TITLE
Add min cmake 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ include(cmake/compilers.cmake)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON) # This also impacts dependencies brought in through CPM
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 
 if(DEFINED ENV{CMAKE_C_COMPILER} AND DEFINED ENV{CMAKE_CXX_COMPILER})
     message(STATUS "Setting C and C++ compiler from environment variables")


### PR DESCRIPTION
### Issue


### Description
Newer images have cmake 4, which removed support for cmake <3.5, and now there's an issue since yaml-cpp has set minimum cmake version 3.4. Setting this option forces all minimum versions to be >= 3.5

### List of the changes
- Added CMAKE_POLICY_VERSION_MINIMUM

### Testing
The code builds on a system on which it didn't build before

### API Changes
There are no API changes in this PR.
