### PR TITLE
Fix UBB wait for eth training

### DIFF
--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -56,10 +56,15 @@ void Chip::wait_chip_to_be_ready() {
 }
 
 void Chip::wait_eth_cores_training(const uint32_t timeout_ms) {
-    const std::vector<CoreCoord> eth_cores = get_soc_descriptor().get_cores(CoreType::ETH, CoordSystem::TRANSLATED);
+    const std::vector<CoreCoord> eth_cores = get_soc_descriptor().get_cores(CoreType::ETH);
     TTDevice* tt_device = get_tt_device();
     for (const CoreCoord& eth_core : eth_cores) {
-        tt_device->wait_eth_core_training(translate_chip_coord_to_translated(eth_core), timeout_ms);
+        // TODO issue 1208: figure out why translated ETH don't work on UBB
+        if (chip_info_.board_type == BoardType::UBB) {
+            tt_device->wait_eth_core_training(soc_descriptor_.translate_coord_to(eth_core, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::NOC0), timeout_ms);
+        } else {  
+            tt_device->wait_eth_core_training(translate_chip_coord_to_translated(eth_core), timeout_ms);
+        }
     }
 }
 

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -61,8 +61,10 @@ void Chip::wait_eth_cores_training(const uint32_t timeout_ms) {
     for (const CoreCoord& eth_core : eth_cores) {
         // TODO issue 1208: figure out why translated ETH don't work on UBB
         if (chip_info_.board_type == BoardType::UBB) {
-            tt_device->wait_eth_core_training(soc_descriptor_.translate_coord_to(eth_core, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::NOC0), timeout_ms);
-        } else {  
+            tt_device->wait_eth_core_training(
+                soc_descriptor_.translate_coord_to(eth_core, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::NOC0),
+                timeout_ms);
+        } else {
             tt_device->wait_eth_core_training(translate_chip_coord_to_translated(eth_core), timeout_ms);
         }
     }


### PR DESCRIPTION
### Issue
This is blocking UMD bump into metal
https://github.com/tenstorrent/tt-metal/actions/runs/17153984542/job/48667442625

### Description
For some reason, this change https://github.com/tenstorrent/tt-umd/pull/1171 in Chip class breaks functionality for UBB.
I didn't debug deeper why this doesn't work on UBB specifically, but reverting it for UBB only helps.
Seems like TRANSLATED eth coord don't work properly on UBB?

### List of the changes
- Revert to using NOC0 instead of TRANSLATED for UBB during waiting for eth cores to train

### Testing
All runs on brosko/test_fix_ubb :
- [x] Galaxy Quick : https://github.com/tenstorrent/tt-metal/actions/runs/17156946576

### API Changes
There are no API changes in this PR.
