### PR TITLE
Fix run benchmark

### DIFF
--- a/.github/workflows/build-and-run-all-benchmarks.yml
+++ b/.github/workflows/build-and-run-all-benchmarks.yml
@@ -49,3 +49,4 @@ jobs:
       ubuntu-docker-version: ${{ matrix.ubuntu-docker-version}}
       card: ${{ matrix.test-group.card}}
       timeout: ${{ matrix.test-group.timeout}}
+      build-type: ${{ inputs.build-type }}

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -16,6 +16,10 @@ on:
       timeout:
         required: true
         type: number
+      build-type:
+        required: true
+        type: string
+        default: Release
 
 env:
   BUILD_OUTPUT_DIR: ./build
@@ -55,7 +59,7 @@ jobs:
       - name: Use build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: build-artifacts-${{ inputs.ubuntu-docker-version }}
+          name: build-artifacts-${{ inputs.ubuntu-docker-version }}-${{ inputs.build-type }}
           path: ./
 
       # This is needed to preserve file permissions


### PR DESCRIPTION
### Issue
Broken after recent changes

### Description
Artifact name was changed in build step, and in run tests, but not in run_benchmarks

### List of the changes
-add missing ${{ inputs.build-type }}

### Testing
CI run: https://github.com/tenstorrent/tt-umd/actions/runs/17980512672

### API Changes
There are no API changes in this PR.
