### PR TITLE
Disable test for verifying topology on 6U

### DIFF
--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -293,6 +293,9 @@ TEST(ApiClusterDescriptorTest, VerifyStandardTopology) {
 
         // This covers 6U galaxy.
         case 32: {
+            GTEST_SKIP() << "Skipping test for 6U Wormhole galaxy since ETH links are flaky and the test fails from "
+                            "time to time.";
+
             auto chips_with_mmio = cluster_desc->get_chips_with_mmio();
             EXPECT_EQ(chips_with_mmio.size(), 32);
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/1904

### Description

Disable VerifyStandardTopology test for 6U since ETH links are flaky for 6U system we have in CI. Disabling this test until we have some workaround or the links stabilize.

### List of the changes

- Disable the test

### Testing
CI

### API Changes
/