### PR TITLE
Update BH runners

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -46,8 +46,7 @@ jobs:
           {arch: wormhole_b0, card: n300, timeout: 15},
           {arch: wormhole_b0, card: tt-beta-ubuntu-2204-n300-large-stable, timeout: 15},
           {arch: wormhole_b0, card: tt-beta-ubuntu-2204-n300-llmbox-large-stable, timeout: 15},
-          {arch: blackhole, card: p150, timeout: 15},
-          {arch: blackhole, card: tt-beta-ubuntu-2204-p150a-large-stable, timeout: 15},
+          {arch: blackhole, card: tt-beta-ubuntu-2204-p150b-large-stable, timeout: 15},
           {arch: baremetal, card: ubuntu-22.04, timeout: 15},
         ]
         ubuntu-docker-version: [


### PR DESCRIPTION
### Issue
No issue

### Description
BH runner in shared pool updated
Our dedicated BH runner should be given back

### List of the changes
- Remove dedicated BH runner
- Switch from p150a to p150b in shared

### Testing
Existing CI

### API Changes
There are no API changes in this PR.
