### PR TITLE
NOC translation disabled in mock cluster

### DIFF
--- a/device/tt_cluster_descriptor.cpp
+++ b/device/tt_cluster_descriptor.cpp
@@ -565,7 +565,8 @@ std::unique_ptr<tt_ClusterDescriptor> tt_ClusterDescriptor::create_mock_cluster(
         desc->chip_board_type.insert({logical_id, board_type});
         desc->chips_with_mmio.insert({logical_id, logical_id});
         desc->chip_arch.insert({logical_id, arch});
-        desc->noc_translation_enabled.insert({logical_id, true});
+        /* NOC translation is not supported for Simulation chips */
+        desc->noc_translation_enabled.insert({logical_id, false});
         desc->harvesting_masks_map.insert({logical_id, harvesting_masks});
     }
     desc->fill_chips_grouped_by_closest_mmio();


### PR DESCRIPTION
### Issue
https://yyz-gitlab.local.tenstorrent.com/tenstorrent/tt-umd-simulators/-/issues/9

### Description
NOC translation is not supported on the Blackhole Simulator, and it should be disabled by default for the mock cluster, since that cluster is used for the Simulator chip.

### List of the changes
(Itemized list of all the changes.)
NOC translation disabled in mock cluster
### Testing
CI
Manual testing on Simulator

### API Changes
/
