### PR TITLE
Make RemoteChip wait for DRAM and ETH

### DIFF
--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -101,10 +101,5 @@ private:
     void wait_for_aiclk_value(tt_DevicePowerState power_state, const uint32_t timeout_ms = 5000);
 
     std::unique_ptr<TTDevice> tt_device_ = nullptr;
-
-protected:
-    void wait_eth_cores_training(const uint32_t timeout_ms = 60000) override;
-
-    void wait_dram_cores_training(const uint32_t timeout_ms = 60000) override;
 };
 }  // namespace tt::umd

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -62,9 +62,58 @@ void Chip::wait_chip_to_be_ready() {
     wait_dram_cores_training();
 }
 
-void Chip::wait_eth_cores_training(const uint32_t timeout_ms) {}
+void Chip::wait_eth_cores_training(const uint32_t timeout_ms) {
+    const std::vector<CoreCoord> eth_cores =
+        get_soc_descriptor().get_cores(CoreType::ETH, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::PHYSICAL);
+    TTDevice* tt_device = get_tt_device();
+    for (const CoreCoord& eth_core : eth_cores) {
+        tt_device->wait_eth_core_training(eth_core, timeout_ms);
+    }
+}
 
-void Chip::wait_dram_cores_training(const uint32_t timeout_ms) {}
+void Chip::wait_dram_cores_training(const uint32_t timeout_ms) {
+    TTDevice* tt_device = get_tt_device();
+
+    auto start = std::chrono::system_clock::now();
+    while (true) {
+        std::vector<DramTrainingStatus> dram_training_status = tt_device->get_dram_training_status();
+
+        if (dram_training_status.empty()) {
+            // DRAM training status is not available, breaking the wait for DRAM training.
+            break;
+        }
+
+        bool all_dram_channels_trained = true;
+        const uint32_t chip_num_dram_channels =
+            std::min(dram_training_status.size(), get_soc_descriptor().get_dram_cores().size());
+        const uint32_t dram_harvesting_mask = get_soc_descriptor().harvesting_masks.dram_harvesting_mask;
+        for (uint32_t dram_channel = 0; dram_channel < chip_num_dram_channels; dram_channel++) {
+            // Skip the check for harvested channels.
+            if (dram_harvesting_mask & (1 << dram_channel)) {
+                continue;
+            }
+
+            // Check if there is an error in training for the channel.
+            if (dram_training_status[dram_channel] == DramTrainingStatus::FAIL) {
+                throw std::runtime_error("DRAM training failed");
+            }
+
+            // Verify whether the channel is trained.
+            all_dram_channels_trained &= (dram_training_status[dram_channel] == DramTrainingStatus::SUCCESS);
+        }
+
+        if (all_dram_channels_trained) {
+            break;
+        }
+
+        auto end = std::chrono::system_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+        if (duration.count() > timeout_ms) {
+            throw std::runtime_error(fmt::format("DRAM training timed out after {} ms", timeout_ms));
+            break;
+        }
+    }
+}
 
 void Chip::enable_ethernet_queue(int timeout_s) {
     TT_ASSERT(

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -145,15 +145,6 @@ void LocalChip::start_device() {
 
 void LocalChip::close_device(){};
 
-void LocalChip::wait_eth_cores_training(const uint32_t timeout_ms) {
-    const std::vector<CoreCoord> eth_cores =
-        get_soc_descriptor().get_cores(CoreType::ETH, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::PHYSICAL);
-    TTDevice* tt_device = get_tt_device();
-    for (const CoreCoord& eth_core : eth_cores) {
-        tt_device->wait_eth_core_training(eth_core, timeout_ms);
-    }
-}
-
 int LocalChip::get_num_host_channels() { return sysmem_manager_->get_num_host_mem_channels(); }
 
 int LocalChip::get_host_channel_size(std::uint32_t channel) {
@@ -428,50 +419,6 @@ std::unique_lock<RobustMutex> LocalChip::acquire_mutex(std::string mutex_name, i
 
 std::unique_lock<RobustMutex> LocalChip::acquire_mutex(MutexType mutex_type, int pci_device_id) {
     return lock_manager_.acquire_mutex(mutex_type, pci_device_id);
-}
-
-void LocalChip::wait_dram_cores_training(const uint32_t timeout_ms) {
-    TTDevice* tt_device = get_tt_device();
-
-    auto start = std::chrono::system_clock::now();
-    while (true) {
-        std::vector<DramTrainingStatus> dram_training_status = tt_device->get_dram_training_status();
-
-        if (dram_training_status.empty()) {
-            // DRAM training status is not available, breaking the wait for DRAM training.
-            break;
-        }
-
-        bool all_dram_channels_trained = true;
-        const uint32_t chip_num_dram_channels =
-            std::min(dram_training_status.size(), get_soc_descriptor().get_dram_cores().size());
-        const uint32_t dram_harvesting_mask = get_soc_descriptor().harvesting_masks.dram_harvesting_mask;
-        for (uint32_t dram_channel = 0; dram_channel < chip_num_dram_channels; dram_channel++) {
-            // Skip the check for harvested channels.
-            if (dram_harvesting_mask & (1 << dram_channel)) {
-                continue;
-            }
-
-            // Check if there is an error in training for the channel.
-            if (dram_training_status[dram_channel] == DramTrainingStatus::FAIL) {
-                throw std::runtime_error("DRAM training failed");
-            }
-
-            // Verify whether the channel is trained.
-            all_dram_channels_trained &= (dram_training_status[dram_channel] == DramTrainingStatus::SUCCESS);
-        }
-
-        if (all_dram_channels_trained) {
-            break;
-        }
-
-        auto end = std::chrono::system_clock::now();
-        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-        if (duration.count() > timeout_ms) {
-            throw std::runtime_error(fmt::format("DRAM training timed out after {} ms", timeout_ms));
-            break;
-        }
-    }
 }
 
 void LocalChip::check_pcie_device_initialized() {

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -23,6 +23,7 @@ RemoteChip::RemoteChip(tt_SocDescriptor soc_descriptor, std::unique_ptr<RemoteWo
     tt_device_ = std::move(remote_tt_device);
     chip_info_ = tt_device_->get_chip_info();
     TT_ASSERT(soc_descriptor_.arch != tt::ARCH::BLACKHOLE, "Non-MMIO targets not supported in Blackhole");
+    wait_chip_to_be_ready();
 }
 
 bool RemoteChip::is_mmio_capable() const { return false; }


### PR DESCRIPTION
### Issue

#1053 

### Description

Make all chips, both Local and Remote wait for ETH to be trained. This is done while constructing the chips. TTDevice is still the one that knows low level details of how it should wait for ETH to be trained

### List of the changes

- Move wait for ETH to Chip
- Move wait for DRAM to chip
- Make RemoteChip wait for both

### Testing
CI

### API Changes
/
