### PR TITLE
Add handling for hidden intermesh eth links

### DIFF
--- a/device/api/umd/device/topology/topology_discovery.h
+++ b/device/api/umd/device/topology/topology_discovery.h
@@ -93,6 +93,15 @@ protected:
     // does not take harvesting into consideration. This function will be overridden just for Blackhole.
     virtual void patch_eth_connections();
 
+    // Intermesh links are ethernet links that are turned off during UMD's topology discovery but are
+    // otherwise physically connected. This is done since not all tools support limiting the discovery as
+    // UMD does. Once all the tools start supporting this, this feature won't be used anymore and this
+    // function will return empty set.
+    // This will extract the list of intermesh links from a config in L1.
+    virtual std::vector<uint32_t> extract_intermesh_eth_links(Chip* chip, tt_xy_pair eth_core) = 0;
+
+    virtual bool is_intermesh_eth_link_trained(Chip* chip, tt_xy_pair eth_core) = 0;
+
     std::map<uint64_t, std::unique_ptr<Chip>> chips_to_discover;
     std::map<uint64_t, std::unique_ptr<Chip>> chips;
 

--- a/device/api/umd/device/topology/topology_discovery_blackhole.h
+++ b/device/api/umd/device/topology/topology_discovery_blackhole.h
@@ -39,6 +39,10 @@ protected:
 
     uint64_t get_remote_board_type(Chip* chip, tt_xy_pair eth_core) override;
 
+    std::vector<uint32_t> extract_intermesh_eth_links(Chip* chip, tt_xy_pair eth_core) override;
+
+    bool is_intermesh_eth_link_trained(Chip* chip, tt_xy_pair eth_core) override;
+
     bool is_using_eth_coords() override;
 
     uint64_t mangle_asic_id(uint64_t board_id, uint8_t asic_location);

--- a/device/api/umd/device/topology/topology_discovery_wormhole.h
+++ b/device/api/umd/device/topology/topology_discovery_wormhole.h
@@ -18,6 +18,7 @@ protected:
     struct EthAddresses {
         uint32_t masked_version;
 
+        uint64_t eth_param_table;
         uint64_t node_info;
         uint64_t eth_conn_info;
         uint64_t results_buf;
@@ -53,6 +54,10 @@ protected:
     uint32_t get_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) override;
 
     uint64_t get_remote_board_type(Chip* chip, tt_xy_pair eth_core) override;
+
+    std::vector<uint32_t> extract_intermesh_eth_links(Chip* chip, tt_xy_pair eth_core) override;
+
+    bool is_intermesh_eth_link_trained(Chip* chip, tt_xy_pair eth_core) override;
 
     std::unique_ptr<RemoteChip> create_remote_chip(
         eth_coord_t eth_coord, Chip* gateway_chip, std::set<uint32_t> gateway_eth_channels) override;

--- a/device/topology/topology_discovery_blackhole.cpp
+++ b/device/topology/topology_discovery_blackhole.cpp
@@ -162,4 +162,14 @@ void TopologyDiscoveryBlackhole::patch_eth_connections() {
     }
 }
 
+std::vector<uint32_t> TopologyDiscoveryBlackhole::extract_intermesh_eth_links(Chip* chip, tt_xy_pair eth_core) {
+    // This function is not important for Blackhole.
+    return {};
+}
+
+bool TopologyDiscoveryBlackhole::is_intermesh_eth_link_trained(Chip* chip, tt_xy_pair eth_core) {
+    // This function is not important for Blackhole.
+    return false;
+}
+
 }  // namespace tt::umd

--- a/device/topology/topology_discovery_wormhole.cpp
+++ b/device/topology/topology_discovery_wormhole.cpp
@@ -20,6 +20,7 @@ TopologyDiscoveryWormhole::TopologyDiscoveryWormhole(
 TopologyDiscoveryWormhole::EthAddresses TopologyDiscoveryWormhole::get_eth_addresses(uint32_t eth_fw_version) {
     uint32_t masked_version = eth_fw_version & 0x00FFFFFF;
 
+    uint64_t eth_param_table;
     uint64_t node_info;
     uint64_t eth_conn_info;
     uint64_t results_buf;
@@ -30,6 +31,7 @@ TopologyDiscoveryWormhole::EthAddresses TopologyDiscoveryWormhole::get_eth_addre
     uint64_t erisc_remote_eth_id_offset;
 
     if (masked_version >= 0x060000) {
+        eth_param_table = 0x1000;
         node_info = 0x1100;
         eth_conn_info = 0x1200;
         results_buf = 0x1ec0;
@@ -54,6 +56,7 @@ TopologyDiscoveryWormhole::EthAddresses TopologyDiscoveryWormhole::get_eth_addre
 
     return TopologyDiscoveryWormhole::EthAddresses{
         masked_version,
+        eth_param_table,
         node_info,
         eth_conn_info,
         results_buf,
@@ -287,6 +290,37 @@ bool TopologyDiscoveryWormhole::is_eth_unconnected(Chip* chip, const tt_xy_pair 
 
 bool TopologyDiscoveryWormhole::is_eth_unknown(Chip* chip, const tt_xy_pair eth_core) {
     return read_port_status(chip, eth_core) == TopologyDiscoveryWormhole::ETH_UNKNOWN;
+}
+
+std::vector<uint32_t> TopologyDiscoveryWormhole::extract_intermesh_eth_links(Chip* chip, tt_xy_pair eth_core) {
+    constexpr uint32_t intermesh_eth_link_config_offset = 19;
+    constexpr uint32_t intermesh_eth_link_bits_shift = 8;
+    constexpr uint32_t intermesh_eth_link_bits_mask = 0xFFFF;
+    TTDevice* tt_device = chip->get_tt_device();
+    uint32_t config_data;
+    tt_device->read_from_device(
+        &config_data,
+        eth_core,
+        eth_addresses.eth_param_table + (4 * intermesh_eth_link_config_offset),
+        sizeof(uint32_t));
+    std::vector<uint32_t> intermesh_eth_links;
+    uint32_t intermesh_eth_links_bits = (config_data >> intermesh_eth_link_bits_shift) & intermesh_eth_link_bits_mask;
+    while (intermesh_eth_links_bits != 0) {
+        uint32_t link = __builtin_ctz(intermesh_eth_links_bits);
+        intermesh_eth_links.push_back(link);
+        intermesh_eth_links_bits &= ~(1 << link);
+    }
+    return intermesh_eth_links;
+}
+
+bool TopologyDiscoveryWormhole::is_intermesh_eth_link_trained(Chip* chip, tt_xy_pair eth_core) {
+    constexpr uint32_t link_status_offset = 1;
+    constexpr uint32_t link_connected_mask = 0x1;
+    uint32_t status;
+    TTDevice* tt_device = chip->get_tt_device();
+    tt_device->read_from_device(
+        &status, eth_core, eth_addresses.node_info + (4 * link_status_offset), sizeof(uint32_t));
+    return (status & link_connected_mask) == link_connected_mask;
 }
 
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description
For multihost systems where T3Ks are connected to each other, we have special SPI programming that makes the links show up as unconnected through the standard port status check, and there is an alternative path to query if these intermesh eth links are up/active. This was to originally prevent UMD and tt-smi from exploring the remote hosts, though now this is only an issue with tt-smi, not UMD.
Once tt-smi's backend is switched to UMD then we will no longer need to do this hiding of eth links, however, to have code that handles eth links in higher level stacks like tt-metal be agnostic of this, we want to push this detection code to UMD until we can get rid of the SPI programming.

### List of the changes
Add `extract_intermesh_eth_links` and `is_intermesh_eth_link_trained` apis to topology discovery (no-op on BH).
`extract_intermesh_eth_links` will return the list of links that are intermesh, and `is_intermesh_eth_link_trained` will return if the specified link is actually active/trained.

### Testing
(Comment on CI testing or Manual testing touching this change.)

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
