### PR TITLE
tt_version bug fixes and questions

### DIFF
--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -738,7 +738,7 @@ private:
     bool use_virtual_coords_for_eth_broadcast = true;
     tt_version eth_fw_version;  // Ethernet FW the driver is interfacing with
     // ERISC FW Version Required by UMD
-    static constexpr std::uint32_t SW_VERSION = 0x06060000;
+    static constexpr std::uint32_t SW_VERSION = TT_VERSION(6, 6, 0);
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/types/cluster_types.hpp
+++ b/device/api/umd/device/types/cluster_types.hpp
@@ -206,6 +206,8 @@ struct tt_version {
     std::string str() const { return fmt::format("{}.{}.{}", major, minor, patch); }
 };
 
+#define TT_VERSION(major, minor, patch) ((major << 16) + (minor << 12) + patch)
+
 constexpr inline bool operator==(const tt_version& a, const tt_version& b) {
     return a.major == b.major && a.minor == b.minor && a.patch == b.patch;
 }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1060,8 +1060,7 @@ void Cluster::verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std
     for (std::uint32_t& fw_version : fw_versions) {
         tt_version fw(fw_version);
         TT_ASSERT(fw == fw_first_eth_core, "FW versions are not the same across different ethernet cores");
-        TT_ASSERT(sw.major <= fw.major, "SW/FW major version number out of sync");
-        TT_ASSERT(sw.minor <= fw.minor, "SW version is newer than FW version");
+        TT_ASSERT(fw >= sw, "SW version is newer than FW version");
     }
 
     // Min ERISC FW version required to support ethernet broadcast is 6.5.0.


### PR DESCRIPTION
### Description
This is with repo head at commit `4146cf6ad52f4aa91ae9e2ac950a04dbbe5f9f84`.

This is not a pull request. It is a request to think about `tt_version`, along with some code which points out some bugs or at least likely unintended behavior.

Please read through `struct tt_version` and see if it makes sense to you. To me, it looks like `patch` is a 12 bit number stored in an 8 bit variable, and `major` is an 8 bit number stored in a 16 bit variable. In `device/api/umd/device/types/cluster_types.hpp`:
```
struct tt_version {
    std::uint16_t major = 0xffff; 
    std::uint8_t minor = 0xff; 
    std::uint8_t patch = 0xff;
        
    tt_version() {}
            
    tt_version(std::uint16_t major_, std::uint8_t minor_, std::uint8_t patch_) {
        major = major_;
        minor = minor_; 
        patch = patch_; 
    }                   
                                
    tt_version(std::uint32_t version) {
        major = (version >> 16) & 0xff;
        minor = (version >> 12) & 0xf;
        patch = version & 0xfff;
    }           
                
    std::string str() const { return fmt::format("{}.{}.{}", major, minor, patch); }
};
```
How should this be? This seems odd: `patch = version & 0xfff;`, storing 12 bits into 8 bits.

### List of the changes
There are 2 changes here.
1. Changing `SW_VERSION` from 0x06060000 to 0x00066000 through the introduction of a macro `TT_VERSION(major, minor, patch)` to compute a `uint32_t`. I'm assuming the intention was for 6.6.0 but the value would go through the constructor and get stored as 6.0.0, with the top 6 ignored. The macro makes it easier to say what is desired without needing to know the bit packing.
2. Change a version compare to use lexicographic order. There is a `tt_version` function override for greater than or equal. Replace 2 compares with that (as it was already being used a few lines later).

Note: the two bugs work together to keep things working. Current fw prints out as 7.0.0. If SW_VERSION came through as 6.6.0, then sw.minor would be greater than fw.minor and things would fail while being fine. But since it sees SW_VERSION as 6.0.0, it passes the test.

Aside: I looked at `luwen` to see if that gave me any insight as to version encoding. Nope, just more confusion:

In `crates/luwen-if/src/chip/remote.rs`
```
    pub(crate) fn check_ethernet_fw_version(&mut self) -> Result<Vec<bool>, PlatformError> {
        let mut valid_fw_version = Vec::with_capacity(self.eth_locations.len());
        for core in &self.eth_locations {
            let eth_fw_version = self.eth_addrs.masked_version;
            let msbyte = (eth_fw_version >> 24) & 0xFF;
            if msbyte != 0x0
                || msbyte != 0x6
                || self.noc_read32(0, core.x, core.y, self.eth_addrs.version)? & 0x00FFFFFF
                    != eth_fw_version
            {
                valid_fw_version.push(true);
            } else {
                valid_fw_version.push(false);
            }
        }

```
I read `msbyte != 0x0 || msbyte != 0x6` as always true (which the further or'ing can't change). Am I mistaken? Is that the intent?

I was surprised to see a shift by 24, after the shift by 16 in the tt-umd code.
If you see it as an issue, and want me to spend time trying to figure out luwen enough to report a bug, let me know. I just did a quick glance there to see get more insight into version coding.

### Testing
It passed a compile. I pulled into tt-metal and built and ran one of the examples, and the SW version printed as 6.6.0, FW version as 7.0.0, and the code kept running. That at least ran the new code and finished to completion.

I didn't write new tests. I'm just trying to tt-inference-server to run for me, and hit tt_version test failing, as the docker image that gets used has an older tt-metal/tt-umd which required version major numbers to be the same. I now have learned enough to hopefully get that going.

### API Changes
There are no API changes in this PR.

Is the addition of TT_VERSION is considered an API change? Is it better to put somewhere else or not at all?