### PR TITLE
Update tt_core_coordinates.h to provide CORE_TYPE_COUNT via enum

### DIFF
--- a/device/api/umd/device/tt_core_coordinates.h
+++ b/device/api/umd/device/tt_core_coordinates.h
@@ -32,6 +32,7 @@ enum class CoreType {
     HARVESTED,
     ETH,
     WORKER,
+    COUNT,
 };
 
 /*


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description
Higher level constructs want to know how many Core Types there can be.

### List of the changes
(Itemized list of all the changes.)

### Testing
(Comment on CI testing or Manual testing touching this change.)

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
