### PR TITLE
Fix BH harvesting checks for P300 and UBB_BLACKHOLE

### DIFF
--- a/device/api/umd/device/types/cluster_descriptor_types.hpp
+++ b/device/api/umd/device/types/cluster_descriptor_types.hpp
@@ -243,10 +243,10 @@ static const std::unordered_map<BoardType, uint32_t> expected_tensix_harvested_u
     {BoardType::N300, 2},
     {BoardType::P100, 2},
     {BoardType::P150, 0},
-    {BoardType::P300, 0},
+    {BoardType::P300, 2},
     {BoardType::GALAXY, 0},
     {BoardType::UBB, 0},
-    {BoardType::UBB_BLACKHOLE, 0},
+    {BoardType::UBB_BLACKHOLE, 1},
 };
 
 static const std::unordered_map<BoardType, uint32_t> expected_dram_harvested_units_map = {
@@ -268,7 +268,7 @@ static const std::unordered_map<BoardType, uint32_t> expected_eth_harvested_unit
     {BoardType::P300, 2},
     {BoardType::GALAXY, 0},
     {BoardType::UBB, 0},
-    {BoardType::UBB_BLACKHOLE, 0},
+    {BoardType::UBB_BLACKHOLE, 2},
 };
 
 struct HarvestingMasks {


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description
P300 and UBB_BLACKHOLE had some expected harvesting values set to 0, when they are expected to actually be harvested.

### List of the changes
- Update P300 to expect 2 harvested tensix units
- Update UBB_BLACKHOLE to expect 1 harvested tensix unit
- Update UBB_BLACKHOLE to expect 2 harvested eth units

### Testing
Verified on local P300 and UBB_BLACKHOLE machines.

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
