### PR TITLE
Revert naming to DDR_SPEED for SMI

### DIFF
--- a/nanobind/py_api_telemetry.cpp
+++ b/nanobind/py_api_telemetry.cpp
@@ -103,7 +103,7 @@ void bind_telemetry(nb::module_& m) {
         .value("L2CPUCLK3", TelemetryTag::L2CPUCLK3)
         .value("ETH_LIVE_STATUS", TelemetryTag::ETH_LIVE_STATUS)
         .value("DDR_STATUS", TelemetryTag::GDDR_STATUS)
-        .value("GDDR_SPEED", TelemetryTag::GDDR_SPEED)
+        .value("DDR_SPEED", TelemetryTag::GDDR_SPEED)
         .value("ETH_FW_VERSION", TelemetryTag::ETH_FW_VERSION)
         .value("GDDR_FW_VERSION", TelemetryTag::GDDR_FW_VERSION)
         .value("DM_APP_FW_VERSION", TelemetryTag::DM_APP_FW_VERSION)


### PR DESCRIPTION
### Issue
#2282 

### Description
This pull request makes a minor correction to the telemetry Python bindings. The change updates the enum value name exposed to Python to use a consistent naming convention.

* Renamed the enum value from `"GDDR_SPEED"` to `"DDR_SPEED"` in the `bind_telemetry` function to match the naming of other DDR-related tags.

### Testing
/

### API Changes
/