### PR TITLE
Remove LocalChip from RemoteTTDevice

### DIFF
--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -18,12 +18,12 @@ public:
     static std::unique_ptr<RemoteChip> create(
         LocalChip* local_chip,
         eth_coord_t target_eth_coord,
-        std::unordered_set<CoreCoord>& remote_transfer_eth_cores,
+        std::unordered_set<CoreCoord> remote_transfer_eth_cores,
         std::string sdesc_path = "");
     static std::unique_ptr<RemoteChip> create(
         LocalChip* local_chip,
         eth_coord_t target_eth_coord,
-        std::unordered_set<CoreCoord>& remote_transfer_eth_cores,
+        std::unordered_set<CoreCoord> remote_transfer_eth_cores,
         tt_SocDescriptor soc_descriptor);
 
     bool is_mmio_capable() const override;

--- a/device/api/umd/device/remote_communication.h
+++ b/device/api/umd/device/remote_communication.h
@@ -16,7 +16,7 @@ class SysmemManager;
 
 class RemoteCommunication {
 public:
-    RemoteCommunication(TTDevice* local_chip, SysmemManager* sysmem_manager = nullptr);
+    RemoteCommunication(TTDevice* local_tt_device, SysmemManager* sysmem_manager = nullptr);
     virtual ~RemoteCommunication();
 
     // Target core should be in translated coords.
@@ -50,7 +50,7 @@ private:
     int active_eth_core_idx = 0;
     bool flush_non_mmio_ = false;
 
-    TTDevice* local_chip_;
+    TTDevice* local_tt_device_;
     LockManager lock_manager_;
     SysmemManager* sysmem_manager_;
 };

--- a/device/api/umd/device/remote_communication.h
+++ b/device/api/umd/device/remote_communication.h
@@ -12,15 +12,16 @@
 
 namespace tt::umd {
 
-class LocalChip;
 class SysmemManager;
 
 class RemoteCommunication {
 public:
-    RemoteCommunication(LocalChip* local_chip, SysmemManager* sysmem_manager = nullptr);
+    RemoteCommunication(TTDevice* local_chip, SysmemManager* sysmem_manager = nullptr);
     virtual ~RemoteCommunication();
 
     // Target core should be in translated coords.
+    // Note that since we're not using TLBManager, the read/writes won't ever go through static TLBs, which should
+    // probably be redesigned in some way.
     void read_non_mmio(
         eth_coord_t target_chip, tt_xy_pair target_core, void* dest, uint64_t core_src, uint32_t size_in_bytes);
 
@@ -36,18 +37,20 @@ public:
     void wait_for_non_mmio_flush();
 
     // Set the ethernet cores which can be used for remote communication on the assigned local chip.
-    void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores);
-    void set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels);
+    // The cores should be in translated coordinates.
+    void set_remote_transfer_ethernet_cores(const std::unordered_set<tt_xy_pair>& cores);
+
+    TTDevice* get_local_device();
 
 private:
-    CoreCoord get_remote_transfer_ethernet_core();
+    tt_xy_pair get_remote_transfer_ethernet_core();
     void update_active_eth_core_idx();
 
-    std::vector<CoreCoord> remote_transfer_eth_cores_;
+    std::vector<tt_xy_pair> remote_transfer_eth_cores_;
     int active_eth_core_idx = 0;
     bool flush_non_mmio_ = false;
 
-    LocalChip* local_chip_;
+    TTDevice* local_chip_;
     LockManager lock_manager_;
     SysmemManager* sysmem_manager_;
 };

--- a/device/api/umd/device/topology/topology_discovery.h
+++ b/device/api/umd/device/topology/topology_discovery.h
@@ -78,8 +78,7 @@ protected:
     virtual bool is_using_eth_coords() = 0;
 
     // eth_core should be in NoC 0 coordinates.
-    virtual std::unique_ptr<RemoteChip> create_remote_chip(
-        Chip* gateway_chip, CoreCoord eth_core) = 0;
+    virtual std::unique_ptr<RemoteChip> create_remote_chip(Chip* gateway_chip, CoreCoord eth_core) = 0;
 
     Chip* get_chip(const uint64_t asic_id);
 

--- a/device/api/umd/device/topology/topology_discovery.h
+++ b/device/api/umd/device/topology/topology_discovery.h
@@ -79,7 +79,7 @@ protected:
 
     // eth_core should be in NoC 0 coordinates.
     virtual std::unique_ptr<RemoteChip> create_remote_chip(
-        Chip* chip, tt_xy_pair eth_core, Chip* gateway_chip, std::set<uint32_t>& eth_channels_to_use) = 0;
+        Chip* gateway_chip, CoreCoord eth_core) = 0;
 
     Chip* get_chip(const uint64_t asic_id);
 

--- a/device/api/umd/device/topology/topology_discovery_blackhole.h
+++ b/device/api/umd/device/topology/topology_discovery_blackhole.h
@@ -48,7 +48,7 @@ protected:
     bool is_eth_unknown(Chip* chip, const tt_xy_pair eth_core) override;
 
     std::unique_ptr<RemoteChip> create_remote_chip(
-        Chip* chip, tt_xy_pair eth_core, Chip* gateway_chip, std::set<uint32_t>& eth_channels_to_use) override;
+        Chip* gateway_chip, CoreCoord eth_core) override;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/topology/topology_discovery_blackhole.h
+++ b/device/api/umd/device/topology/topology_discovery_blackhole.h
@@ -47,8 +47,7 @@ protected:
 
     bool is_eth_unknown(Chip* chip, const tt_xy_pair eth_core) override;
 
-    std::unique_ptr<RemoteChip> create_remote_chip(
-        Chip* gateway_chip, CoreCoord eth_core) override;
+    std::unique_ptr<RemoteChip> create_remote_chip(Chip* gateway_chip, CoreCoord eth_core) override;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/topology/topology_discovery_wormhole.h
+++ b/device/api/umd/device/topology/topology_discovery_wormhole.h
@@ -54,8 +54,7 @@ protected:
 
     uint64_t get_remote_board_type(Chip* chip, tt_xy_pair eth_core) override;
 
-    std::unique_ptr<RemoteChip> create_remote_chip(
-        Chip* gateway_chip, CoreCoord eth_core) override;
+    std::unique_ptr<RemoteChip> create_remote_chip(Chip* gateway_chip, CoreCoord eth_core) override;
 
     bool is_using_eth_coords() override;
 

--- a/device/api/umd/device/topology/topology_discovery_wormhole.h
+++ b/device/api/umd/device/topology/topology_discovery_wormhole.h
@@ -55,7 +55,7 @@ protected:
     uint64_t get_remote_board_type(Chip* chip, tt_xy_pair eth_core) override;
 
     std::unique_ptr<RemoteChip> create_remote_chip(
-        Chip* chip, tt_xy_pair eth_core, Chip* gateway_chip, std::set<uint32_t>& eth_channels_to_use) override;
+        Chip* gateway_chip, CoreCoord eth_core) override;
 
     bool is_using_eth_coords() override;
 

--- a/device/api/umd/device/tt_device/remote_wormhole_tt_device.h
+++ b/device/api/umd/device/tt_device/remote_wormhole_tt_device.h
@@ -12,8 +12,7 @@ namespace tt::umd {
 
 class RemoteWormholeTTDevice : public WormholeTTDevice {
 public:
-    RemoteWormholeTTDevice(
-        LocalChip* local_chip, std::unique_ptr<RemoteCommunication> remote_communication, eth_coord_t target_chip);
+    RemoteWormholeTTDevice(std::unique_ptr<RemoteCommunication> remote_communication, eth_coord_t target_chip);
 
     void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
 
@@ -25,12 +24,9 @@ public:
 
     void wait_for_non_mmio_flush() override;
 
-    LocalChip* get_local_chip();
-
     RemoteCommunication* get_remote_communication();
 
 private:
-    LocalChip* local_chip_;
     eth_coord_t target_chip_;
     std::unique_ptr<RemoteCommunication> remote_communication_;
 };

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -376,12 +376,14 @@ void LocalChip::wait_for_non_mmio_flush() {
 
 void LocalChip::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) {
     // Set cores to be used by the broadcast communication.
-    remote_communication_->set_remote_transfer_ethernet_cores(get_soc_descriptor().translate_coords_to_xy_pair(cores, CoordSystem::TRANSLATED));
+    remote_communication_->set_remote_transfer_ethernet_cores(
+        get_soc_descriptor().translate_coords_to_xy_pair(cores, CoordSystem::TRANSLATED));
 }
 
 void LocalChip::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) {
     // Set cores to be used by the broadcast communication.
-    remote_communication_->set_remote_transfer_ethernet_cores(get_soc_descriptor().get_eth_xy_pairs_for_channels(channels, CoordSystem::TRANSLATED));
+    remote_communication_->set_remote_transfer_ethernet_cores(
+        get_soc_descriptor().get_eth_xy_pairs_for_channels(channels, CoordSystem::TRANSLATED));
 }
 
 std::unique_lock<RobustMutex> LocalChip::acquire_mutex(std::string mutex_name, int pci_device_id) {

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -21,10 +21,12 @@ std::unique_ptr<RemoteChip> RemoteChip::create(
     eth_coord_t target_eth_coord,
     std::unordered_set<CoreCoord> remote_transfer_eth_cores,
     std::string sdesc_path) {
-    auto remote_communication = std::make_unique<RemoteCommunication>(local_chip->get_tt_device(), local_chip->get_sysmem_manager());
-    remote_communication->set_remote_transfer_ethernet_cores(local_chip->get_soc_descriptor().translate_coords_to_xy_pair(remote_transfer_eth_cores, CoordSystem::TRANSLATED));
-    auto remote_tt_device =
-        std::make_unique<RemoteWormholeTTDevice>(std::move(remote_communication), target_eth_coord);
+    auto remote_communication =
+        std::make_unique<RemoteCommunication>(local_chip->get_tt_device(), local_chip->get_sysmem_manager());
+    remote_communication->set_remote_transfer_ethernet_cores(
+        local_chip->get_soc_descriptor().translate_coords_to_xy_pair(
+            remote_transfer_eth_cores, CoordSystem::TRANSLATED));
+    auto remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(std::move(remote_communication), target_eth_coord);
     remote_tt_device->wait_arc_core_start();
 
     tt_SocDescriptor soc_descriptor;
@@ -51,10 +53,12 @@ std::unique_ptr<RemoteChip> RemoteChip::create(
     eth_coord_t target_eth_coord,
     std::unordered_set<CoreCoord> remote_transfer_eth_cores,
     tt_SocDescriptor soc_descriptor) {
-    auto remote_communication = std::make_unique<RemoteCommunication>(local_chip->get_tt_device(), local_chip->get_sysmem_manager());
-    remote_communication->set_remote_transfer_ethernet_cores(local_chip->get_soc_descriptor().translate_coords_to_xy_pair(remote_transfer_eth_cores, CoordSystem::TRANSLATED));
-    auto remote_tt_device =
-        std::make_unique<RemoteWormholeTTDevice>(std::move(remote_communication), target_eth_coord);
+    auto remote_communication =
+        std::make_unique<RemoteCommunication>(local_chip->get_tt_device(), local_chip->get_sysmem_manager());
+    remote_communication->set_remote_transfer_ethernet_cores(
+        local_chip->get_soc_descriptor().translate_coords_to_xy_pair(
+            remote_transfer_eth_cores, CoordSystem::TRANSLATED));
+    auto remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(std::move(remote_communication), target_eth_coord);
     remote_tt_device->wait_arc_core_start();
 
     return std::unique_ptr<tt::umd::RemoteChip>(
@@ -158,11 +162,13 @@ int RemoteChip::get_numa_node() {
 }
 
 void RemoteChip::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) {
-    remote_communication_->set_remote_transfer_ethernet_cores(local_chip_->get_soc_descriptor().translate_coords_to_xy_pair(cores, CoordSystem::TRANSLATED));
+    remote_communication_->set_remote_transfer_ethernet_cores(
+        local_chip_->get_soc_descriptor().translate_coords_to_xy_pair(cores, CoordSystem::TRANSLATED));
 }
 
 void RemoteChip::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) {
-    remote_communication_->set_remote_transfer_ethernet_cores(local_chip_->get_soc_descriptor().get_eth_xy_pairs_for_channels(channels, CoordSystem::TRANSLATED));
+    remote_communication_->set_remote_transfer_ethernet_cores(
+        local_chip_->get_soc_descriptor().get_eth_xy_pairs_for_channels(channels, CoordSystem::TRANSLATED));
 }
 
 TTDevice* RemoteChip::get_tt_device() { return tt_device_.get(); }

--- a/device/remote_communication.cpp
+++ b/device/remote_communication.cpp
@@ -39,7 +39,7 @@ struct routing_cmd_t {
 };
 
 RemoteCommunication::RemoteCommunication(TTDevice* local_tt_device, SysmemManager* sysmem_manager) :
-    local_chip_(local_chip), sysmem_manager_(sysmem_manager) {
+    local_tt_device_(local_tt_device), sysmem_manager_(sysmem_manager) {
     lock_manager_.initialize_mutex(MutexType::NON_MMIO, local_tt_device->get_pci_device()->get_device_num());
 }
 
@@ -583,7 +583,7 @@ void RemoteCommunication::set_remote_transfer_ethernet_cores(
     remote_transfer_eth_cores_.assign(remote_transfer_eth_cores.begin(), remote_transfer_eth_cores.end());
 }
 
-TTDevice* RemoteCommunication::get_local_device() { return local_chip_; }
+TTDevice* RemoteCommunication::get_local_device() { return local_tt_device_; }
 
 tt_xy_pair RemoteCommunication::get_remote_transfer_ethernet_core() {
     if (remote_transfer_eth_cores_.size() > 8) {

--- a/device/remote_communication.cpp
+++ b/device/remote_communication.cpp
@@ -38,9 +38,9 @@ struct routing_cmd_t {
     uint32_t src_addr_tag;  // upper 32-bits of request source address.
 };
 
-RemoteCommunication::RemoteCommunication(TTDevice* local_chip, SysmemManager* sysmem_manager) :
+RemoteCommunication::RemoteCommunication(TTDevice* local_tt_device, SysmemManager* sysmem_manager) :
     local_chip_(local_chip), sysmem_manager_(sysmem_manager) {
-    lock_manager_.initialize_mutex(MutexType::NON_MMIO, local_chip_->get_pci_device()->get_device_num());
+    lock_manager_.initialize_mutex(MutexType::NON_MMIO, local_tt_device->get_pci_device()->get_device_num());
 }
 
 RemoteCommunication::~RemoteCommunication() {}
@@ -101,9 +101,9 @@ void RemoteCommunication::read_non_mmio(
     using data_word_t = uint32_t;
     constexpr int DATA_WORD_SIZE = sizeof(data_word_t);
 
-    auto host_address_params = local_chip_->get_architecture_implementation()->get_host_address_params();
-    auto eth_interface_params = local_chip_->get_architecture_implementation()->get_eth_interface_params();
-    auto noc_params = local_chip_->get_architecture_implementation()->get_noc_params();
+    auto host_address_params = local_tt_device_->get_architecture_implementation()->get_host_address_params();
+    auto eth_interface_params = local_tt_device_->get_architecture_implementation()->get_eth_interface_params();
+    auto noc_params = local_tt_device_->get_architecture_implementation()->get_noc_params();
 
     std::vector<std::uint32_t> erisc_command;
     std::vector<std::uint32_t> erisc_q_rptr;
@@ -122,21 +122,21 @@ void RemoteCommunication::read_non_mmio(
     //                    MUTEX ACQUIRE (NON-MMIO)
     //  do not locate any ethernet core reads/writes before this acquire
     //
-    auto lock = lock_manager_.acquire_mutex(MutexType::NON_MMIO, local_chip_->get_pci_device()->get_device_num());
+    auto lock = lock_manager_.acquire_mutex(MutexType::NON_MMIO, local_tt_device_->get_pci_device()->get_device_num());
 
     const tt_xy_pair remote_transfer_ethernet_core = get_remote_transfer_ethernet_core();
 
-    local_chip_->read_from_device(
+    local_tt_device_->read_from_device(
         erisc_q_ptrs.data(),
         remote_transfer_ethernet_core,
         eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
         eth_interface_params.remote_update_ptr_size_bytes * 2);
-    local_chip_->read_from_device(
+    local_tt_device_->read_from_device(
         erisc_resp_q_wptr.data(),
         remote_transfer_ethernet_core,
         eth_interface_params.response_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
         DATA_WORD_SIZE);
-    local_chip_->read_from_device(
+    local_tt_device_->read_from_device(
         erisc_resp_q_rptr.data(),
         remote_transfer_ethernet_core,
         eth_interface_params.response_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes +
@@ -160,7 +160,7 @@ void RemoteCommunication::read_non_mmio(
 
     while (offset < size_in_bytes) {
         while (full) {
-            local_chip_->read_from_device(
+            local_tt_device_->read_from_device(
                 erisc_q_rptr.data(),
                 remote_transfer_ethernet_core,
                 eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes +
@@ -206,7 +206,7 @@ void RemoteCommunication::read_non_mmio(
         if (use_dram) {
             new_cmd->src_addr_tag = host_dram_block_addr;
         }
-        local_chip_->write_to_device(
+        local_tt_device_->write_to_device(
             erisc_command.data(),
             remote_transfer_ethernet_core,
             eth_interface_params.request_routing_cmd_queue_base + (sizeof(routing_cmd_t) * req_wr_ptr),
@@ -218,7 +218,7 @@ void RemoteCommunication::read_non_mmio(
         std::vector<std::uint32_t> erisc_q_wptr;
         erisc_q_wptr.resize(1);
         erisc_q_wptr[0] = erisc_q_ptrs[0];
-        local_chip_->write_to_device(
+        local_tt_device_->write_to_device(
             erisc_q_wptr.data(),
             remote_transfer_ethernet_core,
             eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
@@ -230,7 +230,7 @@ void RemoteCommunication::read_non_mmio(
         // to poll rd pointer in every iteration.
 
         if (is_non_mmio_cmd_q_full(eth_interface_params, (erisc_q_ptrs[0]), erisc_q_rptr[0])) {
-            local_chip_->read_from_device(
+            local_tt_device_->read_from_device(
                 erisc_q_ptrs.data(),
                 remote_transfer_ethernet_core,
                 eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
@@ -250,7 +250,7 @@ void RemoteCommunication::read_non_mmio(
         // So we have to wait for wrptr to advance, then wait for flags to be nonzero, then read data.
 
         do {
-            local_chip_->read_from_device(
+            local_tt_device_->read_from_device(
                 erisc_resp_q_wptr.data(),
                 remote_transfer_ethernet_core,
                 eth_interface_params.response_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
@@ -260,7 +260,7 @@ void RemoteCommunication::read_non_mmio(
         uint32_t flags_offset = 12 + sizeof(routing_cmd_t) * resp_rd_ptr;
         std::vector<std::uint32_t> erisc_resp_flags = std::vector<uint32_t>(1);
         do {
-            local_chip_->read_from_device(
+            local_tt_device_->read_from_device(
                 erisc_resp_flags.data(),
                 remote_transfer_ethernet_core,
                 eth_interface_params.response_routing_cmd_queue_base + flags_offset,
@@ -272,7 +272,7 @@ void RemoteCommunication::read_non_mmio(
             uint32_t data_offset = 8 + sizeof(routing_cmd_t) * resp_rd_ptr;
             if (block_size == DATA_WORD_SIZE) {
                 std::vector<std::uint32_t> erisc_resp_data = std::vector<uint32_t>(1);
-                local_chip_->read_from_device(
+                local_tt_device_->read_from_device(
                     erisc_resp_data.data(),
                     remote_transfer_ethernet_core,
                     eth_interface_params.response_routing_cmd_queue_base + data_offset,
@@ -294,7 +294,7 @@ void RemoteCommunication::read_non_mmio(
                     uint32_t buf_address =
                         eth_interface_params.eth_routing_data_buffer_addr + resp_rd_ptr * max_block_size;
                     size_buffer_to_capacity(data_block, block_size);
-                    local_chip_->read_from_device(
+                    local_tt_device_->read_from_device(
                         data_block.data(), remote_transfer_ethernet_core, buf_address, block_size);
                 }
                 // assert(dest.size() - (offset/DATA_WORD_SIZE) >= (block_size * DATA_WORD_SIZE));
@@ -308,7 +308,7 @@ void RemoteCommunication::read_non_mmio(
 
         // Finally increment the rdptr for the response command q
         erisc_resp_q_rptr[0] = (erisc_resp_q_rptr[0] + 1) & eth_interface_params.cmd_buf_ptr_mask;
-        local_chip_->write_to_device(
+        local_tt_device_->write_to_device(
             erisc_resp_q_rptr.data(),
             remote_transfer_ethernet_core,
             eth_interface_params.response_cmd_queue_base + sizeof(remote_update_ptr_t) +
@@ -341,9 +341,9 @@ void RemoteCommunication::write_to_non_mmio(
     constexpr int DATA_WORD_SIZE = sizeof(data_word_t);
     constexpr int BROADCAST_HEADER_SIZE = sizeof(data_word_t) * 8;  // Broadcast header is 8 words
 
-    auto host_address_params = local_chip_->get_architecture_implementation()->get_host_address_params();
-    auto eth_interface_params = local_chip_->get_architecture_implementation()->get_eth_interface_params();
-    auto noc_params = local_chip_->get_architecture_implementation()->get_noc_params();
+    auto host_address_params = local_tt_device_->get_architecture_implementation()->get_host_address_params();
+    auto eth_interface_params = local_tt_device_->get_architecture_implementation()->get_eth_interface_params();
+    auto noc_params = local_tt_device_->get_architecture_implementation()->get_noc_params();
 
     std::vector<std::uint32_t> erisc_command;
     std::vector<std::uint32_t> erisc_q_rptr = std::vector<uint32_t>(1);
@@ -370,13 +370,13 @@ void RemoteCommunication::write_to_non_mmio(
     //                    MUTEX ACQUIRE (NON-MMIO)
     //  do not locate any ethernet core reads/writes before this acquire
     //
-    auto lock = lock_manager_.acquire_mutex(MutexType::NON_MMIO, local_chip_->get_pci_device()->get_device_num());
+    auto lock = lock_manager_.acquire_mutex(MutexType::NON_MMIO, local_tt_device_->get_pci_device()->get_device_num());
 
     tt_xy_pair remote_transfer_ethernet_core = get_remote_transfer_ethernet_core();
 
     erisc_command.resize(sizeof(routing_cmd_t) / DATA_WORD_SIZE);
     new_cmd = (routing_cmd_t*)&erisc_command[0];
-    local_chip_->read_from_device(
+    local_tt_device_->read_from_device(
         erisc_q_ptrs.data(),
         remote_transfer_ethernet_core,
         eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
@@ -389,7 +389,7 @@ void RemoteCommunication::write_to_non_mmio(
     erisc_q_rptr[0] = erisc_q_ptrs[4];
     while (offset < size_in_bytes) {
         while (full) {
-            local_chip_->read_from_device(
+            local_tt_device_->read_from_device(
                 erisc_q_rptr.data(),
                 remote_transfer_ethernet_core,
                 eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes +
@@ -463,7 +463,7 @@ void RemoteCommunication::write_to_non_mmio(
                 uint32_t buf_address = eth_interface_params.eth_routing_data_buffer_addr + req_wr_ptr * max_block_size;
                 size_buffer_to_capacity(data_block, block_size);
                 memcpy(&data_block[0], (uint8_t*)src + offset, transfer_size);
-                local_chip_->write_to_device(
+                local_tt_device_->write_to_device(
                     data_block.data(), remote_transfer_ethernet_core, buf_address, data_block.size() * DATA_WORD_SIZE);
             }
             tt_driver_atomics::sfence();
@@ -501,7 +501,7 @@ void RemoteCommunication::write_to_non_mmio(
         if (use_dram) {
             new_cmd->src_addr_tag = host_dram_block_addr;
         }
-        local_chip_->write_to_device(
+        local_tt_device_->write_to_device(
             erisc_command.data(),
             remote_transfer_ethernet_core,
             eth_interface_params.request_routing_cmd_queue_base + (sizeof(routing_cmd_t) * req_wr_ptr),
@@ -512,7 +512,7 @@ void RemoteCommunication::write_to_non_mmio(
         std::vector<std::uint32_t> erisc_q_wptr;
         erisc_q_wptr.resize(1);
         erisc_q_wptr[0] = erisc_q_ptrs[0];
-        local_chip_->write_to_device(
+        local_tt_device_->write_to_device(
             erisc_q_wptr.data(),
             remote_transfer_ethernet_core,
             eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
@@ -530,7 +530,7 @@ void RemoteCommunication::write_to_non_mmio(
                 eth_interface_params, (erisc_q_ptrs[0]) & eth_interface_params.cmd_buf_ptr_mask, erisc_q_rptr[0])) {
             update_active_eth_core_idx();
             remote_transfer_ethernet_core = get_remote_transfer_ethernet_core();
-            local_chip_->read_from_device(
+            local_tt_device_->read_from_device(
                 erisc_q_ptrs.data(),
                 remote_transfer_ethernet_core,
                 eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
@@ -543,10 +543,10 @@ void RemoteCommunication::write_to_non_mmio(
 
 void RemoteCommunication::wait_for_non_mmio_flush() {
     if (flush_non_mmio_) {
-        TT_ASSERT(local_chip_->get_arch() != tt::ARCH::BLACKHOLE, "Non-MMIO flush not supported in Blackhole");
+        TT_ASSERT(local_tt_device_->get_arch() != tt::ARCH::BLACKHOLE, "Non-MMIO flush not supported in Blackhole");
 
-        if (local_chip_->get_arch() == tt::ARCH::WORMHOLE_B0) {
-            auto eth_interface_params = local_chip_->get_architecture_implementation()->get_eth_interface_params();
+        if (local_tt_device_->get_arch() == tt::ARCH::WORMHOLE_B0) {
+            auto eth_interface_params = local_tt_device_->get_architecture_implementation()->get_eth_interface_params();
 
             std::vector<std::uint32_t> erisc_txn_counters = std::vector<uint32_t>(2);
             std::vector<std::uint32_t> erisc_q_ptrs =
@@ -555,7 +555,7 @@ void RemoteCommunication::wait_for_non_mmio_flush() {
             // wait for all queues to be empty.
             for (tt_xy_pair& core : remote_transfer_eth_cores_) {
                 do {
-                    local_chip_->read_from_device(
+                    local_tt_device_->read_from_device(
                         erisc_q_ptrs.data(),
                         core,
                         eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
@@ -565,7 +565,7 @@ void RemoteCommunication::wait_for_non_mmio_flush() {
             // wait for all write responses to come back.
             for (tt_xy_pair& core : remote_transfer_eth_cores_) {
                 do {
-                    local_chip_->read_from_device(
+                    local_tt_device_->read_from_device(
                         erisc_txn_counters.data(), core, eth_interface_params.request_cmd_queue_base, 8);
                 } while (erisc_txn_counters[0] != erisc_txn_counters[1]);
             }

--- a/device/remote_communication.cpp
+++ b/device/remote_communication.cpp
@@ -574,7 +574,8 @@ void RemoteCommunication::wait_for_non_mmio_flush() {
     }
 }
 
-void RemoteCommunication::set_remote_transfer_ethernet_cores(const std::unordered_set<tt_xy_pair>& remote_transfer_eth_cores) {
+void RemoteCommunication::set_remote_transfer_ethernet_cores(
+    const std::unordered_set<tt_xy_pair>& remote_transfer_eth_cores) {
     // Makes UMD aware of which ethernet cores have active links.
     // Based on this information, UMD determines which ethernet cores can be used for host->cluster non-MMIO transfers.
     // This overrides the default ethernet cores tagged for host to cluster routing in the constructor and must be
@@ -582,9 +583,7 @@ void RemoteCommunication::set_remote_transfer_ethernet_cores(const std::unordere
     remote_transfer_eth_cores_.assign(remote_transfer_eth_cores.begin(), remote_transfer_eth_cores.end());
 }
 
-TTDevice* RemoteCommunication::get_local_device() {
-    return local_chip_;
-}
+TTDevice* RemoteCommunication::get_local_device() { return local_chip_; }
 
 tt_xy_pair RemoteCommunication::get_remote_transfer_ethernet_core() {
     if (remote_transfer_eth_cores_.size() > 8) {

--- a/device/remote_communication.cpp
+++ b/device/remote_communication.cpp
@@ -38,10 +38,9 @@ struct routing_cmd_t {
     uint32_t src_addr_tag;  // upper 32-bits of request source address.
 };
 
-RemoteCommunication::RemoteCommunication(LocalChip* local_chip, SysmemManager* sysmem_manager) :
+RemoteCommunication::RemoteCommunication(TTDevice* local_chip, SysmemManager* sysmem_manager) :
     local_chip_(local_chip), sysmem_manager_(sysmem_manager) {
-    lock_manager_.initialize_mutex(
-        MutexType::NON_MMIO, local_chip_->get_tt_device()->get_pci_device()->get_device_num());
+    lock_manager_.initialize_mutex(MutexType::NON_MMIO, local_chip_->get_pci_device()->get_device_num());
 }
 
 RemoteCommunication::~RemoteCommunication() {}
@@ -102,11 +101,9 @@ void RemoteCommunication::read_non_mmio(
     using data_word_t = uint32_t;
     constexpr int DATA_WORD_SIZE = sizeof(data_word_t);
 
-    auto host_address_params =
-        local_chip_->get_tt_device()->get_architecture_implementation()->get_host_address_params();
-    auto eth_interface_params =
-        local_chip_->get_tt_device()->get_architecture_implementation()->get_eth_interface_params();
-    auto noc_params = local_chip_->get_tt_device()->get_architecture_implementation()->get_noc_params();
+    auto host_address_params = local_chip_->get_architecture_implementation()->get_host_address_params();
+    auto eth_interface_params = local_chip_->get_architecture_implementation()->get_eth_interface_params();
+    auto noc_params = local_chip_->get_architecture_implementation()->get_noc_params();
 
     std::vector<std::uint32_t> erisc_command;
     std::vector<std::uint32_t> erisc_q_rptr;
@@ -125,24 +122,23 @@ void RemoteCommunication::read_non_mmio(
     //                    MUTEX ACQUIRE (NON-MMIO)
     //  do not locate any ethernet core reads/writes before this acquire
     //
-    auto lock = lock_manager_.acquire_mutex(
-        MutexType::NON_MMIO, local_chip_->get_tt_device()->get_pci_device()->get_device_num());
+    auto lock = lock_manager_.acquire_mutex(MutexType::NON_MMIO, local_chip_->get_pci_device()->get_device_num());
 
-    const CoreCoord remote_transfer_ethernet_core = get_remote_transfer_ethernet_core();
+    const tt_xy_pair remote_transfer_ethernet_core = get_remote_transfer_ethernet_core();
 
     local_chip_->read_from_device(
-        remote_transfer_ethernet_core,
         erisc_q_ptrs.data(),
+        remote_transfer_ethernet_core,
         eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
         eth_interface_params.remote_update_ptr_size_bytes * 2);
     local_chip_->read_from_device(
-        remote_transfer_ethernet_core,
         erisc_resp_q_wptr.data(),
+        remote_transfer_ethernet_core,
         eth_interface_params.response_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
         DATA_WORD_SIZE);
     local_chip_->read_from_device(
-        remote_transfer_ethernet_core,
         erisc_resp_q_rptr.data(),
+        remote_transfer_ethernet_core,
         eth_interface_params.response_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes +
             eth_interface_params.remote_update_ptr_size_bytes,
         DATA_WORD_SIZE);
@@ -165,8 +161,8 @@ void RemoteCommunication::read_non_mmio(
     while (offset < size_in_bytes) {
         while (full) {
             local_chip_->read_from_device(
-                remote_transfer_ethernet_core,
                 erisc_q_rptr.data(),
+                remote_transfer_ethernet_core,
                 eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes +
                     eth_interface_params.remote_update_ptr_size_bytes,
                 DATA_WORD_SIZE);
@@ -211,8 +207,8 @@ void RemoteCommunication::read_non_mmio(
             new_cmd->src_addr_tag = host_dram_block_addr;
         }
         local_chip_->write_to_device(
-            remote_transfer_ethernet_core,
             erisc_command.data(),
+            remote_transfer_ethernet_core,
             eth_interface_params.request_routing_cmd_queue_base + (sizeof(routing_cmd_t) * req_wr_ptr),
             erisc_command.size() * DATA_WORD_SIZE);
         ;
@@ -223,8 +219,8 @@ void RemoteCommunication::read_non_mmio(
         erisc_q_wptr.resize(1);
         erisc_q_wptr[0] = erisc_q_ptrs[0];
         local_chip_->write_to_device(
-            remote_transfer_ethernet_core,
             erisc_q_wptr.data(),
+            remote_transfer_ethernet_core,
             eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
             erisc_q_wptr.size() * DATA_WORD_SIZE);
         tt_driver_atomics::sfence();
@@ -235,8 +231,8 @@ void RemoteCommunication::read_non_mmio(
 
         if (is_non_mmio_cmd_q_full(eth_interface_params, (erisc_q_ptrs[0]), erisc_q_rptr[0])) {
             local_chip_->read_from_device(
-                remote_transfer_ethernet_core,
                 erisc_q_ptrs.data(),
+                remote_transfer_ethernet_core,
                 eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
                 eth_interface_params.remote_update_ptr_size_bytes * 2);
             full = is_non_mmio_cmd_q_full(eth_interface_params, erisc_q_ptrs[0], erisc_q_ptrs[4]);
@@ -255,8 +251,8 @@ void RemoteCommunication::read_non_mmio(
 
         do {
             local_chip_->read_from_device(
-                remote_transfer_ethernet_core,
                 erisc_resp_q_wptr.data(),
+                remote_transfer_ethernet_core,
                 eth_interface_params.response_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
                 DATA_WORD_SIZE);
         } while (erisc_resp_q_rptr[0] == erisc_resp_q_wptr[0]);
@@ -265,8 +261,8 @@ void RemoteCommunication::read_non_mmio(
         std::vector<std::uint32_t> erisc_resp_flags = std::vector<uint32_t>(1);
         do {
             local_chip_->read_from_device(
-                remote_transfer_ethernet_core,
                 erisc_resp_flags.data(),
+                remote_transfer_ethernet_core,
                 eth_interface_params.response_routing_cmd_queue_base + flags_offset,
                 DATA_WORD_SIZE);
         } while (erisc_resp_flags[0] == 0);
@@ -277,8 +273,8 @@ void RemoteCommunication::read_non_mmio(
             if (block_size == DATA_WORD_SIZE) {
                 std::vector<std::uint32_t> erisc_resp_data = std::vector<uint32_t>(1);
                 local_chip_->read_from_device(
-                    remote_transfer_ethernet_core,
                     erisc_resp_data.data(),
+                    remote_transfer_ethernet_core,
                     eth_interface_params.response_routing_cmd_queue_base + data_offset,
                     DATA_WORD_SIZE);
                 if (size_in_bytes - offset < 4) {
@@ -299,7 +295,7 @@ void RemoteCommunication::read_non_mmio(
                         eth_interface_params.eth_routing_data_buffer_addr + resp_rd_ptr * max_block_size;
                     size_buffer_to_capacity(data_block, block_size);
                     local_chip_->read_from_device(
-                        remote_transfer_ethernet_core, data_block.data(), buf_address, block_size);
+                        data_block.data(), remote_transfer_ethernet_core, buf_address, block_size);
                 }
                 // assert(dest.size() - (offset/DATA_WORD_SIZE) >= (block_size * DATA_WORD_SIZE));
                 TT_ASSERT(
@@ -313,8 +309,8 @@ void RemoteCommunication::read_non_mmio(
         // Finally increment the rdptr for the response command q
         erisc_resp_q_rptr[0] = (erisc_resp_q_rptr[0] + 1) & eth_interface_params.cmd_buf_ptr_mask;
         local_chip_->write_to_device(
-            remote_transfer_ethernet_core,
             erisc_resp_q_rptr.data(),
+            remote_transfer_ethernet_core,
             eth_interface_params.response_cmd_queue_base + sizeof(remote_update_ptr_t) +
                 eth_interface_params.cmd_counters_size_bytes,
             erisc_resp_q_rptr.size() * DATA_WORD_SIZE);
@@ -345,11 +341,9 @@ void RemoteCommunication::write_to_non_mmio(
     constexpr int DATA_WORD_SIZE = sizeof(data_word_t);
     constexpr int BROADCAST_HEADER_SIZE = sizeof(data_word_t) * 8;  // Broadcast header is 8 words
 
-    auto host_address_params =
-        local_chip_->get_tt_device()->get_architecture_implementation()->get_host_address_params();
-    auto eth_interface_params =
-        local_chip_->get_tt_device()->get_architecture_implementation()->get_eth_interface_params();
-    auto noc_params = local_chip_->get_tt_device()->get_architecture_implementation()->get_noc_params();
+    auto host_address_params = local_chip_->get_architecture_implementation()->get_host_address_params();
+    auto eth_interface_params = local_chip_->get_architecture_implementation()->get_eth_interface_params();
+    auto noc_params = local_chip_->get_architecture_implementation()->get_noc_params();
 
     std::vector<std::uint32_t> erisc_command;
     std::vector<std::uint32_t> erisc_q_rptr = std::vector<uint32_t>(1);
@@ -376,16 +370,15 @@ void RemoteCommunication::write_to_non_mmio(
     //                    MUTEX ACQUIRE (NON-MMIO)
     //  do not locate any ethernet core reads/writes before this acquire
     //
-    auto lock = lock_manager_.acquire_mutex(
-        MutexType::NON_MMIO, local_chip_->get_tt_device()->get_pci_device()->get_device_num());
+    auto lock = lock_manager_.acquire_mutex(MutexType::NON_MMIO, local_chip_->get_pci_device()->get_device_num());
 
-    CoreCoord remote_transfer_ethernet_core = get_remote_transfer_ethernet_core();
+    tt_xy_pair remote_transfer_ethernet_core = get_remote_transfer_ethernet_core();
 
     erisc_command.resize(sizeof(routing_cmd_t) / DATA_WORD_SIZE);
     new_cmd = (routing_cmd_t*)&erisc_command[0];
     local_chip_->read_from_device(
-        remote_transfer_ethernet_core,
         erisc_q_ptrs.data(),
+        remote_transfer_ethernet_core,
         eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
         eth_interface_params.remote_update_ptr_size_bytes * 2);
     uint32_t offset = 0;
@@ -397,8 +390,8 @@ void RemoteCommunication::write_to_non_mmio(
     while (offset < size_in_bytes) {
         while (full) {
             local_chip_->read_from_device(
-                remote_transfer_ethernet_core,
                 erisc_q_rptr.data(),
+                remote_transfer_ethernet_core,
                 eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes +
                     eth_interface_params.remote_update_ptr_size_bytes,
                 DATA_WORD_SIZE);
@@ -471,7 +464,7 @@ void RemoteCommunication::write_to_non_mmio(
                 size_buffer_to_capacity(data_block, block_size);
                 memcpy(&data_block[0], (uint8_t*)src + offset, transfer_size);
                 local_chip_->write_to_device(
-                    remote_transfer_ethernet_core, data_block.data(), buf_address, data_block.size() * DATA_WORD_SIZE);
+                    data_block.data(), remote_transfer_ethernet_core, buf_address, data_block.size() * DATA_WORD_SIZE);
             }
             tt_driver_atomics::sfence();
         }
@@ -509,8 +502,8 @@ void RemoteCommunication::write_to_non_mmio(
             new_cmd->src_addr_tag = host_dram_block_addr;
         }
         local_chip_->write_to_device(
-            remote_transfer_ethernet_core,
             erisc_command.data(),
+            remote_transfer_ethernet_core,
             eth_interface_params.request_routing_cmd_queue_base + (sizeof(routing_cmd_t) * req_wr_ptr),
             erisc_command.size() * DATA_WORD_SIZE);
         tt_driver_atomics::sfence();
@@ -520,8 +513,8 @@ void RemoteCommunication::write_to_non_mmio(
         erisc_q_wptr.resize(1);
         erisc_q_wptr[0] = erisc_q_ptrs[0];
         local_chip_->write_to_device(
-            remote_transfer_ethernet_core,
             erisc_q_wptr.data(),
+            remote_transfer_ethernet_core,
             eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
             erisc_q_wptr.size() * DATA_WORD_SIZE);
         tt_driver_atomics::sfence();
@@ -538,8 +531,8 @@ void RemoteCommunication::write_to_non_mmio(
             update_active_eth_core_idx();
             remote_transfer_ethernet_core = get_remote_transfer_ethernet_core();
             local_chip_->read_from_device(
-                remote_transfer_ethernet_core,
                 erisc_q_ptrs.data(),
+                remote_transfer_ethernet_core,
                 eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
                 eth_interface_params.remote_update_ptr_size_bytes * 2);
             full = is_non_mmio_cmd_q_full(eth_interface_params, erisc_q_ptrs[0], erisc_q_ptrs[4]);
@@ -550,32 +543,30 @@ void RemoteCommunication::write_to_non_mmio(
 
 void RemoteCommunication::wait_for_non_mmio_flush() {
     if (flush_non_mmio_) {
-        TT_ASSERT(
-            local_chip_->get_soc_descriptor().arch != tt::ARCH::BLACKHOLE, "Non-MMIO flush not supported in Blackhole");
+        TT_ASSERT(local_chip_->get_arch() != tt::ARCH::BLACKHOLE, "Non-MMIO flush not supported in Blackhole");
 
-        if (local_chip_->get_soc_descriptor().arch == tt::ARCH::WORMHOLE_B0) {
-            auto eth_interface_params =
-                local_chip_->get_tt_device()->get_architecture_implementation()->get_eth_interface_params();
+        if (local_chip_->get_arch() == tt::ARCH::WORMHOLE_B0) {
+            auto eth_interface_params = local_chip_->get_architecture_implementation()->get_eth_interface_params();
 
             std::vector<std::uint32_t> erisc_txn_counters = std::vector<uint32_t>(2);
             std::vector<std::uint32_t> erisc_q_ptrs =
                 std::vector<uint32_t>(eth_interface_params.remote_update_ptr_size_bytes * 2 / sizeof(uint32_t));
 
             // wait for all queues to be empty.
-            for (CoreCoord& core : remote_transfer_eth_cores_) {
+            for (tt_xy_pair& core : remote_transfer_eth_cores_) {
                 do {
                     local_chip_->read_from_device(
-                        core,
                         erisc_q_ptrs.data(),
+                        core,
                         eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
                         eth_interface_params.remote_update_ptr_size_bytes * 2);
                 } while (erisc_q_ptrs[0] != erisc_q_ptrs[4]);
             }
             // wait for all write responses to come back.
-            for (CoreCoord& core : remote_transfer_eth_cores_) {
+            for (tt_xy_pair& core : remote_transfer_eth_cores_) {
                 do {
                     local_chip_->read_from_device(
-                        core, erisc_txn_counters.data(), eth_interface_params.request_cmd_queue_base, 8);
+                        erisc_txn_counters.data(), core, eth_interface_params.request_cmd_queue_base, 8);
                 } while (erisc_txn_counters[0] != erisc_txn_counters[1]);
             }
         }
@@ -583,26 +574,19 @@ void RemoteCommunication::wait_for_non_mmio_flush() {
     }
 }
 
-void RemoteCommunication::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& active_eth_cores) {
+void RemoteCommunication::set_remote_transfer_ethernet_cores(const std::unordered_set<tt_xy_pair>& remote_transfer_eth_cores) {
     // Makes UMD aware of which ethernet cores have active links.
     // Based on this information, UMD determines which ethernet cores can be used for host->cluster non-MMIO transfers.
     // This overrides the default ethernet cores tagged for host to cluster routing in the constructor and must be
     // called for all MMIO devices, if default behaviour is not desired.
-    remote_transfer_eth_cores_ = {};
-    for (const auto& active_eth_core : active_eth_cores) {
-        auto virtual_coord =
-            local_chip_->get_soc_descriptor().translate_coord_to(active_eth_core, CoordSystem::VIRTUAL);
-        remote_transfer_eth_cores_.push_back(active_eth_core);
-    }
+    remote_transfer_eth_cores_.assign(remote_transfer_eth_cores.begin(), remote_transfer_eth_cores.end());
 }
 
-void RemoteCommunication::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) {
-    std::unordered_set<CoreCoord> active_eth_cores =
-        local_chip_->get_soc_descriptor().get_eth_cores_for_channels(channels);
-    set_remote_transfer_ethernet_cores(active_eth_cores);
+TTDevice* RemoteCommunication::get_local_device() {
+    return local_chip_;
 }
 
-CoreCoord RemoteCommunication::get_remote_transfer_ethernet_core() {
+tt_xy_pair RemoteCommunication::get_remote_transfer_ethernet_core() {
     if (remote_transfer_eth_cores_.size() > 8) {
         // We cannot use more than 8 cores for umd access in one direction. Thats because of the available buffering in
         // the outgoing eth channels.

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -129,9 +129,7 @@ void TopologyDiscovery::discover_remote_chips() {
             uint64_t remote_asic_id = get_remote_asic_id(chip, eth_core);
 
             if (discovered_chips.find(remote_asic_id) == discovered_chips.end()) {
-                std::unique_ptr<Chip> remote_chip = create_remote_chip(
-                    chip,
-                    eth_core);
+                std::unique_ptr<Chip> remote_chip = create_remote_chip(chip, eth_core);
 
                 chips_to_discover.emplace(remote_asic_id, std::move(remote_chip));
                 active_eth_channels_per_chip.emplace(remote_asic_id, std::set<uint32_t>());

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -126,16 +126,12 @@ void TopologyDiscovery::discover_remote_chips() {
                 continue;
             }
 
-            chip->set_remote_transfer_ethernet_cores(active_eth_channels_per_chip.at(current_chip_asic_id));
-
             uint64_t remote_asic_id = get_remote_asic_id(chip, eth_core);
 
             if (discovered_chips.find(remote_asic_id) == discovered_chips.end()) {
                 std::unique_ptr<Chip> remote_chip = create_remote_chip(
                     chip,
-                    eth_core,
-                    get_chip(remote_asic_id_to_mmio_chip_id.at(current_chip_asic_id)),
-                    active_eth_channels_per_chip.at(current_chip_asic_id));
+                    eth_core);
 
                 chips_to_discover.emplace(remote_asic_id, std::move(remote_chip));
                 active_eth_channels_per_chip.emplace(remote_asic_id, std::set<uint32_t>());

--- a/device/topology/topology_discovery_blackhole.cpp
+++ b/device/topology/topology_discovery_blackhole.cpp
@@ -25,8 +25,7 @@ TopologyDiscoveryBlackhole::TopologyDiscoveryBlackhole(
     std::unordered_set<chip_id_t> pci_target_devices, const std::string& sdesc_path) :
     TopologyDiscovery(pci_target_devices, sdesc_path) {}
 
-std::unique_ptr<RemoteChip> TopologyDiscoveryBlackhole::create_remote_chip(
-    Chip* gateway_chip, CoreCoord eth_core) {
+std::unique_ptr<RemoteChip> TopologyDiscoveryBlackhole::create_remote_chip(Chip* gateway_chip, CoreCoord eth_core) {
     return nullptr;
 }
 

--- a/device/topology/topology_discovery_blackhole.cpp
+++ b/device/topology/topology_discovery_blackhole.cpp
@@ -26,7 +26,7 @@ TopologyDiscoveryBlackhole::TopologyDiscoveryBlackhole(
     TopologyDiscovery(pci_target_devices, sdesc_path) {}
 
 std::unique_ptr<RemoteChip> TopologyDiscoveryBlackhole::create_remote_chip(
-    Chip* chip, tt_xy_pair eth_core, Chip* gateway_chip, std::set<uint32_t>& eth_channels_to_use) {
+    Chip* gateway_chip, CoreCoord eth_core) {
     return nullptr;
 }
 

--- a/device/topology/topology_discovery_wormhole.cpp
+++ b/device/topology/topology_discovery_wormhole.cpp
@@ -228,8 +228,7 @@ std::optional<eth_coord_t> TopologyDiscoveryWormhole::get_remote_eth_coord(Chip*
     return eth_coord;
 }
 
-std::unique_ptr<RemoteChip> TopologyDiscoveryWormhole::create_remote_chip(
-    Chip* gateway_chip, CoreCoord eth_core) {
+std::unique_ptr<RemoteChip> TopologyDiscoveryWormhole::create_remote_chip(Chip* gateway_chip, CoreCoord eth_core) {
     if (is_running_on_6u) {
         return nullptr;
     }

--- a/device/topology/topology_discovery_wormhole.cpp
+++ b/device/topology/topology_discovery_wormhole.cpp
@@ -229,17 +229,15 @@ std::optional<eth_coord_t> TopologyDiscoveryWormhole::get_remote_eth_coord(Chip*
 }
 
 std::unique_ptr<RemoteChip> TopologyDiscoveryWormhole::create_remote_chip(
-    Chip* chip, tt_xy_pair eth_core, Chip* gateway_chip, std::set<uint32_t>& eth_channels_to_use) {
+    Chip* gateway_chip, CoreCoord eth_core) {
     if (is_running_on_6u) {
         return nullptr;
     }
 
     auto local_chip = dynamic_cast<LocalChip*>(gateway_chip);
-    auto eth_coord = get_remote_eth_coord(chip, eth_core);
-    std::unordered_set<CoreCoord> eth_cores_to_use =
-        local_chip->get_soc_descriptor().get_eth_cores_for_channels(eth_channels_to_use, CoordSystem::TRANSLATED);
+    auto eth_coord = get_remote_eth_coord(gateway_chip, eth_core);
 
-    return RemoteChip::create(local_chip, eth_coord.value(), eth_cores_to_use, sdesc_path);
+    return RemoteChip::create(local_chip, eth_coord.value(), {eth_core}, sdesc_path);
 }
 
 uint32_t TopologyDiscoveryWormhole::get_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) {

--- a/device/tt_device/remote_wormhole_tt_device.cpp
+++ b/device/tt_device/remote_wormhole_tt_device.cpp
@@ -8,9 +8,8 @@
 namespace tt::umd {
 
 RemoteWormholeTTDevice::RemoteWormholeTTDevice(
-    LocalChip *local_chip, std::unique_ptr<RemoteCommunication> remote_communication, eth_coord_t target_chip) :
-    WormholeTTDevice(local_chip->get_tt_device()->get_pci_device()),
-    local_chip_(local_chip),
+    std::unique_ptr<RemoteCommunication> remote_communication, eth_coord_t target_chip) :
+    WormholeTTDevice(remote_communication->get_local_device()->get_pci_device()),
     target_chip_(target_chip),
     remote_communication_(std::move(remote_communication)) {
     is_remote_tt_device = true;
@@ -26,8 +25,6 @@ void RemoteWormholeTTDevice::write_to_device(const void *mem_ptr, tt_xy_pair cor
 }
 
 void RemoteWormholeTTDevice::wait_for_non_mmio_flush() { remote_communication_->wait_for_non_mmio_flush(); }
-
-LocalChip *RemoteWormholeTTDevice::get_local_chip() { return local_chip_; }
 
 RemoteCommunication *RemoteWormholeTTDevice::get_remote_communication() { return remote_communication_.get(); }
 

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -129,10 +129,10 @@ TEST(ApiTTDeviceTest, TestRemoteTTDevice) {
         chip_id_t gateway_id = cluster_desc->get_closest_mmio_capable_chip(remote_chip_id);
         LocalChip* closest_local_chip = cluster->get_local_chip(gateway_id);
         std::unique_ptr<RemoteCommunication> remote_communication =
-            std::make_unique<RemoteCommunication>(closest_local_chip, closest_local_chip->get_sysmem_manager());
-        remote_communication->set_remote_transfer_ethernet_cores(cluster_desc->get_active_eth_channels(gateway_id));
+            std::make_unique<RemoteCommunication>(closest_local_chip->get_tt_device(), closest_local_chip->get_sysmem_manager());
+        remote_communication->set_remote_transfer_ethernet_cores(closest_local_chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(cluster_desc->get_active_eth_channels(gateway_id), CoordSystem::TRANSLATED));
         std::unique_ptr<RemoteWormholeTTDevice> remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(
-            closest_local_chip, std::move(remote_communication), remote_eth_coord);
+            std::move(remote_communication), remote_eth_coord);
 
         std::vector<CoreCoord> tensix_cores =
             cluster->get_chip(remote_chip_id)->get_soc_descriptor().get_cores(CoreType::TENSIX);

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -128,11 +128,13 @@ TEST(ApiTTDeviceTest, TestRemoteTTDevice) {
 
         chip_id_t gateway_id = cluster_desc->get_closest_mmio_capable_chip(remote_chip_id);
         LocalChip* closest_local_chip = cluster->get_local_chip(gateway_id);
-        std::unique_ptr<RemoteCommunication> remote_communication =
-            std::make_unique<RemoteCommunication>(closest_local_chip->get_tt_device(), closest_local_chip->get_sysmem_manager());
-        remote_communication->set_remote_transfer_ethernet_cores(closest_local_chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(cluster_desc->get_active_eth_channels(gateway_id), CoordSystem::TRANSLATED));
-        std::unique_ptr<RemoteWormholeTTDevice> remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(
-            std::move(remote_communication), remote_eth_coord);
+        std::unique_ptr<RemoteCommunication> remote_communication = std::make_unique<RemoteCommunication>(
+            closest_local_chip->get_tt_device(), closest_local_chip->get_sysmem_manager());
+        remote_communication->set_remote_transfer_ethernet_cores(
+            closest_local_chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(
+                cluster_desc->get_active_eth_channels(gateway_id), CoordSystem::TRANSLATED));
+        std::unique_ptr<RemoteWormholeTTDevice> remote_tt_device =
+            std::make_unique<RemoteWormholeTTDevice>(std::move(remote_communication), remote_eth_coord);
 
         std::vector<CoreCoord> tensix_cores =
             cluster->get_chip(remote_chip_id)->get_soc_descriptor().get_cores(CoreType::TENSIX);

--- a/tests/wormhole/test_remote_communication_wh.cpp
+++ b/tests/wormhole/test_remote_communication_wh.cpp
@@ -26,7 +26,8 @@ TEST(RemoteCommunicationWormhole, BasicRemoteCommunicationIO) {
     LocalChip* local_chip = cluster->get_local_chip(mmio_chip_id);
     std::unique_ptr<RemoteCommunication> remote_comm =
         std::make_unique<RemoteCommunication>(local_chip->get_tt_device(), local_chip->get_sysmem_manager());
-    remote_comm->set_remote_transfer_ethernet_cores(local_chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(cluster->get_cluster_description()->get_active_eth_channels(mmio_chip_id), CoordSystem::TRANSLATED));
+    remote_comm->set_remote_transfer_ethernet_cores(local_chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(
+        cluster->get_cluster_description()->get_active_eth_channels(mmio_chip_id), CoordSystem::TRANSLATED));
 
     tt_ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
 

--- a/tests/wormhole/test_remote_communication_wh.cpp
+++ b/tests/wormhole/test_remote_communication_wh.cpp
@@ -23,11 +23,10 @@ TEST(RemoteCommunicationWormhole, BasicRemoteCommunicationIO) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
     chip_id_t mmio_chip_id = *cluster->get_target_mmio_device_ids().begin();
-    std::unique_ptr<RemoteCommunication> remote_comm = std::make_unique<RemoteCommunication>(
-        cluster->get_local_chip(mmio_chip_id), cluster->get_local_chip(mmio_chip_id)->get_sysmem_manager());
-
-    remote_comm->set_remote_transfer_ethernet_cores(
-        cluster->get_cluster_description()->get_active_eth_channels(mmio_chip_id));
+    LocalChip* local_chip = cluster->get_local_chip(mmio_chip_id);
+    std::unique_ptr<RemoteCommunication> remote_comm =
+        std::make_unique<RemoteCommunication>(local_chip->get_tt_device(), local_chip->get_sysmem_manager());
+    remote_comm->set_remote_transfer_ethernet_cores(local_chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(cluster->get_cluster_description()->get_active_eth_channels(mmio_chip_id), CoordSystem::TRANSLATED));
 
     tt_ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
 


### PR DESCRIPTION
### Issue
Final change for separating out the Chip and RemoteCommunication, #995 

### Description
Use TTDevice for RemoteCommunication

### List of the changes
- RemoteCommunication accepts TTDevice instead of LocalChip. Also doesn't use CoreCoord for set_remote_eth_cores but tt_xy_pair
- RemoteWormholeTTDevice accepts remotecommunication only, it doesn't need TTDevice, it can fetch it from remotecommunication. Changed so that it doesn't hold LocalChip but TTDevice, same as RemoteCommunication.
- Adjust TopologyDiscovery remote chip creation
- Change all other constructors accordingly
- Change RemoteCommunication to use TTDevice, changed read/write functions, and removed ->get_tt_device() calls

### Testing
Existing CI tests

### API Changes
API changes for RemoteCommunication, RemoteChip and RemoteWormholeTTDevice. Nothing is directly used currently by tt-metal, so no changes needed
