### PR TITLE
Simplify pkg test jobs

### DIFF
--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -280,9 +280,9 @@ jobs:
       fail-fast: false
       matrix:
         build: [
-          { package: deb, distro: ubuntu-22.04, compiler: gcc },
-          { package: deb, distro: ubuntu-24.04, compiler: gcc },
-          { package: rpm, distro: fedora-39, compiler: gcc }
+          {package: deb, distro: ubuntu-22.04, compiler: gcc},
+          {package: deb, distro: ubuntu-24.04, compiler: gcc},
+          {package: rpm, distro: fedora-39, compiler: gcc}
         ]
 
     name: Test ${{ matrix.build.package }} package on ${{ matrix.build.distro }} with ${{ matrix.build.compiler }}


### PR DESCRIPTION
### Issue


### Description
Simplifies a bit our matrix on how we schedule jobs for testing deb/rpm packages

### List of the changes
- Reduce two dimensions of "os" and "pkg" into a one dimension having both
- Previous allows us to remove some ifelses
- Remove unnecessary env variables

### Testing
CI runs.

### API Changes
There are no API changes in this PR.
