### PR TITLE
Wormhole topology NOC1

### DIFF
--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -14,6 +14,8 @@
 #include "umd/device/types/wormhole_telemetry.h"
 #include "umd/device/wormhole_implementation.h"
 
+extern bool umd_use_noc1;
+
 namespace tt::umd {
 
 std::unique_ptr<tt_ClusterDescriptor> TopologyDiscovery::create_ethernet_map() {
@@ -131,7 +133,8 @@ uint32_t TopologyDiscovery::remote_arc_msg(
     std::unique_ptr<RemoteCommunication> remote_comm =
         std::make_unique<RemoteCommunication>(dynamic_cast<LocalChip*>(mmio_chip));
 
-    auto arc_core = mmio_chip->get_soc_descriptor().get_cores(CoreType::ARC)[0];
+    auto arc_core = mmio_chip->get_soc_descriptor().get_cores(
+        CoreType::ARC, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::NOC0)[0];
     return remote_comm->arc_msg(eth_coord, arc_core, msg_code, true, arg0, arg1, timeout_ms, ret0, ret1);
 }
 
@@ -220,7 +223,8 @@ void TopologyDiscovery::discover_remote_chips() {
     std::unordered_set<eth_coord_t> remote_chips_to_discover = {};
 
     for (const auto& [chip_id, chip] : chips) {
-        std::vector<CoreCoord> eth_cores = chip->get_soc_descriptor().get_cores(CoreType::ETH);
+        std::vector<CoreCoord> eth_cores =
+            chip->get_soc_descriptor().get_cores(CoreType::ETH, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::NOC0);
         TTDevice* tt_device = chip->get_tt_device();
 
         uint32_t current_chip_eth_coord_info;
@@ -241,7 +245,8 @@ void TopologyDiscovery::discover_remote_chips() {
     }
 
     for (const auto& [chip_id, chip] : chips) {
-        std::vector<CoreCoord> eth_cores = chip->get_soc_descriptor().get_cores(CoreType::ETH);
+        std::vector<CoreCoord> eth_cores =
+            chip->get_soc_descriptor().get_cores(CoreType::ETH, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::NOC0);
         TTDevice* tt_device = chip->get_tt_device();
 
         uint32_t current_chip_eth_coord_info;
@@ -326,7 +331,8 @@ void TopologyDiscovery::discover_remote_chips() {
         std::unordered_set<eth_coord_t> new_remote_chips = {};
 
         for (const eth_coord_t& eth_coord : remote_chips_to_discover) {
-            std::vector<CoreCoord> eth_cores = mmio_chip->get_soc_descriptor().get_cores(CoreType::ETH);
+            std::vector<CoreCoord> eth_cores = mmio_chip->get_soc_descriptor().get_cores(
+                CoreType::ETH, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::NOC0);
 
             uint32_t current_chip_eth_coord_info;
             remote_comm->read_non_mmio(

--- a/tests/api/test_noc.cpp
+++ b/tests/api/test_noc.cpp
@@ -75,6 +75,11 @@ TEST(TestNoc, TestNoc1NodeId) {
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
+    auto mmio_chip = *cluster->get_target_mmio_device_ids().begin();
+    if (cluster->get_tt_device(mmio_chip)->get_arch() == tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP() << "Skipping NOC1 test for Blackhole until coordinate translation is fixed.";
+    }
+
     auto read_noc_id_reg = [&](std::unique_ptr<Cluster>& cluster, chip_id_t chip, CoreCoord core) {
         const uint64_t noc_node_id_reg_addr =
             cluster->get_tt_device(0)->get_architecture_implementation()->get_noc_reg_base(core.core_type, 1) +

--- a/tests/api/test_noc.cpp
+++ b/tests/api/test_noc.cpp
@@ -70,7 +70,7 @@ TEST(TestNoc, TestNoc0NodeId) {
     }
 }
 
-TEST(TestNoc, DISABLED_TestNoc1NodeId) {
+TEST(TestNoc, TestNoc1NodeId) {
     TTDevice::use_noc1(true);
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();

--- a/tests/api/test_noc.cpp
+++ b/tests/api/test_noc.cpp
@@ -71,14 +71,16 @@ TEST(TestNoc, TestNoc0NodeId) {
 }
 
 TEST(TestNoc, TestNoc1NodeId) {
-    TTDevice::use_noc1(true);
-
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
-
-    auto mmio_chip = *cluster->get_target_mmio_device_ids().begin();
-    if (cluster->get_tt_device(mmio_chip)->get_arch() == tt::ARCH::BLACKHOLE) {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+    if (pci_device_ids.empty()) {
+        GTEST_SKIP() << "No chips present on the system. Skipping test.";
+    }
+    if (PCIDevice(pci_device_ids[0]).get_arch() == tt::ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping NOC1 test for Blackhole until coordinate translation is fixed.";
     }
+
+    TTDevice::use_noc1(true);
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
     auto read_noc_id_reg = [&](std::unique_ptr<Cluster>& cluster, chip_id_t chip, CoreCoord core) {
         const uint64_t noc_node_id_reg_addr =


### PR DESCRIPTION
### Issue

Test for NOC1 initialization and noc node id readouts started failing for Wormhole. We didn't catch it since the test was disabled due to bug in Blackhole coordinate translation.

### Description

Fix topology discovery for wormhole. ETH and ARC cores were accessed on NOC0. PR introduces handling NOC1 case as well.

### List of the changes

- Get ETH cores on NOC1
- Get ARC core on NOC1

### Testing

CI. Reenabled NOC1 test on Wormhole

### API Changes
/