### PR TITLE
Implement wait for Wormhole ETH training

### DIFF
--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -110,6 +110,10 @@ private:
 
     void wait_for_aiclk_value(tt_DevicePowerState power_state, const uint32_t timeout_ms = 5000);
 
+    void bh_wait_eth_cores_training(const uint32_t timeout_ms = 60000);
+
+    void wh_wait_eth_cores_training(const uint32_t timeout_ms = 60000);
+
 protected:
     void wait_eth_cores_training(const uint32_t timeout_ms = 60000) override;
 

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -110,10 +110,6 @@ private:
 
     void wait_for_aiclk_value(tt_DevicePowerState power_state, const uint32_t timeout_ms = 5000);
 
-    void bh_wait_eth_cores_training(const uint32_t timeout_ms = 60000);
-
-    void wh_wait_eth_cores_training(const uint32_t timeout_ms = 60000);
-
 protected:
     void wait_eth_cores_training(const uint32_t timeout_ms = 60000) override;
 

--- a/device/api/umd/device/tt_device/blackhole_tt_device.h
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.h
@@ -43,6 +43,8 @@ public:
 
     ChipInfo get_chip_info() override;
 
+    void wait_eth_core_training(const tt_xy_pair eth_core, const uint32_t timeout_ms = 60000) override;
+
 private:
     static constexpr uint64_t ATU_OFFSET_IN_BH_BAR2 = 0x1200;
     std::set<size_t> iatu_regions_;

--- a/device/api/umd/device/tt_device/remote_tt_device.h
+++ b/device/api/umd/device/tt_device/remote_tt_device.h
@@ -40,6 +40,8 @@ public:
 
     bool get_noc_translation_enabled() override;
 
+    void wait_eth_core_training(const tt_xy_pair eth_core, const uint32_t timeout_ms = 60000) override;
+
 private:
     LocalChip* local_chip_;
     eth_coord_t target_chip_;

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -172,6 +172,8 @@ public:
 
     virtual void wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms = 1000);
 
+    virtual void wait_eth_core_training(const tt_xy_pair eth_core, const uint32_t timeout_ms = 60000) = 0;
+
     void bar_write32(uint32_t addr, uint32_t data);
 
     uint32_t bar_read32(uint32_t addr);

--- a/device/api/umd/device/tt_device/wormhole_tt_device.h
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.h
@@ -41,6 +41,8 @@ public:
 
     ChipInfo get_chip_info() override;
 
+    void wait_eth_core_training(const tt_xy_pair eth_core, const uint32_t timeout_ms = 60000) override;
+
 private:
     void dma_d2h_transfer(const uint64_t dst, const uint32_t src, const size_t size);
     void dma_h2d_transfer(const uint32_t dst, const uint64_t src, const size_t size);

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -176,15 +176,12 @@ void LocalChip::wh_wait_eth_cores_training(const uint32_t timeout_ms) {
         tt_device->read_from_device(&heartbeat_val, eth_core, eth_core_heartbeat_addr, sizeof(heartbeat_val));
 
         uint32_t new_heartbeat_val = heartbeat_val;
-        while (new_heartbeat_val <= heartbeat_val) {
+        while (new_heartbeat_val != heartbeat_val) {
             tt_device->read_from_device(&new_heartbeat_val, eth_core, eth_core_heartbeat_addr, sizeof(heartbeat_val));
             auto end = std::chrono::system_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
             if (duration.count() > timeout_ms) {
-                // TODO: Exception should be thrown here. ETH connections are very flaky
-                // on Blackhole right now. When this is fixed we can throw the exception here.
-                // Since we are not going to do any remote IO at the moment it is fine to just log the error.
-                log_error("ETH training timed out after {} ms", timeout_ms);
+                throw std::runtime_error(fmt::format("ETH training timed out after {} ms", timeout_ms));
                 break;
             }
         }

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -167,7 +167,8 @@ void LocalChip::bh_wait_eth_cores_training(const uint32_t timeout_ms) {
 
 void LocalChip::wh_wait_eth_cores_training(const uint32_t timeout_ms) {
     const uint64_t eth_core_heartbeat_addr = 0x1C;
-    const std::vector<CoreCoord> eth_cores = get_soc_descriptor().get_cores(CoreType::ETH);
+    const std::vector<CoreCoord> eth_cores =
+        get_soc_descriptor().get_cores(CoreType::ETH, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::PHYSICAL);
     TTDevice* tt_device = get_tt_device();
     auto start = std::chrono::system_clock::now();
     for (const CoreCoord& eth_core : eth_cores) {

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -9,7 +9,6 @@
 #include <tt-logger/tt-logger.hpp>
 
 #include "assert.hpp"
-#include "umd/device/blackhole_implementation.h"
 #include "umd/device/chip_helpers/tlb_manager.h"
 #include "umd/device/driver_atomics.h"
 #include "umd/device/tt_device/tt_device.h"
@@ -137,62 +136,12 @@ void LocalChip::start_device() {
 
 void LocalChip::close_device(){};
 
-void LocalChip::bh_wait_eth_cores_training(const uint32_t timeout_ms) {
-    const std::vector<CoreCoord> eth_cores = get_soc_descriptor().get_cores(CoreType::ETH);
-    TTDevice* tt_device = get_tt_device();
-    auto start = std::chrono::system_clock::now();
-    for (const CoreCoord& eth_core : eth_cores) {
-        const tt_xy_pair eth_core_pair = {eth_core.x, eth_core.y};
-
-        uint32_t port_status_addr = blackhole::BOOT_RESULTS_ADDR + offsetof(blackhole::eth_status_t, port_status);
-        uint32_t port_status_val;
-        tt_device->read_from_device(&port_status_val, eth_core_pair, port_status_addr, sizeof(port_status_val));
-
-        // Port status should be last state to settle during the eth training sequence
-        // PORT_UNKNOWN means that eth is still training
-        while (port_status_val == blackhole::port_status_e::PORT_UNKNOWN) {
-            tt_device->read_from_device(&port_status_val, eth_core_pair, port_status_addr, sizeof(port_status_val));
-            auto end = std::chrono::system_clock::now();
-            auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-            if (duration.count() > timeout_ms) {
-                // TODO: Exception should be thrown here. ETH connections are very flaky
-                // on Blackhole right now. When this is fixed we can throw the exception here.
-                // Since we are not going to do any remote IO at the moment it is fine to just log the error.
-                log_error("ETH training timed out after {} ms", timeout_ms);
-                break;
-            }
-        }
-    }
-}
-
-void LocalChip::wh_wait_eth_cores_training(const uint32_t timeout_ms) {
-    const uint64_t eth_core_heartbeat_addr = 0x1C;
+void LocalChip::wait_eth_cores_training(const uint32_t timeout_ms) {
     const std::vector<CoreCoord> eth_cores =
         get_soc_descriptor().get_cores(CoreType::ETH, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::PHYSICAL);
     TTDevice* tt_device = get_tt_device();
-    auto start = std::chrono::system_clock::now();
     for (const CoreCoord& eth_core : eth_cores) {
-        uint32_t heartbeat_val;
-        tt_device->read_from_device(&heartbeat_val, eth_core, eth_core_heartbeat_addr, sizeof(heartbeat_val));
-
-        uint32_t new_heartbeat_val = heartbeat_val;
-        while (new_heartbeat_val != heartbeat_val) {
-            tt_device->read_from_device(&new_heartbeat_val, eth_core, eth_core_heartbeat_addr, sizeof(heartbeat_val));
-            auto end = std::chrono::system_clock::now();
-            auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-            if (duration.count() > timeout_ms) {
-                throw std::runtime_error(fmt::format("ETH training timed out after {} ms", timeout_ms));
-                break;
-            }
-        }
-    }
-}
-
-void LocalChip::wait_eth_cores_training(const uint32_t timeout_ms) {
-    if (get_tt_device()->get_arch() == tt::ARCH::WORMHOLE_B0) {
-        wh_wait_eth_cores_training(timeout_ms);
-    } else if (get_tt_device()->get_arch() == tt::ARCH::BLACKHOLE) {
-        bh_wait_eth_cores_training(timeout_ms);
+        tt_device->wait_eth_core_training(eth_core, timeout_ms);
     }
 }
 

--- a/device/tt_device/remote_tt_device.cpp
+++ b/device/tt_device/remote_tt_device.cpp
@@ -67,4 +67,6 @@ bool RemoteTTDevice::get_noc_translation_enabled() {
     throw std::runtime_error("get_noc_translation_enabled() not implemented for RemoteTTDevice.");
 }
 
+void RemoteTTDevice::wait_eth_core_training(const tt_xy_pair eth_core, const uint32_t timeout_ms) {}
+
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue

#723 

### Description

Implement wait for training of ETH cores on wormhole. Code polls on heartbeat address of ETH core and waits for the increase of the value. During training, this value is always 0 so the code will busy wait.

### List of the changes

- Split BH and WH training in LocalChip
- Implement WH wait on ETH core training

### Testing
CI
Manually tested the wait during tt-smi reset 

### API Changes
/
