### PR TITLE
Added io_device_type to cluster serialization.

### DIFF
--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -1091,6 +1091,8 @@ std::string ClusterDescriptor::serialize() const {
     }
     out << YAML::EndSeq;
 
+    out << YAML::Key << "io_device_type" << YAML::Value << DeviceTypeToString.at(io_device_type);
+
     out << YAML::Key << "harvesting" << YAML::Value << YAML::BeginMap;
     std::set<chip_id_t> all_chips_map = std::set<chip_id_t>(all_chips.begin(), all_chips.end());
     for (const int &chip : all_chips_map) {


### PR DESCRIPTION
### Issue
 - tt-exalens used has_jtag_ flag in their system which they initialised by reading chips_with_jtag from serialised ClusterDescriptor. 
 - That flag however doesn't exist in ClusterDescriptor. Probably wasn't added and since cli commands that use it didn't work with JTAG it was completely forgotten.

### Description
 - This PR adds a io_device_type into ClusterDescriptor serialisation.