### PR TITLE
Remove duplicate methods in semver_t

### DIFF
--- a/device/api/umd/device/utils/semver.hpp
+++ b/device/api/umd/device/utils/semver.hpp
@@ -26,9 +26,6 @@ public:
 
     constexpr semver_t() : major(0), minor(0), patch(0), pre_release(0) {}
 
-    constexpr semver_t(std::uint32_t version) :
-        major((version >> 16) & 0xff), minor((version >> 12) & 0xf), patch(version & 0xfff), pre_release(0) {}
-
     constexpr semver_t(uint64_t major, uint64_t minor, uint64_t patch, uint64_t pre_release = 00) :
         major(major), minor(minor), patch(patch), pre_release(pre_release) {}
 


### PR DESCRIPTION
### Issue
/

### Description
Remove duplicate methods in semver_t

### List of the changes
- Removed `semver_t::from_eth_fw_tag()`, identical methods exists under different name.
- Removed unused fw bundle tag constructor, better to use explicit static method.

### Testing
CI

### API Changes
There are API changes in this PR.
