### PR TITLE
Fix BH multiprocess tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -129,9 +129,8 @@ jobs:
 
       - name: Run unified tests
         if: ${{ inputs.arch != 'baremetal' }}
-        shell: bash
         run: |
-            ${{ env.TEST_OUTPUT_DIR }}/umd/unified/unified_tests || [[ "${{ inputs.arch }}" == "blackhole" ]]
+            ${{ env.TEST_OUTPUT_DIR }}/umd/unified/unified_tests
 
       - name: Run UMD tools
         shell: bash

--- a/tests/unified/multiprocess.cpp
+++ b/tests/unified/multiprocess.cpp
@@ -67,6 +67,9 @@ static void test_read_write_all_tensix_cores_impl(
             cluster->write_to_device(vector_to_write.data(), data_size, 0, core, address);
             cluster->l1_membar(0, {core});
             test_utils::read_data_from_device(*cluster, readback_vec, 0, core, address, data_size);
+            // NOTE: A bug in Blackhole. On L1 address range 0x10-0x13 any uint32_t value written reads back as 0 on the
+            // first iteration of this loop, mostly on Tensixes in translated column 11. This is fixed by skipping this
+            // address with reserved_size.
             ASSERT_EQ(vector_to_write, readback_vec)
                 << "Vector read back from core " << core.str() << " does not match what was written";
             readback_vec.clear();

--- a/tests/unified/multiprocess.cpp
+++ b/tests/unified/multiprocess.cpp
@@ -67,9 +67,6 @@ static void test_read_write_all_tensix_cores_impl(
             cluster->write_to_device(vector_to_write.data(), data_size, 0, core, address);
             cluster->l1_membar(0, {core});
             test_utils::read_data_from_device(*cluster, readback_vec, 0, core, address, data_size);
-            // NOTE: A bug in Blackhole. On L1 address range 0x10-0x13 any uint32_t value written reads back as 0 on the
-            // first iteration of this loop, mostly on Tensixes in translated column 11. This is fixed by skipping this
-            // address with reserved_size.
             ASSERT_EQ(vector_to_write, readback_vec)
                 << "Vector read back from core " << core.str() << " does not match what was written";
             readback_vec.clear();
@@ -98,6 +95,8 @@ void test_read_write_all_tensix_cores(Cluster* cluster, int thread_id) {
 
 // Same intention as test_read_write_all_tensix_cores, but without modifying first 128 bytes.
 void test_read_write_all_tensix_cores_with_reserved_bytes_at_start(Cluster* cluster, int thread_id) {
+    // NOTE: On Blackhole CMFW >19.3, TENSIX cores reserve address 0x10 for ARC writing throttle state
+    // that is consumed by kernels. We need to skip ahead of this address to prevent failing these checks.
     test_read_write_all_tensix_cores_impl(cluster, thread_id, NUM_OF_BYTES_RESERVED, true);
 }
 

--- a/tests/unified/multiprocess.cpp
+++ b/tests/unified/multiprocess.cpp
@@ -107,7 +107,7 @@ TEST(Multiprocess, MultipleClusters) {
     }
     for (int i = 0; i < NUM_PARALLEL; i++) {
         std::cout << "Running IO for cluster " << i << std::endl;
-        test_read_write_all_tensix_cores(clusters[i].get(), i);
+        test_read_write_all_tensix_cores_with_reserved_bytes_at_start(clusters[i].get(), i);
         std::cout << "Finished IO for cluster " << i << std::endl;
     }
 }
@@ -120,7 +120,7 @@ TEST(Multiprocess, MultipleThreadsSingleCluster) {
     for (int i = 0; i < NUM_PARALLEL; i++) {
         threads.push_back(std::thread([&, i] {
             std::cout << "Running IO for thread " << i << " inside cluster." << std::endl;
-            test_read_write_all_tensix_cores(cluster.get(), i);
+            test_read_write_all_tensix_cores_with_reserved_bytes_at_start(cluster.get(), i);
             std::cout << "Finished read/write test for cluster " << i << std::endl;
         }));
     }
@@ -154,7 +154,7 @@ TEST(Multiprocess, MultipleThreadsMultipleClustersRunning) {
             std::cout << "Creating cluster " << i << std::endl;
             std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
             std::cout << "Running IO for cluster " << i << std::endl;
-            test_read_write_all_tensix_cores(cluster.get(), i);
+            test_read_write_all_tensix_cores_with_reserved_bytes_at_start(cluster.get(), i);
             std::cout << "Finished IO for cluster " << i << std::endl;
         }));
     }
@@ -192,7 +192,7 @@ TEST(Multiprocess, WorkloadVSMonitor) {
         std::cout << "Creating workload cluster" << std::endl;
         std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
         std::cout << "Running IO for workload cluster" << std::endl;
-        test_read_write_all_tensix_cores(cluster.get(), 0);
+        test_read_write_all_tensix_cores_with_reserved_bytes_at_start(cluster.get(), 0);
         std::cout << "Finished IO for workload cluster" << std::endl;
     });
 
@@ -260,7 +260,7 @@ TEST(Multiprocess, LongLivedMonitor) {
         std::cout << "Creating cluster " << i << std::endl;
         std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
         std::cout << "Running IO for cluster " << i << std::endl;
-        test_read_write_all_tensix_cores(cluster.get(), i);
+        test_read_write_all_tensix_cores_with_reserved_bytes_at_start(cluster.get(), i);
         std::cout << "Finished IO for cluster " << i << std::endl;
     }
 


### PR DESCRIPTION
### Issue
#2402 #367 

### Description
Fix BH multiprocess tests. On Blackhole CMFW >19.3, TENSIX cores reserve address 0x10 for ARC writing throttle state that is consumed by kernels. We need to skip ahead of this address to prevent failing the tests.

### List of the changes
- Always use `test_read_write_all_tensix_cores_with_reserved_bytes_at_start()`.
- Remove failure override in run-tests.yml for BH unified tests.

### Testing
CI

### API changes
None.