### PR TITLE
Upgrade libuv to 1.51.0

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -94,7 +94,7 @@ if(TT_UMD_BUILD_SIMULATION)
     CPMAddPackage(
         NAME libuv
         GITHUB_REPOSITORY libuv/libuv
-        GIT_TAG v1.48.0
+        GIT_TAG v1.51.0
         OPTIONS
             "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
             "LIBUV_BUILD_TESTS OFF"

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -98,6 +98,7 @@ if(TT_UMD_BUILD_SIMULATION)
         OPTIONS
             "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
             "LIBUV_BUILD_TESTS OFF"
+            "LIBUV_BUILD_SHARED OFF"
             "BUILD_SHARED_LIBS OFF"
     )
 endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -98,7 +98,7 @@ if(TT_UMD_BUILD_SIMULATION)
         OPTIONS
             "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
             "LIBUV_BUILD_TESTS OFF"
-            "LIBUV_BUILD_SHARED OFF"
+            "BUILD_SHARED_LIBS OFF"
     )
 endif()
 


### PR DESCRIPTION
With CMake >= 4.0, we can see warning about libuv:
```
CMake Deprecation Warning at .cpmcache/libuv/72aa6fc919b0653b47b7e9e7cf59ec92037e8693/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```

Updating version to fix it.