### PR TITLE
Add microbenchmark for IO over ethernet

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -82,3 +82,8 @@ jobs:
         if: ${{ inputs.arch != 'baremetal' }}
         run: |
           ${{ env.TEST_OUTPUT_DIR }}/umd/ubenchmarks/ubench --gtest_filter=MicrobenchmarkOpenCluster*
+
+      - name: Run Ethernet IO benchmarks
+        if: ${{ inputs.arch != 'baremetal' }}
+        run: |
+          ${{ env.TEST_OUTPUT_DIR }}/umd/ubenchmarks/ubench --gtest_filter=MicrobenchmarkEthernetIO*

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           ${{ env.TEST_OUTPUT_DIR }}/umd/ubenchmarks/ubench --gtest_filter=MicrobenchmarkOpenCluster*
 
-      - name: Run Ethernet IO benchmarks
+      - name: Run ethernet IO benchmarks
         if: ${{ inputs.arch != 'baremetal' }}
         run: |
           ${{ env.TEST_OUTPUT_DIR }}/umd/ubenchmarks/ubench --gtest_filter=MicrobenchmarkEthernetIO*

--- a/tests/microbenchmark/CMakeLists.txt
+++ b/tests/microbenchmark/CMakeLists.txt
@@ -3,6 +3,7 @@ set(UBENCH_SRC
     benchmarks/pcie_dma/test_pcie_dma.cpp
     benchmarks/iommu/test_iommu.cpp
     benchmarks/open_cluster/test_open_cluster.cpp
+    benchmarks/ethernet_io/test_ethernet_io.cpp
     common/microbenchmark_utils.cpp
 )
 add_executable(ubench ${UBENCH_SRC})

--- a/tests/microbenchmark/benchmarks/ethernet_io/README.md
+++ b/tests/microbenchmark/benchmarks/ethernet_io/README.md
@@ -1,0 +1,3 @@
+# ETH IO benchmark
+
+This benchmark contains tests that are measuring performance of IO to devices not connected to the host directly over PCIe, rather over ETH to chips connected via PCIe.

--- a/tests/microbenchmark/benchmarks/ethernet_io/test_ethernet_io.cpp
+++ b/tests/microbenchmark/benchmarks/ethernet_io/test_ethernet_io.cpp
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "common/microbenchmark_utils.h"
+#include "gtest/gtest.h"
+
+using namespace tt::umd;
+
+const uint32_t one_mb = 1 << 20;
+const uint32_t NUM_ITERATIONS = 10;
+const uint32_t tlb_1m_index = 0;
+const uint32_t tlb_16m_index = 166;
+
+/**
+ * Measure BW of IO to DRAM core on the ETH connected device.
+ */
+TEST(MicrobenchmarkEthernetIO, DRAM) {
+    // Sizes are chosen in a way to avoid TLB benchmark taking too long. 32 MB already
+    // tests chunking of data into smaller chunks to match TLB size.
+    // 64 MB and above showed the same perf locally.
+    const std::vector<uint32_t> sizes = {
+        1 * one_mb,
+        2 * one_mb,
+        4 * one_mb,
+        8 * one_mb,
+        16 * one_mb,
+        32 * one_mb,
+    };
+
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+
+    if (cluster->get_target_remote_device_ids().empty()) {
+        GTEST_SKIP() << "No ETH connected devices found in the cluster, skipping benchmark.";
+    }
+
+    const chip_id_t chip = *cluster->get_target_remote_device_ids().begin();
+    const CoreCoord dram_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::DRAM)[0];
+    cluster->start_device(tt_device_params{});
+
+    const std::vector<std::string> headers = {
+        "Size (MB)",
+        "Host -> ETH Device DRAM (MB/s)",
+        "ETH Device DRAM -> Host (MB/s)",
+    };
+
+    std::vector<std::vector<std::string>> rows;
+
+    for (uint32_t buf_size : sizes) {
+        std::vector<std::string> row;
+        row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
+        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster, chip, dram_core);
+        row.push_back(test::utils::convert_double_to_string(wr_bw));
+        row.push_back(test::utils::convert_double_to_string(rd_bw));
+        rows.push_back(row);
+    }
+    test::utils::print_markdown_table_format(headers, rows);
+}
+
+/**
+ * Measure BW of IO to Tensix core on ETH connected device.
+ */
+TEST(MicrobenchmarkEthernetIO, Tensix) {
+    const std::vector<uint32_t> sizes = {
+        1 * one_mb,
+    };
+
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+
+    if (cluster->get_target_remote_device_ids().empty()) {
+        GTEST_SKIP() << "No ETH connected devices found in the cluster, skipping benchmark.";
+    }
+
+    const chip_id_t chip = *cluster->get_target_remote_device_ids().begin();
+    const CoreCoord tensix_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)[0];
+    cluster->start_device(tt_device_params{});
+
+    const std::vector<std::string> headers = {
+        "Size (MB)",
+        "Host -> ETH Device Tensix L1 (MB/s)",
+        "ETH Device Tensix L1 -> Host (MB/s)",
+    };
+
+    std::vector<std::vector<std::string>> rows;
+
+    for (uint32_t buf_size : sizes) {
+        std::vector<std::string> row;
+        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster, chip, tensix_core);
+        row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
+        row.push_back(test::utils::convert_double_to_string(wr_bw));
+        row.push_back(test::utils::convert_double_to_string(rd_bw));
+        rows.push_back(row);
+    }
+    test::utils::print_markdown_table_format(headers, rows);
+}

--- a/tests/microbenchmark/benchmarks/ethernet_io/test_ethernet_io.cpp
+++ b/tests/microbenchmark/benchmarks/ethernet_io/test_ethernet_io.cpp
@@ -8,10 +8,8 @@
 
 using namespace tt::umd;
 
-const uint32_t one_mb = 1 << 20;
-const uint32_t NUM_ITERATIONS = 10;
-const uint32_t tlb_1m_index = 0;
-const uint32_t tlb_16m_index = 166;
+constexpr uint32_t one_mb = 1 << 20;
+constexpr uint32_t NUM_ITERATIONS = 10;
 
 /**
  * Measure BW of IO to DRAM core on the ETH connected device.
@@ -20,7 +18,7 @@ TEST(MicrobenchmarkEthernetIO, DRAM) {
     // Sizes are chosen in a way to avoid TLB benchmark taking too long. 32 MB already
     // tests chunking of data into smaller chunks to match TLB size.
     // 64 MB and above showed the same perf locally.
-    const std::vector<uint32_t> sizes = {
+    const std::array<uint32_t, 6> sizes = {
         1 * one_mb,
         2 * one_mb,
         4 * one_mb,
@@ -50,7 +48,7 @@ TEST(MicrobenchmarkEthernetIO, DRAM) {
     for (uint32_t buf_size : sizes) {
         std::vector<std::string> row;
         row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
-        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster, chip, dram_core);
+        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster.get(), chip, dram_core);
         row.push_back(test::utils::convert_double_to_string(wr_bw));
         row.push_back(test::utils::convert_double_to_string(rd_bw));
         rows.push_back(row);
@@ -62,7 +60,7 @@ TEST(MicrobenchmarkEthernetIO, DRAM) {
  * Measure BW of IO to Tensix core on ETH connected device.
  */
 TEST(MicrobenchmarkEthernetIO, Tensix) {
-    const std::vector<uint32_t> sizes = {
+    const std::array<uint32_t, 6> sizes = {
         1 * one_mb,
     };
 
@@ -86,7 +84,7 @@ TEST(MicrobenchmarkEthernetIO, Tensix) {
 
     for (uint32_t buf_size : sizes) {
         std::vector<std::string> row;
-        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster, chip, tensix_core);
+        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster.get(), chip, tensix_core);
         row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
         row.push_back(test::utils::convert_double_to_string(wr_bw));
         row.push_back(test::utils::convert_double_to_string(rd_bw));

--- a/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
+++ b/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
@@ -8,15 +8,6 @@
 #include "common/microbenchmark_utils.h"
 #include "gtest/gtest.h"
 #include "tests/test_utils/device_test_utils.hpp"
-#include "tests/test_utils/generate_cluster_desc.hpp"
-#include "umd/device/chip_helpers/sysmem_manager.h"
-#include "umd/device/cluster.h"
-#include "umd/device/tt_cluster_descriptor.h"
-#include "umd/device/tt_device/wormhole_tt_device.h"
-#include "umd/device/wormhole_implementation.h"
-#include "wormhole/eth_l1_address_map.h"
-#include "wormhole/host_mem_address_map.h"
-#include "wormhole/l1_address_map.h"
 
 using namespace tt::umd;
 

--- a/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
+++ b/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
@@ -8,15 +8,6 @@
 #include "common/microbenchmark_utils.h"
 #include "gtest/gtest.h"
 #include "tests/test_utils/device_test_utils.hpp"
-#include "tests/test_utils/generate_cluster_desc.hpp"
-#include "umd/device/chip_helpers/sysmem_manager.h"
-#include "umd/device/cluster.h"
-#include "umd/device/tt_cluster_descriptor.h"
-#include "umd/device/tt_device/wormhole_tt_device.h"
-#include "umd/device/wormhole_implementation.h"
-#include "wormhole/eth_l1_address_map.h"
-#include "wormhole/host_mem_address_map.h"
-#include "wormhole/l1_address_map.h"
 
 using namespace tt::umd;
 

--- a/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
+++ b/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
@@ -45,7 +45,7 @@ TEST(MicrobenchmarkTLB, TLBDynamicDram) {
     for (uint32_t buf_size : sizes) {
         std::vector<std::string> row;
         row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
-        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster, chip, dram_core);
+        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster.get(), chip, dram_core);
         row.push_back(test::utils::convert_double_to_string(wr_bw));
         row.push_back(test::utils::convert_double_to_string(rd_bw));
         rows.push_back(row);
@@ -75,7 +75,7 @@ TEST(MicrobenchmarkTLB, TLBDynamicTensix) {
 
     for (uint32_t buf_size : sizes) {
         std::vector<std::string> row;
-        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster, chip, tensix_core);
+        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster.get(), chip, tensix_core);
         row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
         row.push_back(test::utils::convert_double_to_string(wr_bw));
         row.push_back(test::utils::convert_double_to_string(rd_bw));
@@ -111,7 +111,7 @@ TEST(MicrobenchmarkTLB, TLBStaticTensix) {
     for (uint32_t buf_size : sizes) {
         std::vector<std::string> row;
         const uint32_t num_io = buf_size / one_mb;
-        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, num_io, cluster, chip, tensix_core);
+        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, num_io, cluster.get(), chip, tensix_core);
         row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
         row.push_back(test::utils::convert_double_to_string(wr_bw));
         row.push_back(test::utils::convert_double_to_string(rd_bw));
@@ -150,7 +150,7 @@ TEST(MicrobenchmarkTLB, TLBStaticDram) {
         std::vector<std::string> row;
         const uint32_t num_io = buf_size / (16 * one_mb);
 
-        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, num_io, cluster, chip, dram_core);
+        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, num_io, cluster.get(), chip, dram_core);
         row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
         row.push_back(test::utils::convert_double_to_string(wr_bw));
         row.push_back(test::utils::convert_double_to_string(rd_bw));

--- a/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
+++ b/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
@@ -5,16 +5,6 @@
  */
 #include "common/microbenchmark_utils.h"
 #include "gtest/gtest.h"
-#include "tests/test_utils/device_test_utils.hpp"
-#include "tests/test_utils/generate_cluster_desc.hpp"
-#include "umd/device/chip_helpers/sysmem_manager.h"
-#include "umd/device/cluster.h"
-#include "umd/device/tt_cluster_descriptor.h"
-#include "umd/device/tt_device/wormhole_tt_device.h"
-#include "umd/device/wormhole_implementation.h"
-#include "wormhole/eth_l1_address_map.h"
-#include "wormhole/host_mem_address_map.h"
-#include "wormhole/l1_address_map.h"
 
 using namespace tt::umd;
 
@@ -23,34 +13,6 @@ const uint32_t one_mb = 1 << 20;
 const uint32_t NUM_ITERATIONS = 10;
 const uint32_t tlb_1m_index = 0;
 const uint32_t tlb_16m_index = 166;
-
-static inline std::pair<double, double> perf_read_write(
-    const uint32_t buf_size,
-    const uint32_t num_iterations,
-    const std::unique_ptr<Cluster>& cluster,
-    const CoreCoord core) {
-    std::vector<uint8_t> pattern(buf_size);
-    test_utils::fill_with_random_bytes(&pattern[0], pattern.size());
-
-    auto now = std::chrono::steady_clock::now();
-    for (int i = 0; i < num_iterations; i++) {
-        cluster->write_to_device(pattern.data(), pattern.size(), chip, core, 0x0);
-    }
-    auto end = std::chrono::steady_clock::now();
-    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
-    double wr_bw = test::utils::calc_speed(num_iterations * pattern.size(), ns);
-
-    std::vector<uint8_t> readback(buf_size, 0x0);
-    now = std::chrono::steady_clock::now();
-    for (int i = 0; i < num_iterations; i++) {
-        cluster->read_from_device(readback.data(), chip, core, 0x0, readback.size());
-    }
-    end = std::chrono::steady_clock::now();
-    ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
-    double rd_bw = test::utils::calc_speed(num_iterations * readback.size(), ns);
-
-    return std::make_pair(wr_bw, rd_bw);
-}
 
 /**
  * Measure BW of IO to DRAM core using dynamically configured TLB.
@@ -83,7 +45,7 @@ TEST(MicrobenchmarkTLB, TLBDynamicDram) {
     for (uint32_t buf_size : sizes) {
         std::vector<std::string> row;
         row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
-        auto [wr_bw, rd_bw] = perf_read_write(buf_size, NUM_ITERATIONS, cluster, dram_core);
+        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster, chip, dram_core);
         row.push_back(test::utils::convert_double_to_string(wr_bw));
         row.push_back(test::utils::convert_double_to_string(rd_bw));
         rows.push_back(row);
@@ -113,7 +75,7 @@ TEST(MicrobenchmarkTLB, TLBDynamicTensix) {
 
     for (uint32_t buf_size : sizes) {
         std::vector<std::string> row;
-        auto [wr_bw, rd_bw] = perf_read_write(buf_size, NUM_ITERATIONS, cluster, tensix_core);
+        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster, chip, tensix_core);
         row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
         row.push_back(test::utils::convert_double_to_string(wr_bw));
         row.push_back(test::utils::convert_double_to_string(rd_bw));
@@ -149,7 +111,7 @@ TEST(MicrobenchmarkTLB, TLBStaticTensix) {
     for (uint32_t buf_size : sizes) {
         std::vector<std::string> row;
         const uint32_t num_io = buf_size / one_mb;
-        auto [wr_bw, rd_bw] = perf_read_write(buf_size, num_io, cluster, tensix_core);
+        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, num_io, cluster, chip, tensix_core);
         row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
         row.push_back(test::utils::convert_double_to_string(wr_bw));
         row.push_back(test::utils::convert_double_to_string(rd_bw));
@@ -188,7 +150,7 @@ TEST(MicrobenchmarkTLB, TLBStaticDram) {
         std::vector<std::string> row;
         const uint32_t num_io = buf_size / (16 * one_mb);
 
-        auto [wr_bw, rd_bw] = perf_read_write(buf_size, num_io, cluster, dram_core);
+        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, num_io, cluster, chip, dram_core);
         row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
         row.push_back(test::utils::convert_double_to_string(wr_bw));
         row.push_back(test::utils::convert_double_to_string(rd_bw));

--- a/tests/microbenchmark/common/microbenchmark_utils.cpp
+++ b/tests/microbenchmark/common/microbenchmark_utils.cpp
@@ -11,7 +11,7 @@ namespace tt::umd::test::utils {
 std::pair<double, double> perf_read_write(
     const uint32_t buf_size,
     const uint32_t num_iterations,
-    const std::unique_ptr<Cluster>& cluster,
+    Cluster* cluster,
     const chip_id_t chip,
     const CoreCoord core) {
     std::vector<uint8_t> pattern(buf_size);

--- a/tests/microbenchmark/common/microbenchmark_utils.cpp
+++ b/tests/microbenchmark/common/microbenchmark_utils.cpp
@@ -13,13 +13,14 @@ std::pair<double, double> perf_read_write(
     const uint32_t num_iterations,
     Cluster* cluster,
     const chip_id_t chip,
-    const CoreCoord core) {
+    const CoreCoord core,
+    const uint32_t address) {
     std::vector<uint8_t> pattern(buf_size);
     test_utils::fill_with_random_bytes(&pattern[0], pattern.size());
 
     auto now = std::chrono::steady_clock::now();
     for (int i = 0; i < num_iterations; i++) {
-        cluster->write_to_device(pattern.data(), pattern.size(), chip, core, 0x0);
+        cluster->write_to_device(pattern.data(), pattern.size(), chip, core, address);
     }
     auto end = std::chrono::steady_clock::now();
     auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();
@@ -28,7 +29,7 @@ std::pair<double, double> perf_read_write(
     std::vector<uint8_t> readback(buf_size, 0x0);
     now = std::chrono::steady_clock::now();
     for (int i = 0; i < num_iterations; i++) {
-        cluster->read_from_device(readback.data(), chip, core, 0x0, readback.size());
+        cluster->read_from_device(readback.data(), chip, core, address, readback.size());
     }
     end = std::chrono::steady_clock::now();
     ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count();

--- a/tests/microbenchmark/common/microbenchmark_utils.h
+++ b/tests/microbenchmark/common/microbenchmark_utils.h
@@ -11,7 +11,26 @@
 #include <string>
 #include <vector>
 
+#include "umd/device/cluster.h"
+
 namespace tt::umd::test::utils {
+
+/**
+ * Return performance of read and write operations to specific chip and core in MBs/s.
+ *
+ * @param buf_size Size of the buffer in bytes.
+ * @param num_iterations Number of iterations to perform for read and write operations.
+ * @param cluster The cluster to perform the operations on.
+ * @param chip The logical chip ID to perform the operations on.
+ * @param core The core coordinates to perform the operations on.
+ * @return A pair containing the write bandwidth and read bandwidth in MB/s.
+ */
+std::pair<double, double> perf_read_write(
+    const uint32_t buf_size,
+    const uint32_t num_iterations,
+    const std::unique_ptr<Cluster>& cluster,
+    const chip_id_t chip,
+    const CoreCoord core);
 
 /**
  * Prints a table in Markdown format. Headers are printed as the first row, followed by a separator row,

--- a/tests/microbenchmark/common/microbenchmark_utils.h
+++ b/tests/microbenchmark/common/microbenchmark_utils.h
@@ -30,7 +30,8 @@ std::pair<double, double> perf_read_write(
     const uint32_t num_iterations,
     Cluster* cluster,
     const chip_id_t chip,
-    const CoreCoord core);
+    const CoreCoord core,
+    const uint32_t address = 0);
 
 /**
  * Prints a table in Markdown format. Headers are printed as the first row, followed by a separator row,

--- a/tests/microbenchmark/common/microbenchmark_utils.h
+++ b/tests/microbenchmark/common/microbenchmark_utils.h
@@ -28,7 +28,7 @@ namespace tt::umd::test::utils {
 std::pair<double, double> perf_read_write(
     const uint32_t buf_size,
     const uint32_t num_iterations,
-    const std::unique_ptr<Cluster>& cluster,
+    Cluster* cluster,
     const chip_id_t chip,
     const CoreCoord core);
 


### PR DESCRIPTION
### Issue

#789 

### Description

Add microbenchmark for IO to devices connected over Ethernet.

### List of the changes

- Add test for IO to Tensix of Eth connected device
- Add test for IO to DRAM of eth connected device
- Cleanup includes in microbenchmarks

### Testing
Manual testing

### API Changes
/