### PR TITLE
Fix wheel artifact name

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -142,5 +142,6 @@ jobs:
       - name: Upload wheel
         uses: actions/upload-artifact@v4
         with:
+          # Note that wheel is built with hardcoded Release build type at the moment.
           name: wheel-artifact-${{ inputs.ubuntu-docker-version }}-${{ inputs.build-type }}
           path: ${{ env.WHEEL_OUTPUT_DIR }}


### PR DESCRIPTION
### Issue
Builds can fail with multiple build types
https://github.com/tenstorrent/tt-umd/actions/runs/17039709545

### Description

### List of the changes
- Add build type to artefact name

### Testing
CI test shows correct artefact name

### API Changes
There are no API changes in this PR.
