### PR TITLE
Add instrumentation to sysmem operations

### DIFF
--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -26,6 +26,7 @@
 #include "assert.hpp"
 #include "cpuset_lib.hpp"
 #include "hugepage.hpp"
+#include "tracy.hpp"
 
 namespace tt::umd {
 
@@ -88,6 +89,7 @@ SiliconSysmemManager::SiliconSysmemManager(TLBManager *tlb_manager, uint32_t num
 }
 
 bool SiliconSysmemManager::pin_or_map_sysmem_to_device() {
+    ZoneScopedC(tracy::Color::Yellow);
     if (tt_device_->get_pci_device()->is_iommu_enabled()) {
         return pin_or_map_iommu();
     } else {
@@ -98,6 +100,7 @@ bool SiliconSysmemManager::pin_or_map_sysmem_to_device() {
 SiliconSysmemManager::~SiliconSysmemManager() { SiliconSysmemManager::unpin_or_unmap_sysmem(); }
 
 bool SiliconSysmemManager::init_sysmem(uint32_t num_host_mem_channels) {
+    ZoneScopedC(tracy::Color::Yellow);
     if (tt_device_->get_pci_device()->is_iommu_enabled()) {
         return init_iommu(num_host_mem_channels);
     } else {
@@ -106,11 +109,13 @@ bool SiliconSysmemManager::init_sysmem(uint32_t num_host_mem_channels) {
 }
 
 void SiliconSysmemManager::unpin_or_unmap_sysmem() {
+    ZoneScopedC(tracy::Color::Yellow);
     // This will unmap the iommu buffer if it was mapped through kmd.
     sysmem_buffer_.reset();
     if (iommu_mapping != nullptr) {
         // This means we have initialized IOMMU mapping, and need to unmap it.
         // It also means that HugepageMappings are faked, so don't unmap them.
+        TracyFreeN(iommu_mapping, "Sysmem");
         munmap(iommu_mapping, iommu_mapping_size);
         iommu_mapping = nullptr;
     } else {
@@ -128,6 +133,7 @@ void SiliconSysmemManager::unpin_or_unmap_sysmem() {
             if (HugepageMapping.mapping) {
                 // Note that we mmap full hugepage, but don't map it filly to NOC.
                 // So the hack for 4th hugepage channel is not present in this branch.
+                TracyFreeN(HugepageMapping.mapping, "Hugepage");
                 munmap(HugepageMapping.mapping, HugepageMapping.mapping_size);
             }
         }
@@ -234,6 +240,7 @@ bool SiliconSysmemManager::init_hugepages(uint32_t num_host_mem_channels) {
         }
 
         hugepage_mapping_per_channel[ch] = {mapping, hugepage_size, 0};
+        TracyAllocN(mapping, hugepage_size, "Hugepage");
     }
 
     return success;
@@ -334,6 +341,7 @@ bool SiliconSysmemManager::init_iommu(uint32_t num_fake_mem_channels) {
             size,
             strerror(errno));
     }
+    TracyAllocN(iommu_mapping, iommu_mapping_size, "Sysmem");
 
     hugepage_mapping_per_channel.resize(num_fake_mem_channels);
 
@@ -395,6 +403,7 @@ void SiliconSysmemManager::print_file_contents(const std::string &filename, cons
 
 std::unique_ptr<SysmemBuffer> SiliconSysmemManager::allocate_sysmem_buffer(
     size_t sysmem_buffer_size, const bool map_to_noc) {
+    ZoneScopedC(tracy::Color::Yellow);
     void *mapping = mmap_with_hugepage_fallback(sysmem_buffer_size);
     if (mapping == MAP_FAILED) {
         TT_THROW("Failed to allocate sysmem buffer of size {:#x} bytes with mmap.", sysmem_buffer_size);

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -18,6 +18,7 @@
 #include "assert.hpp"
 #include "cpuset_lib.hpp"
 #include "hugepage.hpp"
+#include "tracy.hpp"
 
 namespace tt::umd {
 
@@ -27,6 +28,7 @@ SimulationSysmemManager::SimulationSysmemManager(uint32_t num_host_mem_channels,
 }
 
 bool SimulationSysmemManager::init_sysmem(uint32_t num_host_mem_channels) {
+    ZoneScopedC(tracy::Color::Yellow);
     if (num_host_mem_channels == 0) {
         return true;
     }
@@ -62,6 +64,7 @@ bool SimulationSysmemManager::pin_or_map_sysmem_to_device() { return true; }
 SimulationSysmemManager::~SimulationSysmemManager() { SimulationSysmemManager::unpin_or_unmap_sysmem(); }
 
 void SimulationSysmemManager::unpin_or_unmap_sysmem() {
+    ZoneScopedC(tracy::Color::Yellow);
     hugepage_mapping_per_channel.clear();
     if (system_memory_ != nullptr) {
         munmap(system_memory_, system_memory_size_);

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -14,6 +14,7 @@
 
 #include "assert.hpp"
 #include "noc_access.hpp"
+#include "tracy.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 
@@ -29,9 +30,11 @@ SysmemBuffer::SysmemBuffer(TLBManager* tlb_manager, void* buffer_va, size_t buff
         device_io_addr_ = pci_device->map_for_dma(buffer_va_, mapped_buffer_size_);
         noc_addr_ = std::nullopt;
     }
+    TracyAllocN(buffer_va_, mapped_buffer_size_, "SysmemBuffer");
 }
 
 void SysmemBuffer::dma_write_to_device(const size_t offset, size_t size, const tt_xy_pair core, uint64_t addr) {
+    ZoneScopedC(tracy::Color::Yellow);
     TTDevice* tt_device_ = tlb_manager_->get_tt_device();
 
     if (tt_device_->get_pci_device()->get_dma_buffer().buffer == nullptr) {
@@ -87,6 +90,7 @@ void SysmemBuffer::dma_write_to_device(const size_t offset, size_t size, const t
 }
 
 void SysmemBuffer::dma_read_from_device(const size_t offset, size_t size, const tt_xy_pair core, uint64_t addr) {
+    ZoneScopedC(tracy::Color::Yellow);
     TTDevice* tt_device_ = tlb_manager_->get_tt_device();
 
     if (tt_device_->get_pci_device()->get_dma_buffer().buffer == nullptr) {
@@ -141,6 +145,7 @@ void SysmemBuffer::dma_read_from_device(const size_t offset, size_t size, const 
 }
 
 SysmemBuffer::~SysmemBuffer() {
+    TracyFreeN(buffer_va_, "SysmemBuffer");
     try {
         tlb_manager_->get_tt_device()->get_pci_device()->unmap_for_dma(buffer_va_, mapped_buffer_size_);
     } catch (...) {

--- a/device/chip_helpers/sysmem_manager.cpp
+++ b/device/chip_helpers/sysmem_manager.cpp
@@ -17,10 +17,12 @@
 #include "assert.hpp"
 #include "cpuset_lib.hpp"
 #include "hugepage.hpp"
+#include "tracy.hpp"
 
 namespace tt::umd {
 
 void SysmemManager::write_to_sysmem(uint16_t channel, const void *src, uint64_t sysmem_dest, uint32_t size) {
+    ZoneScopedC(tracy::Color::Yellow);
     HugepageMapping hugepage_map = get_hugepage_mapping(channel);
     TT_ASSERT(
         hugepage_map.mapping,
@@ -46,6 +48,7 @@ void SysmemManager::write_to_sysmem(uint16_t channel, const void *src, uint64_t 
 }
 
 void SysmemManager::read_from_sysmem(uint16_t channel, void *dest, uint64_t sysmem_src, uint32_t size) {
+    ZoneScopedC(tracy::Color::Yellow);
     HugepageMapping hugepage_map = get_hugepage_mapping(channel);
     TT_ASSERT(
         hugepage_map.mapping,

--- a/device/common/tracy.hpp
+++ b/device/common/tracy.hpp
@@ -13,4 +13,8 @@
 #define ZoneScopedN(name)
 #define ZoneScopedNC(name, color)
 #define ZoneScopedC(color)
+#define TracyAlloc(ptr, size)
+#define TracyFree(ptr)
+#define TracyAllocN(ptr, size, name)
+#define TracyFreeN(ptr, name)
 #endif


### PR DESCRIPTION
### Issue
#2301

### Description
Add instrumentation to sysmem operations

### List of the changes
 - Added ZoneScoped arround sysmem read/write methods
 - Sysmem memory profiling divided by iommu_enabled on Hugepages and Sysmem
 - SysmemBuffer memory profiling

### Testing
 - CI
 - Visual validation in Tracy GUI

### API Changes
There are no API changes in this PR.
