### PR TITLE
Switch is_hardware_hung to log_debug

### DIFF
--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -241,7 +241,7 @@ bool BlackholeTTDevice::is_hardware_hung() {
     // related to a failure which was obscured by the exception. For now,
     // just return false.  -- @joelsmithTT, Oct 1 2025
 
-    log_warning(LogUMD, "Hang detection is not supported (yet) on Blackhole.");
+    log_debug(LogUMD, "Hang detection is not supported (yet) on Blackhole.");
     return false;
 }
 


### PR DESCRIPTION
### Issue
https://tenstorrent.atlassian.net/browse/GHTTMETAL-11896?actionerId=712020%3A586fd97d-edf3-4b6d-8ec8-9f47cc2e0a4c&sourceType=assign
https://github.com/tenstorrent/tt-metal/issues/30866

### Description
Disable warning for hardware_hung not implemented for BH, as it was spamming with too many warnings.

### List of the changes
- Changed log_warning to log_debug

### Testing
No testing

### API Changes
There are no API changes in this PR.
