### PR TITLE
Refactor TLBManager: separate TLB allocation from window factory

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -136,7 +136,7 @@ if(TT_UMD_BUILD_SIMULATION)
             simulation/rtl_sim_communicator.cpp
             tt_device/rtl_simulation_tt_device.cpp
             tt_device/tt_sim_tt_device.cpp
-            chip_helpers/simulation_tlb_manager.cpp
+            chip_helpers/tlb_allocator.cpp
             tt_device/simulation_device_factory.cpp
             pcie/tt_sim_tlb_window.cpp
             pcie/tt_sim_tlb_handle.cpp
@@ -174,7 +174,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
                 api/umd/device/chip_helpers/sysmem_buffer.hpp
                 api/umd/device/chip_helpers/tlb_manager.hpp
-                api/umd/device/chip_helpers/simulation_tlb_manager.hpp
+                api/umd/device/chip_helpers/tlb_allocator.hpp
                 api/umd/device/cluster.hpp
                 api/umd/device/coordinates/coordinate_manager.hpp
                 api/umd/device/driver_atomics.hpp

--- a/device/api/umd/device/chip_helpers/tlb_allocator.hpp
+++ b/device/api/umd/device/chip_helpers/tlb_allocator.hpp
@@ -4,41 +4,26 @@
 
 #pragma once
 
-#include <functional>
+#include <cstddef>
+#include <cstdint>
 #include <mutex>
 #include <vector>
 
 #include "umd/device/arch/architecture_implementation.hpp"
-#include "umd/device/chip_helpers/tlb_manager.hpp"
+#include "umd/device/types/arch.hpp"
 
 namespace tt::umd {
 
-class SimulationTlbManager;
-
 /**
- * Factory function type for creating TlbWindow instances.
- * Different simulation backends (TTSim, RTL sim) provide their own factory
- * that creates the appropriate TlbHandle + TlbWindow combination.
+ * Pure TLB allocation and bookkeeping class.
+ *
+ * Manages TLB index allocation, deallocation, and address computation
+ * based on architecture configuration. Has no knowledge of TlbHandle,
+ * TlbWindow, or any backend-specific types.
  */
-using TlbWindowFactory = std::function<std::unique_ptr<TlbWindow>(
-    SimulationTlbManager* manager, int tlb_id, size_t size, TlbMapping mapping, tlb_data config)>;
-
-class SimulationTlbManager : public TLBManager {
+class TlbAllocator {
 public:
-    SimulationTlbManager(
-        TTDevice* tt_device,
-        uint64_t bar0_base,
-        const architecture_implementation* arch_impl,
-        TlbWindowFactory factory);
-
-    std::unique_ptr<TlbWindow> allocate_tlb_window(
-        tlb_data config, const TlbMapping mapping = TlbMapping::WC, const size_t tlb_size = 0) override;
-
-    /**
-     * Allocate a TLB window with a default size based on the device architecture.
-     * Returns nullptr if the architecture does not support TLBs.
-     */
-    std::unique_ptr<TlbWindow> allocate_default_tlb_window();
+    TlbAllocator(uint64_t bar0_base, const architecture_implementation* arch_impl);
 
     /**
      * Allocate a TLB index based on the requested size.
@@ -58,36 +43,46 @@ public:
      * @param tlb_index The TLB index
      * @return Size of the TLB in bytes
      */
-    size_t get_tlb_size_from_index(int tlb_index);
+    size_t get_tlb_size_from_index(int tlb_index) const;
 
     /**
      * Calculate the address for a TLB based on its index, starting from BAR0 base.
      * @param tlb_index The TLB index
      * @return Address offset from BAR0 base for this TLB
      */
-    uint64_t get_tlb_address_from_index(int tlb_index);
+    uint64_t get_tlb_address_from_index(int tlb_index) const;
 
-    uint64_t get_tlb_reg_address_from_index(int tlb_index);
+    /**
+     * Calculate the TLB configuration register address for a given index.
+     * @param tlb_index The TLB index
+     * @return Register address for this TLB
+     */
+    uint64_t get_tlb_reg_address_from_index(int tlb_index) const;
 
     /**
      * Get the architecture implementation for architecture-specific operations.
-     * @return Pointer to architecture implementation
      */
     const architecture_implementation* get_architecture_impl() const;
 
-private:
     /**
-     * Initialize architecture-specific TLB configuration based on the device architecture.
+     * Get the architecture type.
      */
+    tt::ARCH get_architecture() const;
+
+    /**
+     * Get the default TLB size for the current architecture.
+     * @return Default TLB size in bytes, or 0 if architecture doesn't support TLBs
+     */
+    size_t get_default_tlb_size() const;
+
+private:
     void initialize_architecture_config();
 
     uint64_t bar0_base_ = 0;
     const architecture_implementation* arch_impl_ = nullptr;
-    TlbWindowFactory factory_;
 
-    // Architecture-specific TLB configuration.
     tt::ARCH architecture_;
-    size_t tlb_reg_size_bytes_ = 8;  // Default to Wormhole size
+    size_t tlb_reg_size_bytes_ = 8;
 
     // TLB size constants (set based on architecture).
     size_t tlb_1mb_size_ = 0;
@@ -109,10 +104,10 @@ private:
 
     // TLB allocation tracking (dynamically sized based on architecture).
     std::mutex allocation_mutex_;
-    std::vector<bool> tlb_1mb_allocated_;   // Wormhole: 156 TLBs, Blackhole: 0
-    std::vector<bool> tlb_2mb_allocated_;   // Wormhole: 10 TLBs, Blackhole: 202
-    std::vector<bool> tlb_16mb_allocated_;  // Wormhole: 20 TLBs, Blackhole: 0
-    std::vector<bool> tlb_4gb_allocated_;   // Wormhole: 0 TLBs, Blackhole: 8
+    std::vector<bool> tlb_1mb_allocated_;
+    std::vector<bool> tlb_2mb_allocated_;
+    std::vector<bool> tlb_16mb_allocated_;
+    std::vector<bool> tlb_4gb_allocated_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/tlb_manager.hpp
@@ -23,7 +23,7 @@ public:
     virtual ~TLBManager() = default;
 
     // All tt_xy_pairs should be in TRANSLATED coords.
-    void configure_tlb(tt_xy_pair core, size_t tlb_size, uint64_t address, uint64_t ordering);
+    virtual void configure_tlb(tt_xy_pair core, size_t tlb_size, uint64_t address, uint64_t ordering);
     bool is_tlb_mapped(tt_xy_pair core);
     bool is_tlb_mapped(tt_xy_pair core, uint64_t address, uint32_t size_in_bytes);
 
@@ -39,11 +39,19 @@ public:
 
     TlbWindow* get_tlb_window(const tt_xy_pair core);
 
-    virtual std::unique_ptr<TlbWindow> allocate_tlb_window(
-        tlb_data config, const TlbMapping mapping = TlbMapping::WC, const size_t tlb_size = 0);
-
     // Clear all static TLB mappings.
     void clear_mapped_tlbs();
+
+protected:
+    /**
+     * Build a tlb_data configuration struct for the given core and address.
+     */
+    tlb_data build_tlb_config(tt_xy_pair core, uint64_t address, uint64_t ordering) const;
+
+    /**
+     * Register a TlbWindow in the bookkeeping maps after allocation.
+     */
+    void register_tlb_window(tt_xy_pair core, size_t tlb_size, uint64_t address, std::unique_ptr<TlbWindow> tlb_window);
 
 private:
     TTDevice* tt_device_;

--- a/device/api/umd/device/pcie/rtl_sim_tlb_handle.hpp
+++ b/device/api/umd/device/pcie/rtl_sim_tlb_handle.hpp
@@ -13,7 +13,7 @@
 
 namespace tt::umd {
 
-class SimulationTlbManager;
+class TlbAllocator;
 
 /**
  * RTL simulation TlbHandle that stores TLB configuration in software only.
@@ -24,20 +24,20 @@ class SimulationTlbManager;
 class RtlSimTlbHandle : public TlbHandle {
 public:
     static std::unique_ptr<RtlSimTlbHandle> create(
-        SimulationTlbManager* manager, int tlb_id, size_t size, TlbMapping mapping);
+        TlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping);
 
     ~RtlSimTlbHandle() noexcept;
 
     void configure(const tlb_data& new_config) override;
 
-    SimulationTlbManager* get_tlb_manager() const { return manager_; }
+    TlbAllocator* get_allocator() const { return allocator_; }
 
 private:
-    RtlSimTlbHandle(SimulationTlbManager* manager, int tlb_id, size_t size, TlbMapping mapping);
+    RtlSimTlbHandle(TlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping);
 
     void free_tlb() noexcept override;
 
-    SimulationTlbManager* manager_;
+    TlbAllocator* allocator_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/pcie/tt_sim_tlb_handle.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_handle.hpp
@@ -14,7 +14,7 @@
 
 namespace tt::umd {
 
-class SimulationTlbManager;
+class TlbAllocator;
 
 /**
  * Simulation-specific TlbHandle that inherits from TlbHandle but bypasses hardware operations.
@@ -27,7 +27,7 @@ public:
      * This bypasses the hardware constructor and sets up simulation state.
      */
     static std::unique_ptr<TTSimTlbHandle> create(
-        SimulationTlbManager* manager,
+        TlbAllocator* allocator,
         class TTSimCommunicator* communicator,
         int tlb_id,
         size_t size,
@@ -37,12 +37,12 @@ public:
 
     void configure(const tlb_data& new_config) override;
 
-    SimulationTlbManager* get_tlb_manager() const { return sim_manager_; }
+    TlbAllocator* get_allocator() const { return allocator_; }
 
 private:
     // Private constructor to enforce use of create() factory method.
     TTSimTlbHandle(
-        SimulationTlbManager* manager,
+        TlbAllocator* allocator,
         class TTSimCommunicator* communicator,
         int tlb_id,
         size_t size,
@@ -50,7 +50,7 @@ private:
 
     void free_tlb() noexcept override;
 
-    SimulationTlbManager* sim_manager_;
+    TlbAllocator* allocator_;
     class TTSimCommunicator* sim_communicator_;
     uint64_t tlb_reg_addr_ = 0;
 };

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -9,7 +9,8 @@
 #include <mutex>
 
 #include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
-#include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
+#include "umd/device/chip_helpers/tlb_allocator.hpp"
+#include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/simulation/rtl_sim_communicator.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
@@ -89,7 +90,8 @@ private:
     SocDescriptor soc_descriptor_;
     std::unique_ptr<architecture_implementation> architecture_impl_;
     std::unique_ptr<SimulationSysmemManager> sysmem_manager_;
-    std::unique_ptr<SimulationTlbManager> tlb_manager_;
+    std::unique_ptr<TlbAllocator> tlb_allocator_;
+    std::unique_ptr<TLBManager> tlb_manager_;
     std::unique_ptr<TlbWindow> cached_tlb_window_;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -9,7 +9,8 @@
 #include <mutex>
 
 #include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
-#include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
+#include "umd/device/chip_helpers/tlb_allocator.hpp"
+#include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/simulation/simulation_host.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"
 #include "umd/device/soc_descriptor.hpp"
@@ -111,7 +112,8 @@ private:
 
     uint32_t libttsim_pci_device_id;
 
-    std::unique_ptr<SimulationTlbManager> tlb_manager_;
+    std::unique_ptr<TlbAllocator> tlb_allocator_;
+    std::unique_ptr<TLBManager> tlb_manager_;
     std::unique_ptr<TlbWindow> cached_tlb_window_ = nullptr;
 };
 }  // namespace tt::umd

--- a/device/chip_helpers/tlb_allocator.cpp
+++ b/device/chip_helpers/tlb_allocator.cpp
@@ -1,34 +1,25 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
+#include "umd/device/chip_helpers/tlb_allocator.hpp"
 
 #include <cstddef>
 #include <cstdint>
-#include <exception>
-#include <memory>
 #include <stdexcept>
 #include <tt-logger/tt-logger.hpp>
-#include <utility>
-#include <vector>
 
-#include "assert.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
-#include "umd/device/tt_device/tt_device.hpp"
-#include "umd/device/types/tlb.hpp"
 
 namespace tt::umd {
 
-SimulationTlbManager::SimulationTlbManager(
-    TTDevice* tt_device, uint64_t bar0_base, const architecture_implementation* arch_impl, TlbWindowFactory factory) :
-    TLBManager(tt_device), bar0_base_(bar0_base), arch_impl_(arch_impl), factory_(std::move(factory)) {
-    // Initialize architecture-specific configuration.
+TlbAllocator::TlbAllocator(uint64_t bar0_base, const architecture_implementation* arch_impl) :
+    bar0_base_(bar0_base), arch_impl_(arch_impl) {
     initialize_architecture_config();
 }
 
-int SimulationTlbManager::allocate_tlb_index(size_t size) {
+int TlbAllocator::allocate_tlb_index(size_t size) {
     std::lock_guard<std::mutex> lock(allocation_mutex_);
 
     if (size == 0) {
@@ -105,7 +96,7 @@ int SimulationTlbManager::allocate_tlb_index(size_t size) {
     return -1;  // No available TLB
 }
 
-void SimulationTlbManager::deallocate_tlb_index(int tlb_index) {
+void TlbAllocator::deallocate_tlb_index(int tlb_index) {
     std::lock_guard<std::mutex> lock(allocation_mutex_);
 
     // Check 1MB TLBs (Wormhole only).
@@ -143,7 +134,7 @@ void SimulationTlbManager::deallocate_tlb_index(int tlb_index) {
     }
 }
 
-size_t SimulationTlbManager::get_tlb_size_from_index(int tlb_index) {
+size_t TlbAllocator::get_tlb_size_from_index(int tlb_index) const {
     // Check 1MB TLBs (Wormhole only).
     if (tlb_1mb_count_ > 0 && tlb_index >= tlb_1mb_start_index_ && tlb_index < tlb_2mb_start_index_) {
         return tlb_1mb_size_;
@@ -168,7 +159,7 @@ size_t SimulationTlbManager::get_tlb_size_from_index(int tlb_index) {
     return 0;
 }
 
-uint64_t SimulationTlbManager::get_tlb_address_from_index(int tlb_index) {
+uint64_t TlbAllocator::get_tlb_address_from_index(int tlb_index) const {
     if (architecture_ == tt::ARCH::WORMHOLE_B0) {
         // Wormhole B0 address calculation.
         if (tlb_1mb_count_ > 0 && tlb_index >= tlb_1mb_start_index_ && tlb_index < tlb_2mb_start_index_) {
@@ -201,58 +192,34 @@ uint64_t SimulationTlbManager::get_tlb_address_from_index(int tlb_index) {
     return 0;
 }
 
-std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_tlb_window(
-    tlb_data config, const TlbMapping mapping, const size_t tlb_size) {
-    const auto* arch_impl = get_architecture_impl();
-    if (arch_impl->get_architecture() == tt::ARCH::WORMHOLE_B0 &&
-        (tlb_size == arch_impl->get_cached_tlb_size() || tlb_size == arch_impl->get_dynamic_tlb_2m_size())) {
-        throw std::runtime_error("TLBs of 1MB and 2MB are not supported in simulation for Wormhole architecture.");
-    }
-
-    int tlb_index = allocate_tlb_index(tlb_size);
-    if (tlb_index == -1) {
-        throw std::runtime_error("No available TLB of requested size");
-    }
-
-    size_t actual_tlb_size = get_tlb_size_from_index(tlb_index);
-
-    return factory_(this, tlb_index, actual_tlb_size, mapping, config);
-}
-
-uint64_t SimulationTlbManager::get_tlb_reg_address_from_index(int tlb_index) {
+uint64_t TlbAllocator::get_tlb_reg_address_from_index(int tlb_index) const {
     // TLB configuration registers start at this offset from BAR0 base.
     static constexpr uint64_t TLB_CONFIG_REG_BASE_OFFSET = 0x1fc00000;
     return bar0_base_ + TLB_CONFIG_REG_BASE_OFFSET + tlb_index * tlb_reg_size_bytes_;
 }
 
-const architecture_implementation* SimulationTlbManager::get_architecture_impl() const { return arch_impl_; }
+const architecture_implementation* TlbAllocator::get_architecture_impl() const { return arch_impl_; }
 
-std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
+tt::ARCH TlbAllocator::get_architecture() const { return architecture_; }
+
+size_t TlbAllocator::get_default_tlb_size() const {
     static constexpr size_t SIZE_2MB = 2 * 1024 * 1024;
     static constexpr size_t SIZE_16MB = 16 * 1024 * 1024;
     switch (architecture_) {
-        case tt::ARCH::BLACKHOLE:
-            return allocate_tlb_window({}, TlbMapping::WC, SIZE_2MB);
-        case tt::ARCH::WORMHOLE_B0:
-            return allocate_tlb_window({}, TlbMapping::WC, SIZE_16MB);
-        default:
-            log_debug(
-                LogUMD,
-                "Architecture {} does not support TLB allocation, returning nullptr.",
-                tt::arch_to_str(architecture_));
-            return nullptr;
+        case tt::ARCH::BLACKHOLE: return SIZE_2MB;
+        case tt::ARCH::WORMHOLE_B0: return SIZE_16MB;
+        default: return 0;
     }
 }
 
-void SimulationTlbManager::initialize_architecture_config() {
-    architecture_ = get_architecture_impl()->get_architecture();
+void TlbAllocator::initialize_architecture_config() {
+    architecture_ = arch_impl_->get_architecture();
 
     if (architecture_ == tt::ARCH::WORMHOLE_B0) {
         // Wormhole B0 configuration.
         tlb_reg_size_bytes_ = 8;  // wormhole::TLB_CFG_REG_SIZE_BYTES
 
-        const auto* arch_impl = get_architecture_impl();
-        const auto& tlb_sizes = arch_impl->get_tlb_sizes();
+        const auto& tlb_sizes = arch_impl_->get_tlb_sizes();
         tlb_1mb_size_ = tlb_sizes[0];   // 1MB
         tlb_2mb_size_ = tlb_sizes[1];   // 2MB
         tlb_16mb_size_ = tlb_sizes[2];  // 16MB
@@ -272,14 +239,12 @@ void SimulationTlbManager::initialize_architecture_config() {
         tlb_1mb_allocated_.resize(tlb_1mb_count_, false);
         tlb_2mb_allocated_.resize(tlb_2mb_count_, false);
         tlb_16mb_allocated_.resize(tlb_16mb_count_, false);
-        // tlb_4gb_allocated_ remains empty
 
     } else if (architecture_ == tt::ARCH::BLACKHOLE) {
         // Blackhole configuration.
         tlb_reg_size_bytes_ = 12;  // blackhole::TLB_CFG_REG_SIZE_BYTES
 
-        const auto* arch_impl = get_architecture_impl();
-        const auto& tlb_sizes = arch_impl->get_tlb_sizes();
+        const auto& tlb_sizes = arch_impl_->get_tlb_sizes();
         tlb_1mb_size_ = 0;             // Not supported
         tlb_2mb_size_ = tlb_sizes[0];  // 2MB
         tlb_16mb_size_ = 0;            // Not supported
@@ -296,7 +261,6 @@ void SimulationTlbManager::initialize_architecture_config() {
         tlb_4gb_start_index_ = tlb_2mb_count_;
 
         // Initialize allocation tracking.
-        // tlb_1mb_allocated_ and tlb_16mb_allocated_ remain empty
         tlb_2mb_allocated_.resize(tlb_2mb_count_, false);
         tlb_4gb_allocated_.resize(tlb_4gb_count_, false);
 

--- a/device/chip_helpers/tlb_allocator.cpp
+++ b/device/chip_helpers/tlb_allocator.cpp
@@ -206,9 +206,12 @@ size_t TlbAllocator::get_default_tlb_size() const {
     static constexpr size_t SIZE_2MB = 2 * 1024 * 1024;
     static constexpr size_t SIZE_16MB = 16 * 1024 * 1024;
     switch (architecture_) {
-        case tt::ARCH::BLACKHOLE: return SIZE_2MB;
-        case tt::ARCH::WORMHOLE_B0: return SIZE_16MB;
-        default: return 0;
+        case tt::ARCH::BLACKHOLE:
+            return SIZE_2MB;
+        case tt::ARCH::WORMHOLE_B0:
+            return SIZE_16MB;
+        default:
+            return 0;
     }
 }
 

--- a/device/chip_helpers/tlb_manager.cpp
+++ b/device/chip_helpers/tlb_manager.cpp
@@ -24,11 +24,10 @@ namespace tt::umd {
 
 TLBManager::TLBManager(TTDevice* tt_device) : tt_device_(tt_device) {}
 
-void TLBManager::configure_tlb(tt_xy_pair core, size_t tlb_size, uint64_t address, uint64_t ordering) {
+tlb_data TLBManager::build_tlb_config(tt_xy_pair core, uint64_t address, uint64_t ordering) const {
     TT_ASSERT(
         ordering == tlb_data::Strict || ordering == tlb_data::Posted || ordering == tlb_data::Relaxed,
         "Invalid ordering specified in Cluster::configure_tlb");
-    log_debug(LogUMD, "Requesting TLB window of size {}", tlb_size);
 
     tlb_data config{};
     config.local_offset = address;
@@ -36,22 +35,55 @@ void TLBManager::configure_tlb(tt_xy_pair core, size_t tlb_size, uint64_t addres
     config.y_end = core.y;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = ordering;
-    config.static_vc = get_tt_device()->get_architecture_implementation()->get_static_vc();
-    std::unique_ptr<TlbWindow> tlb_window = allocate_tlb_window(config, TlbMapping::WC, tlb_size);
+    config.static_vc = tt_device_->get_architecture_implementation()->get_static_vc();
+    return config;
+}
 
+void TLBManager::register_tlb_window(
+    tt_xy_pair core, size_t tlb_size, uint64_t address, std::unique_ptr<TlbWindow> tlb_window) {
     log_debug(
         LogUMD,
-        "Configured TLB window for chip: {} core: {} size: {} address: {} ordering: {} tlb_id: {}",
+        "Configured TLB window for chip: {} core: {} size: {} address: {} tlb_id: {}",
         tt_device_->get_pci_device()->get_device_num(),
         core.str(),
         tlb_size,
         address,
-        ordering,
         tlb_window->handle_ref().get_tlb_id());
 
     tlb_config_map_.insert({tlb_window->handle_ref().get_tlb_id(), (address / tlb_size) * tlb_size});
     map_core_to_tlb_.insert({core, tlb_window->handle_ref().get_tlb_id()});
     tlb_windows_.insert({tlb_window->handle_ref().get_tlb_id(), std::move(tlb_window)});
+}
+
+void TLBManager::configure_tlb(tt_xy_pair core, size_t tlb_size, uint64_t address, uint64_t ordering) {
+    log_debug(LogUMD, "Requesting TLB window of size {}", tlb_size);
+
+    tlb_data config = build_tlb_config(core, address, ordering);
+
+    // Silicon path: create SiliconTlbWindow directly.
+    std::unique_ptr<TlbWindow> tlb_window;
+    if (tlb_size != 0) {
+        tlb_window = std::make_unique<SiliconTlbWindow>(
+            tt_device_->get_pci_device()->allocate_tlb(tlb_size, TlbMapping::WC), config);
+    } else {
+        const std::vector<size_t>& possible_arch_sizes = tt_device_->get_architecture_implementation()->get_tlb_sizes();
+
+        for (const auto& size : possible_arch_sizes) {
+            try {
+                tlb_window = std::make_unique<SiliconTlbWindow>(
+                    tt_device_->get_pci_device()->allocate_tlb(size, TlbMapping::WC), config);
+                break;
+            } catch (const std::exception& e) {
+                log_error(LogUMD, "Failed to allocate TLB window of size {}: {}", size, e.what());
+            }
+        }
+
+        if (!tlb_window) {
+            throw std::runtime_error(fmt::format("Failed to allocate TLB window."));
+        }
+    }
+
+    register_tlb_window(core, tlb_size, address, std::move(tlb_window));
 }
 
 TlbWindow* TLBManager::get_tlb_window(const tt_xy_pair core) {
@@ -92,29 +124,6 @@ tlb_configuration TLBManager::get_tlb_configuration(tt_xy_pair core) {
 
     int tlb_index = map_core_to_tlb_.at(core);
     return tt_device_->get_architecture_implementation()->get_tlb_configuration(tlb_index);
-}
-
-std::unique_ptr<TlbWindow> TLBManager::allocate_tlb_window(
-    tlb_data config, const TlbMapping mapping, const size_t tlb_size) {
-    if (tlb_size != 0) {
-        return std::make_unique<SiliconTlbWindow>(
-            tt_device_->get_pci_device()->allocate_tlb(tlb_size, mapping), config);
-    }
-
-    const std::vector<size_t>& possible_arch_sizes = tt_device_->get_architecture_implementation()->get_tlb_sizes();
-
-    for (const auto& size : possible_arch_sizes) {
-        std::unique_ptr<TlbWindow> tlb_window = nullptr;
-        try {
-            tlb_window =
-                std::make_unique<SiliconTlbWindow>(tt_device_->get_pci_device()->allocate_tlb(size, mapping), config);
-            return tlb_window;
-        } catch (const std::exception& e) {
-            log_error(LogUMD, "Failed to allocate TLB window of size {}: {}", size, e.what());
-        }
-    }
-
-    throw std::runtime_error(fmt::format("Failed to allocate TLB window."));
 }
 
 void TLBManager::clear_mapped_tlbs() {

--- a/device/pcie/rtl_sim_tlb_handle.cpp
+++ b/device/pcie/rtl_sim_tlb_handle.cpp
@@ -9,20 +9,20 @@
 #include <memory>
 #include <tt-logger/tt-logger.hpp>
 
-#include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
+#include "umd/device/chip_helpers/tlb_allocator.hpp"
 
 namespace tt::umd {
 
-RtlSimTlbHandle::RtlSimTlbHandle(SimulationTlbManager* manager, int tlb_id, size_t size, TlbMapping mapping) :
-    manager_(manager) {
+RtlSimTlbHandle::RtlSimTlbHandle(TlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping) :
+    allocator_(allocator) {
     tlb_id_ = tlb_id;
     tlb_size_ = size;
     tlb_mapping_ = mapping;
 
-    if (manager_) {
+    if (allocator_) {
         // This is a fake, non-dereferenceable pointer used only for address arithmetic.
         // For RTL sim, bar0_base is 0, so this will be a near-null address.
-        tlb_base_ = reinterpret_cast<uint8_t*>(manager_->get_tlb_address_from_index(tlb_id_));
+        tlb_base_ = reinterpret_cast<uint8_t*>(allocator_->get_tlb_address_from_index(tlb_id_));
     }
 
     log_debug(
@@ -34,8 +34,8 @@ RtlSimTlbHandle::RtlSimTlbHandle(SimulationTlbManager* manager, int tlb_id, size
 }
 
 std::unique_ptr<RtlSimTlbHandle> RtlSimTlbHandle::create(
-    SimulationTlbManager* manager, int tlb_id, size_t size, TlbMapping mapping) {
-    return std::unique_ptr<RtlSimTlbHandle>(new RtlSimTlbHandle(manager, tlb_id, size, mapping));
+    TlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping) {
+    return std::unique_ptr<RtlSimTlbHandle>(new RtlSimTlbHandle(allocator, tlb_id, size, mapping));
 }
 
 RtlSimTlbHandle::~RtlSimTlbHandle() noexcept { RtlSimTlbHandle::free_tlb(); }
@@ -58,9 +58,9 @@ void RtlSimTlbHandle::configure(const tlb_data& new_config) {
 }
 
 void RtlSimTlbHandle::free_tlb() noexcept {
-    if (manager_) {
-        manager_->deallocate_tlb_index(tlb_id_);
-        manager_ = nullptr;
+    if (allocator_) {
+        allocator_->deallocate_tlb_index(tlb_id_);
+        allocator_ = nullptr;
 
         log_debug(LogUMD, "Freed RTL sim TLB with ID {}", tlb_id_);
     }

--- a/device/pcie/rtl_sim_tlb_window.cpp
+++ b/device/pcie/rtl_sim_tlb_window.cpp
@@ -7,10 +7,9 @@
 #include <cstddef>
 #include <cstdint>
 
-#include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
+#include "umd/device/chip_helpers/tlb_allocator.hpp"
 #include "umd/device/pcie/rtl_sim_tlb_handle.hpp"
 #include "umd/device/simulation/rtl_sim_communicator.hpp"
-#include "umd/device/tt_device/tt_device.hpp"
 
 namespace tt::umd {
 
@@ -68,7 +67,7 @@ uint16_t RtlSimTlbWindow::safe_read16(uint64_t offset) { return read16(offset); 
 
 tt::ARCH RtlSimTlbWindow::get_arch() const {
     auto* handle = dynamic_cast<RtlSimTlbHandle*>(tlb_handle.get());
-    return handle->get_tlb_manager()->get_tt_device()->get_arch();
+    return handle->get_allocator()->get_architecture();
 }
 
 }  // namespace tt::umd

--- a/device/pcie/tt_sim_tlb_handle.cpp
+++ b/device/pcie/tt_sim_tlb_handle.cpp
@@ -12,29 +12,22 @@
 
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
-#include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
+#include "umd/device/chip_helpers/tlb_allocator.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"
 
 namespace tt::umd {
 
-// Forward declaration to avoid circular dependency.
-class SimulationTlbManager;
-
 TTSimTlbHandle::TTSimTlbHandle(
-    SimulationTlbManager* manager,
-    TTSimCommunicator* communicator,
-    int tlb_id,
-    size_t size,
-    const TlbMapping tlb_mapping) :
-    sim_manager_(manager), sim_communicator_(communicator) {
+    TlbAllocator* allocator, TTSimCommunicator* communicator, int tlb_id, size_t size, const TlbMapping tlb_mapping) :
+    allocator_(allocator), sim_communicator_(communicator) {
     tlb_id_ = tlb_id;
     tlb_size_ = size;
     tlb_mapping_ = tlb_mapping;
 
     // Compute the address for this TLB based on BAR0 base + TLB offset.
-    if (sim_manager_) {
-        tlb_base_ = reinterpret_cast<uint8_t*>(sim_manager_->get_tlb_address_from_index(tlb_id_));
-        tlb_reg_addr_ = sim_manager_->get_tlb_reg_address_from_index(tlb_id_);
+    if (allocator_) {
+        tlb_base_ = reinterpret_cast<uint8_t*>(allocator_->get_tlb_address_from_index(tlb_id_));
+        tlb_reg_addr_ = allocator_->get_tlb_reg_address_from_index(tlb_id_);
     }
 
     log_debug(
@@ -46,12 +39,8 @@ TTSimTlbHandle::TTSimTlbHandle(
 }
 
 std::unique_ptr<TTSimTlbHandle> TTSimTlbHandle::create(
-    SimulationTlbManager* manager,
-    TTSimCommunicator* communicator,
-    int tlb_id,
-    size_t size,
-    const TlbMapping tlb_mapping) {
-    return std::unique_ptr<TTSimTlbHandle>(new TTSimTlbHandle(manager, communicator, tlb_id, size, tlb_mapping));
+    TlbAllocator* allocator, TTSimCommunicator* communicator, int tlb_id, size_t size, const TlbMapping tlb_mapping) {
+    return std::unique_ptr<TTSimTlbHandle>(new TTSimTlbHandle(allocator, communicator, tlb_id, size, tlb_mapping));
 }
 
 TTSimTlbHandle::~TTSimTlbHandle() noexcept { TTSimTlbHandle::free_tlb(); }
@@ -64,8 +53,8 @@ void TTSimTlbHandle::configure(const tlb_data& new_config) {
     tlb_config_.ordering = 0;
     tlb_config_.static_vc = 0;
 
-    // Get architecture from manager to determine correct offsets.
-    const architecture_implementation* arch_impl = sim_manager_->get_architecture_impl();
+    // Get architecture from allocator to determine correct offsets.
+    const architecture_implementation* arch_impl = allocator_->get_architecture_impl();
     tt::ARCH architecture = arch_impl->get_architecture();
 
     log_debug(
@@ -143,9 +132,9 @@ void TTSimTlbHandle::configure(const tlb_data& new_config) {
 }
 
 void TTSimTlbHandle::free_tlb() noexcept {
-    if (sim_manager_) {
-        sim_manager_->deallocate_tlb_index(tlb_id_);
-        sim_manager_ = nullptr;
+    if (allocator_) {
+        allocator_->deallocate_tlb_index(tlb_id_);
+        allocator_ = nullptr;
 
         log_debug(LogUMD, "Freed simulation TLB with ID {}", tlb_id_);
     }

--- a/device/pcie/tt_sim_tlb_window.cpp
+++ b/device/pcie/tt_sim_tlb_window.cpp
@@ -9,10 +9,9 @@
 #include <cstring>
 #include <memory>
 
-#include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
+#include "umd/device/chip_helpers/tlb_allocator.hpp"
 #include "umd/device/pcie/tt_sim_tlb_handle.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"
-#include "umd/device/tt_device/tt_device.hpp"
 
 namespace tt::umd {
 
@@ -76,7 +75,7 @@ uint16_t TTSimTlbWindow::safe_read16(uint64_t offset) { return read16(offset); }
 
 tt::ARCH TTSimTlbWindow::get_arch() const {
     auto* sim_handle = dynamic_cast<TTSimTlbHandle*>(tlb_handle.get());
-    return sim_handle->get_tlb_manager()->get_tt_device()->get_arch();
+    return sim_handle->get_allocator()->get_architecture();
 }
 
 }  // namespace tt::umd

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -15,6 +15,52 @@
 
 namespace tt::umd {
 
+namespace {
+
+/**
+ * RTL simulation-specific TLBManager that creates RtlSimTlbHandle + RtlSimTlbWindow directly,
+ * eliminating the need for a std::function factory.
+ */
+class RtlSimTLBManager : public TLBManager {
+public:
+    RtlSimTLBManager(TTDevice* tt_device, TlbAllocator* allocator, RtlSimCommunicator* communicator) :
+        TLBManager(tt_device), allocator_(allocator), communicator_(communicator) {}
+
+    void configure_tlb(tt_xy_pair core, size_t tlb_size, uint64_t address, uint64_t ordering) override {
+        log_debug(LogUMD, "Requesting TLB window of size {}", tlb_size);
+
+        tlb_data config = build_tlb_config(core, address, ordering);
+
+        int tlb_index = allocator_->allocate_tlb_index(tlb_size);
+        if (tlb_index == -1) {
+            throw std::runtime_error("No available TLB of requested size");
+        }
+
+        size_t actual_tlb_size = allocator_->get_tlb_size_from_index(tlb_index);
+        auto handle = RtlSimTlbHandle::create(allocator_, tlb_index, actual_tlb_size, TlbMapping::WC);
+        auto window = std::make_unique<RtlSimTlbWindow>(std::move(handle), communicator_, config);
+
+        register_tlb_window(core, tlb_size, address, std::move(window));
+    }
+
+    std::unique_ptr<TlbWindow> allocate_tlb_window(tlb_data config, TlbMapping mapping, size_t tlb_size) {
+        int tlb_index = allocator_->allocate_tlb_index(tlb_size);
+        if (tlb_index == -1) {
+            throw std::runtime_error("No available TLB of requested size");
+        }
+
+        size_t actual_tlb_size = allocator_->get_tlb_size_from_index(tlb_index);
+        auto handle = RtlSimTlbHandle::create(allocator_, tlb_index, actual_tlb_size, mapping);
+        return std::make_unique<RtlSimTlbWindow>(std::move(handle), communicator_, config);
+    }
+
+private:
+    TlbAllocator* allocator_;
+    RtlSimCommunicator* communicator_;
+};
+
+}  // namespace
+
 static_assert(!std::is_abstract<RtlSimulationTTDevice>(), "RtlSimulationTTDevice must be non-abstract.");
 
 // Array of DM RiscType values for iteration.
@@ -52,16 +98,14 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
     arch = soc_descriptor_.arch;
     communicator_->initialize();
 
-    tlb_manager_ = std::make_unique<SimulationTlbManager>(
-        this,
-        /*bar0_base=*/0,
-        architecture_impl_.get(),
-        [comm = communicator_.get()](
-            SimulationTlbManager* mgr, int id, size_t sz, TlbMapping map, tlb_data cfg) -> std::unique_ptr<TlbWindow> {
-            auto handle = RtlSimTlbHandle::create(mgr, id, sz, map);
-            return std::make_unique<RtlSimTlbWindow>(std::move(handle), comm, cfg);
-        });
-    cached_tlb_window_ = tlb_manager_->allocate_default_tlb_window();
+    tlb_allocator_ = std::make_unique<TlbAllocator>(/*bar0_base=*/0, architecture_impl_.get());
+    tlb_manager_ = std::make_unique<RtlSimTLBManager>(this, tlb_allocator_.get(), communicator_.get());
+
+    size_t default_tlb_size = tlb_allocator_->get_default_tlb_size();
+    if (default_tlb_size > 0) {
+        auto* rtl_tlb_mgr = dynamic_cast<RtlSimTLBManager*>(tlb_manager_.get());
+        cached_tlb_window_ = rtl_tlb_mgr->allocate_tlb_window({}, TlbMapping::WC, default_tlb_size);
+    }
 }
 
 RtlSimulationTTDevice::~RtlSimulationTTDevice() { close_device(); }
@@ -252,6 +296,6 @@ void RtlSimulationTTDevice::retrain_dram_core(const uint32_t dram_channel) {
     throw std::runtime_error("DRAM retraining is not supported in RTL simulation device.");
 }
 
-TLBManager* RtlSimulationTTDevice::get_tlb_manager() { return static_cast<TLBManager*>(tlb_manager_.get()); }
+TLBManager* RtlSimulationTTDevice::get_tlb_manager() { return tlb_manager_.get(); }
 
 }  // namespace tt::umd

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -16,6 +16,58 @@
 
 namespace tt::umd {
 
+namespace {
+
+/**
+ * TTSim-specific TLBManager that creates TTSimTlbHandle + TTSimTlbWindow directly,
+ * eliminating the need for a std::function factory.
+ */
+class TTSimTLBManager : public TLBManager {
+public:
+    TTSimTLBManager(TTDevice* tt_device, TlbAllocator* allocator, TTSimCommunicator* communicator) :
+        TLBManager(tt_device), allocator_(allocator), communicator_(communicator) {}
+
+    void configure_tlb(tt_xy_pair core, size_t tlb_size, uint64_t address, uint64_t ordering) override {
+        log_debug(LogUMD, "Requesting TLB window of size {}", tlb_size);
+
+        tlb_data config = build_tlb_config(core, address, ordering);
+
+        const auto* arch_impl = allocator_->get_architecture_impl();
+        if (arch_impl->get_architecture() == tt::ARCH::WORMHOLE_B0 &&
+            (tlb_size == arch_impl->get_cached_tlb_size() || tlb_size == arch_impl->get_dynamic_tlb_2m_size())) {
+            throw std::runtime_error("TLBs of 1MB and 2MB are not supported in simulation for Wormhole architecture.");
+        }
+
+        int tlb_index = allocator_->allocate_tlb_index(tlb_size);
+        if (tlb_index == -1) {
+            throw std::runtime_error("No available TLB of requested size");
+        }
+
+        size_t actual_tlb_size = allocator_->get_tlb_size_from_index(tlb_index);
+        auto handle = TTSimTlbHandle::create(allocator_, communicator_, tlb_index, actual_tlb_size, TlbMapping::WC);
+        auto window = std::make_unique<TTSimTlbWindow>(std::move(handle), communicator_, config);
+
+        register_tlb_window(core, tlb_size, address, std::move(window));
+    }
+
+    std::unique_ptr<TlbWindow> allocate_tlb_window(tlb_data config, TlbMapping mapping, size_t tlb_size) {
+        int tlb_index = allocator_->allocate_tlb_index(tlb_size);
+        if (tlb_index == -1) {
+            throw std::runtime_error("No available TLB of requested size");
+        }
+
+        size_t actual_tlb_size = allocator_->get_tlb_size_from_index(tlb_index);
+        auto handle = TTSimTlbHandle::create(allocator_, communicator_, tlb_index, actual_tlb_size, mapping);
+        return std::make_unique<TTSimTlbWindow>(std::move(handle), communicator_, config);
+    }
+
+private:
+    TlbAllocator* allocator_;
+    TTSimCommunicator* communicator_;
+};
+
+}  // namespace
+
 static_assert(!std::is_abstract<TTSimTTDevice>(), "TTSimChip must be non-abstract.");
 
 std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create(
@@ -70,16 +122,14 @@ TTSimTTDevice::TTSimTTDevice(
         }
     }
 
-    tlb_manager_ = std::make_unique<SimulationTlbManager>(
-        this,
-        bar0_base,
-        architecture_impl_.get(),
-        [comm = communicator_.get()](
-            SimulationTlbManager* mgr, int id, size_t sz, TlbMapping map, tlb_data cfg) -> std::unique_ptr<TlbWindow> {
-            auto handle = TTSimTlbHandle::create(mgr, comm, id, sz, map);
-            return std::make_unique<TTSimTlbWindow>(std::move(handle), comm, cfg);
-        });
-    cached_tlb_window_ = tlb_manager_->allocate_default_tlb_window();
+    tlb_allocator_ = std::make_unique<TlbAllocator>(bar0_base, architecture_impl_.get());
+    tlb_manager_ = std::make_unique<TTSimTLBManager>(this, tlb_allocator_.get(), communicator_.get());
+
+    size_t default_tlb_size = tlb_allocator_->get_default_tlb_size();
+    if (default_tlb_size > 0) {
+        auto* sim_tlb_mgr = dynamic_cast<TTSimTLBManager*>(tlb_manager_.get());
+        cached_tlb_window_ = sim_tlb_mgr->allocate_tlb_window({}, TlbMapping::WC, default_tlb_size);
+    }
 }
 
 TTSimTTDevice::~TTSimTTDevice() = default;
@@ -265,6 +315,6 @@ void TTSimTTDevice::retrain_dram_core(const uint32_t dram_channel) {
     throw std::runtime_error("DRAM retraining is not supported in TTSim device.");
 }
 
-TLBManager* TTSimTTDevice::get_tlb_manager() { return static_cast<TLBManager*>(tlb_manager_.get()); }
+TLBManager* TTSimTTDevice::get_tlb_manager() { return tlb_manager_.get(); }
 
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue
Resolves #2317

### Description
Refactors the simulation TLB management layer by separating pure TLB allocation/bookkeeping from backend-specific window creation. The monolithic `SimulationTlbManager` class is replaced with a focused `TlbAllocator` (index management, address computation, architecture config) while each simulation backend gets its own `TLBManager` subclass that directly creates its Handle+Window types. This eliminates the `std::function<TlbWindowFactory>` indirection and lambda captures.

### List of the changes
- Renamed `SimulationTlbManager` to `TlbAllocator`, stripping out all `TlbHandle`/`TlbWindow`/`TLBManager` dependencies — it now only manages TLB index allocation and address math.
- Made `TLBManager::configure_tlb` virtual; extracted `build_tlb_config()` and `register_tlb_window()` as protected helpers for subclasses.
- `RtlSimulationTTDevice` now owns both a `TlbAllocator` and an inner `RtlSimTLBManager : TLBManager` that overrides `configure_tlb` and `allocate_tlb_window` to create `RtlSimTlbHandle`/`RtlSimTlbWindow` directly.
- `TTSimTTDevice` similarly owns a `TlbAllocator` and an inner `TTSimTLBManager : TLBManager` that creates `TTSimTlbHandle`/`TTSimTlbWindow` directly.
- Updated `RtlSimTlbHandle` and `TTSimTlbHandle` to reference `TlbAllocator*` instead of `SimulationTlbManager*`.
- Removed the `TlbWindowFactory` type alias and all associated `std::function` / lambda machinery.

### Testing
CI

### API Changes
There are no API changes in this PR.