### PR TITLE
Lower AICLK default wait

### DIFF
--- a/device/api/umd/device/chip/chip.hpp
+++ b/device/api/umd/device/chip/chip.hpp
@@ -135,7 +135,7 @@ protected:
 
     uint32_t get_power_state_arc_msg(DevicePowerState state);
 
-    void wait_for_aiclk_value(TTDevice* tt_device, DevicePowerState power_state, const uint32_t timeout_ms = 5000);
+    void wait_for_aiclk_value(TTDevice* tt_device, DevicePowerState power_state, const uint32_t timeout_ms = 100);
 
     ChipInfo chip_info_;
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/1409

### Description
Reduce wait from 5000ms to 100ms when waiting on aiclk to settle.
The issue is that we don't have aiclk raise implemented (intentionally) on a configuration, and this is increasing startup time by a lot.

### List of the changes
- Change default wait

### Testing
No testing

### API Changes
There are no API changes in this PR.
