### PR TITLE
Move silicon SysmemManager ownership into TTDevice (unified)

### DIFF
--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -80,11 +80,9 @@ private:
     LocalChip(
         SocDescriptor soc_descriptor,
         std::unique_ptr<TTDevice> tt_device,
-        std::unique_ptr<SysmemManager> sysmem_manager,
         std::unique_ptr<RemoteCommunication> remote_communication,
         int num_host_mem_channels);
 
-    std::unique_ptr<SysmemManager> sysmem_manager_;
     LockManager lock_manager_;
     // Used only for ethernet broadcast to all remote chips.
     std::unique_ptr<RemoteCommunication> remote_communication_;

--- a/device/api/umd/device/chip_helpers/sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_manager.hpp
@@ -6,11 +6,12 @@
 
 #include "sysmem_buffer.hpp"
 #include "umd/device/chip_helpers/sysmem_buffer.hpp"
-#include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_types.hpp"
 
 namespace tt::umd {
+
+class TTDevice;
 
 class SysmemManager {
 public:

--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -45,7 +45,7 @@ public:
     EthTrainingStatus read_eth_core_training_status(tt_xy_pair eth_core) override;
 
 protected:
-    BlackholeTTDevice(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api);
+    BlackholeTTDevice(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api, int num_host_mem_channels = 0);
     BlackholeTTDevice(std::unique_ptr<JtagDevice> jtag_device, uint8_t jlink_id);
 
     virtual bool is_arc_available_over_axi();
@@ -58,7 +58,8 @@ protected:
 private:
     int get_pcie_x_coordinate();
 
-    friend std::unique_ptr<TTDevice> TTDevice::create(int device_number, IODeviceType device_type, bool use_safe_api);
+    friend std::unique_ptr<TTDevice> TTDevice::create(
+        int device_number, IODeviceType device_type, bool use_safe_api, int num_host_mem_channels);
 
     static constexpr uint64_t ATU_OFFSET_IN_BH_BAR2 = 0x1000;
     std::set<size_t> iatu_regions_;

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -59,8 +59,6 @@ public:
 
     RtlSimCommunicator* get_communicator() { return communicator_.get(); }
 
-    SimulationSysmemManager* get_sysmem_manager() override { return sysmem_manager_.get(); }
-
 protected:
     void retrain_dram_core(const uint32_t dram_channel) override;
 
@@ -69,7 +67,6 @@ private:
     std::recursive_mutex device_lock;
 
     std::filesystem::path simulator_directory_;
-    std::unique_ptr<SimulationSysmemManager> sysmem_manager_;
     std::unique_ptr<TlbWindow> cached_tlb_window_;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -406,7 +406,7 @@ public:
      */
     virtual void deassert_risc_reset(tt_xy_pair core, const RiscType selected_riscs, bool staggered_start);
 
-    virtual SysmemManager *get_sysmem_manager() { return sysmem_manager_.get(); }
+    SysmemManager *get_sysmem_manager() { return sysmem_manager_.get(); }
 
     // Returns nullptr for non-PCIe communication paths (JTAG, Remote).
     // Ownership is unified at this base: derived classes populate tlb_manager_

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -14,6 +14,7 @@
 #include "umd/device/arc/arc_messenger.hpp"
 #include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
@@ -38,7 +39,6 @@ namespace tt::umd {
 class ArcMessenger;
 class ArcTelemetryReader;
 class RemoteCommunication;
-class SimulationSysmemManager;
 
 // Represents the status of the ETH core.
 enum class EthTrainingStatus {
@@ -55,13 +55,17 @@ public:
      * Jtag support can be enabled.
      */
     static std::unique_ptr<TTDevice> create(
-        int device_number, IODeviceType device_type = IODeviceType::PCIe, bool use_safe_api = false);
+        int device_number,
+        IODeviceType device_type = IODeviceType::PCIe,
+        bool use_safe_api = false,
+        int num_host_mem_channels = 0);
     static std::unique_ptr<TTDevice> create(std::unique_ptr<RemoteCommunication> remote_communication);
 
     TTDevice(
         std::unique_ptr<PCIDevice> pci_device,
         std::unique_ptr<architecture_implementation> architecture_impl,
-        bool use_safe_api);
+        bool use_safe_api,
+        int num_host_mem_channels = 0);
     TTDevice(
         std::unique_ptr<JtagDevice> jtag_device,
         uint8_t jlink_id,
@@ -402,7 +406,7 @@ public:
      */
     virtual void deassert_risc_reset(tt_xy_pair core, const RiscType selected_riscs, bool staggered_start);
 
-    virtual SimulationSysmemManager *get_sysmem_manager() { return nullptr; }
+    virtual SysmemManager *get_sysmem_manager() { return sysmem_manager_.get(); }
 
     // Returns nullptr for non-PCIe communication paths (JTAG, Remote).
     // Ownership is unified at this base: derived classes populate tlb_manager_
@@ -476,13 +480,17 @@ private:
     RemoteInterface *remote_capabilities_ = nullptr;
 
 protected:
-    // MUST be the last-declared member so it is destroyed first (reverse declaration order).
-    // The owned TLBManager destroys cached TlbWindows on teardown:
-    //  - Silicon: SiliconTlbHandle::free_tlb() dereferences PCIDevice held by device_protocol_,
-    //    so tlb_manager_ must die before device_protocol_.
-    //  - Simulation: SimulationTlbManager caches a raw architecture_implementation* obtained
-    //    from architecture_impl_.get(), so tlb_manager_ must die before architecture_impl_.
+    // These two MUST be the last-declared members. Reverse-declaration destruction order is
+    // load-bearing for both:
+    //  - tlb_manager_ destroys cached TlbWindows; on silicon SiliconTlbHandle::free_tlb()
+    //    dereferences the PCIDevice held by device_protocol_, and on simulation
+    //    SimulationTlbManager caches a raw architecture_implementation* from
+    //    architecture_impl_.get(). So tlb_manager_ must die before both.
+    //  - sysmem_manager_ holds a raw TLBManager* (SiliconSysmemManager) used during its
+    //    dtor (unpin/unmap), so sysmem_manager_ must die before tlb_manager_ — i.e.
+    //    declared after tlb_manager_ here.
     std::unique_ptr<TLBManager> tlb_manager_;
+    std::unique_ptr<SysmemManager> sysmem_manager_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -66,8 +66,6 @@ public:
      */
     TTSimCommunicator *get_communicator() { return communicator_.get(); }
 
-    SimulationSysmemManager *get_sysmem_manager() override { return sysmem_manager_.get(); }
-
     uint64_t bar0_base = 0;
 
 protected:
@@ -84,7 +82,6 @@ private:
 
     std::filesystem::path simulator_directory_;
     ChipId chip_id_;
-    std::unique_ptr<SimulationSysmemManager> sysmem_manager_;
 
     uint32_t libttsim_pci_device_id;
 

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -46,14 +46,15 @@ public:
     ~WormholeTTDevice() override = default;
 
 protected:
-    WormholeTTDevice(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api);
+    WormholeTTDevice(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api, int num_host_mem_channels = 0);
     WormholeTTDevice(std::unique_ptr<JtagDevice> jtag_device, uint8_t jlink_id);
     WormholeTTDevice(std::unique_ptr<RemoteCommunication> remote_communication);
 
     void retrain_dram_core(const uint32_t dram_channel) override;
 
 private:
-    friend std::unique_ptr<TTDevice> TTDevice::create(int device_number, IODeviceType device_type, bool use_safe_api);
+    friend std::unique_ptr<TTDevice> TTDevice::create(
+        int device_number, IODeviceType device_type, bool use_safe_api, int num_host_mem_channels);
     friend std::unique_ptr<TTDevice> TTDevice::create(std::unique_ptr<RemoteCommunication> remote_communication);
 };
 }  // namespace tt::umd

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -36,7 +36,7 @@ std::unique_ptr<LocalChip> LocalChip::create(
     int physical_device_id, const std::string& sdesc_path, int num_host_mem_channels, IODeviceType device_type) {
     ZoneScopedC(tracy::Color::DarkGreen);
     // Create TTDevice and make sure the arc is ready so we can read its telemetry.
-    auto tt_device = TTDevice::create(physical_device_id, device_type);
+    auto tt_device = TTDevice::create(physical_device_id, device_type, /*use_safe_api=*/false, num_host_mem_channels);
     tt_device->init_tt_device();
 
     SocDescriptor soc_descriptor;
@@ -56,7 +56,7 @@ std::unique_ptr<LocalChip> LocalChip::create(
     // Create TTDevice and make sure the arc is ready so we can read its telemetry.
     // physical_device_id is not actually physical for JTAG devices here.
     // It represents the index within a vector of jlink devices discovered by JtagDevice.
-    auto tt_device = TTDevice::create(physical_device_id, device_type);
+    auto tt_device = TTDevice::create(physical_device_id, device_type, /*use_safe_api=*/false, num_host_mem_channels);
     tt_device->init_tt_device();
 
     return LocalChip::create(std::move(tt_device), soc_descriptor, num_host_mem_channels);
@@ -64,35 +64,25 @@ std::unique_ptr<LocalChip> LocalChip::create(
 
 std::unique_ptr<LocalChip> LocalChip::create(
     std::unique_ptr<TTDevice> tt_device, const SocDescriptor& soc_descriptor, int num_host_mem_channels) {
-    std::unique_ptr<SysmemManager> sysmem_manager = nullptr;
     std::unique_ptr<RemoteCommunication> remote_communication = nullptr;
 
-    // The variables below are only needed when using PCIe.
-    // JTAG(currently the only communication protocol other than PCIe) has no use of them.
-    if (tt_device->get_pci_device() != nullptr) {
-        sysmem_manager = std::make_unique<SiliconSysmemManager>(tt_device->get_tlb_manager(), num_host_mem_channels);
-    }
     // Note that the eth_coord is not important here since this is only used for eth broadcasting.
     SysmemManager* sysmem_ptr =
-        (sysmem_manager != nullptr && sysmem_manager->get_num_host_mem_channels() > 0) ? sysmem_manager.get() : nullptr;
+        (tt_device->get_sysmem_manager() != nullptr && tt_device->get_sysmem_manager()->get_num_host_mem_channels() > 0)
+            ? tt_device->get_sysmem_manager()
+            : nullptr;
     remote_communication = RemoteCommunication::create_remote_communication(tt_device.get(), {0, 0, 0, 0}, sysmem_ptr);
 
-    return std::unique_ptr<LocalChip>(new LocalChip(
-        soc_descriptor,
-        std::move(tt_device),
-        std::move(sysmem_manager),
-        std::move(remote_communication),
-        num_host_mem_channels));
+    return std::unique_ptr<LocalChip>(
+        new LocalChip(soc_descriptor, std::move(tt_device), std::move(remote_communication), num_host_mem_channels));
 }
 
 LocalChip::LocalChip(
     SocDescriptor soc_descriptor,
     std::unique_ptr<TTDevice> tt_device,
-    std::unique_ptr<SysmemManager> sysmem_manager,
     std::unique_ptr<RemoteCommunication> remote_communication,
     int num_host_mem_channels) :
     Chip(tt_device->get_chip_info(), std::move(soc_descriptor)),
-    sysmem_manager_(std::move(sysmem_manager)),
     remote_communication_(std::move(remote_communication)),
     tt_device_(std::move(tt_device)) {
     tt_device_->set_power_state(true);
@@ -109,7 +99,6 @@ LocalChip::~LocalChip() {
     cached_wc_tlb_window.reset();
     cached_uc_tlb_window.reset();
     remote_communication_.reset();
-    sysmem_manager_.reset();
     tt_device_.reset();
 }
 
@@ -154,7 +143,7 @@ void LocalChip::initialize_membars() {
 
 TTDevice* LocalChip::get_tt_device() { return tt_device_.get(); }
 
-SysmemManager* LocalChip::get_sysmem_manager() { return sysmem_manager_.get(); }
+SysmemManager* LocalChip::get_sysmem_manager() { return tt_device_->get_sysmem_manager(); }
 
 TLBManager* LocalChip::get_tlb_manager() { return tt_device_->get_tlb_manager(); }
 
@@ -170,7 +159,7 @@ void LocalChip::start_device() {
     // The lock here should suffice since we have to open Local chip to have Remote chips initialized.
     chip_started_lock_.emplace(acquire_mutex(MutexType::CHIP_IN_USE, tt_device_->get_pci_device()->get_device_num()));
 
-    sysmem_manager_->pin_or_map_sysmem_to_device();
+    tt_device_->get_sysmem_manager()->pin_or_map_sysmem_to_device();
     if (!tt_device_->get_pci_device()->is_mapping_buffer_to_noc_supported()) {
         // If this is supported by the newer KMD, UMD doesn't have to program the iatu.
         init_pcie_iatus();
@@ -186,8 +175,8 @@ void LocalChip::close_device() {
         set_power_state(DevicePowerState::LONG_IDLE);
         assert_risc_reset(RiscType::ALL);
         // Unmapping might be needed even in the case chip was reset due to kmd mappings.
-        if (sysmem_manager_) {
-            sysmem_manager_->unpin_or_unmap_sysmem();
+        if (tt_device_->get_sysmem_manager()) {
+            tt_device_->get_sysmem_manager()->unpin_or_unmap_sysmem();
         }
         if (auto* tlb_manager = tt_device_->get_tlb_manager()) {
             tlb_manager->clear_mapped_tlbs();
@@ -197,10 +186,11 @@ void LocalChip::close_device() {
 };
 
 int LocalChip::get_num_host_channels() {
-    // log_warning instead of throw because even though sysmem_manager_ may not be initialized in all cases,
+    SysmemManager* sysmem_manager = tt_device_->get_sysmem_manager();
+    // log_warning instead of throw because even though sysmem_manager may not be initialized in all cases,
     // the program should still work. It removes the need for refactoring the whole code in case
     // pcie device breaks or isn't present.
-    if (!sysmem_manager_) {
+    if (!sysmem_manager) {
         log_warning(
             LogUMD,
             "sysmem_manager was not initialized for {} communication protocol",
@@ -208,14 +198,15 @@ int LocalChip::get_num_host_channels() {
         return 0;
     }
 
-    return sysmem_manager_->get_num_host_mem_channels();
+    return sysmem_manager->get_num_host_mem_channels();
 }
 
 int LocalChip::get_host_channel_size(std::uint32_t channel) {
-    // log_warning instead of throw because even though sysmem_manager_ may not be initialized in all cases,
+    SysmemManager* sysmem_manager = tt_device_->get_sysmem_manager();
+    // log_warning instead of throw because even though sysmem_manager may not be initialized in all cases,
     // the program should still work. It removes the need for refactoring the whole code in case
     // pcie device breaks or isn't present.
-    if (!sysmem_manager_) {
+    if (!sysmem_manager) {
         log_warning(
             LogUMD,
             "sysmem_manager was not initialized for {} communication protocol",
@@ -224,37 +215,39 @@ int LocalChip::get_host_channel_size(std::uint32_t channel) {
     }
 
     TT_ASSERT(channel < get_num_host_channels(), "Querying size for a host channel that does not exist.");
-    HugepageMapping hugepage_map = sysmem_manager_->get_hugepage_mapping(channel);
+    HugepageMapping hugepage_map = sysmem_manager->get_hugepage_mapping(channel);
     TT_ASSERT(hugepage_map.mapping_size, "Host channel size can only be queried after the device has been started.");
     return hugepage_map.mapping_size;
 }
 
 void LocalChip::write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) {
-    // log_warning instead of throw because even though sysmem_manager_ may not be initialized in all cases,
+    SysmemManager* sysmem_manager = tt_device_->get_sysmem_manager();
+    // log_warning instead of throw because even though sysmem_manager may not be initialized in all cases,
     // the program should still work. It removes the need for refactoring the whole code in case
     // pcie device breaks or isn't present.
-    if (!sysmem_manager_) {
+    if (!sysmem_manager) {
         log_warning(
             LogUMD,
             "sysmem_manager was not initialized for {} communication protocol",
             DeviceTypeToString.at(tt_device_->get_communication_device_type()));
         return;
     }
-    sysmem_manager_->write_to_sysmem(channel, src, sysmem_dest, size);
+    sysmem_manager->write_to_sysmem(channel, src, sysmem_dest, size);
 }
 
 void LocalChip::read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) {
-    // log_warning instead of throw because even though sysmem_manager_ may not be initialized in all cases,
+    SysmemManager* sysmem_manager = tt_device_->get_sysmem_manager();
+    // log_warning instead of throw because even though sysmem_manager may not be initialized in all cases,
     // the program should still work. It removes the need for refactoring the whole code in case
     // pcie device breaks or isn't present.
-    if (!sysmem_manager_) {
+    if (!sysmem_manager) {
         log_warning(
             LogUMD,
             "sysmem_manager was not initialized for {} communication protocol",
             DeviceTypeToString.at(tt_device_->get_communication_device_type()));
         return;
     }
-    sysmem_manager_->read_from_sysmem(channel, dest, sysmem_src, size);
+    sysmem_manager->read_from_sysmem(channel, dest, sysmem_src, size);
 }
 
 void LocalChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_dest, size_t size) {
@@ -427,9 +420,10 @@ std::unique_lock<RobustMutex> LocalChip::acquire_mutex(MutexType mutex_type, int
 
 void LocalChip::init_pcie_iatus() {
     ZoneScopedC(tracy::Color::DarkGreen);
+    SysmemManager* sysmem_manager = tt_device_->get_sysmem_manager();
     // TODO: this should go away soon; KMD knows how to do this at page pinning time.
-    for (size_t channel = 0; channel < sysmem_manager_->get_num_host_mem_channels(); channel++) {
-        HugepageMapping hugepage_map = sysmem_manager_->get_hugepage_mapping(channel);
+    for (size_t channel = 0; channel < sysmem_manager->get_num_host_mem_channels(); channel++) {
+        HugepageMapping hugepage_map = sysmem_manager->get_hugepage_mapping(channel);
         size_t region_size = hugepage_map.mapping_size;
 
         if (!hugepage_map.mapping) {

--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -26,6 +26,7 @@
 #include "assert.hpp"
 #include "cpuset_lib.hpp"
 #include "hugepage.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
 
 namespace tt::umd {
 

--- a/device/chip_helpers/sysmem_manager.cpp
+++ b/device/chip_helpers/sysmem_manager.cpp
@@ -17,6 +17,7 @@
 #include "assert.hpp"
 #include "cpuset_lib.hpp"
 #include "hugepage.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
 
 namespace tt::umd {
 

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -34,8 +34,9 @@
 
 namespace tt::umd {
 
-BlackholeTTDevice::BlackholeTTDevice(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api) :
-    TTDevice(std::move(pci_device), std::make_unique<blackhole_implementation>(), use_safe_api) {
+BlackholeTTDevice::BlackholeTTDevice(
+    std::unique_ptr<PCIDevice> pci_device, bool use_safe_api, int num_host_mem_channels) :
+    TTDevice(std::move(pci_device), std::make_unique<blackhole_implementation>(), use_safe_api, num_host_mem_channels) {
     arc_core = blackhole::get_arc_core(BlackholeTTDevice::get_noc_translation_enabled(), is_selected_noc1());
     set_hang_detector(std::make_unique<BlackholeHangDetector>(
         get_device_protocol(), get_architecture_implementation(), BlackholeTTDevice::get_noc_translation_enabled()));

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -47,8 +47,8 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
     ChipId chip_id,
     int num_host_mem_channels) :
     communicator_(std::make_unique<RtlSimCommunicator>(simulator_directory)),
-    simulator_directory_(simulator_directory),
-    sysmem_manager_(std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)) {
+    simulator_directory_(simulator_directory) {
+    auto sim_sysmem = std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch);
     log_info(tt::LogEmulationDriver, "Instantiating RTL simulation TTDevice");
     set_soc_descriptor(soc_descriptor);
     architecture_impl_ = architecture_implementation::create(get_soc_descriptor().arch);
@@ -56,7 +56,7 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
 
     // Register sysmem callbacks so the simulator can read/write host memory.
     if (num_host_mem_channels > 0) {
-        SimulationSysmemManager* mgr = sysmem_manager_.get();
+        SimulationSysmemManager* mgr = sim_sysmem.get();
         size_t num_channels = mgr->get_num_host_mem_channels();
         communicator_->set_ram_callbacks(
             // Write callback: simulator writes data into host sysmem.
@@ -97,6 +97,7 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
         });
     cached_tlb_window_ = sim_tlb->allocate_default_tlb_window();
     tlb_manager_ = std::move(sim_tlb);
+    sysmem_manager_ = std::move(sim_sysmem);
 }
 
 RtlSimulationTTDevice::~RtlSimulationTTDevice() { communicator_->shutdown(); }

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -21,6 +21,7 @@
 #include "noc_access.hpp"
 #include "tracy.hpp"
 #include "umd/device/arc/arc_messenger.hpp"
+#include "umd/device/chip_helpers/silicon_sysmem_manager.hpp"
 #include "umd/device/driver_atomics.hpp"
 #include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
@@ -51,7 +52,8 @@ namespace tt::umd {
 TTDevice::TTDevice(
     std::unique_ptr<PCIDevice> pci_device,
     std::unique_ptr<architecture_implementation> architecture_impl,
-    bool use_safe_api) :
+    bool use_safe_api,
+    int num_host_mem_channels) :
     communication_device_type_(IODeviceType::PCIe),
     communication_device_id_(pci_device->get_device_num()),
     architecture_impl_(std::move(architecture_impl)),
@@ -65,6 +67,7 @@ TTDevice::TTDevice(
         set_sigbus_safe_handler(true);
     }
     tlb_manager_ = std::make_unique<TLBManager>(this);
+    sysmem_manager_ = std::make_unique<SiliconSysmemManager>(tlb_manager_.get(), num_host_mem_channels);
 }
 
 TTDevice::TTDevice(
@@ -121,7 +124,7 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms, const 
 }
 
 /* static */ std::unique_ptr<TTDevice> TTDevice::create(
-    int device_number, IODeviceType device_type, bool use_safe_api) {
+    int device_number, IODeviceType device_type, bool use_safe_api, int num_host_mem_channels) {
     ZoneScopedC(tracy::Color::DarkGreen);
     // TODO make abstract IO handler inside TTDevice.
     if (device_type == IODeviceType::JTAG) {
@@ -141,9 +144,11 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms, const 
 
     switch (pci_device->get_arch()) {
         case ARCH::WORMHOLE_B0:
-            return std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(std::move(pci_device), use_safe_api));
+            return std::unique_ptr<WormholeTTDevice>(
+                new WormholeTTDevice(std::move(pci_device), use_safe_api, num_host_mem_channels));
         case ARCH::BLACKHOLE:
-            return std::unique_ptr<BlackholeTTDevice>(new BlackholeTTDevice(std::move(pci_device), use_safe_api));
+            return std::unique_ptr<BlackholeTTDevice>(
+                new BlackholeTTDevice(std::move(pci_device), use_safe_api, num_host_mem_channels));
         default:
             return nullptr;
     }

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -45,8 +45,8 @@ TTSimTTDevice::TTSimTTDevice(
     int num_host_mem_channels) :
     communicator_(std::make_unique<TTSimCommunicator>(simulator_directory, copy_sim_binary)),
     simulator_directory_(simulator_directory),
-    chip_id_(chip_id),
-    sysmem_manager_(std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)) {
+    chip_id_(chip_id) {
+    sysmem_manager_ = std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch);
     set_soc_descriptor(soc_descriptor);
     // Populate the base-class arch field from the soc descriptor. TTSim does not go through
     // init_tt_device() (no PCI probe), so without this arch stays tt::ARCH::Invalid and downstream

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -32,8 +32,9 @@
 
 namespace tt::umd {
 
-WormholeTTDevice::WormholeTTDevice(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api) :
-    TTDevice(std::move(pci_device), std::make_unique<wormhole_implementation>(), use_safe_api) {
+WormholeTTDevice::WormholeTTDevice(
+    std::unique_ptr<PCIDevice> pci_device, bool use_safe_api, int num_host_mem_channels) :
+    TTDevice(std::move(pci_device), std::make_unique<wormhole_implementation>(), use_safe_api, num_host_mem_channels) {
     arc_core = is_selected_noc1() ? tt_xy_pair(
                                         wormhole::NOC0_X_TO_NOC1_X[wormhole::ARC_CORES_NOC0[0].x],
                                         wormhole::NOC0_Y_TO_NOC1_Y[wormhole::ARC_CORES_NOC0[0].y])


### PR DESCRIPTION
### Issue
/

### Description

Stacked on #2516 (TLBManager unification). Completes the pattern for `SysmemManager`: every `TTDevice` flavor — silicon PCIe, `TTSim`, RTL sim — stores its `SysmemManager` in one base-class member, and the `Chip` layer forwards instead of owning.

#### Background

Before this PR the ownership split was:
- **Silicon:** `LocalChip::sysmem_manager_` (a `std::unique_ptr<SysmemManager>` holding a `SiliconSysmemManager`), constructed in `LocalChip::create` when the `TTDevice` is PCIe. `SiliconSysmemManager` needs a `TLBManager*` plus `num_host_mem_channels`.
- **Simulation:** `TTSimTTDevice::sysmem_manager_` / `RtlSimulationTTDevice::sysmem_manager_` (each a `std::unique_ptr<SimulationSysmemManager>`), constructed in the sim subclass ctor from `num_host_mem_channels` + `soc_descriptor.arch`.

#2476 added `virtual SimulationSysmemManager* get_sysmem_manager() { return nullptr; }` to `TTDevice` so simulation could be reached polymorphically. That return type made silicon polymorphism impossible (`SiliconSysmemManager` is a sibling of `SimulationSysmemManager`, not derived).

#### What changes here

- `TTDevice` base gains `std::unique_ptr<SysmemManager> sysmem_manager_` as the single home. Silicon stores a `SiliconSysmemManager` there, simulation stores a `SimulationSysmemManager` there (implicit upcast, public inheritance).
- `TTDevice::get_sysmem_manager()` — added by #2476 as a `virtual` returning `SimulationSysmemManager*` / `nullptr` — becomes a non-virtual accessor returning `SysmemManager*` (base type, so both flavors fit). No subclass overrides it anymore.
- `num_host_mem_channels` is now threaded through `TTDevice::create(int device_number, IODeviceType, bool use_safe_api, int num_host_mem_channels = 0)` and the PCIe `TTDevice` / `Wormhole` / `Blackhole` ctors. `LocalChip::create` — which already has the value — passes it through. Default `0` keeps all other callers (`warm_reset`, `topology_discovery`, test helpers) working unchanged.
- The PCIe `TTDevice` ctor now constructs `SiliconSysmemManager` immediately after `TLBManager` (which it depends on).
- Simulation subclass ctors move their `SimulationSysmemManager` construction from the initializer list into the ctor body — can't initialize an inherited base member from a derived initializer list. The construction is placed before any code that reads `sysmem_manager_` (for `TTSimTTDevice`: before `initialize_sysmem_functions`; for `RtlSimulationTTDevice`: a local `SimulationSysmemManager*` handle keeps the ram-callbacks block unchanged, then moves into the base slot).
- `LocalChip` loses the field + ctor param + dtor reset; `LocalChip::get_sysmem_manager()` forwards to `tt_device_`; six internal direct-access call sites (`start_device`, `close_device`, `get_num_host_channels`, `get_host_channel_size`, `write_to_sysmem`, `read_from_sysmem`, `init_pcie_iatus`) are rewired through the forwarder with a cached local to avoid repeated getter calls.

#### Include-cycle fix

Adding `#include "umd/device/chip_helpers/sysmem_manager.hpp"` to `tt_device.hpp` surfaced an existing circular include: `sysmem_manager.hpp` was pulling `tt_device.hpp` to use `TTDevice*`. `TTDevice*` in that header only needs a forward decl, so `sysmem_manager.hpp` now does `class TTDevice;` and the `.cpp` files that actually dereference `tt_device_` (`sysmem_manager.cpp`, `silicon_sysmem_manager.cpp`) include `tt_device.hpp` directly.

#### Commits

1. **`Move silicon SysmemManager ownership from LocalChip to TTDevice`** — introduces the base member, populates it from the PCIe ctor, threads `num_host_mem_channels`, fixes the circular include, drops `LocalChip`'s field + call sites. Simulation subclasses untouched.
2. **`Unify SysmemManager ownership on TTDevice, drop virtual accessor`** — migrates both simulation subclasses to the base member, removes their field and override, and de-virtualizes `TTDevice::get_sysmem_manager()`.

### List of the changes

- `device/api/umd/device/tt_device/tt_device.hpp`: add `#include "umd/device/chip_helpers/sysmem_manager.hpp"`; remove `class SimulationSysmemManager;` forward decl; add protected `std::unique_ptr<SysmemManager> sysmem_manager_`; change `get_sysmem_manager()` return type to `SysmemManager*`, body to return the member, drop `virtual`; add `int num_host_mem_channels = 0` to the PCIe ctor signature and to the `TTDevice::create(...)` factory signature.
- `device/tt_device/tt_device.cpp`: populate `sysmem_manager_` in the PCIe ctor after `tlb_manager_`; update `TTDevice::create` to pass `num_host_mem_channels` through to `Wormhole/BlackholeTTDevice`.
- `device/api/umd/device/tt_device/wormhole_tt_device.hpp` + `device/tt_device/wormhole_tt_device.cpp`: add `int num_host_mem_channels = 0` to PCIe ctor and forward to base; update friend decl of `TTDevice::create`.
- `device/api/umd/device/tt_device/blackhole_tt_device.hpp` + `device/tt_device/blackhole_tt_device.cpp`: same.
- `device/api/umd/device/chip_helpers/sysmem_manager.hpp`: replace `#include "umd/device/tt_device/tt_device.hpp"` with a forward decl `class TTDevice;` to break the new include cycle.
- `device/chip_helpers/sysmem_manager.cpp` + `device/chip_helpers/silicon_sysmem_manager.cpp`: add `#include "umd/device/tt_device/tt_device.hpp"` (previously transitive).
- `device/api/umd/device/chip/local_chip.hpp`: remove `sysmem_manager_` field and ctor param.
- `device/chip/local_chip.cpp`: drop `SiliconSysmemManager` construction in `LocalChip::create`; source `sysmem_ptr` from `tt_device->get_sysmem_manager()`; drop ctor param/init and dtor reset; make `LocalChip::get_sysmem_manager()` forward; rewire the six internal call sites with cached locals.
- `device/api/umd/device/tt_device/tt_sim_tt_device.hpp` + `.cpp`: remove `sysmem_manager_` field and `get_sysmem_manager()` override; move construction into ctor body before `initialize_sysmem_functions()`.
- `device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp` + `.cpp`: same, using a local typed handle to preserve the ram-callbacks lambda captures.

### Testing

CI. Locally: `cmake --build build` + `pre-commit run --all-files` pass after each commit.

No new tests — pure ownership refactor, behavior unchanged. Existing silicon coverage (`Cluster::get_sysmem_manager()`, `LocalChip` sysmem APIs) and simulation coverage (`TTSimChip` / `RtlSimulationChip` forwarders) exercise both paths through the same non-virtual accessor.

### API Changes

Non-breaking internal changes:
- `TTDevice::get_sysmem_manager()` return type changes from `SimulationSysmemManager*` (as #2476 introduced) to `SysmemManager*`. Callers that were already dealing in `SysmemManager*` (via the sim overrides' covariant return) still compile.
- `TTDevice::get_sysmem_manager()` loses `virtual`. No remaining overrides.
- `TTDevice::create(...)` and `TTDevice(PCIDevice, ...)` ctor gain a trailing `int num_host_mem_channels = 0` param. Default keeps existing callers source-compatible.
- `WormholeTTDevice` / `BlackholeTTDevice` PCIe ctors gain the same trailing param. Not part of the public API (protected, constructed via `TTDevice::create` friend).
- `LocalChip`'s private ctor signature loses the `std::unique_ptr<SysmemManager>` param. Not public.

No header exports or public-facing types change shape.