### PR TITLE
Add cluster descriptor for 8xP150 Loudbox config

### DIFF
--- a/tests/cluster_descriptor_examples/blackhole_8xP150.yaml
+++ b/tests/cluster_descriptor_examples/blackhole_8xP150.yaml
@@ -1,0 +1,258 @@
+arch:
+  0: blackhole
+  1: blackhole
+  2: blackhole
+  3: blackhole
+  4: blackhole
+  5: blackhole
+  6: blackhole
+  7: blackhole
+chips:
+  {}
+chip_unique_ids:
+  7: 143238000805344
+  6: 143238000808160
+  5: 143238000935104
+  4: 143238000807040
+  3: 143238000935392
+  2: 143238000935200
+  1: 143238000934976
+  0: 143238000935680
+ethernet_connections:
+  -
+    - chip: 0
+      chan: 4
+    - chip: 1
+      chan: 9
+  -
+    - chip: 0
+      chan: 5
+    - chip: 4
+      chan: 5
+  -
+    - chip: 0
+      chan: 6
+    - chip: 1
+      chan: 11
+  -
+    - chip: 0
+      chan: 7
+    - chip: 4
+      chan: 7
+  -
+    - chip: 0
+      chan: 9
+    - chip: 2
+      chan: 4
+  -
+    - chip: 0
+      chan: 11
+    - chip: 2
+      chan: 6
+  -
+    - chip: 1
+      chan: 4
+    - chip: 5
+      chan: 4
+  -
+    - chip: 1
+      chan: 6
+    - chip: 5
+      chan: 6
+  -
+    - chip: 2
+      chan: 8
+    - chip: 6
+      chan: 8
+  -
+    - chip: 2
+      chan: 9
+    - chip: 3
+      chan: 4
+  -
+    - chip: 2
+      chan: 10
+    - chip: 6
+      chan: 10
+  -
+    - chip: 2
+      chan: 11
+    - chip: 3
+      chan: 6
+  -
+    - chip: 3
+      chan: 9
+    - chip: 7
+      chan: 9
+  -
+    - chip: 3
+      chan: 11
+    - chip: 7
+      chan: 11
+  -
+    - chip: 4
+      chan: 4
+    - chip: 5
+      chan: 9
+  -
+    - chip: 4
+      chan: 6
+    - chip: 5
+      chan: 11
+  -
+    - chip: 4
+      chan: 9
+    - chip: 6
+      chan: 4
+  -
+    - chip: 4
+      chan: 11
+    - chip: 6
+      chan: 6
+  -
+    - chip: 6
+      chan: 9
+    - chip: 7
+      chan: 4
+  -
+    - chip: 6
+      chan: 11
+    - chip: 7
+      chan: 6
+ethernet_connections_to_remote_devices:
+  []
+chips_with_mmio:
+  - 0: 2
+  - 1: 3
+  - 2: 1
+  - 3: 0
+  - 4: 6
+  - 5: 7
+  - 6: 5
+  - 7: 4
+io_device_type: PCIe
+harvesting:
+  0:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  1:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  2:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  3:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  4:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  5:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  6:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  7:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+chip_to_boardtype:
+  0: p150
+  1: p150
+  2: p150
+  3: p150
+  4: p150
+  5: p150
+  6: p150
+  7: p150
+chip_to_bus_id:
+  0: 0x0001
+  1: 0x0021
+  2: 0x0041
+  3: 0x0061
+  4: 0x0081
+  5: 0x00a1
+  6: 0x00c1
+  7: 0x00e1
+boards:
+  -
+    - board_id: 4476187525167
+    - board_type: p150
+    - chips:
+        - 7
+  -
+    - board_id: 4476187525220
+    - board_type: p150
+    - chips:
+        - 4
+  -
+    - board_id: 4476187525255
+    - board_type: p150
+    - chips:
+        - 6
+  -
+    - board_id: 4476187529218
+    - board_type: p150
+    - chips:
+        - 1
+  -
+    - board_id: 4476187529222
+    - board_type: p150
+    - chips:
+        - 5
+  -
+    - board_id: 4476187529225
+    - board_type: p150
+    - chips:
+        - 2
+  -
+    - board_id: 4476187529231
+    - board_type: p150
+    - chips:
+        - 3
+  -
+    - board_id: 4476187529240
+    - board_type: p150
+    - chips:
+        - 0
+asic_locations:
+  0: 0
+  1: 0
+  2: 0
+  3: 0
+  4: 0
+  5: 0
+  6: 0
+  7: 0

--- a/tests/test_utils/fetch_local_files.hpp
+++ b/tests/test_utils/fetch_local_files.hpp
@@ -38,6 +38,7 @@ inline std::vector<std::string> GetAllClusterDescs() {
     for (const auto& cluster_desc_name : {
              "2x2_n300_cluster_desc.yaml",
              "6u_cluster_desc.yaml",
+             "blackhole_8xP150.yaml",
              "blackhole_P100.yaml",
              "blackhole_P150.yaml",
              "blackhole_P300_first_mmio.yaml",


### PR DESCRIPTION
### Issue
/

### Description

Add cluster descriptor for 8xP150 config.

### List of the changes

- Add cluster descriptor for 8xP150 config and add it to test.

### Testing
CI

### API Changes
/