### PR TITLE
Add debug logs to CI runs

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -14,6 +14,14 @@ on:
           - Debug
           - ASan
           - TSan
+      log-level:
+        required: false
+        default: info
+        type: choice
+        options:
+          - info
+          - debug
+          - trace
   pull_request:
   push:
     branches: ["main"]
@@ -60,3 +68,4 @@ jobs:
       ubuntu-docker-version: ${{ matrix.ubuntu-docker-version}}
       card: ${{ matrix.test-group.card}}
       timeout: ${{ matrix.test-group.timeout}}
+      log-level: ${{ inputs.log-level || 'info' }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -65,26 +65,26 @@ jobs:
 
       - name: Run API tests
         run: |
-          ${{ env.TEST_OUTPUT_DIR }}/umd/api/api_tests
+          TT_LOGGER_LEVEL=debug ${{ env.TEST_OUTPUT_DIR }}/umd/api/api_tests
 
       - name: Run arch-specific UMD unit tests
         if: ${{ inputs.arch != 'baremetal' }}
         run: |
-          ${{ env.TEST_OUTPUT_DIR }}/umd/${{ inputs.arch }}/unit_tests
+          TT_LOGGER_LEVEL=debug ${{ env.TEST_OUTPUT_DIR }}/umd/${{ inputs.arch }}/unit_tests
 
       - name: Run PCI tests
         run: |
-          ${{ env.TEST_OUTPUT_DIR }}/umd/test_pcie_device/test_pcie_device
+          TT_LOGGER_LEVEL=debug ${{ env.TEST_OUTPUT_DIR }}/umd/test_pcie_device/test_pcie_device
 
       - name: Run MISC tests
         run: |
-          ${{ env.TEST_OUTPUT_DIR }}/umd/misc/umd_misc_tests
+          TT_LOGGER_LEVEL=debug ${{ env.TEST_OUTPUT_DIR }}/umd/misc/umd_misc_tests
 
       - name: Run unified tests
         if: ${{ inputs.arch != 'baremetal' }}
         run: |
-          ${{ env.TEST_OUTPUT_DIR }}/umd/unified/unified_tests
+          TT_LOGGER_LEVEL=debug ${{ env.TEST_OUTPUT_DIR }}/umd/unified/unified_tests
 
       - name: Run python example tests
         run: |
-          PYTHONPATH=${{ env.BUILD_OUTPUT_DIR }}/nanobind/ pytest -s
+          TT_LOGGER_LEVEL=debug PYTHONPATH=${{ env.BUILD_OUTPUT_DIR }}/nanobind/ pytest -s

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,12 +16,16 @@ on:
       timeout:
         required: true
         type: number
+      log-level:
+        required: false
+        type: string
+        default: 'info'
 
 env:
   BUILD_OUTPUT_DIR: ./build
   TEST_OUTPUT_DIR: ./build/test
   CREATE_MAP_BINARIES_DIR: ./device/bin/silicon
-  TT_UMD_LOGGER_LEVEL: info
+  TT_LOGGER_LEVEL: ${{ inputs.log-level }}
 
 jobs:
   test:
@@ -65,26 +69,26 @@ jobs:
 
       - name: Run API tests
         run: |
-          TT_LOGGER_LEVEL=debug ${{ env.TEST_OUTPUT_DIR }}/umd/api/api_tests
+          ${{ env.TEST_OUTPUT_DIR }}/umd/api/api_tests
 
       - name: Run arch-specific UMD unit tests
         if: ${{ inputs.arch != 'baremetal' }}
         run: |
-          TT_LOGGER_LEVEL=debug ${{ env.TEST_OUTPUT_DIR }}/umd/${{ inputs.arch }}/unit_tests
+          ${{ env.TEST_OUTPUT_DIR }}/umd/${{ inputs.arch }}/unit_tests
 
       - name: Run PCI tests
         run: |
-          TT_LOGGER_LEVEL=debug ${{ env.TEST_OUTPUT_DIR }}/umd/test_pcie_device/test_pcie_device
+          ${{ env.TEST_OUTPUT_DIR }}/umd/test_pcie_device/test_pcie_device
 
       - name: Run MISC tests
         run: |
-          TT_LOGGER_LEVEL=debug ${{ env.TEST_OUTPUT_DIR }}/umd/misc/umd_misc_tests
+          ${{ env.TEST_OUTPUT_DIR }}/umd/misc/umd_misc_tests
 
       - name: Run unified tests
         if: ${{ inputs.arch != 'baremetal' }}
         run: |
-          TT_LOGGER_LEVEL=debug ${{ env.TEST_OUTPUT_DIR }}/umd/unified/unified_tests
+          ${{ env.TEST_OUTPUT_DIR }}/umd/unified/unified_tests
 
       - name: Run python example tests
         run: |
-          TT_LOGGER_LEVEL=debug PYTHONPATH=${{ env.BUILD_OUTPUT_DIR }}/nanobind/ pytest -s
+          PYTHONPATH=${{ env.BUILD_OUTPUT_DIR }}/nanobind/ pytest -s


### PR DESCRIPTION
### Issue
No specific issue, general debuggability. Related to #1002 

### Description
There are two switches which enable debugging. One is at compile time, and currently it is turned on by default on Debug configuration, and turned off by default for other configurations. The second switch is the one which I'm introducing in this PR on our CI runs. The effect should be as follows:
For our regular Release CI runs, no effect.
If Debug run is requested through CI, we should see additional logs, helping with the debuggability of issues directly from the CI.

### List of the changes
(Itemized list of all the changes.)

### Testing
(Comment on CI testing or Manual testing touching this change.)

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
