### PR TITLE
Refactor init_topology_discovery() 

### DIFF
--- a/device/api/umd/device/topology/topology_discovery.hpp
+++ b/device/api/umd/device/topology/topology_discovery.hpp
@@ -67,7 +67,7 @@ protected:
     std::unique_ptr<ClusterDescriptor> fill_cluster_descriptor_info();
 
     virtual void wait_eth_cores_training(
-        TTDevice* tt_device, const std::chrono::milliseconds timeout_ms = timeout::ETH_TRAINING_TIMEOUT);
+        TTDevice* tt_device, std::chrono::milliseconds timeout_ms = timeout::ETH_TRAINING_TIMEOUT);
 
     // board_type is not used for all configs.
     // We need to know that we are seeing TG board and that we should include it in the topology.
@@ -126,7 +126,8 @@ protected:
 
     TTDevice* get_tt_device(const uint64_t asic_id);
 
-    virtual void init_topology_discovery();
+    // Configure some TopologyDiscovery paramaters from first discovered device.
+    virtual void init_first_device(TTDevice* tt_device) = 0;
 
     virtual bool is_eth_trained(TTDevice* tt_device, const tt_xy_pair eth_core) = 0;
 

--- a/device/api/umd/device/topology/topology_discovery_blackhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_blackhole.hpp
@@ -56,7 +56,7 @@ protected:
 
     void patch_eth_connections() override;
 
-    void init_topology_discovery() override;
+    void init_first_device(TTDevice* tt_device) override;
 
     bool verify_eth_core_fw_version(TTDevice* tt_device, tt_xy_pair eth_core) override;
 };

--- a/device/api/umd/device/topology/topology_discovery_wormhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_wormhole.hpp
@@ -65,7 +65,7 @@ protected:
 
     bool is_using_eth_coords() override;
 
-    void init_topology_discovery() override;
+    void init_first_device(TTDevice* tt_device) override;
 
     bool is_eth_trained(TTDevice* tt_device, const tt_xy_pair eth_core) override;
 

--- a/device/topology/topology_discovery_blackhole.cpp
+++ b/device/topology/topology_discovery_blackhole.cpp
@@ -215,34 +215,7 @@ void TopologyDiscoveryBlackhole::patch_eth_connections() {
     }
 }
 
-void TopologyDiscoveryBlackhole::init_topology_discovery() {
-    int device_id = 0;
-    switch (options.io_device_type) {
-        case IODeviceType::JTAG: {
-            auto device_cnt = JtagDevice::create()->get_device_cnt();
-            if (!device_cnt) {
-                return;
-            }
-            // JTAG devices (j-links) are referred to with their index within a vector
-            // that's stored inside of a JtagDevice object.
-            // That index is completely different from the actual JTAG device id.
-            // So no matter how many JTAG devices (j-links) are present, the one with index 0 will be used here.
-            break;
-        }
-        case IODeviceType::PCIe: {
-            std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-            if (pci_device_ids.empty()) {
-                return;
-            }
-            device_id = pci_device_ids[0];
-            break;
-        }
-        default:
-            TT_THROW("Unsupported IODeviceType during topology discovery.");
-    }
-
-    std::unique_ptr<TTDevice> tt_device = TTDevice::create(device_id, options.io_device_type);
-    tt_device->init_tt_device();
+void TopologyDiscoveryBlackhole::init_first_device(TTDevice* tt_device) {
     is_running_on_6u = tt_device->get_board_type() == BoardType::UBB_BLACKHOLE;
 }
 


### PR DESCRIPTION
### Issue
/

### Description
Removes duplicated code and initialization from init_topology_discovery() and place the equivalent logic in get_connected_devices().

### List of the changes
- Remove duplicated code in init_topology_discovery()
- Remove double or triple creating of TTDevice in  init_topology_discovery().
- Rename init_topology_discovery() to init_first_device().

### Testing
CI

### API Changes
There are no API changes in this PR.
