### PR TITLE
Add ipmi check in tests

### DIFF
--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -60,7 +60,7 @@ std::vector<ClusterOptions> get_cluster_options_for_param_test() {
     return options;
 }
 
-// Small helper function to check if the ipmitool is ready
+// Small helper function to check if the ipmitool is ready.
 bool is_ipmitool_ready() {
     if (system("which ipmitool > /dev/null 2>&1") != 0) {
         std::cout << "ipmitool executable not found." << std::endl;


### PR DESCRIPTION
### Issue
/

### Description
Test fails if there is no ipmitool on host, or if the driver is not present, hence skip the test if the tools aren't available.

### List of the changes
- Added check in test for tool or driver

### Testing
Manual

### API Changes
/
