### PR TITLE
Cluster.cpp dead functions

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -627,19 +627,9 @@ public:
 
 private:
     // Helper functions
-    // Startup + teardown
-    void create_device(
-        const std::set<chip_id_t>& target_mmio_device_ids,
-        const uint32_t& num_host_mem_ch_per_mmio_device,
-        const ChipType& chip_type);
+    // Broadcast
     void broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOptions& soft_resets);
-    void send_remote_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);
-    void send_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);
-    uint32_t get_power_state_arc_msg(chip_id_t chip_id, tt_DevicePowerState state);
-    void enable_ethernet_queue(int timeout);
-
     void deassert_resets_and_set_power_state();
-    int get_clock(int logical_device_id);
 
     // Communication Functions
     void ethernet_broadcast_write(
@@ -658,6 +648,11 @@ private:
     void verify_fw_bundle_version();
     void verify_eth_fw();
     void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions);
+    // To be changed in the next PR
+    void create_device(
+        const std::set<chip_id_t>& target_mmio_device_ids,
+        const uint32_t& num_host_mem_ch_per_mmio_device,
+        const ChipType& chip_type);
 
     // Helper functions for constructing the chips from the cluster descriptor.
     std::unique_ptr<Chip> construct_chip_from_cluster(

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -637,6 +637,7 @@ private:
     void send_tensix_risc_reset_to_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets);
     uint32_t get_power_state_arc_msg(chip_id_t chip_id, tt_DevicePowerState state);
     void enable_ethernet_queue(int timeout);
+
     void deassert_resets_and_set_power_state();
     int get_clock(int logical_device_id);
 

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -648,11 +648,7 @@ private:
     void verify_fw_bundle_version();
     void verify_eth_fw();
     void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions);
-    // To be changed in the next PR
-    void create_device(
-        const std::set<chip_id_t>& target_mmio_device_ids,
-        const uint32_t& num_host_mem_ch_per_mmio_device,
-        const ChipType& chip_type);
+    void verify_sysmem_initialized();
 
     // Helper functions for constructing the chips from the cluster descriptor.
     std::unique_ptr<Chip> construct_chip_from_cluster(

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -920,7 +920,9 @@ void Cluster::deassert_resets_and_set_power_state() {
 
     // MT Initial BH - ARC messages not supported in Blackhole
     if (arch_name != tt::ARCH::BLACKHOLE) {
-        enable_ethernet_queue(30);
+        for (const chip_id_t& chip : all_chip_ids_) {
+            enable_ethernet_queue(30);
+        }
     }
 
     // Set power state to busy

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -449,12 +449,10 @@ tt::Writer Cluster::get_static_tlb_writer(const chip_id_t chip, const CoreCoord 
     return get_tlb_manager(chip)->get_static_tlb_writer(virtual_core);
 }
 
-int Cluster::get_clock(int logical_device_id) { return chips_.at(logical_device_id)->get_clock(); }
-
 std::map<int, int> Cluster::get_clocks() {
     std::map<int, int> clock_freq_map;
     for (auto& chip_id : local_chip_ids_) {
-        clock_freq_map.insert({chip_id, get_clock(chip_id)});
+        clock_freq_map.insert({chip_id, chips_.at(chip_id)->get_clock()});
     }
     return clock_freq_map;
 }
@@ -904,12 +902,6 @@ void Cluster::set_power_state(tt_DevicePowerState device_state) {
     }
 }
 
-void Cluster::enable_ethernet_queue(int timeout) {
-    for (const chip_id_t& chip : all_chip_ids_) {
-        get_chip(chip)->enable_ethernet_queue(timeout);
-    }
-}
-
 void Cluster::deassert_resets_and_set_power_state() {
     // Assert tensix resets on all chips in cluster
     broadcast_tensix_risc_reset_to_cluster(TENSIX_ASSERT_SOFT_RESET);
@@ -921,7 +913,7 @@ void Cluster::deassert_resets_and_set_power_state() {
     // MT Initial BH - ARC messages not supported in Blackhole
     if (arch_name != tt::ARCH::BLACKHOLE) {
         for (const chip_id_t& chip : all_chip_ids_) {
-            enable_ethernet_queue(30);
+            get_chip(chip)->enable_ethernet_queue(30);
         }
     }
 


### PR DESCRIPTION
### Issue
Related to work done as part of #853 

### Description
Modified some outdated cluster functions

### List of the changes
- The remaining functionality of create_device was moved to verify_sysmem_initialized. Callsite was slightly changed to fall under SILICON check
- Removed some functions which were already missing implementation like send_remote_tensix_risc_reset_to_core
- Removed get_clock and enable_ethernet_queue which were too trivial

### Testing
Existing CI tests should cover everything

### API Changes
There are no API changes in this PR.
