### PR TITLE
PCI bdf modification

### DIFF
--- a/device/api/umd/device/pci_device.hpp
+++ b/device/api/umd/device/pci_device.hpp
@@ -31,6 +31,7 @@ struct PciDeviceInfo {
     uint16_t pci_bus;
     uint16_t pci_device;
     uint16_t pci_function;
+    std::string pci_bdf;
     // Physical slot is not always available on the system.
     // It is added to PciDeviceInfo struct in order for tt-metal to be able to use it
     // for machine provisioning tool at the moment, it is not explicitly used by UMD.


### PR DESCRIPTION
### Issue


### Description
Slight modification to how bdf is calculated. This now matches what tt-smi expects, and still is used for pci physical slot needed for 6u.

### List of the changes
- Change bdf calculation to include .function
- Expose it in PCI Device Info
- Use it for try_read_config_byte

### Testing
Existing CI tests

### API Changes
There is an API change in that now the PCIDeviceInfo exposes pci_bdf
