### PR TITLE
Replace hugetlbfs file-backed hugepages with MAP_HUGETLB anonymous mappings

### DIFF
--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -6,8 +6,8 @@
 
 #include "umd/device/chip_helpers/silicon_sysmem_manager.hpp"
 
-#include <sys/mman.h>  // for mmap, munmap
-#include <sys/stat.h>  // for fstat
+#include <linux/mman.h>  // for MAP_HUGE_1GB
+#include <sys/mman.h>   // for mmap, munmap
 
 #include <cerrno>
 #include <cstddef>
@@ -27,6 +27,33 @@
 #include "hugepage.hpp"
 
 namespace tt::umd {
+
+// Try to mmap with 1GB hugepages first, then 2MB hugepages, then regular pages.
+// This is a performance optimization: hugepages reduce page fault overhead during allocation.
+// All three options are functionally correct when IOMMU is enabled.
+static void *mmap_with_hugepage_fallback(size_t size) {
+    void *addr = mmap(
+        nullptr, size, PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_1GB | MAP_POPULATE, -1, 0);
+    if (addr != MAP_FAILED) {
+        log_debug(LogUMD, "Allocated {:#x} bytes using 1GB hugepages.", size);
+        return addr;
+    }
+
+    addr = mmap(
+        nullptr, size, PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_2MB | MAP_POPULATE, -1, 0);
+    if (addr != MAP_FAILED) {
+        log_debug(LogUMD, "Allocated {:#x} bytes using 2MB hugepages.", size);
+        return addr;
+    }
+
+    addr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE, -1, 0);
+    if (addr != MAP_FAILED) {
+        log_debug(LogUMD, "Allocated {:#x} bytes using regular pages.", size);
+    }
+    return addr;
+}
 
 SiliconSysmemManager::SiliconSysmemManager(TLBManager *tlb_manager, uint32_t num_host_mem_channels) {
     tlb_manager_ = tlb_manager;
@@ -113,59 +140,28 @@ bool SiliconSysmemManager::init_hugepages(uint32_t num_host_mem_channels) {
     const size_t hugepage_size = HUGEPAGE_REGION_SIZE;
     auto physical_device_id = tt_device_->get_pci_device()->get_device_num();
 
-    std::string hugepage_dir = find_hugepage_dir(hugepage_size);
-    if (hugepage_dir.empty()) {
-        log_warning(
-            LogUMD,
-            "SiliconSysmemManager::init_hugepage: no huge page mount found for hugepage_size: {}.",
-            hugepage_size);
-        return false;
-    }
-
     bool success = true;
 
     hugepage_mapping_per_channel.resize(num_host_mem_channels);
 
     // Support for more than 1GB host memory accessible per device, via channels.
     for (int ch = 0; ch < num_host_mem_channels; ch++) {
-        int hugepage_fd = open_hugepage_file(hugepage_dir, physical_device_id, ch);
-        if (hugepage_fd == -1) {
-            // Probably a permissions problem.
-            log_warning(
-                LogUMD,
-                "SiliconSysmemManager::init_hugepage: physical_device_id: {} ch: {} creating hugepage mapping file "
-                "failed.",
-                physical_device_id,
-                ch);
-            success = false;
-            continue;
-        }
-
-        // Verify opened file size.
-        struct stat hugepage_st;
-        if (fstat(hugepage_fd, &hugepage_st) == -1) {
-            log_warning(LogUMD, "Error reading hugepage file size after opening.");
-        }
-
-        std::byte *mapping = static_cast<std::byte *>(
-            mmap(nullptr, hugepage_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, hugepage_fd, 0));
-
-        close(hugepage_fd);
+        std::byte *mapping = static_cast<std::byte *>(mmap(
+            nullptr,
+            hugepage_size,
+            PROT_READ | PROT_WRITE,
+            MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_1GB | MAP_POPULATE,
+            -1,
+            0));
 
         if (mapping == MAP_FAILED) {
             log_warning(
                 LogUMD,
-                "UMD: Mapping a hugepage failed. (device: {}, {}/{} errno: {}).",
+                "UMD: Hugepage allocation failed. (device: {}, {}/{} errno: {}).",
                 physical_device_id,
                 ch,
                 num_host_mem_channels,
                 strerror(errno));
-            if (hugepage_st.st_size == 0) {
-                log_warning(
-                    LogUMD,
-                    "Opened hugepage file has zero size, mapping might've failed due to that. Verify that enough "
-                    "hugepages are provided.");
-            }
             print_file_contents("/proc/cmdline");
             print_file_contents(
                 "/sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages");  // Hardcoded for 1GB hugepage.
@@ -173,7 +169,7 @@ bool SiliconSysmemManager::init_hugepages(uint32_t num_host_mem_channels) {
             continue;
         }
 
-        // Beter performance if hugepage just allocated (populate flag to prevent lazy alloc) is migrated to same
+        // Better performance if hugepage just allocated (populate flag to prevent lazy alloc) is migrated to same
         // numanode as TT device.
         if (!tt::cpuset::cpuset_allocator::bind_area_to_memory_nodeset(physical_device_id, mapping, hugepage_size)) {
             log_warning(
@@ -278,8 +274,8 @@ bool SiliconSysmemManager::init_iommu(uint32_t num_fake_mem_channels) {
         TT_THROW("IOMMU is required for sysmem without hugepages.");
     }
 
-    log_info(LogUMD, "Allocating sysmem without hugepages (size: {:#x}).", iommu_mapping_size);
-    iommu_mapping = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
+    log_info(LogUMD, "Allocating sysmem for IOMMU (size: {:#x}).", iommu_mapping_size);
+    iommu_mapping = mmap_with_hugepage_fallback(size);
 
     if (iommu_mapping == MAP_FAILED) {
         TT_THROW(
@@ -348,8 +344,7 @@ void SiliconSysmemManager::print_file_contents(const std::string &filename, cons
 
 std::unique_ptr<SysmemBuffer> SiliconSysmemManager::allocate_sysmem_buffer(
     size_t sysmem_buffer_size, const bool map_to_noc) {
-    void *mapping =
-        mmap(nullptr, sysmem_buffer_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
+    void *mapping = mmap_with_hugepage_fallback(sysmem_buffer_size);
     return map_sysmem_buffer(mapping, sysmem_buffer_size, map_to_noc);
 }
 

--- a/device/hugepage.cpp
+++ b/device/hugepage.cpp
@@ -4,19 +4,13 @@
 
 #include "hugepage.hpp"
 
-#include <fcntl.h>     // for O_RDWR and other constants
-#include <sys/stat.h>  // for umask
-
 #include <algorithm>
 #include <cerrno>
-#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <fstream>
-#include <regex>
 #include <string>
 #include <tt-logger/tt-logger.hpp>
-#include <vector>
 
 #include "assert.hpp"
 #include "cpuset_lib.hpp"
@@ -24,8 +18,6 @@
 namespace tt::umd {
 
 const uint32_t g_MAX_HOST_MEM_CHANNELS = 4;
-
-const std::string hugepage_dir = "/dev/hugepages-1G";
 
 uint32_t get_num_hugepages() {
     std::string nr_hugepages_path = "/sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages";
@@ -104,112 +96,6 @@ uint32_t get_available_num_host_mem_channels(
         g_MAX_HOST_MEM_CHANNELS);
 
     return num_channels_per_device_available;
-}
-
-std::string find_hugepage_dir(std::size_t pagesize) {
-    static const std::regex hugetlbfs_mount_re(
-        fmt::format("^(nodev|hugetlbfs) ({}) hugetlbfs ([^ ]+) 0 0$", hugepage_dir));
-    static const std::regex pagesize_re("(?:^|,)pagesize=([0-9]+)([KMGT])(?:,|$)");
-
-    std::ifstream proc_mounts("/proc/mounts");
-
-    for (std::string line; std::getline(proc_mounts, line);) {
-        if (std::smatch mount_match; std::regex_match(line, mount_match, hugetlbfs_mount_re)) {
-            std::string options = mount_match[3];
-            if (std::smatch pagesize_match; std::regex_search(options, pagesize_match, pagesize_re)) {
-                std::size_t mount_page_size = std::stoull(pagesize_match[1]);
-                switch (pagesize_match[2].str()[0]) {
-                    case 'T':
-                        mount_page_size <<= 10;
-                        [[fallthrough]];
-                    case 'G':
-                        mount_page_size <<= 10;
-                        [[fallthrough]];
-                    case 'M':
-                        mount_page_size <<= 10;
-                        [[fallthrough]];
-                    case 'K':
-                        mount_page_size <<= 10;
-                        break;
-                    default:
-                        // Should never reach here as regex only matches [KMGT].
-                        TT_THROW("Unexpected page size suffix: {}", pagesize_match[2].str());
-                }
-
-                if (mount_page_size == pagesize) {
-                    return mount_match[2];
-                }
-            }
-        }
-    }
-
-    log_warning(
-        LogUMD,
-        "ttSiliconDevice::find_hugepage_dir: no huge page mount found in /proc/mounts for path: {} with hugepage_size: "
-        "{}.",
-        hugepage_dir,
-        pagesize);
-    return std::string();
-}
-
-int open_hugepage_file(const std::string& dir, ChipId physical_device_id, uint16_t channel) {
-    std::vector<char> filename;
-    static const char pipeline_name[] = "tenstorrent";
-
-    filename.insert(filename.end(), dir.begin(), dir.end());
-    if (filename.back() != '/') {
-        filename.push_back('/');
-    }
-
-    // In order to limit number of hugepages while transition from shared hugepage (1 per system) to unique
-    // hugepage per device, will share original/shared hugepage filename with physical device 0.
-    if (physical_device_id != 0 || channel != 0) {
-        std::string device_id_str = fmt::format("device_{}_", physical_device_id);
-        filename.insert(filename.end(), device_id_str.begin(), device_id_str.end());
-    }
-
-    if (channel != 0) {
-        std::string channel_id_str = fmt::format("channel_{}_", channel);
-        filename.insert(filename.end(), channel_id_str.begin(), channel_id_str.end());
-    }
-
-    filename.insert(filename.end(), std::begin(pipeline_name), std::end(pipeline_name));  // includes NUL terminator
-
-    std::string filename_str(filename.begin(), filename.end());
-    filename_str.erase(
-        std::find(filename_str.begin(), filename_str.end(), '\0'),
-        filename_str.end());  // Erase NULL terminator for printing.
-    log_debug(
-        LogUMD,
-        "ttSiliconDevice::open_hugepage_file: using filename: {} for physical_device_id: {} channel: {}",
-        filename_str.c_str(),
-        physical_device_id,
-        channel);
-
-    // Save original and set umask to unrestricted.
-    auto old_umask = umask(0);
-
-    int fd =
-        open(filename.data(), O_RDWR | O_CREAT | O_CLOEXEC, S_IWUSR | S_IRUSR | S_IWGRP | S_IRGRP | S_IWOTH | S_IROTH);
-    if (fd == -1 && errno == EACCES) {
-        log_warning(
-            LogUMD,
-            "ttSiliconDevice::open_hugepage_file could not open filename: {} on first try, unlinking it and retrying.",
-            filename_str);
-        unlink(filename.data());
-        fd = open(
-            filename.data(), O_RDWR | O_CREAT | O_CLOEXEC, S_IWUSR | S_IRUSR | S_IWGRP | S_IRGRP | S_IWOTH | S_IROTH);
-    }
-
-    // Restore original mask.
-    umask(old_umask);
-
-    if (fd == -1) {
-        log_warning(LogUMD, "open_hugepage_file failed");
-        return -1;
-    }
-
-    return fd;
 }
 
 }  // namespace tt::umd

--- a/device/hugepage.hpp
+++ b/device/hugepage.hpp
@@ -5,9 +5,6 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
-
-#include "umd/device/types/cluster_descriptor_types.hpp"
 
 namespace tt::umd {
 
@@ -21,14 +18,5 @@ uint32_t get_num_hugepages();
 // Dynamically figure out how many host memory channels (based on hugepages installed) for each device, based on arch.
 uint32_t get_available_num_host_mem_channels(
     const uint32_t num_channels_per_device_target, const uint16_t device_id, const uint16_t revision_id);
-
-// Looks for hugetlbfs inside /proc/mounts matching desired pagesize (typically 1G).
-std::string find_hugepage_dir(std::size_t pagesize);
-
-// Open a file in <hugepage_dir> for the hugepage mapping.
-// All processes operating on the same pipeline must agree on the file name.
-// Today we assume there's only one pipeline running within the system.
-// One hugepage per device such that each device gets unique memory.
-int open_hugepage_file(const std::string &dir, ChipId physical_device_id, uint16_t channel);
 
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue
Closes #2328
Closes #2329

### Description
Replace the hugetlbfs file-backed hugepage allocation with direct anonymous `mmap` using `MAP_HUGETLB`. This eliminates the hugetlbfs mount requirement, file permission management, and ~100 lines of filesystem interaction code.

For the IOMMU path, add a hugepage fallback cascade (1GB → 2MB → 4KB) so hugepages are an optional performance optimization rather than a requirement.

### List of the changes
- **`init_hugepages()`**: Replace `find_hugepage_dir` + `open_hugepage_file` + file-backed `mmap(MAP_SHARED)` with a single `mmap(MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_1GB | MAP_POPULATE)`
- **IOMMU path**: Add `mmap_with_hugepage_fallback()` helper with 1GB → 2MB → 4KB cascade, used in `init_iommu()` and `allocate_sysmem_buffer()`
- **`hugepage.cpp`**: Remove `find_hugepage_dir()`, `open_hugepage_file()`, and the `hugepage_dir` constant (~100 lines)
- **`hugepage.hpp`**: Remove corresponding declarations and unused includes

### Testing
CI

### API Changes
There are no API changes in this PR.