### PR TITLE
Implement TLB window with unaligned address

### DIFF
--- a/device/api/umd/device/tt_device/tlb_window.h
+++ b/device/api/umd/device/tt_device/tlb_window.h
@@ -36,7 +36,10 @@ public:
 private:
     void validate(uint64_t offset, size_t size) const;
 
+    uint64_t get_total_offset(uint64_t offset) const;
+
     std::unique_ptr<TlbHandle> tlb_handle;
+    uint64_t offset_from_aligned_addr = 0;
 };
 
 }  // namespace tt::umd

--- a/tests/unified/test_tlb.cpp
+++ b/tests/unified/test_tlb.cpp
@@ -207,3 +207,67 @@ TEST(TestTlb, TestTlbWindowReadWrite) {
         EXPECT_EQ(expect0, 0);
     }
 }
+
+TEST(TestTlb, TestTlbOffsetReadWrite) {
+    if (!is_kmd_version_good()) {
+        GTEST_SKIP() << "Skipping test because of old KMD version. Required version of KMD is 1.34 or higher.";
+    }
+    const uint64_t tensix_addr = 0;
+    const chip_id_t chip = 0;
+    const uint64_t two_mb = 1 << 21;
+    const uint64_t one_mb = 1 << 20;
+
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+
+    const std::vector<CoreCoord> tensix_cores =
+        cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
+    PCIDevice* pci_device = cluster->get_tt_device(chip)->get_pci_device().get();
+
+    std::vector<uint8_t> write_pattern(0x100, 0);
+    for (size_t i = 0; i < write_pattern.size(); ++i) {
+        write_pattern[i] = (i % 256);
+    }
+
+    for (CoreCoord core : tensix_cores) {
+        cluster->write_to_device(write_pattern.data(), write_pattern.size(), chip, core, one_mb);
+
+        tlb_data config;
+        config.local_offset = 0;
+        config.x_end = core.x;
+        config.y_end = core.y;
+        config.x_start = 0;
+        config.y_start = 0;
+        config.noc_sel = 0;
+        config.mcast = 0;
+        config.ordering = tlb_data::Relaxed;
+        config.linked = 0;
+        config.static_vc = 1;
+
+        std::unique_ptr<TlbWindow> read_aligned =
+            std::make_unique<TlbWindow>(pci_device->allocate_tlb(two_mb, TlbMapping::WC), config);
+
+        config.local_offset = one_mb;
+        std::unique_ptr<TlbWindow> read_unaligned =
+            std::make_unique<TlbWindow>(pci_device->allocate_tlb(two_mb, TlbMapping::WC), config);
+
+        std::vector<uint8_t> readback_aligned(0x100, 0);
+        read_aligned->read_block(one_mb, readback_aligned.data(), readback_aligned.size());
+
+        EXPECT_EQ(readback_aligned, write_pattern)
+            << "Readback data from aligned TLB window should match the written pattern";
+
+        std::vector<uint8_t> readback_unaligned(0x100, 0);
+        read_unaligned->read_block(0, readback_unaligned.data(), readback_unaligned.size());
+
+        EXPECT_EQ(readback_aligned, readback_unaligned)
+            << "Readback data from aligned and unaligned TLB windows should be the same";
+
+        config.local_offset = (one_mb >> 1);
+        read_unaligned->configure(config);
+        std::vector<uint8_t> readback_unaligned_1(0x100, 0);
+        read_unaligned->read_block(one_mb >> 1, readback_unaligned_1.data(), readback_unaligned_1.size());
+
+        EXPECT_EQ(readback_unaligned_1, write_pattern)
+            << "Readback data from unaligned TLB window with offset should match the written pattern";
+    }
+}


### PR DESCRIPTION
### Issue

#895 

### Description

Implement configuring TlbWindow with address that is not aligned to TLB size. Read/writes should still work. TLB size is effectively getting smaller since the user of TlbWindow should be aware of using address that is not aligned to TLB size. We would probably want to have one more layer on top of it that handles custom IO by reconfiguring TlbWindow as needed.

### List of the changes

- Implement offset inside TLB window
- Add test to confirm reading with different offsets on two windows gives same results
- Add test to confirm exception on out of bounds access

### Testing
CI + additional test

### API Changes
/