### PR TITLE
Small optimization for Topology discovery

### DIFF
--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -182,6 +182,7 @@ void TopologyDiscovery::get_pcie_connected_chips() {
                 continue;
             }
             board_ids.insert(board_id);
+            break;
         }
         chips_to_discover.emplace(chip_id, std::move(chip));
         chip_id++;


### PR DESCRIPTION
### Issue

We were adding board id multiple times inside struct in Topology Discovery. This is not a functional bug but something we don't have to do

### Description

Break the first time we add board id to discovered boards

### List of the changes

- Add break to the loop adding board id

### Testing

CI

### API Changes
/