### PR TITLE
Add unity build support to UMD

### DIFF
--- a/.gersemirc
+++ b/.gersemirc
@@ -4,3 +4,4 @@ definitions: [cmake, cmake/stubs]
 indent: 4
 line_length: 120
 list_expansion: favour-expansion
+warn_about_unknown_commands: false

--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -56,13 +56,15 @@ add_dependencies(device generate_lite_fabric_embed)
 
 # Enable unity builds for faster compilation 
 # Note: Requires TT_ENABLE_UNITY_BUILD function from parent project 
-if(COMMAND TT_ENABLE_UNITY_BUILD) 
-    TT_ENABLE_UNITY_BUILD(device) 
+if(COMMAND TT_ENABLE_UNITY_BUILD)
+    tt_enable_unity_build(device)
     # Exclude files that cause ODR violations due to conflicting eth_interface.h headers 
-    set_source_files_properties( 
-        arch/wormhole_implementation.cpp 
-        arch/blackhole_implementation.cpp 
-        PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON 
+    set_source_files_properties(
+        arch/wormhole_implementation.cpp
+        arch/blackhole_implementation.cpp
+        PROPERTIES
+            SKIP_UNITY_BUILD_INCLUSION
+                ON
     )
 endif()
 


### PR DESCRIPTION
Add unity build support to UMD in order to speed up the e2e build of tt_metal.
UMD is now non trivial part of build of tt_metal ~30s (depending on CPU) this will bring the compile cost to ~1/3, when unity build enabled, which is the default build in tt-metal