### PR TITLE
Revise Chip constructors

### DIFF
--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -15,11 +15,13 @@ namespace tt::umd {
 
 class LocalChip : public Chip {
 public:
-    LocalChip(tt_SocDescriptor soc_descriptor, int pci_device_id, int num_host_mem_channels = 0);
-
-    LocalChip(std::string sdesc_path, std::unique_ptr<TTDevice> tt_device);
-
-    LocalChip(std::unique_ptr<TTDevice> tt_device);
+    // In some of the constructor implementations, we want to create TTDevice objects and then use them to obtain the
+    // necessary information needed for soc descriptor construction. Due to this inverse member initialization order, we
+    // cannot have simple constructors as they require the base class to be constructed first.
+    static std::unique_ptr<LocalChip> create(int pci_device_id, int num_host_mem_channels = 0);
+    static std::unique_ptr<LocalChip> create(int pci_device_id, std::string sdesc_path, int num_host_mem_channels = 0);
+    static std::unique_ptr<LocalChip> create(
+        int pci_device_id, tt_SocDescriptor soc_descriptor, int num_host_mem_channels = 0);
 
     ~LocalChip();
 
@@ -75,6 +77,8 @@ public:
     std::unique_lock<RobustMutex> acquire_mutex(MutexType mutex_type, int pci_device_id);
 
 private:
+    LocalChip(tt_SocDescriptor soc_descriptor, std::unique_ptr<TTDevice> tt_device, int num_host_mem_channels = 0);
+
     std::unique_ptr<TLBManager> tlb_manager_;
     std::unique_ptr<SysmemManager> sysmem_manager_;
     LockManager lock_manager_;
@@ -85,7 +89,6 @@ private:
     int active_eth_core_idx = 0;
     bool flush_non_mmio_ = false;
 
-    void initialize_local_chip();
     void initialize_tlb_manager();
     void initialize_default_chip_mutexes();
     void initialize_membars();

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -18,8 +18,8 @@ public:
     // In some of the constructor implementations, we want to create TTDevice objects and then use them to obtain the
     // necessary information needed for soc descriptor construction. Due to this inverse member initialization order, we
     // cannot have simple constructors as they require the base class to be constructed first.
-    static std::unique_ptr<LocalChip> create(int pci_device_id, int num_host_mem_channels = 0);
-    static std::unique_ptr<LocalChip> create(int pci_device_id, std::string sdesc_path, int num_host_mem_channels = 0);
+    static std::unique_ptr<LocalChip> create(
+        int pci_device_id, std::string sdesc_path = "", int num_host_mem_channels = 0);
     static std::unique_ptr<LocalChip> create(
         int pci_device_id, tt_SocDescriptor soc_descriptor, int num_host_mem_channels = 0);
 

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -15,9 +15,8 @@ class LocalChip;
 
 class RemoteChip : public Chip {
 public:
-    static std::unique_ptr<RemoteChip> create(LocalChip* local_chip, eth_coord_t target_eth_coord);
     static std::unique_ptr<RemoteChip> create(
-        LocalChip* local_chip, eth_coord_t target_eth_coord, std::string sdesc_path);
+        LocalChip* local_chip, eth_coord_t target_eth_coord, std::string sdesc_path = "");
     static std::unique_ptr<RemoteChip> create(
         LocalChip* local_chip, eth_coord_t target_eth_coord, tt_SocDescriptor soc_descriptor);
 

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -15,7 +15,11 @@ class LocalChip;
 
 class RemoteChip : public Chip {
 public:
-    RemoteChip(tt_SocDescriptor soc_descriptor, std::unique_ptr<RemoteWormholeTTDevice> remote_tt_device);
+    static std::unique_ptr<RemoteChip> create(LocalChip* local_chip, eth_coord_t target_eth_coord);
+    static std::unique_ptr<RemoteChip> create(
+        LocalChip* local_chip, eth_coord_t target_eth_coord, std::string sdesc_path);
+    static std::unique_ptr<RemoteChip> create(
+        LocalChip* local_chip, eth_coord_t target_eth_coord, tt_SocDescriptor soc_descriptor);
 
     bool is_mmio_capable() const override;
 
@@ -54,6 +58,11 @@ public:
     int get_numa_node() override;
 
 private:
+    RemoteChip(
+        tt_SocDescriptor soc_descriptor,
+        LocalChip* local_chip,
+        std::unique_ptr<RemoteWormholeTTDevice> remote_tt_device);
+
     LocalChip* local_chip_;
     RemoteCommunication* remote_communication_;
 

--- a/device/api/umd/device/tt_device/blackhole_tt_device.h
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.h
@@ -20,7 +20,7 @@ public:
 
     void configure_iatu_region(size_t region, uint64_t target, size_t region_size) override;
 
-    void wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms = 1000) override;
+    void wait_arc_core_start(const uint32_t timeout_ms = 1000) override;
 
     uint32_t get_clock() override;
 

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -199,7 +199,7 @@ public:
 
     virtual ChipInfo get_chip_info() = 0;
 
-    virtual void wait_arc_core_start(const uint32_t timeout_ms = 1000);
+    virtual void wait_arc_core_start(const uint32_t timeout_ms = 1000) = 0;
 
     virtual void wait_eth_core_training(const tt_xy_pair eth_core, const uint32_t timeout_ms = 60000) = 0;
 

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -199,7 +199,7 @@ public:
 
     virtual ChipInfo get_chip_info() = 0;
 
-    virtual void wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms = 1000);
+    virtual void wait_arc_core_start(const uint32_t timeout_ms = 1000);
 
     virtual void wait_eth_core_training(const tt_xy_pair eth_core, const uint32_t timeout_ms = 60000) = 0;
 

--- a/device/api/umd/device/tt_device/wormhole_tt_device.h
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.h
@@ -17,7 +17,7 @@ public:
 
     void configure_iatu_region(size_t region, uint64_t target, size_t region_size) override;
 
-    void wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms = 1000) override;
+    void wait_arc_core_start(const uint32_t timeout_ms = 1000) override;
 
     uint32_t get_clock() override;
 

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -27,11 +27,17 @@ std::unique_ptr<RemoteChip> RemoteChip::create(LocalChip* local_chip, eth_coord_
         remote_tt_device->get_chip_info().harvesting_masks,
         remote_tt_device->get_chip_info().board_type);
 
-    return std::make_unique<RemoteChip>(soc_descriptor, local_chip, std::move(remote_tt_device));
+    return std::unique_ptr<tt::umd::RemoteChip>(
+        new RemoteChip(soc_descriptor, local_chip, std::move(remote_tt_device)));
 }
 
 std::unique_ptr<RemoteChip> RemoteChip::create(
     LocalChip* local_chip, eth_coord_t target_eth_coord, std::string sdesc_path) {
+    // Just a convenience, if we're not sure if the sdesc_path is empty, we can just call this function which will call
+    // the other version if passed sdesc_path is empty.
+    if (sdesc_path.empty()) {
+        return create(local_chip, target_eth_coord);
+    }
     auto remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(local_chip, target_eth_coord);
 
     auto soc_descriptor = tt_SocDescriptor(
@@ -40,14 +46,16 @@ std::unique_ptr<RemoteChip> RemoteChip::create(
         remote_tt_device->get_chip_info().harvesting_masks,
         remote_tt_device->get_chip_info().board_type);
 
-    return std::make_unique<RemoteChip>(soc_descriptor, local_chip, std::move(remote_tt_device));
+    return std::unique_ptr<tt::umd::RemoteChip>(
+        new RemoteChip(soc_descriptor, local_chip, std::move(remote_tt_device)));
 }
 
 std::unique_ptr<RemoteChip> RemoteChip::create(
     LocalChip* local_chip, eth_coord_t target_eth_coord, tt_SocDescriptor soc_descriptor) {
     auto remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(local_chip, target_eth_coord);
 
-    return std::make_unique<RemoteChip>(soc_descriptor, local_chip, std::move(remote_tt_device));
+    return std::unique_ptr<tt::umd::RemoteChip>(
+        new RemoteChip(soc_descriptor, local_chip, std::move(remote_tt_device)));
 }
 
 RemoteChip::RemoteChip(

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -16,35 +16,25 @@ namespace tt::umd {
 
 static_assert(!std::is_abstract<RemoteChip>(), "RemoteChip must be non-abstract.");
 
-std::unique_ptr<RemoteChip> RemoteChip::create(LocalChip* local_chip, eth_coord_t target_eth_coord) {
-    auto remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(local_chip, target_eth_coord);
-    // TODO: Do we need wait arc core start here?
-    // remote_tt_device->wait_arc_core_start();
-
-    auto soc_descriptor = tt_SocDescriptor(
-        remote_tt_device->get_arch(),
-        remote_tt_device->get_chip_info().noc_translation_enabled,
-        remote_tt_device->get_chip_info().harvesting_masks,
-        remote_tt_device->get_chip_info().board_type);
-
-    return std::unique_ptr<tt::umd::RemoteChip>(
-        new RemoteChip(soc_descriptor, local_chip, std::move(remote_tt_device)));
-}
-
 std::unique_ptr<RemoteChip> RemoteChip::create(
     LocalChip* local_chip, eth_coord_t target_eth_coord, std::string sdesc_path) {
-    // Just a convenience, if we're not sure if the sdesc_path is empty, we can just call this function which will call
-    // the other version if passed sdesc_path is empty.
-    if (sdesc_path.empty()) {
-        return create(local_chip, target_eth_coord);
-    }
     auto remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(local_chip, target_eth_coord);
+    remote_tt_device->wait_arc_core_start();
 
-    auto soc_descriptor = tt_SocDescriptor(
-        sdesc_path,
-        remote_tt_device->get_chip_info().noc_translation_enabled,
-        remote_tt_device->get_chip_info().harvesting_masks,
-        remote_tt_device->get_chip_info().board_type);
+    tt_SocDescriptor soc_descriptor;
+    if (sdesc_path.empty()) {
+        soc_descriptor = tt_SocDescriptor(
+            remote_tt_device->get_arch(),
+            remote_tt_device->get_chip_info().noc_translation_enabled,
+            remote_tt_device->get_chip_info().harvesting_masks,
+            remote_tt_device->get_chip_info().board_type);
+    } else {
+        soc_descriptor = tt_SocDescriptor(
+            sdesc_path,
+            remote_tt_device->get_chip_info().noc_translation_enabled,
+            remote_tt_device->get_chip_info().harvesting_masks,
+            remote_tt_device->get_chip_info().board_type);
+    }
 
     return std::unique_ptr<tt::umd::RemoteChip>(
         new RemoteChip(soc_descriptor, local_chip, std::move(remote_tt_device)));
@@ -53,6 +43,7 @@ std::unique_ptr<RemoteChip> RemoteChip::create(
 std::unique_ptr<RemoteChip> RemoteChip::create(
     LocalChip* local_chip, eth_coord_t target_eth_coord, tt_SocDescriptor soc_descriptor) {
     auto remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(local_chip, target_eth_coord);
+    remote_tt_device->wait_arc_core_start();
 
     return std::unique_ptr<tt::umd::RemoteChip>(
         new RemoteChip(soc_descriptor, local_chip, std::move(remote_tt_device)));

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -16,12 +16,45 @@ namespace tt::umd {
 
 static_assert(!std::is_abstract<RemoteChip>(), "RemoteChip must be non-abstract.");
 
-RemoteChip::RemoteChip(tt_SocDescriptor soc_descriptor, std::unique_ptr<RemoteWormholeTTDevice> remote_tt_device) :
-    Chip(soc_descriptor) {
-    local_chip_ = remote_tt_device->get_local_chip();
+std::unique_ptr<RemoteChip> RemoteChip::create(LocalChip* local_chip, eth_coord_t target_eth_coord) {
+    auto remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(local_chip, target_eth_coord);
+    // TODO: Do we need wait arc core start here?
+    // remote_tt_device->wait_arc_core_start();
+
+    auto soc_descriptor = tt_SocDescriptor(
+        remote_tt_device->get_arch(),
+        remote_tt_device->get_chip_info().noc_translation_enabled,
+        remote_tt_device->get_chip_info().harvesting_masks,
+        remote_tt_device->get_chip_info().board_type);
+
+    return std::make_unique<RemoteChip>(soc_descriptor, local_chip, std::move(remote_tt_device));
+}
+
+std::unique_ptr<RemoteChip> RemoteChip::create(
+    LocalChip* local_chip, eth_coord_t target_eth_coord, std::string sdesc_path) {
+    auto remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(local_chip, target_eth_coord);
+
+    auto soc_descriptor = tt_SocDescriptor(
+        sdesc_path,
+        remote_tt_device->get_chip_info().noc_translation_enabled,
+        remote_tt_device->get_chip_info().harvesting_masks,
+        remote_tt_device->get_chip_info().board_type);
+
+    return std::make_unique<RemoteChip>(soc_descriptor, local_chip, std::move(remote_tt_device));
+}
+
+std::unique_ptr<RemoteChip> RemoteChip::create(
+    LocalChip* local_chip, eth_coord_t target_eth_coord, tt_SocDescriptor soc_descriptor) {
+    auto remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(local_chip, target_eth_coord);
+
+    return std::make_unique<RemoteChip>(soc_descriptor, local_chip, std::move(remote_tt_device));
+}
+
+RemoteChip::RemoteChip(
+    tt_SocDescriptor soc_descriptor, LocalChip* local_chip, std::unique_ptr<RemoteWormholeTTDevice> remote_tt_device) :
+    Chip(remote_tt_device->get_chip_info(), soc_descriptor), local_chip_(local_chip) {
     remote_communication_ = remote_tt_device->get_remote_communication();
     tt_device_ = std::move(remote_tt_device);
-    chip_info_ = tt_device_->get_chip_info();
     TT_ASSERT(soc_descriptor_.arch != tt::ARCH::BLACKHOLE, "Non-MMIO targets not supported in Blackhole");
     wait_chip_to_be_ready();
 }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -237,8 +237,7 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     }
 
     if (cluster_desc->is_chip_mmio_capable(chip_id)) {
-        auto chip = std::make_unique<LocalChip>(
-            soc_desc, cluster_desc->get_chips_with_mmio().at(chip_id), num_host_mem_channels);
+        auto chip = LocalChip::create(cluster_desc->get_chips_with_mmio().at(chip_id), soc_desc, num_host_mem_channels);
         if (cluster_desc->get_arch(chip_id) == tt::ARCH::WORMHOLE_B0) {
             // Remote transfer currently supported only for wormhole.
             chip->set_remote_transfer_ethernet_cores(cluster_desc->get_active_eth_channels(chip_id));
@@ -248,10 +247,8 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
         if (cluster_desc->get_arch(chip_id) != tt::ARCH::WORMHOLE_B0) {
             throw std::runtime_error("Remote chips are supported only for wormhole.");
         }
-        std::unique_ptr<RemoteWormholeTTDevice> remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(
-            get_local_chip(cluster_desc->get_closest_mmio_capable_chip(chip_id)),
-            cluster_desc->get_chip_locations().at(chip_id));
-        return std::make_unique<RemoteChip>(soc_desc, std::move(remote_tt_device));
+        auto local_chip = get_local_chip(cluster_desc->get_closest_mmio_capable_chip(chip_id));
+        return RemoteChip::create(local_chip, cluster_desc->get_chip_locations().at(chip_id), soc_desc);
     }
 }
 
@@ -1064,12 +1061,7 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
         std::unordered_map<chip_id_t, std::unique_ptr<Chip>> chips;
         chip_id_t chip_id = 0;
         for (auto& device_id : pci_device_ids) {
-            std::unique_ptr<LocalChip> chip = nullptr;
-            if (sdesc_path.empty()) {
-                chip = std::make_unique<LocalChip>(TTDevice::create(device_id));
-            } else {
-                chip = std::make_unique<LocalChip>(sdesc_path, TTDevice::create(device_id));
-            }
+            std::unique_ptr<LocalChip> chip = LocalChip::create(device_id, sdesc_path);
             chips.emplace(chip_id, std::move(chip));
             chip_id++;
         }

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -87,7 +87,7 @@ std::unique_ptr<RemoteChip> TopologyDiscovery::create_remote_chip(Chip* chip, tt
     }
 
     auto local_chip = dynamic_cast<LocalChip*>(gateway_chip);
-    auto eth_coord = get_local_eth_coord(gateway_chip);
+    auto eth_coord = get_remote_eth_coord(chip, eth_core);
 
     return RemoteChip::create(local_chip, eth_coord, sdesc_path);
 }

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -85,23 +85,14 @@ std::unique_ptr<RemoteChip> TopologyDiscovery::create_remote_chip(Chip* chip, tt
         return nullptr;
     }
 
-    std::unique_ptr<RemoteWormholeTTDevice> remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(
-        dynamic_cast<LocalChip*>(gateway_chip), get_remote_eth_coord(chip, eth_core));
-
-    ChipInfo chip_info = remote_tt_device->get_chip_info();
+    auto local_chip = dynamic_cast<LocalChip*>(gateway_chip);
+    auto eth_coord = get_local_eth_coord(gateway_chip);
 
     std::unique_ptr<RemoteChip> remote_chip = nullptr;
     if (sdesc_path != "") {
-        remote_chip = std::make_unique<RemoteChip>(
-            tt_SocDescriptor(sdesc_path, chip_info.noc_translation_enabled), std::move(remote_tt_device));
+        remote_chip = RemoteChip::create(local_chip, eth_coord, sdesc_path);
     } else {
-        remote_chip = std::make_unique<RemoteChip>(
-            tt_SocDescriptor(
-                remote_tt_device->get_arch(),
-                chip_info.noc_translation_enabled,
-                chip_info.harvesting_masks,
-                chip_info.board_type),
-            std::move(remote_tt_device));
+        remote_chip = RemoteChip::create(local_chip, eth_coord);
     }
 
     return remote_chip;

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -149,9 +149,9 @@ void TopologyDiscovery::get_pcie_connected_chips() {
         }
         std::unique_ptr<LocalChip> chip = nullptr;
         if (sdesc_path != "") {
-            chip = std::make_unique<LocalChip>(sdesc_path, TTDevice::create(device_id));
+            chip = LocalChip::create(device_id, sdesc_path);
         } else {
-            chip = std::make_unique<LocalChip>(TTDevice::create(device_id));
+            chip = LocalChip::create(device_id);
         }
 
         // ETH addresses need to be initialized after the first chip is created, so we could

--- a/device/topology_discovery.cpp
+++ b/device/topology_discovery.cpp
@@ -89,14 +89,7 @@ std::unique_ptr<RemoteChip> TopologyDiscovery::create_remote_chip(Chip* chip, tt
     auto local_chip = dynamic_cast<LocalChip*>(gateway_chip);
     auto eth_coord = get_local_eth_coord(gateway_chip);
 
-    std::unique_ptr<RemoteChip> remote_chip = nullptr;
-    if (sdesc_path != "") {
-        remote_chip = RemoteChip::create(local_chip, eth_coord, sdesc_path);
-    } else {
-        remote_chip = RemoteChip::create(local_chip, eth_coord);
-    }
-
-    return remote_chip;
+    return RemoteChip::create(local_chip, eth_coord, sdesc_path);
 }
 
 std::optional<eth_coord_t> TopologyDiscovery::get_local_eth_coord(Chip* chip) {
@@ -149,12 +142,7 @@ void TopologyDiscovery::get_pcie_connected_chips() {
 
     bool read_eth_addresses = false;
     for (auto& device_id : pci_device_ids) {
-        std::unique_ptr<LocalChip> chip = nullptr;
-        if (sdesc_path != "") {
-            chip = LocalChip::create(device_id, sdesc_path);
-        } else {
-            chip = LocalChip::create(device_id);
-        }
+        std::unique_ptr<LocalChip> chip = LocalChip::create(device_id, sdesc_path);
 
         // ETH addresses need to be initialized after the first chip is created, so we could
         // read the information about offsets of board IDs on ETH core.

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -158,7 +158,7 @@ ChipInfo BlackholeTTDevice::get_chip_info() {
     return chip_info;
 }
 
-void BlackholeTTDevice::wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms) {
+void BlackholeTTDevice::wait_arc_core_start(const uint32_t timeout_ms) {
     auto start = std::chrono::system_clock::now();
     uint32_t arc_boot_status;
     while (true) {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -354,10 +354,6 @@ void TTDevice::configure_iatu_region(size_t region, uint64_t target, size_t regi
     throw std::runtime_error("configure_iatu_region is not implemented for this device");
 }
 
-void TTDevice::wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms) {
-    throw std::runtime_error("Waiting for ARC core to start is supported only for Blackhole TTDevice.");
-}
-
 void TTDevice::bar_write32(uint32_t addr, uint32_t data) {
     if (addr < get_pci_device()->bar0_uc_offset) {
         write_block(addr, sizeof(data), reinterpret_cast<const uint8_t *>(&data));  // do we have to reinterpret_cast?

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -24,7 +24,6 @@ WormholeTTDevice::WormholeTTDevice(std::shared_ptr<PCIDevice> pci_device) :
                                   tt::umd::wormhole::NOC0_X_TO_NOC1_X[tt::umd::wormhole::ARC_CORES_NOC0[0].x],
                                   tt::umd::wormhole::NOC0_Y_TO_NOC1_Y[tt::umd::wormhole::ARC_CORES_NOC0[0].y])
                             : wormhole::ARC_CORES_NOC0[0];
-    wait_arc_core_start(arc_core, 1000);
 }
 
 bool WormholeTTDevice::get_noc_translation_enabled() {
@@ -70,7 +69,7 @@ ChipInfo WormholeTTDevice::get_chip_info() {
     return chip_info;
 }
 
-void WormholeTTDevice::wait_arc_core_start(const tt_xy_pair arc_core, const uint32_t timeout_ms) {
+void WormholeTTDevice::wait_arc_core_start(const uint32_t timeout_ms) {
     uint32_t bar_read_initial = bar_read32(architecture_impl_->get_arc_reset_scratch_offset() + 3 * 4);
     // TODO: figure out 325 and 500 constants meaning and put it in variable.
     uint32_t arg = bar_read_initial == 500 ? 325 : 500;


### PR DESCRIPTION
### Issue
#1163 

### Description
Revisited our constructors.
Previously LocalChip had to accept constructed TTDevice object, since the first thing it calls is Chip constructor, and it needs info from TTDevice for it. I've circumvented this by using static functions instead of constructors, and using a single private constructor. I've also aligned these functions a bit better.

### List of the changes
- Changed existing LocalChip constructors to more uniform "create" functions
- Make RemoteChip align with said constructors
- wait_arc_core_start remove calling it from Wormhole, and it already wasn't called from Blackhole.
- wait_arc_core_start doesn't need arc core parameter
- Constructor callsites are now simplified

### Testing
CI test should be enough

### API Changes
This PR has API changes for Chip classes, but these are not directly used by metal or exalens.
