### PR TITLE
Print UMD perf in markdown style

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,7 @@ You can also manually auto format the whole repo using mentioned pre-commit:
 # Grayskull End of Life
 
 Grayskull is no longer actively supported by Tenstorrent. [Last UMD commit](https://github.com/tenstorrent/tt-umd/commit/a5b4719b7d44f0c7c953542803faf6851574329a) supporting Grayskull.
+
+| Size (MB) | Host -> Device Tensix L1 (MB/s) | Device Tensix L1 -> Host (MB/s) |
+|---|---|---|
+| 1.000000 | 13288.172328 | 2485.023009 |

--- a/README.md
+++ b/README.md
@@ -165,7 +165,3 @@ You can also manually auto format the whole repo using mentioned pre-commit:
 # Grayskull End of Life
 
 Grayskull is no longer actively supported by Tenstorrent. [Last UMD commit](https://github.com/tenstorrent/tt-umd/commit/a5b4719b7d44f0c7c953542803faf6851574329a) supporting Grayskull.
-
-| Size (MB) | Host -> Device Tensix L1 (MB/s) | Device Tensix L1 -> Host (MB/s) |
-|---|---|---|
-| 1.000000 | 13288.172328 | 2485.023009 |

--- a/tests/microbenchmark/CMakeLists.txt
+++ b/tests/microbenchmark/CMakeLists.txt
@@ -10,7 +10,12 @@ target_link_libraries(
         test_common
         nanobench
 )
-target_include_directories(ubench PRIVATE ${nanobench_SOURCE_DIR}/src/include)
+target_include_directories(
+    ubench
+    PRIVATE
+        ${nanobench_SOURCE_DIR}/src/include
+        .
+)
 set_target_properties(
     ubench
     PROPERTIES

--- a/tests/microbenchmark/CMakeLists.txt
+++ b/tests/microbenchmark/CMakeLists.txt
@@ -2,6 +2,7 @@ set(UBENCH_SRC
     benchmarks/tlb/test_tlb.cpp
     benchmarks/pcie_dma/test_pcie_dma.cpp
     benchmarks/iommu/test_iommu.cpp
+    common/microbenchmark_utils.cpp
 )
 add_executable(ubench ${UBENCH_SRC})
 target_link_libraries(

--- a/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
+++ b/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
@@ -5,6 +5,7 @@
  */
 #include <sys/mman.h>
 
+#include "common/microbenchmark_utils.h"
 #include "gtest/gtest.h"
 #include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
@@ -33,7 +34,8 @@ static void guard_test_iommu() {
     }
 }
 
-void print_results(std::vector<uint64_t>& map_times, std::vector<uint64_t>& unmap_times, uint64_t mapping_size) {
+std::tuple<double, double, double, double> get_results(
+    std::vector<uint64_t>& map_times, std::vector<uint64_t>& unmap_times, uint64_t mapping_size) {
     sort(map_times.begin(), map_times.end());
     sort(unmap_times.begin(), unmap_times.end());
 
@@ -47,13 +49,27 @@ void print_results(std::vector<uint64_t>& map_times, std::vector<uint64_t>& unma
     double bw_map_mbs = (double)mapping_size / map_time_average;
     double bw_unmap_mbs = (double)mapping_size / unmap_time_average;
 
-    std::cout << "Mapped " << num_pages << " pages (" << mapping_size << " bytes, " << ((double)mapping_size / one_mb)
-              << " MB). Median map time: " << map_time_median << " ns, Average map time: " << map_time_average
-              << " ns. Bandwidth: " << bw_map_mbs << " MB/s." << std::endl;
-    std::cout << "Unmapped " << num_pages << " pages (" << mapping_size << " bytes, " << ((double)mapping_size / one_mb)
-              << " MB). Median unmap time: " << unmap_time_median << " ns, Average unmap time: " << unmap_time_average
-              << " ns, Bandwidth: " << bw_unmap_mbs << " MB/s." << std::endl;
-    std::cout << "--------------------------------------------------------" << std::endl;
+    return std::make_tuple(
+        (double)map_time_average,
+        test::utils::calc_speed(mapping_size, map_time_average),
+        (double)unmap_time_average,
+        test::utils::calc_speed(mapping_size, unmap_time_average));
+}
+
+void update_data(
+    std::vector<std::vector<std::string>>& rows,
+    const uint64_t mapping_size,
+    std::vector<uint64_t>& map_times,
+    std::vector<uint64_t>& unmap_times) {
+    auto [avg_map_time, bw_map, avg_unmap_time, bw_unmap] = get_results(map_times, unmap_times, mapping_size);
+    std::vector<std::string> row;
+    row.push_back(test::utils::convert_double_to_string(mapping_size / sysconf(_SC_PAGESIZE)));
+    row.push_back(test::utils::convert_double_to_string(mapping_size / one_mb));
+    row.push_back(test::utils::convert_double_to_string(avg_map_time));
+    row.push_back(test::utils::convert_double_to_string(bw_map));
+    row.push_back(test::utils::convert_double_to_string(avg_unmap_time));
+    row.push_back(test::utils::convert_double_to_string(bw_unmap));
+    rows.push_back(row);
 }
 
 /**
@@ -62,7 +78,7 @@ void print_results(std::vector<uint64_t>& map_times, std::vector<uint64_t>& unma
  * and measures the time it takes to map them through IOMMU. It prints out the time taken for each mapping
  * and the average time per page.
  */
-TEST(BenchmarkIOMMU, MapDifferentSizes) {
+TEST(MicrobenchmarkIOMMU, MapDifferentSizes) {
     guard_test_iommu();
 
     static const auto page_size = sysconf(_SC_PAGESIZE);
@@ -80,6 +96,16 @@ TEST(BenchmarkIOMMU, MapDifferentSizes) {
     });
 
     PCIDevice* pci_device = cluster->get_chip(chip)->get_tt_device()->get_pci_device().get();
+
+    const std::vector<std::string> headers = {
+        "Number of pages",
+        "Mapping size (MB)",
+        "Average map time (ns)",
+        "Bandwidth map (MB/s)",
+        "Average unmap time (ns)",
+        "Bandwidth unmap (MB/s)"};
+
+    std::vector<std::vector<std::string>> rows;
 
     for (uint64_t size = page_size; size <= mapping_size_limit; size *= 2) {
         std::vector<uint64_t> map_times;
@@ -101,8 +127,9 @@ TEST(BenchmarkIOMMU, MapDifferentSizes) {
             munmap(mapping, size);
         }
 
-        print_results(map_times, unmap_times, size);
+        update_data(rows, size, map_times, unmap_times);
     }
+    test::utils::print_markdown_table_format(headers, rows);
 }
 
 /**
@@ -110,7 +137,7 @@ TEST(BenchmarkIOMMU, MapDifferentSizes) {
  * These should be different from regular buffers because it's guaranteed that hugepages are contiguous in memory.
  * Since contiguous memory has less entries in the IOMMU page table, we expect the mapping to be faster.
  */
-TEST(BenchmarkIOMMU, MapHugepages2M) {
+TEST(MicrobenchmarkIOMMU, MapHugepages2M) {
     guard_test_iommu();
 
     static const auto page_size = sysconf(_SC_PAGESIZE);
@@ -121,7 +148,7 @@ TEST(BenchmarkIOMMU, MapHugepages2M) {
     std::cout << "--------------------------------------------------------" << std::endl;
     std::cout << "Page size: " << page_size << " bytes." << std::endl;
 
-    const uint64_t mapping_size = 2 * (1ULL << 20);  // 1 MB
+    const uint64_t mapping_size = 2 * (1ULL << 20);  // 2 MB
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(tt::umd::ClusterOptions{
         .num_host_mem_ch_per_mmio_device = 0,
@@ -131,6 +158,13 @@ TEST(BenchmarkIOMMU, MapHugepages2M) {
 
     std::vector<uint64_t> map_times;
     std::vector<uint64_t> unmap_times;
+
+    const std::vector<std::string> headers = {
+        "Mapping size (MB)",
+        "Average map time (ns)",
+        "Bandwidth map (MB/s)",
+        "Average unmap time (ns)",
+        "Bandwidth unmap (MB/s)"};
 
     for (int i = 0; i < NUM_ITERATIONS; i++) {
         void* mapping = mmap(
@@ -158,7 +192,10 @@ TEST(BenchmarkIOMMU, MapHugepages2M) {
         munmap(mapping, mapping_size);
     }
 
-    print_results(map_times, unmap_times, mapping_size);
+    std::vector<std::vector<std::string>> rows;
+    update_data(rows, mapping_size, map_times, unmap_times);
+
+    test::utils::print_markdown_table_format(headers, rows);
 }
 
 /**
@@ -166,7 +203,7 @@ TEST(BenchmarkIOMMU, MapHugepages2M) {
  * These should be different from regular buffers because it's guaranteed that hugepages are contiguous in memory.
  * Since contiguous memory has less entries in the IOMMU page table, we expect the mapping to be faster.
  */
-TEST(BenchmarkIOMMU, MapHugepages1G) {
+TEST(MicrobenchmarkIOMMU, MapHugepages1G) {
     guard_test_iommu();
 
     static const auto page_size = sysconf(_SC_PAGESIZE);
@@ -187,6 +224,13 @@ TEST(BenchmarkIOMMU, MapHugepages1G) {
 
     std::vector<uint64_t> map_times;
     std::vector<uint64_t> unmap_times;
+
+    const std::vector<std::string> headers = {
+        "Mapping size (MB)",
+        "Average map time (ns)",
+        "Bandwidth map (MB/s)",
+        "Average unmap time (ns)",
+        "Bandwidth unmap (MB/s)"};
 
     for (int i = 0; i < NUM_ITERATIONS; i++) {
         void* mapping = mmap(
@@ -212,5 +256,8 @@ TEST(BenchmarkIOMMU, MapHugepages1G) {
         munmap(mapping, mapping_size);
     }
 
-    print_results(map_times, unmap_times, mapping_size);
+    std::vector<std::vector<std::string>> rows;
+    update_data(rows, mapping_size, map_times, unmap_times);
+
+    test::utils::print_markdown_table_format(headers, rows);
 }

--- a/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
+++ b/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
@@ -206,6 +206,8 @@ TEST(MicrobenchmarkPCIeDMA, DMADram) {
         1024 * one_mb,
     };
 
+    const uint32_t NUM_ITERATIONS = 100;
+
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord dram_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::DRAM)[0];
     cluster->start_device(tt_device_params{});
@@ -236,7 +238,6 @@ TEST(MicrobenchmarkPCIeDMA, DMADram) {
 TEST(MicrobenchmarkPCIeDMA, DMATensixZeroCopy) {
     guard_test_iommu();
 
-    const uint32_t NUM_ITERATIONS = 1000;
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{
         .num_host_mem_ch_per_mmio_device = 0,
     });
@@ -274,7 +275,6 @@ TEST(MicrobenchmarkPCIeDMA, DMATensixZeroCopy) {
 TEST(MicrobenchmarkPCIeDMA, DMATensixMapBufferZeroCopy) {
     guard_test_iommu();
 
-    const uint32_t NUM_ITERATIONS = 100;
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{
         .num_host_mem_ch_per_mmio_device = 0,
     });

--- a/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
+++ b/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
@@ -138,7 +138,7 @@ TEST(MicrobenchmarkPCIeDMA, TensixSweepSizes) {
     const uint64_t limit_buf_size = one_mb;
 
     const std::vector<std::string> headers = {
-        "Size (MB)",
+        "Size (bytes)",
         "Host -> Device Tensix L1 (MB/s)",
         "Device Tensix L1 -> Host (MB/s)",
     };
@@ -146,7 +146,7 @@ TEST(MicrobenchmarkPCIeDMA, TensixSweepSizes) {
     std::vector<std::vector<std::string>> rows;
     for (uint64_t buf_size = 4; buf_size <= limit_buf_size; buf_size *= 2) {
         std::vector<std::string> row;
-        row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
+        row.push_back(test::utils::convert_double_to_string((double)buf_size));
         auto [wr_bw, rd_bw] = perf_read_write(buf_size, NUM_ITERATIONS, cluster, tensix_core);
         row.push_back(test::utils::convert_double_to_string(wr_bw));
         row.push_back(test::utils::convert_double_to_string(rd_bw));

--- a/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
+++ b/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
@@ -5,6 +5,7 @@
  */
 #include <sys/mman.h>
 
+#include "common/microbenchmark_utils.h"
 #include "gtest/gtest.h"
 #include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
@@ -24,26 +25,11 @@ const uint32_t one_mb = 1 << 20;
 const uint32_t one_gb = 1 << 30;
 const uint32_t NUM_ITERATIONS = 1000;
 
-static inline void print_speed(std::string direction, size_t bytes, uint64_t ns) {
-    double seconds = ns / 1e9;
-    double megabytes = static_cast<double>(bytes) / (1024.0 * 1024.0);
-    auto rate = megabytes / seconds;
-    std::cout << direction << ": 0x" << std::hex << bytes << std::dec << " bytes in " << ns << " ns (" << rate
-              << " MB/s)" << std::endl;
-}
-
-static inline void perf_read_write(
+static inline std::pair<double, double> perf_read_write(
     const uint32_t buf_size,
     const uint32_t num_iterations,
     const std::unique_ptr<Cluster>& cluster,
-    const CoreCoord core,
-    const std::string& direction_to_device,
-    const std::string& direction_from_device) {
-    std::cout << std::endl;
-    std::cout << "Reporting results for buffer size " << buf_size << " bytes (" << ((double)buf_size / one_mb)
-              << " MB) being transfered " << num_iterations << " number of times." << std::endl;
-    std::cout << "--------------------------------------------------------" << std::endl;
-
+    const CoreCoord core) {
     std::vector<uint8_t> pattern(buf_size);
     test_utils::fill_with_random_bytes(&pattern[0], pattern.size());
 
@@ -53,7 +39,7 @@ static inline void perf_read_write(
     }
     auto end = std::chrono::steady_clock::now();
     auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
-    print_speed(direction_to_device, num_iterations * pattern.size(), ns);
+    double wr_bw = test::utils::calc_speed(num_iterations * pattern.size(), ns);
 
     std::vector<uint8_t> readback(buf_size, 0x0);
     now = std::chrono::steady_clock::now();
@@ -62,16 +48,18 @@ static inline void perf_read_write(
     }
     end = std::chrono::steady_clock::now();
     ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
-    print_speed(direction_from_device, num_iterations * readback.size(), ns);
+    double rd_bw = test::utils::calc_speed(num_iterations * readback.size(), ns);
+
+    return std::make_pair(wr_bw, rd_bw);
 }
 
-static inline void perf_sysmem_read_write(
+static inline std::pair<double, double> perf_sysmem_read_write(
     const uint32_t buf_size,
     const uint32_t num_iterations,
     const std::unique_ptr<SysmemBuffer>& sysmem_buffer,
-    const CoreCoord core,
-    const std::string& direction_to_device,
-    const std::string& direction_from_device) {
+    const CoreCoord core) {
+    double wr_bw;
+    double rd_bw;
     {
         auto now = std::chrono::steady_clock::now();
         for (int i = 0; i < NUM_ITERATIONS; i++) {
@@ -79,7 +67,7 @@ static inline void perf_sysmem_read_write(
         }
         auto end = std::chrono::steady_clock::now();
         auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
-        print_speed(direction_to_device, one_mb * NUM_ITERATIONS, ns);
+        wr_bw = test::utils::calc_speed(one_mb * NUM_ITERATIONS, ns);
     }
 
     {
@@ -89,8 +77,10 @@ static inline void perf_sysmem_read_write(
         }
         auto end = std::chrono::steady_clock::now();
         auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
-        print_speed(direction_from_device, one_mb * NUM_ITERATIONS, ns);
+        rd_bw = test::utils::calc_speed(one_mb * NUM_ITERATIONS, ns);
     }
+
+    return std::make_pair(wr_bw, rd_bw);
 }
 
 static void guard_test_iommu() {
@@ -112,19 +102,28 @@ TEST(MicrobenchmarkPCIeDMA, DMATensix) {
         1 * one_mb,
     };
 
+    const std::vector<std::string> headers = {
+        "Size (MB)",
+        "Host -> Device Tensix L1 (MB/s)",
+        "Device Tensix L1 -> Host (MB/s)",
+    };
+
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord tensix_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)[0];
     cluster->start_device(tt_device_params{});
 
+    std::vector<std::vector<std::string>> rows;
+
     for (uint32_t buf_size : sizes) {
-        perf_read_write(
-            buf_size,
-            NUM_ITERATIONS,
-            cluster,
-            tensix_core,
-            "DMA: Host -> Device Tensix L1",
-            "DMA: Device Tensix L1 -> Host");
+        std::vector<std::string> row;
+        row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
+        auto [wr_bw, rd_bw] = perf_read_write(buf_size, NUM_ITERATIONS, cluster, tensix_core);
+        row.push_back(test::utils::convert_double_to_string(wr_bw));
+        row.push_back(test::utils::convert_double_to_string(rd_bw));
+        rows.push_back(row);
     }
+
+    test::utils::print_markdown_table_format(headers, rows);
 }
 
 /**
@@ -138,15 +137,23 @@ TEST(MicrobenchmarkPCIeDMA, TensixSweepSizes) {
 
     const uint64_t limit_buf_size = one_mb;
 
+    const std::vector<std::string> headers = {
+        "Size (MB)",
+        "Host -> Device Tensix L1 (MB/s)",
+        "Device Tensix L1 -> Host (MB/s)",
+    };
+
+    std::vector<std::vector<std::string>> rows;
     for (uint64_t buf_size = 4; buf_size <= limit_buf_size; buf_size *= 2) {
-        perf_read_write(
-            buf_size,
-            NUM_ITERATIONS,
-            cluster,
-            tensix_core,
-            "DMA: Host -> Device Tensix L1",
-            "DMA: Device Tensix L1 -> Host");
+        std::vector<std::string> row;
+        row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
+        auto [wr_bw, rd_bw] = perf_read_write(buf_size, NUM_ITERATIONS, cluster, tensix_core);
+        row.push_back(test::utils::convert_double_to_string(wr_bw));
+        row.push_back(test::utils::convert_double_to_string(rd_bw));
+        rows.push_back(row);
     }
+
+    test::utils::print_markdown_table_format(headers, rows);
 }
 
 /**
@@ -155,20 +162,29 @@ TEST(MicrobenchmarkPCIeDMA, TensixSweepSizes) {
  */
 TEST(MicrobenchmarkPCIeDMA, DramSweepSizes) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
-    const CoreCoord tensix_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)[0];
+    const CoreCoord dram_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::DRAM)[0];
     cluster->start_device(tt_device_params{});
 
     const uint64_t limit_buf_size = one_gb;
 
+    const std::vector<std::string> headers = {
+        "Size (MB)",
+        "Host -> Device DRAM (MB/s)",
+        "Device DRAM -> Host (MB/s)",
+    };
+
+    std::vector<std::vector<std::string>> rows;
+
     for (uint64_t buf_size = 4; buf_size <= limit_buf_size; buf_size *= 2) {
-        perf_read_write(
-            buf_size,
-            NUM_ITERATIONS,
-            cluster,
-            tensix_core,
-            "DMA: Host -> Device Tensix L1",
-            "DMA: Device Tensix L1 -> Host");
+        std::vector<std::string> row;
+        row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
+        auto [wr_bw, rd_bw] = perf_read_write(buf_size, NUM_ITERATIONS, cluster, dram_core);
+        row.push_back(test::utils::convert_double_to_string(wr_bw));
+        row.push_back(test::utils::convert_double_to_string(rd_bw));
+        rows.push_back(row);
     }
+
+    test::utils::print_markdown_table_format(headers, rows);
 }
 
 /**
@@ -193,10 +209,23 @@ TEST(MicrobenchmarkPCIeDMA, DMADram) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord dram_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::DRAM)[0];
     cluster->start_device(tt_device_params{});
+
+    const std::vector<std::string> headers = {
+        "Size (MB)",
+        "DMA: Host -> Device DRAM (MB/s)",
+        "DMA: Device DRAM -> Host (MB/s)",
+    };
+    std::vector<std::vector<std::string>> rows;
     for (uint32_t buf_size : sizes) {
-        perf_read_write(
-            buf_size, NUM_ITERATIONS, cluster, dram_core, "DMA: Host -> Device DRAM", "DMA: Device DRAM -> Host");
+        std::vector<std::string> row;
+        row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
+        auto [wr_bw, rd_bw] = perf_read_write(buf_size, NUM_ITERATIONS, cluster, dram_core);
+        row.push_back(test::utils::convert_double_to_string(wr_bw));
+        row.push_back(test::utils::convert_double_to_string(rd_bw));
+        rows.push_back(row);
     }
+
+    test::utils::print_markdown_table_format(headers, rows);
 }
 
 /**
@@ -219,41 +248,22 @@ TEST(MicrobenchmarkPCIeDMA, DMATensixZeroCopy) {
     const uint32_t one_mb = 1 << 20;
     std::unique_ptr<SysmemBuffer> sysmem_buffer = sysmem_manager->allocate_sysmem_buffer(2 * one_mb);
 
+    const std::vector<std::string> headers = {
+        "Size (MB)",
+        "Host -> Device Tensix L1 (MB/s)",
+        "Device Tensix L1 -> Host (MB/s)",
+    };
+
     const CoreCoord tensix_core = cluster->get_soc_descriptor(mmio_chip).get_cores(CoreType::TENSIX)[0];
-    perf_sysmem_read_write(
-        one_mb,
-        NUM_ITERATIONS,
-        sysmem_buffer,
-        tensix_core,
-        "DMA zero copy: Device Tensix L1 -> Host",
-        "DMA zero copy: Device Tensix L1 -> Host");
-}
+    std::vector<std::vector<std::string>> rows;
+    std::vector<std::string> row;
+    auto [wr_bw, rd_bw] = perf_sysmem_read_write(one_mb, NUM_ITERATIONS, sysmem_buffer, tensix_core);
+    row.push_back(test::utils::convert_double_to_string((double)one_mb / one_mb));
+    row.push_back(test::utils::convert_double_to_string(wr_bw));
+    row.push_back(test::utils::convert_double_to_string(rd_bw));
+    rows.push_back(row);
 
-/**
- * Measure the speed of mapping sysmem buffer using SysmemManager.
- */
-TEST(MicrobenchmarkPCIeDMA, MapSysmemBuffer) {
-    guard_test_iommu();
-
-    const uint32_t NUM_ITERATIONS = 1000;
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{
-        .num_host_mem_ch_per_mmio_device = 0,
-    });
-
-    const chip_id_t mmio_chip = *cluster->get_target_mmio_device_ids().begin();
-
-    SysmemManager* sysmem_manager = cluster->get_chip(mmio_chip)->get_sysmem_manager();
-
-    const uint32_t one_mb = 1 << 20;
-
-    void* mapping = mmap(nullptr, one_mb, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
-    auto now = std::chrono::steady_clock::now();
-    for (int i = 0; i < NUM_ITERATIONS; i++) {
-        std::unique_ptr<SysmemBuffer> sysmem_buffer = sysmem_manager->map_sysmem_buffer(mapping, one_mb);
-    }
-    auto end = std::chrono::steady_clock::now();
-    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
-    print_speed("Allocation of sysmem buffers:", one_mb * NUM_ITERATIONS, ns);
+    test::utils::print_markdown_table_format(headers, rows);
 }
 
 /**
@@ -275,6 +285,16 @@ TEST(MicrobenchmarkPCIeDMA, DMATensixMapBufferZeroCopy) {
 
     const uint32_t one_mb = 1 << 20;
 
+    const std::vector<std::string> headers = {
+        "Size (MB)",
+        "Host -> Device Tensix L1 (MB/s)",
+        "Device Tensix L1 -> Host (MB/s)",
+    };
+
+    std::vector<std::vector<std::string>> rows;
+    std::vector<std::string> row;
+    row.push_back(test::utils::convert_double_to_string((double)one_mb / one_mb));
+
     const CoreCoord tensix_core = cluster->get_soc_descriptor(mmio_chip).get_cores(CoreType::TENSIX)[0];
     {
         void* mapping =
@@ -286,7 +306,8 @@ TEST(MicrobenchmarkPCIeDMA, DMATensixMapBufferZeroCopy) {
         }
         auto end = std::chrono::steady_clock::now();
         auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
-        print_speed("DMA mapping buffer and zero copy: Host -> Device Tensix L1", one_mb * NUM_ITERATIONS, ns);
+        double wr_bw = test::utils::calc_speed(one_mb * NUM_ITERATIONS, ns);
+        row.push_back(test::utils::convert_double_to_string(wr_bw));
     }
 
     {
@@ -299,8 +320,11 @@ TEST(MicrobenchmarkPCIeDMA, DMATensixMapBufferZeroCopy) {
         }
         auto end = std::chrono::steady_clock::now();
         auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
-        print_speed("DMA mapping buffer and zero copy: Device Tensix L1 -> Host", one_mb * NUM_ITERATIONS, ns);
+        double rd_bw = test::utils::calc_speed(one_mb * NUM_ITERATIONS, ns);
+        row.push_back(test::utils::convert_double_to_string(rd_bw));
     }
+    rows.push_back(row);
+    test::utils::print_markdown_table_format(headers, rows);
 }
 
 /**
@@ -325,12 +349,20 @@ TEST(MicrobenchmarkPCIeDMA, DMADRAMZeroCopy) {
     const uint32_t two_hundred_mb = 200 * one_mb;
     std::unique_ptr<SysmemBuffer> sysmem_buffer = sysmem_manager->allocate_sysmem_buffer(two_hundred_mb);
 
+    const std::vector<std::string> headers = {
+        "Size (MB)",
+        "DMA: Host -> Device DRAM (MB/s)",
+        "DMA: Device DRAM -> Host (MB/s)",
+    };
+
+    std::vector<std::vector<std::string>> rows;
+    std::vector<std::string> row;
+
     const CoreCoord dram_core = cluster->get_soc_descriptor(mmio_chip).get_cores(CoreType::DRAM)[0];
-    perf_sysmem_read_write(
-        one_mb,
-        NUM_ITERATIONS,
-        sysmem_buffer,
-        dram_core,
-        "DMA zero copy: Device DRAM -> Host",
-        "DMA zero copy: Device DRAM -> Host");
+    auto [wr_bw, rd_bw] = perf_sysmem_read_write(one_mb, NUM_ITERATIONS, sysmem_buffer, dram_core);
+    row.push_back(test::utils::convert_double_to_string((double)one_mb / one_mb));
+    row.push_back(test::utils::convert_double_to_string(wr_bw));
+    row.push_back(test::utils::convert_double_to_string(rd_bw));
+    rows.push_back(row);
+    test::utils::print_markdown_table_format(headers, rows);
 }

--- a/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
+++ b/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include "common/microbenchmark_utils.h"
 #include "gtest/gtest.h"
 #include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
@@ -23,26 +24,11 @@ const uint32_t NUM_ITERATIONS = 10;
 const uint32_t tlb_1m_index = 0;
 const uint32_t tlb_16m_index = 166;
 
-static inline void print_speed(std::string direction, size_t bytes, uint64_t ns) {
-    double seconds = ns / 1e9;
-    double megabytes = static_cast<double>(bytes) / (1024.0 * 1024.0);
-    auto rate = megabytes / seconds;
-    std::cout << direction << ": 0x" << std::hex << bytes << std::dec << " bytes in " << ns << " ns (" << rate
-              << " MB/s)" << std::endl;
-}
-
-static inline void perf_read_write(
+static inline std::pair<double, double> perf_read_write(
     const uint32_t buf_size,
     const uint32_t num_iterations,
     const std::unique_ptr<Cluster>& cluster,
-    const CoreCoord core,
-    const std::string& direction_to_device,
-    const std::string& direction_from_device) {
-    std::cout << std::endl;
-    std::cout << "Reporting results for buffer size " << (buf_size / one_mb) << " MB being transfered "
-              << num_iterations << " number of times." << std::endl;
-    std::cout << "--------------------------------------------------------" << std::endl;
-
+    const CoreCoord core) {
     std::vector<uint8_t> pattern(buf_size);
     test_utils::fill_with_random_bytes(&pattern[0], pattern.size());
 
@@ -52,7 +38,7 @@ static inline void perf_read_write(
     }
     auto end = std::chrono::steady_clock::now();
     auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
-    print_speed(direction_to_device, num_iterations * pattern.size(), ns);
+    double wr_bw = test::utils::calc_speed(num_iterations * pattern.size(), ns);
 
     std::vector<uint8_t> readback(buf_size, 0x0);
     now = std::chrono::steady_clock::now();
@@ -61,7 +47,9 @@ static inline void perf_read_write(
     }
     end = std::chrono::steady_clock::now();
     ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
-    print_speed(direction_from_device, num_iterations * readback.size(), ns);
+    double rd_bw = test::utils::calc_speed(num_iterations * readback.size(), ns);
+
+    return std::make_pair(wr_bw, rd_bw);
 }
 
 /**
@@ -84,15 +72,23 @@ TEST(MicrobenchmarkTLB, TLBDynamicDram) {
     const CoreCoord dram_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::DRAM)[0];
     cluster->start_device(tt_device_params{});
 
+    const std::vector<std::string> headers = {
+        "Size (MB)",
+        "Dynamic TLB: Host -> Device DRAM (MB/s)",
+        "Dynamic TLB: Device DRAM -> Host (MB/s)",
+    };
+
+    std::vector<std::vector<std::string>> rows;
+
     for (uint32_t buf_size : sizes) {
-        perf_read_write(
-            buf_size,
-            NUM_ITERATIONS,
-            cluster,
-            dram_core,
-            "Dynamic TLB: Host -> Device DRAM",
-            "Dynamic TLB: Device DRAM -> Host");
+        std::vector<std::string> row;
+        row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
+        auto [wr_bw, rd_bw] = perf_read_write(buf_size, NUM_ITERATIONS, cluster, dram_core);
+        row.push_back(test::utils::convert_double_to_string(wr_bw));
+        row.push_back(test::utils::convert_double_to_string(rd_bw));
+        rows.push_back(row);
     }
+    test::utils::print_markdown_table_format(headers, rows);
 }
 
 /**
@@ -107,15 +103,23 @@ TEST(MicrobenchmarkTLB, TLBDynamicTensix) {
     const CoreCoord tensix_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)[0];
     cluster->start_device(tt_device_params{});
 
+    const std::vector<std::string> headers = {
+        "Size (MB)",
+        "Dynamic TLB: Host -> Device Tensix L1 (MB/s)",
+        "Dynamic TLB: Device Tensix L1 -> Host (MB/s)",
+    };
+
+    std::vector<std::vector<std::string>> rows;
+
     for (uint32_t buf_size : sizes) {
-        perf_read_write(
-            buf_size,
-            NUM_ITERATIONS,
-            cluster,
-            tensix_core,
-            "Dynamic TLB: Host -> Device Tensix L1",
-            "Dynamic TLB: Device Tensix L1 -> Host");
+        std::vector<std::string> row;
+        auto [wr_bw, rd_bw] = perf_read_write(buf_size, NUM_ITERATIONS, cluster, tensix_core);
+        row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
+        row.push_back(test::utils::convert_double_to_string(wr_bw));
+        row.push_back(test::utils::convert_double_to_string(rd_bw));
+        rows.push_back(row);
     }
+    test::utils::print_markdown_table_format(headers, rows);
 }
 
 /**
@@ -134,16 +138,24 @@ TEST(MicrobenchmarkTLB, TLBStaticTensix) {
         1 * one_mb,
     };
 
+    const std::vector<std::string> headers = {
+        "Size (MB)",
+        "Static TLB: Host -> Device Tensix L1 (MB/s)",
+        "Static TLB: Device Tensix L1 -> Host (MB/s)",
+    };
+
+    std::vector<std::vector<std::string>> rows;
+
     for (uint32_t buf_size : sizes) {
+        std::vector<std::string> row;
         const uint32_t num_io = buf_size / one_mb;
-        perf_read_write(
-            buf_size,
-            num_io,
-            cluster,
-            tensix_core,
-            "Static TLB: Host -> Device Tensix L1",
-            "Static TLB: Device Tensix L1 -> Host");
+        auto [wr_bw, rd_bw] = perf_read_write(buf_size, num_io, cluster, tensix_core);
+        row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
+        row.push_back(test::utils::convert_double_to_string(wr_bw));
+        row.push_back(test::utils::convert_double_to_string(rd_bw));
+        rows.push_back(row);
     }
+    test::utils::print_markdown_table_format(headers, rows);
 }
 
 /**
@@ -166,10 +178,23 @@ TEST(MicrobenchmarkTLB, TLBStaticDram) {
 
     cluster->configure_tlb(0, dram_core, tlb_16m_index, 0x0, tlb_data::Relaxed);
 
+    const std::vector<std::string> headers = {
+        "Size (MB)",
+        "Static TLB: Host -> Device DRAM (MB/s)",
+        "Static TLB: Device DRAM -> Host (MB/s)",
+    };
+
+    std::vector<std::vector<std::string>> rows;
+
     for (uint32_t buf_size : sizes) {
+        std::vector<std::string> row;
         const uint32_t num_io = buf_size / (16 * one_mb);
 
-        perf_read_write(
-            buf_size, num_io, cluster, dram_core, "Static TLB: Host -> Device DRAM", "Static TLB: Device DRAM -> Host");
+        auto [wr_bw, rd_bw] = perf_read_write(buf_size, num_io, cluster, dram_core);
+        row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
+        row.push_back(test::utils::convert_double_to_string(wr_bw));
+        row.push_back(test::utils::convert_double_to_string(rd_bw));
+        rows.push_back(row);
     }
+    test::utils::print_markdown_table_format(headers, rows);
 }

--- a/tests/microbenchmark/common/microbenchmark_utils.cpp
+++ b/tests/microbenchmark/common/microbenchmark_utils.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "common/microbenchmark_utils.h"
+
+namespace tt::umd::test::utils {
+void print_markdown_table_format(
+    const std::vector<std::string>& headers, const std::vector<std::vector<std::string>>& rows) {
+    for (const auto& header : headers) {
+        std::cout << "| " << header << " ";
+    }
+    std::cout << "|\n";
+
+    // Print separator row.
+    for (size_t i = 0; i < headers.size(); ++i) {
+        std::cout << "|---";
+    }
+    std::cout << "|\n";
+
+    for (const auto& row : rows) {
+        for (const auto& cell : row) {
+            std::cout << "| " << cell << " ";
+        }
+        std::cout << "|\n";
+    }
+}
+
+double calc_speed(size_t bytes, uint64_t ns) { return (static_cast<double>(bytes) / (1024.0 * 1024.0)) / (ns / 1e9); }
+
+std::string convert_double_to_string(double value) {
+    std::ostringstream out;
+    out << std::fixed << std::setprecision(2) << value;
+    return out.str();
+}
+}  // namespace tt::umd::test::utils

--- a/tests/microbenchmark/common/microbenchmark_utils.h
+++ b/tests/microbenchmark/common/microbenchmark_utils.h
@@ -15,7 +15,10 @@ namespace tt::umd::test::utils {
 
 /**
  * Prints a table in Markdown format. Headers are printed as the first row, followed by a separator row,
- * and then the data rows. Headers length must match the length of each row.
+ * and then the data rows. Headers length must match the length of each row. Example:
+ * | Size (MB) | Host -> Device Tensix L1 (MB/s) | Device Tensix L1 -> Host (MB/s) |
+ * |---|---|---|
+ * | 1.00 | 13157.70 | 2493.65 |
  *
  * @param headers The headers of the table.
  * @param rows The rows of the table, where each row is a vector of strings.

--- a/tests/microbenchmark/common/microbenchmark_utils.h
+++ b/tests/microbenchmark/common/microbenchmark_utils.h
@@ -12,36 +12,32 @@
 #include <vector>
 
 namespace tt::umd::test::utils {
-static inline void print_markdown_table_format(
-    const std::vector<std::string>& headers, const std::vector<std::vector<std::string>>& rows) {
-    // Print header row
-    for (const auto& header : headers) {
-        std::cout << "| " << header << " ";
-    }
-    std::cout << "|\n";
 
-    // Print separator row
-    for (size_t i = 0; i < headers.size(); ++i) {
-        std::cout << "|---";
-    }
-    std::cout << "|\n";
+/**
+ * Prints a table in Markdown format. Headers are printed as the first row, followed by a separator row,
+ * and then the data rows. Headers length must match the length of each row.
+ *
+ * @param headers The headers of the table.
+ * @param rows The rows of the table, where each row is a vector of strings.
+ */
+void print_markdown_table_format(
+    const std::vector<std::string>& headers, const std::vector<std::vector<std::string>>& rows);
 
-    // Print data rows
-    for (const auto& row : rows) {
-        for (const auto& cell : row) {
-            std::cout << "| " << cell << " ";
-        }
-        std::cout << "|\n";
-    }
-}
+/**
+ * Calculates the speed in MB/s given the number of bytes and the time in nanoseconds.
+ *
+ * @param bytes The number of bytes processed.
+ * @param ns The time taken in nanoseconds.
+ * @return The speed in MB/s.
+ */
+double calc_speed(size_t bytes, uint64_t ns);
 
-static inline double calc_speed(size_t bytes, uint64_t ns) {
-    return (static_cast<double>(bytes) / (1024.0 * 1024.0)) / (ns / 1e9);
-}
+/**
+ * Converts a double value to a string with fixed-point notation and two decimal places.
+ *
+ * @param value The double value to convert.
+ * @return A string representation of the double value.
+ */
+std::string convert_double_to_string(double value);
 
-static inline std::string convert_double_to_string(double value) {
-    std::ostringstream out;
-    out << std::fixed << std::setprecision(2) << value;
-    return out.str();
-}
 }  // namespace tt::umd::test::utils

--- a/tests/microbenchmark/common/microbenchmark_utils.h
+++ b/tests/microbenchmark/common/microbenchmark_utils.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace tt::umd::test::utils {
+static inline void print_markdown_table_format(
+    const std::vector<std::string>& headers, const std::vector<std::vector<std::string>>& rows) {
+    // Print header row
+    for (const auto& header : headers) {
+        std::cout << "| " << header << " ";
+    }
+    std::cout << "|\n";
+
+    // Print separator row
+    for (size_t i = 0; i < headers.size(); ++i) {
+        std::cout << "|---";
+    }
+    std::cout << "|\n";
+
+    // Print data rows
+    for (const auto& row : rows) {
+        for (const auto& cell : row) {
+            std::cout << "| " << cell << " ";
+        }
+        std::cout << "|\n";
+    }
+}
+
+static inline double calc_speed(size_t bytes, uint64_t ns) {
+    return (static_cast<double>(bytes) / (1024.0 * 1024.0)) / (ns / 1e9);
+}
+
+static inline std::string convert_double_to_string(double value) {
+    std::ostringstream out;
+    out << std::fixed << std::setprecision(2) << value;
+    return out.str();
+}
+}  // namespace tt::umd::test::utils


### PR DESCRIPTION
### Issue

#847 

### Description

Add UMD perf print format. Idea is that UMD perf results are printed in the format such that results can be pasted from logs directly to README files and form a table for the results. This PR also introduces common code for UMD benchmarks where some utility that is useful for all the benchmarks is going to be.

### List of the changes

- Add microbenchmark utils functions
- Print results in desired format in PCIe DMA benchmark
- Print results in desired format in TLB benchmark
- Print results in desired format in IOMMU benchmark

### Testing
manual testing

### API Changes
/
