### PR TITLE
Enable noc_translation_enabled for ttsim

### DIFF
--- a/device/simulation/simulation_device.cpp
+++ b/device/simulation/simulation_device.cpp
@@ -66,7 +66,8 @@ SimulationDeviceInit::SimulationDeviceInit(const std::filesystem::path& simulato
     simulator_directory(simulator_directory),
     soc_descriptor(
         (simulator_directory.extension() == ".so") ? (simulator_directory.parent_path() / "soc_descriptor.yaml")
-                                                   : (simulator_directory / "soc_descriptor.yaml")) {}
+                                                   : (simulator_directory / "soc_descriptor.yaml"),
+        ChipInfo{.noc_translation_enabled = (simulator_directory.extension() == ".so")}) {}
 
 SimulationDevice::SimulationDevice(const SimulationDeviceInit& init) : Chip(init.get_soc_descriptor()) {
     log_info(tt::LogEmulationDriver, "Instantiating simulation device");


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/1271

### Description
Enable noc translation on ttsim to fix a variety of test failures, e.g., this fixes a hang in metal_example_noc_tile_transfer as well as being required for many tests that use atomics or multicast.

### List of the changes
Set the flag to true when using the libttsim.so path

### Testing
Ran metal examples locally on simulator

### API Changes
/