### PR TITLE
Add tt-smi tests

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -108,9 +108,11 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {runs-on: "tt-ubuntu-2204-p150b-stable"},
-          {runs-on: "tt-ubuntu-2204-n150-stable"},
-          {runs-on: "tt-ubuntu-2204-n300-stable"},
+          {runs-on: tt-ubuntu-2204-p150b-stable},
+          {runs-on: tt-ubuntu-2204-n150-stable},
+          {runs-on: tt-ubuntu-2204-n300-stable},
+          {runs-on: tt-ubuntu-2204-n300-llmbox-stable},
+          {runs-on: 6u},
         ]
         ubuntu-docker-version: [
           'ubuntu-22.04',
@@ -133,9 +135,9 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {runs-on: "tt-ubuntu-2204-p150b-stable"},
-          {runs-on: "tt-ubuntu-2204-n150-stable"},
-          {runs-on: "tt-ubuntu-2204-n300-stable"},
+          {runs-on: tt-ubuntu-2204-p150b-stable},
+          {runs-on: tt-ubuntu-2204-n150-stable},
+          {runs-on: tt-ubuntu-2204-n300-stable},
         ]
         ubuntu-docker-version: [
           'ubuntu-22.04',

--- a/.github/workflows/run-tooling-tests.yml
+++ b/.github/workflows/run-tooling-tests.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on:
       - ${{ inputs.card }}
     container:
-      image: ghcr.io/tenstorrent/tt-umd/tt-umd-ci-${{ inputs.ubuntu-docker-version }}:latest
+      image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}:latest
       options: --device /dev/tenstorrent
       volumes:
         - /dev/hugepages:/dev/hugepages
@@ -85,6 +85,6 @@ jobs:
               async with app.run_test(headless=True) as pilot:
                   await pilot.press("q")
 
-          asyncio.run(run())
+          asyncio.run(asyncio.wait_for(run(), timeout=60))
           print("tt-smi ran successfully")
           EOF


### PR DESCRIPTION
### Issue
Somewhat related to https://github.com/tenstorrent/tt-umd/issues/1820
A follow up of https://github.com/tenstorrent/tt-umd/pull/2284
Related to https://github.com/tenstorrent/tt-umd/issues/2282

### Description
Introducing tt-smi basic tests inside our workflows.
This should be spawning up tt-smi tool, and verify it can start. It doesn't, however, verify correctness of data.
That should probably be handled in UMDs unit tests.

### List of the changes
- Added a yaml which runs tt-smi in headless mode

### Testing
You can see the failure here, on "intentional fail" commit: https://github.com/tenstorrent/tt-umd/actions/runs/23096717381/job/67090615984?pr=2286


### API Changes
There are no API changes in this PR.
