### PR TITLE
Add caching of TLBs in Chip class

### DIFF
--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -9,6 +9,7 @@
 #include "umd/device/chip/chip.hpp"
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/chip_helpers/tlb_manager.hpp"
+#include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/types/communication_protocol.hpp"
 
@@ -105,5 +106,17 @@ private:
     void insert_host_to_device_barrier(const std::vector<CoreCoord>& cores, const uint32_t barrier_addr);
 
     std::unique_ptr<TTDevice> tt_device_ = nullptr;
+
+    TlbWindow* get_cached_wc_tlb_window(tlb_data config);
+    TlbWindow* get_cached_uc_tlb_window(tlb_data config);
+    TlbWindow* get_cached_pcie_dma_tlb_window(tlb_data config);
+
+    std::unique_ptr<TlbWindow> cached_wc_tlb_window = nullptr;
+    std::unique_ptr<TlbWindow> cached_uc_tlb_window = nullptr;
+    std::unique_ptr<TlbWindow> cached_pcie_dma_tlb_window = nullptr;
+
+    std::mutex wc_tlb_lock;
+    std::mutex uc_tlb_lock;
+    std::mutex pcie_dma_lock;
 };
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue

Splitting #959 

### Description

Add caching of TLBs inside Chip class. This is going to be used when we fully integrate TLBs from KMD. Chip will need to cache TLBs in order to not always map and unmap the TLBs from KMD. Chip will map one WC TLB for memory access (L1, DRAM etc...) and one UC TLB for register access. 

### List of the changes

- Add field for cached TLB WC and UC
- Add method for getting cached TLB

### Testing
This was tested as part of #959 

### API Changes
/
