### PR TITLE
Unify parts of get_chip_info TTDevice function

### DIFF
--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -168,7 +168,7 @@ public:
      */
     virtual void configure_iatu_region(size_t region, uint64_t target, size_t region_size);
 
-    virtual ChipInfo get_chip_info() = 0;
+    virtual ChipInfo get_chip_info();
 
     virtual void wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms = 1000);
 

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -100,7 +100,7 @@ bool BlackholeTTDevice::get_noc_translation_enabled() {
 }
 
 ChipInfo BlackholeTTDevice::get_chip_info() {
-    ChipInfo chip_info;
+    ChipInfo chip_info = TTDevice::get_chip_info();
     chip_info.harvesting_masks.tensix_harvesting_mask = CoordinateManager::shuffle_tensix_harvesting_mask(
         tt::ARCH::BLACKHOLE,
         telemetry->is_entry_available(TAG_ENABLED_TENSIX_COL)
@@ -130,18 +130,6 @@ ChipInfo BlackholeTTDevice::get_chip_info() {
     // TODO: Read asic location of the chip from telemetry when it is available.
     // Until then we have to read it from ETH core, it happens during topology exploration.
     // chip_info.chip_uid.asic_location = telemetry->read_entry(TAG_ASIC_LOCATION);
-
-    chip_info.noc_translation_enabled = get_noc_translation_enabled();
-
-    // It is expected that these entries are always available.
-    chip_info.chip_uid.board_id = get_board_id();
-
-    chip_info.board_type = get_board_type_from_board_id(chip_info.chip_uid.board_id);
-
-    // TODO: likely not needed anymore. Firware on P100 will give 0 for TAG_ENABLED_ETH
-    if (chip_info.board_type == BoardType::P100) {
-        chip_info.harvesting_masks.eth_harvesting_mask = 0x3FFF;
-    }
 
     return chip_info;
 }

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -422,4 +422,12 @@ std::vector<DramTrainingStatus> TTDevice::get_dram_training_status() {
     return dram_training_status;
 }
 
+ChipInfo TTDevice::get_chip_info() {
+    ChipInfo chip_info;
+    chip_info.noc_translation_enabled = get_noc_translation_enabled();
+    chip_info.chip_uid.board_id = get_board_id();
+    chip_info.board_type = get_board_type();
+    return chip_info;
+}
+
 }  // namespace tt::umd

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -43,8 +43,7 @@ bool WormholeTTDevice::get_noc_translation_enabled() {
 }
 
 ChipInfo WormholeTTDevice::get_chip_info() {
-    ChipInfo chip_info;
-    chip_info.noc_translation_enabled = get_noc_translation_enabled();
+    ChipInfo chip_info = TTDevice::get_chip_info();
 
     std::vector<uint32_t> arc_msg_return_values = {0};
     const uint32_t timeout_ms = 1000;
@@ -62,10 +61,6 @@ ChipInfo WormholeTTDevice::get_chip_info() {
 
     chip_info.harvesting_masks.tensix_harvesting_mask =
         CoordinateManager::shuffle_tensix_harvesting_mask(tt::ARCH::WORMHOLE_B0, arc_msg_return_values[0]);
-
-    chip_info.chip_uid.board_id = get_board_id();
-
-    chip_info.board_type = get_board_type();
 
     return chip_info;
 }


### PR DESCRIPTION
### Issue

Remove duplicated code in get_chip_info functions for WH and BH TTDevice

### Description

There is some duplicated code in get_chip_info functions for WH and BH. Put this duplicate code in the base TTDevice class function.

### List of the changes

- Implement common code in TTDevice class function
- Call this function from WH TTDevice
- Call this function from BH TTDevice

### Testing
CI

### API Changes
/
