### PR TITLE
Add dispatch engine core type to CoreType and SoC descriptor

### DIFF
--- a/device/api/umd/device/arch/grendel_implementation.hpp
+++ b/device/api/umd/device/arch/grendel_implementation.hpp
@@ -146,6 +146,9 @@ static const std::vector<tt_xy_pair> SECURITY_CORES_NOC0 = {{8, 2}};
 // We are using P0 on the NOC for all L2CPU cores.
 static const std::vector<tt_xy_pair> L2CPU_CORES_NOC0 = {{8, 3}, {8, 5}, {8, 7}, {8, 9}};
 
+// TODO: Placeholder coordinates — update once dispatch engine NOC positions are finalized.
+static const std::vector<tt_xy_pair> DISPATCH_CORES_NOC0 = {};
+
 // Return to std::array instead of std::vector once we get std::span support in C++20.
 static const std::vector<uint32_t> T6_X_LOCATIONS = {1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13, 14, 15, 16};
 static const std::vector<uint32_t> T6_Y_LOCATIONS = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
@@ -258,7 +261,7 @@ inline constexpr uint32_t TENSIX_L1_SIZE = 1572864;
 inline constexpr uint32_t ETH_L1_SIZE = 262144;
 inline constexpr uint64_t DRAM_BANK_SIZE = 4294967296;
 
-inline constexpr std::array<std::pair<CoreType, uint64_t>, 8> NOC0_CONTROL_REG_ADDR_BASE_MAP = {
+inline constexpr std::array<std::pair<CoreType, uint64_t>, 9> NOC0_CONTROL_REG_ADDR_BASE_MAP = {
     {{CoreType::TENSIX, 0xFFB20000},
      {CoreType::ETH, 0xFFB20000},
      {CoreType::DRAM, 0xFFB20000},
@@ -266,8 +269,9 @@ inline constexpr std::array<std::pair<CoreType, uint64_t>, 8> NOC0_CONTROL_REG_A
      {CoreType::ARC, 0xFFFFFFFFFF000000ULL},
      {CoreType::SECURITY, 0xFFFFFFFFFF000000ULL},
      {CoreType::L2CPU, 0xFFFFFFFFFF000000ULL},
+     {CoreType::DISPATCH, 0xFFB20000},
      {CoreType::ROUTER_ONLY, 0xFF000000}}};
-inline constexpr std::array<std::pair<CoreType, uint64_t>, 8> NOC1_CONTROL_REG_ADDR_BASE_MAP = {
+inline constexpr std::array<std::pair<CoreType, uint64_t>, 9> NOC1_CONTROL_REG_ADDR_BASE_MAP = {
     {{CoreType::TENSIX, 0xFFB30000},
      {CoreType::ETH, 0xFFB30000},
      {CoreType::DRAM, 0xFFB30000},
@@ -275,6 +279,7 @@ inline constexpr std::array<std::pair<CoreType, uint64_t>, 8> NOC1_CONTROL_REG_A
      {CoreType::ARC, 0xFFFFFFFFFF000000ULL},
      {CoreType::SECURITY, 0xFFFFFFFFFF000000ULL},
      {CoreType::L2CPU, 0xFFFFFFFFFF000000ULL},
+     {CoreType::DISPATCH, 0xFFB30000},
      {CoreType::ROUTER_ONLY, 0xFF000000}}};
 
 inline constexpr uint64_t NOC_NODE_ID_OFFSET = 0x44;

--- a/device/api/umd/device/coordinates/blackhole_coordinate_manager.hpp
+++ b/device/api/umd/device/coordinates/blackhole_coordinate_manager.hpp
@@ -26,6 +26,7 @@ public:
         const std::vector<tt_xy_pair>& router_cores,
         const std::vector<tt_xy_pair>& security_cores,
         const std::vector<tt_xy_pair>& l2cpu_cores,
+        const std::vector<tt_xy_pair>& dispatch_cores,
         const std::vector<uint32_t>& noc0_x_to_noc1_x = {},
         const std::vector<uint32_t>& noc0_y_to_noc1_y = {});
 

--- a/device/api/umd/device/coordinates/coordinate_manager.hpp
+++ b/device/api/umd/device/coordinates/coordinate_manager.hpp
@@ -41,6 +41,7 @@ public:
         const std::vector<tt_xy_pair>& router_cores,
         const std::vector<tt_xy_pair>& security_cores,
         const std::vector<tt_xy_pair>& l2cpu_cores,
+        const std::vector<tt_xy_pair>& dispatch_cores,
         const std::vector<uint32_t>& noc0_x_to_noc1_x = {},
         const std::vector<uint32_t>& noc0_y_to_noc1_y = {});
 
@@ -217,6 +218,7 @@ protected:
         const std::vector<tt_xy_pair>& router_cores,
         const std::vector<tt_xy_pair>& security_cores,
         const std::vector<tt_xy_pair>& l2cpu_cores,
+        const std::vector<tt_xy_pair>& dispatch_cores,
         const std::vector<uint32_t>& noc0_x_to_noc1_x = {},
         const std::vector<uint32_t>& noc0_y_to_noc1_y = {});
 
@@ -232,6 +234,7 @@ protected:
     virtual void translate_router_coords();
     virtual void translate_security_coords();
     virtual void translate_l2cpu_coords();
+    virtual void translate_dispatch_coords();
 
     void identity_map_noc0_cores();
     void add_core_translation(const CoreCoord& core_coord, const tt_xy_pair& noc0_pair);
@@ -247,6 +250,8 @@ protected:
     virtual std::vector<CoreCoord> get_harvested_pcie_cores() const;
     virtual std::vector<CoreCoord> get_l2cpu_cores() const;
     virtual std::vector<CoreCoord> get_harvested_l2cpu_cores() const;
+    virtual std::vector<CoreCoord> get_dispatch_cores() const;
+    virtual std::vector<CoreCoord> get_harvested_dispatch_cores() const;
     virtual tt_xy_pair get_tensix_grid_size() const = 0;
     virtual tt_xy_pair get_dram_grid_size() const;
     virtual tt_xy_pair get_harvested_tensix_grid_size() const;
@@ -344,6 +349,8 @@ protected:
     const std::vector<tt_xy_pair> security_cores;
 
     const std::vector<tt_xy_pair> l2cpu_cores;
+
+    const std::vector<tt_xy_pair> dispatch_cores;
 
     const std::vector<uint32_t> noc0_x_to_noc1_x;
     const std::vector<uint32_t> noc0_y_to_noc1_y;

--- a/device/api/umd/device/coordinates/wormhole_coordinate_manager.hpp
+++ b/device/api/umd/device/coordinates/wormhole_coordinate_manager.hpp
@@ -26,6 +26,7 @@ public:
         const std::vector<tt_xy_pair>& router_cores,
         const std::vector<tt_xy_pair>& security_cores,
         const std::vector<tt_xy_pair>& l2cpu_cores,
+        const std::vector<tt_xy_pair>& dispatch_cores,
         const std::vector<uint32_t>& noc0_x_to_noc1_x = {},
         const std::vector<uint32_t>& noc0_y_to_noc1_y = {});
 

--- a/device/api/umd/device/soc_descriptor.hpp
+++ b/device/api/umd/device/soc_descriptor.hpp
@@ -54,6 +54,7 @@ struct SocDescriptorInfo {
     std::vector<tt_xy_pair> router_cores;
     std::vector<tt_xy_pair> security_cores;
     std::vector<tt_xy_pair> l2cpu_cores;
+    std::vector<tt_xy_pair> dispatch_cores;
 
     uint32_t worker_l1_size;
     uint32_t eth_l1_size;
@@ -197,6 +198,7 @@ private:
     std::vector<tt_xy_pair> router_cores;
     std::vector<tt_xy_pair> security_cores;
     std::vector<tt_xy_pair> l2cpu_cores;
+    std::vector<tt_xy_pair> dispatch_cores;
     std::vector<uint32_t> noc0_x_to_noc1_x;
     std::vector<uint32_t> noc0_y_to_noc1_y;
 

--- a/device/api/umd/device/types/core_coordinates.hpp
+++ b/device/api/umd/device/types/core_coordinates.hpp
@@ -29,6 +29,7 @@ enum class CoreType {
     ROUTER_ONLY,
     SECURITY,
     L2CPU,
+    DISPATCH,
     // TODO: this keeps compatibility with existing code in SocDescriptor
     // but it won't be needed later on
     HARVESTED,
@@ -68,6 +69,8 @@ static inline std::string to_str(const CoreType core_type) {
             return "SECURITY";
         case CoreType::L2CPU:
             return "L2CPU";
+        case CoreType::DISPATCH:
+            return "DISPATCH";
         case CoreType::HARVESTED:
             return "HARVESTED";
         case CoreType::ETH:

--- a/device/coordinates/blackhole_coordinate_manager.cpp
+++ b/device/coordinates/blackhole_coordinate_manager.cpp
@@ -30,6 +30,7 @@ BlackholeCoordinateManager::BlackholeCoordinateManager(
     const std::vector<tt_xy_pair>& router_cores,
     const std::vector<tt_xy_pair>& security_cores,
     const std::vector<tt_xy_pair>& l2cpu_cores,
+    const std::vector<tt_xy_pair>& dispatch_cores,
     const std::vector<uint32_t>& noc0_x_to_noc1_x,
     const std::vector<uint32_t>& noc0_y_to_noc1_y) :
     CoordinateManager(
@@ -47,6 +48,7 @@ BlackholeCoordinateManager::BlackholeCoordinateManager(
         router_cores,
         security_cores,
         l2cpu_cores,
+        dispatch_cores,
         noc0_x_to_noc1_x,
         noc0_y_to_noc1_y) {
     initialize();

--- a/device/coordinates/coordinate_manager.cpp
+++ b/device/coordinates/coordinate_manager.cpp
@@ -35,6 +35,7 @@ CoordinateManager::CoordinateManager(
     const std::vector<tt_xy_pair>& router_cores,
     const std::vector<tt_xy_pair>& security_cores,
     const std::vector<tt_xy_pair>& l2cpu_cores,
+    const std::vector<tt_xy_pair>& dispatch_cores,
     const std::vector<uint32_t>& noc0_x_to_noc1_x,
     const std::vector<uint32_t>& noc0_y_to_noc1_y) :
     noc_translation_enabled(noc_translation_enabled),
@@ -52,6 +53,7 @@ CoordinateManager::CoordinateManager(
     router_cores(router_cores),
     security_cores(security_cores),
     l2cpu_cores(l2cpu_cores),
+    dispatch_cores(dispatch_cores),
     noc0_x_to_noc1_x(noc0_x_to_noc1_x),
     noc0_y_to_noc1_y(noc0_y_to_noc1_y) {}
 
@@ -66,6 +68,7 @@ void CoordinateManager::initialize() {
     this->translate_router_coords();
     this->translate_security_coords();
     this->translate_l2cpu_coords();
+    this->translate_dispatch_coords();
     this->add_noc1_to_noc0_mapping();
 }
 
@@ -313,6 +316,14 @@ void CoordinateManager::translate_l2cpu_coords() {
     }
 }
 
+void CoordinateManager::translate_dispatch_coords() {
+    for (tt_xy_pair dispatch_core : dispatch_cores) {
+        CoreCoord translated_coord = CoreCoord(dispatch_core, CoreType::DISPATCH, CoordSystem::TRANSLATED);
+
+        add_core_translation(translated_coord, dispatch_core);
+    }
+}
+
 void CoordinateManager::fill_eth_default_noc0_translated_mapping() {
     for (size_t eth_channel = 0; eth_channel < num_eth_channels; eth_channel++) {
         const tt_xy_pair noc0_pair = eth_cores[eth_channel];
@@ -442,6 +453,8 @@ const std::vector<tt_xy_pair>& CoordinateManager::get_noc0_pairs(const CoreType 
             return security_cores;
         case CoreType::L2CPU:
             return l2cpu_cores;
+        case CoreType::DISPATCH:
+            return dispatch_cores;
         default:
             UMD_THROW(error::RuntimeError, "Core type is not supported for getting NOC0 pairs.");
     }
@@ -505,6 +518,10 @@ std::vector<CoreCoord> CoordinateManager::get_l2cpu_cores() const { return get_a
 
 std::vector<CoreCoord> CoordinateManager::get_harvested_l2cpu_cores() const { return {}; }
 
+std::vector<CoreCoord> CoordinateManager::get_dispatch_cores() const { return get_all_noc0_cores(CoreType::DISPATCH); }
+
+std::vector<CoreCoord> CoordinateManager::get_harvested_dispatch_cores() const { return {}; }
+
 std::vector<CoreCoord> CoordinateManager::get_cores(const CoreType core_type) const {
     switch (core_type) {
         case CoreType::TENSIX:
@@ -517,6 +534,8 @@ std::vector<CoreCoord> CoordinateManager::get_cores(const CoreType core_type) co
             return get_pcie_cores();
         case CoreType::L2CPU:
             return get_l2cpu_cores();
+        case CoreType::DISPATCH:
+            return get_dispatch_cores();
         case CoreType::ARC:
         case CoreType::ROUTER_ONLY:
         case CoreType::SECURITY:
@@ -557,6 +576,7 @@ std::vector<CoreCoord> CoordinateManager::get_harvested_cores(const CoreType cor
         case CoreType::ROUTER_ONLY:
         case CoreType::SECURITY:
         case CoreType::L2CPU:
+        case CoreType::DISPATCH:
             return {};
         default:
             UMD_THROW(error::RuntimeError, "Unsupported core type for get_harvested_cores().");
@@ -615,6 +635,7 @@ std::shared_ptr<CoordinateManager> CoordinateManager::create_coordinate_manager(
                 wormhole::ROUTER_CORES_NOC0,
                 wormhole::SECURITY_CORES_NOC0,
                 wormhole::L2CPU_CORES_NOC0,
+                {},
                 wormhole::NOC0_X_TO_NOC1_X,
                 wormhole::NOC0_Y_TO_NOC1_Y);
         case tt::ARCH::QUASAR:  // TODO (#450): Add Quasar configuration
@@ -635,6 +656,7 @@ std::shared_ptr<CoordinateManager> CoordinateManager::create_coordinate_manager(
                 blackhole::ROUTER_CORES_NOC0,
                 blackhole::SECURITY_CORES_NOC0,
                 blackhole::L2CPU_CORES_NOC0,
+                {},
                 blackhole::NOC0_X_TO_NOC1_X,
                 blackhole::NOC0_Y_TO_NOC1_Y);
         }
@@ -660,6 +682,7 @@ std::shared_ptr<CoordinateManager> CoordinateManager::create_coordinate_manager(
     const std::vector<tt_xy_pair>& router_cores,
     const std::vector<tt_xy_pair>& security_cores,
     const std::vector<tt_xy_pair>& l2cpu_cores,
+    const std::vector<tt_xy_pair>& dispatch_cores,
     const std::vector<uint32_t>& noc0_x_to_noc1_x,
     const std::vector<uint32_t>& noc0_y_to_noc1_y) {
     switch (arch) {
@@ -679,6 +702,7 @@ std::shared_ptr<CoordinateManager> CoordinateManager::create_coordinate_manager(
                 router_cores,
                 security_cores,
                 l2cpu_cores,
+                dispatch_cores,
                 noc0_x_to_noc1_x,
                 noc0_y_to_noc1_y);
         case tt::ARCH::QUASAR:  // TODO (#450): Add Quasar configuration
@@ -698,6 +722,7 @@ std::shared_ptr<CoordinateManager> CoordinateManager::create_coordinate_manager(
                 router_cores,
                 security_cores,
                 l2cpu_cores,
+                dispatch_cores,
                 noc0_x_to_noc1_x,
                 noc0_y_to_noc1_y);
         default:

--- a/device/coordinates/coordinate_manager.cpp
+++ b/device/coordinates/coordinate_manager.cpp
@@ -130,6 +130,11 @@ void CoordinateManager::identity_map_noc0_cores() {
         const CoreCoord core_coord = CoreCoord(core.x, core.y, CoreType::L2CPU, CoordSystem::NOC0);
         add_core_translation(core_coord, core);
     }
+
+    for (auto& core : dispatch_cores) {
+        const CoreCoord core_coord = CoreCoord(core.x, core.y, CoreType::DISPATCH, CoordSystem::NOC0);
+        add_core_translation(core_coord, core);
+    }
 }
 
 CoreCoord CoordinateManager::translate_coord_to(
@@ -317,6 +322,8 @@ void CoordinateManager::translate_l2cpu_coords() {
 }
 
 void CoordinateManager::translate_dispatch_coords() {
+    // Just do identity mapping for translated DISPATCH coordinates.
+    // No logical coordinates available for DISPATCH cores.
     for (tt_xy_pair dispatch_core : dispatch_cores) {
         CoreCoord translated_coord = CoreCoord(dispatch_core, CoreType::DISPATCH, CoordSystem::TRANSLATED);
 
@@ -780,6 +787,7 @@ void CoordinateManager::add_noc1_to_noc0_mapping() {
     map_noc0_to_noc1_cores(router_cores, CoreType::ROUTER_ONLY);
     map_noc0_to_noc1_cores(security_cores, CoreType::SECURITY);
     map_noc0_to_noc1_cores(l2cpu_cores, CoreType::L2CPU);
+    map_noc0_to_noc1_cores(dispatch_cores, CoreType::DISPATCH);
 }
 
 }  // namespace tt::umd

--- a/device/coordinates/wormhole_coordinate_manager.cpp
+++ b/device/coordinates/wormhole_coordinate_manager.cpp
@@ -25,6 +25,7 @@ WormholeCoordinateManager::WormholeCoordinateManager(
     const std::vector<tt_xy_pair>& router_cores,
     const std::vector<tt_xy_pair>& security_cores,
     const std::vector<tt_xy_pair>& l2cpu_cores,
+    const std::vector<tt_xy_pair>& dispatch_cores,
     const std::vector<uint32_t>& noc0_x_to_noc1_x,
     const std::vector<uint32_t>& noc0_y_to_noc1_y) :
     CoordinateManager(
@@ -42,6 +43,7 @@ WormholeCoordinateManager::WormholeCoordinateManager(
         router_cores,
         security_cores,
         l2cpu_cores,
+        dispatch_cores,
         noc0_x_to_noc1_x,
         noc0_y_to_noc1_y) {
     initialize();

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -209,6 +209,7 @@ void SocDescriptor::create_coordinate_manager(const BoardType board_type, const 
         router_cores,
         security_cores,
         l2cpu_cores,
+        dispatch_cores,
         noc0_x_to_noc1_x,
         noc0_y_to_noc1_y);
     get_cores_and_grid_size_from_coordinate_manager();
@@ -358,6 +359,14 @@ void SocDescriptor::load_core_descriptors_from_soc_desc_info(const SocDescriptor
         l2cpu_cores.push_back(core_descriptor.coord);
     }
 
+    for (const auto &dispatch_core : soc_desc_info.dispatch_cores) {
+        CoreDescriptor core_descriptor;
+        core_descriptor.coord = dispatch_core;
+        core_descriptor.type = CoreType::DISPATCH;
+        cores.insert({core_descriptor.coord, core_descriptor});
+        dispatch_cores.push_back(core_descriptor.coord);
+    }
+
     noc0_x_to_noc1_x = soc_desc_info.noc0_x_to_noc1_x;
     noc0_y_to_noc1_y = soc_desc_info.noc0_y_to_noc1_y;
 }
@@ -382,6 +391,7 @@ SocDescriptorInfo SocDescriptor::get_soc_descriptor_info(tt::ARCH arch) {
                 .router_cores = wormhole::ROUTER_CORES_NOC0,
                 .security_cores = wormhole::SECURITY_CORES_NOC0,
                 .l2cpu_cores = wormhole::L2CPU_CORES_NOC0,
+                .dispatch_cores = {},
                 .worker_l1_size = wormhole::TENSIX_L1_SIZE,
                 .eth_l1_size = wormhole::ETH_L1_SIZE,
                 .dram_bank_size = wormhole::DRAM_BANK_SIZE,
@@ -401,6 +411,7 @@ SocDescriptorInfo SocDescriptor::get_soc_descriptor_info(tt::ARCH arch) {
                 .router_cores = blackhole::ROUTER_CORES_NOC0,
                 .security_cores = blackhole::SECURITY_CORES_NOC0,
                 .l2cpu_cores = blackhole::L2CPU_CORES_NOC0,
+                .dispatch_cores = {},
                 .worker_l1_size = blackhole::TENSIX_L1_SIZE,
                 .eth_l1_size = blackhole::ETH_L1_SIZE,
                 .dram_bank_size = blackhole::DRAM_BANK_SIZE,
@@ -420,6 +431,7 @@ SocDescriptorInfo SocDescriptor::get_soc_descriptor_info(tt::ARCH arch) {
                 .router_cores = grendel::ROUTER_CORES_NOC0,
                 .security_cores = grendel::SECURITY_CORES_NOC0,
                 .l2cpu_cores = grendel::L2CPU_CORES_NOC0,
+                .dispatch_cores = grendel::DISPATCH_CORES_NOC0,
                 .worker_l1_size = grendel::TENSIX_L1_SIZE,
                 .eth_l1_size = grendel::ETH_L1_SIZE,
                 .dram_bank_size = grendel::DRAM_BANK_SIZE,
@@ -509,6 +521,11 @@ void SocDescriptor::load_from_yaml(YAML::Node &device_descriptor_yaml) {
     if (device_descriptor_yaml["security"].IsDefined()) {
         soc_desc_info.security_cores =
             SocDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["security"].as<std::vector<std::string>>());
+    }
+
+    if (device_descriptor_yaml["dispatch"].IsDefined()) {
+        soc_desc_info.dispatch_cores =
+            SocDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["dispatch"].as<std::vector<std::string>>());
     }
 
     if (device_descriptor_yaml["noc0_x_to_noc1_x"].IsDefined()) {
@@ -644,6 +661,10 @@ std::string SocDescriptor::serialize() const {
     write_core_locations(&out, CoreType::L2CPU);
     out << YAML::EndSeq;
 
+    out << YAML::Key << "dispatch" << YAML::Value << YAML::BeginSeq;
+    write_core_locations(&out, CoreType::DISPATCH);
+    out << YAML::EndSeq;
+
     // Fill in the rest that are static to our device.
     out << YAML::Key << "worker_l1_size" << YAML::Value << worker_l1_size;
     out << YAML::Key << "dram_bank_size" << YAML::Value << dram_bank_size;
@@ -708,11 +729,12 @@ void SocDescriptor::get_cores_and_grid_size_from_coordinate_manager() {
           CoreType::PCIE,
           CoreType::ROUTER_ONLY,
           CoreType::SECURITY,
-          CoreType::L2CPU}) {
+          CoreType::L2CPU,
+          CoreType::DISPATCH}) {
         cores_map.insert({core_type, coordinate_manager->get_cores(core_type)});
         harvested_cores_map.insert({core_type, coordinate_manager->get_harvested_cores(core_type)});
         if (core_type == CoreType::ETH || core_type == CoreType::ROUTER_ONLY || core_type == CoreType::SECURITY ||
-            core_type == CoreType::L2CPU) {
+            core_type == CoreType::L2CPU || core_type == CoreType::DISPATCH) {
             // Ethernet and Router cores aren't arranged in a grid, initializing as empty.
             grid_size_map.insert({core_type, empty});
             harvested_grid_size_map.insert({core_type, empty});
@@ -793,7 +815,8 @@ std::vector<CoreCoord> SocDescriptor::get_all_cores(const CoordSystem coord_syst
           CoreType::PCIE,
           CoreType::ROUTER_ONLY,
           CoreType::SECURITY,
-          CoreType::L2CPU}) {
+          CoreType::L2CPU,
+          CoreType::DISPATCH}) {
         auto cores = get_cores(core_type, coord_system);
         all_cores.insert(all_cores.end(), cores.begin(), cores.end());
     }
@@ -810,7 +833,8 @@ std::vector<CoreCoord> SocDescriptor::get_all_harvested_cores(const CoordSystem 
           CoreType::PCIE,
           CoreType::ROUTER_ONLY,
           CoreType::SECURITY,
-          CoreType::L2CPU}) {
+          CoreType::L2CPU,
+          CoreType::DISPATCH}) {
         auto harvested_cores = get_harvested_cores(core_type, coord_system);
         all_harvested_cores.insert(all_harvested_cores.end(), harvested_cores.begin(), harvested_cores.end());
     }

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -735,7 +735,7 @@ void SocDescriptor::get_cores_and_grid_size_from_coordinate_manager() {
         harvested_cores_map.insert({core_type, coordinate_manager->get_harvested_cores(core_type)});
         if (core_type == CoreType::ETH || core_type == CoreType::ROUTER_ONLY || core_type == CoreType::SECURITY ||
             core_type == CoreType::L2CPU || core_type == CoreType::DISPATCH) {
-            // Ethernet and Router cores aren't arranged in a grid, initializing as empty.
+            // Ethernet, Router, Security, L2CPU, and Dispatch cores aren't arranged in a grid, initializing as empty.
             grid_size_map.insert({core_type, empty});
             harvested_grid_size_map.insert({core_type, empty});
             continue;

--- a/docs/yaml_schemas/soc_descriptor.yaml
+++ b/docs/yaml_schemas/soc_descriptor.yaml
@@ -106,6 +106,14 @@ properties:
       pattern: ^[0-9]+-[0-9]+$
       description: Coordinate in format "x-y"
 
+  dispatch:
+    type: array
+    description: List of dispatch engine core coordinates
+    items:
+      type: string
+      pattern: ^[0-9]+-[0-9]+$
+      description: Coordinate in format "x-y"
+
   noc0_x_to_noc1_x:
     type: array
     description: Mapping from NOC0 X coordinates to NOC1 X coordinates

--- a/tests/baremetal/test_soc_descriptor.cpp
+++ b/tests/baremetal/test_soc_descriptor.cpp
@@ -701,3 +701,35 @@ TEST(SocDescriptor, SerializeSimulatorQuasar) {
         {.noc_translation_enabled = soc_descriptor.noc_translation_enabled,
          .harvesting_masks = soc_descriptor.harvesting_masks});
 }
+
+TEST(SocDescriptor, SocDescriptorWormholeNoDispatchCores) {
+    SocDescriptor soc_desc_yaml(
+        test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"), {.noc_translation_enabled = true});
+
+    EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::DISPATCH).size(), 0);
+
+    SocDescriptor soc_desc_arch(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
+
+    EXPECT_EQ(soc_desc_arch.get_cores(CoreType::DISPATCH).size(), 0);
+}
+
+TEST(SocDescriptor, SocDescriptorBlackholeNoDispatchCores) {
+    SocDescriptor soc_desc_yaml(
+        test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml"),
+        {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}});
+
+    EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::DISPATCH).size(), 0);
+
+    SocDescriptor soc_desc_arch(
+        tt::ARCH::BLACKHOLE,
+        {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}});
+
+    EXPECT_EQ(soc_desc_arch.get_cores(CoreType::DISPATCH).size(), 0);
+}
+
+TEST(SocDescriptor, SocDescriptorQuasarNoDispatchCores) {
+    SocDescriptor soc_desc_yaml(
+        test_utils::GetSocDescAbsPath("quasar_32_arch.yaml"), {.noc_translation_enabled = true});
+
+    EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::DISPATCH).size(), 0);
+}

--- a/tests/baremetal/test_soc_descriptor.cpp
+++ b/tests/baremetal/test_soc_descriptor.cpp
@@ -733,3 +733,54 @@ TEST(SocDescriptor, SocDescriptorQuasarNoDispatchCores) {
 
     EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::DISPATCH).size(), 0);
 }
+
+TEST(CoordinateManager, DispatchCoreCoordinateTranslation) {
+    // Until Quasar dispatch core coordinates are finalized, exercise the DISPATCH translation
+    // plumbing with a synthetic CoordinateManager containing a single dispatch core. This guards
+    // the NOC0 identity mapping and the NOC0 -> NOC1 mapping for DISPATCH against regressions
+    // that would only surface once DISPATCH_CORES_NOC0 becomes non-empty on real hardware.
+    const tt_xy_pair dispatch_noc0 = {5, 5};
+    const std::vector<tt_xy_pair> dispatch_cores = {dispatch_noc0};
+
+    // Identity NOC0 <-> NOC1 mapping (Quasar is assumed to have identical NOC0/NOC1 layouts for now).
+    const std::vector<uint32_t> noc0_to_noc1 = {0, 1, 2, 3, 4, 5, 6};
+
+    std::shared_ptr<CoordinateManager> coordinate_manager = CoordinateManager::create_coordinate_manager(
+        tt::ARCH::BLACKHOLE,
+        /*noc_translation_enabled=*/false,
+        HarvestingMasks{},
+        /*tensix_grid_size=*/{0, 0},
+        /*tensix_cores=*/{},
+        /*dram_grid_size=*/{0, 0},
+        /*dram_cores=*/{},
+        /*eth_cores=*/{},
+        /*arc_grid_size=*/{0, 0},
+        /*arc_cores=*/{},
+        /*pcie_grid_size=*/{0, 0},
+        /*pcie_cores=*/{},
+        /*router_cores=*/{},
+        /*security_cores=*/{},
+        /*l2cpu_cores=*/{},
+        dispatch_cores,
+        noc0_to_noc1,
+        noc0_to_noc1);
+
+    const std::vector<CoreCoord> returned = coordinate_manager->get_cores(CoreType::DISPATCH);
+    ASSERT_EQ(returned.size(), 1);
+    EXPECT_EQ(returned[0], CoreCoord(dispatch_noc0.x, dispatch_noc0.y, CoreType::DISPATCH, CoordSystem::NOC0));
+
+    const CoreCoord dispatch_noc0_coord =
+        CoreCoord(dispatch_noc0.x, dispatch_noc0.y, CoreType::DISPATCH, CoordSystem::NOC0);
+
+    // NOC0 -> TRANSLATED (identity for DISPATCH, since there are no logical coordinates).
+    const CoreCoord translated = coordinate_manager->translate_coord_to(dispatch_noc0_coord, CoordSystem::TRANSLATED);
+    EXPECT_EQ(translated.core_type, CoreType::DISPATCH);
+    EXPECT_EQ(translated.x, dispatch_noc0.x);
+    EXPECT_EQ(translated.y, dispatch_noc0.y);
+
+    // NOC0 -> NOC1 (identity because we supplied an identity NOC0->NOC1 table).
+    const CoreCoord noc1 = coordinate_manager->translate_coord_to(dispatch_noc0_coord, CoordSystem::NOC1);
+    EXPECT_EQ(noc1.core_type, CoreType::DISPATCH);
+    EXPECT_EQ(noc1.x, noc0_to_noc1[dispatch_noc0.x]);
+    EXPECT_EQ(noc1.y, noc0_to_noc1[dispatch_noc0.y]);
+}

--- a/tests/soc_descs/quasar_32_arch.yaml
+++ b/tests/soc_descs/quasar_32_arch.yaml
@@ -24,6 +24,9 @@ functional_workers:
 router_only:
   [0-2]
 
+dispatch:
+  []
+
 worker_l1_size:
   1499136
 

--- a/tests/soc_descs/quasar_simulation_1x1.yaml
+++ b/tests/soc_descs/quasar_simulation_1x1.yaml
@@ -20,6 +20,9 @@ functional_workers:
 router_only:
   [0-2]
 
+dispatch:
+  []
+
 worker_l1_size:
   4194304
 

--- a/tests/soc_descs/quasar_simulation_1x3.yaml
+++ b/tests/soc_descs/quasar_simulation_1x3.yaml
@@ -23,6 +23,9 @@ harvested_workers:
 router_only:
   [0-2]
 
+dispatch:
+  []
+
 worker_l1_size:
   4194304
 

--- a/tests/soc_descs/quasar_simulation_2x3.yaml
+++ b/tests/soc_descs/quasar_simulation_2x3.yaml
@@ -23,6 +23,9 @@ harvested_workers:
 router_only:
   [1-2, 2-2]
 
+dispatch:
+  []
+
 worker_l1_size:
   4194304
 

--- a/tests/soc_descs/quasar_simulation_2x3.yaml
+++ b/tests/soc_descs/quasar_simulation_2x3.yaml
@@ -21,10 +21,10 @@ harvested_workers:
   []
 
 router_only:
-  [1-2, 2-2]
+  []
 
 dispatch:
-  []
+  [1-2]
 
 worker_l1_size:
   4194304


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2281

### Description
A "dispatch engine" is a new type of core on Quasar that will be dedicated towards fast dispatch. This PR adds a new `DISPATCH` core type throughout the UMD stack so that the fast dispatch code in metal can locate and program these cores through the SoC descriptor.

The implementation follows the same pattern as the existing `L2CPU` and `SECURITY` core types — dispatch engines are not arranged in a grid, don't support harvesting, and use identity-mapped translated coordinates. The actual NOC0 coordinates for dispatch engines are left as an empty placeholder (`DISPATCH_CORES_NOC0 = {}`) until the physical positions are finalized on the Grendel/Quasar chip. Wormhole and Blackhole architectures get empty dispatch core lists since they don't have this core type.

### List of the changes
- Add `DISPATCH` variant to the `CoreType` enum in `core_coordinates.hpp` and add the corresponding case in the `to_str()` string conversion function.
- Add `dispatch_cores` vector to both `SocDescriptorInfo` (used during construction) and `SocDescriptor` (internal storage), mirroring how `l2cpu_cores` and `security_cores` are handled.
- Add YAML parsing for an optional `dispatch:` key in `load_from_yaml()`, and emit it during serialization in `serialize()`.
- Add `dispatch_cores` member to `CoordinateManager` base class, along with `translate_dispatch_coords()`, `get_dispatch_cores()`, and `get_harvested_dispatch_cores()` virtual methods.
- Update all `CoordinateManager` switch statements (`get_noc0_pairs`, `get_cores`, `get_harvested_cores`) and core type iteration lists (`get_cores_and_grid_size_from_coordinate_manager`, `get_all_cores`, `get_all_harvested_cores`) to include `CoreType::DISPATCH`.
- Thread the new `dispatch_cores` parameter through both `create_coordinate_manager` factory overloads and all three coordinate manager constructors (base, `WormholeCoordinateManager`, `BlackholeCoordinateManager`).
- Add `DISPATCH_CORES_NOC0` empty placeholder and `CoreType::DISPATCH` entries to NOC0/NOC1 control register address base maps in `grendel_implementation.hpp`.
- Add `dispatch: []` to all four Quasar SoC descriptor YAML files (`quasar_32_arch.yaml`, `quasar_simulation_1x1.yaml`, `quasar_simulation_1x3.yaml`, `quasar_simulation_2x3.yaml`).
- Pass empty dispatch core lists (`{}`) for Wormhole and Blackhole in `get_soc_descriptor_info()` and the arch-based `create_coordinate_manager` convenience overload.
- Add three new tests: `SocDescriptorWormholeNoDispatchCores`, `SocDescriptorBlackholeNoDispatchCores`, and `SocDescriptorQuasarNoDispatchCores` verifying that all architectures correctly report zero dispatch cores. The existing `AllSocDescriptors` and `SerializeSimulatorQuasar` tests also exercise the new field.

### Testing
CI. New unit tests added in `test_soc_descriptor.cpp` for all three architectures.

### API Changes
- New `CoreType::DISPATCH` enum value added to `core_coordinates.hpp`.
- New optional `dispatch:` field in SoC descriptor YAML files (defaults to empty if not present).
- `CoordinateManager::create_coordinate_manager()` now takes an additional `dispatch_cores` parameter.
- `SocDescriptorInfo` struct has a new `dispatch_cores` member.