### PR TITLE
Add benchmark to compare unicast with multicast

### DIFF
--- a/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
+++ b/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
@@ -304,7 +304,7 @@ TEST(MicrobenchmarkTLB, CompareMulticastandUnicast) {
 
         {
             double total_ns = 0;
-            for (auto tensix_core : tensix_cores) {
+            for (auto &tensix_core : tensix_cores) {
                 auto start = std::chrono::steady_clock::now();
                 cluster->write_to_device(buffer.data(), buf_size, chip, tensix_core, 0);
                 auto end = std::chrono::steady_clock::now();


### PR DESCRIPTION
### Issue

/

### Description

This PR adds simple benchmark which compares time needed to multicast data to all tensix cores and time to unicast data to every single Tensix core. SInce multicast BW is the same as unicast, it just saves time by having multiple endpoints as the destination. Because of that, the test is added, disabled by default, so someone can run it if needed for info, but it's not part of the official benchmarking. 

### List of the changes

- Add test to compare unicast with multicast

### Testing
Manual testing

### API Changes
/
