### PR TITLE
Refactor device creation

### DIFF
--- a/device/api/umd/device/chip/remote_chip.h
+++ b/device/api/umd/device/chip/remote_chip.h
@@ -70,10 +70,7 @@ public:
     int get_numa_node() override;
 
 private:
-    RemoteChip(
-        tt_SocDescriptor soc_descriptor,
-        LocalChip* local_chip,
-        std::unique_ptr<RemoteWormholeTTDevice> remote_tt_device);
+    RemoteChip(tt_SocDescriptor soc_descriptor, LocalChip* local_chip, std::unique_ptr<TTDevice> remote_tt_device);
 
     LocalChip* local_chip_;
     RemoteCommunication* remote_communication_;

--- a/device/api/umd/device/tt_device/blackhole_tt_device.h
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.h
@@ -15,7 +15,6 @@ namespace tt::umd {
 
 class BlackholeTTDevice : public TTDevice {
 public:
-    BlackholeTTDevice(std::shared_ptr<PCIDevice> pci_device);
     ~BlackholeTTDevice();
 
     void configure_iatu_region(size_t region, uint64_t target, size_t region_size) override;
@@ -60,6 +59,10 @@ protected:
     BlackholeTTDevice() = default;
 
 private:
+    BlackholeTTDevice(std::shared_ptr<PCIDevice> pci_device);
+
+    friend std::unique_ptr<TTDevice> TTDevice::create(int device_number, IODeviceType device_type);
+
     static constexpr uint64_t ATU_OFFSET_IN_BH_BAR2 = 0x1000;
     std::set<size_t> iatu_regions_;
     tt_xy_pair arc_core;

--- a/device/api/umd/device/tt_device/remote_wormhole_tt_device.h
+++ b/device/api/umd/device/tt_device/remote_wormhole_tt_device.h
@@ -12,8 +12,6 @@ namespace tt::umd {
 
 class RemoteWormholeTTDevice : public WormholeTTDevice {
 public:
-    RemoteWormholeTTDevice(std::unique_ptr<RemoteCommunication> remote_communication, eth_coord_t target_chip);
-
     void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
 
     void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
@@ -29,6 +27,11 @@ public:
     bool wait_arc_post_reset(const uint32_t timeout_ms = 1000) override;
 
 private:
+    RemoteWormholeTTDevice(std::unique_ptr<RemoteCommunication> remote_communication, eth_coord_t target_chip);
+
+    friend std::unique_ptr<TTDevice> TTDevice::create(
+        std::unique_ptr<RemoteCommunication> remote_communication, eth_coord_t target_chip);
+
     eth_coord_t target_chip_;
     std::unique_ptr<RemoteCommunication> remote_communication_;
 };

--- a/device/api/umd/device/tt_device/tt_device.h
+++ b/device/api/umd/device/tt_device/tt_device.h
@@ -38,6 +38,7 @@ struct dynamic_tlb {
 
 class ArcMessenger;
 class ArcTelemetryReader;
+class RemoteCommunication;
 
 class TTDevice {
 public:
@@ -49,6 +50,8 @@ public:
      * Jtag support can be enabled.
      */
     static std::unique_ptr<TTDevice> create(int device_number, IODeviceType device_type = IODeviceType::PCIe);
+    static std::unique_ptr<TTDevice> create(
+        std::unique_ptr<RemoteCommunication> remote_communication, eth_coord_t target_chip);
 
     TTDevice(std::shared_ptr<PCIDevice> pci_device, std::unique_ptr<architecture_implementation> architecture_impl);
     TTDevice(

--- a/device/api/umd/device/tt_device/wormhole_tt_device.h
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.h
@@ -15,9 +15,6 @@
 namespace tt::umd {
 class WormholeTTDevice : public TTDevice {
 public:
-    WormholeTTDevice(std::shared_ptr<PCIDevice> pci_device);
-    WormholeTTDevice(std::shared_ptr<JtagDevice> jtag_device, uint8_t jlink_id);
-
     void configure_iatu_region(size_t region, uint64_t target, size_t region_size) override;
 
     void wait_arc_core_start(const uint32_t timeout_ms = 1000) override;
@@ -58,7 +55,12 @@ public:
 
     bool wait_arc_post_reset(const uint32_t timeout_ms = 1000) override;
 
+    WormholeTTDevice(std::shared_ptr<PCIDevice> pci_device);
+    WormholeTTDevice(std::shared_ptr<JtagDevice> jtag_device, uint8_t jlink_id);
+
 private:
+    friend std::unique_ptr<TTDevice> TTDevice::create(int device_number, IODeviceType device_type);
+
     void dma_d2h_transfer(const uint64_t dst, const uint32_t src, const size_t size);
     void dma_h2d_transfer(const uint32_t dst, const uint64_t src, const size_t size);
 

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -10,6 +10,8 @@
 
 #include "assert.hpp"
 #include "umd/device/chip/local_chip.h"
+#include "umd/device/tt_device/remote_wormhole_tt_device.h"
+#include "umd/device/tt_device/tt_device.h"
 #include "umd/device/wormhole_implementation.h"
 
 namespace tt::umd {
@@ -26,7 +28,7 @@ std::unique_ptr<RemoteChip> RemoteChip::create(
     remote_communication->set_remote_transfer_ethernet_cores(
         local_chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(
             remote_transfer_eth_channels, CoordSystem::TRANSLATED));
-    auto remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(std::move(remote_communication), target_eth_coord);
+    auto remote_tt_device = TTDevice::create(std::move(remote_communication), target_eth_coord);
     remote_tt_device->init_tt_device();
 
     tt_SocDescriptor soc_descriptor;
@@ -58,7 +60,7 @@ std::unique_ptr<RemoteChip> RemoteChip::create(
     remote_communication->set_remote_transfer_ethernet_cores(
         local_chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(
             remote_transfer_eth_channels, CoordSystem::TRANSLATED));
-    auto remote_tt_device = std::make_unique<RemoteWormholeTTDevice>(std::move(remote_communication), target_eth_coord);
+    auto remote_tt_device = TTDevice::create(std::move(remote_communication), target_eth_coord);
     remote_tt_device->init_tt_device();
 
     return std::unique_ptr<tt::umd::RemoteChip>(
@@ -66,9 +68,18 @@ std::unique_ptr<RemoteChip> RemoteChip::create(
 }
 
 RemoteChip::RemoteChip(
-    tt_SocDescriptor soc_descriptor, LocalChip* local_chip, std::unique_ptr<RemoteWormholeTTDevice> remote_tt_device) :
+    tt_SocDescriptor soc_descriptor, LocalChip* local_chip, std::unique_ptr<TTDevice> remote_tt_device) :
     Chip(remote_tt_device->get_chip_info(), soc_descriptor), local_chip_(local_chip) {
-    remote_communication_ = remote_tt_device->get_remote_communication();
+    // Architectural design issue - this dynamic_cast reveals a leaky abstraction.
+    // The base TTDevice interface should provide access to RemoteCommunication directly,
+    // rather than requiring knowledge of the concrete RemoteWormholeTTDevice type.
+    // This violates the Liskov Substitution Principle and creates tight coupling.
+    // Consider either:
+    //   1. Adding get_remote_communication() to the TTDevice base interface (probably not)
+    //   2. Restructuring the inheritance hierarchy to eliminate this dependency
+    //   3. Using composition instead of inheritance for remote communication
+    // ToDo: Figure out a proper way to make an abstraction to redesign this
+    remote_communication_ = dynamic_cast<RemoteWormholeTTDevice*>(remote_tt_device.get())->get_remote_communication();
     tt_device_ = std::move(remote_tt_device);
     TT_ASSERT(soc_descriptor_.arch != tt::ARCH::BLACKHOLE, "Non-MMIO targets not supported in Blackhole");
     wait_chip_to_be_ready();

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -14,6 +14,7 @@
 #include "umd/device/jtag/jtag_device.h"
 #include "umd/device/pci_device.hpp"
 #include "umd/device/tt_device/blackhole_tt_device.h"
+#include "umd/device/tt_device/remote_wormhole_tt_device.h"
 #include "umd/device/tt_device/wormhole_tt_device.h"
 #include "umd/device/types/communication.h"
 #include "umd/device/utils/lock_manager.h"
@@ -81,6 +82,12 @@ TTDevice::TTDevice() {}
         default:
             return nullptr;
     }
+}
+
+/* static */ std::unique_ptr<TTDevice> TTDevice::create(
+    std::unique_ptr<RemoteCommunication> remote_communication, eth_coord_t target_chip) {
+    return std::unique_ptr<RemoteWormholeTTDevice>(
+        new RemoteWormholeTTDevice(std::move(remote_communication), target_chip));
 }
 
 architecture_implementation *TTDevice::get_architecture_implementation() { return architecture_impl_.get(); }

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -63,7 +63,7 @@ TTDevice::TTDevice() {}
 
         switch (jtag_device->get_jtag_arch(device_number)) {
             case ARCH::WORMHOLE_B0:
-                return std::make_unique<WormholeTTDevice>(jtag_device, device_number);
+                return std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(jtag_device, device_number));
             case ARCH::BLACKHOLE:
                 TT_THROW("JTAG is not yet supported on Blackhole architecture.");
             default:
@@ -75,9 +75,9 @@ TTDevice::TTDevice() {}
 
     switch (pci_device->get_arch()) {
         case ARCH::WORMHOLE_B0:
-            return std::make_unique<WormholeTTDevice>(pci_device);
+            return std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(pci_device));
         case ARCH::BLACKHOLE:
-            return std::make_unique<BlackholeTTDevice>(pci_device);
+            return std::unique_ptr<BlackholeTTDevice>(new BlackholeTTDevice(pci_device));
         default:
             return nullptr;
     }

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -196,8 +196,7 @@ TEST(ApiTTDeviceTest, TestRemoteTTDevice) {
         remote_communication->set_remote_transfer_ethernet_cores(
             closest_local_chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(
                 cluster_desc->get_active_eth_channels(gateway_id), CoordSystem::TRANSLATED));
-        std::unique_ptr<RemoteWormholeTTDevice> remote_tt_device =
-            std::make_unique<RemoteWormholeTTDevice>(std::move(remote_communication), remote_eth_coord);
+        auto remote_tt_device = TTDevice::create(std::move(remote_communication), remote_eth_coord);
         remote_tt_device->init_tt_device();
 
         std::vector<CoreCoord> tensix_cores =


### PR DESCRIPTION
### Issue
#1136 

### Description
Make the only interface to make TTDevice's through TTDevice factory `create`.

### List of the changes
Made:
- Constructors private
  - `BlackholeTTDevice`
  - `RemoteWormholeTTDevice`
- `WormholeTTDevice` constructor protected, as `RemoteWormholeTTDevice` needs to invoke it directly (should be dealt with in a separate PR)
- Changed every instance of creation of all derived `TTDevice` instances to use `create`
- Changed `RemoteChip` to use `TTDevice` instead of `RemoteWormholeTTDevice` and used dynamic cast (should be also dealt with in a separate PR)

### Testing
Manual

### API Changes
/
