### PR TITLE
merge_cluster_ids fix

### DIFF
--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -383,8 +383,6 @@ void TopologyDiscovery::discover_remote_chips() {
 
         remote_chips_to_discover = new_remote_chips;
     }
-
-    tt_ClusterDescriptor::merge_cluster_ids(*cluster_desc.get());
 }
 
 void TopologyDiscovery::fill_cluster_descriptor_info() {
@@ -427,6 +425,7 @@ void TopologyDiscovery::fill_cluster_descriptor_info() {
     }
 
     tt_ClusterDescriptor::fill_galaxy_connections(*cluster_desc.get());
+    tt_ClusterDescriptor::merge_cluster_ids(*cluster_desc.get());
 
     cluster_desc->fill_chips_grouped_by_closest_mmio();
 }


### PR DESCRIPTION
### Issue
Follow up from https://github.com/tenstorrent/tt-umd/pull/939

### Description
This wasn't handled properly in the original PR, but the error that was surfaced led me to think this was an issue in metal. But merge_cluster_ids was called at a point where it would have no effect since relevant structures weren't filled in cluster descriptor at that point.

### List of the changes
- Move merge_cluster_ids to happen later

### Testing
Ran on 2xN300 unconnected cards, test now passes
`./build/test/tt_metal/unit_tests_device --gtest_filter=DevicePool.DevicePoolOpenClose` 

### API Changes
There are no API changes in this PR.
