### PR TITLE
Implement remote TTDevice

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -49,6 +49,7 @@ target_sources(
         tt_device/blackhole_tt_device.cpp
         tt_device/tt_device.cpp
         tt_device/wormhole_tt_device.cpp
+        tt_device/remote_tt_device.cpp
         tt_silicon_driver_common.cpp
         tt_soc_descriptor.cpp
         wormhole/wormhole_coordinate_manager.cpp
@@ -111,6 +112,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/tt_device/blackhole_tt_device.h
                 api/umd/device/tt_device/tt_device.h
                 api/umd/device/tt_device/wormhole_tt_device.h
+                api/umd/device/tt_device/remote_tt_device.h
                 api/umd/device/tt_io.hpp
                 api/umd/device/tt_silicon_driver_common.hpp
                 api/umd/device/tt_simulation_device.h

--- a/device/api/umd/device/tt_device/remote_tt_device.h
+++ b/device/api/umd/device/tt_device/remote_tt_device.h
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "umd/device/chip/local_chip.h"
+
+namespace tt::umd {
+class RemoteTTDevice : public TTDevice {
+public:
+    RemoteTTDevice(LocalChip* local_chip, eth_coord_t target_chip);
+
+    void wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms = 1000) override;
+
+    ChipInfo get_chip_info() override;
+
+    uint32_t get_clock() override;
+
+    uint32_t get_max_clock_freq() override;
+
+    uint32_t get_min_clock_freq() override;
+
+    BoardType get_board_type() override;
+
+    std::vector<DramTrainingStatus> get_dram_training_status() override;
+
+    void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
+
+    void write_to_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
+
+    void dma_d2h(void* dst, uint32_t src, size_t size) override;
+
+    void dma_h2d(uint32_t dst, const void* src, size_t size) override;
+
+    void dma_d2h_zero_copy(void* dst, uint32_t src, size_t size) override;
+
+    void dma_h2d_zero_copy(uint32_t dst, const void* src, size_t size) override;
+
+    bool get_noc_translation_enabled() override;
+
+private:
+    LocalChip* local_chip_;
+    eth_coord_t target_chip_;
+    std::unique_ptr<RemoteCommunication> remote_communication_;
+};
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -114,8 +114,8 @@ public:
     // Read/write functions that always use same TLB entry. This is not supposed to be used
     // on any code path that is performance critical. It is used to read/write the data needed
     // to get the information to form cluster of chips, or just use base TTDevice functions.
-    void read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
-    void write_to_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
+    virtual void read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
+    virtual void write_to_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
 
     // TLB related functions.
     // TODO: These are architecture specific, and will be moved out of the class.
@@ -218,6 +218,8 @@ protected:
     void memcpy_from_device(void *dest, const void *src, std::size_t num_bytes);
 
     virtual void init_tt_device();
+
+    TTDevice();
 
     ChipInfo chip_info;
 };

--- a/device/tt_device/remote_tt_device.cpp
+++ b/device/tt_device/remote_tt_device.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "umd/device/tt_device/remote_tt_device.h"
+
+namespace tt::umd {
+
+RemoteTTDevice::RemoteTTDevice(LocalChip *local_chip, eth_coord_t target_chip) :
+    TTDevice(),
+    local_chip_(local_chip),
+    target_chip_(target_chip),
+    remote_communication_(std::make_unique<RemoteCommunication>(local_chip)) {
+    if (local_chip_->get_tt_device()->get_arch() != tt::ARCH::WORMHOLE_B0) {
+        throw std::runtime_error("Creating remote TTDevice is supported only for Wormhole.");
+    }
+}
+
+void RemoteTTDevice::wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms) {}
+
+ChipInfo RemoteTTDevice::get_chip_info() {
+    throw std::runtime_error("get_chip_info() not implemented for RemoteTTDevice.");
+}
+
+uint32_t RemoteTTDevice::get_clock() { throw std::runtime_error("get_clock() not implemented for RemoteTTDevice."); }
+
+uint32_t RemoteTTDevice::get_max_clock_freq() {
+    throw std::runtime_error("get_max_clock_freq() not implemented for RemoteTTDevice.");
+}
+
+uint32_t RemoteTTDevice::get_min_clock_freq() {
+    throw std::runtime_error("get_min_clock_freq() not implemented for RemoteTTDevice.");
+}
+
+BoardType RemoteTTDevice::get_board_type() {
+    throw std::runtime_error("get_board_type() not implemented for RemoteTTDevice.");
+}
+
+std::vector<DramTrainingStatus> RemoteTTDevice::get_dram_training_status() {
+    throw std::runtime_error("get_dram_training_status() not implemented for RemoteTTDevice.");
+}
+
+void RemoteTTDevice::read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
+    remote_communication_->read_non_mmio(target_chip_, core, mem_ptr, addr, size);
+}
+
+void RemoteTTDevice::write_to_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
+    remote_communication_->write_to_non_mmio(target_chip_, core, mem_ptr, addr, size);
+}
+
+void RemoteTTDevice::dma_d2h(void *dst, uint32_t src, size_t size) {
+    throw std::runtime_error("PCIE DMA transfers not supported for RemoteTTDevice.");
+}
+
+void RemoteTTDevice::dma_h2d(uint32_t dst, const void *src, size_t size) {
+    throw std::runtime_error("PCIE DMA transfers not supported for RemoteTTDevice.");
+}
+
+void RemoteTTDevice::dma_d2h_zero_copy(void *dst, uint32_t src, size_t size) {
+    throw std::runtime_error("PCIE DMA transfers not supported for RemoteTTDevice.");
+}
+
+void RemoteTTDevice::dma_h2d_zero_copy(uint32_t dst, const void *src, size_t size) {
+    throw std::runtime_error("PCIE DMA transfers not supported for RemoteTTDevice.");
+}
+
+bool RemoteTTDevice::get_noc_translation_enabled() {
+    throw std::runtime_error("get_noc_translation_enabled() not implemented for RemoteTTDevice.");
+}
+
+}  // namespace tt::umd

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -31,6 +31,8 @@ void TTDevice::init_tt_device() {
     telemetry = ArcTelemetryReader::create_arc_telemetry_reader(this);
 }
 
+TTDevice::TTDevice() {}
+
 /* static */ std::unique_ptr<TTDevice> TTDevice::create(int pci_device_number) {
     auto pci_device = std::make_unique<PCIDevice>(pci_device_number);
 
@@ -376,7 +378,11 @@ tt::umd::ArcMessenger *TTDevice::get_arc_messenger() const { return arc_messenge
 
 tt::umd::ArcTelemetryReader *TTDevice::get_arc_telemetry_reader() const { return telemetry.get(); }
 
-TTDevice::~TTDevice() { lock_manager.clear_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num()); }
+TTDevice::~TTDevice() {
+    if (get_pci_device() != nullptr) {
+        lock_manager.clear_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num());
+    }
+}
 
 std::vector<DramTrainingStatus> TTDevice::get_dram_training_status() { return {}; }
 

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -4,8 +4,10 @@
 #include <thread>
 
 #include "gtest/gtest.h"
+#include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/blackhole_implementation.h"
 #include "umd/device/cluster.h"
+#include "umd/device/tt_device/remote_tt_device.h"
 #include "umd/device/tt_device/tt_device.h"
 #include "umd/device/wormhole_implementation.h"
 
@@ -103,5 +105,49 @@ TEST(ApiTTDeviceTest, TTDeviceMultipleThreadsIO) {
 
         thread0.join();
         thread1.join();
+    }
+}
+
+TEST(ApiTTDeviceTest, TestRemoteTTDevice) {
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+
+    tt_ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
+
+    auto chip_locations = cluster_desc->get_chip_locations();
+
+    const uint32_t buf_size = 1 << 20;
+    std::vector<uint8_t> zero_out_buffer(buf_size, 0);
+
+    std::vector<uint8_t> pattern_buf(buf_size);
+    for (uint32_t i = 0; i < buf_size; i++) {
+        pattern_buf[i] = (uint8_t)(i % 256);
+    }
+
+    for (chip_id_t remote_chip_id : cluster->get_target_remote_device_ids()) {
+        const CoreCoord tensix_core =
+            cluster->get_chip(remote_chip_id)->get_soc_descriptor().get_cores(CoreType::TENSIX)[0];
+
+        eth_coord_t remote_eth_coord = chip_locations.at(remote_chip_id);
+
+        LocalChip* closest_local_chip =
+            cluster->get_local_chip(cluster_desc->get_closest_mmio_capable_chip(remote_chip_id));
+
+        std::unique_ptr<RemoteTTDevice> remote_tt_device =
+            std::make_unique<RemoteTTDevice>(closest_local_chip, remote_eth_coord);
+
+        remote_tt_device->write_to_device(zero_out_buffer.data(), tensix_core, 0, buf_size);
+
+        // Setting initial value of vector explicitly to 1, to be sure it's not 0 in any case.
+        std::vector<uint8_t> readback_buf(buf_size, 1);
+
+        remote_tt_device->read_from_device(readback_buf.data(), tensix_core, 0, buf_size);
+
+        EXPECT_EQ(zero_out_buffer, readback_buf);
+
+        remote_tt_device->write_to_device(pattern_buf.data(), tensix_core, 0, buf_size);
+
+        remote_tt_device->read_from_device(readback_buf.data(), tensix_core, 0, buf_size);
+
+        EXPECT_EQ(pattern_buf, readback_buf);
     }
 }


### PR DESCRIPTION
### Issue

Initial work towards #730 

### Description

This PR introduces RemoteTTDevice class. The class is derived from base TTDevice class, in order to match the interface of the class that we use in order to get all the required information. It is not going to have PCIDevice and maybe some other things that WH and BH TTDevice has, so maybe we should think about some other hieararchy in the future. I think this should be fine for now. 

Only basic read/write from/to device functions are implemented as part of the PR, other function will come in separate PRs.

### List of the changes

- Add RemoteTTDevice class
- Override read/write functions from TTDevice 
- Add a test for read/write

### Testing

CI + additional test

### API Changes
/