### PR TITLE
Add support for libttsim.so to fix ttsim breakage

### DIFF
--- a/device/api/umd/device/simulation/simulation_device.hpp
+++ b/device/api/umd/device/simulation/simulation_device.hpp
@@ -17,6 +17,14 @@
 
 namespace tt::umd {
 
+typedef void (*libttsim_init_t)();
+typedef void (*libttsim_exit_t)();
+typedef void (*libttsim_tile_rd_bytes_t)(uint32_t x, uint32_t y, uint64_t addr, void* p, uint32_t size);
+typedef void (*libttsim_tile_wr_bytes_t)(uint32_t x, uint32_t y, uint64_t addr, const void* p, uint32_t size);
+typedef void (*libttsim_tensix_reset_deassert_t)(uint32_t x, uint32_t y);
+typedef void (*libttsim_tensix_reset_assert_t)(uint32_t x, uint32_t y);
+typedef void (*libttsim_clock_t)(uint32_t n_clocks);
+
 class SimulationDeviceInit {
 public:
     SimulationDeviceInit(const std::filesystem::path& simulator_directory);
@@ -25,7 +33,7 @@ public:
 
     const SocDescriptor& get_soc_descriptor() const { return soc_descriptor; }
 
-    std::filesystem::path get_simulator_path() const { return simulator_directory / "run.sh"; }
+    std::filesystem::path get_simulator_path() const { return simulator_directory; }
 
 private:
     std::filesystem::path simulator_directory;
@@ -107,6 +115,15 @@ private:
     // the simulation device code should acquire a lock
     // to ensure it can be called safely from multiple threads.
     LockManager lock_manager;
+
+    void* libttsim_handle = nullptr;
+    libttsim_init_t pfn_libttsim_init = nullptr;
+    libttsim_exit_t pfn_libttsim_exit = nullptr;
+    libttsim_tile_rd_bytes_t pfn_libttsim_tile_rd_bytes = nullptr;
+    libttsim_tile_wr_bytes_t pfn_libttsim_tile_wr_bytes = nullptr;
+    libttsim_tensix_reset_deassert_t pfn_libttsim_tensix_reset_deassert = nullptr;
+    libttsim_tensix_reset_assert_t pfn_libttsim_tensix_reset_assert = nullptr;
+    libttsim_clock_t pfn_libttsim_clock = nullptr;
 };
 
 }  // namespace tt::umd

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -435,7 +435,11 @@ Cluster::Cluster(ClusterOptions options) {
 
     if (options.sdesc_path.empty() &&
         (options.chip_type == ChipType::SIMULATION || options.chip_type == ChipType::TTSIM)) {
-        options.sdesc_path = options.simulator_directory / "soc_descriptor.yaml";
+        if (options.simulator_directory.extension() == ".so") {
+            options.sdesc_path = options.simulator_directory.parent_path() / "soc_descriptor.yaml";
+        } else {
+            options.sdesc_path = options.simulator_directory / "soc_descriptor.yaml";
+        }
     }
 
     // Construct all the required chips from the cluster descriptor.

--- a/device/simulation/simulation_device.cpp
+++ b/device/simulation/simulation_device.cpp
@@ -6,6 +6,7 @@
 
 #include "umd/device/simulation/simulation_device.hpp"
 
+#include <dlfcn.h>
 #include <nng/nng.h>
 #include <uv.h>
 
@@ -17,6 +18,12 @@
 #include "assert.hpp"
 #include "simulation_device_generated.h"
 #include "umd/device/driver_atomics.hpp"
+
+#define DLSYM_FUNCTION(func_name)                                                    \
+    pfn_##func_name = (decltype(pfn_##func_name))dlsym(libttsim_handle, #func_name); \
+    if (!pfn_##func_name) {                                                          \
+        TT_THROW("Failed to find '%s' symbol: ", #func_name, dlerror());             \
+    }
 
 namespace tt::umd {
 
@@ -56,7 +63,10 @@ inline static void print_flatbuffer(const DeviceRequestResponse* buf) {
 }
 
 SimulationDeviceInit::SimulationDeviceInit(const std::filesystem::path& simulator_directory) :
-    simulator_directory(simulator_directory), soc_descriptor(simulator_directory / "soc_descriptor.yaml") {}
+    simulator_directory(simulator_directory),
+    soc_descriptor(
+        (simulator_directory.extension() == ".so") ? (simulator_directory.parent_path() / "soc_descriptor.yaml")
+                                                   : (simulator_directory / "soc_descriptor.yaml")) {}
 
 SimulationDevice::SimulationDevice(const SimulationDeviceInit& init) : Chip(init.get_soc_descriptor()) {
     log_info(tt::LogEmulationDriver, "Instantiating simulation device");
@@ -65,75 +75,111 @@ SimulationDevice::SimulationDevice(const SimulationDeviceInit& init) : Chip(init
     arch_name = init.get_arch_name();
     target_devices_in_cluster = {0};
 
-    // Start VCS simulator in a separate process
     std::filesystem::path simulator_path = init.get_simulator_path();
     if (!std::filesystem::exists(simulator_path)) {
         TT_THROW("Simulator binary not found at: ", simulator_path);
     }
-    uv_loop_t* loop = uv_default_loop();
-    std::string simulator_path_string = simulator_path;
 
-    uv_stdio_container_t child_stdio[3];
-    child_stdio[0].flags = UV_IGNORE;
-    child_stdio[1].flags = UV_INHERIT_FD;
-    child_stdio[1].data.fd = 1;
-    child_stdio[2].flags = UV_INHERIT_FD;
-    child_stdio[2].data.fd = 2;
-
-    uv_process_options_t child_options = {0};
-    child_options.file = simulator_path_string.c_str();
-    child_options.flags = UV_PROCESS_DETACHED;
-    child_options.stdio_count = 3;
-    child_options.stdio = child_stdio;
-
-    uv_process_t child_p;
-    int rv = uv_spawn(loop, &child_p, &child_options);
-    if (rv) {
-        TT_THROW("Failed to spawn simulator process: ", uv_strerror(rv));
+    if (simulator_path.extension() == ".so") {
+        // dlopen the simulator library and dlsym the entry points
+        libttsim_handle = dlopen(simulator_path.string().c_str(), RTLD_LAZY);
+        if (!libttsim_handle) {
+            TT_THROW("Failed to dlopen simulator library: ", dlerror());
+        }
+        DLSYM_FUNCTION(libttsim_init)
+        DLSYM_FUNCTION(libttsim_exit)
+        DLSYM_FUNCTION(libttsim_tile_rd_bytes)
+        DLSYM_FUNCTION(libttsim_tile_wr_bytes)
+        DLSYM_FUNCTION(libttsim_tensix_reset_deassert)
+        DLSYM_FUNCTION(libttsim_tensix_reset_assert)
+        DLSYM_FUNCTION(libttsim_clock)
     } else {
-        log_info(tt::LogEmulationDriver, "Simulator process spawned with PID: {}", child_p.pid);
-    }
+        // Start simulator process
+        uv_loop_t* loop = uv_default_loop();
+        std::string simulator_path_string = simulator_path / "run.sh";
+        if (!std::filesystem::exists(simulator_path_string)) {
+            TT_THROW("Simulator binary not found at: ", simulator_path_string);
+        }
 
-    uv_unref((uv_handle_t*)&child_p);
-    uv_run(loop, UV_RUN_DEFAULT);
-    uv_loop_close(loop);
+        uv_stdio_container_t child_stdio[3];
+        child_stdio[0].flags = UV_IGNORE;
+        child_stdio[1].flags = UV_INHERIT_FD;
+        child_stdio[1].data.fd = 1;
+        child_stdio[2].flags = UV_INHERIT_FD;
+        child_stdio[2].data.fd = 2;
+
+        uv_process_options_t child_options = {0};
+        child_options.file = simulator_path_string.c_str();
+        child_options.flags = UV_PROCESS_DETACHED;
+        child_options.stdio_count = 3;
+        child_options.stdio = child_stdio;
+
+        uv_process_t child_p;
+        int rv = uv_spawn(loop, &child_p, &child_options);
+        if (rv) {
+            TT_THROW("Failed to spawn simulator process: ", uv_strerror(rv));
+        } else {
+            log_info(tt::LogEmulationDriver, "Simulator process spawned with PID: {}", child_p.pid);
+        }
+
+        uv_unref((uv_handle_t*)&child_p);
+        uv_run(loop, UV_RUN_DEFAULT);
+        uv_loop_close(loop);
+    }
 }
 
-SimulationDevice::~SimulationDevice() { lock_manager.clear_mutex(MutexType::TT_SIMULATOR); }
+SimulationDevice::~SimulationDevice() {
+    lock_manager.clear_mutex(MutexType::TT_SIMULATOR);
+    if (libttsim_handle) {
+        dlclose(libttsim_handle);
+    }
+}
 
 void SimulationDevice::start_device() {
     auto lock = lock_manager.acquire_mutex(MutexType::TT_SIMULATOR);
-    void* buf_ptr = nullptr;
+    if (libttsim_handle) {
+        pfn_libttsim_init();
+    } else {
+        void* buf_ptr = nullptr;
 
-    host.start_host();
+        host.start_host();
 
-    log_info(tt::LogEmulationDriver, "Waiting for ack msg from remote...");
-    size_t buf_size = host.recv_from_device(&buf_ptr);
-    auto buf = GetDeviceRequestResponse(buf_ptr);
-    auto cmd = buf->command();
-    TT_ASSERT(cmd == DEVICE_COMMAND_EXIT, "Did not receive expected command from remote.");
-    nng_free(buf_ptr, buf_size);
+        log_info(tt::LogEmulationDriver, "Waiting for ack msg from remote...");
+        size_t buf_size = host.recv_from_device(&buf_ptr);
+        auto buf = GetDeviceRequestResponse(buf_ptr);
+        auto cmd = buf->command();
+        TT_ASSERT(cmd == DEVICE_COMMAND_EXIT, "Did not receive expected command from remote.");
+        nng_free(buf_ptr, buf_size);
+    }
 }
 
 void SimulationDevice::send_tensix_risc_reset(tt_xy_pair core, const TensixSoftResetOptions& soft_resets) {
     auto lock = lock_manager.acquire_mutex(MutexType::TT_SIMULATOR);
     if (soft_resets == TENSIX_ASSERT_SOFT_RESET) {
         log_debug(tt::LogEmulationDriver, "Sending assert_risc_reset signal..");
-        auto wr_buffer =
-            create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_ASSERT, std::vector<uint32_t>(1, 0), core, 0);
-        uint8_t* wr_buffer_ptr = wr_buffer.GetBufferPointer();
-        size_t wr_buffer_size = wr_buffer.GetSize();
+        if (libttsim_handle) {
+            pfn_libttsim_tensix_reset_assert(core.x, core.y);
+        } else {
+            auto wr_buffer =
+                create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_ASSERT, std::vector<uint32_t>(1, 0), core, 0);
+            uint8_t* wr_buffer_ptr = wr_buffer.GetBufferPointer();
+            size_t wr_buffer_size = wr_buffer.GetSize();
 
-        print_flatbuffer(GetDeviceRequestResponse(wr_buffer_ptr));
-        host.send_to_device(wr_buffer_ptr, wr_buffer_size);
+            print_flatbuffer(GetDeviceRequestResponse(wr_buffer_ptr));
+            host.send_to_device(wr_buffer_ptr, wr_buffer_size);
+        }
     } else if (soft_resets == TENSIX_DEASSERT_SOFT_RESET) {
         log_debug(tt::LogEmulationDriver, "Sending 'deassert_risc_reset' signal..");
-        auto wr_buffer =
-            create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_DEASSERT, std::vector<uint32_t>(1, 0), core, 0);
-        uint8_t* wr_buffer_ptr = wr_buffer.GetBufferPointer();
-        size_t wr_buffer_size = wr_buffer.GetSize();
+        if (libttsim_handle) {
+            pfn_libttsim_tensix_reset_deassert(core.x, core.y);
+        } else {
+            auto wr_buffer =
+                create_flatbuffer(DEVICE_COMMAND_ALL_TENSIX_RESET_DEASSERT, std::vector<uint32_t>(1, 0), core, 0);
+            uint8_t* wr_buffer_ptr = wr_buffer.GetBufferPointer();
+            size_t wr_buffer_size = wr_buffer.GetSize();
 
-        host.send_to_device(wr_buffer_ptr, wr_buffer_size);
+            host.send_to_device(wr_buffer_ptr, wr_buffer_size);
+        }
     } else {
         TT_THROW("Invalid soft reset option.");
     }
@@ -150,8 +196,12 @@ void SimulationDevice::send_tensix_risc_reset(const TensixSoftResetOptions& soft
 void SimulationDevice::close_device() {
     // disconnect from remote connection
     log_info(tt::LogEmulationDriver, "Sending exit signal to remote...");
-    auto builder = create_flatbuffer(DEVICE_COMMAND_EXIT, std::vector<uint32_t>(1, 0), {0, 0}, 0);
-    host.send_to_device(builder.GetBufferPointer(), builder.GetSize());
+    if (libttsim_handle) {
+        pfn_libttsim_exit();
+    } else {
+        auto builder = create_flatbuffer(DEVICE_COMMAND_EXIT, std::vector<uint32_t>(1, 0), {0, 0}, 0);
+        host.send_to_device(builder.GetBufferPointer(), builder.GetSize());
+    }
 }
 
 void SimulationDevice::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) {}
@@ -163,35 +213,45 @@ void SimulationDevice::write_to_device(CoreCoord core, const void* src, uint64_t
     auto lock = lock_manager.acquire_mutex(MutexType::TT_SIMULATOR);
     log_debug(tt::LogEmulationDriver, "Device writing {} bytes to l1_dest {} in core {}", size, l1_dest, core.str());
     tt_xy_pair translate_core = soc_descriptor_.translate_coord_to(core, CoordSystem::TRANSLATED);
-    std::vector<std::uint32_t> data((uint32_t*)src, (uint32_t*)src + size / sizeof(uint32_t));
-    auto wr_buffer = create_flatbuffer(DEVICE_COMMAND_WRITE, data, translate_core, l1_dest);
-    uint8_t* wr_buffer_ptr = wr_buffer.GetBufferPointer();
-    size_t wr_buffer_size = wr_buffer.GetSize();
+    if (libttsim_handle) {
+        pfn_libttsim_tile_wr_bytes(translate_core.x, translate_core.y, l1_dest, src, size);
+        pfn_libttsim_clock(10);
+    } else {
+        std::vector<std::uint32_t> data((uint32_t*)src, (uint32_t*)src + size / sizeof(uint32_t));
+        auto wr_buffer = create_flatbuffer(DEVICE_COMMAND_WRITE, data, translate_core, l1_dest);
+        uint8_t* wr_buffer_ptr = wr_buffer.GetBufferPointer();
+        size_t wr_buffer_size = wr_buffer.GetSize();
 
-    print_flatbuffer(GetDeviceRequestResponse(wr_buffer_ptr));  // sanity print
-    host.send_to_device(wr_buffer_ptr, wr_buffer_size);
+        print_flatbuffer(GetDeviceRequestResponse(wr_buffer_ptr));  // sanity print
+        host.send_to_device(wr_buffer_ptr, wr_buffer_size);
+    }
 }
 
 void SimulationDevice::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) {
     auto lock = lock_manager.acquire_mutex(MutexType::TT_SIMULATOR);
-    void* rd_resp;
-
-    // Send read request
     tt_xy_pair translate_core = soc_descriptor_.translate_coord_to(core, CoordSystem::TRANSLATED);
-    auto rd_req_buf = create_flatbuffer(DEVICE_COMMAND_READ, {0}, translate_core, l1_src, size);
-    host.send_to_device(rd_req_buf.GetBufferPointer(), rd_req_buf.GetSize());
+    if (libttsim_handle) {
+        pfn_libttsim_tile_rd_bytes(translate_core.x, translate_core.y, l1_src, dest, size);
+        pfn_libttsim_clock(10);
+    } else {
+        void* rd_resp;
 
-    // Get read response
-    size_t rd_rsp_sz = host.recv_from_device(&rd_resp);
+        // Send read request
+        auto rd_req_buf = create_flatbuffer(DEVICE_COMMAND_READ, {0}, translate_core, l1_src, size);
+        host.send_to_device(rd_req_buf.GetBufferPointer(), rd_req_buf.GetSize());
 
-    auto rd_resp_buf = GetDeviceRequestResponse(rd_resp);
+        // Get read response
+        size_t rd_rsp_sz = host.recv_from_device(&rd_resp);
 
-    // Debug level polling as Metal will constantly poll the device, spamming the logs
-    log_debug(tt::LogEmulationDriver, "Device reading vec");
-    print_flatbuffer(rd_resp_buf);
+        auto rd_resp_buf = GetDeviceRequestResponse(rd_resp);
 
-    std::memcpy(dest, rd_resp_buf->data()->data(), rd_resp_buf->data()->size() * sizeof(uint32_t));
-    nng_free(rd_resp, rd_rsp_sz);
+        // Debug level polling as Metal will constantly poll the device, spamming the logs
+        log_debug(tt::LogEmulationDriver, "Device reading vec");
+        print_flatbuffer(rd_resp_buf);
+
+        std::memcpy(dest, rd_resp_buf->data()->data(), rd_resp_buf->data()->size() * sizeof(uint32_t));
+        nng_free(rd_resp, rd_rsp_sz);
+    }
 }
 
 void SimulationDevice::write_to_device_reg(CoreCoord core, const void* src, uint64_t reg_dest, uint32_t size) {


### PR DESCRIPTION
### Issue
#1251 

### Description
Add logic to load libttsim.so and use entry points from it as an alternative to IPC. Fixes failures where all tests are currently failing on ttsim. Removing the IPC is also approximately a 2x speedup in some tests.

### List of the changes
- Add dlopen, dlsym, dlclose of simulator .so
- Route the various simulator messages to these entry points from .so
- Enable this code path when TT_METAL_SIMULATOR points to libttsim.so directly
- Locate soc_descriptor.yaml in the parent directory of libttsim.so

### Testing
local testing of Metal examples on ttsim

### API Changes
/