### PR TITLE
Move sysmemmanager as optional to RemoteCommunication

### DIFF
--- a/device/api/umd/device/remote_communication.h
+++ b/device/api/umd/device/remote_communication.h
@@ -13,10 +13,11 @@
 namespace tt::umd {
 
 class LocalChip;
+class SysmemManager;
 
 class RemoteCommunication {
 public:
-    RemoteCommunication(LocalChip* local_chip);
+    RemoteCommunication(LocalChip* local_chip, SysmemManager* sysmem_manager = nullptr);
     virtual ~RemoteCommunication();
 
     // Target core should be in translated coords.
@@ -48,6 +49,7 @@ private:
 
     LocalChip* local_chip_;
     LockManager lock_manager_;
+    SysmemManager* sysmem_manager_;
 };
 
 }  // namespace tt::umd

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -64,7 +64,7 @@ LocalChip::LocalChip(tt_SocDescriptor soc_descriptor, std::unique_ptr<TTDevice> 
     Chip(tt_device->get_chip_info(), soc_descriptor), tt_device_(std::move(tt_device)) {
     tlb_manager_ = std::make_unique<TLBManager>(tt_device_.get());
     sysmem_manager_ = std::make_unique<SysmemManager>(tlb_manager_.get(), num_host_mem_channels);
-    remote_communication_ = std::make_unique<RemoteCommunication>(this);
+    remote_communication_ = std::make_unique<RemoteCommunication>(this, sysmem_manager_.get());
     initialize_tlb_manager();
     wait_chip_to_be_ready();
     initialize_default_chip_mutexes();

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -51,7 +51,7 @@ std::unique_ptr<RemoteChip> RemoteChip::create(
     eth_coord_t target_eth_coord,
     std::unordered_set<CoreCoord>& remote_transfer_eth_cores,
     tt_SocDescriptor soc_descriptor) {
-    auto remote_communication = std::make_unique<RemoteCommunication>(local_chip);
+    auto remote_communication = std::make_unique<RemoteCommunication>(local_chip, local_chip->get_sysmem_manager());
     remote_communication->set_remote_transfer_ethernet_cores(remote_transfer_eth_cores);
     auto remote_tt_device =
         std::make_unique<RemoteWormholeTTDevice>(local_chip, std::move(remote_communication), target_eth_coord);

--- a/device/remote_communication.cpp
+++ b/device/remote_communication.cpp
@@ -38,7 +38,8 @@ struct routing_cmd_t {
     uint32_t src_addr_tag;  // upper 32-bits of request source address.
 };
 
-RemoteCommunication::RemoteCommunication(LocalChip* local_chip) : local_chip_(local_chip) {
+RemoteCommunication::RemoteCommunication(LocalChip* local_chip, SysmemManager* sysmem_manager) :
+    local_chip_(local_chip), sysmem_manager_(sysmem_manager) {
     lock_manager_.initialize_mutex(
         MutexType::NON_MMIO, local_chip_->get_tt_device()->get_pci_device()->get_device_num());
 }
@@ -154,6 +155,7 @@ void RemoteCommunication::read_non_mmio(
     uint32_t max_block_size;
 
     use_dram = size_in_bytes > 1024;
+    TT_ASSERT(!(use_dram && sysmem_manager_ == nullptr), "Large transfers not available without system memory.");
     max_block_size = use_dram ? host_address_params.eth_routing_block_size : eth_interface_params.max_block_size;
 
     uint32_t offset = 0;
@@ -290,7 +292,7 @@ void RemoteCommunication::read_non_mmio(
                 // Read 4 byte aligned block from device/sysmem
                 if (use_dram) {
                     size_buffer_to_capacity(data_block, block_size);
-                    local_chip_->read_from_sysmem(
+                    sysmem_manager_->read_from_sysmem(
                         host_dram_channel, data_block.data(), host_dram_block_addr, block_size);
                 } else {
                     uint32_t buf_address =
@@ -365,6 +367,9 @@ void RemoteCommunication::write_to_non_mmio(
 
     // Broadcast requires block writes to host dram
     use_dram = broadcast || (size_in_bytes > 256 * DATA_WORD_SIZE);
+    TT_ASSERT(
+        !(use_dram && sysmem_manager_ == nullptr),
+        "Large transfers and broadcasts not available without system memory.");
     max_block_size = use_dram ? host_address_params.eth_routing_block_size : eth_interface_params.max_block_size;
 
     //
@@ -448,14 +453,14 @@ void RemoteCommunication::write_to_non_mmio(
                 memcpy(&data_block[0], (uint8_t*)src + offset, transfer_size);
                 if (broadcast) {
                     // Write broadcast header to sysmem
-                    local_chip_->write_to_sysmem(
+                    sysmem_manager_->write_to_sysmem(
                         host_dram_channel,
                         broadcast_header.data(),
                         host_dram_block_addr,
                         broadcast_header.size() * sizeof(uint32_t));
                 }
                 // Write payload to sysmem
-                local_chip_->write_to_sysmem(
+                sysmem_manager_->write_to_sysmem(
                     host_dram_channel,
                     data_block.data(),
                     host_dram_block_addr + BROADCAST_HEADER_SIZE * broadcast,

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -129,7 +129,7 @@ TEST(ApiTTDeviceTest, TestRemoteTTDevice) {
         chip_id_t gateway_id = cluster_desc->get_closest_mmio_capable_chip(remote_chip_id);
         LocalChip* closest_local_chip = cluster->get_local_chip(gateway_id);
         std::unique_ptr<RemoteCommunication> remote_communication =
-            std::make_unique<RemoteCommunication>(closest_local_chip);
+            std::make_unique<RemoteCommunication>(closest_local_chip, closest_local_chip->get_sysmem_manager());
         remote_communication->set_remote_transfer_ethernet_cores(cluster_desc->get_active_eth_channels(gateway_id));
         std::unique_ptr<RemoteWormholeTTDevice> remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(
             closest_local_chip, std::move(remote_communication), remote_eth_coord);

--- a/tests/wormhole/test_remote_communication_wh.cpp
+++ b/tests/wormhole/test_remote_communication_wh.cpp
@@ -23,8 +23,8 @@ TEST(RemoteCommunicationWormhole, BasicRemoteCommunicationIO) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
     chip_id_t mmio_chip_id = *cluster->get_target_mmio_device_ids().begin();
-    std::unique_ptr<RemoteCommunication> remote_comm =
-        std::make_unique<RemoteCommunication>(cluster->get_local_chip(mmio_chip_id));
+    std::unique_ptr<RemoteCommunication> remote_comm = std::make_unique<RemoteCommunication>(
+        cluster->get_local_chip(mmio_chip_id), cluster->get_local_chip(mmio_chip_id)->get_sysmem_manager());
 
     remote_comm->set_remote_transfer_ethernet_cores(
         cluster->get_cluster_description()->get_active_eth_channels(mmio_chip_id));


### PR DESCRIPTION
### Issue
On a path of https://github.com/tenstorrent/tt-umd/issues/995

### Description
Set sysmem manager as optional, so large remote transfers might not always be initialized.

### List of the changes
- Don't use local_chip for writing to host memory, but sysmem manager explicitly in RemoteCommunication
- Pass sysmemmanager where needed to RemoteCommunication

### Testing
Existing CI tests

### API Changes
There are no API changes in this PR.
