### PR TITLE
Minor pyapi fix for reset

### DIFF
--- a/nanobind/py_api_warm_reset.cpp
+++ b/nanobind/py_api_warm_reset.cpp
@@ -26,6 +26,6 @@ void bind_warm_reset(nb::module_ &m) {
         .def_static(
             "ubb_warm_reset",
             &WarmReset::ubb_warm_reset,
-            nb::arg("timeout_s") = 100,
+            nb::arg("timeout_s") = 100.0,
             "Perform a UBB warm reset with specified timeout in seconds.");
 }

--- a/nanobind/tests/test_py_warm_reset.py
+++ b/nanobind/tests/test_py_warm_reset.py
@@ -37,7 +37,7 @@ class TestWarmReset(unittest.TestCase):
         # In case KMD still doesn't support arch agnostic reset, and in case of UBB, we have to call special UBB warm reset
         if is_wormhole_ubb and not kmd_supports_reset:
             print("Executing UBB warm reset...")
-            tt_umd.WarmReset.ubb_warm_reset(timeout_s=300)
+            tt_umd.WarmReset.ubb_warm_reset()
         else:
             should_perform_secondary_bus_reset = not is_wormhole_ubb
             print(f"Executing standard warm reset, with secondary bus reset: {should_perform_secondary_bus_reset}")


### PR DESCRIPTION
### Issue
#1820 

### Description
Found this minor issue while trying to execute ubb_warm_reset.
The default value seems to be of a wrong type.

### List of the changes
- Changed 100 to 100.0 to match what ubb_warm_reset expects
- Change warm reset test to reuse defualt value

### Testing
Tested manually on a 6U

### API Changes
This PR has minor python API fix
