### PR TITLE
Refactor is_board_id_included() in TopologyDiscovery

### DIFF
--- a/device/api/umd/device/topology/topology_discovery.hpp
+++ b/device/api/umd/device/topology/topology_discovery.hpp
@@ -56,18 +56,12 @@ protected:
     virtual void wait_eth_cores_training(
         TTDevice* tt_device, std::chrono::milliseconds timeout_ms = timeout::ETH_TRAINING_TIMEOUT);
 
-    // board_type is not used for all configs.
-    virtual bool does_board_belong_to_host(uint64_t board_id) const;
+    virtual bool is_board_id_included(uint64_t board_id) const;
 
     // Returns mangled remote board id from local ETH core.
     // This information can still be used to unique identify a board.
     // eth_core should be in physical (NOC0) coordinates.
     virtual uint64_t get_remote_board_id(TTDevice* tt_device, tt_xy_pair eth_core) = 0;
-
-    // Returns mangled remote board type from local ETH core.
-    // This information can still be used to unique identify a board.
-    // eth_core should be in physical (NOC0) coordinates.
-    virtual uint64_t get_remote_board_type(TTDevice* tt_device, tt_xy_pair eth_core) = 0;
 
     // Returns mangled local board id from local ETH core.
     // This information can still be used to unique identify a board.

--- a/device/api/umd/device/topology/topology_discovery_blackhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_blackhole.hpp
@@ -40,8 +40,6 @@ protected:
 
     uint32_t get_logical_remote_eth_channel(TTDevice* tt_device, tt_xy_pair local_eth_core) override;
 
-    uint64_t get_remote_board_type(TTDevice* tt_device, tt_xy_pair eth_core) override;
-
     bool is_using_eth_coords() override;
 
     uint64_t mangle_asic_id(uint64_t board_id, uint8_t asic_location);

--- a/device/api/umd/device/topology/topology_discovery_wormhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_wormhole.hpp
@@ -58,8 +58,6 @@ protected:
 
     uint32_t get_logical_remote_eth_channel(TTDevice* tt_device, tt_xy_pair local_eth_core) override;
 
-    uint64_t get_remote_board_type(TTDevice* tt_device, tt_xy_pair eth_core) override;
-
     std::unique_ptr<TTDevice> create_remote_device(
         std::optional<EthCoord> eth_coord, TTDevice* gateway_device, std::set<uint32_t> gateway_eth_channels) override;
 

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -224,7 +224,7 @@ void TopologyDiscovery::discover_remote_devices() {
             active_eth_channels_per_device.at(current_device_asic_id).insert(channel);
             uint64_t remote_asic_id = get_remote_asic_id(tt_device, eth_core);
 
-            if (!does_board_belong_to_host(get_remote_board_id(tt_device, eth_core)) ||
+            if (!is_board_id_included(get_remote_board_id(tt_device, eth_core)) ||
                 (tt_device->get_arch() == ARCH::BLACKHOLE &&
                  discovered_devices.find(remote_asic_id) == discovered_devices.end())) {
                 ethernet_connections_to_remote_devices.push_back(
@@ -486,7 +486,7 @@ void TopologyDiscovery::wait_eth_cores_training(TTDevice* tt_device, const std::
     }
 }
 
-bool TopologyDiscovery::does_board_belong_to_host(uint64_t board_id) const {
+bool TopologyDiscovery::is_board_id_included(uint64_t board_id) const {
     return board_ids.find(board_id) != board_ids.end();
 }
 

--- a/device/topology/topology_discovery_blackhole.cpp
+++ b/device/topology/topology_discovery_blackhole.cpp
@@ -146,11 +146,6 @@ uint32_t TopologyDiscoveryBlackhole::get_remote_eth_id(TTDevice* tt_device, tt_x
     return remote_eth_id;
 }
 
-uint64_t TopologyDiscoveryBlackhole::get_remote_board_type(TTDevice* tt_device, tt_xy_pair eth_core) {
-    // This function is not important for Blackhole, so we can return any value here.
-    return 0;
-}
-
 uint32_t TopologyDiscoveryBlackhole::get_remote_eth_channel(TTDevice* tt_device, tt_xy_pair local_eth_core) {
     return get_remote_eth_id(tt_device, local_eth_core);
 }

--- a/device/topology/topology_discovery_wormhole.cpp
+++ b/device/topology/topology_discovery_wormhole.cpp
@@ -113,16 +113,6 @@ uint64_t TopologyDiscoveryWormhole::get_local_board_id(TTDevice* tt_device, tt_x
     return ((board_id >> 4) & 0xF0000000) | (board_id & 0x0FFFFFFF);
 }
 
-uint64_t TopologyDiscoveryWormhole::get_remote_board_type(TTDevice* tt_device, tt_xy_pair eth_core) {
-    uint32_t board_id;
-    tt_device->read_from_device(
-        &board_id,
-        eth_core,
-        eth_addresses.results_buf + (4 * eth_addresses.erisc_remote_board_type_offset),
-        sizeof(uint32_t));
-    return board_id;
-}
-
 uint64_t TopologyDiscoveryWormhole::get_local_asic_id(TTDevice* tt_device, tt_xy_pair eth_core) {
     uint32_t asic_id_lo;
     tt_device->read_from_device(


### PR DESCRIPTION
### Issue
/

### Description
Removed unused `board_type` argument in `is_board_id_included()`. This argument was used to support 4U/TG. Since we deprecated support for it, it has been unused.

### List of the changes
- Removed `board_type` argument from `is_board_id_included()`.
- Removed now unused `get_remote_board_type()`.

### Testing
CI

### API Changes
There are no API changes in this PR.
