### PR TITLE
Fix offset because of doppler for safe start of Baby RISCs

### DIFF
--- a/tests/api/test_risc_program.cpp
+++ b/tests/api/test_risc_program.cpp
@@ -40,7 +40,7 @@ TEST(TestRiscProgram, DeassertResetBrisc) {
 
     constexpr uint32_t a_variable_value = 0x87654000;
     constexpr uint64_t a_variable_address = 0x10000;
-    constexpr uint64_t brisc_code_address = 0;
+    constexpr uint64_t brisc_code_address = 0x20;
 
     uint32_t readback = 0;
 
@@ -99,7 +99,7 @@ TEST(TestRiscProgram, DeassertResetWithCounterBrisc) {
     std::vector<uint32_t> zero_data(tensix_l1_size / sizeof(uint32_t), 0);
 
     constexpr uint64_t counter_address = 0x10000;
-    constexpr uint64_t brisc_code_address = 0;
+    constexpr uint64_t brisc_code_address = 0x20;
 
     uint32_t first_readback_value = 0;
     uint32_t second_readback_value = 0;
@@ -185,7 +185,7 @@ TEST_P(ClusterAssertDeassertRiscsTest, TriscNcriscAssertDeassertTest) {
 
     const auto& configurations_of_risc_cores = GetParam();
 
-    constexpr uint64_t brisc_code_address = 0;
+    constexpr uint64_t brisc_code_address = 0x20;
 
     uint32_t first_readback_value = 0;
     uint32_t second_readback_value = 0;

--- a/tests/api/test_risc_program.cpp
+++ b/tests/api/test_risc_program.cpp
@@ -64,6 +64,7 @@ TEST(TestRiscProgram, DeassertResetBrisc) {
 
             cluster->l1_membar(chip_id, {tensix_core});
 
+            cluster->write_to_device(&BRISC_TRAMPOLINE_JMP, sizeof(BRISC_TRAMPOLINE_JMP), chip_id, tensix_core, 0);
             cluster->write_to_device(
                 simple_brisc_program.data(),
                 simple_brisc_program.size() * sizeof(uint32_t),
@@ -117,6 +118,7 @@ TEST(TestRiscProgram, DeassertResetWithCounterBrisc) {
 
             cluster->assert_risc_reset(chip_id, tensix_core, select_all_tensix_riscv_cores);
 
+            cluster->write_to_device(&BRISC_TRAMPOLINE_JMP, sizeof(BRISC_TRAMPOLINE_JMP), chip_id, tensix_core, 0);
             cluster->write_to_device(
                 counter_brisc_program.data(),
                 counter_brisc_program.size() * sizeof(uint32_t),
@@ -214,6 +216,7 @@ TEST_P(ClusterAssertDeassertRiscsTest, TriscNcriscAssertDeassertTest) {
 
             cluster->l1_membar(chip_id, {tensix_core});
 
+            cluster->write_to_device(&BRISC_TRAMPOLINE_JMP, sizeof(BRISC_TRAMPOLINE_JMP), chip_id, tensix_core, 0);
             cluster->write_to_device(
                 brisc_configuration_program.value().data(),
                 brisc_configuration_program.value().size() * sizeof(uint32_t),

--- a/tests/test_utils/assembly_programs_for_tests.hpp
+++ b/tests/test_utils/assembly_programs_for_tests.hpp
@@ -147,7 +147,11 @@ inline constexpr std::array<uint32_t, 14> bh_brisc_configuration_program{
 
 /*
 This program is architecture-agnostic and configures all RISC cores to execute an infinite loop
-at the same address (0x34 = 52 bytes from start of L1).
+at the same address (0x4C = 76 bytes from start of L1).
+
+The 0x4C value is intentional: with the 12-word program loaded at 0x20 (runtime-inserted
+architecture-specific `lui` + 11 instructions below), 0x4C is the address of the trailing
+`jal zero, 0` instruction, so all override PCs start in the self-loop.
 
 The first instruction (lui a5, <base>) sets the architecture-specific base address:
   - Wormhole (WH):  a5 = 0xFFEF'0000  (instruction: 0xffef07b7)
@@ -173,10 +177,10 @@ pseudo-source code:
         unsigned int* trisc2_code_start_reg_addr = (unsigned int*)TRISC_RESET_PC_SEC2_PC;
         unsigned int* ncrisc_code_start_reg_addr = (unsigned int*)NCRISC_RESET_PC_PC;
 
-        *trisc0_code_start_reg_addr = 0x34;
-        *trisc1_code_start_reg_addr = 0x34;
-        *trisc2_code_start_reg_addr = 0x34;
-        *ncrisc_code_start_reg_addr = 0x34;
+        *trisc0_code_start_reg_addr = 0x4C;
+        *trisc1_code_start_reg_addr = 0x4C;
+        *trisc2_code_start_reg_addr = 0x4C;
+        *ncrisc_code_start_reg_addr = 0x4C;
 
         while (true);
     }

--- a/tests/test_utils/assembly_programs_for_tests.hpp
+++ b/tests/test_utils/assembly_programs_for_tests.hpp
@@ -200,3 +200,6 @@ inline constexpr std::array<uint32_t, 11> brisc_configuration_program_default{
 // Architecture-specific first instructions for brisc_configuration_program_default.
 inline constexpr uint32_t WORMHOLE_BRISC_BASE_INSTRUCTION = 0xffef07b7;   // lui a5, 0xffef0
 inline constexpr uint32_t BLACKHOLE_BRISC_BASE_INSTRUCTION = 0xffb127b7;  // lui a5, 0xffb12
+
+// Trampoline instruction: jumps from address 0x0 to 0x20, skipping over firmware data at 0x10.
+inline constexpr uint32_t BRISC_TRAMPOLINE_JMP = 0x0200006f;  // jal zero, 0x20

--- a/tests/test_utils/assembly_programs_for_tests.hpp
+++ b/tests/test_utils/assembly_programs_for_tests.hpp
@@ -189,7 +189,7 @@ inline constexpr std::array<uint32_t, 11> brisc_configuration_program_default{
     0x00100713,  // li a4, 1
     0x28e7a623,  // sw a4, 652(a5)
     0x00078713,  // mv a4, a5
-    0x02c00793,  // li a5, 52
+    0x04c00793,  // li a5, 0x4C
     0x26f72c23,  // sw a5, 632(a4)
     0x26f72e23,  // sw a5, 636(a4)
     0x28f72023,  // sw a5, 640(a4)

--- a/tests/test_utils/setup_risc_cores.hpp
+++ b/tests/test_utils/setup_risc_cores.hpp
@@ -21,6 +21,7 @@ inline void safe_test_cluster_start(Cluster* cluster) {
     std::lock_guard<RobustMutex> lock(mtx);
 
     auto architecture = cluster->get_chip(0)->get_tt_device()->get_arch();
+    static constexpr uint32_t start_address_in_l1 = 0x20;
     std::array<uint32_t, 12> brisc_program_default{};
     std::copy(
         brisc_configuration_program_default.cbegin(),
@@ -54,7 +55,7 @@ inline void safe_test_cluster_start(Cluster* cluster) {
                 brisc_program_default.size() * sizeof(std::uint32_t),
                 chip_id,
                 tensix_core_translated,
-                0);
+                start_address_in_l1);
         }
 
         cluster->l1_membar(chip_id, all_tensix_cores_translated);

--- a/tests/test_utils/setup_risc_cores.hpp
+++ b/tests/test_utils/setup_risc_cores.hpp
@@ -51,6 +51,8 @@ inline void safe_test_cluster_start(Cluster* cluster) {
 
         for (const CoreCoord& tensix_core_translated : all_tensix_cores_translated) {
             cluster->write_to_device(
+                &BRISC_TRAMPOLINE_JMP, sizeof(BRISC_TRAMPOLINE_JMP), chip_id, tensix_core_translated, 0);
+            cluster->write_to_device(
                 brisc_program_default.data(),
                 brisc_program_default.size() * sizeof(std::uint32_t),
                 chip_id,


### PR DESCRIPTION
### Issue
Tied to #2402 

### Description
This pull request updates the BRISC program loading and startup sequence in the test suite to support a new program layout in L1 memory. The main change is introducing a trampoline jump instruction at address 0x0 to redirect execution to the actual BRISC code at address 0x20, ensuring firmware data at 0x10 is skipped. This required updating test code, helper utilities, and the default BRISC configuration program.

### List of the changes
**Test harness and program loading updates:**

* All test cases and helper functions now write a trampoline jump instruction (`BRISC_TRAMPOLINE_JMP`) to address 0x0 before loading the BRISC program at address 0x20, ensuring correct program start and skipping firmware data at 0x10.
* The BRISC program load address in all relevant tests and helpers is updated from `0x0` to `0x20` to match the new layout.

**Assembly program and trampoline definition:**

* Added a new constant, `BRISC_TRAMPOLINE_JMP`, representing the trampoline jump instruction (`jal zero, 0x20`), to be written at address `0x0`.
* Updated the default BRISC configuration program to load the correct value for the new program layout (changed immediate value from `52` to `0x4C`).

### Testing
CI

### API Changes
/