### PR TITLE
Fix bug with NOC1 on 6U galaxy

### DIFF
--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -60,10 +60,10 @@ void Chip::wait_eth_cores_training(const uint32_t timeout_ms) {
     TTDevice* tt_device = get_tt_device();
     for (const CoreCoord& eth_core : eth_cores) {
         tt_xy_pair actual_eth_core = eth_core;
-        if (chip_info_.board_type == BoardType::UBB) {
-            // TODO issue 1208: figure out why translated ETH don't work on UBB
-            actual_eth_core =
-                soc_descriptor_.translate_coord_to(eth_core, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::NOC0);
+        if (get_tt_device()->get_arch() == tt::ARCH::WORMHOLE_B0) {
+            // Translated space for ETH cores is different than NOC1 and wait_eth_core training is expecting NOC0
+            // coordinates.
+            actual_eth_core = soc_descriptor_.translate_coord_to(eth_core, CoordSystem::NOC0);
         } else {
             actual_eth_core = translate_chip_coord_to_translated(eth_core);
         }


### PR DESCRIPTION
### Issue

#1430 

### Description

Fix bug with NOC1 test on 6U galaxy. Waiting for ETH core to start was assuming NOC0 cores always, so a fix was added to check for NOC1 channel as well.

### List of the changes

- Add finding the channel of ETH core even when NOC1 is used
- Populate the vector by coordinates in NOC1 space

### Testing
Local testing on 6u

### API Changes
/