### PR TITLE
Change log level from warning to info for firmware check

### DIFF
--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -386,10 +386,10 @@ bool TopologyDiscovery::verify_fw_bundle_version(Chip* chip) {
         arch_to_str(tt_device->get_arch()));
 
     if (semver_t::compare_firmware_bundle(fw_bundle_version, latest_supported_fw_bundle_version) > 0) {
-        log_warning(
+        log_info(
             LogUMD,
-            "Firmware bundle version {} on the system is newer than the maximum supported version {} for {} "
-            "architecture. New features may not be supported.",
+            "Firmware bundle version {} on the system is newer than the latest fully tested version {} for {} "
+            "architecture. Newest features may not be supported.",
             fw_bundle_version.to_string(),
             latest_supported_fw_bundle_version.to_string(),
             arch_to_str(tt_device->get_arch()));


### PR DESCRIPTION
### Issue
/

### Description
Warning saying that something is not supported can be misleading for customers.

### List of the changes
- Change warn to info
- Change the wording a bit

### Testing
No testing

### API Changes
There are no API changes in this PR.
