### PR TITLE
Add board type for Blackhole UBB

### DIFF
--- a/device/api/umd/device/types/cluster_descriptor_types.hpp
+++ b/device/api/umd/device/types/cluster_descriptor_types.hpp
@@ -29,10 +29,30 @@ enum BoardType : uint32_t {
     P150,
     P300,
     GALAXY,
+    // There is both UBB and UBB_WORMHOLE board types in the system right now.
+    // Since we want to deprecate UBB, we make UBB_WORMHOLE an alias to UBB.
+    // Clients should remove UBB usage and switch to UBB_WORMHOLE.
     UBB,
+    UBB_WORMHOLE = UBB,
+    UBB_BLACKHOLE,
     QUASAR,
     UNKNOWN,
 };
+
+static_assert(E75 == 0, "E75 must be 0");
+static_assert(E150 == 1, "E150 must be 1");
+static_assert(E300 == 2, "E300 must be 2");
+static_assert(N150 == 3, "N150 must be 3");
+static_assert(N300 == 4, "N300 must be 4");
+static_assert(P100 == 5, "P100 must be 5");
+static_assert(P150 == 6, "P150 must be 6");
+static_assert(P300 == 7, "P300 must be 7");
+static_assert(GALAXY == 8, "GALAXY must be 8");
+static_assert(UBB == 9, "UBB must be 9");
+static_assert(UBB_WORMHOLE == 9, "WH_UBB must equal UBB");
+static_assert(UBB_BLACKHOLE == 10, "BH_UBB must be 10");
+static_assert(QUASAR == 11, "QUASAR must be 11");
+static_assert(UNKNOWN == 12, "UNKNOWN must be 12");
 
 namespace tt::umd {
 
@@ -90,6 +110,8 @@ inline const std::unordered_map<std::string_view, BoardType> board_type_name_map
     {"p300", BoardType::P300},
     {"galaxy", BoardType::GALAXY},
     {"ubb", BoardType::UBB},
+    {"ubb_blackhole", BoardType::UBB_BLACKHOLE},
+    {"ubb_wormhole", BoardType::UBB_WORMHOLE},
     {"quasar", BoardType::QUASAR},
     {"unknown", BoardType::UNKNOWN},
     // Aliases (input only)
@@ -111,6 +133,8 @@ inline const std::unordered_map<BoardType, std::string_view> board_type_canonica
     {BoardType::P300, "p300"},
     {BoardType::GALAXY, "galaxy"},
     {BoardType::UBB, "ubb"},
+    {BoardType::UBB_BLACKHOLE, "ubb_blackhole"},
+    {BoardType::UBB_WORMHOLE, "ubb_wormhole"},
     {BoardType::QUASAR, "quasar"},
     {BoardType::UNKNOWN, "unknown"},
 };
@@ -179,7 +203,9 @@ inline uint32_t get_number_of_chips_from_board_type(const BoardType board_type) 
             return 2;
         case BoardType::GALAXY:
             return 1;
+        // TODO: switch usage of UBB to UBB_WORMHOLE.
         case BoardType::UBB:
+        case BoardType::UBB_BLACKHOLE:
             return 32;
         default:
             throw std::runtime_error("Unknown board type for number of chips calculation.");
@@ -198,8 +224,9 @@ inline const std::unordered_map<uint64_t, BoardType> board_upi_map = {
     {0x18, BoardType::N150},
     {0x14, BoardType::N300},
     {0xB, BoardType::GALAXY},
+    // TODO: move 0x35 constant to be equal to UBB_WORMHOLE once we delete UBB.
     {0x35, BoardType::UBB},
-};
+    {0x47, BoardType::UBB_BLACKHOLE}};
 
 inline BoardType get_board_type_from_board_id(const uint64_t board_id) {
     uint64_t upi = (board_id >> 36) & 0xFFFFF;


### PR DESCRIPTION
### Issue

Add missing board type for Blackhole galaxy

### Description

Add missing board type for Blackhole galaxy and make a separation with Wormhole galaxy. There is still old UBB enum which should be renamed to UBB_WORMHOLE in all clients and then we can remove UBB enum

### List of the changes

- Add enums for Wormhole and Blackhole UBB
- Fill helper structures for board types properly
- Add static asserts for values of board type enum

### Testing
CI

### API Changes
/