### PR TITLE
Increase n150 timeout to 20

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {arch: wormhole_b0, card: n150, timeout: 10},
+          {arch: wormhole_b0, card: n150, timeout: 20},
           {arch: wormhole_b0, card: tt-beta-ubuntu-2204-n150-large-stable, timeout: 10},
           {arch: wormhole_b0, card: n300, timeout: 15},
           {arch: wormhole_b0, card: tt-beta-ubuntu-2204-n300-large-stable, timeout: 15},


### PR DESCRIPTION
### Issue


### Description
We stopped using this machine as a required CI. 
Something happened recently to it which makes it super slow. No time to investigate at the moment, especially since we have a working shared pool with n150.
It could be that the better solution would be to just decommission it now.

### List of the changes
- Increase dedicated n150 machine test time to 20min 

### Testing
CI

### API Changes
There are no API changes in this PR.
