### PR TITLE
Propose translate_chip_coord_to_translated fix for WH and BH if translation is enabled

### DIFF
--- a/device/api/umd/device/soc_descriptor.hpp
+++ b/device/api/umd/device/soc_descriptor.hpp
@@ -91,7 +91,7 @@ public:
         const CoordSystem input_coord_system,
         const CoordSystem target_coord_system) const;
     tt_xy_pair translate_chip_coord_to_translated(const CoreCoord core) const;
-    CoreCoord translate_chip_coord_to_umd_device_coords(const CoreCoord core) const;
+    CoreCoord translate_chip_coord_to_translated_coord(const CoreCoord core) const;
 
     // Serialize the soc descriptor to a YAML string, or directly to a file.
     // A default file in /tmp directory will be used if no path is passed.

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -197,12 +197,12 @@ CoreCoord SocDescriptor::translate_coord_to(
 }
 
 // Translates a chip coordinate to the correct device coordinates, returning a CoreCoord
-// with the appropriate coordinate system set. This applies architecture-specific fixups
-// (e.g., Wormhole DRAM/ARC/PCIe cores use NOC0/NOC1 instead of translated coordinates)
-// so the returned coordinate system reflects what is actually used for device access.
-// Prefer this over translate_coord_to when the caller needs device-ready coordinates
-// with the correct CoordSystem tag.
-CoreCoord SocDescriptor::translate_chip_coord_to_umd_device_coords(const CoreCoord core) const {
+// Returns the correct pre-translation coordinates for the given architecture. Note that
+// the returned CoordSystem is not necessarily TRANSLATED — architecture-specific fixups
+// (e.g., Wormhole DRAM/ARC/PCIe cores) may produce NOC0/NOC1 coordinates instead.
+// The key guarantee is that the returned coordinates will be correct for device access
+// on the given architecture.
+CoreCoord SocDescriptor::translate_chip_coord_to_translated_coord(const CoreCoord core) const {
     if (!noc_translation_enabled) {
         return translate_coord_to(core, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0);
     }
@@ -218,12 +218,10 @@ CoreCoord SocDescriptor::translate_chip_coord_to_umd_device_coords(const CoreCoo
     return translate_coord_to(core, CoordSystem::TRANSLATED);
 }
 
-// Note: Despite the name, the returned coordinates are not necessarily in the TRANSLATED
-// coordinate system — architecture-specific fixups in translate_chip_coord_to_umd_device_coords
-// may produce NOC0/NOC1 coordinates instead. This function exists solely to provide a
-// tt_xy_pair return type; the actual logic lives in translate_chip_coord_to_umd_device_coords.
+// Convenience wrapper returning tt_xy_pair; the actual logic lives in
+// translate_chip_coord_to_translated_coord.
 tt_xy_pair SocDescriptor::translate_chip_coord_to_translated(const CoreCoord core) const {
-    return translate_chip_coord_to_umd_device_coords(core);
+    return translate_chip_coord_to_translated_coord(core);
 }
 
 void SocDescriptor::load_core_descriptors_from_soc_desc_info(const SocDescriptorInfo &soc_desc_info) {

--- a/nanobind/py_api_soc_descriptor.cpp
+++ b/nanobind/py_api_soc_descriptor.cpp
@@ -128,10 +128,10 @@ void bind_soc_descriptor(nb::module_ &m) {
             nb::arg("core"),
             "Translate a chip coordinate to translated coordinate system in tt_xy_pair")
         .def(
-            "translate_chip_coord_to_umd_device_coords",
-            &SocDescriptor::translate_chip_coord_to_umd_device_coords,
+            "translate_chip_coord_to_translated_coord",
+            &SocDescriptor::translate_chip_coord_to_translated_coord,
             nb::arg("core"),
-            "Translate a chip coordinate to device-ready coordinates with correct CoordSystem")
+            "Translate a chip coordinate to the correct pre-translation coordinates for device access")
         .def(
             "get_coord_at",
             &SocDescriptor::get_coord_at,


### PR DESCRIPTION
### Issue
/

### Description
This pull request refactors the coordinate translation API in the `SocDescriptor` class to clarify the distinction between translated coordinates and device-ready coordinates, and to provide more accurate, architecture-aware coordinate mapping. The main changes involve renaming and updating methods, improving documentation, and updating the Python API bindings to match the new function names and semantics.

### List of the changes
**API Refactoring and Clarification:**

* Renamed `translate_chip_coord_to_translated_coord` to `translate_chip_coord_to_umd_device_coords` in `SocDescriptor`, clarifying that the method returns device-ready coordinates with the correct `CoordSystem` tag, not necessarily in the translated coordinate system.
* Updated the implementation of `translate_chip_coord_to_umd_device_coords` to apply architecture-specific fixups (e.g., for Wormhole DRAM/ARC/PCIe cores) and ensure the returned coordinate system matches what is actually used for device access (and migrated the behavior from `translate_chip_coord_to_translated`).

**Documentation and Interface Improvements:**

* Improved documentation and comments to explain the difference between coordinate translation methods and the rationale for architecture-specific handling.

**Python API Update:**

* Updated the Python bindings in `nanobind/py_api_soc_descriptor.cpp` to expose the new `translate_chip_coord_to_umd_device_coords` method, replacing the old method and updating the docstring to reflect its new purpose.

**Legacy Method Handling:**

* Updated the legacy `translate_chip_coord_to_translated` method to delegate to the new `translate_chip_coord_to_umd_device_coords`, maintaining backward compatibility while clarifying its actual behavior.

### Testing
CI and manual

### API Changes
* Renamed `translate_chip_coord_to_translated_coord` to `translate_chip_coord_to_umd_device_coords`