### PR TITLE
Skip heartbeat check if eth core disabled

### DIFF
--- a/device/api/umd/device/topology/topology_discovery.hpp
+++ b/device/api/umd/device/topology/topology_discovery.hpp
@@ -74,6 +74,8 @@ protected:
     // eth_core should be in NoC 0 coordinates.
     virtual uint64_t get_remote_asic_id(TTDevice* tt_device, tt_xy_pair eth_core) = 0;
 
+    virtual bool is_eth_port_disabled(TTDevice* tt_device, tt_xy_pair eth_core) { return false; }
+
     virtual bool eth_heartbeat_running(TTDevice* tt_device, tt_xy_pair eth_core);
 
     virtual uint32_t get_eth_heartbeat(TTDevice* tt_device, tt_xy_pair eth_core) = 0;

--- a/device/api/umd/device/topology/topology_discovery_wormhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_wormhole.hpp
@@ -67,6 +67,8 @@ protected:
 
     bool verify_eth_core_fw_version(TTDevice* tt_device, tt_xy_pair eth_core) override;
 
+    bool is_eth_port_disabled(TTDevice* tt_device, tt_xy_pair eth_core) override;
+
     uint32_t get_eth_heartbeat(TTDevice* tt_device, tt_xy_pair eth_core) override;
 
     uint32_t get_eth_postcode(TTDevice* tt_device, tt_xy_pair eth_core) override;

--- a/device/api/umd/device/types/wormhole_eth.hpp
+++ b/device/api/umd/device/types/wormhole_eth.hpp
@@ -30,4 +30,8 @@ inline constexpr uint32_t ETH_LINK_UNUSED_ERROR_CODE_RANGE_START = 11;
 inline constexpr uint32_t ETH_POSTCODE_ADDR = 0xFFB3010C;
 inline constexpr uint32_t ETH_HEARTBEAT_ADDR = 0x1F80;  // test_results[48];
 
+// boot_params_t is copied from SPI to ETH core L1 at 0x1000.
+// port_disable_mask is field [2] (8 bytes in): bit N=1 means port N is disabled.
+inline constexpr uint32_t ETH_BOOT_PARAMS_PORT_DISABLE_ADDR = 0x1008;
+
 }  // namespace tt::umd::wormhole

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -197,6 +197,16 @@ void TopologyDiscovery::discover_remote_devices() {
         for (const CoreCoord& eth_core : eth_cores) {
             const uint32_t channel = get_soc_descriptor(tt_device).get_eth_channel_for_core(eth_core);
 
+            if (is_eth_port_disabled(tt_device, eth_core)) {
+                log_debug(
+                    LogUMD,
+                    "Skipping disabled ETH core {} on device ASIC ID: {} (port_disable_mask bit {} is set)",
+                    eth_core.str(),
+                    current_device_asic_id,
+                    channel);
+                continue;
+            }
+
             if (!eth_heartbeat_running(tt_device, eth_core)) {
                 std::string msg = fmt::format(
                     "ETH core heartbeat check failed on device ASIC ID: {}, ETH core {}, post code: {:x}",

--- a/device/topology/topology_discovery_wormhole.cpp
+++ b/device/topology/topology_discovery_wormhole.cpp
@@ -276,6 +276,16 @@ void TopologyDiscoveryWormhole::verify_routing_firmware_state(TTDevice* tt_devic
     }
 }
 
+bool TopologyDiscoveryWormhole::is_eth_port_disabled(TTDevice* tt_device, tt_xy_pair eth_core) {
+    uint32_t port_disable_mask = 0;
+    tt_device->read_from_device(
+        &port_disable_mask, eth_core, wormhole::ETH_BOOT_PARAMS_PORT_DISABLE_ADDR, sizeof(uint32_t));
+    const CoordSystem noc_system = is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0;
+    const uint32_t channel =
+        get_soc_descriptor(tt_device).translate_coord_to(eth_core, noc_system, CoordSystem::LOGICAL).y;
+    return (port_disable_mask >> channel) & 1;
+}
+
 uint32_t TopologyDiscoveryWormhole::get_eth_heartbeat(TTDevice* tt_device, tt_xy_pair eth_core) {
     uint32_t heartbeat_value = 0;
     tt_device->read_from_device(&heartbeat_value, eth_core, wormhole::ETH_HEARTBEAT_ADDR, sizeof(uint32_t));


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2162
A follow up to https://github.com/tenstorrent/tt-umd/pull/2109

### Description
This check fails if eth core is intentionaly disabled. Which is not a wanted behavior.
I let claude code figure this out from syseng and tt-topology repos.

### List of the changes
- Check if ETH core is disabled
- Skip other checks in this case

### Testing
Tested manually on an IRD machine which was previously failing. This is an N300 machine which is connected to other cards (probably t3k ?), with disabled eth so users can share more cards.
Also verified the log_debug output.

### API Changes
There are no API changes in this PR.
