### PR TITLE
Implement deterministic chip IDs in Topology

### DIFF
--- a/device/api/umd/device/topology_discovery.h
+++ b/device/api/umd/device/topology_discovery.h
@@ -102,20 +102,19 @@ private:
     // eth_core should be in physical (NOC0) coordinates.
     std::unique_ptr<RemoteChip> create_remote_chip(Chip* chip, tt_xy_pair eth_core, Chip* gateway_chip);
 
-    Chip* get_chip(const chip_id_t chip_id);
+    Chip* get_chip(const uint64_t asic_id);
 
-    std::map<chip_id_t, std::unique_ptr<Chip>> chips_to_discover;
-    std::map<chip_id_t, std::unique_ptr<Chip>> chips;
+    std::map<uint64_t, std::unique_ptr<Chip>> chips_to_discover;
+    std::map<uint64_t, std::unique_ptr<Chip>> chips;
 
-    std::unordered_map<uint64_t, chip_id_t> asic_id_to_chip_id;
+    std::unordered_map<uint64_t, eth_coord_t> eth_coords;
 
-    std::unordered_map<chip_id_t, eth_coord_t> eth_coords;
+    std::vector<std::pair<std::pair<uint64_t, uint32_t>, std::pair<uint64_t, uint32_t>>> ethernet_connections;
 
-    std::vector<std::pair<std::pair<chip_id_t, uint32_t>, std::pair<chip_id_t, uint32_t>>> ethernet_connections;
+    std::vector<std::pair<std::pair<uint64_t, uint32_t>, std::pair<uint64_t, uint32_t>>>
+        ethernet_connections_to_remote_devices;
 
     std::unique_ptr<tt_ClusterDescriptor> cluster_desc;
-
-    chip_id_t chip_id = 0;
 
     EthAddresses eth_addresses;
 
@@ -124,7 +123,7 @@ private:
     // All board ids that should be included in the cluster descriptor.
     std::unordered_set<uint64_t> board_ids;
 
-    std::unordered_map<chip_id_t, std::set<uint32_t>> active_eth_channels_per_chip;
+    std::unordered_map<uint64_t, std::set<uint32_t>> active_eth_channels_per_chip;
 
     const std::string sdesc_path;
 

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -151,7 +151,7 @@ eth_coord_t TopologyDiscovery::get_remote_eth_coord(Chip* chip, tt_xy_pair eth_c
 void TopologyDiscovery::get_pcie_connected_chips() {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
-    chip_id = 0;
+    bool read_eth_addresses = false;
     for (auto& device_id : pci_device_ids) {
         if (!is_pcie_chip_id_included(device_id)) {
             continue;
@@ -167,11 +167,12 @@ void TopologyDiscovery::get_pcie_connected_chips() {
         // read the information about offsets of board IDs on ETH core.
         // TODO: confirm that we should only support one set of addresses so we can remove
         // figuring out ETH addresses from runtime and move it to constants.
-        if (chip_id == 0) {
+        if (!read_eth_addresses) {
             eth_addresses = TopologyDiscovery::get_eth_addresses(
                 chip->get_tt_device()->get_arc_telemetry_reader()->read_entry(wormhole::TAG_ETH_FW_VERSION));
 
             is_running_on_6u = chip->get_tt_device()->get_board_type() == BoardType::UBB;
+            read_eth_addresses = true;
         }
 
         std::vector<CoreCoord> eth_cores =
@@ -184,8 +185,7 @@ void TopologyDiscovery::get_pcie_connected_chips() {
             board_ids.insert(board_id);
             break;
         }
-        chips_to_discover.emplace(chip_id, std::move(chip));
-        chip_id++;
+        chips_to_discover.emplace(get_asic_id(chip.get()), std::move(chip));
     }
 }
 
@@ -221,38 +221,32 @@ void TopologyDiscovery::discover_remote_chips() {
 
     std::set<uint64_t> discovered_chips = {};
     // Needed to know which chip to use for remote communication.
-    std::map<uint64_t, chip_id_t> remote_asic_id_to_mmio_chip_id = {};
+    std::map<uint64_t, uint64_t> remote_asic_id_to_mmio_chip_id = {};
 
-    for (const auto& [current_chip_id, chip] : chips_to_discover) {
-        uint64_t current_chip_asic_id = get_asic_id(chip.get());
-
-        asic_id_to_chip_id.emplace(current_chip_asic_id, current_chip_id);
-
+    for (const auto& [current_chip_asic_id, chip] : chips_to_discover) {
         discovered_chips.insert(current_chip_asic_id);
 
-        remote_asic_id_to_mmio_chip_id.emplace(current_chip_asic_id, current_chip_id);
+        remote_asic_id_to_mmio_chip_id.emplace(current_chip_asic_id, current_chip_asic_id);
 
-        active_eth_channels_per_chip.emplace(current_chip_id, std::set<uint32_t>());
+        active_eth_channels_per_chip.emplace(current_chip_asic_id, std::set<uint32_t>());
 
         if (!is_running_on_6u) {
-            eth_coords.emplace(current_chip_id, get_local_eth_coord(chip.get()));
+            eth_coords.emplace(current_chip_asic_id, get_local_eth_coord(chip.get()));
         }
     }
 
     while (!chips_to_discover.empty()) {
         auto it = chips_to_discover.begin();
-        auto current_chip_id = it->first;
+        uint64_t current_chip_asic_id = it->first;
         std::unique_ptr<Chip> chip_unique = std::move(it->second);
         chips_to_discover.erase(it);
         Chip* chip = chip_unique.get();
-        chips.emplace(current_chip_id, std::move(chip_unique));
+        chips.emplace(current_chip_asic_id, std::move(chip_unique));
 
-        active_eth_channels_per_chip.emplace(current_chip_id, std::set<uint32_t>());
+        active_eth_channels_per_chip.emplace(current_chip_asic_id, std::set<uint32_t>());
         std::vector<CoreCoord> eth_cores =
             chip->get_soc_descriptor().get_cores(CoreType::ETH, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::NOC0);
         TTDevice* tt_device = chip->get_tt_device();
-
-        uint64_t current_chip_asic_id = get_asic_id(chip);
 
         uint32_t channel = 0;
         for (const CoreCoord& eth_core : eth_cores) {
@@ -263,7 +257,7 @@ void TopologyDiscovery::discover_remote_chips() {
                 continue;
             }
 
-            active_eth_channels_per_chip.at(current_chip_id).insert(channel);
+            active_eth_channels_per_chip.at(current_chip_asic_id).insert(channel);
 
             if (!is_board_id_included(get_remote_board_id(chip, eth_core))) {
                 uint32_t remote_eth_channel;
@@ -278,36 +272,31 @@ void TopologyDiscovery::discover_remote_chips() {
                                 CoordSystem::LOGICAL)
                             .y;
                 }
-                cluster_desc->ethernet_connections_to_remote_devices[current_chip_id][channel] = {
-                    get_remote_asic_id(chip, eth_core), remote_eth_channel};
+                ethernet_connections_to_remote_devices.push_back(
+                    {{current_chip_asic_id, channel}, {get_remote_asic_id(chip, eth_core), remote_eth_channel}});
 
                 channel++;
                 continue;
             }
 
-            chip->set_remote_transfer_ethernet_cores(active_eth_channels_per_chip.at(current_chip_id));
+            chip->set_remote_transfer_ethernet_cores(active_eth_channels_per_chip.at(current_chip_asic_id));
 
             uint64_t remote_asic_id = get_remote_asic_id(chip, eth_core);
 
             if (discovered_chips.find(remote_asic_id) == discovered_chips.end()) {
-                chip_id_t map_chip_id = remote_asic_id_to_mmio_chip_id.at(current_chip_asic_id);
                 std::unique_ptr<Chip> remote_chip = create_remote_chip(
                     chip, eth_core, get_chip(remote_asic_id_to_mmio_chip_id.at(current_chip_asic_id)));
 
-                chips_to_discover.emplace(chip_id, std::move(remote_chip));
-                active_eth_channels_per_chip.emplace(chip_id, std::set<uint32_t>());
-                asic_id_to_chip_id.emplace(remote_asic_id, chip_id);
+                chips_to_discover.emplace(remote_asic_id, std::move(remote_chip));
+                active_eth_channels_per_chip.emplace(remote_asic_id, std::set<uint32_t>());
                 discovered_chips.insert(remote_asic_id);
                 remote_asic_id_to_mmio_chip_id.emplace(
                     remote_asic_id, remote_asic_id_to_mmio_chip_id.at(current_chip_asic_id));
                 if (!is_running_on_6u) {
-                    eth_coords.emplace(chip_id, get_remote_eth_coord(chip, eth_core));
+                    eth_coords.emplace(remote_asic_id, get_remote_eth_coord(chip, eth_core));
                 }
-
-                chip_id++;
             } else {
-                chip_id_t remote_chip_id = asic_id_to_chip_id.at(remote_asic_id);
-                Chip* remote_chip = get_chip(remote_chip_id);
+                Chip* remote_chip = get_chip(remote_asic_id);
                 uint32_t remote_eth_channel;
                 if (is_running_on_6u) {
                     remote_eth_channel = get_remote_eth_id(chip, eth_core);
@@ -318,16 +307,23 @@ void TopologyDiscovery::discover_remote_chips() {
                             .translate_coord_to(remote_eth_core, CoordSystem::PHYSICAL, CoordSystem::LOGICAL)
                             .y;
                 }
-                ethernet_connections.push_back({{current_chip_id, channel}, {remote_chip_id, remote_eth_channel}});
+                ethernet_connections.push_back({{current_chip_asic_id, channel}, {remote_asic_id, remote_eth_channel}});
             }
             channel++;
         }
-        chip->set_remote_transfer_ethernet_cores(active_eth_channels_per_chip.at(current_chip_id));
+        chip->set_remote_transfer_ethernet_cores(active_eth_channels_per_chip.at(current_chip_asic_id));
     }
 }
 
 void TopologyDiscovery::fill_cluster_descriptor_info() {
-    for (const auto& [current_chip_id, chip] : chips) {
+    std::map<uint64_t, chip_id_t> asic_id_to_chip_id;
+    chip_id_t chip_id = 0;
+    for (const auto& [current_chip_asic_id, chip] : chips) {
+        asic_id_to_chip_id.emplace(current_chip_asic_id, chip_id++);
+    }
+
+    for (const auto& [current_chip_asic_id, chip] : chips) {
+        chip_id_t current_chip_id = asic_id_to_chip_id.at(current_chip_asic_id);
         cluster_desc->all_chips.insert(current_chip_id);
         cluster_desc->chip_arch.insert({current_chip_id, tt::ARCH::WORMHOLE_B0});
 
@@ -342,7 +338,7 @@ void TopologyDiscovery::fill_cluster_descriptor_info() {
         cluster_desc->harvesting_masks_map.insert({current_chip_id, chip->get_chip_info().harvesting_masks});
         // TODO: this neeeds to be moved to specific logic for Wormhole with legacy FW.
         if (!is_running_on_6u) {
-            eth_coord_t eth_coord = eth_coords.at(current_chip_id);
+            eth_coord_t eth_coord = eth_coords.at(current_chip_asic_id);
             cluster_desc->chip_locations.insert({current_chip_id, eth_coord});
             cluster_desc->coords_to_chip_ids[eth_coord.rack][eth_coord.shelf][eth_coord.y][eth_coord.x] =
                 current_chip_id;
@@ -356,13 +352,22 @@ void TopologyDiscovery::fill_cluster_descriptor_info() {
     }
 
     for (auto [ethernet_connection_logical, ethernet_connection_remote] : ethernet_connections) {
-        cluster_desc->ethernet_connections[ethernet_connection_logical.first][ethernet_connection_logical.second] = {
-            ethernet_connection_remote.first, ethernet_connection_remote.second};
-        cluster_desc->ethernet_connections[ethernet_connection_remote.first][ethernet_connection_remote.second] = {
-            ethernet_connection_logical.first, ethernet_connection_logical.second};
+        chip_id_t local_chip_id = asic_id_to_chip_id.at(ethernet_connection_logical.first);
+        chip_id_t remote_chip_id = asic_id_to_chip_id.at(ethernet_connection_remote.first);
+        cluster_desc->ethernet_connections[local_chip_id][ethernet_connection_logical.second] = {
+            remote_chip_id, ethernet_connection_remote.second};
+        cluster_desc->ethernet_connections[remote_chip_id][ethernet_connection_remote.second] = {
+            local_chip_id, ethernet_connection_logical.second};
     }
 
-    for (auto [current_chip_id, active_eth_channels] : active_eth_channels_per_chip) {
+    for (auto [ethernet_connection_logical, ethernet_connection_remote] : ethernet_connections_to_remote_devices) {
+        chip_id_t local_chip_id = asic_id_to_chip_id.at(ethernet_connection_logical.first);
+        cluster_desc->ethernet_connections_to_remote_devices[local_chip_id][ethernet_connection_logical.second] = {
+            ethernet_connection_remote.first, ethernet_connection_remote.second};
+    }
+
+    for (auto [current_chip_asic_id, active_eth_channels] : active_eth_channels_per_chip) {
+        chip_id_t current_chip_id = asic_id_to_chip_id.at(current_chip_asic_id);
         for (int i = 0; i < wormhole::NUM_ETH_CHANNELS; i++) {
             cluster_desc->idle_eth_channels[current_chip_id].insert(i);
         }
@@ -504,11 +509,11 @@ uint32_t TopologyDiscovery::get_remote_eth_id(Chip* chip, tt_xy_pair local_eth_c
     return remote_eth_id;
 }
 
-Chip* TopologyDiscovery::get_chip(const chip_id_t chip_id) {
-    if (chips_to_discover.find(chip_id) != chips_to_discover.end()) {
-        return chips_to_discover.at(chip_id).get();
+Chip* TopologyDiscovery::get_chip(const uint64_t asic_id) {
+    if (chips_to_discover.find(asic_id) != chips_to_discover.end()) {
+        return chips_to_discover.at(asic_id).get();
     }
-    return chips.at(chip_id).get();
+    return chips.at(asic_id).get();
 }
 
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue

#600 

### Description

Implement deterministic chip IDs in Topology discovery. Code has previously relied on PCI device enumeration, where now it will rely on unique chip IDs in order to assing logical IDs. These should stay consistent across reset.

### List of the changes

- Use ASIC id as key in maps in Topology Discovery
- Have separate struct for remote ETH connections in order to remap properly

### Testing

Manual testing on all configs

### API Changes
/