### PR TITLE
Fix 6u secondary reset

### DIFF
--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -199,6 +199,7 @@ PciDeviceInfo PCIDevice::read_device_info(int fd) {
 
 static void reset_device_ioctl(const std::unordered_set<int> &pci_target_devices, uint32_t flags) {
     for (int n : PCIDevice::enumerate_devices(pci_target_devices)) {
+        log_debug(tt::LogUMD, "Issuing reset ioctl on PCI device ID {} with flags {}", n, flags);
         int fd = open(fmt::format("/dev/tenstorrent/{}", n).c_str(), O_RDWR | O_CLOEXEC | O_APPEND);
         if (fd == -1) {
             continue;

--- a/device/warm_reset.cpp
+++ b/device/warm_reset.cpp
@@ -41,10 +41,11 @@ void WarmReset::warm_reset(std::vector<int> pci_device_ids, bool reset_m3, bool 
         pci_device_ids = PCIDevice::enumerate_devices();
     }
 
+    log_info(tt::LogUMD, "Notifying all listeners of impending warm reset.");
     WarmResetCommunication::Notifier::notify_all_listeners_pre_reset(std::chrono::milliseconds(2000));
 
     if (PCIDevice::is_arch_agnostic_reset_supported()) {
-        warm_reset_arch_agnostic(pci_device_ids, reset_m3);
+        warm_reset_arch_agnostic(pci_device_ids, reset_m3, timeout::WARM_RESET_M3_TIMEOUT, secondary_bus_reset);
     } else if (auto enumerate_devices = PCIDevice::enumerate_devices_info(); enumerate_devices.empty()) {
         // Re-enumerate here as a safety net for potential race conditions where devices disappear
         // between the pre-reset notification and now. Clients are still guaranteed to receive the
@@ -69,6 +70,7 @@ void WarmReset::warm_reset(std::vector<int> pci_device_ids, bool reset_m3, bool 
         }
     }
 
+    log_info(tt::LogUMD, "Notifying all listeners of completed warm reset.");
     WarmResetCommunication::Notifier::notify_all_listeners_post_reset();
 }
 


### PR DESCRIPTION
### Issue
Fixing issue introduced by https://github.com/tenstorrent/tt-umd/pull/1773

### Description
This change mistakenly drops some arguments (likely after a rebase).
The effect was that secondary_bus_reset argument started being ignored, leading to warm reset again taking ~6min on 6u instead of 1min.

### List of the changes
- Revert arguments to warm_reset_agnostic method
- Added a few logs that helped me debug and could be useful.

### Testing
On this PR, it takes 1min: https://github.com/tenstorrent/tt-umd/actions/runs/21292215069/job/61289034264?pr=1896#step:7:26
Previously it took 6min: https://github.com/tenstorrent/tt-umd/actions/runs/21283969115/job/61260921026#step:7:26

### API Changes
There are no API changes in this PR.
