### PR TITLE
send_tensix_risc_reset now supports core coord for Simulator

### DIFF
--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -99,18 +99,10 @@ void tt_SimulationDevice::start_device() {
 }
 
 void tt_SimulationDevice::send_tensix_risc_reset(tt_xy_pair core, const TensixSoftResetOptions& soft_resets) {
-    log_info(
-        tt::LogEmulationDriver,
-        "Sending 'send_tensix_risc_reset' for core.. (Not implemented, defaulting to 'send_tensix_risc_reset' "
-        "instead)");
-    send_tensix_risc_reset(soft_resets);
-}
-
-void tt_SimulationDevice::send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) {
     if (soft_resets == TENSIX_ASSERT_SOFT_RESET) {
         log_info(tt::LogEmulationDriver, "Sending assert_risc_reset signal..");
         auto wr_buffer =
-            create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_ASSERT, std::vector<uint32_t>(1, 0), {0, 0}, 0);
+            create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_ASSERT, std::vector<uint32_t>(1, 0), core, 0);
         uint8_t* wr_buffer_ptr = wr_buffer.GetBufferPointer();
         size_t wr_buffer_size = wr_buffer.GetSize();
 
@@ -119,7 +111,7 @@ void tt_SimulationDevice::send_tensix_risc_reset(const TensixSoftResetOptions& s
     } else if (soft_resets == TENSIX_DEASSERT_SOFT_RESET) {
         log_info(tt::LogEmulationDriver, "Sending 'deassert_risc_reset' signal..");
         auto wr_buffer =
-            create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_DEASSERT, std::vector<uint32_t>(1, 0), {0, 0}, 0);
+            create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_DEASSERT, std::vector<uint32_t>(1, 0), core, 0);
         uint8_t* wr_buffer_ptr = wr_buffer.GetBufferPointer();
         size_t wr_buffer_size = wr_buffer.GetSize();
 
@@ -127,6 +119,10 @@ void tt_SimulationDevice::send_tensix_risc_reset(const TensixSoftResetOptions& s
     } else {
         TT_THROW("Invalid soft reset option.");
     }
+}
+
+void tt_SimulationDevice::send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) {
+    send_tensix_risc_reset({0, 0}, soft_resets);
 }
 
 void tt_SimulationDevice::close_device() {


### PR DESCRIPTION
### Issue
NA

### Description
Update the simulation device’s send_tensix_risc_reset to support specific core coordinates.  


### List of the changes
**send_tensix_risc_reset** now accepts a core argument and passes it to the flatbuffer, enabling core-specific RISC reset commands for the simulator.

### Testing
CI

### API Changes
/
