### PR TITLE
Move SocDescriptor tests to separate file

### DIFF
--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -2,6 +2,7 @@ set(API_TESTS_SRCS
     test_chip.cpp
     test_cluster_descriptor.cpp
     test_cluster.cpp
+    test_soc_descriptor.cpp
     test_risc_program.cpp
     test_tlb_manager.cpp
     test_software_harvesting.cpp

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -667,20 +667,6 @@ TEST(TestCluster, TestClusterAICLKControl) {
     }
 }
 
-TEST(TestCluster, SocDescriptorSerialize) {
-    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
-
-    for (auto chip_id : umd_cluster->get_target_device_ids()) {
-        const SocDescriptor& soc_descriptor = umd_cluster->get_soc_descriptor(chip_id);
-
-        std::filesystem::path file_path = soc_descriptor.serialize_to_file();
-        SocDescriptor soc(
-            file_path.string(),
-            {.noc_translation_enabled = soc_descriptor.noc_translation_enabled,
-             .harvesting_masks = soc_descriptor.harvesting_masks});
-    }
-}
-
 TEST(TestCluster, GetEthernetFirmware) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// This file holds Cluster specific API examples.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <random>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "umd/device/cluster.hpp"
+#include "utils.hpp"
+
+using namespace tt::umd;
+
+TEST(TestSocDescriptor, SocDescriptorSerialize) {
+    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
+
+    for (auto chip_id : umd_cluster->get_target_device_ids()) {
+        const SocDescriptor& soc_descriptor = umd_cluster->get_soc_descriptor(chip_id);
+
+        std::filesystem::path file_path = soc_descriptor.serialize_to_file();
+        SocDescriptor soc(
+            file_path.string(),
+            {.noc_translation_enabled = soc_descriptor.noc_translation_enabled,
+             .harvesting_masks = soc_descriptor.harvesting_masks});
+    }
+}


### PR DESCRIPTION
### Issue

Try to remove tests out of test_cluster.cpp

### Description

Move SocDescriptor tests to separate file

### List of the changes

- Move SocDescriptor tests to separate file

### Testing
CI

### API Changes
/