### PR TITLE
Count ETH training timeout for all cores

### DIFF
--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -43,7 +43,7 @@ public:
 
     ChipInfo get_chip_info() override;
 
-    void wait_eth_core_training(const tt_xy_pair eth_core, const uint32_t timeout_ms = 60000) override;
+    uint32_t wait_eth_core_training(const tt_xy_pair eth_core, const uint32_t timeout_ms = 60000) override;
 
     uint64_t get_arc_noc_base_address() const override;
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -230,7 +230,11 @@ public:
      */
     virtual void wait_arc_core_start(const uint32_t timeout_ms = 1000) = 0;
 
-    virtual void wait_eth_core_training(const tt_xy_pair eth_core, const uint32_t timeout_ms = 60000) = 0;
+    /**
+     * Waits for ETH core training to complete.
+     * Returns time left from timeout in ms.
+     */
+    virtual uint32_t wait_eth_core_training(const tt_xy_pair eth_core, const uint32_t timeout_ms = 60000) = 0;
 
     void wait_dram_channel_training(const uint32_t dram_channel, const uint32_t timeout_ms = 60000);
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -232,7 +232,9 @@ public:
 
     /**
      * Waits for ETH core training to complete.
-     * Returns time left from timeout in ms.
+     * @param eth_core Specific ETH core to wait on.
+     * @param timeout_ms Timeout in ms.
+     * @return Time taken in ms.
      */
     virtual uint32_t wait_eth_core_training(const tt_xy_pair eth_core, const uint32_t timeout_ms = 60000) = 0;
 

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -41,7 +41,7 @@ public:
 
     ChipInfo get_chip_info() override;
 
-    void wait_eth_core_training(const tt_xy_pair eth_core, const uint32_t timeout_ms = 60000) override;
+    uint32_t wait_eth_core_training(const tt_xy_pair eth_core, const uint32_t timeout_ms = 60000) override;
 
     uint64_t get_arc_noc_base_address() const override;
 

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -67,6 +67,7 @@ void Chip::wait_eth_cores_training(const uint32_t timeout_ms) {
             timeout_left -=
                 tt_device->wait_eth_core_training(translate_chip_coord_to_translated(eth_core), timeout_left);
         }
+        log_debug(LogSiliconDriver, "!!!ETH Training {} took {} ms.", eth_core.str(), timeout_ms - timeout_left);
     }
 }
 

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -54,16 +54,18 @@ void Chip::wait_chip_to_be_ready() {
 }
 
 void Chip::wait_eth_cores_training(const uint32_t timeout_ms) {
+    uint32_t timeout_left = timeout_ms;
     const std::vector<CoreCoord> eth_cores = get_soc_descriptor().get_cores(CoreType::ETH);
     TTDevice* tt_device = get_tt_device();
     for (const CoreCoord& eth_core : eth_cores) {
         // TODO issue 1208: figure out why translated ETH don't work on UBB
         if (chip_info_.board_type == BoardType::UBB) {
-            tt_device->wait_eth_core_training(
+            timeout_left -= tt_device->wait_eth_core_training(
                 soc_descriptor_.translate_coord_to(eth_core, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::NOC0),
-                timeout_ms);
+                timeout_left);
         } else {
-            tt_device->wait_eth_core_training(translate_chip_coord_to_translated(eth_core), timeout_ms);
+            timeout_left -=
+                tt_device->wait_eth_core_training(translate_chip_coord_to_translated(eth_core), timeout_left);
         }
     }
 }

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -67,7 +67,6 @@ void Chip::wait_eth_cores_training(const uint32_t timeout_ms) {
             timeout_left -=
                 tt_device->wait_eth_core_training(translate_chip_coord_to_translated(eth_core), timeout_left);
         }
-        log_debug(LogSiliconDriver, "!!!ETH Training {} took {} ms.", eth_core.str(), timeout_ms - timeout_left);
     }
 }
 

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -228,8 +228,8 @@ uint32_t BlackholeTTDevice::wait_eth_core_training(const tt_xy_pair eth_core, co
         read_from_device(&port_status_val, eth_core, port_status_addr, sizeof(port_status_val));
         auto end = std::chrono::system_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-        time_taken += duration.count();
-        if (duration.count() > timeout_ms) {
+        time_taken = duration.count();
+        if (time_taken > timeout_ms) {
             // TODO: Exception should be thrown here. ETH connections are very flaky
             // on Blackhole right now. When this is fixed we can throw the exception here.
             // Since we are not going to do any remote IO at the moment it is fine to just log the error.


### PR DESCRIPTION
### Issue
#1210

### Description
On chip initialization, the ETH training timeout of 60s was counted separately for every core (or every step in checking completion for every core in WH). This PR introduces a global 60s timeout for an entire chip. 
Although there is no ETH training length distribution data, having a chip-bound timeout is better than having a shorter per-core timeout assuming high variance in per-core training time lengths.

### List of the changes
- Functions waiting on ETH training completion for WH, BH return time taken to complete.
- `Chip::wait_eth_cores_training()` counts down time taken by each core and reduces timeout for the subsequent call.

### Testing
CI

### API Changes
There are no API changes in this PR.
