### PR TITLE
Fix new soft reset api for simulation/ttsim

### DIFF
--- a/device/api/umd/device/types/arch.hpp
+++ b/device/api/umd/device/types/arch.hpp
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <fmt/core.h>
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <ostream>
 
@@ -57,3 +60,15 @@ static inline std::string arch_to_str(const tt::ARCH arch) {
 static inline std::ostream &operator<<(std::ostream &out, const tt::ARCH &arch) { return out << arch_to_str(arch); }
 
 }  // namespace tt
+
+namespace fmt {
+template <>
+struct formatter<tt::ARCH> {
+    constexpr auto parse(fmt::format_parse_context &ctx) { return ctx.begin(); }
+
+    template <typename Context>
+    constexpr auto format(tt::ARCH const &arch, Context &ctx) const {
+        return format_to(ctx.out(), "{}", tt::arch_to_str(arch));
+    }
+};
+}  // namespace fmt


### PR DESCRIPTION
### Issue
Unblocking PR https://github.com/tenstorrent/tt-metal/pull/27737

### Description
The code was to specific on the requested RiscType. So when I changed ::ALL_TENSIX to ::ALL to be less confusing in tt_metal PR, this lead to this branch not being supported by sim.
I've now implemented the logic such that only for Quasar and for DM core reset one command is called, in any other case the old one is called. This is more flexible (also more error prone, but I don't think that will be the problem at this layer).
Also added a ttsim branch for this.

### List of the changes
- Invert the ifelses, such that now dm core reset is the first case checked
- In all other cases (compared to just being specific on ::ALL_TENSIX or ::BRISC) call the old function for assert/deassert
- Implement ARCH formatter, I saw that actually the runtime code fails on throwing the exception because this wasn't implemented

### Testing
TBD: link a passing tt_metal sim run...

### API Changes
This PR has API changes for simulator for newly introduced assert/deassert api.
