### PR TITLE
Switching how simulator and host connect to each other

### DIFF
--- a/device/api/umd/device/jtag/jtag_device.h
+++ b/device/api/umd/device/jtag/jtag_device.h
@@ -19,6 +19,8 @@ public:
 
     static std::shared_ptr<JtagDevice> create(std::filesystem::path& binary_directory = jtag_library_path);
 
+    void close_device() {}
+
     uint32_t get_device_cnt() const;
     std::optional<uint32_t> get_efuse_harvesting(uint8_t chip_id) const;
 

--- a/device/api/umd/device/tt_simulation_host.hpp
+++ b/device/api/umd/device/tt_simulation_host.hpp
@@ -9,8 +9,6 @@
 
 #include "umd/device/tt_xy_pair.h"
 
-#define NNG_SOCKET_PREFIX "tcp://soc-zebu-01:5556"
-
 typedef struct nng_socket_s nng_socket;
 typedef struct nng_listener_s nng_listener;
 

--- a/device/api/umd/device/tt_simulation_host.hpp
+++ b/device/api/umd/device/tt_simulation_host.hpp
@@ -9,10 +9,10 @@
 
 #include "umd/device/tt_xy_pair.h"
 
-#define NNG_SOCKET_PREFIX "ipc:///tmp/"
+#define NNG_SOCKET_PREFIX "tcp://soc-zebu-01:5556"
 
 typedef struct nng_socket_s nng_socket;
-typedef struct nng_dialer_s nng_dialer;
+typedef struct nng_listener_s nng_listener;
 
 namespace tt::umd {
 
@@ -27,7 +27,7 @@ public:
 
 private:
     std::unique_ptr<nng_socket> host_socket;
-    std::unique_ptr<nng_dialer> host_dialer;
+    std::unique_ptr<nng_listener> host_listener;
 };
 
 }  // namespace tt::umd

--- a/device/simulation/tt_simulation_host.cpp
+++ b/device/simulation/tt_simulation_host.cpp
@@ -14,47 +14,81 @@
 #include <sstream>
 #include <tt-logger/tt-logger.hpp>
 #include <typeinfo>
+#include <random>
+#include <unistd.h>
 
 #include "assert.hpp"
 
 namespace tt::umd {
 
 tt_SimulationHost::tt_SimulationHost() {
-    // Initialize socket and dialer
+    // Initialize socket and listener
     host_socket = std::make_unique<nng_socket>();
-    host_dialer = std::make_unique<nng_dialer>();
+    host_listener = std::make_unique<nng_listener>();
 
-    // Get socket name, using PID to make it unique with multiple runs in parallel
-    const char *nng_socket_name = std::getenv("NNG_SOCKET_NAME") ? std::getenv("NNG_SOCKET_NAME") : "ttsim_nng_ipc";
+    // Check if NNG_SOCKET_LOCAL_PORT is set
+    const char *local_socket_port_str = std::getenv("NNG_SOCKET_LOCAL_PORT");
+    std::string nng_socket_addr_str;
+
+    // Generate socket address with hostname and random port
+    char hostname[256];
+    if (gethostname(hostname, sizeof(hostname)) != 0) {
+        strcpy(hostname, "localhost");
+    }
+
+    int port;
+
+    if (local_socket_port_str) {
+        port = atoi(local_socket_port_str);
+        log_info(tt::LogEmulationDriver, "Using specified NNG_SOCKET_LOCAL_PORT: {}", port);
+    } else {
+        // Generate random port in range 50000-59999
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_int_distribution<> dis(50000, 59999);
+
+        port = dis(gen);
+        log_info(tt::LogEmulationDriver, "Using generated port: {}", port);
+    }
 
     std::ostringstream ss;
-    ss << NNG_SOCKET_PREFIX << nng_socket_name << "_" << getpid();
-    std::string nng_socket_addr_str = ss.str();
-    const char *nng_socket_addr = nng_socket_addr_str.c_str();
-    setenv("NNG_SOCKET_ADDR", nng_socket_addr, 1);  // pass NNG_SOCKET_ADDR to remote
+    ss << "tcp://" << hostname << ":" << port;
+    nng_socket_addr_str = ss.str();
 
-    // Open socket and create dialer
-    log_info(tt::LogEmulationDriver, "Dialing: {}", nng_socket_addr);
+    // Export the address for client to use
+    if (std::getenv("NNG_SOCKET_ADDR") == nullptr) {
+        setenv("NNG_SOCKET_ADDR", nng_socket_addr_str.c_str(), 1);
+        log_info(tt::LogEmulationDriver, "Generated NNG_SOCKET_ADDR: {}", nng_socket_addr_str);
+    }
+
+    const char *nng_socket_addr = nng_socket_addr_str.c_str();
+
+    // Open socket and create listener (server mode)
+    log_info(tt::LogEmulationDriver, "Listening on: {}", nng_socket_addr);
     nng_pair1_open(host_socket.get());
-    int rv = nng_dialer_create(host_dialer.get(), *host_socket, nng_socket_addr);
-    TT_ASSERT(rv == 0, "Failed to create dialer: {} {}", nng_strerror(rv), nng_socket_addr);
+    // // Set receive timeout to 1000 ms (1 seconds)
+    // nng_socket_set_ms(*host_socket, NNG_OPT_RECVTIMEO, 1000);
+    // // Set send timeout to 1000 ms (1 seconds)
+    // nng_socket_set_ms(*host_socket, NNG_OPT_SENDTIMEO, 1000);
+    int rv = nng_listener_create(host_listener.get(), *host_socket, nng_socket_addr);
+    TT_ASSERT(rv == 0, "Failed to create listener: {} {}", nng_strerror(rv), nng_socket_addr);
 }
 
 tt_SimulationHost::~tt_SimulationHost() {
-    nng_dialer_close(*host_dialer);
+    nng_listener_close(*host_listener);
     nng_close(*host_socket);
 }
 
 void tt_SimulationHost::start_host() {
-    // Establish connection with remote VCS simulator
-    int rv;
-    do {
-        rv = nng_dialer_start(*host_dialer, 0);
-        if (rv != 0) {
-            log_info(tt::LogEmulationDriver, "Waiting for remote: {}", nng_strerror(rv));
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-        }
-    } while (rv != 0);
+    // Start listening for connections from client
+    int rv = nng_listener_start(*host_listener, 0);
+    if (rv != 0) {
+        log_error(tt::LogEmulationDriver, "Failed to start listener: {}", nng_strerror(rv));
+        return;
+    }
+    
+    log_info(tt::LogEmulationDriver, "Server started, waiting for client to connect...");
+
 }
 
 void tt_SimulationHost::send_to_device(uint8_t *buf, size_t buf_size) {
@@ -74,9 +108,9 @@ void tt_SimulationHost::send_to_device(uint8_t *buf, size_t buf_size) {
 size_t tt_SimulationHost::recv_from_device(void **data_ptr) {
     int rv;
     size_t data_size;
-    log_debug(tt::LogEmulationDriver, "Receiving messsage from remote..");
+    log_info(tt::LogEmulationDriver, "Receiving messsage from remote..");
     rv = nng_recv(*host_socket, data_ptr, &data_size, NNG_FLAG_ALLOC);
-    log_debug(tt::LogEmulationDriver, "Message received.");
+    log_info(tt::LogEmulationDriver, "Message received.");
     if (rv != 0) {
         log_info(tt::LogEmulationDriver, "Failed to receive message from remote: {}", nng_strerror(rv));
     }


### PR DESCRIPTION
For aether emulation, we needed to switch to emulator connecting to UMD host (because we don't know machine name where emulation will be scheduled).
In order to have single UMD code, we switched for simulators as well.