### PR TITLE
Report telemetry from all devices in telemetry tool

### DIFF
--- a/tools/telemetry.cpp
+++ b/tools/telemetry.cpp
@@ -33,7 +33,7 @@
 
 using namespace tt::umd;
 
-std::string run_default_telemetry(tt::ChipId chip_id, FirmwareInfoProvider* firmware_info_provider, tt::ARCH arch) {
+std::string run_default_telemetry(tt::ChipId chip_id, FirmwareInfoProvider* firmware_info_provider) {
     if (firmware_info_provider == nullptr) {
         return fmt::format("Could not get information for chip ID {}.", chip_id);
     }
@@ -87,7 +87,7 @@ int main(int argc, char* argv[]) {
     int frequency_us = result["freq"].as<int>();
     int telemetry_tag = result["tag"].as<int>();
 
-    auto [[maybe_unused]] [cluster_desc, tt_devices_map] = TopologyDiscovery::discover();
+    auto [cluster_desc, tt_devices_map] = TopologyDiscovery::discover();
 
     std::ofstream output_file;
     if (result.count("outfile")) {
@@ -117,7 +117,7 @@ int main(int argc, char* argv[]) {
             if (telemetry_tag == -1) {
                 auto arch = tt_devices.at(i)->get_arch();
                 if (arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE) {
-                    telemetry_message = run_default_telemetry(chip_id, firmware_info_provider, arch);
+                    telemetry_message = run_default_telemetry(chip_id, firmware_info_provider);
                 } else {
                     throw std::runtime_error("Unsupported device architecture");
                 }


### PR DESCRIPTION
## Description
Update the telemetry tool to discover and report telemetry from all devices in the system, including remote (ETH-connected) chips, not just PCIe-connected ones.

Users who need to restrict which devices are visible can use the `TT_VISIBLE_DEVICES` environment variable, which is already respected by the PCIe enumeration layer inside topology discovery.

## List of the changes

**Use `TopologyDiscovery::discover()` instead of `PCIDevice::enumerate_devices()`:**
- Replaces direct PCIe device enumeration with topology discovery, which also finds ETH-connected remote chips.
- Devices are now identified by logical `ChipId` instead of PCIe device ID.

**Remove `--devices` CLI option:**
- The option for filtering by PCIe device IDs is removed. Use `TT_VISIBLE_DEVICES` to control which devices are visible.

## Testing
Manual

## API Changes
/