### PR TITLE
Added noc1 support for JTAG.

### DIFF
--- a/device/api/umd/device/jtag/jtag.hpp
+++ b/device/api/umd/device/jtag/jtag.hpp
@@ -37,9 +37,9 @@ public:
     void dbus_sigdump(
         const char* client_name, uint32_t dbg_client_id, uint32_t dbg_signal_sel_start, uint32_t dbg_signal_sel_end);
     void write_axi(uint32_t reg_addr, uint32_t data);
-    void write_noc_xy(uint32_t node_x_id, uint32_t node_y_id, uint64_t noc_addr, uint32_t noc_data);
+    void write_noc_xy(uint32_t node_x_id, uint32_t node_y_id, uint64_t noc_addr, uint32_t noc_data, uint8_t noc_id);
     uint32_t read_axi(uint32_t reg_addr);
-    uint32_t read_noc_xy(uint32_t node_x_id, uint32_t node_y_id, uint64_t noc_addr);
+    uint32_t read_noc_xy(uint32_t node_x_id, uint32_t node_y_id, uint64_t noc_addr, uint8_t noc_id);
     std::vector<uint32_t> enumerate_jlink();
     void close_jlink();
     uint32_t read_id_raw();

--- a/device/api/umd/device/jtag/jtag_device.hpp
+++ b/device/api/umd/device/jtag/jtag_device.hpp
@@ -47,12 +47,20 @@ public:
         uint32_t dbg_signal_sel_start,
         uint32_t dbg_signal_sel_end);
     void write32_axi(uint8_t chip_id, uint32_t address, uint32_t data);
-    void write32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address, uint32_t data);
-    void write(uint8_t chip_id, const void* mem_ptr, uint8_t noc_x, uint8_t noc_y, uint64_t addr, uint32_t size);
+    void write32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address, uint32_t data, uint8_t noc_id = 0);
+    void write(
+        uint8_t chip_id,
+        const void* mem_ptr,
+        uint8_t noc_x,
+        uint8_t noc_y,
+        uint64_t addr,
+        uint32_t size,
+        uint8_t noc_id = 0);
 
     std::optional<uint32_t> read32_axi(uint8_t chip_id, uint32_t address);
-    std::optional<uint32_t> read32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address);
-    void read(uint8_t chip_id, void* mem_ptr, uint8_t noc_x, uint8_t noc_y, uint64_t addr, uint32_t size);
+    std::optional<uint32_t> read32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address, uint8_t noc_id = 0);
+    void read(
+        uint8_t chip_id, void* mem_ptr, uint8_t noc_x, uint8_t noc_y, uint64_t addr, uint32_t size, uint8_t noc_id = 0);
 
     std::optional<std::vector<uint32_t>> enumerate_jlink();
     void close_jlink(uint8_t chip_id);

--- a/device/jtag/jtag.cpp
+++ b/device/jtag/jtag.cpp
@@ -114,14 +114,14 @@ void Jtag::dbus_sigdump(
 
 void Jtag::write_axi(uint32_t reg_addr, uint32_t data) { GET_FUNCTION_POINTER(write_axi)(reg_addr, data); }
 
-void Jtag::write_noc_xy(uint32_t node_x_id, uint32_t node_y_id, uint64_t noc_addr, uint32_t noc_data) {
-    return GET_FUNCTION_POINTER(write_noc_xy)(node_x_id, node_y_id, noc_addr, noc_data);
+void Jtag::write_noc_xy(uint32_t node_x_id, uint32_t node_y_id, uint64_t noc_addr, uint32_t noc_data, uint8_t noc_id) {
+    return GET_FUNCTION_POINTER(write_noc_xy)(node_x_id, node_y_id, noc_addr, noc_data, noc_id);
 }
 
 uint32_t Jtag::read_axi(uint32_t reg_addr) { return GET_FUNCTION_POINTER(read_axi)(reg_addr); }
 
-uint32_t Jtag::read_noc_xy(uint32_t node_x_id, uint32_t node_y_id, uint64_t noc_addr) {
-    return GET_FUNCTION_POINTER(read_noc_xy)(node_x_id, node_y_id, noc_addr);
+uint32_t Jtag::read_noc_xy(uint32_t node_x_id, uint32_t node_y_id, uint64_t noc_addr, uint8_t noc_id) {
+    return GET_FUNCTION_POINTER(read_noc_xy)(node_x_id, node_y_id, noc_addr, noc_id);
 }
 
 std::vector<uint32_t> Jtag::enumerate_jlink() {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -299,7 +299,7 @@ void TTDevice::read_block(uint64_t byte_addr, uint64_t num_bytes, uint8_t *buffe
 
 void TTDevice::read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
     if (communication_device_type_ == IODeviceType::JTAG) {
-        jtag_device_->read(jlink_id_, mem_ptr, core.x, core.y, addr, size);
+        jtag_device_->read(jlink_id_, mem_ptr, core.x, core.y, addr, size, umd_use_noc1 ? 1 : 0);
         return;
     }
     auto lock = lock_manager.acquire_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num());
@@ -318,7 +318,7 @@ void TTDevice::read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, u
 
 void TTDevice::write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
     if (communication_device_type_ == IODeviceType::JTAG) {
-        jtag_device_->write(jlink_id_, mem_ptr, core.x, core.y, addr, size);
+        jtag_device_->write(jlink_id_, mem_ptr, core.x, core.y, addr, size, umd_use_noc1 ? 1 : 0);
         return;
     }
     auto lock = lock_manager.acquire_mutex(MutexType::TT_DEVICE_IO, get_pci_device()->get_device_num());

--- a/tests/api/test_jtag.cpp
+++ b/tests/api/test_jtag.cpp
@@ -175,6 +175,27 @@ TEST_F(ApiJtagDeviceTest, JtagTranslatedCoordsTest) {
     }
 }
 
+TEST_F(ApiJtagDeviceTest, JtagTestNoc1) {
+    std::vector<uint32_t> data_write = {11, 22, 33, 44, 55, 66, 77, 88, 99, 111};
+    std::vector<uint32_t> data_read(data_write.size(), 0);
+    uint64_t address = 0x0;
+
+    for (const auto& device : device_data_) {
+        tt_SocDescriptor soc_desc(device.tt_device_->get_arch(), device.tt_device_->get_chip_info());
+        tt_xy_pair test_core_noc_0 = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::NOC0)[0];
+        tt_xy_pair test_core_noc_1 = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::NOC1)[0];
+
+        device.tt_device_->write_to_device(
+            data_write.data(), test_core_noc_0, address, data_write.size() * sizeof(uint32_t));
+        TTDevice::use_noc1(true);
+        device.tt_device_->read_from_device(
+            data_read.data(), test_core_noc_1, address, data_read.size() * sizeof(uint32_t));
+        TTDevice::use_noc1(false);
+        ASSERT_EQ(data_write, data_read);
+        std::fill(data_read.begin(), data_read.end(), 0);
+    }
+}
+
 TEST(ApiJtagClusterTest, JtagClusterIOTest) {
     if (!std::filesystem::exists(JtagDevice::jtag_library_path)) {
         GTEST_SKIP() << "JTAG library does not exist at " << JtagDevice::jtag_library_path.string();


### PR DESCRIPTION
### Description
JTAG library supported noc1 but was hardcoded to use noc0.
First the API was changed to have a selection for noc_id and then UMD api was changed to
support it as well.

### List of the changes
 - JtagDevice and jtag -> API.
 - test_jtag added test.
 - TTDevice changed jtag write and read to choose noc id based on global umd_use_noc1 variable.

### Testing
 - Added a test in test_jtag to first write data into first tensix core using NOC0 coordinates over jtag and then reading from that same core using NOC0 coordinates hoping to read the same data.
 
### API Changes
 - Jtag read and write now have additional noc_id parameter.
 - It is set to 0 by default so no code using older API should be harmed.
