### PR TITLE
TTSim: drop sim-clock advance from TTSimTTDevice::write_to_device

### DIFF
--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -114,13 +114,6 @@ void TTSimTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64
     } else {
         communicator_->tile_write_bytes(core.x, core.y, addr, mem_ptr, size);
     }
-    // Advance the sim on host writes. Without this, sequences like "load BRISC ELF, deassert
-    // BRISC, write first command mailbox" all sit at the same simulated timestamp — BRISC never
-    // gets cycles to finish its CRT init before the command mailbox write, so BRISC's clear of
-    // brisc_command_buffer at startup clobbers the host's command and the handshake hangs. The
-    // floor guarantees that a tiny 4-byte deassert write still gives the newly-started core
-    // enough cycles to make meaningful progress before the next host operation lands.
-    communicator_->advance_clock(std::max<uint32_t>(1000, size));
 }
 
 void TTSimTTDevice::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {


### PR DESCRIPTION
### Issue
Closes #2561

### Description
The clock-advance in `TTSimTTDevice::write_to_device` (`advance_clock(max(1000, size))`) was a workaround for an LLK-test infra startup race where BRISC's CRT init clobbered the host's first command mailbox write. That race has been fixed at the protocol layer in tt-metal via a boot-ready sentinel handshake on the BRISC counter mailbox (tenstorrent/tt-metal#43438, branch `pjanevski/llk_infra_fix`, commit tenstorrent/tt-metal@9d9a976), so the umd-side workaround is no longer needed.

Test runs do many more writes than reads (ELF loads, stimuli, runtime args), so ticking the sim on every write was a meaningful slowdown. `read_from_device` keeps its `advance_clock(1)` for spin-loop purposes.

### List of the changes
- Remove `communicator_->advance_clock(std::max<uint32_t>(1000, size))` from `TTSimTTDevice::write_to_device` (and the explanatory comment that went with it).

### Testing
- `cmake --build build` clean.
- `pre-commit run --all-files` clean.
- Functional validation runs as part of the tt-metal companion change (tenstorrent/tt-metal#43438).

### API Changes
There are no API changes in this PR.