### PR TITLE
Read out and print/validate PCI ID from ttsim

### DIFF
--- a/device/api/umd/device/simulation/tt_simulation_chip.hpp
+++ b/device/api/umd/device/simulation/tt_simulation_chip.hpp
@@ -32,8 +32,10 @@ public:
 
 private:
     void* libttsim_handle = nullptr;
+    uint32_t libttsim_pci_device_id = 0;
     void (*pfn_libttsim_init)() = nullptr;
     void (*pfn_libttsim_exit)() = nullptr;
+    uint32_t (*pfn_libttsim_pci_config_rd32)(uint32_t bus_device_function, uint32_t offset) = nullptr;
     void (*pfn_libttsim_tile_rd_bytes)(uint32_t x, uint32_t y, uint64_t addr, void* p, uint32_t size) = nullptr;
     void (*pfn_libttsim_tile_wr_bytes)(uint32_t x, uint32_t y, uint64_t addr, const void* p, uint32_t size) = nullptr;
     void (*pfn_libttsim_tensix_reset_deassert)(uint32_t x, uint32_t y) = nullptr;


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/ttsim/issues/45

### Description
Query the PCI device ID and vendor ID out of the simulator. Required for several other upcoming simulator changes.

### List of the changes
Obtain the libttsim_pci_config_rd32 entry point
Query and print the PCI device and vendor ID
Assert that the vendor ID is the expected value
Save off the device ID for downstream code

### Testing
Ran metal examples locally on ttsim

### API Changes
/