### PR TITLE
Fix logical ethernet channel mapping for firmware 18.12.0+

### DIFF
--- a/device/topology/topology_discovery_blackhole.cpp
+++ b/device/topology/topology_discovery_blackhole.cpp
@@ -166,10 +166,17 @@ uint32_t TopologyDiscoveryBlackhole::get_logical_remote_eth_channel(Chip* chip, 
     uint8_t remote_logical_eth_id;
     chip->get_tt_device()->read_from_device(
         &remote_logical_eth_id, translated_eth_core, 0x7CFE3, sizeof(remote_logical_eth_id));
-    // Adding 4 here, since for P150, the logical eth chan id stored at address 0x7CFE3 hides
-    // the first 4 ethernet channels (these channels are using SerDes for PCIe)
-    // These channels are visible to UMD, and are thus accounted for in this API.
-    return remote_logical_eth_id + 4;
+
+    auto fw_bundle_version = chip->get_tt_device()->get_firmware_version();
+
+    if (fw_bundle_version >= semver_t(18, 12, 0)) {
+        return remote_logical_eth_id;
+    } else {
+        // Adding 4 here, since for P150, the logical eth chan id stored at address 0x7CFE3 hides
+        // the first 4 ethernet channels (these channels are using SerDes for PCIe)
+        // These channels are visible to UMD, and are thus accounted for in this API.
+        return remote_logical_eth_id + 4;
+    }
 }
 
 bool TopologyDiscoveryBlackhole::is_using_eth_coords() { return false; }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Logical ethernet channel mapping incorrectly added offset of 4 for all firmware versions, causing incorrect channel IDs with firmware 18.12.0+.

### What's changed
- Added firmware version check in `get_logical_remote_eth_channel()` in `topology_discovery_blackhole.cpp`
- For firmware >= 18.12.0, returns `remote_logical_eth_id` directly without offset
- For older firmware, maintains the +4 offset to account for PCIe SerDes channels
- Ensures correct ethernet channel mapping across different firmware versions

<img width="942" height="799" alt="image" src="https://github.com/user-attachments/assets/d1020e97-ffc8-41af-83f5-a58a443873eb" />


### CI Runs
- [ ] New/Existing tests provide coverage for changes