### PR TITLE
Update APIs to be compatible with clang tidy

### DIFF
--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -222,7 +222,7 @@ public:
      */
     void configure_tlb(
         chip_id_t logical_device_id,
-        CoreCoord core,
+        const CoreCoord& core,
         int32_t tlb_index,
         uint64_t address,
         uint64_t ordering = tlb_data::Relaxed);
@@ -286,9 +286,7 @@ public:
      * @param soft_resets Specifies which RISCV cores on Tensix to deassert.
      */
     void deassert_risc_reset_at_core(
-        const chip_id_t chip,
-        const CoreCoord core,
-        const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET);
+        chip_id_t chip, const CoreCoord& core, const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET);
 
     /**
      * Broadcast BRISC assert BRISC soft Tensix Reset to the entire device.
@@ -307,9 +305,7 @@ public:
      * @param soft_resets Specifies which RISCV cores on Tensix to deassert.
      */
     void assert_risc_reset_at_core(
-        const chip_id_t chip,
-        const CoreCoord core,
-        const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET);
+        chip_id_t chip, const CoreCoord& core, const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET);
 
     //---------- New API for starting/stopping the device, with variants for Tensix and Neo.
 
@@ -319,7 +315,7 @@ public:
      * @param chip Chip to target.
      * @param core Core to target.
      */
-    RiscType get_risc_reset_state(const chip_id_t chip, const CoreCoord core);
+    RiscType get_risc_reset_state(chip_id_t chip, const CoreCoord& core);
 
     /**
      * Assert the soft reset signal at designated RISC cores on a single tensix core.
@@ -331,7 +327,7 @@ public:
      * @param core Core to target.
      * @param risc_type Specifies which RISCV cores on Tensix to assert.
      */
-    void assert_risc_reset(const chip_id_t chip, const CoreCoord core, const RiscType risc_type);
+    void assert_risc_reset(chip_id_t chip, const CoreCoord& core, RiscType risc_type);
 
     /**
      * Deassert the soft reset signal at designated RISC cores on a single tensix core.
@@ -344,8 +340,7 @@ public:
      * @param risc_type Specifies which RISCV cores on Tensix to deassert.
      * @param staggered_start Specifies whether the stagger signal should be active.
      */
-    void deassert_risc_reset(
-        const chip_id_t chip, const CoreCoord core, const RiscType risc_type, bool staggered_start = true);
+    void deassert_risc_reset(chip_id_t chip, const CoreCoord& core, RiscType risc_type, bool staggered_start = true);
 
     //---------- IO functions for Tensix cores, including DRAM.
 
@@ -360,7 +355,8 @@ public:
      * @param core Core to target.
      * @param addr Address to write to.
      */
-    void write_to_device(const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, CoreCoord core, uint64_t addr);
+    void write_to_device(
+        const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, const CoreCoord& core, uint64_t addr);
 
     /**
      * Read uint32_t data from a specified device, core and address to host memory (defined for Silicon).
@@ -373,7 +369,7 @@ public:
      * @param addr Address to read from.
      * @param size Number of bytes to read.
      */
-    void read_from_device(void* mem_ptr, chip_id_t chip, CoreCoord core, uint64_t addr, uint32_t size);
+    void read_from_device(void* mem_ptr, chip_id_t chip, const CoreCoord& core, uint64_t addr, uint32_t size);
 
     /**
      * Write uint32_t data (as specified by ptr + len pair) to specified device, core and address (defined for Silicon).
@@ -389,7 +385,7 @@ public:
      * @param addr Address to write to.
      */
     void write_to_device_reg(
-        const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, CoreCoord core, uint64_t addr);
+        const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, const CoreCoord& core, uint64_t addr);
 
     /**
      * Read uint32_t data from a specified device, core and address to host memory (defined for Silicon).
@@ -404,7 +400,7 @@ public:
      * @param addr Address to read from.
      * @param size Number of bytes to read.
      */
-    void read_from_device_reg(void* mem_ptr, chip_id_t chip, CoreCoord core, uint64_t addr, uint32_t size);
+    void read_from_device_reg(void* mem_ptr, chip_id_t chip, const CoreCoord& core, uint64_t addr, uint32_t size);
 
     /**
      * Use PCIe DMA to write device memory (L1 or DRAM).
@@ -415,7 +411,7 @@ public:
      * @param core Core to target.
      * @param addr Address to write to.
      */
-    void dma_write_to_device(const void* src, size_t size, chip_id_t chip, CoreCoord core, uint64_t addr);
+    void dma_write_to_device(const void* src, size_t size, chip_id_t chip, const CoreCoord& core, uint64_t addr);
 
     /**
      * Use PCIe DMA to read device memory (L1 or DRAM).
@@ -426,7 +422,7 @@ public:
      * @param core Core to target.
      * @param addr Address to read from.
      */
-    void dma_read_from_device(void* dst, size_t size, chip_id_t chip, CoreCoord core, uint64_t addr);
+    void dma_read_from_device(void* dst, size_t size, chip_id_t chip, const CoreCoord& core, uint64_t addr);
 
     /**
      * This function writes to multiple chips and cores in the cluster. A set of chips, rows and columns can be excluded
@@ -465,7 +461,7 @@ public:
      *
      * @param target The target chip and core to write to.
      */
-    Writer get_static_tlb_writer(const chip_id_t chip, const CoreCoord core);
+    Writer get_static_tlb_writer(chip_id_t chip, const CoreCoord& core);
 
     //---------- Functions for synchronization and memory barriers.
 
@@ -477,7 +473,7 @@ public:
      * @param chip Chip to target.
      * @param cores Cores being targeted.
      */
-    void l1_membar(const chip_id_t chip, const std::unordered_set<CoreCoord>& cores = {});
+    void l1_membar(chip_id_t chip, const std::unordered_set<CoreCoord>& cores = {});
 
     /**
      * DRAM memory barrier.
@@ -487,7 +483,7 @@ public:
      * @param chip Chip to target.
      * @param channels Channels being targeted.
      */
-    void dram_membar(const chip_id_t chip, const std::unordered_set<uint32_t>& channels = {});
+    void dram_membar(chip_id_t chip, const std::unordered_set<uint32_t>& channels = {});
 
     /**
      * DRAM memory barrier.
@@ -497,7 +493,7 @@ public:
      * @param chip Chip being targeted.
      * @param cores Cores being targeted.
      */
-    void dram_membar(const chip_id_t chip, const std::unordered_set<CoreCoord>& cores = {});
+    void dram_membar(chip_id_t chip, const std::unordered_set<CoreCoord>& cores = {});
 
     // Runtime functions
     /**
@@ -516,7 +512,7 @@ public:
      *
      * @param chip_id Chip to target.
      */
-    void wait_for_non_mmio_flush(const chip_id_t chip_id);
+    void wait_for_non_mmio_flush(chip_id_t chip_id);
 
     //---------- IO functions for host memory. Write and read functions, and getting host memory info.
 
@@ -669,7 +665,7 @@ public:
     /**
      * Exposes how TLBs are configured for a specific device.
      */
-    tlb_configuration get_tlb_configuration(const chip_id_t chip, const CoreCoord core);
+    tlb_configuration get_tlb_configuration(chip_id_t chip, const CoreCoord& core);
 
 private:
     // Helper functions

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -524,25 +524,24 @@ void Cluster::assert_risc_reset() { broadcast_tensix_risc_reset_to_cluster(TENSI
 void Cluster::deassert_risc_reset() { broadcast_tensix_risc_reset_to_cluster(TENSIX_DEASSERT_SOFT_RESET); }
 
 void Cluster::deassert_risc_reset_at_core(
-    const chip_id_t chip, const CoreCoord core, const TensixSoftResetOptions& soft_resets) {
+    chip_id_t chip, const CoreCoord& core, const TensixSoftResetOptions& soft_resets) {
     get_chip(chip)->send_tensix_risc_reset(core, soft_resets);
 }
 
 void Cluster::assert_risc_reset_at_core(
-    const chip_id_t chip, const CoreCoord core, const TensixSoftResetOptions& soft_resets) {
+    chip_id_t chip, const CoreCoord& core, const TensixSoftResetOptions& soft_resets) {
     get_chip(chip)->send_tensix_risc_reset(core, soft_resets);
 }
 
-RiscType Cluster::get_risc_reset_state(const chip_id_t chip, const CoreCoord core) {
+RiscType Cluster::get_risc_reset_state(chip_id_t chip, const CoreCoord& core) {
     return get_chip(chip)->get_risc_reset_state(core);
 }
 
-void Cluster::assert_risc_reset(const chip_id_t chip, const CoreCoord core, const RiscType risc_type) {
+void Cluster::assert_risc_reset(chip_id_t chip, const CoreCoord& core, RiscType risc_type) {
     get_chip(chip)->assert_risc_reset(core, risc_type);
 }
 
-void Cluster::deassert_risc_reset(
-    const chip_id_t chip, const CoreCoord core, const RiscType risc_type, bool staggered_start) {
+void Cluster::deassert_risc_reset(chip_id_t chip, const CoreCoord& core, RiscType risc_type, bool staggered_start) {
     get_chip(chip)->deassert_risc_reset(core, risc_type, staggered_start);
 }
 
@@ -553,7 +552,7 @@ std::function<void(uint32_t, uint32_t, const uint8_t*)> Cluster::get_fast_pcie_s
     return chips_.at(device_id)->get_fast_pcie_static_tlb_write_callable();
 }
 
-Writer Cluster::get_static_tlb_writer(const chip_id_t chip, const CoreCoord core) {
+Writer Cluster::get_static_tlb_writer(chip_id_t chip, const CoreCoord& core) {
     tt_xy_pair translated_core = get_chip(chip)->translate_chip_coord_to_translated(core);
     return get_tlb_manager(chip)->get_static_tlb_writer(translated_core);
 }
@@ -572,7 +571,7 @@ Cluster::~Cluster() {
     cluster_desc.reset();
 }
 
-tlb_configuration Cluster::get_tlb_configuration(const chip_id_t chip, CoreCoord core) {
+tlb_configuration Cluster::get_tlb_configuration(chip_id_t chip, const CoreCoord& core) {
     tt_xy_pair translated_core = get_chip(chip)->translate_chip_coord_to_translated(core);
     return get_tlb_manager(chip)->get_tlb_configuration(translated_core);
 }
@@ -589,7 +588,7 @@ void Cluster::configure_tlb(
 }
 
 void Cluster::configure_tlb(
-    chip_id_t logical_device_id, CoreCoord core, int32_t tlb_index, uint64_t address, uint64_t ordering) {
+    chip_id_t logical_device_id, const CoreCoord& core, int32_t tlb_index, uint64_t address, uint64_t ordering) {
     tt_xy_pair translated_core = get_chip(logical_device_id)->translate_chip_coord_to_translated(core);
     get_tlb_manager(logical_device_id)->configure_tlb(translated_core, tlb_index, address, ordering);
 }
@@ -628,7 +627,7 @@ RemoteChip* Cluster::get_remote_chip(chip_id_t device_id) const {
     return dynamic_cast<RemoteChip*>(get_chip(device_id));
 }
 
-void Cluster::wait_for_non_mmio_flush(const chip_id_t chip_id) { get_chip(chip_id)->wait_for_non_mmio_flush(); }
+void Cluster::wait_for_non_mmio_flush(chip_id_t chip_id) { get_chip(chip_id)->wait_for_non_mmio_flush(); }
 
 void Cluster::wait_for_non_mmio_flush() {
     for (auto& [chip_id, chip] : chips_) {
@@ -921,41 +920,41 @@ void Cluster::read_from_sysmem(void* mem_ptr, uint64_t addr, uint16_t channel, u
     get_chip(src_device_id)->read_from_sysmem(channel, mem_ptr, addr, size);
 }
 
-void Cluster::l1_membar(const chip_id_t chip, const std::unordered_set<CoreCoord>& cores) {
+void Cluster::l1_membar(chip_id_t chip, const std::unordered_set<CoreCoord>& cores) {
     get_chip(chip)->l1_membar(cores);
 }
 
-void Cluster::dram_membar(const chip_id_t chip, const std::unordered_set<CoreCoord>& cores) {
+void Cluster::dram_membar(chip_id_t chip, const std::unordered_set<CoreCoord>& cores) {
     get_chip(chip)->dram_membar(cores);
 }
 
-void Cluster::dram_membar(const chip_id_t chip, const std::unordered_set<uint32_t>& channels) {
+void Cluster::dram_membar(chip_id_t chip, const std::unordered_set<uint32_t>& channels) {
     get_chip(chip)->dram_membar(channels);
 }
 
 void Cluster::write_to_device(
-    const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, CoreCoord core, uint64_t addr) {
+    const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, const CoreCoord& core, uint64_t addr) {
     get_chip(chip)->write_to_device(core, mem_ptr, addr, size_in_bytes);
 }
 
 void Cluster::write_to_device_reg(
-    const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, CoreCoord core, uint64_t addr) {
+    const void* mem_ptr, uint32_t size_in_bytes, chip_id_t chip, const CoreCoord& core, uint64_t addr) {
     get_chip(chip)->write_to_device_reg(core, mem_ptr, addr, size_in_bytes);
 }
 
-void Cluster::dma_write_to_device(const void* src, size_t size, chip_id_t chip, CoreCoord core, uint64_t addr) {
+void Cluster::dma_write_to_device(const void* src, size_t size, chip_id_t chip, const CoreCoord& core, uint64_t addr) {
     get_chip(chip)->dma_write_to_device(src, size, core, addr);
 }
 
-void Cluster::dma_read_from_device(void* dst, size_t size, chip_id_t chip, CoreCoord core, uint64_t addr) {
+void Cluster::dma_read_from_device(void* dst, size_t size, chip_id_t chip, const CoreCoord& core, uint64_t addr) {
     get_chip(chip)->dma_read_from_device(dst, size, core, addr);
 }
 
-void Cluster::read_from_device(void* mem_ptr, chip_id_t chip, CoreCoord core, uint64_t addr, uint32_t size) {
+void Cluster::read_from_device(void* mem_ptr, chip_id_t chip, const CoreCoord& core, uint64_t addr, uint32_t size) {
     get_chip(chip)->read_from_device(core, mem_ptr, addr, size);
 }
 
-void Cluster::read_from_device_reg(void* mem_ptr, chip_id_t chip, CoreCoord core, uint64_t addr, uint32_t size) {
+void Cluster::read_from_device_reg(void* mem_ptr, chip_id_t chip, const CoreCoord& core, uint64_t addr, uint32_t size) {
     get_chip(chip)->read_from_device_reg(core, mem_ptr, addr, size);
 }
 


### PR DESCRIPTION
### Issue
No Ticket.

### Description
- Clang Tidy failures gating some Metal PRs including `cluster.hpp` after more stringent linter checks went in recently
- Warnings point to APIs using `const val`

### List of the changes
- Update APIs in `cluster.hpp` to use `const ref` for `CoreCoord` and `val` for small data-types

### Testing
(Comment on CI testing or Manual testing touching this change.)

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
