### PR TITLE
Support SysmemBuffer mapping and NOC routing for TTSim

### DIFF
--- a/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
@@ -51,16 +51,16 @@ private:
         uint8_t* host_va;
     };
 
-    // Mapped/allocated SysmemBuffers live above the maximum 4-channel layout so they can never
-    // collide with channel regions, regardless of how many channels were requested.
-    static constexpr uint64_t kMappedBufferRegionBase = 4ULL << 30;
-
     uint8_t* system_memory_ = nullptr;
     size_t system_memory_size_ = 0;
 
     std::mutex regions_mutex_;
     std::vector<PaddrRegion> paddr_regions_;
-    uint64_t next_alloc_paddr_ = kMappedBufferRegionBase;
+    // Mapped/allocated SysmemBuffers live immediately above the channel region. The TTSim
+    // simulator's translate_pci_dma_addr only handles paddrs in the lower NOC range, so we
+    // can't simply park them above the maximum 4-channel layout; we start at the first paddr
+    // not occupied by an enabled channel. With 0 channels (the typical TTSim case) this is 0.
+    uint64_t next_alloc_paddr_ = 0;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
@@ -4,6 +4,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 
 namespace tt::umd {
@@ -23,12 +27,40 @@ public:
     std::unique_ptr<SysmemBuffer> map_sysmem_buffer(
         void* buffer, size_t sysmem_buffer_size, const bool map_to_noc = false) override;
 
+    /**
+     * Routes a paddr (PCIe-core-local address presented by the TTSim simulator on
+     * device-initiated NOC<->PCIe transactions) to the host VA that backs that range.
+     *
+     * Looks across both the channel-region mappings populated in init_sysmem and any
+     * mapped/allocated SysmemBuffers that have been registered via this manager.
+     *
+     * @param paddr Start of the requested transfer in PCIe-core-local address space.
+     * @param size  Size of the transfer in bytes. The full range [paddr, paddr+size) must lie
+     *              within a single registered region; otherwise nullptr is returned.
+     * @return Host VA corresponding to paddr, or nullptr if no region covers the range.
+     */
+    uint8_t* find_paddr_host_va(uint64_t paddr, uint32_t size);
+
 protected:
     bool init_sysmem(uint32_t num_host_mem_channels) override;
 
 private:
+    struct PaddrRegion {
+        uint64_t paddr_start;
+        uint64_t paddr_end;  // exclusive
+        uint8_t* host_va;
+    };
+
+    // Mapped/allocated SysmemBuffers live above the maximum 4-channel layout so they can never
+    // collide with channel regions, regardless of how many channels were requested.
+    static constexpr uint64_t kMappedBufferRegionBase = 4ULL << 30;
+
     uint8_t* system_memory_ = nullptr;
     size_t system_memory_size_ = 0;
+
+    std::mutex regions_mutex_;
+    std::vector<PaddrRegion> paddr_regions_;
+    uint64_t next_alloc_paddr_ = kMappedBufferRegionBase;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
@@ -6,6 +6,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <optional>
 
 #include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/types/xy_pair.hpp"
@@ -23,51 +25,55 @@ namespace tt::umd {
  * Traditionally, we have referred to the sysmem buffer as something that is
  * visible to device, has its own NOC address. Without changes to KMD, this is still not fully supported for IOMMU
  * buffers.
+ *
+ * The class is platform-agnostic: the owning SysmemManager is responsible for performing any
+ * platform-specific mapping (e.g. KMD pin-and-map on silicon, paddr-region registration on the
+ * TTSim simulator) and passing the resulting addresses into the constructor. Cleanup work that
+ * mirrors the mapping is supplied as the on_destroy callback.
  */
 class SysmemBuffer {
 public:
     /**
-     * Constructor for SysmemBuffer. Start of the buffer must be aligned
-     * to page size. In case of unaligned buffer start address, the buffer will be aligned to the page size and the
-     * buffer size will be adjusted accordingly. However, the adjusted buffer size won't be visible to the user. It will
-     * see a buffer of the original size. Same as for buffer size, user won't be able to access the memory before the
-     * start of the buffer, aligning is transparent to the user.
-     * Pages separated by | AB - Aligned buffer,
-     * UB - Unaligned buffer, UE - Unaligned end, AE - Aligned end
-     *
-     * |     Page 0     |     Page 1     |     Page 2     |     Page 3     |
-     * +----------------+----------------+----------------+----------------+
-     * ^                ^       ^                    ^    ^
-     * Page Start       AB      UB                   UE   AE
-     *                          |<--- buffer_size -->|
-     *                  |<----- mapped_buffer_size ----->|
-     *
-     * @param tlb_manager Pointer to the TLBManager that manages the TLB entries for this buffer.
-     * @param buffer_va Pointer to the virtual address of the buffer in the process address space.
-     * @param buffer_size Size of the buffer requested by the user.
-     * @param map_to_noc If true, the buffer will be mapped to be accessible over NOC from device.
+     * @param tlb_manager TLB manager used by the silicon DMA fast paths (dma_write_to_device /
+     *                    dma_read_from_device). May be nullptr when those paths are not used
+     *                    (e.g. simulation).
+     * @param buffer_va   Host virtual address of the buffer as the user sees it. Returned verbatim
+     *                    by get_buffer_va().
+     * @param buffer_size Size of the user-visible buffer.
+     * @param device_io_addr Device IO (system bus) address corresponding to user offset 0. The
+     *                       owning manager has already accounted for any internal alignment
+     *                       padding; get_device_io_addr(offset) simply returns this + offset.
+     * @param noc_addr    NOC address corresponding to user offset 0, when the buffer was mapped
+     *                    visible on the NOC. std::nullopt otherwise.
+     * @param on_destroy  Optional cleanup callback invoked from the destructor. The owning manager
+     *                    captures whatever state is needed to undo its mapping (KMD unmap on
+     *                    silicon, region deregistration / munmap on simulation).
      */
-    SysmemBuffer(TLBManager* tlb_manager, void* buffer_va, size_t buffer_size, bool map_to_noc = false);
+    SysmemBuffer(
+        TLBManager* tlb_manager,
+        void* buffer_va,
+        size_t buffer_size,
+        uint64_t device_io_addr,
+        std::optional<uint64_t> noc_addr,
+        std::function<void()> on_destroy = {});
     ~SysmemBuffer();
 
     /**
-     * Returns the virtual address of the buffer in the process address space.
-     * Both in case of aligned and unaligned buffers, this will return the original buffer address.
+     * Returns the virtual address of the buffer in the process address space (the same pointer the
+     * user passed in to the manager).
      */
     void* get_buffer_va() const;
 
     /**
      * Returns the size of the buffer passed by the user.
-     *
-     * @return Size of the buffer passed by the user.
      */
     size_t get_buffer_size() const;
 
     /**
-     * Returns device IOVA (IO virtual address) of the buffer on the offset from the start of the buffer.
+     * Returns device IOVA (IO virtual address) of the buffer at the offset from the start of the
+     * buffer.
      *
      * @param offset Offset from the start of the buffer. Must be less than the size of the buffer.
-     * @return Device IOVA of the buffer on the offset from the start of the buffer.
      */
     uint64_t get_device_io_addr(const size_t offset = 0) const;
 
@@ -97,18 +103,8 @@ public:
 
 private:
     /**
-     * Aligns the address and size of the buffer to the page size. If the buffer is not aligned to the page size,
-     * it will be aligned and the size will be adjusted accordingly. The original buffer size will not be changed.
-     * However, behaviour (calculation of offset) of the SysmemBuffer is always going to be based on the original VA and
-     * size.
-     */
-    void align_address_and_size();
-
-    /**
      * Validates that the offset is within the bounds of the buffer.
      * Throws an exception if the offset is out of bounds.
-     *
-     * @param offset Offset to validate.
      */
     void validate(const size_t offset) const;
 
@@ -116,25 +112,20 @@ private:
 
     TLBManager* tlb_manager_;
 
-    // Virtual address in process addr space.
+    // Virtual address of the buffer as the user sees it.
     void* buffer_va_;
 
-    // Size of the memory that is mapped through KMD to be visible to the device.
-    size_t mapped_buffer_size_;
-
-    // Size of the buffer requested by user. If the buffer is not aligned to the page size, size of the memory
-    // mapped through KMD will be larger than this. This is used to return the size of the buffer requested by the user.
-    // Offsets in other SysmemBuffer functions are not allowed to be larger than this size.
+    // Size of the buffer requested by the user.
     size_t buffer_size_;
 
-    // Address that is used on the system bus to access the beginning of the mapped buffer.
+    // Device IO address (system bus) corresponding to user offset 0.
     uint64_t device_io_addr_;
 
-    uint64_t offset_from_aligned_addr_ = 0;
-
-    // Address that is used on the NOC to access the buffer.  NOC target must be
-    // the PCIE core that is connected to the host and this address.
+    // NOC address corresponding to user offset 0, when the buffer is NOC-visible.
     std::optional<uint64_t> noc_addr_;
+
+    // Cleanup callback supplied by the owning manager. Invoked from the destructor.
+    std::function<void()> on_destroy_;
 
     std::unique_ptr<TlbWindow> cached_tlb_window = nullptr;
 };

--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -18,10 +18,12 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <tuple>
+#include <utility>
 
 #include "assert.hpp"
 #include "cpuset_lib.hpp"
@@ -418,7 +420,40 @@ std::unique_ptr<SysmemBuffer> SiliconSysmemManager::allocate_sysmem_buffer(
 std::unique_ptr<SysmemBuffer> SiliconSysmemManager::map_sysmem_buffer(
     void *buffer, size_t sysmem_buffer_size, const bool map_to_noc) {
     log_debug(LogUMD, "Mapping sysmem buffer to NOC: {:#x}", sysmem_buffer_size);
-    return std::make_unique<SysmemBuffer>(tlb_manager_, buffer, sysmem_buffer_size, map_to_noc);
+
+    // KMD's pin/map ioctls require page-aligned VAs and sizes. Round buffer down to the page
+    // boundary, round size up, and remember the offset so we can return user-facing addresses
+    // (device_io_addr/noc_addr at user offset 0) to the SysmemBuffer.
+    static const auto page_size = sysconf(_SC_PAGESIZE);
+    const uint64_t user_va = reinterpret_cast<uint64_t>(buffer);
+    const uint64_t aligned_va_int = user_va & ~(page_size - 1);
+    const uint64_t offset_from_aligned = user_va - aligned_va_int;
+    const size_t mapped_size = (sysmem_buffer_size + offset_from_aligned + page_size - 1) & ~(page_size - 1);
+    void *aligned_va = reinterpret_cast<void *>(aligned_va_int);
+
+    PCIDevice *pci_device = tt_device_->get_pci_device();
+    uint64_t device_io_addr;
+    std::optional<uint64_t> noc_addr;
+    if (map_to_noc) {
+        auto [noc_aligned, dev_io_aligned] = pci_device->map_buffer_to_noc(aligned_va, mapped_size);
+        device_io_addr = dev_io_aligned + offset_from_aligned;
+        noc_addr = noc_aligned + offset_from_aligned;
+    } else {
+        device_io_addr = pci_device->map_for_dma(aligned_va, mapped_size) + offset_from_aligned;
+        noc_addr = std::nullopt;
+    }
+
+    auto on_destroy = [pci_device, aligned_va, mapped_size, device_io_addr]() {
+        try {
+            pci_device->unmap_for_dma(aligned_va, mapped_size);
+        } catch (...) {
+            log_warning(
+                LogUMD, "Failed to unmap sysmem buffer (size: {:#x}, IOVA: {:#x}).", mapped_size, device_io_addr);
+        }
+    };
+
+    return std::make_unique<SysmemBuffer>(
+        tlb_manager_, buffer, sysmem_buffer_size, device_io_addr, noc_addr, std::move(on_destroy));
 }
 
 }  // namespace tt::umd

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -4,21 +4,28 @@
 
 #include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
 
+#include <fmt/format.h>
 #include <sys/mman.h>  // for mmap, munmap
 #include <sys/stat.h>  // for fstat
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <tt-logger/tt-logger.hpp>
+#include <utility>
 
 #include "assert.hpp"
 #include "cpuset_lib.hpp"
 #include "hugepage.hpp"
 #include "tracy.hpp"
+#include "umd/device/chip_helpers/sysmem_buffer.hpp"
+#include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
 
@@ -53,10 +60,14 @@ bool SimulationSysmemManager::init_sysmem(uint32_t num_host_mem_channels) {
     madvise(system_memory_, total_size, MADV_HUGEPAGE);
     system_memory_size_ = total_size;
 
+    std::lock_guard<std::mutex> lock(regions_mutex_);
     for (int i = 0; i < num_host_mem_channels; i++) {
         size_t channel_size = (i == 3 && num_host_mem_channels == 4) ? (768 * (1ULL << 20)) : (1ULL << 30);
-        hugepage_mapping_per_channel.push_back(
-            {system_memory_ + i * (1ULL << 30), channel_size, pcie_base_ + i * (1ULL << 30)});
+        uint8_t *channel_va = system_memory_ + i * (1ULL << 30);
+        hugepage_mapping_per_channel.push_back({channel_va, channel_size, pcie_base_ + i * (1ULL << 30)});
+        // Channel i occupies paddr [i*1GB, i*1GB + channel_size). The simulator strips
+        // pcie_base_ before issuing pci_dma callbacks, so paddr space starts at 0.
+        paddr_regions_.push_back({i * (1ULL << 30), i * (1ULL << 30) + channel_size, channel_va});
     }
 
     return true;
@@ -68,6 +79,10 @@ SimulationSysmemManager::~SimulationSysmemManager() { SimulationSysmemManager::u
 
 void SimulationSysmemManager::unpin_or_unmap_sysmem() {
     ZoneScopedC(tracy::Color::Yellow);
+    {
+        std::lock_guard<std::mutex> lock(regions_mutex_);
+        paddr_regions_.clear();
+    }
     hugepage_mapping_per_channel.clear();
     if (system_memory_ != nullptr) {
         munmap(system_memory_, system_memory_size_);
@@ -78,11 +93,74 @@ void SimulationSysmemManager::unpin_or_unmap_sysmem() {
 
 std::unique_ptr<SysmemBuffer> SimulationSysmemManager::allocate_sysmem_buffer(
     size_t sysmem_buffer_size, const bool map_to_noc) {
-    return nullptr;
+    void *buffer =
+        mmap(nullptr, sysmem_buffer_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE, -1, 0);
+    if (buffer == MAP_FAILED) {
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format("Failed to mmap simulation sysmem buffer of size {:#x}.", sysmem_buffer_size));
+    }
+
+    uint64_t paddr_start;
+    {
+        std::lock_guard<std::mutex> lock(regions_mutex_);
+        paddr_start = next_alloc_paddr_;
+        next_alloc_paddr_ += sysmem_buffer_size;
+        paddr_regions_.push_back({paddr_start, paddr_start + sysmem_buffer_size, static_cast<uint8_t *>(buffer)});
+    }
+
+    std::optional<uint64_t> noc_addr = map_to_noc ? std::optional<uint64_t>(pcie_base_ + paddr_start) : std::nullopt;
+
+    auto on_destroy = [this, paddr_start, buffer, sysmem_buffer_size]() {
+        {
+            std::lock_guard<std::mutex> lock(regions_mutex_);
+            auto it = std::find_if(paddr_regions_.begin(), paddr_regions_.end(), [paddr_start](const PaddrRegion &r) {
+                return r.paddr_start == paddr_start;
+            });
+            if (it != paddr_regions_.end()) {
+                paddr_regions_.erase(it);
+            }
+        }
+        munmap(buffer, sysmem_buffer_size);
+    };
+
+    return std::make_unique<SysmemBuffer>(
+        nullptr, buffer, sysmem_buffer_size, paddr_start, noc_addr, std::move(on_destroy));
 }
 
 std::unique_ptr<SysmemBuffer> SimulationSysmemManager::map_sysmem_buffer(
     void *buffer, size_t sysmem_buffer_size, const bool map_to_noc) {
+    uint64_t paddr_start;
+    {
+        std::lock_guard<std::mutex> lock(regions_mutex_);
+        paddr_start = next_alloc_paddr_;
+        next_alloc_paddr_ += sysmem_buffer_size;
+        paddr_regions_.push_back({paddr_start, paddr_start + sysmem_buffer_size, static_cast<uint8_t *>(buffer)});
+    }
+
+    std::optional<uint64_t> noc_addr = map_to_noc ? std::optional<uint64_t>(pcie_base_ + paddr_start) : std::nullopt;
+
+    auto on_destroy = [this, paddr_start]() {
+        std::lock_guard<std::mutex> lock(regions_mutex_);
+        auto it = std::find_if(paddr_regions_.begin(), paddr_regions_.end(), [paddr_start](const PaddrRegion &r) {
+            return r.paddr_start == paddr_start;
+        });
+        if (it != paddr_regions_.end()) {
+            paddr_regions_.erase(it);
+        }
+    };
+
+    return std::make_unique<SysmemBuffer>(
+        nullptr, buffer, sysmem_buffer_size, paddr_start, noc_addr, std::move(on_destroy));
+}
+
+uint8_t *SimulationSysmemManager::find_paddr_host_va(uint64_t paddr, uint32_t size) {
+    std::lock_guard<std::mutex> lock(regions_mutex_);
+    for (const auto &r : paddr_regions_) {
+        if (paddr >= r.paddr_start && paddr + size <= r.paddr_end) {
+            return r.host_va + (paddr - r.paddr_start);
+        }
+    }
     return nullptr;
 }
 

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -69,6 +69,11 @@ bool SimulationSysmemManager::init_sysmem(uint32_t num_host_mem_channels) {
         // pcie_base_ before issuing pci_dma callbacks, so paddr space starts at 0.
         paddr_regions_.push_back({i * (1ULL << 30), i * (1ULL << 30) + channel_size, channel_va});
     }
+    // Mapped/allocated buffers begin in the first paddr slot not reserved for a channel.
+    // We reserve a full 1 GiB slot per channel (matching the simulator's channel layout),
+    // even when channel 3 has the 256 MiB carveout — that 256 MiB is left unused so we
+    // don't have to special-case the boundary.
+    next_alloc_paddr_ = static_cast<uint64_t>(num_host_mem_channels) * (1ULL << 30);
 
     return true;
 }

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -9,10 +9,11 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <tt-logger/tt-logger.hpp>
-#include <tuple>
+#include <utility>
 
 #include "noc_access.hpp"
 #include "tracy.hpp"
@@ -22,17 +23,20 @@
 
 namespace tt::umd {
 
-SysmemBuffer::SysmemBuffer(TLBManager* tlb_manager, void* buffer_va, size_t buffer_size, bool map_to_noc) :
-    tlb_manager_(tlb_manager), buffer_va_(buffer_va), mapped_buffer_size_(buffer_size), buffer_size_(buffer_size) {
-    align_address_and_size();
-    PCIDevice* pci_device = tlb_manager->get_tt_device()->get_pci_device();
-    if (map_to_noc) {
-        std::tie(noc_addr_, device_io_addr_) = pci_device->map_buffer_to_noc(buffer_va_, mapped_buffer_size_);
-    } else {
-        device_io_addr_ = pci_device->map_for_dma(buffer_va_, mapped_buffer_size_);
-        noc_addr_ = std::nullopt;
-    }
-    TracyAllocN(buffer_va_, mapped_buffer_size_, "SysmemBuffer");
+SysmemBuffer::SysmemBuffer(
+    TLBManager* tlb_manager,
+    void* buffer_va,
+    size_t buffer_size,
+    uint64_t device_io_addr,
+    std::optional<uint64_t> noc_addr,
+    std::function<void()> on_destroy) :
+    tlb_manager_(tlb_manager),
+    buffer_va_(buffer_va),
+    buffer_size_(buffer_size),
+    device_io_addr_(device_io_addr),
+    noc_addr_(noc_addr),
+    on_destroy_(std::move(on_destroy)) {
+    TracyAllocN(buffer_va_, buffer_size_, "SysmemBuffer");
 }
 
 void SysmemBuffer::dma_write_to_device(const size_t offset, size_t size, const tt_xy_pair core, uint64_t addr) {
@@ -152,29 +156,22 @@ void SysmemBuffer::dma_read_from_device(const size_t offset, size_t size, const 
 
 SysmemBuffer::~SysmemBuffer() {
     TracyFreeN(buffer_va_, "SysmemBuffer");
-    try {
-        tlb_manager_->get_tt_device()->get_pci_device()->unmap_for_dma(buffer_va_, mapped_buffer_size_);
-    } catch (...) {
-        log_warning(
-            LogUMD, "Failed to unmap sysmem buffer (size: {:#x}, IOVA: {:#x}).", mapped_buffer_size_, device_io_addr_);
+    if (on_destroy_) {
+        try {
+            on_destroy_();
+        } catch (...) {
+            log_warning(LogUMD, "SysmemBuffer on_destroy callback threw; ignoring.");
+        }
     }
 }
 
-void SysmemBuffer::align_address_and_size() {
-    static const auto page_size = sysconf(_SC_PAGESIZE);
-    uint64_t aligned_buffer_va = reinterpret_cast<uint64_t>(buffer_va_) & ~(page_size - 1);
-    offset_from_aligned_addr_ = reinterpret_cast<uint64_t>(buffer_va_) - aligned_buffer_va;
-    buffer_va_ = reinterpret_cast<void*>(aligned_buffer_va);
-    mapped_buffer_size_ = (mapped_buffer_size_ + offset_from_aligned_addr_ + page_size - 1) & ~(page_size - 1);
-}
-
-void* SysmemBuffer::get_buffer_va() const { return static_cast<uint8_t*>(buffer_va_) + offset_from_aligned_addr_; }
+void* SysmemBuffer::get_buffer_va() const { return buffer_va_; }
 
 size_t SysmemBuffer::get_buffer_size() const { return buffer_size_; }
 
 uint64_t SysmemBuffer::get_device_io_addr(const size_t offset) const {
     validate(offset);
-    return device_io_addr_ + offset + offset_from_aligned_addr_;
+    return device_io_addr_ + offset;
 }
 
 void SysmemBuffer::validate(const size_t offset) const {

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -6,6 +6,7 @@
 
 #include <fmt/format.h>
 
+#include <cstring>
 #include <filesystem>
 #include <tt-logger/tt-logger.hpp>
 
@@ -272,15 +273,25 @@ void TTSimTTDevice::initialize_sysmem_functions() {
 }
 
 void TTSimTTDevice::pci_dma_read_bytes(uint64_t paddr, void* p, uint32_t size) {
-    uint64_t channel = paddr / (1ULL << 30);
-    uint64_t offset = paddr % (1ULL << 30);
-    sysmem_manager_->read_from_sysmem(channel, p, offset, size);
+    uint8_t* host_va = sysmem_manager_->find_paddr_host_va(paddr, size);
+    if (host_va == nullptr) {
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format(
+                "TTSim pci_dma_read_bytes: no registered sysmem region covers paddr {:#x} size {}.", paddr, size));
+    }
+    std::memcpy(p, host_va, size);
 }
 
 void TTSimTTDevice::pci_dma_write_bytes(uint64_t paddr, const void* p, uint32_t size) {
-    uint64_t channel = paddr / (1ULL << 30);
-    uint64_t offset = paddr % (1ULL << 30);
-    sysmem_manager_->write_to_sysmem(channel, p, offset, size);
+    uint8_t* host_va = sysmem_manager_->find_paddr_host_va(paddr, size);
+    if (host_va == nullptr) {
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format(
+                "TTSim pci_dma_write_bytes: no registered sysmem region covers paddr {:#x} size {}.", paddr, size));
+    }
+    std::memcpy(host_va, p, size);
 }
 
 void TTSimTTDevice::retrain_dram_core(const uint32_t dram_channel) {

--- a/tests/api/test_simulation_sysmem_manager.cpp
+++ b/tests/api/test_simulation_sysmem_manager.cpp
@@ -124,20 +124,32 @@ TEST(ApiSimulationSysmemManager, MapSysmemBufferReturnsBuffer) {
 }
 
 TEST(ApiSimulationSysmemManager, NocAddrAssignedAboveChannelRegion) {
-    auto sysmem = std::make_unique<SimulationSysmemManager>(0, tt::ARCH::WORMHOLE_B0);
-    const uint64_t pcie_base = sysmem->get_pcie_base();
-    const size_t size = 1 << 20;
+    // With no channels, the mapped-buffer region starts at paddr 0 (NOC pcie_base).
+    {
+        auto sysmem = std::make_unique<SimulationSysmemManager>(0, tt::ARCH::WORMHOLE_B0);
+        const uint64_t pcie_base = sysmem->get_pcie_base();
+        const size_t size = 1 << 20;
 
-    auto first = sysmem->allocate_sysmem_buffer(size, /*map_to_noc=*/true);
-    auto second = sysmem->allocate_sysmem_buffer(size, /*map_to_noc=*/true);
+        auto first = sysmem->allocate_sysmem_buffer(size, /*map_to_noc=*/true);
+        auto second = sysmem->allocate_sysmem_buffer(size, /*map_to_noc=*/true);
 
-    ASSERT_TRUE(first->get_noc_addr().has_value());
-    ASSERT_TRUE(second->get_noc_addr().has_value());
+        ASSERT_TRUE(first->get_noc_addr().has_value());
+        ASSERT_TRUE(second->get_noc_addr().has_value());
 
-    // First buffer sits at the start of the mapped-buffer region (4 GiB above pcie_base).
-    EXPECT_EQ(first->get_noc_addr().value(), pcie_base + (4ULL << 30));
-    // Second buffer follows immediately after.
-    EXPECT_EQ(second->get_noc_addr().value(), first->get_noc_addr().value() + size);
+        EXPECT_EQ(first->get_noc_addr().value(), pcie_base);
+        EXPECT_EQ(second->get_noc_addr().value(), first->get_noc_addr().value() + size);
+    }
+
+    // With 2 channels, mapped buffers start at the first paddr slot above the channel region.
+    {
+        auto sysmem = std::make_unique<SimulationSysmemManager>(2, tt::ARCH::WORMHOLE_B0);
+        const uint64_t pcie_base = sysmem->get_pcie_base();
+        const size_t size = 1 << 20;
+
+        auto first = sysmem->allocate_sysmem_buffer(size, /*map_to_noc=*/true);
+        ASSERT_TRUE(first->get_noc_addr().has_value());
+        EXPECT_EQ(first->get_noc_addr().value(), pcie_base + (2ULL << 30));
+    }
 }
 
 TEST(ApiSimulationSysmemManager, MapToNocFalseHidesNocAddr) {

--- a/tests/api/test_simulation_sysmem_manager.cpp
+++ b/tests/api/test_simulation_sysmem_manager.cpp
@@ -6,12 +6,14 @@
 #include <sys/mman.h>
 
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <vector>
 
 #include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/chip_helpers/silicon_sysmem_manager.hpp"
 #include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
+#include "umd/device/chip_helpers/sysmem_buffer.hpp"
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_types.hpp"
@@ -92,4 +94,114 @@ TEST(ApiSimulationSysmemManager, TestFourChannels) {
     for (int i = 0; i < data_write.size(); i++) {
         EXPECT_EQ(static_cast<uint8_t*>(channel_3_mapping)[i], data_write[i]);
     }
+}
+
+// ---------------------------------------------------------------------------
+// SysmemBuffer-related tests for SimulationSysmemManager.
+// ---------------------------------------------------------------------------
+
+TEST(ApiSimulationSysmemManager, AllocateSysmemBufferReturnsBuffer) {
+    auto sysmem = std::make_unique<SimulationSysmemManager>(0, tt::ARCH::WORMHOLE_B0);
+    const size_t size = 1 << 20;
+
+    auto buffer = sysmem->allocate_sysmem_buffer(size, /*map_to_noc=*/true);
+    ASSERT_NE(buffer, nullptr);
+    EXPECT_NE(buffer->get_buffer_va(), nullptr);
+    EXPECT_EQ(buffer->get_buffer_size(), size);
+    ASSERT_TRUE(buffer->get_noc_addr().has_value());
+}
+
+TEST(ApiSimulationSysmemManager, MapSysmemBufferReturnsBuffer) {
+    auto sysmem = std::make_unique<SimulationSysmemManager>(0, tt::ARCH::WORMHOLE_B0);
+    const size_t size = 1 << 20;
+
+    std::vector<uint8_t> backing(size, 0);
+    auto buffer = sysmem->map_sysmem_buffer(backing.data(), size, /*map_to_noc=*/true);
+    ASSERT_NE(buffer, nullptr);
+    EXPECT_EQ(buffer->get_buffer_va(), backing.data());
+    EXPECT_EQ(buffer->get_buffer_size(), size);
+    ASSERT_TRUE(buffer->get_noc_addr().has_value());
+}
+
+TEST(ApiSimulationSysmemManager, NocAddrAssignedAboveChannelRegion) {
+    auto sysmem = std::make_unique<SimulationSysmemManager>(0, tt::ARCH::WORMHOLE_B0);
+    const uint64_t pcie_base = sysmem->get_pcie_base();
+    const size_t size = 1 << 20;
+
+    auto first = sysmem->allocate_sysmem_buffer(size, /*map_to_noc=*/true);
+    auto second = sysmem->allocate_sysmem_buffer(size, /*map_to_noc=*/true);
+
+    ASSERT_TRUE(first->get_noc_addr().has_value());
+    ASSERT_TRUE(second->get_noc_addr().has_value());
+
+    // First buffer sits at the start of the mapped-buffer region (4 GiB above pcie_base).
+    EXPECT_EQ(first->get_noc_addr().value(), pcie_base + (4ULL << 30));
+    // Second buffer follows immediately after.
+    EXPECT_EQ(second->get_noc_addr().value(), first->get_noc_addr().value() + size);
+}
+
+TEST(ApiSimulationSysmemManager, MapToNocFalseHidesNocAddr) {
+    auto sysmem = std::make_unique<SimulationSysmemManager>(0, tt::ARCH::WORMHOLE_B0);
+    const size_t size = 1 << 20;
+
+    auto buffer = sysmem->allocate_sysmem_buffer(size, /*map_to_noc=*/false);
+    ASSERT_NE(buffer, nullptr);
+    EXPECT_FALSE(buffer->get_noc_addr().has_value());
+}
+
+TEST(ApiSimulationSysmemManager, RoutingHostInitWriteAndRead) {
+    // Use 1 channel so we can verify routing covers channel regions too.
+    auto sysmem = std::make_unique<SimulationSysmemManager>(1, tt::ARCH::WORMHOLE_B0);
+
+    // Write into channel 0 by paddr (channel 0 is at paddr 0).
+    std::vector<uint8_t> chan_pattern = {10, 20, 30, 40};
+    uint8_t* chan_va = sysmem->find_paddr_host_va(0x100, chan_pattern.size());
+    ASSERT_NE(chan_va, nullptr);
+    std::memcpy(chan_va, chan_pattern.data(), chan_pattern.size());
+    // Confirm same bytes show up via the channel-keyed sysmem accessor.
+    std::vector<uint8_t> chan_readback(chan_pattern.size(), 0);
+    sysmem->read_from_sysmem(0, chan_readback.data(), 0x100, chan_readback.size());
+    EXPECT_EQ(chan_readback, chan_pattern);
+
+    // Allocate a buffer and exercise paddr routing into it.
+    const size_t size = 4096;
+    auto buffer = sysmem->allocate_sysmem_buffer(size, /*map_to_noc=*/true);
+    const uint64_t pcie_base = sysmem->get_pcie_base();
+    const uint64_t buf_paddr = buffer->get_noc_addr().value() - pcie_base;
+
+    std::vector<uint8_t> buf_pattern(size);
+    for (size_t i = 0; i < size; ++i) {
+        buf_pattern[i] = static_cast<uint8_t>(i % 256);
+    }
+
+    uint8_t* buf_routed = sysmem->find_paddr_host_va(buf_paddr, size);
+    ASSERT_NE(buf_routed, nullptr);
+    EXPECT_EQ(buf_routed, buffer->get_buffer_va());
+    std::memcpy(buf_routed, buf_pattern.data(), size);
+
+    // Read the same data back through the user-facing buffer pointer.
+    EXPECT_EQ(std::memcmp(buffer->get_buffer_va(), buf_pattern.data(), size), 0);
+}
+
+TEST(ApiSimulationSysmemManager, BufferDeregistersOnDestroy) {
+    auto sysmem = std::make_unique<SimulationSysmemManager>(0, tt::ARCH::WORMHOLE_B0);
+    const size_t size = 4096;
+
+    uint64_t paddr_to_check;
+    {
+        auto buffer = sysmem->allocate_sysmem_buffer(size, /*map_to_noc=*/true);
+        paddr_to_check = buffer->get_noc_addr().value() - sysmem->get_pcie_base();
+        EXPECT_NE(sysmem->find_paddr_host_va(paddr_to_check, size), nullptr);
+    }
+    // After the buffer is destroyed, the region must no longer be routable.
+    EXPECT_EQ(sysmem->find_paddr_host_va(paddr_to_check, size), nullptr);
+}
+
+TEST(ApiSimulationSysmemManager, FindPaddrRejectsOutOfRange) {
+    auto sysmem = std::make_unique<SimulationSysmemManager>(1, tt::ARCH::WORMHOLE_B0);
+    // 1 channel covers paddr [0, 1GiB). Above that there are no buffers.
+    EXPECT_EQ(sysmem->find_paddr_host_va(2ULL << 30, 4), nullptr);
+
+    // A request that straddles the end of channel 0 must also fail.
+    EXPECT_EQ(sysmem->find_paddr_host_va((1ULL << 30) - 2, 8), nullptr);
 }

--- a/tests/api/test_ttsim_device_io.cpp
+++ b/tests/api/test_ttsim_device_io.cpp
@@ -404,6 +404,36 @@ TEST_F(TTSimDeviceIOFixture, SysmemBufferReadViaPcieNocSeesHostVa) {
         << "read_from_device(pcie_core, noc_addr) did not return sysmem buffer host VA contents";
 }
 
+// User-allocated buffer mapped via map_sysmem_buffer must also be reachable via NOC.
+TEST_F(TTSimDeviceIOFixture, MapSysmemBufferRoutesToHostVa) {
+    const SocDescriptor& soc = tt_device->get_soc_descriptor();
+    auto pcie_cores = soc.get_cores(CoreType::PCIE);
+    if (pcie_cores.empty()) {
+        GTEST_SKIP() << "No PCIE cores in SoC descriptor.";
+    }
+    const tt_xy_pair pcie_core = soc.translate_coord_to(pcie_cores.at(0), CoordSystem::TRANSLATED);
+
+    SimulationSysmemManager* sysmem = tt_device->get_sysmem_manager();
+    ASSERT_NE(sysmem, nullptr);
+
+    constexpr size_t data_size = 4096;
+    std::vector<uint8_t> backing(data_size, 0);
+    auto buffer = sysmem->map_sysmem_buffer(backing.data(), data_size, /*map_to_noc=*/true);
+    ASSERT_NE(buffer, nullptr);
+    ASSERT_TRUE(buffer->get_noc_addr().has_value());
+    EXPECT_EQ(buffer->get_buffer_va(), backing.data());
+
+    auto write_data = make_pattern(data_size, [](size_t i) { return (i * 11 + 5) % 256; });
+    tt_device->write_to_device(write_data.data(), pcie_core, buffer->get_noc_addr().value(), data_size);
+
+    EXPECT_EQ(0, std::memcmp(backing.data(), write_data.data(), data_size))
+        << "write_to_device(pcie_core, noc_addr) did not land in user-mapped buffer";
+
+    std::vector<uint8_t> read_data(data_size, 0);
+    tt_device->read_from_device(read_data.data(), pcie_core, buffer->get_noc_addr().value(), data_size);
+    EXPECT_EQ(write_data, read_data) << "read_from_device(pcie_core, noc_addr) did not see mapped-buffer contents";
+}
+
 // Two buffers must route independently — writes to one must not bleed into the other.
 TEST_F(TTSimDeviceIOFixture, MultipleSysmemBuffersRouteIndependently) {
     const SocDescriptor& soc = tt_device->get_soc_descriptor();

--- a/tests/api/test_ttsim_device_io.cpp
+++ b/tests/api/test_ttsim_device_io.cpp
@@ -10,9 +10,12 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <memory>
 #include <vector>
 
+#include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
+#include "umd/device/chip_helpers/sysmem_buffer.hpp"
 #include "umd/device/simulation/simulation_chip.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"
 #include "umd/device/tt_device/simulation_device_factory.hpp"
@@ -333,6 +336,101 @@ TEST_F(TTSimDeviceIOFixture, MultiCoreTileWrBytesReadByReadFromDeviceNoBleed) {
         tt_device->read_from_device(read_data.data(), core, addr, data_size);
         EXPECT_EQ(all_patterns[i], read_data) << "Data bleed detected on core index " << i;
     }
+}
+
+// ---------------------------------------------------------------------------
+// Repeated write/read cycles (mirrors DynamicTLB_RW style)
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// SysmemBuffer NOC routing: writes/reads to pcie_core at a buffer's NOC address
+// must reach (or come from) the host VA backing that buffer. This is the
+// device-initiated path that SimulationSysmemManager's paddr-region routing
+// is responsible for.
+// ---------------------------------------------------------------------------
+
+// Write a pattern to PCIE core at the buffer's NOC address; expect the data to
+// land in the host VA returned by get_buffer_va().
+TEST_F(TTSimDeviceIOFixture, SysmemBufferWriteViaPcieNocReachesHostVa) {
+    const SocDescriptor& soc = tt_device->get_soc_descriptor();
+    auto pcie_cores = soc.get_cores(CoreType::PCIE);
+    if (pcie_cores.empty()) {
+        GTEST_SKIP() << "No PCIE cores in SoC descriptor; cannot exercise NOC->host routing.";
+    }
+    const tt_xy_pair pcie_core = soc.translate_coord_to(pcie_cores.at(0), CoordSystem::TRANSLATED);
+
+    SimulationSysmemManager* sysmem = tt_device->get_sysmem_manager();
+    ASSERT_NE(sysmem, nullptr);
+
+    constexpr size_t data_size = 4096;
+    auto buffer = sysmem->allocate_sysmem_buffer(data_size, /*map_to_noc=*/true);
+    ASSERT_NE(buffer, nullptr);
+    ASSERT_TRUE(buffer->get_noc_addr().has_value());
+
+    std::memset(buffer->get_buffer_va(), 0, data_size);
+
+    auto write_data = make_pattern(data_size, [](size_t i) { return i % 256; });
+    tt_device->write_to_device(write_data.data(), pcie_core, buffer->get_noc_addr().value(), data_size);
+
+    EXPECT_EQ(0, std::memcmp(buffer->get_buffer_va(), write_data.data(), data_size))
+        << "write_to_device(pcie_core, noc_addr) did not land in sysmem buffer host VA";
+}
+
+// Place a pattern directly in the buffer's host VA, then read it back through
+// PCIE core at the buffer's NOC address.
+TEST_F(TTSimDeviceIOFixture, SysmemBufferReadViaPcieNocSeesHostVa) {
+    const SocDescriptor& soc = tt_device->get_soc_descriptor();
+    auto pcie_cores = soc.get_cores(CoreType::PCIE);
+    if (pcie_cores.empty()) {
+        GTEST_SKIP() << "No PCIE cores in SoC descriptor; cannot exercise host->NOC routing.";
+    }
+    const tt_xy_pair pcie_core = soc.translate_coord_to(pcie_cores.at(0), CoordSystem::TRANSLATED);
+
+    SimulationSysmemManager* sysmem = tt_device->get_sysmem_manager();
+    ASSERT_NE(sysmem, nullptr);
+
+    constexpr size_t data_size = 4096;
+    auto buffer = sysmem->allocate_sysmem_buffer(data_size, /*map_to_noc=*/true);
+    ASSERT_NE(buffer, nullptr);
+    ASSERT_TRUE(buffer->get_noc_addr().has_value());
+
+    auto pattern = make_pattern(data_size, [](size_t i) { return (i * 7 + 3) % 256; });
+    std::memcpy(buffer->get_buffer_va(), pattern.data(), data_size);
+
+    std::vector<uint8_t> read_data(data_size, 0);
+    tt_device->read_from_device(read_data.data(), pcie_core, buffer->get_noc_addr().value(), data_size);
+
+    EXPECT_EQ(pattern, read_data)
+        << "read_from_device(pcie_core, noc_addr) did not return sysmem buffer host VA contents";
+}
+
+// Two buffers must route independently — writes to one must not bleed into the other.
+TEST_F(TTSimDeviceIOFixture, MultipleSysmemBuffersRouteIndependently) {
+    const SocDescriptor& soc = tt_device->get_soc_descriptor();
+    auto pcie_cores = soc.get_cores(CoreType::PCIE);
+    if (pcie_cores.empty()) {
+        GTEST_SKIP() << "No PCIE cores in SoC descriptor.";
+    }
+    const tt_xy_pair pcie_core = soc.translate_coord_to(pcie_cores.at(0), CoordSystem::TRANSLATED);
+
+    SimulationSysmemManager* sysmem = tt_device->get_sysmem_manager();
+
+    constexpr size_t data_size = 1024;
+    auto buf_a = sysmem->allocate_sysmem_buffer(data_size, /*map_to_noc=*/true);
+    auto buf_b = sysmem->allocate_sysmem_buffer(data_size, /*map_to_noc=*/true);
+    ASSERT_NE(buf_a->get_noc_addr().value(), buf_b->get_noc_addr().value());
+
+    std::memset(buf_a->get_buffer_va(), 0, data_size);
+    std::memset(buf_b->get_buffer_va(), 0, data_size);
+
+    auto pattern_a = make_pattern(data_size, [](size_t i) { return (i + 0xA0) % 256; });
+    auto pattern_b = make_pattern(data_size, [](size_t i) { return (i + 0xB0) % 256; });
+
+    tt_device->write_to_device(pattern_a.data(), pcie_core, buf_a->get_noc_addr().value(), data_size);
+    tt_device->write_to_device(pattern_b.data(), pcie_core, buf_b->get_noc_addr().value(), data_size);
+
+    EXPECT_EQ(0, std::memcmp(buf_a->get_buffer_va(), pattern_a.data(), data_size));
+    EXPECT_EQ(0, std::memcmp(buf_b->get_buffer_va(), pattern_b.data(), data_size));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Issue
/

### Description
Implements `SimulationSysmemManager::allocate_sysmem_buffer` and `map_sysmem_buffer` (previously stubs) and routes device-initiated NOC ↔ PCIe traffic in TTSim through a unified paddr-region table on the manager.

`SysmemBuffer` is refactored from "constructor does the silicon mapping" to "constructor takes pre-computed addresses + cleanup callback", so the silicon and simulation code paths share the same class. Page-alignment moves into `SiliconSysmemManager`.

`SimulationSysmemManager` registers each enabled host-mem channel in the paddr-region table at init, and assigns mapped buffers paddrs immediately above the channel region (paddr 0 when no channels are configured). This keeps mapped buffers within the simulator's supported `translate_pci_dma_addr` range.

`TTSimTTDevice::pci_dma_{read,write}_bytes` replaces the channel-arithmetic path with a single `find_paddr_host_va` lookup that covers both channel regions and mapped buffers.

Requires the matching ttsim change for Blackhole NOC→PCIe paddr translation: [`pjanevski/bh_pcie_noc_addr`](https://github.com/tenstorrent/ttsim-private/tree/pjanevski/bh_pcie_noc_addr) (`Add logic for pcie noc addr translation`). Without that, the BH end-to-end test will fail on `translate_pci_dma_addr`.

### List of the changes
- `SysmemBuffer` ctor now takes pre-computed `device_io_addr` / `noc_addr` / `on_destroy` callback. Alignment moves into `SiliconSysmemManager`.
- `SimulationSysmemManager` implements `allocate_sysmem_buffer` / `map_sysmem_buffer`; tracks paddr regions; `find_paddr_host_va` is the unified routing entrypoint. Mapped-buffer base is dynamic.
- `TTSimTTDevice::pci_dma_{read,write}_bytes` uses `find_paddr_host_va`.
- 7 new unit tests in `test_simulation_sysmem_manager.cpp`.
- 3 new TTSim end-to-end tests in `test_ttsim_device_io.cpp` exercising `write_to_device(pcie_core, get_noc_addr(), ...)` and the symmetric read. Verified on both Wormhole and Blackhole TTSim binaries.

### Testing
CI; locally verified `ApiSimulationSysmemManager.*` (10 tests) and `TTSimDeviceIOFixture.*` (15 tests, against both `libttsim_wh.so` and `libttsim_bh.so`).

### API Changes
`SysmemBuffer` constructor signature changes from `(TLBManager*, void*, size_t, bool map_to_noc)` to `(TLBManager*, void*, size_t, uint64_t device_io_addr, std::optional<uint64_t> noc_addr, std::function<void()> on_destroy)`. All in-tree callers go through `SysmemManager::map_sysmem_buffer` / `allocate_sysmem_buffer`, which keep their existing API.