### PR TITLE
Fill idle and active cores for ubb galaxy

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -366,10 +366,12 @@ void Cluster::ubb_eth_connections(
                 }
             }
             if (port_status == eth_unconnected) {
+                cluster_desc->idle_eth_channels[chip_id].insert(channel);
                 channel++;
                 continue;
             }
             if (port_status == eth_connected) {
+                cluster_desc->active_eth_channels[chip_id].insert(channel);
                 uint64_t remote_chip_id;
                 tt_device->read_from_device(
                     &remote_chip_id,


### PR DESCRIPTION
### Issue
A commit was reverted in https://github.com/tenstorrent/tt-metal/commit/17c897f7c80034e6fe46a416f309138785b765ff

### Description
active and idle eth links were not filed up for ubb. Therefore some recent change which switched some code in metal's tt_cluster to consume these collections was failing on ubb.

### List of the changes
- Add idle and active channels for ubb in topo discovery.

### Testing
Manually tested on g11glx6u02

### API Changes
There are no API changes in this PR.
