### PR TITLE
Telemetry update only dynamic entries - with new wormhole in mind

### DIFF
--- a/device/api/umd/device/arc_telemetry_reader.h
+++ b/device/api/umd/device/arc_telemetry_reader.h
@@ -57,8 +57,7 @@ protected:
     TTDevice* tt_device;
 
 private:
-    std::unordered_set<uint16_t> static_entries{};
-    const std::unordered_set<uint16_t> possible_static_entries{
+    const std::unordered_set<uint16_t> static_entries{
         TAG_BOARD_ID_HIGH,
         TAG_BOARD_ID_LOW,
         TAG_ASIC_ID,

--- a/device/api/umd/device/arc_telemetry_reader.h
+++ b/device/api/umd/device/arc_telemetry_reader.h
@@ -6,9 +6,11 @@
 #pragma once
 
 #include <map>
+#include <unordered_set>
 
 #include "umd/device/tt_device/tt_device.h"
 #include "umd/device/tt_xy_pair.h"
+#include "umd/device/types/telemetry.h"
 
 namespace tt::umd {
 
@@ -53,6 +55,27 @@ protected:
     tt_xy_pair arc_core;
 
     TTDevice* tt_device;
+
+private:
+    std::unordered_set<uint16_t> static_entries{};
+    const std::unordered_set<uint16_t> possible_static_entries{
+        TAG_BOARD_ID_HIGH,
+        TAG_BOARD_ID_LOW,
+        TAG_ASIC_ID,
+        TAG_HARVESTING_STATE,
+        TAG_UPDATE_TELEM_SPEED,
+        TAG_ETH_FW_VERSION,
+        TAG_DDR_FW_VERSION,
+        TAG_BM_APP_FW_VERSION,
+        TAG_BM_BL_FW_VERSION,
+        TAG_FLASH_BUNDLE_VERSION,
+        TAG_CM_FW_VERSION,
+        TAG_L2CPU_FW_VERSION,
+        TAG_ENABLED_TENSIX_COL,
+        TAG_ENABLED_ETH,
+        TAG_ENABLED_GDDR,
+        TAG_ENABLED_L2CPU,
+        TAG_PCIE_USAGE};
 };
 
 }  // namespace tt::umd

--- a/device/arc_telemetry_reader.cpp
+++ b/device/arc_telemetry_reader.cpp
@@ -45,9 +45,6 @@ void ArcTelemetryReader::initialize_telemetry() {
 
         telemetry_values.insert({tag_val, telemetry_data[offset_val]});
         telemetry_offset.insert({tag_val, offset_val});
-        if (possible_static_entries.find(tag_val) != possible_static_entries.end()) {
-            static_entries.insert(tag_val);
-        }
     }
 }
 

--- a/device/arc_telemetry_reader.cpp
+++ b/device/arc_telemetry_reader.cpp
@@ -45,6 +45,9 @@ void ArcTelemetryReader::initialize_telemetry() {
 
         telemetry_values.insert({tag_val, telemetry_data[offset_val]});
         telemetry_offset.insert({tag_val, offset_val});
+        if (possible_static_entries.find(tag_val) != possible_static_entries.end()) {
+            static_entries.insert(tag_val);
+        }
     }
 }
 
@@ -53,6 +56,10 @@ uint32_t ArcTelemetryReader::read_entry(const uint8_t telemetry_tag) {
         throw std::runtime_error(fmt::format(
             "Telemetry entry {} not available. You can use is_entry_available() to check if the entry is available.",
             telemetry_tag));
+    }
+
+    if (static_entries.find(telemetry_tag) != static_entries.end()) {
+        return telemetry_values[telemetry_tag];
     }
 
     const uint32_t offset = telemetry_offset.at(telemetry_tag);

--- a/device/arc_telemetry_reader.cpp
+++ b/device/arc_telemetry_reader.cpp
@@ -56,7 +56,7 @@ uint32_t ArcTelemetryReader::read_entry(const uint8_t telemetry_tag) {
     }
 
     if (static_entries.find(telemetry_tag) != static_entries.end()) {
-        return telemetry_values[telemetry_tag];
+        return telemetry_values.at(telemetry_tag);
     }
 
     const uint32_t offset = telemetry_offset.at(telemetry_tag);

--- a/tests/api/test_arc_telemetry.cpp
+++ b/tests/api/test_arc_telemetry.cpp
@@ -12,11 +12,11 @@ TEST(TestTelemetry, BasicTelemetry) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        std::unique_ptr<ArcTelemetryReader> blackhole_arc_telemetry_reader =
+        std::unique_ptr<ArcTelemetryReader> arc_telemetry_reader =
             ArcTelemetryReader::create_arc_telemetry_reader(tt_device.get());
 
-        uint32_t board_id_high = blackhole_arc_telemetry_reader->read_entry(TAG_BOARD_ID_HIGH);
-        uint32_t board_id_low = blackhole_arc_telemetry_reader->read_entry(TAG_BOARD_ID_LOW);
+        uint32_t board_id_high = arc_telemetry_reader->read_entry(TAG_BOARD_ID_HIGH);
+        uint32_t board_id_low = arc_telemetry_reader->read_entry(TAG_BOARD_ID_LOW);
 
         const uint64_t board_id = ((uint64_t)board_id_high << 32) | (board_id_low);
         EXPECT_NO_THROW(get_board_type_from_board_id(board_id));
@@ -28,13 +28,13 @@ TEST(TestTelemetry, TelemetryEntryAvailable) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        std::unique_ptr<ArcTelemetryReader> blackhole_arc_telemetry_reader =
+        std::unique_ptr<ArcTelemetryReader> arc_telemetry_reader =
             ArcTelemetryReader::create_arc_telemetry_reader(tt_device.get());
 
-        EXPECT_TRUE(blackhole_arc_telemetry_reader->is_entry_available(TAG_BOARD_ID_HIGH));
-        EXPECT_TRUE(blackhole_arc_telemetry_reader->is_entry_available(TAG_BOARD_ID_LOW));
+        EXPECT_TRUE(arc_telemetry_reader->is_entry_available(TAG_BOARD_ID_HIGH));
+        EXPECT_TRUE(arc_telemetry_reader->is_entry_available(TAG_BOARD_ID_LOW));
 
         // Blackhole tag table is still not finalized, but we are probably never going to have 200 tags.
-        EXPECT_FALSE(blackhole_arc_telemetry_reader->is_entry_available(200));
+        EXPECT_FALSE(arc_telemetry_reader->is_entry_available(200));
     }
 }


### PR DESCRIPTION
### Issue
#507 

### Description
Read static entries only once in ARC telemetry reader and store them for later re-use.

### List of the changes
- Added hashed map of static entries in ARC telemetry reader to read out static values at time of initialization


### Testing
Manual

### API Changes
/
