### PR TITLE
[WIP] Support returning unhealthy devices in TopologyDiscovery

### DIFF
--- a/device/api/umd/device/cluster_descriptor.hpp
+++ b/device/api/umd/device/cluster_descriptor.hpp
@@ -247,6 +247,8 @@ public:
 
     const std::unordered_map<ChipId, std::string> &get_chip_pci_bdfs() const;
 
+    const std::vector<ChipId> &get_unhealthy_devices() const { return unhealthy_devices; };
+
 private:
     int get_ethernet_link_coord_distance(const EthCoord &location_a, const EthCoord &location_b) const;
 
@@ -307,6 +309,8 @@ private:
     std::unordered_map<ChipId, std::string> chip_pci_bdfs;
 
     std::map<ChipId, HarvestingMasks> harvesting_masks_map;
+
+    std::vector<ChipId> unhealthy_devices;
 
     IODeviceType io_device_type = IODeviceType::PCIe;
 

--- a/device/api/umd/device/topology/topology_discovery.hpp
+++ b/device/api/umd/device/topology/topology_discovery.hpp
@@ -131,6 +131,8 @@ protected:
     std::map<uint64_t, std::unique_ptr<TTDevice>> devices;
     SocDescriptor get_soc_descriptor(TTDevice* tt_device);
 
+    std::deque<std::unique_ptr<TTDevice>> unhealthy_local_devices;
+
     std::unordered_map<uint64_t, EthCoord> eth_coords;
 
     std::vector<std::pair<std::pair<uint64_t, uint32_t>, std::pair<uint64_t, uint32_t>>> ethernet_connections;

--- a/device/api/umd/device/topology/topology_discovery_options.hpp
+++ b/device/api/umd/device/topology/topology_discovery_options.hpp
@@ -61,6 +61,12 @@ struct TopologyDiscoveryOptions {
     Action eth_fw_heartbeat_failure = Action::THROW;
 
     /**
+     * @brief Action to take when device initialization fails.
+     * Defaults to THROW.
+     */
+    Action device_init_failure_action = Action::THROW;
+
+    /**
      * @brief If true, the discovery process will attempt to find and include remote devices connected via Ethernet.
      * If false, only locally connected devices will be discovered.
      * Defaults to true.

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -295,7 +295,10 @@ void TopologyDiscovery::discover_remote_devices() {
                     eth_coord,
                     devices.at(gateway_device_id).get(),
                     active_eth_channels_per_device.at(gateway_device_id));
-
+                if (remote_device == nullptr) {
+                    log_warning(LogUMD, "Failed to init. remote device ASIC ID: {}.", remote_asic_id);
+                    continue;
+                }
                 devices_to_discover.emplace(remote_asic_id, std::move(remote_device));
                 active_eth_channels_per_device.emplace(remote_asic_id, std::set<uint32_t>());
                 discovered_devices.insert(remote_asic_id);

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -28,6 +28,7 @@
 #include "umd/device/cluster_descriptor.hpp"
 #include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/topology/topology_discovery.hpp"
+#include "umd/device/topology/topology_discovery_options.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
@@ -136,7 +137,14 @@ void TopologyDiscovery::get_connected_devices() {
         }
 
         // When coming out of reset, devices can take on the order of minutes to become ready.
-        tt_device->init_tt_device(timeout::ARC_LONG_POST_RESET_TIMEOUT);
+        auto init_result = tt_device->init_tt_device(
+            timeout::ARC_LONG_POST_RESET_TIMEOUT,
+            /*throw_on_arc_failure=*/options.device_init_failure_action == TopologyDiscoveryOptions::Action::THROW);
+        if (init_result != TTDeviceInitResult::SUCCESSFUL) {
+            unhealthy_local_devices.push_back(std::move(tt_device));
+            log_warning(LogUMD, "Marked device {} unhealthy.", device_id);
+            continue;
+        }
 
         verify_fw_bundle_version(tt_device.get());
 
@@ -303,10 +311,19 @@ void TopologyDiscovery::discover_remote_devices() {
     patch_eth_connections();
 }
 
+static bool is_device_unhealthy(uint64_t asic_id) { return (asic_id >> 32) & 0xDEADDEAD; }
+
 std::unique_ptr<ClusterDescriptor> TopologyDiscovery::fill_cluster_descriptor_info() {
     std::unique_ptr<ClusterDescriptor> cluster_desc = std::make_unique<ClusterDescriptor>();
     std::map<uint64_t, ChipId> asic_id_to_chip_id;
     ChipId chip_id = 0;
+
+    // Go through unhealthy devices and assign them mock ASIC IDs:
+    uint64_t mock_asic_id = 0xDEADDEAD00000000;
+    for (std::unique_ptr<TTDevice>& bad_device : unhealthy_local_devices) {
+        devices.emplace(mock_asic_id, std::move(bad_device));
+        mock_asic_id++;
+    }
 
     if (!devices.empty() && devices.begin()->second->get_communication_device_type() == IODeviceType::PCIe) {
         std::vector<std::pair<std::string, uint64_t>> sorted_device_bdfs;
@@ -325,6 +342,9 @@ std::unique_ptr<ClusterDescriptor> TopologyDiscovery::fill_cluster_descriptor_in
             asic_id_to_chip_id.emplace(asic_id, chip_id);
             cluster_desc->chip_unique_ids.emplace(chip_id, asic_id);
             cluster_desc->chip_pci_bdfs.emplace(chip_id, bdf);
+            if (is_device_unhealthy(asic_id)) {
+                cluster_desc->unhealthy_devices.push_back(chip_id);
+            }
             chip_id++;
         }
     } else {
@@ -332,6 +352,9 @@ std::unique_ptr<ClusterDescriptor> TopologyDiscovery::fill_cluster_descriptor_in
             if (!tt_device->is_remote()) {
                 asic_id_to_chip_id.emplace(current_device_asic_id, chip_id);
                 cluster_desc->chip_unique_ids.emplace(chip_id, current_device_asic_id);
+                if (is_device_unhealthy(current_device_asic_id)) {
+                    cluster_desc->unhealthy_devices.push_back(chip_id);
+                }
                 chip_id++;
             }
         }
@@ -350,6 +373,9 @@ std::unique_ptr<ClusterDescriptor> TopologyDiscovery::fill_cluster_descriptor_in
     }
 
     for (const auto& [current_device_asic_id, tt_device] : devices) {
+        if (is_device_unhealthy(current_device_asic_id)) {
+            continue;
+        }
         ChipId current_chip_id = asic_id_to_chip_id.at(current_device_asic_id);
         cluster_desc->all_chips.insert(current_chip_id);
         cluster_desc->chip_arch.insert({current_chip_id, tt_device->get_arch()});

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -311,7 +311,7 @@ void TopologyDiscovery::discover_remote_devices() {
     patch_eth_connections();
 }
 
-static bool is_device_unhealthy(uint64_t asic_id) { return (asic_id >> 32) & 0xDEADDEAD; }
+static bool is_device_unhealthy(uint64_t asic_id) { return (asic_id >> 32) == 0xDEADDEAD; }
 
 std::unique_ptr<ClusterDescriptor> TopologyDiscovery::fill_cluster_descriptor_info() {
     std::unique_ptr<ClusterDescriptor> cluster_desc = std::make_unique<ClusterDescriptor>();

--- a/device/topology/topology_discovery_wormhole.cpp
+++ b/device/topology/topology_discovery_wormhole.cpp
@@ -18,6 +18,7 @@
 #include "noc_access.hpp"
 #include "umd/device/firmware/erisc_firmware.hpp"
 #include "umd/device/firmware/firmware_utils.hpp"
+#include "umd/device/topology/topology_discovery_options.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/tt_device/wormhole_tt_device.hpp"
@@ -168,7 +169,15 @@ std::unique_ptr<TTDevice> TopologyDiscoveryWormhole::create_remote_device(
         get_soc_descriptor(gateway_device)
             .get_eth_xy_pairs_for_channels(gateway_eth_channels, CoordSystem::TRANSLATED));
     std::unique_ptr<TTDevice> remote_tt_device = TTDevice::create(std::move(remote_communication));
-    remote_tt_device->init_tt_device();
+    try {
+        remote_tt_device->init_tt_device();
+    } catch (std::runtime_error& re) {
+        if (options.device_init_failure_action == TopologyDiscoveryOptions::Action::THROW) {
+            throw;
+        }
+        return nullptr;
+    }
+
     if (options.wait_on_ethernet_link_training) {
         wait_eth_cores_training(remote_tt_device.get());
     }


### PR DESCRIPTION
### Issue
#2388 

### Description
Support returning unhealthy devices in TopologyDiscovery instead of always throwing exceptions. Required for tt-triage.

### List of the changes
tbd

### Testing
CI, manually on n300.

### API Changes
This PR has API changes.
