### PR TITLE
Use size_t in SysmemManager class functions

### DIFF
--- a/device/api/umd/device/chip_helpers/sysmem_manager.h
+++ b/device/api/umd/device/chip_helpers/sysmem_manager.h
@@ -29,9 +29,9 @@ public:
     size_t get_num_host_mem_channels() const;
     hugepage_mapping get_hugepage_mapping(size_t channel) const;
 
-    std::unique_ptr<SysmemBuffer> allocate_sysmem_buffer(uint32_t sysmem_buffer_size);
+    std::unique_ptr<SysmemBuffer> allocate_sysmem_buffer(size_t sysmem_buffer_size);
 
-    std::unique_ptr<SysmemBuffer> map_sysmem_buffer(void* buffer, uint32_t sysmem_buffer_size);
+    std::unique_ptr<SysmemBuffer> map_sysmem_buffer(void* buffer, size_t sysmem_buffer_size);
 
 private:
     /**

--- a/device/chip_helpers/sysmem_manager.cpp
+++ b/device/chip_helpers/sysmem_manager.cpp
@@ -274,13 +274,13 @@ void SysmemManager::print_file_contents(std::string filename, std::string hint) 
     }
 }
 
-std::unique_ptr<SysmemBuffer> SysmemManager::allocate_sysmem_buffer(uint32_t sysmem_buffer_size) {
+std::unique_ptr<SysmemBuffer> SysmemManager::allocate_sysmem_buffer(size_t sysmem_buffer_size) {
     void *mapping =
         mmap(nullptr, sysmem_buffer_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
     return map_sysmem_buffer(mapping, sysmem_buffer_size);
 }
 
-std::unique_ptr<SysmemBuffer> SysmemManager::map_sysmem_buffer(void *buffer, uint32_t sysmem_buffer_size) {
+std::unique_ptr<SysmemBuffer> SysmemManager::map_sysmem_buffer(void *buffer, size_t sysmem_buffer_size) {
     return std::make_unique<SysmemBuffer>(tlb_manager_, buffer, sysmem_buffer_size);
 }
 


### PR DESCRIPTION
### Issue

#964 

### Description

Use size_t for size of mappings in SysmemManager class 

### List of the changes

- Use size_t for size of mappings in SysmemManager class

### Testing
CI. Manual test that 4GB mappings are properly mapped now

### API Changes
/
