### PR TITLE
Remove Grayskull End of Life section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,3 @@ There is an automated workflow for creating releases. It is triggered by merging
 You can change the VERSION as part of another PR or as an isolated PR. Please also update the CHANGELOG with the exact version you are changeing to.
 
 Once the PR is merged, a draft Release will be created with the generated changelog and artifacts. Please review it and publish it using the tag which exactly matches the version of the release.
-
-# Grayskull End of Life
-
-Grayskull is no longer actively supported by Tenstorrent. [Last UMD commit](https://github.com/tenstorrent/tt-umd/commit/a5b4719b7d44f0c7c953542803faf6851574329a) supporting Grayskull.


### PR DESCRIPTION
I don’t think we need to talk about Grayskull anymore.

### Issue
https://github.com/tenstorrent/tt-umd/issues/567

### Description
(Add freeform description.)

### List of the changes
(Itemized list of all the changes.)

### Testing
(Comment on CI testing or Manual testing touching this change.)

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
