### PR TITLE
Add tt_kmd_lib files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ project(
     DESCRIPTION "Tenstorrent User Mode Driver"
     HOMEPAGE_URL "https://github.com/tenstorrent/tt-umd"
     LANGUAGES
+        C
         CXX
 )
 

--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -108,6 +108,7 @@ target_sources(
         jtag/jtag.cpp
         lite_fabric/lite_fabric_host_utils.cpp
         ${LITE_FABRIC_EMBED} # include generated embed file
+        tt_kmd_lib/tt_kmd_lib.c
 )
 
 if(TT_UMD_BUILD_SIMULATION)
@@ -210,6 +211,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/arch/wormhole_implementation.hpp
                 api/umd/device/jtag/jtag_device.hpp
                 api/umd/device/jtag/jtag.hpp
+                api/umd/device/tt_kmd_lib/tt_kmd_lib.h
     )
 endif()
 

--- a/device/api/umd/device/tt_kmd_lib/tt_kmd_lib.h
+++ b/device/api/umd/device/tt_kmd_lib/tt_kmd_lib.h
@@ -1,0 +1,397 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TTKMD_H_
+#define TTKMD_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TENSTORRENT_DRIVER_VERSION_MAJOR 2
+#define TENSTORRENT_DRIVER_VERSION_MINOR 3
+#define TENSTORRENT_DRIVER_VERSION_PATCH 0
+#define TENSTORRENT_DRIVER_VERSION_SUFFIX ""  // e.g. "-rc1"
+
+/**
+ * @brief Opaque handle to a Tenstorrent PCIe device.
+ */
+typedef struct tt_device_t tt_device_t;
+
+/**
+ * @brief Opaque handle to a TLB window.
+ *
+ * A TLB window is a fixed size aperture in the host address space that is
+ * mappable to a device NOC (Network on Chip) location.
+ */
+typedef struct tt_tlb_t tt_tlb_t;
+
+/**
+ * @brief Opaque handle to a DMA mapping.
+ *
+ * A DMA mapping is host memory made device-accessible by the driver.
+ */
+typedef struct tt_dma_t tt_dma_t;
+
+/**
+ * @brief Configuration for a TLB window's mapping to the device NOC.
+ *
+ * These parameters control how memory operations on a TLB window are translated
+ * into transactions on the device's NOC. See `tt_tlb_map()` for details.
+ */
+typedef struct tt_noc_addr_config_t {
+    uint64_t addr;     /**< Local address aligned to the TLB window size */
+    uint16_t x_end;    /**< X coord for unicast; rectangle end for multicast */
+    uint16_t y_end;    /**< Y coord for unicast; rectangle end for multicast */
+    uint16_t x_start;  /**< 0 for unicast; rectangle start for multicast */
+    uint16_t y_start;  /**< 0 for unicast; rectangle start for multicast */
+    uint8_t noc;       /**< 0 or 1 */
+    uint8_t mcast;     /**< 1 to enable multicast */
+    uint8_t ordering;  /**< Ordering semantics; see `enum tt_noc_ordering` */
+    uint8_t static_vc; /**< 1 to enable static virtual channel */
+} tt_noc_addr_config_t;
+
+/**
+ * @brief Supported Tenstorrent device architectures.
+ */
+enum tt_device_arch { TT_DEVICE_ARCH_UNKNOWN = 0, TT_DEVICE_ARCH_WORMHOLE, TT_DEVICE_ARCH_BLACKHOLE };
+
+/**
+ * @brief Queryable attributes of a Tenstorrent device.
+ */
+enum tt_device_attr {
+    TT_DEVICE_ATTR_PCI_DOMAIN = 0,
+    TT_DEVICE_ATTR_PCI_BUS = 1,
+    TT_DEVICE_ATTR_PCI_DEVICE = 2,
+    TT_DEVICE_ATTR_PCI_FUNCTION = 3,
+    TT_DEVICE_ATTR_PCI_VENDOR_ID = 4,
+    TT_DEVICE_ATTR_PCI_DEVICE_ID = 5,
+    TT_DEVICE_ATTR_PCI_SUBSYSTEM_ID = 6,
+    TT_DEVICE_ATTR_CHIP_ARCH = 7,
+    TT_DEVICE_ATTR_NUM_1M_TLBS = 8,
+    TT_DEVICE_ATTR_NUM_2M_TLBS = 9,
+    TT_DEVICE_ATTR_NUM_16M_TLBS = 10,
+    TT_DEVICE_ATTR_NUM_4G_TLBS = 11,
+};
+
+/**
+ * @brief Queryable attributes of the Tenstorrent driver.
+ */
+enum tt_driver_attr {
+    TT_DRIVER_API_VERSION = 0,
+    TT_DRIVER_SEMVER_MAJOR = 1,
+    TT_DRIVER_SEMVER_MINOR = 2,
+    TT_DRIVER_SEMVER_PATCH = 3,
+};
+
+/**
+ * @brief Caching modes for TLB windows mapped to the NOC.
+ */
+enum tt_tlb_cache_mode {
+    TT_MMIO_CACHE_MODE_UC = 0, /**< Uncached; use for register accesses */
+    TT_MMIO_CACHE_MODE_WC = 1, /**< Write Combined; use for memory accesses */
+};
+
+/**
+ * @brief Ordering modes for NOC transactions.
+ */
+enum tt_noc_ordering {
+    TT_NOC_ORDERING_RELAXED = 0,      /**< Relaxed (no read-after-write hazard) */
+    TT_NOC_ORDERING_STRICT = 1,       /**< Full AXI ordering */
+    TT_NOC_ORDERING_POSTED = 2,       /**< May have read-after-write hazard */
+    TT_NOC_ORDERING_POSTED_STRICT = 3 /**< BH only, Unicast only */
+};
+
+/**
+ * @brief Supported TLB window sizes.
+ */
+#define TT_TLB_SIZE_1M (1ULL << 20)  /**< 1 MiB TLB window (WH only) */
+#define TT_TLB_SIZE_2M (1ULL << 21)  /**< 2 MiB TLB window (WH and BH) */
+#define TT_TLB_SIZE_16M (1ULL << 24) /**< 16 MiB TLB window (WH only) */
+#define TT_TLB_SIZE_4G (1ULL << 32)  /**< 4 GiB TLB window (BH only) */
+
+/**
+ * @brief Open a Tenstorrent device.
+ *
+ * @param chardev_path e.g. "/dev/tenstorrent/0"
+ * @param out_dev Device handle
+ */
+int tt_device_open(const char* chardev_path, tt_device_t** out_dev);
+
+/**
+ * @brief Close a Tenstorrent device.
+ *
+ * @param dev Device handle
+ */
+int tt_device_close(tt_device_t* dev);
+
+/**
+ * @brief Query device attributes.
+ *
+ * @param dev Device handle
+ * @param attr Attribute to query
+ * @param out_value Attribute value
+ * @return 0 on success, error code on failure
+ */
+int tt_device_get_attr(tt_device_t* dev, enum tt_device_attr attr, uint64_t* out_value);
+
+/**
+ * @brief Query driver attributes.
+ *
+ * @param dev Device handle; may be NULL for API version query
+ * @param attr Attribute to query
+ * @param out_value Attribute value
+ * @return 0 on success, error code on failure
+ */
+int tt_driver_get_attr(tt_device_t* dev, enum tt_driver_attr attr, uint64_t* out_value);
+
+/**
+ * @brief Convenience function to read a 32-bit value from a device NOC address.
+ *
+ * Appropriate for reading device registers or memory.
+ * Inefficient due to resource lifecycle management overhead.
+ *
+ * @param dev Device handle
+ * @param x NOC0 x-coordinate
+ * @param y NOC0 y-coordinate
+ * @param addr NOC address
+ * @param value Pointer to store the read value
+ * @return int 0 on success, error code on failure
+ */
+int tt_noc_read32(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, uint32_t* value);
+
+/**
+ * @brief Convenience function to write a 32-bit value to a device NOC address.
+ *
+ * Appropriate for writing device registers or memory.
+ * Inefficient due to resource lifecycle management overhead.
+ *
+ * @param dev Device handle
+ * @param x NOC0 x-coordinate
+ * @param y NOC0 y-coordinate
+ * @param addr NOC address
+ * @param value Value to write
+ * @return int 0 on success, error code on failure
+ */
+int tt_noc_write32(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, uint32_t value);
+
+/**
+ * @brief Convenience function for reading from the device NOC.
+ *
+ * Appropriate for reading device memory (L1/DRAM).
+ * Inefficient due to resource lifecycle management overhead.
+ *
+ * @param dev Device handle
+ * @param x NOC0 x-coordinate
+ * @param y NOC0 y-coordinate
+ * @param addr NOC address
+ * @param dst Pointer to store the read data
+ * @param len Number of bytes to read
+ * @return int 0 on success, error code on failure
+ */
+int tt_noc_read(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, void* dst, size_t len);
+
+/**
+ * @brief Convenience function for writing to the device NOC.
+ *
+ * Appropriate for writing device memory (L1/DRAM).
+ * Inefficient due to resource lifecycle management overhead.
+ *
+ * @param dev Device handle
+ * @param x NOC0 x-coordinate
+ * @param y NOC0 y-coordinate
+ * @param addr NOC address
+ * @param src Pointer to the data to write
+ * @param len Number of bytes to write
+ * @return int 0 on success, error code on failure
+ */
+int tt_noc_write(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, const void* src, size_t len);
+
+/**
+ * @brief Flags to control how a host memory buffer is mapped for device access.
+ *
+ * These flags are used with `tt_dma_map()` to control how a NOC address is
+ * generated for the host memory buffer.
+ *
+ * `TT_DMA_FLAG_NOC` and `TT_DMA_FLAG_NOC_TOP_DOWN` are mutually exclusive.
+ */
+enum tt_dma_map_flags {
+    /**
+     * @brief Do not request a mapping in the device's NOC-to-host aperture.
+     */
+    TT_DMA_FLAG_NONE = 0,
+
+    /**
+     * @brief Requests a mapping in the device's NOC-to-host aperture, allocated
+     * from the bottom up.
+     *
+     * This flag instructs the driver to reserve a region within the PCIe tile's
+     * NOC-to-host address space, mapping it to the pinned host memory. The
+     * driver allocates the lowest available address range within the aperture.
+     *
+     * This technique is intended for applications that have expectations about
+     * the NOC address (i.e. hard-coded in device-side software). Because the
+     * aperture is a shared resource among all clients, the application MUST
+     * validate the address returned by `tt_dma_get_noc_addr()` to ensure it
+     * matches its expectation.
+     */
+    TT_DMA_FLAG_NOC = 1 << 0,
+
+    /**
+     * @brief Requests a mapping in the device's NOC-to-host aperture, allocated
+     * from the top down.
+     *
+     * This flag acts similarly to `TT_DMA_FLAG_NOC`, but allocates from the
+     * highest available address range within the aperture.
+     *
+     * It is intended for tools and runtime components, allowing them to avoid
+     * collisions with bottom-up application mappings. This separation is useful
+     * on Wormhole devices due to their more constrained aperture. While this
+     * flag is supported on Blackhole for consistency, its use is less critical
+     * given Blackhole's larger address space.
+     */
+    TT_DMA_FLAG_NOC_TOP_DOWN = 1 << 1,
+};
+
+/**
+ * @brief Pins a host memory buffer and maps it for device access.
+ *
+ * This function makes a region of host memory accessible to a Tenstorrent
+ * device. It can be used to prepare a buffer for access by the hardware DMA
+ * engine or by device-side software via NOC transactions. If the system IOMMU
+ * is not active, the buffer must be physically contiguous.
+ *
+ * `TT_DMA_FLAG_NOC` or `TT_DMA_FLAG_NOC_TOP_DOWN` flags impose constraints:
+ * WH:
+ * - Per-buffer size: 0x1000 <= len <= 0xFFFE_0000
+ * - Cumulative mapping size limit: 0xFFFE_0000
+ * - Maximum mappings: 16 simultaneous
+ * BH:
+ * - Per-buffer size: 0x1000 <= len <= 0xFFFF_F000
+ * - Maximum mappings: 16 simultaneous
+ *
+ * @param dev Device handle
+ * @param addr Virtual address of memory to map; must be page-aligned
+ * @param len Number of bytes; must be a multiple of the page size
+ * @param flags Bitmask of flags from `enum tt_dma_map_flags`
+ * @param out_dma On success, a handle for the pinned mapping
+ * @return 0 on success, error code on failure
+ */
+int tt_dma_map(tt_device_t* dev, void* addr, size_t len, int flags, tt_dma_t** out_dma);
+
+/**
+ * @brief Unpins a previously mapped memory region.
+ *
+ * Releases all resources associated with the mapping.
+ *
+ * @param dev Device handle
+ * @param dma DMA handle from `tt_dma_map()`
+ * @return 0 on success, error code on failure
+ */
+int tt_dma_unmap(tt_device_t* dev, tt_dma_t* dma);
+
+/**
+ * @brief Gets the DMA address for a mapped memory region.
+ *
+ * The address will be an I/O Virtual Address (IOVA) if an IOMMU is active on
+ * the system, or a physical address (PA) otherwise. The address is always
+ * available and is suitable for programming the hardware PCIe DMA engine.
+ *
+ * @param dma DMA handle from `tt_dma_map()`
+ * @param out_dma_addr DMA address (IOVA or PA) for PCIe DMA operations
+ * @return 0 on success, error code on failure
+ */
+int tt_dma_get_dma_addr(tt_dma_t* dma, uint64_t* out_dma_addr);
+
+/**
+ * @brief Gets the NOC-accessible address for a mapped memory region.
+ *
+ * Returns the address that device-side software must use to access the pinned
+ * host buffer via the NOC.
+ *
+ * @param dma DMA handle from `tt_dma_map()`
+ * @param out_noc_addr NOC address for device-side software access
+ * @return 0 on success, error code on failure
+ */
+int tt_dma_get_noc_addr(tt_dma_t* dma, uint64_t* out_noc_addr);
+
+/**
+ * @brief Allocates a TLB window.
+ *
+ * Quantities and sizes of TLB windows vary by device architecture:
+ *
+ * Wormhole:
+ *   156x  1 MiB windows
+ *    10x  2 MiB windows
+ *    20x 16 MiB windows
+ * Blackhole:
+ *   202x  2 MiB windows
+ *     8x  4 GiB windows
+ *
+ * The driver may reserve one or more TLB windows for internal use.
+ *
+ * @param dev Device handle
+ * @param size 1, 2, or 16 MiB (WH); 2 MiB or 4 GiB (BH)
+ * @param cache Caching attribute; see `enum tt_tlb_cache_mode`
+ * @param out_tlb On success, a handle to the allocated TLB window
+ * @return 0 on success, error code on failure
+ */
+int tt_tlb_alloc(tt_device_t* dev, size_t size, enum tt_tlb_cache_mode cache, tt_tlb_t** out_tlb);
+
+/**
+ * @brief Releases a TLB window.
+ *
+ * @param dev Device handle
+ * @param tlb TLB window to release
+ * @return 0 on success, error code on failure
+ */
+int tt_tlb_free(tt_device_t* dev, tt_tlb_t* tlb);
+
+/**
+ * @brief Get a pointer to the MMIO region of a TLB window.
+ *
+ * Loads/stores using this pointer will access the device NOC according to the
+ * TLB window's configuration. Dereferencing the pointer after calling
+ * `tt_tlb_free()` on the TLB handle will invoke undefined behavior.
+ *
+ * @param tlb TLB window handle from `tt_tlb_alloc()`
+ * @param out_mmio Pointer to the MMIO region of the TLB window
+ * @return 0 on success, error code on failure
+ */
+int tt_tlb_get_mmio(tt_tlb_t* tlb, void** out_mmio);
+
+/**
+ * @brief Maps a TLB window to a NOC endpoint.
+ *
+ * @param dev Device handle
+ * @param tlb TLB window handle from `tt_tlb_alloc()`
+ * @param config NOC address configuration
+ * @return 0 on success, error code on failure
+ */
+int tt_tlb_map(tt_device_t* dev, tt_tlb_t* tlb, tt_noc_addr_config_t* config);
+
+/**
+ * @brief Maps a TLB window to a NOC endpoint.
+ *
+ * This is a convenience function for a common operation. See `tt_tlb_map()`.
+ *
+ * @param dev Device handle
+ * @param tlb TLB window handle from `tt_tlb_alloc()`
+ * @param x NOC0 x-coordinate
+ * @param y NOC0 y-coordinate
+ * @param addr Address in the tile; must be a multiple of the TLB size
+ * @return 0 on success, error code on failure
+ */
+int tt_tlb_map_unicast(tt_device_t* dev, tt_tlb_t* tlb, uint8_t x, uint8_t y, uint64_t addr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TTKMD_H_

--- a/device/pcie/ioctl.h
+++ b/device/pcie/ioctl.h
@@ -337,6 +337,5 @@ struct tenstorrent_set_noc_cleanup {
 	__u64 data;
 };
 
-
 #endif
 // clang-format on

--- a/device/tt_kmd_lib/tt_kmd_lib.c
+++ b/device/tt_kmd_lib/tt_kmd_lib.c
@@ -1,0 +1,534 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "umd/device/tt_kmd_lib/tt_kmd_lib.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/mman.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "pcie/ioctl.h"
+
+#define BLACKHOLE_PCI_DEVICE_ID 0xb140
+#define WORMHOLE_PCI_DEVICE_ID 0x401e
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define DEBUG(fmt, ...)                                                        \
+    do {                                                                       \
+        fprintf(stderr, "%s:%d " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); \
+    } while (0)
+
+static uint64_t TLB_COUNT_1M[] = {
+    [TT_DEVICE_ARCH_UNKNOWN] = 0,
+    [TT_DEVICE_ARCH_WORMHOLE] = 156,
+    [TT_DEVICE_ARCH_BLACKHOLE] = 0,
+};
+
+static uint64_t TLB_COUNT_2M[] = {
+    [TT_DEVICE_ARCH_UNKNOWN] = 0,
+    [TT_DEVICE_ARCH_WORMHOLE] = 10,
+    [TT_DEVICE_ARCH_BLACKHOLE] = 202,
+};
+
+static uint64_t TLB_COUNT_16M[] = {
+    [TT_DEVICE_ARCH_UNKNOWN] = 0,
+    [TT_DEVICE_ARCH_WORMHOLE] = 20,
+    [TT_DEVICE_ARCH_BLACKHOLE] = 0,
+};
+
+static uint64_t TLB_COUNT_4G[] = {
+    [TT_DEVICE_ARCH_UNKNOWN] = 0, [TT_DEVICE_ARCH_WORMHOLE] = 0, [TT_DEVICE_ARCH_BLACKHOLE] = 8};
+
+struct tt_device_t {
+    int fd;
+};
+
+struct tt_tlb_t {
+    uint32_t id;
+    size_t size;
+    void* mmio;
+};
+
+struct tt_dma_t {
+    void* addr;    /* Virtual address */
+    size_t len;    /* Bytes */
+    uint64_t iova; /* I/O Virtual Address */
+    uint64_t noc;  /* NOC address (inside EP PCIe tile) */
+};
+
+int tt_device_open(const char* chardev_path, tt_device_t** out_dev) {
+    struct tt_device_t* dev = malloc(sizeof(struct tt_device_t));
+
+    if (!dev) {
+        return -ENOMEM;
+    }
+
+    memset(dev, 0, sizeof(struct tt_device_t));
+
+    dev->fd = open(chardev_path, O_RDWR | O_CLOEXEC);
+    if (dev->fd == -1) {
+        int e = errno;
+        free(dev);
+        return -e;
+    }
+
+    uint64_t major = 0;
+    uint64_t minor = 0;
+    uint64_t patch = 0;
+
+    int ret;
+    if ((ret = tt_driver_get_attr(dev, TT_DRIVER_SEMVER_MAJOR, &major)) != 0 ||
+        (ret = tt_driver_get_attr(dev, TT_DRIVER_SEMVER_MINOR, &minor)) != 0 ||
+        (ret = tt_driver_get_attr(dev, TT_DRIVER_SEMVER_PATCH, &patch)) != 0) {
+        close(dev->fd);
+        free(dev);
+        return ret;
+    }
+
+    if (major != TENSTORRENT_DRIVER_VERSION_MAJOR || minor < TENSTORRENT_DRIVER_VERSION_MINOR) {
+        DEBUG(
+            "Driver version mismatch: compiled for v%d.%d.%d; detected v%lu.%lu.%lu\n",
+            TENSTORRENT_DRIVER_VERSION_MAJOR,
+            TENSTORRENT_DRIVER_VERSION_MINOR,
+            TENSTORRENT_DRIVER_VERSION_PATCH,
+            major,
+            minor,
+            patch);
+        close(dev->fd);
+        free(dev);
+        return -ENODEV;
+    }
+
+    *out_dev = dev;
+
+    return 0;
+}
+
+int tt_device_close(tt_device_t* dev) {
+    if (close(dev->fd) != 0) {
+        return -errno;
+    }
+
+    free(dev);
+    return 0;
+}
+
+int tt_device_get_attr(tt_device_t* dev, enum tt_device_attr attr, uint64_t* out_value) {
+    struct tenstorrent_get_device_info get_device_info = {0};
+
+    get_device_info.in.output_size_bytes = sizeof(get_device_info.out);
+
+    if (ioctl(dev->fd, TENSTORRENT_IOCTL_GET_DEVICE_INFO, &get_device_info) != 0) {
+        return -errno;
+    }
+
+    uint64_t arch = TT_DEVICE_ARCH_UNKNOWN;
+    if (get_device_info.out.device_id == BLACKHOLE_PCI_DEVICE_ID) {
+        arch = TT_DEVICE_ARCH_BLACKHOLE;
+    } else if (get_device_info.out.device_id == WORMHOLE_PCI_DEVICE_ID) {
+        arch = TT_DEVICE_ARCH_WORMHOLE;
+    }
+
+    switch (attr) {
+        case TT_DEVICE_ATTR_PCI_DOMAIN:
+            *out_value = get_device_info.out.pci_domain;
+            break;
+        case TT_DEVICE_ATTR_PCI_BUS:
+            *out_value = get_device_info.out.bus_dev_fn >> 8;
+            break;
+        case TT_DEVICE_ATTR_PCI_DEVICE:
+            *out_value = (get_device_info.out.bus_dev_fn >> 3) & 0x1F;
+            break;
+        case TT_DEVICE_ATTR_PCI_FUNCTION:
+            *out_value = get_device_info.out.bus_dev_fn & 0x07;
+            break;
+        case TT_DEVICE_ATTR_PCI_VENDOR_ID:
+            *out_value = get_device_info.out.vendor_id;
+            break;
+        case TT_DEVICE_ATTR_PCI_DEVICE_ID:
+            *out_value = get_device_info.out.device_id;
+            break;
+        case TT_DEVICE_ATTR_PCI_SUBSYSTEM_ID:
+            *out_value = get_device_info.out.subsystem_id;
+            break;
+        case TT_DEVICE_ATTR_CHIP_ARCH:
+            *out_value = arch;
+            break;
+        case TT_DEVICE_ATTR_NUM_1M_TLBS:
+            *out_value = TLB_COUNT_1M[arch];
+            break;
+        case TT_DEVICE_ATTR_NUM_2M_TLBS:
+            *out_value = TLB_COUNT_2M[arch];
+            break;
+        case TT_DEVICE_ATTR_NUM_16M_TLBS:
+            *out_value = TLB_COUNT_16M[arch];
+            break;
+        case TT_DEVICE_ATTR_NUM_4G_TLBS:
+            *out_value = TLB_COUNT_4G[arch];
+            break;
+        default:
+            return -EINVAL;
+    }
+
+    return 0;
+}
+
+int tt_driver_get_attr(tt_device_t* dev, enum tt_driver_attr attr, uint64_t* out_value) {
+    struct tenstorrent_get_driver_info get_driver_info = {0};
+    get_driver_info.in.output_size_bytes = sizeof(get_driver_info.out);
+
+    /* OK to call with NULL dev, but can't return semver without a device. */
+    if (dev) {
+        if (ioctl(dev->fd, TENSTORRENT_IOCTL_GET_DRIVER_INFO, &get_driver_info) != 0) {
+            return -errno;
+        }
+    }
+
+    switch (attr) {
+        case TT_DRIVER_API_VERSION:
+            *out_value = TENSTORRENT_DRIVER_VERSION;
+            return 0;
+        case TT_DRIVER_SEMVER_MAJOR:
+            *out_value = get_driver_info.out.driver_version_major;
+            return dev ? 0 : -ENODEV;
+        case TT_DRIVER_SEMVER_MINOR:
+            *out_value = get_driver_info.out.driver_version_minor;
+            return dev ? 0 : -ENODEV;
+        case TT_DRIVER_SEMVER_PATCH:
+            *out_value = get_driver_info.out.driver_version_patch;
+            return dev ? 0 : -ENODEV;
+        default:
+            return -EINVAL;
+    }
+
+    return 0;
+}
+
+int tt_noc_read32(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, uint32_t* value) {
+    if (addr % 4 != 0) {
+        return -EINVAL;
+    }
+
+    tt_tlb_t* tlb;
+    int ret = tt_tlb_alloc(dev, TT_TLB_SIZE_2M, TT_MMIO_CACHE_MODE_UC, &tlb);
+    if (ret != 0) {
+        return ret;
+    }
+
+    uint64_t aligned_addr = addr & ~(tlb->size - 1);
+    ret = tt_tlb_map_unicast(dev, tlb, x, y, aligned_addr);
+
+    if (ret != 0) {
+        tt_tlb_free(dev, tlb);
+        return ret;
+    }
+
+    uint64_t offset = addr & (tlb->size - 1);
+    *value = *(volatile uint32_t*)((uint8_t*)tlb->mmio + offset);
+
+    tt_tlb_free(dev, tlb);
+    return 0;
+}
+
+int tt_noc_write32(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, uint32_t value) {
+    if (addr % 4 != 0) {
+        return -EINVAL;
+    }
+
+    tt_tlb_t* tlb;
+    int ret = tt_tlb_alloc(dev, TT_TLB_SIZE_2M, TT_MMIO_CACHE_MODE_UC, &tlb);
+    if (ret != 0) {
+        return ret;
+    }
+
+    uint64_t aligned_addr = addr & ~(tlb->size - 1);
+    ret = tt_tlb_map_unicast(dev, tlb, x, y, aligned_addr);
+
+    if (ret != 0) {
+        tt_tlb_free(dev, tlb);
+        return ret;
+    }
+
+    uint64_t offset = addr & (tlb->size - 1);
+    *(volatile uint32_t*)((uint8_t*)tlb->mmio + offset) = value;
+
+    tt_tlb_free(dev, tlb);
+    return 0;
+}
+
+int tt_noc_read(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, void* dst, size_t len) {
+    uint8_t* dst_ptr = (uint8_t*)dst;
+    tt_tlb_t* tlb;
+    int32_t ret;
+
+    if (addr % 4 != 0 || len % 4 != 0) {
+        return -EINVAL;
+    }
+
+    ret = tt_tlb_alloc(dev, TT_TLB_SIZE_2M, TT_MMIO_CACHE_MODE_WC, &tlb);
+    if (ret != 0) {
+        return ret;
+    }
+
+    while (len > 0) {
+        uint64_t aligned_addr = addr & ~(tlb->size - 1);
+        uint64_t offset = addr & (tlb->size - 1);
+        size_t chunk_size = MIN(len, tlb->size - offset);
+        uint8_t* src_ptr = (uint8_t*)tlb->mmio + offset;
+
+        ret = tt_tlb_map_unicast(dev, tlb, x, y, aligned_addr);
+
+        if (ret != 0) {
+            tt_tlb_free(dev, tlb);
+            return ret;
+        }
+
+        memcpy(dst_ptr, src_ptr, chunk_size);
+
+        dst_ptr += chunk_size;
+        len -= chunk_size;
+        addr += chunk_size;
+    }
+
+    tt_tlb_free(dev, tlb);
+
+    return 0;
+}
+
+int tt_noc_write(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, const void* src, size_t len) {
+    const uint8_t* src_ptr = (const uint8_t*)src;
+    tt_tlb_t* tlb;
+    int32_t ret;
+
+    if (addr % 4 != 0 || len % 4 != 0) {
+        return -EINVAL;
+    }
+
+    ret = tt_tlb_alloc(dev, TT_TLB_SIZE_2M, TT_MMIO_CACHE_MODE_WC, &tlb);
+    if (ret != 0) {
+        return ret;
+    }
+
+    while (len > 0) {
+        uint64_t aligned_addr = addr & ~(tlb->size - 1);
+        uint64_t offset = addr & (tlb->size - 1);
+        size_t chunk_size = MIN(len, tlb->size - offset);
+        uint8_t* dst_ptr = (uint8_t*)tlb->mmio + offset;
+
+        ret = tt_tlb_map_unicast(dev, tlb, x, y, aligned_addr);
+
+        if (ret != 0) {
+            tt_tlb_free(dev, tlb);
+            return ret;
+        }
+
+        memcpy(dst_ptr, src_ptr, chunk_size);
+
+        src_ptr += chunk_size;
+        len -= chunk_size;
+        addr += chunk_size;
+    }
+
+    tt_tlb_free(dev, tlb);
+
+    return 0;
+}
+
+int tt_dma_map(tt_device_t* dev, void* addr, size_t len, int flags, tt_dma_t** out_dma) {
+    int page_size = getpagesize();
+    if (len == 0 || len % page_size != 0 || addr == NULL || (uint64_t)addr % page_size != 0) {
+        return -EINVAL;
+    }
+
+    struct tt_dma_t* dma = malloc(sizeof(struct tt_dma_t));
+
+    if (!dma) {
+        return -ENOMEM;
+    }
+
+    memset(dma, 0, sizeof(struct tt_dma_t));
+
+    struct {
+        struct tenstorrent_pin_pages_in in;
+        struct tenstorrent_pin_pages_out_extended out;
+    } pin_pages;
+
+    memset(&pin_pages, 0, sizeof(pin_pages));
+
+    pin_pages.in.output_size_bytes = sizeof(pin_pages.out);
+    pin_pages.in.virtual_address = (uint64_t)addr;
+    pin_pages.in.size = len;
+
+    if (flags & TT_DMA_FLAG_NOC) {
+        pin_pages.in.flags = TENSTORRENT_PIN_PAGES_NOC_DMA;
+    } else if (flags & TT_DMA_FLAG_NOC_TOP_DOWN) {
+        pin_pages.in.flags = TENSTORRENT_PIN_PAGES_NOC_TOP_DOWN;
+    } else {
+        pin_pages.in.flags = 0;
+    }
+
+    if (ioctl(dev->fd, TENSTORRENT_IOCTL_PIN_PAGES, &pin_pages) != 0) {
+        int e = errno;
+        free(dma);
+        return -e;
+    }
+
+    dma->addr = addr;
+    dma->len = len;
+    dma->iova = pin_pages.out.physical_address;
+
+    if (flags & (TT_DMA_FLAG_NOC | TT_DMA_FLAG_NOC_TOP_DOWN)) {
+        dma->noc = pin_pages.out.noc_address;
+    } else {
+        dma->noc = ~0ULL;
+    }
+
+    *out_dma = dma;
+
+    return 0;
+}
+
+int tt_dma_unmap(tt_device_t* dev, tt_dma_t* dma) {
+    struct tenstorrent_unpin_pages unpin = {0};
+    unpin.in.virtual_address = (uint64_t)dma->addr;
+    unpin.in.size = dma->len;
+
+    if (ioctl(dev->fd, TENSTORRENT_IOCTL_UNPIN_PAGES, &unpin) != 0) {
+        return -errno;
+    }
+
+    free(dma);
+
+    return 0;
+}
+
+int tt_dma_get_dma_addr(tt_dma_t* dma, uint64_t* out_dma_addr) {
+    *out_dma_addr = dma->iova;
+    return 0;
+}
+
+int tt_dma_get_noc_addr(tt_dma_t* dma, uint64_t* out_noc_addr) {
+    if (dma->noc == ~0ULL) {
+        return -EINVAL;
+    }
+
+    *out_noc_addr = dma->noc;
+    return 0;
+}
+
+int tt_tlb_alloc(tt_device_t* dev, size_t size, enum tt_tlb_cache_mode cache, tt_tlb_t** out_tlb) {
+    struct tt_tlb_t* tlb = malloc(sizeof(struct tt_tlb_t));
+
+    if (!tlb) {
+        return -ENOMEM;
+    }
+
+    memset(tlb, 0, sizeof(struct tt_tlb_t));
+
+    struct tenstorrent_allocate_tlb alloc_tlb = {0};
+    alloc_tlb.in.size = size;
+
+    if (ioctl(dev->fd, TENSTORRENT_IOCTL_ALLOCATE_TLB, &alloc_tlb) != 0) {
+        int e = errno;
+        free(tlb);
+        return -e;
+    }
+
+    off_t offset = cache == TT_MMIO_CACHE_MODE_UC ? alloc_tlb.out.mmap_offset_uc : alloc_tlb.out.mmap_offset_wc;
+    tlb->id = alloc_tlb.out.id;
+    tlb->size = size;
+    tlb->mmio = mmap(NULL, tlb->size, PROT_READ | PROT_WRITE, MAP_SHARED, dev->fd, offset);
+
+    if (tlb->mmio == MAP_FAILED) {
+        struct tenstorrent_free_tlb free_tlb = {0};
+        int e = errno;
+        free_tlb.in.id = tlb->id;
+        if (ioctl(dev->fd, TENSTORRENT_IOCTL_FREE_TLB, &free_tlb) != 0) {
+            fprintf(stderr, "Leaked TLB %u: after mmap failure: %s\n", tlb->id, strerror(errno));
+        }
+
+        free(tlb);
+        errno = e;
+        return -e;
+    }
+
+    *out_tlb = tlb;
+
+    return 0;
+}
+
+int tt_tlb_free(tt_device_t* dev, tt_tlb_t* tlb) {
+    int ret = 0;
+
+    /* Unmap the userspace view of the TLB. This is required by the driver. */
+    munmap(tlb->mmio, tlb->size);
+
+    /* Tell the driver to release the backing hardware resource. */
+    struct tenstorrent_free_tlb free_tlb = {0};
+    free_tlb.in.id = tlb->id;
+    if (ioctl(dev->fd, TENSTORRENT_IOCTL_FREE_TLB, &free_tlb) != 0) {
+        ret = -errno;
+    }
+
+    free(tlb);
+
+    return ret;
+}
+
+int tt_tlb_get_mmio(tt_tlb_t* tlb, void** out_mmio) {
+    *out_mmio = tlb->mmio;
+    return 0;
+}
+
+int tt_tlb_map(tt_device_t* dev, tt_tlb_t* tlb, tt_noc_addr_config_t* config) {
+    struct tenstorrent_configure_tlb configure_tlb = {0};
+
+    if (config->addr & (tlb->size - 1)) {
+        return -EINVAL;
+    }
+
+    configure_tlb.in.id = tlb->id;
+    configure_tlb.in.config.addr = config->addr;
+    configure_tlb.in.config.x_end = config->x_end;
+    configure_tlb.in.config.y_end = config->y_end;
+    configure_tlb.in.config.x_start = config->x_start;
+    configure_tlb.in.config.y_start = config->y_start;
+    configure_tlb.in.config.noc = config->noc;
+    configure_tlb.in.config.mcast = config->mcast;
+    configure_tlb.in.config.ordering = config->ordering;
+    configure_tlb.in.config.static_vc = config->static_vc;
+
+    if (ioctl(dev->fd, TENSTORRENT_IOCTL_CONFIGURE_TLB, &configure_tlb) != 0) {
+        return -errno;
+    }
+
+    return 0;
+}
+
+int tt_tlb_map_unicast(tt_device_t* dev, tt_tlb_t* tlb, uint8_t x, uint8_t y, uint64_t addr) {
+    struct tenstorrent_configure_tlb configure_tlb = {0};
+
+    if (addr & (tlb->size - 1)) {
+        return -EINVAL;
+    }
+
+    configure_tlb.in.id = tlb->id;
+    configure_tlb.in.config.addr = addr;
+    configure_tlb.in.config.x_end = x;
+    configure_tlb.in.config.y_end = y;
+
+    if (ioctl(dev->fd, TENSTORRENT_IOCTL_CONFIGURE_TLB, &configure_tlb) != 0) {
+        return -errno;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Issue

Work towards #1199 

### Description

Add files implemented by @joelsmithTT, known as tt kmd lib. These files were implemented in https://github.com/tenstorrent/tt-kmd/pull/101. The discussions led to the idea to integrate this into UMD for now, as first tester of these files. This is going to build up on work done in #959. This PR is meant just to include these files, there will be a follow up PR that integrates usage of these functions to UMD.

### List of the changes

- Add tt_kmd_lib.c 
- Add tt_kmb_lib.h
- Fix cmake files to be able to build these files inside UMD

### Testing
/

### API Changes
/