### PR TITLE
Add umd_utils.h to public API

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -129,6 +129,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/tt_simulation_host.hpp
                 api/umd/device/tt_soc_descriptor.h
                 api/umd/device/tt_xy_pair.h
+                api/umd/device/umd_utils.h
                 api/umd/device/types/arch.h
                 api/umd/device/types/blackhole_arc.h
                 api/umd/device/types/cluster_descriptor_types.h


### PR DESCRIPTION
### Issue
Blocking UMD bump in tt-metal https://github.com/tenstorrent/tt-metal/actions/runs/17153962482/job/48667246184?pr=27219

### Description
This PR: https://github.com/tenstorrent/tt-umd/pull/1191 - introduced an include from arch.h to umd_utils.h, but umd_utils wasn't marked as part of the public API, so includes of arch.h can fail.

### List of the changes
- Add umd_utils.h to public API of umd library

### Testing
No testing

### API Changes
This PR has API changes in a sense that it includes another header file
