### PR TITLE
Fix build problem in verify_eth_core_fw_version()

### DIFF
--- a/device/topology/topology_discovery_wormhole.cpp
+++ b/device/topology/topology_discovery_wormhole.cpp
@@ -318,7 +318,7 @@ bool TopologyDiscoveryWormhole::verify_eth_core_fw_version(TTDevice* tt_device, 
 
     bool eth_fw_problem = false;
     if (!expected_eth_fw_version.has_value()) {
-        expected_eth_fw_version = chip->get_tt_device()->get_firmware_info_provider()->get_eth_fw_version_semver();
+        expected_eth_fw_version = tt_device->get_firmware_info_provider()->get_eth_fw_version_semver();
         if (expected_eth_fw_version.has_value()) {
             log_debug(LogUMD, "Expected ETH FW version from telemetry: {}", expected_eth_fw_version->to_string());
         } else {


### PR DESCRIPTION
### Issue
#1861

### Description
Fix build issue in TopologyDiscovery.

### List of the changes
- Use TTDevice instead of Chip in verify_eth_core_fw_version()

### Testing
CI

### API Changes
There are no API changes in this PR.
