### PR TITLE
Only include print_flatbuffer code in debug builds

### DIFF
--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -33,7 +33,8 @@ flatbuffers::FlatBufferBuilder create_flatbuffer(
     return builder;
 }
 
-void print_flatbuffer(const DeviceRequestResponse* buf) {
+static void print_flatbuffer(const DeviceRequestResponse* buf) {
+#ifdef DEBUG
     std::vector<uint32_t> data_vec(buf->data()->begin(), buf->data()->end());
     uint64_t addr = buf->address();
     uint32_t size = buf->size();
@@ -51,6 +52,7 @@ void print_flatbuffer(const DeviceRequestResponse* buf) {
 
     log_debug(tt::LogEmulationDriver, "{} bytes @ address {} in core ({}, {})", size, addr_hex, core.x, core.y);
     log_debug(tt::LogEmulationDriver, "Data: {}", data_hex);
+#endif
 }
 
 tt_SimulationDeviceInit::tt_SimulationDeviceInit(const std::filesystem::path& simulator_directory) :


### PR DESCRIPTION
### Issue
none

### Description
print_flatbuffer was building up a hex string for logging purposes and then throwing it away, even in release builds

### List of the changes
Wrap code in #ifdef DEBUG
Mark function only used in this file as static

### Testing
Ran metal programming examples on simulator locally

### API Changes
/
