### PR TITLE
Fully cleanup microbenchmark TLB tests

### DIFF
--- a/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
+++ b/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
@@ -9,10 +9,10 @@
 using namespace tt::umd;
 
 constexpr chip_id_t chip = 0;
-constexpr uint32_t one_mb = 1 << 20;
+constexpr size_t one_kb = 1 << 10;
+constexpr size_t one_mb = 1 << 20;
 constexpr size_t one_gb = 1ULL << 30;
 constexpr uint32_t NUM_ITERATIONS = 10;
-constexpr uint32_t one_kb = 1 << 10;
 constexpr uint32_t tlb_1m_index = 0;
 constexpr uint32_t tlb_16m_index = 166;
 
@@ -64,7 +64,7 @@ TEST(MicrobenchmarkTLB, TLBDynamicDram) {
  * Measure BW of IO to Tensix core using dynamically configured TLB.
  */
 TEST(MicrobenchmarkTLB, TLBDynamicTensix) {
-    const std::vector<uint32_t> sizes = {
+    const std::vector<size_t> sizes = {
         1,
         2,
         4,
@@ -87,7 +87,7 @@ TEST(MicrobenchmarkTLB, TLBDynamicTensix) {
 
     std::vector<std::vector<std::string>> rows;
 
-    for (uint32_t buf_size : sizes) {
+    for (size_t buf_size : sizes) {
         std::vector<std::string> row;
         auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster.get(), chip, tensix_core);
         row.push_back(test::utils::convert_double_to_string(buf_size));
@@ -107,7 +107,7 @@ TEST(MicrobenchmarkTLB, TLBStaticTensix) {
 
     cluster->configure_tlb(0, tensix_core, tlb_1m_index, 0x0, tlb_data::Relaxed);
 
-    const std::vector<uint32_t> sizes = {
+    const std::vector<size_t> sizes = {
         1,
         2,
         4,
@@ -127,7 +127,7 @@ TEST(MicrobenchmarkTLB, TLBStaticTensix) {
 
     std::vector<std::vector<std::string>> rows;
 
-    for (uint32_t buf_size : sizes) {
+    for (size_t buf_size : sizes) {
         std::vector<std::string> row;
         auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster.get(), chip, tensix_core);
         row.push_back(test::utils::convert_double_to_string(buf_size));
@@ -174,7 +174,7 @@ TEST(MicrobenchmarkTLB, TLBStaticDram) {
 
     std::vector<std::vector<std::string>> rows;
 
-    for (uint32_t buf_size : sizes) {
+    for (size_t buf_size : sizes) {
         std::vector<std::string> row;
         auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster.get(), chip, dram_core);
         row.push_back(test::utils::convert_double_to_string(buf_size));
@@ -189,7 +189,7 @@ TEST(MicrobenchmarkTLB, TLBStaticDram) {
  * Measure BW of IO to Ethernet core using dynamically configured TLB.
  */
 TEST(MicrobenchmarkTLB, TLBDynamicEth) {
-    const std::vector<uint32_t> sizes = {
+    const std::vector<size_t> sizes = {
         1,
         2,
         4,
@@ -212,7 +212,7 @@ TEST(MicrobenchmarkTLB, TLBDynamicEth) {
 
     std::vector<std::vector<std::string>> rows;
     constexpr uint32_t address = 128 * one_kb;
-    for (uint32_t buf_size : sizes) {
+    for (size_t buf_size : sizes) {
         std::vector<std::string> row;
         auto [wr_bw, rd_bw] =
             test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster.get(), chip, eth_core, address);
@@ -234,7 +234,7 @@ TEST(MicrobenchmarkTLB, TLBStaticEth) {
     constexpr uint32_t address = 128 * one_kb;
     cluster->configure_tlb(chip, eth_core, tlb_1m_index, address, tlb_data::Relaxed);
 
-    const std::vector<uint32_t> sizes = {
+    const std::vector<size_t> sizes = {
         1,
         2,
         4,
@@ -254,7 +254,7 @@ TEST(MicrobenchmarkTLB, TLBStaticEth) {
 
     std::vector<std::vector<std::string>> rows;
 
-    for (uint32_t buf_size : sizes) {
+    for (size_t buf_size : sizes) {
         std::vector<std::string> row;
         auto [wr_bw, rd_bw] =
             test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster.get(), chip, eth_core, address);

--- a/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
+++ b/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
@@ -10,7 +10,8 @@ using namespace tt::umd;
 
 constexpr chip_id_t chip = 0;
 constexpr uint32_t one_mb = 1 << 20;
-constexpr uint32_t NUM_ITERATIONS = 1;
+constexpr size_t one_gb = 1ULL << 30;
+constexpr uint32_t NUM_ITERATIONS = 10;
 constexpr uint32_t one_kb = 1 << 10;
 constexpr uint32_t tlb_1m_index = 0;
 constexpr uint32_t tlb_16m_index = 166;
@@ -22,30 +23,35 @@ TEST(MicrobenchmarkTLB, TLBDynamicDram) {
     // Sizes are chosen in a way to avoid TLB benchmark taking too long. 32 MB already
     // tests chunking of data into smaller chunks to match TLB size.
     // 64 MB and above showed the same perf locally.
-    const std::vector<uint32_t> sizes = {
+    const std::vector<size_t> sizes = {
+        1,
+        2,
+        4,
+        8,
+        1 * one_kb,
+        2 * one_kb,
+        4 * one_kb,
+        8 * one_kb,
         1 * one_mb,
         2 * one_mb,
         4 * one_mb,
         8 * one_mb,
-        16 * one_mb,
-        32 * one_mb,
     };
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord dram_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::DRAM)[0];
-    cluster->start_device(device_params{});
 
     const std::vector<std::string> headers = {
-        "Size (MB)",
+        "Size (bytes)",
         "Dynamic TLB: Host -> Device DRAM (MB/s)",
         "Dynamic TLB: Device DRAM -> Host (MB/s)",
     };
 
     std::vector<std::vector<std::string>> rows;
 
-    for (uint32_t buf_size : sizes) {
+    for (size_t buf_size : sizes) {
         std::vector<std::string> row;
-        row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
+        row.push_back(test::utils::convert_double_to_string((buf_size)));
         auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster.get(), chip, dram_core);
         row.push_back(test::utils::convert_double_to_string(wr_bw));
         row.push_back(test::utils::convert_double_to_string(rd_bw));
@@ -59,15 +65,22 @@ TEST(MicrobenchmarkTLB, TLBDynamicDram) {
  */
 TEST(MicrobenchmarkTLB, TLBDynamicTensix) {
     const std::vector<uint32_t> sizes = {
+        1,
+        2,
+        4,
+        8,
+        1 * one_kb,
+        2 * one_kb,
+        4 * one_kb,
+        8 * one_kb,
         1 * one_mb,
     };
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord tensix_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)[0];
-    cluster->start_device(device_params{});
 
     const std::vector<std::string> headers = {
-        "Size (MB)",
+        "Size (bytes)",
         "Dynamic TLB: Host -> Device Tensix L1 (MB/s)",
         "Dynamic TLB: Device Tensix L1 -> Host (MB/s)",
     };
@@ -77,7 +90,7 @@ TEST(MicrobenchmarkTLB, TLBDynamicTensix) {
     for (uint32_t buf_size : sizes) {
         std::vector<std::string> row;
         auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster.get(), chip, tensix_core);
-        row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
+        row.push_back(test::utils::convert_double_to_string(buf_size));
         row.push_back(test::utils::convert_double_to_string(wr_bw));
         row.push_back(test::utils::convert_double_to_string(rd_bw));
         rows.push_back(row);
@@ -91,16 +104,23 @@ TEST(MicrobenchmarkTLB, TLBDynamicTensix) {
 TEST(MicrobenchmarkTLB, TLBStaticTensix) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord tensix_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)[0];
-    cluster->start_device(device_params{});
 
     cluster->configure_tlb(0, tensix_core, tlb_1m_index, 0x0, tlb_data::Relaxed);
 
     const std::vector<uint32_t> sizes = {
+        1,
+        2,
+        4,
+        8,
+        1 * one_kb,
+        2 * one_kb,
+        4 * one_kb,
+        8 * one_kb,
         1 * one_mb,
     };
 
     const std::vector<std::string> headers = {
-        "Size (MB)",
+        "Size (bytes)",
         "Static TLB: Host -> Device Tensix L1 (MB/s)",
         "Static TLB: Device Tensix L1 -> Host (MB/s)",
     };
@@ -109,9 +129,8 @@ TEST(MicrobenchmarkTLB, TLBStaticTensix) {
 
     for (uint32_t buf_size : sizes) {
         std::vector<std::string> row;
-        const uint32_t num_io = buf_size / one_mb;
-        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, num_io, cluster.get(), chip, tensix_core);
-        row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
+        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster.get(), chip, tensix_core);
+        row.push_back(test::utils::convert_double_to_string(buf_size));
         row.push_back(test::utils::convert_double_to_string(wr_bw));
         row.push_back(test::utils::convert_double_to_string(rd_bw));
         rows.push_back(row);
@@ -126,19 +145,29 @@ TEST(MicrobenchmarkTLB, TLBStaticDram) {
     // Sizes are chosen in a way to avoid TLB benchmark taking too long. 32 MB already
     // tests chunking of data into smaller chunks to match TLB size.
     // 64 MB and above showed the same perf locally.
-    const std::vector<uint32_t> sizes = {
+    const std::vector<size_t> sizes = {
+        1,
+        2,
+        4,
+        8,
+        1 * one_kb,
+        2 * one_kb,
+        4 * one_kb,
+        8 * one_kb,
+        1 * one_mb,
+        2 * one_mb,
+        4 * one_mb,
+        8 * one_mb,
         16 * one_mb,
-        32 * one_mb,
-    };
+        32 * one_mb};
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord dram_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::DRAM)[0];
-    cluster->start_device(device_params{});
 
     cluster->configure_tlb(0, dram_core, tlb_16m_index, 0x0, tlb_data::Relaxed);
 
     const std::vector<std::string> headers = {
-        "Size (MB)",
+        "Size (bytes)",
         "Static TLB: Host -> Device DRAM (MB/s)",
         "Static TLB: Device DRAM -> Host (MB/s)",
     };
@@ -147,10 +176,8 @@ TEST(MicrobenchmarkTLB, TLBStaticDram) {
 
     for (uint32_t buf_size : sizes) {
         std::vector<std::string> row;
-        const uint32_t num_io = buf_size / (16 * one_mb);
-
-        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, num_io, cluster.get(), chip, dram_core);
-        row.push_back(test::utils::convert_double_to_string((double)buf_size / one_mb));
+        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster.get(), chip, dram_core);
+        row.push_back(test::utils::convert_double_to_string(buf_size));
         row.push_back(test::utils::convert_double_to_string(wr_bw));
         row.push_back(test::utils::convert_double_to_string(rd_bw));
         rows.push_back(row);
@@ -163,15 +190,22 @@ TEST(MicrobenchmarkTLB, TLBStaticDram) {
  */
 TEST(MicrobenchmarkTLB, TLBDynamicEth) {
     const std::vector<uint32_t> sizes = {
+        1,
+        2,
+        4,
+        8,
+        1 * one_kb,
+        2 * one_kb,
+        4 * one_kb,
+        8 * one_kb,
         128 * one_kb,
     };
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord eth_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::ETH)[0];
-    cluster->start_device(device_params{});
 
     const std::vector<std::string> headers = {
-        "Size (KB)",
+        "Size (bytes)",
         "Dynamic TLB: Host -> Device ETH L1 (MB/s)",
         "Dynamic TLB: Device ETH L1 -> Host (MB/s)",
     };
@@ -182,7 +216,7 @@ TEST(MicrobenchmarkTLB, TLBDynamicEth) {
         std::vector<std::string> row;
         auto [wr_bw, rd_bw] =
             test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster.get(), chip, eth_core, address);
-        row.push_back(test::utils::convert_double_to_string((double)buf_size / one_kb));
+        row.push_back(test::utils::convert_double_to_string(buf_size));
         row.push_back(test::utils::convert_double_to_string(wr_bw));
         row.push_back(test::utils::convert_double_to_string(rd_bw));
         rows.push_back(row);
@@ -196,17 +230,24 @@ TEST(MicrobenchmarkTLB, TLBDynamicEth) {
 TEST(MicrobenchmarkTLB, TLBStaticEth) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     const CoreCoord eth_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::ETH)[0];
-    cluster->start_device(device_params{});
 
     constexpr uint32_t address = 128 * one_kb;
     cluster->configure_tlb(chip, eth_core, tlb_1m_index, address, tlb_data::Relaxed);
 
     const std::vector<uint32_t> sizes = {
+        1,
+        2,
+        4,
+        8,
+        1 * one_kb,
+        2 * one_kb,
+        4 * one_kb,
+        8 * one_kb,
         128 * one_kb,
     };
 
     const std::vector<std::string> headers = {
-        "Size (KB)",
+        "Size (bytes)",
         "Static TLB: Host -> Device ETH L1 (MB/s)",
         "Static TLB: Device ETH L1 -> Host (MB/s)",
     };
@@ -215,9 +256,9 @@ TEST(MicrobenchmarkTLB, TLBStaticEth) {
 
     for (uint32_t buf_size : sizes) {
         std::vector<std::string> row;
-        const uint32_t num_io = buf_size / one_mb;
-        auto [wr_bw, rd_bw] = test::utils::perf_read_write(buf_size, num_io, cluster.get(), chip, eth_core, address);
-        row.push_back(test::utils::convert_double_to_string((double)buf_size / one_kb));
+        auto [wr_bw, rd_bw] =
+            test::utils::perf_read_write(buf_size, NUM_ITERATIONS, cluster.get(), chip, eth_core, address);
+        row.push_back(test::utils::convert_double_to_string(buf_size));
         row.push_back(test::utils::convert_double_to_string(wr_bw));
         row.push_back(test::utils::convert_double_to_string(rd_bw));
         rows.push_back(row);

--- a/tests/microbenchmark/common/microbenchmark_utils.cpp
+++ b/tests/microbenchmark/common/microbenchmark_utils.cpp
@@ -9,7 +9,7 @@
 namespace tt::umd::test::utils {
 
 std::pair<double, double> perf_read_write(
-    const uint32_t buf_size,
+    const size_t buf_size,
     const uint32_t num_iterations,
     Cluster* cluster,
     const chip_id_t chip,

--- a/tests/microbenchmark/common/microbenchmark_utils.hpp
+++ b/tests/microbenchmark/common/microbenchmark_utils.hpp
@@ -26,7 +26,7 @@ namespace tt::umd::test::utils {
  * @return A pair containing the write bandwidth and read bandwidth in MB/s.
  */
 std::pair<double, double> perf_read_write(
-    const uint32_t buf_size,
+    const size_t buf_size,
     const uint32_t num_iterations,
     Cluster* cluster,
     const chip_id_t chip,


### PR DESCRIPTION
### Issue

#1096 

### Description

Complete TLB perf tests. 

### List of the changes

- Set NUM_ITERATIONS to 10 in order to make speed of tests reasonable
- Sweep sizes for all tests
- Report results in bytes instead of MB

### Testing

Local run

### API Changes
/