### PR TITLE
Fix mock eth harvesting BH

### DIFF
--- a/device/api/umd/device/simulation/simulation_device.hpp
+++ b/device/api/umd/device/simulation/simulation_device.hpp
@@ -42,6 +42,9 @@ private:
 
 class SimulationDevice : public Chip {
 public:
+    SimulationDevice(const std::filesystem::path& simulator_directory, SocDescriptor soc_descriptor);
+
+    // TODO: Following constructors are deprecated and should be removed.
     SimulationDevice(const std::filesystem::path& simulator_directory) :
         SimulationDevice(SimulationDeviceInit(simulator_directory)) {}
 
@@ -104,6 +107,8 @@ public:
         uint32_t* return_4 = nullptr) override;
 
 private:
+    // TODO: To be removed once clients switch to new constructor.
+    void initialize(const std::filesystem::path& simulator_directory, SocDescriptor soc_descriptor);
     void send_tensix_risc_reset(tt_xy_pair core, const TensixSoftResetOptions& soft_resets);
 
     // State variables

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -277,7 +277,6 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     if (chip_type == ChipType::SIMULATION) {
 #ifdef TT_UMD_BUILD_SIMULATION
         log_info(LogSiliconDriver, "Creating Simulation device");
-        // Note that passed soc descriptor is ignored in favor of soc descriptor from simulator_directory.
         return std::make_unique<SimulationDevice>(simulator_directory, soc_desc);
 #else
         throw std::runtime_error(

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -278,7 +278,7 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
 #ifdef TT_UMD_BUILD_SIMULATION
         log_info(LogSiliconDriver, "Creating Simulation device");
         // Note that passed soc descriptor is ignored in favor of soc descriptor from simulator_directory.
-        return std::make_unique<SimulationDevice>(simulator_directory);
+        return std::make_unique<SimulationDevice>(simulator_directory, soc_desc);
 #else
         throw std::runtime_error(
             "Simulation device is not supported in this build. Set '-DTT_UMD_BUILD_SIMULATION=ON' during cmake "

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -473,7 +473,7 @@ std::unique_ptr<ClusterDescriptor> ClusterDescriptor::create_mock_cluster(
         case tt::ARCH::QUASAR:  // TODO (#450): Add Quasar configuration
         case tt::ARCH::BLACKHOLE:
             board_type = BoardType::UNKNOWN;
-            harvesting_masks.pcie_harvesting_mask = 0x0;
+            harvesting_masks.eth_harvesting_mask = 0x120;
             break;
         default:
             board_type = BoardType::UNKNOWN;

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -473,6 +473,7 @@ std::unique_ptr<ClusterDescriptor> ClusterDescriptor::create_mock_cluster(
         case tt::ARCH::QUASAR:  // TODO (#450): Add Quasar configuration
         case tt::ARCH::BLACKHOLE:
             board_type = BoardType::UNKNOWN;
+            // Example value from silicon machine.
             harvesting_masks.eth_harvesting_mask = 0x120;
             break;
         default:

--- a/device/simulation/simulation_device.cpp
+++ b/device/simulation/simulation_device.cpp
@@ -80,13 +80,22 @@ SimulationDeviceInit::SimulationDeviceInit(const std::filesystem::path& simulato
                                                    : (simulator_directory / "soc_descriptor.yaml"),
         ChipInfo{.noc_translation_enabled = (simulator_directory.extension() == ".so")}) {}
 
+SimulationDevice::SimulationDevice(const std::filesystem::path& simulator_directory, SocDescriptor soc_descriptor) :
+    Chip(soc_descriptor) {
+    initialize(simulator_directory, soc_descriptor);
+}
+
 SimulationDevice::SimulationDevice(const SimulationDeviceInit& init) : Chip(init.get_soc_descriptor()) {
+    initialize(init.get_simulator_path(), init.get_soc_descriptor());
+}
+
+void SimulationDevice::initialize(const std::filesystem::path& simulator_directory, SocDescriptor soc_descriptor) {
     log_info(tt::LogEmulationDriver, "Instantiating simulation device");
-    soc_descriptor_per_chip.emplace(0, init.get_soc_descriptor());
-    arch_name = init.get_arch_name();
+    soc_descriptor_per_chip.emplace(0, soc_descriptor);
+    arch_name = soc_descriptor.arch;
     target_devices_in_cluster = {0};
 
-    std::filesystem::path simulator_path = init.get_simulator_path();
+    std::filesystem::path simulator_path = simulator_directory;
     if (!std::filesystem::exists(simulator_path)) {
         TT_THROW("Simulator binary not found at: ", simulator_path);
     }

--- a/tests/baremetal/test_cluster_descriptor_offline.cpp
+++ b/tests/baremetal/test_cluster_descriptor_offline.cpp
@@ -26,6 +26,7 @@ int count_connections(const std::unordered_map<
 TEST(ApiClusterDescriptorOfflineTest, TestAllOfflineClusterDescriptors) {
     for (std::string cluster_desc_yaml : {
              "blackhole_P100.yaml",
+             "blackhole_P150.yaml",
              "galaxy.yaml",
              "wormhole_2xN300_unconnected.yaml",
              "wormhole_4xN300_mesh.yaml",

--- a/tests/cluster_descriptor_examples/blackhole_P150.yaml
+++ b/tests/cluster_descriptor_examples/blackhole_P150.yaml
@@ -1,0 +1,28 @@
+arch:
+  0: blackhole
+chips:
+  {}
+chip_unique_ids:
+  0: 4476187513037
+ethernet_connections:
+  []
+ethernet_connections_to_remote_devices:
+  []
+chips_with_mmio:
+  - 0: 0
+harvesting:
+  0:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+chip_to_boardtype:
+  0: p150
+boards:
+  -
+    - board_id: 4476187513037
+    - board_type: p150
+    - chips:
+        - 0


### PR DESCRIPTION
### Issue
Fixes https://github.com/tenstorrent/tt-umd/issues/1320

### Description
Add default bh eth harvesting mask to mock cluster descriptor.
This is required since BH always has 2 eth cores harvested.
Following changes will further cleanup SimulationDeviceInit, I've left it out of this change so that the fix goes in faster.

### List of the changes
- Add eth harvesting to mock cluster descriptor
- Add p150 cluster descriptor yaml
- Pass soc descriptor to SimulationDevice
- I've had to create another constructor, which circumvents the SimulationDeviceInit. This is temporary.

### Testing
Tested manually that after this change, ttsim run doesn't access (33,25) coords anymore.

### API Changes
There are no API changes in this PR.
