### PR TITLE
Set remote transfer cores to active channels

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -85,6 +85,7 @@ public:
         uint32_t* return_4 = nullptr) = 0;
 
     virtual void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores);
+    virtual void set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channel);
 
     // TODO: To be moved to private implementation once methods are moved to chip
     void enable_ethernet_queue(int timeout_s);

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -31,6 +31,7 @@ public:
     TLBManager* get_tlb_manager() override;
 
     void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) override;
+    void set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) override;
     // TODO: Figure out if this should remain public or used another way.
     tt_xy_pair get_remote_transfer_ethernet_core();
     void update_active_eth_core_idx();

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -96,7 +96,6 @@ private:
     void initialize_local_chip(int num_host_mem_channels = 0);
     void initialize_tlb_manager();
     void initialize_default_chip_mutexes();
-    void initialize_default_remote_transfer_ethernet_cores();
     void initialize_membars();
 
     tt_xy_pair translate_chip_coord_virtual_to_translated(const tt_xy_pair core) const;

--- a/device/api/umd/device/topology_discovery.h
+++ b/device/api/umd/device/topology_discovery.h
@@ -70,10 +70,6 @@ private:
 
     std::unordered_map<chip_id_t, eth_coord_t> eth_coords;
 
-    // Remote transfer eth cores for each TTDevice, key of the map is pcie device that we
-    // create tt device for.
-    std::unordered_map<uint32_t, std::vector<tt_xy_pair>> remote_transfer_ethernet_cores;
-
     std::vector<std::pair<std::pair<chip_id_t, uint32_t>, std::pair<chip_id_t, uint32_t>>> ethernet_connections;
 
     std::unique_ptr<tt_ClusterDescriptor> cluster_desc;

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -116,6 +116,10 @@ void Chip::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord
     throw std::runtime_error("Chip::set_remote_transfer_ethernet_cores is not available for this chip.");
 }
 
+void Chip::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channel) {
+    throw std::runtime_error("Chip::set_remote_transfer_ethernet_cores is not available for this chip.");
+}
+
 int Chip::get_numa_node() { throw std::runtime_error("Chip::get_numa_node is not available for this chip."); }
 
 void Chip::wait_dram_cores_training(const uint32_t timeout_ms) {}

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -67,7 +67,6 @@ void LocalChip::initialize_local_chip(int num_host_mem_channels) {
     }
     wait_chip_to_be_ready();
     initialize_default_chip_mutexes();
-    initialize_default_remote_transfer_ethernet_cores();
 }
 
 void LocalChip::initialize_tlb_manager() {
@@ -383,25 +382,20 @@ tt_xy_pair LocalChip::translate_chip_coord_virtual_to_translated(const tt_xy_pai
     }
 }
 
-void LocalChip::initialize_default_remote_transfer_ethernet_cores() {
-    if (tt_device_->get_arch() == tt::ARCH::WORMHOLE_B0) {
-        // By default, until set_remote_transfer_ethernet_cores is called, the remote transfer cores by default are set
-        // to the first 6 ones.
-        // TODO: Figure out why only 6. Figure out why other combination doesn't work on galaxy.
-        for (int channel = 0; channel < 6; channel++) {
-            remote_transfer_eth_cores_.push_back(
-                soc_descriptor_.get_eth_core_for_channel(channel, CoordSystem::VIRTUAL));
-        }
-    }
-}
-
-void LocalChip::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& active_eth_cores_per_chip) {
+void LocalChip::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& active_eth_cores) {
     // Makes UMD aware of which ethernet cores have active links.
     // Based on this information, UMD determines which ethernet cores can be used for host->cluster non-MMIO transfers.
     // This overrides the default ethernet cores tagged for host to cluster routing in the constructor and must be
     // called for all MMIO devices, if default behaviour is not desired.
     TT_ASSERT(soc_descriptor_.arch == tt::ARCH::WORMHOLE_B0, "{} can only be called for Wormhole arch", __FUNCTION__);
-    for (const auto& active_eth_core : active_eth_cores_per_chip) {
+    if (active_eth_cores.size() > 8) {
+        // We cannot use more than 8 cores for umd access in one direction. Thats because of the available buffering in
+        // the outgoing eth channels.
+        log_warning(
+            LogSiliconDriver, "Number of active ethernet cores {} exceeds the maximum of 8.", active_eth_cores.size());
+    }
+    remote_transfer_eth_cores_ = {};
+    for (const auto& active_eth_core : active_eth_cores) {
         auto virtual_coord = soc_descriptor_.translate_coord_to(active_eth_core, CoordSystem::VIRTUAL);
         remote_transfer_eth_cores_.push_back(active_eth_core);
     }
@@ -410,7 +404,7 @@ void LocalChip::set_remote_transfer_ethernet_cores(const std::unordered_set<Core
 void LocalChip::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) {
     std::unordered_set<CoreCoord> active_eth_cores;
     for (const auto& channel : channels) {
-        active_eth_cores.insert(soc_descriptor_.get_eth_core_for_channel(channel, CoordSystem::VIRTUAL));
+        active_eth_cores.insert(soc_descriptor_.get_eth_core_for_channel(channel));
     }
     set_remote_transfer_ethernet_cores(active_eth_cores);
 }

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -419,6 +419,14 @@ void LocalChip::set_remote_transfer_ethernet_cores(const std::unordered_set<Core
     }
 }
 
+void LocalChip::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) {
+    std::unordered_set<CoreCoord> active_eth_cores;
+    for (const auto& channel : channels) {
+        active_eth_cores.insert(soc_descriptor_.get_eth_core_for_channel(channel, CoordSystem::VIRTUAL));
+    }
+    set_remote_transfer_ethernet_cores(active_eth_cores);
+}
+
 tt_xy_pair LocalChip::get_remote_transfer_ethernet_core() {
     return {remote_transfer_eth_cores_[active_eth_core_idx].x, remote_transfer_eth_cores_[active_eth_core_idx].y};
 }

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -401,21 +401,9 @@ void LocalChip::set_remote_transfer_ethernet_cores(const std::unordered_set<Core
     // This overrides the default ethernet cores tagged for host to cluster routing in the constructor and must be
     // called for all MMIO devices, if default behaviour is not desired.
     TT_ASSERT(soc_descriptor_.arch == tt::ARCH::WORMHOLE_B0, "{} can only be called for Wormhole arch", __FUNCTION__);
-    // Cores 0, 1, 6, 7 are only available if in the active set
-    static std::unordered_set<tt_xy_pair> eth_cores_available_if_active = {
-        soc_descriptor_.get_eth_core_for_channel(0, CoordSystem::VIRTUAL),
-        soc_descriptor_.get_eth_core_for_channel(1, CoordSystem::VIRTUAL),
-        soc_descriptor_.get_eth_core_for_channel(6, CoordSystem::VIRTUAL),
-        soc_descriptor_.get_eth_core_for_channel(7, CoordSystem::VIRTUAL)};
-    // Eth cores 8 and 9 are always available
-    remote_transfer_eth_cores_ = {
-        soc_descriptor_.get_eth_core_for_channel(8, CoordSystem::VIRTUAL),
-        soc_descriptor_.get_eth_core_for_channel(9, CoordSystem::VIRTUAL)};
     for (const auto& active_eth_core : active_eth_cores_per_chip) {
         auto virtual_coord = soc_descriptor_.translate_coord_to(active_eth_core, CoordSystem::VIRTUAL);
-        if (eth_cores_available_if_active.find(active_eth_core) != eth_cores_available_if_active.end()) {
-            remote_transfer_eth_cores_.push_back(active_eth_core);
-        }
+        remote_transfer_eth_cores_.push_back(active_eth_core);
     }
 }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -178,8 +178,13 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     }
 
     if (cluster_desc->is_chip_mmio_capable(chip_id)) {
-        return std::make_unique<LocalChip>(
+        auto chip = std::make_unique<LocalChip>(
             soc_desc, cluster_desc->get_chips_with_mmio().at(chip_id), num_host_mem_channels);
+        if (cluster_desc->get_arch(chip_id) == tt::ARCH::WORMHOLE_B0) {
+            // Remote transfer currently supported only for wormhole.
+            chip->set_remote_transfer_ethernet_cores(cluster_desc->get_active_eth_channels(chip_id));
+        }
+        return chip;
     } else {
         if (cluster_desc->get_arch(chip_id) != tt::ARCH::WORMHOLE_B0) {
             throw std::runtime_error("Remote chips are supported only for wormhole.");

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -142,8 +142,6 @@ uint32_t TopologyDiscovery::remote_arc_msg(
 BoardType TopologyDiscovery::get_board_type(eth_coord_t eth_coord, Chip* mmio_chip) {
     std::unique_ptr<RemoteCommunication> remote_comm =
         std::make_unique<RemoteCommunication>(dynamic_cast<LocalChip*>(mmio_chip));
-    tt_xy_pair eth_core =
-        remote_transfer_ethernet_cores.at(mmio_chip->get_tt_device()->get_pci_device()->get_device_num()).at(0);
 
     uint32_t ret0;
     uint32_t exit_code = remote_arc_msg(
@@ -176,7 +174,6 @@ ChipInfo TopologyDiscovery::read_non_mmio_chip_info(eth_coord_t eth_coord, Chip*
     TTDevice* tt_device = mmio_chip->get_tt_device();
     std::unique_ptr<RemoteCommunication> remote_comm =
         std::make_unique<RemoteCommunication>(dynamic_cast<LocalChip*>(mmio_chip));
-    tt_xy_pair eth_core = remote_transfer_ethernet_cores.at(tt_device->get_pci_device()->get_device_num()).at(0);
     ChipInfo chip_info;
 
     uint32_t niu_cfg;
@@ -277,8 +274,7 @@ void TopologyDiscovery::discover_remote_chips() {
                 continue;
             }
 
-            remote_transfer_ethernet_cores[tt_device->get_pci_device()->get_device_num()].push_back(
-                {eth_core.x, eth_core.y});
+            active_eth_channels.insert(channel);
 
             uint32_t remote_id;
             tt_device->read_from_device(
@@ -314,7 +310,6 @@ void TopologyDiscovery::discover_remote_chips() {
                 CoreCoord logical_remote_eth =
                     remote_chip->get_soc_descriptor().translate_coord_to(physical_remote_eth, CoordSystem::LOGICAL);
                 ethernet_connections.push_back({{current_chip_id, channel}, {remote_chip_id, logical_remote_eth.y}});
-                active_eth_channels.insert(channel);
             }
             channel++;
         }
@@ -329,7 +324,6 @@ void TopologyDiscovery::discover_remote_chips() {
     TTDevice* tt_device = mmio_chip->get_tt_device();
     std::unique_ptr<RemoteCommunication> remote_comm =
         std::make_unique<RemoteCommunication>(dynamic_cast<LocalChip*>(mmio_chip));
-    tt_xy_pair eth_core = remote_transfer_ethernet_cores.at(tt_device->get_pci_device()->get_device_num()).at(0);
 
     while (!remote_chips_to_discover.empty()) {
         std::unordered_set<eth_coord_t> new_remote_chips = {};

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -261,6 +261,8 @@ void TopologyDiscovery::discover_remote_chips() {
         current_chip_eth_coord.rack = current_chip_eth_coord_info & 0xFF;
         current_chip_eth_coord.shelf = (current_chip_eth_coord_info >> 8) & 0xFF;
 
+        std::set<uint32_t> active_eth_channels;
+
         uint32_t channel = 0;
         for (const CoreCoord& eth_core : eth_cores) {
             uint32_t port_status;
@@ -312,10 +314,11 @@ void TopologyDiscovery::discover_remote_chips() {
                 CoreCoord logical_remote_eth =
                     remote_chip->get_soc_descriptor().translate_coord_to(physical_remote_eth, CoordSystem::LOGICAL);
                 ethernet_connections.push_back({{current_chip_id, channel}, {remote_chip_id, logical_remote_eth.y}});
+                active_eth_channels.insert(channel);
             }
-
             channel++;
         }
+        chip->set_remote_transfer_ethernet_cores(active_eth_channels);
     }
 
     if (remote_chips_to_discover.empty()) {


### PR DESCRIPTION
### Issue
Needed for #856
Should also solve #320

### Description
Main motivation was that this was needed to make our own topology discovery work, since once metal is ran, it goes over eth FWs, and than our current remotecommunication/topologydiscovery stops working.

### List of the changes
- Set remote transfer cores to active eth cores, since idle ones can be reflashed
- Set it every time on Cluster constructor
- Set it during topology discovery once we know which links are active.

### Testing
I've seen this previously fail on TG, so here's a metal test.
All runs on brosko/setremotecores :
- [x] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15223663334
- [x] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15223664291
- [ ] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/15223665178
- [ ] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/15223665773
- [x] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15223666447
- [ ] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/15223667704
- [x] (TG) TG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/15223669245
- [x] (TG) TG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/15223670705

### API Changes
There are no API changes in this PR.
