### PR TITLE
Remove incorrect '%s' in error message

### DIFF
--- a/device/simulation/tt_sim_chip.cpp
+++ b/device/simulation/tt_sim_chip.cpp
@@ -17,7 +17,7 @@
 #define DLSYM_FUNCTION(func_name)                                                    \
     pfn_##func_name = (decltype(pfn_##func_name))dlsym(libttsim_handle, #func_name); \
     if (!pfn_##func_name) {                                                          \
-        TT_THROW("Failed to find '%s' symbol: ", #func_name, dlerror());             \
+        TT_THROW("Failed to find symbol: ", #func_name, dlerror());                  \
     }
 
 namespace tt::umd {


### PR DESCRIPTION
### Issue
none

### Description
This '%s' didn't actually do anything, it just printed the actual text '%s'. The function name and dlerror() are already printed, and this stays the same.

### List of the changes
Removed '%s'.

### Testing
Ran Metal examples locally on ttsim

### API Changes
/