### PR TITLE
Add TTSim device IO tests in CI

### DIFF
--- a/.github/workflows/build-clients.yml
+++ b/.github/workflows/build-clients.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Run UMD TestDeviceIOFixture on tt-sim wormhole
         env:
-          TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_wh
+          TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_wh/libttsim.so
         run: |
           tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
 


### PR DESCRIPTION
### Issue
#2185

### Description
Adds UMD `TestDeviceIOFixture` test execution to the existing `build-tt-sim` CI job so that all device IO tests run against the WH TTSim simulator on every PR/push.

### List of the changes
- Added a build step that compiles the UMD `api_tests` binary with `-DTT_UMD_BUILD_SIMULATION=ON` from the UMD submodule inside the tt-metal checkout.
- Added a run step that executes `api_tests --gtest_filter="TestDeviceIOFixture.*"` with `TT_UMD_SIMULATOR` pointing to the WH simulator directory.

### Testing
CI

### API Changes
There are no API changes in this PR.