### PR TITLE
Add -march=x86-64-v3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ add_subdirectory(third_party)
 # Ignore unused variables and functions since there is no harm.
 # TODO: Re-enable sign-compare
 add_compile_options(
+    "$<$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},x86_64>:-march=x86-64-v3>"
     -Wall
     -Werror
     -Wno-unused-variable


### PR DESCRIPTION
### Issue
none

### Description
Enable usage of new x86 ISA features, same as recently done in tt-metal.

### List of the changes
Add -march=x86-64-v3 to compiler options when targeting x86_64.

### Testing
https://github.com/tenstorrent/tt-umd/actions/runs/16573462166

### API Changes
/