### PR TITLE
Add unified open_tlb_window API for single-call TLB allocation and configuration

### DIFF
--- a/device/api/umd/device/chip/chip.hpp
+++ b/device/api/umd/device/chip/chip.hpp
@@ -7,11 +7,13 @@
 #include <chrono>
 #include <unordered_set>
 
+#include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/cluster_types.hpp"
 #include "umd/device/types/tensix_soft_reset_options.hpp"
+#include "umd/device/types/tlb.hpp"
 #include "umd/device/utils/lock_manager.hpp"
 #include "umd/device/utils/timeouts.hpp"
 
@@ -44,6 +46,17 @@ public:
     virtual TTDevice* get_tt_device() = 0;
     virtual SysmemManager* get_sysmem_manager() = 0;
     virtual TLBManager* get_tlb_manager() = 0;
+
+    // Allocate and configure a TLB window in a single call.
+    // Translates core to TRANSLATED coordinates and delegates to TLBManager.
+    // Can be called with just a core to reserve a TLB (address defaults to 0, ordering to Relaxed,
+    // mapping to WC, and tlb_size to 0 which auto-selects the best available size).
+    virtual std::unique_ptr<TlbWindow> open_tlb_window(
+        CoreCoord core,
+        uint64_t address = 0,
+        uint64_t ordering = tlb_data::Relaxed,
+        TlbMapping mapping = TlbMapping::WC,
+        size_t tlb_size = 0);
 
     virtual int get_num_host_channels() = 0;
     virtual int get_host_channel_size(std::uint32_t channel) = 0;

--- a/device/api/umd/device/chip_helpers/tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/tlb_manager.hpp
@@ -39,6 +39,17 @@ public:
 
     TlbWindow* get_tlb_window(const tt_xy_pair core);
 
+    // Allocate and configure a TLB window in a single call.
+    // The caller owns the returned window; it is not stored in internal maps.
+    // Can be called with just a core to reserve a TLB (address defaults to 0, ordering to Relaxed,
+    // mapping to WC, and tlb_size to 0 which auto-selects the best available size).
+    std::unique_ptr<TlbWindow> open_tlb_window(
+        tt_xy_pair core,
+        uint64_t address = 0,
+        uint64_t ordering = tlb_data::Relaxed,
+        TlbMapping mapping = TlbMapping::WC,
+        size_t tlb_size = 0);
+
     virtual std::unique_ptr<TlbWindow> allocate_tlb_window(
         tlb_data config, const TlbMapping mapping = TlbMapping::WC, const size_t tlb_size = 0);
 

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -493,6 +493,28 @@ public:
      */
     TlbWindow* get_static_tlb_window(const ChipId chip, const CoreCoord core);
 
+    /**
+     * Allocate and configure a TLB window in a single call.
+     * The caller owns the returned window and controls its lifetime.
+     * Can be called with just chip and core to reserve a TLB (address defaults to 0, ordering to Relaxed,
+     * mapping to WC, and tlb_size to 0 which auto-selects the best available size).
+     *
+     * @param chip Target chip ID.
+     * @param core Target core (any coordinate system).
+     * @param address Start address the TLB is mapped to. Default: 0.
+     * @param ordering Ordering mode (Relaxed, Strict, or Posted). Default: Relaxed.
+     * @param mapping TLB mapping type (WC or UC). Default: WC.
+     * @param tlb_size Requested TLB size in bytes. 0 means auto-select. Default: 0.
+     * @return A unique_ptr to the configured TlbWindow.
+     */
+    std::unique_ptr<TlbWindow> open_tlb_window(
+        ChipId chip,
+        CoreCoord core,
+        uint64_t address = 0,
+        uint64_t ordering = tlb_data::Relaxed,
+        TlbMapping mapping = TlbMapping::WC,
+        size_t tlb_size = 0);
+
     //---------- Functions for synchronization and memory barriers.
 
     /**

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -18,6 +18,7 @@
 #include "tracy.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/driver_atomics.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/types/blackhole_arc.hpp"
@@ -262,6 +263,12 @@ void Chip::noc_multicast_write(void* dst, size_t size, CoreCoord core_start, Cor
         get_soc_descriptor().translate_chip_coord_to_translated(core_start),
         get_soc_descriptor().translate_chip_coord_to_translated(core_end),
         addr);
+}
+
+std::unique_ptr<TlbWindow> Chip::open_tlb_window(
+    CoreCoord core, uint64_t address, uint64_t ordering, TlbMapping mapping, size_t tlb_size) {
+    tt_xy_pair translated_core = get_soc_descriptor().translate_chip_coord_to_translated(core);
+    return get_tlb_manager()->open_tlb_window(translated_core, address, ordering, mapping, tlb_size);
 }
 
 }  // namespace tt::umd

--- a/device/chip_helpers/tlb_manager.cpp
+++ b/device/chip_helpers/tlb_manager.cpp
@@ -94,6 +94,23 @@ tlb_configuration TLBManager::get_tlb_configuration(tt_xy_pair core) {
     return tt_device_->get_architecture_implementation()->get_tlb_configuration(tlb_index);
 }
 
+std::unique_ptr<TlbWindow> TLBManager::open_tlb_window(
+    tt_xy_pair core, uint64_t address, uint64_t ordering, TlbMapping mapping, size_t tlb_size) {
+    TT_ASSERT(
+        ordering == tlb_data::Strict || ordering == tlb_data::Posted || ordering == tlb_data::Relaxed,
+        "Invalid ordering specified in TLBManager::open_tlb_window");
+
+    tlb_data config{};
+    config.local_offset = address;
+    config.x_end = core.x;
+    config.y_end = core.y;
+    config.noc_sel = is_selected_noc1() ? 1 : 0;
+    config.ordering = ordering;
+    config.static_vc = get_tt_device()->get_architecture_implementation()->get_static_vc();
+
+    return allocate_tlb_window(config, mapping, tlb_size);
+}
+
 std::unique_ptr<TlbWindow> TLBManager::allocate_tlb_window(
     tlb_data config, const TlbMapping mapping, const size_t tlb_size) {
     if (tlb_size != 0) {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -557,6 +557,11 @@ TlbWindow* Cluster::get_static_tlb_window(const ChipId chip, const CoreCoord cor
     return get_tlb_manager(chip)->get_tlb_window(translated_core);
 }
 
+std::unique_ptr<TlbWindow> Cluster::open_tlb_window(
+    ChipId chip, CoreCoord core, uint64_t address, uint64_t ordering, TlbMapping mapping, size_t tlb_size) {
+    return get_chip(chip)->open_tlb_window(core, address, ordering, mapping, tlb_size);
+}
+
 std::map<int, int> Cluster::get_clocks() {
     std::map<int, int> clock_freq_map;
     for (auto& chip_id : local_chip_ids_) {

--- a/tests/api/test_tlb_manager.cpp
+++ b/tests/api/test_tlb_manager.cpp
@@ -12,11 +12,37 @@
 #include <vector>
 
 #include "tests/test_utils/device_test_utils.hpp"
+#include "umd/device/chip_helpers/tlb_manager.hpp"
+#include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/tt_io.hpp"
 
 using namespace tt::umd;
+
+TEST(ApiTLBManager, OpenTlbWindow) {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+
+    for (int pci_device_id : pci_device_ids) {
+        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        tt_device->set_power_state(true);
+        tt_device->init_tt_device();
+
+        std::unique_ptr<TLBManager> tlb_manager = std::make_unique<TLBManager>(tt_device.get());
+        ChipInfo chip_info = tt_device->get_chip_info();
+        SocDescriptor soc_desc(tt_device->get_arch(), chip_info);
+
+        auto any_core = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
+
+        std::unique_ptr<TlbWindow> window =
+            tlb_manager->open_tlb_window(any_core, 0, tlb_data::Relaxed, TlbMapping::WC);
+
+        EXPECT_NE(window, nullptr);
+        EXPECT_GT(window->get_size(), 0);
+
+        tt_device->set_power_state(false);
+    }
+}
 
 // TODO: Once default auto TLB setup is in, check it is setup properly.
 TEST(ApiTLBManager, ManualTLBConfiguration) {

--- a/tests/unified/test_tlb.cpp
+++ b/tests/unified/test_tlb.cpp
@@ -483,3 +483,68 @@ TEST(TestTlb, TLBStaticTensix) {
         EXPECT_EQ(readback[i], i);
     }
 }
+
+TEST(TestTlb, TestOpenTlbWindow) {
+    if (!is_kmd_version_good()) {
+        GTEST_SKIP() << "Skipping test because of old KMD version. Required version of KMD is 1.34 or higher.";
+    }
+    const uint64_t tensix_addr = 0;
+    const ChipId chip = 0;
+
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+
+    uint32_t val = 0;
+    std::vector<CoreCoord> tensix_cores =
+        cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
+    for (CoreCoord core : tensix_cores) {
+        cluster->write_to_device(&val, sizeof(uint32_t), chip, core, tensix_addr);
+        val++;
+    }
+
+    uint32_t value_check = 0;
+    for (CoreCoord core : tensix_cores) {
+        std::unique_ptr<TlbWindow> tlb_window =
+            cluster->open_tlb_window(chip, core, tensix_addr, tlb_data::Relaxed, TlbMapping::WC);
+
+        uint32_t readback_value = tlb_window->read32(0);
+        EXPECT_EQ(readback_value, value_check);
+        value_check++;
+    }
+}
+
+TEST(TestTlb, TestOpenTlbWindowReuse) {
+    if (!is_kmd_version_good()) {
+        GTEST_SKIP() << "Skipping test because of old KMD version. Required version of KMD is 1.34 or higher.";
+    }
+    const uint64_t tensix_addr = 0;
+    const ChipId chip = 0;
+
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+
+    uint32_t val = 0;
+    std::vector<CoreCoord> tensix_cores =
+        cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
+    for (CoreCoord core : tensix_cores) {
+        cluster->write_to_device(&val, sizeof(uint32_t), chip, core, tensix_addr);
+        val++;
+    }
+
+    // Allocate a single window and reconfigure it for each core.
+    std::unique_ptr<TlbWindow> tlb_window =
+        cluster->open_tlb_window(chip, tensix_cores[0], tensix_addr, tlb_data::Relaxed, TlbMapping::WC);
+
+    uint32_t value_check = 0;
+    for (CoreCoord core : tensix_cores) {
+        tlb_data config{};
+        config.local_offset = 0;
+        config.x_end = core.x;
+        config.y_end = core.y;
+        config.ordering = tlb_data::Relaxed;
+
+        tlb_window->configure(config);
+
+        uint32_t readback_value = tlb_window->read32(0);
+        EXPECT_EQ(readback_value, value_check);
+        value_check++;
+    }
+}


### PR DESCRIPTION
### Issue
/

### Description
Currently, obtaining a usable `TlbWindow` requires multiple separate steps depending on the API level used:

**Path 1 — Cluster (high-level, being deprecated):**
```cpp
cluster->configure_tlb(chip, core, tlb_size, address, ordering);
TlbWindow* window = cluster->get_static_tlb_window(chip, core);
```
Two calls, and the window is stored internally in TLBManager's maps (keyed by core, one TLB per core).

**Path 2 — TLBManager (mid-level):**
```cpp
tlb_manager->configure_tlb(translated_core, tlb_size, address, ordering);
TlbWindow* window = tlb_manager->get_tlb_window(translated_core);
```
Same two-step pattern, requires pre-translated `tt_xy_pair` coordinates.

**Path 3 — PCIDevice (low-level, very verbose):**
```cpp
PCIDevice* pci = cluster->get_tt_device(chip)->get_pci_device();
tlb_data config{};
config.local_offset = 0;
config.x_end = core.x;
config.y_end = core.y;
config.noc_sel = 0;
config.mcast = 0;
config.ordering = tlb_data::Relaxed;
config.linked = 0;
config.static_vc = 1;
auto window = std::make_unique<SiliconTlbWindow>(pci->allocate_tlb(two_mb_size, TlbMapping::WC), config);
```
12+ lines, exposes internal details like `noc_sel`, `static_vc`, and requires constructing `SiliconTlbWindow` directly.

This PR adds a new **`open_tlb_window`** API that combines allocation and configuration into a single call, returning an owned `unique_ptr<TlbWindow>`. All the examples above reduce to:

```cpp
// Full control:
auto window = cluster->open_tlb_window(chip, core, address, tlb_data::Relaxed, TlbMapping::WC, tlb_size);

// Or just reserve a TLB with defaults:
auto window = cluster->open_tlb_window(chip, core);
```

The new API is added **alongside** existing APIs so clients can transition gradually. Internal fields like `noc_sel` and `static_vc` are auto-derived from device state.

The API is available at three levels:
- **`TLBManager::open_tlb_window(tt_xy_pair, ...)`** — primary implementation, builds the `tlb_data` config and delegates to the existing virtual `allocate_tlb_window()` (so simulation support works automatically).
- **`Chip::open_tlb_window(CoreCoord, ...)`** — translates `CoreCoord` to translated coordinates and delegates to `TLBManager`.
- **`Cluster::open_tlb_window(ChipId, CoreCoord, ...)`** — convenience wrapper, delegates to `Chip`.

Unlike `configure_tlb()`, the returned window is **not** stored in TLBManager's internal maps — the caller owns it and controls its lifetime.

### List of the changes
- Add `TLBManager::open_tlb_window()` in `tlb_manager.hpp/cpp`
- Add `Chip::open_tlb_window()` virtual method in `chip.hpp/cpp`
- Add `Cluster::open_tlb_window()` convenience wrapper in `cluster.hpp/cpp`
- Add `TestOpenTlbWindow` and `TestOpenTlbWindowReuse` tests in `tests/unified/test_tlb.cpp`
- Add `ApiTLBManager.OpenTlbWindow` test in `tests/api/test_tlb_manager.cpp`

### Testing
CI

### API Changes
This PR has API changes:
- New method: `TLBManager::open_tlb_window(tt_xy_pair core, uint64_t address = 0, uint64_t ordering = Relaxed, TlbMapping mapping = WC, size_t tlb_size = 0)`
- New method: `Chip::open_tlb_window(CoreCoord core, uint64_t address = 0, uint64_t ordering = Relaxed, TlbMapping mapping = WC, size_t tlb_size = 0)`
- New method: `Cluster::open_tlb_window(ChipId chip, CoreCoord core, uint64_t address = 0, uint64_t ordering = Relaxed, TlbMapping mapping = WC, size_t tlb_size = 0)`