### PR TITLE
Consolidate debug logs to reduce terminal noise

### DIFF
--- a/device/chip_helpers/sysmem_manager.cpp
+++ b/device/chip_helpers/sysmem_manager.cpp
@@ -58,7 +58,7 @@ void SysmemManager::read_from_sysmem(uint16_t channel, void *dest, uint64_t sysm
     if (tt_device_) {
         log_debug(
             LogUMD,
-            "Cluster::read_buffer (comm. device ID: {}, ch: {}) from {:p}",
+            "SysmemManager: read_from_sysmem (comm. device ID: {}, ch: {}) from {:p}",
             tt_device_->get_communication_device_id(),
             channel,
             user_scratchspace);

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -94,7 +94,7 @@ bool ClusterDescriptor::is_chip_remote(const ChipId chip_id) const { return !is_
 
 // Returns the closest mmio chip to the given chip.
 ChipId ClusterDescriptor::get_closest_mmio_capable_chip(const ChipId chip) {
-    log_debug(LogUMD, "get_closest_mmio_chip to chip{}", chip);
+    log_trace(LogUMD, "get_closest_mmio_chip to chip{}", chip);
 
     if (this->is_chip_mmio_capable(chip)) {
         return chip;


### PR DESCRIPTION
### Issue
/

### Description
Consolidate log messages to reduce terminal spam when debugging tt-metal programs. Fixes a misleading log prefix and downgrades a frequently-hit log to trace level.

### List of the changes
- Fix log message in `SysmemManager::read_from_sysmem` to use correct class name instead of stale "Cluster::read_buffer" prefix
- Downgrade `get_closest_mmio_chip` log in `ClusterDescriptor` from `log_debug` to `log_trace` as it fires very frequently

### Testing
CI

### API Changes
There are no API changes in this PR.