### PR TITLE
Refactor harvesting masks usage

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -656,8 +656,6 @@ private:
         tt_ClusterDescriptor* cluster_desc,
         bool perform_harvesting,
         HarvestingMasks& simulated_harvesting_masks);
-    uint32_t get_tensix_harvesting_mask(
-        chip_id_t chip_id, tt_ClusterDescriptor* cluster_desc, HarvestingMasks& simulated_harvesting_masks);
     void construct_cluster(const uint32_t& num_host_mem_ch_per_mmio_device, const ChipType& chip_type);
     tt_xy_pair translate_to_api_coords(const chip_id_t chip, const tt::umd::CoreCoord core_coord) const;
     // Most of the old APIs accept virtual coordinates, but we communicate with the device through translated

--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -91,9 +91,7 @@ protected:
 
     void fill_chips_grouped_by_closest_mmio();
 
-    std::map<chip_id_t, uint32_t> dram_harvesting_masks = {};
-    std::map<chip_id_t, uint32_t> eth_harvesting_masks = {};
-    std::map<chip_id_t, uint32_t> pcie_harvesting_masks = {};
+    std::map<chip_id_t, tt::umd::HarvestingMasks> harvesting_masks_map = {};
 
 public:
     /*
@@ -158,7 +156,5 @@ public:
     std::set<uint32_t> get_active_eth_channels(chip_id_t chip_id);
     std::set<uint32_t> get_idle_eth_channels(chip_id_t chip_id);
 
-    uint32_t get_dram_harvesting_mask(chip_id_t chip_id) const;
-    uint32_t get_eth_harvesting_mask(chip_id_t chip_id) const;
-    uint32_t get_pcie_harvesting_mask(chip_id_t chip_id) const;
+    tt::umd::HarvestingMasks get_harvesting_masks(chip_id_t chip_id) const;
 };

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -271,7 +271,17 @@ HarvestingMasks Cluster::get_harvesting_masks(
         return HarvestingMasks{};
     }
 
-    return cluster_desc->get_harvesting_masks(chip_id) | simulated_harvesting_masks;
+    HarvestingMasks cluster_harvesting_masks = cluster_desc->get_harvesting_masks(chip_id);
+    log_info(
+        LogSiliconDriver,
+        "Harvesting mask for chip {} is {:#x} (NOC0: {:#x}, simulated harvesting mask: "
+        "{:#x}).",
+        chip_id,
+        cluster_harvesting_masks.tensix_harvesting_mask | simulated_harvesting_masks.tensix_harvesting_mask,
+        cluster_harvesting_masks.tensix_harvesting_mask,
+        simulated_harvesting_masks.tensix_harvesting_mask);
+
+    return cluster_harvesting_masks | simulated_harvesting_masks;
 }
 
 void Cluster::ubb_eth_connections(

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -261,23 +261,6 @@ void Cluster::add_chip(const chip_id_t& chip_id, const ChipType& chip_type, std:
     chips_.emplace(chip_id, std::move(chip));
 }
 
-uint32_t Cluster::get_tensix_harvesting_mask(
-    chip_id_t chip_id, tt_ClusterDescriptor* cluster_desc, HarvestingMasks& simulated_harvesting_masks) {
-    uint32_t tensix_harvesting_mask_physical_layout = cluster_desc->get_harvesting_info().at(chip_id);
-    uint32_t tensix_harvesting_mask = CoordinateManager::shuffle_tensix_harvesting_mask(
-        cluster_desc->get_arch(chip_id), tensix_harvesting_mask_physical_layout);
-    log_info(
-        LogSiliconDriver,
-        "Harvesting mask for chip {} is 0x{:x} (physical layout: 0x{:x}, logical: 0x{:x}, simulated harvesting mask: "
-        "0x{:x}).",
-        chip_id,
-        tensix_harvesting_mask | simulated_harvesting_masks.tensix_harvesting_mask,
-        tensix_harvesting_mask_physical_layout,
-        tensix_harvesting_mask,
-        simulated_harvesting_masks.tensix_harvesting_mask);
-    return tensix_harvesting_mask | simulated_harvesting_masks.tensix_harvesting_mask;
-}
-
 HarvestingMasks Cluster::get_harvesting_masks(
     chip_id_t chip_id,
     tt_ClusterDescriptor* cluster_desc,
@@ -287,14 +270,8 @@ HarvestingMasks Cluster::get_harvesting_masks(
         log_info(LogSiliconDriver, "Skipping harvesting for chip {}.", chip_id);
         return HarvestingMasks{};
     }
-    return HarvestingMasks{
-        .tensix_harvesting_mask = get_tensix_harvesting_mask(chip_id, cluster_desc, simulated_harvesting_masks),
-        .dram_harvesting_mask =
-            cluster_desc->get_dram_harvesting_mask(chip_id) | simulated_harvesting_masks.dram_harvesting_mask,
-        .eth_harvesting_mask =
-            cluster_desc->get_eth_harvesting_mask(chip_id) | simulated_harvesting_masks.eth_harvesting_mask,
-        .pcie_harvesting_mask =
-            cluster_desc->get_pcie_harvesting_mask(chip_id) | simulated_harvesting_masks.pcie_harvesting_mask};
+
+    return cluster_desc->get_harvesting_masks(chip_id) | simulated_harvesting_masks;
 }
 
 void Cluster::ubb_eth_connections(
@@ -1259,9 +1236,7 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
 
         desc->noc_translation_enabled.insert({chip_id, chip->get_chip_info().noc_translation_enabled});
         desc->harvesting_masks.insert({chip_id, chip->get_chip_info().harvesting_masks.tensix_harvesting_mask});
-        desc->dram_harvesting_masks.insert({chip_id, chip->get_chip_info().harvesting_masks.dram_harvesting_mask});
-        desc->eth_harvesting_masks.insert({chip_id, chip->get_chip_info().harvesting_masks.eth_harvesting_mask});
-        desc->pcie_harvesting_masks.insert({chip_id, chip->get_chip_info().harvesting_masks.pcie_harvesting_mask});
+        desc->harvesting_masks_map.insert({chip_id, chip->get_chip_info().harvesting_masks});
 
         desc->add_chip_to_board(chip_id, chip->get_chip_info().chip_uid.board_id);
     }

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -398,10 +398,7 @@ void TopologyDiscovery::fill_cluster_descriptor_info() {
 
         cluster_desc->noc_translation_enabled.insert({chip_id, chip->get_chip_info().noc_translation_enabled});
         cluster_desc->harvesting_masks.insert({chip_id, chip->get_chip_info().harvesting_masks.tensix_harvesting_mask});
-        cluster_desc->dram_harvesting_masks.insert(
-            {chip_id, chip->get_chip_info().harvesting_masks.dram_harvesting_mask});
-        cluster_desc->eth_harvesting_masks.insert(
-            {chip_id, chip->get_chip_info().harvesting_masks.eth_harvesting_mask});
+        cluster_desc->harvesting_masks_map.insert({chip_id, chip->get_chip_info().harvesting_masks});
         eth_coord_t eth_coord = eth_coords.at(chip_id);
         cluster_desc->chip_locations.insert({chip_id, eth_coord});
         cluster_desc->coords_to_chip_ids[eth_coord.rack][eth_coord.shelf][eth_coord.y][eth_coord.x] = chip_id;

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -8,6 +8,7 @@
 #include <tt-logger/tt-logger.hpp>
 
 #include "umd/device/blackhole_implementation.h"
+#include "umd/device/coordinate_manager.h"
 #include "umd/device/types/blackhole_eth.h"
 #include "umd/device/types/blackhole_telemetry.h"
 
@@ -100,10 +101,11 @@ bool BlackholeTTDevice::get_noc_translation_enabled() {
 
 ChipInfo BlackholeTTDevice::get_chip_info() {
     ChipInfo chip_info;
-    chip_info.harvesting_masks.tensix_harvesting_mask =
+    chip_info.harvesting_masks.tensix_harvesting_mask = CoordinateManager::shuffle_tensix_harvesting_mask(
+        tt::ARCH::BLACKHOLE,
         telemetry->is_entry_available(blackhole::TAG_ENABLED_TENSIX_COL)
             ? (~telemetry->read_entry(blackhole::TAG_ENABLED_TENSIX_COL) & 0x3FFF)
-            : 0;
+            : 0);
     chip_info.harvesting_masks.dram_harvesting_mask = telemetry->is_entry_available(blackhole::TAG_ENABLED_GDDR)
                                                           ? (~telemetry->read_entry(blackhole::TAG_ENABLED_GDDR) & 0xFF)
                                                           : 0;

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -5,6 +5,7 @@
 
 #include <tt-logger/tt-logger.hpp>
 
+#include "umd/device/coordinate_manager.h"
 #include "umd/device/types/wormhole_dram.h"
 #include "umd/device/types/wormhole_telemetry.h"
 #include "umd/device/wormhole_implementation.h"
@@ -59,7 +60,8 @@ ChipInfo WormholeTTDevice::get_chip_info() {
         throw std::runtime_error(fmt::format("Failed to get harvesting masks with exit code {}", ret_code));
     }
 
-    chip_info.harvesting_masks.tensix_harvesting_mask = arc_msg_return_values[0];
+    chip_info.harvesting_masks.tensix_harvesting_mask =
+        CoordinateManager::shuffle_tensix_harvesting_mask(tt::ARCH::WORMHOLE_B0, arc_msg_return_values[0]);
 
     chip_info.chip_uid.board_id = get_board_id();
 

--- a/tests/wormhole/test_arc_messages_wh.cpp
+++ b/tests/wormhole/test_arc_messages_wh.cpp
@@ -30,7 +30,9 @@ TEST(WormholeArcMessages, WormholeArcMessagesHarvesting) {
             0,
             0);
 
-        EXPECT_EQ(arc_msg_return_values[0], harvesting_mask_cluster_desc);
+        EXPECT_EQ(
+            CoordinateManager::shuffle_tensix_harvesting_mask(tt::ARCH::WORMHOLE_B0, arc_msg_return_values[0]),
+            harvesting_mask_cluster_desc);
     }
 }
 

--- a/tests/wormhole/test_arc_messages_wh.cpp
+++ b/tests/wormhole/test_arc_messages_wh.cpp
@@ -93,7 +93,9 @@ TEST(WormholeArcMessages, MultipleThreadsArcMessages) {
                     0,
                     0);
 
-                EXPECT_EQ(arc_msg_return_values[0], harvesting_mask_cluster_desc);
+                EXPECT_EQ(
+                    CoordinateManager::shuffle_tensix_harvesting_mask(tt::ARCH::WORMHOLE_B0, arc_msg_return_values[0]),
+                    harvesting_mask_cluster_desc);
             }
         });
 
@@ -109,7 +111,9 @@ TEST(WormholeArcMessages, MultipleThreadsArcMessages) {
                     0,
                     0);
 
-                EXPECT_EQ(arc_msg_return_values[0], harvesting_mask_cluster_desc);
+                EXPECT_EQ(
+                    CoordinateManager::shuffle_tensix_harvesting_mask(tt::ARCH::WORMHOLE_B0, arc_msg_return_values[0]),
+                    harvesting_mask_cluster_desc);
             }
         });
 

--- a/tools/harvesting.cpp
+++ b/tools/harvesting.cpp
@@ -39,18 +39,15 @@ int main(int argc, char* argv[]) {
 
     for (chip_id_t chip : cluster->get_target_device_ids()) {
         std::cout << "Chip " << chip << std::endl;
+        HarvestingMasks harvesting_masks = cluster->get_cluster_description()->get_harvesting_masks(chip);
 
-        std::cout << "Tensix harvesting mask 0x" << std::hex
-                  << cluster->get_cluster_description()->get_harvesting_info().at(chip) << std::endl;
+        std::cout << "Tensix harvesting mask 0x" << std::hex << harvesting_masks.tensix_harvesting_mask << std::endl;
 
-        std::cout << "DRAM harvesting mask 0x" << std::hex
-                  << cluster->get_cluster_description()->get_dram_harvesting_mask(chip) << std::endl;
+        std::cout << "DRAM harvesting mask 0x" << std::hex << harvesting_masks.dram_harvesting_mask << std::endl;
 
-        std::cout << "ETH harvesting mask 0x" << std::hex
-                  << cluster->get_cluster_description()->get_eth_harvesting_mask(chip) << std::endl;
+        std::cout << "ETH harvesting mask 0x" << std::hex << harvesting_masks.eth_harvesting_mask << std::endl;
 
-        std::cout << "PCIE harvesting mask 0x" << std::hex
-                  << cluster->get_cluster_description()->get_pcie_harvesting_mask(chip) << std::endl;
+        std::cout << "PCIE harvesting mask 0x" << std::hex << harvesting_masks.pcie_harvesting_mask << std::endl;
 
         print_cores(chip, CoreType::TENSIX);
         print_cores(chip, CoreType::ETH);


### PR DESCRIPTION
### Issue

#820 

### Description

Refactor harvesting mask usage. This PR makes all harvesting masks on all architecture be stored in a way that hides physical harvesting masks. For example, on Wormhole, tensix harvesting masks are reported in a way that bit 0 represents physical row 0 etc...This PR changes all harvesting masks to correspond to NOC0 layout (bit 0 is for NOC0 row 0, DRAM bank 0 from soc descriptor etc...). It also adds a map of harvesting masks structures rather than storing each harvesting mask (DRAM, ETH, PCIE, Tensix) separately.

### List of the changes

- Store tensix harvesting mask in NOC0 layout
- Remove separete maps for each harvesting mask type
- Add map for storing harvesting masks structures
- Change the tests to reflect the changes

### Testing
CI

### API Changes
/
