### PR TITLE
Fix 6U topology discovery

### DIFF
--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -265,15 +265,21 @@ void TopologyDiscovery::discover_remote_chips() {
             active_eth_channels_per_chip.at(current_chip_id).insert(channel);
 
             if (!is_board_id_included(get_remote_board_id(chip, eth_core))) {
-                tt_xy_pair remote_eth_core = get_remote_eth_core(chip, eth_core);
-                uint32_t remote_eth_id =
-                    chip->get_soc_descriptor()
-                        .translate_coord_to(
-                            CoreCoord(remote_eth_core.x, remote_eth_core.y, CoreType::ETH, CoordSystem::PHYSICAL),
-                            CoordSystem::LOGICAL)
-                        .y;
+                uint32_t remote_eth_channel;
+                if (is_running_on_6u) {
+                    remote_eth_channel = get_remote_eth_id(chip, eth_core);
+                } else {
+                    tt_xy_pair remote_eth_core = get_remote_eth_core(chip, eth_core);
+                    remote_eth_channel =
+                        chip->get_soc_descriptor()
+                            .translate_coord_to(
+                                CoreCoord(remote_eth_core.x, remote_eth_core.y, CoreType::ETH, CoordSystem::PHYSICAL),
+                                CoordSystem::LOGICAL)
+                            .y;
+                }
                 cluster_desc->ethernet_connections_to_remote_devices[current_chip_id][channel] = {
-                    get_remote_asic_id(chip, eth_core), remote_eth_id};
+                    get_remote_asic_id(chip, eth_core), remote_eth_channel};
+
                 channel++;
                 continue;
             }


### PR DESCRIPTION
### Issue

Fix 6U topology discovery when we put some chips in the docker

### Description

Fix 6U topology discovery for the case when we put some chips from the 6U inside the docker.

### List of the changes

- Use get_remote_eth_id for 6U for connections outside of visible chips

### Testing

Manual testing on 6U

### API Changes
/
