### PR TITLE
Sweep buffer sizes in PCIe DMA benchmark

### DIFF
--- a/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
+++ b/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
@@ -21,6 +21,7 @@ using namespace tt::umd;
 
 const chip_id_t chip = 0;
 const uint32_t one_mb = 1 << 20;
+const uint32_t one_gb = 1 << 30;
 const uint32_t NUM_ITERATIONS = 1000;
 
 static inline void print_speed(std::string direction, size_t bytes, uint64_t ns) {
@@ -39,8 +40,8 @@ static inline void perf_read_write(
     const std::string& direction_to_device,
     const std::string& direction_from_device) {
     std::cout << std::endl;
-    std::cout << "Reporting results for buffer size " << (buf_size / one_mb) << " MB being transfered "
-              << num_iterations << " number of times." << std::endl;
+    std::cout << "Reporting results for buffer size " << buf_size << " bytes (" << ((double)buf_size / one_mb)
+              << " MB) being transfered " << num_iterations << " number of times." << std::endl;
     std::cout << "--------------------------------------------------------" << std::endl;
 
     std::vector<uint8_t> pattern(buf_size);
@@ -116,6 +117,50 @@ TEST(MicrobenchmarkPCIeDMA, DMATensix) {
     cluster->start_device(tt_device_params{});
 
     for (uint32_t buf_size : sizes) {
+        perf_read_write(
+            buf_size,
+            NUM_ITERATIONS,
+            cluster,
+            tensix_core,
+            "DMA: Host -> Device Tensix L1",
+            "DMA: Device Tensix L1 -> Host");
+    }
+}
+
+/**
+ * Microbenchmark to test the PCIe DMA reads/write to Tensix by sweeping through
+ * different buffer sizes, starting from 4 bytes up to 1 MB.
+ */
+TEST(MicrobenchmarkPCIeDMA, TensixSweepSizes) {
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    const CoreCoord tensix_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)[0];
+    cluster->start_device(tt_device_params{});
+
+    const uint64_t limit_buf_size = one_mb;
+
+    for (uint64_t buf_size = 4; buf_size <= limit_buf_size; buf_size *= 2) {
+        perf_read_write(
+            buf_size,
+            NUM_ITERATIONS,
+            cluster,
+            tensix_core,
+            "DMA: Host -> Device Tensix L1",
+            "DMA: Device Tensix L1 -> Host");
+    }
+}
+
+/**
+ * Microbenchmark to test the PCIe DMA reads/writes to DRAM by sweeping through
+ * different buffer sizes, starting from 4 bytes up to 1 MB.
+ */
+TEST(MicrobenchmarkPCIeDMA, DramSweepSizes) {
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    const CoreCoord tensix_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)[0];
+    cluster->start_device(tt_device_params{});
+
+    const uint64_t limit_buf_size = one_gb;
+
+    for (uint64_t buf_size = 4; buf_size <= limit_buf_size; buf_size *= 2) {
         perf_read_write(
             buf_size,
             NUM_ITERATIONS,


### PR DESCRIPTION
### Issue

Have a benchmark to sweep all buffer sizes for PCIe DMA transfers

### Description

Add a benchmark to sweep across sizes for PCIe DMA transfers. Results seem bad for smaller sizes which was expected, I am going to add results in the follow up PR

### List of the changes

- Add benchmark to sweep sizes for Tensix transfers
- Add benchmark to sweep sizes for DRAM sizes

### Testing
CI

### API Changes
/