### PR TITLE
Add CMakePresets for clang-tidy with automatic fix support

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,104 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "default",
+            "displayName": "Default Config",
+            "description": "Default build using Ninja",
+            "generator": "Ninja Multi-Config",
+            "binaryDir": "${sourceDir}/.build/default",
+            "cacheVariables": {
+                "TT_UMD_BUILD_TESTS": {
+                    "value": "TRUE"
+                },
+                "TT_UMD_BUILD_SIMULATION": {
+                    "value": "TRUE"
+                },
+                "CMAKE_EXPORT_COMPILE_COMMANDS": {
+                    "value": "TRUE"
+                }
+            }
+        },
+        {
+            "name": "clang-tidy",
+            "inherits": "default",
+            "description": "Run Clang Tidy checks during build",
+            "binaryDir": "${sourceDir}/.build/clang-tidy",
+            "cacheVariables": {
+                "TT_UMD_ENABLE_CLANG_TIDY": {
+                    "value": "OFF"
+                },
+                "CMAKE_CXX_CLANG_TIDY": {
+                    "value": "clang-tidy-17;--config-file=${sourceDir}/.clang-tidy;--warnings-as-errors=*"
+                },
+                "CMAKE_EXPORT_COMPILE_COMMANDS": {
+                    "value": "TRUE"
+                },
+                "CMAKE_DISABLE_PRECOMPILE_HEADERS": {
+                    "value": "TRUE"
+                }
+            }
+        },
+        {
+            "name": "clang-tidy-fix",
+            "inherits": "clang-tidy",
+            "description": "Run Clang Tidy and apply fixes",
+            "binaryDir": "${sourceDir}/.build/clang-tidy-fix",
+            "cacheVariables": {
+                "CMAKE_CXX_CLANG_TIDY": {
+                    "value": "clang-tidy-17;--config-file=${sourceDir}/.clang-tidy;--fix"
+                }
+            }
+        },
+        {
+            "name": "clang-tidy-fix-parallel",
+            "inherits": "clang-tidy",
+            "description":
+                "Run Clang Tidy in parallel and export fixes to YAML files (apply with clang-apply-replacements)",
+            "binaryDir": "${sourceDir}/.build/clang-tidy-fix-parallel",
+            "cacheVariables": {
+                "CMAKE_CXX_CLANG_TIDY": {
+                    "value":
+                        "${sourceDir}/cmake/clang-tidy-export-fixes-wrapper.sh;${sourceDir}/.build/clang-tidy-fix-parallel/fixes;--config-file=${sourceDir}/.clang-tidy"
+                }
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "default",
+            "configurePreset": "default",
+            "configuration": "Release"
+        },
+        {
+            "name": "debug",
+            "configurePreset": "default",
+            "configuration": "Debug"
+        },
+        {
+            "name": "clang-tidy",
+            "configurePreset": "clang-tidy",
+            "configuration": "Release",
+            "nativeToolOptions": [
+                "-k0"
+            ]
+        },
+        {
+            "name": "clang-tidy-fix",
+            "configurePreset": "clang-tidy-fix",
+            "configuration": "Release",
+            "nativeToolOptions": [
+                "-j1",
+                "-k0"
+            ]
+        },
+        {
+            "name": "clang-tidy-fix-parallel",
+            "configurePreset": "clang-tidy-fix-parallel",
+            "configuration": "Release",
+            "nativeToolOptions": [
+                "-k0"
+            ]
+        }
+    ]
+}

--- a/cmake/clang-tidy-export-fixes-wrapper.sh
+++ b/cmake/clang-tidy-export-fixes-wrapper.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Wrapper script for clang-tidy that exports fixes to unique YAML files
+# Usage: clang-tidy-export-fixes-wrapper.sh <fixes-dir> <clang-tidy-args...>
+#
+# This script invokes clang-tidy and exports fixes to a unique file based on
+# the hash of the source file path, allowing parallel execution without conflicts.
+#
+# The script intentionally ignores clang-tidy's exit code to allow the build
+# to continue even when warnings-as-errors are found. Fixes are exported to
+# YAML files and can be applied later with clang-apply-replacements.
+
+set -uo pipefail
+
+FIXES_DIR="$1"
+shift
+
+# Create the fixes directory if it doesn't exist
+mkdir -p "$FIXES_DIR"
+
+# Find the source file from the arguments (last argument that's a file)
+SOURCE_FILE=""
+for arg in "$@"; do
+    if [[ "$arg" != -* ]]; then
+        SOURCE_FILE="$arg"
+    fi
+done
+
+if [[ -z "$SOURCE_FILE" ]]; then
+    # If no source file found, just run clang-tidy without export-fixes
+    clang-tidy-17 "$@" || true
+    exit 0
+fi
+
+# Generate a unique filename based on the absolute source file path
+SOURCE_FILE_ABS=$(realpath "$SOURCE_FILE")
+HASH=$(echo "$SOURCE_FILE_ABS" | md5sum | cut -d' ' -f1)
+BASENAME=$(basename "$SOURCE_FILE")
+FIXES_FILE="${FIXES_DIR}/${BASENAME}-${HASH}.yaml"
+
+# Run clang-tidy but ignore exit code (warnings-as-errors would cause non-zero)
+# Fixes are still exported to the YAML file
+clang-tidy-17 --export-fixes="$FIXES_FILE" "$@" || true
+exit 0


### PR DESCRIPTION
### Summary

Adds `CMakePresets.json` with presets for running clang-tidy checks and applying automatic fixes, following the same conventions as tt-metal.

### New Presets

| Preset | Description |
|--------|-------------|
| `clang-tidy` | Run checks with warnings-as-errors |
| `clang-tidy-fix` | Apply fixes sequentially (safe, slower) |
| `clang-tidy-fix-parallel` | Export fixes to YAML files for parallel execution |

### Usage

**Check only (fails on violations):**
```bash
cmake --preset clang-tidy
cmake --build --preset clang-tidy
```

**Apply fixes sequentially:**
```bash
cmake --preset clang-tidy-fix
cmake --build --preset clang-tidy-fix
```

**Apply fixes in parallel (faster for large codebases):**
```bash
cmake --preset clang-tidy-fix-parallel
cmake --build --preset clang-tidy-fix-parallel
clang-apply-replacements-17 .build/clang-tidy-fix-parallel/fixes/
```

### Implementation Details

- Sets `TT_UMD_ENABLE_CLANG_TIDY=OFF` to use `CMAKE_CXX_CLANG_TIDY` directly, avoiding conflicts with UMD's built-in clang-tidy configuration
- `clang-tidy-fix` uses `-j1` to prevent race conditions when multiple processes modify the same header files
- `clang-tidy-fix-parallel` uses a wrapper script (`cmake/clang-tidy-export-fixes-wrapper.sh`) that exports fixes to unique YAML files based on source file path hashes, enabling safe parallel execution
- All presets use `-k0` to continue on errors so all files are processed
- Build directories follow `.build/<preset-name>` convention

### Files Added/Modified

- `CMakePresets.json` - New file with preset definitions
- `cmake/clang-tidy-export-fixes-wrapper.sh` - New wrapper script for parallel fix export

---