### PR TITLE
Exclude tt_kmd_lib from simulation builds

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -113,10 +113,17 @@ target_sources(
         tt_device/remote_communication_legacy_firmware.cpp
         jtag/jtag_device.cpp
         jtag/jtag.cpp
-        tt_kmd_lib/tt_kmd_lib.c
         arc/wormhole_spi_tt_device.cpp
         arc/blackhole_spi_tt_device.cpp
 )
+
+if(NOT TT_UMD_BUILD_SIMULATION)
+    target_sources(
+        device
+        PRIVATE
+            tt_kmd_lib/tt_kmd_lib.c
+    )
+endif()
 
 if(TT_UMD_BUILD_SIMULATION)
     target_sources(


### PR DESCRIPTION
### Issue
/

### Description
`tt_kmd_lib.c` is a C wrapper around kernel-mode driver ioctls and is only needed for real hardware (PCIe) access. It was previously compiled unconditionally, meaning it was included even in simulation builds where it is never used.

This change moves it out of the unconditional `target_sources` block and guards it with `NOT TT_UMD_BUILD_SIMULATION`.

### List of the changes
- Move `tt_kmd_lib/tt_kmd_lib.c` out of the base `target_sources` list.
- Add a `if(NOT TT_UMD_BUILD_SIMULATION)` block that compiles it only for non-simulation builds.

### Testing
CI

### API Changes
There are no API changes in this PR.