### PR TITLE
Add hardware hang check for JTAG.

### DIFF
--- a/device/api/umd/device/jtag/jtag_device.hpp
+++ b/device/api/umd/device/jtag/jtag_device.hpp
@@ -68,7 +68,7 @@ public:
     std::optional<uint32_t> read_id(uint8_t chip_id);
     std::optional<uint8_t> get_current_device_idx() const;
     int get_device_id(uint8_t chip_id) const;
-
+    bool is_hardware_hung(uint8_t chip_id);
     static std::filesystem::path jtag_library_path;
 
 private:

--- a/device/api/umd/device/jtag/jtag_device.hpp
+++ b/device/api/umd/device/jtag/jtag_device.hpp
@@ -28,6 +28,12 @@ public:
 
     int open_jlink_by_serial_wrapper(uint8_t chip_id, unsigned int serial_number);
     int open_jlink_wrapper(uint8_t chip_id);
+
+    /*
+     * chip_id -> J-link device index in vector of devices.
+     * client -> debug client name (e.g. "arc", "pcie"). Communicates with JTAG ports on clients through TDR(TAP Data
+     * Register). reg_offset -> Register offset inside the client.
+     */
     std::optional<uint32_t> read_tdr(uint8_t chip_id, const char* client, uint32_t reg_offset);
     std::optional<uint32_t> readmon_tdr(uint8_t chip_id, const char* client, uint32_t id, uint32_t reg_offset);
     std::optional<int> writemon_tdr(

--- a/device/jtag/jtag_device.cpp
+++ b/device/jtag/jtag_device.cpp
@@ -319,8 +319,9 @@ bool JtagDevice::is_hardware_hung(uint8_t chip_id) {
     uint32_t timeout = 10;
     std::optional<uint32_t> status;
     do {
+        // Details about status format can be found inside JTAG library.
         status = read_tdr(chip_id, "arc", 0x4);
-        status = ((status.value() >> 16) & 0xf);
+        status = status.value() >> 16;
         timeout--;
     } while (((status.value() & 0x1) == 0) && (timeout > 0));
     return timeout == 0;


### PR DESCRIPTION
### Description
Jtag Device has internal check for hardware hang inside of its library for each write and read operation when accessing axi bus (which happens every time with current implementation).

This PR enables user to check hardware hang explicitly if in the future JTAG I/O implementation changes or for whatever other reason.

### List of the changes
JtagDevice

