### PR TITLE
hugepage: Stop using a mounted hugetlbfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To determine whether your system requires hugepage configuration, run the provid
 
 ### Wormhole and Blackhole
 If your system IOMMU is enabled, no hugepage setup is required.
-If you don't have IOMMU enabled, than hugepages might be required for some of the driver functionality.
+If you don't have IOMMU enabled, then hugepages might be required for some of the driver functionality.
 [1G hugepages](https://www.kernel.org/doc/Documentation/admin-guide/mm/hugetlbpage.rst) are required for shared device/host memory.  Techniques for setup:
   * Recommended: the [tt-system-tools](https://github.com/tenstorrent/tt-system-tools) repository contains a .deb package which will configure your system
       * `sudo dpkg -i tenstorrent-tools_1.1-5_all.deb`
@@ -42,7 +42,6 @@ If you don't have IOMMU enabled, than hugepages might be required for some of th
   * For experts:
     * Put system IOMMU in passthrough mode or disable it
     * Allocate 1 or more 1G hugepages
-    * Mount the hugetlbfs at /dev/hugepages-1G (e.g. `mount -t hugetlbfs hugetlbfs /dev/hugepages-1G -o mode=777,pagesize=1024M`)
 
 ## Install and use UMD
 

--- a/device/api/umd/device/hugepage.h
+++ b/device/api/umd/device/hugepage.h
@@ -7,9 +7,6 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
-
-#include "umd/device/types/cluster_descriptor_types.h"
 
 namespace tt::umd {
 
@@ -23,14 +20,5 @@ uint32_t get_num_hugepages();
 // Dynamically figure out how many host memory channels (based on hugepages installed) for each device, based on arch.
 uint32_t get_available_num_host_mem_channels(
     const uint32_t num_channels_per_device_target, const uint16_t device_id, const uint16_t revision_id);
-
-// Looks for hugetlbfs inside /proc/mounts matching desired pagesize (typically 1G)
-std::string find_hugepage_dir(std::size_t pagesize);
-
-// Open a file in <hugepage_dir> for the hugepage mapping.
-// All processes operating on the same pipeline must agree on the file name.
-// Today we assume there's only one pipeline running within the system.
-// One hugepage per device such that each device gets unique memory.
-int open_hugepage_file(const std::string &dir, chip_id_t physical_device_id, uint16_t channel);
 
 }  // namespace tt::umd

--- a/device/hugepage.cpp
+++ b/device/hugepage.cpp
@@ -20,8 +20,6 @@ namespace tt::umd {
 
 const uint32_t g_MAX_HOST_MEM_CHANNELS = 4;
 
-const std::string hugepage_dir = "/dev/hugepages-1G";
-
 uint32_t get_num_hugepages() {
     std::string nr_hugepages_path = "/sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages";
     std::ifstream hugepages_file(nr_hugepages_path);
@@ -99,105 +97,6 @@ uint32_t get_available_num_host_mem_channels(
         g_MAX_HOST_MEM_CHANNELS);
 
     return num_channels_per_device_available;
-}
-
-std::string find_hugepage_dir(std::size_t pagesize) {
-    static const std::regex hugetlbfs_mount_re(
-        fmt::format("^(nodev|hugetlbfs) ({}) hugetlbfs ([^ ]+) 0 0$", hugepage_dir));
-    static const std::regex pagesize_re("(?:^|,)pagesize=([0-9]+)([KMGT])(?:,|$)");
-
-    std::ifstream proc_mounts("/proc/mounts");
-
-    for (std::string line; std::getline(proc_mounts, line);) {
-        if (std::smatch mount_match; std::regex_match(line, mount_match, hugetlbfs_mount_re)) {
-            std::string options = mount_match[3];
-            if (std::smatch pagesize_match; std::regex_search(options, pagesize_match, pagesize_re)) {
-                std::size_t mount_page_size = std::stoull(pagesize_match[1]);
-                switch (pagesize_match[2].str()[0]) {
-                    case 'T':
-                        mount_page_size <<= 10;
-                    case 'G':
-                        mount_page_size <<= 10;
-                    case 'M':
-                        mount_page_size <<= 10;
-                    case 'K':
-                        mount_page_size <<= 10;
-                }
-
-                if (mount_page_size == pagesize) {
-                    return mount_match[2];
-                }
-            }
-        }
-    }
-
-    log_warning(
-        LogSiliconDriver,
-        "ttSiliconDevice::find_hugepage_dir: no huge page mount found in /proc/mounts for path: {} with hugepage_size: "
-        "{}.",
-        hugepage_dir,
-        pagesize);
-    return std::string();
-}
-
-int open_hugepage_file(const std::string& dir, chip_id_t physical_device_id, uint16_t channel) {
-    std::vector<char> filename;
-    static const char pipeline_name[] = "tenstorrent";
-
-    filename.insert(filename.end(), dir.begin(), dir.end());
-    if (filename.back() != '/') {
-        filename.push_back('/');
-    }
-
-    // In order to limit number of hugepages while transition from shared hugepage (1 per system) to unique
-    // hugepage per device, will share original/shared hugepage filename with physical device 0.
-    if (physical_device_id != 0 || channel != 0) {
-        std::string device_id_str = fmt::format("device_{}_", physical_device_id);
-        filename.insert(filename.end(), device_id_str.begin(), device_id_str.end());
-    }
-
-    if (channel != 0) {
-        std::string channel_id_str = fmt::format("channel_{}_", channel);
-        filename.insert(filename.end(), channel_id_str.begin(), channel_id_str.end());
-    }
-
-    filename.insert(filename.end(), std::begin(pipeline_name), std::end(pipeline_name));  // includes NUL terminator
-
-    std::string filename_str(filename.begin(), filename.end());
-    filename_str.erase(
-        std::find(filename_str.begin(), filename_str.end(), '\0'),
-        filename_str.end());  // Erase NULL terminator for printing.
-    log_debug(
-        LogSiliconDriver,
-        "ttSiliconDevice::open_hugepage_file: using filename: {} for physical_device_id: {} channel: {}",
-        filename_str.c_str(),
-        physical_device_id,
-        channel);
-
-    // Save original and set umask to unrestricted.
-    auto old_umask = umask(0);
-
-    int fd =
-        open(filename.data(), O_RDWR | O_CREAT | O_CLOEXEC, S_IWUSR | S_IRUSR | S_IWGRP | S_IRGRP | S_IWOTH | S_IROTH);
-    if (fd == -1 && errno == EACCES) {
-        log_warning(
-            LogSiliconDriver,
-            "ttSiliconDevice::open_hugepage_file could not open filename: {} on first try, unlinking it and retrying.",
-            filename_str);
-        unlink(filename.data());
-        fd = open(
-            filename.data(), O_RDWR | O_CREAT | O_CLOEXEC, S_IWUSR | S_IRUSR | S_IWGRP | S_IRGRP | S_IWOTH | S_IROTH);
-    }
-
-    // Restore original mask
-    umask(old_umask);
-
-    if (fd == -1) {
-        log_warning(LogSiliconDriver, "open_hugepage_file failed");
-        return -1;
-    }
-
-    return fd;
 }
 
 }  // namespace tt::umd


### PR DESCRIPTION
The kernel's `hugetlbpage.rst` documentation states that mounting a `hugetlbfs` filesystem is not required when an application uses `mmap` with the `MAP_HUGETLB` flag.

This commit refactors the driver to adopt this simpler approach. It now allocates huge pages by calling `mmap` directly with the flags `MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_1GB`.

This change provides two main benefits:

1.  Simplified setup: Users no longer need to manually configure a `hugetlbfs` mount point.

2.  Simplified code: The logic for finding a mount point and managing backing files (`find_hugepage_dir`, `open_hugepage_file`) is no longer needed and has been removed.

### Issue
(Link to Github issue(s))

### Description
(Add freeform description.)

### List of the changes
(Itemized list of all the changes.)

### Testing
(Comment on CI testing or Manual testing touching this change.)

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
