### PR TITLE
Add a workaround to support remote communication over JTAG again.

### DIFF
--- a/device/api/umd/device/tt_device/remote_wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/remote_wormhole_tt_device.hpp
@@ -41,6 +41,19 @@ public:
 private:
     RemoteWormholeTTDevice(std::unique_ptr<RemoteCommunication> remote_communication, eth_coord_t target_chip);
 
+    /*
+     * This is a constructor primarily used for JTAG to create a RemoteWormholeTTDevice
+     * without an underlying communication device.
+     * It was created as a workaround to allow RemoteWormholeTTDevice creation over JTAG.
+     * It should not be used for PCIe as certain functionalities from base class rely on the presence of an underlying
+     * communication device. Creating a RemoteWormholeTTDevice without an underlying communication device over PCIe
+     * would require overriding several methods from the base class.
+     * TODO: In the future, either remove this constructor or refactor the class hierarchy to better support PCIe use
+     * case.
+     */
+    RemoteWormholeTTDevice(
+        std::unique_ptr<RemoteCommunication> remote_communication, eth_coord_t target_chip, IODeviceType device_type);
+
     friend std::unique_ptr<TTDevice> TTDevice::create(
         std::unique_ptr<RemoteCommunication> remote_communication, eth_coord_t target_chip);
 

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -52,6 +52,9 @@ protected:
     /*
      * Create a device without an underlying communication device.
      * Used for remote devices that depend on remote_communication.
+     * WARNING: This constructor should not be used for PCIe devices as certain functionalities from base class rely on
+     * the presence of an underlying communication device. Creating a WormholeTTDevice without an underlying
+     * communication device over PCIe would require overriding several methods from the base class.
      */
     WormholeTTDevice();
 

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -48,10 +48,10 @@ std::unique_ptr<LocalChip> LocalChip::create(
     if (device_type == IODeviceType::PCIe) {
         tlb_manager = std::make_unique<TLBManager>(tt_device.get());
         sysmem_manager = std::make_unique<SysmemManager>(tlb_manager.get(), num_host_mem_channels);
-        // Note that the eth_coord is not important here since this is only used for eth broadcasting.
-        remote_communication =
-            RemoteCommunication::create_remote_communication(tt_device.get(), {0, 0, 0, 0}, sysmem_manager.get());
     }
+    // Note that the eth_coord is not important here since this is only used for eth broadcasting.
+    remote_communication =
+        RemoteCommunication::create_remote_communication(tt_device.get(), {0, 0, 0, 0}, sysmem_manager.get());
 
     return std::unique_ptr<LocalChip>(new LocalChip(
         soc_descriptor,
@@ -79,10 +79,11 @@ std::unique_ptr<LocalChip> LocalChip::create(
     if (device_type == IODeviceType::PCIe) {
         tlb_manager = std::make_unique<TLBManager>(tt_device.get());
         sysmem_manager = std::make_unique<SysmemManager>(tlb_manager.get(), num_host_mem_channels);
-        // Note that the eth_coord is not important here since this is only used for eth broadcasting.
-        remote_communication =
-            RemoteCommunication::create_remote_communication(tt_device.get(), {0, 0, 0, 0}, sysmem_manager.get());
     }
+    // Note that the eth_coord is not important here since this is only used for eth broadcasting.
+    remote_communication =
+        RemoteCommunication::create_remote_communication(tt_device.get(), {0, 0, 0, 0}, sysmem_manager.get());
+
     return std::unique_ptr<LocalChip>(new LocalChip(
         soc_descriptor,
         std::move(tt_device),

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -295,10 +295,7 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
             num_host_mem_channels,
             cluster_desc->io_device_type);
 
-        // Currrently remote transfer is only supported by PCIe.
-        // TODO: implement remote transfer for JTAG comm.
-        if (cluster_desc->get_arch(chip_id) == tt::ARCH::WORMHOLE_B0 &&
-            cluster_desc->get_io_device_type() == IODeviceType::PCIe) {
+        if (cluster_desc->get_arch(chip_id) == tt::ARCH::WORMHOLE_B0) {
             // Remote transfer currently supported only for wormhole.
             chip->set_remote_transfer_ethernet_cores(cluster_desc->get_active_eth_channels(chip_id));
         }

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -422,6 +422,7 @@ std::unique_ptr<ClusterDescriptor> ClusterDescriptor::create_constrained_cluster
     desc->harvesting_masks_map = filter_chip_collection(full_cluster_desc->harvesting_masks_map, target_chip_ids);
 
     desc->asic_locations = filter_chip_collection(full_cluster_desc->asic_locations, target_chip_ids);
+    desc->io_device_type = full_cluster_desc->io_device_type;
 
     // Write explicitly filters for more complex structures.
     for (const auto &[chip_id, eth_connections] : full_cluster_desc->ethernet_connections) {

--- a/device/tt_device/remote_wormhole_tt_device.cpp
+++ b/device/tt_device/remote_wormhole_tt_device.cpp
@@ -5,6 +5,7 @@
 
 #include "assert.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/types/communication_protocol.hpp"
 
 namespace tt::umd {
 
@@ -13,6 +14,12 @@ RemoteWormholeTTDevice::RemoteWormholeTTDevice(
     WormholeTTDevice(remote_communication->get_local_device()->get_pci_device()),
     target_chip_(target_chip),
     remote_communication_(std::move(remote_communication)) {
+    is_remote_tt_device = true;
+}
+
+RemoteWormholeTTDevice::RemoteWormholeTTDevice(
+    std::unique_ptr<RemoteCommunication> remote_communication, eth_coord_t target_chip, IODeviceType device_type) :
+    WormholeTTDevice(), target_chip_(target_chip), remote_communication_(std::move(remote_communication)) {
     // Since RemoteWormholeTTDevice uses RemoteCommunication and doesn't have an underlying I/O device,
     // which in turn uses a local TTDevice for communication,
     // the device type of the underlying communication device is the device type of the local TTDevice.


### PR DESCRIPTION
### Description
Remote communication for JTAG threw errors after https://github.com/tenstorrent/tt-umd/pull/1390 was merged. 

This PR creates a workaround by avoiding the creation of empty (No IO device) TTDevice for PCIe protocol and does it only for JTAG. 

### List of the changes
 - New constructor for RemoteWormholeTTDevice.
 - remote communication now gets initialised properly in local_chip which was an error in earlier versions.
 - remote cores now get set earlier in construct_chip_from_cluster in cluster. (Removed the PCIe check)
 - create_constrained_cluster now sets the io_device_type to suit exalens use.
 - TTDevice Remote device factory was refactored.
 
### Testing
ApiJtagClusterTest.