### PR TITLE
Remove unused write_regs

### DIFF
--- a/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
@@ -45,7 +45,6 @@ public:
     virtual void noc_multicast_write(
         const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) = 0;
 
-    virtual void write_regs(volatile uint32_t* dest, const uint32_t* src, uint32_t word_len) = 0;
     virtual void bar_write32(uint32_t addr, uint32_t data) = 0;
     virtual uint32_t bar_read32(uint32_t addr) = 0;
 };

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -61,7 +61,6 @@ public:
     void dma_h2d_zero_copy(uint32_t dst, const void* src, size_t size) override;
     void noc_multicast_write(
         const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) override;
-    void write_regs(volatile uint32_t* dest, const uint32_t* src, uint32_t word_len) override;
     void bar_write32(uint32_t addr, uint32_t data) override;
     uint32_t bar_read32(uint32_t addr) override;
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -269,8 +269,6 @@ public:
      */
     virtual void write_to_arc_csm(const void *mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) = 0;
 
-    void write_regs(volatile uint32_t *dest, const uint32_t *src, uint32_t word_len);
-
     /**
      * Configures a PCIe Address Translation Unit (iATU) region.
      *

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -116,12 +116,6 @@ void PcieProtocol::noc_multicast_write(
     }
 }
 
-void PcieProtocol::write_regs(volatile uint32_t* dest, const uint32_t* src, uint32_t word_len) {
-    while (word_len-- != 0) {
-        *dest++ = *src++;
-    }
-}
-
 void PcieProtocol::bar_write32(uint32_t addr, uint32_t data) {
     if (addr < BAR0_OFFSET) {
         UMD_THROW(error::RuntimeError, "Write Invalid BAR address for this device.");

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -295,10 +295,6 @@ std::unique_ptr<TlbWindow> TTDevice::get_io_window(tlb_data config, TlbMapping m
     UMD_THROW(error::RuntimeError, "Failed to allocate TLB window.");
 }
 
-void TTDevice::write_regs(volatile uint32_t *dest, const uint32_t *src, uint32_t word_len) {
-    get_pcie_interface()->write_regs(dest, src, word_len);
-}
-
 void TTDevice::read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     ZoneScopedC(tracy::Color::Orange);
     device_protocol_->read_from_device(mem_ptr, core, addr, size, get_selected_noc_id());


### PR DESCRIPTION
### Issue
No issue

### Description
Remove unused function.
Note that SIliconTlbWindow::write_regs is still there

### List of the changes
- Removed TTDevice::write_regs because it is unnecessary and unused.

### Testing
Code builds

### API Changes
This PR has API changes removed TTDevice::regs
