### PR TITLE
Switch TTSim read_from_device to TLB-based path

### DIFF
--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -76,17 +76,7 @@ void TTSimTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64
 
 void TTSimTTDevice::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
     std::lock_guard<std::recursive_mutex> lock(device_lock);
-    if (tlb_region_size_) {  // if set, split into requests that do not span TLB regions
-        while (size) {
-            uint32_t cur_size = std::min(size, tlb_region_size_ - uint32_t(addr & (tlb_region_size_ - 1)));
-            communicator_->tile_read_bytes(core.x, core.y, addr, mem_ptr, cur_size);
-            addr += cur_size;
-            mem_ptr = reinterpret_cast<uint8_t*>(mem_ptr) + cur_size;
-            size -= cur_size;
-        }
-    } else {
-        communicator_->tile_read_bytes(core.x, core.y, addr, mem_ptr, size);
-    }
+    get_cached_tlb_window()->read_block_reconfigure(mem_ptr, core, addr, size);
     communicator_->advance_clock(10);
 }
 


### PR DESCRIPTION
### Issue
#2185

### Description
Switches `TTSimTTDevice::read_from_device` to use the TLB-based `read_block_reconfigure` path (same as the write path) instead of calling `tile_read_bytes` directly.

The previous `tile_read_bytes` implementation was intentionally kept during development to validate the TLB write path: reads via the proven `tile_read_bytes` API served as a ground-truth check that data written through the TLB window was landing correctly. Once the write path was confirmed good, the read side was updated to use the same TLB mechanism for consistency.

### List of the changes
- Replaced the manual TLB-region-chunking loop (and `tile_read_bytes` fallback) in `TTSimTTDevice::read_from_device` with a single call to `get_cached_tlb_window()->read_block_reconfigure`, matching the write path.

### Testing
CI — covered by the `TestDeviceIOFixture` suite running against WH TTSim.

### API Changes
There are no API changes in this PR.