### PR TITLE
Run perf benchmarks on P150 cards

### DIFF
--- a/.github/workflows/build-and-run-all-benchmarks.yml
+++ b/.github/workflows/build-and-run-all-benchmarks.yml
@@ -61,7 +61,7 @@ jobs:
         test-group: [
           {arch: wormhole_b0, card: tt-ubuntu-2204-n150-viommu-stable},
           {arch: wormhole_b0, card: tt-ubuntu-2204-n300-viommu-stable},
-          {arch: blackhole, card: tt-ubuntu-2204-p100a-viommu-stable},
+          {arch: blackhole, card: tt-ubuntu-2204-p150b-viommu-stable},
         ]
         ubuntu-docker-version: [
           'ubuntu-22.04',

--- a/device/api/umd/device/types/blackhole_arc.hpp
+++ b/device/api/umd/device/types/blackhole_arc.hpp
@@ -6,7 +6,6 @@
 
 #include <cstdint>
 
-
 namespace tt::umd::blackhole {
 
 // Note, this only includes message IDs that have actually be implemented in CMFW.
@@ -51,5 +50,4 @@ enum BlackholeArcMessageQueueIndex : uint8_t {
     APPLICATION = 3,
 };
 
-} // namespace tt::umd::blackhole
-
+}  // namespace tt::umd::blackhole

--- a/device/api/umd/device/types/blackhole_eth.hpp
+++ b/device/api/umd/device/types/blackhole_eth.hpp
@@ -8,7 +8,6 @@
 
 #include "umd/device/types/cluster_descriptor_types.hpp"
 
-
 namespace tt::umd::blackhole {
 
 static constexpr uint32_t POSTCODE_ETH_INIT_SKIP = 0xC0DE0000;
@@ -175,5 +174,4 @@ struct boot_results_t {
 
 constexpr uint32_t BOOT_RESULTS_ADDR = 0x7CC00;
 
-} // namespace tt::umd::blackhole
-
+}  // namespace tt::umd::blackhole

--- a/device/api/umd/device/types/wormhole_dram.hpp
+++ b/device/api/umd/device/types/wormhole_dram.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-
 namespace tt::umd::wormhole {
 
 enum WormholeDramTrainingStatus : uint8_t {
@@ -18,5 +17,4 @@ enum WormholeDramTrainingStatus : uint8_t {
     CaDebug,
 };
 
-} // namespace tt::umd::wormhole
-
+}  // namespace tt::umd::wormhole

--- a/device/api/umd/device/types/wormhole_telemetry.hpp
+++ b/device/api/umd/device/types/wormhole_telemetry.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-
 namespace tt::umd::wormhole {
 
 enum TelemetryTag : uint8_t {
@@ -61,5 +60,4 @@ enum TelemetryTag : uint8_t {
     NUMBER_OF_TAGS = 50
 };
 
-} // namespace tt::umd::wormhole
-
+}  // namespace tt::umd::wormhole

--- a/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
+++ b/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
@@ -262,6 +262,9 @@ TEST(MicrobenchmarkPCIeDMA, TensixMapBufferZeroCopy) {
     if (!PCIDevice(pci_device_ids.at(0)).is_iommu_enabled()) {
         GTEST_SKIP() << "Skipping test since IOMMU is not enabled on the system.";
     }
+    if (PCIDevice(pci_device_ids.at(0)).get_arch() == tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP() << "Skipping test since PCIe DMA is not enabled for Blackhole.";
+    }
 
     auto bench = ankerl::nanobench::Bench().title("DMA_Tensix_MapBuffer_ZeroCopy").unit("byte");
     const uint64_t ADDRESS = 0x0;


### PR DESCRIPTION
### Issue

#1545 

### Description

Run perf benchmarks on P150. Changed yaml to run on P150 since we want to utilize tests that touch ETH cores as well.

### List of the changes

- Changed yaml to run on P150 card

### Testing
CI

### API Changes
/
