### PR TITLE
Remove machines with old versions of firmware and KMD

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -41,10 +41,8 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {arch: wormhole_b0, card: n150, timeout: 10},
           {arch: wormhole_b0, card: tt-beta-ubuntu-2204-n150-large-stable, timeout: 10},
           {arch: wormhole_b0, card: tt-beta-ubuntu-2204-n150-viommu-large-stable, timeout: 10},
-          {arch: wormhole_b0, card: n300, timeout: 15},
           {arch: wormhole_b0, card: tt-beta-ubuntu-2204-n300-large-stable, timeout: 15},
           {arch: wormhole_b0, card: tt-beta-ubuntu-2204-n300-viommu-large-stable, timeout: 15},
           {arch: wormhole_b0, card: tt-beta-ubuntu-2204-n300-llmbox-large-stable, timeout: 15},


### PR DESCRIPTION
### Issue
Currently blocking #1054 

### Description
The machines from the workflow that are removed are not being properly maintained and lead to failed CI tests without an evident reason (they contain older versions of the firmware and KMD)

### List of the changes
- Remove two lines (n150 and n300 based machines from CI)

### Testing
Manual

### API Changes
/
