### PR TITLE
Add test to verify standard topologies

### DIFF
--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -343,6 +343,10 @@ TEST(ApiClusterDescriptorTest, VerifyStandardTopology) {
 
     auto all_chips = cluster_desc->get_all_chips();
 
+    if (all_chips.size() == 0) {
+        GTEST_SKIP() << "No chips present on the system. Skipping test.";
+    }
+
     switch (all_chips.size()) {
         // This covers N150, P100, P150.
         case 1: {

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -430,5 +430,10 @@ TEST(ApiClusterDescriptorTest, VerifyStandardTopology) {
             EXPECT_EQ(count_n150, 4) << "Expected 4 N150 chips in 4U galaxy, found " << count_n150;
             break;
         }
+
+        default: {
+            throw std::runtime_error(
+                "Unexpected number of chips in the cluster descriptor: " + std::to_string(all_chips.size()));
+        }
     }
 }

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -393,7 +393,7 @@ TEST(ApiClusterDescriptorTest, VerifyStandardTopology) {
             break;
         }
 
-            // This covers 6U galaxy.
+        // This covers 6U galaxy.
         case 32: {
             auto chips_with_mmio = cluster_desc->get_chips_with_mmio();
             EXPECT_EQ(chips_with_mmio.size(), 32);
@@ -415,9 +415,8 @@ TEST(ApiClusterDescriptorTest, VerifyStandardTopology) {
             auto chips_with_mmio = cluster_desc->get_chips_with_mmio();
             EXPECT_EQ(chips_with_mmio.size(), 4);
 
-            // TODO: is this fixed for 4U
-            // auto eth_connections = cluster_desc->get_ethernet_connections();
-            // EXPECT_EQ(count_connections(eth_connections), 0);
+            auto eth_connections = cluster_desc->get_ethernet_connections();
+            EXPECT_EQ(count_connections(eth_connections), 432);
 
             size_t count_n150 = 0;
             for (auto chip : all_chips) {

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -14,6 +14,16 @@
 
 using namespace tt::umd;
 
+int count_connections(const std::unordered_map<
+                      chip_id_t,
+                      std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>>& connections) {
+    size_t count = 0;
+    for (const auto& [_, channels] : connections) {
+        count += channels.size();
+    }
+    return count;
+}
+
 TEST(ApiClusterDescriptorTest, DetectArch) {
     std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
 
@@ -230,18 +240,6 @@ TEST(ApiClusterDescriptorTest, ConstrainedTopology) {
     std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(
         test_utils::GetAbsPath("tests/api/cluster_descriptor_examples/wormhole_4xN300_mesh.yaml"));
 
-    // Lambda which counts number of items in the ethernet connections map.
-    auto count_connections =
-        [](const std::unordered_map<
-            chip_id_t,
-            std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>>& connections) {
-            size_t count = 0;
-            for (const auto& [_, channels] : connections) {
-                count += channels.size();
-            }
-            return count;
-        };
-
     // Lambda which counts of unique chip links.
     auto count_unique_chip_connections =
         [](const std::unordered_map<
@@ -352,7 +350,7 @@ TEST(ApiClusterDescriptorTest, VerifyStandardTopology) {
             EXPECT_EQ(chips_with_mmio.size(), 1);
 
             auto eth_connections = cluster_desc->get_ethernet_connections();
-            EXPECT_EQ(eth_connections.size(), 0);
+            EXPECT_EQ(count_connections(eth_connections), 0);
 
             for (auto chip : all_chips) {
                 BoardType board_type = cluster_desc->get_board_type(chip);
@@ -369,7 +367,7 @@ TEST(ApiClusterDescriptorTest, VerifyStandardTopology) {
             EXPECT_EQ(chips_with_mmio.size(), 1);
 
             auto eth_connections = cluster_desc->get_ethernet_connections();
-            EXPECT_EQ(eth_connections.size(), 2);
+            EXPECT_EQ(count_connections(eth_connections), 4);
 
             for (auto chip : all_chips) {
                 BoardType board_type = cluster_desc->get_board_type(chip);
@@ -385,7 +383,7 @@ TEST(ApiClusterDescriptorTest, VerifyStandardTopology) {
             EXPECT_EQ(chips_with_mmio.size(), 4);
 
             auto eth_connections = cluster_desc->get_ethernet_connections();
-            EXPECT_EQ(eth_connections.size(), 20);
+            EXPECT_EQ(count_connections(eth_connections), 40);
 
             for (auto chip : all_chips) {
                 BoardType board_type = cluster_desc->get_board_type(chip);
@@ -402,7 +400,7 @@ TEST(ApiClusterDescriptorTest, VerifyStandardTopology) {
 
             // TODO: is this fixed for 6U
             // auto eth_connections = cluster_desc->get_ethernet_connections();
-            // EXPECT_EQ(eth_connections.size(), 0);
+            // EXPECT_EQ(count_connections(eth_connections), 0);
 
             for (auto chip : all_chips) {
                 BoardType board_type = cluster_desc->get_board_type(chip);
@@ -419,7 +417,7 @@ TEST(ApiClusterDescriptorTest, VerifyStandardTopology) {
 
             // TODO: is this fixed for 4U
             // auto eth_connections = cluster_desc->get_ethernet_connections();
-            // EXPECT_EQ(eth_connections.size(), 0);
+            // EXPECT_EQ(count_connections(eth_connections), 0);
 
             size_t count_n150 = 0;
             for (auto chip : all_chips) {

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -402,9 +402,8 @@ TEST(ApiClusterDescriptorTest, VerifyStandardTopology) {
             auto chips_with_mmio = cluster_desc->get_chips_with_mmio();
             EXPECT_EQ(chips_with_mmio.size(), 32);
 
-            // TODO: is this fixed for 6U
-            // auto eth_connections = cluster_desc->get_ethernet_connections();
-            // EXPECT_EQ(count_connections(eth_connections), 0);
+            auto eth_connections = cluster_desc->get_ethernet_connections();
+            EXPECT_EQ(count_connections(eth_connections), 512);
 
             for (auto chip : all_chips) {
                 BoardType board_type = cluster_desc->get_board_type(chip);


### PR DESCRIPTION
### Issue

Have some level of certainty that topology discovery reports good topology on standard TT topologies

### Description

Add test that based on number of chips in topology asserts on some common numbers expected in standard TT topologies. This test is supposed to be run in CI to verify that topology discovery works as expected on standard TT topologies
- single chip N150, P150
- multichip N300, P300
- T3000
- Galaxies

### List of the changes

- Add a test
- Assert on number of ETH connections
- Assert on board types

### Testing
CI

### API Changes
/
