### PR TITLE
Fix local nanobind

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -162,6 +162,18 @@ CPMAddPackage(
 ####################################################################################################################
 # nanobind
 ####################################################################################################################
+if(CPM_LOCAL_PACKAGES_ONLY)
+    # When using only local packages, CPM uses "find_package".
+    # nanobind wants python included before CPM calls "find_package". 
+    find_package(
+        Python
+        COMPONENTS
+            Interpreter
+            Development
+        REQUIRED
+    )
+endif()
+
 CPMAddPackage(
     NAME nanobind
     GITHUB_REPOSITORY wjakob/nanobind


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description

Fixes this error when forcing CPM to use local packages:
```
CMake Error at /nix/store/vg5k7104cj9mldy3vkcz97jx337896hd-nanobind-2.11.0/nanobind/cmake/nanobind-config.cmake:4 (message):
  You must invoke 'find_package(Python COMPONENTS Interpreter Development
  REQUIRED)' prior to including nanobind.
Call Stack (most recent call first):
  cmake/CPM.cmake:249 (find_package)
  cmake/CPM.cmake:720 (cpm_find_package)
  third_party/CMakeLists.txt:165 (CPMAddPackage)
```

### List of the changes
(Itemized list of all the changes.)

### Testing

Try building `tt-umd` from https://github.com/NixOS/nixpkgs/pull/494239 via `nix-build -A tt-umd` after cloning the PR.

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
