### PR TITLE
Remove redundant timeout for WormholeArcMessenger::send_message

### DIFF
--- a/device/arc/wormhole_arc_messenger.cpp
+++ b/device/arc/wormhole_arc_messenger.cpp
@@ -95,12 +95,6 @@ uint32_t WormholeArcMessenger::send_message(
     uint32_t status = 0xbadbad;
     auto start = std::chrono::steady_clock::now();
     while (true) {
-        auto end = std::chrono::steady_clock::now();
-        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-        if ((duration.count() > timeout_ms.count()) && (timeout_ms != std::chrono::milliseconds(0))) {
-            throw std::runtime_error(fmt::format("Timed out after waiting {} ms for ARC to respond", timeout_ms));
-        }
-
         tt_device->read_from_arc_apb(&status, wormhole::ARC_RESET_SCRATCH_STATUS_OFFSET, sizeof(uint32_t));
 
         if ((status & 0xffff) == (msg_code & 0xff)) {


### PR DESCRIPTION
### Issue
/

### Description
This pull request makes a small change to the timeout logic in the `send_message` method of `wormhole_arc_messenger.cpp`. The code that checked for a timeout and threw an exception if the ARC did not respond within the specified time has been removed.

### List of the changes
- Removed manual timeout

### Testing
CI

### API Changes
/
