### PR TITLE
Improve PCI id filtering

### DIFF
--- a/device/api/umd/device/pci_device.hpp
+++ b/device/api/umd/device/pci_device.hpp
@@ -11,6 +11,7 @@
 #include <map>
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "fmt/format.h"
@@ -61,12 +62,12 @@ public:
     /**
      * @return a list of integers corresponding to character devices in /dev/tenstorrent/
      */
-    static std::vector<int> enumerate_devices();
+    static std::vector<int> enumerate_devices(std::unordered_set<int> pci_target_devices = {});
 
     /**
      * @return a map of PCI device numbers (/dev/tenstorrent/N) to PciDeviceInfo
      */
-    static std::map<int, PciDeviceInfo> enumerate_devices_info();
+    static std::map<int, PciDeviceInfo> enumerate_devices_info(std::unordered_set<int> pci_target_devices = {});
 
     /**
      * PCI device constructor.

--- a/device/api/umd/device/topology_discovery.h
+++ b/device/api/umd/device/topology_discovery.h
@@ -43,8 +43,6 @@ private:
 
     void fill_cluster_descriptor_info();
 
-    bool is_pcie_chip_id_included(int pci_id) const;
-
     // board_type is not used for all configs.
     // We need to know that we are seeing TG board and that we should include it in the topology.
     bool is_board_id_included(uint64_t board_id, uint64_t board_type) const;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1057,9 +1057,9 @@ void Cluster::set_barrier_address_params(const barrier_address_params& barrier_a
 
 std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
     std::string sdesc_path, std::unordered_set<chip_id_t> pci_target_devices) {
-    std::map<int, PciDeviceInfo> pci_device_info = PCIDevice::enumerate_devices_info();
+    std::map<int, PciDeviceInfo> pci_device_info = PCIDevice::enumerate_devices_info(pci_target_devices);
     if (pci_device_info.begin()->second.get_arch() == tt::ARCH::BLACKHOLE) {
-        std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+        std::vector<int> pci_device_ids = PCIDevice::enumerate_devices(pci_target_devices);
 
         std::unordered_map<chip_id_t, std::unique_ptr<Chip>> chips;
         chip_id_t chip_id = 0;

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -149,13 +149,10 @@ eth_coord_t TopologyDiscovery::get_remote_eth_coord(Chip* chip, tt_xy_pair eth_c
 }
 
 void TopologyDiscovery::get_pcie_connected_chips() {
-    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices(pci_target_devices);
 
     bool read_eth_addresses = false;
     for (auto& device_id : pci_device_ids) {
-        if (!is_pcie_chip_id_included(device_id)) {
-            continue;
-        }
         std::unique_ptr<LocalChip> chip = nullptr;
         if (sdesc_path != "") {
             chip = std::make_unique<LocalChip>(sdesc_path, TTDevice::create(device_id));
@@ -387,11 +384,6 @@ void TopologyDiscovery::fill_cluster_descriptor_info() {
     cluster_desc->fill_chips_grouped_by_closest_mmio();
 
     cluster_desc->verify_cluster_descriptor_info();
-}
-
-// If pci_target_devices is empty, we should take all the PCI devices found in the system.
-bool TopologyDiscovery::is_pcie_chip_id_included(int pci_id) const {
-    return pci_target_devices.empty() || pci_target_devices.find(pci_id) != pci_target_devices.end();
 }
 
 // If pci_target_devices is empty, we should take all the PCI devices found in the system.


### PR DESCRIPTION
### Issue

Improve PCI id filtering in UMD

### Description

Improve PCI id filtering in UMD by doing it in PCIDevice layer. UMD will actually completely ignore pci devices not specified in pci_target_devices so logic can be simplified in TopologyDiscovery

### List of the changes

- Add pci_target_devices to enumerate functions
- Filter pci target devices in PCIDevice layer
- Remove pci id filtering logic from TopologyDiscovery

### Testing

CI + manual testing on T3K

### API Changes
/