### PR TITLE
Add new runner names

### DIFF
--- a/.github/workflows/build-and-run-all-benchmarks.yml
+++ b/.github/workflows/build-and-run-all-benchmarks.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {arch: wormhole_b0, card: tt-beta-ubuntu-2204-n150-viommu-large-stable, timeout: 45},
+          {arch: wormhole_b0, card: tt-ubuntu-2204-n150-viommu-stable, timeout: 45},
         ]
         ubuntu-docker-version: [
           'ubuntu-22.04',

--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -72,14 +72,14 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {arch: wormhole_b0, card: tt-beta-ubuntu-2204-n150-large-stable},
-          {arch: wormhole_b0, card: tt-beta-ubuntu-2204-n150-viommu-large-stable},
-          {arch: wormhole_b0, card: tt-beta-ubuntu-2204-n300-large-stable},
-          {arch: wormhole_b0, card: tt-beta-ubuntu-2204-n300-viommu-large-stable},
-          {arch: wormhole_b0, card: tt-beta-ubuntu-2204-n300-llmbox-large-stable},
+          {arch: wormhole_b0, card: tt-ubuntu-2204-n150-stable},
+          {arch: wormhole_b0, card: tt-ubuntu-2204-n150-viommu-stable},
+          {arch: wormhole_b0, card: tt-ubuntu-2204-n300-stable},
+          {arch: wormhole_b0, card: tt-ubuntu-2204-n300-viommu-stable},
+          {arch: wormhole_b0, card: tt-ubuntu-2204-n300-llmbox-stable},
           {arch: wormhole_b0, card: tt-ubuntu-2204-n300-llmbox-viommu-stable},
-          {arch: blackhole, card: tt-beta-ubuntu-2204-p150b-large-stable},
-          {arch: blackhole, card: tt-beta-ubuntu-2204-p150b-viommu-large-stable},
+          {arch: blackhole, card: tt-ubuntu-2204-p150b-stable},
+          {arch: blackhole, card: tt-ubuntu-2204-p150b-viommu-stable},
           {arch: baremetal, card: ubuntu-22.04},
         ]
         ubuntu-docker-version: [

--- a/.github/workflows/build-clients.yml
+++ b/.github/workflows/build-clients.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.timeout || '90') }}
 
     name: Build tt-metal with newest UMD
-    runs-on: tt-beta-ubuntu-2204-large
+    runs-on: tt-ubuntu-2204-large-stable
     container:
       image: ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest
       env:

--- a/.github/workflows/test-runner.yaml
+++ b/.github/workflows/test-runner.yaml
@@ -19,13 +19,15 @@ jobs:
         machine: [
           ubuntu-22.04,
           ubuntu-24.04,
-          n150,
-          n300,
-          p150,
-          tt-beta-ubuntu-2204-large,
-          tt-beta-ubuntu-2204-small,
-          tt-beta-ubuntu-2204-n300-large-stable,
-          tt-beta-ubuntu-2204-n150-large-stable]
+          tt-ubuntu-2204-large-stable,
+          tt-ubuntu-2204-n150-stable,
+          tt-ubuntu-2204-n150-viommu-stable,
+          tt-ubuntu-2204-n300-stable,
+          tt-ubuntu-2204-n300-viommu-stable,
+          tt-ubuntu-2204-n300-llmbox-stable,
+          tt-ubuntu-2204-n300-llmbox-viommu-stable,
+          tt-ubuntu-2204-p150b-stable,
+          tt-ubuntu-2204-p150b-viommu-stable]
 
     name: Check runner
     runs-on: ${{ matrix.machine }}
@@ -78,13 +80,15 @@ jobs:
         machine: [
           ubuntu-22.04,
           ubuntu-24.04,
-          n150,
-          n300,
-          p150,
-          tt-beta-ubuntu-2204-large,
-          tt-beta-ubuntu-2204-small,
-          tt-beta-ubuntu-2204-n300-large-stable,
-          tt-beta-ubuntu-2204-n150-large-stable]
+          tt-ubuntu-2204-large-stable,
+          tt-ubuntu-2204-n150-stable,
+          tt-ubuntu-2204-n150-viommu-stable,
+          tt-ubuntu-2204-n300-stable,
+          tt-ubuntu-2204-n300-viommu-stable,
+          tt-ubuntu-2204-n300-llmbox-stable,
+          tt-ubuntu-2204-n300-llmbox-viommu-stable,
+          tt-ubuntu-2204-p150b-stable,
+          tt-ubuntu-2204-p150b-viommu-stable]
         image: [tt-umd-ci-ubuntu-22.04, tt-umd-ci-ubuntu-24.04]
 
     name: Check runner docker


### PR DESCRIPTION
### Issue
Related to github-ci-infra message

### Description
Change the names to new runner names

### List of the changes
- Change the names of runners, drop the beta prefix
- Update test-runners yaml which was a bit outdated

### Testing
CI should show if the names are correct
And here is the test-runners run: https://github.com/tenstorrent/tt-umd/actions/runs/16931029292

### API Changes
There are no API changes in this PR.
