### PR TITLE
Fix telemetry tool help text to not claim WH-only support

### DIFF
--- a/tools/telemetry.cpp
+++ b/tools/telemetry.cpp
@@ -68,8 +68,8 @@ int main(int argc, char* argv[]) {
 
     options.add_options()(
         "t,tag",
-        "Telemetry tag to read. If set to -1, will run default telemetry mode which works only for WH and reads aiclk, "
-        "power, temperature and vcore. See device/api/umd/device/types/telemetry.hpp"
+        "Telemetry tag to read. If set to -1, will run default telemetry mode which reads aiclk, "
+        "power, temperature and vcore. See device/api/umd/device/types/telemetry.hpp "
         "for all available tags.",
         cxxopts::value<int>()->default_value("-1"))(
         "f,freq", "Frequency of polling in microseconds.", cxxopts::value<int>()->default_value("1000"))(


### PR DESCRIPTION
### Issue
/

### Description
The telemetry tool's help text incorrectly states that the default telemetry mode "works only for WH". This is not true — it works for both Wormhole and Blackhole architectures.

### List of the changes
- Removed the incorrect "works only for WH" note from the telemetry tool's `--tag` option help text.

### Testing
CI

### API Changes
There are no API changes in this PR.