### PR TITLE
Remove BAR4 mapping from PCI device

### DIFF
--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -293,9 +293,6 @@ public:
     void *bar2_uc = nullptr;
     size_t bar2_uc_size;
 
-    void *bar4_wc = nullptr;
-    uint64_t bar4_wc_size;
-
     uint32_t read_checking_offset;
 
 private:

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -432,25 +432,6 @@ PCIDevice::PCIDevice(int pci_device_number) :
         if (bar2_uc == MAP_FAILED) {
             throw std::runtime_error(fmt::format("BAR2 UC mapping failed for device {}.", pci_device_num));
         }
-
-        if (bar4_wc_mapping.mapping_id != TENSTORRENT_MAPPING_RESOURCE2_WC) {
-            throw std::runtime_error(fmt::format("Device {} has no BAR4 WC mapping.", pci_device_num));
-        }
-
-        // Using Write-Combine memory mode. This is used for accessing DRAM on Blackhole.
-        // WC doesn't guarantee write ordering but has better performance.
-        bar4_wc_size = bar4_wc_mapping.mapping_size;
-        bar4_wc = mmap(
-            NULL,
-            bar4_wc_mapping.mapping_size,
-            PROT_READ | PROT_WRITE,
-            MAP_SHARED,
-            pci_device_file_desc,
-            bar4_wc_mapping.mapping_base);
-
-        if (bar4_wc == MAP_FAILED) {
-            throw std::runtime_error(fmt::format("BAR4 WC mapping failed for device {}.", pci_device_num));
-        }
     }
 
     allocate_pcie_dma_buffer();
@@ -475,10 +456,6 @@ PCIDevice::~PCIDevice() {
 
     if (bar2_uc != nullptr && bar2_uc != MAP_FAILED) {
         munmap(bar2_uc, bar2_uc_size);
-    }
-
-    if (bar4_wc != nullptr && bar4_wc != MAP_FAILED) {
-        munmap(bar4_wc, bar4_wc_size);
     }
 
     if (dma_buffer.buffer != nullptr && dma_buffer.buffer != MAP_FAILED) {


### PR DESCRIPTION
### Issue

Not map BAR4 now when we have KMD management of TLBs

### Description

This changes was overlooked in #959. Remove mapping the whole BAR4 in PCIDevice for Blackhole. It worked because it's always mapped as WC so mapping it twice if someone requests 4GB TLB would still work

### List of the changes

- Remove mapping and umapping of bar4 for Blackhole
- Remove bar4 related variables since it's not used for WH

### Testing
CI

### API Changes
/
