### PR TITLE
Implement TT_VISIBLE_DEVICES

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -1,0 +1,139 @@
+arch:
+  0: wormhole_b0
+  1: wormhole_b0
+  2: wormhole_b0
+  3: wormhole_b0
+chips:
+  0:
+    - 1
+    - 0
+    - 0
+    - 0
+  1:
+    - 1
+    - 1
+    - 0
+    - 0
+  2:
+    - 0
+    - 0
+    - 0
+    - 0
+  3:
+    - 0
+    - 1
+    - 0
+    - 0
+chip_unique_ids:
+  3: 14251340180
+  2: 14251340054
+  1: 9956372884
+  0: 9956372758
+ethernet_connections:
+  -
+    - chip: 0
+      chan: 8
+    - chip: 2
+      chan: 0
+  -
+    - chip: 0
+      chan: 9
+    - chip: 2
+      chan: 1
+  -
+    - chip: 0
+      chan: 14
+    - chip: 1
+      chan: 14
+  -
+    - chip: 0
+      chan: 15
+    - chip: 1
+      chan: 15
+  -
+    - chip: 1
+      chan: 8
+    - chip: 3
+      chan: 0
+  -
+    - chip: 1
+      chan: 9
+    - chip: 3
+      chan: 1
+  -
+    - chip: 2
+      chan: 6
+    - chip: 3
+      chan: 6
+  -
+    - chip: 2
+      chan: 7
+    - chip: 3
+      chan: 7
+ethernet_connections_to_remote_devices:
+  -
+    - chip: 1
+      chan: 7
+    - remote_chip_id: 9956434105
+      chan: 7
+  -
+    - chip: 1
+      chan: 6
+    - remote_chip_id: 9956434105
+      chan: 6
+  -
+    - chip: 0
+      chan: 1
+    - remote_chip_id: 9956372761
+      chan: 1
+  -
+    - chip: 0
+      chan: 0
+    - remote_chip_id: 9956372761
+      chan: 0
+chips_with_mmio:
+  - 0: 0
+  - 1: 1
+harvesting:
+  0:
+    noc_translation: true
+    harvest_mask: 576
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+  1:
+    noc_translation: true
+    harvest_mask: 640
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+  2:
+    noc_translation: true
+    harvest_mask: 516
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+  3:
+    noc_translation: true
+    harvest_mask: 768
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+chip_to_boardtype:
+  0: n300
+  1: n300
+  2: n300
+  3: n300
+boards:
+  -
+    - board_id: 72058990194995478
+    - board_type: n300
+    - chips:
+        - 2
+        - 0
+  -
+    - board_id: 72058990194995604
+    - board_type: n300
+    - chips:
+        - 3
+        - 1

--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -8,11 +8,13 @@
 
 #include <filesystem>
 #include <iostream>
+#include <optional>
 #include <string>
+#include <unordered_set>
 
 namespace tt::umd::utils {
 
-std::string get_abs_path(std::string path) {
+static std::string get_abs_path(std::string path) {
     // Note that __FILE__ might be resolved at compile time to an absolute or relative address, depending on the
     // compiler.
     std::filesystem::path current_file_path = std::filesystem::path(__FILE__);
@@ -26,6 +28,35 @@ std::string get_abs_path(std::string path) {
     }
     std::filesystem::path abs_path = umd_root / path;
     return abs_path.string();
+}
+
+static std::optional<std::string> get_env_var_value(const char* env_var_name) {
+    const char* env_var = std::getenv(env_var_name);
+    if (!env_var) {
+        return std::nullopt;
+    }
+    return std::string(env_var);
+}
+
+static std::optional<std::unordered_set<int>> get_unordered_set_from_string(const std::string& input) {
+    std::unordered_set<int> result_set;
+    std::stringstream ss(input);
+    std::string token;
+
+    while (std::getline(ss, token, ',')) {
+        try {
+            result_set.insert(std::stoi(token));
+        } catch (const std::exception& e) {
+            throw std::runtime_error(
+                fmt::format("Input string is not a valid set of integers: '{}'. Error: {}", input, e.what()));
+        }
+    }
+
+    if (result_set.empty()) {
+        return std::nullopt;
+    }
+
+    return result_set;
 }
 
 }  // namespace tt::umd::utils

--- a/device/api/umd/device/pci_device.hpp
+++ b/device/api/umd/device/pci_device.hpp
@@ -51,6 +51,8 @@ struct DmaBuffer {
     uint64_t completion_pa = 0;
 };
 
+constexpr const char *TT_VISIBLE_DEVICES_ENV = "TT_VISIBLE_DEVICES";
+
 class PCIDevice {
     const std::string device_path;   // Path to character device: /dev/tenstorrent/N
     const int pci_device_num;        // N in /dev/tenstorrent/N
@@ -62,6 +64,10 @@ class PCIDevice {
     const semver_t kmd_version;      // KMD version
     const bool iommu_enabled;        // Whether the system is protected from this device by an IOMMU
     DmaBuffer dma_buffer{};
+
+private:
+    static std::optional<std::unordered_set<int>> get_visible_devices(
+        const std::unordered_set<int> &pci_target_devices);
 
 public:
     /**

--- a/device/api/umd/device/pci_device.hpp
+++ b/device/api/umd/device/pci_device.hpp
@@ -51,7 +51,7 @@ struct DmaBuffer {
     uint64_t completion_pa = 0;
 };
 
-constexpr const char *TT_VISIBLE_DEVICES_ENV = "TT_VISIBLE_DEVICES";
+inline constexpr std::string_view TT_VISIBLE_DEVICES_ENV = "TT_VISIBLE_DEVICES";
 
 class PCIDevice {
     const std::string device_path;   // Path to character device: /dev/tenstorrent/N

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -189,7 +189,7 @@ std::optional<std::unordered_set<int>> PCIDevice::get_visible_devices(
         return pci_target_devices;
     }
 
-    const char *env_var = std::getenv(TT_VISIBLE_DEVICES_ENV);
+    const char *env_var = std::getenv(TT_VISIBLE_DEVICES_ENV.data());
     if (!env_var) {
         return std::nullopt;
     }
@@ -204,7 +204,10 @@ std::optional<std::unordered_set<int>> PCIDevice::get_visible_devices(
             visible_devices.insert(std::stoi(token));
         } catch (const std::exception &e) {
             throw std::runtime_error(fmt::format(
-                "Invalid device ID '{}' in {} environment variable: {}", token, TT_VISIBLE_DEVICES_ENV, e.what()));
+                "Invalid device ID '{}' in {} environment variable: {}",
+                token,
+                TT_VISIBLE_DEVICES_ENV.data(),
+                e.what()));
         }
     }
 

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -105,9 +105,8 @@ TEST(ApiClusterTest, OpenChipsByPciId) {
 
         std::string value = test_utils::convert_to_comma_separated_string(target_pci_device_ids);
 
-        if (setenv(TT_VISIBLE_DEVICES_ENV, value.c_str(), 1) != 0) {
-            std::cerr << "Failed to set environment variable." << std::endl;
-            return;
+        if (setenv(TT_VISIBLE_DEVICES_ENV.data(), value.c_str(), 1) != 0) {
+            ASSERT_TRUE(false) << "Failed to unset environment variable.";
         }
 
         // Make sure that Cluster construction is without exceptions.
@@ -116,9 +115,8 @@ TEST(ApiClusterTest, OpenChipsByPciId) {
             .pci_target_devices = {},
         });
 
-        if (unsetenv(TT_VISIBLE_DEVICES_ENV) != 0) {
-            std::cerr << "Failed to unset environment variable." << std::endl;
-            return;
+        if (unsetenv(TT_VISIBLE_DEVICES_ENV.data()) != 0) {
+            ASSERT_TRUE(false) << "Failed to unset environment variable.";
         }
     }
 }

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -115,6 +115,15 @@ TEST(ApiClusterTest, OpenChipsByPciId) {
             .pci_target_devices = {},
         });
 
+        if (!target_pci_device_ids.empty()) {
+            // If target_pci_device_ids is empty, then full cluster will be created, so skip the check.
+            // Check that the cluster has the expected number of chips.
+            auto actual_pci_device_ids = cluster->get_target_mmio_device_ids();
+            EXPECT_EQ(actual_pci_device_ids.size(), target_pci_device_ids.size());
+            // Always expect logical id 0 to exist, that's the way filtering by pci ids work.
+            EXPECT_TRUE(actual_pci_device_ids.find(0) != actual_pci_device_ids.end());
+        }
+
         if (unsetenv(TT_VISIBLE_DEVICES_ENV.data()) != 0) {
             ASSERT_TRUE(false) << "Failed to unset environment variable.";
         }

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -44,4 +44,17 @@ inline void fill_with_random_bytes(uint8_t* data, size_t n) {
     }
 }
 
+inline std::string convert_to_comma_separated_string(const std::unordered_set<int>& devices) {
+    std::ostringstream oss;
+    bool first = true;
+    for (int d : devices) {
+        if (!first) {
+            oss << ",";
+        }
+        oss << d;
+        first = false;
+    }
+    return oss.str();
+}
+
 }  // namespace test_utils

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
+#include <fmt/ranges.h>
 
 #include <cstdint>
 #include <random>
@@ -45,16 +46,7 @@ inline void fill_with_random_bytes(uint8_t* data, size_t n) {
 }
 
 inline std::string convert_to_comma_separated_string(const std::unordered_set<int>& devices) {
-    std::ostringstream oss;
-    bool first = true;
-    for (int d : devices) {
-        if (!first) {
-            oss << ",";
-        }
-        oss << d;
-        first = false;
-    }
-    return oss.str();
+    return fmt::format("{}", fmt::join(devices, ","));
 }
 
 }  // namespace test_utils

--- a/tools/topology.cpp
+++ b/tools/topology.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[]) {
         for (const auto &device : vec_devices) {
             oss << "," << device;
         }
-        if (setenv(TT_VISIBLE_DEVICES_ENV, oss.str().c_str(), 1) != 0) {
+        if (setenv(TT_VISIBLE_DEVICES_ENV.data(), oss.str().c_str(), 1) != 0) {
             throw std::runtime_error("Failed to set environment variable.");
         }
     }
@@ -63,7 +63,7 @@ int main(int argc, char *argv[]) {
     log_info(tt::LogSiliconDriver, "Cluster descriptor serialized to {}", output_path);
 
     if (result.count("pci_devices")) {
-        if (unsetenv(TT_VISIBLE_DEVICES_ENV) != 0) {
+        if (unsetenv(TT_VISIBLE_DEVICES_ENV.data()) != 0) {
             throw std::runtime_error("Failed to unset environment variable.");
         }
     }


### PR DESCRIPTION
### Issue

#1153 

### Description

Implement support for specifying visible devices by env var `TT_VISIBLE_DEVICES`. For now we are keeping the compatibility with specifying `pci_target_devices` as well because that's what metal relies on. In the future we should drop this API and have user only use `TT_VISIBLE_DEVICES`

### List of the changes

- Add support for `TT_VISIBLE_DEVICES` env var
- Keep compatibility with `pci_target_devices` API
- Change tests to test this as well
- Make topology tool use this path as well

### Testing

CI + manual testing on T3K

### API Changes
/
