### PR TITLE
Make TTDevice write src const void pointer

### DIFF
--- a/device/api/umd/device/tt_device/remote_wormhole_tt_device.h
+++ b/device/api/umd/device/tt_device/remote_wormhole_tt_device.h
@@ -15,7 +15,7 @@ public:
 
     void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
 
-    void write_to_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
+    void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
 
     void wait_for_non_mmio_flush() override;
 

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -115,7 +115,7 @@ public:
     // on any code path that is performance critical. It is used to read/write the data needed
     // to get the information to form cluster of chips, or just use base TTDevice functions.
     virtual void read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
-    virtual void write_to_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
+    virtual void write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
 
     // TLB related functions.
     // TODO: These are architecture specific, and will be moved out of the class.

--- a/device/blackhole/blackhole_arc_message_queue.cpp
+++ b/device/blackhole/blackhole_arc_message_queue.cpp
@@ -30,7 +30,7 @@ void BlackholeArcMessageQueue::write_words(uint32_t* data, size_t num_words, siz
 }
 
 void BlackholeArcMessageQueue::trigger_fw_int() {
-    tt_device->write_to_device((void*)&ARC_FW_INT_VAL, arc_core, ARC_FW_INT_ADDR, sizeof(uint32_t));
+    tt_device->write_to_device(&ARC_FW_INT_VAL, arc_core, ARC_FW_INT_ADDR, sizeof(uint32_t));
 }
 
 void BlackholeArcMessageQueue::push_request(

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -33,7 +33,7 @@ void RemoteChip::close_device() {}
 
 void RemoteChip::write_to_device(tt_xy_pair core, const void* src, uint64_t l1_dest, uint32_t size) {
     auto translated_core = translate_chip_coord_virtual_to_translated(core);
-    tt_device_->write_to_device((void*)src, translated_core, l1_dest, size);
+    tt_device_->write_to_device(src, translated_core, l1_dest, size);
 }
 
 void RemoteChip::read_from_device(tt_xy_pair core, void* dest, uint64_t l1_src, uint32_t size) {

--- a/device/tt_device/remote_wormhole_tt_device.cpp
+++ b/device/tt_device/remote_wormhole_tt_device.cpp
@@ -18,7 +18,7 @@ void RemoteWormholeTTDevice::read_from_device(void *mem_ptr, tt_xy_pair core, ui
     remote_communication_->read_non_mmio(target_chip_, core, mem_ptr, addr, size);
 }
 
-void RemoteWormholeTTDevice::write_to_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
+void RemoteWormholeTTDevice::write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
     remote_communication_->write_to_non_mmio(target_chip_, core, mem_ptr, addr, size);
 }
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -233,9 +233,9 @@ void TTDevice::read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, u
     }
 }
 
-void TTDevice::write_to_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
+void TTDevice::write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
     auto lock = lock_manager.acquire_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num());
-    uint8_t *buffer_addr = static_cast<uint8_t *>(mem_ptr);
+    uint8_t *buffer_addr = (uint8_t *)(uintptr_t)(mem_ptr);
     const uint32_t tlb_index = get_architecture_implementation()->get_small_read_write_tlb();
 
     while (size > 0) {

--- a/device/wormhole/wormhole_arc_messenger.cpp
+++ b/device/wormhole/wormhole_arc_messenger.cpp
@@ -56,7 +56,7 @@ uint32_t WormholeArcMessenger::send_message(
         wormhole::ARC_RESET_SCRATCH_ADDR + wormhole::ARC_SCRATCH_RES0_OFFSET * sizeof(uint32_t),
         sizeof(uint32_t));
     tt_device->write_to_device(
-        (void*)&msg_code,
+        &msg_code,
         arc_core,
         wormhole::ARC_RESET_SCRATCH_ADDR + wormhole::ARC_SCRATCH_STATUS_OFFSET * sizeof(uint32_t),
         sizeof(uint32_t));


### PR DESCRIPTION
### Issue

Make src pointer for write_to_device const, to match rest of write APIs

### Description

Make src pointer `const void*` for `TTDevice::write_to_device`

### List of the changes

- Make src pointer `const void*` for `TTDevice::write_to_device`

### Testing
CI

### API Changes
/
