### PR TITLE
Update latest supported FW version to 19.0.0

### DIFF
--- a/device/firmware/firmware_info_provider.cpp
+++ b/device/firmware/firmware_info_provider.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<FirmwareInfoProvider> FirmwareInfoProvider::create_firmware_info
 
 semver_t FirmwareInfoProvider::get_firmware_version() const { return firmware_version; }
 
-semver_t FirmwareInfoProvider::get_latest_supported_firmware_version(tt::ARCH arch) { return semver_t(18, 10, 0); }
+semver_t FirmwareInfoProvider::get_latest_supported_firmware_version(tt::ARCH arch) { return semver_t(19, 0, 0); }
 
 semver_t FirmwareInfoProvider::get_minimum_compatible_firmware_version(tt::ARCH arch) {
     switch (arch) {


### PR DESCRIPTION
### Issue

Latest fully supported FW version was 18.10 so people were getting warnings about compatibility

### Description

Since we are supporting all the features important for UMD/metal up until the newest release, which is 19.0.0, we can bump newest version to that one.

### List of the changes

- Update latest fully supported firmware version

### Testing
CI

### API Changes
/