### PR TITLE
No ETH FW strictness on by default for Cluster

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1023,6 +1023,7 @@ std::unique_ptr<ClusterDescriptor> Cluster::create_cluster_descriptor(
     TopologyDiscoveryOptions options;
     options.soc_descriptor_path = std::move(sdesc_path);
     options.io_device_type = device_type;
+    options.no_eth_firmware_strictness = true;
     return TopologyDiscovery::discover(std::move(options)).first;
 }
 


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description
(Add freeform description.)

### List of the changes
(Itemized list of all the changes.)

### Testing
(Comment on CI testing or Manual testing touching this change.)

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
