### PR TITLE
Customisable host memory for simulation

### DIFF
--- a/device/api/umd/device/simulation/rtl_simulation_chip.hpp
+++ b/device/api/umd/device/simulation/rtl_simulation_chip.hpp
@@ -15,7 +15,11 @@ namespace tt::umd {
 // RTL simulation implementation using subprocess and flatbuffer communication.
 class RtlSimulationChip : public SimulationChip {
 public:
-    RtlSimulationChip(const std::filesystem::path& simulator_directory, SocDescriptor soc_descriptor, ChipId chip_id);
+    RtlSimulationChip(
+        const std::filesystem::path& simulator_directory,
+        SocDescriptor soc_descriptor,
+        ChipId chip_id,
+        int num_host_mem_channels = 0);
     ~RtlSimulationChip() override = default;
 
     void start_device() override;

--- a/device/api/umd/device/simulation/simulation_chip.hpp
+++ b/device/api/umd/device/simulation/simulation_chip.hpp
@@ -25,7 +25,8 @@ public:
         const std::filesystem::path& simulator_directory,
         SocDescriptor soc_descriptor,
         ChipId chip_id,
-        size_t num_chips);
+        size_t num_chips,
+        int num_host_mem_channels = 0);
 
     virtual ~SimulationChip() = default;
 
@@ -85,7 +86,11 @@ public:
     virtual void deassert_risc_reset(CoreCoord core, const RiscType selected_riscs, bool staggered_start) override = 0;
 
 protected:
-    SimulationChip(const std::filesystem::path& simulator_directory, SocDescriptor soc_descriptor, ChipId chip_id);
+    SimulationChip(
+        const std::filesystem::path& simulator_directory,
+        SocDescriptor soc_descriptor,
+        ChipId chip_id,
+        int num_host_mem_channels = 0);
 
     // Simulator directory.
     // Common state variables.

--- a/device/api/umd/device/simulation/tt_sim_chip.hpp
+++ b/device/api/umd/device/simulation/tt_sim_chip.hpp
@@ -20,7 +20,8 @@ public:
         const std::filesystem::path& simulator_directory,
         SocDescriptor soc_descriptor,
         ChipId chip_id,
-        bool copy_sim_binary = false);
+        bool copy_sim_binary = false,
+        int num_host_mem_channels = 0);
     ~TTSimChip() override;
 
     void start_device() override;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -220,7 +220,8 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     if (chip_type == ChipType::SIMULATION) {
 #ifdef TT_UMD_BUILD_SIMULATION
         log_info(LogUMD, "Creating Simulation device");
-        return SimulationChip::create(simulator_directory, soc_desc, chip_id, cluster_desc->get_number_of_chips());
+        return SimulationChip::create(
+            simulator_directory, soc_desc, chip_id, cluster_desc->get_number_of_chips(), num_host_mem_channels);
 #else
         throw std::runtime_error(
             "Simulation device is not supported in this build. Set '-DTT_UMD_BUILD_SIMULATION=ON' during cmake "

--- a/device/simulation/rtl_simulation_chip.cpp
+++ b/device/simulation/rtl_simulation_chip.cpp
@@ -75,8 +75,11 @@ inline void send_command_to_simulation_host(SimulationHost& host, flatbuffers::F
 }
 
 RtlSimulationChip::RtlSimulationChip(
-    const std::filesystem::path& simulator_directory, SocDescriptor soc_descriptor, ChipId chip_id) :
-    SimulationChip(simulator_directory, soc_descriptor, chip_id) {
+    const std::filesystem::path& simulator_directory,
+    SocDescriptor soc_descriptor,
+    ChipId chip_id,
+    int num_host_mem_channels) :
+    SimulationChip(simulator_directory, soc_descriptor, chip_id, num_host_mem_channels) {
     log_info(tt::LogEmulationDriver, "Instantiating RTL simulation device");
 
     if (!std::filesystem::exists(simulator_directory)) {

--- a/device/simulation/simulation_chip.cpp
+++ b/device/simulation/simulation_chip.cpp
@@ -15,11 +15,16 @@
 namespace tt::umd {
 
 std::unique_ptr<SimulationChip> SimulationChip::create(
-    const std::filesystem::path& simulator_directory, SocDescriptor soc_descriptor, ChipId chip_id, size_t num_chips) {
+    const std::filesystem::path& simulator_directory,
+    SocDescriptor soc_descriptor,
+    ChipId chip_id,
+    size_t num_chips,
+    int num_host_mem_channels) {
     if (simulator_directory.extension() == ".so") {
-        return std::make_unique<TTSimChip>(simulator_directory, soc_descriptor, chip_id, num_chips > 1);
+        return std::make_unique<TTSimChip>(
+            simulator_directory, soc_descriptor, chip_id, num_chips > 1, num_host_mem_channels);
     } else {
-        return std::make_unique<RtlSimulationChip>(simulator_directory, soc_descriptor, chip_id);
+        return std::make_unique<RtlSimulationChip>(simulator_directory, soc_descriptor, chip_id, num_host_mem_channels);
     }
 }
 
@@ -29,13 +34,16 @@ std::string SimulationChip::get_soc_descriptor_path_from_simulator_path(const st
 }
 
 SimulationChip::SimulationChip(
-    const std::filesystem::path& simulator_directory, SocDescriptor soc_descriptor, ChipId chip_id) :
+    const std::filesystem::path& simulator_directory,
+    SocDescriptor soc_descriptor,
+    ChipId chip_id,
+    int num_host_mem_channels) :
     Chip(soc_descriptor), arch_name(soc_descriptor.arch), chip_id_(chip_id), simulator_directory_(simulator_directory) {
     if (!std::filesystem::exists(simulator_directory_)) {
         TT_THROW("Simulator binary not found at: ", simulator_directory_);
     }
 
-    sysmem_manager_ = std::make_unique<SimulationSysmemManager>(4);
+    sysmem_manager_ = std::make_unique<SimulationSysmemManager>(num_host_mem_channels);
 }
 
 // Base class implementations (common simple methods).

--- a/device/simulation/tt_sim_chip.cpp
+++ b/device/simulation/tt_sim_chip.cpp
@@ -36,8 +36,9 @@ TTSimChip::TTSimChip(
     const std::filesystem::path& simulator_directory,
     SocDescriptor soc_descriptor,
     ChipId chip_id,
-    bool copy_sim_binary) :
-    SimulationChip(simulator_directory, soc_descriptor, chip_id),
+    bool copy_sim_binary,
+    int num_host_mem_channels) :
+    SimulationChip(simulator_directory, soc_descriptor, chip_id, num_host_mem_channels),
     architecture_impl_(architecture_implementation::create(soc_descriptor_.arch)) {
     if (copy_sim_binary) {
         create_simulator_binary();


### PR DESCRIPTION
### Issue
Related to metal failure on https://github.com/tenstorrent/tt-metal/pull/35440
Related to adding the check on our side as well in https://github.com/tenstorrent/tt-umd/pull/1788

### Description
We added support for host memory for simulation.
Unfortunately, we left 4 channels as default per chip, and tt-metal folks introduced galaxy tests in the meantime on metal ci.
So these tests would try 

### List of the changes
- Pass num channels for host mem from ClusterOptions to SimulationChip creation
- Make it 0 by default

### Testing
I've tested manually the ttsim test introduced in related PR.
Also if this PR gets in, it means it's working (I cherry picked this commit to that bump to unblock progress): https://github.com/tenstorrent/tt-metal/pull/35440

### API Changes
There are API changes in this PR, simulation will now react to ClusterOption's num_host_mem_channels
