### PR TITLE
Skip heartbeat check altogether when THROW is selected

### DIFF
--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -207,18 +207,21 @@ void TopologyDiscovery::discover_remote_devices() {
                 continue;
             }
 
-            if (!eth_heartbeat_running(tt_device, eth_core)) {
-                std::string msg = fmt::format(
-                    "ETH core heartbeat check failed on device ASIC ID: {}, ETH core {}, post code: {:x}",
-                    current_device_asic_id,
-                    eth_core.str(),
-                    get_eth_postcode(tt_device, eth_core));
-                if (options.eth_fw_heartbeat_failure == TopologyDiscoveryOptions::Action::THROW) {
-                    // TODO #2318: Re-enable throwing once Fabric fixes bug that breaks ETH heartbeat.
-                    // TT_THROW(msg);.
-                } else {
-                    log_warning(LogUMD, msg);
-                    continue;
+            // TODO #2318: Re-enable throwing once Fabric fixes bug that breaks ETH heartbeat.
+            // Note that even checking can slow down the CI enough for it to time out.
+            if (options.eth_fw_heartbeat_failure != TopologyDiscoveryOptions::Action::THROW) {
+                if (!eth_heartbeat_running(tt_device, eth_core)) {
+                    std::string msg = fmt::format(
+                        "ETH core heartbeat check failed on device ASIC ID: {}, ETH core {}, post code: {:x}",
+                        current_device_asic_id,
+                        eth_core.str(),
+                        get_eth_postcode(tt_device, eth_core));
+                    if (options.eth_fw_heartbeat_failure == TopologyDiscoveryOptions::Action::THROW) {
+                        TT_THROW(msg);
+                    } else {
+                        log_warning(LogUMD, msg);
+                        continue;
+                    }
                 }
             }
 


### PR DESCRIPTION
### Issue
Related to #2318 

### Description
Even though we don't throw, the problem is that performing the check significantly increases runtime, enough for tt_metal CI to timeout: https://github.com/tenstorrent/tt-metal/actions/runs/23313161215

### List of the changes
- Wrap up the check around the check whether this is THROW. So THROW will now mean SKIP essentially.

### Testing
https://github.com/tenstorrent/tt-metal/actions/runs/23363223428

### API Changes
There are no API changes in this PR.
