### PR TITLE
Add initial clang static analyzer + copilot infra

### DIFF
--- a/.codechecker.json
+++ b/.codechecker.json
@@ -1,0 +1,9 @@
+{
+    "analyze": [
+        "--analyzers",
+        "clangsa",
+        "--skip",
+        "${sourceDir}/.codechecker.skiplist",
+        "--drop-reports-from-skipped-files"
+    ]
+}

--- a/.codechecker.skiplist
+++ b/.codechecker.skiplist
@@ -1,0 +1,21 @@
+# CodeChecker skip list - exclude third-party and generated code
+# See: https://codechecker.readthedocs.io/en/latest/analyzer/user_guide/#skip
+
+# External third-party dependencies
+-*/.cpmcache/*
+-*/third_party/*
+
+# Build directories
+-*/.build/*
+-*/build/*
+-*/build-*/*
+
+# System headers
+-/usr/*
+
+# Generated files
+-*_generated.h
+-*_generated.cpp
+-*.pb.h
+-*.pb.cc
+

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -1,0 +1,324 @@
+name: "Code analysis"
+
+on:
+  schedule:
+    # Static analysis: 6 PM PST Mon/Wed/Fri (2 AM UTC Tue/Thu/Sat)
+    - cron: "0 2 * * 2,4,6"
+  workflow_call:
+    inputs:
+      enable-static-analysis:
+        description: "Enable Clang Static Analyzer (CSA) via CodeChecker"
+        required: false
+        type: boolean
+        default: false
+      debug-file-filter:
+        description: "Analyze only specific file(s) for fast debugging (e.g., 'device/**/*.hpp' or 'path/to/file.cpp')"
+        required: false
+        type: string
+        default: ""
+      enable-copilot-fix:
+        description: "Enable Copilot to automatically fix ClangSA issues and create a PR"
+        required: false
+        type: boolean
+        default: false
+      copilot-max-fixes:
+        description: "Maximum number of issues for Copilot to fix (default: 15)"
+        required: false
+        type: string
+        default: ""
+  workflow_dispatch:
+    inputs:
+      enable-static-analysis:
+        description: "Enable Clang Static Analyzer (CSA) via CodeChecker"
+        required: false
+        type: boolean
+        default: false
+      debug-file-filter:
+        description: "Analyze only specific file(s) for fast debugging (e.g., 'device/**/*.hpp' or 'path/to/file.cpp')"
+        required: false
+        type: string
+        default: ""
+      enable-copilot-fix:
+        description: "Enable Copilot to automatically fix ClangSA issues and create a PR"
+        required: false
+        type: boolean
+        default: false
+      copilot-max-fixes:
+        description: "Maximum number of issues for Copilot to fix (default: 15)"
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  clang-static-analyzer:
+    name: 🔬 Clang Static Analyzer
+    if: ${{ inputs.enable-static-analysis == true || github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    container:
+      image: harbor.ci.tenstorrent.net/ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest
+      volumes:
+        - ${{ github.workspace }}:/work
+      options: --tmpfs /tmp
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Configure git safe.directory
+        run: git config --global --add safe.directory /work
+
+      - name: 🔧 CMake configure
+        run: cmake --preset clang-static-analyzer
+
+      - name: Setup clang symlinks for CodeChecker
+        run: |
+          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-20 100 || true
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-20 100 || true
+
+      - name: Install CodeChecker
+        run: |
+          # Pre-install CodeChecker in the container's venv using uv.
+          # Pin to a specific version for reproducibility.
+          uv pip install codechecker==6.27.1
+
+      - name: 🔬 Analyze with CodeChecker
+        id: codechecker
+        run: |
+          set -euo pipefail
+
+          OUTPUT_DIR=/work/.build/codechecker-reports
+          mkdir -p "$OUTPUT_DIR"
+
+          echo "=== Starting CodeChecker analysis ==="
+
+          # Build command with optional file filter
+          ANALYZE_CMD="CodeChecker analyze \
+            /work/.build/clang-static-analyzer/compile_commands.json \
+            --output $OUTPUT_DIR \
+            --jobs $(nproc) \
+            --config /work/.codechecker.json"
+
+          if [ -n "${{ inputs.debug-file-filter }}" ]; then
+            echo "🐛 DEBUG MODE: Analyzing only: ${{ inputs.debug-file-filter }}"
+            ANALYZE_CMD="$ANALYZE_CMD --file '${{ inputs.debug-file-filter }}'"
+          fi
+
+          # Run analysis (don't fail on analyzer crashes - common with static analysis)
+          eval "$ANALYZE_CMD" || echo "⚠️ Analysis completed with warnings"
+
+          # Set output for downstream steps
+          echo "analyze-output=$OUTPUT_DIR" >> "$GITHUB_OUTPUT"
+
+          # Show summary
+          PLIST_COUNT=$(find "$OUTPUT_DIR" -name "*.plist" 2>/dev/null | wc -l)
+          echo "✅ Generated $PLIST_COUNT plist files"
+
+      - name: Generate JSON and HTML reports from analysis results
+        run: |
+          set -euo pipefail
+
+          OUTPUT_DIR="${{ steps.codechecker.outputs.analyze-output }}"
+          JSON_OUTPUT="/work/.build/codechecker_issues.json"
+          HTML_OUTPUT="/work/.build/codechecker_html"
+
+          echo "=== Generating JSON report ==="
+          # CodeChecker parse can fail if no issues found or plist files corrupted - that's OK
+          CodeChecker parse "$OUTPUT_DIR" --export json --output "$JSON_OUTPUT" || true
+
+          if [ -f "$JSON_OUTPUT" ] && [ -s "$JSON_OUTPUT" ]; then
+            ISSUE_COUNT=$(jq '.reports | length' "$JSON_OUTPUT" || echo "0")
+            echo "✅ JSON report contains $ISSUE_COUNT issues"
+          else
+            echo "⚠️ No JSON output, creating empty report"
+            echo '{"version": 1, "reports": []}' > "$JSON_OUTPUT"
+          fi
+
+          echo ""
+          echo "=== Generating HTML report ==="
+          mkdir -p "$HTML_OUTPUT"
+          # Same as above - parse can fail for non-fatal reasons
+          CodeChecker parse "$OUTPUT_DIR" --export html --output "$HTML_OUTPUT" || true
+
+          if [ -d "$HTML_OUTPUT" ] && [ -n "$(ls -A "$HTML_OUTPUT")" ]; then
+            echo "✅ HTML report generated"
+          else
+            echo "⚠️ HTML report is empty or missing"
+          fi
+
+      - name: Upload JSON report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: CodeChecker-JSON-Report
+          path: /work/.build/codechecker_issues.json
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: CodeChecker-HTML-Report
+          path: /work/.build/codechecker_html
+
+  copilot-fix-clangsa-issue:
+    name: 🤖 Copilot Fix ClangSA Issue
+    needs: [clang-static-analyzer]
+    if: |
+      always() &&
+      (inputs.enable-copilot-fix == true || github.event_name == 'schedule') &&
+      needs.clang-static-analyzer.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      pr-url: ${{ steps.copilot-fix.outputs.pr-url }}
+      pr-created: ${{ steps.copilot-fix.outputs.pr-created }}
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install GitHub CLI for Copilot integration
+        run: |
+          # Install gh CLI if not present
+          if ! command -v gh &> /dev/null; then
+            type -p curl >/dev/null || (apt update && apt install -y curl)
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
+              dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+            chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) \
+              signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
+              https://cli.github.com/packages stable main" | \
+              tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            apt update && apt install -y gh
+          fi
+
+      - name: Download CodeChecker JSON report
+        uses: actions/download-artifact@v4
+        with:
+          name: CodeChecker-JSON-Report
+          path: /tmp
+
+      - name: Check for issues and run Copilot fix
+        id: copilot-fix
+        timeout-minutes: 30
+        env:
+          COPILOT_OAUTH_TOKEN: ${{ secrets.COPILOT_OAUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Check for issues
+          if [ ! -f "/tmp/codechecker_issues.json" ]; then
+            echo "No issues found"
+            echo "has-issues=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          ISSUE_COUNT=$(jq '.reports | length' /tmp/codechecker_issues.json 2>/dev/null || echo "0")
+          if [ "$ISSUE_COUNT" = "0" ]; then
+            echo "No issues found"
+            echo "has-issues=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Found $ISSUE_COUNT issues"
+          echo "has-issues=true" >> "$GITHUB_OUTPUT"
+
+          # Authenticate with OAuth token (required for agent-task)
+          if [ -z "$COPILOT_OAUTH_TOKEN" ]; then
+            echo "::error::COPILOT_OAUTH_TOKEN secret not set. \
+              Run 'gh auth login' locally, then 'gh auth token' and add as secret."
+            exit 1
+          fi
+          echo "$COPILOT_OAUTH_TOKEN" | gh auth login --with-token
+
+          # Build prompt
+          LIMIT="${{ inputs.copilot-max-fixes }}"
+          LIMIT="${LIMIT:-15}"
+
+          {
+            echo "Fix these Clang Static Analyzer issues:"
+            echo ""
+            jq -r --argjson limit "$LIMIT" '
+              .reports[:$limit][] |
+              "- \(.checker_name) in \(.file.path | sub("^/work/"; "")):\(.line) \
+                — \(.message)"
+            ' /tmp/codechecker_issues.json
+            echo ""
+            echo "For each: verify it's real, apply minimal fix, follow coding standards."
+          } > /tmp/prompt.txt
+
+          cat /tmp/prompt.txt
+
+          # Run Copilot
+          BASE_BRANCH="${{ github.event_name == 'schedule' && 'main' || github.ref_name }}"
+
+          gh agent-task create -F /tmp/prompt.txt \
+            --base "$BASE_BRANCH" \
+            --repo "${{ github.repository }}" \
+            --follow
+
+          # Get the PR that was created
+          PR_NUMBER=$(gh agent-task list --limit 1 | grep -oE '#[0-9]+' | tr -d '#' || true)
+
+          if [ -n "$PR_NUMBER" ]; then
+            echo "pr-url=https://github.com/${{ github.repository }}/pull/${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+            echo "pr-created=true" >> "$GITHUB_OUTPUT"
+            gh pr comment "$PR_NUMBER" -R "${{ github.repository }}" --body "/codeowners ping" || true
+          else
+            echo "pr-created=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Output job summary
+        if: always()
+        run: |
+          echo "## 🤖 Copilot Auto-Fix" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.copilot-fix.outputs.has-issues }}" != "true" ]; then
+            echo "No issues found." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${{ steps.copilot-fix.outputs.pr-created }}" = "true" ]; then
+            echo "✅ **PR Created:** ${{ steps.copilot-fix.outputs.pr-url }}" \
+              >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "⚠️ No PR created. \
+              Check [Copilot dashboard](https://github.com/${{ github.repository }}/copilot)." \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  publish-clangsa-pages:
+    name: 📄 Publish CSA HTML to GitHub Pages
+    needs: [clang-static-analyzer]
+    # Only publish on full scans (skip when debug-file-filter is used)
+    if: >-
+      ${{ always() &&
+      needs.clang-static-analyzer.result == 'success' &&
+      inputs.debug-file-filter == '' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download CodeChecker HTML report
+        uses: actions/download-artifact@v4
+        with:
+          name: CodeChecker-HTML-Report
+          path: site
+
+      - name: Add .nojekyll
+        run: touch site/.nojekyll
+
+      - name: Publish to GitHub Pages (requires PAT secret)
+        uses: peaceiris/actions-gh-pages@v4
+        if: ${{ secrets.CLANGSA_RESULTS_PAT != '' }}
+        with:
+          personal_token: ${{ secrets.CLANGSA_RESULTS_PAT }}
+          external_repository: blozano-tt/umd-clangsa-results
+          publish_branch: gh-pages
+          publish_dir: site
+          force_orphan: true
+          commit_message: >-
+            Update CSA reports from ${{ github.repository }} @ ${{ github.sha }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -62,6 +62,21 @@
                         "${sourceDir}/cmake/clang-tidy-export-fixes-wrapper.sh;${sourceDir}/.build/clang-tidy-fix-parallel/fixes;--config-file=${sourceDir}/.clang-tidy"
                 }
             }
+        },
+        {
+            "name": "clang-static-analyzer",
+            "inherits": "default",
+            "description": "Run Clang Static Analyzer",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/.build/clang-static-analyzer",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": {
+                    "value": "Debug"
+                },
+                "TT_UMD_BUILD_SIMULATION": {
+                    "value": "FALSE"
+                }
+            }
         }
     ],
     "buildPresets": [


### PR DESCRIPTION
This is initial infra for static analysis + copilot collaboration.

Once this lands on main, it will be easier for me to iterate, and test it out.

Please blindly merge. 

The goal is to have copilot autogenerate fixes for issues caught by static analyzers.

Issues such as dead stores, divide by zero hazards, virtual dispatch bypass ... etc ... 

https://blozano-tt.github.io/clangsa-results/blackhole_arc_message_queue.cpp_clangsa_7984745c0402ac69e08b1466f86abc0c.plist.html#reportHash=c6d35f3c1adca99af403f26699c12a5e