### PR TITLE
Use MAP_HUGETLB in IOMMU path for allocation performance

### DIFF
--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -33,28 +33,39 @@ namespace tt::umd {
 // This is a performance optimization: hugepages reduce page fault overhead during allocation.
 // All three options are functionally correct when IOMMU is enabled.
 static void *mmap_with_hugepage_fallback(size_t size) {
-    void *addr = mmap(
-        nullptr,
-        size,
-        PROT_READ | PROT_WRITE,
-        MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_1GB | MAP_POPULATE,
-        -1,
-        0);
-    if (addr != MAP_FAILED) {
-        log_debug(LogUMD, "Allocated {:#x} bytes using 1GB hugepages.", size);
-        return addr;
+    constexpr size_t kHugepage1GiB = 1ULL << 30;
+    constexpr size_t kHugepage2MiB = 2ULL << 20;
+
+    void *addr = MAP_FAILED;
+
+    // Only attempt 1GiB hugepages when the size is a multiple of 1GiB.
+    if (size >= kHugepage1GiB && (size % kHugepage1GiB) == 0) {
+        addr = mmap(
+            nullptr,
+            size,
+            PROT_READ | PROT_WRITE,
+            MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_1GB | MAP_POPULATE,
+            -1,
+            0);
+        if (addr != MAP_FAILED) {
+            log_debug(LogUMD, "Allocated {:#x} bytes using 1GB hugepages.", size);
+            return addr;
+        }
     }
 
-    addr = mmap(
-        nullptr,
-        size,
-        PROT_READ | PROT_WRITE,
-        MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_2MB | MAP_POPULATE,
-        -1,
-        0);
-    if (addr != MAP_FAILED) {
-        log_debug(LogUMD, "Allocated {:#x} bytes using 2MB hugepages.", size);
-        return addr;
+    // Only attempt 2MiB hugepages when the size is a multiple of 2MiB.
+    if (size >= kHugepage2MiB && (size % kHugepage2MiB) == 0) {
+        addr = mmap(
+            nullptr,
+            size,
+            PROT_READ | PROT_WRITE,
+            MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_2MB | MAP_POPULATE,
+            -1,
+            0);
+        if (addr != MAP_FAILED) {
+            log_debug(LogUMD, "Allocated {:#x} bytes using 2MB hugepages.", size);
+            return addr;
+        }
     }
 
     addr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE, -1, 0);
@@ -385,6 +396,9 @@ void SiliconSysmemManager::print_file_contents(const std::string &filename, cons
 std::unique_ptr<SysmemBuffer> SiliconSysmemManager::allocate_sysmem_buffer(
     size_t sysmem_buffer_size, const bool map_to_noc) {
     void *mapping = mmap_with_hugepage_fallback(sysmem_buffer_size);
+    if (mapping == MAP_FAILED) {
+        TT_THROW("Failed to allocate sysmem buffer of size {:#x} bytes with mmap.", sysmem_buffer_size);
+    }
     return map_sysmem_buffer(mapping, sysmem_buffer_size, map_to_noc);
 }
 


### PR DESCRIPTION
### Issue
Closes #2329

### Description
Add hugepage fallback cascade to the IOMMU mmap path. When allocating sysmem buffers with IOMMU, try 1GB hugepages first, then 2MB, then regular 4KB pages. This reduces page faults from ~1M to 4 for a 4GB buffer when 1GB hugepages are available, with no correctness impact on fallback.

### List of the changes
- Add `mmap_with_hugepage_fallback()` helper with 1GB → 2MB → 4KB cascade
- Use it in `init_iommu()` and `allocate_sysmem_buffer()`
- Add `#include <linux/mman.h>` for `MAP_HUGE_1GB` / `MAP_HUGE_2MB`

### Testing
CI

### API Changes
There are no API changes in this PR.