### PR TITLE
Add get_static_tlb_window to Cluster API

### DIFF
--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -474,6 +474,19 @@ public:
      *
      * @param target The target chip and core to write to.
      */
+    Writer get_static_tlb_writer(const ChipId chip, const CoreCoord core);
+
+    /**
+     * Provide fast read/write access to a statically-mapped TLB.
+     * It is the caller's responsibility to ensure that
+     * - the target has a static TLB mapping configured.
+     * - the mapping is unchanged during the lifetime of the returned pointer.
+     * - the Cluster instance outlives the returned pointer.
+     * - use of the returned pointer is congruent with the target's TLB setup.
+     *
+     * @param chip The chip to access.
+     * @param core The core to access.
+     */
     TlbWindow* get_static_tlb_window(const ChipId chip, const CoreCoord core);
 
     //---------- Functions for synchronization and memory barriers.

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -458,6 +458,11 @@ void Cluster::deassert_risc_reset(
 
 ClusterDescriptor* Cluster::get_cluster_description() { return cluster_desc.get(); }
 
+Writer Cluster::get_static_tlb_writer(const ChipId chip, const CoreCoord core) {
+    tt_xy_pair translated_core = get_chip(chip)->get_soc_descriptor().translate_chip_coord_to_translated(core);
+    return get_tlb_manager(chip)->get_static_tlb_writer(translated_core);
+}
+
 TlbWindow* Cluster::get_static_tlb_window(const ChipId chip, const CoreCoord core) {
     tt_xy_pair translated_core = get_chip(chip)->get_soc_descriptor().translate_chip_coord_to_translated(core);
     return get_tlb_manager(chip)->get_tlb_window(translated_core);


### PR DESCRIPTION
**Issue**
/

**Description**
Add `get_static_tlb_window` method to `Cluster` that returns a `TlbWindow*` for direct read/write access to a statically-mapped TLB. This is needed for Metal fast dispatch changes that require direct TLB window access rather than going through the `Writer` abstraction.

`get_static_tlb_writer` and the `Writer` class will be removed once all downstream consumers have migrated to use `TlbWindow`.

**List of the changes**
- Added `Cluster::get_static_tlb_window` returning `TlbWindow*` for a given chip and core
- Retained existing `Cluster::get_static_tlb_writer` unchanged

**Testing**
CI

**API Changes**
New public method on `Cluster`: `get_static_tlb_window(ChipId, CoreCoord)`.