### PR TITLE
Fixing the return of grid size

### DIFF
--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -652,7 +652,7 @@ void SocDescriptor::get_cores_and_grid_size_from_coordinate_manager() {
         harvested_cores_map.insert({core_type, coordinate_manager->get_harvested_cores(core_type)});
         if (core_type == CoreType::ETH || core_type == CoreType::ROUTER_ONLY || core_type == CoreType::SECURITY ||
             core_type == CoreType::L2CPU) {
-            // Ethernet and Router cores aren't arranged in a grid, initializing as empty         
+            // Ethernet and Router cores aren't arranged in a grid, initializing as empty
             grid_size_map.insert({core_type, empty});
             harvested_grid_size_map.insert({core_type, empty});
             continue;


### PR DESCRIPTION
### Issue
[Semaphores out of bound](https://github.com/tenstorrent/tt-metal/issues/22411)

### Description
When requesting a grid size of cores that are not arranged in a grid (e.g. ETH) the function throws a null dereferencing exception instead of returning a value. Both tt_metal and ttnn agree that returning a grid size (0,0) is more appropriate.

### List of the changes
Both grid_size_map and harvested_grid_size_map now map (0,0) as grid size for the cores that are not arranged in a grid

### Testing

