### PR TITLE
Make WH ARC messenger use NOC

### DIFF
--- a/device/api/umd/device/wormhole_implementation.h
+++ b/device/api/umd/device/wormhole_implementation.h
@@ -247,6 +247,9 @@ static constexpr uint32_t ARC_SCRATCH_RES0_OFFSET = 3;
 static constexpr uint32_t ARC_SCRATCH_RES1_OFFSET = 4;
 static constexpr uint32_t ARC_SCRATCH_STATUS_OFFSET = 5;
 
+constexpr uint64_t ARC_RESET_SCRATCH_ADDR = 0x880030060;
+constexpr uint64_t ARC_RESET_MISC_CNTL_ADDR = 0x880030100;
+
 static constexpr uint32_t AICLK_BUSY_VAL = 1000;
 static constexpr uint32_t AICLK_IDLE_VAL = 500;
 

--- a/device/wormhole/wormhole_arc_messenger.cpp
+++ b/device/wormhole/wormhole_arc_messenger.cpp
@@ -11,6 +11,8 @@
 #include "umd/device/tt_device/tt_device.h"
 #include "umd/device/wormhole_implementation.h"
 
+extern bool umd_use_noc1;
+
 namespace tt::umd {
 
 WormholeArcMessenger::WormholeArcMessenger(TTDevice* tt_device) : ArcMessenger(tt_device) {}
@@ -23,6 +25,14 @@ uint32_t WormholeArcMessenger::send_message(
 
     TT_ASSERT(arg0 <= 0xffff and arg1 <= 0xffff, "Only 16 bits allowed in arc_msg args");
 
+    constexpr uint64_t ARC_RESET_SCRATCH_ADDR = 0x880030060;
+    constexpr uint64_t ARC_RESET_MISC_CNTL_ADDR = 0x880030100;
+    const tt_xy_pair arc_core = umd_use_noc1
+                                    ? tt_xy_pair(
+                                          tt::umd::wormhole::NOC0_X_TO_NOC1_X[tt::umd::wormhole::ARC_CORES_NOC0[0].x],
+                                          tt::umd::wormhole::NOC0_Y_TO_NOC1_Y[tt::umd::wormhole::ARC_CORES_NOC0[0].y])
+                                    : tt::umd::wormhole::ARC_CORES_NOC0[0];
+
     auto lock = lock_manager.acquire_mutex(MutexType::ARC_MSG, tt_device->get_pci_device()->get_device_num());
 
     auto architecture_implementation = tt_device->get_architecture_implementation();
@@ -30,21 +40,25 @@ uint32_t WormholeArcMessenger::send_message(
     uint32_t fw_arg = arg0 | (arg1 << 16);
     int exit_code = 0;
 
-    tt_device->bar_write32(
-        architecture_implementation->get_arc_reset_scratch_offset() +
-            wormhole::ARC_SCRATCH_RES0_OFFSET * sizeof(uint32_t),
-        fw_arg);
-    tt_device->bar_write32(
-        architecture_implementation->get_arc_reset_scratch_offset() +
-            wormhole::ARC_SCRATCH_STATUS_OFFSET * sizeof(uint32_t),
-        msg_code);
+    tt_device->write_to_device(
+        &fw_arg,
+        arc_core,
+        ARC_RESET_SCRATCH_ADDR + wormhole::ARC_SCRATCH_RES0_OFFSET * sizeof(uint32_t),
+        sizeof(uint32_t));
+    tt_device->write_to_device(
+        (void*)&msg_code,
+        arc_core,
+        ARC_RESET_SCRATCH_ADDR + wormhole::ARC_SCRATCH_STATUS_OFFSET * sizeof(uint32_t),
+        sizeof(uint32_t));
 
-    uint32_t misc = tt_device->bar_read32(architecture_implementation->get_arc_reset_arc_misc_cntl_offset());
+    uint32_t misc;
+    tt_device->read_from_device(&misc, arc_core, ARC_RESET_MISC_CNTL_ADDR, sizeof(uint32_t));
     if (misc & (1 << 16)) {
         log_error("trigger_fw_int failed on device {}", 0);
         return 1;
     } else {
-        tt_device->bar_write32(architecture_implementation->get_arc_reset_arc_misc_cntl_offset(), misc | (1 << 16));
+        uint32_t val_wr = misc | (1 << 16);
+        tt_device->write_to_device(&val_wr, arc_core, ARC_RESET_MISC_CNTL_ADDR, sizeof(uint32_t));
     }
 
     uint32_t status = 0xbadbad;
@@ -56,21 +70,27 @@ uint32_t WormholeArcMessenger::send_message(
             throw std::runtime_error(fmt::format("Timed out after waiting {} ms for ARC to respond", timeout_ms));
         }
 
-        status = tt_device->bar_read32(
-            architecture_implementation->get_arc_reset_scratch_offset() +
-            wormhole::ARC_SCRATCH_STATUS_OFFSET * sizeof(uint32_t));
+        tt_device->read_from_device(
+            &status,
+            arc_core,
+            ARC_RESET_SCRATCH_ADDR + wormhole::ARC_SCRATCH_STATUS_OFFSET * sizeof(uint32_t),
+            sizeof(uint32_t));
 
         if ((status & 0xffff) == (msg_code & 0xff)) {
             if (return_values.size() >= 1) {
-                return_values[0] = tt_device->bar_read32(
-                    architecture_implementation->get_arc_reset_scratch_offset() +
-                    wormhole::ARC_SCRATCH_RES0_OFFSET * sizeof(uint32_t));
+                tt_device->read_from_device(
+                    &return_values[0],
+                    arc_core,
+                    ARC_RESET_SCRATCH_ADDR + wormhole::ARC_SCRATCH_RES0_OFFSET * sizeof(uint32_t),
+                    sizeof(uint32_t));
             }
 
             if (return_values.size() >= 2) {
-                return_values[1] = tt_device->bar_read32(
-                    architecture_implementation->get_arc_reset_scratch_offset() +
-                    wormhole::ARC_SCRATCH_RES1_OFFSET * sizeof(uint32_t));
+                tt_device->read_from_device(
+                    &return_values[1],
+                    arc_core,
+                    ARC_RESET_SCRATCH_ADDR + wormhole::ARC_SCRATCH_RES1_OFFSET * sizeof(uint32_t),
+                    sizeof(uint32_t));
             }
 
             exit_code = (status & 0xffff0000) >> 16;

--- a/device/wormhole/wormhole_arc_messenger.cpp
+++ b/device/wormhole/wormhole_arc_messenger.cpp
@@ -25,8 +25,6 @@ uint32_t WormholeArcMessenger::send_message(
 
     TT_ASSERT(arg0 <= 0xffff and arg1 <= 0xffff, "Only 16 bits allowed in arc_msg args");
 
-    constexpr uint64_t ARC_RESET_SCRATCH_ADDR = 0x880030060;
-    constexpr uint64_t ARC_RESET_MISC_CNTL_ADDR = 0x880030100;
     const tt_xy_pair arc_core = umd_use_noc1
                                     ? tt_xy_pair(
                                           tt::umd::wormhole::NOC0_X_TO_NOC1_X[tt::umd::wormhole::ARC_CORES_NOC0[0].x],
@@ -43,22 +41,22 @@ uint32_t WormholeArcMessenger::send_message(
     tt_device->write_to_device(
         &fw_arg,
         arc_core,
-        ARC_RESET_SCRATCH_ADDR + wormhole::ARC_SCRATCH_RES0_OFFSET * sizeof(uint32_t),
+        wormhole::ARC_RESET_SCRATCH_ADDR + wormhole::ARC_SCRATCH_RES0_OFFSET * sizeof(uint32_t),
         sizeof(uint32_t));
     tt_device->write_to_device(
         (void*)&msg_code,
         arc_core,
-        ARC_RESET_SCRATCH_ADDR + wormhole::ARC_SCRATCH_STATUS_OFFSET * sizeof(uint32_t),
+        wormhole::ARC_RESET_SCRATCH_ADDR + wormhole::ARC_SCRATCH_STATUS_OFFSET * sizeof(uint32_t),
         sizeof(uint32_t));
 
     uint32_t misc;
-    tt_device->read_from_device(&misc, arc_core, ARC_RESET_MISC_CNTL_ADDR, sizeof(uint32_t));
+    tt_device->read_from_device(&misc, arc_core, wormhole::ARC_RESET_MISC_CNTL_ADDR, sizeof(uint32_t));
     if (misc & (1 << 16)) {
         log_error("trigger_fw_int failed on device {}", 0);
         return 1;
     } else {
         uint32_t val_wr = misc | (1 << 16);
-        tt_device->write_to_device(&val_wr, arc_core, ARC_RESET_MISC_CNTL_ADDR, sizeof(uint32_t));
+        tt_device->write_to_device(&val_wr, arc_core, wormhole::ARC_RESET_MISC_CNTL_ADDR, sizeof(uint32_t));
     }
 
     uint32_t status = 0xbadbad;
@@ -73,7 +71,7 @@ uint32_t WormholeArcMessenger::send_message(
         tt_device->read_from_device(
             &status,
             arc_core,
-            ARC_RESET_SCRATCH_ADDR + wormhole::ARC_SCRATCH_STATUS_OFFSET * sizeof(uint32_t),
+            wormhole::ARC_RESET_SCRATCH_ADDR + wormhole::ARC_SCRATCH_STATUS_OFFSET * sizeof(uint32_t),
             sizeof(uint32_t));
 
         if ((status & 0xffff) == (msg_code & 0xff)) {
@@ -81,7 +79,7 @@ uint32_t WormholeArcMessenger::send_message(
                 tt_device->read_from_device(
                     &return_values[0],
                     arc_core,
-                    ARC_RESET_SCRATCH_ADDR + wormhole::ARC_SCRATCH_RES0_OFFSET * sizeof(uint32_t),
+                    wormhole::ARC_RESET_SCRATCH_ADDR + wormhole::ARC_SCRATCH_RES0_OFFSET * sizeof(uint32_t),
                     sizeof(uint32_t));
             }
 
@@ -89,7 +87,7 @@ uint32_t WormholeArcMessenger::send_message(
                 tt_device->read_from_device(
                     &return_values[1],
                     arc_core,
-                    ARC_RESET_SCRATCH_ADDR + wormhole::ARC_SCRATCH_RES1_OFFSET * sizeof(uint32_t),
+                    wormhole::ARC_RESET_SCRATCH_ADDR + wormhole::ARC_SCRATCH_RES1_OFFSET * sizeof(uint32_t),
                     sizeof(uint32_t));
             }
 


### PR DESCRIPTION
### Issue

Work towards implementing remote TT device

### Description

Make wormhole ARC messenger use NOC instead of AXI read/writes. Blackhole ARC messenger is already using this. This is going to make the integration with Remote communication much easier, we won't need to derive special ARC messenger for remote stuff. Just overriding read_from_device, write_to_device is going to be enough in order to make remote ARC messages work. In the future, it would be ideal to have special function for rw for ARC core, and TTDevice instance can now whether to go over AXI or NOC.

### List of the changes

- Change bar_read32 with read_from_device
- Change bar_write_32 with write_to_device

### Testing
CI. There are tests for WH ARC messages

### API Changes
/