### PR TITLE
Skip linting old way 

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -155,6 +155,9 @@ if(TT_UMD_BUILD_SIMULATION)
             uv_a
     )
 
+    # Add compile definition to main device target for simulation support
+    target_compile_definitions(device PRIVATE TT_UMD_BUILD_SIMULATION)
+
     target_link_libraries(device PRIVATE simulation_obj)
 endif()
 


### PR DESCRIPTION
### Issue
#1035 

### Description
Skip linting by making library objects and linking them against device, and unset CXX_CLANG_TIDY

### List of the changes
/

### Testing
/

### API Changes
/