### PR TITLE
Unmap DMA buffer at PCIDevice destruction

### DIFF
--- a/device/api/umd/device/pci_device.hpp
+++ b/device/api/umd/device/pci_device.hpp
@@ -100,13 +100,6 @@ public:
     int get_numa_node() const { return numa_node; }
 
     /**
-     * @return underlying file descriptor
-     * TODO: this is an abstraction violation to be removed when this class
-     * assumes control over hugepage/DMA mapping code.
-     */
-    int get_fd() const { return pci_device_file_desc; }
-
-    /**
      * @return N in /dev/tenstorrent/N
      * TODO: target for removal; upper layers should not care about this.
      */

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -26,6 +26,9 @@ static const uint16_t GS_PCIE_DEVICE_ID = 0xfaca;
 static const uint16_t WH_PCIE_DEVICE_ID = 0x401e;
 static const uint16_t BH_PCIE_DEVICE_ID = 0xb140;
 
+static const size_t DMABUF_SIZE = (1 << 20);                   // 1 MiB
+static const size_t DMABUF_TOTAL_SIZE = DMABUF_SIZE + 0x1000;  // Extra page for completion
+
 // TODO: we'll have to rethink this when KMD takes control of the inbound PCIe
 // TLB windows and there is no longer a pre-defined WC/UC split.
 static const uint32_t GS_BAR0_WC_MAPPING_SIZE = (156 << 20) + (10 << 21) + (18 << 24);
@@ -385,10 +388,9 @@ PCIDevice::PCIDevice(int pci_device_number) :
     // poll a completion page to know when the DMA is done instead of receiving
     // an interrupt.
     if (arch == tt::ARCH::WORMHOLE_B0) {
-        const uint32_t buf_size = (1 << 20);  // 1 MiB
         tenstorrent_allocate_dma_buf dma_buf{};
 
-        dma_buf.in.requested_size = buf_size + 0x1000;
+        dma_buf.in.requested_size = DMABUF_TOTAL_SIZE;
         dma_buf.in.buf_index = 0;
 
         if (ioctl(pci_device_file_desc, TENSTORRENT_IOCTL_ALLOCATE_DMA_BUF, &dma_buf)) {
@@ -404,7 +406,7 @@ PCIDevice::PCIDevice(int pci_device_number) :
             // OK - we have a buffer.  Map it.
             void *buffer = mmap(
                 nullptr,
-                buf_size + 0x1000,
+                DMABUF_TOTAL_SIZE,
                 PROT_READ | PROT_WRITE,
                 MAP_SHARED,
                 pci_device_file_desc,
@@ -416,10 +418,10 @@ PCIDevice::PCIDevice(int pci_device_number) :
                 log_error("Failed to map DMA buffer: {}", strerror(errno));
             } else {
                 dma_buffer.buffer = (uint8_t *)buffer;
-                dma_buffer.completion = (uint8_t *)buffer + buf_size;
+                dma_buffer.completion = (uint8_t *)buffer + DMABUF_SIZE;
                 dma_buffer.buffer_pa = dma_buf.out.physical_address;
-                dma_buffer.completion_pa = dma_buf.out.physical_address + buf_size;
-                dma_buffer.size = buf_size;
+                dma_buffer.completion_pa = dma_buf.out.physical_address + DMABUF_SIZE;
+                dma_buffer.size = DMABUF_SIZE;
             }
         }
     }
@@ -446,6 +448,10 @@ PCIDevice::~PCIDevice() {
 
     if (system_reg_mapping != nullptr && system_reg_mapping != MAP_FAILED) {
         munmap(system_reg_mapping, system_reg_mapping_size);
+    }
+
+    if (dma_buffer.buffer != nullptr && dma_buffer.buffer != MAP_FAILED) {
+        munmap(dma_buffer.buffer, DMABUF_TOTAL_SIZE);
     }
 }
 


### PR DESCRIPTION
### Issue
N/A

### Description
Lack of munmap for the DMA buffer kept the device file descriptor alive longer than intended.  During unit tests, this had the effect of preventing resource cleanup between tests.  This manifested as unexpected test failures on WH systems with IOMMU enabled and default (limited) IOVA range.

### List of the changes
* Use named constants for DMA buffer size
* Explicitly unmap the DMA buffer if it exists
* Remove an unused method on the PCIDevice interface

### Testing
CI and Manual

### API Changes
This PR has API changes: `PCIDevice::get_fd()` is removed.  I grepped for this in tt-metal and tt-exalens projects; they do not appear to be using it.
