### PR TITLE
Minor fix robust mutex for tsan runs

### DIFF
--- a/device/utils/robust_mutex.cpp
+++ b/device/utils/robust_mutex.cpp
@@ -123,7 +123,7 @@ void* get_tsan_mutex_id(std::string mutex_name) {
 }
 #endif
 
-static void tsan_annotate_mutex_init(const std::string& name) {
+static void tsan_annotate_mutex_init(const std::string& mutex_name) {
 #ifdef __SANITIZE_THREAD__
     // Register this mutex name in the TSAN tracking storage.
     // This ensures all threads using the same mutex name will use the same
@@ -135,21 +135,21 @@ static void tsan_annotate_mutex_init(const std::string& name) {
 #endif
 }
 
-static void tsan_annotate_mutex_acquire(const std::string& name) {
+static void tsan_annotate_mutex_acquire(const std::string& mutex_name) {
 #ifdef __SANITIZE_THREAD__
     // Inform TSAN that we've acquired the mutex, establishing a happens-before relationship.
     // This must be called AFTER the actual lock acquisition so TSAN sees that we now have
     // the synchronization point established by the previous owner's __tsan_release.
-    __tsan_acquire(get_tsan_mutex_id(name));
+    __tsan_acquire(get_tsan_mutex_id(mutex_name));
 #endif
 }
 
-static void tsan_annotate_mutex_release(const std::string& name) {
+static void tsan_annotate_mutex_release(const std::string& mutex_name) {
 #ifdef __SANITIZE_THREAD__
     // Inform TSAN that we're releasing the mutex, establishing a happens-before relationship.
     // This must be called BEFORE the actual unlock so TSAN sees the release before other
     // threads/processes can acquire the lock.
-    __tsan_release(get_tsan_mutex_id(name));
+    __tsan_release(get_tsan_mutex_id(mutex_name));
 #endif
 }
 


### PR DESCRIPTION
### Issue
No issue, found this while bumping to metal: https://github.com/tenstorrent/tt-metal/actions/runs/20518466630/job/58949911287

### Description
This was present in https://github.com/tenstorrent/tt-umd/pull/1668 but I still haven't checked that one in

### List of the changes
- Change "name" to "mutex_name" in tsan related functions

### Testing
TSAN run: https://github.com/tenstorrent/tt-umd/actions/runs/20518649717

### API Changes
There are no API changes in this PR.
