### PR TITLE
Rename TTSimulation -> TTSim

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -186,7 +186,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/types/tensix_soft_reset_options.hpp
                 api/umd/device/types/risc_type.hpp
                 api/umd/device/simulation/simulation_chip.hpp
-                api/umd/device/simulation/tt_simulation_chip.hpp
+                api/umd/device/simulation/tt_sim_chip.hpp
                 api/umd/device/simulation/rtl_simulation_chip.hpp
                 api/umd/device/simulation/simulation_host.hpp
                 api/umd/device/soc_descriptor.hpp

--- a/device/api/umd/device/simulation/tt_sim_chip.hpp
+++ b/device/api/umd/device/simulation/tt_sim_chip.hpp
@@ -14,10 +14,10 @@
 namespace tt::umd {
 
 // TTSIM implementation using dynamic library (.so files).
-class TTSimulationChip : public SimulationChip {
+class TTSimChip : public SimulationChip {
 public:
-    TTSimulationChip(const std::filesystem::path& simulator_directory, SocDescriptor soc_descriptor);
-    ~TTSimulationChip() override;
+    TTSimChip(const std::filesystem::path& simulator_directory, SocDescriptor soc_descriptor);
+    ~TTSimChip() override;
 
     void start_device() override;
     void close_device() override;

--- a/device/simulation/simulation_chip.cpp
+++ b/device/simulation/simulation_chip.cpp
@@ -10,14 +10,14 @@
 
 #include "assert.hpp"
 #include "umd/device/simulation/rtl_simulation_chip.hpp"
-#include "umd/device/simulation/tt_simulation_chip.hpp"
+#include "umd/device/simulation/tt_sim_chip.hpp"
 
 namespace tt::umd {
 
 std::unique_ptr<SimulationChip> SimulationChip::create(
     const std::filesystem::path& simulator_directory, SocDescriptor soc_descriptor) {
     if (simulator_directory.extension() == ".so") {
-        return std::make_unique<TTSimulationChip>(simulator_directory, soc_descriptor);
+        return std::make_unique<TTSimChip>(simulator_directory, soc_descriptor);
     } else {
         return std::make_unique<RtlSimulationChip>(simulator_directory, soc_descriptor);
     }

--- a/device/simulation/tt_sim_chip.cpp
+++ b/device/simulation/tt_sim_chip.cpp
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "umd/device/simulation/tt_sim_chip.hpp"
+
 #include <dlfcn.h>
 
 #include <tt-logger/tt-logger.hpp>
 
 #include "assert.hpp"
 #include "umd/device/driver_atomics.hpp"
-#include "umd/device/simulation/tt_simulation_chip.hpp"
 
 #define DLSYM_FUNCTION(func_name)                                                    \
     pfn_##func_name = (decltype(pfn_##func_name))dlsym(libttsim_handle, #func_name); \
@@ -20,9 +21,9 @@
 
 namespace tt::umd {
 
-static_assert(!std::is_abstract<TTSimulationChip>(), "TTSimulationChip must be non-abstract.");
+static_assert(!std::is_abstract<TTSimChip>(), "TTSimChip must be non-abstract.");
 
-TTSimulationChip::TTSimulationChip(const std::filesystem::path& simulator_directory, SocDescriptor soc_descriptor) :
+TTSimChip::TTSimChip(const std::filesystem::path& simulator_directory, SocDescriptor soc_descriptor) :
     SimulationChip(simulator_directory, soc_descriptor),
     architecture_impl_(architecture_implementation::create(soc_descriptor_.arch)) {
     if (!std::filesystem::exists(simulator_directory)) {
@@ -42,9 +43,9 @@ TTSimulationChip::TTSimulationChip(const std::filesystem::path& simulator_direct
     DLSYM_FUNCTION(libttsim_clock)
 }
 
-TTSimulationChip::~TTSimulationChip() { dlclose(libttsim_handle); }
+TTSimChip::~TTSimChip() { dlclose(libttsim_handle); }
 
-void TTSimulationChip::start_device() {
+void TTSimChip::start_device() {
     std::lock_guard<std::mutex> lock(device_lock);
     pfn_libttsim_init();
 
@@ -56,26 +57,26 @@ void TTSimulationChip::start_device() {
     TT_ASSERT(vendor_id == 0x1E52, "Unexpected PCI vendor ID.");
 }
 
-void TTSimulationChip::close_device() {
+void TTSimChip::close_device() {
     log_info(tt::LogEmulationDriver, "Sending exit signal to remote...");
     pfn_libttsim_exit();
 }
 
-void TTSimulationChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) {
+void TTSimChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) {
     std::lock_guard<std::mutex> lock(device_lock);
     log_debug(tt::LogEmulationDriver, "Device writing {} bytes to l1_dest {} in core {}", size, l1_dest, core.str());
     tt_xy_pair translate_core = soc_descriptor_.translate_coord_to(core, CoordSystem::TRANSLATED);
     pfn_libttsim_tile_wr_bytes(translate_core.x, translate_core.y, l1_dest, src, size);
 }
 
-void TTSimulationChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) {
+void TTSimChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) {
     std::lock_guard<std::mutex> lock(device_lock);
     tt_xy_pair translate_core = soc_descriptor_.translate_coord_to(core, CoordSystem::TRANSLATED);
     pfn_libttsim_tile_rd_bytes(translate_core.x, translate_core.y, l1_src, dest, size);
     pfn_libttsim_clock(10);
 }
 
-void TTSimulationChip::send_tensix_risc_reset(tt_xy_pair translated_core, const TensixSoftResetOptions& soft_resets) {
+void TTSimChip::send_tensix_risc_reset(tt_xy_pair translated_core, const TensixSoftResetOptions& soft_resets) {
     std::lock_guard<std::mutex> lock(device_lock);
     if ((libttsim_pci_device_id == 0x401E) || (libttsim_pci_device_id == 0xB140)) {  // WH/BH
         uint32_t soft_reset_addr = architecture_impl_->get_tensix_soft_reset_addr();
@@ -87,11 +88,11 @@ void TTSimulationChip::send_tensix_risc_reset(tt_xy_pair translated_core, const 
     }
 }
 
-void TTSimulationChip::send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) {
+void TTSimChip::send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) {
     Chip::send_tensix_risc_reset(soft_resets);
 }
 
-void TTSimulationChip::assert_risc_reset(CoreCoord core, const RiscType selected_riscs) {
+void TTSimChip::assert_risc_reset(CoreCoord core, const RiscType selected_riscs) {
     std::lock_guard<std::mutex> lock(device_lock);
     log_debug(tt::LogEmulationDriver, "Sending 'assert_risc_reset' signal for risc_type {}", selected_riscs);
     TT_THROW("Untested implementation of assert_risc_reset, test and then enable");
@@ -104,7 +105,7 @@ void TTSimulationChip::assert_risc_reset(CoreCoord core, const RiscType selected
     pfn_libttsim_tile_wr_bytes(translate_core.x, translate_core.y, soft_reset_addr, &reset_value, sizeof(reset_value));
 }
 
-void TTSimulationChip::deassert_risc_reset(CoreCoord core, const RiscType selected_riscs, bool staggered_start) {
+void TTSimChip::deassert_risc_reset(CoreCoord core, const RiscType selected_riscs, bool staggered_start) {
     std::lock_guard<std::mutex> lock(device_lock);
     log_debug(tt::LogEmulationDriver, "Sending 'deassert_risc_reset' signal for risc_type {}", selected_riscs);
     TT_THROW("Untested implementation of deassert_risc_reset, test and then enable");


### PR DESCRIPTION
### Issue
Follow up from https://github.com/tenstorrent/tt-umd/pull/1364

### Description
I wrongly changed only tt_simulation_chip.cpp to tt_sim_chip.cpp, without changing the class name and header file. Cursor changed it like this, and I didn't check.

### List of the changes
- Rename all tt_simulation_ to tt_sim_
- Rename TTSimulationChip to TTSimChip

### Testing
Code builds

### API Changes
There are no API changes in this PR.
