### PR TITLE
Change EXPECT to ASSERT in sysmem tests

### DIFF
--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -90,7 +90,7 @@ TEST(ApiSysmemManager, SysmemBuffers) {
     cluster->dma_read_from_device(readback.data(), one_mb, mmio_chip, tensix_core, 0);
 
     for (uint32_t i = 0; i < one_mb; ++i) {
-        EXPECT_EQ(sysmem_data[i], readback[i]);
+        ASSERT_EQ(sysmem_data[i], readback[i]);
     }
 
     uint8_t* sysmem_data_readback = sysmem_data + one_mb;
@@ -104,7 +104,7 @@ TEST(ApiSysmemManager, SysmemBuffers) {
     sysmem_buffer->dma_read_from_device(one_mb, one_mb, tensix_core, 0);
 
     for (uint32_t i = 0; i < one_mb; ++i) {
-        EXPECT_EQ(sysmem_data[i], sysmem_data_readback[i]);
+        ASSERT_EQ(sysmem_data[i], sysmem_data_readback[i]);
     }
 }
 
@@ -162,7 +162,7 @@ TEST(ApiSysmemManager, SysmemBufferUnaligned) {
     cluster->dma_read_from_device(readback.data(), one_mb, mmio_chip, tensix_core, 0);
 
     for (uint32_t i = 0; i < one_mb; ++i) {
-        EXPECT_EQ(sysmem_data[i], readback[i]);
+        ASSERT_EQ(sysmem_data[i], readback[i]);
     }
 
     // Zero out sysmem_data before reading back.
@@ -174,7 +174,7 @@ TEST(ApiSysmemManager, SysmemBufferUnaligned) {
     sysmem_buffer->dma_read_from_device(0, one_mb, tensix_core, 0);
 
     for (uint32_t i = 0; i < one_mb; ++i) {
-        EXPECT_EQ(sysmem_data[i], readback[i]);
+        ASSERT_EQ(sysmem_data[i], readback[i]);
     }
 }
 
@@ -258,7 +258,7 @@ TEST(ApiSysmemManager, SysmemBufferNocAddress) {
     EXPECT_EQ(readback, data_write);
 
     for (uint32_t i = 0; i < one_mb; ++i) {
-        EXPECT_EQ(sysmem_data[i], data_write[i])
+        ASSERT_EQ(sysmem_data[i], data_write[i])
             << "Mismatch at index " << i << ": expected " << static_cast<int>(data_write[i]) << ", got "
             << static_cast<int>(sysmem_data[i]);
     }


### PR DESCRIPTION
### Issue
Uncovered by failure in https://github.com/tenstorrent/tt-umd/actions/runs/19768960443/job/56649021362?pr=1669

### Description
When sysmem is setup bad, likely the whole full 1 megabyte will be bad. Printing it for every byte just makes a ton of longs on CI without any benefit. Changing this to ASSERT will stop the test after the first failure

### List of the changes
- Change EXPECT_EQ to ASSERT_EQ in each for loop which goes over 1 megabyte.

### Testing
No testing

### API Changes
There are no API changes in this PR.
