### PR TITLE
Opportunistically use hugepages for simulated system memory

### DIFF
--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -46,6 +46,7 @@ bool SimulationSysmemManager::init_sysmem(uint32_t num_host_mem_channels) {
     system_memory_ =
         static_cast<uint8_t *>(mmap(nullptr, total_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
     TT_ASSERT(system_memory_ != MAP_FAILED, "system_memory mmap() failed");
+    madvise(system_memory_, total_size, MADV_HUGEPAGE);
     system_memory_size_ = total_size;
 
     for (int i = 0; i < num_host_mem_channels; i++) {


### PR DESCRIPTION
### Issue
/

### Description
For very large zeroed CoW memory buffers like this, 2MB pages are generally a win to avoid large numbers of page faults. A similar change was already made inside ttsim and found to be a performance win.

### List of the changes
Call madvise() on the mmap() buffer to set MADV_HUGEPAGE. OK if madvise fails.

### Testing
CI testing only

### API Changes
There are no API changes in this PR.