### PR TITLE
Add IOMMU mapping benchmark

### DIFF
--- a/tests/microbenchmark/CMakeLists.txt
+++ b/tests/microbenchmark/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(UBENCH_SRC
     benchmarks/tlb/test_tlb.cpp
     benchmarks/pcie_dma/test_pcie_dma.cpp
+    benchmarks/iommu/test_iommu.cpp
 )
 add_executable(ubench ${UBENCH_SRC})
 target_link_libraries(

--- a/tests/microbenchmark/benchmarks/iommu/README.md
+++ b/tests/microbenchmark/benchmarks/iommu/README.md
@@ -1,0 +1,6 @@
+# IOMMU benchmark
+
+This benchmark contains tests that are measuring performance of different IOMMU operations through UMD and KMD.
+
+IOMMU operations that UMD does are mapping the buffer through IOMMU and unampping it when it is not needed anymore. Both operations are done by making ioctl call to KMD.
+

--- a/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
+++ b/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
@@ -38,7 +38,7 @@ static void guard_test_iommu() {
  * and measures the time it takes to map them through IOMMU. It prints out the time taken for each mapping
  * and the average time per page.
  */
-TEST(BenchmarkIOMMU, AllocateDifferentSizes) {
+TEST(BenchmarkIOMMU, MapDifferentSizes) {
     guard_test_iommu();
 
     static const auto page_size = sysconf(_SC_PAGESIZE);

--- a/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
+++ b/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <sys/mman.h>
+
+#include "gtest/gtest.h"
+#include "tests/test_utils/device_test_utils.hpp"
+#include "tests/test_utils/generate_cluster_desc.hpp"
+#include "umd/device/chip_helpers/sysmem_manager.h"
+#include "umd/device/cluster.h"
+#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/tt_device/wormhole_tt_device.h"
+#include "umd/device/wormhole_implementation.h"
+#include "wormhole/eth_l1_address_map.h"
+#include "wormhole/host_mem_address_map.h"
+#include "wormhole/l1_address_map.h"
+
+using namespace tt::umd;
+
+const chip_id_t chip = 0;
+const uint64_t one_mb = 1 << 20;
+
+static void guard_test_iommu() {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+    if (pci_device_ids.empty()) {
+        GTEST_SKIP() << "No chips present on the system. Skipping test.";
+    }
+    if (!PCIDevice(pci_device_ids[0]).is_iommu_enabled()) {
+        GTEST_SKIP() << "Skipping test since IOMMU is not enabled on the system.";
+    }
+}
+
+/**
+ * Measure the time it takes to map buffers of different sizes through IOMMU.
+ * This test allocates buffers of different size, starting from single page (usually 4KB) up to 1GB,
+ * and measures the time it takes to map them through IOMMU. It prints out the time taken for each mapping
+ * and the average time per page.
+ */
+TEST(BenchmarkIOMMU, AllocateDifferentSizes) {
+    guard_test_iommu();
+
+    static const auto page_size = sysconf(_SC_PAGESIZE);
+
+    const std::vector<uint64_t> mapping_sizes;
+
+    std::cout << "Running IOMMU benchmark for different mapping sizes." << std::endl;
+    std::cout << "--------------------------------------------------------" << std::endl;
+    std::cout << "Page size: " << page_size << " bytes." << std::endl;
+
+    const uint64_t mapping_size_limit = 1ULL << 30;  // 1 GB
+
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(tt::umd::ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = 0,
+    });
+
+    SysmemManager* sysmem_manager = cluster->get_chip(chip)->get_sysmem_manager();
+
+    for (uint64_t size = page_size; size <= mapping_size_limit; size *= 2) {
+        void* mapping = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
+        if (mapping == MAP_FAILED) {
+            std::cerr << "Failed to allocate mapping of size " << size << " bytes." << std::endl;
+            continue;
+        }
+
+        auto now = std::chrono::steady_clock::now();
+        std::unique_ptr<SysmemBuffer> sysmem_buffer = sysmem_manager->map_sysmem_buffer(mapping, size);
+        auto end = std::chrono::steady_clock::now();
+        auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
+
+        const uint64_t num_pages = size / page_size;
+        double map_per_page = ns / num_pages;
+
+        std::cout << "Mapped " << num_pages << " pages (" << size << " bytes, " << ((double)size / one_mb) << " MB) in "
+                  << ns << " ns. Mapping time per page: " << map_per_page << " ns." << std::endl;
+
+        munmap(mapping, size);
+    }
+}

--- a/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
+++ b/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
@@ -44,15 +44,15 @@ void print_results(std::vector<uint64_t>& map_times, std::vector<uint64_t>& unma
     uint64_t unmap_time_average = std::accumulate(unmap_times.begin(), unmap_times.end(), 0ULL) / NUM_ITERATIONS;
 
     const uint64_t num_pages = mapping_size / sysconf(_SC_PAGESIZE);
-    double map_per_page = (double)map_time_average / num_pages;
-    double unmap_per_page = (double)unmap_time_average / num_pages;
+    double bw_map_mbs = (double)mapping_size / map_time_average;
+    double bw_unmap_mbs = (double)mapping_size / unmap_time_average;
 
     std::cout << "Mapped " << num_pages << " pages (" << mapping_size << " bytes, " << ((double)mapping_size / one_mb)
               << " MB). Median map time: " << map_time_median << " ns, Average map time: " << map_time_average
-              << " ns, Map time per page: " << map_per_page << " ns." << std::endl;
+              << " ns. Bandwidth: " << bw_map_mbs << " MB/s." << std::endl;
     std::cout << "Unmapped " << num_pages << " pages (" << mapping_size << " bytes, " << ((double)mapping_size / one_mb)
               << " MB). Median unmap time: " << unmap_time_median << " ns, Average unmap time: " << unmap_time_average
-              << " ns, Unmap time per page: " << unmap_per_page << " ns." << std::endl;
+              << " ns, Bandwidth: " << bw_unmap_mbs << " MB/s." << std::endl;
     std::cout << "--------------------------------------------------------" << std::endl;
 }
 


### PR DESCRIPTION
### Issue

#1072 

### Description

Add benchmark for IOMMU mapping/umapping operations. Tests map/unmap buffers in multiple iterations and print average and median values. We calculate average time to map buffers of multiple sizes, as well as time per page to map.

### List of the changes

- Add test for mapping/unmapping user buffers
- Add test for mapping/unmapping 2MB hugepages
- Add test for mapping/unmapping 1G hugepages

### Testing
CI

### API Changes
/