### PR TITLE
Simplify getting board ID in TopologyDiscovery

### DIFF
--- a/device/topology/topology_discovery_wormhole.cpp
+++ b/device/topology/topology_discovery_wormhole.cpp
@@ -96,14 +96,7 @@ uint64_t TopologyDiscoveryWormhole::get_local_board_id(Chip* chip, tt_xy_pair et
         return get_local_asic_id(chip, eth_core);
     }
 
-    TTDevice* tt_device = chip->get_tt_device();
-    uint32_t board_id;
-    tt_device->read_from_device(
-        &board_id,
-        eth_core,
-        eth_addresses.results_buf + (4 * eth_addresses.erisc_local_board_id_lo_offset),
-        sizeof(uint32_t));
-    return board_id;
+    return chip->get_tt_device()->get_firmware_info_provider()->get_board_id();
 }
 
 uint64_t TopologyDiscoveryWormhole::get_remote_board_type(Chip* chip, tt_xy_pair eth_core) {


### PR DESCRIPTION
### Issue
#1585


### Description
Remove code duplication when getting local board ID in TopologyDiscovery

### List of the changes
/

### Testing
CI

### API Changes
There are no API changes in this PR.

