### PR TITLE
Fix BH p300 machine runs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -72,6 +72,7 @@ jobs:
         # This might include: .pytest_cache, .venv, artifact.tar, build, tests, tt-umd, tt_umd-*.whl
         # Just nuke everything to be safe.
         run: |
+          echo "Cleaning up working directory from previous runs: $(pwd)"
           rm -rf *
 
       - name: Use wheel artifact


### PR DESCRIPTION
### Issue
Blackhole dedicated machine gets broken after asan tsan runs from https://github.com/tenstorrent/tt-umd/pull/1668

### Description
The problem is that the cleanup of the folders was not done properly. Artefacts from the previous runs were left, so the python tests ended up using Asan builds.
It is actually the same problem that #1652 tried to resolve.
And I also managed to confirm that #1662 will solve it as well, but nevertheless, clean slate is better anyway.

### List of the changes
- rm -rf everything in workspace folder before running tests

### Testing
CI passes on this run, and subsequent scheduled runs on other PRs also pass after this fix.

### API Changes
There are no API changes in this PR.
