### PR TITLE
Populate ethernet_connections_to_remote_devices with Logical Eth Channels for P150

### DIFF
--- a/device/api/umd/device/topology/topology_discovery.hpp
+++ b/device/api/umd/device/topology/topology_discovery.hpp
@@ -77,6 +77,14 @@ protected:
 
     virtual uint32_t get_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) = 0;
 
+    // API exposed as a temporary workaround for issue: https://tenstorrent.atlassian.net/browse/SYS-2064.
+    // This is used for querying the logical remote eth channel on Multi-Host Blackhole P150 systems, where
+    // we don't have access to the ethernet harvesting mask for the remote chip.
+    // Logic in this API can be placed in get_remote_eth_channel, and patch_eth_connections can be removed,
+    // once the issue outlined in the ticket is resolved (at which point, UMD can directly query the logical
+    // ethernet channel for the remote chip on all board types).
+    virtual uint32_t get_logical_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) = 0;
+
     // eth_core should be in NoC 0 coordinates..
     virtual uint32_t read_port_status(Chip* chip, tt_xy_pair eth_core) = 0;
 

--- a/device/api/umd/device/topology/topology_discovery_blackhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_blackhole.hpp
@@ -37,6 +37,8 @@ protected:
 
     uint32_t get_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) override;
 
+    uint32_t get_logical_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) override;
+
     uint64_t get_remote_board_type(Chip* chip, tt_xy_pair eth_core) override;
 
     std::vector<uint32_t> extract_intermesh_eth_links(Chip* chip, tt_xy_pair eth_core) override;

--- a/device/api/umd/device/topology/topology_discovery_wormhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_wormhole.hpp
@@ -55,6 +55,8 @@ protected:
 
     uint32_t get_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) override;
 
+    uint32_t get_logical_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) override;
+
     uint64_t get_remote_board_type(Chip* chip, tt_xy_pair eth_core) override;
 
     std::vector<uint32_t> extract_intermesh_eth_links(Chip* chip, tt_xy_pair eth_core) override;

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -167,9 +167,14 @@ void TopologyDiscovery::discover_remote_chips() {
 
             if (!is_board_id_included(get_remote_board_id(chip, eth_core), get_remote_board_type(chip, eth_core))) {
                 uint64_t remote_asic_id = get_remote_asic_id(chip, eth_core);
-                ethernet_connections_to_remote_devices.push_back(
-                    {{current_chip_asic_id, channel}, {remote_asic_id, get_remote_eth_channel(chip, eth_core)}});
-
+                if (chip->get_chip_info().board_type == BoardType::P150) {
+                    ethernet_connections_to_remote_devices.push_back(
+                        {{current_chip_asic_id, channel},
+                         {remote_asic_id, get_logical_remote_eth_channel(chip, eth_core)}});
+                } else {
+                    ethernet_connections_to_remote_devices.push_back(
+                        {{current_chip_asic_id, channel}, {remote_asic_id, get_remote_eth_channel(chip, eth_core)}});
+                }
                 log_debug(LogSiliconDriver, "Remote chip outside of UMD cluster {}.", remote_asic_id);
 
                 channel++;
@@ -276,7 +281,6 @@ void TopologyDiscovery::fill_cluster_descriptor_info() {
             cluster_desc->idle_eth_channels[current_chip_id].erase(active_channel);
         }
     }
-
     cluster_desc->io_device_type = io_device_type;
     cluster_desc->fill_galaxy_connections();
     cluster_desc->merge_cluster_ids();

--- a/device/topology/topology_discovery_wormhole.cpp
+++ b/device/topology/topology_discovery_wormhole.cpp
@@ -253,6 +253,10 @@ uint32_t TopologyDiscoveryWormhole::get_remote_eth_channel(Chip* chip, tt_xy_pai
     return chip->get_soc_descriptor().translate_coord_to(remote_eth_core, CoordSystem::NOC0, CoordSystem::LOGICAL).y;
 }
 
+uint32_t TopologyDiscoveryWormhole::get_logical_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) {
+    return get_remote_eth_channel(chip, local_eth_core);
+}
+
 bool TopologyDiscoveryWormhole::is_using_eth_coords() { return !is_running_on_6u; }
 
 void TopologyDiscoveryWormhole::init_topology_discovery() {


### PR DESCRIPTION
### Issue
No Ticket.

### Description
- `ethernet_connections_to_remote_devices` in `topology.cpp` is currently populated with the physical Ethernet Channel ID for the remote device
- This is okay for WH systems, since there is no ethernet harvesting. On BH systems, with harvested ethernet, this causes issues, since users expect UMD to provide logical ethernet channel IDs for all connection endpoints
- For neighbor chips on the local host, `TopologyDiscovery::patch_eth_connections()` ensures that logical channels are reported
- This cannot be done for chips on the remote host, as the ethernet harvesting mask is unavailable
- Add an API to query the remote logical ethernet channel, specifically for P150

### List of the changes
- Add `TopologyDiscovery::get_logical_remote_eth_channel` API
   - On WH this is a passthrough to `TopologyDiscovery::get_remote_eth_channel`
   - On BH this API reads the address shared in the Eth Mem Map shared here https://tenstorrent.atlassian.net/browse/SYS-2064
   - Specifically on BH, we need to add 4 (this is specifically for P150) to the value that is read back, since the "logical" space captured at this address and the logical IDs that we expect are shifted
   - **This currently only works with P150**, which is not a real blocker since we are not using P100 or P300 for scaleout. An assert has been added to reflect this

### Testing
(Comment on CI testing or Manual testing touching this change.)

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
