### PR TITLE
Parametrize deb/rpm in build job

### DIFF
--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -143,6 +143,7 @@ jobs:
 
       - name: Generate ${{ matrix.image.package }} package
         working-directory: ${{ env.TT_UMD_DIR }}/build
+        shell: bash
         run: |
           PKG="${{ matrix.image.package }}"
           cpack -G "${PKG^^}"
@@ -225,6 +226,7 @@ jobs:
 
       - name: Generate ${{ matrix.image.package }} package for umd-python
         working-directory: ${{ env.TT_UMD_DIR }}/build
+        shell: bash
         run: |
           PKG="${{ matrix.image.package }}"
           cpack -G "${PKG^^}"


### PR DESCRIPTION
### Issue
No issue, follow up from https://github.com/tenstorrent/tt-umd/pull/2116

### Description
While looking at something else, I realized I previously refactored only the test part and not the build part of this file.
Simplify jobs by adding pkg name into matrix.

### List of the changes
- Add deb/rpm to build matrix

### Testing
If the workflows pass on this PR, its enough of a test

### API Changes
There are no API changes in this PR.
