### PR TITLE
Refactor NOC tests

### DIFF
--- a/tests/api/test_noc.cpp
+++ b/tests/api/test_noc.cpp
@@ -15,7 +15,12 @@ using namespace tt::umd;
 
 class TestNoc : public ::testing::Test {
 public:
-    void SetUp() override { cluster_ = std::make_unique<Cluster>(); }
+    void SetUp() override {
+        cluster_ = std::make_unique<Cluster>();
+        if (cluster_->get_cluster_description()->get_all_chips().empty()) {
+            GTEST_SKIP() << "No chips present on the system. Skipping test.";
+        }
+    }
 
     void check_noc_id_cores(ChipId chip, CoreType core_type, CoordSystem noc) {
         const std::vector<CoreCoord>& cores = cluster_->get_soc_descriptor(chip).get_cores(core_type, noc);


### PR DESCRIPTION
### Issue
#1823 - Not solving the issue, just adhering to the boy scout rule of making the code better than it was found - subsequent PRs to this issue will tackle the NOC problem itself with tests and new functionality.

### Description
This pull request refactors the `TestNoc` tests in `tests/api/test_noc.cpp` to improve code organization, reusability, and clarity. The two previously separate tests are now unified under a single test fixture class, and duplicated logic has been consolidated into reusable member functions. The tests now support both NOC0 and NOC1 coordinate systems in a more systematic way.

### List of the changes
Test infrastructure improvements:
* Refactored the two separate test cases (`TestNoc0NodeId` and `TestNoc1NodeId`) into a single `TestNoc` test fixture class derived from `::testing::Test`, encapsulating shared setup and helper functions.
* Moved repeated logic for reading node IDs and checking core coordinates into member functions (`read_noc_id_reg`, `check_noc_id_cores`, `check_noc_id_harvested_cores`), reducing code duplication and improving maintainability.

Test coverage and clarity:
* Updated tests to explicitly pass the `CoordSystem` (NOC0 or NOC1) as a parameter, making the tests more flexible and easier to extend.
* Improved clarity by renaming variables and functions for better readability, and by adding comments for known TODOs and architecture-specific conditions.

### Testing
CI + Manual

### API Changes
/
