### PR TITLE
Make RobustMutex::lock() interruptible by SIGINT

### DIFF
--- a/device/utils/robust_mutex.cpp
+++ b/device/utils/robust_mutex.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2026 Sungjoon Moon
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,9 +16,12 @@
 
 #include <cerrno>  // errno, ENOENT
 #include <chrono>
+#include <csignal>  // sigaction, SIGINT
 #include <cstdint>
 #include <ctime>  // clock_gettime, timespec
+#include <mutex>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <utility>
@@ -94,6 +98,53 @@ private:
 };
 
 pthread_mutex_t RobustMutex::multithread_mutex_ = PTHREAD_MUTEX_INITIALIZER;
+
+namespace {
+
+volatile sig_atomic_t sigint_seq = 0;
+
+void sigint_handler(int /*sig*/) { ++sigint_seq; }
+
+class SigintHandlerScope {
+public:
+    SigintHandlerScope() {
+        std::lock_guard<std::mutex> guard(mutex_);
+        seq_at_install_ = sigint_seq;
+        if (refcount_ == 0) {
+            struct sigaction sa = {};
+            sa.sa_handler = sigint_handler;
+            sigemptyset(&sa.sa_mask);
+            sa.sa_flags = 0;
+            int rc = sigaction(SIGINT, &sa, &saved_action_);
+            UMD_ASSERT(
+                rc == 0,
+                error::RuntimeError,
+                fmt::format("sigaction() install failed errno: {}", std::to_string(errno)));
+        }
+        ++refcount_;
+    }
+
+    ~SigintHandlerScope() noexcept {
+        std::lock_guard<std::mutex> guard(mutex_);
+        --refcount_;
+        if (refcount_ == 0) {
+            int rc = sigaction(SIGINT, &saved_action_, nullptr);
+            if (rc != 0) {
+                log_warning(LogUMD, "sigaction() restore failed errno: {}", std::to_string(errno));
+            }
+        }
+    }
+
+    bool interrupted() const { return sigint_seq != seq_at_install_; }
+
+private:
+    inline static std::mutex mutex_;
+    inline static int refcount_ = 0;
+    inline static struct sigaction saved_action_ = {};
+    sig_atomic_t seq_at_install_ = 0;
+};
+
+}  // namespace
 
 #ifdef __SANITIZE_THREAD__
 // Static storage for TSAN mutex identifiers.
@@ -448,33 +499,31 @@ std::optional<std::pair<pid_t, pid_t>> RobustMutex::probe_lock(std::chrono::seco
 }
 
 void RobustMutex::lock() {
-    // Use a 1-second timed attempt first so we can emit a warning when the lock is contended.
-    if (auto owner = probe_lock(std::chrono::seconds(1))) {
-        log_warning(
-            LogUMD,
-            "Waiting for lock '{}' which is currently held by thread TID: {}, PID: {}",
-            mutex_name_,
-            owner->second,
-            owner->first);
-
-        // Block indefinitely until the lock becomes available.
-        int lock_res = pthread_mutex_lock(&(mutex_wrapper_ptr_->mutex));
-        if (lock_res == EOWNERDEAD) {
-            int err = pthread_mutex_consistent(&(mutex_wrapper_ptr_->mutex));
-            if (err != 0) {
-                UMD_THROW(
-                    error::RuntimeError,
-                    fmt::format(
-                        "pthread_mutex_consistent() failed for mutex {} errno: {}", mutex_name_, std::to_string(err)));
-            }
-        } else if (lock_res != 0) {
-            UMD_THROW(
-                error::RuntimeError,
-                fmt::format(
-                    "pthread_mutex_lock() failed for mutex {} errno: {}", mutex_name_, std::to_string(lock_res)));
-        }
-        record_acquisition();
+    auto owner = probe_lock(std::chrono::seconds(1));
+    if (!owner) {
+        return;
     }
+
+    log_warning(
+        LogUMD,
+        "Waiting for lock '{}' which is currently held by thread TID: {}, PID: {}",
+        mutex_name_,
+        owner->second,
+        owner->first);
+
+    {
+        SigintHandlerScope sigint_scope;
+        while (!sigint_scope.interrupted()) {
+            owner = probe_lock(std::chrono::seconds(1));
+            if (!owner) {
+                return;
+            }
+        }
+    }
+
+    log_warning(LogUMD, "Lock acquisition for '{}' interrupted", mutex_name_);
+    raise(SIGINT);
+    throw std::runtime_error("Interrupted");
 }
 
 }  // namespace tt::umd

--- a/tests/misc/CMakeLists.txt
+++ b/tests/misc/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(UMD_MISC_TESTS_SRCS
     test_semver.cpp
     test_errors.cpp
+    test_robust_mutex_sigint.cpp
 )
 
 add_executable(umd_misc_tests ${UMD_MISC_TESTS_SRCS})

--- a/tests/misc/test_robust_mutex_sigint.cpp
+++ b/tests/misc/test_robust_mutex_sigint.cpp
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: © 2026 Sungjoon Moon
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <csignal>
+#include <thread>
+
+#include "umd/device/utils/robust_mutex.hpp"
+
+using tt::umd::RobustMutex;
+
+static constexpr const char* TEST_MUTEX_NAME = "TEST_SIGINT";
+
+static void noop_handler(int) {}
+
+class RobustMutexSigintTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        shm_unlink(("TT_UMD_LOCK." + std::string(TEST_MUTEX_NAME)).c_str());
+        struct sigaction sa = {};
+        sa.sa_handler = noop_handler;
+        sigemptyset(&sa.sa_mask);
+        ASSERT_EQ(sigaction(SIGINT, &sa, &old_action_), 0);
+    }
+
+    void TearDown() override {
+        ASSERT_EQ(sigaction(SIGINT, &old_action_, nullptr), 0);
+        shm_unlink(("TT_UMD_LOCK." + std::string(TEST_MUTEX_NAME)).c_str());
+    }
+
+    struct sigaction old_action_ = {};
+};
+
+TEST_F(RobustMutexSigintTest, NormalLockSucceeds) {
+    RobustMutex m(TEST_MUTEX_NAME);
+    m.initialize();
+    m.lock();
+    m.unlock();
+}
+
+TEST_F(RobustMutexSigintTest, SigintAbortsPendingLock) {
+    RobustMutex holder(TEST_MUTEX_NAME);
+    holder.initialize();
+    holder.lock();
+
+    std::thread waiter([&] {
+        RobustMutex m(TEST_MUTEX_NAME);
+        m.initialize();
+        EXPECT_THROW(m.lock(), std::exception);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+    kill(getpid(), SIGINT);
+
+    waiter.join();
+    holder.unlock();
+}
+
+TEST_F(RobustMutexSigintTest, SigintWithChildProcess) {
+    int ready_pipe[2];
+    int done_pipe[2];
+    ASSERT_EQ(pipe(ready_pipe), 0);
+    ASSERT_EQ(pipe(done_pipe), 0);
+
+    pid_t pid = fork();
+    ASSERT_NE(pid, -1);
+
+    if (pid == 0) {
+        if (close(ready_pipe[0]) != 0) {
+            _exit(10);
+        }
+        if (close(done_pipe[1]) != 0) {
+            _exit(11);
+        }
+
+        RobustMutex m(TEST_MUTEX_NAME);
+        m.initialize();
+        m.lock();
+
+        char ready = 1;
+        if (write(ready_pipe[1], &ready, 1) != 1) {
+            _exit(12);
+        }
+        if (close(ready_pipe[1]) != 0) {
+            _exit(13);
+        }
+
+        char buf;
+        if (read(done_pipe[0], &buf, 1) < 0) {
+            _exit(14);
+        }
+        m.unlock();
+        if (close(done_pipe[0]) != 0) {
+            _exit(15);
+        }
+        _exit(0);
+    }
+
+    ASSERT_EQ(close(ready_pipe[1]), 0);
+    ASSERT_EQ(close(done_pipe[0]), 0);
+
+    char ready;
+    ASSERT_EQ(read(ready_pipe[0], &ready, 1), 1);
+    ASSERT_EQ(close(ready_pipe[0]), 0);
+
+    RobustMutex m(TEST_MUTEX_NAME);
+    m.initialize();
+
+    std::thread waiter([&] { EXPECT_THROW(m.lock(), std::exception); });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+    kill(getpid(), SIGINT);
+
+    waiter.join();
+
+    ASSERT_EQ(close(done_pipe[1]), 0);
+    int status;
+    ASSERT_EQ(waitpid(pid, &status, 0), pid);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+}


### PR DESCRIPTION
Replace pthread_mutex_lock() (blocks forever) with a pthread_mutex_timedlock() loop. Install a temporary SIGINT handler during lock contention so Ctrl+C can abort the wait.

### Issue
#2336 

### Description
When a process waits for a device lock (e.g. `CHIP_IN_USE`) held by another process, Ctrl+C is ignored. The only way to stop it is `kill -9` from another terminal.

This happens because `lock()` calls `pthread_mutex_lock()` after the first 1-second timeout, which blocks forever with no way to interrupt.

### List of the changes
  - Replace blocking `pthread_mutex_lock()` with a `pthread_mutex_timedlock()` loop (1-second retries) via the existing `probe_lock()` helper
  - Add `SigintHandlerScope` (RAII): refcounted, process-wide install/restore of a SIGINT handler so concurrent `RobustMutex::lock()` callers don't race on `sigaction()` state
  - Use a monotonic `sigint_seq` counter (incremented by the handler, never reset) so concurrent waiters can't clear each other's interrupt notification
  - On interrupt: restore the previous handler, `raise(SIGINT)` so the original (e.g. Python) handler observes the signal, then throw `std::runtime_error("Interrupted")`
  - Add 3 unit tests (normal lock, same-process thread contention, cross-process via fork)

### Testing
- Unit tests pass (no hardware needed)
- Manually tested on Blackhole:
> Terminal 1: 
```python
python -c "import ttnn; device = ttnn.open_device(device_id=0); input('Press Enter to close'); ttnn.close_device(device)"
```
> Terminal 2:
```python
python -c "import ttnn; device = ttnn.open_device(device_id=0)"
```
> Ctrl+C on terminal 2:
```sh
2026-03-20 02:26:44.191 | info     |             UMD | Starting devices in cluster (cluster.cpp:946)                                                                                                                                                                                                                                                                                            
2026-03-20 02:26:45.191 | warning  |             UMD | Waiting for lock 'CHIP_IN_USE_0_PCIe' which is currently held by thread TID: 2550360, PID: 2550360 (robust_mutex.cpp:429)                                                                                                                                                                                                                
^C2026-03-20 02:26:46.191 | warning  |             UMD | Lock acquisition for 'CHIP_IN_USE_0_PCIe' interrupted (robust_mutex.cpp:419)                                                                                                                                                                                                                                                           
object address  : 0x7f38aacba2c0                                                                                                                                                                                                                                                                                                                                                                
object refcount : 3                                                                                                                                                                                                                                                                                                                                                                             
object type     : 0x13fae58                                                                                                                                                                                                                                                                                                                                                                     
object type name: RuntimeError                                                                                                                                                                                                                                                                                                                                                                  
object repr     : RuntimeError('Interrupted')                                                                                                                                                                                                                                                                                                                                                   
lost sys.stderr                              

```
### API Changes
No API changes here

### Note
- #2287 also changes `lock()` -- happy to rebase.
- The `object address` / `lost sys.stderr` output on exit is a tt-metal issue (exception not caught during interpreter shutdown), not a tt-umd issue.
```
object address  : 0x7f38aacba2c0                                                                                                                                                                                                                                                                                                                                                                
object refcount : 3                                                                                                                                                                                                                                                                                                                                                                             
object type     : 0x13fae58                                                                                                                                                                                                                                                                                                                                                                     
object type name: RuntimeError                                                                                                                                                                                                                                                                                                                                                                  
object repr     : RuntimeError('Interrupted')                                                                                                                                                                                                                                                                                                                                                   
lost sys.stderr 
```