### PR TITLE
Add compile time control of debug/trace log messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,11 @@ message(STATUS "UMD build type: ${CMAKE_BUILD_TYPE}")
 
 option(TT_UMD_BUILD_TESTS "Enables build of tt_umd tests" OFF)
 option(TT_UMD_BUILD_SIMULATION "Enables build of tt_umd simulation harnessing" OFF)
+option(TT_UMD_ENABLE_LOGGING "Enables inclusion of log_trace and log_debug into the binary." OFF)
+
+if(TT_UMD_ENABLE_LOGGING)
+    add_compile_definitions(SPDLOG_ACTIVE_LEVEL=trace)
+endif()
 
 add_subdirectory(third_party)
 


### PR DESCRIPTION
### Issue
None

### Description
Today, by default, log_debug and log_trace logging macros are compiled out. This is SPDLOG's default behavior.

### List of the changes
- Add cmake option to enable logging, and therfore include log_debug and log_trace in the binary.

### Testing
CI

### API Changes
There are no API changes in this PR.
