### PR TITLE
enable chiplock

### DIFF
--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -189,9 +189,7 @@ void LocalChip::start_device() {
 
     // TODO: acquire mutex should live in Chip class. Currently we don't have unique id for all chips.
     // The lock here should suffice since we have to open Local chip to have Remote chips initialized.
-    // TODO: Enable this once all tt-metal tests are passing.
-    // chip_started_lock_.emplace(acquire_mutex(MutexType::CHIP_IN_USE,
-    // tt_device_->get_pci_device()->get_device_num()));
+    chip_started_lock_.emplace(acquire_mutex(MutexType::CHIP_IN_USE, tt_device_->get_pci_device()->get_device_num()));
 
     check_pcie_device_initialized();
     sysmem_manager_->pin_or_map_sysmem_to_device();


### PR DESCRIPTION
### Issue
#971 

### Description
It seems like finally chip lock can be enabled, and metal tests will start passing.

### List of the changes
- Enable chiplock on start_device

### Testing

All runs on brosko/chiplock_final_base (without change) :
- [ ] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/18274360941
- [ ] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/18274363968
- [ ] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/18275786637
- [ ] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/18275789509
- [ ] (Single-card) Demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/18275792544
- [ ] (Galaxy) Quick : https://github.com/tenstorrent/tt-metal/actions/runs/18275795836
- [ ] Galaxy demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/18275798915
- [ ] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/18275801950
- [ ] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/18275805550

All runs on brosko/chiplock_final :
- [ ] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/18274430583
- [ ] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/18274433491
- [ ] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/18275911922
- [ ] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/18275914827
- [ ] (Single-card) Demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/18275918090
- [ ] (Galaxy) Quick : https://github.com/tenstorrent/tt-metal/actions/runs/18275921351
- [ ] Galaxy demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/18275924711
- [ ] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/18275928639
- [ ] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/18275931609

### API Changes
There are no API changes in this PR.
