### PR TITLE
Integrate notify in warm reset

### DIFF
--- a/device/warm_reset.cpp
+++ b/device/warm_reset.cpp
@@ -46,6 +46,9 @@ void WarmReset::warm_reset(std::vector<int> pci_device_ids, bool reset_m3, bool 
     if (PCIDevice::is_arch_agnostic_reset_supported()) {
         warm_reset_arch_agnostic(pci_device_ids, reset_m3);
     } else if (auto enumerate_devices = PCIDevice::enumerate_devices_info(); enumerate_devices.empty()) {
+        // Re-enumerate here as a safety net for potential race conditions where devices disappear
+        // between the pre-reset notification and now. Clients are still guaranteed to receive the
+        // post-reset notification since it's sent unconditionally after this block.
         log_warning(tt::LogUMD, "No devices found to reset in legacy path.");
     } else {
         auto arch = enumerate_devices.begin()->second.get_arch();


### PR DESCRIPTION
### Issue
#1351

### Description
This pull request adds a new feature to the `warm_reset` function in `warm_reset.cpp` by adding the notification process for listeners and making the legacy reset path more robust. The changes ensure that notifications are sent both before and after the reset, and add better handling when no devices are found for reset.

### List of the changes

* Added a call to `WarmResetCommunication::Notifier::notify_all_listeners_pre_reset` before performing the reset, and a call to `notify_all_listeners_post_reset` after the reset completes, ensuring all listeners are properly notified around the reset operation.
* Improved the legacy reset path by checking if `enumerate_devices` is empty and logging a warning if no devices are found, rather than proceeding with the reset. Also, added a warning for unknown architectures instead of silently returning.

### Testing
CI

### API Changes
/
