### PR TITLE
Fixes to topology discovery

### DIFF
--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -457,10 +457,7 @@ void TopologyDiscovery::fill_cluster_descriptor_info() {
         cluster_desc->chip_locations.insert({chip_id, eth_coord});
         cluster_desc->coords_to_chip_ids[eth_coord.rack][eth_coord.shelf][eth_coord.y][eth_coord.x] = chip_id;
 
-        int num_channels =
-            tt::umd::architecture_implementation::create(tt::ARCH::WORMHOLE_B0)->get_num_eth_channels() -
-            CoordinateManager::get_num_harvested(chip->get_chip_info().harvesting_masks.eth_harvesting_mask);
-        for (int i = 0; i < num_channels; i++) {
+        for (int i = 0; i < wormhole::NUM_ETH_CHANNELS; i++) {
             cluster_desc->idle_eth_channels[chip_id].insert(i);
         }
     }

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -629,21 +629,23 @@ void tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descripto
         int channel_0 = endpoints.at(0)["chan"].as<int>();
         int chip_1 = endpoints.at(1)["chip"].as<int>();
         int channel_1 = endpoints.at(1)["chan"].as<int>();
-        if (desc.ethernet_connections[chip_0].find(channel_0) != desc.ethernet_connections[chip_0].end()) {
+        auto &eth_conn_chip_0 = desc.ethernet_connections.at(chip_0);
+        if (eth_conn_chip_0.find(channel_0) != eth_conn_chip_0.end()) {
             TT_ASSERT(
-                (std::get<0>(desc.ethernet_connections[chip_0][channel_0]) == chip_1) &&
-                    (std::get<1>(desc.ethernet_connections[chip_0][channel_0]) == channel_1),
+                (std::get<0>(eth_conn_chip_0.at(channel_0)) == chip_1) &&
+                    (std::get<1>(eth_conn_chip_0.at(channel_0)) == channel_1),
                 "Duplicate eth connection found in cluster desc yaml");
         } else {
-            desc.ethernet_connections[chip_0][channel_0] = {chip_1, channel_1};
+            eth_conn_chip_0.insert({channel_0, {chip_1, channel_1}});
         }
-        if (desc.ethernet_connections[chip_1].find(channel_1) != desc.ethernet_connections[chip_0].end()) {
+        auto &eth_conn_chip_1 = desc.ethernet_connections.at(chip_1);
+        if (eth_conn_chip_1.find(channel_1) != eth_conn_chip_1.end()) {
             TT_ASSERT(
-                (std::get<0>(desc.ethernet_connections[chip_1][channel_1]) == chip_0) &&
-                    (std::get<1>(desc.ethernet_connections[chip_1][channel_1]) == channel_0),
+                (std::get<0>(eth_conn_chip_1.at(channel_1)) == chip_0) &&
+                    (std::get<1>(eth_conn_chip_1.at(channel_1)) == channel_0),
                 "Duplicate eth connection found in cluster desc yaml");
         } else {
-            desc.ethernet_connections[chip_1][channel_1] = {chip_0, channel_0};
+            eth_conn_chip_1.insert({channel_1, {chip_0, channel_0}});
         }
         desc.active_eth_channels[chip_0].insert(channel_0);
         desc.idle_eth_channels[chip_0].erase(channel_0);
@@ -844,6 +846,7 @@ void tt_ClusterDescriptor::load_chips_from_connectivity_descriptor(YAML::Node &y
         std::string arch_str = node->second.as<std::string>();
         desc.all_chips.insert(chip_id);
         desc.chip_arch.insert({chip_id, tt::arch_from_str(arch_str)});
+        desc.ethernet_connections.insert({chip_id, {}});
     }
 
     for (YAML::const_iterator node = yaml["chips"].begin(); node != yaml["chips"].end(); ++node) {


### PR DESCRIPTION
### Issue
Needed for https://github.com/tenstorrent/tt-umd/issues/856

### Description
Some fixes that I saw needed for topology discovery to work as intended

### List of the changes
- Filling up idle and active eth channels
- Filling up coords_to_chip_ids
- Filling up ethernet_connections in both ways
- Fixed an issue with the check (note the chip_0 and chip_1): 
if (desc.ethernet_connections[chip_1].find(channel_1) != desc.ethernet_connections[chip_0].end())
- Also refactored a bit not to use square brackets but explicitly .at or .insert

### Testing
Existing CI tests should be enough

### API Changes
There are no API changes in this PR.
