### PR TITLE
Update build-clients

### DIFF
--- a/.github/workflows/build-clients.yml
+++ b/.github/workflows/build-clients.yml
@@ -13,6 +13,8 @@ on:
     branches: ["main"]
 
 jobs:
+  # Note: this job also serves as the tt-metal build verification job —
+  # building tt-metal is a required step before running ttsim tests.
   build-tt-sim:
     # Due to parsing bug, fromJSON is used to convert string to number.
     # In pull_request or push events, the input context is not available, stating the default again here.


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/1858

### Description
As a follow up of https://github.com/tenstorrent/tt-umd/pull/1833 I looked at our workflows.
Also after recent changes in how ttsim tests are run in https://github.com/tenstorrent/tt-umd/issues/1788 we now don't even need another job which just build tt-metal, since ttsim one already does that

### List of the changes
- Remove build tt-metal job, as it is included in ttsim job
- Change docker download to use harbor.ci

### Testing


### API Changes
There are no API changes in this PR.
