### PR TITLE
Fix Tsan/Asan python builds

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -83,7 +83,7 @@ jobs:
           cmake -B ${{ env.BUILD_OUTPUT_DIR }} -G Ninja \
             -DTT_UMD_BUILD_TESTS=ON \
             -DTT_UMD_BUILD_SIMULATION=OFF \
-            -DTT_UMD_BUILD_PYTHON=ON \
+            -DTT_UMD_BUILD_PYTHON=OFF \
             -DTT_UMD_BUILD_EXAMPLES=OFF \
             -DTT_UMD_BUILD_TOOLS=OFF \
             -DTT_UMD_ENABLE_CLANG_TIDY=OFF \
@@ -138,7 +138,17 @@ jobs:
           source .venv/bin/activate
           python -m pip install --upgrade pip wheel
           echo "Compiling the code..."
-          pip wheel . --wheel-dir ${{ env.WHEEL_OUTPUT_DIR }}
+          # Override CMAKE_BUILD_TYPE to Release for sanitizer builds to avoid symbol conflicts with Python
+          # Python interpreters are not built with sanitizers, so TSAN/ASAN wheels cannot be loaded
+          BUILD_TYPE="${{ inputs.build-type }}"
+          if [[ "$BUILD_TYPE" == "ASan" || "$BUILD_TYPE" == "TSan" ]]; then
+            echo "Overriding CMAKE_BUILD_TYPE from $BUILD_TYPE to Release for Python wheel compatibility"
+            WHEEL_BUILD_TYPE="Release"
+          else
+            echo "Using CMAKE_BUILD_TYPE=$BUILD_TYPE for Python wheel"
+            WHEEL_BUILD_TYPE="$BUILD_TYPE"
+          fi
+          CMAKE_BUILD_TYPE="$WHEEL_BUILD_TYPE" pip wheel . --wheel-dir ${{ env.WHEEL_OUTPUT_DIR }}
           echo "Compile complete."
 
       - name: Move python bindings tests in the same wheel folder

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -73,6 +73,36 @@ jobs:
           mkdir tt-umd
           cd tt-umd
 
+      - name: Clean up old wheel artifacts
+        run: |
+          echo "Cleaning up old wheel artifacts in case of previous downloads..."
+          rm -f tt_umd-*.whl
+          rm -rf tests/
+
+      - name: Use wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.WHEEL_ARTIFACT_NAME }}
+          path: ./
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install wheel and run pytest
+        shell: bash
+        run: |
+          echo "Setting up virtual environment..."
+          python -m venv .venv
+          source .venv/bin/activate
+          python -m pip install --upgrade pip wheel pytest
+          echo "Installing the wheel..."
+          pip install tt_umd-*.whl --force-reinstall
+          echo "Installation complete."
+          echo "Running tests..."
+          .venv/bin/python -m pytest -s tests
+
       - name: Use build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -110,33 +140,3 @@ jobs:
         if: ${{ inputs.arch != 'baremetal' }}
         run: |
           ${{ env.TEST_OUTPUT_DIR }}/umd/unified/unified_tests
-
-      - name: Clean up old wheel artifacts
-        run: |
-          echo "Cleaning up old wheel artifacts in case of previous downloads..."
-          rm -f tt_umd-*.whl
-          rm -rf tests/
-
-      - name: Use wheel artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ env.WHEEL_ARTIFACT_NAME }}
-          path: ./
-
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-
-      - name: Install wheel and run pytest
-        shell: bash
-        run: |
-          echo "Setting up virtual environment..."
-          python -m venv .venv
-          source .venv/bin/activate
-          python -m pip install --upgrade pip wheel pytest
-          echo "Installing the wheel..."
-          pip install tt_umd-*.whl --force-reinstall
-          echo "Installation complete."
-          echo "Running tests..."
-          .venv/bin/python -m pytest -s tests

--- a/nanobind/CMakeLists.txt
+++ b/nanobind/CMakeLists.txt
@@ -18,6 +18,18 @@ find_package(Python REQUIRED COMPONENTS Development.Module)
 # Define the Python interface target
 nanobind_add_module(nanobind_tt_umd MODULE py_api_module.cpp py_api_basic_types.cpp py_api_topology_discovery.cpp py_api_telemetry.cpp py_api_tt_device.cpp py_api_cluster.cpp py_api_warm_reset.cpp py_api_soc_descriptor.cpp)
 
+# Error out if trying to build Python bindings with sanitizers
+# Python interpreters are not built with sanitizers, so the resulting wheel cannot be loaded
+if(CMAKE_BUILD_TYPE MATCHES "ASan|TSan")
+    message(
+        FATAL_ERROR
+        "Cannot build Python bindings (nanobind_tt_umd) with CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}. "
+        "Python interpreters are not built with sanitizers, resulting in undefined symbol errors. "
+        "Please use Release, RelWithDebInfo or Debug for Python builds, "
+        "or disable Python bindings with -DTT_UMD_BUILD_PYTHON=OFF"
+    )
+endif()
+
 # Set properties for the Python module
 set_target_properties(
     nanobind_tt_umd


### PR DESCRIPTION
### Issue
On a path to https://github.com/tenstorrent/tt-umd/issues/636

### Description
Fix python tests in case of asan and tsan, which currently don't work if you manually run https://github.com/tenstorrent/tt-umd/actions/workflows/build-and-run-all-tests.yml

### List of the changes
- Change the order of tests, so that we first install the wheel and run python tests, and then download build artefacts and run cpp unit tests. This is because the libdevice.so might get loaded instead of the one from the wheel. Hopefully the #1340 might help in general with this issue
- Block building python lib in case of asan/tsan
- Don't build python lib when building unit tests, they are unnecessary
- Override Asan and Tsan to Release when building python wheel in our CI

### Testing
CI TSAN tests, with some other changes combined: https://github.com/tenstorrent/tt-umd/actions/runs/19664175096

### API Changes
There are no API changes in this PR.
