### PR TITLE
Fix CMake targets

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -43,6 +43,7 @@ CPMAddPackage(
         "YAML_CPP_BUILD_TESTS OFF"
         "YAML_CPP_BUILD_TOOLS OFF"
         "YAML_BUILD_SHARED_LIBS OFF"
+    FIND_PACKAGE_ARGUMENTS GLOBAL
 )
 
 if(yaml-cpp_ADDED)
@@ -146,7 +147,13 @@ CPMAddPackage(
 ####################################################################################################################
 # tt-logger
 ####################################################################################################################
-CPMAddPackage(NAME tt-logger GITHUB_REPOSITORY tenstorrent/tt-logger VERSION 1.1.8 SYSTEM YES)
+CPMAddPackage(
+    NAME tt-logger
+    GITHUB_REPOSITORY tenstorrent/tt-logger
+    VERSION 1.1.8
+    SYSTEM YES
+    FIND_PACKAGE_ARGUMENTS GLOBAL
+)
 
 ####################################################################################################################
 # cxxopts
@@ -159,6 +166,7 @@ CPMAddPackage(
     SYSTEM YES
     OPTIONS
         "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
+    FIND_PACKAGE_ARGUMENTS GLOBAL
 )
 
 ####################################################################################################################


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description

Fixes various CMake issues which prevent tt-umd from configuring and building correctly for Nix.

### List of the changes

- Fixes `hwloc.h` not found
- Fixes `tt-logger::tt-logger` target not found
- Fixes `spdlog::spdlog_header_only` target not found
- Fixes `fmt::fmt-header-only` target not found
- Fixes CMake trying to do `-ltt-logger`
- Fixes CMake trying to do `-tcxxopts`

### Testing

Try building `tt-umd` from https://github.com/NixOS/nixpkgs/pull/494239 via `nix-build -A tt-umd` after cloning the PR.

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
