### PR TITLE
Fix active_idx set

### DIFF
--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -409,13 +409,14 @@ void LocalChip::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& cha
 }
 
 tt_xy_pair LocalChip::get_remote_transfer_ethernet_core() {
+    if (remote_transfer_eth_cores_.empty()) {
+        throw std::runtime_error("No remote transfer ethernet cores set.");
+    }
     return {remote_transfer_eth_cores_[active_eth_core_idx].x, remote_transfer_eth_cores_[active_eth_core_idx].y};
 }
 
 void LocalChip::update_active_eth_core_idx() {
-    active_eth_core_idx++;
-    uint32_t update_mask_for_chip = remote_transfer_eth_cores_.size() - 1;
-    active_eth_core_idx = active_eth_core_idx & update_mask_for_chip;
+    active_eth_core_idx = (active_eth_core_idx + 1) % remote_transfer_eth_cores_.size();
 }
 
 int LocalChip::get_active_eth_core_idx() { return active_eth_core_idx; }


### PR DESCRIPTION
### Issue
An issue was reported by some metal folks

### Description
I assume that the code was meant to do mod, but original write knew in advance that the size wold always be a power of 2. This makes the code correct.

### List of the changes
- Fix active_eth_core_idx core assignment
- Give more descriptive message for when remote_transfer_eth_cores_.empty()

### Testing


### API Changes
There are no API changes in this PR.
