### PR TITLE
Avoid creating socket when using libttsim.so path

### DIFF
--- a/device/api/umd/device/simulation/simulation_host.hpp
+++ b/device/api/umd/device/simulation/simulation_host.hpp
@@ -19,6 +19,7 @@ public:
     SimulationHost();
     ~SimulationHost();
 
+    void init();
     void start_host();
     void send_to_device(uint8_t *buf, size_t buf_size);
     size_t recv_from_device(void **data_ptr);

--- a/device/simulation/simulation_device.cpp
+++ b/device/simulation/simulation_device.cpp
@@ -94,6 +94,8 @@ SimulationDevice::SimulationDevice(const SimulationDeviceInit& init) : Chip(init
         DLSYM_FUNCTION(libttsim_tensix_reset_assert)
         DLSYM_FUNCTION(libttsim_clock)
     } else {
+        host.init();
+
         // Start simulator process
         uv_loop_t* loop = uv_default_loop();
         std::string simulator_path_string = simulator_path / "run.sh";

--- a/device/simulation/simulation_host.cpp
+++ b/device/simulation/simulation_host.cpp
@@ -44,7 +44,9 @@ SimulationHost::SimulationHost() {
     // Initialize socket and listener
     host_socket = std::make_unique<nng_socket>();
     host_listener = std::make_unique<nng_listener>();
+}
 
+void SimulationHost::init() {
     // Check if NNG_SOCKET_LOCAL_PORT is set
     const char *local_socket_port_str = std::getenv("NNG_SOCKET_LOCAL_PORT");
     std::string nng_socket_addr_str;


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/ttsim/issues/36

### Description
Socket was being created even when it was unused.  This also led to creation of a large number of unused pthreads inside the nng library and extra confusing debug output at startup time, and likely slowed down startup time somewhat as well.

### List of the changes
Split most of the SimulationHost init out of the constructor so that it can be called conditionally.

### Testing
Ran programming examples locally on simulator

### API Changes
/