### PR TITLE
Fix active eth links for filtering by pci_target_devices

### DIFF
--- a/device/api/umd/device/topology_discovery.h
+++ b/device/api/umd/device/topology_discovery.h
@@ -103,6 +103,8 @@ private:
 
     // All board ids that should be included in the cluster descriptor.
     std::unordered_set<uint32_t> board_ids;
+
+    std::unordered_map<chip_id_t, std::set<uint32_t>> active_eth_channels_per_chip;
 };
 
 }  // namespace tt::umd

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -167,6 +167,7 @@ void TopologyDiscovery::discover_remote_chips() {
     }
 
     for (const auto& [chip_id, chip] : chips) {
+        active_eth_channels_per_chip.emplace(chip_id, std::set<uint32_t>());
         std::vector<CoreCoord> eth_cores =
             chip->get_soc_descriptor().get_cores(CoreType::ETH, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::NOC0);
         TTDevice* tt_device = chip->get_tt_device();
@@ -183,8 +184,6 @@ void TopologyDiscovery::discover_remote_chips() {
         current_chip_unique_coord.eth_coord.rack = current_chip_eth_coord_info & 0xFF;
         current_chip_unique_coord.eth_coord.shelf = (current_chip_eth_coord_info >> 8) & 0xFF;
 
-        std::set<uint32_t> active_eth_channels;
-
         uint32_t channel = 0;
         for (const CoreCoord& eth_core : eth_cores) {
             uint32_t port_status;
@@ -199,12 +198,12 @@ void TopologyDiscovery::discover_remote_chips() {
                 continue;
             }
 
+            active_eth_channels_per_chip.at(chip_id).insert(channel);
+
             if (!is_board_id_included(get_remote_board_id(chip.get(), eth_core))) {
                 channel++;
                 continue;
             }
-
-            active_eth_channels.insert(channel);
 
             uint32_t remote_id;
             tt_device->read_from_device(
@@ -229,7 +228,7 @@ void TopologyDiscovery::discover_remote_chips() {
             unique_coord.eth_coord.rack = remote_rack_x;
             unique_coord.eth_coord.shelf = remote_rack_y;
 
-            chip->set_remote_transfer_ethernet_cores(active_eth_channels);
+            chip->set_remote_transfer_ethernet_cores(active_eth_channels_per_chip.at(chip_id));
             std::unique_ptr<RemoteWormholeTTDevice> remote_tt_device =
                 std::make_unique<RemoteWormholeTTDevice>(dynamic_cast<LocalChip*>(chip.get()), unique_coord.eth_coord);
 
@@ -250,7 +249,7 @@ void TopologyDiscovery::discover_remote_chips() {
             }
             channel++;
         }
-        chip->set_remote_transfer_ethernet_cores(active_eth_channels);
+        chip->set_remote_transfer_ethernet_cores(active_eth_channels_per_chip.at(chip_id));
     }
 
     if (remote_chips_to_discover.empty()) {
@@ -300,6 +299,7 @@ void TopologyDiscovery::discover_remote_chips() {
                 std::move(remote_tt_device));
 
             chips.emplace(chip_id, std::move(chip));
+            active_eth_channels_per_chip.emplace(chip_id, std::set<uint32_t>());
             eth_coords.emplace(chip_id, current_chip_unique_coord.eth_coord);
             unique_coord_to_chip_id.emplace(current_chip_unique_coord, chip_id);
             chip_id++;
@@ -318,6 +318,8 @@ void TopologyDiscovery::discover_remote_chips() {
                     channel++;
                     continue;
                 }
+
+                active_eth_channels_per_chip.at(unique_coord_to_chip_id.at(current_chip_unique_coord)).insert(channel);
 
                 if (!is_board_id_included(get_remote_board_id(chips.at(chip_id - 1).get(), eth_core))) {
                     channel++;
@@ -404,10 +406,6 @@ void TopologyDiscovery::fill_cluster_descriptor_info() {
         cluster_desc->coords_to_chip_ids[eth_coord.rack][eth_coord.shelf][eth_coord.y][eth_coord.x] = chip_id;
 
         cluster_desc->add_chip_to_board(chip_id, chip->get_chip_info().chip_uid.board_id);
-
-        for (int i = 0; i < wormhole::NUM_ETH_CHANNELS; i++) {
-            cluster_desc->idle_eth_channels[chip_id].insert(i);
-        }
     }
 
     for (auto [ethernet_connection_logical, ethernet_connection_remote] : ethernet_connections) {
@@ -415,10 +413,17 @@ void TopologyDiscovery::fill_cluster_descriptor_info() {
             ethernet_connection_remote.first, ethernet_connection_remote.second};
         cluster_desc->ethernet_connections[ethernet_connection_remote.first][ethernet_connection_remote.second] = {
             ethernet_connection_logical.first, ethernet_connection_logical.second};
-        cluster_desc->active_eth_channels[ethernet_connection_logical.first].insert(ethernet_connection_logical.second);
-        cluster_desc->idle_eth_channels[ethernet_connection_logical.first].erase(ethernet_connection_logical.second);
-        cluster_desc->active_eth_channels[ethernet_connection_remote.first].insert(ethernet_connection_remote.second);
-        cluster_desc->idle_eth_channels[ethernet_connection_remote.first].erase(ethernet_connection_remote.second);
+    }
+
+    for (auto [chip_id, active_eth_channels] : active_eth_channels_per_chip) {
+        for (int i = 0; i < wormhole::NUM_ETH_CHANNELS; i++) {
+            cluster_desc->idle_eth_channels[chip_id].insert(i);
+        }
+
+        for (const auto& active_channel : active_eth_channels) {
+            cluster_desc->active_eth_channels[chip_id].insert(active_channel);
+            cluster_desc->idle_eth_channels[chip_id].erase(active_channel);
+        }
     }
 
     tt_ClusterDescriptor::fill_galaxy_connections(*cluster_desc.get());


### PR DESCRIPTION
### Issue
The issue is in the future which we're trying to avoid

### Description
We had a mismatch in functionality on logical id and pci id filtering, in how eth links which are outside of filtered cluster are reported.
This is important, since wrong reporting will lead to metal putting its own eth dispatch firmware on all idle cores, and then without reset you can't make the whole cluster work again.

### List of the changes
- Change the way we track active_eth_links in topology discovery

### Testing
Tested manually on an IRD T3K machine with -p filter.

### API Changes
There are no API changes in this PR.
