### PR TITLE
Supress gtest warnings

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -18,6 +18,11 @@ if(TT_UMD_BUILD_TESTS)
         OPTIONS
             "INSTALL_GTEST OFF"
     )
+    if(googletest_ADDED AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        # Suppress clang's -Wimplicit-int-float-conversion just for gtest targets
+        target_compile_options(gtest PRIVATE -Wno-implicit-int-float-conversion)
+        target_compile_options(gtest_main PRIVATE -Wno-implicit-int-float-conversion)
+    endif()
 endif()
 
 ####################################################################################################################

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -18,10 +18,8 @@ if(TT_UMD_BUILD_TESTS)
         OPTIONS
             "INSTALL_GTEST OFF"
     )
-    if(googletest_ADDED AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        # Suppress clang's -Wimplicit-int-float-conversion just for gtest targets
+    if(googletest_ADDED)
         target_compile_options(gtest PRIVATE -Wno-implicit-int-float-conversion)
-        target_compile_options(gtest_main PRIVATE -Wno-implicit-int-float-conversion)
     endif()
 endif()
 


### PR DESCRIPTION
### Issue
NA

### Description
The goal here is to make these noisy warnings disappear...

```
/__w/tt-umd/tt-umd/.cpmcache/googletest/96129d89f45386492ae46d6bb8c027bc3df5f949/googletest/include/gtest/gtest-printers.h:532:9: warning: implicit conversion from 'int32_t' (aka 'int') to 'float' may lose precision [-Wimplicit-int-float-conversion]
  532 |     if (static_cast<int32_t>(val * mulfor6 + 0.5) / mulfor6 == val) return 6;
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~
/__w/tt-umd/tt-umd/.cpmcache/googletest/96129d89f45386492ae46d6bb8c027bc3df5f949/googletest/include/gtest/gtest-printers.h:551:17: note: in instantiation of function template specialization 'testing::internal::AppropriateResolution<float>' requested here
  551 |   os->precision(AppropriateResolution(f));
      |                 ^
/__w/tt-umd/tt-umd/.cpmcache/googletest/96129d89f45386492ae46d6bb8c027bc3df5f949/googletest/include/gtest/gtest-printers.h:544:9: warning: implicit conversion from 'int32_t' (aka 'int') to 'float' may lose precision [-Wimplicit-int-float-conversion]
  544 |     if (static_cast<int32_t>(val / divfor6 + 0.5) * divfor6 == val) return 6;
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~
2 warnings generated.
```

### List of the changes
Disable this warning, because it is only to do with gtest code.

### Testing
CI

### API Changes
There are no API changes in this PR.
