### PR TITLE
Fix local umd_asio

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -194,9 +194,18 @@ endif()
 ####################################################################################################################
 # asio (Standalone)
 ####################################################################################################################
-CPMAddPackage(NAME umd_asio GITHUB_REPOSITORY chriskohlhoff/asio GIT_TAG asio-1-30-2 SYSTEM YES DOWNLOAD_ONLY YES)
+if(NOT CPM_LOCAL_PACKAGES_ONLY)
+    CPMAddPackage(NAME umd_asio GITHUB_REPOSITORY chriskohlhoff/asio GIT_TAG asio-1-30-2 SYSTEM YES DOWNLOAD_ONLY YES)
+endif()
 
-if(umd_asio_ADDED)
+if(CPM_LOCAL_PACKAGES_ONLY AND NOT DEFINED umd_asio_SOURCE_DIR)
+    message(
+        FATAL_ERROR
+        "CPM_LOCAL_PACKAGES_ONLY is ON, but umd_asio_SOURCE_DIR is not defined. Please provide the path to the Asio source."
+    )
+endif()
+
+if(umd_asio_ADDED OR CPM_LOCAL_PACKAGES_ONLY)
     add_library(umd_asio_lib INTERFACE)
 
     target_include_directories(umd_asio_lib SYSTEM INTERFACE "${umd_asio_SOURCE_DIR}/asio/include")


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description
Fixes umd_asio when `CPM_LOCAL_PACKAGES_ONLY` is set:
```
tt-umd> -- CPM: Adding package umd_asio@ (asio-1-30-2)
tt-umd> -- Populating umd_asio
tt-umd> CMake Error at /nix/store/jzkw4x0b77fv2il53vpp6fylc09a6p75-cmake-4.1.2/share/cmake-4.1/Modules/ExternalProject/shared_internal_commands.cmake:928 (message):
tt-umd>   error: could not find git for clone of umd_asio-populate
tt-umd> Call Stack (most recent call first):
tt-umd>   /nix/store/jzkw4x0b77fv2il53vpp6fylc09a6p75-cmake-4.1.2/share/cmake-4.1/Modules/ExternalProject.cmake:3080 (_ep_add_download_command)
tt-umd>   CMakeLists.txt:29 (ExternalProject_Add)
tt-umd>
tt-umd>
tt-umd> -- Configuring incomplete, errors occurred!
tt-umd> CMake Error at /nix/store/jzkw4x0b77fv2il53vpp6fylc09a6p75-cmake-4.1.2/share/cmake-4.1/Modules/FetchContent.cmake:1906 (message):
tt-umd>   CMake step for umd_asio failed: 1
tt-umd> Call Stack (most recent call first):
tt-umd>   /nix/store/jzkw4x0b77fv2il53vpp6fylc09a6p75-cmake-4.1.2/share/cmake-4.1/Modules/FetchContent.cmake:1609 (__FetchContent_populateSubbuild)
tt-umd>   /nix/store/jzkw4x0b77fv2il53vpp6fylc09a6p75-cmake-4.1.2/share/cmake-4.1/Modules/FetchContent.cmake:1997 (__FetchContent_doPopulation)
tt-umd>   /nix/store/jzkw4x0b77fv2il53vpp6fylc09a6p75-cmake-4.1.2/share/cmake-4.1/Modules/FetchContent.cmake:1978:EVAL:1 (__FetchContent_Populate)
tt-umd>   /nix/store/jzkw4x0b77fv2il53vpp6fylc09a6p75-cmake-4.1.2/share/cmake-4.1/Modules/FetchContent.cmake:1978 (cmake_language)
tt-umd>   cmake/CPM.cmake:1106 (FetchContent_Populate)
tt-umd>   cmake/CPM.cmake:895 (cpm_fetch_package)
tt-umd>   third_party/CMakeLists.txt:201 (CPMAddPackage)
```
Necessary for sandboxed builds.

### List of the changes
(Itemized list of all the changes.)

### Testing

Try building `tt-umd` from https://github.com/NixOS/nixpkgs/pull/494239 via `nix-build -A tt-umd` after cloning the PR.

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
