### PR TITLE
Move silicon TLBManager ownership into TTDevice (unified)

### DIFF
--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -80,12 +80,10 @@ private:
     LocalChip(
         SocDescriptor soc_descriptor,
         std::unique_ptr<TTDevice> tt_device,
-        std::unique_ptr<TLBManager> tlb_manager,
         std::unique_ptr<SysmemManager> sysmem_manager,
         std::unique_ptr<RemoteCommunication> remote_communication,
         int num_host_mem_channels);
 
-    std::unique_ptr<TLBManager> tlb_manager_;
     std::unique_ptr<SysmemManager> sysmem_manager_;
     LockManager lock_manager_;
     // Used only for ethernet broadcast to all remote chips.

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -61,8 +61,6 @@ public:
 
     SimulationSysmemManager* get_sysmem_manager() override { return sysmem_manager_.get(); }
 
-    TLBManager* get_tlb_manager() override;
-
 protected:
     void retrain_dram_core(const uint32_t dram_channel) override;
 
@@ -72,7 +70,6 @@ private:
 
     std::filesystem::path simulator_directory_;
     std::unique_ptr<SimulationSysmemManager> sysmem_manager_;
-    std::unique_ptr<SimulationTlbManager> tlb_manager_;
     std::unique_ptr<TlbWindow> cached_tlb_window_;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -404,6 +404,9 @@ public:
 
     virtual SimulationSysmemManager *get_sysmem_manager() { return nullptr; }
 
+    // Returns nullptr for non-PCIe communication paths (JTAG, Remote).
+    // Ownership is unified at this base: derived classes populate tlb_manager_
+    // directly rather than overriding this accessor (the accessor is non-virtual).
     TLBManager *get_tlb_manager() { return tlb_manager_.get(); }
 
     virtual void dma_write_to_device(const void *src, size_t size, tt_xy_pair core, uint64_t addr);
@@ -444,6 +447,10 @@ protected:
     LockManager lock_manager;
     std::unique_ptr<ArcTelemetryReader> telemetry = nullptr;
     std::unique_ptr<FirmwareInfoProvider> firmware_info_provider = nullptr;
+    // MUST be declared after architecture_impl_: SimulationTlbManager (a TLBManager
+    // subclass) caches a raw architecture_implementation* obtained from
+    // architecture_impl_.get(). Reverse-declaration destruction order ensures
+    // tlb_manager_ is torn down while architecture_impl_ is still alive.
     std::unique_ptr<TLBManager> tlb_manager_;
 
     TTDevice();

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -404,7 +404,7 @@ public:
 
     virtual SimulationSysmemManager *get_sysmem_manager() { return nullptr; }
 
-    virtual TLBManager *get_tlb_manager() { return nullptr; }
+    virtual TLBManager *get_tlb_manager() { return tlb_manager_.get(); }
 
     virtual void dma_write_to_device(const void *src, size_t size, tt_xy_pair core, uint64_t addr);
 
@@ -444,6 +444,7 @@ protected:
     LockManager lock_manager;
     std::unique_ptr<ArcTelemetryReader> telemetry = nullptr;
     std::unique_ptr<FirmwareInfoProvider> firmware_info_provider = nullptr;
+    std::unique_ptr<TLBManager> tlb_manager_;
 
     TTDevice();
     TTDevice(std::unique_ptr<architecture_implementation> architecture_impl);

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -447,11 +447,6 @@ protected:
     LockManager lock_manager;
     std::unique_ptr<ArcTelemetryReader> telemetry = nullptr;
     std::unique_ptr<FirmwareInfoProvider> firmware_info_provider = nullptr;
-    // MUST be declared after architecture_impl_: SimulationTlbManager (a TLBManager
-    // subclass) caches a raw architecture_implementation* obtained from
-    // architecture_impl_.get(). Reverse-declaration destruction order ensures
-    // tlb_manager_ is torn down while architecture_impl_ is still alive.
-    std::unique_ptr<TLBManager> tlb_manager_;
 
     TTDevice();
     TTDevice(std::unique_ptr<architecture_implementation> architecture_impl);
@@ -479,6 +474,15 @@ private:
     PcieInterface *pcie_capabilities_ = nullptr;
     JtagInterface *jtag_capabilities_ = nullptr;
     RemoteInterface *remote_capabilities_ = nullptr;
+
+protected:
+    // MUST be the last-declared member so it is destroyed first (reverse declaration order).
+    // The owned TLBManager destroys cached TlbWindows on teardown:
+    //  - Silicon: SiliconTlbHandle::free_tlb() dereferences PCIDevice held by device_protocol_,
+    //    so tlb_manager_ must die before device_protocol_.
+    //  - Simulation: SimulationTlbManager caches a raw architecture_implementation* obtained
+    //    from architecture_impl_.get(), so tlb_manager_ must die before architecture_impl_.
+    std::unique_ptr<TLBManager> tlb_manager_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -404,7 +404,7 @@ public:
 
     virtual SimulationSysmemManager *get_sysmem_manager() { return nullptr; }
 
-    virtual TLBManager *get_tlb_manager() { return tlb_manager_.get(); }
+    TLBManager *get_tlb_manager() { return tlb_manager_.get(); }
 
     virtual void dma_write_to_device(const void *src, size_t size, tt_xy_pair core, uint64_t addr);
 

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -68,8 +68,6 @@ public:
 
     SimulationSysmemManager *get_sysmem_manager() override { return sysmem_manager_.get(); }
 
-    TLBManager *get_tlb_manager() override;
-
     uint64_t bar0_base = 0;
 
 protected:
@@ -90,7 +88,6 @@ private:
 
     uint32_t libttsim_pci_device_id;
 
-    std::unique_ptr<SimulationTlbManager> tlb_manager_;
     std::unique_ptr<TlbWindow> cached_tlb_window_ = nullptr;
 };
 }  // namespace tt::umd

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -64,15 +64,13 @@ std::unique_ptr<LocalChip> LocalChip::create(
 
 std::unique_ptr<LocalChip> LocalChip::create(
     std::unique_ptr<TTDevice> tt_device, const SocDescriptor& soc_descriptor, int num_host_mem_channels) {
-    std::unique_ptr<TLBManager> tlb_manager = nullptr;
     std::unique_ptr<SysmemManager> sysmem_manager = nullptr;
     std::unique_ptr<RemoteCommunication> remote_communication = nullptr;
 
     // The variables below are only needed when using PCIe.
     // JTAG(currently the only communication protocol other than PCIe) has no use of them.
     if (tt_device->get_pci_device() != nullptr) {
-        tlb_manager = std::make_unique<TLBManager>(tt_device.get());
-        sysmem_manager = std::make_unique<SiliconSysmemManager>(tlb_manager.get(), num_host_mem_channels);
+        sysmem_manager = std::make_unique<SiliconSysmemManager>(tt_device->get_tlb_manager(), num_host_mem_channels);
     }
     // Note that the eth_coord is not important here since this is only used for eth broadcasting.
     SysmemManager* sysmem_ptr =
@@ -82,7 +80,6 @@ std::unique_ptr<LocalChip> LocalChip::create(
     return std::unique_ptr<LocalChip>(new LocalChip(
         soc_descriptor,
         std::move(tt_device),
-        std::move(tlb_manager),
         std::move(sysmem_manager),
         std::move(remote_communication),
         num_host_mem_channels));
@@ -91,18 +88,16 @@ std::unique_ptr<LocalChip> LocalChip::create(
 LocalChip::LocalChip(
     SocDescriptor soc_descriptor,
     std::unique_ptr<TTDevice> tt_device,
-    std::unique_ptr<TLBManager> tlb_manager,
     std::unique_ptr<SysmemManager> sysmem_manager,
     std::unique_ptr<RemoteCommunication> remote_communication,
     int num_host_mem_channels) :
     Chip(tt_device->get_chip_info(), std::move(soc_descriptor)),
-    tlb_manager_(std::move(tlb_manager)),
     sysmem_manager_(std::move(sysmem_manager)),
     remote_communication_(std::move(remote_communication)),
     tt_device_(std::move(tt_device)) {
     tt_device_->set_power_state(true);
     wait_chip_to_be_ready();
-    if (tlb_manager_ != nullptr) {
+    if (tt_device_->get_tlb_manager() != nullptr) {
         initialize_default_chip_mutexes();
     }
 }
@@ -115,7 +110,6 @@ LocalChip::~LocalChip() {
     cached_uc_tlb_window.reset();
     remote_communication_.reset();
     sysmem_manager_.reset();
-    tlb_manager_.reset();
     tt_device_.reset();
 }
 
@@ -162,7 +156,7 @@ TTDevice* LocalChip::get_tt_device() { return tt_device_.get(); }
 
 SysmemManager* LocalChip::get_sysmem_manager() { return sysmem_manager_.get(); }
 
-TLBManager* LocalChip::get_tlb_manager() { return tlb_manager_.get(); }
+TLBManager* LocalChip::get_tlb_manager() { return tt_device_->get_tlb_manager(); }
 
 bool LocalChip::is_mmio_capable() const { return true; }
 
@@ -195,8 +189,8 @@ void LocalChip::close_device() {
         if (sysmem_manager_) {
             sysmem_manager_->unpin_or_unmap_sysmem();
         }
-        if (tlb_manager_) {
-            tlb_manager_->clear_mapped_tlbs();
+        if (tt_device_->get_tlb_manager()) {
+            tt_device_->get_tlb_manager()->clear_mapped_tlbs();
         }
     }
     chip_started_lock_.reset();
@@ -280,8 +274,9 @@ void LocalChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_des
         return;
     }
 
-    if (tlb_manager_->is_tlb_mapped(translated_core, l1_dest, size)) {
-        TlbWindow* tlb_window = tlb_manager_->get_tlb_window(translated_core);
+    TLBManager* tlb_manager = tt_device_->get_tlb_manager();
+    if (tlb_manager->is_tlb_mapped(translated_core, l1_dest, size)) {
+        TlbWindow* tlb_window = tlb_manager->get_tlb_window(translated_core);
         tlb_window->write_block(l1_dest - tlb_window->get_base_address(), src, size);
     } else {
         std::lock_guard<std::mutex> lock(wc_tlb_lock);
@@ -305,8 +300,9 @@ void LocalChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, si
         tt_device_->read_from_device(dest, translated_core, l1_src, size);
         return;
     }
-    if (tlb_manager_->is_tlb_mapped(translated_core, l1_src, size)) {
-        TlbWindow* tlb_window = tlb_manager_->get_tlb_window(translated_core);
+    TLBManager* tlb_manager = tt_device_->get_tlb_manager();
+    if (tlb_manager->is_tlb_mapped(translated_core, l1_src, size)) {
+        TlbWindow* tlb_window = tlb_manager->get_tlb_window(translated_core);
         tlb_window->read_block(l1_src - tlb_window->get_base_address(), dest, size);
     } else {
         std::lock_guard<std::mutex> lock(wc_tlb_lock);

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -189,8 +189,8 @@ void LocalChip::close_device() {
         if (sysmem_manager_) {
             sysmem_manager_->unpin_or_unmap_sysmem();
         }
-        if (tt_device_->get_tlb_manager()) {
-            tt_device_->get_tlb_manager()->clear_mapped_tlbs();
+        if (auto* tlb_manager = tt_device_->get_tlb_manager()) {
+            tlb_manager->clear_mapped_tlbs();
         }
     }
     chip_started_lock_.reset();

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -83,6 +83,9 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
 
     communicator_->initialize();
 
+    // Local typed handle: allocate_default_tlb_window() is SimulationTlbManager-only,
+    // so we keep the derived type until after the call, then upcast into the
+    // base-owned tlb_manager_ via implicit unique_ptr<Derived> -> unique_ptr<Base>.
     auto sim_tlb = std::make_unique<SimulationTlbManager>(
         this,
         /*bar0_base=*/0,

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -83,7 +83,7 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
 
     communicator_->initialize();
 
-    tlb_manager_ = std::make_unique<SimulationTlbManager>(
+    auto sim_tlb = std::make_unique<SimulationTlbManager>(
         this,
         /*bar0_base=*/0,
         architecture_impl_.get(),
@@ -92,7 +92,8 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
             auto handle = RtlSimTlbHandle::create(mgr, id, sz, map);
             return std::make_unique<RtlSimTlbWindow>(std::move(handle), comm, cfg);
         });
-    cached_tlb_window_ = tlb_manager_->allocate_default_tlb_window();
+    cached_tlb_window_ = sim_tlb->allocate_default_tlb_window();
+    tlb_manager_ = std::move(sim_tlb);
 }
 
 RtlSimulationTTDevice::~RtlSimulationTTDevice() { communicator_->shutdown(); }
@@ -289,7 +290,5 @@ void RtlSimulationTTDevice::dma_multicast_write(
 void RtlSimulationTTDevice::retrain_dram_core(const uint32_t dram_channel) {
     UMD_THROW(error::RuntimeError, "DRAM retraining is not supported in RTL simulation device.");
 }
-
-TLBManager* RtlSimulationTTDevice::get_tlb_manager() { return static_cast<TLBManager*>(tlb_manager_.get()); }
 
 }  // namespace tt::umd

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -64,6 +64,7 @@ TTDevice::TTDevice(
     if (use_safe_api) {
         set_sigbus_safe_handler(true);
     }
+    tlb_manager_ = std::make_unique<TLBManager>(this);
 }
 
 TTDevice::TTDevice(

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -82,6 +82,9 @@ TTSimTTDevice::TTSimTTDevice(
         }
     }
 
+    // Local typed handle: allocate_default_tlb_window() is SimulationTlbManager-only,
+    // so we keep the derived type until after the call, then upcast into the
+    // base-owned tlb_manager_ via implicit unique_ptr<Derived> -> unique_ptr<Base>.
     auto sim_tlb = std::make_unique<SimulationTlbManager>(
         this,
         bar0_base,

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -82,7 +82,7 @@ TTSimTTDevice::TTSimTTDevice(
         }
     }
 
-    tlb_manager_ = std::make_unique<SimulationTlbManager>(
+    auto sim_tlb = std::make_unique<SimulationTlbManager>(
         this,
         bar0_base,
         architecture_impl_.get(),
@@ -91,7 +91,8 @@ TTSimTTDevice::TTSimTTDevice(
             auto handle = TTSimTlbHandle::create(mgr, comm, id, sz, map);
             return std::make_unique<TTSimTlbWindow>(std::move(handle), comm, cfg);
         });
-    cached_tlb_window_ = tlb_manager_->allocate_default_tlb_window();
+    cached_tlb_window_ = sim_tlb->allocate_default_tlb_window();
+    tlb_manager_ = std::move(sim_tlb);
 }
 
 TTSimTTDevice::~TTSimTTDevice() { communicator_->shutdown(); }
@@ -286,7 +287,5 @@ void TTSimTTDevice::pci_dma_write_bytes(uint64_t paddr, const void* p, uint32_t 
 void TTSimTTDevice::retrain_dram_core(const uint32_t dram_channel) {
     UMD_THROW(error::RuntimeError, "DRAM retraining is not supported in TTSim device.");
 }
-
-TLBManager* TTSimTTDevice::get_tlb_manager() { return static_cast<TLBManager*>(tlb_manager_.get()); }
 
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue
/

### Description

Stacked on #2476. This PR unifies `TLBManager` ownership across every `TTDevice` flavor — silicon PCIe, `TTSim`, and RTL sim — so that all of them hold their `TLBManager` in the same base-class member, and the `Chip` layer no longer has to care about who owns it.

#### Background

Before this PR there were two independent ownership paths for `TLBManager`:

- **Silicon:** `LocalChip::tlb_manager_` (a `std::unique_ptr<TLBManager>`), constructed in `LocalChip::create` when the underlying `TTDevice` has a `PCIDevice`. Consumers reach it via `LocalChip::get_tlb_manager()`.
- **Simulation:** `TTSimTTDevice::tlb_manager_` / `RtlSimulationTTDevice::tlb_manager_` (each a `std::unique_ptr<SimulationTlbManager>`), constructed in the simulation `TTDevice` subclass ctor. The corresponding `TTSimChip` / `RtlSimulationChip` already forward `get_tlb_manager()` to `tt_device_->get_tlb_manager()`.

#2476 introduced `virtual TLBManager* get_tlb_manager() { return nullptr; }` on `TTDevice` so that simulation subclasses could expose their `TLBManager` polymorphically through a `TTDevice*`. Silicon still kept its manager on `LocalChip`, which meant the same conceptual resource was owned by two different classes and accessed through two different code paths.

#### What changes here

- `TTDevice` base gains a single protected member `std::unique_ptr<TLBManager> tlb_manager_`. This is the one home for the `TLBManager` from now on — silicon puts a plain `TLBManager` there, simulation puts a `SimulationTlbManager` there (implicit upcast, public inheritance).
- `TTDevice::get_tlb_manager()` — added by #2476 as a `virtual` returning `nullptr` — becomes a non-virtual accessor that returns the base member. No subclass overrides it anymore.
- The PCIe `TTDevice` constructor populates the member with `std::make_unique<TLBManager>(this)`. JTAG and Remote constructors leave it null (preserves current behavior — silicon `TLBManager` only exists for PCIe).
- Simulation subclass constructors (`TTSimTTDevice`, `RtlSimulationTTDevice`) build a `SimulationTlbManager` into a local typed handle, call `allocate_default_tlb_window()` on that handle (a `SimulationTlbManager`-only method), then move the handle into the base member.
- `LocalChip` loses its `tlb_manager_` field, its ctor param, its explicit dtor reset, and the three internal direct-access call sites in `close_device`/`write_to_device`/`read_from_device`. `LocalChip::get_tlb_manager()` is now a one-liner that forwards to `tt_device_->get_tlb_manager()` — symmetric with what `TTSimChip::get_tlb_manager()` and `RtlSimulationChip::get_tlb_manager()` already do.

#### Why non-virtual getter

After both subclass overrides are removed, there is no reason to keep virtual dispatch for this accessor — all `TTDevice` subclasses now use the same base-owned slot. Dropping `virtual` reduces one level of indirection in a hot helper (`TLBManager* mgr = tt_device_->get_tlb_manager();` is called inside `LocalChip::write_to_device` / `read_from_device`).

#### Destruction ordering

`tlb_manager_` is declared in `TTDevice` after `std::unique_ptr<architecture_implementation> architecture_impl_`, so it is destroyed first. This matters for the simulation case: `SimulationTlbManager` caches a raw `architecture_implementation*` obtained from `architecture_impl_.get()`. Destruction runs in reverse declaration order, so `tlb_manager_` is torn down while `architecture_impl_` is still alive.

On the `LocalChip` side, `SiliconSysmemManager` stores a raw `TLBManager*` obtained at construction from `tt_device->get_tlb_manager()`. The existing explicit reset order in `~LocalChip` (`sysmem_manager_.reset(); tt_device_.reset();`) ensures `SiliconSysmemManager` is torn down before `tt_device_` (and therefore before the owned `TLBManager`) — the raw pointer is valid throughout `~SiliconSysmemManager`.

#### Commits

This PR is split into two logical commits for reviewability:

1. **`Move silicon TLBManager ownership from LocalChip to TTDevice`** — introduces the base-class member, populates it from the PCIe ctor, routes the PR #2476 virtual body to the member, and drops `LocalChip`'s field + call sites. Simulation subclasses are untouched in this commit; their existing `get_tlb_manager()` override still dispatches to their own field.
2. **`Unify TLBManager ownership on TTDevice, drop virtual accessor`** — migrates both simulation subclasses to use the base member, removes their field and override, and de-virtualizes `TTDevice::get_tlb_manager()`.

### List of the changes

- `device/api/umd/device/tt_device/tt_device.hpp`: add protected `std::unique_ptr<TLBManager> tlb_manager_` member; change `get_tlb_manager()` body from `return nullptr;` to `return tlb_manager_.get();` and drop the `virtual` qualifier.
- `device/tt_device/tt_device.cpp`: populate `tlb_manager_` at the end of the PCIe `TTDevice` constructor.
- `device/api/umd/device/chip/local_chip.hpp`: remove `tlb_manager_` field and `std::unique_ptr<TLBManager>` ctor parameter.
- `device/chip/local_chip.cpp`: drop local `tlb_manager` construction in `LocalChip::create` and feed `SiliconSysmemManager` from `tt_device->get_tlb_manager()`; drop ctor member init and the `tlb_manager_.reset()` in the dtor; update the `initialize_default_chip_mutexes()` guard to check `tt_device_->get_tlb_manager()`; make `LocalChip::get_tlb_manager()` forward; update the three internal call sites (`close_device`, `write_to_device`, `read_from_device`) to source the manager from `tt_device_` (local `TLBManager*` alias in the two hot-path methods to avoid repeated getter calls).
- `device/api/umd/device/tt_device/tt_sim_tt_device.hpp`: remove the private `std::unique_ptr<SimulationTlbManager> tlb_manager_` field and the `get_tlb_manager()` override declaration.
- `device/tt_device/tt_sim_tt_device.cpp`: rework the ctor to build a local `std::unique_ptr<SimulationTlbManager>`, call `allocate_default_tlb_window()` on that handle, and move it into the inherited base member; remove the `get_tlb_manager()` override definition.
- `device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp` + `device/tt_device/rtl_simulation_tt_device.cpp`: same transformation as the `TTSim` pair.

### Testing

CI. Pre-commit clean locally (`cmake --build build` + `pre-commit run --all-files` after each commit).

No new tests — this is a pure ownership refactor with no behavior change. Existing silicon coverage exercises `Cluster::get_tlb_manager()` / `LocalChip::get_tlb_manager()`; simulation coverage exercises `TTSimChip::get_tlb_manager()` / `RtlSimulationChip::get_tlb_manager()`. Both routes ultimately resolve to the same non-virtual `TTDevice::get_tlb_manager()` after this PR.

### API Changes

Non-breaking internal change:
- `TTDevice::get_tlb_manager()` loses its `virtual` qualifier. No known external subclass overrides it (all simulation overrides are removed in this PR; silicon subclasses never overrode it).
- `LocalChip`'s private constructor signature loses one parameter. Not part of the public API.

No header exports or types change shape.