### PR TITLE
Fix segfault in ApiSimulationSysmemManager.BasicIOSingleChannel

### DIFF
--- a/device/api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
@@ -17,7 +17,7 @@ static constexpr size_t HUGEPAGE_CHANNEL_3_SIZE_LIMIT = 768 * (1 << 20);
 class SiliconSysmemManager : public SysmemManager {
 public:
     SiliconSysmemManager(TLBManager* tlb_manager, uint32_t num_host_mem_channels);
-    virtual ~SiliconSysmemManager();
+    ~SiliconSysmemManager() override;
 
     bool pin_or_map_sysmem_to_device() override;
 

--- a/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
@@ -11,7 +11,7 @@ namespace tt::umd {
 class SimulationSysmemManager : public SysmemManager {
 public:
     SimulationSysmemManager(uint32_t num_host_mem_channels);
-    ~SimulationSysmemManager();
+    ~SimulationSysmemManager() override;
 
     bool pin_or_map_sysmem_to_device() override;
 

--- a/device/chip_helpers/sysmem_manager.cpp
+++ b/device/chip_helpers/sysmem_manager.cpp
@@ -52,13 +52,14 @@ void SysmemManager::read_from_sysmem(uint16_t channel, void *dest, uint64_t sysm
 
     void *user_scratchspace = static_cast<char *>(hugepage_map.mapping) + (sysmem_src % hugepage_map.mapping_size);
 
-    log_debug(
-        LogUMD,
-        "Cluster::read_buffer (pci device num: {}, ch: {}) from {:p}",
-        tt_device_->get_pci_device()->get_device_num(),
-        channel,
-        user_scratchspace);
-
+    if (tt_device_) {
+        log_debug(
+            LogUMD,
+            "Cluster::read_buffer (comm. device ID: {}, ch: {}) from {:p}",
+            tt_device_->get_communication_device_id(),
+            channel,
+            user_scratchspace);
+    }
     memcpy(dest, user_scratchspace, size);
 }
 


### PR DESCRIPTION
### Issue
#1784

### Description
Fix segfault in ApiSimulationSysmemManager.BasicIOSingleChannel.
This bug was caused due to bad class abstraction of simulation and silicon SysmemManager.

### List of the changes
- Check if tt_device_ is not nullptr before logging read from sysmem.

### Testing
CI

### API Changes
There are no API changes in this PR.
