### PR TITLE
Replace raw memcpy with streaming stores for TLB window writes/reads

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -68,6 +68,7 @@ target_sources(
         chip_helpers/sysmem_buffer.cpp
         chip_helpers/tlb_manager.cpp
         pcie/tlb_window.cpp
+        pcie/device_memcpy.cpp
         pcie/silicon_tlb_window.cpp
         pcie/silicon_tlb_handle.cpp
         cluster.cpp

--- a/device/api/umd/device/pcie/device_memcpy.hpp
+++ b/device/api/umd/device/pcie/device_memcpy.hpp
@@ -5,12 +5,6 @@
 #pragma once
 
 #include <cstddef>
-#include <cstdint>
-#include <cstring>
-
-#if defined(__x86_64__) || defined(_M_X64)
-#include <immintrin.h>
-#endif
 
 namespace tt::umd {
 
@@ -26,111 +20,11 @@ namespace tt::umd {
  *
  * On other architectures: falls back to explicit single-byte/4-byte stores (no double writes).
  *
- * Handles arbitrary alignment and size — uses read-modify-write for leading/trailing
- * partial 4-byte words on the device side.
+ * Handles arbitrary alignment and size — leading/trailing bytes smaller than a DWORD are
+ * written as individual byte-wide PCIe transactions (the Blackhole PCIe controller supports
+ * sub-DWORD writes natively, so no read-modify-write is required).
  */
-inline void streaming_memcpy_to_device(void* dest, const void* src, std::size_t size) {
-    auto* d = static_cast<volatile std::uint8_t*>(dest);
-    auto* s = static_cast<const std::uint8_t*>(src);
-
-    // Phase 0: Align device destination to 4 bytes using byte-wide volatile stores.
-    while (size > 0 && (reinterpret_cast<std::uintptr_t>(d) % 4) != 0) {
-        *d++ = *s++;
-        size--;
-    }
-
-#if defined(__x86_64__) || defined(_M_X64)
-    // d is now 4-byte aligned. Cast to non-volatile for SIMD intrinsics — the intrinsics
-    // are opaque to the compiler and won't be reordered or eliminated.
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast).
-    auto* d_aligned = const_cast<std::uint8_t*>(static_cast<const volatile std::uint8_t*>(d));
-
-    // Phase 1: Align destination to 32 bytes using 4-byte streaming stores.
-    while (size >= 4 && (reinterpret_cast<std::uintptr_t>(d_aligned) % 32) != 0) {
-        std::uint32_t tmp;
-        std::memcpy(&tmp, s, sizeof(tmp));
-        _mm_stream_si32(reinterpret_cast<int*>(d_aligned), static_cast<int>(tmp));
-        d_aligned += 4;
-        s += 4;
-        size -= 4;
-    }
-
-    // Phase 2: Bulk 256-byte blocks (8 x 32-byte AVX2 streaming stores).
-    while (size >= 256) {
-        __m256i v0 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s));
-        __m256i v1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + 32));
-        __m256i v2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + 64));
-        __m256i v3 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + 96));
-        __m256i v4 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + 128));
-        __m256i v5 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + 160));
-        __m256i v6 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + 192));
-        __m256i v7 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + 224));
-
-        _mm256_stream_si256(reinterpret_cast<__m256i*>(d_aligned), v0);
-        _mm256_stream_si256(reinterpret_cast<__m256i*>(d_aligned + 32), v1);
-        _mm256_stream_si256(reinterpret_cast<__m256i*>(d_aligned + 64), v2);
-        _mm256_stream_si256(reinterpret_cast<__m256i*>(d_aligned + 96), v3);
-        _mm256_stream_si256(reinterpret_cast<__m256i*>(d_aligned + 128), v4);
-        _mm256_stream_si256(reinterpret_cast<__m256i*>(d_aligned + 160), v5);
-        _mm256_stream_si256(reinterpret_cast<__m256i*>(d_aligned + 192), v6);
-        _mm256_stream_si256(reinterpret_cast<__m256i*>(d_aligned + 224), v7);
-
-        d_aligned += 256;
-        s += 256;
-        size -= 256;
-    }
-
-    // Phase 3: Remaining 32-byte chunks.
-    while (size >= 32) {
-        __m256i v = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s));
-        _mm256_stream_si256(reinterpret_cast<__m256i*>(d_aligned), v);
-        d_aligned += 32;
-        s += 32;
-        size -= 32;
-    }
-
-    // Phase 4: Remaining 16-byte chunk.
-    if (size >= 16) {
-        __m128i v = _mm_loadu_si128(reinterpret_cast<const __m128i*>(s));
-        _mm_stream_si128(reinterpret_cast<__m128i*>(d_aligned), v);
-        d_aligned += 16;
-        s += 16;
-        size -= 16;
-    }
-
-    // Phase 5: Remaining 4-byte chunks.
-    while (size >= 4) {
-        std::uint32_t tmp;
-        std::memcpy(&tmp, s, sizeof(tmp));
-        _mm_stream_si32(reinterpret_cast<int*>(d_aligned), static_cast<int>(tmp));
-        d_aligned += 4;
-        s += 4;
-        size -= 4;
-    }
-
-    // Ensure all streaming stores are globally visible.
-    _mm_sfence();
-
-    d = reinterpret_cast<volatile std::uint8_t*>(d_aligned);
-
-#else
-    // Portable fallback: explicit 4-byte stores for the aligned middle.
-    while (size >= 4) {
-        std::uint32_t tmp;
-        std::memcpy(&tmp, s, sizeof(tmp));
-        *reinterpret_cast<volatile std::uint32_t*>(const_cast<volatile std::uint8_t*>(d)) = tmp;
-        d += 4;
-        s += 4;
-        size -= 4;
-    }
-#endif
-
-    // Phase 6: Trailing bytes (0-3) using byte-wide volatile stores.
-    while (size > 0) {
-        *d++ = *s++;
-        size--;
-    }
-}
+void streaming_memcpy_to_device(volatile void* dest, const void* src, std::size_t size);
 
 /**
  * Streaming memcpy for reads from device memory mapped through a TLB window.
@@ -142,101 +36,6 @@ inline void streaming_memcpy_to_device(void* dest, const void* src, std::size_t 
  *
  * Handles arbitrary alignment and size.
  */
-inline void streaming_memcpy_from_device(void* dest, const volatile void* src, std::size_t size) {
-    auto* d = static_cast<std::uint8_t*>(dest);
-    auto* s = static_cast<const volatile std::uint8_t*>(src);
-
-    // Phase 0: Align device source to 4 bytes using byte-wide volatile loads.
-    while (size > 0 && (reinterpret_cast<std::uintptr_t>(s) % 4) != 0) {
-        *d++ = *s++;
-        size--;
-    }
-
-#if defined(__x86_64__) || defined(_M_X64)
-    // s is now 4-byte aligned. Cast to non-volatile for SIMD intrinsics — the intrinsics
-    // are opaque to the compiler and won't be reordered or eliminated.
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast).
-    auto* s_aligned = const_cast<std::uint8_t*>(static_cast<const volatile std::uint8_t*>(s));
-
-    // Phase 1: Align source to 32 bytes using 4-byte volatile loads.
-    while (size >= 4 && (reinterpret_cast<std::uintptr_t>(s_aligned) % 32) != 0) {
-        std::uint32_t tmp = *reinterpret_cast<volatile std::uint32_t*>(s_aligned);
-        std::memcpy(d, &tmp, sizeof(tmp));
-        d += 4;
-        s_aligned += 4;
-        size -= 4;
-    }
-
-    // Phase 2: Bulk 256-byte blocks (8 x 32-byte AVX2 streaming loads).
-    while (size >= 256) {
-        __m256i v0 = _mm256_stream_load_si256(reinterpret_cast<const __m256i*>(s_aligned));
-        __m256i v1 = _mm256_stream_load_si256(reinterpret_cast<const __m256i*>(s_aligned + 32));
-        __m256i v2 = _mm256_stream_load_si256(reinterpret_cast<const __m256i*>(s_aligned + 64));
-        __m256i v3 = _mm256_stream_load_si256(reinterpret_cast<const __m256i*>(s_aligned + 96));
-        __m256i v4 = _mm256_stream_load_si256(reinterpret_cast<const __m256i*>(s_aligned + 128));
-        __m256i v5 = _mm256_stream_load_si256(reinterpret_cast<const __m256i*>(s_aligned + 160));
-        __m256i v6 = _mm256_stream_load_si256(reinterpret_cast<const __m256i*>(s_aligned + 192));
-        __m256i v7 = _mm256_stream_load_si256(reinterpret_cast<const __m256i*>(s_aligned + 224));
-
-        _mm256_storeu_si256(reinterpret_cast<__m256i*>(d), v0);
-        _mm256_storeu_si256(reinterpret_cast<__m256i*>(d + 32), v1);
-        _mm256_storeu_si256(reinterpret_cast<__m256i*>(d + 64), v2);
-        _mm256_storeu_si256(reinterpret_cast<__m256i*>(d + 96), v3);
-        _mm256_storeu_si256(reinterpret_cast<__m256i*>(d + 128), v4);
-        _mm256_storeu_si256(reinterpret_cast<__m256i*>(d + 160), v5);
-        _mm256_storeu_si256(reinterpret_cast<__m256i*>(d + 192), v6);
-        _mm256_storeu_si256(reinterpret_cast<__m256i*>(d + 224), v7);
-
-        d += 256;
-        s_aligned += 256;
-        size -= 256;
-    }
-
-    // Phase 3: Remaining 32-byte chunks.
-    while (size >= 32) {
-        __m256i v = _mm256_stream_load_si256(reinterpret_cast<const __m256i*>(s_aligned));
-        _mm256_storeu_si256(reinterpret_cast<__m256i*>(d), v);
-        d += 32;
-        s_aligned += 32;
-        size -= 32;
-    }
-
-    // Phase 3b: Remaining 16-byte chunk.
-    if (size >= 16) {
-        __m128i v = _mm_stream_load_si128(reinterpret_cast<__m128i*>(s_aligned));
-        _mm_storeu_si128(reinterpret_cast<__m128i*>(d), v);
-        d += 16;
-        s_aligned += 16;
-        size -= 16;
-    }
-
-    // Phase 4: Remaining 4-byte chunks.
-    while (size >= 4) {
-        std::uint32_t tmp = *reinterpret_cast<volatile std::uint32_t*>(s_aligned);
-        std::memcpy(d, &tmp, sizeof(tmp));
-        d += 4;
-        s_aligned += 4;
-        size -= 4;
-    }
-
-    s = reinterpret_cast<const volatile std::uint8_t*>(s_aligned);
-
-#else
-    // Portable fallback: explicit 4-byte loads for the aligned middle.
-    while (size >= 4) {
-        std::uint32_t tmp = *reinterpret_cast<const volatile std::uint32_t*>(s);
-        std::memcpy(d, &tmp, sizeof(tmp));
-        d += 4;
-        s += 4;
-        size -= 4;
-    }
-#endif
-
-    // Phase 5: Trailing bytes (0-3) using byte-wide volatile loads.
-    while (size > 0) {
-        *d++ = *s++;
-        size--;
-    }
-}
+void streaming_memcpy_from_device(void* dest, const volatile void* src, std::size_t size);
 
 }  // namespace tt::umd

--- a/device/api/umd/device/pcie/silicon_tlb_window.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_window.hpp
@@ -76,7 +76,7 @@ private:
     // which glibc's memcpy may perform when unrolling. This affects from and to device.
     // 2. syseng#3487 WH GDDR5 controller has a bug when 1-byte writes are temporarily adjacent
     // to 2-byte writes. We avoid ever performing a 1-byte write to the device. This only affects to device.
-    static void memcpy_from_device(void* dest, const void* src, std::size_t num_bytes);
+    static void memcpy_from_device(void* dest, const volatile void* src, std::size_t num_bytes);
     static void memcpy_to_device(void* dest, const void* src, std::size_t num_bytes);
 
     void write_regs(volatile uint32_t* dest, const uint32_t* src, uint32_t word_len);

--- a/device/pcie/device_memcpy.cpp
+++ b/device/pcie/device_memcpy.cpp
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/pcie/device_memcpy.hpp"
+
+#include <cstdint>
+#include <cstring>
+
+#if defined(__x86_64__) || defined(_M_X64)
+#include <immintrin.h>
+#endif
+
+namespace tt::umd {
+
+void streaming_memcpy_to_device(volatile void* dest, const void* src, std::size_t size) {
+    auto* d = static_cast<volatile std::uint8_t*>(dest);
+    auto* s = static_cast<const std::uint8_t*>(src);
+
+    // Phase 0: Align device destination address to 4 bytes using byte-wide volatile stores.
+    while (size > 0 && (reinterpret_cast<std::uintptr_t>(d) % 4) != 0) {
+        *d++ = *s++;
+        size--;
+    }
+
+#if defined(__x86_64__) || defined(_M_X64)
+    // d is now 4-byte aligned. Cast to non-volatile for SIMD intrinsics — the intrinsics
+    // are opaque to the compiler and won't be reordered or eliminated.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast).
+    auto* d_aligned = const_cast<std::uint8_t*>(static_cast<const volatile std::uint8_t*>(d));
+
+    // Phase 1: Align destination to 32 bytes using 4-byte streaming stores.
+    // This prepares for Phase 2 which uses _mm256_stream_si256 (VMOVNTDQ) to write
+    // 256 bits (32 bytes) at a time — that instruction requires 32-byte alignment.
+    while (size >= 4 && (reinterpret_cast<std::uintptr_t>(d_aligned) % 32) != 0) {
+        std::uint32_t tmp;
+        std::memcpy(&tmp, s, sizeof(tmp));
+        _mm_stream_si32(reinterpret_cast<int*>(d_aligned), static_cast<int>(tmp));
+        d_aligned += 4;
+        s += 4;
+        size -= 4;
+    }
+
+    // Phase 2: Bulk 256-byte blocks (8 x 32-byte AVX2 streaming stores).
+    while (size >= 256) {
+        __m256i v0 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s));
+        __m256i v1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + 32));
+        __m256i v2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + 64));
+        __m256i v3 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + 96));
+        __m256i v4 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + 128));
+        __m256i v5 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + 160));
+        __m256i v6 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + 192));
+        __m256i v7 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + 224));
+
+        _mm256_stream_si256(reinterpret_cast<__m256i*>(d_aligned), v0);
+        _mm256_stream_si256(reinterpret_cast<__m256i*>(d_aligned + 32), v1);
+        _mm256_stream_si256(reinterpret_cast<__m256i*>(d_aligned + 64), v2);
+        _mm256_stream_si256(reinterpret_cast<__m256i*>(d_aligned + 96), v3);
+        _mm256_stream_si256(reinterpret_cast<__m256i*>(d_aligned + 128), v4);
+        _mm256_stream_si256(reinterpret_cast<__m256i*>(d_aligned + 160), v5);
+        _mm256_stream_si256(reinterpret_cast<__m256i*>(d_aligned + 192), v6);
+        _mm256_stream_si256(reinterpret_cast<__m256i*>(d_aligned + 224), v7);
+
+        d_aligned += 256;
+        s += 256;
+        size -= 256;
+    }
+
+    // Phase 3: Remaining 32-byte chunks.
+    while (size >= 32) {
+        __m256i v = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s));
+        _mm256_stream_si256(reinterpret_cast<__m256i*>(d_aligned), v);
+        d_aligned += 32;
+        s += 32;
+        size -= 32;
+    }
+
+    // Phase 4: Remaining 16-byte chunk.
+    if (size >= 16) {
+        __m128i v = _mm_loadu_si128(reinterpret_cast<const __m128i*>(s));
+        _mm_stream_si128(reinterpret_cast<__m128i*>(d_aligned), v);
+        d_aligned += 16;
+        s += 16;
+        size -= 16;
+    }
+
+    // Phase 5: Remaining 4-byte chunks.
+    while (size >= 4) {
+        std::uint32_t tmp;
+        std::memcpy(&tmp, s, sizeof(tmp));
+        _mm_stream_si32(reinterpret_cast<int*>(d_aligned), static_cast<int>(tmp));
+        d_aligned += 4;
+        s += 4;
+        size -= 4;
+    }
+
+    // Ensure all streaming stores are globally visible.
+    _mm_sfence();
+    // TODO: PCIe health check — after the sfence we could read a known device register
+    // to detect a hung PCIe controller (0xFFFFFFFF readback = link down / completion timeout).
+
+    d = reinterpret_cast<volatile std::uint8_t*>(d_aligned);
+
+#else
+    // Portable fallback: explicit 4-byte stores for the aligned middle.
+    while (size >= 4) {
+        std::uint32_t tmp;
+        std::memcpy(&tmp, s, sizeof(tmp));
+        *reinterpret_cast<volatile std::uint32_t*>(const_cast<volatile std::uint8_t*>(d)) = tmp;
+        d += 4;
+        s += 4;
+        size -= 4;
+    }
+#endif
+
+    // Phase 6: Trailing bytes (0-3) using byte-wide volatile stores.
+    while (size > 0) {
+        *d++ = *s++;
+        size--;
+    }
+}
+
+void streaming_memcpy_from_device(void* dest, const volatile void* src, std::size_t size) {
+    auto* d = static_cast<std::uint8_t*>(dest);
+    auto* s = static_cast<const volatile std::uint8_t*>(src);
+
+    // Phase 0: Align device source to 4 bytes using byte-wide volatile loads.
+    while (size > 0 && (reinterpret_cast<std::uintptr_t>(s) % 4) != 0) {
+        *d++ = *s++;
+        size--;
+    }
+
+#if defined(__x86_64__) || defined(_M_X64)
+    // s is now 4-byte aligned. Cast to non-volatile for SIMD intrinsics — the intrinsics
+    // are opaque to the compiler and won't be reordered or eliminated.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast).
+    auto* s_aligned = const_cast<std::uint8_t*>(static_cast<const volatile std::uint8_t*>(s));
+
+    // Phase 1: Align source to 32 bytes using 4-byte volatile loads.
+    while (size >= 4 && (reinterpret_cast<std::uintptr_t>(s_aligned) % 32) != 0) {
+        std::uint32_t tmp = *reinterpret_cast<volatile std::uint32_t*>(s_aligned);
+        std::memcpy(d, &tmp, sizeof(tmp));
+        d += 4;
+        s_aligned += 4;
+        size -= 4;
+    }
+
+    // Phase 2: Bulk 256-byte blocks (8 x 32-byte AVX2 streaming loads).
+    while (size >= 256) {
+        __m256i v0 = _mm256_stream_load_si256(reinterpret_cast<const __m256i*>(s_aligned));
+        __m256i v1 = _mm256_stream_load_si256(reinterpret_cast<const __m256i*>(s_aligned + 32));
+        __m256i v2 = _mm256_stream_load_si256(reinterpret_cast<const __m256i*>(s_aligned + 64));
+        __m256i v3 = _mm256_stream_load_si256(reinterpret_cast<const __m256i*>(s_aligned + 96));
+        __m256i v4 = _mm256_stream_load_si256(reinterpret_cast<const __m256i*>(s_aligned + 128));
+        __m256i v5 = _mm256_stream_load_si256(reinterpret_cast<const __m256i*>(s_aligned + 160));
+        __m256i v6 = _mm256_stream_load_si256(reinterpret_cast<const __m256i*>(s_aligned + 192));
+        __m256i v7 = _mm256_stream_load_si256(reinterpret_cast<const __m256i*>(s_aligned + 224));
+
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(d), v0);
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(d + 32), v1);
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(d + 64), v2);
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(d + 96), v3);
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(d + 128), v4);
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(d + 160), v5);
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(d + 192), v6);
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(d + 224), v7);
+
+        d += 256;
+        s_aligned += 256;
+        size -= 256;
+    }
+
+    // Phase 3: Remaining 32-byte chunks.
+    while (size >= 32) {
+        __m256i v = _mm256_stream_load_si256(reinterpret_cast<const __m256i*>(s_aligned));
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(d), v);
+        d += 32;
+        s_aligned += 32;
+        size -= 32;
+    }
+
+    // Phase 3b: Remaining 16-byte chunk.
+    if (size >= 16) {
+        __m128i v = _mm_stream_load_si128(reinterpret_cast<__m128i*>(s_aligned));
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(d), v);
+        d += 16;
+        s_aligned += 16;
+        size -= 16;
+    }
+
+    // Phase 4: Remaining 4-byte chunks.
+    while (size >= 4) {
+        std::uint32_t tmp = *reinterpret_cast<volatile std::uint32_t*>(s_aligned);
+        std::memcpy(d, &tmp, sizeof(tmp));
+        d += 4;
+        s_aligned += 4;
+        size -= 4;
+    }
+
+    s = reinterpret_cast<const volatile std::uint8_t*>(s_aligned);
+
+#else
+    // Portable fallback: explicit 4-byte loads for the aligned middle.
+    while (size >= 4) {
+        std::uint32_t tmp = *reinterpret_cast<const volatile std::uint32_t*>(s);
+        std::memcpy(d, &tmp, sizeof(tmp));
+        d += 4;
+        s += 4;
+        size -= 4;
+    }
+#endif
+
+    // Phase 5: Trailing bytes (0-3) using byte-wide volatile loads.
+    while (size > 0) {
+        *d++ = *s++;
+        size--;
+    }
+}
+
+}  // namespace tt::umd

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -106,20 +106,19 @@ void SiliconTlbWindow::read_register(uint64_t offset, void *data, size_t size) {
 }
 
 void SiliconTlbWindow::write_block(uint64_t offset, const void *data, size_t size) {
-    auto *src = static_cast<const uint32_t *>(data);
     auto *dst = reinterpret_cast<volatile uint32_t *>(tlb_handle->get_base() + get_total_offset(offset));
 
     validate(offset, size);
 
     if (PCIDevice::get_pcie_arch() == tt::ARCH::WORMHOLE_B0) {
-        memcpy_to_device((void *)dst, src, size);
+        memcpy_to_device((void *)dst, data, size);
     } else {
-        streaming_memcpy_to_device((void *)dst, src, size);
+        streaming_memcpy_to_device(dst, data, size);
     }
 }
 
 void SiliconTlbWindow::read_block(uint64_t offset, void *data, size_t size) {
-    void *src = tlb_handle->get_base() + get_total_offset(offset);
+    const volatile void *src = tlb_handle->get_base() + get_total_offset(offset);
 
     validate(offset, size);
 
@@ -130,8 +129,8 @@ void SiliconTlbWindow::read_block(uint64_t offset, void *data, size_t size) {
     }
 }
 
-void SiliconTlbWindow::memcpy_from_device(void *dest, const void *src, std::size_t num_bytes) {
-    typedef std::uint32_t copy_t;
+void SiliconTlbWindow::memcpy_from_device(void *dest, const volatile void *src, std::size_t num_bytes) {
+    using copy_t = std::uint32_t;
 
     // Start by aligning the source (device) pointer.
     const volatile copy_t *sp;
@@ -170,7 +169,7 @@ void SiliconTlbWindow::memcpy_from_device(void *dest, const void *src, std::size
 }
 
 void SiliconTlbWindow::memcpy_to_device(void *dest, const void *src, std::size_t num_bytes) {
-    typedef std::uint32_t copy_t;
+    using copy_t = std::uint32_t;
 
     // Start by aligning the destination (device) pointer. If needed, do RMW to fix up the
     // first partial word.
@@ -200,8 +199,7 @@ void SiliconTlbWindow::memcpy_to_device(void *dest, const void *src, std::size_t
     // Copy the destination-aligned middle using streaming stores.
     std::size_t num_words = num_bytes / sizeof(copy_t);
     std::size_t middle_bytes = num_words * sizeof(copy_t);
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast).
-    streaming_memcpy_to_device(const_cast<copy_t *>(dp), src, middle_bytes);
+    streaming_memcpy_to_device(dp, src, middle_bytes);
 
     dp += num_words;
     auto *sp = static_cast<const char *>(src) + middle_bytes;

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -504,8 +504,9 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as
 }
 
 TEST(SiliconDriverBH, DebugDoubleWrite) {
-    // NOC register that counts the number of nonposted write requests received by a core.
-    constexpr uint64_t NIU_SLV_NONPOSTED_WR_REQ_RECEIVED = 0xffb202e8;
+    // NOC register that counts the number of posted write requests received by a core.
+    // Streaming stores go through write-combining BAR and generate posted PCIe writes.
+    constexpr uint64_t NIU_SLV_POSTED_WR_REQ_RECEIVED = 0xffb202e0;
 
     Cluster cluster;
     set_barrier_params(cluster);
@@ -519,16 +520,14 @@ TEST(SiliconDriverBH, DebugDoubleWrite) {
     uint32_t counter = 0;
 
     uint32_t base_reg_val;
-    cluster.read_from_device_reg(
-        &base_reg_val, chip_id, tensix_core, NIU_SLV_NONPOSTED_WR_REQ_RECEIVED, sizeof(uint32_t));
+    cluster.read_from_device_reg(&base_reg_val, chip_id, tensix_core, NIU_SLV_POSTED_WR_REQ_RECEIVED, sizeof(uint32_t));
 
     for (uint32_t i = 0; i < 100000; i++) {
         cluster.write_to_device(&data, sizeof(data), chip_id, tensix_core, addr);
         counter++;
 
         uint32_t reg_val;
-        cluster.read_from_device_reg(
-            &reg_val, chip_id, tensix_core, NIU_SLV_NONPOSTED_WR_REQ_RECEIVED, sizeof(uint32_t));
+        cluster.read_from_device_reg(&reg_val, chip_id, tensix_core, NIU_SLV_POSTED_WR_REQ_RECEIVED, sizeof(uint32_t));
 
         uint32_t diff = reg_val - base_reg_val;
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/1265

### Description

#### Problem

glibc's `memcpy` implementation can emit **overlapping stores** to the same address. For example, when copying between 4 and 7 bytes, glibc's `between_4_7` routine reads two overlapping 4-byte chunks and writes them both — meaning the overlapping bytes get written twice. On normal (cacheable) memory this is invisible, but when the destination is **device memory mapped through a TLB window**, each store is a separate PCIe write transaction. A double write corrupts data on the device side because the device sees two distinct writes to the same address with potentially different values (since the second write may carry stale data from the overlapping read).

This has been independently hit by multiple teams (BH-104, LLK test infra) and was expensive to debug.

#### Solution

Replace all raw `memcpy` calls that target device-mapped memory with custom copy routines (`streaming_memcpy_to`, `streaming_memcpy_from`) that guarantee **each address is written/read exactly once**.

On x86_64, these use **non-temporal (streaming) SIMD instructions**:
- **Writes**: AVX2 `_mm256_stream_si256` for 32-byte stores, SSE `_mm_stream_si128` for 16-byte, `_mm_stream_si32` for 4-byte, with an `_mm_sfence()` at the end.
- **Reads**: SSE4.1 `_mm_stream_load_si128` (MOVNTDQA) for 16-byte loads, with regular `_mm_storeu_si128` stores to host memory.

On other architectures (aarch64), a portable fallback uses explicit 4-byte volatile loads/stores.

#### Why streaming (non-temporal) stores/loads?

1. **No double writes**: Each SIMD instruction writes a fixed, non-overlapping region — the hardware guarantees a single store per address.
2. **Cache bypass**: Non-temporal stores bypass the CPU cache hierarchy and write directly to the write-combining buffer. This is faster for device memory (which is typically mapped as write-combining/uncacheable) because the data won't be read back from cache anyway — caching it just wastes cache lines and evicts useful data.
3. **Write combining**: The CPU's write-combining buffer can merge multiple streaming stores into fewer, larger PCIe transactions, improving bus utilization.
4. **~1.4-1.8x throughput improvement** over `memcpy` for device memory writes (based on tt-metal's experience with a similar approach).

#### Alignment handling

TLB window offsets can be arbitrary (not necessarily 4-byte aligned), and transfer sizes can be any number of bytes. The functions handle this with a phased approach:
- **Phase 0**: Byte-wide volatile stores/loads to align the device pointer to 4 bytes
- **Phase 1-5**: Progressively larger SIMD operations (4B → 32B → 256B bulk → tail)
- **Final phase**: Byte-wide volatile stores/loads for trailing bytes (0-3)

The existing Wormhole-specific `memcpy_to_device` / `memcpy_from_device` (which handle WH-specific device bugs like GDDR5 1-byte write adjacency) are also updated to use the streaming functions for their aligned middle section, while keeping their own RMW handling for leading/trailing partial words.

#### Trade-offs

- **x86_64 only for SIMD path**: The AVX2/SSE path is `#ifdef`'d to x86_64. Other architectures get a correct but non-optimized fallback using explicit 4-byte volatile stores.
- **`_mm_sfence()` cost**: Each call to `streaming_memcpy_to` ends with a store fence. For many small writes this adds overhead, but for the typical use case (large block transfers) it's negligible.
- **Write ordering**: Non-temporal stores are weakly ordered — they may reach the device in any order. The `_mm_sfence()` at the end ensures all stores from this call are visible before the function returns, but there is no ordering guarantee between individual stores within the call. This matches the existing `write_to_device` semantics (async, no ordering, use `l1_membar` for ordering).

### List of the changes
- Add `device_memcpy.hpp` with `streaming_memcpy_to` (AVX2 non-temporal stores) and `streaming_memcpy_from` (SSE4.1 non-temporal loads) — handles arbitrary alignment and size
- Replace raw `memcpy` in `write_block`/`read_block` for non-Wormhole architectures (Blackhole) with streaming functions
- Replace word-by-word copy loop in WH-specific `memcpy_to_device`/`memcpy_from_device` aligned middle with streaming functions
- Portable fallback (aarch64) uses explicit 4-byte volatile stores/loads

### Testing
CI

### API Changes
There are no API changes in this PR.

## Performance Results (CI comparison vs main)

| | WH N300 | WH N150 | WH N300-viommu | WH N150-viommu | WH N300-llmbox | BH P150b | BH P150b-viommu | BH P100a-viommu |
|---|---|---|---|---|---|---|---|---|
| **API Tests** | 1499→1379 ms (-8%) | 147→118 ms (-20%) | 6024→5779 ms (-4%) | 4499→4093 ms (-9%) | 6717→6391 ms (-5%) | 190→211 ms (+11%) | 2667→2588 ms (-3%) | 3764→3618 ms (-4%) |
| **Arch Tests** | 20178→6753 ms (**-67%**) | 19174→2447 ms (**-87%**) | 292236→123352 ms (**-58%**) | 29430→12837 ms (**-56%**) | 48434→28145 ms (**-42%**) | 15159→15433 ms (+2%) | 21834→20915 ms (-4%) | 20703→15593 ms (**-25%**) |
| **ReadWriteL1** | 2465→451 ms (**-82%**) | 1074→38 ms (**-96%**) | 2341→381 ms (**-84%**) | 1101→88 ms (**-92%**) | 8836→1956 ms (**-78%**) | 192→170 ms (-11%) | 236→185 ms (-22%) | 294→74 ms (**-75%**) |
