### PR TITLE
Fix reading fw version for 4u galaxy

### DIFF
--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -64,8 +64,15 @@ ChipInfo WormholeTTDevice::get_chip_info() {
 
     chip_info.board_type = get_board_type();
 
-    chip_info.firmware_version =
-        fw_version_from_telemetry(telemetry->read_entry(wormhole::TelemetryTag::FW_BUNDLE_VERSION));
+    if (chip_info.board_type == BoardType::GALAXY) {
+        // There is a hack for galaxy board such that ARC puts this information as tt_flash version.
+        // For more information see https://github.com/tenstorrent/tt-smi/issues/72
+        chip_info.firmware_version =
+            fw_version_from_telemetry(telemetry->read_entry(wormhole::TelemetryTag::TT_FLASH_VERSION));
+    } else {
+        chip_info.firmware_version =
+            fw_version_from_telemetry(telemetry->read_entry(wormhole::TelemetryTag::FW_BUNDLE_VERSION));
+    }
 
     return chip_info;
 }


### PR DESCRIPTION
### Issue
Fixes https://github.com/tenstorrent/tt-umd/issues/1041

### Description
For some reason, the fw bundle version is in tt flash version telemetry.

### List of the changes
- In case of 4u board (note that on n150 which are present in galaxy system, the fw is still in the expected telemetry)

### Testing
Manually tested and matched info with the one reported by tt-smi

### API Changes
There are no API changes in this PR.
