### PR TITLE
Use KMD PIN_PAGES for configuring NOC access to host memory

### DIFF
--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -102,7 +102,6 @@ private:
 
     void check_pcie_device_initialized();
     int test_setup_interface();
-    void init_pcie_iatus();
 
     void set_membar_flag(
         const std::vector<CoreCoord>& cores, const uint32_t barrier_value, const uint32_t barrier_addr);

--- a/device/api/umd/device/chip_helpers/sysmem_buffer.h
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.h
@@ -27,7 +27,10 @@ namespace tt::umd {
  */
 class SysmemBuffer {
 public:
-    SysmemBuffer(TLBManager* tlb_manager, void* buffer_va, size_t buffer_size);
+    // TODO: maybe get rid of map_to_noc, make noc_addr non-optional?
+    // "Sysmem" is always mapped to NOC, but this class could be used as a DMA
+    // buffer (used by PCIE DMA engine) and not accessed by NOC at all.
+    SysmemBuffer(TLBManager* tlb_manager, void* buffer_va, size_t buffer_size, bool map_to_noc = false);
     ~SysmemBuffer();
 
     void* get_buffer_va() const { return buffer_va; }
@@ -35,6 +38,8 @@ public:
     size_t get_buffer_size() const { return buffer_size; }
 
     uint64_t get_device_io_addr(const size_t offset = 0) const { return device_io_addr + offset; }
+
+    std::optional<uint64_t> get_noc_addr() const { return noc_addr; }
 
     void dma_write_to_device(size_t offset, size_t size, tt_xy_pair core, uint64_t addr);
 
@@ -50,6 +55,10 @@ private:
 
     // Address that is used on the system bus to access the buffer.
     uint64_t device_io_addr;
+
+    // Address that is used on the NOC to access the buffer.  NOC target must be
+    // the PCIE core that is connected to the host and this address.
+    std::optional<uint64_t> noc_addr;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/sysmem_manager.h
+++ b/device/api/umd/device/chip_helpers/sysmem_manager.h
@@ -38,15 +38,16 @@ private:
      * Allocate sysmem without hugepages and map it through IOMMU.
      * This is used when the system is protected by an IOMMU.  The mappings will
      * still appear as hugepages to the caller.
-     * @param size sysmem size in bytes; size % (1UL << 30) == 0
+     * @param num_fake_mem_channels number of fake mem channels to allocate
      * @return whether allocation/mapping succeeded.
      */
-    bool init_iommu(size_t size);
+    bool init_iommu(size_t num_fake_mem_channels);
 
     // For debug purposes when various stages fails.
     void print_file_contents(std::string filename, std::string hint = "");
 
     TLBManager* tlb_manager_;
+    uint64_t pcie_base_;
 
     std::vector<hugepage_mapping> hugepage_mapping_per_channel;
 

--- a/device/api/umd/device/pci_device.hpp
+++ b/device/api/umd/device/pci_device.hpp
@@ -136,6 +136,22 @@ public:
     uint64_t map_for_hugepage(void *buffer, size_t size);
 
     /**
+     * Map a buffer so it is accessible by the device NOC.
+     * @param buffer must be page-aligned
+     * @param size must be a multiple of the page size
+     * @return uint64_t NOC address, uint64_t PA or IOVA
+     */
+    std::pair<uint64_t, uint64_t> map_buffer_to_noc(void *buffer, size_t size);
+
+    /**
+     * Map a hugepage so it is accessible by the device NOC.
+     * @param hugepage 1G hugepage
+     * @param size in bytes (OK to be smaller than the hugepage size)
+     * @return uint64_t NOC address, uint64_t PA or IOVA
+     */
+    std::pair<uint64_t, uint64_t> map_hugepage_to_noc(void *hugepage, size_t size);
+
+    /**
      * Map a buffer for DMA access by the device.
      *
      * Supports mapping physically-contiguous buffers (e.g. hugepages) for the

--- a/device/api/umd/device/tt_device/blackhole_tt_device.h
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.h
@@ -17,8 +17,6 @@ public:
     BlackholeTTDevice(std::unique_ptr<PCIDevice> pci_device);
     ~BlackholeTTDevice();
 
-    void configure_iatu_region(size_t region, uint64_t target, size_t region_size) override;
-
     void wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms = 1000) override;
 
     uint32_t get_clock() override;

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -140,34 +140,6 @@ public:
         tt_xy_pair end,
         std::uint64_t ordering = tt::umd::tlb_data::Relaxed);
 
-    /**
-     * Configures a PCIe Address Translation Unit (iATU) region.
-     *
-     * Device software expects to be able to access memory that is shared with
-     * the host using the following NOC addresses at the PCIe core:
-     * - GS: 0x0
-     * - WH: 0x8_0000_0000
-     * - BH: 0x1000_0000_0000_0000
-     * Without iATU configuration, these map to host PA 0x0.
-     *
-     * While modern hardware supports IOMMU with flexible IOVA mapping, we must
-     * maintain the iATU configuration to satisfy software that has hard-coded
-     * the above NOC addresses rather than using driver-provided IOVAs.
-     *
-     * This interface is only intended to be used for configuring sysmem with
-     * either 1GB hugepages or a compatible scheme.
-     *
-     * @param region iATU region index (0-15)
-     * @param target DMA address (PA or IOVA) to map to
-     * @param region_size size of the mapping window; must be (1 << 30)
-     *
-     * NOTE: Programming the iATU from userspace is architecturally incorrect:
-     * - iATU should be managed by KMD to ensure proper cleanup on process exit
-     * - Multiple processes can corrupt each other's iATU configurations
-     * We should fix this!
-     */
-    virtual void configure_iatu_region(size_t region, uint64_t target, size_t region_size);
-
     virtual ChipInfo get_chip_info() = 0;
 
     virtual void wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms = 1000);

--- a/device/api/umd/device/tt_device/wormhole_tt_device.h
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.h
@@ -15,8 +15,6 @@ class WormholeTTDevice : public TTDevice {
 public:
     WormholeTTDevice(std::unique_ptr<PCIDevice> pci_device);
 
-    void configure_iatu_region(size_t region, uint64_t target, size_t region_size) override;
-
     void wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms = 1000) override;
 
     uint32_t get_clock() override;

--- a/device/api/umd/device/types/cluster_types.h
+++ b/device/api/umd/device/types/cluster_types.h
@@ -217,5 +217,4 @@ constexpr inline bool operator>=(const tt_version& a, const tt_version& b) {
 struct hugepage_mapping {
     void* mapping = nullptr;
     size_t mapping_size = 0;
-    uint64_t physical_address = 0;  // or IOVA, if IOMMU is enabled
 };

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -131,7 +131,6 @@ bool LocalChip::is_mmio_capable() const { return true; }
 
 void LocalChip::start_device() {
     check_pcie_device_initialized();
-    init_pcie_iatus();
     initialize_membars();
 }
 
@@ -567,27 +566,6 @@ int LocalChip::test_setup_interface() {
         return 0;
     } else {
         throw std::runtime_error(fmt::format("Unsupported architecture: {}", arch_to_str(soc_descriptor_.arch)));
-    }
-}
-
-void LocalChip::init_pcie_iatus() {
-    // TODO: this should go away soon; KMD knows how to do this at page pinning time.
-    for (size_t channel = 0; channel < sysmem_manager_->get_num_host_mem_channels(); channel++) {
-        hugepage_mapping hugepage_map = sysmem_manager_->get_hugepage_mapping(channel);
-        size_t region_size = hugepage_map.mapping_size;
-
-        if (!hugepage_map.mapping) {
-            throw std::runtime_error(fmt::format("Hugepages are not allocated for ch: {}", channel));
-        }
-
-        if (soc_descriptor_.arch == tt::ARCH::WORMHOLE_B0) {
-            // TODO: stop doing this.  The intent was good, but it's not
-            // documented and nothing takes advantage of it.
-            if (channel == 3) {
-                region_size = HUGEPAGE_CHANNEL_3_SIZE_LIMIT;
-            }
-        }
-        tt_device_->configure_iatu_region(channel, hugepage_map.physical_address, region_size);
     }
 }
 

--- a/device/chip_helpers/sysmem_manager.cpp
+++ b/device/chip_helpers/sysmem_manager.cpp
@@ -18,7 +18,16 @@
 
 namespace tt::umd {
 
-SysmemManager::SysmemManager(TLBManager *tlb_manager) : tlb_manager_(tlb_manager) {}
+SysmemManager::SysmemManager(TLBManager *tlb_manager) : tlb_manager_(tlb_manager) {
+    auto arch = tlb_manager_->get_tt_device()->get_arch();
+
+    // TODO: I could only find these constants in cluster.cpp...
+    // Historically, the sysmem implementation has always placed the starting
+    // address of the hugepages/faked hugepages at the bottom of the device's
+    // PCIE address range that is mapped to the host system bus.  pcie_base_ is
+    // used to validate this behavior.
+    pcie_base_ = (arch == tt::ARCH::WORMHOLE_B0 ? 0x800000000 : (arch == tt::ARCH::BLACKHOLE ? 4ULL << 58 : 0));
+}
 
 SysmemManager::~SysmemManager() {
     for (const auto &hugepage_mapping : hugepage_mapping_per_channel) {
@@ -79,6 +88,8 @@ void SysmemManager::read_from_sysmem(uint16_t channel, void *dest, uint64_t sysm
 
 bool SysmemManager::init_hugepage(uint32_t num_host_mem_channels) {
     TTDevice *tt_device_ = tlb_manager_->get_tt_device();
+    auto arch = tt_device_->get_arch();
+
     // TODO: get rid of this when the following Metal CI issue is resolved.
     // https://github.com/tenstorrent/tt-metal/issues/15675
     // The notion that we should clamp the number of host mem channels to
@@ -102,8 +113,7 @@ bool SysmemManager::init_hugepage(uint32_t num_host_mem_channels) {
     const size_t hugepage_size = HUGEPAGE_REGION_SIZE;
 
     if (tt_device_->get_pci_device()->is_iommu_enabled()) {
-        size_t size = hugepage_size * num_host_mem_channels;
-        return init_iommu(size);
+        return init_iommu(num_host_mem_channels);
     }
 
     auto physical_device_id = tt_device_->get_pci_device()->get_device_num();
@@ -183,25 +193,20 @@ bool SysmemManager::init_hugepage(uint32_t num_host_mem_channels) {
         size_t actual_size = (tt_device_->get_arch() == tt::ARCH::WORMHOLE_B0 && ch == 3)
                                  ? HUGEPAGE_CHANNEL_3_SIZE_LIMIT
                                  : hugepage_size;
-        uint64_t physical_address = tt_device_->get_pci_device()->map_for_hugepage(mapping, actual_size);
+        auto [noc_address, physical_address] = tt_device_->get_pci_device()->map_hugepage_to_noc(mapping, actual_size);
+        uint64_t expected_noc_address = pcie_base_ + (ch * hugepage_size);
 
-        if (physical_address == 0) {
-            log_warning(
-                LogSiliconDriver,
-                "---- ttSiliconDevice::init_hugepage: physical_device_id: {} ch: {} TENSTORRENT_IOCTL_PIN_PAGES failed "
-                "(errno: {}). Common Issue: Requires TTMKD >= 1.11, see following file contents...",
-                physical_device_id,
-                ch,
-                strerror(errno));
-            munmap(mapping, hugepage_size);
-            print_file_contents("/sys/module/tenstorrent/version", "(TTKMD version)");
-            print_file_contents("/proc/meminfo");
-            print_file_contents("/proc/buddyinfo");
-            success = false;
-            continue;
+        // Note that the truncated page is the final one, so there is no need to
+        // give expected_noc_address special treatment for a subsequent page.
+        if (noc_address != expected_noc_address) {
+            log_fatal(
+                "NOC address of a hugepage does not match the expected address. Proceeding could lead to undefined "
+                "behavior");
+        } else {
+            log_info(LogSiliconDriver, "Mapped hugepage {:#x} to NOC address {:#x}", physical_address, noc_address);
         }
 
-        hugepage_mapping_per_channel[ch] = {mapping, hugepage_size, physical_address};
+        hugepage_mapping_per_channel[ch] = {mapping, hugepage_size};
 
         log_debug(
             LogSiliconDriver,
@@ -215,14 +220,20 @@ bool SysmemManager::init_hugepage(uint32_t num_host_mem_channels) {
     return success;
 }
 
-bool SysmemManager::init_iommu(size_t size) {
+bool SysmemManager::init_iommu(size_t num_fake_mem_channels) {
     constexpr size_t carveout_size = HUGEPAGE_REGION_SIZE - HUGEPAGE_CHANNEL_3_SIZE_LIMIT;  // 1GB - 768MB = 256MB
-    const size_t num_fake_mem_channels = size / HUGEPAGE_REGION_SIZE;
-
+    const size_t size = num_fake_mem_channels * HUGEPAGE_REGION_SIZE;
     TTDevice *tt_device_ = tlb_manager_->get_tt_device();
-    // Caclulate the size of the mapping in order to avoid overlap with PCIE registers.
-    size_t map_size =
-        (tt_device_->get_arch() == tt::ARCH::WORMHOLE_B0 && num_fake_mem_channels == 4) ? (size - carveout_size) : size;
+
+    if (num_fake_mem_channels > 4) {
+        TT_THROW("Max of 4 host memory channels per device are supported, got: {}", num_fake_mem_channels);
+    }
+
+    // Caclulate the size of the mapping in order to avoid overlap with PCIE registers on WH.
+    // This doesn't have to be applied on BH, but it is anyway for consistency.
+    size_t map_size = (num_fake_mem_channels == 4) ? (size - carveout_size) : size;
+
+    log_info(LogSiliconDriver, "Initializing iommu for sysmem (size: {:#x}).", map_size);
 
     if (!tt_device_->get_pci_device()->is_iommu_enabled()) {
         TT_THROW("IOMMU is required for sysmem without hugepages.");
@@ -240,15 +251,30 @@ bool SysmemManager::init_iommu(size_t size) {
 
     sysmem_buffer_ = map_sysmem_buffer(mapping, map_size);
     uint64_t iova = sysmem_buffer_->get_device_io_addr();
+    auto noc_address = sysmem_buffer_->get_noc_addr();
 
-    log_info(LogSiliconDriver, "Mapped sysmem without hugepages to IOVA {:#x}.", iova);
+    if (!noc_address.has_value()) {
+        TT_THROW("NOC address is not set for sysmem buffer.");
+    }
+
+    if (*noc_address != pcie_base_) {
+        // If this happens, it means that something else is using the address
+        // space that UMD typically uses.  Historically, this would have crashed
+        // or done something inscrutable.  Now it is just an error.
+        log_error("Expected NOC address: {:#x}, but got {:#x}", pcie_base_, *noc_address);
+        TT_THROW("Proceeding could lead to undefined behavior");
+    }
+
+
+    log_info(LogSiliconDriver, "Mapped sysmem without hugepages to IOVA {:#x}; NOC address {:#x}", iova, *noc_address);
 
     hugepage_mapping_per_channel.resize(num_fake_mem_channels);
 
     // Support for more than 1GB host memory accessible per device, via channels.
     for (size_t ch = 0; ch < num_fake_mem_channels; ch++) {
         uint8_t *base = static_cast<uint8_t *>(mapping) + ch * HUGEPAGE_REGION_SIZE;
-        hugepage_mapping_per_channel[ch] = {base, HUGEPAGE_REGION_SIZE, iova + ch * HUGEPAGE_REGION_SIZE};
+        size_t actual_size = (ch == 3) ? HUGEPAGE_CHANNEL_3_SIZE_LIMIT : HUGEPAGE_REGION_SIZE;
+        hugepage_mapping_per_channel[ch] = {base, actual_size};
     }
 
     return true;
@@ -258,7 +284,7 @@ size_t SysmemManager::get_num_host_mem_channels() const { return hugepage_mappin
 
 hugepage_mapping SysmemManager::get_hugepage_mapping(size_t channel) const {
     if (hugepage_mapping_per_channel.size() <= channel) {
-        return {nullptr, 0, 0};
+        return {nullptr, 0};
     } else {
         return hugepage_mapping_per_channel[channel];
     }
@@ -281,7 +307,9 @@ std::unique_ptr<SysmemBuffer> SysmemManager::allocate_sysmem_buffer(uint32_t sys
 }
 
 std::unique_ptr<SysmemBuffer> SysmemManager::map_sysmem_buffer(void *buffer, uint32_t sysmem_buffer_size) {
-    return std::make_unique<SysmemBuffer>(tlb_manager_, buffer, sysmem_buffer_size);
+    log_info(LogSiliconDriver, "Mapping sysmem buffer to NOC: {:#x}", sysmem_buffer_size);
+    const bool map_to_noc = true;
+    return std::make_unique<SysmemBuffer>(tlb_manager_, buffer, sysmem_buffer_size, map_to_noc);
 }
 
 }  // namespace tt::umd

--- a/device/ioctl.h
+++ b/device/ioctl.h
@@ -1,11 +1,5 @@
-/*
- * SPDX-FileCopyrightText: (c) 2023 Tenstorrent Inc.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-// clang-format off
-// This file is copied from KMD, so we don't want clang formatting diff.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only WITH Linux-syscall-note
 
 #ifndef TTDRIVER_IOCTL_H_INCLUDED
 #define TTDRIVER_IOCTL_H_INCLUDED
@@ -13,7 +7,7 @@
 #include <linux/types.h>
 #include <linux/ioctl.h>
 
-#define TENSTORRENT_DRIVER_VERSION 1
+#define TENSTORRENT_DRIVER_VERSION 2
 
 #define TENSTORRENT_IOCTL_MAGIC 0xFA
 
@@ -25,7 +19,12 @@
 #define TENSTORRENT_IOCTL_GET_DRIVER_INFO	_IO(TENSTORRENT_IOCTL_MAGIC, 5)
 #define TENSTORRENT_IOCTL_RESET_DEVICE		_IO(TENSTORRENT_IOCTL_MAGIC, 6)
 #define TENSTORRENT_IOCTL_PIN_PAGES		_IO(TENSTORRENT_IOCTL_MAGIC, 7)
+#define TENSTORRENT_IOCTL_LOCK_CTL		_IO(TENSTORRENT_IOCTL_MAGIC, 8)
+#define TENSTORRENT_IOCTL_MAP_PEER_BAR		_IO(TENSTORRENT_IOCTL_MAGIC, 9)
 #define TENSTORRENT_IOCTL_UNPIN_PAGES		_IO(TENSTORRENT_IOCTL_MAGIC, 10)
+#define TENSTORRENT_IOCTL_ALLOCATE_TLB		_IO(TENSTORRENT_IOCTL_MAGIC, 11)
+#define TENSTORRENT_IOCTL_FREE_TLB		_IO(TENSTORRENT_IOCTL_MAGIC, 12)
+#define TENSTORRENT_IOCTL_CONFIGURE_TLB		_IO(TENSTORRENT_IOCTL_MAGIC, 13)
 
 // For tenstorrent_mapping.mapping_id. These are not array indices.
 #define TENSTORRENT_MAPPING_UNUSED		0
@@ -36,7 +35,10 @@
 #define TENSTORRENT_MAPPING_RESOURCE2_UC	5
 #define TENSTORRENT_MAPPING_RESOURCE2_WC	6
 
-#define TENSTORRENT_MAX_DMA_BUFS	8
+#define TENSTORRENT_MAX_DMA_BUFS	256
+#define TENSTORRENT_MAX_INBOUND_TLBS	256
+
+#define TENSTORRENT_RESOURCE_LOCK_COUNT 64
 
 struct tenstorrent_get_device_info_in {
 	__u32 output_size_bytes;
@@ -49,8 +51,8 @@ struct tenstorrent_get_device_info_out {
 	__u16 subsystem_vendor_id;
 	__u16 subsystem_id;
 	__u16 bus_dev_fn;	// [0:2] function, [3:7] device, [8:15] bus
-	__u16 max_dma_buf_size_log2;
-	__u16 pci_domain;
+	__u16 max_dma_buf_size_log2;	// Since 1.0
+	__u16 pci_domain;		// Since 1.23
 };
 
 struct tenstorrent_get_device_info {
@@ -124,6 +126,11 @@ struct tenstorrent_get_driver_info {
 	struct tenstorrent_get_driver_info_out out;
 };
 
+// tenstorrent_reset_device_in.flags
+#define TENSTORRENT_RESET_DEVICE_RESTORE_STATE 0
+#define TENSTORRENT_RESET_DEVICE_RESET_PCIE_LINK 1
+#define TENSTORRENT_RESET_DEVICE_CONFIG_WRITE 2
+
 struct tenstorrent_reset_device_in {
 	__u32 output_size_bytes;
 	__u32 flags;
@@ -140,7 +147,9 @@ struct tenstorrent_reset_device {
 };
 
 // tenstorrent_pin_pages_in.flags
-#define TENSTORRENT_PIN_PAGES_CONTIGUOUS 1
+#define TENSTORRENT_PIN_PAGES_CONTIGUOUS 1	// app attests that the pages are physically contiguous
+#define TENSTORRENT_PIN_PAGES_NOC_DMA 2		// app wants to use the pages for NOC DMA
+#define TENSTORRENT_PIN_PAGES_NOC_TOP_DOWN 4	// NOC DMA will be allocated top-down (default is bottom-up)
 
 struct tenstorrent_pin_pages_in {
 	__u32 output_size_bytes;
@@ -150,17 +159,17 @@ struct tenstorrent_pin_pages_in {
 };
 
 struct tenstorrent_pin_pages_out {
-	__u64 physical_address;
+	__u64 physical_address;	// or IOVA
 };
 
-struct tenstorrent_pin_pages {
-	struct tenstorrent_pin_pages_in in;
-	struct tenstorrent_pin_pages_out out;
+struct tenstorrent_pin_pages_out_extended {
+	__u64 physical_address;	// or IOVA
+	__u64 noc_address;
 };
 
+// unpinning subset of a pinned buffer is not supported
 struct tenstorrent_unpin_pages_in {
-	// Original VA used to pin, not current VA if remapped.
-	__u64 virtual_address;	
+	__u64 virtual_address;	// original VA used to pin, not current VA if remapped
 	__u64 size;
 	__u64 reserved;
 };
@@ -172,5 +181,107 @@ struct tenstorrent_unpin_pages {
 	struct tenstorrent_unpin_pages_in in;
 	struct tenstorrent_unpin_pages_out out;
 };
+
+struct tenstorrent_pin_pages {
+	struct tenstorrent_pin_pages_in in;
+	struct tenstorrent_pin_pages_out out;
+};
+
+// tenstorrent_lock_ctl_in.flags
+#define TENSTORRENT_LOCK_CTL_ACQUIRE 0
+#define TENSTORRENT_LOCK_CTL_RELEASE 1
+#define TENSTORRENT_LOCK_CTL_TEST 2
+
+struct tenstorrent_lock_ctl_in {
+	__u32 output_size_bytes;
+	__u32 flags;
+	__u8  index;
+};
+
+struct tenstorrent_lock_ctl_out {
+	__u8 value;
+};
+
+struct tenstorrent_lock_ctl {
+	struct tenstorrent_lock_ctl_in in;
+	struct tenstorrent_lock_ctl_out out;
+};
+
+struct tenstorrent_map_peer_bar_in {
+	__u32 peer_fd;
+	__u32 peer_bar_index;
+	__u32 peer_bar_offset;
+	__u32 peer_bar_length;
+	__u32 flags;
+};
+
+struct tenstorrent_map_peer_bar_out {
+	__u64 dma_address;
+	__u64 reserved;
+};
+
+struct tenstorrent_map_peer_bar {
+	struct tenstorrent_map_peer_bar_in in;
+	struct tenstorrent_map_peer_bar_out out;
+};
+
+struct tenstorrent_allocate_tlb_in {
+	__u64 size;
+	__u64 reserved;
+};
+
+struct tenstorrent_allocate_tlb_out {
+	__u32 id;
+	__u32 reserved0;
+	__u64 mmap_offset_uc;
+	__u64 mmap_offset_wc;
+	__u64 reserved1;
+};
+
+struct tenstorrent_allocate_tlb {
+	struct tenstorrent_allocate_tlb_in in;
+	struct tenstorrent_allocate_tlb_out out;
+};
+
+struct tenstorrent_free_tlb_in {
+	__u32 id;
+};
+
+struct tenstorrent_free_tlb_out {
+};
+
+struct tenstorrent_free_tlb {
+	struct tenstorrent_free_tlb_in in;
+	struct tenstorrent_free_tlb_out out;
+};
+
+struct tenstorrent_noc_tlb_config {
+	__u64 addr;
+	__u16 x_end;
+	__u16 y_end;
+	__u16 x_start;
+	__u16 y_start;
+	__u8 noc;
+	__u8 mcast;
+	__u8 ordering;
+	__u8 linked;
+	__u8 static_vc;
+	__u8 reserved0[3];
+	__u32 reserved1[2];
+};
+
+struct tenstorrent_configure_tlb_in {
+	__u32 id;
+	struct tenstorrent_noc_tlb_config config;
+};
+
+struct tenstorrent_configure_tlb_out {
+	__u64 reserved;
+};
+
+struct tenstorrent_configure_tlb {
+	struct tenstorrent_configure_tlb_in in;
+	struct tenstorrent_configure_tlb_out out;
+};
+
 #endif
-// clang-format on

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -183,12 +183,23 @@ PCIDevice::PCIDevice(int pci_device_number) :
         TT_THROW("Running with IOMMU support requires KMD version {} or newer", kmd_ver_for_iommu.to_string());
     }
 
+    tenstorrent_get_driver_info driver_info{};
+    driver_info.in.output_size_bytes = sizeof(driver_info.out);
+    if (ioctl(pci_device_file_desc, TENSTORRENT_IOCTL_GET_DRIVER_INFO, &driver_info) == -1) {
+        TT_THROW("TENSTORRENT_IOCTL_GET_DRIVER_INFO failed");
+    }
+
     log_info(
         LogSiliconDriver,
-        "Opened PCI device {}; KMD version: {}, IOMMU: {}",
+        "Opened PCI device {}; KMD version: {}; API: {}; IOMMU: {}",
         pci_device_num,
         kmd_version.to_string(),
+        driver_info.out.driver_version,
         iommu_enabled ? "enabled" : "disabled");
+
+    if (driver_info.out.driver_version < 2) {
+        TT_THROW("UMD requires a KMD version that supports APIv2 or greater.  Please update to the latest tt-kmd");
+    }
 
     TT_ASSERT(arch != tt::ARCH::WORMHOLE_B0 || revision == 0x01, "Wormhole B0 must have revision 0x01");
 
@@ -468,6 +479,71 @@ uint64_t PCIDevice::map_for_hugepage(void *buffer, size_t size) {
     }
 
     return pin_pages.out.physical_address;
+}
+
+std::pair<uint64_t, uint64_t> PCIDevice::map_buffer_to_noc(void *buffer, size_t size) {
+    static const auto page_size = sysconf(_SC_PAGESIZE);
+    const uint64_t vaddr = reinterpret_cast<uint64_t>(buffer);
+
+    if (vaddr % page_size != 0 || size % page_size != 0) {
+        TT_THROW("Buffer must be page-aligned with a size that is a multiple of the page size");
+    }
+
+    if (size > page_size && !is_iommu_enabled()) {
+        TT_THROW("Cannot map buffer of size {} to NOC with IOMMU disabled", size);
+    }
+
+    struct
+    {
+        tenstorrent_pin_pages_in in;
+        tenstorrent_pin_pages_out_extended out;
+    } pin{};
+    pin.in.output_size_bytes = sizeof(pin.out);
+    pin.in.flags = TENSTORRENT_PIN_PAGES_NOC_DMA;
+    pin.in.virtual_address = vaddr;
+    pin.in.size = size;
+
+    log_info(LogSiliconDriver, "Pinning pages for DMA: {:#x} {:#x}", vaddr, size);
+
+    if (ioctl(pci_device_file_desc, TENSTORRENT_IOCTL_PIN_PAGES, &pin) == -1) {
+        TT_THROW("Failed to pin pages for DMA: {}", strerror(errno));
+    }
+
+    return {pin.out.noc_address, pin.out.physical_address};
+}
+
+std::pair<uint64_t, uint64_t> PCIDevice::map_hugepage_to_noc(void *hugepage, size_t size) {
+    static const auto page_size = sysconf(_SC_PAGESIZE);
+    const uint64_t vaddr = reinterpret_cast<uint64_t>(hugepage);
+
+    if (size > (1 << 30)) {
+        TT_THROW("Not a hugepage");
+    }
+
+    if (vaddr % page_size != 0 || size % page_size != 0) {
+        TT_THROW("Buffer must be page-aligned with a size that is a multiple of the page size");
+    }
+
+    if (is_iommu_enabled()) {
+        // IOMMU is enabled, so we don't need huge pages.
+        log_warning(LogSiliconDriver, "Mapping a hugepage with IOMMU enabled.");
+    }
+
+    struct
+    {
+        tenstorrent_pin_pages_in in;
+        tenstorrent_pin_pages_out_extended out;
+    } pin{};
+    pin.in.output_size_bytes = sizeof(pin.out);
+    pin.in.flags = TENSTORRENT_PIN_PAGES_CONTIGUOUS | TENSTORRENT_PIN_PAGES_NOC_DMA;
+    pin.in.virtual_address = reinterpret_cast<std::uintptr_t>(hugepage);
+    pin.in.size = size;
+
+    if (ioctl(pci_device_file_desc, TENSTORRENT_IOCTL_PIN_PAGES, &pin) == -1) {
+        TT_THROW("Failed to pin pages for DMA: {} {}", strerror(errno), pin.in.flags);
+    }
+
+    return {pin.out.noc_address, pin.out.physical_address};
 }
 
 uint64_t PCIDevice::map_for_dma(void *buffer, size_t size) {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -348,10 +348,6 @@ dynamic_tlb TTDevice::set_dynamic_tlb_broadcast(
     return set_dynamic_tlb(tlb_index, start, end, address, true, ordering);
 }
 
-void TTDevice::configure_iatu_region(size_t region, uint64_t target, size_t region_size) {
-    throw std::runtime_error("configure_iatu_region is not implemented for this device");
-}
-
 void TTDevice::wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms) {
     throw std::runtime_error("Waiting for ARC core to start is supported only for Blackhole TTDevice.");
 }

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -797,6 +797,12 @@ TEST(SiliconDriverBH, RandomSysmemTestWithPcie) {
         uint64_t lo = (ONE_GIG * channel);
         uint64_t hi = (lo + ONE_GIG) - 1;
 
+        if (channel == 3) {
+            // Avoid the top 256MB of the 4th channel.
+            // TODO(joelsmithTT) - This is a hack.
+            hi &= ~0x0fff'ffffULL;
+        }
+
         for (size_t i = 0; i < num_tests; ++i) {
             uint64_t address = generate_aligned_address(lo, hi);
             uint64_t noc_addr = base_address + address;


### PR DESCRIPTION
This is example/reference code not intended to be merged in this PR, demonstrating:
* detecting whether KMD is new enough for new APIs
* using KMD for sysmem NOC mapping

RE: KMD API detection -- the forthcoming KMD release will bump its API version number to 2.  The suggestion is for UMD to fail with an actionable error message ("Please update tt-kmd") if an older version is detected.

RE: iATU setup -- the updated PIN_PAGES API is part of the effort to enable IOMMU for WH.  More details [here](https://tenstorrent.atlassian.net/wiki/spaces/syseng/pages/903544840/32-bit+DMA+migration+to+IOMMU).  Impact to UMD:
* UMD will no longer need architecture-specific code paths for iATU setup
* KMD iATU management allows tooling/application SW coexistence based on an established but incompletely implemented convention (256 MB carveout at the top of the sysmem address space)

