### PR TITLE
Topology tool constrained topology

### DIFF
--- a/tools/common.h
+++ b/tools/common.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cxxopts.hpp>
+#include <vector>
+
+inline std::vector<int> extract_int_vector(const cxxopts::OptionValue& cxxoption) {
+    std::vector<int> int_vector;
+    for (std::string item : cxxoption.as<std::vector<std::string>>()) {
+        int_vector.push_back(std::stoi(item));
+    }
+    return int_vector;
+}
+
+inline std::unordered_set<int> extract_int_set(const cxxopts::OptionValue& cxxoption) {
+    std::unordered_set<int> int_set;
+    for (std::string item : cxxoption.as<std::vector<std::string>>()) {
+        int_set.insert(std::stoi(item));
+    }
+    return int_set;
+}

--- a/tools/topology.cpp
+++ b/tools/topology.cpp
@@ -4,6 +4,7 @@
 #include <cxxopts.hpp>
 #include <tt-logger/tt-logger.hpp>
 
+#include "common.h"
 #include "umd/device/cluster.h"
 #include "umd/device/tt_cluster_descriptor.h"
 
@@ -12,8 +13,13 @@ using namespace tt::umd;
 int main(int argc, char *argv[]) {
     cxxopts::Options options("topology", "Extract system topology and save it to a yaml file.");
 
-    options.add_options()("p,path", "File path to save cluster descriptor to.", cxxopts::value<std::string>())(
-        "h,help", "Print usage");
+    options.add_options()("f,path", "File path to save cluster descriptor to.", cxxopts::value<std::string>())(
+        "d,devices",
+        "List of logical device ids to filter cluster descriptor for.",
+        cxxopts::value<std::vector<std::string>>())(
+        "p,pci_devices",
+        "List of pci device ids to perform topology discovery on.",
+        cxxopts::value<std::vector<std::string>>())("h,help", "Print usage");
 
     auto result = options.parse(argc, argv);
 
@@ -27,7 +33,21 @@ int main(int argc, char *argv[]) {
         cluster_descriptor_path = result["path"].as<std::string>();
     }
 
-    std::string output_path = tt::umd::Cluster::create_cluster_descriptor()->serialize_to_file(cluster_descriptor_path);
+    std::unordered_set<int> pci_ids = {};
+    if (result.count("pci_devices")) {
+        pci_ids = extract_int_set(result["pci_devices"]);
+    }
+
+    std::unique_ptr<tt_ClusterDescriptor> cluster_descriptor = tt::umd::Cluster::create_cluster_descriptor("", pci_ids);
+
+    if (result.count("devices")) {
+        std::unordered_set<int> logical_device_ids = extract_int_set(result["devices"]);
+
+        cluster_descriptor =
+            tt_ClusterDescriptor::create_constrained_cluster_descriptor(cluster_descriptor.get(), logical_device_ids);
+    }
+
+    std::string output_path = cluster_descriptor->serialize_to_file(cluster_descriptor_path);
     log_info(tt::LogSiliconDriver, "Cluster descriptor serialized to {}", output_path);
     return 0;
 }


### PR DESCRIPTION
### Issue


### Description
Improve topology tool to allow constraining topology

### List of the changes
- Add --device option to filter cluster descriptor based on logical devices
- Add --pci_devices option to perform contrained topology discovery based on pci ids

### Testing
Ran manually on a 3xN300 system, confirmed cluster descriptor was as expected

### API Changes
There are no API changes in this PR.
