### PR TITLE
Add set_level api for clients to control UMD log level

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(POSITION_INDEPENDENT_CODE ON)
 
-add_subdirectory(logger_init)
-
 if(TT_UMD_BUILD_SIMULATION)
     set(FBS_FILE ${PROJECT_SOURCE_DIR}/device/simulation/tt_simulation_device.fbs)
     get_filename_component(FBS_FILE_NAME ${FBS_FILE} NAME_WLE)
@@ -43,6 +41,7 @@ target_sources(
         wormhole/wormhole_implementation.cpp
         blackhole/blackhole_implementation.cpp
         hugepage.cpp
+        logging/config.cpp
         pcie/pci_device.cpp
         tlb.cpp
         tt_cluster_descriptor.cpp
@@ -145,7 +144,6 @@ target_link_libraries(
     PRIVATE
         umd::Common
         umd::Firmware
-        umd::Logger::Init
         hwloc
         rt
         spdlog::spdlog_header_only

--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -102,6 +102,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/device_api_metal.h
                 api/umd/device/driver_atomics.h
                 api/umd/device/hugepage.h
+                api/umd/device/logging/config.h
                 api/umd/device/utils/lock_manager.h
                 api/umd/device/pci_device.hpp
                 api/umd/device/semver.hpp

--- a/device/api/umd/device/logging/config.h
+++ b/device/api/umd/device/logging/config.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @brief UMD logger configuration and utilities
+ *
+ * This namespace contains functionality for configuring the logging system
+ * used by the UMD (User Mode Driver).
+ */
+namespace tt::umd::logging {
+
+/**
+ * @brief Logging severity levels
+ *
+ * Defines the different severity levels for logging messages, from most
+ * verbose (trace) to most severe (critical), with an option to disable
+ * logging completely (off).
+ */
+enum class level {
+    trace,     ///< Most detailed logging level, for tracing program execution
+    debug,     ///< Debugging information, useful during development
+    info,      ///< General informational messages about program operation
+    warn,      ///< Warning messages for potentially harmful situations
+    error,     ///< Error messages for serious problems
+    critical,  ///< Critical errors that may lead to program termination
+    off        ///< Disables all logging
+};
+
+/**
+ * @brief Sets the global logging level
+ *
+ * @param lvl The new logging level to set. Messages with severity levels
+ *            lower than this level will not be logged.
+ */
+void set_level(level lvl);
+
+}  // namespace tt::umd::logging

--- a/device/api/umd/device/logging/config.h
+++ b/device/api/umd/device/logging/config.h
@@ -5,7 +5,7 @@
 #pragma once
 
 /**
- * @brief UMD logger configuration and utilities
+ * @brief UMD logger configuration and utilities.
  *
  * This namespace contains functionality for configuring the logging system
  * used by the UMD (User Mode Driver).

--- a/device/logger_init/CMakeLists.txt
+++ b/device/logger_init/CMakeLists.txt
@@ -1,4 +1,0 @@
-add_library(umd-logger-init OBJECT logger_init.cpp)
-add_library(umd::Logger::Init ALIAS umd-logger-init)
-
-target_link_libraries(umd-logger-init PRIVATE tt-logger::tt-logger)

--- a/device/logging/config.cpp
+++ b/device/logging/config.cpp
@@ -14,6 +14,7 @@
 #include "umd/device/logging/config.h"
 
 #include <spdlog/spdlog.h>
+
 #include <tt-logger/tt-logger-initializer.hpp>
 
 namespace tt::umd::logging {

--- a/device/logging/config.cpp
+++ b/device/logging/config.cpp
@@ -11,9 +11,9 @@
  * environment variable names for UMD logging configuration.
  */
 
-#include <spdlog/spdlog.h>
 #include "umd/device/logging/config.h"
 
+#include <spdlog/spdlog.h>
 #include <tt-logger/tt-logger-initializer.hpp>
 
 namespace tt::umd::logging {

--- a/device/logging/config.cpp
+++ b/device/logging/config.cpp
@@ -12,7 +12,7 @@
  */
 
 #include <spdlog/spdlog.h>
-#include <umd/device/logging/config.h>
+#include "umd/device/logging/config.h"
 
 #include <tt-logger/tt-logger-initializer.hpp>
 
@@ -36,7 +36,7 @@ constexpr auto log_pattern = "[%Y-%m-%d %H:%M:%S.%e] [%l] [%s:%#] %v";
  */
 static tt::LoggerInitializer loggerInitializer(file_env_var, level_env_var, log_pattern);
 
-/// Map our internal enum to spdlog's level enum
+/// Map our internal enum to spdlog's level enum.
 spdlog::level::level_enum to_spdlog_level(level lvl) {
     switch (lvl) {
         case level::trace:

--- a/device/logging/config.cpp
+++ b/device/logging/config.cpp
@@ -3,13 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * @file logger_init.cpp
+ * @file config.cpp
  * @brief Implementation of UMD (User Mode Driver) logging initialization
  *
  * This file contains the initialization code for the UMD logging system.
  * It creates a static instance of the TT LoggerInitializer with specific
  * environment variable names for UMD logging configuration.
  */
+
+#include <spdlog/spdlog.h>
+#include <umd/device/logging/config.h>
 
 #include <tt-logger/tt-logger-initializer.hpp>
 
@@ -33,6 +36,27 @@ constexpr auto log_pattern = "[%Y-%m-%d %H:%M:%S.%e] [%l] [%s:%#] %v";
  */
 static tt::LoggerInitializer loggerInitializer(file_env_var, level_env_var, log_pattern);
 
-// Note - Using default logger pattern, until source_location info can be fixed
+/// Map our internal enum to spdlog's level enum
+spdlog::level::level_enum to_spdlog_level(level lvl) {
+    switch (lvl) {
+        case level::trace:
+            return spdlog::level::trace;
+        case level::debug:
+            return spdlog::level::debug;
+        case level::info:
+            return spdlog::level::info;
+        case level::warn:
+            return spdlog::level::warn;
+        case level::error:
+            return spdlog::level::err;
+        case level::critical:
+            return spdlog::level::critical;
+        case level::off:
+            return spdlog::level::off;
+    }
+    return spdlog::level::info;  // fallback
+}
+
+void set_level(level lvl) { spdlog::set_level(to_spdlog_level(lvl)); }
 
 }  // namespace tt::umd::logging


### PR DESCRIPTION
### Issue
Requested by @tt-vjovanovic over slack.

### Description
Clients of UMD may want to adjust log level without resorting to an ENV.
This PR adds a set_level API.

### List of the changes
- Add new public API header `<umd/logging/config.h>`
  - Currently only exposes one function and associated level enum
- Added a corresponding `logging/config.cpp` for implementation, also absorbed the init code.
- Removed the object library that was used previously for simplicity

### Testing
CI is my test bed

### API Changes
This PR has API changes:
- Since this is a newly introduced API in a new namespace, it can't possible break anyone. 
