### PR TITLE
Allow ethernet FW Major version to be >= UMD SW version

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1040,7 +1040,7 @@ void Cluster::verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std
     for (std::uint32_t& fw_version : fw_versions) {
         tt_version fw(fw_version);
         TT_ASSERT(fw == fw_first_eth_core, "FW versions are not the same across different ethernet cores");
-        TT_ASSERT(sw.major == fw.major, "SW/FW major version number out of sync");
+        TT_ASSERT(sw.major <= fw.major, "SW/FW major version number out of sync");
         TT_ASSERT(sw.minor <= fw.minor, "SW version is newer than FW version");
     }
 


### PR DESCRIPTION
### Issue
No Ticket.

### Description
Currently UMD asserts if the Ethernet FW Version Major field does not equal the UMD SW Version Major field. This is inconsistent with the other checks and problematic for FW version 7.0.0.

### List of the changes
Minor change to `device/cluster.cpp` allowing FW version major >= SW version major.

### Testing
Tested this with Ethernet FW 7.0.0 and UMD 6.0.0.