### PR TITLE
Minor static/cached tlb constant cleanup

### DIFF
--- a/device/api/umd/device/arch/architecture_implementation.hpp
+++ b/device/api/umd/device/arch/architecture_implementation.hpp
@@ -54,8 +54,6 @@ public:
     virtual uint32_t get_mem_large_read_tlb() const = 0;
     virtual uint32_t get_mem_large_write_tlb() const = 0;
     virtual uint32_t get_num_eth_channels() const = 0;
-    virtual uint32_t get_static_tlb_cfg_addr() const = 0;
-    virtual uint32_t get_static_tlb_size() const = 0;
     virtual uint32_t get_read_checking_offset() const = 0;
     virtual uint32_t get_reg_tlb() const = 0;
     virtual uint32_t get_tlb_base_index_16m() const = 0;

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -157,7 +157,7 @@ static const std::vector<uint32_t> T6_Y_LOCATIONS = {2, 3, 4, 5, 6, 7, 8, 9, 10,
 static const std::vector<uint32_t> HARVESTING_NOC_LOCATIONS = {1, 16, 2, 15, 3, 14, 4, 13, 5, 12, 6, 11, 7, 10};
 static const std::vector<uint32_t> LOGICAL_HARVESTING_LAYOUT = {0, 2, 4, 6, 8, 10, 12, 13, 11, 9, 7, 5, 3, 1};
 
-inline constexpr uint32_t STATIC_TLB_SIZE = 1024 * 1024;  // TODO: Copied from wormhole. Need to verify.
+inline constexpr uint32_t STATIC_TLB_SIZE = 2 * 1024 * 1024;  // 2MB
 
 inline constexpr xy_pair BROADCAST_LOCATION = {0, 0};  // TODO: Copied from wormhole. Need to verify.
 inline constexpr uint32_t BROADCAST_TLB_INDEX = 0;     // TODO: Copied from wormhole. Need to verify.
@@ -395,10 +395,6 @@ public:
 
     uint32_t get_num_eth_channels() const override { return blackhole::NUM_ETH_CHANNELS; }
 
-    uint32_t get_static_tlb_cfg_addr() const override { return blackhole::STATIC_TLB_CFG_ADDR; }
-
-    uint32_t get_static_tlb_size() const override { return blackhole::STATIC_TLB_SIZE; }
-
     uint32_t get_read_checking_offset() const override { return blackhole::BH_NOC_NODE_ID_OFFSET; }
 
     uint32_t get_reg_tlb() const override { return blackhole::REG_TLB; }
@@ -471,7 +467,7 @@ public:
 
     uint64_t get_noc_reg_base(const CoreType core_type, const uint32_t noc, const uint32_t noc_port = 0) const override;
 
-    size_t get_cached_tlb_size() const override { return 1 << 21; }  // 2MB
+    size_t get_cached_tlb_size() const override { return blackhole::STATIC_TLB_SIZE; }
 
     bool get_static_vc() const override { return false; }  // False due to a known HW issue.
 };

--- a/device/api/umd/device/arch/grendel_implementation.hpp
+++ b/device/api/umd/device/arch/grendel_implementation.hpp
@@ -151,7 +151,7 @@ static const std::vector<uint32_t> T6_Y_LOCATIONS = {2, 3, 4, 5, 6, 7, 8, 9, 10,
 static const std::vector<uint32_t> HARVESTING_NOC_LOCATIONS = {1, 16, 2, 15, 3, 14, 4, 13, 5, 12, 6, 11, 7, 10};
 static const std::vector<uint32_t> LOGICAL_HARVESTING_LAYOUT = {0, 2, 4, 6, 8, 10, 12, 13, 11, 9, 7, 5, 3, 1};
 
-inline constexpr uint32_t STATIC_TLB_SIZE = 1024 * 1024;  // TODO: Copied from wormhole. Need to verify.
+inline constexpr uint32_t STATIC_TLB_SIZE = 2 * 1024 * 1024;  // TODO: Copied from blackhole. Need to verify.
 
 inline constexpr xy_pair BROADCAST_LOCATION = {0, 0};  // TODO: Copied from wormhole. Need to verify.
 inline constexpr uint32_t BROADCAST_TLB_INDEX = 0;     // TODO: Copied from wormhole. Need to verify.
@@ -392,10 +392,6 @@ public:
 
     uint32_t get_num_eth_channels() const override { return grendel::NUM_ETH_CHANNELS; }
 
-    uint32_t get_static_tlb_cfg_addr() const override { return grendel::STATIC_TLB_CFG_ADDR; }
-
-    uint32_t get_static_tlb_size() const override { return grendel::STATIC_TLB_SIZE; }
-
     uint32_t get_read_checking_offset() const override { return grendel::BH_NOC_NODE_ID_OFFSET; }
 
     uint32_t get_reg_tlb() const override { return grendel::REG_TLB; }
@@ -470,7 +466,7 @@ public:
 
     uint64_t get_noc_reg_base(const CoreType core_type, const uint32_t noc, const uint32_t noc_port = 0) const override;
 
-    size_t get_cached_tlb_size() const override { return 1 << 21; }  // 2MB
+    size_t get_cached_tlb_size() const override { return grendel::STATIC_TLB_SIZE; }
 
     bool get_static_vc() const override { return true; }
 };

--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -180,7 +180,7 @@ static const std::vector<uint32_t> T6_Y_LOCATIONS = {1, 2, 3, 4, 5, 7, 8, 9, 10,
 static const std::vector<uint32_t> HARVESTING_NOC_LOCATIONS = {11, 1, 10, 2, 9, 3, 8, 4, 7, 5};
 static const std::vector<uint32_t> LOGICAL_HARVESTING_LAYOUT = {1, 3, 5, 7, 9, 8, 6, 4, 2, 0};
 
-inline constexpr uint32_t STATIC_TLB_SIZE = 1024 * 1024;
+inline constexpr uint32_t STATIC_TLB_SIZE = 1 * 1024 * 1024;  // 1MB
 
 inline constexpr xy_pair BROADCAST_LOCATION = {0, 0};
 inline constexpr uint32_t BROADCAST_TLB_INDEX = 0;
@@ -404,11 +404,7 @@ public:
 
     uint32_t get_num_eth_channels() const override { return wormhole::NUM_ETH_CHANNELS; }
 
-    uint32_t get_static_tlb_cfg_addr() const override { return wormhole::STATIC_TLB_CFG_ADDR; }
-
     uint32_t get_read_checking_offset() const override { return wormhole::ARC_SCRATCH_6_OFFSET; }
-
-    uint32_t get_static_tlb_size() const override { return wormhole::STATIC_TLB_SIZE; }
 
     uint32_t get_reg_tlb() const override { return wormhole::REG_TLB; }
 
@@ -480,7 +476,7 @@ public:
 
     uint64_t get_noc_reg_base(const CoreType core_type, const uint32_t noc, const uint32_t noc_port = 0) const override;
 
-    size_t get_cached_tlb_size() const override { return 1 << 20; }  // 1MB
+    size_t get_cached_tlb_size() const override { return wormhole::STATIC_TLB_SIZE; }
 
     bool get_static_vc() const override { return true; }
 };


### PR DESCRIPTION
### Issue
/

### Description
I found this while working on some changes in tlb manager. Cursor mistakenly started using get_static_tlb_size, an then I realised we have duplicate get_static_tlb_size and get_cached_tlb_size which should be the same in essence.
I removed the ones unused, and changed the get_cached version to use the constant which we already had.

### List of the changes
- Remove get_static_tlb_cfg_addr and get_static_tlb_size
- Update STATIC_TLB_SIZE
- Update get_cached_tlb_size

### Testing
No testing, values are the same.

### API Changes
There are no API changes in this PR.
