### PR TITLE
Remove incorrect filtering of remote eth connections during serialization

### DIFF
--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -1076,14 +1076,9 @@ std::string ClusterDescriptor::serialize() const {
     out << YAML::EndSeq;
 
     out << YAML::Key << "ethernet_connections_to_remote_devices" << YAML::Value << YAML::BeginSeq;
-    serialized_connections.clear();
     for (const auto &[src_chip, channels] : ethernet_connections_to_remote_devices) {
         for (const auto &[src_chan, dest] : channels) {
-            if (serialized_connections.find({src_chip, src_chan}) != serialized_connections.end()) {
-                continue;
-            }
             auto [dest_chip, dest_chan] = dest;
-            serialized_connections.insert({dest_chip, dest_chan});
             out << YAML::BeginSeq;
             out << YAML::BeginMap << YAML::Key << "chip" << YAML::Value << src_chip << YAML::Key << "chan"
                 << YAML::Value << src_chan << YAML::EndMap;


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description
There is a bug in cluster desc serialization where we were storing a remote unique chip id (uint64_t) into a list of ChipId and trying to filter out duplicate connections by comparing this unique chip id to a regular chip id, so we might drop connections that should have been legitimate.
This case is unlikely to happen in actual application as it would require the unique id and a regular id to alias, but should be fixed either way.

### List of the changes
Remove filtering of local chip ids by remote unique ids.

### Testing
(Comment on CI testing or Manual testing touching this change.)

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
