### PR TITLE
Add PCIDevice::read_device_info API

### DIFF
--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -136,6 +136,13 @@ public:
     static std::map<int, PciDeviceInfo> enumerate_devices_info(const std::unordered_set<int> &pci_target_devices = {});
 
     /**
+     * Read device information from sysfs.
+     * @param fd Integer corresponding to the character device descriptor of the PCI device.
+     * @return PciDeviceInfo struct containing the device information.
+     */
+    static PciDeviceInfo read_device_info(int fd);
+
+    /**
      * PCI device constructor.
      *
      * Opens the character device file descriptor, reads device information from

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -170,7 +170,7 @@ static std::optional<int> get_physical_slot_for_pcie_bdf(const std::string &targ
     return std::nullopt;
 }
 
-static PciDeviceInfo read_device_info(int fd) {
+PciDeviceInfo PCIDevice::read_device_info(int fd) {
     tenstorrent_get_device_info info{};
     info.in.output_size_bytes = sizeof(info.out);
 

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -80,6 +80,7 @@ void bind_tt_device(nb::module_ &m) {
         .def("get_device_info", &PCIDevice::get_device_info)
         .def("get_device_num", &PCIDevice::get_device_num)
         .def_static("read_kmd_version", &PCIDevice::read_kmd_version, "Read KMD version installed on the system.")
+        .def_static("read_device_info", &PCIDevice::read_device_info, nb::arg("fd"), "Read PCI device information.")
         .def_static(
             "is_arch_agnostic_reset_supported",
             &PCIDevice::is_arch_agnostic_reset_supported,


### PR DESCRIPTION
### Issue
#1820 

### Description
We already had this functions, just wasn't part of the class, and wasn't exposed.
This will allow the user to read device info for a single device rather than having to read it for all devices always.

### List of the changes
- Put read_device_info inside PCIDebice
- Expose it in python API

### Testing
No additional testing.

### API Changes
This PR has API changes, introduces PCIDevice::read_device_info
