### PR TITLE
Use `override` keyword consistently, introduce clang-tidy check

### DIFF
--- a/.clang-tidy-build
+++ b/.clang-tidy-build
@@ -1,6 +1,7 @@
 ---
 Checks: >
     -*,
+    modernize-use-override,
     -clang-diagnostic-unknown-warning-option,
     bugprone-use-after-move,
     bugprone-redundant-branch-condition,

--- a/tests/galaxy/test_umd_remote_api_stability.cpp
+++ b/tests/galaxy/test_umd_remote_api_stability.cpp
@@ -42,9 +42,9 @@ protected:
         }
     }
 
-    virtual int get_detected_num_chips() { return detected_num_chips; }
+    int get_detected_num_chips() override { return detected_num_chips; }
 
-    virtual bool is_test_skipped() { return skip_tests; }
+    bool is_test_skipped() override { return skip_tests; }
 };
 
 int WormholeGalaxyStabilityTestFixture::detected_num_chips = -1;

--- a/tests/wormhole/test_umd_remote_api_stability.cpp
+++ b/tests/wormhole/test_umd_remote_api_stability.cpp
@@ -44,9 +44,9 @@ protected:
         }
     }
 
-    virtual int get_detected_num_chips() { return detected_num_chips; }
+    int get_detected_num_chips() override { return detected_num_chips; }
 
-    virtual bool is_test_skipped() { return skip_tests; }
+    bool is_test_skipped() override { return skip_tests; }
 };
 
 int WormholeNebulaX2TestFixture::detected_num_chips = -1;


### PR DESCRIPTION
### Issue
#734 

### Description
Resolves C++ hygiene issue related to override keyword not being used consistently in UMD

### List of the changes
- Added clang-tidy check `modernize-use-override`
- Fixed problems with override so build passes

### Testing
CI

### API Changes
There are no API changes in this PR.
