### PR TITLE
Fix segfault in debug build by initializing with nullptr

### DIFF
--- a/device/api/umd/device/chip_helpers/sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_manager.hpp
@@ -45,8 +45,8 @@ public:
 protected:
     virtual bool init_sysmem(uint32_t num_host_mem_channels) = 0;
 
-    TLBManager* tlb_manager_;
-    TTDevice* tt_device_;
+    TLBManager* tlb_manager_ = nullptr;
+    TTDevice* tt_device_ = nullptr;
     // const uint64_t pcie_base_;
     uint64_t pcie_base_;
 


### PR DESCRIPTION
### Issue
#2113 

### Description
This pull request makes a small change to the `SysmemManager` class, initializing the `tlb_manager_` and `tt_device_` member pointers to `nullptr` to ensure they have a defined value upon construction.

### Testing
Manual

### API Changes
/
