### PR TITLE
Add device process api

### DIFF
--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -47,6 +47,11 @@ struct PciDeviceInfo {
     // onto this struct as methods?  e.g. current_link_width etc.
 };
 
+struct DeviceProcess {
+    pid_t pid;
+    int device;
+};
+
 struct DmaBuffer {
     uint8_t *buffer = nullptr;
     uint8_t *completion = nullptr;
@@ -137,6 +142,13 @@ public:
      * @return a map of PCI device numbers (/dev/tenstorrent/N) to PciDeviceInfo
      */
     static std::map<int, PciDeviceInfo> enumerate_devices_info();
+
+    /**
+     * @return a list of (pid, device) pairs for all processes with open file descriptors
+     * to Tenstorrent devices, read from /proc/driver/tenstorrent/N/pids.
+     * Deduplicated per (pid, device). Sorted by (device, pid).
+     */
+    static std::vector<DeviceProcess> get_device_processes();
 
     /**
      * Returns the PCI device ID for the given UMD logical ID (index into enumerate_devices()).

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -10,6 +10,7 @@
 #include <sys/mman.h>   // for mmap, munmap
 #include <unistd.h>     // for ::close
 
+#include <algorithm>
 #include <cctype>
 #include <cerrno>
 #include <cstdint>
@@ -26,6 +27,7 @@
 #include <stdexcept>
 #include <string>
 #include <tt-logger/tt-logger.hpp>
+#include <tuple>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -377,6 +379,57 @@ std::map<int, PciDeviceInfo> PCIDevice::enumerate_devices_info() {
         close(fd);
     }
     return infos;
+}
+
+std::vector<DeviceProcess> PCIDevice::get_device_processes() {
+    std::vector<DeviceProcess> result;
+    std::string procfs_base = "/proc/driver/tenstorrent";
+
+    if (!std::filesystem::exists(procfs_base)) {
+        return result;
+    }
+
+    std::set<std::pair<pid_t, int>> seen;
+
+    for (const auto &entry : std::filesystem::directory_iterator(procfs_base)) {
+        if (!entry.is_directory()) {
+            continue;
+        }
+        const std::string name = entry.path().filename().string();
+        int device;
+        try {
+            device = std::stoi(name);
+        } catch (...) {
+            continue;
+        }
+
+        std::ifstream pids_file(entry.path() / "pids");
+        if (!pids_file.is_open()) {
+            continue;
+        }
+
+        std::string line;
+        while (std::getline(pids_file, line)) {
+            if (line.empty()) {
+                continue;
+            }
+            pid_t pid;
+            try {
+                pid = std::stoi(line);
+            } catch (...) {
+                continue;
+            }
+            if (seen.emplace(pid, device).second) {
+                result.push_back({pid, device});
+            }
+        }
+    }
+
+    std::sort(result.begin(), result.end(), [](const DeviceProcess &a, const DeviceProcess &b) {
+        return std::tie(a.device, a.pid) < std::tie(b.device, b.pid);
+    });
+
+    return result;
 }
 
 std::optional<int> PCIDevice::get_pci_device_id(int umd_logical_id) {

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -106,7 +106,15 @@ void bind_tt_device(nb::module_ &m) {
         .def_static(
             "is_arch_agnostic_reset_supported",
             &PCIDevice::is_arch_agnostic_reset_supported,
-            "Check if KMD supports arch agnostic reset.");
+            "Check if KMD supports arch agnostic reset.")
+        .def_static(
+            "get_device_processes",
+            &PCIDevice::get_device_processes,
+            "Get list of processes with open file descriptors to Tenstorrent devices.");
+
+    nb::class_<DeviceProcess>(m, "DeviceProcess")
+        .def_ro("pid", &DeviceProcess::pid)
+        .def_ro("device", &DeviceProcess::device);
 
     nb::class_<RemoteCommunication>(m, "RemoteCommunication")
         .def(

--- a/nanobind/tests/test_py_device_processes.py
+++ b/nanobind/tests/test_py_device_processes.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import unittest
+import tt_umd
+
+
+class TestDeviceProcesses(unittest.TestCase):
+    def test_returns_list(self):
+        procs = tt_umd.PCIDevice.get_device_processes()
+        self.assertIsInstance(procs, list)
+
+    def test_own_pid_visible(self):
+        pci_ids = tt_umd.PCIDevice.enumerate_devices()
+        if not pci_ids:
+            self.skipTest("No devices found")
+
+        dev = tt_umd.PCIDevice(pci_ids[0])
+        procs = tt_umd.PCIDevice.get_device_processes()
+        pids = [p.pid for p in procs]
+        self.assertIn(os.getpid(), pids)
+
+    def test_no_duplicates(self):
+        procs = tt_umd.PCIDevice.get_device_processes()
+        seen = set()
+        for p in procs:
+            key = (p.pid, p.device)
+            self.assertNotIn(key, seen, f"Duplicate: pid={p.pid} device={p.device}")
+            seen.add(key)
+
+    def test_sorted(self):
+        procs = tt_umd.PCIDevice.get_device_processes()
+        for i in range(1, len(procs)):
+            self.assertLessEqual(
+                (procs[i - 1].device, procs[i - 1].pid),
+                (procs[i].device, procs[i].pid),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description
Add API to query which processes have open file descriptors to Tenstorrent devices, reading from `/proc/driver/tenstorrent/N/pids`.

### List of the changes
- Add `DeviceProcess` struct (pid, device)
- Add `PCIDevice::get_device_processes()` static function
- Add nanobind binding
- Add Python tests

### Testing
- C++ unit tests pass (no hardware needed)
- Python unit tests pass
- Manually verified on Blackhole with tt-smi running

### API Changes
This PR has API changes (non-breaking, additive only):
- `DeviceProcess` -- new struct
- `PCIDevice::get_device_processes()` -- new static function