### PR TITLE
Simulation: add advance_device_execution API to enable fast-dispatch on tt-sim

### DIFF
--- a/device/api/umd/device/chip/chip.hpp
+++ b/device/api/umd/device/chip/chip.hpp
@@ -115,6 +115,11 @@ public:
     virtual int get_clock() = 0;
     virtual int get_numa_node() = 0;
 
+    // Advance the chip by one clock cycle. Delegates to the underlying TTDevice, which
+    // is a no-op for chips without a controllable clock and drives the simulator clock
+    // synchronously (no background thread) for deterministic simulation.
+    void advance_device_execution();
+
     virtual int arc_msg(
         uint32_t msg_code,
         bool wait_for_done = true,

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -582,6 +582,8 @@ public:
      */
     void read_from_sysmem(void* mem_ptr, uint64_t addr, uint16_t channel, uint32_t size, ChipId src_device_id);
 
+    void advance_device_execution(ChipId device_id);
+
     /**
      * Query number of memory channels on Host device allocated for a specific device during initialization.
      *

--- a/device/api/umd/device/pcie/tt_sim_tlb_handle.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_handle.hpp
@@ -34,7 +34,7 @@ public:
         size_t size,
         const TlbMapping tlb_mapping);
 
-    ~TTSimTlbHandle() noexcept;
+    ~TTSimTlbHandle() noexcept override = default;
 
     void configure(const tlb_data& new_config) override;
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -350,6 +350,12 @@ public:
 
     virtual uint32_t get_min_clock_freq() = 0;
 
+    // Advance the device by one clock cycle. No-op by default; overridden by devices with a
+    // controllable clock (e.g. simulation). Simulator clocking must be deterministic, so the
+    // clock is advanced synchronously from the calling thread rather than driven by a
+    // background thread.
+    virtual void advance_device_execution();
+
     uint64_t get_board_id();
 
     uint8_t get_asic_location();

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -70,6 +70,8 @@ public:
     void assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs) override;
     void deassert_risc_reset(tt_xy_pair core, const RiscType selected_riscs, bool staggered_start) override;
 
+    void advance_device_execution() override;
+
     /**
      * Get the TTSimCommunicator for low-level device operations.
      * @return Pointer to TTSimCommunicator

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -208,6 +208,12 @@ int Chip::arc_msg(
     return exit_code;
 }
 
+void Chip::advance_device_execution() {
+    if (auto* td = get_tt_device()) {
+        td->advance_device_execution();
+    }
+}
+
 void Chip::set_power_state(DevicePowerState state) {
     ZoneScopedN("UMD_Chip::set_power_state");
     int exit_code = 0;

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -48,7 +48,7 @@ bool SimulationSysmemManager::init_sysmem(uint32_t num_host_mem_channels) {
     }
 
     system_memory_ =
-        static_cast<uint8_t *>(mmap(nullptr, total_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+        static_cast<uint8_t*>(mmap(nullptr, total_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
     UMD_ASSERT(system_memory_ != MAP_FAILED, error::RuntimeError, "system_memory mmap() failed");
     madvise(system_memory_, total_size, MADV_HUGEPAGE);
     system_memory_size_ = total_size;
@@ -82,7 +82,7 @@ std::unique_ptr<SysmemBuffer> SimulationSysmemManager::allocate_sysmem_buffer(
 }
 
 std::unique_ptr<SysmemBuffer> SimulationSysmemManager::map_sysmem_buffer(
-    void *buffer, size_t sysmem_buffer_size, const bool map_to_noc) {
+    void* buffer, size_t sysmem_buffer_size, const bool map_to_noc) {
     return nullptr;
 }
 

--- a/device/chip_helpers/tlb_manager.cpp
+++ b/device/chip_helpers/tlb_manager.cpp
@@ -45,10 +45,11 @@ void TLBManager::configure_tlb(tt_xy_pair core, size_t tlb_size, uint64_t addres
     config.static_vc = get_tt_device()->get_architecture_implementation()->get_static_vc();
     std::unique_ptr<TlbWindow> tlb_window = allocate_tlb_window(config, TlbMapping::WC, tlb_size);
 
+    // Simulation TTDevices have no PCI device; report chip 0 in the log line in that case.
     log_debug(
         LogUMD,
         "Configured TLB window for chip: {} core: {} size: {} address: {} ordering: {} tlb_id: {}",
-        tt_device_->get_pci_device()->get_device_num(),
+        tt_device_->get_pci_device() != nullptr ? tt_device_->get_pci_device()->get_device_num() : 0,
         core.str(),
         tlb_size,
         address,

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -914,6 +914,8 @@ void Cluster::read_from_sysmem(void* mem_ptr, uint64_t addr, uint16_t channel, u
     get_chip(src_device_id)->read_from_sysmem(channel, mem_ptr, addr, size);
 }
 
+void Cluster::advance_device_execution(ChipId device_id) { get_chip(device_id)->advance_device_execution(); }
+
 void Cluster::l1_membar(const ChipId chip, const std::unordered_set<CoreCoord>& cores) {
     get_chip(chip)->l1_membar(cores);
 }

--- a/device/pcie/tt_sim_tlb_handle.cpp
+++ b/device/pcie/tt_sim_tlb_handle.cpp
@@ -55,8 +55,6 @@ std::unique_ptr<TTSimTlbHandle> TTSimTlbHandle::create(
     return std::unique_ptr<TTSimTlbHandle>(new TTSimTlbHandle(manager, communicator, tlb_id, size, tlb_mapping));
 }
 
-TTSimTlbHandle::~TTSimTlbHandle() noexcept { TTSimTlbHandle::free_tlb(); }
-
 void TTSimTlbHandle::configure(const tlb_data& new_config) {
     tlb_config_ = new_config;
     tlb_config_.local_offset = new_config.local_offset / tlb_size_;

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -405,6 +405,8 @@ ChipInfo TTDevice::get_chip_info() {
 
 uint32_t TTDevice::get_max_clock_freq() { return get_firmware_info_provider()->get_max_clock_freq(); }
 
+void TTDevice::advance_device_execution() {}
+
 uint32_t TTDevice::get_risc_reset_state(tt_xy_pair core) {
     uint32_t tensix_risc_state;
     read_from_device(&tensix_risc_state, core, architecture_impl_->get_tensix_soft_reset_addr(), sizeof(uint32_t));

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -194,6 +194,17 @@ void TTSimTTDevice::deassert_risc_reset(tt_xy_pair core, const RiscType selected
     }
 }
 
+void TTSimTTDevice::advance_device_execution() {
+    // Simulator clocking is driven synchronously from the calling thread to keep the simulation
+    // deterministic. A background clock thread would race with reads/writes and produce
+    // non-reproducible runs, so we advance the clock here instead.
+    // Ideally we would not auto-clock on reads at all, but some clocking is required to avoid
+    // hangs in the absence of an API reliably called from all spin loops polling the device.
+    if (communicator_) {
+        communicator_->advance_clock(1);
+    }
+}
+
 void TTSimTTDevice::dma_d2h(void* dst, uint32_t src, size_t size) {
     UMD_THROW(error::RuntimeError, "DMA operations are not supported in TTSim simulation device.");
 }


### PR DESCRIPTION
### Issue
/

### Description
Enables fast-dispatch execution on the TT simulator (`tt-sim`). Adds a `Cluster::advance_device_execution` API that lets clients advance the simulation clock from the calling thread, plus a couple of simulation-only fixes encountered while bringing up fast-dispatch.

**Why no clocking thread?** Simulator clocking must remain deterministic so runs are reproducible. A background thread driving `advance_clock` would race with reads/writes and produce non-reproducible behavior, so the clock is advanced synchronously from the calling thread via the explicit `advance_device_execution` API. The same rationale is captured in code on `TTDevice::advance_device_execution` and `TTSimTTDevice::advance_device_execution`.

### List of the changes
- Added `virtual void advance_device_execution()` on `TTDevice` (no-op default), overridden by `TTSimTTDevice` to call `communicator_->advance_clock(1)` — the API lives at the device layer so chip/cluster code is a thin pass-through.
- Added `void Chip::advance_device_execution()` that delegates to its underlying `TTDevice`.
- Added `Cluster::advance_device_execution(ChipId)` public API that forwards to the chip.
- Made `TLBManager::configure_tlb` debug logging safe when `get_pci_device()` returns nullptr (simulation case) and added an inline comment explaining the chip-id 0 fallback.
- Fixed `TTSimTlbHandle`'s destructor to avoid teardown issues (defaulted, no `free_tlb()` call — the manager/communicator may already be torn down by the time the handle dies during simulation chip shutdown).
- Minor pointer-style cleanup in `SimulationSysmemManager` (`void *` → `void*`, picked up by clang-format).

### Testing
CI

### API Changes
This PR adds a new function to the public API: `Cluster::advance_device_execution(ChipId device_id)`. This is a non-breaking additive change.