### PR TITLE
Adding UMD support for the new libttsim_set_debug_core API. 

### DIFF
--- a/device/api/umd/device/simulation/tt_sim_chip.hpp
+++ b/device/api/umd/device/simulation/tt_sim_chip.hpp
@@ -30,6 +30,8 @@ public:
     void assert_risc_reset(CoreCoord core, const RiscType selected_riscs) override;
     void deassert_risc_reset(CoreCoord core, const RiscType selected_riscs, bool staggered_start) override;
 
+    void set_debug_core(uint32_t x, uint32_t y);
+
 private:
     std::unique_ptr<architecture_implementation> architecture_impl_;
     std::filesystem::path copied_simulator_directory_;
@@ -42,6 +44,7 @@ private:
     void (*pfn_libttsim_tile_rd_bytes)(uint32_t x, uint32_t y, uint64_t addr, void* p, uint32_t size) = nullptr;
     void (*pfn_libttsim_tile_wr_bytes)(uint32_t x, uint32_t y, uint64_t addr, const void* p, uint32_t size) = nullptr;
     void (*pfn_libttsim_clock)(uint32_t n_clocks) = nullptr;
+    void (*pfn_libttsim_set_debug_core)(uint32_t x, uint32_t y) = nullptr;
 };
 
 }  // namespace tt::umd

--- a/device/simulation/tt_sim_chip.cpp
+++ b/device/simulation/tt_sim_chip.cpp
@@ -62,6 +62,7 @@ TTSimChip::TTSimChip(const std::filesystem::path& simulator_directory, SocDescri
     DLSYM_FUNCTION(libttsim_tile_rd_bytes)
     DLSYM_FUNCTION(libttsim_tile_wr_bytes)
     DLSYM_FUNCTION(libttsim_clock)
+    DLSYM_FUNCTION(libttsim_set_debug_core)
 }
 
 TTSimChip::~TTSimChip() {
@@ -141,6 +142,11 @@ void TTSimChip::deassert_risc_reset(CoreCoord core, const RiscType selected_risc
     pfn_libttsim_tile_rd_bytes(translate_core.x, translate_core.y, soft_reset_addr, &reset_value, sizeof(reset_value));
     reset_value &= ~soft_reset_update;
     pfn_libttsim_tile_wr_bytes(translate_core.x, translate_core.y, soft_reset_addr, &reset_value, sizeof(reset_value));
+}
+
+void TTSimChip::set_debug_core(uint32_t x, uint32_t y) {
+    std::lock_guard<std::mutex> lock(device_lock);
+    pfn_libttsim_set_debug_core(x, y);
 }
 
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue
N/A. Required to make https://github.com/tenstorrent/tt-metal/pull/31880 work

### Description
As part of enabling a Tensix state dump on TTSIM, a new API on TTSIM has been added allowing TTSIM to read which cores have been set in the environment variable TT_METAL_DPRINT_CORES. This allows the user to specify which Tensix cores to perform the TTSIM_TENSIX_DUMP on.

### List of the changes
On TTSIM:  Added a set_debug_core api to set whether each Tensix tile core is to be included in the Tensix state dump or not.

On UMD: added class method in TTSimChip to include this new API exposed on libttsim.so. 

### Testing
Manual testing done on metal to ensure this debug feature and, in particular, the communication of the DPRINT_CORES environment variable information from TT-METAL to TTSIM via UMD is working.

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
