### PR TITLE
Add function to PCIDevice to get architecture

### DIFF
--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -245,6 +245,13 @@ public:
      */
     static bool is_mapping_buffer_to_noc_supported();
 
+    /**
+     * Get the architecture of the PCIe device driver. The function enumerates PCIe devices on the system
+     * and returns the architecture of the first device it finds. If no devices are found, returns Invalid architecture.
+     * It also caches the value so subsequent calls are faster.
+     */
+    static tt::ARCH get_pcie_arch();
+
 public:
     // TODO: we can and should make all of these private.
     void *bar0_uc = nullptr;

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -848,4 +848,20 @@ void PCIDevice::allocate_pcie_dma_buffer() {
     }
 }
 
+tt::ARCH PCIDevice::get_pcie_arch() {
+    static bool enumerated_devices = false;
+    static tt::ARCH cached_arch = tt::ARCH::Invalid;
+    if (!enumerated_devices) {
+        auto devices = PCIDevice::enumerate_devices_info();
+        if (devices.empty()) {
+            return tt::ARCH::Invalid;
+        }
+        enumerated_devices = true;
+        cached_arch = devices.begin()->second.get_arch();
+        return cached_arch;
+    }
+
+    return cached_arch;
+}
+
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue

Splitting PR #959 

### Description

Add static function to PCIDevice which returns architectures of the chip connected to a system. It also caches the architecture so the subsequent calls are fast

### List of the changes

- Add static function to PCIDevice which gets architecture
- Cache returned value for subsequent calls

### Testing
/

### API Changes
/
