### PR TITLE
Skip unnecessary lite fabric init

### DIFF
--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -105,6 +105,8 @@ void TopologyDiscovery::get_connected_chips() {
                 break;
             }
         }
+
+        initialize_remote_communication(chip.get());
         uint64_t asic_id = get_asic_id(chip.get());
         chips_to_discover.emplace(asic_id, std::move(chip));
         log_debug(
@@ -190,11 +192,6 @@ void TopologyDiscovery::discover_remote_chips() {
             uint64_t remote_asic_id = get_remote_asic_id(chip, eth_core);
 
             if (discovered_chips.find(remote_asic_id) == discovered_chips.end()) {
-                // We need to initialize remote communication on local chip just if we have discovered some new remote
-                // chip. One of these cases is P300 board with one chip visible on PCIe. This way we won't initialize
-                // lite fabric on two connected P150 chips, since they both have access over PCIe
-                initialize_remote_communication(chip);
-
                 uint64_t gateway_chip_id = remote_asic_id_to_mmio_chip_id.at(current_chip_asic_id);
                 std::optional<eth_coord_t> eth_coord = get_remote_eth_coord(chip, eth_core);
                 std::unique_ptr<Chip> remote_chip = create_remote_chip(

--- a/device/topology/topology_discovery_blackhole.cpp
+++ b/device/topology/topology_discovery_blackhole.cpp
@@ -226,6 +226,13 @@ bool TopologyDiscoveryBlackhole::is_intermesh_eth_link_trained(Chip* chip, tt_xy
 }
 
 void TopologyDiscoveryBlackhole::initialize_remote_communication(Chip* chip) {
+    // We don't want to initialize lite fabric on non-P300 boards. For all configurations we have at the moment,
+    // we would need to init lite fabric just on LocalChips of P300 boards.
+    // TODO: Think about future configurations where we might want to init lite fabric on other boards as well.
+    if (chip->get_tt_device()->get_board_type() != BoardType::P300) {
+        return;
+    }
+
     auto eth_cores =
         chip->get_soc_descriptor().get_cores(CoreType::ETH, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::NOC0);
 


### PR DESCRIPTION
### Issue

#1355 

### Description

Lite fabric was being initialized on all Blackhole chips, even if there was no need to do remote communication, like with two P150s connected. This PR changes that initialization of lite fabric is being done only when necessary, like in P300 case with only one chip visible over PCIe.

### List of the changes

- Init lite fabric just in case we discover undiscovered remote chip
- Remove if for Blackhole galaxy

### Testing
CI + local testing on P300

### API Changes
/