### PR TITLE
Remove unused functions and add Routing FW Validation on WH

### DIFF
--- a/device/api/umd/device/topology/topology_discovery.hpp
+++ b/device/api/umd/device/topology/topology_discovery.hpp
@@ -120,18 +120,11 @@ protected:
 
     virtual bool is_eth_trained(Chip* chip, const tt_xy_pair eth_core) = 0;
 
+    virtual void validate_routing_firmware_state(const std::map<uint64_t, std::unique_ptr<Chip>>& chips) = 0;
+
     // This is hack to report proper logical ETH IDs, since eth id on ETH core on Blackhole
     // does not take harvesting into consideration. This function will be overridden just for Blackhole.
     virtual void patch_eth_connections();
-
-    // Intermesh links are ethernet links that are turned off during UMD's topology discovery but are
-    // otherwise physically connected. This is done since not all tools support limiting the discovery as
-    // UMD does. Once all the tools start supporting this, this feature won't be used anymore and this
-    // function will return empty set.
-    // This will extract the list of intermesh links from a config in L1.
-    virtual std::vector<uint32_t> extract_intermesh_eth_links(Chip* chip, tt_xy_pair eth_core) = 0;
-
-    virtual bool is_intermesh_eth_link_trained(Chip* chip, tt_xy_pair eth_core) = 0;
 
     // This function is going to be implemented for Blackhole since it needs to load communication
     // firmware in runtime onto ETH cores. Wormhole will have this function empty since the routing FW

--- a/device/api/umd/device/topology/topology_discovery_blackhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_blackhole.hpp
@@ -42,15 +42,13 @@ protected:
 
     uint64_t get_remote_board_type(Chip* chip, tt_xy_pair eth_core) override;
 
-    std::vector<uint32_t> extract_intermesh_eth_links(Chip* chip, tt_xy_pair eth_core) override;
-
-    bool is_intermesh_eth_link_trained(Chip* chip, tt_xy_pair eth_core) override;
-
     bool is_using_eth_coords() override;
 
     uint64_t mangle_asic_id(uint64_t board_id, uint8_t asic_location);
 
     bool is_eth_trained(Chip* chip, const tt_xy_pair eth_core) override;
+
+    void validate_routing_firmware_state(const std::map<uint64_t, std::unique_ptr<Chip>>& chips) override;
 
     std::unique_ptr<RemoteChip> create_remote_chip(
         std::optional<EthCoord> eth_coord, Chip* gateway_chip, std::set<uint32_t> gateway_eth_channels) override;

--- a/device/api/umd/device/topology/topology_discovery_wormhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_wormhole.hpp
@@ -18,6 +18,7 @@ protected:
         uint32_t masked_version;
 
         uint64_t eth_param_table;
+        uint64_t routing_firmware_state;
         uint64_t node_info;
         uint64_t eth_conn_info;
         uint64_t results_buf;
@@ -58,10 +59,6 @@ protected:
 
     uint64_t get_remote_board_type(Chip* chip, tt_xy_pair eth_core) override;
 
-    std::vector<uint32_t> extract_intermesh_eth_links(Chip* chip, tt_xy_pair eth_core) override;
-
-    bool is_intermesh_eth_link_trained(Chip* chip, tt_xy_pair eth_core) override;
-
     std::unique_ptr<RemoteChip> create_remote_chip(
         std::optional<EthCoord> eth_coord, Chip* gateway_chip, std::set<uint32_t> gateway_eth_channels) override;
 
@@ -70,6 +67,8 @@ protected:
     void init_topology_discovery() override;
 
     bool is_eth_trained(Chip* chip, const tt_xy_pair eth_core) override;
+
+    void validate_routing_firmware_state(const std::map<uint64_t, std::unique_ptr<Chip>>& chips) override;
 
     EthAddresses eth_addresses;
 

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -212,6 +212,7 @@ void TopologyDiscovery::discover_remote_chips() {
     }
 
     patch_eth_connections();
+    validate_routing_firmware_state(chips);
 }
 
 std::unique_ptr<ClusterDescriptor> TopologyDiscovery::fill_cluster_descriptor_info() {

--- a/device/topology/topology_discovery_blackhole.cpp
+++ b/device/topology/topology_discovery_blackhole.cpp
@@ -218,16 +218,6 @@ void TopologyDiscoveryBlackhole::patch_eth_connections() {
     }
 }
 
-std::vector<uint32_t> TopologyDiscoveryBlackhole::extract_intermesh_eth_links(Chip* chip, tt_xy_pair eth_core) {
-    // This function is not important for Blackhole.
-    return {};
-}
-
-bool TopologyDiscoveryBlackhole::is_intermesh_eth_link_trained(Chip* chip, tt_xy_pair eth_core) {
-    // This function is not important for Blackhole.
-    return false;
-}
-
 void TopologyDiscoveryBlackhole::initialize_remote_communication(Chip* chip) {
     // We don't want to initialize lite fabric on non-P300 boards. For all configurations we have at the moment,
     // we would need to init lite fabric just on LocalChips of P300 boards.
@@ -329,5 +319,8 @@ uint64_t TopologyDiscoveryBlackhole::get_unconnected_chip_id(Chip* chip) {
     uint32_t asic_id_hi = tt_device->get_arc_telemetry_reader()->read_entry(TelemetryTag::ASIC_ID_HIGH);
     return (static_cast<uint64_t>(asic_id_hi) << 32) | asic_id_lo;
 }
+
+void TopologyDiscoveryBlackhole::validate_routing_firmware_state(
+    const std::map<uint64_t, std::unique_ptr<Chip>>& chips) {}
 
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue
No Ticket.

### Description
- Functions related to intermesh links are no longer needed in `topology_discovery`, since we no longer rely on the Port Connection table for determining port statuses
- Additionally, UMD needs a check to ensure that base routing firmware is disabled on WH 6U Galaxy systems

### List of the changes
- Remove `extract_intermesh_eth_links` and `is_intermesh_eth_link_trained` APIs
- Add `validate_routing_firmware_state` API to `topology_discovery` to ensure that routing firmware is disabled on 6U Galaxy systems and enabled on all other WH systems

### Testing
(Comment on CI testing or Manual testing touching this change.)

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
