### PR TITLE
Fix creating RemoteChip if Lite Fabric not loaded

### DIFF
--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -196,6 +196,11 @@ void TopologyDiscovery::discover_remote_chips() {
             }
 
             uint64_t remote_asic_id = get_remote_asic_id(chip, eth_core);
+            if (chips_to_discover.find(remote_asic_id) != chips_to_discover.end()) {
+                // Do not create links for chips already connected by PCIe/JTAG.
+                channel++;
+                continue;
+            }
 
             if (discovered_chips.find(remote_asic_id) == discovered_chips.end()) {
                 uint64_t gateway_chip_id = remote_asic_id_to_mmio_chip_id.at(current_chip_asic_id);


### PR DESCRIPTION
### Issue
#1629 

### Description
Fix P300 bug where UMD hangs on LiteFabric I/O when Lite Fabric loading is skipped because the chip is already connected via PCIe on P300.

### List of the changes
- Skip creating links if remote asic ID already present in `chips_to_discover`.

### Testing
CI

### API Changes
There are no API changes in this PR.
