### PR TITLE
Fix TTDevice read/write for registers

### DIFF
--- a/device/api/umd/device/arch/architecture_implementation.hpp
+++ b/device/api/umd/device/arch/architecture_implementation.hpp
@@ -66,6 +66,7 @@ public:
     virtual uint32_t get_reg_tlb() const = 0;
     virtual uint32_t get_tlb_base_index_16m() const = 0;
     virtual uint32_t get_tensix_soft_reset_addr() const = 0;
+    virtual uint32_t get_debug_reg_addr() const = 0;
     virtual uint32_t get_grid_size_x() const = 0;
     virtual uint32_t get_grid_size_y() const = 0;
     virtual uint32_t get_tlb_cfg_reg_size_bytes() const = 0;

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -218,6 +218,8 @@ static constexpr uint32_t ARC_CSM_MAILBOX_SIZE_OFFSET = ARC_CSM_OFFSET + 0x784C4
 
 static constexpr uint32_t TENSIX_SOFT_RESET_ADDR = 0xFFB121B0;
 
+static constexpr uint32_t RISCV_DEBUG_REG_DBG_BUS_CNTL_REG = 0xFFB12000 + 0x54;
+
 static constexpr uint32_t MSG_TYPE_SETUP_IATU_FOR_PEER_TO_PEER = 0x97;
 
 static const uint32_t BH_NOC_NODE_ID_OFFSET = 0x1FD04044;
@@ -396,6 +398,8 @@ public:
     }
 
     uint32_t get_tensix_soft_reset_addr() const override { return blackhole::TENSIX_SOFT_RESET_ADDR; }
+
+    uint32_t get_debug_reg_addr() const override { return blackhole::RISCV_DEBUG_REG_DBG_BUS_CNTL_REG; }
 
     uint32_t get_grid_size_x() const override { return blackhole::GRID_SIZE_X; }
 

--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -242,6 +242,8 @@ static constexpr uint32_t ARC_CSM_MAILBOX_SIZE_OFFSET = 0x1FEF84C4;
 
 static constexpr uint32_t TENSIX_SOFT_RESET_ADDR = 0xFFB121B0;
 
+static constexpr uint32_t RISCV_DEBUG_REG_DBG_BUS_CNTL_REG = 0xFFB12000 + 0x54;
+
 static constexpr uint32_t ARC_SCRATCH_6_OFFSET = 0x1FF30078;
 
 static constexpr uint32_t ARC_RESET_UNIT_OFFSET = 0x30000;
@@ -386,6 +388,8 @@ public:
     uint32_t get_tlb_base_index_16m() const override { return wormhole::TLB_BASE_INDEX_16M; }
 
     uint32_t get_tensix_soft_reset_addr() const override { return wormhole::TENSIX_SOFT_RESET_ADDR; }
+
+    uint32_t get_debug_reg_addr() const override { return wormhole::RISCV_DEBUG_REG_DBG_BUS_CNTL_REG; }
 
     uint32_t get_grid_size_x() const override { return wormhole::GRID_SIZE_X; }
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -34,7 +34,6 @@ TTDevice::TTDevice(
     architecture_impl_(std::move(architecture_impl)),
     arch(architecture_impl_->get_architecture()) {
     lock_manager.initialize_mutex(MutexType::TT_DEVICE_IO, get_communication_device_id());
-    lock_manager.initialize_mutex("REG_TLB", get_communication_device_id());
 }
 
 TTDevice::TTDevice(
@@ -47,7 +46,6 @@ TTDevice::TTDevice(
     architecture_impl_(std::move(architecture_impl)),
     arch(architecture_impl_->get_architecture()) {
     lock_manager.initialize_mutex(MutexType::TT_DEVICE_IO, get_communication_device_id(), IODeviceType::JTAG);
-    lock_manager.initialize_mutex("REG_TLB", get_communication_device_id(), IODeviceType::JTAG);
 }
 
 void TTDevice::init_tt_device() {
@@ -302,7 +300,7 @@ void TTDevice::read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, u
         jtag_device_->read(jlink_id_, mem_ptr, core.x, core.y, addr, size);
         return;
     }
-    auto lock = lock_manager.acquire_mutex("REG_TLB", get_pci_device()->get_device_num());
+    auto lock = lock_manager.acquire_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num());
     uint8_t *buffer_addr = static_cast<uint8_t *>(mem_ptr);
     const uint32_t tlb_index = get_architecture_implementation()->get_reg_tlb();
     while (size > 0) {
@@ -321,7 +319,7 @@ void TTDevice::write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t ad
         jtag_device_->write(jlink_id_, mem_ptr, core.x, core.y, addr, size);
         return;
     }
-    auto lock = lock_manager.acquire_mutex("REG_TLB", get_pci_device()->get_device_num());
+    auto lock = lock_manager.acquire_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num());
     uint8_t *buffer_addr = (uint8_t *)(uintptr_t)(mem_ptr);
     const uint32_t tlb_index = get_architecture_implementation()->get_reg_tlb();
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -301,8 +301,10 @@ void TTDevice::read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, u
         return;
     }
     auto lock = lock_manager.acquire_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num());
+    // TODO: figure out how not to have multiple locks here.
+    auto lock2 = lock_manager.acquire_mutex("REG_TLB", get_pci_device()->get_device_num());
     uint8_t *buffer_addr = static_cast<uint8_t *>(mem_ptr);
-    const uint32_t tlb_index = get_architecture_implementation()->get_small_read_write_tlb();
+    const uint32_t tlb_index = get_architecture_implementation()->get_reg_tlb();
     while (size > 0) {
         auto [mapped_address, tlb_size] = set_dynamic_tlb(tlb_index, core, addr, tlb_data::Strict);
         uint32_t transfer_size = std::min((uint64_t)size, tlb_size);
@@ -320,8 +322,10 @@ void TTDevice::write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t ad
         return;
     }
     auto lock = lock_manager.acquire_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num());
+    // TODO: figure out how not to have multiple locks here.
+    auto lock2 = lock_manager.acquire_mutex("REG_TLB", get_pci_device()->get_device_num());
     uint8_t *buffer_addr = (uint8_t *)(uintptr_t)(mem_ptr);
-    const uint32_t tlb_index = get_architecture_implementation()->get_small_read_write_tlb();
+    const uint32_t tlb_index = get_architecture_implementation()->get_reg_tlb();
 
     while (size > 0) {
         auto [mapped_address, tlb_size] = set_dynamic_tlb(tlb_index, core, addr, tlb_data::Strict);

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -302,9 +302,7 @@ void TTDevice::read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, u
         jtag_device_->read(jlink_id_, mem_ptr, core.x, core.y, addr, size);
         return;
     }
-    auto lock = lock_manager.acquire_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num());
-    // TODO: figure out how not to have multiple locks here.
-    auto lock2 = lock_manager.acquire_mutex("REG_TLB", get_pci_device()->get_device_num());
+    auto lock = lock_manager.acquire_mutex("REG_TLB", get_pci_device()->get_device_num());
     uint8_t *buffer_addr = static_cast<uint8_t *>(mem_ptr);
     const uint32_t tlb_index = get_architecture_implementation()->get_reg_tlb();
     while (size > 0) {
@@ -323,9 +321,7 @@ void TTDevice::write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t ad
         jtag_device_->write(jlink_id_, mem_ptr, core.x, core.y, addr, size);
         return;
     }
-    auto lock = lock_manager.acquire_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num());
-    // TODO: figure out how not to have multiple locks here.
-    auto lock2 = lock_manager.acquire_mutex("REG_TLB", get_pci_device()->get_device_num());
+    auto lock = lock_manager.acquire_mutex("REG_TLB", get_pci_device()->get_device_num());
     uint8_t *buffer_addr = (uint8_t *)(uintptr_t)(mem_ptr);
     const uint32_t tlb_index = get_architecture_implementation()->get_reg_tlb();
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -34,6 +34,7 @@ TTDevice::TTDevice(
     architecture_impl_(std::move(architecture_impl)),
     arch(architecture_impl_->get_architecture()) {
     lock_manager.initialize_mutex(MutexType::TT_DEVICE_IO, get_communication_device_id());
+    lock_manager.initialize_mutex("REG_TLB", get_communication_device_id());
 }
 
 TTDevice::TTDevice(
@@ -46,6 +47,7 @@ TTDevice::TTDevice(
     architecture_impl_(std::move(architecture_impl)),
     arch(architecture_impl_->get_architecture()) {
     lock_manager.initialize_mutex(MutexType::TT_DEVICE_IO, get_communication_device_id(), IODeviceType::JTAG);
+    lock_manager.initialize_mutex("REG_TLB", get_communication_device_id(), IODeviceType::JTAG);
 }
 
 void TTDevice::init_tt_device() {

--- a/device/utils/lock_manager.cpp
+++ b/device/utils/lock_manager.cpp
@@ -15,7 +15,7 @@ const std::unordered_map<MutexType, std::string> LockManager::MutexTypeToString 
     // It is important that this mutex is named the same as corresponding fallback_tlb, this is due to the same tlb
     // index being used. This will be changed once we have a cleaner way to allocate TLBs instead of hardcoding fallback
     // tlbs.
-    {MutexType::TT_DEVICE_IO, "SMALL_READ_WRITE_TLB"},
+    {MutexType::TT_DEVICE_IO, "REG_TLB"},
     {MutexType::NON_MMIO, "NON_MMIO"},
     {MutexType::MEM_BARRIER, "MEM_BARRIER"},
     {MutexType::CREATE_ETH_MAP, "CREATE_ETH_MAP"},

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -44,8 +44,8 @@ TEST(ApiTTDeviceTest, BasicTTDeviceIO) {
 TEST(ApiTTDeviceTest, TTDeviceRegIO) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
-    std::vector<uint32_t> data_write0 = {0};
-    std::vector<uint32_t> data_write1 = {1};
+    std::vector<uint32_t> data_write0 = {1};
+    std::vector<uint32_t> data_write1 = {2};
     std::vector<uint32_t> data_read(data_write0.size(), 0);
 
     for (int pci_device_id : pci_device_ids) {

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -41,6 +41,36 @@ TEST(ApiTTDeviceTest, BasicTTDeviceIO) {
     }
 }
 
+TEST(ApiTTDeviceTest, TTDeviceRegIO) {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+
+    std::vector<uint32_t> data_write0 = {0};
+    std::vector<uint32_t> data_write1 = {1};
+    std::vector<uint32_t> data_read(data_write0.size(), 0);
+
+    for (int pci_device_id : pci_device_ids) {
+        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        tt_device->init_tt_device();
+        uint64_t address = tt_device->get_architecture_implementation()->get_debug_reg_addr();
+
+        ChipInfo chip_info = tt_device->get_chip_info();
+
+        SocDescriptor soc_desc(tt_device->get_arch(), chip_info);
+
+        tt_xy_pair tensix_core = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
+
+        tt_device->write_to_device(data_write0.data(), tensix_core, address, data_write0.size() * sizeof(uint32_t));
+        tt_device->read_from_device(data_read.data(), tensix_core, address, data_read.size() * sizeof(uint32_t));
+        ASSERT_EQ(data_write0, data_read);
+        data_read = std::vector<uint32_t>(data_write0.size(), 0);
+
+        tt_device->write_to_device(data_write1.data(), tensix_core, address, data_write1.size() * sizeof(uint32_t));
+        tt_device->read_from_device(data_read.data(), tensix_core, address, data_read.size() * sizeof(uint32_t));
+        ASSERT_EQ(data_write1, data_read);
+        data_read = std::vector<uint32_t>(data_write0.size(), 0);
+    }
+}
+
 TEST(ApiTTDeviceTest, TTDeviceGetBoardType) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
     for (int pci_device_id : pci_device_ids) {


### PR DESCRIPTION
### Issue
Found while debugging why this PR didn't work: https://github.com/tenstorrent/tt-umd/pull/1241
Issue to investigate https://github.com/tenstorrent/tt-umd/issues/1290

### Description
Change TTDevice read/write to use REG_TLB. For some reason, other TLB doesn't have access to registers. This is not necessary, but changing so that somebody doesn't hit this in the future.

### List of the changes
- Add a random debug register for testing reads/writes
- Add a test which reads/writes to reg space using TTDevice
- Change small_read_write_tlb to reg_tlb
- Added another lock for theoretical correctness, although we might not hit these cases in real scenarios.

### Testing
You can see the tests fail after first commit
And on the last commit the tests pass

### API Changes
There are no API changes in this PR.
