### PR TITLE
Move remote arc msg to RemoteComm

### DIFF
--- a/device/api/umd/device/remote_communication.h
+++ b/device/api/umd/device/remote_communication.h
@@ -31,6 +31,17 @@ public:
 
     void wait_for_non_mmio_flush();
 
+    int arc_msg(
+        eth_coord_t target_chip,
+        tt_xy_pair remote_arc_core,
+        uint32_t msg_code,
+        bool wait_for_done,
+        uint32_t arg0,
+        uint32_t arg1,
+        uint32_t timeout_ms,
+        uint32_t* return_3,
+        uint32_t* return_4);
+
 private:
     LocalChip* local_chip_;
 };

--- a/device/api/umd/device/utils/lock_manager.h
+++ b/device/api/umd/device/utils/lock_manager.h
@@ -16,6 +16,8 @@ namespace tt::umd {
 enum class MutexType {
     // Used to serialize communication with the ARC.
     ARC_MSG,
+    // Used to serialize communication with the remote ARC over ethernet.
+    REMOTE_ARC_MSG,
     // Used to serialize IO operations which are done directly through TTDevice. This is needed since it goes through a
     // single TLB.
     TT_DEVICE_IO,

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -98,6 +98,7 @@ void LocalChip::initialize_default_chip_mutexes() {
     // ethernet broadcast
     if (tt_device_->get_arch() == tt::ARCH::WORMHOLE_B0) {
         lock_manager_.initialize_mutex(MutexType::NON_MMIO, pci_device_id);
+        lock_manager_.initialize_mutex(MutexType::REMOTE_ARC_MSG, pci_device_id);
     }
 
     // Initialize interprocess mutexes to make host -> device memory barriers atomic

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -77,70 +77,9 @@ int RemoteChip::arc_msg(
     uint32_t timeout_ms,
     uint32_t* return_3,
     uint32_t* return_4) {
-    constexpr uint64_t ARC_RESET_SCRATCH_ADDR = 0x880030060;
-    constexpr uint64_t ARC_RESET_MISC_CNTL_ADDR = 0x880030100;
-
     auto arc_core = soc_descriptor_.get_cores(CoreType::ARC).at(0);
-
-    if ((msg_code & 0xff00) != 0xaa00) {
-        log_error("Malformed message. msg_code is 0x{:x} but should be 0xaa..", msg_code);
-    }
-    log_assert(arg0 <= 0xffff and arg1 <= 0xffff, "Only 16 bits allowed in arc_msg args");  // Only 16 bits are allowed
-
-    uint32_t fw_arg = arg0 | (arg1 << 16);
-    int exit_code = 0;
-
-    { write_to_device(arc_core, &fw_arg, ARC_RESET_SCRATCH_ADDR + 3 * 4, sizeof(fw_arg)); }
-
-    { write_to_device(arc_core, &msg_code, ARC_RESET_SCRATCH_ADDR + 5 * 4, sizeof(fw_arg)); }
-
-    wait_for_non_mmio_flush();
-    uint32_t misc = 0;
-
-    read_from_device(arc_core, &misc, ARC_RESET_MISC_CNTL_ADDR, 4);
-
-    if (misc & (1 << 16)) {
-        log_error("trigger_fw_int failed on device");
-        return 1;
-    } else {
-        misc |= (1 << 16);
-        write_to_device(arc_core, &misc, ARC_RESET_MISC_CNTL_ADDR, sizeof(misc));
-    }
-
-    if (wait_for_done) {
-        uint32_t status = 0xbadbad;
-        auto start = std::chrono::steady_clock::now();
-        while (true) {
-            auto now = std::chrono::steady_clock::now();
-            auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count();
-            if (elapsed_ms > timeout_ms && timeout_ms != 0) {
-                std::stringstream ss;
-                ss << std::hex << msg_code;
-                throw std::runtime_error(fmt::format(
-                    "Timed out after waiting {} ms for device ARC to respond to message 0x{}", timeout_ms, ss.str()));
-            }
-
-            uint32_t status = 0;
-            read_from_device(arc_core, &status, ARC_RESET_SCRATCH_ADDR + 5 * 4, sizeof(status));
-            if ((status & 0xffff) == (msg_code & 0xff)) {
-                if (return_3 != nullptr) {
-                    read_from_device(arc_core, return_3, ARC_RESET_SCRATCH_ADDR + 3 * 4, sizeof(uint32_t));
-                }
-
-                if (return_4 != nullptr) {
-                    read_from_device(arc_core, return_4, ARC_RESET_SCRATCH_ADDR + 4 * 4, sizeof(uint32_t));
-                }
-
-                exit_code = (status & 0xffff0000) >> 16;
-                break;
-            } else if (status == HANG_READ_VALUE) {
-                log_warning(LogSiliconDriver, "Message code 0x{:x} not recognized by FW", msg_code);
-                exit_code = HANG_READ_VALUE;
-                break;
-            }
-        }
-    }
-    return exit_code;
+    return remote_communication_->arc_msg(
+        eth_chip_location_, arc_core, msg_code, wait_for_done, arg0, arg1, timeout_ms, return_3, return_4);
 }
 
 void RemoteChip::l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) { wait_for_non_mmio_flush(); }

--- a/device/remote_communication.cpp
+++ b/device/remote_communication.cpp
@@ -571,4 +571,84 @@ void RemoteCommunication::wait_for_non_mmio_flush() {
     }
 }
 
+int RemoteCommunication::arc_msg(
+    eth_coord_t target_chip,
+    tt_xy_pair remote_arc_core,
+    uint32_t msg_code,
+    bool wait_for_done,
+    uint32_t arg0,
+    uint32_t arg1,
+    uint32_t timeout_ms,
+    uint32_t* return_3,
+    uint32_t* return_4) {
+    constexpr uint64_t ARC_RESET_SCRATCH_ADDR = 0x880030060;
+    constexpr uint64_t ARC_RESET_MISC_CNTL_ADDR = 0x880030100;
+
+    // Remote arc has to be locked under critical section, only one remote arc message can be processed at the moment
+    auto lock = local_chip_->acquire_mutex(
+        MutexType::REMOTE_ARC_MSG, local_chip_->get_tt_device()->get_pci_device()->get_device_num());
+
+    if ((msg_code & 0xff00) != 0xaa00) {
+        log_error("Malformed message. msg_code is 0x{:x} but should be 0xaa..", msg_code);
+    }
+    log_assert(arg0 <= 0xffff and arg1 <= 0xffff, "Only 16 bits allowed in arc_msg args");  // Only 16 bits are allowed
+
+    uint32_t fw_arg = arg0 | (arg1 << 16);
+    int exit_code = 0;
+
+    { write_to_non_mmio(target_chip, remote_arc_core, &fw_arg, ARC_RESET_SCRATCH_ADDR + 3 * 4, sizeof(fw_arg)); }
+
+    { write_to_non_mmio(target_chip, remote_arc_core, &msg_code, ARC_RESET_SCRATCH_ADDR + 5 * 4, sizeof(fw_arg)); }
+
+    wait_for_non_mmio_flush();
+    uint32_t misc = 0;
+
+    read_non_mmio(target_chip, remote_arc_core, &misc, ARC_RESET_MISC_CNTL_ADDR, 4);
+
+    if (misc & (1 << 16)) {
+        log_error("trigger_fw_int failed on device");
+        return 1;
+    } else {
+        misc |= (1 << 16);
+        write_to_non_mmio(target_chip, remote_arc_core, &misc, ARC_RESET_MISC_CNTL_ADDR, sizeof(misc));
+    }
+
+    if (wait_for_done) {
+        uint32_t status = 0xbadbad;
+        auto start = std::chrono::steady_clock::now();
+        while (true) {
+            auto now = std::chrono::steady_clock::now();
+            auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count();
+            if (elapsed_ms > timeout_ms && timeout_ms != 0) {
+                std::stringstream ss;
+                ss << std::hex << msg_code;
+                throw std::runtime_error(fmt::format(
+                    "Timed out after waiting {} ms for device ARC to respond to message 0x{}", timeout_ms, ss.str()));
+            }
+
+            uint32_t status = 0;
+            read_non_mmio(target_chip, remote_arc_core, &status, ARC_RESET_SCRATCH_ADDR + 5 * 4, sizeof(status));
+            if ((status & 0xffff) == (msg_code & 0xff)) {
+                if (return_3 != nullptr) {
+                    read_non_mmio(
+                        target_chip, remote_arc_core, return_3, ARC_RESET_SCRATCH_ADDR + 3 * 4, sizeof(uint32_t));
+                }
+
+                if (return_4 != nullptr) {
+                    read_non_mmio(
+                        target_chip, remote_arc_core, return_4, ARC_RESET_SCRATCH_ADDR + 4 * 4, sizeof(uint32_t));
+                }
+
+                exit_code = (status & 0xffff0000) >> 16;
+                break;
+            } else if (status == HANG_READ_VALUE) {
+                log_warning(LogSiliconDriver, "Message code 0x{:x} not recognized by FW", msg_code);
+                exit_code = HANG_READ_VALUE;
+                break;
+            }
+        }
+    }
+    return exit_code;
+}
+
 }  // namespace tt::umd

--- a/device/utils/lock_manager.cpp
+++ b/device/utils/lock_manager.cpp
@@ -11,6 +11,7 @@ namespace tt::umd {
 
 const std::unordered_map<MutexType, std::string> LockManager::MutexTypeToString = {
     {MutexType::ARC_MSG, "TT_ARC_MSG"},
+    {MutexType::REMOTE_ARC_MSG, "TT_REMOTE_ARC_MSG"},
     // It is important that this mutex is named the same as corresponding fallback_tlb, this is due to the same tlb
     // index being used. This will be changed once we have a cleaner way to allocate TLBs instead of hardcoding fallback
     // tlbs.


### PR DESCRIPTION
### Issue
Related to #730, needed for #856

### Description
Move remote arc message which can be used for remote communication over local chip.
Unify code for remote chip and topo discovery

### List of the changes
- Added new lock Remote arc msg in lock manager
- Moved code from RemoteChip to RemoteCommunication
- Make both RemoteChip and TopologyDiscovery call RemoteCommunication for arc messageing

### Testing
Existing CI should cover this.

### API Changes
There are no API changes in this PR.
