### PR TITLE
Fix TT_VISIBLE_DEVICES to use direct KMD device IDs instead of BDF-so…

### DIFF
--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -266,13 +266,8 @@ std::vector<int> PCIDevice::enumerate_devices() {
 
     std::vector<std::string> device_tokens = utils::split_string_by_comma(tt_visible_devices_str);
 
+    std::vector<int> all_device_ids = get_all_device_ids();
     std::map<std::string, int> bdf_to_device_id_map = get_bdf_to_device_id_map();
-
-    std::vector<int> all_device_ids = {};
-
-    for (const auto &[bdf, device_id] : get_bdf_to_device_id_map()) {
-        all_device_ids.push_back(device_id);
-    }
 
     std::set<int> filtered_device_ids;
 
@@ -310,23 +305,16 @@ std::vector<int> PCIDevice::enumerate_devices() {
         bool is_integer = !device_token.empty() && std::all_of(device_token.begin(), device_token.end(), ::isdigit);
 
         if (is_integer) {
-            int logical_device_id = std::stoi(device_token);
-
-            if (logical_device_id < 0 || logical_device_id >= all_device_ids.size()) {
+            int device_id = std::stoi(device_token);
+            if (std::find(all_device_ids.begin(), all_device_ids.end(), device_id) != all_device_ids.end()) {
+                filtered_device_ids.insert(device_id);
+                log_debug(LogUMD, "Added device id {} because of token filter {}.", device_id, device_token);
+            } else {
                 TT_THROW(
                     "Invalid device ID in TT_VISIBLE_DEVICES: {}.  Valid device identifiers are either integers or "
-                    "part of the BDF string. Valid integer IDs are between 0 and {}.",
-                    device_token,
-                    all_device_ids.size() - 1);
+                    "part of the BDF string.",
+                    device_token);
             }
-
-            log_debug(
-                LogUMD,
-                "Added device id {} because of token filter {}.",
-                all_device_ids[logical_device_id],
-                device_token);
-
-            filtered_device_ids.insert(all_device_ids[logical_device_id]);
 
         } else {
             TT_THROW(


### PR DESCRIPTION
- Integer values in `TT_VISIBLE_DEVICES` were interpreted as **BDF-sorted indices** (0-based position in PCI Bus:Device.Function alphabetical order) rather than direct KMD device IDs (`/dev/tenstorrent/N`).
- On mixed-architecture systems (e.g., Blackhole + Wormhole), BDF order can differ from KMD ID order, causing `TT_VISIBLE_DEVICES=5` to select the wrong device (a Blackhole instead of the intended Wormhole N300, or vice versa).
- This change makes integer tokens map directly to `/dev/tenstorrent/N` KMD device IDs, matching the numbering users see in `tt-smi -ls`.

## Root Cause

Commit `01af8038` ("Change TT_VISIBLE_DEVICES to use logical IDs") built `all_device_ids` by iterating `get_bdf_to_device_id_map()` (a `std::map<std::string, int>` sorted by BDF string), then used index-based lookup (`all_device_ids[logical_device_id]`). This made `TT_VISIBLE_DEVICES=N` select the Nth device in BDF alphabetical order, not KMD device N.


Changes:
- Build all_device_ids from get_all_device_ids() (enumerates /dev/tenstorrent/ directly) instead of iterating BDF-sorted map
- Use std::find for direct KMD ID matching instead of index-based array lookup

Fixes device misselection on heterogeneous systems with mixed Blackhole/Wormhole devices where BDF order != KMD ID order.

### Issue
(Link to Github issue(s))

### Description
(Add freeform description.)

### List of the changes
(Itemized list of all the changes.)

### Testing
(Comment on CI testing or Manual testing touching this change.)

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
