### PR TITLE
Add sysmem buffers perf tests

### DIFF
--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -174,10 +174,6 @@ void WormholeTTDevice::dma_d2h_transfer(void *dst, uint32_t src, size_t size) {
         throw std::runtime_error("DMA size must be a multiple of 4");
     }
 
-    if (size > dma_buffer.size) {
-        throw std::runtime_error("DMA size exceeds buffer size");
-    }
-
     if (!bar2) {
         throw std::runtime_error("BAR2 is not mapped");
     }
@@ -253,10 +249,6 @@ void WormholeTTDevice::dma_h2d_transfer(uint32_t dst, const void *src, size_t si
         throw std::runtime_error("DMA size must be a multiple of 4");
     }
 
-    if (size > dma_buffer.size) {
-        throw std::runtime_error("DMA size exceeds buffer size");
-    }
-
     if (!bar2) {
         throw std::runtime_error("BAR2 is not mapped");
     }
@@ -306,12 +298,22 @@ void WormholeTTDevice::dma_h2d_transfer(uint32_t dst, const void *src, size_t si
 // the application will require IOMMU support.  One day...
 void WormholeTTDevice::dma_d2h(void *dst, uint32_t src, size_t size) {
     DmaBuffer &dma_buffer = pci_device_->get_dma_buffer();
+
+    if (size > dma_buffer.size) {
+        throw std::runtime_error("DMA size exceeds buffer size");
+    }
+
     dma_d2h_transfer((void *)(uintptr_t)dma_buffer.buffer_pa, src, size);
     memcpy(dst, dma_buffer.buffer, size);
 }
 
 void WormholeTTDevice::dma_h2d(uint32_t dst, const void *src, size_t size) {
     DmaBuffer &dma_buffer = pci_device_->get_dma_buffer();
+
+    if (size > dma_buffer.size) {
+        throw std::runtime_error("DMA size exceeds buffer size");
+    }
+
     memcpy(dma_buffer.buffer, src, size);
     dma_h2d_transfer(dst, (void *)(uintptr_t)dma_buffer.buffer_pa, size);
 }

--- a/tests/microbenchmark/test_perf_dma.cpp
+++ b/tests/microbenchmark/test_perf_dma.cpp
@@ -3,6 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <sys/mman.h>
+
 #include "gtest/gtest.h"
 #include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
@@ -62,6 +64,44 @@ static inline void perf_read_write(
     print_speed(direction_from_device, num_iterations * readback.size(), ns);
 }
 
+static inline void perf_sysmem_read_write(
+    const uint32_t buf_size,
+    const uint32_t num_iterations,
+    const std::unique_ptr<SysmemBuffer>& sysmem_buffer,
+    const CoreCoord core,
+    const std::string& direction_to_device,
+    const std::string& direction_from_device) {
+    {
+        auto now = std::chrono::steady_clock::now();
+        for (int i = 0; i < NUM_ITERATIONS; i++) {
+            sysmem_buffer->dma_write_to_device(0, one_mb, core, 0);
+        }
+        auto end = std::chrono::steady_clock::now();
+        auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
+        print_speed(direction_to_device, one_mb * NUM_ITERATIONS, ns);
+    }
+
+    {
+        auto now = std::chrono::steady_clock::now();
+        for (int i = 0; i < NUM_ITERATIONS; i++) {
+            sysmem_buffer->dma_read_from_device(0, one_mb, core, 0);
+        }
+        auto end = std::chrono::steady_clock::now();
+        auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
+        print_speed(direction_from_device, one_mb * NUM_ITERATIONS, ns);
+    }
+}
+
+static void guard_test_iommu() {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+    if (pci_device_ids.empty()) {
+        GTEST_SKIP() << "No chips present on the system. Skipping test.";
+    }
+    if (!PCIDevice(pci_device_ids[0]).is_iommu_enabled()) {
+        GTEST_SKIP() << "Skipping test since IOMMU is not enabled on the system.";
+    }
+}
+
 /**
  * Test the PCIe DMA controller by using it to write random fixed-size pattern
  * to 0x0 tensix core, then reading them back and verifying.
@@ -112,4 +152,122 @@ TEST(TestPerf, DMADram) {
         perf_read_write(
             buf_size, NUM_ITERATIONS, cluster, dram_core, "DMA: Host -> Device DRAM", "DMA: Device DRAM -> Host");
     }
+}
+
+TEST(TestPerf, DMATensixZeroCopy) {
+    guard_test_iommu();
+
+    const uint32_t NUM_ITERATIONS = 1000;
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(tt::umd::ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = 0,
+    });
+
+    const chip_id_t mmio_chip = *cluster->get_target_mmio_device_ids().begin();
+
+    SysmemManager* sysmem_manager = cluster->get_chip(mmio_chip)->get_sysmem_manager();
+
+    const uint32_t one_mb = 1 << 20;
+    std::unique_ptr<SysmemBuffer> sysmem_buffer = sysmem_manager->allocate_sysmem_buffer(2 * one_mb);
+
+    const CoreCoord tensix_core = cluster->get_soc_descriptor(mmio_chip).get_cores(CoreType::TENSIX)[0];
+    perf_sysmem_read_write(
+        one_mb,
+        NUM_ITERATIONS,
+        sysmem_buffer,
+        tensix_core,
+        "DMA zero copy: Device Tensix L1 -> Host",
+        "DMA zero copy: Device Tensix L1 -> Host");
+}
+
+TEST(TestPerf, MapSysmemBuffer) {
+    guard_test_iommu();
+
+    const uint32_t NUM_ITERATIONS = 1000;
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(tt::umd::ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = 0,
+    });
+
+    const chip_id_t mmio_chip = *cluster->get_target_mmio_device_ids().begin();
+
+    SysmemManager* sysmem_manager = cluster->get_chip(mmio_chip)->get_sysmem_manager();
+
+    const uint32_t one_mb = 1 << 20;
+
+    void* mapping = mmap(nullptr, one_mb, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
+    auto now = std::chrono::steady_clock::now();
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+        std::unique_ptr<SysmemBuffer> sysmem_buffer = sysmem_manager->map_sysmem_buffer(mapping, one_mb);
+    }
+    auto end = std::chrono::steady_clock::now();
+    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
+    print_speed("Allocation of sysmem buffers:", one_mb * NUM_ITERATIONS, ns);
+}
+
+TEST(TestPerf, DMATensixMapBufferZeroCopy) {
+    guard_test_iommu();
+
+    const uint32_t NUM_ITERATIONS = 100;
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(tt::umd::ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = 0,
+    });
+
+    const chip_id_t mmio_chip = *cluster->get_target_mmio_device_ids().begin();
+
+    SysmemManager* sysmem_manager = cluster->get_chip(mmio_chip)->get_sysmem_manager();
+
+    const uint32_t one_mb = 1 << 20;
+
+    const CoreCoord tensix_core = cluster->get_soc_descriptor(mmio_chip).get_cores(CoreType::TENSIX)[0];
+    {
+        void* mapping =
+            mmap(nullptr, one_mb, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
+        auto now = std::chrono::steady_clock::now();
+        for (int i = 0; i < NUM_ITERATIONS; i++) {
+            std::unique_ptr<SysmemBuffer> sysmem_buffer = sysmem_manager->map_sysmem_buffer(mapping, one_mb);
+            sysmem_buffer->dma_write_to_device(0, one_mb, tensix_core, 0);
+        }
+        auto end = std::chrono::steady_clock::now();
+        auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
+        print_speed("DMA mapping buffer and zero copy: Host -> Device Tensix L1", one_mb * NUM_ITERATIONS, ns);
+    }
+
+    {
+        void* mapping =
+            mmap(nullptr, one_mb, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
+        auto now = std::chrono::steady_clock::now();
+        for (int i = 0; i < NUM_ITERATIONS; i++) {
+            std::unique_ptr<SysmemBuffer> sysmem_buffer = sysmem_manager->map_sysmem_buffer(mapping, one_mb);
+            sysmem_buffer->dma_read_from_device(0, one_mb, tensix_core, 0);
+        }
+        auto end = std::chrono::steady_clock::now();
+        auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
+        print_speed("DMA mapping buffer and zero copy: Device Tensix L1 -> Host", one_mb * NUM_ITERATIONS, ns);
+    }
+}
+
+TEST(TestPerf, DMADRAMZeroCopy) {
+    guard_test_iommu();
+
+    const uint32_t NUM_ITERATIONS = 10;
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(tt::umd::ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = 0,
+    });
+
+    const chip_id_t mmio_chip = *cluster->get_target_mmio_device_ids().begin();
+
+    SysmemManager* sysmem_manager = cluster->get_chip(mmio_chip)->get_sysmem_manager();
+
+    const uint32_t one_mb = 1 << 20;
+    const uint32_t one_hundred_mb = 100 * one_mb;
+    const uint32_t two_hundred_mb = 200 * one_mb;
+    std::unique_ptr<SysmemBuffer> sysmem_buffer = sysmem_manager->allocate_sysmem_buffer(two_hundred_mb);
+
+    const CoreCoord dram_core = cluster->get_soc_descriptor(mmio_chip).get_cores(CoreType::DRAM)[0];
+    perf_sysmem_read_write(
+        one_mb,
+        NUM_ITERATIONS,
+        sysmem_buffer,
+        dram_core,
+        "DMA zero copy: Device DRAM -> Host",
+        "DMA zero copy: Device DRAM -> Host");
 }


### PR DESCRIPTION
### Issue

#861 

### Description

Add tests for perf of reading/writing through sysmem buffers. Perf tests are testing zero copy transfer using DMA, mapping of the buffers, as well as reading/writing when you both have to map the buffer and read/write through it. Tests should represent the examples of how you can use the sysmem buffer.

### List of the changes

- Add test for zero copy transfer to tensix
- Add test for zero copy transfer to DRAM
- Add test for mapping the buffers
- Add test for rw with both mapping and DMA transfer

### Testing
CI

### API Changes
/
