### PR TITLE
Fix local googletest

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -17,7 +17,7 @@ include(${PROJECT_SOURCE_DIR}/cmake/ttexalens_private.cmake)
 ####################################################################################################################
 if(TT_UMD_BUILD_TESTS)
     CPMAddPackage(
-        NAME googletest
+        NAME GTest
         GITHUB_REPOSITORY google/googletest
         GIT_TAG v1.13.0
         VERSION 1.13.0
@@ -25,8 +25,8 @@ if(TT_UMD_BUILD_TESTS)
         OPTIONS
             "INSTALL_GTEST OFF"
     )
-    if(googletest_ADDED)
-        target_compile_options(gtest PRIVATE -Wno-implicit-int-float-conversion)
+    if(GTest_ADDED)
+        target_compile_options(GTest PRIVATE -Wno-implicit-int-float-conversion)
     endif()
 endif()
 
@@ -118,7 +118,7 @@ endif()
 # fmt : https://github.com/fmtlib/fmt
 ###################################################################################################################
 
-CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 11.1.4 SYSTEM YES)
+CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 11.1.4 SYSTEM YES FIND_PACKAGE_ARGUMENTS GLOBAL)
 
 ###################################################################################################################
 # nanobench (for uBenchmarking)
@@ -140,6 +140,7 @@ CPMAddPackage(
         "SPDLOG_FMT_EXTERNAL_HO ON"
         "SPDLOG_INSTALL ON"
         "BUILD_SHARED_LIBS OFF"
+    FIND_PACKAGE_ARGUMENTS GLOBAL
 )
 
 ####################################################################################################################
@@ -165,7 +166,7 @@ CPMAddPackage(
 ####################################################################################################################
 if(CPM_LOCAL_PACKAGES_ONLY)
     # When using only local packages, CPM uses "find_package".
-    # nanobind wants python included before CPM calls "find_package". 
+    # nanobind wants python included before CPM calls "find_package".
     find_package(
         Python
         COMPONENTS

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -26,7 +26,7 @@ if(TT_UMD_BUILD_TESTS)
             "INSTALL_GTEST OFF"
     )
     if(GTest_ADDED)
-        target_compile_options(GTest PRIVATE -Wno-implicit-int-float-conversion)
+        target_compile_options(gtest PRIVATE -Wno-implicit-int-float-conversion)
     endif()
 endif()
 


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description
Fixes this error when building with `CPM_LOCAL_PACKAGES_ONLY`
```
tt-umd> CMake Error at cmake/CPM.cmake:728 (message):
tt-umd>   CPM: googletest not found via find_package(googletest 1.13.0)
tt-umd> Call Stack (most recent call first):
tt-umd>   third_party/CMakeLists.txt:19 (CPMAddPackage)
tt-umd>
tt-umd>
tt-umd> -- CPM: Adding package googletest@1.13.0 (v1.13.0)
tt-umd> CMake Warning at /nix/store/jzkw4x0b77fv2il53vpp6fylc09a6p75-cmake-4.1.2/share/cmake-4.1/Modules/FetchContent.cmake:2111 (message):
tt-umd>   FETCHCONTENT_FULLY_DISCONNECTED is set to true, which requires the source
tt-umd>   directory for dependency googletest to already be populated.  This
tt-umd>   generally means it must not be set to true the first time CMake is run in a
tt-umd>   build directory.  The following source directory should already be
tt-umd>   populated, but it doesn't exist:
tt-umd>
tt-umd>     /build/source/build/_deps/googletest-src
tt-umd>
tt-umd>   Policy CMP0170 controls enforcement of this requirement.
tt-umd> Call Stack (most recent call first):
tt-umd>   /nix/store/jzkw4x0b77fv2il53vpp6fylc09a6p75-cmake-4.1.2/share/cmake-4.1/Modules/FetchContent.cmake:2384 (__FetchContent_Populate)
tt-umd>   cmake/CPM.cmake:1114 (FetchContent_MakeAvailable)
tt-umd>   cmake/CPM.cmake:895 (cpm_fetch_package)
tt-umd>   third_party/CMakeLists.txt:19 (CPMAddPackage)
tt-umd>
tt-umd>
tt-umd> CMake Error at third_party/CMakeLists.txt:29 (target_compile_options):
tt-umd>   Cannot specify compile options for target "gtest" which is not built by
tt-umd>   this project.
```

And this as well:
```
tt-umd> CMake Error at tests/CMakeLists.txt:2 (target_link_libraries):
tt-umd>   The link interface of target "test_common" contains:
tt-umd>
tt-umd>     spdlog::spdlog_header_only
tt-umd>
tt-umd>   but the target was not found.  Possible reasons include:
tt-umd>
tt-umd>     * There is a typo in the target name.
tt-umd>     * A find_package call is missing for an IMPORTED target.
tt-umd>     * An ALIAS target is missing.
```

### List of the changes
(Itemized list of all the changes.)

### Testing

Try building `tt-umd` from https://github.com/NixOS/nixpkgs/pull/494239 via `nix-build -A tt-umd` after cloning the PR.

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
