### PR TITLE
Rename tt_ClusterDescriptor

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -46,7 +46,7 @@ target_sources(
         logging/config.cpp
         pcie/pci_device.cpp
         tlb.cpp
-        tt_cluster_descriptor.cpp
+        cluster_descriptor.cpp
         tt_device/blackhole_tt_device.cpp
         tt_device/tt_device.cpp
         tt_device/wormhole_tt_device.cpp
@@ -121,7 +121,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/warm_reset.h
                 api/umd/device/semver.hpp
                 api/umd/device/utils/robust_mutex.h
-                api/umd/device/tt_cluster_descriptor.h
+                api/umd/device/cluster_descriptor.h
                 api/umd/device/tt_core_coordinates.h
                 api/umd/device/tt_device/blackhole_tt_device.h
                 api/umd/device/tt_device/tt_device.h

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -19,7 +19,7 @@
 #include "fmt/core.h"
 #include "tt_silicon_driver_common.hpp"
 #include "umd/device/chip/chip.h"
-#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/cluster_descriptor.h"
 #include "umd/device/tt_device/tt_device.h"
 #include "umd/device/tt_io.hpp"
 #include "umd/device/types/arch.h"
@@ -29,7 +29,7 @@
 
 namespace tt::umd {
 
-class tt_ClusterDescriptor;
+class ClusterDescriptor;
 class LocalChip;
 class RemoteChip;
 
@@ -89,11 +89,11 @@ struct ClusterOptions {
      */
     std::unordered_set<chip_id_t> pci_target_devices = {};
     /**
-     * If not passed, topology discovery will be ran and tt_ClusterDescriptor will be constructed. If passed, and chip
+     * If not passed, topology discovery will be ran and ClusterDescriptor will be constructed. If passed, and chip
      * type is SILICON, the constructor will throw if cluster_descriptor configuration shows chips which don't exist on
      * the system.
      */
-    tt_ClusterDescriptor* cluster_descriptor = nullptr;
+    ClusterDescriptor* cluster_descriptor = nullptr;
     /**
      * This parameter is used only for SIMULATION chip type.
      */
@@ -134,14 +134,14 @@ public:
      * soc descriptor yaml file passed to the constructor. If no soc descriptor is passed, the function will create a
      * cluster descriptor object based on the devices connected to the system.
      */
-    static std::unique_ptr<tt_ClusterDescriptor> create_cluster_descriptor(
+    static std::unique_ptr<ClusterDescriptor> create_cluster_descriptor(
         std::string sdesc_path = "", std::unordered_set<chip_id_t> pci_target_devices = {});
 
     /**
      * Get cluster descriptor object being used. This object contains topology information about the cluster.
-     * Consult tt_ClusterDescriptor documentation for more information on the cluster descriptor.
+     * Consult ClusterDescriptor documentation for more information on the cluster descriptor.
      */
-    tt_ClusterDescriptor* get_cluster_description();
+    ClusterDescriptor* get_cluster_description();
 
     /**
      * Get set of chip ids for all chips in the cluster.
@@ -651,7 +651,7 @@ private:
     std::unique_ptr<Chip> construct_chip_from_cluster(
         chip_id_t chip_id,
         const ChipType& chip_type,
-        tt_ClusterDescriptor* cluster_desc,
+        ClusterDescriptor* cluster_desc,
         SocDescriptor& soc_desc,
         int num_host_mem_channels,
         const std::filesystem::path& simulator_directory);
@@ -659,14 +659,14 @@ private:
         const std::string& soc_desc_path,
         chip_id_t chip_id,
         ChipType chip_type,
-        tt_ClusterDescriptor* cluster_desc,
+        ClusterDescriptor* cluster_desc,
         bool perform_harvesting,
         HarvestingMasks& simulated_harvesting_masks);
 
     void add_chip(const chip_id_t& chip_id, const ChipType& chip_type, std::unique_ptr<Chip> chip);
     HarvestingMasks get_harvesting_masks(
         chip_id_t chip_id,
-        tt_ClusterDescriptor* cluster_desc,
+        ClusterDescriptor* cluster_desc,
         bool perform_harvesting,
         HarvestingMasks& simulated_harvesting_masks);
     void construct_cluster(const uint32_t& num_host_mem_ch_per_mmio_device, const ChipType& chip_type);
@@ -681,7 +681,7 @@ private:
     tt::ARCH arch_name;
     tt::umd::ChipType chip_type_;
 
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc;
+    std::unique_ptr<ClusterDescriptor> cluster_desc;
 
     std::map<std::set<chip_id_t>, std::unordered_map<chip_id_t, std::vector<std::vector<int>>>> bcast_header_cache = {};
     bool use_ethernet_broadcast = true;

--- a/device/api/umd/device/cluster_descriptor.h
+++ b/device/api/umd/device/cluster_descriptor.h
@@ -309,3 +309,4 @@ private:
 
 // TODO: To be removed once clients switch to namespace usage.
 using tt::umd::ClusterDescriptor;
+using tt_ClusterDescriptor = tt::umd::ClusterDescriptor;

--- a/device/api/umd/device/cluster_descriptor.h
+++ b/device/api/umd/device/cluster_descriptor.h
@@ -30,14 +30,14 @@ class Node;
 namespace tt::umd {
 class Cluster;
 
-class tt_ClusterDescriptor {
+class ClusterDescriptor {
     // TODO: Only Topo Discovery should have access.
     friend class Cluster;
     friend class TopologyDiscovery;
 
 public:
     /* Construction related functions. */
-    tt_ClusterDescriptor() = default;
+    ClusterDescriptor() = default;
 
     /**
      * Serializes the cluster descriptor to a YAML string.
@@ -55,7 +55,7 @@ public:
      * Creates a cluster descriptor from a YAML file.
      * @param cluster_descriptor_file_path Path to the YAML file containing the cluster descriptor.
      */
-    static std::unique_ptr<tt_ClusterDescriptor> create_from_yaml(const std::string &cluster_descriptor_file_path);
+    static std::unique_ptr<ClusterDescriptor> create_from_yaml(const std::string &cluster_descriptor_file_path);
 
     /**
      * Creates a mock cluster descriptor with the given logical device IDs and architecture.
@@ -63,7 +63,7 @@ public:
      * @param logical_device_ids Vector of logical device IDs to be included in the mock cluster.
      * @param arch Architecture of the mock cluster.
      */
-    static std::unique_ptr<tt_ClusterDescriptor> create_mock_cluster(
+    static std::unique_ptr<ClusterDescriptor> create_mock_cluster(
         const std::vector<chip_id_t> &logical_device_ids, tt::ARCH arch);
 
     /**
@@ -72,8 +72,8 @@ public:
      * created.
      * @param target_chip_ids Set of logical chip IDs for filtering.
      */
-    static std::unique_ptr<tt_ClusterDescriptor> create_constrained_cluster_descriptor(
-        const tt_ClusterDescriptor *full_cluster_desc, const std::unordered_set<chip_id_t> &target_chip_ids);
+    static std::unique_ptr<ClusterDescriptor> create_constrained_cluster_descriptor(
+        const ClusterDescriptor *full_cluster_desc, const std::unordered_set<chip_id_t> &target_chip_ids);
 
     /* Getters for various chip related information. */
 
@@ -308,4 +308,4 @@ private:
 }  // namespace tt::umd
 
 // TODO: To be removed once clients switch to namespace usage.
-using tt::umd::tt_ClusterDescriptor;
+using tt::umd::ClusterDescriptor;

--- a/device/api/umd/device/topology/topology_discovery.h
+++ b/device/api/umd/device/topology/topology_discovery.h
@@ -9,22 +9,22 @@
 
 #include "umd/device/chip/chip.h"
 #include "umd/device/chip/remote_chip.h"
-#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/cluster_descriptor.h"
 #include "umd/device/tt_device/remote_wormhole_tt_device.h"
 #include "umd/device/tt_device/tt_device.h"
 
 namespace tt::umd {
 
-class tt_ClusterDescriptor;
+class ClusterDescriptor;
 
 // TopologyDiscovery class creates cluster descriptor by discovering all chips connected to the system.
 class TopologyDiscovery {
 public:
-    static std::unique_ptr<tt_ClusterDescriptor> create_cluster_descriptor(
+    static std::unique_ptr<ClusterDescriptor> create_cluster_descriptor(
         std::unordered_set<chip_id_t> pci_target_devices = {}, const std::string& sdesc_path = "");
     TopologyDiscovery(std::unordered_set<chip_id_t> pci_target_devices = {}, const std::string& sdesc_path = "");
     virtual ~TopologyDiscovery() = default;
-    std::unique_ptr<tt_ClusterDescriptor> create_ethernet_map();
+    std::unique_ptr<ClusterDescriptor> create_ethernet_map();
 
 protected:
     void get_pcie_connected_chips();
@@ -112,7 +112,7 @@ protected:
     std::vector<std::pair<std::pair<uint64_t, uint32_t>, std::pair<uint64_t, uint32_t>>>
         ethernet_connections_to_remote_devices;
 
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc;
+    std::unique_ptr<ClusterDescriptor> cluster_desc;
 
     std::unordered_set<chip_id_t> pci_target_devices = {};
 

--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -1,7 +1,0 @@
-/*
- * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-// TODO: To be removed once clients switch to including the other header.
-#include "umd/device/cluster_descriptor.h"

--- a/device/api/umd/device/tt_cluster_descriptor.h
+++ b/device/api/umd/device/tt_cluster_descriptor.h
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+// TODO: To be removed once clients switch to including the other header.
+#include "umd/device/cluster_descriptor.h"

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -98,7 +98,7 @@ private:
     std::set<chip_id_t> target_devices_in_cluster = {};
     std::set<chip_id_t> target_remote_chips = {};
     tt::ARCH arch_name;
-    std::shared_ptr<tt_ClusterDescriptor> cluster_descriptor;
+    std::shared_ptr<ClusterDescriptor> cluster_descriptor;
     std::unordered_map<chip_id_t, SocDescriptor> soc_descriptor_per_chip = {};
 
     // To enable DPRINT usage in the Simulator,

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -12,8 +12,8 @@
 #include "api/umd/device/topology/topology_discovery_wormhole.h"
 #include "umd/device/arch/wormhole_implementation.h"
 #include "umd/device/chip/local_chip.h"
+#include "umd/device/cluster_descriptor.h"
 #include "umd/device/remote_communication.h"
-#include "umd/device/tt_cluster_descriptor.h"
 #include "umd/device/tt_device/remote_wormhole_tt_device.h"
 #include "umd/device/types/cluster_types.h"
 
@@ -21,11 +21,11 @@ extern bool umd_use_noc1;
 
 namespace tt::umd {
 
-std::unique_ptr<tt_ClusterDescriptor> TopologyDiscovery::create_cluster_descriptor(
+std::unique_ptr<ClusterDescriptor> TopologyDiscovery::create_cluster_descriptor(
     std::unordered_set<chip_id_t> pci_target_devices, const std::string& sdesc_path) {
     auto pci_devices_info = PCIDevice::enumerate_devices_info(pci_target_devices);
     if (pci_devices_info.empty()) {
-        return std::make_unique<tt_ClusterDescriptor>();
+        return std::make_unique<ClusterDescriptor>();
     }
 
     switch (pci_devices_info.begin()->second.get_arch()) {
@@ -41,9 +41,9 @@ std::unique_ptr<tt_ClusterDescriptor> TopologyDiscovery::create_cluster_descript
 TopologyDiscovery::TopologyDiscovery(std::unordered_set<chip_id_t> pci_target_devices, const std::string& sdesc_path) :
     pci_target_devices(pci_target_devices), sdesc_path(sdesc_path) {}
 
-std::unique_ptr<tt_ClusterDescriptor> TopologyDiscovery::create_ethernet_map() {
+std::unique_ptr<ClusterDescriptor> TopologyDiscovery::create_ethernet_map() {
     init_topology_discovery();
-    cluster_desc = std::unique_ptr<tt_ClusterDescriptor>(new tt_ClusterDescriptor());
+    cluster_desc = std::unique_ptr<ClusterDescriptor>(new ClusterDescriptor());
     get_pcie_connected_chips();
     discover_remote_chips();
     fill_cluster_descriptor_info();

--- a/device/topology/topology_discovery_blackhole.cpp
+++ b/device/topology/topology_discovery_blackhole.cpp
@@ -11,8 +11,8 @@
 #include "umd/device/arch/blackhole_implementation.h"
 #include "umd/device/chip/local_chip.h"
 #include "umd/device/chip/remote_chip.h"
+#include "umd/device/cluster_descriptor.h"
 #include "umd/device/remote_communication.h"
-#include "umd/device/tt_cluster_descriptor.h"
 #include "umd/device/types/blackhole_eth.h"
 #include "umd/device/types/cluster_types.h"
 

--- a/docs/CUSTOM_MODIFICATION_GUIDE.md
+++ b/docs/CUSTOM_MODIFICATION_GUIDE.md
@@ -18,7 +18,7 @@ It is important to note that this file is not utilized by UMD, and therefore, fu
 
 ## API changes
 
-At the moment, most of the API that needs to be reimplemented for custom SoC is located in the [cluster.h](../device/api/umd/device/cluster.h) file and in the [tt_cluster_descriptor.h](../device/api/umd/device/tt_cluster_descriptor.h). The files have header comments on all the functions which are the current contract with higher software stacks like tt-metal.
+At the moment, most of the API that needs to be reimplemented for custom SoC is located in the [cluster.h](../device/api/umd/device/cluster.h) file and in the [cluster_descriptor.h](../device/api/umd/device/cluster_descriptor.h). The files have header comments on all the functions which are the current contract with higher software stacks like tt-metal.
 
 The current implementation maintains a SocDescriptor for each chip. This functionality must also be implemented within the class derived from a custom Chip, as there is an API available to retrieve the descriptors.
 

--- a/nanobind/py_api_topology_discovery.cpp
+++ b/nanobind/py_api_topology_discovery.cpp
@@ -11,8 +11,8 @@
 #include <nanobind/stl/unordered_set.h>
 #include <nanobind/stl/vector.h>
 
+#include "umd/device/cluster_descriptor.h"
 #include "umd/device/topology/topology_discovery.h"
-#include "umd/device/tt_cluster_descriptor.h"
 
 namespace nb = nanobind;
 

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -17,7 +17,7 @@
 // TODO: change to tt_cluster
 #include "umd/device/arch/architecture_implementation.h"
 #include "umd/device/cluster.h"
-#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/cluster_descriptor.h"
 
 using namespace tt::umd;
 

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -26,7 +26,7 @@
 #include "umd/device/chip/local_chip.h"
 #include "umd/device/chip/mock_chip.h"
 #include "umd/device/cluster.h"
-#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/cluster_descriptor.h"
 #include "umd/device/tt_core_coordinates.h"
 #include "umd/device/tt_silicon_driver_common.hpp"
 #include "umd/device/types/arch.h"
@@ -137,7 +137,7 @@ TEST(ApiClusterTest, OpenClusterByLogicalID) {
     std::filesystem::path cluster_path = Cluster::create_cluster_descriptor()->serialize_to_file();
 
     // Now, the user can create the cluster descriptor without touching the devices.
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(cluster_path);
+    std::unique_ptr<ClusterDescriptor> cluster_desc = ClusterDescriptor::create_from_yaml(cluster_path);
     // You can test the cluster descriptor here to see if the topology matched the one you'd expect.
     // For example, you can check if the number of chips is correct, or number of pci devices, or nature of eth
     // connections.
@@ -217,7 +217,7 @@ TEST(ApiClusterTest, DifferentConstructors) {
     std::filesystem::path cluster_path2 = umd_cluster->get_cluster_description()->serialize_to_file();
     umd_cluster = nullptr;
 
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(cluster_path1);
+    std::unique_ptr<ClusterDescriptor> cluster_desc = ClusterDescriptor::create_from_yaml(cluster_path1);
     umd_cluster = std::make_unique<Cluster>(ClusterOptions{
         .cluster_descriptor = cluster_desc.get(),
     });
@@ -234,7 +234,7 @@ TEST(ApiClusterTest, DifferentConstructors) {
 TEST(ApiClusterTest, SimpleIOAllSiliconChips) {
     std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
 
-    const tt_ClusterDescriptor* cluster_desc = umd_cluster->get_cluster_description();
+    const ClusterDescriptor* cluster_desc = umd_cluster->get_cluster_description();
 
     // Initialize random data.
     size_t data_size = 1024;
@@ -277,7 +277,7 @@ TEST(ApiClusterTest, SimpleIOAllSiliconChips) {
 TEST(ApiClusterTest, RemoteFlush) {
     std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
 
-    const tt_ClusterDescriptor* cluster_desc = umd_cluster->get_cluster_description();
+    const ClusterDescriptor* cluster_desc = umd_cluster->get_cluster_description();
 
     size_t data_size = 1024;
     std::vector<uint8_t> data(data_size, 0);
@@ -326,7 +326,7 @@ TEST(ApiClusterTest, SimpleIOSpecificSiliconChips) {
         .target_devices = {0},
     });
 
-    const tt_ClusterDescriptor* cluster_desc = umd_cluster->get_cluster_description();
+    const ClusterDescriptor* cluster_desc = umd_cluster->get_cluster_description();
 
     // Initialize random data.
     size_t data_size = 1024;
@@ -459,7 +459,7 @@ TEST(TestCluster, PrintAllSiliconChipsAllCores) {
 TEST(TestCluster, TestClusterLogicalETHChannelsConnectivity) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
-    tt_ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
+    ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
 
     for (auto [chip, connections] : cluster_desc->get_ethernet_connections()) {
         const uint32_t num_channels_local_chip = cluster->get_soc_descriptor(chip).get_cores(CoreType::ETH).size();

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -9,8 +9,8 @@
 #include "disjoint_set.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "umd/device/cluster.h"
+#include "umd/device/cluster_descriptor.h"
 #include "umd/device/pci_device.hpp"
-#include "umd/device/tt_cluster_descriptor.h"
 
 using namespace tt::umd;
 
@@ -25,7 +25,7 @@ int count_connections(const std::unordered_map<
 }
 
 TEST(ApiClusterDescriptorTest, DetectArch) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
+    std::unique_ptr<ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
 
     if (cluster_desc->get_number_of_chips() == 0) {
         // Expect it to be invalid if no devices are found.
@@ -57,7 +57,7 @@ TEST(ApiClusterDescriptorTest, DetectArch) {
 }
 
 TEST(ApiClusterDescriptorTest, BasicFunctionality) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
+    std::unique_ptr<ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
 
     if (cluster_desc == nullptr) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
@@ -85,7 +85,7 @@ TEST(ApiClusterDescriptorTest, BasicFunctionality) {
 }
 
 TEST(ApiClusterDescriptorTest, EthernetConnectivity) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
+    std::unique_ptr<ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
 
     if (cluster_desc == nullptr) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
@@ -161,7 +161,7 @@ TEST(ApiClusterDescriptorTest, PrintClusterDescriptor) {
 }
 
 TEST(ApiClusterDescriptorTest, VerifyEthConnections) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
+    std::unique_ptr<ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
 
     std::unordered_map<chip_id_t, std::unordered_map<ethernet_channel_t, std::tuple<chip_id_t, ethernet_channel_t>>>
         eth_connections = cluster_desc->get_ethernet_connections();
@@ -187,7 +187,7 @@ TEST(ApiClusterDescriptorTest, VerifyEthConnections) {
  * expected.
  */
 TEST(ApiClusterDescriptorTest, VerifyStandardTopology) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
+    std::unique_ptr<ClusterDescriptor> cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
 
     auto all_chips = cluster_desc->get_all_chips();
 

--- a/tests/api/test_noc.cpp
+++ b/tests/api/test_noc.cpp
@@ -7,7 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "umd/device/cluster.h"
-#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/cluster_descriptor.h"
 
 using namespace tt::umd;
 

--- a/tests/api/test_software_harvesting.cpp
+++ b/tests/api/test_software_harvesting.cpp
@@ -10,7 +10,7 @@
 #include "umd/device/arch/blackhole_implementation.h"
 #include "umd/device/arch/wormhole_implementation.h"
 #include "umd/device/cluster.h"
-#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/cluster_descriptor.h"
 
 using namespace tt::umd;
 

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -170,7 +170,7 @@ TEST(ApiTTDeviceTest, TTDeviceWarmResetAfterNocHang) {
 TEST(ApiTTDeviceTest, TestRemoteTTDevice) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
-    tt_ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
+    ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
 
     auto chip_locations = cluster_desc->get_chip_locations();
 

--- a/tests/baremetal/test_cluster_descriptor_offline.cpp
+++ b/tests/baremetal/test_cluster_descriptor_offline.cpp
@@ -9,7 +9,7 @@
 #include "disjoint_set.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "umd/device/cluster.h"
-#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/cluster_descriptor.h"
 
 using namespace tt::umd;
 
@@ -37,7 +37,7 @@ TEST(ApiClusterDescriptorOfflineTest, TestAllOfflineClusterDescriptors) {
              "wormhole_N300_with_remote_connections.yaml",
          }) {
         std::cout << "Testing " << cluster_desc_yaml << std::endl;
-        std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(
+        std::unique_ptr<ClusterDescriptor> cluster_desc = ClusterDescriptor::create_from_yaml(
             test_utils::GetAbsPath("tests/cluster_descriptor_examples/" + cluster_desc_yaml));
 
         std::unordered_set<chip_id_t> all_chips = cluster_desc->get_all_chips();
@@ -59,7 +59,7 @@ TEST(ApiClusterDescriptorOfflineTest, TestAllOfflineClusterDescriptors) {
 }
 
 TEST(ApiClusterDescriptorOfflineTest, SeparateClusters) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(
+    std::unique_ptr<ClusterDescriptor> cluster_desc = ClusterDescriptor::create_from_yaml(
         test_utils::GetAbsPath("tests/cluster_descriptor_examples/wormhole_2xN300_unconnected.yaml"));
 
     auto all_chips = cluster_desc->get_all_chips();
@@ -88,7 +88,7 @@ TEST(ApiClusterDescriptorOfflineTest, SeparateClusters) {
 }
 
 TEST(ApiClusterDescriptorOfflineTest, ConstrainedTopology) {
-    std::unique_ptr<tt_ClusterDescriptor> cluster_desc = tt_ClusterDescriptor::create_from_yaml(
+    std::unique_ptr<ClusterDescriptor> cluster_desc = ClusterDescriptor::create_from_yaml(
         test_utils::GetAbsPath("tests/cluster_descriptor_examples/wormhole_4xN300_mesh.yaml"));
 
     // Lambda which counts of unique chip links.
@@ -123,7 +123,7 @@ TEST(ApiClusterDescriptorOfflineTest, ConstrainedTopology) {
     EXPECT_EQ(cluster_desc->get_chip_locations().size(), 8);
 
     // Create with just two PCI chips
-    std::unique_ptr<tt_ClusterDescriptor> constrained_cluster_desc =
+    std::unique_ptr<ClusterDescriptor> constrained_cluster_desc =
         cluster_desc->create_constrained_cluster_descriptor(cluster_desc.get(), {0, 1});
 
     EXPECT_EQ(constrained_cluster_desc->get_chips_with_mmio().size(), 2);

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -14,7 +14,7 @@
 #include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "umd/device/arch/blackhole_implementation.h"
-#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/cluster_descriptor.h"
 
 using namespace tt::umd;
 
@@ -84,7 +84,7 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //     std::set<chip_id_t> target_devices = {0, 1};
 //     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 30}, {1, 60}};
 //     {
-//         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
+//         std::unique_ptr<ClusterDescriptor> cluster_desc_uniq =
 //             Cluster::create_cluster_descriptor();
 //         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
 //             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
@@ -113,7 +113,7 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //     std::set<chip_id_t> target_devices = {0, 1};
 //     std::unordered_map<chip_id_t, uint32_t> simulated_harvesting_masks = {{0, 30}, {1, 60}};
 //     {
-//         std::unique_ptr<tt_ClusterDescriptor> cluster_desc_uniq =
+//         std::unique_ptr<ClusterDescriptor> cluster_desc_uniq =
 //             Cluster::create_cluster_descriptor();
 //         if (cluster_desc_uniq->get_number_of_chips() != target_devices.size()) {
 //             GTEST_SKIP() << "SiliconDriverWH.Harvesting skipped because it can only be run on a two chip nebula
@@ -827,7 +827,7 @@ TEST(ClusterBH, TotalNumberOfEthCores) {
 
     const uint32_t num_eth_cores = cluster->get_soc_descriptor(0).get_cores(CoreType::ETH).size();
 
-    tt_ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
+    ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
     const uint32_t num_active_channels = cluster_desc->get_active_eth_channels(0).size();
     const uint32_t num_idle_channels = cluster_desc->get_idle_eth_channels(0).size();
 

--- a/tests/galaxy/test_umd_concurrent_threads.cpp
+++ b/tests/galaxy/test_umd_concurrent_threads.cpp
@@ -13,7 +13,7 @@
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/wormhole/test_wh_common.h"
 #include "umd/device/cluster.h"
-#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/cluster_descriptor.h"
 #include "wormhole/eth_interface.h"
 #include "wormhole/host_mem_address_map.h"
 #include "wormhole/l1_address_map.h"
@@ -22,7 +22,7 @@
 TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
     // Galaxy Setup
 
-    std::shared_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
+    std::shared_ptr<ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
     std::set<chip_id_t> target_devices_th1 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
     std::set<chip_id_t> target_devices_th2 = {17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32};
     std::unordered_set<chip_id_t> all_devices = {};
@@ -115,7 +115,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
 
 TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
     // Galaxy Setup
-    std::shared_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
+    std::shared_ptr<ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
     std::set<chip_id_t> target_devices_th1 = {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32};
     std::set<chip_id_t> target_devices_th2 = {1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31};
     std::unordered_set<chip_id_t> all_devices = {};
@@ -199,7 +199,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
 
 TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
     // Galaxy Setup
-    std::shared_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
+    std::shared_ptr<ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
     std::unordered_set<chip_id_t> target_devices = {0, 1, 2, 3, 4, 5, 6, 7, 8};
     for (const auto& chip : target_devices) {
         // Verify that selected chips are in the cluster

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -12,7 +12,7 @@
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/wormhole/test_wh_common.h"
 #include "umd/device/cluster.h"
-#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/cluster_descriptor.h"
 #include "wormhole/eth_interface.h"
 #include "wormhole/host_mem_address_map.h"
 #include "wormhole/l1_address_map.h"

--- a/tests/galaxy/test_umd_remote_api_stability.cpp
+++ b/tests/galaxy/test_umd_remote_api_stability.cpp
@@ -15,8 +15,8 @@
 #include "tests/test_utils/stimulus_generators.hpp"
 #include "tests/wormhole/test_wh_common.h"
 #include "umd/device/cluster.h"
+#include "umd/device/cluster_descriptor.h"
 #include "umd/device/soc_descriptor.h"
-#include "umd/device/tt_cluster_descriptor.h"
 #include "wormhole/eth_interface.h"
 #include "wormhole/host_mem_address_map.h"
 #include "wormhole/l1_address_map.h"
@@ -33,7 +33,7 @@ protected:
     static uint32_t scale_number_of_tests;
 
     static void SetUpTestSuite() {
-        std::unique_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
+        std::unique_ptr<ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
         detected_num_chips = cluster_desc->get_number_of_chips();
         if (detected_num_chips < EXPECTED_MIN_CHIPS) {
             skip_tests = true;

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -12,7 +12,7 @@
 #include <vector>
 
 #include "umd/device/cluster.h"
-#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/cluster_descriptor.h"
 
 using namespace tt::umd;
 

--- a/tests/test_utils/stimulus_generators.hpp
+++ b/tests/test_utils/stimulus_generators.hpp
@@ -13,7 +13,7 @@
 #include <vector>
 
 #include "umd/device/cluster.h"
-#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/cluster_descriptor.h"
 #include "umd/device/tt_xy_pair.h"
 
 /* Sizes:
@@ -347,7 +347,7 @@ template <typename T>
 static auto passthrough_constrainer = [](T const& t) -> T { return t; };
 
 static inline std::vector<destination_t> generate_core_index_locations(
-    tt_ClusterDescriptor const& cluster_desc, SocDescriptor const& soc_desc) {
+    ClusterDescriptor const& cluster_desc, SocDescriptor const& soc_desc) {
     std::vector<destination_t> core_index_to_location = {};
 
     for (chip_id_t chip : cluster_desc.get_all_chips()) {
@@ -546,7 +546,7 @@ get_default_address_generator(int seed, address_t start, address_t end) {
 static ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int_distribution>
 get_default_full_dram_dest_generator(int seed, Cluster* cluster) {
     assert(cluster != nullptr);
-    tt_ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
+    ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
     SocDescriptor const& soc_desc = cluster->get_soc_descriptor(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
 
@@ -562,7 +562,7 @@ static WriteCommandGenerator<
     transfer_size_t,
     std::uniform_int_distribution>
 build_dummy_write_command_generator(Cluster& cluster) {
-    tt_ClusterDescriptor* cluster_desc = cluster.get_cluster_description();
+    ClusterDescriptor* cluster_desc = cluster.get_cluster_description();
     SocDescriptor const& soc_desc = cluster.get_soc_descriptor(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
     auto dest_generator = ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int_distribution>(
@@ -587,7 +587,7 @@ static ReadCommandGenerator<
     transfer_size_t,
     std::uniform_int_distribution>
 build_dummy_read_command_generator(Cluster& cluster) {
-    tt_ClusterDescriptor* cluster_desc = cluster.get_cluster_description();
+    ClusterDescriptor* cluster_desc = cluster.get_cluster_description();
     SocDescriptor const& soc_desc = cluster.get_soc_descriptor(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
     auto dest_generator = ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int_distribution>(
@@ -628,7 +628,7 @@ void RunMixedTransfersUniformDistributions(
 
     bool record_command_history = false,
     std::vector<remote_transfer_sample_t>* command_history = nullptr) {
-    tt_ClusterDescriptor* cluster_desc = cluster.get_cluster_description();
+    ClusterDescriptor* cluster_desc = cluster.get_cluster_description();
     SocDescriptor const& soc_desc = cluster.get_soc_descriptor(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
 

--- a/tests/wormhole/test_arc_messages_wh.cpp
+++ b/tests/wormhole/test_arc_messages_wh.cpp
@@ -8,7 +8,7 @@
 #include "umd/device/arc/arc_messenger.h"
 #include "umd/device/arch/wormhole_implementation.h"
 #include "umd/device/cluster.h"
-#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/cluster_descriptor.h"
 
 using namespace tt::umd;
 

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -9,7 +9,7 @@
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "umd/device/arch/wormhole_implementation.h"
 #include "umd/device/cluster.h"
-#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/cluster_descriptor.h"
 #include "wormhole/eth_l1_address_map.h"
 #include "wormhole/host_mem_address_map.h"
 #include "wormhole/l1_address_map.h"

--- a/tests/wormhole/test_remote_communication_wh.cpp
+++ b/tests/wormhole/test_remote_communication_wh.cpp
@@ -6,8 +6,8 @@
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "umd/device/arch/wormhole_implementation.h"
 #include "umd/device/cluster.h"
+#include "umd/device/cluster_descriptor.h"
 #include "umd/device/remote_communication.h"
-#include "umd/device/tt_cluster_descriptor.h"
 #include "umd/device/types/cluster_types.h"
 #include "wormhole/host_mem_address_map.h"
 #include "wormhole/l1_address_map.h"
@@ -29,7 +29,7 @@ TEST(RemoteCommunicationWormhole, BasicRemoteCommunicationIO) {
     remote_comm->set_remote_transfer_ethernet_cores(local_chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(
         cluster->get_cluster_description()->get_active_eth_channels(mmio_chip_id), CoordSystem::TRANSLATED));
 
-    tt_ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
+    ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
 
     std::vector<uint32_t> data_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     std::vector<uint32_t> data_read(10, 0);

--- a/tests/wormhole/test_umd_remote_api_stability.cpp
+++ b/tests/wormhole/test_umd_remote_api_stability.cpp
@@ -16,8 +16,8 @@
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/test_utils/stimulus_generators.hpp"
 #include "umd/device/cluster.h"
+#include "umd/device/cluster_descriptor.h"
 #include "umd/device/soc_descriptor.h"
-#include "umd/device/tt_cluster_descriptor.h"
 #include "wormhole/eth_interface.h"
 #include "wormhole/host_mem_address_map.h"
 #include "wormhole/l1_address_map.h"
@@ -33,7 +33,7 @@ protected:
     static uint32_t scale_number_of_tests;
 
     static void SetUpTestSuite() {
-        std::unique_ptr<tt_ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
+        std::unique_ptr<ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
         detected_num_chips = cluster_desc->get_number_of_chips();
         if (detected_num_chips != EXPECTED_NUM_CHIPS) {
             skip_tests = true;

--- a/tests/wormhole/test_wh_common.h
+++ b/tests/wormhole/test_wh_common.h
@@ -8,7 +8,7 @@
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/test_utils/stimulus_generators.hpp"
 #include "umd/device/cluster.h"
-#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/cluster_descriptor.h"
 #include "umd/device/tt_xy_pair.h"
 #include "wormhole/eth_l1_address_map.h"
 #include "wormhole/l1_address_map.h"

--- a/tools/system_health.cpp
+++ b/tools/system_health.cpp
@@ -6,8 +6,8 @@
 
 #include "common.h"
 #include "umd/device/cluster.h"
+#include "umd/device/cluster_descriptor.h"
 #include "umd/device/soc_descriptor.h"
-#include "umd/device/tt_cluster_descriptor.h"
 #include "umd/device/tt_core_coordinates.h"
 #include "umd/device/types/cluster_descriptor_types.h"
 
@@ -49,7 +49,7 @@ UbbId get_ubb_id(Cluster* cluster, const chip_id_t chip_id, const unsigned long 
 }
 
 bool check_if_external_cable_is_used(
-    tt_ClusterDescriptor* cluster_descriptor,
+    ClusterDescriptor* cluster_descriptor,
     const BoardType board_type,
     const chip_id_t chip_id,
     const unsigned long unique_chip_id,

--- a/tools/topology.cpp
+++ b/tools/topology.cpp
@@ -6,7 +6,7 @@
 
 #include "common.h"
 #include "umd/device/cluster.h"
-#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/cluster_descriptor.h"
 
 using namespace tt::umd;
 
@@ -43,13 +43,13 @@ int main(int argc, char *argv[]) {
         pci_ids = extract_int_set(result["pci_devices"]);
     }
 
-    std::unique_ptr<tt_ClusterDescriptor> cluster_descriptor = Cluster::create_cluster_descriptor("", pci_ids);
+    std::unique_ptr<ClusterDescriptor> cluster_descriptor = Cluster::create_cluster_descriptor("", pci_ids);
 
     if (result.count("logical_devices")) {
         std::unordered_set<int> logical_device_ids = extract_int_set(result["logical_devices"]);
 
         cluster_descriptor =
-            tt_ClusterDescriptor::create_constrained_cluster_descriptor(cluster_descriptor.get(), logical_device_ids);
+            ClusterDescriptor::create_constrained_cluster_descriptor(cluster_descriptor.get(), logical_device_ids);
     }
 
     std::string output_path = cluster_descriptor->serialize_to_file(cluster_descriptor_path);


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/1167

### Description
Rename tt_ClusterDescriptor to ClusterDescriptor

### List of the changes
- Rename tt_ClusterDescriptor to ClusterDescriptor
- Rename tt_cluster_descriptor to cluster_descriptor

### Testing
Builds

### API Changes
This PR has API changes, but I'll leave old header files if necessary until the clients move forward.
You will see that metal build fails on this PR, but it builds at the tip of the PR stack:
https://github.com/tenstorrent/tt-umd/pull/1218

