### PR TITLE
Split SocDescriptor into static (SocArchDescriptor) and runtime parts

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -105,6 +105,7 @@ target_sources(
         firmware/firmware_utils.cpp
         types/tensix_soft_reset_options.cpp
         types/risc_type.cpp
+        soc_arch_descriptor.cpp
         soc_descriptor.cpp
         coordinates/wormhole_coordinate_manager.cpp
         coordinates/blackhole_coordinate_manager.cpp
@@ -246,6 +247,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/simulation/simulation_host.hpp
                 api/umd/device/simulation/tt_sim_communicator.hpp
                 api/umd/device/simulation/rtl_sim_communicator.hpp
+                api/umd/device/soc_arch_descriptor.hpp
                 api/umd/device/soc_descriptor.hpp
                 api/umd/device/topology/topology_discovery_blackhole.hpp
                 api/umd/device/topology/topology_discovery_wormhole.hpp

--- a/device/api/umd/device/soc_arch_descriptor.hpp
+++ b/device/api/umd/device/soc_arch_descriptor.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 

--- a/device/api/umd/device/soc_arch_descriptor.hpp
+++ b/device/api/umd/device/soc_arch_descriptor.hpp
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/xy_pair.hpp"
+
+namespace YAML {
+class Node;
+}
+
+namespace tt::umd {
+
+//! CoreDescriptor contains information regarding a single core on the SOC.
+struct CoreDescriptor {
+    tt_xy_pair coord = tt_xy_pair(0, 0);
+    CoreType type;
+
+    std::size_t l1_size = 0;
+};
+
+// SocArchDescriptor contains the static, architecture-determined properties of a chip.
+// This data is identical for every chip of a given architecture and does not depend on
+// per-chip runtime state like harvesting masks or NOC translation settings.
+class SocArchDescriptor {
+public:
+    // Create from architecture enum (uses hardcoded constants).
+    static SocArchDescriptor create(tt::ARCH arch);
+
+    // Create from a YAML device descriptor file.
+    static SocArchDescriptor create(const std::string& device_descriptor_path);
+
+    // Helpers for extracting info from a YAML descriptor file without fully constructing.
+    static tt::ARCH get_arch_from_path(const std::string& soc_descriptor_path);
+    static tt_xy_pair get_grid_size_from_path(const std::string& soc_descriptor_path);
+
+    // Calculate grid size from a list of cores.
+    static tt_xy_pair calculate_grid_size(const std::vector<tt_xy_pair>& cores);
+
+    // Architecture.
+    tt::ARCH arch;
+
+    // Full NOC grid size (unharvested).
+    tt_xy_pair grid_size;
+
+    // Core locations in NOC0 coordinates.
+    std::vector<tt_xy_pair> tensix_cores;
+    std::vector<std::vector<tt_xy_pair>> dram_cores;  // Per-channel list.
+    std::vector<tt_xy_pair> eth_cores;
+    std::vector<tt_xy_pair> arc_cores;
+    std::vector<tt_xy_pair> pcie_cores;
+    std::vector<tt_xy_pair> router_cores;
+    std::vector<tt_xy_pair> security_cores;
+    std::vector<tt_xy_pair> l2cpu_cores;
+    std::vector<tt_xy_pair> dispatch_cores;
+
+    // Memory sizes.
+    uint32_t worker_l1_size = 0;
+    uint32_t eth_l1_size = 0;
+    uint64_t dram_bank_size = 0;
+
+    // NOC0 to NOC1 coordinate translation tables.
+    std::vector<uint32_t> noc0_x_to_noc1_x;
+    std::vector<uint32_t> noc0_y_to_noc1_y;
+
+    // Feature versions (populated from YAML; zero when created from arch enum).
+    int overlay_version = 0;
+    int unpacker_version = 0;
+    int dst_size_alignment = 0;
+    int packer_version = 0;
+
+    // TRISC sizes.
+    std::vector<std::size_t> trisc_sizes;
+
+    // Path to the source YAML descriptor file (empty when created from arch enum).
+    std::string device_descriptor_file_path;
+
+    // Derived data, computed at construction time.
+
+    // Core descriptor map (NOC0 coord -> CoreDescriptor).
+    std::unordered_map<tt_xy_pair, CoreDescriptor> cores;
+
+    // Worker grid size (computed from tensix core locations).
+    tt_xy_pair worker_grid_size;
+
+    // Channel maps.
+    std::unordered_map<tt_xy_pair, std::tuple<int, int>> dram_core_channel_map;
+    std::unordered_map<tt_xy_pair, int> ethernet_core_channel_map;
+
+private:
+    SocArchDescriptor() = default;
+
+    // Build derived data (cores map, channel maps, worker_grid_size) from core location vectors.
+    void build_derived_data();
+
+    // Load from YAML node.
+    void load_from_yaml(YAML::Node& device_descriptor_yaml);
+
+    // Helper for YAML parsing.
+    static std::vector<tt_xy_pair> convert_to_tt_xy_pair(const std::vector<std::string>& core_strings);
+    static std::vector<std::vector<tt_xy_pair>> convert_dram_cores_from_yaml(
+        YAML::Node& device_descriptor_yaml, const std::string& dram_core = "dram");
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/soc_arch_descriptor.hpp
+++ b/device/api/umd/device/soc_arch_descriptor.hpp
@@ -47,54 +47,73 @@ public:
     static tt_xy_pair calculate_grid_size(const std::vector<tt_xy_pair>& cores);
 
     // Architecture.
-    tt::ARCH arch;
+    tt::ARCH get_arch() const { return arch_; }
 
     // Full NOC grid size (unharvested).
-    tt_xy_pair grid_size;
+    const tt_xy_pair& get_grid_size() const { return grid_size_; }
 
     // Core locations in NOC0 coordinates.
-    std::vector<tt_xy_pair> tensix_cores;
-    std::vector<std::vector<tt_xy_pair>> dram_cores;  // Per-channel list.
-    std::vector<tt_xy_pair> eth_cores;
-    std::vector<tt_xy_pair> arc_cores;
-    std::vector<tt_xy_pair> pcie_cores;
-    std::vector<tt_xy_pair> router_cores;
-    std::vector<tt_xy_pair> security_cores;
-    std::vector<tt_xy_pair> l2cpu_cores;
-    std::vector<tt_xy_pair> dispatch_cores;
+    const std::vector<tt_xy_pair>& get_tensix_cores() const { return tensix_cores_; }
+
+    const std::vector<std::vector<tt_xy_pair>>& get_dram_cores() const { return dram_cores_; }
+
+    const std::vector<tt_xy_pair>& get_eth_cores() const { return eth_cores_; }
+
+    const std::vector<tt_xy_pair>& get_arc_cores() const { return arc_cores_; }
+
+    const std::vector<tt_xy_pair>& get_pcie_cores() const { return pcie_cores_; }
+
+    const std::vector<tt_xy_pair>& get_router_cores() const { return router_cores_; }
+
+    const std::vector<tt_xy_pair>& get_security_cores() const { return security_cores_; }
+
+    const std::vector<tt_xy_pair>& get_l2cpu_cores() const { return l2cpu_cores_; }
+
+    const std::vector<tt_xy_pair>& get_dispatch_cores() const { return dispatch_cores_; }
 
     // Memory sizes.
-    uint32_t worker_l1_size = 0;
-    uint32_t eth_l1_size = 0;
-    uint64_t dram_bank_size = 0;
+    uint32_t get_worker_l1_size() const { return worker_l1_size_; }
+
+    uint32_t get_eth_l1_size() const { return eth_l1_size_; }
+
+    uint64_t get_dram_bank_size() const { return dram_bank_size_; }
 
     // NOC0 to NOC1 coordinate translation tables.
-    std::vector<uint32_t> noc0_x_to_noc1_x;
-    std::vector<uint32_t> noc0_y_to_noc1_y;
+    const std::vector<uint32_t>& get_noc0_x_to_noc1_x() const { return noc0_x_to_noc1_x_; }
+
+    const std::vector<uint32_t>& get_noc0_y_to_noc1_y() const { return noc0_y_to_noc1_y_; }
 
     // Feature versions (populated from YAML; zero when created from arch enum).
-    int overlay_version = 0;
-    int unpacker_version = 0;
-    int dst_size_alignment = 0;
-    int packer_version = 0;
+    int get_overlay_version() const { return overlay_version_; }
+
+    int get_unpacker_version() const { return unpacker_version_; }
+
+    int get_dst_size_alignment() const { return dst_size_alignment_; }
+
+    int get_packer_version() const { return packer_version_; }
 
     // TRISC sizes.
-    std::vector<std::size_t> trisc_sizes;
+    const std::vector<std::size_t>& get_trisc_sizes() const { return trisc_sizes_; }
 
     // Path to the source YAML descriptor file (empty when created from arch enum).
-    std::string device_descriptor_file_path;
+    const std::string& get_device_descriptor_file_path() const { return device_descriptor_file_path_; }
 
     // Derived data, computed at construction time.
 
     // Core descriptor map (NOC0 coord -> CoreDescriptor).
-    std::unordered_map<tt_xy_pair, CoreDescriptor> cores;
+    const std::unordered_map<tt_xy_pair, CoreDescriptor>& get_cores() const { return cores_; }
 
     // Worker grid size (computed from tensix core locations).
-    tt_xy_pair worker_grid_size;
+    const tt_xy_pair& get_worker_grid_size() const { return worker_grid_size_; }
 
     // Channel maps.
-    std::unordered_map<tt_xy_pair, std::tuple<int, int>> dram_core_channel_map;
-    std::unordered_map<tt_xy_pair, int> ethernet_core_channel_map;
+    const std::unordered_map<tt_xy_pair, std::tuple<int, int>>& get_dram_core_channel_map() const {
+        return dram_core_channel_map_;
+    }
+
+    const std::unordered_map<tt_xy_pair, int>& get_ethernet_core_channel_map() const {
+        return ethernet_core_channel_map_;
+    }
 
 private:
     SocArchDescriptor() = default;
@@ -109,6 +128,33 @@ private:
     static std::vector<tt_xy_pair> convert_to_tt_xy_pair(const std::vector<std::string>& core_strings);
     static std::vector<std::vector<tt_xy_pair>> convert_dram_cores_from_yaml(
         YAML::Node& device_descriptor_yaml, const std::string& dram_core = "dram");
+
+    tt::ARCH arch_;
+    tt_xy_pair grid_size_;
+    std::vector<tt_xy_pair> tensix_cores_;
+    std::vector<std::vector<tt_xy_pair>> dram_cores_;
+    std::vector<tt_xy_pair> eth_cores_;
+    std::vector<tt_xy_pair> arc_cores_;
+    std::vector<tt_xy_pair> pcie_cores_;
+    std::vector<tt_xy_pair> router_cores_;
+    std::vector<tt_xy_pair> security_cores_;
+    std::vector<tt_xy_pair> l2cpu_cores_;
+    std::vector<tt_xy_pair> dispatch_cores_;
+    uint32_t worker_l1_size_ = 0;
+    uint32_t eth_l1_size_ = 0;
+    uint64_t dram_bank_size_ = 0;
+    std::vector<uint32_t> noc0_x_to_noc1_x_;
+    std::vector<uint32_t> noc0_y_to_noc1_y_;
+    int overlay_version_ = 0;
+    int unpacker_version_ = 0;
+    int dst_size_alignment_ = 0;
+    int packer_version_ = 0;
+    std::vector<std::size_t> trisc_sizes_;
+    std::string device_descriptor_file_path_;
+    std::unordered_map<tt_xy_pair, CoreDescriptor> cores_;
+    tt_xy_pair worker_grid_size_;
+    std::unordered_map<tt_xy_pair, std::tuple<int, int>> dram_core_channel_map_;
+    std::unordered_map<tt_xy_pair, int> ethernet_core_channel_map_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/soc_descriptor.hpp
+++ b/device/api/umd/device/soc_descriptor.hpp
@@ -11,6 +11,7 @@
 #include <filesystem>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -18,13 +19,10 @@
 #include <vector>
 
 #include "umd/device/coordinates/coordinate_manager.hpp"
+#include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
-
-namespace YAML {
-class Node;
-}
 
 namespace tt::umd {
 
@@ -32,40 +30,9 @@ std::string format_node(tt_xy_pair xy);
 
 tt_xy_pair format_node(const std::string& str);
 
-//! SocNodeDescriptor contains information regarding the Node/Core
-/*!
-    Should only contain relevant configuration for SOC
-*/
-struct CoreDescriptor {
-    tt_xy_pair coord = tt_xy_pair(0, 0);
-    CoreType type;
-
-    std::size_t l1_size = 0;
-};
-
-struct SocDescriptorInfo {
-    tt::ARCH arch;
-    tt_xy_pair grid_size;
-    std::vector<tt_xy_pair> tensix_cores;
-    std::vector<std::vector<tt_xy_pair>> dram_cores;
-    std::vector<tt_xy_pair> eth_cores;
-    std::vector<tt_xy_pair> arc_cores;
-    std::vector<tt_xy_pair> pcie_cores;
-    std::vector<tt_xy_pair> router_cores;
-    std::vector<tt_xy_pair> security_cores;
-    std::vector<tt_xy_pair> l2cpu_cores;
-    std::vector<tt_xy_pair> dispatch_cores;
-
-    uint32_t worker_l1_size;
-    uint32_t eth_l1_size;
-    uint64_t dram_bank_size;
-    std::vector<uint32_t> noc0_x_to_noc1_x;
-    std::vector<uint32_t> noc0_y_to_noc1_y;
-};
-
 //! SocDescriptor contains information regarding the SOC configuration targetted.
 /*!
-    Should only contain relevant configuration for SOC
+    Should only contain relevant configuration for SOC.
 */
 class SocDescriptor {
 public:
@@ -76,9 +43,15 @@ public:
 
     SocDescriptor(const tt::ARCH arch, const ChipInfo chip_info = {});
 
+    // Constructor with explicit arch descriptor (enables sharing).
+    SocDescriptor(std::shared_ptr<const SocArchDescriptor> arch_desc, const ChipInfo chip_info = {});
+
     // Helpers for extracting info from soc descriptor file.
     static tt::ARCH get_arch_from_soc_descriptor_path(const std::string& soc_descriptor_path);
     static tt_xy_pair get_grid_size_from_soc_descriptor_path(const std::string& soc_descriptor_path);
+
+    // Access the underlying static architecture descriptor.
+    const SocArchDescriptor& get_arch_descriptor() const;
 
     // CoreCoord conversions.
     CoreCoord translate_coord_to(const CoreCoord core_coord, const CoordSystem coord_system) const;
@@ -133,9 +106,12 @@ public:
     std::pair<int, int> get_dram_channel_for_core(
         const CoreCoord& core_coord, const CoordSystem coord_system = CoordSystem::NOC0) const;
 
+    // Public data members kept for backward compatibility (Phase 1).
+    // These are copied from the SocArchDescriptor at construction time.
+    // In a future phase, they will be replaced by getter methods.
     tt::ARCH arch;
     tt_xy_pair grid_size;
-    std::vector<std::size_t> trisc_sizes;  // Most of software stack assumes same trisc size for whole chip..
+    std::vector<std::size_t> trisc_sizes;  // Most of software stack assumes same trisc size for whole chip.
     std::string device_descriptor_file_path = std::string("");
 
     int overlay_version;
@@ -160,22 +136,9 @@ public:
     HarvestingMasks harvesting_masks;
 
 private:
+    void init_from_arch_descriptor(const ChipInfo& chip_info);
     void create_coordinate_manager(const BoardType board_type, const uint8_t asic_location);
     void get_cores_and_grid_size_from_coordinate_manager();
-    void load_from_yaml(YAML::Node& device_descriptor_yaml);
-    void load_from_soc_desc_info(const SocDescriptorInfo& soc_desc_info);
-    void load_core_descriptors_from_soc_desc_info(const SocDescriptorInfo& soc_desc_info);
-    void load_soc_features_from_soc_desc_info(const SocDescriptorInfo& soc_desc_info);
-
-    static std::vector<tt_xy_pair> convert_to_tt_xy_pair(const std::vector<std::string>& core_strings);
-    static std::vector<std::vector<tt_xy_pair>> convert_dram_cores_from_yaml(
-        YAML::Node& device_descriptor_yaml, const std::string& dram_core = "dram");
-
-    static SocDescriptorInfo get_soc_descriptor_info(tt::ARCH arch);
-
-    static tt_xy_pair calculate_grid_size(const std::vector<tt_xy_pair>& cores);
-    std::vector<CoreCoord> translate_coordinates(
-        const std::vector<CoreCoord>& noc0_cores, const CoordSystem coord_system) const;
 
     static std::filesystem::path get_default_soc_descriptor_file_path();
 
@@ -184,23 +147,11 @@ private:
     void write_core_locations(void* out, const CoreType& core_type) const;
     void serialize_dram_cores(void* out, const std::vector<std::vector<CoreCoord>>& cores) const;
 
-    // Internal structures, read from yaml.
-    tt_xy_pair worker_grid_size;
-    std::unordered_map<tt_xy_pair, CoreDescriptor> cores;
-    std::vector<tt_xy_pair> arc_cores;
-    std::vector<tt_xy_pair> workers;
-    std::vector<tt_xy_pair> pcie_cores;
-    std::vector<std::vector<tt_xy_pair>> dram_cores;  // per channel list of dram cores
+    std::vector<CoreCoord> translate_coordinates(
+        const std::vector<CoreCoord>& noc0_cores, const CoordSystem coord_system) const;
 
-    std::unordered_map<tt_xy_pair, std::tuple<int, int>> dram_core_channel_map;  // map dram core to chan/subchan
-    std::vector<tt_xy_pair> ethernet_cores;                                      // ethernet cores (index == channel id)
-    std::unordered_map<tt_xy_pair, int> ethernet_core_channel_map;
-    std::vector<tt_xy_pair> router_cores;
-    std::vector<tt_xy_pair> security_cores;
-    std::vector<tt_xy_pair> l2cpu_cores;
-    std::vector<tt_xy_pair> dispatch_cores;
-    std::vector<uint32_t> noc0_x_to_noc1_x;
-    std::vector<uint32_t> noc0_y_to_noc1_y;
+    // The static architecture descriptor (shared across chips of the same arch).
+    std::shared_ptr<const SocArchDescriptor> arch_desc_;
 
     // TODO: change this to unique pointer as soon as copying of SocDescriptor
     // is not needed anymore. Soc descriptor and coordinate manager should be

--- a/device/soc_arch_descriptor.cpp
+++ b/device/soc_arch_descriptor.cpp
@@ -228,15 +228,13 @@ void SocArchDescriptor::load_from_yaml(YAML::Node& device_descriptor_yaml) {
     arch_name_value = trim(arch_name_value);
     arch = tt::arch_from_str(arch_name_value);
 
-    tensix_cores =
-        SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["functional_workers"].as<std::vector<std::string>>());
+    tensix_cores = SocArchDescriptor::convert_to_tt_xy_pair(
+        device_descriptor_yaml["functional_workers"].as<std::vector<std::string>>());
     dram_cores = SocArchDescriptor::convert_dram_cores_from_yaml(device_descriptor_yaml, "dram");
     pcie_cores =
         SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["pcie"].as<std::vector<std::string>>());
-    eth_cores =
-        SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["eth"].as<std::vector<std::string>>());
-    arc_cores =
-        SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["arc"].as<std::vector<std::string>>());
+    eth_cores = SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["eth"].as<std::vector<std::string>>());
+    arc_cores = SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["arc"].as<std::vector<std::string>>());
     router_cores =
         SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["router_only"].as<std::vector<std::string>>());
 

--- a/device/soc_arch_descriptor.cpp
+++ b/device/soc_arch_descriptor.cpp
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/soc_arch_descriptor.hpp"
+
+#include <fmt/core.h>
+#include <yaml-cpp/yaml.h>
+
+#include <fstream>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "umd/device/arch/blackhole_implementation.hpp"
+#include "umd/device/arch/grendel_implementation.hpp"
+#include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/soc_descriptor.hpp"
+
+namespace tt::umd {
+
+SocArchDescriptor SocArchDescriptor::create(tt::ARCH arch_enum) {
+    SocArchDescriptor desc;
+
+    switch (arch_enum) {
+        case tt::ARCH::WORMHOLE_B0:
+            desc.arch = tt::ARCH::WORMHOLE_B0;
+            desc.grid_size = wormhole::GRID_SIZE;
+            desc.tensix_cores = wormhole::TENSIX_CORES_NOC0;
+            desc.dram_cores = wormhole::DRAM_CORES_NOC0;
+            desc.eth_cores = wormhole::ETH_CORES_NOC0;
+            desc.arc_cores = wormhole::ARC_CORES_NOC0;
+            desc.pcie_cores = wormhole::PCIE_CORES_NOC0;
+            desc.router_cores = wormhole::ROUTER_CORES_NOC0;
+            desc.security_cores = wormhole::SECURITY_CORES_NOC0;
+            desc.l2cpu_cores = wormhole::L2CPU_CORES_NOC0;
+            desc.worker_l1_size = wormhole::TENSIX_L1_SIZE;
+            desc.eth_l1_size = wormhole::ETH_L1_SIZE;
+            desc.dram_bank_size = wormhole::DRAM_BANK_SIZE;
+            desc.noc0_x_to_noc1_x = wormhole::NOC0_X_TO_NOC1_X;
+            desc.noc0_y_to_noc1_y = wormhole::NOC0_Y_TO_NOC1_Y;
+            break;
+        case tt::ARCH::BLACKHOLE:
+            desc.arch = tt::ARCH::BLACKHOLE;
+            desc.grid_size = blackhole::GRID_SIZE;
+            desc.tensix_cores = blackhole::TENSIX_CORES_NOC0;
+            desc.dram_cores = blackhole::DRAM_CORES_NOC0;
+            desc.eth_cores = blackhole::ETH_CORES_NOC0;
+            desc.arc_cores = blackhole::ARC_CORES_NOC0;
+            desc.pcie_cores = blackhole::PCIE_CORES_NOC0;
+            desc.router_cores = blackhole::ROUTER_CORES_NOC0;
+            desc.security_cores = blackhole::SECURITY_CORES_NOC0;
+            desc.l2cpu_cores = blackhole::L2CPU_CORES_NOC0;
+            desc.worker_l1_size = blackhole::TENSIX_L1_SIZE;
+            desc.eth_l1_size = blackhole::ETH_L1_SIZE;
+            desc.dram_bank_size = blackhole::DRAM_BANK_SIZE;
+            desc.noc0_x_to_noc1_x = blackhole::NOC0_X_TO_NOC1_X;
+            desc.noc0_y_to_noc1_y = blackhole::NOC0_Y_TO_NOC1_Y;
+            break;
+        case tt::ARCH::QUASAR:
+            desc.arch = tt::ARCH::QUASAR;
+            desc.grid_size = grendel::GRID_SIZE;
+            desc.tensix_cores = grendel::TENSIX_CORES_NOC0;
+            desc.dram_cores = grendel::DRAM_CORES_NOC0;
+            desc.eth_cores = grendel::ETH_CORES_NOC0;
+            desc.arc_cores = grendel::ARC_CORES_NOC0;
+            desc.pcie_cores = grendel::PCIE_CORES_NOC0;
+            desc.router_cores = grendel::ROUTER_CORES_NOC0;
+            desc.security_cores = grendel::SECURITY_CORES_NOC0;
+            desc.l2cpu_cores = grendel::L2CPU_CORES_NOC0;
+            desc.dispatch_cores = grendel::DISPATCH_CORES_NOC0;
+            desc.worker_l1_size = grendel::TENSIX_L1_SIZE;
+            desc.eth_l1_size = grendel::ETH_L1_SIZE;
+            desc.dram_bank_size = grendel::DRAM_BANK_SIZE;
+            desc.noc0_x_to_noc1_x = grendel::NOC0_X_TO_NOC1_X;
+            desc.noc0_y_to_noc1_y = grendel::NOC0_Y_TO_NOC1_Y;
+            break;
+        default:
+            throw std::runtime_error("Invalid architecture for creating SocArchDescriptor.");
+    }
+
+    desc.build_derived_data();
+    return desc;
+}
+
+SocArchDescriptor SocArchDescriptor::create(const std::string& device_descriptor_path) {
+    std::ifstream fdesc(device_descriptor_path);
+    if (fdesc.fail()) {
+        throw std::runtime_error(
+            fmt::format("Error: device descriptor file {} does not exist!", device_descriptor_path));
+    }
+    fdesc.close();
+
+    YAML::Node device_descriptor_yaml = YAML::LoadFile(device_descriptor_path);
+
+    SocArchDescriptor desc;
+    desc.device_descriptor_file_path = device_descriptor_path;
+    desc.load_from_yaml(device_descriptor_yaml);
+    desc.build_derived_data();
+    return desc;
+}
+
+tt::ARCH SocArchDescriptor::get_arch_from_path(const std::string& soc_descriptor_path) {
+    YAML::Node device_descriptor_yaml = YAML::LoadFile(soc_descriptor_path);
+    return tt::arch_from_str(device_descriptor_yaml["arch_name"].as<std::string>());
+}
+
+tt_xy_pair SocArchDescriptor::calculate_grid_size(const std::vector<tt_xy_pair>& cores) {
+    std::unordered_set<size_t> x;
+    std::unordered_set<size_t> y;
+    for (auto core : cores) {
+        x.insert(core.x);
+        y.insert(core.y);
+    }
+    return {x.size(), y.size()};
+}
+
+tt_xy_pair SocArchDescriptor::get_grid_size_from_path(const std::string& soc_descriptor_path) {
+    YAML::Node device_descriptor_yaml = YAML::LoadFile(soc_descriptor_path);
+    return tt_xy_pair(
+        device_descriptor_yaml["grid"]["x_size"].as<int>(), device_descriptor_yaml["grid"]["y_size"].as<int>());
+}
+
+void SocArchDescriptor::build_derived_data() {
+    // Build core descriptor map.
+    for (const auto& arc_core : arc_cores) {
+        CoreDescriptor core_descriptor;
+        core_descriptor.coord = arc_core;
+        core_descriptor.type = CoreType::ARC;
+        cores.insert({core_descriptor.coord, core_descriptor});
+    }
+
+    for (const auto& pcie_core : pcie_cores) {
+        CoreDescriptor core_descriptor;
+        core_descriptor.coord = pcie_core;
+        core_descriptor.type = CoreType::PCIE;
+        cores.insert({core_descriptor.coord, core_descriptor});
+    }
+
+    int current_dram_channel = 0;
+    for (const auto& channel : dram_cores) {
+        for (unsigned int i = 0; i < channel.size(); i++) {
+            CoreDescriptor core_descriptor;
+            core_descriptor.coord = channel[i];
+            core_descriptor.type = CoreType::DRAM;
+            cores.insert({core_descriptor.coord, core_descriptor});
+            dram_core_channel_map[core_descriptor.coord] = {current_dram_channel, static_cast<int>(i)};
+        }
+        current_dram_channel++;
+    }
+
+    int current_ethernet_channel = 0;
+    for (const auto& eth_core : eth_cores) {
+        CoreDescriptor core_descriptor;
+        core_descriptor.coord = eth_core;
+        core_descriptor.type = CoreType::ETH;
+        core_descriptor.l1_size = eth_l1_size;
+        cores.insert({core_descriptor.coord, core_descriptor});
+        ethernet_core_channel_map[core_descriptor.coord] = current_ethernet_channel;
+        current_ethernet_channel++;
+    }
+
+    std::set<int> worker_routing_coords_x;
+    std::set<int> worker_routing_coords_y;
+    for (const auto& tensix_core : tensix_cores) {
+        CoreDescriptor core_descriptor;
+        core_descriptor.coord = tensix_core;
+        core_descriptor.type = CoreType::WORKER;
+        core_descriptor.l1_size = worker_l1_size;
+        cores.insert({core_descriptor.coord, core_descriptor});
+        worker_routing_coords_x.insert(core_descriptor.coord.x);
+        worker_routing_coords_y.insert(core_descriptor.coord.y);
+    }
+
+    worker_grid_size = tt_xy_pair(worker_routing_coords_x.size(), worker_routing_coords_y.size());
+
+    for (const auto& router_core : router_cores) {
+        CoreDescriptor core_descriptor;
+        core_descriptor.coord = router_core;
+        core_descriptor.type = CoreType::ROUTER_ONLY;
+        cores.insert({core_descriptor.coord, core_descriptor});
+    }
+
+    for (const auto& security_core : security_cores) {
+        CoreDescriptor core_descriptor;
+        core_descriptor.coord = security_core;
+        core_descriptor.type = CoreType::SECURITY;
+        cores.insert({core_descriptor.coord, core_descriptor});
+    }
+
+    for (const auto& l2cpu_core : l2cpu_cores) {
+        CoreDescriptor core_descriptor;
+        core_descriptor.coord = l2cpu_core;
+        core_descriptor.type = CoreType::L2CPU;
+        cores.insert({core_descriptor.coord, core_descriptor});
+    }
+
+    for (const auto& dispatch_core : dispatch_cores) {
+        CoreDescriptor core_descriptor;
+        core_descriptor.coord = dispatch_core;
+        core_descriptor.type = CoreType::DISPATCH;
+        cores.insert({core_descriptor.coord, core_descriptor});
+    }
+}
+
+// Trimming helpers for YAML parsing.
+static const char* ws = " \t\n\r\f\v";
+
+static inline std::string& rtrim(std::string& s, const char* t = ws) {
+    s.erase(s.find_last_not_of(t) + 1);
+    return s;
+}
+
+static inline std::string& ltrim(std::string& s, const char* t = ws) {
+    s.erase(0, s.find_first_not_of(t));
+    return s;
+}
+
+static inline std::string& trim(std::string& s, const char* t = ws) { return ltrim(rtrim(s, t), t); }
+
+void SocArchDescriptor::load_from_yaml(YAML::Node& device_descriptor_yaml) {
+    grid_size = tt_xy_pair(
+        device_descriptor_yaml["grid"]["x_size"].as<int>(), device_descriptor_yaml["grid"]["y_size"].as<int>());
+
+    std::string arch_name_value = device_descriptor_yaml["arch_name"].as<std::string>();
+    arch_name_value = trim(arch_name_value);
+    arch = tt::arch_from_str(arch_name_value);
+
+    tensix_cores =
+        SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["functional_workers"].as<std::vector<std::string>>());
+    dram_cores = SocArchDescriptor::convert_dram_cores_from_yaml(device_descriptor_yaml, "dram");
+    pcie_cores =
+        SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["pcie"].as<std::vector<std::string>>());
+    eth_cores =
+        SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["eth"].as<std::vector<std::string>>());
+    arc_cores =
+        SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["arc"].as<std::vector<std::string>>());
+    router_cores =
+        SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["router_only"].as<std::vector<std::string>>());
+
+    if (device_descriptor_yaml["l2cpu"].IsDefined()) {
+        l2cpu_cores =
+            SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["l2cpu"].as<std::vector<std::string>>());
+    }
+
+    if (device_descriptor_yaml["security"].IsDefined()) {
+        security_cores =
+            SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["security"].as<std::vector<std::string>>());
+    }
+
+    if (device_descriptor_yaml["dispatch"].IsDefined()) {
+        dispatch_cores =
+            SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["dispatch"].as<std::vector<std::string>>());
+    }
+
+    if (device_descriptor_yaml["noc0_x_to_noc1_x"].IsDefined()) {
+        noc0_x_to_noc1_x = device_descriptor_yaml["noc0_x_to_noc1_x"].as<std::vector<uint32_t>>();
+        noc0_y_to_noc1_y = device_descriptor_yaml["noc0_y_to_noc1_y"].as<std::vector<uint32_t>>();
+    }
+
+    worker_l1_size = device_descriptor_yaml["worker_l1_size"].as<uint32_t>();
+    eth_l1_size = device_descriptor_yaml["eth_l1_size"].as<uint32_t>();
+    dram_bank_size = device_descriptor_yaml["dram_bank_size"].as<uint64_t>();
+}
+
+std::vector<tt_xy_pair> SocArchDescriptor::convert_to_tt_xy_pair(const std::vector<std::string>& core_strings) {
+    std::vector<tt_xy_pair> core_pairs;
+    core_pairs.reserve(core_strings.size());
+    for (const auto& core_string : core_strings) {
+        core_pairs.push_back(format_node(core_string));
+    }
+    return core_pairs;
+}
+
+std::vector<std::vector<tt_xy_pair>> SocArchDescriptor::convert_dram_cores_from_yaml(
+    YAML::Node& device_descriptor_yaml, const std::string& dram_core) {
+    std::vector<std::vector<tt_xy_pair>> result;
+    for (auto channel_it = device_descriptor_yaml[dram_core].begin();
+         channel_it != device_descriptor_yaml[dram_core].end();
+         ++channel_it) {
+        result.push_back(convert_to_tt_xy_pair((*channel_it).as<std::vector<std::string>>()));
+    }
+    return result;
+}
+
+}  // namespace tt::umd

--- a/device/soc_arch_descriptor.cpp
+++ b/device/soc_arch_descriptor.cpp
@@ -124,6 +124,11 @@ tt_xy_pair SocArchDescriptor::get_grid_size_from_path(const std::string& soc_des
 }
 
 void SocArchDescriptor::build_derived_data() {
+    // Clear derived data in case this is called more than once.
+    cores_.clear();
+    dram_core_channel_map_.clear();
+    ethernet_core_channel_map_.clear();
+
     // Build core descriptor map.
     for (const auto& arc_core : arc_cores_) {
         CoreDescriptor core_descriptor;
@@ -209,7 +214,12 @@ void SocArchDescriptor::build_derived_data() {
 static const char* ws = " \t\n\r\f\v";
 
 static inline std::string& rtrim(std::string& s, const char* t = ws) {
-    s.erase(s.find_last_not_of(t) + 1);
+    auto pos = s.find_last_not_of(t);
+    if (pos == std::string::npos) {
+        s.clear();
+    } else {
+        s.erase(pos + 1);
+    }
     return s;
 }
 
@@ -261,6 +271,22 @@ void SocArchDescriptor::load_from_yaml(YAML::Node& device_descriptor_yaml) {
     worker_l1_size_ = device_descriptor_yaml["worker_l1_size"].as<uint32_t>();
     eth_l1_size_ = device_descriptor_yaml["eth_l1_size"].as<uint32_t>();
     dram_bank_size_ = device_descriptor_yaml["dram_bank_size"].as<uint64_t>();
+
+    if (device_descriptor_yaml["features"].IsDefined()) {
+        auto features = device_descriptor_yaml["features"];
+        if (features["overlay"].IsDefined() && features["overlay"]["version"].IsDefined()) {
+            overlay_version_ = features["overlay"]["version"].as<int>();
+        }
+        if (features["unpacker"].IsDefined() && features["unpacker"]["version"].IsDefined()) {
+            unpacker_version_ = features["unpacker"]["version"].as<int>();
+        }
+        if (features["math"].IsDefined() && features["math"]["dst_size_alignment"].IsDefined()) {
+            dst_size_alignment_ = features["math"]["dst_size_alignment"].as<int>();
+        }
+        if (features["packer"].IsDefined() && features["packer"]["version"].IsDefined()) {
+            packer_version_ = features["packer"]["version"].as<int>();
+        }
+    }
 }
 
 std::vector<tt_xy_pair> SocArchDescriptor::convert_to_tt_xy_pair(const std::vector<std::string>& core_strings) {

--- a/device/soc_arch_descriptor.cpp
+++ b/device/soc_arch_descriptor.cpp
@@ -26,56 +26,56 @@ SocArchDescriptor SocArchDescriptor::create(tt::ARCH arch_enum) {
 
     switch (arch_enum) {
         case tt::ARCH::WORMHOLE_B0:
-            desc.arch = tt::ARCH::WORMHOLE_B0;
-            desc.grid_size = wormhole::GRID_SIZE;
-            desc.tensix_cores = wormhole::TENSIX_CORES_NOC0;
-            desc.dram_cores = wormhole::DRAM_CORES_NOC0;
-            desc.eth_cores = wormhole::ETH_CORES_NOC0;
-            desc.arc_cores = wormhole::ARC_CORES_NOC0;
-            desc.pcie_cores = wormhole::PCIE_CORES_NOC0;
-            desc.router_cores = wormhole::ROUTER_CORES_NOC0;
-            desc.security_cores = wormhole::SECURITY_CORES_NOC0;
-            desc.l2cpu_cores = wormhole::L2CPU_CORES_NOC0;
-            desc.worker_l1_size = wormhole::TENSIX_L1_SIZE;
-            desc.eth_l1_size = wormhole::ETH_L1_SIZE;
-            desc.dram_bank_size = wormhole::DRAM_BANK_SIZE;
-            desc.noc0_x_to_noc1_x = wormhole::NOC0_X_TO_NOC1_X;
-            desc.noc0_y_to_noc1_y = wormhole::NOC0_Y_TO_NOC1_Y;
+            desc.arch_ = tt::ARCH::WORMHOLE_B0;
+            desc.grid_size_ = wormhole::GRID_SIZE;
+            desc.tensix_cores_ = wormhole::TENSIX_CORES_NOC0;
+            desc.dram_cores_ = wormhole::DRAM_CORES_NOC0;
+            desc.eth_cores_ = wormhole::ETH_CORES_NOC0;
+            desc.arc_cores_ = wormhole::ARC_CORES_NOC0;
+            desc.pcie_cores_ = wormhole::PCIE_CORES_NOC0;
+            desc.router_cores_ = wormhole::ROUTER_CORES_NOC0;
+            desc.security_cores_ = wormhole::SECURITY_CORES_NOC0;
+            desc.l2cpu_cores_ = wormhole::L2CPU_CORES_NOC0;
+            desc.worker_l1_size_ = wormhole::TENSIX_L1_SIZE;
+            desc.eth_l1_size_ = wormhole::ETH_L1_SIZE;
+            desc.dram_bank_size_ = wormhole::DRAM_BANK_SIZE;
+            desc.noc0_x_to_noc1_x_ = wormhole::NOC0_X_TO_NOC1_X;
+            desc.noc0_y_to_noc1_y_ = wormhole::NOC0_Y_TO_NOC1_Y;
             break;
         case tt::ARCH::BLACKHOLE:
-            desc.arch = tt::ARCH::BLACKHOLE;
-            desc.grid_size = blackhole::GRID_SIZE;
-            desc.tensix_cores = blackhole::TENSIX_CORES_NOC0;
-            desc.dram_cores = blackhole::DRAM_CORES_NOC0;
-            desc.eth_cores = blackhole::ETH_CORES_NOC0;
-            desc.arc_cores = blackhole::ARC_CORES_NOC0;
-            desc.pcie_cores = blackhole::PCIE_CORES_NOC0;
-            desc.router_cores = blackhole::ROUTER_CORES_NOC0;
-            desc.security_cores = blackhole::SECURITY_CORES_NOC0;
-            desc.l2cpu_cores = blackhole::L2CPU_CORES_NOC0;
-            desc.worker_l1_size = blackhole::TENSIX_L1_SIZE;
-            desc.eth_l1_size = blackhole::ETH_L1_SIZE;
-            desc.dram_bank_size = blackhole::DRAM_BANK_SIZE;
-            desc.noc0_x_to_noc1_x = blackhole::NOC0_X_TO_NOC1_X;
-            desc.noc0_y_to_noc1_y = blackhole::NOC0_Y_TO_NOC1_Y;
+            desc.arch_ = tt::ARCH::BLACKHOLE;
+            desc.grid_size_ = blackhole::GRID_SIZE;
+            desc.tensix_cores_ = blackhole::TENSIX_CORES_NOC0;
+            desc.dram_cores_ = blackhole::DRAM_CORES_NOC0;
+            desc.eth_cores_ = blackhole::ETH_CORES_NOC0;
+            desc.arc_cores_ = blackhole::ARC_CORES_NOC0;
+            desc.pcie_cores_ = blackhole::PCIE_CORES_NOC0;
+            desc.router_cores_ = blackhole::ROUTER_CORES_NOC0;
+            desc.security_cores_ = blackhole::SECURITY_CORES_NOC0;
+            desc.l2cpu_cores_ = blackhole::L2CPU_CORES_NOC0;
+            desc.worker_l1_size_ = blackhole::TENSIX_L1_SIZE;
+            desc.eth_l1_size_ = blackhole::ETH_L1_SIZE;
+            desc.dram_bank_size_ = blackhole::DRAM_BANK_SIZE;
+            desc.noc0_x_to_noc1_x_ = blackhole::NOC0_X_TO_NOC1_X;
+            desc.noc0_y_to_noc1_y_ = blackhole::NOC0_Y_TO_NOC1_Y;
             break;
         case tt::ARCH::QUASAR:
-            desc.arch = tt::ARCH::QUASAR;
-            desc.grid_size = grendel::GRID_SIZE;
-            desc.tensix_cores = grendel::TENSIX_CORES_NOC0;
-            desc.dram_cores = grendel::DRAM_CORES_NOC0;
-            desc.eth_cores = grendel::ETH_CORES_NOC0;
-            desc.arc_cores = grendel::ARC_CORES_NOC0;
-            desc.pcie_cores = grendel::PCIE_CORES_NOC0;
-            desc.router_cores = grendel::ROUTER_CORES_NOC0;
-            desc.security_cores = grendel::SECURITY_CORES_NOC0;
-            desc.l2cpu_cores = grendel::L2CPU_CORES_NOC0;
-            desc.dispatch_cores = grendel::DISPATCH_CORES_NOC0;
-            desc.worker_l1_size = grendel::TENSIX_L1_SIZE;
-            desc.eth_l1_size = grendel::ETH_L1_SIZE;
-            desc.dram_bank_size = grendel::DRAM_BANK_SIZE;
-            desc.noc0_x_to_noc1_x = grendel::NOC0_X_TO_NOC1_X;
-            desc.noc0_y_to_noc1_y = grendel::NOC0_Y_TO_NOC1_Y;
+            desc.arch_ = tt::ARCH::QUASAR;
+            desc.grid_size_ = grendel::GRID_SIZE;
+            desc.tensix_cores_ = grendel::TENSIX_CORES_NOC0;
+            desc.dram_cores_ = grendel::DRAM_CORES_NOC0;
+            desc.eth_cores_ = grendel::ETH_CORES_NOC0;
+            desc.arc_cores_ = grendel::ARC_CORES_NOC0;
+            desc.pcie_cores_ = grendel::PCIE_CORES_NOC0;
+            desc.router_cores_ = grendel::ROUTER_CORES_NOC0;
+            desc.security_cores_ = grendel::SECURITY_CORES_NOC0;
+            desc.l2cpu_cores_ = grendel::L2CPU_CORES_NOC0;
+            desc.dispatch_cores_ = grendel::DISPATCH_CORES_NOC0;
+            desc.worker_l1_size_ = grendel::TENSIX_L1_SIZE;
+            desc.eth_l1_size_ = grendel::ETH_L1_SIZE;
+            desc.dram_bank_size_ = grendel::DRAM_BANK_SIZE;
+            desc.noc0_x_to_noc1_x_ = grendel::NOC0_X_TO_NOC1_X;
+            desc.noc0_y_to_noc1_y_ = grendel::NOC0_Y_TO_NOC1_Y;
             break;
         default:
             throw std::runtime_error("Invalid architecture for creating SocArchDescriptor.");
@@ -96,7 +96,7 @@ SocArchDescriptor SocArchDescriptor::create(const std::string& device_descriptor
     YAML::Node device_descriptor_yaml = YAML::LoadFile(device_descriptor_path);
 
     SocArchDescriptor desc;
-    desc.device_descriptor_file_path = device_descriptor_path;
+    desc.device_descriptor_file_path_ = device_descriptor_path;
     desc.load_from_yaml(device_descriptor_yaml);
     desc.build_derived_data();
     return desc;
@@ -125,83 +125,83 @@ tt_xy_pair SocArchDescriptor::get_grid_size_from_path(const std::string& soc_des
 
 void SocArchDescriptor::build_derived_data() {
     // Build core descriptor map.
-    for (const auto& arc_core : arc_cores) {
+    for (const auto& arc_core : arc_cores_) {
         CoreDescriptor core_descriptor;
         core_descriptor.coord = arc_core;
         core_descriptor.type = CoreType::ARC;
-        cores.insert({core_descriptor.coord, core_descriptor});
+        cores_.insert({core_descriptor.coord, core_descriptor});
     }
 
-    for (const auto& pcie_core : pcie_cores) {
+    for (const auto& pcie_core : pcie_cores_) {
         CoreDescriptor core_descriptor;
         core_descriptor.coord = pcie_core;
         core_descriptor.type = CoreType::PCIE;
-        cores.insert({core_descriptor.coord, core_descriptor});
+        cores_.insert({core_descriptor.coord, core_descriptor});
     }
 
     int current_dram_channel = 0;
-    for (const auto& channel : dram_cores) {
+    for (const auto& channel : dram_cores_) {
         for (unsigned int i = 0; i < channel.size(); i++) {
             CoreDescriptor core_descriptor;
             core_descriptor.coord = channel[i];
             core_descriptor.type = CoreType::DRAM;
-            cores.insert({core_descriptor.coord, core_descriptor});
-            dram_core_channel_map[core_descriptor.coord] = {current_dram_channel, static_cast<int>(i)};
+            cores_.insert({core_descriptor.coord, core_descriptor});
+            dram_core_channel_map_[core_descriptor.coord] = {current_dram_channel, static_cast<int>(i)};
         }
         current_dram_channel++;
     }
 
     int current_ethernet_channel = 0;
-    for (const auto& eth_core : eth_cores) {
+    for (const auto& eth_core : eth_cores_) {
         CoreDescriptor core_descriptor;
         core_descriptor.coord = eth_core;
         core_descriptor.type = CoreType::ETH;
-        core_descriptor.l1_size = eth_l1_size;
-        cores.insert({core_descriptor.coord, core_descriptor});
-        ethernet_core_channel_map[core_descriptor.coord] = current_ethernet_channel;
+        core_descriptor.l1_size = eth_l1_size_;
+        cores_.insert({core_descriptor.coord, core_descriptor});
+        ethernet_core_channel_map_[core_descriptor.coord] = current_ethernet_channel;
         current_ethernet_channel++;
     }
 
     std::set<int> worker_routing_coords_x;
     std::set<int> worker_routing_coords_y;
-    for (const auto& tensix_core : tensix_cores) {
+    for (const auto& tensix_core : tensix_cores_) {
         CoreDescriptor core_descriptor;
         core_descriptor.coord = tensix_core;
         core_descriptor.type = CoreType::WORKER;
-        core_descriptor.l1_size = worker_l1_size;
-        cores.insert({core_descriptor.coord, core_descriptor});
+        core_descriptor.l1_size = worker_l1_size_;
+        cores_.insert({core_descriptor.coord, core_descriptor});
         worker_routing_coords_x.insert(core_descriptor.coord.x);
         worker_routing_coords_y.insert(core_descriptor.coord.y);
     }
 
-    worker_grid_size = tt_xy_pair(worker_routing_coords_x.size(), worker_routing_coords_y.size());
+    worker_grid_size_ = tt_xy_pair(worker_routing_coords_x.size(), worker_routing_coords_y.size());
 
-    for (const auto& router_core : router_cores) {
+    for (const auto& router_core : router_cores_) {
         CoreDescriptor core_descriptor;
         core_descriptor.coord = router_core;
         core_descriptor.type = CoreType::ROUTER_ONLY;
-        cores.insert({core_descriptor.coord, core_descriptor});
+        cores_.insert({core_descriptor.coord, core_descriptor});
     }
 
-    for (const auto& security_core : security_cores) {
+    for (const auto& security_core : security_cores_) {
         CoreDescriptor core_descriptor;
         core_descriptor.coord = security_core;
         core_descriptor.type = CoreType::SECURITY;
-        cores.insert({core_descriptor.coord, core_descriptor});
+        cores_.insert({core_descriptor.coord, core_descriptor});
     }
 
-    for (const auto& l2cpu_core : l2cpu_cores) {
+    for (const auto& l2cpu_core : l2cpu_cores_) {
         CoreDescriptor core_descriptor;
         core_descriptor.coord = l2cpu_core;
         core_descriptor.type = CoreType::L2CPU;
-        cores.insert({core_descriptor.coord, core_descriptor});
+        cores_.insert({core_descriptor.coord, core_descriptor});
     }
 
-    for (const auto& dispatch_core : dispatch_cores) {
+    for (const auto& dispatch_core : dispatch_cores_) {
         CoreDescriptor core_descriptor;
         core_descriptor.coord = dispatch_core;
         core_descriptor.type = CoreType::DISPATCH;
-        cores.insert({core_descriptor.coord, core_descriptor});
+        cores_.insert({core_descriptor.coord, core_descriptor});
     }
 }
 
@@ -221,46 +221,46 @@ static inline std::string& ltrim(std::string& s, const char* t = ws) {
 static inline std::string& trim(std::string& s, const char* t = ws) { return ltrim(rtrim(s, t), t); }
 
 void SocArchDescriptor::load_from_yaml(YAML::Node& device_descriptor_yaml) {
-    grid_size = tt_xy_pair(
+    grid_size_ = tt_xy_pair(
         device_descriptor_yaml["grid"]["x_size"].as<int>(), device_descriptor_yaml["grid"]["y_size"].as<int>());
 
     std::string arch_name_value = device_descriptor_yaml["arch_name"].as<std::string>();
     arch_name_value = trim(arch_name_value);
-    arch = tt::arch_from_str(arch_name_value);
+    arch_ = tt::arch_from_str(arch_name_value);
 
-    tensix_cores = SocArchDescriptor::convert_to_tt_xy_pair(
+    tensix_cores_ = SocArchDescriptor::convert_to_tt_xy_pair(
         device_descriptor_yaml["functional_workers"].as<std::vector<std::string>>());
-    dram_cores = SocArchDescriptor::convert_dram_cores_from_yaml(device_descriptor_yaml, "dram");
-    pcie_cores =
+    dram_cores_ = SocArchDescriptor::convert_dram_cores_from_yaml(device_descriptor_yaml, "dram");
+    pcie_cores_ =
         SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["pcie"].as<std::vector<std::string>>());
-    eth_cores = SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["eth"].as<std::vector<std::string>>());
-    arc_cores = SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["arc"].as<std::vector<std::string>>());
-    router_cores =
+    eth_cores_ = SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["eth"].as<std::vector<std::string>>());
+    arc_cores_ = SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["arc"].as<std::vector<std::string>>());
+    router_cores_ =
         SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["router_only"].as<std::vector<std::string>>());
 
     if (device_descriptor_yaml["l2cpu"].IsDefined()) {
-        l2cpu_cores =
+        l2cpu_cores_ =
             SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["l2cpu"].as<std::vector<std::string>>());
     }
 
     if (device_descriptor_yaml["security"].IsDefined()) {
-        security_cores =
+        security_cores_ =
             SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["security"].as<std::vector<std::string>>());
     }
 
     if (device_descriptor_yaml["dispatch"].IsDefined()) {
-        dispatch_cores =
+        dispatch_cores_ =
             SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["dispatch"].as<std::vector<std::string>>());
     }
 
     if (device_descriptor_yaml["noc0_x_to_noc1_x"].IsDefined()) {
-        noc0_x_to_noc1_x = device_descriptor_yaml["noc0_x_to_noc1_x"].as<std::vector<uint32_t>>();
-        noc0_y_to_noc1_y = device_descriptor_yaml["noc0_y_to_noc1_y"].as<std::vector<uint32_t>>();
+        noc0_x_to_noc1_x_ = device_descriptor_yaml["noc0_x_to_noc1_x"].as<std::vector<uint32_t>>();
+        noc0_y_to_noc1_y_ = device_descriptor_yaml["noc0_y_to_noc1_y"].as<std::vector<uint32_t>>();
     }
 
-    worker_l1_size = device_descriptor_yaml["worker_l1_size"].as<uint32_t>();
-    eth_l1_size = device_descriptor_yaml["eth_l1_size"].as<uint32_t>();
-    dram_bank_size = device_descriptor_yaml["dram_bank_size"].as<uint64_t>();
+    worker_l1_size_ = device_descriptor_yaml["worker_l1_size"].as<uint32_t>();
+    eth_l1_size_ = device_descriptor_yaml["eth_l1_size"].as<uint32_t>();
+    dram_bank_size_ = device_descriptor_yaml["dram_bank_size"].as<uint64_t>();
 }
 
 std::vector<tt_xy_pair> SocArchDescriptor::convert_to_tt_xy_pair(const std::vector<std::string>& core_strings) {

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -217,6 +217,9 @@ SocDescriptor::SocDescriptor(const std::string &device_descriptor_path, ChipInfo
 
 SocDescriptor::SocDescriptor(std::shared_ptr<const SocArchDescriptor> arch_desc, const ChipInfo chip_info) :
     arch_desc_(std::move(arch_desc)) {
+    if (!arch_desc_) {
+        throw std::invalid_argument("SocArchDescriptor pointer must not be null.");
+    }
     init_from_arch_descriptor(chip_info);
 }
 

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -13,11 +13,9 @@
 #include <fstream>
 #include <iostream>
 #include <optional>
-#include <regex>
 #include <set>
 #include <stdexcept>
 #include <string>
-#include <tt-logger/tt-logger.hpp>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -26,13 +24,9 @@
 #include "assert.hpp"
 #include "noc_access.hpp"
 #include "umd/device/arc/blackhole_arc_telemetry_reader.hpp"
-#include "umd/device/arch/blackhole_implementation.hpp"
-#include "umd/device/arch/grendel_implementation.hpp"
-#include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "utils.hpp"
-
-// #include "l1_address_map.h"
 
 namespace tt::umd {
 
@@ -62,23 +56,6 @@ tt_xy_pair format_node(const std::string &str) {
     }
 }
 
-const char *ws = " \t\n\r\f\v";
-
-// trim from end of string (right)
-inline std::string &rtrim(std::string &s, const char *t = ws) {
-    s.erase(s.find_last_not_of(t) + 1);
-    return s;
-}
-
-// trim from beginning of string (left)
-inline std::string &ltrim(std::string &s, const char *t = ws) {
-    s.erase(0, s.find_first_not_of(t));
-    return s;
-}
-
-// trim from both ends of string (right then left)
-inline std::string &trim(std::string &s, const char *t = ws) { return ltrim(rtrim(s, t), t); }
-
 // clang-format off
 static const std::unordered_map<tt_xy_pair, tt_xy_pair> ROUTER_NOC1_TO_TRANSLATED_BLACKHOLE = {
     {{15, 11}, {15,  0}},
@@ -102,16 +79,6 @@ static const std::unordered_map<tt_xy_pair, tt_xy_pair> ROUTER_NOC1_TO_TRANSLATE
 };
 
 // clang-format on
-
-tt_xy_pair SocDescriptor::calculate_grid_size(const std::vector<tt_xy_pair> &cores) {
-    std::unordered_set<size_t> x;
-    std::unordered_set<size_t> y;
-    for (auto core : cores) {
-        x.insert(core.x);
-        y.insert(core.y);
-    }
-    return {x.size(), y.size()};
-}
 
 void SocDescriptor::write_coords(void *out, const CoreCoord &core) const {
     YAML::Emitter *emitter = static_cast<YAML::Emitter *>(out);
@@ -160,13 +127,36 @@ void SocDescriptor::serialize_dram_cores(void *out, const std::vector<std::vecto
     }
 }
 
+void SocDescriptor::init_from_arch_descriptor(const ChipInfo &chip_info) {
+    // Copy static fields from arch descriptor for backward compatibility.
+    arch = arch_desc_->arch;
+    grid_size = arch_desc_->grid_size;
+    worker_l1_size = arch_desc_->worker_l1_size;
+    eth_l1_size = arch_desc_->eth_l1_size;
+    dram_bank_size = arch_desc_->dram_bank_size;
+    trisc_sizes = arch_desc_->trisc_sizes;
+    device_descriptor_file_path = arch_desc_->device_descriptor_file_path;
+    overlay_version = arch_desc_->overlay_version;
+    unpacker_version = arch_desc_->unpacker_version;
+    dst_size_alignment = arch_desc_->dst_size_alignment;
+    packer_version = arch_desc_->packer_version;
+
+    // Set runtime fields.
+    noc_translation_enabled = chip_info.noc_translation_enabled;
+    harvesting_masks = chip_info.harvesting_masks;
+
+    // Create coordinate manager from static + runtime data.
+    create_coordinate_manager(chip_info.board_type, chip_info.asic_location);
+}
+
 void SocDescriptor::create_coordinate_manager(const BoardType board_type, const uint8_t asic_location) {
-    const tt_xy_pair dram_grid_size = tt_xy_pair(dram_cores.size(), dram_cores.empty() ? 0 : dram_cores[0].size());
-    const tt_xy_pair arc_grid_size = SocDescriptor::calculate_grid_size(arc_cores);
-    tt_xy_pair pcie_grid_size = SocDescriptor::calculate_grid_size(pcie_cores);
+    const tt_xy_pair dram_grid_size = tt_xy_pair(
+        arch_desc_->dram_cores.size(), arch_desc_->dram_cores.empty() ? 0 : arch_desc_->dram_cores[0].size());
+    tt_xy_pair arc_grid_size = SocArchDescriptor::calculate_grid_size(arch_desc_->arc_cores);
+    tt_xy_pair pcie_grid_size = SocArchDescriptor::calculate_grid_size(arch_desc_->pcie_cores);
 
     std::vector<tt_xy_pair> dram_cores_unpacked;
-    for (const auto &vec : dram_cores) {
+    for (const auto &vec : arch_desc_->dram_cores) {
         for (const auto &core : vec) {
             dram_cores_unpacked.push_back(core);
         }
@@ -191,29 +181,54 @@ void SocDescriptor::create_coordinate_manager(const BoardType board_type, const 
         UMD_THROW(error::RuntimeError, "P300 card right chip should always have PCIe core (2, 0) harvested.");
     }
 
-    pcie_grid_size = SocDescriptor::calculate_grid_size(pcie_cores);
+    pcie_grid_size = SocArchDescriptor::calculate_grid_size(arch_desc_->pcie_cores);
 
     coordinate_manager = CoordinateManager::create_coordinate_manager(
         arch,
         noc_translation_enabled,
         harvesting_masks,
-        worker_grid_size,
-        workers,
+        arch_desc_->worker_grid_size,
+        arch_desc_->tensix_cores,
         dram_grid_size,
         dram_cores_unpacked,
-        ethernet_cores,
+        arch_desc_->eth_cores,
         arc_grid_size,
-        arc_cores,
+        arch_desc_->arc_cores,
         pcie_grid_size,
-        pcie_cores,
-        router_cores,
-        security_cores,
-        l2cpu_cores,
-        dispatch_cores,
-        noc0_x_to_noc1_x,
-        noc0_y_to_noc1_y);
+        arch_desc_->pcie_cores,
+        arch_desc_->router_cores,
+        arch_desc_->security_cores,
+        arch_desc_->l2cpu_cores,
+        arch_desc_->dispatch_cores,
+        arch_desc_->noc0_x_to_noc1_x,
+        arch_desc_->noc0_y_to_noc1_y);
     get_cores_and_grid_size_from_coordinate_manager();
 }
+
+SocDescriptor::SocDescriptor(const tt::ARCH arch_soc, ChipInfo chip_info) {
+    arch_desc_ = std::make_shared<const SocArchDescriptor>(SocArchDescriptor::create(arch_soc));
+    init_from_arch_descriptor(chip_info);
+}
+
+SocDescriptor::SocDescriptor(const std::string &device_descriptor_path, ChipInfo chip_info) {
+    arch_desc_ = std::make_shared<const SocArchDescriptor>(SocArchDescriptor::create(device_descriptor_path));
+    init_from_arch_descriptor(chip_info);
+}
+
+SocDescriptor::SocDescriptor(std::shared_ptr<const SocArchDescriptor> arch_desc, const ChipInfo chip_info) :
+    arch_desc_(std::move(arch_desc)) {
+    init_from_arch_descriptor(chip_info);
+}
+
+tt::ARCH SocDescriptor::get_arch_from_soc_descriptor_path(const std::string &soc_descriptor_path) {
+    return SocArchDescriptor::get_arch_from_path(soc_descriptor_path);
+}
+
+tt_xy_pair SocDescriptor::get_grid_size_from_soc_descriptor_path(const std::string &soc_descriptor_path) {
+    return SocArchDescriptor::get_grid_size_from_path(soc_descriptor_path);
+}
+
+const SocArchDescriptor &SocDescriptor::get_arch_descriptor() const { return *arch_desc_; }
 
 CoreCoord SocDescriptor::translate_coord_to(const CoreCoord core_coord, const CoordSystem coord_system) const {
     return coordinate_manager->translate_coord_to(core_coord, coord_system);
@@ -228,7 +243,7 @@ CoreCoord SocDescriptor::translate_coord_to(
     return coordinate_manager->translate_coord_to(core_location, input_coord_system, target_coord_system);
 }
 
-// Translates a chip coordinate to the correct device coordinates, returning a CoreCoord
+// Translates a chip coordinate to the correct device coordinates, returning a CoreCoord.
 // Returns the correct pre-translation coordinates for the given architecture. Note that
 // the returned CoordSystem is not necessarily TRANSLATED — architecture-specific fixups
 // (e.g., Wormhole DRAM/ARC/PCIe cores) may produce NOC0/NOC1 coordinates instead.
@@ -267,295 +282,6 @@ CoreCoord SocDescriptor::translate_chip_coord_to_translated_coord(const CoreCoor
 // translate_chip_coord_to_translated_coord.
 tt_xy_pair SocDescriptor::translate_chip_coord_to_translated(const CoreCoord core) const {
     return translate_chip_coord_to_translated_coord(core);
-}
-
-void SocDescriptor::load_core_descriptors_from_soc_desc_info(const SocDescriptorInfo &soc_desc_info) {
-    auto worker_l1_size = soc_desc_info.worker_l1_size;
-    auto eth_l1_size = soc_desc_info.eth_l1_size;
-
-    for (const auto &arc_core : soc_desc_info.arc_cores) {
-        CoreDescriptor core_descriptor;
-        core_descriptor.coord = arc_core;
-        core_descriptor.type = CoreType::ARC;
-        cores.insert({core_descriptor.coord, core_descriptor});
-        arc_cores.push_back(core_descriptor.coord);
-    }
-
-    for (const auto &pcie_core : soc_desc_info.pcie_cores) {
-        CoreDescriptor core_descriptor;
-        core_descriptor.coord = pcie_core;
-        core_descriptor.type = CoreType::PCIE;
-        cores.insert({core_descriptor.coord, core_descriptor});
-        pcie_cores.push_back(core_descriptor.coord);
-    }
-
-    int current_dram_channel = 0;
-    for (auto channel_it = soc_desc_info.dram_cores.begin(); channel_it != soc_desc_info.dram_cores.end();
-         ++channel_it) {
-        dram_cores.push_back({});
-        auto &soc_dram_cores = dram_cores.at(dram_cores.size() - 1);
-        const auto &dram_cores = (*channel_it);
-        for (unsigned int i = 0; i < dram_cores.size(); i++) {
-            const auto &dram_core = dram_cores.at(i);
-            CoreDescriptor core_descriptor;
-            core_descriptor.coord = dram_core;
-            core_descriptor.type = CoreType::DRAM;
-            cores.insert({core_descriptor.coord, core_descriptor});
-            soc_dram_cores.push_back(core_descriptor.coord);
-            dram_core_channel_map[core_descriptor.coord] = {current_dram_channel, i};
-        }
-        current_dram_channel++;
-    }
-
-    int current_ethernet_channel = 0;
-    for (const auto &eth_core : soc_desc_info.eth_cores) {
-        CoreDescriptor core_descriptor;
-        core_descriptor.coord = eth_core;
-        core_descriptor.type = CoreType::ETH;
-        core_descriptor.l1_size = eth_l1_size;
-        cores.insert({core_descriptor.coord, core_descriptor});
-        ethernet_cores.push_back(core_descriptor.coord);
-
-        ethernet_core_channel_map[core_descriptor.coord] = current_ethernet_channel;
-        current_ethernet_channel++;
-    }
-
-    std::set<int> worker_routing_coords_x;
-    std::set<int> worker_routing_coords_y;
-    for (const auto &tensix_core : soc_desc_info.tensix_cores) {
-        CoreDescriptor core_descriptor;
-        core_descriptor.coord = tensix_core;
-        core_descriptor.type = CoreType::WORKER;
-        core_descriptor.l1_size = worker_l1_size;
-        cores.insert({core_descriptor.coord, core_descriptor});
-        workers.push_back(core_descriptor.coord);
-        worker_routing_coords_x.insert(core_descriptor.coord.x);
-        worker_routing_coords_y.insert(core_descriptor.coord.y);
-    }
-
-    worker_grid_size = tt_xy_pair(worker_routing_coords_x.size(), worker_routing_coords_y.size());
-
-    for (const auto &router_core : soc_desc_info.router_cores) {
-        CoreDescriptor core_descriptor;
-        core_descriptor.coord = router_core;
-        core_descriptor.type = CoreType::ROUTER_ONLY;
-        cores.insert({core_descriptor.coord, core_descriptor});
-        router_cores.push_back(core_descriptor.coord);
-    }
-
-    for (const auto &security_core : soc_desc_info.security_cores) {
-        CoreDescriptor core_descriptor;
-        core_descriptor.coord = security_core;
-        core_descriptor.type = CoreType::SECURITY;
-        cores.insert({core_descriptor.coord, core_descriptor});
-        security_cores.push_back(core_descriptor.coord);
-    }
-
-    for (const auto &l2cpu_core : soc_desc_info.l2cpu_cores) {
-        CoreDescriptor core_descriptor;
-        core_descriptor.coord = l2cpu_core;
-        core_descriptor.type = CoreType::L2CPU;
-        cores.insert({core_descriptor.coord, core_descriptor});
-        l2cpu_cores.push_back(core_descriptor.coord);
-    }
-
-    for (const auto &dispatch_core : soc_desc_info.dispatch_cores) {
-        CoreDescriptor core_descriptor;
-        core_descriptor.coord = dispatch_core;
-        core_descriptor.type = CoreType::DISPATCH;
-        cores.insert({core_descriptor.coord, core_descriptor});
-        dispatch_cores.push_back(core_descriptor.coord);
-    }
-
-    noc0_x_to_noc1_x = soc_desc_info.noc0_x_to_noc1_x;
-    noc0_y_to_noc1_y = soc_desc_info.noc0_y_to_noc1_y;
-}
-
-void SocDescriptor::load_soc_features_from_soc_desc_info(const SocDescriptorInfo &soc_desc_info) {
-    worker_l1_size = soc_desc_info.worker_l1_size;
-    eth_l1_size = soc_desc_info.eth_l1_size;
-    dram_bank_size = soc_desc_info.dram_bank_size;
-}
-
-SocDescriptorInfo SocDescriptor::get_soc_descriptor_info(tt::ARCH arch) {
-    switch (arch) {
-        case tt::ARCH::WORMHOLE_B0: {
-            return SocDescriptorInfo{
-                .arch = tt::ARCH::WORMHOLE_B0,
-                .grid_size = wormhole::GRID_SIZE,
-                .tensix_cores = wormhole::TENSIX_CORES_NOC0,
-                .dram_cores = wormhole::DRAM_CORES_NOC0,
-                .eth_cores = wormhole::ETH_CORES_NOC0,
-                .arc_cores = wormhole::ARC_CORES_NOC0,
-                .pcie_cores = wormhole::PCIE_CORES_NOC0,
-                .router_cores = wormhole::ROUTER_CORES_NOC0,
-                .security_cores = wormhole::SECURITY_CORES_NOC0,
-                .l2cpu_cores = wormhole::L2CPU_CORES_NOC0,
-                .dispatch_cores = {},
-                .worker_l1_size = wormhole::TENSIX_L1_SIZE,
-                .eth_l1_size = wormhole::ETH_L1_SIZE,
-                .dram_bank_size = wormhole::DRAM_BANK_SIZE,
-                .noc0_x_to_noc1_x = wormhole::NOC0_X_TO_NOC1_X,
-                .noc0_y_to_noc1_y = wormhole::NOC0_Y_TO_NOC1_Y};
-            break;
-        }
-        case tt::ARCH::BLACKHOLE: {
-            return SocDescriptorInfo{
-                .arch = tt::ARCH::BLACKHOLE,
-                .grid_size = blackhole::GRID_SIZE,
-                .tensix_cores = blackhole::TENSIX_CORES_NOC0,
-                .dram_cores = blackhole::DRAM_CORES_NOC0,
-                .eth_cores = blackhole::ETH_CORES_NOC0,
-                .arc_cores = blackhole::ARC_CORES_NOC0,
-                .pcie_cores = blackhole::PCIE_CORES_NOC0,
-                .router_cores = blackhole::ROUTER_CORES_NOC0,
-                .security_cores = blackhole::SECURITY_CORES_NOC0,
-                .l2cpu_cores = blackhole::L2CPU_CORES_NOC0,
-                .dispatch_cores = {},
-                .worker_l1_size = blackhole::TENSIX_L1_SIZE,
-                .eth_l1_size = blackhole::ETH_L1_SIZE,
-                .dram_bank_size = blackhole::DRAM_BANK_SIZE,
-                .noc0_x_to_noc1_x = blackhole::NOC0_X_TO_NOC1_X,
-                .noc0_y_to_noc1_y = blackhole::NOC0_Y_TO_NOC1_Y};
-            break;
-        }
-        case tt::ARCH::QUASAR: {
-            return SocDescriptorInfo{
-                .arch = tt::ARCH::QUASAR,
-                .grid_size = grendel::GRID_SIZE,
-                .tensix_cores = grendel::TENSIX_CORES_NOC0,
-                .dram_cores = grendel::DRAM_CORES_NOC0,
-                .eth_cores = grendel::ETH_CORES_NOC0,
-                .arc_cores = grendel::ARC_CORES_NOC0,
-                .pcie_cores = grendel::PCIE_CORES_NOC0,
-                .router_cores = grendel::ROUTER_CORES_NOC0,
-                .security_cores = grendel::SECURITY_CORES_NOC0,
-                .l2cpu_cores = grendel::L2CPU_CORES_NOC0,
-                .dispatch_cores = grendel::DISPATCH_CORES_NOC0,
-                .worker_l1_size = grendel::TENSIX_L1_SIZE,
-                .eth_l1_size = grendel::ETH_L1_SIZE,
-                .dram_bank_size = grendel::DRAM_BANK_SIZE,
-                .noc0_x_to_noc1_x = grendel::NOC0_X_TO_NOC1_X,
-                .noc0_y_to_noc1_y = grendel::NOC0_Y_TO_NOC1_Y};
-            break;
-        }
-        default:
-            UMD_THROW(error::RuntimeError, "Invalid architecture for creating SocDescriptorInfo.");
-    }
-}
-
-SocDescriptor::SocDescriptor(const tt::ARCH arch_soc, ChipInfo chip_info) :
-    noc_translation_enabled(chip_info.noc_translation_enabled), harvesting_masks(chip_info.harvesting_masks) {
-    SocDescriptorInfo soc_desc_info = SocDescriptor::get_soc_descriptor_info(arch_soc);
-    load_from_soc_desc_info(soc_desc_info);
-    create_coordinate_manager(chip_info.board_type, chip_info.asic_location);
-}
-
-void SocDescriptor::load_from_soc_desc_info(const SocDescriptorInfo &soc_desc_info) {
-    arch = soc_desc_info.arch;
-    grid_size = soc_desc_info.grid_size;
-    load_core_descriptors_from_soc_desc_info(soc_desc_info);
-    load_soc_features_from_soc_desc_info(soc_desc_info);
-}
-
-std::vector<tt_xy_pair> SocDescriptor::convert_to_tt_xy_pair(const std::vector<std::string> &core_strings) {
-    std::vector<tt_xy_pair> core_pairs;
-    core_pairs.reserve(core_strings.size());
-    for (const auto &core_string : core_strings) {
-        core_pairs.push_back(format_node(core_string));
-    }
-
-    return core_pairs;
-}
-
-tt::ARCH SocDescriptor::get_arch_from_soc_descriptor_path(const std::string &soc_descriptor_path) {
-    YAML::Node device_descriptor_yaml = YAML::LoadFile(soc_descriptor_path);
-    return tt::arch_from_str(device_descriptor_yaml["arch_name"].as<std::string>());
-}
-
-tt_xy_pair SocDescriptor::get_grid_size_from_soc_descriptor_path(const std::string &soc_descriptor_path) {
-    YAML::Node device_descriptor_yaml = YAML::LoadFile(soc_descriptor_path);
-    return tt_xy_pair(
-        device_descriptor_yaml["grid"]["x_size"].as<int>(), device_descriptor_yaml["grid"]["y_size"].as<int>());
-}
-
-std::vector<std::vector<tt_xy_pair>> SocDescriptor::convert_dram_cores_from_yaml(
-    YAML::Node &device_descriptor_yaml, const std::string &dram_core) {
-    std::vector<std::vector<tt_xy_pair>> dram_cores;
-    for (auto channel_it = device_descriptor_yaml[dram_core].begin();
-         channel_it != device_descriptor_yaml[dram_core].end();
-         ++channel_it) {
-        dram_cores.push_back(convert_to_tt_xy_pair((*channel_it).as<std::vector<std::string>>()));
-    }
-
-    return dram_cores;
-}
-
-void SocDescriptor::load_from_yaml(YAML::Node &device_descriptor_yaml) {
-    SocDescriptorInfo soc_desc_info;
-
-    soc_desc_info.grid_size = tt_xy_pair(
-        device_descriptor_yaml["grid"]["x_size"].as<int>(), device_descriptor_yaml["grid"]["y_size"].as<int>());
-
-    std::string arch_name_value = device_descriptor_yaml["arch_name"].as<std::string>();
-    arch_name_value = trim(arch_name_value);
-    arch = tt::arch_from_str(arch_name_value);
-    soc_desc_info.arch = arch;
-
-    soc_desc_info.tensix_cores = SocDescriptor::convert_to_tt_xy_pair(
-        device_descriptor_yaml["functional_workers"].as<std::vector<std::string>>());
-    soc_desc_info.dram_cores = SocDescriptor::convert_dram_cores_from_yaml(device_descriptor_yaml, "dram");
-    soc_desc_info.pcie_cores =
-        SocDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["pcie"].as<std::vector<std::string>>());
-    soc_desc_info.eth_cores =
-        SocDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["eth"].as<std::vector<std::string>>());
-    soc_desc_info.arc_cores =
-        SocDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["arc"].as<std::vector<std::string>>());
-    soc_desc_info.router_cores =
-        SocDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["router_only"].as<std::vector<std::string>>());
-    if (device_descriptor_yaml["l2cpu"].IsDefined()) {
-        soc_desc_info.l2cpu_cores =
-            SocDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["l2cpu"].as<std::vector<std::string>>());
-    }
-
-    if (device_descriptor_yaml["security"].IsDefined()) {
-        soc_desc_info.security_cores =
-            SocDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["security"].as<std::vector<std::string>>());
-    }
-
-    if (device_descriptor_yaml["dispatch"].IsDefined()) {
-        soc_desc_info.dispatch_cores =
-            SocDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["dispatch"].as<std::vector<std::string>>());
-    }
-
-    if (device_descriptor_yaml["noc0_x_to_noc1_x"].IsDefined()) {
-        soc_desc_info.noc0_x_to_noc1_x = device_descriptor_yaml["noc0_x_to_noc1_x"].as<std::vector<uint32_t>>();
-        soc_desc_info.noc0_y_to_noc1_y = device_descriptor_yaml["noc0_y_to_noc1_y"].as<std::vector<uint32_t>>();
-    }
-
-    soc_desc_info.worker_l1_size = device_descriptor_yaml["worker_l1_size"].as<uint32_t>();
-    soc_desc_info.eth_l1_size = device_descriptor_yaml["eth_l1_size"].as<uint32_t>();
-    soc_desc_info.dram_bank_size = device_descriptor_yaml["dram_bank_size"].as<uint64_t>();
-
-    load_from_soc_desc_info(soc_desc_info);
-}
-
-SocDescriptor::SocDescriptor(const std::string &device_descriptor_path, ChipInfo chip_info) :
-    noc_translation_enabled(chip_info.noc_translation_enabled), harvesting_masks(chip_info.harvesting_masks) {
-    std::ifstream fdesc(device_descriptor_path);
-    if (fdesc.fail()) {
-        UMD_THROW(
-            error::RuntimeError,
-            fmt::format("Error: SoC descriptor file does not exist at path: {}", device_descriptor_path));
-    }
-    fdesc.close();
-
-    YAML::Node device_descriptor_yaml = YAML::LoadFile(device_descriptor_path);
-
-    device_descriptor_file_path = device_descriptor_path;
-    load_from_yaml(device_descriptor_yaml);
-
-    create_coordinate_manager(chip_info.board_type, chip_info.asic_location);
 }
 
 int SocDescriptor::get_num_dram_channels() const { return get_grid_size(CoreType::DRAM).x; }

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -129,17 +129,17 @@ void SocDescriptor::serialize_dram_cores(void *out, const std::vector<std::vecto
 
 void SocDescriptor::init_from_arch_descriptor(const ChipInfo &chip_info) {
     // Copy static fields from arch descriptor for backward compatibility.
-    arch = arch_desc_->arch;
-    grid_size = arch_desc_->grid_size;
-    worker_l1_size = arch_desc_->worker_l1_size;
-    eth_l1_size = arch_desc_->eth_l1_size;
-    dram_bank_size = arch_desc_->dram_bank_size;
-    trisc_sizes = arch_desc_->trisc_sizes;
-    device_descriptor_file_path = arch_desc_->device_descriptor_file_path;
-    overlay_version = arch_desc_->overlay_version;
-    unpacker_version = arch_desc_->unpacker_version;
-    dst_size_alignment = arch_desc_->dst_size_alignment;
-    packer_version = arch_desc_->packer_version;
+    arch = arch_desc_->get_arch();
+    grid_size = arch_desc_->get_grid_size();
+    worker_l1_size = arch_desc_->get_worker_l1_size();
+    eth_l1_size = arch_desc_->get_eth_l1_size();
+    dram_bank_size = arch_desc_->get_dram_bank_size();
+    trisc_sizes = arch_desc_->get_trisc_sizes();
+    device_descriptor_file_path = arch_desc_->get_device_descriptor_file_path();
+    overlay_version = arch_desc_->get_overlay_version();
+    unpacker_version = arch_desc_->get_unpacker_version();
+    dst_size_alignment = arch_desc_->get_dst_size_alignment();
+    packer_version = arch_desc_->get_packer_version();
 
     // Set runtime fields.
     noc_translation_enabled = chip_info.noc_translation_enabled;
@@ -150,13 +150,13 @@ void SocDescriptor::init_from_arch_descriptor(const ChipInfo &chip_info) {
 }
 
 void SocDescriptor::create_coordinate_manager(const BoardType board_type, const uint8_t asic_location) {
-    const tt_xy_pair dram_grid_size = tt_xy_pair(
-        arch_desc_->dram_cores.size(), arch_desc_->dram_cores.empty() ? 0 : arch_desc_->dram_cores[0].size());
-    tt_xy_pair arc_grid_size = SocArchDescriptor::calculate_grid_size(arch_desc_->arc_cores);
-    tt_xy_pair pcie_grid_size = SocArchDescriptor::calculate_grid_size(arch_desc_->pcie_cores);
+    const auto &dram_cores = arch_desc_->get_dram_cores();
+    const tt_xy_pair dram_grid_size = tt_xy_pair(dram_cores.size(), dram_cores.empty() ? 0 : dram_cores[0].size());
+    tt_xy_pair arc_grid_size = SocArchDescriptor::calculate_grid_size(arch_desc_->get_arc_cores());
+    tt_xy_pair pcie_grid_size = SocArchDescriptor::calculate_grid_size(arch_desc_->get_pcie_cores());
 
     std::vector<tt_xy_pair> dram_cores_unpacked;
-    for (const auto &vec : arch_desc_->dram_cores) {
+    for (const auto &vec : dram_cores) {
         for (const auto &core : vec) {
             dram_cores_unpacked.push_back(core);
         }
@@ -181,27 +181,27 @@ void SocDescriptor::create_coordinate_manager(const BoardType board_type, const 
         UMD_THROW(error::RuntimeError, "P300 card right chip should always have PCIe core (2, 0) harvested.");
     }
 
-    pcie_grid_size = SocArchDescriptor::calculate_grid_size(arch_desc_->pcie_cores);
+    pcie_grid_size = SocArchDescriptor::calculate_grid_size(arch_desc_->get_pcie_cores());
 
     coordinate_manager = CoordinateManager::create_coordinate_manager(
         arch,
         noc_translation_enabled,
         harvesting_masks,
-        arch_desc_->worker_grid_size,
-        arch_desc_->tensix_cores,
+        arch_desc_->get_worker_grid_size(),
+        arch_desc_->get_tensix_cores(),
         dram_grid_size,
         dram_cores_unpacked,
-        arch_desc_->eth_cores,
+        arch_desc_->get_eth_cores(),
         arc_grid_size,
-        arch_desc_->arc_cores,
+        arch_desc_->get_arc_cores(),
         pcie_grid_size,
-        arch_desc_->pcie_cores,
-        arch_desc_->router_cores,
-        arch_desc_->security_cores,
-        arch_desc_->l2cpu_cores,
-        arch_desc_->dispatch_cores,
-        arch_desc_->noc0_x_to_noc1_x,
-        arch_desc_->noc0_y_to_noc1_y);
+        arch_desc_->get_pcie_cores(),
+        arch_desc_->get_router_cores(),
+        arch_desc_->get_security_cores(),
+        arch_desc_->get_l2cpu_cores(),
+        arch_desc_->get_dispatch_cores(),
+        arch_desc_->get_noc0_x_to_noc1_x(),
+        arch_desc_->get_noc0_y_to_noc1_y());
     get_cores_and_grid_size_from_coordinate_manager();
 }
 

--- a/tests/baremetal/CMakeLists.txt
+++ b/tests/baremetal/CMakeLists.txt
@@ -2,6 +2,7 @@ set(BAREMETAL_TESTS_SRCS
     test_cluster_descriptor_offline.cpp
     test_core_coord_translation_wh.cpp
     test_core_coord_translation_bh.cpp
+    test_soc_arch_descriptor.cpp
     test_soc_descriptor.cpp
     test_long_jump.cpp
     test_notification_mechanism.cpp

--- a/tests/baremetal/test_soc_arch_descriptor.cpp
+++ b/tests/baremetal/test_soc_arch_descriptor.cpp
@@ -299,6 +299,127 @@ TEST(SocArchDescriptor, BlackholeHasSecurityAndL2CPU) {
     EXPECT_FALSE(desc.l2cpu_cores.empty());
 }
 
+// Test Blackhole simulation 1x2 YAML descriptor.
+TEST(SocArchDescriptor, BlackholeSimulation1x2) {
+    auto desc = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("blackhole_simulation_1x2.yaml"));
+
+    EXPECT_EQ(desc.arch, tt::ARCH::BLACKHOLE);
+    EXPECT_EQ(desc.grid_size, tt_xy_pair(2, 2));
+
+    // 2 tensix cores: (0,1) and (1,1).
+    EXPECT_EQ(desc.tensix_cores.size(), 2);
+    EXPECT_EQ(desc.tensix_cores[0], tt_xy_pair(0, 1));
+    EXPECT_EQ(desc.tensix_cores[1], tt_xy_pair(1, 1));
+
+    // 1 DRAM bank with 1 core: (1,0).
+    ASSERT_EQ(desc.dram_cores.size(), 1);
+    ASSERT_EQ(desc.dram_cores[0].size(), 1);
+    EXPECT_EQ(desc.dram_cores[0][0], tt_xy_pair(1, 0));
+
+    // 1 router core: (0,0).
+    EXPECT_EQ(desc.router_cores.size(), 1);
+    EXPECT_EQ(desc.router_cores[0], tt_xy_pair(0, 0));
+
+    // No ARC, PCIe, ETH cores.
+    EXPECT_TRUE(desc.arc_cores.empty());
+    EXPECT_TRUE(desc.pcie_cores.empty());
+    EXPECT_TRUE(desc.eth_cores.empty());
+
+    // Memory sizes.
+    EXPECT_EQ(desc.worker_l1_size, 1572864);
+    EXPECT_EQ(desc.dram_bank_size, 1073741824);
+    EXPECT_EQ(desc.eth_l1_size, 0);
+
+    // Worker grid size: 2x1.
+    EXPECT_EQ(desc.worker_grid_size, tt_xy_pair(2, 1));
+
+    // NOC mappings.
+    ASSERT_EQ(desc.noc0_x_to_noc1_x.size(), 2);
+    EXPECT_EQ(desc.noc0_x_to_noc1_x[0], 1);
+    EXPECT_EQ(desc.noc0_x_to_noc1_x[1], 0);
+    ASSERT_EQ(desc.noc0_y_to_noc1_y.size(), 2);
+    EXPECT_EQ(desc.noc0_y_to_noc1_y[0], 1);
+    EXPECT_EQ(desc.noc0_y_to_noc1_y[1], 0);
+}
+
+// Test Quasar simulation 1x1 YAML descriptor.
+TEST(SocArchDescriptor, QuasarSimulation1x1) {
+    auto desc = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("quasar_simulation_1x1.yaml"));
+
+    EXPECT_EQ(desc.arch, tt::ARCH::QUASAR);
+    EXPECT_EQ(desc.grid_size, tt_xy_pair(1, 3));
+
+    // 1 tensix core: (0,1).
+    ASSERT_EQ(desc.tensix_cores.size(), 1);
+    EXPECT_EQ(desc.tensix_cores[0], tt_xy_pair(0, 1));
+
+    // 1 DRAM bank with 1 core: (0,0).
+    ASSERT_EQ(desc.dram_cores.size(), 1);
+    ASSERT_EQ(desc.dram_cores[0].size(), 1);
+    EXPECT_EQ(desc.dram_cores[0][0], tt_xy_pair(0, 0));
+
+    // 1 router core: (0,2).
+    EXPECT_EQ(desc.router_cores.size(), 1);
+    EXPECT_EQ(desc.router_cores[0], tt_xy_pair(0, 2));
+
+    // No ARC, PCIe, ETH cores.
+    EXPECT_TRUE(desc.arc_cores.empty());
+    EXPECT_TRUE(desc.pcie_cores.empty());
+    EXPECT_TRUE(desc.eth_cores.empty());
+
+    // Memory sizes.
+    EXPECT_EQ(desc.worker_l1_size, 4194304);
+    EXPECT_EQ(desc.dram_bank_size, 1073741824);
+    EXPECT_EQ(desc.eth_l1_size, 0);
+
+    // Worker grid size: 1x1.
+    EXPECT_EQ(desc.worker_grid_size, tt_xy_pair(1, 1));
+}
+
+// Test Wormhole B0 1x1 YAML descriptor.
+TEST(SocArchDescriptor, WormholeB01x1) {
+    auto desc = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("wormhole_b0_1x1.yaml"));
+
+    EXPECT_EQ(desc.arch, tt::ARCH::WORMHOLE_B0);
+    EXPECT_EQ(desc.grid_size, tt_xy_pair(10, 12));
+
+    // 1 tensix core: (1,1).
+    ASSERT_EQ(desc.tensix_cores.size(), 1);
+    EXPECT_EQ(desc.tensix_cores[0], tt_xy_pair(1, 1));
+
+    // 6 DRAM banks with 3 ports each.
+    ASSERT_EQ(desc.dram_cores.size(), 6);
+    for (const auto& bank : desc.dram_cores) {
+        EXPECT_EQ(bank.size(), 3);
+    }
+
+    // 16 ETH cores.
+    EXPECT_EQ(desc.eth_cores.size(), 16);
+
+    // 1 ARC core: (0,10).
+    ASSERT_EQ(desc.arc_cores.size(), 1);
+    EXPECT_EQ(desc.arc_cores[0], tt_xy_pair(0, 10));
+
+    // 1 PCIe core: (0,3).
+    ASSERT_EQ(desc.pcie_cores.size(), 1);
+    EXPECT_EQ(desc.pcie_cores[0], tt_xy_pair(0, 3));
+
+    // Memory sizes match wormhole constants.
+    EXPECT_EQ(desc.worker_l1_size, wormhole::TENSIX_L1_SIZE);
+    EXPECT_EQ(desc.dram_bank_size, wormhole::DRAM_BANK_SIZE);
+    EXPECT_EQ(desc.eth_l1_size, wormhole::ETH_L1_SIZE);
+
+    // Worker grid size: 1x1.
+    EXPECT_EQ(desc.worker_grid_size, tt_xy_pair(1, 1));
+
+    // NOC mappings should be the same as full wormhole.
+    EXPECT_EQ(desc.noc0_x_to_noc1_x, wormhole::NOC0_X_TO_NOC1_X);
+    EXPECT_EQ(desc.noc0_y_to_noc1_y, wormhole::NOC0_Y_TO_NOC1_Y);
+
+    // Many router cores (grid is full 10x12 but only 1 tensix worker).
+    EXPECT_FALSE(desc.router_cores.empty());
+}
+
 // Test all available YAML descriptors can be loaded.
 TEST(SocArchDescriptor, AllSocDescriptors) {
     for (const std::string& soc_desc_yaml : test_utils::GetAllSocDescs()) {

--- a/tests/baremetal/test_soc_arch_descriptor.cpp
+++ b/tests/baremetal/test_soc_arch_descriptor.cpp
@@ -1,0 +1,307 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "tests/test_utils/fetch_local_files.hpp"
+#include "umd/device/arch/blackhole_implementation.hpp"
+#include "umd/device/arch/grendel_implementation.hpp"
+#include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/soc_arch_descriptor.hpp"
+
+using namespace tt;
+using namespace tt::umd;
+
+// Test SocArchDescriptor creation from arch enum for Wormhole.
+TEST(SocArchDescriptor, WormholeFromArch) {
+    auto desc = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
+
+    EXPECT_EQ(desc.arch, tt::ARCH::WORMHOLE_B0);
+    EXPECT_EQ(desc.grid_size, wormhole::GRID_SIZE);
+    EXPECT_EQ(desc.tensix_cores.size(), wormhole::TENSIX_CORES_NOC0.size());
+    EXPECT_EQ(desc.tensix_cores, wormhole::TENSIX_CORES_NOC0);
+    EXPECT_EQ(desc.dram_cores.size(), wormhole::DRAM_CORES_NOC0.size());
+    EXPECT_EQ(desc.eth_cores.size(), wormhole::ETH_CORES_NOC0.size());
+    EXPECT_EQ(desc.eth_cores, wormhole::ETH_CORES_NOC0);
+    EXPECT_EQ(desc.arc_cores.size(), wormhole::ARC_CORES_NOC0.size());
+    EXPECT_EQ(desc.arc_cores, wormhole::ARC_CORES_NOC0);
+    EXPECT_EQ(desc.pcie_cores.size(), wormhole::PCIE_CORES_NOC0.size());
+    EXPECT_EQ(desc.pcie_cores, wormhole::PCIE_CORES_NOC0);
+    EXPECT_EQ(desc.router_cores.size(), wormhole::ROUTER_CORES_NOC0.size());
+    EXPECT_EQ(desc.worker_l1_size, wormhole::TENSIX_L1_SIZE);
+    EXPECT_EQ(desc.eth_l1_size, wormhole::ETH_L1_SIZE);
+    EXPECT_EQ(desc.dram_bank_size, wormhole::DRAM_BANK_SIZE);
+    EXPECT_EQ(desc.noc0_x_to_noc1_x, wormhole::NOC0_X_TO_NOC1_X);
+    EXPECT_EQ(desc.noc0_y_to_noc1_y, wormhole::NOC0_Y_TO_NOC1_Y);
+    EXPECT_TRUE(desc.device_descriptor_file_path.empty());
+}
+
+// Test SocArchDescriptor creation from arch enum for Blackhole.
+TEST(SocArchDescriptor, BlackholeFromArch) {
+    auto desc = SocArchDescriptor::create(tt::ARCH::BLACKHOLE);
+
+    EXPECT_EQ(desc.arch, tt::ARCH::BLACKHOLE);
+    EXPECT_EQ(desc.grid_size, blackhole::GRID_SIZE);
+    EXPECT_EQ(desc.tensix_cores.size(), blackhole::TENSIX_CORES_NOC0.size());
+    EXPECT_EQ(desc.tensix_cores, blackhole::TENSIX_CORES_NOC0);
+    EXPECT_EQ(desc.dram_cores.size(), blackhole::DRAM_CORES_NOC0.size());
+    EXPECT_EQ(desc.eth_cores.size(), blackhole::ETH_CORES_NOC0.size());
+    EXPECT_EQ(desc.eth_cores, blackhole::ETH_CORES_NOC0);
+    EXPECT_EQ(desc.arc_cores.size(), blackhole::ARC_CORES_NOC0.size());
+    EXPECT_EQ(desc.pcie_cores.size(), blackhole::PCIE_CORES_NOC0.size());
+    EXPECT_EQ(desc.worker_l1_size, blackhole::TENSIX_L1_SIZE);
+    EXPECT_EQ(desc.eth_l1_size, blackhole::ETH_L1_SIZE);
+    EXPECT_EQ(desc.dram_bank_size, blackhole::DRAM_BANK_SIZE);
+    EXPECT_EQ(desc.noc0_x_to_noc1_x, blackhole::NOC0_X_TO_NOC1_X);
+    EXPECT_EQ(desc.noc0_y_to_noc1_y, blackhole::NOC0_Y_TO_NOC1_Y);
+}
+
+// Test SocArchDescriptor creation from arch enum for Quasar.
+TEST(SocArchDescriptor, QuasarFromArch) {
+    auto desc = SocArchDescriptor::create(tt::ARCH::QUASAR);
+
+    EXPECT_EQ(desc.arch, tt::ARCH::QUASAR);
+    EXPECT_EQ(desc.grid_size, grendel::GRID_SIZE);
+    EXPECT_EQ(desc.tensix_cores.size(), grendel::TENSIX_CORES_NOC0.size());
+    EXPECT_EQ(desc.dram_cores.size(), grendel::DRAM_CORES_NOC0.size());
+    EXPECT_EQ(desc.eth_cores.size(), grendel::ETH_CORES_NOC0.size());
+    EXPECT_EQ(desc.worker_l1_size, grendel::TENSIX_L1_SIZE);
+    EXPECT_EQ(desc.eth_l1_size, grendel::ETH_L1_SIZE);
+    EXPECT_EQ(desc.dram_bank_size, grendel::DRAM_BANK_SIZE);
+}
+
+// Test SocArchDescriptor creation from YAML for Wormhole.
+TEST(SocArchDescriptor, WormholeFromYaml) {
+    auto desc = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"));
+
+    EXPECT_EQ(desc.arch, tt::ARCH::WORMHOLE_B0);
+    EXPECT_EQ(desc.grid_size, wormhole::GRID_SIZE);
+    EXPECT_EQ(desc.tensix_cores.size(), wormhole::TENSIX_CORES_NOC0.size());
+    EXPECT_EQ(desc.dram_cores.size(), wormhole::DRAM_CORES_NOC0.size());
+    EXPECT_EQ(desc.eth_cores.size(), wormhole::ETH_CORES_NOC0.size());
+    EXPECT_EQ(desc.arc_cores.size(), wormhole::ARC_CORES_NOC0.size());
+    EXPECT_EQ(desc.pcie_cores.size(), wormhole::PCIE_CORES_NOC0.size());
+    EXPECT_FALSE(desc.device_descriptor_file_path.empty());
+}
+
+// Test SocArchDescriptor creation from YAML for Blackhole.
+TEST(SocArchDescriptor, BlackholeFromYaml) {
+    auto desc = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"));
+
+    EXPECT_EQ(desc.arch, tt::ARCH::BLACKHOLE);
+    EXPECT_EQ(desc.grid_size, blackhole::GRID_SIZE);
+    EXPECT_EQ(desc.tensix_cores.size(), blackhole::TENSIX_CORES_NOC0.size());
+    EXPECT_EQ(desc.dram_cores.size(), blackhole::DRAM_CORES_NOC0.size());
+}
+
+// Test that arch enum and YAML produce consistent results for Wormhole.
+TEST(SocArchDescriptor, WormholeArchAndYamlConsistency) {
+    auto from_arch = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
+    auto from_yaml = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"));
+
+    EXPECT_EQ(from_arch.arch, from_yaml.arch);
+    EXPECT_EQ(from_arch.grid_size, from_yaml.grid_size);
+    EXPECT_EQ(from_arch.tensix_cores, from_yaml.tensix_cores);
+    EXPECT_EQ(from_arch.eth_cores, from_yaml.eth_cores);
+    EXPECT_EQ(from_arch.arc_cores, from_yaml.arc_cores);
+    EXPECT_EQ(from_arch.pcie_cores, from_yaml.pcie_cores);
+    EXPECT_EQ(from_arch.router_cores, from_yaml.router_cores);
+    EXPECT_EQ(from_arch.worker_l1_size, from_yaml.worker_l1_size);
+    EXPECT_EQ(from_arch.eth_l1_size, from_yaml.eth_l1_size);
+    EXPECT_EQ(from_arch.dram_bank_size, from_yaml.dram_bank_size);
+
+    // DRAM cores: compare per-channel.
+    ASSERT_EQ(from_arch.dram_cores.size(), from_yaml.dram_cores.size());
+    for (size_t i = 0; i < from_arch.dram_cores.size(); i++) {
+        EXPECT_EQ(from_arch.dram_cores[i], from_yaml.dram_cores[i]);
+    }
+}
+
+// Test that arch enum and YAML produce consistent results for Blackhole.
+TEST(SocArchDescriptor, BlackholeArchAndYamlConsistency) {
+    auto from_arch = SocArchDescriptor::create(tt::ARCH::BLACKHOLE);
+    auto from_yaml = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"));
+
+    EXPECT_EQ(from_arch.arch, from_yaml.arch);
+    EXPECT_EQ(from_arch.grid_size, from_yaml.grid_size);
+    EXPECT_EQ(from_arch.tensix_cores, from_yaml.tensix_cores);
+    EXPECT_EQ(from_arch.arc_cores, from_yaml.arc_cores);
+    EXPECT_EQ(from_arch.pcie_cores, from_yaml.pcie_cores);
+    EXPECT_EQ(from_arch.worker_l1_size, from_yaml.worker_l1_size);
+    EXPECT_EQ(from_arch.eth_l1_size, from_yaml.eth_l1_size);
+    EXPECT_EQ(from_arch.dram_bank_size, from_yaml.dram_bank_size);
+
+    ASSERT_EQ(from_arch.dram_cores.size(), from_yaml.dram_cores.size());
+    for (size_t i = 0; i < from_arch.dram_cores.size(); i++) {
+        EXPECT_EQ(from_arch.dram_cores[i], from_yaml.dram_cores[i]);
+    }
+}
+
+// Test derived data: cores map is populated correctly.
+TEST(SocArchDescriptor, WormholeDerivedCoresMap) {
+    auto desc = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
+
+    // Total cores in the map should equal sum of all core type vectors.
+    size_t expected_total = desc.tensix_cores.size() + desc.eth_cores.size() + desc.arc_cores.size() +
+                            desc.pcie_cores.size() + desc.router_cores.size() + desc.security_cores.size() +
+                            desc.l2cpu_cores.size();
+    for (const auto& channel : desc.dram_cores) {
+        expected_total += channel.size();
+    }
+    EXPECT_EQ(desc.cores.size(), expected_total);
+
+    // Verify tensix cores are in the map with correct type.
+    for (const auto& core : desc.tensix_cores) {
+        auto it = desc.cores.find(core);
+        ASSERT_NE(it, desc.cores.end());
+        EXPECT_EQ(it->second.type, CoreType::WORKER);
+        EXPECT_EQ(it->second.l1_size, desc.worker_l1_size);
+    }
+
+    // Verify ETH cores are in the map with correct type.
+    for (const auto& core : desc.eth_cores) {
+        auto it = desc.cores.find(core);
+        ASSERT_NE(it, desc.cores.end());
+        EXPECT_EQ(it->second.type, CoreType::ETH);
+        EXPECT_EQ(it->second.l1_size, desc.eth_l1_size);
+    }
+
+    // Verify ARC cores.
+    for (const auto& core : desc.arc_cores) {
+        auto it = desc.cores.find(core);
+        ASSERT_NE(it, desc.cores.end());
+        EXPECT_EQ(it->second.type, CoreType::ARC);
+    }
+
+    // Verify PCIE cores.
+    for (const auto& core : desc.pcie_cores) {
+        auto it = desc.cores.find(core);
+        ASSERT_NE(it, desc.cores.end());
+        EXPECT_EQ(it->second.type, CoreType::PCIE);
+    }
+}
+
+// Test derived data: DRAM channel map.
+TEST(SocArchDescriptor, WormholeDRAMChannelMap) {
+    auto desc = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
+
+    EXPECT_EQ(desc.dram_cores.size(), wormhole::NUM_DRAM_BANKS);
+    for (size_t channel = 0; channel < desc.dram_cores.size(); channel++) {
+        for (size_t subchannel = 0; subchannel < desc.dram_cores[channel].size(); subchannel++) {
+            const tt_xy_pair& core = desc.dram_cores[channel][subchannel];
+            auto it = desc.dram_core_channel_map.find(core);
+            ASSERT_NE(it, desc.dram_core_channel_map.end());
+            EXPECT_EQ(std::get<0>(it->second), static_cast<int>(channel));
+            EXPECT_EQ(std::get<1>(it->second), static_cast<int>(subchannel));
+        }
+    }
+}
+
+// Test derived data: ETH channel map.
+TEST(SocArchDescriptor, WormholeETHChannelMap) {
+    auto desc = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
+
+    EXPECT_EQ(desc.eth_cores.size(), wormhole::ETH_CORES_NOC0.size());
+    for (size_t channel = 0; channel < desc.eth_cores.size(); channel++) {
+        auto it = desc.ethernet_core_channel_map.find(desc.eth_cores[channel]);
+        ASSERT_NE(it, desc.ethernet_core_channel_map.end());
+        EXPECT_EQ(it->second, static_cast<int>(channel));
+    }
+}
+
+// Test derived data: worker grid size.
+TEST(SocArchDescriptor, WormholeWorkerGridSize) {
+    auto desc = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
+    EXPECT_EQ(desc.worker_grid_size, wormhole::TENSIX_GRID_SIZE);
+}
+
+TEST(SocArchDescriptor, BlackholeWorkerGridSize) {
+    auto desc = SocArchDescriptor::create(tt::ARCH::BLACKHOLE);
+    EXPECT_EQ(desc.worker_grid_size, blackhole::TENSIX_GRID_SIZE);
+}
+
+// Test static helpers.
+TEST(SocArchDescriptor, GetArchFromPath) {
+    EXPECT_EQ(
+        SocArchDescriptor::get_arch_from_path(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml")),
+        tt::ARCH::WORMHOLE_B0);
+    EXPECT_EQ(
+        SocArchDescriptor::get_arch_from_path(test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml")),
+        tt::ARCH::BLACKHOLE);
+}
+
+TEST(SocArchDescriptor, GetGridSizeFromPath) {
+    EXPECT_EQ(
+        SocArchDescriptor::get_grid_size_from_path(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml")),
+        wormhole::GRID_SIZE);
+    EXPECT_EQ(
+        SocArchDescriptor::get_grid_size_from_path(test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml")),
+        blackhole::GRID_SIZE);
+}
+
+// Test invalid arch throws.
+TEST(SocArchDescriptor, InvalidArchThrows) {
+    EXPECT_THROW(SocArchDescriptor::create(tt::ARCH::Invalid), std::runtime_error);
+}
+
+// Test invalid YAML path throws.
+TEST(SocArchDescriptor, InvalidPathThrows) {
+    EXPECT_THROW(SocArchDescriptor::create("/nonexistent/path.yaml"), std::runtime_error);
+}
+
+// Test calculate_grid_size utility.
+TEST(SocArchDescriptor, CalculateGridSize) {
+    std::vector<tt_xy_pair> cores = {{1, 2}, {1, 3}, {2, 2}, {2, 3}, {3, 2}, {3, 3}};
+    tt_xy_pair grid = SocArchDescriptor::calculate_grid_size(cores);
+    EXPECT_EQ(grid.x, 3);
+    EXPECT_EQ(grid.y, 2);
+
+    std::vector<tt_xy_pair> empty_cores = {};
+    tt_xy_pair empty_grid = SocArchDescriptor::calculate_grid_size(empty_cores);
+    EXPECT_EQ(empty_grid.x, 0);
+    EXPECT_EQ(empty_grid.y, 0);
+}
+
+// Test Blackhole derived data.
+TEST(SocArchDescriptor, BlackholeDRAMChannelMap) {
+    auto desc = SocArchDescriptor::create(tt::ARCH::BLACKHOLE);
+
+    EXPECT_EQ(desc.dram_cores.size(), blackhole::NUM_DRAM_BANKS);
+    for (size_t channel = 0; channel < desc.dram_cores.size(); channel++) {
+        EXPECT_EQ(desc.dram_cores[channel].size(), blackhole::NUM_NOC_PORTS_PER_DRAM_BANK);
+        for (size_t subchannel = 0; subchannel < desc.dram_cores[channel].size(); subchannel++) {
+            const tt_xy_pair& core = desc.dram_cores[channel][subchannel];
+            auto it = desc.dram_core_channel_map.find(core);
+            ASSERT_NE(it, desc.dram_core_channel_map.end());
+            EXPECT_EQ(std::get<0>(it->second), static_cast<int>(channel));
+            EXPECT_EQ(std::get<1>(it->second), static_cast<int>(subchannel));
+        }
+    }
+}
+
+// Test Wormhole: no security and no L2CPU cores.
+TEST(SocArchDescriptor, WormholeNoSecurityNoL2CPU) {
+    auto desc = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
+    EXPECT_TRUE(desc.security_cores.empty());
+    EXPECT_TRUE(desc.l2cpu_cores.empty());
+}
+
+// Test Blackhole: has security and L2CPU cores.
+TEST(SocArchDescriptor, BlackholeHasSecurityAndL2CPU) {
+    auto desc = SocArchDescriptor::create(tt::ARCH::BLACKHOLE);
+    EXPECT_FALSE(desc.security_cores.empty());
+    EXPECT_FALSE(desc.l2cpu_cores.empty());
+}
+
+// Test all available YAML descriptors can be loaded.
+TEST(SocArchDescriptor, AllSocDescriptors) {
+    for (const std::string& soc_desc_yaml : test_utils::GetAllSocDescs()) {
+        EXPECT_NO_THROW(SocArchDescriptor::create(soc_desc_yaml)) << "Failed to load: " << soc_desc_yaml;
+    }
+}

--- a/tests/baremetal/test_soc_arch_descriptor.cpp
+++ b/tests/baremetal/test_soc_arch_descriptor.cpp
@@ -22,82 +22,82 @@ using namespace tt::umd;
 TEST(SocArchDescriptor, WormholeFromArch) {
     auto desc = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
 
-    EXPECT_EQ(desc.arch, tt::ARCH::WORMHOLE_B0);
-    EXPECT_EQ(desc.grid_size, wormhole::GRID_SIZE);
-    EXPECT_EQ(desc.tensix_cores.size(), wormhole::TENSIX_CORES_NOC0.size());
-    EXPECT_EQ(desc.tensix_cores, wormhole::TENSIX_CORES_NOC0);
-    EXPECT_EQ(desc.dram_cores.size(), wormhole::DRAM_CORES_NOC0.size());
-    EXPECT_EQ(desc.eth_cores.size(), wormhole::ETH_CORES_NOC0.size());
-    EXPECT_EQ(desc.eth_cores, wormhole::ETH_CORES_NOC0);
-    EXPECT_EQ(desc.arc_cores.size(), wormhole::ARC_CORES_NOC0.size());
-    EXPECT_EQ(desc.arc_cores, wormhole::ARC_CORES_NOC0);
-    EXPECT_EQ(desc.pcie_cores.size(), wormhole::PCIE_CORES_NOC0.size());
-    EXPECT_EQ(desc.pcie_cores, wormhole::PCIE_CORES_NOC0);
-    EXPECT_EQ(desc.router_cores.size(), wormhole::ROUTER_CORES_NOC0.size());
-    EXPECT_EQ(desc.worker_l1_size, wormhole::TENSIX_L1_SIZE);
-    EXPECT_EQ(desc.eth_l1_size, wormhole::ETH_L1_SIZE);
-    EXPECT_EQ(desc.dram_bank_size, wormhole::DRAM_BANK_SIZE);
-    EXPECT_EQ(desc.noc0_x_to_noc1_x, wormhole::NOC0_X_TO_NOC1_X);
-    EXPECT_EQ(desc.noc0_y_to_noc1_y, wormhole::NOC0_Y_TO_NOC1_Y);
-    EXPECT_TRUE(desc.device_descriptor_file_path.empty());
+    EXPECT_EQ(desc.get_arch(), tt::ARCH::WORMHOLE_B0);
+    EXPECT_EQ(desc.get_grid_size(), wormhole::GRID_SIZE);
+    EXPECT_EQ(desc.get_tensix_cores().size(), wormhole::TENSIX_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_tensix_cores(), wormhole::TENSIX_CORES_NOC0);
+    EXPECT_EQ(desc.get_dram_cores().size(), wormhole::DRAM_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_eth_cores().size(), wormhole::ETH_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_eth_cores(), wormhole::ETH_CORES_NOC0);
+    EXPECT_EQ(desc.get_arc_cores().size(), wormhole::ARC_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_arc_cores(), wormhole::ARC_CORES_NOC0);
+    EXPECT_EQ(desc.get_pcie_cores().size(), wormhole::PCIE_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_pcie_cores(), wormhole::PCIE_CORES_NOC0);
+    EXPECT_EQ(desc.get_router_cores().size(), wormhole::ROUTER_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_worker_l1_size(), wormhole::TENSIX_L1_SIZE);
+    EXPECT_EQ(desc.get_eth_l1_size(), wormhole::ETH_L1_SIZE);
+    EXPECT_EQ(desc.get_dram_bank_size(), wormhole::DRAM_BANK_SIZE);
+    EXPECT_EQ(desc.get_noc0_x_to_noc1_x(), wormhole::NOC0_X_TO_NOC1_X);
+    EXPECT_EQ(desc.get_noc0_y_to_noc1_y(), wormhole::NOC0_Y_TO_NOC1_Y);
+    EXPECT_TRUE(desc.get_device_descriptor_file_path().empty());
 }
 
 // Test SocArchDescriptor creation from arch enum for Blackhole.
 TEST(SocArchDescriptor, BlackholeFromArch) {
     auto desc = SocArchDescriptor::create(tt::ARCH::BLACKHOLE);
 
-    EXPECT_EQ(desc.arch, tt::ARCH::BLACKHOLE);
-    EXPECT_EQ(desc.grid_size, blackhole::GRID_SIZE);
-    EXPECT_EQ(desc.tensix_cores.size(), blackhole::TENSIX_CORES_NOC0.size());
-    EXPECT_EQ(desc.tensix_cores, blackhole::TENSIX_CORES_NOC0);
-    EXPECT_EQ(desc.dram_cores.size(), blackhole::DRAM_CORES_NOC0.size());
-    EXPECT_EQ(desc.eth_cores.size(), blackhole::ETH_CORES_NOC0.size());
-    EXPECT_EQ(desc.eth_cores, blackhole::ETH_CORES_NOC0);
-    EXPECT_EQ(desc.arc_cores.size(), blackhole::ARC_CORES_NOC0.size());
-    EXPECT_EQ(desc.pcie_cores.size(), blackhole::PCIE_CORES_NOC0.size());
-    EXPECT_EQ(desc.worker_l1_size, blackhole::TENSIX_L1_SIZE);
-    EXPECT_EQ(desc.eth_l1_size, blackhole::ETH_L1_SIZE);
-    EXPECT_EQ(desc.dram_bank_size, blackhole::DRAM_BANK_SIZE);
-    EXPECT_EQ(desc.noc0_x_to_noc1_x, blackhole::NOC0_X_TO_NOC1_X);
-    EXPECT_EQ(desc.noc0_y_to_noc1_y, blackhole::NOC0_Y_TO_NOC1_Y);
+    EXPECT_EQ(desc.get_arch(), tt::ARCH::BLACKHOLE);
+    EXPECT_EQ(desc.get_grid_size(), blackhole::GRID_SIZE);
+    EXPECT_EQ(desc.get_tensix_cores().size(), blackhole::TENSIX_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_tensix_cores(), blackhole::TENSIX_CORES_NOC0);
+    EXPECT_EQ(desc.get_dram_cores().size(), blackhole::DRAM_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_eth_cores().size(), blackhole::ETH_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_eth_cores(), blackhole::ETH_CORES_NOC0);
+    EXPECT_EQ(desc.get_arc_cores().size(), blackhole::ARC_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_pcie_cores().size(), blackhole::PCIE_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_worker_l1_size(), blackhole::TENSIX_L1_SIZE);
+    EXPECT_EQ(desc.get_eth_l1_size(), blackhole::ETH_L1_SIZE);
+    EXPECT_EQ(desc.get_dram_bank_size(), blackhole::DRAM_BANK_SIZE);
+    EXPECT_EQ(desc.get_noc0_x_to_noc1_x(), blackhole::NOC0_X_TO_NOC1_X);
+    EXPECT_EQ(desc.get_noc0_y_to_noc1_y(), blackhole::NOC0_Y_TO_NOC1_Y);
 }
 
 // Test SocArchDescriptor creation from arch enum for Quasar.
 TEST(SocArchDescriptor, QuasarFromArch) {
     auto desc = SocArchDescriptor::create(tt::ARCH::QUASAR);
 
-    EXPECT_EQ(desc.arch, tt::ARCH::QUASAR);
-    EXPECT_EQ(desc.grid_size, grendel::GRID_SIZE);
-    EXPECT_EQ(desc.tensix_cores.size(), grendel::TENSIX_CORES_NOC0.size());
-    EXPECT_EQ(desc.dram_cores.size(), grendel::DRAM_CORES_NOC0.size());
-    EXPECT_EQ(desc.eth_cores.size(), grendel::ETH_CORES_NOC0.size());
-    EXPECT_EQ(desc.worker_l1_size, grendel::TENSIX_L1_SIZE);
-    EXPECT_EQ(desc.eth_l1_size, grendel::ETH_L1_SIZE);
-    EXPECT_EQ(desc.dram_bank_size, grendel::DRAM_BANK_SIZE);
+    EXPECT_EQ(desc.get_arch(), tt::ARCH::QUASAR);
+    EXPECT_EQ(desc.get_grid_size(), grendel::GRID_SIZE);
+    EXPECT_EQ(desc.get_tensix_cores().size(), grendel::TENSIX_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_dram_cores().size(), grendel::DRAM_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_eth_cores().size(), grendel::ETH_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_worker_l1_size(), grendel::TENSIX_L1_SIZE);
+    EXPECT_EQ(desc.get_eth_l1_size(), grendel::ETH_L1_SIZE);
+    EXPECT_EQ(desc.get_dram_bank_size(), grendel::DRAM_BANK_SIZE);
 }
 
 // Test SocArchDescriptor creation from YAML for Wormhole.
 TEST(SocArchDescriptor, WormholeFromYaml) {
     auto desc = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"));
 
-    EXPECT_EQ(desc.arch, tt::ARCH::WORMHOLE_B0);
-    EXPECT_EQ(desc.grid_size, wormhole::GRID_SIZE);
-    EXPECT_EQ(desc.tensix_cores.size(), wormhole::TENSIX_CORES_NOC0.size());
-    EXPECT_EQ(desc.dram_cores.size(), wormhole::DRAM_CORES_NOC0.size());
-    EXPECT_EQ(desc.eth_cores.size(), wormhole::ETH_CORES_NOC0.size());
-    EXPECT_EQ(desc.arc_cores.size(), wormhole::ARC_CORES_NOC0.size());
-    EXPECT_EQ(desc.pcie_cores.size(), wormhole::PCIE_CORES_NOC0.size());
-    EXPECT_FALSE(desc.device_descriptor_file_path.empty());
+    EXPECT_EQ(desc.get_arch(), tt::ARCH::WORMHOLE_B0);
+    EXPECT_EQ(desc.get_grid_size(), wormhole::GRID_SIZE);
+    EXPECT_EQ(desc.get_tensix_cores().size(), wormhole::TENSIX_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_dram_cores().size(), wormhole::DRAM_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_eth_cores().size(), wormhole::ETH_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_arc_cores().size(), wormhole::ARC_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_pcie_cores().size(), wormhole::PCIE_CORES_NOC0.size());
+    EXPECT_FALSE(desc.get_device_descriptor_file_path().empty());
 }
 
 // Test SocArchDescriptor creation from YAML for Blackhole.
 TEST(SocArchDescriptor, BlackholeFromYaml) {
     auto desc = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"));
 
-    EXPECT_EQ(desc.arch, tt::ARCH::BLACKHOLE);
-    EXPECT_EQ(desc.grid_size, blackhole::GRID_SIZE);
-    EXPECT_EQ(desc.tensix_cores.size(), blackhole::TENSIX_CORES_NOC0.size());
-    EXPECT_EQ(desc.dram_cores.size(), blackhole::DRAM_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_arch(), tt::ARCH::BLACKHOLE);
+    EXPECT_EQ(desc.get_grid_size(), blackhole::GRID_SIZE);
+    EXPECT_EQ(desc.get_tensix_cores().size(), blackhole::TENSIX_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_dram_cores().size(), blackhole::DRAM_CORES_NOC0.size());
 }
 
 // Test that arch enum and YAML produce consistent results for Wormhole.
@@ -105,21 +105,21 @@ TEST(SocArchDescriptor, WormholeArchAndYamlConsistency) {
     auto from_arch = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
     auto from_yaml = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"));
 
-    EXPECT_EQ(from_arch.arch, from_yaml.arch);
-    EXPECT_EQ(from_arch.grid_size, from_yaml.grid_size);
-    EXPECT_EQ(from_arch.tensix_cores, from_yaml.tensix_cores);
-    EXPECT_EQ(from_arch.eth_cores, from_yaml.eth_cores);
-    EXPECT_EQ(from_arch.arc_cores, from_yaml.arc_cores);
-    EXPECT_EQ(from_arch.pcie_cores, from_yaml.pcie_cores);
-    EXPECT_EQ(from_arch.router_cores, from_yaml.router_cores);
-    EXPECT_EQ(from_arch.worker_l1_size, from_yaml.worker_l1_size);
-    EXPECT_EQ(from_arch.eth_l1_size, from_yaml.eth_l1_size);
-    EXPECT_EQ(from_arch.dram_bank_size, from_yaml.dram_bank_size);
+    EXPECT_EQ(from_arch.get_arch(), from_yaml.get_arch());
+    EXPECT_EQ(from_arch.get_grid_size(), from_yaml.get_grid_size());
+    EXPECT_EQ(from_arch.get_tensix_cores(), from_yaml.get_tensix_cores());
+    EXPECT_EQ(from_arch.get_eth_cores(), from_yaml.get_eth_cores());
+    EXPECT_EQ(from_arch.get_arc_cores(), from_yaml.get_arc_cores());
+    EXPECT_EQ(from_arch.get_pcie_cores(), from_yaml.get_pcie_cores());
+    EXPECT_EQ(from_arch.get_router_cores(), from_yaml.get_router_cores());
+    EXPECT_EQ(from_arch.get_worker_l1_size(), from_yaml.get_worker_l1_size());
+    EXPECT_EQ(from_arch.get_eth_l1_size(), from_yaml.get_eth_l1_size());
+    EXPECT_EQ(from_arch.get_dram_bank_size(), from_yaml.get_dram_bank_size());
 
     // DRAM cores: compare per-channel.
-    ASSERT_EQ(from_arch.dram_cores.size(), from_yaml.dram_cores.size());
-    for (size_t i = 0; i < from_arch.dram_cores.size(); i++) {
-        EXPECT_EQ(from_arch.dram_cores[i], from_yaml.dram_cores[i]);
+    ASSERT_EQ(from_arch.get_dram_cores().size(), from_yaml.get_dram_cores().size());
+    for (size_t i = 0; i < from_arch.get_dram_cores().size(); i++) {
+        EXPECT_EQ(from_arch.get_dram_cores()[i], from_yaml.get_dram_cores()[i]);
     }
 }
 
@@ -128,18 +128,18 @@ TEST(SocArchDescriptor, BlackholeArchAndYamlConsistency) {
     auto from_arch = SocArchDescriptor::create(tt::ARCH::BLACKHOLE);
     auto from_yaml = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"));
 
-    EXPECT_EQ(from_arch.arch, from_yaml.arch);
-    EXPECT_EQ(from_arch.grid_size, from_yaml.grid_size);
-    EXPECT_EQ(from_arch.tensix_cores, from_yaml.tensix_cores);
-    EXPECT_EQ(from_arch.arc_cores, from_yaml.arc_cores);
-    EXPECT_EQ(from_arch.pcie_cores, from_yaml.pcie_cores);
-    EXPECT_EQ(from_arch.worker_l1_size, from_yaml.worker_l1_size);
-    EXPECT_EQ(from_arch.eth_l1_size, from_yaml.eth_l1_size);
-    EXPECT_EQ(from_arch.dram_bank_size, from_yaml.dram_bank_size);
+    EXPECT_EQ(from_arch.get_arch(), from_yaml.get_arch());
+    EXPECT_EQ(from_arch.get_grid_size(), from_yaml.get_grid_size());
+    EXPECT_EQ(from_arch.get_tensix_cores(), from_yaml.get_tensix_cores());
+    EXPECT_EQ(from_arch.get_arc_cores(), from_yaml.get_arc_cores());
+    EXPECT_EQ(from_arch.get_pcie_cores(), from_yaml.get_pcie_cores());
+    EXPECT_EQ(from_arch.get_worker_l1_size(), from_yaml.get_worker_l1_size());
+    EXPECT_EQ(from_arch.get_eth_l1_size(), from_yaml.get_eth_l1_size());
+    EXPECT_EQ(from_arch.get_dram_bank_size(), from_yaml.get_dram_bank_size());
 
-    ASSERT_EQ(from_arch.dram_cores.size(), from_yaml.dram_cores.size());
-    for (size_t i = 0; i < from_arch.dram_cores.size(); i++) {
-        EXPECT_EQ(from_arch.dram_cores[i], from_yaml.dram_cores[i]);
+    ASSERT_EQ(from_arch.get_dram_cores().size(), from_yaml.get_dram_cores().size());
+    for (size_t i = 0; i < from_arch.get_dram_cores().size(); i++) {
+        EXPECT_EQ(from_arch.get_dram_cores()[i], from_yaml.get_dram_cores()[i]);
     }
 }
 
@@ -148,41 +148,41 @@ TEST(SocArchDescriptor, WormholeDerivedCoresMap) {
     auto desc = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
 
     // Total cores in the map should equal sum of all core type vectors.
-    size_t expected_total = desc.tensix_cores.size() + desc.eth_cores.size() + desc.arc_cores.size() +
-                            desc.pcie_cores.size() + desc.router_cores.size() + desc.security_cores.size() +
-                            desc.l2cpu_cores.size();
-    for (const auto& channel : desc.dram_cores) {
+    size_t expected_total = desc.get_tensix_cores().size() + desc.get_eth_cores().size() + desc.get_arc_cores().size() +
+                            desc.get_pcie_cores().size() + desc.get_router_cores().size() +
+                            desc.get_security_cores().size() + desc.get_l2cpu_cores().size();
+    for (const auto& channel : desc.get_dram_cores()) {
         expected_total += channel.size();
     }
-    EXPECT_EQ(desc.cores.size(), expected_total);
+    EXPECT_EQ(desc.get_cores().size(), expected_total);
 
     // Verify tensix cores are in the map with correct type.
-    for (const auto& core : desc.tensix_cores) {
-        auto it = desc.cores.find(core);
-        ASSERT_NE(it, desc.cores.end());
+    for (const auto& core : desc.get_tensix_cores()) {
+        auto it = desc.get_cores().find(core);
+        ASSERT_NE(it, desc.get_cores().end());
         EXPECT_EQ(it->second.type, CoreType::WORKER);
-        EXPECT_EQ(it->second.l1_size, desc.worker_l1_size);
+        EXPECT_EQ(it->second.l1_size, desc.get_worker_l1_size());
     }
 
     // Verify ETH cores are in the map with correct type.
-    for (const auto& core : desc.eth_cores) {
-        auto it = desc.cores.find(core);
-        ASSERT_NE(it, desc.cores.end());
+    for (const auto& core : desc.get_eth_cores()) {
+        auto it = desc.get_cores().find(core);
+        ASSERT_NE(it, desc.get_cores().end());
         EXPECT_EQ(it->second.type, CoreType::ETH);
-        EXPECT_EQ(it->second.l1_size, desc.eth_l1_size);
+        EXPECT_EQ(it->second.l1_size, desc.get_eth_l1_size());
     }
 
     // Verify ARC cores.
-    for (const auto& core : desc.arc_cores) {
-        auto it = desc.cores.find(core);
-        ASSERT_NE(it, desc.cores.end());
+    for (const auto& core : desc.get_arc_cores()) {
+        auto it = desc.get_cores().find(core);
+        ASSERT_NE(it, desc.get_cores().end());
         EXPECT_EQ(it->second.type, CoreType::ARC);
     }
 
     // Verify PCIE cores.
-    for (const auto& core : desc.pcie_cores) {
-        auto it = desc.cores.find(core);
-        ASSERT_NE(it, desc.cores.end());
+    for (const auto& core : desc.get_pcie_cores()) {
+        auto it = desc.get_cores().find(core);
+        ASSERT_NE(it, desc.get_cores().end());
         EXPECT_EQ(it->second.type, CoreType::PCIE);
     }
 }
@@ -191,12 +191,12 @@ TEST(SocArchDescriptor, WormholeDerivedCoresMap) {
 TEST(SocArchDescriptor, WormholeDRAMChannelMap) {
     auto desc = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
 
-    EXPECT_EQ(desc.dram_cores.size(), wormhole::NUM_DRAM_BANKS);
-    for (size_t channel = 0; channel < desc.dram_cores.size(); channel++) {
-        for (size_t subchannel = 0; subchannel < desc.dram_cores[channel].size(); subchannel++) {
-            const tt_xy_pair& core = desc.dram_cores[channel][subchannel];
-            auto it = desc.dram_core_channel_map.find(core);
-            ASSERT_NE(it, desc.dram_core_channel_map.end());
+    EXPECT_EQ(desc.get_dram_cores().size(), wormhole::NUM_DRAM_BANKS);
+    for (size_t channel = 0; channel < desc.get_dram_cores().size(); channel++) {
+        for (size_t subchannel = 0; subchannel < desc.get_dram_cores()[channel].size(); subchannel++) {
+            const tt_xy_pair& core = desc.get_dram_cores()[channel][subchannel];
+            auto it = desc.get_dram_core_channel_map().find(core);
+            ASSERT_NE(it, desc.get_dram_core_channel_map().end());
             EXPECT_EQ(std::get<0>(it->second), static_cast<int>(channel));
             EXPECT_EQ(std::get<1>(it->second), static_cast<int>(subchannel));
         }
@@ -207,10 +207,10 @@ TEST(SocArchDescriptor, WormholeDRAMChannelMap) {
 TEST(SocArchDescriptor, WormholeETHChannelMap) {
     auto desc = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
 
-    EXPECT_EQ(desc.eth_cores.size(), wormhole::ETH_CORES_NOC0.size());
-    for (size_t channel = 0; channel < desc.eth_cores.size(); channel++) {
-        auto it = desc.ethernet_core_channel_map.find(desc.eth_cores[channel]);
-        ASSERT_NE(it, desc.ethernet_core_channel_map.end());
+    EXPECT_EQ(desc.get_eth_cores().size(), wormhole::ETH_CORES_NOC0.size());
+    for (size_t channel = 0; channel < desc.get_eth_cores().size(); channel++) {
+        auto it = desc.get_ethernet_core_channel_map().find(desc.get_eth_cores()[channel]);
+        ASSERT_NE(it, desc.get_ethernet_core_channel_map().end());
         EXPECT_EQ(it->second, static_cast<int>(channel));
     }
 }
@@ -218,12 +218,12 @@ TEST(SocArchDescriptor, WormholeETHChannelMap) {
 // Test derived data: worker grid size.
 TEST(SocArchDescriptor, WormholeWorkerGridSize) {
     auto desc = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
-    EXPECT_EQ(desc.worker_grid_size, wormhole::TENSIX_GRID_SIZE);
+    EXPECT_EQ(desc.get_worker_grid_size(), wormhole::TENSIX_GRID_SIZE);
 }
 
 TEST(SocArchDescriptor, BlackholeWorkerGridSize) {
     auto desc = SocArchDescriptor::create(tt::ARCH::BLACKHOLE);
-    EXPECT_EQ(desc.worker_grid_size, blackhole::TENSIX_GRID_SIZE);
+    EXPECT_EQ(desc.get_worker_grid_size(), blackhole::TENSIX_GRID_SIZE);
 }
 
 // Test static helpers.
@@ -272,13 +272,13 @@ TEST(SocArchDescriptor, CalculateGridSize) {
 TEST(SocArchDescriptor, BlackholeDRAMChannelMap) {
     auto desc = SocArchDescriptor::create(tt::ARCH::BLACKHOLE);
 
-    EXPECT_EQ(desc.dram_cores.size(), blackhole::NUM_DRAM_BANKS);
-    for (size_t channel = 0; channel < desc.dram_cores.size(); channel++) {
-        EXPECT_EQ(desc.dram_cores[channel].size(), blackhole::NUM_NOC_PORTS_PER_DRAM_BANK);
-        for (size_t subchannel = 0; subchannel < desc.dram_cores[channel].size(); subchannel++) {
-            const tt_xy_pair& core = desc.dram_cores[channel][subchannel];
-            auto it = desc.dram_core_channel_map.find(core);
-            ASSERT_NE(it, desc.dram_core_channel_map.end());
+    EXPECT_EQ(desc.get_dram_cores().size(), blackhole::NUM_DRAM_BANKS);
+    for (size_t channel = 0; channel < desc.get_dram_cores().size(); channel++) {
+        EXPECT_EQ(desc.get_dram_cores()[channel].size(), blackhole::NUM_NOC_PORTS_PER_DRAM_BANK);
+        for (size_t subchannel = 0; subchannel < desc.get_dram_cores()[channel].size(); subchannel++) {
+            const tt_xy_pair& core = desc.get_dram_cores()[channel][subchannel];
+            auto it = desc.get_dram_core_channel_map().find(core);
+            ASSERT_NE(it, desc.get_dram_core_channel_map().end());
             EXPECT_EQ(std::get<0>(it->second), static_cast<int>(channel));
             EXPECT_EQ(std::get<1>(it->second), static_cast<int>(subchannel));
         }
@@ -288,136 +288,136 @@ TEST(SocArchDescriptor, BlackholeDRAMChannelMap) {
 // Test Wormhole: no security and no L2CPU cores.
 TEST(SocArchDescriptor, WormholeNoSecurityNoL2CPU) {
     auto desc = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
-    EXPECT_TRUE(desc.security_cores.empty());
-    EXPECT_TRUE(desc.l2cpu_cores.empty());
+    EXPECT_TRUE(desc.get_security_cores().empty());
+    EXPECT_TRUE(desc.get_l2cpu_cores().empty());
 }
 
 // Test Blackhole: has security and L2CPU cores.
 TEST(SocArchDescriptor, BlackholeHasSecurityAndL2CPU) {
     auto desc = SocArchDescriptor::create(tt::ARCH::BLACKHOLE);
-    EXPECT_FALSE(desc.security_cores.empty());
-    EXPECT_FALSE(desc.l2cpu_cores.empty());
+    EXPECT_FALSE(desc.get_security_cores().empty());
+    EXPECT_FALSE(desc.get_l2cpu_cores().empty());
 }
 
 // Test Blackhole simulation 1x2 YAML descriptor.
 TEST(SocArchDescriptor, BlackholeSimulation1x2) {
     auto desc = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("blackhole_simulation_1x2.yaml"));
 
-    EXPECT_EQ(desc.arch, tt::ARCH::BLACKHOLE);
-    EXPECT_EQ(desc.grid_size, tt_xy_pair(2, 2));
+    EXPECT_EQ(desc.get_arch(), tt::ARCH::BLACKHOLE);
+    EXPECT_EQ(desc.get_grid_size(), tt_xy_pair(2, 2));
 
     // 2 tensix cores: (0,1) and (1,1).
-    EXPECT_EQ(desc.tensix_cores.size(), 2);
-    EXPECT_EQ(desc.tensix_cores[0], tt_xy_pair(0, 1));
-    EXPECT_EQ(desc.tensix_cores[1], tt_xy_pair(1, 1));
+    EXPECT_EQ(desc.get_tensix_cores().size(), 2);
+    EXPECT_EQ(desc.get_tensix_cores()[0], tt_xy_pair(0, 1));
+    EXPECT_EQ(desc.get_tensix_cores()[1], tt_xy_pair(1, 1));
 
     // 1 DRAM bank with 1 core: (1,0).
-    ASSERT_EQ(desc.dram_cores.size(), 1);
-    ASSERT_EQ(desc.dram_cores[0].size(), 1);
-    EXPECT_EQ(desc.dram_cores[0][0], tt_xy_pair(1, 0));
+    ASSERT_EQ(desc.get_dram_cores().size(), 1);
+    ASSERT_EQ(desc.get_dram_cores()[0].size(), 1);
+    EXPECT_EQ(desc.get_dram_cores()[0][0], tt_xy_pair(1, 0));
 
     // 1 router core: (0,0).
-    EXPECT_EQ(desc.router_cores.size(), 1);
-    EXPECT_EQ(desc.router_cores[0], tt_xy_pair(0, 0));
+    EXPECT_EQ(desc.get_router_cores().size(), 1);
+    EXPECT_EQ(desc.get_router_cores()[0], tt_xy_pair(0, 0));
 
     // No ARC, PCIe, ETH cores.
-    EXPECT_TRUE(desc.arc_cores.empty());
-    EXPECT_TRUE(desc.pcie_cores.empty());
-    EXPECT_TRUE(desc.eth_cores.empty());
+    EXPECT_TRUE(desc.get_arc_cores().empty());
+    EXPECT_TRUE(desc.get_pcie_cores().empty());
+    EXPECT_TRUE(desc.get_eth_cores().empty());
 
     // Memory sizes.
-    EXPECT_EQ(desc.worker_l1_size, 1572864);
-    EXPECT_EQ(desc.dram_bank_size, 1073741824);
-    EXPECT_EQ(desc.eth_l1_size, 0);
+    EXPECT_EQ(desc.get_worker_l1_size(), 1572864);
+    EXPECT_EQ(desc.get_dram_bank_size(), 1073741824);
+    EXPECT_EQ(desc.get_eth_l1_size(), 0);
 
     // Worker grid size: 2x1.
-    EXPECT_EQ(desc.worker_grid_size, tt_xy_pair(2, 1));
+    EXPECT_EQ(desc.get_worker_grid_size(), tt_xy_pair(2, 1));
 
     // NOC mappings.
-    ASSERT_EQ(desc.noc0_x_to_noc1_x.size(), 2);
-    EXPECT_EQ(desc.noc0_x_to_noc1_x[0], 1);
-    EXPECT_EQ(desc.noc0_x_to_noc1_x[1], 0);
-    ASSERT_EQ(desc.noc0_y_to_noc1_y.size(), 2);
-    EXPECT_EQ(desc.noc0_y_to_noc1_y[0], 1);
-    EXPECT_EQ(desc.noc0_y_to_noc1_y[1], 0);
+    ASSERT_EQ(desc.get_noc0_x_to_noc1_x().size(), 2);
+    EXPECT_EQ(desc.get_noc0_x_to_noc1_x()[0], 1);
+    EXPECT_EQ(desc.get_noc0_x_to_noc1_x()[1], 0);
+    ASSERT_EQ(desc.get_noc0_y_to_noc1_y().size(), 2);
+    EXPECT_EQ(desc.get_noc0_y_to_noc1_y()[0], 1);
+    EXPECT_EQ(desc.get_noc0_y_to_noc1_y()[1], 0);
 }
 
 // Test Quasar simulation 1x1 YAML descriptor.
 TEST(SocArchDescriptor, QuasarSimulation1x1) {
     auto desc = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("quasar_simulation_1x1.yaml"));
 
-    EXPECT_EQ(desc.arch, tt::ARCH::QUASAR);
-    EXPECT_EQ(desc.grid_size, tt_xy_pair(1, 3));
+    EXPECT_EQ(desc.get_arch(), tt::ARCH::QUASAR);
+    EXPECT_EQ(desc.get_grid_size(), tt_xy_pair(1, 3));
 
     // 1 tensix core: (0,1).
-    ASSERT_EQ(desc.tensix_cores.size(), 1);
-    EXPECT_EQ(desc.tensix_cores[0], tt_xy_pair(0, 1));
+    ASSERT_EQ(desc.get_tensix_cores().size(), 1);
+    EXPECT_EQ(desc.get_tensix_cores()[0], tt_xy_pair(0, 1));
 
     // 1 DRAM bank with 1 core: (0,0).
-    ASSERT_EQ(desc.dram_cores.size(), 1);
-    ASSERT_EQ(desc.dram_cores[0].size(), 1);
-    EXPECT_EQ(desc.dram_cores[0][0], tt_xy_pair(0, 0));
+    ASSERT_EQ(desc.get_dram_cores().size(), 1);
+    ASSERT_EQ(desc.get_dram_cores()[0].size(), 1);
+    EXPECT_EQ(desc.get_dram_cores()[0][0], tt_xy_pair(0, 0));
 
     // 1 router core: (0,2).
-    EXPECT_EQ(desc.router_cores.size(), 1);
-    EXPECT_EQ(desc.router_cores[0], tt_xy_pair(0, 2));
+    EXPECT_EQ(desc.get_router_cores().size(), 1);
+    EXPECT_EQ(desc.get_router_cores()[0], tt_xy_pair(0, 2));
 
     // No ARC, PCIe, ETH cores.
-    EXPECT_TRUE(desc.arc_cores.empty());
-    EXPECT_TRUE(desc.pcie_cores.empty());
-    EXPECT_TRUE(desc.eth_cores.empty());
+    EXPECT_TRUE(desc.get_arc_cores().empty());
+    EXPECT_TRUE(desc.get_pcie_cores().empty());
+    EXPECT_TRUE(desc.get_eth_cores().empty());
 
     // Memory sizes.
-    EXPECT_EQ(desc.worker_l1_size, 4194304);
-    EXPECT_EQ(desc.dram_bank_size, 1073741824);
-    EXPECT_EQ(desc.eth_l1_size, 0);
+    EXPECT_EQ(desc.get_worker_l1_size(), 4194304);
+    EXPECT_EQ(desc.get_dram_bank_size(), 1073741824);
+    EXPECT_EQ(desc.get_eth_l1_size(), 0);
 
     // Worker grid size: 1x1.
-    EXPECT_EQ(desc.worker_grid_size, tt_xy_pair(1, 1));
+    EXPECT_EQ(desc.get_worker_grid_size(), tt_xy_pair(1, 1));
 }
 
 // Test Wormhole B0 1x1 YAML descriptor.
 TEST(SocArchDescriptor, WormholeB01x1) {
     auto desc = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("wormhole_b0_1x1.yaml"));
 
-    EXPECT_EQ(desc.arch, tt::ARCH::WORMHOLE_B0);
-    EXPECT_EQ(desc.grid_size, tt_xy_pair(10, 12));
+    EXPECT_EQ(desc.get_arch(), tt::ARCH::WORMHOLE_B0);
+    EXPECT_EQ(desc.get_grid_size(), tt_xy_pair(10, 12));
 
     // 1 tensix core: (1,1).
-    ASSERT_EQ(desc.tensix_cores.size(), 1);
-    EXPECT_EQ(desc.tensix_cores[0], tt_xy_pair(1, 1));
+    ASSERT_EQ(desc.get_tensix_cores().size(), 1);
+    EXPECT_EQ(desc.get_tensix_cores()[0], tt_xy_pair(1, 1));
 
     // 6 DRAM banks with 3 ports each.
-    ASSERT_EQ(desc.dram_cores.size(), 6);
-    for (const auto& bank : desc.dram_cores) {
+    ASSERT_EQ(desc.get_dram_cores().size(), 6);
+    for (const auto& bank : desc.get_dram_cores()) {
         EXPECT_EQ(bank.size(), 3);
     }
 
     // 16 ETH cores.
-    EXPECT_EQ(desc.eth_cores.size(), 16);
+    EXPECT_EQ(desc.get_eth_cores().size(), 16);
 
     // 1 ARC core: (0,10).
-    ASSERT_EQ(desc.arc_cores.size(), 1);
-    EXPECT_EQ(desc.arc_cores[0], tt_xy_pair(0, 10));
+    ASSERT_EQ(desc.get_arc_cores().size(), 1);
+    EXPECT_EQ(desc.get_arc_cores()[0], tt_xy_pair(0, 10));
 
     // 1 PCIe core: (0,3).
-    ASSERT_EQ(desc.pcie_cores.size(), 1);
-    EXPECT_EQ(desc.pcie_cores[0], tt_xy_pair(0, 3));
+    ASSERT_EQ(desc.get_pcie_cores().size(), 1);
+    EXPECT_EQ(desc.get_pcie_cores()[0], tt_xy_pair(0, 3));
 
     // Memory sizes match wormhole constants.
-    EXPECT_EQ(desc.worker_l1_size, wormhole::TENSIX_L1_SIZE);
-    EXPECT_EQ(desc.dram_bank_size, wormhole::DRAM_BANK_SIZE);
-    EXPECT_EQ(desc.eth_l1_size, wormhole::ETH_L1_SIZE);
+    EXPECT_EQ(desc.get_worker_l1_size(), wormhole::TENSIX_L1_SIZE);
+    EXPECT_EQ(desc.get_dram_bank_size(), wormhole::DRAM_BANK_SIZE);
+    EXPECT_EQ(desc.get_eth_l1_size(), wormhole::ETH_L1_SIZE);
 
     // Worker grid size: 1x1.
-    EXPECT_EQ(desc.worker_grid_size, tt_xy_pair(1, 1));
+    EXPECT_EQ(desc.get_worker_grid_size(), tt_xy_pair(1, 1));
 
     // NOC mappings should be the same as full wormhole.
-    EXPECT_EQ(desc.noc0_x_to_noc1_x, wormhole::NOC0_X_TO_NOC1_X);
-    EXPECT_EQ(desc.noc0_y_to_noc1_y, wormhole::NOC0_Y_TO_NOC1_Y);
+    EXPECT_EQ(desc.get_noc0_x_to_noc1_x(), wormhole::NOC0_X_TO_NOC1_X);
+    EXPECT_EQ(desc.get_noc0_y_to_noc1_y(), wormhole::NOC0_Y_TO_NOC1_Y);
 
     // Many router cores (grid is full 10x12 but only 1 tensix worker).
-    EXPECT_FALSE(desc.router_cores.empty());
+    EXPECT_FALSE(desc.get_router_cores().empty());
 }
 
 // Test all available YAML descriptors can be loaded.


### PR DESCRIPTION
### Issue

#2355 

### Description
Extract static, architecture-determined properties from SocDescriptor into a new SocArchDescriptor class. SocDescriptor now composes a shared_ptr<const SocArchDescriptor> and retains only runtime per-chip state (harvesting, NOC translation, coordinate manager). Public API on SocDescriptor is unchanged — static fields are copied for backward compatibility. SocArchDescriptor uses proper encapsulation with private members and public getter methods.

### List of the changes
- New `SocArchDescriptor` class (`soc_arch_descriptor.hpp/cpp`) holding static chip properties (core locations, grid size, memory sizes, NOC mappings, feature versions)
- All `SocArchDescriptor` data members are private with public const-ref getter methods
- `SocDescriptor` refactored to compose `shared_ptr<const SocArchDescriptor>` internally
- Removed `SocDescriptorInfo` struct (replaced by `SocArchDescriptor`)
- Moved `CoreDescriptor` struct to `soc_arch_descriptor.hpp`
- New `SocDescriptor` constructor accepting `shared_ptr<const SocArchDescriptor>` for sharing
- Added `get_arch_descriptor()` accessor on `SocDescriptor`
- Added 24 baremetal tests for `SocArchDescriptor` covering arch enum creation, YAML creation, arch/YAML consistency, derived data, simulation descriptors, static helpers, and error cases

### Testing
CI + 24 new baremetal tests (all passing)

### API Changes
- New public class: `SocArchDescriptor` with factory methods `create(tt::ARCH)` and `create(const std::string&)`
- New `SocDescriptor` constructor: `SocDescriptor(shared_ptr<const SocArchDescriptor>, ChipInfo)`
- New accessor: `SocDescriptor::get_arch_descriptor()`
- `CoreDescriptor` moved from `soc_descriptor.hpp` to `soc_arch_descriptor.hpp` (still accessible via include chain)
- `SocDescriptorInfo` removed (internal only, no external consumers)