### PR TITLE
Reduce ttsim clocking from 10 cycles to 1

### DIFF
--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -105,6 +105,8 @@ void TTSimTTDevice::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t ad
     } else {
         communicator_->tile_read_bytes(core.x, core.y, addr, mem_ptr, size);
     }
+    // Ideally we would not auto-clock on reads at all, but some clocking is required to avoid hangs
+    // in the absence of an API reliably called from all spin loops polling the device
     communicator_->advance_clock(1);
 }
 

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -105,7 +105,7 @@ void TTSimTTDevice::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t ad
     } else {
         communicator_->tile_read_bytes(core.x, core.y, addr, mem_ptr, size);
     }
-    communicator_->advance_clock(10);
+    communicator_->advance_clock(1);
 }
 
 void TTSimTTDevice::send_tensix_risc_reset(tt_xy_pair translated_core, const TensixSoftResetOptions& soft_resets) {


### PR DESCRIPTION
### Issue
/

### Description
Many paths do reads from the simulator when no simulator advancement at all is needed (e.g. reshape kernels reading various sharded chunks of data from DRAM), and in these cases, advancing the simulator 10 steps is quite wasteful. This will become even more wasteful with upcoming changes to cause the simulator to do more work per step (for improved simulation performance).

### List of the changes
Reduced number of clocks to advance from 10 to 1.

### Testing
Ran some local ttnn tests

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
