### PR TITLE
Correctly initialize communication_device_type in TTDevice

### DIFF
--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -309,7 +309,7 @@ public:
 protected:
     std::shared_ptr<PCIDevice> pci_device_;
     std::shared_ptr<JtagDevice> jtag_device_;
-    IODeviceType communication_device_type_ = IODeviceType::UNKNOWN;
+    IODeviceType communication_device_type_ = IODeviceType::UNDEFINED;
     int communication_device_id_;
     std::unique_ptr<architecture_implementation> architecture_impl_;
     tt::ARCH arch;

--- a/device/api/umd/device/types/communication_protocol.hpp
+++ b/device/api/umd/device/types/communication_protocol.hpp
@@ -11,14 +11,14 @@ namespace tt::umd {
 enum class IODeviceType {
     PCIe,
     JTAG,
-    UNKNOWN,
+    UNDEFINED,
 };
 
 // Const map of Device type names for each of the types listed in the enum.
 static const std::unordered_map<IODeviceType, std::string> DeviceTypeToString = {
     {IODeviceType::PCIe, "PCIe"},
     {IODeviceType::JTAG, "JTAG"},
-    {IODeviceType::UNKNOWN, "Unknown"},
+    {IODeviceType::UNDEFINED, "Undefined"},
 };
 
 }  // namespace tt::umd

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -44,7 +44,10 @@ std::unique_ptr<TTDevice> create_remote_wormhole_tt_device(
 }
 
 void bind_tt_device(nb::module_ &m) {
-    nb::enum_<IODeviceType>(m, "IODeviceType").value("PCIe", IODeviceType::PCIe).value("JTAG", IODeviceType::JTAG);
+    nb::enum_<IODeviceType>(m, "IODeviceType")
+        .value("PCIe", IODeviceType::PCIe)
+        .value("JTAG", IODeviceType::JTAG)
+        .value("Undefined", IODeviceType::UNDEFINED);
 
     nb::class_<PciDeviceInfo>(m, "PciDeviceInfo")
         .def_ro("vendor_id", &PciDeviceInfo::vendor_id)


### PR DESCRIPTION
### Issue
#1778 

### Description
TTDevice::communication_device_type was left uninitialized when instantiating some inherited classes. 

### List of the changes
- Introduce new IODeviceType UNDEFINED
- Initialize TTDevice::communication_device_type to UNDEFINED

### Testing
CI

### API Changes
There are no API changes in this PR.
