### PR TITLE
Automatically set number of host mem channels in Cluster constructor

### DIFF
--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -82,8 +82,7 @@ private:
         std::unique_ptr<TTDevice> tt_device,
         std::unique_ptr<TLBManager> tlb_manager,
         std::unique_ptr<SysmemManager> sysmem_manager,
-        std::unique_ptr<RemoteCommunication> remote_communication,
-        int num_host_mem_channels);
+        std::unique_ptr<RemoteCommunication> remote_communication);
 
     std::unique_ptr<TLBManager> tlb_manager_;
     std::unique_ptr<SysmemManager> sysmem_manager_;

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -62,8 +62,10 @@ struct ClusterOptions {
 
     /**
      * Number of host memory channels (hugepages) per MMIO device.
+     * If not provided, the value is determined automatically by determining the max
+     * amount of chips connected through one PCIe interface in the ClusterDescriptor.
      */
-    uint32_t num_host_mem_ch_per_mmio_device = 0;
+    std::optional<uint32_t> num_host_mem_ch_per_mmio_device = 0;
 
     /**
      * If set, this soc descriptor will be used to construct devices on this cluster. If not set, the default soc

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -84,8 +84,7 @@ std::unique_ptr<LocalChip> LocalChip::create(
         std::move(tt_device),
         std::move(tlb_manager),
         std::move(sysmem_manager),
-        std::move(remote_communication),
-        num_host_mem_channels));
+        std::move(remote_communication)));
 }
 
 LocalChip::LocalChip(
@@ -93,8 +92,7 @@ LocalChip::LocalChip(
     std::unique_ptr<TTDevice> tt_device,
     std::unique_ptr<TLBManager> tlb_manager,
     std::unique_ptr<SysmemManager> sysmem_manager,
-    std::unique_ptr<RemoteCommunication> remote_communication,
-    int num_host_mem_channels) :
+    std::unique_ptr<RemoteCommunication> remote_communication) :
     Chip(tt_device->get_chip_info(), std::move(soc_descriptor)),
     tlb_manager_(std::move(tlb_manager)),
     sysmem_manager_(std::move(sysmem_manager)),

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -395,6 +395,16 @@ Cluster::Cluster(ClusterOptions options) {  // NOLINT(performance-unnecessary-va
             UMD_THROW(error::RuntimeError, "Unsupported chip type.");
     }
 
+    if (!options.num_host_mem_ch_per_mmio_device.has_value()) {
+        auto grouped_chips = cluster_desc->get_chips_grouped_by_closest_mmio();
+        uint32_t max_chips_per_mmio = 0;
+        for (const auto& [mmio_device_id, chips] : grouped_chips) {
+            max_chips_per_mmio = std::max(max_chips_per_mmio, static_cast<uint32_t>(chips.size()));
+        }
+        options.num_host_mem_ch_per_mmio_device = std::min(MAX_HOST_MEM_CHANNELS, max_chips_per_mmio);
+        log_debug(LogUMD, "Set number of host memory channels to {}.", options.num_host_mem_ch_per_mmio_device.value());
+    }
+
     // Construct all the required chips from the cluster descriptor.
     for (auto& chip_id : cluster_desc->get_chips_local_first(cluster_desc->get_all_chips())) {
         SocDescriptor soc_desc =
@@ -416,12 +426,12 @@ Cluster::Cluster(ClusterOptions options) {  // NOLINT(performance-unnecessary-va
                 options.chip_type,
                 cluster_desc.get(),
                 soc_desc,
-                options.num_host_mem_ch_per_mmio_device,
+                options.num_host_mem_ch_per_mmio_device.value(),
                 options.simulator_directory,
                 std::move(tt_device)));
     }
 
-    construct_cluster(options.num_host_mem_ch_per_mmio_device, options.chip_type);
+    construct_cluster(options.num_host_mem_ch_per_mmio_device.value(), options.chip_type);
 }
 
 void Cluster::configure_active_ethernet_cores_for_mmio_device(

--- a/device/hugepage.cpp
+++ b/device/hugepage.cpp
@@ -24,8 +24,6 @@
 
 namespace tt::umd {
 
-const uint32_t g_MAX_HOST_MEM_CHANNELS = 4;
-
 const std::string hugepage_dir = "/dev/hugepages-1G";
 
 uint32_t get_num_hugepages() {
@@ -101,10 +99,10 @@ uint32_t get_available_num_host_mem_channels(
     }
 
     TT_ASSERT(
-        num_channels_per_device_available <= g_MAX_HOST_MEM_CHANNELS,
+        num_channels_per_device_available <= MAX_HOST_MEM_CHANNELS,
         "NumHostMemChannels: {} exceeds supported maximum: {}, this is unexpected.",
         num_channels_per_device_available,
-        g_MAX_HOST_MEM_CHANNELS);
+        MAX_HOST_MEM_CHANNELS);
 
     return num_channels_per_device_available;
 }

--- a/device/hugepage.hpp
+++ b/device/hugepage.hpp
@@ -15,6 +15,8 @@ namespace tt::umd {
 // It's important that this is 64 bits, so that it doesn't overflow when multiplied to 4.
 const uint64_t HUGEPAGE_REGION_SIZE = 1ULL << 30;  // 1GB
 
+const uint32_t MAX_HOST_MEM_CHANNELS = 4;
+
 // Get number of 1GB host hugepages installed.
 uint32_t get_num_hugepages();
 

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -8,11 +8,14 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <vector>
 
 #include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/chip_helpers/silicon_sysmem_manager.hpp"
+#include "umd/device/cluster.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
 
 using namespace tt::umd;
 
@@ -264,4 +267,18 @@ TEST(ApiSysmemManager, SysmemBufferNocAddress) {
     std::unique_ptr<SysmemBuffer> sysmem_buffer2 = sysmem_manager->allocate_sysmem_buffer(one_mb, true);
     EXPECT_TRUE(sysmem_buffer2->get_noc_addr().has_value());
     EXPECT_GT(sysmem_buffer2->get_noc_addr().value(), cluster->get_pcie_base_addr_from_device(mmio_chip));
+}
+
+TEST(ApiSysmemManager, AutoNumChannels) {
+    // Automatically set number of host memory channels.
+    std::unique_ptr<Cluster> cluster =
+        std::make_unique<Cluster>(ClusterOptions{.num_host_mem_ch_per_mmio_device = std::nullopt});
+    bool has_n300 = false;  // Only supported HW with two chips per PCIe channel.
+    for (auto device_id : cluster->get_target_mmio_device_ids()) {
+        has_n300 |= (cluster->get_tt_device(device_id)->get_board_type() == tt::N300);
+    }
+    const uint32_t expected_channels = has_n300 ? 2 : 1;
+    for (auto device_id : cluster->get_target_mmio_device_ids()) {
+        EXPECT_EQ(cluster->get_num_host_channels(device_id), expected_channels);
+    }
 }


### PR DESCRIPTION
### Issue
/

### Description
Automatically set number of host mem channels in Cluster constructor. Initial work for removing passing already created ClusterDescriptors to Cluster for SILICON chip type.

### List of the changes
- Renamed `g_MAX_HOST_MEM_CHANNELS` to `MAX_HOST_MEM_CHANNELS`.
- Made `ClusterOptions::num_host_mem_ch_per_mmio_device` an optional.
- Automatically determine num_host_mem_ch_per_mmio_device by max amount of chips connected through one PCIe interface in the ClusterDescriptor.

### Testing
CI

### API Changes
This PR has API changes.
