### PR TITLE
Speed up TLB IO tests

### DIFF
--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -176,7 +176,8 @@ TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
     auto& sdesc = cluster.get_soc_descriptor(chip_id);
     for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
         // Statically mapping a 2MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
-        cluster.configure_tlb(chip_id, core, STATIC_TLB_SIZE, l1_mem::address_map::NCRISC_FIRMWARE_BASE);
+        cluster.configure_tlb(
+            chip_id, core, tt::umd::blackhole::STATIC_TLB_SIZE, l1_mem::address_map::NCRISC_FIRMWARE_BASE);
     }
 
     test_utils::safe_test_cluster_start(&cluster);
@@ -215,7 +216,8 @@ TEST(SiliconDriverBH, StaticTLB_RW) {
     auto& sdesc = cluster.get_soc_descriptor(chip_id);
     for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
         // Statically mapping a 2MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
-        cluster.configure_tlb(chip_id, core, STATIC_TLB_SIZE, l1_mem::address_map::NCRISC_FIRMWARE_BASE);
+        cluster.configure_tlb(
+            chip_id, core, tt::umd::blackhole::STATIC_TLB_SIZE, l1_mem::address_map::NCRISC_FIRMWARE_BASE);
     }
 
     std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -369,7 +371,7 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
         auto& sdesc = cluster.get_soc_descriptor(chip_id);
         for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
             // Statically mapping a 2MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
-            cluster.configure_tlb(chip_id, core, STATIC_TLB_SIZE, base_addr);
+            cluster.configure_tlb(chip_id, core, tt::umd::blackhole::STATIC_TLB_SIZE, base_addr);
         }
     }
 

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -99,7 +99,8 @@ TEST(SiliconDriverWH, HarvestingRuntime) {
         auto& sdesc = cluster.get_soc_descriptor(chip_id);
         for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
             // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
-            cluster.configure_tlb(chip_id, core, STATIC_TLB_SIZE, l1_mem::address_map::NCRISC_FIRMWARE_BASE);
+            cluster.configure_tlb(
+                chip_id, core, tt::umd::wormhole::STATIC_TLB_SIZE, l1_mem::address_map::NCRISC_FIRMWARE_BASE);
         }
     }
 
@@ -165,7 +166,8 @@ TEST(SiliconDriverWH, UnalignedStaticTLB_RW) {
     auto& sdesc = cluster.get_soc_descriptor(chip_id);
     for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
         // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
-        cluster.configure_tlb(chip_id, core, STATIC_TLB_SIZE, l1_mem::address_map::NCRISC_FIRMWARE_BASE);
+        cluster.configure_tlb(
+            chip_id, core, tt::umd::wormhole::STATIC_TLB_SIZE, l1_mem::address_map::NCRISC_FIRMWARE_BASE);
     }
 
     test_utils::safe_test_cluster_start(&cluster);
@@ -204,7 +206,8 @@ TEST(SiliconDriverWH, StaticTLB_RW) {
     auto& sdesc = cluster.get_soc_descriptor(chip_id);
     for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
         // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
-        cluster.configure_tlb(chip_id, core, STATIC_TLB_SIZE, l1_mem::address_map::NCRISC_FIRMWARE_BASE);
+        cluster.configure_tlb(
+            chip_id, core, tt::umd::wormhole::STATIC_TLB_SIZE, l1_mem::address_map::NCRISC_FIRMWARE_BASE);
     }
 
     std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -335,7 +338,7 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
         auto& sdesc = cluster.get_soc_descriptor(chip_id);
         for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
-            cluster.configure_tlb(chip_id, core, STATIC_TLB_SIZE, base_addr);
+            cluster.configure_tlb(chip_id, core, tt::umd::wormhole::STATIC_TLB_SIZE, base_addr);
         }
     }
 
@@ -606,7 +609,7 @@ TEST(SiliconDriverWH, LargeAddressTlb) {
     uint64_t scratch_offset = 0x60;
 
     // Map a TLB to the reset unit in ARC core:
-    cluster.configure_tlb(0, ARC_CORE, STATIC_TLB_SIZE, arc_reset_noc);
+    cluster.configure_tlb(0, ARC_CORE, tt::umd::wormhole::STATIC_TLB_SIZE, arc_reset_noc);
 
     // Address of the scratch register in the reset unit:
     uint64_t addr = arc_reset_noc + scratch_offset;


### PR DESCRIPTION
### Issue
#1824 

### Description
I notices some tests take unnecessarily long time.

### List of the changes
- Changed all TLB_EW tests to run only on a single chip instead of all chips.

### Testing
main -> this branch speedup:
| UnalignedStaticTLB_RW [ms] | main | this PR |
|--------|----------|-----|
| N150 | 3980 | 3997 |
| N300 | 9755 | 3579 |
| LLMBOX | 43765 | 4071 |
| 6u | 138310 | 15756 |
| p100 | 4242 | 4299 |
| p150 | 802 | 702 |
| p300 | 5668 | 5014 |
| BH Loudbox | 21165 | 16465 |

| StaticTLB_RW [ms] | main | this PR |
|--------|----------|-----|
| N150 | 105 | 113 |
| N300 | 1290 | 115 |
| LLMBOX | 8419 | 203 |
| 6u | 3764 | 640 |
| p100 | 10 | 67 |
| p150 | 9 | 45 |
| p300 | 33 | 58 |
| BH Loudbox | 73 | 81 |

| DynamicTLB_RW [ms] | main | this PR |
|--------|----------|-----|
| N150 | 123 | 129 |
| N300 | 1306 | 132 |
| LLMBOX | 8602 | 229 |
| 6u | 4132 | 645 |
| p100 | 139 | 111 |
| p150 | 92 | 93 |
| p300 | 211 | 99 |
| BH Loudbox | 841 | 136 |

Total speedup:
- n150 - insignificant
- n300 - ~ 8sec
- llmbox - ~55sec
- 6u - ~128sec (main motivation for this PR)
- p100 - insignificant
- p150 - insignificant
- p300 - insignificant
- bh loudbox - ~5sec

### API Changes
There are no API changes in this PR.
