### PR TITLE
Remove guard for baremetal systems in tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -117,6 +117,7 @@ jobs:
           ${{ env.TEST_OUTPUT_DIR }}/umd/test_utils/test_utils_tests
 
       - name: Run API tests
+        if: ${{ inputs.arch != 'baremetal' }}
         run: |
           ${{ env.TEST_OUTPUT_DIR }}/umd/api/api_tests
 

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -27,10 +27,6 @@ using namespace tt::umd;
 TEST(ApiChipTest, DISABLED_ManualTLBConfiguration) {
     std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
 
-    if (umd_cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
-
     // Expect to throw for remote chip for any worker core.
     auto remote_chips = umd_cluster->get_target_remote_device_ids();
     if (!remote_chips.empty()) {
@@ -74,10 +70,6 @@ TEST(ApiChipTest, DISABLED_ManualTLBConfiguration) {
 TEST(ApiChipTest, SimpleAPIShowcase) {
     std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
 
-    if (umd_cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
-
     ChipId chip_id = umd_cluster->get_cluster_description()->get_chips_with_mmio().begin()->first;
 
     // TODO: In future, will be accessed through Chip api.
@@ -90,10 +82,6 @@ TEST(ApiChipTest, SimpleAPIShowcase) {
 // // It reads back the risc reset reg to validate
 // TEST(ApiChipTest, DeassertRiscResetOnCore) {
 //     std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
-
-//     if (umd_cluster == nullptr || umd_cluster->get_target_device_ids().empty()) {
-//         GTEST_SKIP() << "No chips present on the system. Skipping test.";
-//     }
 
 //     tt_cxy_pair chip_core_coord = get_tensix_chip_core_coord(umd_cluster);
 
@@ -114,10 +102,6 @@ TEST(ApiChipTest, SimpleAPIShowcase) {
 // TEST(ApiChipTest, SpecifyLegalDeassertRiscResetOnCore) {
 //     std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
 
-//     if (umd_cluster == nullptr || umd_cluster->get_target_device_ids().empty()) {
-//         GTEST_SKIP() << "No chips present on the system. Skipping test.";
-//     }
-
 //     tt_cxy_pair chip_core_coord = get_tensix_chip_core_coord(umd_cluster);
 
 //     umd_cluster->assert_risc_reset_at_core(chip_core_coord);
@@ -135,10 +119,6 @@ TEST(ApiChipTest, SimpleAPIShowcase) {
 // // // It reads back the risc reset reg to validate that reset reg is in a legal state
 // TEST(ApiChipTest, SpecifyIllegalDeassertRiscResetOnCore) {
 //     std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
-
-//     if (umd_cluster == nullptr || umd_cluster->get_target_device_ids().empty()) {
-//         GTEST_SKIP() << "No chips present on the system. Skipping test.";
-//     }
 
 //     tt_cxy_pair chip_core_coord = get_tensix_chip_core_coord(umd_cluster);
 

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -108,10 +108,6 @@ TEST(TestCluster, TestClusterAICLKControl) {
 TEST(TestCluster, GetEthernetFirmware) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
-    if (cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
-
     // BoardType P100 doesn't have eth cores.
     std::optional<SemVer> eth_version;
     EXPECT_NO_THROW(eth_version = cluster->get_ethernet_firmware_version());

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -72,10 +72,6 @@ TEST(TestClusterDescriptor, DetectArch) {
 TEST(TestClusterDescriptor, BasicFunctionality) {
     std::unique_ptr<ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
 
-    if (cluster_desc == nullptr) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
-
     std::unordered_set<ChipId> all_chips = cluster_desc->get_all_chips();
     std::unordered_map<ChipId, EthCoord> eth_chip_coords = cluster_desc->get_chip_locations();
     std::unordered_map<ChipId, ChipId> local_chips_to_pci_device_id = cluster_desc->get_chips_with_mmio();
@@ -103,10 +99,6 @@ TEST(TestClusterDescriptor, BasicFunctionality) {
 
 TEST(TestClusterDescriptor, EthernetConnectivity) {
     std::unique_ptr<ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
-
-    if (cluster_desc == nullptr) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
 
     auto ethernet_connections = cluster_desc->get_ethernet_connections();
     for (const auto& [chip, connections] : ethernet_connections) {
@@ -158,9 +150,6 @@ TEST(TestClusterDescriptor, EthernetConnectivity) {
 
 TEST(TestClusterDescriptor, PrintClusterDescriptor) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
 
     // In case of u6 galaxy and blackhole, we generate the cluster descriptor.
     // For wormhole we still use create-ethernet-map.
@@ -207,10 +196,6 @@ TEST(TestClusterDescriptor, VerifyStandardTopology) {
     std::unique_ptr<ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
 
     auto all_chips = cluster_desc->get_all_chips();
-
-    if (all_chips.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
 
     switch (all_chips.size()) {
         // This covers N150, P100, P150.

--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -144,10 +144,6 @@ TEST(TestDeviceIO, RemoteFlush) {
 TEST(TestDeviceIO, SimpleIOSpecificSiliconChips) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
-
     std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>(ClusterOptions{
         .target_devices = {0},
     });
@@ -237,10 +233,6 @@ TEST(TestDeviceIO, DynamicTLB_RW) {
 TEST(TestDeviceIO, TestMulticastWrite) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
-    if (cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
-
     const tt_xy_pair grid_size = {8, 8};
 
     const CoreCoord start_tensix = CoreCoord(0, 0, CoreType::TENSIX, CoordSystem::LOGICAL);
@@ -282,10 +274,6 @@ TEST(TestDeviceIO, TestMulticastWrite) {
 
 TEST(TestDeviceIO, TestDmaMulticastWrite) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
-
-    if (cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
 
     if (cluster->get_tt_device(0)->get_arch() == tt::ARCH::BLACKHOLE) {
         GTEST_SKIP() << "DMA multicast write is not supported on Blackhole architecture.";
@@ -370,9 +358,6 @@ TEST_P(ClusterReadWriteL1Test, ReadWriteL1) {
     ClusterOptions options = GetParam();
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(options);
 
-    if (cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
     if (options.chip_type == SIMULATION) {
         cluster->start_device({.init_device = true});
     }
@@ -443,12 +428,6 @@ INSTANTIATE_TEST_SUITE_P(
  * 5. Verifies that the offsets have been zeroed from host's perspective.
  */
 TEST(TestDeviceIO, SysmemReadWrite) {
-    {
-        Cluster cluster;
-        if (cluster.get_target_device_ids().empty()) {
-            GTEST_SKIP() << "No chips present on the system. Skipping test.";
-        }
-    }
     constexpr size_t ONE_GIG = 1ULL << 30;
     constexpr uint64_t ALIGNMENT = sizeof(uint32_t);
     const bool is_vm = test_utils::is_virtual_machine();
@@ -627,9 +606,6 @@ TEST(TestDeviceIO, TTSimSysmemReadWrite) {
 
 TEST(TestDeviceIO, RegReadWrite) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
-    if (cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
 
     const CoreCoord tensix_core = cluster->get_soc_descriptor(0).get_cores(CoreType::TENSIX)[0];
 
@@ -675,9 +651,6 @@ TEST(TestDeviceIO, RegReadWrite) {
 
 TEST(TestDeviceIO, WriteDataReadReg) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
-    if (cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
 
     const CoreCoord tensix_core = cluster->get_soc_descriptor(0).get_cores(CoreType::TENSIX)[0];
 

--- a/tests/api/test_noc.cpp
+++ b/tests/api/test_noc.cpp
@@ -22,12 +22,7 @@ using namespace tt::umd;
 
 class TestNoc : public ::testing::Test {
 public:
-    void SetUp() override {
-        cluster_ = std::make_unique<Cluster>();
-        if (cluster_->get_cluster_description()->get_all_chips().empty()) {
-            GTEST_SKIP() << "No chips present on the system. Skipping test.";
-        }
-    }
+    void SetUp() override { cluster_ = std::make_unique<Cluster>(); }
 
     void verify_noc_id_cores_via_other_noc(
         ChipId chip, CoreType core_type, CoordSystem this_noc, bool use_harvested_cores) {

--- a/tests/api/test_risc_program.cpp
+++ b/tests/api/test_risc_program.cpp
@@ -45,10 +45,6 @@ TEST(TestRiscProgram, DeassertResetBrisc) {
     std::unique_ptr<Cluster> cluster =
         std::make_unique<Cluster>(ClusterOptions{.num_host_mem_ch_per_mmio_device = get_num_host_ch_for_test()});
 
-    if (cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
-
     constexpr uint32_t a_variable_value = 0x87654000;
     constexpr uint64_t a_variable_address = 0x10000;
     constexpr uint64_t brisc_code_address = 0;
@@ -100,10 +96,6 @@ TEST(TestRiscProgram, DeassertResetWithCounterBrisc) {
     // The test has large transfers to remote chip, so system memory significantly speeds up the test.
     std::unique_ptr<Cluster> cluster =
         std::make_unique<Cluster>(ClusterOptions{.num_host_mem_ch_per_mmio_device = get_num_host_ch_for_test()});
-
-    if (cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
 
     // TODO: remove this check when it is figured out what is happening with Blackhole version of this test.
     if (cluster->get_tt_device(0)->get_arch() == tt::ARCH::BLACKHOLE) {
@@ -174,10 +166,6 @@ TEST_P(ClusterAssertDeassertRiscsTest, TriscNcriscAssertDeassertTest) {
     // The test has large transfers to remote chip, so system memory significantly speeds up the test.
     std::unique_ptr<Cluster> cluster =
         std::make_unique<Cluster>(ClusterOptions{.num_host_mem_ch_per_mmio_device = get_num_host_ch_for_test()});
-
-    if (cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
 
     // TODO: remove this check when it is figured out what is happening with Blackhole version of this test.
     if (cluster->get_tt_device(0)->get_arch() == tt::ARCH::BLACKHOLE) {
@@ -296,10 +284,6 @@ TEST(TestRiscProgram, StartDeviceWithValidRiscProgram) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
     constexpr uint64_t write_address = 0x1000;
 
-    if (cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
-
     test_utils::safe_test_cluster_start(cluster.get());
 
     // Initialize random data.
@@ -336,9 +320,7 @@ TEST(TestRiscProgram, StartDeviceWithValidRiscProgram) {
 
 TEST(TestRiscProgram, DISABLED_EriscFirmwareHashCheck) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
-    if (cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
+
     auto eth_fw_version = cluster->get_ethernet_firmware_version();
     if (!eth_fw_version.has_value()) {
         GTEST_SKIP() << "No ETH cores in Cluster. Skipping test.";

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -55,9 +55,7 @@ TEST(ApiSysmemManager, BasicIO) {
 
 TEST(ApiSysmemManager, SysmemBuffers) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
+
     std::unique_ptr<PCIDevice> pci_device = std::make_unique<PCIDevice>(pci_device_ids[0]);
 
     if (!pci_device->is_iommu_enabled()) {
@@ -117,9 +115,6 @@ TEST(ApiSysmemManager, SysmemBuffers) {
 
 TEST(ApiSysmemManager, SysmemBufferUnaligned) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
     std::unique_ptr<PCIDevice> pci_device = std::make_unique<PCIDevice>(pci_device_ids[0]);
     if (!pci_device->is_iommu_enabled()) {
         GTEST_SKIP() << "Skipping test since IOMMU is not enabled.";
@@ -185,9 +180,6 @@ TEST(ApiSysmemManager, SysmemBufferUnaligned) {
 
 TEST(ApiSysmemManager, SysmemBufferFunctions) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
     if (!PCIDevice(pci_device_ids[0]).is_iommu_enabled()) {
         GTEST_SKIP() << "Skipping test since IOMMU is not enabled.";
     }
@@ -214,9 +206,6 @@ TEST(ApiSysmemManager, SysmemBufferFunctions) {
 
 TEST(ApiSysmemManager, SysmemBufferNocAddress) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
     if (!PCIDevice(pci_device_ids[0]).is_iommu_enabled()) {
         GTEST_SKIP() << "Skipping test since IOMMU is not enabled.";
     }

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -192,10 +192,6 @@ TEST(ApiTTDeviceTest, TestRemoteTTDevice) {
 TEST(ApiTTDeviceTest, MulticastIO) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
-
     std::map<int, PciDeviceInfo> pci_devices_info = PCIDevice::enumerate_devices_info();
 
     const tt::ARCH arch = pci_devices_info.at(pci_device_ids[0]).get_arch();

--- a/tests/api/test_tt_visible_devices.cpp
+++ b/tests/api/test_tt_visible_devices.cpp
@@ -78,10 +78,6 @@ TEST(TestTTVisibleDevices, OpenChipsByBDF) {
     // Get all available PCI devices and their BDF addresses.
     auto device_info_map = PCIDevice::enumerate_devices_info();
 
-    if (device_info_map.empty()) {
-        GTEST_SKIP() << "No PCI devices found for testing TT_VISIBLE_DEVICES";
-    }
-
     // Extract BDF addresses.
     std::vector<std::string> pci_bdf_addresses;
     pci_bdf_addresses.reserve(device_info_map.size());
@@ -142,10 +138,6 @@ TEST(TestTTVisibleDevices, OpenChipsByBDFWormhole6U) {
     // Get all available PCI devices and their BDF addresses.
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
-    if (cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No PCI devices found for testing TT_VISIBLE_DEVICES";
-    }
-
     if (cluster->get_tt_device(0)->get_board_type() != BoardType::UBB_WORMHOLE) {
         GTEST_SKIP() << "This test is intended to be run on Wormhole 6U systems only.";
     }
@@ -171,10 +163,6 @@ TEST(TestTTVisibleDevices, OpenChipsByBDFWormhole6U) {
 TEST(TestTTVisibleDevices, OpenChipsByBDFWormhole6USameChip) {
     // Get all available PCI devices and their BDF addresses.
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
-
-    if (cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No PCI devices found for testing TT_VISIBLE_DEVICES.";
-    }
 
     if (cluster->get_tt_device(0)->get_board_type() != BoardType::UBB_WORMHOLE) {
         GTEST_SKIP() << "This test is intended to be run on Wormhole 6U systems only.";
@@ -204,10 +192,6 @@ TEST(TestTTVisibleDevices, OpenChipsByBDFWormhole6UPattern) {
     // Get all available PCI devices and their BDF addresses.
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
-    if (cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No PCI devices found for testing TT_VISIBLE_DEVICES.";
-    }
-
     if (cluster->get_tt_device(0)->get_board_type() != BoardType::UBB_WORMHOLE) {
         GTEST_SKIP() << "This test is intended to be run on Wormhole 6U systems only.";
     }
@@ -233,10 +217,6 @@ TEST(TestTTVisibleDevices, OpenChipsByBDFWormhole6UPattern) {
 
 TEST(TestTTVisibleDevices, OpenChipsByIdException) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No PCI devices found for testing TT_VISIBLE_DEVICES.";
-    }
 
     std::unordered_set<int> target_device_ids;
     target_device_ids.insert(pci_device_ids.size());
@@ -275,9 +255,6 @@ TEST(TestTTVisibleDevices, OpenClusterByLogicalID) {
     std::unordered_map<ChipId, ChipId> chips_with_pcie = cluster_desc->get_chips_with_mmio();
     auto eth_connections = cluster_desc->get_ethernet_connections();
 
-    if (all_chips.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
     // Now we can choose which chips to open. This can be hardcoded if you already have expected topology.
     // The first cluster will open the first chip only, and the second cluster will open the rest of them.
     ChipId first_chip_only = chips_with_pcie.begin()->first;

--- a/tests/api/test_warm_reset.cpp
+++ b/tests/api/test_warm_reset.cpp
@@ -59,9 +59,6 @@ bool is_ipmitool_ready() {
 
 TEST(WarmResetTest, DISABLED_TTDeviceWarmResetAfterNocHang) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
 
     auto arch = PCIDevice(pci_device_ids[0]).get_arch();
     if (arch == tt::ARCH::WORMHOLE_B0) {
@@ -152,10 +149,6 @@ class WarmResetParamTest : public ::testing::TestWithParam<int> {};
 TEST_P(WarmResetParamTest, DISABLED_SafeApiHandlesReset) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
-
     int delay_us = GetParam();
     std::atomic<bool> sigbus_caught{false};
 
@@ -235,10 +228,6 @@ INSTANTIATE_TEST_SUITE_P(ResetTimingVariations, WarmResetParamTest, ::testing::V
 TEST(WarmResetTest, DISABLED_SafeApiMultiThreaded) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
-
     uint64_t address = 0x0;
     std::vector<uint32_t> data_write = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     std::vector<uint32_t> data_read(data_write.size(), 0);
@@ -292,10 +281,6 @@ TEST(WarmResetTest, DISABLED_SafeApiMultiThreaded) {
 // reset occurs, allowing user-space to detect and handle the invalidation gracefully.
 TEST(WarmResetTest, DISABLED_SafeApiMultiProcess) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
 
     constexpr int NUM_CHILDREN = 3;
     utils::MultiProcessPipe pipes(NUM_CHILDREN);
@@ -359,10 +344,6 @@ TEST(WarmResetTest, DISABLED_SafeApiMultiProcess) {
 TEST(WarmResetTest, DISABLED_ClusterWarmResetScratch) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
-    if (cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
-
     if (is_galaxy_configuration(cluster.get())) {
         GTEST_SKIP() << "Skipping test calling warm_reset() on Galaxy configurations.";
     }
@@ -395,10 +376,6 @@ TEST(WarmResetTest, DISABLED_ClusterWarmResetScratch) {
 TEST(WarmResetTest, GalaxyWarmResetScratch) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
     static constexpr uint32_t DEFAULT_VALUE_IN_SCRATCH_REGISTER = 0;
-
-    if (cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
 
     if (!is_galaxy_configuration(cluster.get())) {
         GTEST_SKIP() << "Only galaxy test configuration.";
@@ -446,10 +423,6 @@ TEST(WarmResetTest, ClusterWarmReset) {
         GTEST_SKIP() << "Warm reset is disabled on ARM64 due to instability.";
     }
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
-
-    if (cluster->get_target_device_ids().empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
 
     if (is_galaxy_configuration(cluster.get())) {
         GTEST_SKIP() << "Skipping test calling warm_reset() on Galaxy configurations.";

--- a/tests/baremetal/CMakeLists.txt
+++ b/tests/baremetal/CMakeLists.txt
@@ -5,6 +5,7 @@ set(BAREMETAL_TESTS_SRCS
     test_soc_descriptor.cpp
     test_long_jump.cpp
     test_notification_mechanism.cpp
+    test_cluster.cpp
 )
 
 add_executable(baremetal_tests ${BAREMETAL_TESTS_SRCS})

--- a/tests/baremetal/test_cluster.cpp
+++ b/tests/baremetal/test_cluster.cpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// This file holds Cluster specific API examples.
+
+#include <gtest/gtest.h>
+
+#include "umd/device/cluster.hpp"
+
+using namespace tt::umd;
+
+// This test is used that cluster can be created in a baremetal environment.
+TEST(TestClusterBaremetal, BasicClusterAPI) {
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+
+    EXPECT_EQ(cluster->get_target_device_ids().size(), 0);
+    EXPECT_EQ(cluster->get_target_mmio_device_ids().size(), 0);
+    EXPECT_EQ(cluster->get_target_remote_device_ids().size(), 0);
+}

--- a/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
+++ b/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
@@ -29,9 +29,6 @@ constexpr uint32_t NUM_EPOCHS = 100;
 // and the average time per page.
 TEST(MicrobenchmarkIOMMU, MapDifferentSizes) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
     if (!PCIDevice(pci_device_ids.at(0)).is_iommu_enabled()) {
         GTEST_SKIP() << "Skipping test since IOMMU is not enabled on the system.";
     }
@@ -82,9 +79,6 @@ TEST(MicrobenchmarkIOMMU, MapDifferentSizes) {
 // Since contiguous memory has less entries in the IOMMU page table, we expect the mapping to be faster.
 TEST(MicrobenchmarkIOMMU, MapHugepages2M) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
     if (!PCIDevice(pci_device_ids.at(0)).is_iommu_enabled()) {
         GTEST_SKIP() << "Skipping test since IOMMU is not enabled on the system.";
     }
@@ -139,9 +133,6 @@ TEST(MicrobenchmarkIOMMU, MapHugepages2M) {
 // Since contiguous memory has less entries in the IOMMU page table, we expect the mapping to be faster.
 TEST(MicrobenchmarkIOMMU, MapHugepages1G) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
     if (!PCIDevice(pci_device_ids.at(0)).is_iommu_enabled()) {
         GTEST_SKIP() << "Skipping test since IOMMU is not enabled on the system.";
     }

--- a/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
+++ b/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
@@ -194,9 +194,6 @@ TEST(MicrobenchmarkPCIeDMA, EthernetSweepSizes) {
 // to and from the device.
 TEST(MicrobenchmarkPCIeDMA, DRAMZeroCopy) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
     if (!PCIDevice(pci_device_ids.at(0)).is_iommu_enabled()) {
         GTEST_SKIP() << "Skipping test since IOMMU is not enabled on the system.";
     }
@@ -231,9 +228,6 @@ TEST(MicrobenchmarkPCIeDMA, DRAMZeroCopy) {
 // This test measures bandwidth of IO using PCIe DMA engine without overhead of copying data into DMA buffer.
 TEST(MicrobenchmarkPCIeDMA, TensixZeroCopy) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
     if (!PCIDevice(pci_device_ids.at(0)).is_iommu_enabled()) {
         GTEST_SKIP() << "Skipping test since IOMMU is not enabled on the system.";
     }
@@ -269,9 +263,6 @@ TEST(MicrobenchmarkPCIeDMA, TensixZeroCopy) {
 // to and from the device.
 TEST(MicrobenchmarkPCIeDMA, TensixMapBufferZeroCopy) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
     if (!PCIDevice(pci_device_ids.at(0)).is_iommu_enabled()) {
         GTEST_SKIP() << "Skipping test since IOMMU is not enabled on the system.";
     }

--- a/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
+++ b/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
@@ -40,9 +40,6 @@ TEST(MicrobenchmarkTLB, DRAM) {
         16 * ONE_MIB,
         32 * ONE_MIB};
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
-    if (cluster->get_cluster_description()->get_number_of_chips() == 0) {
-        GTEST_SKIP() << "No chips found on system.";
-    }
     const CoreCoord dram_core = cluster->get_soc_descriptor(CHIP_ID).get_cores(CoreType::DRAM)[0];
     for (size_t batch_size : BATCH_SIZES) {
         std::vector<uint8_t> pattern(batch_size);
@@ -80,9 +77,6 @@ TEST(MicrobenchmarkTLB, Tensix) {
     const std::vector<size_t> BATCH_SIZES = {
         1, 2, 4, 8, 1 * ONE_KIB, 2 * ONE_KIB, 4 * ONE_KIB, 8 * ONE_KIB, 1 * ONE_MIB};
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
-    if (cluster->get_cluster_description()->get_number_of_chips() == 0) {
-        GTEST_SKIP() << "No chips found on system.";
-    }
     const CoreCoord tensix_core = cluster->get_soc_descriptor(CHIP_ID).get_cores(CoreType::TENSIX)[0];
     for (size_t batch_size : BATCH_SIZES) {
         std::vector<uint8_t> pattern(batch_size);
@@ -120,9 +114,6 @@ TEST(MicrobenchmarkTLB, Ethernet) {
     const std::vector<size_t> BATCH_SIZES = {
         1, 2, 4, 8, 1 * ONE_KIB, 2 * ONE_KIB, 4 * ONE_KIB, 8 * ONE_KIB, 128 * ONE_KIB};
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
-    if (cluster->get_cluster_description()->get_number_of_chips() == 0) {
-        GTEST_SKIP() << "No chips found on system.";
-    }
     if (cluster->get_soc_descriptor(CHIP_ID).get_num_eth_channels() == 0) {
         GTEST_SKIP() << "No ETH cores found on system.";
     }
@@ -180,9 +171,6 @@ TEST(MicrobenchmarkTLB, CompareMulticastandUnicast) {
         512 * ONE_KIB,
         1 * ONE_MIB};
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
-    if (cluster->get_cluster_description()->get_number_of_chips() == 0) {
-        GTEST_SKIP() << "No chips found on system.";
-    }
     std::vector<Result> results;
     auto tensix_cores = cluster->get_soc_descriptor(CHIP_ID).get_cores(CoreType::TENSIX);
     for (size_t batch_size : BATCH_SIZES) {

--- a/tests/unified/multiprocess.cpp
+++ b/tests/unified/multiprocess.cpp
@@ -173,10 +173,6 @@ TEST(Multiprocess, MultipleThreadsMultipleClustersOpenClose) {
 TEST(Multiprocess, WorkloadVSMonitor) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
-
     auto workload_thread = std::thread([&] {
         std::cout << "Creating workload cluster" << std::endl;
         std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
@@ -224,10 +220,6 @@ TEST(Multiprocess, WorkloadVSMonitor) {
 
 TEST(Multiprocess, LongLivedMonitor) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
 
     auto low_level_monitor_thread = std::thread([&] {
         std::cout << "Creating low level monitor cluster" << std::endl;
@@ -311,10 +303,6 @@ TEST(Multiprocess, ClusterAndTTDeviceTest) {
 TEST(Multiprocess, DMAWriteReadRaceCondition) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
-
     // Use the first available PCI device for this test.
     const int test_device_id = pci_device_ids.at(0);
     const int num_processes = 4;
@@ -387,10 +375,6 @@ TEST(Multiprocess, DMAWriteReadRaceCondition) {
 
 TEST(Multiprocess, DMAWriteReadRaceConditionProcessIsolation) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No chips present on the system. Skipping test.";
-    }
 
     constexpr int NUM_PROCESSES = 4;
     std::vector<pid_t> pids;


### PR DESCRIPTION
### Issue

Small changes to more easily support the changes in #2208 

### Description

Remove guards for baremetal systems in non-baremetal tests. Copy some tests from api tests to baremetal in order to be sure that Cluster is successfully created on baremetal systems. We are also going to run smaller number of tests on baremetal now. The benefit of this is to not add guard for number of chips on each test and make the load on CI smaller.

### List of the changes

- Add test_cluster.cpp to baremetal tests to test Cluster creation on baremetal system
- Remove guards for number of chips in api tests
- Don't run api_tests on baremetal systems

### Testing
CI

### API Changes
/
