### PR TITLE
Adding SMN support

### DIFF
--- a/device/api/umd/device/simulation/rtl_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/rtl_sim_communicator.hpp
@@ -15,7 +15,6 @@
 #include <thread>
 
 #include "umd/device/simulation/simulation_host.hpp"
-#include "umd/device/types/arch.hpp"
 
 namespace tt::umd {
 
@@ -33,7 +32,7 @@ public:
      *
      * @param simulator_directory Path to the simulator binary/directory
      */
-    RtlSimCommunicator(const std::filesystem::path &simulator_directory, tt::ARCH arch);
+    explicit RtlSimCommunicator(const std::filesystem::path &simulator_directory);
 
     /**
      * Destructor that properly cleans up simulation host.
@@ -73,6 +72,28 @@ public:
      * @param size Number of bytes to write
      */
     void tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size);
+
+    /**
+     * Read data from a tile core via SMN.
+     *
+     * @param x Core X coordinate
+     * @param y Core Y coordinate
+     * @param addr Address to read from
+     * @param data Buffer to store read data
+     * @param size Number of bytes to read
+     */
+    void smn_tile_read_bytes(uint32_t x, uint32_t y, uint64_t addr, void *data, uint32_t size);
+
+    /**
+     * Write data to a tile core via SMN.
+     *
+     * @param x Core X coordinate
+     * @param y Core Y coordinate
+     * @param addr Address to write to
+     * @param data Data to write
+     * @param size Number of bytes to write
+     */
+    void smn_tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size);
 
     /**
      * Assert reset for all Tensix cores.
@@ -202,9 +223,6 @@ private:
 
     // Simulator directory path.
     std::filesystem::path simulator_directory_;
-
-    // Architecture of the device.
-    tt::ARCH arch_;
 
     // Simulation host for communication.
     SimulationHost host_;

--- a/device/api/umd/device/simulation/rtl_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/rtl_sim_communicator.hpp
@@ -15,6 +15,7 @@
 #include <thread>
 
 #include "umd/device/simulation/simulation_host.hpp"
+#include "umd/device/types/arch.hpp"
 
 namespace tt::umd {
 
@@ -32,7 +33,7 @@ public:
      *
      * @param simulator_directory Path to the simulator binary/directory
      */
-    explicit RtlSimCommunicator(const std::filesystem::path &simulator_directory);
+    RtlSimCommunicator(const std::filesystem::path &simulator_directory, tt::ARCH arch);
 
     /**
      * Destructor that properly cleans up simulation host.
@@ -72,28 +73,6 @@ public:
      * @param size Number of bytes to write
      */
     void tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size);
-
-    /**
-     * Read data from a tile core via SMN.
-     *
-     * @param x Core X coordinate
-     * @param y Core Y coordinate
-     * @param addr Address to read from
-     * @param data Buffer to store read data
-     * @param size Number of bytes to read
-     */
-    void smn_tile_read_bytes(uint32_t x, uint32_t y, uint64_t addr, void *data, uint32_t size);
-
-    /**
-     * Write data to a tile core via SMN.
-     *
-     * @param x Core X coordinate
-     * @param y Core Y coordinate
-     * @param addr Address to write to
-     * @param data Data to write
-     * @param size Number of bytes to write
-     */
-    void smn_tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size);
 
     /**
      * Assert reset for all Tensix cores.
@@ -223,6 +202,9 @@ private:
 
     // Simulator directory path.
     std::filesystem::path simulator_directory_;
+
+    // Architecture of the device.
+    tt::ARCH arch_;
 
     // Simulation host for communication.
     SimulationHost host_;

--- a/device/api/umd/device/simulation/rtl_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/rtl_sim_communicator.hpp
@@ -74,6 +74,28 @@ public:
     void tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size);
 
     /**
+     * Read data from a tile core via SMN.
+     *
+     * @param x Core X coordinate
+     * @param y Core Y coordinate
+     * @param addr Address to read from
+     * @param data Buffer to store read data
+     * @param size Number of bytes to read
+     */
+    void smn_tile_read_bytes(uint32_t x, uint32_t y, uint64_t addr, void *data, uint32_t size);
+
+    /**
+     * Write data to a tile core via SMN.
+     *
+     * @param x Core X coordinate
+     * @param y Core Y coordinate
+     * @param addr Address to write to
+     * @param data Data to write
+     * @param size Number of bytes to write
+     */
+    void smn_tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size);
+
+    /**
      * Assert reset for all Tensix cores.
      *
      * @param x Core X coordinate

--- a/device/simulation/rtl_sim_communicator.cpp
+++ b/device/simulation/rtl_sim_communicator.cpp
@@ -21,6 +21,7 @@
 #include "simulation_device_generated.h"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/noc_access.hpp"
 
 namespace tt::umd {
 
@@ -55,8 +56,8 @@ inline void send_command_to_simulation_host(SimulationHost &host, const flatbuff
 
 }  // namespace
 
-RtlSimCommunicator::RtlSimCommunicator(const std::filesystem::path &simulator_directory) :
-    simulator_directory_(simulator_directory) {
+RtlSimCommunicator::RtlSimCommunicator(const std::filesystem::path &simulator_directory, tt::ARCH arch) :
+    simulator_directory_(simulator_directory), arch_(arch) {
     if (!std::filesystem::exists(simulator_directory_)) {
         UMD_THROW(
             error::RuntimeError, fmt::format("Simulator directory not found at: {}", simulator_directory_.string()));
@@ -155,12 +156,22 @@ void RtlSimCommunicator::shutdown() {
 }
 
 void RtlSimCommunicator::tile_read_bytes(uint32_t x, uint32_t y, uint64_t addr, void *data, uint32_t size) {
+    NocId noc_id = get_selected_noc_id();
+
+    if (noc_id == NocId::SYSTEM_NOC && arch_ != tt::ARCH::QUASAR) {
+        UMD_THROW(error::RuntimeError, "System NOC is only supported on Grendel (Quasar) architecture.");
+    }
+    if (noc_id == NocId::NOC1 && arch_ == tt::ARCH::QUASAR) {
+        UMD_THROW(error::RuntimeError, "NOC1 is not supported on Grendel (Quasar) architecture.");
+    }
+
     {
         std::lock_guard<std::mutex> lock(device_lock_);
         tt_xy_pair core = {x, y};
 
         // Send read request.
-        send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_READ, {0}, core, addr, size));
+        DEVICE_COMMAND command = (noc_id == NocId::SYSTEM_NOC) ? DEVICE_COMMAND_SMN_READ : DEVICE_COMMAND_READ;
+        send_command_to_simulation_host(host_, create_flatbuffer(command, {0}, core, addr, size));
     }
 
     // Get read response from the command queue (populated by notification thread).
@@ -184,6 +195,15 @@ void RtlSimCommunicator::tile_read_bytes(uint32_t x, uint32_t y, uint64_t addr, 
 }
 
 void RtlSimCommunicator::tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size) {
+    NocId noc_id = get_selected_noc_id();
+
+    if (noc_id == NocId::SYSTEM_NOC && arch_ != tt::ARCH::QUASAR) {
+        UMD_THROW(error::RuntimeError, "System NOC is only supported on Grendel (Quasar) architecture.");
+    }
+    if (noc_id == NocId::NOC1 && arch_ == tt::ARCH::QUASAR) {
+        UMD_THROW(error::RuntimeError, "NOC1 is not supported on Grendel (Quasar) architecture.");
+    }
+
     std::lock_guard<std::mutex> lock(device_lock_);
     log_debug(tt::LogEmulationDriver, "Device writing {} bytes to address {} in core ({}, {})", size, addr, x, y);
 
@@ -192,38 +212,11 @@ void RtlSimCommunicator::tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr,
     const auto *data_ptr = static_cast<const uint32_t *>(data);
     std::vector<uint32_t> data_vec(data_ptr, data_ptr + num_elements);
 
-    send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_WRITE, data_vec, core, addr));
+    // Send write request.
+    DEVICE_COMMAND command = (noc_id == NocId::SYSTEM_NOC) ? DEVICE_COMMAND_SMN_WRITE : DEVICE_COMMAND_WRITE;
+    send_command_to_simulation_host(host_, create_flatbuffer(command, data_vec, core, addr));
 }
 
-void RtlSimCommunicator::smn_tile_read_bytes(uint32_t x, uint32_t y, uint64_t addr, void *data, uint32_t size) {
-    std::lock_guard<std::mutex> lock(device_lock_);
-    tt_xy_pair core = {x, y};
-    void *rd_resp;
-
-    // Send SMN read request.
-    send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_SMN_READ, {0}, core, addr, size));
-
-    // Get read response.
-    size_t rd_rsp_sz = host_.recv_from_device(&rd_resp);
-    auto rd_resp_buf = GetDeviceRequestResponse(rd_resp);
-
-    log_debug(tt::LogEmulationDriver, "Device SMN reading {} bytes from address {} in core ({}, {})", size, addr, x, y);
-
-    std::memcpy(data, rd_resp_buf->data()->data(), rd_resp_buf->data()->size() * sizeof(uint32_t));
-    nng_free(rd_resp, rd_rsp_sz);
-}
-
-void RtlSimCommunicator::smn_tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size) {
-    std::lock_guard<std::mutex> lock(device_lock_);
-    log_debug(tt::LogEmulationDriver, "Device SMN writing {} bytes to address {} in core ({}, {})", size, addr, x, y);
-
-    tt_xy_pair core = {x, y};
-    const uint32_t num_elements = size / sizeof(uint32_t);
-    const auto *data_ptr = static_cast<const uint32_t *>(data);
-    std::vector<uint32_t> data_vec(data_ptr, data_ptr + num_elements);
-
-    send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_SMN_WRITE, data_vec, core, addr));
-}
 
 void RtlSimCommunicator::all_tensix_reset_assert(uint32_t x, uint32_t y) {
     std::lock_guard<std::mutex> lock(device_lock_);

--- a/device/simulation/rtl_sim_communicator.cpp
+++ b/device/simulation/rtl_sim_communicator.cpp
@@ -196,26 +196,42 @@ void RtlSimCommunicator::tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr,
 }
 
 void RtlSimCommunicator::smn_tile_read_bytes(uint32_t x, uint32_t y, uint64_t addr, void *data, uint32_t size) {
-    std::lock_guard<std::mutex> lock(device_lock_);
-    tt_xy_pair core = {x, y};
-    void *rd_resp;
+    {
+        std::lock_guard<std::mutex> lock(device_lock_);
+        tt_xy_pair core = {x, y};
 
-    // Send SMN read request.
-    send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_SMN_READ, {0}, core, addr, size));
+        // Send SMN read request.
+        send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_SMN_READ, {0}, core, addr, size));
+    }
 
-    // Get read response.
-    size_t rd_rsp_sz = host_.recv_from_device(&rd_resp);
-    auto rd_resp_buf = GetDeviceRequestResponse(rd_resp);
+    // Get read response from the command queue (populated by notification thread).
+    auto msg = wait_for_command_response();
+    if (msg.data == nullptr || msg.size == 0) {
+        UMD_THROW(
+            error::RuntimeError, "Failed to receive response from device - notification thread may have stopped.");
+    }
+
+    auto rd_resp_buf = GetDeviceRequestResponse(msg.data);
 
     log_debug(tt::LogEmulationDriver, "Device SMN reading {} bytes from address {} in core ({}, {})", size, addr, x, y);
 
-    std::memcpy(data, rd_resp_buf->data()->data(), rd_resp_buf->data()->size() * sizeof(uint32_t));
-    nng_free(rd_resp, rd_rsp_sz);
+    uint32_t response_bytes = rd_resp_buf->data()->size() * sizeof(uint32_t);
+    UMD_ASSERT(
+        response_bytes >= size,
+        error::RuntimeError,
+        fmt::format("smn_tile_read_bytes response size {} is smaller than requested size {}.", response_bytes, size));
+    std::memcpy(data, rd_resp_buf->data()->data(), size);
+    nng_free(msg.data, msg.size);
 }
 
 void RtlSimCommunicator::smn_tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size) {
     std::lock_guard<std::mutex> lock(device_lock_);
     log_debug(tt::LogEmulationDriver, "Device SMN writing {} bytes to address {} in core ({}, {})", size, addr, x, y);
+
+    UMD_ASSERT(
+        size % sizeof(uint32_t) == 0,
+        error::RuntimeError,
+        fmt::format("smn_tile_write_bytes size {} must be a multiple of {} bytes.", size, sizeof(uint32_t)));
 
     tt_xy_pair core = {x, y};
     const uint32_t num_elements = size / sizeof(uint32_t);

--- a/device/simulation/rtl_sim_communicator.cpp
+++ b/device/simulation/rtl_sim_communicator.cpp
@@ -170,6 +170,7 @@ void RtlSimCommunicator::tile_read_bytes(uint32_t x, uint32_t y, uint64_t addr, 
         tt_xy_pair core = {x, y};
 
         // Send read request.
+        // System NOC only available with aether-main-v2026.W10.1_smn_support tag and 2x3_SMU config
         DEVICE_COMMAND command = (noc_id == NocId::SYSTEM_NOC) ? DEVICE_COMMAND_SMN_READ : DEVICE_COMMAND_READ;
         send_command_to_simulation_host(host_, create_flatbuffer(command, {0}, core, addr, size));
     }
@@ -213,6 +214,7 @@ void RtlSimCommunicator::tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr,
     std::vector<uint32_t> data_vec(data_ptr, data_ptr + num_elements);
 
     // Send write request.
+    // System NOC only available with aether-main-v2026.W10.1_smn_support tag and 2x3_SMU config
     DEVICE_COMMAND command = (noc_id == NocId::SYSTEM_NOC) ? DEVICE_COMMAND_SMN_WRITE : DEVICE_COMMAND_WRITE;
     send_command_to_simulation_host(host_, create_flatbuffer(command, data_vec, core, addr));
 }

--- a/device/simulation/rtl_sim_communicator.cpp
+++ b/device/simulation/rtl_sim_communicator.cpp
@@ -18,10 +18,10 @@
 #include <utility>
 #include <vector>
 
+#include "noc_access.hpp"
 #include "simulation_device_generated.h"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error.hpp"
-#include "umd/device/noc_access.hpp"
 
 namespace tt::umd {
 
@@ -170,7 +170,7 @@ void RtlSimCommunicator::tile_read_bytes(uint32_t x, uint32_t y, uint64_t addr, 
         tt_xy_pair core = {x, y};
 
         // Send read request.
-        // System NOC only available with aether-main-v2026.W10.1_smn_support tag and 2x3_SMU config
+        // System NOC only available with aether-main-v2026.W10.1_smn_support tag and 2x3_SMU config.
         DEVICE_COMMAND command = (noc_id == NocId::SYSTEM_NOC) ? DEVICE_COMMAND_SMN_READ : DEVICE_COMMAND_READ;
         send_command_to_simulation_host(host_, create_flatbuffer(command, {0}, core, addr, size));
     }
@@ -214,11 +214,10 @@ void RtlSimCommunicator::tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr,
     std::vector<uint32_t> data_vec(data_ptr, data_ptr + num_elements);
 
     // Send write request.
-    // System NOC only available with aether-main-v2026.W10.1_smn_support tag and 2x3_SMU config
+    // System NOC only available with aether-main-v2026.W10.1_smn_support tag and 2x3_SMU config.
     DEVICE_COMMAND command = (noc_id == NocId::SYSTEM_NOC) ? DEVICE_COMMAND_SMN_WRITE : DEVICE_COMMAND_WRITE;
     send_command_to_simulation_host(host_, create_flatbuffer(command, data_vec, core, addr));
 }
-
 
 void RtlSimCommunicator::all_tensix_reset_assert(uint32_t x, uint32_t y) {
     std::lock_guard<std::mutex> lock(device_lock_);

--- a/device/simulation/rtl_sim_communicator.cpp
+++ b/device/simulation/rtl_sim_communicator.cpp
@@ -195,6 +195,36 @@ void RtlSimCommunicator::tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr,
     send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_WRITE, data_vec, core, addr));
 }
 
+void RtlSimCommunicator::smn_tile_read_bytes(uint32_t x, uint32_t y, uint64_t addr, void *data, uint32_t size) {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    tt_xy_pair core = {x, y};
+    void *rd_resp;
+
+    // Send SMN read request.
+    send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_SMN_READ, {0}, core, addr, size));
+
+    // Get read response.
+    size_t rd_rsp_sz = host_.recv_from_device(&rd_resp);
+    auto rd_resp_buf = GetDeviceRequestResponse(rd_resp);
+
+    log_debug(tt::LogEmulationDriver, "Device SMN reading {} bytes from address {} in core ({}, {})", size, addr, x, y);
+
+    std::memcpy(data, rd_resp_buf->data()->data(), rd_resp_buf->data()->size() * sizeof(uint32_t));
+    nng_free(rd_resp, rd_rsp_sz);
+}
+
+void RtlSimCommunicator::smn_tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size) {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    log_debug(tt::LogEmulationDriver, "Device SMN writing {} bytes to address {} in core ({}, {})", size, addr, x, y);
+
+    tt_xy_pair core = {x, y};
+    const uint32_t num_elements = size / sizeof(uint32_t);
+    const auto *data_ptr = static_cast<const uint32_t *>(data);
+    std::vector<uint32_t> data_vec(data_ptr, data_ptr + num_elements);
+
+    send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_SMN_WRITE, data_vec, core, addr));
+}
+
 void RtlSimCommunicator::all_tensix_reset_assert(uint32_t x, uint32_t y) {
     std::lock_guard<std::mutex> lock(device_lock_);
     log_debug(tt::LogEmulationDriver, "Sending all_tensix_reset_assert signal to core ({}, {})", x, y);

--- a/device/simulation/rtl_sim_communicator.cpp
+++ b/device/simulation/rtl_sim_communicator.cpp
@@ -18,7 +18,6 @@
 #include <utility>
 #include <vector>
 
-#include "noc_access.hpp"
 #include "simulation_device_generated.h"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error.hpp"
@@ -56,8 +55,8 @@ inline void send_command_to_simulation_host(SimulationHost &host, const flatbuff
 
 }  // namespace
 
-RtlSimCommunicator::RtlSimCommunicator(const std::filesystem::path &simulator_directory, tt::ARCH arch) :
-    simulator_directory_(simulator_directory), arch_(arch) {
+RtlSimCommunicator::RtlSimCommunicator(const std::filesystem::path &simulator_directory) :
+    simulator_directory_(simulator_directory) {
     if (!std::filesystem::exists(simulator_directory_)) {
         UMD_THROW(
             error::RuntimeError, fmt::format("Simulator directory not found at: {}", simulator_directory_.string()));
@@ -156,23 +155,12 @@ void RtlSimCommunicator::shutdown() {
 }
 
 void RtlSimCommunicator::tile_read_bytes(uint32_t x, uint32_t y, uint64_t addr, void *data, uint32_t size) {
-    NocId noc_id = get_selected_noc_id();
-
-    if (noc_id == NocId::SYSTEM_NOC && arch_ != tt::ARCH::QUASAR) {
-        UMD_THROW(error::RuntimeError, "System NOC is only supported on Grendel (Quasar) architecture.");
-    }
-    if (noc_id == NocId::NOC1 && arch_ == tt::ARCH::QUASAR) {
-        UMD_THROW(error::RuntimeError, "NOC1 is not supported on Grendel (Quasar) architecture.");
-    }
-
     {
         std::lock_guard<std::mutex> lock(device_lock_);
         tt_xy_pair core = {x, y};
 
         // Send read request.
-        // System NOC only available with aether-main-v2026.W10.1_smn_support tag and 2x3_SMU config.
-        DEVICE_COMMAND command = (noc_id == NocId::SYSTEM_NOC) ? DEVICE_COMMAND_SMN_READ : DEVICE_COMMAND_READ;
-        send_command_to_simulation_host(host_, create_flatbuffer(command, {0}, core, addr, size));
+        send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_READ, {0}, core, addr, size));
     }
 
     // Get read response from the command queue (populated by notification thread).
@@ -196,15 +184,6 @@ void RtlSimCommunicator::tile_read_bytes(uint32_t x, uint32_t y, uint64_t addr, 
 }
 
 void RtlSimCommunicator::tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size) {
-    NocId noc_id = get_selected_noc_id();
-
-    if (noc_id == NocId::SYSTEM_NOC && arch_ != tt::ARCH::QUASAR) {
-        UMD_THROW(error::RuntimeError, "System NOC is only supported on Grendel (Quasar) architecture.");
-    }
-    if (noc_id == NocId::NOC1 && arch_ == tt::ARCH::QUASAR) {
-        UMD_THROW(error::RuntimeError, "NOC1 is not supported on Grendel (Quasar) architecture.");
-    }
-
     std::lock_guard<std::mutex> lock(device_lock_);
     log_debug(tt::LogEmulationDriver, "Device writing {} bytes to address {} in core ({}, {})", size, addr, x, y);
 
@@ -213,10 +192,37 @@ void RtlSimCommunicator::tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr,
     const auto *data_ptr = static_cast<const uint32_t *>(data);
     std::vector<uint32_t> data_vec(data_ptr, data_ptr + num_elements);
 
-    // Send write request.
-    // System NOC only available with aether-main-v2026.W10.1_smn_support tag and 2x3_SMU config.
-    DEVICE_COMMAND command = (noc_id == NocId::SYSTEM_NOC) ? DEVICE_COMMAND_SMN_WRITE : DEVICE_COMMAND_WRITE;
-    send_command_to_simulation_host(host_, create_flatbuffer(command, data_vec, core, addr));
+    send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_WRITE, data_vec, core, addr));
+}
+
+void RtlSimCommunicator::smn_tile_read_bytes(uint32_t x, uint32_t y, uint64_t addr, void *data, uint32_t size) {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    tt_xy_pair core = {x, y};
+    void *rd_resp;
+
+    // Send SMN read request.
+    send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_SMN_READ, {0}, core, addr, size));
+
+    // Get read response.
+    size_t rd_rsp_sz = host_.recv_from_device(&rd_resp);
+    auto rd_resp_buf = GetDeviceRequestResponse(rd_resp);
+
+    log_debug(tt::LogEmulationDriver, "Device SMN reading {} bytes from address {} in core ({}, {})", size, addr, x, y);
+
+    std::memcpy(data, rd_resp_buf->data()->data(), rd_resp_buf->data()->size() * sizeof(uint32_t));
+    nng_free(rd_resp, rd_rsp_sz);
+}
+
+void RtlSimCommunicator::smn_tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size) {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    log_debug(tt::LogEmulationDriver, "Device SMN writing {} bytes to address {} in core ({}, {})", size, addr, x, y);
+
+    tt_xy_pair core = {x, y};
+    const uint32_t num_elements = size / sizeof(uint32_t);
+    const auto *data_ptr = static_cast<const uint32_t *>(data);
+    std::vector<uint32_t> data_vec(data_ptr, data_ptr + num_elements);
+
+    send_command_to_simulation_host(host_, create_flatbuffer(DEVICE_COMMAND_SMN_WRITE, data_vec, core, addr));
 }
 
 void RtlSimCommunicator::all_tensix_reset_assert(uint32_t x, uint32_t y) {

--- a/device/simulation/simulation_device.fbs
+++ b/device/simulation/simulation_device.fbs
@@ -17,6 +17,8 @@ enum DEVICE_COMMAND : byte {
     // to match these values before this can work end-to-end.
     AXI_RAM_WRITE_NOTIFICATION = 10,
     AXI_RAM_READ_NOTIFICATION = 11,
+    SMN_WRITE = 12,
+    SMN_READ = 13,
     ALL_NEO_DMS_UNCORE_RESET_DEASSERT = 14,
     ALL_NEO_DMS_UNCORE_RESET_ASSERT = 15,
     NEO_DM_UNCORE_RESET_ASSERT = 16,

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -44,6 +44,17 @@ static constexpr std::array<RiscType, 8> RISC_TYPES_DMS = {
 
 static constexpr ChipId DEFAULT_CHIP_ID = 0;
 
+namespace {
+void validate_noc_for_arch(NocId noc_id, tt::ARCH arch) {
+    if (noc_id == NocId::SYSTEM_NOC && arch != tt::ARCH::QUASAR) {
+        UMD_THROW(error::RuntimeError, "System NOC is only supported on Grendel (Quasar) architecture.");
+    }
+    if (noc_id == NocId::NOC1 && arch == tt::ARCH::QUASAR) {
+        UMD_THROW(error::RuntimeError, "NOC1 is not supported on Grendel (Quasar) architecture.");
+    }
+}
+}  // namespace
+
 std::unique_ptr<RtlSimulationTTDevice> RtlSimulationTTDevice::create(
     const std::filesystem::path& simulator_directory, int num_host_mem_channels) {
     auto soc_desc_path = SimulationChip::get_soc_descriptor_path_from_simulator_path(simulator_directory);
@@ -113,12 +124,7 @@ void RtlSimulationTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core
     log_debug(tt::LogEmulationDriver, "Device writing {} bytes to l1_dest {} in core {}", size, addr, core.str());
 
     NocId noc_id = get_selected_noc_id();
-    if (noc_id == NocId::SYSTEM_NOC && get_soc_descriptor().arch != tt::ARCH::QUASAR) {
-        UMD_THROW(error::RuntimeError, "System NOC is only supported on Grendel (Quasar) architecture.");
-    }
-    if (noc_id == NocId::NOC1 && get_soc_descriptor().arch == tt::ARCH::QUASAR) {
-        UMD_THROW(error::RuntimeError, "NOC1 is not supported on Grendel (Quasar) architecture.");
-    }
+    validate_noc_for_arch(noc_id, get_soc_descriptor().arch);
 
     if (noc_id == NocId::SYSTEM_NOC) {
         communicator_->smn_tile_write_bytes(core.x, core.y, addr, mem_ptr, size);
@@ -136,12 +142,7 @@ void RtlSimulationTTDevice::read_from_device(void* mem_ptr, tt_xy_pair core, uin
     std::lock_guard<std::recursive_mutex> lock(device_lock);
 
     NocId noc_id = get_selected_noc_id();
-    if (noc_id == NocId::SYSTEM_NOC && get_soc_descriptor().arch != tt::ARCH::QUASAR) {
-        UMD_THROW(error::RuntimeError, "System NOC is only supported on Grendel (Quasar) architecture.");
-    }
-    if (noc_id == NocId::NOC1 && get_soc_descriptor().arch == tt::ARCH::QUASAR) {
-        UMD_THROW(error::RuntimeError, "NOC1 is not supported on Grendel (Quasar) architecture.");
-    }
+    validate_noc_for_arch(noc_id, get_soc_descriptor().arch);
 
     if (noc_id == NocId::SYSTEM_NOC) {
         communicator_->smn_tile_read_bytes(core.x, core.y, addr, mem_ptr, size);

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -56,7 +56,7 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
     const SocDescriptor& soc_descriptor,
     ChipId chip_id,
     int num_host_mem_channels) :
-    communicator_(std::make_unique<RtlSimCommunicator>(simulator_directory)),
+    communicator_(std::make_unique<RtlSimCommunicator>(simulator_directory, soc_descriptor.arch)),
     simulator_directory_(simulator_directory),
     sysmem_manager_(std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)) {
     log_info(tt::LogEmulationDriver, "Instantiating RTL simulation TTDevice");

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -11,6 +11,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "noc_access.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
@@ -56,7 +57,7 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
     const SocDescriptor& soc_descriptor,
     ChipId chip_id,
     int num_host_mem_channels) :
-    communicator_(std::make_unique<RtlSimCommunicator>(simulator_directory, soc_descriptor.arch)),
+    communicator_(std::make_unique<RtlSimCommunicator>(simulator_directory)),
     simulator_directory_(simulator_directory),
     sysmem_manager_(std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)) {
     log_info(tt::LogEmulationDriver, "Instantiating RTL simulation TTDevice");
@@ -110,6 +111,20 @@ RtlSimulationTTDevice::~RtlSimulationTTDevice() { communicator_->shutdown(); }
 void RtlSimulationTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     std::lock_guard<std::recursive_mutex> lock(device_lock);
     log_debug(tt::LogEmulationDriver, "Device writing {} bytes to l1_dest {} in core {}", size, addr, core.str());
+
+    NocId noc_id = get_selected_noc_id();
+    if (noc_id == NocId::SYSTEM_NOC && get_soc_descriptor().arch != tt::ARCH::QUASAR) {
+        UMD_THROW(error::RuntimeError, "System NOC is only supported on Grendel (Quasar) architecture.");
+    }
+    if (noc_id == NocId::NOC1 && get_soc_descriptor().arch == tt::ARCH::QUASAR) {
+        UMD_THROW(error::RuntimeError, "NOC1 is not supported on Grendel (Quasar) architecture.");
+    }
+
+    if (noc_id == NocId::SYSTEM_NOC) {
+        communicator_->smn_tile_write_bytes(core.x, core.y, addr, mem_ptr, size);
+        return;
+    }
+
     if (cached_tlb_window_) {
         cached_tlb_window_->write_block_reconfigure(mem_ptr, core, addr, size);
     } else {
@@ -119,6 +134,20 @@ void RtlSimulationTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core
 
 void RtlSimulationTTDevice::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     std::lock_guard<std::recursive_mutex> lock(device_lock);
+
+    NocId noc_id = get_selected_noc_id();
+    if (noc_id == NocId::SYSTEM_NOC && get_soc_descriptor().arch != tt::ARCH::QUASAR) {
+        UMD_THROW(error::RuntimeError, "System NOC is only supported on Grendel (Quasar) architecture.");
+    }
+    if (noc_id == NocId::NOC1 && get_soc_descriptor().arch == tt::ARCH::QUASAR) {
+        UMD_THROW(error::RuntimeError, "NOC1 is not supported on Grendel (Quasar) architecture.");
+    }
+
+    if (noc_id == NocId::SYSTEM_NOC) {
+        communicator_->smn_tile_read_bytes(core.x, core.y, addr, mem_ptr, size);
+        return;
+    }
+
     if (cached_tlb_window_) {
         cached_tlb_window_->read_block_reconfigure(mem_ptr, core, addr, size);
     } else {

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -16,6 +16,7 @@
 #include <tt-logger/tt-logger.hpp>
 
 #include "umd/device/arc/spi_tt_device.hpp"
+#include "umd/device/noc_access.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/pcie/pci_device.hpp"
@@ -563,7 +564,8 @@ void bind_tt_device(nb::module_ &m) {
             [](RtlSimulationTTDevice &self, uint32_t core_x, uint32_t core_y, uint64_t addr, uint32_t size)
                 -> nb::bytes {
                 std::vector<uint8_t> buffer(size);
-                self.get_communicator()->smn_tile_read_bytes(core_x, core_y, addr, buffer.data(), size);
+                NocIdSwitcher switcher(NocId::SYSTEM_NOC);
+                self.get_communicator()->tile_read_bytes(core_x, core_y, addr, buffer.data(), size);
                 return nb::bytes(reinterpret_cast<const char *>(buffer.data()), buffer.size());
             },
             nb::arg("core_x"),
@@ -574,7 +576,8 @@ void bind_tt_device(nb::module_ &m) {
         .def(
             "smn_write",
             [](RtlSimulationTTDevice &self, uint32_t core_x, uint32_t core_y, uint64_t addr, nb::bytes data) -> void {
-                self.get_communicator()->smn_tile_write_bytes(
+                NocIdSwitcher switcher(NocId::SYSTEM_NOC);
+                self.get_communicator()->tile_write_bytes(
                     core_x, core_y, addr, data.c_str(), static_cast<uint32_t>(data.size()));
             },
             nb::arg("core_x"),

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -557,8 +557,7 @@ void bind_tt_device(nb::module_ &m) {
             "get_soc_descriptor",
             &RtlSimulationTTDevice::get_soc_descriptor,
             nb::rv_policy::reference_internal,
-            "Get the SocDescriptor associated with this RTL simulation device.")
-        ;
+            "Get the SocDescriptor associated with this RTL simulation device.");
 #endif
 
     m.def(

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -16,7 +16,6 @@
 #include <tt-logger/tt-logger.hpp>
 
 #include "umd/device/arc/spi_tt_device.hpp"
-#include "umd/device/noc_access.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/pcie/pci_device.hpp"
@@ -559,32 +558,7 @@ void bind_tt_device(nb::module_ &m) {
             &RtlSimulationTTDevice::get_soc_descriptor,
             nb::rv_policy::reference_internal,
             "Get the SocDescriptor associated with this RTL simulation device.")
-        .def(
-            "smn_read",
-            [](RtlSimulationTTDevice &self, uint32_t core_x, uint32_t core_y, uint64_t addr, uint32_t size)
-                -> nb::bytes {
-                std::vector<uint8_t> buffer(size);
-                NocIdSwitcher switcher(NocId::SYSTEM_NOC);
-                self.get_communicator()->tile_read_bytes(core_x, core_y, addr, buffer.data(), size);
-                return nb::bytes(reinterpret_cast<const char *>(buffer.data()), buffer.size());
-            },
-            nb::arg("core_x"),
-            nb::arg("core_y"),
-            nb::arg("addr"),
-            nb::arg("size"),
-            "Read arbitrary-length data from a core via SMN at the specified address")
-        .def(
-            "smn_write",
-            [](RtlSimulationTTDevice &self, uint32_t core_x, uint32_t core_y, uint64_t addr, nb::bytes data) -> void {
-                NocIdSwitcher switcher(NocId::SYSTEM_NOC);
-                self.get_communicator()->tile_write_bytes(
-                    core_x, core_y, addr, data.c_str(), static_cast<uint32_t>(data.size()));
-            },
-            nb::arg("core_x"),
-            nb::arg("core_y"),
-            nb::arg("addr"),
-            nb::arg("data"),
-            "Write arbitrary-length data to a core via SMN at the specified address");
+        ;
 #endif
 
     m.def(

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -557,7 +557,31 @@ void bind_tt_device(nb::module_ &m) {
             "get_soc_descriptor",
             &RtlSimulationTTDevice::get_soc_descriptor,
             nb::rv_policy::reference_internal,
-            "Get the SocDescriptor associated with this RTL simulation device.");
+            "Get the SocDescriptor associated with this RTL simulation device.")
+        .def(
+            "smn_read",
+            [](RtlSimulationTTDevice &self, uint32_t core_x, uint32_t core_y, uint64_t addr, uint32_t size)
+                -> nb::bytes {
+                std::vector<uint8_t> buffer(size);
+                self.get_communicator()->smn_tile_read_bytes(core_x, core_y, addr, buffer.data(), size);
+                return nb::bytes(reinterpret_cast<const char *>(buffer.data()), buffer.size());
+            },
+            nb::arg("core_x"),
+            nb::arg("core_y"),
+            nb::arg("addr"),
+            nb::arg("size"),
+            "Read arbitrary-length data from a core via SMN at the specified address")
+        .def(
+            "smn_write",
+            [](RtlSimulationTTDevice &self, uint32_t core_x, uint32_t core_y, uint64_t addr, nb::bytes data) -> void {
+                self.get_communicator()->smn_tile_write_bytes(
+                    core_x, core_y, addr, data.c_str(), static_cast<uint32_t>(data.size()));
+            },
+            nb::arg("core_x"),
+            nb::arg("core_y"),
+            nb::arg("addr"),
+            nb::arg("data"),
+            "Write arbitrary-length data to a core via SMN at the specified address");
 #endif
 
     m.def(


### PR DESCRIPTION
### Issue
/

### Description
Added support for SMN reads and writes.
**Disclaimer**: Simulator with SMN is still not official version, added comment explaining that, will remove once this gets into official tag.

### List of the changes
- Extended `DEVICE_COMMAND` enum with `SMN_WRITE=12` and `SMN_READ=13` matching simulator with SMN support
- Added logic to `tile_read_bytes` and `tile_write_bytes` in `RtlSimCommunicator` to know which `DEVICE_COMMAND` to sent based on selected `NocId`.

### Testing
/

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
