### PR TITLE
Move Blackhole ARC tests to lower level

### DIFF
--- a/tests/blackhole/test_arc_messages_bh.cpp
+++ b/tests/blackhole/test_arc_messages_bh.cpp
@@ -68,16 +68,16 @@ TEST(BlackholeArcMessages, BlackholeArcMessageHigherAIClock) {
 }
 
 TEST(BlackholeArcMessages, MultipleThreadsArcMessages) {
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     const uint32_t num_loops = 1000;
 
-    for (uint32_t chip_id : cluster->get_target_mmio_device_ids()) {
-        TTDevice* tt_device = cluster->get_tt_device(chip_id);
+    for (int pci_device_id : pci_device_ids) {
+        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
         tt_device->init_tt_device();
 
         std::thread thread0([&]() {
-            std::unique_ptr<ArcMessenger> arc_messenger = ArcMessenger::create_arc_messenger(tt_device);
+            std::unique_ptr<ArcMessenger> arc_messenger = ArcMessenger::create_arc_messenger(tt_device.get());
 
             for (uint32_t loop = 0; loop < num_loops; loop++) {
                 uint32_t response = arc_messenger->send_message((uint32_t)blackhole::ArcMessageType::TEST);
@@ -86,8 +86,7 @@ TEST(BlackholeArcMessages, MultipleThreadsArcMessages) {
         });
 
         std::thread thread1([&]() {
-            std::unique_ptr<ArcMessenger> arc_messenger = ArcMessenger::create_arc_messenger(tt_device);
-
+            std::unique_ptr<ArcMessenger> arc_messenger = ArcMessenger::create_arc_messenger(tt_device.get());
             for (uint32_t loop = 0; loop < num_loops; loop++) {
                 uint32_t response = arc_messenger->send_message((uint32_t)blackhole::ArcMessageType::TEST);
                 ASSERT_EQ(response, 0);


### PR DESCRIPTION
### Issue

Looking to improve tests organization in general.

### Description

Remove Cluster usage in Blackhole ARC messaging tests. This is a lower level component so we shouldn't use Cluster at this level of tests.

### List of the changes

- Use PCIDevice enumeration instead of Cluster

### Testing
CI

### API Changes
/
