### PR TITLE
Remove test_setup_interface

### DIFF
--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -96,8 +96,6 @@ private:
     void initialize_default_chip_mutexes();
     void initialize_membars();
 
-    void check_pcie_device_initialized();
-    int test_setup_interface();
     void init_pcie_iatus();
 
     void set_membar_flag(


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/1759

### Description
This code is 3+ years old, and it was initially written for GS and WH.
As far as I see from https://github.com/tenstorrent/tt-isa-documentation/blob/main/WormholeB0/NoC/MemoryMap.md#router_cfg_1
It looks like it reads from Router cfg register. Devs might be doing something different on 6u galaxies, I don't want to investigate further, I'd rather just declare such way of verifying our interface is functional outdated.

Given that we've since developed other ways of verifying functional chip, I don't feel the need to change this with something else.

If there is indeed some issue on these machines where this error popped up, we will see it.

### List of the changes
- Remove test_setup_interface code

### Testing
No additional testing

### API Changes
There are no API changes in this PR.
