### PR TITLE
Split copilot autofix into separate workflow

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -16,16 +16,6 @@ on:
         required: false
         type: string
         default: ""
-      enable-copilot-fix:
-        description: "Enable Copilot to automatically fix ClangSA issues and create a PR"
-        required: false
-        type: boolean
-        default: false
-      copilot-max-fixes:
-        description: "Maximum number of issues for Copilot to fix"
-        required: false
-        type: string
-        default: ""
 
 jobs:
   clang-static-analyzer:
@@ -143,146 +133,8 @@ jobs:
           name: CodeChecker-HTML-Report
           path: /work/.build/codechecker_html
 
-  copilot-fix-clangsa-issue:
-    name: 🤖 Copilot Fix ClangSA Issue
-    needs: [clang-static-analyzer]
-    if: |
-      always() &&
-      (inputs.enable-copilot-fix == true || github.event_name == 'schedule') &&
-      needs.clang-static-analyzer.result == 'success'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    outputs:
-      pr-url: ${{ steps.copilot-fix.outputs.pr-url }}
-      pr-created: ${{ steps.copilot-fix.outputs.pr-created }}
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install GitHub CLI for Copilot integration
-        run: |
-          # Install gh CLI if not present
-          if ! command -v gh &> /dev/null; then
-            type -p curl >/dev/null || (apt update && apt install -y curl)
-            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
-              dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-            chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-            echo "deb [arch=$(dpkg --print-architecture) \
-              signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
-              https://cli.github.com/packages stable main" | \
-              tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-            apt update && apt install -y gh
-          fi
-
-      - name: Download CodeChecker JSON report
-        uses: actions/download-artifact@v4
-        with:
-          name: CodeChecker-JSON-Report
-          path: /tmp
-
-      - name: Check for issues and run Copilot fix
-        id: copilot-fix
-        timeout-minutes: 30
-        env:
-          COPILOT_OAUTH_TOKEN: ${{ secrets.COPILOT_OAUTH_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          # Authenticate first (required for all gh commands)
-          if [ -z "$COPILOT_OAUTH_TOKEN" ]; then
-            echo "::error::COPILOT_OAUTH_TOKEN secret not set. \
-              Run 'gh auth login' locally, then 'gh auth token' and add as secret."
-            exit 1
-          fi
-          echo "$COPILOT_OAUTH_TOKEN" | gh auth login --with-token
-
-          # Check for issues
-          if [ ! -f "/tmp/codechecker_issues.json" ]; then
-            echo "No issues found"
-            echo "has-issues=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          ISSUE_COUNT=$(jq '.reports | length' /tmp/codechecker_issues.json 2>/dev/null || echo "0")
-          if [ "$ISSUE_COUNT" = "0" ]; then
-            echo "No issues found"
-            echo "has-issues=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Found $ISSUE_COUNT issues"
-          echo "has-issues=true" >> "$GITHUB_OUTPUT"
-
-          # Check for existing open Copilot PRs to avoid duplicates
-          OPEN_COPILOT_PRS=$(gh pr list --repo "${{ github.repository }}" \
-            --state open --label "copilot-autofix" --json number --jq 'length' 2>/dev/null || echo "0")
-          if [ "$OPEN_COPILOT_PRS" -gt 0 ]; then
-            echo "⏭️ Skipping: $OPEN_COPILOT_PRS open Copilot PR(s) already exist"
-            echo "Review and merge existing PRs before creating new ones."
-            echo "has-issues=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Build prompt - default to 1 issue for focused, quality fixes
-          LIMIT="${{ inputs.copilot-max-fixes }}"
-          LIMIT="${LIMIT:-1}"  # Default: 1 issue per run
-
-          {
-            echo "Fix these Clang Static Analyzer issues:"
-            echo ""
-            jq -r --argjson limit "$LIMIT" \
-              '.reports[:$limit][] |
-               "- \(.checker_name) in \(.file.path | sub("^/work/"; "")):\(.line) — \(.message)"' \
-              /tmp/codechecker_issues.json
-            echo ""
-            echo "For each: verify it's real, apply minimal fix, follow coding standards."
-          } > /tmp/prompt.txt
-
-          cat /tmp/prompt.txt
-
-          # Run Copilot
-          BASE_BRANCH="${{ github.event_name == 'schedule' && 'main' || github.ref_name }}"
-
-          gh agent-task create -F /tmp/prompt.txt \
-            --base "$BASE_BRANCH" \
-            --repo "${{ github.repository }}" \
-            --follow
-
-          # Get the PR that was created
-          PR_NUMBER=$(gh agent-task list --limit 1 | grep -oE '#[0-9]+' | tr -d '#' || true)
-
-          if [ -n "$PR_NUMBER" ]; then
-            echo "pr-url=https://github.com/${{ github.repository }}/pull/${PR_NUMBER}" >> "$GITHUB_OUTPUT"
-            echo "pr-created=true" >> "$GITHUB_OUTPUT"
-            # Add label to track Copilot PRs and prevent duplicates
-            gh pr edit "$PR_NUMBER" -R "${{ github.repository }}" --add-label "copilot-autofix" || true
-            # Mark PR as ready for review (not draft) so CI runs automatically
-            gh pr ready "$PR_NUMBER" -R "${{ github.repository }}" || true
-          else
-            echo "pr-created=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Output job summary
-        if: always()
-        run: |
-          echo "## 🤖 Copilot Auto-Fix" >> "$GITHUB_STEP_SUMMARY"
-          if [ "${{ steps.copilot-fix.outputs.has-issues }}" != "true" ]; then
-            echo "No issues found." >> "$GITHUB_STEP_SUMMARY"
-          elif [ "${{ steps.copilot-fix.outputs.pr-created }}" = "true" ]; then
-            echo "✅ **PR Created:** ${{ steps.copilot-fix.outputs.pr-url }}" \
-              >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "⚠️ No PR created. \
-              Check [Copilot dashboard](https://github.com/${{ github.repository }}/copilot)." \
-              >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-  publish-clangsa-pages:
-    name: 📄 Publish CSA HTML to GitHub Pages
+  publish-clangsa-results:
+    name: 📄 Publish CSA Results
     needs: [clang-static-analyzer]
     # Only publish on full scans (skip when debug-file-filter is used)
     if: >-
@@ -296,6 +148,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: CodeChecker-HTML-Report
+          path: site
+
+      - name: Download CodeChecker JSON report
+        uses: actions/download-artifact@v4
+        with:
+          name: CodeChecker-JSON-Report
           path: site
 
       - name: Add .nojekyll

--- a/.github/workflows/copilot-autofix-clangsa.yaml
+++ b/.github/workflows/copilot-autofix-clangsa.yaml
@@ -1,0 +1,193 @@
+name: "Copilot Autofix ClangSA"
+
+on:
+  schedule:
+    # Run daily at 8 PM PST (4 AM UTC next day) - 2 hours after analysis
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+    inputs:
+      max-fixes:
+        description: "Maximum number of issues to fix in this run"
+        required: false
+        type: string
+        default: "1"
+
+jobs:
+  copilot-autofix:
+    name: 🤖 Copilot Autofix ClangSA Issue
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      pr-url: ${{ steps.copilot-fix.outputs.pr-url }}
+      pr-created: ${{ steps.copilot-fix.outputs.pr-created }}
+
+    steps:
+      - name: Check out source repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout results repo
+        uses: actions/checkout@v4
+        with:
+          repository: blozano-tt/umd-clangsa-results
+          ref: gh-pages
+          path: clangsa-results
+          token: ${{ secrets.CLANGSA_RESULTS_PAT }}
+
+      - name: Restore attempted hashes cache
+        uses: actions/cache/restore@v4
+        with:
+          path: attempted_hashes.txt
+          key: copilot-autofix-clangsa-attempted-${{ github.run_id }}
+          restore-keys: copilot-autofix-clangsa-attempted-
+
+      - name: Initialize attempted hashes file
+        run: touch attempted_hashes.txt
+
+      - name: Select unprocessed issue
+        id: select-issue
+        run: |
+          set -euo pipefail
+
+          JSON_FILE="clangsa-results/codechecker_issues.json"
+
+          if [ ! -f "$JSON_FILE" ]; then
+            echo "::error::No codechecker_issues.json found in results repo"
+            echo "has-issue=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          TOTAL_ISSUES=$(jq '.reports | length' "$JSON_FILE" 2>/dev/null || echo "0")
+          if [ "$TOTAL_ISSUES" = "0" ]; then
+            echo "No issues in JSON report"
+            echo "has-issue=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Total issues in report: $TOTAL_ISSUES"
+
+          # Read attempted hashes into a variable (newline-separated)
+          ATTEMPTED=$(cat attempted_hashes.txt)
+
+          # Find first issue whose hash is not in attempted list
+          ISSUE=$(jq -c --arg attempted "$ATTEMPTED" '
+            .reports[] |
+            select(.report_hash as $h | $attempted | split("\n") | index($h) | not)
+          ' "$JSON_FILE" | head -1)
+
+          if [ -z "$ISSUE" ]; then
+            echo "All issues have been attempted"
+            echo "has-issue=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Extract details
+          HASH=$(echo "$ISSUE" | jq -r '.report_hash')
+          FILE=$(echo "$ISSUE" | jq -r '.file.path | sub("^/work/"; "")')
+          LINE=$(echo "$ISSUE" | jq -r '.line')
+          CHECKER=$(echo "$ISSUE" | jq -r '.checker_name')
+          MESSAGE=$(echo "$ISSUE" | jq -r '.message')
+
+          echo "Selected issue:"
+          echo "  Hash: $HASH"
+          echo "  File: $FILE:$LINE"
+          echo "  Checker: $CHECKER"
+          echo "  Message: $MESSAGE"
+
+          # Mark as attempted
+          echo "$HASH" >> attempted_hashes.txt
+
+          # Set outputs
+          echo "has-issue=true" >> "$GITHUB_OUTPUT"
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+          echo "file=$FILE" >> "$GITHUB_OUTPUT"
+          echo "line=$LINE" >> "$GITHUB_OUTPUT"
+          echo "checker=$CHECKER" >> "$GITHUB_OUTPUT"
+          echo "message=$MESSAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Save attempted hashes cache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: attempted_hashes.txt
+          key: copilot-autofix-clangsa-attempted-${{ github.run_id }}
+
+      - name: Run Copilot fix
+        if: steps.select-issue.outputs.has-issue == 'true'
+        id: copilot-fix
+        timeout-minutes: 30
+        env:
+          COPILOT_OAUTH_TOKEN: ${{ secrets.COPILOT_OAUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Authenticate
+          if [ -z "$COPILOT_OAUTH_TOKEN" ]; then
+            echo "::error::COPILOT_OAUTH_TOKEN secret not set. \
+              Run 'gh auth login' locally, then 'gh auth token' and add as secret."
+            exit 1
+          fi
+          echo "$COPILOT_OAUTH_TOKEN" | gh auth login --with-token
+
+          # Build prompt
+          CHECKER="${{ steps.select-issue.outputs.checker }}"
+          FILE="${{ steps.select-issue.outputs.file }}"
+          LINE="${{ steps.select-issue.outputs.line }}"
+          MSG="${{ steps.select-issue.outputs.message }}"
+
+          {
+            echo "Fix this Clang Static Analyzer issue:"
+            echo ""
+            echo "- $CHECKER in $FILE:$LINE — $MSG"
+            echo ""
+            echo "Verify it's a real issue, apply minimal fix, follow coding standards."
+          } > /tmp/prompt.txt
+
+          cat /tmp/prompt.txt
+
+          # Run Copilot
+          BASE_BRANCH="${{ github.event_name == 'schedule' && 'main' || github.ref_name }}"
+
+          gh agent-task create -F /tmp/prompt.txt \
+            --base "$BASE_BRANCH" \
+            --repo "${{ github.repository }}" \
+            --follow
+
+          # Get the PR that was created
+          PR_NUMBER=$(gh agent-task list --limit 1 | grep -oE '#[0-9]+' | tr -d '#' || true)
+
+          if [ -n "$PR_NUMBER" ]; then
+            echo "pr-url=https://github.com/${{ github.repository }}/pull/${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+            echo "pr-created=true" >> "$GITHUB_OUTPUT"
+            # Add label to track Copilot PRs and prevent duplicates
+            gh pr edit "$PR_NUMBER" -R "${{ github.repository }}" --add-label "copilot-autofix" || true
+            # Mark PR as ready for review (not draft) so CI runs automatically
+            gh pr ready "$PR_NUMBER" -R "${{ github.repository }}" || true
+          else
+            echo "pr-created=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Output job summary
+        if: always()
+        run: |
+          SUMMARY="$GITHUB_STEP_SUMMARY"
+          echo "## 🤖 Copilot Autofix ClangSA" >> "$SUMMARY"
+
+          if [ "${{ steps.select-issue.outputs.has-issue }}" != "true" ]; then
+            echo "No unprocessed issues found." >> "$SUMMARY"
+          elif [ "${{ steps.copilot-fix.outputs.pr-created }}" = "true" ]; then
+            echo "✅ **PR Created:** ${{ steps.copilot-fix.outputs.pr-url }}" >> "$SUMMARY"
+            echo "" >> "$SUMMARY"
+            echo "**Issue fixed:**" >> "$SUMMARY"
+            CHECKER="${{ steps.select-issue.outputs.checker }}"
+            FILE="${{ steps.select-issue.outputs.file }}"
+            LINE="${{ steps.select-issue.outputs.line }}"
+            echo "- \`$CHECKER\` in \`$FILE:$LINE\`" >> "$SUMMARY"
+            echo "- ${{ steps.select-issue.outputs.message }}" >> "$SUMMARY"
+          else
+            REPO="${{ github.repository }}"
+            echo "⚠️ No PR created. Check [Copilot dashboard](https://github.com/$REPO/copilot)." >> "$SUMMARY"
+          fi


### PR DESCRIPTION
## Summary

This PR splits the Copilot autofix job into its own workflow for better control and state management.

## Changes

1. **Removed from :**
   -  and  inputs
   - The entire  job
   
2. **Added to :**
   - JSON report now published alongside HTML to results repo

3. **New workflow :**
   - Runs independently on schedule (2 hours after analysis)
   - Reads  from results repo
   - Uses GitHub Actions cache to track attempted issue hashes
   - Processes one issue per run to avoid duplicates
   - No dependency on the analysis workflow

## Benefits

- **Decoupled workflows:** Analysis and autofix can run independently
- **State management via cache:** Each issue hash tracked in cache, preventing duplicate attempts
- **Simpler control:** Can trigger autofix manually without re-running analysis
- **Results repo as source of truth:** JSON published alongside HTML for consistency

## Testing

- [ ] Verify analysis workflow publishes JSON to results repo
- [ ] Verify copilot workflow reads JSON and selects unprocessed issues
- [ ] Verify cache properly tracks attempted hashes across runs