### PR TITLE
Use correct variable for clang-tidy path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,10 +111,10 @@ if(TT_UMD_ENABLE_CLANG_TIDY)
     # warning flags instead of treating them as fatal errors.
     if(CLANG_TIDY_EXE)
         set(CMAKE_CXX_CLANG_TIDY
-            "${CLANG_TIDY_EXE};--config-file=${PROJECT_SOURCE_DIR}/.clang-tidy-build;--extra-arg=-Wno-unknown-warning-option;--extra-arg=-Wno-error=unknown-warning-option"
+            "${CLANG_TIDY_EXE};--config-file=${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy-build;--extra-arg=-Wno-unknown-warning-option;--extra-arg=-Wno-error=unknown-warning-option"
         )
         set(CMAKE_C_CLANG_TIDY
-            "${CLANG_TIDY_EXE};--config-file=${PROJECT_SOURCE_DIR}/.clang-tidy-build;--extra-arg=-Wno-unknown-warning-option;--extra-arg=-Wno-error=unknown-warning-option"
+            "${CLANG_TIDY_EXE};--config-file=${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy-build;--extra-arg=-Wno-unknown-warning-option;--extra-arg=-Wno-error=unknown-warning-option"
         )
     endif()
 endif()


### PR DESCRIPTION
### Issue
/

### Description
This pull request makes a small update to the `CMakeLists.txt` file, ensuring that the correct `.clang-tidy-build` configuration file is used during static analysis. This allows the project to be consumed safely as a submodule.

### List of the changes
- Updated the `CMAKE_CXX_CLANG_TIDY` and `CMAKE_C_CLANG_TIDY` commands to use `${CMAKE_CURRENT_SOURCE_DIR}` instead of `${PROJECT_SOURCE_DIR}` for the `--config-file` argument, ensuring the correct `.clang-tidy-build` file is referenced in each source directory.

### Testing
Manual

### API Changes
/
