### PR TITLE
Add TTDevice::get_io_window

### DIFF
--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -75,8 +75,7 @@ public:
 
     TLBManager* get_tlb_manager() override;
 
-    std::unique_ptr<TlbWindow> get_io_window(
-        tlb_data config, TlbMapping mapping = TlbMapping::WC, size_t size = 0) override;
+    std::unique_ptr<TlbWindow> get_io_window(tlb_data config, TlbMapping mapping, size_t size) override;
 
 protected:
     void retrain_dram_core(const uint32_t dram_channel) override;

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -75,6 +75,9 @@ public:
 
     TLBManager* get_tlb_manager() override;
 
+    std::unique_ptr<TlbWindow> get_io_window(
+        tlb_data config, TlbMapping mapping = TlbMapping::WC, size_t size = 0) override;
+
 protected:
     void retrain_dram_core(const uint32_t dram_channel) override;
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -445,6 +445,20 @@ public:
 
     virtual TLBManager *get_tlb_manager() { return nullptr; }
 
+    /**
+     * Allocate a TlbWindow for use by callers (typically TLBManager).
+     *
+     * Default implementation uses PCIDevice::allocate_tlb (silicon path) and
+     * wraps the resulting handle in a SiliconTlbWindow. Simulation TTDevice
+     * subclasses override this to allocate from their backend-specific path.
+     *
+     * @param config tlb_data configuration applied to the new window.
+     * @param mapping UC or WC.
+     * @param size Requested TLB size in bytes (0 means try arch-supported sizes in order).
+     */
+    virtual std::unique_ptr<TlbWindow> get_io_window(
+        tlb_data config, TlbMapping mapping = TlbMapping::WC, size_t size = 0);
+
     virtual void dma_write_to_device(const void *src, size_t size, tt_xy_pair core, uint64_t addr);
 
     virtual void dma_read_from_device(void *dst, size_t size, tt_xy_pair core, uint64_t addr);

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -84,6 +84,9 @@ public:
 
     TLBManager *get_tlb_manager() override;
 
+    std::unique_ptr<TlbWindow> get_io_window(
+        tlb_data config, TlbMapping mapping = TlbMapping::WC, size_t size = 0) override;
+
     uint64_t bar0_base = 0;
     uint64_t bar4_base = 0;
 

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -84,8 +84,7 @@ public:
 
     TLBManager *get_tlb_manager() override;
 
-    std::unique_ptr<TlbWindow> get_io_window(
-        tlb_data config, TlbMapping mapping = TlbMapping::WC, size_t size = 0) override;
+    std::unique_ptr<TlbWindow> get_io_window(tlb_data config, TlbMapping mapping, size_t size) override;
 
     uint64_t bar0_base = 0;
     uint64_t bar4_base = 0;

--- a/device/chip_helpers/tlb_manager.cpp
+++ b/device/chip_helpers/tlb_manager.cpp
@@ -45,11 +45,10 @@ void TLBManager::configure_tlb(tt_xy_pair core, size_t tlb_size, uint64_t addres
     config.static_vc = get_tt_device()->get_architecture_implementation()->get_static_vc();
     std::unique_ptr<TlbWindow> tlb_window = allocate_tlb_window(config, TlbMapping::WC, tlb_size);
 
-    // Simulation TTDevices have no PCI device; report chip 0 in the log line in that case.
     log_debug(
         LogUMD,
         "Configured TLB window for chip: {} core: {} size: {} address: {} ordering: {} tlb_id: {}",
-        tt_device_->get_pci_device() != nullptr ? tt_device_->get_pci_device()->get_device_num() : 0,
+        tt_device_->get_communication_device_id(),
         core.str(),
         tlb_size,
         address,
@@ -98,25 +97,7 @@ tlb_configuration TLBManager::get_tlb_configuration(tt_xy_pair core) {
 std::unique_ptr<TlbWindow> TLBManager::allocate_tlb_window(
     tlb_data config, const TlbMapping mapping, const size_t tlb_size) {
     ZoneScopedC(tracy::Color::Cyan);
-    if (tlb_size != 0) {
-        return std::make_unique<SiliconTlbWindow>(
-            tt_device_->get_pci_device()->allocate_tlb(tlb_size, mapping), config);
-    }
-
-    const std::vector<size_t>& possible_arch_sizes = tt_device_->get_architecture_implementation()->get_tlb_sizes();
-
-    for (const auto& size : possible_arch_sizes) {
-        std::unique_ptr<TlbWindow> tlb_window = nullptr;
-        try {
-            tlb_window =
-                std::make_unique<SiliconTlbWindow>(tt_device_->get_pci_device()->allocate_tlb(size, mapping), config);
-            return tlb_window;
-        } catch (const std::exception& e) {
-            log_error(LogUMD, "Failed to allocate TLB window of size {}: {}", size, e.what());
-        }
-    }
-
-    UMD_THROW(error::RuntimeError, fmt::format("Failed to allocate TLB window."));
+    return tt_device_->get_io_window(config, mapping, tlb_size);
 }
 
 void TLBManager::clear_mapped_tlbs() {

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -336,4 +336,8 @@ void RtlSimulationTTDevice::noc_multicast_write(void* src, size_t size, uint64_t
 
 TLBManager* RtlSimulationTTDevice::get_tlb_manager() { return static_cast<TLBManager*>(tlb_manager_.get()); }
 
+std::unique_ptr<TlbWindow> RtlSimulationTTDevice::get_io_window(tlb_data config, TlbMapping mapping, size_t size) {
+    return tlb_manager_->allocate_tlb_window(config, mapping, size);
+}
+
 }  // namespace tt::umd

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -266,6 +266,29 @@ bool TTDevice::is_noc_hung(NocId noc, TTDevice::HangAction action) {
     return false;
 }
 
+std::unique_ptr<TlbWindow> TTDevice::get_io_window(tlb_data config, TlbMapping mapping, size_t size) {
+    PCIDevice *pci = get_pci_device();
+    if (pci == nullptr) {
+        UMD_THROW(error::RuntimeError, "TTDevice::get_io_window default implementation requires a PCIDevice.");
+    }
+
+    if (size != 0) {
+        return std::make_unique<SiliconTlbWindow>(pci->allocate_tlb(size, mapping), config);
+    }
+
+    // Caller didn't specify a size — try arch-supported sizes in preference order.
+    const std::vector<size_t> &possible_sizes = get_architecture_implementation()->get_tlb_sizes();
+    for (const auto &s : possible_sizes) {
+        try {
+            return std::make_unique<SiliconTlbWindow>(pci->allocate_tlb(s, mapping), config);
+        } catch (const std::exception &e) {
+            log_error(LogUMD, "Failed to allocate TLB window of size {}: {}", s, e.what());
+        }
+    }
+
+    UMD_THROW(error::RuntimeError, "Failed to allocate TLB window.");
+}
+
 // This is only needed for the BH workaround in iatu_configure_peer_region since no arc.
 void TTDevice::write_regs(volatile uint32_t *dest, const uint32_t *src, uint32_t word_len) {
     get_pcie_interface()->write_regs(dest, src, word_len);

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -268,9 +268,8 @@ bool TTDevice::is_noc_hung(NocId noc, TTDevice::HangAction action) {
 
 std::unique_ptr<TlbWindow> TTDevice::get_io_window(tlb_data config, TlbMapping mapping, size_t size) {
     PCIDevice *pci = get_pci_device();
-    if (pci == nullptr) {
-        UMD_THROW(error::RuntimeError, "TTDevice::get_io_window default implementation requires a PCIDevice.");
-    }
+    UMD_ASSERT(
+        pci != nullptr, error::RuntimeError, "TTDevice::get_io_window default implementation requires a PCIDevice.");
 
     if (size != 0) {
         return std::make_unique<SiliconTlbWindow>(pci->allocate_tlb(size, mapping), config);

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -318,4 +318,8 @@ void TTSimTTDevice::noc_multicast_write(void* src, size_t size, uint64_t addr) {
 
 TLBManager* TTSimTTDevice::get_tlb_manager() { return static_cast<TLBManager*>(tlb_manager_.get()); }
 
+std::unique_ptr<TlbWindow> TTSimTTDevice::get_io_window(tlb_data config, TlbMapping mapping, size_t size) {
+    return tlb_manager_->allocate_tlb_window(config, mapping, size);
+}
+
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue

Refs #2317. Stacked on #2540. Followed by #2544.

### Description

Adds a virtual `TTDevice::get_io_window(config, mapping, size)` entry point for TLB-window allocation, with a default silicon implementation that uses `PCIDevice::allocate_tlb` plus the size-fallback loop and wraps the resulting handle in a `SiliconTlbWindow`. `WormholeTTDevice` and `BlackholeTTDevice` use the default unchanged.

Simulation `TTDevice`s (`TTSimTTDevice`, `RtlSimulationTTDevice`) override `get_io_window` to forward to their existing `tlb_manager_->allocate_tlb_window` — `SimulationTlbManager` and the bitmap allocator + factory it owns continue to do the actual sim allocation. Removing `SimulationTlbManager` is the next PR in the stack (#2544).

`TLBManager::allocate_tlb_window` collapses to a one-liner that delegates to `tt_device_->get_io_window`. Size-fallback logic moves into the silicon default impl. `TLBManager::configure_tlb` logging switches from `pci_device->get_device_num` (silicon-only, would crash on sim) to `tt_device->get_communication_device_id` which is universal.

### List of the changes

- **`TTDevice` base** (`tt_device.hpp` / `tt_device.cpp`): add `virtual std::unique_ptr<TlbWindow> get_io_window(tlb_data config, TlbMapping mapping = WC, size_t size = 0)` with default impl that uses `PCIDevice::allocate_tlb` + size fallback + `SiliconTlbWindow` wrapping.
- **`TTSimTTDevice` / `RtlSimulationTTDevice`**: override `get_io_window` with a one-line forward to `tlb_manager_->allocate_tlb_window(...)`. `SimulationTlbManager` keeps doing the bitmap allocation + factory work for now.
- **`TLBManager::allocate_tlb_window`** (`tlb_manager.cpp`): one-liner — `return tt_device_->get_io_window(config, mapping, tlb_size);`.
- **`TLBManager::configure_tlb`** logging: `pci_device->get_device_num()` → `tt_device->get_communication_device_id()`.

### Testing

CI.

### API Changes

There are no API changes in this PR.
