### PR TITLE
Add simulation accessor virtual methods to TTDevice base class

### DIFF
--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -59,9 +59,9 @@ public:
 
     RtlSimCommunicator* get_communicator() { return communicator_.get(); }
 
-    SimulationSysmemManager* get_sysmem_manager() { return sysmem_manager_.get(); }
+    SimulationSysmemManager* get_sysmem_manager() override { return sysmem_manager_.get(); }
 
-    TLBManager* get_tlb_manager();
+    TLBManager* get_tlb_manager() override;
 
 protected:
     void retrain_dram_core(const uint32_t dram_channel) override;

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -38,6 +38,7 @@ namespace tt::umd {
 class ArcMessenger;
 class ArcTelemetryReader;
 class RemoteCommunication;
+class SimulationSysmemManager;
 
 // Represents the status of the ETH core.
 enum class EthTrainingStatus {
@@ -400,6 +401,10 @@ public:
      * @param staggered_start Whether to use staggered start
      */
     virtual void deassert_risc_reset(tt_xy_pair core, const RiscType selected_riscs, bool staggered_start);
+
+    virtual SimulationSysmemManager *get_sysmem_manager() { return nullptr; }
+
+    virtual TLBManager *get_tlb_manager() { return nullptr; }
 
     virtual void dma_write_to_device(const void *src, size_t size, tt_xy_pair core, uint64_t addr);
 

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -65,9 +65,9 @@ public:
      */
     TTSimCommunicator *get_communicator() { return communicator_.get(); }
 
-    SimulationSysmemManager *get_sysmem_manager() { return sysmem_manager_.get(); }
+    SimulationSysmemManager *get_sysmem_manager() override { return sysmem_manager_.get(); }
 
-    TLBManager *get_tlb_manager();
+    TLBManager *get_tlb_manager() override;
 
     uint64_t bar0_base = 0;
 


### PR DESCRIPTION
### Issue
/

### Description
Move get_soc_descriptor, get_sysmem_manager, and get_tlb_manager into the TTDevice base class as virtual methods (returning nullptr by default), so simulation TTDevice subclasses can be used polymorphically behind a TTDevice pointer without downcasting for these accessors.

### List of the changes
- Add virtual get_soc_descriptor(), get_sysmem_manager(), get_tlb_manager() to TTDevice (default: nullptr)
- Add forward declarations for SocDescriptor and SimulationSysmemManager in tt_device.hpp
- Mark overrides in TTSimTTDevice and RtlSimulationTTDevice with override keyword

### Testing
CI

### API Changes
This PR has API changes:
- Non-breaking: adds new virtual methods to TTDevice with nullptr defaults