### PR TITLE
Skip making a copy of the ttsim binary for single chip workloads

### DIFF
--- a/device/api/umd/device/simulation/simulation_chip.hpp
+++ b/device/api/umd/device/simulation/simulation_chip.hpp
@@ -23,7 +23,10 @@ public:
     static std::string get_soc_descriptor_path_from_simulator_path(const std::filesystem::path& simulator_path);
 
     static std::unique_ptr<SimulationChip> create(
-        const std::filesystem::path& simulator_directory, SocDescriptor soc_descriptor, ChipId chip_id);
+        const std::filesystem::path& simulator_directory,
+        SocDescriptor soc_descriptor,
+        ChipId chip_id,
+        size_t num_chips);
 
     virtual ~SimulationChip() = default;
 

--- a/device/api/umd/device/simulation/tt_sim_chip.hpp
+++ b/device/api/umd/device/simulation/tt_sim_chip.hpp
@@ -18,7 +18,11 @@ namespace tt::umd {
 // TTSIM implementation using dynamic library (.so files).
 class TTSimChip : public SimulationChip {
 public:
-    TTSimChip(const std::filesystem::path& simulator_directory, SocDescriptor soc_descriptor, ChipId chip_id);
+    TTSimChip(
+        const std::filesystem::path& simulator_directory,
+        SocDescriptor soc_descriptor,
+        ChipId chip_id,
+        bool copy_sim_binary = false);
     ~TTSimChip() override;
 
     void start_device() override;
@@ -38,7 +42,7 @@ private:
     void copy_simulator_binary();
     void secure_simulator_binary();
     void close_simulator_binary();
-    void load_simulator_library();
+    void load_simulator_library(const std::filesystem::path& path);
     std::unique_ptr<architecture_implementation> architecture_impl_;
     int copied_simulator_fd_ = -1;
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -241,7 +241,7 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     if (chip_type == ChipType::SIMULATION) {
 #ifdef TT_UMD_BUILD_SIMULATION
         log_info(LogUMD, "Creating Simulation device");
-        return SimulationChip::create(simulator_directory, soc_desc, chip_id);
+        return SimulationChip::create(simulator_directory, soc_desc, chip_id, cluster_desc->get_number_of_chips());
 #else
         throw std::runtime_error(
             "Simulation device is not supported in this build. Set '-DTT_UMD_BUILD_SIMULATION=ON' during cmake "

--- a/device/simulation/simulation_chip.cpp
+++ b/device/simulation/simulation_chip.cpp
@@ -17,9 +17,9 @@
 namespace tt::umd {
 
 std::unique_ptr<SimulationChip> SimulationChip::create(
-    const std::filesystem::path& simulator_directory, SocDescriptor soc_descriptor, ChipId chip_id) {
+    const std::filesystem::path& simulator_directory, SocDescriptor soc_descriptor, ChipId chip_id, size_t num_chips) {
     if (simulator_directory.extension() == ".so") {
-        return std::make_unique<TTSimChip>(simulator_directory, soc_descriptor, chip_id);
+        return std::make_unique<TTSimChip>(simulator_directory, soc_descriptor, chip_id, num_chips > 1);
     } else {
         return std::make_unique<RtlSimulationChip>(simulator_directory, soc_descriptor, chip_id);
     }

--- a/tests/simulation/device_fixture.hpp
+++ b/tests/simulation/device_fixture.hpp
@@ -29,7 +29,7 @@ protected:
         }
         auto soc_descriptor_path = SimulationChip::get_soc_descriptor_path_from_simulator_path(simulator_path);
         auto soc_descriptor = SocDescriptor(soc_descriptor_path);
-        device = SimulationChip::create(simulator_path, soc_descriptor, 0);
+        device = SimulationChip::create(simulator_path, soc_descriptor, 0, 1);
         device->start_device();
     }
 


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description
Copying the simulator binary is only required for multi-chip workloads in the same process, so we are creating unnecessary copies in the single chip case.

### List of the changes
Skip copying the sim binary when the cluster is only a single chip.

### Testing
Local testing.

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
