### PR TITLE
Mock device

### DIFF
--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -807,6 +807,21 @@ void ClusterDescriptor::load_chips_from_connectivity_descriptor(YAML::Node &yaml
             }
             chip_board_type.insert({chip, board_type});
         }
+    } else if (yaml["boardtype"]) {
+        // Legacy format support: parse old "boardtype" field for backward compatibility.
+        for (const auto &yaml_chip_board_type : yaml["boardtype"].as<std::map<int, std::string>>()) {
+            auto &chip = yaml_chip_board_type.first;
+            const std::string &board_type_str = yaml_chip_board_type.second;
+            BoardType board_type = board_type_from_string(board_type_str);
+            if (board_type == BoardType::UNKNOWN) {
+                log_warning(
+                    LogUMD,
+                    "Unknown board type for chip {} from legacy boardtype field. "
+                    "Defaulting to UNKNOWN",
+                    chip);
+            }
+            chip_board_type.insert({chip, board_type});
+        }
     } else {
         for (const auto &chip : all_chips) {
             chip_board_type.insert({chip, BoardType::UNKNOWN});
@@ -837,6 +852,13 @@ void ClusterDescriptor::load_chips_from_connectivity_descriptor(YAML::Node &yaml
             auto &chip = chip_unique_id.first;
             auto &unique_id = chip_unique_id.second;
             chip_unique_ids.insert({chip, unique_id});
+        }
+    } else {
+        // Legacy format or mock descriptors may not have chip_unique_ids
+        // Generate synthetic IDs for backward compatibility.
+        for (const auto &chip : all_chips) {
+            // Use chip ID shifted left to create unique synthetic IDs.
+            chip_unique_ids.insert({chip, static_cast<uint64_t>(chip) << 32});
         }
     }
 


### PR DESCRIPTION
## Issue

Main issue :https://github.com/tenstorrent/tt-metal/issues/14000

This PR fixes backward compatibility issues with older cluster descriptor files used in mock device testing.

## Description

This change allows UMD to parse older cluster descriptor YAML files that use the `boardtype` field instead of the newer `chip_to_boardtype` format. It also handles cases where `chip_unique_ids` is missing by generating synthetic IDs. This is needed for mock device testing in tt-metal, particularly with Wormhole N300/N150 configurations.

## Changes

**`device/cluster_descriptor.cpp`**:
- Added parsing for the legacy `boardtype` field to support older YAML files
- Generate synthetic `chip_unique_ids` when not provided (using `chip_id << 32` as the synthetic ID)
- Maintains compatibility with both old and new descriptor formats

## Testing

Tested with legacy Wormhole N300 and N150 cluster descriptors to verify:
- Legacy `boardtype` field is correctly parsed
- Synthetic unique IDs are generated consistently when missing
- Modern descriptor formats continue to work as expected

## API Changes

None.

## Used By

**tt-metal PR**: https://github.com/tenstorrent/tt-metal/pull/34194 - Mock device support with Fast Dispatch mode