### PR TITLE
Added PCI device info logs into cluster

### DIFF
--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -632,6 +632,7 @@ private:
         const std::set<chip_id_t>& chips_to_exclude);
     // Test functions
     void verify_fw_bundle_version();
+    void log_pci_device_summary();
     void verify_eth_fw();
     void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions);
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -290,7 +290,7 @@ tt_SocDescriptor Cluster::construct_soc_descriptor(
     bool noc_translation_table_en =
         chip_in_cluster_descriptor ? cluster_desc->get_noc_translation_table_en().at(chip_id) : false;
     HarvestingMasks harvesting_masks =
-        chip_in_cluster_descriptor 
+        chip_in_cluster_descriptor
             ? get_harvesting_masks(chip_id, cluster_desc, perform_harvesting, simulated_harvesting_masks)
             : HarvestingMasks{};
     BoardType chip_board_type = chip_in_cluster_descriptor ? cluster_desc->get_board_type(chip_id) : BoardType::UNKNOWN;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -148,17 +148,18 @@ void Cluster::log_pci_device_summary() {
 
     for (chip_id_t chip_id : local_chip_ids_) {
         auto pci_device = chips_.at(chip_id)->get_tt_device()->get_pci_device();
-        if (pci_device) {
-            bool current_iommu_state = pci_device->is_iommu_enabled();
-            if (current_iommu_state != expected_iommu_state) {
-                log_warning(
-                    LogSiliconDriver,
-                    "IOMMU state mismatch for chip {}: expected {}, got {}",
-                    chip_id,
-                    iommu_state_str(expected_iommu_state),
-                    iommu_state_str(current_iommu_state));
-                all_devices_same_iommu_state = false;
-            }
+        if (!pci_device) {
+            continue;
+        }
+        bool current_iommu_state = pci_device->is_iommu_enabled();
+        if (current_iommu_state != expected_iommu_state) {
+            log_warning(
+                LogSiliconDriver,
+                "IOMMU state mismatch for chip {}: expected {}, got {}",
+                chip_id,
+                iommu_state_str(expected_iommu_state),
+                iommu_state_str(current_iommu_state));
+            all_devices_same_iommu_state = false;
         }
 
         if (!all_devices_same_iommu_state) {
@@ -289,7 +290,7 @@ tt_SocDescriptor Cluster::construct_soc_descriptor(
     bool noc_translation_table_en =
         chip_in_cluster_descriptor ? cluster_desc->get_noc_translation_table_en().at(chip_id) : false;
     HarvestingMasks harvesting_masks =
-        chip_in_cluster_descriptor
+        chip_in_cluster_descriptor 
             ? get_harvesting_masks(chip_id, cluster_desc, perform_harvesting, simulated_harvesting_masks)
             : HarvestingMasks{};
     BoardType chip_board_type = chip_in_cluster_descriptor ? cluster_desc->get_board_type(chip_id) : BoardType::UNKNOWN;

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -189,7 +189,7 @@ PCIDevice::PCIDevice(int pci_device_number) :
         TT_THROW("TENSTORRENT_IOCTL_GET_DRIVER_INFO failed");
     }
 
-    log_info(
+    log_debug(
         LogSiliconDriver,
         "Opened PCI device {}; KMD version: {}; API: {}; IOMMU: {}",
         pci_device_num,


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/1092

### Description
Added log_pci_device_summary() into cluster which is called during its construction.
It's used to log all information about used PCI devices.
Similar to how it was done in pci_device during it's construction, now we print the same logs, just collapsed into a shorter version like on the available picture.

<img width="979" height="46" alt="Screenshot 2025-07-18 at 18 13 29" src="https://github.com/user-attachments/assets/22deca26-d5c1-4ffa-a692-60187de8e3b7" />

### Testing
Changes visible when running OpenChipsByPciId test within api tests.

