### PR TITLE
Don't constrain ClusterDescriptor if full set of chips

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -418,10 +418,16 @@ Cluster::Cluster(ClusterOptions options) {
     // If no target devices are passed, obtain them from the cluster descriptor.
     if (chips_to_construct.empty()) {
         chips_to_construct = temp_full_cluster_desc->get_all_chips();
+        // If no target devices are passed and the cluster descriptor is not constrained, we can use the full cluster.
+        // Note that the pointer is being dereferenced below, that means that the default copy constructor will be
+        // called for tt_ClusterDescriptor to construct the object which will end up in the unique_ptr, note that the
+        // line below doesn't take ownership of already existing object pointed to by temp_full_cluster_desc.
+        cluster_desc = std::make_unique<tt_ClusterDescriptor>(*temp_full_cluster_desc);
+    } else {
+        // Create constrained cluster descriptor which only contains the chips to be in this Cluster.
+        cluster_desc =
+            tt_ClusterDescriptor::create_constrained_cluster_descriptor(temp_full_cluster_desc, chips_to_construct);
     }
-    // Create constrained cluster descriptor which only contains the chips to be in this Cluster.
-    cluster_desc =
-        tt_ClusterDescriptor::create_constrained_cluster_descriptor(temp_full_cluster_desc, chips_to_construct);
     std::vector<chip_id_t> chips_to_construct_vec(chips_to_construct.begin(), chips_to_construct.end());
     // Check target_devices against the cluster descriptor in case of silicon chips.
     // We also have to sort them so that local chips are constructed first.


### PR DESCRIPTION
### Issue
After #870 , and while trying to merge it to main on metal: https://github.com/tenstorrent/tt-metal/pull/22078

### Description
There is likely a test issue in t3k fabric tests, but I can't find it.
The previous code would tumble the order in unordered_maps, leading to some failure in said test. I couldn't find the exact issue.

### List of the changes
- If full set of chips, call default copy constructor instead of function for constraining.

### Testing
I've manually ran this test on a t3k machine, and saw it passing only after this change.
./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric2DPushFixture.TestUnicastRaw"

### API Changes
There are no API changes in this PR.
