### PR TITLE
Add SocDesciptor to TTDevice

### DIFF
--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -23,7 +23,7 @@ class RtlSimulationTTDevice : public TTDevice {
 public:
     RtlSimulationTTDevice(
         const std::filesystem::path& simulator_directory,
-        SocDescriptor soc_descriptor,
+        const SocDescriptor& soc_descriptor,
         ChipId chip_id,
         int num_host_mem_channels = 0);
     ~RtlSimulationTTDevice();
@@ -33,8 +33,6 @@ public:
 
     void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
     void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
-
-    SocDescriptor* get_soc_descriptor() { return &soc_descriptor_; }
 
     void dma_d2h(void* dst, uint32_t src, size_t size) override;
     void dma_d2h_zero_copy(void* dst, uint32_t src, size_t size) override;
@@ -73,7 +71,6 @@ private:
     std::recursive_mutex device_lock;
 
     std::filesystem::path simulator_directory_;
-    SocDescriptor soc_descriptor_;
     std::unique_ptr<SimulationSysmemManager> sysmem_manager_;
     std::unique_ptr<SimulationTlbManager> tlb_manager_;
     std::unique_ptr<TlbWindow> cached_tlb_window_;

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -341,7 +341,9 @@ public:
 
     bool is_remote();
 
-    void init_tt_device(std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT);
+    void init_tt_device(
+        std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT,
+        const std::string &soc_descriptor_path = "");
 
     uint64_t get_refclk_counter();
 
@@ -426,7 +428,7 @@ public:
      */
     virtual EthTrainingStatus read_eth_core_training_status(tt_xy_pair eth_core) = 0;
 
-    const virtual SocDescriptor &get_soc_descriptor() const;
+    const SocDescriptor &get_soc_descriptor() const;
 
 protected:
     IODeviceType communication_device_type_ = IODeviceType::UNDEFINED;
@@ -437,7 +439,6 @@ protected:
     LockManager lock_manager;
     std::unique_ptr<ArcTelemetryReader> telemetry = nullptr;
     std::unique_ptr<FirmwareInfoProvider> firmware_info_provider = nullptr;
-    std::optional<SocDescriptor> soc_descriptor_ = std::nullopt;
 
     TTDevice();
     TTDevice(std::unique_ptr<architecture_implementation> architecture_impl);
@@ -453,12 +454,13 @@ protected:
     tt_xy_pair arc_core;
 
     // Assigns default SocDescriptor.
-    void construct_soc_descriptor();
-    void construct_soc_descriptor(const std::string &soc_descriptor_path);
+    void construct_soc_descriptor(const std::string &soc_descriptor_path = "");
+    void set_soc_descriptor(const SocDescriptor &soc_descriptor);
 
 private:
     void probe_arc();
 
+    std::optional<SocDescriptor> soc_descriptor_ = std::nullopt;
     std::unique_ptr<DeviceProtocol> device_protocol_;
     std::unique_ptr<HangDetector> hang_detector_;
     PcieInterface *pcie_capabilities_ = nullptr;

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -426,10 +426,7 @@ public:
      */
     virtual EthTrainingStatus read_eth_core_training_status(tt_xy_pair eth_core) = 0;
 
-    const SocDescriptor &get_soc_descriptor() const;
-    // Assigns default SocDescriptor.
-    void construct_soc_descriptor();
-    void construct_soc_descriptor(const std::string &soc_descriptor_path);
+    const virtual SocDescriptor &get_soc_descriptor() const;
 
 protected:
     IODeviceType communication_device_type_ = IODeviceType::UNDEFINED;
@@ -454,6 +451,10 @@ protected:
     bool is_remote_tt_device = false;
 
     tt_xy_pair arc_core;
+
+    // Assigns default SocDescriptor.
+    void construct_soc_descriptor();
+    void construct_soc_descriptor(const std::string &soc_descriptor_path);
 
 private:
     void probe_arc();

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -19,6 +19,7 @@
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
+#include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/hang_detection/hang_detector.hpp"
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/jtag_interface.hpp"
@@ -425,6 +426,11 @@ public:
      */
     virtual EthTrainingStatus read_eth_core_training_status(tt_xy_pair eth_core) = 0;
 
+    const SocDescriptor &get_soc_descriptor() const;
+    // Assigns default SocDescriptor.
+    void construct_soc_descriptor();
+    void construct_soc_descriptor(const std::string &soc_descriptor_path);
+
 protected:
     IODeviceType communication_device_type_ = IODeviceType::UNDEFINED;
     int communication_device_id_ = -1;
@@ -434,6 +440,7 @@ protected:
     LockManager lock_manager;
     std::unique_ptr<ArcTelemetryReader> telemetry = nullptr;
     std::unique_ptr<FirmwareInfoProvider> firmware_info_provider = nullptr;
+    std::optional<SocDescriptor> soc_descriptor_ = std::nullopt;
 
     TTDevice();
     TTDevice(std::unique_ptr<architecture_implementation> architecture_impl);

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -24,7 +24,7 @@ class TTSimTTDevice : public TTDevice {
 public:
     TTSimTTDevice(
         const std::filesystem::path &simulator_directory,
-        SocDescriptor soc_descriptor,
+        const SocDescriptor &soc_descriptor,
         ChipId chip_id,
         bool copy_sim_binary = false,
         int num_host_mem_channels = 0);
@@ -35,8 +35,6 @@ public:
 
     void read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
     void write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
-
-    SocDescriptor *get_soc_descriptor() { return &soc_descriptor_; }
 
     void dma_d2h(void *dst, uint32_t src, size_t size) override;
     void dma_d2h_zero_copy(void *dst, uint32_t src, size_t size) override;
@@ -86,7 +84,6 @@ private:
     std::recursive_mutex device_lock;
 
     std::filesystem::path simulator_directory_;
-    SocDescriptor soc_descriptor_;
     ChipId chip_id_;
     std::unique_ptr<SimulationSysmemManager> sysmem_manager_;
 

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -47,7 +47,7 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
     simulator_directory_(simulator_directory),
     sysmem_manager_(std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)) {
     log_info(tt::LogEmulationDriver, "Instantiating RTL simulation TTDevice");
-    soc_descriptor_ = soc_descriptor;
+    set_soc_descriptor(soc_descriptor);
     architecture_impl_ = architecture_implementation::create(get_soc_descriptor().arch);
     arch = get_soc_descriptor().arch;
 

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -40,16 +40,16 @@ std::unique_ptr<RtlSimulationTTDevice> RtlSimulationTTDevice::create(
 
 RtlSimulationTTDevice::RtlSimulationTTDevice(
     const std::filesystem::path& simulator_directory,
-    SocDescriptor soc_descriptor,
+    const SocDescriptor& soc_descriptor,
     ChipId chip_id,
     int num_host_mem_channels) :
     communicator_(std::make_unique<RtlSimCommunicator>(simulator_directory)),
     simulator_directory_(simulator_directory),
-    soc_descriptor_(std::move(soc_descriptor)),
-    sysmem_manager_(std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor_.arch)) {
+    sysmem_manager_(std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)) {
     log_info(tt::LogEmulationDriver, "Instantiating RTL simulation TTDevice");
-    architecture_impl_ = architecture_implementation::create(soc_descriptor_.arch);
-    arch = soc_descriptor_.arch;
+    soc_descriptor_ = soc_descriptor;
+    architecture_impl_ = architecture_implementation::create(get_soc_descriptor().arch);
+    arch = get_soc_descriptor().arch;
 
     // Register sysmem callbacks so the simulator can read/write host memory.
     if (num_host_mem_channels > 0) {
@@ -140,7 +140,7 @@ void RtlSimulationTTDevice::assert_risc_reset(tt_xy_pair core, const RiscType se
     std::lock_guard<std::recursive_mutex> lock(device_lock);
     log_debug(tt::LogEmulationDriver, "Sending 'assert_risc_reset' signal for risc_type {}", selected_riscs);
     // If the architecture is Quasar, a special case is needed to control the NEO Data Movement cores.
-    if (soc_descriptor_.arch == tt::ARCH::QUASAR) {
+    if (get_soc_descriptor().arch == tt::ARCH::QUASAR) {
         if (selected_riscs == RiscType::ALL_NEO_DMS) {
             // Reset all DM cores.
             communicator_->all_neo_dms_reset_assert(core.x, core.y);
@@ -154,7 +154,7 @@ void RtlSimulationTTDevice::assert_risc_reset(tt_xy_pair core, const RiscType se
         }
     }
 
-    if (soc_descriptor_.arch != tt::ARCH::QUASAR || (selected_riscs | RiscType::ALL_NEO_DMS) == RiscType::NONE) {
+    if (get_soc_descriptor().arch != tt::ARCH::QUASAR || (selected_riscs | RiscType::ALL_NEO_DMS) == RiscType::NONE) {
         // In case of Wormhole and Blackhole, we don't check which cores are selected, we just assert all tensix cores.
         // So the functionality is if we called with RiscType::ALL_TENSIX or RiscType::ALL.
         // In case of Quasar, this won't assert the NEO Data Movement cores, but will assert the Tensix cores.
@@ -168,7 +168,7 @@ void RtlSimulationTTDevice::deassert_risc_reset(tt_xy_pair core, const RiscType 
     std::lock_guard<std::recursive_mutex> lock(device_lock);
     log_debug(tt::LogEmulationDriver, "Sending 'deassert_risc_reset' signal for risc_type {}", selected_riscs);
     // See the comment in assert_risc_reset for more details.
-    if (soc_descriptor_.arch == tt::ARCH::QUASAR) {
+    if (get_soc_descriptor().arch == tt::ARCH::QUASAR) {
         if (selected_riscs == RiscType::ALL_NEO_DMS) {
             // Reset all DM cores.
             communicator_->all_neo_dms_reset_deassert(core.x, core.y);
@@ -182,7 +182,7 @@ void RtlSimulationTTDevice::deassert_risc_reset(tt_xy_pair core, const RiscType 
         }
     }
 
-    if (soc_descriptor_.arch != tt::ARCH::QUASAR || (selected_riscs | RiscType::ALL_NEO_DMS) == RiscType::NONE) {
+    if (get_soc_descriptor().arch != tt::ARCH::QUASAR || (selected_riscs | RiscType::ALL_NEO_DMS) == RiscType::NONE) {
         // See the comment in assert_risc_reset for more details.
         communicator_->all_tensix_reset_deassert(core.x, core.y);
     }

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -26,6 +26,7 @@
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
+#include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/blackhole_tt_device.hpp"
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_protocol.hpp"
@@ -100,7 +101,7 @@ void TTDevice::probe_arc() {
     read_from_arc_apb(&dummy, architecture_impl_->get_arc_reset_scratch_offset(), sizeof(dummy));  // SCRATCH_0
 }
 
-void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
+void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms, const std::string &soc_descriptor_path) {
     ZoneScopedC(tracy::Color::DarkGreen);
     if (pcie_capabilities_ != nullptr) {
         is_pcie_hung();
@@ -115,7 +116,7 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     arc_messenger_ = ArcMessenger::create_arc_messenger(this);
     telemetry = ArcTelemetryReader::create_arc_telemetry_reader(this);
     firmware_info_provider = FirmwareInfoProvider::create_firmware_info_provider(this);
-    construct_soc_descriptor();
+    construct_soc_descriptor(soc_descriptor_path);
 }
 
 /* static */ std::unique_ptr<TTDevice> TTDevice::create(
@@ -508,9 +509,19 @@ void TTDevice::dma_h2d_zero_copy(uint32_t dst, const void *src, size_t size) {
 
 const SocDescriptor &TTDevice::get_soc_descriptor() const { return soc_descriptor_.value(); }
 
-void TTDevice::construct_soc_descriptor() { soc_descriptor_ = SocDescriptor(get_arch(), get_chip_info()); }
-
 void TTDevice::construct_soc_descriptor(const std::string &soc_descriptor_path) {
-    soc_descriptor_ = SocDescriptor(soc_descriptor_path, get_chip_info());
+    if (soc_descriptor_path.empty()) {
+        soc_descriptor_ = SocDescriptor(get_arch(), get_chip_info());
+    } else {
+        soc_descriptor_ = SocDescriptor(soc_descriptor_path, get_chip_info());
+    }
 }
+
+void TTDevice::set_soc_descriptor(const SocDescriptor &soc_descriptor) {
+    if (soc_descriptor_.has_value()) {
+        UMD_THROW(error::RuntimeError, "SocDescriptor cannot be re-assgined to TTDevice.");
+    }
+    soc_descriptor_ = soc_descriptor;
+}
+
 }  // namespace tt::umd

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -115,6 +115,7 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     arc_messenger_ = ArcMessenger::create_arc_messenger(this);
     telemetry = ArcTelemetryReader::create_arc_telemetry_reader(this);
     firmware_info_provider = FirmwareInfoProvider::create_firmware_info_provider(this);
+    construct_soc_descriptor();
 }
 
 /* static */ std::unique_ptr<TTDevice> TTDevice::create(
@@ -505,4 +506,11 @@ void TTDevice::dma_h2d_zero_copy(uint32_t dst, const void *src, size_t size) {
     get_pcie_interface()->dma_h2d_zero_copy(dst, src, size);
 }
 
+const SocDescriptor &TTDevice::get_soc_descriptor() const { return soc_descriptor_.value(); }
+
+void TTDevice::construct_soc_descriptor() { soc_descriptor_ = SocDescriptor(get_arch(), get_chip_info()); }
+
+void TTDevice::construct_soc_descriptor(const std::string &soc_descriptor_path) {
+    soc_descriptor_ = SocDescriptor(soc_descriptor_path, get_chip_info());
+}
 }  // namespace tt::umd

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -36,16 +36,16 @@ std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create(
 
 TTSimTTDevice::TTSimTTDevice(
     const std::filesystem::path& simulator_directory,
-    SocDescriptor soc_descriptor,
+    const SocDescriptor& soc_descriptor,
     ChipId chip_id,
     bool copy_sim_binary,
     int num_host_mem_channels) :
     communicator_(std::make_unique<TTSimCommunicator>(simulator_directory, copy_sim_binary)),
     simulator_directory_(simulator_directory),
-    soc_descriptor_(std::move(soc_descriptor)),
     chip_id_(chip_id),
-    sysmem_manager_(std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor_.arch)) {
-    architecture_impl_ = architecture_implementation::create(soc_descriptor_.arch);
+    sysmem_manager_(std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)) {
+    soc_descriptor_ = soc_descriptor;
+    architecture_impl_ = architecture_implementation::create(soc_descriptor.arch);
     communicator_->initialize();
     initialize_sysmem_functions();
     communicator_->start_sim();
@@ -132,7 +132,7 @@ void TTSimTTDevice::send_tensix_risc_reset(tt_xy_pair translated_core, const Ten
 }
 
 void TTSimTTDevice::send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) {
-    for (const tt_xy_pair core : soc_descriptor_.get_cores(CoreType::TENSIX)) {
+    for (const tt_xy_pair core : get_soc_descriptor().get_cores(CoreType::TENSIX)) {
         send_tensix_risc_reset(core, soft_resets);
     }
 }

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -44,7 +44,7 @@ TTSimTTDevice::TTSimTTDevice(
     simulator_directory_(simulator_directory),
     chip_id_(chip_id),
     sysmem_manager_(std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)) {
-    soc_descriptor_ = soc_descriptor;
+    set_soc_descriptor(soc_descriptor);
     architecture_impl_ = architecture_implementation::create(soc_descriptor.arch);
     communicator_->initialize();
     initialize_sysmem_functions();

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -143,7 +143,12 @@ void bind_tt_device(nb::module_ &m) {
             nb::arg("use_safe_api") = true,
             nb::rv_policy::take_ownership)
         .def("set_power_state", &TTDevice::set_power_state, nb::arg("busy"))
-        .def("init_tt_device", &TTDevice::init_tt_device, nb::arg("timeout_ms") = timeout::ARC_STARTUP_TIMEOUT)
+        .def(
+            "init_tt_device",
+            &TTDevice::init_tt_device,
+            nb::arg("timeout_ms") = timeout::ARC_STARTUP_TIMEOUT,
+            nb::arg("soc_descriptor_path") = "")
+        .def("get_soc_descriptor", &TTDevice::get_soc_descriptor)
         .def("get_chip_info", &TTDevice::get_chip_info)
         .def("get_arc_telemetry_reader", &TTDevice::get_arc_telemetry_reader, nb::rv_policy::reference_internal)
         .def("get_arch", &TTDevice::get_arch)

--- a/tests/api/test_ttsim_device_io.cpp
+++ b/tests/api/test_ttsim_device_io.cpp
@@ -62,9 +62,9 @@ protected:
 
 // Write a pattern via the TLB path, read it back via tile_rd_bytes and compare.
 TEST_F(TTSimDeviceIOFixture, WriteToDeviceReadByTileRdBytes) {
-    const SocDescriptor* soc = tt_device->get_soc_descriptor();
-    auto tensix_cores = soc->get_cores(CoreType::TENSIX);
-    const tt_xy_pair core = soc->translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
+    const SocDescriptor& soc = tt_device->get_soc_descriptor();
+    auto tensix_cores = soc.get_cores(CoreType::TENSIX);
+    const tt_xy_pair core = soc.translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
 
     constexpr size_t data_size = 1024;
     constexpr uint64_t addr = 0x100;
@@ -81,9 +81,9 @@ TEST_F(TTSimDeviceIOFixture, WriteToDeviceReadByTileRdBytes) {
 
 // Write zeros via TLB then a pattern via TLB; confirm tile_rd_bytes sees each state.
 TEST_F(TTSimDeviceIOFixture, WriteToDeviceZeroThenPatternReadByTileRdBytes) {
-    const SocDescriptor* soc = tt_device->get_soc_descriptor();
-    auto tensix_cores = soc->get_cores(CoreType::TENSIX);
-    const tt_xy_pair core = soc->translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
+    const SocDescriptor& soc = tt_device->get_soc_descriptor();
+    auto tensix_cores = soc.get_cores(CoreType::TENSIX);
+    const tt_xy_pair core = soc.translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
 
     constexpr size_t data_size = 256;
     constexpr uint64_t addr = 0x200;
@@ -108,9 +108,9 @@ TEST_F(TTSimDeviceIOFixture, WriteToDeviceZeroThenPatternReadByTileRdBytes) {
 
 // Large write (4 KB) via TLB path, read back via tile_rd_bytes.
 TEST_F(TTSimDeviceIOFixture, LargeWriteToDeviceReadByTileRdBytes) {
-    const SocDescriptor* soc = tt_device->get_soc_descriptor();
-    auto tensix_cores = soc->get_cores(CoreType::TENSIX);
-    const tt_xy_pair core = soc->translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
+    const SocDescriptor& soc = tt_device->get_soc_descriptor();
+    auto tensix_cores = soc.get_cores(CoreType::TENSIX);
+    const tt_xy_pair core = soc.translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
 
     constexpr size_t data_size = 4 * 1024;
     constexpr uint64_t addr = 0x0;
@@ -131,9 +131,9 @@ TEST_F(TTSimDeviceIOFixture, LargeWriteToDeviceReadByTileRdBytes) {
 
 // Write a pattern via tile_wr_bytes, read it back via read_from_device and compare.
 TEST_F(TTSimDeviceIOFixture, TileWrBytesReadByReadFromDevice) {
-    const SocDescriptor* soc = tt_device->get_soc_descriptor();
-    auto tensix_cores = soc->get_cores(CoreType::TENSIX);
-    const tt_xy_pair core = soc->translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
+    const SocDescriptor& soc = tt_device->get_soc_descriptor();
+    auto tensix_cores = soc.get_cores(CoreType::TENSIX);
+    const tt_xy_pair core = soc.translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
 
     constexpr size_t data_size = 1024;
     constexpr uint64_t addr = 0x300;
@@ -150,9 +150,9 @@ TEST_F(TTSimDeviceIOFixture, TileWrBytesReadByReadFromDevice) {
 
 // Write zeros via tile_wr_bytes then a pattern; confirm read_from_device sees each state.
 TEST_F(TTSimDeviceIOFixture, TileWrBytesZeroThenPatternReadByReadFromDevice) {
-    const SocDescriptor* soc = tt_device->get_soc_descriptor();
-    auto tensix_cores = soc->get_cores(CoreType::TENSIX);
-    const tt_xy_pair core = soc->translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
+    const SocDescriptor& soc = tt_device->get_soc_descriptor();
+    auto tensix_cores = soc.get_cores(CoreType::TENSIX);
+    const tt_xy_pair core = soc.translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
 
     constexpr size_t data_size = 256;
     constexpr uint64_t addr = 0x400;
@@ -177,9 +177,9 @@ TEST_F(TTSimDeviceIOFixture, TileWrBytesZeroThenPatternReadByReadFromDevice) {
 
 // Large write (4 KB) via tile_wr_bytes, read back via read_from_device.
 TEST_F(TTSimDeviceIOFixture, LargeTileWrBytesReadByReadFromDevice) {
-    const SocDescriptor* soc = tt_device->get_soc_descriptor();
-    auto tensix_cores = soc->get_cores(CoreType::TENSIX);
-    const tt_xy_pair core = soc->translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
+    const SocDescriptor& soc = tt_device->get_soc_descriptor();
+    auto tensix_cores = soc.get_cores(CoreType::TENSIX);
+    const tt_xy_pair core = soc.translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
 
     constexpr size_t data_size = 4 * 1024;
     constexpr uint64_t addr = 0x0;
@@ -200,9 +200,9 @@ TEST_F(TTSimDeviceIOFixture, LargeTileWrBytesReadByReadFromDevice) {
 
 // Write via TLB; both read_from_device and tile_rd_bytes must return the same data.
 TEST_F(TTSimDeviceIOFixture, WriteToDeviceBothReadsConsistent) {
-    const SocDescriptor* soc = tt_device->get_soc_descriptor();
-    auto tensix_cores = soc->get_cores(CoreType::TENSIX);
-    const tt_xy_pair core = soc->translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
+    const SocDescriptor& soc = tt_device->get_soc_descriptor();
+    auto tensix_cores = soc.get_cores(CoreType::TENSIX);
+    const tt_xy_pair core = soc.translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
 
     constexpr size_t data_size = 256;
     constexpr uint64_t addr = 0x500;
@@ -223,9 +223,9 @@ TEST_F(TTSimDeviceIOFixture, WriteToDeviceBothReadsConsistent) {
 
 // Write via tile_wr_bytes; both read_from_device and tile_rd_bytes must return the same data.
 TEST_F(TTSimDeviceIOFixture, TileWrBytesBothReadsConsistent) {
-    const SocDescriptor* soc = tt_device->get_soc_descriptor();
-    auto tensix_cores = soc->get_cores(CoreType::TENSIX);
-    const tt_xy_pair core = soc->translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
+    const SocDescriptor& soc = tt_device->get_soc_descriptor();
+    auto tensix_cores = soc.get_cores(CoreType::TENSIX);
+    const tt_xy_pair core = soc.translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
 
     constexpr size_t data_size = 256;
     constexpr uint64_t addr = 0x600;
@@ -251,15 +251,15 @@ TEST_F(TTSimDeviceIOFixture, TileWrBytesBothReadsConsistent) {
 // Write to the first N TENSIX cores alternating between the two write APIs;
 // verify that both read APIs agree with what was written on every core.
 TEST_F(TTSimDeviceIOFixture, MultiCoreAlternatingAPIsConsistent) {
-    const SocDescriptor* soc = tt_device->get_soc_descriptor();
-    auto tensix_cores = soc->get_cores(CoreType::TENSIX);
+    const SocDescriptor& soc = tt_device->get_soc_descriptor();
+    auto tensix_cores = soc.get_cores(CoreType::TENSIX);
 
     const size_t num_cores = std::min(tensix_cores.size(), size_t(4));
     constexpr size_t data_size = 128;
     constexpr uint64_t addr = 0x700;
 
     for (size_t i = 0; i < num_cores; i++) {
-        const tt_xy_pair core = soc->translate_coord_to(tensix_cores[i], CoordSystem::TRANSLATED);
+        const tt_xy_pair core = soc.translate_coord_to(tensix_cores[i], CoordSystem::TRANSLATED);
 
         auto write_data = make_pattern(data_size, [i](size_t j) { return (i * 50 + j) % 256; });
 
@@ -284,8 +284,8 @@ TEST_F(TTSimDeviceIOFixture, MultiCoreAlternatingAPIsConsistent) {
 // Write distinct data to multiple cores via write_to_device, read back via
 // tile_rd_bytes; confirm no data bleed between cores.
 TEST_F(TTSimDeviceIOFixture, MultiCoreWriteToDeviceReadByTileRdBytesNoBleed) {
-    const SocDescriptor* soc = tt_device->get_soc_descriptor();
-    auto tensix_cores = soc->get_cores(CoreType::TENSIX);
+    const SocDescriptor& soc = tt_device->get_soc_descriptor();
+    auto tensix_cores = soc.get_cores(CoreType::TENSIX);
 
     const size_t num_cores = std::min(tensix_cores.size(), size_t(4));
     constexpr size_t data_size = 64;
@@ -294,14 +294,14 @@ TEST_F(TTSimDeviceIOFixture, MultiCoreWriteToDeviceReadByTileRdBytesNoBleed) {
     // Write distinct patterns to each core.
     std::vector<std::vector<uint8_t>> all_patterns(num_cores);
     for (size_t i = 0; i < num_cores; i++) {
-        const tt_xy_pair core = soc->translate_coord_to(tensix_cores[i], CoordSystem::TRANSLATED);
+        const tt_xy_pair core = soc.translate_coord_to(tensix_cores[i], CoordSystem::TRANSLATED);
         all_patterns[i] = make_pattern(data_size, [i](size_t j) { return (i * 31 + j) % 256; });
         tt_device->write_to_device(all_patterns[i].data(), core, addr, data_size);
     }
 
     // Read back and verify each core still holds its own pattern.
     for (size_t i = 0; i < num_cores; i++) {
-        const tt_xy_pair core = soc->translate_coord_to(tensix_cores[i], CoordSystem::TRANSLATED);
+        const tt_xy_pair core = soc.translate_coord_to(tensix_cores[i], CoordSystem::TRANSLATED);
         std::vector<uint8_t> read_data(data_size, 0);
         tt_device->get_communicator()->tile_read_bytes(core.x, core.y, addr, read_data.data(), data_size);
         EXPECT_EQ(all_patterns[i], read_data) << "Data bleed detected on core index " << i;
@@ -311,8 +311,8 @@ TEST_F(TTSimDeviceIOFixture, MultiCoreWriteToDeviceReadByTileRdBytesNoBleed) {
 // Write distinct data to multiple cores via tile_wr_bytes, read back via
 // read_from_device; confirm no data bleed between cores.
 TEST_F(TTSimDeviceIOFixture, MultiCoreTileWrBytesReadByReadFromDeviceNoBleed) {
-    const SocDescriptor* soc = tt_device->get_soc_descriptor();
-    auto tensix_cores = soc->get_cores(CoreType::TENSIX);
+    const SocDescriptor& soc = tt_device->get_soc_descriptor();
+    auto tensix_cores = soc.get_cores(CoreType::TENSIX);
 
     const size_t num_cores = std::min(tensix_cores.size(), size_t(4));
     constexpr size_t data_size = 64;
@@ -321,14 +321,14 @@ TEST_F(TTSimDeviceIOFixture, MultiCoreTileWrBytesReadByReadFromDeviceNoBleed) {
     // Write distinct patterns to each core.
     std::vector<std::vector<uint8_t>> all_patterns(num_cores);
     for (size_t i = 0; i < num_cores; i++) {
-        const tt_xy_pair core = soc->translate_coord_to(tensix_cores[i], CoordSystem::TRANSLATED);
+        const tt_xy_pair core = soc.translate_coord_to(tensix_cores[i], CoordSystem::TRANSLATED);
         all_patterns[i] = make_pattern(data_size, [i](size_t j) { return (i * 41 + j * 3) % 256; });
         tt_device->get_communicator()->tile_write_bytes(core.x, core.y, addr, all_patterns[i].data(), data_size);
     }
 
     // Read back and verify each core still holds its own pattern.
     for (size_t i = 0; i < num_cores; i++) {
-        const tt_xy_pair core = soc->translate_coord_to(tensix_cores[i], CoordSystem::TRANSLATED);
+        const tt_xy_pair core = soc.translate_coord_to(tensix_cores[i], CoordSystem::TRANSLATED);
         std::vector<uint8_t> read_data(data_size, 0);
         tt_device->read_from_device(read_data.data(), core, addr, data_size);
         EXPECT_EQ(all_patterns[i], read_data) << "Data bleed detected on core index " << i;
@@ -342,9 +342,9 @@ TEST_F(TTSimDeviceIOFixture, MultiCoreTileWrBytesReadByReadFromDeviceNoBleed) {
 // Repeatedly write a pattern then zeros via alternating APIs across several
 // address offsets, confirming both read APIs agree at each step.
 TEST_F(TTSimDeviceIOFixture, RepeatedWriteReadCycles) {
-    const SocDescriptor* soc = tt_device->get_soc_descriptor();
-    auto tensix_cores = soc->get_cores(CoreType::TENSIX);
-    const tt_xy_pair core = soc->translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
+    const SocDescriptor& soc = tt_device->get_soc_descriptor();
+    auto tensix_cores = soc.get_cores(CoreType::TENSIX);
+    const tt_xy_pair core = soc.translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
 
     constexpr size_t data_size = 40;
     constexpr uint32_t num_loops = 10;


### PR DESCRIPTION
### Issue
#1716

### Description
This PR adds an owned SocDescriptor to TTDevice. It does not move SocDescriptor from Chip, this will be handled in another PR. 

### List of the changes
- Add SocDescriptor to TTDevice.
- Init. SocDescriptor on `init_tt_device()`.
- Adjust constructors for simulation TTDevices.

### Testing
CI

### API Changes
This PR has API changes.