### PR TITLE
Add check for latest supported firmware

### DIFF
--- a/device/api/umd/device/firmware/firmware_info_provider.hpp
+++ b/device/api/umd/device/firmware/firmware_info_provider.hpp
@@ -37,7 +37,7 @@ public:
     static semver_t get_minimum_compatible_firmware_version(tt::ARCH arch);
 
     /**
-     * This function should capture laters firmware version that is supported by the UMD.
+     * This function should capture latest firmware version that is supported by the UMD.
      * It is used to verify that the firmware running on the device is not newer than what UMD supports.
      * The function is meant to change on every FW release, so we can keep track of supported features
      * from new FW versions.

--- a/device/api/umd/device/firmware/firmware_info_provider.hpp
+++ b/device/api/umd/device/firmware/firmware_info_provider.hpp
@@ -36,6 +36,14 @@ public:
 
     static semver_t get_minimum_compatible_firmware_version(tt::ARCH arch);
 
+    /**
+     * This function should capture laters firmware version that is supported by the UMD.
+     * It is used to verify that the firmware running on the device is not newer than what UMD supports.
+     * The function is meant to change on every FW release, so we can keep track of supported features
+     * from new FW versions.
+     */
+    static semver_t get_latest_supported_firmware_version(tt::ARCH arch);
+
     virtual uint64_t get_board_id();
 
     virtual uint32_t get_eth_fw_version();

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -189,11 +189,13 @@ void Cluster::verify_fw_bundle_version() {
         semver_t::compare_firmware_bundle(fw_bundle_version, latest_supported_fw_version);
 
     if (compare_fw_bundle_with_latest == 1) {
-        throw std::runtime_error(fmt::format(
-            "Firmware version {} on the system is newer than the maximum supported version {} for {} architecture.",
+        log_warning(
+            LogSiliconDriver,
+            "Firmware version {} on the system is newer than the maximum supported version {} for {} architecture. New "
+            "features may not be supported.",
             fw_bundle_version.to_string(),
             latest_supported_fw_version.to_string(),
-            arch_to_str(chips_.begin()->second->get_tt_device()->get_arch())));
+            arch_to_str(chips_.begin()->second->get_tt_device()->get_arch()));
     }
 
     bool all_device_same_fw_bundle_version = true;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -182,6 +182,20 @@ void Cluster::verify_fw_bundle_version() {
             arch_to_str(chips_.begin()->second->get_tt_device()->get_arch())));
     }
 
+    semver_t latest_supported_fw_version = FirmwareInfoProvider::get_latest_supported_firmware_version(
+        chips_.begin()->second->get_tt_device()->get_arch());
+
+    int compare_fw_bundle_with_latest =
+        semver_t::compare_firmware_bundle(fw_bundle_version, latest_supported_fw_version);
+
+    if (compare_fw_bundle_with_latest == 1) {
+        throw std::runtime_error(fmt::format(
+            "Firmware version {} on the system is newer than the maximum supported version {} for {} architecture.",
+            fw_bundle_version.to_string(),
+            latest_supported_fw_version.to_string(),
+            arch_to_str(chips_.begin()->second->get_tt_device()->get_arch())));
+    }
+
     bool all_device_same_fw_bundle_version = true;
     for (const auto& [chip_id, chip] : chips_) {
         if (chip->get_tt_device()->get_firmware_version() != fw_bundle_version) {

--- a/device/firmware/firmware_info_provider.cpp
+++ b/device/firmware/firmware_info_provider.cpp
@@ -36,6 +36,8 @@ std::unique_ptr<FirmwareInfoProvider> FirmwareInfoProvider::create_firmware_info
 
 semver_t FirmwareInfoProvider::get_firmware_version() { return firmware_version; }
 
+semver_t FirmwareInfoProvider::get_latest_supported_firmware_version(tt::ARCH arch) { return semver_t(18, 9, 0); }
+
 semver_t FirmwareInfoProvider::get_minimum_compatible_firmware_version(tt::ARCH arch) {
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: {


### PR DESCRIPTION
### Issue

#557 

### Description

Add a function that returns latest supported FW version by UMD. This function is meant to change on new FW releases so we can more easily keep track of new FW features.

### List of the changes

- Add function for latest supported firmware
- Check that fw bundle is not later than latest supported

### Testing
CI

### API Changes
/
