### PR TITLE
Remove deprecated .harvesting_masks from ClusterDescriptor

### DIFF
--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -272,7 +272,6 @@ private:
     std::unordered_map<chip_id_t, chip_id_t> chips_with_mmio;
     std::unordered_set<chip_id_t> all_chips;
     std::unordered_map<chip_id_t, bool> noc_translation_enabled = {};
-    std::unordered_map<chip_id_t, std::uint32_t> harvesting_masks = {};
     std::unordered_map<chip_id_t, chip_id_t> closest_mmio_chip_cache = {};
     std::unordered_map<chip_id_t, BoardType> chip_board_type = {};
     std::unordered_map<chip_id_t, std::unordered_set<chip_id_t>> chips_grouped_by_closest_mmio;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1082,7 +1082,6 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
         desc->chip_board_type.insert({chip_id, chip->get_chip_info().board_type});
 
         desc->noc_translation_enabled.insert({chip_id, chip->get_chip_info().noc_translation_enabled});
-        desc->harvesting_masks.insert({chip_id, chip->get_chip_info().harvesting_masks.tensix_harvesting_mask});
         desc->harvesting_masks_map.insert({chip_id, chip->get_chip_info().harvesting_masks});
 
         desc->add_chip_to_board(chip_id, chip->get_chip_info().chip_uid.board_id);

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -338,8 +338,6 @@ void TopologyDiscovery::fill_cluster_descriptor_info() {
         cluster_desc->chip_board_type.insert({current_chip_id, chip->get_chip_info().board_type});
 
         cluster_desc->noc_translation_enabled.insert({current_chip_id, chip->get_chip_info().noc_translation_enabled});
-        cluster_desc->harvesting_masks.insert(
-            {current_chip_id, chip->get_chip_info().harvesting_masks.tensix_harvesting_mask});
         cluster_desc->harvesting_masks_map.insert({current_chip_id, chip->get_chip_info().harvesting_masks});
         // TODO: this neeeds to be moved to specific logic for Wormhole with legacy FW.
         if (!is_running_on_6u) {

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -478,7 +478,6 @@ std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_constrained_c
     desc->chips_with_mmio = filter_chip_collection(full_cluster_desc->chips_with_mmio, target_chip_ids);
     desc->all_chips = filter_chip_collection(full_cluster_desc->all_chips, target_chip_ids);
     desc->noc_translation_enabled = filter_chip_collection(full_cluster_desc->noc_translation_enabled, target_chip_ids);
-    desc->harvesting_masks = filter_chip_collection(full_cluster_desc->harvesting_masks, target_chip_ids);
     // desc->closest_mmio_chip_cache is not copied intentionally, it could hold wrong information.
     desc->chip_board_type = filter_chip_collection(full_cluster_desc->chip_board_type, target_chip_ids);
     desc->chip_arch = filter_chip_collection(full_cluster_desc->chip_arch, target_chip_ids);
@@ -564,7 +563,6 @@ std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_mock_cluster(
         desc->chips_with_mmio.insert({logical_id, logical_id});
         desc->chip_arch.insert({logical_id, arch});
         desc->noc_translation_enabled.insert({logical_id, true});
-        desc->harvesting_masks.insert({logical_id, 0});
     }
     desc->fill_chips_grouped_by_closest_mmio();
 
@@ -947,7 +945,6 @@ void tt_ClusterDescriptor::load_harvesting_information(YAML::Node &yaml) {
 
             HarvestingMasks harvesting{0, 0, 0, 0};
 
-            harvesting_masks.insert({chip, harvesting_info["harvest_mask"].as<std::uint32_t>()});
             harvesting.tensix_harvesting_mask = harvesting_info["harvest_mask"].as<std::uint32_t>();
 
             if (harvesting_info["dram_harvesting_mask"].IsDefined()) {


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description
(Add freeform description.)

### List of the changes
(Itemized list of all the changes.)

### Testing
(Comment on CI testing or Manual testing touching this change.)

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
