### PR TITLE
Python api adjustments for tooling

### DIFF
--- a/device/api/umd/device/tt_device/remote_communication_legacy_firmware.hpp
+++ b/device/api/umd/device/tt_device/remote_communication_legacy_firmware.hpp
@@ -45,6 +45,7 @@ public:
 
 private:
     EthCoord target_chip;
+    bool large_transfer_warning_printed_ = false;
 };
 
 }  // namespace tt::umd

--- a/device/tt_device/remote_communication_legacy_firmware.cpp
+++ b/device/tt_device/remote_communication_legacy_firmware.cpp
@@ -155,9 +155,10 @@ void RemoteCommunicationLegacyFirmware::read_non_mmio(
 
     bool system_mem_available = sysmem_manager_ != nullptr && sysmem_manager_->get_num_host_mem_channels() > 0;
     bool use_host_dram = size_in_bytes > 256 * DATA_WORD_SIZE && system_mem_available;
-    // Print a warning in case of missing perf for larger transfers.
-    if (size_in_bytes > 256 * DATA_WORD_SIZE && !system_mem_available) {
-        log_warning(LogUMD, "Large transfer without system memory setup. Performance will be degraded.");
+    // Print a warning in case of missing perf for larger transfers (once per instance).
+    if (size_in_bytes > 256 * DATA_WORD_SIZE && !system_mem_available && !large_transfer_warning_printed_) {
+        log_warning(LogUMD, "Large transfer to remote chip without system memory setup. Performance will be degraded.");
+        large_transfer_warning_printed_ = true;
     }
 
     // When sysmem_manager is not available, we chunk the transfer using smaller blocks.
@@ -379,9 +380,10 @@ void RemoteCommunicationLegacyFirmware::write_to_non_mmio(
     // When sysmem_manager is not available, we chunk the transfer using smaller blocks.
     bool system_mem_available = sysmem_manager_ != nullptr && sysmem_manager_->get_num_host_mem_channels() > 0;
     bool use_host_dram = (broadcast || (size_in_bytes > 256 * DATA_WORD_SIZE)) && system_mem_available;
-    // Print a warning in case of missing perf for larger transfers.
-    if (size_in_bytes > 256 * DATA_WORD_SIZE && !system_mem_available) {
-        log_warning(LogUMD, "Large transfer without system memory setup. Performance will be degraded.");
+    // Print a warning in case of missing perf for larger transfers (once per instance).
+    if (size_in_bytes > 256 * DATA_WORD_SIZE && !system_mem_available && !large_transfer_warning_printed_) {
+        log_warning(LogUMD, "Large transfer to remote chip without system memory setup. Performance will be degraded.");
+        large_transfer_warning_printed_ = true;
     }
 
     UMD_ASSERT(

--- a/nanobind/py_api_topology_discovery.cpp
+++ b/nanobind/py_api_topology_discovery.cpp
@@ -84,7 +84,15 @@ void bind_topology_discovery(nb::module_& m) {
             nb::arg("chip"),
             release_gil(),
             "Get board ID for a chip")
-        .def("get_unhealthy_devices", &ClusterDescriptor::get_unhealthy_devices, release_gil());
+        .def("get_unhealthy_devices", &ClusterDescriptor::get_unhealthy_devices, release_gil())
+        .def_static(
+            "create_constrained_cluster_descriptor",
+            [](const ClusterDescriptor& full_cluster_desc, const std::unordered_set<ChipId>& target_chip_ids) {
+                return ClusterDescriptor::create_constrained_cluster_descriptor(&full_cluster_desc, target_chip_ids);
+            },
+            nb::arg("full_cluster_desc"),
+            nb::arg("target_chip_ids") = std::unordered_set<ChipId>{},
+            "Create a constrained cluster descriptor filtered to the given chip IDs");
 
     nb::class_<TopologyDiscoveryOptions> topology_discovery_options(m, "TopologyDiscoveryOptions");
 

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -583,7 +583,7 @@ void bind_tt_device(nb::module_ &m) {
                 tt_xy_pair core = {core_x, core_y};
                 const char *data_ptr = data.c_str();
                 size_t data_size = data.size();
-                self.write_to_device(data_ptr, core, addr, static_cast<uint32_t>(data_size));
+                self.write_to_device(data_ptr, core, addr, data_size);
             },
             nb::arg("noc_id"),
             nb::arg("core_x"),

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -187,21 +187,31 @@ void bind_tt_device(nb::module_ &m) {
         .def("get_communication_device_type", &TTDevice::get_communication_device_type, release_gil())
         .def("get_communication_device_id", &TTDevice::get_communication_device_id, release_gil())
         .def("get_pci_device", &TTDevice::get_pci_device, nb::rv_policy::reference, release_gil())
+        .def(
+            "get_pci_interface_id",
+            [](TTDevice &self) -> int {
+                auto pci_device = self.get_pci_device();
+                if (pci_device) {
+                    return pci_device->get_device_num();
+                } else {
+                    return -1;
+                }
+            })
         .def("get_noc_translation_enabled", &TTDevice::get_noc_translation_enabled, release_gil())
         .def("is_remote", &TTDevice::is_remote, release_gil(), "Returns true if this is a remote TTDevice")
         .def("get_remote_communication", &TTDevice::get_remote_communication, nb::rv_policy::reference_internal)
         .def("get_firmware_info_provider", &TTDevice::get_firmware_info_provider, nb::rv_policy::reference_internal)
-        // Compatibility with luwen's API - these methods just return self.
+        // Compatibility with luwen's API - return self if arch matches, else None.
         .def(
             "as_wh",
-            [](TTDevice &self) -> TTDevice & { return self; },
+            [](TTDevice &self) -> TTDevice * { return self.get_arch() == tt::ARCH::WORMHOLE_B0 ? &self : nullptr; },
             nb::rv_policy::reference_internal,
-            "Return self - for compatibility with luwen's API")
+            "Return self if Wormhole, else None - for compatibility with luwen's API")
         .def(
             "as_bh",
-            [](TTDevice &self) -> TTDevice & { return self; },
+            [](TTDevice &self) -> TTDevice * { return self.get_arch() == tt::ARCH::BLACKHOLE ? &self : nullptr; },
             nb::rv_policy::reference_internal,
-            "Return self - for compatibility with luwen's API")
+            "Return self if Blackhole, else None - for compatibility with luwen's API")
         .def(
             "noc_read32",
             [](TTDevice &self, uint32_t core_x, uint32_t core_y, uint64_t addr) -> uint32_t {
@@ -247,27 +257,6 @@ void bind_tt_device(nb::module_ &m) {
             nb::arg("addr"),
             nb::arg("size"),
             "Read arbitrary-length data from a core at the specified address")
-        .def(
-            "noc_read",
-            [](TTDevice &self, uint32_t noc_id, uint32_t core_x, uint32_t core_y, uint64_t addr, nb::bytearray buffer)
-                -> void {
-                if (noc_id != 0) {
-                    UMD_THROW(error::RuntimeError, "noc_id must be 0");
-                }
-                tt_xy_pair core = {core_x, core_y};
-                uint8_t *data_ptr = reinterpret_cast<uint8_t *>(buffer.data());
-                size_t data_size = buffer.size();
-                {
-                    nb::gil_scoped_release release;
-                    self.read_from_device(data_ptr, core, addr, data_size);
-                }
-            },
-            nb::arg("noc_id"),
-            nb::arg("core_x"),
-            nb::arg("core_y"),
-            nb::arg("addr"),
-            nb::arg("buffer"),
-            "Read data into the provided buffer from a core at the specified address. noc_id must be 0 for now.")
         .def(
             "noc_write",
             [](TTDevice &self, uint32_t core_x, uint32_t core_y, uint64_t addr, nb::bytes data) -> void {
@@ -409,27 +398,6 @@ void bind_tt_device(nb::module_ &m) {
             nb::arg("size"),
             "Read arbitrary-length data from a core at the specified address")
         .def(
-            "dma_read_from_device",
-            [](TTDevice &self, uint32_t noc_id, uint32_t core_x, uint32_t core_y, uint64_t addr, nb::bytearray buffer)
-                -> void {
-                if (noc_id != 0) {
-                    UMD_THROW(error::RuntimeError, "noc_id must be 0.");
-                }
-                tt_xy_pair core = {core_x, core_y};
-                uint8_t *data_ptr = reinterpret_cast<uint8_t *>(buffer.data());
-                size_t data_size = buffer.size();
-                {
-                    nb::gil_scoped_release release;
-                    self.dma_read_from_device(data_ptr, data_size, core, addr);
-                }
-            },
-            nb::arg("noc_id"),
-            nb::arg("core_x"),
-            nb::arg("core_y"),
-            nb::arg("addr"),
-            nb::arg("buffer"),
-            "Read data into the provided buffer from a core at the specified address. noc_id must be 0 for now.")
-        .def(
             "dma_write_to_device",
             [](TTDevice &self, uint32_t core_x, uint32_t core_y, uint64_t addr, nb::bytes data) -> void {
                 tt_xy_pair core = {core_x, core_y};
@@ -517,10 +485,10 @@ void bind_tt_device(nb::module_ &m) {
             "arc_msg",
             [](TTDevice &self,
                uint32_t msg_code,
-               bool wait_for_done,
+               bool wait_for_done = true,
                // Default to 0xFFFF: packed as (arg0 | arg1 << 16), the firmware treats the combined
                // value 0xFFFFFFFF as a sentinel meaning "no argument provided".
-               uint32_t arg0,
+               uint32_t arg0 = 0xffff,
                uint32_t arg1 = 0xffff,
                uint32_t timeout = 1) -> std::tuple<uint32_t, uint32_t, uint32_t> {
                 // Warn if wait_for_done is False.
@@ -547,7 +515,124 @@ void bind_tt_device(nb::module_ &m) {
             nb::arg("arg0") = 0xffff,
             nb::arg("arg1") = 0xffff,
             nb::arg("timeout") = 1,
-            "Send ARC message with two arguments and return (exit_code, return_3, return_4). Timeout is in seconds.");
+            "Send ARC message with two arguments and return (exit_code, return_3, return_4). Timeout is in seconds.")
+        // ---------------------------------------------------------------------------
+        // noc_id variants — temporary until noc_id is added to the main read/write
+        // interface in TTDevice. All functions below accept noc_id as the first
+        // argument and throw if it is not 0.
+        // ---------------------------------------------------------------------------
+        .def(
+            "noc_read",
+            [](TTDevice &self, uint32_t noc_id, uint32_t core_x, uint32_t core_y, uint64_t addr, nb::bytearray buffer)
+                -> void {
+                if (noc_id != 0) {
+                    UMD_THROW(error::RuntimeError, "noc_id must be 0");
+                }
+                tt_xy_pair core = {core_x, core_y};
+                uint8_t *data_ptr = reinterpret_cast<uint8_t *>(buffer.data());
+                size_t data_size = buffer.size();
+                self.read_from_device(data_ptr, core, addr, data_size);
+            },
+            nb::arg("noc_id"),
+            nb::arg("core_x"),
+            nb::arg("core_y"),
+            nb::arg("addr"),
+            nb::arg("buffer"),
+            "Read data into the provided buffer from a core at the specified address. noc_id must be 0 for now.")
+        .def(
+            "dma_read_from_device",
+            [](TTDevice &self, uint32_t noc_id, uint32_t core_x, uint32_t core_y, uint64_t addr, nb::bytearray buffer)
+                -> void {
+                if (noc_id != 0) {
+                    UMD_THROW(error::RuntimeError, "noc_id must be 0.");
+                }
+                tt_xy_pair core = {core_x, core_y};
+                uint8_t *data_ptr = reinterpret_cast<uint8_t *>(buffer.data());
+                size_t data_size = buffer.size();
+                self.dma_read_from_device(data_ptr, data_size, core, addr);
+            },
+            nb::arg("noc_id"),
+            nb::arg("core_x"),
+            nb::arg("core_y"),
+            nb::arg("addr"),
+            nb::arg("buffer"),
+            "Read data into the provided buffer from a core at the specified address. noc_id must be 0 for now.")
+        .def(
+            "noc_read32",
+            [](TTDevice &self, uint32_t noc_id, uint32_t core_x, uint32_t core_y, uint64_t addr) -> uint32_t {
+                if (noc_id != 0) {
+                    UMD_THROW(error::RuntimeError, "noc_id must be 0.");
+                }
+                tt_xy_pair core = {core_x, core_y};
+                uint32_t value = 0;
+                self.read_from_device(&value, core, addr, sizeof(uint32_t));
+                return value;
+            },
+            nb::arg("noc_id"),
+            nb::arg("core_x"),
+            nb::arg("core_y"),
+            nb::arg("addr"),
+            "Read a 32-bit value from a core at the specified address. noc_id must be 0 for now.")
+        .def(
+            "noc_write",
+            [](TTDevice &self, uint32_t noc_id, uint32_t core_x, uint32_t core_y, uint64_t addr, const nb::bytes &data)
+                -> void {
+                if (noc_id != 0) {
+                    UMD_THROW(error::RuntimeError, "noc_id must be 0.");
+                }
+                tt_xy_pair core = {core_x, core_y};
+                const char *data_ptr = data.c_str();
+                size_t data_size = data.size();
+                self.write_to_device(data_ptr, core, addr, static_cast<uint32_t>(data_size));
+            },
+            nb::arg("noc_id"),
+            nb::arg("core_x"),
+            nb::arg("core_y"),
+            nb::arg("addr"),
+            nb::arg("data"),
+            "Write arbitrary-length data to a core at the specified address. noc_id must be 0 for now.")
+        .def(
+            "noc_write32",
+            [](TTDevice &self, uint32_t noc_id, uint32_t core_x, uint32_t core_y, uint64_t addr, uint32_t value)
+                -> void {
+                if (noc_id != 0) {
+                    UMD_THROW(error::RuntimeError, "noc_id must be 0.");
+                }
+                tt_xy_pair core = {core_x, core_y};
+                self.write_to_device(&value, core, addr, sizeof(uint32_t));
+            },
+            nb::arg("noc_id"),
+            nb::arg("core_x"),
+            nb::arg("core_y"),
+            nb::arg("addr"),
+            nb::arg("value"),
+            "Write a 32-bit value to a core at the specified address. noc_id must be 0 for now.")
+        .def(
+            "noc_broadcast",
+            [](TTDevice &self, uint32_t noc_id, uint64_t addr, const nb::bytes &data) -> void {
+                if (noc_id != 0) {
+                    UMD_THROW(error::RuntimeError, "noc_id must be 0.");
+                }
+                std::vector<uint8_t> buffer(data.c_str(), data.c_str() + data.size());
+                self.noc_broadcast(buffer.data(), buffer.size(), addr);
+            },
+            nb::arg("noc_id"),
+            nb::arg("addr"),
+            nb::arg("data"),
+            "Broadcast arbitrary-length data to all cores on the chip at the specified address. noc_id must be 0 for "
+            "now.")
+        .def(
+            "noc_broadcast32",
+            [](TTDevice &self, uint32_t noc_id, uint64_t addr, uint32_t value) -> void {
+                if (noc_id != 0) {
+                    UMD_THROW(error::RuntimeError, "noc_id must be 0.");
+                }
+                self.noc_broadcast(&value, sizeof(uint32_t), addr);
+            },
+            nb::arg("noc_id"),
+            nb::arg("addr"),
+            nb::arg("value"),
+            "Broadcast a 32-bit value to all cores on the chip at the specified address. noc_id must be 0 for now.");
 
     nb::class_<SPITTDevice>(m, "SPITTDevice")
         .def_static(

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -614,7 +614,7 @@ void bind_tt_device(nb::module_ &m) {
                     UMD_THROW(error::RuntimeError, "noc_id must be 0.");
                 }
                 std::vector<uint8_t> buffer(data.c_str(), data.c_str() + data.size());
-                self.noc_broadcast(buffer.data(), buffer.size(), addr);
+                self.noc_multicast_write(buffer.data(), buffer.size(), addr);
             },
             nb::arg("noc_id"),
             nb::arg("addr"),
@@ -627,7 +627,7 @@ void bind_tt_device(nb::module_ &m) {
                 if (noc_id != 0) {
                     UMD_THROW(error::RuntimeError, "noc_id must be 0.");
                 }
-                self.noc_broadcast(&value, sizeof(uint32_t), addr);
+                self.noc_multicast_write(&value, sizeof(uint32_t), addr);
             },
             nb::arg("noc_id"),
             nb::arg("addr"),

--- a/nanobind/tests/test_py_tt_device.py
+++ b/nanobind/tests/test_py_tt_device.py
@@ -281,42 +281,6 @@ class TestTTDevice(unittest.TestCase):
             self.assertEqual(return_3, expected_value)
             dev.set_power_state(False)
 
-    def test_arc_msg_test_increment(self):
-        """TEST (0x90) increments arg0 and returns it. Call twice to verify arg passing and return values."""
-        pci_ids = tt_umd.PCIDevice.enumerate_devices()
-        if len(pci_ids) == 0:
-            print("No PCI devices found.")
-            return
-
-        for dev_id in pci_ids:
-            dev = tt_umd.TTDevice.create(dev_id)
-            dev.init_tt_device()
-            arch = dev.get_arch()
-            print(f"Testing arc_msg TEST increment on device {dev_id} with arch {arch}")
-
-            # Test out both arg passing styles (args list vs individual arg) to ensure both work correctly.
-            # Wormhole accepts only two arguments. And both are passed packed into a single uint32 value.
-            # What that means, is that the returned uint32 will contain both.
-            # On blackhole with new arc msg protocol, we have up to 8 arguments each being uint32. So the
-            # test message will only take the actual first argument into consideration.
-            # The TEST message just increments the arg passed.
-            random_arg = 42
-            default_arg_1 = 0xFFFF
-            expected_value = (
-                random_arg
-                + 1
-                + (default_arg_1 << 16 if arch == tt_umd.ARCH.WORMHOLE_B0 else 0)
-            )
-            exit_code, return_3, return_4 = dev.arc_msg(0x90, True, arg0=random_arg)
-            print(f"Call 1: exit_code={exit_code:#x}, return_3={return_3:#x}")
-            self.assertEqual(exit_code, 0)
-            self.assertEqual(return_3, expected_value)
-
-            exit_code, return_3, return_4 = dev.arc_msg(0x90, args=[random_arg])
-            print(f"Call 1: exit_code={exit_code:#x}, return_3={return_3:#x}")
-            self.assertEqual(exit_code, 0)
-            self.assertEqual(return_3, expected_value)
-
     def test_get_chip_info(self):
         """Test get_chip_info method."""
         pci_ids = tt_umd.PCIDevice.enumerate_devices()

--- a/nanobind/tests/test_py_tt_device.py
+++ b/nanobind/tests/test_py_tt_device.py
@@ -281,6 +281,42 @@ class TestTTDevice(unittest.TestCase):
             self.assertEqual(return_3, expected_value)
             dev.set_power_state(False)
 
+    def test_arc_msg_test_increment(self):
+        """TEST (0x90) increments arg0 and returns it. Call twice to verify arg passing and return values."""
+        pci_ids = tt_umd.PCIDevice.enumerate_devices()
+        if len(pci_ids) == 0:
+            print("No PCI devices found.")
+            return
+
+        for dev_id in pci_ids:
+            dev = tt_umd.TTDevice.create(dev_id)
+            dev.init_tt_device()
+            arch = dev.get_arch()
+            print(f"Testing arc_msg TEST increment on device {dev_id} with arch {arch}")
+
+            # Test out both arg passing styles (args list vs individual arg) to ensure both work correctly.
+            # Wormhole accepts only two arguments. And both are passed packed into a single uint32 value.
+            # What that means, is that the returned uint32 will contain both.
+            # On blackhole with new arc msg protocol, we have up to 8 arguments each being uint32. So the
+            # test message will only take the actual first argument into consideration.
+            # The TEST message just increments the arg passed.
+            random_arg = 42
+            default_arg_1 = 0xFFFF
+            expected_value = (
+                random_arg
+                + 1
+                + (default_arg_1 << 16 if arch == tt_umd.ARCH.WORMHOLE_B0 else 0)
+            )
+            exit_code, return_3, return_4 = dev.arc_msg(0x90, True, arg0=random_arg)
+            print(f"Call 1: exit_code={exit_code:#x}, return_3={return_3:#x}")
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(return_3, expected_value)
+
+            exit_code, return_3, return_4 = dev.arc_msg(0x90, args=[random_arg])
+            print(f"Call 1: exit_code={exit_code:#x}, return_3={return_3:#x}")
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(return_3, expected_value)
+
     def test_get_chip_info(self):
         """Test get_chip_info method."""
         pci_ids = tt_umd.PCIDevice.enumerate_devices()


### PR DESCRIPTION
### Issue
#1433 
#1432 
#1436 

### Description
Add some missing functionality which makes it easier to integrate with tools

### List of the changes
- Noc broadcast was already added prior to this PR
- Added large_transfer_warning_printed_ so that log_warning is printed once, not on each remote transfer
- Added some python apis, create_constrained_cluster_descriptor, get_pci_interface_id, 
- as_wh and as_bh now return self, to better match luwen and integrate more easily
- default args for arc_msg so calls are not ambiguous
- dedicated section for apis with noc_id 

### Testing
Manual testing, some time ago
TBD test again before merging and bumping a version

### API Changes
This PR has py API changes, mostly additions
