### PR TITLE
Fix noc_overlay header include

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,7 +30,7 @@ set(ARCHS
 )
 foreach(ARCH IN LISTS ARCHS)
     set(HW_NOC_PARAMETERS_URL
-        "https://raw.githubusercontent.com/tenstorrent/tt-metal/refs/heads/main/tt_metal/hw/inc/${ARCH}/noc/noc_parameters.h"
+        "https://raw.githubusercontent.com/tenstorrent/tt-metal/refs/heads/main/tt_metal/hw/inc/tt-1xx/${ARCH}/noc/noc_parameters.h"
     )
     set(DESTINATION_DIR ${CMAKE_CURRENT_BINARY_DIR}/${ARCH}/noc)
     file(MAKE_DIRECTORY ${DESTINATION_DIR})


### PR DESCRIPTION
### Issue

### Description
Fix include of noc_paramters.h

### List of the changes
- Changed include based on https://github.com/tenstorrent/tt-metal/pull/29908/files#diff-b501548d99e3b502ca8de723a3b16e9de06db48e005488054a0b90dce3f4a255

### Testing
CI tests pass

### API Changes
There are no API changes in this PR.
