### PR TITLE
Improve Blackhole ChipInfo tests

### DIFF
--- a/tests/blackhole/test_chip_info_bh.cpp
+++ b/tests/blackhole/test_chip_info_bh.cpp
@@ -23,9 +23,8 @@ TEST(BlackholeChipInfo, BasicChipInfo) {
 
         EXPECT_TRUE(
             chip_info.board_type == BoardType::P100 || chip_info.board_type == BoardType::P150 ||
-            chip_info.board_type == BoardType::P300);
+            chip_info.board_type == BoardType::P300 || chip_info.board_type == BoardType::UBB_BLACKHOLE);
 
-        // TODO: uncomment this when we can read asic location properly from telemetry.
-        // EXPECT_TRUE(chip_info.asic_location == 0 || chip_info.asic_location == 1);.
+        EXPECT_TRUE(chip_info.asic_location == 0 || chip_info.asic_location == 1);
     }
 }


### PR DESCRIPTION
### Issue

Fix TODOs from Blackhole comments

### Description

Fix TODO in Blackhole ChipInfo test and add Blackhole UBB board type.

### List of the changes

- Remove TODO comment and uncomment line for asic location.
- Add UBB blackhole board type to the test.

### Testing
CI

### API Changes
/