### PR TITLE
Remove get_register_address dead code

### DIFF
--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -318,9 +318,6 @@ protected:
     std::unique_ptr<ArcTelemetryReader> telemetry = nullptr;
     std::unique_ptr<FirmwareInfoProvider> firmware_info_provider = nullptr;
 
-    template <typename T>
-    T *get_register_address(uint32_t register_offset);
-
     semver_t fw_version_from_telemetry(const uint32_t telemetry_data) const;
 
     TTDevice();


### PR DESCRIPTION
### Issue

#63 

### Description

This function doesn't exist for quite some time, but the declaration remained as dead code inside TTDevice. This PR removes it.

### List of the changes

- Remove dead code from TTDevice

### Testing
CI

### API Changes
/