### PR TITLE
Driver version mismatch removal

### DIFF
--- a/device/api/umd/device/tt_kmd_lib/tt_kmd_lib.h
+++ b/device/api/umd/device/tt_kmd_lib/tt_kmd_lib.h
@@ -14,11 +14,6 @@
 extern "C" {
 #endif
 
-#define TENSTORRENT_DRIVER_VERSION_MAJOR 2
-#define TENSTORRENT_DRIVER_VERSION_MINOR 3
-#define TENSTORRENT_DRIVER_VERSION_PATCH 0
-#define TENSTORRENT_DRIVER_VERSION_SUFFIX ""  // e.g. "-rc1"
-
 /**
  * @brief Opaque handle to a Tenstorrent PCIe device.
  */

--- a/device/tt_kmd_lib/tt_kmd_lib.c
+++ b/device/tt_kmd_lib/tt_kmd_lib.c
@@ -81,33 +81,6 @@ int tt_device_open(const char* chardev_path, tt_device_t** out_dev) {
         return -e;
     }
 
-    uint64_t major = 0;
-    uint64_t minor = 0;
-    uint64_t patch = 0;
-
-    int ret;
-    if ((ret = tt_driver_get_attr(dev, TT_DRIVER_SEMVER_MAJOR, &major)) != 0 ||
-        (ret = tt_driver_get_attr(dev, TT_DRIVER_SEMVER_MINOR, &minor)) != 0 ||
-        (ret = tt_driver_get_attr(dev, TT_DRIVER_SEMVER_PATCH, &patch)) != 0) {
-        close(dev->fd);
-        free(dev);
-        return ret;
-    }
-
-    if (major != TENSTORRENT_DRIVER_VERSION_MAJOR || minor < TENSTORRENT_DRIVER_VERSION_MINOR) {
-        DEBUG(
-            "Driver version mismatch: compiled for v%d.%d.%d; detected v%lu.%lu.%lu\n",
-            TENSTORRENT_DRIVER_VERSION_MAJOR,
-            TENSTORRENT_DRIVER_VERSION_MINOR,
-            TENSTORRENT_DRIVER_VERSION_PATCH,
-            major,
-            minor,
-            patch);
-        close(dev->fd);
-        free(dev);
-        return -ENODEV;
-    }
-
     *out_dev = dev;
 
     return 0;


### PR DESCRIPTION
### Issue
Aftermath of https://github.com/tenstorrent/tt-umd/pull/1556

### Description
Seems like a check was leftover that effectivelly ties us to a single kmd version. And looks like all our CI machines are using the same KMD version.

### List of the changes
- Remove the checks for driver version

### Testing
No testing

### API Changes
There are no API changes in this PR.
