### PR TITLE
Fix topology discover for multiple clusters

### DIFF
--- a/device/api/umd/device/topology_discovery.h
+++ b/device/api/umd/device/topology_discovery.h
@@ -93,8 +93,6 @@ private:
 
     // All board ids that should be included in the cluster descriptor.
     std::unordered_set<uint64_t> board_ids;
-
-    LockManager lock_manager;
 };
 
 }  // namespace tt::umd

--- a/device/arc_messenger.cpp
+++ b/device/arc_messenger.cpp
@@ -30,6 +30,8 @@ std::unique_ptr<ArcMessenger> ArcMessenger::create_arc_messenger(TTDevice* tt_de
 ArcMessenger::ArcMessenger(TTDevice* tt_device) : tt_device(tt_device) {
     lock_manager.initialize_mutex(MutexType::ARC_MSG, tt_device->get_pci_device()->get_device_num());
     lock_manager.initialize_mutex(MutexType::REMOTE_ARC_MSG, tt_device->get_pci_device()->get_device_num());
+    // TODO: Remove this once we have proper mutex usage
+    lock_manager.initialize_mutex(MutexType::ARC_MSG);
 }
 
 uint32_t ArcMessenger::send_message(const uint32_t msg_code, uint16_t arg0, uint16_t arg1, uint32_t timeout_ms) {

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -21,14 +21,7 @@ extern bool umd_use_noc1;
 namespace tt::umd {
 
 TopologyDiscovery::TopologyDiscovery(std::unordered_set<chip_id_t> pci_target_devices) :
-    pci_target_devices(pci_target_devices) {
-    // TODO: Remove this once we have unique chip ids to lock ARC_MSG mutexes.
-    // It can happen that multiple topology discovery instances run in parallel, and they can create multuple
-    // RemoteTTDevice objects over the same remote chip but using different local one. This will make the locks (which
-    // are over pci device num) allow multiple remote arc messages to the same remote chip which will break the
-    // communication.
-    lock_manager.initialize_mutex(MutexType::CREATE_ETH_MAP);
-}
+    pci_target_devices(pci_target_devices) {}
 
 std::unique_ptr<tt_ClusterDescriptor> TopologyDiscovery::create_ethernet_map() {
     cluster_desc = std::unique_ptr<tt_ClusterDescriptor>(new tt_ClusterDescriptor());
@@ -118,8 +111,6 @@ void TopologyDiscovery::get_pcie_connected_chips() {
 }
 
 void TopologyDiscovery::discover_remote_chips() {
-    auto lock = lock_manager.acquire_mutex(MutexType::CREATE_ETH_MAP);
-
     const uint32_t eth_unknown = 0;
     const uint32_t eth_unconnected = 1;
     const uint32_t shelf_offset = 9;

--- a/device/wormhole/wormhole_arc_messenger.cpp
+++ b/device/wormhole/wormhole_arc_messenger.cpp
@@ -34,11 +34,16 @@ uint32_t WormholeArcMessenger::send_message(
     // TODO: Once local and remote ttdevice is properly separated, reenable this code.
     // TODO2: Once we have unique chip ids other than PCI dev number, use that for both local and remote chips for
     // locks.
-    // auto lock =
+    // It can happen that multiple topology discovery instances run in parallel, and they can create multiple
+    // RemoteTTDevice objects over the same remote chip but using different local one. This will make the locks (which
+    // are over pci device num) allow multiple remote arc messages to the same remote chip which will break the
+    // communication. It can also happen that while topology discovery is running on a remote chip through one local
+    // chip, regular cluster construction is running through another local chip. Currently there's no other solution
+    // than to just lock all arc communication through the same lock. auto lock =
     //     tt_device->is_remote()
     //         ? lock_manager.acquire_mutex(MutexType::REMOTE_ARC_MSG, tt_device->get_pci_device()->get_device_num())
     //         : lock_manager.acquire_mutex(MutexType::ARC_MSG, tt_device->get_pci_device()->get_device_num());
-    auto lock = lock_manager.acquire_mutex(MutexType::ARC_MSG, tt_device->get_pci_device()->get_device_num());
+    auto lock = lock_manager.acquire_mutex(MutexType::ARC_MSG);
 
     auto architecture_implementation = tt_device->get_architecture_implementation();
 


### PR DESCRIPTION
### Issue
Users started reporting issues on two unconnected n300 system

### Description
Topology discovery was previously assuming eth_coords were unique in a cluster, but it can happen they aren't since multiple cards can be unconnected and have their own separate eth_coords

### List of the changes
- Introduce temporary UniqueCoords comprising of board id and eth coord
- Change code in topo discovery to use this as a unique identifier
- Don't always use local chip 0 for remote communication.
- Call merge_cluser_ids at the end.

### Testing
Tested on a system with 2xn300 which are unconnected, verified unit tests pass and topology is correct.

### API Changes
There are no API changes in this PR.
