### PR TITLE
Return const ref for get_ethernet_connections_to_remote_devices

### DIFF
--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -125,7 +125,7 @@ public:
         get_ethernet_connections() const;
     // TODO: unify uint64_t with ChipUID
     const std::
-        unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<uint64_t, ethernet_channel_t>>>
+        unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<uint64_t, ethernet_channel_t>>> &
         get_ethernet_connections_to_remote_devices() const;
     const std::unordered_map<chip_id_t, chip_id_t> &get_chips_with_mmio() const;
     const std::unordered_set<chip_id_t> &get_all_chips() const;

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -981,7 +981,7 @@ tt_ClusterDescriptor::get_ethernet_connections() const {
     return ethernet_connections;
 }
 
-const std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<uint64_t, ethernet_channel_t>>>
+const std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<uint64_t, ethernet_channel_t>>> &
 tt_ClusterDescriptor::get_ethernet_connections_to_remote_devices() const {
     return this->ethernet_connections_to_remote_devices;
 }


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description
get_ethernet_connections_to_remote_devices should return a const ref to avoid copying the map each invocation.

### List of the changes

- Return const ref for get_ethernet_connections_to_remote_devices

### Testing
https://github.com/tenstorrent/tt-umd/actions/runs/16101467452

### API Changes
/