### PR TITLE
Sort IDs from enumerate_devices based on PCI BDF

### DIFF
--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -359,6 +359,12 @@ private:
      */
     static std::vector<int> get_all_device_ids();
 
+    /**
+     * Sort a list of device IDs by their PCI BDF (Bus:Device.Function) order.
+     * Any IDs that cannot be mapped to a BDF are appended at the end in their original order.
+     * @param pci_device_ids list of device IDs to sort
+     * @return sorted device IDs
+     */
     static std::vector<int> sort_ids_based_on_bdf(const std::vector<int> &pci_device_ids);
 
     /**

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -10,7 +10,6 @@
 #include <sys/mman.h>   // for mmap, munmap
 #include <unistd.h>     // for ::close
 
-#include <algorithm>
 #include <cctype>
 #include <cerrno>
 #include <cstdint>
@@ -343,8 +342,20 @@ std::vector<int> PCIDevice::enumerate_devices() {
 std::vector<int> PCIDevice::sort_ids_based_on_bdf(const std::vector<int> &pci_device_ids) {
     std::vector<int> sorted_ids_based_on_bdf;
     std::map<std::string, int> bdf_to_device_id_map = get_bdf_to_device_id_map();
+    std::unordered_set<int> input_ids(pci_device_ids.begin(), pci_device_ids.end());
+    std::unordered_set<int> mapped_ids;
+
     for (const auto &[bdf, device_id] : bdf_to_device_id_map) {
-        if (std::find(pci_device_ids.begin(), pci_device_ids.end(), device_id) != pci_device_ids.end()) {
+        if (input_ids.count(device_id)) {
+            sorted_ids_based_on_bdf.push_back(device_id);
+            mapped_ids.insert(device_id);
+        }
+    }
+
+    // Append any IDs that could not be mapped to a BDF, preserving input order.
+    for (int device_id : pci_device_ids) {
+        if (!mapped_ids.count(device_id)) {
+            log_debug(tt::LogUMD, "Device ID {} could not be mapped to a BDF, appending at end.", device_id);
             sorted_ids_based_on_bdf.push_back(device_id);
         }
     }

--- a/tests/api/test_tt_visible_devices.cpp
+++ b/tests/api/test_tt_visible_devices.cpp
@@ -254,6 +254,9 @@ TEST(TestTTVisibleDevices, LogicalIdMatchesEnumerateDevicesOrder) {
         ASSERT_NE(tt_device, nullptr) << "No TTDevice found for logical ID " << chip_id;
         std::shared_ptr<PCIDevice> pci_device = tt_device->get_pci_device();
         ASSERT_NE(pci_device, nullptr) << "No PCI device found for logical ID " << chip_id;
+        ASSERT_LT(chip_id, enumerated_ids.size())
+            << "Logical chip ID " << chip_id << " is out of bounds for enumerate_devices() result of size "
+            << enumerated_ids.size();
         EXPECT_EQ(pci_device->get_device_num(), enumerated_ids[chip_id])
             << "Chip ID " << chip_id << " maps to PCI device " << pci_device->get_device_num()
             << " but enumerate_devices() returned " << enumerated_ids[chip_id] << " at index " << chip_id;


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description
Ensures that device IDs returned by `enumerate_devices` are consistently ordered by PCI Bus/Device/Function (BDF) address rather than by arbitrary kernel-assigned device ID. This provides a stable, hardware-topology-based ordering for multi-device setups.

### List of the changes
- Add `PCIDevice::sort_ids_based_on_bdf()` private static helper that reorders a list of device IDs by their BDF string (which sorts lexicographically by bus, device, function)
- Replace the previous `std::sort` (numeric order) in `enumerate_devices()` with the new BDF-based sort, both for the `TT_VISIBLE_DEVICES` path and the default path
- Remove the `std::sort` from `get_all_device_ids()` since ordering is now handled by `sort_ids_based_on_bdf()`

### Testing
CI

### API Changes
There are no API changes in this PR.