### PR TITLE
Fix Core translation skipped for JTAG in LocalChip::read_from_device_reg()

### DIFF
--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -376,14 +376,15 @@ void LocalChip::read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_sr
         throw std::runtime_error("Register address must be 4-byte aligned");
     }
 
+    auto translated_core = get_soc_descriptor().translate_chip_coord_to_translated(core);
+
     if (tt_device_->get_communication_device_type() != IODeviceType::PCIe) {
-        tt_device_->read_from_device(dest, core, reg_src, size);
+        tt_device_->read_from_device(dest, translated_core, reg_src, size);
         return;
     }
 
     std::lock_guard<std::mutex> lock(uc_tlb_lock);
 
-    auto translated_core = get_soc_descriptor().translate_chip_coord_to_translated(core);
     tlb_data config{};
     config.local_offset = reg_src;
     config.x_end = translated_core.x;


### PR DESCRIPTION
### Issue
/

### Description
Fixed a small discrepancy for JTAG in LocalChip where coords were not being translated for JTAG but were for PCIe.

### List of the changes
- Use `translated_core` in `read_from_device_reg()` for JTAG.

### Testing
CI, Verified using JTAG on bgd-lab-05

### API Changes
There are no API changes in this PR.