### PR TITLE
Implement new Wormhole telemetry

### DIFF
--- a/device/api/umd/device/arc_telemetry_reader.h
+++ b/device/api/umd/device/arc_telemetry_reader.h
@@ -5,7 +5,10 @@
  */
 #pragma once
 
+#include <map>
+
 #include "umd/device/tt_device/tt_device.h"
+#include "umd/device/tt_xy_pair.h"
 
 namespace tt::umd {
 
@@ -13,14 +16,41 @@ class ArcTelemetryReader {
 public:
     virtual ~ArcTelemetryReader() = default;
 
-    virtual uint32_t read_entry(const uint8_t telemetry_tag) = 0;
+    uint32_t read_entry(const uint8_t telemetry_tag);
 
-    virtual bool is_entry_available(const uint8_t telemetry_tag) = 0;
+    bool is_entry_available(const uint8_t telemetry_tag);
 
     static std::unique_ptr<ArcTelemetryReader> create_arc_telemetry_reader(TTDevice* tt_device);
 
 protected:
     ArcTelemetryReader(TTDevice* tt_device);
+
+    virtual void get_telemetry_address() = 0;
+
+    void initialize_telemetry();
+
+    // Address of the telemetry table struct on ARC core.
+    uint32_t telemetry_table_addr;
+
+    // Number of entries in the telemetry table.
+    uint32_t entry_count;
+
+    // After entry_count the telemetry contains entry_count structs of TelemetryTagEntry.
+    // Each struct contains tag and offset. Tag represents what is represented by the value.
+    // Offset is the index of the telemetry value in the telemetry_values array.
+    struct TelemetryTagEntry {
+        uint16_t tag;
+        uint16_t offset;
+    };
+
+    // Address of the telemetry data on ARC core.
+    uint32_t telemetry_values_addr;
+
+    std::map<uint32_t, uint32_t> telemetry_values;
+    std::map<uint32_t, uint32_t> telemetry_offset;
+
+    // During initialization of telemetry, if the NOC0 is hung then we need to read the telemetry values from NOC1.
+    tt_xy_pair arc_core;
 
     TTDevice* tt_device;
 };

--- a/device/api/umd/device/blackhole_arc_telemetry_reader.h
+++ b/device/api/umd/device/blackhole_arc_telemetry_reader.h
@@ -6,9 +6,6 @@
 #pragma once
 
 #include "umd/device/arc_telemetry_reader.h"
-#include "umd/device/blackhole_implementation.h"
-
-extern bool umd_use_noc1;
 
 namespace tt::umd {
 
@@ -16,35 +13,8 @@ class BlackholeArcTelemetryReader : public ArcTelemetryReader {
 public:
     BlackholeArcTelemetryReader(TTDevice* tt_device);
 
-    uint32_t read_entry(const uint8_t telemetry_tag) override;
-
-    bool is_entry_available(const uint8_t telemetry_tag) override;
-
-private:
-    void initialize_telemetry();
-
-    // Address of the telemetry table struct on ARC core.
-    uint32_t telemetry_table_addr;
-
-    // Number of entries in the telemetry table.
-    uint32_t entry_count;
-
-    // After entry_count the telemetry contains entry_count structs of TelemetryTagEntry.
-    // Each struct contains tag and offset. Tag represents what is represented by the value.
-    // Offset is the index of the telemetry value in the telemetry_values array.
-    struct TelemetryTagEntry {
-        uint16_t tag;
-        uint16_t offset;
-    };
-
-    // Address of the telemetry data on ARC core.
-    uint32_t telemetry_values_addr;
-
-    std::map<uint32_t, uint32_t> telemetry_values;
-    std::map<uint32_t, uint32_t> telemetry_offset;
-
-    // During initialization of telemetry, if the NOC0 is hung then we need to read the telemetry values from NOC1.
-    const tt_xy_pair arc_core;
+protected:
+    void get_telemetry_address() override;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/wormhole_arc_telemetry_reader.h
+++ b/device/api/umd/device/wormhole_arc_telemetry_reader.h
@@ -5,11 +5,7 @@
  */
 #pragma once
 
-#include "umd/device/arc_messenger.h"
 #include "umd/device/arc_telemetry_reader.h"
-#include "umd/device/wormhole_implementation.h"
-
-extern bool umd_use_noc1;
 
 namespace tt::umd {
 
@@ -17,23 +13,11 @@ class WormholeArcTelemetryReader : public ArcTelemetryReader {
 public:
     WormholeArcTelemetryReader(TTDevice* tt_device);
 
-    uint32_t read_entry(const uint8_t telemetry_tag) override;
-
-    bool is_entry_available(const uint8_t telemetry_tag) override;
+protected:
+    void get_telemetry_address() override;
 
 private:
-    void initialize_telemetry();
-
     void verify_telemetry();
-
-    uint64_t telemetry_base_noc_addr;
-
-    // During initialization of telemetry, if the NOC0 is hung then we need to read the telemetry values from NOC1.
-    const tt_xy_pair arc_core = !umd_use_noc1
-                                    ? tt::umd::wormhole::ARC_CORES_NOC0[0]
-                                    : tt_xy_pair(
-                                          tt::umd::wormhole::NOC0_X_TO_NOC1_X[tt::umd::wormhole::ARC_CORES_NOC0[0].x],
-                                          tt::umd::wormhole::NOC0_Y_TO_NOC1_Y[tt::umd::wormhole::ARC_CORES_NOC0[0].y]);
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/wormhole_implementation.h
+++ b/device/api/umd/device/wormhole_implementation.h
@@ -268,6 +268,8 @@ constexpr std::array<std::pair<CoreType, uint64_t>, 5> NOC1_CONTROL_REG_ADDR_BAS
      {CoreType::ARC, 0xFFFB30000}}};
 static const uint64_t NOC_NODE_ID_OFFSET = 0x2C;
 
+static const uint64_t ARC_RESET_UNIT_BASE_ADDR = 0x880030000;
+
 static const size_t tensix_translated_coordinate_start_x = 18;
 static const size_t tensix_translated_coordinate_start_y = 18;
 

--- a/device/arc_telemetry_reader.cpp
+++ b/device/arc_telemetry_reader.cpp
@@ -23,4 +23,46 @@ std::unique_ptr<ArcTelemetryReader> ArcTelemetryReader::create_arc_telemetry_rea
     }
 }
 
+void ArcTelemetryReader::initialize_telemetry() {
+    tt_device->read_from_device(&entry_count, arc_core, telemetry_table_addr + sizeof(uint32_t), sizeof(uint32_t));
+
+    // We offset the tag_table_address by 2 * sizeof(uint32_t) to skip the first two uint32_t values,
+    // which are version and entry count. For representaiton look at blackhole_telemetry.h
+    uint32_t tag_table_address = telemetry_table_addr + 2 * sizeof(uint32_t);
+    std::vector<TelemetryTagEntry> telemetry_tag_entries(entry_count);
+    tt_device->read_from_device(
+        telemetry_tag_entries.data(), arc_core, tag_table_address, entry_count * sizeof(TelemetryTagEntry));
+
+    std::vector<uint32_t> telemetry_data(entry_count);
+    tt_device->read_from_device(telemetry_data.data(), arc_core, telemetry_values_addr, entry_count * sizeof(uint32_t));
+
+    for (const TelemetryTagEntry& tag_entry : telemetry_tag_entries) {
+        const uint16_t tag_val = tag_entry.tag;
+        const uint16_t offset_val = tag_entry.offset;
+
+        telemetry_values.insert({tag_val, telemetry_data[offset_val]});
+        telemetry_offset.insert({tag_val, offset_val});
+    }
+}
+
+uint32_t ArcTelemetryReader::read_entry(const uint8_t telemetry_tag) {
+    if (!is_entry_available(telemetry_tag)) {
+        throw std::runtime_error(fmt::format(
+            "Telemetry entry {} not available. You can use is_entry_available() to check if the entry is available.",
+            telemetry_tag));
+    }
+
+    const uint32_t offset = telemetry_offset.at(telemetry_tag);
+    uint32_t telemetry_val;
+    tt_device->read_from_device(
+        &telemetry_val, arc_core, telemetry_values_addr + offset * sizeof(uint32_t), sizeof(uint32_t));
+
+    telemetry_values[telemetry_tag] = telemetry_val;
+    return telemetry_values[telemetry_tag];
+}
+
+bool ArcTelemetryReader::is_entry_available(const uint8_t telemetry_tag) {
+    return telemetry_values.find(telemetry_tag) != telemetry_values.end();
+}
+
 }  // namespace tt::umd

--- a/device/blackhole/blackhole_arc_telemetry_reader.cpp
+++ b/device/blackhole/blackhole_arc_telemetry_reader.cpp
@@ -7,65 +7,23 @@
 
 #include <fmt/core.h>
 
+#include "umd/device/blackhole_implementation.h"
 #include "umd/device/types/blackhole_telemetry.h"
 
 extern bool umd_use_noc1;
 
 namespace tt::umd {
 
-BlackholeArcTelemetryReader::BlackholeArcTelemetryReader(TTDevice* tt_device) :
-    ArcTelemetryReader(tt_device),
-    arc_core(blackhole::get_arc_core(tt_device->get_noc_translation_enabled(), umd_use_noc1)) {
+BlackholeArcTelemetryReader::BlackholeArcTelemetryReader(TTDevice* tt_device) : ArcTelemetryReader(tt_device) {
+    arc_core = blackhole::get_arc_core(tt_device->get_noc_translation_enabled(), umd_use_noc1);
+    get_telemetry_address();
     initialize_telemetry();
 }
 
-void BlackholeArcTelemetryReader::initialize_telemetry() {
+void BlackholeArcTelemetryReader::get_telemetry_address() {
     tt_device->read_from_device(&telemetry_table_addr, arc_core, tt::umd::blackhole::SCRATCH_RAM_13, sizeof(uint32_t));
 
-    tt_device->read_from_device(&entry_count, arc_core, telemetry_table_addr + sizeof(uint32_t), sizeof(uint32_t));
-
     tt_device->read_from_device(&telemetry_values_addr, arc_core, tt::umd::blackhole::SCRATCH_RAM_12, sizeof(uint32_t));
-
-    // We offset the tag_table_address by 2 * sizeof(uint32_t) to skip the first two uint32_t values,
-    // which are version and entry count. For representaiton look at blackhole_telemetry.h
-    uint32_t tag_table_address = telemetry_table_addr + 2 * sizeof(uint32_t);
-    std::vector<TelemetryTagEntry> telemetry_tag_entries(entry_count);
-    tt_device->read_from_device(
-        telemetry_tag_entries.data(), arc_core, tag_table_address, entry_count * sizeof(TelemetryTagEntry));
-
-    std::vector<uint32_t> telemetry_data(entry_count);
-    tt_device->read_from_device(telemetry_data.data(), arc_core, telemetry_values_addr, entry_count * sizeof(uint32_t));
-
-    for (const TelemetryTagEntry& tag_entry : telemetry_tag_entries) {
-        const uint16_t tag_val = tag_entry.tag;
-        const uint16_t offset_val = tag_entry.offset;
-
-        telemetry_values.insert({tag_val, telemetry_data[offset_val]});
-        telemetry_offset.insert({tag_val, offset_val});
-    }
-}
-
-uint32_t BlackholeArcTelemetryReader::read_entry(const uint8_t telemetry_tag) {
-    if (!is_entry_available(telemetry_tag)) {
-        throw std::runtime_error(fmt::format(
-            "Telemetry entry {} not available. You can use is_entry_available() to check if the entry is available.",
-            telemetry_tag));
-    }
-
-    const uint32_t offset = telemetry_offset.at(telemetry_tag);
-    uint32_t telemetry_val;
-    tt_device->read_from_device(
-        &telemetry_val,
-        BlackholeArcTelemetryReader::arc_core,
-        telemetry_values_addr + offset * sizeof(uint32_t),
-        sizeof(uint32_t));
-
-    telemetry_values[telemetry_tag] = telemetry_val;
-    return telemetry_values[telemetry_tag];
-}
-
-bool BlackholeArcTelemetryReader::is_entry_available(const uint8_t telemetry_tag) {
-    return telemetry_values.find(telemetry_tag) != telemetry_values.end();
 }
 
 }  // namespace tt::umd

--- a/device/wormhole/wormhole_arc_telemetry_reader.cpp
+++ b/device/wormhole/wormhole_arc_telemetry_reader.cpp
@@ -6,27 +6,28 @@
 #include "umd/device/wormhole_arc_telemetry_reader.h"
 
 #include "umd/device/types/wormhole_telemetry.h"
+#include "umd/device/wormhole_implementation.h"
+
+extern bool umd_use_noc1;
 
 namespace tt::umd {
 
 WormholeArcTelemetryReader::WormholeArcTelemetryReader(TTDevice* tt_device) : ArcTelemetryReader(tt_device) {
+    arc_core = !umd_use_noc1 ? tt::umd::wormhole::ARC_CORES_NOC0[0]
+                             : tt_xy_pair(
+                                   tt::umd::wormhole::NOC0_X_TO_NOC1_X[tt::umd::wormhole::ARC_CORES_NOC0[0].x],
+                                   tt::umd::wormhole::NOC0_Y_TO_NOC1_Y[tt::umd::wormhole::ARC_CORES_NOC0[0].y]);
+    get_telemetry_address();
     initialize_telemetry();
+    verify_telemetry();
 }
 
-void WormholeArcTelemetryReader::initialize_telemetry() {
-    std::vector<uint32_t> arc_msg_return_values = {0};
-    static const uint32_t timeout_ms = 1000;
-    uint32_t exit_code = tt_device->get_arc_messenger()->send_message(
-        tt::umd::wormhole::ARC_MSG_COMMON_PREFIX |
-            (uint32_t)tt::umd::wormhole::arc_message_type::GET_SMBUS_TELEMETRY_ADDR,
-        arc_msg_return_values,
-        0,
-        0,
-        timeout_ms);
+void WormholeArcTelemetryReader::get_telemetry_address() {
+    tt_device->read_from_device(
+        &telemetry_table_addr, arc_core, tt::umd::wormhole::ARC_RESET_UNIT_BASE_ADDR + 0x1D0, sizeof(uint32_t));
 
-    static constexpr uint64_t noc_telemetry_offset = 0x810000000;
-    telemetry_base_noc_addr = arc_msg_return_values[0] + noc_telemetry_offset;
-    verify_telemetry();
+    tt_device->read_from_device(
+        &telemetry_values_addr, arc_core, tt::umd::wormhole::ARC_RESET_UNIT_BASE_ADDR + 0x1D4, sizeof(uint32_t));
 }
 
 void WormholeArcTelemetryReader::verify_telemetry() {
@@ -36,24 +37,6 @@ void WormholeArcTelemetryReader::verify_telemetry() {
         throw std::runtime_error(
             fmt::format("Tenstorrent vendor ID mismatch. Expected: 0x{:x}, Got: 0x{:x}", tt_vendor_id, vendor_id));
     }
-}
-
-uint32_t WormholeArcTelemetryReader::read_entry(const uint8_t telemetry_tag) {
-    if (!is_entry_available(telemetry_tag)) {
-        throw std::runtime_error(fmt::format(
-            "Telemetry entry {} not available. You can use is_entry_available() to check if the entry is available.",
-            telemetry_tag));
-    }
-
-    uint32_t telemetry_value;
-    tt_device->read_from_device(
-        &telemetry_value, arc_core, telemetry_base_noc_addr + telemetry_tag * sizeof(uint32_t), sizeof(uint32_t));
-
-    return telemetry_value;
-}
-
-bool WormholeArcTelemetryReader::is_entry_available(const uint8_t telemetry_tag) {
-    return telemetry_tag >= 0 && telemetry_tag < tt::umd::wormhole::TELEMETRY_NUMBER_OF_TAGS;
 }
 
 }  // namespace tt::umd

--- a/tests/blackhole/test_arc_messages_bh.cpp
+++ b/tests/blackhole/test_arc_messages_bh.cpp
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include "umd/device/arc_messenger.h"
 #include "umd/device/blackhole_arc_telemetry_reader.h"
+#include "umd/device/blackhole_implementation.h"
 #include "umd/device/cluster.h"
 #include "umd/device/types/blackhole_arc.h"
 


### PR DESCRIPTION
### Issue

https://github.com/tenstorrent/tt-umd/issues/892

### Description

Implement new Wormhole telemetry. It is going to use the same scheme as Blackhole telemetry. Reading of telemetry address is different than Blackhole. Other things stay the same.

### List of the changes

- Make both WH and BH telemetry use the same scheme
- Implement arch specific reading of telemetry address

### Testing
CI. Tests for telemetry should just pass

### API Changes
/
