### PR TITLE
Add Quasar SOC descriptor

### DIFF
--- a/tests/soc_descs/quasar_32_arch.yaml
+++ b/tests/soc_descs/quasar_32_arch.yaml
@@ -1,0 +1,47 @@
+grid:
+  x_size: 8
+  y_size: 4
+
+arc:
+  []
+
+pcie:
+  []
+
+dram:
+  [[2-7],
+  [3-7]]
+
+eth:
+  []
+
+functional_workers:
+  [2-2, 3-2, 4-2, 5-2, 6-2, 7-2, 8-2, 9-2,
+  2-3, 3-3, 4-3, 5-3, 6-3, 7-3, 8-3, 9-3,
+  2-4, 3-4, 4-4, 5-4, 6-4, 7-4, 8-4, 9-4,
+  2-5, 3-5, 4-5, 5-5, 6-5, 7-5, 8-5, 9-5]
+
+router_only:
+  [0-2]
+
+worker_l1_size:
+  1499136
+
+dram_bank_size:
+  1073741824
+
+eth_l1_size:
+  0
+
+arch_name: QUASAR
+
+features:
+  unpacker:
+    version: 1
+    inline_srca_trans_without_srca_trans_instr: False
+  math:
+    dst_size_alignment: 32768
+  packer:
+    version: 1
+  overlay:
+    version: 1

--- a/tests/test_utils/fetch_local_files.hpp
+++ b/tests/test_utils/fetch_local_files.hpp
@@ -73,6 +73,7 @@ inline std::vector<std::string> GetAllSocDescs() {
              "wormhole_b0_1x1.yaml",
              "wormhole_b0_8x10.yaml",
              "wormhole_b0_one_dram_one_tensix_no_eth.yaml",
+             "quasar_32_arch.yaml",
          }) {
         soc_desc_names.push_back(GetSocDescAbsPath(soc_desc_name));
     }


### PR DESCRIPTION
### Issue
/

### Description
Adds the SOC descriptor for the Quasar architecture (quasar_32_arch.yaml) with a 8x4 grid, 32 functional workers, 2 DRAM banks, and registers it in the test utils file list.

### List of the changes
- Add `tests/soc_descs/quasar_32_arch.yaml` with Quasar 32-core SOC descriptor
- Register `quasar_32_arch.yaml` in `tests/test_utils/fetch_local_files.hpp`

### Testing
CI

### API Changes
There are no API changes in this PR.