### PR TITLE
Remove tt::umd when unnecessary

### DIFF
--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -67,10 +67,9 @@ static std::optional<std::unordered_set<int>> get_unordered_set_from_string(cons
 inline constexpr std::string_view TT_VISIBLE_DEVICES_ENV = "TT_VISIBLE_DEVICES";
 
 static std::unordered_set<int> get_visible_devices(const std::unordered_set<int>& target_devices) {
-    const std::optional<std::string> env_var_value = tt::umd::utils::get_env_var_value(TT_VISIBLE_DEVICES_ENV.data());
+    const std::optional<std::string> env_var_value = get_env_var_value(TT_VISIBLE_DEVICES_ENV.data());
     return target_devices.empty() && env_var_value.has_value()
-               ? tt::umd::utils::get_unordered_set_from_string(env_var_value.value())
-                     .value_or(std::unordered_set<int>{})
+               ? get_unordered_set_from_string(env_var_value.value()).value_or(std::unordered_set<int>{})
                : target_devices;
 }
 

--- a/device/api/umd/device/arch/architecture_implementation.hpp
+++ b/device/api/umd/device/arch/architecture_implementation.hpp
@@ -63,8 +63,8 @@ public:
     virtual uint32_t get_tlb_base_index_16m() const = 0;
     virtual uint32_t get_tensix_soft_reset_addr() const = 0;
     virtual uint32_t get_debug_reg_addr() const = 0;
-    virtual uint32_t get_soft_reset_reg_value(tt::umd::RiscType risc_type) const = 0;
-    virtual tt::umd::RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const = 0;
+    virtual uint32_t get_soft_reset_reg_value(RiscType risc_type) const = 0;
+    virtual RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const = 0;
     virtual uint32_t get_soft_reset_staggered_start() const = 0;
     virtual uint32_t get_grid_size_x() const = 0;
     virtual uint32_t get_grid_size_y() const = 0;

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -414,9 +414,9 @@ public:
 
     uint32_t get_debug_reg_addr() const override { return blackhole::RISCV_DEBUG_REG_DBG_BUS_CNTL_REG; }
 
-    uint32_t get_soft_reset_reg_value(tt::umd::RiscType risc_type) const override;
+    uint32_t get_soft_reset_reg_value(RiscType risc_type) const override;
 
-    tt::umd::RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const override;
+    RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const override;
 
     uint32_t get_soft_reset_staggered_start() const override { return blackhole::SOFT_RESET_STAGGERED_START; }
 

--- a/device/api/umd/device/arch/grendel_implementation.hpp
+++ b/device/api/umd/device/arch/grendel_implementation.hpp
@@ -411,9 +411,9 @@ public:
 
     uint32_t get_debug_reg_addr() const override { return grendel::RISCV_DEBUG_REG_DBG_BUS_CNTL_REG; }
 
-    uint32_t get_soft_reset_reg_value(tt::umd::RiscType risc_type) const override;
+    uint32_t get_soft_reset_reg_value(RiscType risc_type) const override;
 
-    tt::umd::RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const override;
+    RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const override;
 
     uint32_t get_soft_reset_staggered_start() const override {
         return 0;

--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -420,9 +420,9 @@ public:
 
     uint32_t get_debug_reg_addr() const override { return wormhole::RISCV_DEBUG_REG_DBG_BUS_CNTL_REG; }
 
-    uint32_t get_soft_reset_reg_value(tt::umd::RiscType risc_type) const override;
+    uint32_t get_soft_reset_reg_value(RiscType risc_type) const override;
 
-    tt::umd::RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const override;
+    RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const override;
 
     uint32_t get_soft_reset_staggered_start() const override { return wormhole::SOFT_RESET_STAGGERED_START; }
 

--- a/device/api/umd/device/chip_helpers/tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/tlb_manager.hpp
@@ -41,7 +41,7 @@ public:
     TlbWindow* get_tlb_window(const tt_xy_pair core);
 
     std::unique_ptr<TlbWindow> allocate_tlb_window(
-        tlb_data config, const tt::umd::TlbMapping mapping = tt::umd::TlbMapping::WC, const size_t tlb_size = 0);
+        tlb_data config, const TlbMapping mapping = TlbMapping::WC, const size_t tlb_size = 0);
 
 private:
     // TODO: move these functions to the layer below, or make separate functions

--- a/device/arc/blackhole_arc_telemetry_reader.cpp
+++ b/device/arc/blackhole_arc_telemetry_reader.cpp
@@ -22,10 +22,10 @@ BlackholeArcTelemetryReader::BlackholeArcTelemetryReader(TTDevice* tt_device) : 
 
 void BlackholeArcTelemetryReader::get_telemetry_address() {
     uint32_t telemetry_table_addr_u32;
-    tt_device->read_from_arc_apb(&telemetry_table_addr_u32, tt::umd::blackhole::SCRATCH_RAM_13, sizeof(uint32_t));
+    tt_device->read_from_arc_apb(&telemetry_table_addr_u32, blackhole::SCRATCH_RAM_13, sizeof(uint32_t));
     telemetry_table_addr = telemetry_table_addr_u32;
     uint32_t telemetry_values_addr_u32;
-    tt_device->read_from_arc_apb(&telemetry_values_addr_u32, tt::umd::blackhole::SCRATCH_RAM_12, sizeof(uint32_t));
+    tt_device->read_from_arc_apb(&telemetry_values_addr_u32, blackhole::SCRATCH_RAM_12, sizeof(uint32_t));
     telemetry_values_addr = telemetry_values_addr_u32;
 }
 

--- a/device/arc/smbus_arc_telemetry_reader.cpp
+++ b/device/arc/smbus_arc_telemetry_reader.cpp
@@ -13,10 +13,10 @@ extern bool umd_use_noc1;
 namespace tt::umd {
 
 SmBusArcTelemetryReader::SmBusArcTelemetryReader(TTDevice* tt_device) : ArcTelemetryReader(tt_device) {
-    arc_core = !umd_use_noc1 ? tt::umd::wormhole::ARC_CORES_NOC0[0]
+    arc_core = !umd_use_noc1 ? wormhole::ARC_CORES_NOC0[0]
                              : tt_xy_pair(
-                                   tt::umd::wormhole::NOC0_X_TO_NOC1_X[tt::umd::wormhole::ARC_CORES_NOC0[0].x],
-                                   tt::umd::wormhole::NOC0_Y_TO_NOC1_Y[tt::umd::wormhole::ARC_CORES_NOC0[0].y]);
+                                   wormhole::NOC0_X_TO_NOC1_X[wormhole::ARC_CORES_NOC0[0].x],
+                                   wormhole::NOC0_Y_TO_NOC1_Y[wormhole::ARC_CORES_NOC0[0].y]);
     get_telemetry_address();
 }
 

--- a/device/arc/wormhole_arc_telemetry_reader.cpp
+++ b/device/arc/wormhole_arc_telemetry_reader.cpp
@@ -13,10 +13,10 @@ extern bool umd_use_noc1;
 namespace tt::umd {
 
 WormholeArcTelemetryReader::WormholeArcTelemetryReader(TTDevice* tt_device) : ArcTelemetryReader(tt_device) {
-    arc_core = !umd_use_noc1 ? tt::umd::wormhole::ARC_CORES_NOC0[0]
+    arc_core = !umd_use_noc1 ? wormhole::ARC_CORES_NOC0[0]
                              : tt_xy_pair(
-                                   tt::umd::wormhole::NOC0_X_TO_NOC1_X[tt::umd::wormhole::ARC_CORES_NOC0[0].x],
-                                   tt::umd::wormhole::NOC0_Y_TO_NOC1_Y[tt::umd::wormhole::ARC_CORES_NOC0[0].y]);
+                                   wormhole::NOC0_X_TO_NOC1_X[wormhole::ARC_CORES_NOC0[0].x],
+                                   wormhole::NOC0_Y_TO_NOC1_Y[wormhole::ARC_CORES_NOC0[0].y]);
     get_telemetry_address();
     initialize_telemetry();
 }
@@ -27,7 +27,7 @@ void WormholeArcTelemetryReader::get_telemetry_address() {
     tt_device->read_from_device(
         &telemetry_table_addr_offset,
         arc_core,
-        tt::umd::wormhole::ARC_NOC_RESET_UNIT_BASE_ADDR + tt::umd::wormhole::NOC_NODEID_X_0,
+        wormhole::ARC_NOC_RESET_UNIT_BASE_ADDR + wormhole::NOC_NODEID_X_0,
         sizeof(uint32_t));
 
     telemetry_table_addr = telemetry_table_addr_offset + noc_telemetry_offset;
@@ -36,7 +36,7 @@ void WormholeArcTelemetryReader::get_telemetry_address() {
     tt_device->read_from_device(
         &telemetry_values_addr_offset,
         arc_core,
-        tt::umd::wormhole::ARC_NOC_RESET_UNIT_BASE_ADDR + tt::umd::wormhole::NOC_NODEID_Y_0,
+        wormhole::ARC_NOC_RESET_UNIT_BASE_ADDR + wormhole::NOC_NODEID_Y_0,
         sizeof(uint32_t));
 
     telemetry_values_addr = telemetry_values_addr_offset + noc_telemetry_offset;

--- a/device/arch/blackhole_implementation.cpp
+++ b/device/arch/blackhole_implementation.cpp
@@ -117,7 +117,7 @@ uint64_t blackhole_implementation::get_noc_reg_base(
     throw std::runtime_error("Invalid core type or NOC for getting NOC register addr base.");
 }
 
-uint32_t blackhole_implementation::get_soft_reset_reg_value(tt::umd::RiscType risc_type) const {
+uint32_t blackhole_implementation::get_soft_reset_reg_value(RiscType risc_type) const {
     if ((risc_type & RiscType::ALL_NEO) != RiscType::NONE) {
         // Throw if any of the NEO cores are selected.
         TT_THROW("NEO risc cores should not be used on Blackhole architecture.");

--- a/device/arch/grendel_implementation.cpp
+++ b/device/arch/grendel_implementation.cpp
@@ -115,7 +115,7 @@ uint64_t grendel_implementation::get_noc_reg_base(
     throw std::runtime_error("Invalid core type or NOC for getting NOC register addr base.");
 }
 
-uint32_t grendel_implementation::get_soft_reset_reg_value(tt::umd::RiscType risc_type) const {
+uint32_t grendel_implementation::get_soft_reset_reg_value(RiscType risc_type) const {
     if ((risc_type & RiscType::ALL_TENSIX) != RiscType::NONE) {
         // Throw if any of the NEO cores are selected.
         TT_THROW("TENSIX risc cores should not be used on Grendel architecture.");

--- a/device/arch/wormhole_implementation.cpp
+++ b/device/arch/wormhole_implementation.cpp
@@ -123,7 +123,7 @@ uint64_t wormhole_implementation::get_noc_reg_base(
     throw std::runtime_error("Invalid core type or NOC for getting NOC register addr base.");
 }
 
-uint32_t wormhole_implementation::get_soft_reset_reg_value(tt::umd::RiscType risc_type) const {
+uint32_t wormhole_implementation::get_soft_reset_reg_value(RiscType risc_type) const {
     if ((risc_type & RiscType::ALL_NEO) != RiscType::NONE) {
         // Throw if any of the NEO cores are selected.
         TT_THROW("NEO risc cores should not be used on Wormhole architecture.");

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -39,8 +39,7 @@ std::unique_ptr<RemoteChip> RemoteChip::create(
     } else {
         soc_descriptor = SocDescriptor(sdesc_path, remote_tt_device->get_chip_info());
     }
-    return std::unique_ptr<tt::umd::RemoteChip>(
-        new RemoteChip(soc_descriptor, local_chip, std::move(remote_tt_device)));
+    return std::unique_ptr<RemoteChip>(new RemoteChip(soc_descriptor, local_chip, std::move(remote_tt_device)));
 }
 
 std::unique_ptr<RemoteChip> RemoteChip::create(
@@ -56,8 +55,7 @@ std::unique_ptr<RemoteChip> RemoteChip::create(
     auto remote_tt_device = TTDevice::create(std::move(remote_communication));
     remote_tt_device->init_tt_device();
 
-    return std::unique_ptr<tt::umd::RemoteChip>(
-        new RemoteChip(soc_descriptor, local_chip, std::move(remote_tt_device)));
+    return std::unique_ptr<RemoteChip>(new RemoteChip(soc_descriptor, local_chip, std::move(remote_tt_device)));
 }
 
 RemoteChip::RemoteChip(

--- a/device/chip_helpers/tlb_manager.cpp
+++ b/device/chip_helpers/tlb_manager.cpp
@@ -105,7 +105,7 @@ Writer TLBManager::get_static_tlb_writer(tt_xy_pair core) {
     auto tlb_data = tt_device_->get_architecture_implementation()->get_tlb_configuration(tlb_index);
     TlbWindow* tlb_window = tlb_windows_.at(tlb_index).get();
 
-    return tt::umd::Writer(tlb_window->handle_ref().get_base(), tlb_data.size);
+    return Writer(tlb_window->handle_ref().get_base(), tlb_data.size);
 }
 
 tlb_configuration TLBManager::get_tlb_configuration(tt_xy_pair core) {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -407,7 +407,7 @@ Cluster::Cluster(ClusterOptions options) {
     } else if (options.chip_type == ChipType::SIMULATION && options.cluster_descriptor) {
         // Filter devices only when a cluster descriptor is passed for simulation.
         // Note that this is filtered based on logical chip ids, which is different from how silicon chips are filtered.
-        auto visible_devices = tt::umd::utils::get_visible_devices(options.target_devices);
+        auto visible_devices = utils::get_visible_devices(options.target_devices);
         if (!visible_devices.empty()) {
             cluster_desc =
                 ClusterDescriptor::create_constrained_cluster_descriptor(temp_full_cluster_desc, visible_devices);

--- a/device/firmware/firmware_utils.cpp
+++ b/device/firmware/firmware_utils.cpp
@@ -32,8 +32,7 @@ semver_t get_firmware_version_util(TTDevice* tt_device) {
         auto start = std::chrono::steady_clock::now();
         auto timeout_duration = std::chrono::milliseconds(250);
         while (std::chrono::steady_clock::now() - start < timeout_duration) {
-            auto fw_bundle_version =
-                smbus_telemetry_reader->read_entry(tt::umd::wormhole::TelemetryTag::FW_BUNDLE_VERSION);
+            auto fw_bundle_version = smbus_telemetry_reader->read_entry(wormhole::TelemetryTag::FW_BUNDLE_VERSION);
             if (fw_bundle_version != 0) {
                 return fw_version_from_telemetry(fw_bundle_version);
             }
@@ -41,8 +40,7 @@ semver_t get_firmware_version_util(TTDevice* tt_device) {
         }
         log_warning(
             tt::LogUMD, "Timeout reading firmware bundle version (250ms), returning potentially invalid version");
-        return fw_version_from_telemetry(
-            smbus_telemetry_reader->read_entry(tt::umd::wormhole::TelemetryTag::FW_BUNDLE_VERSION));
+        return fw_version_from_telemetry(smbus_telemetry_reader->read_entry(wormhole::TelemetryTag::FW_BUNDLE_VERSION));
     }
     ArcTelemetryReader* telemetry = tt_device->get_arc_telemetry_reader();
     return telemetry->is_entry_available(TelemetryTag::FLASH_BUNDLE_VERSION)

--- a/device/firmware/wormhole_18_3_firmware_info_provider.cpp
+++ b/device/firmware/wormhole_18_3_firmware_info_provider.cpp
@@ -77,7 +77,7 @@ std::vector<DramTrainingStatus> Wormhole_18_3_FirmwareInfoProvider::get_dram_tra
 }
 
 uint32_t Wormhole_18_3_FirmwareInfoProvider::get_max_clock_freq() const {
-    uint32_t aiclk_telemetry = tt_device->get_arc_telemetry_reader()->read_entry(tt::umd::wormhole::AICLK);
+    uint32_t aiclk_telemetry = tt_device->get_arc_telemetry_reader()->read_entry(wormhole::AICLK);
     return (aiclk_telemetry >> 16) & 0xFFFF;
 }
 

--- a/device/firmware/wormhole_18_7_firmware_info_provider.cpp
+++ b/device/firmware/wormhole_18_7_firmware_info_provider.cpp
@@ -16,7 +16,7 @@ Wormhole_18_7_FirmwareInfoProvider::Wormhole_18_7_FirmwareInfoProvider(TTDevice*
 uint32_t Wormhole_18_7_FirmwareInfoProvider::get_max_clock_freq() const {
     const std::unique_ptr<SmBusArcTelemetryReader> sm_bus_telemetry =
         std::make_unique<SmBusArcTelemetryReader>(tt_device);
-    uint32_t aiclk_telemetry = sm_bus_telemetry->read_entry(tt::umd::wormhole::AICLK);
+    uint32_t aiclk_telemetry = sm_bus_telemetry->read_entry(wormhole::AICLK);
     return (aiclk_telemetry >> 16) & 0xFFFF;
 }
 

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -237,7 +237,7 @@ std::vector<int> PCIDevice::enumerate_devices(std::unordered_set<int> pci_target
         return device_ids;
     }
 
-    std::unordered_set<int> visible_devices = tt::umd::utils::get_visible_devices(pci_target_devices);
+    std::unordered_set<int> visible_devices = utils::get_visible_devices(pci_target_devices);
 
     for (const auto &entry : std::filesystem::directory_iterator(path)) {
         std::string filename = entry.path().filename().string();

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -649,14 +649,14 @@ std::string SocDescriptor::get_soc_descriptor_path(tt::ARCH arch) {
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0:
             // TODO: this path needs to be changed to point to soc descriptors outside of tests directory.
-            return tt::umd::utils::get_abs_path("tests/soc_descs/wormhole_b0_8x10.yaml");
+            return utils::get_abs_path("tests/soc_descs/wormhole_b0_8x10.yaml");
         case tt::ARCH::BLACKHOLE: {
             // TODO: this path needs to be changed to point to soc descriptors outside of tests directory.
-            return tt::umd::utils::get_abs_path("tests/soc_descs/blackhole_140_arch.yaml");
+            return utils::get_abs_path("tests/soc_descs/blackhole_140_arch.yaml");
         }
         case tt::ARCH::QUASAR: {
             // TODO: this path needs to be changed to point to soc descriptors outside of tests directory.
-            return tt::umd::utils::get_abs_path("tests/soc_descs/quasar_simulation_1x1.yaml");
+            return utils::get_abs_path("tests/soc_descs/quasar_simulation_1x1.yaml");
         }
         default:
             throw std::runtime_error("Invalid architecture");

--- a/device/topology/topology_discovery_blackhole.cpp
+++ b/device/topology/topology_discovery_blackhole.cpp
@@ -204,7 +204,7 @@ void TopologyDiscoveryBlackhole::patch_eth_connections() {
 
         Chip* remote_chip_ptr = get_chip(remote_chip);
 
-        auto eth_core_noc0 = tt::umd::blackhole::ETH_CORES_NOC0[remote_channel];
+        auto eth_core_noc0 = blackhole::ETH_CORES_NOC0[remote_channel];
         CoreCoord eth_core_coord = CoreCoord(eth_core_noc0.x, eth_core_noc0.y, CoreType::ETH, CoordSystem::NOC0);
         CoreCoord logical_coord =
             remote_chip_ptr->get_soc_descriptor().translate_coord_to(eth_core_coord, CoordSystem::LOGICAL);

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -24,12 +24,12 @@ namespace tt::umd {
 
 BlackholeTTDevice::BlackholeTTDevice(std::shared_ptr<PCIDevice> pci_device) :
     TTDevice(pci_device, std::make_unique<blackhole_implementation>()) {
-    arc_core = tt::umd::blackhole::get_arc_core(get_noc_translation_enabled(), umd_use_noc1);
+    arc_core = blackhole::get_arc_core(get_noc_translation_enabled(), umd_use_noc1);
 }
 
 BlackholeTTDevice::BlackholeTTDevice(std::shared_ptr<JtagDevice> jtag_device, uint8_t jlink_id) :
     TTDevice(jtag_device, jlink_id, std::make_unique<blackhole_implementation>()) {
-    arc_core = tt::umd::blackhole::get_arc_core(get_noc_translation_enabled(), umd_use_noc1);
+    arc_core = blackhole::get_arc_core(get_noc_translation_enabled(), umd_use_noc1);
 }
 
 BlackholeTTDevice::~BlackholeTTDevice() {

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -27,8 +27,8 @@ static constexpr uint32_t DMA_TIMEOUT_MS = 10000;  // 10 seconds
 WormholeTTDevice::WormholeTTDevice(std::shared_ptr<PCIDevice> pci_device) :
     TTDevice(pci_device, std::make_unique<wormhole_implementation>()) {
     arc_core = umd_use_noc1 ? tt_xy_pair(
-                                  tt::umd::wormhole::NOC0_X_TO_NOC1_X[tt::umd::wormhole::ARC_CORES_NOC0[0].x],
-                                  tt::umd::wormhole::NOC0_Y_TO_NOC1_Y[tt::umd::wormhole::ARC_CORES_NOC0[0].y])
+                                  wormhole::NOC0_X_TO_NOC1_X[wormhole::ARC_CORES_NOC0[0].x],
+                                  wormhole::NOC0_Y_TO_NOC1_Y[wormhole::ARC_CORES_NOC0[0].y])
                             : wormhole::ARC_CORES_NOC0[0];
 }
 
@@ -39,16 +39,16 @@ void WormholeTTDevice::post_init_hook() {
 WormholeTTDevice::WormholeTTDevice(std::shared_ptr<JtagDevice> jtag_device, uint8_t jlink_id) :
     TTDevice(jtag_device, jlink_id, std::make_unique<wormhole_implementation>()) {
     arc_core = umd_use_noc1 ? tt_xy_pair(
-                                  tt::umd::wormhole::NOC0_X_TO_NOC1_X[tt::umd::wormhole::ARC_CORES_NOC0[0].x],
-                                  tt::umd::wormhole::NOC0_Y_TO_NOC1_Y[tt::umd::wormhole::ARC_CORES_NOC0[0].y])
+                                  wormhole::NOC0_X_TO_NOC1_X[wormhole::ARC_CORES_NOC0[0].x],
+                                  wormhole::NOC0_Y_TO_NOC1_Y[wormhole::ARC_CORES_NOC0[0].y])
                             : wormhole::ARC_CORES_NOC0[0];
     init_tt_device();
 }
 
 WormholeTTDevice::WormholeTTDevice() : TTDevice(std::make_unique<wormhole_implementation>()) {
     arc_core = umd_use_noc1 ? tt_xy_pair(
-                                  tt::umd::wormhole::NOC0_X_TO_NOC1_X[tt::umd::wormhole::ARC_CORES_NOC0[0].x],
-                                  tt::umd::wormhole::NOC0_Y_TO_NOC1_Y[tt::umd::wormhole::ARC_CORES_NOC0[0].y])
+                                  wormhole::NOC0_X_TO_NOC1_X[wormhole::ARC_CORES_NOC0[0].x],
+                                  wormhole::NOC0_Y_TO_NOC1_Y[wormhole::ARC_CORES_NOC0[0].y])
                             : wormhole::ARC_CORES_NOC0[0];
     log_warning(tt::LogUMD, "Created WormholeTTDevice without an underlying I/O device (PCIe or JTAG).");
 }

--- a/device/warm_reset.cpp
+++ b/device/warm_reset.cpp
@@ -125,12 +125,12 @@ void WarmReset::warm_reset_arch_agnostic(
     }
 
     log_info(tt::LogUMD, "Starting reset on devices at PCI indices: {}", fmt::join(pci_device_id_set, ", "));
-    PCIDevice::reset_device_ioctl(pci_device_id_set, tt::umd::TenstorrentResetDevice::RESET_PCIE_LINK);
+    PCIDevice::reset_device_ioctl(pci_device_id_set, TenstorrentResetDevice::RESET_PCIE_LINK);
 
     if (reset_m3) {
-        PCIDevice::reset_device_ioctl(pci_device_id_set, tt::umd::TenstorrentResetDevice::ASIC_DMC_RESET);
+        PCIDevice::reset_device_ioctl(pci_device_id_set, TenstorrentResetDevice::ASIC_DMC_RESET);
     } else {
-        PCIDevice::reset_device_ioctl(pci_device_id_set, tt::umd::TenstorrentResetDevice::ASIC_RESET);
+        PCIDevice::reset_device_ioctl(pci_device_id_set, TenstorrentResetDevice::ASIC_RESET);
     }
 
     // Calculate post-reset wait time: use provided M3 timeout if M3 reset, otherwise scale based on device count
@@ -153,12 +153,12 @@ void WarmReset::warm_reset_arch_agnostic(
         }
     }
 
-    PCIDevice::reset_device_ioctl(pci_device_id_set, tt::umd::TenstorrentResetDevice::POST_RESET);
+    PCIDevice::reset_device_ioctl(pci_device_id_set, TenstorrentResetDevice::POST_RESET);
 }
 
 void WarmReset::warm_reset_blackhole_legacy(std::vector<int> pci_device_ids) {
     std::unordered_set<int> pci_device_ids_set(pci_device_ids.begin(), pci_device_ids.end());
-    PCIDevice::reset_device_ioctl(pci_device_ids_set, tt::umd::TenstorrentResetDevice::CONFIG_WRITE);
+    PCIDevice::reset_device_ioctl(pci_device_ids_set, TenstorrentResetDevice::CONFIG_WRITE);
 
     std::map<int, bool> reset_bits;
 

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -188,7 +188,7 @@ TEST(ApiClusterDescriptorTest, VerifyEthConnections) {
  * expected.
  */
 TEST(ApiClusterDescriptorTest, VerifyStandardTopology) {
-    std::unique_ptr<ClusterDescriptor> cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
+    std::unique_ptr<ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
 
     auto all_chips = cluster_desc->get_all_chips();
 

--- a/tests/galaxy/test_umd_concurrent_threads.cpp
+++ b/tests/galaxy/test_umd_concurrent_threads.cpp
@@ -20,6 +20,8 @@
 #include "wormhole/host_mem_address_map.h"
 #include "wormhole/l1_address_map.h"
 
+using namespace tt::umd;
+
 // Have 2 threads read and write to all cores on the Galaxy
 TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
     auto cluster = std::make_unique<Cluster>();
@@ -60,7 +62,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
         .target_devices = all_devices,
     });
 
-    tt::umd::test::utils::set_barrier_params(device);
+    test::utils::set_barrier_params(device);
 
     DeviceParams default_params;
     device.start_device(default_params);
@@ -163,7 +165,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
         .target_devices = all_devices,
     });
 
-    tt::umd::test::utils::set_barrier_params(device);
+    test::utils::set_barrier_params(device);
 
     DeviceParams default_params;
     device.start_device(default_params);
@@ -222,7 +224,7 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
     std::shared_ptr<ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
     Cluster device;
     std::unordered_set<ChipId> target_devices = cluster_desc->get_all_chips();
-    tt::umd::test::utils::set_barrier_params(device);
+    test::utils::set_barrier_params(device);
 
     DeviceParams default_params;
     device.start_device(default_params);

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -18,10 +18,12 @@
 #include "wormhole/host_mem_address_map.h"
 #include "wormhole/l1_address_map.h"
 
+using namespace tt::umd;
+
 void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
     Cluster device;
 
-    tt::umd::test::utils::set_barrier_params(device);
+    test::utils::set_barrier_params(device);
 
     DeviceParams default_params;
     device.start_device(default_params);
@@ -120,7 +122,7 @@ void run_data_mover_test(
     ASSERT_TRUE(it != target_devices.end())
         << "Receiver core is on chip " << sender_core.chip << " which is not in the Galaxy cluster";
 
-    tt::umd::test::utils::set_barrier_params(device);
+    test::utils::set_barrier_params(device);
 
     DeviceParams default_params;
     device.start_device(default_params);
@@ -232,7 +234,7 @@ void run_data_broadcast_test(
             << "Receiver core is on chip " << sender_core.chip << " which is not in the Galaxy cluster";
     }
 
-    tt::umd::test::utils::set_barrier_params(device);
+    test::utils::set_barrier_params(device);
 
     DeviceParams default_params;
     device.start_device(default_params);

--- a/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
+++ b/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
@@ -82,7 +82,7 @@ TEST(MicrobenchmarkIOMMU, MapDifferentSizes) {
 
     const uint64_t mapping_size_limit = 1ULL << 30;  // 1 GB
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(tt::umd::ClusterOptions{
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{
         .num_host_mem_ch_per_mmio_device = 0,
     });
 
@@ -141,7 +141,7 @@ TEST(MicrobenchmarkIOMMU, MapHugepages2M) {
 
     const uint64_t mapping_size = 2 * (1ULL << 20);  // 2 MB
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(tt::umd::ClusterOptions{
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{
         .num_host_mem_ch_per_mmio_device = 0,
     });
 
@@ -207,7 +207,7 @@ TEST(MicrobenchmarkIOMMU, MapHugepages1G) {
 
     const uint64_t mapping_size = 1ULL << 30;  // 1 GB
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(tt::umd::ClusterOptions{
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{
         .num_host_mem_ch_per_mmio_device = 0,
     });
 

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -48,7 +48,7 @@ static void set_barrier_params(Cluster& cluster) {
 }
 
 TEST(SiliconDriverWH, OneDramOneTensixNoEthSocDesc) {
-    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>(tt::umd::ClusterOptions{
+    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>(ClusterOptions{
         .sdesc_path = "tests/soc_descs/wormhole_b0_one_dram_one_tensix_no_eth.yaml",
     });
 }

--- a/tools/topology.cpp
+++ b/tools/topology.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[]) {
     }
 
     std::unordered_set<int> device_ids = {};
-    tt::umd::IODeviceType device_type = IODeviceType::PCIe;
+    IODeviceType device_type = IODeviceType::PCIe;
 
     if (result["jtag"].as<bool>()) {
         device_type = IODeviceType::JTAG;


### PR DESCRIPTION
### Issue
#103 

### Description
Remove some tt::umd prefixes where it wasn't needed. This is a follow up from putting everything in tt::umd namespace

### List of the changes
- Remove tt::umd:: where it was not needed
- Add "using namespace tt::umd" at two test files

### Testing
Code builds

### API Changes
There are no API changes in this PR.
