### PR TITLE
Refactor get_arch() in tlb_window and tlb_handle

### DIFF
--- a/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
@@ -75,6 +75,8 @@ public:
      */
     const architecture_implementation* get_architecture_impl() const;
 
+    tt::ARCH get_arch() const;
+
 private:
     /**
      * Initialize architecture-specific TLB configuration based on the device architecture.

--- a/device/api/umd/device/pcie/rtl_sim_tlb_handle.hpp
+++ b/device/api/umd/device/pcie/rtl_sim_tlb_handle.hpp
@@ -32,6 +32,8 @@ public:
 
     SimulationTlbManager* get_tlb_manager() const { return manager_; }
 
+    tt::ARCH get_arch() const override;
+
 private:
     RtlSimTlbHandle(SimulationTlbManager* manager, int tlb_id, size_t size, TlbMapping mapping);
 

--- a/device/api/umd/device/pcie/rtl_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/rtl_sim_tlb_window.hpp
@@ -34,9 +34,6 @@ public:
     void safe_write16(uint64_t offset, uint16_t value) override;
     uint16_t safe_read16(uint64_t offset) override;
 
-protected:
-    tt::ARCH get_arch() const override;
-
 private:
     /**
      * Translate a TLB window offset to (core, address) and perform a write via the communicator.

--- a/device/api/umd/device/pcie/silicon_tlb_handle.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_handle.hpp
@@ -37,6 +37,8 @@ public:
 
     void configure(const tlb_data& new_config) override;
 
+    tt::ARCH get_arch() const override;
+
 private:
     void free_tlb() noexcept override;
 

--- a/device/api/umd/device/pcie/silicon_tlb_window.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_window.hpp
@@ -65,9 +65,6 @@ public:
 
     static void set_sigbus_safe_handler(bool set_safe_handler);
 
-protected:
-    tt::ARCH get_arch() const override;
-
 private:
     // Custom device memcpy. This is only safe for memory-like regions on the device (Tensix L1, DRAM, ARC CSM).
     // Both routines assume that misaligned accesses are permitted on host memory.

--- a/device/api/umd/device/pcie/tlb_handle.hpp
+++ b/device/api/umd/device/pcie/tlb_handle.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "umd/device/types/arch.hpp"
 #include "umd/device/types/tlb.hpp"
 
 namespace tt::umd {
@@ -50,6 +51,8 @@ public:
      * Returns the TLB ID, representing index of TLB in BAR0.
      */
     int get_tlb_id() const { return tlb_id_; }
+
+    virtual tt::ARCH get_arch() const = 0;
 
 protected:
     /**

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -88,8 +88,6 @@ protected:
     void validate(uint64_t offset, size_t size) const;
     uint64_t get_total_offset(uint64_t offset) const;
 
-    virtual tt::ARCH get_arch() const = 0;
-
     std::unique_ptr<TlbHandle> tlb_handle;
     uint64_t offset_from_aligned_addr = 0;
 };

--- a/device/api/umd/device/pcie/tt_sim_tlb_handle.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_handle.hpp
@@ -39,6 +39,8 @@ public:
 
     SimulationTlbManager* get_tlb_manager() const { return sim_manager_; }
 
+    tt::ARCH get_arch() const override;
+
 private:
     // Private constructor to enforce use of create() factory method.
     TTSimTlbHandle(

--- a/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
@@ -37,9 +37,6 @@ public:
 
     uint16_t safe_read16(uint64_t offset) override;
 
-protected:
-    tt::ARCH get_arch() const override;
-
 private:
     /**
      * Get the physical address for a TLB window offset.

--- a/device/chip_helpers/simulation_tlb_manager.cpp
+++ b/device/chip_helpers/simulation_tlb_manager.cpp
@@ -222,6 +222,8 @@ uint64_t SimulationTlbManager::get_tlb_reg_address_from_index(int tlb_index) {
 
 const architecture_implementation* SimulationTlbManager::get_architecture_impl() const { return arch_impl_; }
 
+tt::ARCH SimulationTlbManager::get_arch() const { return architecture_; }
+
 std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
     static constexpr size_t SIZE_2MB = 2 * 1024 * 1024;
     static constexpr size_t SIZE_16MB = 16 * 1024 * 1024;

--- a/device/pcie/rtl_sim_tlb_handle.cpp
+++ b/device/pcie/rtl_sim_tlb_handle.cpp
@@ -66,4 +66,6 @@ void RtlSimTlbHandle::free_tlb() noexcept {
     }
 }
 
+tt::ARCH RtlSimTlbHandle::get_arch() const { return manager_->get_arch(); }
+
 }  // namespace tt::umd

--- a/device/pcie/rtl_sim_tlb_window.cpp
+++ b/device/pcie/rtl_sim_tlb_window.cpp
@@ -66,9 +66,4 @@ void RtlSimTlbWindow::safe_write16(uint64_t offset, uint16_t value) { write16(of
 
 uint16_t RtlSimTlbWindow::safe_read16(uint64_t offset) { return read16(offset); }
 
-tt::ARCH RtlSimTlbWindow::get_arch() const {
-    auto* handle = dynamic_cast<RtlSimTlbHandle*>(tlb_handle.get());
-    return handle->get_tlb_manager()->get_tt_device()->get_arch();
-}
-
 }  // namespace tt::umd

--- a/device/pcie/silicon_tlb_handle.cpp
+++ b/device/pcie/silicon_tlb_handle.cpp
@@ -57,4 +57,6 @@ void SiliconTlbHandle::configure(const tlb_data& new_config) {
 
 void SiliconTlbHandle::free_tlb() noexcept { tt_tlb_free(pci_device_.get_tt_device_handle(), tlb_handle_); }
 
+tt::ARCH SiliconTlbHandle::get_arch() const { return pci_device_.get_arch(); }
+
 }  // namespace tt::umd

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -16,7 +16,6 @@
 #include <functional>
 #include <memory>
 
-#include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
@@ -110,7 +109,7 @@ void SiliconTlbWindow::write_block(uint64_t offset, const void *data, size_t siz
 
     validate(offset, size);
 
-    if (PCIDevice::get_pcie_arch() == tt::ARCH::WORMHOLE_B0) {
+    if (tlb_handle->get_arch() == tt::ARCH::WORMHOLE_B0) {
         memcpy_to_device((void *)dst, src, size);
     } else {
         memcpy((void *)dst, (void *)src, size);
@@ -122,7 +121,7 @@ void SiliconTlbWindow::read_block(uint64_t offset, void *data, size_t size) {
 
     validate(offset, size);
 
-    if (PCIDevice::get_pcie_arch() == tt::ARCH::WORMHOLE_B0) {
+    if (tlb_handle->get_arch() == tt::ARCH::WORMHOLE_B0) {
         memcpy_from_device(data, src, size);
     } else {
         memcpy(data, src, size);
@@ -285,7 +284,5 @@ void SiliconTlbWindow::safe_noc_multicast_write_reconfigure(
     void *dst, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, uint64_t ordering) {
     execute_safe(&SiliconTlbWindow::noc_multicast_write_reconfigure, dst, size, core_start, core_end, addr, ordering);
 }
-
-tt::ARCH SiliconTlbWindow::get_arch() const { return PCIDevice::get_pcie_arch(); }
 
 }  // namespace tt::umd

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "umd/device/pcie/tlb_window.hpp"
+
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -11,7 +13,6 @@
 #include <utility>
 
 #include "noc_access.hpp"
-#include "umd/device/pcie/silicon_tlb_window.hpp"
 
 namespace tt::umd {
 

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -11,7 +11,6 @@
 #include <utility>
 
 #include "noc_access.hpp"
-#include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
 
 namespace tt::umd {
@@ -31,7 +30,7 @@ void TlbWindow::read_block_reconfigure(void* mem_ptr, tt_xy_pair core, uint64_t 
     config.y_end = core.y;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = ordering;
-    config.static_vc = get_arch() != tt::ARCH::BLACKHOLE;
+    config.static_vc = tlb_handle->get_arch() != tt::ARCH::BLACKHOLE;
 
     while (size > 0) {
         configure(config);
@@ -57,7 +56,7 @@ void TlbWindow::write_block_reconfigure(
     config.y_end = core.y;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = ordering;
-    config.static_vc = get_arch() != tt::ARCH::BLACKHOLE;
+    config.static_vc = tlb_handle->get_arch() != tt::ARCH::BLACKHOLE;
 
     while (size > 0) {
         configure(config);
@@ -87,7 +86,7 @@ void TlbWindow::noc_multicast_write_reconfigure(
     config.mcast = true;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = ordering;
-    config.static_vc = get_arch() != tt::ARCH::BLACKHOLE;
+    config.static_vc = tlb_handle->get_arch() != tt::ARCH::BLACKHOLE;
 
     while (size > 0) {
         configure(config);

--- a/device/pcie/tt_sim_tlb_handle.cpp
+++ b/device/pcie/tt_sim_tlb_handle.cpp
@@ -65,8 +65,7 @@ void TTSimTlbHandle::configure(const tlb_data& new_config) {
     tlb_config_.static_vc = 0;
 
     // Get architecture from manager to determine correct offsets.
-    const architecture_implementation* arch_impl = sim_manager_->get_architecture_impl();
-    tt::ARCH architecture = arch_impl->get_architecture();
+    tt::ARCH architecture = get_arch();
 
     log_debug(
         LogUMD,
@@ -150,5 +149,7 @@ void TTSimTlbHandle::free_tlb() noexcept {
         log_debug(LogUMD, "Freed simulation TLB with ID {}", tlb_id_);
     }
 }
+
+tt::ARCH TTSimTlbHandle::get_arch() const { return sim_manager_->get_arch(); }
 
 }  // namespace tt::umd

--- a/device/pcie/tt_sim_tlb_window.cpp
+++ b/device/pcie/tt_sim_tlb_window.cpp
@@ -74,9 +74,4 @@ void TTSimTlbWindow::safe_write16(uint64_t offset, uint16_t value) { write16(off
 
 uint16_t TTSimTlbWindow::safe_read16(uint64_t offset) { return read16(offset); }
 
-tt::ARCH TTSimTlbWindow::get_arch() const {
-    auto* sim_handle = dynamic_cast<TTSimTlbHandle*>(tlb_handle.get());
-    return sim_handle->get_tlb_manager()->get_tt_device()->get_arch();
-}
-
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description
Motivation is to remove unnecessary dependancy, in simulation tlb window on tlb_manager, and in silicon tlb window on free standing PCIDevice function to get architecture

### List of the changes
- Add get_arch to all tlb handles. They have to know the arch anyway
- Remove get_arch from tlb windows.
- Remove simulation's dependancy on get_tlb_manager
- Remove silicon's call to PCIDevice::get_pcie_arch()

### Testing
Code builds, that's enough

### API Changes
There are no API changes in this PR.
