### PR TITLE
Fix BH noc1 

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1213,7 +1213,8 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
 
         // TODO: Remove this when we can read asic location from the Blackhole telemetry.
         // Until then we have to read it from ETH core.
-        const std::vector<CoreCoord> eth_cores = chip->get_soc_descriptor().get_cores(CoreType::ETH);
+        const std::vector<CoreCoord> eth_cores = chip->get_soc_descriptor().get_cores(
+            CoreType::ETH, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::TRANSLATED);
         for (size_t eth_channel = 0; eth_channel < eth_cores.size(); eth_channel++) {
             const CoreCoord& eth_core = eth_cores[eth_channel];
             TTDevice* tt_device = chip->get_tt_device();
@@ -1256,7 +1257,8 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
             const chip_id_t chip_id = it.first;
             const std::unique_ptr<Chip>& chip = it.second;
 
-            const std::vector<CoreCoord> eth_cores = chip->get_soc_descriptor().get_cores(CoreType::ETH);
+            const std::vector<CoreCoord> eth_cores = chip->get_soc_descriptor().get_cores(
+                CoreType::ETH, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::TRANSLATED);
 
             for (size_t eth_channel = 0; eth_channel < eth_cores.size(); eth_channel++) {
                 const CoreCoord& eth_core = eth_cores[eth_channel];

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -326,12 +326,14 @@ dynamic_tlb TTDevice::set_dynamic_tlb(
     log_debug(
         LogSiliconDriver,
         "set_dynamic_tlb() with tlb_index: {} tlb_index_offset: {} dynamic_tlb_size: {}MB tlb_base: 0x{:x} "
-        "tlb_cfg_reg: 0x{:x}",
+        "tlb_cfg_reg: 0x{:x} to core ({},{})",
         tlb_index,
         tlb_config.index_offset,
         tlb_config.size / (1024 * 1024),
         tlb_base,
-        tlb_cfg_reg);
+        tlb_cfg_reg,
+        end.x,
+        end.y);
     write_tlb_reg(tlb_cfg_reg, tlb_data.first, tlb_data.second, TLB_CFG_REG_SIZE_BYTES);
 
     return {tlb_base + local_address, tlb_config.size - local_address};


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/967

### Description
BH CI failing on new FW. Likely the new FW enables harvesting, and now this change starts hitting some harvested tensix cores.

### List of the changes
- Use NOC1 coord system when it is supposed to be used, during topology discovery.

### Testing
Tested manually on our dedicated bh-40 with 18.4.0 FW, the api_tests start passing after this change

### API Changes
There are no API changes in this PR.
