### PR TITLE
Fix BH DRAM coord translation

### DIFF
--- a/device/coordinates/blackhole_coordinate_manager.cpp
+++ b/device/coordinates/blackhole_coordinate_manager.cpp
@@ -363,8 +363,7 @@ void BlackholeCoordinateManager::fill_dram_noc0_translated_mapping() {
 
                 CoreCoord translated_dram_core =
                     CoreCoord(noc0_dram_core.x, noc0_dram_core.y, CoreType::DRAM, CoordSystem::TRANSLATED);
-                to_noc0_map[translated_dram_core] = noc0_dram_core;
-                from_noc0_map[{{noc0_dram_core.x, noc0_dram_core.y}, CoordSystem::TRANSLATED}] = translated_dram_core;
+                add_core_translation(translated_dram_core, noc0_dram_core);
             }
         }
         return;


### PR DESCRIPTION
### Issue
This was bogging the development on Quasar
I have no idea why we didn't see this earlier, specifically on BH silicon.

### Description
.get_coord_at uses a different map from translate_coord_to
This was being filled in add_core_translation, but for some reason, blackhole translated coords were being filled up without this function.

### List of the changes
- Use add_core_translation when filling up TRANSLATED bh coords.

### Testing
Manual testing using qsr libttsim and custom blackhole simulation yaml 

### API Changes
There are no API changes in this PR.
