### PR TITLE
Modifications to support Ethernet Link Retraining

### DIFF
--- a/device/api/umd/device/topology/topology_discovery.hpp
+++ b/device/api/umd/device/topology/topology_discovery.hpp
@@ -87,9 +87,6 @@ protected:
     // ethernet channel for the remote chip on all board types).
     virtual uint32_t get_logical_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) = 0;
 
-    // eth_core should be in NoC 0 coordinates..
-    virtual uint32_t read_port_status(Chip* chip, tt_xy_pair eth_core) = 0;
-
     virtual bool is_using_eth_coords() = 0;
 
     // eth_core should be in NoC 0 coordinates.
@@ -100,9 +97,7 @@ protected:
 
     virtual void init_topology_discovery();
 
-    virtual bool is_eth_unconnected(Chip* chip, const tt_xy_pair eth_core) = 0;
-
-    virtual bool is_eth_unknown(Chip* chip, const tt_xy_pair eth_core) = 0;
+    virtual bool is_eth_trained(Chip* chip, const tt_xy_pair eth_core) = 0;
 
     // This is hack to report proper logical ETH IDs, since eth id on ETH core on Blackhole
     // does not take harvesting into consideration. This function will be overridden just for Blackhole.

--- a/device/api/umd/device/topology/topology_discovery_blackhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_blackhole.hpp
@@ -32,7 +32,7 @@ protected:
 
     tt_xy_pair get_remote_eth_core(Chip* chip, tt_xy_pair local_eth_core) override;
 
-    uint32_t read_port_status(Chip* chip, tt_xy_pair eth_core) override;
+    uint32_t read_port_status(Chip* chip, tt_xy_pair eth_core);
 
     uint32_t get_remote_eth_id(Chip* chip, tt_xy_pair local_eth_core) override;
 
@@ -50,9 +50,7 @@ protected:
 
     uint64_t mangle_asic_id(uint64_t board_id, uint8_t asic_location);
 
-    bool is_eth_unconnected(Chip* chip, const tt_xy_pair eth_core) override;
-
-    bool is_eth_unknown(Chip* chip, const tt_xy_pair eth_core) override;
+    bool is_eth_trained(Chip* chip, const tt_xy_pair eth_core) override;
 
     std::unique_ptr<RemoteChip> create_remote_chip(
         std::optional<EthCoord> eth_coord, Chip* gateway_chip, std::set<uint32_t> gateway_eth_channels) override;

--- a/device/api/umd/device/topology/topology_discovery_wormhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_wormhole.hpp
@@ -51,7 +51,7 @@ protected:
 
     tt_xy_pair get_remote_eth_core(Chip* chip, tt_xy_pair local_eth_core) override;
 
-    uint32_t read_port_status(Chip* chip, tt_xy_pair eth_core) override;
+    uint32_t read_training_status(Chip* chip, tt_xy_pair eth_core);
 
     uint32_t get_remote_eth_id(Chip* chip, tt_xy_pair local_eth_core) override;
 
@@ -72,13 +72,11 @@ protected:
 
     void init_topology_discovery() override;
 
-    bool is_eth_unconnected(Chip* chip, const tt_xy_pair eth_core) override;
-
-    bool is_eth_unknown(Chip* chip, const tt_xy_pair eth_core) override;
+    bool is_eth_trained(Chip* chip, const tt_xy_pair eth_core) override;
 
     EthAddresses eth_addresses;
 
-    static const uint32_t ETH_UNKNOWN = 0;
-    static const uint32_t ETH_UNCONNECTED = 1;
+    static constexpr uint32_t LINK_TRAIN_SUCCESS = 1;
+    static constexpr uint32_t LINK_TRAIN_TRAINING = 0;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -81,11 +81,10 @@ private:
         uint64_t erisc_remote_eth_id_offset;
     };
 
-    static constexpr uint32_t ETH_UNKNOWN = 0;
-    static constexpr uint32_t ETH_UNCONNECTED = 1;
+    static constexpr uint32_t LINK_TRAIN_TRAINING = 0;
 
     static EthAddresses get_eth_addresses(const uint32_t eth_fw_version);
-    uint32_t read_port_status(tt_xy_pair eth_core);
+    uint32_t read_training_status(tt_xy_pair eth_core);
 
     // Enforce single-threaded access, even though there are more serious issues
     // surrounding resource management as it relates to DMA.

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -136,7 +136,6 @@ void TopologyDiscovery::discover_remote_chips() {
             }
         }
     }
-
     while (!chips_to_discover.empty()) {
         auto it = chips_to_discover.begin();
         uint64_t current_chip_asic_id = it->first;
@@ -148,27 +147,12 @@ void TopologyDiscovery::discover_remote_chips() {
             chip->get_soc_descriptor().get_cores(CoreType::ETH, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::NOC0);
         TTDevice* tt_device = chip->get_tt_device();
 
-        std::vector<uint32_t> intermesh_eth_links;
-        if (eth_cores.size() > 0) {
-            intermesh_eth_links = extract_intermesh_eth_links(chip, eth_cores.front());
-        }
-
         uint32_t channel = 0;
         for (const CoreCoord& eth_core : eth_cores) {
-            uint32_t port_status = read_port_status(chip, eth_core);
-
-            if (is_eth_unknown(chip, eth_core) || is_eth_unconnected(chip, eth_core)) {
-                if (std::find(intermesh_eth_links.begin(), intermesh_eth_links.end(), channel) ==
-                    intermesh_eth_links.end()) {
-                    channel++;
-                    continue;
-                }
-                if (!is_intermesh_eth_link_trained(chip, eth_core)) {
-                    channel++;
-                    continue;
-                }
+            if (!is_eth_trained(chip, eth_core)) {
+                channel++;
+                continue;
             }
-
             active_eth_channels_per_chip.at(current_chip_asic_id).insert(channel);
 
             if (!is_board_id_included(get_remote_board_id(chip, eth_core), get_remote_board_type(chip, eth_core))) {
@@ -321,9 +305,7 @@ uint64_t TopologyDiscovery::get_asic_id(Chip* chip) {
         chip->get_soc_descriptor().get_cores(CoreType::ETH, umd_use_noc1 ? CoordSystem::NOC1 : CoordSystem::NOC0);
 
     for (const CoreCoord& eth_core : eth_cores) {
-        uint32_t port_status = read_port_status(chip, eth_core);
-
-        if (is_eth_unknown(chip, eth_core) || is_eth_unconnected(chip, eth_core)) {
+        if (!is_eth_trained(chip, eth_core)) {
             continue;
         }
 

--- a/device/topology/topology_discovery_blackhole.cpp
+++ b/device/topology/topology_discovery_blackhole.cpp
@@ -182,13 +182,8 @@ uint64_t TopologyDiscoveryBlackhole::mangle_asic_id(uint64_t board_id, uint8_t a
     return ((board_id << 5) | (asic_location & 0x1F));
 }
 
-bool TopologyDiscoveryBlackhole::is_eth_unconnected(Chip* chip, const tt_xy_pair eth_core) {
-    return read_port_status(chip, eth_core) == blackhole::port_status_e::PORT_UNUSED;
-}
-
-bool TopologyDiscoveryBlackhole::is_eth_unknown(Chip* chip, const tt_xy_pair eth_core) {
-    uint32_t port_status = read_port_status(chip, eth_core);
-    return port_status == blackhole::port_status_e::PORT_UNKNOWN || port_status == blackhole::port_status_e::PORT_DOWN;
+bool TopologyDiscoveryBlackhole::is_eth_trained(Chip* chip, const tt_xy_pair eth_core) {
+    return read_port_status(chip, eth_core) == blackhole::port_status_e::PORT_UP;
 }
 
 void TopologyDiscoveryBlackhole::patch_eth_connections() {
@@ -239,9 +234,7 @@ void TopologyDiscoveryBlackhole::initialize_remote_communication(Chip* chip) {
     std::unordered_map<uint64_t, std::vector<CoreCoord>> remote_asic_ids_to_eth_cores;
 
     for (const auto& eth_core : eth_cores) {
-        uint32_t port_status = read_port_status(chip, eth_core);
-
-        if (is_eth_unknown(chip, eth_core) || is_eth_unconnected(chip, eth_core)) {
+        if (!is_eth_trained(chip, eth_core)) {
             continue;
         }
 

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -429,10 +429,8 @@ uint32_t WormholeTTDevice::wait_eth_core_training(const tt_xy_pair eth_core, con
         }
     }
 
-    uint32_t port_status = read_port_status(eth_core);
     start = std::chrono::system_clock::now();
-    while (port_status == ETH_UNKNOWN) {
-        port_status = read_port_status(eth_core);
+    while (read_training_status(eth_core) == LINK_TRAIN_TRAINING) {
         auto end = std::chrono::system_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
         time_taken_port = duration.count();
@@ -449,19 +447,15 @@ uint32_t WormholeTTDevice::wait_eth_core_training(const tt_xy_pair eth_core, con
 
 uint64_t WormholeTTDevice::get_arc_noc_base_address() const { return wormhole::ARC_NOC_XBAR_ADDRESS_START; }
 
-uint32_t WormholeTTDevice::read_port_status(tt_xy_pair eth_core) {
-    uint32_t channel = std::distance(
-        wormhole::ETH_CORES_NOC0.begin(),
-        std::find(wormhole::ETH_CORES_NOC0.begin(), wormhole::ETH_CORES_NOC0.end(), eth_core));
-
-    uint32_t port_status;
+uint32_t WormholeTTDevice::read_training_status(tt_xy_pair eth_core) {
+    uint32_t training_status;
     read_from_device(
-        &port_status,
+        &training_status,
         umd_use_noc1 ? tt_xy_pair(wormhole::NOC0_X_TO_NOC1_X[eth_core.x], wormhole::NOC0_Y_TO_NOC1_Y[eth_core.y])
                      : eth_core,
-        eth_addresses.eth_conn_info + (channel * 4),
+        0x1104,
         sizeof(uint32_t));
-    return port_status;
+    return training_status;
 }
 
 WormholeTTDevice::EthAddresses WormholeTTDevice::get_eth_addresses(const uint32_t eth_fw_version) {


### PR DESCRIPTION
### Issue
No Ticket.

### Description
-  Wormhole Changes
   - Topology Discovery relies on the Port Connection Table populated by ERISC Base Firmware to query Ethernet Link status
   - ERISC FW 7.2.0 supports directed ethernet links retraining. Once a links is successfully retrained, its training status is modified, however this is not reflected in the Port Connection table
   - Thus, in order to support real-time link retraining, we must modify how active links are queried in `topology_discovery.cpp`
   - This PR removes the reliance of `topology_discovery.cpp` on `read_port_status`, which looks up the channel in the Port Connection Table
   - Instead, we query the Link Train status, to determine if a Link is Up, currently being trained or down

- Blackhole Changes
   - No functional changes, since we were already relying on training status values to query links
   - Renamed and cleaned up APIs to be consistent with WH changes



### List of the changes
- Make `topology_discovery` query Link Training status using `is_eth_trained` API, instead of using `is_eth_unknown` and `is_eth_unconnected`
- Modify `wormhole_tt_device::wait_eth_core_training` and `blackhole_tt_device::wait_eth_core_training` to monitor link training status using `is_eth_link_trained`
- Remove  `read_port_status`m `is_eth_unknown` and `is_eth_unconnected` APIs, since they're now unused

### Testing
- Upstreamed to TT-Metal and tested

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
