### PR TITLE
Run tt-exalens tests with NOC1 on both tests

### DIFF
--- a/.github/workflows/run-exalens-tests.yml
+++ b/.github/workflows/run-exalens-tests.yml
@@ -96,12 +96,6 @@ jobs:
           TTEXALENS_TESTS_USE_NOC1: 1
         shell: bash
         run: |
-          # HACK: By running tt-exalens application in the background,
-          # we prevent KMD from setting the devices to low power mode.
-          # Exalens tests recreate context very often, which causes KMD to
-          # oscillate between high power and low power mode, causing some
-          # transient hangs on NOC1.
-          python3 tt-exalens.py > /dev/null 2>&1 &
           python3 -m unittest discover -v -t . -s test/ttexalens -p *test*.py
 
       - name: Run Python tests for tt-exalens app (NOC1)

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -403,14 +403,9 @@ std::optional<int> PCIDevice::get_pci_device_id(int umd_logical_id) {
 }
 
 static int open_pci_device(const std::string &device_path) {
-    // O_APPEND opts out of legacy mode in KMD >= 2.6.0, allowing the device to enter low-power idle states.
+    // Force legacy mode (no O_APPEND) to test if O_APPEND causes NOC1 issues.
     int flags = O_RDWR | O_CLOEXEC;
-    if (PCIDevice::read_kmd_version() >= KMD_POWER_STATE && PCIDevice::get_pcie_arch() == tt::ARCH::BLACKHOLE) {
-        log_debug(LogUMD, fmt::format("Opening device {} in power aware mode.", device_path));
-        flags |= O_APPEND;
-    } else {
-        log_debug(LogUMD, fmt::format("Opening device {} in legacy mode regarding device power.", device_path));
-    }
+    log_debug(LogUMD, fmt::format("Opening device {} in legacy mode regarding device power.", device_path));
     return open(device_path.c_str(), flags);
 }
 
@@ -442,7 +437,7 @@ PCIDevice::PCIDevice(int pci_device_number) :
             KMD_MAP_TO_NOC.to_string());
     }
 
-    int extra_flags = (kmd_version >= KMD_POWER_STATE) ? O_APPEND : 0;
+    int extra_flags = 0;
     int ret_code = tt_device_open(device_path.c_str(), &tt_device_handle, extra_flags);
 
     if (ret_code != 0) {

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -403,7 +403,8 @@ std::optional<int> PCIDevice::get_pci_device_id(int umd_logical_id) {
 }
 
 static int open_pci_device(const std::string &device_path) {
-    // Force legacy mode (no O_APPEND) to test if O_APPEND causes NOC1 issues.
+    // O_APPEND is temporarily disabled to investigate NOC1 issues. See
+    // https://github.com/tenstorrent/tt-umd/issues/2531.
     int flags = O_RDWR | O_CLOEXEC;
     log_debug(LogUMD, fmt::format("Opening device {} in legacy mode regarding device power.", device_path));
     return open(device_path.c_str(), flags);

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -132,6 +132,10 @@ void TopologyDiscovery::get_connected_devices() {
     for (auto& device_id : local_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(device_id, io_device_type);
         if (!options.low_power) {
+            log_warning(
+                LogUMD,
+                "Low power mode is disabled while UMD holds open file descriptors. The device will return to low power "
+                "mode once all file descriptors are closed.");
             tt_device->set_power_state(true);
         }
         if (tt_device->get_arch() != get_topology_arch()) {

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -132,6 +132,7 @@ void TopologyDiscovery::get_connected_devices() {
     for (auto& device_id : local_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(device_id, io_device_type);
         if (!options.low_power) {
+            // Low power mode is temporarily disabled. See https://github.com/tenstorrent/tt-umd/issues/2531.
             log_warning(
                 LogUMD,
                 "Low power mode is disabled while UMD holds open file descriptors. The device will return to low power "

--- a/nanobind/py_api_topology_discovery.cpp
+++ b/nanobind/py_api_topology_discovery.cpp
@@ -78,6 +78,7 @@ void bind_topology_discovery(nb::module_& m) {
         .def_rw("discover_remote_devices", &TopologyDiscoveryOptions::discover_remote_devices)
         .def_rw("wait_on_ethernet_link_training", &TopologyDiscoveryOptions::wait_on_ethernet_link_training)
         .def_rw("perform_6u_eth_retrain", &TopologyDiscoveryOptions::perform_6u_eth_retrain)
+        // Low power mode is temporarily disabled. See https://github.com/tenstorrent/tt-umd/issues/2531.
         .def_rw("low_power", &TopologyDiscoveryOptions::low_power);
 
     nb::class_<TopologyDiscovery>(m, "TopologyDiscovery")


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2449

### Description
Delete hack from PR https://github.com/tenstorrent/tt-umd/pull/2467 and don't use O_APPEND until it's investigated why it's making a problem.

### List of the changes
- Removed O_APPEND usage
- Removed hack for workflow

### Testing
CI testing with 50 consecutive passes on the tests that were failing: https://github.com/tenstorrent/tt-umd/actions/runs/24941251006

### API Changes
/