### PR TITLE
Extract SimulationTlbAllocator out of SimulationTlbManager

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -147,6 +147,7 @@ if(TT_UMD_BUILD_SIMULATION)
             simulation/rtl_sim_communicator.cpp
             tt_device/rtl_simulation_tt_device.cpp
             tt_device/tt_sim_tt_device.cpp
+            chip_helpers/simulation_tlb_allocator.cpp
             chip_helpers/simulation_tlb_manager.cpp
             tt_device/simulation_device_factory.cpp
             pcie/tt_sim_tlb_window.cpp
@@ -191,6 +192,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
                 api/umd/device/chip_helpers/sysmem_buffer.hpp
                 api/umd/device/chip_helpers/tlb_manager.hpp
+                api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
                 api/umd/device/chip_helpers/simulation_tlb_manager.hpp
                 api/umd/device/cluster.hpp
                 api/umd/device/coordinates/coordinate_manager.hpp

--- a/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
+#include "umd/device/types/arch.hpp"
+
+namespace tt::umd {
+
+class architecture_implementation;
+
+/**
+ * In-process allocator for simulation TLB indices.
+ *
+ * Tracks which TLB indices are allocated per size class, and computes BAR0-relative
+ * addresses for a given index. Counterpart to KMD-managed allocation on silicon —
+ * no knowledge of TlbHandle / TlbWindow types.
+ */
+class SimulationTlbAllocator {
+public:
+    SimulationTlbAllocator(uint64_t bar0_base, const architecture_implementation* arch_impl);
+
+    /**
+     * Allocate a TLB index that fits the requested size. If size is 0, allocate
+     * any available TLB, preferring smaller sizes first.
+     *
+     * @param size Requested TLB size in bytes (0 means any available).
+     * @return TLB index if successful, -1 if no TLB available.
+     */
+    int allocate_tlb_index(size_t size);
+
+    /**
+     * Mark a TLB index as free.
+     */
+    void deallocate_tlb_index(int tlb_index);
+
+    /**
+     * Size of the TLB at the given index, in bytes.
+     */
+    size_t get_tlb_size_from_index(int tlb_index);
+
+    /**
+     * BAR0-relative address mapped by the TLB at the given index.
+     */
+    uint64_t get_tlb_address_from_index(int tlb_index);
+
+    /**
+     * Address of the TLB configuration register for the given index.
+     */
+    uint64_t get_tlb_reg_address_from_index(int tlb_index);
+
+    const architecture_implementation* get_architecture_impl() const;
+
+private:
+    void initialize_architecture_config();
+
+    // Allocate a TLB index assuming allocation_mutex_ is already held by the caller.
+    // Used for the size==0 path which recurses internally.
+    int allocate_tlb_index_locked(size_t size);
+
+    uint64_t bar0_base_ = 0;
+    const architecture_implementation* arch_impl_ = nullptr;
+
+    // Architecture-specific TLB configuration.
+    tt::ARCH architecture_;
+    size_t tlb_reg_size_bytes_ = 8;  // Default to Wormhole size.
+
+    // TLB size constants (set based on architecture).
+    size_t tlb_1mb_size_ = 0;
+    size_t tlb_2mb_size_ = 0;
+    size_t tlb_16mb_size_ = 0;
+    size_t tlb_4gb_size_ = 0;
+
+    // TLB count constants (set based on architecture).
+    size_t tlb_1mb_count_ = 0;
+    size_t tlb_2mb_count_ = 0;
+    size_t tlb_16mb_count_ = 0;
+    size_t tlb_4gb_count_ = 0;
+
+    // TLB index ranges (set based on architecture).
+    size_t tlb_1mb_start_index_ = 0;
+    size_t tlb_2mb_start_index_ = 0;
+    size_t tlb_16mb_start_index_ = 0;
+    size_t tlb_4gb_start_index_ = 0;
+
+    // TLB allocation tracking (dynamically sized based on architecture).
+    std::mutex allocation_mutex_;
+    std::vector<bool> tlb_1mb_allocated_;   // Wormhole: 156 TLBs, Blackhole: 0.
+    std::vector<bool> tlb_2mb_allocated_;   // Wormhole: 10 TLBs, Blackhole: 202.
+    std::vector<bool> tlb_16mb_allocated_;  // Wormhole: 20 TLBs, Blackhole: 0.
+    std::vector<bool> tlb_4gb_allocated_;   // Wormhole: 0 TLBs, Blackhole: 8.
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
@@ -76,10 +76,6 @@ private:
 
     void initialize_architecture_config();
 
-    // Allocate a TLB index assuming allocation_mutex_ is already held by the caller.
-    // Used for the size==0 path which recurses internally.
-    int allocate_tlb_index_internal(size_t size);
-
     // Returns the pool that owns `tlb_index`, or nullptr if no pool covers it
     // (including for negative indices).
     TlbSizeClass* find_size_class_for_index(int tlb_index);

--- a/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
@@ -61,43 +62,35 @@ public:
     const architecture_implementation* get_architecture_impl() const;
 
 private:
+    // A pool of TLB indices that all share a single size.
+    struct TlbSizeClass {
+        size_t size = 0;         // Bytes per TLB; 0 means unused on the current arch.
+        size_t count = 0;        // Number of TLBs in the pool.
+        size_t start_index = 0;  // First global TLB index belonging to this pool.
+        std::vector<bool> allocated;
+    };
+
+    // Indices into size_classes_; ordered smallest -> largest so allocate-with-escalation
+    // and address-layout iteration both Just Work.
+    enum SizeClass : size_t { ONE_MB = 0, TWO_MB = 1, SIXTEEN_MB = 2, FOUR_GB = 3, NUM_SIZE_CLASSES = 4 };
+
     void initialize_architecture_config();
 
     // Allocate a TLB index assuming allocation_mutex_ is already held by the caller.
     // Used for the size==0 path which recurses internally.
     int allocate_tlb_index_internal(size_t size);
 
+    // Returns the pool that owns `tlb_index`, or nullptr if no pool covers it
+    // (including for negative indices).
+    TlbSizeClass* find_size_class_for_index(int tlb_index);
+
     uint64_t bar0_base_ = 0;
     const architecture_implementation* arch_impl_ = nullptr;
-
-    // Architecture-specific TLB configuration.
     tt::ARCH architecture_;
     size_t tlb_reg_size_bytes_ = 8;  // Default to Wormhole size.
 
-    // TLB size constants (set based on architecture).
-    size_t tlb_1mb_size_ = 0;
-    size_t tlb_2mb_size_ = 0;
-    size_t tlb_16mb_size_ = 0;
-    size_t tlb_4gb_size_ = 0;
-
-    // TLB count constants (set based on architecture).
-    size_t tlb_1mb_count_ = 0;
-    size_t tlb_2mb_count_ = 0;
-    size_t tlb_16mb_count_ = 0;
-    size_t tlb_4gb_count_ = 0;
-
-    // TLB index ranges (set based on architecture).
-    size_t tlb_1mb_start_index_ = 0;
-    size_t tlb_2mb_start_index_ = 0;
-    size_t tlb_16mb_start_index_ = 0;
-    size_t tlb_4gb_start_index_ = 0;
-
-    // TLB allocation tracking (dynamically sized based on architecture).
     std::mutex allocation_mutex_;
-    std::vector<bool> tlb_1mb_allocated_;   // Wormhole: 156 TLBs, Blackhole: 0.
-    std::vector<bool> tlb_2mb_allocated_;   // Wormhole: 10 TLBs, Blackhole: 202.
-    std::vector<bool> tlb_16mb_allocated_;  // Wormhole: 20 TLBs, Blackhole: 0.
-    std::vector<bool> tlb_4gb_allocated_;   // Wormhole: 0 TLBs, Blackhole: 8.
+    std::array<TlbSizeClass, NUM_SIZE_CLASSES> size_classes_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
@@ -27,8 +27,11 @@ public:
     SimulationTlbAllocator(uint64_t bar0_base, const architecture_implementation* arch_impl);
 
     /**
-     * Allocate a TLB index that fits the requested size. If size is 0, allocate
-     * any available TLB, preferring smaller sizes first.
+     * Allocate the smallest TLB whose size class is >= the requested size. If no
+     * TLB is free in that size class, escalate to the next larger size class and
+     * retry, continuing until a TLB is allocated or all size classes are exhausted.
+     *
+     * If size is 0, allocate any available TLB, preferring smaller size classes first.
      *
      * @param size Requested TLB size in bytes (0 means any available).
      * @return TLB index if successful, -1 if no TLB available.
@@ -62,7 +65,7 @@ private:
 
     // Allocate a TLB index assuming allocation_mutex_ is already held by the caller.
     // Used for the size==0 path which recurses internally.
-    int allocate_tlb_index_locked(size_t size);
+    int allocate_tlb_index_internal(size_t size);
 
     uint64_t bar0_base_ = 0;
     const architecture_implementation* arch_impl_ = nullptr;

--- a/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
@@ -8,10 +8,8 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <mutex>
-#include <vector>
 
-#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 #include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/types/tlb.hpp"
@@ -51,81 +49,22 @@ public:
      */
     std::unique_ptr<TlbWindow> allocate_default_tlb_window();
 
-    /**
-     * Allocate a TLB index based on the requested size.
-     * @param size Requested TLB size (0 means any available)
-     * @return TLB index if successful, -1 if no TLB available
-     */
+    // The methods below forward to the underlying SimulationTlbAllocator. They are
+    // exposed on SimulationTlbManager for back-compat with simulation TlbHandle
+    // subclasses that hold a SimulationTlbManager* back-pointer.
+
     int allocate_tlb_index(size_t size);
-
-    /**
-     * Deallocate a TLB index, making it available for reuse.
-     * @param tlb_index The TLB index to deallocate
-     */
     void deallocate_tlb_index(int tlb_index);
-
-    /**
-     * Get the size of TLB based on its index.
-     * @param tlb_index The TLB index
-     * @return Size of the TLB in bytes
-     */
     size_t get_tlb_size_from_index(int tlb_index);
-
-    /**
-     * Calculate the address for a TLB based on its index, starting from BAR0 base.
-     * @param tlb_index The TLB index
-     * @return Address offset from BAR0 base for this TLB
-     */
     uint64_t get_tlb_address_from_index(int tlb_index);
-
     uint64_t get_tlb_reg_address_from_index(int tlb_index);
-
-    /**
-     * Get the architecture implementation for architecture-specific operations.
-     * @return Pointer to architecture implementation
-     */
     const architecture_implementation* get_architecture_impl() const;
 
     tt::ARCH get_arch() const;
 
 private:
-    /**
-     * Initialize architecture-specific TLB configuration based on the device architecture.
-     */
-    void initialize_architecture_config();
-
-    uint64_t bar0_base_ = 0;
-    const architecture_implementation* arch_impl_ = nullptr;
+    SimulationTlbAllocator allocator_;
     TlbWindowFactory factory_;
-
-    // Architecture-specific TLB configuration.
-    tt::ARCH architecture_;
-    size_t tlb_reg_size_bytes_ = 8;  // Default to Wormhole size
-
-    // TLB size constants (set based on architecture).
-    size_t tlb_1mb_size_ = 0;
-    size_t tlb_2mb_size_ = 0;
-    size_t tlb_16mb_size_ = 0;
-    size_t tlb_4gb_size_ = 0;
-
-    // TLB count constants (set based on architecture).
-    size_t tlb_1mb_count_ = 0;
-    size_t tlb_2mb_count_ = 0;
-    size_t tlb_16mb_count_ = 0;
-    size_t tlb_4gb_count_ = 0;
-
-    // TLB index ranges (set based on architecture).
-    size_t tlb_1mb_start_index_ = 0;
-    size_t tlb_2mb_start_index_ = 0;
-    size_t tlb_16mb_start_index_ = 0;
-    size_t tlb_4gb_start_index_ = 0;
-
-    // TLB allocation tracking (dynamically sized based on architecture).
-    std::mutex allocation_mutex_;
-    std::vector<bool> tlb_1mb_allocated_;   // Wormhole: 156 TLBs, Blackhole: 0
-    std::vector<bool> tlb_2mb_allocated_;   // Wormhole: 10 TLBs, Blackhole: 202
-    std::vector<bool> tlb_16mb_allocated_;  // Wormhole: 20 TLBs, Blackhole: 0
-    std::vector<bool> tlb_4gb_allocated_;   // Wormhole: 0 TLBs, Blackhole: 8
 };
 
 }  // namespace tt::umd

--- a/device/chip_helpers/simulation_tlb_allocator.cpp
+++ b/device/chip_helpers/simulation_tlb_allocator.cpp
@@ -24,36 +24,36 @@ SimulationTlbAllocator::SimulationTlbAllocator(uint64_t bar0_base, const archite
 int SimulationTlbAllocator::allocate_tlb_index(size_t size) {
     ZoneScopedC(tracy::Color::Cyan);
     std::lock_guard<std::mutex> lock(allocation_mutex_);
-    return allocate_tlb_index_locked(size);
+    return allocate_tlb_index_internal(size);
 }
 
-int SimulationTlbAllocator::allocate_tlb_index_locked(size_t size) {
+int SimulationTlbAllocator::allocate_tlb_index_internal(size_t size) {
     if (size == 0) {
         // Allocate any available TLB, prefer smaller sizes first.
         // Recurse into the locked helper so we don't re-enter the non-recursive mutex.
         if (tlb_1mb_size_ > 0) {
-            int tlb_index = allocate_tlb_index_locked(tlb_1mb_size_);
+            int tlb_index = allocate_tlb_index_internal(tlb_1mb_size_);
             if (tlb_index != -1) {
                 return tlb_index;
             }
         }
 
         if (tlb_2mb_size_ > 0) {
-            int tlb_index = allocate_tlb_index_locked(tlb_2mb_size_);
+            int tlb_index = allocate_tlb_index_internal(tlb_2mb_size_);
             if (tlb_index != -1) {
                 return tlb_index;
             }
         }
 
         if (tlb_16mb_size_ > 0) {
-            int tlb_index = allocate_tlb_index_locked(tlb_16mb_size_);
+            int tlb_index = allocate_tlb_index_internal(tlb_16mb_size_);
             if (tlb_index != -1) {
                 return tlb_index;
             }
         }
 
         if (tlb_4gb_size_ > 0) {
-            return allocate_tlb_index_locked(tlb_4gb_size_);
+            return allocate_tlb_index_internal(tlb_4gb_size_);
         }
 
         return -1;
@@ -104,6 +104,11 @@ int SimulationTlbAllocator::allocate_tlb_index_locked(size_t size) {
 
 void SimulationTlbAllocator::deallocate_tlb_index(int tlb_index) {
     ZoneScopedC(tracy::Color::Cyan);
+    // Guard against negative tlb_index before signed/unsigned comparisons below
+    // promote it to SIZE_MAX and accidentally land in a valid range.
+    if (tlb_index < 0) {
+        return;
+    }
     std::lock_guard<std::mutex> lock(allocation_mutex_);
 
     // Check 1MB TLBs (Wormhole only).
@@ -142,6 +147,9 @@ void SimulationTlbAllocator::deallocate_tlb_index(int tlb_index) {
 }
 
 size_t SimulationTlbAllocator::get_tlb_size_from_index(int tlb_index) {
+    if (tlb_index < 0) {
+        return 0;
+    }
     // Check 1MB TLBs (Wormhole only).
     if (tlb_1mb_count_ > 0 && tlb_index >= tlb_1mb_start_index_ && tlb_index < tlb_2mb_start_index_) {
         return tlb_1mb_size_;
@@ -167,6 +175,9 @@ size_t SimulationTlbAllocator::get_tlb_size_from_index(int tlb_index) {
 }
 
 uint64_t SimulationTlbAllocator::get_tlb_address_from_index(int tlb_index) {
+    if (tlb_index < 0) {
+        return 0;
+    }
     if (architecture_ == tt::ARCH::WORMHOLE_B0) {
         // Wormhole B0 address calculation.
         if (tlb_1mb_count_ > 0 && tlb_index >= tlb_1mb_start_index_ && tlb_index < tlb_2mb_start_index_) {
@@ -201,6 +212,9 @@ uint64_t SimulationTlbAllocator::get_tlb_address_from_index(int tlb_index) {
 }
 
 uint64_t SimulationTlbAllocator::get_tlb_reg_address_from_index(int tlb_index) {
+    if (tlb_index < 0) {
+        return 0;
+    }
     // TLB configuration registers start at this offset from BAR0 base.
     static constexpr uint64_t TLB_CONFIG_REG_BASE_OFFSET = 0x1fc00000;
     return bar0_base_ + TLB_CONFIG_REG_BASE_OFFSET + tlb_index * tlb_reg_size_bytes_;

--- a/device/chip_helpers/simulation_tlb_allocator.cpp
+++ b/device/chip_helpers/simulation_tlb_allocator.cpp
@@ -56,13 +56,16 @@ void SimulationTlbAllocator::deallocate_tlb_index(int tlb_index) {
 
 size_t SimulationTlbAllocator::get_tlb_size_from_index(int tlb_index) {
     auto* sc = find_size_class_for_index(tlb_index);
-    return sc ? sc->size : 0;
+    if (!sc) {
+        UMD_THROW(error::RuntimeError, fmt::format("Invalid simulation TLB index {}.", tlb_index));
+    }
+    return sc->size;
 }
 
 uint64_t SimulationTlbAllocator::get_tlb_address_from_index(int tlb_index) {
     auto* sc = find_size_class_for_index(tlb_index);
     if (!sc) {
-        return 0;
+        UMD_THROW(error::RuntimeError, fmt::format("Invalid simulation TLB index {}.", tlb_index));
     }
 
     // BH 4GB TLBs live in BAR4, not BAR0; this path doesn't yet support them.
@@ -85,8 +88,8 @@ uint64_t SimulationTlbAllocator::get_tlb_address_from_index(int tlb_index) {
 }
 
 uint64_t SimulationTlbAllocator::get_tlb_reg_address_from_index(int tlb_index) {
-    if (tlb_index < 0) {
-        return 0;
+    if (!find_size_class_for_index(tlb_index)) {
+        UMD_THROW(error::RuntimeError, fmt::format("Invalid simulation TLB index {}.", tlb_index));
     }
     // TLB configuration registers start at this offset from BAR0 base.
     static constexpr uint64_t TLB_CONFIG_REG_BASE_OFFSET = 0x1fc00000;
@@ -136,6 +139,12 @@ void SimulationTlbAllocator::initialize_architecture_config() {
         // ONE_MB and SIXTEEN_MB stay at default (count=0).
 
     } else {
+        // Intentional: architectures like QUASAR construct SimulationTlbManager
+        // but bypass this allocator entirely (allocate_default_tlb_window
+        // short-circuits to a fixed dummy index without ever calling
+        // allocate_tlb_index). Leaving every pool empty is the signal that
+        // allocator-driven addressing is not in use; clients can detect this
+        // via has_configured_pools().
         log_debug(
             LogUMD,
             fmt::format(

--- a/device/chip_helpers/simulation_tlb_allocator.cpp
+++ b/device/chip_helpers/simulation_tlb_allocator.cpp
@@ -1,0 +1,275 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
+
+#include <fmt/format.h>
+
+#include <tt-logger/tt-logger.hpp>
+
+#include "tracy.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/blackhole_implementation.hpp"
+#include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/utils/error.hpp"
+
+namespace tt::umd {
+
+SimulationTlbAllocator::SimulationTlbAllocator(uint64_t bar0_base, const architecture_implementation* arch_impl) :
+    bar0_base_(bar0_base), arch_impl_(arch_impl) {
+    initialize_architecture_config();
+}
+
+int SimulationTlbAllocator::allocate_tlb_index(size_t size) {
+    ZoneScopedC(tracy::Color::Cyan);
+    std::lock_guard<std::mutex> lock(allocation_mutex_);
+    return allocate_tlb_index_locked(size);
+}
+
+int SimulationTlbAllocator::allocate_tlb_index_locked(size_t size) {
+    if (size == 0) {
+        // Allocate any available TLB, prefer smaller sizes first.
+        // Recurse into the locked helper so we don't re-enter the non-recursive mutex.
+        if (tlb_1mb_size_ > 0) {
+            int tlb_index = allocate_tlb_index_locked(tlb_1mb_size_);
+            if (tlb_index != -1) {
+                return tlb_index;
+            }
+        }
+
+        if (tlb_2mb_size_ > 0) {
+            int tlb_index = allocate_tlb_index_locked(tlb_2mb_size_);
+            if (tlb_index != -1) {
+                return tlb_index;
+            }
+        }
+
+        if (tlb_16mb_size_ > 0) {
+            int tlb_index = allocate_tlb_index_locked(tlb_16mb_size_);
+            if (tlb_index != -1) {
+                return tlb_index;
+            }
+        }
+
+        if (tlb_4gb_size_ > 0) {
+            return allocate_tlb_index_locked(tlb_4gb_size_);
+        }
+
+        return -1;
+    }
+
+    // Try 1MB TLBs (Wormhole only).
+    if (tlb_1mb_size_ > 0 && size <= tlb_1mb_size_) {
+        for (size_t i = 0; i < tlb_1mb_count_; ++i) {
+            if (!tlb_1mb_allocated_[i]) {
+                tlb_1mb_allocated_[i] = true;
+                return static_cast<int>(tlb_1mb_start_index_ + i);
+            }
+        }
+    }
+
+    // Try 2MB TLBs (both architectures).
+    if (tlb_2mb_size_ > 0 && size <= tlb_2mb_size_) {
+        for (size_t i = 0; i < tlb_2mb_count_; ++i) {
+            if (!tlb_2mb_allocated_[i]) {
+                tlb_2mb_allocated_[i] = true;
+                return static_cast<int>(tlb_2mb_start_index_ + i);
+            }
+        }
+    }
+
+    // Try 16MB TLBs (Wormhole only).
+    if (tlb_16mb_size_ > 0 && size <= tlb_16mb_size_) {
+        for (size_t i = 0; i < tlb_16mb_count_; ++i) {
+            if (!tlb_16mb_allocated_[i]) {
+                tlb_16mb_allocated_[i] = true;
+                return static_cast<int>(tlb_16mb_start_index_ + i);
+            }
+        }
+    }
+
+    // Try 4GB TLBs (Blackhole only).
+    if (tlb_4gb_size_ > 0 && size <= tlb_4gb_size_) {
+        for (size_t i = 0; i < tlb_4gb_count_; ++i) {
+            if (!tlb_4gb_allocated_[i]) {
+                tlb_4gb_allocated_[i] = true;
+                return static_cast<int>(tlb_4gb_start_index_ + i);
+            }
+        }
+    }
+
+    return -1;  // No available TLB.
+}
+
+void SimulationTlbAllocator::deallocate_tlb_index(int tlb_index) {
+    ZoneScopedC(tracy::Color::Cyan);
+    std::lock_guard<std::mutex> lock(allocation_mutex_);
+
+    // Check 1MB TLBs (Wormhole only).
+    if (tlb_1mb_count_ > 0 && tlb_index >= tlb_1mb_start_index_ && tlb_index < tlb_2mb_start_index_) {
+        size_t local_index = tlb_index - tlb_1mb_start_index_;
+        if (local_index < tlb_1mb_count_) {
+            tlb_1mb_allocated_[local_index] = false;
+        }
+    }
+    // Check 2MB TLBs (both architectures).
+    else if (
+        tlb_2mb_count_ > 0 && tlb_index >= tlb_2mb_start_index_ &&
+        (tlb_16mb_count_ == 0 || tlb_index < tlb_16mb_start_index_) &&
+        (tlb_4gb_count_ == 0 || tlb_index < tlb_4gb_start_index_)) {
+        size_t local_index = tlb_index - tlb_2mb_start_index_;
+        if (local_index < tlb_2mb_count_) {
+            tlb_2mb_allocated_[local_index] = false;
+        }
+    }
+    // Check 16MB TLBs (Wormhole only).
+    else if (
+        tlb_16mb_count_ > 0 && tlb_index >= tlb_16mb_start_index_ &&
+        (tlb_4gb_count_ == 0 || tlb_index < tlb_4gb_start_index_)) {
+        size_t local_index = tlb_index - tlb_16mb_start_index_;
+        if (local_index < tlb_16mb_count_) {
+            tlb_16mb_allocated_[local_index] = false;
+        }
+    }
+    // Check 4GB TLBs (Blackhole only).
+    else if (tlb_4gb_count_ > 0 && tlb_index >= tlb_4gb_start_index_) {
+        size_t local_index = tlb_index - tlb_4gb_start_index_;
+        if (local_index < tlb_4gb_count_) {
+            tlb_4gb_allocated_[local_index] = false;
+        }
+    }
+}
+
+size_t SimulationTlbAllocator::get_tlb_size_from_index(int tlb_index) {
+    // Check 1MB TLBs (Wormhole only).
+    if (tlb_1mb_count_ > 0 && tlb_index >= tlb_1mb_start_index_ && tlb_index < tlb_2mb_start_index_) {
+        return tlb_1mb_size_;
+    }
+    // Check 2MB TLBs (both architectures).
+    else if (
+        tlb_2mb_count_ > 0 && tlb_index >= tlb_2mb_start_index_ &&
+        (tlb_16mb_count_ == 0 || tlb_index < tlb_16mb_start_index_) &&
+        (tlb_4gb_count_ == 0 || tlb_index < tlb_4gb_start_index_)) {
+        return tlb_2mb_size_;
+    }
+    // Check 16MB TLBs (Wormhole only).
+    else if (
+        tlb_16mb_count_ > 0 && tlb_index >= tlb_16mb_start_index_ &&
+        (tlb_4gb_count_ == 0 || tlb_index < tlb_4gb_start_index_)) {
+        return tlb_16mb_size_;
+    }
+    // Check 4GB TLBs (Blackhole only).
+    else if (tlb_4gb_count_ > 0 && tlb_index >= tlb_4gb_start_index_) {
+        return tlb_4gb_size_;
+    }
+    return 0;
+}
+
+uint64_t SimulationTlbAllocator::get_tlb_address_from_index(int tlb_index) {
+    if (architecture_ == tt::ARCH::WORMHOLE_B0) {
+        // Wormhole B0 address calculation.
+        if (tlb_1mb_count_ > 0 && tlb_index >= tlb_1mb_start_index_ && tlb_index < tlb_2mb_start_index_) {
+            // 1MB TLBs: indices 0-155.
+            return bar0_base_ + (static_cast<uint64_t>(tlb_index) * tlb_1mb_size_);
+        } else if (tlb_2mb_count_ > 0 && tlb_index >= tlb_2mb_start_index_ && tlb_index < tlb_16mb_start_index_) {
+            // 2MB TLBs: indices 156-165.
+            uint64_t offset_1mb_region = tlb_1mb_count_ * tlb_1mb_size_;
+            uint64_t offset_in_2mb_region = static_cast<uint64_t>(tlb_index - tlb_2mb_start_index_) * tlb_2mb_size_;
+            return bar0_base_ + offset_1mb_region + offset_in_2mb_region;
+        } else if (tlb_16mb_count_ > 0 && tlb_index >= tlb_16mb_start_index_) {
+            // 16MB TLBs: indices 166-185.
+            uint64_t offset_1mb_region = tlb_1mb_count_ * tlb_1mb_size_;
+            uint64_t offset_2mb_region = tlb_2mb_count_ * tlb_2mb_size_;
+            uint64_t offset_in_16mb_region = static_cast<uint64_t>(tlb_index - tlb_16mb_start_index_) * tlb_16mb_size_;
+            return bar0_base_ + offset_1mb_region + offset_2mb_region + offset_in_16mb_region;
+        }
+    } else if (architecture_ == tt::ARCH::BLACKHOLE) {
+        // Blackhole address calculation.
+        if (tlb_2mb_count_ > 0 && tlb_index >= tlb_2mb_start_index_ && tlb_index < tlb_4gb_start_index_) {
+            // 2MB TLBs: indices 0-201.
+            return bar0_base_ + (static_cast<uint64_t>(tlb_index) * tlb_2mb_size_);
+        } else if (tlb_4gb_count_ > 0 && tlb_index >= tlb_4gb_start_index_) {
+            // 4GB TLBs are in BAR4, not BAR0 for Blackhole.
+            UMD_THROW(
+                error::RuntimeError, "4GB TLBs in Blackhole are not currently supported in simulation TLB allocation.");
+        }
+    }
+
+    // Invalid TLB index.
+    return 0;
+}
+
+uint64_t SimulationTlbAllocator::get_tlb_reg_address_from_index(int tlb_index) {
+    // TLB configuration registers start at this offset from BAR0 base.
+    static constexpr uint64_t TLB_CONFIG_REG_BASE_OFFSET = 0x1fc00000;
+    return bar0_base_ + TLB_CONFIG_REG_BASE_OFFSET + tlb_index * tlb_reg_size_bytes_;
+}
+
+const architecture_implementation* SimulationTlbAllocator::get_architecture_impl() const { return arch_impl_; }
+
+void SimulationTlbAllocator::initialize_architecture_config() {
+    architecture_ = arch_impl_->get_architecture();
+
+    if (architecture_ == tt::ARCH::WORMHOLE_B0) {
+        // Wormhole B0 configuration.
+        tlb_reg_size_bytes_ = 8;  // wormhole::TLB_CFG_REG_SIZE_BYTES.
+
+        const auto& tlb_sizes = arch_impl_->get_tlb_sizes();
+        tlb_1mb_size_ = tlb_sizes[0];   // 1MB.
+        tlb_2mb_size_ = tlb_sizes[1];   // 2MB.
+        tlb_16mb_size_ = tlb_sizes[2];  // 16MB.
+        tlb_4gb_size_ = 0;              // Not supported.
+
+        tlb_1mb_count_ = 156;
+        tlb_2mb_count_ = 10;
+        tlb_16mb_count_ = 20;
+        tlb_4gb_count_ = 0;
+
+        tlb_1mb_start_index_ = 0;
+        tlb_2mb_start_index_ = tlb_1mb_start_index_ + tlb_1mb_count_;
+        tlb_16mb_start_index_ = tlb_2mb_start_index_ + tlb_2mb_count_;
+        tlb_4gb_start_index_ = 0;  // Not applicable.
+
+        // Initialize allocation tracking.
+        tlb_1mb_allocated_.resize(tlb_1mb_count_, false);
+        tlb_2mb_allocated_.resize(tlb_2mb_count_, false);
+        tlb_16mb_allocated_.resize(tlb_16mb_count_, false);
+        // tlb_4gb_allocated_ remains empty.
+
+    } else if (architecture_ == tt::ARCH::BLACKHOLE) {
+        // Blackhole configuration.
+        tlb_reg_size_bytes_ = 12;  // blackhole::TLB_CFG_REG_SIZE_BYTES.
+
+        const auto& tlb_sizes = arch_impl_->get_tlb_sizes();
+        tlb_1mb_size_ = 0;             // Not supported.
+        tlb_2mb_size_ = tlb_sizes[0];  // 2MB.
+        tlb_16mb_size_ = 0;            // Not supported.
+        tlb_4gb_size_ = tlb_sizes[1];  // 4GB (second element in Blackhole tlb_sizes).
+
+        tlb_1mb_count_ = 0;
+        tlb_2mb_count_ = 202;
+        tlb_16mb_count_ = 0;
+        tlb_4gb_count_ = 8;
+
+        tlb_1mb_start_index_ = 0;  // Not applicable.
+        tlb_2mb_start_index_ = 0;
+        tlb_16mb_start_index_ = 0;  // Not applicable.
+        tlb_4gb_start_index_ = tlb_2mb_count_;
+
+        // Initialize allocation tracking.
+        // tlb_1mb_allocated_ and tlb_16mb_allocated_ remain empty.
+        tlb_2mb_allocated_.resize(tlb_2mb_count_, false);
+        tlb_4gb_allocated_.resize(tlb_4gb_count_, false);
+
+    } else {
+        log_debug(
+            LogUMD,
+            fmt::format(
+                "Architecture {} does not yet have support for TLB management in simulation. UMD will use legacy "
+                "tile_wr_bytes and tile_rd_bytes path.",
+                tt::arch_to_str(architecture_)));
+    }
+}
+
+}  // namespace tt::umd

--- a/device/chip_helpers/simulation_tlb_allocator.cpp
+++ b/device/chip_helpers/simulation_tlb_allocator.cpp
@@ -24,26 +24,13 @@ SimulationTlbAllocator::SimulationTlbAllocator(uint64_t bar0_base, const archite
 int SimulationTlbAllocator::allocate_tlb_index(size_t size) {
     ZoneScopedC(tracy::Color::Cyan);
     std::lock_guard<std::mutex> lock(allocation_mutex_);
-    return allocate_tlb_index_internal(size);
-}
 
-int SimulationTlbAllocator::allocate_tlb_index_internal(size_t size) {
-    if (size == 0) {
-        // Allocate any available TLB; prefer smaller size classes first.
-        // Recurse into the internal helper so we don't re-enter the non-recursive mutex.
-        for (auto& sc : size_classes_) {
-            if (sc.size > 0) {
-                int tlb_index = allocate_tlb_index_internal(sc.size);
-                if (tlb_index != -1) {
-                    return tlb_index;
-                }
-            }
-        }
-        return -1;
-    }
-
-    // Try each size class in order, smallest first; escalate to a larger class
-    // when the current one is full (a larger TLB still satisfies the request).
+    // Walk size classes smallest-first; pick the first free slot in the first
+    // class that can satisfy the request. Escalate to a larger class when the
+    // current one is full (a larger TLB still satisfies the request).
+    //
+    // size == 0 is handled by the same loop: `0 > sc.size` is always false for
+    // size_t, so every non-empty class is considered, smallest first.
     for (auto& sc : size_classes_) {
         if (sc.size == 0 || size > sc.size) {
             continue;

--- a/device/chip_helpers/simulation_tlb_allocator.cpp
+++ b/device/chip_helpers/simulation_tlb_allocator.cpp
@@ -29,72 +29,29 @@ int SimulationTlbAllocator::allocate_tlb_index(size_t size) {
 
 int SimulationTlbAllocator::allocate_tlb_index_internal(size_t size) {
     if (size == 0) {
-        // Allocate any available TLB, prefer smaller sizes first.
-        // Recurse into the locked helper so we don't re-enter the non-recursive mutex.
-        if (tlb_1mb_size_ > 0) {
-            int tlb_index = allocate_tlb_index_internal(tlb_1mb_size_);
-            if (tlb_index != -1) {
-                return tlb_index;
+        // Allocate any available TLB; prefer smaller size classes first.
+        // Recurse into the internal helper so we don't re-enter the non-recursive mutex.
+        for (auto& sc : size_classes_) {
+            if (sc.size > 0) {
+                int tlb_index = allocate_tlb_index_internal(sc.size);
+                if (tlb_index != -1) {
+                    return tlb_index;
+                }
             }
         }
-
-        if (tlb_2mb_size_ > 0) {
-            int tlb_index = allocate_tlb_index_internal(tlb_2mb_size_);
-            if (tlb_index != -1) {
-                return tlb_index;
-            }
-        }
-
-        if (tlb_16mb_size_ > 0) {
-            int tlb_index = allocate_tlb_index_internal(tlb_16mb_size_);
-            if (tlb_index != -1) {
-                return tlb_index;
-            }
-        }
-
-        if (tlb_4gb_size_ > 0) {
-            return allocate_tlb_index_internal(tlb_4gb_size_);
-        }
-
         return -1;
     }
 
-    // Try 1MB TLBs (Wormhole only).
-    if (tlb_1mb_size_ > 0 && size <= tlb_1mb_size_) {
-        for (size_t i = 0; i < tlb_1mb_count_; ++i) {
-            if (!tlb_1mb_allocated_[i]) {
-                tlb_1mb_allocated_[i] = true;
-                return static_cast<int>(tlb_1mb_start_index_ + i);
-            }
+    // Try each size class in order, smallest first; escalate to a larger class
+    // when the current one is full (a larger TLB still satisfies the request).
+    for (auto& sc : size_classes_) {
+        if (sc.size == 0 || size > sc.size) {
+            continue;
         }
-    }
-
-    // Try 2MB TLBs (both architectures).
-    if (tlb_2mb_size_ > 0 && size <= tlb_2mb_size_) {
-        for (size_t i = 0; i < tlb_2mb_count_; ++i) {
-            if (!tlb_2mb_allocated_[i]) {
-                tlb_2mb_allocated_[i] = true;
-                return static_cast<int>(tlb_2mb_start_index_ + i);
-            }
-        }
-    }
-
-    // Try 16MB TLBs (Wormhole only).
-    if (tlb_16mb_size_ > 0 && size <= tlb_16mb_size_) {
-        for (size_t i = 0; i < tlb_16mb_count_; ++i) {
-            if (!tlb_16mb_allocated_[i]) {
-                tlb_16mb_allocated_[i] = true;
-                return static_cast<int>(tlb_16mb_start_index_ + i);
-            }
-        }
-    }
-
-    // Try 4GB TLBs (Blackhole only).
-    if (tlb_4gb_size_ > 0 && size <= tlb_4gb_size_) {
-        for (size_t i = 0; i < tlb_4gb_count_; ++i) {
-            if (!tlb_4gb_allocated_[i]) {
-                tlb_4gb_allocated_[i] = true;
-                return static_cast<int>(tlb_4gb_start_index_ + i);
+        for (size_t i = 0; i < sc.count; ++i) {
+            if (!sc.allocated[i]) {
+                sc.allocated[i] = true;
+                return static_cast<int>(sc.start_index + i);
             }
         }
     }
@@ -104,111 +61,40 @@ int SimulationTlbAllocator::allocate_tlb_index_internal(size_t size) {
 
 void SimulationTlbAllocator::deallocate_tlb_index(int tlb_index) {
     ZoneScopedC(tracy::Color::Cyan);
-    // Guard against negative tlb_index before signed/unsigned comparisons below
-    // promote it to SIZE_MAX and accidentally land in a valid range.
-    if (tlb_index < 0) {
-        return;
-    }
     std::lock_guard<std::mutex> lock(allocation_mutex_);
-
-    // Check 1MB TLBs (Wormhole only).
-    if (tlb_1mb_count_ > 0 && tlb_index >= tlb_1mb_start_index_ && tlb_index < tlb_2mb_start_index_) {
-        size_t local_index = tlb_index - tlb_1mb_start_index_;
-        if (local_index < tlb_1mb_count_) {
-            tlb_1mb_allocated_[local_index] = false;
-        }
-    }
-    // Check 2MB TLBs (both architectures).
-    else if (
-        tlb_2mb_count_ > 0 && tlb_index >= tlb_2mb_start_index_ &&
-        (tlb_16mb_count_ == 0 || tlb_index < tlb_16mb_start_index_) &&
-        (tlb_4gb_count_ == 0 || tlb_index < tlb_4gb_start_index_)) {
-        size_t local_index = tlb_index - tlb_2mb_start_index_;
-        if (local_index < tlb_2mb_count_) {
-            tlb_2mb_allocated_[local_index] = false;
-        }
-    }
-    // Check 16MB TLBs (Wormhole only).
-    else if (
-        tlb_16mb_count_ > 0 && tlb_index >= tlb_16mb_start_index_ &&
-        (tlb_4gb_count_ == 0 || tlb_index < tlb_4gb_start_index_)) {
-        size_t local_index = tlb_index - tlb_16mb_start_index_;
-        if (local_index < tlb_16mb_count_) {
-            tlb_16mb_allocated_[local_index] = false;
-        }
-    }
-    // Check 4GB TLBs (Blackhole only).
-    else if (tlb_4gb_count_ > 0 && tlb_index >= tlb_4gb_start_index_) {
-        size_t local_index = tlb_index - tlb_4gb_start_index_;
-        if (local_index < tlb_4gb_count_) {
-            tlb_4gb_allocated_[local_index] = false;
-        }
+    if (auto* sc = find_size_class_for_index(tlb_index)) {
+        sc->allocated[static_cast<size_t>(tlb_index) - sc->start_index] = false;
     }
 }
 
 size_t SimulationTlbAllocator::get_tlb_size_from_index(int tlb_index) {
-    if (tlb_index < 0) {
-        return 0;
-    }
-    // Check 1MB TLBs (Wormhole only).
-    if (tlb_1mb_count_ > 0 && tlb_index >= tlb_1mb_start_index_ && tlb_index < tlb_2mb_start_index_) {
-        return tlb_1mb_size_;
-    }
-    // Check 2MB TLBs (both architectures).
-    else if (
-        tlb_2mb_count_ > 0 && tlb_index >= tlb_2mb_start_index_ &&
-        (tlb_16mb_count_ == 0 || tlb_index < tlb_16mb_start_index_) &&
-        (tlb_4gb_count_ == 0 || tlb_index < tlb_4gb_start_index_)) {
-        return tlb_2mb_size_;
-    }
-    // Check 16MB TLBs (Wormhole only).
-    else if (
-        tlb_16mb_count_ > 0 && tlb_index >= tlb_16mb_start_index_ &&
-        (tlb_4gb_count_ == 0 || tlb_index < tlb_4gb_start_index_)) {
-        return tlb_16mb_size_;
-    }
-    // Check 4GB TLBs (Blackhole only).
-    else if (tlb_4gb_count_ > 0 && tlb_index >= tlb_4gb_start_index_) {
-        return tlb_4gb_size_;
-    }
-    return 0;
+    auto* sc = find_size_class_for_index(tlb_index);
+    return sc ? sc->size : 0;
 }
 
 uint64_t SimulationTlbAllocator::get_tlb_address_from_index(int tlb_index) {
-    if (tlb_index < 0) {
+    auto* sc = find_size_class_for_index(tlb_index);
+    if (!sc) {
         return 0;
     }
-    if (architecture_ == tt::ARCH::WORMHOLE_B0) {
-        // Wormhole B0 address calculation.
-        if (tlb_1mb_count_ > 0 && tlb_index >= tlb_1mb_start_index_ && tlb_index < tlb_2mb_start_index_) {
-            // 1MB TLBs: indices 0-155.
-            return bar0_base_ + (static_cast<uint64_t>(tlb_index) * tlb_1mb_size_);
-        } else if (tlb_2mb_count_ > 0 && tlb_index >= tlb_2mb_start_index_ && tlb_index < tlb_16mb_start_index_) {
-            // 2MB TLBs: indices 156-165.
-            uint64_t offset_1mb_region = tlb_1mb_count_ * tlb_1mb_size_;
-            uint64_t offset_in_2mb_region = static_cast<uint64_t>(tlb_index - tlb_2mb_start_index_) * tlb_2mb_size_;
-            return bar0_base_ + offset_1mb_region + offset_in_2mb_region;
-        } else if (tlb_16mb_count_ > 0 && tlb_index >= tlb_16mb_start_index_) {
-            // 16MB TLBs: indices 166-185.
-            uint64_t offset_1mb_region = tlb_1mb_count_ * tlb_1mb_size_;
-            uint64_t offset_2mb_region = tlb_2mb_count_ * tlb_2mb_size_;
-            uint64_t offset_in_16mb_region = static_cast<uint64_t>(tlb_index - tlb_16mb_start_index_) * tlb_16mb_size_;
-            return bar0_base_ + offset_1mb_region + offset_2mb_region + offset_in_16mb_region;
-        }
-    } else if (architecture_ == tt::ARCH::BLACKHOLE) {
-        // Blackhole address calculation.
-        if (tlb_2mb_count_ > 0 && tlb_index >= tlb_2mb_start_index_ && tlb_index < tlb_4gb_start_index_) {
-            // 2MB TLBs: indices 0-201.
-            return bar0_base_ + (static_cast<uint64_t>(tlb_index) * tlb_2mb_size_);
-        } else if (tlb_4gb_count_ > 0 && tlb_index >= tlb_4gb_start_index_) {
-            // 4GB TLBs are in BAR4, not BAR0 for Blackhole.
-            UMD_THROW(
-                error::RuntimeError, "4GB TLBs in Blackhole are not currently supported in simulation TLB allocation.");
-        }
+
+    // BH 4GB TLBs live in BAR4, not BAR0; this path doesn't yet support them.
+    if (architecture_ == tt::ARCH::BLACKHOLE && sc == &size_classes_[FOUR_GB]) {
+        UMD_THROW(
+            error::RuntimeError, "4GB TLBs in Blackhole are not currently supported in simulation TLB allocation.");
     }
 
-    // Invalid TLB index.
-    return 0;
+    // Size classes are laid out contiguously in BAR0; sum the sizes of all classes
+    // ordered before this one to get the offset where this class's region begins.
+    uint64_t region_offset = 0;
+    for (const auto& earlier : size_classes_) {
+        if (&earlier == sc) {
+            break;
+        }
+        region_offset += earlier.count * earlier.size;
+    }
+
+    return bar0_base_ + region_offset + (static_cast<uint64_t>(tlb_index) - sc->start_index) * sc->size;
 }
 
 uint64_t SimulationTlbAllocator::get_tlb_reg_address_from_index(int tlb_index) {
@@ -222,59 +108,45 @@ uint64_t SimulationTlbAllocator::get_tlb_reg_address_from_index(int tlb_index) {
 
 const architecture_implementation* SimulationTlbAllocator::get_architecture_impl() const { return arch_impl_; }
 
+SimulationTlbAllocator::TlbSizeClass* SimulationTlbAllocator::find_size_class_for_index(int tlb_index) {
+    // Returning nullptr for negative indices avoids signed/unsigned comparison
+    // pitfalls below (where size_t promotion would turn -1 into SIZE_MAX).
+    if (tlb_index < 0) {
+        return nullptr;
+    }
+    auto idx = static_cast<size_t>(tlb_index);
+    for (auto& sc : size_classes_) {
+        if (sc.count > 0 && idx >= sc.start_index && idx < sc.start_index + sc.count) {
+            return &sc;
+        }
+    }
+    return nullptr;
+}
+
 void SimulationTlbAllocator::initialize_architecture_config() {
     architecture_ = arch_impl_->get_architecture();
 
     if (architecture_ == tt::ARCH::WORMHOLE_B0) {
-        // Wormhole B0 configuration.
         tlb_reg_size_bytes_ = 8;  // wormhole::TLB_CFG_REG_SIZE_BYTES.
 
         const auto& tlb_sizes = arch_impl_->get_tlb_sizes();
-        tlb_1mb_size_ = tlb_sizes[0];   // 1MB.
-        tlb_2mb_size_ = tlb_sizes[1];   // 2MB.
-        tlb_16mb_size_ = tlb_sizes[2];  // 16MB.
-        tlb_4gb_size_ = 0;              // Not supported.
-
-        tlb_1mb_count_ = 156;
-        tlb_2mb_count_ = 10;
-        tlb_16mb_count_ = 20;
-        tlb_4gb_count_ = 0;
-
-        tlb_1mb_start_index_ = 0;
-        tlb_2mb_start_index_ = tlb_1mb_start_index_ + tlb_1mb_count_;
-        tlb_16mb_start_index_ = tlb_2mb_start_index_ + tlb_2mb_count_;
-        tlb_4gb_start_index_ = 0;  // Not applicable.
-
-        // Initialize allocation tracking.
-        tlb_1mb_allocated_.resize(tlb_1mb_count_, false);
-        tlb_2mb_allocated_.resize(tlb_2mb_count_, false);
-        tlb_16mb_allocated_.resize(tlb_16mb_count_, false);
-        // tlb_4gb_allocated_ remains empty.
+        size_classes_[ONE_MB].size = tlb_sizes[0];  // 1MB.
+        size_classes_[ONE_MB].count = 156;
+        size_classes_[TWO_MB].size = tlb_sizes[1];  // 2MB.
+        size_classes_[TWO_MB].count = 10;
+        size_classes_[SIXTEEN_MB].size = tlb_sizes[2];  // 16MB.
+        size_classes_[SIXTEEN_MB].count = 20;
+        // FOUR_GB stays at default (count=0).
 
     } else if (architecture_ == tt::ARCH::BLACKHOLE) {
-        // Blackhole configuration.
         tlb_reg_size_bytes_ = 12;  // blackhole::TLB_CFG_REG_SIZE_BYTES.
 
         const auto& tlb_sizes = arch_impl_->get_tlb_sizes();
-        tlb_1mb_size_ = 0;             // Not supported.
-        tlb_2mb_size_ = tlb_sizes[0];  // 2MB.
-        tlb_16mb_size_ = 0;            // Not supported.
-        tlb_4gb_size_ = tlb_sizes[1];  // 4GB (second element in Blackhole tlb_sizes).
-
-        tlb_1mb_count_ = 0;
-        tlb_2mb_count_ = 202;
-        tlb_16mb_count_ = 0;
-        tlb_4gb_count_ = 8;
-
-        tlb_1mb_start_index_ = 0;  // Not applicable.
-        tlb_2mb_start_index_ = 0;
-        tlb_16mb_start_index_ = 0;  // Not applicable.
-        tlb_4gb_start_index_ = tlb_2mb_count_;
-
-        // Initialize allocation tracking.
-        // tlb_1mb_allocated_ and tlb_16mb_allocated_ remain empty.
-        tlb_2mb_allocated_.resize(tlb_2mb_count_, false);
-        tlb_4gb_allocated_.resize(tlb_4gb_count_, false);
+        size_classes_[TWO_MB].size = tlb_sizes[0];  // 2MB.
+        size_classes_[TWO_MB].count = 202;
+        size_classes_[FOUR_GB].size = tlb_sizes[1];  // 4GB.
+        size_classes_[FOUR_GB].count = 8;
+        // ONE_MB and SIXTEEN_MB stay at default (count=0).
 
     } else {
         log_debug(
@@ -283,6 +155,18 @@ void SimulationTlbAllocator::initialize_architecture_config() {
                 "Architecture {} does not yet have support for TLB management in simulation. UMD will use legacy "
                 "tile_wr_bytes and tile_rd_bytes path.",
                 tt::arch_to_str(architecture_)));
+        return;
+    }
+
+    // Lay out size classes contiguously in BAR0: each non-empty class starts where
+    // the previous one ends.
+    size_t next_start = 0;
+    for (auto& sc : size_classes_) {
+        sc.start_index = next_start;
+        if (sc.count > 0) {
+            sc.allocated.resize(sc.count, false);
+            next_start += sc.count;
+        }
     }
 }
 

--- a/device/chip_helpers/simulation_tlb_manager.cpp
+++ b/device/chip_helpers/simulation_tlb_manager.cpp
@@ -4,13 +4,8 @@
 
 #include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
 
-#include <fmt/format.h>
-
-#include <memory>
-#include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <utility>
-#include <vector>
 
 #include "tracy.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
@@ -19,214 +14,23 @@
 #include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
-class TTDevice;
 
 SimulationTlbManager::SimulationTlbManager(
     TTDevice* tt_device, uint64_t bar0_base, const architecture_implementation* arch_impl, TlbWindowFactory factory) :
-    TLBManager(tt_device), bar0_base_(bar0_base), arch_impl_(arch_impl), factory_(std::move(factory)) {
-    // Initialize architecture-specific configuration.
-    initialize_architecture_config();
-}
-
-int SimulationTlbManager::allocate_tlb_index(size_t size) {
-    ZoneScopedC(tracy::Color::Cyan);
-    std::lock_guard<std::mutex> lock(allocation_mutex_);
-
-    if (size == 0) {
-        // Allocate any available TLB, prefer smaller sizes first.
-        if (tlb_1mb_size_ > 0) {
-            int tlb_index = allocate_tlb_index(tlb_1mb_size_);
-            if (tlb_index != -1) {
-                return tlb_index;
-            }
-        }
-
-        if (tlb_2mb_size_ > 0) {
-            int tlb_index = allocate_tlb_index(tlb_2mb_size_);
-            if (tlb_index != -1) {
-                return tlb_index;
-            }
-        }
-
-        if (tlb_16mb_size_ > 0) {
-            int tlb_index = allocate_tlb_index(tlb_16mb_size_);
-            if (tlb_index != -1) {
-                return tlb_index;
-            }
-        }
-
-        if (tlb_4gb_size_ > 0) {
-            int tlb_index = allocate_tlb_index(tlb_4gb_size_);
-            return tlb_index;
-        }
-
-        return -1;
-    }
-
-    // Try 1MB TLBs (Wormhole only).
-    if (tlb_1mb_size_ > 0 && size <= tlb_1mb_size_) {
-        for (size_t i = 0; i < tlb_1mb_count_; ++i) {
-            if (!tlb_1mb_allocated_[i]) {
-                tlb_1mb_allocated_[i] = true;
-                return static_cast<int>(tlb_1mb_start_index_ + i);
-            }
-        }
-    }
-
-    // Try 2MB TLBs (both architectures).
-    if (tlb_2mb_size_ > 0 && size <= tlb_2mb_size_) {
-        for (size_t i = 0; i < tlb_2mb_count_; ++i) {
-            if (!tlb_2mb_allocated_[i]) {
-                tlb_2mb_allocated_[i] = true;
-                return static_cast<int>(tlb_2mb_start_index_ + i);
-            }
-        }
-    }
-
-    // Try 16MB TLBs (Wormhole only).
-    if (tlb_16mb_size_ > 0 && size <= tlb_16mb_size_) {
-        for (size_t i = 0; i < tlb_16mb_count_; ++i) {
-            if (!tlb_16mb_allocated_[i]) {
-                tlb_16mb_allocated_[i] = true;
-                return static_cast<int>(tlb_16mb_start_index_ + i);
-            }
-        }
-    }
-
-    // Try 4GB TLBs (Blackhole only).
-    if (tlb_4gb_size_ > 0 && size <= tlb_4gb_size_) {
-        for (size_t i = 0; i < tlb_4gb_count_; ++i) {
-            if (!tlb_4gb_allocated_[i]) {
-                tlb_4gb_allocated_[i] = true;
-                return static_cast<int>(tlb_4gb_start_index_ + i);
-            }
-        }
-    }
-
-    return -1;  // No available TLB
-}
-
-void SimulationTlbManager::deallocate_tlb_index(int tlb_index) {
-    ZoneScopedC(tracy::Color::Cyan);
-    std::lock_guard<std::mutex> lock(allocation_mutex_);
-
-    // Check 1MB TLBs (Wormhole only).
-    if (tlb_1mb_count_ > 0 && tlb_index >= tlb_1mb_start_index_ && tlb_index < tlb_2mb_start_index_) {
-        size_t local_index = tlb_index - tlb_1mb_start_index_;
-        if (local_index < tlb_1mb_count_) {
-            tlb_1mb_allocated_[local_index] = false;
-        }
-    }
-    // Check 2MB TLBs (both architectures).
-    else if (
-        tlb_2mb_count_ > 0 && tlb_index >= tlb_2mb_start_index_ &&
-        (tlb_16mb_count_ == 0 || tlb_index < tlb_16mb_start_index_) &&
-        (tlb_4gb_count_ == 0 || tlb_index < tlb_4gb_start_index_)) {
-        size_t local_index = tlb_index - tlb_2mb_start_index_;
-        if (local_index < tlb_2mb_count_) {
-            tlb_2mb_allocated_[local_index] = false;
-        }
-    }
-    // Check 16MB TLBs (Wormhole only).
-    else if (
-        tlb_16mb_count_ > 0 && tlb_index >= tlb_16mb_start_index_ &&
-        (tlb_4gb_count_ == 0 || tlb_index < tlb_4gb_start_index_)) {
-        size_t local_index = tlb_index - tlb_16mb_start_index_;
-        if (local_index < tlb_16mb_count_) {
-            tlb_16mb_allocated_[local_index] = false;
-        }
-    }
-    // Check 4GB TLBs (Blackhole only).
-    else if (tlb_4gb_count_ > 0 && tlb_index >= tlb_4gb_start_index_) {
-        size_t local_index = tlb_index - tlb_4gb_start_index_;
-        if (local_index < tlb_4gb_count_) {
-            tlb_4gb_allocated_[local_index] = false;
-        }
-    }
-}
-
-size_t SimulationTlbManager::get_tlb_size_from_index(int tlb_index) {
-    // Check 1MB TLBs (Wormhole only).
-    if (tlb_1mb_count_ > 0 && tlb_index >= tlb_1mb_start_index_ && tlb_index < tlb_2mb_start_index_) {
-        return tlb_1mb_size_;
-    }
-    // Check 2MB TLBs (both architectures).
-    else if (
-        tlb_2mb_count_ > 0 && tlb_index >= tlb_2mb_start_index_ &&
-        (tlb_16mb_count_ == 0 || tlb_index < tlb_16mb_start_index_) &&
-        (tlb_4gb_count_ == 0 || tlb_index < tlb_4gb_start_index_)) {
-        return tlb_2mb_size_;
-    }
-    // Check 16MB TLBs (Wormhole only).
-    else if (
-        tlb_16mb_count_ > 0 && tlb_index >= tlb_16mb_start_index_ &&
-        (tlb_4gb_count_ == 0 || tlb_index < tlb_4gb_start_index_)) {
-        return tlb_16mb_size_;
-    }
-    // Check 4GB TLBs (Blackhole only).
-    else if (tlb_4gb_count_ > 0 && tlb_index >= tlb_4gb_start_index_) {
-        return tlb_4gb_size_;
-    }
-    return 0;
-}
-
-uint64_t SimulationTlbManager::get_tlb_address_from_index(int tlb_index) {
-    if (architecture_ == tt::ARCH::WORMHOLE_B0) {
-        // Wormhole B0 address calculation.
-        if (tlb_1mb_count_ > 0 && tlb_index >= tlb_1mb_start_index_ && tlb_index < tlb_2mb_start_index_) {
-            // 1MB TLBs: indices 0-155
-            return bar0_base_ + (static_cast<uint64_t>(tlb_index) * tlb_1mb_size_);
-        } else if (tlb_2mb_count_ > 0 && tlb_index >= tlb_2mb_start_index_ && tlb_index < tlb_16mb_start_index_) {
-            // 2MB TLBs: indices 156-165
-            uint64_t offset_1mb_region = tlb_1mb_count_ * tlb_1mb_size_;
-            uint64_t offset_in_2mb_region = static_cast<uint64_t>(tlb_index - tlb_2mb_start_index_) * tlb_2mb_size_;
-            return bar0_base_ + offset_1mb_region + offset_in_2mb_region;
-        } else if (tlb_16mb_count_ > 0 && tlb_index >= tlb_16mb_start_index_) {
-            // 16MB TLBs: indices 166-185
-            uint64_t offset_1mb_region = tlb_1mb_count_ * tlb_1mb_size_;
-            uint64_t offset_2mb_region = tlb_2mb_count_ * tlb_2mb_size_;
-            uint64_t offset_in_16mb_region = static_cast<uint64_t>(tlb_index - tlb_16mb_start_index_) * tlb_16mb_size_;
-            return bar0_base_ + offset_1mb_region + offset_2mb_region + offset_in_16mb_region;
-        }
-    } else if (architecture_ == tt::ARCH::BLACKHOLE) {
-        // Blackhole address calculation.
-        if (tlb_2mb_count_ > 0 && tlb_index >= tlb_2mb_start_index_ && tlb_index < tlb_4gb_start_index_) {
-            // 2MB TLBs: indices 0-201
-            return bar0_base_ + (static_cast<uint64_t>(tlb_index) * tlb_2mb_size_);
-        } else if (tlb_4gb_count_ > 0 && tlb_index >= tlb_4gb_start_index_) {
-            // 4GB TLBs are in BAR4, not BAR0 for Blackhole
-            UMD_THROW(
-                error::RuntimeError, "4GB TLBs in Blackhole are not currently supported in simulation TLB allocation.");
-        }
-    }
-
-    // Invalid TLB index.
-    return 0;
-}
+    TLBManager(tt_device), allocator_(bar0_base, arch_impl), factory_(std::move(factory)) {}
 
 std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_tlb_window(
     tlb_data config, const TlbMapping mapping, const size_t tlb_size) {
     ZoneScopedC(tracy::Color::Cyan);
-
-    int tlb_index = allocate_tlb_index(tlb_size);
+    int tlb_index = allocator_.allocate_tlb_index(tlb_size);
     if (tlb_index == -1) {
         UMD_THROW(error::RuntimeError, "No available TLB of requested size.");
     }
 
-    size_t actual_tlb_size = get_tlb_size_from_index(tlb_index);
+    size_t actual_tlb_size = allocator_.get_tlb_size_from_index(tlb_index);
 
     return factory_(this, tlb_index, actual_tlb_size, mapping, config);
 }
-
-uint64_t SimulationTlbManager::get_tlb_reg_address_from_index(int tlb_index) {
-    // TLB configuration registers start at this offset from BAR0 base.
-    static constexpr uint64_t TLB_CONFIG_REG_BASE_OFFSET = 0x1fc00000;
-    return bar0_base_ + TLB_CONFIG_REG_BASE_OFFSET + tlb_index * tlb_reg_size_bytes_;
-}
-
-const architecture_implementation* SimulationTlbManager::get_architecture_impl() const { return arch_impl_; }
-
-tt::ARCH SimulationTlbManager::get_arch() const { return architecture_; }
 
 std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
     static constexpr size_t SIZE_2MB = 2 * 1024 * 1024;
@@ -236,7 +40,8 @@ std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
     // TlbWindow::validate doesn't reject any valid access (size 0 would cause
     // division by zero in RtlSimTlbHandle::configure).
     static constexpr size_t SIZE_4GB = 4ULL * 1024 * 1024 * 1024;
-    switch (architecture_) {
+    const tt::ARCH architecture = allocator_.get_architecture_impl()->get_architecture();
+    switch (architecture) {
         case tt::ARCH::BLACKHOLE:
             return allocate_tlb_window({}, TlbMapping::WC, SIZE_2MB);
         case tt::ARCH::WORMHOLE_B0:
@@ -247,75 +52,31 @@ std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
             log_debug(
                 LogUMD,
                 "Architecture {} does not support TLB allocation, returning nullptr.",
-                tt::arch_to_str(architecture_));
+                tt::arch_to_str(architecture));
             return nullptr;
     }
 }
 
-void SimulationTlbManager::initialize_architecture_config() {
-    architecture_ = get_architecture_impl()->get_architecture();
+int SimulationTlbManager::allocate_tlb_index(size_t size) { return allocator_.allocate_tlb_index(size); }
 
-    if (architecture_ == tt::ARCH::WORMHOLE_B0) {
-        // Wormhole B0 configuration.
-        tlb_reg_size_bytes_ = 8;  // wormhole::TLB_CFG_REG_SIZE_BYTES
+void SimulationTlbManager::deallocate_tlb_index(int tlb_index) { allocator_.deallocate_tlb_index(tlb_index); }
 
-        const auto* arch_impl = get_architecture_impl();
-        const auto& tlb_sizes = arch_impl->get_tlb_sizes();
-        tlb_1mb_size_ = tlb_sizes[0];   // 1MB
-        tlb_2mb_size_ = tlb_sizes[1];   // 2MB
-        tlb_16mb_size_ = tlb_sizes[2];  // 16MB
-        tlb_4gb_size_ = 0;              // Not supported
-
-        tlb_1mb_count_ = 156;
-        tlb_2mb_count_ = 10;
-        tlb_16mb_count_ = 20;
-        tlb_4gb_count_ = 0;
-
-        tlb_1mb_start_index_ = 0;
-        tlb_2mb_start_index_ = tlb_1mb_start_index_ + tlb_1mb_count_;
-        tlb_16mb_start_index_ = tlb_2mb_start_index_ + tlb_2mb_count_;
-        tlb_4gb_start_index_ = 0;  // Not applicable
-
-        // Initialize allocation tracking.
-        tlb_1mb_allocated_.resize(tlb_1mb_count_, false);
-        tlb_2mb_allocated_.resize(tlb_2mb_count_, false);
-        tlb_16mb_allocated_.resize(tlb_16mb_count_, false);
-        // tlb_4gb_allocated_ remains empty
-
-    } else if (architecture_ == tt::ARCH::BLACKHOLE) {
-        // Blackhole configuration.
-        tlb_reg_size_bytes_ = 12;  // blackhole::TLB_CFG_REG_SIZE_BYTES
-
-        const auto* arch_impl = get_architecture_impl();
-        const auto& tlb_sizes = arch_impl->get_tlb_sizes();
-        tlb_1mb_size_ = 0;             // Not supported
-        tlb_2mb_size_ = tlb_sizes[0];  // 2MB
-        tlb_16mb_size_ = 0;            // Not supported
-        tlb_4gb_size_ = tlb_sizes[1];  // 4GB (second element in Blackhole tlb_sizes)
-
-        tlb_1mb_count_ = 0;
-        tlb_2mb_count_ = 202;
-        tlb_16mb_count_ = 0;
-        tlb_4gb_count_ = 8;
-
-        tlb_1mb_start_index_ = 0;  // Not applicable
-        tlb_2mb_start_index_ = 0;
-        tlb_16mb_start_index_ = 0;  // Not applicable
-        tlb_4gb_start_index_ = tlb_2mb_count_;
-
-        // Initialize allocation tracking.
-        // tlb_1mb_allocated_ and tlb_16mb_allocated_ remain empty
-        tlb_2mb_allocated_.resize(tlb_2mb_count_, false);
-        tlb_4gb_allocated_.resize(tlb_4gb_count_, false);
-
-    } else {
-        log_debug(
-            LogUMD,
-            fmt::format(
-                "Architecture {} does not yet have support for TLB management in simulation. UMD will use legacy "
-                "tile_wr_bytes and tile_rd_bytes path.",
-                tt::arch_to_str(architecture_)));
-    }
+size_t SimulationTlbManager::get_tlb_size_from_index(int tlb_index) {
+    return allocator_.get_tlb_size_from_index(tlb_index);
 }
+
+uint64_t SimulationTlbManager::get_tlb_address_from_index(int tlb_index) {
+    return allocator_.get_tlb_address_from_index(tlb_index);
+}
+
+uint64_t SimulationTlbManager::get_tlb_reg_address_from_index(int tlb_index) {
+    return allocator_.get_tlb_reg_address_from_index(tlb_index);
+}
+
+const architecture_implementation* SimulationTlbManager::get_architecture_impl() const {
+    return allocator_.get_architecture_impl();
+}
+
+tt::ARCH SimulationTlbManager::get_arch() const { return allocator_.get_architecture_impl()->get_architecture(); }
 
 }  // namespace tt::umd

--- a/device/pcie/rtl_sim_tlb_handle.cpp
+++ b/device/pcie/rtl_sim_tlb_handle.cpp
@@ -10,6 +10,7 @@
 #include <tt-logger/tt-logger.hpp>
 
 #include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
+#include "umd/device/types/arch.hpp"
 #include "umd/device/types/tlb.hpp"
 
 namespace tt::umd {
@@ -20,7 +21,10 @@ RtlSimTlbHandle::RtlSimTlbHandle(SimulationTlbManager* manager, int tlb_id, size
     tlb_size_ = size;
     tlb_mapping_ = mapping;
 
-    if (manager_) {
+    // QUASAR bypasses the simulation TLB allocator (see SimulationTlbManager::
+    // allocate_default_tlb_window); skip the allocator query for it so
+    // get_tlb_address_from_index doesn't throw on the empty pool.
+    if (manager_ && manager_->get_arch() != tt::ARCH::QUASAR) {
         // This is a fake, non-dereferenceable pointer used only for address arithmetic.
         // For RTL sim, bar0_base is 0, so this will be a near-null address.
         tlb_base_ = reinterpret_cast<uint8_t*>(manager_->get_tlb_address_from_index(tlb_id_));

--- a/device/pcie/tt_sim_tlb_handle.cpp
+++ b/device/pcie/tt_sim_tlb_handle.cpp
@@ -33,7 +33,11 @@ TTSimTlbHandle::TTSimTlbHandle(
     tlb_mapping_ = tlb_mapping;
 
     // Compute the address for this TLB based on BAR0 base + TLB offset.
-    if (sim_manager_) {
+    // QUASAR bypasses the simulation TLB allocator entirely (the communicator
+    // handles all I/O), so the allocator has no pools and the get_*_from_index
+    // calls would throw. Skip them for QUASAR; tlb_base_ / tlb_reg_addr_ stay at
+    // their defaults (nullptr / 0), which the QUASAR path never dereferences.
+    if (sim_manager_ && sim_manager_->get_arch() != tt::ARCH::QUASAR) {
         tlb_base_ = reinterpret_cast<uint8_t*>(sim_manager_->get_tlb_address_from_index(tlb_id_));
         tlb_reg_addr_ = sim_manager_->get_tlb_reg_address_from_index(tlb_id_);
     }

--- a/tests/baremetal/CMakeLists.txt
+++ b/tests/baremetal/CMakeLists.txt
@@ -14,6 +14,9 @@ target_link_libraries(baremetal_tests PRIVATE test_common)
 if(TT_UMD_BUILD_EMULE)
     target_sources(baremetal_tests PRIVATE test_sw_emule_chip.cpp)
 endif()
+if(TT_UMD_BUILD_SIMULATION)
+    target_sources(baremetal_tests PRIVATE test_simulation_tlb_allocator.cpp)
+endif()
 set_target_properties(
     baremetal_tests
     PROPERTIES

--- a/tests/baremetal/test_simulation_tlb_allocator.cpp
+++ b/tests/baremetal/test_simulation_tlb_allocator.cpp
@@ -67,6 +67,21 @@ TEST(SimulationTlbAllocator, WormholeAllocateZeroPicksSmallest) {
     EXPECT_EQ(allocator.get_tlb_size_from_index(idx), 0x100000);
 }
 
+TEST(SimulationTlbAllocator, WormholeAllocateZeroFallsBackWhenSmallestClassExhausted) {
+    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+
+    // Drain the 1MB pool entirely (Wormhole has 156 1MB TLBs).
+    for (size_t i = 0; i < 156; ++i) {
+        ASSERT_NE(allocator.allocate_tlb_index(0x100000), -1);
+    }
+
+    // size == 0 should fall through to the next non-empty class (2MB) rather than fail.
+    int idx = allocator.allocate_tlb_index(0);
+    ASSERT_NE(idx, -1);
+    EXPECT_EQ(allocator.get_tlb_size_from_index(idx), 0x200000);
+}
+
 TEST(SimulationTlbAllocator, WormholeIndicesAreUniqueWithinSizeClass) {
     auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());

--- a/tests/baremetal/test_simulation_tlb_allocator.cpp
+++ b/tests/baremetal/test_simulation_tlb_allocator.cpp
@@ -176,3 +176,19 @@ TEST(SimulationTlbAllocator, BlackholeRegAddressFromIndex) {
     EXPECT_EQ(allocator.get_tlb_reg_address_from_index(0), 0x2FC00000ULL);
     EXPECT_EQ(allocator.get_tlb_reg_address_from_index(5), 0x2FC0003CULL);
 }
+
+TEST(SimulationTlbAllocator, GettersThrowOnInvalidIndex) {
+    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+
+    // Negative indices are rejected.
+    EXPECT_THROW(allocator.get_tlb_size_from_index(-1), std::exception);
+    EXPECT_THROW(allocator.get_tlb_address_from_index(-1), std::exception);
+    EXPECT_THROW(allocator.get_tlb_reg_address_from_index(-1), std::exception);
+
+    // Indices past the highest valid index (Wormhole has 156+10+20 = 186 TLBs,
+    // so 186 is the first invalid index) are also rejected.
+    EXPECT_THROW(allocator.get_tlb_size_from_index(186), std::exception);
+    EXPECT_THROW(allocator.get_tlb_address_from_index(186), std::exception);
+    EXPECT_THROW(allocator.get_tlb_reg_address_from_index(186), std::exception);
+}

--- a/tests/baremetal/test_simulation_tlb_allocator.cpp
+++ b/tests/baremetal/test_simulation_tlb_allocator.cpp
@@ -1,0 +1,196 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <unordered_set>
+
+#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
+#include "umd/device/types/arch.hpp"
+
+using namespace tt;
+using namespace tt::umd;
+
+namespace {
+
+// Wormhole TLB pool layout (indices and sizes match SimulationTlbAllocator's
+// initialize_architecture_config for tt::ARCH::WORMHOLE_B0).
+constexpr size_t WH_NUM_1MB_TLBS = 156;
+constexpr size_t WH_NUM_2MB_TLBS = 10;
+constexpr size_t WH_TLB_1MB_SIZE = 1ULL << 20;
+constexpr size_t WH_TLB_2MB_SIZE = 2ULL << 20;
+constexpr size_t WH_TLB_16MB_SIZE = 16ULL << 20;
+constexpr size_t WH_TLB_REG_STRIDE = 8;
+
+// Blackhole TLB pool layout.
+constexpr size_t BH_NUM_2MB_TLBS = 202;
+constexpr size_t BH_TLB_2MB_SIZE = 2ULL << 20;
+constexpr size_t BH_TLB_REG_STRIDE = 12;
+
+// Arbitrary nonzero base for address-math assertions.
+constexpr uint64_t TEST_BAR0_BASE = 0x10'000'000ULL;
+
+// TLB configuration registers start at this offset from BAR0 base
+// (see SimulationTlbAllocator::get_tlb_reg_address_from_index).
+constexpr uint64_t TLB_CONFIG_REG_BASE_OFFSET = 0x1fc00000;
+
+}  // namespace
+
+TEST(SimulationTlbAllocator, WormholeBasicAllocateAndDeallocate) {
+    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+
+    int idx = allocator.allocate_tlb_index(WH_TLB_1MB_SIZE);
+    ASSERT_NE(idx, -1);
+    EXPECT_GE(idx, 0);
+    EXPECT_LT(idx, static_cast<int>(WH_NUM_1MB_TLBS));
+    EXPECT_EQ(allocator.get_tlb_size_from_index(idx), WH_TLB_1MB_SIZE);
+
+    allocator.deallocate_tlb_index(idx);
+
+    // After deallocation the same index can be returned again.
+    int idx2 = allocator.allocate_tlb_index(WH_TLB_1MB_SIZE);
+    ASSERT_NE(idx2, -1);
+    EXPECT_EQ(idx2, idx);
+}
+
+TEST(SimulationTlbAllocator, WormholeAllocateEachSizeClass) {
+    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+
+    int idx_1mb = allocator.allocate_tlb_index(WH_TLB_1MB_SIZE);
+    ASSERT_NE(idx_1mb, -1);
+    EXPECT_EQ(allocator.get_tlb_size_from_index(idx_1mb), WH_TLB_1MB_SIZE);
+
+    int idx_2mb = allocator.allocate_tlb_index(WH_TLB_2MB_SIZE);
+    ASSERT_NE(idx_2mb, -1);
+    EXPECT_EQ(allocator.get_tlb_size_from_index(idx_2mb), WH_TLB_2MB_SIZE);
+
+    int idx_16mb = allocator.allocate_tlb_index(WH_TLB_16MB_SIZE);
+    ASSERT_NE(idx_16mb, -1);
+    EXPECT_EQ(allocator.get_tlb_size_from_index(idx_16mb), WH_TLB_16MB_SIZE);
+}
+
+TEST(SimulationTlbAllocator, WormholeAllocateZeroPicksSmallest) {
+    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+
+    int idx = allocator.allocate_tlb_index(0);
+    ASSERT_NE(idx, -1);
+    // Smallest size class on Wormhole is 1MB, indices 0..155.
+    EXPECT_EQ(allocator.get_tlb_size_from_index(idx), WH_TLB_1MB_SIZE);
+}
+
+TEST(SimulationTlbAllocator, WormholeIndicesAreUniqueWithinSizeClass) {
+    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+
+    std::unordered_set<int> seen_indices;
+    seen_indices.reserve(WH_NUM_1MB_TLBS);
+    for (size_t i = 0; i < WH_NUM_1MB_TLBS; ++i) {
+        int idx = allocator.allocate_tlb_index(WH_TLB_1MB_SIZE);
+        ASSERT_NE(idx, -1) << "exhausted at iteration " << i;
+        ASSERT_TRUE(seen_indices.insert(idx).second) << "duplicate index " << idx;
+        ASSERT_EQ(allocator.get_tlb_size_from_index(idx), WH_TLB_1MB_SIZE);
+    }
+}
+
+TEST(SimulationTlbAllocator, WormholeFallsBackToLargerSizeClassWhenExhausted) {
+    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+
+    // Drain the 1MB pool entirely.
+    for (size_t i = 0; i < WH_NUM_1MB_TLBS; ++i) {
+        ASSERT_NE(allocator.allocate_tlb_index(WH_TLB_1MB_SIZE), -1);
+    }
+
+    // A 1MB request now upgrades to a 2MB index because 1MB <= 2MB.
+    int upgraded = allocator.allocate_tlb_index(WH_TLB_1MB_SIZE);
+    ASSERT_NE(upgraded, -1);
+    EXPECT_EQ(allocator.get_tlb_size_from_index(upgraded), WH_TLB_2MB_SIZE);
+}
+
+TEST(SimulationTlbAllocator, WormholeReturnsNegativeOneWhenAllPoolsExhausted) {
+    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+
+    // Exhaust every size class. allocate_tlb_index(0) picks any available TLB.
+    while (allocator.allocate_tlb_index(0) != -1) {
+        // keep allocating.
+    }
+
+    EXPECT_EQ(allocator.allocate_tlb_index(WH_TLB_1MB_SIZE), -1);
+    EXPECT_EQ(allocator.allocate_tlb_index(0), -1);
+}
+
+TEST(SimulationTlbAllocator, WormholeAddressFromIndex) {
+    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+
+    // First 1MB TLB sits at bar0 base.
+    EXPECT_EQ(allocator.get_tlb_address_from_index(0), TEST_BAR0_BASE);
+    // Last 1MB TLB.
+    EXPECT_EQ(
+        allocator.get_tlb_address_from_index(WH_NUM_1MB_TLBS - 1),
+        TEST_BAR0_BASE + (WH_NUM_1MB_TLBS - 1) * WH_TLB_1MB_SIZE);
+    // First 2MB TLB sits right after the 1MB region.
+    const uint64_t end_of_1mb_region = TEST_BAR0_BASE + WH_NUM_1MB_TLBS * WH_TLB_1MB_SIZE;
+    EXPECT_EQ(allocator.get_tlb_address_from_index(WH_NUM_1MB_TLBS), end_of_1mb_region);
+    // First 16MB TLB sits right after the 2MB region.
+    const uint64_t end_of_2mb_region = end_of_1mb_region + WH_NUM_2MB_TLBS * WH_TLB_2MB_SIZE;
+    EXPECT_EQ(allocator.get_tlb_address_from_index(WH_NUM_1MB_TLBS + WH_NUM_2MB_TLBS), end_of_2mb_region);
+}
+
+TEST(SimulationTlbAllocator, WormholeRegAddressFromIndex) {
+    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+
+    EXPECT_EQ(allocator.get_tlb_reg_address_from_index(0), TEST_BAR0_BASE + TLB_CONFIG_REG_BASE_OFFSET);
+    EXPECT_EQ(
+        allocator.get_tlb_reg_address_from_index(7),
+        TEST_BAR0_BASE + TLB_CONFIG_REG_BASE_OFFSET + 7 * WH_TLB_REG_STRIDE);
+}
+
+TEST(SimulationTlbAllocator, BlackholeBasicAllocate) {
+    auto arch_impl = architecture_implementation::create(tt::ARCH::BLACKHOLE);
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+
+    int idx = allocator.allocate_tlb_index(BH_TLB_2MB_SIZE);
+    ASSERT_NE(idx, -1);
+    EXPECT_GE(idx, 0);
+    EXPECT_LT(idx, static_cast<int>(BH_NUM_2MB_TLBS));
+    EXPECT_EQ(allocator.get_tlb_size_from_index(idx), BH_TLB_2MB_SIZE);
+}
+
+TEST(SimulationTlbAllocator, BlackholeAddressFromIndex) {
+    auto arch_impl = architecture_implementation::create(tt::ARCH::BLACKHOLE);
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+
+    EXPECT_EQ(allocator.get_tlb_address_from_index(0), TEST_BAR0_BASE);
+    EXPECT_EQ(
+        allocator.get_tlb_address_from_index(BH_NUM_2MB_TLBS - 1),
+        TEST_BAR0_BASE + (BH_NUM_2MB_TLBS - 1) * BH_TLB_2MB_SIZE);
+}
+
+TEST(SimulationTlbAllocator, BlackholeRegAddressFromIndex) {
+    auto arch_impl = architecture_implementation::create(tt::ARCH::BLACKHOLE);
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+
+    // Blackhole uses a 12-byte register stride.
+    EXPECT_EQ(allocator.get_tlb_reg_address_from_index(0), TEST_BAR0_BASE + TLB_CONFIG_REG_BASE_OFFSET);
+    EXPECT_EQ(
+        allocator.get_tlb_reg_address_from_index(5),
+        TEST_BAR0_BASE + TLB_CONFIG_REG_BASE_OFFSET + 5 * BH_TLB_REG_STRIDE);
+}
+
+TEST(SimulationTlbAllocator, GetArchitectureImpl) {
+    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    const architecture_implementation* raw = arch_impl.get();
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, raw);
+
+    EXPECT_EQ(allocator.get_architecture_impl(), raw);
+}

--- a/tests/baremetal/test_simulation_tlb_allocator.cpp
+++ b/tests/baremetal/test_simulation_tlb_allocator.cpp
@@ -17,26 +17,8 @@ using namespace tt::umd;
 
 namespace {
 
-// Wormhole TLB pool layout (indices and sizes match SimulationTlbAllocator's
-// initialize_architecture_config for tt::ARCH::WORMHOLE_B0).
-constexpr size_t WH_NUM_1MB_TLBS = 156;
-constexpr size_t WH_NUM_2MB_TLBS = 10;
-constexpr size_t WH_TLB_1MB_SIZE = 1ULL << 20;
-constexpr size_t WH_TLB_2MB_SIZE = 2ULL << 20;
-constexpr size_t WH_TLB_16MB_SIZE = 16ULL << 20;
-constexpr size_t WH_TLB_REG_STRIDE = 8;
-
-// Blackhole TLB pool layout.
-constexpr size_t BH_NUM_2MB_TLBS = 202;
-constexpr size_t BH_TLB_2MB_SIZE = 2ULL << 20;
-constexpr size_t BH_TLB_REG_STRIDE = 12;
-
 // Arbitrary nonzero base for address-math assertions.
-constexpr uint64_t TEST_BAR0_BASE = 0x10'000'000ULL;
-
-// TLB configuration registers start at this offset from BAR0 base
-// (see SimulationTlbAllocator::get_tlb_reg_address_from_index).
-constexpr uint64_t TLB_CONFIG_REG_BASE_OFFSET = 0x1fc00000;
+constexpr uint64_t TEST_BAR0_BASE = 0x10000000ULL;
 
 }  // namespace
 
@@ -44,16 +26,16 @@ TEST(SimulationTlbAllocator, WormholeBasicAllocateAndDeallocate) {
     auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
-    int idx = allocator.allocate_tlb_index(WH_TLB_1MB_SIZE);
+    int idx = allocator.allocate_tlb_index(0x100000);
     ASSERT_NE(idx, -1);
     EXPECT_GE(idx, 0);
-    EXPECT_LT(idx, static_cast<int>(WH_NUM_1MB_TLBS));
-    EXPECT_EQ(allocator.get_tlb_size_from_index(idx), WH_TLB_1MB_SIZE);
+    EXPECT_LT(idx, 156);
+    EXPECT_EQ(allocator.get_tlb_size_from_index(idx), 0x100000);
 
     allocator.deallocate_tlb_index(idx);
 
     // After deallocation the same index can be returned again.
-    int idx2 = allocator.allocate_tlb_index(WH_TLB_1MB_SIZE);
+    int idx2 = allocator.allocate_tlb_index(0x100000);
     ASSERT_NE(idx2, -1);
     EXPECT_EQ(idx2, idx);
 }
@@ -62,17 +44,17 @@ TEST(SimulationTlbAllocator, WormholeAllocateEachSizeClass) {
     auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
-    int idx_1mb = allocator.allocate_tlb_index(WH_TLB_1MB_SIZE);
+    int idx_1mb = allocator.allocate_tlb_index(0x100000);
     ASSERT_NE(idx_1mb, -1);
-    EXPECT_EQ(allocator.get_tlb_size_from_index(idx_1mb), WH_TLB_1MB_SIZE);
+    EXPECT_EQ(allocator.get_tlb_size_from_index(idx_1mb), 0x100000);
 
-    int idx_2mb = allocator.allocate_tlb_index(WH_TLB_2MB_SIZE);
+    int idx_2mb = allocator.allocate_tlb_index(0x200000);
     ASSERT_NE(idx_2mb, -1);
-    EXPECT_EQ(allocator.get_tlb_size_from_index(idx_2mb), WH_TLB_2MB_SIZE);
+    EXPECT_EQ(allocator.get_tlb_size_from_index(idx_2mb), 0x200000);
 
-    int idx_16mb = allocator.allocate_tlb_index(WH_TLB_16MB_SIZE);
+    int idx_16mb = allocator.allocate_tlb_index(0x1000000);
     ASSERT_NE(idx_16mb, -1);
-    EXPECT_EQ(allocator.get_tlb_size_from_index(idx_16mb), WH_TLB_16MB_SIZE);
+    EXPECT_EQ(allocator.get_tlb_size_from_index(idx_16mb), 0x1000000);
 }
 
 TEST(SimulationTlbAllocator, WormholeAllocateZeroPicksSmallest) {
@@ -81,8 +63,8 @@ TEST(SimulationTlbAllocator, WormholeAllocateZeroPicksSmallest) {
 
     int idx = allocator.allocate_tlb_index(0);
     ASSERT_NE(idx, -1);
-    // Smallest size class on Wormhole is 1MB, indices 0..155.
-    EXPECT_EQ(allocator.get_tlb_size_from_index(idx), WH_TLB_1MB_SIZE);
+    // Smallest size class on Wormhole is 1MB.
+    EXPECT_EQ(allocator.get_tlb_size_from_index(idx), 0x100000);
 }
 
 TEST(SimulationTlbAllocator, WormholeIndicesAreUniqueWithinSizeClass) {
@@ -90,12 +72,12 @@ TEST(SimulationTlbAllocator, WormholeIndicesAreUniqueWithinSizeClass) {
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
     std::unordered_set<int> seen_indices;
-    seen_indices.reserve(WH_NUM_1MB_TLBS);
-    for (size_t i = 0; i < WH_NUM_1MB_TLBS; ++i) {
-        int idx = allocator.allocate_tlb_index(WH_TLB_1MB_SIZE);
+    seen_indices.reserve(156);
+    for (size_t i = 0; i < 156; ++i) {
+        int idx = allocator.allocate_tlb_index(0x100000);
         ASSERT_NE(idx, -1) << "exhausted at iteration " << i;
         ASSERT_TRUE(seen_indices.insert(idx).second) << "duplicate index " << idx;
-        ASSERT_EQ(allocator.get_tlb_size_from_index(idx), WH_TLB_1MB_SIZE);
+        ASSERT_EQ(allocator.get_tlb_size_from_index(idx), 0x100000);
     }
 }
 
@@ -103,15 +85,15 @@ TEST(SimulationTlbAllocator, WormholeFallsBackToLargerSizeClassWhenExhausted) {
     auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
-    // Drain the 1MB pool entirely.
-    for (size_t i = 0; i < WH_NUM_1MB_TLBS; ++i) {
-        ASSERT_NE(allocator.allocate_tlb_index(WH_TLB_1MB_SIZE), -1);
+    // Drain the 1MB pool entirely (Wormhole has 156 1MB TLBs).
+    for (size_t i = 0; i < 156; ++i) {
+        ASSERT_NE(allocator.allocate_tlb_index(0x100000), -1);
     }
 
     // A 1MB request now upgrades to a 2MB index because 1MB <= 2MB.
-    int upgraded = allocator.allocate_tlb_index(WH_TLB_1MB_SIZE);
+    int upgraded = allocator.allocate_tlb_index(0x100000);
     ASSERT_NE(upgraded, -1);
-    EXPECT_EQ(allocator.get_tlb_size_from_index(upgraded), WH_TLB_2MB_SIZE);
+    EXPECT_EQ(allocator.get_tlb_size_from_index(upgraded), 0x200000);
 }
 
 TEST(SimulationTlbAllocator, WormholeReturnsNegativeOneWhenAllPoolsExhausted) {
@@ -123,7 +105,7 @@ TEST(SimulationTlbAllocator, WormholeReturnsNegativeOneWhenAllPoolsExhausted) {
         // keep allocating.
     }
 
-    EXPECT_EQ(allocator.allocate_tlb_index(WH_TLB_1MB_SIZE), -1);
+    EXPECT_EQ(allocator.allocate_tlb_index(0x100000), -1);
     EXPECT_EQ(allocator.allocate_tlb_index(0), -1);
 }
 
@@ -131,66 +113,51 @@ TEST(SimulationTlbAllocator, WormholeAddressFromIndex) {
     auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
-    // First 1MB TLB sits at bar0 base.
-    EXPECT_EQ(allocator.get_tlb_address_from_index(0), TEST_BAR0_BASE);
-    // Last 1MB TLB.
-    EXPECT_EQ(
-        allocator.get_tlb_address_from_index(WH_NUM_1MB_TLBS - 1),
-        TEST_BAR0_BASE + (WH_NUM_1MB_TLBS - 1) * WH_TLB_1MB_SIZE);
-    // First 2MB TLB sits right after the 1MB region.
-    const uint64_t end_of_1mb_region = TEST_BAR0_BASE + WH_NUM_1MB_TLBS * WH_TLB_1MB_SIZE;
-    EXPECT_EQ(allocator.get_tlb_address_from_index(WH_NUM_1MB_TLBS), end_of_1mb_region);
-    // First 16MB TLB sits right after the 2MB region.
-    const uint64_t end_of_2mb_region = end_of_1mb_region + WH_NUM_2MB_TLBS * WH_TLB_2MB_SIZE;
-    EXPECT_EQ(allocator.get_tlb_address_from_index(WH_NUM_1MB_TLBS + WH_NUM_2MB_TLBS), end_of_2mb_region);
+    // Wormhole layout from BAR0 base 0x10000000:
+    //   indices   0..155: 156 x 1MB  (0x10000000 .. 0x19BFFFFF)
+    //   indices 156..165: 10  x 2MB  (0x19C00000 .. 0x1AFFFFFF)
+    //   indices 166..185: 20  x 16MB (0x1B000000 .. 0x2AFFFFFF)
+    EXPECT_EQ(allocator.get_tlb_address_from_index(0), 0x10000000ULL);
+    EXPECT_EQ(allocator.get_tlb_address_from_index(155), 0x19B00000ULL);
+    EXPECT_EQ(allocator.get_tlb_address_from_index(156), 0x19C00000ULL);
+    EXPECT_EQ(allocator.get_tlb_address_from_index(166), 0x1B000000ULL);
 }
 
 TEST(SimulationTlbAllocator, WormholeRegAddressFromIndex) {
     auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
-    EXPECT_EQ(allocator.get_tlb_reg_address_from_index(0), TEST_BAR0_BASE + TLB_CONFIG_REG_BASE_OFFSET);
-    EXPECT_EQ(
-        allocator.get_tlb_reg_address_from_index(7),
-        TEST_BAR0_BASE + TLB_CONFIG_REG_BASE_OFFSET + 7 * WH_TLB_REG_STRIDE);
+    // TLB config registers start at BAR0+0x1FC00000 with 8-byte stride on Wormhole.
+    EXPECT_EQ(allocator.get_tlb_reg_address_from_index(0), 0x2FC00000ULL);
+    EXPECT_EQ(allocator.get_tlb_reg_address_from_index(7), 0x2FC00038ULL);
 }
 
 TEST(SimulationTlbAllocator, BlackholeBasicAllocate) {
     auto arch_impl = architecture_implementation::create(tt::ARCH::BLACKHOLE);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
-    int idx = allocator.allocate_tlb_index(BH_TLB_2MB_SIZE);
+    int idx = allocator.allocate_tlb_index(0x200000);
     ASSERT_NE(idx, -1);
     EXPECT_GE(idx, 0);
-    EXPECT_LT(idx, static_cast<int>(BH_NUM_2MB_TLBS));
-    EXPECT_EQ(allocator.get_tlb_size_from_index(idx), BH_TLB_2MB_SIZE);
+    EXPECT_LT(idx, 202);
+    EXPECT_EQ(allocator.get_tlb_size_from_index(idx), 0x200000);
 }
 
 TEST(SimulationTlbAllocator, BlackholeAddressFromIndex) {
     auto arch_impl = architecture_implementation::create(tt::ARCH::BLACKHOLE);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
-    EXPECT_EQ(allocator.get_tlb_address_from_index(0), TEST_BAR0_BASE);
-    EXPECT_EQ(
-        allocator.get_tlb_address_from_index(BH_NUM_2MB_TLBS - 1),
-        TEST_BAR0_BASE + (BH_NUM_2MB_TLBS - 1) * BH_TLB_2MB_SIZE);
+    // Blackhole layout from BAR0 base 0x10000000:
+    //   indices 0..201: 202 x 2MB (0x10000000 .. 0x291FFFFF)
+    EXPECT_EQ(allocator.get_tlb_address_from_index(0), 0x10000000ULL);
+    EXPECT_EQ(allocator.get_tlb_address_from_index(201), 0x29200000ULL);
 }
 
 TEST(SimulationTlbAllocator, BlackholeRegAddressFromIndex) {
     auto arch_impl = architecture_implementation::create(tt::ARCH::BLACKHOLE);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
-    // Blackhole uses a 12-byte register stride.
-    EXPECT_EQ(allocator.get_tlb_reg_address_from_index(0), TEST_BAR0_BASE + TLB_CONFIG_REG_BASE_OFFSET);
-    EXPECT_EQ(
-        allocator.get_tlb_reg_address_from_index(5),
-        TEST_BAR0_BASE + TLB_CONFIG_REG_BASE_OFFSET + 5 * BH_TLB_REG_STRIDE);
-}
-
-TEST(SimulationTlbAllocator, GetArchitectureImpl) {
-    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
-    const architecture_implementation* raw = arch_impl.get();
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, raw);
-
-    EXPECT_EQ(allocator.get_architecture_impl(), raw);
+    // TLB config registers start at BAR0+0x1FC00000 with 12-byte stride on Blackhole.
+    EXPECT_EQ(allocator.get_tlb_reg_address_from_index(0), 0x2FC00000ULL);
+    EXPECT_EQ(allocator.get_tlb_reg_address_from_index(5), 0x2FC0003CULL);
 }


### PR DESCRIPTION
### Issue

Refs #2317. First PR in a stack of five for #2317. Followed by #2540.

### Description

Pure refactor — no behavior change. First step toward the `TLBManager` allocation/factory split tracked in #2317.

Today `SimulationTlbManager` mixes two unrelated responsibilities: TLB index bookkeeping (size-class bitmaps, free/used tracking, BAR0-relative address math) and `TlbHandle`/`TlbWindow` construction (the `TlbWindowFactory` callable used by simulation backends).

This PR carves the bookkeeping half out into a new `SimulationTlbAllocator` class. `SimulationTlbManager` holds one as a member and forwards the index/address methods to it. The factory-half stays put for now; it moves out in later PRs in the stack.

### List of the changes

- New class `SimulationTlbAllocator` (`device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp`, `device/chip_helpers/simulation_tlb_allocator.cpp`) owning: per-size-class allocation bitmaps, allocation mutex, per-arch sizes/counts/start indices, `bar0_base_`, `arch_impl_`, and the methods `allocate_tlb_index`, `deallocate_tlb_index`, `get_tlb_size_from_index`, `get_tlb_address_from_index`, `get_tlb_reg_address_from_index`, `get_architecture_impl`.
- `SimulationTlbManager` now holds a `SimulationTlbAllocator allocator_` member. The same index/address methods stay on `SimulationTlbManager` as thin forwarders so simulation `TlbHandle` subclasses (`TTSimTlbHandle`, `RtlSimTlbHandle`) that hold a `SimulationTlbManager*` back-pointer keep working unchanged. Handle back-pointer migration is the next PR in the stack (#2540).
- `allocate_tlb_window` and `allocate_default_tlb_window` keep their semantics: they consult the allocator for index/size and pass `this` to the existing `TlbWindowFactory`.
- `device/CMakeLists.txt`: registered the new header in the public API file set and the new cpp in the simulation sources block.

### Testing

CI.

### API Changes

There are no API changes in this PR.
