### PR TITLE
Add MultiArchTopologyDiscovery for heterogeneous device systems

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -108,6 +108,7 @@ target_sources(
         topology/topology_discovery.cpp
         topology/topology_discovery_blackhole.cpp
         topology/topology_discovery_wormhole.cpp
+        topology/multi_arch_topology_discovery.cpp
         tt_device/remote_communication.cpp
         tt_device/remote_communication_legacy_firmware.cpp
         jtag/jtag_device.cpp
@@ -200,6 +201,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/topology/topology_discovery_blackhole.hpp
                 api/umd/device/topology/topology_discovery_wormhole.hpp
                 api/umd/device/topology/topology_discovery.hpp
+                api/umd/device/topology/multi_arch_topology_discovery.hpp
                 api/umd/device/topology/topology_utils.hpp
                 api/umd/device/utils/common.hpp
                 api/umd/device/utils/timeouts.hpp

--- a/device/api/umd/device/topology/multi_arch_topology_discovery.hpp
+++ b/device/api/umd/device/topology/multi_arch_topology_discovery.hpp
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <unordered_set>
+
+#include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/topology/topology_discovery.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
+
+namespace tt::umd {
+
+/**
+ * @brief Multi-architecture topology discovery for heterogeneous systems.
+ *
+ * Enables discovery of devices across multiple architectures (e.g., Wormhole + Blackhole)
+ * by creating separate, isolated clusters per architecture. Each cluster is independently
+ * validated and managed, avoiding conflicts from mixed-architecture validation.
+ *
+ * This is designed for monitoring tools, heterogeneous compute nodes, and systems where
+ * different architectures coexist but workloads target specific architectures at runtime.
+ */
+class MultiArchTopologyDiscovery {
+public:
+    /**
+     * @brief Represents a cluster of devices for a single architecture.
+     */
+    struct ArchCluster {
+        tt::ARCH arch;
+        std::unique_ptr<ClusterDescriptor> descriptor;
+        std::map<uint64_t, std::unique_ptr<TTDevice>> devices;
+        std::unordered_set<int> pci_ordinals;  // PCI device ordinals in this cluster
+        bool discovery_successful;
+        std::string error_message;
+
+        ArchCluster() : arch(tt::ARCH::Invalid), discovery_successful(false) {}
+
+        ArchCluster(tt::ARCH a) : arch(a), discovery_successful(false) {}
+    };
+
+    /**
+     * @brief Discover devices grouped by architecture, creating isolated clusters.
+     *
+     * @param options Base topology discovery options (applied to each architecture)
+     * @return Map of architecture to its cluster (only successful discoveries included)
+     *
+     * Algorithm:
+     * 1. Enumerate all PCI devices and group by architecture
+     * 2. For each architecture:
+     *    a. Filter environment (TT_VISIBLE_DEVICES) to only that architecture's devices
+     *    b. Run TopologyDiscovery::discover() in isolated context
+     *    c. Store result in separate ArchCluster
+     * 3. Return all successful clusters
+     *
+     * Benefits:
+     * - Each architecture validates independently (no mixed-arch conflicts)
+     * - Remote devices discovered per-architecture (n300 R chip with n300 L)
+     * - Telemetry works during execution (uses TTDevice per-arch)
+     * - Failures in one architecture don't affect others
+     */
+    static std::map<tt::ARCH, ArchCluster> discover_by_architecture(
+        const TopologyDiscoveryOptions& base_options = TopologyDiscoveryOptions());
+
+    /**
+     * @brief Discover devices for a specific architecture only.
+     *
+     * @param target_arch Architecture to discover
+     * @param options Topology discovery options
+     * @return ArchCluster for the specified architecture (check discovery_successful)
+     */
+    static ArchCluster discover_single_architecture(
+        tt::ARCH target_arch, const TopologyDiscoveryOptions& options = TopologyDiscoveryOptions());
+
+    /**
+     * @brief Get list of architectures present in the system (via PCI enumeration).
+     *
+     * @return Set of architectures detected on PCI bus
+     */
+    static std::unordered_set<tt::ARCH> get_available_architectures();
+
+private:
+    /**
+     * @brief Helper to set TT_VISIBLE_DEVICES to filter to specific PCI ordinals.
+     *
+     * @param ordinals PCI device ordinals to make visible
+     * @return Previous value of TT_VISIBLE_DEVICES (empty string if unset)
+     */
+    static std::string set_visible_devices_filter(const std::unordered_set<int>& ordinals);
+
+    /**
+     * @brief Restore TT_VISIBLE_DEVICES to previous value.
+     *
+     * @param previous_value Value to restore (empty to unset)
+     */
+    static void restore_visible_devices(const std::string& previous_value);
+};
+
+}  // namespace tt::umd

--- a/device/topology/multi_arch_topology_discovery.cpp
+++ b/device/topology/multi_arch_topology_discovery.cpp
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/topology/multi_arch_topology_discovery.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <sstream>
+#include <string>
+#include <tt-logger/tt-logger.hpp>
+#include <vector>
+
+#include "fmt/format.h"
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+
+namespace tt::umd {
+
+std::unordered_set<tt::ARCH> MultiArchTopologyDiscovery::get_available_architectures() {
+    std::unordered_set<tt::ARCH> architectures;
+
+    try {
+        auto pci_devices = PCIDevice::enumerate_devices_info();
+        for (const auto& [ordinal, info] : pci_devices) {
+            tt::ARCH arch = info.get_arch();
+            if (arch != tt::ARCH::Invalid) {
+                architectures.insert(arch);
+            }
+        }
+    } catch (const std::exception& e) {
+        log_warning(LogUMD, "Failed to enumerate PCI devices: {}", e.what());
+    }
+
+    return architectures;
+}
+
+std::string MultiArchTopologyDiscovery::set_visible_devices_filter(const std::unordered_set<int>& ordinals) {
+    // Save current value.
+    const char* current = std::getenv("TT_VISIBLE_DEVICES");
+    std::string previous_value = current ? current : "";
+
+    // Build new value: comma-separated ordinals.
+    std::ostringstream oss;
+    bool first = true;
+    for (int ordinal : ordinals) {
+        if (!first) {
+            oss << ",";
+        }
+        oss << ordinal;
+        first = false;
+    }
+
+    // Set new value.
+    std::string new_value = oss.str();
+    if (!new_value.empty()) {
+        setenv("TT_VISIBLE_DEVICES", new_value.c_str(), 1);
+        log_debug(LogUMD, "Set TT_VISIBLE_DEVICES={} for architecture filtering", new_value);
+    }
+
+    return previous_value;
+}
+
+void MultiArchTopologyDiscovery::restore_visible_devices(const std::string& previous_value) {
+    if (previous_value.empty()) {
+        unsetenv("TT_VISIBLE_DEVICES");
+        log_debug(LogUMD, "Cleared TT_VISIBLE_DEVICES filter");
+    } else {
+        setenv("TT_VISIBLE_DEVICES", previous_value.c_str(), 1);
+        log_debug(LogUMD, "Restored TT_VISIBLE_DEVICES={}", previous_value);
+    }
+}
+
+MultiArchTopologyDiscovery::ArchCluster MultiArchTopologyDiscovery::discover_single_architecture(
+    tt::ARCH target_arch, const TopologyDiscoveryOptions& options) {
+    ArchCluster cluster(target_arch);
+
+    try {
+        // Find PCI devices for this architecture.
+        auto pci_devices = PCIDevice::enumerate_devices_info();
+        std::unordered_set<int> target_ordinals;
+
+        for (const auto& [ordinal, info] : pci_devices) {
+            if (info.get_arch() == target_arch) {
+                target_ordinals.insert(ordinal);
+                cluster.pci_ordinals.insert(ordinal);
+            }
+        }
+
+        if (target_ordinals.empty()) {
+            cluster.error_message =
+                fmt::format("No PCI devices found for architecture {}", static_cast<int>(target_arch));
+            log_info(LogUMD, "{}", cluster.error_message);
+            return cluster;
+        }
+
+        log_info(
+            LogUMD,
+            "Discovering architecture {} with {} PCI device(s)",
+            static_cast<int>(target_arch),
+            target_ordinals.size());
+
+        // Filter TT_VISIBLE_DEVICES to this architecture.
+        std::string previous_visible = set_visible_devices_filter(target_ordinals);
+
+        try {
+            // Run topology discovery isolated to this architecture.
+            auto [descriptor, devices] = TopologyDiscovery::discover(options);
+
+            cluster.descriptor = std::move(descriptor);
+            cluster.devices = std::move(devices);
+            cluster.discovery_successful = true;
+
+            log_info(
+                LogUMD,
+                "Successfully discovered {} device(s) for architecture {}",
+                cluster.devices.size(),
+                static_cast<int>(target_arch));
+
+        } catch (const std::exception& e) {
+            cluster.error_message = fmt::format(
+                "TopologyDiscovery failed for architecture {}: {}", static_cast<int>(target_arch), e.what());
+            log_warning(LogUMD, "{}", cluster.error_message);
+        }
+
+        // Restore environment.
+        restore_visible_devices(previous_visible);
+
+    } catch (const std::exception& e) {
+        cluster.error_message =
+            fmt::format("PCI enumeration failed for architecture {}: {}", static_cast<int>(target_arch), e.what());
+        log_error(LogUMD, "{}", cluster.error_message);
+    }
+
+    return cluster;
+}
+
+std::map<tt::ARCH, MultiArchTopologyDiscovery::ArchCluster> MultiArchTopologyDiscovery::discover_by_architecture(
+    const TopologyDiscoveryOptions& base_options) {
+    std::map<tt::ARCH, ArchCluster> clusters;
+
+    log_info(LogUMD, "Starting multi-architecture topology discovery");
+
+    // Detect available architectures.
+    auto architectures = get_available_architectures();
+
+    if (architectures.empty()) {
+        log_warning(LogUMD, "No Tenstorrent devices found on PCI bus");
+        return clusters;
+    }
+
+    log_info(LogUMD, "Detected {} architecture(s) on PCI bus", architectures.size());
+
+    // Discover each architecture independently.
+    for (tt::ARCH arch : architectures) {
+        log_info(LogUMD, "Discovering devices for architecture {}...", static_cast<int>(arch));
+
+        auto cluster = discover_single_architecture(arch, base_options);
+
+        if (cluster.discovery_successful) {
+            log_info(
+                LogUMD,
+                "  ✓ Architecture {} discovery successful: {} device(s) found",
+                static_cast<int>(arch),
+                cluster.devices.size());
+            clusters[arch] = std::move(cluster);
+        } else {
+            log_warning(
+                LogUMD, "  ✗ Architecture {} discovery failed: {}", static_cast<int>(arch), cluster.error_message);
+            // Still add to map to preserve error information.
+            clusters[arch] = std::move(cluster);
+        }
+    }
+
+    // Summary.
+    size_t total_devices = 0;
+    size_t successful_archs = 0;
+    for (const auto& [arch, cluster] : clusters) {
+        if (cluster.discovery_successful) {
+            total_devices += cluster.devices.size();
+            successful_archs++;
+        }
+    }
+
+    log_info(
+        LogUMD,
+        "Multi-architecture discovery complete: {} architecture(s) successful, {} total device(s)",
+        successful_archs,
+        total_devices);
+
+    return clusters;
+}
+
+}  // namespace tt::umd


### PR DESCRIPTION
Introduces a new topology discovery class that supports systems with multiple Tenstorrent architectures (e.g., Wormhole + Blackhole) present simultaneously on the PCI bus.

The existing TopologyDiscovery::discover() validates all devices under a single architecture assumption. On mixed-arch nodes this causes failures because validation logic conflicts across architectures. This change works around that by running discovery in per-architecture isolated contexts using TT_VISIBLE_DEVICES filtering.

Changes:
- device/topology/multi_arch_topology_discovery.cpp: implementation
- device/api/umd/device/topology/multi_arch_topology_discovery.hpp: public API
- device/CMakeLists.txt: register new source and header in build

API surface:
  MultiArchTopologyDiscovery::discover_by_architecture()  - discover all archs MultiArchTopologyDiscovery::discover_single_architecture() - target one arch MultiArchTopologyDiscovery::get_available_architectures() - PCI enumeration

### Issue
(Link to Github issue(s))

### Description
(Add freeform description.)

### List of the changes
(Itemized list of all the changes.)

### Testing
(Comment on CI testing or Manual testing touching this change.)

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
