### PR TITLE
Don't clock libttsim on writes

### DIFF
--- a/device/simulation/tt_sim_chip.cpp
+++ b/device/simulation/tt_sim_chip.cpp
@@ -59,7 +59,6 @@ void TTSimulationChip::write_to_device(CoreCoord core, const void* src, uint64_t
     log_debug(tt::LogEmulationDriver, "Device writing {} bytes to l1_dest {} in core {}", size, l1_dest, core.str());
     tt_xy_pair translate_core = soc_descriptor_.translate_coord_to(core, CoordSystem::TRANSLATED);
     pfn_libttsim_tile_wr_bytes(translate_core.x, translate_core.y, l1_dest, src, size);
-    pfn_libttsim_clock(10);
 }
 
 void TTSimulationChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) {


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/ttsim/issues/72

### Description
Remove excessive simulator clocking that isn't needed. Only reads require implicit advancement.

### List of the changes
Remove call to libttsim_clock() in the write code path

### Testing
Ran metal examples and unit tests locally on WH and BH ttsi

### API Changes
/