### PR TITLE
Add microbenchmark for opening Cluster

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -77,3 +77,8 @@ jobs:
         if: ${{ inputs.arch != 'baremetal' }}
         run: |
           ${{ env.TEST_OUTPUT_DIR }}/umd/ubenchmarks/ubench --gtest_filter=MicrobenchmarkIOMMU*
+
+      - name: Run Cluster open benchmarks
+        if: ${{ inputs.arch != 'baremetal' }}
+        run: |
+          ${{ env.TEST_OUTPUT_DIR }}/umd/ubenchmarks/ubench --gtest_filter=MicrobenchmarkOpenCluster*

--- a/tests/microbenchmark/CMakeLists.txt
+++ b/tests/microbenchmark/CMakeLists.txt
@@ -2,6 +2,7 @@ set(UBENCH_SRC
     benchmarks/tlb/test_tlb.cpp
     benchmarks/pcie_dma/test_pcie_dma.cpp
     benchmarks/iommu/test_iommu.cpp
+    benchmarks/open_cluster/test_open_cluster.cpp
     common/microbenchmark_utils.cpp
 )
 add_executable(ubench ${UBENCH_SRC})

--- a/tests/microbenchmark/benchmarks/open_cluster/README.md
+++ b/tests/microbenchmark/benchmarks/open_cluster/README.md
@@ -1,0 +1,3 @@
+# Cluster open benchmark
+
+This benchmark contains tests that are measuring performance of opening/constructing Cluster object. Since work done in the cluster objects is non-trivial, it is important to measure how long it takes to open the cluster and how long it takes to construct the Cluster object. This should run on all our configurations.

--- a/tests/microbenchmark/benchmarks/open_cluster/test_open_cluster.cpp
+++ b/tests/microbenchmark/benchmarks/open_cluster/test_open_cluster.cpp
@@ -12,7 +12,7 @@
 using namespace tt::umd;
 
 /**
- * Measure the time it takes to open/construct a Cluster object.
+ * Measure the time it takes to open/construct a Cluster object with default ClusterOptions.
  */
 TEST(MicrobenchmarkOpenCluster, ClusterConstructor) {
     const std::vector<std::string> headers = {"Opening cluster of devices (ms)"};

--- a/tests/microbenchmark/benchmarks/open_cluster/test_open_cluster.cpp
+++ b/tests/microbenchmark/benchmarks/open_cluster/test_open_cluster.cpp
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <sys/mman.h>
+
+#include "common/microbenchmark_utils.h"
+#include "gtest/gtest.h"
+#include "umd/device/cluster.h"
+
+using namespace tt::umd;
+
+/**
+ * Measure the time it takes to open/construct a Cluster object.
+ */
+TEST(MicrobenchmarkOpenCluster, ClusterConstructor) {
+    const std::vector<std::string> headers = {"Opening cluster of devices (ms)"};
+
+    auto now = std::chrono::steady_clock::now();
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    auto end = std::chrono::steady_clock::now();
+
+    std::vector<std::vector<std::string>> rows;
+    std::vector<std::string> row;
+    row.push_back(test::utils::convert_double_to_string(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(end - now).count() / (double)1e6));
+    rows.push_back(row);
+
+    test::utils::print_markdown_table_format(headers, rows);
+}


### PR DESCRIPTION
### Issue

#953 

### Description

Add microbenchmark for opening the cluster. The goal of the benchmark is to be able to report performance of just opening UMD via main Cluster object.

### List of the changes

- Add microbenchmark tests for opening Cluster of devices

### Testing
Manual

### API Changes
/
