### PR TITLE
Add NEO DM uncore reset commands for RTL simulation

### DIFF
--- a/device/api/umd/device/simulation/rtl_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/rtl_sim_communicator.hpp
@@ -123,6 +123,32 @@ public:
     void neo_dm_reset_deassert(uint32_t x, uint32_t y, uint32_t dm_index);
 
     /**
+     * Assert uncore reset for all NEO DM cores across all tensix cores.
+     */
+    void all_neo_dms_uncore_reset_assert();
+
+    /**
+     * Deassert uncore reset for all NEO DM cores across all tensix cores.
+     */
+    void all_neo_dms_uncore_reset_deassert();
+
+    /**
+     * Assert uncore reset for NEO DM cores on a specific tensix core.
+     *
+     * @param x Core X coordinate.
+     * @param y Core Y coordinate.
+     */
+    void neo_dm_uncore_reset_assert(uint32_t x, uint32_t y);
+
+    /**
+     * Deassert uncore reset for NEO DM cores on a specific tensix core.
+     *
+     * @param x Core X coordinate.
+     * @param y Core Y coordinate.
+     */
+    void neo_dm_uncore_reset_deassert(uint32_t x, uint32_t y);
+
+    /**
      * Get the simulation host reference.
      *
      * @return Reference to the SimulationHost

--- a/device/api/umd/device/types/risc_type.hpp
+++ b/device/api/umd/device/types/risc_type.hpp
@@ -83,6 +83,10 @@ enum class RiscType : std::uint64_t {
     ALL_NEO_TRISCS = ALL_NEO0_TRISCS | ALL_NEO1_TRISCS | ALL_NEO2_TRISCS | ALL_NEO3_TRISCS,
     ALL_NEO_DMS = DM0 | DM1 | DM2 | DM3 | DM4 | DM5 | DM6 | DM7,
     ALL_NEO = ALL_NEO_TRISCS | ALL_NEO_DMS,
+
+    // Uncore reset flags for NEO DM cores.
+    ALL_NEO_DMS_UNCORE = 1ULL << 32,
+    NEO_DM_UNCORE = 1ULL << 33,
 };
 
 std::string RiscTypeToString(RiscType value);

--- a/device/simulation/rtl_sim_communicator.cpp
+++ b/device/simulation/rtl_sim_communicator.cpp
@@ -238,6 +238,34 @@ void RtlSimCommunicator::neo_dm_reset_deassert(uint32_t x, uint32_t y, uint32_t 
         host_, create_flatbuffer(DEVICE_COMMAND_NEO_DM_RESET_DEASSERT, {0}, core, dm_index));
 }
 
+void RtlSimCommunicator::all_neo_dms_uncore_reset_assert() {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    log_debug(tt::LogEmulationDriver, "Sending all_neo_dms_uncore_reset_assert signal.");
+    tt_xy_pair core = {0, 0};
+    send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_ALL_NEO_DMS_UNCORE_RESET_ASSERT, core));
+}
+
+void RtlSimCommunicator::all_neo_dms_uncore_reset_deassert() {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    log_debug(tt::LogEmulationDriver, "Sending all_neo_dms_uncore_reset_deassert signal.");
+    tt_xy_pair core = {0, 0};
+    send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_ALL_NEO_DMS_UNCORE_RESET_DEASSERT, core));
+}
+
+void RtlSimCommunicator::neo_dm_uncore_reset_assert(uint32_t x, uint32_t y) {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    log_debug(tt::LogEmulationDriver, "Sending neo_dm_uncore_reset_assert signal to core ({}, {}).", x, y);
+    tt_xy_pair core = {x, y};
+    send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_NEO_DM_UNCORE_RESET_ASSERT, core));
+}
+
+void RtlSimCommunicator::neo_dm_uncore_reset_deassert(uint32_t x, uint32_t y) {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    log_debug(tt::LogEmulationDriver, "Sending neo_dm_uncore_reset_deassert signal to core ({}, {}).", x, y);
+    tt_xy_pair core = {x, y};
+    send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_NEO_DM_UNCORE_RESET_DEASSERT, core));
+}
+
 void RtlSimCommunicator::set_ram_callbacks(RamWriteCallback write_cb, RamReadCallback read_cb) {
     ram_write_callback_ = std::move(write_cb);
     ram_read_callback_ = std::move(read_cb);

--- a/device/simulation/simulation_device.fbs
+++ b/device/simulation/simulation_device.fbs
@@ -17,6 +17,10 @@ enum DEVICE_COMMAND : byte {
     // to match these values before this can work end-to-end.
     AXI_RAM_WRITE_NOTIFICATION = 10,
     AXI_RAM_READ_NOTIFICATION = 11,
+    ALL_NEO_DMS_UNCORE_RESET_DEASSERT = 14,
+    ALL_NEO_DMS_UNCORE_RESET_ASSERT = 15,
+    NEO_DM_UNCORE_RESET_ASSERT = 16,
+    NEO_DM_UNCORE_RESET_DEASSERT = 17,
 }
 
 struct tt_vcs_core {

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -145,8 +145,15 @@ void RtlSimulationTTDevice::assert_risc_reset(tt_xy_pair core, const RiscType se
     // If the architecture is Quasar, a special case is needed to control the NEO Data Movement cores.
     if (get_soc_descriptor().arch == tt::ARCH::QUASAR) {
         if (selected_riscs == RiscType::ALL_NEO_DMS) {
-            // Reset all DM cores.
             communicator_->all_neo_dms_reset_assert(core.x, core.y);
+            return;
+        }
+        if (selected_riscs == RiscType::ALL_NEO_DMS_UNCORE) {
+            communicator_->all_neo_dms_uncore_reset_assert();
+            return;
+        }
+        if ((selected_riscs & RiscType::NEO_DM_UNCORE) != RiscType::NONE) {
+            communicator_->neo_dm_uncore_reset_assert(core.x, core.y);
             return;
         }
         // Check if this is a request per individual DM core reset.
@@ -173,8 +180,15 @@ void RtlSimulationTTDevice::deassert_risc_reset(tt_xy_pair core, const RiscType 
     // See the comment in assert_risc_reset for more details.
     if (get_soc_descriptor().arch == tt::ARCH::QUASAR) {
         if (selected_riscs == RiscType::ALL_NEO_DMS) {
-            // Reset all DM cores.
             communicator_->all_neo_dms_reset_deassert(core.x, core.y);
+            return;
+        }
+        if (selected_riscs == RiscType::ALL_NEO_DMS_UNCORE) {
+            communicator_->all_neo_dms_uncore_reset_deassert();
+            return;
+        }
+        if ((selected_riscs & RiscType::NEO_DM_UNCORE) != RiscType::NONE) {
+            communicator_->neo_dm_uncore_reset_deassert(core.x, core.y);
             return;
         }
         // Check if this is a request per individual DM core reset.

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -144,6 +144,12 @@ void RtlSimulationTTDevice::assert_risc_reset(tt_xy_pair core, const RiscType se
     log_debug(tt::LogEmulationDriver, "Sending 'assert_risc_reset' signal for risc_type {}.", selected_riscs);
     // If the architecture is Quasar, a special case is needed to control the NEO Data Movement cores.
     if (get_soc_descriptor().arch == tt::ARCH::QUASAR) {
+        if (selected_riscs == RiscType::ALL) {
+            communicator_->all_tensix_reset_assert(core.x, core.y);
+            communicator_->all_neo_dms_reset_assert(core.x, core.y);
+            communicator_->all_neo_dms_uncore_reset_assert();
+            return;
+        }
         if (selected_riscs == RiscType::ALL_NEO_DMS) {
             communicator_->all_neo_dms_reset_assert(core.x, core.y);
             return;
@@ -179,6 +185,12 @@ void RtlSimulationTTDevice::deassert_risc_reset(tt_xy_pair core, const RiscType 
     log_debug(tt::LogEmulationDriver, "Sending 'deassert_risc_reset' signal for risc_type {}", selected_riscs);
     // See the comment in assert_risc_reset for more details.
     if (get_soc_descriptor().arch == tt::ARCH::QUASAR) {
+        if (selected_riscs == RiscType::ALL) {
+            communicator_->all_neo_dms_uncore_reset_deassert();
+            communicator_->all_neo_dms_reset_deassert(core.x, core.y);
+            communicator_->all_tensix_reset_deassert(core.x, core.y);
+            return;
+        }
         if (selected_riscs == RiscType::ALL_NEO_DMS) {
             communicator_->all_neo_dms_reset_deassert(core.x, core.y);
             return;

--- a/device/types/risc_type.cpp
+++ b/device/types/risc_type.cpp
@@ -111,6 +111,14 @@ std::string RiscTypeToString(RiscType value) {
         output += "DM7 | ";
     }
 
+    // Check NEO DM uncore reset flags.
+    if ((value & RiscType::ALL_NEO_DMS_UNCORE) != RiscType::NONE) {
+        output += "ALL_NEO_DMS_UNCORE | ";
+    }
+    if ((value & RiscType::NEO_DM_UNCORE) != RiscType::NONE) {
+        output += "NEO_DM_UNCORE | ";
+    }
+
     if (output.empty()) {
         output = "NONE";
     } else {


### PR DESCRIPTION
### Issue
/

### Description
Add support for NEO DM uncore reset assert/deassert commands in the RTL simulation
communicator, with both per-core and all-cores variants.

### List of the changes
- Add 4 new DEVICE_COMMAND enum values to the FlatBuffers schema (14-17)
- Add 4 new methods to RtlSimCommunicator for uncore reset assert/deassert
- Add RiscType::ALL_NEO_DMS_UNCORE and RiscType::NEO_DM_UNCORE flags
- Wire up uncore reset in RtlSimulationTTDevice::assert_risc_reset/deassert_risc_reset

### Testing
CI

### API Changes
This PR has API changes:
- New RiscType flags: ALL_NEO_DMS_UNCORE, NEO_DM_UNCORE
- New RtlSimCommunicator methods for uncore reset