### PR TITLE
Fix Blackhole NOC1 translation

### DIFF
--- a/device/api/umd/device/types/blackhole_eth.h
+++ b/device/api/umd/device/types/blackhole_eth.h
@@ -44,14 +44,14 @@ typedef enum {
     PORT_UNUSED,
 } port_status_e;
 
-struct fw_version_t {
+typedef struct {
     uint32_t patch : 8;
     uint32_t minor : 8;
     uint32_t major : 8;
     uint32_t unused : 8;
-};
+} fw_version_t;
 
-struct chip_info_t {
+typedef struct {
     uint8_t pcb_type;  // 0
     uint8_t asic_location;
     uint8_t eth_id;
@@ -69,43 +69,29 @@ struct chip_info_t {
         chip_uid.asic_location = asic_location;
         return chip_uid;
     }
-};
+} chip_info_t;
 
-struct serdes_rx_bist_results_t {
+typedef struct {
     uint32_t bist_mode;  // 0
     uint32_t test_time;  // 1
     // test_time in cycles for bist mode 0 and ms for bist mode 1
     uint32_t error_cnt_nt[NUM_SERDES_LANES];           // 2-9
     uint32_t error_cnt_55t32_nt[NUM_SERDES_LANES];     // 10-17
     uint32_t error_cnt_overflow_nt[NUM_SERDES_LANES];  // 18-25
-};
+} serdes_rx_bist_results_t;
 
-struct eth_status_t {
+typedef struct {
     // Basic status
     uint32_t postcode;                 // 0
     port_status_e port_status;         // 1
     link_train_status_e train_status;  // 2
     uint32_t train_speed;              // 3 - Actual resulting speed from training
-
-    // Live status/retrain related
-    uint32_t retrain_count;   // 4
-    uint32_t mac_pcs_errors;  // 5
-    uint32_t corr_dw_hi;      // 6
-    uint32_t corr_dw_lo;      // 7
-    uint32_t uncorr_dw_hi;    // 8
-    uint32_t uncorr_dw_lo;    // 9
-    uint32_t frames_rxd_hi;   // 10
-    uint32_t frames_rxd_lo;   // 11
-    uint32_t bytes_rxd_hi;    // 12
-    uint32_t bytes_rxd_lo;    // 13
-
-    uint32_t spare[28 - 14];  // 14-27
-
+    uint32_t spare[28 - 4];            // 4-27
     // Heartbeat
     uint32_t heartbeat[4];  // 28-31
-};
+} eth_status_t;
 
-struct serdes_results_t {
+typedef struct {
     uint32_t postcode;           // 0
     uint32_t serdes_inst;        // 1
     uint32_t serdes_lane_mask;   // 2
@@ -113,11 +99,9 @@ struct serdes_results_t {
     uint32_t data_rate;          // 4
     uint32_t data_width;         // 5
     uint32_t spare_main[8 - 6];  // 6-7
-
     // Training retries
-    uint32_t lt_retry_cnt;   // 8
-    uint32_t spare[16 - 9];  // 9-15
-
+    uint32_t anlt_retry_cnt;  // 8
+    uint32_t spare[16 - 9];   // 9-15
     // BIST
     uint32_t bist_mode;       // 16
     uint32_t bist_test_time;  // 17
@@ -125,48 +109,74 @@ struct serdes_results_t {
     uint32_t bist_err_cnt_nt[NUM_SERDES_LANES];           // 18-25
     uint32_t bist_err_cnt_55t32_nt[NUM_SERDES_LANES];     // 26-33
     uint32_t bist_err_cnt_overflow_nt[NUM_SERDES_LANES];  // 34-41
-
-    uint32_t spare2[48 - 42];  // 42-47
-
+    uint32_t cdr_unlocked_cnt;                            // 42
+    uint32_t cdr_unlock_transitions;                      // 43
+    uint32_t spare2[48 - 44];                             // 44-47
     // Training times
     uint32_t man_eq_cmn_pstate_time;      // 48
     uint32_t man_eq_tx_ack_time;          // 49
     uint32_t man_eq_rx_ack_time;          // 50
-    uint32_t man_eq_rx_iffsm_time;        // 51
-    uint32_t man_eq_rx_eq_assert_time;    // 52
-    uint32_t man_eq_rx_eq_deassert_time;  // 53
-    uint32_t anlt_auto_neg_time;          // 54
-    uint32_t anlt_link_train_time;        // 55
+    uint32_t man_eq_rx_eq_assert_time;    // 51
+    uint32_t man_eq_rx_eq_deassert_time;  // 52
+    uint32_t anlt_auto_neg_time;          // 53
+    uint32_t anlt_link_train_time;        // 54
+    uint32_t anlt_retrain_time;           // 55
     uint32_t cdr_lock_time;               // 56
     uint32_t bist_lock_time;              // 57
+    uint32_t spare_time[64 - 58];         // 58-63
+} serdes_results_t;
 
-    uint32_t spare_time[64 - 58];  // 58-63
-};
-
-struct macpcs_results_t {
-    uint32_t postcode;  // 0
-
-    uint32_t spare[24 - 1];  // 1-23
-
+typedef struct {
+    uint32_t postcode;          // 0
+    uint32_t macpcs_retry_cnt;  // 1
+    uint32_t spare[24 - 2];     // 2-23
     // Training times
-    uint32_t link_up_time;    // 24
-    uint32_t chip_info_time;  // 25
-
+    uint32_t link_up_time;         // 24
+    uint32_t chip_info_time;       // 25
     uint32_t spare_time[32 - 26];  // 26-31
-};
+} macpcs_results_t;
 
-struct boot_results_t {
-    eth_status_t eth_status;          // 0-31
-    serdes_results_t serdes_results;  // 32 - 95
-    macpcs_results_t macpcs_results;  // 96 - 127
+typedef struct {
+    uint32_t retrain_count;  // 0
+    uint32_t rx_link_up;     // 1 - MAC/PCS RX Link Up
+    uint32_t spare[8 - 2];   // 2-7
+    // Snapshot registers
+    uint64_t frames_txd;          // 8,9 - Cumulative TX Packets Transmitted count
+    uint64_t frames_txd_ok;       // 10,11 - Cumulative TX Packets Transmitted OK count
+    uint64_t frames_txd_badfcs;   // 12,13 - Cumulative TX Packets Transmitted with BAD FCS count
+    uint64_t bytes_txd;           // 14,15 - Cumulative TX Bytes Transmitted count
+    uint64_t bytes_txd_ok;        // 16,17 - Cumulative TX Bytes Transmitted OK count
+    uint64_t bytes_txd_badfcs;    // 18,19 - Cumulative TX Bytes Transmitted with BAD FCS count
+    uint64_t frames_rxd;          // 20,21 - Cumulative Packets Received count
+    uint64_t frames_rxd_ok;       // 22,23 - Cumulative Packets Received OK count
+    uint64_t frames_rxd_badfcs;   // 24,25 - Cumulative Packets Received with BAD FCS count
+    uint64_t frames_rxd_dropped;  // 26,27 - Cumulative Dropped Packets Received count
+    uint64_t bytes_rxd;           // 28,29 - Cumulative Bytes received count
+    uint64_t bytes_rxd_ok;        // 30,31 - Cumulative Bytes received OK count
+    uint64_t bytes_rxd_badfcs;    // 32,33 - Cumulative Bytes received with BAD FCS count
+    uint64_t bytes_rxd_dropped;   // 34,35 - Cumulative Bytes received and dropped count
+    uint64_t corr_cw;             // 36,37 - Cumulative Corrected Codeword count
+    uint64_t uncorr_cw;           // 38,39 - Cumulative Uncorrected Codeword count
+    uint32_t spare2[64 - 40];     // 40-63
+} eth_live_status_t;
 
-    uint32_t spare[238 - 128];  // 128 - 237
+typedef struct {
+    uint32_t* eth_link_status_check_ptr;  // 0 - Pointer to the link status check function
+    uint32_t spare[16 - 1];               // 1-15
+} eth_api_table_t;
 
-    fw_version_t serdes_fw_ver;  // 238
-    fw_version_t eth_fw_ver;     // 239
-    chip_info_t local_info;      // 240 - 247
-    chip_info_t remote_info;     // 248 - 255
-};
+typedef struct {
+    eth_status_t eth_status;            // 0-31
+    serdes_results_t serdes_results;    // 32 - 95
+    macpcs_results_t macpcs_results;    // 96 - 127
+    eth_live_status_t eth_live_status;  // 128 - 191
+    eth_api_table_t eth_api_table;      // 192 - 207
+    uint32_t spare[238 - 208];          // 208 - 237
+    fw_version_t serdes_fw_ver;         // 238
+    fw_version_t eth_fw_ver;            // 239
+    chip_info_t local_info;             // 240 - 247
+    chip_info_t remote_info;            // 248 - 255
+} boot_results_t;
 
 constexpr uint32_t BOOT_RESULTS_ADDR = 0x7CC00;
 

--- a/device/api/umd/device/types/blackhole_eth.h
+++ b/device/api/umd/device/types/blackhole_eth.h
@@ -44,14 +44,14 @@ typedef enum {
     PORT_UNUSED,
 } port_status_e;
 
-typedef struct {
+struct fw_version_t {
     uint32_t patch : 8;
     uint32_t minor : 8;
     uint32_t major : 8;
     uint32_t unused : 8;
-} fw_version_t;
+};
 
-typedef struct {
+struct chip_info_t {
     uint8_t pcb_type;  // 0
     uint8_t asic_location;
     uint8_t eth_id;
@@ -69,18 +69,18 @@ typedef struct {
         chip_uid.asic_location = asic_location;
         return chip_uid;
     }
-} chip_info_t;
+};
 
-typedef struct {
+struct serdes_rx_bist_results_t {
     uint32_t bist_mode;  // 0
     uint32_t test_time;  // 1
     // test_time in cycles for bist mode 0 and ms for bist mode 1
     uint32_t error_cnt_nt[NUM_SERDES_LANES];           // 2-9
     uint32_t error_cnt_55t32_nt[NUM_SERDES_LANES];     // 10-17
     uint32_t error_cnt_overflow_nt[NUM_SERDES_LANES];  // 18-25
-} serdes_rx_bist_results_t;
+};
 
-typedef struct {
+struct eth_status_t {
     // Basic status
     uint32_t postcode;                 // 0
     port_status_e port_status;         // 1
@@ -89,9 +89,9 @@ typedef struct {
     uint32_t spare[28 - 4];            // 4-27
     // Heartbeat
     uint32_t heartbeat[4];  // 28-31
-} eth_status_t;
+};
 
-typedef struct {
+struct serdes_results_t {
     uint32_t postcode;           // 0
     uint32_t serdes_inst;        // 1
     uint32_t serdes_lane_mask;   // 2
@@ -124,9 +124,9 @@ typedef struct {
     uint32_t cdr_lock_time;               // 56
     uint32_t bist_lock_time;              // 57
     uint32_t spare_time[64 - 58];         // 58-63
-} serdes_results_t;
+};
 
-typedef struct {
+struct macpcs_results_t {
     uint32_t postcode;          // 0
     uint32_t macpcs_retry_cnt;  // 1
     uint32_t spare[24 - 2];     // 2-23
@@ -134,9 +134,9 @@ typedef struct {
     uint32_t link_up_time;         // 24
     uint32_t chip_info_time;       // 25
     uint32_t spare_time[32 - 26];  // 26-31
-} macpcs_results_t;
+};
 
-typedef struct {
+struct eth_live_status_t {
     uint32_t retrain_count;  // 0
     uint32_t rx_link_up;     // 1 - MAC/PCS RX Link Up
     uint32_t spare[8 - 2];   // 2-7
@@ -158,14 +158,14 @@ typedef struct {
     uint64_t corr_cw;             // 36,37 - Cumulative Corrected Codeword count
     uint64_t uncorr_cw;           // 38,39 - Cumulative Uncorrected Codeword count
     uint32_t spare2[64 - 40];     // 40-63
-} eth_live_status_t;
+};
 
-typedef struct {
+struct eth_api_table_t {
     uint32_t* eth_link_status_check_ptr;  // 0 - Pointer to the link status check function
     uint32_t spare[16 - 1];               // 1-15
-} eth_api_table_t;
+};
 
-typedef struct {
+struct boot_results_t {
     eth_status_t eth_status;            // 0-31
     serdes_results_t serdes_results;    // 32 - 95
     macpcs_results_t macpcs_results;    // 96 - 127
@@ -176,7 +176,7 @@ typedef struct {
     fw_version_t eth_fw_ver;            // 239
     chip_info_t local_info;             // 240 - 247
     chip_info_t remote_info;            // 248 - 255
-} boot_results_t;
+};
 
 constexpr uint32_t BOOT_RESULTS_ADDR = 0x7CC00;
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1106,18 +1106,13 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
 
         // TODO: Remove this when we can read asic location from the Blackhole telemetry.
         // Until then we have to read it from ETH core.
-        const std::vector<CoreCoord> eth_cores = chip->get_soc_descriptor().get_cores(
-            CoreType::ETH, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::TRANSLATED);
+        const std::vector<CoreCoord> eth_cores = chip->get_soc_descriptor().get_cores(CoreType::ETH);
         for (size_t eth_channel = 0; eth_channel < eth_cores.size(); eth_channel++) {
             const CoreCoord& eth_core = eth_cores[eth_channel];
-            TTDevice* tt_device = chip->get_tt_device();
             blackhole::boot_results_t boot_results;
 
-            tt_device->read_from_device(
-                (uint8_t*)&boot_results,
-                tt_xy_pair(eth_core.x, eth_core.y),
-                blackhole::BOOT_RESULTS_ADDR,
-                sizeof(boot_results));
+            chip->read_from_device(
+                eth_cores[eth_channel], (uint8_t*)&boot_results, blackhole::BOOT_RESULTS_ADDR, sizeof(boot_results));
 
             // We can read the asic location only from active ETH cores.
             if (boot_results.eth_status.port_status == blackhole::port_status_e::PORT_UP) {
@@ -1148,19 +1143,14 @@ std::unique_ptr<tt_ClusterDescriptor> Cluster::create_cluster_descriptor(
         const chip_id_t chip_id = it.first;
         const std::unique_ptr<Chip>& chip = it.second;
 
-        const std::vector<CoreCoord> eth_cores = chip->get_soc_descriptor().get_cores(
-            CoreType::ETH, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::TRANSLATED);
+        const std::vector<CoreCoord> eth_cores = chip->get_soc_descriptor().get_cores(CoreType::ETH);
 
         for (size_t eth_channel = 0; eth_channel < eth_cores.size(); eth_channel++) {
             const CoreCoord& eth_core = eth_cores[eth_channel];
-            TTDevice* tt_device = chip->get_tt_device();
             blackhole::boot_results_t boot_results;
 
-            tt_device->read_from_device(
-                (uint8_t*)&boot_results,
-                tt_xy_pair(eth_core.x, eth_core.y),
-                blackhole::BOOT_RESULTS_ADDR,
-                sizeof(boot_results));
+            chip->read_from_device(
+                eth_cores[eth_channel], (uint8_t*)&boot_results, blackhole::BOOT_RESULTS_ADDR, sizeof(boot_results));
 
             if (boot_results.eth_status.port_status == blackhole::port_status_e::PORT_UP) {
                 // active eth core

--- a/tests/api/test_noc.cpp
+++ b/tests/api/test_noc.cpp
@@ -70,7 +70,7 @@ TEST(TestNoc, TestNoc0NodeId) {
     }
 }
 
-TEST(TestNoc, DISABLED_TestNoc1NodeId) {
+TEST(TestNoc, TestNoc1NodeId) {
     TTDevice::use_noc1(true);
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();


### PR DESCRIPTION
### Issue

#1049 

### Description

Fix failing NOC1 test on Blackhole. Translation for different core types was not working resulting in NOC1 test to fail. Also the structure for ETH connection on BH changed with FW 18.5. Add new struct to blackhole_eth file

### List of the changes

- Fix translation for core types on Blackhole
- Fix translation for ETH cores when waiting for ETH core training
- Add new ETH struct

### Testing
CI

### API Changes
/
