### PR TITLE
Add TLB for simulation for quasar

### DIFF
--- a/device/chip_helpers/simulation_tlb_manager.cpp
+++ b/device/chip_helpers/simulation_tlb_manager.cpp
@@ -230,7 +230,10 @@ const architecture_implementation* SimulationTlbManager::get_architecture_impl()
 std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
     static constexpr size_t SIZE_2MB = 2 * 1024 * 1024;
     static constexpr size_t SIZE_16MB = 16 * 1024 * 1024;
-    // Quasar has no TLB size list; use a large virtual TLB so the communicator handles all I/O.
+    // Quasar has no real TLBs; the communicator handles all I/O underneath.
+    // The size here is a dummy value — it just needs to be large enough so that
+    // TlbWindow::validate doesn't reject any valid access (size 0 would cause
+    // division by zero in RtlSimTlbHandle::configure).
     static constexpr size_t SIZE_4GB = 4ULL * 1024 * 1024 * 1024;
     switch (architecture_) {
         case tt::ARCH::BLACKHOLE:

--- a/device/chip_helpers/simulation_tlb_manager.cpp
+++ b/device/chip_helpers/simulation_tlb_manager.cpp
@@ -230,11 +230,15 @@ const architecture_implementation* SimulationTlbManager::get_architecture_impl()
 std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
     static constexpr size_t SIZE_2MB = 2 * 1024 * 1024;
     static constexpr size_t SIZE_16MB = 16 * 1024 * 1024;
+    // Quasar has no TLB size list; use a large virtual TLB so the communicator handles all I/O.
+    static constexpr size_t SIZE_4GB = 4ULL * 1024 * 1024 * 1024;
     switch (architecture_) {
         case tt::ARCH::BLACKHOLE:
             return allocate_tlb_window({}, TlbMapping::WC, SIZE_2MB);
         case tt::ARCH::WORMHOLE_B0:
             return allocate_tlb_window({}, TlbMapping::WC, SIZE_16MB);
+        case tt::ARCH::QUASAR:
+            return factory_(this, 0, SIZE_4GB, TlbMapping::WC, {});
         default:
             log_debug(
                 LogUMD,


### PR DESCRIPTION
### Issue
/

### Description
Add default TLB window allocation for Quasar in SimulationTlbManager. Quasar has no real TLBs — the communicator handles all I/O — so the TLB window is created directly via the factory with a dummy size, bypassing the normal `allocate_tlb_window` path which requires a TLB size list.

### List of the changes
- Add `QUASAR` case in `SimulationTlbManager::allocate_default_tlb_window()` that creates a TLB window directly via `factory_` with a 4GB dummy size
- Add comments explaining why the size is a dummy value and why size 0 cannot be used

### Testing
CI

### API Changes
There are no API changes in this PR.