### PR TITLE
Expose ID in python binding

### DIFF
--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -134,6 +134,7 @@ void bind_tt_device(nb::module_ &m) {
         .def("board_id", &TTDevice::get_board_id)
         .def("get_board_type", &TTDevice::get_board_type)
         .def("get_communication_device_type", &TTDevice::get_communication_device_type)
+        .def("get_communication_device_id", &TTDevice::get_communication_device_id)
         .def("get_pci_device", &TTDevice::get_pci_device, nb::rv_policy::reference)
         .def("get_noc_translation_enabled", &TTDevice::get_noc_translation_enabled)
         .def("is_remote", &TTDevice::is_remote, "Returns true if this is a remote TTDevice")


### PR DESCRIPTION
### Issue
/

### Description
Expose device ID in nanobind

### List of the changes
* Added `.def("get_communication_device_id", &TTDevice::get_communication_device_id)` to the `TTDevice` bindings in `nanobind/py_api_tt_device.cpp`, enabling access to the communication device ID from Python.

### Testing
CI

### API Changes
/
