### PR TITLE
Rename ttsim to ttsim-private

### DIFF
--- a/.github/workflows/build-clients.yml
+++ b/.github/workflows/build-clients.yml
@@ -140,7 +140,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ttsim
-          repository: tenstorrent/ttsim
+          repository: tenstorrent/ttsim-private
           ref: ${{ steps.get-ttsim-ref.outputs.ttsim-ref }}
           submodules: recursive
           token: ${{ secrets.TTSIM_TOKEN }}


### PR DESCRIPTION
### Issue
none

### Description
tenstorrent/ttsim is being renamed to ttsim-private to make room for public repo

### List of the changes
Change repo path

### Testing
n/a

### API Changes
/