### PR TITLE
Fix too many open file descriptors due to locks

### DIFF
--- a/device/utils/robust_mutex.cpp
+++ b/device/utils/robust_mutex.cpp
@@ -111,39 +111,42 @@ void RobustMutex::initialize() {
     // multithread_mutex_ for all different RobustMutex instances which can affect perf of these operations, but that is
     // fine since this is executed rarely, only on initialization and only once after booting the system. Regarding
     // flock perf, this happens only when initializing the mutex, so it is not a big deal.
-    // The critical_section object will get destroyed at the end of this function or when an exception is thrown, so the
+    // The critical_section object will get destroyed at the end of this block or when an exception is thrown, so the
     // critical section will be released automatically.
-    CriticalSectionScopeGuard critical_section(shm_fd_, &multithread_mutex_, mutex_name_);
+    {
+        CriticalSectionScopeGuard critical_section(shm_fd_, &multithread_mutex_, mutex_name_);
 
-    // Resize file if needed.
-    bool file_was_resized = resize_shm_file();
+        // Resize file if needed.
+        bool file_was_resized = resize_shm_file();
 
-    // We now open the mutex in the shared memory file.
-    open_pthread_mutex();
+        // We now open the mutex in the shared memory file.
+        open_pthread_mutex();
 
-    // Report warning in case:
-    //  - File was not resized, but the initialized flag is wrong.
-    //  - File was resized, but the initialized flag is correct (this is a bit unexpected, but theoretically possible).
-    if (mutex_wrapper_ptr_->initialized != INITIALIZED_FLAG && !file_was_resized) {
-        log_warning(
-            tt::LogUMD,
-            "The file was already of correct size, but the initialized flag is wrong. This could "
-            "be due to previously failed initialization, or some other external factor. Mutex name: {}",
-            mutex_name_);
-    }
-    if (mutex_wrapper_ptr_->initialized == INITIALIZED_FLAG && file_was_resized) {
-        log_warning(
-            tt::LogUMD,
-            "The file was resized, but the initialized flag is correct. This is an unexpected "
-            "case, the mutex might fail. Mutex name: {}",
-            mutex_name_);
-    }
+        // Report warning in case:
+        //  - File was not resized, but the initialized flag is wrong.
+        //  - File was resized, but the initialized flag is correct (this is a bit unexpected, but theoretically
+        //  possible).
+        if (mutex_wrapper_ptr_->initialized != INITIALIZED_FLAG && !file_was_resized) {
+            log_warning(
+                tt::LogUMD,
+                "The file was already of correct size, but the initialized flag is wrong. This could "
+                "be due to previously failed initialization, or some other external factor. Mutex name: {}",
+                mutex_name_);
+        }
+        if (mutex_wrapper_ptr_->initialized == INITIALIZED_FLAG && file_was_resized) {
+            log_warning(
+                tt::LogUMD,
+                "The file was resized, but the initialized flag is correct. This is an unexpected "
+                "case, the mutex might fail. Mutex name: {}",
+                mutex_name_);
+        }
 
-    // Initialize the mutex if it wasn't properly initialized before.
-    if (mutex_wrapper_ptr_->initialized != INITIALIZED_FLAG) {
-        // We need to initialize the mutex here, since it is the first time it is being used.
-        initialize_pthread_mutex_first_use();
-    }
+        // Initialize the mutex if it wasn't properly initialized before.
+        if (mutex_wrapper_ptr_->initialized != INITIALIZED_FLAG) {
+            // We need to initialize the mutex here, since it is the first time it is being used.
+            initialize_pthread_mutex_first_use();
+        }
+    }  // CriticalSectionScopeGuard destructor is called here, releasing the flock and mutex
 
     // Close the file descriptor after mapping is complete.
     // The mapped memory will remain valid even after closing the fd.


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/28669

### Description
We should be able to close the underlying file while still having mmap valid. This should avoid the file descriptor limit.

### List of the changes
- Close shm file during initialization

### Testing
CI tests 
Manual test on BH GLX by @nhuang-tt 

### API Changes
There are no API changes in this PR.
