### PR TITLE
Update initialization timeout to match the ones from luwen

### DIFF
--- a/device/api/umd/device/utils/timeouts.hpp
+++ b/device/api/umd/device/utils/timeouts.hpp
@@ -10,13 +10,13 @@ namespace tt::umd::timeout {
 inline constexpr auto NON_MMIO_RW_TIMEOUT = std::chrono::milliseconds(5'000);
 
 inline constexpr auto ARC_MESSAGE_TIMEOUT = std::chrono::milliseconds(1'000);
-inline constexpr auto ARC_STARTUP_TIMEOUT = std::chrono::milliseconds(5'000);
+inline constexpr auto ARC_STARTUP_TIMEOUT = std::chrono::milliseconds(300'000);
 inline constexpr auto ARC_POST_RESET_TIMEOUT = std::chrono::milliseconds(1'000);
 inline constexpr auto ARC_LONG_POST_RESET_TIMEOUT = std::chrono::milliseconds(300'000);
 
-inline constexpr auto DRAM_TRAINING_TIMEOUT = std::chrono::milliseconds(60'000);
+inline constexpr auto DRAM_TRAINING_TIMEOUT = std::chrono::milliseconds(300'000);
 inline constexpr auto ETH_QUEUE_ENABLE_TIMEOUT = std::chrono::milliseconds(30'000);
-inline constexpr auto ETH_TRAINING_TIMEOUT = std::chrono::milliseconds(60'000);
+inline constexpr auto ETH_TRAINING_TIMEOUT = std::chrono::milliseconds(900'000);
 
 inline constexpr auto AICLK_TIMEOUT = std::chrono::milliseconds(100);
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/1789
https://github.com/tenstorrent/tt-umd/issues/1820

### Description
The timeouts are defined here: 
https://github.com/tenstorrent/luwen/blob/main/crates/luwen-api/src/chip/wormhole.rs#L334-L360
https://github.com/tenstorrent/luwen/blob/main/crates/luwen-api/src/chip/blackhole.rs#L535-L565

### List of the changes
- Change our timeouts

### Testing
- Tested that reset now passes on previously failing configuration

### API Changes
There are no API changes in this PR.
