### PR TITLE
Fix TSAN data race for remote communication

### DIFF
--- a/device/tt_device/remote_communication_legacy_firmware.cpp
+++ b/device/tt_device/remote_communication_legacy_firmware.cpp
@@ -340,6 +340,7 @@ void RemoteCommunicationLegacyFirmware::write_to_non_mmio(
     std::vector<int> broadcast_header,
     const std::chrono::milliseconds timeout_ms) {
     auto lock = lock_manager_.acquire_mutex(MutexType::NON_MMIO, local_tt_device_->get_communication_device_id());
+    flush_non_mmio_ = true;
 
     using data_word_t = uint32_t;
     constexpr int DATA_WORD_SIZE = sizeof(data_word_t);


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/636

### Description
TSAN found these failures, specifically the flush_non_mmio_ was not guarded by the locks.

### List of the changes
- Move locking in read/write non_mmio to the top of the function

### Testing
CI TSAN tests, with some other changes combined: https://github.com/tenstorrent/tt-umd/actions/runs/19664175096

### API Changes
There are no API changes in this PR.
