### PR TITLE
Change libttsim reset API calls to tile_wr_bytes.

### DIFF
--- a/device/api/umd/device/simulation/tt_simulation_chip.hpp
+++ b/device/api/umd/device/simulation/tt_simulation_chip.hpp
@@ -38,8 +38,6 @@ private:
     uint32_t (*pfn_libttsim_pci_config_rd32)(uint32_t bus_device_function, uint32_t offset) = nullptr;
     void (*pfn_libttsim_tile_rd_bytes)(uint32_t x, uint32_t y, uint64_t addr, void* p, uint32_t size) = nullptr;
     void (*pfn_libttsim_tile_wr_bytes)(uint32_t x, uint32_t y, uint64_t addr, const void* p, uint32_t size) = nullptr;
-    void (*pfn_libttsim_tensix_reset_deassert)(uint32_t x, uint32_t y) = nullptr;
-    void (*pfn_libttsim_tensix_reset_assert)(uint32_t x, uint32_t y) = nullptr;
     void (*pfn_libttsim_clock)(uint32_t n_clocks) = nullptr;
 };
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/ttsim/issues/65

### Description
Reset API is deprecated and does not correspond to any concept/packet on a PCIE bus. Change to use writes to soft reset register.

### List of the changes
Stop querying libttsim reset entry points
Change libttsim reset API call to tile_wr_bytes

### Testing
Ran metal examples locally with latest ttsim

### API Changes
/