### PR TITLE
Fixes needed for simulator to work

### DIFF
--- a/device/architecture_implementation.cpp
+++ b/device/architecture_implementation.cpp
@@ -11,6 +11,7 @@ namespace tt::umd {
 
 std::unique_ptr<architecture_implementation> architecture_implementation::create(tt::ARCH architecture) {
     switch (architecture) {
+        case tt::ARCH::QUASAR:  // TODO (#450): Add Quasar configuration
         case tt::ARCH::BLACKHOLE:
             return std::make_unique<blackhole_implementation>();
         case tt::ARCH::WORMHOLE_B0:

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -408,11 +408,12 @@ Cluster::Cluster(ClusterOptions options) {
             }
         }
         if (construct_mock_cluster_descriptor) {
-#ifdef TT_UMD_BUILD_SIMULATION
-            tt_SimulationDeviceInit init(options.simulator_directory);
-            auto arch = init.get_soc_descriptor().arch;
-#else
             auto arch = tt::ARCH::WORMHOLE_B0;
+#ifdef TT_UMD_BUILD_SIMULATION
+            if (options.chip_type == ChipType::SIMULATION) {
+                tt_SimulationDeviceInit init(options.simulator_directory);
+                arch = init.get_soc_descriptor().arch;
+            }
 #endif
             cluster_desc = tt_ClusterDescriptor::create_mock_cluster(chips_to_construct_vec, arch);
         }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -409,7 +409,8 @@ Cluster::Cluster(ClusterOptions options) {
         }
         if (construct_mock_cluster_descriptor) {
             tt_SimulationDeviceInit init(options.simulator_directory);
-            cluster_desc = tt_ClusterDescriptor::create_mock_cluster(chips_to_construct_vec, init.get_soc_descriptor().arch);
+            cluster_desc =
+                tt_ClusterDescriptor::create_mock_cluster(chips_to_construct_vec, init.get_soc_descriptor().arch);
         }
         if (options.sdesc_path.empty()) {
             options.sdesc_path = options.simulator_directory / "soc_descriptor.yaml";

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -412,10 +412,9 @@ Cluster::Cluster(ClusterOptions options) {
             tt_SimulationDeviceInit init(options.simulator_directory);
             auto arch = init.get_soc_descriptor().arch;
 #else
-            auto arch = tt::ARCH::WORMHOLE_B0
+            auto arch = tt::ARCH::WORMHOLE_B0;
 #endif
-            cluster_desc =
-                tt_ClusterDescriptor::create_mock_cluster(chips_to_construct_vec, arch);
+            cluster_desc = tt_ClusterDescriptor::create_mock_cluster(chips_to_construct_vec, arch);
         }
         if (options.sdesc_path.empty()) {
             options.sdesc_path = options.simulator_directory / "soc_descriptor.yaml";

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -416,7 +416,7 @@ Cluster::Cluster(ClusterOptions options) {
 #endif
             cluster_desc = tt_ClusterDescriptor::create_mock_cluster(chips_to_construct_vec, arch);
         }
-        if (options.sdesc_path.empty()) {
+        if (options.sdesc_path.empty() && options.chip_type == ChipType::SIMULATION) {
             options.sdesc_path = options.simulator_directory / "soc_descriptor.yaml";
         }
     }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -408,9 +408,14 @@ Cluster::Cluster(ClusterOptions options) {
             }
         }
         if (construct_mock_cluster_descriptor) {
+#ifdef TT_UMD_BUILD_SIMULATION
             tt_SimulationDeviceInit init(options.simulator_directory);
+            auto arch = init.get_soc_descriptor().arch;
+#else
+            auto arch = tt::ARCH::WORMHOLE_B0
+#endif
             cluster_desc =
-                tt_ClusterDescriptor::create_mock_cluster(chips_to_construct_vec, init.get_soc_descriptor().arch);
+                tt_ClusterDescriptor::create_mock_cluster(chips_to_construct_vec, arch);
         }
         if (options.sdesc_path.empty()) {
             options.sdesc_path = options.simulator_directory / "soc_descriptor.yaml";

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -408,7 +408,11 @@ Cluster::Cluster(ClusterOptions options) {
             }
         }
         if (construct_mock_cluster_descriptor) {
-            cluster_desc = tt_ClusterDescriptor::create_mock_cluster(chips_to_construct_vec, tt::ARCH::WORMHOLE_B0);
+            tt_SimulationDeviceInit init(options.simulator_directory);
+            cluster_desc = tt_ClusterDescriptor::create_mock_cluster(chips_to_construct_vec, init.get_soc_descriptor().arch);
+        }
+        if (options.sdesc_path.empty()) {
+            options.sdesc_path = options.simulator_directory / "soc_descriptor.yaml";
         }
     }
     for (auto& chip_id : chips_to_construct_vec) {

--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -544,9 +544,10 @@ std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_mock_cluster(
         case tt::ARCH::WORMHOLE_B0:
             board_type = BoardType::N150;
             break;
+        case tt::ARCH::QUASAR:  // TODO (#450): Add Quasar configuration
         case tt::ARCH::BLACKHOLE:
-            board_type = BoardType::P150;
-            harvesting_masks.pcie_harvesting_mask = 0x2;
+            board_type = BoardType::UNKNOWN;
+            harvesting_masks.pcie_harvesting_mask = 0x0;
             break;
         default:
             board_type = BoardType::UNKNOWN;

--- a/device/tt_soc_descriptor.cpp
+++ b/device/tt_soc_descriptor.cpp
@@ -88,10 +88,16 @@ void tt_SocDescriptor::write_core_locations(void *out, const CoreType &core_type
 
 void tt_SocDescriptor::serialize_dram_cores(void *out, const std::vector<std::vector<CoreCoord>> &cores) const {
     YAML::Emitter *emitter = static_cast<YAML::Emitter *>(out);
+    bool sequence_started = false;
 
     for (const auto &dram_cores : cores) {
         // Insert the dram core if it's within the given grid
         bool serialize_cores = true;
+
+        if (sequence_started) {
+            *emitter << YAML::EndSeq;
+            sequence_started = false;
+        }
 
         for (const auto &dram_core : dram_cores) {
             if ((dram_core.x > grid_size.x) || (dram_core.y > grid_size.y)) {
@@ -103,6 +109,7 @@ void tt_SocDescriptor::serialize_dram_cores(void *out, const std::vector<std::ve
             for (const auto &dram_core : dram_cores) {
                 if (dram_count % 3 == 0) {
                     *emitter << YAML::BeginSeq;
+                    sequence_started = true;
                 }
                 if (dram_core.x < grid_size.x && dram_core.y < grid_size.y) {
                     write_coords(emitter, dram_core);
@@ -113,6 +120,11 @@ void tt_SocDescriptor::serialize_dram_cores(void *out, const std::vector<std::ve
                 dram_count++;
             }
         }
+    }
+
+    if (sequence_started) {
+        *emitter << YAML::EndSeq;
+        sequence_started = false;
     }
 }
 

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -650,6 +650,22 @@ TEST(SocDescriptor, SocDescriptorSerialize) {
     }
 }
 
+TEST(SocDescriptor, SerializeSimulatorBlackhole) {
+    const tt_SocDescriptor& soc_descriptor =
+        tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/blackhole_simulation_1x2.yaml"), false);
+
+    std::filesystem::path file_path = soc_descriptor.serialize_to_file();
+    tt_SocDescriptor soc(file_path.string(), soc_descriptor.noc_translation_enabled, soc_descriptor.harvesting_masks);
+}
+
+TEST(SocDescriptor, SerializeSimulatorQuasar) {
+    const tt_SocDescriptor& soc_descriptor =
+        tt_SocDescriptor(test_utils::GetAbsPath("tests/soc_descs/quasar_simulation_1x1.yaml"), false);
+
+    std::filesystem::path file_path = soc_descriptor.serialize_to_file();
+    tt_SocDescriptor soc(file_path.string(), soc_descriptor.noc_translation_enabled, soc_descriptor.harvesting_masks);
+}
+
 TEST(SocDescriptor, SocDescriptorCreatFromSerialized) {
     HarvestingMasks harvesting_masks;
 

--- a/tests/soc_descs/quasar_simulation_1x1.yaml
+++ b/tests/soc_descs/quasar_simulation_1x1.yaml
@@ -1,6 +1,6 @@
 grid:
-  x_size: 2
-  y_size: 2
+  x_size: 1
+  y_size: 3
 
 arc:
   []
@@ -9,32 +9,22 @@ pcie:
   []
 
 dram:
-  [[1-0]]
+  [[0-0]]
 
 eth:
   []
 
 functional_workers:
-  [0-1, 1-1]
+  [0-1]
 
 harvested_workers:
   []
 
 router_only:
-  [0-0]
-
-noc0_x_to_noc1_x:
-  [
-   1, 0
-  ]
-
-noc0_y_to_noc1_y:
-  [
-    1, 0
-  ]
+  [0-2]
 
 worker_l1_size:
-  1572864
+  4194304
 
 dram_bank_size:
   1073741824
@@ -42,7 +32,7 @@ dram_bank_size:
 eth_l1_size:
   0
 
-arch_name: BLACKHOLE
+arch_name: QUASAR
 
 features:
   unpacker:


### PR DESCRIPTION
There were 4 issues:
- Even though we are using simulator, we still need to provide soc_descriptor to `ClusterOptions`
- There was hardcoded version to be used to create mock cluster for simulation (wormhole_b0)
- archutecture_implementation didn't know what to do with Quasar (it uses blackhole now, but that should be fixed with #450)
- Serialization of soc descriptor created invalid yaml file if dram doesn't have 3 end points (simulators have one or two)