### PR TITLE
Fix topology discovery for 4U galaxy

### DIFF
--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -363,6 +363,7 @@ void TopologyDiscovery::discover_remote_chips() {
                 if (discovered_chips.find(new_unique_coord) == discovered_chips.end()) {
                     if (remote_chips_to_discover.find(new_unique_coord) == remote_chips_to_discover.end()) {
                         new_remote_chips.insert(new_unique_coord);
+                        remote_unique_coord_to_mmio_chip_id.emplace(new_unique_coord, mmio_chip_id);
                     }
                 } else {
                     chip_id_t current_chip_id = unique_coord_to_chip_id.at(current_chip_unique_coord);


### PR DESCRIPTION
### Issue
Aftermath of https://github.com/tenstorrent/tt-umd/pull/939

### Description
I haven't tested my changes on 4U galaxy, and now the tests are failing when I try to bump to metal.

### List of the changes
- This collection was not being filled in case new remote chips were discovered from remote chips, which currently only exists on 4u galaxy.

### Testing
Tested on 4U galaxy

### API Changes
There are no API changes in this PR.
