### PR TITLE
blackhole: Remove BAR4 handling from UMD

### DIFF
--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -172,8 +172,8 @@ inline constexpr uint32_t TLB_2M_SIZE = 2 * 1024 * 1024;
 
 inline constexpr uint32_t TLB_CFG_REG_SIZE_BYTES = 12;
 
-inline constexpr uint32_t TLB_COUNT_4G = 8;
-inline constexpr uint32_t TLB_BASE_4G = 0;  // 0 in BAR4
+inline constexpr uint32_t TLB_COUNT_4G = 8;  // NB: Unused, and assumes a 32 GiB BAR4.
+inline constexpr uint32_t TLB_BASE_4G = 0;   // 0 in BAR4
 inline constexpr uint32_t TLB_BASE_INDEX_4G = TLB_COUNT_2M;
 inline constexpr uint64_t TLB_4G_SIZE = 4ULL * 1024ULL * 1024ULL * 1024ULL;
 inline constexpr uint64_t DYNAMIC_TLB_4G_SIZE = TLB_4G_SIZE;

--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -259,9 +259,6 @@ public:
     void *bar2_uc = nullptr;
     size_t bar2_uc_size;
 
-    void *bar4_wc = nullptr;
-    uint64_t bar4_wc_size;
-
     // TODO: let's get rid of this unless we need to run UMD on WH systems with
     // shrunk BAR0.  If we don't (and we shouldn't), then we can just use BAR0
     // and simplify the code.
@@ -274,7 +271,7 @@ public:
 
     template <typename T>
     T *get_register_address(uint32_t register_offset) {
-        // Right now, address can either be exposed register in BAR, or TLB window in BAR0 (BAR4 for Blackhole).
+        // Right now, address can either be exposed register in BAR, or TLB window in BAR0.
         // Should clarify this interface
         void *reg_mapping;
         if (system_reg_mapping != nullptr && register_offset >= system_reg_start_offset) {

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -29,12 +29,6 @@ namespace tt::umd {
 // See /vendor_ip/synopsys/052021/bh_pcie_ctl_gen5/export/configuration/DWC_pcie_ctl.h
 static const uint64_t UNROLL_ATU_OFFSET_BAR = 0x1200;
 
-// TODO: should be removed from tt_device.h, and put into blackhole_tt_device.h
-// TODO: this is a bit of a hack... something to revisit when we formalize an
-// abstraction for IO.
-// BAR0 size for Blackhole, used to determine whether write block should use BAR0 or BAR4
-static const uint64_t BAR0_BH_SIZE = 512 * 1024 * 1024;
-
 struct dynamic_tlb {
     uint64_t bar_offset;      // Offset that address is mapped to, within the PCI BAR.
     uint64_t remaining_size;  // Bytes remaining between bar_offset and end of the TLB.

--- a/device/arch/blackhole_implementation.cpp
+++ b/device/arch/blackhole_implementation.cpp
@@ -30,17 +30,10 @@ std::tuple<xy_pair, xy_pair> blackhole_implementation::multicast_workaround(xy_p
 }
 
 tlb_configuration blackhole_implementation::get_tlb_configuration(uint32_t tlb_index) const {
-    // If TLB index is in range for 4GB tlbs (8 TLBs after 202 TLBs for 2MB)
-    if (tlb_index >= blackhole::TLB_COUNT_2M && tlb_index < blackhole::TLB_COUNT_2M + blackhole::TLB_COUNT_4G) {
-        return tlb_configuration{
-            .size = blackhole::DYNAMIC_TLB_4G_SIZE,
-            .base = blackhole::DYNAMIC_TLB_4G_BASE,
-            .cfg_addr = blackhole::DYNAMIC_TLB_4G_CFG_ADDR,
-            .index_offset = tlb_index - blackhole::TLB_BASE_INDEX_4G,
-            .tlb_offset = blackhole::DYNAMIC_TLB_4G_BASE +
-                          (tlb_index - blackhole::TLB_BASE_INDEX_4G) * blackhole::DYNAMIC_TLB_4G_SIZE,
-            .offset = blackhole::TLB_4G_OFFSET,
-        };
+    if (tlb_index >= blackhole::TLB_COUNT_2M) {
+        // 4G TLBs windows are not supported by the UMD due to variable size BAR4 as a feature.
+        // If/when support is needed, the suggestion is to use the KMD API to allocate/map the 4G TLBs.
+        throw std::runtime_error(fmt::format("Invalid TLB index: {}", tlb_index));
     }
 
     return tlb_configuration{

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -299,14 +299,7 @@ void LocalChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_des
     }
     if (tlb_manager_->is_tlb_mapped(translated_core, l1_dest, size)) {
         tlb_configuration tlb_description = tlb_manager_->get_tlb_configuration(translated_core);
-        if (tt_device_->get_pci_device()->bar4_wc != nullptr && tlb_description.size == BH_4GB_TLB_SIZE) {
-            // This is only for Blackhole. If we want to  write to DRAM (BAR4 space), we add offset
-            // to which we write so write_block knows it needs to target BAR4
-            tt_device_->write_block(
-                (tlb_description.tlb_offset + l1_dest % tlb_description.size) + BAR0_BH_SIZE, size, buffer_addr);
-        } else {
-            tt_device_->write_block(tlb_description.tlb_offset + l1_dest % tlb_description.size, size, buffer_addr);
-        }
+        tt_device_->write_block(tlb_description.tlb_offset + l1_dest % tlb_description.size, size, buffer_addr);
     } else {
         std::string fallback_tlb = "LARGE_WRITE_TLB";
         const auto tlb_index = tlb_manager_->dynamic_tlb_config_.at(fallback_tlb);
@@ -346,14 +339,7 @@ void LocalChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, ui
     }
     if (tlb_manager_->is_tlb_mapped(translated_core, l1_src, size)) {
         tlb_configuration tlb_description = tlb_manager_->get_tlb_configuration(translated_core);
-        if (tt_device_->get_pci_device()->bar4_wc != nullptr && tlb_description.size == BH_4GB_TLB_SIZE) {
-            // This is only for Blackhole. If we want to  read from DRAM (BAR4 space), we add offset
-            // from which we read so read_block knows it needs to target BAR4
-            tt_device_->read_block(
-                (tlb_description.tlb_offset + l1_src % tlb_description.size) + BAR0_BH_SIZE, size, buffer_addr);
-        } else {
-            tt_device_->read_block(tlb_description.tlb_offset + l1_src % tlb_description.size, size, buffer_addr);
-        }
+        tt_device_->read_block(tlb_description.tlb_offset + l1_src % tlb_description.size, size, buffer_addr);
         log_trace(
             LogUMD,
             "  read_block called with tlb_offset: {}, tlb_size: {}",

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -464,25 +464,6 @@ PCIDevice::PCIDevice(int pci_device_number) :
         if (bar2_uc == MAP_FAILED) {
             throw std::runtime_error(fmt::format("BAR2 UC mapping failed for device {}.", pci_device_num));
         }
-
-        if (bar4_wc_mapping.mapping_id != TENSTORRENT_MAPPING_RESOURCE2_WC) {
-            throw std::runtime_error(fmt::format("Device {} has no BAR4 WC mapping.", pci_device_num));
-        }
-
-        // Using Write-Combine memory mode. This is used for accessing DRAM on Blackhole.
-        // WC doesn't guarantee write ordering but has better performance.
-        bar4_wc_size = bar4_wc_mapping.mapping_size;
-        bar4_wc = mmap(
-            NULL,
-            bar4_wc_mapping.mapping_size,
-            PROT_READ | PROT_WRITE,
-            MAP_SHARED,
-            pci_device_file_desc,
-            bar4_wc_mapping.mapping_base);
-
-        if (bar4_wc == MAP_FAILED) {
-            throw std::runtime_error(fmt::format("BAR4 WC mapping failed for device {}.", pci_device_num));
-        }
     }
 
     allocate_pcie_dma_buffer();
@@ -501,10 +482,6 @@ PCIDevice::~PCIDevice() {
 
     if (bar2_uc != nullptr && bar2_uc != MAP_FAILED) {
         munmap(bar2_uc, bar2_uc_size);
-    }
-
-    if (bar4_wc != nullptr && bar4_wc != MAP_FAILED) {
-        munmap(bar4_wc, bar4_wc_size);
     }
 
     if (system_reg_mapping != nullptr && system_reg_mapping != MAP_FAILED) {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -270,13 +270,7 @@ void TTDevice::write_block(uint64_t byte_addr, uint64_t num_bytes, const uint8_t
     if (communication_device_type_ == IODeviceType::JTAG) {
         TT_THROW("write_block is not applicable for JTAG communication type.");
     }
-    void *dest = nullptr;
-    if (pci_device_->bar4_wc != nullptr && byte_addr >= BAR0_BH_SIZE) {
-        byte_addr -= BAR0_BH_SIZE;
-        dest = reinterpret_cast<uint8_t *>(pci_device_->bar4_wc) + byte_addr;
-    } else {
-        dest = pci_device_->get_register_address<uint8_t>(byte_addr);
-    }
+    void *dest = pci_device_->get_register_address<uint8_t>(byte_addr);
 
     const void *src = reinterpret_cast<const void *>(buffer_addr);
     bool use_safe_memcpy = false;
@@ -296,13 +290,7 @@ void TTDevice::read_block(uint64_t byte_addr, uint64_t num_bytes, uint8_t *buffe
     if (communication_device_type_ == IODeviceType::JTAG) {
         TT_THROW("read_block is not applicable for JTAG communication type.");
     }
-    void *src = nullptr;
-    if (pci_device_->bar4_wc != nullptr && byte_addr >= BAR0_BH_SIZE) {
-        byte_addr -= BAR0_BH_SIZE;
-        src = reinterpret_cast<uint8_t *>(pci_device_->bar4_wc) + byte_addr;
-    } else {
-        src = pci_device_->get_register_address<uint8_t>(byte_addr);
-    }
+    void *src = pci_device_->get_register_address<uint8_t>(byte_addr);
 
     void *dest = reinterpret_cast<void *>(buffer_addr);
     bool use_safe_memcpy = false;


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-kmd/pull/168
https://tenstorrent.atlassian.net/browse/CUST-497

### Description
Removes support for Blackhole BAR4 from UMD.  It is currently unused by Metal, so there should be no impact to functionality.  This change is to accommodate small BAR4 sizes implemented by CMFW, which enables use of Blackhole cards on resource-constrained systems.

I tested reduced BAR4 (1 MiB) with unmodified UMD, and it worked.  In this case, UMD mmaps only 1 MiB of BAR4.  However, in this case the underlying TLB window is difficult to use correctly (4 GiB alignment still applies) and there is no enforcement of the 1 MiB boundary.  Hence it is simpler to remove this unused functionality than to fix it up.

### List of the changes
- Delete bar4_wc mapping and BAR0_BH_SIZE offset constant
- Remove BAR4 offset logic from write_block/read_block
- Remove unreachable BAR4 paths in write_to_device/read_from_device
- Update comments to reflect current usage

### Testing
CI

### API Changes
N/A
