### PR TITLE
Fix multicast for Blackhole simulation

### DIFF
--- a/device/simulation/simulation_chip.cpp
+++ b/device/simulation/simulation_chip.cpp
@@ -71,6 +71,12 @@ void SimulationChip::noc_multicast_write(
     const tt_xy_pair translated_end = soc_descriptor_.translate_coord_to(core_end, CoordSystem::TRANSLATED);
     for (uint32_t x = translated_start.x; x <= translated_end.x; ++x) {
         for (uint32_t y = translated_start.y; y <= translated_end.y; ++y) {
+            // Since we are doing set of unicasts, we must skip cores that are not actual Tensix cores.
+            // These are in columns where x = 8 (ARC core, L2CPU) and x = 9 (GDDR).
+            // TODO: investigate proper multicast support for simulations so we can remove this workaround.
+            if (soc_descriptor_.arch == tt::ARCH::BLACKHOLE && (x == 8 || x == 9)) {
+                continue;
+            }
             write_to_device(CoreCoord(x, y, core_start.core_type, core_start.coord_system), dst, addr, size);
         }
     }


### PR DESCRIPTION
### Issue

https://github.com/tenstorrent/tt-umd/issues/1714

### Description

Fix NOC multicast for Blackhole simulation. Since we are doing set of unicasts we need to skip columns with non-tensix cores (x = 8 and x = 9)

### List of the changes

- Add check for skipping blackhole NOC x = 8 and x = 9

### Testing
/

### API Changes
/