### PR TITLE
Verify cluster descriptor information

### DIFF
--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -91,6 +91,8 @@ protected:
 
     void fill_chips_grouped_by_closest_mmio();
 
+    void verify_cluster_descriptor_info();
+
     std::map<chip_id_t, tt::umd::HarvestingMasks> harvesting_masks_map = {};
 
 public:

--- a/device/api/umd/device/types/cluster_descriptor_types.h
+++ b/device/api/umd/device/types/cluster_descriptor_types.h
@@ -129,9 +129,9 @@ inline uint32_t get_number_of_chips_from_board_type(const BoardType board_type) 
         case BoardType::P300:
             return 2;
         case BoardType::GALAXY:
-            return 32;
+            return 1;
         case BoardType::UBB:
-            return 8;
+            return 32;
         default:
             throw std::runtime_error("Unknown board type for number of chips calculation.");
     }

--- a/device/api/umd/device/types/cluster_descriptor_types.h
+++ b/device/api/umd/device/types/cluster_descriptor_types.h
@@ -116,6 +116,27 @@ inline BlackholeChipType get_blackhole_chip_type(const BoardType board_type, con
     }
 }
 
+inline uint32_t get_number_of_chips_from_board_type(const BoardType board_type) {
+    switch (board_type) {
+        case BoardType::N150:
+            return 1;
+        case BoardType::N300:
+            return 2;
+        case BoardType::P100:
+            return 1;
+        case BoardType::P150:
+            return 1;
+        case BoardType::P300:
+            return 2;
+        case BoardType::GALAXY:
+            return 32;
+        case BoardType::UBB:
+            return 8;
+        default:
+            throw std::runtime_error("Unknown board type for number of chips calculation.");
+    }
+}
+
 inline BoardType get_board_type_from_board_id(const uint64_t board_id) {
     uint64_t upi = (board_id >> 36) & 0xFFFFF;
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1180,6 +1180,8 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
 
     desc->fill_chips_grouped_by_closest_mmio();
 
+    desc->verify_cluster_descriptor_info();
+
     return desc;
 }
 

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -437,6 +437,8 @@ void TopologyDiscovery::fill_cluster_descriptor_info() {
     tt_ClusterDescriptor::merge_cluster_ids(*cluster_desc.get());
 
     cluster_desc->fill_chips_grouped_by_closest_mmio();
+
+    cluster_desc->verify_cluster_descriptor_info();
 }
 
 // If pci_target_devices is empty, we should take all the PCI devices found in the system.


### PR DESCRIPTION
### Issue

Add function to verify number of chips in cluster descriptor. Motivated by #855 

### Description

Add function to verify that each chip is assigned a board and the number of chips per board is as expected according to board type.

### List of the changes

- Add function for getting number of chips based on board type
- Add function to verify number of chips and chip to board assignment

### Testing
CI

### API Changes
/
