### PR TITLE
Read UBB S/N as Board ID for 6U Topology Discovery

### DIFF
--- a/device/topology/topology_discovery_blackhole.cpp
+++ b/device/topology/topology_discovery_blackhole.cpp
@@ -52,11 +52,6 @@ std::optional<EthCoord> TopologyDiscoveryBlackhole::get_remote_eth_coord(TTDevic
 }
 
 uint64_t TopologyDiscoveryBlackhole::get_remote_board_id(TTDevice* tt_device, tt_xy_pair eth_core) {
-    if (is_running_on_6u) {
-        // See comment in get_local_board_id.
-        return get_remote_asic_id(tt_device, eth_core);
-    }
-
     tt_xy_pair translated_eth_core = get_soc_descriptor(tt_device).translate_coord_to(
         eth_core, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0, CoordSystem::TRANSLATED);
     uint32_t board_id_lo;
@@ -69,15 +64,6 @@ uint64_t TopologyDiscoveryBlackhole::get_remote_board_id(TTDevice* tt_device, tt
 }
 
 uint64_t TopologyDiscoveryBlackhole::get_local_board_id(TTDevice* tt_device, tt_xy_pair eth_core) {
-    if (is_running_on_6u) {
-        // For 6U, since the whole trays have the same board ID, and we'd want to be able to open
-        // only some chips, we hack the board_id to be the asic ID. That way, the TT_VISIBLE_DEVICES filter
-        // from the ClusterOptions will work correctly on 6U.
-        // Note that the board_id will still be reported properly in the cluster descriptor, since it is
-        // fetched through another function when cluster descriptor is being filled up.
-        return get_local_asic_id(tt_device, eth_core);
-    }
-
     tt_xy_pair translated_eth_core = get_soc_descriptor(tt_device).translate_coord_to(
         eth_core, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0, CoordSystem::TRANSLATED);
     uint32_t board_id_lo;


### PR DESCRIPTION
### Issue
/

### Description
For 6U, as a hack for preventing creating remote devices on UBB, board ID was replaced with ASIC ID.
This is no longer necessary, because we can limit creating remote devices to only N300 boards.

### List of the changes
- Limit remote device creation only to N300 boards.
- Read UBB S/N as board_id for 6U instead of ASIC ID (which was actually board ID).


### Testing
6U CI, Manual testing on 6U

### API Changes
There are no API changes in this PR.
