### PR TITLE
use simple mutex structure instead of OS wide

### DIFF
--- a/device/api/umd/device/simulation/simulation_device.hpp
+++ b/device/api/umd/device/simulation/simulation_device.hpp
@@ -114,7 +114,7 @@ private:
     // To enable DPRINT usage in the Simulator,
     // the simulation device code should acquire a lock
     // to ensure it can be called safely from multiple threads.
-    LockManager lock_manager;
+    std::mutex device_lock;
 
     void* libttsim_handle = nullptr;
     libttsim_init_t pfn_libttsim_init = nullptr;

--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -28,8 +28,6 @@ enum class MutexType {
     MEM_BARRIER,
     // Used for calling CEM tool.
     CREATE_ETH_MAP,
-    // Used to enable DPRINT usage in the Simulator.
-    TT_SIMULATOR,
     // Used for guarding against multiple users initializing the same chip.
     CHIP_IN_USE,
 };

--- a/device/utils/lock_manager.cpp
+++ b/device/utils/lock_manager.cpp
@@ -19,7 +19,6 @@ const std::unordered_map<MutexType, std::string> LockManager::MutexTypeToString 
     {MutexType::NON_MMIO, "NON_MMIO"},
     {MutexType::MEM_BARRIER, "MEM_BARRIER"},
     {MutexType::CREATE_ETH_MAP, "CREATE_ETH_MAP"},
-    {MutexType::TT_SIMULATOR, "TT_SIMULATOR"},
     {MutexType::CHIP_IN_USE, "CHIP_IN_USE"},
 };
 


### PR DESCRIPTION
Issue
https://github.com/tenstorrent/tt-umd/issues/1253

Description
Introduction of lock on the simulator path decreased the perf significantly.
Use a simple c++ mutex instead of custom written robust mutex.
Also supersedes https://github.com/tenstorrent/tt-umd/pull/1267

### List of the changes
- Remove TT_SIMULATOR lock
- Use std::mutex instead of the lock_manager

### Testing


API Changes
There are no API changes in this PR.
