### PR TITLE
Add TLB microbenchmark for ETH core

### DIFF
--- a/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
+++ b/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
@@ -11,7 +11,7 @@ using namespace tt::umd;
 constexpr chip_id_t chip = 0;
 constexpr uint32_t one_mb = 1 << 20;
 constexpr uint32_t NUM_ITERATIONS = 1;
-constexpr uint32_t one_kb = 1 << 20;
+constexpr uint32_t one_kb = 1 << 10;
 constexpr uint32_t tlb_1m_index = 0;
 constexpr uint32_t tlb_16m_index = 166;
 
@@ -89,8 +89,6 @@ TEST(MicrobenchmarkTLB, TLBDynamicTensix) {
  * Measure BW of IO to Tensix core using statically configured TLB.
  */
 TEST(MicrobenchmarkTLB, TLBStaticTensix) {
-    const size_t tlb_1m_index = 0;
-
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord tensix_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)[0];
     cluster->start_device(tt_device_params{});
@@ -196,8 +194,6 @@ TEST(MicrobenchmarkTLB, TLBDynamicEth) {
  * Measure BW of IO to Eth core using statically configured TLB.
  */
 TEST(MicrobenchmarkTLB, TLBStaticEth) {
-    const size_t tlb_1m_index = 0;
-
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord eth_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::ETH)[0];
     cluster->start_device(tt_device_params{});


### PR DESCRIPTION
### Issue 

Work towards #1096 

### Description

We should work towards making TLB tests complete, both in terms of sizes we are targeting, as well as core types we are targeting. This PR addresses ETH core type to complete Tensix, DRAM and ETH core types. Apart from small ARC writes these core types are the only ones targeted throug UMD.

### List of the changes

- Make num iterations for TLB tests to be 1. This doesn't impact TLB perf tests. Having it at 10 or bigger slows down the tests since TLB reads are painfully slow.
- Add test that targets ETH core through dynamic TLB
- Add test that targets ETH core through static TLB

### Testing
CI + manual testing

### API Changes
/
