### PR TITLE
Consolidate constexpr in architecture header files

### DIFF
--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -18,7 +18,7 @@ namespace tt::umd {
 
 namespace blackhole {
 
-static constexpr auto TLB_2M_OFFSET = tlb_offsets{
+inline constexpr auto TLB_2M_OFFSET = tlb_offsets{
     .local_offset = 0,
     .x_end = 43,
     .y_end = 49,
@@ -32,7 +32,7 @@ static constexpr auto TLB_2M_OFFSET = tlb_offsets{
     // missing .stream_header
     .static_vc_end = 75};
 
-static constexpr auto TLB_4G_OFFSET = tlb_offsets{
+inline constexpr auto TLB_4G_OFFSET = tlb_offsets{
     .local_offset = 0,
     .x_end = 32,
     .y_end = 38,
@@ -60,7 +60,7 @@ enum class arc_message_type {
 };
 
 // DEVICE_DATA
-static const tt_xy_pair GRID_SIZE = {17, 12};
+inline constexpr tt_xy_pair GRID_SIZE = {17, 12};
 // Vectors for mapping NOC0 x and y coordinates to NOC1 x and y coordinates.
 // NOC0_X_TO_NOC1_X[noc0_x] is the NOC1 x coordinate corresponding to NOC0 x coordinate noc0_x.
 // NOC0_Y_TO_NOC1_Y[noc0_y] is the NOC1 y coordinate corresponding to NOC0 y coordinate noc0_y.
@@ -82,9 +82,9 @@ const static std::vector<tt_xy_pair> TENSIX_CORES_NOC0 = {
 };
 // clang-format on
 
-const std::size_t NUM_DRAM_BANKS = 8;
-const std::size_t NUM_NOC_PORTS_PER_DRAM_BANK = 3;
-static const tt_xy_pair DRAM_GRID_SIZE = {NUM_DRAM_BANKS, NUM_NOC_PORTS_PER_DRAM_BANK};
+inline constexpr std::size_t NUM_DRAM_BANKS = 8;
+inline constexpr std::size_t NUM_NOC_PORTS_PER_DRAM_BANK = 3;
+inline constexpr tt_xy_pair DRAM_GRID_SIZE = {NUM_DRAM_BANKS, NUM_NOC_PORTS_PER_DRAM_BANK};
 // clang-format off
 static const std::vector<std::vector<tt_xy_pair>> DRAM_CORES_NOC0 = {
     {{0, 0},  {0, 1}, {0, 11}},
@@ -100,11 +100,11 @@ static const std::vector<std::vector<tt_xy_pair>> DRAM_CORES_NOC0 = {
 // the existing code in clients which rely on DRAM_LOCATIONS.
 static const std::vector<tt_xy_pair> DRAM_LOCATIONS = flatten_vector(DRAM_CORES_NOC0);
 
-static const tt_xy_pair ARC_GRID_SIZE = {1, 1};
+inline constexpr tt_xy_pair ARC_GRID_SIZE = {1, 1};
 static const std::vector<tt_xy_pair> ARC_CORES_NOC0 = {{8, 0}};
 static const std::vector<tt_xy_pair> ARC_LOCATIONS = ARC_CORES_NOC0;
 
-static const tt_xy_pair PCIE_GRID_SIZE = {2, 1};
+inline constexpr tt_xy_pair PCIE_GRID_SIZE = {2, 1};
 static const std::vector<tt_xy_pair> PCIE_CORES_TYPE2_NOC0 = {{{2, 0}}};
 static const std::vector<tt_xy_pair> PCI_LOCATIONS = PCIE_CORES_TYPE2_NOC0;
 static const std::vector<tt_xy_pair> PCIE_CORES_TYPE1_NOC0 = {{{11, 0}}};
@@ -130,7 +130,7 @@ static const std::vector<tt_xy_pair> ROUTER_CORES_NOC0 = {
     {8, 4},
     {8, 11}};
 
-static const size_t NUM_ETH_CHANNELS = 14;
+inline constexpr size_t NUM_ETH_CHANNELS = 14;
 static const std::vector<tt_xy_pair> ETH_CORES_NOC0 = {
     {{1, 1},
      {16, 1},
@@ -159,108 +159,108 @@ static const std::vector<uint32_t> T6_Y_LOCATIONS = {2, 3, 4, 5, 6, 7, 8, 9, 10,
 static const std::vector<uint32_t> HARVESTING_NOC_LOCATIONS = {1, 16, 2, 15, 3, 14, 4, 13, 5, 12, 6, 11, 7, 10};
 static const std::vector<uint32_t> LOGICAL_HARVESTING_LAYOUT = {0, 2, 4, 6, 8, 10, 12, 13, 11, 9, 7, 5, 3, 1};
 
-static constexpr uint32_t STATIC_TLB_SIZE = 1024 * 1024;  // TODO: Copied from wormhole. Need to verify.
+inline constexpr uint32_t STATIC_TLB_SIZE = 1024 * 1024;  // TODO: Copied from wormhole. Need to verify.
 
-static constexpr xy_pair BROADCAST_LOCATION = {0, 0};  // TODO: Copied from wormhole. Need to verify.
-static constexpr uint32_t BROADCAST_TLB_INDEX = 0;     // TODO: Copied from wormhole. Need to verify.
-static constexpr uint32_t STATIC_TLB_CFG_ADDR = 0x1fc00000;
+inline constexpr xy_pair BROADCAST_LOCATION = {0, 0};  // TODO: Copied from wormhole. Need to verify.
+inline constexpr uint32_t BROADCAST_TLB_INDEX = 0;     // TODO: Copied from wormhole. Need to verify.
+inline constexpr uint32_t STATIC_TLB_CFG_ADDR = 0x1fc00000;
 
-static constexpr uint32_t TLB_COUNT_2M = 202;
-static constexpr uint32_t TLB_BASE_2M = 0;  // 0 in BAR0
-static constexpr uint32_t TLB_BASE_INDEX_2M = 0;
-static constexpr uint32_t TLB_2M_SIZE = 2 * 1024 * 1024;
+inline constexpr uint32_t TLB_COUNT_2M = 202;
+inline constexpr uint32_t TLB_BASE_2M = 0;  // 0 in BAR0
+inline constexpr uint32_t TLB_BASE_INDEX_2M = 0;
+inline constexpr uint32_t TLB_2M_SIZE = 2 * 1024 * 1024;
 
-static constexpr uint32_t TLB_CFG_REG_SIZE_BYTES = 12;
+inline constexpr uint32_t TLB_CFG_REG_SIZE_BYTES = 12;
 
-static constexpr uint32_t TLB_COUNT_4G = 8;
-static constexpr uint32_t TLB_BASE_4G = 0;  // 0 in BAR4
-static constexpr uint32_t TLB_BASE_INDEX_4G = TLB_COUNT_2M;
-static constexpr uint64_t TLB_4G_SIZE = 4ULL * 1024ULL * 1024ULL * 1024ULL;
-static constexpr uint64_t DYNAMIC_TLB_4G_SIZE = TLB_4G_SIZE;
-static constexpr uint32_t DYNAMIC_TLB_4G_CFG_ADDR = STATIC_TLB_CFG_ADDR + (TLB_BASE_INDEX_4G * TLB_CFG_REG_SIZE_BYTES);
-static constexpr uint32_t DYNAMIC_TLB_4G_BASE = TLB_BASE_4G;
+inline constexpr uint32_t TLB_COUNT_4G = 8;
+inline constexpr uint32_t TLB_BASE_4G = 0;  // 0 in BAR4
+inline constexpr uint32_t TLB_BASE_INDEX_4G = TLB_COUNT_2M;
+inline constexpr uint64_t TLB_4G_SIZE = 4ULL * 1024ULL * 1024ULL * 1024ULL;
+inline constexpr uint64_t DYNAMIC_TLB_4G_SIZE = TLB_4G_SIZE;
+inline constexpr uint32_t DYNAMIC_TLB_4G_CFG_ADDR = STATIC_TLB_CFG_ADDR + (TLB_BASE_INDEX_4G * TLB_CFG_REG_SIZE_BYTES);
+inline constexpr uint32_t DYNAMIC_TLB_4G_BASE = TLB_BASE_4G;
 
-static constexpr uint32_t DYNAMIC_TLB_COUNT = 16;
+inline constexpr uint32_t DYNAMIC_TLB_COUNT = 16;
 
-static constexpr uint32_t DYNAMIC_TLB_2M_SIZE = 2 * 1024 * 1024;
-static constexpr uint32_t DYNAMIC_TLB_2M_CFG_ADDR = STATIC_TLB_CFG_ADDR + (TLB_BASE_INDEX_2M * TLB_CFG_REG_SIZE_BYTES);
-static constexpr uint32_t DYNAMIC_TLB_2M_BASE = TLB_BASE_2M;
+inline constexpr uint32_t DYNAMIC_TLB_2M_SIZE = 2 * 1024 * 1024;
+inline constexpr uint32_t DYNAMIC_TLB_2M_CFG_ADDR = STATIC_TLB_CFG_ADDR + (TLB_BASE_INDEX_2M * TLB_CFG_REG_SIZE_BYTES);
+inline constexpr uint32_t DYNAMIC_TLB_2M_BASE = TLB_BASE_2M;
 
 // REG_TLB for dynamic writes to registers. They are aligned with the kernel driver's WC/UC split.  But kernel driver
 // uses different TLB's for these.
 // Revisit for BH
-static constexpr unsigned int REG_TLB = TLB_BASE_INDEX_2M + 191;
+inline constexpr unsigned int REG_TLB = TLB_BASE_INDEX_2M + 191;
 
-static constexpr uint32_t DYNAMIC_TLB_BASE_INDEX = TLB_BASE_INDEX_2M + 180;
-static constexpr unsigned int MEM_LARGE_WRITE_TLB = TLB_BASE_INDEX_2M + 181;
-static constexpr unsigned int MEM_LARGE_READ_TLB = TLB_BASE_INDEX_2M + 182;
-static constexpr unsigned int MEM_SMALL_READ_WRITE_TLB = TLB_BASE_INDEX_2M + 183;
+inline constexpr uint32_t DYNAMIC_TLB_BASE_INDEX = TLB_BASE_INDEX_2M + 180;
+inline constexpr unsigned int MEM_LARGE_WRITE_TLB = TLB_BASE_INDEX_2M + 181;
+inline constexpr unsigned int MEM_LARGE_READ_TLB = TLB_BASE_INDEX_2M + 182;
+inline constexpr unsigned int MEM_SMALL_READ_WRITE_TLB = TLB_BASE_INDEX_2M + 183;
 
-static constexpr uint32_t DRAM_CHANNEL_0_X = 0;
-static constexpr uint32_t DRAM_CHANNEL_0_Y = 1;
-static constexpr uint32_t DRAM_CHANNEL_0_PEER2PEER_REGION_START = 0x30000000;  // This is the last 256MB of DRAM
+inline constexpr uint32_t DRAM_CHANNEL_0_X = 0;
+inline constexpr uint32_t DRAM_CHANNEL_0_Y = 1;
+inline constexpr uint32_t DRAM_CHANNEL_0_PEER2PEER_REGION_START = 0x30000000;  // This is the last 256MB of DRAM
 
-static constexpr uint32_t GRID_SIZE_X = 17;
-static constexpr uint32_t GRID_SIZE_Y = 12;
+inline constexpr uint32_t GRID_SIZE_X = 17;
+inline constexpr uint32_t GRID_SIZE_Y = 12;
 
 // AXI Resets accessed through TLB
-static constexpr uint32_t TENSIX_SM_TLB_INDEX = 188;
-static constexpr uint32_t AXI_RESET_OFFSET = TLB_BASE_2M + TENSIX_SM_TLB_INDEX * TLB_2M_SIZE;
-static constexpr uint32_t ARC_RESET_ARC_MISC_CNTL_OFFSET = AXI_RESET_OFFSET + 0x0100;
+inline constexpr uint32_t TENSIX_SM_TLB_INDEX = 188;
+inline constexpr uint32_t AXI_RESET_OFFSET = TLB_BASE_2M + TENSIX_SM_TLB_INDEX * TLB_2M_SIZE;
+inline constexpr uint32_t ARC_RESET_ARC_MISC_CNTL_OFFSET = AXI_RESET_OFFSET + 0x0100;
 
 // Computed this value from AXI_RESET_OFFSET
-static constexpr uint32_t ARC_APB_BAR0_XBAR_OFFSET_START = 0x1FF00000;
+inline constexpr uint32_t ARC_APB_BAR0_XBAR_OFFSET_START = 0x1FF00000;
 
 // MT: This is no longer valid for Blackhole. Review messages to ARC
-static constexpr uint32_t ARC_CSM_OFFSET = 0x1FE80000;
-static constexpr uint32_t ARC_CSM_MAILBOX_OFFSET = ARC_CSM_OFFSET + 0x783C4;
-static constexpr uint32_t ARC_CSM_MAILBOX_SIZE_OFFSET = ARC_CSM_OFFSET + 0x784C4;
+inline constexpr uint32_t ARC_CSM_OFFSET = 0x1FE80000;
+inline constexpr uint32_t ARC_CSM_MAILBOX_OFFSET = ARC_CSM_OFFSET + 0x783C4;
+inline constexpr uint32_t ARC_CSM_MAILBOX_SIZE_OFFSET = ARC_CSM_OFFSET + 0x784C4;
 
-static constexpr uint32_t TENSIX_SOFT_RESET_ADDR = 0xFFB121B0;
+inline constexpr uint32_t TENSIX_SOFT_RESET_ADDR = 0xFFB121B0;
 
-static constexpr uint32_t RISCV_DEBUG_REG_DBG_BUS_CNTL_REG = 0xFFB12000 + 0x54;
+inline constexpr uint32_t RISCV_DEBUG_REG_DBG_BUS_CNTL_REG = 0xFFB12000 + 0x54;
 
-static constexpr uint32_t MSG_TYPE_SETUP_IATU_FOR_PEER_TO_PEER = 0x97;
+inline constexpr uint32_t MSG_TYPE_SETUP_IATU_FOR_PEER_TO_PEER = 0x97;
 
 static const uint32_t BH_NOC_NODE_ID_OFFSET = 0x1FD04044;
 
-constexpr uint64_t ARC_NOC_XBAR_ADDRESS_START = 0x80000000;
+inline constexpr uint64_t ARC_NOC_XBAR_ADDRESS_START = 0x80000000;
 
-static constexpr uint32_t ARC_RESET_UNIT_OFFSET = 0x30000;
-static constexpr uint32_t ARC_RESET_SCRATCH_OFFSET = ARC_RESET_UNIT_OFFSET + 0x0060;
-static constexpr uint32_t ARC_RESET_SCRATCH_2_OFFSET = ARC_RESET_SCRATCH_OFFSET + 0x8;
-static constexpr uint32_t ARC_RESET_REFCLK_LOW_OFFSET = ARC_RESET_UNIT_OFFSET + 0xE0;
-static constexpr uint32_t ARC_RESET_REFCLK_HIGH_OFFSET = ARC_RESET_UNIT_OFFSET + 0xE4;
+inline constexpr uint32_t ARC_RESET_UNIT_OFFSET = 0x30000;
+inline constexpr uint32_t ARC_RESET_SCRATCH_OFFSET = ARC_RESET_UNIT_OFFSET + 0x0060;
+inline constexpr uint32_t ARC_RESET_SCRATCH_2_OFFSET = ARC_RESET_SCRATCH_OFFSET + 0x8;
+inline constexpr uint32_t ARC_RESET_REFCLK_LOW_OFFSET = ARC_RESET_UNIT_OFFSET + 0xE0;
+inline constexpr uint32_t ARC_RESET_REFCLK_HIGH_OFFSET = ARC_RESET_UNIT_OFFSET + 0xE4;
 
 // Register from which address of the ARC queue control block is read.
-constexpr uint32_t SCRATCH_RAM_11 = ARC_RESET_UNIT_OFFSET + 0x42C;
+inline constexpr uint32_t SCRATCH_RAM_11 = ARC_RESET_UNIT_OFFSET + 0x42C;
 
 // ARC message queue header and entry size in bytes.
-constexpr uint32_t ARC_MSG_QUEUE_HEADER_SIZE = 32;
-constexpr uint32_t ARC_QUEUE_ENTRY_SIZE = 32;
+inline constexpr uint32_t ARC_MSG_QUEUE_HEADER_SIZE = 32;
+inline constexpr uint32_t ARC_QUEUE_ENTRY_SIZE = 32;
 
 // ARC firmware interrupt address and value to write in order
 // to make an interrupt request.
-constexpr uint32_t ARC_FW_INT_ADDR = ARC_RESET_UNIT_OFFSET + 0x100;
+inline constexpr uint32_t ARC_FW_INT_ADDR = ARC_RESET_UNIT_OFFSET + 0x100;
 constexpr uint32_t ARC_FW_INT_VAL = 65536;
 
-constexpr uint32_t ARC_MSG_RESPONSE_OK_LIMIT = 240;
+inline constexpr uint32_t ARC_MSG_RESPONSE_OK_LIMIT = 240;
 
-static const uint32_t SCRATCH_RAM_2 = ARC_RESET_UNIT_OFFSET + 0x408;
-static const uint32_t SCRATCH_RAM_12 = ARC_RESET_UNIT_OFFSET + 0x430;
-static const uint32_t SCRATCH_RAM_13 = ARC_RESET_UNIT_OFFSET + 0x434;
+inline constexpr uint32_t SCRATCH_RAM_2 = ARC_RESET_UNIT_OFFSET + 0x408;
+inline constexpr uint32_t SCRATCH_RAM_12 = ARC_RESET_UNIT_OFFSET + 0x430;
+inline constexpr uint32_t SCRATCH_RAM_13 = ARC_RESET_UNIT_OFFSET + 0x434;
 
-static const uint32_t NIU_CFG_NOC0_BAR_ADDR = 0x1FD04100;
-static const uint32_t NIU_CFG_NOC1_BAR_ADDR = 0x1FD14100;
+inline constexpr uint32_t NIU_CFG_NOC0_BAR_ADDR = 0x1FD04100;
+inline constexpr uint32_t NIU_CFG_NOC1_BAR_ADDR = 0x1FD14100;
 
-static constexpr uint32_t AICLK_BUSY_VAL = 1350;
-static constexpr uint32_t AICLK_IDLE_VAL = 800;
+inline constexpr uint32_t AICLK_BUSY_VAL = 1350;
+inline constexpr uint32_t AICLK_IDLE_VAL = 800;
 
-static constexpr uint32_t TENSIX_L1_SIZE = 1572864;
-static constexpr uint32_t ETH_L1_SIZE = 262144;
-static constexpr uint64_t DRAM_BANK_SIZE = 4294967296;
+inline constexpr uint32_t TENSIX_L1_SIZE = 1572864;
+inline constexpr uint32_t ETH_L1_SIZE = 262144;
+inline constexpr uint64_t DRAM_BANK_SIZE = 4294967296;
 
-constexpr std::array<std::pair<CoreType, uint64_t>, 8> NOC0_CONTROL_REG_ADDR_BASE_MAP = {
+inline constexpr std::array<std::pair<CoreType, uint64_t>, 8> NOC0_CONTROL_REG_ADDR_BASE_MAP = {
     {{CoreType::TENSIX, 0xFFB20000},
      {CoreType::ETH, 0xFFB20000},
      {CoreType::DRAM, 0xFFB20000},
@@ -269,7 +269,7 @@ constexpr std::array<std::pair<CoreType, uint64_t>, 8> NOC0_CONTROL_REG_ADDR_BAS
      {CoreType::SECURITY, 0xFFFFFFFFFF000000ULL},
      {CoreType::L2CPU, 0xFFFFFFFFFF000000ULL},
      {CoreType::ROUTER_ONLY, 0xFF000000}}};
-constexpr std::array<std::pair<CoreType, uint64_t>, 8> NOC1_CONTROL_REG_ADDR_BASE_MAP = {
+inline constexpr std::array<std::pair<CoreType, uint64_t>, 8> NOC1_CONTROL_REG_ADDR_BASE_MAP = {
     {{CoreType::TENSIX, 0xFFB30000},
      {CoreType::ETH, 0xFFB30000},
      {CoreType::DRAM, 0xFFB30000},
@@ -279,24 +279,24 @@ constexpr std::array<std::pair<CoreType, uint64_t>, 8> NOC1_CONTROL_REG_ADDR_BAS
      {CoreType::L2CPU, 0xFFFFFFFFFF000000ULL},
      {CoreType::ROUTER_ONLY, 0xFF000000}}};
 
-static const uint64_t NOC_NODE_ID_OFFSET = 0x44;
+inline constexpr uint64_t NOC_NODE_ID_OFFSET = 0x44;
 
-static const size_t eth_translated_coordinate_start_x = 20;
-static const size_t eth_translated_coordinate_start_y = 25;
+inline constexpr size_t eth_translated_coordinate_start_x = 20;
+inline constexpr size_t eth_translated_coordinate_start_y = 25;
 
-static const size_t pcie_translated_coordinate_start_x = 19;
-static const size_t pcie_translated_coordinate_start_y = 24;
+inline constexpr size_t pcie_translated_coordinate_start_x = 19;
+inline constexpr size_t pcie_translated_coordinate_start_y = 24;
 
-static const size_t dram_translated_coordinate_start_x = 17;
-static const size_t dram_translated_coordinate_start_y = 12;
+inline constexpr size_t dram_translated_coordinate_start_x = 17;
+inline constexpr size_t dram_translated_coordinate_start_y = 12;
 
 // Constants related to bits in the soft reset register.
-static const uint32_t SOFT_RESET_BRISC = 1 << 11;
-static const uint32_t SOFT_RESET_TRISC0 = 1 << 12;
-static const uint32_t SOFT_RESET_TRISC1 = 1 << 13;
-static const uint32_t SOFT_RESET_TRISC2 = 1 << 14;
-static const uint32_t SOFT_RESET_NCRISC = 1 << 18;
-static const uint32_t SOFT_RESET_STAGGERED_START = 1 << 31;
+inline constexpr uint32_t SOFT_RESET_BRISC = 1 << 11;
+inline constexpr uint32_t SOFT_RESET_TRISC0 = 1 << 12;
+inline constexpr uint32_t SOFT_RESET_TRISC1 = 1 << 13;
+inline constexpr uint32_t SOFT_RESET_TRISC2 = 1 << 14;
+inline constexpr uint32_t SOFT_RESET_NCRISC = 1 << 18;
+inline constexpr uint32_t SOFT_RESET_STAGGERED_START = 1 << 31;
 
 // Return arc core pair that can be used to access ARC core on the device. This depends on information
 // whether NOC translation is enabled and if we want to use NOC0 or NOC1.

--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -29,7 +29,7 @@ namespace wormhole {
 // ordering:     [ 0, 43, 42,  "ordering mode (01 = strict (full AXI ordering), 00 = relaxed (no RAW hazard), 10 = posted (may have RAW hazard)"]
 // linked:       [ 0, 44, 44,  "linked"]
 // clang-format on
-static constexpr auto TLB_1M_OFFSET = tlb_offsets{
+inline constexpr auto TLB_1M_OFFSET = tlb_offsets{
     .local_offset = 0,
     .x_end = 16,
     .y_end = 22,
@@ -53,7 +53,7 @@ static constexpr auto TLB_1M_OFFSET = tlb_offsets{
 // ordering:     [ 0, 42, 41,  "ordering mode (01 = strict (full AXI ordering), 00 = relaxed (no RAW hazard), 10 = posted (may have RAW hazard)"]
 // linked:       [ 0, 43, 43,  "linked"]
 // clang-format on
-static constexpr auto TLB_2M_OFFSET = tlb_offsets{
+inline constexpr auto TLB_2M_OFFSET = tlb_offsets{
     .local_offset = 0,
     .x_end = 15,
     .y_end = 21,
@@ -77,7 +77,7 @@ static constexpr auto TLB_2M_OFFSET = tlb_offsets{
 // ordering:     [ 0, 39, 38,  "ordering mode (01 = strict (full AXI ordering), 00 = relaxed (no RAW hazard), 10 = posted (may have RAW hazard)"]
 // linked:       [ 0, 40, 40,  "linked"]
 // clang-format on
-static constexpr auto TLB_16M_OFFSET = tlb_offsets{
+inline constexpr auto TLB_16M_OFFSET = tlb_offsets{
     .local_offset = 0,
     .x_end = 12,
     .y_end = 18,
@@ -105,13 +105,13 @@ enum class arc_message_type {
 };
 
 // DEVICE_DATA
-static const tt_xy_pair GRID_SIZE = {10, 12};
+inline constexpr tt_xy_pair GRID_SIZE = {10, 12};
 // Vectors for mapping NOC0 x and y coordinates to NOC1 x and y coordinates.
 // NOC0_X_TO_NOC1_X[noc0_x] is the NOC1 x coordinate corresponding to NOC0 x coordinate noc0_x.
 // NOC0_Y_TO_NOC1_Y[noc0_y] is the NOC1 y coordinate corresponding to NOC0 y coordinate noc0_y.
 static const std::vector<uint32_t> NOC0_X_TO_NOC1_X = {9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
 static const std::vector<uint32_t> NOC0_Y_TO_NOC1_Y = {11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
-static const tt_xy_pair TENSIX_GRID_SIZE = {8, 10};
+inline constexpr tt_xy_pair TENSIX_GRID_SIZE = {8, 10};
 // clang-format off
 static const std::vector<tt_xy_pair> TENSIX_CORES_NOC0 = {
     {1, 1},   {2, 1},  {3, 1},  {4, 1},  {6, 1},  {7, 1},  {8, 1},  {9, 1},
@@ -127,9 +127,9 @@ static const std::vector<tt_xy_pair> TENSIX_CORES_NOC0 = {
 };
 // clang-format on
 
-static const std::size_t NUM_DRAM_BANKS = 6;
-static const std::size_t NUM_NOC_PORTS_PER_DRAM_BANK = 3;
-static const tt_xy_pair DRAM_GRID_SIZE = {NUM_DRAM_BANKS, NUM_NOC_PORTS_PER_DRAM_BANK};
+inline constexpr std::size_t NUM_DRAM_BANKS = 6;
+inline constexpr std::size_t NUM_NOC_PORTS_PER_DRAM_BANK = 3;
+inline constexpr tt_xy_pair DRAM_GRID_SIZE = {NUM_DRAM_BANKS, NUM_NOC_PORTS_PER_DRAM_BANK};
 // clang-format off
 static const std::vector<std::vector<tt_xy_pair>> DRAM_CORES_NOC0 = {
     {{0, 0}, {0, 1}, {0, 11}},
@@ -143,7 +143,7 @@ static const std::vector<std::vector<tt_xy_pair>> DRAM_CORES_NOC0 = {
 // the existing code in clients which rely on DRAM_LOCATIONS.
 static const std::vector<tt_xy_pair> DRAM_LOCATIONS = flatten_vector(DRAM_CORES_NOC0);
 
-static const size_t NUM_ETH_CHANNELS = 16;
+inline constexpr size_t NUM_ETH_CHANNELS = 16;
 static const std::vector<tt_xy_pair> ETH_CORES_NOC0 = {
     {{9, 0},
      {1, 0},
@@ -163,11 +163,11 @@ static const std::vector<tt_xy_pair> ETH_CORES_NOC0 = {
      {4, 6}}};
 static const std::vector<tt_xy_pair> ETH_LOCATIONS = ETH_CORES_NOC0;
 
-static const tt_xy_pair ARC_GRID_SIZE = {1, 1};
+inline constexpr tt_xy_pair ARC_GRID_SIZE = {1, 1};
 static const std::vector<tt_xy_pair> ARC_CORES_NOC0 = {{0, 10}};
 static const std::vector<tt_xy_pair> ARC_LOCATIONS = ARC_CORES_NOC0;
 
-static const tt_xy_pair PCIE_GRID_SIZE = {1, 1};
+inline constexpr tt_xy_pair PCIE_GRID_SIZE = {1, 1};
 static const std::vector<tt_xy_pair> PCIE_CORES_NOC0 = {{{0, 3}}};
 static const std::vector<tt_xy_pair> PCI_LOCATIONS = PCIE_CORES_NOC0;
 
@@ -182,94 +182,94 @@ static const std::vector<uint32_t> T6_Y_LOCATIONS = {1, 2, 3, 4, 5, 7, 8, 9, 10,
 static const std::vector<uint32_t> HARVESTING_NOC_LOCATIONS = {11, 1, 10, 2, 9, 3, 8, 4, 7, 5};
 static const std::vector<uint32_t> LOGICAL_HARVESTING_LAYOUT = {1, 3, 5, 7, 9, 8, 6, 4, 2, 0};
 
-static constexpr uint32_t STATIC_TLB_SIZE = 1024 * 1024;
+inline constexpr uint32_t STATIC_TLB_SIZE = 1024 * 1024;
 
-static constexpr xy_pair BROADCAST_LOCATION = {0, 0};
-static constexpr uint32_t BROADCAST_TLB_INDEX = 0;
-static constexpr uint32_t STATIC_TLB_CFG_ADDR = 0x1fc00000;
-static constexpr uint32_t TLB_CFG_REG_SIZE_BYTES = 8;
+inline constexpr xy_pair BROADCAST_LOCATION = {0, 0};
+inline constexpr uint32_t BROADCAST_TLB_INDEX = 0;
+inline constexpr uint32_t STATIC_TLB_CFG_ADDR = 0x1fc00000;
+inline constexpr uint32_t TLB_CFG_REG_SIZE_BYTES = 8;
 
-static constexpr uint32_t TLB_COUNT_1M = 156;
-static constexpr uint32_t TLB_COUNT_2M = 10;
-static constexpr uint32_t TLB_COUNT_16M = 20;
+inline constexpr uint32_t TLB_COUNT_1M = 156;
+inline constexpr uint32_t TLB_COUNT_2M = 10;
+inline constexpr uint32_t TLB_COUNT_16M = 20;
 
-static constexpr uint32_t TLB_BASE_1M = 0;
-static constexpr uint32_t TLB_BASE_2M = TLB_COUNT_1M * (1 << 20);
-static constexpr uint32_t TLB_BASE_16M = TLB_BASE_2M + TLB_COUNT_2M * (1 << 21);
+inline constexpr uint32_t TLB_BASE_1M = 0;
+inline constexpr uint32_t TLB_BASE_2M = TLB_COUNT_1M * (1 << 20);
+inline constexpr uint32_t TLB_BASE_16M = TLB_BASE_2M + TLB_COUNT_2M * (1 << 21);
 
-static constexpr uint32_t TLB_BASE_INDEX_1M = 0;
-static constexpr uint32_t TLB_BASE_INDEX_2M = TLB_COUNT_1M;
-static constexpr uint32_t TLB_BASE_INDEX_16M = TLB_BASE_INDEX_2M + TLB_COUNT_2M;
+inline constexpr uint32_t TLB_BASE_INDEX_1M = 0;
+inline constexpr uint32_t TLB_BASE_INDEX_2M = TLB_COUNT_1M;
+inline constexpr uint32_t TLB_BASE_INDEX_16M = TLB_BASE_INDEX_2M + TLB_COUNT_2M;
 
-static constexpr uint32_t DYNAMIC_TLB_COUNT = 16;
+inline constexpr uint32_t DYNAMIC_TLB_COUNT = 16;
 
-static constexpr uint32_t DYNAMIC_TLB_16M_SIZE = 16 * 1024 * 1024;
-static constexpr uint32_t DYNAMIC_TLB_16M_CFG_ADDR =
+inline constexpr uint32_t DYNAMIC_TLB_16M_SIZE = 16 * 1024 * 1024;
+inline constexpr uint32_t DYNAMIC_TLB_16M_CFG_ADDR =
     STATIC_TLB_CFG_ADDR + (TLB_BASE_INDEX_16M * TLB_CFG_REG_SIZE_BYTES);
-static constexpr uint32_t DYNAMIC_TLB_16M_BASE = TLB_BASE_16M;
+inline constexpr uint32_t DYNAMIC_TLB_16M_BASE = TLB_BASE_16M;
 
-static constexpr uint32_t DYNAMIC_TLB_2M_SIZE = 2 * 1024 * 1024;
-static constexpr uint32_t DYNAMIC_TLB_2M_CFG_ADDR = STATIC_TLB_CFG_ADDR + (TLB_BASE_INDEX_2M * TLB_CFG_REG_SIZE_BYTES);
-static constexpr uint32_t DYNAMIC_TLB_2M_BASE = TLB_BASE_2M;
+inline constexpr uint32_t DYNAMIC_TLB_2M_SIZE = 2 * 1024 * 1024;
+inline constexpr uint32_t DYNAMIC_TLB_2M_CFG_ADDR = STATIC_TLB_CFG_ADDR + (TLB_BASE_INDEX_2M * TLB_CFG_REG_SIZE_BYTES);
+inline constexpr uint32_t DYNAMIC_TLB_2M_BASE = TLB_BASE_2M;
 
-static constexpr uint32_t DYNAMIC_TLB_1M_SIZE = 1 * 1024 * 1024;
-static constexpr uint32_t DYNAMIC_TLB_1M_CFG_ADDR = STATIC_TLB_CFG_ADDR + (TLB_BASE_INDEX_1M * TLB_CFG_REG_SIZE_BYTES);
-static constexpr uint32_t DYNAMIC_TLB_1M_BASE = TLB_BASE_1M;
+inline constexpr uint32_t DYNAMIC_TLB_1M_SIZE = 1 * 1024 * 1024;
+inline constexpr uint32_t DYNAMIC_TLB_1M_CFG_ADDR = STATIC_TLB_CFG_ADDR + (TLB_BASE_INDEX_1M * TLB_CFG_REG_SIZE_BYTES);
+inline constexpr uint32_t DYNAMIC_TLB_1M_BASE = TLB_BASE_1M;
 
 // MEM_*_TLB are for dynamic read/writes to memory, either 16MB (large read/writes) or 2MB (polling). REG_TLB for
 // dynamic writes to registers.   They are aligned with the kernel driver's WC/UC split.  But kernel driver uses
 // different TLB's for these.
-static constexpr unsigned int REG_TLB = TLB_BASE_INDEX_16M + 18;
-static constexpr unsigned int MEM_LARGE_WRITE_TLB = TLB_BASE_INDEX_16M + 17;
-static constexpr unsigned int MEM_LARGE_READ_TLB = TLB_BASE_INDEX_16M + 0;
-static constexpr unsigned int MEM_SMALL_READ_WRITE_TLB = TLB_BASE_INDEX_2M + 1;
-static constexpr uint32_t DYNAMIC_TLB_BASE_INDEX = MEM_LARGE_READ_TLB + 1;
-static constexpr uint32_t INTERNAL_TLB_INDEX = DYNAMIC_TLB_BASE_INDEX + DYNAMIC_TLB_COUNT;  // pcie_write_xy and similar
-static constexpr uint32_t DRAM_CHANNEL_0_X = 0;
-static constexpr uint32_t DRAM_CHANNEL_0_Y = 0;
-static constexpr uint32_t DRAM_CHANNEL_0_PEER2PEER_REGION_START = 0x30000000;  // This is the last 256MB of DRAM
+inline constexpr unsigned int REG_TLB = TLB_BASE_INDEX_16M + 18;
+inline constexpr unsigned int MEM_LARGE_WRITE_TLB = TLB_BASE_INDEX_16M + 17;
+inline constexpr unsigned int MEM_LARGE_READ_TLB = TLB_BASE_INDEX_16M + 0;
+inline constexpr unsigned int MEM_SMALL_READ_WRITE_TLB = TLB_BASE_INDEX_2M + 1;
+inline constexpr uint32_t DYNAMIC_TLB_BASE_INDEX = MEM_LARGE_READ_TLB + 1;
+inline constexpr uint32_t INTERNAL_TLB_INDEX = DYNAMIC_TLB_BASE_INDEX + DYNAMIC_TLB_COUNT;  // pcie_write_xy and similar
+inline constexpr uint32_t DRAM_CHANNEL_0_X = 0;
+inline constexpr uint32_t DRAM_CHANNEL_0_Y = 0;
+inline constexpr uint32_t DRAM_CHANNEL_0_PEER2PEER_REGION_START = 0x30000000;  // This is the last 256MB of DRAM
 
-static constexpr uint32_t GRID_SIZE_X = 10;
-static constexpr uint32_t GRID_SIZE_Y = 12;
+inline constexpr uint32_t GRID_SIZE_X = 10;
+inline constexpr uint32_t GRID_SIZE_Y = 12;
 
-static constexpr uint32_t ARC_MSG_COMMON_PREFIX = 0xAA00;
+inline constexpr uint32_t ARC_MSG_COMMON_PREFIX = 0xAA00;
 
-static constexpr uint32_t ARC_APB_BAR0_XBAR_OFFSET_START = 0x1FF00000;
-static constexpr uint32_t ARC_APB_BAR0_XBAR_OFFSET_END = 0x1FFFFFFF;
+inline constexpr uint32_t ARC_APB_BAR0_XBAR_OFFSET_START = 0x1FF00000;
+inline constexpr uint32_t ARC_APB_BAR0_XBAR_OFFSET_END = 0x1FFFFFFF;
 
-static constexpr uint32_t ARC_CSM_MAILBOX_OFFSET = 0x1FEF83C4;
-static constexpr uint32_t ARC_CSM_MAILBOX_SIZE_OFFSET = 0x1FEF84C4;
+inline constexpr uint32_t ARC_CSM_MAILBOX_OFFSET = 0x1FEF83C4;
+inline constexpr uint32_t ARC_CSM_MAILBOX_SIZE_OFFSET = 0x1FEF84C4;
 
-static constexpr uint32_t TENSIX_SOFT_RESET_ADDR = 0xFFB121B0;
+inline constexpr uint32_t TENSIX_SOFT_RESET_ADDR = 0xFFB121B0;
 
-static constexpr uint32_t RISCV_DEBUG_REG_DBG_BUS_CNTL_REG = 0xFFB12000 + 0x54;
+inline constexpr uint32_t RISCV_DEBUG_REG_DBG_BUS_CNTL_REG = 0xFFB12000 + 0x54;
 
-static constexpr uint32_t ARC_SCRATCH_6_OFFSET = 0x1FF30078;
+inline constexpr uint32_t ARC_SCRATCH_6_OFFSET = 0x1FF30078;
 
-static constexpr uint32_t ARC_RESET_UNIT_OFFSET = 0x30000;
-static constexpr uint32_t ARC_RESET_SCRATCH_OFFSET = ARC_RESET_UNIT_OFFSET + 0x60;
-static constexpr uint32_t ARC_RESET_SCRATCH_2_OFFSET = ARC_RESET_SCRATCH_OFFSET + 0x8;
-static constexpr uint32_t ARC_RESET_SCRATCH_RES0_OFFSET = ARC_RESET_SCRATCH_OFFSET + 0xC;
-static constexpr uint32_t ARC_RESET_SCRATCH_RES1_OFFSET = ARC_RESET_SCRATCH_OFFSET + 0x10;
-static constexpr uint32_t ARC_RESET_SCRATCH_STATUS_OFFSET = ARC_RESET_SCRATCH_OFFSET + 0x14;
-static constexpr uint32_t ARC_RESET_REFCLK_LOW_OFFSET = ARC_RESET_UNIT_OFFSET + 0xE0;
-static constexpr uint32_t ARC_RESET_REFCLK_HIGH_OFFSET = ARC_RESET_UNIT_OFFSET + 0xE4;
-static constexpr uint32_t ARC_RESET_ARC_MISC_CNTL_OFFSET = ARC_RESET_UNIT_OFFSET + 0x0100;
+inline constexpr uint32_t ARC_RESET_UNIT_OFFSET = 0x30000;
+inline constexpr uint32_t ARC_RESET_SCRATCH_OFFSET = ARC_RESET_UNIT_OFFSET + 0x60;
+inline constexpr uint32_t ARC_RESET_SCRATCH_2_OFFSET = ARC_RESET_SCRATCH_OFFSET + 0x8;
+inline constexpr uint32_t ARC_RESET_SCRATCH_RES0_OFFSET = ARC_RESET_SCRATCH_OFFSET + 0xC;
+inline constexpr uint32_t ARC_RESET_SCRATCH_RES1_OFFSET = ARC_RESET_SCRATCH_OFFSET + 0x10;
+inline constexpr uint32_t ARC_RESET_SCRATCH_STATUS_OFFSET = ARC_RESET_SCRATCH_OFFSET + 0x14;
+inline constexpr uint32_t ARC_RESET_REFCLK_LOW_OFFSET = ARC_RESET_UNIT_OFFSET + 0xE0;
+inline constexpr uint32_t ARC_RESET_REFCLK_HIGH_OFFSET = ARC_RESET_UNIT_OFFSET + 0xE4;
+inline constexpr uint32_t ARC_RESET_ARC_MISC_CNTL_OFFSET = ARC_RESET_UNIT_OFFSET + 0x0100;
 
-static constexpr uint32_t ARC_XBAR_ADDRESS_END = 0xFFFFFFFF;
+inline constexpr uint32_t ARC_XBAR_ADDRESS_END = 0xFFFFFFFF;
 
-constexpr uint64_t ARC_NOC_XBAR_ADDRESS_START = 0x880000000;
-constexpr uint64_t ARC_NOC_XBAR_ADDRESS_END = 0x8FFFFFFFF;
+inline constexpr uint64_t ARC_NOC_XBAR_ADDRESS_START = 0x880000000;
+inline constexpr uint64_t ARC_NOC_XBAR_ADDRESS_END = 0x8FFFFFFFF;
 
-constexpr uint64_t ARC_RESET_SCRATCH_ADDR = 0x880030060;
-constexpr uint64_t ARC_RESET_MISC_CNTL_ADDR = 0x880030100;
+inline constexpr uint64_t ARC_RESET_SCRATCH_ADDR = 0x880030060;
+inline constexpr uint64_t ARC_RESET_MISC_CNTL_ADDR = 0x880030100;
 
-static constexpr uint32_t AICLK_BUSY_VAL = 1000;
-static constexpr uint32_t AICLK_IDLE_VAL = 500;
+inline constexpr uint32_t AICLK_BUSY_VAL = 1000;
+inline constexpr uint32_t AICLK_IDLE_VAL = 500;
 
-static constexpr uint32_t TENSIX_L1_SIZE = 1499136;
-static constexpr uint32_t ETH_L1_SIZE = 262144;
-static constexpr uint64_t DRAM_BANK_SIZE = 2147483648;
+inline constexpr uint32_t TENSIX_L1_SIZE = 1499136;
+inline constexpr uint32_t ETH_L1_SIZE = 262144;
+inline constexpr uint64_t DRAM_BANK_SIZE = 2147483648;
 
 constexpr std::array<std::pair<CoreType, uint64_t>, 6> NOC0_CONTROL_REG_ADDR_BASE_MAP = {
     {{CoreType::TENSIX, 0xFFB20000},
@@ -285,27 +285,27 @@ constexpr std::array<std::pair<CoreType, uint64_t>, 6> NOC1_CONTROL_REG_ADDR_BAS
      {CoreType::PCIE, 0xFFFB30000},
      {CoreType::ARC, 0xFFFB30000},
      {CoreType::ROUTER_ONLY, 0xFFB20000}}};
-static const uint64_t NOC_NODE_ID_OFFSET = 0x2C;
+inline constexpr uint64_t NOC_NODE_ID_OFFSET = 0x2C;
 
-static const uint64_t ARC_NOC_RESET_UNIT_BASE_ADDR = 0x880030000;
+inline constexpr uint64_t ARC_NOC_RESET_UNIT_BASE_ADDR = 0x880030000;
 // Offset of NOC node id registers on ARC core which are
 // used to store telemetry addresses, not used for NOC routing.
-static const uint64_t NOC_NODEID_X_0 = 0x1D0;
-static const uint64_t NOC_NODEID_Y_0 = 0x1D4;
+inline constexpr uint64_t NOC_NODEID_X_0 = 0x1D0;
+inline constexpr uint64_t NOC_NODEID_Y_0 = 0x1D4;
 
-static const size_t tensix_translated_coordinate_start_x = 18;
-static const size_t tensix_translated_coordinate_start_y = 18;
+inline constexpr size_t tensix_translated_coordinate_start_x = 18;
+inline constexpr size_t tensix_translated_coordinate_start_y = 18;
 
-static const size_t eth_translated_coordinate_start_x = 18;
-static const size_t eth_translated_coordinate_start_y = 16;
+inline constexpr size_t eth_translated_coordinate_start_x = 18;
+inline constexpr size_t eth_translated_coordinate_start_y = 16;
 
 // Constants related to bits in the soft reset register
-static const uint32_t SOFT_RESET_BRISC = 1 << 11;
-static const uint32_t SOFT_RESET_TRISC0 = 1 << 12;
-static const uint32_t SOFT_RESET_TRISC1 = 1 << 13;
-static const uint32_t SOFT_RESET_TRISC2 = 1 << 14;
-static const uint32_t SOFT_RESET_NCRISC = 1 << 18;
-static const uint32_t SOFT_RESET_STAGGERED_START = 1 << 31;
+inline constexpr uint32_t SOFT_RESET_BRISC = 1 << 11;
+inline constexpr uint32_t SOFT_RESET_TRISC0 = 1 << 12;
+inline constexpr uint32_t SOFT_RESET_TRISC1 = 1 << 13;
+inline constexpr uint32_t SOFT_RESET_TRISC2 = 1 << 14;
+inline constexpr uint32_t SOFT_RESET_NCRISC = 1 << 18;
+inline constexpr uint32_t SOFT_RESET_STAGGERED_START = 1 << 31;
 
 }  // namespace wormhole
 


### PR DESCRIPTION
### Issue

#1299 

### Description

Consolidate constexpr usage in architecture implementation header files.

### List of the changes

- Change `static const` to `inline constexpr`
- Add static to some vectors that were already const

### Testing
CI

### API Changes
/
