### PR TITLE
Disable test for BH galaxy and add more informative errno print

### DIFF
--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -219,7 +219,8 @@ static void reset_device_ioctl(const std::unordered_set<int> &pci_target_devices
             reset_info.out.output_size_bytes = 0;
             reset_info.out.result = 0;
             if (ioctl(fd, TENSTORRENT_IOCTL_RESET_DEVICE, &reset_info) == -1) {
-                TT_THROW("TENSTORRENT_IOCTL_RESET_DEVICE failed");
+                TT_THROW(
+                    "TENSTORRENT_IOCTL_RESET_DEVICE failed on device {} with flags {}: {}", n, flags, strerror(errno));
             }
         } catch (const std::exception &e) {
             log_error(tt::LogUMD, "Reset IOCTL failed: {}", e.what());

--- a/tests/test_utils/test_api_common.hpp
+++ b/tests/test_utils/test_api_common.hpp
@@ -87,7 +87,8 @@ private:
 // Helper function to detect if the cluster is a Galaxy configuration, including 4U and 6U configurations.
 inline bool is_galaxy_configuration(Cluster* cluster) {
     return !cluster->get_target_device_ids().empty() &&
-           cluster->get_cluster_description()->get_board_type(0) == tt::BoardType::UBB;
+           (cluster->get_cluster_description()->get_board_type(0) == tt::BoardType::UBB_WORMHOLE ||
+            cluster->get_cluster_description()->get_board_type(0) == tt::BoardType::UBB_BLACKHOLE);
 }
 
 inline bool has_remote_chips() {


### PR DESCRIPTION
### Issue
/

### Description
This pull request makes targeted improvements to error handling and configuration detection in the PCIe device reset logic and test utilities.

### List of the changes
**Error Handling Improvements:**

* Enhanced the error message in `reset_device_ioctl` (in `pci_device.cpp`) to include the device number, flags, and the system error string when the IOCTL reset fails, providing more context for debugging.

**Configuration Detection Updates:**

* Updated the `is_galaxy_configuration` helper function (in `test_api_common.hpp`) to recognize both `UBB_WORMHOLE` and `UBB_BLACKHOLE` board types as valid Galaxy configurations, improving the accuracy of test environment detection.

### Testing
CI

### API Changes
/
