### PR TITLE
Customize noc dram port for dram_membar

### DIFF
--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -25,6 +25,8 @@ static_assert(!std::is_abstract<LocalChip>(), "LocalChip must be non-abstract.")
 // TLB size for DRAM on blackhole - 4GB
 const uint64_t BH_4GB_TLB_SIZE = 4ULL * 1024 * 1024 * 1024;
 
+constexpr uint32_t DRAM_SUBCHANNEL_FOR_MEMBAR = 0;
+
 std::unique_ptr<LocalChip> LocalChip::create(
     int physical_device_id, std::string sdesc_path, int num_host_mem_channels, IODeviceType device_type) {
     // Create TTDevice and make sure the arc is ready so we can read its telemetry.
@@ -173,7 +175,8 @@ void LocalChip::initialize_membars() {
 
     std::vector<CoreCoord> dram_cores_vector = {};
     for (std::uint32_t dram_idx = 0; dram_idx < soc_descriptor_.get_num_dram_channels(); dram_idx++) {
-        dram_cores_vector.push_back(soc_descriptor_.get_dram_core_for_channel(dram_idx, 0, CoordSystem::TRANSLATED));
+        dram_cores_vector.push_back(
+            soc_descriptor_.get_dram_core_for_channel(dram_idx, DRAM_SUBCHANNEL_FOR_MEMBAR, CoordSystem::TRANSLATED));
     }
     set_membar_flag(dram_cores_vector, MemBarFlag::RESET, dram_address_params.DRAM_BARRIER_BASE);
 }
@@ -675,8 +678,8 @@ void LocalChip::dram_membar(const std::unordered_set<CoreCoord>& cores) {
         // Insert Barrier on all DRAM Cores
         std::vector<CoreCoord> dram_cores_vector = {};
         for (std::uint32_t dram_idx = 0; dram_idx < soc_descriptor_.get_num_dram_channels(); dram_idx++) {
-            dram_cores_vector.push_back(
-                soc_descriptor_.get_dram_core_for_channel(dram_idx, 0, CoordSystem::TRANSLATED));
+            dram_cores_vector.push_back(soc_descriptor_.get_dram_core_for_channel(
+                dram_idx, DRAM_SUBCHANNEL_FOR_MEMBAR, CoordSystem::TRANSLATED));
         }
         insert_host_to_device_barrier(dram_cores_vector, dram_address_params.DRAM_BARRIER_BASE);
     }
@@ -685,7 +688,8 @@ void LocalChip::dram_membar(const std::unordered_set<CoreCoord>& cores) {
 void LocalChip::dram_membar(const std::unordered_set<uint32_t>& channels) {
     std::unordered_set<CoreCoord> dram_cores_to_sync = {};
     for (const auto& chan : channels) {
-        dram_cores_to_sync.insert(soc_descriptor_.get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED));
+        dram_cores_to_sync.insert(
+            soc_descriptor_.get_dram_core_for_channel(chan, DRAM_SUBCHANNEL_FOR_MEMBAR, CoordSystem::TRANSLATED));
     }
     dram_membar(dram_cores_to_sync);
 }


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/919

### Description
Update our code so that it is easily customizable which subchannel is used for dram membar operations.
I think that adding this to API is an overkill, and this approach still allows easy modifications if this is needed for debugging purposes (we only had one such instance up to now).

### List of the changes
- Add a constant to local_chip to control which subchannel is used.

### Testing
No additional testing

### API Changes
There are no API changes in this PR.
