### PR TITLE
Further improve sysmem(DMA) buffers - chapter 2

### DIFF
--- a/device/api/umd/device/chip_helpers/sysmem_buffer.h
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.h
@@ -13,10 +13,22 @@
 
 namespace tt::umd {
 
+/**
+ * SysmemBuffer class should represent the resource of the HOST memory that is visible to the device.
+ * Currently, there are two types of sysmem buffers:
+ * 1. Hugepage-based sysmem buffer, that represents old system memory scheme used, that we still want to support until
+ * transition to IOMMU is complete.
+ * 2. Sysmem buffer, that is used when the system is protected by an IOMMU. With IOMMU, the mappings can be requested at
+ * much finer granularity than hugepages.
+ *
+ * Traditionally, we have reffered to the sysmem buffer as something that is
+ * visible to device, has it's own NOC address. Without changes to KMD, this is still not fully supported for IOMMU
+ * buffers.
+ */
 class SysmemBuffer {
 public:
-    SysmemBuffer(TLBManager* tlb_manager, void* buffer_va, size_t buffer_size, uint64_t device_io_addr);
-    ~SysmemBuffer() = default;
+    SysmemBuffer(TLBManager* tlb_manager, void* buffer_va, size_t buffer_size);
+    ~SysmemBuffer();
 
     void* get_buffer_va() const { return buffer_va; }
 

--- a/device/api/umd/device/chip_helpers/sysmem_buffer.h
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.h
@@ -21,8 +21,8 @@ namespace tt::umd {
  * 2. Sysmem buffer, that is used when the system is protected by an IOMMU. With IOMMU, the mappings can be requested at
  * much finer granularity than hugepages.
  *
- * Traditionally, we have reffered to the sysmem buffer as something that is
- * visible to device, has it's own NOC address. Without changes to KMD, this is still not fully supported for IOMMU
+ * Traditionally, we have referred to the sysmem buffer as something that is
+ * visible to device, has its own NOC address. Without changes to KMD, this is still not fully supported for IOMMU
  * buffers.
  */
 class SysmemBuffer {

--- a/device/api/umd/device/chip_helpers/sysmem_manager.h
+++ b/device/api/umd/device/chip_helpers/sysmem_manager.h
@@ -49,6 +49,8 @@ private:
     TLBManager* tlb_manager_;
 
     std::vector<hugepage_mapping> hugepage_mapping_per_channel;
+
+    std::unique_ptr<SysmemBuffer> sysmem_buffer_ = nullptr;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/pci_device.hpp
+++ b/device/api/umd/device/pci_device.hpp
@@ -43,8 +43,8 @@ struct DmaBuffer {
     uint8_t *completion = nullptr;
     size_t size = 0;
 
-    uint32_t buffer_pa = 0;
-    uint32_t completion_pa = 0;
+    uint64_t buffer_pa = 0;
+    uint64_t completion_pa = 0;
 };
 
 class PCIDevice {
@@ -153,6 +153,14 @@ public:
      * chunk the desired transfer size to fit within it.
      */
     DmaBuffer &get_dma_buffer() { return dma_buffer; }
+
+    /**
+     * Unmap a buffer that was previously mapped for DMA access.
+     *
+     * @param buffer must be page-aligned
+     * @param size must be a multiple of the page size
+     */
+    void unmap_for_dma(void *buffer, size_t size);
 
     /**
      * Read KMD version installed on the system.

--- a/device/api/umd/device/tt_device/wormhole_tt_device.h
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.h
@@ -42,8 +42,8 @@ public:
     ChipInfo get_chip_info() override;
 
 private:
-    void dma_d2h_transfer(void *dst, uint32_t src, size_t size);
-    void dma_h2d_transfer(uint32_t dst, const void *src, size_t size);
+    void dma_d2h_transfer(const uint64_t dst, const uint32_t src, const size_t size);
+    void dma_h2d_transfer(const uint32_t dst, const uint64_t src, const size_t size);
 
     // Enforce single-threaded access, even though there are more serious issues
     // surrounding resource management as it relates to DMA.

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -10,8 +10,11 @@
 
 namespace tt::umd {
 
-SysmemBuffer::SysmemBuffer(TLBManager* tlb_manager, void* buffer_va, size_t buffer_size, uint64_t device_io_addr) :
-    tlb_manager_(tlb_manager), buffer_va(buffer_va), buffer_size(buffer_size), device_io_addr(device_io_addr) {}
+SysmemBuffer::SysmemBuffer(TLBManager* tlb_manager, void* buffer_va, size_t buffer_size) :
+    tlb_manager_(tlb_manager),
+    buffer_va(buffer_va),
+    buffer_size(buffer_size),
+    device_io_addr(tlb_manager->get_tt_device()->get_pci_device()->map_for_dma(buffer_va, buffer_size)) {}
 
 void SysmemBuffer::dma_write_to_device(size_t offset, size_t size, tt_xy_pair core, uint64_t addr) {
     static const std::string tlb_name = "LARGE_WRITE_TLB";
@@ -67,6 +70,10 @@ void SysmemBuffer::dma_read_from_device(size_t offset, size_t size, tt_xy_pair c
         addr += transfer_size;
         buffer += transfer_size;
     }
+}
+
+SysmemBuffer::~SysmemBuffer() {
+    tlb_manager_->get_tt_device()->get_pci_device()->unmap_for_dma(buffer_va, buffer_size);
 }
 
 }  // namespace tt::umd

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -6,6 +6,8 @@
 
 #include "umd/device/chip_helpers/sysmem_buffer.h"
 
+#include <tt-logger/tt-logger.hpp>
+
 #include "umd/device/tt_device/tt_device.h"
 
 namespace tt::umd {
@@ -73,7 +75,12 @@ void SysmemBuffer::dma_read_from_device(size_t offset, size_t size, tt_xy_pair c
 }
 
 SysmemBuffer::~SysmemBuffer() {
-    tlb_manager_->get_tt_device()->get_pci_device()->unmap_for_dma(buffer_va, buffer_size);
+    try {
+        tlb_manager_->get_tt_device()->get_pci_device()->unmap_for_dma(buffer_va, buffer_size);
+    } catch (...) {
+        log_warning(
+            LogSiliconDriver, "Failed to unmap sysmem buffer (size: {:#x}, IOVA: {:#x}).", buffer_size, device_io_addr);
+    }
 }
 
 }  // namespace tt::umd

--- a/device/chip_helpers/sysmem_manager.cpp
+++ b/device/chip_helpers/sysmem_manager.cpp
@@ -220,6 +220,7 @@ bool SysmemManager::init_iommu(size_t size) {
     const size_t num_fake_mem_channels = size / HUGEPAGE_REGION_SIZE;
 
     TTDevice *tt_device_ = tlb_manager_->get_tt_device();
+    // Caclulate the size of the mapping in order to avoid overlap with PCIE registers.
     size_t map_size =
         (tt_device_->get_arch() == tt::ARCH::WORMHOLE_B0 && num_fake_mem_channels == 4) ? (size - carveout_size) : size;
 
@@ -237,7 +238,7 @@ bool SysmemManager::init_iommu(size_t size) {
             strerror(errno));
     }
 
-    sysmem_buffer_ = map_sysmem_buffer(mapping, size);
+    sysmem_buffer_ = map_sysmem_buffer(mapping, map_size);
     uint64_t iova = sysmem_buffer_->get_device_io_addr();
 
     log_info(LogSiliconDriver, "Mapped sysmem without hugepages to IOVA {:#x}.", iova);

--- a/device/chip_helpers/sysmem_manager.cpp
+++ b/device/chip_helpers/sysmem_manager.cpp
@@ -237,8 +237,8 @@ bool SysmemManager::init_iommu(size_t size) {
             strerror(errno));
     }
 
-    std::shared_ptr<SysmemBuffer> sysmem_buffer = map_sysmem_buffer(mapping, size);
-    uint64_t iova = sysmem_buffer->get_device_io_addr();
+    sysmem_buffer_ = map_sysmem_buffer(mapping, size);
+    uint64_t iova = sysmem_buffer_->get_device_io_addr();
 
     log_info(LogSiliconDriver, "Mapped sysmem without hugepages to IOVA {:#x}.", iova);
 
@@ -280,20 +280,7 @@ std::unique_ptr<SysmemBuffer> SysmemManager::allocate_sysmem_buffer(uint32_t sys
 }
 
 std::unique_ptr<SysmemBuffer> SysmemManager::map_sysmem_buffer(void *buffer, uint32_t sysmem_buffer_size) {
-    TTDevice *tt_device_ = tlb_manager_->get_tt_device();
-    uint32_t page_size = sysconf(_SC_PAGESIZE);
-    uint64_t buffer_addr = reinterpret_cast<uint64_t>(buffer);
-
-    if (buffer_addr % page_size != 0 || sysmem_buffer_size % page_size != 0) {
-        throw std::runtime_error("Buffer must be page-aligned with a size that is a multiple of the page size");
-    }
-
-    uint64_t device_io_addr = tt_device_->get_pci_device()->map_for_dma(buffer, sysmem_buffer_size);
-
-    std::unique_ptr<SysmemBuffer> sysmem_buffer =
-        std::make_unique<SysmemBuffer>(tlb_manager_, buffer, sysmem_buffer_size, device_io_addr);
-
-    return sysmem_buffer;
+    return std::make_unique<SysmemBuffer>(tlb_manager_, buffer, sysmem_buffer_size);
 }
 
 }  // namespace tt::umd

--- a/device/ioctl.h
+++ b/device/ioctl.h
@@ -25,6 +25,7 @@
 #define TENSTORRENT_IOCTL_GET_DRIVER_INFO	_IO(TENSTORRENT_IOCTL_MAGIC, 5)
 #define TENSTORRENT_IOCTL_RESET_DEVICE		_IO(TENSTORRENT_IOCTL_MAGIC, 6)
 #define TENSTORRENT_IOCTL_PIN_PAGES		_IO(TENSTORRENT_IOCTL_MAGIC, 7)
+#define TENSTORRENT_IOCTL_UNPIN_PAGES		_IO(TENSTORRENT_IOCTL_MAGIC, 10)
 
 // For tenstorrent_mapping.mapping_id. These are not array indices.
 #define TENSTORRENT_MAPPING_UNUSED		0
@@ -157,5 +158,19 @@ struct tenstorrent_pin_pages {
 	struct tenstorrent_pin_pages_out out;
 };
 
+struct tenstorrent_unpin_pages_in {
+	// Original VA used to pin, not current VA if remapped.
+	__u64 virtual_address;	
+	__u64 size;
+	__u64 reserved;
+};
+
+struct tenstorrent_unpin_pages_out {
+};
+
+struct tenstorrent_unpin_pages {
+	struct tenstorrent_unpin_pages_in in;
+	struct tenstorrent_unpin_pages_out out;
+};
 #endif
 // clang-format on

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -493,6 +493,24 @@ uint64_t PCIDevice::map_for_dma(void *buffer, size_t size) {
     return pin_pages.out.physical_address;
 }
 
+void PCIDevice::unmap_for_dma(void *buffer, size_t size) {
+    static const auto page_size = sysconf(_SC_PAGESIZE);
+
+    const uint64_t vaddr = reinterpret_cast<uint64_t>(buffer);
+
+    if (vaddr % page_size != 0 || size % page_size != 0) {
+        TT_THROW("Buffer must be page-aligned with a size that is a multiple of the page size");
+    }
+
+    tenstorrent_unpin_pages unpin_pages{};
+    unpin_pages.in.virtual_address = vaddr;
+    unpin_pages.in.size = size;
+
+    if (ioctl(pci_device_file_desc, TENSTORRENT_IOCTL_UNPIN_PAGES, &unpin_pages) < 0) {
+        TT_THROW("Failed to unpin pages for DMA buffer: {}", strerror(errno));
+    }
+}
+
 semver_t PCIDevice::read_kmd_version() {
     static const std::string path = "/sys/module/tenstorrent/version";
     std::ifstream file(path);


### PR DESCRIPTION
### Issue

#884 

### Description

Chapter 2 of improvements for Sysmem buffers. This PR addresses comments from Joel on the previous PR that should push the design in the right direction. After this, NOC address support from KMD should be integrated into sysmem buffers, so we can make this fully available for everyone to use. 

I kept the API in `SysmemManager` to get the buffers in order to be able to provide only buffer size, or both the mem pointer and buffer size, that simply calls into `SysmemBuffer` constructor. I think external user wouldn't want to have to get TLB manager in order to create `SysmemBuffer`

### List of the changes

- Make src and dst for DMA transfer uint64_t
- Address nit comments
- Make SysmemBuffer control the underlying resource
- Add IOCTL for unmapping the buffers
- Unmap the buffers through SysmemBuffer
- Change tests a bit

### Testing

CI. Manual testing for IOMMU tests

### API Changes
/