### PR TITLE
Implement multicast to all TENSIX cores

### DIFF
--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -51,6 +51,9 @@ public:
 
     EthTrainingStatus read_eth_core_training_status(tt_xy_pair eth_core) override;
 
+    using TTDevice::noc_multicast_write;
+    void noc_multicast_write(void *src, size_t size, uint64_t addr) override;
+
 protected:
     BlackholeTTDevice(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api);
     BlackholeTTDevice(std::unique_ptr<JtagDevice> jtag_device, uint8_t jlink_id);

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -67,6 +67,8 @@ public:
     void assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs) override;
     void deassert_risc_reset(tt_xy_pair core, const RiscType selected_riscs, bool staggered_start) override;
 
+    void noc_multicast_write(void* src, size_t size, uint64_t addr) override;
+
     RtlSimCommunicator* get_communicator() { return communicator_.get(); }
 
     SimulationSysmemManager* get_sysmem_manager() override { return sysmem_manager_.get(); }

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -204,6 +204,15 @@ public:
     virtual void noc_multicast_write(void *src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr);
 
     /**
+     * NOC multicast write function that will write data to full NOC grid.
+     *
+     * @param src pointer to memory from which the data is sent
+     * @param size number of bytes
+     * @param addr address on the device where data will be written
+     */
+    virtual void noc_multicast_write(void *src, size_t size, uint64_t addr) = 0;
+
+    /**
      * Read function that will send read message to the ARC core APB peripherals.
      *
      * @param mem_ptr pointer to memory which will receive the data

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -204,7 +204,7 @@ public:
     virtual void noc_multicast_write(void *src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr);
 
     /**
-     * NOC multicast write function that will write data to full NOC grid.
+     * NOC multicast write function that will write data to all TENSIX cores in the grid.
      *
      * @param src pointer to memory from which the data is sent
      * @param size number of bytes

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -65,6 +65,8 @@ public:
     void dma_multicast_write(
         void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
 
+    void noc_multicast_write(void *src, size_t size, uint64_t addr) override;
+
     void send_tensix_risc_reset(tt_xy_pair translated_core, const TensixSoftResetOptions &soft_resets) override;
     void send_tensix_risc_reset(const TensixSoftResetOptions &soft_resets) override;
     void assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs) override;

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -51,6 +51,9 @@ public:
     void noc_multicast_write(
         void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
 
+    using TTDevice::noc_multicast_write;
+    void noc_multicast_write(void *src, size_t size, uint64_t addr) override;
+
     ~WormholeTTDevice() override = default;
 
 protected:

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -896,11 +896,23 @@ void PCIDevice::configure_tlb(const uint32_t tlb_index, const tlb_data &tlb_conf
 
     log_trace(
         LogUMD,
-        "Configured TLB index {} at address 0x{:x} with lower=0x{:x}, upper=0x{:x}",
+        "Configured TLB index {} at address 0x{:x} with lower=0x{:x}, upper=0x{:x} "
+        "[local_offset={}, x_end={}, y_end={}, x_start={}, y_start={}, noc_sel={}, mcast={}, ordering={}, linked={}, "
+        "static_vc={}]",
         tlb_index,
         tlb_register_addr,
         lower_64,
-        upper_64);
+        upper_64,
+        tlb_config.local_offset,
+        tlb_config.x_end,
+        tlb_config.y_end,
+        tlb_config.x_start,
+        tlb_config.y_start,
+        tlb_config.noc_sel,
+        tlb_config.mcast,
+        tlb_config.ordering,
+        tlb_config.linked,
+        tlb_config.static_vc);
 }
 
 void PCIDevice::reset_device_ioctl(const std::unordered_set<int> &pci_target_devices, TenstorrentResetDevice flag) {

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -321,17 +321,13 @@ void BlackholeTTDevice::noc_multicast_write(void *src, size_t size, uint64_t add
     //                           NOC1: start=(1,2), end=(2,3).
     xy_pair start_coord;
     xy_pair end_coord;
-    if (get_chip_info().noc_translation_enabled) {
-        if (is_selected_noc1()) {
-            start_coord = xy_pair{1, 2};
-            end_coord = xy_pair{2, 3};
-        } else {
-            start_coord = xy_pair{2, 3};
-            end_coord = xy_pair{1, 2};
-        }
+    UMD_ASSERT(get_chip_info().noc_translation_enabled, "Multicast not implemented for BH devices without NOC translation enabled.");
+    if (is_selected_noc1()) {
+        start_coord = xy_pair{1, 2};
+        end_coord = xy_pair{2, 3};
     } else {
-        start_coord = xy_pair{0, 1};
-        end_coord = xy_pair{16, 11};
+        start_coord = xy_pair{2, 3};
+        end_coord = xy_pair{1, 2};
     }
     noc_multicast_write(src, size, start_coord, end_coord, addr);
 }

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -321,7 +321,9 @@ void BlackholeTTDevice::noc_multicast_write(void *src, size_t size, uint64_t add
     //                           NOC1: start=(1,2), end=(2,3).
     xy_pair start_coord;
     xy_pair end_coord;
-    UMD_ASSERT(get_chip_info().noc_translation_enabled, "Multicast not implemented for BH devices without NOC translation enabled.");
+    UMD_ASSERT(
+        get_chip_info().noc_translation_enabled,
+        "Multicast not implemented for BH devices without NOC translation enabled.");
     if (is_selected_noc1()) {
         start_coord = xy_pair{1, 2};
         end_coord = xy_pair{2, 3};

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -323,6 +323,7 @@ void BlackholeTTDevice::noc_multicast_write(void *src, size_t size, uint64_t add
     xy_pair end_coord;
     UMD_ASSERT(
         get_chip_info().noc_translation_enabled,
+        error::RuntimeError,
         "Multicast not implemented for BH devices without NOC translation enabled.");
     if (is_selected_noc1()) {
         start_coord = xy_pair{1, 2};

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -312,4 +312,28 @@ void BlackholeTTDevice::retrain_dram_core(const uint32_t dram_channel) {
     }
 }
 
+void BlackholeTTDevice::noc_multicast_write(void *src, size_t size, uint64_t addr) {
+    // BH grid is 17x12. Broadcast coordinates depend on NOC translation:
+    //   Translation disabled: full grid hardware multicast, skipping NOC controller row at y=0.
+    //   Translation enabled:  hardware broadcast is avoided; use a software multicast with
+    //                         wraparound coordinates that differ per NOC:
+    //                           NOC0: start=(2,3), end=(1,2)
+    //                           NOC1: start=(1,2), end=(2,3).
+    xy_pair start_coord;
+    xy_pair end_coord;
+    if (get_chip_info().noc_translation_enabled) {
+        if (is_selected_noc1()) {
+            start_coord = xy_pair{1, 2};
+            end_coord = xy_pair{2, 3};
+        } else {
+            start_coord = xy_pair{2, 3};
+            end_coord = xy_pair{1, 2};
+        }
+    } else {
+        start_coord = xy_pair{0, 1};
+        end_coord = xy_pair{16, 11};
+    }
+    noc_multicast_write(src, size, start_coord, end_coord, addr);
+}
+
 }  // namespace tt::umd

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -330,6 +330,10 @@ void RtlSimulationTTDevice::retrain_dram_core(const uint32_t dram_channel) {
     UMD_THROW(error::RuntimeError, "DRAM retraining is not supported in RTL simulation device.");
 }
 
+void RtlSimulationTTDevice::noc_multicast_write(void* src, size_t size, uint64_t addr) {
+    UMD_THROW(error::RuntimeError, "NOC multicast write is not supported in RTL simulation device.");
+}
+
 TLBManager* RtlSimulationTTDevice::get_tlb_manager() { return static_cast<TLBManager*>(tlb_manager_.get()); }
 
 }  // namespace tt::umd

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -303,6 +303,10 @@ void TTSimTTDevice::retrain_dram_core(const uint32_t dram_channel) {
     UMD_THROW(error::RuntimeError, "DRAM retraining is not supported in TTSim device.");
 }
 
+void TTSimTTDevice::noc_multicast_write(void* src, size_t size, uint64_t addr) {
+    UMD_THROW(error::RuntimeError, "NOC multicast write is not supported in TTSim simulation device.");
+}
+
 TLBManager* TTSimTTDevice::get_tlb_manager() { return static_cast<TLBManager*>(tlb_manager_.get()); }
 
 }  // namespace tt::umd

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -442,4 +442,22 @@ void WormholeTTDevice::noc_multicast_write(
     }
 }
 
+void WormholeTTDevice::noc_multicast_write(void *src, size_t size, uint64_t addr) {
+    xy_pair start_core;
+    xy_pair end_core;
+    if (get_chip_info().noc_translation_enabled) {
+        // If NOC translation is enabled, we can use the regular NOC multicast write which will handle the translation
+        // for us.
+        start_core = {18, 18};
+        end_core = {27, 25};
+        return;
+    } else {
+        // WH grid is 10x12. NOC controller occupies x=0, so broadcast starts at x=1.
+        // Translation has no effect on broadcast coordinates for WH; same range for NOC0 and NOC1.
+        start_core = {1, 0};
+        end_core = {9, 11};
+    }
+    noc_multicast_write(src, size, start_core, end_core, addr);
+}
+
 }  // namespace tt::umd

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -450,12 +450,10 @@ void WormholeTTDevice::noc_multicast_write(void *src, size_t size, uint64_t addr
         // for us.
         start_core = {18, 18};
         end_core = {27, 25};
-        return;
     } else {
-        // WH grid is 10x12. NOC controller occupies x=0, so broadcast starts at x=1.
         // Translation has no effect on broadcast coordinates for WH; same range for NOC0 and NOC1.
-        start_core = {1, 0};
-        end_core = {9, 11};
+        start_core = {1, 1};
+        end_core = {11, 9};
     }
     noc_multicast_write(src, size, start_core, end_core, addr);
 }

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -443,19 +443,11 @@ void WormholeTTDevice::noc_multicast_write(
 }
 
 void WormholeTTDevice::noc_multicast_write(void *src, size_t size, uint64_t addr) {
-    xy_pair start_core;
-    xy_pair end_core;
-    if (get_chip_info().noc_translation_enabled) {
-        // If NOC translation is enabled, we can use the regular NOC multicast write which will handle the translation
-        // for us.
-        start_core = {18, 18};
-        end_core = {27, 25};
-    } else {
-        // Translation has no effect on broadcast coordinates for WH; same range for NOC0 and NOC1.
-        start_core = {1, 1};
-        end_core = {11, 9};
-    }
-    noc_multicast_write(src, size, start_core, end_core, addr);
+    // Same range is used for NOC0 and NOC1.
+    // Note that when multicasting in translated space, you have to skip harvested rows. So we can just always use NOC0
+    // coords for broadcasting, since these are always the same and guaranteed to land at all TENSIX cores.
+
+    noc_multicast_write(src, size, xy_pair{1, 1}, xy_pair{9, 11}, addr);
 }
 
 }  // namespace tt::umd

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -292,7 +292,7 @@ void bind_tt_device(nb::module_ &m) {
             },
             nb::arg("addr"),
             nb::arg("data"),
-            "Broadcast arbitrary-length data to all cores on the chip at the specified address")
+            "Broadcast arbitrary-length data to all tensix cores on the chip at the specified address")
         .def(
             "noc_broadcast32",
             [](TTDevice &self, uint64_t addr, uint32_t value) -> void {
@@ -300,7 +300,7 @@ void bind_tt_device(nb::module_ &m) {
             },
             nb::arg("addr"),
             nb::arg("value"),
-            "Broadcast a 32-bit value to all cores on the chip at the specified address")
+            "Broadcast a 32-bit value to all tensix cores on the chip at the specified address")
         .def(
             "noc_multicast",
             [](TTDevice &self,

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -285,6 +285,64 @@ void bind_tt_device(nb::module_ &m) {
             nb::arg("data"),
             "Write arbitrary-length data to a core at the specified address")
         .def(
+            "noc_broadcast",
+            [](TTDevice &self, uint64_t addr, const nb::bytes &data) -> void {
+                std::vector<uint8_t> buffer(data.c_str(), data.c_str() + data.size());
+                self.noc_multicast_write(buffer.data(), buffer.size(), addr);
+            },
+            nb::arg("addr"),
+            nb::arg("data"),
+            "Broadcast arbitrary-length data to all cores on the chip at the specified address")
+        .def(
+            "noc_broadcast32",
+            [](TTDevice &self, uint64_t addr, uint32_t value) -> void {
+                self.noc_multicast_write(&value, sizeof(uint32_t), addr);
+            },
+            nb::arg("addr"),
+            nb::arg("value"),
+            "Broadcast a 32-bit value to all cores on the chip at the specified address")
+        .def(
+            "noc_multicast",
+            [](TTDevice &self,
+               uint32_t start_x,
+               uint32_t start_y,
+               uint32_t end_x,
+               uint32_t end_y,
+               uint64_t addr,
+               const nb::bytes &data) -> void {
+                tt_xy_pair core_start = {start_x, start_y};
+                tt_xy_pair core_end = {end_x, end_y};
+                std::vector<uint8_t> buffer(data.c_str(), data.c_str() + data.size());
+                self.noc_multicast_write(buffer.data(), buffer.size(), core_start, core_end, addr);
+            },
+            nb::arg("start_x"),
+            nb::arg("start_y"),
+            nb::arg("end_x"),
+            nb::arg("end_y"),
+            nb::arg("addr"),
+            nb::arg("data"),
+            "Broadcast arbitrary-length data to all cores in the rectangle [start, end] at the specified address")
+        .def(
+            "noc_multicast32",
+            [](TTDevice &self,
+               uint32_t start_x,
+               uint32_t start_y,
+               uint32_t end_x,
+               uint32_t end_y,
+               uint64_t addr,
+               uint32_t value) -> void {
+                tt_xy_pair core_start = {start_x, start_y};
+                tt_xy_pair core_end = {end_x, end_y};
+                self.noc_multicast_write(&value, sizeof(uint32_t), core_start, core_end, addr);
+            },
+            nb::arg("start_x"),
+            nb::arg("start_y"),
+            nb::arg("end_x"),
+            nb::arg("end_y"),
+            nb::arg("addr"),
+            nb::arg("value"),
+            "Broadcast a 32-bit value to all cores in the rectangle [start, end] at the specified address")
+        .def(
             "bar_read32",
             &TTDevice::bar_read32,
             nb::arg("addr"),

--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -305,7 +305,7 @@ TEST_F(TestDeviceIOFixture, TestDmaMulticastWrite) {
     }
 }
 
-class TestMulticastWriteFixture : public ::testing::TestWithParam<std::tuple<bool>> {};
+class TestMulticastWriteFixture : public ::testing::TestWithParam<std::tuple<bool, bool>> {};
 
 // Parametrized over (use_noc0, full_grid, sysmem_enabled):
 //   use_noc0       - true: NOC0 coordinates; false: translated coordinates
@@ -314,9 +314,8 @@ class TestMulticastWriteFixture : public ::testing::TestWithParam<std::tuple<boo
 // For full_grid+NOC0 the range is {0,0}–{grid_size-1}; for full_grid+translated the tensix corners are used.
 // Bystander verification is only performed for isolated-core multicasts.
 TEST_P(TestMulticastWriteFixture, TestMulticastWrite) {
-    // TODO: full_grid parameter to be added in following PR.
     // TODO: sysmem_enabled parameter to be added in the following PR.
-    auto [use_noc0] = GetParam();
+    auto [use_noc0, full_grid] = GetParam();
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{.num_host_mem_ch_per_mmio_device = 0});
 
@@ -339,7 +338,7 @@ TEST_P(TestMulticastWriteFixture, TestMulticastWrite) {
             LogUMD,
             "Testing {} {} multicast writes on chip {} remote: {}",
             use_noc0 ? "NOC0" : "translated",
-            "single-core",  // full_grid ? "full-grid" : "single-core",
+            full_grid ? "full-grid" : "single-core",
             chip_id,
             cluster->get_cluster_description()->is_chip_remote(chip_id));
 
@@ -363,17 +362,17 @@ TEST_P(TestMulticastWriteFixture, TestMulticastWrite) {
         // it doesn't spill to another.
         CoreCoord bystander_tensix_core;
         std::vector<uint32_t> bystander_original(num_words, 0);
-        // if (!full_grid) {
-        for (const auto& c : soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)) {
-            if (std::find(representative_cores.begin(), representative_cores.end(), c) == representative_cores.end()) {
-                bystander_tensix_core = c;
-                break;
+        if (!full_grid) {
+            for (const auto& c : soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)) {
+                if (std::find(representative_cores.begin(), representative_cores.end(), c) == representative_cores.end()) {
+                    bystander_tensix_core = c;
+                    break;
+                }
             }
+            ASSERT_NE(bystander_tensix_core.core_type, CoreType::UNSPECIFIED)
+                << "No bystander TENSIX core found on chip " << chip_id;
+            tt_device->read_from_device(bystander_original.data(), bystander_tensix_core, address, data_size);
         }
-        ASSERT_NE(bystander_tensix_core.core_type, CoreType::UNSPECIFIED)
-            << "No bystander TENSIX core found on chip " << chip_id;
-        tt_device->read_from_device(bystander_original.data(), bystander_tensix_core, address, data_size);
-        // }
 
         // Fill up values from other chips, before we multicast, to have values to compare against afterwards.
         std::vector<std::vector<uint32_t>> other_chip_bystander_originals(other_chip_bystander_cores.size());
@@ -397,10 +396,14 @@ TEST_P(TestMulticastWriteFixture, TestMulticastWrite) {
                 v++;
             }
 
-            const tt_xy_pair multicast_coord =
-                soc_desc.translate_coord_to(core, use_noc0 ? CoordSystem::NOC0 : CoordSystem::TRANSLATED);
-            log_info(LogUMD, "Multicast to core {} on chip {}", multicast_coord.str(), chip_id);
-            tt_device->noc_multicast_write(write_data.data(), data_size, multicast_coord, multicast_coord, address);
+            if (full_grid) {
+                tt_device->noc_multicast_write(write_data.data(), data_size, address);
+            } else {
+                const tt_xy_pair multicast_coord =
+                    soc_desc.translate_coord_to(core, use_noc0 ? CoordSystem::NOC0 : CoordSystem::TRANSLATED);
+                log_info(LogUMD, "Multicast to core {} on chip {}", multicast_coord.str(), chip_id);
+                tt_device->noc_multicast_write(write_data.data(), data_size, multicast_coord, multicast_coord, address);
+            }
 
             std::vector<uint32_t> readback(num_words);
             tt_device->read_from_device(readback.data(), core, address, data_size);
@@ -409,18 +412,19 @@ TEST_P(TestMulticastWriteFixture, TestMulticastWrite) {
             if (core.core_type == CoreType::TENSIX) {
                 EXPECT_EQ(write_data, readback) << "TENSIX core " << core.str() << " on chip " << chip_id
                                                 << " should have received the multicast write.";
-                // if (!full_grid) {
-                std::vector<uint32_t> bystander_readback(num_words, 0);
-                tt_device->read_from_device(bystander_readback.data(), bystander_tensix_core, address, data_size);
-                EXPECT_EQ(bystander_original, bystander_readback)
-                    << "Bystander TENSIX core " << bystander_tensix_core.str() << " on chip " << chip_id
-                    << " should not have been modified by the multicast write targeting " << multicast_coord.str();
-                // }
+                if (!full_grid) {
+                    std::vector<uint32_t> bystander_readback(num_words, 0);
+                    tt_device->read_from_device(bystander_readback.data(), bystander_tensix_core, address, data_size);
+                    EXPECT_EQ(bystander_original, bystander_readback)
+                        << "Bystander TENSIX core " << bystander_tensix_core.str() << " on chip " << chip_id
+                        << " should not have been modified by the multicast write targeting " << multicast_coord.str();
+                }
             } else {
                 EXPECT_EQ(original, readback) << "Non-TENSIX core " << core.str() << " on chip " << chip_id
                                               << " should not have been modified by the multicast write.";
             }
         }
+
 
         // Now verify that no cores on other chips have been overwritten.
         for (size_t i = 0; i < other_chip_bystander_cores.size(); ++i) {
@@ -439,20 +443,27 @@ TEST_P(TestMulticastWriteFixture, TestMulticastWrite) {
     }
 }
 
-static std::vector<std::tuple<bool>> get_multicast_write_params() {
-    if (PCIDevice::get_pcie_arch() == tt::ARCH::BLACKHOLE) {
-        return {{false}};  // NOC0 multicast not supported on Blackhole
+static std::vector<std::tuple<bool, bool>> get_multicast_write_params() {
+    const bool is_blackhole = PCIDevice::get_pcie_arch() == tt::ARCH::BLACKHOLE;
+    std::vector<std::tuple<bool, bool>> params;
+    for (bool use_noc0 : {false, true}) {
+        if (use_noc0 && is_blackhole) {
+            continue;  // NOC0 multicast not supported on Blackhole
+        }
+        for (bool full_grid : {false, true}) {
+            params.emplace_back(use_noc0, full_grid);
+        }
     }
-    return {{false}, {true}};
+    return params;
 }
 
 INSTANTIATE_TEST_SUITE_P(
     AllCombinations,
     TestMulticastWriteFixture,
     ::testing::ValuesIn(get_multicast_write_params()),
-    [](const ::testing::TestParamInfo<std::tuple<bool>>& info) {
-        auto [use_noc0] = info.param;
-        return std::string(use_noc0 ? "NOC0" : "Translated");
+    [](const ::testing::TestParamInfo<std::tuple<bool, bool>>& info) {
+        return std::string(std::get<0>(info.param) ? "NOC0" : "Translated") + "_" +
+               (std::get<1>(info.param) ? "FullGrid" : "SingleCore");
     });
 
 TEST_P(ClusterReadWriteL1Test, ReadWriteL1) {

--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -364,7 +364,8 @@ TEST_P(TestMulticastWriteFixture, TestMulticastWrite) {
         std::vector<uint32_t> bystander_original(num_words, 0);
         if (!full_grid) {
             for (const auto& c : soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)) {
-                if (std::find(representative_cores.begin(), representative_cores.end(), c) == representative_cores.end()) {
+                if (std::find(representative_cores.begin(), representative_cores.end(), c) ==
+                    representative_cores.end()) {
                     bystander_tensix_core = c;
                     break;
                 }
@@ -424,7 +425,6 @@ TEST_P(TestMulticastWriteFixture, TestMulticastWrite) {
                                               << " should not have been modified by the multicast write.";
             }
         }
-
 
         // Now verify that no cores on other chips have been overwritten.
         for (size_t i = 0; i < other_chip_bystander_cores.size(); ++i) {

--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -319,7 +319,7 @@ TEST_P(TestMulticastWriteFixture, TestMulticastWrite) {
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{.num_host_mem_ch_per_mmio_device = 0});
 
-    constexpr uint64_t address = 0x100;
+    constexpr uint64_t address = SAFE_IO_L1_ADDRESS;
     constexpr size_t num_words = 10;
     constexpr size_t data_size = num_words * sizeof(uint32_t);
 
@@ -400,7 +400,7 @@ TEST_P(TestMulticastWriteFixture, TestMulticastWrite) {
             const tt_xy_pair multicast_coord =
                 soc_desc.translate_coord_to(core, use_noc0 ? CoordSystem::NOC0 : CoordSystem::TRANSLATED);
             if (full_grid) {
-                log_info(LogUMD, "Multicast to full grid on chip {}", multicast_coord.str(), chip_id);
+                log_info(LogUMD, "Multicast to full grid from coord {} on chip {}", multicast_coord.str(), chip_id);
                 tt_device->noc_multicast_write(write_data.data(), data_size, address);
             } else {
                 log_info(LogUMD, "Multicast to core {} on chip {}", multicast_coord.str(), chip_id);

--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -397,11 +397,12 @@ TEST_P(TestMulticastWriteFixture, TestMulticastWrite) {
                 v++;
             }
 
+            const tt_xy_pair multicast_coord =
+                soc_desc.translate_coord_to(core, use_noc0 ? CoordSystem::NOC0 : CoordSystem::TRANSLATED);
             if (full_grid) {
+                log_info(LogUMD, "Multicast to full grid on chip {}", multicast_coord.str(), chip_id);
                 tt_device->noc_multicast_write(write_data.data(), data_size, address);
             } else {
-                const tt_xy_pair multicast_coord =
-                    soc_desc.translate_coord_to(core, use_noc0 ? CoordSystem::NOC0 : CoordSystem::TRANSLATED);
                 log_info(LogUMD, "Multicast to core {} on chip {}", multicast_coord.str(), chip_id);
                 tt_device->noc_multicast_write(write_data.data(), data_size, multicast_coord, multicast_coord, address);
             }

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -266,7 +266,6 @@ TEST(ApiTTDeviceTest, MulticastIO) {
 TEST(ApiTTDeviceTest, BroadcastIO) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
-    uint64_t address = 0x0;
     std::vector<uint32_t> data_write = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
     for (int pci_device_id : pci_device_ids) {
@@ -276,28 +275,28 @@ TEST(ApiTTDeviceTest, BroadcastIO) {
 
         ChipInfo chip_info = tt_device->get_chip_info();
         SocDescriptor soc_desc(tt_device->get_arch(), chip_info);
-        const std::vector<CoreCoord>& tensix_cores = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
+        const std::vector<CoreCoord> tensix_cores = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
 
         // Zero out all tensix cores before broadcasting.
         std::vector<uint32_t> zeros(data_write.size(), 0);
         for (const CoreCoord& core : tensix_cores) {
-            tt_device->write_to_device(zeros.data(), core, address, zeros.size() * sizeof(uint32_t));
+            tt_device->write_to_device(zeros.data(), core, SAFE_IO_L1_ADDRESS, zeros.size() * sizeof(uint32_t));
         }
 
         // Verify zeros landed.
         for (const CoreCoord& core : tensix_cores) {
             std::vector<uint32_t> readback(data_write.size(), 1);
-            tt_device->read_from_device(readback.data(), core, address, readback.size() * sizeof(uint32_t));
+            tt_device->read_from_device(readback.data(), core, SAFE_IO_L1_ADDRESS, readback.size() * sizeof(uint32_t));
             ASSERT_EQ(zeros, readback) << "Core " << core.str() << " on chip " << pci_device_id
                                        << " should have been zeroed before the broadcast write.";
         }
 
-        tt_device->noc_multicast_write(data_write.data(), data_write.size() * sizeof(uint32_t), address);
+        tt_device->noc_multicast_write(data_write.data(), data_write.size() * sizeof(uint32_t), SAFE_IO_L1_ADDRESS);
 
         // All tensix cores should now have the broadcast data.
         for (const CoreCoord& core : tensix_cores) {
             std::vector<uint32_t> readback(data_write.size());
-            tt_device->read_from_device(readback.data(), core, address, readback.size() * sizeof(uint32_t));
+            tt_device->read_from_device(readback.data(), core, SAFE_IO_L1_ADDRESS, readback.size() * sizeof(uint32_t));
             ASSERT_EQ(data_write, readback) << "Core " << core.str() << " on chip " << pci_device_id
                                             << " should have received the broadcast write.";
         }

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -267,7 +267,7 @@ TEST(ApiTTDeviceTest, BroadcastIO) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     uint64_t address = 0x0;
-    std::vector<uint8_t> data_write = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    std::vector<uint32_t> data_write = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
@@ -279,14 +279,14 @@ TEST(ApiTTDeviceTest, BroadcastIO) {
         const std::vector<CoreCoord>& tensix_cores = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
 
         // Zero out all tensix cores before broadcasting.
-        std::vector<uint8_t> zeros(data_write.size(), 0);
+        std::vector<uint32_t> zeros(data_write.size(), 0);
         for (const CoreCoord& core : tensix_cores) {
             tt_device->write_to_device(zeros.data(), core, address, zeros.size());
         }
 
         // Verify zeros landed.
         for (const CoreCoord& core : tensix_cores) {
-            std::vector<uint8_t> readback(data_write.size(), 1);
+            std::vector<uint32_t> readback(data_write.size(), 1);
             tt_device->read_from_device(readback.data(), core, address, readback.size());
             ASSERT_EQ(zeros, readback) << "Core " << core.str() << " on chip " << pci_device_id
                                        << " should have been zeroed before the broadcast write.";
@@ -296,7 +296,7 @@ TEST(ApiTTDeviceTest, BroadcastIO) {
 
         // All tensix cores should now have the broadcast data.
         for (const CoreCoord& core : tensix_cores) {
-            std::vector<uint8_t> readback(data_write.size());
+            std::vector<uint32_t> readback(data_write.size());
             tt_device->read_from_device(readback.data(), core, address, readback.size());
             ASSERT_EQ(data_write, readback) << "Core " << core.str() << " on chip " << pci_device_id
                                             << " should have received the broadcast write.";

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -281,23 +281,23 @@ TEST(ApiTTDeviceTest, BroadcastIO) {
         // Zero out all tensix cores before broadcasting.
         std::vector<uint32_t> zeros(data_write.size(), 0);
         for (const CoreCoord& core : tensix_cores) {
-            tt_device->write_to_device(zeros.data(), core, address, zeros.size());
+            tt_device->write_to_device(zeros.data(), core, address, zeros.size() * sizeof(uint32_t));
         }
 
         // Verify zeros landed.
         for (const CoreCoord& core : tensix_cores) {
             std::vector<uint32_t> readback(data_write.size(), 1);
-            tt_device->read_from_device(readback.data(), core, address, readback.size());
+            tt_device->read_from_device(readback.data(), core, address, readback.size() * sizeof(uint32_t));
             ASSERT_EQ(zeros, readback) << "Core " << core.str() << " on chip " << pci_device_id
                                        << " should have been zeroed before the broadcast write.";
         }
 
-        tt_device->noc_multicast_write(data_write.data(), data_write.size(), address);
+        tt_device->noc_multicast_write(data_write.data(), data_write.size() * sizeof(uint32_t), address);
 
         // All tensix cores should now have the broadcast data.
         for (const CoreCoord& core : tensix_cores) {
             std::vector<uint32_t> readback(data_write.size());
-            tt_device->read_from_device(readback.data(), core, address, readback.size());
+            tt_device->read_from_device(readback.data(), core, address, readback.size() * sizeof(uint32_t));
             ASSERT_EQ(data_write, readback) << "Core " << core.str() << " on chip " << pci_device_id
                                             << " should have received the broadcast write.";
         }

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -288,7 +288,8 @@ TEST(ApiTTDeviceTest, BroadcastIO) {
         for (const CoreCoord& core : tensix_cores) {
             std::vector<uint8_t> readback(data_write.size(), 1);
             tt_device->read_from_device(readback.data(), core, address, readback.size());
-            EXPECT_EQ(zeros, readback);
+            ASSERT_EQ(zeros, readback) << "Core " << core.str() << " on chip " << pci_device_id
+                                       << " should have been zeroed before the broadcast write.";
         }
 
         tt_device->noc_multicast_write(data_write.data(), data_write.size(), address);
@@ -297,7 +298,8 @@ TEST(ApiTTDeviceTest, BroadcastIO) {
         for (const CoreCoord& core : tensix_cores) {
             std::vector<uint8_t> readback(data_write.size());
             tt_device->read_from_device(readback.data(), core, address, readback.size());
-            EXPECT_EQ(data_write, readback);
+            ASSERT_EQ(data_write, readback) << "Core " << core.str() << " on chip " << pci_device_id
+                                            << " should have received the broadcast write.";
         }
 
         tt_device->set_power_state(false);

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -273,8 +273,7 @@ TEST(ApiTTDeviceTest, BroadcastIO) {
         tt_device->set_power_state(true);
         tt_device->init_tt_device();
 
-        ChipInfo chip_info = tt_device->get_chip_info();
-        SocDescriptor soc_desc(tt_device->get_arch(), chip_info);
+        const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
         const std::vector<CoreCoord> tensix_cores = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
 
         // Zero out all tensix cores before broadcasting.

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -262,3 +262,44 @@ TEST(ApiTTDeviceTest, MulticastIO) {
         tt_device->set_power_state(false);
     }
 }
+
+TEST(ApiTTDeviceTest, BroadcastIO) {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+
+    uint64_t address = 0x0;
+    std::vector<uint8_t> data_write = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+
+    for (int pci_device_id : pci_device_ids) {
+        std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
+        tt_device->set_power_state(true);
+        tt_device->init_tt_device();
+
+        ChipInfo chip_info = tt_device->get_chip_info();
+        SocDescriptor soc_desc(tt_device->get_arch(), chip_info);
+        const std::vector<CoreCoord>& tensix_cores = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
+
+        // Zero out all tensix cores before broadcasting.
+        std::vector<uint8_t> zeros(data_write.size(), 0);
+        for (const CoreCoord& core : tensix_cores) {
+            tt_device->write_to_device(zeros.data(), core, address, zeros.size());
+        }
+
+        // Verify zeros landed.
+        for (const CoreCoord& core : tensix_cores) {
+            std::vector<uint8_t> readback(data_write.size(), 1);
+            tt_device->read_from_device(readback.data(), core, address, readback.size());
+            EXPECT_EQ(zeros, readback);
+        }
+
+        tt_device->noc_multicast_write(data_write.data(), data_write.size(), address);
+
+        // All tensix cores should now have the broadcast data.
+        for (const CoreCoord& core : tensix_cores) {
+            std::vector<uint8_t> readback(data_write.size());
+            tt_device->read_from_device(readback.data(), core, address, readback.size());
+            EXPECT_EQ(data_write, readback);
+        }
+
+        tt_device->set_power_state(false);
+    }
+}


### PR DESCRIPTION
### Issue
#2521 

### Description
Add a helper function to TTDevice to multicast to all tensix cores

### List of the changes
- Implement noc_multicast_write without core_start/core_end (multicasts to all tensix)
- Enhance PCIDevice's log_trace for tlb config
- Implement WH and BH specific multicast functions
- Add noc_multicast and noc_broadcast to py_api
- Add full_grid version of MulticastWrite tests
- Add dedicated BroadcastIO test

### Testing
Tests in this PR cover the new functionality

### API Changes
This PR has API changes: added noc_broadcast 
