### PR TITLE
Add ERISC FW 7.2.0 for CMFW 19.4.1

### DIFF
--- a/device/api/umd/device/firmware/erisc_firmware.hpp
+++ b/device/api/umd/device/firmware/erisc_firmware.hpp
@@ -34,7 +34,8 @@ static const std::vector<std::pair<semver_t, semver_t>> WH_ERISC_FW_VERSION_MAP 
     {{18, 6, 0}, {7, 0, 0}},
     {{18, 12, 0}, {7, 1, 0}},
     {{19, 0, 0}, {7, 2, 0}},
-    {{19, 4, 0}, {7, 3, 0}}};
+    {{19, 4, 0}, {7, 3, 0}},
+    {{19, 4, 1}, {7, 2, 0}}};
 static const std::vector<std::pair<semver_t, semver_t>> BH_ERISC_FW_VERSION_MAP = {
     {{18, 5, 0}, {1, 4, 1}},
     {{18, 6, 0}, {1, 4, 2}},


### PR DESCRIPTION
### Issue
#1702 

### Description
CMFW 19.4.1 reverts ERISC FW to 7.2.0

### List of the changes
- Add ERISC FW 7.2.0 for CMFW 19.4.1

### Testing
Ci

### API Changes
There are no API changes in this PR.
