### PR TITLE
Add support for isolating chips on 6U

### DIFF
--- a/device/api/umd/device/topology_discovery.h
+++ b/device/api/umd/device/topology_discovery.h
@@ -45,21 +45,21 @@ private:
 
     bool is_pcie_chip_id_included(int pci_id) const;
 
-    bool is_board_id_included(uint32_t board_id) const;
+    bool is_board_id_included(uint64_t board_id) const;
 
     // Returns mangled remote board id from local ETH core.
     // This information can still be used to unique identify a board.
     // TODO: override this logic for different configs. This is in group of functions
     // that we should override for T3K/6U/BH...
     // eth_core should be in physical (NOC0) coordinates.
-    uint32_t get_remote_board_id(Chip* chip, tt_xy_pair eth_core);
+    uint64_t get_remote_board_id(Chip* chip, tt_xy_pair eth_core);
 
     // Returns mangled local board id from local ETH core.
     // This information can still be used to unique identify a board.
     // TODO: override this logic for different configs. This is in group of functions
     // that we should override for T3K/6U/BH...
     // eth_core should be in physical (NOC0) coordinates.
-    uint32_t get_local_board_id(Chip* chip, tt_xy_pair eth_core);
+    uint64_t get_local_board_id(Chip* chip, tt_xy_pair eth_core);
 
     // TODO: override this logic for different configs. This is in group of functions
     // that we should override for T3K/6U/BH...
@@ -122,7 +122,7 @@ private:
     std::unordered_set<chip_id_t> pci_target_devices = {};
 
     // All board ids that should be included in the cluster descriptor.
-    std::unordered_set<uint32_t> board_ids;
+    std::unordered_set<uint64_t> board_ids;
 
     std::unordered_map<chip_id_t, std::set<uint32_t>> active_eth_channels_per_chip;
 

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -177,7 +177,7 @@ void TopologyDiscovery::get_pcie_connected_chips() {
         std::vector<CoreCoord> eth_cores =
             chip->get_soc_descriptor().get_cores(CoreType::ETH, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::NOC0);
         for (const CoreCoord& eth_core : eth_cores) {
-            uint32_t board_id = get_local_board_id(chip.get(), eth_core);
+            uint64_t board_id = get_local_board_id(chip.get(), eth_core);
             if (board_id == 0) {
                 continue;
             }
@@ -388,7 +388,7 @@ bool TopologyDiscovery::is_pcie_chip_id_included(int pci_id) const {
 }
 
 // If pci_target_devices is empty, we should take all the PCI devices found in the system.
-bool TopologyDiscovery::is_board_id_included(uint32_t board_id) const {
+bool TopologyDiscovery::is_board_id_included(uint64_t board_id) const {
     // Since at the moment we don't want to go outside of single host on 6U,
     // we just check for board ids that are discovered from pci_target_devices.
     if (is_running_on_6u) {
@@ -400,7 +400,11 @@ bool TopologyDiscovery::is_board_id_included(uint32_t board_id) const {
     return pci_target_devices.empty() || board_ids.find(board_id) != board_ids.end();
 }
 
-uint32_t TopologyDiscovery::get_remote_board_id(Chip* chip, tt_xy_pair eth_core) {
+uint64_t TopologyDiscovery::get_remote_board_id(Chip* chip, tt_xy_pair eth_core) {
+    if (is_running_on_6u) {
+        return get_remote_asic_id(chip, eth_core);
+    }
+
     TTDevice* tt_device = chip->get_tt_device();
     uint32_t board_id;
     tt_device->read_from_device(
@@ -411,7 +415,11 @@ uint32_t TopologyDiscovery::get_remote_board_id(Chip* chip, tt_xy_pair eth_core)
     return board_id;
 }
 
-uint32_t TopologyDiscovery::get_local_board_id(Chip* chip, tt_xy_pair eth_core) {
+uint64_t TopologyDiscovery::get_local_board_id(Chip* chip, tt_xy_pair eth_core) {
+    if (is_running_on_6u) {
+        return get_local_asic_id(chip, eth_core);
+    }
+
     TTDevice* tt_device = chip->get_tt_device();
     uint32_t board_id;
     tt_device->read_from_device(


### PR DESCRIPTION
### Issue

Be able to isolate just specific chips on 6U galaxy

### Description

Add support for isolating specific chips on 6U galaxy. We hack the topology discovery in a way that board_id during topology discovery is actually equal to asic id so you can isolate even a single chip.

### List of the changes

- In 6U case, return remote asic ID as remote board ID
- in 6U case, return local asic ID as local board ID 

### Testing

Manual testing on 6U

### API Changes
/