### PR TITLE
const src in all noc_multicast_write

### DIFF
--- a/device/api/umd/device/chip/chip.hpp
+++ b/device/api/umd/device/chip/chip.hpp
@@ -67,8 +67,9 @@ public:
     virtual void dma_read_from_device(void* dst, size_t size, CoreCoord core, uint64_t addr) = 0;
     virtual void dma_multicast_write(
         void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) = 0;
-    virtual void noc_multicast_write(void* dst, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr);
-    virtual void noc_multicast_write(void* dst, size_t size, uint64_t addr);
+    virtual void noc_multicast_write(
+        const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr);
+    virtual void noc_multicast_write(const void* src, size_t size, uint64_t addr);
 
     virtual void wait_for_non_mmio_flush() = 0;
 

--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -71,7 +71,8 @@ public:
     void read_from_device(CoreCoord core, void* dest, uint64_t l1_src, size_t size) override;
     void write_to_device_reg(CoreCoord core, const void* src, uint64_t reg_dest, uint32_t size) override;
     void read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_src, uint32_t size) override;
-    void noc_multicast_write(void* dst, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
+    void noc_multicast_write(
+        const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
 
     void dma_write_to_device(const void* src, size_t size, CoreCoord core, uint64_t addr) override;
     void dma_read_from_device(void* dst, size_t size, CoreCoord core, uint64_t addr) override;

--- a/device/api/umd/device/chip/mock_chip.hpp
+++ b/device/api/umd/device/chip/mock_chip.hpp
@@ -42,7 +42,8 @@ public:
     void dma_write_to_device(const void* src, size_t size, CoreCoord core, uint64_t addr) override;
     void dma_multicast_write(void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
     void dma_read_from_device(void* dst, size_t size, CoreCoord core, uint64_t addr) override;
-    void noc_multicast_write(void* dst, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
+    void noc_multicast_write(
+        const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
 
     int arc_msg(
         uint32_t msg_code,

--- a/device/api/umd/device/chip/sw_emule_chip.hpp
+++ b/device/api/umd/device/chip/sw_emule_chip.hpp
@@ -55,7 +55,8 @@ public:
     void dma_write_to_device(const void* src, size_t size, CoreCoord core, uint64_t addr) override;
     void dma_read_from_device(void* dst, size_t size, CoreCoord core, uint64_t addr) override;
     void dma_multicast_write(void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
-    void noc_multicast_write(void* dst, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
+    void noc_multicast_write(
+        const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
 
     // Barriers, resets, power — no-ops.
     void wait_for_non_mmio_flush() override;

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -445,7 +445,7 @@ public:
         void* src, size_t size, ChipId chip, CoreCoord core_start, CoreCoord core_end, uint64_t addr);
 
     void noc_multicast_write(
-        void* dst, size_t size, ChipId chip, CoreCoord core_start, CoreCoord core_end, uint64_t addr);
+        const void* src, size_t size, ChipId chip, CoreCoord core_start, CoreCoord core_end, uint64_t addr);
 
     /**
      * This function writes to multiple chips and cores in the cluster. A set of chips, rows and columns can be excluded

--- a/device/api/umd/device/pcie/silicon_tlb_window.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_window.hpp
@@ -63,7 +63,7 @@ public:
         override;
 
     void safe_noc_multicast_write_reconfigure(
-        void* dst,
+        const void* src,
         size_t size,
         tt_xy_pair core_start,
         tt_xy_pair core_end,

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -50,7 +50,7 @@ public:
         uint64_t ordering = tlb_data::Strict);
 
     virtual void noc_multicast_write_reconfigure(
-        void* dst,
+        const void* src,
         size_t size,
         tt_xy_pair core_start,
         tt_xy_pair core_end,
@@ -86,7 +86,7 @@ public:
         void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
 
     virtual void safe_noc_multicast_write_reconfigure(
-        void* dst,
+        const void* src,
         size_t size,
         tt_xy_pair core_start,
         tt_xy_pair core_end,

--- a/device/api/umd/device/simulation/simulation_chip.hpp
+++ b/device/api/umd/device/simulation/simulation_chip.hpp
@@ -65,7 +65,8 @@ public:
     void dma_write_to_device(const void* src, size_t size, CoreCoord core, uint64_t addr) override;
     void dma_multicast_write(void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
     void dma_read_from_device(void* dst, size_t size, CoreCoord core, uint64_t addr) override;
-    void noc_multicast_write(void* dst, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
+    void noc_multicast_write(
+        const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
 
     void wait_for_non_mmio_flush() override;
 

--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -52,7 +52,7 @@ public:
     EthTrainingStatus read_eth_core_training_status(tt_xy_pair eth_core) override;
 
     using TTDevice::noc_multicast_write;
-    void noc_multicast_write(void *src, size_t size, uint64_t addr) override;
+    void noc_multicast_write(const void *src, size_t size, uint64_t addr) override;
 
 protected:
     BlackholeTTDevice(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api);

--- a/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
@@ -43,7 +43,7 @@ public:
     virtual void dma_h2d_zero_copy(uint32_t dst, const void* src, size_t size) = 0;
 
     virtual void noc_multicast_write(
-        void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) = 0;
+        const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) = 0;
 
     virtual void write_regs(volatile uint32_t* dest, const uint32_t* src, uint32_t word_len) = 0;
     virtual void bar_write32(uint32_t addr, uint32_t data) = 0;

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -60,7 +60,7 @@ public:
     void dma_h2d(uint32_t dst, const void* src, size_t size) override;
     void dma_h2d_zero_copy(uint32_t dst, const void* src, size_t size) override;
     void noc_multicast_write(
-        void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) override;
+        const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) override;
     void write_regs(volatile uint32_t* dest, const uint32_t* src, uint32_t word_len) override;
     void bar_write32(uint32_t addr, uint32_t data) override;
     uint32_t bar_read32(uint32_t addr) override;

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -63,7 +63,7 @@ public:
     void assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs) override;
     void deassert_risc_reset(tt_xy_pair core, const RiscType selected_riscs, bool staggered_start) override;
 
-    void noc_multicast_write(void* src, size_t size, uint64_t addr) override;
+    void noc_multicast_write(const void* src, size_t size, uint64_t addr) override;
 
     RtlSimCommunicator* get_communicator() { return communicator_.get(); }
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -198,8 +198,10 @@ public:
      * @param core_end ending core coordinates (x,y) of the multicast write
      * @param addr address on the device where data will be written
      */
-    virtual void noc_multicast_write(void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr);
-    virtual void noc_multicast_write(void *src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr);
+    virtual void noc_multicast_write(
+        const void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr);
+    virtual void noc_multicast_write(
+        const void *src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr);
 
     /**
      * NOC multicast write function that will write data to all TENSIX cores in the grid.
@@ -208,7 +210,7 @@ public:
      * @param size number of bytes
      * @param addr address on the device where data will be written
      */
-    virtual void noc_multicast_write(void *src, size_t size, uint64_t addr) = 0;
+    virtual void noc_multicast_write(const void *src, size_t size, uint64_t addr) = 0;
 
     /**
      * Read function that will send read message to the ARC core APB peripherals.

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -73,7 +73,7 @@ public:
 
     void close_device();
     void start_device();
-    void noc_multicast_write(void *src, size_t size, uint64_t addr) override;
+    void noc_multicast_write(const void *src, size_t size, uint64_t addr) override;
 
     void assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs) override;
     void deassert_risc_reset(tt_xy_pair core, const RiscType selected_riscs, bool staggered_start) override;

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -52,7 +52,7 @@ public:
         void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
 
     using TTDevice::noc_multicast_write;
-    void noc_multicast_write(void *src, size_t size, uint64_t addr) override;
+    void noc_multicast_write(const void *src, size_t size, uint64_t addr) override;
 
     ~WormholeTTDevice() override = default;
 

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -49,7 +49,7 @@ public:
     EthTrainingStatus read_eth_core_training_status(tt_xy_pair eth_core) override;
 
     void noc_multicast_write(
-        void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
+        const void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
 
     using TTDevice::noc_multicast_write;
     void noc_multicast_write(const void *src, size_t size, uint64_t addr) override;

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -269,21 +269,21 @@ void Chip::wait_for_aiclk_value(
     }
 }
 
-void Chip::noc_multicast_write(void* dst, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) {
+void Chip::noc_multicast_write(const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) {
     // TODO: Support other core types once needed.
     if (core_start.core_type != CoreType::TENSIX || core_end.core_type != CoreType::TENSIX) {
         UMD_THROW(error::RuntimeError, "noc_multicast_write is only supported for Tensix cores.");
     }
     get_tt_device()->noc_multicast_write(
-        dst,
+        src,
         size,
         get_soc_descriptor().translate_chip_coord_to_translated(core_start),
         get_soc_descriptor().translate_chip_coord_to_translated(core_end),
         addr);
 }
 
-void Chip::noc_multicast_write(void* dst, size_t size, uint64_t addr) {
-    get_tt_device()->noc_multicast_write(dst, size, addr);
+void Chip::noc_multicast_write(const void* src, size_t size, uint64_t addr) {
+    get_tt_device()->noc_multicast_write(src, size, addr);
 }
 
 }  // namespace tt::umd

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -612,7 +612,8 @@ TlbWindow* LocalChip::get_cached_uc_tlb_window() {
     return cached_uc_tlb_window.get();
 }
 
-void LocalChip::noc_multicast_write(void* dst, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) {
+void LocalChip::noc_multicast_write(
+    const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) {
     // TODO: Support other core types once needed.
     if (core_start.core_type != CoreType::TENSIX || core_end.core_type != CoreType::TENSIX) {
         UMD_THROW(error::RuntimeError, "noc_multicast_write is only supported for Tensix cores.");
@@ -626,7 +627,7 @@ void LocalChip::noc_multicast_write(void* dst, size_t size, CoreCoord core_start
     std::lock_guard<std::mutex> lock(wc_tlb_lock);
 
     get_cached_wc_tlb_window()->noc_multicast_write_reconfigure(
-        dst,
+        src,
         size,
         get_soc_descriptor().translate_chip_coord_to_translated(core_start),
         get_soc_descriptor().translate_chip_coord_to_translated(core_end),

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -51,7 +51,8 @@ void MockChip::dma_read_from_device(void* dst, size_t size, CoreCoord core, uint
 
 void MockChip::dma_multicast_write(void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) {}
 
-void MockChip::noc_multicast_write(void* dst, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) {}
+void MockChip::noc_multicast_write(
+    const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) {}
 
 int MockChip::arc_msg(
     uint32_t msg_code,

--- a/device/chip/sw_emule_chip.cpp
+++ b/device/chip/sw_emule_chip.cpp
@@ -147,7 +147,7 @@ void SWEmuleChip::dma_multicast_write(void*, size_t, CoreCoord, CoreCoord, uint6
     throw std::runtime_error("SWEmuleChip::dma_multicast_write is not implemented");
 }
 
-void SWEmuleChip::noc_multicast_write(void*, size_t, CoreCoord, CoreCoord, uint64_t) {
+void SWEmuleChip::noc_multicast_write(const void*, size_t, CoreCoord, CoreCoord, uint64_t) {
     throw std::runtime_error("SWEmuleChip::noc_multicast_write is not implemented");
 }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1149,9 +1149,9 @@ void Cluster::read_from_device_reg(void* mem_ptr, ChipId chip, CoreCoord core, u
 }
 
 void Cluster::noc_multicast_write(
-    void* dst, size_t size, ChipId chip, CoreCoord core_start, CoreCoord core_end, uint64_t addr) {
+    const void* src, size_t size, ChipId chip, CoreCoord core_start, CoreCoord core_end, uint64_t addr) {
     ZoneScopedC(tracy::Color::Orange);
-    get_chip(chip)->noc_multicast_write(dst, size, core_start, core_end, addr);
+    get_chip(chip)->noc_multicast_write(src, size, core_start, core_end, addr);
 }
 
 int Cluster::arc_msg(

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -286,7 +286,7 @@ void SiliconTlbWindow::safe_read_block_reconfigure(
 }
 
 void SiliconTlbWindow::safe_noc_multicast_write_reconfigure(
-    void *dst,
+    const void *src,
     size_t size,
     tt_xy_pair core_start,
     tt_xy_pair core_end,
@@ -294,7 +294,7 @@ void SiliconTlbWindow::safe_noc_multicast_write_reconfigure(
     NocId noc_id,
     uint64_t ordering) {
     execute_safe(
-        &SiliconTlbWindow::noc_multicast_write_reconfigure, dst, size, core_start, core_end, addr, noc_id, ordering);
+        &SiliconTlbWindow::noc_multicast_write_reconfigure, src, size, core_start, core_end, addr, noc_id, ordering);
 }
 
 }  // namespace tt::umd

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -77,14 +77,14 @@ void TlbWindow::write_block_reconfigure(
 }
 
 void TlbWindow::noc_multicast_write_reconfigure(
-    void* dst,
+    const void* src,
     size_t size,
     tt_xy_pair core_start,
     tt_xy_pair core_end,
     uint64_t addr,
     NocId noc_id,
     uint64_t ordering) {
-    uint8_t* buffer_addr = static_cast<uint8_t*>(dst);
+    const uint8_t* buffer_addr = static_cast<const uint8_t*>(src);
     tlb_data config{};
     config.local_offset = addr;
     config.x_start = core_start.x;
@@ -160,14 +160,14 @@ void TlbWindow::safe_read_block_reconfigure(
 }
 
 void TlbWindow::safe_noc_multicast_write_reconfigure(
-    void* dst,
+    const void* src,
     size_t size,
     tt_xy_pair core_start,
     tt_xy_pair core_end,
     uint64_t addr,
     NocId noc_id,
     uint64_t ordering) {
-    noc_multicast_write_reconfigure(dst, size, core_start, core_end, addr, noc_id, ordering);
+    noc_multicast_write_reconfigure(src, size, core_start, core_end, addr, noc_id, ordering);
 }
 
 }  // namespace tt::umd

--- a/device/simulation/simulation_chip.cpp
+++ b/device/simulation/simulation_chip.cpp
@@ -68,7 +68,7 @@ void SimulationChip::dma_multicast_write(
 }
 
 void SimulationChip::noc_multicast_write(
-    void* dst, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) {
+    const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) {
     // TODO: Support other core types once needed.
     if (core_start.core_type != CoreType::TENSIX || core_end.core_type != CoreType::TENSIX) {
         UMD_THROW(error::RuntimeError, "noc_multicast_write is only supported for Tensix cores.");
@@ -85,7 +85,7 @@ void SimulationChip::noc_multicast_write(
             if (soc_descriptor_.arch == tt::ARCH::BLACKHOLE && (x == 8 || x == 9)) {
                 continue;
             }
-            write_to_device(CoreCoord(x, y, core_start.core_type, CoordSystem::TRANSLATED), dst, addr, size);
+            write_to_device(CoreCoord(x, y, core_start.core_type, CoordSystem::TRANSLATED), src, addr, size);
         }
     }
 }

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -312,7 +312,7 @@ void BlackholeTTDevice::retrain_dram_core(const uint32_t dram_channel) {
     }
 }
 
-void BlackholeTTDevice::noc_multicast_write(void *src, size_t size, uint64_t addr) {
+void BlackholeTTDevice::noc_multicast_write(const void *src, size_t size, uint64_t addr) {
     // BH grid is 17x12. Broadcast coordinates depend on NOC translation:
     //   Translation disabled: full grid hardware multicast, skipping NOC controller row at y=0.
     //   Translation enabled:  hardware broadcast is avoided; use a software multicast with

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -105,7 +105,7 @@ bool PcieProtocol::write_to_core_range(const void*, tt_xy_pair, tt_xy_pair, uint
 int PcieProtocol::get_mmio_id() { return pci_device_->get_pci_device_id(); }
 
 void PcieProtocol::noc_multicast_write(
-    void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) {
+    const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) {
     std::lock_guard<std::mutex> lock(io_lock_);
     if (use_safe_api_) {
         get_cached_tlb_window()->safe_noc_multicast_write_reconfigure(

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -334,7 +334,7 @@ void RtlSimulationTTDevice::retrain_dram_core(const uint32_t dram_channel) {
     UMD_THROW(error::RuntimeError, "DRAM retraining is not supported in RTL simulation device.");
 }
 
-void RtlSimulationTTDevice::noc_multicast_write(void* src, size_t size, uint64_t addr) {
+void RtlSimulationTTDevice::noc_multicast_write(const void* src, size_t size, uint64_t addr) {
     UMD_THROW(error::RuntimeError, "NOC multicast write is not supported in RTL simulation device.");
 }
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -470,12 +470,14 @@ void TTDevice::deassert_risc_reset(tt_xy_pair core, const RiscType selected_risc
 
 tt_xy_pair TTDevice::get_arc_core() const { return arc_core; }
 
-void TTDevice::noc_multicast_write(void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) {
+void TTDevice::noc_multicast_write(
+    const void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) {
     ZoneScopedC(tracy::Color::Orange);
     get_pcie_interface()->noc_multicast_write(src, size, core_start, core_end, addr, get_selected_noc_id());
 }
 
-void TTDevice::noc_multicast_write(void *src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) {
+void TTDevice::noc_multicast_write(
+    const void *src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) {
     const SocDescriptor &soc_desc = get_soc_descriptor();
     noc_multicast_write(
         src,

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -391,7 +391,7 @@ void TTSimTTDevice::retrain_dram_core(const uint32_t dram_channel) {
     UMD_THROW(error::RuntimeError, "DRAM retraining is not supported in TTSim device.");
 }
 
-void TTSimTTDevice::noc_multicast_write(void* src, size_t size, uint64_t addr) {
+void TTSimTTDevice::noc_multicast_write(const void* src, size_t size, uint64_t addr) {
     UMD_THROW(error::RuntimeError, "NOC multicast write is not supported in TTSim simulation device.");
 }
 

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -442,7 +442,7 @@ void WormholeTTDevice::noc_multicast_write(
     }
 }
 
-void WormholeTTDevice::noc_multicast_write(void *src, size_t size, uint64_t addr) {
+void WormholeTTDevice::noc_multicast_write(const void *src, size_t size, uint64_t addr) {
     // Same range is used for NOC0 and NOC1.
     // Note that when multicasting in translated space, you have to skip harvested rows. So we can just always use NOC0
     // coords for broadcasting, since these are always the same and guaranteed to land at all TENSIX cores.

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -418,7 +418,7 @@ void WormholeTTDevice::retrain_dram_core(const uint32_t dram_channel) {
 }
 
 void WormholeTTDevice::noc_multicast_write(
-    void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) {
+    const void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) {
     ZoneScopedC(tracy::Color::Orange);
     if (!is_remote_tt_device) {
         TTDevice::noc_multicast_write(src, size, core_start, core_end, addr);


### PR DESCRIPTION
### Issue
Found while working on #2521 

### Description
No functional changes, just change multicast related functions to have const void *src as first arg

### List of the changes
- const void *src

### Testing
code builds

### API Changes
Adds const to API parameter, which should make the api more flexible
