### PR TITLE
Mock chip start/close

### DIFF
--- a/device/api/umd/device/chip/mock_chip.hpp
+++ b/device/api/umd/device/chip/mock_chip.hpp
@@ -49,7 +49,10 @@ public:
     void dram_membar(const std::unordered_set<CoreCoord>& cores = {}) override;
     void dram_membar(const std::unordered_set<uint32_t>& channels = {}) override;
 
+    void send_tensix_risc_reset(CoreCoord core, const TensixSoftResetOptions& soft_resets) override;
+    void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) override;
     void deassert_risc_resets() override;
+
     void set_power_state(DevicePowerState state) override;
     int get_clock() override;
     int get_numa_node() override;

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -680,7 +680,6 @@ private:
     std::set<chip_id_t> local_chip_ids_ = {};
     std::unordered_map<chip_id_t, std::unique_ptr<Chip>> chips_;
     tt::ARCH arch_name;
-    tt::umd::ChipType chip_type_;
 
     std::unique_ptr<ClusterDescriptor> cluster_desc;
 

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -58,6 +58,7 @@ int MockChip::arc_msg(
     uint32_t timeout_ms,
     uint32_t* return_3,
     uint32_t* return_4) {
+    *return_3 = 1;
     return 0;
 }
 
@@ -68,6 +69,10 @@ void MockChip::l1_membar(const std::unordered_set<CoreCoord>& cores) {}
 void MockChip::dram_membar(const std::unordered_set<CoreCoord>& cores) {}
 
 void MockChip::dram_membar(const std::unordered_set<uint32_t>& channels) {}
+
+void MockChip::send_tensix_risc_reset(CoreCoord core, const TensixSoftResetOptions& soft_resets) {}
+
+void MockChip::send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) {}
 
 void MockChip::deassert_risc_resets() {}
 

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -58,6 +58,7 @@ int MockChip::arc_msg(
     uint32_t timeout_ms,
     uint32_t* return_3,
     uint32_t* return_4) {
+    // This designates success for the ARC enable eth queue message.
     *return_3 = 1;
     return 0;
 }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -227,7 +227,7 @@ void Cluster::construct_cluster(const uint32_t& num_host_mem_ch_per_mmio_device,
 
     // Disable dependency to ethernet firmware for all BH devices and WH devices with all chips having MMIO (e.g. UBB
     // Galaxy, or P300).
-    if (remote_chip_ids_.empty()) {
+    if (remote_chip_ids_.empty() || chip_type != ChipType::SILICON) {
         use_ethernet_broadcast = false;
     }
 }
@@ -391,7 +391,6 @@ Cluster::Cluster(ClusterOptions options) {
     // If the cluster descriptor is not provided, create a new one.
     ClusterDescriptor* temp_full_cluster_desc = options.cluster_descriptor;
     std::unique_ptr<ClusterDescriptor> temp_full_cluster_desc_ptr;
-    chip_type_ = options.chip_type;
 
     // We need to constuct a cluster descriptor if a custom one was not passed.
     if (temp_full_cluster_desc == nullptr) {
@@ -1042,11 +1041,6 @@ void Cluster::verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std
 }
 
 void Cluster::start_device(const device_params& device_params) {
-    if (this->chip_type_ == tt::umd::ChipType::MOCK) {
-        // Mock cluster doesn't need to start device
-        return;
-    }
-
     if (device_params.init_device) {
         for (auto chip_id : all_chip_ids_) {
             get_chip(chip_id)->start_device();
@@ -1057,11 +1051,6 @@ void Cluster::start_device(const device_params& device_params) {
 }
 
 void Cluster::close_device() {
-    if (this->chip_type_ == tt::umd::ChipType::MOCK) {
-        // Mock cluster doesn't need to close device
-        return;
-    }
-
     // Close remote device first because sending risc reset requires corresponding pcie device to be active
     for (auto remote_chip_id : remote_chip_ids_) {
         get_chip(remote_chip_id)->close_device();


### PR DESCRIPTION
### Issue
A follow up from https://github.com/tenstorrent/tt-umd/pull/1191

### Description
Trying to make mock/silicon more common, by not skipping start/close device.

### List of the changes
- remove skipping start/close for mock
- Remove chip_type_ in cluster
- Override send tensix reset for mock chip which is empty
- Turn off use_ethernet_broadcast for non silicon chip types
- Mock arc msg set success

### Testing
In tt_metal, ran:
`TT_METAL_MOCK_CLUSTER_DESC_PATH=tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/2x2_n300_cluster_desc.yaml TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*TestCustom2x2MeshAPIs"`

### API Changes
There are no API changes in this PR.
