### PR TITLE
Remote TTSim assert/deassert throw

### DIFF
--- a/device/simulation/tt_sim_chip.cpp
+++ b/device/simulation/tt_sim_chip.cpp
@@ -94,7 +94,6 @@ void TTSimulationChip::send_tensix_risc_reset(const TensixSoftResetOptions& soft
 void TTSimulationChip::assert_risc_reset(CoreCoord core, const RiscType selected_riscs) {
     std::lock_guard<std::mutex> lock(device_lock);
     log_debug(tt::LogEmulationDriver, "Sending 'assert_risc_reset' signal for risc_type {}", selected_riscs);
-    TT_THROW("Untested implementation of assert_risc_reset, test and then enable");
     tt_xy_pair translate_core = soc_descriptor_.translate_coord_to(core, CoordSystem::TRANSLATED);
     uint32_t soft_reset_addr = architecture_impl_->get_tensix_soft_reset_addr();
     uint32_t soft_reset_update = architecture_impl_->get_soft_reset_reg_value(selected_riscs);
@@ -107,7 +106,6 @@ void TTSimulationChip::assert_risc_reset(CoreCoord core, const RiscType selected
 void TTSimulationChip::deassert_risc_reset(CoreCoord core, const RiscType selected_riscs, bool staggered_start) {
     std::lock_guard<std::mutex> lock(device_lock);
     log_debug(tt::LogEmulationDriver, "Sending 'deassert_risc_reset' signal for risc_type {}", selected_riscs);
-    TT_THROW("Untested implementation of deassert_risc_reset, test and then enable");
     tt_xy_pair translate_core = soc_descriptor_.translate_coord_to(core, CoordSystem::TRANSLATED);
     uint32_t soft_reset_addr = architecture_impl_->get_tensix_soft_reset_addr();
     uint32_t soft_reset_update = architecture_impl_->get_soft_reset_reg_value(selected_riscs);


### PR DESCRIPTION
### Issue
Needed to unblock https://github.com/tenstorrent/tt-metal/pull/30260

### Description
Enable new assert/deassert path for ttsim.
It is functional, just blocked with these throws. 

### List of the changes
- Remove TT_THROW in assert deassert for ttsim chip

### Testing
You can see a passing ttsim-integrations pipelines on referenced tt-metal change

### API Changes
There are no API changes in this PR.
