### PR TITLE
Fix chip unique IDs for 6U

### DIFF
--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -64,7 +64,6 @@ protected:
     std::map<chip_id_t, std::set<uint32_t>> idle_eth_channels = {};
     std::map<uint64_t, std::unordered_set<chip_id_t>> board_to_chips = {};
     std::unordered_map<chip_id_t, uint64_t> chip_to_board_id = {};
-    std::map<chip_id_t, uint64_t> chip_to_unique_id = {};
 
     // one-to-many chip connections
     struct Chip2ChipConnection {

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -412,7 +412,7 @@ void TopologyDiscovery::fill_cluster_descriptor_info() {
     }
 
     for (const auto& [asic_id, chip_id] : asic_id_to_chip_id) {
-        cluster_desc->chip_to_unique_id.emplace(chip_id, asic_id);
+        cluster_desc->chip_unique_ids.emplace(chip_id, asic_id);
     }
 
     for (auto [ethernet_connection_logical, ethernet_connection_remote] : ethernet_connections) {

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -934,7 +934,7 @@ void tt_ClusterDescriptor::load_chips_from_connectivity_descriptor(YAML::Node &y
         for (const auto &chip_unique_id : yaml["chip_unique_ids"].as<std::map<int, uint64_t>>()) {
             auto &chip = chip_unique_id.first;
             auto &unique_id = chip_unique_id.second;
-            desc.chip_to_unique_id.insert({chip, unique_id});
+            desc.chip_unique_ids.insert({chip, unique_id});
         }
     }
 }
@@ -1115,7 +1115,7 @@ std::string tt_ClusterDescriptor::serialize() const {
     out << YAML::EndMap;
 
     out << YAML::Key << "chip_unique_ids" << YAML::Value << YAML::BeginMap;
-    for (const auto &[chip_id, unique_id] : chip_to_unique_id) {
+    for (const auto &[chip_id, unique_id] : chip_unique_ids) {
         out << YAML::Key << chip_id << YAML::Value << unique_id;
     }
     out << YAML::EndMap;


### PR DESCRIPTION
### Issue

Fix tt cluster descriptor chip unique IDs struct for 6U

### Description

Fix tt cluster descriptor chip unique IDs struct for 6U

### List of the changes

- Fix tt cluster descriptor chip unique IDs struct for 6U

### Testing
CI + local testing

### API Changes
/
