### PR TITLE
Add JTAG support in topology tool.

### DIFF
--- a/device/api/umd/device/jtag/jtag_device.hpp
+++ b/device/api/umd/device/jtag/jtag_device.hpp
@@ -8,16 +8,19 @@
 #include <filesystem>
 #include <memory>
 #include <optional>
+#include <unordered_set>
 
 #include "umd/device/jtag/jtag.hpp"
 #include "umd/device/types/arch.hpp"
 
 class JtagDevice {
 public:
-    explicit JtagDevice(std::unique_ptr<Jtag> jtag_device);
+    explicit JtagDevice(std::unique_ptr<Jtag> jtag_device, const std::unordered_set<int>& target_devices = {});
     ~JtagDevice();
 
-    static std::shared_ptr<JtagDevice> create(const std::filesystem::path& binary_directory = jtag_library_path);
+    static std::shared_ptr<JtagDevice> create(
+        const std::filesystem::path& binary_directory = jtag_library_path,
+        const std::unordered_set<int>& target_devices = {});
 
     void close_device() {}
 

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -85,7 +85,7 @@ void TopologyDiscovery::get_connected_chips() {
             break;
         }
         case IODeviceType::JTAG: {
-            auto device_cnt = JtagDevice::create()->get_device_cnt();
+            auto device_cnt = JtagDevice::create(JtagDevice::jtag_library_path, target_devices)->get_device_cnt();
             device_ids = std::vector<int>(device_cnt);
             std::iota(device_ids.begin(), device_ids.end(), 0);
             break;

--- a/device/topology/topology_discovery_wormhole.cpp
+++ b/device/topology/topology_discovery_wormhole.cpp
@@ -265,7 +265,7 @@ void TopologyDiscoveryWormhole::init_topology_discovery() {
         case IODeviceType::JTAG: {
             auto device_cnt = JtagDevice::create()->get_device_cnt();
             if (!device_cnt) {
-                return;
+                TT_THROW("Topology discovery initialisation failed, no JTAG devices were found..");
             }
             // JTAG devices (j-links) are referred to with their index within a vector
             // that's stored inside of a JtagDevice object.

--- a/tools/topology.cpp
+++ b/tools/topology.cpp
@@ -17,9 +17,13 @@ int main(int argc, char *argv[]) {
         "l,logical_devices",
         "List of logical device ids to filter cluster descriptor for.",
         cxxopts::value<std::vector<std::string>>())(
-        "p,pci_devices",
-        "List of pci device ids to perform topology discovery on.",
-        cxxopts::value<std::vector<std::string>>())("h,help", "Print usage");
+        "d,devices",
+        "List of device(PCIe by default) ids to perform topology discovery on. If not provided, all connected devices "
+        "will be used.",
+        cxxopts::value<std::vector<std::string>>())(
+        "j,jtag",
+        "Use JTAG mode for device communication. If not provided, PCIe will be used by default.",
+        cxxopts::value<bool>()->default_value("false"))("h,help", "Print usage");
 
     auto result = options.parse(argc, argv);
 
@@ -28,8 +32,8 @@ int main(int argc, char *argv[]) {
         return 0;
     }
 
-    if (result.count("logical_devices") && result.count("pci_devices")) {
-        std::cerr << "Error: Using both 'pci_devices' and 'logical_devices' options is not allowed." << std::endl;
+    if (result.count("logical_devices") && result.count("devices")) {
+        std::cerr << "Error: Using both 'devices' and 'logical_devices' options is not allowed." << std::endl;
         return 1;
     }
 
@@ -38,12 +42,19 @@ int main(int argc, char *argv[]) {
         cluster_descriptor_path = result["path"].as<std::string>();
     }
 
-    std::unordered_set<int> pci_ids = {};
-    if (result.count("pci_devices")) {
-        pci_ids = extract_int_set(result["pci_devices"]);
+    std::unordered_set<int> device_ids = {};
+    tt::umd::IODeviceType device_type = IODeviceType::PCIe;
+
+    if (result["jtag"].as<bool>()) {
+        device_type = IODeviceType::JTAG;
     }
 
-    std::unique_ptr<ClusterDescriptor> cluster_descriptor = Cluster::create_cluster_descriptor("", pci_ids);
+    if (result.count("devices")) {
+        device_ids = extract_int_set(result["devices"]);
+    }
+
+    std::unique_ptr<ClusterDescriptor> cluster_descriptor =
+        Cluster::create_cluster_descriptor("", device_ids, device_type);
 
     if (result.count("logical_devices")) {
         std::unordered_set<int> logical_device_ids = extract_int_set(result["logical_devices"]);


### PR DESCRIPTION
### Description
 - Topology tool can now be used with JTAG as well.

### List of the changes
 - Target devices were added to JTAG initialisation.
 - Changed -p parameter in topology to -d as in device. Also added -j to specify wether JTAG should be used instead of PCIe.

### Testing
 - Manually generated cluster.yaml files with both PCIe and JTAG. Files were the exact same.
