### PR TITLE
Remove TT_BACKEND_HUGEPAGE_DIR

### DIFF
--- a/device/hugepage.cpp
+++ b/device/hugepage.cpp
@@ -20,7 +20,7 @@ namespace tt::umd {
 
 const uint32_t g_MAX_HOST_MEM_CHANNELS = 4;
 
-std::string hugepage_dir = "/dev/hugepages-1G";
+const std::string hugepage_dir = "/dev/hugepages-1G";
 
 uint32_t get_num_hugepages() {
     std::string nr_hugepages_path = "/sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages";


### PR DESCRIPTION
### Issue
#146 

### Description
This is not used anywhere. Hugepages are on a path of depreciation, so this flexibility is not needed.
This is not used by tt_metal repo anywhere

### List of the changes
- Remove TT_BACKEND_HUGEPAGE_DIR

### Testing
Code builds

### API Changes
There are no API changes in this PR.
