### PR TITLE
Move remote transfer cores to RemoteCommunication

### DIFF
--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -86,7 +86,7 @@ public:
         uint32_t* return_4 = nullptr);
 
     virtual void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) = 0;
-    virtual void set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channel) = 0;
+    virtual void set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) = 0;
 
     // TODO: To be moved to private implementation once methods are moved to chip
     void enable_ethernet_queue(int timeout_s);

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -34,11 +34,6 @@ public:
 
     void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) override;
     void set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) override;
-    // TODO: Figure out if this should remain public or used another way.
-    CoreCoord get_remote_transfer_ethernet_core();
-    void update_active_eth_core_idx();
-    int get_active_eth_core_idx();
-    std::vector<CoreCoord> get_remote_transfer_ethernet_cores();
 
     int get_num_host_channels() override;
     int get_host_channel_size(std::uint32_t channel) override;
@@ -81,8 +76,6 @@ private:
     // Used only for ethernet broadcast to all remote chips.
     std::unique_ptr<RemoteCommunication> remote_communication_;
 
-    std::vector<CoreCoord> remote_transfer_eth_cores_;
-    int active_eth_core_idx = 0;
     bool flush_non_mmio_ = false;
 
     void initialize_local_chip();

--- a/device/api/umd/device/chip/mock_chip.h
+++ b/device/api/umd/device/chip/mock_chip.h
@@ -55,6 +55,6 @@ public:
     int get_numa_node() override;
 
     void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) override;
-    void set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channel) override;
+    void set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) override;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -16,9 +16,15 @@ class LocalChip;
 class RemoteChip : public Chip {
 public:
     static std::unique_ptr<RemoteChip> create(
-        LocalChip* local_chip, eth_coord_t target_eth_coord, std::string sdesc_path = "");
+        LocalChip* local_chip,
+        eth_coord_t target_eth_coord,
+        std::unordered_set<CoreCoord>& remote_transfer_eth_cores,
+        std::string sdesc_path = "");
     static std::unique_ptr<RemoteChip> create(
-        LocalChip* local_chip, eth_coord_t target_eth_coord, tt_SocDescriptor soc_descriptor);
+        LocalChip* local_chip,
+        eth_coord_t target_eth_coord,
+        std::unordered_set<CoreCoord>& remote_transfer_eth_cores,
+        tt_SocDescriptor soc_descriptor);
 
     bool is_mmio_capable() const override;
 

--- a/device/api/umd/device/remote_communication.h
+++ b/device/api/umd/device/remote_communication.h
@@ -5,6 +5,9 @@
  */
 #pragma once
 
+#include <set>
+#include <unordered_set>
+
 #include "umd/device/tt_device/tt_device.h"
 
 namespace tt::umd {
@@ -31,7 +34,17 @@ public:
 
     void wait_for_non_mmio_flush();
 
+    // Set the ethernet cores which can be used for remote communication on the assigned local chip.
+    void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores);
+    void set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels);
+
 private:
+    CoreCoord get_remote_transfer_ethernet_core();
+    void update_active_eth_core_idx();
+
+    std::vector<CoreCoord> remote_transfer_eth_cores_;
+    int active_eth_core_idx = 0;
+
     LocalChip* local_chip_;
 };
 

--- a/device/api/umd/device/topology_discovery.h
+++ b/device/api/umd/device/topology_discovery.h
@@ -107,7 +107,8 @@ private:
     // TODO: override this logic for different configs. This is in group of functions
     // that we should override for T3K/6U/BH...
     // eth_core should be in NoC 0 coordinates.
-    std::unique_ptr<RemoteChip> create_remote_chip(Chip* chip, tt_xy_pair eth_core, Chip* gateway_chip);
+    std::unique_ptr<RemoteChip> create_remote_chip(
+        Chip* chip, tt_xy_pair eth_core, Chip* gateway_chip, std::set<uint32_t>& eth_channels_to_use);
 
     Chip* get_chip(const uint64_t asic_id);
 

--- a/device/api/umd/device/tt_device/remote_wormhole_tt_device.h
+++ b/device/api/umd/device/tt_device/remote_wormhole_tt_device.h
@@ -12,7 +12,8 @@ namespace tt::umd {
 
 class RemoteWormholeTTDevice : public WormholeTTDevice {
 public:
-    RemoteWormholeTTDevice(LocalChip* local_chip, eth_coord_t target_chip);
+    RemoteWormholeTTDevice(
+        LocalChip* local_chip, std::unique_ptr<RemoteCommunication> remote_communication, eth_coord_t target_chip);
 
     void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
 

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -379,11 +379,13 @@ void LocalChip::set_flush_non_mmio(bool flush_non_mmio) { flush_non_mmio_ = flus
 bool LocalChip::get_flush_non_mmio() const { return flush_non_mmio_; }
 
 void LocalChip::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& active_eth_cores) {
-    // Local chips don't use remote communication, so this is a noop.
+    // Set cores to be used by the broadcast communication.
+    remote_communication_->set_remote_transfer_ethernet_cores(active_eth_cores);
 }
 
 void LocalChip::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) {
-    // Local chips don't use remote communication, so this is a noop.
+    // Set cores to be used by the broadcast communication.
+    remote_communication_->set_remote_transfer_ethernet_cores(channels);
 }
 
 std::unique_lock<RobustMutex> LocalChip::acquire_mutex(std::string mutex_name, int pci_device_id) {

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -79,5 +79,5 @@ int MockChip::get_numa_node() { return 0; }
 
 void MockChip::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) {}
 
-void MockChip::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channel) {}
+void MockChip::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) {}
 }  // namespace tt::umd

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -17,8 +17,14 @@ namespace tt::umd {
 static_assert(!std::is_abstract<RemoteChip>(), "RemoteChip must be non-abstract.");
 
 std::unique_ptr<RemoteChip> RemoteChip::create(
-    LocalChip* local_chip, eth_coord_t target_eth_coord, std::string sdesc_path) {
-    auto remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(local_chip, target_eth_coord);
+    LocalChip* local_chip,
+    eth_coord_t target_eth_coord,
+    std::unordered_set<CoreCoord>& remote_transfer_eth_cores,
+    std::string sdesc_path) {
+    auto remote_communication = std::make_unique<RemoteCommunication>(local_chip);
+    remote_communication->set_remote_transfer_ethernet_cores(remote_transfer_eth_cores);
+    auto remote_tt_device =
+        std::make_unique<RemoteWormholeTTDevice>(local_chip, std::move(remote_communication), target_eth_coord);
     remote_tt_device->wait_arc_core_start();
 
     tt_SocDescriptor soc_descriptor;
@@ -41,8 +47,14 @@ std::unique_ptr<RemoteChip> RemoteChip::create(
 }
 
 std::unique_ptr<RemoteChip> RemoteChip::create(
-    LocalChip* local_chip, eth_coord_t target_eth_coord, tt_SocDescriptor soc_descriptor) {
-    auto remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(local_chip, target_eth_coord);
+    LocalChip* local_chip,
+    eth_coord_t target_eth_coord,
+    std::unordered_set<CoreCoord>& remote_transfer_eth_cores,
+    tt_SocDescriptor soc_descriptor) {
+    auto remote_communication = std::make_unique<RemoteCommunication>(local_chip);
+    remote_communication->set_remote_transfer_ethernet_cores(remote_transfer_eth_cores);
+    auto remote_tt_device =
+        std::make_unique<RemoteWormholeTTDevice>(local_chip, std::move(remote_communication), target_eth_coord);
     remote_tt_device->wait_arc_core_start();
 
     return std::unique_ptr<tt::umd::RemoteChip>(
@@ -150,7 +162,7 @@ void RemoteChip::set_remote_transfer_ethernet_cores(const std::unordered_set<Cor
 }
 
 void RemoteChip::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) {
-    remote_communication_->set_remote_transfer_ethernet_cores(channel);
+    remote_communication_->set_remote_transfer_ethernet_cores(channels);
 }
 
 TTDevice* RemoteChip::get_tt_device() { return tt_device_.get(); }

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -113,9 +113,13 @@ int RemoteChip::get_numa_node() {
     throw std::runtime_error("RemoteChip::get_numa_node is not available for this chip.");
 }
 
-void RemoteChip::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) {}
+void RemoteChip::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) {
+    remote_communication_->set_remote_transfer_ethernet_cores(cores);
+}
 
-void RemoteChip::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channel) {}
+void RemoteChip::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channel) {
+    remote_communication_->set_remote_transfer_ethernet_cores(channel);
+}
 
 TTDevice* RemoteChip::get_tt_device() { return tt_device_.get(); }
 

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -117,7 +117,7 @@ void RemoteChip::set_remote_transfer_ethernet_cores(const std::unordered_set<Cor
     remote_communication_->set_remote_transfer_ethernet_cores(cores);
 }
 
-void RemoteChip::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channel) {
+void RemoteChip::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) {
     remote_communication_->set_remote_transfer_ethernet_cores(channel);
 }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -248,9 +248,12 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
         if (cluster_desc->get_arch(chip_id) != tt::ARCH::WORMHOLE_B0) {
             throw std::runtime_error("Remote chips are supported only for wormhole.");
         }
+        chip_id_t gateway_id = cluster_desc->get_closest_mmio_capable_chip(chip_id);
+        LocalChip* local_chip = get_local_chip(gateway_id);
+        std::unique_ptr<RemoteCommunication> remote_communication = std::make_unique<RemoteCommunication>(local_chip);
+        remote_communication->set_remote_transfer_ethernet_cores(cluster_desc->get_active_eth_channels(gateway_id));
         std::unique_ptr<RemoteWormholeTTDevice> remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(
-            get_local_chip(cluster_desc->get_closest_mmio_capable_chip(chip_id)),
-            cluster_desc->get_chip_locations().at(chip_id));
+            local_chip, std::move(remote_communication), cluster_desc->get_chip_locations().at(chip_id));
         return std::make_unique<RemoteChip>(soc_desc, std::move(remote_tt_device));
     }
 }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -449,9 +449,7 @@ void Cluster::configure_active_ethernet_cores_for_mmio_device(
         }
     }
     // Local chips hold communication primitives for broadcasting, so we have to set this up for them as well.
-    for (const auto& local_chip_id : local_chip_ids_) {
-        get_local_chip(local_chip_id)->set_remote_transfer_ethernet_cores(active_eth_cores_per_chip);
-    }
+    get_local_chip(mmio_chip)->set_remote_transfer_ethernet_cores(active_eth_cores_per_chip);
 }
 
 std::set<chip_id_t> Cluster::get_target_device_ids() { return all_chip_ids_; }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -437,7 +437,14 @@ Cluster::Cluster(ClusterOptions options) {
 
 void Cluster::configure_active_ethernet_cores_for_mmio_device(
     chip_id_t mmio_chip, const std::unordered_set<CoreCoord>& active_eth_cores_per_chip) {
-    chips_.at(mmio_chip)->set_remote_transfer_ethernet_cores(active_eth_cores_per_chip);
+    // The ethernet cores that should be used for remote transfer are set in the RemoteCommunication structure.
+    // This structure is used by remote chips. So we need to find all remote chips that use the passed in mmio_chip,
+    // and set the active ethernet cores for them.
+    for (const auto& remote_chip_id : remote_chip_ids_) {
+        if (cluster_desc->get_closest_mmio_capable_chip(remote_chip_id) == mmio_chip) {
+            get_remote_chip(remote_chip_id)->set_remote_transfer_ethernet_cores(active_eth_cores_per_chip);
+        }
+    }
 }
 
 std::set<chip_id_t> Cluster::get_target_device_ids() { return all_chip_ids_; }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -249,7 +249,13 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
         }
         chip_id_t gateway_id = cluster_desc->get_closest_mmio_capable_chip(chip_id);
         LocalChip* local_chip = get_local_chip(gateway_id);
-        return RemoteChip::create(local_chip, cluster_desc->get_chip_locations().at(chip_id), soc_desc);
+        std::unordered_set<CoreCoord> eth_cores_to_use;
+        for (auto channel : cluster_desc->get_active_eth_channels(gateway_id)) {
+            eth_cores_to_use.insert(
+                local_chip->get_soc_descriptor().get_eth_core_for_channel(channel, CoordSystem::TRANSLATED));
+        }
+        return RemoteChip::create(
+            local_chip, cluster_desc->get_chip_locations().at(chip_id), eth_cores_to_use, soc_desc);
     }
 }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -445,6 +445,10 @@ void Cluster::configure_active_ethernet_cores_for_mmio_device(
             get_remote_chip(remote_chip_id)->set_remote_transfer_ethernet_cores(active_eth_cores_per_chip);
         }
     }
+    // Local chips hold communication primitives for broadcasting, so we have to set this up for them as well.
+    for (const auto& local_chip_id : local_chip_ids_) {
+        get_local_chip(local_chip_id)->set_remote_transfer_ethernet_cores(active_eth_cores_per_chip);
+    }
 }
 
 std::set<chip_id_t> Cluster::get_target_device_ids() { return all_chip_ids_; }

--- a/device/simulation/tt_simulation_device.cpp
+++ b/device/simulation/tt_simulation_device.cpp
@@ -148,7 +148,7 @@ void tt_SimulationDevice::close_device() {
 
 void tt_SimulationDevice::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) {}
 
-void tt_SimulationDevice::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channel) {}
+void tt_SimulationDevice::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) {}
 
 // Runtime Functions
 void tt_SimulationDevice::write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) {

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -89,8 +89,13 @@ std::unique_ptr<RemoteChip> TopologyDiscovery::create_remote_chip(
 
     auto local_chip = dynamic_cast<LocalChip*>(gateway_chip);
     auto eth_coord = get_remote_eth_coord(chip, eth_core);
+    std::unordered_set<CoreCoord> eth_cores_to_use;
+    for (auto channel : eth_channels_to_use) {
+        eth_cores_to_use.insert(
+            local_chip->get_soc_descriptor().get_eth_core_for_channel(channel, CoordSystem::TRANSLATED));
+    }
 
-    return RemoteChip::create(local_chip, eth_coord, sdesc_path);
+    return RemoteChip::create(local_chip, eth_coord, eth_cores_to_use, sdesc_path);
 }
 
 std::optional<eth_coord_t> TopologyDiscovery::get_local_eth_coord(Chip* chip) {

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -275,13 +275,13 @@ void TopologyDiscovery::discover_remote_chips() {
                 continue;
             }
 
-            chip->set_remote_transfer_ethernet_cores(active_eth_channels_per_chip.at(current_chip_asic_id));
-
             uint64_t remote_asic_id = get_remote_asic_id(chip, eth_core);
 
             if (discovered_chips.find(remote_asic_id) == discovered_chips.end()) {
                 std::unique_ptr<Chip> remote_chip = create_remote_chip(
                     chip, eth_core, get_chip(remote_asic_id_to_mmio_chip_id.at(current_chip_asic_id)));
+
+                remote_chip->set_remote_transfer_ethernet_cores(active_eth_channels_per_chip.at(current_chip_asic_id));
 
                 chips_to_discover.emplace(remote_asic_id, std::move(remote_chip));
                 active_eth_channels_per_chip.emplace(remote_asic_id, std::set<uint32_t>());
@@ -306,7 +306,6 @@ void TopologyDiscovery::discover_remote_chips() {
                 ethernet_connections.push_back({{current_chip_asic_id, channel}, {remote_asic_id, remote_eth_channel}});
             }
         }
-        chip->set_remote_transfer_ethernet_cores(active_eth_channels_per_chip.at(current_chip_asic_id));
     }
 }
 

--- a/device/tt_device/remote_wormhole_tt_device.cpp
+++ b/device/tt_device/remote_wormhole_tt_device.cpp
@@ -7,11 +7,12 @@
 
 namespace tt::umd {
 
-RemoteWormholeTTDevice::RemoteWormholeTTDevice(LocalChip *local_chip, eth_coord_t target_chip) :
+RemoteWormholeTTDevice::RemoteWormholeTTDevice(
+    LocalChip *local_chip, std::unique_ptr<RemoteCommunication> remote_communication, eth_coord_t target_chip) :
     WormholeTTDevice(local_chip->get_tt_device()->get_pci_device()),
     local_chip_(local_chip),
     target_chip_(target_chip),
-    remote_communication_(std::make_unique<RemoteCommunication>(local_chip_)) {
+    remote_communication_(std::move(remote_communication)) {
     is_remote_tt_device = true;
     init_tt_device();
 }

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -126,11 +126,13 @@ TEST(ApiTTDeviceTest, TestRemoteTTDevice) {
     for (chip_id_t remote_chip_id : cluster->get_target_remote_device_ids()) {
         eth_coord_t remote_eth_coord = chip_locations.at(remote_chip_id);
 
-        LocalChip* closest_local_chip =
-            cluster->get_local_chip(cluster_desc->get_closest_mmio_capable_chip(remote_chip_id));
-
-        std::unique_ptr<RemoteWormholeTTDevice> remote_tt_device =
-            std::make_unique<RemoteWormholeTTDevice>(closest_local_chip, remote_eth_coord);
+        chip_id_t gateway_id = cluster_desc->get_closest_mmio_capable_chip(remote_chip_id);
+        LocalChip* closest_local_chip = cluster->get_local_chip(gateway_id);
+        std::unique_ptr<RemoteCommunication> remote_communication =
+            std::make_unique<RemoteCommunication>(closest_local_chip);
+        remote_communication->set_remote_transfer_ethernet_cores(cluster_desc->get_active_eth_channels(gateway_id));
+        std::unique_ptr<RemoteWormholeTTDevice> remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(
+            closest_local_chip, std::move(remote_communication), remote_eth_coord);
 
         std::vector<CoreCoord> tensix_cores =
             cluster->get_chip(remote_chip_id)->get_soc_descriptor().get_cores(CoreType::TENSIX);

--- a/tests/wormhole/test_remote_communication_wh.cpp
+++ b/tests/wormhole/test_remote_communication_wh.cpp
@@ -26,6 +26,9 @@ TEST(RemoteCommunicationWormhole, BasicRemoteCommunicationIO) {
     std::unique_ptr<RemoteCommunication> remote_comm =
         std::make_unique<RemoteCommunication>(cluster->get_local_chip(mmio_chip_id));
 
+    remote_comm->set_remote_transfer_ethernet_cores(
+        cluster->get_cluster_description()->get_active_eth_channels(mmio_chip_id));
+
     tt_ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
 
     std::vector<uint32_t> data_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};


### PR DESCRIPTION
### Issue
Related to https://github.com/tenstorrent/tt-umd/issues/995

### Description
Eth cores to use for remote communication are ideologically part of RemoteCommunication class, not LocalChip.
This is on a path for removing dependancy from RemoteWormholeTTDevice to LocalChip.

### List of the changes
- Move remote eth cores related functions to RemoteCommunication
- Now RemoteChip has to implement set_remote_ethernet_cores since it has to update its RemoteCommunication class object
- LocalChip also still has to do this, since LocalChip holds RemoteCommunication object for broadcast purposes.
- Callsites have to be changed, since now this has to be called for remoteChip (or remote communication) and not localchip
- RemoteWormholeTTDevice has to accept RemoteCommunication object, it can't construct it on it's own. The RemoteCommunication has to have its remote transfer eth cores already set before it is passed to the TTDevice since the constructor uses RemoteCommunication (Note: this might be changed with some of Nenad's changes in https://github.com/tenstorrent/tt-umd/issues/1162, but we can change this later again, not a problem).

### Testing
CI tests

### API Changes
This PR has API changes but they aren't directly used by tt-metal. It does affect how tt-smi will use these.
