### PR TITLE
Read asic location from telemetry

### DIFF
--- a/device/api/umd/device/firmware/firmware_info_provider.hpp
+++ b/device/api/umd/device/firmware/firmware_info_provider.hpp
@@ -46,6 +46,8 @@ public:
 
     virtual uint32_t get_max_clock_freq();
 
+    virtual uint8_t get_asic_location();
+
 protected:
     TTDevice* tt_device = nullptr;
 

--- a/device/api/umd/device/firmware/wormhole_18_3_firmware_info_provider.hpp
+++ b/device/api/umd/device/firmware/wormhole_18_3_firmware_info_provider.hpp
@@ -30,6 +30,8 @@ public:
     DramTrainingStatus get_dram_training_status(uint32_t dram_channel) override;
 
     uint32_t get_max_clock_freq() override;
+
+    uint8_t get_asic_location() override;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -252,6 +252,8 @@ public:
 
     uint64_t get_board_id();
 
+    uint8_t get_asic_location();
+
     BoardType get_board_type();
 
     virtual bool get_noc_translation_enabled() = 0;

--- a/device/firmware/firmware_info_provider.cpp
+++ b/device/firmware/firmware_info_provider.cpp
@@ -102,4 +102,11 @@ uint32_t FirmwareInfoProvider::get_max_clock_freq() {
     return tt_device->get_arc_telemetry_reader()->read_entry(TelemetryTag::AICLK_LIMIT_MAX);
 }
 
+uint8_t FirmwareInfoProvider::get_asic_location() {
+    ArcTelemetryReader* telemetry = tt_device->get_arc_telemetry_reader();
+    return telemetry->is_entry_available(TelemetryTag::ASIC_LOCATION)
+               ? static_cast<uint8_t>(telemetry->read_entry(TelemetryTag::ASIC_LOCATION))
+               : 0;
+}
+
 }  // namespace tt::umd

--- a/device/firmware/wormhole_18_3_firmware_info_provider.cpp
+++ b/device/firmware/wormhole_18_3_firmware_info_provider.cpp
@@ -54,4 +54,11 @@ uint32_t Wormhole_18_3_FirmwareInfoProvider::get_max_clock_freq() {
     return (aiclk_telemetry >> 16) & 0xFFFF;
 }
 
+uint8_t Wormhole_18_3_FirmwareInfoProvider::get_asic_location() {
+    // 0 is a placeholder value for older WH fw versions. This is something that is not used by SW for older Wormhole FW
+    // versions.
+    // TODO: support asic location to be optional if needed, at the moment this is not a priroty.
+    return 0;
+}
+
 }  // namespace tt::umd

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -131,8 +131,6 @@ ChipInfo BlackholeTTDevice::get_chip_info() {
         chip_info.harvesting_masks.pcie_harvesting_mask |= (1 << 1);
     }
 
-    chip_info.asic_location = telemetry->read_entry(TelemetryTag::ASIC_LOCATION);
-
     return chip_info;
 }
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -571,11 +571,16 @@ std::vector<DramTrainingStatus> TTDevice::get_dram_training_status() {
 
 double TTDevice::get_asic_temperature() { return get_firmware_info_provider()->get_asic_temperature(); }
 
+uint8_t TTDevice::get_asic_location() { return get_firmware_info_provider()->get_asic_location(); }
+
 ChipInfo TTDevice::get_chip_info() {
     ChipInfo chip_info;
+
     chip_info.noc_translation_enabled = get_noc_translation_enabled();
     chip_info.chip_uid.board_id = get_board_id();
     chip_info.board_type = get_board_type();
+    chip_info.asic_location = get_asic_location();
+
     return chip_info;
 }
 


### PR DESCRIPTION
### Issue

https://github.com/tenstorrent/tt-umd/issues/587

### Description

Read asic location from CMFW telemetry rather than reading it from ETH core.

### List of the changes
- Read asic location from CMFW telemetry
- Delete reading it from ETH cores

### Testing

CI

### API Changes
/