### PR TITLE
Reenable warm reset scratch test

### DIFF
--- a/tests/api/test_warm_reset.cpp
+++ b/tests/api/test_warm_reset.cpp
@@ -356,7 +356,7 @@ TEST(WarmResetTest, DISABLED_SafeApiMultiProcess) {
     }
 }
 
-TEST(WarmResetTest, DISABLED_ClusterWarmResetScratch) {
+TEST(WarmResetTest, ClusterWarmResetScratch) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
 
     if (cluster->get_target_device_ids().empty()) {
@@ -369,7 +369,7 @@ TEST(WarmResetTest, DISABLED_ClusterWarmResetScratch) {
 
     uint32_t write_test_data = 0xDEADBEEF;
 
-    auto chip_id = *cluster->get_target_device_ids().begin();
+    auto chip_id = *cluster->get_target_mmio_device_ids().begin();
     auto tt_device = cluster->get_chip(chip_id)->get_tt_device();
 
     tt_device->bar_write32(
@@ -382,7 +382,7 @@ TEST(WarmResetTest, DISABLED_ClusterWarmResetScratch) {
     cluster.reset();
 
     cluster = std::make_unique<Cluster>();
-    chip_id = *cluster->get_target_device_ids().begin();
+    chip_id = *cluster->get_target_mmio_device_ids().begin();
     tt_device = cluster->get_chip(chip_id)->get_tt_device();
 
     auto read_test_data = tt_device->bar_read32(


### PR DESCRIPTION
### Issue
#1246

### Description
This pull request makes targeted updates to the `ClusterWarmResetScratch` test in `test_warm_reset.cpp` to enable it and improve device selection for MMIO operations.

Because the test was flaky because of the ethernet bug (which was minimized or mitigated).

### List of the changes
Test enablement:

* The `ClusterWarmResetScratch` test is now enabled by removing the `DISABLED_` prefix, allowing it to run as part of the test suite.

Device selection improvements:

* Updated the test to use `get_target_mmio_device_ids()` instead of `get_target_device_ids()` when selecting the chip for MMIO operations, ensuring the correct device type is targeted for both initial and subsequent cluster creation.


### Testing
CI

### API Changes
/
