### PR TITLE
Change DMA buffer allocation to start at 512KB with halving fallback

### DIFF
--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -968,22 +968,25 @@ void PCIDevice::allocate_pcie_dma_buffer() {
         return;
     }
     // DMA buffer allocation.
-    // Allocation tries to allocate larger DMA buffers first. Starting size depends on whether IOMMU is enabled or not.
-    // If IOMMU is enabled, we will try to allocate 16MB buffer first.
-    // If IOMMU is not enabled, we will try to allocate 2MB buffer first.
+    // 512KB is the empirical sweet spot for per-chunk DMA throughput
+    // Measured different dma buffer sizes scaling, observations on https://github.com/tenstorrent/tt-umd/issues/2454
     // If that fails, we will try smaller sizes until we can't allocate even single page.
     // + 0x1000 is for the completion page.  Since this entire implementation
     // is a temporary hack until it's implemented in the driver, we'll need to
     // poll a completion page to know when the DMA is done instead of receiving
     // an interrupt.
-    uint32_t dma_buf_size;
-    static const uint32_t page_size = static_cast<uint32_t>(sysconf(_SC_PAGESIZE));
-    const uint32_t one_mb = 1 << 20;
-    if (is_iommu_enabled()) {
-        dma_buf_size = 16 * one_mb;
-    } else {
-        dma_buf_size = 2 * one_mb;
+
+    uint32_t dma_buf_size = 512 * 1024;  // 512 KB
+
+    // TT_DMA_BUF_SIZE env var overrides the default if explicitly set.
+    const char *dma_buf_size_env = std::getenv("TT_DMA_BUF_SIZE");
+    if (dma_buf_size_env) {
+        uint64_t override_size = std::stoull(dma_buf_size_env);
+        if (override_size > 0) {
+            dma_buf_size = static_cast<uint32_t>(override_size);
+        }
     }
+    static const uint32_t page_size = static_cast<uint32_t>(sysconf(_SC_PAGESIZE));
 
     while (dma_buf_size >= page_size) {
         bool dma_buf_allocation_success = false;

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -977,15 +977,6 @@ void PCIDevice::allocate_pcie_dma_buffer() {
     // an interrupt.
 
     uint32_t dma_buf_size = 512 * 1024;  // 512 KB
-
-    // TT_DMA_BUF_SIZE env var overrides the default if explicitly set.
-    const char *dma_buf_size_env = std::getenv("TT_DMA_BUF_SIZE");
-    if (dma_buf_size_env) {
-        uint64_t override_size = std::stoull(dma_buf_size_env);
-        if (override_size > 0) {
-            dma_buf_size = static_cast<uint32_t>(override_size);
-        }
-    }
     static const uint32_t page_size = static_cast<uint32_t>(sysconf(_SC_PAGESIZE));
 
     while (dma_buf_size >= page_size) {


### PR DESCRIPTION
### Issue
#2454

### Description
Change DMA buffer allocation to start at 512KB with halving fallback, after trying out different sizes and measuring DMA reads/writes scaling, based on observations summarized in https://github.com/tenstorrent/tt-umd/issues/2454

### List of the changes
 - Removed previous strategy which firstly tried to allocate 16MB buffer when IOMMU enabled and 2MB when disabled
 - Changed it to start trying allocation at 512 KB size for both

### Testing
 - CI
 - Microbencmarks and Tracy profiling

### API Changes
There are no API changes in this PR.