### PR TITLE
Fix CPack functions being undefined

### DIFF
--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -70,6 +70,11 @@ set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 set(CPACK_RPM_PACKAGE_LICENSE "Apache-2.0")
 set(CPACK_RPM_PACKAGE_GROUP "Development/Libraries")
 
+# Include CPack configuration only if not building as a static library
+if(NOT TT_UMD_BUILD_STATIC)
+    include(CPack)
+endif()
+
 # 1. The runtime library package (libdevice.so)
 cpack_add_component(
     umd-runtime
@@ -94,8 +99,3 @@ cpack_add_component(
     DEPENDS
         umd-runtime # Makes the python package depend on the runtime
 )
-
-# Include CPack configuration only if not building as a static library
-if(NOT TT_UMD_BUILD_STATIC)
-    include(CPack)
-endif()


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description

Fixes this error which occurs when building with Nix:
```
tt-umd> -- Building umd with Tools
tt-umd> CMake Error at cmake/packaging.cmake:74 (cpack_add_component):
tt-umd>   Unknown CMake command "cpack_add_component".
tt-umd> Call Stack (most recent call first):
tt-umd>   CMakeLists.txt:168 (include)
tt-umd>
tt-umd>
tt-umd> -- Configuring incomplete, errors occurred!
```

The problem is CPack functions are used before they're defined.

### List of the changes
(Itemized list of all the changes.)

### Testing

Try building `tt-umd` from https://github.com/NixOS/nixpkgs/pull/494239 via `nix-build -A tt-umd` after cloning the PR.

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
