### PR TITLE
Remove getenv() of USER, as it is not set in all environments

### DIFF
--- a/device/simulation/tt_simulation_host.cpp
+++ b/device/simulation/tt_simulation_host.cpp
@@ -25,11 +25,10 @@ tt_SimulationHost::tt_SimulationHost() {
     host_dialer = std::make_unique<nng_dialer>();
 
     // Get socket name, using PID to make it unique with multiple runs in parallel
-    const char *nng_socket_name = std::getenv("NNG_SOCKET_NAME") ? std::getenv("NNG_SOCKET_NAME") : "nng_ipc";
-    const char *user_name = std::getenv("USER");
+    const char *nng_socket_name = std::getenv("NNG_SOCKET_NAME") ? std::getenv("NNG_SOCKET_NAME") : "ttsim_nng_ipc";
 
     std::ostringstream ss;
-    ss << NNG_SOCKET_PREFIX << user_name << "_" << getpid() << "_" << nng_socket_name;
+    ss << NNG_SOCKET_PREFIX << nng_socket_name << "_" << getpid();
     std::string nng_socket_addr_str = ss.str();
     const char *nng_socket_addr = nng_socket_addr_str.c_str();
     setenv("NNG_SOCKET_ADDR", nng_socket_addr, 1);  // pass NNG_SOCKET_ADDR to remote


### PR DESCRIPTION
### Issue
none

### Description
Change naming scheme for simulator pipe to not include username.  Use a slightly different scheme of the form `/tmp/ttsim_nng_ipc_{getpid()}`.

### List of the changes
Remove getenv of USER, which can return null, and remove this from the pipe name.
Change default value for NNG_SOCKET_NAME from nng_ipc to ttsim_nng_ipc.
Put NNG_SOCKET_NAME portion of pipe name first so it's before the process ID.

### Testing
Ran metal programming examples locally on simulator

### API Changes
none