### PR TITLE
Move tt_device_ to SimulationChip base using common TTDevice interface

### DIFF
--- a/device/api/umd/device/simulation/rtl_simulation_chip.hpp
+++ b/device/api/umd/device/simulation/rtl_simulation_chip.hpp
@@ -9,7 +9,6 @@
 #include <memory>
 
 #include "umd/device/simulation/simulation_chip.hpp"
-#include "umd/device/tt_device/rtl_simulation_tt_device.hpp"
 
 namespace tt::umd {
 
@@ -33,11 +32,6 @@ public:
     void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) override;
     void assert_risc_reset(CoreCoord core, const RiscType selected_riscs) override;
     void deassert_risc_reset(CoreCoord core, const RiscType selected_riscs, bool staggered_start) override;
-
-    SysmemManager* get_sysmem_manager() override { return tt_device_->get_sysmem_manager(); }
-
-private:
-    std::unique_ptr<RtlSimulationTTDevice> tt_device_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/simulation/simulation_chip.hpp
+++ b/device/api/umd/device/simulation/simulation_chip.hpp
@@ -11,6 +11,7 @@
 
 #include "umd/device/chip/chip.hpp"
 #include "umd/device/cluster.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/utils/lock_manager.hpp"
 
 namespace tt::umd {
@@ -35,7 +36,8 @@ public:
     void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) override;
     void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) override;
 
-    TTDevice* get_tt_device() override;
+    TTDevice* get_tt_device() override { return tt_device_.get(); }
+
     SysmemManager* get_sysmem_manager() override;
     TLBManager* get_tlb_manager() override;
 
@@ -89,7 +91,8 @@ protected:
     SimulationChip(
         const std::filesystem::path& simulator_directory, const SocDescriptor& soc_descriptor, ChipId chip_id);
 
-    // Simulator directory.
+    std::unique_ptr<TTDevice> tt_device_;
+
     // Common state variables.
     DriverNocParams noc_params;
     tt::ARCH arch_name;

--- a/device/api/umd/device/simulation/tt_sim_chip.hpp
+++ b/device/api/umd/device/simulation/tt_sim_chip.hpp
@@ -10,7 +10,6 @@
 #include <filesystem>
 
 #include "umd/device/simulation/simulation_chip.hpp"
-#include "umd/device/tt_device/tt_sim_tt_device.hpp"
 
 namespace tt::umd {
 
@@ -36,12 +35,6 @@ public:
     void assert_risc_reset(CoreCoord core, const RiscType selected_riscs) override;
     void deassert_risc_reset(CoreCoord core, const RiscType selected_riscs, bool staggered_start) override;
 
-    SysmemManager* get_sysmem_manager() override { return tt_device_->get_sysmem_manager(); }
-
-    TTDevice* get_tt_device() override { return tt_device_.get(); }
-
-    TLBManager* get_tlb_manager() override;
-
 private:
     void create_simulator_binary();
     off_t resize_simulator_binary(int src_fd);
@@ -49,8 +42,6 @@ private:
     void secure_simulator_binary();
     void close_simulator_binary();
     void load_simulator_library(const std::filesystem::path& path);
-
-    std::unique_ptr<TTSimTTDevice> tt_device_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -56,17 +56,17 @@ public:
     void dma_multicast_write(
         void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
 
-    void close_device();
-    void start_device();
+    void close_device() override;
+    void start_device() override;
 
-    void send_tensix_risc_reset(tt_xy_pair translated_core, const TensixSoftResetOptions& soft_resets);
-    void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets);
-    void assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs);
-    void deassert_risc_reset(tt_xy_pair core, const RiscType selected_riscs, bool staggered_start);
+    void send_tensix_risc_reset(tt_xy_pair translated_core, const TensixSoftResetOptions& soft_resets) override;
+    void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) override;
+    void assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs) override;
+    void deassert_risc_reset(tt_xy_pair core, const RiscType selected_riscs, bool staggered_start) override;
 
     RtlSimCommunicator* get_communicator() { return communicator_.get(); }
 
-    SimulationSysmemManager* get_sysmem_manager() { return sysmem_manager_.get(); }
+    SimulationSysmemManager* get_sysmem_manager() override { return sysmem_manager_.get(); }
 
 protected:
     void retrain_dram_core(const uint32_t dram_channel) override;

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -20,6 +20,8 @@
 #include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/communication_protocol.hpp"
+#include "umd/device/types/risc_type.hpp"
+#include "umd/device/types/tensix_soft_reset_options.hpp"
 #include "umd/device/utils/lock_manager.hpp"
 #include "umd/device/utils/timeouts.hpp"
 
@@ -28,6 +30,7 @@ namespace tt::umd {
 class ArcMessenger;
 class ArcTelemetryReader;
 class RemoteCommunication;
+class SysmemManager;
 
 enum class TTDeviceInitResult {
     UNKNOWN = 0,
@@ -342,6 +345,17 @@ public:
      * @return Training status
      */
     virtual EthTrainingStatus read_eth_core_training_status(tt_xy_pair eth_core) = 0;
+
+    virtual void start_device();
+    virtual void close_device();
+
+    virtual void send_tensix_risc_reset(tt_xy_pair translated_core, const TensixSoftResetOptions &soft_resets);
+    virtual void send_tensix_risc_reset(const TensixSoftResetOptions &soft_resets);
+    virtual void assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs);
+    virtual void deassert_risc_reset(tt_xy_pair core, const RiscType selected_riscs, bool staggered_start);
+
+    virtual SysmemManager *get_sysmem_manager();
+    virtual TLBManager *get_tlb_manager();
 
 protected:
     std::shared_ptr<PCIDevice> pci_device_;

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -58,13 +58,13 @@ public:
     void dma_multicast_write(
         void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
 
-    void close_device();
-    void start_device();
+    void close_device() override;
+    void start_device() override;
 
-    void send_tensix_risc_reset(tt_xy_pair translated_core, const TensixSoftResetOptions &soft_resets);
-    void send_tensix_risc_reset(const TensixSoftResetOptions &soft_resets);
-    void assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs);
-    void deassert_risc_reset(tt_xy_pair core, const RiscType selected_riscs, bool staggered_start);
+    void send_tensix_risc_reset(tt_xy_pair translated_core, const TensixSoftResetOptions &soft_resets) override;
+    void send_tensix_risc_reset(const TensixSoftResetOptions &soft_resets) override;
+    void assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs) override;
+    void deassert_risc_reset(tt_xy_pair core, const RiscType selected_riscs, bool staggered_start) override;
 
     /**
      * Get the TTSimCommunicator for low-level device operations.
@@ -72,7 +72,7 @@ public:
      */
     TTSimCommunicator *get_communicator() { return communicator_.get(); }
 
-    SimulationSysmemManager *get_sysmem_manager() { return sysmem_manager_.get(); }
+    SimulationSysmemManager *get_sysmem_manager() override { return sysmem_manager_.get(); }
 
     /**
      * Get the architecture implementation.
@@ -80,7 +80,7 @@ public:
      */
     const architecture_implementation *get_architecture_impl() const { return architecture_impl_.get(); }
 
-    TLBManager *get_tlb_manager();
+    TLBManager *get_tlb_manager() override;
 
     uint64_t bar0_base = 0;
 

--- a/device/simulation/rtl_simulation_chip.cpp
+++ b/device/simulation/rtl_simulation_chip.cpp
@@ -9,6 +9,7 @@
 #include <tt-logger/tt-logger.hpp>
 
 #include "assert.hpp"
+#include "umd/device/tt_device/rtl_simulation_tt_device.hpp"
 
 namespace tt::umd {
 
@@ -19,9 +20,9 @@ RtlSimulationChip::RtlSimulationChip(
     const SocDescriptor& soc_descriptor,
     ChipId chip_id,
     int num_host_mem_channels) :
-    SimulationChip(simulator_directory, soc_descriptor, chip_id),
-    tt_device_(
-        std::make_unique<RtlSimulationTTDevice>(simulator_directory, soc_descriptor, chip_id, num_host_mem_channels)) {
+    SimulationChip(simulator_directory, soc_descriptor, chip_id) {
+    tt_device_ =
+        std::make_unique<RtlSimulationTTDevice>(simulator_directory, soc_descriptor, chip_id, num_host_mem_channels);
     log_info(tt::LogEmulationDriver, "Instantiating RTL simulation device");
 }
 

--- a/device/simulation/simulation_chip.cpp
+++ b/device/simulation/simulation_chip.cpp
@@ -157,15 +157,9 @@ int SimulationChip::get_numa_node() {
     throw std::runtime_error("SimulationChip::get_numa_node is not available for this chip.");
 }
 
-TTDevice* SimulationChip::get_tt_device() {
-    throw std::runtime_error("SimulationChip::get_tt_device is not available for this chip.");
-}
+SysmemManager* SimulationChip::get_sysmem_manager() { return tt_device_ ? tt_device_->get_sysmem_manager() : nullptr; }
 
-SysmemManager* SimulationChip::get_sysmem_manager() { return nullptr; }
-
-TLBManager* SimulationChip::get_tlb_manager() {
-    throw std::runtime_error("SimulationChip::get_tlb_manager is not available for this chip.");
-}
+TLBManager* SimulationChip::get_tlb_manager() { return tt_device_ ? tt_device_->get_tlb_manager() : nullptr; }
 
 void SimulationChip::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) {}
 

--- a/device/simulation/tt_sim_chip.cpp
+++ b/device/simulation/tt_sim_chip.cpp
@@ -20,6 +20,7 @@
 #include <tt-logger/tt-logger.hpp>
 
 #include "assert.hpp"
+#include "umd/device/tt_device/tt_sim_tt_device.hpp"
 
 namespace tt::umd {
 
@@ -71,7 +72,5 @@ void TTSimChip::deassert_risc_reset(CoreCoord core, const RiscType selected_risc
     tt_device_->deassert_risc_reset(
         soc_descriptor_.translate_coord_to(core, CoordSystem::TRANSLATED), selected_riscs, staggered_start);
 }
-
-TLBManager* TTSimChip::get_tlb_manager() { return tt_device_->get_tlb_manager(); }
 
 }  // namespace tt::umd

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -18,6 +18,7 @@
 #include "assert.hpp"
 #include "noc_access.hpp"
 #include "umd/device/arc/arc_messenger.hpp"
+#include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/driver_atomics.hpp"
 #include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
@@ -314,6 +315,30 @@ FirmwareInfoProvider *TTDevice::get_firmware_info_provider() const { return firm
 FirmwareBundleVersion TTDevice::get_firmware_version() { return get_firmware_info_provider()->get_firmware_version(); }
 
 void TTDevice::wait_for_non_mmio_flush() {}
+
+void TTDevice::start_device() { throw std::runtime_error("TTDevice::start_device is not implemented."); }
+
+void TTDevice::close_device() { throw std::runtime_error("TTDevice::close_device is not implemented."); }
+
+void TTDevice::send_tensix_risc_reset(tt_xy_pair translated_core, const TensixSoftResetOptions &soft_resets) {
+    throw std::runtime_error("TTDevice::send_tensix_risc_reset is not implemented.");
+}
+
+void TTDevice::send_tensix_risc_reset(const TensixSoftResetOptions &soft_resets) {
+    throw std::runtime_error("TTDevice::send_tensix_risc_reset is not implemented.");
+}
+
+void TTDevice::assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs) {
+    throw std::runtime_error("TTDevice::assert_risc_reset is not implemented.");
+}
+
+void TTDevice::deassert_risc_reset(tt_xy_pair core, const RiscType selected_riscs, bool staggered_start) {
+    throw std::runtime_error("TTDevice::deassert_risc_reset is not implemented.");
+}
+
+SysmemManager *TTDevice::get_sysmem_manager() { return nullptr; }
+
+TLBManager *TTDevice::get_tlb_manager() { return nullptr; }
 
 bool TTDevice::is_remote() { return is_remote_tt_device; }
 


### PR DESCRIPTION
### Issue
/

### Description
TTSimChip and RtlSimulationChip each had their own tt_device_ fields typed to concrete TTSimTTDevice / RtlSimulationTTDevice. This change moves the field to the common SimulationChip base class as std::unique_ptr<TTDevice>, and adds the missing virtual methods to TTDevice so both simulation devices can be used through the base interface.

### List of the changes
- Add virtual start_device(), close_device(), send_tensix_risc_reset(), assert_risc_reset(), deassert_risc_reset(), get_sysmem_manager(), get_tlb_manager() to TTDevice with default implementations
- Mark corresponding methods as override in TTSimTTDevice and RtlSimulationTTDevice
- Move tt_device_ (as unique_ptr<TTDevice>) to SimulationChip, implement get_tt_device/get_sysmem_manager/get_tlb_manager there
- Remove redundant tt_device_ fields and accessor overrides from TTSimChip and RtlSimulationChip

### Testing
CI

### API Changes
There are no API changes in this PR.