### PR TITLE
Add bookkeeping for eth connections going to remote host devices

### DIFF
--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -43,6 +43,9 @@ private:
 protected:
     std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>>
         ethernet_connections;
+    // TODO: unify uint64_t with ChipUID
+    std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<uint64_t, ethernet_channel_t>>>
+        ethernet_connections_to_remote_mmio_devices;
     std::unordered_map<chip_id_t, eth_coord_t> chip_locations;
     // reverse map: rack/shelf/y/x -> chip_id
     std::map<int, std::map<int, std::map<int, std::map<int, chip_id_t>>>> coords_to_chip_ids;
@@ -120,6 +123,10 @@ public:
     const std::
         unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>> &
         get_ethernet_connections() const;
+    // TODO: unify uint64_t with ChipUID
+    const std::
+        unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<uint64_t, ethernet_channel_t>>>
+        get_ethernet_connections_to_remote_mmio_devices() const;
     const std::unordered_map<chip_id_t, chip_id_t> &get_chips_with_mmio() const;
     const std::unordered_set<chip_id_t> &get_all_chips() const;
     const std::vector<chip_id_t> get_chips_local_first(std::unordered_set<chip_id_t> chips) const;

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -22,9 +22,13 @@ using namespace tt;
 
 bool tt_ClusterDescriptor::ethernet_core_has_active_ethernet_link(
     chip_id_t local_chip, ethernet_channel_t local_ethernet_channel) const {
-    return this->ethernet_connections.find(local_chip) != this->ethernet_connections.end() &&
-           this->ethernet_connections.at(local_chip).find(local_ethernet_channel) !=
-               this->ethernet_connections.at(local_chip).end();
+    return (this->ethernet_connections.find(local_chip) != this->ethernet_connections.end() &&
+            this->ethernet_connections.at(local_chip).find(local_ethernet_channel) !=
+                this->ethernet_connections.at(local_chip).end()) ||
+           (this->ethernet_connections_to_remote_mmio_devices.find(local_chip) !=
+                this->ethernet_connections_to_remote_mmio_devices.end() &&
+            this->ethernet_connections_to_remote_mmio_devices.at(local_chip).find(local_ethernet_channel) !=
+                this->ethernet_connections_to_remote_mmio_devices.at(local_chip).end());
 }
 
 std::tuple<chip_id_t, ethernet_channel_t> tt_ClusterDescriptor::get_chip_and_channel_of_remote_ethernet_core(
@@ -830,6 +834,11 @@ void tt_ClusterDescriptor::fill_chips_grouped_by_closest_mmio() {
 const std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>> &
 tt_ClusterDescriptor::get_ethernet_connections() const {
     return ethernet_connections;
+}
+
+const std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<uint64_t, ethernet_channel_t>>>
+tt_ClusterDescriptor::get_ethernet_connections_to_remote_mmio_devices() const {
+    return this->ethernet_connections_to_remote_mmio_devices;
 }
 
 const std::unordered_map<chip_id_t, eth_coord_t> &tt_ClusterDescriptor::get_chip_locations() const {


### PR DESCRIPTION
### Issue
N/A
### Description
Add bookkeeping of ethernet connections to remote host systems, e.g. Dual Galaxy setup.

### List of the changes
- changes mostly contained to `ubb_eth_connections`
- added timeout to wait for ethernet port to come up, in case UMD is used shortly after reset
- added a throw if port status is not 0,1,2, indicating that routing FW may be enabled.

### Testing
(Comment on CI testing or Manual testing touching this change.)

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
