### PR TITLE
Improve TopologyDiscovery with getting ID for chips

### DIFF
--- a/device/api/umd/device/topology/topology_discovery.hpp
+++ b/device/api/umd/device/topology/topology_discovery.hpp
@@ -65,6 +65,8 @@ protected:
 
     uint64_t get_asic_id(Chip* chip);
 
+    virtual uint64_t get_unconnected_chip_id(Chip* chip) = 0;
+
     virtual std::optional<eth_coord_t> get_local_eth_coord(Chip* chip) = 0;
 
     virtual std::optional<eth_coord_t> get_remote_eth_coord(Chip* chip, tt_xy_pair eth_core) = 0;

--- a/device/api/umd/device/topology/topology_discovery_blackhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_blackhole.hpp
@@ -25,6 +25,8 @@ protected:
 
     uint64_t get_remote_asic_id(Chip* chip, tt_xy_pair eth_core) override;
 
+    uint64_t get_unconnected_chip_id(Chip* chip) override;
+
     std::optional<eth_coord_t> get_local_eth_coord(Chip* chip) override;
 
     std::optional<eth_coord_t> get_remote_eth_coord(Chip* chip, tt_xy_pair eth_core) override;

--- a/device/api/umd/device/topology/topology_discovery_wormhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_wormhole.hpp
@@ -43,6 +43,8 @@ protected:
 
     uint64_t get_remote_asic_id(Chip* chip, tt_xy_pair eth_core) override;
 
+    uint64_t get_unconnected_chip_id(Chip* chip) override;
+
     std::optional<eth_coord_t> get_local_eth_coord(Chip* chip) override;
 
     std::optional<eth_coord_t> get_remote_eth_coord(Chip* chip, tt_xy_pair eth_core) override;

--- a/device/api/umd/device/types/telemetry.hpp
+++ b/device/api/umd/device/types/telemetry.hpp
@@ -51,6 +51,8 @@ enum TelemetryTag : uint8_t {
     PCIE_USAGE = 38,
     NUMBER_OF_TAGS = 39,
     ASIC_LOCATION = 52,
+    ASIC_ID_HIGH = 61,
+    ASIC_ID_LOW = 62,
     AICLK_LIMIT_MAX = 63,
 };
 

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -330,7 +330,7 @@ uint64_t TopologyDiscovery::get_asic_id(Chip* chip) {
         return get_local_asic_id(chip, eth_core);
     }
 
-    return chip->get_tt_device()->get_board_id();
+    return get_unconnected_chip_id(chip);
 }
 
 void TopologyDiscovery::patch_eth_connections() {}

--- a/device/topology/topology_discovery_blackhole.cpp
+++ b/device/topology/topology_discovery_blackhole.cpp
@@ -286,4 +286,11 @@ void TopologyDiscoveryBlackhole::init_topology_discovery() {
     is_running_on_6u = tt_device->get_board_type() == BoardType::UBB_BLACKHOLE;
 }
 
+uint64_t TopologyDiscoveryBlackhole::get_unconnected_chip_id(Chip* chip) {
+    TTDevice* tt_device = chip->get_tt_device();
+    uint32_t asic_id_lo = tt_device->get_arc_telemetry_reader()->read_entry(TelemetryTag::ASIC_ID_LOW);
+    uint32_t asic_id_hi = tt_device->get_arc_telemetry_reader()->read_entry(TelemetryTag::ASIC_ID_HIGH);
+    return (static_cast<uint64_t>(asic_id_hi) << 32) | asic_id_lo;
+}
+
 }  // namespace tt::umd

--- a/device/topology/topology_discovery_wormhole.cpp
+++ b/device/topology/topology_discovery_wormhole.cpp
@@ -347,4 +347,8 @@ bool TopologyDiscoveryWormhole::is_intermesh_eth_link_trained(Chip* chip, tt_xy_
     return (status & link_connected_mask) == link_connected_mask;
 }
 
+uint64_t TopologyDiscoveryWormhole::get_unconnected_chip_id(Chip* chip) {
+    return chip->get_tt_device()->get_board_id();
+}
+
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue

#1464 

### Description

Even if I feel that this issue is not a UMD problem, rather galaxy not being flashed with proper FW, there is room for improvement for getting ID of the chips that are not connected to any other chips. So far we took board ID and that can be wrong when all chips are disconnected. 

### List of the changes

- Add function for getting ID of the chip that is not connected to other chips
- Take asic ID for blackhole
- Still take board ID for wormhole

### Testing
CI

### API Changes
/
