### PR TITLE
Add support for ETH links to chips outside of cluster scope

### DIFF
--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -45,7 +45,7 @@ protected:
         ethernet_connections;
     // TODO: unify uint64_t with ChipUID
     std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<uint64_t, ethernet_channel_t>>>
-        ethernet_connections_to_remote_mmio_devices;
+        ethernet_connections_to_remote_devices;
     std::unordered_map<chip_id_t, eth_coord_t> chip_locations;
     // reverse map: rack/shelf/y/x -> chip_id
     std::map<int, std::map<int, std::map<int, std::map<int, chip_id_t>>>> coords_to_chip_ids;
@@ -126,7 +126,7 @@ public:
     // TODO: unify uint64_t with ChipUID
     const std::
         unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<uint64_t, ethernet_channel_t>>>
-        get_ethernet_connections_to_remote_mmio_devices() const;
+        get_ethernet_connections_to_remote_devices() const;
     const std::unordered_map<chip_id_t, chip_id_t> &get_chips_with_mmio() const;
     const std::unordered_set<chip_id_t> &get_all_chips() const;
     const std::vector<chip_id_t> get_chips_local_first(std::unordered_set<chip_id_t> chips) const;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -399,7 +399,7 @@ void Cluster::ubb_eth_connections(
                     &remote_eth_id, tt_cxy_pair(chip_id, eth_core.x, eth_core.y), base_addr + 76 * 4, sizeof(uint32_t));
 
                 if (chip_uid_to_local_chip_id.find(remote_chip_id) == chip_uid_to_local_chip_id.end()) {
-                    cluster_desc->ethernet_connections_to_remote_mmio_devices[chip_id][channel] = {
+                    cluster_desc->ethernet_connections_to_remote_devices[chip_id][channel] = {
                         remote_chip_id, remote_eth_id};
                     channel++;
                 } else {

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -313,12 +313,12 @@ void TopologyDiscovery::discover_remote_chips() {
 
                 tt_xy_pair remote_eth_core = get_remote_eth_core(remote_chip_ptr, eth_core);
 
-                uint64_t new_asic_id = get_remote_asic_id(remote_chip_ptr, {eth_core.x, eth_core.y});
+                uint64_t new_asic_id = get_remote_asic_id(remote_chip_ptr, eth_core);
 
                 if (discovered_chips.find(new_asic_id) == discovered_chips.end()) {
                     if (remote_chips_to_discover.find(new_asic_id) == remote_chips_to_discover.end()) {
                         std::unique_ptr<RemoteWormholeTTDevice> new_remote_tt_device =
-                            create_remote_tt_device(remote_chip_ptr, {eth_core.x, eth_core.y}, mmio_chip);
+                            create_remote_tt_device(remote_chip_ptr, eth_core, mmio_chip);
                         new_chips.emplace(new_asic_id, std::move(new_remote_tt_device));
                         remote_asic_id_to_mmio_chip_id.emplace(new_asic_id, mmio_chip_id);
                     }

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -317,14 +317,13 @@ void TopologyDiscovery::discover_remote_chips() {
 
                 if (!is_board_id_included(get_remote_board_id(remote_chip_ptr, eth_core))) {
                     tt_xy_pair remote_eth_core = get_remote_eth_core(chips.at(chip_id - 1).get(), eth_core);
-                    uint32_t remote_eth_id =
+                    uint32_t remote_eth_chan =
                         mmio_chip->get_soc_descriptor()
                             .translate_coord_to(
-                                CoreCoord(remote_eth_core.x, remote_eth_core.y, CoreType::ETH, CoordSystem::PHYSICAL),
-                                CoordSystem::LOGICAL)
+                                CoreCoord(remote_eth_core, CoreType::ETH, CoordSystem::PHYSICAL), CoordSystem::LOGICAL)
                             .y;
                     cluster_desc->ethernet_connections_to_remote_devices[chip_id - 1][channel] = {
-                        get_remote_asic_id(chips.at(chip_id - 1).get(), eth_core), remote_eth_id};
+                        get_remote_asic_id(chips.at(chip_id - 1).get(), eth_core), remote_eth_chan};
                     channel++;
                     continue;
                 }

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -224,6 +224,15 @@ void TopologyDiscovery::discover_remote_chips() {
             active_eth_channels_per_chip.at(chip_id).insert(channel);
 
             if (!is_board_id_included(get_remote_board_id(chip.get(), eth_core))) {
+                tt_xy_pair remote_eth_core = get_remote_eth_core(chip.get(), eth_core);
+                uint32_t remote_eth_id =
+                    chip->get_soc_descriptor()
+                        .translate_coord_to(
+                            CoreCoord(remote_eth_core.x, remote_eth_core.y, CoreType::ETH, CoordSystem::PHYSICAL),
+                            CoordSystem::LOGICAL)
+                        .y;
+                cluster_desc->ethernet_connections_to_remote_devices[chip_id][channel] = {
+                    get_remote_asic_id(chip.get(), eth_core), remote_eth_id};
                 channel++;
                 continue;
             }
@@ -307,6 +316,15 @@ void TopologyDiscovery::discover_remote_chips() {
                 active_eth_channels_per_chip.at(new_remote_chip_id).insert(channel);
 
                 if (!is_board_id_included(get_remote_board_id(remote_chip_ptr, eth_core))) {
+                    tt_xy_pair remote_eth_core = get_remote_eth_core(chips.at(chip_id - 1).get(), eth_core);
+                    uint32_t remote_eth_id =
+                        mmio_chip->get_soc_descriptor()
+                            .translate_coord_to(
+                                CoreCoord(remote_eth_core.x, remote_eth_core.y, CoreType::ETH, CoordSystem::PHYSICAL),
+                                CoordSystem::LOGICAL)
+                            .y;
+                    cluster_desc->ethernet_connections_to_remote_devices[chip_id - 1][channel] = {
+                        get_remote_asic_id(chips.at(chip_id - 1).get(), eth_core), remote_eth_id};
                     channel++;
                     continue;
                 }

--- a/tests/api/cluster_descriptor_examples/wormhole_N300_with_remote_connections.yaml
+++ b/tests/api/cluster_descriptor_examples/wormhole_N300_with_remote_connections.yaml
@@ -1,0 +1,81 @@
+arch:
+  0: wormhole_b0
+  1: wormhole_b0
+chips:
+  0:
+    - 1
+    - 0
+    - 0
+    - 0
+  1:
+    - 0
+    - 0
+    - 0
+    - 0
+ethernet_connections:
+  -
+    - chip: 0
+      chan: 9
+    - chip: 1
+      chan: 1
+  -
+    - chip: 0
+      chan: 8
+    - chip: 1
+      chan: 0
+ethernet_connections_to_remote_devices:
+  -
+    - chip: 1
+      chan: 7
+    - remote_chip_id: 14251335820
+      chan: 7
+  -
+    - chip: 1
+      chan: 6
+    - remote_chip_id: 14251335820
+      chan: 6
+  -
+    - chip: 0
+      chan: 15
+    - remote_chip_id: 9956368524
+      chan: 15
+  -
+    - chip: 0
+      chan: 14
+    - remote_chip_id: 9956368524
+      chan: 14
+  -
+    - chip: 0
+      chan: 1
+    - remote_chip_id: 9956368575
+      chan: 1
+  -
+    - chip: 0
+      chan: 0
+    - remote_chip_id: 9956368575
+      chan: 0
+chips_with_mmio:
+  - 0: 0
+harvesting:
+  0:
+    noc_translation: true
+    harvest_mask: 136
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+  1:
+    noc_translation: true
+    harvest_mask: 576
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+chip_to_boardtype:
+  0: n300
+  1: n300
+boards:
+  -
+    - board_id: 72058990194991233
+    - board_type: n300
+    - chips:
+        - 0
+        - 1

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -83,6 +83,7 @@ TEST(ApiClusterDescriptorTest, TestAllOfflineClusterDescriptors) {
              "wormhole_N300_routing_info.yaml",
              "wormhole_N300_board_info.yaml",
              "wormhole_N150_unique_ids.yaml",
+             "wormhole_N300_with_remote_connections.yaml",
          }) {
         std::cout << "Testing " << cluster_desc_yaml << std::endl;
         std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(

--- a/tools/system_health.cpp
+++ b/tools/system_health.cpp
@@ -136,7 +136,7 @@ int main(int argc, char* argv[]) {
                            << connected_chip_id << " " << logical_eth_coord.str();
                 } else {
                     const auto& ethernet_connections_to_remote_cluster =
-                        cluster_descriptor->get_ethernet_connections_to_remote_mmio_devices();
+                        cluster_descriptor->get_ethernet_connections_to_remote_devices();
                     const auto& local_chip_id = chip_id;
                     const auto& local_connected_eth_core =
                         ethernet_connections_to_remote_cluster.at(local_chip_id).at(chan);


### PR DESCRIPTION
### Issue

#1021 

### Description

Provide support for ETH links going outside of pci_visible_devices, same what was done for 6U work. Format of reporting the links is going to bne 
- (logical chip id, eth channel) -> (unique remote chip id, eth channel)

### List of the changes

- Store information about hidden ETH links while doing topology discovery
- Serialize this struct into yaml
- Support deserializing it from yaml

### Testing
CI + manual testing on T3K with different combinations of pci_visible_devices

### API Changes
/
