### PR TITLE
Move safe_* default implementations to TlbWindow base class

### DIFF
--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -46,23 +46,23 @@ public:
         uint64_t addr,
         uint64_t ordering = tlb_data::Strict);
 
-    virtual void safe_write32(uint64_t offset, uint32_t value) = 0;
+    virtual void safe_write32(uint64_t offset, uint32_t value);
 
-    virtual uint32_t safe_read32(uint64_t offset) = 0;
+    virtual uint32_t safe_read32(uint64_t offset);
 
-    virtual void safe_write_register(uint64_t offset, const void* data, size_t size) = 0;
+    virtual void safe_write_register(uint64_t offset, const void* data, size_t size);
 
-    virtual void safe_read_register(uint64_t offset, void* data, size_t size) = 0;
+    virtual void safe_read_register(uint64_t offset, void* data, size_t size);
 
-    virtual void safe_write_block(uint64_t offset, const void* data, size_t size) = 0;
+    virtual void safe_write_block(uint64_t offset, const void* data, size_t size);
 
-    virtual void safe_read_block(uint64_t offset, void* data, size_t size) = 0;
+    virtual void safe_read_block(uint64_t offset, void* data, size_t size);
 
     virtual void safe_write_block_reconfigure(
-        const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering = tlb_data::Strict) = 0;
+        const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering = tlb_data::Strict);
 
     virtual void safe_read_block_reconfigure(
-        void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering = tlb_data::Strict) = 0;
+        void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering = tlb_data::Strict);
 
     virtual void safe_noc_multicast_write_reconfigure(
         void* dst,
@@ -70,7 +70,7 @@ public:
         tt_xy_pair core_start,
         tt_xy_pair core_end,
         uint64_t addr,
-        uint64_t ordering = tlb_data::Strict) = 0;
+        uint64_t ordering = tlb_data::Strict);
 
     // Shared utility methods.
     TlbHandle& handle_ref() const;

--- a/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
@@ -31,36 +31,6 @@ public:
     void write_block(uint64_t offset, const void* data, size_t size) override;
     void read_block(uint64_t offset, void* data, size_t size) override;
 
-    void safe_write32(uint64_t offset, uint32_t value) override;
-
-    uint32_t safe_read32(uint64_t offset) override;
-
-    void safe_write_register(uint64_t offset, const void* data, size_t size) override;
-
-    void safe_read_register(uint64_t offset, void* data, size_t size) override;
-
-    void safe_write_block(uint64_t offset, const void* data, size_t size) override;
-
-    void safe_read_block(uint64_t offset, void* data, size_t size) override;
-
-    void safe_write_block_reconfigure(
-        const void* mem_ptr,
-        tt_xy_pair core,
-        uint64_t addr,
-        uint32_t size,
-        uint64_t ordering = tlb_data::Strict) override;
-
-    void safe_read_block_reconfigure(
-        void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering = tlb_data::Strict) override;
-
-    void safe_noc_multicast_write_reconfigure(
-        void* dst,
-        size_t size,
-        tt_xy_pair core_start,
-        tt_xy_pair core_end,
-        uint64_t addr,
-        uint64_t ordering = tlb_data::Strict) override;
-
 protected:
     tt::ARCH get_arch() const override;
 

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -129,4 +129,33 @@ uint64_t TlbWindow::get_base_address() const {
     return handle_ref().get_config().local_offset + offset_from_aligned_addr;
 }
 
+void TlbWindow::safe_write32(uint64_t offset, uint32_t value) { write32(offset, value); }
+
+uint32_t TlbWindow::safe_read32(uint64_t offset) { return read32(offset); }
+
+void TlbWindow::safe_write_register(uint64_t offset, const void* data, size_t size) {
+    write_register(offset, data, size);
+}
+
+void TlbWindow::safe_read_register(uint64_t offset, void* data, size_t size) { read_register(offset, data, size); }
+
+void TlbWindow::safe_write_block(uint64_t offset, const void* data, size_t size) { write_block(offset, data, size); }
+
+void TlbWindow::safe_read_block(uint64_t offset, void* data, size_t size) { read_block(offset, data, size); }
+
+void TlbWindow::safe_write_block_reconfigure(
+    const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering) {
+    write_block_reconfigure(mem_ptr, core, addr, size, ordering);
+}
+
+void TlbWindow::safe_read_block_reconfigure(
+    void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering) {
+    read_block_reconfigure(mem_ptr, core, addr, size, ordering);
+}
+
+void TlbWindow::safe_noc_multicast_write_reconfigure(
+    void* dst, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, uint64_t ordering) {
+    noc_multicast_write_reconfigure(dst, size, core_start, core_end, addr, ordering);
+}
+
 }  // namespace tt::umd

--- a/device/pcie/tt_sim_tlb_window.cpp
+++ b/device/pcie/tt_sim_tlb_window.cpp
@@ -59,46 +59,6 @@ uint64_t TTSimTlbWindow::get_physical_address(uint64_t offset) const {
     return reinterpret_cast<uint64_t>(tlb_handle->get_base()) + get_total_offset(offset);
 }
 
-void TTSimTlbWindow::safe_write32(uint64_t offset, uint32_t value) {
-    // In simulation, we can assume all accesses are "safe" since we're not dealing with real hardware constraints.
-    // However, we still want to validate the offset and size to prevent out-of-bounds access in our simulated memory.
-    write32(offset, value);
-}
-
-uint32_t TTSimTlbWindow::safe_read32(uint64_t offset) {
-    // Similar to safe_write32, we will just call the regular read32 after validating the offset.
-    return read32(offset);
-}
-
-void TTSimTlbWindow::safe_write_register(uint64_t offset, const void* data, size_t size) {
-    write_register(offset, data, size);
-}
-
-void TTSimTlbWindow::safe_read_register(uint64_t offset, void* data, size_t size) {
-    read_register(offset, data, size);
-}
-
-void TTSimTlbWindow::safe_write_block(uint64_t offset, const void* data, size_t size) {
-    write_block(offset, data, size);
-}
-
-void TTSimTlbWindow::safe_read_block(uint64_t offset, void* data, size_t size) { read_block(offset, data, size); }
-
-void TTSimTlbWindow::safe_write_block_reconfigure(
-    const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering) {
-    write_block_reconfigure(mem_ptr, core, addr, size, ordering);
-}
-
-void TTSimTlbWindow::safe_read_block_reconfigure(
-    void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering) {
-    read_block_reconfigure(mem_ptr, core, addr, size, ordering);
-}
-
-void TTSimTlbWindow::safe_noc_multicast_write_reconfigure(
-    void* dst, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, uint64_t ordering) {
-    noc_multicast_write_reconfigure(dst, size, core_start, core_end, addr, ordering);
-}
-
 tt::ARCH TTSimTlbWindow::get_arch() const {
     TTSimTlbHandle* sim_handle = dynamic_cast<TTSimTlbHandle*>(tlb_handle.get());
     return sim_handle->get_tlb_manager()->get_tt_device()->get_arch();


### PR DESCRIPTION
### Issue
/

### Description
Move safe_* method default implementations from pure virtual in TlbWindow to base class implementations that delegate to the unsafe counterparts. Only SiliconTlbWindow keeps its overrides (SIGBUS handler).

### List of the changes
- `tlb_window.hpp`: Change safe_* methods from pure virtual (`= 0`) to virtual with default implementations
- `tlb_window.cpp`: Add default implementations that call the non-safe counterparts
- `tt_sim_tlb_window.hpp/cpp`: Remove redundant safe_* overrides (now inherited from base)
- `silicon_tlb_window.hpp/cpp`: Unchanged — keeps SIGBUS-wrapped safe_* overrides

### Testing
CI

### API Changes
There are no API changes in this PR.