### PR TITLE
Change ethernet_broadcast interface to use translated space

### DIFF
--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -476,9 +476,12 @@ public:
      * @param size_in_bytes Size of data to write.
      * @param address Address to write to.
      * @param chips_to_exclude Chips to exclude from the broadcast.
-     * @param rows_to_exclude  NOC0 rows to exclude from the broadcast.
-     * @param columns_to_exclude NOC0 columns to exclude from the broadcast.
-     * @param use_translated_coords If true, rows and columns to be excluded are in translated-index space.
+     * @param rows_to_exclude Rows to exclude from the broadcast, in NOC0 space when
+     *                        @p use_translated_coords is false, or in translated-index space when true.
+     * @param columns_to_exclude Columns to exclude from the broadcast, in NOC0 space when
+     *                           @p use_translated_coords is false, or in translated-index space when true.
+     * @param use_translated_coords Selects the coordinate space of @p rows_to_exclude and
+     *                              @p columns_to_exclude; callers must supply values in the matching space.
      */
     void broadcast_write_to_cluster(
         const void* mem_ptr,
@@ -716,6 +719,16 @@ private:
     // Broadcast.
     void broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOptions& soft_resets);
     void deassert_resets_and_set_power_state();
+
+    // Validates that the caller-supplied rows/columns lie in the coordinate space selected by
+    // @p use_translated_coords (NOC0 when false, translated-index when true) and emits their
+    // virtual-space equivalents used by the ethernet broadcast path.
+    static void adjust_coordinates_for_ethernet_broadcast(
+        const std::set<uint32_t>& rows_to_exclude,
+        const std::set<uint32_t>& columns_to_exclude,
+        bool use_translated_coords,
+        std::set<uint32_t>& rows_to_exclude_virtual,
+        std::set<uint32_t>& cols_to_exclude_virtual);
 
     // Communication Functions.
     void ethernet_broadcast_write(

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -478,6 +478,7 @@ public:
      * @param chips_to_exclude Chips to exclude from the broadcast.
      * @param rows_to_exclude  NOC0 rows to exclude from the broadcast.
      * @param columns_to_exclude NOC0 columns to exclude from the broadcast.
+     * @param use_translated_coords If true, rows and columns to be excluded are in translated-index space.
      */
     void broadcast_write_to_cluster(
         const void* mem_ptr,
@@ -485,7 +486,8 @@ public:
         uint64_t address,
         const std::set<ChipId>& chips_to_exclude,
         std::set<uint32_t>& rows_to_exclude,
-        std::set<uint32_t>& columns_to_exclude);
+        std::set<uint32_t>& columns_to_exclude,
+        bool use_translated_coords);
 
     /**
      * Provide fast read/write access to a statically-mapped TLB.

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -820,24 +820,39 @@ void Cluster::broadcast_write_to_cluster(
     uint64_t address,
     const std::set<ChipId>& chips_to_exclude,
     std::set<uint32_t>& rows_to_exclude,
-    std::set<uint32_t>& columns_to_exclude) {
+    std::set<uint32_t>& columns_to_exclude,
+    bool use_translated_coords) {
     if (arch_name != tt::ARCH::WORMHOLE_B0) {
         UMD_THROW(error::RuntimeError, "Broadcast write is only supported on Wormhole architecture.");
     }
 
+    std::set<uint32_t> rows_to_exclude_virtual;
+    std::set<uint32_t> cols_to_exclude_virtual;
+    for (const auto& row : rows_to_exclude) {
+        rows_to_exclude_virtual.insert(
+            use_translated_coords ? wormhole::TRANSLATED_TO_VIRTUAL_Y.at(row - wormhole::translated_coordinate_start_y)
+                                  : row);
+    }
+
+    for (const auto& col : columns_to_exclude) {
+        cols_to_exclude_virtual.insert(
+            use_translated_coords ? wormhole::TRANSLATED_TO_VIRTUAL_X.at(col - wormhole::translated_coordinate_start_x)
+                                  : col);
+    }
+
     auto architecture_implementation = architecture_implementation::create(arch_name);
-    if (columns_to_exclude.find(0) == columns_to_exclude.end() or
-        columns_to_exclude.find(5) == columns_to_exclude.end()) {
+    if (columns_to_exclude_virtual.find(0) == columns_to_exclude_virtual.end() or
+        columns_to_exclude_virtual.find(5) == columns_to_exclude_virtual.end()) {
         UMD_ASSERT(
-            !tensix_or_eth_in_broadcast(columns_to_exclude, architecture_implementation.get()),
+            !tensix_or_eth_in_broadcast(columns_to_exclude_virtual, architecture_implementation.get()),
             error::RuntimeError,
             "Cannot broadcast to tensix/ethernet and DRAM simultaneously on Wormhole.");
-        if (columns_to_exclude.find(0) == columns_to_exclude.end()) {
+        if (cols_to_exclude_virtual.find(0) == cols_to_exclude_virtual.end()) {
             // When broadcast includes column zero Exclude PCIe, ARC and router cores from broadcast explictly,
             // since writing to these is unsafe ERISC FW does not exclude these.
             std::set<uint32_t> unsafe_rows = {2, 3, 4, 8, 9, 10};
-            std::set<uint32_t> cols_to_exclude_for_col_0_bcast = columns_to_exclude;
-            std::set<uint32_t> rows_to_exclude_for_col_0_bcast = rows_to_exclude;
+            std::set<uint32_t> cols_to_exclude_for_col_0_bcast = cols_to_exclude_virtual;
+            std::set<uint32_t> rows_to_exclude_for_col_0_bcast = rows_to_exclude_virtual;
             cols_to_exclude_for_col_0_bcast.insert(5);
             rows_to_exclude_for_col_0_bcast.insert(unsafe_rows.begin(), unsafe_rows.end());
             ethernet_broadcast_write(
@@ -849,22 +864,22 @@ void Cluster::broadcast_write_to_cluster(
                 cols_to_exclude_for_col_0_bcast,
                 false);
         }
-        if (columns_to_exclude.find(5) == columns_to_exclude.end()) {
-            std::set<uint32_t> cols_to_exclude_for_col_5_bcast = columns_to_exclude;
+        if (cols_to_exclude_virtual.find(5) == cols_to_exclude_virtual.end()) {
+            std::set<uint32_t> cols_to_exclude_for_col_5_bcast = cols_to_exclude_virtual;
             cols_to_exclude_for_col_5_bcast.insert(0);
             ethernet_broadcast_write(
                 mem_ptr,
                 size_in_bytes,
                 address,
                 chips_to_exclude,
-                rows_to_exclude,
+                rows_to_exclude_virtual,
                 cols_to_exclude_for_col_5_bcast,
                 false);
         }
     } else {
         UMD_ASSERT(
             use_translated_coords_for_eth_broadcast or
-                valid_tensix_broadcast_grid(rows_to_exclude, columns_to_exclude, architecture_implementation.get()),
+                valid_tensix_broadcast_grid(rows_to_exclude_virtual, columns_to_exclude_virtual, architecture_implementation.get()),
             error::RuntimeError,
             "Must broadcast to all tensix rows when ERISC FW is < 6.8.0.");
         ethernet_broadcast_write(
@@ -872,8 +887,8 @@ void Cluster::broadcast_write_to_cluster(
             size_in_bytes,
             address,
             chips_to_exclude,
-            rows_to_exclude,
-            columns_to_exclude,
+            rows_to_exclude_virtual,
+            cols_to_exclude_virtual,
             use_translated_coords_for_eth_broadcast);
     }
 }
@@ -972,14 +987,34 @@ void Cluster::broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOption
     std::set<uint32_t> rows_to_exclude;
     std::set<uint32_t> columns_to_exclude;
     if (arch_name == tt::ARCH::BLACKHOLE) {
-        rows_to_exclude = {0, 1};
-        columns_to_exclude = {0, 8, 9};
+        if (use_translated_coords_for_eth_broadcast) {
+            rows_to_exclude = {0, 1};
+            columns_to_exclude = {0, 8, 9};
+        } else {
+            // PCIE and ETH are on these rows in translated space.
+            // Note: But the algorithm won't ever try even writing to them, since ethernet broadcast is disabled for
+            // blackhole.
+            rows_to_exclude = {24, 25};
+            // DRAM is on these columns in translated space.
+            columns_to_exclude = {17, 18};
+        }
     } else if (arch_name == tt::ARCH::WORMHOLE_B0) {
-        rows_to_exclude = {0, 6};
-        columns_to_exclude = {0, 5};
+        if (use_translated_coords_for_eth_broadcast) {
+            rows_to_exclude = {16, 17};
+            columns_to_exclude = {16, 17};
+        } else {
+            rows_to_exclude = {0, 6};
+            columns_to_exclude = {0, 5};
+        }
     }
     broadcast_write_to_cluster(
-        &valid_val, sizeof(uint32_t), 0xFFB121B0, chips_to_exclude, rows_to_exclude, columns_to_exclude);
+        &valid_val,
+        sizeof(uint32_t),
+        0xFFB121B0,
+        chips_to_exclude,
+        rows_to_exclude,
+        columns_to_exclude,
+        use_translated_coords_for_eth_broadcast);
     // Ensure that reset signal is globally visible.
     wait_for_non_mmio_flush();
 }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -828,33 +828,37 @@ void Cluster::broadcast_write_to_cluster(
 
     if (use_translated_coords) {
         for (const auto& row : rows_to_exclude) {
-            TT_ASSERT(
+            UMD_ASSERT(
                 row >= wormhole::translated_coordinate_start_y,
-                "Row {} must be in translated coordinate space (>= {}).",
-                row,
-                wormhole::translated_coordinate_start_y);
+                error::RuntimeError,
+                fmt::format(
+                    "Row {} must be in translated coordinate space (>= {}).",
+                    row,
+                    wormhole::translated_coordinate_start_y));
         }
         for (const auto& col : columns_to_exclude) {
-            TT_ASSERT(
+            UMD_ASSERT(
                 col >= wormhole::translated_coordinate_start_x,
-                "Col {} must be in translated coordinate space (>= {}).",
-                col,
-                wormhole::translated_coordinate_start_x);
+                error::RuntimeError,
+                fmt::format(
+                    "Col {} must be in translated coordinate space (>= {}).",
+                    col,
+                    wormhole::translated_coordinate_start_x));
         }
     } else {
         for (const auto& row : rows_to_exclude) {
-            TT_ASSERT(
+            UMD_ASSERT(
                 row < wormhole::translated_coordinate_start_y,
-                "Row {} must be in NOC0 coordinate space (< {}).",
-                row,
-                wormhole::translated_coordinate_start_y);
+                error::RuntimeError,
+                fmt::format(
+                    "Row {} must be in NOC0 coordinate space (< {}).", row, wormhole::translated_coordinate_start_y));
         }
         for (const auto& col : columns_to_exclude) {
-            TT_ASSERT(
+            UMD_ASSERT(
                 col < wormhole::translated_coordinate_start_x,
-                "Col {} must be in NOC0 coordinate space (< {}).",
-                col,
-                wormhole::translated_coordinate_start_x);
+                error::RuntimeError,
+                fmt::format(
+                    "Col {} must be in NOC0 coordinate space (< {}).", col, wormhole::translated_coordinate_start_x));
         }
     }
 
@@ -873,10 +877,10 @@ void Cluster::broadcast_write_to_cluster(
     }
 
     auto architecture_implementation = architecture_implementation::create(arch_name);
-    if (columns_to_exclude_virtual.find(0) == columns_to_exclude_virtual.end() or
-        columns_to_exclude_virtual.find(5) == columns_to_exclude_virtual.end()) {
+    if (cols_to_exclude_virtual.find(0) == cols_to_exclude_virtual.end() or
+        cols_to_exclude_virtual.find(5) == cols_to_exclude_virtual.end()) {
         UMD_ASSERT(
-            !tensix_or_eth_in_broadcast(columns_to_exclude_virtual, architecture_implementation.get()),
+            !tensix_or_eth_in_broadcast(cols_to_exclude_virtual, architecture_implementation.get()),
             error::RuntimeError,
             "Cannot broadcast to tensix/ethernet and DRAM simultaneously on Wormhole.");
         if (cols_to_exclude_virtual.find(0) == cols_to_exclude_virtual.end()) {
@@ -912,7 +916,7 @@ void Cluster::broadcast_write_to_cluster(
         UMD_ASSERT(
             use_translated_coords_for_eth_broadcast or
                 valid_tensix_broadcast_grid(
-                    rows_to_exclude_virtual, columns_to_exclude_virtual, architecture_implementation.get()),
+                    rows_to_exclude_virtual, cols_to_exclude_virtual, architecture_implementation.get()),
             error::RuntimeError,
             "Must broadcast to all tensix rows when ERISC FW is < 6.8.0.");
         ethernet_broadcast_write(

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -911,7 +911,8 @@ void Cluster::broadcast_write_to_cluster(
     } else {
         UMD_ASSERT(
             use_translated_coords_for_eth_broadcast or
-                valid_tensix_broadcast_grid(rows_to_exclude_virtual, columns_to_exclude_virtual, architecture_implementation.get()),
+                valid_tensix_broadcast_grid(
+                    rows_to_exclude_virtual, columns_to_exclude_virtual, architecture_implementation.get()),
             error::RuntimeError,
             "Must broadcast to all tensix rows when ERISC FW is < 6.8.0.");
         ethernet_broadcast_write(

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -814,36 +814,36 @@ void Cluster::ethernet_broadcast_write(
     }
 }
 
-void Cluster::broadcast_write_to_cluster(
-    const void* mem_ptr,
-    uint32_t size_in_bytes,
-    uint64_t address,
-    const std::set<ChipId>& chips_to_exclude,
-    std::set<uint32_t>& rows_to_exclude,
-    std::set<uint32_t>& columns_to_exclude,
-    bool use_translated_coords) {
-    if (arch_name != tt::ARCH::WORMHOLE_B0) {
-        UMD_THROW(error::RuntimeError, "Broadcast write is only supported on Wormhole architecture.");
-    }
-
+void Cluster::adjust_coordinates_for_ethernet_broadcast(
+    const std::set<uint32_t>& rows_to_exclude,
+    const std::set<uint32_t>& columns_to_exclude,
+    bool use_translated_coords,
+    std::set<uint32_t>& rows_to_exclude_virtual,
+    std::set<uint32_t>& cols_to_exclude_virtual) {
     if (use_translated_coords) {
+        const uint32_t translated_row_end =
+            wormhole::translated_coordinate_start_y + wormhole::TRANSLATED_TO_VIRTUAL_Y.size();
+        const uint32_t translated_col_end =
+            wormhole::translated_coordinate_start_x + wormhole::TRANSLATED_TO_VIRTUAL_X.size();
         for (const auto& row : rows_to_exclude) {
             UMD_ASSERT(
-                row >= wormhole::translated_coordinate_start_y,
+                row >= wormhole::translated_coordinate_start_y && row < translated_row_end,
                 error::RuntimeError,
                 fmt::format(
-                    "Row {} must be in translated coordinate space (>= {}).",
+                    "Row {} must be in translated coordinate space [{}, {}).",
                     row,
-                    wormhole::translated_coordinate_start_y));
+                    wormhole::translated_coordinate_start_y,
+                    translated_row_end));
         }
         for (const auto& col : columns_to_exclude) {
             UMD_ASSERT(
-                col >= wormhole::translated_coordinate_start_x,
+                col >= wormhole::translated_coordinate_start_x && col < translated_col_end,
                 error::RuntimeError,
                 fmt::format(
-                    "Col {} must be in translated coordinate space (>= {}).",
+                    "Col {} must be in translated coordinate space [{}, {}).",
                     col,
-                    wormhole::translated_coordinate_start_x));
+                    wormhole::translated_coordinate_start_x,
+                    translated_col_end));
         }
     } else {
         for (const auto& row : rows_to_exclude) {
@@ -862,8 +862,6 @@ void Cluster::broadcast_write_to_cluster(
         }
     }
 
-    std::set<uint32_t> rows_to_exclude_virtual;
-    std::set<uint32_t> cols_to_exclude_virtual;
     for (const auto& row : rows_to_exclude) {
         rows_to_exclude_virtual.insert(
             use_translated_coords ? wormhole::TRANSLATED_TO_VIRTUAL_Y.at(row - wormhole::translated_coordinate_start_y)
@@ -875,8 +873,26 @@ void Cluster::broadcast_write_to_cluster(
             use_translated_coords ? wormhole::TRANSLATED_TO_VIRTUAL_X.at(col - wormhole::translated_coordinate_start_x)
                                   : col);
     }
+}
 
-    auto architecture_implementation = architecture_implementation::create(arch_name);
+void Cluster::broadcast_write_to_cluster(
+    const void* mem_ptr,
+    uint32_t size_in_bytes,
+    uint64_t address,
+    const std::set<ChipId>& chips_to_exclude,
+    std::set<uint32_t>& rows_to_exclude,
+    std::set<uint32_t>& columns_to_exclude,
+    bool use_translated_coords) {
+    if (arch_name != tt::ARCH::WORMHOLE_B0) {
+        UMD_THROW(error::RuntimeError, "Broadcast write is only supported on Wormhole architecture.");
+    }
+
+    std::set<uint32_t> rows_to_exclude_virtual;
+    std::set<uint32_t> cols_to_exclude_virtual;
+    adjust_coordinates_for_ethernet_broadcast(
+        rows_to_exclude, columns_to_exclude, use_translated_coords, rows_to_exclude_virtual, cols_to_exclude_virtual);
+
+    auto architecture_implementation = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
     if (cols_to_exclude_virtual.find(0) == cols_to_exclude_virtual.end() or
         cols_to_exclude_virtual.find(5) == cols_to_exclude_virtual.end()) {
         UMD_ASSERT(

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -826,6 +826,38 @@ void Cluster::broadcast_write_to_cluster(
         UMD_THROW(error::RuntimeError, "Broadcast write is only supported on Wormhole architecture.");
     }
 
+    if (use_translated_coords) {
+        for (const auto& row : rows_to_exclude) {
+            TT_ASSERT(
+                row >= wormhole::translated_coordinate_start_y,
+                "Row {} must be in translated coordinate space (>= {}).",
+                row,
+                wormhole::translated_coordinate_start_y);
+        }
+        for (const auto& col : columns_to_exclude) {
+            TT_ASSERT(
+                col >= wormhole::translated_coordinate_start_x,
+                "Col {} must be in translated coordinate space (>= {}).",
+                col,
+                wormhole::translated_coordinate_start_x);
+        }
+    } else {
+        for (const auto& row : rows_to_exclude) {
+            TT_ASSERT(
+                row < wormhole::translated_coordinate_start_y,
+                "Row {} must be in NOC0 coordinate space (< {}).",
+                row,
+                wormhole::translated_coordinate_start_y);
+        }
+        for (const auto& col : columns_to_exclude) {
+            TT_ASSERT(
+                col < wormhole::translated_coordinate_start_x,
+                "Col {} must be in NOC0 coordinate space (< {}).",
+                col,
+                wormhole::translated_coordinate_start_x);
+        }
+    }
+
     std::set<uint32_t> rows_to_exclude_virtual;
     std::set<uint32_t> cols_to_exclude_virtual;
     for (const auto& row : rows_to_exclude) {

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -461,7 +461,7 @@ TEST(SiliconDriverWH, BroadcastWrite) {
         }
         // Broadcast to Tensix.
         cluster.broadcast_write_to_cluster(
-            vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude);
+            vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude, false);
         cluster.wait_for_non_mmio_flush();
         // Broadcast to DRAM.
         cluster.broadcast_write_to_cluster(
@@ -470,7 +470,8 @@ TEST(SiliconDriverWH, BroadcastWrite) {
             address,
             {},
             rows_to_exclude_for_dram_broadcast,
-            cols_to_exclude_for_dram_broadcast);
+            cols_to_exclude_for_dram_broadcast,
+            false);
         cluster.wait_for_non_mmio_flush();
 
         for (auto chip_id : cluster.get_target_device_ids()) {
@@ -524,8 +525,8 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
 
     std::vector<uint32_t> broadcast_sizes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
     uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
-    // This excludes DRAM and ETH banks (positioned in 16, 17 on both rows and columns) and some tensix rows and columns in
-    // translated space.
+    // This excludes DRAM and ETH banks (positioned in 16, 17 on both rows and columns) and some tensix rows and columns
+    // in translated space.
     std::set<uint32_t> rows_to_exclude = {16, 17, 20, 22, 26, 27};
     std::set<uint32_t> cols_to_exclude = {16, 17, 20};
     // This excludes all tensix columns 18-25 in translated space.
@@ -542,7 +543,7 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
         }
         // Broadcast to Tensix.
         cluster.broadcast_write_to_cluster(
-            vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude);
+            vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude, true);
         cluster.wait_for_non_mmio_flush();
         // Broadcast to DRAM.
         cluster.broadcast_write_to_cluster(
@@ -551,7 +552,8 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
             address,
             {},
             rows_to_exclude_for_dram_broadcast,
-            cols_to_exclude_for_dram_broadcast);
+            cols_to_exclude_for_dram_broadcast,
+            true);
         cluster.wait_for_non_mmio_flush();
 
         for (auto chip_id : cluster.get_target_device_ids()) {
@@ -610,8 +612,8 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
 
     std::vector<uint32_t> broadcast_sizes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
     uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
-    // This excludes DRAM and ETH banks (positioned in 16, 17 on both rows and columns) and some tensix rows and columns in
-    // translated space.
+    // This excludes DRAM and ETH banks (positioned in 16, 17 on both rows and columns) and some tensix rows and columns
+    // in translated space.
     std::set<uint32_t> rows_to_exclude = {16, 17, 20, 22, 26, 27};
     std::set<uint32_t> cols_to_exclude = {16, 17, 20};
     // This excludes all tensix columns 18-25 in translated space.
@@ -638,7 +640,8 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
                 address,
                 chips_to_exclude,
                 rows_to_exclude,
-                cols_to_exclude);
+                cols_to_exclude,
+                true);
             cluster.wait_for_non_mmio_flush();
 
             // Broadcast to DRAM.
@@ -648,20 +651,17 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
                 address,
                 chips_to_exclude,
                 rows_to_exclude_for_dram_broadcast,
-                cols_to_exclude_for_dram_broadcast);
+                cols_to_exclude_for_dram_broadcast,
+                true);
             cluster.wait_for_non_mmio_flush();
 
             for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
                 const CoreCoord translated_core =
                     cluster.get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
-                uint32_t virtual_y = tt::umd::wormhole::TRANSLATED_TO_VIRTUAL_Y.at(
-                    translated_core.y - tt::umd::wormhole::translated_coordinate_start_y);
-                if (rows_to_exclude.find(virtual_y) != rows_to_exclude.end()) {
+                if (rows_to_exclude.find(translated_core.y) != rows_to_exclude.end()) {
                     continue;
                 }
-                uint32_t virtual_x = tt::umd::wormhole::TRANSLATED_TO_VIRTUAL_X.at(
-                    translated_core.x - tt::umd::wormhole::translated_coordinate_start_x);
-                if (cols_to_exclude.find(virtual_x) != cols_to_exclude.end()) {
+                if (cols_to_exclude.find(translated_core.x) != cols_to_exclude.end()) {
                     continue;
                 }
                 test_utils::read_data_from_device(

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -524,12 +524,13 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
 
     std::vector<uint32_t> broadcast_sizes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
     uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
-    // This excludes DRAM and ETH banks and some tensix rows in virtual space.
-    std::set<uint32_t> rows_to_exclude = {0, 3, 5, 6, 8, 9};
-    std::set<uint32_t> cols_to_exclude = {0, 3, 5};
-    // This excludes all tensix columns in virtual space.
+    // This excludes DRAM and ETH banks (positioned in 16, 17 on both rows and columns) and some tensix rows and columns in
+    // translated space.
+    std::set<uint32_t> rows_to_exclude = {16, 17, 20, 22, 26, 27};
+    std::set<uint32_t> cols_to_exclude = {16, 17, 20};
+    // This excludes all tensix columns 18-25 in translated space.
     std::set<uint32_t> rows_to_exclude_for_dram_broadcast = {};
-    std::set<uint32_t> cols_to_exclude_for_dram_broadcast = {1, 2, 3, 4, 6, 7, 8, 9};
+    std::set<uint32_t> cols_to_exclude_for_dram_broadcast = {18, 19, 20, 21, 22, 23, 24, 25};
 
     for (const auto& size : broadcast_sizes) {
         std::vector<uint32_t> vector_to_write(size);
@@ -555,18 +556,12 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
 
         for (auto chip_id : cluster.get_target_device_ids()) {
             for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
-                // Rows are excluded according to virtual coordinates, so we have to translate to that system before
-                // accessing .y coordinate.
                 const CoreCoord translated_core =
                     cluster.get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
-                uint32_t virtual_y = tt::umd::wormhole::TRANSLATED_TO_VIRTUAL_Y.at(
-                    translated_core.y - tt::umd::wormhole::translated_coordinate_start_y);
-                if (rows_to_exclude.find(virtual_y) != rows_to_exclude.end()) {
+                if (rows_to_exclude.find(translated_core.y) != rows_to_exclude.end()) {
                     continue;
                 }
-                uint32_t virtual_x = tt::umd::wormhole::TRANSLATED_TO_VIRTUAL_X.at(
-                    translated_core.x - tt::umd::wormhole::translated_coordinate_start_x);
-                if (cols_to_exclude.find(virtual_x) != cols_to_exclude.end()) {
+                if (cols_to_exclude.find(translated_core.x) != cols_to_exclude.end()) {
                     continue;
                 }
                 test_utils::read_data_from_device(
@@ -615,12 +610,13 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
 
     std::vector<uint32_t> broadcast_sizes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
     uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
-    // This excludes DRAM and ETH banks and some tensix rows in virtual space.
-    std::set<uint32_t> rows_to_exclude = {0, 3, 5, 6, 8, 9};
-    std::set<uint32_t> cols_to_exclude = {0, 3, 5};
-    // This excludes all tensix columns in virtual space.
+    // This excludes DRAM and ETH banks (positioned in 16, 17 on both rows and columns) and some tensix rows and columns in
+    // translated space.
+    std::set<uint32_t> rows_to_exclude = {16, 17, 20, 22, 26, 27};
+    std::set<uint32_t> cols_to_exclude = {16, 17, 20};
+    // This excludes all tensix columns 18-25 in translated space.
     std::set<uint32_t> rows_to_exclude_for_dram_broadcast = {};
-    std::set<uint32_t> cols_to_exclude_for_dram_broadcast = {1, 2, 3, 4, 6, 7, 8, 9};
+    std::set<uint32_t> cols_to_exclude_for_dram_broadcast = {18, 19, 20, 21, 22, 23, 24, 25};
 
     for (auto chip_id : cluster.get_target_device_ids()) {
         for (const auto& size : broadcast_sizes) {
@@ -656,8 +652,6 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
             cluster.wait_for_non_mmio_flush();
 
             for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
-                // Rows are excluded according to virtual coordinates, so we have to translate to that system before
-                // accessing .y coordinate.
                 const CoreCoord translated_core =
                     cluster.get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
                 uint32_t virtual_y = tt::umd::wormhole::TRANSLATED_TO_VIRTUAL_Y.at(


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2521

### Description
Since we purged VIRTUAL out of our repo, contain it inside the implementation of broadcast function. Change the API to accept TRANSLATED coords

### List of the changes
- Pass use_translated_coords into broadcast_write_to_cluster
- The cols and rows to exclude arguments are accepted as translated now
- Inside the function, do necessary translation
- Change the usages (test + broadcast_tensix_reset) to send translated coordinates instead of virtual.

### Testing
CI Tests that are adjusted in this PR

### API Changes
This PR has API changes, broadcast_write_to_cluster accepts TRANSLATED coords now. But not sure if anyone is even using this API
