### PR TITLE
Cleaning up includes with IWYU

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -60,7 +60,6 @@ Checks: >
     -llvmlibc-*,
     -misc-const-correctness,
     -misc-definitions-in-headers,
-    -misc-header-include-cycle,
     -misc-include-cleaner,
     -misc-non-private-member-variables-in-classes,
     -misc-no-recursion,

--- a/.iwyu_mappings.imp
+++ b/.iwyu_mappings.imp
@@ -1,0 +1,6 @@
+[
+  # Map fmt internal headers to the main public header
+  { "include": ["\"base.h\"", "private", "<fmt/format.h>", "public"] },
+  { "include": ["<fmt/base.h>", "private", "<fmt/format.h>", "public"] },
+  { "include": ["\"fmt/base.h\"", "private", "<fmt/format.h>", "public"] },
+]

--- a/.iwyu_mappings.imp
+++ b/.iwyu_mappings.imp
@@ -1,6 +1,0 @@
-[
-  # Map fmt internal headers to the main public header
-  { "include": ["\"base.h\"", "private", "<fmt/format.h>", "public"] },
-  { "include": ["<fmt/base.h>", "private", "<fmt/format.h>", "public"] },
-  { "include": ["\"fmt/base.h\"", "private", "<fmt/format.h>", "public"] },
-]

--- a/device/api/umd/device/arc/arc_messenger.hpp
+++ b/device/api/umd/device/arc/arc_messenger.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string_view>

--- a/device/api/umd/device/arc/arc_telemetry_reader.hpp
+++ b/device/api/umd/device/arc/arc_telemetry_reader.hpp
@@ -10,7 +10,6 @@
 #include <memory>
 #include <unordered_set>
 
-#include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/telemetry.hpp"
 #include "umd/device/types/xy_pair.hpp"
 

--- a/device/api/umd/device/arc/arc_telemetry_reader.hpp
+++ b/device/api/umd/device/arc/arc_telemetry_reader.hpp
@@ -4,7 +4,10 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include <map>
+#include <memory>
 #include <unordered_set>
 
 #include "umd/device/tt_device/tt_device.hpp"
@@ -12,6 +15,7 @@
 #include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
+class TTDevice;
 
 class ArcTelemetryReader {
 public:

--- a/device/api/umd/device/arc/arc_telemetry_reader.hpp
+++ b/device/api/umd/device/arc/arc_telemetry_reader.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <unordered_set>

--- a/device/api/umd/device/arc/blackhole_arc_message_queue.hpp
+++ b/device/api/umd/device/arc/blackhole_arc_message_queue.hpp
@@ -5,10 +5,10 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdint.h>
 
 #include <array>
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <tuple>
 #include <vector>

--- a/device/api/umd/device/arc/blackhole_arc_message_queue.hpp
+++ b/device/api/umd/device/arc/blackhole_arc_message_queue.hpp
@@ -4,10 +4,9 @@
 
 #pragma once
 
-#include <stddef.h>
-
 #include <array>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <tuple>

--- a/device/api/umd/device/arc/blackhole_arc_message_queue.hpp
+++ b/device/api/umd/device/arc/blackhole_arc_message_queue.hpp
@@ -4,9 +4,23 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
+#include <array>
+#include <chrono>
+#include <memory>
+#include <tuple>
+#include <vector>
+
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/types/blackhole_arc.hpp"
+#include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/timeouts.hpp"
+
+namespace tt::umd::blackhole {
+enum class ArcMessageType : uint8_t;
+}  // namespace tt::umd::blackhole
 
 using namespace tt::umd::blackhole;
 

--- a/device/api/umd/device/arc/blackhole_arc_messenger.hpp
+++ b/device/api/umd/device/arc/blackhole_arc_messenger.hpp
@@ -4,9 +4,8 @@
 
 #pragma once
 
-#include <stdint.h>
-
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/device/api/umd/device/arc/blackhole_arc_messenger.hpp
+++ b/device/api/umd/device/arc/blackhole_arc_messenger.hpp
@@ -4,11 +4,18 @@
 
 #pragma once
 
+#include <stdint.h>
+
+#include <chrono>
+#include <memory>
+#include <vector>
+
 #include "umd/device/arc/arc_messenger.hpp"
 #include "umd/device/arc/blackhole_arc_message_queue.hpp"
 #include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
+class TTDevice;
 
 class BlackholeArcMessenger : public ArcMessenger {
 public:

--- a/device/api/umd/device/arc/blackhole_arc_telemetry_reader.hpp
+++ b/device/api/umd/device/arc/blackhole_arc_telemetry_reader.hpp
@@ -8,6 +8,7 @@
 #include "umd/device/arch/blackhole_implementation.hpp"
 
 namespace tt::umd {
+class TTDevice;
 
 class BlackholeArcTelemetryReader : public ArcTelemetryReader {
 public:

--- a/device/api/umd/device/arc/blackhole_spi_tt_device.hpp
+++ b/device/api/umd/device/arc/blackhole_spi_tt_device.hpp
@@ -6,8 +6,7 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <string>

--- a/device/api/umd/device/arc/blackhole_spi_tt_device.hpp
+++ b/device/api/umd/device/arc/blackhole_spi_tt_device.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <stddef.h>
+
 #include <cstdint>
 #include <optional>
 #include <string>

--- a/device/api/umd/device/arc/smbus_arc_telemetry_reader.hpp
+++ b/device/api/umd/device/arc/smbus_arc_telemetry_reader.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <map>
 #include <unordered_set>
 

--- a/device/api/umd/device/arc/smbus_arc_telemetry_reader.hpp
+++ b/device/api/umd/device/arc/smbus_arc_telemetry_reader.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include <map>
 #include <unordered_set>
 
@@ -13,6 +15,7 @@
 #include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
+class TTDevice;
 
 class SmBusArcTelemetryReader : public ArcTelemetryReader {
 public:

--- a/device/api/umd/device/arc/wormhole_arc_messenger.hpp
+++ b/device/api/umd/device/arc/wormhole_arc_messenger.hpp
@@ -4,10 +4,16 @@
 
 #pragma once
 
+#include <stdint.h>
+
+#include <chrono>
+#include <vector>
+
 #include "umd/device/arc/arc_messenger.hpp"
 #include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
+class TTDevice;
 
 class WormholeArcMessenger : public ArcMessenger {
 public:

--- a/device/api/umd/device/arc/wormhole_arc_messenger.hpp
+++ b/device/api/umd/device/arc/wormhole_arc_messenger.hpp
@@ -4,9 +4,8 @@
 
 #pragma once
 
-#include <stdint.h>
-
 #include <chrono>
+#include <cstdint>
 #include <vector>
 
 #include "umd/device/arc/arc_messenger.hpp"

--- a/device/api/umd/device/arc/wormhole_arc_telemetry_reader.hpp
+++ b/device/api/umd/device/arc/wormhole_arc_telemetry_reader.hpp
@@ -9,6 +9,7 @@
 #include "umd/device/arch/wormhole_implementation.hpp"
 
 namespace tt::umd {
+class TTDevice;
 
 class WormholeArcTelemetryReader : public ArcTelemetryReader {
 public:

--- a/device/api/umd/device/arc/wormhole_spi_tt_device.hpp
+++ b/device/api/umd/device/arc/wormhole_spi_tt_device.hpp
@@ -6,8 +6,7 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 
 #include "umd/device/arc/spi_tt_device.hpp"

--- a/device/api/umd/device/arc/wormhole_spi_tt_device.hpp
+++ b/device/api/umd/device/arc/wormhole_spi_tt_device.hpp
@@ -7,7 +7,8 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdint.h>
+
+#include <cstdint>
 
 #include "umd/device/arc/spi_tt_device.hpp"
 

--- a/device/api/umd/device/arc/wormhole_spi_tt_device.hpp
+++ b/device/api/umd/device/arc/wormhole_spi_tt_device.hpp
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "umd/device/arc/spi_tt_device.hpp"
 
 namespace tt::umd {

--- a/device/api/umd/device/arch/architecture_implementation.hpp
+++ b/device/api/umd/device/arch/architecture_implementation.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <iterator>
 #include <memory>

--- a/device/api/umd/device/arch/architecture_implementation.hpp
+++ b/device/api/umd/device/arch/architecture_implementation.hpp
@@ -4,10 +4,14 @@
 
 #pragma once
 
+#include <stddef.h>
+
 #include <cstdint>
+#include <iterator>
 #include <memory>
 #include <optional>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include "umd/device/types/arch.hpp"
@@ -16,6 +20,10 @@
 #include "umd/device/types/risc_type.hpp"
 #include "umd/device/types/tlb.hpp"
 #include "umd/device/types/xy_pair.hpp"
+
+namespace tt {
+enum class CoreType;
+}  // namespace tt
 
 namespace tt::umd {
 

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -4,10 +4,9 @@
 
 #pragma once
 
-#include <stdint.h>
-
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <iterator>
 #include <stdexcept>
 #include <string>

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -4,14 +4,25 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include <array>
+#include <cstddef>
+#include <iterator>
 #include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/tlb.hpp"
+#include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/common.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/api/umd/device/arch/grendel_implementation.hpp
+++ b/device/api/umd/device/arch/grendel_implementation.hpp
@@ -4,10 +4,9 @@
 
 #pragma once
 
-#include <stdint.h>
-
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <iterator>
 #include <stdexcept>
 #include <string>

--- a/device/api/umd/device/arch/grendel_implementation.hpp
+++ b/device/api/umd/device/arch/grendel_implementation.hpp
@@ -4,14 +4,25 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include <array>
+#include <cstddef>
+#include <iterator>
 #include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/tlb.hpp"
+#include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/common.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -5,10 +5,17 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
+#include <iterator>
+#include <utility>
+#include <vector>
 
 #include "architecture_implementation.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/tlb.hpp"
+#include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/common.hpp"
 
 namespace tt::umd {

--- a/device/api/umd/device/chip/chip.hpp
+++ b/device/api/umd/device/chip/chip.hpp
@@ -4,22 +4,34 @@
 
 #pragma once
 
+#include <stddef.h>
+
 #include <chrono>
+#include <cstdint>
+#include <set>
 #include <unordered_set>
+#include <vector>
 
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/cluster_types.hpp"
+#include "umd/device/types/risc_type.hpp"
 #include "umd/device/types/tensix_soft_reset_options.hpp"
 #include "umd/device/utils/lock_manager.hpp"
 #include "umd/device/utils/timeouts.hpp"
+
+namespace tt {
+enum class ARCH;
+}  // namespace tt
 
 namespace tt::umd {
 
 class TTDevice;
 class SysmemManager;
 class TLBManager;
+enum class TensixSoftResetOptions : std::uint32_t;
+struct CoreCoord;
 
 // An abstract class that represents a chip.
 class Chip {

--- a/device/api/umd/device/chip/chip.hpp
+++ b/device/api/umd/device/chip/chip.hpp
@@ -4,9 +4,8 @@
 
 #pragma once
 
-#include <stddef.h>
-
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <set>
 #include <unordered_set>

--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -4,14 +4,32 @@
 
 #pragma once
 
+#include <stddef.h>
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
 #include "umd/device/chip/chip.hpp"
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/communication_protocol.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/utils/lock_manager.hpp"
+#include "umd/device/utils/robust_mutex.hpp"
 
 namespace tt::umd {
+class RemoteCommunication;
+class SocDescriptor;
+class SysmemManager;
+class TLBManager;
 
 class LocalChip : public Chip {
 public:

--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>

--- a/device/api/umd/device/chip/mock_chip.hpp
+++ b/device/api/umd/device/chip/mock_chip.hpp
@@ -4,9 +4,8 @@
 
 #pragma once
 
-#include <stddef.h>
-
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <unordered_set>
 #include <vector>

--- a/device/api/umd/device/chip/mock_chip.hpp
+++ b/device/api/umd/device/chip/mock_chip.hpp
@@ -4,9 +4,21 @@
 
 #pragma once
 
+#include <stddef.h>
+
+#include <chrono>
+#include <cstdint>
+#include <unordered_set>
+#include <vector>
+
 #include "umd/device/chip/chip.hpp"
+#include "umd/device/types/cluster_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
+class SocDescriptor;
+
 class MockChip : public Chip {
 public:
     MockChip(SocDescriptor soc_descriptor);

--- a/device/api/umd/device/chip/remote_chip.hpp
+++ b/device/api/umd/device/chip/remote_chip.hpp
@@ -4,15 +4,31 @@
 
 #pragma once
 
+#include <stddef.h>
+
+#include <cstdint>
+#include <memory>
+#include <set>
+#include <string>
+#include <unordered_set>
+
 #include "umd/device/chip/chip.hpp"
 // TODO : tt-metal uses SysmemBuffer transitively through this header. Remove once tt-metal includes it directly.
 // Link to issue: https://github.com/tenstorrent/tt-umd/issues/2437.
 #include "umd/device/chip_helpers/sysmem_buffer.hpp"
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+
+namespace tt {
+struct EthCoord;
+}  // namespace tt
 
 namespace tt::umd {
 class LocalChip;
+class RemoteCommunication;
+class SocDescriptor;
 
 class RemoteChip : public Chip {
 public:

--- a/device/api/umd/device/chip/remote_chip.hpp
+++ b/device/api/umd/device/chip/remote_chip.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <set>

--- a/device/api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
@@ -6,8 +6,8 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdint.h>
 
+#include <cstdint>
 #include <string>
 
 #include "umd/device/chip_helpers/sysmem_manager.hpp"

--- a/device/api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
@@ -5,9 +5,15 @@
  */
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
+#include <string>
+
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 
 namespace tt::umd {
+class TLBManager;
 
 // Don't use the top 256MB of the 4th hugepage region on WH.  Two reasons:
 // 1. There are PCIE PHY registers at the top

--- a/device/api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
@@ -5,8 +5,7 @@
  */
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <string>
 

--- a/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 
 #include "umd/device/chip_helpers/sysmem_manager.hpp"

--- a/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
@@ -4,7 +4,14 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
+
+namespace tt {
+enum class ARCH;
+}  // namespace tt
 
 namespace tt::umd {
 

--- a/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
@@ -5,7 +5,8 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdint.h>
+
+#include <cstdint>
 
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 

--- a/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
@@ -5,8 +5,8 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdint.h>
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>

--- a/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
@@ -4,16 +4,28 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <vector>
 
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/chip_helpers/tlb_manager.hpp"
+#include "umd/device/pcie/tlb_window.hpp"
+#include "umd/device/types/tlb.hpp"
+
+namespace tt {
+enum class ARCH;
+}  // namespace tt
 
 namespace tt::umd {
 
 class SimulationTlbManager;
+class TTDevice;
+class architecture_implementation;
 
 /**
  * Factory function type for creating TlbWindow instances.

--- a/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>

--- a/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
@@ -6,11 +6,15 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
+#include <optional>
 
 #include "umd/device/chip_helpers/tlb_manager.hpp"
+#include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
+class TLBManager;
 
 /**
  * SysmemBuffer class should represent the resource of the HOST memory that is visible to the device.

--- a/device/api/umd/device/chip_helpers/sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_manager.hpp
@@ -4,13 +4,25 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
+#include <memory>
+#include <vector>
+
 #include "sysmem_buffer.hpp"
 #include "umd/device/chip_helpers/sysmem_buffer.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_types.hpp"
 
+namespace tt {
+enum class ARCH;
+}  // namespace tt
+
 namespace tt::umd {
+class TLBManager;
+class TTDevice;
 
 class SysmemManager {
 public:

--- a/device/api/umd/device/chip_helpers/sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_manager.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <vector>

--- a/device/api/umd/device/chip_helpers/sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_manager.hpp
@@ -5,8 +5,8 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdint.h>
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/device/api/umd/device/chip_helpers/tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/tlb_manager.hpp
@@ -4,6 +4,10 @@
 
 #pragma once
 
+#include <stddef.h>
+
+#include <cstdint>
+#include <memory>
 #include <unordered_map>
 #include <vector>
 

--- a/device/api/umd/device/chip_helpers/tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/tlb_manager.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <unordered_map>

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -4,35 +4,54 @@
 
 #pragma once
 #include <fmt/core.h>
+#include <stddef.h>
 
 #include <cassert>
+#include <chrono>
 #include <cstdint>
 #include <filesystem>
+#include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "umd/device/chip/chip.hpp"
 #include "umd/device/chip/remote_chip.hpp"
 #include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/soc_descriptor.hpp"
 #include "umd/device/topology/topology_discovery.hpp"
+#include "umd/device/topology/topology_discovery_options.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/cluster_types.hpp"
+#include "umd/device/types/communication_protocol.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/risc_type.hpp"
 #include "umd/device/types/tensix_soft_reset_options.hpp"
 #include "umd/device/types/tlb.hpp"
+#include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/semver.hpp"
+#include "umd/device/utils/timeouts.hpp"
+
+namespace tt {
+enum class ARCH;
+}  // namespace tt
 
 namespace tt::umd {
 
 class ClusterDescriptor;
 class LocalChip;
 class RemoteChip;
+class PCIDevice;
+class TLBManager;
+class TlbWindow;
 
 /**
  * Chip type to create under the Cluster class.

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -4,10 +4,10 @@
 
 #pragma once
 #include <fmt/format.h>
-#include <stddef.h>
 
 #include <cassert>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <map>

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <stddef.h>
 
 #include <cassert>

--- a/device/api/umd/device/cluster_descriptor.hpp
+++ b/device/api/umd/device/cluster_descriptor.hpp
@@ -4,10 +4,12 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <tuple>
@@ -19,6 +21,7 @@
 #include "umd/device/topology/topology_discovery.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/semver.hpp"
 

--- a/device/api/umd/device/cluster_descriptor.hpp
+++ b/device/api/umd/device/cluster_descriptor.hpp
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include "umd/device/chip/chip.hpp"
-#include "umd/device/topology/topology_discovery.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/communication_protocol.hpp"

--- a/device/api/umd/device/coordinates/blackhole_coordinate_manager.hpp
+++ b/device/api/umd/device/coordinates/blackhole_coordinate_manager.hpp
@@ -5,8 +5,8 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdint.h>
 
+#include <cstdint>
 #include <vector>
 
 #include "umd/device/arch/blackhole_implementation.hpp"

--- a/device/api/umd/device/coordinates/blackhole_coordinate_manager.hpp
+++ b/device/api/umd/device/coordinates/blackhole_coordinate_manager.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 

--- a/device/api/umd/device/coordinates/blackhole_coordinate_manager.hpp
+++ b/device/api/umd/device/coordinates/blackhole_coordinate_manager.hpp
@@ -4,8 +4,18 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
+#include <vector>
+
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/coordinates/coordinate_manager.hpp"
+#include "umd/device/types/xy_pair.hpp"
+
+namespace tt {
+struct HarvestingMasks;
+}  // namespace tt
 
 namespace tt::umd {
 

--- a/device/api/umd/device/coordinates/coordinate_manager.hpp
+++ b/device/api/umd/device/coordinates/coordinate_manager.hpp
@@ -4,15 +4,24 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
+#include <iterator>
 #include <map>
 #include <memory>
 #include <set>
+#include <utility>
 #include <vector>
 
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/xy_pair.hpp"
+
+namespace tt {
+enum class ARCH;
+}  // namespace tt
 
 namespace tt::umd {
 

--- a/device/api/umd/device/coordinates/coordinate_manager.hpp
+++ b/device/api/umd/device/coordinates/coordinate_manager.hpp
@@ -5,8 +5,8 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdint.h>
 
+#include <cstdint>
 #include <iterator>
 #include <map>
 #include <memory>

--- a/device/api/umd/device/coordinates/coordinate_manager.hpp
+++ b/device/api/umd/device/coordinates/coordinate_manager.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <iterator>
 #include <map>

--- a/device/api/umd/device/coordinates/wormhole_coordinate_manager.hpp
+++ b/device/api/umd/device/coordinates/wormhole_coordinate_manager.hpp
@@ -4,8 +4,17 @@
 
 #pragma once
 
+#include <stdint.h>
+
+#include <vector>
+
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/coordinates/coordinate_manager.hpp"
+#include "umd/device/types/xy_pair.hpp"
+
+namespace tt {
+struct HarvestingMasks;
+}  // namespace tt
 
 namespace tt::umd {
 

--- a/device/api/umd/device/coordinates/wormhole_coordinate_manager.hpp
+++ b/device/api/umd/device/coordinates/wormhole_coordinate_manager.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <vector>
 
 #include "umd/device/arch/wormhole_implementation.hpp"

--- a/device/api/umd/device/firmware/firmware_info_provider.hpp
+++ b/device/api/umd/device/firmware/firmware_info_provider.hpp
@@ -4,14 +4,21 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include <memory>
 #include <optional>
+#include <vector>
 
 #include "umd/device/firmware/firmware_telemetry_mapping.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/gddr_telemetry.hpp"
 #include "umd/device/utils/semver.hpp"
+
+namespace tt {
+enum class ARCH;
+}  // namespace tt
 
 namespace tt::umd {
 class TTDevice;

--- a/device/api/umd/device/firmware/firmware_info_provider.hpp
+++ b/device/api/umd/device/firmware/firmware_info_provider.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <vector>

--- a/device/api/umd/device/firmware/firmware_utils.hpp
+++ b/device/api/umd/device/firmware/firmware_utils.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <optional>
 
 #include "umd/device/tt_device/tt_device.hpp"

--- a/device/api/umd/device/firmware/firmware_utils.hpp
+++ b/device/api/umd/device/firmware/firmware_utils.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include <optional>
 
 #include "umd/device/tt_device/tt_device.hpp"
@@ -11,7 +13,13 @@
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/semver.hpp"
 
+namespace tt {
+enum class ARCH;
+}  // namespace tt
+
 namespace tt::umd {
+class TTDevice;
+
 FirmwareBundleVersion get_firmware_version_util(TTDevice* tt_device);
 
 SemVer get_tt_flash_version_from_telemetry(const uint32_t telemetry_data);

--- a/device/api/umd/device/jtag/jtag_device.hpp
+++ b/device/api/umd/device/jtag/jtag_device.hpp
@@ -8,10 +8,15 @@
 #include <filesystem>
 #include <memory>
 #include <optional>
+#include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "umd/device/jtag/jtag.hpp"
 #include "umd/device/types/arch.hpp"
+
+class Jtag;
 
 typedef enum { DEVICE_FAMILY_UNKNOWN, DEVICE_FAMILY_WORMHOLE, DEVICE_FAMILY_BLACKHOLE } DeviceFamily;
 

--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -8,11 +8,14 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <iterator>
 #include <map>
 #include <memory>
 #include <optional>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "umd/device/arch/architecture_implementation.hpp"
@@ -25,6 +28,7 @@
 #include "umd/device/utils/semver.hpp"
 
 namespace tt::umd {
+class architecture_implementation;
 
 struct PciDeviceInfo {
     uint16_t vendor_id;

--- a/device/api/umd/device/pcie/rtl_sim_tlb_handle.hpp
+++ b/device/api/umd/device/pcie/rtl_sim_tlb_handle.hpp
@@ -14,6 +14,7 @@
 namespace tt::umd {
 
 class SimulationTlbManager;
+enum TlbMapping : uint8_t;
 
 /**
  * RTL simulation TlbHandle that stores TLB configuration in software only.

--- a/device/api/umd/device/pcie/rtl_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/rtl_sim_tlb_window.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 

--- a/device/api/umd/device/pcie/rtl_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/rtl_sim_tlb_window.hpp
@@ -5,8 +5,8 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdint.h>
 
+#include <cstdint>
 #include <memory>
 
 #include "umd/device/pcie/tlb_window.hpp"

--- a/device/api/umd/device/pcie/rtl_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/rtl_sim_tlb_window.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include <memory>
 
 #include "umd/device/pcie/tlb_window.hpp"
@@ -11,6 +14,8 @@
 namespace tt::umd {
 
 class RtlSimCommunicator;
+class TlbHandle;
+struct tlb_data;
 
 /**
  * RTL simulation TlbWindow implementation that translates TLB-based memory access

--- a/device/api/umd/device/pcie/silicon_tlb_window.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_window.hpp
@@ -4,12 +4,18 @@
 
 #pragma once
 
+#include <stdint.h>
+
+#include <cstddef>
 #include <memory>
 
 #include "umd/device/pcie/tlb_handle.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
+#include "umd/device/types/tlb.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
+class TlbHandle;
 
 /**
  * Silicon TlbWindow implementation that performs direct memory access

--- a/device/api/umd/device/pcie/silicon_tlb_window.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_window.hpp
@@ -4,9 +4,8 @@
 
 #pragma once
 
-#include <stdint.h>
-
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 
 #include "umd/device/pcie/tlb_handle.hpp"

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -4,10 +4,14 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include <memory>
 
 #include "umd/device/pcie/tlb_handle.hpp"
 #include "umd/device/types/arch.hpp"
+#include "umd/device/types/tlb.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -5,8 +5,8 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdint.h>
 
+#include <cstdint>
 #include <memory>
 
 #include "umd/device/pcie/tlb_handle.hpp"

--- a/device/api/umd/device/pcie/tt_sim_tlb_handle.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_handle.hpp
@@ -15,6 +15,7 @@
 namespace tt::umd {
 
 class SimulationTlbManager;
+enum TlbMapping : uint8_t;
 
 /**
  * Simulation-specific TlbHandle that inherits from TlbHandle but bypasses hardware operations.

--- a/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 

--- a/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
@@ -5,8 +5,8 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdint.h>
 
+#include <cstdint>
 #include <memory>
 
 #include "umd/device/pcie/tlb_window.hpp"

--- a/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include <memory>
 
 #include "umd/device/pcie/tlb_window.hpp"
@@ -12,6 +15,8 @@ namespace tt::umd {
 
 // Forward declaration.
 class TTSimCommunicator;
+class TlbHandle;
+struct tlb_data;
 
 /**
  * Simulation TlbWindow implementation that uses TTSimCommunicator

--- a/device/api/umd/device/simulation/rtl_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/rtl_sim_communicator.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <stddef.h>
+
 #include <atomic>
 #include <condition_variable>
 #include <cstdint>

--- a/device/api/umd/device/simulation/rtl_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/rtl_sim_communicator.hpp
@@ -4,10 +4,9 @@
 
 #pragma once
 
-#include <stddef.h>
-
 #include <atomic>
 #include <condition_variable>
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <functional>

--- a/device/api/umd/device/simulation/rtl_simulation_chip.hpp
+++ b/device/api/umd/device/simulation/rtl_simulation_chip.hpp
@@ -4,14 +4,20 @@
 
 #pragma once
 
+#include <stddef.h>
+
 #include <cstdint>
 #include <filesystem>
 #include <memory>
 
+#include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
 #include "umd/device/simulation/simulation_chip.hpp"
 #include "umd/device/tt_device/rtl_simulation_tt_device.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
+class SocDescriptor;
 
 // RTL simulation implementation using subprocess and flatbuffer communication.
 class RtlSimulationChip : public SimulationChip {

--- a/device/api/umd/device/simulation/rtl_simulation_chip.hpp
+++ b/device/api/umd/device/simulation/rtl_simulation_chip.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <memory>

--- a/device/api/umd/device/simulation/simulation_chip.hpp
+++ b/device/api/umd/device/simulation/simulation_chip.hpp
@@ -4,16 +4,34 @@
 
 #pragma once
 
+#include <stddef.h>
+
+#include <chrono>
 #include <cstdint>
 #include <filesystem>
+#include <memory>
 #include <mutex>
+#include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "umd/device/chip/chip.hpp"
 #include "umd/device/cluster.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/cluster_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/lock_manager.hpp"
+#include "umd/device/utils/timeouts.hpp"
+
+namespace tt {
+enum class ARCH;
+}  // namespace tt
 
 namespace tt::umd {
+class ClusterDescriptor;
+class SocDescriptor;
+enum class TensixSoftResetOptions : std::uint32_t;
 
 // Base class for all simulation devices.
 class SimulationChip : public Chip {

--- a/device/api/umd/device/simulation/simulation_chip.hpp
+++ b/device/api/umd/device/simulation/simulation_chip.hpp
@@ -4,9 +4,8 @@
 
 #pragma once
 
-#include <stddef.h>
-
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <memory>

--- a/device/api/umd/device/simulation/simulation_host.hpp
+++ b/device/api/umd/device/simulation/simulation_host.hpp
@@ -4,9 +4,7 @@
 
 #pragma once
 
-#include <nng/nng.h>
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <vector>

--- a/device/api/umd/device/simulation/simulation_host.hpp
+++ b/device/api/umd/device/simulation/simulation_host.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <nng/nng.h>
+#include <stddef.h>
+
 #include <cstdint>
 #include <memory>
 #include <vector>

--- a/device/api/umd/device/simulation/tt_sim_chip.hpp
+++ b/device/api/umd/device/simulation/tt_sim_chip.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include <stddef.h>
 #include <sys/types.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <memory>

--- a/device/api/umd/device/simulation/tt_sim_chip.hpp
+++ b/device/api/umd/device/simulation/tt_sim_chip.hpp
@@ -4,15 +4,21 @@
 
 #pragma once
 
+#include <stddef.h>
 #include <sys/types.h>
 
 #include <cstdint>
 #include <filesystem>
+#include <memory>
 
+#include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
 #include "umd/device/simulation/simulation_chip.hpp"
 #include "umd/device/tt_device/tt_sim_tt_device.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
+class SocDescriptor;
 
 // TTSIM implementation using dynamic library (.so files).
 class TTSimChip : public SimulationChip {

--- a/device/api/umd/device/simulation/tt_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/tt_sim_communicator.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <sys/types.h>
+
 #include <cstdint>
 #include <filesystem>
 #include <functional>

--- a/device/api/umd/device/soc_arch_descriptor.hpp
+++ b/device/api/umd/device/soc_arch_descriptor.hpp
@@ -15,6 +15,10 @@
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
+namespace tt {
+enum class CoreType;
+}  // namespace tt
+
 namespace YAML {
 class Node;
 }

--- a/device/api/umd/device/soc_descriptor.hpp
+++ b/device/api/umd/device/soc_descriptor.hpp
@@ -10,10 +10,13 @@
 #include <cstdint>
 #include <filesystem>
 #include <iostream>
+#include <iterator>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "umd/device/coordinates/coordinate_manager.hpp"
@@ -21,8 +24,11 @@
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
+class CoordinateManager;
+class SocArchDescriptor;
 
 tt_xy_pair format_node(const std::string& str);
 

--- a/device/api/umd/device/soc_descriptor.hpp
+++ b/device/api/umd/device/soc_descriptor.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cstddef>
 #include <cstdint>

--- a/device/api/umd/device/topology/topology_discovery.hpp
+++ b/device/api/umd/device/topology/topology_discovery.hpp
@@ -31,8 +31,6 @@
 
 namespace tt::umd {
 
-class ClusterDescriptor;
-
 // TopologyDiscovery creates cluster descriptor after discovering all devices connected to the system.
 class TopologyDiscovery {
 public:

--- a/device/api/umd/device/topology/topology_discovery.hpp
+++ b/device/api/umd/device/topology/topology_discovery.hpp
@@ -4,9 +4,8 @@
 
 #pragma once
 
-#include <stdint.h>
-
 #include <chrono>
+#include <cstdint>
 #include <iterator>
 #include <map>
 #include <memory>

--- a/device/api/umd/device/topology/topology_discovery.hpp
+++ b/device/api/umd/device/topology/topology_discovery.hpp
@@ -4,9 +4,19 @@
 
 #pragma once
 
+#include <stdint.h>
+
+#include <chrono>
+#include <iterator>
+#include <map>
 #include <memory>
 #include <optional>
+#include <set>
+#include <string>
+#include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "umd/device/cluster_descriptor.hpp"
 #include "umd/device/soc_descriptor.hpp"
@@ -17,6 +27,7 @@
 #include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/semver.hpp"
+#include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
 

--- a/device/api/umd/device/topology/topology_discovery_blackhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_blackhole.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
 
 #include "umd/device/topology/topology_discovery.hpp"

--- a/device/api/umd/device/topology/topology_discovery_blackhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_blackhole.hpp
@@ -4,11 +4,18 @@
 
 #pragma once
 
+#include <stdint.h>
+
+#include <string>
+
 #include "umd/device/topology/topology_discovery.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
+enum class IODeviceType;
+struct TopologyDiscoveryOptions;
 
 class TopologyDiscoveryBlackhole : public TopologyDiscovery {
 public:

--- a/device/api/umd/device/topology/topology_discovery_wormhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_wormhole.hpp
@@ -4,12 +4,18 @@
 
 #pragma once
 
+#include <stdint.h>
+
+#include <string>
+
 #include "umd/device/topology/topology_discovery.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
+enum class IODeviceType;
+struct TopologyDiscoveryOptions;
 
 class TopologyDiscoveryWormhole : public TopologyDiscovery {
 public:

--- a/device/api/umd/device/topology/topology_discovery_wormhole.hpp
+++ b/device/api/umd/device/topology/topology_discovery_wormhole.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
 
 #include "umd/device/topology/topology_discovery.hpp"

--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -4,16 +4,24 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include <chrono>
+#include <memory>
 #include <mutex>
 #include <set>
 
 #include "umd/device/arc/blackhole_arc_telemetry_reader.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/blackhole_eth.hpp"
+#include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
+class JtagDevice;
+class PCIDevice;
+enum class IODeviceType;
 
 class BlackholeTTDevice : public TTDevice {
 public:

--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -4,9 +4,8 @@
 
 #pragma once
 
-#include <stddef.h>
-
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>

--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -5,9 +5,9 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdint.h>
 
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <set>

--- a/device/api/umd/device/tt_device/hang_detection/blackhole_hang_detector.hpp
+++ b/device/api/umd/device/tt_device/hang_detection/blackhole_hang_detector.hpp
@@ -5,9 +5,15 @@
  */
 #pragma once
 
+#include <stdint.h>
+
 #include "umd/device/tt_device/hang_detection/hang_detector.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
+class DeviceProtocol;
+class architecture_implementation;
+enum class NocId : uint8_t;
 
 // Blackhole variant: reads BAR and NOC node ID from the PCIe tile.
 // NOC1 hang detection requires knowing whether NOC translation is enabled,

--- a/device/api/umd/device/tt_device/hang_detection/blackhole_hang_detector.hpp
+++ b/device/api/umd/device/tt_device/hang_detection/blackhole_hang_detector.hpp
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "umd/device/tt_device/hang_detection/hang_detector.hpp"
 #include "umd/device/types/xy_pair.hpp"

--- a/device/api/umd/device/tt_device/hang_detection/hang_detector.hpp
+++ b/device/api/umd/device/tt_device/hang_detection/hang_detector.hpp
@@ -15,6 +15,7 @@ namespace tt::umd {
 
 class DeviceProtocol;
 class PcieInterface;
+enum class NocId : uint8_t;
 
 /**
  * HangDetector checks whether the device hardware is hung.

--- a/device/api/umd/device/tt_device/hang_detection/wormhole_hang_detector.hpp
+++ b/device/api/umd/device/tt_device/hang_detection/wormhole_hang_detector.hpp
@@ -5,9 +5,15 @@
  */
 #pragma once
 
+#include <stdint.h>
+
 #include "umd/device/tt_device/hang_detection/hang_detector.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
+class DeviceProtocol;
+class architecture_implementation;
+enum class NocId : uint8_t;
 
 // Wormhole variant: reads BAR and NOC node ID from the ARC tile.
 class WormholeHangDetector : public HangDetector {

--- a/device/api/umd/device/tt_device/hang_detection/wormhole_hang_detector.hpp
+++ b/device/api/umd/device/tt_device/hang_detection/wormhole_hang_detector.hpp
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "umd/device/tt_device/hang_detection/hang_detector.hpp"
 #include "umd/device/types/xy_pair.hpp"

--- a/device/api/umd/device/tt_device/protocol/jtag_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/jtag_protocol.hpp
@@ -6,8 +6,8 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdint.h>
 
+#include <cstdint>
 #include <memory>
 
 #include "umd/device/tt_device/protocol/device_protocol.hpp"

--- a/device/api/umd/device/tt_device/protocol/jtag_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/jtag_protocol.hpp
@@ -5,8 +5,7 @@
  */
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 

--- a/device/api/umd/device/tt_device/protocol/jtag_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/jtag_protocol.hpp
@@ -5,10 +5,14 @@
  */
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include <memory>
 
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/jtag_interface.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -5,6 +5,9 @@
  */
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -13,6 +16,11 @@
 #include "umd/device/tt_device/protocol/pcie_dma/dma_transfer.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
 #include "umd/device/types/arch.hpp"
+#include "umd/device/types/xy_pair.hpp"
+
+namespace tt {
+enum class ARCH;
+}  // namespace tt
 
 namespace tt::umd {
 

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -6,8 +6,8 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdint.h>
 
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <optional>

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -5,8 +5,7 @@
  */
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>

--- a/device/api/umd/device/tt_device/protocol/remote_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/remote_protocol.hpp
@@ -6,8 +6,8 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdint.h>
 
+#include <cstdint>
 #include <memory>
 
 #include "umd/device/tt_device/protocol/device_protocol.hpp"

--- a/device/api/umd/device/tt_device/protocol/remote_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/remote_protocol.hpp
@@ -5,10 +5,15 @@
  */
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include <memory>
 
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/remote_interface.hpp"
+#include "umd/device/tt_device/remote_communication.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 

--- a/device/api/umd/device/tt_device/protocol/remote_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/remote_protocol.hpp
@@ -5,8 +5,7 @@
  */
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 

--- a/device/api/umd/device/tt_device/remote_communication.hpp
+++ b/device/api/umd/device/tt_device/remote_communication.hpp
@@ -4,9 +4,8 @@
 
 #pragma once
 
-#include <stdint.h>
-
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <set>
 #include <unordered_set>

--- a/device/api/umd/device/tt_device/remote_communication.hpp
+++ b/device/api/umd/device/tt_device/remote_communication.hpp
@@ -4,15 +4,27 @@
 
 #pragma once
 
+#include <stdint.h>
+
+#include <chrono>
+#include <memory>
 #include <set>
 #include <unordered_set>
+#include <vector>
 
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/lock_manager.hpp"
 #include "umd/device/utils/timeouts.hpp"
+
+namespace tt {
+struct EthCoord;
+}  // namespace tt
 
 namespace tt::umd {
 
 class SysmemManager;
+class TTDevice;
 
 class RemoteCommunication {
 public:

--- a/device/api/umd/device/tt_device/remote_communication_legacy_firmware.hpp
+++ b/device/api/umd/device/tt_device/remote_communication_legacy_firmware.hpp
@@ -4,14 +4,22 @@
 
 #pragma once
 
+#include <stdint.h>
+
+#include <chrono>
 #include <set>
 #include <unordered_set>
+#include <vector>
 
 #include "umd/device/tt_device/remote_communication.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
 
 class SysmemManager;
+class TTDevice;
 
 class RemoteCommunicationLegacyFirmware : public RemoteCommunication {
 public:

--- a/device/api/umd/device/tt_device/remote_communication_legacy_firmware.hpp
+++ b/device/api/umd/device/tt_device/remote_communication_legacy_firmware.hpp
@@ -4,9 +4,8 @@
 
 #pragma once
 
-#include <stdint.h>
-
 #include <chrono>
+#include <cstdint>
 #include <set>
 #include <unordered_set>
 #include <vector>

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -4,7 +4,11 @@
 
 #pragma once
 
+#include <stddef.h>
+
+#include <chrono>
 #include <cstdint>
+#include <filesystem>
 #include <memory>
 #include <mutex>
 
@@ -13,11 +17,18 @@
 #include "umd/device/simulation/rtl_sim_communicator.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/tensix_soft_reset_options.hpp"
+#include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
 
 class RtlSimCommunicator;
+class SimulationSysmemManager;
+class SimulationTlbManager;
+class SocDescriptor;
+class TlbWindow;
 
 class RtlSimulationTTDevice : public TTDevice {
 public:

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -4,9 +4,8 @@
 
 #pragma once
 
-#include <stddef.h>
-
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <memory>

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -4,11 +4,17 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <memory>
+#include <optional>
+#include <string>
 #include <string_view>
+#include <utility>
 
 #include "tt_device_error.hpp"
 #include "umd/device/arc/arc_messenger.hpp"
@@ -25,13 +31,16 @@
 #include "umd/device/tt_device/protocol/jtag_interface.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
 #include "umd/device/tt_device/protocol/remote_interface.hpp"
+#include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/risc_type.hpp"
 #include "umd/device/types/tensix_soft_reset_options.hpp"
+#include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/lock_manager.hpp"
+#include "umd/device/utils/semver.hpp"
 #include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
@@ -40,6 +49,16 @@ class ArcMessenger;
 class ArcTelemetryReader;
 class RemoteCommunication;
 class SimulationSysmemManager;
+class JtagDevice;
+class JtagInterface;
+class PCIDevice;
+class PcieInterface;
+class RemoteInterface;
+class TLBManager;
+enum class NocId : uint8_t;
+enum class RiscType : std::uint64_t;
+enum class TensixSoftResetOptions : std::uint32_t;
+struct CoreCoord;
 
 // Represents the status of the ETH core.
 enum class EthTrainingStatus {

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -4,10 +4,9 @@
 
 #pragma once
 
-#include <stddef.h>
-
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <memory>

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -9,6 +9,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <filesystem>
 #include <memory>
 #include <optional>

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdint.h>
 
 #include <atomic>
 #include <chrono>

--- a/device/api/umd/device/tt_device/tt_device_error.hpp
+++ b/device/api/umd/device/tt_device/tt_device_error.hpp
@@ -12,6 +12,7 @@
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/noc_id.hpp"
+#include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -4,9 +4,8 @@
 
 #pragma once
 
-#include <stddef.h>
-
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <memory>

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -4,21 +4,32 @@
 
 #pragma once
 
+#include <stddef.h>
+
+#include <chrono>
 #include <cstdint>
+#include <filesystem>
 #include <memory>
 #include <mutex>
 
 #include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
+#include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/simulation/simulation_host.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/tensix_soft_reset_options.hpp"
+#include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
 
 class TTSimCommunicator;
+class SimulationSysmemManager;
+class SimulationTlbManager;
+class SocDescriptor;
 
 class TTSimTTDevice : public TTDevice {
 public:

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <stddef.h>
+
 #include <chrono>
 #include <cstdint>
 #include <memory>
@@ -12,8 +14,14 @@
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
+class JtagDevice;
+class PCIDevice;
+class RemoteCommunication;
+enum class IODeviceType;
+
 class WormholeTTDevice : public TTDevice {
 public:
     void configure_iatu_region(size_t region, uint64_t target, size_t region_size) override;

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -4,9 +4,8 @@
 
 #pragma once
 
-#include <stddef.h>
-
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>

--- a/device/api/umd/device/types/arch.hpp
+++ b/device/api/umd/device/types/arch.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <fmt/core.h>
 #include <fmt/format.h>
 
 #include <algorithm>

--- a/device/api/umd/device/types/cluster_descriptor_types.hpp
+++ b/device/api/umd/device/types/cluster_descriptor_types.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <fmt/core.h>
 #include <fmt/format.h>
 
 #include <cstdint>

--- a/device/api/umd/device/types/cluster_types.hpp
+++ b/device/api/umd/device/types/cluster_types.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cassert>
 #include <optional>

--- a/device/api/umd/device/types/risc_type.hpp
+++ b/device/api/umd/device/types/risc_type.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <fmt/core.h>
 #include <fmt/format.h>
 
 #include <cstdint>

--- a/device/api/umd/device/types/xy_pair.hpp
+++ b/device/api/umd/device/types/xy_pair.hpp
@@ -6,7 +6,10 @@
 
 #include <string>
 // TODO: To be removed once this is fixed in tt_metal.
+#include <cstddef>
 #include <deque>
+#include <functional>
+#include <string_view>
 
 // Types in this file can be used without using the driver, hence they aren't in tt::umd namespace.
 namespace tt {

--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "umd/device/types/communication_protocol.hpp"

--- a/device/api/umd/device/utils/robust_mutex.hpp
+++ b/device/api/umd/device/utils/robust_mutex.hpp
@@ -5,10 +5,10 @@
 #pragma once
 
 #include <pthread.h>
-#include <stddef.h>
 #include <sys/types.h>
 
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <string>

--- a/device/api/umd/device/utils/robust_mutex.hpp
+++ b/device/api/umd/device/utils/robust_mutex.hpp
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <pthread.h>
+#include <stddef.h>
+#include <sys/types.h>
 
 #include <chrono>
 #include <cstdint>

--- a/device/arc/arc_messenger.cpp
+++ b/device/arc/arc_messenger.cpp
@@ -7,13 +7,15 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
-#include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "umd/device/arc/blackhole_arc_messenger.hpp"
 #include "umd/device/arc/wormhole_arc_messenger.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
-#include "umd/device/utils/common.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/arc/arc_telemetry_reader.cpp
+++ b/device/arc/arc_telemetry_reader.cpp
@@ -4,11 +4,10 @@
 
 #include "umd/device/arc/arc_telemetry_reader.hpp"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
-#include <cstdint>
 #include <memory>
-#include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "tt-logger/tt-logger.hpp"
@@ -16,7 +15,10 @@
 #include "umd/device/arc/smbus_arc_telemetry_reader.hpp"
 #include "umd/device/arc/wormhole_arc_telemetry_reader.hpp"
 #include "umd/device/firmware/firmware_utils.hpp"
-#include "umd/device/types/wormhole_telemetry.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "umd/device/utils/semver.hpp"
 
 namespace tt::umd {

--- a/device/arc/blackhole_arc_message_queue.cpp
+++ b/device/arc/blackhole_arc_message_queue.cpp
@@ -4,18 +4,28 @@
 
 #include "umd/device/arc/blackhole_arc_message_queue.hpp"
 
+#include <fmt/format.h>
+
 #include <array>
 #include <chrono>
-#include <cstddef>
-#include <cstdint>
 #include <cstdlib>
 #include <memory>
-#include <stdexcept>
+#include <optional>
+#include <string>
 #include <vector>
 
 #include "noc_access.hpp"
+#include "umd/device/arch/blackhole_implementation.hpp"
+#include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/communication_protocol.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "utils.hpp"
+
+namespace tt::umd::blackhole {
+enum class ArcMessageType : uint8_t;
+}  // namespace tt::umd::blackhole
 
 namespace tt::umd {
 

--- a/device/arc/blackhole_arc_messenger.cpp
+++ b/device/arc/blackhole_arc_messenger.cpp
@@ -7,11 +7,12 @@
 #include <fmt/ranges.h>
 
 #include <chrono>
-#include <cstdint>
 #include <tt-logger/tt-logger.hpp>
-#include <vector>
 
+#include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/blackhole_arc.hpp"
+#include "umd/device/utils/lock_manager.hpp"
 
 namespace tt::umd {
 

--- a/device/arc/blackhole_arc_telemetry_reader.cpp
+++ b/device/arc/blackhole_arc_telemetry_reader.cpp
@@ -4,13 +4,11 @@
 
 #include "umd/device/arc/blackhole_arc_telemetry_reader.hpp"
 
-#include <fmt/core.h>
-
 #include <cstdint>
 
 #include "noc_access.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
-#include "umd/device/types/telemetry.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
 
 namespace tt::umd {
 

--- a/device/arc/blackhole_spi_tt_device.cpp
+++ b/device/arc/blackhole_spi_tt_device.cpp
@@ -8,16 +8,16 @@
 
 #include <algorithm>
 #include <chrono>
-#include <stdexcept>
 #include <thread>
 #include <tt-logger/tt-logger.hpp>
-#include <utility>
 #include <vector>
 
 #include "umd/device/arc/arc_messenger.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/blackhole_arc.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "umd/device/utils/semver.hpp"
 
 namespace tt::umd {

--- a/device/arc/smbus_arc_telemetry_reader.cpp
+++ b/device/arc/smbus_arc_telemetry_reader.cpp
@@ -4,13 +4,19 @@
 
 #include "umd/device/arc/smbus_arc_telemetry_reader.hpp"
 
-#include <cstdint>
-#include <stdexcept>
+#include <fmt/format.h>
+
+#include <string>
 #include <vector>
 
 #include "noc_access.hpp"
+#include "umd/device/arc/arc_messenger.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/wormhole_telemetry.hpp"
+#include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/arc/spi_tt_device.cpp
+++ b/device/arc/spi_tt_device.cpp
@@ -6,12 +6,14 @@
 #include <fmt/format.h>
 
 #include <memory>
-#include <stdexcept>
+#include <string>
 
 #include "umd/device/arc/blackhole_spi_tt_device.hpp"
 #include "umd/device/arc/wormhole_spi_tt_device.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/arc/wormhole_arc_messenger.cpp
+++ b/device/arc/wormhole_arc_messenger.cpp
@@ -4,18 +4,20 @@
 
 #include "umd/device/arc/wormhole_arc_messenger.hpp"
 
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 
 #include <chrono>
-#include <cstdint>
-#include <stdexcept>
+#include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <vector>
 
-#include "assert.hpp"
-#include "noc_access.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
+#include "umd/device/utils/lock_manager.hpp"
 #include "utils.hpp"
 
 namespace tt::umd {

--- a/device/arc/wormhole_arc_messenger.cpp
+++ b/device/arc/wormhole_arc_messenger.cpp
@@ -128,7 +128,7 @@ uint32_t WormholeArcMessenger::send_message(
             fmt::format(
                 "Timed out after waiting {} ms for ARC to respond. Message code 0x{:x} with arguments 0x{:x} and "
                 "0x{:x}",
-                timeout_ms,
+                timeout_ms.count(),
                 msg_code,
                 arg0,
                 arg1));

--- a/device/arc/wormhole_arc_telemetry_reader.cpp
+++ b/device/arc/wormhole_arc_telemetry_reader.cpp
@@ -5,10 +5,12 @@
 #include "umd/device/arc/wormhole_arc_telemetry_reader.hpp"
 
 #include <cstdint>
+#include <vector>
 
 #include "noc_access.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
-#include "umd/device/types/telemetry.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 

--- a/device/arc/wormhole_spi_tt_device.cpp
+++ b/device/arc/wormhole_spi_tt_device.cpp
@@ -6,12 +6,13 @@
 
 #include "umd/device/arc/wormhole_spi_tt_device.hpp"
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <cmath>
-#include <cstdint>
 #include <cstring>
 #include <exception>
-#include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "umd/device/arc/arc_messenger.hpp"
@@ -19,6 +20,8 @@
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/telemetry.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "umd/device/utils/semver.hpp"
 
 namespace tt::umd {

--- a/device/arch/blackhole_implementation.cpp
+++ b/device/arch/blackhole_implementation.cpp
@@ -7,15 +7,14 @@
 #include <fmt/format.h>
 
 #include <cstdint>
-#include <stdexcept>
-#include <tt-logger/tt-logger.hpp>
 #include <tuple>
 
 #include "blackhole/eth_interface.h"
 #include "blackhole/eth_l1_address_map.h"
 #include "blackhole/host_mem_address_map.h"
 #include "blackhole/l1_address_map.h"
-#include "umd/device/cluster.hpp"
+#include "umd/device/types/cluster_types.hpp"
+#include "umd/device/types/risc_type.hpp"
 #include "umd/device/utils/error.hpp"
 
 constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h, common for WH && BH

--- a/device/arch/grendel_implementation.cpp
+++ b/device/arch/grendel_implementation.cpp
@@ -4,16 +4,17 @@
 
 #include "umd/device/arch/grendel_implementation.hpp"
 
+#include <fmt/format.h>
+
 #include <cstdint>
-#include <stdexcept>
-#include <tt-logger/tt-logger.hpp>
 #include <tuple>
 
 #include "blackhole/eth_interface.h"
 #include "blackhole/eth_l1_address_map.h"
 #include "blackhole/host_mem_address_map.h"
 #include "blackhole/l1_address_map.h"
-#include "umd/device/cluster.hpp"
+#include "umd/device/types/cluster_types.hpp"
+#include "umd/device/types/risc_type.hpp"
 #include "umd/device/utils/error.hpp"
 
 constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h, common for WH && BH

--- a/device/arch/wormhole_implementation.cpp
+++ b/device/arch/wormhole_implementation.cpp
@@ -7,13 +7,14 @@
 #include <fmt/format.h>
 
 #include <cstdint>
-#include <stdexcept>
+#include <string>
 #include <tuple>
 
-#include "assert.hpp"
-#include "umd/device/cluster.hpp"
+#include "umd/device/types/cluster_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/risc_type.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "wormhole/eth_interface.h"
 #include "wormhole/eth_l1_address_map.h"
 #include "wormhole/host_mem_address_map.h"

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -8,26 +8,29 @@
 
 #include <algorithm>
 #include <chrono>
-#include <cstddef>
 #include <cstdint>
-#include <stdexcept>
+#include <memory>
+#include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <utility>
 #include <vector>
 
 #include "assert.hpp"
-#include "noc_access.hpp"
 #include "tracy.hpp"
+#include "umd/device/arc/arc_messenger.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
-#include "umd/device/driver_atomics.hpp"
-#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
 #include "umd/device/types/blackhole_arc.hpp"
-#include "umd/device/types/tensix_soft_reset_options.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
+enum class TensixSoftResetOptions : std::uint32_t;
 
 Chip::Chip(SocDescriptor soc_descriptor) : soc_descriptor_(std::move(soc_descriptor)) {
     set_default_params(soc_descriptor_.arch);

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -4,15 +4,15 @@
 
 #include "umd/device/chip/local_chip.hpp"
 
-#include <cstddef>
+#include <fmt/format.h>
+
 #include <cstdint>
 #include <memory>
 #include <mutex>
-#include <set>
-#include <stdexcept>
 #include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <type_traits>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -20,13 +20,24 @@
 #include "assert.hpp"
 #include "noc_access.hpp"
 #include "tracy.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/chip_helpers/silicon_sysmem_manager.hpp"
+#include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/driver_atomics.hpp"
+#include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_types.hpp"
+#include "umd/device/types/risc_type.hpp"
+#include "umd/device/types/tlb.hpp"
+#include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -5,13 +5,11 @@
 #include "umd/device/chip/mock_chip.hpp"
 
 #include <chrono>
-#include <cstddef>
 #include <cstdint>
-#include <set>
 #include <type_traits>
-#include <unordered_set>
 #include <utility>
-#include <vector>
+
+#include "umd/device/soc_descriptor.hpp"
 
 namespace tt::umd {
 

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -4,23 +4,26 @@
 
 #include "umd/device/chip/remote_chip.hpp"
 
-#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <set>
-#include <stdexcept>
 #include <string>
-#include <tt-logger/tt-logger.hpp>
 #include <type_traits>
-#include <unordered_set>
 #include <utility>
 
-#include "assert.hpp"
 #include "tracy.hpp"
-#include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/chip/local_chip.hpp"
+#include "umd/device/chip_helpers/sysmem_manager.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/cluster_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/risc_type.hpp"
+#include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -6,7 +6,6 @@
 
 #include "umd/device/chip_helpers/silicon_sysmem_manager.hpp"
 
-#include <bits/mman-map-flags-generic.h>
 #include <fmt/format.h>
 #include <linux/mman.h>  // for MAP_HUGE_1GB, MAP_HUGE_2MB
 #include <sys/mman.h>    // for mmap, munmap

--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -6,27 +6,38 @@
 
 #include "umd/device/chip_helpers/silicon_sysmem_manager.hpp"
 
+#include <bits/mman-map-flags-generic.h>
+#include <fmt/format.h>
 #include <linux/mman.h>  // for MAP_HUGE_1GB, MAP_HUGE_2MB
 #include <sys/mman.h>    // for mmap, munmap
 #include <sys/stat.h>    // for fstat
+#include <unistd.h>
 
 #include <cerrno>
 #include <cstddef>
-#include <cstdint>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <memory>
-#include <ostream>
+#include <optional>
 #include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <tuple>
+#include <vector>
 
 #include "assert.hpp"
 #include "cpuset_lib.hpp"
 #include "hugepage.hpp"
 #include "tracy.hpp"
+#include "umd/device/chip_helpers/sysmem_buffer.hpp"
+#include "umd/device/chip_helpers/tlb_manager.hpp"
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_types.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -4,21 +4,23 @@
 
 #include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
 
+#include <fmt/format.h>
 #include <sys/mman.h>  // for mmap, munmap
-#include <sys/stat.h>  // for fstat
 
-#include <cstddef>
-#include <cstdint>
-#include <filesystem>
-#include <fstream>
-#include <iostream>
 #include <memory>
-#include <tt-logger/tt-logger.hpp>
+#include <string>
+#include <vector>
 
 #include "assert.hpp"
-#include "cpuset_lib.hpp"
-#include "hugepage.hpp"
 #include "tracy.hpp"
+#include "umd/device/chip_helpers/sysmem_buffer.hpp"
+#include "umd/device/types/cluster_types.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
+
+namespace tt {
+enum class ARCH;
+}  // namespace tt
 
 namespace tt::umd {
 

--- a/device/chip_helpers/simulation_tlb_manager.cpp
+++ b/device/chip_helpers/simulation_tlb_manager.cpp
@@ -4,22 +4,22 @@
 
 #include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
 
-#include <cstddef>
-#include <cstdint>
-#include <exception>
+#include <fmt/format.h>
+
 #include <memory>
-#include <stdexcept>
+#include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <utility>
 #include <vector>
 
-#include "assert.hpp"
-#include "umd/device/arch/blackhole_implementation.hpp"
-#include "umd/device/arch/wormhole_implementation.hpp"
-#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/types/arch.hpp"
 #include "umd/device/types/tlb.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
+class TTDevice;
 
 SimulationTlbManager::SimulationTlbManager(
     TTDevice* tt_device, uint64_t bar0_base, const architecture_implementation* arch_impl, TlbWindowFactory factory) :

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -5,20 +5,28 @@
 #include "umd/device/chip_helpers/sysmem_buffer.hpp"
 
 #include <fmt/format.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <tuple>
 
 #include "noc_access.hpp"
 #include "tracy.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/chip_helpers/tlb_manager.hpp"
+#include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
+#include "umd/device/pcie/tlb_handle.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/tlb.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/chip_helpers/sysmem_manager.cpp
+++ b/device/chip_helpers/sysmem_manager.cpp
@@ -4,20 +4,13 @@
 
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 
-#include <sys/mman.h>  // for mmap, munmap
-#include <sys/stat.h>  // for fstat
-
-#include <cstddef>
-#include <cstdint>
 #include <cstring>
-#include <filesystem>
-#include <fstream>
 #include <tt-logger/tt-logger.hpp>
 
 #include "assert.hpp"
-#include "cpuset_lib.hpp"
-#include "hugepage.hpp"
 #include "tracy.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
 
 namespace tt::umd {
 

--- a/device/chip_helpers/tlb_manager.cpp
+++ b/device/chip_helpers/tlb_manager.cpp
@@ -4,20 +4,26 @@
 
 #include "umd/device/chip_helpers/tlb_manager.hpp"
 
-#include <cstddef>
+#include <fmt/format.h>
+
 #include <cstdint>
 #include <exception>
 #include <memory>
-#include <stdexcept>
+#include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <utility>
 #include <vector>
 
 #include "assert.hpp"
 #include "noc_access.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
+#include "umd/device/pcie/tlb_handle.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/tlb.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -4,37 +4,20 @@
 
 #include "api/umd/device/cluster.hpp"
 
-#include <dirent.h>
 #include <fmt/format.h>
-#include <fmt/ranges.h>  // Needed to format vectors
-#include <sys/mman.h>
-#include <yaml-cpp/yaml.h>
 
 #include <algorithm>
-#include <cassert>
-#include <cerrno>
 #include <chrono>
-#include <cstdarg>
 #include <cstddef>
 #include <cstdint>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
 #include <filesystem>
-#include <fstream>
-#include <iomanip>
-#include <iterator>
-#include <limits>
+#include <initializer_list>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <optional>
-#include <ratio>
-#include <regex>
 #include <set>
 #include <stdexcept>
 #include <string>
-#include <thread>
 #include <tt-logger/tt-logger.hpp>
 #include <tuple>
 #include <type_traits>
@@ -43,44 +26,35 @@
 #include <utility>
 #include <vector>
 
-#include "api/umd/device/types/core_coordinates.hpp"
 #include "assert.hpp"
 #include "hugepage.hpp"
 #include "tracy.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
-#include "umd/device/arch/blackhole_implementation.hpp"
-#include "umd/device/arch/grendel_implementation.hpp"
-#include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/chip/local_chip.hpp"
 #include "umd/device/chip/mock_chip.hpp"
 #include "umd/device/chip/remote_chip.hpp"
-#include "umd/device/chip/sw_emule_chip.hpp"
+#include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
-#include "umd/device/driver_atomics.hpp"
-#include "umd/device/firmware/erisc_firmware.hpp"
+#include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/simulation/simulation_chip.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/topology/topology_discovery.hpp"
-#include "umd/device/topology/topology_discovery_blackhole.hpp"
 #include "umd/device/topology/topology_discovery_options.hpp"
-#include "umd/device/topology/topology_discovery_wormhole.hpp"
-#include "umd/device/topology/topology_utils.hpp"
 #include "umd/device/types/arch.hpp"
-#include "umd/device/types/blackhole_eth.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/cluster_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/tensix_soft_reset_options.hpp"
 #include "umd/device/types/tlb.hpp"
 #include "umd/device/types/xy_pair.hpp"
-#include "umd/device/utils/common.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "umd/device/utils/semver.hpp"
-#include "utils.hpp"
 
 namespace tt::umd {
+class TlbWindow;
 
 struct routing_cmd_t {
     uint64_t sys_addr;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -5,6 +5,7 @@
 #include "api/umd/device/cluster.hpp"
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include <algorithm>
 #include <chrono>

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -5,7 +5,15 @@
 #include "umd/device/cluster_descriptor.hpp"
 
 #include <fmt/format.h>
-#include <yaml-cpp/yaml.h>
+#include <yaml-cpp/emitter.h>
+#include <yaml-cpp/emittermanip.h>
+#include <yaml-cpp/node/detail/impl.h>
+#include <yaml-cpp/node/detail/iterator.h>
+#include <yaml-cpp/node/detail/iterator_fwd.h>
+#include <yaml-cpp/node/impl.h>
+#include <yaml-cpp/node/iterator.h>
+#include <yaml-cpp/node/node.h>
+#include <yaml-cpp/node/parse.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -13,12 +21,10 @@
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
-#include <limits>
 #include <map>
 #include <memory>
 #include <set>
 #include <sstream>
-#include <stdexcept>
 #include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <tuple>
@@ -27,14 +33,14 @@
 #include <utility>
 #include <vector>
 
-#include "api/umd/device/arch/blackhole_implementation.hpp"
-#include "api/umd/device/arch/grendel_implementation.hpp"
-#include "api/umd/device/arch/wormhole_implementation.hpp"
 #include "api/umd/device/types/cluster_descriptor_types.hpp"
 #include "assert.hpp"
 #include "common/utils.hpp"
 #include "disjoint_set.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/coordinates/coordinate_manager.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "umd/device/utils/semver.hpp"
 
 namespace tt::umd {

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -5,15 +5,7 @@
 #include "umd/device/cluster_descriptor.hpp"
 
 #include <fmt/format.h>
-#include <yaml-cpp/emitter.h>
-#include <yaml-cpp/emittermanip.h>
-#include <yaml-cpp/node/detail/impl.h>
-#include <yaml-cpp/node/detail/iterator.h>
-#include <yaml-cpp/node/detail/iterator_fwd.h>
-#include <yaml-cpp/node/impl.h>
-#include <yaml-cpp/node/iterator.h>
-#include <yaml-cpp/node/node.h>
-#include <yaml-cpp/node/parse.h>
+#include <yaml-cpp/yaml.h>
 
 #include <algorithm>
 #include <cstddef>

--- a/device/common/assert.hpp
+++ b/device/common/assert.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <spdlog/spdlog.h>
 #include <stdlib.h>

--- a/device/coordinates/blackhole_coordinate_manager.cpp
+++ b/device/coordinates/blackhole_coordinate_manager.cpp
@@ -5,13 +5,16 @@
 #include "umd/device/coordinates/blackhole_coordinate_manager.hpp"
 
 #include <algorithm>
-#include <cstddef>
-#include <cstdint>
-#include <stdexcept>
+#include <iterator>
+#include <map>
 #include <string>
-#include <tt-logger/tt-logger.hpp>
 #include <utility>
 #include <vector>
+
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/coordinates/coordinate_manager.cpp
+++ b/device/coordinates/coordinate_manager.cpp
@@ -4,19 +4,21 @@
 
 #include "api/umd/device/coordinates/coordinate_manager.hpp"
 
+#include <fmt/format.h>
+
 #include <algorithm>
-#include <cstddef>
-#include <cstdint>
 #include <memory>
-#include <stdexcept>
 #include <string>
-#include <tt-logger/tt-logger.hpp>
 #include <vector>
 
+#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/blackhole_implementation.hpp"
+#include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/coordinates/blackhole_coordinate_manager.hpp"
 #include "umd/device/coordinates/coordinate_manager.hpp"
 #include "umd/device/coordinates/wormhole_coordinate_manager.hpp"
 #include "umd/device/types/arch.hpp"
+#include "umd/device/utils/common.hpp"
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/error_detail.hpp"
 

--- a/device/coordinates/wormhole_coordinate_manager.cpp
+++ b/device/coordinates/wormhole_coordinate_manager.cpp
@@ -5,8 +5,12 @@
 #include "umd/device/coordinates/wormhole_coordinate_manager.hpp"
 
 #include <cstddef>
-#include <cstdint>
+#include <map>
 #include <vector>
+
+#include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 
 namespace tt::umd {
 

--- a/device/cpuset_lib.cpp
+++ b/device/cpuset_lib.cpp
@@ -4,7 +4,6 @@
 
 #include "cpuset_lib.hpp"
 
-#include <fmt/base.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <fmt/std.h>

--- a/device/cpuset_lib.cpp
+++ b/device/cpuset_lib.cpp
@@ -5,13 +5,10 @@
 #include "cpuset_lib.hpp"
 
 #include <fmt/format.h>
-#include <fmt/ranges.h>  // Needed to format vectors
-#include <fmt/std.h>     // Needed to format thread_id
+#include <unistd.h>
 
 #include <algorithm>
 #include <cerrno>
-#include <cstddef>
-#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -23,8 +20,6 @@
 #include <tt-logger/tt-logger.hpp>
 #include <utility>
 #include <vector>
-
-#include "umd/device/cluster.hpp"
 
 namespace tt::cpuset {
 

--- a/device/cpuset_lib.cpp
+++ b/device/cpuset_lib.cpp
@@ -4,7 +4,10 @@
 
 #include "cpuset_lib.hpp"
 
+#include <fmt/base.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <fmt/std.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -380,12 +383,12 @@ bool cpuset_allocator::init_determine_cpuset_allocations() {
             log_debug(
                 LogUMD,
                 "Done init_determine_cpuset_allocations(). Summary => for mmio physical_device_id: {} package_id: {} "
-                "device_alloc_idx: {} picked {} PU's {}",
+                "device_alloc_idx: {} picked {} PU's [{}]",
                 physical_device_id,
                 package_id,
                 device_alloc_idx,
                 num_pu_ids,
-                pu_ids_vector);
+                fmt::join(pu_ids_vector, ", "));
         }
     }
 

--- a/device/cpuset_lib.hpp
+++ b/device/cpuset_lib.hpp
@@ -6,10 +6,10 @@
 
 #include <hwloc.h>
 #include <hwloc/bitmap.h>
-#include <stddef.h>
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <iterator>
 #include <map>

--- a/device/cpuset_lib.hpp
+++ b/device/cpuset_lib.hpp
@@ -5,12 +5,19 @@
 #pragma once
 
 #include <hwloc.h>
+#include <hwloc/bitmap.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
 #include <unistd.h>
 
+#include <iterator>
 #include <map>
 #include <mutex>
+#include <ostream>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "umd/device/types/cluster_descriptor_types.hpp"  // For ChipId

--- a/device/cpuset_lib.hpp
+++ b/device/cpuset_lib.hpp
@@ -7,10 +7,10 @@
 #include <hwloc.h>
 #include <hwloc/bitmap.h>
 #include <stddef.h>
-#include <stdint.h>
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <cstdint>
 #include <iterator>
 #include <map>
 #include <mutex>

--- a/device/firmware/firmware_info_provider.cpp
+++ b/device/firmware/firmware_info_provider.cpp
@@ -4,14 +4,15 @@
 
 #include "umd/device/firmware/firmware_info_provider.hpp"
 
-#include <fmt/format.h>
-
-#include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <variant>
 #include <vector>
 
-#include "assert.hpp"
 #include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/arc/smbus_arc_telemetry_reader.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
@@ -24,6 +25,7 @@
 #include "umd/device/types/wormhole_dram.hpp"
 #include "umd/device/types/wormhole_telemetry.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "umd/device/utils/semver.hpp"
 
 namespace tt::umd {

--- a/device/firmware/firmware_utils.cpp
+++ b/device/firmware/firmware_utils.cpp
@@ -5,28 +5,21 @@
 #include "umd/device/firmware/firmware_utils.hpp"
 
 #include <chrono>
-#include <cstddef>
-#include <cstdint>
-#include <iterator>
 #include <memory>
-#include <optional>
-#include <stdexcept>
 #include <string>
 #include <thread>
 #include <tt-logger/tt-logger.hpp>
-#include <unordered_map>
-#include <utility>
-#include <vector>
 
+#include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/arc/smbus_arc_telemetry_reader.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
-#include "umd/device/arch/wormhole_implementation.hpp"
-#include "umd/device/firmware/erisc_firmware.hpp"
-#include "umd/device/firmware/firmware_info_provider.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/telemetry.hpp"
 #include "umd/device/types/wormhole_eth.hpp"
 #include "umd/device/types/wormhole_telemetry.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "umd/device/utils/semver.hpp"
 
 namespace tt::umd {

--- a/device/hugepage.cpp
+++ b/device/hugepage.cpp
@@ -4,8 +4,10 @@
 
 #include "hugepage.hpp"
 
-#include <fcntl.h>     // for O_RDWR and other constants
+#include <fcntl.h>  // for O_RDWR and other constants
+#include <fmt/format.h>
 #include <sys/stat.h>  // for umask
+#include <unistd.h>
 
 #include <algorithm>
 #include <cerrno>
@@ -13,6 +15,7 @@
 #include <cstdint>
 #include <cstring>
 #include <fstream>
+#include <iterator>
 #include <regex>
 #include <string>
 #include <tt-logger/tt-logger.hpp>
@@ -21,6 +24,7 @@
 #include "assert.hpp"
 #include "cpuset_lib.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/hugepage.hpp
+++ b/device/hugepage.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 

--- a/device/jtag/jtag.cpp
+++ b/device/jtag/jtag.cpp
@@ -4,17 +4,18 @@
 
 #include "umd/device/jtag/jtag.hpp"
 
+#include <fmt/format.h>
+
 #include <cstdint>
 #include <filesystem>
 #include <iostream>
-#include <stdexcept>
 #include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <unordered_map>
 #include <vector>
 
-#include "assert.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 using namespace tt::umd;
 

--- a/device/jtag/jtag_device.cpp
+++ b/device/jtag/jtag_device.cpp
@@ -5,11 +5,11 @@
 #include "umd/device/jtag/jtag_device.hpp"
 
 #include <fmt/format.h>
-#include <limits.h>
 #include <sys/types.h>
 #include <unistd.h>
 
 #include <algorithm>
+#include <climits>
 #include <cstdint>
 #include <cstring>
 #include <filesystem>

--- a/device/jtag/jtag_device.cpp
+++ b/device/jtag/jtag_device.cpp
@@ -4,6 +4,11 @@
 
 #include "umd/device/jtag/jtag_device.hpp"
 
+#include <fmt/format.h>
+#include <limits.h>
+#include <sys/types.h>
+#include <unistd.h>
+
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
@@ -16,10 +21,9 @@
 #include <utility>
 #include <vector>
 
-#include "assert.hpp"
 #include "umd/device/jtag/jtag.hpp"
-#include "umd/device/utils/common.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "utils.hpp"
 
 constexpr uint32_t WORMHOLE_ARC_EFUSE_BOX1 = 0x80042000;

--- a/device/logging/config.cpp
+++ b/device/logging/config.cpp
@@ -13,6 +13,8 @@
 
 #include "umd/device/logging/config.hpp"
 
+#include <spdlog/common.h>
+
 #include <tt-logger/tt-logger.hpp>
 
 namespace tt::umd::logging {

--- a/device/noc_access.cpp
+++ b/device/noc_access.cpp
@@ -4,6 +4,8 @@
 
 #include "noc_access.hpp"
 
+#include "umd/device/types/noc_id.hpp"
+
 namespace tt::umd {
 
 // NocId that is stored for current thread in TLS.

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -4,28 +4,27 @@
 
 #include "umd/device/pcie/pci_device.hpp"
 
-#include <fcntl.h>      // for ::open
-#include <linux/pci.h>  // for PCI_SLOT, PCI_FUNC
+#include <fcntl.h>  // for ::open
+#include <fmt/format.h>
 #include <sys/ioctl.h>  // for ioctl
 #include <sys/mman.h>   // for mmap, munmap
 #include <unistd.h>     // for ::close
 
-#include <cctype>
 #include <cerrno>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>  // for memcpy
 #include <exception>
 #include <filesystem>
 #include <fstream>
-#include <ios>
 #include <map>
 #include <memory>
 #include <optional>
 #include <set>
 #include <sstream>
-#include <stdexcept>
 #include <string>
 #include <tt-logger/tt-logger.hpp>
+#include <type_traits>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -34,9 +33,12 @@
 #include "ioctl.h"
 #include "tracy.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/pcie/pci_ids.h"
+#include "umd/device/pcie/silicon_tlb_handle.hpp"
 #include "umd/device/tt_kmd_lib/tt_kmd_lib.h"
 #include "umd/device/types/arch.hpp"
-#include "umd/device/utils/common.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "umd/device/utils/kmd_versions.hpp"
 #include "utils.hpp"
 

--- a/device/pcie/rtl_sim_tlb_handle.cpp
+++ b/device/pcie/rtl_sim_tlb_handle.cpp
@@ -10,6 +10,7 @@
 #include <tt-logger/tt-logger.hpp>
 
 #include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
+#include "umd/device/types/tlb.hpp"
 
 namespace tt::umd {
 

--- a/device/pcie/rtl_sim_tlb_window.cpp
+++ b/device/pcie/rtl_sim_tlb_window.cpp
@@ -4,13 +4,14 @@
 
 #include "umd/device/pcie/rtl_sim_tlb_window.hpp"
 
-#include <cstddef>
-#include <cstdint>
+#include <utility>
 
 #include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
 #include "umd/device/pcie/rtl_sim_tlb_handle.hpp"
+#include "umd/device/pcie/tlb_handle.hpp"
 #include "umd/device/simulation/rtl_sim_communicator.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/tlb.hpp"
 
 namespace tt::umd {
 

--- a/device/pcie/silicon_tlb_handle.cpp
+++ b/device/pcie/silicon_tlb_handle.cpp
@@ -4,18 +4,15 @@
 
 #include "umd/device/pcie/silicon_tlb_handle.hpp"
 
-#include <sys/ioctl.h>
-#include <sys/mman.h>
+#include <fmt/format.h>
 
 #include <cstddef>
 #include <cstdint>
-#include <stdexcept>
-#include <tt-logger/tt-logger.hpp>
+#include <string>
 
-#include "assert.hpp"
-#include "ioctl.h"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -4,7 +4,6 @@
 
 #include "umd/device/pcie/silicon_tlb_window.hpp"
 
-#include <stdio.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -13,6 +12,7 @@
 #include <csignal>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <functional>
 #include <memory>

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -4,6 +4,7 @@
 
 #include "umd/device/pcie/silicon_tlb_window.hpp"
 
+#include <stdio.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -15,8 +16,12 @@
 #include <cstring>
 #include <functional>
 #include <memory>
+#include <string>
+#include <utility>
 
 #include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/pcie/tlb_handle.hpp"
+#include "umd/device/types/arch.hpp"
 #include "umd/device/utils/error.hpp"
 
 namespace tt::umd {

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -2,17 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "umd/device/pcie/tlb_window.hpp"
+
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <utility>
 
 #include "noc_access.hpp"
-#include "umd/device/pcie/pci_device.hpp"
-#include "umd/device/pcie/silicon_tlb_window.hpp"
+#include "umd/device/pcie/tlb_handle.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/tlb.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -5,8 +5,6 @@
 #include "umd/device/pcie/tlb_window.hpp"
 
 #include <algorithm>
-#include <cstddef>
-#include <cstdint>
 #include <memory>
 #include <stdexcept>
 #include <utility>

--- a/device/pcie/tt_sim_tlb_handle.cpp
+++ b/device/pcie/tt_sim_tlb_handle.cpp
@@ -9,16 +9,17 @@
 #include <cstring>
 #include <memory>
 #include <tt-logger/tt-logger.hpp>
+#include <utility>
 
+#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/tlb.hpp"
 
 namespace tt::umd {
-
-// Forward declaration to avoid circular dependency.
-class SimulationTlbManager;
 
 TTSimTlbHandle::TTSimTlbHandle(
     SimulationTlbManager* manager,

--- a/device/pcie/tt_sim_tlb_window.cpp
+++ b/device/pcie/tt_sim_tlb_window.cpp
@@ -4,15 +4,15 @@
 
 #include "umd/device/pcie/tt_sim_tlb_window.hpp"
 
-#include <cstddef>
-#include <cstdint>
-#include <cstring>
 #include <memory>
+#include <utility>
 
 #include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
+#include "umd/device/pcie/tlb_handle.hpp"
 #include "umd/device/pcie/tt_sim_tlb_handle.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/tlb.hpp"
 
 namespace tt::umd {
 

--- a/device/simulation/rtl_sim_communicator.cpp
+++ b/device/simulation/rtl_sim_communicator.cpp
@@ -4,16 +4,25 @@
 
 #include "umd/device/simulation/rtl_sim_communicator.hpp"
 
+#include <flatbuffers/buffer.h>
+#include <flatbuffers/flatbuffer_builder.h>
+#include <flatbuffers/vector.h>
+#include <fmt/format.h>
 #include <nng/nng.h>
 #include <uv.h>
 
 #include <cstring>
+#include <exception>
+#include <string>
 #include <tt-logger/tt-logger.hpp>
+#include <utility>
 #include <vector>
 
 #include "assert.hpp"
 #include "simulation_device_generated.h"
+#include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/simulation/rtl_simulation_chip.cpp
+++ b/device/simulation/rtl_simulation_chip.cpp
@@ -4,12 +4,13 @@
 
 #include "umd/device/simulation/rtl_simulation_chip.hpp"
 
-#include <iostream>
-#include <string>
+#include <mutex>
 #include <tt-logger/tt-logger.hpp>
+#include <type_traits>
 
-#include "assert.hpp"
 #include "tracy.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 
 namespace tt::umd {
 

--- a/device/simulation/simulation_chip.cpp
+++ b/device/simulation/simulation_chip.cpp
@@ -6,14 +6,17 @@
 
 #include <fmt/format.h>
 
-#include <stdexcept>
 #include <tt-logger/tt-logger.hpp>
 
 #include "assert.hpp"
+#include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/simulation/rtl_simulation_chip.hpp"
 #include "umd/device/simulation/tt_sim_chip.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/arch.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/simulation/simulation_host.cpp
+++ b/device/simulation/simulation_host.cpp
@@ -4,21 +4,19 @@
 
 #include "umd/device/simulation/simulation_host.hpp"
 
+#include <arpa/inet.h>
 #include <netinet/in.h>
 #include <nng/nng.h>
 #include <nng/protocol/pair1/pair.h>
 #include <sys/socket.h>
-#include <sys/types.h>
 #include <unistd.h>
 
-#include <cassert>
 #include <cstdlib>
-#include <filesystem>
-#include <iomanip>
+#include <cstring>
 #include <random>
 #include <sstream>
+#include <string>
 #include <tt-logger/tt-logger.hpp>
-#include <typeinfo>
 
 #include "assert.hpp"
 

--- a/device/simulation/tt_sim_chip.cpp
+++ b/device/simulation/tt_sim_chip.cpp
@@ -4,23 +4,13 @@
 
 #include "umd/device/simulation/tt_sim_chip.hpp"
 
-#include <dlfcn.h>
-#include <fcntl.h>
-#include <fmt/format.h>
-#include <sys/mman.h>
-#include <sys/sendfile.h>
-#include <sys/stat.h>
-#include <unistd.h>
-
-#include <cerrno>
-#include <cstring>
 #include <filesystem>
-#include <iostream>
 #include <mutex>
-#include <tt-logger/tt-logger.hpp>
+#include <type_traits>
 
-#include "assert.hpp"
 #include "tracy.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 
 namespace tt::umd {
 

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -14,10 +14,12 @@
 
 #include <cerrno>
 #include <cstring>
+#include <string>
 #include <tt-logger/tt-logger.hpp>
+#include <utility>
 
-#include "assert.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 // NOLINTBEGIN.
 #define DLSYM_FUNCTION(func_name)                                                                           \

--- a/device/soc_arch_descriptor.cpp
+++ b/device/soc_arch_descriptor.cpp
@@ -4,8 +4,13 @@
 
 #include "umd/device/soc_arch_descriptor.hpp"
 
-#include <fmt/core.h>
-#include <yaml-cpp/yaml.h>
+#include <fmt/format.h>
+#include <yaml-cpp/node/detail/impl.h>
+#include <yaml-cpp/node/detail/iterator.h>
+#include <yaml-cpp/node/impl.h>
+#include <yaml-cpp/node/iterator.h>
+#include <yaml-cpp/node/node.h>
+#include <yaml-cpp/node/parse.h>
 
 #include <fstream>
 #include <set>
@@ -18,6 +23,7 @@
 #include "umd/device/arch/grendel_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 
 namespace tt::umd {
 

--- a/device/soc_arch_descriptor.cpp
+++ b/device/soc_arch_descriptor.cpp
@@ -5,12 +5,7 @@
 #include "umd/device/soc_arch_descriptor.hpp"
 
 #include <fmt/format.h>
-#include <yaml-cpp/node/detail/impl.h>
-#include <yaml-cpp/node/detail/iterator.h>
-#include <yaml-cpp/node/impl.h>
-#include <yaml-cpp/node/iterator.h>
-#include <yaml-cpp/node/node.h>
-#include <yaml-cpp/node/parse.h>
+#include <yaml-cpp/yaml.h>
 
 #include <fstream>
 #include <set>

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -4,14 +4,16 @@
 
 #include "umd/device/soc_descriptor.hpp"
 
-#include <fmt/core.h>
-#include <yaml-cpp/yaml.h>
+#include <fmt/format.h>
+#include <yaml-cpp/emitter.h>
+#include <yaml-cpp/emittermanip.h>
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
-#include <iostream>
+#include <initializer_list>
 #include <optional>
 #include <set>
 #include <stdexcept>
@@ -23,12 +25,12 @@
 
 #include "assert.hpp"
 #include "noc_access.hpp"
-#include "umd/device/arc/blackhole_arc_telemetry_reader.hpp"
+#include "umd/device/coordinates/coordinate_manager.hpp"
 #include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error.hpp"
-#include "utils.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -5,8 +5,7 @@
 #include "umd/device/soc_descriptor.hpp"
 
 #include <fmt/format.h>
-#include <yaml-cpp/emitter.h>
-#include <yaml-cpp/emittermanip.h>
+#include <yaml-cpp/yaml.h>
 
 #include <cstddef>
 #include <cstdint>

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -6,28 +6,27 @@
 
 #include <fmt/format.h>
 
-#include <algorithm>
 #include <chrono>
-#include <cstdint>
 #include <map>
 #include <memory>
 #include <numeric>
 #include <optional>
 #include <set>
-#include <stdexcept>
 #include <string>
 #include <thread>
 #include <tt-logger/tt-logger.hpp>
+#include <tuple>
 #include <utility>
 #include <vector>
 
 #include "api/umd/device/topology/topology_discovery_blackhole.hpp"
 #include "api/umd/device/topology/topology_discovery_wormhole.hpp"
-#include "assert.hpp"
-#include "noc_access.hpp"
 #include "tracy.hpp"
 #include "umd/device/cluster_descriptor.hpp"
 #include "umd/device/firmware/firmware_info_provider.hpp"
+#include "umd/device/jtag/jtag_device.hpp"
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/soc_descriptor.hpp"
 #include "umd/device/topology/topology_discovery.hpp"
 #include "umd/device/topology/topology_discovery_options.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
@@ -35,6 +34,7 @@
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/utils/error.hpp"
 #include "umd/device/utils/error_detail.hpp"
 #include "umd/device/utils/semver.hpp"
 #include "umd/device/utils/timeouts.hpp"

--- a/device/topology/topology_discovery_blackhole.cpp
+++ b/device/topology/topology_discovery_blackhole.cpp
@@ -5,7 +5,6 @@
 #include "umd/device/topology/topology_discovery_blackhole.hpp"
 
 #include <cstddef>
-#include <iterator>
 #include <memory>
 #include <optional>
 #include <set>

--- a/device/topology/topology_discovery_blackhole.cpp
+++ b/device/topology/topology_discovery_blackhole.cpp
@@ -4,28 +4,36 @@
 
 #include "umd/device/topology/topology_discovery_blackhole.hpp"
 
-#include <cstdint>
+#include <stddef.h>
+
+#include <iterator>
 #include <memory>
 #include <optional>
 #include <set>
-#include <stdexcept>
 #include <tt-logger/tt-logger.hpp>
 #include <utility>
+#include <vector>
 
-#include "noc_access.hpp"
+#include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
-#include "umd/device/cluster_descriptor.hpp"
 #include "umd/device/firmware/erisc_firmware.hpp"
+#include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/firmware/firmware_utils.hpp"
+#include "umd/device/soc_descriptor.hpp"
 #include "umd/device/topology/topology_discovery.hpp"
-#include "umd/device/tt_device/blackhole_tt_device.hpp"
-#include "umd/device/tt_device/remote_communication.hpp"
+#include "umd/device/topology/topology_discovery_options.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/blackhole_eth.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/telemetry.hpp"
 #include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "umd/device/utils/semver.hpp"
 
 namespace tt::umd {
+enum class IODeviceType;
 
 TopologyDiscoveryBlackhole::TopologyDiscoveryBlackhole(
     const TopologyDiscoveryOptions& options, IODeviceType io_device_type, const std::string& soc_descriptor_path) :

--- a/device/topology/topology_discovery_blackhole.cpp
+++ b/device/topology/topology_discovery_blackhole.cpp
@@ -4,8 +4,7 @@
 
 #include "umd/device/topology/topology_discovery_blackhole.hpp"
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <iterator>
 #include <memory>
 #include <optional>

--- a/device/topology/topology_discovery_wormhole.cpp
+++ b/device/topology/topology_discovery_wormhole.cpp
@@ -6,28 +6,33 @@
 
 #include <fmt/format.h>
 
-#include <cstdint>
+#include <map>
 #include <memory>
 #include <optional>
 #include <set>
-#include <stdexcept>
 #include <tt-logger/tt-logger.hpp>
 #include <utility>
+#include <vector>
 
-#include "assert.hpp"
 #include "noc_access.hpp"
 #include "umd/device/firmware/erisc_firmware.hpp"
+#include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/firmware/firmware_utils.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/topology/topology_discovery_options.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/tt_device/wormhole_tt_device.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/wormhole_eth.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "umd/device/utils/semver.hpp"
-#include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
+enum class IODeviceType;
 
 TopologyDiscoveryWormhole::TopologyDiscoveryWormhole(
     const TopologyDiscoveryOptions& options, IODeviceType io_device_type, const std::string& soc_descriptor_path) :

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -5,28 +5,33 @@
 #include "umd/device/tt_device/blackhole_tt_device.hpp"
 
 #include <fmt/format.h>
-#include <fmt/ranges.h>
 #include <sys/mman.h>  // for MAP_FAILED
 
 #include <chrono>
-#include <cstddef>
-#include <cstdint>
-#include <cstring>
 #include <memory>
-#include <stdexcept>
+#include <optional>
+#include <string>
 #include <thread>
 #include <tt-logger/tt-logger.hpp>
 #include <utility>
+#include <vector>
 
 #include "noc_access.hpp"
-#include "umd/device/arc/blackhole_spi_tt_device.hpp"
+#include "umd/device/arc/arc_messenger.hpp"
+#include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/coordinates/coordinate_manager.hpp"
+#include "umd/device/jtag/jtag_device.hpp"
+#include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/tt_device/hang_detection/blackhole_hang_detector.hpp"
+#include "umd/device/tt_device/hang_detection/hang_detector.hpp"
+#include "umd/device/tt_device/tt_device_error.hpp"
+#include "umd/device/types/arch.hpp"
 #include "umd/device/types/blackhole_arc.hpp"
 #include "umd/device/types/blackhole_eth.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/telemetry.hpp"
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/error_detail.hpp"

--- a/device/tt_device/hang_detection/blackhole_hang_detector.cpp
+++ b/device/tt_device/hang_detection/blackhole_hang_detector.cpp
@@ -6,10 +6,14 @@
 
 #include "umd/device/tt_device/hang_detection/blackhole_hang_detector.hpp"
 
-#include "noc_access.hpp"
+#include <vector>
+
+#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/noc_id.hpp"
 
 namespace tt::umd {
 

--- a/device/tt_device/hang_detection/hang_detector.cpp
+++ b/device/tt_device/hang_detection/hang_detector.cpp
@@ -9,6 +9,7 @@
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
 #include "umd/device/tt_device/protocol/remote_interface.hpp"
+#include "umd/device/types/noc_id.hpp"
 
 namespace tt::umd {
 

--- a/device/tt_device/hang_detection/wormhole_hang_detector.cpp
+++ b/device/tt_device/hang_detection/wormhole_hang_detector.cpp
@@ -6,10 +6,14 @@
 
 #include "umd/device/tt_device/hang_detection/wormhole_hang_detector.hpp"
 
-#include "noc_access.hpp"
+#include <vector>
+
+#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/noc_id.hpp"
 
 namespace tt::umd {
 

--- a/device/tt_device/protocol/jtag_protocol.cpp
+++ b/device/tt_device/protocol/jtag_protocol.cpp
@@ -6,6 +6,8 @@
 
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
 
+#include <utility>
+
 #include "noc_access.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
 

--- a/device/tt_device/protocol/pcie_dma/blackhole_dma_transfer.cpp
+++ b/device/tt_device/protocol/pcie_dma/blackhole_dma_transfer.cpp
@@ -7,10 +7,11 @@
 #include "umd/device/tt_device/protocol/pcie_dma/blackhole_dma_transfer.hpp"
 
 #include <chrono>
-#include <stdexcept>
+#include <string>
 
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/tt_device/protocol/pcie_dma/wormhole_dma_transfer.cpp
+++ b/device/tt_device/protocol/pcie_dma/wormhole_dma_transfer.cpp
@@ -7,10 +7,11 @@
 #include "umd/device/tt_device/protocol/pcie_dma/wormhole_dma_transfer.hpp"
 
 #include <chrono>
-#include <stdexcept>
+#include <string>
 
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -9,15 +9,23 @@
 #include <algorithm>
 #include <cstring>
 #include <mutex>
-#include <stdexcept>
+#include <string>
 #include <tt-logger/tt-logger.hpp>
+#include <utility>
 #include <variant>
 
 #include "noc_access.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
+#include "umd/device/pcie/tlb_handle.hpp"
+#include "umd/device/pcie/tlb_window.hpp"
+#include "umd/device/tt_device/protocol/pcie_dma/blackhole_dma_transfer.hpp"
+#include "umd/device/tt_device/protocol/pcie_dma/wormhole_dma_transfer.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/tlb.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/tt_device/protocol/remote_protocol.cpp
+++ b/device/tt_device/protocol/remote_protocol.cpp
@@ -6,7 +6,10 @@
 
 #include "umd/device/tt_device/protocol/remote_protocol.hpp"
 
+#include <utility>
+
 #include "umd/device/tt_device/remote_communication.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
 
 namespace tt::umd {
 

--- a/device/tt_device/remote_communication.cpp
+++ b/device/tt_device/remote_communication.cpp
@@ -5,16 +5,16 @@
 #include "umd/device/tt_device/remote_communication.hpp"
 
 #include <memory>
-#include <stdexcept>
+#include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <unordered_set>
 
-#include "assert.hpp"
-#include "umd/device/chip/local_chip.hpp"
-#include "umd/device/driver_atomics.hpp"
-#include "umd/device/topology/topology_utils.hpp"
 #include "umd/device/tt_device/remote_communication_legacy_firmware.hpp"
-#include "umd/device/utils/common.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "umd/device/utils/lock_manager.hpp"
 
 namespace tt::umd {

--- a/device/tt_device/remote_communication_legacy_firmware.cpp
+++ b/device/tt_device/remote_communication_legacy_firmware.cpp
@@ -8,15 +8,19 @@
 #include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <vector>
 
 #include "assert.hpp"
 #include "noc_access.hpp"
-#include "umd/device/chip/local_chip.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/driver_atomics.hpp"
 #include "umd/device/topology/topology_utils.hpp"
-#include "umd/device/utils/common.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_types.hpp"
 #include "umd/device/utils/lock_manager.hpp"
 #include "utils.hpp"
 

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -4,17 +4,29 @@
 
 #include "umd/device/tt_device/rtl_simulation_tt_device.hpp"
 
-#include <fmt/format.h>
-
 #include <array>
 #include <filesystem>
+#include <string>
 #include <tt-logger/tt-logger.hpp>
+#include <type_traits>
+#include <utility>
 
 #include "assert.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
+#include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
 #include "umd/device/pcie/rtl_sim_tlb_handle.hpp"
 #include "umd/device/pcie/rtl_sim_tlb_window.hpp"
+#include "umd/device/pcie/tlb_window.hpp"
+#include "umd/device/simulation/rtl_sim_communicator.hpp"
 #include "umd/device/simulation/simulation_chip.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/risc_type.hpp"
+#include "umd/device/types/tensix_soft_reset_options.hpp"
+#include "umd/device/types/tlb.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -6,21 +6,20 @@
 
 #include <fmt/format.h>
 
-#include <algorithm>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>
-#include <stdexcept>
+#include <thread>
 #include <tt-logger/tt-logger.hpp>
 #include <utility>
 #include <vector>
 
-#include "assert.hpp"
 #include "noc_access.hpp"
 #include "tracy.hpp"
 #include "umd/device/arc/arc_messenger.hpp"
+#include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/driver_atomics.hpp"
 #include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
@@ -28,22 +27,28 @@
 #include "umd/device/pcie/silicon_tlb_window.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/blackhole_tt_device.hpp"
+#include "umd/device/tt_device/protocol/jtag_interface.hpp"
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
+#include "umd/device/tt_device/protocol/pcie_interface.hpp"
 #include "umd/device/tt_device/protocol/pcie_protocol.hpp"
+#include "umd/device/tt_device/protocol/remote_interface.hpp"
 #include "umd/device/tt_device/protocol/remote_protocol.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
+#include "umd/device/tt_device/tt_device_error.hpp"
 #include "umd/device/tt_device/wormhole_tt_device.hpp"
 #include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/noc_id.hpp"
-#include "umd/device/types/telemetry.hpp"
+#include "umd/device/types/tensix_soft_reset_options.hpp"
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/error_detail.hpp"
 #include "umd/device/utils/lock_manager.hpp"
+#include "umd/device/utils/robust_mutex.hpp"
 #include "umd/device/utils/semver.hpp"
 #include "utils.hpp"
 
 namespace tt::umd {
+enum class RiscType : std::uint64_t;
 
 /* static */ void TTDevice::set_sigbus_safe_handler(bool set_safe_handler) {
     SiliconTlbWindow::set_sigbus_safe_handler(set_safe_handler);

--- a/device/tt_device/tt_device_error.cpp
+++ b/device/tt_device/tt_device_error.cpp
@@ -6,6 +6,9 @@
 
 #include <fmt/format.h>
 
+#include <string>
+#include <unordered_map>
+
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/noc_id.hpp"

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -4,18 +4,31 @@
 
 #include "umd/device/tt_device/tt_sim_tt_device.hpp"
 
-#include <fmt/format.h>
-
+#include <algorithm>
 #include <filesystem>
+#include <functional>
+#include <string>
 #include <tt-logger/tt-logger.hpp>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 #include "assert.hpp"
-#include "simulation_device_generated.h"
+#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
+#include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
 #include "umd/device/pcie/pci_ids.h"
 #include "umd/device/pcie/tt_sim_tlb_handle.hpp"
 #include "umd/device/pcie/tt_sim_tlb_window.hpp"
 #include "umd/device/simulation/simulation_chip.hpp"
+#include "umd/device/simulation/tt_sim_communicator.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/tensix_soft_reset_options.hpp"
+#include "umd/device/types/tlb.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -4,27 +4,34 @@
 
 #include "umd/device/tt_device/wormhole_tt_device.hpp"
 
+#include <fmt/format.h>
+
 #include <chrono>
-#include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <memory>
-#include <mutex>
-#include <stdexcept>
+#include <optional>
+#include <string>
 #include <thread>
 #include <tt-logger/tt-logger.hpp>
 #include <utility>
 #include <vector>
 
 #include "noc_access.hpp"
+#include "umd/device/arc/arc_messenger.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/coordinates/coordinate_manager.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/tt_device/hang_detection/hang_detector.hpp"
 #include "umd/device/tt_device/hang_detection/wormhole_hang_detector.hpp"
+#include "umd/device/tt_device/protocol/remote_interface.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
+#include "umd/device/tt_device/tt_device_error.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/wormhole_eth.hpp"
-#include "umd/device/types/wormhole_telemetry.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/error_detail.hpp"

--- a/device/tt_kmd_lib/tt_kmd_lib.c
+++ b/device/tt_kmd_lib/tt_kmd_lib.c
@@ -6,16 +6,16 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <linux/mman.h>
-#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include "pcie/ioctl.h"
+#include "umd/device/pcie/pci_ids.h"
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define DEBUG(fmt, ...)                                                        \

--- a/device/types/tensix_soft_reset_options.cpp
+++ b/device/types/tensix_soft_reset_options.cpp
@@ -7,9 +7,6 @@
 #include <cstdint>
 #include <string>
 
-#include "umd/device/cluster.hpp"
-#include "umd/device/types/xy_pair.hpp"
-
 namespace tt::umd {
 
 std::string TensixSoftResetOptionsToString(TensixSoftResetOptions value) {

--- a/device/types/tlb.cpp
+++ b/device/types/tlb.cpp
@@ -5,10 +5,11 @@
 #include "umd/device/types/tlb.hpp"
 
 #include <cstdint>
-#include <stdexcept>
+#include <string>
 #include <utility>
 
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/utils/lock_manager.cpp
+++ b/device/utils/lock_manager.cpp
@@ -5,12 +5,12 @@
 #include "umd/device/utils/lock_manager.hpp"
 
 #include <mutex>
-#include <stdexcept>
 #include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <unordered_map>
 
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 namespace tt::umd {
 

--- a/device/utils/robust_mutex.cpp
+++ b/device/utils/robust_mutex.cpp
@@ -4,7 +4,8 @@
 
 #include "umd/device/utils/robust_mutex.hpp"
 
-#include <fcntl.h>        // O_RDWR, O_CREATE
+#include <fcntl.h>  // O_RDWR, O_CREATE
+#include <fmt/format.h>
 #include <pthread.h>      // pthread_mutexattr_init, pthread_mutexattr_setpshared, pthread_mutex_t
 #include <sys/file.h>     // flock
 #include <sys/mman.h>     // shm_open, shm_unlink, mmap, munmap,
@@ -16,18 +17,14 @@
 #include <chrono>
 #include <cstdint>
 #include <ctime>  // clock_gettime, timespec
-#include <functional>
-#include <mutex>
 #include <optional>
-#include <stdexcept>
 #include <string>
-#include <thread>
 #include <tt-logger/tt-logger.hpp>
-#include <unordered_map>
 #include <utility>
 
 #include "assert.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 
 // TSAN (ThreadSanitizer) annotations for cross-process mutex synchronization.
 // These are only available when building with TSAN enabled.

--- a/device/warm_reset.cpp
+++ b/device/warm_reset.cpp
@@ -10,27 +10,7 @@
 #include <unistd.h>
 
 #include <algorithm>
-#include <asio/associated_cancellation_slot.hpp>
-#include <asio/async_result.hpp>
-#include <asio/basic_stream_socket.hpp>
-#include <asio/basic_waitable_timer.hpp>
-#include <asio/buffer.hpp>
-#include <asio/detail/handler_cont_helpers.hpp>
-#include <asio/detail/impl/epoll_reactor.hpp>
-#include <asio/detail/impl/reactive_socket_service_base.ipp>
-#include <asio/detail/impl/scheduler.ipp>
-#include <asio/detail/impl/service_registry.hpp>
-#include <asio/execution/context_as.hpp>
-#include <asio/execution/prefer_only.hpp>
-#include <asio/impl/any_io_executor.ipp>
-#include <asio/impl/io_context.hpp>
-#include <asio/impl/io_context.ipp>
-#include <asio/impl/write.hpp>
-#include <asio/io_context.hpp>
-#include <asio/local/detail/impl/endpoint.ipp>
-#include <asio/local/stream_protocol.hpp>
-#include <asio/socket_base.hpp>
-#include <asio/steady_timer.hpp>
+#include <asio.hpp>
 #include <atomic>
 #include <cerrno>
 #include <charconv>  // for std::from_chars

--- a/device/warm_reset.cpp
+++ b/device/warm_reset.cpp
@@ -4,11 +4,33 @@
 
 #include "api/umd/device/warm_reset.hpp"
 
-#include <fmt/color.h>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <glob.h>
+#include <unistd.h>
 
 #include <algorithm>
-#include <asio.hpp>
+#include <asio/associated_cancellation_slot.hpp>
+#include <asio/async_result.hpp>
+#include <asio/basic_stream_socket.hpp>
+#include <asio/basic_waitable_timer.hpp>
+#include <asio/buffer.hpp>
+#include <asio/detail/handler_cont_helpers.hpp>
+#include <asio/detail/impl/epoll_reactor.hpp>
+#include <asio/detail/impl/reactive_socket_service_base.ipp>
+#include <asio/detail/impl/scheduler.ipp>
+#include <asio/detail/impl/service_registry.hpp>
+#include <asio/execution/context_as.hpp>
+#include <asio/execution/prefer_only.hpp>
+#include <asio/impl/any_io_executor.ipp>
+#include <asio/impl/io_context.hpp>
+#include <asio/impl/io_context.ipp>
+#include <asio/impl/write.hpp>
+#include <asio/io_context.hpp>
+#include <asio/local/detail/impl/endpoint.ipp>
+#include <asio/local/stream_protocol.hpp>
+#include <asio/socket_base.hpp>
+#include <asio/steady_timer.hpp>
 #include <atomic>
 #include <cerrno>
 #include <charconv>  // for std::from_chars
@@ -21,6 +43,8 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
+#include <new>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -31,13 +55,12 @@
 #include <utility>
 #include <vector>
 
-#include "api/umd/device/arch/blackhole_implementation.hpp"
-#include "api/umd/device/arch/grendel_implementation.hpp"
 #include "api/umd/device/arch/wormhole_implementation.hpp"
 #include "api/umd/device/pcie/pci_device.hpp"
+#include "umd/device/arc/arc_messenger.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/tt_device_error.hpp"
 #include "umd/device/types/arch.hpp"
-#include "umd/device/utils/error.hpp"
 #include "umd/device/utils/timeouts.hpp"
 #include "utils.hpp"
 

--- a/device/warm_reset.cpp
+++ b/device/warm_reset.cpp
@@ -24,7 +24,6 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <new>
 #include <optional>
 #include <string>
 #include <string_view>

--- a/src/firmware/riscv/blackhole/eth_interface.h
+++ b/src/firmware/riscv/blackhole/eth_interface.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 const uint32_t NOC_SIZE_X = 10;
 const uint32_t NOC_SIZE_Y = 12;

--- a/src/firmware/riscv/blackhole/eth_l1_address_map.h
+++ b/src/firmware/riscv/blackhole/eth_l1_address_map.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <cstddef>
-#include <stdint.h>
+#include <cstdint>
 
 namespace eth_l1_mem {
 

--- a/src/firmware/riscv/blackhole/host_mem_address_map.h
+++ b/src/firmware/riscv/blackhole/host_mem_address_map.h
@@ -4,7 +4,6 @@
 
 #pragma once
 #include <cstdint>
-#include <stdint.h>
 
 // Remove inline ASAP.
 inline namespace blackhole {

--- a/src/firmware/riscv/blackhole/l1_address_map.h
+++ b/src/firmware/riscv/blackhole/l1_address_map.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 // Aux variable used to align addresses to platform specific width. BH requires 64B alignment.
 #define NOC_ADDRESS_ALIGNMENT (64)

--- a/src/firmware/riscv/wormhole/eth_interface.h
+++ b/src/firmware/riscv/wormhole/eth_interface.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 const uint32_t NOC_SIZE_X = 10;
 const uint32_t NOC_SIZE_Y = 12;

--- a/src/firmware/riscv/wormhole/eth_l1_address_map.h
+++ b/src/firmware/riscv/wormhole/eth_l1_address_map.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace eth_l1_mem {
 

--- a/src/firmware/riscv/wormhole/host_mem_address_map.h
+++ b/src/firmware/riscv/wormhole/host_mem_address_map.h
@@ -3,10 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include <cstdint>
 #include <stdint.h>
 
-// Remove inline ASAP.
 inline namespace wormhole {
 
 namespace host_mem {

--- a/tests/api/test_arc_telemetry.cpp
+++ b/tests/api/test_arc_telemetry.cpp
@@ -6,13 +6,20 @@
 
 #include <cstdint>
 #include <memory>
+#include <set>
+#include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <vector>
 
 #include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/chip/remote_chip.hpp"
 #include "umd/device/cluster.hpp"
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/tt_device/remote_communication.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/telemetry.hpp"
+#include "umd/device/utils/semver.hpp"
 
 using namespace tt;
 using namespace tt::umd;

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -4,21 +4,22 @@
 
 // This file holds Chip specific API examples.
 
-#include <fmt/xchar.h>
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <cstdint>
-#include <filesystem>
 #include <memory>
+#include <set>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
-#include "tests/test_utils/fetch_local_files.hpp"
-#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 
 using namespace tt;
 using namespace tt::umd;

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -6,28 +6,34 @@
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <cstdint>
-#include <cstdlib>
-#include <cstring>
-#include <filesystem>
+#include <iostream>
+#include <map>
 #include <memory>
 #include <optional>
-#include <random>
+#include <set>
 #include <string>
-#include <unordered_set>
+#include <utility>
 #include <vector>
 
-#include "test_utils/setup_risc_cores.hpp"
-#include "tests/test_utils/device_test_utils.hpp"
-#include "tests/test_utils/test_api_common.hpp"
 #include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/cluster.hpp"
+#include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/topology/topology_discovery.hpp"
+#include "umd/device/topology/topology_discovery_options.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/cluster_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/telemetry.hpp"
-#include "utils.hpp"
+#include "umd/device/utils/semver.hpp"
 
+using namespace tt;
 using namespace tt::umd;
 
 // These tests are intended to be run with the same code on all kinds of systems:

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -5,25 +5,31 @@
 #include <gtest/gtest.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <memory>
-#include <ostream>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
-#include "disjoint_set.hpp"
-#include "tests/test_utils/fetch_local_files.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
 #include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/soc_descriptor.hpp"
 #include "umd/device/topology/topology_discovery.hpp"
+#include "umd/device/topology/topology_discovery_options.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 
 using namespace tt;
 using namespace tt::umd;

--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -4,12 +4,8 @@
 
 // This file holds Cluster specific API examples.
 
-#include <fmt/format.h>
-#include <fmt/xchar.h>
 #include <gtest/gtest.h>
 
-#include <algorithm>
-#include <array>
 #include <cstdint>
 #include <cstdlib>  // for std::getenv
 #include <cstring>
@@ -18,23 +14,25 @@
 #include <memory>
 #include <optional>
 #include <random>
+#include <set>
 #include <sstream>
-#include <stdexcept>
 #include <string>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "test_utils/setup_risc_cores.hpp"
 #include "tests/test_utils/device_test_utils.hpp"
-#include "tests/test_utils/fetch_local_files.hpp"
 #include "tests/test_utils/test_api_common.hpp"
-#include "umd/device/arch/blackhole_implementation.hpp"
-#include "umd/device/arch/grendel_implementation.hpp"
-#include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/cluster.hpp"
-#include "umd/device/warm_reset.hpp"
-#include "utils.hpp"
+#include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/cluster_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 using namespace tt::umd;
 

--- a/tests/api/test_firmware_info_provider.cpp
+++ b/tests/api/test_firmware_info_provider.cpp
@@ -2,21 +2,30 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <fmt/base.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 #include <tt-logger/tt-logger.hpp>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
+#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/gddr_telemetry.hpp"
 #include "umd/device/utils/semver.hpp"
 
 using namespace tt;

--- a/tests/api/test_hang_detection.cpp
+++ b/tests/api/test_hang_detection.cpp
@@ -2,27 +2,30 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <fmt/base.h>
 #include <gtest/gtest.h>
 
 #include <cstdint>
 #include <memory>
+#include <set>
+#include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <vector>
 
-#include "assert.hpp"
 #include "device/api/umd/device/warm_reset.hpp"
-#include "tests/test_utils/device_test_utils.hpp"
-#include "tests/test_utils/test_api_common.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/cluster.hpp"
+#include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/tensix_soft_reset_options.hpp"
+#include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/error_detail.hpp"
 #include "utils.hpp"
 
 using namespace tt;

--- a/tests/api/test_jtag.cpp
+++ b/tests/api/test_jtag.cpp
@@ -10,19 +10,22 @@
 #include <filesystem>
 #include <iostream>
 #include <memory>
-#include <ostream>
+#include <set>
+#include <string>
 #include <tt-logger/tt-logger.hpp>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
-#include "assert.hpp"
 #include "umd/device/cluster.hpp"
-#include "umd/device/cluster_descriptor.hpp"
 #include "umd/device/jtag/jtag.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
+#include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/communication_protocol.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error.hpp"

--- a/tests/api/test_noc.cpp
+++ b/tests/api/test_noc.cpp
@@ -4,18 +4,31 @@
 
 // This file holds Cluster specific API examples.
 
+#include <fmt/base.h>
 #include <gtest/gtest.h>
 
-#include <array>
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <set>
+#include <stdexcept>
+#include <string>
 #include <tt-logger/tt-logger.hpp>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <variant>
 #include <vector>
 
+#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/xy_pair.hpp"

--- a/tests/api/test_risc_program.cpp
+++ b/tests/api/test_risc_program.cpp
@@ -4,37 +4,30 @@
 
 // This file holds RISC processor specific API tests for brisc, ncrisc, and other RISC cores.
 
-#include <fmt/format.h>
-#include <fmt/xchar.h>
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstring>
-#include <filesystem>
-#include <iostream>
 #include <memory>
 #include <optional>
-#include <random>
-#include <sstream>
-#include <stdexcept>
+#include <set>
 #include <string>
-#include <unordered_map>
+#include <tuple>
 #include <unordered_set>
 #include <vector>
 
+#include "test_utils/assembly_programs_for_tests.hpp"
 #include "test_utils/setup_risc_cores.hpp"
 #include "tests/test_utils/test_api_common.hpp"
-#include "umd/device/arch/blackhole_implementation.hpp"
-#include "umd/device/arch/grendel_implementation.hpp"
-#include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/cluster.hpp"
-#include "umd/device/firmware/erisc_firmware.hpp"
-#include "umd/device/firmware/firmware_utils.hpp"
-#include "umd/device/types/tensix_soft_reset_options.hpp"
-#include "umd/device/warm_reset.hpp"
-#include "utils.hpp"
+#include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/risc_type.hpp"
 
 using namespace tt::umd;
 

--- a/tests/api/test_simulation_sysmem_manager.cpp
+++ b/tests/api/test_simulation_sysmem_manager.cpp
@@ -3,16 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <sys/mman.h>
 
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 
-#include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/chip_helpers/silicon_sysmem_manager.hpp"
 #include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
-#include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_types.hpp"
 

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -6,21 +6,17 @@
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
-#include <cstdint>
-#include <cstdlib>
-#include <cstring>
 #include <filesystem>
 #include <memory>
-#include <optional>
-#include <random>
+#include <set>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 #include "umd/device/cluster.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
-#include "utils.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 using namespace tt::umd;
 

--- a/tests/api/test_spi_tt_device.cpp
+++ b/tests/api/test_spi_tt_device.cpp
@@ -9,18 +9,24 @@
 #include <iomanip>
 #include <iostream>
 #include <memory>
+#include <stdexcept>
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
-#include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/arc/spi_tt_device.hpp"
-#include "umd/device/cluster.hpp"
+#include "umd/device/cluster_descriptor.hpp"
 #include "umd/device/soc_descriptor.hpp"
+#include "umd/device/topology/topology_discovery.hpp"
+#include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
-#include "utils.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/communication_protocol.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
+using namespace tt;
 using namespace tt::umd;
 
 // SPI Address Constants.

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -9,14 +9,26 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <set>
 #include <stdexcept>
+#include <string>
+#include <unordered_set>
 #include <vector>
 
-#include "tests/test_utils/device_test_utils.hpp"
+#include "umd/device/chip/chip.hpp"
 #include "umd/device/chip_helpers/silicon_sysmem_manager.hpp"
+#include "umd/device/chip_helpers/sysmem_buffer.hpp"
+#include "umd/device/chip_helpers/sysmem_manager.hpp"
+#include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/cluster.hpp"
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 
+using namespace tt;
 using namespace tt::umd;
 
 const uint32_t HUGEPAGE_REGION_SIZE = 1ULL << 30;  // 1GB

--- a/tests/api/test_tlb_manager.cpp
+++ b/tests/api/test_tlb_manager.cpp
@@ -9,13 +9,20 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 
-#include "tests/test_utils/device_test_utils.hpp"
+#include "umd/device/chip_helpers/tlb_manager.hpp"
+#include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/tlb.hpp"
 
+using namespace tt;
 using namespace tt::umd;
 
 // TODO: Once default auto TLB setup is in, check it is setup properly.

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -7,19 +7,28 @@
 #include <cstdint>
 #include <map>
 #include <memory>
-#include <stdexcept>
+#include <optional>
+#include <set>
+#include <string>
 #include <thread>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
-#include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/test_api_common.hpp"
-#include "umd/device/arch/blackhole_implementation.hpp"
-#include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/chip/chip.hpp"
 #include "umd/device/cluster.hpp"
+#include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
-#include "umd/device/utils/error.hpp"
-#include "utils.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
+using namespace tt;
 using namespace tt::umd;
 
 TEST(ApiTTDeviceTest, BasicTTDeviceIO) {

--- a/tests/api/test_tt_visible_devices.cpp
+++ b/tests/api/test_tt_visible_devices.cpp
@@ -6,21 +6,31 @@
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
+#include <iostream>
+#include <map>
 #include <memory>
+#include <set>
+#include <stdexcept>
 #include <string>
-#include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/fetch_local_files.hpp"
 #include "umd/device/cluster.hpp"
+#include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
 #include "utils.hpp"
+
+namespace tt {
+enum class ARCH;
+}  // namespace tt
 
 using namespace tt::umd;
 

--- a/tests/api/test_ttsim_device_io.cpp
+++ b/tests/api/test_ttsim_device_io.cpp
@@ -10,14 +10,18 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstdlib>
+#include <filesystem>
 #include <memory>
+#include <string>
 #include <vector>
 
-#include "umd/device/simulation/simulation_chip.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"
+#include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/simulation_device_factory.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/tt_device/tt_sim_tt_device.hpp"
 #include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 

--- a/tests/api/test_warm_reset.cpp
+++ b/tests/api/test_warm_reset.cpp
@@ -3,12 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
+#include <exception>
 #include <filesystem>
 #include <fstream>
 #include <functional>
@@ -16,23 +19,35 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <system_error>
 #include <thread>
+#include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "device/api/umd/device/warm_reset.hpp"
-#include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/pipe_communication.hpp"
 #include "tests/test_utils/test_api_common.hpp"
-#include "umd/device/arch/blackhole_implementation.hpp"
-#include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/chip/chip.hpp"
 #include "umd/device/cluster.hpp"
+#include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/communication_protocol.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/risc_type.hpp"
+#include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error.hpp"
 #include "utils.hpp"
 
+using namespace tt;
 using namespace tt::umd;
 using namespace tt::umd::error;
 

--- a/tests/baremetal/test_cluster.cpp
+++ b/tests/baremetal/test_cluster.cpp
@@ -6,6 +6,10 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+#include <set>
+#include <string>
+
 #include "umd/device/cluster.hpp"
 
 using namespace tt::umd;

--- a/tests/baremetal/test_cluster_descriptor_offline.cpp
+++ b/tests/baremetal/test_cluster_descriptor_offline.cpp
@@ -10,19 +10,24 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
-#include <ostream>
+#include <set>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "disjoint_set.hpp"
 #include "tests/test_utils/fetch_local_files.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 #include "utils.hpp"
 
 using namespace tt;

--- a/tests/baremetal/test_core_coord_translation_bh.cpp
+++ b/tests/baremetal/test_core_coord_translation_bh.cpp
@@ -7,15 +7,22 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <initializer_list>
 #include <map>
 #include <memory>
 #include <set>
 #include <stdexcept>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/coordinates/coordinate_manager.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/common.hpp"
 
 using namespace tt;
 using namespace tt::umd;

--- a/tests/baremetal/test_core_coord_translation_wh.cpp
+++ b/tests/baremetal/test_core_coord_translation_wh.cpp
@@ -10,12 +10,17 @@
 #include <memory>
 #include <set>
 #include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/coordinates/coordinate_manager.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/common.hpp"
 
 using namespace tt;
 using namespace tt::umd;

--- a/tests/baremetal/test_long_jump.cpp
+++ b/tests/baremetal/test_long_jump.cpp
@@ -5,15 +5,20 @@
  */
 
 #include <gtest/gtest.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include <atomic>
+#include <chrono>
 #include <csetjmp>
 #include <csignal>
-#include <cstring>
+#include <cstdio>
+#include <cstdlib>
 #include <functional>
 #include <iostream>
 #include <stdexcept>
+#include <string>
 #include <thread>
 #include <vector>
 

--- a/tests/baremetal/test_notification_mechanism.cpp
+++ b/tests/baremetal/test_notification_mechanism.cpp
@@ -3,10 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
 #include <chrono>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <functional>

--- a/tests/baremetal/test_soc_arch_descriptor.cpp
+++ b/tests/baremetal/test_soc_arch_descriptor.cpp
@@ -5,8 +5,11 @@
 #include <gtest/gtest.h>
 
 #include <cstddef>
-#include <cstdint>
+#include <stdexcept>
 #include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "tests/test_utils/fetch_local_files.hpp"
@@ -14,6 +17,9 @@
 #include "umd/device/arch/grendel_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/soc_arch_descriptor.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 using namespace tt;
 using namespace tt::umd;

--- a/tests/baremetal/test_soc_descriptor.cpp
+++ b/tests/baremetal/test_soc_descriptor.cpp
@@ -8,17 +8,22 @@
 #include <cstdint>
 #include <filesystem>
 #include <iostream>
-#include <ostream>
+#include <memory>
+#include <optional>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "tests/test_utils/fetch_local_files.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
-#include "umd/device/arch/grendel_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
-#include "umd/device/cluster.hpp"
+#include "umd/device/coordinates/coordinate_manager.hpp"
 #include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/common.hpp"
 
 using namespace tt;
 using namespace tt::umd;

--- a/tests/blackhole/test_arc_messages_bh.cpp
+++ b/tests/blackhole/test_arc_messages_bh.cpp
@@ -7,13 +7,14 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <thread>
 #include <vector>
 
 #include "umd/device/arc/arc_messenger.hpp"
-#include "umd/device/arc/blackhole_arc_telemetry_reader.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
-#include "umd/device/cluster.hpp"
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/blackhole_arc.hpp"
 
 using namespace tt::umd;

--- a/tests/blackhole/test_chip_info_bh.cpp
+++ b/tests/blackhole/test_chip_info_bh.cpp
@@ -5,9 +5,13 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
+#include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
 
 using namespace tt;
 using namespace tt::umd;

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -4,24 +4,29 @@
 
 #include <gtest/gtest.h>
 
-#include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <initializer_list>
 #include <memory>
 #include <numeric>
+#include <optional>
 #include <set>
+#include <string>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 #include "blackhole/eth_l1_address_map.h"
-#include "blackhole/host_mem_address_map.h"
 #include "blackhole/l1_address_map.h"
 #include "tests/test_utils/device_test_utils.hpp"
-#include "tests/test_utils/fetch_local_files.hpp"
 #include "tests/test_utils/setup_risc_cores.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/cluster_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/utils/semver.hpp"
 
 using namespace tt::umd;

--- a/tests/galaxy/test_galaxy_common.cpp
+++ b/tests/galaxy/test_galaxy_common.cpp
@@ -8,6 +8,8 @@
 #include <vector>
 
 #include "tests/test_utils/device_test_utils.hpp"
+#include "umd/device/cluster.hpp"
+#include "umd/device/soc_descriptor.hpp"
 
 void move_data(
     Cluster& device, tt_multichip_core_addr sender_core, tt_multichip_core_addr receiver_core, uint32_t size) {

--- a/tests/galaxy/test_galaxy_common.hpp
+++ b/tests/galaxy/test_galaxy_common.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <set>
 #include <sstream>

--- a/tests/galaxy/test_galaxy_common.hpp
+++ b/tests/galaxy/test_galaxy_common.hpp
@@ -4,8 +4,10 @@
 
 #pragma once
 
+#include <fmt/base.h>
 #include <fmt/format.h>
 
+#include <cstdint>
 #include <set>
 #include <sstream>
 #include <string>
@@ -13,7 +15,13 @@
 #include <vector>
 
 #include "umd/device/cluster.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/xy_pair.hpp"
+
+namespace tt::umd {
+class Cluster;
+}  // namespace tt::umd
 
 // static const std::string SOC_DESC_PATH = "./tests/soc_descs/wormhole_b0_8x10.yaml";
 

--- a/tests/galaxy/test_umd_concurrent_threads.cpp
+++ b/tests/galaxy/test_umd_concurrent_threads.cpp
@@ -6,26 +6,25 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <filesystem>
+#include <initializer_list>
 #include <iterator>
 #include <memory>
-#include <numeric>
 #include <set>
+#include <string>
 #include <thread>
-#include <tt-logger/tt-logger.hpp>
+#include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
-#include "test_galaxy_common.hpp"
 #include "tests/test_utils/device_test_utils.hpp"
-#include "tests/test_utils/fetch_local_files.hpp"
 #include "tests/test_utils/setup_risc_cores.hpp"
-#include "tests/test_utils/test_api_common.hpp"
 #include "tests/wormhole/test_wh_common.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
-#include "wormhole/eth_interface.h"
-#include "wormhole/host_mem_address_map.h"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 #include "wormhole/l1_address_map.h"
 
 using namespace tt::umd;

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -4,22 +4,22 @@
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <chrono>
 #include <cstdint>
-#include <filesystem>
+#include <initializer_list>
 #include <numeric>
-#include <tt-logger/tt-logger.hpp>
+#include <set>
+#include <string>
 #include <vector>
 
 #include "test_galaxy_common.hpp"
+#include "test_utils/setup_risc_cores.hpp"
 #include "tests/test_utils/device_test_utils.hpp"
-#include "tests/test_utils/fetch_local_files.hpp"
 #include "tests/wormhole/test_wh_common.hpp"
 #include "umd/device/cluster.hpp"
-#include "umd/device/cluster_descriptor.hpp"
-#include "wormhole/eth_interface.h"
-#include "wormhole/host_mem_address_map.h"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 #include "wormhole/l1_address_map.h"
 
 using namespace tt::umd;

--- a/tests/galaxy/test_umd_remote_api_stability.cpp
+++ b/tests/galaxy/test_umd_remote_api_stability.cpp
@@ -2,27 +2,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <gtest/gtest.h>
+
 #include <cassert>
 #include <cstdint>
 #include <cstdlib>
-#include <filesystem>
 #include <memory>
-#include <numeric>
 #include <random>
+#include <string>
 #include <thread>
 #include <tt-logger/tt-logger.hpp>
 #include <vector>
 
-#include "tests/galaxy/test_galaxy_common.hpp"
-#include "tests/test_utils/fetch_local_files.hpp"
 #include "tests/test_utils/stimulus_generators.hpp"
 #include "tests/wormhole/test_wh_common.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
-#include "umd/device/soc_descriptor.hpp"
-#include "wormhole/eth_interface.h"
-#include "wormhole/host_mem_address_map.h"
-#include "wormhole/l1_address_map.h"
 
 namespace tt::umd::test::utils {
 

--- a/tests/microbenchmark/benchmarks/ethernet_io/test_ethernet_io.cpp
+++ b/tests/microbenchmark/benchmarks/ethernet_io/test_ethernet_io.cpp
@@ -2,17 +2,25 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <fmt/base.h>
 #include <gtest/gtest.h>
 #include <nanobench.h>
 
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "common/microbenchmark_utils.hpp"
 #include "test_utils/test_api_common.hpp"
 #include "umd/device/cluster.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 
 using namespace tt;
 using namespace tt::umd;

--- a/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
+++ b/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
@@ -2,19 +2,28 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <fmt/base.h>
 #include <gtest/gtest.h>
 #include <nanobench.h>
 #include <sys/mman.h>
+#include <unistd.h>
 
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <memory>
+#include <optional>
+#include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include "common/microbenchmark_utils.hpp"
+#include "umd/device/chip/chip.hpp"
 #include "umd/device/cluster.hpp"
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
 
 using namespace tt;
 using namespace tt::umd;

--- a/tests/microbenchmark/benchmarks/open_cluster/test_open_cluster.cpp
+++ b/tests/microbenchmark/benchmarks/open_cluster/test_open_cluster.cpp
@@ -4,17 +4,23 @@
 
 #include <gtest/gtest.h>
 #include <nanobench.h>
-#include <sys/mman.h>
 
 #include <chrono>
+#include <map>
 #include <memory>
+#include <string>
+#include <utility>
 
 #include "common/microbenchmark_utils.hpp"
 #include "test_utils/fetch_local_files.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/topology/topology_discovery.hpp"
-#include "umd/device/warm_reset.hpp"
+#include "umd/device/types/communication_protocol.hpp"
+
+namespace tt {
+enum class ARCH;
+}  // namespace tt
 
 using namespace tt::umd;
 using namespace tt::umd::test::utils;

--- a/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
+++ b/tests/microbenchmark/benchmarks/pcie_dma/test_pcie_dma.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <fmt/base.h>
 #include <gtest/gtest.h>
 #include <nanobench.h>
 #include <sys/mman.h>
@@ -9,12 +10,24 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "common/microbenchmark_utils.hpp"
+#include "umd/device/chip/chip.hpp"
+#include "umd/device/chip_helpers/sysmem_buffer.hpp"
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/cluster.hpp"
+#include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/cluster_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 
 using namespace tt;
 using namespace tt::umd;

--- a/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
+++ b/tests/microbenchmark/benchmarks/tlb/test_tlb.cpp
@@ -2,17 +2,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <fmt/base.h>
 #include <gtest/gtest.h>
 #include <nanobench.h>
 
-#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "common/microbenchmark_utils.hpp"
 #include "umd/device/cluster.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/tlb.hpp"
 
 using namespace tt;
 using namespace tt::umd;

--- a/tests/misc/test_assert.cpp
+++ b/tests/misc/test_assert.cpp
@@ -5,7 +5,6 @@
 #include <gtest/gtest.h>
 
 #include <functional>
-#include <ostream>
 #include <sstream>
 #include <stdexcept>
 #include <string>

--- a/tests/misc/test_errors.cpp
+++ b/tests/misc/test_errors.cpp
@@ -2,11 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <fmt/format.h>
-#include <gtest/gtest-spi.h>
+#include <fmt/base.h>
 #include <gtest/gtest.h>
 
+#include <cstdint>
+#include <iostream>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "umd/device/utils/error_detail.hpp"
 

--- a/tests/misc/test_semver.cpp
+++ b/tests/misc/test_semver.cpp
@@ -6,13 +6,10 @@
 
 #include <exception>
 #include <map>
-#include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
-#include "umd/device/firmware/erisc_firmware.hpp"
-#include "umd/device/firmware/firmware_utils.hpp"
-#include "umd/device/types/arch.hpp"
 #include "umd/device/utils/semver.hpp"
 
 using namespace tt::umd;

--- a/tests/pcie/test_pcie_device.cpp
+++ b/tests/pcie/test_pcie_device.cpp
@@ -2,11 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <fmt/xchar.h>
+#include <fmt/base.h>
+#include <fmt/ranges.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <filesystem>
 #include <string>
 #include <vector>
 

--- a/tests/simulation/test_simulation_device.cpp
+++ b/tests/simulation/test_simulation_device.cpp
@@ -2,10 +2,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <random>
+#include <string>
+#include <vector>
 
 #include "device_fixture.hpp"
-#include "tests/test_utils/device_test_utils.hpp"
+#include "umd/device/simulation/simulation_chip.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/risc_type.hpp"
+#include "umd/device/types/xy_pair.hpp"
+
+using namespace tt;
+using namespace tt::umd;
 
 std::vector<uint32_t> generate_data(uint32_t size_in_bytes) {
     size_t size = size_in_bytes / sizeof(uint32_t);

--- a/tests/test_utils/fetch_local_files.hpp
+++ b/tests/test_utils/fetch_local_files.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <filesystem>
 #include <iostream>

--- a/tests/test_utils/test_utils.cpp
+++ b/tests/test_utils/test_utils.cpp
@@ -3,8 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include <chrono>
+#include <string>
 #include <thread>
 #include <vector>
 

--- a/tests/unified/multiprocess.cpp
+++ b/tests/unified/multiprocess.cpp
@@ -3,22 +3,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include <algorithm>
-#include <array>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <exception>
 #include <iostream>
-#include <iterator>
 #include <memory>
-#include <ostream>
+#include <optional>
+#include <set>
+#include <string>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 #include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/setup_risc_cores.hpp"
 #include "umd/device/cluster.hpp"
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 
 using namespace tt::umd;
 

--- a/tests/unified/test_tlb.cpp
+++ b/tests/unified/test_tlb.cpp
@@ -7,12 +7,20 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "umd/device/cluster.hpp"
+#include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/tlb.hpp"
+#include "umd/device/utils/semver.hpp"
 
 using namespace tt;
 using namespace tt::umd;

--- a/tests/wormhole/test_arc_messages_wh.cpp
+++ b/tests/wormhole/test_arc_messages_wh.cpp
@@ -8,14 +8,20 @@
 #include <cstdint>
 #include <memory>
 #include <set>
+#include <string>
 #include <thread>
 #include <unordered_map>
 #include <vector>
 
 #include "umd/device/arc/arc_messenger.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/coordinates/coordinate_manager.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
 
 using namespace tt::umd;
 

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -6,25 +6,30 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <initializer_list>
 #include <ios>
 #include <memory>
 #include <numeric>
-#include <random>
+#include <optional>
 #include <set>
+#include <string>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 #include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/fetch_local_files.hpp"
 #include "tests/test_utils/setup_risc_cores.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/chip/chip.hpp"
 #include "umd/device/cluster.hpp"
-#include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/semver.hpp"
 #include "wormhole/eth_l1_address_map.h"
-#include "wormhole/host_mem_address_map.h"
 #include "wormhole/l1_address_map.h"
 
 using namespace tt::umd;

--- a/tests/wormhole/test_remote_communication_wh.cpp
+++ b/tests/wormhole/test_remote_communication_wh.cpp
@@ -9,20 +9,28 @@
 #include <ios>
 #include <memory>
 #include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
-#include "tests/test_utils/device_test_utils.hpp"
-#include "tests/test_utils/fetch_local_files.hpp"
-#include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/chip/local_chip.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/topology/topology_discovery.hpp"
+#include "umd/device/topology/topology_discovery_options.hpp"
+#include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/remote_communication_legacy_firmware.hpp"
-#include "umd/device/types/cluster_types.hpp"
-#include "wormhole/host_mem_address_map.h"
-#include "wormhole/l1_address_map.h"
+#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
+using namespace tt;
 using namespace tt::umd;
 
 TEST(RemoteCommunicationWormhole, BasicRemoteCommunicationIO) {

--- a/tests/wormhole/test_umd_remote_api_stability.cpp
+++ b/tests/wormhole/test_umd_remote_api_stability.cpp
@@ -5,27 +5,20 @@
 #include <gtest/gtest.h>
 
 #include <cassert>
-#include <chrono>
 #include <cstdint>
 #include <cstdlib>
-#include <ctime>
-#include <filesystem>
+#include <functional>
 #include <memory>
-#include <numeric>
 #include <random>
+#include <string>
 #include <thread>
 #include <tt-logger/tt-logger.hpp>
 #include <vector>
 
 #include "test_wh_common.hpp"
-#include "tests/test_utils/fetch_local_files.hpp"
 #include "tests/test_utils/stimulus_generators.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
-#include "umd/device/soc_descriptor.hpp"
-#include "wormhole/eth_interface.h"
-#include "wormhole/host_mem_address_map.h"
-#include "wormhole/l1_address_map.h"
 
 namespace tt::umd::test::utils {
 class WormholeNebulaX2TestFixture : public WormholeTestFixture {

--- a/tools/telemetry.cpp
+++ b/tools/telemetry.cpp
@@ -4,7 +4,6 @@
 
 #include "umd/device/types/telemetry.hpp"
 
-#include <fmt/core.h>
 #include <fmt/format.h>
 
 #include <chrono>

--- a/tools/tlb_virus.cpp
+++ b/tools/tlb_virus.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <fmt/core.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 

--- a/tools/warm_reset.cpp
+++ b/tools/warm_reset.cpp
@@ -4,7 +4,6 @@
 
 #include "umd/device/warm_reset.hpp"
 
-#include <fmt/core.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 


### PR DESCRIPTION
### Issue
Prerequisite for #2250.

### Description
Cleaning up includes with IWYU.
An automated IWYU workflow is probably possible, but there were many problems with our 3rd party dependencies, which could not be fixed with config or a mapping file, so I had to manually fix them.
Clang-tidy's `misc-include-cleaner` also struggles with 3rd party dependencies and some transitive includes, but is even more complicated to configure.

### List of the changes
- Ran IWYU over /device and /tests
- FIxed build errors after IWYU.
- Added `misc-header-include-cycle` to clang-tidy.

### Testing
CI

### API Changes
There are no API changes in this PR.
