### PR TITLE
Fix local picosha2

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -174,17 +174,26 @@ CPMAddPackage(
 ####################################################################################################################
 # picosha2
 ####################################################################################################################
-CPMAddPackage(
-    NAME picosha2
-    GITHUB_REPOSITORY okdshin/PicoSHA2
-    GIT_TAG v1.0.1
-    SYSTEM YES
-    OPTIONS
-        "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
-    DOWNLOAD_ONLY YES
-)
+if(NOT CPM_LOCAL_PACKAGES_ONLY)
+    CPMAddPackage(
+        NAME picosha2
+        GITHUB_REPOSITORY okdshin/PicoSHA2
+        GIT_TAG v1.0.1
+        SYSTEM YES
+        OPTIONS
+            "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
+        DOWNLOAD_ONLY YES
+    )
+endif()
 
-if(picosha2_ADDED)
+if(CPM_LOCAL_PACKAGES_ONLY AND NOT DEFINED picosha2_SOURCE_DIR)
+    message(
+        FATAL_ERROR
+        "CPM_LOCAL_PACKAGES_ONLY is ON, but picosha2_SOURCE_DIR is not defined. Please provide the path to the PicoSHA2 source."
+    )
+endif()
+
+if(picosha2_ADDED OR CPM_LOCAL_PACKAGES_ONLY)
     # picosha2 is header-only, create an interface library
     add_library(picosha2 INTERFACE)
     target_include_directories(picosha2 SYSTEM INTERFACE ${picosha2_SOURCE_DIR})


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description
Fixes this problem when `CPM_LOCAL_PACKAGES_ONLY` is set:
```
tt-umd> -- CPM: Adding package picosha2@1.0.1 (v1.0.1)
tt-umd> -- Populating picosha2
tt-umd> CMake Error at /nix/store/jzkw4x0b77fv2il53vpp6fylc09a6p75-cmake-4.1.2/share/cmake-4.1/Modules/ExternalProject/shared_internal_commands.cmake:928 (message):
tt-umd>   error: could not find git for clone of picosha2-populate
tt-umd> Call Stack (most recent call first):
tt-umd>   /nix/store/jzkw4x0b77fv2il53vpp6fylc09a6p75-cmake-4.1.2/share/cmake-4.1/Modules/ExternalProject.cmake:3080 (_ep_add_download_command)
tt-umd>   CMakeLists.txt:29 (ExternalProject_Add)
tt-umd>
tt-umd>
tt-umd> -- Configuring incomplete, errors occurred!
tt-umd> CMake Error at /nix/store/jzkw4x0b77fv2il53vpp6fylc09a6p75-cmake-4.1.2/share/cmake-4.1/Modules/FetchContent.cmake:1906 (message):
tt-umd>   CMake step for picosha2 failed: 1
tt-umd> Call Stack (most recent call first):
tt-umd>   /nix/store/jzkw4x0b77fv2il53vpp6fylc09a6p75-cmake-4.1.2/share/cmake-4.1/Modules/FetchContent.cmake:1609 (__FetchContent_populateSubbuild)
tt-umd>   /nix/store/jzkw4x0b77fv2il53vpp6fylc09a6p75-cmake-4.1.2/share/cmake-4.1/Modules/FetchContent.cmake:1997 (__FetchContent_doPopulation)
tt-umd>   /nix/store/jzkw4x0b77fv2il53vpp6fylc09a6p75-cmake-4.1.2/share/cmake-4.1/Modules/FetchContent.cmake:1978:EVAL:1 (__FetchContent_Populate)
tt-umd>   /nix/store/jzkw4x0b77fv2il53vpp6fylc09a6p75-cmake-4.1.2/share/cmake-4.1/Modules/FetchContent.cmake:1978 (cmake_language)
tt-umd>   cmake/CPM.cmake:1106 (FetchContent_Populate)
tt-umd>   cmake/CPM.cmake:895 (cpm_fetch_package)
tt-umd>   third_party/CMakeLists.txt:179 (CPMAddPackage)
```
This is useful and practically necessary for sandboxed builds.

### List of the changes
(Itemized list of all the changes.)

### Testing

Try building `tt-umd` from https://github.com/NixOS/nixpkgs/pull/494239 via `nix-build -A tt-umd` after cloning the PR.

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
