### PR TITLE
Fix SiliconDriverWH.CustomSocDesc

### DIFF
--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -21,6 +21,7 @@
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/utils/semver.hpp"
 #include "wormhole/eth_l1_address_map.h"
 #include "wormhole/host_mem_address_map.h"
@@ -77,7 +78,10 @@ TEST(SiliconDriverWH, CustomSocDesc) {
         .sdesc_path = test_utils::GetSocDescAbsPath("wormhole_b0_1x1.yaml"),
     });
     for (const auto& chip : cluster.get_target_device_ids()) {
-        ASSERT_EQ(cluster.get_soc_descriptor(chip).get_cores(CoreType::TENSIX).size(), 1)
+        ASSERT_EQ(
+            cluster.get_soc_descriptor(chip).get_cores(CoreType::TENSIX).size() +
+                cluster.get_soc_descriptor(chip).get_harvested_cores(CoreType::TENSIX).size(),
+            1)
             << "Expected 1x1 SOC descriptor to be unmodified by driver";
     }
 }


### PR DESCRIPTION
### Issue
#2360 

### Description
Fixed SiliconDriverWH.CustomSocDesc to be independent from the tensix harvesting mask of the tested chip.

### Testing
CI

### API Changes
There are no API changes in this PR.
