### PR TITLE
Use TTDevice instead of Chip in TopologyDiscovery

### DIFF
--- a/device/api/umd/device/topology/topology_discovery.hpp
+++ b/device/api/umd/device/topology/topology_discovery.hpp
@@ -6,10 +6,12 @@
 
 #include <memory>
 #include <optional>
+#include <unordered_set>
 
 #include "umd/device/chip/chip.hpp"
 #include "umd/device/chip/remote_chip.hpp"
 #include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/xy_pair.hpp"
@@ -19,16 +21,16 @@ namespace tt::umd {
 class ClusterDescriptor;
 
 struct TopologyDiscoveryOptions {
-    // Path to custom SoC descriptor when creating chips. See ClusterOptions.
+    // Path to custom SoC descriptor when creating devices. See ClusterOptions.
     std::string soc_descriptor_path = "";
 
     // I/O device type to use when discovering. See ClusterOptions.
     IODeviceType io_device_type = IODeviceType::PCIe;
 
-    // Skip discovery of chips connected via Ethernet.
+    // Skip discovery of devices connected via Ethernet.
     bool no_remote_discovery = false;
 
-    // Skip waiting for ETH training. TODO: Currently unimplemented.
+    // Skip waiting for ETH core training.
     bool no_wait_for_eth_training = false;
 
     // Allow unsupported ETH firmware versions and do not fail when
@@ -43,10 +45,10 @@ struct TopologyDiscoveryOptions {
     bool verify_eth_fw_hash = false;
 };
 
-// TopologyDiscovery class creates cluster descriptor by discovering all chips connected to the system.
+// TopologyDiscovery creates cluster descriptor after discovering all devices connected to the system.
 class TopologyDiscovery {
 public:
-    static std::pair<std::unique_ptr<ClusterDescriptor>, std::map<uint64_t, std::unique_ptr<Chip>>> discover(
+    static std::pair<std::unique_ptr<ClusterDescriptor>, std::map<uint64_t, std::unique_ptr<TTDevice>>> discover(
         const TopologyDiscoveryOptions& options);
 
     virtual ~TopologyDiscovery() = default;
@@ -58,11 +60,14 @@ protected:
 
     std::unique_ptr<ClusterDescriptor> create_ethernet_map();
 
-    void get_connected_chips();
+    void get_connected_devices();
 
-    void discover_remote_chips();
+    void discover_remote_devices();
 
     std::unique_ptr<ClusterDescriptor> fill_cluster_descriptor_info();
+
+    virtual void wait_eth_cores_training(
+        TTDevice* tt_device, const std::chrono::milliseconds timeout_ms = timeout::ETH_TRAINING_TIMEOUT);
 
     // board_type is not used for all configs.
     // We need to know that we are seeing TG board and that we should include it in the topology.
@@ -71,68 +76,69 @@ protected:
     // Returns mangled remote board id from local ETH core.
     // This information can still be used to unique identify a board.
     // eth_core should be in physical (NOC0) coordinates.
-    virtual uint64_t get_remote_board_id(Chip* chip, tt_xy_pair eth_core) = 0;
+    virtual uint64_t get_remote_board_id(TTDevice* tt_device, tt_xy_pair eth_core) = 0;
 
     // Returns mangled remote board type from local ETH core.
     // This information can still be used to unique identify a board.
     // eth_core should be in physical (NOC0) coordinates.
-    virtual uint64_t get_remote_board_type(Chip* chip, tt_xy_pair eth_core) = 0;
+    virtual uint64_t get_remote_board_type(TTDevice* tt_device, tt_xy_pair eth_core) = 0;
 
     // Returns mangled local board id from local ETH core.
     // This information can still be used to unique identify a board.
     // eth_core should be in physical (NOC0) coordinates.
-    virtual uint64_t get_local_board_id(Chip* chip, tt_xy_pair eth_core) = 0;
+    virtual uint64_t get_local_board_id(TTDevice* tt_device, tt_xy_pair eth_core) = 0;
 
     // eth_core should be in NoC 0 coordinates.
-    virtual uint64_t get_local_asic_id(Chip* chip, tt_xy_pair eth_core) = 0;
+    virtual uint64_t get_local_asic_id(TTDevice* tt_device, tt_xy_pair eth_core) = 0;
 
     // eth_core should be in NoC 0 coordinates.
-    virtual uint64_t get_remote_asic_id(Chip* chip, tt_xy_pair eth_core) = 0;
+    virtual uint64_t get_remote_asic_id(TTDevice* tt_device, tt_xy_pair eth_core) = 0;
 
-    uint64_t get_asic_id(Chip* chip);
+    uint64_t get_asic_id(TTDevice* tt_device);
 
-    virtual uint64_t get_unconnected_chip_id(Chip* chip) = 0;
+    virtual uint64_t get_unconnected_device_id(TTDevice* tt_device) = 0;
 
-    virtual std::optional<EthCoord> get_local_eth_coord(Chip* chip, tt_xy_pair eth_core) = 0;
+    virtual std::optional<EthCoord> get_local_eth_coord(TTDevice* tt_device, tt_xy_pair eth_core) = 0;
 
-    virtual std::optional<EthCoord> get_remote_eth_coord(Chip* chip, tt_xy_pair eth_core) = 0;
-
-    // local_eth_core should be in NoC 0 coordinates.
-    virtual tt_xy_pair get_remote_eth_core(Chip* chip, tt_xy_pair local_eth_core) = 0;
+    virtual std::optional<EthCoord> get_remote_eth_coord(TTDevice* tt_device, tt_xy_pair eth_core) = 0;
 
     // local_eth_core should be in NoC 0 coordinates.
-    virtual uint32_t get_remote_eth_id(Chip* chip, tt_xy_pair local_eth_core) = 0;
+    virtual tt_xy_pair get_remote_eth_core(TTDevice* tt_device, tt_xy_pair local_eth_core) = 0;
 
-    virtual uint32_t get_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) = 0;
+    // local_eth_core should be in NoC 0 coordinates.
+    virtual uint32_t get_remote_eth_id(TTDevice* tt_device, tt_xy_pair local_eth_core) = 0;
+
+    virtual uint32_t get_remote_eth_channel(TTDevice* tt_device, tt_xy_pair local_eth_core) = 0;
 
     // API exposed as a temporary workaround for issue: https://tenstorrent.atlassian.net/browse/SYS-2064.
     // This is used for querying the logical remote eth channel on Multi-Host Blackhole P150 systems, where
-    // we don't have access to the ethernet harvesting mask for the remote chip.
+    // we don't have access to the ethernet harvesting mask for the remote device.
     // Logic in this API can be placed in get_remote_eth_channel, and patch_eth_connections can be removed,
     // once the issue outlined in the ticket is resolved (at which point, UMD can directly query the logical
-    // ethernet channel for the remote chip on all board types).
-    virtual uint32_t get_logical_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) = 0;
+    // ethernet channel for the remote device on all board types).
+    virtual uint32_t get_logical_remote_eth_channel(TTDevice* tt_device, tt_xy_pair local_eth_core) = 0;
 
     virtual bool is_using_eth_coords() = 0;
 
     // eth_core should be in NoC 0 coordinates.
-    virtual std::unique_ptr<RemoteChip> create_remote_chip(
-        std::optional<EthCoord> eth_coord, Chip* gateway_chip, std::set<uint32_t> gateway_eth_channels) = 0;
+    virtual std::unique_ptr<TTDevice> create_remote_device(
+        std::optional<EthCoord> eth_coord, TTDevice* gateway_device, std::set<uint32_t> gateway_eth_channels) = 0;
 
-    Chip* get_chip(const uint64_t asic_id);
+    TTDevice* get_tt_device(const uint64_t asic_id);
 
     virtual void init_topology_discovery();
 
-    virtual bool is_eth_trained(Chip* chip, const tt_xy_pair eth_core) = 0;
+    virtual bool is_eth_trained(TTDevice* tt_device, const tt_xy_pair eth_core) = 0;
 
-    virtual bool verify_routing_firmware_state(Chip* chip, const tt_xy_pair eth_core) = 0;
+    virtual bool verify_routing_firmware_state(TTDevice* tt_device, const tt_xy_pair eth_core) = 0;
 
     // This is hack to report proper logical ETH IDs, since eth id on ETH core on Blackhole
     // does not take harvesting into consideration. This function will be overridden just for Blackhole.
     virtual void patch_eth_connections();
 
-    std::map<uint64_t, std::unique_ptr<Chip>> chips_to_discover;
-    std::map<uint64_t, std::unique_ptr<Chip>> chips;
+    std::map<uint64_t, std::unique_ptr<TTDevice>> devices_to_discover;
+    std::map<uint64_t, std::unique_ptr<TTDevice>> devices;
+    SocDescriptor get_soc_descriptor(TTDevice* tt_device);
 
     std::unordered_map<uint64_t, EthCoord> eth_coords;
 
@@ -144,26 +150,30 @@ protected:
     // All board ids that should be included in the cluster descriptor.
     std::unordered_set<uint64_t> board_ids;
 
-    std::unordered_map<uint64_t, std::set<uint32_t>> active_eth_channels_per_chip;
+    std::unordered_map<uint64_t, std::set<uint32_t>> active_eth_channels_per_device;
 
     // It's required to know which chip should be used for remote communication.
-    std::map<uint64_t, uint64_t> remote_asic_id_to_mmio_chip_id = {};
+    std::map<uint64_t, uint64_t> remote_asic_id_to_mmio_device_id = {};
 
     TopologyDiscoveryOptions options;
 
     bool is_running_on_6u = false;
 
-    virtual bool verify_eth_core_fw_version(Chip* chip, CoreCoord eth_core) = 0;
+    virtual bool verify_eth_core_fw_version(TTDevice* tt_device, tt_xy_pair eth_core) = 0;
 
-    virtual bool verify_fw_bundle_version(Chip* chip);
+    virtual bool verify_fw_bundle_version(TTDevice* tt_device);
 
     // The expected ETH FW version, matching the version shipped in the firmware bundle.
-    // If there is no available expected version, we use the version from the first discovered local chip.
+    // If there is no available expected version, we use the version from the first discovered local device.
     std::optional<semver_t> expected_eth_fw_version;
 
-    // The FW bundle version found on the first discovered local chip, that needs
-    // to match with all of the other discovered FW bundle versions on all chips.
+    // The FW bundle version found on the first discovered local device, that needs
+    // to match with all of the other discovered FW bundle versions on all devices.
     std::optional<semver_t> first_fw_bundle_version;
+
+private:
+    // Hack used to cache SocDescriptors.
+    std::unordered_map<TTDevice*, SocDescriptor> soc_descriptor_cache;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/topology/topology_discovery_blackhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_blackhole.hpp
@@ -5,6 +5,8 @@
 #pragma once
 
 #include "umd/device/topology/topology_discovery.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 
@@ -15,48 +17,48 @@ public:
 protected:
     bool is_board_id_included(uint64_t board_id, uint64_t board_type) const override;
 
-    uint64_t get_remote_board_id(Chip* chip, tt_xy_pair eth_core) override;
+    uint64_t get_remote_board_id(TTDevice* tt_device, tt_xy_pair eth_core) override;
 
-    uint64_t get_local_board_id(Chip* chip, tt_xy_pair eth_core) override;
+    uint64_t get_local_board_id(TTDevice* tt_device, tt_xy_pair eth_core) override;
 
-    uint64_t get_local_asic_id(Chip* chip, tt_xy_pair eth_core) override;
+    uint64_t get_local_asic_id(TTDevice* tt_device, tt_xy_pair eth_core) override;
 
-    uint64_t get_remote_asic_id(Chip* chip, tt_xy_pair eth_core) override;
+    uint64_t get_remote_asic_id(TTDevice* tt_device, tt_xy_pair eth_core) override;
 
-    uint64_t get_unconnected_chip_id(Chip* chip) override;
+    uint64_t get_unconnected_device_id(TTDevice* tt_device) override;
 
-    std::optional<EthCoord> get_local_eth_coord(Chip* chip, tt_xy_pair eth_core) override;
+    std::optional<EthCoord> get_local_eth_coord(TTDevice* tt_device, tt_xy_pair eth_core) override;
 
-    std::optional<EthCoord> get_remote_eth_coord(Chip* chip, tt_xy_pair eth_core) override;
+    std::optional<EthCoord> get_remote_eth_coord(TTDevice* tt_device, tt_xy_pair eth_core) override;
 
-    tt_xy_pair get_remote_eth_core(Chip* chip, tt_xy_pair local_eth_core) override;
+    tt_xy_pair get_remote_eth_core(TTDevice* tt_device, tt_xy_pair local_eth_core) override;
 
-    uint32_t read_port_status(Chip* chip, tt_xy_pair eth_core);
+    uint32_t read_port_status(TTDevice* tt_device, tt_xy_pair eth_core);
 
-    uint32_t get_remote_eth_id(Chip* chip, tt_xy_pair local_eth_core) override;
+    uint32_t get_remote_eth_id(TTDevice* tt_device, tt_xy_pair local_eth_core) override;
 
-    uint32_t get_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) override;
+    uint32_t get_remote_eth_channel(TTDevice* tt_device, tt_xy_pair local_eth_core) override;
 
-    uint32_t get_logical_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) override;
+    uint32_t get_logical_remote_eth_channel(TTDevice* tt_device, tt_xy_pair local_eth_core) override;
 
-    uint64_t get_remote_board_type(Chip* chip, tt_xy_pair eth_core) override;
+    uint64_t get_remote_board_type(TTDevice* tt_device, tt_xy_pair eth_core) override;
 
     bool is_using_eth_coords() override;
 
     uint64_t mangle_asic_id(uint64_t board_id, uint8_t asic_location);
 
-    bool is_eth_trained(Chip* chip, const tt_xy_pair eth_core) override;
+    bool is_eth_trained(TTDevice* tt_device, const tt_xy_pair eth_core) override;
 
-    bool verify_routing_firmware_state(Chip* chip, const tt_xy_pair eth_core) override;
+    bool verify_routing_firmware_state(TTDevice* tt_device, const tt_xy_pair eth_core) override;
 
-    std::unique_ptr<RemoteChip> create_remote_chip(
-        std::optional<EthCoord> eth_coord, Chip* gateway_chip, std::set<uint32_t> gateway_eth_channels) override;
+    std::unique_ptr<TTDevice> create_remote_device(
+        std::optional<EthCoord> eth_coord, TTDevice* gateway_chip, std::set<uint32_t> gateway_eth_channels) override;
 
     void patch_eth_connections() override;
 
     void init_topology_discovery() override;
 
-    bool verify_eth_core_fw_version(Chip* chip, CoreCoord eth_core) override;
+    bool verify_eth_core_fw_version(TTDevice* tt_device, tt_xy_pair eth_core) override;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/topology/topology_discovery_wormhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_wormhole.hpp
@@ -5,6 +5,8 @@
 #pragma once
 
 #include "umd/device/topology/topology_discovery.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 
@@ -32,46 +34,46 @@ protected:
 
     static EthAddresses get_eth_addresses(uint32_t eth_fw_version);
 
-    uint64_t get_remote_board_id(Chip* chip, tt_xy_pair eth_core) override;
+    uint64_t get_remote_board_id(TTDevice* tt_device, tt_xy_pair eth_core) override;
 
-    uint64_t get_local_board_id(Chip* chip, tt_xy_pair eth_core) override;
+    uint64_t get_local_board_id(TTDevice* tt_device, tt_xy_pair eth_core) override;
 
-    uint64_t get_local_asic_id(Chip* chip, tt_xy_pair eth_core) override;
+    uint64_t get_local_asic_id(TTDevice* tt_device, tt_xy_pair eth_core) override;
 
-    uint64_t get_remote_asic_id(Chip* chip, tt_xy_pair eth_core) override;
+    uint64_t get_remote_asic_id(TTDevice* tt_device, tt_xy_pair eth_core) override;
 
-    uint64_t get_unconnected_chip_id(Chip* chip) override;
+    uint64_t get_unconnected_device_id(TTDevice* tt_device) override;
 
-    std::optional<EthCoord> get_local_eth_coord(Chip* chip, tt_xy_pair eth_core) override;
+    std::optional<EthCoord> get_local_eth_coord(TTDevice* tt_device, tt_xy_pair eth_core) override;
 
-    std::optional<EthCoord> get_remote_eth_coord(Chip* chip, tt_xy_pair eth_core) override;
+    std::optional<EthCoord> get_remote_eth_coord(TTDevice* tt_device, tt_xy_pair eth_core) override;
 
-    tt_xy_pair get_remote_eth_core(Chip* chip, tt_xy_pair local_eth_core) override;
+    tt_xy_pair get_remote_eth_core(TTDevice* tt_device, tt_xy_pair local_eth_core) override;
 
-    uint32_t read_training_status(Chip* chip, tt_xy_pair eth_core);
+    uint32_t read_training_status(TTDevice* tt_device, tt_xy_pair eth_core);
 
-    uint32_t get_remote_eth_id(Chip* chip, tt_xy_pair local_eth_core) override;
+    uint32_t get_remote_eth_id(TTDevice* tt_device, tt_xy_pair local_eth_core) override;
 
-    uint32_t get_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) override;
+    uint32_t get_remote_eth_channel(TTDevice* tt_device, tt_xy_pair local_eth_core) override;
 
-    uint32_t get_logical_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) override;
+    uint32_t get_logical_remote_eth_channel(TTDevice* tt_device, tt_xy_pair local_eth_core) override;
 
-    uint64_t get_remote_board_type(Chip* chip, tt_xy_pair eth_core) override;
+    uint64_t get_remote_board_type(TTDevice* tt_device, tt_xy_pair eth_core) override;
 
-    std::unique_ptr<RemoteChip> create_remote_chip(
-        std::optional<EthCoord> eth_coord, Chip* gateway_chip, std::set<uint32_t> gateway_eth_channels) override;
+    std::unique_ptr<TTDevice> create_remote_device(
+        std::optional<EthCoord> eth_coord, TTDevice* gateway_chip, std::set<uint32_t> gateway_eth_channels) override;
 
     bool is_using_eth_coords() override;
 
     void init_topology_discovery() override;
 
-    bool is_eth_trained(Chip* chip, const tt_xy_pair eth_core) override;
+    bool is_eth_trained(TTDevice* tt_device, const tt_xy_pair eth_core) override;
 
-    bool verify_routing_firmware_state(Chip* chip, const tt_xy_pair eth_core) override;
+    bool verify_routing_firmware_state(TTDevice* tt_device, const tt_xy_pair eth_core) override;
 
     EthAddresses eth_addresses;
 
-    bool verify_eth_core_fw_version(Chip* chip, CoreCoord eth_core) override;
+    bool verify_eth_core_fw_version(TTDevice* tt_device, tt_xy_pair eth_core) override;
 
     static constexpr uint32_t LINK_TRAIN_SUCCESS = 1;
     static constexpr uint32_t LINK_TRAIN_TRAINING = 0;

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -15,9 +15,7 @@
 #include "api/umd/device/topology/topology_discovery_wormhole.hpp"
 #include "assert.hpp"
 #include "noc_access.hpp"
-#include "umd/device/chip/local_chip.hpp"
 #include "umd/device/cluster_descriptor.hpp"
-#include "umd/device/firmware/erisc_firmware.hpp"
 #include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/utils/semver.hpp"
@@ -68,153 +66,162 @@ TopologyDiscovery::TopologyDiscovery(const TopologyDiscoveryOptions& options) : 
 std::unique_ptr<ClusterDescriptor> TopologyDiscovery::create_ethernet_map() {
     log_debug(LogUMD, "Starting topology discovery.");
     init_topology_discovery();
-    get_connected_chips();
-    discover_remote_chips();
+    get_connected_devices();
+    discover_remote_devices();
     log_debug(LogUMD, "Completed topology discovery.");
     return fill_cluster_descriptor_info();
 }
 
-std::pair<std::unique_ptr<ClusterDescriptor>, std::map<uint64_t, std::unique_ptr<Chip>>> TopologyDiscovery::discover(
-    const TopologyDiscoveryOptions& options) {
-    std::map<uint64_t, std::unique_ptr<Chip>> chips;
+std::pair<std::unique_ptr<ClusterDescriptor>, std::map<uint64_t, std::unique_ptr<TTDevice>>>
+TopologyDiscovery::discover(const TopologyDiscoveryOptions& options) {
+    std::map<uint64_t, std::unique_ptr<TTDevice>> devices;
     std::unique_ptr<TopologyDiscovery> td = TopologyDiscovery::create_topology_discovery(options);
     if (td == nullptr) {
-        return std::make_pair(std::make_unique<ClusterDescriptor>(), std::move(chips));
+        return std::make_pair(std::make_unique<ClusterDescriptor>(), std::move(devices));
     }
     std::unique_ptr<ClusterDescriptor> cluster_desc = td->create_ethernet_map();
-    return std::make_pair(std::move(cluster_desc), std::move(td->chips));
+    return std::make_pair(std::move(cluster_desc), std::move(td->devices));
 }
 
 void TopologyDiscovery::init_topology_discovery() {}
 
-void TopologyDiscovery::get_connected_chips() {
-    std::vector<int> device_ids;
+void TopologyDiscovery::get_connected_devices() {
+    std::vector<int> local_device_ids;
     switch (options.io_device_type) {
         case IODeviceType::PCIe: {
-            device_ids = PCIDevice::enumerate_devices();
+            local_device_ids = PCIDevice::enumerate_devices();
             break;
         }
         case IODeviceType::JTAG: {
             auto device_cnt = JtagDevice::create(JtagDevice::jtag_library_path)->get_device_cnt();
-            device_ids = std::vector<int>(device_cnt);
-            std::iota(device_ids.begin(), device_ids.end(), 0);
+            local_device_ids = std::vector<int>(device_cnt);
+            std::iota(local_device_ids.begin(), local_device_ids.end(), 0);
             break;
         }
         default:
             TT_THROW("Unsupported device type.");
     }
-    for (auto& device_id : device_ids) {
-        std::unique_ptr<LocalChip> chip =
-            LocalChip::create(device_id, options.soc_descriptor_path, 0, options.io_device_type);
 
-        std::vector<CoreCoord> eth_cores = chip->get_soc_descriptor().get_cores(
-            CoreType::ETH, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0);
+    for (auto& device_id : local_device_ids) {
+        std::unique_ptr<TTDevice> tt_device = TTDevice::create(device_id, options.io_device_type);
+        tt_device->init_tt_device();
+
+        if (!options.no_wait_for_eth_training) {
+            wait_eth_cores_training(tt_device.get());
+        }
+
+        std::vector<CoreCoord> eth_cores =
+            get_soc_descriptor(tt_device.get())
+                .get_cores(CoreType::ETH, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0);
         for (const CoreCoord& eth_core : eth_cores) {
-            uint64_t board_id = get_local_board_id(chip.get(), eth_core);
+            uint64_t board_id = get_local_board_id(tt_device.get(), eth_core);
             if (board_id != 0) {
                 board_ids.insert(board_id);
                 break;
             }
         }
 
-        uint64_t asic_id = get_asic_id(chip.get());
-        chips_to_discover.emplace(asic_id, std::move(chip));
+        uint64_t asic_id = get_asic_id(tt_device.get());
+        devices_to_discover.emplace(asic_id, std::move(tt_device));
 
         log_debug(
             LogUMD,
-            "Discovered {} chip w/ MMIO, ID: {}, ASIC ID {}",
+            "Discovered {} device w/ MMIO, ID: {}, ASIC ID {}",
             DeviceTypeToString.at(options.io_device_type),
             device_id,
             asic_id);
     }
 }
 
-void TopologyDiscovery::discover_remote_chips() {
-    std::set<uint64_t> discovered_chips = {};
-    for (const auto& [current_chip_asic_id, chip] : chips_to_discover) {
-        discovered_chips.insert(current_chip_asic_id);
-        remote_asic_id_to_mmio_chip_id.emplace(current_chip_asic_id, current_chip_asic_id);
-        active_eth_channels_per_chip.emplace(current_chip_asic_id, std::set<uint32_t>());
+void TopologyDiscovery::discover_remote_devices() {
+    std::set<uint64_t> discovered_devices = {};
+    for (const auto& [current_device_asic_id, tt_device] : devices_to_discover) {
+        discovered_devices.insert(current_device_asic_id);
+        remote_asic_id_to_mmio_device_id.emplace(current_device_asic_id, current_device_asic_id);
+        active_eth_channels_per_device.emplace(current_device_asic_id, std::set<uint32_t>());
     }
-    while (!chips_to_discover.empty()) {
-        auto it = chips_to_discover.begin();
-        uint64_t current_chip_asic_id = it->first;
-        chips.emplace(current_chip_asic_id, std::move(it->second));
-        chips_to_discover.erase(it);
-        Chip* chip = chips.at(current_chip_asic_id).get();
+    while (!devices_to_discover.empty()) {
+        auto it = devices_to_discover.begin();
+        uint64_t current_device_asic_id = it->first;
+        devices.emplace(current_device_asic_id, std::move(it->second));
+        devices_to_discover.erase(it);
+        TTDevice* tt_device = devices.at(current_device_asic_id).get();
 
         if (options.no_remote_discovery) {
             continue;
         }
 
-        std::vector<CoreCoord> eth_cores = chip->get_soc_descriptor().get_cores(
+        std::vector<CoreCoord> eth_cores = get_soc_descriptor(tt_device).get_cores(
             CoreType::ETH, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0);
 
-        verify_fw_bundle_version(chip);
+        verify_fw_bundle_version(tt_device);
 
         uint32_t channel = 0;
         for (const CoreCoord& eth_core : eth_cores) {
-            if (!verify_eth_core_fw_version(chip, eth_core)) {
+            if (!verify_eth_core_fw_version(tt_device, eth_core)) {
                 log_warning(
                     LogUMD,
-                    "Skipping discovery from chip {} ETH core {}",
-                    get_local_asic_id(chip, eth_core),
+                    "Skipping discovery from device {} ETH core {}",
+                    get_local_asic_id(tt_device, eth_core),
                     eth_core.str());
                 channel++;
                 continue;
             }
 
-            if (is_using_eth_coords() && eth_coords.find(current_chip_asic_id) == eth_coords.end()) {
-                auto local_eth_coord = get_local_eth_coord(chip, eth_core);
+            if (is_using_eth_coords() && eth_coords.find(current_device_asic_id) == eth_coords.end()) {
+                auto local_eth_coord = get_local_eth_coord(tt_device, eth_core);
                 if (local_eth_coord.has_value()) {
-                    eth_coords.emplace(current_chip_asic_id, local_eth_coord.value());
-                    log_debug(LogUMD, "Device {} has ETH coord: {}", current_chip_asic_id, local_eth_coord.value());
+                    eth_coords.emplace(current_device_asic_id, local_eth_coord.value());
+                    log_debug(LogUMD, "Device {} has ETH coord: {}", current_device_asic_id, local_eth_coord.value());
                 }
             }
 
-            if (!is_eth_trained(chip, eth_core)) {
+            if (!is_eth_trained(tt_device, eth_core)) {
                 channel++;
                 continue;
             }
 
-            if (!verify_routing_firmware_state(chip, eth_core)) {
+            if (!verify_routing_firmware_state(tt_device, eth_core)) {
                 channel++;
                 continue;
             }
 
-            active_eth_channels_per_chip.at(current_chip_asic_id).insert(channel);
+            active_eth_channels_per_device.at(current_device_asic_id).insert(channel);
 
-            if (!is_board_id_included(get_remote_board_id(chip, eth_core), get_remote_board_type(chip, eth_core)) ||
-                (chip->get_tt_device()->get_arch() == ARCH::BLACKHOLE &&
-                 discovered_chips.find(get_remote_asic_id(chip, eth_core)) == discovered_chips.end())) {
-                uint64_t remote_asic_id = get_remote_asic_id(chip, eth_core);
+            if (!is_board_id_included(
+                    get_remote_board_id(tt_device, eth_core), get_remote_board_type(tt_device, eth_core)) ||
+                (tt_device->get_arch() == ARCH::BLACKHOLE &&
+                 discovered_devices.find(get_remote_asic_id(tt_device, eth_core)) == discovered_devices.end())) {
+                uint64_t remote_asic_id = get_remote_asic_id(tt_device, eth_core);
                 ethernet_connections_to_remote_devices.push_back(
-                    {{current_chip_asic_id, channel},
-                     {remote_asic_id, get_logical_remote_eth_channel(chip, eth_core)}});
-                log_debug(LogUMD, "Remote chip outside of UMD cluster {}.", remote_asic_id);
+                    {{current_device_asic_id, channel},
+                     {remote_asic_id, get_logical_remote_eth_channel(tt_device, eth_core)}});
+                log_debug(LogUMD, "Remote device outside of UMD cluster {}.", remote_asic_id);
 
                 channel++;
                 continue;
             }
 
-            uint64_t remote_asic_id = get_remote_asic_id(chip, eth_core);
+            uint64_t remote_asic_id = get_remote_asic_id(tt_device, eth_core);
 
-            if (discovered_chips.find(remote_asic_id) == discovered_chips.end()) {
-                uint64_t gateway_chip_id = remote_asic_id_to_mmio_chip_id.at(current_chip_asic_id);
-                std::optional<EthCoord> eth_coord = get_remote_eth_coord(chip, eth_core);
-                std::unique_ptr<Chip> remote_chip = create_remote_chip(
-                    eth_coord, chips.at(gateway_chip_id).get(), active_eth_channels_per_chip.at(gateway_chip_id));
+            if (discovered_devices.find(remote_asic_id) == discovered_devices.end()) {
+                uint64_t gateway_device_id = remote_asic_id_to_mmio_device_id.at(current_device_asic_id);
+                std::optional<EthCoord> eth_coord = get_remote_eth_coord(tt_device, eth_core);
+                std::unique_ptr<TTDevice> remote_device = create_remote_device(
+                    eth_coord,
+                    devices.at(gateway_device_id).get(),
+                    active_eth_channels_per_device.at(gateway_device_id));
 
-                chips_to_discover.emplace(remote_asic_id, std::move(remote_chip));
-                active_eth_channels_per_chip.emplace(remote_asic_id, std::set<uint32_t>());
-                discovered_chips.insert(remote_asic_id);
-                remote_asic_id_to_mmio_chip_id.emplace(remote_asic_id, gateway_chip_id);
+                devices_to_discover.emplace(remote_asic_id, std::move(remote_device));
+                active_eth_channels_per_device.emplace(remote_asic_id, std::set<uint32_t>());
+                discovered_devices.insert(remote_asic_id);
+                remote_asic_id_to_mmio_device_id.emplace(remote_asic_id, gateway_device_id);
                 if (is_using_eth_coords()) {
                     eth_coords.emplace(remote_asic_id, eth_coord.value());
                 }
             } else {
                 ethernet_connections.push_back(
-                    {{current_chip_asic_id, channel}, {remote_asic_id, get_remote_eth_channel(chip, eth_core)}});
+                    {{current_device_asic_id, channel}, {remote_asic_id, get_remote_eth_channel(tt_device, eth_core)}});
             }
             channel++;
         }
@@ -227,57 +234,57 @@ std::unique_ptr<ClusterDescriptor> TopologyDiscovery::fill_cluster_descriptor_in
     std::unique_ptr<ClusterDescriptor> cluster_desc = std::make_unique<ClusterDescriptor>();
     std::map<uint64_t, ChipId> asic_id_to_chip_id;
     ChipId chip_id = 0;
-    for (const auto& [current_chip_asic_id, chip] : chips) {
-        if (chip->is_mmio_capable()) {
-            asic_id_to_chip_id.emplace(current_chip_asic_id, chip_id);
-            cluster_desc->chip_unique_ids.emplace(chip_id, current_chip_asic_id);
+    for (const auto& [current_device_asic_id, tt_device] : devices) {
+        if (!tt_device->is_remote()) {
+            asic_id_to_chip_id.emplace(current_device_asic_id, chip_id);
+            cluster_desc->chip_unique_ids.emplace(chip_id, current_device_asic_id);
             chip_id++;
         }
     }
 
-    for (const auto& [current_chip_asic_id, chip] : chips) {
-        if (!chip->is_mmio_capable()) {
-            asic_id_to_chip_id.emplace(current_chip_asic_id, chip_id);
-            cluster_desc->chip_unique_ids.emplace(chip_id, current_chip_asic_id);
+    for (const auto& [current_device_asic_id, tt_device] : devices) {
+        if (tt_device->is_remote()) {
+            asic_id_to_chip_id.emplace(current_device_asic_id, chip_id);
+            cluster_desc->chip_unique_ids.emplace(chip_id, current_device_asic_id);
             if (eth_coords.empty()) {
                 cluster_desc->closest_mmio_chip_cache[chip_id] =
-                    asic_id_to_chip_id.at(remote_asic_id_to_mmio_chip_id.at(current_chip_asic_id));
+                    asic_id_to_chip_id.at(remote_asic_id_to_mmio_device_id.at(current_device_asic_id));
             }
             chip_id++;
         }
     }
 
-    for (const auto& [current_chip_asic_id, chip] : chips) {
-        ChipId current_chip_id = asic_id_to_chip_id.at(current_chip_asic_id);
+    for (const auto& [current_device_asic_id, tt_device] : devices) {
+        ChipId current_chip_id = asic_id_to_chip_id.at(current_device_asic_id);
         cluster_desc->all_chips.insert(current_chip_id);
-        cluster_desc->chip_arch.insert({current_chip_id, chip->get_tt_device()->get_arch()});
+        cluster_desc->chip_arch.insert({current_chip_id, tt_device->get_arch()});
 
-        if (chip->is_mmio_capable()) {
-            cluster_desc->chips_with_mmio.insert(
-                {current_chip_id, chip->get_tt_device()->get_communication_device_id()});
+        if (!tt_device->is_remote()) {
+            cluster_desc->chips_with_mmio.insert({current_chip_id, tt_device->get_communication_device_id()});
         }
 
-        cluster_desc->chip_board_type.insert({current_chip_id, chip->get_chip_info().board_type});
+        cluster_desc->chip_board_type.insert({current_chip_id, tt_device->get_chip_info().board_type});
 
-        cluster_desc->noc_translation_enabled.insert({current_chip_id, chip->get_chip_info().noc_translation_enabled});
-        cluster_desc->harvesting_masks_map.insert({current_chip_id, chip->get_chip_info().harvesting_masks});
-        cluster_desc->asic_locations.insert({current_chip_id, chip->get_tt_device()->get_chip_info().asic_location});
+        cluster_desc->noc_translation_enabled.insert(
+            {current_chip_id, tt_device->get_chip_info().noc_translation_enabled});
+        cluster_desc->harvesting_masks_map.insert({current_chip_id, tt_device->get_chip_info().harvesting_masks});
+        cluster_desc->asic_locations.insert({current_chip_id, tt_device->get_chip_info().asic_location});
 
-        if (chip->get_tt_device()->get_pci_device()) {
+        if (tt_device->get_pci_device()) {
             cluster_desc->chip_to_bus_id.insert(
-                {current_chip_id, chip->get_tt_device()->get_pci_device()->get_device_info().pci_bus});
+                {current_chip_id, tt_device->get_pci_device()->get_device_info().pci_bus});
         }
 
         if (is_using_eth_coords()) {
             if (!eth_coords.empty()) {
-                EthCoord eth_coord = eth_coords.at(current_chip_asic_id);
+                EthCoord eth_coord = eth_coords.at(current_device_asic_id);
                 cluster_desc->chip_locations.insert({current_chip_id, eth_coord});
                 cluster_desc->coords_to_chip_ids[eth_coord.rack][eth_coord.shelf][eth_coord.y][eth_coord.x] =
                     current_chip_id;
             }
         }
 
-        cluster_desc->add_chip_to_board(current_chip_id, chip->get_chip_info().board_id);
+        cluster_desc->add_chip_to_board(current_chip_id, tt_device->get_chip_info().board_id);
     }
 
     for (auto [ethernet_connection_logical, ethernet_connection_remote] : ethernet_connections) {
@@ -295,8 +302,8 @@ std::unique_ptr<ClusterDescriptor> TopologyDiscovery::fill_cluster_descriptor_in
             ethernet_connection_remote.first, ethernet_connection_remote.second};
     }
 
-    const uint32_t num_eth_channels = chips.begin()->second->get_soc_descriptor().get_cores(CoreType::ETH).size();
-    for (auto [current_chip_asic_id, active_eth_channels] : active_eth_channels_per_chip) {
+    const uint32_t num_eth_channels = get_soc_descriptor(devices.begin()->second.get()).get_cores(CoreType::ETH).size();
+    for (auto [current_chip_asic_id, active_eth_channels] : active_eth_channels_per_device) {
         ChipId current_chip_id = asic_id_to_chip_id.at(current_chip_asic_id);
         for (int i = 0; i < num_eth_channels; i++) {
             cluster_desc->idle_eth_channels[current_chip_id].insert(i);
@@ -318,36 +325,35 @@ std::unique_ptr<ClusterDescriptor> TopologyDiscovery::fill_cluster_descriptor_in
     return cluster_desc;
 }
 
-Chip* TopologyDiscovery::get_chip(const uint64_t asic_id) {
-    if (chips_to_discover.find(asic_id) != chips_to_discover.end()) {
-        return chips_to_discover.at(asic_id).get();
+TTDevice* TopologyDiscovery::get_tt_device(const uint64_t asic_id) {
+    if (devices_to_discover.find(asic_id) != devices_to_discover.end()) {
+        return devices_to_discover.at(asic_id).get();
     }
-    return chips.at(asic_id).get();
+    return devices.at(asic_id).get();
 }
 
-uint64_t TopologyDiscovery::get_asic_id(Chip* chip) {
-    // This function should return a unique ID for the chip. At the moment we are going to use mangled board ID
+uint64_t TopologyDiscovery::get_asic_id(TTDevice* tt_device) {
+    // This function should return a unique ID for the device. At the moment we are going to use mangled board ID
     // and asic location from active (connected) ETH cores. If we have multiple ETH cores, we will use the first one.
-    // If we have no ETH cores, we will use the board ID, since no other chip can have the same board ID.
+    // If we have no ETH cores, we will use the board ID, since no other device can have the same board ID.
     // Using board ID should happen only for unconnected boards (N150, P150).
-    std::vector<CoreCoord> eth_cores =
-        chip->get_soc_descriptor().get_cores(CoreType::ETH, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0);
+    std::vector<CoreCoord> eth_cores = get_soc_descriptor(tt_device).get_cores(
+        CoreType::ETH, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0);
 
     for (const CoreCoord& eth_core : eth_cores) {
-        if (!is_eth_trained(chip, eth_core)) {
+        if (!is_eth_trained(tt_device, eth_core)) {
             continue;
         }
 
-        return get_local_asic_id(chip, eth_core);
+        return get_local_asic_id(tt_device, eth_core);
     }
 
-    return get_unconnected_chip_id(chip);
+    return get_unconnected_device_id(tt_device);
 }
 
 void TopologyDiscovery::patch_eth_connections() {}
 
-bool TopologyDiscovery::verify_fw_bundle_version(Chip* chip) {
-    TTDevice* tt_device = chip->get_tt_device();
+bool TopologyDiscovery::verify_fw_bundle_version(TTDevice* tt_device) {
     semver_t fw_bundle_version = tt_device->get_firmware_version();
 
     if (first_fw_bundle_version.has_value()) {
@@ -356,9 +362,9 @@ bool TopologyDiscovery::verify_fw_bundle_version(Chip* chip) {
                 LogUMD,
                 fmt::format(
                     "Firmware bundle version mismatch for device {}: expected {}, got {}",
-                    get_asic_id(chip),
+                    get_asic_id(tt_device),
                     fw_bundle_version.to_string(),
-                    chip->get_tt_device()->get_firmware_version().to_string()));
+                    tt_device->get_firmware_version().to_string()));
             return false;
         }
         return true;
@@ -394,6 +400,45 @@ bool TopologyDiscovery::verify_fw_bundle_version(Chip* chip) {
             arch_to_str(tt_device->get_arch()));
     }
     return true;
+}
+
+void TopologyDiscovery::wait_eth_cores_training(TTDevice* tt_device, const std::chrono::milliseconds timeout_ms) {
+    auto timeout_left = timeout_ms;
+    const std::vector<CoreCoord> eth_cores = get_soc_descriptor(tt_device).get_cores(CoreType::ETH);
+    for (const CoreCoord& eth_core : eth_cores) {
+        tt_xy_pair actual_eth_core = eth_core;
+        if (tt_device->get_arch() == tt::ARCH::WORMHOLE_B0) {
+            // Translated space for ETH cores is different than NOC1 and wait_eth_core training is expecting NOC0
+            // coordinates.
+            actual_eth_core = get_soc_descriptor(tt_device).translate_coord_to(eth_core, CoordSystem::NOC0);
+        } else {
+            actual_eth_core = get_soc_descriptor(tt_device).translate_chip_coord_to_translated(eth_core);
+        }
+
+        timeout_left -= tt_device->wait_eth_core_training(actual_eth_core, timeout_left);
+    }
+}
+
+SocDescriptor TopologyDiscovery::get_soc_descriptor(TTDevice* tt_device) {
+    // HACK: This methods shows that SocDescriptor is needed with almost every use of
+    // TTDevice in TopologyDiscovery, so the SocDescriptor itself should be owned by
+    // TTDevice. This method caches SocDescriptors to reduce the overhead of creating one
+    // on the spot every time.
+    auto it = soc_descriptor_cache.find(tt_device);
+    if (it != soc_descriptor_cache.end()) {
+        return it->second;
+    }
+
+    SocDescriptor soc_descriptor;
+    if (options.soc_descriptor_path.empty()) {
+        // In case soc descriptor yaml wasn't passed, we create soc descriptor with default values for the architecture.
+        soc_descriptor = SocDescriptor(tt_device->get_arch(), tt_device->get_chip_info());
+    } else {
+        soc_descriptor = SocDescriptor(options.soc_descriptor_path, tt_device->get_chip_info());
+    }
+
+    soc_descriptor_cache[tt_device] = soc_descriptor;
+    return soc_descriptor;
 }
 
 }  // namespace tt::umd

--- a/device/topology/topology_discovery_blackhole.cpp
+++ b/device/topology/topology_discovery_blackhole.cpp
@@ -10,46 +10,50 @@
 #include "assert.hpp"
 #include "noc_access.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
-#include "umd/device/chip/local_chip.hpp"
-#include "umd/device/chip/remote_chip.hpp"
 #include "umd/device/cluster_descriptor.hpp"
 #include "umd/device/firmware/erisc_firmware.hpp"
 #include "umd/device/firmware/firmware_utils.hpp"
 #include "umd/device/topology/topology_discovery.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/blackhole_eth.hpp"
-#include "umd/device/types/cluster_types.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 
 TopologyDiscoveryBlackhole::TopologyDiscoveryBlackhole(const TopologyDiscoveryOptions& options) :
     TopologyDiscovery(options) {}
 
-std::unique_ptr<RemoteChip> TopologyDiscoveryBlackhole::create_remote_chip(
-    std::optional<EthCoord> eth_coord, Chip* gateway_chip, std::set<uint32_t> gateway_eth_channels) {
+std::unique_ptr<TTDevice> TopologyDiscoveryBlackhole::create_remote_device(
+    std::optional<EthCoord> eth_coord, TTDevice* gateway_device, std::set<uint32_t> gateway_eth_channels) {
     // ETH coord is not used for Blackhole, as Blackhole does not have a concept of ETH coordinates.
-    return RemoteChip::create(
-        dynamic_cast<LocalChip*>(gateway_chip), {0, 0, 0, 0}, gateway_eth_channels, options.soc_descriptor_path);
+    std::unique_ptr<RemoteCommunication> remote_communication =
+        RemoteCommunication::create_remote_communication(gateway_device, {0, 0, 0, 0});
+    remote_communication->set_remote_transfer_ethernet_cores(
+        get_soc_descriptor(gateway_device)
+            .get_eth_xy_pairs_for_channels(gateway_eth_channels, CoordSystem::TRANSLATED));
+    std::unique_ptr<TTDevice> remote_tt_device = TTDevice::create(std::move(remote_communication));
+    remote_tt_device->init_tt_device();
+    return remote_tt_device;
 }
 
-std::optional<EthCoord> TopologyDiscoveryBlackhole::get_local_eth_coord(Chip* chip, tt_xy_pair eth_core) {
+std::optional<EthCoord> TopologyDiscoveryBlackhole::get_local_eth_coord(TTDevice* tt_device, tt_xy_pair eth_core) {
     return std::nullopt;
 }
 
-std::optional<EthCoord> TopologyDiscoveryBlackhole::get_remote_eth_coord(Chip* chip, tt_xy_pair eth_core) {
+std::optional<EthCoord> TopologyDiscoveryBlackhole::get_remote_eth_coord(TTDevice* tt_device, tt_xy_pair eth_core) {
     return std::nullopt;
 }
 
-uint64_t TopologyDiscoveryBlackhole::get_remote_board_id(Chip* chip, tt_xy_pair eth_core) {
+uint64_t TopologyDiscoveryBlackhole::get_remote_board_id(TTDevice* tt_device, tt_xy_pair eth_core) {
     if (is_running_on_6u) {
         // See comment in get_local_board_id.
-        return get_remote_asic_id(chip, eth_core);
+        return get_remote_asic_id(tt_device, eth_core);
     }
 
-    tt_xy_pair translated_eth_core = chip->get_soc_descriptor().translate_coord_to(
+    tt_xy_pair translated_eth_core = get_soc_descriptor(tt_device).translate_coord_to(
         eth_core, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0, CoordSystem::TRANSLATED);
     uint32_t board_id_lo;
-    TTDevice* tt_device = chip->get_tt_device();
     tt_device->read_from_device(&board_id_lo, translated_eth_core, 0x7CFE8, sizeof(board_id_lo));
 
     uint32_t board_id_hi;
@@ -58,20 +62,19 @@ uint64_t TopologyDiscoveryBlackhole::get_remote_board_id(Chip* chip, tt_xy_pair 
     return (static_cast<uint64_t>(board_id_hi) << 32) | board_id_lo;
 }
 
-uint64_t TopologyDiscoveryBlackhole::get_local_board_id(Chip* chip, tt_xy_pair eth_core) {
+uint64_t TopologyDiscoveryBlackhole::get_local_board_id(TTDevice* tt_device, tt_xy_pair eth_core) {
     if (is_running_on_6u) {
         // For 6U, since the whole trays have the same board ID, and we'd want to be able to open
         // only some chips, we hack the board_id to be the asic ID. That way, the pci_target_devices filter
         // from the ClusterOptions will work correctly on 6U.
         // Note that the board_id will still be reported properly in the cluster descriptor, since it is
         // fetched through another function when cluster descriptor is being filled up.
-        return get_local_asic_id(chip, eth_core);
+        return get_local_asic_id(tt_device, eth_core);
     }
 
-    tt_xy_pair translated_eth_core = chip->get_soc_descriptor().translate_coord_to(
+    tt_xy_pair translated_eth_core = get_soc_descriptor(tt_device).translate_coord_to(
         eth_core, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0, CoordSystem::TRANSLATED);
     uint32_t board_id_lo;
-    TTDevice* tt_device = chip->get_tt_device();
     tt_device->read_from_device(&board_id_lo, translated_eth_core, 0x7CFC8, sizeof(board_id_lo));
 
     uint32_t board_id_hi;
@@ -80,11 +83,9 @@ uint64_t TopologyDiscoveryBlackhole::get_local_board_id(Chip* chip, tt_xy_pair e
     return (static_cast<uint64_t>(board_id_hi) << 32) | board_id_lo;
 }
 
-uint64_t TopologyDiscoveryBlackhole::get_local_asic_id(Chip* chip, tt_xy_pair eth_core) {
-    tt_xy_pair translated_eth_core = chip->get_soc_descriptor().translate_coord_to(
+uint64_t TopologyDiscoveryBlackhole::get_local_asic_id(TTDevice* tt_device, tt_xy_pair eth_core) {
+    tt_xy_pair translated_eth_core = get_soc_descriptor(tt_device).translate_coord_to(
         eth_core, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0, CoordSystem::TRANSLATED);
-
-    TTDevice* tt_device = chip->get_tt_device();
 
     if (is_running_on_6u) {
         uint32_t asic_id_hi;
@@ -96,18 +97,16 @@ uint64_t TopologyDiscoveryBlackhole::get_local_asic_id(Chip* chip, tt_xy_pair et
         return ((uint64_t)asic_id_hi << 32) | asic_id_lo;
     }
 
-    uint64_t board_id = get_local_board_id(chip, eth_core);
+    uint64_t board_id = get_local_board_id(tt_device, eth_core);
     uint8_t asic_location;
     tt_device->read_from_device(&asic_location, translated_eth_core, 0x7CFC1, sizeof(asic_location));
 
     return mangle_asic_id(board_id, asic_location);
 }
 
-uint64_t TopologyDiscoveryBlackhole::get_remote_asic_id(Chip* chip, tt_xy_pair eth_core) {
-    tt_xy_pair translated_eth_core = chip->get_soc_descriptor().translate_coord_to(
+uint64_t TopologyDiscoveryBlackhole::get_remote_asic_id(TTDevice* tt_device, tt_xy_pair eth_core) {
+    tt_xy_pair translated_eth_core = get_soc_descriptor(tt_device).translate_coord_to(
         eth_core, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0, CoordSystem::TRANSLATED);
-
-    TTDevice* tt_device = chip->get_tt_device();
 
     if (is_running_on_6u) {
         uint32_t asic_id_hi;
@@ -119,60 +118,56 @@ uint64_t TopologyDiscoveryBlackhole::get_remote_asic_id(Chip* chip, tt_xy_pair e
         return ((uint64_t)asic_id_hi << 32) | asic_id_lo;
     }
 
-    uint64_t board_id = get_remote_board_id(chip, eth_core);
+    uint64_t board_id = get_remote_board_id(tt_device, eth_core);
     uint8_t asic_location;
     tt_device->read_from_device(&asic_location, translated_eth_core, 0x7CFE1, sizeof(asic_location));
 
     return mangle_asic_id(board_id, asic_location);
 }
 
-tt_xy_pair TopologyDiscoveryBlackhole::get_remote_eth_core(Chip* chip, tt_xy_pair local_eth_core) {
+tt_xy_pair TopologyDiscoveryBlackhole::get_remote_eth_core(TTDevice* tt_device, tt_xy_pair local_eth_core) {
     throw std::runtime_error(
         "get_remote_eth_core is not implemented for Blackhole. Calling this function for Blackhole likely indicates a "
         "bug.");
 }
 
-uint32_t TopologyDiscoveryBlackhole::read_port_status(Chip* chip, tt_xy_pair eth_core) {
-    tt_xy_pair translated_eth_core = chip->get_soc_descriptor().translate_coord_to(
+uint32_t TopologyDiscoveryBlackhole::read_port_status(TTDevice* tt_device, tt_xy_pair eth_core) {
+    tt_xy_pair translated_eth_core = get_soc_descriptor(tt_device).translate_coord_to(
         eth_core, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0, CoordSystem::TRANSLATED);
     uint8_t port_status;
-    TTDevice* tt_device = chip->get_tt_device();
     tt_device->read_from_device(&port_status, translated_eth_core, 0x7CC04, sizeof(port_status));
     return port_status;
 }
 
-uint32_t TopologyDiscoveryBlackhole::get_remote_eth_id(Chip* chip, tt_xy_pair local_eth_core) {
-    tt_xy_pair translated_eth_core = chip->get_soc_descriptor().translate_coord_to(
+uint32_t TopologyDiscoveryBlackhole::get_remote_eth_id(TTDevice* tt_device, tt_xy_pair local_eth_core) {
+    tt_xy_pair translated_eth_core = get_soc_descriptor(tt_device).translate_coord_to(
         local_eth_core, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0, CoordSystem::TRANSLATED);
-    TTDevice* tt_device = chip->get_tt_device();
     uint8_t remote_eth_id;
     tt_device->read_from_device(&remote_eth_id, translated_eth_core, 0x7CFE2, sizeof(remote_eth_id));
     return remote_eth_id;
 }
 
-uint64_t TopologyDiscoveryBlackhole::get_remote_board_type(Chip* chip, tt_xy_pair eth_core) {
+uint64_t TopologyDiscoveryBlackhole::get_remote_board_type(TTDevice* tt_device, tt_xy_pair eth_core) {
     // This function is not important for Blackhole, so we can return any value here.
     return 0;
 }
 
-uint32_t TopologyDiscoveryBlackhole::get_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) {
-    return get_remote_eth_id(chip, local_eth_core);
+uint32_t TopologyDiscoveryBlackhole::get_remote_eth_channel(TTDevice* tt_device, tt_xy_pair local_eth_core) {
+    return get_remote_eth_id(tt_device, local_eth_core);
 }
 
-uint32_t TopologyDiscoveryBlackhole::get_logical_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) {
-    auto fw_bundle_version = chip->get_tt_device()->get_firmware_version();
-    auto translated_eth_core = chip->get_soc_descriptor().translate_coord_to(
+uint32_t TopologyDiscoveryBlackhole::get_logical_remote_eth_channel(TTDevice* tt_device, tt_xy_pair local_eth_core) {
+    auto translated_eth_core = get_soc_descriptor(tt_device).translate_coord_to(
         local_eth_core, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0, CoordSystem::TRANSLATED);
     uint8_t remote_logical_eth_id;
-    chip->get_tt_device()->read_from_device(
-        &remote_logical_eth_id, translated_eth_core, 0x7CFE3, sizeof(remote_logical_eth_id));
+    tt_device->read_from_device(&remote_logical_eth_id, translated_eth_core, 0x7CFE3, sizeof(remote_logical_eth_id));
 
     // For FW Versions older than 18.12.0, querying remote eth channels in logical space is only supported
     // for P150 Board Types (with a  SW workaround).
-    if (fw_bundle_version >= semver_t(18, 12, 0)) {
+    if (first_fw_bundle_version >= semver_t(18, 12, 0)) {
         return remote_logical_eth_id;
     }
-    if (chip->get_chip_info().board_type != BoardType::P150) {
+    if (tt_device->get_chip_info().board_type != BoardType::P150) {
         throw std::runtime_error(
             "Querying Logical Eth Channels on a Remote Host is only supported for P150 Board Types.");
     }
@@ -192,31 +187,31 @@ uint64_t TopologyDiscoveryBlackhole::mangle_asic_id(uint64_t board_id, uint8_t a
     return ((board_id << 5) | (asic_location & 0x1F));
 }
 
-bool TopologyDiscoveryBlackhole::is_eth_trained(Chip* chip, const tt_xy_pair eth_core) {
-    return read_port_status(chip, eth_core) == blackhole::port_status_e::PORT_UP;
+bool TopologyDiscoveryBlackhole::is_eth_trained(TTDevice* tt_device, const tt_xy_pair eth_core) {
+    return read_port_status(tt_device, eth_core) == blackhole::port_status_e::PORT_UP;
 }
 
 void TopologyDiscoveryBlackhole::patch_eth_connections() {
     std::set<std::pair<std::pair<uint64_t, uint32_t>, std::pair<uint64_t, uint32_t>>> ethernet_connections_fixed;
     for (auto& eth_connections_original : ethernet_connections) {
-        auto& [local_chip, local_channel] = eth_connections_original.first;
-        auto& [remote_chip, remote_channel] = eth_connections_original.second;
+        auto& [local_device, local_channel] = eth_connections_original.first;
+        auto& [remote_device, remote_channel] = eth_connections_original.second;
 
-        Chip* remote_chip_ptr = get_chip(remote_chip);
+        TTDevice* remote_device_ptr = get_tt_device(remote_device);
 
         auto eth_core_noc0 = blackhole::ETH_CORES_NOC0[remote_channel];
         CoreCoord eth_core_coord = CoreCoord(eth_core_noc0.x, eth_core_noc0.y, CoreType::ETH, CoordSystem::NOC0);
         CoreCoord logical_coord =
-            remote_chip_ptr->get_soc_descriptor().translate_coord_to(eth_core_coord, CoordSystem::LOGICAL);
+            get_soc_descriptor(remote_device_ptr).translate_coord_to(eth_core_coord, CoordSystem::LOGICAL);
 
-        ethernet_connections_fixed.insert({{local_chip, local_channel}, {remote_chip, logical_coord.y}});
+        ethernet_connections_fixed.insert({{local_device, local_channel}, {remote_device, logical_coord.y}});
     }
 
     ethernet_connections.clear();
     for (auto& eth_connections_fixed : ethernet_connections_fixed) {
-        auto& [local_chip, local_channel] = eth_connections_fixed.first;
-        auto& [remote_chip, remote_channel] = eth_connections_fixed.second;
-        ethernet_connections.push_back({{local_chip, local_channel}, {remote_chip, remote_channel}});
+        auto& [local_device, local_channel] = eth_connections_fixed.first;
+        auto& [remote_device, remote_channel] = eth_connections_fixed.second;
+        ethernet_connections.push_back({{local_device, local_channel}, {remote_device, remote_channel}});
     }
 }
 
@@ -251,7 +246,9 @@ void TopologyDiscoveryBlackhole::init_topology_discovery() {
     is_running_on_6u = tt_device->get_board_type() == BoardType::UBB_BLACKHOLE;
 }
 
-bool TopologyDiscoveryBlackhole::verify_eth_core_fw_version(Chip* chip, CoreCoord eth_core) {
+bool TopologyDiscoveryBlackhole::verify_eth_core_fw_version(TTDevice* tt_device, tt_xy_pair eth_core) {
+    tt_xy_pair translated_eth_core = get_soc_descriptor(tt_device).translate_coord_to(
+        eth_core, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0, CoordSystem::TRANSLATED);
     static constexpr uint64_t eth_fw_major_addr = 0x7CFBE;
     static constexpr uint64_t eth_fw_minor_addr = 0x7CFBD;
     static constexpr uint64_t eth_fw_patch_addr = 0x7CFBC;
@@ -259,9 +256,9 @@ bool TopologyDiscoveryBlackhole::verify_eth_core_fw_version(Chip* chip, CoreCoor
     uint8_t minor = 0;
     uint8_t patch = 0;
 
-    chip->read_from_device(eth_core, &major, eth_fw_major_addr, sizeof(uint8_t));
-    chip->read_from_device(eth_core, &minor, eth_fw_minor_addr, sizeof(uint8_t));
-    chip->read_from_device(eth_core, &patch, eth_fw_patch_addr, sizeof(uint8_t));
+    tt_device->read_from_device(&major, translated_eth_core, eth_fw_major_addr, sizeof(uint8_t));
+    tt_device->read_from_device(&minor, translated_eth_core, eth_fw_minor_addr, sizeof(uint8_t));
+    tt_device->read_from_device(&patch, translated_eth_core, eth_fw_patch_addr, sizeof(uint8_t));
     semver_t eth_fw_version = semver_t(major, minor, patch);
 
     bool eth_fw_problem = false;
@@ -284,22 +281,20 @@ bool TopologyDiscoveryBlackhole::verify_eth_core_fw_version(Chip* chip, CoreCoor
     if (eth_fw_version != expected_eth_fw_version) {
         log_warning(
             LogUMD,
-            "ETH FW version mismatch for chip {} ETH core {}, found: {}.",
-            get_local_asic_id(chip, eth_core),
+            "ETH FW version mismatch for device {} ETH core {}, found: {}.",
+            get_local_asic_id(tt_device, eth_core),
             eth_core.str(),
             eth_fw_version.to_string());
         eth_fw_problem = true;
     }
 
-    if (options.verify_eth_fw_hash && chip->is_mmio_capable()) {
-        tt_xy_pair translated_eth_core = chip->get_soc_descriptor().translate_coord_to(
-            eth_core, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0, CoordSystem::TRANSLATED);
-        auto hash_check = verify_eth_fw_integrity(chip->get_tt_device(), translated_eth_core, eth_fw_version);
+    if (options.verify_eth_fw_hash && !tt_device->is_remote()) {
+        auto hash_check = verify_eth_fw_integrity(tt_device, translated_eth_core, eth_fw_version);
         if (hash_check.has_value() && hash_check.value() == false) {
             log_warning(
                 LogUMD,
-                "ETH FW version hash check failed for chip {} ETH core {}",
-                get_local_asic_id(chip, eth_core),
+                "ETH FW version hash check failed for device {} ETH core {}",
+                get_local_asic_id(tt_device, eth_core),
                 eth_core.str());
             eth_fw_problem = true;
         }
@@ -308,13 +303,14 @@ bool TopologyDiscoveryBlackhole::verify_eth_core_fw_version(Chip* chip, CoreCoor
     return options.no_eth_firmware_strictness || !eth_fw_problem;
 }
 
-uint64_t TopologyDiscoveryBlackhole::get_unconnected_chip_id(Chip* chip) {
-    TTDevice* tt_device = chip->get_tt_device();
+uint64_t TopologyDiscoveryBlackhole::get_unconnected_device_id(TTDevice* tt_device) {
     uint32_t asic_id_lo = tt_device->get_arc_telemetry_reader()->read_entry(TelemetryTag::ASIC_ID_LOW);
     uint32_t asic_id_hi = tt_device->get_arc_telemetry_reader()->read_entry(TelemetryTag::ASIC_ID_HIGH);
     return (static_cast<uint64_t>(asic_id_hi) << 32) | asic_id_lo;
 }
 
-bool TopologyDiscoveryBlackhole::verify_routing_firmware_state(Chip* chip, const tt_xy_pair eth_core) { return true; }
+bool TopologyDiscoveryBlackhole::verify_routing_firmware_state(TTDevice* tt_device, const tt_xy_pair eth_core) {
+    return true;
+}
 
 }  // namespace tt::umd

--- a/device/topology/topology_discovery_wormhole.cpp
+++ b/device/topology/topology_discovery_wormhole.cpp
@@ -12,9 +12,12 @@
 #include "assert.hpp"
 #include "umd/device/firmware/erisc_firmware.hpp"
 #include "umd/device/firmware/firmware_utils.hpp"
+#include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
+#include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/semver.hpp"
+#include "wormhole/eth_l1_address_map.h"
 
 namespace tt::umd {
 
@@ -74,13 +77,12 @@ TopologyDiscoveryWormhole::EthAddresses TopologyDiscoveryWormhole::get_eth_addre
         erisc_remote_eth_id_offset};
 }
 
-uint64_t TopologyDiscoveryWormhole::get_remote_board_id(Chip* chip, tt_xy_pair eth_core) {
+uint64_t TopologyDiscoveryWormhole::get_remote_board_id(TTDevice* tt_device, tt_xy_pair eth_core) {
     if (is_running_on_6u) {
         // See comment in get_local_board_id.
-        return get_remote_asic_id(chip, eth_core);
+        return get_remote_asic_id(tt_device, eth_core);
     }
 
-    TTDevice* tt_device = chip->get_tt_device();
     uint32_t board_id;
     tt_device->read_from_device(
         &board_id,
@@ -90,24 +92,22 @@ uint64_t TopologyDiscoveryWormhole::get_remote_board_id(Chip* chip, tt_xy_pair e
     return board_id;
 }
 
-uint64_t TopologyDiscoveryWormhole::get_local_board_id(Chip* chip, tt_xy_pair eth_core) {
+uint64_t TopologyDiscoveryWormhole::get_local_board_id(TTDevice* tt_device, tt_xy_pair eth_core) {
     if (is_running_on_6u) {
         // For 6U, since the whole trays have the same board ID, and we'd want to be able to open
         // only some chips, we hack the board_id to be the asic ID. That way, the pci_target_devices filter
         // from the ClusterOptions will work correctly on 6U.
         // Note that the board_id will still be reported properly in the cluster descriptor, since it is
         // fetched through another function when cluster descriptor is being filled up.
-        return get_local_asic_id(chip, eth_core);
+        return get_local_asic_id(tt_device, eth_core);
     }
 
-    TTDevice* tt_device = chip->get_tt_device();
     // WH-ERISC mangles the ARC board id into 32 bits, just enough to be uniquely identifying.
     uint64_t board_id = tt_device->get_board_id();
     return ((board_id >> 4) & 0xF0000000) | (board_id & 0x0FFFFFFF);
 }
 
-uint64_t TopologyDiscoveryWormhole::get_remote_board_type(Chip* chip, tt_xy_pair eth_core) {
-    TTDevice* tt_device = chip->get_tt_device();
+uint64_t TopologyDiscoveryWormhole::get_remote_board_type(TTDevice* tt_device, tt_xy_pair eth_core) {
     uint32_t board_id;
     tt_device->read_from_device(
         &board_id,
@@ -117,8 +117,7 @@ uint64_t TopologyDiscoveryWormhole::get_remote_board_type(Chip* chip, tt_xy_pair
     return board_id;
 }
 
-uint64_t TopologyDiscoveryWormhole::get_local_asic_id(Chip* chip, tt_xy_pair eth_core) {
-    TTDevice* tt_device = chip->get_tt_device();
+uint64_t TopologyDiscoveryWormhole::get_local_asic_id(TTDevice* tt_device, tt_xy_pair eth_core) {
     uint32_t asic_id_lo;
     tt_device->read_from_device(
         &asic_id_lo,
@@ -134,8 +133,7 @@ uint64_t TopologyDiscoveryWormhole::get_local_asic_id(Chip* chip, tt_xy_pair eth
     return ((static_cast<uint64_t>(asic_id_hi) << 32) | asic_id_lo);
 }
 
-uint64_t TopologyDiscoveryWormhole::get_remote_asic_id(Chip* chip, tt_xy_pair eth_core) {
-    TTDevice* tt_device = chip->get_tt_device();
+uint64_t TopologyDiscoveryWormhole::get_remote_asic_id(TTDevice* tt_device, tt_xy_pair eth_core) {
     uint32_t asic_id_lo;
     tt_device->read_from_device(
         &asic_id_lo,
@@ -151,9 +149,8 @@ uint64_t TopologyDiscoveryWormhole::get_remote_asic_id(Chip* chip, tt_xy_pair et
     return ((static_cast<uint64_t>(asic_id_hi) << 32) | asic_id_lo);
 }
 
-tt_xy_pair TopologyDiscoveryWormhole::get_remote_eth_core(Chip* chip, tt_xy_pair local_eth_core) {
+tt_xy_pair TopologyDiscoveryWormhole::get_remote_eth_core(TTDevice* tt_device, tt_xy_pair local_eth_core) {
     const uint32_t shelf_offset = 9;
-    TTDevice* tt_device = chip->get_tt_device();
     uint32_t remote_id;
     tt_device->read_from_device(
         &remote_id,
@@ -164,20 +161,18 @@ tt_xy_pair TopologyDiscoveryWormhole::get_remote_eth_core(Chip* chip, tt_xy_pair
     return tt_xy_pair{(remote_id >> 4) & 0x3F, (remote_id >> 10) & 0x3F};
 }
 
-uint32_t TopologyDiscoveryWormhole::read_training_status(Chip* chip, tt_xy_pair eth_core) {
+uint32_t TopologyDiscoveryWormhole::read_training_status(TTDevice* tt_device, tt_xy_pair eth_core) {
     uint32_t training_status;
-    TTDevice* tt_device = chip->get_tt_device();
     tt_device->read_from_device(&training_status, eth_core, 0x1104, sizeof(uint32_t));
     return training_status;
 }
 
-uint32_t TopologyDiscoveryWormhole::get_remote_eth_id(Chip* chip, tt_xy_pair local_eth_core) {
+uint32_t TopologyDiscoveryWormhole::get_remote_eth_id(TTDevice* tt_device, tt_xy_pair local_eth_core) {
     if (!is_running_on_6u) {
         throw std::runtime_error(
             "get_remote_eth_id should not be called on non-6U configurations. This message likely indicates a bug.");
     }
     uint32_t remote_eth_id;
-    TTDevice* tt_device = chip->get_tt_device();
     tt_device->read_from_device(
         &remote_eth_id,
         local_eth_core,
@@ -186,26 +181,24 @@ uint32_t TopologyDiscoveryWormhole::get_remote_eth_id(Chip* chip, tt_xy_pair loc
     return remote_eth_id;
 }
 
-std::optional<EthCoord> TopologyDiscoveryWormhole::get_local_eth_coord(Chip* chip, tt_xy_pair eth_core) {
-    TTDevice* tt_device = chip->get_tt_device();
-
-    uint32_t current_chip_eth_coord_info;
-    tt_device->read_from_device(&current_chip_eth_coord_info, eth_core, eth_addresses.node_info + 8, sizeof(uint32_t));
+std::optional<EthCoord> TopologyDiscoveryWormhole::get_local_eth_coord(TTDevice* tt_device, tt_xy_pair eth_core) {
+    uint32_t current_device_eth_coord_info;
+    tt_device->read_from_device(
+        &current_device_eth_coord_info, eth_core, eth_addresses.node_info + 8, sizeof(uint32_t));
 
     EthCoord eth_coord;
     eth_coord.cluster_id = 0;
-    eth_coord.x = (current_chip_eth_coord_info >> 16) & 0xFF;
-    eth_coord.y = (current_chip_eth_coord_info >> 24) & 0xFF;
-    eth_coord.rack = current_chip_eth_coord_info & 0xFF;
-    eth_coord.shelf = (current_chip_eth_coord_info >> 8) & 0xFF;
+    eth_coord.x = (current_device_eth_coord_info >> 16) & 0xFF;
+    eth_coord.y = (current_device_eth_coord_info >> 24) & 0xFF;
+    eth_coord.rack = current_device_eth_coord_info & 0xFF;
+    eth_coord.shelf = (current_device_eth_coord_info >> 8) & 0xFF;
 
     return eth_coord;
 }
 
-std::optional<EthCoord> TopologyDiscoveryWormhole::get_remote_eth_coord(Chip* chip, tt_xy_pair eth_core) {
+std::optional<EthCoord> TopologyDiscoveryWormhole::get_remote_eth_coord(TTDevice* tt_device, tt_xy_pair eth_core) {
     const uint32_t shelf_offset = 9;
     const uint32_t rack_offset = 10;
-    TTDevice* tt_device = chip->get_tt_device();
     EthCoord eth_coord;
     eth_coord.cluster_id = 0;
     uint32_t remote_id;
@@ -224,32 +217,35 @@ std::optional<EthCoord> TopologyDiscoveryWormhole::get_remote_eth_coord(Chip* ch
     return eth_coord;
 }
 
-std::unique_ptr<RemoteChip> TopologyDiscoveryWormhole::create_remote_chip(
-    std::optional<EthCoord> eth_coord, Chip* gateway_chip, std::set<uint32_t> gateway_eth_channels) {
+std::unique_ptr<TTDevice> TopologyDiscoveryWormhole::create_remote_device(
+    std::optional<EthCoord> eth_coord, TTDevice* gateway_device, std::set<uint32_t> gateway_eth_channels) {
     if (is_running_on_6u) {
         return nullptr;
     }
-    EthCoord remote_chip_eth_coord = eth_coord.has_value() ? eth_coord.value() : EthCoord{0, 0, 0, 0};
+    EthCoord remote_device_eth_coord = eth_coord.has_value() ? eth_coord.value() : EthCoord{0, 0, 0, 0};
 
-    return RemoteChip::create(
-        dynamic_cast<LocalChip*>(gateway_chip),
-        remote_chip_eth_coord,
-        gateway_eth_channels,
-        options.soc_descriptor_path);
+    std::unique_ptr<RemoteCommunication> remote_communication =
+        RemoteCommunication::create_remote_communication(gateway_device, remote_device_eth_coord);
+    remote_communication->set_remote_transfer_ethernet_cores(
+        get_soc_descriptor(gateway_device)
+            .get_eth_xy_pairs_for_channels(gateway_eth_channels, CoordSystem::TRANSLATED));
+    std::unique_ptr<TTDevice> remote_tt_device = TTDevice::create(std::move(remote_communication));
+    remote_tt_device->init_tt_device();
+    return remote_tt_device;
 }
 
-uint32_t TopologyDiscoveryWormhole::get_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) {
+uint32_t TopologyDiscoveryWormhole::get_remote_eth_channel(TTDevice* tt_device, tt_xy_pair local_eth_core) {
     if (is_running_on_6u) {
-        return get_remote_eth_id(chip, local_eth_core);
+        return get_remote_eth_id(tt_device, local_eth_core);
     }
-    tt_xy_pair remote_eth_core = get_remote_eth_core(chip, local_eth_core);
+    tt_xy_pair remote_eth_core = get_remote_eth_core(tt_device, local_eth_core);
 
     // TODO(pjanevski): explain in comment why we are using chip instead of remote chip.
-    return chip->get_soc_descriptor().translate_coord_to(remote_eth_core, CoordSystem::NOC0, CoordSystem::LOGICAL).y;
+    return get_soc_descriptor(tt_device).translate_coord_to(remote_eth_core, CoordSystem::NOC0, CoordSystem::LOGICAL).y;
 }
 
-uint32_t TopologyDiscoveryWormhole::get_logical_remote_eth_channel(Chip* chip, tt_xy_pair local_eth_core) {
-    return get_remote_eth_channel(chip, local_eth_core);
+uint32_t TopologyDiscoveryWormhole::get_logical_remote_eth_channel(TTDevice* tt_device, tt_xy_pair local_eth_core) {
+    return get_remote_eth_channel(tt_device, local_eth_core);
 }
 
 bool TopologyDiscoveryWormhole::is_using_eth_coords() { return !is_running_on_6u; }
@@ -309,13 +305,14 @@ bool TopologyDiscoveryWormhole::is_board_id_included(uint64_t board_id, uint64_t
     return board_ids.find(board_id) != board_ids.end();
 }
 
-bool TopologyDiscoveryWormhole::is_eth_trained(Chip* chip, const tt_xy_pair eth_core) {
-    return read_training_status(chip, eth_core) == LINK_TRAIN_SUCCESS;
+bool TopologyDiscoveryWormhole::is_eth_trained(TTDevice* tt_device, const tt_xy_pair eth_core) {
+    return read_training_status(tt_device, eth_core) == LINK_TRAIN_SUCCESS;
 }
 
-bool TopologyDiscoveryWormhole::verify_eth_core_fw_version(Chip* chip, CoreCoord eth_core) {
+bool TopologyDiscoveryWormhole::verify_eth_core_fw_version(TTDevice* tt_device, tt_xy_pair eth_core) {
     uint32_t eth_fw_version_read;
-    chip->read_from_device(eth_core, &eth_fw_version_read, chip->l1_address_params.fw_version_addr, sizeof(uint32_t));
+    tt_device->read_from_device(
+        &eth_fw_version_read, eth_core, eth_l1_mem::address_map::FW_VERSION_ADDR, sizeof(uint32_t));
 
     semver_t eth_fw_version = semver_t::from_wormhole_eth_firmware_tag(eth_fw_version_read);
 
@@ -339,20 +336,20 @@ bool TopologyDiscoveryWormhole::verify_eth_core_fw_version(Chip* chip, CoreCoord
     if (eth_fw_version != expected_eth_fw_version) {
         log_warning(
             LogUMD,
-            "ETH FW version mismatch for chip {} ETH core {}, found: {}.",
-            get_local_asic_id(chip, eth_core),
+            "ETH FW version mismatch for device {} ETH core {}, found: {}.",
+            get_local_asic_id(tt_device, eth_core),
             eth_core.str(),
             eth_fw_version.to_string());
         eth_fw_problem = true;
     }
 
     if (options.verify_eth_fw_hash) {
-        auto hash_check = verify_eth_fw_integrity(chip->get_tt_device(), eth_core, eth_fw_version);
+        auto hash_check = verify_eth_fw_integrity(tt_device, eth_core, eth_fw_version);
         if (hash_check.has_value() && hash_check.value() == false) {
             log_warning(
                 LogUMD,
-                "ETH FW version hash check failed for chip {} ETH core {}",
-                get_local_asic_id(chip, eth_core),
+                "ETH FW version hash check failed for device {} ETH core {}",
+                get_local_asic_id(tt_device, eth_core),
                 eth_core.str());
             eth_fw_problem = true;
         }
@@ -361,19 +358,16 @@ bool TopologyDiscoveryWormhole::verify_eth_core_fw_version(Chip* chip, CoreCoord
     return options.no_eth_firmware_strictness || !eth_fw_problem;
 }
 
-uint64_t TopologyDiscoveryWormhole::get_unconnected_chip_id(Chip* chip) {
-    return chip->get_tt_device()->get_board_id();
-}
+uint64_t TopologyDiscoveryWormhole::get_unconnected_device_id(TTDevice* tt_device) { return tt_device->get_board_id(); }
 
-bool TopologyDiscoveryWormhole::verify_routing_firmware_state(Chip* chip, const tt_xy_pair eth_core) {
+bool TopologyDiscoveryWormhole::verify_routing_firmware_state(TTDevice* tt_device, const tt_xy_pair eth_core) {
     uint32_t routing_firmware_disabled;
-    TTDevice* tt_device = chip->get_tt_device();
     tt_device->read_from_device(
         &routing_firmware_disabled, eth_core, eth_addresses.routing_firmware_state, sizeof(uint32_t));
     if (is_running_on_6u && routing_firmware_disabled == 0) {
         auto message = fmt::format(
-            "Routing FW on 6U unexpectedly enabled on chip {} core {}.",
-            get_local_asic_id(chip, eth_core),
+            "Routing FW on 6U unexpectedly enabled on device {} core {}.",
+            get_local_asic_id(tt_device, eth_core),
             eth_core.str());
         if (options.no_eth_firmware_strictness) {
             log_warning(LogUMD, message);
@@ -382,7 +376,9 @@ bool TopologyDiscoveryWormhole::verify_routing_firmware_state(Chip* chip, const 
         TT_THROW(message);
     } else if (!is_running_on_6u && routing_firmware_disabled == 1) {
         auto message = fmt::format(
-            "Routing FW unexpectedly disabled on chip {} core {}.", get_local_asic_id(chip, eth_core), eth_core.str());
+            "Routing FW unexpectedly disabled on device {} core {}.",
+            get_local_asic_id(tt_device, eth_core),
+            eth_core.str());
         if (options.no_eth_firmware_strictness) {
             log_warning(LogUMD, message);
             return false;


### PR DESCRIPTION
### Issue
#1548 

### Description
Use TTDevice instead of Chip in TopologyDiscovery

### List of the changes
See #1696 and #1806

### Testing
CI, tested before revert.

### API Changes
There are no API changes in this PR.
