### PR TITLE
Add NOC hang check to init_tt_device

### DIFF
--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -21,8 +21,7 @@ public:
 
     void configure_iatu_region(size_t region, uint64_t target, size_t region_size) override;
 
-    bool wait_arc_core_start(
-        const std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT) noexcept override;
+    void wait_arc_core_start(const std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT) override;
 
     uint32_t get_clock() override;
 

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -44,7 +44,7 @@ public:
     void write_to_arc_apb(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
     void read_from_arc_csm(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
     void write_to_arc_csm(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
-    bool wait_arc_core_start(const std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT) override;
+    void wait_arc_core_start(const std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT) override;
     std::chrono::milliseconds wait_eth_core_training(
         const tt_xy_pair eth_core, const std::chrono::milliseconds timeout_ms = timeout::ETH_TRAINING_TIMEOUT) override;
     EthTrainingStatus read_eth_core_training_status(tt_xy_pair eth_core) override;

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -291,7 +291,7 @@ public:
      * Must be called before using ArcMessenger.
      * This ensures the ARC core is completely initialized and operational.
      */
-    virtual bool wait_arc_core_start(const std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT) = 0;
+    virtual void wait_arc_core_start(const std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT) = 0;
 
     /**
      * Waits for ETH core training to complete.

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -37,16 +37,6 @@ class ArcMessenger;
 class ArcTelemetryReader;
 class RemoteCommunication;
 
-enum class TTDeviceInitResult {
-    UNKNOWN = 0,
-    UNINITIALIZED,
-    ARC_STARTUP_FAILED,
-    ARC_MESSENGER_UNAVAILABLE,
-    ARC_TELEMETRY_UNAVAILABLE,
-    FIRMWARE_INFO_PROVIDER_UNAVAILABLE,
-    SUCCESSFUL,
-};
-
 // Represents the status of the ETH core.
 enum class EthTrainingStatus {
     IN_PROGRESS = 0,
@@ -355,8 +345,7 @@ public:
 
     bool is_remote();
 
-    TTDeviceInitResult init_tt_device(
-        std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT, bool throw_on_arc_failure = true);
+    void init_tt_device(std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT);
 
     uint64_t get_refclk_counter();
 

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -46,7 +46,7 @@ public:
     void write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
     void read_from_arc_csm(void *mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
     void write_to_arc_csm(const void *mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
-    bool wait_arc_core_start(const std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT) override;
+    void wait_arc_core_start(const std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT) override;
     std::chrono::milliseconds wait_eth_core_training(
         const tt_xy_pair eth_core, const std::chrono::milliseconds timeout_ms = timeout::ETH_TRAINING_TIMEOUT) override;
     EthTrainingStatus read_eth_core_training_status(tt_xy_pair eth_core) override;

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -18,8 +18,7 @@ class WormholeTTDevice : public TTDevice {
 public:
     void configure_iatu_region(size_t region, uint64_t target, size_t region_size) override;
 
-    bool wait_arc_core_start(
-        const std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT) noexcept override;
+    void wait_arc_core_start(const std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT) override;
 
     uint32_t get_clock() override;
 

--- a/device/api/umd/device/types/noc_id.hpp
+++ b/device/api/umd/device/types/noc_id.hpp
@@ -5,11 +5,23 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 namespace tt::umd {
 
 // NOC Identifiers that can be selected when communicating with the device.
 enum class NocId : uint8_t { DEFAULT_NOC = 0, NOC0 = 0, NOC1 = 1, SYSTEM_NOC = 2 };
+
+std::string noc_to_str(NocId noc_id) noexcept {
+    switch (noc_id) {
+        case NocId::NOC0:
+            return "NOC0";
+        case NocId::NOC1:
+            return "NOC1";
+        case NocId::SYSTEM_NOC:
+            return "System NOC";
+    }
+}
 
 // Set the NocId for the current thread.
 // All subsequent device communications from this thread will use the selected NocId.

--- a/device/api/umd/device/types/noc_id.hpp
+++ b/device/api/umd/device/types/noc_id.hpp
@@ -12,7 +12,7 @@ namespace tt::umd {
 // NOC Identifiers that can be selected when communicating with the device.
 enum class NocId : uint8_t { DEFAULT_NOC = 0, NOC0 = 0, NOC1 = 1, SYSTEM_NOC = 2 };
 
-std::string noc_to_str(NocId noc_id) noexcept {
+inline std::string noc_to_str(NocId noc_id) noexcept {
     switch (noc_id) {
         case NocId::NOC0:
             return "NOC0";

--- a/device/api/umd/device/types/noc_id.hpp
+++ b/device/api/umd/device/types/noc_id.hpp
@@ -14,6 +14,7 @@ enum class NocId : uint8_t { DEFAULT_NOC = 0, NOC0 = 0, NOC1 = 1, SYSTEM_NOC = 2
 
 inline std::string noc_to_str(NocId noc_id) noexcept {
     switch (noc_id) {
+        // DEFAULT_NOC is missing because it will be removed once stateless NOC in the near future.
         case NocId::NOC0:
             return "NOC0";
         case NocId::NOC1:

--- a/device/api/umd/device/types/noc_id.hpp
+++ b/device/api/umd/device/types/noc_id.hpp
@@ -21,6 +21,7 @@ inline std::string noc_to_str(NocId noc_id) noexcept {
         case NocId::SYSTEM_NOC:
             return "System NOC";
     }
+    return "";
 }
 
 // Set the NocId for the current thread.

--- a/device/api/umd/device/utils/error.hpp
+++ b/device/api/umd/device/utils/error.hpp
@@ -89,6 +89,14 @@ struct NocHangError : UmdError<NocHangData> {
     NocHangError(TTDevice& tt_device, NocId noc_id);
 };
 
+struct PcieHangData : TTDeviceData {
+    uint32_t data_read;
+};
+
+struct PcieHangError : UmdError<TTDeviceData> {
+    PcieHangError(TTDevice& tt_device, uint32_t data_read);
+};
+
 /**
  * @brief Exception thrown when a SIGBUS signal is intercepted.
  * This indicates a hardware access error, likely due to a reset or

--- a/device/api/umd/device/utils/error.hpp
+++ b/device/api/umd/device/utils/error.hpp
@@ -71,12 +71,12 @@ struct ArcStartupError : UmdError<ArcStartupData> {
         uint32_t postcode,
         std::optional<uint32_t> message_id = std::nullopt);
     ArcStartupError(
-        std::chrono::milliseconds timeout,
         TTDevice& tt_device,
         NocId noc_id,
         xy_pair arc_core,
         uint32_t scratch_status,
         uint32_t postcode,
+        std::chrono::milliseconds timeout,
         std::optional<uint32_t> message_id = std::nullopt);
 };
 

--- a/device/api/umd/device/utils/error.hpp
+++ b/device/api/umd/device/utils/error.hpp
@@ -10,7 +10,6 @@
 #include <stdexcept>
 #include <string>
 
-#include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/communication_protocol.hpp"

--- a/device/api/umd/device/utils/error.hpp
+++ b/device/api/umd/device/utils/error.hpp
@@ -4,10 +4,23 @@
 
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <optional>
 #include <stdexcept>
 #include <string>
 
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/communication_protocol.hpp"
+#include "umd/device/types/noc_id.hpp"
+#include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error_detail.hpp"
+
+namespace tt::umd {
+class TTDevice;
+}
 
 namespace tt::umd::error {
 
@@ -28,6 +41,52 @@ struct NoData {};
  */
 struct RuntimeError : public UmdError<NoData> {
     explicit RuntimeError(const std::string& message) : UmdError<NoData>(message, {}) {}
+};
+
+struct TTDeviceData {
+    TTDeviceData(TTDevice& tt_device, std::optional<uint64_t> discovery_unique_id = std::nullopt);
+
+    IODeviceType io_device_type = IODeviceType::UNDEFINED;
+    ChipId chip_id = 0;
+    tt::ARCH arch = tt::ARCH::Invalid;
+    std::optional<uint64_t> discovery_unique_id = std::nullopt;
+};
+
+struct DeviceCoreData : public TTDeviceData {
+    xy_pair core = {0, 0};
+    NocId noc_id = NocId::DEFAULT_NOC;
+};
+
+struct ArcStartupData : public DeviceCoreData {
+    uint32_t scratch_status = 0;
+    uint32_t postcode = 0;
+    std::optional<uint32_t> message_id = std::nullopt;
+};
+
+struct ArcStartupError : UmdError<ArcStartupData> {
+    ArcStartupError(
+        TTDevice& tt_device,
+        NocId noc_id,
+        xy_pair arc_core,
+        uint32_t scratch_status,
+        uint32_t postcode,
+        std::optional<uint32_t> message_id = std::nullopt);
+    ArcStartupError(
+        std::chrono::milliseconds timeout,
+        TTDevice& tt_device,
+        NocId noc_id,
+        xy_pair arc_core,
+        uint32_t scratch_status,
+        uint32_t postcode,
+        std::optional<uint32_t> message_id = std::nullopt);
+};
+
+struct NocHangData : TTDeviceData {
+    NocId noc_id = NocId::DEFAULT_NOC;
+};
+
+struct NocHangError : UmdError<NocHangData> {
+    NocHangError(TTDevice& tt_device, NocId noc_id);
 };
 
 /**

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -36,11 +36,7 @@ std::unique_ptr<LocalChip> LocalChip::create(
     ZoneScopedC(tracy::Color::DarkGreen);
     // Create TTDevice and make sure the arc is ready so we can read its telemetry.
     auto tt_device = TTDevice::create(physical_device_id, device_type);
-    TTDeviceInitResult init_result = tt_device->init_tt_device();
-    if (init_result != TTDeviceInitResult::SUCCESSFUL) {
-        throw std::runtime_error(fmt::format(
-            "Failed to initialize TTDevice for device {}: {}", physical_device_id, static_cast<int>(init_result)));
-    }
+    tt_device->init_tt_device();
 
     SocDescriptor soc_descriptor;
     if (sdesc_path.empty()) {
@@ -60,11 +56,7 @@ std::unique_ptr<LocalChip> LocalChip::create(
     // physical_device_id is not actually physical for JTAG devices here.
     // It represents the index within a vector of jlink devices discovered by JtagDevice.
     auto tt_device = TTDevice::create(physical_device_id, device_type);
-    TTDeviceInitResult init_result = tt_device->init_tt_device();
-    if (init_result != TTDeviceInitResult::SUCCESSFUL) {
-        throw std::runtime_error(fmt::format(
-            "Failed to initialize TTDevice for device {}: {}", physical_device_id, static_cast<int>(init_result)));
-    }
+    tt_device->init_tt_device();
 
     return LocalChip::create(std::move(tt_device), soc_descriptor, num_host_mem_channels);
 }

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -41,11 +41,7 @@ std::unique_ptr<RemoteChip> RemoteChip::create(
         local_chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(
             remote_transfer_eth_channels, CoordSystem::TRANSLATED));
     auto remote_tt_device = TTDevice::create(std::move(remote_communication));
-    TTDeviceInitResult init_result = remote_tt_device->init_tt_device();
-    if (init_result != TTDeviceInitResult::SUCCESSFUL) {
-        throw std::runtime_error(
-            fmt::format("Failed to initialize remote TTDevice: {}", static_cast<int>(init_result)));
-    }
+    remote_tt_device->init_tt_device();
 
     SocDescriptor soc_descriptor;
     if (sdesc_path.empty()) {
@@ -72,11 +68,7 @@ std::unique_ptr<RemoteChip> RemoteChip::create(
         local_chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(
             remote_transfer_eth_channels, CoordSystem::TRANSLATED));
     auto remote_tt_device = TTDevice::create(std::move(remote_communication));
-    TTDeviceInitResult init_result = remote_tt_device->init_tt_device();
-    if (init_result != TTDeviceInitResult::SUCCESSFUL) {
-        throw std::runtime_error(
-            fmt::format("Failed to initialize remote TTDevice: {}", static_cast<int>(init_result)));
-    }
+    remote_tt_device->init_tt_device();
 
     return std::unique_ptr<RemoteChip>(
         new RemoteChip(std::move(soc_descriptor), local_chip, std::move(remote_tt_device)));

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -28,6 +28,8 @@
 #include "umd/device/types/blackhole_eth.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/telemetry.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "utils.hpp"
 
 namespace tt::umd {
@@ -172,16 +174,18 @@ ChipInfo BlackholeTTDevice::get_chip_info() {
     return chip_info;
 }
 
-bool BlackholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeout_ms) noexcept {
-    uint32_t arc_boot_status;
+void BlackholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeout_ms) {
+    uint32_t arc_boot_status = 0;
+    uint32_t arc_postcode = 0;
     const auto start = std::chrono::steady_clock::now();
     constexpr auto spin_limit = std::chrono::microseconds(1000);
     while (true) {
         read_from_arc_apb(&arc_boot_status, blackhole::SCRATCH_RAM_2, sizeof(arc_boot_status));
+        read_from_arc_apb(&arc_postcode, architecture_impl_->get_arc_reset_scratch_offset(), sizeof(arc_boot_status));
 
         // ARC started successfully.
         if ((arc_boot_status & 0x7) == 0x5) {
-            return true;
+            return;
         }
 
         auto elapsed = std::chrono::steady_clock::now() - start;
@@ -191,21 +195,27 @@ bool BlackholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds time
         if (elapsed < spin_limit) {
             // Optional: For 0ms timeouts, check manually here without strings.
             if (elapsed > timeout_ms) {
-                return false;
+                UMD_THROW(
+                    error::ArcStartupError,
+                    timeout_ms,
+                    *this,
+                    get_selected_noc_id(),
+                    arc_core,
+                    arc_boot_status,
+                    arc_postcode);
             }
             continue;
         }
 
-        if (utils::check_timeout(
-                start,
+        if (utils::check_timeout(start, timeout_ms)) {
+            UMD_THROW(
+                error::ArcStartupError,
                 timeout_ms,
-                fmt::format(
-                    "ARC core {} startup timed out after: {}. Status: 0x{:x}",
-                    arc_core.str(),
-                    timeout_ms.count(),
-                    arc_boot_status),
-                utils::TimeoutAction::Return)) {
-            return false;
+                *this,
+                get_selected_noc_id(),
+                arc_core,
+                arc_boot_status,
+                arc_postcode);
         }
 
         // If past 200us, avoid busy-waiting. Request a 10us sleep (minimum) -

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -197,12 +197,12 @@ void BlackholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds time
             if (elapsed > timeout_ms) {
                 UMD_THROW(
                     error::ArcStartupError,
-                    timeout_ms,
                     *this,
                     get_selected_noc_id(),
                     arc_core,
                     arc_boot_status,
-                    arc_postcode);
+                    arc_postcode,
+                    timeout_ms);
             }
             continue;
         }
@@ -210,12 +210,12 @@ void BlackholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds time
         if (utils::check_timeout(start, timeout_ms)) {
             UMD_THROW(
                 error::ArcStartupError,
-                timeout_ms,
                 *this,
                 get_selected_noc_id(),
                 arc_core,
                 arc_boot_status,
-                arc_postcode);
+                arc_postcode,
+                timeout_ms);
         }
 
         // If past 200us, avoid busy-waiting. Request a 10us sleep (minimum) -

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -222,9 +222,8 @@ void RtlSimulationTTDevice::write_to_arc_csm(
     TT_THROW("write_to_arc_csm not supported for RTL simulation");
 }
 
-bool RtlSimulationTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeout_ms) {
+void RtlSimulationTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeout_ms) {
     // RTL simulation doesn't have ARC cores in the same way.
-    return true;
 }
 
 std::chrono::milliseconds RtlSimulationTTDevice::wait_eth_core_training(

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -106,12 +106,10 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     bool noc_hang_check_result =
         hang_detector_->is_noc_hung(is_selected_noc1() ? NocId::NOC1 : NocId::NOC0).value_or(false);
     if (noc_hang_check_result) {
-        UMD_THROW(error::RuntimeError, fmt::format("NOC{} is hung.", is_selected_noc1() ? "1" : "0"));
+        UMD_THROW(error::NocHangError, *this, is_selected_noc1() ? NocId::NOC1 : NocId::NOC0);
     }
     probe_arc();
-    if (!wait_arc_core_start(timeout_ms)) {
-        UMD_THROW(error::RuntimeError, fmt::format("ARC core {} failed to start.", arc_core.str()));
-    }
+    wait_arc_core_start(timeout_ms);
     arc_messenger_ = ArcMessenger::create_arc_messenger(this);
     telemetry = ArcTelemetryReader::create_arc_telemetry_reader(this);
     firmware_info_provider = FirmwareInfoProvider::create_firmware_info_provider(this);

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -104,8 +104,8 @@ void TTDevice::probe_arc() {
 void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     ZoneScopedC(tracy::Color::DarkGreen);
     bool noc_hang_check_result =
-        hang_detector_->is_noc_hung(is_selected_noc1() ? NocId::NOC1 : NocId::NOC0).value_or(true);
-    if (!noc_hang_check_result) {
+        hang_detector_->is_noc_hung(is_selected_noc1() ? NocId::NOC1 : NocId::NOC0).value_or(false);
+    if (noc_hang_check_result) {
         UMD_THROW(error::RuntimeError, fmt::format("NOC{} is hung.", is_selected_noc1() ? "1" : "0"));
     }
     probe_arc();

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -103,6 +103,9 @@ void TTDevice::probe_arc() {
 
 void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     ZoneScopedC(tracy::Color::DarkGreen);
+    if (has_pcie_interface()) {
+        is_pcie_hung();
+    }
     bool noc_hang_check_result =
         hang_detector_->is_noc_hung(is_selected_noc1() ? NocId::NOC1 : NocId::NOC0).value_or(false);
     if (noc_hang_check_result) {
@@ -208,7 +211,7 @@ bool TTDevice::is_pcie_hung(std::uint32_t data_read, TTDevice::HangAction action
     }
     if (result.value()) {
         if (action == TTDevice::HangAction::THROW) {
-            throw std::runtime_error("Read 0xffffffff from PCIe: you should reset the board.");
+            UMD_THROW(error::PcieHangError, *this, data_read);
         }
         return true;
     }

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -103,7 +103,7 @@ void TTDevice::probe_arc() {
 
 void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     ZoneScopedC(tracy::Color::DarkGreen);
-    if (has_pcie_interface()) {
+    if (pcie_capabilities_ != nullptr) {
         is_pcie_hung();
     }
     bool noc_hang_check_result =

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -96,32 +96,15 @@ void TTDevice::probe_arc() {
     read_from_arc_apb(&dummy, architecture_impl_->get_arc_reset_scratch_offset(), sizeof(dummy));  // SCRATCH_0
 }
 
-TTDeviceInitResult TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms, bool throw_on_arc_failure) {
+void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     ZoneScopedC(tracy::Color::DarkGreen);
     probe_arc();
     if (!wait_arc_core_start(timeout_ms)) {
-        if (throw_on_arc_failure) {
-            throw std::runtime_error(fmt::format("ARC core ({}, {}) failed to start.", arc_core.x, arc_core.y));
-        } else {
-            return TTDeviceInitResult::ARC_STARTUP_FAILED;
-        }
+        throw std::runtime_error(fmt::format("ARC core ({}, {}) failed to start.", arc_core.x, arc_core.y));
     }
-    try {
-        arc_messenger_ = ArcMessenger::create_arc_messenger(this);
-    } catch (const std::runtime_error &e) {
-        return TTDeviceInitResult::ARC_MESSENGER_UNAVAILABLE;
-    }
-    try {
-        telemetry = ArcTelemetryReader::create_arc_telemetry_reader(this);
-    } catch (const std::runtime_error &e) {
-        return TTDeviceInitResult::ARC_TELEMETRY_UNAVAILABLE;
-    }
-    try {
-        firmware_info_provider = FirmwareInfoProvider::create_firmware_info_provider(this);
-    } catch (const std::runtime_error &e) {
-        return TTDeviceInitResult::FIRMWARE_INFO_PROVIDER_UNAVAILABLE;
-    }
-    return TTDeviceInitResult::SUCCESSFUL;
+    arc_messenger_ = ArcMessenger::create_arc_messenger(this);
+    telemetry = ArcTelemetryReader::create_arc_telemetry_reader(this);
+    firmware_info_provider = FirmwareInfoProvider::create_firmware_info_provider(this);
 }
 
 /* static */ std::unique_ptr<TTDevice> TTDevice::create(

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -4,6 +4,8 @@
 
 #include "umd/device/tt_device/tt_device.hpp"
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
@@ -32,7 +34,10 @@
 #include "umd/device/tt_device/remote_wormhole_tt_device.hpp"
 #include "umd/device/tt_device/wormhole_tt_device.hpp"
 #include "umd/device/types/communication_protocol.hpp"
+#include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/telemetry.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "umd/device/utils/lock_manager.hpp"
 #include "umd/device/utils/semver.hpp"
 #include "utils.hpp"
@@ -98,9 +103,14 @@ void TTDevice::probe_arc() {
 
 void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     ZoneScopedC(tracy::Color::DarkGreen);
+    bool noc_hang_check_result =
+        hang_detector_->is_noc_hung(is_selected_noc1() ? NocId::NOC1 : NocId::NOC0).value_or(true);
+    if (!noc_hang_check_result) {
+        UMD_THROW(error::RuntimeError, fmt::format("NOC{} is hung.", is_selected_noc1() ? "1" : "0"));
+    }
     probe_arc();
     if (!wait_arc_core_start(timeout_ms)) {
-        throw std::runtime_error(fmt::format("ARC core ({}, {}) failed to start.", arc_core.x, arc_core.y));
+        UMD_THROW(error::RuntimeError, fmt::format("ARC core {} failed to start.", arc_core.str()));
     }
     arc_messenger_ = ArcMessenger::create_arc_messenger(this);
     telemetry = ArcTelemetryReader::create_arc_telemetry_reader(this);

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -206,7 +206,7 @@ void TTSimTTDevice::write_to_arc_csm(const void* mem_ptr, uint64_t arc_addr_offs
     throw std::runtime_error("ARC CSM access is not supported in TTSim simulation device.");
 }
 
-bool TTSimTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeout_ms) {
+void TTSimTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeout_ms) {
     throw std::runtime_error("Waiting for ARC core start is not supported in TTSim simulation device.");
 }
 

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -27,6 +27,8 @@
 #include "umd/device/types/wormhole_eth.hpp"
 #include "umd/device/types/wormhole_telemetry.hpp"
 #include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "utils.hpp"
 
 namespace tt::umd {
@@ -275,7 +277,7 @@ void WormholeTTDevice::retrain_eth_core(tt_xy_pair eth_core) {
     write_to_device(&trigger_val, eth_core, wormhole::ETH_RETRAIN_ADDR, sizeof(uint32_t));
 }
 
-bool WormholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeout_ms) noexcept {
+void WormholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeout_ms) {
     // Status codes.
     constexpr uint32_t STATUS_NO_ACCESS = 0xFFFFFFFF;
     constexpr uint32_t STATUS_WATCHDOG_TRIGGERED = 0xDEADC0DE;
@@ -324,22 +326,25 @@ bool WormholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeo
 
         switch (bar_read_arc_reset_scratch_status) {
             case STATUS_NO_ACCESS:
-                log_error(LogUMD, "NoAccess error");
-                return false;
             case STATUS_WATCHDOG_TRIGGERED:
-                log_error(LogUMD, "WatchdogTriggered error");
-                return false;
+                UMD_THROW(
+                    error::ArcStartupError,
+                    *this,
+                    get_selected_noc_id(),
+                    arc_core,
+                    bar_read_arc_reset_scratch_status,
+                    bar_read_arc_post_code);
 
             case STATUS_INIT_DONE_1:
             case STATUS_INIT_DONE_2:
-                return true;
+                return;
 
             case STATUS_OLD_POST_CODE: {
                 bool pc_idle = (bar_read_arc_post_code == POST_CODE_INIT_DONE) ||
                                (bar_read_arc_post_code >= POST_CODE_ARC_MSG_HANDLE_DONE &&
                                 bar_read_arc_post_code <= POST_CODE_ARC_TIME_LAST);
                 if (pc_idle) {
-                    return true;
+                    return;
                 }
                 break;
             }
@@ -365,8 +370,8 @@ bool WormholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeo
         } else if (is_handling) {
             message_id = (bar_read_arc_reset_scratch_status >> 16) & 0xFF;
         } else if (is_complete && !dma_request) {
-            // We only return true if the message says complete and DMA is idle.
-            return true;
+            // We only return if the message says complete and DMA is idle.
+            return;
         }
 
         auto elapsed = std::chrono::steady_clock::now() - start;
@@ -376,23 +381,29 @@ bool WormholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeo
         if (elapsed < spin_limit) {
             // Optional: For 0ms timeouts, check manually here without strings.
             if (elapsed > timeout_ms) {
-                return false;
+                UMD_THROW(
+                    error::ArcStartupError,
+                    timeout_ms,
+                    *this,
+                    get_selected_noc_id(),
+                    arc_core,
+                    bar_read_arc_reset_scratch_status,
+                    bar_read_arc_post_code,
+                    message_id);
             }
             continue;
         }
 
-        if (utils::check_timeout(
-                start,
+        if (utils::check_timeout(start, timeout_ms)) {
+            UMD_THROW(
+                error::ArcStartupError,
                 timeout_ms,
-                fmt::format(
-                    "ARC core {} startup timed out after: {}. Status: 0x{:x}, PostCode: 0x{:x}, MessageId 0x{:x}",
-                    arc_core.str(),
-                    timeout_ms.count(),
-                    bar_read_arc_reset_scratch_status,
-                    bar_read_arc_post_code,
-                    message_id),
-                utils::TimeoutAction::Return)) {
-            return false;
+                *this,
+                get_selected_noc_id(),
+                arc_core,
+                bar_read_arc_reset_scratch_status,
+                bar_read_arc_post_code,
+                message_id);
         }
 
         // If past 200us, avoid busy-waiting. Request a 10us sleep (minimum) -

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -383,12 +383,12 @@ void WormholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeo
             if (elapsed > timeout_ms) {
                 UMD_THROW(
                     error::ArcStartupError,
-                    timeout_ms,
                     *this,
                     get_selected_noc_id(),
                     arc_core,
                     bar_read_arc_reset_scratch_status,
                     bar_read_arc_post_code,
+                    timeout_ms,
                     message_id);
             }
             continue;
@@ -397,12 +397,12 @@ void WormholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeo
         if (utils::check_timeout(start, timeout_ms)) {
             UMD_THROW(
                 error::ArcStartupError,
-                timeout_ms,
                 *this,
                 get_selected_noc_id(),
                 arc_core,
                 bar_read_arc_reset_scratch_status,
                 bar_read_arc_post_code,
+                timeout_ms,
                 message_id);
         }
 

--- a/device/utils/error.cpp
+++ b/device/utils/error.cpp
@@ -22,6 +22,14 @@ TTDeviceData::TTDeviceData(TTDevice& tt_device, std::optional<uint64_t> discover
 NocHangError::NocHangError(TTDevice& tt_device, NocId noc_id) :
     UmdError<NocHangData>(fmt::format("{} is hung.", noc_to_str(noc_id)), {{tt_device}, noc_id}) {}
 
+PcieHangError::PcieHangError(TTDevice& tt_device, uint32_t data_read) :
+    UmdError<TTDeviceData>(
+        fmt::format(
+            "Read {:#x} over PCIe ID {}: the board should be reset.",
+            data_read,
+            tt_device.get_communication_device_id()),
+        {{tt_device}, data_read}) {}
+
 ArcStartupError::ArcStartupError(
     TTDevice& tt_device,
     NocId noc_id,

--- a/device/utils/error.cpp
+++ b/device/utils/error.cpp
@@ -6,7 +6,56 @@
 
 #include <fmt/format.h>
 
-namespace tt::umd::error {
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/noc_id.hpp"
+
 using namespace tt::umd;
+
+namespace tt::umd::error {
+
+TTDeviceData::TTDeviceData(TTDevice& tt_device, std::optional<uint64_t> discovery_unique_id) :
+    io_device_type(tt_device.get_communication_device_type()),
+    chip_id(tt_device.get_communication_device_id()),
+    arch(tt_device.get_arch()),
+    discovery_unique_id(discovery_unique_id) {}
+
+NocHangError::NocHangError(TTDevice& tt_device, NocId noc_id) :
+    UmdError<NocHangData>(fmt::format("{} is hung.", noc_to_str(noc_id)), {{tt_device}, noc_id}) {}
+
+ArcStartupError::ArcStartupError(
+    TTDevice& tt_device,
+    NocId noc_id,
+    xy_pair arc_core,
+    uint32_t scratch_status,
+    uint32_t postcode,
+    std::optional<uint32_t> message_id) :
+    UmdError<ArcStartupData>(
+        fmt::format(
+            "ARC startup error at core {} over {}: scratch_status={:#x}, postcode={:#x}{}",
+            arc_core.str(),
+            noc_to_str(noc_id),
+            scratch_status,
+            postcode,
+            message_id.has_value() ? fmt::format(", message_id={:#x}", message_id.value()) : ""),
+        {{{tt_device}, arc_core, noc_id}, scratch_status, postcode, message_id}) {}
+
+ArcStartupError::ArcStartupError(
+    std::chrono::milliseconds timeout,
+    TTDevice& tt_device,
+    NocId noc_id,
+    xy_pair arc_core,
+    uint32_t scratch_status,
+    uint32_t postcode,
+    std::optional<uint32_t> message_id) :
+    UmdError<ArcStartupData>(
+        fmt::format(
+            "ARC startup timed out after {} ms on core {} over {}: scratch_status={:#x}, postcode={:#x}{}",
+            timeout.count(),
+            arc_core.str(),
+            noc_to_str(noc_id),
+            scratch_status,
+            postcode,
+            message_id.has_value() ? fmt::format(", message_id={:#x}", message_id.value()) : ""),
+        {{{tt_device}, arc_core, noc_id}, scratch_status, postcode, message_id}) {}
 
 }  // namespace tt::umd::error

--- a/device/utils/error.cpp
+++ b/device/utils/error.cpp
@@ -48,22 +48,15 @@ ArcStartupError::ArcStartupError(
         {{{tt_device}, arc_core, noc_id}, scratch_status, postcode, message_id}) {}
 
 ArcStartupError::ArcStartupError(
-    std::chrono::milliseconds timeout,
     TTDevice& tt_device,
     NocId noc_id,
     xy_pair arc_core,
     uint32_t scratch_status,
     uint32_t postcode,
+    std::chrono::milliseconds timeout,
     std::optional<uint32_t> message_id) :
-    UmdError<ArcStartupData>(
-        fmt::format(
-            "ARC startup timed out after {} ms on core {} over {}: scratch_status={:#x}, postcode={:#x}{}",
-            timeout.count(),
-            arc_core.str(),
-            noc_to_str(noc_id),
-            scratch_status,
-            postcode,
-            message_id.has_value() ? fmt::format(", message_id={:#x}", message_id.value()) : ""),
-        {{{tt_device}, arc_core, noc_id}, scratch_status, postcode, message_id}) {}
+    ArcStartupError(tt_device, noc_id, arc_core, scratch_status, postcode, message_id) {
+    message().append(fmt::format(" (Timed out after {} ms)", timeout.count()));
+}
 
 }  // namespace tt::umd::error

--- a/device/warm_reset.cpp
+++ b/device/warm_reset.cpp
@@ -37,6 +37,7 @@
 #include "api/umd/device/pcie/pci_device.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
+#include "umd/device/utils/error.hpp"
 #include "umd/device/utils/timeouts.hpp"
 #include "utils.hpp"
 
@@ -301,8 +302,10 @@ bool WarmReset::warm_reset_wormhole_legacy(std::vector<int> pci_device_ids, bool
 
     for (auto& i : pci_device_ids) {
         auto tt_device = TTDevice::create(i);
-        if (!tt_device->wait_arc_core_start(timeout::ARC_LONG_POST_RESET_TIMEOUT)) {
-            log_warning(tt::LogUMD, "Reset failed for PCI id {} - ARC core init failed", i);
+        try {
+            tt_device->wait_arc_core_start(timeout::ARC_LONG_POST_RESET_TIMEOUT);
+        } catch (error::ArcStartupError& arc_error) {
+            log_warning(LogUMD, arc_error.message());
             continue;
         }
         tt_devices.emplace_back(std::move(tt_device));

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -83,15 +83,6 @@ void bind_tt_device(nb::module_ &m) {
         .def_ro("pci_bdf", &PciDeviceInfo::pci_bdf)
         .def("get_arch", &PciDeviceInfo::get_arch);
 
-    nb::enum_<TTDeviceInitResult>(m, "TTDeviceInitResult")
-        .value("UNKNOWN", TTDeviceInitResult::UNKNOWN)
-        .value("UNINITIALIZED", TTDeviceInitResult::UNINITIALIZED)
-        .value("ARC_STARTUP_FAILED", TTDeviceInitResult::ARC_STARTUP_FAILED)
-        .value("ARC_MESSENGER_UNAVAILABLE", TTDeviceInitResult::ARC_MESSENGER_UNAVAILABLE)
-        .value("ARC_TELEMETRY_UNAVAILABLE", TTDeviceInitResult::ARC_TELEMETRY_UNAVAILABLE)
-        .value("FIRMWARE_INFO_PROVIDER_UNAVAILABLE", TTDeviceInitResult::FIRMWARE_INFO_PROVIDER_UNAVAILABLE)
-        .value("SUCCESSFUL", TTDeviceInitResult::SUCCESSFUL);
-
     nb::class_<PCIDevice>(m, "PCIDevice")
         .def(nb::init<int>())
         .def_static(
@@ -142,11 +133,7 @@ void bind_tt_device(nb::module_ &m) {
             nb::arg("use_safe_api") = true,
             nb::rv_policy::take_ownership)
         .def("set_power_state", &TTDevice::set_power_state, nb::arg("busy"))
-        .def(
-            "init_tt_device",
-            &TTDevice::init_tt_device,
-            nb::arg("timeout_ms") = timeout::ARC_STARTUP_TIMEOUT,
-            nb::arg("throw_on_arc_failure") = true)
+        .def("init_tt_device", &TTDevice::init_tt_device, nb::arg("timeout_ms") = timeout::ARC_STARTUP_TIMEOUT)
         .def("get_chip_info", &TTDevice::get_chip_info)
         .def("get_arc_telemetry_reader", &TTDevice::get_arc_telemetry_reader, nb::rv_policy::reference_internal)
         .def("get_arch", &TTDevice::get_arch)


### PR DESCRIPTION
### Issue
#2388 

### Description
Adds a NOC hang check and PCIe hang check in `init_tt_device()`. The function will throw if the currently selected NOC is hung or the PCIe interface to the device is hung. A `NocHangError` can be caught to signify the user should use a different NOC.

### List of the changes
- Added checking for NOC hangs in `init_tt_device()`.
- Removed `TTDeviceInitResult`. `init_tt_device()` returns void or throws errors.
- Introduced new error types `NocHangError`, `PCIeHangError` and `ArcStartupError`.
- Utility function `noc_to_str()`.

### Testing
CI, manual testing.

### API Changes
This PR has API changes.
