### PR TITLE
Disable flaky warm reset test

### DIFF
--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -505,7 +505,7 @@ TEST(TestCluster, TestClusterAICLKControl) {
     }
 }
 
-TEST(TestCluster, WarmResetScratch) {
+TEST(TestCluster, DISABLED_WarmResetScratch) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
     if (cluster->get_target_device_ids().empty()) {


### PR DESCRIPTION
### Issue

Related to #1246, test should be reenabled when debugged

### Description

Disable flaky warm reset test

### List of the changes

- Disable flaky warm reset test

### Testing
CI

### API Changes
/
