### PR TITLE
Unmap TLBs on close_device

### DIFF
--- a/device/api/umd/device/chip_helpers/tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/tlb_manager.hpp
@@ -42,6 +42,9 @@ public:
     std::unique_ptr<TlbWindow> allocate_tlb_window(
         tlb_data config, const TlbMapping mapping = TlbMapping::WC, const size_t tlb_size = 0);
 
+    // Clear all static TLB mappings.
+    void clear_mapped_tlbs();
+
 private:
     TTDevice* tt_device_;
 };

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -199,6 +199,9 @@ void LocalChip::close_device() {
         if (sysmem_manager_) {
             sysmem_manager_->unpin_or_unmap_sysmem();
         }
+        if (tlb_manager_) {
+            tlb_manager_->clear_mapped_tlbs();
+        }
     }
     chip_started_lock_.reset();
 };

--- a/device/chip_helpers/tlb_manager.cpp
+++ b/device/chip_helpers/tlb_manager.cpp
@@ -131,4 +131,11 @@ std::unique_ptr<TlbWindow> TLBManager::allocate_tlb_window(
     throw std::runtime_error(fmt::format("Failed to allocate TLB window."));
 }
 
+void TLBManager::clear_mapped_tlbs() {
+    log_debug(LogUMD, "Clearing all TLB mappings.");
+    tlb_config_map_.clear();
+    map_core_to_tlb_.clear();
+    tlb_windows_.clear();
+}
+
 };  // namespace tt::umd


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/34034

### Description
If we don't explicitly cleanup these TLBs, we can run into problems due to the way python cleans up stale objects. MetalContext might be cleaned up, but the object is still live and hence it will still hold TLBs unless explicitly cleaned up.

### List of the changes
- Clean up all cached TLB mappings when close_device is called

### Testing
Checked that the function is called as part of StartDeviceWithValidRiscProgram test runtime.

### API Changes
There are no API changes in this PR.
