### PR TITLE
Fix logging EthCoords for remote devices

### DIFF
--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -205,7 +205,11 @@ void TopologyDiscovery::discover_remote_devices() {
                 auto local_eth_coord = get_local_eth_coord(tt_device, eth_core);
                 if (local_eth_coord.has_value()) {
                     eth_coords.emplace(current_device_asic_id, local_eth_coord.value());
-                    log_debug(LogUMD, "Device {} has ETH coord: {}", current_device_asic_id, local_eth_coord.value());
+                    log_debug(
+                        LogUMD,
+                        "Device ASIC ID: {} has ETH coord: {}",
+                        current_device_asic_id,
+                        local_eth_coord.value());
                 }
             }
 


### PR DESCRIPTION
### Issue
/

### Description
Fix a small bug where EthCoords of remote devices aren't being logged because they are added immediately after discovery instead of when their ETH links are being discovered.

### List of the changes
- Removed setting EthCoords for newly discovered remote device so the same EthCoords can be logged.

### Testing
manually verified on n300.

### API Changes
There are no API changes in this PR.
