### PR TITLE
Put everything in tt::umd namespace

### DIFF
--- a/device/api/umd/device/architecture_implementation.h
+++ b/device/api/umd/device/architecture_implementation.h
@@ -17,12 +17,12 @@
 #include "umd/device/types/tlb.h"
 #include "umd/device/types/xy_pair.h"
 
+namespace tt::umd {
+
 struct tt_device_l1_address_params;
 struct tt_driver_host_address_params;
 struct tt_driver_eth_interface_params;
 struct tt_driver_noc_params;
-
-namespace tt::umd {
 
 static const uint32_t HANG_READ_VALUE = 0xFFFFFFFFu;
 

--- a/device/api/umd/device/blackhole_coordinate_manager.h
+++ b/device/api/umd/device/blackhole_coordinate_manager.h
@@ -9,11 +9,13 @@
 #include "umd/device/blackhole_implementation.h"
 #include "umd/device/coordinate_manager.h"
 
+namespace tt::umd {
+
 class BlackholeCoordinateManager : public CoordinateManager {
 public:
     BlackholeCoordinateManager(
         const bool noc_translation_enabled,
-        tt::umd::HarvestingMasks harvesting_masks,
+        HarvestingMasks harvesting_masks,
         const tt_xy_pair& tensix_grid_size,
         const std::vector<tt_xy_pair>& tensix_cores,
         const tt_xy_pair& dram_grid_size,
@@ -43,14 +45,14 @@ protected:
     void fill_pcie_physical_translated_mapping() override;
     void fill_arc_physical_translated_mapping() override;
 
-    std::vector<tt::umd::CoreCoord> get_tensix_cores() const override;
-    std::vector<tt::umd::CoreCoord> get_harvested_tensix_cores() const override;
-    std::vector<tt::umd::CoreCoord> get_dram_cores() const override;
-    std::vector<tt::umd::CoreCoord> get_harvested_dram_cores() const override;
-    std::vector<tt::umd::CoreCoord> get_eth_cores() const override;
-    std::vector<tt::umd::CoreCoord> get_harvested_eth_cores() const override;
-    std::vector<tt::umd::CoreCoord> get_pcie_cores() const override;
-    std::vector<tt::umd::CoreCoord> get_harvested_pcie_cores() const override;
+    std::vector<CoreCoord> get_tensix_cores() const override;
+    std::vector<CoreCoord> get_harvested_tensix_cores() const override;
+    std::vector<CoreCoord> get_dram_cores() const override;
+    std::vector<CoreCoord> get_harvested_dram_cores() const override;
+    std::vector<CoreCoord> get_eth_cores() const override;
+    std::vector<CoreCoord> get_harvested_eth_cores() const override;
+    std::vector<CoreCoord> get_pcie_cores() const override;
+    std::vector<CoreCoord> get_harvested_pcie_cores() const override;
     tt_xy_pair get_tensix_grid_size() const override;
     tt_xy_pair get_dram_grid_size() const override;
     tt_xy_pair get_harvested_tensix_grid_size() const override;
@@ -61,5 +63,7 @@ private:
         const size_t start_bank,
         const size_t end_bank,
         const size_t x_coord,
-        const size_t y_coord_start = tt::umd::blackhole::dram_translated_coordinate_start_y);
+        const size_t y_coord_start = blackhole::dram_translated_coordinate_start_y);
 };
+
+}  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/tlb_manager.h
+++ b/device/api/umd/device/chip_helpers/tlb_manager.h
@@ -10,12 +10,9 @@
 #include "umd/device/tt_xy_pair.h"
 #include "umd/device/types/tlb.h"
 
-namespace tt {
-class Writer;
-}
-
 namespace tt::umd {
 
+class Writer;
 class TTDevice;
 
 class TLBManager {
@@ -34,7 +31,7 @@ public:
     bool is_tlb_mapped(tt_xy_pair core);
     bool is_tlb_mapped(tt_xy_pair core, uint64_t address, uint32_t size_in_bytes);
 
-    tt::Writer get_static_tlb_writer(tt_xy_pair core);
+    Writer get_static_tlb_writer(tt_xy_pair core);
     tlb_configuration get_tlb_configuration(tt_xy_pair core);
 
     // TODO: the following members will be moved to private once enough stuff is moved out of cluster.

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -27,12 +27,9 @@
 #include "umd/device/types/cluster_types.h"
 #include "umd/device/types/tlb.h"
 
-using TLB_DATA = tt::umd::tlb_data;
-
-class tt_ClusterDescriptor;
-
 namespace tt::umd {
 
+class tt_ClusterDescriptor;
 class LocalChip;
 class RemoteChip;
 
@@ -175,7 +172,7 @@ public:
         tt_xy_pair core,
         int32_t tlb_index,
         uint64_t address,
-        uint64_t ordering = TLB_DATA::Relaxed);
+        uint64_t ordering = tlb_data::Relaxed);
 
     /**
      * Configure a TLB to point to a specific core and an address within that core. Should be done for Static TLBs.
@@ -189,10 +186,10 @@ public:
      */
     void configure_tlb(
         chip_id_t logical_device_id,
-        tt::umd::CoreCoord core,
+        CoreCoord core,
         int32_t tlb_index,
         uint64_t address,
-        uint64_t ordering = TLB_DATA::Relaxed);
+        uint64_t ordering = tlb_data::Relaxed);
 
     /**
      * Pass in ethernet cores with active links for a specific MMIO chip. When called, this function will force UMD to
@@ -205,7 +202,7 @@ public:
      * @param active_eth_cores_per_chip The active ethernet cores for this chip.
      */
     void configure_active_ethernet_cores_for_mmio_device(
-        chip_id_t mmio_chip, const std::unordered_set<tt::umd::CoreCoord>& active_eth_cores_per_chip);
+        chip_id_t mmio_chip, const std::unordered_set<CoreCoord>& active_eth_cores_per_chip);
 
     //---------- Start and stop the device and tensix cores.
 
@@ -254,7 +251,7 @@ public:
      */
     void deassert_risc_reset_at_core(
         const chip_id_t chip,
-        const tt::umd::CoreCoord core,
+        const CoreCoord core,
         const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET);
 
     /**
@@ -275,7 +272,7 @@ public:
      */
     void assert_risc_reset_at_core(
         const chip_id_t chip,
-        const tt::umd::CoreCoord core,
+        const CoreCoord core,
         const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET);
 
     //---------- IO functions for Tensix cores, including DRAM.
@@ -291,8 +288,7 @@ public:
      * @param core Core to target.
      * @param addr Address to write to.
      */
-    void write_to_device(
-        const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr);
+    void write_to_device(const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, CoreCoord core, uint64_t addr);
 
     /**
      * Read uint32_t data from a specified device, core and address to host memory (defined for Silicon).
@@ -305,7 +301,7 @@ public:
      * @param addr Address to read from.
      * @param size Number of bytes to read.
      */
-    void read_from_device(void* mem_ptr, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr, uint32_t size);
+    void read_from_device(void* mem_ptr, chip_id_t chip, CoreCoord core, uint64_t addr, uint32_t size);
 
     /**
      * Write uint32_t data (as specified by ptr + len pair) to specified device, core and address (defined for Silicon).
@@ -321,7 +317,7 @@ public:
      * @param addr Address to write to.
      */
     void write_to_device_reg(
-        const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr);
+        const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, CoreCoord core, uint64_t addr);
 
     /**
      * Read uint32_t data from a specified device, core and address to host memory (defined for Silicon).
@@ -336,7 +332,7 @@ public:
      * @param addr Address to read from.
      * @param size Number of bytes to read.
      */
-    void read_from_device_reg(void* mem_ptr, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr, uint32_t size);
+    void read_from_device_reg(void* mem_ptr, chip_id_t chip, CoreCoord core, uint64_t addr, uint32_t size);
 
     /**
      * Use PCIe DMA to write device memory (L1 or DRAM).
@@ -347,7 +343,7 @@ public:
      * @param core Core to target.
      * @param addr Address to write to.
      */
-    void dma_write_to_device(const void* src, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr);
+    void dma_write_to_device(const void* src, size_t size, chip_id_t chip, CoreCoord core, uint64_t addr);
 
     /**
      * Use PCIe DMA to read device memory (L1 or DRAM).
@@ -358,7 +354,7 @@ public:
      * @param core Core to target.
      * @param addr Address to read from.
      */
-    void dma_read_from_device(void* dst, size_t size, chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr);
+    void dma_read_from_device(void* dst, size_t size, chip_id_t chip, CoreCoord core, uint64_t addr);
 
     /**
      * This function writes to multiple chips and cores in the cluster. A set of chips, rows and columns can be excluded
@@ -397,7 +393,7 @@ public:
      *
      * @param target The target chip and core to write to.
      */
-    tt::Writer get_static_tlb_writer(const chip_id_t chip, const tt::umd::CoreCoord target);
+    Writer get_static_tlb_writer(const chip_id_t chip, const CoreCoord target);
 
     //---------- Functions for synchronization and memory barriers.
 
@@ -409,7 +405,7 @@ public:
      * @param chip Chip to target.
      * @param cores Cores being targeted.
      */
-    void l1_membar(const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores = {});
+    void l1_membar(const chip_id_t chip, const std::unordered_set<CoreCoord>& cores = {});
 
     /**
      * DRAM memory barrier.
@@ -429,7 +425,7 @@ public:
      * @param chip Chip being targeted.
      * @param cores Cores being targeted.
      */
-    void dram_membar(const chip_id_t chip, const std::unordered_set<tt::umd::CoreCoord>& cores = {});
+    void dram_membar(const chip_id_t chip, const std::unordered_set<CoreCoord>& cores = {});
 
     // Runtime functions
     /**
@@ -601,7 +597,7 @@ public:
     /**
      * Exposes how TLBs are configured for a specific device.
      */
-    tlb_configuration get_tlb_configuration(const chip_id_t chip, const tt::umd::CoreCoord core);
+    tlb_configuration get_tlb_configuration(const chip_id_t chip, const CoreCoord core);
 
 private:
     // Helper functions
@@ -660,7 +656,7 @@ private:
     void construct_cluster(const uint32_t& num_host_mem_ch_per_mmio_device, const ChipType& chip_type);
 
     static std::unique_ptr<tt_ClusterDescriptor> create_cluster_descriptor(
-        const std::unordered_map<chip_id_t, std::unique_ptr<tt::umd::Chip>>& chips);
+        const std::unordered_map<chip_id_t, std::unique_ptr<Chip>>& chips);
 
     static void verify_cluster_options(const ClusterOptions& options);
 

--- a/device/api/umd/device/coordinate_manager.h
+++ b/device/api/umd/device/coordinate_manager.h
@@ -239,3 +239,6 @@ protected:
 };
 
 }  // namespace tt::umd
+
+// TODO: To be removed once clients switch to namespace usage.
+using tt::umd::CoordinateManager;

--- a/device/api/umd/device/coordinate_manager.h
+++ b/device/api/umd/device/coordinate_manager.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <map>
+#include <memory>
 #include <set>
 #include <vector>
 
@@ -15,6 +16,8 @@
 #include "umd/device/types/arch.h"
 #include "umd/device/types/cluster_descriptor_types.h"
 #include "umd/device/types/harvesting.h"
+
+namespace tt::umd {
 
 class CoordinateManager {
 public:
@@ -29,7 +32,7 @@ public:
     static std::shared_ptr<CoordinateManager> create_coordinate_manager(
         tt::ARCH arch,
         const bool noc_translation_enabled,
-        tt::umd::HarvestingMasks harvesting_masks,
+        HarvestingMasks harvesting_masks,
         const tt_xy_pair& tensix_grid_size,
         const std::vector<tt_xy_pair>& tensix_cores,
         const tt_xy_pair& dram_grid_size,
@@ -48,7 +51,7 @@ public:
     static std::shared_ptr<CoordinateManager> create_coordinate_manager(
         tt::ARCH arch,
         const bool noc_translation_enabled,
-        const tt::umd::HarvestingMasks harvesting_masks = {0, 0, 0},
+        const HarvestingMasks harvesting_masks = {0, 0, 0},
         const BoardType board_type = BoardType::UNKNOWN,
         const uint8_t asic_location = 0);
 
@@ -62,18 +65,18 @@ public:
     static uint32_t shuffle_tensix_harvesting_mask_to_noc0_coords(
         tt::ARCH arch, uint32_t tensix_harvesting_logical_layout);
 
-    tt::umd::CoreCoord translate_coord_to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const;
-    tt::umd::CoreCoord get_coord_at(const tt_xy_pair core, const CoordSystem coord_system) const;
-    tt::umd::CoreCoord translate_coord_to(
+    CoreCoord translate_coord_to(const CoreCoord core_coord, const CoordSystem coord_system) const;
+    CoreCoord get_coord_at(const tt_xy_pair core, const CoordSystem coord_system) const;
+    CoreCoord translate_coord_to(
         const tt_xy_pair core, const CoordSystem input_coord_system, const CoordSystem target_coord_system) const;
 
-    std::vector<tt::umd::CoreCoord> get_cores(const CoreType core_type) const;
+    std::vector<CoreCoord> get_cores(const CoreType core_type) const;
     tt_xy_pair get_grid_size(const CoreType core_type) const;
 
-    std::vector<tt::umd::CoreCoord> get_harvested_cores(const CoreType core_type) const;
+    std::vector<CoreCoord> get_harvested_cores(const CoreType core_type) const;
     tt_xy_pair get_harvested_grid_size(const CoreType core_type) const;
 
-    tt::umd::HarvestingMasks get_harvesting_masks() const;
+    HarvestingMasks get_harvesting_masks() const;
 
     uint32_t get_num_eth_channels() const;
 
@@ -81,7 +84,7 @@ public:
 
 private:
     const std::vector<tt_xy_pair>& get_physical_pairs(const CoreType core_type) const;
-    std::vector<tt::umd::CoreCoord> get_all_physical_cores(const CoreType core_type) const;
+    std::vector<CoreCoord> get_all_physical_cores(const CoreType core_type) const;
 
 protected:
     /*
@@ -94,7 +97,7 @@ protected:
      */
     CoordinateManager(
         const bool noc_translation_enabled,
-        const tt::umd::HarvestingMasks harvesting_masks,
+        const HarvestingMasks harvesting_masks,
         const tt_xy_pair& tensix_grid_size,
         const std::vector<tt_xy_pair>& tensix_cores,
         const tt_xy_pair& dram_grid_size,
@@ -124,17 +127,17 @@ protected:
     virtual void translate_l2cpu_coords();
 
     void identity_map_physical_cores();
-    void add_core_translation(const tt::umd::CoreCoord& core_coord, const tt_xy_pair& physical_pair);
+    void add_core_translation(const CoreCoord& core_coord, const tt_xy_pair& physical_pair);
     void add_noc1_to_noc0_mapping();
 
-    virtual std::vector<tt::umd::CoreCoord> get_tensix_cores() const;
-    virtual std::vector<tt::umd::CoreCoord> get_harvested_tensix_cores() const;
-    virtual std::vector<tt::umd::CoreCoord> get_dram_cores() const;
-    virtual std::vector<tt::umd::CoreCoord> get_harvested_dram_cores() const;
-    virtual std::vector<tt::umd::CoreCoord> get_eth_cores() const;
-    virtual std::vector<tt::umd::CoreCoord> get_harvested_eth_cores() const;
-    virtual std::vector<tt::umd::CoreCoord> get_pcie_cores() const;
-    virtual std::vector<tt::umd::CoreCoord> get_harvested_pcie_cores() const;
+    virtual std::vector<CoreCoord> get_tensix_cores() const;
+    virtual std::vector<CoreCoord> get_harvested_tensix_cores() const;
+    virtual std::vector<CoreCoord> get_dram_cores() const;
+    virtual std::vector<CoreCoord> get_harvested_dram_cores() const;
+    virtual std::vector<CoreCoord> get_eth_cores() const;
+    virtual std::vector<CoreCoord> get_harvested_eth_cores() const;
+    virtual std::vector<CoreCoord> get_pcie_cores() const;
+    virtual std::vector<CoreCoord> get_harvested_pcie_cores() const;
     virtual tt_xy_pair get_tensix_grid_size() const = 0;
     virtual tt_xy_pair get_dram_grid_size() const;
     virtual tt_xy_pair get_harvested_tensix_grid_size() const;
@@ -195,19 +198,19 @@ protected:
     virtual void fill_arc_physical_translated_mapping() = 0;
 
     // Maps full CoreCoord from any CoordSystem to physical coordinates.
-    std::map<tt::umd::CoreCoord, tt_xy_pair> to_physical_map;
+    std::map<CoreCoord, tt_xy_pair> to_physical_map;
     // Maps physical coordinates given a target CoordSystem to full CoreCoord.
-    std::map<std::pair<tt_xy_pair, CoordSystem>, tt::umd::CoreCoord> from_physical_map;
+    std::map<std::pair<tt_xy_pair, CoordSystem>, CoreCoord> from_physical_map;
     // Maps coordinates in the designated CoordSystem to a full CoreCoord at that location holding the right CoreType.
     // Doesn't include logical CoordSystem.
-    std::map<std::pair<tt_xy_pair, CoordSystem>, tt::umd::CoreCoord> to_core_type_map;
+    std::map<std::pair<tt_xy_pair, CoordSystem>, CoreCoord> to_core_type_map;
 
     // Whether NOC translation is enabled on chip.
     // This flag affects how Translated coords are calculated. If translation is enabled on the chip, than we can
     // interface it with a coordinate system which abstracts away harvested cores. If it is not enabled, then we need to
     // interface it with noc0 coordinates.
     bool noc_translation_enabled;
-    tt::umd::HarvestingMasks harvesting_masks;
+    HarvestingMasks harvesting_masks;
 
     tt_xy_pair tensix_grid_size;
     const std::vector<tt_xy_pair> tensix_cores;
@@ -234,3 +237,5 @@ protected:
     const std::vector<uint32_t> noc0_x_to_noc1_x;
     const std::vector<uint32_t> noc0_y_to_noc1_y;
 };
+
+}  // namespace tt::umd

--- a/device/api/umd/device/hugepage.h
+++ b/device/api/umd/device/hugepage.h
@@ -31,4 +31,5 @@ std::string find_hugepage_dir(std::size_t pagesize);
 // Today we assume there's only one pipeline running within the system.
 // One hugepage per device such that each device gets unique memory.
 int open_hugepage_file(const std::string &dir, chip_id_t physical_device_id, uint16_t channel);
+
 }  // namespace tt::umd

--- a/device/api/umd/device/pci_device.hpp
+++ b/device/api/umd/device/pci_device.hpp
@@ -217,3 +217,6 @@ public:
 };
 
 }  // namespace tt::umd
+
+// TODO: To be removed once clients switch to namespace usage.
+using tt::umd::PCIDevice;

--- a/device/api/umd/device/pci_device.hpp
+++ b/device/api/umd/device/pci_device.hpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <map>
+#include <memory>
 #include <unordered_map>
 #include <vector>
 
@@ -21,7 +22,6 @@
 
 namespace tt::umd {
 class semver_t;
-}  // namespace tt::umd
 
 struct PciDeviceInfo {
     uint16_t vendor_id;
@@ -35,9 +35,6 @@ struct PciDeviceInfo {
     // TODO: does it make sense to move attributes that we can read from sysfs
     // onto this struct as methods?  e.g. current_link_width etc.
 };
-
-// Do we want to put everything into this file into tt::umd namespace?
-using tt::umd::semver_t;
 
 struct DmaBuffer {
     uint8_t *buffer = nullptr;
@@ -174,8 +171,7 @@ public:
      * @param tlb_size Size of the TLB caller wants to allocate.
      * @param mapping_type Type of TLB mapping to allocate (UC or WC).
      */
-    std::unique_ptr<tt::umd::TlbHandle> allocate_tlb(
-        const size_t tlb_size, const tt::umd::TlbMapping tlb_mapping = tt::umd::TlbMapping::UC);
+    std::unique_ptr<TlbHandle> allocate_tlb(const size_t tlb_size, const TlbMapping tlb_mapping = TlbMapping::UC);
 
 public:
     // TODO: we can and should make all of these private.
@@ -219,3 +215,5 @@ public:
         return reinterpret_cast<T *>(static_cast<uint8_t *>(reg_mapping) + register_offset);
     }
 };
+
+}  // namespace tt::umd

--- a/device/api/umd/device/topology_discovery.h
+++ b/device/api/umd/device/topology_discovery.h
@@ -9,9 +9,9 @@
 #include "umd/device/tt_device/remote_wormhole_tt_device.h"
 #include "umd/device/tt_device/tt_device.h"
 
-class tt_ClusterDescriptor;
-
 namespace tt::umd {
+
+class tt_ClusterDescriptor;
 
 // TopologyDiscovery class creates cluster descriptor only for Wormhole configurations with old routing fw.
 // TODO: Move Blackhole topology discovery to this class.

--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -29,11 +29,10 @@ class Node;
 
 namespace tt::umd {
 class Cluster;
-}
 
 class tt_ClusterDescriptor {
-    friend class tt::umd::Cluster;
-    friend class tt::umd::TopologyDiscovery;
+    friend class Cluster;
+    friend class TopologyDiscovery;
 
 private:
     tt_ClusterDescriptor() = default;
@@ -93,7 +92,7 @@ protected:
 
     void verify_cluster_descriptor_info();
 
-    std::map<chip_id_t, tt::umd::HarvestingMasks> harvesting_masks_map = {};
+    std::map<chip_id_t, HarvestingMasks> harvesting_masks_map = {};
 
 public:
     /*
@@ -158,5 +157,7 @@ public:
     std::set<uint32_t> get_active_eth_channels(chip_id_t chip_id);
     std::set<uint32_t> get_idle_eth_channels(chip_id_t chip_id);
 
-    tt::umd::HarvestingMasks get_harvesting_masks(chip_id_t chip_id) const;
+    HarvestingMasks get_harvesting_masks(chip_id_t chip_id) const;
 };
+
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -161,3 +161,6 @@ public:
 };
 
 }  // namespace tt::umd
+
+// TODO: To be removed once clients switch to namespace usage.
+using tt::umd::tt_ClusterDescriptor;

--- a/device/api/umd/device/tt_core_coordinates.h
+++ b/device/api/umd/device/tt_core_coordinates.h
@@ -145,16 +145,20 @@ struct CoreCoord : public tt_xy_pair {
 
 }  // namespace tt::umd
 
-namespace std {
-template <>
-struct hash<tt::umd::CoreCoord> {
-    size_t operator()(const tt::umd::CoreCoord& core_coord) const {
-        size_t seed = 0;
-        seed = std::hash<size_t>{}(core_coord.x) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-        seed = std::hash<size_t>{}(core_coord.y) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-        seed = std::hash<tt::umd::CoreType>{}(core_coord.core_type) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-        seed = std::hash<tt::umd::CoordSystem>{}(core_coord.coord_system) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-        return seed;
-    }
-};
+// TODO: To be removed once clients switch to namespace usage.
+using tt::umd::CoreType;
+using tt::umd::CoordSystem
+
+    namespace std {
+    template <>
+    struct hash<tt::umd::CoreCoord> {
+        size_t operator()(const tt::umd::CoreCoord& core_coord) const {
+            size_t seed = 0;
+            seed = std::hash<size_t>{}(core_coord.x) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+            seed = std::hash<size_t>{}(core_coord.y) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+            seed = std::hash<tt::umd::CoreType>{}(core_coord.core_type) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+            seed = std::hash<tt::umd::CoordSystem>{}(core_coord.coord_system) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+            return seed;
+        }
+    };
 }  // namespace std

--- a/device/api/umd/device/tt_core_coordinates.h
+++ b/device/api/umd/device/tt_core_coordinates.h
@@ -10,8 +10,6 @@
 
 #include "umd/device/tt_xy_pair.h"
 
-namespace tt::umd {
-
 // For documentation on Coordinate systems, lookup docs/coordinate_systems.md
 
 /*
@@ -37,6 +35,7 @@ enum class CoreType {
     COUNT,
 };
 
+namespace tt::umd {
 /*
  * CoordSystem is an enum class that represents all types of coordinate
  * systems that can be used to represent a core's location.
@@ -147,7 +146,11 @@ struct CoreCoord : public tt_xy_pair {
 
 // TODO: To be removed once clients switch to namespace usage.
 using tt::umd::CoordSystem;
-using tt::umd::CoreType;
+
+namespace tt::umd {
+// We can't define CoreType originally in the tt::umd namespace, due to a forward declaration in tt_metal.
+using CoreType = ::CoreType;
+}  // namespace tt::umd
 
 namespace std {
 template <>
@@ -162,7 +165,3 @@ struct hash<tt::umd::CoreCoord> {
     }
 };
 }  // namespace std
-
-// TODO: To be removed once clients switch to namespace usage.
-// This uglyness is needed since there are forward declarations in tt_metal.
-#define CoreType tt::umd::CoreType

--- a/device/api/umd/device/tt_core_coordinates.h
+++ b/device/api/umd/device/tt_core_coordinates.h
@@ -10,6 +10,8 @@
 
 #include "umd/device/tt_xy_pair.h"
 
+namespace tt::umd {
+
 // For documentation on Coordinate systems, lookup docs/coordinate_systems.md
 
 /*
@@ -96,8 +98,6 @@ static inline std::string to_str(const CoordSystem coord_system) {
     }
 }
 
-namespace tt::umd {
-
 struct CoreCoord : public tt_xy_pair {
     CoreCoord() {}
 
@@ -138,8 +138,8 @@ struct CoreCoord : public tt_xy_pair {
     }
 
     std::string str() const {
-        return "CoreCoord: (" + std::to_string(x) + ", " + std::to_string(y) + ", " + ::to_str(core_type) + ", " +
-               ::to_str(coord_system) + ")";
+        return "CoreCoord: (" + std::to_string(x) + ", " + std::to_string(y) + ", " + to_str(core_type) + ", " +
+               to_str(coord_system) + ")";
     }
 };
 
@@ -152,8 +152,8 @@ struct hash<tt::umd::CoreCoord> {
         size_t seed = 0;
         seed = std::hash<size_t>{}(core_coord.x) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
         seed = std::hash<size_t>{}(core_coord.y) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-        seed = std::hash<CoreType>{}(core_coord.core_type) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-        seed = std::hash<CoordSystem>{}(core_coord.coord_system) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        seed = std::hash<tt::umd::CoreType>{}(core_coord.core_type) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        seed = std::hash<tt::umd::CoordSystem>{}(core_coord.coord_system) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
         return seed;
     }
 };

--- a/device/api/umd/device/tt_core_coordinates.h
+++ b/device/api/umd/device/tt_core_coordinates.h
@@ -146,19 +146,19 @@ struct CoreCoord : public tt_xy_pair {
 }  // namespace tt::umd
 
 // TODO: To be removed once clients switch to namespace usage.
+using tt::umd::CoordSystem;
 using tt::umd::CoreType;
-using tt::umd::CoordSystem
 
-    namespace std {
-    template <>
-    struct hash<tt::umd::CoreCoord> {
-        size_t operator()(const tt::umd::CoreCoord& core_coord) const {
-            size_t seed = 0;
-            seed = std::hash<size_t>{}(core_coord.x) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-            seed = std::hash<size_t>{}(core_coord.y) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-            seed = std::hash<tt::umd::CoreType>{}(core_coord.core_type) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-            seed = std::hash<tt::umd::CoordSystem>{}(core_coord.coord_system) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-            return seed;
-        }
-    };
+namespace std {
+template <>
+struct hash<tt::umd::CoreCoord> {
+    size_t operator()(const tt::umd::CoreCoord& core_coord) const {
+        size_t seed = 0;
+        seed = std::hash<size_t>{}(core_coord.x) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        seed = std::hash<size_t>{}(core_coord.y) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        seed = std::hash<tt::umd::CoreType>{}(core_coord.core_type) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        seed = std::hash<tt::umd::CoordSystem>{}(core_coord.coord_system) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        return seed;
+    }
+};
 }  // namespace std

--- a/device/api/umd/device/tt_core_coordinates.h
+++ b/device/api/umd/device/tt_core_coordinates.h
@@ -162,3 +162,7 @@ struct hash<tt::umd::CoreCoord> {
     }
 };
 }  // namespace std
+
+// TODO: To be removed once clients switch to namespace usage.
+// This uglyness is needed since there are forward declarations in tt_metal.
+#define CoreType tt::umd::CoreType

--- a/device/api/umd/device/tt_device/blackhole_tt_device.h
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.h
@@ -12,6 +12,7 @@
 #include "umd/device/tt_device/tt_device.h"
 
 namespace tt::umd {
+
 class BlackholeTTDevice : public TTDevice {
 public:
     BlackholeTTDevice(std::shared_ptr<PCIDevice> pci_device);
@@ -52,4 +53,5 @@ private:
     static constexpr uint64_t ATU_OFFSET_IN_BH_BAR2 = 0x1200;
     std::set<size_t> iatu_regions_;
 };
+
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/remote_blackhole_tt_device.h
+++ b/device/api/umd/device/tt_device/remote_blackhole_tt_device.h
@@ -9,8 +9,10 @@
 #include "umd/device/tt_device/blackhole_tt_device.h"
 
 namespace tt::umd {
+
 class RemoteBlackholeTTDevice : public BlackholeTTDevice {
 public:
     RemoteBlackholeTTDevice();
 };
+
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/remote_wormhole_tt_device.h
+++ b/device/api/umd/device/tt_device/remote_wormhole_tt_device.h
@@ -9,6 +9,7 @@
 #include "umd/device/tt_device/wormhole_tt_device.h"
 
 namespace tt::umd {
+
 class RemoteWormholeTTDevice : public WormholeTTDevice {
 public:
     RemoteWormholeTTDevice(LocalChip* local_chip, eth_coord_t target_chip);
@@ -28,4 +29,5 @@ private:
     eth_coord_t target_chip_;
     std::unique_ptr<RemoteCommunication> remote_communication_;
 };
+
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tlb_handle.h
+++ b/device/api/umd/device/tt_device/tlb_handle.h
@@ -63,4 +63,5 @@ private:
     uint32_t fd;
     TlbMapping tlb_mapping;
 };
+
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -15,6 +15,8 @@
 #include "umd/device/pci_device.hpp"
 #include "umd/device/types/cluster_descriptor_types.h"
 
+namespace tt::umd {
+
 // TODO: Should be moved to blackhole_architecture_implementation.h
 // See /vendor_ip/synopsys/052021/bh_pcie_ctl_gen5/export/configuration/DWC_pcie_ctl.h
 static const uint64_t UNROLL_ATU_OFFSET_BAR = 0x1200;
@@ -29,8 +31,6 @@ struct dynamic_tlb {
     uint64_t bar_offset;      // Offset that address is mapped to, within the PCI BAR.
     uint64_t remaining_size;  // Bytes remaining between bar_offset and end of the TLB.
 };
-
-namespace tt::umd {
 
 class ArcMessenger;
 class ArcTelemetryReader;
@@ -129,16 +129,13 @@ public:
         bool multicast,
         std::uint64_t ordering);
     dynamic_tlb set_dynamic_tlb(
-        unsigned int tlb_index,
-        tt_xy_pair target,
-        std::uint64_t address,
-        std::uint64_t ordering = tt::umd::tlb_data::Relaxed);
+        unsigned int tlb_index, tt_xy_pair target, std::uint64_t address, std::uint64_t ordering = tlb_data::Relaxed);
     dynamic_tlb set_dynamic_tlb_broadcast(
         unsigned int tlb_index,
         std::uint64_t address,
         tt_xy_pair start,
         tt_xy_pair end,
-        std::uint64_t ordering = tt::umd::tlb_data::Relaxed);
+        std::uint64_t ordering = tlb_data::Relaxed);
 
     /**
      * Configures a PCIe Address Translation Unit (iATU) region.
@@ -235,4 +232,5 @@ protected:
 
     bool is_remote_tt_device = false;
 };
+
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_io.hpp
+++ b/device/api/umd/device/tt_io.hpp
@@ -62,3 +62,8 @@ private:
 };
 
 }  // namespace tt::umd
+
+// TODO: To be removed once clients switch to namespace usage.
+namespace tt {
+using Writer = umd::Writer;
+}

--- a/device/api/umd/device/tt_io.hpp
+++ b/device/api/umd/device/tt_io.hpp
@@ -8,11 +8,9 @@
 #include <cstdint>
 #include <stdexcept>
 
-namespace tt {
+namespace tt::umd {
 
-namespace umd {
 class Cluster;
-}
 
 /**
  * @brief Provides write access to a SoC core via a statically-mapped TLB.
@@ -23,7 +21,7 @@ class Cluster;
  * It is the caller's responsibility to manage the lifetime of Writer objects.
  */
 class Writer {
-    friend class tt::umd::TLBManager;
+    friend class TLBManager;
 
 public:
     /**
@@ -49,7 +47,7 @@ public:
 
 private:
     /**
-     * @brief tt::umd::Cluster interface to construct a new Writer object.
+     * @brief Cluster interface to construct a new Writer object.
      *
      * @param base pointer to the base address of a mapped TLB.
      * @param tlb_size size of the mapped TLB.
@@ -63,4 +61,4 @@ private:
     size_t tlb_size{0};
 };
 
-}  // namespace tt
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_silicon_driver_common.hpp
+++ b/device/api/umd/device/tt_silicon_driver_common.hpp
@@ -58,3 +58,8 @@ static constexpr TensixSoftResetOptions TENSIX_DEASSERT_SOFT_RESET_NO_STAGGER =
     TensixSoftResetOptions::NCRISC | ALL_TRISC_SOFT_RESET;
 
 }  // namespace tt::umd
+
+// TODO: To be removed once clients switch to namespace usage.
+using tt::umd::TENSIX_ASSERT_SOFT_RESET;
+using tt::umd::TENSIX_DEASSERT_SOFT_RESET;
+using tt::umd::TensixSoftResetOptions;

--- a/device/api/umd/device/tt_silicon_driver_common.hpp
+++ b/device/api/umd/device/tt_silicon_driver_common.hpp
@@ -9,6 +9,8 @@
 #include <cstdint>
 #include <string>
 
+namespace tt::umd {
+
 enum class TensixSoftResetOptions : std::uint32_t {
     NONE = 0,
     BRISC = ((std::uint32_t)1 << 11),
@@ -54,3 +56,5 @@ static constexpr TensixSoftResetOptions TENSIX_DEASSERT_SOFT_RESET =
 
 static constexpr TensixSoftResetOptions TENSIX_DEASSERT_SOFT_RESET_NO_STAGGER =
     TensixSoftResetOptions::NCRISC | ALL_TRISC_SOFT_RESET;
+
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -101,3 +101,6 @@ private:
 };
 
 }  // namespace tt::umd
+
+// TODO: To be removed once clients switch to namespace usage.
+using tt::umd::tt_SimulationDeviceInit;

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -14,6 +14,8 @@
 #include "umd/device/cluster.h"
 #include "umd/device/tt_simulation_host.hpp"
 
+namespace tt::umd {
+
 class tt_SimulationDeviceInit {
 public:
     tt_SimulationDeviceInit(const std::filesystem::path& simulator_directory);
@@ -29,7 +31,7 @@ private:
     tt_SocDescriptor soc_descriptor;
 };
 
-class tt_SimulationDevice : public tt::umd::Chip {
+class tt_SimulationDevice : public Chip {
 public:
     tt_SimulationDevice(const std::filesystem::path& simulator_directory) :
         tt_SimulationDevice(tt_SimulationDeviceInit(simulator_directory)) {}
@@ -46,32 +48,32 @@ public:
     void start_device() override;
     void close_device() override;
 
-    tt::umd::TTDevice* get_tt_device() override;
-    tt::umd::SysmemManager* get_sysmem_manager() override;
-    tt::umd::TLBManager* get_tlb_manager() override;
+    TTDevice* get_tt_device() override;
+    SysmemManager* get_sysmem_manager() override;
+    TLBManager* get_tlb_manager() override;
 
     bool is_mmio_capable() const override { return false; }
 
-    void set_remote_transfer_ethernet_cores(const std::unordered_set<tt::umd::CoreCoord>& cores) override;
+    void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) override;
     void set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) override;
 
     // All tt_xy_pair cores in this class are defined in VIRTUAL coords.
-    void write_to_device(tt::umd::CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) override;
-    void read_from_device(tt::umd::CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) override;
-    void write_to_device_reg(tt::umd::CoreCoord core, const void* src, uint64_t reg_dest, uint32_t size) override;
-    void read_from_device_reg(tt::umd::CoreCoord core, void* dest, uint64_t reg_src, uint32_t size) override;
-    void dma_write_to_device(const void* src, size_t size, tt::umd::CoreCoord core, uint64_t addr) override;
-    void dma_read_from_device(void* dst, size_t size, tt::umd::CoreCoord core, uint64_t addr) override;
+    void write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) override;
+    void read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) override;
+    void write_to_device_reg(CoreCoord core, const void* src, uint64_t reg_dest, uint32_t size) override;
+    void read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_src, uint32_t size) override;
+    void dma_write_to_device(const void* src, size_t size, CoreCoord core, uint64_t addr) override;
+    void dma_read_from_device(void* dst, size_t size, CoreCoord core, uint64_t addr) override;
 
     std::function<void(uint32_t, uint32_t, const uint8_t*)> get_fast_pcie_static_tlb_write_callable() override;
 
     void wait_for_non_mmio_flush() override;
 
-    void l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
-    void dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores = {}) override;
+    void l1_membar(const std::unordered_set<CoreCoord>& cores = {}) override;
+    void dram_membar(const std::unordered_set<CoreCoord>& cores = {}) override;
     void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
 
-    void send_tensix_risc_reset(tt::umd::CoreCoord core, const TensixSoftResetOptions& soft_resets) override;
+    void send_tensix_risc_reset(CoreCoord core, const TensixSoftResetOptions& soft_resets) override;
     void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) override;
     void deassert_risc_resets() override;
 
@@ -97,3 +99,5 @@ private:
     std::shared_ptr<tt_ClusterDescriptor> cluster_descriptor;
     std::unordered_map<chip_id_t, tt_SocDescriptor> soc_descriptor_per_chip = {};
 };
+
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_simulation_host.hpp
+++ b/device/api/umd/device/tt_simulation_host.hpp
@@ -14,6 +14,8 @@
 typedef struct nng_socket_s nng_socket;
 typedef struct nng_dialer_s nng_dialer;
 
+namespace tt::umd {
+
 class tt_SimulationHost {
 public:
     tt_SimulationHost();
@@ -27,3 +29,5 @@ private:
     std::unique_ptr<nng_socket> host_socket;
     std::unique_ptr<nng_dialer> host_dialer;
 };
+
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -214,4 +214,5 @@ private:
 }  // namespace tt::umd
 
 // TODO: To be removed once clients switch to namespace usage.
+using tt::umd::CoreDescriptor;
 using tt::umd::tt_SocDescriptor;

--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -27,6 +27,8 @@ namespace YAML {
 class Node;
 }
 
+namespace tt::umd {
+
 std::string format_node(tt_xy_pair xy);
 
 tt_xy_pair format_node(std::string str);
@@ -73,21 +75,21 @@ public:
     tt_SocDescriptor(
         std::string device_descriptor_path,
         const bool noc_translation_enabled,
-        const tt::umd::HarvestingMasks harvesting_masks = {0, 0, 0},
+        const HarvestingMasks harvesting_masks = {0, 0, 0},
         const BoardType board_type = BoardType::UNKNOWN,
         const uint8_t asic_location = 0);
 
     tt_SocDescriptor(
         const tt::ARCH arch,
         const bool noc_translation_enabled,
-        const tt::umd::HarvestingMasks harvesting_masks = {0, 0, 0},
+        const HarvestingMasks harvesting_masks = {0, 0, 0},
         const BoardType board_type = BoardType::UNKNOWN,
         const uint8_t asic_location = 0);
 
     // CoreCoord conversions.
-    tt::umd::CoreCoord translate_coord_to(const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const;
-    tt::umd::CoreCoord get_coord_at(const tt_xy_pair core, const CoordSystem coord_system) const;
-    tt::umd::CoreCoord translate_coord_to(
+    CoreCoord translate_coord_to(const CoreCoord core_coord, const CoordSystem coord_system) const;
+    CoreCoord get_coord_at(const tt_xy_pair core, const CoordSystem coord_system) const;
+    CoreCoord translate_coord_to(
         const tt_xy_pair core_location,
         const CoordSystem input_coord_system,
         const CoordSystem target_coord_system) const;
@@ -99,19 +101,18 @@ public:
 
     static std::string get_soc_descriptor_path(tt::ARCH arch);
 
-    std::vector<tt::umd::CoreCoord> get_cores(
+    std::vector<CoreCoord> get_cores(
         const CoreType core_type, const CoordSystem coord_system = CoordSystem::PHYSICAL) const;
-    std::vector<tt::umd::CoreCoord> get_harvested_cores(
+    std::vector<CoreCoord> get_harvested_cores(
         const CoreType core_type, const CoordSystem coord_system = CoordSystem::PHYSICAL) const;
-    std::vector<tt::umd::CoreCoord> get_all_cores(const CoordSystem coord_system = CoordSystem::PHYSICAL) const;
-    std::vector<tt::umd::CoreCoord> get_all_harvested_cores(
-        const CoordSystem coord_system = CoordSystem::PHYSICAL) const;
+    std::vector<CoreCoord> get_all_cores(const CoordSystem coord_system = CoordSystem::PHYSICAL) const;
+    std::vector<CoreCoord> get_all_harvested_cores(const CoordSystem coord_system = CoordSystem::PHYSICAL) const;
 
     tt_xy_pair get_grid_size(const CoreType core_type) const;
     tt_xy_pair get_harvested_grid_size(const CoreType core_type) const;
 
-    std::vector<std::vector<tt::umd::CoreCoord>> get_dram_cores() const;
-    std::vector<std::vector<tt::umd::CoreCoord>> get_harvested_dram_cores() const;
+    std::vector<std::vector<CoreCoord>> get_dram_cores() const;
+    std::vector<std::vector<CoreCoord>> get_harvested_dram_cores() const;
 
     int get_num_dram_channels() const;
 
@@ -120,10 +121,9 @@ public:
 
     // LOGICAL coordinates for DRAM and ETH are tightly coupled with channels, so this code is very similar to what
     // would translate_coord_to do for a coord with LOGICAL coords.
-    tt::umd::CoreCoord get_dram_core_for_channel(
+    CoreCoord get_dram_core_for_channel(
         int dram_chan, int subchannel, const CoordSystem coord_system = CoordSystem::PHYSICAL) const;
-    tt::umd::CoreCoord get_eth_core_for_channel(
-        int eth_chan, const CoordSystem coord_system = CoordSystem::PHYSICAL) const;
+    CoreCoord get_eth_core_for_channel(int eth_chan, const CoordSystem coord_system = CoordSystem::PHYSICAL) const;
 
     tt::ARCH arch;
     tt_xy_pair grid_size;
@@ -149,7 +149,7 @@ public:
     //   - Eth harvesting mask "2" would mean that the second core in eth_cores in soc descriptor is harvested, which
     //     is the same one that would be reported as channel 1 and would have logical coords (0, 1). This mask doesn't
     //     mean that the second core in NOC0 chain is harvested.
-    tt::umd::HarvestingMasks harvesting_masks;
+    HarvestingMasks harvesting_masks;
 
 private:
     void create_coordinate_manager(const BoardType board_type, const uint8_t asic_location);
@@ -166,15 +166,15 @@ private:
     static SocDescriptorInfo get_soc_descriptor_info(tt::ARCH arch);
 
     static tt_xy_pair calculate_grid_size(const std::vector<tt_xy_pair> &cores);
-    std::vector<tt::umd::CoreCoord> translate_coordinates(
-        const std::vector<tt::umd::CoreCoord> &physical_cores, const CoordSystem coord_system) const;
+    std::vector<CoreCoord> translate_coordinates(
+        const std::vector<CoreCoord> &physical_cores, const CoordSystem coord_system) const;
 
     static std::filesystem::path get_default_soc_descriptor_file_path();
 
     // Since including yaml-cpp/yaml.h here breaks metal build we use void* type instead of YAML::Emitter
-    void write_coords(void *out, const tt::umd::CoreCoord &core) const;
+    void write_coords(void *out, const CoreCoord &core) const;
     void write_core_locations(void *out, const CoreType &core_type) const;
-    void serialize_dram_cores(void *out, const std::vector<std::vector<tt::umd::CoreCoord>> &cores) const;
+    void serialize_dram_cores(void *out, const std::vector<std::vector<CoreCoord>> &cores) const;
 
     // Internal structures, read from yaml.
     tt_xy_pair worker_grid_size;
@@ -200,16 +200,15 @@ private:
     // is not needed anymore. Soc descriptor and coordinate manager should be
     // created once per chip.
     std::shared_ptr<CoordinateManager> coordinate_manager = nullptr;
-    std::map<CoreType, std::vector<tt::umd::CoreCoord>> cores_map;
+    std::map<CoreType, std::vector<CoreCoord>> cores_map;
     std::map<CoreType, tt_xy_pair> grid_size_map;
-    std::map<CoreType, std::vector<tt::umd::CoreCoord>> harvested_cores_map;
+    std::map<CoreType, std::vector<CoreCoord>> harvested_cores_map;
     std::map<CoreType, tt_xy_pair> harvested_grid_size_map;
 
     // DRAM cores are kept in additional vector struct since one DRAM bank
     // has multiple NOC endpoints, so some UMD clients prefer vector of vectors returned.
-    std::vector<std::vector<tt::umd::CoreCoord>> dram_cores_core_coord;
-    std::vector<std::vector<tt::umd::CoreCoord>> harvested_dram_cores_core_coord;
+    std::vector<std::vector<CoreCoord>> dram_cores_core_coord;
+    std::vector<std::vector<CoreCoord>> harvested_dram_cores_core_coord;
 };
 
-// Allocates a new soc descriptor on the heap. Returns an owning pointer.
-// std::unique_ptr<tt_SocDescriptor> load_soc_descriptor_from_yaml(std::string device_descriptor_file_path);
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_soc_descriptor.h
+++ b/device/api/umd/device/tt_soc_descriptor.h
@@ -212,3 +212,6 @@ private:
 };
 
 }  // namespace tt::umd
+
+// TODO: To be removed once clients switch to namespace usage.
+using tt::umd::tt_SocDescriptor;

--- a/device/api/umd/device/tt_xy_pair.h
+++ b/device/api/umd/device/tt_xy_pair.h
@@ -5,11 +5,4 @@
  */
 
 #pragma once
-
-#include <regex>
-
 #include "umd/device/types/xy_pair.h"
-
-// TODO: These usings and this whole file are to be removed.
-using tt_xy_pair = tt::umd::xy_pair;
-using tt_cxy_pair = tt::umd::cxy_pair;

--- a/device/api/umd/device/types/cluster_descriptor_types.h
+++ b/device/api/umd/device/types/cluster_descriptor_types.h
@@ -15,6 +15,21 @@
 #include "umd/device/semver.hpp"
 #include "umd/device/types/harvesting.h"
 
+// TODO: To be moved inside tt::umd namespace once all clients switch to namespace usage.
+enum BoardType : uint32_t {
+    E75,
+    E150,
+    E300,
+    N150,
+    N300,
+    P100,
+    P150,
+    P300,
+    GALAXY,
+    UBB,
+    UNKNOWN,
+};
+
 namespace tt::umd {
 
 // Small performant hash combiner taken from boost library.
@@ -40,20 +55,6 @@ struct eth_coord_t {
             cluster_id == other.cluster_id and x == other.x and y == other.y and rack == other.rack and
             shelf == other.shelf);
     }
-};
-
-enum BoardType : uint32_t {
-    E75,
-    E150,
-    E300,
-    N150,
-    N300,
-    P100,
-    P150,
-    P300,
-    GALAXY,
-    UBB,
-    UNKNOWN,
 };
 
 inline std::string board_type_to_string(const BoardType board_type) {
@@ -196,6 +197,10 @@ enum class DramTrainingStatus : uint8_t {
 using tt::umd::chip_id_t;
 using tt::umd::eth_coord_t;
 using tt::umd::ethernet_channel_t;
+
+namespace tt::umd {
+using BoardType = ::BoardType;
+}
 
 namespace std {
 template <>

--- a/device/api/umd/device/types/cluster_descriptor_types.h
+++ b/device/api/umd/device/types/cluster_descriptor_types.h
@@ -194,6 +194,8 @@ enum class DramTrainingStatus : uint8_t {
 
 // TODO: To be removed once clients switch to namespace usage.
 using tt::umd::chip_id_t;
+using tt::umd::eth_coord_t;
+using tt::umd::ethernet_channel_t;
 
 namespace std {
 template <>

--- a/device/api/umd/device/types/cluster_descriptor_types.h
+++ b/device/api/umd/device/types/cluster_descriptor_types.h
@@ -192,6 +192,9 @@ enum class DramTrainingStatus : uint8_t {
 
 }  // namespace tt::umd
 
+// TODO: To be removed once clients switch to namespace usage.
+using tt::umd::chip_id_t;
+
 namespace std {
 template <>
 struct hash<tt::umd::eth_coord_t> {

--- a/device/api/umd/device/types/cluster_descriptor_types.h
+++ b/device/api/umd/device/types/cluster_descriptor_types.h
@@ -15,6 +15,8 @@
 #include "umd/device/semver.hpp"
 #include "umd/device/types/harvesting.h"
 
+namespace tt::umd {
+
 // Small performant hash combiner taken from boost library.
 // Not using boost::hash_combine due to dependency complications.
 inline void boost_hash_combine(std::size_t &seed, const int value) {
@@ -175,11 +177,11 @@ struct ChipUID {
 };
 
 struct ChipInfo {
-    tt::umd::HarvestingMasks harvesting_masks;
+    HarvestingMasks harvesting_masks;
     BoardType board_type;
     ChipUID chip_uid;
     bool noc_translation_enabled;
-    tt::umd::semver_t firmware_version = {0, 0, 0};
+    semver_t firmware_version = {0, 0, 0};
 };
 
 enum class DramTrainingStatus : uint8_t {
@@ -188,16 +190,18 @@ enum class DramTrainingStatus : uint8_t {
     SUCCESS = 2,
 };
 
+}  // namespace tt::umd
+
 namespace std {
 template <>
-struct hash<eth_coord_t> {
-    std::size_t operator()(eth_coord_t const &c) const {
+struct hash<tt::umd::eth_coord_t> {
+    std::size_t operator()(tt::umd::eth_coord_t const &c) const {
         std::size_t seed = 0;
-        boost_hash_combine(seed, c.cluster_id);
-        boost_hash_combine(seed, c.x);
-        boost_hash_combine(seed, c.y);
-        boost_hash_combine(seed, c.rack);
-        boost_hash_combine(seed, c.shelf);
+        tt::umd::boost_hash_combine(seed, c.cluster_id);
+        tt::umd::boost_hash_combine(seed, c.x);
+        tt::umd::boost_hash_combine(seed, c.y);
+        tt::umd::boost_hash_combine(seed, c.rack);
+        tt::umd::boost_hash_combine(seed, c.shelf);
         return seed;
     }
 };

--- a/device/api/umd/device/types/cluster_types.h
+++ b/device/api/umd/device/types/cluster_types.h
@@ -12,6 +12,8 @@
 
 #include "fmt/core.h"
 
+namespace tt::umd {
+
 enum tt_DevicePowerState { BUSY, SHORT_IDLE, LONG_IDLE };
 
 enum tt_MemBarFlag {
@@ -219,3 +221,5 @@ struct hugepage_mapping {
     size_t mapping_size = 0;
     uint64_t physical_address = 0;  // or IOVA, if IOMMU is enabled
 };
+
+}  // namespace tt::umd

--- a/device/api/umd/device/types/tlb.h
+++ b/device/api/umd/device/types/tlb.h
@@ -63,3 +63,6 @@ enum TlbMapping : uint8_t {
 };
 
 }  // namespace tt::umd
+
+// TODO: To be removed once clients switch to namespace usage.
+using TLB_DATA = tt::umd::tlb_data;

--- a/device/api/umd/device/types/xy_pair.h
+++ b/device/api/umd/device/types/xy_pair.h
@@ -55,6 +55,10 @@ constexpr inline bool operator<(const cxy_pair &left, const cxy_pair &right) {
 
 }  // namespace tt::umd
 
+// These are convenience typedefs for the xy_pair and cxy_pair types.
+using tt_xy_pair = tt::umd::xy_pair;
+using tt_cxy_pair = tt::umd::cxy_pair;
+
 namespace std {
 template <>
 struct hash<tt::umd::xy_pair> {

--- a/device/api/umd/device/types/xy_pair.h
+++ b/device/api/umd/device/types/xy_pair.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <string>
+// TODO: To be removed once this is fixed in tt_metal
+#include <deque>
 
 namespace tt::umd {
 

--- a/device/api/umd/device/wormhole_arc_telemetry_reader.h
+++ b/device/api/umd/device/wormhole_arc_telemetry_reader.h
@@ -29,11 +29,10 @@ private:
     uint64_t telemetry_base_noc_addr;
 
     // During initialization of telemetry, if the NOC0 is hung then we need to read the telemetry values from NOC1.
-    const tt_xy_pair arc_core = !umd_use_noc1
-                                    ? tt::umd::wormhole::ARC_CORES_NOC0[0]
-                                    : tt_xy_pair(
-                                          tt::umd::wormhole::NOC0_X_TO_NOC1_X[tt::umd::wormhole::ARC_CORES_NOC0[0].x],
-                                          tt::umd::wormhole::NOC0_Y_TO_NOC1_Y[tt::umd::wormhole::ARC_CORES_NOC0[0].y]);
+    const tt_xy_pair arc_core = !umd_use_noc1 ? wormhole::ARC_CORES_NOC0[0]
+                                              : tt_xy_pair(
+                                                    wormhole::NOC0_X_TO_NOC1_X[wormhole::ARC_CORES_NOC0[0].x],
+                                                    wormhole::NOC0_Y_TO_NOC1_Y[wormhole::ARC_CORES_NOC0[0].y]);
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/wormhole_coordinate_manager.h
+++ b/device/api/umd/device/wormhole_coordinate_manager.h
@@ -9,11 +9,13 @@
 #include "umd/device/coordinate_manager.h"
 #include "umd/device/wormhole_implementation.h"
 
+namespace tt::umd {
+
 class WormholeCoordinateManager : public CoordinateManager {
 public:
     WormholeCoordinateManager(
         const bool noc_translation_enabled,
-        tt::umd::HarvestingMasks harvesting_masks,
+        HarvestingMasks harvesting_masks,
         const tt_xy_pair& tensix_grid_size,
         const std::vector<tt_xy_pair>& tensix_cores,
         const tt_xy_pair& dram_grid_size,
@@ -38,3 +40,5 @@ protected:
 
     tt_xy_pair get_tensix_grid_size() const override;
 };
+
+}  // namespace tt::umd

--- a/device/blackhole/blackhole_arc_message_queue.cpp
+++ b/device/blackhole/blackhole_arc_message_queue.cpp
@@ -116,8 +116,7 @@ uint32_t BlackholeArcMessageQueue::send_message(
 
 std::unique_ptr<BlackholeArcMessageQueue> BlackholeArcMessageQueue::get_blackhole_arc_message_queue(
     TTDevice* tt_device, const size_t queue_index) {
-    const tt_xy_pair arc_core =
-        tt::umd::blackhole::get_arc_core(tt_device->get_noc_translation_enabled(), umd_use_noc1);
+    const tt_xy_pair arc_core = blackhole::get_arc_core(tt_device->get_noc_translation_enabled(), umd_use_noc1);
 
     uint32_t queue_control_block_addr;
     tt_device->read_from_device(&queue_control_block_addr, arc_core, blackhole::SCRATCH_RAM_11, sizeof(uint32_t));
@@ -132,8 +131,7 @@ std::unique_ptr<BlackholeArcMessageQueue> BlackholeArcMessageQueue::get_blackhol
     uint32_t msg_queue_size = 2 * num_entries_per_queue * ARC_QUEUE_ENTRY_SIZE + ARC_MSG_QUEUE_HEADER_SIZE;
     uint32_t msg_queue_base = queue_base_addr + queue_index * msg_queue_size;
 
-    return std::make_unique<tt::umd::BlackholeArcMessageQueue>(
-        tt_device, msg_queue_base, num_entries_per_queue, arc_core);
+    return std::make_unique<BlackholeArcMessageQueue>(tt_device, msg_queue_base, num_entries_per_queue, arc_core);
 }
 
 }  // namespace tt::umd

--- a/device/blackhole/blackhole_arc_telemetry_reader.cpp
+++ b/device/blackhole/blackhole_arc_telemetry_reader.cpp
@@ -20,11 +20,11 @@ BlackholeArcTelemetryReader::BlackholeArcTelemetryReader(TTDevice* tt_device) :
 }
 
 void BlackholeArcTelemetryReader::initialize_telemetry() {
-    tt_device->read_from_device(&telemetry_table_addr, arc_core, tt::umd::blackhole::SCRATCH_RAM_13, sizeof(uint32_t));
+    tt_device->read_from_device(&telemetry_table_addr, arc_core, blackhole::SCRATCH_RAM_13, sizeof(uint32_t));
 
     tt_device->read_from_device(&entry_count, arc_core, telemetry_table_addr + sizeof(uint32_t), sizeof(uint32_t));
 
-    tt_device->read_from_device(&telemetry_values_addr, arc_core, tt::umd::blackhole::SCRATCH_RAM_12, sizeof(uint32_t));
+    tt_device->read_from_device(&telemetry_values_addr, arc_core, blackhole::SCRATCH_RAM_12, sizeof(uint32_t));
 
     // We offset the tag_table_address by 2 * sizeof(uint32_t) to skip the first two uint32_t values,
     // which are version and entry count. For representaiton look at blackhole_telemetry.h

--- a/device/blackhole/blackhole_coordinate_manager.cpp
+++ b/device/blackhole/blackhole_coordinate_manager.cpp
@@ -7,7 +7,7 @@
 
 #include <tt-logger/tt-logger.hpp>
 
-using namespace tt::umd;
+namespace tt::umd {
 
 BlackholeCoordinateManager::BlackholeCoordinateManager(
     const bool noc_translation_enabled,
@@ -73,10 +73,10 @@ void BlackholeCoordinateManager::translate_tensix_coords() {
         if (harvesting_masks.tensix_harvesting_mask & (1 << x)) {
             const tt_xy_pair& physical_core = tensix_cores[x];
             const size_t die_x_index = std::find(
-                                           tt::umd::blackhole::HARVESTING_NOC_LOCATIONS.begin(),
-                                           tt::umd::blackhole::HARVESTING_NOC_LOCATIONS.end(),
+                                           blackhole::HARVESTING_NOC_LOCATIONS.begin(),
+                                           blackhole::HARVESTING_NOC_LOCATIONS.end(),
                                            physical_core.x) -
-                                       tt::umd::blackhole::HARVESTING_NOC_LOCATIONS.begin();
+                                       blackhole::HARVESTING_NOC_LOCATIONS.begin();
             die_harvested_tensix_columns.push_back(std::make_pair(die_x_index, x));
         } else {
             for (size_t y = 0; y < grid_size_y; y++) {
@@ -569,3 +569,5 @@ tt_xy_pair BlackholeCoordinateManager::get_dram_grid_size() const {
         dram_grid_size.x - CoordinateManager::get_num_harvested(harvesting_masks.dram_harvesting_mask),
         dram_grid_size.y};
 }
+
+}  // namespace tt::umd

--- a/device/blackhole/blackhole_implementation.cpp
+++ b/device/blackhole/blackhole_implementation.cpp
@@ -119,10 +119,10 @@ uint64_t blackhole_implementation::get_noc_reg_base(
 namespace blackhole {
 tt_xy_pair get_arc_core(const bool noc_translation_enabled, const bool umd_use_noc1) {
     return (noc_translation_enabled || !umd_use_noc1)
-               ? tt::umd::blackhole::ARC_CORES_NOC0[0]
+               ? blackhole::ARC_CORES_NOC0[0]
                : tt_xy_pair(
-                     tt::umd::blackhole::NOC0_X_TO_NOC1_X[tt::umd::blackhole::ARC_CORES_NOC0[0].x],
-                     tt::umd::blackhole::NOC0_Y_TO_NOC1_Y[tt::umd::blackhole::ARC_CORES_NOC0[0].y]);
+                     blackhole::NOC0_X_TO_NOC1_X[blackhole::ARC_CORES_NOC0[0].x],
+                     blackhole::NOC0_Y_TO_NOC1_Y[blackhole::ARC_CORES_NOC0[0].y]);
 }
 }  // namespace blackhole
 

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -28,7 +28,7 @@ tt_SocDescriptor& Chip::get_soc_descriptor() { return soc_descriptor_; }
 
 // TODO: This will be moved to LocalChip.
 void Chip::set_default_params(ARCH arch) {
-    auto architecture_implementation = tt::umd::architecture_implementation::create(arch);
+    auto architecture_implementation = architecture_implementation::create(arch);
 
     // Default initialize l1_address_params based on detected arch
     l1_address_params = architecture_implementation->get_l1_address_params();
@@ -84,7 +84,7 @@ void Chip::enable_ethernet_queue(int timeout_s) {
 void Chip::send_tensix_risc_reset(CoreCoord core, const TensixSoftResetOptions& soft_resets) {
     auto valid = soft_resets & ALL_TENSIX_SOFT_RESET;
     uint32_t valid_val = (std::underlying_type<TensixSoftResetOptions>::type)valid;
-    auto architecture_implementation = tt::umd::architecture_implementation::create(get_tt_device()->get_arch());
+    auto architecture_implementation = architecture_implementation::create(get_tt_device()->get_arch());
     write_to_device_reg(core, &valid_val, architecture_implementation->get_tensix_soft_reset_addr(), sizeof(uint32_t));
     tt_driver_atomics::sfence();
 }
@@ -97,7 +97,7 @@ void Chip::send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) {
 
 void Chip::set_tensix_risc_reset(CoreCoord core, const TensixSoftResetOptions& selected_riscs) {
     uint32_t tensix_risc_state = 0x00000000;
-    auto architecture_implementation = tt::umd::architecture_implementation::create(get_tt_device()->get_arch());
+    auto architecture_implementation = architecture_implementation::create(get_tt_device()->get_arch());
     read_from_device_reg(
         core, &tensix_risc_state, architecture_implementation->get_tensix_soft_reset_addr(), sizeof(uint32_t));
     TensixSoftResetOptions set_selected_riscs = static_cast<TensixSoftResetOptions>(tensix_risc_state) | selected_riscs;
@@ -106,7 +106,7 @@ void Chip::set_tensix_risc_reset(CoreCoord core, const TensixSoftResetOptions& s
 
 void Chip::unset_tensix_risc_reset(CoreCoord core, const TensixSoftResetOptions& selected_riscs) {
     uint32_t tensix_risc_state = 0x00000000;
-    auto architecture_implementation = tt::umd::architecture_implementation::create(get_tt_device()->get_arch());
+    auto architecture_implementation = architecture_implementation::create(get_tt_device()->get_arch());
     read_from_device_reg(
         core, &tensix_risc_state, architecture_implementation->get_tensix_soft_reset_addr(), sizeof(uint32_t));
     TensixSoftResetOptions set_selected_riscs =

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -337,8 +337,8 @@ void LocalChip::write_to_device_reg(CoreCoord core, const void* src, uint64_t re
     auto lock = lock_manager_.acquire_mutex(fallback_tlb, tt_device_->get_pci_device()->get_device_num());
     log_debug(LogSiliconDriver, "  dynamic tlb_index: {}", tlb_index);
 
-    auto [mapped_address, tlb_size] = tt_device_->set_dynamic_tlb(
-        tlb_index, translate_chip_coord_to_translated(core), reg_dest, tt::umd::tlb_data::Strict);
+    auto [mapped_address, tlb_size] =
+        tt_device_->set_dynamic_tlb(tlb_index, translate_chip_coord_to_translated(core), reg_dest, tlb_data::Strict);
     tt_device_->write_regs(mapped_address, size / sizeof(uint32_t), src);
 }
 
@@ -356,8 +356,8 @@ void LocalChip::read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_sr
     auto lock = lock_manager_.acquire_mutex(fallback_tlb, tt_device_->get_pci_device()->get_device_num());
     log_debug(LogSiliconDriver, "  dynamic tlb_index: {}", tlb_index);
 
-    auto [mapped_address, tlb_size] = tt_device_->set_dynamic_tlb(
-        tlb_index, translate_chip_coord_to_translated(core), reg_src, tt::umd::tlb_data::Strict);
+    auto [mapped_address, tlb_size] =
+        tt_device_->set_dynamic_tlb(tlb_index, translate_chip_coord_to_translated(core), reg_src, tlb_data::Strict);
     tt_device_->read_regs(mapped_address, size / sizeof(uint32_t), dest);
 }
 
@@ -572,7 +572,7 @@ void LocalChip::insert_host_to_device_barrier(const std::vector<CoreCoord>& core
     set_membar_flag(cores, tt_MemBarFlag::RESET, barrier_addr);
 }
 
-void LocalChip::l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) {
+void LocalChip::l1_membar(const std::unordered_set<CoreCoord>& cores) {
     if (cores.size()) {
         // Insert barrier on specific cores with L1
         std::vector<CoreCoord> workers_to_sync = {};
@@ -600,7 +600,7 @@ void LocalChip::l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) {
     }
 }
 
-void LocalChip::dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) {
+void LocalChip::dram_membar(const std::unordered_set<CoreCoord>& cores) {
     if (cores.size()) {
         for (const auto& core : cores) {
             TT_ASSERT(
@@ -645,11 +645,11 @@ void LocalChip::set_power_state(tt_DevicePowerState state) {
         exit_code = arc_msg(wormhole::ARC_MSG_COMMON_PREFIX | msg, true, 0, 0);
     } else if (soc_descriptor_.arch == tt::ARCH::BLACKHOLE) {
         if (state == tt_DevicePowerState::BUSY) {
-            exit_code = tt_device_->get_arc_messenger()->send_message(
-                (uint32_t)tt::umd::blackhole::ArcMessageType::AICLK_GO_BUSY);
+            exit_code =
+                tt_device_->get_arc_messenger()->send_message((uint32_t)blackhole::ArcMessageType::AICLK_GO_BUSY);
         } else {
-            exit_code = tt_device_->get_arc_messenger()->send_message(
-                (uint32_t)tt::umd::blackhole::ArcMessageType::AICLK_GO_LONG_IDLE);
+            exit_code =
+                tt_device_->get_arc_messenger()->send_message((uint32_t)blackhole::ArcMessageType::AICLK_GO_LONG_IDLE);
         }
     }
     TT_ASSERT(exit_code == 0, "Failed to set power state to {} with exit code: {}", (int)state, exit_code);

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -64,9 +64,9 @@ void RemoteChip::wait_for_non_mmio_flush() {
     remote_communication_->wait_for_non_mmio_flush();
 }
 
-void RemoteChip::l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) { wait_for_non_mmio_flush(); }
+void RemoteChip::l1_membar(const std::unordered_set<CoreCoord>& cores) { wait_for_non_mmio_flush(); }
 
-void RemoteChip::dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) { wait_for_non_mmio_flush(); }
+void RemoteChip::dram_membar(const std::unordered_set<CoreCoord>& cores) { wait_for_non_mmio_flush(); }
 
 void RemoteChip::dram_membar(const std::unordered_set<uint32_t>& channels) { wait_for_non_mmio_flush(); }
 
@@ -102,7 +102,7 @@ int RemoteChip::get_numa_node() {
     throw std::runtime_error("RemoteChip::get_numa_node is not available for this chip.");
 }
 
-void RemoteChip::set_remote_transfer_ethernet_cores(const std::unordered_set<tt::umd::CoreCoord>& cores) {}
+void RemoteChip::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) {}
 
 void RemoteChip::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channel) {}
 

--- a/device/chip_helpers/sysmem_manager.cpp
+++ b/device/chip_helpers/sysmem_manager.cpp
@@ -9,6 +9,7 @@
 #include <sys/mman.h>  // for mmap, munmap
 #include <sys/stat.h>  // for fstat
 
+#include <filesystem>
 #include <fstream>
 #include <tt-logger/tt-logger.hpp>
 

--- a/device/chip_helpers/tlb_manager.cpp
+++ b/device/chip_helpers/tlb_manager.cpp
@@ -85,7 +85,7 @@ bool TLBManager::is_tlb_mapped(tt_xy_pair core, uint64_t address, uint32_t size_
     return address_in_tlb_space(address, size_in_bytes, tlb_index, tlb_description.size);
 }
 
-tt::Writer TLBManager::get_static_tlb_writer(tt_xy_pair core) {
+Writer TLBManager::get_static_tlb_writer(tt_xy_pair core) {
     if (!is_tlb_mapped(core)) {
         throw std::runtime_error(fmt::format("TLBs not initialized for core: {}", core.str()));
     }
@@ -99,7 +99,7 @@ tt::Writer TLBManager::get_static_tlb_writer(tt_xy_pair core) {
 
     auto* base = reinterpret_cast<uint8_t*>(tt_device_->get_pci_device()->bar0_wc);
 
-    return tt::Writer(base + tlb_data.tlb_offset, tlb_data.size);
+    return Writer(base + tlb_data.tlb_offset, tlb_data.size);
 }
 
 tlb_configuration TLBManager::get_tlb_configuration(tt_xy_pair core) {

--- a/device/coordinate_manager.cpp
+++ b/device/coordinate_manager.cpp
@@ -12,7 +12,7 @@
 #include "umd/device/blackhole_coordinate_manager.h"
 #include "umd/device/wormhole_coordinate_manager.h"
 
-using namespace tt::umd;
+namespace tt::umd {
 
 CoordinateManager::CoordinateManager(
     const bool noc_translation_enabled,
@@ -391,7 +391,7 @@ HarvestingMasks CoordinateManager::get_harvesting_masks() const { return harvest
 
 uint32_t CoordinateManager::shuffle_tensix_harvesting_mask(tt::ARCH arch, uint32_t tensix_harvesting_physical_layout) {
     std::vector<uint32_t> harvesting_locations =
-        tt::umd::architecture_implementation::create(arch)->get_harvesting_noc_locations();
+        architecture_implementation::create(arch)->get_harvesting_noc_locations();
 
     std::vector<uint32_t> sorted_harvesting_locations = harvesting_locations;
     std::sort(sorted_harvesting_locations.begin(), sorted_harvesting_locations.end());
@@ -415,7 +415,7 @@ uint32_t CoordinateManager::shuffle_tensix_harvesting_mask(tt::ARCH arch, uint32
 uint32_t CoordinateManager::shuffle_tensix_harvesting_mask_to_noc0_coords(
     tt::ARCH arch, uint32_t tensix_harvesting_logical_layout) {
     std::vector<uint32_t> sorted_harvesting_locations =
-        tt::umd::architecture_implementation::create(arch)->get_harvesting_noc_locations();
+        architecture_implementation::create(arch)->get_harvesting_noc_locations();
 
     std::sort(sorted_harvesting_locations.begin(), sorted_harvesting_locations.end());
     size_t new_harvesting_mask = 0;
@@ -508,7 +508,7 @@ std::vector<CoreCoord> CoordinateManager::get_pcie_cores() const { return get_al
 
 std::vector<CoreCoord> CoordinateManager::get_harvested_pcie_cores() const { return {}; }
 
-std::vector<tt::umd::CoreCoord> CoordinateManager::get_cores(const CoreType core_type) const {
+std::vector<CoreCoord> CoordinateManager::get_cores(const CoreType core_type) const {
     switch (core_type) {
         case CoreType::TENSIX:
             return get_tensix_cores();
@@ -545,7 +545,7 @@ tt_xy_pair CoordinateManager::get_grid_size(const CoreType core_type) const {
     }
 }
 
-std::vector<tt::umd::CoreCoord> CoordinateManager::get_harvested_cores(const CoreType core_type) const {
+std::vector<CoreCoord> CoordinateManager::get_harvested_cores(const CoreType core_type) const {
     switch (core_type) {
         case CoreType::TENSIX:
             return get_harvested_tensix_cores();
@@ -605,40 +605,40 @@ std::shared_ptr<CoordinateManager> CoordinateManager::create_coordinate_manager(
                 arch,
                 noc_translation_enabled,
                 harvesting_masks,
-                tt::umd::wormhole::TENSIX_GRID_SIZE,
-                tt::umd::wormhole::TENSIX_CORES_NOC0,
-                tt::umd::wormhole::DRAM_GRID_SIZE,
-                flatten_vector(tt::umd::wormhole::DRAM_CORES_NOC0),
-                tt::umd::wormhole::ETH_CORES_NOC0,
-                tt::umd::wormhole::ARC_GRID_SIZE,
-                tt::umd::wormhole::ARC_CORES_NOC0,
-                tt::umd::wormhole::PCIE_GRID_SIZE,
-                tt::umd::wormhole::PCIE_CORES_NOC0,
-                tt::umd::wormhole::ROUTER_CORES_NOC0,
-                tt::umd::wormhole::SECURITY_CORES_NOC0,
-                tt::umd::wormhole::L2CPU_CORES_NOC0,
-                tt::umd::wormhole::NOC0_X_TO_NOC1_X,
-                tt::umd::wormhole::NOC0_Y_TO_NOC1_Y);
+                wormhole::TENSIX_GRID_SIZE,
+                wormhole::TENSIX_CORES_NOC0,
+                wormhole::DRAM_GRID_SIZE,
+                flatten_vector(wormhole::DRAM_CORES_NOC0),
+                wormhole::ETH_CORES_NOC0,
+                wormhole::ARC_GRID_SIZE,
+                wormhole::ARC_CORES_NOC0,
+                wormhole::PCIE_GRID_SIZE,
+                wormhole::PCIE_CORES_NOC0,
+                wormhole::ROUTER_CORES_NOC0,
+                wormhole::SECURITY_CORES_NOC0,
+                wormhole::L2CPU_CORES_NOC0,
+                wormhole::NOC0_X_TO_NOC1_X,
+                wormhole::NOC0_Y_TO_NOC1_Y);
         case tt::ARCH::QUASAR:  // TODO (#450): Add Quasar configuration
         case tt::ARCH::BLACKHOLE: {
             return create_coordinate_manager(
                 arch,
                 noc_translation_enabled,
                 harvesting_masks,
-                tt::umd::blackhole::TENSIX_GRID_SIZE,
-                tt::umd::blackhole::TENSIX_CORES_NOC0,
-                tt::umd::blackhole::DRAM_GRID_SIZE,
-                flatten_vector(tt::umd::blackhole::DRAM_CORES_NOC0),
-                tt::umd::blackhole::ETH_CORES_NOC0,
-                tt::umd::blackhole::ARC_GRID_SIZE,
-                tt::umd::blackhole::ARC_CORES_NOC0,
-                tt::umd::blackhole::PCIE_GRID_SIZE,
-                tt::umd::blackhole::PCIE_CORES_NOC0,
-                tt::umd::blackhole::ROUTER_CORES_NOC0,
-                tt::umd::blackhole::SECURITY_CORES_NOC0,
-                tt::umd::blackhole::L2CPU_CORES_NOC0,
-                tt::umd::blackhole::NOC0_X_TO_NOC1_X,
-                tt::umd::blackhole::NOC0_Y_TO_NOC1_Y);
+                blackhole::TENSIX_GRID_SIZE,
+                blackhole::TENSIX_CORES_NOC0,
+                blackhole::DRAM_GRID_SIZE,
+                flatten_vector(blackhole::DRAM_CORES_NOC0),
+                blackhole::ETH_CORES_NOC0,
+                blackhole::ARC_GRID_SIZE,
+                blackhole::ARC_CORES_NOC0,
+                blackhole::PCIE_GRID_SIZE,
+                blackhole::PCIE_CORES_NOC0,
+                blackhole::ROUTER_CORES_NOC0,
+                blackhole::SECURITY_CORES_NOC0,
+                blackhole::L2CPU_CORES_NOC0,
+                blackhole::NOC0_X_TO_NOC1_X,
+                blackhole::NOC0_Y_TO_NOC1_Y);
         }
         case tt::ARCH::Invalid:
             throw std::runtime_error("Invalid architecture for creating coordinate manager");
@@ -760,3 +760,5 @@ void CoordinateManager::add_noc1_to_noc0_mapping() {
     map_noc0_to_noc1_cores(security_cores, CoreType::SECURITY);
     map_noc0_to_noc1_cores(l2cpu_cores, CoreType::L2CPU);
 }
+
+}  // namespace tt::umd

--- a/device/cpuset_lib.cpp
+++ b/device/cpuset_lib.cpp
@@ -10,17 +10,16 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <regex>
 #include <thread>
 #include <tt-logger/tt-logger.hpp>
 
 #include "cpuset_lib.hpp"
 #include "umd/device/cluster.h"
 
-namespace tt {
+namespace tt::cpuset {
 
 namespace fs = std::filesystem;
-
-namespace cpuset {
 
 /////////////////////////////////////////////////////////////////////////
 // Initialization Functions /////////////////////////////////////////////
@@ -650,5 +649,4 @@ void tt_cpuset_allocator::print_hwloc_object(hwloc_obj_t &obj, int depth, bool v
     printf("\n");
 }
 
-}  // namespace cpuset
-}  // namespace tt
+}  // namespace tt::cpuset

--- a/device/cpuset_lib.hpp
+++ b/device/cpuset_lib.hpp
@@ -15,13 +15,12 @@
 #include <vector>
 
 #include "hwloc.h"
-#include "umd/device/tt_cluster_descriptor.h"  // For chip_id_t
+#include "umd/device/types/cluster_descriptor_types.h"  // For chip_id_t
 
-using tt_cluster_description = tt_ClusterDescriptor;
-
-namespace tt {
+namespace tt::cpuset {
 //! Utility functions for various backend paramsf
-namespace cpuset {
+
+using tt::umd::chip_id_t;
 
 // CPU ID allocator for pinning threads to cpu_ids
 // It's a singleton that should be retrieved via get()
@@ -124,5 +123,4 @@ std::ostream &operator<<(std::ostream &os, const std::vector<T> &v) {
     return os;
 }
 
-}  // namespace cpuset
-}  // namespace tt
+}  // namespace tt::cpuset

--- a/device/hugepage.cpp
+++ b/device/hugepage.cpp
@@ -10,18 +10,19 @@
 #include <sys/stat.h>  // for umask
 
 #include <fstream>
+#include <regex>
 #include <tt-logger/tt-logger.hpp>
 
 #include "assert.hpp"
 #include "cpuset_lib.hpp"
+
+namespace tt::umd {
 
 const uint32_t g_MAX_HOST_MEM_CHANNELS = 4;
 
 // Hardcode (but allow override) of path now, to support environments with other 1GB hugepage mounts not for runtime.
 const char* hugepage_dir_env = std::getenv("TT_BACKEND_HUGEPAGE_DIR");
 std::string hugepage_dir = hugepage_dir_env ? hugepage_dir_env : "/dev/hugepages-1G";
-
-namespace tt::umd {
 
 uint32_t get_num_hugepages() {
     std::string nr_hugepages_path = "/sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages";

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -24,6 +24,8 @@
 #include "ioctl.h"
 #include "umd/device/types/arch.h"
 
+namespace tt::umd {
+
 static const uint16_t GS_PCIE_DEVICE_ID = 0xfaca;
 static const uint16_t WH_PCIE_DEVICE_ID = 0x401e;
 static const uint16_t BH_PCIE_DEVICE_ID = 0xb140;
@@ -37,9 +39,6 @@ static const uint32_t GS_BAR0_WC_MAPPING_SIZE = (156 << 20) + (10 << 21) + (18 <
 
 // Defines the address for WC region. addresses 0 to BH_BAR0_WC_MAPPING_SIZE are in WC, above that are UC
 static const uint32_t BH_BAR0_WC_MAPPING_SIZE = 188 << 21;
-
-using namespace tt;
-using namespace tt::umd;
 
 template <typename T>
 static std::optional<T> try_read_sysfs(const PciDeviceInfo &device_info, const std::string &attribute_name) {
@@ -536,3 +535,5 @@ semver_t PCIDevice::read_kmd_version() {
 std::unique_ptr<TlbHandle> PCIDevice::allocate_tlb(const size_t tlb_size, const TlbMapping tlb_mapping) {
     return std::make_unique<TlbHandle>(pci_device_file_desc, tlb_size, tlb_mapping);
 }
+
+}  // namespace tt::umd

--- a/device/remote_communication.cpp
+++ b/device/remote_communication.cpp
@@ -16,6 +16,8 @@
 
 extern bool umd_use_noc1;
 
+namespace tt::umd {
+
 static constexpr uint32_t REMOTE_CMD_NOC_BIT = 9;
 
 struct remote_update_ptr_t {
@@ -35,8 +37,6 @@ struct routing_cmd_t {
     uint16_t padding;
     uint32_t src_addr_tag;  // upper 32-bits of request source address.
 };
-
-namespace tt::umd {
 
 RemoteCommunication::RemoteCommunication(LocalChip* local_chip) : local_chip_(local_chip) {}
 

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -18,6 +18,8 @@
 #include "tt_simulation_device_generated.h"
 #include "umd/device/driver_atomics.h"
 
+namespace tt::umd {
+
 static_assert(!std::is_abstract<tt_SimulationDevice>(), "tt_SimulationDevice must be non-abstract.");
 
 flatbuffers::FlatBufferBuilder create_flatbuffer(
@@ -98,7 +100,7 @@ void tt_SimulationDevice::start_device() {
     nng_free(buf_ptr, buf_size);
 }
 
-void tt_SimulationDevice::send_tensix_risc_reset(tt::umd::CoreCoord core, const TensixSoftResetOptions& soft_resets) {
+void tt_SimulationDevice::send_tensix_risc_reset(CoreCoord core, const TensixSoftResetOptions& soft_resets) {
     tt_xy_pair translate_core = soc_descriptor_.translate_coord_to(core, CoordSystem::TRANSLATED);
     if (soft_resets == TENSIX_ASSERT_SOFT_RESET) {
         log_debug(tt::LogEmulationDriver, "Sending assert_risc_reset signal..");
@@ -133,12 +135,12 @@ void tt_SimulationDevice::close_device() {
     host.send_to_device(builder.GetBufferPointer(), builder.GetSize());
 }
 
-void tt_SimulationDevice::set_remote_transfer_ethernet_cores(const std::unordered_set<tt::umd::CoreCoord>& cores) {}
+void tt_SimulationDevice::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) {}
 
 void tt_SimulationDevice::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channel) {}
 
 // Runtime Functions
-void tt_SimulationDevice::write_to_device(tt::umd::CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) {
+void tt_SimulationDevice::write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) {
     log_debug(tt::LogEmulationDriver, "Device writing {} bytes to l1_dest {} in core {}", size, l1_dest, core.str());
     tt_xy_pair translate_core = soc_descriptor_.translate_coord_to(core, CoordSystem::TRANSLATED);
     std::vector<std::uint32_t> data((uint32_t*)src, (uint32_t*)src + size / sizeof(uint32_t));
@@ -150,7 +152,7 @@ void tt_SimulationDevice::write_to_device(tt::umd::CoreCoord core, const void* s
     host.send_to_device(wr_buffer_ptr, wr_buffer_size);
 }
 
-void tt_SimulationDevice::read_from_device(tt::umd::CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) {
+void tt_SimulationDevice::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) {
     void* rd_resp;
 
     // Send read request
@@ -171,20 +173,19 @@ void tt_SimulationDevice::read_from_device(tt::umd::CoreCoord core, void* dest, 
     nng_free(rd_resp, rd_rsp_sz);
 }
 
-void tt_SimulationDevice::write_to_device_reg(
-    tt::umd::CoreCoord core, const void* src, uint64_t reg_dest, uint32_t size) {
+void tt_SimulationDevice::write_to_device_reg(CoreCoord core, const void* src, uint64_t reg_dest, uint32_t size) {
     write_to_device(core, src, reg_dest, size);
 }
 
-void tt_SimulationDevice::read_from_device_reg(tt::umd::CoreCoord core, void* dest, uint64_t reg_src, uint32_t size) {
+void tt_SimulationDevice::read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_src, uint32_t size) {
     read_from_device(core, dest, reg_src, size);
 }
 
-void tt_SimulationDevice::dma_write_to_device(const void* src, size_t size, tt::umd::CoreCoord core, uint64_t addr) {
+void tt_SimulationDevice::dma_write_to_device(const void* src, size_t size, CoreCoord core, uint64_t addr) {
     write_to_device(core, src, addr, size);
 }
 
-void tt_SimulationDevice::dma_read_from_device(void* dst, size_t size, tt::umd::CoreCoord core, uint64_t addr) {
+void tt_SimulationDevice::dma_read_from_device(void* dst, size_t size, CoreCoord core, uint64_t addr) {
     read_from_device(core, dst, addr, size);
 }
 
@@ -195,11 +196,11 @@ std::function<void(uint32_t, uint32_t, const uint8_t*)> tt_SimulationDevice::get
 
 void tt_SimulationDevice::wait_for_non_mmio_flush() {}
 
-void tt_SimulationDevice::l1_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) {}
+void tt_SimulationDevice::l1_membar(const std::unordered_set<CoreCoord>& cores) {}
 
 void tt_SimulationDevice::dram_membar(const std::unordered_set<uint32_t>& channels) {}
 
-void tt_SimulationDevice::dram_membar(const std::unordered_set<tt::umd::CoreCoord>& cores) {}
+void tt_SimulationDevice::dram_membar(const std::unordered_set<CoreCoord>& cores) {}
 
 void tt_SimulationDevice::deassert_risc_resets() {}
 
@@ -237,14 +238,16 @@ int tt_SimulationDevice::get_numa_node() {
     throw std::runtime_error("tt_SimulationDevice::get_numa_node is not available for this chip.");
 }
 
-tt::umd::TTDevice* tt_SimulationDevice::get_tt_device() {
+TTDevice* tt_SimulationDevice::get_tt_device() {
     throw std::runtime_error("tt_SimulationDevice::get_tt_device is not available for this chip.");
 }
 
-tt::umd::SysmemManager* tt_SimulationDevice::get_sysmem_manager() {
+SysmemManager* tt_SimulationDevice::get_sysmem_manager() {
     throw std::runtime_error("tt_SimulationDevice::get_sysmem_manager is not available for this chip.");
 }
 
-tt::umd::TLBManager* tt_SimulationDevice::get_tlb_manager() {
+TLBManager* tt_SimulationDevice::get_tlb_manager() {
     throw std::runtime_error("tt_SimulationDevice::get_tlb_manager is not available for this chip.");
 }
+
+}  // namespace tt::umd

--- a/device/simulation/tt_simulation_host.cpp
+++ b/device/simulation/tt_simulation_host.cpp
@@ -17,6 +17,8 @@
 
 #include "assert.hpp"
 
+namespace tt::umd {
+
 tt_SimulationHost::tt_SimulationHost() {
     // Initialize socket and dialer
     host_socket = std::make_unique<nng_socket>();
@@ -87,3 +89,5 @@ size_t tt_SimulationHost::recv_from_device(void **data_ptr) {
     }
     return data_size;
 }
+
+}  // namespace tt::umd

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -18,8 +18,7 @@
 #include "assert.hpp"
 #include "disjoint_set.hpp"
 
-using namespace tt;
-using namespace tt::umd;
+namespace tt::umd {
 
 bool tt_ClusterDescriptor::ethernet_core_has_active_ethernet_link(
     chip_id_t local_chip, ethernet_channel_t local_ethernet_channel) const {
@@ -584,9 +583,8 @@ void tt_ClusterDescriptor::load_ethernet_connections_from_connectivity_descripto
             desc.harvesting_masks_map.empty()
                 ? 0
                 : CoordinateManager::get_num_harvested(desc.harvesting_masks_map.at(chip).eth_harvesting_mask);
-        int num_channels =
-            tt::umd::architecture_implementation::create(desc.chip_arch.at(chip))->get_num_eth_channels() -
-            num_harvested_channels;
+        int num_channels = architecture_implementation::create(desc.chip_arch.at(chip))->get_num_eth_channels() -
+                           num_harvested_channels;
         for (int i = 0; i < num_channels; i++) {
             desc.idle_eth_channels[chip].insert(i);
         }
@@ -1315,3 +1313,5 @@ void tt_ClusterDescriptor::verify_cluster_descriptor_info() {
         }
     }
 }
+
+}  // namespace tt::umd

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -157,7 +157,7 @@ void BlackholeTTDevice::wait_arc_core_start(const tt_xy_pair arc_core, const uin
     auto start = std::chrono::system_clock::now();
     uint32_t arc_boot_status;
     while (true) {
-        read_from_device(&arc_boot_status, arc_core, tt::umd::blackhole::SCRATCH_RAM_2, sizeof(arc_boot_status));
+        read_from_device(&arc_boot_status, arc_core, blackhole::SCRATCH_RAM_2, sizeof(arc_boot_status));
 
         // ARC started successfully.
         if ((arc_boot_status & 0x7) == 0x5) {
@@ -187,9 +187,9 @@ uint32_t BlackholeTTDevice::get_clock() {
 
 // TODO: figure out if Blackhole has the information on maximum possible
 // clock frequency. For now, we are using the maximum possible value.
-uint32_t BlackholeTTDevice::get_max_clock_freq() { return tt::umd::blackhole::AICLK_BUSY_VAL; }
+uint32_t BlackholeTTDevice::get_max_clock_freq() { return blackhole::AICLK_BUSY_VAL; }
 
-uint32_t BlackholeTTDevice::get_min_clock_freq() { return tt::umd::blackhole::AICLK_IDLE_VAL; }
+uint32_t BlackholeTTDevice::get_min_clock_freq() { return blackhole::AICLK_IDLE_VAL; }
 
 uint64_t BlackholeTTDevice::get_board_id() {
     return ((uint64_t)telemetry->read_entry(blackhole::TAG_BOARD_ID_HIGH) << 32) |
@@ -213,11 +213,11 @@ void BlackholeTTDevice::dma_d2h_zero_copy(void *dst, uint32_t src, size_t size) 
 }
 
 std::vector<DramTrainingStatus> BlackholeTTDevice::get_dram_training_status() {
-    if (!telemetry->is_entry_available(tt::umd::blackhole::TAG_DDR_STATUS)) {
+    if (!telemetry->is_entry_available(blackhole::TAG_DDR_STATUS)) {
         return {};
     }
 
-    uint32_t telemetry_data = telemetry->read_entry(tt::umd::blackhole::TAG_DDR_STATUS);
+    uint32_t telemetry_data = telemetry->read_entry(blackhole::TAG_DDR_STATUS);
     std::vector<DramTrainingStatus> dram_training_status;
     const uint32_t num_dram_channels = blackhole::NUM_DRAM_BANKS;
     // Format of the dram training status is as follows:

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -223,7 +223,7 @@ void TTDevice::read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, u
     uint8_t *buffer_addr = static_cast<uint8_t *>(mem_ptr);
     const uint32_t tlb_index = get_architecture_implementation()->get_small_read_write_tlb();
     while (size > 0) {
-        auto [mapped_address, tlb_size] = set_dynamic_tlb(tlb_index, core, addr, tt::umd::tlb_data::Strict);
+        auto [mapped_address, tlb_size] = set_dynamic_tlb(tlb_index, core, addr, tlb_data::Strict);
         uint32_t transfer_size = std::min((uint64_t)size, tlb_size);
         read_block(mapped_address, transfer_size, buffer_addr);
 
@@ -239,7 +239,7 @@ void TTDevice::write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t ad
     const uint32_t tlb_index = get_architecture_implementation()->get_small_read_write_tlb();
 
     while (size > 0) {
-        auto [mapped_address, tlb_size] = set_dynamic_tlb(tlb_index, core, addr, tt::umd::tlb_data::Strict);
+        auto [mapped_address, tlb_size] = set_dynamic_tlb(tlb_index, core, addr, tlb_data::Strict);
         uint32_t transfer_size = std::min((uint64_t)size, tlb_size);
         write_block(mapped_address, transfer_size, buffer_addr);
 
@@ -298,15 +298,15 @@ dynamic_tlb TTDevice::set_dynamic_tlb(
         multicast,
         (int)ordering);
 
-    tt::umd::tlb_configuration tlb_config = architecture_impl_->get_tlb_configuration(tlb_index);
+    tlb_configuration tlb_config = architecture_impl_->get_tlb_configuration(tlb_index);
     std::uint32_t TLB_CFG_REG_SIZE_BYTES = architecture_impl_->get_tlb_cfg_reg_size_bytes();
     uint64_t tlb_address = address / tlb_config.size;
     uint32_t local_address = address % tlb_config.size;
     uint64_t tlb_base = tlb_config.base + (tlb_config.size * tlb_config.index_offset);
     uint32_t tlb_cfg_reg = tlb_config.cfg_addr + (TLB_CFG_REG_SIZE_BYTES * tlb_config.index_offset);
 
-    std::pair<std::uint64_t, std::uint64_t> tlb_data =
-        tt::umd::tlb_data{
+    std::pair<std::uint64_t, std::uint64_t> tlb_reg_config =
+        tlb_data{
             .local_offset = tlb_address,
             .x_end = static_cast<uint64_t>(end.x),
             .y_end = static_cast<uint64_t>(end.y),
@@ -334,7 +334,7 @@ dynamic_tlb TTDevice::set_dynamic_tlb(
         tlb_cfg_reg,
         end.x,
         end.y);
-    write_tlb_reg(tlb_cfg_reg, tlb_data.first, tlb_data.second, TLB_CFG_REG_SIZE_BYTES);
+    write_tlb_reg(tlb_cfg_reg, tlb_reg_config.first, tlb_reg_config.second, TLB_CFG_REG_SIZE_BYTES);
 
     return {tlb_base + local_address, tlb_config.size - local_address};
 }
@@ -376,9 +376,9 @@ uint32_t TTDevice::bar_read32(uint32_t addr) {
     return data;
 }
 
-tt::umd::ArcMessenger *TTDevice::get_arc_messenger() const { return arc_messenger_.get(); }
+ArcMessenger *TTDevice::get_arc_messenger() const { return arc_messenger_.get(); }
 
-tt::umd::ArcTelemetryReader *TTDevice::get_arc_telemetry_reader() const { return telemetry.get(); }
+ArcTelemetryReader *TTDevice::get_arc_telemetry_reader() const { return telemetry.get(); }
 
 TTDevice::~TTDevice() { lock_manager.clear_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num()); }
 

--- a/device/tt_silicon_driver_common.cpp
+++ b/device/tt_silicon_driver_common.cpp
@@ -7,6 +7,8 @@
 #include "umd/device/cluster.h"
 #include "umd/device/tt_xy_pair.h"
 
+namespace tt::umd {
+
 std::string TensixSoftResetOptionsToString(TensixSoftResetOptions value) {
     std::string output;
 
@@ -43,3 +45,5 @@ TensixSoftResetOptions invert_selected_options(TensixSoftResetOptions selected) 
     uint32_t inverted = (~selected_bits) & static_cast<uint32_t>(ALL_TENSIX_SOFT_RESET);
     return static_cast<TensixSoftResetOptions>(inverted);
 }
+
+}  // namespace tt::umd

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -22,7 +22,7 @@
 
 // #include "l1_address_map.h"
 
-using namespace tt::umd;
+namespace tt::umd {
 
 std::string format_node(tt_xy_pair xy) { return fmt::format("{}-{}", xy.x, xy.y); }
 
@@ -71,7 +71,7 @@ tt_xy_pair tt_SocDescriptor::calculate_grid_size(const std::vector<tt_xy_pair> &
     return {x.size(), y.size()};
 }
 
-void tt_SocDescriptor::write_coords(void *out, const tt::umd::CoreCoord &core) const {
+void tt_SocDescriptor::write_coords(void *out, const CoreCoord &core) const {
     YAML::Emitter *emitter = static_cast<YAML::Emitter *>(out);
 
     if (core.x < grid_size.x && core.y < grid_size.y) {
@@ -86,8 +86,7 @@ void tt_SocDescriptor::write_core_locations(void *out, const CoreType &core_type
     }
 }
 
-void tt_SocDescriptor::serialize_dram_cores(
-    void *out, const std::vector<std::vector<tt::umd::CoreCoord>> &cores) const {
+void tt_SocDescriptor::serialize_dram_cores(void *out, const std::vector<std::vector<CoreCoord>> &cores) const {
     YAML::Emitter *emitter = static_cast<YAML::Emitter *>(out);
 
     for (const auto &dram_cores : cores) {
@@ -171,16 +170,15 @@ void tt_SocDescriptor::create_coordinate_manager(const BoardType board_type, con
     get_cores_and_grid_size_from_coordinate_manager();
 }
 
-tt::umd::CoreCoord tt_SocDescriptor::translate_coord_to(
-    const tt::umd::CoreCoord core_coord, const CoordSystem coord_system) const {
+CoreCoord tt_SocDescriptor::translate_coord_to(const CoreCoord core_coord, const CoordSystem coord_system) const {
     return coordinate_manager->translate_coord_to(core_coord, coord_system);
 }
 
-tt::umd::CoreCoord tt_SocDescriptor::get_coord_at(const tt_xy_pair core, const CoordSystem coord_system) const {
+CoreCoord tt_SocDescriptor::get_coord_at(const tt_xy_pair core, const CoordSystem coord_system) const {
     return coordinate_manager->get_coord_at(core, coord_system);
 }
 
-tt::umd::CoreCoord tt_SocDescriptor::translate_coord_to(
+CoreCoord tt_SocDescriptor::translate_coord_to(
     const tt_xy_pair core_location, const CoordSystem input_coord_system, const CoordSystem target_coord_system) const {
     return coordinate_manager->translate_coord_to(core_location, input_coord_system, target_coord_system);
 }
@@ -290,39 +288,39 @@ SocDescriptorInfo tt_SocDescriptor::get_soc_descriptor_info(tt::ARCH arch) {
         case tt::ARCH::WORMHOLE_B0: {
             return SocDescriptorInfo{
                 .arch = tt::ARCH::WORMHOLE_B0,
-                .grid_size = tt::umd::wormhole::GRID_SIZE,
-                .tensix_cores = tt::umd::wormhole::TENSIX_CORES_NOC0,
-                .dram_cores = tt::umd::wormhole::DRAM_CORES_NOC0,
-                .eth_cores = tt::umd::wormhole::ETH_CORES_NOC0,
-                .arc_cores = tt::umd::wormhole::ARC_CORES_NOC0,
-                .pcie_cores = tt::umd::wormhole::PCIE_CORES_NOC0,
-                .router_cores = tt::umd::wormhole::ROUTER_CORES_NOC0,
-                .security_cores = tt::umd::wormhole::SECURITY_CORES_NOC0,
-                .l2cpu_cores = tt::umd::wormhole::L2CPU_CORES_NOC0,
-                .worker_l1_size = tt::umd::wormhole::TENSIX_L1_SIZE,
-                .eth_l1_size = tt::umd::wormhole::ETH_L1_SIZE,
-                .dram_bank_size = tt::umd::wormhole::DRAM_BANK_SIZE,
-                .noc0_x_to_noc1_x = tt::umd::wormhole::NOC0_X_TO_NOC1_X,
-                .noc0_y_to_noc1_y = tt::umd::wormhole::NOC0_Y_TO_NOC1_Y};
+                .grid_size = wormhole::GRID_SIZE,
+                .tensix_cores = wormhole::TENSIX_CORES_NOC0,
+                .dram_cores = wormhole::DRAM_CORES_NOC0,
+                .eth_cores = wormhole::ETH_CORES_NOC0,
+                .arc_cores = wormhole::ARC_CORES_NOC0,
+                .pcie_cores = wormhole::PCIE_CORES_NOC0,
+                .router_cores = wormhole::ROUTER_CORES_NOC0,
+                .security_cores = wormhole::SECURITY_CORES_NOC0,
+                .l2cpu_cores = wormhole::L2CPU_CORES_NOC0,
+                .worker_l1_size = wormhole::TENSIX_L1_SIZE,
+                .eth_l1_size = wormhole::ETH_L1_SIZE,
+                .dram_bank_size = wormhole::DRAM_BANK_SIZE,
+                .noc0_x_to_noc1_x = wormhole::NOC0_X_TO_NOC1_X,
+                .noc0_y_to_noc1_y = wormhole::NOC0_Y_TO_NOC1_Y};
             break;
         }
         case tt::ARCH::BLACKHOLE: {
             return SocDescriptorInfo{
                 .arch = tt::ARCH::BLACKHOLE,
-                .grid_size = tt::umd::blackhole::GRID_SIZE,
-                .tensix_cores = tt::umd::blackhole::TENSIX_CORES_NOC0,
-                .dram_cores = tt::umd::blackhole::DRAM_CORES_NOC0,
-                .eth_cores = tt::umd::blackhole::ETH_CORES_NOC0,
-                .arc_cores = tt::umd::blackhole::ARC_CORES_NOC0,
-                .pcie_cores = tt::umd::blackhole::PCIE_CORES_NOC0,
-                .router_cores = tt::umd::blackhole::ROUTER_CORES_NOC0,
-                .security_cores = tt::umd::blackhole::SECURITY_CORES_NOC0,
-                .l2cpu_cores = tt::umd::blackhole::L2CPU_CORES_NOC0,
-                .worker_l1_size = tt::umd::blackhole::TENSIX_L1_SIZE,
-                .eth_l1_size = tt::umd::blackhole::ETH_L1_SIZE,
-                .dram_bank_size = tt::umd::blackhole::DRAM_BANK_SIZE,
-                .noc0_x_to_noc1_x = tt::umd::blackhole::NOC0_X_TO_NOC1_X,
-                .noc0_y_to_noc1_y = tt::umd::blackhole::NOC0_Y_TO_NOC1_Y};
+                .grid_size = blackhole::GRID_SIZE,
+                .tensix_cores = blackhole::TENSIX_CORES_NOC0,
+                .dram_cores = blackhole::DRAM_CORES_NOC0,
+                .eth_cores = blackhole::ETH_CORES_NOC0,
+                .arc_cores = blackhole::ARC_CORES_NOC0,
+                .pcie_cores = blackhole::PCIE_CORES_NOC0,
+                .router_cores = blackhole::ROUTER_CORES_NOC0,
+                .security_cores = blackhole::SECURITY_CORES_NOC0,
+                .l2cpu_cores = blackhole::L2CPU_CORES_NOC0,
+                .worker_l1_size = blackhole::TENSIX_L1_SIZE,
+                .eth_l1_size = blackhole::ETH_L1_SIZE,
+                .dram_bank_size = blackhole::DRAM_BANK_SIZE,
+                .noc0_x_to_noc1_x = blackhole::NOC0_X_TO_NOC1_X,
+                .noc0_y_to_noc1_y = blackhole::NOC0_Y_TO_NOC1_Y};
             break;
         }
         default:
@@ -640,8 +638,7 @@ std::vector<CoreCoord> tt_SocDescriptor::translate_coordinates(
     return translated_cores;
 }
 
-std::vector<tt::umd::CoreCoord> tt_SocDescriptor::get_cores(
-    const CoreType core_type, const CoordSystem coord_system) const {
+std::vector<CoreCoord> tt_SocDescriptor::get_cores(const CoreType core_type, const CoordSystem coord_system) const {
     auto cores_map_it = cores_map.find(core_type);
     if (coord_system != CoordSystem::PHYSICAL) {
         return translate_coordinates(cores_map_it->second, coord_system);
@@ -649,7 +646,7 @@ std::vector<tt::umd::CoreCoord> tt_SocDescriptor::get_cores(
     return cores_map_it->second;
 }
 
-std::vector<tt::umd::CoreCoord> tt_SocDescriptor::get_harvested_cores(
+std::vector<CoreCoord> tt_SocDescriptor::get_harvested_cores(
     const CoreType core_type, const CoordSystem coord_system) const {
     if (coord_system == CoordSystem::LOGICAL) {
         throw std::runtime_error("Harvested cores are not supported for logical coordinates");
@@ -661,8 +658,8 @@ std::vector<tt::umd::CoreCoord> tt_SocDescriptor::get_harvested_cores(
     return harvested_cores_map_it->second;
 }
 
-std::vector<tt::umd::CoreCoord> tt_SocDescriptor::get_all_cores(const CoordSystem coord_system) const {
-    std::vector<tt::umd::CoreCoord> all_cores;
+std::vector<CoreCoord> tt_SocDescriptor::get_all_cores(const CoordSystem coord_system) const {
+    std::vector<CoreCoord> all_cores;
     for (const auto &core_type :
          {CoreType::TENSIX,
           CoreType::DRAM,
@@ -678,8 +675,8 @@ std::vector<tt::umd::CoreCoord> tt_SocDescriptor::get_all_cores(const CoordSyste
     return all_cores;
 }
 
-std::vector<tt::umd::CoreCoord> tt_SocDescriptor::get_all_harvested_cores(const CoordSystem coord_system) const {
-    std::vector<tt::umd::CoreCoord> all_harvested_cores;
+std::vector<CoreCoord> tt_SocDescriptor::get_all_harvested_cores(const CoordSystem coord_system) const {
+    std::vector<CoreCoord> all_harvested_cores;
     for (const auto &core_type :
          {CoreType::TENSIX,
           CoreType::DRAM,
@@ -712,3 +709,5 @@ uint32_t tt_SocDescriptor::get_num_eth_channels() const { return coordinate_mana
 uint32_t tt_SocDescriptor::get_num_harvested_eth_channels() const {
     return coordinate_manager->get_num_harvested_eth_channels();
 }
+
+}  // namespace tt::umd

--- a/device/utils/robust_mutex.cpp
+++ b/device/utils/robust_mutex.cpp
@@ -19,12 +19,12 @@
 #include <stdexcept>
 #include <tt-logger/tt-logger.hpp>
 
+namespace tt::umd {
+
 static constexpr int ALL_RW_PERMISSION = 0666;
 static constexpr std::string_view UMD_LOCK_PREFIX = "TT_UMD_LOCK.";
 // Any value which is unlikely to be found at random in the memory.
 static constexpr uint64_t INITIALIZED_FLAG = 0x5454554d444d5458;  // TTUMDMTX
-
-using namespace tt::umd;
 
 // A small helper class which will ensure that the critical section is released in a RAII manner.
 // flock ensures only multiprocess locking, but does not guarantee
@@ -290,3 +290,5 @@ void RobustMutex::lock() {
             fmt::format("pthread_mutex_lock failed for mutex {} errno: {}", mutex_name_, std::to_string(lock_res)));
     }
 }
+
+}  // namespace tt::umd

--- a/device/wormhole/wormhole_arc_messenger.cpp
+++ b/device/wormhole/wormhole_arc_messenger.cpp
@@ -25,11 +25,10 @@ uint32_t WormholeArcMessenger::send_message(
 
     TT_ASSERT(arg0 <= 0xffff and arg1 <= 0xffff, "Only 16 bits allowed in arc_msg args");
 
-    const tt_xy_pair arc_core = umd_use_noc1
-                                    ? tt_xy_pair(
-                                          tt::umd::wormhole::NOC0_X_TO_NOC1_X[tt::umd::wormhole::ARC_CORES_NOC0[0].x],
-                                          tt::umd::wormhole::NOC0_Y_TO_NOC1_Y[tt::umd::wormhole::ARC_CORES_NOC0[0].y])
-                                    : tt::umd::wormhole::ARC_CORES_NOC0[0];
+    const tt_xy_pair arc_core = umd_use_noc1 ? tt_xy_pair(
+                                                   wormhole::NOC0_X_TO_NOC1_X[wormhole::ARC_CORES_NOC0[0].x],
+                                                   wormhole::NOC0_Y_TO_NOC1_Y[wormhole::ARC_CORES_NOC0[0].y])
+                                             : wormhole::ARC_CORES_NOC0[0];
 
     // TODO: Once local and remote ttdevice is properly separated, reenable this code.
     // TODO2: Once we have unique chip ids other than PCI dev number, use that for both local and remote chips for

--- a/device/wormhole/wormhole_arc_telemetry_reader.cpp
+++ b/device/wormhole/wormhole_arc_telemetry_reader.cpp
@@ -17,8 +17,7 @@ void WormholeArcTelemetryReader::initialize_telemetry() {
     std::vector<uint32_t> arc_msg_return_values = {0};
     static const uint32_t timeout_ms = 1000;
     uint32_t exit_code = tt_device->get_arc_messenger()->send_message(
-        tt::umd::wormhole::ARC_MSG_COMMON_PREFIX |
-            (uint32_t)tt::umd::wormhole::arc_message_type::GET_SMBUS_TELEMETRY_ADDR,
+        wormhole::ARC_MSG_COMMON_PREFIX | (uint32_t)wormhole::arc_message_type::GET_SMBUS_TELEMETRY_ADDR,
         arc_msg_return_values,
         0,
         0,
@@ -33,7 +32,7 @@ void WormholeArcTelemetryReader::verify_telemetry() {
     // Seems that TAG_DEVICE_ID field in remote telemetry is not populated in the same way for remote and local chips.
     // TODO: figure out if there is any way for both local and remote chips to verify telemetry readouts.
     if (!tt_device->is_remote()) {
-        uint32_t vendor_id = read_entry(tt::umd::wormhole::TAG_DEVICE_ID);
+        uint32_t vendor_id = read_entry(wormhole::TAG_DEVICE_ID);
         constexpr uint32_t tt_vendor_id = 0x1e52;
         if ((vendor_id & 0xFFFF) != tt_vendor_id) {
             throw std::runtime_error(
@@ -57,7 +56,7 @@ uint32_t WormholeArcTelemetryReader::read_entry(const uint8_t telemetry_tag) {
 }
 
 bool WormholeArcTelemetryReader::is_entry_available(const uint8_t telemetry_tag) {
-    return telemetry_tag >= 0 && telemetry_tag < tt::umd::wormhole::TELEMETRY_NUMBER_OF_TAGS;
+    return telemetry_tag >= 0 && telemetry_tag < wormhole::TELEMETRY_NUMBER_OF_TAGS;
 }
 
 }  // namespace tt::umd

--- a/device/wormhole/wormhole_coordinate_manager.cpp
+++ b/device/wormhole/wormhole_coordinate_manager.cpp
@@ -5,7 +5,7 @@
  */
 #include "umd/device/wormhole_coordinate_manager.h"
 
-using namespace tt::umd;
+namespace tt::umd {
 
 WormholeCoordinateManager::WormholeCoordinateManager(
     const bool noc_translation_enabled,
@@ -120,3 +120,5 @@ tt_xy_pair WormholeCoordinateManager::get_tensix_grid_size() const {
         tensix_grid_size.x,
         tensix_grid_size.y - CoordinateManager::get_num_harvested(harvesting_masks.tensix_harvesting_mask)};
 }
+
+}  // namespace tt::umd

--- a/device/wormhole/wormhole_implementation.cpp
+++ b/device/wormhole/wormhole_implementation.cpp
@@ -12,10 +12,10 @@
 #include "wormhole/host_mem_address_map.h"
 #include "wormhole/l1_address_map.h"
 
+namespace tt::umd {
+
 constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h, common for WH && BH
 constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6;  // source: noc_parameters.h, common for WH && BH
-
-namespace tt::umd {
 
 std::tuple<xy_pair, xy_pair> wormhole_implementation::multicast_workaround(xy_pair start, xy_pair end) const {
     // When multicasting there is a rare case where including the multicasting node in the box can result in a backup

--- a/docs/CUSTOM_MODIFICATION_GUIDE.md
+++ b/docs/CUSTOM_MODIFICATION_GUIDE.md
@@ -39,7 +39,7 @@ The function [get_platform_architecture](https://github.com/tenstorrent/tt-metal
 
 #### tt_cluster.cpp
 
-Most of the interfacing with the UMD is done through this [tt_cluster.cpp](https://github.com/tenstorrent/tt-metal/blob/main/tt_metal/llrt/tt_cluster.cpp). To change the usage to a custom driver for custom device, one should exchange the creation of tt::umd::Cluster
+Most of the interfacing with the UMD is done through this [tt_cluster.cpp](https://github.com/tenstorrent/tt-metal/blob/main/tt_metal/llrt/tt_cluster.cpp). To change the usage to a custom driver for custom device, one should exchange the creation of Cluster
 with the class derived from tt_device. For instructions on what each of the functions represents and how to implement them, please see [cluster.h](../device/api/umd/device/cluster.h).
 
 #### soc_descriptor in tt_metal

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -90,7 +90,7 @@ TEST(ApiChipTest, SimpleAPIShowcase) {
 
     chip_id_t chip_id = umd_cluster->get_cluster_description()->get_chips_with_mmio().begin()->first;
 
-    // TODO: In future, will be accessed through tt::umd::Chip api.
+    // TODO: In future, will be accessed through Chip api.
     umd_cluster->get_pcie_base_addr_from_device(chip_id);
     umd_cluster->get_num_host_channels(chip_id);
 }

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -104,7 +104,7 @@ TEST(ApiClusterTest, OpenChipsByPciId) {
 TEST(ApiClusterTest, OpenClusterByLogicalID) {
     // First, pregenerate a cluster descriptor and save it to a file.
     // This will run topology discovery and touch all the devices.
-    std::filesystem::path cluster_path = tt::umd::Cluster::create_cluster_descriptor()->serialize_to_file();
+    std::filesystem::path cluster_path = Cluster::create_cluster_descriptor()->serialize_to_file();
 
     // Now, the user can create the cluster descriptor without touching the devices.
     std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(cluster_path);
@@ -182,7 +182,7 @@ TEST(ApiClusterTest, DifferentConstructors) {
     // This could be cluster descriptor cached from previous runtime, or with some custom modifications.
     // You can just create a cluster descriptor and serialize it to file, or fetch a cluster descriptor from already
     // created Cluster class.
-    std::filesystem::path cluster_path1 = tt::umd::Cluster::create_cluster_descriptor()->serialize_to_file();
+    std::filesystem::path cluster_path1 = Cluster::create_cluster_descriptor()->serialize_to_file();
     umd_cluster = std::make_unique<Cluster>();
     std::filesystem::path cluster_path2 = umd_cluster->get_cluster_description()->serialize_to_file();
     umd_cluster = nullptr;
@@ -451,9 +451,9 @@ TEST(TestCluster, TestClusterAICLKControl) {
     auto get_expected_clock_val = [&cluster](chip_id_t chip_id, bool busy) {
         tt::ARCH arch = cluster->get_cluster_description()->get_arch(chip_id);
         if (arch == tt::ARCH::WORMHOLE_B0) {
-            return busy ? tt::umd::wormhole::AICLK_BUSY_VAL : tt::umd::wormhole::AICLK_IDLE_VAL;
+            return busy ? wormhole::AICLK_BUSY_VAL : wormhole::AICLK_IDLE_VAL;
         } else if (arch == tt::ARCH::BLACKHOLE) {
-            return busy ? tt::umd::blackhole::AICLK_BUSY_VAL : tt::umd::blackhole::AICLK_IDLE_VAL;
+            return busy ? blackhole::AICLK_BUSY_VAL : blackhole::AICLK_IDLE_VAL;
         }
         return 0u;
     };

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -15,7 +15,7 @@
 using namespace tt::umd;
 
 TEST(ApiClusterDescriptorTest, DetectArch) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
 
     if (cluster_desc->get_number_of_chips() == 0) {
         // Expect it to be invalid if no devices are found.
@@ -47,7 +47,7 @@ TEST(ApiClusterDescriptorTest, DetectArch) {
 }
 
 TEST(ApiClusterDescriptorTest, BasicFunctionality) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
 
     if (cluster_desc == nullptr) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
@@ -149,7 +149,7 @@ TEST(ApiClusterDescriptorTest, SeparateClusters) {
 }
 
 TEST(ApiClusterDescriptorTest, EthernetConnectivity) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
 
     if (cluster_desc == nullptr) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
@@ -172,8 +172,7 @@ TEST(ApiClusterDescriptorTest, EthernetConnectivity) {
     for (auto chip : cluster_desc->get_all_chips()) {
         // Wormhole has 16 and Blackhole has 14 ethernet channels.
         for (int eth_chan = 0;
-             eth_chan <
-             tt::umd::architecture_implementation::create(cluster_desc->get_arch(chip))->get_num_eth_channels();
+             eth_chan < architecture_implementation::create(cluster_desc->get_arch(chip))->get_num_eth_channels();
              eth_chan++) {
             bool has_active_link = cluster_desc->ethernet_core_has_active_ethernet_link(chip, eth_chan);
             std::cout << "Chip " << chip << " channel " << eth_chan << " has active link: " << has_active_link
@@ -214,7 +213,7 @@ TEST(ApiClusterDescriptorTest, PrintClusterDescriptor) {
     // In case of u6 galaxy and blackhole, we generate the cluster descriptor.
     // For wormhole we still use create-ethernet-map.
     std::filesystem::path cluster_path;
-    cluster_path = tt::umd::Cluster::create_cluster_descriptor()->serialize_to_file();
+    cluster_path = Cluster::create_cluster_descriptor()->serialize_to_file();
 
     std::cout << "Cluster descriptor file path: " << cluster_path << std::endl;
     std::cout << "Contents:" << std::endl;
@@ -315,7 +314,7 @@ TEST(ApiClusterDescriptorTest, ConstrainedTopology) {
 }
 
 TEST(ApiClusterDescriptorTest, VerifyEthConnections) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
+    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
 
     std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>>
         eth_connections = cluster_desc->get_ethernet_connections();

--- a/tests/api/test_core_coord_translation_bh.cpp
+++ b/tests/api/test_core_coord_translation_bh.cpp
@@ -16,7 +16,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeNoHarvesting) {
         CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true);
 
     // We expect full grid size since there is no harvesting.
-    tt_xy_pair tensix_grid_size = tt::umd::blackhole::TENSIX_GRID_SIZE;
+    tt_xy_pair tensix_grid_size = blackhole::TENSIX_GRID_SIZE;
     for (size_t x = 0; x < tensix_grid_size.x; x++) {
         for (size_t y = 0; y < tensix_grid_size.y; y++) {
             CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
@@ -106,7 +106,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeLogicalPhysicalMapping) {
 
         std::map<CoreCoord, CoreCoord> logical_to_physical;
         std::set<CoreCoord> physical_coords_set;
-        tt_xy_pair tensix_grid_size = tt::umd::blackhole::TENSIX_GRID_SIZE;
+        tt_xy_pair tensix_grid_size = blackhole::TENSIX_GRID_SIZE;
 
         size_t num_harvested_x = CoordinateManager::get_num_harvested(tensix_harvesting_mask);
 
@@ -150,7 +150,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeLogicalVirtualMapping) {
 
         std::map<CoreCoord, CoreCoord> logical_to_virtual;
         std::set<CoreCoord> virtual_coords_set;
-        tt_xy_pair tensix_grid_size = tt::umd::blackhole::TENSIX_GRID_SIZE;
+        tt_xy_pair tensix_grid_size = blackhole::TENSIX_GRID_SIZE;
 
         size_t num_harvested_x = CoordinateManager::get_num_harvested(tensix_harvesting_mask);
 
@@ -194,7 +194,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeLogicalTranslatedMapping) {
 
             std::map<CoreCoord, CoreCoord> logical_to_translated;
             std::set<CoreCoord> translated_coords_set;
-            tt_xy_pair tensix_grid_size = tt::umd::blackhole::TENSIX_GRID_SIZE;
+            tt_xy_pair tensix_grid_size = blackhole::TENSIX_GRID_SIZE;
 
             size_t num_harvested_x = CoordinateManager::get_num_harvested(tensix_harvesting_mask);
 
@@ -241,8 +241,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeVirtualEqualTranslated) {
 
             size_t num_harvested_x = CoordinateManager::get_num_harvested(tensix_harvesting_mask);
 
-            for (size_t x = 0; x < tt::umd::blackhole::TENSIX_GRID_SIZE.x - num_harvested_x; x++) {
-                for (size_t y = 0; y < tt::umd::blackhole::TENSIX_GRID_SIZE.y; y++) {
+            for (size_t x = 0; x < blackhole::TENSIX_GRID_SIZE.x - num_harvested_x; x++) {
+                for (size_t y = 0; y < blackhole::TENSIX_GRID_SIZE.y; y++) {
                     CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
                     CoreCoord translated_coords =
                         coordinate_manager->translate_coord_to(logical_coords, CoordSystem::TRANSLATED);
@@ -264,8 +264,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeTensixTranslatedMappingHarvest
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true, {tensix_harvesting_mask});
 
-    const tt_xy_pair tensix_grid_size = tt::umd::blackhole::TENSIX_GRID_SIZE;
-    const std::vector<tt_xy_pair> tensix_cores = tt::umd::blackhole::TENSIX_CORES_NOC0;
+    const tt_xy_pair tensix_grid_size = blackhole::TENSIX_GRID_SIZE;
+    const std::vector<tt_xy_pair> tensix_cores = blackhole::TENSIX_CORES_NOC0;
 
     size_t num_harvested_x = CoordinateManager::get_num_harvested(tensix_harvesting_mask);
 
@@ -293,9 +293,9 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMNoHarvesting) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true);
 
-    const size_t num_dram_banks = tt::umd::blackhole::NUM_DRAM_BANKS;
-    const size_t num_noc_ports_per_bank = tt::umd::blackhole::NUM_NOC_PORTS_PER_DRAM_BANK;
-    const std::vector<tt_xy_pair>& dram_cores = flatten_vector(tt::umd::blackhole::DRAM_CORES_NOC0);
+    const size_t num_dram_banks = blackhole::NUM_DRAM_BANKS;
+    const size_t num_noc_ports_per_bank = blackhole::NUM_NOC_PORTS_PER_DRAM_BANK;
+    const std::vector<tt_xy_pair>& dram_cores = flatten_vector(blackhole::DRAM_CORES_NOC0);
 
     for (size_t dram_bank = 0; dram_bank < num_dram_banks; dram_bank++) {
         for (size_t noc_port = 0; noc_port < num_noc_ports_per_bank; noc_port++) {
@@ -333,10 +333,10 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMTopLeft) {
 // For the reverse mapping back of physical to logical coordinates we expect that same logical coordinates are returned
 // as from original mapping.
 TEST(CoordinateManager, CoordinateManagerBlackholeDRAMLogicalPhysicalMapping) {
-    const size_t max_num_banks_harvested = tt::umd::blackhole::NUM_DRAM_BANKS;
-    const size_t num_dram_banks = tt::umd::blackhole::NUM_DRAM_BANKS;
-    const size_t num_noc_ports_per_bank = tt::umd::blackhole::NUM_NOC_PORTS_PER_DRAM_BANK;
-    const std::vector<tt_xy_pair>& dram_cores = flatten_vector(tt::umd::blackhole::DRAM_CORES_NOC0);
+    const size_t max_num_banks_harvested = blackhole::NUM_DRAM_BANKS;
+    const size_t num_dram_banks = blackhole::NUM_DRAM_BANKS;
+    const size_t num_noc_ports_per_bank = blackhole::NUM_NOC_PORTS_PER_DRAM_BANK;
+    const std::vector<tt_xy_pair>& dram_cores = flatten_vector(blackhole::DRAM_CORES_NOC0);
 
     for (size_t dram_harvesting_mask = 0; dram_harvesting_mask < (1 << max_num_banks_harvested);
          dram_harvesting_mask++) {
@@ -384,9 +384,9 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMLogicalPhysicalMapping) {
 // For the reverse mapping back of virtual to logical coordinates it is expected that same logical coordinates are
 // returned as from original mapping.
 TEST(CoordinateManager, CoordinateManagerBlackholeDRAMLogicalVirtualMapping) {
-    const size_t max_num_banks_harvested = tt::umd::blackhole::NUM_DRAM_BANKS;
-    const size_t num_dram_banks = tt::umd::blackhole::NUM_DRAM_BANKS;
-    const size_t num_noc_ports_per_bank = tt::umd::blackhole::NUM_NOC_PORTS_PER_DRAM_BANK;
+    const size_t max_num_banks_harvested = blackhole::NUM_DRAM_BANKS;
+    const size_t num_dram_banks = blackhole::NUM_DRAM_BANKS;
+    const size_t num_noc_ports_per_bank = blackhole::NUM_NOC_PORTS_PER_DRAM_BANK;
 
     for (size_t dram_harvesting_mask = 0; dram_harvesting_mask < (1 << max_num_banks_harvested);
          dram_harvesting_mask++) {
@@ -427,9 +427,9 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMLogicalVirtualMapping) {
 
 // Test DRAM translated mapping.
 TEST(CoordinateManager, CoordinateManagerBlackholeDRAMTranslatedMapping) {
-    const size_t max_num_banks_harvested = tt::umd::blackhole::NUM_DRAM_BANKS;
-    const size_t num_dram_banks = tt::umd::blackhole::NUM_DRAM_BANKS;
-    const size_t num_noc_ports_per_bank = tt::umd::blackhole::NUM_NOC_PORTS_PER_DRAM_BANK;
+    const size_t max_num_banks_harvested = blackhole::NUM_DRAM_BANKS;
+    const size_t num_dram_banks = blackhole::NUM_DRAM_BANKS;
+    const size_t num_noc_ports_per_bank = blackhole::NUM_NOC_PORTS_PER_DRAM_BANK;
 
     for (size_t dram_harvesting_mask = 0; dram_harvesting_mask < (1 << max_num_banks_harvested);
          dram_harvesting_mask++) {
@@ -451,8 +451,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMTranslatedMapping) {
                 const CoreCoord translated_coords =
                     coordinate_manager->translate_coord_to(logical_coords, CoordSystem::TRANSLATED);
 
-                EXPECT_GE(translated_coords.x, tt::umd::blackhole::dram_translated_coordinate_start_x);
-                EXPECT_GE(translated_coords.y, tt::umd::blackhole::dram_translated_coordinate_start_y);
+                EXPECT_GE(translated_coords.x, blackhole::dram_translated_coordinate_start_x);
+                EXPECT_GE(translated_coords.y, blackhole::dram_translated_coordinate_start_y);
 
                 logical_to_translated[logical_coords] = translated_coords;
 
@@ -477,11 +477,11 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMTranslatedMapping) {
 
 // Test DRAM translated/virtual/physical mapping
 TEST(CoordinateManager, CoordinateManagerBlackholeDRAMVirtualPhysicalMapping) {
-    const size_t max_num_banks_harvested = tt::umd::blackhole::NUM_DRAM_BANKS;
-    const size_t num_dram_banks = tt::umd::blackhole::NUM_DRAM_BANKS;
-    const size_t num_noc_ports_per_bank = tt::umd::blackhole::NUM_NOC_PORTS_PER_DRAM_BANK;
+    const size_t max_num_banks_harvested = blackhole::NUM_DRAM_BANKS;
+    const size_t num_dram_banks = blackhole::NUM_DRAM_BANKS;
+    const size_t num_noc_ports_per_bank = blackhole::NUM_NOC_PORTS_PER_DRAM_BANK;
 
-    const std::vector<tt_xy_pair> dram_cores = flatten_vector(tt::umd::blackhole::DRAM_CORES_NOC0);
+    const std::vector<tt_xy_pair> dram_cores = flatten_vector(blackhole::DRAM_CORES_NOC0);
 
     const size_t dram_harvesting_mask = 1;
 
@@ -492,9 +492,9 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMVirtualPhysicalMapping) {
     const size_t physical_index = 0;
     const size_t virtual_index = (num_dram_banks - 1) * num_noc_ports_per_bank;
 
-    const size_t harvested_translated_bank_x = tt::umd::blackhole::dram_translated_coordinate_start_x + 1;
+    const size_t harvested_translated_bank_x = blackhole::dram_translated_coordinate_start_x + 1;
     const size_t harvested_translated_bank_y =
-        tt::umd::blackhole::dram_translated_coordinate_start_y + 3 * num_noc_ports_per_bank;
+        blackhole::dram_translated_coordinate_start_y + 3 * num_noc_ports_per_bank;
 
     for (size_t noc_port = 0; noc_port < num_noc_ports_per_bank; noc_port++) {
         const tt_xy_pair physical_pair = dram_cores[physical_index + noc_port];
@@ -520,9 +520,9 @@ TEST(CoordinateManager, CoordinateManagerBlackholeDRAMVirtualPhysicalMapping) {
 
 // Test that we cannot create a coordinate manager with more than one DRAM bank harvested.
 TEST(CoordinateManager, CoordinateManagerBlackholeDRAMPMoreThanOneDRAMBankHarvested) {
-    const size_t max_num_banks_harvested = tt::umd::blackhole::NUM_DRAM_BANKS;
-    const size_t num_dram_banks = tt::umd::blackhole::NUM_DRAM_BANKS;
-    const size_t num_noc_ports_per_bank = tt::umd::blackhole::NUM_NOC_PORTS_PER_DRAM_BANK;
+    const size_t max_num_banks_harvested = blackhole::NUM_DRAM_BANKS;
+    const size_t num_dram_banks = blackhole::NUM_DRAM_BANKS;
+    const size_t num_noc_ports_per_bank = blackhole::NUM_NOC_PORTS_PER_DRAM_BANK;
 
     for (size_t dram_harvesting_mask = 0; dram_harvesting_mask < (1 << max_num_banks_harvested);
          dram_harvesting_mask++) {
@@ -575,7 +575,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholePCIETranslationRemote) {
 TEST(CoordinateManager, CoordinateManagerBlackholeARCTranslation) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true);
-    const tt_xy_pair arc_grid_size = tt::umd::blackhole::ARC_GRID_SIZE;
+    const tt_xy_pair arc_grid_size = blackhole::ARC_GRID_SIZE;
 
     for (size_t x = 0; x < arc_grid_size.x; x++) {
         for (size_t y = 0; y < arc_grid_size.y; y++) {
@@ -598,7 +598,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeARCTranslation) {
 TEST(CoordinateManager, CoordinateManagerBlackholeETHTranslation) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true);
-    const size_t num_eth_channels = tt::umd::blackhole::NUM_ETH_CHANNELS;
+    const size_t num_eth_channels = blackhole::NUM_ETH_CHANNELS;
 
     const size_t eth_translated_coordinate_start_x = 20;
     const size_t eth_translated_coordinate_start_y = 25;
@@ -620,8 +620,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeETHTranslation) {
 // Test ETH harvesting and coordinate translation for Blackhole.
 TEST(CoordinateManager, CoordinateManagerBlackholeETHHarvesting) {
     const size_t num_harvested_cores = 2;
-    const std::vector<tt_xy_pair> eth_cores = tt::umd::blackhole::ETH_CORES_NOC0;
-    const size_t num_eth_channels = tt::umd::blackhole::NUM_ETH_CHANNELS;
+    const std::vector<tt_xy_pair> eth_cores = blackhole::ETH_CORES_NOC0;
+    const size_t num_eth_channels = blackhole::NUM_ETH_CHANNELS;
     for (size_t eth_harvesting_mask = 0; eth_harvesting_mask < (1 << num_eth_channels); eth_harvesting_mask++) {
         // We should have exactly 2 harvested ETH cores.
         if (CoordinateManager::get_num_harvested(eth_harvesting_mask) != num_harvested_cores) {
@@ -642,8 +642,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholeETHHarvesting) {
             EXPECT_EQ(eth_virtual.x, eth_cores[eth_channel].x);
             EXPECT_EQ(eth_virtual.y, eth_cores[eth_channel].y);
 
-            EXPECT_EQ(eth_translated.x, tt::umd::blackhole::eth_translated_coordinate_start_x + eth_channel);
-            EXPECT_EQ(eth_translated.y, tt::umd::blackhole::eth_translated_coordinate_start_y);
+            EXPECT_EQ(eth_translated.x, blackhole::eth_translated_coordinate_start_x + eth_channel);
+            EXPECT_EQ(eth_translated.y, blackhole::eth_translated_coordinate_start_y);
         }
 
         // Verify that translated coordinates for harvested cores are same as physical coordinates.
@@ -676,8 +676,8 @@ TEST(CoordinateManager, CoordinateManagerBlackholePhysicalLayoutTensixHarvesting
 
 // Test whether we properly shuffle the harvesting mask based on the physical layout of the chip.
 TEST(CoordinateManager, CoordinateManagerBlackholeHarvestingShuffle) {
-    for (size_t i = 0; i < tt::umd::blackhole::LOGICAL_HARVESTING_LAYOUT.size(); i++) {
-        const size_t tensix_harvesting_mask_physical_layout = (1 << tt::umd::blackhole::LOGICAL_HARVESTING_LAYOUT[i]);
+    for (size_t i = 0; i < blackhole::LOGICAL_HARVESTING_LAYOUT.size(); i++) {
+        const size_t tensix_harvesting_mask_physical_layout = (1 << blackhole::LOGICAL_HARVESTING_LAYOUT[i]);
         const size_t tensix_harvesting_mask = CoordinateManager::shuffle_tensix_harvesting_mask(
             tt::ARCH::BLACKHOLE, tensix_harvesting_mask_physical_layout);
 
@@ -712,7 +712,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeETHNoNocTranslationMapping) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, false);
 
-    const std::vector<tt_xy_pair> eth_pairs = tt::umd::blackhole::ETH_CORES_NOC0;
+    const std::vector<tt_xy_pair> eth_pairs = blackhole::ETH_CORES_NOC0;
     for (const tt_xy_pair& eth_pair : eth_pairs) {
         const CoreCoord eth_core = CoreCoord(eth_pair.x, eth_pair.y, CoreType::ETH, CoordSystem::PHYSICAL);
         const CoreCoord eth_translated = coordinate_manager->translate_coord_to(eth_core, CoordSystem::TRANSLATED);
@@ -788,19 +788,19 @@ TEST(CoordinateManager, CoordinateManagerBlackholeNoc1Noc0Mapping) {
         }
     };
 
-    check_noc0_noc1_mapping(tt::umd::blackhole::TENSIX_CORES_NOC0, TENSIX_CORES_NOC1, CoreType::TENSIX);
+    check_noc0_noc1_mapping(blackhole::TENSIX_CORES_NOC0, TENSIX_CORES_NOC1, CoreType::TENSIX);
     check_noc0_noc1_mapping(
-        flatten_vector(tt::umd::blackhole::DRAM_CORES_NOC0), flatten_vector(DRAM_CORES_NOC1), CoreType::DRAM);
-    check_noc0_noc1_mapping(tt::umd::blackhole::ETH_CORES_NOC0, ETH_CORES_NOC1, CoreType::ETH);
-    check_noc0_noc1_mapping(tt::umd::blackhole::ARC_CORES_NOC0, ARC_CORES_NOC1, CoreType::ARC);
-    check_noc0_noc1_mapping(tt::umd::blackhole::PCIE_CORES_NOC0, PCIE_CORES_NOC1, CoreType::PCIE);
+        flatten_vector(blackhole::DRAM_CORES_NOC0), flatten_vector(DRAM_CORES_NOC1), CoreType::DRAM);
+    check_noc0_noc1_mapping(blackhole::ETH_CORES_NOC0, ETH_CORES_NOC1, CoreType::ETH);
+    check_noc0_noc1_mapping(blackhole::ARC_CORES_NOC0, ARC_CORES_NOC1, CoreType::ARC);
+    check_noc0_noc1_mapping(blackhole::PCIE_CORES_NOC0, PCIE_CORES_NOC1, CoreType::PCIE);
 }
 
 TEST(CoordinateManager, CoordinateManagerBlackholeSecurityTranslation) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true);
 
-    const std::vector<tt_xy_pair> security_cores = tt::umd::blackhole::SECURITY_CORES_NOC0;
+    const std::vector<tt_xy_pair> security_cores = blackhole::SECURITY_CORES_NOC0;
     for (const auto& security_core : security_cores) {
         const CoreCoord noc0_coord =
             CoreCoord(security_core.x, security_core.y, CoreType::SECURITY, CoordSystem::PHYSICAL);
@@ -820,7 +820,7 @@ TEST(CoordinateManager, CoordinateManagerBlackholeL2CPUTranslation) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::BLACKHOLE, true);
 
-    const std::vector<tt_xy_pair> l2cpu_cores = tt::umd::blackhole::L2CPU_CORES_NOC0;
+    const std::vector<tt_xy_pair> l2cpu_cores = blackhole::L2CPU_CORES_NOC0;
     for (const auto& l2cpu_core : l2cpu_cores) {
         const CoreCoord noc0_coord = CoreCoord(l2cpu_core.x, l2cpu_core.y, CoreType::L2CPU, CoordSystem::PHYSICAL);
         const CoreCoord virtual_coord = coordinate_manager->translate_coord_to(noc0_coord, CoordSystem::VIRTUAL);

--- a/tests/api/test_core_coord_translation_wh.cpp
+++ b/tests/api/test_core_coord_translation_wh.cpp
@@ -17,7 +17,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeNoHarvesting) {
         CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true);
 
     // We expect full grid size since there is no harvesting.
-    tt_xy_pair tensix_grid_size = tt::umd::wormhole::TENSIX_GRID_SIZE;
+    tt_xy_pair tensix_grid_size = wormhole::TENSIX_GRID_SIZE;
     for (size_t x = 0; x < tensix_grid_size.x; x++) {
         for (size_t y = 0; y < tensix_grid_size.y; y++) {
             const CoreCoord logical_coords = CoreCoord(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
@@ -111,7 +111,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeLogicalPhysicalMapping) {
 
         std::map<CoreCoord, CoreCoord> logical_to_physical;
         std::set<CoreCoord> physical_coords_set;
-        tt_xy_pair tensix_grid_size = tt::umd::wormhole::TENSIX_GRID_SIZE;
+        tt_xy_pair tensix_grid_size = wormhole::TENSIX_GRID_SIZE;
 
         size_t num_harvested_y = CoordinateManager::get_num_harvested(harvesting_mask);
 
@@ -156,7 +156,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeLogicalVirtualMapping) {
 
         std::map<CoreCoord, CoreCoord> logical_to_virtual;
         std::set<CoreCoord> virtual_coords_set;
-        tt_xy_pair tensix_grid_size = tt::umd::wormhole::TENSIX_GRID_SIZE;
+        tt_xy_pair tensix_grid_size = wormhole::TENSIX_GRID_SIZE;
 
         size_t num_harvested_y = CoordinateManager::get_num_harvested(harvesting_mask);
 
@@ -198,7 +198,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeLogicalTranslatedTopLeft) {
         std::shared_ptr<CoordinateManager> coordinate_manager =
             CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true, {harvesting_mask});
 
-        tt_xy_pair tensix_grid_size = tt::umd::wormhole::TENSIX_GRID_SIZE;
+        tt_xy_pair tensix_grid_size = wormhole::TENSIX_GRID_SIZE;
 
         size_t num_harvested_y = CoordinateManager::get_num_harvested(harvesting_mask);
 
@@ -227,8 +227,8 @@ TEST(CoordinateManager, CoordinateManagerWormholePhysicalVirtualHarvestedMapping
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true, {harvesting_mask});
 
-    const std::vector<tt_xy_pair> tensix_cores = tt::umd::wormhole::TENSIX_CORES_NOC0;
-    const tt_xy_pair tensix_grid_size = tt::umd::wormhole::TENSIX_GRID_SIZE;
+    const std::vector<tt_xy_pair> tensix_cores = wormhole::TENSIX_CORES_NOC0;
+    const tt_xy_pair tensix_grid_size = wormhole::TENSIX_GRID_SIZE;
 
     size_t virtual_index = (tensix_grid_size.y - num_harvested) * tensix_grid_size.x;
 
@@ -252,13 +252,13 @@ TEST(CoordinateManager, CoordinateManagerWormholePhysicalTranslatedHarvestedMapp
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true, {harvesting_mask});
 
-    const std::vector<tt_xy_pair> tensix_cores = tt::umd::wormhole::TENSIX_CORES_NOC0;
-    const tt_xy_pair tensix_grid_size = tt::umd::wormhole::TENSIX_GRID_SIZE;
+    const std::vector<tt_xy_pair> tensix_cores = wormhole::TENSIX_CORES_NOC0;
+    const tt_xy_pair tensix_grid_size = wormhole::TENSIX_GRID_SIZE;
 
     size_t virtual_index = (tensix_grid_size.y - num_harvested) * tensix_grid_size.x;
 
-    const size_t translated_x_start = tt::umd::wormhole::tensix_translated_coordinate_start_x;
-    const size_t translated_y_start = tt::umd::wormhole::tensix_translated_coordinate_start_y;
+    const size_t translated_x_start = wormhole::tensix_translated_coordinate_start_x;
+    const size_t translated_y_start = wormhole::tensix_translated_coordinate_start_y;
 
     size_t logical_x = 0;
     size_t logical_y = tensix_grid_size.y - num_harvested;
@@ -296,9 +296,9 @@ TEST(CoordinateManager, CoordinateManagerWormholeDRAMNoHarvesting) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true);
 
-    const size_t num_dram_banks = tt::umd::wormhole::NUM_DRAM_BANKS;
-    const size_t num_noc_ports_per_bank = tt::umd::wormhole::NUM_NOC_PORTS_PER_DRAM_BANK;
-    const std::vector<tt_xy_pair>& dram_cores = flatten_vector(tt::umd::wormhole::DRAM_CORES_NOC0);
+    const size_t num_dram_banks = wormhole::NUM_DRAM_BANKS;
+    const size_t num_noc_ports_per_bank = wormhole::NUM_NOC_PORTS_PER_DRAM_BANK;
+    const std::vector<tt_xy_pair>& dram_cores = flatten_vector(wormhole::DRAM_CORES_NOC0);
 
     for (size_t dram_bank = 0; dram_bank < num_dram_banks; dram_bank++) {
         for (size_t noc_port = 0; noc_port < num_noc_ports_per_bank; noc_port++) {
@@ -322,7 +322,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeDRAMNoHarvesting) {
 TEST(CoordinateManager, CoordinateManagerWormholeETHPhysicalEqualVirtual) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true);
-    const size_t num_eth_channels = tt::umd::wormhole::NUM_ETH_CHANNELS;
+    const size_t num_eth_channels = wormhole::NUM_ETH_CHANNELS;
 
     for (size_t eth_channel = 0; eth_channel < num_eth_channels; eth_channel++) {
         const CoreCoord eth_logical = CoreCoord(0, eth_channel, CoreType::ETH, CoordSystem::LOGICAL);
@@ -354,7 +354,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeETHTranslated) {
 TEST(CoordinateManager, CoordinateManagerWormholeARCTranslation) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true);
-    const tt_xy_pair arc_grid_size = tt::umd::wormhole::ARC_GRID_SIZE;
+    const tt_xy_pair arc_grid_size = wormhole::ARC_GRID_SIZE;
 
     for (size_t x = 0; x < arc_grid_size.x; x++) {
         for (size_t y = 0; y < arc_grid_size.y; y++) {
@@ -377,7 +377,7 @@ TEST(CoordinateManager, CoordinateManagerWormholeARCTranslation) {
 TEST(CoordinateManager, CoordinateManagerWormholePCIETranslation) {
     std::shared_ptr<CoordinateManager> coordinate_manager =
         CoordinateManager::create_coordinate_manager(tt::ARCH::WORMHOLE_B0, true);
-    const tt_xy_pair pcie_grid_size = tt::umd::wormhole::PCIE_GRID_SIZE;
+    const tt_xy_pair pcie_grid_size = wormhole::PCIE_GRID_SIZE;
 
     for (size_t x = 0; x < pcie_grid_size.x; x++) {
         for (size_t y = 0; y < pcie_grid_size.y; y++) {
@@ -422,8 +422,8 @@ TEST(CoordinateManager, CoordinateManagerWormholePhysicalLayoutTensixHarvestingM
 
 // Test whether we properly shuffle the harvesting mask based on the physical layout of the chip.
 TEST(CoordinateManager, CoordinateManagerWormholeHarvestingShuffle) {
-    for (size_t i = 0; i < tt::umd::wormhole::LOGICAL_HARVESTING_LAYOUT.size(); i++) {
-        const size_t harvesting_mask_physical_layout = (1 << tt::umd::wormhole::LOGICAL_HARVESTING_LAYOUT[i]);
+    for (size_t i = 0; i < wormhole::LOGICAL_HARVESTING_LAYOUT.size(); i++) {
+        const size_t harvesting_mask_physical_layout = (1 << wormhole::LOGICAL_HARVESTING_LAYOUT[i]);
         const size_t harvesting_mask =
             CoordinateManager::shuffle_tensix_harvesting_mask(tt::ARCH::WORMHOLE_B0, harvesting_mask_physical_layout);
 
@@ -520,10 +520,9 @@ TEST(CoordinateManager, CoordinateManagerWormholeNoc1Noc0Mapping) {
         }
     };
 
-    check_noc0_noc1_mapping(tt::umd::wormhole::TENSIX_CORES_NOC0, TENSIX_CORES_NOC1, CoreType::TENSIX);
-    check_noc0_noc1_mapping(
-        flatten_vector(tt::umd::wormhole::DRAM_CORES_NOC0), flatten_vector(DRAM_CORES_NOC1), CoreType::DRAM);
-    check_noc0_noc1_mapping(tt::umd::wormhole::ETH_CORES_NOC0, ETH_CORES_NOC1, CoreType::ETH);
-    check_noc0_noc1_mapping(tt::umd::wormhole::ARC_CORES_NOC0, ARC_CORES_NOC1, CoreType::ARC);
-    check_noc0_noc1_mapping(tt::umd::wormhole::PCIE_CORES_NOC0, PCIE_CORES_NOC1, CoreType::PCIE);
+    check_noc0_noc1_mapping(wormhole::TENSIX_CORES_NOC0, TENSIX_CORES_NOC1, CoreType::TENSIX);
+    check_noc0_noc1_mapping(flatten_vector(wormhole::DRAM_CORES_NOC0), flatten_vector(DRAM_CORES_NOC1), CoreType::DRAM);
+    check_noc0_noc1_mapping(wormhole::ETH_CORES_NOC0, ETH_CORES_NOC1, CoreType::ETH);
+    check_noc0_noc1_mapping(wormhole::ARC_CORES_NOC0, ARC_CORES_NOC1, CoreType::ARC);
+    check_noc0_noc1_mapping(wormhole::PCIE_CORES_NOC0, PCIE_CORES_NOC1, CoreType::PCIE);
 }

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -16,9 +16,9 @@ using namespace tt::umd;
 TEST(SocDescriptor, SocDescriptorWormholeNoHarvesting) {
     tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), true);
 
-    const std::vector<tt_xy_pair> wormhole_tensix_cores = tt::umd::wormhole::TENSIX_CORES_NOC0;
+    const std::vector<tt_xy_pair> wormhole_tensix_cores = wormhole::TENSIX_CORES_NOC0;
 
-    ASSERT_EQ(soc_desc.get_num_dram_channels(), tt::umd::wormhole::NUM_DRAM_BANKS);
+    ASSERT_EQ(soc_desc.get_num_dram_channels(), wormhole::NUM_DRAM_BANKS);
 
     for (const tt_xy_pair& tensix_core : wormhole_tensix_cores) {
         CoreCoord core_coord = soc_desc.get_coord_at(tensix_core, CoordSystem::PHYSICAL);
@@ -37,16 +37,16 @@ TEST(SocDescriptor, SocDescriptorWormholeDRAM) {
 
     const std::vector<std::vector<CoreCoord>> dram_cores = soc_desc.get_dram_cores();
 
-    ASSERT_EQ(dram_cores.size(), tt::umd::wormhole::NUM_DRAM_BANKS);
+    ASSERT_EQ(dram_cores.size(), wormhole::NUM_DRAM_BANKS);
     for (auto& vec : dram_cores) {
-        ASSERT_EQ(vec.size(), tt::umd::wormhole::NUM_NOC_PORTS_PER_DRAM_BANK);
+        ASSERT_EQ(vec.size(), wormhole::NUM_NOC_PORTS_PER_DRAM_BANK);
     }
 }
 
 // Test soc descriptor API for Wormhole when there is tensix harvesting.
 TEST(SocDescriptor, SocDescriptorWormholeOneRowHarvesting) {
-    const tt_xy_pair wormhole_tensix_grid_size = tt::umd::wormhole::TENSIX_GRID_SIZE;
-    const std::vector<tt_xy_pair> wormhole_tensix_cores = tt::umd::wormhole::TENSIX_CORES_NOC0;
+    const tt_xy_pair wormhole_tensix_grid_size = wormhole::TENSIX_GRID_SIZE;
+    const std::vector<tt_xy_pair> wormhole_tensix_cores = wormhole::TENSIX_CORES_NOC0;
     const HarvestingMasks harvesting_masks = {.tensix_harvesting_mask = (1 << 0)};
 
     tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), true, harvesting_masks);
@@ -78,7 +78,7 @@ TEST(SocDescriptor, SocDescriptorWormholeOneRowHarvesting) {
 TEST(SocDescriptor, SocDescriptorWormholeETHLogicalToPhysical) {
     const tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), true);
 
-    const std::vector<tt_xy_pair>& wormhole_eth_cores = tt::umd::wormhole::ETH_CORES_NOC0;
+    const std::vector<tt_xy_pair>& wormhole_eth_cores = wormhole::ETH_CORES_NOC0;
     const uint32_t num_eth_channels = soc_desc.get_num_eth_channels();
     const std::vector<CoreCoord> eth_cores = soc_desc.get_cores(CoreType::ETH);
 
@@ -103,10 +103,10 @@ TEST(SocDescriptor, SocDescriptorWormholeETHLogicalToPhysical) {
 
 // Test ETH translation from logical to physical coordinates.
 TEST(SocDescriptor, SocDescriptorBlackholeETHHarvesting) {
-    const size_t num_eth_cores = tt::umd::blackhole::ETH_CORES_NOC0.size();
+    const size_t num_eth_cores = blackhole::ETH_CORES_NOC0.size();
     const size_t num_harvested_eth_cores = 2;
-    const size_t num_eth_channels = tt::umd::blackhole::NUM_ETH_CHANNELS;
-    const std::vector<tt_xy_pair> blackhole_eth_cores = tt::umd::blackhole::ETH_CORES_NOC0;
+    const size_t num_eth_channels = blackhole::NUM_ETH_CHANNELS;
+    const std::vector<tt_xy_pair> blackhole_eth_cores = blackhole::ETH_CORES_NOC0;
     for (size_t eth_harvesting_mask = 0; eth_harvesting_mask < (1 << num_eth_cores); eth_harvesting_mask++) {
         if (CoordinateManager::get_num_harvested(eth_harvesting_mask) != num_harvested_eth_cores) {
             continue;
@@ -148,9 +148,9 @@ TEST(SocDescriptor, SocDescriptorBlackholeETHHarvesting) {
 TEST(SocDescriptor, SocDescriptorBlackholeNoHarvesting) {
     tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), true);
 
-    const std::vector<tt_xy_pair> blackhole_tensix_cores = tt::umd::blackhole::TENSIX_CORES_NOC0;
+    const std::vector<tt_xy_pair> blackhole_tensix_cores = blackhole::TENSIX_CORES_NOC0;
 
-    ASSERT_EQ(soc_desc.get_num_dram_channels(), tt::umd::blackhole::NUM_DRAM_BANKS);
+    ASSERT_EQ(soc_desc.get_num_dram_channels(), blackhole::NUM_DRAM_BANKS);
 
     for (const tt_xy_pair& tensix_core : blackhole_tensix_cores) {
         CoreCoord core_coord = soc_desc.get_coord_at(tensix_core, CoordSystem::PHYSICAL);
@@ -165,8 +165,8 @@ TEST(SocDescriptor, SocDescriptorBlackholeNoHarvesting) {
 
 // Test soc descriptor API for Blackhole when there is tensix harvesting.
 TEST(SocDescriptor, SocDescriptorBlackholeOneRowHarvesting) {
-    const tt_xy_pair blackhole_tensix_grid_size = tt::umd::blackhole::TENSIX_GRID_SIZE;
-    const std::vector<tt_xy_pair> blackhole_tensix_cores = tt::umd::blackhole::TENSIX_CORES_NOC0;
+    const tt_xy_pair blackhole_tensix_grid_size = blackhole::TENSIX_GRID_SIZE;
+    const std::vector<tt_xy_pair> blackhole_tensix_cores = blackhole::TENSIX_CORES_NOC0;
 
     const HarvestingMasks harvesting_masks = {.tensix_harvesting_mask = 1};
 
@@ -206,19 +206,19 @@ TEST(SocDescriptor, SocDescriptorBlackholeDRAM) {
 
     const std::vector<std::vector<CoreCoord>> dram_cores = soc_desc.get_dram_cores();
 
-    ASSERT_EQ(dram_cores.size(), tt::umd::blackhole::NUM_DRAM_BANKS);
+    ASSERT_EQ(dram_cores.size(), blackhole::NUM_DRAM_BANKS);
     for (auto& vec : dram_cores) {
-        ASSERT_EQ(vec.size(), tt::umd::blackhole::NUM_NOC_PORTS_PER_DRAM_BANK);
+        ASSERT_EQ(vec.size(), blackhole::NUM_NOC_PORTS_PER_DRAM_BANK);
     }
 }
 
 // Test soc descriptor API for Blackhole when there is DRAM harvesting.
 TEST(SocDescriptor, SocDescriptorBlackholeDRAMHarvesting) {
-    const tt_xy_pair blackhole_tensix_grid_size = tt::umd::blackhole::TENSIX_GRID_SIZE;
-    const std::vector<tt_xy_pair> blackhole_tensix_cores = tt::umd::blackhole::TENSIX_CORES_NOC0;
-    const std::vector<tt_xy_pair> blackhole_dram_cores = flatten_vector(tt::umd::blackhole::DRAM_CORES_NOC0);
-    const size_t num_dram_banks = tt::umd::blackhole::NUM_DRAM_BANKS;
-    const size_t num_noc_ports_per_bank = tt::umd::blackhole::NUM_NOC_PORTS_PER_DRAM_BANK;
+    const tt_xy_pair blackhole_tensix_grid_size = blackhole::TENSIX_GRID_SIZE;
+    const std::vector<tt_xy_pair> blackhole_tensix_cores = blackhole::TENSIX_CORES_NOC0;
+    const std::vector<tt_xy_pair> blackhole_dram_cores = flatten_vector(blackhole::DRAM_CORES_NOC0);
+    const size_t num_dram_banks = blackhole::NUM_DRAM_BANKS;
+    const size_t num_noc_ports_per_bank = blackhole::NUM_NOC_PORTS_PER_DRAM_BANK;
 
     const HarvestingMasks harvesting_masks = {.tensix_harvesting_mask = 0, .dram_harvesting_mask = 1};
 
@@ -314,7 +314,7 @@ TEST(SocDescriptor, CustomSocDescriptor) {
 TEST(SocDescriptor, SocDescriptorWormholeMultipleCoordinateSystems) {
     tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/wormhole_b0_8x10.yaml"), true);
 
-    const std::vector<tt_xy_pair> cores_physical = tt::umd::wormhole::TENSIX_CORES_NOC0;
+    const std::vector<tt_xy_pair> cores_physical = wormhole::TENSIX_CORES_NOC0;
 
     std::vector<CoreCoord> virtual_from_physical;
     std::vector<CoreCoord> logical_from_physical;
@@ -339,7 +339,7 @@ TEST(SocDescriptor, SocDescriptorWormholeMultipleCoordinateSystems) {
 TEST(SocDescriptor, SocDescriptorBlackholeMultipleCoordinateSystems) {
     tt_SocDescriptor soc_desc(test_utils::GetAbsPath("tests/soc_descs/blackhole_140_arch_no_eth.yaml"), true);
 
-    const std::vector<tt_xy_pair> cores_physical = tt::umd::blackhole::TENSIX_CORES_NOC0;
+    const std::vector<tt_xy_pair> cores_physical = blackhole::TENSIX_CORES_NOC0;
 
     std::vector<CoreCoord> virtual_from_physical;
     std::vector<CoreCoord> logical_from_physical;
@@ -507,7 +507,7 @@ TEST(SocDescriptor, WormholeNOC1Cores) {
 
     EXPECT_EQ(
         tensix_cores_noc1_yaml.size(),
-        tt::umd::wormhole::TENSIX_GRID_SIZE.x * (tt::umd::wormhole::TENSIX_GRID_SIZE.y - num_harvested_rows));
+        wormhole::TENSIX_GRID_SIZE.x * (wormhole::TENSIX_GRID_SIZE.y - num_harvested_rows));
 
     for (size_t i = 0; i < tensix_cores_noc1_yaml.size(); i++) {
         EXPECT_EQ(tensix_cores_noc1_yaml[i], tensix_cores_noc1_arch[i]);
@@ -556,7 +556,7 @@ TEST(SocDescriptor, BlackholeNOC1Cores) {
 
     EXPECT_EQ(
         tensix_cores_noc1_yaml.size(),
-        tt::umd::blackhole::TENSIX_GRID_SIZE.y * (tt::umd::blackhole::TENSIX_GRID_SIZE.x - num_harvested_columns));
+        blackhole::TENSIX_GRID_SIZE.y * (blackhole::TENSIX_GRID_SIZE.x - num_harvested_columns));
 
     for (size_t i = 0; i < tensix_cores_noc1_yaml.size(); i++) {
         EXPECT_EQ(tensix_cores_noc1_yaml[i], tensix_cores_noc1_arch[i]);

--- a/tests/api/test_tlb_manager.cpp
+++ b/tests/api/test_tlb_manager.cpp
@@ -74,7 +74,7 @@ TEST(ApiTLBManager, ManualTLBConfiguration) {
 
         // Another way to write to the TLB.
         // TODO: This should be converted to AbstractIO writer.
-        tt::Writer writer = tlb_manager->get_static_tlb_writer(any_worker_virtual_core);
+        Writer writer = tlb_manager->get_static_tlb_writer(any_worker_virtual_core);
         writer.write(address_l1_to_write, buffer_to_write[0]);
     }
 }

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -85,7 +85,7 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 30}, {1, 60}};
 //     {
 //         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
-//             tt::umd::Cluster::create_cluster_descriptor();
+//             Cluster::create_cluster_descriptor();
 //         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
 //             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
 //             system";
@@ -114,7 +114,7 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 30}, {1, 60}};
 //     {
 //         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
-//             tt::umd::Cluster::create_cluster_descriptor();
+//             Cluster::create_cluster_descriptor();
 //         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
 //             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
 //             system";

--- a/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
+++ b/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
@@ -163,7 +163,7 @@ TEST(MicrobenchmarkPCIeDMA, DMATensixZeroCopy) {
     guard_test_iommu();
 
     const uint32_t NUM_ITERATIONS = 1000;
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(tt::umd::ClusterOptions{
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{
         .num_host_mem_ch_per_mmio_device = 0,
     });
 
@@ -191,7 +191,7 @@ TEST(MicrobenchmarkPCIeDMA, MapSysmemBuffer) {
     guard_test_iommu();
 
     const uint32_t NUM_ITERATIONS = 1000;
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(tt::umd::ClusterOptions{
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{
         .num_host_mem_ch_per_mmio_device = 0,
     });
 
@@ -220,7 +220,7 @@ TEST(MicrobenchmarkPCIeDMA, DMATensixMapBufferZeroCopy) {
     guard_test_iommu();
 
     const uint32_t NUM_ITERATIONS = 100;
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(tt::umd::ClusterOptions{
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{
         .num_host_mem_ch_per_mmio_device = 0,
     });
 
@@ -267,7 +267,7 @@ TEST(MicrobenchmarkPCIeDMA, DMADRAMZeroCopy) {
     guard_test_iommu();
 
     const uint32_t NUM_ITERATIONS = 10;
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(tt::umd::ClusterOptions{
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{
         .num_host_mem_ch_per_mmio_device = 0,
     });
 

--- a/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
+++ b/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
@@ -128,7 +128,7 @@ TEST(MicrobenchmarkTLB, TLBStaticTensix) {
     const CoreCoord tensix_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)[0];
     cluster->start_device(tt_device_params{});
 
-    cluster->configure_tlb(0, tensix_core, tlb_1m_index, 0x0, TLB_DATA::Relaxed);
+    cluster->configure_tlb(0, tensix_core, tlb_1m_index, 0x0, tlb_data::Relaxed);
 
     const std::vector<uint32_t> sizes = {
         1 * one_mb,
@@ -164,7 +164,7 @@ TEST(MicrobenchmarkTLB, TLBStaticDram) {
     const CoreCoord dram_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::DRAM)[0];
     cluster->start_device(tt_device_params{});
 
-    cluster->configure_tlb(0, dram_core, tlb_16m_index, 0x0, TLB_DATA::Relaxed);
+    cluster->configure_tlb(0, dram_core, tlb_16m_index, 0x0, tlb_data::Relaxed);
 
     for (uint32_t buf_size : sizes) {
         const uint32_t num_io = buf_size / (16 * one_mb);

--- a/tests/misc/test_semver.cpp
+++ b/tests/misc/test_semver.cpp
@@ -10,7 +10,7 @@
 
 #include "umd/device/semver.hpp"
 
-using tt::umd::semver_t;
+using namespace tt::umd;
 
 TEST(Semver, Valid) {
     const std::map<std::string, semver_t> valid_test_cases = {

--- a/tests/pcie/test_pcie_device.cpp
+++ b/tests/pcie/test_pcie_device.cpp
@@ -14,6 +14,8 @@
 #include "fmt/xchar.h"
 #include "umd/device/pci_device.hpp"
 
+using namespace tt::umd;
+
 TEST(PcieDeviceTest, Numa) {
     std::vector<int> nodes;
 

--- a/tests/simulation/device_fixture.hpp
+++ b/tests/simulation/device_fixture.hpp
@@ -15,6 +15,8 @@
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "umd/device/tt_simulation_device.h"
 
+namespace tt::umd {
+
 class SimulationDeviceFixture : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
@@ -34,3 +36,5 @@ protected:
 };
 
 std::unique_ptr<tt_SimulationDevice> SimulationDeviceFixture::device = nullptr;
+
+}  // namespace tt::umd

--- a/tests/simulation/test_simulation_device.cpp
+++ b/tests/simulation/test_simulation_device.cpp
@@ -29,7 +29,7 @@ TEST_P(LoopbackAllCoresParam, LoopbackSingleTensix) {
     std::vector<uint32_t> wdata = {1, 2, 3, 4, 5};
     std::vector<uint32_t> rdata(wdata.size(), 0);
     auto &soc_desc = device->get_soc_descriptor();
-    tt::umd::CoreCoord core = soc_desc.get_coord_at(GetParam(), CoordSystem::VIRTUAL);
+    CoreCoord core = soc_desc.get_coord_at(GetParam(), CoordSystem::VIRTUAL);
 
     device->write_to_device(core, wdata.data(), 0x100, wdata.size() * sizeof(uint32_t));
     device->read_from_device(core, rdata.data(), 0x100, rdata.size() * sizeof(uint32_t));
@@ -37,7 +37,7 @@ TEST_P(LoopbackAllCoresParam, LoopbackSingleTensix) {
     ASSERT_EQ(wdata, rdata);
 }
 
-bool loopback_stress_size(std::unique_ptr<tt_SimulationDevice> &device, tt::umd::CoreCoord core, uint32_t byte_shift) {
+bool loopback_stress_size(std::unique_ptr<tt_SimulationDevice> &device, CoreCoord core, uint32_t byte_shift) {
     uint64_t addr = 0x0;
 
     std::vector<uint32_t> wdata = generate_data(1 << byte_shift);
@@ -51,8 +51,8 @@ bool loopback_stress_size(std::unique_ptr<tt_SimulationDevice> &device, tt::umd:
 
 TEST_P(LoopbackAllCoresParam, LoopbackStressSize) {
     auto &soc_desc = device->get_soc_descriptor();
-    tt::umd::CoreCoord core = soc_desc.get_coord_at(GetParam(), CoordSystem::VIRTUAL);
-    tt::umd::CoreCoord dram = soc_desc.get_coord_at({1, 0}, CoordSystem::VIRTUAL);
+    CoreCoord core = soc_desc.get_coord_at(GetParam(), CoordSystem::VIRTUAL);
+    CoreCoord dram = soc_desc.get_coord_at({1, 0}, CoordSystem::VIRTUAL);
     if (core == dram) {
         for (uint32_t i = 2; i <= 30; ++i) {  // 2^30 = 1 GB
             ASSERT_TRUE(loopback_stress_size(device, core, i));
@@ -70,8 +70,8 @@ TEST_F(SimulationDeviceFixture, LoopbackTwoTensix) {
     std::vector<uint32_t> wdata2 = {6, 7, 8, 9, 10};
     std::vector<uint32_t> rdata1(wdata1.size());
     std::vector<uint32_t> rdata2(wdata2.size());
-    tt::umd::CoreCoord core1 = soc_desc.get_coord_at({0, 1}, CoordSystem::VIRTUAL);
-    tt::umd::CoreCoord core2 = soc_desc.get_coord_at({1, 1}, CoordSystem::VIRTUAL);
+    CoreCoord core1 = soc_desc.get_coord_at({0, 1}, CoordSystem::VIRTUAL);
+    CoreCoord core2 = soc_desc.get_coord_at({1, 1}, CoordSystem::VIRTUAL);
 
     device->write_to_device(core1, wdata1.data(), 0x100, wdata1.size() * sizeof(uint32_t));
     device->write_to_device(core2, wdata2.data(), 0x100, wdata2.size() * sizeof(uint32_t));

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -13,6 +13,8 @@
 #include "umd/device/cluster.h"
 #include "umd/device/tt_cluster_descriptor.h"
 
+using namespace tt::umd;
+
 namespace test_utils {
 
 template <typename T>
@@ -25,12 +27,7 @@ static void size_buffer_to_capacity(std::vector<T>& data_buf, std::size_t size_i
 }
 
 static void read_data_from_device(
-    tt::umd::Cluster& cluster,
-    std::vector<uint32_t>& vec,
-    chip_id_t chip_id,
-    tt::umd::CoreCoord core,
-    uint64_t addr,
-    uint32_t size) {
+    Cluster& cluster, std::vector<uint32_t>& vec, chip_id_t chip_id, CoreCoord core, uint64_t addr, uint32_t size) {
     size_buffer_to_capacity(vec, size);
     cluster.read_from_device(vec.data(), chip_id, core, addr, size);
 }

--- a/tests/wormhole/test_arc_messages_wh.cpp
+++ b/tests/wormhole/test_arc_messages_wh.cpp
@@ -24,7 +24,7 @@ TEST(WormholeArcMessages, WormholeArcMessagesHarvesting) {
 
         std::vector<uint32_t> arc_msg_return_values = {0};
         uint32_t response = arc_messenger->send_message(
-            tt::umd::wormhole::ARC_MSG_COMMON_PREFIX |
+            wormhole::ARC_MSG_COMMON_PREFIX |
                 tt_device->get_architecture_implementation()->get_arc_message_arc_get_harvesting(),
             arc_msg_return_values,
             0,
@@ -47,7 +47,7 @@ TEST(WormholeArcMessages, WormholeArcMessagesAICLK) {
         std::unique_ptr<ArcMessenger> arc_messenger = ArcMessenger::create_arc_messenger(tt_device);
 
         uint32_t response = arc_messenger->send_message(
-            tt::umd::wormhole::ARC_MSG_COMMON_PREFIX |
+            wormhole::ARC_MSG_COMMON_PREFIX |
                 tt_device->get_architecture_implementation()->get_arc_message_arc_go_busy(),
             0,
             0);
@@ -57,10 +57,10 @@ TEST(WormholeArcMessages, WormholeArcMessagesAICLK) {
         uint32_t aiclk = tt_device->get_clock();
 
         // TODO #781: For now expect only that busy val is something larger than idle val.
-        EXPECT_GT(aiclk, tt::umd::wormhole::AICLK_IDLE_VAL);
+        EXPECT_GT(aiclk, wormhole::AICLK_IDLE_VAL);
 
         response = arc_messenger->send_message(
-            tt::umd::wormhole::ARC_MSG_COMMON_PREFIX |
+            wormhole::ARC_MSG_COMMON_PREFIX |
                 tt_device->get_architecture_implementation()->get_arc_message_arc_go_long_idle(),
             0,
             0);
@@ -69,7 +69,7 @@ TEST(WormholeArcMessages, WormholeArcMessagesAICLK) {
 
         aiclk = tt_device->get_clock();
 
-        EXPECT_EQ(aiclk, tt::umd::wormhole::AICLK_IDLE_VAL);
+        EXPECT_EQ(aiclk, wormhole::AICLK_IDLE_VAL);
     }
 }
 
@@ -89,7 +89,7 @@ TEST(WormholeArcMessages, MultipleThreadsArcMessages) {
             for (uint32_t loop = 0; loop < num_loops; loop++) {
                 std::vector<uint32_t> arc_msg_return_values = {0};
                 uint32_t response = arc_messenger->send_message(
-                    tt::umd::wormhole::ARC_MSG_COMMON_PREFIX |
+                    wormhole::ARC_MSG_COMMON_PREFIX |
                         tt_device->get_architecture_implementation()->get_arc_message_arc_get_harvesting(),
                     arc_msg_return_values,
                     0,
@@ -107,7 +107,7 @@ TEST(WormholeArcMessages, MultipleThreadsArcMessages) {
             for (uint32_t loop = 0; loop < num_loops; loop++) {
                 std::vector<uint32_t> arc_msg_return_values = {0};
                 uint32_t response = arc_messenger->send_message(
-                    tt::umd::wormhole::ARC_MSG_COMMON_PREFIX |
+                    wormhole::ARC_MSG_COMMON_PREFIX |
                         tt_device->get_architecture_implementation()->get_arc_message_arc_get_harvesting(),
                     arc_msg_return_values,
                     0,

--- a/tools/topology.cpp
+++ b/tools/topology.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[]) {
         pci_ids = extract_int_set(result["pci_devices"]);
     }
 
-    std::unique_ptr<tt_ClusterDescriptor> cluster_descriptor = tt::umd::Cluster::create_cluster_descriptor("", pci_ids);
+    std::unique_ptr<tt_ClusterDescriptor> cluster_descriptor = Cluster::create_cluster_descriptor("", pci_ids);
 
     if (result.count("logical_devices")) {
         std::unordered_set<int> logical_device_ids = extract_int_set(result["logical_devices"]);


### PR DESCRIPTION
### Issue
#103 

### Description
Making our classes consistent with tt::umd namespace. Following PR will change the naming to remove tt_ prefixes.

### List of the changes
- Wrapped all in tt::umd namespace
- Removed all tt::umd:: prefixes for types
- Removed using TLB_DATA = tt::umd::tlb_data;
- Added tt::umd:: prefixes for std::hash implementations
- Removed "using namespace tt::umd;" from .cpp files, and switched to "namespace tt::umd {"
- Changed "namespace tt { namespace cpuset {" to "namespace tt::cpuset {"
- Changed "#include "umd/device/tt_cluster_descriptor.h" to "#include "umd/device/types/cluster_descriptor_types.h"" in cpuset, and added missing regex/memory includes in other files
- Added many usings at the end of the header files so that we can do two phase change in tt_metal and exalens

### Testing
Not much testing, clients still build

### API Changes
There are API changes in the naming, but I created a change so it allows for both new and old names to be used, and will create metal changes subsequently.
