### PR TITLE
Make write method of Writer const

### DIFF
--- a/device/api/umd/device/tt_io.hpp
+++ b/device/api/umd/device/tt_io.hpp
@@ -31,7 +31,7 @@ public:
      * @param value
      */
     template <class T>
-    void write(uint32_t address, T value) {
+    void write(uint32_t address, T value) const {
         auto dst = reinterpret_cast<uintptr_t>(base) + address;
 
         if (address >= tlb_size) {


### PR DESCRIPTION
### Issue

Make method of Writer class const. This is needed for first step in refactoring metal code to new TLB scheme. The first step is to remove fast_pcie_write_callable. Related changes https://github.com/tenstorrent/tt-metal/compare/main...pjanevski/bar0_2

### Description

Make write method of Writer const

### List of the changes

- Make write method of Writer const

### Testing
CI

### API Changes
/
