### PR TITLE
Prefer get_chip to get_local_chip where possible

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -113,7 +113,7 @@ void Cluster::create_device(
     for (const chip_id_t& logical_device_id : target_mmio_device_ids) {
         if (chip_type == ChipType::SILICON) {
             bool hugepages_initialized =
-                (get_local_chip(logical_device_id)->get_sysmem_manager()->get_hugepage_mapping(0).mapping != nullptr);
+                (get_chip(logical_device_id)->get_sysmem_manager()->get_hugepage_mapping(0).mapping != nullptr);
             // Large writes to remote chips require hugepages to be initialized.
             // Conservative assert - end workload if remote chips present but hugepages not initialized (failures caused
             // if using remote only for small transactions)
@@ -568,7 +568,7 @@ void Cluster::configure_tlb(
 }
 
 void* Cluster::host_dma_address(std::uint64_t offset, chip_id_t src_device_id, uint16_t channel) const {
-    hugepage_mapping hugepage_map = get_local_chip(src_device_id)->get_sysmem_manager()->get_hugepage_mapping(channel);
+    hugepage_mapping hugepage_map = get_chip(src_device_id)->get_sysmem_manager()->get_hugepage_mapping(channel);
     if (hugepage_map.mapping != nullptr) {
         return static_cast<std::byte*>(hugepage_map.mapping) + offset;
     } else {
@@ -582,7 +582,7 @@ TTDevice* Cluster::get_tt_device(chip_id_t device_id) const {
     return tt_device;
 }
 
-TLBManager* Cluster::get_tlb_manager(chip_id_t device_id) const { return get_local_chip(device_id)->get_tlb_manager(); }
+TLBManager* Cluster::get_tlb_manager(chip_id_t device_id) const { return get_chip(device_id)->get_tlb_manager(); }
 
 Chip* Cluster::get_chip(chip_id_t device_id) const {
     auto chip_it = chips_.find(device_id);
@@ -888,11 +888,11 @@ void Cluster::broadcast_write_to_cluster(
 
 void Cluster::write_to_sysmem(
     const void* mem_ptr, std::uint32_t size, uint64_t addr, uint16_t channel, chip_id_t src_device_id) {
-    get_local_chip(src_device_id)->write_to_sysmem(channel, mem_ptr, addr, size);
+    get_chip(src_device_id)->write_to_sysmem(channel, mem_ptr, addr, size);
 }
 
 void Cluster::read_from_sysmem(void* mem_ptr, uint64_t addr, uint16_t channel, uint32_t size, chip_id_t src_device_id) {
-    get_local_chip(src_device_id)->read_from_sysmem(channel, mem_ptr, addr, size);
+    get_chip(src_device_id)->read_from_sysmem(channel, mem_ptr, addr, size);
 }
 
 void Cluster::l1_membar(const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores) {


### PR DESCRIPTION
### Issue
none

### Description
get_local_chip fails on simulation, so use get_chip instead as this allows
the simulation device to provide an implementation

### List of the changes
Change get_local_chip calls to get_chip

### Testing
Tested with Metal programming examples on simulator

### API Changes
/