### PR TITLE
Sort serialized cluster yaml sections

### DIFF
--- a/nanobind/CMakeLists.txt
+++ b/nanobind/CMakeLists.txt
@@ -2,7 +2,7 @@
 # https://github.com/wjakob/nanobind/blob/master/docs/building.rst
 # Use Development.Module to support manylinux
 # Python module library should not dynamically link libpython.so or use Development.Embed
-find_package(Python REQUIRED COMPONENTS Development.Module)
+find_package(Python REQUIRED COMPONENTS Development)
 
 # Define the Python interface target
 nanobind_add_module(nanobind_libdevice MODULE cluster.cpp)

--- a/nanobind/CMakeLists.txt
+++ b/nanobind/CMakeLists.txt
@@ -2,7 +2,7 @@
 # https://github.com/wjakob/nanobind/blob/master/docs/building.rst
 # Use Development.Module to support manylinux
 # Python module library should not dynamically link libpython.so or use Development.Embed
-find_package(Python REQUIRED COMPONENTS Development)
+find_package(Python REQUIRED COMPONENTS Development.Module)
 
 # Define the Python interface target
 nanobind_add_module(nanobind_libdevice MODULE cluster.cpp)


### PR DESCRIPTION
### Issue

Make all sections inside cluster descriptor sorted

### Description

Sort all sections inside cluster descriptor yaml. Since we are focusing on rewriting topology discovery, having standardized yamls helps. Also, output looks much better when sorted by chip_id, eth channel or other parameters. Changing all unordered sets/maps to regular ones is bigger change that requires more work, we can do that if needed later on, this should be quick way of having sorted sections.

### List of the changes

- Change ETH connections to map instead of unordered_map
- Sort output for all sections of cluster descriptor

### Testing
CI, manual testing

### API Changes
/
