### PR TITLE
Rename structs

### DIFF
--- a/device/api/umd/device/arch/architecture_implementation.h
+++ b/device/api/umd/device/arch/architecture_implementation.h
@@ -20,10 +20,10 @@
 
 namespace tt::umd {
 
-struct tt_device_l1_address_params;
-struct tt_driver_host_address_params;
-struct tt_driver_eth_interface_params;
-struct tt_driver_noc_params;
+struct device_l1_address_params;
+struct driver_host_address_params;
+struct driver_eth_interface_params;
+struct driver_noc_params;
 
 static const uint32_t HANG_READ_VALUE = 0xFFFFFFFFu;
 
@@ -85,10 +85,10 @@ public:
     virtual std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const = 0;
     virtual tlb_configuration get_tlb_configuration(uint32_t tlb_index) const = 0;
 
-    virtual tt_device_l1_address_params get_l1_address_params() const = 0;
-    virtual tt_driver_host_address_params get_host_address_params() const = 0;
-    virtual tt_driver_eth_interface_params get_eth_interface_params() const = 0;
-    virtual tt_driver_noc_params get_noc_params() const = 0;
+    virtual device_l1_address_params get_l1_address_params() const = 0;
+    virtual driver_host_address_params get_host_address_params() const = 0;
+    virtual driver_eth_interface_params get_eth_interface_params() const = 0;
+    virtual driver_noc_params get_noc_params() const = 0;
 
     static std::unique_ptr<architecture_implementation> create(tt::ARCH architecture);
 

--- a/device/api/umd/device/arch/blackhole_implementation.h
+++ b/device/api/umd/device/arch/blackhole_implementation.h
@@ -432,10 +432,10 @@ public:
     std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const override;
     tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
 
-    tt_device_l1_address_params get_l1_address_params() const override;
-    tt_driver_host_address_params get_host_address_params() const override;
-    tt_driver_eth_interface_params get_eth_interface_params() const override;
-    tt_driver_noc_params get_noc_params() const override;
+    device_l1_address_params get_l1_address_params() const override;
+    driver_host_address_params get_host_address_params() const override;
+    driver_eth_interface_params get_eth_interface_params() const override;
+    driver_noc_params get_noc_params() const override;
 
     virtual uint64_t get_noc_node_id_offset() const override { return blackhole::NOC_NODE_ID_OFFSET; }
 

--- a/device/api/umd/device/arch/wormhole_implementation.h
+++ b/device/api/umd/device/arch/wormhole_implementation.h
@@ -424,10 +424,10 @@ public:
     std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const override;
     tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
 
-    tt_device_l1_address_params get_l1_address_params() const override;
-    tt_driver_host_address_params get_host_address_params() const override;
-    tt_driver_eth_interface_params get_eth_interface_params() const override;
-    tt_driver_noc_params get_noc_params() const override;
+    device_l1_address_params get_l1_address_params() const override;
+    driver_host_address_params get_host_address_params() const override;
+    driver_eth_interface_params get_eth_interface_params() const override;
+    driver_noc_params get_noc_params() const override;
 
     virtual uint64_t get_noc_node_id_offset() const override { return wormhole::NOC_NODE_ID_OFFSET; }
 

--- a/device/api/umd/device/chip/chip.h
+++ b/device/api/umd/device/chip/chip.h
@@ -72,7 +72,7 @@ public:
     virtual void set_tensix_risc_reset(CoreCoord core, const TensixSoftResetOptions& selected_riscs);
     virtual void unset_tensix_risc_reset(CoreCoord core, const TensixSoftResetOptions& selected_riscs);
 
-    virtual void set_power_state(tt_DevicePowerState state) = 0;
+    virtual void set_power_state(DevicePowerState state) = 0;
     virtual int get_clock() = 0;
     virtual int get_numa_node() = 0;
 
@@ -93,8 +93,8 @@ public:
 
     // TODO: This should be private, once enough stuff is moved inside chip.
     // Probably also moved to LocalChip.
-    tt_device_dram_address_params dram_address_params;
-    tt_device_l1_address_params l1_address_params;
+    device_dram_address_params dram_address_params;
+    device_l1_address_params l1_address_params;
 
     // TODO: To be removed once we properly refactor usage of NOC1 coords.
     tt_xy_pair translate_chip_coord_to_translated(const CoreCoord core) const;
@@ -108,9 +108,9 @@ protected:
 
     void set_default_params(ARCH arch);
 
-    uint32_t get_power_state_arc_msg(tt_DevicePowerState state);
+    uint32_t get_power_state_arc_msg(DevicePowerState state);
 
-    void wait_for_aiclk_value(TTDevice* tt_device, tt_DevicePowerState power_state, const uint32_t timeout_ms = 5000);
+    void wait_for_aiclk_value(TTDevice* tt_device, DevicePowerState power_state, const uint32_t timeout_ms = 5000);
 
     ChipInfo chip_info_;
 

--- a/device/api/umd/device/chip/local_chip.h
+++ b/device/api/umd/device/chip/local_chip.h
@@ -62,7 +62,7 @@ public:
     void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
 
     void deassert_risc_resets() override;
-    void set_power_state(tt_DevicePowerState state) override;
+    void set_power_state(DevicePowerState state) override;
     int get_clock() override;
     int get_numa_node() override;
 

--- a/device/api/umd/device/chip/mock_chip.h
+++ b/device/api/umd/device/chip/mock_chip.h
@@ -50,7 +50,7 @@ public:
     void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
 
     void deassert_risc_resets() override;
-    void set_power_state(tt_DevicePowerState state) override;
+    void set_power_state(DevicePowerState state) override;
     int get_clock() override;
     int get_numa_node() override;
 

--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -65,7 +65,7 @@ public:
     void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
 
     void deassert_risc_resets() override;
-    void set_power_state(tt_DevicePowerState state) override;
+    void set_power_state(DevicePowerState state) override;
     int get_clock() override;
     int get_numa_node() override;
 

--- a/device/api/umd/device/cluster.h
+++ b/device/api/umd/device/cluster.h
@@ -239,7 +239,7 @@ public:
      *
      * @param device_params Object specifying initialization configuration.
      */
-    void start_device(const tt_device_params& device_params);
+    void start_device(const device_params& device_params);
 
     /**
      * To be called at the end of a run.
@@ -253,7 +253,7 @@ public:
      * Explicitly set the power state of the device.
      * Note that start/close the device already do this implicitly.
      */
-    void set_power_state(tt_DevicePowerState state);
+    void set_power_state(DevicePowerState state);
 
     /**
      * Broadcast deassert BRISC soft Tensix Reset to the entire device.

--- a/device/api/umd/device/simulation/simulation_device.h
+++ b/device/api/umd/device/simulation/simulation_device.h
@@ -79,7 +79,7 @@ public:
     void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) override;
     void deassert_risc_resets() override;
 
-    void set_power_state(tt_DevicePowerState state) override;
+    void set_power_state(DevicePowerState state) override;
     int get_clock() override;
     int get_numa_node() override;
 
@@ -94,7 +94,7 @@ public:
 
 private:
     // State variables
-    tt_driver_noc_params noc_params;
+    driver_noc_params noc_params;
     std::set<chip_id_t> target_devices_in_cluster = {};
     std::set<chip_id_t> target_remote_chips = {};
     tt::ARCH arch_name;

--- a/device/api/umd/device/topology_utils.h
+++ b/device/api/umd/device/topology_utils.h
@@ -20,7 +20,7 @@ void size_buffer_to_capacity(std::vector<T>& data_buf, std::size_t size_in_bytes
 }
 
 static inline uint64_t get_sys_addr(
-    const tt_driver_noc_params& noc_params,
+    const driver_noc_params& noc_params,
     uint32_t chip_x,
     uint32_t chip_y,
     uint32_t noc_x,
@@ -40,7 +40,7 @@ static inline uint64_t get_sys_addr(
 }
 
 static inline uint16_t get_sys_rack(
-    const tt_driver_eth_interface_params& eth_interface_params, uint32_t rack_x, uint32_t rack_y) {
+    const driver_eth_interface_params& eth_interface_params, uint32_t rack_x, uint32_t rack_y) {
     uint32_t result = rack_y;
     result <<= eth_interface_params.eth_rack_coord_width;
     result |= rack_x;
@@ -49,7 +49,7 @@ static inline uint16_t get_sys_rack(
 }
 
 static inline bool is_non_mmio_cmd_q_full(
-    const tt_driver_eth_interface_params& eth_interface_params, uint32_t curr_wptr, uint32_t curr_rptr) {
+    const driver_eth_interface_params& eth_interface_params, uint32_t curr_wptr, uint32_t curr_rptr) {
     return (curr_wptr != curr_rptr) && ((curr_wptr & eth_interface_params.cmd_buf_size_mask) ==
                                         (curr_rptr & eth_interface_params.cmd_buf_size_mask));
 }

--- a/device/api/umd/device/types/cluster_types.h
+++ b/device/api/umd/device/types/cluster_types.h
@@ -13,7 +13,7 @@
 #include "fmt/core.h"
 
 // TODO: To me moved inside tt::umd namespace once all clients switch to namespace usage.
-struct tt_device_params {
+struct device_params {
     bool register_monitor = false;
     bool enable_perf_scoreboard = false;
     std::vector<std::string> vcd_dump_cores;
@@ -99,22 +99,22 @@ struct tt_device_params {
 
 namespace tt::umd {
 
-enum tt_DevicePowerState { BUSY, SHORT_IDLE, LONG_IDLE };
+enum DevicePowerState { BUSY, SHORT_IDLE, LONG_IDLE };
 
-enum tt_MemBarFlag {
+enum MemBarFlag {
     SET = 0xaa,
     RESET = 0xbb,
 };
 
-inline std::ostream& operator<<(std::ostream& os, const tt_DevicePowerState power_state) {
+inline std::ostream& operator<<(std::ostream& os, const DevicePowerState power_state) {
     switch (power_state) {
-        case tt_DevicePowerState::BUSY:
+        case DevicePowerState::BUSY:
             os << "Busy";
             break;
-        case tt_DevicePowerState::SHORT_IDLE:
+        case DevicePowerState::SHORT_IDLE:
             os << "SHORT_IDLE";
             break;
-        case tt_DevicePowerState::LONG_IDLE:
+        case DevicePowerState::LONG_IDLE:
             os << "LONG_IDLE";
             break;
         default:
@@ -129,7 +129,7 @@ struct barrier_address_params {
     std::uint32_t dram_barrier_base = 0;
 };
 
-struct tt_device_dram_address_params {
+struct device_dram_address_params {
     std::uint32_t DRAM_BARRIER_BASE = 0;
 };
 
@@ -137,7 +137,7 @@ struct tt_device_dram_address_params {
  * Struct encapsulating all L1 Address Map parameters required by UMD.
  * These parameters are passed to the constructor.
  */
-struct tt_device_l1_address_params {
+struct device_l1_address_params {
     std::uint32_t tensix_l1_barrier_base = 0;
     std::uint32_t eth_l1_barrier_base = 0;
     std::uint32_t fw_version_addr = 0;
@@ -147,12 +147,12 @@ struct tt_device_l1_address_params {
  * Struct encapsulating all Host Address Map parameters required by UMD.
  * These parameters are passed to the constructor and are needed for non-MMIO transactions.
  */
-struct tt_driver_host_address_params {
+struct driver_host_address_params {
     std::uint32_t eth_routing_block_size = 0;
     std::uint32_t eth_routing_buffers_start = 0;
 };
 
-struct tt_driver_noc_params {
+struct driver_noc_params {
     std::uint32_t noc_addr_local_bits = 0;
     std::uint32_t noc_addr_node_id_bits = 0;
 };
@@ -161,7 +161,7 @@ struct tt_driver_noc_params {
  * Struct encapsulating all ERISC Firmware parameters required by UMD.
  * These parameters are passed to the constructor and are needed for non-MMIO transactions.
  */
-struct tt_driver_eth_interface_params {
+struct driver_eth_interface_params {
     std::uint32_t eth_rack_coord_width = 0;
     std::uint32_t cmd_buf_size_mask = 0;
     std::uint32_t max_block_size = 0;
@@ -227,7 +227,7 @@ struct hugepage_mapping {
 
 // TODO: To be removed once clients switch to namespace usage.
 namespace tt::umd {
-using tt_device_params = ::tt_device_params;
+using device_params = ::device_params;
 }
 
 using tt::umd::barrier_address_params;

--- a/device/api/umd/device/types/cluster_types.h
+++ b/device/api/umd/device/types/cluster_types.h
@@ -12,8 +12,8 @@
 
 #include "fmt/core.h"
 
-// TODO: To me moved inside tt::umd namespace once all clients switch to namespace usage.
-struct device_params {
+// TODO: To me moved inside tt::umd namespace and renamed to device_params once all clients switch to namespace usage.
+struct tt_device_params {
     bool register_monitor = false;
     bool enable_perf_scoreboard = false;
     std::vector<std::string> vcd_dump_cores;
@@ -227,7 +227,7 @@ struct hugepage_mapping {
 
 // TODO: To be removed once clients switch to namespace usage.
 namespace tt::umd {
-using device_params = ::device_params;
+using device_params = ::tt_device_params;
 }
 
 using tt::umd::barrier_address_params;

--- a/device/arch/blackhole_implementation.cpp
+++ b/device/arch/blackhole_implementation.cpp
@@ -53,7 +53,7 @@ tlb_configuration blackhole_implementation::get_tlb_configuration(uint32_t tlb_i
     };
 }
 
-tt_device_l1_address_params blackhole_implementation::get_l1_address_params() const {
+device_l1_address_params blackhole_implementation::get_l1_address_params() const {
     // L1 barrier base and erisc barrier base should be explicitly set by the client.
     // Setting some default values here, but it should be ultimately overridden by the client.
     return {
@@ -62,13 +62,13 @@ tt_device_l1_address_params blackhole_implementation::get_l1_address_params() co
         ::eth_l1_mem::address_map::FW_VERSION_ADDR};
 }
 
-tt_driver_host_address_params blackhole_implementation::get_host_address_params() const {
+driver_host_address_params blackhole_implementation::get_host_address_params() const {
     return {
         ::blackhole::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE,
         ::blackhole::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
 }
 
-tt_driver_eth_interface_params blackhole_implementation::get_eth_interface_params() const {
+driver_eth_interface_params blackhole_implementation::get_eth_interface_params() const {
     return {
         ETH_RACK_COORD_WIDTH,
         CMD_BUF_SIZE_MASK,
@@ -93,7 +93,7 @@ tt_driver_eth_interface_params blackhole_implementation::get_eth_interface_param
     };
 }
 
-tt_driver_noc_params blackhole_implementation::get_noc_params() const {
+driver_noc_params blackhole_implementation::get_noc_params() const {
     return {NOC_ADDR_LOCAL_BITS, NOC_ADDR_NODE_ID_BITS};
 }
 

--- a/device/arch/wormhole_implementation.cpp
+++ b/device/arch/wormhole_implementation.cpp
@@ -60,7 +60,7 @@ tlb_configuration wormhole_implementation::get_tlb_configuration(uint32_t tlb_in
     }
 }
 
-tt_device_l1_address_params wormhole_implementation::get_l1_address_params() const {
+device_l1_address_params wormhole_implementation::get_l1_address_params() const {
     // L1 barrier base and erisc barrier base should be explicitly set by the client.
     // Setting some default values here, but it should be ultimately overridden by the client.
     return {
@@ -69,13 +69,13 @@ tt_device_l1_address_params wormhole_implementation::get_l1_address_params() con
         ::eth_l1_mem::address_map::FW_VERSION_ADDR};
 }
 
-tt_driver_host_address_params wormhole_implementation::get_host_address_params() const {
+driver_host_address_params wormhole_implementation::get_host_address_params() const {
     return {
         ::wormhole::host_mem::address_map::ETH_ROUTING_BLOCK_SIZE,
         ::wormhole::host_mem::address_map::ETH_ROUTING_BUFFERS_START};
 }
 
-tt_driver_eth_interface_params wormhole_implementation::get_eth_interface_params() const {
+driver_eth_interface_params wormhole_implementation::get_eth_interface_params() const {
     return {
         ETH_RACK_COORD_WIDTH,
         CMD_BUF_SIZE_MASK,
@@ -100,7 +100,7 @@ tt_driver_eth_interface_params wormhole_implementation::get_eth_interface_params
     };
 }
 
-tt_driver_noc_params wormhole_implementation::get_noc_params() const {
+driver_noc_params wormhole_implementation::get_noc_params() const {
     return {NOC_ADDR_LOCAL_BITS, NOC_ADDR_NODE_ID_BITS};
 }
 

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -134,7 +134,7 @@ void Chip::unset_tensix_risc_reset(CoreCoord core, const TensixSoftResetOptions&
     send_tensix_risc_reset(core, set_selected_riscs);
 }
 
-uint32_t Chip::get_power_state_arc_msg(tt_DevicePowerState state) {
+uint32_t Chip::get_power_state_arc_msg(DevicePowerState state) {
     uint32_t msg = wormhole::ARC_MSG_COMMON_PREFIX;
     switch (state) {
         case BUSY: {
@@ -198,12 +198,12 @@ tt_xy_pair Chip::translate_chip_coord_to_translated(const CoreCoord core) const 
     return soc_descriptor_.translate_coord_to(core, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::TRANSLATED);
 }
 
-void Chip::wait_for_aiclk_value(TTDevice* tt_device, tt_DevicePowerState power_state, const uint32_t timeout_ms) {
+void Chip::wait_for_aiclk_value(TTDevice* tt_device, DevicePowerState power_state, const uint32_t timeout_ms) {
     auto start = std::chrono::system_clock::now();
     uint32_t target_aiclk = 0;
-    if (power_state == tt_DevicePowerState::BUSY) {
+    if (power_state == DevicePowerState::BUSY) {
         target_aiclk = tt_device->get_max_clock_freq();
-    } else if (power_state == tt_DevicePowerState::LONG_IDLE) {
+    } else if (power_state == DevicePowerState::LONG_IDLE) {
         target_aiclk = tt_device->get_min_clock_freq();
     }
     uint32_t aiclk = tt_device->get_clock();

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -71,7 +71,7 @@ void MockChip::dram_membar(const std::unordered_set<uint32_t>& channels) {}
 
 void MockChip::deassert_risc_resets() {}
 
-void MockChip::set_power_state(tt_DevicePowerState state) {}
+void MockChip::set_power_state(DevicePowerState state) {}
 
 int MockChip::get_clock() { return 0; }
 

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -86,7 +86,7 @@ void RemoteChip::close_device() {
     // in LONG_IDLE by tt-smi reset would hang
     if ((uint32_t)local_chip_->get_clock() != local_chip_->get_tt_device()->get_min_clock_freq()) {
         if ((uint32_t)get_clock() != get_tt_device()->get_min_clock_freq()) {
-            set_power_state(tt_DevicePowerState::LONG_IDLE);
+            set_power_state(DevicePowerState::LONG_IDLE);
             send_tensix_risc_reset(TENSIX_ASSERT_SOFT_RESET);
         }
     }
@@ -133,7 +133,7 @@ void RemoteChip::dram_membar(const std::unordered_set<uint32_t>& channels) { wai
 
 void RemoteChip::deassert_risc_resets() { local_chip_->deassert_risc_resets(); }
 
-void RemoteChip::set_power_state(tt_DevicePowerState state) {
+void RemoteChip::set_power_state(DevicePowerState state) {
     if (soc_descriptor_.arch == tt::ARCH::WORMHOLE_B0) {
         uint32_t msg = get_power_state_arc_msg(state);
         int exit_code = arc_msg(wormhole::ARC_MSG_COMMON_PREFIX | msg, true, 0, 0);

--- a/device/chip_helpers/sysmem_manager.cpp
+++ b/device/chip_helpers/sysmem_manager.cpp
@@ -203,7 +203,7 @@ bool SysmemManager::init_hugepages(uint32_t num_host_mem_channels) {
 
         // Beter performance if hugepage just allocated (populate flag to prevent lazy alloc) is migrated to same
         // numanode as TT device.
-        if (!tt::cpuset::tt_cpuset_allocator::bind_area_to_memory_nodeset(physical_device_id, mapping, hugepage_size)) {
+        if (!tt::cpuset::cpuset_allocator::bind_area_to_memory_nodeset(physical_device_id, mapping, hugepage_size)) {
             log_warning(
                 LogSiliconDriver,
                 "---- ttSiliconDevice::init_hugepage: bind_area_to_memory_nodeset() failed (physical_device_id: {} ch: "

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -961,7 +961,7 @@ void Cluster::broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOption
     wait_for_non_mmio_flush();
 }
 
-void Cluster::set_power_state(tt_DevicePowerState device_state) {
+void Cluster::set_power_state(DevicePowerState device_state) {
     for (auto& [_, chip] : chips_) {
         chip->set_power_state(device_state);
     }
@@ -983,7 +983,7 @@ void Cluster::deassert_resets_and_set_power_state() {
     }
 
     // Set power state to busy
-    set_power_state(tt_DevicePowerState::BUSY);
+    set_power_state(DevicePowerState::BUSY);
 }
 
 void Cluster::verify_eth_fw() {
@@ -1031,7 +1031,7 @@ void Cluster::verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std
         get_soc_descriptor(device_id).noc_translation_enabled;
 }
 
-void Cluster::start_device(const tt_device_params& device_params) {
+void Cluster::start_device(const device_params& device_params) {
     if (this->chip_type_ == tt::umd::ChipType::MOCK) {
         // Mock cluster doesn't need to start device
         return;

--- a/device/cpuset_lib.cpp
+++ b/device/cpuset_lib.cpp
@@ -26,7 +26,7 @@ namespace fs = std::filesystem;
 /////////////////////////////////////////////////////////////////////////
 
 // Constructor for singleton class cpu id allocator
-tt_cpuset_allocator::tt_cpuset_allocator() {
+cpuset_allocator::cpuset_allocator() {
     m_pid = getpid();
     m_debug = std::getenv("TT_BACKEND_CPUSET_ALLOCATOR_DEBUG") ? true : false;
 
@@ -36,7 +36,7 @@ tt_cpuset_allocator::tt_cpuset_allocator() {
     auto system_tid = std::this_thread::get_id();
     log_debug(
         LogSiliconDriver,
-        "Starting tt_cpuset_allocator constructor now for process_id: {} thread_id: {}",
+        "Starting cpuset_allocator constructor now for process_id: {} thread_id: {}",
         m_pid,
         system_tid);
 
@@ -60,7 +60,7 @@ tt_cpuset_allocator::tt_cpuset_allocator() {
 
         log_debug(
             LogSiliconDriver,
-            "Finished tt_cpuset_allocator constructor now with m_enable_cpuset_allocator: {} for process_id: {} "
+            "Finished cpuset_allocator constructor now with m_enable_cpuset_allocator: {} for process_id: {} "
             "thread_id: {} ",
             m_enable_cpuset_allocator,
             m_pid,
@@ -69,8 +69,8 @@ tt_cpuset_allocator::tt_cpuset_allocator() {
 }
 
 // Step 1 : Initialize and perform m_topology detection
-bool tt_cpuset_allocator::init_topology_init_and_load() {
-    log_debug(LogSiliconDriver, "Inside tt_cpuset_allocator::topology_init_and_load()");
+bool cpuset_allocator::init_topology_init_and_load() {
+    log_debug(LogSiliconDriver, "Inside cpuset_allocator::topology_init_and_load()");
 
     if (!m_enable_cpuset_allocator) {
         return false;
@@ -94,12 +94,12 @@ bool tt_cpuset_allocator::init_topology_init_and_load() {
 
 // Step 2 - Find TT PCI devices in topology by vendor_id to get their PCI bus_id and physical device_id, and package and
 // numamode.
-bool tt_cpuset_allocator::init_find_tt_pci_devices_packages_numanodes() {
+bool cpuset_allocator::init_find_tt_pci_devices_packages_numanodes() {
     if (!m_enable_cpuset_allocator) {
         return false;
     }
 
-    log_debug(LogSiliconDriver, "Starting tt_cpuset_allocator::init_find_tt_pci_devices_packages_numanodes()");
+    log_debug(LogSiliconDriver, "Starting cpuset_allocator::init_find_tt_pci_devices_packages_numanodes()");
     m_num_tt_device_by_pci_device_id_map.clear();
 
     hwloc_obj_t pci_device_obj = NULL;
@@ -199,7 +199,7 @@ bool tt_cpuset_allocator::init_find_tt_pci_devices_packages_numanodes() {
 
     log_debug(
         LogSiliconDriver,
-        "Finshed tt_cpuset_allocator::init_find_tt_pci_devices_packages_numanodes() found {} devices",
+        "Finshed cpuset_allocator::init_find_tt_pci_devices_packages_numanodes() found {} devices",
         m_all_tt_devices.size());
 
     // Sort these 2 vectors of device_ids before we are done, since discovery can be in any order.
@@ -213,7 +213,7 @@ bool tt_cpuset_allocator::init_find_tt_pci_devices_packages_numanodes() {
 }
 
 // Step 3 : Detect the number of packages.
-bool tt_cpuset_allocator::init_get_number_of_packages() {
+bool cpuset_allocator::init_get_number_of_packages() {
     if (!m_enable_cpuset_allocator) {
         return false;
     }
@@ -224,7 +224,7 @@ bool tt_cpuset_allocator::init_get_number_of_packages() {
 }
 
 // Step 4 : Return true if all packages are models we want to support. Env-var can be used to ignore this check.
-bool tt_cpuset_allocator::init_is_cpu_model_supported() {
+bool cpuset_allocator::init_is_cpu_model_supported() {
     if (!m_enable_cpuset_allocator) {
         return false;
     }
@@ -236,7 +236,7 @@ bool tt_cpuset_allocator::init_is_cpu_model_supported() {
 
     bool use_any_cpu = std::getenv("TT_BACKEND_CPUSET_ALLOCATOR_SUPPORT_ANY_CPU") ? true : false;
 
-    log_debug(LogSiliconDriver, "Inside tt_cpuset_allocator::check_if_cpu_model_supported()");
+    log_debug(LogSiliconDriver, "Inside cpuset_allocator::check_if_cpu_model_supported()");
 
     // Supported CPU Models for enabling CPUSET Allocator.  Keep the list small to production machines to start.
     std::vector<std::string> supported_cpu_models = {
@@ -286,12 +286,12 @@ bool tt_cpuset_allocator::init_is_cpu_model_supported() {
 
 // Step 5: Get all target allocation objects (ie. L3Cache if IO thread to be allocated per L3Cache cpuset) for a given
 // socket/package.
-bool tt_cpuset_allocator::init_determine_cpuset_allocations() {
+bool cpuset_allocator::init_determine_cpuset_allocations() {
     if (!m_enable_cpuset_allocator) {
         return false;
     }
 
-    log_debug(LogSiliconDriver, "Inside tt_cpuset_allocator::init_determine_cpuset_allocations()");
+    log_debug(LogSiliconDriver, "Inside cpuset_allocator::init_determine_cpuset_allocations()");
     for (const auto &package : m_package_id_to_devices_map) {
         int package_id = package.first;
         auto num_tt_devices_for_cpu_package = package.second.size();
@@ -407,7 +407,7 @@ bool tt_cpuset_allocator::init_determine_cpuset_allocations() {
 
 // Given a physical device_id, determine the right numa nodes associated with it and attempt to membind a previously
 // allocated memory region to it.
-bool tt_cpuset_allocator::bind_area_memory_nodeset(chip_id_t physical_device_id, const void *addr, size_t len) {
+bool cpuset_allocator::bind_area_memory_nodeset(chip_id_t physical_device_id, const void *addr, size_t len) {
     auto tid = std::this_thread::get_id();
     log_debug(
         LogSiliconDriver,
@@ -467,7 +467,7 @@ bool tt_cpuset_allocator::bind_area_memory_nodeset(chip_id_t physical_device_id,
     return true;  // Success
 }
 
-int tt_cpuset_allocator::_get_num_tt_pci_devices() {
+int cpuset_allocator::_get_num_tt_pci_devices() {
     for (auto &d : m_physical_device_id_to_package_id_map) {
         log_trace(LogSiliconDriver, "Found physical_device_id: {} ", d.first);
     }
@@ -478,7 +478,7 @@ int tt_cpuset_allocator::_get_num_tt_pci_devices() {
 // Helper Functions //////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////
 
-std::string tt_cpuset_allocator::get_pci_bus_id(hwloc_obj_t pci_device_obj) {
+std::string cpuset_allocator::get_pci_bus_id(hwloc_obj_t pci_device_obj) {
     std::string pci_bus_id_str = "";
 
     if (hwloc_obj_type_is_io(pci_device_obj->type)) {
@@ -489,7 +489,7 @@ std::string tt_cpuset_allocator::get_pci_bus_id(hwloc_obj_t pci_device_obj) {
     return pci_bus_id_str;
 }
 
-int tt_cpuset_allocator::get_package_id_from_device(hwloc_obj_t pci_device_obj, chip_id_t physical_device_id) {
+int cpuset_allocator::get_package_id_from_device(hwloc_obj_t pci_device_obj, chip_id_t physical_device_id) {
     auto pci_bus_id_str = m_physical_device_id_to_pci_bus_id_map.at(physical_device_id);
 
     log_debug(
@@ -535,7 +535,7 @@ int tt_cpuset_allocator::get_package_id_from_device(hwloc_obj_t pci_device_obj, 
     return package_id;
 }
 
-hwloc_nodeset_t tt_cpuset_allocator::get_numa_nodeset_from_device(
+hwloc_nodeset_t cpuset_allocator::get_numa_nodeset_from_device(
     hwloc_obj_t pci_device_obj, chip_id_t physical_device_id) {
     hwloc_nodeset_t nodeset = 0x0;
 
@@ -581,7 +581,7 @@ hwloc_nodeset_t tt_cpuset_allocator::get_numa_nodeset_from_device(
     return nodeset;
 }
 
-int tt_cpuset_allocator::_get_num_tt_pci_devices_by_pci_device_id(uint16_t device_id, uint16_t revision) {
+int cpuset_allocator::_get_num_tt_pci_devices_by_pci_device_id(uint16_t device_id, uint16_t revision) {
     std::pair<uint16_t, uint16_t> device_id_revision = std::make_pair(device_id, revision);
 
     if (m_num_tt_device_by_pci_device_id_map.find(device_id_revision) != m_num_tt_device_by_pci_device_id_map.end()) {
@@ -601,7 +601,7 @@ int tt_cpuset_allocator::_get_num_tt_pci_devices_by_pci_device_id(uint16_t devic
 /////////////////////////////////////////////////////////////////////////
 
 // Get all PU ids (or numa nodes) in a vector, for legacy/back-compat/debug purposes.
-std::vector<int> tt_cpuset_allocator::get_hwloc_bitmap_vector(hwloc_bitmap_t &bitmap) {
+std::vector<int> cpuset_allocator::get_hwloc_bitmap_vector(hwloc_bitmap_t &bitmap) {
     std::vector<int> indices;
     int index;
     if (bitmap) {
@@ -611,25 +611,25 @@ std::vector<int> tt_cpuset_allocator::get_hwloc_bitmap_vector(hwloc_bitmap_t &bi
     return indices;
 }
 
-std::vector<int> tt_cpuset_allocator::get_hwloc_cpuset_vector(hwloc_obj_t &obj) {
+std::vector<int> cpuset_allocator::get_hwloc_cpuset_vector(hwloc_obj_t &obj) {
     return get_hwloc_bitmap_vector(obj->cpuset);
 }
 
-std::vector<int> tt_cpuset_allocator::get_hwloc_nodeset_vector(hwloc_obj_t &obj) {
+std::vector<int> cpuset_allocator::get_hwloc_nodeset_vector(hwloc_obj_t &obj) {
     return get_hwloc_bitmap_vector(obj->nodeset);
 }
 
 // Nicer way to print pu ids as a vector on single line.
-void tt_cpuset_allocator::print_hwloc_cpuset(hwloc_obj_t &obj) {
+void cpuset_allocator::print_hwloc_cpuset(hwloc_obj_t &obj) {
     std::cout << " Number: " << hwloc_bitmap_weight(obj->cpuset) << " cpuset_pu_ids: " << get_hwloc_cpuset_vector(obj);
 }
 
-void tt_cpuset_allocator::print_hwloc_nodeset(hwloc_obj_t &obj) {
+void cpuset_allocator::print_hwloc_nodeset(hwloc_obj_t &obj) {
     std::cout << " Number: " << hwloc_bitmap_weight(obj->nodeset)
               << " nodeset node_ids: " << get_hwloc_nodeset_vector(obj);
 }
 
-void tt_cpuset_allocator::print_hwloc_object(hwloc_obj_t &obj, int depth, bool verbose, bool show_cpuids) {
+void cpuset_allocator::print_hwloc_object(hwloc_obj_t &obj, int depth, bool verbose, bool show_cpuids) {
     char type[32], attr[1024];
 
     hwloc_obj_type_snprintf(type, sizeof(type), obj, verbose);

--- a/device/cpuset_lib.hpp
+++ b/device/cpuset_lib.hpp
@@ -24,34 +24,34 @@ using tt::umd::chip_id_t;
 
 // CPU ID allocator for pinning threads to cpu_ids
 // It's a singleton that should be retrieved via get()
-struct tt_cpuset_allocator {
+struct cpuset_allocator {
 public:
-    tt_cpuset_allocator(tt_cpuset_allocator const &) = delete;
-    void operator=(tt_cpuset_allocator const &) = delete;
+    cpuset_allocator(cpuset_allocator const &) = delete;
+    void operator=(cpuset_allocator const &) = delete;
 
     // Bind an already allocated memory region to particular numa nodes
     static bool bind_area_to_memory_nodeset(chip_id_t physical_device_id, const void *addr, size_t len) {
-        auto &instance = tt_cpuset_allocator::get();
+        auto &instance = cpuset_allocator::get();
         return instance.bind_area_memory_nodeset(physical_device_id, addr, len);
     }
 
     static int get_num_tt_pci_devices() {
-        auto &instance = tt_cpuset_allocator::get();
+        auto &instance = cpuset_allocator::get();
         return instance._get_num_tt_pci_devices();
     }
 
     static int get_num_tt_pci_devices_by_pci_device_id(uint16_t device_id, uint16_t revision_id) {
-        auto &instance = tt_cpuset_allocator::get();
+        auto &instance = cpuset_allocator::get();
         return instance._get_num_tt_pci_devices_by_pci_device_id(device_id, revision_id);
     }
 
 private:
-    static tt_cpuset_allocator &get() {
-        static tt_cpuset_allocator instance;
+    static cpuset_allocator &get() {
+        static cpuset_allocator instance;
         return instance;
     }
 
-    tt_cpuset_allocator();
+    cpuset_allocator();
 
     int TENSTORRENT_VENDOR_ID = 0x1e52;
 

--- a/device/hugepage.cpp
+++ b/device/hugepage.cpp
@@ -42,9 +42,9 @@ uint32_t get_num_hugepages() {
 uint32_t get_available_num_host_mem_channels(
     const uint32_t num_channels_per_device_target, const uint16_t device_id, const uint16_t revision_id) {
     // To minimally support hybrid dev systems with mix of ARCH, get only devices matching current ARCH's device_id.
-    uint32_t total_num_tt_mmio_devices = tt::cpuset::tt_cpuset_allocator::get_num_tt_pci_devices();
+    uint32_t total_num_tt_mmio_devices = tt::cpuset::cpuset_allocator::get_num_tt_pci_devices();
     uint32_t num_tt_mmio_devices_for_arch =
-        tt::cpuset::tt_cpuset_allocator::get_num_tt_pci_devices_by_pci_device_id(device_id, revision_id);
+        tt::cpuset::cpuset_allocator::get_num_tt_pci_devices_by_pci_device_id(device_id, revision_id);
     uint32_t total_hugepages = get_num_hugepages();
 
     // This shouldn't happen on silicon machines.

--- a/device/simulation/simulation_device.cpp
+++ b/device/simulation/simulation_device.cpp
@@ -222,7 +222,7 @@ void SimulationDevice::dram_membar(const std::unordered_set<CoreCoord>& cores) {
 
 void SimulationDevice::deassert_risc_resets() {}
 
-void SimulationDevice::set_power_state(tt_DevicePowerState state) {}
+void SimulationDevice::set_power_state(DevicePowerState state) {}
 
 int SimulationDevice::get_clock() { return 0; }
 

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -372,7 +372,7 @@ TEST(ClusterAPI, DynamicTLB_RW) {
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
-    tt_device_params default_params;
+    device_params default_params;
     cluster->start_device(default_params);
 
     std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -488,7 +488,7 @@ TEST(TestCluster, TestClusterAICLKControl) {
         return 0u;
     };
 
-    cluster->set_power_state(tt_DevicePowerState::BUSY);
+    cluster->set_power_state(DevicePowerState::BUSY);
 
     auto clocks_busy = cluster->get_clocks();
     for (auto& clock : clocks_busy) {
@@ -497,7 +497,7 @@ TEST(TestCluster, TestClusterAICLKControl) {
         EXPECT_GT(clock.second, get_expected_clock_val(clock.first, false));
     }
 
-    cluster->set_power_state(tt_DevicePowerState::LONG_IDLE);
+    cluster->set_power_state(DevicePowerState::LONG_IDLE);
 
     auto clocks_idle = cluster->get_clocks();
     for (auto& clock : clocks_idle) {
@@ -860,7 +860,7 @@ TEST_P(ClusterReadWriteL1Test, ReadWriteL1) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
     }
     if (options.chip_type == SIMULATION) {
-        tt_device_params device_params;
+        device_params device_params;
         device_params.init_device = true;
         cluster->start_device(device_params);
     }

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -71,7 +71,7 @@ std::int32_t get_static_tlb_index(tt_xy_pair target) {
 }
 
 TEST(SiliconDriverBH, CreateDestroy) {
-    tt_device_params default_params;
+    device_params default_params;
     for (int i = 0; i < 50; i++) {
         Cluster cluster;
         set_barrier_params(cluster);
@@ -145,7 +145,7 @@ TEST(SiliconDriverBH, CreateDestroy) {
 //         }
 //     }
 
-//     tt_device_params default_params;
+//     device_params default_params;
 //     cluster.start_device(default_params);
 
 //     std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -227,7 +227,7 @@ TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
         }
     }
 
-    tt_device_params default_params;
+    device_params default_params;
     cluster.start_device(default_params);
 
     std::vector<uint32_t> unaligned_sizes = {3, 14, 21, 255, 362, 430, 1022, 1023, 1025};
@@ -281,7 +281,7 @@ TEST(SiliconDriverBH, StaticTLB_RW) {
 
     printf("MT: Static TLBs set\n");
 
-    tt_device_params default_params;
+    device_params default_params;
     cluster.start_device(default_params);
 
     std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -321,7 +321,7 @@ TEST(SiliconDriverBH, DynamicTLB_RW) {
     Cluster cluster;
     set_barrier_params(cluster);
 
-    tt_device_params default_params;
+    device_params default_params;
     cluster.start_device(default_params);
 
     std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -385,7 +385,7 @@ TEST(SiliconDriverBH, MultiThreadedDevice) {
 
     set_barrier_params(cluster);
 
-    tt_device_params default_params;
+    device_params default_params;
     cluster.start_device(default_params);
 
     std::thread th1 = std::thread([&] {
@@ -453,7 +453,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
         }
     }
 
-    tt_device_params default_params;
+    device_params default_params;
     cluster.start_device(default_params);
 
     std::vector<uint32_t> readback_membar_vec = {};
@@ -553,7 +553,7 @@ TEST(SiliconDriverBH, DISABLED_BroadcastWrite) {  // Cannot broadcast to tensix/
     set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
 
-    tt_device_params default_params;
+    device_params default_params;
     cluster.start_device(default_params);
     std::vector<uint32_t> broadcast_sizes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
     uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
@@ -630,7 +630,7 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as
     set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
 
-    tt_device_params default_params;
+    device_params default_params;
     cluster.start_device(default_params);
     auto eth_version = cluster.get_ethernet_fw_version();
     bool virtual_bcast_supported = (eth_version >= tt_version(6, 8, 0) || eth_version == tt_version(6, 7, 241)) &&
@@ -716,7 +716,7 @@ TEST(SiliconDriverBH, SysmemTestWithPcie) {
     Cluster cluster;
 
     set_barrier_params(cluster);
-    cluster.start_device(tt_device_params{});  // no special parameters
+    cluster.start_device(device_params{});  // no special parameters
 
     const chip_id_t mmio_chip_id = 0;
     const auto PCIE = cluster.get_soc_descriptor(mmio_chip_id).get_cores(CoreType::PCIE).at(0);
@@ -770,7 +770,7 @@ TEST(SiliconDriverBH, RandomSysmemTestWithPcie) {
     });
 
     set_barrier_params(cluster);
-    cluster.start_device(tt_device_params{});  // no special parameters
+    cluster.start_device(device_params{});  // no special parameters
 
     const chip_id_t mmio_chip_id = 0;
     const auto pci_cores = cluster.get_soc_descriptor(mmio_chip_id).get_cores(CoreType::PCIE);

--- a/tests/galaxy/test_galaxy_common.cpp
+++ b/tests/galaxy/test_galaxy_common.cpp
@@ -6,8 +6,7 @@
 
 #include "tests/test_utils/device_test_utils.hpp"
 
-void move_data(
-    Cluster& device, tt_multichip_core_addr sender_core, tt_multichip_core_addr receiver_core, uint32_t size) {
+void move_data(Cluster& device, multichip_core_addr sender_core, multichip_core_addr receiver_core, uint32_t size) {
     std::vector<uint32_t> readback_vec = {};
     test_utils::read_data_from_device(
         device,
@@ -28,10 +27,7 @@ void move_data(
 }
 
 void broadcast_data(
-    Cluster& device,
-    tt_multichip_core_addr sender_core,
-    std::vector<tt_multichip_core_addr> receiver_cores,
-    uint32_t size) {
+    Cluster& device, multichip_core_addr sender_core, std::vector<multichip_core_addr> receiver_cores, uint32_t size) {
     std::vector<uint32_t> readback_vec = {};
     test_utils::read_data_from_device(
         device,

--- a/tests/galaxy/test_galaxy_common.cpp
+++ b/tests/galaxy/test_galaxy_common.cpp
@@ -6,7 +6,8 @@
 
 #include "tests/test_utils/device_test_utils.hpp"
 
-void move_data(Cluster& device, multichip_core_addr sender_core, multichip_core_addr receiver_core, uint32_t size) {
+void move_data(
+    Cluster& device, tt_multichip_core_addr sender_core, tt_multichip_core_addr receiver_core, uint32_t size) {
     std::vector<uint32_t> readback_vec = {};
     test_utils::read_data_from_device(
         device,
@@ -27,7 +28,10 @@ void move_data(Cluster& device, multichip_core_addr sender_core, multichip_core_
 }
 
 void broadcast_data(
-    Cluster& device, multichip_core_addr sender_core, std::vector<multichip_core_addr> receiver_cores, uint32_t size) {
+    Cluster& device,
+    tt_multichip_core_addr sender_core,
+    std::vector<tt_multichip_core_addr> receiver_cores,
+    uint32_t size) {
     std::vector<uint32_t> readback_vec = {};
     test_utils::read_data_from_device(
         device,

--- a/tests/galaxy/test_umd_concurrent_threads.cpp
+++ b/tests/galaxy/test_umd_concurrent_threads.cpp
@@ -51,7 +51,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
 
     tt::umd::test::utils::set_barrier_params(device);
 
-    tt_device_params default_params;
+    device_params default_params;
     device.start_device(default_params);
 
     // Test
@@ -144,7 +144,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
 
     tt::umd::test::utils::set_barrier_params(device);
 
-    tt_device_params default_params;
+    device_params default_params;
     device.start_device(default_params);
 
     // Test
@@ -214,7 +214,7 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
 
     tt::umd::test::utils::set_barrier_params(device);
 
-    tt_device_params default_params;
+    device_params default_params;
     device.start_device(default_params);
     device.deassert_risc_reset();
 

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -12,7 +12,7 @@
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/wormhole/test_wh_common.h"
 #include "umd/device/cluster.h"
-#include "umd/device/cluster_descriptor.h"
+#include "umd/device/tt_cluster_descriptor.h"
 #include "wormhole/eth_interface.h"
 #include "wormhole/host_mem_address_map.h"
 #include "wormhole/l1_address_map.h"
@@ -281,7 +281,7 @@ TEST(GalaxyDataMovement, BroadcastData1) {
     std::vector<tt_multichip_core_addr> receiver_cores;
 
     for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
-        receiver_cores.push_back(multichip_core_addr(5, core, 0x6000));
+        receiver_cores.push_back(tt_multichip_core_addr(5, core, 0x6000));
     }
     run_data_broadcast_test(100, sender_core, receiver_cores);
 }
@@ -293,22 +293,38 @@ TEST(GalaxyDataMovement, BroadcastData2) {
     tt_multichip_core_addr sender_core(12, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
     std::vector<tt_multichip_core_addr> receiver_cores;
 
-    receiver_cores.push_back(multichip_core_addr(1, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(multichip_core_addr(2, CoreCoord(2, 3, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(multichip_core_addr(3, CoreCoord(2, 4, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(multichip_core_addr(4, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(multichip_core_addr(5, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(multichip_core_addr(6, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(multichip_core_addr(7, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(multichip_core_addr(8, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(multichip_core_addr(9, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(multichip_core_addr(10, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(multichip_core_addr(11, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(multichip_core_addr(12, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(multichip_core_addr(13, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(multichip_core_addr(14, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(multichip_core_addr(15, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(multichip_core_addr(16, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(1, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(2, CoreCoord(2, 3, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(3, CoreCoord(2, 4, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(4, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(5, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(6, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(7, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(8, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(9, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(10, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(11, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(12, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(13, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(14, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(15, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(16, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
     run_data_broadcast_test(1000, sender_core, receiver_cores);
 }
 
@@ -319,10 +335,14 @@ TEST(GalaxyDataMovement, BroadcastData3) {
     tt_multichip_core_addr sender_core(10, CoreCoord(0, 0, CoreType::DRAM, CoordSystem::VIRTUAL), 0x20000);
     std::vector<tt_multichip_core_addr> receiver_cores;
 
-    receiver_cores.push_back(multichip_core_addr(5, CoreCoord(1, 8, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000));
-    receiver_cores.push_back(multichip_core_addr(10, CoreCoord(1, 9, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(multichip_core_addr(15, CoreCoord(1, 10, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x7000));
-    receiver_cores.push_back(multichip_core_addr(20, CoreCoord(1, 11, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x8000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(5, CoreCoord(1, 8, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(10, CoreCoord(1, 9, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(15, CoreCoord(1, 10, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x7000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(20, CoreCoord(1, 11, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x8000));
     run_data_broadcast_test(2000, sender_core, receiver_cores);
 }
 
@@ -333,12 +353,13 @@ TEST(GalaxyDataMovement, BroadcastData4) {
     tt_multichip_core_addr sender_core(17, CoreCoord(8, 8, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x20000);
     std::vector<tt_multichip_core_addr> receiver_cores;
 
-    receiver_cores.push_back(multichip_core_addr(21, CoreCoord(0, 1, CoreType::DRAM, CoordSystem::VIRTUAL), 0x5000));
-    receiver_cores.push_back(multichip_core_addr(22, CoreCoord(0, 6, CoreType::DRAM, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(multichip_core_addr(23, CoreCoord(5, 1, CoreType::DRAM, CoordSystem::VIRTUAL), 0x7000));
-    receiver_cores.push_back(multichip_core_addr(24, CoreCoord(5, 9, CoreType::DRAM, CoordSystem::VIRTUAL), 0x8000));
-    receiver_cores.push_back(multichip_core_addr(25, CoreCoord(5, 4, CoreType::DRAM, CoordSystem::VIRTUAL), 0x9000));
-    receiver_cores.push_back(multichip_core_addr(26, CoreCoord(5, 6, CoreType::DRAM, CoordSystem::VIRTUAL), 0x10000));
+    receiver_cores.push_back(tt_multichip_core_addr(21, CoreCoord(0, 1, CoreType::DRAM, CoordSystem::VIRTUAL), 0x5000));
+    receiver_cores.push_back(tt_multichip_core_addr(22, CoreCoord(0, 6, CoreType::DRAM, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(tt_multichip_core_addr(23, CoreCoord(5, 1, CoreType::DRAM, CoordSystem::VIRTUAL), 0x7000));
+    receiver_cores.push_back(tt_multichip_core_addr(24, CoreCoord(5, 9, CoreType::DRAM, CoordSystem::VIRTUAL), 0x8000));
+    receiver_cores.push_back(tt_multichip_core_addr(25, CoreCoord(5, 4, CoreType::DRAM, CoordSystem::VIRTUAL), 0x9000));
+    receiver_cores.push_back(
+        tt_multichip_core_addr(26, CoreCoord(5, 6, CoreType::DRAM, CoordSystem::VIRTUAL), 0x10000));
     run_data_broadcast_test(150, sender_core, receiver_cores);
 }
 
@@ -349,10 +370,10 @@ TEST(GalaxyDataMovement, BroadcastData5) {
     tt_multichip_core_addr sender_core(31, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x20000);
     std::vector<tt_multichip_core_addr> receiver_cores;
 
-    receiver_cores.push_back(multichip_core_addr(21, CoreCoord(0, 1, CoreType::DRAM, CoordSystem::VIRTUAL), 0x5000));
-    receiver_cores.push_back(multichip_core_addr(30, CoreCoord(0, 6, CoreType::DRAM, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(multichip_core_addr(11, CoreCoord(5, 1, CoreType::DRAM, CoordSystem::VIRTUAL), 0x7000));
-    receiver_cores.push_back(multichip_core_addr(17, CoreCoord(5, 9, CoreType::DRAM, CoordSystem::VIRTUAL), 0x8000));
+    receiver_cores.push_back(tt_multichip_core_addr(21, CoreCoord(0, 1, CoreType::DRAM, CoordSystem::VIRTUAL), 0x5000));
+    receiver_cores.push_back(tt_multichip_core_addr(30, CoreCoord(0, 6, CoreType::DRAM, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(tt_multichip_core_addr(11, CoreCoord(5, 1, CoreType::DRAM, CoordSystem::VIRTUAL), 0x7000));
+    receiver_cores.push_back(tt_multichip_core_addr(17, CoreCoord(5, 9, CoreType::DRAM, CoordSystem::VIRTUAL), 0x8000));
     run_data_broadcast_test(2500, sender_core, receiver_cores);
 }
 

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -22,7 +22,7 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
 
     tt::umd::test::utils::set_barrier_params(device);
 
-    tt_device_params default_params;
+    device_params default_params;
     device.start_device(default_params);
     device.deassert_risc_reset();
 
@@ -106,8 +106,7 @@ TEST(GalaxyBasicReadWrite, LargeRemoteDramBlockReadWrite) { run_remote_read_writ
 
 // block write and read back 2048 uint32_t to L1 of every worker core on every chip in the cluster
 
-void run_data_mover_test(
-    uint32_t vector_size, tt_multichip_core_addr sender_core, tt_multichip_core_addr receiver_core) {
+void run_data_mover_test(uint32_t vector_size, multichip_core_addr sender_core, multichip_core_addr receiver_core) {
     Cluster device;
     auto target_devices = device.get_target_device_ids();
 
@@ -122,7 +121,7 @@ void run_data_mover_test(
 
     tt::umd::test::utils::set_barrier_params(device);
 
-    tt_device_params default_params;
+    device_params default_params;
     device.start_device(default_params);
     device.deassert_risc_reset();
 
@@ -167,50 +166,50 @@ void run_data_mover_test(
 
 // L1 to L1
 TEST(GalaxyDataMovement, TwoChipMoveData1) {
-    tt_multichip_core_addr sender_core(4, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
-    tt_multichip_core_addr receiver_core(5, CoreCoord(9, 11, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000);
+    multichip_core_addr sender_core(4, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
+    multichip_core_addr receiver_core(5, CoreCoord(9, 11, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000);
     run_data_mover_test(100, sender_core, receiver_core);
 
-    sender_core = tt_multichip_core_addr(31, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
-    receiver_core = tt_multichip_core_addr(9, CoreCoord(8, 8, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000);
+    sender_core = multichip_core_addr(31, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
+    receiver_core = multichip_core_addr(9, CoreCoord(8, 8, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000);
     run_data_mover_test(30000, sender_core, receiver_core);
 }
 
 // L1 to Dram
 TEST(GalaxyDataMovement, TwoChipMoveData2) {
-    tt_multichip_core_addr sender_core(1, CoreCoord(2, 3, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x30000);
-    tt_multichip_core_addr receiver_core(6, CoreCoord(5, 0, CoreType::DRAM, CoordSystem::VIRTUAL), 0x0);
+    multichip_core_addr sender_core(1, CoreCoord(2, 3, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x30000);
+    multichip_core_addr receiver_core(6, CoreCoord(5, 0, CoreType::DRAM, CoordSystem::VIRTUAL), 0x0);
     run_data_mover_test(2000, sender_core, receiver_core);
 
-    sender_core = tt_multichip_core_addr(11, CoreCoord(3, 3, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x50000);
-    receiver_core = tt_multichip_core_addr(5, CoreCoord(0, 0, CoreType::DRAM, CoordSystem::VIRTUAL), 0x60000);
+    sender_core = multichip_core_addr(11, CoreCoord(3, 3, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x50000);
+    receiver_core = multichip_core_addr(5, CoreCoord(0, 0, CoreType::DRAM, CoordSystem::VIRTUAL), 0x60000);
     run_data_mover_test(20000, sender_core, receiver_core);
 }
 
 // Dram to L1
 TEST(GalaxyDataMovement, TwoChipMoveData3) {
-    tt_multichip_core_addr sender_core(8, CoreCoord(5, 9, CoreType::DRAM, CoordSystem::VIRTUAL), 0x90000);
-    tt_multichip_core_addr receiver_core(21, CoreCoord(1, 9, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5200);
+    multichip_core_addr sender_core(8, CoreCoord(5, 9, CoreType::DRAM, CoordSystem::VIRTUAL), 0x90000);
+    multichip_core_addr receiver_core(21, CoreCoord(1, 9, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5200);
     run_data_mover_test(1200, sender_core, receiver_core);
 
-    sender_core = tt_multichip_core_addr(11, CoreCoord(5, 5, CoreType::DRAM, CoordSystem::VIRTUAL), 0x40000);
-    receiver_core = tt_multichip_core_addr(18, CoreCoord(8, 7, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x7000);
+    sender_core = multichip_core_addr(11, CoreCoord(5, 5, CoreType::DRAM, CoordSystem::VIRTUAL), 0x40000);
+    receiver_core = multichip_core_addr(18, CoreCoord(8, 7, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x7000);
     run_data_mover_test(8800, sender_core, receiver_core);
 }
 
 // Dram to Dram
 TEST(GalaxyDataMovement, TwoChipMoveData4) {
-    tt_multichip_core_addr sender_core(7, CoreCoord(0, 6, CoreType::DRAM, CoordSystem::VIRTUAL), 0x300000);
-    tt_multichip_core_addr receiver_core(19, CoreCoord(0, 0, CoreType::DRAM, CoordSystem::VIRTUAL), 0x300000);
+    multichip_core_addr sender_core(7, CoreCoord(0, 6, CoreType::DRAM, CoordSystem::VIRTUAL), 0x300000);
+    multichip_core_addr receiver_core(19, CoreCoord(0, 0, CoreType::DRAM, CoordSystem::VIRTUAL), 0x300000);
     run_data_mover_test(1200, sender_core, receiver_core);
 
-    sender_core = tt_multichip_core_addr(15, CoreCoord(5, 2, CoreType::DRAM, CoordSystem::VIRTUAL), 0x400000);
-    receiver_core = tt_multichip_core_addr(16, CoreCoord(0, 11, CoreType::DRAM, CoordSystem::VIRTUAL), 0x400000);
+    sender_core = multichip_core_addr(15, CoreCoord(5, 2, CoreType::DRAM, CoordSystem::VIRTUAL), 0x400000);
+    receiver_core = multichip_core_addr(16, CoreCoord(0, 11, CoreType::DRAM, CoordSystem::VIRTUAL), 0x400000);
     run_data_mover_test(8800, sender_core, receiver_core);
 }
 
 void run_data_broadcast_test(
-    uint32_t vector_size, tt_multichip_core_addr sender_core, std::vector<tt_multichip_core_addr> receiver_cores) {
+    uint32_t vector_size, multichip_core_addr sender_core, std::vector<multichip_core_addr> receiver_cores) {
     Cluster device;
     auto target_devices = device.get_target_device_ids();
 
@@ -227,7 +226,7 @@ void run_data_broadcast_test(
 
     tt::umd::test::utils::set_barrier_params(device);
 
-    tt_device_params default_params;
+    device_params default_params;
     device.start_device(default_params);
     device.deassert_risc_reset();
 
@@ -277,11 +276,11 @@ void run_data_broadcast_test(
 TEST(GalaxyDataMovement, BroadcastData1) {
     SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
 
-    tt_multichip_core_addr sender_core(4, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
-    std::vector<tt_multichip_core_addr> receiver_cores;
+    multichip_core_addr sender_core(4, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
+    std::vector<multichip_core_addr> receiver_cores;
 
     for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
-        receiver_cores.push_back(tt_multichip_core_addr(5, core, 0x6000));
+        receiver_cores.push_back(multichip_core_addr(5, core, 0x6000));
     }
     run_data_broadcast_test(100, sender_core, receiver_cores);
 }
@@ -290,41 +289,25 @@ TEST(GalaxyDataMovement, BroadcastData1) {
 TEST(GalaxyDataMovement, BroadcastData2) {
     SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
 
-    tt_multichip_core_addr sender_core(12, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
-    std::vector<tt_multichip_core_addr> receiver_cores;
+    multichip_core_addr sender_core(12, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
+    std::vector<multichip_core_addr> receiver_cores;
 
-    receiver_cores.push_back(
-        tt_multichip_core_addr(1, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(2, CoreCoord(2, 3, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(3, CoreCoord(2, 4, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(4, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(5, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(6, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(7, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(8, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(9, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(10, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(11, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(12, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(13, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(14, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(15, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(16, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(1, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(2, CoreCoord(2, 3, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(3, CoreCoord(2, 4, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(4, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(5, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(6, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(7, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(8, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(9, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(10, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(11, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(12, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(13, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(14, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(15, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(16, CoreCoord(2, 5, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
     run_data_broadcast_test(1000, sender_core, receiver_cores);
 }
 
@@ -332,17 +315,13 @@ TEST(GalaxyDataMovement, BroadcastData2) {
 TEST(GalaxyDataMovement, BroadcastData3) {
     SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
 
-    tt_multichip_core_addr sender_core(10, CoreCoord(0, 0, CoreType::DRAM, CoordSystem::VIRTUAL), 0x20000);
-    std::vector<tt_multichip_core_addr> receiver_cores;
+    multichip_core_addr sender_core(10, CoreCoord(0, 0, CoreType::DRAM, CoordSystem::VIRTUAL), 0x20000);
+    std::vector<multichip_core_addr> receiver_cores;
 
-    receiver_cores.push_back(
-        tt_multichip_core_addr(5, CoreCoord(1, 8, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(10, CoreCoord(1, 9, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(15, CoreCoord(1, 10, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x7000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(20, CoreCoord(1, 11, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x8000));
+    receiver_cores.push_back(multichip_core_addr(5, CoreCoord(1, 8, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000));
+    receiver_cores.push_back(multichip_core_addr(10, CoreCoord(1, 9, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(15, CoreCoord(1, 10, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x7000));
+    receiver_cores.push_back(multichip_core_addr(20, CoreCoord(1, 11, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x8000));
     run_data_broadcast_test(2000, sender_core, receiver_cores);
 }
 
@@ -350,16 +329,15 @@ TEST(GalaxyDataMovement, BroadcastData3) {
 TEST(GalaxyDataMovement, BroadcastData4) {
     SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
 
-    tt_multichip_core_addr sender_core(17, CoreCoord(8, 8, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x20000);
-    std::vector<tt_multichip_core_addr> receiver_cores;
+    multichip_core_addr sender_core(17, CoreCoord(8, 8, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x20000);
+    std::vector<multichip_core_addr> receiver_cores;
 
-    receiver_cores.push_back(tt_multichip_core_addr(21, CoreCoord(0, 1, CoreType::DRAM, CoordSystem::VIRTUAL), 0x5000));
-    receiver_cores.push_back(tt_multichip_core_addr(22, CoreCoord(0, 6, CoreType::DRAM, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(tt_multichip_core_addr(23, CoreCoord(5, 1, CoreType::DRAM, CoordSystem::VIRTUAL), 0x7000));
-    receiver_cores.push_back(tt_multichip_core_addr(24, CoreCoord(5, 9, CoreType::DRAM, CoordSystem::VIRTUAL), 0x8000));
-    receiver_cores.push_back(tt_multichip_core_addr(25, CoreCoord(5, 4, CoreType::DRAM, CoordSystem::VIRTUAL), 0x9000));
-    receiver_cores.push_back(
-        tt_multichip_core_addr(26, CoreCoord(5, 6, CoreType::DRAM, CoordSystem::VIRTUAL), 0x10000));
+    receiver_cores.push_back(multichip_core_addr(21, CoreCoord(0, 1, CoreType::DRAM, CoordSystem::VIRTUAL), 0x5000));
+    receiver_cores.push_back(multichip_core_addr(22, CoreCoord(0, 6, CoreType::DRAM, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(23, CoreCoord(5, 1, CoreType::DRAM, CoordSystem::VIRTUAL), 0x7000));
+    receiver_cores.push_back(multichip_core_addr(24, CoreCoord(5, 9, CoreType::DRAM, CoordSystem::VIRTUAL), 0x8000));
+    receiver_cores.push_back(multichip_core_addr(25, CoreCoord(5, 4, CoreType::DRAM, CoordSystem::VIRTUAL), 0x9000));
+    receiver_cores.push_back(multichip_core_addr(26, CoreCoord(5, 6, CoreType::DRAM, CoordSystem::VIRTUAL), 0x10000));
     run_data_broadcast_test(150, sender_core, receiver_cores);
 }
 
@@ -367,24 +345,24 @@ TEST(GalaxyDataMovement, BroadcastData4) {
 TEST(GalaxyDataMovement, BroadcastData5) {
     SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
 
-    tt_multichip_core_addr sender_core(31, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x20000);
-    std::vector<tt_multichip_core_addr> receiver_cores;
+    multichip_core_addr sender_core(31, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x20000);
+    std::vector<multichip_core_addr> receiver_cores;
 
-    receiver_cores.push_back(tt_multichip_core_addr(21, CoreCoord(0, 1, CoreType::DRAM, CoordSystem::VIRTUAL), 0x5000));
-    receiver_cores.push_back(tt_multichip_core_addr(30, CoreCoord(0, 6, CoreType::DRAM, CoordSystem::VIRTUAL), 0x6000));
-    receiver_cores.push_back(tt_multichip_core_addr(11, CoreCoord(5, 1, CoreType::DRAM, CoordSystem::VIRTUAL), 0x7000));
-    receiver_cores.push_back(tt_multichip_core_addr(17, CoreCoord(5, 9, CoreType::DRAM, CoordSystem::VIRTUAL), 0x8000));
+    receiver_cores.push_back(multichip_core_addr(21, CoreCoord(0, 1, CoreType::DRAM, CoordSystem::VIRTUAL), 0x5000));
+    receiver_cores.push_back(multichip_core_addr(30, CoreCoord(0, 6, CoreType::DRAM, CoordSystem::VIRTUAL), 0x6000));
+    receiver_cores.push_back(multichip_core_addr(11, CoreCoord(5, 1, CoreType::DRAM, CoordSystem::VIRTUAL), 0x7000));
+    receiver_cores.push_back(multichip_core_addr(17, CoreCoord(5, 9, CoreType::DRAM, CoordSystem::VIRTUAL), 0x8000));
     run_data_broadcast_test(2500, sender_core, receiver_cores);
 }
 
 // L1 to L1 cores on many chips
 // TODO: Failing with mismatch
 TEST(GalaxyDataMovement, DISABLED_BroadcastData6) {
-    tt_multichip_core_addr sender_core(1, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
-    std::vector<tt_multichip_core_addr> receiver_cores;
+    multichip_core_addr sender_core(1, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
+    std::vector<multichip_core_addr> receiver_cores;
     for (int i = 2; i < 33; ++i) {
         receiver_cores.push_back(
-            tt_multichip_core_addr(i, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x7000));
+            multichip_core_addr(i, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x7000));
     }
     run_data_broadcast_test(10000, sender_core, receiver_cores);
 }

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -106,7 +106,8 @@ TEST(GalaxyBasicReadWrite, LargeRemoteDramBlockReadWrite) { run_remote_read_writ
 
 // block write and read back 2048 uint32_t to L1 of every worker core on every chip in the cluster
 
-void run_data_mover_test(uint32_t vector_size, multichip_core_addr sender_core, multichip_core_addr receiver_core) {
+void run_data_mover_test(
+    uint32_t vector_size, tt_multichip_core_addr sender_core, tt_multichip_core_addr receiver_core) {
     Cluster device;
     auto target_devices = device.get_target_device_ids();
 
@@ -166,50 +167,50 @@ void run_data_mover_test(uint32_t vector_size, multichip_core_addr sender_core, 
 
 // L1 to L1
 TEST(GalaxyDataMovement, TwoChipMoveData1) {
-    multichip_core_addr sender_core(4, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
-    multichip_core_addr receiver_core(5, CoreCoord(9, 11, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000);
+    tt_multichip_core_addr sender_core(4, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
+    tt_multichip_core_addr receiver_core(5, CoreCoord(9, 11, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000);
     run_data_mover_test(100, sender_core, receiver_core);
 
-    sender_core = multichip_core_addr(31, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
-    receiver_core = multichip_core_addr(9, CoreCoord(8, 8, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000);
+    sender_core = tt_multichip_core_addr(31, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
+    receiver_core = tt_multichip_core_addr(9, CoreCoord(8, 8, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000);
     run_data_mover_test(30000, sender_core, receiver_core);
 }
 
 // L1 to Dram
 TEST(GalaxyDataMovement, TwoChipMoveData2) {
-    multichip_core_addr sender_core(1, CoreCoord(2, 3, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x30000);
-    multichip_core_addr receiver_core(6, CoreCoord(5, 0, CoreType::DRAM, CoordSystem::VIRTUAL), 0x0);
+    tt_multichip_core_addr sender_core(1, CoreCoord(2, 3, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x30000);
+    tt_multichip_core_addr receiver_core(6, CoreCoord(5, 0, CoreType::DRAM, CoordSystem::VIRTUAL), 0x0);
     run_data_mover_test(2000, sender_core, receiver_core);
 
-    sender_core = multichip_core_addr(11, CoreCoord(3, 3, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x50000);
-    receiver_core = multichip_core_addr(5, CoreCoord(0, 0, CoreType::DRAM, CoordSystem::VIRTUAL), 0x60000);
+    sender_core = tt_multichip_core_addr(11, CoreCoord(3, 3, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x50000);
+    receiver_core = tt_multichip_core_addr(5, CoreCoord(0, 0, CoreType::DRAM, CoordSystem::VIRTUAL), 0x60000);
     run_data_mover_test(20000, sender_core, receiver_core);
 }
 
 // Dram to L1
 TEST(GalaxyDataMovement, TwoChipMoveData3) {
-    multichip_core_addr sender_core(8, CoreCoord(5, 9, CoreType::DRAM, CoordSystem::VIRTUAL), 0x90000);
-    multichip_core_addr receiver_core(21, CoreCoord(1, 9, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5200);
+    tt_multichip_core_addr sender_core(8, CoreCoord(5, 9, CoreType::DRAM, CoordSystem::VIRTUAL), 0x90000);
+    tt_multichip_core_addr receiver_core(21, CoreCoord(1, 9, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5200);
     run_data_mover_test(1200, sender_core, receiver_core);
 
-    sender_core = multichip_core_addr(11, CoreCoord(5, 5, CoreType::DRAM, CoordSystem::VIRTUAL), 0x40000);
-    receiver_core = multichip_core_addr(18, CoreCoord(8, 7, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x7000);
+    sender_core = tt_multichip_core_addr(11, CoreCoord(5, 5, CoreType::DRAM, CoordSystem::VIRTUAL), 0x40000);
+    receiver_core = tt_multichip_core_addr(18, CoreCoord(8, 7, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x7000);
     run_data_mover_test(8800, sender_core, receiver_core);
 }
 
 // Dram to Dram
 TEST(GalaxyDataMovement, TwoChipMoveData4) {
-    multichip_core_addr sender_core(7, CoreCoord(0, 6, CoreType::DRAM, CoordSystem::VIRTUAL), 0x300000);
-    multichip_core_addr receiver_core(19, CoreCoord(0, 0, CoreType::DRAM, CoordSystem::VIRTUAL), 0x300000);
+    tt_multichip_core_addr sender_core(7, CoreCoord(0, 6, CoreType::DRAM, CoordSystem::VIRTUAL), 0x300000);
+    tt_multichip_core_addr receiver_core(19, CoreCoord(0, 0, CoreType::DRAM, CoordSystem::VIRTUAL), 0x300000);
     run_data_mover_test(1200, sender_core, receiver_core);
 
-    sender_core = multichip_core_addr(15, CoreCoord(5, 2, CoreType::DRAM, CoordSystem::VIRTUAL), 0x400000);
-    receiver_core = multichip_core_addr(16, CoreCoord(0, 11, CoreType::DRAM, CoordSystem::VIRTUAL), 0x400000);
+    sender_core = tt_multichip_core_addr(15, CoreCoord(5, 2, CoreType::DRAM, CoordSystem::VIRTUAL), 0x400000);
+    receiver_core = tt_multichip_core_addr(16, CoreCoord(0, 11, CoreType::DRAM, CoordSystem::VIRTUAL), 0x400000);
     run_data_mover_test(8800, sender_core, receiver_core);
 }
 
 void run_data_broadcast_test(
-    uint32_t vector_size, multichip_core_addr sender_core, std::vector<multichip_core_addr> receiver_cores) {
+    uint32_t vector_size, tt_multichip_core_addr sender_core, std::vector<tt_multichip_core_addr> receiver_cores) {
     Cluster device;
     auto target_devices = device.get_target_device_ids();
 
@@ -276,8 +277,8 @@ void run_data_broadcast_test(
 TEST(GalaxyDataMovement, BroadcastData1) {
     SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
 
-    multichip_core_addr sender_core(4, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
-    std::vector<multichip_core_addr> receiver_cores;
+    tt_multichip_core_addr sender_core(4, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
+    std::vector<tt_multichip_core_addr> receiver_cores;
 
     for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
         receiver_cores.push_back(multichip_core_addr(5, core, 0x6000));
@@ -289,8 +290,8 @@ TEST(GalaxyDataMovement, BroadcastData1) {
 TEST(GalaxyDataMovement, BroadcastData2) {
     SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
 
-    multichip_core_addr sender_core(12, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
-    std::vector<multichip_core_addr> receiver_cores;
+    tt_multichip_core_addr sender_core(12, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
+    std::vector<tt_multichip_core_addr> receiver_cores;
 
     receiver_cores.push_back(multichip_core_addr(1, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
     receiver_cores.push_back(multichip_core_addr(2, CoreCoord(2, 3, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
@@ -315,8 +316,8 @@ TEST(GalaxyDataMovement, BroadcastData2) {
 TEST(GalaxyDataMovement, BroadcastData3) {
     SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
 
-    multichip_core_addr sender_core(10, CoreCoord(0, 0, CoreType::DRAM, CoordSystem::VIRTUAL), 0x20000);
-    std::vector<multichip_core_addr> receiver_cores;
+    tt_multichip_core_addr sender_core(10, CoreCoord(0, 0, CoreType::DRAM, CoordSystem::VIRTUAL), 0x20000);
+    std::vector<tt_multichip_core_addr> receiver_cores;
 
     receiver_cores.push_back(multichip_core_addr(5, CoreCoord(1, 8, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000));
     receiver_cores.push_back(multichip_core_addr(10, CoreCoord(1, 9, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x6000));
@@ -329,8 +330,8 @@ TEST(GalaxyDataMovement, BroadcastData3) {
 TEST(GalaxyDataMovement, BroadcastData4) {
     SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
 
-    multichip_core_addr sender_core(17, CoreCoord(8, 8, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x20000);
-    std::vector<multichip_core_addr> receiver_cores;
+    tt_multichip_core_addr sender_core(17, CoreCoord(8, 8, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x20000);
+    std::vector<tt_multichip_core_addr> receiver_cores;
 
     receiver_cores.push_back(multichip_core_addr(21, CoreCoord(0, 1, CoreType::DRAM, CoordSystem::VIRTUAL), 0x5000));
     receiver_cores.push_back(multichip_core_addr(22, CoreCoord(0, 6, CoreType::DRAM, CoordSystem::VIRTUAL), 0x6000));
@@ -345,8 +346,8 @@ TEST(GalaxyDataMovement, BroadcastData4) {
 TEST(GalaxyDataMovement, BroadcastData5) {
     SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
 
-    multichip_core_addr sender_core(31, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x20000);
-    std::vector<multichip_core_addr> receiver_cores;
+    tt_multichip_core_addr sender_core(31, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x20000);
+    std::vector<tt_multichip_core_addr> receiver_cores;
 
     receiver_cores.push_back(multichip_core_addr(21, CoreCoord(0, 1, CoreType::DRAM, CoordSystem::VIRTUAL), 0x5000));
     receiver_cores.push_back(multichip_core_addr(30, CoreCoord(0, 6, CoreType::DRAM, CoordSystem::VIRTUAL), 0x6000));
@@ -358,11 +359,11 @@ TEST(GalaxyDataMovement, BroadcastData5) {
 // L1 to L1 cores on many chips
 // TODO: Failing with mismatch
 TEST(GalaxyDataMovement, DISABLED_BroadcastData6) {
-    multichip_core_addr sender_core(1, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
-    std::vector<multichip_core_addr> receiver_cores;
+    tt_multichip_core_addr sender_core(1, CoreCoord(1, 1, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x5000);
+    std::vector<tt_multichip_core_addr> receiver_cores;
     for (int i = 2; i < 33; ++i) {
         receiver_cores.push_back(
-            multichip_core_addr(i, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x7000));
+            tt_multichip_core_addr(i, CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::VIRTUAL), 0x7000));
     }
     run_data_broadcast_test(10000, sender_core, receiver_cores);
 }

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -12,7 +12,7 @@
 #include "tests/test_utils/generate_cluster_desc.hpp"
 #include "tests/wormhole/test_wh_common.h"
 #include "umd/device/cluster.h"
-#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/cluster_descriptor.h"
 #include "wormhole/eth_interface.h"
 #include "wormhole/host_mem_address_map.h"
 #include "wormhole/l1_address_map.h"

--- a/tests/microbenchmark/benchmarks/ethernet_io/test_ethernet_io.cpp
+++ b/tests/microbenchmark/benchmarks/ethernet_io/test_ethernet_io.cpp
@@ -36,7 +36,7 @@ TEST(MicrobenchmarkEthernetIO, DRAM) {
 
     const chip_id_t chip = *cluster->get_target_remote_device_ids().begin();
     const CoreCoord dram_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::DRAM)[0];
-    cluster->start_device(tt_device_params{});
+    cluster->start_device(device_params{});
 
     const std::vector<std::string> headers = {
         "Size (MB)",
@@ -73,7 +73,7 @@ TEST(MicrobenchmarkEthernetIO, Tensix) {
 
     const chip_id_t chip = *cluster->get_target_remote_device_ids().begin();
     const CoreCoord tensix_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)[0];
-    cluster->start_device(tt_device_params{});
+    cluster->start_device(device_params{});
 
     const std::vector<std::string> headers = {
         "Size (MB)",
@@ -109,7 +109,7 @@ TEST(MicrobenchmarkEthernetIO, Eth) {
     }
     const chip_id_t chip = *cluster->get_target_remote_device_ids().begin();
     const CoreCoord eth_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::ETH)[0];
-    cluster->start_device(tt_device_params{});
+    cluster->start_device(device_params{});
 
     const std::vector<std::string> headers = {
         "Size (KB)",

--- a/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
+++ b/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
@@ -109,7 +109,7 @@ TEST(MicrobenchmarkPCIeDMA, Tensix) {
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord tensix_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)[0];
-    cluster->start_device(tt_device_params{});
+    cluster->start_device(device_params{});
 
     std::vector<std::vector<std::string>> rows;
 
@@ -132,7 +132,7 @@ TEST(MicrobenchmarkPCIeDMA, Tensix) {
 TEST(MicrobenchmarkPCIeDMA, TensixSweepSizes) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord tensix_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)[0];
-    cluster->start_device(tt_device_params{});
+    cluster->start_device(device_params{});
 
     constexpr uint64_t limit_buf_size = one_mb;
 
@@ -162,7 +162,7 @@ TEST(MicrobenchmarkPCIeDMA, TensixSweepSizes) {
 TEST(MicrobenchmarkPCIeDMA, DramSweepSizes) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord dram_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::DRAM)[0];
-    cluster->start_device(tt_device_params{});
+    cluster->start_device(device_params{});
 
     constexpr uint64_t limit_buf_size = one_gb;
 
@@ -209,7 +209,7 @@ TEST(MicrobenchmarkPCIeDMA, Dram) {
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord dram_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::DRAM)[0];
-    cluster->start_device(tt_device_params{});
+    cluster->start_device(device_params{});
 
     const std::vector<std::string> headers = {
         "Size (MB)",
@@ -379,7 +379,7 @@ TEST(MicrobenchmarkPCIeDMA, Eth) {
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord eth_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::ETH)[0];
-    cluster->start_device(tt_device_params{});
+    cluster->start_device(device_params{});
 
     std::vector<std::vector<std::string>> rows;
 
@@ -439,7 +439,7 @@ TEST(MicrobenchmarkPCIeDMA, EthZeroCopy) {
 TEST(MicrobenchmarkPCIeDMA, EthSweepSizes) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord eth_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::ETH)[0];
-    cluster->start_device(tt_device_params{});
+    cluster->start_device(device_params{});
 
     constexpr uint64_t limit_buf_size = 128 * one_kb;
     constexpr uint32_t address = 128 * one_kb;

--- a/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
+++ b/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
@@ -33,7 +33,7 @@ TEST(MicrobenchmarkTLB, TLBDynamicDram) {
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord dram_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::DRAM)[0];
-    cluster->start_device(tt_device_params{});
+    cluster->start_device(device_params{});
 
     const std::vector<std::string> headers = {
         "Size (MB)",
@@ -64,7 +64,7 @@ TEST(MicrobenchmarkTLB, TLBDynamicTensix) {
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord tensix_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)[0];
-    cluster->start_device(tt_device_params{});
+    cluster->start_device(device_params{});
 
     const std::vector<std::string> headers = {
         "Size (MB)",
@@ -91,7 +91,7 @@ TEST(MicrobenchmarkTLB, TLBDynamicTensix) {
 TEST(MicrobenchmarkTLB, TLBStaticTensix) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord tensix_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)[0];
-    cluster->start_device(tt_device_params{});
+    cluster->start_device(device_params{});
 
     cluster->configure_tlb(0, tensix_core, tlb_1m_index, 0x0, tlb_data::Relaxed);
 
@@ -133,7 +133,7 @@ TEST(MicrobenchmarkTLB, TLBStaticDram) {
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord dram_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::DRAM)[0];
-    cluster->start_device(tt_device_params{});
+    cluster->start_device(device_params{});
 
     cluster->configure_tlb(0, dram_core, tlb_16m_index, 0x0, tlb_data::Relaxed);
 
@@ -168,7 +168,7 @@ TEST(MicrobenchmarkTLB, TLBDynamicEth) {
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord eth_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::ETH)[0];
-    cluster->start_device(tt_device_params{});
+    cluster->start_device(device_params{});
 
     const std::vector<std::string> headers = {
         "Size (KB)",
@@ -196,7 +196,7 @@ TEST(MicrobenchmarkTLB, TLBDynamicEth) {
 TEST(MicrobenchmarkTLB, TLBStaticEth) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord eth_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::ETH)[0];
-    cluster->start_device(tt_device_params{});
+    cluster->start_device(device_params{});
 
     constexpr uint32_t address = 128 * one_kb;
     cluster->configure_tlb(chip, eth_core, tlb_1m_index, address, tlb_data::Relaxed);

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -78,7 +78,7 @@ TEST(SiliconDriverWH, OneDramOneTensixNoEthSocDesc) {
 }
 
 TEST(SiliconDriverWH, CreateDestroy) {
-    tt_device_params default_params;
+    device_params default_params;
     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting
     for (int i = 0; i < 50; i++) {
         Cluster cluster(ClusterOptions{
@@ -132,7 +132,7 @@ TEST(SiliconDriverWH, HarvestingRuntime) {
         }
     }
 
-    tt_device_params default_params;
+    device_params default_params;
     cluster.start_device(default_params);
 
     std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -208,7 +208,7 @@ TEST(SiliconDriverWH, UnalignedStaticTLB_RW) {
         }
     }
 
-    tt_device_params default_params;
+    device_params default_params;
     cluster.start_device(default_params);
 
     std::vector<uint32_t> unaligned_sizes = {3, 14, 21, 255, 362, 430, 1022, 1023, 1025};
@@ -260,7 +260,7 @@ TEST(SiliconDriverWH, StaticTLB_RW) {
         }
     }
 
-    tt_device_params default_params;
+    device_params default_params;
     cluster.start_device(default_params);
 
     std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -302,7 +302,7 @@ TEST(SiliconDriverWH, DynamicTLB_RW) {
 
     set_barrier_params(cluster);
 
-    tt_device_params default_params;
+    device_params default_params;
     cluster.start_device(default_params);
 
     std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -338,7 +338,7 @@ TEST(SiliconDriverWH, MultiThreadedDevice) {
     Cluster cluster;
     set_barrier_params(cluster);
 
-    tt_device_params default_params;
+    device_params default_params;
     cluster.start_device(default_params);
 
     std::thread th1 = std::thread([&] {
@@ -408,7 +408,7 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
         }
     }
 
-    tt_device_params default_params;
+    device_params default_params;
     cluster.start_device(default_params);
 
     std::vector<uint32_t> readback_membar_vec = {};
@@ -507,7 +507,7 @@ TEST(SiliconDriverWH, BroadcastWrite) {
     set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
 
-    tt_device_params default_params;
+    device_params default_params;
     cluster.start_device(default_params);
     std::vector<uint32_t> broadcast_sizes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
     uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
@@ -583,7 +583,7 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
     set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
 
-    tt_device_params default_params;
+    device_params default_params;
     cluster.start_device(default_params);
     auto eth_version = cluster.get_ethernet_fw_version();
     bool virtual_bcast_supported = (eth_version >= tt_version(6, 8, 0) || eth_version == tt_version(6, 7, 241)) &&
@@ -691,7 +691,7 @@ TEST(SiliconDriverWH, SysmemTestWithPcie) {
     Cluster cluster;
 
     set_barrier_params(cluster);
-    cluster.start_device(tt_device_params{});  // no special parameters
+    cluster.start_device(device_params{});  // no special parameters
 
     const chip_id_t mmio_chip_id = 0;
     const auto PCIE = cluster.get_soc_descriptor(mmio_chip_id).get_cores(CoreType::PCIE).at(0);
@@ -752,7 +752,7 @@ TEST(SiliconDriverWH, RandomSysmemTestWithPcie) {
     });
 
     set_barrier_params(cluster);
-    cluster.start_device(tt_device_params{});  // no special parameters
+    cluster.start_device(device_params{});  // no special parameters
 
     const chip_id_t mmio_chip_id = 0;
     const auto PCIE = cluster.get_soc_descriptor(mmio_chip_id).get_cores(CoreType::PCIE).at(0);
@@ -810,7 +810,7 @@ TEST(SiliconDriverWH, LargeAddressTlb) {
     const CoreCoord ARC_CORE = cluster.get_soc_descriptor(0).get_cores(CoreType::ARC).at(0);
 
     set_barrier_params(cluster);
-    cluster.start_device(tt_device_params{});
+    cluster.start_device(device_params{});
 
     auto get_static_tlb_index_callback = [](tt_xy_pair target) { return 0; };
 
@@ -857,7 +857,7 @@ TEST(SiliconDriverWH, DMA1) {
     const chip_id_t chip = 0;
     Cluster cluster;
 
-    cluster.start_device(tt_device_params{});
+    cluster.start_device(device_params{});
 
     auto& soc_descriptor = cluster.get_soc_descriptor(chip);
     size_t dram_count = soc_descriptor.get_num_dram_channels();
@@ -908,7 +908,7 @@ TEST(SiliconDriverWH, DMA2) {
     Cluster cluster;
 
     set_barrier_params(cluster);
-    cluster.start_device(tt_device_params{});
+    cluster.start_device(device_params{});
 
     auto& soc_descriptor = cluster.get_soc_descriptor(chip);
     size_t dram_count = soc_descriptor.get_num_dram_channels();

--- a/tests/wormhole/test_wh_common.h
+++ b/tests/wormhole/test_wh_common.h
@@ -56,7 +56,7 @@ protected:
 
         set_barrier_params(*cluster);
 
-        tt_device_params default_params;
+        device_params default_params;
         cluster->start_device(default_params);
 
         cluster->deassert_risc_reset();


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/1167

### Description
Rename many structs to drop tt_ prefixes.

### List of the changes
- Rename tt_device_l1_address_params, tt_driver_host_address_params, tt_driver_eth_interface_params, tt_driver_noc_params
- Rename tt_DevicePowerState, tt_MemBarFlag
- Rename tt_device_dram_address_params, tt_device_l1_address_params
- Rename tt_cpuset_allocator

### Testing
Builds

### API Changes
This PR has API changes, but I'll leave old header files if necessary until the clients move forward.
You will see that metal build fails on this PR, but it builds at the tip of the PR stack:
https://github.com/tenstorrent/tt-umd/pull/1218

