### PR TITLE
Add NEO DM uncore reset commands for RTL simulation

### DIFF
--- a/device/api/umd/device/chip/chip.hpp
+++ b/device/api/umd/device/chip/chip.hpp
@@ -50,8 +50,8 @@ public:
     virtual void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) = 0;
     virtual void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) = 0;
 
-    virtual void write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) = 0;
-    virtual void read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) = 0;
+    virtual void write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, size_t size) = 0;
+    virtual void read_from_device(CoreCoord core, void* dest, uint64_t l1_src, size_t size) = 0;
     virtual void write_to_device_reg(CoreCoord core, const void* src, uint64_t reg_dest, uint32_t size) = 0;
     virtual void read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_src, uint32_t size) = 0;
     virtual void dma_write_to_device(const void* src, size_t size, CoreCoord core, uint64_t addr) = 0;

--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -50,8 +50,8 @@ public:
     void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) override;
     void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) override;
 
-    void write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) override;
-    void read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) override;
+    void write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, size_t size) override;
+    void read_from_device(CoreCoord core, void* dest, uint64_t l1_src, size_t size) override;
     void write_to_device_reg(CoreCoord core, const void* src, uint64_t reg_dest, uint32_t size) override;
     void read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_src, uint32_t size) override;
     void noc_multicast_write(void* dst, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;

--- a/device/api/umd/device/chip/mock_chip.hpp
+++ b/device/api/umd/device/chip/mock_chip.hpp
@@ -24,8 +24,8 @@ public:
     void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) override;
     void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) override;
 
-    void write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) override;
-    void read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) override;
+    void write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, size_t size) override;
+    void read_from_device(CoreCoord core, void* dest, uint64_t l1_src, size_t size) override;
     void write_to_device_reg(CoreCoord core, const void* src, uint64_t reg_dest, uint32_t size) override;
     void read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_src, uint32_t size) override;
     void dma_write_to_device(const void* src, size_t size, CoreCoord core, uint64_t addr) override;

--- a/device/api/umd/device/chip/remote_chip.hpp
+++ b/device/api/umd/device/chip/remote_chip.hpp
@@ -50,8 +50,8 @@ public:
     void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) override;
     void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) override;
 
-    void write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) override;
-    void read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) override;
+    void write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, size_t size) override;
+    void read_from_device(CoreCoord core, void* dest, uint64_t l1_src, size_t size) override;
     void write_to_device_reg(CoreCoord core, const void* src, uint64_t reg_dest, uint32_t size) override;
     void read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_src, uint32_t size) override;
     void dma_write_to_device(const void* src, size_t size, CoreCoord core, uint64_t addr) override;

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -360,7 +360,7 @@ public:
      * @param core Core to target.
      * @param addr Address to write to.
      */
-    void write_to_device(const void* mem_ptr, uint32_t size_in_bytes, ChipId chip, CoreCoord core, uint64_t addr);
+    void write_to_device(const void* mem_ptr, size_t size_in_bytes, ChipId chip, CoreCoord core, uint64_t addr);
 
     /**
      * Read uint32_t data from a specified device, core and address to host memory (defined for Silicon).
@@ -373,7 +373,7 @@ public:
      * @param addr Address to read from.
      * @param size Number of bytes to read.
      */
-    void read_from_device(void* mem_ptr, ChipId chip, CoreCoord core, uint64_t addr, uint32_t size);
+    void read_from_device(void* mem_ptr, ChipId chip, CoreCoord core, uint64_t addr, size_t size);
 
     /**
      * Write uint32_t data (as specified by ptr + len pair) to specified device, core and address (defined for Silicon).

--- a/device/api/umd/device/pcie/silicon_tlb_window.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_window.hpp
@@ -49,11 +49,11 @@ public:
         const void* mem_ptr,
         tt_xy_pair core,
         uint64_t addr,
-        uint32_t size,
+        size_t size,
         uint64_t ordering = tlb_data::Strict) override;
 
     void safe_read_block_reconfigure(
-        void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering = tlb_data::Strict) override;
+        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, uint64_t ordering = tlb_data::Strict) override;
 
     void safe_noc_multicast_write_reconfigure(
         void* dst,

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -35,10 +35,10 @@ public:
 
     // Shared higher-level methods that use the virtual methods above.
     virtual void read_block_reconfigure(
-        void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering = tlb_data::Strict);
+        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, uint64_t ordering = tlb_data::Strict);
 
     virtual void write_block_reconfigure(
-        const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering = tlb_data::Strict);
+        const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, uint64_t ordering = tlb_data::Strict);
 
     virtual void noc_multicast_write_reconfigure(
         void* dst,
@@ -65,10 +65,10 @@ public:
     virtual void safe_read_block(uint64_t offset, void* data, size_t size);
 
     virtual void safe_write_block_reconfigure(
-        const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering = tlb_data::Strict);
+        const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, uint64_t ordering = tlb_data::Strict);
 
     virtual void safe_read_block_reconfigure(
-        void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering = tlb_data::Strict);
+        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, uint64_t ordering = tlb_data::Strict);
 
     virtual void safe_noc_multicast_write_reconfigure(
         void* dst,

--- a/device/api/umd/device/simulation/rtl_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/rtl_sim_communicator.hpp
@@ -124,6 +124,32 @@ public:
     void neo_dm_reset_deassert(uint32_t x, uint32_t y, uint32_t dm_index);
 
     /**
+     * Assert uncore reset for all NEO DM cores across all tensix cores.
+     */
+    void all_neo_dms_uncore_reset_assert();
+
+    /**
+     * Deassert uncore reset for all NEO DM cores across all tensix cores.
+     */
+    void all_neo_dms_uncore_reset_deassert();
+
+    /**
+     * Assert uncore reset for NEO DM cores on a specific tensix core.
+     *
+     * @param x Core X coordinate.
+     * @param y Core Y coordinate.
+     */
+    void neo_dm_uncore_reset_assert(uint32_t x, uint32_t y);
+
+    /**
+     * Deassert uncore reset for NEO DM cores on a specific tensix core.
+     *
+     * @param x Core X coordinate.
+     * @param y Core Y coordinate.
+     */
+    void neo_dm_uncore_reset_deassert(uint32_t x, uint32_t y);
+
+    /**
      * Get the simulation host reference.
      *
      * @return Reference to the SimulationHost

--- a/device/api/umd/device/simulation/rtl_simulation_chip.hpp
+++ b/device/api/umd/device/simulation/rtl_simulation_chip.hpp
@@ -26,8 +26,8 @@ public:
     void start_device() override;
     void close_device() override;
 
-    void write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) override;
-    void read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) override;
+    void write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, size_t size) override;
+    void read_from_device(CoreCoord core, void* dest, uint64_t l1_src, size_t size) override;
 
     void send_tensix_risc_reset(tt_xy_pair translated_core, const TensixSoftResetOptions& soft_resets) override;
     void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) override;

--- a/device/api/umd/device/simulation/simulation_chip.hpp
+++ b/device/api/umd/device/simulation/simulation_chip.hpp
@@ -77,8 +77,8 @@ public:
     void close_device() override = 0;
 
     // All tt_xy_pair cores in this class are defined in VIRTUAL coords.
-    void write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) override = 0;
-    void read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) override = 0;
+    void write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, size_t size) override = 0;
+    void read_from_device(CoreCoord core, void* dest, uint64_t l1_src, size_t size) override = 0;
 
     virtual void send_tensix_risc_reset(tt_xy_pair translated_core, const TensixSoftResetOptions& soft_resets) = 0;
     void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) override = 0;

--- a/device/api/umd/device/simulation/tt_sim_chip.hpp
+++ b/device/api/umd/device/simulation/tt_sim_chip.hpp
@@ -28,8 +28,8 @@ public:
     void start_device() override;
     void close_device() override;
 
-    void write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) override;
-    void read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) override;
+    void write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, size_t size) override;
+    void read_from_device(CoreCoord core, void* dest, uint64_t l1_src, size_t size) override;
 
     void send_tensix_risc_reset(tt_xy_pair translated_core, const TensixSoftResetOptions& soft_resets) override;
     void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) override;

--- a/device/api/umd/device/tt_device/protocol/device_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/device_protocol.hpp
@@ -23,8 +23,8 @@ class DeviceProtocol {
 public:
     virtual ~DeviceProtocol() = default;
 
-    virtual void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) = 0;
-    virtual void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) = 0;
+    virtual void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) = 0;
+    virtual void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) = 0;
 
     // [[nodiscard]] tells the compiler that the return value should not be ignored.
     // This ensures the caller handles the software fallback

--- a/device/api/umd/device/tt_device/protocol/jtag_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/jtag_protocol.hpp
@@ -24,8 +24,8 @@ public:
     ~JtagProtocol() override;
 
     // DeviceProtocol interface.
-    void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
-    void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
+    void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
+    void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
     bool write_to_core_range(
         const void* mem_ptr, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, uint32_t size) override;
     int get_mmio_id() override;

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -33,8 +33,8 @@ public:
     ~PcieProtocol() override;
 
     // DeviceProtocol interface.
-    void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
-    void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
+    void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
+    void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
     bool write_to_core_range(
         const void* mem_ptr, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, uint32_t size) override;
     int get_mmio_id() override;
@@ -71,9 +71,9 @@ private:
     bool dma_transfer(void* buffer, size_t size, uint64_t addr, tlb_data config, DmaDirection direction);
 
     template <bool safe>
-    void write_to_device_impl(const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
+    void write_to_device_impl(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size);
     template <bool safe>
-    void read_from_device_impl(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
+    void read_from_device_impl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size);
 
     // Offset used to access NOC2AXI config + ARC specific memory (ICCM + CSM + APB).
     static constexpr uint32_t BAR0_OFFSET = 0x1FD00000;

--- a/device/api/umd/device/tt_device/protocol/remote_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/remote_protocol.hpp
@@ -26,8 +26,8 @@ public:
     ~RemoteProtocol() override = default;
 
     // DeviceProtocol interface.
-    void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
-    void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
+    void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
+    void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
     bool write_to_core_range(
         const void* mem_ptr, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, uint32_t size) override;
     int get_mmio_id() override;

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -31,8 +31,8 @@ public:
     static std::unique_ptr<RtlSimulationTTDevice> create(
         const std::filesystem::path& simulator_directory, int num_host_mem_channels = 0);
 
-    void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
-    void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
+    void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
+    void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
 
     SocDescriptor* get_soc_descriptor() { return &soc_descriptor_; }
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -162,8 +162,8 @@ public:
     // Read/write functions that always use same TLB entry. This is not supposed to be used
     // on any code path that is performance critical. It is used to read/write the data needed
     // to get the information to form cluster of chips, or just use base TTDevice functions.
-    virtual void read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
-    virtual void write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size);
+    virtual void read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size);
+    virtual void write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size);
 
     /**
      * NOC multicast write function that will write data to multiple cores on NOC grid. Multicast writes data to a grid

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -33,8 +33,8 @@ public:
     static std::unique_ptr<TTSimTTDevice> create(
         const std::filesystem::path &simulator_directory, int num_host_mem_channels = 0, bool copy_sim_binary = false);
 
-    void read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
-    void write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) override;
+    void read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
+    void write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
 
     SocDescriptor *get_soc_descriptor() { return &soc_descriptor_; }
 

--- a/device/api/umd/device/types/risc_type.hpp
+++ b/device/api/umd/device/types/risc_type.hpp
@@ -83,6 +83,10 @@ enum class RiscType : std::uint64_t {
     ALL_NEO_TRISCS = ALL_NEO0_TRISCS | ALL_NEO1_TRISCS | ALL_NEO2_TRISCS | ALL_NEO3_TRISCS,
     ALL_NEO_DMS = DM0 | DM1 | DM2 | DM3 | DM4 | DM5 | DM6 | DM7,
     ALL_NEO = ALL_NEO_TRISCS | ALL_NEO_DMS,
+
+    // Uncore reset flags for NEO DM cores.
+    ALL_NEO_DMS_UNCORE = 1ULL << 32,
+    NEO_DM_UNCORE = 1ULL << 33,
 };
 
 std::string RiscTypeToString(RiscType value);

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -262,7 +262,7 @@ void LocalChip::read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_s
     sysmem_manager_->read_from_sysmem(channel, dest, sysmem_src, size);
 }
 
-void LocalChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) {
+void LocalChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, size_t size) {
     log_trace(
         LogUMD,
         "Chip::write_to_device to {} dev {} core {} at 0x{:x} size: {}",
@@ -288,7 +288,7 @@ void LocalChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_des
     }
 }
 
-void LocalChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) {
+void LocalChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, size_t size) {
     log_trace(
         LogUMD,
         "Chip::read_from_device from {} device {} core {} at 0x{:x} size: {}",

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -39,9 +39,9 @@ void MockChip::write_to_sysmem(uint16_t channel, const void* src, uint64_t sysme
 
 void MockChip::read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) {}
 
-void MockChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) {}
+void MockChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, size_t size) {}
 
-void MockChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) {}
+void MockChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, size_t size) {}
 
 void MockChip::write_to_device_reg(CoreCoord core, const void* src, uint64_t reg_dest, uint32_t size) {}
 

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -98,11 +98,11 @@ void RemoteChip::close_device() {
     }
 }
 
-void RemoteChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) {
+void RemoteChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, size_t size) {
     tt_device_->write_to_device(src, get_soc_descriptor().translate_chip_coord_to_translated(core), l1_dest, size);
 }
 
-void RemoteChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) {
+void RemoteChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, size_t size) {
     tt_device_->read_from_device(dest, get_soc_descriptor().translate_chip_coord_to_translated(core), l1_src, size);
 }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -909,7 +909,7 @@ void Cluster::dram_membar(const ChipId chip, const std::unordered_set<uint32_t>&
     get_chip(chip)->dram_membar(channels);
 }
 
-void Cluster::write_to_device(const void* mem_ptr, uint32_t size_in_bytes, ChipId chip, CoreCoord core, uint64_t addr) {
+void Cluster::write_to_device(const void* mem_ptr, size_t size_in_bytes, ChipId chip, CoreCoord core, uint64_t addr) {
     get_chip(chip)->write_to_device(core, mem_ptr, addr, size_in_bytes);
 }
 
@@ -931,7 +931,7 @@ void Cluster::dma_multicast_write(
     get_chip(chip)->dma_multicast_write(src, size, core_start, core_end, addr);
 }
 
-void Cluster::read_from_device(void* mem_ptr, ChipId chip, CoreCoord core, uint64_t addr, uint32_t size) {
+void Cluster::read_from_device(void* mem_ptr, ChipId chip, CoreCoord core, uint64_t addr, size_t size) {
     get_chip(chip)->read_from_device(core, mem_ptr, addr, size);
 }
 

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -272,12 +272,12 @@ void SiliconTlbWindow::safe_read_block(uint64_t offset, void *data, size_t size)
 }
 
 void SiliconTlbWindow::safe_write_block_reconfigure(
-    const void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering) {
+    const void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, uint64_t ordering) {
     execute_safe(&SiliconTlbWindow::write_block_reconfigure, mem_ptr, core, addr, size, ordering);
 }
 
 void SiliconTlbWindow::safe_read_block_reconfigure(
-    void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering) {
+    void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, uint64_t ordering) {
     execute_safe(&SiliconTlbWindow::read_block_reconfigure, mem_ptr, core, addr, size, ordering);
 }
 

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -23,8 +23,7 @@ TlbWindow::TlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config) :
     offset_from_aligned_addr = config.local_offset - (config.local_offset & ~(tlb_handle->get_size() - 1));
 }
 
-void TlbWindow::read_block_reconfigure(
-    void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering) {
+void TlbWindow::read_block_reconfigure(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, uint64_t ordering) {
     uint8_t* buffer_addr = static_cast<uint8_t*>(mem_ptr);
     tlb_data config{};
     config.local_offset = addr;
@@ -36,8 +35,8 @@ void TlbWindow::read_block_reconfigure(
 
     while (size > 0) {
         configure(config);
-        uint32_t tlb_size = get_size();
-        uint32_t transfer_size = std::min(size, tlb_size);
+        size_t tlb_size = get_size();
+        size_t transfer_size = std::min(size, tlb_size);
 
         read_block(0, buffer_addr, transfer_size);
 
@@ -50,7 +49,7 @@ void TlbWindow::read_block_reconfigure(
 }
 
 void TlbWindow::write_block_reconfigure(
-    const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering) {
+    const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, uint64_t ordering) {
     const uint8_t* buffer_addr = static_cast<const uint8_t*>(mem_ptr);
     tlb_data config{};
     config.local_offset = addr;
@@ -62,9 +61,9 @@ void TlbWindow::write_block_reconfigure(
 
     while (size > 0) {
         configure(config);
-        uint32_t tlb_size = get_size();
+        size_t tlb_size = get_size();
 
-        uint32_t transfer_size = std::min(size, tlb_size);
+        size_t transfer_size = std::min(size, tlb_size);
 
         write_block(0, buffer_addr, transfer_size);
 
@@ -94,7 +93,7 @@ void TlbWindow::noc_multicast_write_reconfigure(
         configure(config);
         size_t tlb_size = get_size();
 
-        uint32_t transfer_size = std::min(size, tlb_size);
+        size_t transfer_size = std::min(size, tlb_size);
 
         write_block(0, buffer_addr, transfer_size);
 
@@ -144,12 +143,12 @@ void TlbWindow::safe_write_block(uint64_t offset, const void* data, size_t size)
 void TlbWindow::safe_read_block(uint64_t offset, void* data, size_t size) { read_block(offset, data, size); }
 
 void TlbWindow::safe_write_block_reconfigure(
-    const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering) {
+    const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, uint64_t ordering) {
     write_block_reconfigure(mem_ptr, core, addr, size, ordering);
 }
 
 void TlbWindow::safe_read_block_reconfigure(
-    void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size, uint64_t ordering) {
+    void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, uint64_t ordering) {
     read_block_reconfigure(mem_ptr, core, addr, size, ordering);
 }
 

--- a/device/simulation/rtl_sim_communicator.cpp
+++ b/device/simulation/rtl_sim_communicator.cpp
@@ -235,6 +235,34 @@ void RtlSimCommunicator::neo_dm_reset_deassert(uint32_t x, uint32_t y, uint32_t 
         host_, create_flatbuffer(DEVICE_COMMAND_NEO_DM_RESET_DEASSERT, {0}, core, dm_index));
 }
 
+void RtlSimCommunicator::all_neo_dms_uncore_reset_assert() {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    log_debug(tt::LogEmulationDriver, "Sending all_neo_dms_uncore_reset_assert signal.");
+    tt_xy_pair core = {0, 0};
+    send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_ALL_NEO_DMS_UNCORE_RESET_ASSERT, core));
+}
+
+void RtlSimCommunicator::all_neo_dms_uncore_reset_deassert() {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    log_debug(tt::LogEmulationDriver, "Sending all_neo_dms_uncore_reset_deassert signal.");
+    tt_xy_pair core = {0, 0};
+    send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_ALL_NEO_DMS_UNCORE_RESET_DEASSERT, core));
+}
+
+void RtlSimCommunicator::neo_dm_uncore_reset_assert(uint32_t x, uint32_t y) {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    log_debug(tt::LogEmulationDriver, "Sending neo_dm_uncore_reset_assert signal to core ({}, {}).", x, y);
+    tt_xy_pair core = {x, y};
+    send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_NEO_DM_UNCORE_RESET_ASSERT, core));
+}
+
+void RtlSimCommunicator::neo_dm_uncore_reset_deassert(uint32_t x, uint32_t y) {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    log_debug(tt::LogEmulationDriver, "Sending neo_dm_uncore_reset_deassert signal to core ({}, {}).", x, y);
+    tt_xy_pair core = {x, y};
+    send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_NEO_DM_UNCORE_RESET_DEASSERT, core));
+}
+
 void RtlSimCommunicator::set_ram_callbacks(RamWriteCallback write_cb, RamReadCallback read_cb) {
     ram_write_callback_ = std::move(write_cb);
     ram_read_callback_ = std::move(read_cb);

--- a/device/simulation/rtl_simulation_chip.cpp
+++ b/device/simulation/rtl_simulation_chip.cpp
@@ -30,13 +30,13 @@ void RtlSimulationChip::start_device() {}
 
 void RtlSimulationChip::close_device() {}
 
-void RtlSimulationChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) {
+void RtlSimulationChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, size_t size) {
     std::lock_guard<std::mutex> lock(device_lock);
     tt_xy_pair translate_core = soc_descriptor_.translate_chip_coord_to_translated(core);
     tt_device_->write_to_device(src, translate_core, l1_dest, size);
 }
 
-void RtlSimulationChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) {
+void RtlSimulationChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, size_t size) {
     std::lock_guard<std::mutex> lock(device_lock);
     tt_xy_pair translate_core = soc_descriptor_.translate_chip_coord_to_translated(core);
     tt_device_->read_from_device(dest, translate_core, l1_src, size);

--- a/device/simulation/simulation_device.fbs
+++ b/device/simulation/simulation_device.fbs
@@ -17,6 +17,10 @@ enum DEVICE_COMMAND : byte {
     // to match these values before this can work end-to-end.
     AXI_RAM_WRITE_NOTIFICATION = 10,
     AXI_RAM_READ_NOTIFICATION = 11,
+    ALL_NEO_DMS_UNCORE_RESET_DEASSERT = 14,
+    ALL_NEO_DMS_UNCORE_RESET_ASSERT = 15,
+    NEO_DM_UNCORE_RESET_ASSERT = 16,
+    NEO_DM_UNCORE_RESET_DEASSERT = 17,
 }
 
 struct tt_vcs_core {

--- a/device/simulation/tt_sim_chip.cpp
+++ b/device/simulation/tt_sim_chip.cpp
@@ -43,12 +43,12 @@ void TTSimChip::start_device() {}
 
 void TTSimChip::close_device() {}
 
-void TTSimChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, uint32_t size) {
+void TTSimChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, size_t size) {
     std::lock_guard<std::mutex> lock(device_lock);
     tt_device_->write_to_device(src, soc_descriptor_.translate_chip_coord_to_translated(core), l1_dest, size);
 }
 
-void TTSimChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, uint32_t size) {
+void TTSimChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, size_t size) {
     std::lock_guard<std::mutex> lock(device_lock);
     tt_device_->read_from_device(dest, soc_descriptor_.translate_chip_coord_to_translated(core), l1_src, size);
 }

--- a/device/tt_device/protocol/jtag_protocol.cpp
+++ b/device/tt_device/protocol/jtag_protocol.cpp
@@ -16,11 +16,11 @@ JtagProtocol::JtagProtocol(std::unique_ptr<JtagDevice> jtag_device, uint8_t jlin
 
 JtagProtocol::~JtagProtocol() = default;
 
-void JtagProtocol::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
+void JtagProtocol::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     jtag_device_->write(mmio_id_, mem_ptr, core.x, core.y, addr, size, is_selected_noc1() ? 1 : 0);
 }
 
-void JtagProtocol::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
+void JtagProtocol::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     jtag_device_->read(mmio_id_, mem_ptr, core.x, core.y, addr, size, is_selected_noc1() ? 1 : 0);
 }
 

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -57,7 +57,7 @@ TlbWindow* PcieProtocol::get_cached_tlb_window() {
     return cached_tlb_window_.get();
 }
 
-void PcieProtocol::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
+void PcieProtocol::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     std::lock_guard<std::mutex> lock(io_lock_);
     if (use_safe_api_) {
         write_to_device_impl<true>(mem_ptr, core, addr, size);
@@ -66,7 +66,7 @@ void PcieProtocol::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_
     }
 }
 
-void PcieProtocol::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
+void PcieProtocol::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     std::lock_guard<std::mutex> lock(io_lock_);
     if (use_safe_api_) {
         read_from_device_impl<true>(mem_ptr, core, addr, size);
@@ -76,7 +76,7 @@ void PcieProtocol::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t add
 }
 
 template <bool safe>
-void PcieProtocol::write_to_device_impl(const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
+void PcieProtocol::write_to_device_impl(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     if constexpr (safe) {
         get_cached_tlb_window()->safe_write_block_reconfigure(mem_ptr, core, addr, size);
     } else {
@@ -85,7 +85,7 @@ void PcieProtocol::write_to_device_impl(const void* mem_ptr, tt_xy_pair core, ui
 }
 
 template <bool safe>
-void PcieProtocol::read_from_device_impl(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
+void PcieProtocol::read_from_device_impl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     if constexpr (safe) {
         get_cached_tlb_window()->safe_read_block_reconfigure(mem_ptr, core, addr, size);
     } else {

--- a/device/tt_device/protocol/remote_protocol.cpp
+++ b/device/tt_device/protocol/remote_protocol.cpp
@@ -13,11 +13,11 @@ namespace tt::umd {
 RemoteProtocol::RemoteProtocol(std::unique_ptr<RemoteCommunication> remote_communication) :
     remote_communication_(std::move(remote_communication)) {}
 
-void RemoteProtocol::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
+void RemoteProtocol::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     remote_communication_->write_to_non_mmio(core, mem_ptr, addr, size);
 }
 
-void RemoteProtocol::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
+void RemoteProtocol::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     remote_communication_->read_non_mmio(core, mem_ptr, addr, size);
 }
 

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -142,8 +142,15 @@ void RtlSimulationTTDevice::assert_risc_reset(tt_xy_pair core, const RiscType se
     // If the architecture is Quasar, a special case is needed to control the NEO Data Movement cores.
     if (soc_descriptor_.arch == tt::ARCH::QUASAR) {
         if (selected_riscs == RiscType::ALL_NEO_DMS) {
-            // Reset all DM cores.
             communicator_->all_neo_dms_reset_assert(core.x, core.y);
+            return;
+        }
+        if (selected_riscs == RiscType::ALL_NEO_DMS_UNCORE) {
+            communicator_->all_neo_dms_uncore_reset_assert();
+            return;
+        }
+        if ((selected_riscs & RiscType::NEO_DM_UNCORE) != RiscType::NONE) {
+            communicator_->neo_dm_uncore_reset_assert(core.x, core.y);
             return;
         }
         // Check if this is a request per individual DM core reset.
@@ -170,8 +177,15 @@ void RtlSimulationTTDevice::deassert_risc_reset(tt_xy_pair core, const RiscType 
     // See the comment in assert_risc_reset for more details.
     if (soc_descriptor_.arch == tt::ARCH::QUASAR) {
         if (selected_riscs == RiscType::ALL_NEO_DMS) {
-            // Reset all DM cores.
             communicator_->all_neo_dms_reset_deassert(core.x, core.y);
+            return;
+        }
+        if (selected_riscs == RiscType::ALL_NEO_DMS_UNCORE) {
+            communicator_->all_neo_dms_uncore_reset_deassert();
+            return;
+        }
+        if ((selected_riscs & RiscType::NEO_DM_UNCORE) != RiscType::NONE) {
+            communicator_->neo_dm_uncore_reset_deassert(core.x, core.y);
             return;
         }
         // Check if this is a request per individual DM core reset.

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -94,7 +94,7 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
 
 RtlSimulationTTDevice::~RtlSimulationTTDevice() { communicator_->shutdown(); }
 
-void RtlSimulationTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
+void RtlSimulationTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     std::lock_guard<std::recursive_mutex> lock(device_lock);
     log_debug(tt::LogEmulationDriver, "Device writing {} bytes to l1_dest {} in core {}", size, addr, core.str());
     if (cached_tlb_window_) {
@@ -104,7 +104,7 @@ void RtlSimulationTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core
     }
 }
 
-void RtlSimulationTTDevice::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
+void RtlSimulationTTDevice::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     std::lock_guard<std::recursive_mutex> lock(device_lock);
     if (cached_tlb_window_) {
         cached_tlb_window_->read_block_reconfigure(mem_ptr, core, addr, size);

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -261,11 +261,11 @@ void TTDevice::write_regs(volatile uint32_t *dest, const uint32_t *src, uint32_t
     get_pcie_interface()->write_regs(dest, src, word_len);
 }
 
-void TTDevice::read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
+void TTDevice::read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     device_protocol_->read_from_device(mem_ptr, core, addr, size);
 }
 
-void TTDevice::write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
+void TTDevice::write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     device_protocol_->write_to_device(mem_ptr, core, addr, size);
 }
 

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -89,7 +89,7 @@ TTSimTTDevice::TTSimTTDevice(
 
 TTSimTTDevice::~TTSimTTDevice() { communicator_->shutdown(); }
 
-void TTSimTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
+void TTSimTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     std::lock_guard<std::recursive_mutex> lock(device_lock);
     if (cached_tlb_window_) {
         cached_tlb_window_->write_block_reconfigure(mem_ptr, core, addr, size);
@@ -98,7 +98,7 @@ void TTSimTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64
     }
 }
 
-void TTSimTTDevice::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
+void TTSimTTDevice::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     std::lock_guard<std::recursive_mutex> lock(device_lock);
     if (cached_tlb_window_) {
         cached_tlb_window_->read_block_reconfigure(mem_ptr, core, addr, size);

--- a/device/types/risc_type.cpp
+++ b/device/types/risc_type.cpp
@@ -111,6 +111,14 @@ std::string RiscTypeToString(RiscType value) {
         output += "DM7 | ";
     }
 
+    // Check NEO DM uncore reset flags.
+    if ((value & RiscType::ALL_NEO_DMS_UNCORE) != RiscType::NONE) {
+        output += "ALL_NEO_DMS_UNCORE | ";
+    }
+    if ((value & RiscType::NEO_DM_UNCORE) != RiscType::NONE) {
+        output += "NEO_DM_UNCORE | ";
+    }
+
     if (output.empty()) {
         output = "NONE";
     } else {

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -191,7 +191,7 @@ void bind_tt_device(nb::module_ &m) {
             "Write a 32-bit value to a core at the specified address")
         .def(
             "noc_read",
-            [](TTDevice &self, uint32_t core_x, uint32_t core_y, uint64_t addr, uint32_t size) -> nb::bytes {
+            [](TTDevice &self, uint32_t core_x, uint32_t core_y, uint64_t addr, size_t size) -> nb::bytes {
                 tt_xy_pair core = {core_x, core_y};
                 std::vector<uint8_t> buffer(size);
                 self.read_from_device(buffer.data(), core, addr, size);
@@ -212,7 +212,7 @@ void bind_tt_device(nb::module_ &m) {
                 tt_xy_pair core = {core_x, core_y};
                 uint8_t *data_ptr = reinterpret_cast<uint8_t *>(buffer.data());
                 size_t data_size = buffer.size();
-                self.read_from_device(data_ptr, core, addr, static_cast<uint32_t>(data_size));
+                self.read_from_device(data_ptr, core, addr, data_size);
             },
             nb::arg("noc_id"),
             nb::arg("core_x"),
@@ -226,7 +226,7 @@ void bind_tt_device(nb::module_ &m) {
                 tt_xy_pair core = {core_x, core_y};
                 const char *data_ptr = data.c_str();
                 size_t data_size = data.size();
-                self.write_to_device(data_ptr, core, addr, static_cast<uint32_t>(data_size));
+                self.write_to_device(data_ptr, core, addr, data_size);
             },
             nb::arg("core_x"),
             nb::arg("core_y"),
@@ -279,7 +279,7 @@ void bind_tt_device(nb::module_ &m) {
             "The bit layout of this value corresponds to TensixSoftResetOptions; do not pass RiscType bits here.")
         .def(
             "dma_read_from_device",
-            [](TTDevice &self, uint32_t core_x, uint32_t core_y, uint64_t addr, uint32_t size) -> nb::bytes {
+            [](TTDevice &self, uint32_t core_x, uint32_t core_y, uint64_t addr, size_t size) -> nb::bytes {
                 tt_xy_pair core = {core_x, core_y};
                 std::vector<uint8_t> buffer(size);
                 self.dma_read_from_device(buffer.data(), size, core, addr);
@@ -300,7 +300,7 @@ void bind_tt_device(nb::module_ &m) {
                 tt_xy_pair core = {core_x, core_y};
                 uint8_t *data_ptr = reinterpret_cast<uint8_t *>(buffer.data());
                 size_t data_size = buffer.size();
-                self.dma_read_from_device(data_ptr, static_cast<uint32_t>(data_size), core, addr);
+                self.dma_read_from_device(data_ptr, data_size, core, addr);
             },
             nb::arg("noc_id"),
             nb::arg("core_x"),
@@ -314,7 +314,7 @@ void bind_tt_device(nb::module_ &m) {
                 tt_xy_pair core = {core_x, core_y};
                 const char *data_ptr = data.c_str();
                 size_t data_size = data.size();
-                self.dma_write_to_device(data_ptr, static_cast<uint32_t>(data_size), core, addr);
+                self.dma_write_to_device(data_ptr, data_size, core, addr);
             },
             nb::arg("core_x"),
             nb::arg("core_y"),


### PR DESCRIPTION
### Issue
/

### Description
Add support for NEO DM uncore reset assert/deassert commands in the RTL simulation
communicator, with both per-core and all-cores variants.

### List of the changes
- Add 4 new DEVICE_COMMAND enum values to the FlatBuffers schema (14-17)
- Add 4 new methods to RtlSimCommunicator for uncore reset assert/deassert
- Add RiscType::ALL_NEO_DMS_UNCORE and RiscType::NEO_DM_UNCORE flags
- Wire up uncore reset in RtlSimulationTTDevice::assert_risc_reset/deassert_risc_reset

### Testing
CI

### API Changes
This PR has API changes:
- New RiscType flags: ALL_NEO_DMS_UNCORE, NEO_DM_UNCORE
- New RtlSimCommunicator methods for uncore reset