### PR TITLE
Update close device to check if dev in long idle and close remote devices first

### DIFF
--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -143,7 +143,14 @@ void LocalChip::start_device() {
     initialize_membars();
 }
 
-void LocalChip::close_device(){};
+void LocalChip::close_device() {
+    // Investigating https://github.com/tenstorrent/tt-metal/issues/25377 found that closing device that was already put
+    // in LONG_IDLE by tt-smi reset would hang
+    if ((uint32_t)get_clock() != get_tt_device()->get_min_clock_freq()) {
+        set_power_state(tt_DevicePowerState::LONG_IDLE);
+        send_tensix_risc_reset(TENSIX_ASSERT_SOFT_RESET);
+    }
+};
 
 int LocalChip::get_num_host_channels() { return sysmem_manager_->get_num_host_mem_channels(); }
 

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -30,7 +30,16 @@ bool RemoteChip::is_mmio_capable() const { return false; }
 
 void RemoteChip::start_device() {}
 
-void RemoteChip::close_device() {}
+void RemoteChip::close_device() {
+    // Investigating https://github.com/tenstorrent/tt-metal/issues/25377 found that closing device that was already put
+    // in LONG_IDLE by tt-smi reset would hang
+    if ((uint32_t)local_chip_->get_clock() != local_chip_->get_tt_device()->get_min_clock_freq()) {
+        if ((uint32_t)get_clock() != get_tt_device()->get_min_clock_freq()) {
+            set_power_state(tt_DevicePowerState::LONG_IDLE);
+            send_tensix_risc_reset(TENSIX_ASSERT_SOFT_RESET);
+        }
+    }
+}
 
 void RemoteChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) {
     tt_device_->write_to_device(src, translate_chip_coord_to_translated(core), l1_dest, size);

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -960,11 +960,14 @@ void Cluster::start_device(const tt_device_params& device_params) {
 }
 
 void Cluster::close_device() {
-    for (auto chip_id : all_chip_ids_) {
+    // Close remote device first because sending risc reset requires corresponding pcie device to be active
+    for (auto remote_chip_id : remote_chip_ids_) {
+        get_chip(remote_chip_id)->close_device();
+    }
+
+    for (auto chip_id : local_chip_ids_) {
         get_chip(chip_id)->close_device();
     }
-    set_power_state(tt_DevicePowerState::LONG_IDLE);
-    broadcast_tensix_risc_reset_to_cluster(TENSIX_ASSERT_SOFT_RESET);
 }
 
 std::uint32_t Cluster::get_num_host_channels(std::uint32_t device_id) {


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/25377#issuecomment

### Description
There was a change to ensure Metal objects are destructed on exit. This behaviour was causing a hang in tt::Cluster descriptor after pytest has exception because it invokes `tt-smi reset` first. Seems like the issue is due to remote/local device accesses when the device was already put in `LONG_IDLE`

### List of the changes
Update close_device to first close remote chips because they need corresponding pcie chip to be active and then only try setting power state and sending risc reset val if the chip (or corresponding pcie chip) is not in `LONG_IDLE`

### Testing
Used the repro in the Metal issue

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
