### PR TITLE
Temporarily disable throwing on ETH hearbeat check

### DIFF
--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -204,7 +204,7 @@ void TopologyDiscovery::discover_remote_devices() {
                     eth_core.str(),
                     get_eth_postcode(tt_device, eth_core));
                 if (options.eth_fw_heartbeat_failure == TopologyDiscoveryOptions::Action::THROW) {
-                    // TODO: Re-enable throwing once Fabric fixes bug that breaks ETH heartbeat.
+                    // TODO #2318: Re-enable throwing once Fabric fixes bug that breaks ETH heartbeat.
                     // TT_THROW(msg);.
                 } else {
                     log_warning(LogUMD, msg);


### PR DESCRIPTION
### Issue
#2318

### Description
Temporarily disable throwing on ETH hearbeat check to unblock push to Metal.

### List of the changes
- Temporarily disable throwing on ETH hearbeat check.

### Testing
CI

### API Changes
There are no API changes in this PR.
