### PR TITLE
Add example of cluster descriptor with JTAG communication

### DIFF
--- a/tests/cluster_descriptor_examples/wormhole_N300_jtag.yaml
+++ b/tests/cluster_descriptor_examples/wormhole_N300_jtag.yaml
@@ -1,0 +1,66 @@
+arch:
+  0: wormhole_b0
+  1: wormhole_b0
+chips:
+  0:
+    - 0
+    - 0
+    - 0
+    - 0
+  1:
+    - 1
+    - 0
+    - 0
+    - 0
+chip_unique_ids:
+  1: 14521786549
+  0: 10226819253
+ethernet_connections:
+  -
+    - chip: 0
+      chan: 8
+    - chip: 1
+      chan: 0
+  -
+    - chip: 0
+      chan: 9
+    - chip: 1
+      chan: 1
+ethernet_connections_to_remote_devices:
+  []
+chips_with_mmio:
+  - 0: 1
+  - 1: 0
+io_device_type: JTAG
+harvesting:
+  0:
+    noc_translation: true
+    harvest_mask: 48
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  1:
+    noc_translation: true
+    harvest_mask: 129
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+chip_to_boardtype:
+  0: n300
+  1: n300
+chip_to_bus_id:
+  {}
+boards:
+  -
+    - board_id: 72058994491973813
+    - board_type: n300
+    - chips:
+        - 1
+        - 0
+asic_locations:
+  0: 0
+  1: 1
+chip_pci_bdfs:
+  {}

--- a/tests/test_utils/fetch_local_files.hpp
+++ b/tests/test_utils/fetch_local_files.hpp
@@ -54,6 +54,7 @@ inline std::vector<std::string> GetAllClusterDescs() {
              "wormhole_N300_with_remote_connections.yaml",
              "wormhole_N300_with_bus_id.yaml",
              "wormhole_N300.yaml",
+             "wormhole_N300_jtag.yaml",
              "wormhole_N300_pci_bdf.yaml",
          }) {
         cluster_desc_names.push_back(GetClusterDescAbsPath(cluster_desc_name));


### PR DESCRIPTION
### Issue
N/A

### Description
Adds a cluster descriptor YAML example for a Wormhole N300 board using JTAG as the I/O device type (`io_device_type: JTAG`). This serves as a reference configuration for JTAG-based communication setups.

### List of the changes
* Added `wormhole_N300_jtag.yaml` under `tests/cluster_descriptor_examples/` with full harvesting, ethernet connection, and board metadata for a two-chip N300 setup over JTAG.
* Registered the new example in `fetch_local_files.hpp` so it is picked up by `GetAllClusterDescs()` and included in cluster descriptor tests.

### Testing
CI

### API Changes
/