### PR TITLE
Move ETH FW version check to TopologyDiscovery

### DIFF
--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -691,11 +691,10 @@ private:
         const std::set<chip_id_t>& chips_to_exclude);
 
     // Test functions
+    // TODO: Move this check to TopologyDiscovery
     void verify_fw_bundle_version();
     void log_device_summary();
     void log_pci_device_summary();
-    void verify_eth_fw();
-    void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions);
     void verify_sysmem_initialized();
 
     // Helper functions for constructing the chips from the cluster descriptor.

--- a/device/api/umd/device/cluster_descriptor.hpp
+++ b/device/api/umd/device/cluster_descriptor.hpp
@@ -310,6 +310,8 @@ private:
 
     // Bus ID needs to be cached in cluster descriptor for use to pin chip location for UBB trays
     std::unordered_map<chip_id_t, uint16_t> chip_to_bus_id = {};
+
+    tt_version eth_fw_version;
 };
 
 using tt_ClusterDescriptor = ClusterDescriptor;

--- a/device/api/umd/device/topology/topology_discovery.hpp
+++ b/device/api/umd/device/topology/topology_discovery.hpp
@@ -12,6 +12,7 @@
 #include "umd/device/cluster_descriptor.hpp"
 #include "umd/device/tt_device/remote_wormhole_tt_device.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/cluster_types.hpp"
 
 namespace tt::umd {
 
@@ -147,6 +148,10 @@ protected:
     const IODeviceType io_device_type;
 
     bool is_running_on_6u = false;
+
+    // The ETH FW version found on the first discovered local chip, that needs
+    // to match with all of the other discovered ETH FW versions on all chips.
+    std::optional<tt_version> first_eth_fw_version;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/types/cluster_types.hpp
+++ b/device/api/umd/device/types/cluster_types.hpp
@@ -188,15 +188,15 @@ struct tt_version {
     std::uint8_t minor = 0xff;
     std::uint8_t patch = 0xff;
 
-    tt_version() {}
+    constexpr tt_version() {}
 
-    tt_version(std::uint16_t major_, std::uint8_t minor_, std::uint8_t patch_) {
+    constexpr tt_version(std::uint16_t major_, std::uint8_t minor_, std::uint8_t patch_) {
         major = major_;
         minor = minor_;
         patch = patch_;
     }
 
-    tt_version(std::uint32_t version) {
+    constexpr tt_version(std::uint32_t version) {
         major = (version >> 16) & 0xff;
         minor = (version >> 12) & 0xf;
         patch = version & 0xfff;
@@ -209,12 +209,19 @@ constexpr inline bool operator==(const tt_version& a, const tt_version& b) {
     return a.major == b.major && a.minor == b.minor && a.patch == b.patch;
 }
 
+constexpr inline bool operator!=(const tt_version& a, const tt_version& b) { return !(a == b); }
+
 constexpr inline bool operator>=(const tt_version& a, const tt_version& b) {
     bool fw_major_greater = a.major > b.major;
     bool fw_minor_greater = (a.major == b.major) && (a.minor > b.minor);
     bool patch_greater_or_equal = (a.major == b.major) && (a.minor == b.minor) && (a.patch >= b.patch);
     return fw_major_greater || fw_minor_greater || patch_greater_or_equal;
 }
+
+// ERISC FW version Required by UMD
+static constexpr tt_version ERISC_FW_SUPPORTED_VERSION_MIN = tt_version(0x06060000);
+static constexpr tt_version ERISC_FW_ETH_BROADCAST_SUPPORTED_MIN = tt_version(6, 5, 0);
+static constexpr tt_version ERISC_FW_ETH_BROADCAST_VIRTUAL_COORDS_MIN = tt_version(6, 8, 0);
 
 struct HugepageMapping {
     void* mapping = nullptr;


### PR DESCRIPTION
### Issue
#1413

### Description
Right now, this check happens late, in `construct_cluster()` which happens after a `ClusterDescriptor` was created by TopologyDiscovery.

To better accommodate Exalens's ask for making `create_cluster_descriptor()` resilient, we need to make this ETH FW check happen earlier in the code, before discovery of remote chips.
When there is a problem with ETH firmware, we should be able to allow `TopologyDiscovery` to create a cluster only with local chips.

### List of the changes
- Made `tt_version` constructors constexpr
- Added cluster `eth_fw_version` to ClusterDescriptor
- Changed poorly named `SW_VERSION` constant to `ERISC_FW_SUPPORTED_VERSION_MIN` in `cluster_types.hpp` along with other relevant ETH FW versions
- Removed `verify_eth_fw()` and `verify_sw_fw_versions()` from `Cluster` and moved them to relevant locations in TopologyDiscovery

### Testing
CI

### API Changes
There are no API changes in this PR.