### PR TITLE
Move more workflows to use harbor.ci for download docker images

### DIFF
--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -260,7 +260,7 @@ jobs:
         shell: bash
         env:
           # Use custom manylinux Docker image with all dependencies pre-installed
-          CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/tenstorrent/tt-umd/tt-umd-ci-manylinux:latest
+          CIBW_MANYLINUX_X86_64_IMAGE: harbor.ci.tenstorrent.net/ghcr.io/tenstorrent/tt-umd/tt-umd-ci-manylinux:latest
           # This command will be executed for each wheel build to verify that the wheel is functional.
           CIBW_TEST_COMMAND: 'python -c "import tt_umd"'
         run: |

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -62,7 +62,9 @@ jobs:
 
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}:latest
+      image: >-
+        harbor.ci.tenstorrent.net/ghcr.io/${{ github.repository }}/tt-umd-ci-${{
+        inputs.ubuntu-docker-version }}:latest
 
     steps:
       - name: Print all params
@@ -115,7 +117,9 @@ jobs:
     name: Build umd wheel on ${{ inputs.ubuntu-docker-version }}
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}:latest
+      image: >-
+        harbor.ci.tenstorrent.net/ghcr.io/${{ github.repository }}/tt-umd-ci-${{
+        inputs.ubuntu-docker-version }}:latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,7 +248,7 @@ jobs:
           'fedora-39',
         ]
     container:
-      image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ matrix.docker-version }}:latest
+      image: harbor.ci.tenstorrent.net/ghcr.io/${{ github.repository }}/tt-umd-ci-${{ matrix.docker-version }}:latest
 
     steps:
       - uses: actions/checkout@v4
@@ -322,7 +322,7 @@ jobs:
         shell: bash
         env:
           # Use custom manylinux Docker image with all dependencies pre-installed
-          CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/tenstorrent/tt-umd/tt-umd-ci-manylinux:latest
+          CIBW_MANYLINUX_X86_64_IMAGE: harbor.ci.tenstorrent.net/ghcr.io/tenstorrent/tt-umd/tt-umd-ci-manylinux:latest
           # This command will be executed for each wheel build to verify that the wheel is functional.
           CIBW_TEST_COMMAND: 'python -c "import tt_umd"'
         run: |

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -36,7 +36,9 @@ jobs:
     runs-on:
       - ${{ inputs.card }}
     container:
-      image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}:latest
+      image: >-
+        harbor.ci.tenstorrent.net/ghcr.io/${{ github.repository }}/tt-umd-ci-${{
+        inputs.ubuntu-docker-version }}:latest
       # Set dummy var for baremetal, as options has to have some value
       options: ${{ inputs.arch != 'baremetal' && '--device /dev/tenstorrent' || '-e DUMMY_VAR=' }}
       volumes:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -44,7 +44,9 @@ jobs:
     runs-on:
       - ${{ inputs.card }}
     container:
-      image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}:latest
+      image: >-
+        harbor.ci.tenstorrent.net/ghcr.io/${{ github.repository }}/tt-umd-ci-${{
+        inputs.ubuntu-docker-version }}:latest
       # Set dummy var for baremetal, as options has to have some value
       options: ${{ inputs.arch != 'baremetal' && '--device /dev/tenstorrent' || '-e DUMMY_VAR=' }}
       volumes:


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/1858

### Description
This is supposedly faster

### List of the changes
- Change ghcr.io to harbor.ci.tenstorrent.net/ghcr.io at almost all places

### Testing
CI should show if this works

### API Changes
There are no API changes in this PR.
