### PR TITLE
Add deb/rpm dependancies in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,7 +328,7 @@ jobs:
 
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
-    needs: [prepare-release, build-python-wheels]
+    needs: [prepare-release, build-python-wheels, build-cpp-artifacts]
     runs-on: ubuntu-22.04
 
     environment:
@@ -353,7 +353,7 @@ jobs:
 
   publish-to-pypi:
     name: Publish Python 🐍 distribution 📦 to PyPI
-    needs: [prepare-release, build-python-wheels, publish-to-testpypi]
+    needs: [prepare-release, build-python-wheels, build-cpp-artifacts, publish-to-testpypi]
     runs-on: ubuntu-22.04
 
     environment:


### PR DESCRIPTION
### Issue
Investigating failure in https://github.com/tenstorrent/tt-umd/actions/runs/23553077426

### Description
Making publishing to pypi dependant on all previous jobs, including deb/rpm

### List of the changes
- Add job dependancies

### Testing
No testing

### API Changes
There are no API changes in this PR.
