### PR TITLE
Move soc descriptor serialize test out of baremetal

### DIFF
--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -749,6 +749,20 @@ TEST(TestCluster, DeassertResetWithCounterBrisc) {
     }
 }
 
+TEST(TestCluster, SocDescriptorSerialize) {
+    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
+
+    for (auto chip_id : umd_cluster->get_target_device_ids()) {
+        const SocDescriptor& soc_descriptor = umd_cluster->get_soc_descriptor(chip_id);
+
+        std::filesystem::path file_path = soc_descriptor.serialize_to_file();
+        SocDescriptor soc(
+            file_path.string(),
+            {.noc_translation_enabled = soc_descriptor.noc_translation_enabled,
+             .harvesting_masks = soc_descriptor.harvesting_masks});
+    }
+}
+
 TEST_P(ClusterAssertDeassertRiscsTest, TriscNcriscAssertDeassertTest) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 

--- a/tests/baremetal/test_soc_descriptor.cpp
+++ b/tests/baremetal/test_soc_descriptor.cpp
@@ -647,20 +647,6 @@ TEST(SocDescriptor, SocDescriptorBlackholeL2CPU) {
     EXPECT_EQ(soc_desc_arch.get_cores(CoreType::L2CPU).size(), 4);
 }
 
-TEST(SocDescriptor, SocDescriptorSerialize) {
-    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
-
-    for (auto chip_id : umd_cluster->get_target_device_ids()) {
-        const SocDescriptor& soc_descriptor = umd_cluster->get_soc_descriptor(chip_id);
-
-        std::filesystem::path file_path = soc_descriptor.serialize_to_file();
-        SocDescriptor soc(
-            file_path.string(),
-            {.noc_translation_enabled = soc_descriptor.noc_translation_enabled,
-             .harvesting_masks = soc_descriptor.harvesting_masks});
-    }
-}
-
 TEST(SocDescriptor, SerializeSimulatorBlackhole) {
     const SocDescriptor& soc_descriptor = SocDescriptor(
         test_utils::GetSocDescAbsPath("blackhole_simulation_1x2.yaml"),


### PR DESCRIPTION
### Issue

#1369 

### Description

Move soc descriptor serialize test to Cluster API test group. This was previously in baremetal tests which wasn't right place for it, since it creates Cluster object. I was not able to reproduce the error in the issue on P100, it might be that it got fixed by some other commit.

### List of the changes

- Move test to test_cluster.cpp

### Testing
CI

### API Changes
/