### PR TITLE
Wait ETH training for remote tt_device

### DIFF
--- a/device/topology/topology_discovery_wormhole.cpp
+++ b/device/topology/topology_discovery_wormhole.cpp
@@ -236,6 +236,9 @@ std::unique_ptr<TTDevice> TopologyDiscoveryWormhole::create_remote_device(
             .get_eth_xy_pairs_for_channels(gateway_eth_channels, CoordSystem::TRANSLATED));
     std::unique_ptr<TTDevice> remote_tt_device = TTDevice::create(std::move(remote_communication));
     remote_tt_device->init_tt_device();
+    if (!options.no_wait_for_eth_training) {
+        wait_eth_cores_training(remote_tt_device.get());
+    }
     return remote_tt_device;
 }
 


### PR DESCRIPTION
### Issue
Found this while working on https://github.com/tenstorrent/tt-umd/issues/1904

### Description
We should perform this for remote tt_devices as well. Theoretically, if they are daisy chained, this has to be verified. I don't expect any functional changes currently though.

### List of the changes
- Wait eth training on remote chips, during TopologyDiscovery

### Testing
I saw through some other change through logs that this is now called.

### API Changes
There are no API changes in this PR.
