### PR TITLE
Add DRAM_WORKER CoreType

### DIFF
--- a/device/api/umd/device/types/core_coordinates.hpp
+++ b/device/api/umd/device/types/core_coordinates.hpp
@@ -34,6 +34,9 @@ enum class CoreType {
     HARVESTED,
     ETH,
     WORKER,
+    // Represents programmable DRISCs on hardware DRAM cores, distinct from CoreType::DRAM
+    // which is used for DRAM bank data-access routing endpoints.
+    DRAM_WORKER,
     COUNT,
 };
 
@@ -74,6 +77,8 @@ static inline std::string to_str(const CoreType core_type) {
             return "ETH";
         case CoreType::WORKER:
             return "WORKER";
+        case CoreType::DRAM_WORKER:
+            return "DRAM_WORKER";
         default:
             return "UNKNOWN";
     }

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -113,8 +113,9 @@ void Chip::enable_ethernet_queue(const std::chrono::milliseconds timeout_ms) {
 // TODO: Remove this API once we switch to the new one.
 void Chip::send_tensix_risc_reset(CoreCoord core, const TensixSoftResetOptions& soft_resets) {
     TT_ASSERT(
-        core.core_type == CoreType::TENSIX || core.core_type == CoreType::ETH,
-        "Cannot control soft reset on a non-tensix or harvested core");
+        core.core_type == CoreType::TENSIX || core.core_type == CoreType::ETH ||
+            core.core_type == CoreType::DRAM_WORKER,
+        "Cannot control soft reset on a non-programmable or harvested core");
     auto valid = soft_resets & ALL_TENSIX_SOFT_RESET;
     uint32_t valid_val = static_cast<uint32_t>(valid);
     get_tt_device()->set_risc_reset_state(get_soc_descriptor().translate_chip_coord_to_translated(core), valid_val);

--- a/device/coordinates/coordinate_manager.cpp
+++ b/device/coordinates/coordinate_manager.cpp
@@ -130,6 +130,15 @@ void CoordinateManager::identity_map_noc0_cores() {
 
 CoreCoord CoordinateManager::translate_coord_to(
     const CoreCoord core_coord, const CoordSystem target_coord_system) const {
+    // DRAM_WORKER shares physical positions with DRAM. Delegate through the DRAM path
+    // and remap the result's core_type back to DRAM_WORKER.
+    if (core_coord.core_type == CoreType::DRAM_WORKER) {
+        CoreCoord dram_coord(core_coord.x, core_coord.y, CoreType::DRAM, core_coord.coord_system);
+        CoreCoord result = translate_coord_to(dram_coord, target_coord_system);
+        result.core_type = CoreType::DRAM_WORKER;
+        return result;
+    }
+
     auto noc0_coord_it = to_noc0_map.find(core_coord);
     if (noc0_coord_it == to_noc0_map.end()) {
         throw std::runtime_error(fmt::format(
@@ -422,6 +431,7 @@ const std::vector<tt_xy_pair>& CoordinateManager::get_noc0_pairs(const CoreType 
         case CoreType::TENSIX:
             return tensix_cores;
         case CoreType::DRAM:
+        case CoreType::DRAM_WORKER:
             return dram_cores;
         case CoreType::ETH:
             return eth_cores;
@@ -498,12 +508,21 @@ std::vector<CoreCoord> CoordinateManager::get_l2cpu_cores() const { return get_a
 
 std::vector<CoreCoord> CoordinateManager::get_harvested_l2cpu_cores() const { return {}; }
 
+static std::vector<CoreCoord> remap_core_type(std::vector<CoreCoord> cores, CoreType target_type) {
+    for (auto& core : cores) {
+        core.core_type = target_type;
+    }
+    return cores;
+}
+
 std::vector<CoreCoord> CoordinateManager::get_cores(const CoreType core_type) const {
     switch (core_type) {
         case CoreType::TENSIX:
             return get_tensix_cores();
         case CoreType::DRAM:
             return get_dram_cores();
+        case CoreType::DRAM_WORKER:
+            return remap_core_type(get_dram_cores(), CoreType::DRAM_WORKER);
         case CoreType::ETH:
             return get_eth_cores();
         case CoreType::PCIE:
@@ -526,6 +545,7 @@ tt_xy_pair CoordinateManager::get_grid_size(const CoreType core_type) const {
         case CoreType::TENSIX:
             return get_tensix_grid_size();
         case CoreType::DRAM:
+        case CoreType::DRAM_WORKER:
             return get_dram_grid_size();
         case CoreType::ARC:
             return arc_grid_size;
@@ -542,6 +562,8 @@ std::vector<CoreCoord> CoordinateManager::get_harvested_cores(const CoreType cor
             return get_harvested_tensix_cores();
         case CoreType::DRAM:
             return get_harvested_dram_cores();
+        case CoreType::DRAM_WORKER:
+            return remap_core_type(get_harvested_dram_cores(), CoreType::DRAM_WORKER);
         case CoreType::ETH:
             return get_harvested_eth_cores();
         case CoreType::PCIE:
@@ -567,6 +589,7 @@ tt_xy_pair CoordinateManager::get_harvested_grid_size(const CoreType core_type) 
         case CoreType::TENSIX:
             return get_harvested_tensix_grid_size();
         case CoreType::DRAM:
+        case CoreType::DRAM_WORKER:
             return get_harvested_dram_grid_size();
         case CoreType::ARC:
         case CoreType::PCIE:

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -209,7 +209,8 @@ tt_xy_pair SocDescriptor::translate_chip_coord_to_translated(const CoreCoord cor
     // is not used (for now), and UMD is using NOC0/NOC1 (depending on the selected NOC).
     // Task to address this: https://github.com/tenstorrent/tt-umd/issues/2176.
     if (noc_translation_enabled && (arch == tt::ARCH::WORMHOLE_B0) &&
-        (core.core_type == CoreType::DRAM || core.core_type == CoreType::ARC || core.core_type == CoreType::PCIE)) {
+        (core.core_type == CoreType::DRAM || core.core_type == CoreType::DRAM_WORKER ||
+         core.core_type == CoreType::ARC || core.core_type == CoreType::PCIE)) {
         return translate_coord_to(core, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0);
     }
 
@@ -663,6 +664,7 @@ void SocDescriptor::get_cores_and_grid_size_from_coordinate_manager() {
     for (const auto &core_type :
          {CoreType::TENSIX,
           CoreType::DRAM,
+          CoreType::DRAM_WORKER,
           CoreType::ETH,
           CoreType::ARC,
           CoreType::PCIE,
@@ -713,7 +715,9 @@ std::vector<CoreCoord> SocDescriptor::get_cores(
     // Filter cores by channel if specified.
     // At this time, only applicable for DRAM cores.
     if (channel.has_value()) {
-        TT_ASSERT(core_type == CoreType::DRAM, "Core type must be DRAM when setting channel.");
+        TT_ASSERT(
+            core_type == CoreType::DRAM || core_type == CoreType::DRAM_WORKER,
+            "Core type must be DRAM or DRAM_WORKER when setting channel.");
         TT_ASSERT(channel.value() < get_num_dram_channels(), "Channel value exceeds number of DRAM channels.");
         std::vector<CoreCoord> filtered_cores;
         for (const auto &core : cores) {

--- a/docs/COORDINATE_SYSTEMS.md
+++ b/docs/COORDINATE_SYSTEMS.md
@@ -125,6 +125,12 @@ Logical coordinates can be used for all core types. Each core type has a logical
    - X coordinate -> in range [0, number of banks - 1]
    - Y coordinate -> in range [0, number of noc ports for each bank - 1]
 
+- DRAM_WORKER cores
+   - Represents programmable DRISCs on DRAM banks (available on Blackhole). These cores share the same physical NOC0 positions and logical coordinate grid as DRAM cores, but are semantically distinct: DRAM is used for memory data-access routing endpoints, while DRAM_WORKER is used for kernel placement on the programmable RISC-V (DRISC) attached to each DRAM bank.
+   - Coordinate translations for DRAM_WORKER delegate through the DRAM path internally, so `translate_coord_to(DRAM_WORKER, LOGICAL)` will produce the same physical position as the equivalent DRAM translation, but with `core_type == DRAM_WORKER` in the result.
+   - X coordinate -> in range [0, number of banks - 1]
+   - Y coordinate -> in range [0, number of noc ports for each bank - 1]
+
 - ETH cores
    - X coordinate -> always 0
    - Y coordinate -> represents ETH ID (TODO: add ETH ID to core mapping)
@@ -167,6 +173,7 @@ enum class CoreType {
     TENSIX,
     ROUTER_ONLY,
     ETH,
+    DRAM_WORKER,
 };
 
 enum class CoordSystem : std::uint8_t {

--- a/nanobind/py_api_soc_descriptor.cpp
+++ b/nanobind/py_api_soc_descriptor.cpp
@@ -33,6 +33,7 @@ void bind_soc_descriptor(nb::module_ &m) {
         .value("HARVESTED", CoreType::HARVESTED)
         .value("ETH", CoreType::ETH)
         .value("WORKER", CoreType::WORKER)
+        .value("DRAM_WORKER", CoreType::DRAM_WORKER)
         .def("__str__", [](CoreType ct) { return to_str(ct); })
         .def("__repr__", [](CoreType ct) { return "CoreType." + to_str(ct); });
 

--- a/tests/baremetal/test_soc_descriptor.cpp
+++ b/tests/baremetal/test_soc_descriptor.cpp
@@ -701,3 +701,135 @@ TEST(SocDescriptor, SerializeSimulatorQuasar) {
         {.noc_translation_enabled = soc_descriptor.noc_translation_enabled,
          .harvesting_masks = soc_descriptor.harvesting_masks});
 }
+
+// DRAM_WORKER shares physical positions with DRAM but has a distinct CoreType tag.
+// These tests verify that DRAM_WORKER coordinates delegate through DRAM correctly.
+
+TEST(SocDescriptor, DramWorkerMatchesDramCoresWormhole) {
+    SocDescriptor soc_desc(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"), {.noc_translation_enabled = true});
+
+    const auto dram_cores = soc_desc.get_cores(CoreType::DRAM);
+    const auto dram_worker_cores = soc_desc.get_cores(CoreType::DRAM_WORKER);
+
+    ASSERT_EQ(dram_cores.size(), dram_worker_cores.size());
+    for (size_t i = 0; i < dram_cores.size(); i++) {
+        EXPECT_EQ(dram_cores[i].x, dram_worker_cores[i].x);
+        EXPECT_EQ(dram_cores[i].y, dram_worker_cores[i].y);
+        EXPECT_EQ(dram_cores[i].coord_system, dram_worker_cores[i].coord_system);
+        EXPECT_EQ(dram_worker_cores[i].core_type, CoreType::DRAM_WORKER);
+        EXPECT_EQ(dram_cores[i].core_type, CoreType::DRAM);
+    }
+
+    EXPECT_EQ(soc_desc.get_grid_size(CoreType::DRAM), soc_desc.get_grid_size(CoreType::DRAM_WORKER));
+}
+
+TEST(SocDescriptor, DramWorkerTranslationWormhole) {
+    SocDescriptor soc_desc(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"), {.noc_translation_enabled = true});
+
+    const tt_xy_pair grid_size = soc_desc.get_grid_size(CoreType::DRAM_WORKER);
+
+    for (size_t x = 0; x < grid_size.x; x++) {
+        for (size_t y = 0; y < grid_size.y; y++) {
+            CoreCoord dram_logical(x, y, CoreType::DRAM, CoordSystem::LOGICAL);
+            CoreCoord dram_worker_logical(x, y, CoreType::DRAM_WORKER, CoordSystem::LOGICAL);
+
+            CoreCoord dram_noc0 = soc_desc.translate_coord_to(dram_logical, CoordSystem::NOC0);
+            CoreCoord dram_worker_noc0 = soc_desc.translate_coord_to(dram_worker_logical, CoordSystem::NOC0);
+
+            EXPECT_EQ(dram_noc0.x, dram_worker_noc0.x);
+            EXPECT_EQ(dram_noc0.y, dram_worker_noc0.y);
+            EXPECT_EQ(dram_worker_noc0.core_type, CoreType::DRAM_WORKER);
+
+            CoreCoord dram_translated = soc_desc.translate_coord_to(dram_logical, CoordSystem::TRANSLATED);
+            CoreCoord dram_worker_translated = soc_desc.translate_coord_to(dram_worker_logical, CoordSystem::TRANSLATED);
+
+            EXPECT_EQ(dram_translated.x, dram_worker_translated.x);
+            EXPECT_EQ(dram_translated.y, dram_worker_translated.y);
+            EXPECT_EQ(dram_worker_translated.core_type, CoreType::DRAM_WORKER);
+        }
+    }
+}
+
+TEST(SocDescriptor, DramWorkerMatchesDramCoresBlackhole) {
+    SocDescriptor soc_desc(
+        test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"), {.noc_translation_enabled = true});
+
+    const auto dram_cores = soc_desc.get_cores(CoreType::DRAM);
+    const auto dram_worker_cores = soc_desc.get_cores(CoreType::DRAM_WORKER);
+
+    ASSERT_EQ(dram_cores.size(), dram_worker_cores.size());
+    for (size_t i = 0; i < dram_cores.size(); i++) {
+        EXPECT_EQ(dram_cores[i].x, dram_worker_cores[i].x);
+        EXPECT_EQ(dram_cores[i].y, dram_worker_cores[i].y);
+        EXPECT_EQ(dram_worker_cores[i].core_type, CoreType::DRAM_WORKER);
+    }
+
+    EXPECT_EQ(soc_desc.get_grid_size(CoreType::DRAM), soc_desc.get_grid_size(CoreType::DRAM_WORKER));
+    EXPECT_EQ(
+        soc_desc.get_harvested_grid_size(CoreType::DRAM), soc_desc.get_harvested_grid_size(CoreType::DRAM_WORKER));
+}
+
+TEST(SocDescriptor, DramWorkerHarvestingBlackhole) {
+    const size_t num_dram_banks = blackhole::NUM_DRAM_BANKS;
+    const size_t num_noc_ports_per_bank = blackhole::NUM_NOC_PORTS_PER_DRAM_BANK;
+
+    const HarvestingMasks harvesting_masks = {.tensix_harvesting_mask = 0, .dram_harvesting_mask = 1};
+
+    SocDescriptor soc_desc(
+        test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"),
+        {.noc_translation_enabled = true, .harvesting_masks = harvesting_masks});
+
+    const auto dram_cores = soc_desc.get_cores(CoreType::DRAM);
+    const auto dram_worker_cores = soc_desc.get_cores(CoreType::DRAM_WORKER);
+
+    ASSERT_EQ(dram_cores.size(), dram_worker_cores.size());
+    ASSERT_EQ(dram_cores.size(), (num_dram_banks - 1) * num_noc_ports_per_bank);
+
+    for (size_t i = 0; i < dram_cores.size(); i++) {
+        EXPECT_EQ(dram_cores[i].x, dram_worker_cores[i].x);
+        EXPECT_EQ(dram_cores[i].y, dram_worker_cores[i].y);
+        EXPECT_EQ(dram_worker_cores[i].core_type, CoreType::DRAM_WORKER);
+    }
+
+    const auto harvested_dram = soc_desc.get_harvested_cores(CoreType::DRAM);
+    const auto harvested_dram_worker = soc_desc.get_harvested_cores(CoreType::DRAM_WORKER);
+
+    ASSERT_EQ(harvested_dram.size(), harvested_dram_worker.size());
+    ASSERT_EQ(harvested_dram.size(), num_noc_ports_per_bank);
+
+    for (size_t i = 0; i < harvested_dram.size(); i++) {
+        EXPECT_EQ(harvested_dram[i].x, harvested_dram_worker[i].x);
+        EXPECT_EQ(harvested_dram[i].y, harvested_dram_worker[i].y);
+        EXPECT_EQ(harvested_dram_worker[i].core_type, CoreType::DRAM_WORKER);
+    }
+
+    EXPECT_EQ(soc_desc.get_grid_size(CoreType::DRAM), soc_desc.get_grid_size(CoreType::DRAM_WORKER));
+}
+
+TEST(SocDescriptor, DramWorkerTranslationBlackhole) {
+    SocDescriptor soc_desc(
+        test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"), {.noc_translation_enabled = true});
+
+    const tt_xy_pair grid_size = soc_desc.get_grid_size(CoreType::DRAM_WORKER);
+
+    for (size_t x = 0; x < grid_size.x; x++) {
+        for (size_t y = 0; y < grid_size.y; y++) {
+            CoreCoord dram_logical(x, y, CoreType::DRAM, CoordSystem::LOGICAL);
+            CoreCoord dram_worker_logical(x, y, CoreType::DRAM_WORKER, CoordSystem::LOGICAL);
+
+            CoreCoord dram_noc0 = soc_desc.translate_coord_to(dram_logical, CoordSystem::NOC0);
+            CoreCoord dram_worker_noc0 = soc_desc.translate_coord_to(dram_worker_logical, CoordSystem::NOC0);
+
+            EXPECT_EQ(dram_noc0.x, dram_worker_noc0.x);
+            EXPECT_EQ(dram_noc0.y, dram_worker_noc0.y);
+            EXPECT_EQ(dram_worker_noc0.core_type, CoreType::DRAM_WORKER);
+
+            CoreCoord dram_translated = soc_desc.translate_coord_to(dram_logical, CoordSystem::TRANSLATED);
+            CoreCoord dram_worker_translated = soc_desc.translate_coord_to(dram_worker_logical, CoordSystem::TRANSLATED);
+
+            EXPECT_EQ(dram_translated.x, dram_worker_translated.x);
+            EXPECT_EQ(dram_translated.y, dram_worker_translated.y);
+            EXPECT_EQ(dram_worker_translated.core_type, CoreType::DRAM_WORKER);
+        }
+    }
+}


### PR DESCRIPTION
## Description
We're adding support to metal for running kernels on DRAM cores on blackhole. Each DRAM bank has 3 endpoints (noc addresses), and each endpoint has its own RISC core.

CoreType::DRAM is used inside metal to signify the DRAM bank itself and not a specific endpoint, so there is a non-trivial mapping between the two (e.g. the same logical coordinate may specify a different endpoint, depending on which NOC is used). To allow us to uniquely identify the endpoint (and RISC itself), add a new DRAM_WORKER type that metal won't adjust that way.

### List of the changes
Add CoreType::DRAM_WORKER and add support to a couple of places that need it.

### Testing
Builds.

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
This PR has API changes: these changes aren't breaking.