### PR TITLE
Make TLBManager::allocate_tlb_window virtual and add virtual destructor

### DIFF
--- a/device/api/umd/device/chip_helpers/tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/tlb_manager.hpp
@@ -20,6 +20,7 @@ class TTDevice;
 class TLBManager {
 public:
     TLBManager(TTDevice* tt_device);
+    virtual ~TLBManager() = default;
 
     // All tt_xy_pairs should be in TRANSLATED coords.
     void configure_tlb(tt_xy_pair core, size_t tlb_size, uint64_t address, uint64_t ordering);
@@ -38,7 +39,7 @@ public:
 
     TlbWindow* get_tlb_window(const tt_xy_pair core);
 
-    std::unique_ptr<TlbWindow> allocate_tlb_window(
+    virtual std::unique_ptr<TlbWindow> allocate_tlb_window(
         tlb_data config, const TlbMapping mapping = TlbMapping::WC, const size_t tlb_size = 0);
 
     // Clear all static TLB mappings.

--- a/device/api/umd/device/chip_helpers/tt_sim_tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/tt_sim_tlb_manager.hpp
@@ -21,7 +21,7 @@ public:
     TTSimTlbManager(TTDevice* tt_device);
 
     std::unique_ptr<TlbWindow> allocate_tlb_window(
-        tlb_data config, const TlbMapping mapping = TlbMapping::WC, const size_t tlb_size = 0);
+        tlb_data config, const TlbMapping mapping = TlbMapping::WC, const size_t tlb_size = 0) override;
 
     /**
      * Allocate a TLB index based on the requested size.


### PR DESCRIPTION
### Issue
/

### Description
`TTSimTlbManager` derives from `TLBManager` and shadows `allocate_tlb_window` without it being virtual, causing incorrect dispatch through base pointers. This makes it virtual and adds a virtual destructor.

### List of the changes
- Mark `TLBManager::allocate_tlb_window` as `virtual`
- Add `virtual ~TLBManager() = default`
- Add `override` to `TTSimTlbManager::allocate_tlb_window`

### Testing
CI

### API Changes
There are no API changes in this PR.