### PR TITLE
Some log adjustments

### DIFF
--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -765,19 +765,19 @@ void ClusterDescriptor::merge_cluster_ids() {
     DisjointSet<ChipId> chip_sets;
     for (const auto &[chip, _] : chip_locations) {
         chip_sets.add_item(chip);
-        log_debug(LogUMD, "Adding chip {} to disjoint set", chip);
+        log_trace(LogUMD, "Adding chip {} to disjoint set", chip);
     }
 
     for (const auto &[chip, chan_to_chip_chan_map] : ethernet_connections) {
         for (const auto &[chan, dest_chip_chan_tuple] : chan_to_chip_chan_map) {
             chip_sets.merge(chip, std::get<0>(dest_chip_chan_tuple));
-            log_debug(LogUMD, "Merging chip {} and chip {}", chip, std::get<0>(dest_chip_chan_tuple));
+            log_trace(LogUMD, "Merging chip {} and chip {}", chip, std::get<0>(dest_chip_chan_tuple));
         }
     }
 
     for (const auto &[chip, chip_eth_coords] : chip_locations) {
         chip_locations[chip].cluster_id = chip_sets.get_set(chip);
-        log_debug(LogUMD, "Chip {} belongs to cluster {}", chip, chip_sets.get_set(chip));
+        log_trace(LogUMD, "Chip {} belongs to cluster {}", chip, chip_sets.get_set(chip));
     }
 }
 

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -434,7 +434,7 @@ PCIDevice::PCIDevice(int pci_device_number) :
             bar4_wc_mapping = mappings.mapping_array[i];
         }
 
-        log_debug(
+        log_trace(
             LogUMD,
             "BAR mapping id {} base {} size {}",
             mappings.mapping_array[i].mapping_id,

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -441,8 +441,16 @@ std::chrono::milliseconds WormholeTTDevice::wait_eth_core_training(
                     timeout_ms.count(),
                     eth_core.x,
                     eth_core.y));
+            } else {
+                // We don't want to throw on 6u systems, but log a warning so it is visible.
+                log_warning(
+                    LogUMD,
+                    "ETH training timed out after {} ms, on eth core {}, {}. Continuing for UBB board.",
+                    timeout_ms.count(),
+                    eth_core.x,
+                    eth_core.y);
+                break;
             }
-            break;
         }
     }
     return time_taken_heartbeat + time_taken_port;

--- a/device/warm_reset.cpp
+++ b/device/warm_reset.cpp
@@ -89,7 +89,7 @@ void WarmReset::warm_reset(std::vector<int> pci_device_ids, bool reset_m3, bool 
 
 int wait_for_pci_bdf_to_reappear(
     const std::string& bdf, const std::chrono::milliseconds timeout_ms = timeout::WARM_RESET_DEVICES_REAPPEAR_TIMEOUT) {
-    log_debug(tt::LogUMD, "Waiting for devices to reappear on pci bus.");
+    log_debug(tt::LogUMD, "Waiting for device {} to reappear on pci bus.", bdf);
 
     auto deadline = std::chrono::steady_clock::now() + timeout_ms;
     bool device_reappeared = false;


### PR DESCRIPTION
### Issue
Found while working on https://github.com/tenstorrent/tt-umd/issues/1904

### Description
Some logs were too spammy.

### List of the changes
- Move some logs from debug to trace, so they aren't spamming too much, specifically on 6u.
- If eth training times out on 6u, don't fail, but at least print a warning

### Testing
No testing

### API Changes
There are no API changes in this PR.
