### PR TITLE
Integrate JTAG I/O into Cluster.

### DIFF
--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -10,6 +10,7 @@
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
+#include "umd/device/types/communication.hpp"
 
 namespace tt::umd {
 
@@ -19,9 +20,15 @@ public:
     // necessary information needed for soc descriptor construction. Due to this inverse member initialization order, we
     // cannot have simple constructors as they require the base class to be constructed first.
     static std::unique_ptr<LocalChip> create(
-        int pci_device_id, std::string sdesc_path = "", int num_host_mem_channels = 0);
+        int device_id,
+        std::string sdesc_path = "",
+        int num_host_mem_channels = 0,
+        IODeviceType device_type = IODeviceType::PCIe);
     static std::unique_ptr<LocalChip> create(
-        int pci_device_id, SocDescriptor soc_descriptor, int num_host_mem_channels = 0);
+        int device_id,
+        SocDescriptor soc_descriptor,
+        int num_host_mem_channels = 0,
+        IODeviceType device_type = IODeviceType::PCIe);
 
     ~LocalChip();
 

--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -70,7 +70,13 @@ public:
     std::unique_lock<RobustMutex> acquire_mutex(MutexType mutex_type, int pci_device_id);
 
 private:
-    LocalChip(SocDescriptor soc_descriptor, std::unique_ptr<TTDevice> tt_device, int num_host_mem_channels = 0);
+    LocalChip(
+        tt_SocDescriptor soc_descriptor,
+        std::unique_ptr<TTDevice> tt_device,
+        std::unique_ptr<TLBManager> tlb_manager,
+        std::unique_ptr<SysmemManager> sysmem_manager,
+        std::unique_ptr<RemoteCommunication> remote_communication,
+        int num_host_mem_channels);
 
     std::unique_ptr<TLBManager> tlb_manager_;
     std::unique_ptr<SysmemManager> sysmem_manager_;

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -98,6 +98,12 @@ struct ClusterOptions {
      * This parameter is used only for SIMULATION chip type.
      */
     std::filesystem::path simulator_directory = "";
+
+    /**
+     * I/O device type to use for the cluster.
+     * This determines how the cluster will communicate with the underlying hardware.
+     */
+    IODeviceType io_device_type = IODeviceType::PCIe;
 };
 
 /**
@@ -135,7 +141,9 @@ public:
      * cluster descriptor object based on the devices connected to the system.
      */
     static std::unique_ptr<ClusterDescriptor> create_cluster_descriptor(
-        std::string sdesc_path = "", std::unordered_set<chip_id_t> pci_target_devices = {});
+        std::string sdesc_path = "",
+        std::unordered_set<chip_id_t> pci_target_devices = {},
+        IODeviceType device_type = IODeviceType::PCIe);
 
     /**
      * Get cluster descriptor object being used. This object contains topology information about the cluster.
@@ -642,7 +650,9 @@ private:
 
     // Test functions
     void verify_fw_bundle_version();
+    void log_device_summary();
     void log_pci_device_summary();
+    void log_jtag_device_summary();
     void verify_eth_fw();
     void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions);
     void verify_sysmem_initialized();

--- a/device/api/umd/device/cluster_descriptor.hpp
+++ b/device/api/umd/device/cluster_descriptor.hpp
@@ -241,6 +241,8 @@ public:
 
     uint8_t get_asic_location(chip_id_t chip_id) const;
 
+    IODeviceType get_io_device_type() const;
+
 private:
     int get_ethernet_link_coord_distance(const eth_coord_t &location_a, const eth_coord_t &location_b) const;
 
@@ -303,6 +305,8 @@ private:
     std::unordered_map<int, std::unordered_map<int, Chip2ChipConnection>> galaxy_racks_exit_chip_coords_per_x_dim = {};
 
     std::map<chip_id_t, HarvestingMasks> harvesting_masks_map = {};
+
+    IODeviceType io_device_type = IODeviceType::PCIe;
 };
 
 using tt_ClusterDescriptor = ClusterDescriptor;

--- a/device/api/umd/device/jtag/jtag_device.hpp
+++ b/device/api/umd/device/jtag/jtag_device.hpp
@@ -9,17 +9,14 @@
 #include <memory>
 #include <optional>
 
-#include "umd/device/jtag/jtag.hpp"
-#include "umd/device/types/arch.hpp"
+#include "umd/device/jtag/jtag.h"
+#include "umd/device/types/arch.h"
 
 class JtagDevice {
 public:
-    explicit JtagDevice(std::unique_ptr<Jtag> jtag_device);
     ~JtagDevice();
 
     static std::shared_ptr<JtagDevice> create(std::filesystem::path& binary_directory = jtag_library_path);
-
-    void close_device() {}
 
     uint32_t get_device_cnt() const;
     std::optional<uint32_t> get_efuse_harvesting(uint8_t chip_id) const;
@@ -64,8 +61,9 @@ public:
     static std::filesystem::path jtag_library_path;
 
 private:
+    JtagDevice();
     void select_device(uint8_t chip_id);
-    std::unique_ptr<Jtag> jtag;
+    static std::unique_ptr<Jtag> jtag;
     std::vector<uint32_t> jlink_devices;
     std::vector<uint32_t> efuse_harvesting;
     std::optional<uint8_t> curr_device_idx = std::nullopt;

--- a/device/api/umd/device/topology/topology_discovery.hpp
+++ b/device/api/umd/device/topology/topology_discovery.hpp
@@ -21,13 +21,18 @@ class ClusterDescriptor;
 class TopologyDiscovery {
 public:
     static std::unique_ptr<ClusterDescriptor> create_cluster_descriptor(
-        std::unordered_set<chip_id_t> pci_target_devices = {}, const std::string& sdesc_path = "");
-    TopologyDiscovery(std::unordered_set<chip_id_t> pci_target_devices = {}, const std::string& sdesc_path = "");
+        std::unordered_set<chip_id_t> pci_target_devices = {},
+        const std::string& sdesc_path = "",
+        IODeviceType io_device_type = IODeviceType::PCIe);
+    TopologyDiscovery(
+        std::unordered_set<chip_id_t> pci_target_devices = {},
+        const std::string& sdesc_path = "",
+        IODeviceType io_device_type = IODeviceType::PCIe);
     virtual ~TopologyDiscovery() = default;
     std::unique_ptr<ClusterDescriptor> create_ethernet_map();
 
 protected:
-    void get_pcie_connected_chips();
+    void get_connected_chips();
 
     void discover_remote_chips();
 
@@ -114,7 +119,7 @@ protected:
 
     std::unique_ptr<ClusterDescriptor> cluster_desc;
 
-    std::unordered_set<chip_id_t> pci_target_devices = {};
+    std::unordered_set<chip_id_t> target_devices = {};
 
     // All board ids that should be included in the cluster descriptor.
     std::unordered_set<uint64_t> board_ids;
@@ -122,6 +127,8 @@ protected:
     std::unordered_map<uint64_t, std::set<uint32_t>> active_eth_channels_per_chip;
 
     const std::string sdesc_path;
+
+    const IODeviceType io_device_type;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/topology/topology_discovery_wormhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_wormhole.hpp
@@ -12,7 +12,9 @@ namespace tt::umd {
 class TopologyDiscoveryWormhole : public TopologyDiscovery {
 public:
     TopologyDiscoveryWormhole(
-        std::unordered_set<chip_id_t> pci_target_devices = {}, const std::string& sdesc_path = "");
+        std::unordered_set<chip_id_t> pci_target_devices = {},
+        const std::string& sdesc_path = "",
+        IODeviceType device_type = IODeviceType::PCIe);
 
 protected:
     struct EthAddresses {

--- a/device/api/umd/device/types/communication.hpp
+++ b/device/api/umd/device/types/communication.hpp
@@ -5,12 +5,20 @@
  */
 
 #pragma once
+#include <string>
+#include <unordered_map>
 
 namespace tt::umd {
 
 enum class IODeviceType {
     PCIe,
     JTAG,
+};
+
+// Const map of Device type names for each of the types listed in the enum.
+static const std::unordered_map<IODeviceType, std::string> DeviceTypeToString = {
+    {IODeviceType::PCIe, "PCIe"},
+    {IODeviceType::JTAG, "JTAG"},
 };
 
 }  // namespace tt::umd

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -25,9 +25,10 @@ static_assert(!std::is_abstract<LocalChip>(), "LocalChip must be non-abstract.")
 // TLB size for DRAM on blackhole - 4GB
 const uint64_t BH_4GB_TLB_SIZE = 4ULL * 1024 * 1024 * 1024;
 
-std::unique_ptr<LocalChip> LocalChip::create(int pci_device_id, std::string sdesc_path, int num_host_mem_channels) {
+std::unique_ptr<LocalChip> LocalChip::create(
+    int device_id, std::string sdesc_path, int num_host_mem_channels, IODeviceType device_type) {
     // Create TTDevice and make sure the arc is ready so we can read its telemetry.
-    auto tt_device = TTDevice::create(pci_device_id);
+    auto tt_device = TTDevice::create(device_id);
     tt_device->init_tt_device();
 
     SocDescriptor soc_descriptor;
@@ -42,9 +43,9 @@ std::unique_ptr<LocalChip> LocalChip::create(int pci_device_id, std::string sdes
 }
 
 std::unique_ptr<LocalChip> LocalChip::create(
-    int pci_device_id, SocDescriptor soc_descriptor, int num_host_mem_channels) {
+    int device_id, SocDescriptor soc_descriptor, int num_host_mem_channels, IODeviceType device_type) {
     // Create TTDevice and make sure the arc is ready so we can read its telemetry.
-    auto tt_device = TTDevice::create(pci_device_id);
+    auto tt_device = TTDevice::create(device_id);
     tt_device->init_tt_device();
 
     std::unique_ptr<TLBManager> tlb_mgr;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -162,6 +162,14 @@ void Cluster::log_pci_device_summary() {
     log_info(LogSiliconDriver, "KMD version: {}", kmd_version);
 }
 
+void Cluster::log_jtag_device_summary() {
+    if (local_chip_ids_.empty()) {
+        return;
+    }
+    // TODO: move read_kmd_version from PCIDevice to something more universal.
+    log_info(LogSiliconDriver, "KMD version: {}", PCIDevice::read_kmd_version().to_string());
+}
+
 void Cluster::verify_fw_bundle_version() {
     if (chips_.empty()) {
         return;
@@ -217,7 +225,7 @@ void Cluster::construct_cluster(const uint32_t& num_host_mem_ch_per_mmio_device,
             pci_ids,
             remote_chip_ids_);
         verify_fw_bundle_version();
-        log_pci_device_summary();
+        log_device_summary();
         if (arch_name == tt::ARCH::WORMHOLE_B0) {
             verify_eth_fw();
         }
@@ -253,8 +261,16 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     }
 
     if (cluster_desc->is_chip_mmio_capable(chip_id)) {
-        auto chip = LocalChip::create(cluster_desc->get_chips_with_mmio().at(chip_id), soc_desc, num_host_mem_channels);
-        if (cluster_desc->get_arch(chip_id) == tt::ARCH::WORMHOLE_B0) {
+        auto chip = LocalChip::create(
+            cluster_desc->get_chips_with_mmio().at(chip_id),
+            soc_desc,
+            num_host_mem_channels,
+            cluster_desc->io_device_type);
+
+        // Currrently remote transfer is only supported by PCIe.
+        // TODO: implement remote transfer for JTAG comm.
+        if (cluster_desc->get_arch(chip_id) == tt::ARCH::WORMHOLE_B0 &&
+            cluster_desc->get_io_device_type() == IODeviceType::PCIe) {
             // Remote transfer currently supported only for wormhole.
             chip->set_remote_transfer_ethernet_cores(cluster_desc->get_active_eth_channels(chip_id));
         }
@@ -378,7 +394,10 @@ Cluster::Cluster(ClusterOptions options) {
     ClusterDescriptor* temp_full_cluster_desc = options.cluster_descriptor;
     std::unique_ptr<ClusterDescriptor> temp_full_cluster_desc_ptr;
     if (temp_full_cluster_desc == nullptr) {
-        temp_full_cluster_desc_ptr = Cluster::create_cluster_descriptor(options.sdesc_path, options.pci_target_devices);
+        temp_full_cluster_desc_ptr = Cluster::create_cluster_descriptor(
+            options.sdesc_path,
+            options.io_device_type == IODeviceType::PCIe ? options.pci_target_devices : options.target_devices,
+            options.io_device_type);
         temp_full_cluster_desc = temp_full_cluster_desc_ptr.get();
     }
     chip_type_ = options.chip_type;

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -1198,4 +1198,6 @@ uint8_t ClusterDescriptor::get_asic_location(chip_id_t chip_id) const {
     return it->second;
 }
 
+IODeviceType ClusterDescriptor::get_io_device_type() const { return io_device_type; }
+
 }  // namespace tt::umd

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -190,7 +190,7 @@ void TopologyDiscovery::fill_cluster_descriptor_info() {
 
         if (chip->is_mmio_capable()) {
             cluster_desc->chips_with_mmio.insert(
-                {current_chip_id, chip->get_tt_device()->get_pci_device()->get_device_num()});
+                {current_chip_id, chip->get_tt_device()->get_communication_device_id()});
         }
 
         cluster_desc->chip_board_type.insert({current_chip_id, chip->get_chip_info().board_type});

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -5,11 +5,13 @@
  */
 #include "umd/device/topology/topology_discovery.hpp"
 
+#include <numeric>
 #include <tt-logger/tt-logger.hpp>
 
 #include "api/umd/device/topology/topology_discovery.hpp"
 #include "api/umd/device/topology/topology_discovery_blackhole.hpp"
 #include "api/umd/device/topology/topology_discovery_wormhole.hpp"
+#include "assert.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/chip/local_chip.hpp"
 #include "umd/device/cluster_descriptor.hpp"
@@ -21,30 +23,53 @@ extern bool umd_use_noc1;
 
 namespace tt::umd {
 
-std::unique_ptr<ClusterDescriptor> TopologyDiscovery::create_cluster_descriptor(
-    std::unordered_set<chip_id_t> pci_target_devices, const std::string& sdesc_path) {
-    auto pci_devices_info = PCIDevice::enumerate_devices_info(pci_target_devices);
-    if (pci_devices_info.empty()) {
-        return std::make_unique<ClusterDescriptor>();
+std::unique_ptr<tt_ClusterDescriptor> TopologyDiscovery::create_cluster_descriptor(
+    std::unordered_set<chip_id_t> target_devices, const std::string& sdesc_path, const IODeviceType device_type) {
+    tt::ARCH current_arch = ARCH::Invalid;
+
+    switch (device_type) {
+        case IODeviceType::PCIe: {
+            auto pci_devices_info = PCIDevice::enumerate_devices_info(target_devices);
+            if (pci_devices_info.empty()) {
+                return std::make_unique<tt_ClusterDescriptor>();
+            }
+            current_arch = pci_devices_info.begin()->second.get_arch();
+            break;
+        }
+        case IODeviceType::JTAG: {
+            auto jtag_device = JtagDevice::create();
+            if (!jtag_device->get_device_cnt()) {
+                return std::make_unique<tt_ClusterDescriptor>();
+            }
+            current_arch = jtag_device->get_jtag_arch(0);
+            break;
+        }
+        default:
+            TT_THROW("Unsupported device type for topology discovery");
     }
 
-    switch (pci_devices_info.begin()->second.get_arch()) {
+    if (current_arch == tt::ARCH::BLACKHOLE && device_type == IODeviceType::JTAG) {
+        TT_THROW("Blackhole architecture is not yet supported over JTAG interface.");
+    }
+
+    switch (current_arch) {
         case tt::ARCH::WORMHOLE_B0:
-            return TopologyDiscoveryWormhole(pci_target_devices, sdesc_path).create_ethernet_map();
+            return TopologyDiscoveryWormhole(target_devices, sdesc_path, device_type).create_ethernet_map();
         case tt::ARCH::BLACKHOLE:
-            return TopologyDiscoveryBlackhole(pci_target_devices, sdesc_path).create_ethernet_map();
+            return TopologyDiscoveryBlackhole(target_devices, sdesc_path).create_ethernet_map();
         default:
             throw std::runtime_error(fmt::format("Unsupported architecture for topology discovery."));
     }
 }
 
-TopologyDiscovery::TopologyDiscovery(std::unordered_set<chip_id_t> pci_target_devices, const std::string& sdesc_path) :
-    pci_target_devices(pci_target_devices), sdesc_path(sdesc_path) {}
+TopologyDiscovery::TopologyDiscovery(
+    std::unordered_set<chip_id_t> target_devices, const std::string& sdesc_path, const IODeviceType device_type) :
+    target_devices(target_devices), sdesc_path(sdesc_path), io_device_type(device_type) {}
 
 std::unique_ptr<ClusterDescriptor> TopologyDiscovery::create_ethernet_map() {
     init_topology_discovery();
     cluster_desc = std::unique_ptr<ClusterDescriptor>(new ClusterDescriptor());
-    get_pcie_connected_chips();
+    get_connected_chips();
     discover_remote_chips();
     fill_cluster_descriptor_info();
     return std::move(cluster_desc);
@@ -52,10 +77,23 @@ std::unique_ptr<ClusterDescriptor> TopologyDiscovery::create_ethernet_map() {
 
 void TopologyDiscovery::init_topology_discovery() {}
 
-void TopologyDiscovery::get_pcie_connected_chips() {
-    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices(pci_target_devices);
-
-    for (auto& device_id : pci_device_ids) {
+void TopologyDiscovery::get_connected_chips() {
+    std::vector<int> device_ids;
+    switch (io_device_type) {
+        case IODeviceType::PCIe: {
+            device_ids = PCIDevice::enumerate_devices(target_devices);
+            break;
+        }
+        case IODeviceType::JTAG: {
+            auto device_cnt = JtagDevice::create()->get_device_cnt();
+            device_ids = std::vector<int>(device_cnt);
+            std::iota(device_ids.begin(), device_ids.end(), 0);
+            break;
+        }
+        default:
+            TT_THROW("Unsupported device type.");
+    }
+    for (auto& device_id : device_ids) {
         std::unique_ptr<LocalChip> chip = LocalChip::create(device_id, sdesc_path);
 
         std::vector<CoreCoord> eth_cores =
@@ -239,6 +277,7 @@ void TopologyDiscovery::fill_cluster_descriptor_info() {
         }
     }
 
+    cluster_desc->io_device_type = io_device_type;
     cluster_desc->fill_galaxy_connections();
     cluster_desc->merge_cluster_ids();
 

--- a/device/topology/topology_discovery_wormhole.cpp
+++ b/device/topology/topology_discovery_wormhole.cpp
@@ -7,6 +7,7 @@
 
 #include <tt-logger/tt-logger.hpp>
 
+#include "assert.hpp"
 #include "umd/device/types/wormhole_telemetry.hpp"
 
 extern bool umd_use_noc1;
@@ -14,8 +15,8 @@ extern bool umd_use_noc1;
 namespace tt::umd {
 
 TopologyDiscoveryWormhole::TopologyDiscoveryWormhole(
-    std::unordered_set<chip_id_t> pci_target_devices, const std::string& sdesc_path) :
-    TopologyDiscovery(pci_target_devices, sdesc_path) {}
+    std::unordered_set<chip_id_t> target_devices, const std::string& sdesc_path, IODeviceType device_type) :
+    TopologyDiscovery(target_devices, sdesc_path, device_type) {}
 
 TopologyDiscoveryWormhole::EthAddresses TopologyDiscoveryWormhole::get_eth_addresses(uint32_t eth_fw_version) {
     uint32_t masked_version = eth_fw_version & 0x00FFFFFF;
@@ -276,7 +277,7 @@ void TopologyDiscoveryWormhole::init_topology_discovery() {
             TT_THROW("Unsupported IODeviceType during topology discovery.");
     }
 
-    std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_ids[0]);
+    std::unique_ptr<TTDevice> tt_device = TTDevice::create(device_id, io_device_type);
     tt_device->init_tt_device();
     is_running_on_6u = tt_device->get_board_type() == BoardType::UBB;
     eth_addresses =

--- a/device/topology/topology_discovery_wormhole.cpp
+++ b/device/topology/topology_discovery_wormhole.cpp
@@ -255,10 +255,25 @@ uint32_t TopologyDiscoveryWormhole::get_remote_eth_channel(Chip* chip, tt_xy_pai
 bool TopologyDiscoveryWormhole::is_using_eth_coords() { return !is_running_on_6u; }
 
 void TopologyDiscoveryWormhole::init_topology_discovery() {
-    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-
-    if (pci_device_ids.empty()) {
-        return;
+    int device_id = 0;
+    switch (io_device_type) {
+        case IODeviceType::JTAG: {
+            auto device_cnt = JtagDevice::create()->get_device_cnt();
+            if (!device_cnt) {
+                return;
+            }
+            break;
+        }
+        case IODeviceType::PCIe: {
+            std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+            if (pci_device_ids.empty()) {
+                return;
+            }
+            device_id = pci_device_ids[0];
+            break;
+        }
+        default:
+            TT_THROW("Unsupported IODeviceType during topology discovery.");
     }
 
     std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_ids[0]);

--- a/tests/api/test_jtag.cpp
+++ b/tests/api/test_jtag.cpp
@@ -6,6 +6,8 @@
 
 #include "gtest/gtest.h"
 #include "tt-logger/tt-logger.hpp"
+#include "umd/device/cluster.hpp"
+#include "umd/device/cluster_descriptor.hpp"
 #include "umd/device/jtag/jtag.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/soc_descriptor.hpp"
@@ -115,5 +117,49 @@ TEST_F(ApiJtagDeviceTest, JtagIOLessThanWordSizeUnalignedAddress) {
     std::vector<uint8_t> data_write = {10, 20, 30};
     for (const auto& device : device_data_) {
         check_io(device, address, data_write);
+    }
+}
+
+TEST(ApiJtagClusterTest, JtagClusterIOTest) {
+    if (!JtagDevice::create()->get_device_cnt()) {
+        GTEST_SKIP() << "No usable JTAG devices with current JTAG implementation.";
+    }
+
+    std::unique_ptr<Cluster> umd_cluster =
+        std::make_unique<Cluster>(ClusterOptions{.io_device_type = IODeviceType::JTAG});
+
+    const ClusterDescriptor* cluster_desc = umd_cluster->get_cluster_description();
+
+    // Initialize random data.
+    size_t data_size = 1024;
+    std::vector<uint8_t> data(data_size, 0);
+    for (int i = 0; i < data_size; i++) {
+        data[i] = i % 256;
+    }
+
+    for (auto chip_id : umd_cluster->get_target_device_ids()) {
+        const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(chip_id);
+
+        CoreCoord any_core = soc_desc.get_cores(CoreType::TENSIX)[0];
+
+        std::cout << "Writing to chip " << chip_id << " core " << any_core.str() << std::endl;
+
+        umd_cluster->write_to_device(data.data(), data_size, chip_id, any_core, 0);
+
+        umd_cluster->wait_for_non_mmio_flush(chip_id);
+    }
+
+    // Now read back the data.
+    for (auto chip_id : umd_cluster->get_target_device_ids()) {
+        const tt_SocDescriptor& soc_desc = umd_cluster->get_soc_descriptor(chip_id);
+
+        const CoreCoord any_core = soc_desc.get_cores(CoreType::TENSIX)[0];
+
+        std::cout << "Reading from chip " << chip_id << " core " << any_core.str() << std::endl;
+
+        std::vector<uint8_t> readback_data(data_size, 0);
+        umd_cluster->read_from_device(readback_data.data(), chip_id, any_core, 0, data_size);
+
+        ASSERT_EQ(data, readback_data);
     }
 }


### PR DESCRIPTION
### Description
Jtag has recently been added as a possible communication protocol in tt_device. This PR raises it to Cluster so users are able to create Cluster that works with either PCIe or JTAG. 

Currently, because of lack of testing resources, remote communication with JTAG could not be tested, therefore it wasn't implemented.

This isn't the final version, yet just a step towards the main goal of making cluster completely independent from PCIe if that is ever needed in UMD.

Changed jtag_device to keep Jtag object as a singleton. This is not mandatory, however, when running tests, a lot of jlink enumerations take place. They each require accessing the library through Jtag object which would get created each time if it wasn't kept as a singleton. Its creation opens a dynamic library which is a time-expensive operation and makes an unnecessary slowdown on tests. Since JtagDevice is an interface for accessing Jtag object, it keeps the singleton Jtag instance. Jtag however isn't fixed as a Singleton type. Users can still create it without going through JtagDevice. That is not recommended, but was left to comply with current tt-exalens implementation. Once Jtag gets moved completely to UMD, exalens will be fixed/changed.

### List of the changes
Cluster, 
LocalChip,
TopologyDiscovery, 
TopologyDiscoveryWormhole,
ClusterDescriptor,
ClusterOptions
...

### Testing
Added a test in test_jtag that checks the basic operations with JTAG cluster on a single Wormhole n150.
