### PR TITLE
Add TlbAllocator interface; introduce KmdTlbAllocator; SimulationTlbAllocator inherits

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -74,6 +74,7 @@ target_sources(
         chip_helpers/simulation_sysmem_manager.cpp
         chip_helpers/silicon_sysmem_manager.cpp
         chip_helpers/sysmem_buffer.cpp
+        chip_helpers/kmd_tlb_allocator.cpp
         chip_helpers/tlb_manager.cpp
         pcie/tlb_window.cpp
         pcie/silicon_tlb_window.cpp
@@ -190,7 +191,9 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/chip_helpers/sysmem_manager.hpp
                 api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
                 api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
+                api/umd/device/chip_helpers/kmd_tlb_allocator.hpp
                 api/umd/device/chip_helpers/sysmem_buffer.hpp
+                api/umd/device/chip_helpers/tlb_allocator.hpp
                 api/umd/device/chip_helpers/tlb_manager.hpp
                 api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
                 api/umd/device/chip_helpers/simulation_tlb_manager.hpp

--- a/device/api/umd/device/chip_helpers/kmd_tlb_allocator.hpp
+++ b/device/api/umd/device/chip_helpers/kmd_tlb_allocator.hpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "umd/device/chip_helpers/tlb_allocator.hpp"
+
+namespace tt::umd {
+
+class PCIDevice;
+class architecture_implementation;
+
+/**
+ * Silicon TLB allocator. Delegates to KMD via PCIDevice::allocate_tlb.
+ *
+ * KMD owns the actual bookkeeping. This class only handles the size-fallback
+ * loop when the caller passes size=0.
+ */
+class KmdTlbAllocator : public TlbAllocator {
+public:
+    KmdTlbAllocator(PCIDevice* pci_device, const architecture_implementation* arch_impl);
+
+    std::unique_ptr<TlbHandle> allocate(size_t size, TlbMapping mapping) override;
+
+private:
+    PCIDevice* pci_device_ = nullptr;
+    const architecture_implementation* arch_impl_ = nullptr;
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
@@ -6,25 +6,46 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <mutex>
 #include <vector>
 
+#include "umd/device/chip_helpers/tlb_allocator.hpp"
 #include "umd/device/types/arch.hpp"
 
 namespace tt::umd {
 
 class architecture_implementation;
+class SimulationTlbAllocator;
+
+/**
+ * Backend-specific factory: builds a TlbHandle for a given index.
+ * Different sim backends (TTSim, RTL sim) provide their own factory.
+ */
+using TlbHandleFactory = std::function<std::unique_ptr<TlbHandle>(
+    SimulationTlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping)>;
 
 /**
  * In-process allocator for simulation TLB indices.
  *
  * Tracks which TLB indices are allocated per size class, and computes BAR0-relative
  * addresses for a given index. Counterpart to KMD-managed allocation on silicon —
- * no knowledge of TlbHandle / TlbWindow types.
+ * allocate() returns a fully-built TlbHandle by combining the index allocation with
+ * a backend-supplied TlbHandleFactory.
  */
-class SimulationTlbAllocator {
+class SimulationTlbAllocator : public TlbAllocator {
 public:
-    SimulationTlbAllocator(uint64_t bar0_base, const architecture_implementation* arch_impl);
+    SimulationTlbAllocator(
+        uint64_t bar0_base, const architecture_implementation* arch_impl, TlbHandleFactory handle_factory);
+
+    std::unique_ptr<TlbHandle> allocate(size_t size, TlbMapping mapping) override;
+
+    /**
+     * Build a handle for an explicit (non-allocated) TLB index. Used by simulation
+     * backends like Quasar that do not back windows with real TLBs but still need
+     * a handle. Bypasses bitmap allocation entirely.
+     */
+    std::unique_ptr<TlbHandle> build_handle_for_index(int tlb_index, size_t size, TlbMapping mapping);
 
     /**
      * Allocate a TLB index that fits the requested size. If size is 0, allocate
@@ -62,6 +83,7 @@ private:
 
     uint64_t bar0_base_ = 0;
     const architecture_implementation* arch_impl_ = nullptr;
+    TlbHandleFactory handle_factory_;
 
     // Architecture-specific TLB configuration.
     tt::ARCH architecture_;

--- a/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
@@ -11,16 +11,14 @@
 
 namespace tt::umd {
 
-class SimulationTlbManager;
 class architecture_implementation;
 
 /**
- * Factory function type for creating TlbWindow instances.
- * Different simulation backends (TTSim, RTL sim) provide their own factory
- * that creates the appropriate TlbHandle + TlbWindow combination.
+ * Backend-specific builder that wraps a TlbHandle in the appropriate TlbWindow
+ * subclass (e.g. TTSimTlbWindow, RtlSimTlbWindow) and applies the supplied config.
  */
-using TlbWindowFactory = std::function<std::unique_ptr<TlbWindow>(
-    SimulationTlbManager* manager, int tlb_id, size_t size, TlbMapping mapping, tlb_data config)>;
+using TlbWindowBuilder =
+    std::function<std::unique_ptr<TlbWindow>(std::unique_ptr<TlbHandle> handle, const tlb_data& config)>;
 
 class SimulationTlbManager : public TLBManager {
 public:
@@ -28,7 +26,8 @@ public:
         TTDevice* tt_device,
         uint64_t bar0_base,
         const architecture_implementation* arch_impl,
-        TlbWindowFactory factory);
+        TlbHandleFactory handle_factory,
+        TlbWindowBuilder window_builder);
 
     std::unique_ptr<TlbWindow> allocate_tlb_window(
         tlb_data config, const TlbMapping mapping = TlbMapping::WC, const size_t tlb_size = 0) override;
@@ -39,20 +38,11 @@ public:
      */
     std::unique_ptr<TlbWindow> allocate_default_tlb_window();
 
-    // The methods below forward to the underlying SimulationTlbAllocator. They are
-    // exposed on SimulationTlbManager for back-compat with simulation TlbHandle
-    // subclasses that hold a SimulationTlbManager* back-pointer.
-
-    int allocate_tlb_index(size_t size);
-    void deallocate_tlb_index(int tlb_index);
-    size_t get_tlb_size_from_index(int tlb_index);
-    uint64_t get_tlb_address_from_index(int tlb_index);
-    uint64_t get_tlb_reg_address_from_index(int tlb_index);
-    const architecture_implementation* get_architecture_impl() const;
+    SimulationTlbAllocator& get_allocator() { return allocator_; }
 
 private:
     SimulationTlbAllocator allocator_;
-    TlbWindowFactory factory_;
+    TlbWindowBuilder window_builder_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/tlb_allocator.hpp
+++ b/device/api/umd/device/chip_helpers/tlb_allocator.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include "umd/device/types/tlb.hpp"
+
+namespace tt::umd {
+
+class TlbHandle;
+
+/**
+ * Backend-agnostic interface for TLB allocation.
+ *
+ * Concrete implementations:
+ * - KmdTlbAllocator: silicon, delegates to KMD via PCIDevice::allocate_tlb.
+ * - SimulationTlbAllocator: simulation, in-process bitmap allocator.
+ */
+class TlbAllocator {
+public:
+    virtual ~TlbAllocator() = default;
+
+    /**
+     * Allocate a TlbHandle of the requested size.
+     *
+     * @param size Requested TLB size in bytes. If 0, the allocator is free to
+     *             pick any architecturally supported size (typically smallest first).
+     * @param mapping UC or WC.
+     * @return Owning TlbHandle. Throws on failure.
+     */
+    virtual std::unique_ptr<TlbHandle> allocate(size_t size, TlbMapping mapping) = 0;
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/pcie/rtl_sim_tlb_handle.hpp
+++ b/device/api/umd/device/pcie/rtl_sim_tlb_handle.hpp
@@ -13,7 +13,7 @@
 
 namespace tt::umd {
 
-class SimulationTlbManager;
+class SimulationTlbAllocator;
 
 /**
  * RTL simulation TlbHandle that stores TLB configuration in software only.
@@ -24,20 +24,20 @@ class SimulationTlbManager;
 class RtlSimTlbHandle : public TlbHandle {
 public:
     static std::unique_ptr<RtlSimTlbHandle> create(
-        SimulationTlbManager* manager, int tlb_id, size_t size, TlbMapping mapping);
+        SimulationTlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping);
 
     ~RtlSimTlbHandle() noexcept;
 
     void configure(const tlb_data& new_config) override;
 
-    SimulationTlbManager* get_tlb_manager() const { return manager_; }
+    SimulationTlbAllocator* get_tlb_allocator() const { return allocator_; }
 
 private:
-    RtlSimTlbHandle(SimulationTlbManager* manager, int tlb_id, size_t size, TlbMapping mapping);
+    RtlSimTlbHandle(SimulationTlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping);
 
     void free_tlb() noexcept override;
 
-    SimulationTlbManager* manager_;
+    SimulationTlbAllocator* allocator_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/pcie/tt_sim_tlb_handle.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_handle.hpp
@@ -14,7 +14,7 @@
 
 namespace tt::umd {
 
-class SimulationTlbManager;
+class SimulationTlbAllocator;
 
 /**
  * Simulation-specific TlbHandle that inherits from TlbHandle but bypasses hardware operations.
@@ -27,7 +27,7 @@ public:
      * This bypasses the hardware constructor and sets up simulation state.
      */
     static std::unique_ptr<TTSimTlbHandle> create(
-        SimulationTlbManager* manager,
+        SimulationTlbAllocator* allocator,
         class TTSimCommunicator* communicator,
         int tlb_id,
         size_t size,
@@ -37,12 +37,12 @@ public:
 
     void configure(const tlb_data& new_config) override;
 
-    SimulationTlbManager* get_tlb_manager() const { return sim_manager_; }
+    SimulationTlbAllocator* get_tlb_allocator() const { return allocator_; }
 
 private:
     // Private constructor to enforce use of create() factory method.
     TTSimTlbHandle(
-        SimulationTlbManager* manager,
+        SimulationTlbAllocator* allocator,
         class TTSimCommunicator* communicator,
         int tlb_id,
         size_t size,
@@ -50,7 +50,7 @@ private:
 
     void free_tlb() noexcept override;
 
-    SimulationTlbManager* sim_manager_;
+    SimulationTlbAllocator* allocator_;
     class TTSimCommunicator* sim_communicator_;
     uint64_t tlb_reg_addr_ = 0;
 };

--- a/device/chip_helpers/kmd_tlb_allocator.cpp
+++ b/device/chip_helpers/kmd_tlb_allocator.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/chip_helpers/kmd_tlb_allocator.hpp"
+
+#include <exception>
+#include <tt-logger/tt-logger.hpp>
+#include <vector>
+
+#include "assert.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/utils/error.hpp"
+
+namespace tt::umd {
+
+KmdTlbAllocator::KmdTlbAllocator(PCIDevice* pci_device, const architecture_implementation* arch_impl) :
+    pci_device_(pci_device), arch_impl_(arch_impl) {}
+
+std::unique_ptr<TlbHandle> KmdTlbAllocator::allocate(size_t size, TlbMapping mapping) {
+    if (size != 0) {
+        return pci_device_->allocate_tlb(size, mapping);
+    }
+
+    // Caller didn't specify a size — try arch-supported sizes in preference order.
+    const std::vector<size_t>& possible_sizes = arch_impl_->get_tlb_sizes();
+    for (const auto& s : possible_sizes) {
+        try {
+            return pci_device_->allocate_tlb(s, mapping);
+        } catch (const std::exception& e) {
+            log_error(LogUMD, "Failed to allocate TLB window of size {}: {}", s, e.what());
+        }
+    }
+
+    UMD_THROW(error::RuntimeError, "Failed to allocate TLB window.");
+}
+
+}  // namespace tt::umd

--- a/device/chip_helpers/simulation_tlb_allocator.cpp
+++ b/device/chip_helpers/simulation_tlb_allocator.cpp
@@ -5,17 +5,35 @@
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 
 #include <tt-logger/tt-logger.hpp>
+#include <utility>
 
 #include "assert.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/pcie/tlb_handle.hpp"
+#include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
 
-SimulationTlbAllocator::SimulationTlbAllocator(uint64_t bar0_base, const architecture_implementation* arch_impl) :
-    bar0_base_(bar0_base), arch_impl_(arch_impl) {
+SimulationTlbAllocator::SimulationTlbAllocator(
+    uint64_t bar0_base, const architecture_implementation* arch_impl, TlbHandleFactory handle_factory) :
+    bar0_base_(bar0_base), arch_impl_(arch_impl), handle_factory_(std::move(handle_factory)) {
     initialize_architecture_config();
+}
+
+std::unique_ptr<TlbHandle> SimulationTlbAllocator::allocate(size_t size, TlbMapping mapping) {
+    int tlb_index = allocate_tlb_index(size);
+    if (tlb_index == -1) {
+        UMD_THROW(error::RuntimeError, "No available TLB of requested size.");
+    }
+    size_t actual_size = get_tlb_size_from_index(tlb_index);
+    return handle_factory_(this, tlb_index, actual_size, mapping);
+}
+
+std::unique_ptr<TlbHandle> SimulationTlbAllocator::build_handle_for_index(
+    int tlb_index, size_t size, TlbMapping mapping) {
+    return handle_factory_(this, tlb_index, size, mapping);
 }
 
 int SimulationTlbAllocator::allocate_tlb_index(size_t size) {

--- a/device/chip_helpers/simulation_tlb_manager.cpp
+++ b/device/chip_helpers/simulation_tlb_manager.cpp
@@ -15,19 +15,19 @@
 namespace tt::umd {
 
 SimulationTlbManager::SimulationTlbManager(
-    TTDevice* tt_device, uint64_t bar0_base, const architecture_implementation* arch_impl, TlbWindowFactory factory) :
-    TLBManager(tt_device), allocator_(bar0_base, arch_impl), factory_(std::move(factory)) {}
+    TTDevice* tt_device,
+    uint64_t bar0_base,
+    const architecture_implementation* arch_impl,
+    TlbHandleFactory handle_factory,
+    TlbWindowBuilder window_builder) :
+    TLBManager(tt_device),
+    allocator_(bar0_base, arch_impl, std::move(handle_factory)),
+    window_builder_(std::move(window_builder)) {}
 
 std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_tlb_window(
     tlb_data config, const TlbMapping mapping, const size_t tlb_size) {
-    int tlb_index = allocator_.allocate_tlb_index(tlb_size);
-    if (tlb_index == -1) {
-        UMD_THROW(error::RuntimeError, "No available TLB of requested size.");
-    }
-
-    size_t actual_tlb_size = allocator_.get_tlb_size_from_index(tlb_index);
-
-    return factory_(this, tlb_index, actual_tlb_size, mapping, config);
+    auto handle = allocator_.allocate(tlb_size, mapping);
+    return window_builder_(std::move(handle), config);
 }
 
 std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
@@ -44,8 +44,10 @@ std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
             return allocate_tlb_window({}, TlbMapping::WC, SIZE_2MB);
         case tt::ARCH::WORMHOLE_B0:
             return allocate_tlb_window({}, TlbMapping::WC, SIZE_16MB);
-        case tt::ARCH::QUASAR:
-            return factory_(this, 0, SIZE_4GB, TlbMapping::WC, {});
+        case tt::ARCH::QUASAR: {
+            auto handle = allocator_.build_handle_for_index(0, SIZE_4GB, TlbMapping::WC);
+            return window_builder_(std::move(handle), {});
+        }
         default:
             log_debug(
                 LogUMD,
@@ -53,26 +55,6 @@ std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
                 tt::arch_to_str(architecture));
             return nullptr;
     }
-}
-
-int SimulationTlbManager::allocate_tlb_index(size_t size) { return allocator_.allocate_tlb_index(size); }
-
-void SimulationTlbManager::deallocate_tlb_index(int tlb_index) { allocator_.deallocate_tlb_index(tlb_index); }
-
-size_t SimulationTlbManager::get_tlb_size_from_index(int tlb_index) {
-    return allocator_.get_tlb_size_from_index(tlb_index);
-}
-
-uint64_t SimulationTlbManager::get_tlb_address_from_index(int tlb_index) {
-    return allocator_.get_tlb_address_from_index(tlb_index);
-}
-
-uint64_t SimulationTlbManager::get_tlb_reg_address_from_index(int tlb_index) {
-    return allocator_.get_tlb_reg_address_from_index(tlb_index);
-}
-
-const architecture_implementation* SimulationTlbManager::get_architecture_impl() const {
-    return allocator_.get_architecture_impl();
 }
 
 }  // namespace tt::umd

--- a/device/pcie/rtl_sim_tlb_handle.cpp
+++ b/device/pcie/rtl_sim_tlb_handle.cpp
@@ -9,20 +9,20 @@
 #include <memory>
 #include <tt-logger/tt-logger.hpp>
 
-#include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
+#include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 
 namespace tt::umd {
 
-RtlSimTlbHandle::RtlSimTlbHandle(SimulationTlbManager* manager, int tlb_id, size_t size, TlbMapping mapping) :
-    manager_(manager) {
+RtlSimTlbHandle::RtlSimTlbHandle(SimulationTlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping) :
+    allocator_(allocator) {
     tlb_id_ = tlb_id;
     tlb_size_ = size;
     tlb_mapping_ = mapping;
 
-    if (manager_) {
+    if (allocator_) {
         // This is a fake, non-dereferenceable pointer used only for address arithmetic.
         // For RTL sim, bar0_base is 0, so this will be a near-null address.
-        tlb_base_ = reinterpret_cast<uint8_t*>(manager_->get_tlb_address_from_index(tlb_id_));
+        tlb_base_ = reinterpret_cast<uint8_t*>(allocator_->get_tlb_address_from_index(tlb_id_));
     }
 
     log_debug(
@@ -34,8 +34,8 @@ RtlSimTlbHandle::RtlSimTlbHandle(SimulationTlbManager* manager, int tlb_id, size
 }
 
 std::unique_ptr<RtlSimTlbHandle> RtlSimTlbHandle::create(
-    SimulationTlbManager* manager, int tlb_id, size_t size, TlbMapping mapping) {
-    return std::unique_ptr<RtlSimTlbHandle>(new RtlSimTlbHandle(manager, tlb_id, size, mapping));
+    SimulationTlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping) {
+    return std::unique_ptr<RtlSimTlbHandle>(new RtlSimTlbHandle(allocator, tlb_id, size, mapping));
 }
 
 RtlSimTlbHandle::~RtlSimTlbHandle() noexcept { RtlSimTlbHandle::free_tlb(); }
@@ -58,9 +58,9 @@ void RtlSimTlbHandle::configure(const tlb_data& new_config) {
 }
 
 void RtlSimTlbHandle::free_tlb() noexcept {
-    if (manager_) {
-        manager_->deallocate_tlb_index(tlb_id_);
-        manager_ = nullptr;
+    if (allocator_) {
+        allocator_->deallocate_tlb_index(tlb_id_);
+        allocator_ = nullptr;
 
         log_debug(LogUMD, "Freed RTL sim TLB with ID {}", tlb_id_);
     }

--- a/device/pcie/rtl_sim_tlb_window.cpp
+++ b/device/pcie/rtl_sim_tlb_window.cpp
@@ -68,7 +68,7 @@ uint16_t RtlSimTlbWindow::safe_read16(uint64_t offset) { return read16(offset); 
 
 tt::ARCH RtlSimTlbWindow::get_arch() const {
     auto* handle = dynamic_cast<RtlSimTlbHandle*>(tlb_handle.get());
-    return handle->get_tlb_manager()->get_tt_device()->get_arch();
+    return handle->get_tlb_allocator()->get_architecture_impl()->get_architecture();
 }
 
 }  // namespace tt::umd

--- a/device/pcie/tt_sim_tlb_handle.cpp
+++ b/device/pcie/tt_sim_tlb_handle.cpp
@@ -12,29 +12,26 @@
 
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
-#include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
+#include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"
 
 namespace tt::umd {
 
-// Forward declaration to avoid circular dependency.
-class SimulationTlbManager;
-
 TTSimTlbHandle::TTSimTlbHandle(
-    SimulationTlbManager* manager,
+    SimulationTlbAllocator* allocator,
     TTSimCommunicator* communicator,
     int tlb_id,
     size_t size,
     const TlbMapping tlb_mapping) :
-    sim_manager_(manager), sim_communicator_(communicator) {
+    allocator_(allocator), sim_communicator_(communicator) {
     tlb_id_ = tlb_id;
     tlb_size_ = size;
     tlb_mapping_ = tlb_mapping;
 
     // Compute the address for this TLB based on BAR0 base + TLB offset.
-    if (sim_manager_) {
-        tlb_base_ = reinterpret_cast<uint8_t*>(sim_manager_->get_tlb_address_from_index(tlb_id_));
-        tlb_reg_addr_ = sim_manager_->get_tlb_reg_address_from_index(tlb_id_);
+    if (allocator_) {
+        tlb_base_ = reinterpret_cast<uint8_t*>(allocator_->get_tlb_address_from_index(tlb_id_));
+        tlb_reg_addr_ = allocator_->get_tlb_reg_address_from_index(tlb_id_);
     }
 
     log_debug(
@@ -46,12 +43,12 @@ TTSimTlbHandle::TTSimTlbHandle(
 }
 
 std::unique_ptr<TTSimTlbHandle> TTSimTlbHandle::create(
-    SimulationTlbManager* manager,
+    SimulationTlbAllocator* allocator,
     TTSimCommunicator* communicator,
     int tlb_id,
     size_t size,
     const TlbMapping tlb_mapping) {
-    return std::unique_ptr<TTSimTlbHandle>(new TTSimTlbHandle(manager, communicator, tlb_id, size, tlb_mapping));
+    return std::unique_ptr<TTSimTlbHandle>(new TTSimTlbHandle(allocator, communicator, tlb_id, size, tlb_mapping));
 }
 
 TTSimTlbHandle::~TTSimTlbHandle() noexcept { TTSimTlbHandle::free_tlb(); }
@@ -64,8 +61,8 @@ void TTSimTlbHandle::configure(const tlb_data& new_config) {
     tlb_config_.ordering = 0;
     tlb_config_.static_vc = 0;
 
-    // Get architecture from manager to determine correct offsets.
-    const architecture_implementation* arch_impl = sim_manager_->get_architecture_impl();
+    // Get architecture from allocator to determine correct offsets.
+    const architecture_implementation* arch_impl = allocator_->get_architecture_impl();
     tt::ARCH architecture = arch_impl->get_architecture();
 
     log_debug(
@@ -143,9 +140,9 @@ void TTSimTlbHandle::configure(const tlb_data& new_config) {
 }
 
 void TTSimTlbHandle::free_tlb() noexcept {
-    if (sim_manager_) {
-        sim_manager_->deallocate_tlb_index(tlb_id_);
-        sim_manager_ = nullptr;
+    if (allocator_) {
+        allocator_->deallocate_tlb_index(tlb_id_);
+        allocator_ = nullptr;
 
         log_debug(LogUMD, "Freed simulation TLB with ID {}", tlb_id_);
     }

--- a/device/pcie/tt_sim_tlb_window.cpp
+++ b/device/pcie/tt_sim_tlb_window.cpp
@@ -76,7 +76,7 @@ uint16_t TTSimTlbWindow::safe_read16(uint64_t offset) { return read16(offset); }
 
 tt::ARCH TTSimTlbWindow::get_arch() const {
     auto* sim_handle = dynamic_cast<TTSimTlbHandle*>(tlb_handle.get());
-    return sim_handle->get_tlb_manager()->get_tt_device()->get_arch();
+    return sim_handle->get_tlb_allocator()->get_architecture_impl()->get_architecture();
 }
 
 }  // namespace tt::umd

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -87,11 +87,11 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
         this,
         /*bar0_base=*/0,
         architecture_impl_.get(),
-        [comm = communicator_.get()](
-            SimulationTlbManager* mgr, int id, size_t sz, TlbMapping map, tlb_data cfg) -> std::unique_ptr<TlbWindow> {
-            auto handle = RtlSimTlbHandle::create(mgr, id, sz, map);
-            return std::make_unique<RtlSimTlbWindow>(std::move(handle), comm, cfg);
-        });
+        [](SimulationTlbAllocator* alloc, int id, size_t sz, TlbMapping map) -> std::unique_ptr<TlbHandle> {
+            return RtlSimTlbHandle::create(alloc, id, sz, map);
+        },
+        [comm = communicator_.get()](std::unique_ptr<TlbHandle> handle, const tlb_data& cfg)
+            -> std::unique_ptr<TlbWindow> { return std::make_unique<RtlSimTlbWindow>(std::move(handle), comm, cfg); });
     cached_tlb_window_ = tlb_manager_->allocate_default_tlb_window();
 }
 

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -86,11 +86,10 @@ TTSimTTDevice::TTSimTTDevice(
         this,
         bar0_base,
         architecture_impl_.get(),
-        [comm = communicator_.get()](
-            SimulationTlbManager* mgr, int id, size_t sz, TlbMapping map, tlb_data cfg) -> std::unique_ptr<TlbWindow> {
-            auto handle = TTSimTlbHandle::create(mgr, comm, id, sz, map);
-            return std::make_unique<TTSimTlbWindow>(std::move(handle), comm, cfg);
-        });
+        [comm = communicator_.get()](SimulationTlbAllocator* alloc, int id, size_t sz, TlbMapping map)
+            -> std::unique_ptr<TlbHandle> { return TTSimTlbHandle::create(alloc, comm, id, sz, map); },
+        [comm = communicator_.get()](std::unique_ptr<TlbHandle> handle, const tlb_data& cfg)
+            -> std::unique_ptr<TlbWindow> { return std::make_unique<TTSimTlbWindow>(std::move(handle), comm, cfg); });
     cached_tlb_window_ = tlb_manager_->allocate_default_tlb_window();
 }
 


### PR DESCRIPTION
### Issue

Refs #2317. Stacked on #2538.

### Description

Introduces a backend-agnostic `TlbAllocator` abstract base with two concrete implementations:

- `KmdTlbAllocator` (silicon) — delegates to `PCIDevice::allocate_tlb`. Owns the size-fallback loop when the caller passes `size=0`.
- `SimulationTlbAllocator` (simulation) — already-existing class, now inherits from `TlbAllocator` and implements `allocate()` by combining its existing index allocation with a backend-supplied `TlbHandleFactory`.

The interface is handle-first: `allocate(size, mapping) -> unique_ptr<TlbHandle>`. This matches silicon's natural API shape (KMD returns an opaque handle directly) and avoids forcing a synthetic "index" concept onto the silicon path. The simulation backend pays a small cost — a `TlbHandleFactory` callable injected at construction — so that `allocate()` can return a fully-built handle.

To make this clean, simulation `TlbHandle` subclasses now hold a `SimulationTlbAllocator*` back-pointer (instead of a `SimulationTlbManager*` back-pointer). The methods they called on the manager (`deallocate_tlb_index`, `get_tlb_address_from_index`, `get_tlb_reg_address_from_index`, `get_architecture_impl`) all live on the allocator now, so this is a pointer-type rename rather than new logic. The forwarding methods previously kept on `SimulationTlbManager` for back-compat are removed.

`SimulationTlbManager` itself no longer owns a `TlbWindowFactory` that knows about cores, ids, and configs all at once. Instead it gets two simpler callables at construction: a `TlbHandleFactory` (passed straight to its `SimulationTlbAllocator`) and a `TlbWindowBuilder` (`(handle, config) -> window`) that wraps the allocator-produced handle into the right backend-specific `TlbWindow`. The simulation `TTDevice` subclasses provide both lambdas.

This is the wiring step for #2317's allocator/factory split. The next task (add `TTDevice::get_io_window`) will route allocation through this interface.

### List of the changes

- New abstract interface `TlbAllocator` (`device/api/umd/device/chip_helpers/tlb_allocator.hpp`) with single virtual method `allocate(size, mapping) -> unique_ptr<TlbHandle>`.
- New `KmdTlbAllocator` (`device/api/umd/device/chip_helpers/kmd_tlb_allocator.hpp`, `device/chip_helpers/kmd_tlb_allocator.cpp`): silicon implementation, delegates to `PCIDevice::allocate_tlb`. Owns the size-fallback loop previously in `TLBManager::allocate_tlb_window`.
- `SimulationTlbAllocator` inherits from `TlbAllocator`. Constructor now takes a `TlbHandleFactory`. `allocate()` allocates an index and calls the factory. Adds `build_handle_for_index()` for backends like Quasar that need a handle without going through the bitmap.
- `SimulationTlbManager`:
  - Constructor takes a `TlbHandleFactory` (passed to allocator) plus a `TlbWindowBuilder` (`(handle, cfg) -> window`).
  - `allocate_tlb_window` now: `allocator_.allocate(...)` + `window_builder_(...)`.
  - The `allocate_tlb_index` / `deallocate_tlb_index` / `get_tlb_address_from_index` / `get_tlb_reg_address_from_index` / `get_architecture_impl` forwarders are removed (no longer needed).
- Simulation `TlbHandle` subclasses (`TTSimTlbHandle`, `RtlSimTlbHandle`):
  - Back-pointer changes from `SimulationTlbManager*` to `SimulationTlbAllocator*`.
  - Constructor and `create()` signatures updated.
  - `free_tlb()` calls `allocator_->deallocate_tlb_index()` directly.
  - `get_tlb_manager()` accessor renamed to `get_tlb_allocator()`. Single use site (`get_arch()` in the matching `TlbWindow` subclass) updated to chain through `allocator_->get_architecture_impl()->get_architecture()`.
- `tt_sim_tt_device.cpp` and `rtl_simulation_tt_device.cpp`: factory lambdas split into a handle-factory and a window-builder.
- `device/CMakeLists.txt`: registered `kmd_tlb_allocator.{cpp,hpp}` and `tlb_allocator.hpp`.

### Testing

CI. Locally: `cmake --build build` clean; `pre-commit run --all-files` clean; `baremetal_tests` (121 tests) and `test_utils_tests` (3 tests) pass.

### API Changes

There are no API changes in this PR.
