### PR TITLE
Add release build jobs with slightly different options

### DIFF
--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -85,8 +85,9 @@ jobs:
           # compiler, and whether they used release cmake flags or not.
           # This suffix should be used for all package artifacts so their names
           # don't overlap for different configurations.
-          # Example: BUILD_ID=ubuntu-24.04-clang-20-release
-          echo "BUILD_ID=${{ matrix.image.distro }}-${{ matrix.image.compiler-c }}${RELEASE_SUFFIX}" >> $GITHUB_ENV
+          # Example: PLATFORM_SUFFIX=ubuntu-24.04-clang-20-release
+          PLATFORM_SUFFIX="${{ matrix.image.distro }}-${{ matrix.image.compiler-c }}${RELEASE_SUFFIX}"
+          echo "PLATFORM_SUFFIX=${PLATFORM_SUFFIX}" >> $GITHUB_ENV
 
       # Build with all components to verify the build passes.
       # Release-flags builds mirror the flags used in release.yml to catch clang-tidy issues early.
@@ -121,7 +122,7 @@ jobs:
         if: always()
         with:
           # example: clang-tidy-compile-commands-ubuntu-24.04-clang-20-release
-          name: clang-tidy-compile-commands-${{ env.BUILD_ID }}
+          name: clang-tidy-compile-commands-${{ env.PLATFORM_SUFFIX }}
           path: ${{ env.TT_UMD_DIR }}/build/compile_commands.json
 
       - name: Prepare clang-tidy config file for upload
@@ -137,7 +138,7 @@ jobs:
         if: always()
         with:
           # example: clang-tidy-config-ubuntu-24.04-clang-20-release
-          name: clang-tidy-config-${{ env.BUILD_ID }}
+          name: clang-tidy-config-${{ env.PLATFORM_SUFFIX }}
           path: ${{ runner.temp }}/clang-tidy-build-config
 
       - name: Generate .deb package
@@ -157,7 +158,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           # example: tt-umd-packages-ubuntu-24.04-clang-20-release
-          name: tt-umd-packages-${{ env.BUILD_ID }}
+          name: tt-umd-packages-${{ env.PLATFORM_SUFFIX }}
           path: |
             ${{ env.TT_UMD_DIR }}/build/*.deb
           if-no-files-found: error
@@ -167,7 +168,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           # example: tt-umd-packages-ubuntu-24.04-clang-20-release
-          name: tt-umd-packages-${{ env.BUILD_ID }}
+          name: tt-umd-packages-${{ env.PLATFORM_SUFFIX }}
           path: |
             ${{ env.TT_UMD_DIR }}/build/*.rpm
           if-no-files-found: error
@@ -176,7 +177,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           # example: tt-umd-examples-ubuntu-24.04-clang-20-release
-          name: tt-umd-examples-${{ env.BUILD_ID }}
+          name: tt-umd-examples-${{ env.PLATFORM_SUFFIX }}
           path: |
             ${{ env.TT_UMD_DIR }}/cmake/example_client.cmake
             ${{ env.TT_UMD_DIR }}/cmake/CPM.cmake
@@ -250,7 +251,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           # example: tt-umd-python-ubuntu-24.04-clang-20-release
-          name: tt-umd-python-${{ env.BUILD_ID }}
+          name: tt-umd-python-${{ env.PLATFORM_SUFFIX }}
           path: |
             ${{ env.TT_UMD_DIR }}/build/*umd-python*.deb
           if-no-files-found: error
@@ -266,7 +267,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           # example: tt-umd-python-ubuntu-24.04-clang-20-release
-          name: tt-umd-python-${{ env.BUILD_ID }}
+          name: tt-umd-python-${{ env.PLATFORM_SUFFIX }}
           path: |
             ${{ env.TT_UMD_DIR }}/build/*umd-python*.rpm
           if-no-files-found: error
@@ -341,29 +342,29 @@ jobs:
         run: |
           # Note that BUILD ID doesn't include the option with the -release suffix
           # as the above matrix which builds packages. We test only one variant.
-          echo "BUILD_ID=${{ matrix.build.distro }}-${{ matrix.build.compiler-c }}" >> $GITHUB_ENV
+          echo "PLATFORM_SUFFIX=${{ matrix.build.distro }}-${{ matrix.build.compiler-c }}" >> $GITHUB_ENV
 
       - name: Download Packages Artifact
         uses: actions/download-artifact@v4
         with:
           # example: tt-umd-packages-ubuntu-24.04-clang-20
-          name: tt-umd-packages-${{ env.BUILD_ID }}
-          path: ./downloaded-artifact/tt-umd-packages-${{ env.BUILD_ID }}-package
+          name: tt-umd-packages-${{ env.PLATFORM_SUFFIX }}
+          path: ./downloaded-artifact/tt-umd-packages-${{ env.PLATFORM_SUFFIX }}-package
 
       - name: Download Examples Artifact
         uses: actions/download-artifact@v4
         with:
           # example: tt-umd-examples-ubuntu-24.04-clang-20
-          name: tt-umd-examples-${{ env.BUILD_ID }}
-          path: ./downloaded-artifact/tt-umd-examples-${{ env.BUILD_ID }}-example
+          name: tt-umd-examples-${{ env.PLATFORM_SUFFIX }}
+          path: ./downloaded-artifact/tt-umd-examples-${{ env.PLATFORM_SUFFIX }}-example
 
       - name: Download Python Packages Artifact
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
           # example: tt-umd-python-ubuntu-24.04-clang-20
-          name: tt-umd-python-${{ env.BUILD_ID }}
-          path: ./downloaded-artifact/tt-umd-python-${{ env.BUILD_ID }}-package
+          name: tt-umd-python-${{ env.PLATFORM_SUFFIX }}
+          path: ./downloaded-artifact/tt-umd-python-${{ env.PLATFORM_SUFFIX }}-package
 
       - name: Run test on example and python with packages
         shell: bash
@@ -372,9 +373,9 @@ jobs:
           PKG_FMT="${{ matrix.build.package }}"
 
           # Directories from downloaded artifacts
-          PACKAGE_DIR="./downloaded-artifact/tt-umd-packages-${BUILD_ID}-package"
-          PY_PACKAGE_DIR="./downloaded-artifact/tt-umd-python-${BUILD_ID}-package"
-          EXAMPLE_DIR="./downloaded-artifact/tt-umd-examples-${BUILD_ID}-example"
+          PACKAGE_DIR="./downloaded-artifact/tt-umd-packages-${PLATFORM_SUFFIX}-package"
+          PY_PACKAGE_DIR="./downloaded-artifact/tt-umd-python-${PLATFORM_SUFFIX}-package"
+          EXAMPLE_DIR="./downloaded-artifact/tt-umd-examples-${PLATFORM_SUFFIX}-example"
 
           echo "Install .${PKG_FMT} packages from ${PACKAGE_DIR}"
           DEV_PKG="$(find "${PACKAGE_DIR}" -maxdepth 1 -type f \


### PR DESCRIPTION
### Issue
#2366

### Description
This pull request updates the CI workflow in `.github/workflows/build-device.yml` to improve build artifact naming consistency and add explicit release-flags builds. The main changes include adding new matrix entries to test release CMake flags, standardizing artifact naming using a new `BUILD_ID` environment variable, and updating artifact download and usage in downstream jobs.

### List of the changes

**CI workflow improvements:**

* Added new matrix entries to build with release CMake flags (`TT_UMD_BUILD_SIMULATION=OFF`, `CMAKE_BUILD_TYPE=Release`) on both Ubuntu 24.04 (clang-20) and Fedora 39 (clang-17), ensuring clang-tidy issues are caught before merging. The job name now indicates whether release or dev flags are used.
* The build step now conditionally applies the correct CMake flags based on whether release flags are being tested.

**Artifact naming and handling:**

* Introduced a `BUILD_ID` environment variable to standardize artifact names across all upload and download steps, replacing the previous pattern that used separate distro and compiler variables. This affects all package, example, and Python artifact uploads and downloads.
* Updated downstream jobs to use the new `BUILD_ID` for downloading artifacts and for referencing artifact directories in test scripts, ensuring consistency and reducing the risk of mismatches.

### Testing
CI

### API Changes
/
