### PR TITLE
Rename simulation files and move them

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(POSITION_INDEPENDENT_CODE ON)
 
 if(TT_UMD_BUILD_SIMULATION)
-    set(FBS_FILE ${PROJECT_SOURCE_DIR}/device/simulation/tt_simulation_device.fbs)
+    set(FBS_FILE ${PROJECT_SOURCE_DIR}/device/simulation/simulation_device.fbs)
     get_filename_component(FBS_FILE_NAME ${FBS_FILE} NAME_WLE)
     set(FBS_GENERATED_HEADER "${CMAKE_CURRENT_BINARY_DIR}/${FBS_FILE_NAME}_generated.h")
     set(FBS_DEPENDS "")
@@ -84,8 +84,8 @@ if(TT_UMD_BUILD_SIMULATION)
     target_sources(
         device
         PRIVATE
-            simulation/tt_simulation_device.cpp
-            simulation/tt_simulation_host.cpp
+            simulation/simulation_device.cpp
+            simulation/simulation_host.cpp
             ${FBS_GENERATED_HEADER}
     )
     target_compile_definitions(device PRIVATE TT_UMD_BUILD_SIMULATION)
@@ -134,8 +134,8 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/firmware/firmware_utils.h
                 api/umd/device/tt_io.hpp
                 api/umd/device/tt_silicon_driver_common.hpp
-                api/umd/device/tt_simulation_device.h
-                api/umd/device/tt_simulation_host.hpp
+                api/umd/device/simulation/simulation_device.h
+                api/umd/device/simulation/simulation_host.hpp
                 api/umd/device/soc_descriptor.h
                 api/umd/device/tt_xy_pair.h
                 api/umd/device/umd_utils.h

--- a/device/api/umd/device/simulation/simulation_device.h
+++ b/device/api/umd/device/simulation/simulation_device.h
@@ -111,3 +111,4 @@ private:
 
 // TODO: To be removed once clients switch to namespace usage.
 using tt::umd::SimulationDeviceInit;
+using tt_SimulationDeviceInit = tt::umd::SimulationDeviceInit;

--- a/device/api/umd/device/simulation/simulation_device.h
+++ b/device/api/umd/device/simulation/simulation_device.h
@@ -12,14 +12,14 @@
 
 #include "umd/device/chip/chip.h"
 #include "umd/device/cluster.h"
-#include "umd/device/tt_simulation_host.hpp"
+#include "umd/device/simulation/simulation_host.hpp"
 #include "umd/device/utils/lock_manager.h"
 
 namespace tt::umd {
 
-class tt_SimulationDeviceInit {
+class SimulationDeviceInit {
 public:
-    tt_SimulationDeviceInit(const std::filesystem::path& simulator_directory);
+    SimulationDeviceInit(const std::filesystem::path& simulator_directory);
 
     tt::ARCH get_arch_name() const { return soc_descriptor.arch; }
 
@@ -32,15 +32,15 @@ private:
     SocDescriptor soc_descriptor;
 };
 
-class tt_SimulationDevice : public Chip {
+class SimulationDevice : public Chip {
 public:
-    tt_SimulationDevice(const std::filesystem::path& simulator_directory) :
-        tt_SimulationDevice(tt_SimulationDeviceInit(simulator_directory)) {}
+    SimulationDevice(const std::filesystem::path& simulator_directory) :
+        SimulationDevice(SimulationDeviceInit(simulator_directory)) {}
 
-    tt_SimulationDevice(const tt_SimulationDeviceInit& init);
-    ~tt_SimulationDevice();
+    SimulationDevice(const SimulationDeviceInit& init);
+    ~SimulationDevice();
 
-    tt_SimulationHost host;
+    SimulationHost host;
 
     int get_num_host_channels() override;
     int get_host_channel_size(std::uint32_t channel) override;
@@ -110,4 +110,4 @@ private:
 }  // namespace tt::umd
 
 // TODO: To be removed once clients switch to namespace usage.
-using tt::umd::tt_SimulationDeviceInit;
+using tt::umd::SimulationDeviceInit;

--- a/device/api/umd/device/simulation/simulation_host.hpp
+++ b/device/api/umd/device/simulation/simulation_host.hpp
@@ -16,10 +16,10 @@ typedef struct nng_dialer_s nng_dialer;
 
 namespace tt::umd {
 
-class tt_SimulationHost {
+class SimulationHost {
 public:
-    tt_SimulationHost();
-    ~tt_SimulationHost();
+    SimulationHost();
+    ~SimulationHost();
 
     void start_host();
     void send_to_device(uint8_t *buf, size_t buf_size);

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+// TODO: To be removed once clients switch to including the other header.
+#include "umd/device/simulation/simulation_device.h"

--- a/device/api/umd/device/tt_simulation_device.h
+++ b/device/api/umd/device/tt_simulation_device.h
@@ -1,7 +1,0 @@
-/*
- * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-// TODO: To be removed once clients switch to including the other header.
-#include "umd/device/simulation/simulation_device.h"

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -49,12 +49,12 @@
 #include "umd/device/cluster_descriptor.h"
 #include "umd/device/driver_atomics.h"
 #include "umd/device/hugepage.h"
+#include "umd/device/simulation/simulation_device.h"
 #include "umd/device/soc_descriptor.h"
 #include "umd/device/topology/topology_discovery_blackhole.h"
 #include "umd/device/topology/topology_discovery_wormhole.h"
 #include "umd/device/topology_utils.h"
 #include "umd/device/tt_core_coordinates.h"
-#include "umd/device/tt_simulation_device.h"
 #include "umd/device/types/arch.h"
 #include "umd/device/types/blackhole_eth.h"
 #include "umd/device/types/tlb.h"
@@ -244,7 +244,7 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     if (chip_type == ChipType::SIMULATION) {
 #ifdef TT_UMD_BUILD_SIMULATION
         // Note that passed soc descriptor is ignored in favor of soc descriptor from simulator_directory.
-        return std::make_unique<tt_SimulationDevice>(simulator_directory);
+        return std::make_unique<SimulationDevice>(simulator_directory);
 #else
         throw std::runtime_error(
             "Simulation device is not supported in this build. Set '-DTT_UMD_BUILD_SIMULATION=ON' during cmake "
@@ -423,7 +423,7 @@ Cluster::Cluster(ClusterOptions options) {
             auto arch = tt::ARCH::WORMHOLE_B0;
 #ifdef TT_UMD_BUILD_SIMULATION
             if (options.chip_type == ChipType::SIMULATION) {
-                tt_SimulationDeviceInit init(options.simulator_directory);
+                SimulationDeviceInit init(options.simulator_directory);
                 arch = init.get_soc_descriptor().arch;
             }
 #endif

--- a/device/simulation/simulation_device.cpp
+++ b/device/simulation/simulation_device.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "umd/device/tt_simulation_device.h"
+#include "umd/device/simulation/simulation_device.h"
 
 #include <nng/nng.h>
 #include <uv.h>
@@ -15,12 +15,12 @@
 #include <vector>
 
 #include "assert.hpp"
-#include "tt_simulation_device_generated.h"
+#include "simulation_device_generated.h"
 #include "umd/device/driver_atomics.h"
 
 namespace tt::umd {
 
-static_assert(!std::is_abstract<tt_SimulationDevice>(), "tt_SimulationDevice must be non-abstract.");
+static_assert(!std::is_abstract<SimulationDevice>(), "SimulationDevice must be non-abstract.");
 
 flatbuffers::FlatBufferBuilder create_flatbuffer(
     DEVICE_COMMAND rw, std::vector<uint32_t> vec, tt_xy_pair core_, uint64_t addr, uint64_t size_ = 0) {
@@ -55,10 +55,10 @@ static void print_flatbuffer(const DeviceRequestResponse* buf) {
 #endif
 }
 
-tt_SimulationDeviceInit::tt_SimulationDeviceInit(const std::filesystem::path& simulator_directory) :
+SimulationDeviceInit::SimulationDeviceInit(const std::filesystem::path& simulator_directory) :
     simulator_directory(simulator_directory), soc_descriptor(simulator_directory / "soc_descriptor.yaml") {}
 
-tt_SimulationDevice::tt_SimulationDevice(const tt_SimulationDeviceInit& init) : Chip(init.get_soc_descriptor()) {
+SimulationDevice::SimulationDevice(const SimulationDeviceInit& init) : Chip(init.get_soc_descriptor()) {
     log_info(tt::LogEmulationDriver, "Instantiating simulation device");
     lock_manager.initialize_mutex(MutexType::TT_SIMULATOR);
     soc_descriptor_per_chip.emplace(0, init.get_soc_descriptor());
@@ -99,9 +99,9 @@ tt_SimulationDevice::tt_SimulationDevice(const tt_SimulationDeviceInit& init) : 
     uv_loop_close(loop);
 }
 
-tt_SimulationDevice::~tt_SimulationDevice() { lock_manager.clear_mutex(MutexType::TT_SIMULATOR); }
+SimulationDevice::~SimulationDevice() { lock_manager.clear_mutex(MutexType::TT_SIMULATOR); }
 
-void tt_SimulationDevice::start_device() {
+void SimulationDevice::start_device() {
     auto lock = lock_manager.acquire_mutex(MutexType::TT_SIMULATOR);
     void* buf_ptr = nullptr;
 
@@ -115,7 +115,7 @@ void tt_SimulationDevice::start_device() {
     nng_free(buf_ptr, buf_size);
 }
 
-void tt_SimulationDevice::send_tensix_risc_reset(CoreCoord core, const TensixSoftResetOptions& soft_resets) {
+void SimulationDevice::send_tensix_risc_reset(CoreCoord core, const TensixSoftResetOptions& soft_resets) {
     auto lock = lock_manager.acquire_mutex(MutexType::TT_SIMULATOR);
     tt_xy_pair translate_core = soc_descriptor_.translate_coord_to(core, CoordSystem::TRANSLATED);
     if (soft_resets == TENSIX_ASSERT_SOFT_RESET) {
@@ -140,23 +140,23 @@ void tt_SimulationDevice::send_tensix_risc_reset(CoreCoord core, const TensixSof
     }
 }
 
-void tt_SimulationDevice::send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) {
+void SimulationDevice::send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) {
     send_tensix_risc_reset(soc_descriptor_.get_coord_at({0, 0}, CoordSystem::TRANSLATED), soft_resets);
 }
 
-void tt_SimulationDevice::close_device() {
+void SimulationDevice::close_device() {
     // disconnect from remote connection
     log_info(tt::LogEmulationDriver, "Sending exit signal to remote...");
     auto builder = create_flatbuffer(DEVICE_COMMAND_EXIT, std::vector<uint32_t>(1, 0), {0, 0}, 0);
     host.send_to_device(builder.GetBufferPointer(), builder.GetSize());
 }
 
-void tt_SimulationDevice::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) {}
+void SimulationDevice::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) {}
 
-void tt_SimulationDevice::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) {}
+void SimulationDevice::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) {}
 
 // Runtime Functions
-void tt_SimulationDevice::write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) {
+void SimulationDevice::write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) {
     auto lock = lock_manager.acquire_mutex(MutexType::TT_SIMULATOR);
     log_debug(tt::LogEmulationDriver, "Device writing {} bytes to l1_dest {} in core {}", size, l1_dest, core.str());
     tt_xy_pair translate_core = soc_descriptor_.translate_coord_to(core, CoordSystem::TRANSLATED);
@@ -169,7 +169,7 @@ void tt_SimulationDevice::write_to_device(CoreCoord core, const void* src, uint6
     host.send_to_device(wr_buffer_ptr, wr_buffer_size);
 }
 
-void tt_SimulationDevice::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) {
+void SimulationDevice::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) {
     auto lock = lock_manager.acquire_mutex(MutexType::TT_SIMULATOR);
     void* rd_resp;
 
@@ -191,42 +191,42 @@ void tt_SimulationDevice::read_from_device(CoreCoord core, void* dest, uint64_t 
     nng_free(rd_resp, rd_rsp_sz);
 }
 
-void tt_SimulationDevice::write_to_device_reg(CoreCoord core, const void* src, uint64_t reg_dest, uint32_t size) {
+void SimulationDevice::write_to_device_reg(CoreCoord core, const void* src, uint64_t reg_dest, uint32_t size) {
     write_to_device(core, src, reg_dest, size);
 }
 
-void tt_SimulationDevice::read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_src, uint32_t size) {
+void SimulationDevice::read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_src, uint32_t size) {
     read_from_device(core, dest, reg_src, size);
 }
 
-void tt_SimulationDevice::dma_write_to_device(const void* src, size_t size, CoreCoord core, uint64_t addr) {
+void SimulationDevice::dma_write_to_device(const void* src, size_t size, CoreCoord core, uint64_t addr) {
     write_to_device(core, src, addr, size);
 }
 
-void tt_SimulationDevice::dma_read_from_device(void* dst, size_t size, CoreCoord core, uint64_t addr) {
+void SimulationDevice::dma_read_from_device(void* dst, size_t size, CoreCoord core, uint64_t addr) {
     read_from_device(core, dst, addr, size);
 }
 
-std::function<void(uint32_t, uint32_t, const uint8_t*)> tt_SimulationDevice::get_fast_pcie_static_tlb_write_callable() {
+std::function<void(uint32_t, uint32_t, const uint8_t*)> SimulationDevice::get_fast_pcie_static_tlb_write_callable() {
     throw std::runtime_error(
-        "tt_SimulationDevice::get_fast_pcie_static_tlb_write_callable is not available for this chip.");
+        "SimulationDevice::get_fast_pcie_static_tlb_write_callable is not available for this chip.");
 }
 
-void tt_SimulationDevice::wait_for_non_mmio_flush() {}
+void SimulationDevice::wait_for_non_mmio_flush() {}
 
-void tt_SimulationDevice::l1_membar(const std::unordered_set<CoreCoord>& cores) {}
+void SimulationDevice::l1_membar(const std::unordered_set<CoreCoord>& cores) {}
 
-void tt_SimulationDevice::dram_membar(const std::unordered_set<uint32_t>& channels) {}
+void SimulationDevice::dram_membar(const std::unordered_set<uint32_t>& channels) {}
 
-void tt_SimulationDevice::dram_membar(const std::unordered_set<CoreCoord>& cores) {}
+void SimulationDevice::dram_membar(const std::unordered_set<CoreCoord>& cores) {}
 
-void tt_SimulationDevice::deassert_risc_resets() {}
+void SimulationDevice::deassert_risc_resets() {}
 
-void tt_SimulationDevice::set_power_state(tt_DevicePowerState state) {}
+void SimulationDevice::set_power_state(tt_DevicePowerState state) {}
 
-int tt_SimulationDevice::get_clock() { return 0; }
+int SimulationDevice::get_clock() { return 0; }
 
-int tt_SimulationDevice::arc_msg(
+int SimulationDevice::arc_msg(
     uint32_t msg_code,
     bool wait_for_done,
     uint32_t arg0,
@@ -238,34 +238,34 @@ int tt_SimulationDevice::arc_msg(
     return 0;
 }
 
-int tt_SimulationDevice::get_num_host_channels() { return 0; }
+int SimulationDevice::get_num_host_channels() { return 0; }
 
-int tt_SimulationDevice::get_host_channel_size(std::uint32_t channel) {
+int SimulationDevice::get_host_channel_size(std::uint32_t channel) {
     throw std::runtime_error("There are no host channels available.");
 }
 
-void tt_SimulationDevice::write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) {
-    throw std::runtime_error("tt_SimulationDevice::write_to_sysmem is not available for this chip.");
+void SimulationDevice::write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) {
+    throw std::runtime_error("SimulationDevice::write_to_sysmem is not available for this chip.");
 }
 
-void tt_SimulationDevice::read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) {
-    throw std::runtime_error("tt_SimulationDevice::read_from_sysmem is not available for this chip.");
+void SimulationDevice::read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) {
+    throw std::runtime_error("SimulationDevice::read_from_sysmem is not available for this chip.");
 }
 
-int tt_SimulationDevice::get_numa_node() {
-    throw std::runtime_error("tt_SimulationDevice::get_numa_node is not available for this chip.");
+int SimulationDevice::get_numa_node() {
+    throw std::runtime_error("SimulationDevice::get_numa_node is not available for this chip.");
 }
 
-TTDevice* tt_SimulationDevice::get_tt_device() {
-    throw std::runtime_error("tt_SimulationDevice::get_tt_device is not available for this chip.");
+TTDevice* SimulationDevice::get_tt_device() {
+    throw std::runtime_error("SimulationDevice::get_tt_device is not available for this chip.");
 }
 
-SysmemManager* tt_SimulationDevice::get_sysmem_manager() {
-    throw std::runtime_error("tt_SimulationDevice::get_sysmem_manager is not available for this chip.");
+SysmemManager* SimulationDevice::get_sysmem_manager() {
+    throw std::runtime_error("SimulationDevice::get_sysmem_manager is not available for this chip.");
 }
 
-TLBManager* tt_SimulationDevice::get_tlb_manager() {
-    throw std::runtime_error("tt_SimulationDevice::get_tlb_manager is not available for this chip.");
+TLBManager* SimulationDevice::get_tlb_manager() {
+    throw std::runtime_error("SimulationDevice::get_tlb_manager is not available for this chip.");
 }
 
 }  // namespace tt::umd

--- a/device/simulation/simulation_device.fbs
+++ b/device/simulation/simulation_device.fbs
@@ -1,4 +1,4 @@
-// Schema for tt_simulation_device
+// Schema for simulation_device
 
 enum DEVICE_COMMAND : byte {
     WRITE = 0,

--- a/device/simulation/simulation_host.cpp
+++ b/device/simulation/simulation_host.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "umd/device/tt_simulation_host.hpp"
+#include "umd/device/simulation/simulation_host.hpp"
 
 #include <nng/nng.h>
 #include <nng/protocol/pair1/pair.h>
@@ -19,7 +19,7 @@
 
 namespace tt::umd {
 
-tt_SimulationHost::tt_SimulationHost() {
+SimulationHost::SimulationHost() {
     // Initialize socket and dialer
     host_socket = std::make_unique<nng_socket>();
     host_dialer = std::make_unique<nng_dialer>();
@@ -40,12 +40,12 @@ tt_SimulationHost::tt_SimulationHost() {
     TT_ASSERT(rv == 0, "Failed to create dialer: {} {}", nng_strerror(rv), nng_socket_addr);
 }
 
-tt_SimulationHost::~tt_SimulationHost() {
+SimulationHost::~SimulationHost() {
     nng_dialer_close(*host_dialer);
     nng_close(*host_socket);
 }
 
-void tt_SimulationHost::start_host() {
+void SimulationHost::start_host() {
     // Establish connection with remote VCS simulator
     int rv;
     do {
@@ -57,7 +57,7 @@ void tt_SimulationHost::start_host() {
     } while (rv != 0);
 }
 
-void tt_SimulationHost::send_to_device(uint8_t *buf, size_t buf_size) {
+void SimulationHost::send_to_device(uint8_t *buf, size_t buf_size) {
     int rv;
     log_debug(tt::LogEmulationDriver, "Sending messsage to remote..");
 
@@ -71,7 +71,7 @@ void tt_SimulationHost::send_to_device(uint8_t *buf, size_t buf_size) {
     }
 }
 
-size_t tt_SimulationHost::recv_from_device(void **data_ptr) {
+size_t SimulationHost::recv_from_device(void **data_ptr) {
     int rv;
     size_t data_size;
     log_debug(tt::LogEmulationDriver, "Receiving messsage from remote..");

--- a/tests/simulation/device_fixture.hpp
+++ b/tests/simulation/device_fixture.hpp
@@ -13,7 +13,7 @@
 #include <stdexcept>
 
 #include "tests/test_utils/generate_cluster_desc.hpp"
-#include "umd/device/tt_simulation_device.h"
+#include "umd/device/simulation/simulation_device.h"
 
 namespace tt::umd {
 
@@ -26,15 +26,15 @@ protected:
             throw std::runtime_error(
                 "You need to define TT_UMD_SIMULATOR that will point to simulator path. eg. build/versim-wormhole-b0");
         }
-        device = std::make_unique<tt_SimulationDevice>(simulator_path);
+        device = std::make_unique<SimulationDevice>(simulator_path);
         device->start_device();
     }
 
     static void TearDownTestSuite() { device->close_device(); }
 
-    static std::unique_ptr<tt_SimulationDevice> device;
+    static std::unique_ptr<SimulationDevice> device;
 };
 
-std::unique_ptr<tt_SimulationDevice> SimulationDeviceFixture::device = nullptr;
+std::unique_ptr<SimulationDevice> SimulationDeviceFixture::device = nullptr;
 
 }  // namespace tt::umd

--- a/tests/simulation/test_simulation_device.cpp
+++ b/tests/simulation/test_simulation_device.cpp
@@ -37,7 +37,7 @@ TEST_P(LoopbackAllCoresParam, LoopbackSingleTensix) {
     ASSERT_EQ(wdata, rdata);
 }
 
-bool loopback_stress_size(std::unique_ptr<tt_SimulationDevice> &device, CoreCoord core, uint32_t byte_shift) {
+bool loopback_stress_size(std::unique_ptr<SimulationDevice> &device, CoreCoord core, uint32_t byte_shift) {
     uint64_t addr = 0x0;
 
     std::vector<uint32_t> wdata = generate_data(1 << byte_shift);


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/1167

### Description
Rename Simulation related classes not to have tt_ prefix

### List of the changes
- Rename tt_SimulationDeviceInit to SimulationDeviceInit
- Rename tt_SimulationDevice to SimulationDevice
- Rename tt_SimulationHost to SimulationHost
- Renamed files accordingly
- Moved files to simulation folder

### Testing
Builds
Tested that simulation tests still pass

### API Changes
This PR has API changes, but I'll leave old header files if necessary until the clients move forward.
You will see that metal build fails on this PR, but it builds at the tip of the PR stack:
https://github.com/tenstorrent/tt-umd/pull/1218

