### PR TITLE
Update CMakeLists.txt - Path to noc_parameters.h has changed.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,7 +30,7 @@ set(ARCHS
 )
 foreach(ARCH IN LISTS ARCHS)
     set(HW_NOC_PARAMETERS_URL
-        "https://raw.githubusercontent.com/tenstorrent/tt-metal/refs/heads/main/tt_metal/hw/inc/${ARCH}/noc/noc_parameters.h"
+        "https://raw.githubusercontent.com/tenstorrent/tt-metal/refs/heads/main/tt_metal/hw/inc/tt-1xx/${ARCH}/noc/noc_parameters.h"
     )
     set(DESTINATION_DIR ${CMAKE_CURRENT_BINARY_DIR}/${ARCH}/noc)
     file(MAKE_DIRECTORY ${DESTINATION_DIR})


### PR DESCRIPTION
### Issue
NA

### Description

These files were moved in metal.

https://github.com/tenstorrent/tt-metal/pull/29908/files#diff-c695d1d63291af2faa967b2196bdab278769c30f0bf13ed03b38efb5f081b98d

### List of the changes


### Testing
CI

### API Changes
There are no API changes in this PR.

