### PR TITLE
Remove enabled devices from ClusterDescriptor

### DIFF
--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -50,7 +50,6 @@ protected:
     std::unordered_set<chip_id_t> all_chips;
     std::unordered_map<chip_id_t, bool> noc_translation_enabled = {};
     std::unordered_map<chip_id_t, std::uint32_t> harvesting_masks = {};
-    std::unordered_set<chip_id_t> enabled_active_chips;
     std::unordered_map<chip_id_t, chip_id_t> closest_mmio_chip_cache = {};
     std::unordered_map<chip_id_t, BoardType> chip_board_type = {};
     std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> chips_grouped_by_closest_mmio;
@@ -119,9 +118,9 @@ public:
     const std::unordered_map<chip_id_t, eth_coord_t> &get_chip_locations() const;
     const std::unordered_map<chip_id_t, uint64_t> &get_chip_unique_ids() const;
     const std::
-        unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>>
+        unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>> &
         get_ethernet_connections() const;
-    const std::unordered_map<chip_id_t, chip_id_t> get_chips_with_mmio() const;
+    const std::unordered_map<chip_id_t, chip_id_t> &get_chips_with_mmio() const;
     const std::unordered_set<chip_id_t> &get_all_chips() const;
     const std::vector<chip_id_t> get_chips_local_first(std::unordered_set<chip_id_t> chips) const;
     const std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> &get_chips_grouped_by_closest_mmio() const;
@@ -139,8 +138,6 @@ public:
     bool ethernet_core_has_active_ethernet_link(chip_id_t local_chip, ethernet_channel_t local_ethernet_channel) const;
     std::tuple<chip_id_t, ethernet_channel_t> get_chip_and_channel_of_remote_ethernet_core(
         chip_id_t local_chip, ethernet_channel_t local_ethernet_channel) const;
-
-    void enable_all_devices();
 
     // Serialize the cluster descriptor to a YAML string, or directly to a file.
     // A default file in /tmp directory will be used if no path is passed.

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1261,8 +1261,6 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
         ubb_eth_connections(chips, desc);
     }
 
-    desc->enable_all_devices();
-
     desc->fill_chips_grouped_by_closest_mmio();
 
     return desc;

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -456,8 +456,6 @@ void TopologyDiscovery::fill_cluster_descriptor_info() {
 
     tt_ClusterDescriptor::fill_galaxy_connections(*cluster_desc.get());
 
-    cluster_desc->enable_all_devices();
-
     cluster_desc->fill_chips_grouped_by_closest_mmio();
 }
 

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -28,7 +28,7 @@ bool tt_ClusterDescriptor::ethernet_core_has_active_ethernet_link(
 std::tuple<chip_id_t, ethernet_channel_t> tt_ClusterDescriptor::get_chip_and_channel_of_remote_ethernet_core(
     chip_id_t local_chip, ethernet_channel_t local_ethernet_channel) const {
     std::vector<std::tuple<ethernet_channel_t, ethernet_channel_t>> directly_connected_channels = {};
-    if (this->enabled_active_chips.find(local_chip) == this->enabled_active_chips.end() ||
+    if (this->all_chips.find(local_chip) == this->all_chips.end() ||
         this->ethernet_connections.at(local_chip).find(local_ethernet_channel) ==
             this->ethernet_connections.at(local_chip).end()) {
         return {};
@@ -36,7 +36,7 @@ std::tuple<chip_id_t, ethernet_channel_t> tt_ClusterDescriptor::get_chip_and_cha
 
     const auto &[connected_chip, connected_channel] =
         this->ethernet_connections.at(local_chip).at(local_ethernet_channel);
-    if (this->enabled_active_chips.find(connected_chip) == this->enabled_active_chips.end()) {
+    if (this->all_chips.find(connected_chip) == this->all_chips.end()) {
         return {};
     } else {
         return {connected_chip, connected_channel};
@@ -49,8 +49,7 @@ std::vector<std::tuple<ethernet_channel_t, ethernet_channel_t>>
 tt_ClusterDescriptor::get_directly_connected_ethernet_channels_between_chips(
     const chip_id_t &first, const chip_id_t &second) const {
     std::vector<std::tuple<ethernet_channel_t, ethernet_channel_t>> directly_connected_channels = {};
-    if (this->enabled_active_chips.find(first) == this->enabled_active_chips.end() ||
-        this->enabled_active_chips.find(second) == this->enabled_active_chips.end()) {
+    if (this->all_chips.find(first) == this->all_chips.end() || this->all_chips.find(second) == this->all_chips.end()) {
         return {};
     }
 
@@ -432,7 +431,6 @@ std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_from_yaml(
     tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descriptor(yaml, *desc);
     tt_ClusterDescriptor::merge_cluster_ids(*desc);
     tt_ClusterDescriptor::fill_galaxy_connections(*desc);
-    desc->enable_all_devices();
 
     desc->fill_chips_grouped_by_closest_mmio();
 
@@ -472,8 +470,6 @@ std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_mock_cluster(
         desc->chips_with_mmio.insert({logical_id, logical_id});
         desc->chip_arch.insert({logical_id, arch});
     }
-
-    desc->enable_all_devices();
 
     return desc;
 }
@@ -821,8 +817,6 @@ void tt_ClusterDescriptor::load_harvesting_information(YAML::Node &yaml, tt_Clus
     }
 }
 
-void tt_ClusterDescriptor::enable_all_devices() { this->enabled_active_chips = this->all_chips; }
-
 void tt_ClusterDescriptor::fill_chips_grouped_by_closest_mmio() {
     for (const auto &chip : this->all_chips) {
         // This will also fill up the closest_mmio_chip_cache
@@ -831,34 +825,13 @@ void tt_ClusterDescriptor::fill_chips_grouped_by_closest_mmio() {
     }
 }
 
-const std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>>
+const std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>> &
 tt_ClusterDescriptor::get_ethernet_connections() const {
-    auto eth_connections = std::
-        unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>>();
-
-    for (const auto &[chip, channel_mapping] : this->ethernet_connections) {
-        if (this->enabled_active_chips.find(chip) != this->enabled_active_chips.end()) {
-            eth_connections[chip] = {};
-            for (const auto &[src_channel, chip_channel] : channel_mapping) {
-                const auto &[dest_chip, dest_channel] = chip_channel;
-                if (this->enabled_active_chips.find(dest_chip) != this->enabled_active_chips.end()) {
-                    eth_connections[chip][src_channel] = chip_channel;
-                }
-            }
-        }
-    }
-    return eth_connections;
+    return ethernet_connections;
 }
 
 const std::unordered_map<chip_id_t, eth_coord_t> &tt_ClusterDescriptor::get_chip_locations() const {
-    static auto locations = std::unordered_map<chip_id_t, eth_coord_t>();
-    if (locations.empty() and !this->chip_locations.empty()) {
-        for (auto chip_id : this->enabled_active_chips) {
-            locations[chip_id] = chip_locations.at(chip_id);
-        }
-    }
-
-    return locations;
+    return chip_locations;
 }
 
 // Note: this API works only for Wormhole 6U galaxy at the moment.
@@ -880,27 +853,17 @@ chip_id_t tt_ClusterDescriptor::get_shelf_local_physical_chip_coords(chip_id_t v
 }
 
 // Return map, but filter by enabled active chips.
-const std::unordered_map<chip_id_t, chip_id_t> tt_ClusterDescriptor::get_chips_with_mmio() const {
-    auto chips_map = std::unordered_map<chip_id_t, chip_id_t>();
-    for (const auto &pair : chips_with_mmio) {
-        auto &chip_id = pair.first;
-        if (this->enabled_active_chips.find(chip_id) != this->enabled_active_chips.end()) {
-            chips_map.insert(pair);
-        }
-    }
-
-    return chips_map;
+const std::unordered_map<chip_id_t, chip_id_t> &tt_ClusterDescriptor::get_chips_with_mmio() const {
+    return chips_with_mmio;
 }
 
-const std::unordered_set<chip_id_t> &tt_ClusterDescriptor::get_all_chips() const { return this->enabled_active_chips; }
+const std::unordered_set<chip_id_t> &tt_ClusterDescriptor::get_all_chips() const { return this->all_chips; }
 
 const std::vector<chip_id_t> tt_ClusterDescriptor::get_chips_local_first(std::unordered_set<chip_id_t> chips) const {
     std::vector<chip_id_t> chips_local_first;
     for (const auto &chip : chips) {
         log_assert(
-            this->enabled_active_chips.find(chip) != this->enabled_active_chips.end(),
-            "Chip {} not found in cluster descriptor.",
-            chip);
+            this->all_chips.find(chip) != this->all_chips.end(), "Chip {} not found in cluster descriptor.", chip);
     }
     for (const auto &chip : chips) {
         if (is_chip_mmio_capable(chip)) {
@@ -923,7 +886,7 @@ const std::unordered_map<chip_id_t, bool> &tt_ClusterDescriptor::get_noc_transla
     return noc_translation_enabled;
 }
 
-std::size_t tt_ClusterDescriptor::get_number_of_chips() const { return this->enabled_active_chips.size(); }
+std::size_t tt_ClusterDescriptor::get_number_of_chips() const { return this->all_chips.size(); }
 
 int tt_ClusterDescriptor::get_ethernet_link_distance(chip_id_t chip_a, chip_id_t chip_b) const {
     log_assert(


### PR DESCRIPTION
### Issue
Slightly related to #870 , but more of a general refactor

### Description
This was probably some feature which we dropped along the way. Anyway it is broken right now, and nobody uses it outside tt-umd

### List of the changes
- Remove enabled_all_devices()
- Remove enabled_active_chips var

### Testing
Existing tests, and clients build

### API Changes
There are API changes in this PR, but nobody uses that api
