### PR TITLE
Preparation for switch from deprecated tile_rd/wr to pci_rd/wr

### DIFF
--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -69,9 +69,12 @@ private:
     void (*pfn_libttsim_init)() = nullptr;
     void (*pfn_libttsim_exit)() = nullptr;
     uint32_t (*pfn_libttsim_pci_config_rd32)(uint32_t bus_device_function, uint32_t offset) = nullptr;
+    void (*pfn_libttsim_pci_mem_rd_bytes)(uint64_t paddr, void *p, uint32_t size) = nullptr;
+    void (*pfn_libttsim_pci_mem_wr_bytes)(uint64_t paddr, const void *p, uint32_t size) = nullptr;
     void (*pfn_libttsim_tile_rd_bytes)(uint32_t x, uint32_t y, uint64_t addr, void *p, uint32_t size) = nullptr;
     void (*pfn_libttsim_tile_wr_bytes)(uint32_t x, uint32_t y, uint64_t addr, const void *p, uint32_t size) = nullptr;
     void (*pfn_libttsim_clock)(uint32_t n_clocks) = nullptr;
+    uint32_t tlb_region_size = 0;
 
     std::mutex device_lock;
     std::filesystem::path simulator_directory_;

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -75,6 +75,11 @@ void TTSimTTDevice::start_device() {
     libttsim_pci_device_id = pci_id >> 16;
     log_info(tt::LogEmulationDriver, "PCI vendor_id=0x{:x} device_id=0x{:x}", vendor_id, libttsim_pci_device_id);
     TT_ASSERT(vendor_id == 0x1E52, "Unexpected PCI vendor ID.");
+    if (libttsim_pci_device_id == 0x401E) {  // WH: use 16MiB TLB regions
+        tlb_region_size = 0x1000000;
+    } else if (libttsim_pci_device_id == 0xB140) {  // BH: use 2MiB TLB regions
+        tlb_region_size = 0x200000;
+    }
 }
 
 void TTSimTTDevice::close_device() {
@@ -86,12 +91,32 @@ void TTSimTTDevice::close_device() {
 void TTSimTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
     std::lock_guard<std::mutex> lock(device_lock);
     log_debug(tt::LogUMD, "Device writing {} bytes to l1_dest {} in core {}", size, addr, core.str());
-    pfn_libttsim_tile_wr_bytes(core.x, core.y, addr, mem_ptr, size);
+    if (tlb_region_size) {  // if set, split into requests that do not span TLB regions
+        while (size) {
+            uint32_t cur_size = std::min(size, tlb_region_size - uint32_t(addr & (tlb_region_size - 1)));
+            pfn_libttsim_tile_wr_bytes(core.x, core.y, addr, mem_ptr, cur_size);
+            addr += cur_size;
+            mem_ptr = reinterpret_cast<const uint8_t*>(mem_ptr) + cur_size;
+            size -= cur_size;
+        }
+    } else {
+        pfn_libttsim_tile_wr_bytes(core.x, core.y, addr, mem_ptr, size);
+    }
 }
 
 void TTSimTTDevice::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
     std::lock_guard<std::mutex> lock(device_lock);
-    pfn_libttsim_tile_rd_bytes(core.x, core.y, addr, mem_ptr, size);
+    if (tlb_region_size) {  // if set, split into requests that do not span TLB regions
+        while (size) {
+            uint32_t cur_size = std::min(size, tlb_region_size - uint32_t(addr & (tlb_region_size - 1)));
+            pfn_libttsim_tile_rd_bytes(core.x, core.y, addr, mem_ptr, cur_size);
+            addr += cur_size;
+            mem_ptr = reinterpret_cast<uint8_t*>(mem_ptr) + cur_size;
+            size -= cur_size;
+        }
+    } else {
+        pfn_libttsim_tile_rd_bytes(core.x, core.y, addr, mem_ptr, size);
+    }
     pfn_libttsim_clock(10);
 }
 
@@ -276,6 +301,8 @@ void TTSimTTDevice::load_simulator_library(const std::filesystem::path& path) {
     DLSYM_FUNCTION(libttsim_init)
     DLSYM_FUNCTION(libttsim_exit)
     DLSYM_FUNCTION(libttsim_pci_config_rd32)
+    DLSYM_FUNCTION(libttsim_pci_mem_rd_bytes)
+    DLSYM_FUNCTION(libttsim_pci_mem_wr_bytes)
     DLSYM_FUNCTION(libttsim_tile_rd_bytes)
     DLSYM_FUNCTION(libttsim_tile_wr_bytes)
     DLSYM_FUNCTION(libttsim_clock)


### PR DESCRIPTION
### Issue
/ 

### Description
Preparatory changes for transition to host-to-device traffic going through libttsim_pci_rd/wr_bytes.

### List of the changes
- Query the pci_rd/wr APIs with dlsym.
- Determine the TLB region size for WH and BH.
- Split tile read/write requests so that they will not span TLB regions.

### Testing
CI ttsim testing
 
### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
