### PR TITLE
Skip reset tests for 4U

### DIFF
--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -512,6 +512,10 @@ TEST(TestCluster, WarmResetScratch) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
     }
 
+    if (is_galaxy_configuration(cluster)) {
+        GTEST_SKIP() << "Skipping reset test for Galaxy configuration.";
+    }
+
     uint32_t write_test_data = 0xDEADBEEF;
 
     auto chip_id = *cluster->get_target_device_ids().begin();
@@ -542,6 +546,10 @@ TEST(TestCluster, WarmReset) {
 
     if (cluster->get_target_device_ids().empty()) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
+    }
+
+    if (is_galaxy_configuration(cluster)) {
+        GTEST_SKIP() << "Skipping reset test for Galaxy configuration.";
     }
 
     auto arch = cluster->get_tt_device(0)->get_arch();
@@ -613,6 +621,10 @@ TEST(TestCluster, DeassertResetBrisc) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
     }
 
+    if (is_galaxy_configuration(cluster)) {
+        GTEST_SKIP() << "Skipping reset test for Galaxy configuration.";
+    }
+
     constexpr uint32_t a_variable_value = 0x87654000;
     constexpr uint64_t a_variable_address = 0x10000;
     constexpr uint64_t brisc_code_address = 0;
@@ -666,6 +678,10 @@ TEST(TestCluster, DeassertResetWithCounterBrisc) {
 
     if (cluster->get_target_device_ids().empty()) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
+    }
+
+    if (is_galaxy_configuration(cluster)) {
+        GTEST_SKIP() << "Skipping reset test for Galaxy configuration.";
     }
 
     // TODO: remove this check when it is figured out what is happening with Blackhole version of this test.

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -512,7 +512,7 @@ TEST(TestCluster, WarmResetScratch) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
     }
 
-    if (is_galaxy_configuration(cluster)) {
+    if (is_galaxy_configuration(cluster.get())) {
         GTEST_SKIP() << "Skipping reset test for Galaxy configuration.";
     }
 
@@ -548,7 +548,7 @@ TEST(TestCluster, WarmReset) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
     }
 
-    if (is_galaxy_configuration(cluster)) {
+    if (is_galaxy_configuration(cluster.get())) {
         GTEST_SKIP() << "Skipping reset test for Galaxy configuration.";
     }
 
@@ -621,7 +621,7 @@ TEST(TestCluster, DeassertResetBrisc) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
     }
 
-    if (is_galaxy_configuration(cluster)) {
+    if (is_galaxy_configuration(cluster.get())) {
         GTEST_SKIP() << "Skipping reset test for Galaxy configuration.";
     }
 
@@ -680,7 +680,7 @@ TEST(TestCluster, DeassertResetWithCounterBrisc) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
     }
 
-    if (is_galaxy_configuration(cluster)) {
+    if (is_galaxy_configuration(cluster.get())) {
         GTEST_SKIP() << "Skipping reset test for Galaxy configuration.";
     }
 

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -116,11 +116,12 @@ TEST(ApiTTDeviceTest, TTDeviceWarmResetAfterNocHang) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
     }
 
-    // Check for galaxy configuration using cluster
+    // Unfortunatelly, there is no way to check from Local TTDevice if this is GALAXY configuration.
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
-    if (is_galaxy_configuration(cluster)) {
+    if (is_galaxy_configuration(cluster.get())) {
         GTEST_SKIP() << "Skipping reset test for Galaxy configuration.";
     }
+    cluster.reset();
 
     auto arch = PCIDevice(pci_device_ids[0]).get_arch();
     if (arch == tt::ARCH::WORMHOLE_B0) {
@@ -154,7 +155,7 @@ TEST(ApiTTDeviceTest, TTDeviceWarmResetAfterNocHang) {
     // After a warm reset, topology discovery must be performed to detect available chips.
     // Creating a Cluster triggers this discovery process, which is why a Cluster is instantiated here,
     // even though this is a TTDevice test.
-    auto cluster = std::make_unique<Cluster>();
+    cluster = std::make_unique<Cluster>();
 
     EXPECT_FALSE(cluster->get_target_device_ids().empty()) << "No chips present after reset.";
 

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -6,6 +6,7 @@
 #include "device/api/umd/device/warm_reset.hpp"
 #include "gtest/gtest.h"
 #include "tests/test_utils/device_test_utils.hpp"
+#include "tests/test_utils/test_api_common.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/cluster.hpp"
@@ -113,6 +114,12 @@ TEST(ApiTTDeviceTest, TTDeviceWarmResetAfterNocHang) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
     if (pci_device_ids.empty()) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
+    }
+
+    // Check for galaxy configuration using cluster
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    if (is_galaxy_configuration(cluster)) {
+        GTEST_SKIP() << "Skipping reset test for Galaxy configuration.";
     }
 
     auto arch = PCIDevice(pci_device_ids[0]).get_arch();

--- a/tests/test_utils/test_api_common.hpp
+++ b/tests/test_utils/test_api_common.hpp
@@ -84,3 +84,17 @@ private:
 };
 
 class ClusterReadWriteL1Test : public ::testing::TestWithParam<ClusterOptions> {};
+
+// Helper function to detect if any device in cluster is Galaxy board type
+inline bool is_galaxy_configuration(const std::unique_ptr<Cluster>& cluster) {
+    if (!cluster || cluster->get_target_device_ids().empty()) {
+        return false;
+    }
+
+    for (const auto& chip_id : cluster->get_target_device_ids()) {
+        if (cluster->get_tt_device(chip_id)->get_board_type() == BoardType::GALAXY) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/tests/test_utils/test_api_common.hpp
+++ b/tests/test_utils/test_api_common.hpp
@@ -86,15 +86,8 @@ private:
 class ClusterReadWriteL1Test : public ::testing::TestWithParam<ClusterOptions> {};
 
 // Helper function to detect if any device in cluster is Galaxy board type
-inline bool is_galaxy_configuration(const std::unique_ptr<Cluster>& cluster) {
-    if (!cluster || cluster->get_target_device_ids().empty()) {
-        return false;
-    }
-
-    for (const auto& chip_id : cluster->get_target_device_ids()) {
-        if (cluster->get_tt_device(chip_id)->get_board_type() == BoardType::GALAXY) {
-            return true;
-        }
-    }
-    return false;
+inline bool is_galaxy_configuration(const Cluster* cluster) {
+    return cluster != nullptr && cluster->get_target_remote_device_ids().size() > 0 &&
+           cluster->get_cluster_description()->get_board_type(cluster->get_target_remote_device_ids()[0]) ==
+               BoardType::GALAXY;
 }

--- a/tests/test_utils/test_api_common.hpp
+++ b/tests/test_utils/test_api_common.hpp
@@ -85,9 +85,9 @@ private:
 
 class ClusterReadWriteL1Test : public ::testing::TestWithParam<ClusterOptions> {};
 
-// Helper function to detect if any device in cluster is Galaxy board type
-inline bool is_galaxy_configuration(const Cluster* cluster) {
+// Helper function to detect if any device in cluster is Galaxy board type.
+inline bool is_galaxy_configuration(Cluster* cluster) {
     return cluster != nullptr && cluster->get_target_remote_device_ids().size() > 0 &&
-           cluster->get_cluster_description()->get_board_type(cluster->get_target_remote_device_ids()[0]) ==
+           cluster->get_cluster_description()->get_board_type(*cluster->get_target_remote_device_ids().begin()) ==
                BoardType::GALAXY;
 }


### PR DESCRIPTION
### Issue
Already unintentially broke two 4u galaxies

### Description
This reset won't work as intended on 4u galaxy, since those systems have different reset procedure, where manual topology flash is required

### List of the changes
- Disable all warm reset tests if one of the chips is detected as GALAXY

### Testing
No testing

### API Changes
There are no API changes in this PR.
