### PR TITLE
Support SysmemBuffer with unaligned address and size

### DIFF
--- a/device/api/umd/device/chip_helpers/sysmem_buffer.h
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.h
@@ -28,11 +28,20 @@ namespace tt::umd {
 class SysmemBuffer {
 public:
     /**
-     * Constructor for SysmemBuffer. As described in the comment above this class, this is a resource that represents
-     * the memory that is visible to the device. The memory is mapped through KMD. Start of the buffer must be aligned
+     * Constructor for SysmemBuffer. Start of the buffer must be aligned
      * to page size. In case of unaligned buffer start address, the buffer will be aligned to the page size and the
      * buffer size will be adjusted accordingly. However, the adjusted buffer size won't be visible to the user. It will
-     * see a buffer of the original size.
+     * see a buffer of the original size. Same as for buffer size, user won't be able to access the memory before the
+     * start of the buffer, aligning is transparent to the user.
+     * Pages separated by | AB - Aligned buffer,
+     * UB - Unaligned buffer, UE - Unaligned end, AE - Aligned end
+     *
+     * |     Page 0     |     Page 1     |     Page 2     |     Page 3     |
+     * +----------------+----------------+----------------+----------------+
+     * ^                ^       ^                    ^    ^
+     * Page Start       AB      UB                   UE   AE
+     *                          |<--- buffer_size -->|
+     *                  |<----- mapped_buffer_size ----->|
      *
      * @param tlb_manager Pointer to the TLBManager that manages the TLB entries for this buffer.
      * @param buffer_va Pointer to the virtual address of the buffer in the process address space.

--- a/device/api/umd/device/chip_helpers/sysmem_buffer.h
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.h
@@ -30,17 +30,21 @@ public:
     SysmemBuffer(TLBManager* tlb_manager, void* buffer_va, size_t buffer_size);
     ~SysmemBuffer();
 
-    void* get_buffer_va() const { return buffer_va; }
+    void* get_buffer_va() const { return (uint8_t*)buffer_va + offset_from_aligned_addr; }
 
     size_t get_buffer_size() const { return buffer_size; }
 
-    uint64_t get_device_io_addr(const size_t offset = 0) const { return device_io_addr + offset; }
+    uint64_t get_device_io_addr(const size_t offset = 0) const {
+        return device_io_addr + offset + offset_from_aligned_addr;
+    }
 
     void dma_write_to_device(size_t offset, size_t size, tt_xy_pair core, uint64_t addr);
 
     void dma_read_from_device(size_t offset, size_t size, tt_xy_pair core, uint64_t addr);
 
 private:
+    void align_address_and_size();
+
     TLBManager* tlb_manager_;
 
     // Virtual address in process addr space.
@@ -50,6 +54,8 @@ private:
 
     // Address that is used on the system bus to access the buffer.
     uint64_t device_io_addr;
+
+    uint64_t offset_from_aligned_addr = 0;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/sysmem_buffer.h
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.h
@@ -43,14 +43,22 @@ public:
 private:
     void align_address_and_size();
 
+    void validate(const size_t offset) const;
+
     TLBManager* tlb_manager_;
 
     // Virtual address in process addr space.
     void* buffer_va_;
 
+    // Size of the memory that is mapped through KMD to be visible to the device.
     size_t buffer_size_;
 
-    // Address that is used on the system bus to access the buffer.
+    // Size of the buffer requested by user. If the buffer is not aligned to the page size, size of the memory
+    // mapped through KMD will be larger than this. This is used to return the size of the buffer requested by the user.
+    // Offsets in other SysmemBuffer functions are not allowed to be larger than this size.
+    size_t original_buffer_size_;
+
+    // Address that is used on the system bus to access the beginning of the mapped buffer.
     uint64_t device_io_addr_;
 
     uint64_t offset_from_aligned_addr_ = 0;

--- a/device/api/umd/device/chip_helpers/sysmem_buffer.h
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.h
@@ -30,13 +30,11 @@ public:
     SysmemBuffer(TLBManager* tlb_manager, void* buffer_va, size_t buffer_size);
     ~SysmemBuffer();
 
-    void* get_buffer_va() const { return (uint8_t*)buffer_va + offset_from_aligned_addr; }
+    void* get_buffer_va() const;
 
-    size_t get_buffer_size() const { return buffer_size; }
+    size_t get_buffer_size() const;
 
-    uint64_t get_device_io_addr(const size_t offset = 0) const {
-        return device_io_addr + offset + offset_from_aligned_addr;
-    }
+    uint64_t get_device_io_addr(const size_t offset = 0) const;
 
     void dma_write_to_device(size_t offset, size_t size, tt_xy_pair core, uint64_t addr);
 
@@ -48,14 +46,14 @@ private:
     TLBManager* tlb_manager_;
 
     // Virtual address in process addr space.
-    void* buffer_va;
+    void* buffer_va_;
 
-    size_t buffer_size;
+    size_t buffer_size_;
 
     // Address that is used on the system bus to access the buffer.
-    uint64_t device_io_addr;
+    uint64_t device_io_addr_;
 
-    uint64_t offset_from_aligned_addr = 0;
+    uint64_t offset_from_aligned_addr_ = 0;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/sysmem_buffer.h
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.h
@@ -116,12 +116,12 @@ private:
     void* buffer_va_;
 
     // Size of the memory that is mapped through KMD to be visible to the device.
-    size_t buffer_size_;
+    size_t mapped_buffer_size_;
 
     // Size of the buffer requested by user. If the buffer is not aligned to the page size, size of the memory
     // mapped through KMD will be larger than this. This is used to return the size of the buffer requested by the user.
     // Offsets in other SysmemBuffer functions are not allowed to be larger than this size.
-    size_t original_buffer_size_;
+    size_t buffer_size_;
 
     // Address that is used on the system bus to access the beginning of the mapped buffer.
     uint64_t device_io_addr_;

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -14,9 +14,9 @@
 namespace tt::umd {
 
 SysmemBuffer::SysmemBuffer(TLBManager* tlb_manager, void* buffer_va, size_t buffer_size) :
-    tlb_manager_(tlb_manager), buffer_va_(buffer_va), buffer_size_(buffer_size), original_buffer_size_(buffer_size) {
+    tlb_manager_(tlb_manager), buffer_va_(buffer_va), mapped_buffer_size_(buffer_size), buffer_size_(buffer_size) {
     align_address_and_size();
-    device_io_addr_ = tlb_manager->get_tt_device()->get_pci_device()->map_for_dma(buffer_va_, buffer_size_);
+    device_io_addr_ = tlb_manager->get_tt_device()->get_pci_device()->map_for_dma(buffer_va_, mapped_buffer_size_);
 }
 
 void SysmemBuffer::dma_write_to_device(const size_t offset, size_t size, const tt_xy_pair core, uint64_t addr) {
@@ -79,12 +79,12 @@ void SysmemBuffer::dma_read_from_device(const size_t offset, size_t size, const 
 
 SysmemBuffer::~SysmemBuffer() {
     try {
-        tlb_manager_->get_tt_device()->get_pci_device()->unmap_for_dma(buffer_va_, buffer_size_);
+        tlb_manager_->get_tt_device()->get_pci_device()->unmap_for_dma(buffer_va_, mapped_buffer_size_);
     } catch (...) {
         log_warning(
             LogSiliconDriver,
             "Failed to unmap sysmem buffer (size: {:#x}, IOVA: {:#x}).",
-            buffer_size_,
+            mapped_buffer_size_,
             device_io_addr_);
     }
 }
@@ -95,12 +95,12 @@ void SysmemBuffer::align_address_and_size() {
     uint64_t aligned_buffer_va = reinterpret_cast<uint64_t>(buffer_va_) & ~(page_size - 1);
     offset_from_aligned_addr_ = reinterpret_cast<uint64_t>(buffer_va_) - aligned_buffer_va;
     buffer_va_ = reinterpret_cast<void*>(aligned_buffer_va);
-    buffer_size_ = (buffer_size_ + offset_from_aligned_addr_ + page_size - 1) & ~(page_size - 1);
+    mapped_buffer_size_ = (mapped_buffer_size_ + offset_from_aligned_addr_ + page_size - 1) & ~(page_size - 1);
 }
 
 void* SysmemBuffer::get_buffer_va() const { return (uint8_t*)buffer_va_ + offset_from_aligned_addr_; }
 
-size_t SysmemBuffer::get_buffer_size() const { return original_buffer_size_; }
+size_t SysmemBuffer::get_buffer_size() const { return buffer_size_; }
 
 uint64_t SysmemBuffer::get_device_io_addr(const size_t offset) const {
     validate(offset);
@@ -108,8 +108,8 @@ uint64_t SysmemBuffer::get_device_io_addr(const size_t offset) const {
 }
 
 void SysmemBuffer::validate(const size_t offset) const {
-    if (offset >= original_buffer_size_) {
-        TT_THROW("Offset {:#x} is out of bounds for SysmemBuffer of size {#:x}", offset, original_buffer_size_);
+    if (offset >= buffer_size_) {
+        TT_THROW("Offset {:#x} is out of bounds for SysmemBuffer of size {#:x}", offset, buffer_size_);
     }
 }
 

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -147,4 +147,16 @@ TEST(ApiSysmemManager, SysmemBufferUnaligned) {
     for (uint32_t i = 0; i < one_mb; ++i) {
         EXPECT_EQ(sysmem_data[i], readback[i]);
     }
+
+    // Zero out sysmem_data before reading back.
+    for (uint32_t i = 0; i < one_mb; ++i) {
+        sysmem_data[i] = 0;
+    }
+
+    // Read data back from Tensix L1 to sysmem_data.
+    sysmem_buffer->dma_read_from_device(0, one_mb, tensix_core, 0);
+
+    for (uint32_t i = 0; i < one_mb; ++i) {
+        EXPECT_EQ(sysmem_data[i], readback[i]);
+    }
 }


### PR DESCRIPTION
### Issue

#860 

### Description

Implement support for SysmemBuffer class when original virtual address is not aligned. Since KMD mappings need to be page aligned and the size needs to be multiple of page size, UMD needs to implement the logic of calling KMD in a proper way even when user passes in something that does not follow these requirements. However, SysmemBuffer exposes everything to the user as it's sized with VA and buffer size that user passed in.

### List of the changes

- Add function to align the address
- Add function to resize the mapping if needed
- Make all functions behave like original VA and buffer size is used
- Add tests to showcase this
- Add documentation to SysmemBuffer functions

### Testing
CI. Tested manually on system with IOMMU enabled

### API Changes
/
