### PR TITLE
Add Quasar simulation SoC descriptors

### DIFF
--- a/tests/soc_descs/quasar_simulation_1x3.yaml
+++ b/tests/soc_descs/quasar_simulation_1x3.yaml
@@ -1,0 +1,46 @@
+grid:
+  x_size: 1
+  y_size: 3
+
+arc:
+  []
+
+pcie:
+  []
+
+dram:
+  [[0-0]]
+
+eth:
+  []
+
+functional_workers:
+  [0-1]
+
+harvested_workers:
+  []
+
+router_only:
+  [0-2]
+
+worker_l1_size:
+  4194304
+
+dram_bank_size:
+  1073741824
+
+eth_l1_size:
+  0
+
+arch_name: QUASAR
+
+features:
+  unpacker:
+    version: 1
+    inline_srca_trans_without_srca_trans_instr: False
+  math:
+    dst_size_alignment: 32768
+  packer:
+    version: 1
+  overlay:
+    version: 1

--- a/tests/soc_descs/quasar_simulation_2x3.yaml
+++ b/tests/soc_descs/quasar_simulation_2x3.yaml
@@ -1,0 +1,46 @@
+grid:
+  x_size: 2
+  y_size: 3
+
+arc:
+  []
+
+pcie:
+  []
+
+dram:
+  [[1-0], [0-0]]
+
+eth:
+  []
+
+functional_workers:
+  [0-1, 1-1]
+
+harvested_workers:
+  []
+
+router_only:
+  [1-2, 2-2]
+
+worker_l1_size:
+  4194304
+
+dram_bank_size:
+  1073741824
+
+eth_l1_size:
+  0
+
+arch_name: QUASAR
+
+features:
+  unpacker:
+    version: 1
+    inline_srca_trans_without_srca_trans_instr: False
+  math:
+    dst_size_alignment: 32768
+  packer:
+    version: 1
+  overlay:
+    version: 1

--- a/tests/test_utils/fetch_local_files.hpp
+++ b/tests/test_utils/fetch_local_files.hpp
@@ -74,6 +74,8 @@ inline std::vector<std::string> GetAllSocDescs() {
              "wormhole_b0_8x10.yaml",
              "wormhole_b0_one_dram_one_tensix_no_eth.yaml",
              "quasar_32_arch.yaml",
+             "quasar_simulation_1x3.yaml",
+             "quasar_simulation_2x3.yaml",
          }) {
         soc_desc_names.push_back(GetSocDescAbsPath(soc_desc_name));
     }


### PR DESCRIPTION
### Issue
/

### Description
Add Quasar simulation SoC descriptors for 1x3 and 2x3 grid configurations.

### List of the changes
- Add `quasar_simulation_1x3.yaml` SoC descriptor (1x3 grid, 1 DRAM bank, 1 functional worker)
- Add `quasar_simulation_2x3.yaml` SoC descriptor (2x3 grid, 2 DRAM banks, 2 functional workers)
- Register new descriptors in `fetch_local_files.hpp` test utility

### Testing
CI

### API Changes
There are no API changes in this PR.