### PR TITLE
Remove usage of TensixSoftReset

### DIFF
--- a/device/api/umd/device/chip/chip.hpp
+++ b/device/api/umd/device/chip/chip.hpp
@@ -70,6 +70,7 @@ public:
     virtual void dma_multicast_write(
         void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) = 0;
     virtual void noc_multicast_write(void* dst, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr);
+    virtual void noc_multicast_write(void* dst, size_t size, uint64_t addr);
 
     virtual void wait_for_non_mmio_flush() = 0;
 

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -717,7 +717,7 @@ public:
 private:
     // Helper functions
     // Broadcast.
-    void broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOptions& soft_resets);
+    void broadcast_tensix_risc_reset_to_cluster(uint32_t reg_value);
     void deassert_resets_and_set_power_state();
 
     // Validates that the caller-supplied rows/columns lie in the coordinate space selected by

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -299,4 +299,8 @@ void Chip::noc_multicast_write(void* dst, size_t size, CoreCoord core_start, Cor
         addr);
 }
 
+void Chip::noc_multicast_write(void* dst, size_t size, uint64_t addr) {
+    get_tt_device()->noc_multicast_write(dst, size, addr);
+}
+
 }  // namespace tt::umd

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1037,13 +1037,6 @@ void Cluster::broadcast_tensix_risc_reset_to_cluster(uint32_t reg_value) {
         // Nowhere to broadcast to.
         return;
     }
-    // If ethernet broadcast is not supported, do it one by one.
-    if (!use_ethernet_broadcast) {
-        for (auto& chip_id : all_chip_ids_) {
-            get_chip(chip_id)->noc_multicast_write(&reg_value, sizeof(uint32_t), 0xFFB121B0);
-        }
-        return;
-    }
 
     std::set<ChipId> chips_to_exclude = {};
     std::set<uint32_t> rows_to_exclude;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -440,9 +440,10 @@ void Cluster::assert_risc_reset() {
 }
 
 void Cluster::deassert_risc_reset() {
-    // Lower the reset signal for BRISC only.
-    uint32_t reset_reg_value = architecture_implementation::create(arch_name)->get_soft_reset_reg_value(
-        RiscType::ALL_TENSIX & ~RiscType::BRISC);
+    // Lower the reset signal for BRISC only, with staggered start enabled.
+    auto arch_impl = architecture_implementation::create(arch_name);
+    uint32_t reset_reg_value = arch_impl->get_soft_reset_reg_value(RiscType::ALL_TENSIX & ~RiscType::BRISC) |
+                               arch_impl->get_soft_reset_staggered_start();
     broadcast_tensix_risc_reset_to_cluster(reset_reg_value);
 }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -432,9 +432,19 @@ std::set<ChipId> Cluster::get_target_mmio_device_ids() { return local_chip_ids_;
 
 std::set<ChipId> Cluster::get_target_remote_device_ids() { return remote_chip_ids_; }
 
-void Cluster::assert_risc_reset() { broadcast_tensix_risc_reset_to_cluster(TENSIX_ASSERT_SOFT_RESET); }
+void Cluster::assert_risc_reset() {
+    // Raise reset signal for all cores.
+    uint32_t reset_reg_value =
+        architecture_implementation::create(arch_name)->get_soft_reset_reg_value(RiscType::ALL_TENSIX);
+    broadcast_tensix_risc_reset_to_cluster(reset_reg_value);
+}
 
-void Cluster::deassert_risc_reset() { broadcast_tensix_risc_reset_to_cluster(TENSIX_DEASSERT_SOFT_RESET); }
+void Cluster::deassert_risc_reset() {
+    // Lower the reset signal for BRISC only.
+    uint32_t reset_reg_value = architecture_implementation::create(arch_name)->get_soft_reset_reg_value(
+        RiscType::ALL_TENSIX & ~RiscType::BRISC);
+    broadcast_tensix_risc_reset_to_cluster(reset_reg_value);
+}
 
 void Cluster::deassert_risc_reset_at_core(
     const ChipId chip, const CoreCoord core, const TensixSoftResetOptions& soft_resets) {
@@ -1022,7 +1032,7 @@ int Cluster::arc_msg(
     return get_chip(logical_device_id)->arc_msg(msg_code, wait_for_done, args, timeout_ms, return_3, return_4);
 }
 
-void Cluster::broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOptions& soft_resets) {
+void Cluster::broadcast_tensix_risc_reset_to_cluster(uint32_t reg_value) {
     if (chips_.empty()) {
         // Nowhere to broadcast to.
         return;
@@ -1030,13 +1040,11 @@ void Cluster::broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOption
     // If ethernet broadcast is not supported, do it one by one.
     if (!use_ethernet_broadcast) {
         for (auto& chip_id : all_chip_ids_) {
-            get_chip(chip_id)->send_tensix_risc_reset(soft_resets);
+            get_chip(chip_id)->noc_multicast_write(&reg_value, sizeof(uint32_t), 0xFFB121B0);
         }
         return;
     }
 
-    auto valid = soft_resets & ALL_TENSIX_SOFT_RESET;
-    uint32_t valid_val = (std::underlying_type<TensixSoftResetOptions>::type)valid;
     std::set<ChipId> chips_to_exclude = {};
     std::set<uint32_t> rows_to_exclude;
     std::set<uint32_t> columns_to_exclude;
@@ -1060,7 +1068,7 @@ void Cluster::broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOption
         }
     }
     broadcast_write_to_cluster(
-        &valid_val,
+        &reg_value,
         sizeof(uint32_t),
         0xFFB121B0,
         chips_to_exclude,
@@ -1080,7 +1088,7 @@ void Cluster::set_power_state(DevicePowerState device_state) {
 void Cluster::deassert_resets_and_set_power_state() {
     ZoneScopedC(tracy::Color::DarkGreen);
     // Assert tensix resets on all chips in cluster.
-    broadcast_tensix_risc_reset_to_cluster(TENSIX_ASSERT_SOFT_RESET);
+    assert_risc_reset();
 
     for (auto& [_, chip] : chips_) {
         chip->deassert_risc_resets();


### PR DESCRIPTION
### Issue
#1303 
Part of effort #2521 

### Description
This enum was being purged, and this was the only place left. Now we have much better test coverage than when this effort was started.

### List of the changes
- Remove TensixSoftResetOptions from broadcast_tensix_risc_reset_to_cluster
- Expose noc_multicast_write in Chip
- deassert_resets_and_set_power_state calls assert_rist_reset()

### Testing
Existing CI should cover this flow

### API Changes
There are no API changes in this PR, changes are internal
