### PR TITLE
[Bug fix] Fix integer overflow in TLB window read/write reconfigure

### DIFF
--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -36,8 +36,8 @@ void TlbWindow::read_block_reconfigure(
 
     while (size > 0) {
         configure(config);
-        uint32_t tlb_size = get_size();
-        uint32_t transfer_size = std::min(size, tlb_size);
+        const size_t tlb_size = get_size();
+        const uint32_t transfer_size = std::min((size_t)size, tlb_size);
 
         read_block(0, buffer_addr, transfer_size);
 
@@ -62,9 +62,8 @@ void TlbWindow::write_block_reconfigure(
 
     while (size > 0) {
         configure(config);
-        uint32_t tlb_size = get_size();
-
-        uint32_t transfer_size = std::min(size, tlb_size);
+        const size_t tlb_size = get_size();
+        const uint32_t transfer_size = std::min((size_t)size, tlb_size);
 
         write_block(0, buffer_addr, transfer_size);
 


### PR DESCRIPTION
Fixes an integer overflow issue in TLB window configuration by correcting type mismatches in `read_block_reconfigure()` and `write_block_reconfigure()`.

The functions were storing the result of `get_size()` (which returns `size_t`) into a `uint32_t` variable, causing overflow when sizes exceeded 32-bit range. The fix uses `size_t` for `tlb_size` to preserve the full value returned by `get_size()`, and casts the `size` parameter to `size_t` when comparing with `tlb_size` in `std::min()`.