### PR TITLE
Bump CMake to 3.27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.27)
 
 option(TT_UMD_BUILD_JTAG "Enable JTAG support" OFF)
 set(DOWNLOAD_TTEXALENS_PRIVATE ${TT_UMD_BUILD_JTAG})

--- a/cmake/ttexalens_private.cmake
+++ b/cmake/ttexalens_private.cmake
@@ -21,7 +21,7 @@ if(DOWNLOAD_TTEXALENS_PRIVATE)
         file(
             WRITE
             "${CMAKE_BINARY_DIR}/tt_exalens_private_check/CMakeLists.txt"
-            "cmake_minimum_required(VERSION 3.16)\ncmake_policy(VERSION 3.16)\ninclude(\${CMAKE_CURRENT_LIST_DIR}/ttexalens_private_check.cmake)"
+            "cmake_minimum_required(VERSION 3.27)\ncmake_policy(VERSION 3.27)\ninclude(\${CMAKE_CURRENT_LIST_DIR}/ttexalens_private_check.cmake)"
         )
 
         message(STATUS "Checking for git-lfs...")

--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.27)
 
 set(POSITION_INDEPENDENT_CODE ON)
 include(CheckFunctionExists)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Check if this is being built as a standalone project by running cmake from this dir
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     # This is a root project build from install artifacts
-    cmake_minimum_required(VERSION 3.16)
+    cmake_minimum_required(VERSION 3.27)
     project(tt_umd_examples)
 
     message(STATUS "Building examples as standalone project from UMD install artifacts")

--- a/nanobind/CMakeLists.txt
+++ b/nanobind/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Check if this is being built as a standalone project by running cmake from this dir
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     # This is a root project build from install artifacts
-    cmake_minimum_required(VERSION 3.16)
+    cmake_minimum_required(VERSION 3.27)
     project(tt_umd_nanobind)
 
     message(STATUS "Building nanobind as standalone project from UMD install artifacts")

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Check if this is being built as a standalone project by running cmake from this dir
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     # This is a root project build from install artifacts
-    cmake_minimum_required(VERSION 3.16)
+    cmake_minimum_required(VERSION 3.27)
     project(tt_umd_tools)
 
     message(STATUS "Building tools as standalone project from UMD install artifacts")


### PR DESCRIPTION
### Issue
#1035 

### Description
Bumped CMake as it has features for skipping linting in some parts of the codebase which is necessary for clang-tidy

### List of the changes
- Change versions from 3.16 to 3.27

### Testing
CI

### API Changes
/