### PR TITLE
fix/Asserting on correct Blackhole firmware version check (18.5.0)

### DIFF
--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -378,7 +378,7 @@ bool TopologyDiscovery::verify_fw_bundle_version(Chip* chip) {
         latest_supported_fw_bundle_version.to_string());
 
     TT_ASSERT(
-        semver_t::compare_firmware_bundle(fw_bundle_version, minimum_compatible_fw_bundle_version) > 0,
+        semver_t::compare_firmware_bundle(fw_bundle_version, minimum_compatible_fw_bundle_version) >= 0,
         "Firmware bundle version {} on the system is older than the minimum compatible version {} for {} "
         "architecture.",
         fw_bundle_version.to_string(),


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/1719

### Description
The minimum version for Blackhole devices is 18.5.0. 
When tt-firmware is set to 18.5.0, UMD will prevent running tt programs with assert with the following error:

'Firmware bundle version 18.5.0 on the system is older than the minimum compatible version 18.5.0 for blackhole architecture.'

When looking at the code that prints this assert message (`device/topology/topology_discovery.cpp`), we see that the assert condition prevents any FW that is not newer than 18.5.0, but the message implies that the the asset condition prevents any FW that is older than 18.5.0. 

This excludes the case of FW being 18.5.0, which is the SAME as the condition.

So we need to consider the case for 18.5.0 as well.

### List of the changes

- Add equality for tt-firmware 18.5.0.

### Testing
(Comment on CI testing or Manual testing touching this change.)

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
