### PR TITLE
Remove some dead code from ClusterDescriptor

### DIFF
--- a/device/api/umd/device/cluster_descriptor.hpp
+++ b/device/api/umd/device/cluster_descriptor.hpp
@@ -210,13 +210,6 @@ public:
     const std::unordered_map<ChipId, std::unordered_set<ChipId>> &get_chips_grouped_by_closest_mmio() const;
 
     /**
-     * Return the distance between two chips in terms of ethernet hops.
-     * @param chip_a Logical chip id of the first chip.
-     * @param chip_b Logical chip id of the second chip.
-     */
-    int get_ethernet_link_distance(ChipId chip_a, ChipId chip_b) const;
-
-    /**
      * Returns wether the ethernet core has an active ethernet link.
      */
     bool ethernet_core_has_active_ethernet_link(ChipId local_chip, EthernetChannel local_ethernet_channel) const;

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -1008,13 +1008,6 @@ const std::unordered_map<ChipId, bool> &ClusterDescriptor::get_noc_translation_t
 
 std::size_t ClusterDescriptor::get_number_of_chips() const { return this->all_chips.size(); }
 
-int ClusterDescriptor::get_ethernet_link_distance(ChipId chip_a, ChipId chip_b) const {
-    TT_ASSERT(
-        !this->chip_locations.empty(),
-        "Getting noc0 chip coordinates is only valid for systems where chips have coordinates");
-    return this->get_ethernet_link_coord_distance(chip_locations.at(chip_a), chip_locations.at(chip_b));
-}
-
 BoardType ClusterDescriptor::get_board_type(ChipId chip_id) const {
     TT_ASSERT(
         chip_board_type.find(chip_id) != chip_board_type.end(),


### PR DESCRIPTION
### Issue

/

### Description

Remove dead code that is not called by anyone from ClusteDescriptor. Stumbled on it during cleanup of 4U code.

### List of the changes

- Remove function get_ethernet_link_distance from ClusterDescriptor

### Testing
CI

### API Changes
/