### PR TITLE
Offer alternative to SimulationDeviceInit

### DIFF
--- a/device/api/umd/device/soc_descriptor.hpp
+++ b/device/api/umd/device/soc_descriptor.hpp
@@ -77,6 +77,11 @@ public:
 
     SocDescriptor(const tt::ARCH arch, const ChipInfo chip_info = {});
 
+    // Helpers for extracting info from soc descriptor file.
+    static std::string get_soc_descriptor_path_from_simulator_path(const std::filesystem::path &simulator_path);
+    static tt::ARCH get_arch_from_soc_descriptor_path(const std::string &soc_descriptor_path);
+    static tt_xy_pair get_grid_size_from_soc_descriptor_path(const std::string &soc_descriptor_path);
+
     // CoreCoord conversions.
     CoreCoord translate_coord_to(const CoreCoord core_coord, const CoordSystem coord_system) const;
     std::unordered_set<CoreCoord> translate_coords_to(

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -353,6 +353,22 @@ std::vector<tt_xy_pair> SocDescriptor::convert_to_tt_xy_pair(const std::vector<s
     return core_pairs;
 }
 
+std::string SocDescriptor::get_soc_descriptor_path_from_simulator_path(const std::filesystem::path &simulator_path) {
+    return (simulator_path.extension() == ".so") ? (simulator_path.parent_path() / "soc_descriptor.yaml")
+                                                 : (simulator_path / "soc_descriptor.yaml");
+}
+
+tt::ARCH SocDescriptor::get_arch_from_soc_descriptor_path(const std::string &soc_descriptor_path) {
+    YAML::Node device_descriptor_yaml = YAML::LoadFile(soc_descriptor_path);
+    return tt::arch_from_str(device_descriptor_yaml["arch_name"].as<std::string>());
+}
+
+tt_xy_pair SocDescriptor::get_grid_size_from_soc_descriptor_path(const std::string &soc_descriptor_path) {
+    YAML::Node device_descriptor_yaml = YAML::LoadFile(soc_descriptor_path);
+    return tt_xy_pair(
+        device_descriptor_yaml["grid"]["x_size"].as<int>(), device_descriptor_yaml["grid"]["y_size"].as<int>());
+}
+
 std::vector<std::vector<tt_xy_pair>> SocDescriptor::convert_dram_cores_from_yaml(
     YAML::Node &device_descriptor_yaml, const std::string &dram_core) {
     std::vector<std::vector<tt_xy_pair>> dram_cores;


### PR DESCRIPTION
### Issue
Related to https://github.com/tenstorrent/tt-umd/issues/1320

### Description
Offer an alternative way to get arch and grid size from soc descriptor. Also as a convenience, a method which returns exact soc_desc yaml.
It is important to add this alternative, since default soc descriptor, and this simulationDeviceInit won't be able to be created without specifying eth harvesting mask. This is added in the following PR

### List of the changes
- Add convenience functions to get arch and grid_size from soc_descriptor
- Use them in cluster.cpp

### Testing
Corresponding metal change: https://github.com/tenstorrent/tt-metal/pull/28663
Tested with manual run of ttsim

### API Changes
This PR has API changes, but they aren't breaking, as both new and old APIs will live.
