### PR TITLE
Implement constrained topology

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -68,6 +68,11 @@ struct ClusterOptions {
     // will be checked against the cluster descriptor. In case of MOCK and SIMULATION chip types, this check will be
     // skipped, and you can create chips regardless of the devices on the system.
     std::unordered_set<chip_id_t> target_devices = {};
+    // If set, Cluster will target only boards that have the IDs of the chips specified in this set.
+    // If not set, all discovered PCI devices will be used. This can only be used with SILICON chip type.
+    // Corner case of setting this is if we have multiple chips visible over PCIE on same boards. If at least one
+    // of the PCIE chips on certain board is specified, UMD will take all chips from the board.
+    std::unordered_set<chip_id_t> pci_target_devices = {};
     // If not passed, topology discovery will be ran and tt_ClusterDescriptor will be constructed. If passed, and chip
     // type is SILICON, the constructor will throw if cluster_descriptor configuration shows chips which don't exist on
     // the system.
@@ -111,7 +116,8 @@ public:
      * soc descriptor yaml file passed to the constructor. If no soc descriptor is passed, the function will create a
      * cluster descriptor object based on the devices connected to the system.
      */
-    static std::unique_ptr<tt_ClusterDescriptor> create_cluster_descriptor(std::string sdesc_path = "");
+    static std::unique_ptr<tt_ClusterDescriptor> create_cluster_descriptor(
+        std::string sdesc_path = "", std::unordered_set<chip_id_t> pci_target_devices = {});
 
     /**
      * Get cluster descriptor object being used in UMD instance.
@@ -664,6 +670,8 @@ private:
     static void ubb_eth_connections(
         const std::unordered_map<chip_id_t, std::unique_ptr<tt::umd::Chip>>& chips,
         std::unique_ptr<tt_ClusterDescriptor>& cluster_desc);
+
+    static void verify_cluster_options(const ClusterOptions& options);
 
     // State variables
     std::set<chip_id_t> all_chip_ids_ = {};

--- a/device/api/umd/device/topology_discovery.h
+++ b/device/api/umd/device/topology_discovery.h
@@ -16,6 +16,7 @@ namespace tt::umd {
 // TODO: Move Blackhole and 6U topology discovery to this class.
 class TopologyDiscovery {
 public:
+    TopologyDiscovery(std::unordered_set<chip_id_t> pci_target_devices = {});
     std::unique_ptr<tt_ClusterDescriptor> create_ethernet_map();
 
 private:
@@ -44,6 +45,10 @@ private:
 
     void fill_cluster_descriptor_info();
 
+    bool is_pcie_chip_id_included(int pci_id) const;
+
+    bool is_board_id_included(uint64_t board_id) const;
+
     std::unordered_map<chip_id_t, std::unique_ptr<Chip>> chips;
 
     std::unordered_map<eth_coord_t, chip_id_t> eth_coord_to_chip_id;
@@ -57,6 +62,11 @@ private:
     chip_id_t chip_id = 0;
 
     EthAddresses eth_addresses;
+
+    std::unordered_set<chip_id_t> pci_target_devices = {};
+
+    // All board ids that should be included in the cluster descriptor.
+    std::unordered_set<uint64_t> board_ids;
 };
 
 }  // namespace tt::umd

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -412,12 +412,25 @@ void Cluster::ubb_eth_connections(
     }
 }
 
+void Cluster::verify_cluster_options(const ClusterOptions& options) {
+    if (!options.pci_target_devices.empty() && !options.target_devices.empty()) {
+        throw std::runtime_error("Cannot pass both target_devices and pci_target_devices to Cluster constructor.");
+    }
+
+    if (!options.pci_target_devices.empty() && options.cluster_descriptor != nullptr) {
+        throw std::runtime_error(
+            "Cannot pass pci_target_devices and custom cluster descriptor to Cluster constructor. "
+            "Custom cluster descriptor should be used together with target_devices (logical IDs).");
+    }
+}
+
 Cluster::Cluster(ClusterOptions options) {
+    Cluster::verify_cluster_options(options);
     // If the cluster descriptor is not provided, create a new one.
     tt_ClusterDescriptor* temp_full_cluster_desc = options.cluster_descriptor;
     std::unique_ptr<tt_ClusterDescriptor> temp_full_cluster_desc_ptr;
     if (temp_full_cluster_desc == nullptr) {
-        temp_full_cluster_desc_ptr = Cluster::create_cluster_descriptor();
+        temp_full_cluster_desc_ptr = Cluster::create_cluster_descriptor(options.sdesc_path, options.pci_target_devices);
         temp_full_cluster_desc = temp_full_cluster_desc_ptr.get();
     }
 
@@ -1143,7 +1156,8 @@ tt_xy_pair Cluster::translate_chip_coord_virtual_to_translated(const chip_id_t c
     }
 }
 
-std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(std::string sdesc_path) {
+std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
+    std::string sdesc_path, std::unordered_set<chip_id_t> pci_target_devices) {
     std::map<int, PciDeviceInfo> pci_device_info = PCIDevice::enumerate_devices_info();
     if (pci_device_info.begin()->second.get_arch() == tt::ARCH::BLACKHOLE) {
         std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
@@ -1174,7 +1188,7 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(std::st
         // Topology discovery from source is supported for Wormhole UBB at the moment,
         // other Wormhole specs need to go through a legacy create-ethernet-map.
         if (!tt_devices.empty() && tt_devices[0]->get_board_type() != BoardType::UBB) {
-            return TopologyDiscovery().create_ethernet_map();
+            return TopologyDiscovery(pci_target_devices).create_ethernet_map();
         }
 
         std::unordered_map<chip_id_t, std::unique_ptr<Chip>> chips;


### PR DESCRIPTION
### Issue

#870 

### Description

Implement constrained topology. This PR adds the option to filter Topology discovery based on PCI device id. For example, this enabled someone who uses UMD to take 2 out of 4 cards in T3k system configuration. The idea is to not make any reads/writes to the cards that are not present in pci_target_devices. UMD is going to make reads to get board id from neighbouring chip at the moment. We should work towards reading this information from local ETH core and never have to go to the remote chip. This is going to be addressed in V2 of this feature.

### List of the changes

- Add target_pci_devices to ClusterOptions
- Implemenet constrained topology for Wormhole that is not 6U (Blackhole has all chips PCIE visible at the moment)
- Add a test

### Testing
CI

### API Changes
/
