### PR TITLE
Add fallback for PCIe DMA when there is no buffer

### DIFF
--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -385,6 +385,15 @@ void LocalChip::dma_write_to_device(const void* src, size_t size, CoreCoord core
             DeviceTypeToString.at(tt_device_->get_communication_device_type()));
     }
 
+    if (get_tt_device()->get_pci_device()->get_dma_buffer().buffer == nullptr) {
+        log_warning(
+            LogSiliconDriver,
+            "DMA buffer was not allocated for PCI device {}, falling back to non-DMA (regular MMIO TLB) write.",
+            get_tt_device()->get_communication_device_id());
+        write_to_device(core, src, addr, size);
+        return;
+    }
+
     static const std::string tlb_name = "LARGE_WRITE_TLB";
 
     const uint8_t* buffer = static_cast<const uint8_t*>(src);
@@ -415,6 +424,15 @@ void LocalChip::dma_read_from_device(void* dst, size_t size, CoreCoord core, uin
         TT_THROW(
             "DMA operations are not supported for {} devices.",
             DeviceTypeToString.at(tt_device_->get_communication_device_type()));
+    }
+
+    if (get_tt_device()->get_pci_device()->get_dma_buffer().buffer == nullptr) {
+        log_warning(
+            LogSiliconDriver,
+            "DMA buffer was not allocated for PCI device {}, falling back to non-DMA (regular MMIO TLB) read.",
+            get_tt_device()->get_communication_device_id());
+        read_from_device(core, dst, addr, size);
+        return;
     }
 
     static const std::string tlb_name = "LARGE_READ_TLB";

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -26,10 +26,18 @@ SysmemBuffer::SysmemBuffer(TLBManager* tlb_manager, void* buffer_va, size_t buff
 }
 
 void SysmemBuffer::dma_write_to_device(const size_t offset, size_t size, const tt_xy_pair core, uint64_t addr) {
+    TTDevice* tt_device_ = tlb_manager_->get_tt_device();
+
+    if (tt_device_->get_pci_device()->get_dma_buffer().buffer == nullptr) {
+        TT_THROW(
+            "DMA buffer is not allocated on PCI device {}, PCIe DMA operations not supported.",
+            tt_device_->get_pci_device()->get_device_num());
+    }
+
     validate(offset);
+
     static const std::string tlb_name = "LARGE_WRITE_TLB";
 
-    TTDevice* tt_device_ = tlb_manager_->get_tt_device();
     const uint8_t* buffer = (uint8_t*)get_device_io_addr(offset);
 
     auto tlb_index = tlb_manager_->dynamic_tlb_config_.at(tlb_name);
@@ -55,10 +63,18 @@ void SysmemBuffer::dma_write_to_device(const size_t offset, size_t size, const t
 }
 
 void SysmemBuffer::dma_read_from_device(const size_t offset, size_t size, const tt_xy_pair core, uint64_t addr) {
+    TTDevice* tt_device_ = tlb_manager_->get_tt_device();
+
+    if (tt_device_->get_pci_device()->get_dma_buffer().buffer == nullptr) {
+        TT_THROW(
+            "DMA buffer is not allocated on PCI device {}, PCIe DMA operations not supported.",
+            tt_device_->get_pci_device()->get_device_num());
+    }
+
     validate(offset);
+
     static const std::string tlb_name = "LARGE_READ_TLB";
     uint8_t* buffer = (uint8_t*)get_device_io_addr(offset);
-    TTDevice* tt_device_ = tlb_manager_->get_tt_device();
     auto tlb_index = tlb_manager_->dynamic_tlb_config_.at(tlb_name);
     auto ordering = tlb_manager_->dynamic_tlb_ordering_modes_.at(tlb_name);
     PCIDevice* pci_device = tt_device_->get_pci_device().get();


### PR DESCRIPTION
### Issue

https://github.com/tenstorrent/tt-umd/issues/746

### Description

Fallback to regular IO (TLBs) when PCIDevice can't allocate PCIe DMA buffer. In case of SysmemBuffer we throw the exception since the use case is a bit different, SysmemBuffer can be used for NOC access as well so we want to enable user to choose what is going to happen with the data, while Cluster API should ensure that write has landed. 

### List of the changes

- Add fallback for DMA IO in Cluster API
- Add check for PCIe DMA buffer in SysmemBuffer

### Testing
Manual testing

### API Changes
/
