### PR TITLE
Add caching of TLB to TTDevice class

### DIFF
--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -17,6 +17,7 @@
 #include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/utils/lock_manager.hpp"
 
@@ -341,6 +342,12 @@ private:
     virtual void pre_init_hook(){};
 
     virtual void post_init_hook(){};
+
+    std::unique_ptr<TlbWindow> cached_tlb_window = nullptr;
+
+    TlbWindow *get_cached_tlb_window(tlb_data config);
+
+    std::mutex tt_device_io_lock;
 };
 
 }  // namespace tt::umd

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -607,4 +607,13 @@ void TTDevice::set_risc_reset_state(tt_xy_pair core, const uint32_t risc_flags) 
 
 tt_xy_pair TTDevice::get_arc_core() const { return arc_core; }
 
+TlbWindow *TTDevice::get_cached_tlb_window(tlb_data config) {
+    if (cached_tlb_window == nullptr) {
+        cached_tlb_window =
+            std::make_unique<TlbWindow>(get_pci_device()->allocate_tlb(1 << 21, TlbMapping::UC), config);
+        return cached_tlb_window.get();
+    }
+    cached_tlb_window->configure(config);
+    return cached_tlb_window.get();
+}
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue

Splitting #959  

### Description

Add caching of TLBs inside TTDevice class. This is needed for UMD to not always map/unmap TLBs that it gets from KMD, since this is quite slow. There is only one UC TLB cached for all accesses.

### List of the changes

- Add field for cached TLB inside TTDevice
- Add method for getting cached TLB when needed

### Testing
Tested as part of #959 

### API Changes
/