### PR TITLE
Add bare simulation classes on TTDevice layer

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -76,6 +76,8 @@ target_sources(
         tt_device/wormhole_tt_device.cpp
         tt_device/remote_wormhole_tt_device.cpp
         tt_device/remote_blackhole_tt_device.cpp
+        tt_device/rtl_simulation_tt_device.cpp
+        tt_device/tt_sim_tt_device.cpp
         firmware/firmware_info_provider.cpp
         firmware/wormhole_18_3_firmware_info_provider.cpp
         firmware/wormhole_18_7_firmware_info_provider.cpp
@@ -166,6 +168,8 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/tt_device/wormhole_tt_device.hpp
                 api/umd/device/tt_device/remote_wormhole_tt_device.hpp
                 api/umd/device/tt_device/remote_blackhole_tt_device.hpp
+                api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+                api/umd/device/tt_device/tt_sim_tt_device.hpp
                 api/umd/device/tt_device/remote_communication.hpp
                 api/umd/device/tt_device/remote_communication_legacy_firmware.hpp
                 api/umd/device/tt_device/remote_communication_lite_fabric.hpp

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+
+#include "umd/device/tt_device/tt_device.hpp"
+
+namespace tt::umd {
+class RtlSimulationTTDevice : public TTDevice {
+public:
+    RtlSimulationTTDevice();
+};
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+
+#include "umd/device/tt_device/tt_device.hpp"
+
+namespace tt::umd {
+class TTSimTTDevice : public TTDevice {
+public:
+    TTSimTTDevice();
+};
+}  // namespace tt::umd

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "umd/device/tt_device/rtl_simulation_tt_device.hpp"
+
+namespace tt::umd {
+
+RtlSimulationTTDevice::RtlSimulationTTDevice() {
+    throw std::runtime_error(
+        "Creating RtlSimulationTTDevice without an underlying communication device is not supported.");
+}
+
+}  // namespace tt::umd

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "umd/device/tt_device/tt_sim_tt_device.hpp"
+
+namespace tt::umd {
+
+TTSimTTDevice::TTSimTTDevice() {
+    throw std::runtime_error("Creating TTSimTTDevice without an underlying communication device is not supported.");
+}
+
+}  // namespace tt::umd


### PR DESCRIPTION
### Issue

Work towards #1467 #1466  

### Description

Add bare classes on TTDevice layer for both RTL and ttsim simulation. Just the constructor is implemented, there will be follow up PRs to implement one by one functionality.

### List of the changes

- Add RTLSimulationTTDevice class
- Add TTSimTTDevice class
- Update Cmake

### Testing
CI

### API Changes
/