### PR TITLE
Demote lite fabric logs to log_debug

### DIFF
--- a/device/lite_fabric/lite_fabric_host_utils.cpp
+++ b/device/lite_fabric/lite_fabric_host_utils.cpp
@@ -105,7 +105,7 @@ void launch_lite_fabric(Chip* chip, const std::vector<CoreCoord>& eth_cores) {
 
     for (auto tunnel_1x : eth_cores) {
         wait_for_state(chip, tunnel_1x, get_state_address(), InitState::READY);
-        log_info(LogSiliconDriver, "Lite Fabric ready on core ({}, {})", tunnel_1x.x, tunnel_1x.y);
+        log_debug(LogSiliconDriver, "Lite Fabric ready on core ({}, {})", tunnel_1x.x, tunnel_1x.y);
     }
 }
 
@@ -114,7 +114,7 @@ void terminate_lite_fabric(Chip* chip, const std::vector<CoreCoord>& eth_cores) 
         LITE_FABRIC_CONFIG_START + offsetof(LiteFabricMemoryMap, config) + offsetof(LiteFabricConfig, routing_enabled);
     uint32_t enabled = 0;
     for (const auto& tunnel_1x : eth_cores) {
-        log_info(LogSiliconDriver, "Host to terminate lite fabric on core ({}, {})", tunnel_1x.x, tunnel_1x.y);
+        log_debug(LogSiliconDriver, "Host to terminate lite fabric on core ({}, {})", tunnel_1x.x, tunnel_1x.y);
         chip->write_to_device(tunnel_1x, (void*)&enabled, routing_enabled_address, sizeof(uint32_t));
     }
     chip->l1_membar();


### PR DESCRIPTION
### Issue

Fabric logs for start and terminate shouldn't be log info, more useful for debug

### Description
Demote lite fabric logs to log_debug

### List of the changes
Demote lite fabric logs to log_debug

### Testing
CI

### API Changes
/