### PR TITLE
Split sysmem init and pinning/mapping

### DIFF
--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -85,7 +85,7 @@ private:
     int active_eth_core_idx = 0;
     bool flush_non_mmio_ = false;
 
-    void initialize_local_chip(int num_host_mem_channels = 0);
+    void initialize_local_chip();
     void initialize_tlb_manager();
     void initialize_default_chip_mutexes();
     void initialize_membars();

--- a/device/api/umd/device/chip_helpers/sysmem_manager.h
+++ b/device/api/umd/device/chip_helpers/sysmem_manager.h
@@ -19,13 +19,20 @@ static constexpr size_t HUGEPAGE_CHANNEL_3_SIZE_LIMIT = 768 * (1 << 20);
 
 class SysmemManager {
 public:
-    SysmemManager(TLBManager* tlb_manager);
+    SysmemManager(TLBManager* tlb_manager, uint32_t num_host_mem_channels);
     ~SysmemManager();
 
     void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size);
     void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size);
 
-    bool init_hugepage(uint32_t num_host_mem_channels);
+    /**
+     * Further initializes system memory for usage.
+     * Includes both hugepage and IOMMU settings, depending on which configuration is enabled.
+     * This call will pin the memory and fill up the physical address field in the maps
+     * which should be used further to program the iatu.
+     */
+    bool pin_sysmem_to_device();
+
     size_t get_num_host_mem_channels() const;
     hugepage_mapping get_hugepage_mapping(size_t channel) const;
 
@@ -35,20 +42,30 @@ public:
 
 private:
     /**
+     * Allocate sysmem with hugepages.
+     */
+    bool init_hugepages(uint32_t num_host_mem_channels);
+    /**
      * Allocate sysmem without hugepages and map it through IOMMU.
      * This is used when the system is protected by an IOMMU.  The mappings will
      * still appear as hugepages to the caller.
-     * @param size sysmem size in bytes; size % (1UL << 30) == 0
+     * @param size number of fake hugepage channels to allocate.
      * @return whether allocation/mapping succeeded.
      */
-    bool init_iommu(size_t size);
+    bool init_iommu(uint32_t num_host_mem_channels);
+
+    bool map_hugepages();
+    bool map_iommu();
 
     // For debug purposes when various stages fails.
     void print_file_contents(std::string filename, std::string hint = "");
 
     TLBManager* tlb_manager_;
+    TTDevice* tt_device_;
 
     std::vector<hugepage_mapping> hugepage_mapping_per_channel;
+    void* iommu_mapping = nullptr;
+    size_t iommu_mapping_size = 0;
 
     std::unique_ptr<SysmemBuffer> sysmem_buffer_ = nullptr;
 };

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -30,9 +30,9 @@ LocalChip::LocalChip(tt_SocDescriptor soc_descriptor, int pci_device_id, int num
     tt_device_ = TTDevice::create(pci_device_id);
     chip_info_ = tt_device_->get_chip_info();
     tlb_manager_ = std::make_unique<TLBManager>(tt_device_.get());
-    sysmem_manager_ = std::make_unique<SysmemManager>(tlb_manager_.get());
+    sysmem_manager_ = std::make_unique<SysmemManager>(tlb_manager_.get(), num_host_mem_channels);
     remote_communication_ = std::make_unique<RemoteCommunication>(this);
-    initialize_local_chip(num_host_mem_channels);
+    initialize_local_chip();
 }
 
 LocalChip::LocalChip(std::string sdesc_path, std::unique_ptr<TTDevice> tt_device) :
@@ -44,7 +44,7 @@ LocalChip::LocalChip(std::string sdesc_path, std::unique_ptr<TTDevice> tt_device
             tt_device->get_chip_info().harvesting_masks,
             tt_device->get_chip_info().board_type)),
     tlb_manager_(std::make_unique<TLBManager>(tt_device.get())),
-    sysmem_manager_(std::make_unique<SysmemManager>(tlb_manager_.get())) {
+    sysmem_manager_(std::make_unique<SysmemManager>(tlb_manager_.get(), 0)) {
     tt_device_ = std::move(tt_device);
     initialize_local_chip();
 }
@@ -58,7 +58,7 @@ LocalChip::LocalChip(std::unique_ptr<TTDevice> tt_device) :
             tt_device->get_chip_info().harvesting_masks,
             tt_device->get_chip_info().board_type)),
     tlb_manager_(std::make_unique<TLBManager>(tt_device.get())),
-    sysmem_manager_(std::make_unique<SysmemManager>(tlb_manager_.get())) {
+    sysmem_manager_(std::make_unique<SysmemManager>(tlb_manager_.get(), 0)) {
     tt_device_ = std::move(tt_device);
     initialize_local_chip();
 }
@@ -72,11 +72,8 @@ LocalChip::~LocalChip() {
     tt_device_.reset();
 }
 
-void LocalChip::initialize_local_chip(int num_host_mem_channels) {
+void LocalChip::initialize_local_chip() {
     initialize_tlb_manager();
-    if (num_host_mem_channels > 0) {
-        sysmem_manager_->init_hugepage(num_host_mem_channels);
-    }
     wait_chip_to_be_ready();
     initialize_default_chip_mutexes();
 }
@@ -141,6 +138,7 @@ bool LocalChip::is_mmio_capable() const { return true; }
 
 void LocalChip::start_device() {
     check_pcie_device_initialized();
+    sysmem_manager_->pin_sysmem_to_device();
     init_pcie_iatus();
     initialize_membars();
 }

--- a/device/chip_helpers/sysmem_manager.cpp
+++ b/device/chip_helpers/sysmem_manager.cpp
@@ -44,10 +44,11 @@ SysmemManager::~SysmemManager() {
         // This means we have initialized IOMMU mapping, and need to unmap it.
         // It also means that hugepage_mappings are faked, so don't unmap them.
         munmap(iommu_mapping, iommu_mapping_size);
-    }
-    for (const auto &hugepage_mapping : hugepage_mapping_per_channel) {
-        if (hugepage_mapping.mapping) {
-            munmap(hugepage_mapping.mapping, hugepage_mapping.mapping_size);
+    } else {
+        for (const auto &hugepage_mapping : hugepage_mapping_per_channel) {
+            if (hugepage_mapping.mapping) {
+                munmap(hugepage_mapping.mapping, hugepage_mapping.mapping_size);
+            }
         }
     }
 }

--- a/device/chip_helpers/sysmem_manager.cpp
+++ b/device/chip_helpers/sysmem_manager.cpp
@@ -18,9 +18,33 @@
 
 namespace tt::umd {
 
-SysmemManager::SysmemManager(TLBManager *tlb_manager) : tlb_manager_(tlb_manager) {}
+SysmemManager::SysmemManager(TLBManager *tlb_manager, uint32_t num_host_mem_channels) :
+    tlb_manager_(tlb_manager), tt_device_(tlb_manager_->get_tt_device()) {
+    TT_ASSERT(
+        num_host_mem_channels <= 4,
+        "Only 4 host memory channels are supported per device, but {} requested.",
+        num_host_mem_channels);
+    if (tt_device_->get_pci_device()->is_iommu_enabled()) {
+        init_iommu(num_host_mem_channels);
+    } else {
+        init_hugepages(num_host_mem_channels);
+    }
+}
+
+bool SysmemManager::pin_sysmem_to_device() {
+    if (tt_device_->get_pci_device()->is_iommu_enabled()) {
+        return map_iommu();
+    } else {
+        return map_hugepages();
+    }
+}
 
 SysmemManager::~SysmemManager() {
+    if (iommu_mapping != nullptr) {
+        // This means we have initialized IOMMU mapping, and need to unmap it.
+        // It also means that hugepage_mappings are faked, so don't unmap them.
+        munmap(iommu_mapping, iommu_mapping_size);
+    }
     for (const auto &hugepage_mapping : hugepage_mapping_per_channel) {
         if (hugepage_mapping.mapping) {
             munmap(hugepage_mapping.mapping, hugepage_mapping.mapping_size);
@@ -29,7 +53,6 @@ SysmemManager::~SysmemManager() {
 }
 
 void SysmemManager::write_to_sysmem(uint16_t channel, const void *src, uint64_t sysmem_dest, uint32_t size) {
-    TTDevice *tt_device_ = tlb_manager_->get_tt_device();
     hugepage_mapping hugepage_map = get_hugepage_mapping(channel);
     TT_ASSERT(
         hugepage_map.mapping,
@@ -56,7 +79,6 @@ void SysmemManager::write_to_sysmem(uint16_t channel, const void *src, uint64_t 
 }
 
 void SysmemManager::read_from_sysmem(uint16_t channel, void *dest, uint64_t sysmem_src, uint32_t size) {
-    TTDevice *tt_device_ = tlb_manager_->get_tt_device();
     hugepage_mapping hugepage_map = get_hugepage_mapping(channel);
     TT_ASSERT(
         hugepage_map.mapping,
@@ -77,8 +99,7 @@ void SysmemManager::read_from_sysmem(uint16_t channel, void *dest, uint64_t sysm
     memcpy(dest, user_scratchspace, size);
 }
 
-bool SysmemManager::init_hugepage(uint32_t num_host_mem_channels) {
-    TTDevice *tt_device_ = tlb_manager_->get_tt_device();
+bool SysmemManager::init_hugepages(uint32_t num_host_mem_channels) {
     // TODO: get rid of this when the following Metal CI issue is resolved.
     // https://github.com/tenstorrent/tt-metal/issues/15675
     // The notion that we should clamp the number of host mem channels to
@@ -86,12 +107,9 @@ bool SysmemManager::init_hugepage(uint32_t num_host_mem_channels) {
     // application might try to use the channels it asked for.  We should
     // just fail early since the error message will be actionable instead of
     // a segfault or memory corruption.
-    if (!tt_device_->get_pci_device()->is_iommu_enabled()) {
-        uint16_t pcie_device_id = tt_device_->get_pci_device()->get_pci_device_id();
-        uint32_t pcie_revision = tt_device_->get_pci_device()->get_pci_revision();
-        num_host_mem_channels =
-            get_available_num_host_mem_channels(num_host_mem_channels, pcie_device_id, pcie_revision);
-    }
+    uint16_t pcie_device_id = tt_device_->get_pci_device()->get_pci_device_id();
+    uint32_t pcie_revision = tt_device_->get_pci_device()->get_pci_revision();
+    num_host_mem_channels = get_available_num_host_mem_channels(num_host_mem_channels, pcie_device_id, pcie_revision);
 
     log_debug(
         LogSiliconDriver,
@@ -100,12 +118,6 @@ bool SysmemManager::init_hugepage(uint32_t num_host_mem_channels) {
         tt_device_->get_pci_device()->get_device_num());
 
     const size_t hugepage_size = HUGEPAGE_REGION_SIZE;
-
-    if (tt_device_->get_pci_device()->is_iommu_enabled()) {
-        size_t size = hugepage_size * num_host_mem_channels;
-        return init_iommu(size);
-    }
-
     auto physical_device_id = tt_device_->get_pci_device()->get_device_num();
 
     std::string hugepage_dir = find_hugepage_dir(hugepage_size);
@@ -180,6 +192,21 @@ bool SysmemManager::init_hugepage(uint32_t num_host_mem_channels) {
                 ch);
         }
 
+        hugepage_mapping_per_channel[ch] = {mapping, hugepage_size, 0};
+    }
+
+    return success;
+}
+
+bool SysmemManager::map_hugepages() {
+    auto physical_device_id = tt_device_->get_pci_device()->get_device_num();
+
+    bool success = true;
+
+    // Support for more than 1GB host memory accessible per device, via channels.
+    for (int ch = 0; ch < hugepage_mapping_per_channel.size(); ch++) {
+        void *mapping = hugepage_mapping_per_channel.at(ch).mapping;
+        size_t hugepage_size = hugepage_mapping_per_channel.at(ch).mapping_size;
         size_t actual_size = (tt_device_->get_arch() == tt::ARCH::WORMHOLE_B0 && ch == 3)
                                  ? HUGEPAGE_CHANNEL_3_SIZE_LIMIT
                                  : hugepage_size;
@@ -201,7 +228,7 @@ bool SysmemManager::init_hugepage(uint32_t num_host_mem_channels) {
             continue;
         }
 
-        hugepage_mapping_per_channel[ch] = {mapping, hugepage_size, physical_address};
+        hugepage_mapping_per_channel.at(ch).physical_address = physical_address;
 
         log_debug(
             LogSiliconDriver,
@@ -215,40 +242,51 @@ bool SysmemManager::init_hugepage(uint32_t num_host_mem_channels) {
     return success;
 }
 
-bool SysmemManager::init_iommu(size_t size) {
-    constexpr size_t carveout_size = HUGEPAGE_REGION_SIZE - HUGEPAGE_CHANNEL_3_SIZE_LIMIT;  // 1GB - 768MB = 256MB
-    const size_t num_fake_mem_channels = size / HUGEPAGE_REGION_SIZE;
+bool SysmemManager::init_iommu(uint32_t num_host_mem_channels) {
+    const size_t hugepage_size = HUGEPAGE_REGION_SIZE;
+    size_t size = hugepage_size * num_host_mem_channels;
 
-    TTDevice *tt_device_ = tlb_manager_->get_tt_device();
+    constexpr size_t carveout_size = HUGEPAGE_REGION_SIZE - HUGEPAGE_CHANNEL_3_SIZE_LIMIT;  // 1GB - 768MB = 256MB
+
     // Caclulate the size of the mapping in order to avoid overlap with PCIE registers.
-    size_t map_size =
-        (tt_device_->get_arch() == tt::ARCH::WORMHOLE_B0 && num_fake_mem_channels == 4) ? (size - carveout_size) : size;
+    iommu_mapping_size =
+        (tt_device_->get_arch() == tt::ARCH::WORMHOLE_B0 && num_host_mem_channels == 4) ? (size - carveout_size) : size;
 
     if (!tt_device_->get_pci_device()->is_iommu_enabled()) {
         TT_THROW("IOMMU is required for sysmem without hugepages.");
     }
 
-    log_info(LogSiliconDriver, "Allocating sysmem without hugepages (size: {:#x}).", size);
-    void *mapping = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
+    log_info(LogSiliconDriver, "Allocating sysmem without hugepages (size: {:#x}).", iommu_mapping_size);
+    iommu_mapping = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
 
-    if (mapping == MAP_FAILED) {
+    if (iommu_mapping == MAP_FAILED) {
         TT_THROW(
             "UMD: Failed to allocate memory for device/host shared buffer (size: {} errno: {}).",
             size,
             strerror(errno));
     }
 
-    sysmem_buffer_ = map_sysmem_buffer(mapping, map_size);
+    hugepage_mapping_per_channel.resize(num_host_mem_channels);
+
+    // Support for more than 1GB host memory accessible per device, via channels.
+    for (size_t ch = 0; ch < num_host_mem_channels; ch++) {
+        uint8_t *fake_mapping = static_cast<uint8_t *>(iommu_mapping) + ch * HUGEPAGE_REGION_SIZE;
+        hugepage_mapping_per_channel[ch] = {fake_mapping, HUGEPAGE_REGION_SIZE, 0};
+    }
+
+    return true;
+}
+
+bool SysmemManager::map_iommu() {
+    sysmem_buffer_ = map_sysmem_buffer(iommu_mapping, iommu_mapping_size);
     uint64_t iova = sysmem_buffer_->get_device_io_addr();
 
     log_info(LogSiliconDriver, "Mapped sysmem without hugepages to IOVA {:#x}.", iova);
 
-    hugepage_mapping_per_channel.resize(num_fake_mem_channels);
-
     // Support for more than 1GB host memory accessible per device, via channels.
-    for (size_t ch = 0; ch < num_fake_mem_channels; ch++) {
-        uint8_t *base = static_cast<uint8_t *>(mapping) + ch * HUGEPAGE_REGION_SIZE;
-        hugepage_mapping_per_channel[ch] = {base, HUGEPAGE_REGION_SIZE, iova + ch * HUGEPAGE_REGION_SIZE};
+    for (size_t ch = 0; ch < hugepage_mapping_per_channel.size(); ch++) {
+        uint64_t fake_physical_address = iova + ch * HUGEPAGE_REGION_SIZE;
+        hugepage_mapping_per_channel.at(ch).physical_address = fake_physical_address;
     }
 
     return true;

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -19,10 +19,10 @@ TEST(ApiSysmemManager, BasicIO) {
 
         std::unique_ptr<TLBManager> tlb_manager = std::make_unique<TLBManager>(tt_device.get());
 
-        std::unique_ptr<SysmemManager> sysmem = std::make_unique<SysmemManager>(tlb_manager.get());
-
         // Initializes system memory with one channel.
-        sysmem->init_hugepage(1);
+        std::unique_ptr<SysmemManager> sysmem = std::make_unique<SysmemManager>(tlb_manager.get(), 1);
+
+        sysmem->pin_sysmem_to_device();
 
         // Simple write and read test.
         std::vector<uint32_t> data_write = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};


### PR DESCRIPTION
### Issue
A pre work needed for https://github.com/tenstorrent/tt-umd/issues/913

### Description
This PR explicitly splits initialisation of memory, and pinning it in KMD. This doesn't make much sense on it's own at this moment, but it will make much more sense once the functionality is added from newer KMD which also maps the buffers to device in the same KMD call.
This PR will allow us to properly separate initialising the buffers and mapping them to the device in start_device call. This is important in multiprocessing since even though we could initialise many buffers, we can't map many to the device. The start_device call will guard mapping the buffer, and if we make sure that only one start_device is called at each time this will prevent us from mapping multiple buffers from multiple drivers to the same device.

### List of the changes
- Explicitly save the iommu mapping
- Fix the destructor, unmap the mapped iommu memory instead of memory faked through hugepages.
- Properly separate init_hugepages and init_iommu, so that iommu part is not called from hugepages part
- Split init_hugepages and init_iommu into two functions, first are init_ second one are map_, therefore explicitly separating initialisation of memory and pinning the memory.
- The init part is now called by default through constructor
- The map part now has to be explicitly called, similar to how we called init_hugepages before

Functionality should stay the same

### Testing
Existing CI should cover both hugepage and iommu paths.

### API Changes
There are no API changes in this PR.
