### PR TITLE
Add file for different KMD versions

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -157,6 +157,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/driver_atomics.hpp
                 api/umd/device/logging/config.hpp
                 api/umd/device/utils/lock_manager.hpp
+                api/umd/device/utils/kmd_versions.hpp
                 api/umd/device/pcie/pci_device.hpp
                 api/umd/device/pcie/tlb_handle.hpp
                 api/umd/device/pcie/tlb_window.hpp

--- a/device/api/umd/device/utils/kmd_versions.hpp
+++ b/device/api/umd/device/utils/kmd_versions.hpp
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "umd/device/utils/semver.hpp"
+
+namespace tt::umd {
+
+/**
+ * KMD version 1.29.0 introduced IOMMU support. UMD requires at least this version to run with IOMMU enabled.
+ * With never versions of KMD, UMD will still work when IOMMU is disabled on the system.
+ */
+inline constexpr semver_t KMD_IOMMU = semver_t(1, 29, 0);
+
+/**
+ * KMD version 2.0.0 introduced support for mapping buffers to NOC by using IOCTL. Before 2.0.0, UMD used to access
+ * iATU configuration registers directly to perform such mappings. KMD exposed this functionality via IOCTL which brings
+ * the ability to map buffers from multiple processes safely. While it's still possible to use direct register access
+ * for mapping buffers to NOC on KMD versions older than 2.0.0, it's discouraged to do so.
+ */
+inline constexpr semver_t KMD_MAP_TO_NOC = semver_t(2, 0, 0);
+
+/**
+ * KMD version 2.4.1 introduced architecture agnostic reset support. With the new IOCTL in KMD 2.4.1, by using the same
+ * IOCTL UMD can now reset different architectures without needing to have architecture specific reset IOCTLs.
+ */
+inline constexpr semver_t KMD_ARCH_AGNOSTIC_RESET = semver_t{2, 4, 1};
+}  // namespace tt::umd

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -207,8 +207,6 @@ TEST(ApiSysmemManager, SysmemBufferFunctions) {
     EXPECT_EQ(sysmem_buffer->get_buffer_va(), mapped_buffer);
 }
 
-static const semver_t kmd_ver_for_map_to_noc = semver_t(2, 0, 0);
-
 TEST(ApiSysmemManager, SysmemBufferNocAddress) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
     if (pci_device_ids.empty()) {


### PR DESCRIPTION
### Issue

#1596 

### Description

Add a file that should be dedicated to different KMD versions. It keeps important versions of KMD which introduced new features which UMD uses. It now has a documentation on how UMD behaves on older and newer versions.

### List of the changes

- Create `kmd_versions.hpp` file
- Move KMD versions from `pci_device.cpp` to `kmd_versions.hpp`
- Make other UMD code use versions from that file

### Testing
CI

### API Changes
/
