### PR TITLE
Separate ttsim and Simulator path

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -86,6 +86,8 @@ if(TT_UMD_BUILD_SIMULATION)
         PRIVATE
             simulation/simulation_device.cpp
             simulation/simulation_host.cpp
+            simulation/ttsim_device.cpp
+            simulation/ttsim_host.cpp
             ${FBS_GENERATED_HEADER}
     )
     target_compile_definitions(device PRIVATE TT_UMD_BUILD_SIMULATION)
@@ -135,6 +137,8 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/types/tensix_soft_reset_options.hpp
                 api/umd/device/simulation/simulation_device.hpp
                 api/umd/device/simulation/simulation_host.hpp
+                api/umd/device/simulation/ttsim_device.hpp
+                api/umd/device/simulation/ttsim_host.hpp
                 api/umd/device/soc_descriptor.hpp
                 api/umd/device/tt_xy_pair.h
                 api/umd/device/utils/common.hpp

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -42,6 +42,7 @@ class RemoteChip;
 enum ChipType {
     SILICON,
     SIMULATION,
+    TTSIM,
     MOCK,
 };
 

--- a/device/api/umd/device/simulation/simulation_device.hpp
+++ b/device/api/umd/device/simulation/simulation_device.hpp
@@ -93,6 +93,8 @@ public:
         uint32_t* return_4 = nullptr) override;
 
 private:
+    void send_tensix_risc_reset(tt_xy_pair core, const TensixSoftResetOptions& soft_resets);
+
     // State variables
     driver_noc_params noc_params;
     std::set<chip_id_t> target_devices_in_cluster = {};

--- a/device/api/umd/device/simulation/simulation_host.hpp
+++ b/device/api/umd/device/simulation/simulation_host.hpp
@@ -9,10 +9,8 @@
 
 #include "umd/device/tt_xy_pair.h"
 
-#define NNG_SOCKET_PREFIX "ipc:///tmp/"
-
 typedef struct nng_socket_s nng_socket;
-typedef struct nng_dialer_s nng_dialer;
+typedef struct nng_listener_s nng_listener;
 
 namespace tt::umd {
 
@@ -27,7 +25,7 @@ public:
 
 private:
     std::unique_ptr<nng_socket> host_socket;
-    std::unique_ptr<nng_dialer> host_dialer;
+    std::unique_ptr<nng_listener> host_listener;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/simulation/ttsim_device.hpp
+++ b/device/api/umd/device/simulation/ttsim_device.hpp
@@ -92,6 +92,8 @@ public:
         uint32_t* return_4 = nullptr) override;
 
 private:
+    void send_tensix_risc_reset(tt_xy_pair core, const TensixSoftResetOptions& soft_resets);
+
     // State variables
     driver_noc_params noc_params;
     std::set<chip_id_t> target_devices_in_cluster = {};

--- a/device/api/umd/device/simulation/ttsim_device.hpp
+++ b/device/api/umd/device/simulation/ttsim_device.hpp
@@ -1,0 +1,113 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2023 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <vector>
+
+#include "umd/device/chip/chip.hpp"
+#include "umd/device/cluster.hpp"
+#include "umd/device/simulation/ttsim_host.hpp"
+#include "umd/device/utils/lock_manager.hpp"
+
+namespace tt::umd {
+
+class TTSimDeviceInit {
+public:
+    TTSimDeviceInit(const std::filesystem::path& simulator_directory);
+
+    tt::ARCH get_arch_name() const { return soc_descriptor.arch; }
+
+    const SocDescriptor& get_soc_descriptor() const { return soc_descriptor; }
+
+    std::filesystem::path get_simulator_path() const { return simulator_directory / "run.sh"; }
+
+private:
+    std::filesystem::path simulator_directory;
+    SocDescriptor soc_descriptor;
+};
+
+class TTSimDevice : public Chip {
+public:
+    TTSimDevice(const std::filesystem::path& simulator_directory) : TTSimDevice(TTSimDeviceInit(simulator_directory)) {}
+
+    TTSimDevice(const TTSimDeviceInit& init);
+    ~TTSimDevice();
+
+    TTSimHost host;
+
+    int get_num_host_channels() override;
+    int get_host_channel_size(std::uint32_t channel) override;
+    void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) override;
+    void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) override;
+
+    void start_device() override;
+    void close_device() override;
+
+    TTDevice* get_tt_device() override;
+    SysmemManager* get_sysmem_manager() override;
+    TLBManager* get_tlb_manager() override;
+
+    bool is_mmio_capable() const override { return false; }
+
+    void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) override;
+    void set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) override;
+
+    // All tt_xy_pair cores in this class are defined in VIRTUAL coords.
+    void write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) override;
+    void read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) override;
+    void write_to_device_reg(CoreCoord core, const void* src, uint64_t reg_dest, uint32_t size) override;
+    void read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_src, uint32_t size) override;
+    void dma_write_to_device(const void* src, size_t size, CoreCoord core, uint64_t addr) override;
+    void dma_read_from_device(void* dst, size_t size, CoreCoord core, uint64_t addr) override;
+
+    std::function<void(uint32_t, uint32_t, const uint8_t*)> get_fast_pcie_static_tlb_write_callable() override;
+
+    void wait_for_non_mmio_flush() override;
+
+    void l1_membar(const std::unordered_set<CoreCoord>& cores = {}) override;
+    void dram_membar(const std::unordered_set<CoreCoord>& cores = {}) override;
+    void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
+
+    void send_tensix_risc_reset(CoreCoord core, const TensixSoftResetOptions& soft_resets) override;
+    void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) override;
+    void deassert_risc_resets() override;
+
+    void set_power_state(DevicePowerState state) override;
+    int get_clock() override;
+    int get_numa_node() override;
+
+    int arc_msg(
+        uint32_t msg_code,
+        bool wait_for_done = true,
+        uint32_t arg0 = 0,
+        uint32_t arg1 = 0,
+        uint32_t timeout_ms = 1000,
+        uint32_t* return_3 = nullptr,
+        uint32_t* return_4 = nullptr) override;
+
+private:
+    // State variables
+    driver_noc_params noc_params;
+    std::set<chip_id_t> target_devices_in_cluster = {};
+    std::set<chip_id_t> target_remote_chips = {};
+    tt::ARCH arch_name;
+    std::shared_ptr<ClusterDescriptor> cluster_descriptor;
+    std::unordered_map<chip_id_t, SocDescriptor> soc_descriptor_per_chip = {};
+
+    // To enable DPRINT usage in the Simulator,
+    // the simulation device code should acquire a lock
+    // to ensure it can be called safely from multiple threads.
+    LockManager lock_manager;
+};
+
+}  // namespace tt::umd
+
+// TODO: To be removed once clients switch to namespace usage.
+using tt::umd::TTSimDeviceInit;
+using tt_TTSimDeviceInit = tt::umd::TTSimDeviceInit;

--- a/device/api/umd/device/simulation/ttsim_host.hpp
+++ b/device/api/umd/device/simulation/ttsim_host.hpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: (c) 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "umd/device/tt_xy_pair.h"
+
+#define NNG_SOCKET_PREFIX "ipc:///tmp/"
+
+typedef struct nng_socket_s nng_socket;
+typedef struct nng_dialer_s nng_dialer;
+
+namespace tt::umd {
+
+class TTSimHost {
+public:
+    TTSimHost();
+    ~TTSimHost();
+
+    void start_host();
+    void send_to_device(uint8_t *buf, size_t buf_size);
+    size_t recv_from_device(void **data_ptr);
+
+private:
+    std::unique_ptr<nng_socket> host_socket;
+    std::unique_ptr<nng_dialer> host_dialer;
+};
+
+}  // namespace tt::umd

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -255,13 +255,13 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     }
 
     if (chip_type == ChipType::TTSIM) {
-#ifdef TT_UMD_BUILD_TTSIM
+#ifdef TT_UMD_BUILD_SIMULATION
         log_info(LogSiliconDriver, "Creating TTSim Simulation device");
         return std::make_unique<TTSimDevice>(simulator_directory);
 #else
         throw std::runtime_error(
-            "TTSim device is not supported in this build. Set '-DTT_UMD_BUILD_TTSIM=ON' during cmake configuration to "
-            "enable TTSim device.");
+            "TTSim device is not supported in this build. Set '-TT_UMD_BUILD_SIMULATION=ON' during cmake configuration "
+            "to enable TTSim device.");
 #endif
     }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -244,6 +244,7 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     }
     if (chip_type == ChipType::SIMULATION) {
 #ifdef TT_UMD_BUILD_SIMULATION
+        log_info(LogSiliconDriver, "Creating Simulation device");
         // Note that passed soc descriptor is ignored in favor of soc descriptor from simulator_directory.
         return std::make_unique<SimulationDevice>(simulator_directory);
 #else
@@ -255,6 +256,7 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
 
     if (chip_type == ChipType::TTSIM) {
 #ifdef TT_UMD_BUILD_TTSIM
+        log_info(LogSiliconDriver, "Creating TTSim Simulation device");
         return std::make_unique<TTSimDevice>(simulator_directory);
 #else
         throw std::runtime_error(

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -492,7 +492,7 @@ std::unique_ptr<ClusterDescriptor> ClusterDescriptor::create_mock_cluster(
         desc->chips_with_mmio.insert({logical_id, logical_id});
         desc->chip_arch.insert({logical_id, arch});
         /* NOC translation is not supported for Simulation chips */
-        desc->noc_translation_enabled.insert({logical_id, false});
+        desc->noc_translation_enabled.insert({logical_id, true});
         desc->harvesting_masks_map.insert({logical_id, harvesting_masks});
     }
     desc->fill_chips_grouped_by_closest_mmio();

--- a/device/simulation/simulation_device.cpp
+++ b/device/simulation/simulation_device.cpp
@@ -115,13 +115,12 @@ void SimulationDevice::start_device() {
     nng_free(buf_ptr, buf_size);
 }
 
-void SimulationDevice::send_tensix_risc_reset(CoreCoord core, const TensixSoftResetOptions& soft_resets) {
+void SimulationDevice::send_tensix_risc_reset(tt_xy_pair core, const TensixSoftResetOptions& soft_resets) {
     auto lock = lock_manager.acquire_mutex(MutexType::TT_SIMULATOR);
-    tt_xy_pair translate_core = soc_descriptor_.translate_coord_to(core, CoordSystem::TRANSLATED);
     if (soft_resets == TENSIX_ASSERT_SOFT_RESET) {
         log_debug(tt::LogEmulationDriver, "Sending assert_risc_reset signal..");
         auto wr_buffer =
-            create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_ASSERT, std::vector<uint32_t>(1, 0), translate_core, 0);
+            create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_ASSERT, std::vector<uint32_t>(1, 0), core, 0);
         uint8_t* wr_buffer_ptr = wr_buffer.GetBufferPointer();
         size_t wr_buffer_size = wr_buffer.GetSize();
 
@@ -130,7 +129,7 @@ void SimulationDevice::send_tensix_risc_reset(CoreCoord core, const TensixSoftRe
     } else if (soft_resets == TENSIX_DEASSERT_SOFT_RESET) {
         log_debug(tt::LogEmulationDriver, "Sending 'deassert_risc_reset' signal..");
         auto wr_buffer =
-            create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_DEASSERT, std::vector<uint32_t>(1, 0), translate_core, 0);
+            create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_DEASSERT, std::vector<uint32_t>(1, 0), core, 0);
         uint8_t* wr_buffer_ptr = wr_buffer.GetBufferPointer();
         size_t wr_buffer_size = wr_buffer.GetSize();
 
@@ -140,8 +139,12 @@ void SimulationDevice::send_tensix_risc_reset(CoreCoord core, const TensixSoftRe
     }
 }
 
+void SimulationDevice::send_tensix_risc_reset(CoreCoord core, const TensixSoftResetOptions& soft_resets) {
+    send_tensix_risc_reset(tt_xy_pair(soc_descriptor_.translate_coord_to(core, CoordSystem::TRANSLATED)), soft_resets);
+}
+
 void SimulationDevice::send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) {
-    send_tensix_risc_reset(soc_descriptor_.get_coord_at({0, 0}, CoordSystem::TRANSLATED), soft_resets);
+    send_tensix_risc_reset({0, 0}, soft_resets);
 }
 
 void SimulationDevice::close_device() {

--- a/device/simulation/simulation_host.cpp
+++ b/device/simulation/simulation_host.cpp
@@ -4,13 +4,18 @@
 
 #include "umd/device/simulation/simulation_host.hpp"
 
+#include <netinet/in.h>
 #include <nng/nng.h>
 #include <nng/protocol/pair1/pair.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include <cassert>
 #include <cstdlib>
 #include <filesystem>
 #include <iomanip>
+#include <random>
 #include <sstream>
 #include <tt-logger/tt-logger.hpp>
 #include <typeinfo>
@@ -19,42 +24,87 @@
 
 namespace tt::umd {
 
-SimulationHost::SimulationHost() {
-    // Initialize socket and dialer
-    host_socket = std::make_unique<nng_socket>();
-    host_dialer = std::make_unique<nng_dialer>();
+bool is_port_free(int port) {
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0) {
+        return false;
+    }
 
-    // Get socket name, using PID to make it unique with multiple runs in parallel
-    const char *nng_socket_name = std::getenv("NNG_SOCKET_NAME") ? std::getenv("NNG_SOCKET_NAME") : "ttsim_nng_ipc";
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = INADDR_ANY;
+    addr.sin_port = htons(port);
+
+    bool free = (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+    close(sock);
+    return free;
+}
+
+SimulationHost::SimulationHost() {
+    // Initialize socket and listener
+    host_socket = std::make_unique<nng_socket>();
+    host_listener = std::make_unique<nng_listener>();
+
+    // Check if NNG_SOCKET_LOCAL_PORT is set
+    const char *local_socket_port_str = std::getenv("NNG_SOCKET_LOCAL_PORT");
+    std::string nng_socket_addr_str;
+
+    // Generate socket address with hostname and random port
+    char hostname[256];
+    if (gethostname(hostname, sizeof(hostname)) != 0) {
+        strcpy(hostname, "localhost");
+    }
+
+    int port;
+
+    if (local_socket_port_str) {
+        port = atoi(local_socket_port_str);
+        log_info(tt::LogEmulationDriver, "Using specified NNG_SOCKET_LOCAL_PORT: {}", port);
+    } else {
+        // Generate random port in range 50000-59999
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_int_distribution<> dis(50000, 59999);
+
+        do {
+            port = dis(gen);
+        } while (!is_port_free(port));
+        log_info(tt::LogEmulationDriver, "Using generated port: {}", port);
+    }
 
     std::ostringstream ss;
-    ss << NNG_SOCKET_PREFIX << nng_socket_name << "_" << getpid();
-    std::string nng_socket_addr_str = ss.str();
-    const char *nng_socket_addr = nng_socket_addr_str.c_str();
-    setenv("NNG_SOCKET_ADDR", nng_socket_addr, 1);  // pass NNG_SOCKET_ADDR to remote
+    ss << "tcp://" << hostname << ":" << port;
+    nng_socket_addr_str = ss.str();
 
-    // Open socket and create dialer
-    log_info(tt::LogEmulationDriver, "Dialing: {}", nng_socket_addr);
+    // Export the address for client to use
+    if (std::getenv("NNG_SOCKET_ADDR") == nullptr) {
+        setenv("NNG_SOCKET_ADDR", nng_socket_addr_str.c_str(), 1);
+        log_info(tt::LogEmulationDriver, "Generated NNG_SOCKET_ADDR: {}", nng_socket_addr_str);
+    }
+
+    const char *nng_socket_addr = nng_socket_addr_str.c_str();
+
+    // Open socket and create listener (server mode)
+    log_info(tt::LogEmulationDriver, "Listening on: {}", nng_socket_addr);
     nng_pair1_open(host_socket.get());
-    int rv = nng_dialer_create(host_dialer.get(), *host_socket, nng_socket_addr);
-    TT_ASSERT(rv == 0, "Failed to create dialer: {} {}", nng_strerror(rv), nng_socket_addr);
+    int rv = nng_listener_create(host_listener.get(), *host_socket, nng_socket_addr);
+    TT_ASSERT(rv == 0, "Failed to create listener: {} {}", nng_strerror(rv), nng_socket_addr);
 }
 
 SimulationHost::~SimulationHost() {
-    nng_dialer_close(*host_dialer);
+    nng_listener_close(*host_listener);
     nng_close(*host_socket);
 }
 
 void SimulationHost::start_host() {
-    // Establish connection with remote VCS simulator
-    int rv;
-    do {
-        rv = nng_dialer_start(*host_dialer, 0);
-        if (rv != 0) {
-            log_info(tt::LogEmulationDriver, "Waiting for remote: {}", nng_strerror(rv));
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-        }
-    } while (rv != 0);
+    // Start listening for connections from client
+    int rv = nng_listener_start(*host_listener, 0);
+    if (rv != 0) {
+        log_error(tt::LogEmulationDriver, "Failed to start listener: {}", nng_strerror(rv));
+        return;
+    }
+
+    log_info(tt::LogEmulationDriver, "Server started, waiting for client to connect...");
 }
 
 void SimulationHost::send_to_device(uint8_t *buf, size_t buf_size) {

--- a/device/simulation/ttsim_device.cpp
+++ b/device/simulation/ttsim_device.cpp
@@ -56,7 +56,8 @@ inline static void print_flatbuffer(const DeviceRequestResponse* buf) {
 }
 
 TTSimDeviceInit::TTSimDeviceInit(const std::filesystem::path& simulator_directory) :
-    simulator_directory(simulator_directory), soc_descriptor(simulator_directory / "soc_descriptor.yaml") {}
+    simulator_directory(simulator_directory),
+    soc_descriptor(simulator_directory / "soc_descriptor.yaml", ChipInfo{.noc_translation_enabled = true}) {}
 
 TTSimDevice::TTSimDevice(const TTSimDeviceInit& init) : Chip(init.get_soc_descriptor()) {
     log_info(tt::LogEmulationDriver, "Instantiating simulation device");

--- a/device/simulation/ttsim_host.cpp
+++ b/device/simulation/ttsim_host.cpp
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: (c) 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/simulation/ttsim_host.hpp"
+
+#include <nng/nng.h>
+#include <nng/protocol/pair1/pair.h>
+
+#include <cassert>
+#include <cstdlib>
+#include <filesystem>
+#include <iomanip>
+#include <sstream>
+#include <tt-logger/tt-logger.hpp>
+#include <typeinfo>
+
+#include "assert.hpp"
+
+namespace tt::umd {
+
+TTSimHost::TTSimHost() {
+    // Initialize socket and dialer
+    host_socket = std::make_unique<nng_socket>();
+    host_dialer = std::make_unique<nng_dialer>();
+
+    // Get socket name, using PID to make it unique with multiple runs in parallel
+    const char *nng_socket_name = std::getenv("NNG_SOCKET_NAME") ? std::getenv("NNG_SOCKET_NAME") : "ttsim_nng_ipc";
+
+    std::ostringstream ss;
+    ss << NNG_SOCKET_PREFIX << nng_socket_name << "_" << getpid();
+    std::string nng_socket_addr_str = ss.str();
+    const char *nng_socket_addr = nng_socket_addr_str.c_str();
+    setenv("NNG_SOCKET_ADDR", nng_socket_addr, 1);  // pass NNG_SOCKET_ADDR to remote
+
+    // Open socket and create dialer
+    log_info(tt::LogEmulationDriver, "Dialing: {}", nng_socket_addr);
+    nng_pair1_open(host_socket.get());
+    int rv = nng_dialer_create(host_dialer.get(), *host_socket, nng_socket_addr);
+    TT_ASSERT(rv == 0, "Failed to create dialer: {} {}", nng_strerror(rv), nng_socket_addr);
+}
+
+TTSimHost::~TTSimHost() {
+    nng_dialer_close(*host_dialer);
+    nng_close(*host_socket);
+}
+
+void TTSimHost::start_host() {
+    // Establish connection with remote VCS simulator
+    int rv;
+    do {
+        rv = nng_dialer_start(*host_dialer, 0);
+        if (rv != 0) {
+            log_info(tt::LogEmulationDriver, "Waiting for remote: {}", nng_strerror(rv));
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+    } while (rv != 0);
+}
+
+void TTSimHost::send_to_device(uint8_t *buf, size_t buf_size) {
+    int rv;
+    log_debug(tt::LogEmulationDriver, "Sending messsage to remote..");
+
+    void *msg = nng_alloc(buf_size);
+    std::memcpy(msg, buf, buf_size);
+
+    rv = nng_send(*host_socket, msg, buf_size, NNG_FLAG_ALLOC);
+    log_debug(tt::LogEmulationDriver, "Message sent.");
+    if (rv != 0) {
+        log_info(tt::LogEmulationDriver, "Failed to send message to remote: {}", nng_strerror(rv));
+    }
+}
+
+size_t TTSimHost::recv_from_device(void **data_ptr) {
+    int rv;
+    size_t data_size;
+    log_debug(tt::LogEmulationDriver, "Receiving messsage from remote..");
+    rv = nng_recv(*host_socket, data_ptr, &data_size, NNG_FLAG_ALLOC);
+    log_debug(tt::LogEmulationDriver, "Message received.");
+    if (rv != 0) {
+        log_info(tt::LogEmulationDriver, "Failed to receive message from remote: {}", nng_strerror(rv));
+    }
+    return data_size;
+}
+
+}  // namespace tt::umd

--- a/tests/simulation/CMakeLists.txt
+++ b/tests/simulation/CMakeLists.txt
@@ -1,4 +1,7 @@
-set(SIMULATION_TEST_SRCS test_simulation_device.cpp)
+set(SIMULATION_TEST_SRCS
+    test_simulation_device.cpp
+    test_ttsim_device.cpp
+)
 
 foreach(TEST ${SIMULATION_TEST_SRCS})
     get_filename_component(TEST_NAME ${TEST} NAME_WE)

--- a/tests/simulation/test_ttsim_device.cpp
+++ b/tests/simulation/test_ttsim_device.cpp
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: (c) 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <random>
+
+#include "tests/test_utils/device_test_utils.hpp"
+#include "ttsim_device_fixture.hpp"
+
+std::vector<uint32_t> generate_data(uint32_t size_in_bytes) {
+    size_t size = size_in_bytes / sizeof(uint32_t);
+    std::vector<uint32_t> data(size);
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<uint32_t> dis(0, 100);
+
+    for (uint32_t i = 0; i < size; i++) {
+        data[i] = dis(gen);
+    }
+    return data;
+}
+
+class LoopbackAllCoresParam : public TTSimDeviceFixture, public ::testing::WithParamInterface<tt_xy_pair> {};
+
+INSTANTIATE_TEST_SUITE_P(
+    LoopbackAllCores, LoopbackAllCoresParam, ::testing::Values(tt_xy_pair{0, 1}, tt_xy_pair{1, 1}, tt_xy_pair{1, 0}));
+
+TEST_P(LoopbackAllCoresParam, LoopbackSingleTensix) {
+    std::vector<uint32_t> wdata = {1, 2, 3, 4, 5};
+    std::vector<uint32_t> rdata(wdata.size(), 0);
+    auto &soc_desc = device->get_soc_descriptor();
+    CoreCoord core = soc_desc.get_coord_at(GetParam(), CoordSystem::VIRTUAL);
+
+    device->write_to_device(core, wdata.data(), 0x100, wdata.size() * sizeof(uint32_t));
+    device->read_from_device(core, rdata.data(), 0x100, rdata.size() * sizeof(uint32_t));
+
+    ASSERT_EQ(wdata, rdata);
+}
+
+bool loopback_stress_size(std::unique_ptr<TTSimDevice> &device, CoreCoord core, uint32_t byte_shift) {
+    uint64_t addr = 0x0;
+
+    std::vector<uint32_t> wdata = generate_data(1 << byte_shift);
+    std::vector<uint32_t> rdata(wdata.size(), 0);
+
+    device->write_to_device(core, wdata.data(), addr, wdata.size() * sizeof(uint32_t));
+    device->read_from_device(core, rdata.data(), addr, rdata.size() * sizeof(uint32_t));
+
+    return wdata == rdata;
+}
+
+TEST_P(LoopbackAllCoresParam, LoopbackStressSize) {
+    auto &soc_desc = device->get_soc_descriptor();
+    CoreCoord core = soc_desc.get_coord_at(GetParam(), CoordSystem::VIRTUAL);
+    CoreCoord dram = soc_desc.get_coord_at({1, 0}, CoordSystem::VIRTUAL);
+    if (core == dram) {
+        for (uint32_t i = 2; i <= 30; ++i) {  // 2^30 = 1 GB
+            ASSERT_TRUE(loopback_stress_size(device, core, i));
+        }
+    } else {
+        for (uint32_t i = 2; i <= 20; ++i) {  // 2^20 = 1 MB
+            ASSERT_TRUE(loopback_stress_size(device, core, i));
+        }
+    }
+}
+
+TEST_F(TTSimDeviceFixture, LoopbackTwoTensix) {
+    auto &soc_desc = device->get_soc_descriptor();
+    std::vector<uint32_t> wdata1 = {1, 2, 3, 4, 5};
+    std::vector<uint32_t> wdata2 = {6, 7, 8, 9, 10};
+    std::vector<uint32_t> rdata1(wdata1.size());
+    std::vector<uint32_t> rdata2(wdata2.size());
+    CoreCoord core1 = soc_desc.get_coord_at({0, 1}, CoordSystem::VIRTUAL);
+    CoreCoord core2 = soc_desc.get_coord_at({1, 1}, CoordSystem::VIRTUAL);
+
+    device->write_to_device(core1, wdata1.data(), 0x100, wdata1.size() * sizeof(uint32_t));
+    device->write_to_device(core2, wdata2.data(), 0x100, wdata2.size() * sizeof(uint32_t));
+
+    device->read_from_device(core1, rdata1.data(), 0x100, rdata1.size() * sizeof(uint32_t));
+    device->read_from_device(core2, rdata2.data(), 0x100, rdata2.size() * sizeof(uint32_t));
+
+    ASSERT_EQ(wdata1, rdata1);
+    ASSERT_EQ(wdata2, rdata2);
+}

--- a/tests/simulation/ttsim_device_fixture.hpp
+++ b/tests/simulation/ttsim_device_fixture.hpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <nng/nng.h>
+#include <nng/protocol/pair1/pair.h>
+#include <nng/protocol/pipeline0/pull.h>
+#include <nng/protocol/pipeline0/push.h>
+
+#include <stdexcept>
+
+#include "tests/test_utils/generate_cluster_desc.hpp"
+#include "umd/device/simulation/ttsim_device.hpp"
+
+namespace tt::umd {
+
+class TTSimDeviceFixture : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() {
+        // yaml path is dummy and won't change test behavior
+        const char* simulator_path = getenv("TT_UMD_SIMULATOR");
+        if (simulator_path == nullptr) {
+            throw std::runtime_error(
+                "You need to define TT_UMD_SIMULATOR that will point to simulator path. eg. build/versim-wormhole-b0");
+        }
+        device = std::make_unique<TTSimDevice>(simulator_path);
+        device->start_device();
+    }
+
+    static void TearDownTestSuite() { device->close_device(); }
+
+    static std::unique_ptr<TTSimDevice> device;
+};
+
+std::unique_ptr<TTSimDevice> TTSimDeviceFixture::device = nullptr;
+
+}  // namespace tt::umd


### PR DESCRIPTION
### Issue
Related to a couple of issues
Outdates https://github.com/tenstorrent/tt-umd/pull/1235
Related to https://github.com/tenstorrent/tt-umd/issues/1237
Also probably fixes https://github.com/tenstorrent/ttsim/issues/30 , at least to some extent
Also https://github.com/tenstorrent/ttsim/issues/15

### Description
Since we have different paths we want to take for the two simulators, separate them into two different classes. The expectation is that this might be diverging even further.

### List of the changes
- I've copied simulation_device, _host and test , and renamed with ttsim prefix
- Then reverted https://github.com/tenstorrent/tt-umd/pull/1236 , which should fix vcs simulator path
- Changed TTSim device to always use translation enabled
- Fixed an issue which always expected 0,0 in translated coords on send_tensix_reset, in both codepaths

### Testing
I've tested manually that both paths work, with tt_metal change: https://github.com/tenstorrent/tt-metal/pull/27763

### API Changes
This PR has API changes. It adds another class TTSim which should be used for the other simulator. Metal changes are accompanying this new usage
