### PR TITLE
Add P300 runner to UMD CI

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -79,6 +79,8 @@ jobs:
           {arch: wormhole_b0, card: tt-ubuntu-2204-n300-llmbox-viommu-stable},
           {arch: blackhole, card: tt-ubuntu-2204-p150b-stable},
           {arch: blackhole, card: tt-ubuntu-2204-p150b-viommu-stable},
+          # bh-gh-07 is a P300 runner.
+          {arch: blackhole, card: bh-gh-07},
           {arch: baremetal, card: ubuntu-22.04},
         ]
         ubuntu-docker-version: [

--- a/.github/workflows/test-runner.yaml
+++ b/.github/workflows/test-runner.yaml
@@ -27,7 +27,8 @@ jobs:
           tt-ubuntu-2204-n300-llmbox-stable,
           tt-ubuntu-2204-n300-llmbox-viommu-stable,
           tt-ubuntu-2204-p150b-stable,
-          tt-ubuntu-2204-p150b-viommu-stable]
+          tt-ubuntu-2204-p150b-viommu-stable,
+          bh-gh-07]
 
     name: Check runner
     runs-on: ${{ matrix.machine }}
@@ -88,7 +89,8 @@ jobs:
           tt-ubuntu-2204-n300-llmbox-stable,
           tt-ubuntu-2204-n300-llmbox-viommu-stable,
           tt-ubuntu-2204-p150b-stable,
-          tt-ubuntu-2204-p150b-viommu-stable]
+          tt-ubuntu-2204-p150b-viommu-stable,
+          bh-gh-07]
         image: [tt-umd-ci-ubuntu-22.04, tt-umd-ci-ubuntu-24.04]
 
     name: Check runner docker


### PR DESCRIPTION
### Issue

Add P300 machine to CI

### Description

Add P300 runner to UMD CI, one out of 3 that was dedicated to metal. This machine is shared with tt-metal team

### List of the changes

- Add P300 runner (bh gh 07) to list of runner and run blackhole tests on it

### Testing
CI

### API Changes
/
