### PR TITLE
Enhance WH eth train status readout

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -212,6 +212,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/types/telemetry.hpp
                 api/umd/device/types/tlb.hpp
                 api/umd/device/types/wormhole_dram.hpp
+                api/umd/device/types/wormhole_eth.hpp
                 api/umd/device/types/wormhole_telemetry.hpp
                 api/umd/device/types/xy_pair.hpp
                 api/umd/device/coordinates/wormhole_coordinate_manager.hpp

--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -338,21 +338,6 @@ inline constexpr uint32_t SPI_PAGE_ERASE_SIZE = 0x1000;
 inline constexpr uint32_t SPI_ROM_SIZE = 1 << 24;
 inline constexpr uint32_t ARC_SPI_CHUNK_SIZE = SPI_PAGE_ERASE_SIZE;
 
-// This constant is tied to the wormhole eth fw layout, so it's arch specific.
-inline constexpr uint32_t ETH_TRAIN_STATUS_ADDR = 0x1104;
-inline constexpr uint32_t ETH_RETRAIN_ADDR = 0x1EFC;
-inline constexpr uint32_t ETH_LINK_ERR_STATUS_ADDR = 0x1440;
-inline constexpr uint32_t ETH_TRIGGER_RETRAIN_VAL = 1;
-
-// There are various errors being reported by the eth FW, but only these are relevant for reporting unconnected eth
-// links. Other errors are all lower then this range and designate a true training failure.
-//
-// Not connected:     LINK_INACTIVE_TIMEOUT_SIGDET: 11
-// Not connected:     LINK_INACTIVE_TIMEOUT_PG_RCV: 12
-// Unused:        LINK_INACTIVE_PORT_NOT_POPULATED: 13
-// Port disabled:    LINK_INACTIVE_PORT_MASKED_OFF: 14.
-inline constexpr uint32_t ETH_LINK_UNUSED_ERROR_CODE_RANGE_START = 11;
-
 }  // namespace wormhole
 
 class wormhole_implementation : public architecture_implementation {

--- a/device/api/umd/device/types/wormhole_eth.hpp
+++ b/device/api/umd/device/types/wormhole_eth.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "umd/device/types/xy_pair.hpp"
+
+namespace tt::umd::wormhole {
+
+// Tied to the wormhole ETH FW layout.
+inline constexpr uint32_t ETH_TRAIN_STATUS_ADDR = 0x1104;
+inline constexpr uint32_t ETH_RETRAIN_ADDR = 0x1EFC;
+inline constexpr uint32_t ETH_LINK_ERR_STATUS_ADDR = 0x1440;
+inline constexpr uint32_t ETH_TRIGGER_RETRAIN_VAL = 1;
+
+// Errors >= this code are used for reporting unconnected/unused ETH links (e.g. LINK_INACTIVE_TIMEOUT_SIGDET: 11),
+// not true training failures.
+inline constexpr uint32_t ETH_LINK_UNUSED_ERROR_CODE_RANGE_START = 11;
+
+}  // namespace tt::umd::wormhole

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -22,6 +22,7 @@
 #include "umd/device/coordinates/coordinate_manager.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/types/communication_protocol.hpp"
+#include "umd/device/types/wormhole_eth.hpp"
 #include "umd/device/types/wormhole_telemetry.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "utils.hpp"


### PR DESCRIPTION
### Issue
Related to https://github.com/tenstorrent/tt-umd/issues/1904
A follow up of https://github.com/tenstorrent/tt-umd/pull/2012

### Description
Enhancing further how eth train status is obtained from WH.
I went through a couple of iterations, read a bit of syseng code and tested on some systems.

### List of the changes
- If retrain is active, don't read training_status as it is not valid, the training is ongoing
- If training failed, read why it failed and differentiate between Fail and NotConnected

### Testing
Tested on several systems with added traces

### API Changes
This PR has API changes, waiting on eth core to train is a bit different. Shouldn't break any usages
