### PR TITLE
Migrate simulation TlbHandle back-pointer to SimulationTlbAllocator

### DIFF
--- a/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
@@ -61,6 +61,8 @@ public:
 
     const architecture_implementation* get_architecture_impl() const;
 
+    tt::ARCH get_architecture() const;
+
 private:
     // A pool of TLB indices that all share a single size.
     struct TlbSizeClass {

--- a/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
@@ -20,8 +20,6 @@ enum class ARCH;
 
 namespace tt::umd {
 
-class SimulationTlbManager;
-class TTDevice;
 class architecture_implementation;
 
 /**
@@ -30,7 +28,7 @@ class architecture_implementation;
  * that creates the appropriate TlbHandle + TlbWindow combination.
  */
 using TlbWindowFactory = std::function<std::unique_ptr<TlbWindow>(
-    SimulationTlbManager* manager, int tlb_id, size_t size, TlbMapping mapping, tlb_data config)>;
+    SimulationTlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping, tlb_data config)>;
 
 class SimulationTlbManager : public TLBManager {
 public:
@@ -49,16 +47,7 @@ public:
      */
     std::unique_ptr<TlbWindow> allocate_default_tlb_window();
 
-    // The methods below forward to the underlying SimulationTlbAllocator. They are
-    // exposed on SimulationTlbManager for back-compat with simulation TlbHandle
-    // subclasses that hold a SimulationTlbManager* back-pointer.
-
-    int allocate_tlb_index(size_t size);
-    void deallocate_tlb_index(int tlb_index);
-    size_t get_tlb_size_from_index(int tlb_index);
-    uint64_t get_tlb_address_from_index(int tlb_index);
-    uint64_t get_tlb_reg_address_from_index(int tlb_index);
-    const architecture_implementation* get_architecture_impl() const;
+    SimulationTlbAllocator& get_allocator() { return allocator_; }
 
     tt::ARCH get_arch() const;
 

--- a/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
@@ -49,8 +49,6 @@ public:
 
     SimulationTlbAllocator& get_allocator() { return allocator_; }
 
-    tt::ARCH get_arch() const;
-
 private:
     SimulationTlbAllocator allocator_;
     TlbWindowFactory factory_;

--- a/device/api/umd/device/pcie/rtl_sim_tlb_handle.hpp
+++ b/device/api/umd/device/pcie/rtl_sim_tlb_handle.hpp
@@ -13,7 +13,7 @@
 
 namespace tt::umd {
 
-class SimulationTlbManager;
+class SimulationTlbAllocator;
 enum TlbMapping : uint8_t;
 
 /**
@@ -25,22 +25,22 @@ enum TlbMapping : uint8_t;
 class RtlSimTlbHandle : public TlbHandle {
 public:
     static std::unique_ptr<RtlSimTlbHandle> create(
-        SimulationTlbManager* manager, int tlb_id, size_t size, TlbMapping mapping);
+        SimulationTlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping);
 
     ~RtlSimTlbHandle() noexcept;
 
     void configure(const tlb_data& new_config) override;
 
-    SimulationTlbManager* get_tlb_manager() const { return manager_; }
+    SimulationTlbAllocator* get_tlb_allocator() const { return allocator_; }
 
     tt::ARCH get_arch() const override;
 
 private:
-    RtlSimTlbHandle(SimulationTlbManager* manager, int tlb_id, size_t size, TlbMapping mapping);
+    RtlSimTlbHandle(SimulationTlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping);
 
     void free_tlb() noexcept override;
 
-    SimulationTlbManager* manager_;
+    SimulationTlbAllocator* allocator_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/pcie/tt_sim_tlb_handle.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_handle.hpp
@@ -14,7 +14,7 @@
 
 namespace tt::umd {
 
-class SimulationTlbManager;
+class SimulationTlbAllocator;
 enum TlbMapping : uint8_t;
 
 /**
@@ -28,7 +28,7 @@ public:
      * This bypasses the hardware constructor and sets up simulation state.
      */
     static std::unique_ptr<TTSimTlbHandle> create(
-        SimulationTlbManager* manager,
+        SimulationTlbAllocator* allocator,
         class TTSimCommunicator* communicator,
         int tlb_id,
         size_t size,
@@ -38,14 +38,14 @@ public:
 
     void configure(const tlb_data& new_config) override;
 
-    SimulationTlbManager* get_tlb_manager() const { return sim_manager_; }
+    SimulationTlbAllocator* get_tlb_allocator() const { return allocator_; }
 
     tt::ARCH get_arch() const override;
 
 private:
     // Private constructor to enforce use of create() factory method.
     TTSimTlbHandle(
-        SimulationTlbManager* manager,
+        SimulationTlbAllocator* allocator,
         class TTSimCommunicator* communicator,
         int tlb_id,
         size_t size,
@@ -53,7 +53,7 @@ private:
 
     void free_tlb() noexcept override;
 
-    SimulationTlbManager* sim_manager_;
+    SimulationTlbAllocator* allocator_;
     class TTSimCommunicator* sim_communicator_;
     uint64_t tlb_reg_addr_ = 0;
 };

--- a/device/chip_helpers/simulation_tlb_allocator.cpp
+++ b/device/chip_helpers/simulation_tlb_allocator.cpp
@@ -98,6 +98,8 @@ uint64_t SimulationTlbAllocator::get_tlb_reg_address_from_index(int tlb_index) {
 
 const architecture_implementation* SimulationTlbAllocator::get_architecture_impl() const { return arch_impl_; }
 
+tt::ARCH SimulationTlbAllocator::get_architecture() const { return architecture_; }
+
 SimulationTlbAllocator::TlbSizeClass* SimulationTlbAllocator::find_size_class_for_index(int tlb_index) {
     // Returning nullptr for negative indices avoids signed/unsigned comparison
     // pitfalls below (where size_t promotion would turn -1 into SIZE_MAX).

--- a/device/chip_helpers/simulation_tlb_manager.cpp
+++ b/device/chip_helpers/simulation_tlb_manager.cpp
@@ -40,7 +40,7 @@ std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
     // TlbWindow::validate doesn't reject any valid access (size 0 would cause
     // division by zero in RtlSimTlbHandle::configure).
     static constexpr size_t SIZE_4GB = 4ULL * 1024 * 1024 * 1024;
-    const tt::ARCH architecture = allocator_.get_architecture_impl()->get_architecture();
+    const tt::ARCH architecture = allocator_.get_architecture();
     switch (architecture) {
         case tt::ARCH::BLACKHOLE:
             return allocate_tlb_window({}, TlbMapping::WC, SIZE_2MB);
@@ -56,7 +56,5 @@ std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
             return nullptr;
     }
 }
-
-tt::ARCH SimulationTlbManager::get_arch() const { return allocator_.get_architecture_impl()->get_architecture(); }
 
 }  // namespace tt::umd

--- a/device/chip_helpers/simulation_tlb_manager.cpp
+++ b/device/chip_helpers/simulation_tlb_manager.cpp
@@ -29,7 +29,7 @@ std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_tlb_window(
 
     size_t actual_tlb_size = allocator_.get_tlb_size_from_index(tlb_index);
 
-    return factory_(this, tlb_index, actual_tlb_size, mapping, config);
+    return factory_(&allocator_, tlb_index, actual_tlb_size, mapping, config);
 }
 
 std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
@@ -47,7 +47,7 @@ std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
         case tt::ARCH::WORMHOLE_B0:
             return allocate_tlb_window({}, TlbMapping::WC, SIZE_16MB);
         case tt::ARCH::QUASAR:
-            return factory_(this, 0, SIZE_4GB, TlbMapping::WC, {});
+            return factory_(&allocator_, 0, SIZE_4GB, TlbMapping::WC, {});
         default:
             log_debug(
                 LogUMD,
@@ -55,26 +55,6 @@ std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
                 tt::arch_to_str(architecture));
             return nullptr;
     }
-}
-
-int SimulationTlbManager::allocate_tlb_index(size_t size) { return allocator_.allocate_tlb_index(size); }
-
-void SimulationTlbManager::deallocate_tlb_index(int tlb_index) { allocator_.deallocate_tlb_index(tlb_index); }
-
-size_t SimulationTlbManager::get_tlb_size_from_index(int tlb_index) {
-    return allocator_.get_tlb_size_from_index(tlb_index);
-}
-
-uint64_t SimulationTlbManager::get_tlb_address_from_index(int tlb_index) {
-    return allocator_.get_tlb_address_from_index(tlb_index);
-}
-
-uint64_t SimulationTlbManager::get_tlb_reg_address_from_index(int tlb_index) {
-    return allocator_.get_tlb_reg_address_from_index(tlb_index);
-}
-
-const architecture_implementation* SimulationTlbManager::get_architecture_impl() const {
-    return allocator_.get_architecture_impl();
 }
 
 tt::ARCH SimulationTlbManager::get_arch() const { return allocator_.get_architecture_impl()->get_architecture(); }

--- a/device/pcie/rtl_sim_tlb_handle.cpp
+++ b/device/pcie/rtl_sim_tlb_handle.cpp
@@ -9,14 +9,15 @@
 #include <memory>
 #include <tt-logger/tt-logger.hpp>
 
-#include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/tlb.hpp"
 
 namespace tt::umd {
 
-RtlSimTlbHandle::RtlSimTlbHandle(SimulationTlbManager* manager, int tlb_id, size_t size, TlbMapping mapping) :
-    manager_(manager) {
+RtlSimTlbHandle::RtlSimTlbHandle(SimulationTlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping) :
+    allocator_(allocator) {
     tlb_id_ = tlb_id;
     tlb_size_ = size;
     tlb_mapping_ = mapping;
@@ -24,10 +25,10 @@ RtlSimTlbHandle::RtlSimTlbHandle(SimulationTlbManager* manager, int tlb_id, size
     // QUASAR bypasses the simulation TLB allocator (see SimulationTlbManager::
     // allocate_default_tlb_window); skip the allocator query for it so
     // get_tlb_address_from_index doesn't throw on the empty pool.
-    if (manager_ && manager_->get_arch() != tt::ARCH::QUASAR) {
+    if (allocator_ && allocator_->get_architecture_impl()->get_architecture() != tt::ARCH::QUASAR) {
         // This is a fake, non-dereferenceable pointer used only for address arithmetic.
         // For RTL sim, bar0_base is 0, so this will be a near-null address.
-        tlb_base_ = reinterpret_cast<uint8_t*>(manager_->get_tlb_address_from_index(tlb_id_));
+        tlb_base_ = reinterpret_cast<uint8_t*>(allocator_->get_tlb_address_from_index(tlb_id_));
     }
 
     log_debug(
@@ -39,8 +40,8 @@ RtlSimTlbHandle::RtlSimTlbHandle(SimulationTlbManager* manager, int tlb_id, size
 }
 
 std::unique_ptr<RtlSimTlbHandle> RtlSimTlbHandle::create(
-    SimulationTlbManager* manager, int tlb_id, size_t size, TlbMapping mapping) {
-    return std::unique_ptr<RtlSimTlbHandle>(new RtlSimTlbHandle(manager, tlb_id, size, mapping));
+    SimulationTlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping) {
+    return std::unique_ptr<RtlSimTlbHandle>(new RtlSimTlbHandle(allocator, tlb_id, size, mapping));
 }
 
 RtlSimTlbHandle::~RtlSimTlbHandle() noexcept { RtlSimTlbHandle::free_tlb(); }
@@ -63,14 +64,14 @@ void RtlSimTlbHandle::configure(const tlb_data& new_config) {
 }
 
 void RtlSimTlbHandle::free_tlb() noexcept {
-    if (manager_) {
-        manager_->deallocate_tlb_index(tlb_id_);
-        manager_ = nullptr;
+    if (allocator_) {
+        allocator_->deallocate_tlb_index(tlb_id_);
+        allocator_ = nullptr;
 
         log_debug(LogUMD, "Freed RTL sim TLB with ID {}", tlb_id_);
     }
 }
 
-tt::ARCH RtlSimTlbHandle::get_arch() const { return manager_->get_arch(); }
+tt::ARCH RtlSimTlbHandle::get_arch() const { return allocator_->get_architecture_impl()->get_architecture(); }
 
 }  // namespace tt::umd

--- a/device/pcie/rtl_sim_tlb_handle.cpp
+++ b/device/pcie/rtl_sim_tlb_handle.cpp
@@ -72,6 +72,6 @@ void RtlSimTlbHandle::free_tlb() noexcept {
     }
 }
 
-tt::ARCH RtlSimTlbHandle::get_arch() const { return allocator_->get_architecture_impl()->get_architecture(); }
+tt::ARCH RtlSimTlbHandle::get_arch() const { return allocator_->get_architecture(); }
 
 }  // namespace tt::umd

--- a/device/pcie/rtl_sim_tlb_window.cpp
+++ b/device/pcie/rtl_sim_tlb_window.cpp
@@ -6,7 +6,6 @@
 
 #include <utility>
 
-#include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
 #include "umd/device/pcie/rtl_sim_tlb_handle.hpp"
 #include "umd/device/pcie/tlb_handle.hpp"
 #include "umd/device/simulation/rtl_sim_communicator.hpp"

--- a/device/pcie/tt_sim_tlb_handle.cpp
+++ b/device/pcie/tt_sim_tlb_handle.cpp
@@ -14,7 +14,7 @@
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
-#include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
+#include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/tlb.hpp"
@@ -22,12 +22,12 @@
 namespace tt::umd {
 
 TTSimTlbHandle::TTSimTlbHandle(
-    SimulationTlbManager* manager,
+    SimulationTlbAllocator* allocator,
     TTSimCommunicator* communicator,
     int tlb_id,
     size_t size,
     const TlbMapping tlb_mapping) :
-    sim_manager_(manager), sim_communicator_(communicator) {
+    allocator_(allocator), sim_communicator_(communicator) {
     tlb_id_ = tlb_id;
     tlb_size_ = size;
     tlb_mapping_ = tlb_mapping;
@@ -37,9 +37,9 @@ TTSimTlbHandle::TTSimTlbHandle(
     // handles all I/O), so the allocator has no pools and the get_*_from_index
     // calls would throw. Skip them for QUASAR; tlb_base_ / tlb_reg_addr_ stay at
     // their defaults (nullptr / 0), which the QUASAR path never dereferences.
-    if (sim_manager_ && sim_manager_->get_arch() != tt::ARCH::QUASAR) {
-        tlb_base_ = reinterpret_cast<uint8_t*>(sim_manager_->get_tlb_address_from_index(tlb_id_));
-        tlb_reg_addr_ = sim_manager_->get_tlb_reg_address_from_index(tlb_id_);
+    if (allocator_ && allocator_->get_architecture_impl()->get_architecture() != tt::ARCH::QUASAR) {
+        tlb_base_ = reinterpret_cast<uint8_t*>(allocator_->get_tlb_address_from_index(tlb_id_));
+        tlb_reg_addr_ = allocator_->get_tlb_reg_address_from_index(tlb_id_);
     }
 
     log_debug(
@@ -51,12 +51,12 @@ TTSimTlbHandle::TTSimTlbHandle(
 }
 
 std::unique_ptr<TTSimTlbHandle> TTSimTlbHandle::create(
-    SimulationTlbManager* manager,
+    SimulationTlbAllocator* allocator,
     TTSimCommunicator* communicator,
     int tlb_id,
     size_t size,
     const TlbMapping tlb_mapping) {
-    return std::unique_ptr<TTSimTlbHandle>(new TTSimTlbHandle(manager, communicator, tlb_id, size, tlb_mapping));
+    return std::unique_ptr<TTSimTlbHandle>(new TTSimTlbHandle(allocator, communicator, tlb_id, size, tlb_mapping));
 }
 
 void TTSimTlbHandle::configure(const tlb_data& new_config) {
@@ -67,7 +67,7 @@ void TTSimTlbHandle::configure(const tlb_data& new_config) {
     tlb_config_.ordering = 0;
     tlb_config_.static_vc = 0;
 
-    // Get architecture from manager to determine correct offsets.
+    // Get architecture from allocator to determine correct offsets.
     tt::ARCH architecture = get_arch();
 
     log_debug(
@@ -145,14 +145,14 @@ void TTSimTlbHandle::configure(const tlb_data& new_config) {
 }
 
 void TTSimTlbHandle::free_tlb() noexcept {
-    if (sim_manager_) {
-        sim_manager_->deallocate_tlb_index(tlb_id_);
-        sim_manager_ = nullptr;
+    if (allocator_) {
+        allocator_->deallocate_tlb_index(tlb_id_);
+        allocator_ = nullptr;
 
         log_debug(LogUMD, "Freed simulation TLB with ID {}", tlb_id_);
     }
 }
 
-tt::ARCH TTSimTlbHandle::get_arch() const { return sim_manager_->get_arch(); }
+tt::ARCH TTSimTlbHandle::get_arch() const { return allocator_->get_architecture_impl()->get_architecture(); }
 
 }  // namespace tt::umd

--- a/device/pcie/tt_sim_tlb_handle.cpp
+++ b/device/pcie/tt_sim_tlb_handle.cpp
@@ -153,6 +153,6 @@ void TTSimTlbHandle::free_tlb() noexcept {
     }
 }
 
-tt::ARCH TTSimTlbHandle::get_arch() const { return allocator_->get_architecture_impl()->get_architecture(); }
+tt::ARCH TTSimTlbHandle::get_arch() const { return allocator_->get_architecture(); }
 
 }  // namespace tt::umd

--- a/device/pcie/tt_sim_tlb_window.cpp
+++ b/device/pcie/tt_sim_tlb_window.cpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <utility>
 
-#include "umd/device/chip_helpers/simulation_tlb_manager.hpp"
 #include "umd/device/pcie/tlb_handle.hpp"
 #include "umd/device/pcie/tt_sim_tlb_handle.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -109,9 +109,9 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
         this,
         /*bar0_base=*/0,
         architecture_impl_.get(),
-        [comm = communicator_.get()](
-            SimulationTlbManager* mgr, int id, size_t sz, TlbMapping map, tlb_data cfg) -> std::unique_ptr<TlbWindow> {
-            auto handle = RtlSimTlbHandle::create(mgr, id, sz, map);
+        [comm = communicator_.get()](SimulationTlbAllocator* alloc, int id, size_t sz, TlbMapping map, tlb_data cfg)
+            -> std::unique_ptr<TlbWindow> {
+            auto handle = RtlSimTlbHandle::create(alloc, id, sz, map);
             return std::make_unique<RtlSimTlbWindow>(std::move(handle), comm, cfg);
         });
     cached_tlb_window_ = tlb_manager_->allocate_default_tlb_window();

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -98,9 +98,9 @@ TTSimTTDevice::TTSimTTDevice(
         this,
         bar0_base,
         architecture_impl_.get(),
-        [comm = communicator_.get()](
-            SimulationTlbManager* mgr, int id, size_t sz, TlbMapping map, tlb_data cfg) -> std::unique_ptr<TlbWindow> {
-            auto handle = TTSimTlbHandle::create(mgr, comm, id, sz, map);
+        [comm = communicator_.get()](SimulationTlbAllocator* alloc, int id, size_t sz, TlbMapping map, tlb_data cfg)
+            -> std::unique_ptr<TlbWindow> {
+            auto handle = TTSimTlbHandle::create(alloc, comm, id, sz, map);
             return std::make_unique<TTSimTlbWindow>(std::move(handle), comm, cfg);
         });
     cached_tlb_window_ = tlb_manager_->allocate_default_tlb_window();


### PR DESCRIPTION
### Issue

Refs #2317. Stacked on #2538. Followed by #2541.

### Description

The simulation `TlbHandle` subclasses (`TTSimTlbHandle`, `RtlSimTlbHandle`) hold a back-pointer to `SimulationTlbManager` purely for `deallocate_tlb_index` on destruction and a few address/arch lookups. Since #2538 moved that bookkeeping into `SimulationTlbAllocator`, the manager is now a passthrough for these calls — the natural owner is the allocator itself.

This PR migrates the back-pointer from `SimulationTlbManager*` to `SimulationTlbAllocator*` end-to-end:

- `TTSimTlbHandle` and `RtlSimTlbHandle` hold a `SimulationTlbAllocator*` and call `allocator_->deallocate_tlb_index()` / `get_tlb_address_from_index()` / `get_tlb_reg_address_from_index()` / `get_architecture_impl()` directly.
- `TlbWindowFactory` typedef on `SimulationTlbManager` takes `SimulationTlbAllocator*` as its first argument instead of `SimulationTlbManager*`. The simulation `TTDevice` factory lambdas pass through unchanged in shape.
- `SimulationTlbManager`'s passthrough forwarders introduced in #2538 (`allocate_tlb_index`, `deallocate_tlb_index`, `get_tlb_size_from_index`, `get_tlb_address_from_index`, `get_tlb_reg_address_from_index`, `get_architecture_impl`) are removed — nothing reaches into the manager for these anymore. A `get_allocator()` accessor is added so callers that need the allocator can still get to it.
- The single use site of the old `get_tlb_manager()` accessor on each handle (`get_arch()` in the matching `TlbWindow` subclass) is updated to chain through `allocator_->get_architecture_impl()->get_architecture()` instead of going `manager_ → tt_device_ → arch`.

This keeps `SimulationTlbAllocator` purely about bookkeeping — no `TlbHandleFactory` injection, no `allocate()` method, no abstract `TlbAllocator` base. Subsequent PRs in the stack add `TTDevice::get_io_window(...)` (#2541) and then move end-to-end construction into the simulation `TTDevice` subclasses (#2544) — silicon calls `pci_device_->allocate_tlb()` directly, simulation calls `allocator_->allocate_tlb_index()` and builds the handle/window inline. No abstract `TlbAllocator` interface is needed because each backend speaks its own primitive at that layer.

(Replaces #2539, which had attempted a unified `TlbAllocator` abstract base and was closed in favor of this simpler shape.)

### List of the changes

- `TTSimTlbHandle`, `RtlSimTlbHandle`: replace `SimulationTlbManager* sim_manager_` / `manager_` with `SimulationTlbAllocator* allocator_`. Constructor and `create()` signatures updated. `free_tlb()` calls `allocator_->deallocate_tlb_index()` directly. `get_tlb_manager()` accessor renamed to `get_tlb_allocator()`.
- `TTSimTlbWindow::get_arch()` and `RtlSimTlbWindow::get_arch()`: chain through `handle->get_tlb_allocator()->get_architecture_impl()->get_architecture()`.
- `SimulationTlbManager`:
  - `TlbWindowFactory` typedef: first parameter type changes from `SimulationTlbManager*` to `SimulationTlbAllocator*`.
  - `allocate_tlb_window` / `allocate_default_tlb_window`: pass `&allocator_` to factory instead of `this`.
  - Passthrough forwarders removed.
  - Adds `SimulationTlbAllocator& get_allocator()` accessor.
- `tt_sim_tt_device.cpp` and `rtl_simulation_tt_device.cpp`: factory lambdas updated to take `SimulationTlbAllocator*` and pass it to handle `create()`.

### Testing

CI.

### API Changes

This PR changes signatures in exported public headers, an API break for any downstream code constructing the simulation TLB handle types directly or implementing a `TlbWindowFactory`:

- `TTSimTlbHandle::TTSimTlbHandle` / `TTSimTlbHandle::create`: first parameter changes from `SimulationTlbManager*` to `SimulationTlbAllocator*`. The `get_tlb_manager()` accessor is renamed to `get_tlb_allocator()`.
- `RtlSimTlbHandle::RtlSimTlbHandle` / `RtlSimTlbHandle::create`: same change. `get_tlb_manager()` accessor renamed to `get_tlb_allocator()`.
- `TlbWindowFactory` typedef on `SimulationTlbManager`: first parameter changes from `SimulationTlbManager*` to `SimulationTlbAllocator*`.
- `SimulationTlbManager` drops the passthrough forwarders introduced in #2538 (`allocate_tlb_index`, `deallocate_tlb_index`, `get_tlb_size_from_index`, `get_tlb_address_from_index`, `get_tlb_reg_address_from_index`, `get_architecture_impl`, `get_arch`). A `get_allocator()` accessor is added for callers that still need allocator-level operations.

No deprecated compatibility shims are added: the back-pointer migration is the point of this PR.