### PR TITLE
Speed up WormholeArcMessagesAICLK test

### DIFF
--- a/tests/wormhole/test_arc_messages_wh.cpp
+++ b/tests/wormhole/test_arc_messages_wh.cpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
+#include <set>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -46,7 +47,7 @@ TEST(WormholeArcMessages, WormholeArcMessagesAICLK) {
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
-    std::vector<uint32_t> target_chips = cluster->get_target_device_ids();
+    std::set<tt::ChipId> target_chips = cluster->get_target_device_ids();
     std::unordered_map<uint32_t, TTDevice*> tt_devices;
     std::unordered_map<uint32_t, std::unique_ptr<ArcMessenger>> arc_messengers;
 


### PR DESCRIPTION
### Issue
#1824 

### Description
This test tests changing AICLK, and waits two times two seconds per chip, which means that we have an idle wait of 2mins on a galaxy system.
Speeding up this test, by testing on all chips at the same time.

### List of the changes
- Broke down single for loop into several foreach loops, in a way that waiting for ARC message happens only once for all chips

### Testing
main -> this branch speedups:
- N150 : 4007ms -> 4007ms
- N300 : 8030ms -> 4032ms
- llmbox : 32136ms -> 4131ms
- 6u : 128606ms -> 4557ms
- blackhole not affected

### API Changes
There are no API changes in this PR.
