### PR TITLE
Add UMD perf workflow

### DIFF
--- a/.github/workflows/build-and-run-all-benchmarks.yml
+++ b/.github/workflows/build-and-run-all-benchmarks.yml
@@ -1,0 +1,44 @@
+# Build and then run all benchmarks, on all supported archs.
+name: Build and run all benchmarks
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-type:
+        required: false
+        default: Release
+
+jobs:
+  build-tests:
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu-docker-version: [
+          'ubuntu-22.04',
+          'ubuntu-24.04',
+        ]
+    uses: ./.github/workflows/build-tests.yml
+    with:
+      ubuntu-docker-version: ${{ matrix.ubuntu-docker-version}}
+      timeout: 10
+      build-type: ${{ inputs.build-type || 'Release' }}
+
+  run-benchmarks:
+    secrets: inherit
+    needs: build-tests
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          {arch: wormhole_b0, card: tt-beta-ubuntu-2204-n150-viommu-large-stable, timeout: 45},
+        ]
+        ubuntu-docker-version: [
+          'ubuntu-22.04',
+        ]
+    uses: ./.github/workflows/run-benchmarks.yml
+    with:
+      arch: ${{ matrix.test-group.arch}}
+      ubuntu-docker-version: ${{ matrix.ubuntu-docker-version}}
+      card: ${{ matrix.test-group.card}}
+      timeout: ${{ matrix.test-group.timeout}}

--- a/.github/workflows/build-and-run-all-benchmarks.yml
+++ b/.github/workflows/build-and-run-all-benchmarks.yml
@@ -7,6 +7,13 @@ on:
       build-type:
         required: false
         default: Release
+        type: choice
+        options:
+          - Release
+          - RelWithDebInfo
+          - Debug
+          - ASan
+          - TSan
 
 jobs:
   build-tests:

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -1,0 +1,79 @@
+# Run UMD benchmarks on the specified architecture and card, on all supported OS versions.
+name: Run UMD benchmarks
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      ubuntu-docker-version:
+        required: true
+        type: string
+      card:
+        required: true
+        type: string
+      timeout:
+        required: true
+        type: number
+
+env:
+  BUILD_OUTPUT_DIR: ./build
+  TEST_OUTPUT_DIR: ./build/test
+  CREATE_MAP_BINARIES_DIR: ./device/bin/silicon
+  TT_UMD_LOGGER_LEVEL: info
+
+jobs:
+  test:
+    # Due to parsing bug, fromJSON is used to convert string to number
+    timeout-minutes: ${{ fromJSON(inputs.timeout) }}
+
+    name: Run benchmarks for ${{ inputs.arch }} on ${{ inputs.card }} on ${{ inputs.ubuntu-docker-version }}
+    runs-on:
+      - ${{ inputs.card }}
+    container:
+      image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}:latest
+      options: --user root ${{ inputs.arch != 'baremetal' && '--device /dev/tenstorrent' || '' }}
+      volumes:
+        - /dev/hugepages:/dev/hugepages
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /etc/udev/rules.d:/etc/udev/rules.d
+        - /lib/modules:/lib/modules
+        - /opt/tt_metal_infra/provisioning/provisioning_env:/opt/tt_metal_infra/provisioning/provisioning_env
+
+    env:
+      LD_LIBRARY_PATH: ./build/lib
+
+    steps:
+      - name: Cleanup tt-umd dir, and change directory as if we were in a github.repository
+        run: |
+          rm -rf tt-umd
+          mkdir tt-umd
+          cd tt-umd
+
+      - name: Use build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts-${{ inputs.ubuntu-docker-version }}
+          path: ./
+
+      # This is needed to preserve file permissions
+      # https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss
+      - name: 'Untar build artifacts'
+        shell: bash
+        run: tar xvf artifact.tar
+
+      - name: Run TLB benchmarks
+        if: ${{ inputs.arch != 'baremetal' }}
+        run: |
+          ${{ env.TEST_OUTPUT_DIR }}/umd/ubenchmarks/ubench --gtest_filter=MicrobenchmarkTLB*
+
+      - name: Run PCIe benchmarks
+        if: ${{ inputs.arch != 'baremetal' }}
+        run: |
+          ${{ env.TEST_OUTPUT_DIR }}/umd/ubenchmarks/ubench --gtest_filter=MicrobenchmarkPCIeDMA*
+
+      - name: Run IOMMU benchmarks
+        if: ${{ inputs.arch != 'baremetal' }}
+        run: |
+          ${{ env.TEST_OUTPUT_DIR }}/umd/ubenchmarks/ubench --gtest_filter=MicrobenchmarkIOMMU*

--- a/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
+++ b/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
@@ -75,9 +75,6 @@ TEST(MicrobenchmarkTLB, TLBDynamicDram) {
         8 * one_mb,
         16 * one_mb,
         32 * one_mb,
-        64 * one_mb,
-        128 * one_mb,
-        256 * one_mb,
     };
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
@@ -153,11 +150,6 @@ TEST(MicrobenchmarkTLB, TLBStaticDram) {
     const std::vector<uint32_t> sizes = {
         16 * one_mb,
         32 * one_mb,
-        64 * one_mb,
-        128 * one_mb,
-        256 * one_mb,
-        512 * one_mb,
-        1024 * one_mb,
     };
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();

--- a/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
+++ b/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
@@ -68,6 +68,9 @@ static inline void perf_read_write(
  * Measure BW of IO to DRAM core using dynamically configured TLB.
  */
 TEST(MicrobenchmarkTLB, TLBDynamicDram) {
+    // Sizes are chosen in a way to avoid TLB benchmark taking too long. 32 MB already
+    // tests chunking of data into smaller chunks to match TLB size.
+    // 64 MB and above showed the same perf locally.
     const std::vector<uint32_t> sizes = {
         1 * one_mb,
         2 * one_mb,
@@ -147,6 +150,9 @@ TEST(MicrobenchmarkTLB, TLBStaticTensix) {
  * Measure BW of IO to DRAM core using dynamically configured TLB.
  */
 TEST(MicrobenchmarkTLB, TLBStaticDram) {
+    // Sizes are chosen in a way to avoid TLB benchmark taking too long. 32 MB already
+    // tests chunking of data into smaller chunks to match TLB size.
+    // 64 MB and above showed the same perf locally.
     const std::vector<uint32_t> sizes = {
         16 * one_mb,
         32 * one_mb,


### PR DESCRIPTION
### Issue

#1052 

### Description

Add Github workflow for UMD perf tests. We are not going to run this on CI for now, because it takes lot more time than regular CI. Idea is that someone who wants to see UMD perf can run Github action and just copy-paste perf if needed from the log to the README table. For now we are running perf tests just on N150 with IOMMU enabled.

### List of the changes

- Add yaml for build and run benchmarks workflow
- Add yaml for run benchmarks workflow
- Reduce TLB tests in terms of sizes since they take too long. We should think about proper number of iterations/sizes for these tests

### Testing

Manual testing by running Github actions

### API Changes
/