### PR TITLE
Fix TopologyDiscovery crashes on hosts with multiple archs

### DIFF
--- a/device/api/umd/device/topology/topology_discovery.hpp
+++ b/device/api/umd/device/topology/topology_discovery.hpp
@@ -63,7 +63,7 @@ protected:
         IODeviceType io_device_type = IODeviceType::PCIe,
         const std::string& soc_descriptor_path = "");
 
-    virtual tt::ARCH get_topology_arch(TTDevice* tt_device) const = 0;
+    virtual tt::ARCH get_topology_arch() const = 0;
 
     std::unique_ptr<ClusterDescriptor> create_ethernet_map();
 

--- a/device/api/umd/device/topology/topology_discovery_blackhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_blackhole.hpp
@@ -16,7 +16,7 @@ public:
         const TopologyDiscoveryOptions& options, IODeviceType io_device_type, const std::string& soc_descriptor_path);
 
 protected:
-    tt::ARCH get_topology_arch(TTDevice* tt_device) const override { return tt::ARCH::BLACKHOLE; }
+    tt::ARCH get_topology_arch() const override { return tt::ARCH::BLACKHOLE; }
 
     bool is_board_id_included(uint64_t board_id, uint64_t board_type) const override;
 

--- a/device/api/umd/device/topology/topology_discovery_wormhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_wormhole.hpp
@@ -17,7 +17,7 @@ public:
         const TopologyDiscoveryOptions& options, IODeviceType io_device_type, const std::string& soc_descriptor_path);
 
 protected:
-    tt::ARCH get_topology_arch(TTDevice* tt_device) const override { return tt::ARCH::WORMHOLE_B0; }
+    tt::ARCH get_topology_arch() const override { return tt::ARCH::WORMHOLE_B0; }
 
     struct EthAddresses {
         uint32_t masked_version;

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -25,6 +25,7 @@
 #include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/topology/topology_discovery.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/utils/semver.hpp"
 #include "umd/device/utils/timeouts.hpp"
@@ -60,6 +61,7 @@ std::unique_ptr<TopologyDiscovery> TopologyDiscovery::create_topology_discovery(
             TT_THROW("Unsupported device type for topology discovery");
     }
 
+    log_info(LogUMD, "Creating TopologyDiscovery for architecture: {}", arch_to_str(current_arch));
     switch (current_arch) {
         case tt::ARCH::WORMHOLE_B0:
             return std::make_unique<TopologyDiscoveryWormhole>(options, io_device_type, soc_descriptor_path);
@@ -117,7 +119,12 @@ void TopologyDiscovery::get_connected_devices() {
 
     for (auto& device_id : local_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(device_id, io_device_type);
-        if (tt_device->get_arch() != get_topology_arch(tt_device.get())) {
+        if (tt_device->get_arch() != get_topology_arch()) {
+            log_warning(
+                LogUMD,
+                "Skipped device {} with different architecture: {}",
+                device_id,
+                arch_to_str(tt_device->get_arch()));
             continue;
         }
 


### PR DESCRIPTION
### Issue
#2205 

### Description
This PR resolves an issue for hosts with multiple cards of differing architectures by converging to the first observed architecture and skipping devices not matching that architecture.

To clear any confusion, this PR does not introduce support for any kind of heterogeneous cluster. It simply avoids crashes caused by UMD trying to create a heterogeneous cluster.

### List of the changes
- Added get_topology_arch()
- Check arch of MMIO devices and skip if doesn't match the arch. of the topology discovery object.

### Testing
Manually verified on sjc-lab-t7003 (KMD dev machine).

### API Changes
There are no API changes in this PR.