### PR TITLE
Clean up SocDescriptor constructors

### DIFF
--- a/device/api/umd/device/soc_arch_descriptor.hpp
+++ b/device/api/umd/device/soc_arch_descriptor.hpp
@@ -39,10 +39,10 @@ struct CoreDescriptor {
 class SocArchDescriptor {
 public:
     // Create from architecture enum (uses hardcoded constants).
-    static SocArchDescriptor create(tt::ARCH arch);
+    SocArchDescriptor(tt::ARCH arch);
 
-    // Create from a YAML device descriptor file.
-    static SocArchDescriptor create(const std::string& device_descriptor_path);
+    // Create from a YAML SoC descriptor file.
+    SocArchDescriptor(const std::string& soc_descriptor_path);
 
     // Helpers for extracting info from a YAML descriptor file without fully constructing.
     static tt::ARCH get_arch_from_path(const std::string& soc_descriptor_path);

--- a/device/api/umd/device/soc_descriptor.hpp
+++ b/device/api/umd/device/soc_descriptor.hpp
@@ -30,8 +30,6 @@ namespace tt::umd {
 class CoordinateManager;
 class SocArchDescriptor;
 
-tt_xy_pair format_node(const std::string& str);
-
 //! SocDescriptor contains information regarding the SOC configuration targetted.
 /*!
     Should only contain relevant configuration for SOC.

--- a/device/api/umd/device/soc_descriptor.hpp
+++ b/device/api/umd/device/soc_descriptor.hpp
@@ -41,8 +41,6 @@ public:
     // Default constructor. Creates uninitialized object with public access to all of its attributes.
     SocDescriptor() = default;
 
-    SocDescriptor(const tt::ARCH arch, const ChipInfo chip_info = {});
-
     // Constructor with explicit arch descriptor (enables sharing).
     SocDescriptor(std::shared_ptr<const SocArchDescriptor> arch_desc, const ChipInfo chip_info = {});
 

--- a/device/api/umd/device/soc_descriptor.hpp
+++ b/device/api/umd/device/soc_descriptor.hpp
@@ -38,10 +38,6 @@ tt_xy_pair format_node(const std::string& str);
 */
 class SocDescriptor {
 public:
-    // Default constructor. Creates uninitialized object with public access to all of its attributes.
-    SocDescriptor() = default;
-
-    // Constructor with explicit arch descriptor (enables sharing).
     SocDescriptor(std::shared_ptr<const SocArchDescriptor> arch_desc, const ChipInfo chip_info = {});
 
     // Helpers for extracting info from soc descriptor file.

--- a/device/api/umd/device/soc_descriptor.hpp
+++ b/device/api/umd/device/soc_descriptor.hpp
@@ -40,8 +40,6 @@ class SocDescriptor {
 public:
     // Default constructor. Creates uninitialized object with public access to all of its attributes.
     SocDescriptor() = default;
-    // Constructor used to build object from device descriptor file.
-    SocDescriptor(const std::string& device_descriptor_path, const ChipInfo chip_info = {});
 
     SocDescriptor(const tt::ARCH arch, const ChipInfo chip_info = {});
 

--- a/device/api/umd/device/utils/error_detail.hpp
+++ b/device/api/umd/device/utils/error_detail.hpp
@@ -7,7 +7,7 @@
 // IWYU pragma: private, include "umd/device/utils/error.hpp".
 
 #ifndef UMD_ERROR_HPP_INTERNAL_INCLUDE
-#error "error_detail.hpp is a private header. Include umd/device/utils/error.hpp instead"
+#error "error_detail.hpp is a private header. Include umd/device/utils/error.hpp instead."
 #endif
 #include <cxxabi.h>
 #include <execinfo.h>

--- a/device/api/umd/device/utils/error_detail.hpp
+++ b/device/api/umd/device/utils/error_detail.hpp
@@ -7,7 +7,7 @@
 // IWYU pragma: private, include "umd/device/utils/error.hpp".
 
 #ifndef UMD_ERROR_HPP_INTERNAL_INCLUDE
-#error "error_detail.hpp is a private header. Include umd/device/utils/error.hpp instead."
+#error "error_detail.hpp is a private header. Include umd/device/utils/error.hpp instead"
 #endif
 #include <cxxabi.h>
 #include <execinfo.h>

--- a/device/api/umd/device/utils/error_detail.hpp
+++ b/device/api/umd/device/utils/error_detail.hpp
@@ -14,7 +14,6 @@
 
 #include <cstdint>
 #include <cstdlib>
-#include <exception>
 #include <iomanip>
 #include <memory>
 #include <sstream>

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -48,16 +48,14 @@ std::unique_ptr<LocalChip> LocalChip::create(
     auto tt_device = TTDevice::create(physical_device_id, device_type);
     tt_device->init_tt_device();
 
-    SocDescriptor soc_descriptor;
+    std::shared_ptr<SocArchDescriptor> sad = nullptr;
     if (sdesc_path.empty()) {
-        std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(tt_device->get_arch());
-        soc_descriptor = SocDescriptor(sad, tt_device->get_chip_info());
+        sad = std::make_shared<SocArchDescriptor>(tt_device->get_arch());
     } else {
-        std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(sdesc_path);
-        soc_descriptor = SocDescriptor(sad, tt_device->get_chip_info());
+        sad = std::make_shared<SocArchDescriptor>(sdesc_path);
     }
-
-    return LocalChip::create(std::move(tt_device), soc_descriptor, num_host_mem_channels);
+    ChipInfo chip_info = tt_device->get_chip_info();
+    return LocalChip::create(std::move(tt_device), SocDescriptor(sad, chip_info), num_host_mem_channels);
 }
 
 std::unique_ptr<LocalChip> LocalChip::create(

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -50,10 +50,11 @@ std::unique_ptr<LocalChip> LocalChip::create(
 
     SocDescriptor soc_descriptor;
     if (sdesc_path.empty()) {
-        // In case soc descriptor yaml wasn't passed, we create soc descriptor with default values for the architecture.
-        soc_descriptor = SocDescriptor(tt_device->get_arch(), tt_device->get_chip_info());
+        std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(tt_device->get_arch());
+        soc_descriptor = SocDescriptor(sad, tt_device->get_chip_info());
     } else {
-        soc_descriptor = SocDescriptor(sdesc_path, tt_device->get_chip_info());
+        std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(sdesc_path);
+        soc_descriptor = SocDescriptor(sad, tt_device->get_chip_info());
     }
 
     return LocalChip::create(std::move(tt_device), soc_descriptor, num_host_mem_channels);

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -48,14 +48,15 @@ std::unique_ptr<LocalChip> LocalChip::create(
     auto tt_device = TTDevice::create(physical_device_id, device_type);
     tt_device->init_tt_device();
 
-    std::shared_ptr<SocArchDescriptor> sad = nullptr;
+    std::shared_ptr<SocArchDescriptor> soc_arch_descriptor = nullptr;
     if (sdesc_path.empty()) {
-        sad = std::make_shared<SocArchDescriptor>(tt_device->get_arch());
+        soc_arch_descriptor = std::make_shared<SocArchDescriptor>(tt_device->get_arch());
     } else {
-        sad = std::make_shared<SocArchDescriptor>(sdesc_path);
+        soc_arch_descriptor = std::make_shared<SocArchDescriptor>(sdesc_path);
     }
     ChipInfo chip_info = tt_device->get_chip_info();
-    return LocalChip::create(std::move(tt_device), SocDescriptor(sad, chip_info), num_host_mem_channels);
+    return LocalChip::create(
+        std::move(tt_device), SocDescriptor(soc_arch_descriptor, chip_info), num_host_mem_channels);
 }
 
 std::unique_ptr<LocalChip> LocalChip::create(

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -47,9 +47,11 @@ std::unique_ptr<RemoteChip> RemoteChip::create(
 
     SocDescriptor soc_descriptor;
     if (sdesc_path.empty()) {
-        soc_descriptor = SocDescriptor(remote_tt_device->get_arch(), remote_tt_device->get_chip_info());
+        std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(remote_tt_device->get_arch());
+        soc_descriptor = SocDescriptor(sad, remote_tt_device->get_chip_info());
     } else {
-        soc_descriptor = SocDescriptor(sdesc_path, remote_tt_device->get_chip_info());
+        std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(sdesc_path);
+        soc_descriptor = SocDescriptor(sad, remote_tt_device->get_chip_info());
     }
     return std::unique_ptr<RemoteChip>(
         new RemoteChip(std::move(soc_descriptor), local_chip, std::move(remote_tt_device)));

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -45,16 +45,15 @@ std::unique_ptr<RemoteChip> RemoteChip::create(
     auto remote_tt_device = TTDevice::create(std::move(remote_communication));
     remote_tt_device->init_tt_device();
 
-    SocDescriptor soc_descriptor;
+    std::shared_ptr<SocArchDescriptor> sad = nullptr;
     if (sdesc_path.empty()) {
-        std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(remote_tt_device->get_arch());
-        soc_descriptor = SocDescriptor(sad, remote_tt_device->get_chip_info());
+        sad = std::make_shared<SocArchDescriptor>(remote_tt_device->get_arch());
     } else {
-        std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(sdesc_path);
-        soc_descriptor = SocDescriptor(sad, remote_tt_device->get_chip_info());
+        sad = std::make_shared<SocArchDescriptor>(sdesc_path);
     }
+    ChipInfo chip_info = remote_tt_device->get_chip_info();
     return std::unique_ptr<RemoteChip>(
-        new RemoteChip(std::move(soc_descriptor), local_chip, std::move(remote_tt_device)));
+        new RemoteChip(SocDescriptor(sad, chip_info), local_chip, std::move(remote_tt_device)));
 }
 
 std::unique_ptr<RemoteChip> RemoteChip::create(

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -45,15 +45,15 @@ std::unique_ptr<RemoteChip> RemoteChip::create(
     auto remote_tt_device = TTDevice::create(std::move(remote_communication));
     remote_tt_device->init_tt_device();
 
-    std::shared_ptr<SocArchDescriptor> sad = nullptr;
+    std::shared_ptr<SocArchDescriptor> soc_arch_descriptor = nullptr;
     if (sdesc_path.empty()) {
-        sad = std::make_shared<SocArchDescriptor>(remote_tt_device->get_arch());
+        soc_arch_descriptor = std::make_shared<SocArchDescriptor>(remote_tt_device->get_arch());
     } else {
-        sad = std::make_shared<SocArchDescriptor>(sdesc_path);
+        soc_arch_descriptor = std::make_shared<SocArchDescriptor>(sdesc_path);
     }
     ChipInfo chip_info = remote_tt_device->get_chip_info();
     return std::unique_ptr<RemoteChip>(
-        new RemoteChip(SocDescriptor(sad, chip_info), local_chip, std::move(remote_tt_device)));
+        new RemoteChip(SocDescriptor(soc_arch_descriptor, chip_info), local_chip, std::move(remote_tt_device)));
 }
 
 std::unique_ptr<RemoteChip> RemoteChip::create(

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -272,13 +272,11 @@ SocDescriptor Cluster::construct_soc_descriptor(
     if (soc_desc_path.empty()) {
         tt::ARCH arch = chip_in_cluster_descriptor ? cluster_desc->get_arch(chip_id) : tt::ARCH::WORMHOLE_B0;
 
-        std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(arch);
-        SocDescriptor soc_descriptor = SocDescriptor(sad, chip_info);
+        SocDescriptor soc_descriptor = SocDescriptor(std::make_shared<SocArchDescriptor>(arch), chip_info);
         return soc_descriptor;
 
     } else {
-        std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(soc_desc_path);
-        SocDescriptor soc_descriptor = SocDescriptor(sad, chip_info);
+        SocDescriptor soc_descriptor = SocDescriptor(std::make_shared<SocArchDescriptor>(soc_desc_path), chip_info);
 
         // In this case, check that the passed soc descriptor architecture doesn't conflate with the one in the cluster
         // descriptor.

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -272,24 +272,27 @@ SocDescriptor Cluster::construct_soc_descriptor(
     if (soc_desc_path.empty()) {
         tt::ARCH arch = chip_in_cluster_descriptor ? cluster_desc->get_arch(chip_id) : tt::ARCH::WORMHOLE_B0;
 
-        return SocDescriptor(arch, chip_info);
+        std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(arch);
+        SocDescriptor soc_descriptor = SocDescriptor(sad, chip_info);
+        return soc_descriptor;
 
     } else {
-        SocDescriptor soc_desc = SocDescriptor(soc_desc_path, chip_info);
+        std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(soc_desc_path);
+        SocDescriptor soc_descriptor = SocDescriptor(sad, chip_info);
 
         // In this case, check that the passed soc descriptor architecture doesn't conflate with the one in the cluster
         // descriptor.
-        if (chip_in_cluster_descriptor && soc_desc.arch != cluster_desc->get_arch(chip_id)) {
+        if (chip_in_cluster_descriptor && soc_descriptor.arch != cluster_desc->get_arch(chip_id)) {
             UMD_THROW(
                 error::RuntimeError,
                 fmt::format(
                     "Passed SOC descriptor has {} architecture, but Chip ID {} has {} architecture.",
-                    arch_to_str(soc_desc.arch),
+                    arch_to_str(soc_descriptor.arch),
                     chip_id,
                     arch_to_str(cluster_desc->get_arch(chip_id))));
         }
 
-        return soc_desc;
+        return soc_descriptor;
     }
 }
 

--- a/device/soc_arch_descriptor.cpp
+++ b/device/soc_arch_descriptor.cpp
@@ -9,7 +9,6 @@
 
 #include <fstream>
 #include <set>
-#include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -19,88 +18,82 @@
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
 
-SocArchDescriptor SocArchDescriptor::create(tt::ARCH arch_enum) {
-    SocArchDescriptor desc;
-
+SocArchDescriptor::SocArchDescriptor(tt::ARCH arch_enum) {
     switch (arch_enum) {
         case tt::ARCH::WORMHOLE_B0:
-            desc.arch_ = tt::ARCH::WORMHOLE_B0;
-            desc.grid_size_ = wormhole::GRID_SIZE;
-            desc.tensix_cores_ = wormhole::TENSIX_CORES_NOC0;
-            desc.dram_cores_ = wormhole::DRAM_CORES_NOC0;
-            desc.eth_cores_ = wormhole::ETH_CORES_NOC0;
-            desc.arc_cores_ = wormhole::ARC_CORES_NOC0;
-            desc.pcie_cores_ = wormhole::PCIE_CORES_NOC0;
-            desc.router_cores_ = wormhole::ROUTER_CORES_NOC0;
-            desc.security_cores_ = wormhole::SECURITY_CORES_NOC0;
-            desc.l2cpu_cores_ = wormhole::L2CPU_CORES_NOC0;
-            desc.worker_l1_size_ = wormhole::TENSIX_L1_SIZE;
-            desc.eth_l1_size_ = wormhole::ETH_L1_SIZE;
-            desc.dram_bank_size_ = wormhole::DRAM_BANK_SIZE;
-            desc.noc0_x_to_noc1_x_ = wormhole::NOC0_X_TO_NOC1_X;
-            desc.noc0_y_to_noc1_y_ = wormhole::NOC0_Y_TO_NOC1_Y;
+            arch_ = tt::ARCH::WORMHOLE_B0;
+            grid_size_ = wormhole::GRID_SIZE;
+            tensix_cores_ = wormhole::TENSIX_CORES_NOC0;
+            dram_cores_ = wormhole::DRAM_CORES_NOC0;
+            eth_cores_ = wormhole::ETH_CORES_NOC0;
+            arc_cores_ = wormhole::ARC_CORES_NOC0;
+            pcie_cores_ = wormhole::PCIE_CORES_NOC0;
+            router_cores_ = wormhole::ROUTER_CORES_NOC0;
+            security_cores_ = wormhole::SECURITY_CORES_NOC0;
+            l2cpu_cores_ = wormhole::L2CPU_CORES_NOC0;
+            worker_l1_size_ = wormhole::TENSIX_L1_SIZE;
+            eth_l1_size_ = wormhole::ETH_L1_SIZE;
+            dram_bank_size_ = wormhole::DRAM_BANK_SIZE;
+            noc0_x_to_noc1_x_ = wormhole::NOC0_X_TO_NOC1_X;
+            noc0_y_to_noc1_y_ = wormhole::NOC0_Y_TO_NOC1_Y;
             break;
         case tt::ARCH::BLACKHOLE:
-            desc.arch_ = tt::ARCH::BLACKHOLE;
-            desc.grid_size_ = blackhole::GRID_SIZE;
-            desc.tensix_cores_ = blackhole::TENSIX_CORES_NOC0;
-            desc.dram_cores_ = blackhole::DRAM_CORES_NOC0;
-            desc.eth_cores_ = blackhole::ETH_CORES_NOC0;
-            desc.arc_cores_ = blackhole::ARC_CORES_NOC0;
-            desc.pcie_cores_ = blackhole::PCIE_CORES_NOC0;
-            desc.router_cores_ = blackhole::ROUTER_CORES_NOC0;
-            desc.security_cores_ = blackhole::SECURITY_CORES_NOC0;
-            desc.l2cpu_cores_ = blackhole::L2CPU_CORES_NOC0;
-            desc.worker_l1_size_ = blackhole::TENSIX_L1_SIZE;
-            desc.eth_l1_size_ = blackhole::ETH_L1_SIZE;
-            desc.dram_bank_size_ = blackhole::DRAM_BANK_SIZE;
-            desc.noc0_x_to_noc1_x_ = blackhole::NOC0_X_TO_NOC1_X;
-            desc.noc0_y_to_noc1_y_ = blackhole::NOC0_Y_TO_NOC1_Y;
+            arch_ = tt::ARCH::BLACKHOLE;
+            grid_size_ = blackhole::GRID_SIZE;
+            tensix_cores_ = blackhole::TENSIX_CORES_NOC0;
+            dram_cores_ = blackhole::DRAM_CORES_NOC0;
+            eth_cores_ = blackhole::ETH_CORES_NOC0;
+            arc_cores_ = blackhole::ARC_CORES_NOC0;
+            pcie_cores_ = blackhole::PCIE_CORES_NOC0;
+            router_cores_ = blackhole::ROUTER_CORES_NOC0;
+            security_cores_ = blackhole::SECURITY_CORES_NOC0;
+            l2cpu_cores_ = blackhole::L2CPU_CORES_NOC0;
+            worker_l1_size_ = blackhole::TENSIX_L1_SIZE;
+            eth_l1_size_ = blackhole::ETH_L1_SIZE;
+            dram_bank_size_ = blackhole::DRAM_BANK_SIZE;
+            noc0_x_to_noc1_x_ = blackhole::NOC0_X_TO_NOC1_X;
+            noc0_y_to_noc1_y_ = blackhole::NOC0_Y_TO_NOC1_Y;
             break;
         case tt::ARCH::QUASAR:
-            desc.arch_ = tt::ARCH::QUASAR;
-            desc.grid_size_ = grendel::GRID_SIZE;
-            desc.tensix_cores_ = grendel::TENSIX_CORES_NOC0;
-            desc.dram_cores_ = grendel::DRAM_CORES_NOC0;
-            desc.eth_cores_ = grendel::ETH_CORES_NOC0;
-            desc.arc_cores_ = grendel::ARC_CORES_NOC0;
-            desc.pcie_cores_ = grendel::PCIE_CORES_NOC0;
-            desc.router_cores_ = grendel::ROUTER_CORES_NOC0;
-            desc.security_cores_ = grendel::SECURITY_CORES_NOC0;
-            desc.l2cpu_cores_ = grendel::L2CPU_CORES_NOC0;
-            desc.dispatch_cores_ = grendel::DISPATCH_CORES_NOC0;
-            desc.worker_l1_size_ = grendel::TENSIX_L1_SIZE;
-            desc.eth_l1_size_ = grendel::ETH_L1_SIZE;
-            desc.dram_bank_size_ = grendel::DRAM_BANK_SIZE;
-            desc.noc0_x_to_noc1_x_ = grendel::NOC0_X_TO_NOC1_X;
-            desc.noc0_y_to_noc1_y_ = grendel::NOC0_Y_TO_NOC1_Y;
+            arch_ = tt::ARCH::QUASAR;
+            grid_size_ = grendel::GRID_SIZE;
+            tensix_cores_ = grendel::TENSIX_CORES_NOC0;
+            dram_cores_ = grendel::DRAM_CORES_NOC0;
+            eth_cores_ = grendel::ETH_CORES_NOC0;
+            arc_cores_ = grendel::ARC_CORES_NOC0;
+            pcie_cores_ = grendel::PCIE_CORES_NOC0;
+            router_cores_ = grendel::ROUTER_CORES_NOC0;
+            security_cores_ = grendel::SECURITY_CORES_NOC0;
+            l2cpu_cores_ = grendel::L2CPU_CORES_NOC0;
+            dispatch_cores_ = grendel::DISPATCH_CORES_NOC0;
+            worker_l1_size_ = grendel::TENSIX_L1_SIZE;
+            eth_l1_size_ = grendel::ETH_L1_SIZE;
+            dram_bank_size_ = grendel::DRAM_BANK_SIZE;
+            noc0_x_to_noc1_x_ = grendel::NOC0_X_TO_NOC1_X;
+            noc0_y_to_noc1_y_ = grendel::NOC0_Y_TO_NOC1_Y;
             break;
         default:
-            throw std::runtime_error("Invalid architecture for creating SocArchDescriptor.");
+            UMD_THROW(error::RuntimeError, "Invalid architecture for creating SocArchDescriptor.");
     }
 
-    desc.build_derived_data();
-    return desc;
+    build_derived_data();
 }
 
-SocArchDescriptor SocArchDescriptor::create(const std::string& device_descriptor_path) {
-    std::ifstream fdesc(device_descriptor_path);
-    if (fdesc.fail()) {
-        throw std::runtime_error(
-            fmt::format("Error: device descriptor file {} does not exist!", device_descriptor_path));
+SocArchDescriptor::SocArchDescriptor(const std::string& soc_descriptor_path) {
+    std::ifstream soc_descriptor_file(soc_descriptor_path);
+    if (soc_descriptor_file.fail()) {
+        UMD_THROW(error::RuntimeError, "SocDescriptor file does not exist at path: " + soc_descriptor_path);
     }
-    fdesc.close();
+    soc_descriptor_file.close();
+    YAML::Node device_descriptor_yaml = YAML::LoadFile(soc_descriptor_path);
 
-    YAML::Node device_descriptor_yaml = YAML::LoadFile(device_descriptor_path);
-
-    SocArchDescriptor desc;
-    desc.device_descriptor_file_path_ = device_descriptor_path;
-    desc.load_from_yaml(device_descriptor_yaml);
-    desc.build_derived_data();
-    return desc;
+    device_descriptor_file_path_ = soc_descriptor_path;
+    load_from_yaml(device_descriptor_yaml);
+    build_derived_data();
 }
 
 tt::ARCH SocArchDescriptor::get_arch_from_path(const std::string& soc_descriptor_path) {

--- a/device/soc_arch_descriptor.cpp
+++ b/device/soc_arch_descriptor.cpp
@@ -16,7 +16,6 @@
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/arch/grendel_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
-#include "umd/device/soc_descriptor.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/utils/error.hpp"
 
@@ -201,6 +200,30 @@ void SocArchDescriptor::build_derived_data() {
         core_descriptor.coord = dispatch_core;
         core_descriptor.type = CoreType::DISPATCH;
         cores_.insert({core_descriptor.coord, core_descriptor});
+    }
+}
+
+tt_xy_pair format_node(const std::string& str) {
+    // Find the separator character.
+    size_t sep_pos = std::string::npos;
+    for (size_t i = 0; i < str.size(); ++i) {
+        if (str[i] == '-') {
+            sep_pos = i;
+            break;
+        }
+    }
+
+    if (sep_pos == std::string::npos || sep_pos == 0 || sep_pos >= str.size() - 1) {
+        UMD_THROW(error::RuntimeError, fmt::format("Could not parse core coordinate: {}", str));
+    }
+
+    try {
+        const char* str_cstr = str.c_str();
+        int x_coord = std::atoi(str_cstr);
+        int y_coord = std::atoi(str_cstr + sep_pos + 1);
+        return tt_xy_pair(x_coord, y_coord);
+    } catch (...) {
+        UMD_THROW(error::RuntimeError, fmt::format("Could not parse core coordinate:  {}", str));
     }
 }
 

--- a/device/soc_arch_descriptor.cpp
+++ b/device/soc_arch_descriptor.cpp
@@ -7,6 +7,7 @@
 #include <fmt/format.h>
 #include <yaml-cpp/yaml.h>
 
+#include <cstdlib>
 #include <fstream>
 #include <set>
 #include <string>

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -208,11 +208,6 @@ SocDescriptor::SocDescriptor(const tt::ARCH arch_soc, ChipInfo chip_info) {
     init_from_arch_descriptor(chip_info);
 }
 
-SocDescriptor::SocDescriptor(const std::string &device_descriptor_path, ChipInfo chip_info) {
-    arch_desc_ = std::make_shared<const SocArchDescriptor>(device_descriptor_path);
-    init_from_arch_descriptor(chip_info);
-}
-
 SocDescriptor::SocDescriptor(std::shared_ptr<const SocArchDescriptor> arch_desc, const ChipInfo chip_info) :
     arch_desc_(std::move(arch_desc)) {
     if (!arch_desc_) {

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -204,12 +204,12 @@ void SocDescriptor::create_coordinate_manager(const BoardType board_type, const 
 }
 
 SocDescriptor::SocDescriptor(const tt::ARCH arch_soc, ChipInfo chip_info) {
-    arch_desc_ = std::make_shared<const SocArchDescriptor>(SocArchDescriptor::create(arch_soc));
+    arch_desc_ = std::make_shared<const SocArchDescriptor>(arch_soc);
     init_from_arch_descriptor(chip_info);
 }
 
 SocDescriptor::SocDescriptor(const std::string &device_descriptor_path, ChipInfo chip_info) {
-    arch_desc_ = std::make_shared<const SocArchDescriptor>(SocArchDescriptor::create(device_descriptor_path));
+    arch_desc_ = std::make_shared<const SocArchDescriptor>(device_descriptor_path);
     init_from_arch_descriptor(chip_info);
 }
 

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -31,30 +31,6 @@
 
 namespace tt::umd {
 
-tt_xy_pair format_node(const std::string &str) {
-    // Find the separator character.
-    size_t sep_pos = std::string::npos;
-    for (size_t i = 0; i < str.size(); ++i) {
-        if (str[i] == '-') {
-            sep_pos = i;
-            break;
-        }
-    }
-
-    if (sep_pos == std::string::npos || sep_pos == 0 || sep_pos >= str.size() - 1) {
-        UMD_THROW(error::RuntimeError, fmt::format("Could not parse core coordinate: {}", str));
-    }
-
-    try {
-        const char *str_cstr = str.c_str();
-        int x_coord = std::atoi(str_cstr);
-        int y_coord = std::atoi(str_cstr + sep_pos + 1);
-        return tt_xy_pair(x_coord, y_coord);
-    } catch (...) {
-        UMD_THROW(error::RuntimeError, fmt::format("Could not parse core coordinate:  {}", str));
-    }
-}
-
 // clang-format off
 static const std::unordered_map<tt_xy_pair, tt_xy_pair> ROUTER_NOC1_TO_TRANSLATED_BLACKHOLE = {
     {{15, 11}, {15,  0}},

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -203,11 +203,6 @@ void SocDescriptor::create_coordinate_manager(const BoardType board_type, const 
         arch_desc_->get_noc0_y_to_noc1_y());
 }
 
-SocDescriptor::SocDescriptor(const tt::ARCH arch_soc, ChipInfo chip_info) {
-    arch_desc_ = std::make_shared<const SocArchDescriptor>(arch_soc);
-    init_from_arch_descriptor(chip_info);
-}
-
 SocDescriptor::SocDescriptor(std::shared_ptr<const SocArchDescriptor> arch_desc, const ChipInfo chip_info) :
     arch_desc_(std::move(arch_desc)) {
     if (!arch_desc_) {

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -46,8 +46,7 @@ static constexpr ChipId DEFAULT_CHIP_ID = 0;
 std::unique_ptr<RtlSimulationTTDevice> RtlSimulationTTDevice::create(
     const std::filesystem::path& simulator_directory, int num_host_mem_channels) {
     auto soc_desc_path = SimulationChip::get_soc_descriptor_path_from_simulator_path(simulator_directory);
-    std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(soc_desc_path);
-    SocDescriptor soc_descriptor = SocDescriptor(sad);
+    SocDescriptor soc_descriptor = SocDescriptor(std::make_shared<SocArchDescriptor>(soc_desc_path));
     return std::make_unique<RtlSimulationTTDevice>(
         simulator_directory, soc_descriptor, DEFAULT_CHIP_ID, num_host_mem_channels);
 }

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -46,7 +46,8 @@ static constexpr ChipId DEFAULT_CHIP_ID = 0;
 std::unique_ptr<RtlSimulationTTDevice> RtlSimulationTTDevice::create(
     const std::filesystem::path& simulator_directory, int num_host_mem_channels) {
     auto soc_desc_path = SimulationChip::get_soc_descriptor_path_from_simulator_path(simulator_directory);
-    SocDescriptor soc_descriptor = SocDescriptor(soc_desc_path);
+    std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(soc_desc_path);
+    SocDescriptor soc_descriptor = SocDescriptor(sad);
     return std::make_unique<RtlSimulationTTDevice>(
         simulator_directory, soc_descriptor, DEFAULT_CHIP_ID, num_host_mem_channels);
 }

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -554,11 +554,9 @@ const SocDescriptor &TTDevice::get_soc_descriptor() const { return soc_descripto
 
 void TTDevice::construct_soc_descriptor(const std::string &soc_descriptor_path) {
     if (soc_descriptor_path.empty()) {
-        std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(get_arch());
-        soc_descriptor_ = SocDescriptor(sad, get_chip_info());
+        soc_descriptor_ = SocDescriptor(std::make_shared<SocArchDescriptor>(get_arch()), get_chip_info());
     } else {
-        std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(soc_descriptor_path);
-        soc_descriptor_ = SocDescriptor(sad, get_chip_info());
+        soc_descriptor_ = SocDescriptor(std::make_shared<SocArchDescriptor>(soc_descriptor_path), get_chip_info());
     }
 }
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -25,6 +25,7 @@
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
+#include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/blackhole_tt_device.hpp"
 #include "umd/device/tt_device/protocol/jtag_interface.hpp"
@@ -553,9 +554,11 @@ const SocDescriptor &TTDevice::get_soc_descriptor() const { return soc_descripto
 
 void TTDevice::construct_soc_descriptor(const std::string &soc_descriptor_path) {
     if (soc_descriptor_path.empty()) {
-        soc_descriptor_ = SocDescriptor(get_arch(), get_chip_info());
+        std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(get_arch());
+        soc_descriptor_ = SocDescriptor(sad, get_chip_info());
     } else {
-        soc_descriptor_ = SocDescriptor(soc_descriptor_path, get_chip_info());
+        std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(soc_descriptor_path);
+        soc_descriptor_ = SocDescriptor(sad, get_chip_info());
     }
 }
 

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -43,8 +43,7 @@ std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create(
         // without creating ClusterDescriptor, so we need to add it here as well.
         chip_info.harvesting_masks.eth_harvesting_mask = 0x120;
     }
-    std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(soc_desc_path);
-    SocDescriptor soc_descriptor = SocDescriptor(sad, chip_info);
+    SocDescriptor soc_descriptor = SocDescriptor(std::make_shared<SocArchDescriptor>(soc_desc_path), chip_info);
     return std::make_unique<TTSimTTDevice>(
         simulator_directory, soc_descriptor, 0, copy_sim_binary, num_host_mem_channels);
 }

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -43,7 +43,8 @@ std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create(
         // without creating ClusterDescriptor, so we need to add it here as well.
         chip_info.harvesting_masks.eth_harvesting_mask = 0x120;
     }
-    SocDescriptor soc_descriptor = SocDescriptor(soc_desc_path, chip_info);
+    std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(soc_desc_path);
+    SocDescriptor soc_descriptor = SocDescriptor(sad, chip_info);
     return std::make_unique<TTSimTTDevice>(
         simulator_directory, soc_descriptor, 0, copy_sim_binary, num_host_mem_channels);
 }

--- a/examples/tt_device_example/tt_device_example.cpp
+++ b/examples/tt_device_example/tt_device_example.cpp
@@ -67,10 +67,8 @@ int main(int argc, char* argv[]) {
         std::cout << "ArcTelemetryReader available: " << (device->get_arc_telemetry_reader() ? "Yes" : "No")
                   << std::endl;
 
-        ChipInfo chip_info = device->get_chip_info();
-        SocDescriptor soc_desc(device->get_arch(), chip_info);
-
-        const std::vector<CoreCoord>& tensix_cores = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
+        const std::vector<CoreCoord>& tensix_cores =
+            device->get_soc_descriptor().get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
         if (tensix_cores.empty()) {
             std::cout << "No Tensix cores available" << std::endl;
             continue;

--- a/nanobind/py_api_soc_descriptor.cpp
+++ b/nanobind/py_api_soc_descriptor.cpp
@@ -69,7 +69,7 @@ void bind_soc_descriptor(nb::module_ &m) {
         .def(
             "__init__",
             [](SocDescriptor *soc_desc, TTDevice &tt_device) {
-                new (soc_desc) SocDescriptor(tt_device.get_arch(), tt_device.get_chip_info());
+                new (soc_desc) SocDescriptor(tt_device.get_soc_descriptor());
             },
             nb::arg("tt_device"),
             "Create a SocDescriptor from a TTDevice")

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -37,20 +37,20 @@ using namespace tt::umd;
 
 // Helper function for easy creation of a remote TTDevice.
 std::unique_ptr<TTDevice> create_remote_tt_device(
-    TTDevice *local_chip, ClusterDescriptor *cluster_descriptor, ChipId remote_chip_id) {
+    TTDevice *local_tt_device, ClusterDescriptor *cluster_descriptor, ChipId remote_chip_id) {
     // Note: this chip id has to match the local_chip passed. Figure out if there's a better way to do this.
     ChipId local_chip_id = cluster_descriptor->get_closest_mmio_capable_chip(remote_chip_id);
     EthCoord target_chip = cluster_descriptor->get_chip_locations().at(remote_chip_id);
-    SocDescriptor local_soc_descriptor = SocDescriptor(local_chip->get_arch(), local_chip->get_chip_info());
-    auto remote_communication = RemoteCommunication::create_remote_communication(local_chip, target_chip);
+    auto remote_communication = RemoteCommunication::create_remote_communication(local_tt_device, target_chip);
     if (!remote_communication) {
         UMD_THROW(
             error::RuntimeError,
-            std::string("Remote communication is not supported for ") + arch_to_str(local_chip->get_arch()) +
+            std::string("Remote communication is not supported for ") + arch_to_str(local_tt_device->get_arch()) +
                 " architecture.");
     }
-    remote_communication->set_remote_transfer_ethernet_cores(local_soc_descriptor.get_eth_xy_pairs_for_channels(
-        cluster_descriptor->get_active_eth_channels(local_chip_id), CoordSystem::TRANSLATED));
+    remote_communication->set_remote_transfer_ethernet_cores(
+        local_tt_device->get_soc_descriptor().get_eth_xy_pairs_for_channels(
+            cluster_descriptor->get_active_eth_channels(local_chip_id), CoordSystem::TRANSLATED));
     return TTDevice::create(std::move(remote_communication));
 }
 

--- a/tests/api/test_hang_detection.cpp
+++ b/tests/api/test_hang_detection.cpp
@@ -53,7 +53,7 @@ protected:
     void init_device(int pci_device_id) {
         tt_device_ = TTDevice::create(pci_device_id);
         tt_device_->init_tt_device();
-        soc_desc_ = std::make_unique<SocDescriptor>(tt_device_->get_arch(), tt_device_->get_chip_info());
+        soc_desc_ = std::make_unique<SocDescriptor>(tt_device_->get_soc_descriptor());
     }
 
     // Deliberately hangs the specified NOC by reading an address that causes the NOC transaction to

--- a/tests/api/test_jtag.cpp
+++ b/tests/api/test_jtag.cpp
@@ -63,9 +63,8 @@ protected:
             DeviceData device_data;
             device_data.tt_device_ = TTDevice::create(jlink_device_id, IODeviceType::JTAG);
             device_data.tt_device_->init_tt_device();
-            auto soc_descriptor =
-                SocDescriptor(device_data.tt_device_->get_arch(), device_data.tt_device_->get_chip_info());
-            device_data.tensix_core_ = soc_descriptor.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
+            device_data.tensix_core_ =
+                device_data.tt_device_->get_soc_descriptor().get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
             device_data_.push_back(std::move(device_data));
         }
 
@@ -160,9 +159,8 @@ TEST_F(ApiJtagDeviceTest, JtagTranslatedCoordsTest) {
         pci_tt_device->init_tt_device();
 
         ChipInfo chip_info = pci_tt_device->get_chip_info();
-
         tt_xy_pair tensix_core =
-            SocDescriptor(pci_tt_device->get_arch(), chip_info).get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
+            pci_tt_device->get_soc_descriptor().get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
 
         // clear the memory first with zeros.
         pci_tt_device->write_to_device(data_read.data(), tensix_core, address, data_read.size() * sizeof(uint32_t));
@@ -195,7 +193,7 @@ TEST_F(ApiJtagDeviceTest, JtagTestNoc1) {
     uint64_t address = 0x0;
 
     for (const auto& device : device_data_) {
-        SocDescriptor soc_desc(device.tt_device_->get_arch(), device.tt_device_->get_chip_info());
+        const SocDescriptor& soc_desc = device.tt_device_->get_soc_descriptor();
         tt_xy_pair test_core_noc_0 = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::NOC0)[0];
         tt_xy_pair test_core_noc_1 = soc_desc.translate_coord_to(test_core_noc_0, CoordSystem::NOC0, CoordSystem::NOC1);
 

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -28,7 +28,7 @@ TEST(TestSocDescriptor, SocDescriptorSerialize) {
 
         std::filesystem::path file_path = soc_descriptor.serialize_to_file();
         SocDescriptor soc(
-            file_path.string(),
+            std::make_shared<SocArchDescriptor>(file_path.string()),
             {.noc_translation_enabled = soc_descriptor.noc_translation_enabled,
              .harvesting_masks = soc_descriptor.harvesting_masks});
     }

--- a/tests/api/test_spi_tt_device.cpp
+++ b/tests/api/test_spi_tt_device.cpp
@@ -54,35 +54,14 @@ struct SpiTestDevices {
 
 // Helper function to set up devices for SPI testing.
 SpiTestDevices setup_spi_test_devices() {
-    auto [cluster_desc, _] = TopologyDiscovery::discover({});
+    auto [cluster_desc, tt_devices] = TopologyDiscovery::discover({});
     SpiTestDevices result;
 
     for (ChipId chip_id : cluster_desc->get_chips_local_first(cluster_desc->get_all_chips())) {
         std::cout << "Setting up device " << chip_id << " local: " << cluster_desc->is_chip_mmio_capable(chip_id)
                   << std::endl;
 
-        if (cluster_desc->is_chip_mmio_capable(chip_id)) {
-            int physical_device_id = cluster_desc->get_chips_with_mmio().at(chip_id);
-            auto tt_device = TTDevice::create(physical_device_id, IODeviceType::PCIe);
-            tt_device->set_power_state(true);
-            tt_device->init_tt_device();
-            result.tt_devices[chip_id] = std::move(tt_device);
-        } else {
-            ChipId closest_mmio_chip_id = cluster_desc->get_closest_mmio_capable_chip(chip_id);
-            std::unique_ptr<TTDevice>& local_tt_device = result.tt_devices.at(closest_mmio_chip_id);
-
-            SocDescriptor local_soc_descriptor =
-                SocDescriptor(local_tt_device->get_arch(), local_tt_device->get_chip_info());
-            EthCoord target_chip = cluster_desc->get_chip_locations().at(chip_id);
-            auto remote_communication = RemoteCommunication::create_remote_communication(
-                local_tt_device.get(), target_chip, nullptr);  // nullptr for sysmem_manager
-            remote_communication->set_remote_transfer_ethernet_cores(local_soc_descriptor.get_eth_xy_pairs_for_channels(
-                cluster_desc->get_active_eth_channels(closest_mmio_chip_id)));
-            std::unique_ptr<TTDevice> remote_tt_device = TTDevice::create(std::move(remote_communication));
-            remote_tt_device->init_tt_device();
-            result.tt_devices[chip_id] = std::move(remote_tt_device);
-        }
-
+        result.tt_devices[chip_id] = std::move(tt_devices.at(chip_id));
         result.spi_devices[chip_id] = SPITTDevice::create(result.tt_devices[chip_id].get());
     }
 

--- a/tests/api/test_tlb_manager.cpp
+++ b/tests/api/test_tlb_manager.cpp
@@ -36,9 +36,8 @@ TEST(ApiTLBManager, ManualTLBConfiguration) {
         tt_device->init_tt_device();
 
         std::unique_ptr<TLBManager> tlb_manager = std::make_unique<TLBManager>(tt_device.get());
-        ChipInfo chip_info = tt_device->get_chip_info();
 
-        SocDescriptor soc_desc(tt_device->get_arch(), chip_info);
+        const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
 
         std::int32_t c_zero_address = 0;
 
@@ -54,7 +53,5 @@ TEST(ApiTLBManager, ManualTLBConfiguration) {
         std::vector<uint8_t> buffer_to_write = {0x01, 0x02, 0x03, 0x04};
         TlbWindow* window = tlb_manager->get_tlb_window(any_worker_translated_core);
         window->write_register(address_l1_to_write, buffer_to_write.data(), buffer_to_write.size());
-
-        tt_device->set_power_state(false);
     }
 }

--- a/tests/api/test_tlb_manager.cpp
+++ b/tests/api/test_tlb_manager.cpp
@@ -53,5 +53,7 @@ TEST(ApiTLBManager, ManualTLBConfiguration) {
         std::vector<uint8_t> buffer_to_write = {0x01, 0x02, 0x03, 0x04};
         TlbWindow* window = tlb_manager->get_tlb_window(any_worker_translated_core);
         window->write_register(address_l1_to_write, buffer_to_write.data(), buffer_to_write.size());
+
+        tt_device->set_power_state(false);
     }
 }

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -43,9 +43,7 @@ TEST(ApiTTDeviceTest, BasicTTDeviceIO) {
         tt_device->set_power_state(true);
         tt_device->init_tt_device();
 
-        ChipInfo chip_info = tt_device->get_chip_info();
-
-        SocDescriptor soc_desc(tt_device->get_arch(), chip_info);
+        const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
 
         tt_xy_pair tensix_core = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
 
@@ -74,9 +72,7 @@ TEST(ApiTTDeviceTest, TTDeviceRegIO) {
         tt_device->init_tt_device();
         uint64_t address = tt_device->get_architecture_implementation()->get_debug_reg_addr();
 
-        ChipInfo chip_info = tt_device->get_chip_info();
-
-        SocDescriptor soc_desc(tt_device->get_arch(), chip_info);
+        const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
 
         tt_xy_pair tensix_core = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
 
@@ -125,9 +121,7 @@ TEST(ApiTTDeviceTest, TTDeviceMultipleThreadsIO) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
         tt_device->set_power_state(true);
         tt_device->init_tt_device();
-        ChipInfo chip_info = tt_device->get_chip_info();
-
-        SocDescriptor soc_desc(tt_device->get_arch(), chip_info);
+        const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
 
         tt_xy_pair tensix_core = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
 

--- a/tests/api/test_warm_reset.cpp
+++ b/tests/api/test_warm_reset.cpp
@@ -102,7 +102,7 @@ TEST(WarmResetTest, DISABLED_TTDeviceWarmResetAfterNocHang) {
     tt_device->set_power_state(true);
     tt_device->init_tt_device();
 
-    SocDescriptor soc_desc(tt_device->get_arch(), tt_device->get_chip_info());
+    const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
 
     tt_xy_pair tensix_core = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
 
@@ -184,9 +184,7 @@ TEST_P(WarmResetParamTest, DISABLED_SafeApiHandlesReset) {
 
         tt_devices[pci_device_id]->init_tt_device();
 
-        ChipInfo chip_info = tt_devices[pci_device_id]->get_chip_info();
-
-        SocDescriptor soc_desc(tt_devices[pci_device_id]->get_arch(), chip_info);
+        const SocDescriptor& soc_desc = tt_devices[pci_device_id]->get_soc_descriptor();
 
         tensix_core = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
     }
@@ -261,9 +259,7 @@ TEST(WarmResetTest, DISABLED_SafeApiMultiThreaded) {
 
         tt_devices[pci_device_id]->init_tt_device();
 
-        ChipInfo chip_info = tt_devices[pci_device_id]->get_chip_info();
-
-        SocDescriptor soc_desc(tt_devices[pci_device_id]->get_arch(), chip_info);
+        const SocDescriptor& soc_desc = tt_devices[pci_device_id]->get_soc_descriptor();
 
         tensix_core = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
     }
@@ -324,9 +320,7 @@ TEST(WarmResetTest, DISABLED_SafeApiMultiProcess) {
 
                 tt_devices[pci_device_id]->init_tt_device();
 
-                ChipInfo chip_info = tt_devices[pci_device_id]->get_chip_info();
-
-                SocDescriptor soc_desc(tt_devices[pci_device_id]->get_arch(), chip_info);
+                const SocDescriptor& soc_desc = tt_devices[pci_device_id]->get_soc_descriptor();
 
                 tensix_core = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
             }

--- a/tests/baremetal/test_soc_arch_descriptor.cpp
+++ b/tests/baremetal/test_soc_arch_descriptor.cpp
@@ -20,13 +20,14 @@
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/error.hpp"
 
 using namespace tt;
 using namespace tt::umd;
 
 // Test SocArchDescriptor creation from arch enum for Wormhole.
 TEST(SocArchDescriptor, WormholeFromArch) {
-    auto desc = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
+    auto desc = SocArchDescriptor(tt::ARCH::WORMHOLE_B0);
 
     EXPECT_EQ(desc.get_arch(), tt::ARCH::WORMHOLE_B0);
     EXPECT_EQ(desc.get_grid_size(), wormhole::GRID_SIZE);
@@ -50,7 +51,7 @@ TEST(SocArchDescriptor, WormholeFromArch) {
 
 // Test SocArchDescriptor creation from arch enum for Blackhole.
 TEST(SocArchDescriptor, BlackholeFromArch) {
-    auto desc = SocArchDescriptor::create(tt::ARCH::BLACKHOLE);
+    auto desc = SocArchDescriptor(tt::ARCH::BLACKHOLE);
 
     EXPECT_EQ(desc.get_arch(), tt::ARCH::BLACKHOLE);
     EXPECT_EQ(desc.get_grid_size(), blackhole::GRID_SIZE);
@@ -70,7 +71,7 @@ TEST(SocArchDescriptor, BlackholeFromArch) {
 
 // Test SocArchDescriptor creation from arch enum for Quasar.
 TEST(SocArchDescriptor, QuasarFromArch) {
-    auto desc = SocArchDescriptor::create(tt::ARCH::QUASAR);
+    auto desc = SocArchDescriptor(tt::ARCH::QUASAR);
 
     EXPECT_EQ(desc.get_arch(), tt::ARCH::QUASAR);
     EXPECT_EQ(desc.get_grid_size(), grendel::GRID_SIZE);
@@ -84,7 +85,7 @@ TEST(SocArchDescriptor, QuasarFromArch) {
 
 // Test SocArchDescriptor creation from YAML for Wormhole.
 TEST(SocArchDescriptor, WormholeFromYaml) {
-    auto desc = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"));
+    auto desc = SocArchDescriptor(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"));
 
     EXPECT_EQ(desc.get_arch(), tt::ARCH::WORMHOLE_B0);
     EXPECT_EQ(desc.get_grid_size(), wormhole::GRID_SIZE);
@@ -98,7 +99,7 @@ TEST(SocArchDescriptor, WormholeFromYaml) {
 
 // Test SocArchDescriptor creation from YAML for Blackhole.
 TEST(SocArchDescriptor, BlackholeFromYaml) {
-    auto desc = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"));
+    auto desc = SocArchDescriptor(test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"));
 
     EXPECT_EQ(desc.get_arch(), tt::ARCH::BLACKHOLE);
     EXPECT_EQ(desc.get_grid_size(), blackhole::GRID_SIZE);
@@ -108,8 +109,8 @@ TEST(SocArchDescriptor, BlackholeFromYaml) {
 
 // Test that arch enum and YAML produce consistent results for Wormhole.
 TEST(SocArchDescriptor, WormholeArchAndYamlConsistency) {
-    auto from_arch = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
-    auto from_yaml = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"));
+    auto from_arch = SocArchDescriptor(tt::ARCH::WORMHOLE_B0);
+    auto from_yaml = SocArchDescriptor(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"));
 
     EXPECT_EQ(from_arch.get_arch(), from_yaml.get_arch());
     EXPECT_EQ(from_arch.get_grid_size(), from_yaml.get_grid_size());
@@ -131,8 +132,8 @@ TEST(SocArchDescriptor, WormholeArchAndYamlConsistency) {
 
 // Test that arch enum and YAML produce consistent results for Blackhole.
 TEST(SocArchDescriptor, BlackholeArchAndYamlConsistency) {
-    auto from_arch = SocArchDescriptor::create(tt::ARCH::BLACKHOLE);
-    auto from_yaml = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"));
+    auto from_arch = SocArchDescriptor(tt::ARCH::BLACKHOLE);
+    auto from_yaml = SocArchDescriptor(test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"));
 
     EXPECT_EQ(from_arch.get_arch(), from_yaml.get_arch());
     EXPECT_EQ(from_arch.get_grid_size(), from_yaml.get_grid_size());
@@ -151,7 +152,7 @@ TEST(SocArchDescriptor, BlackholeArchAndYamlConsistency) {
 
 // Test derived data: cores map is populated correctly.
 TEST(SocArchDescriptor, WormholeDerivedCoresMap) {
-    auto desc = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
+    auto desc = SocArchDescriptor(tt::ARCH::WORMHOLE_B0);
 
     // Total cores in the map should equal sum of all core type vectors.
     size_t expected_total = desc.get_tensix_cores().size() + desc.get_eth_cores().size() + desc.get_arc_cores().size() +
@@ -195,7 +196,7 @@ TEST(SocArchDescriptor, WormholeDerivedCoresMap) {
 
 // Test derived data: DRAM channel map.
 TEST(SocArchDescriptor, WormholeDRAMChannelMap) {
-    auto desc = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
+    auto desc = SocArchDescriptor(tt::ARCH::WORMHOLE_B0);
 
     EXPECT_EQ(desc.get_dram_cores().size(), wormhole::NUM_DRAM_BANKS);
     for (size_t channel = 0; channel < desc.get_dram_cores().size(); channel++) {
@@ -211,7 +212,7 @@ TEST(SocArchDescriptor, WormholeDRAMChannelMap) {
 
 // Test derived data: ETH channel map.
 TEST(SocArchDescriptor, WormholeETHChannelMap) {
-    auto desc = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
+    auto desc = SocArchDescriptor(tt::ARCH::WORMHOLE_B0);
 
     EXPECT_EQ(desc.get_eth_cores().size(), wormhole::ETH_CORES_NOC0.size());
     for (size_t channel = 0; channel < desc.get_eth_cores().size(); channel++) {
@@ -223,12 +224,12 @@ TEST(SocArchDescriptor, WormholeETHChannelMap) {
 
 // Test derived data: worker grid size.
 TEST(SocArchDescriptor, WormholeWorkerGridSize) {
-    auto desc = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
+    auto desc = SocArchDescriptor(tt::ARCH::WORMHOLE_B0);
     EXPECT_EQ(desc.get_worker_grid_size(), wormhole::TENSIX_GRID_SIZE);
 }
 
 TEST(SocArchDescriptor, BlackholeWorkerGridSize) {
-    auto desc = SocArchDescriptor::create(tt::ARCH::BLACKHOLE);
+    auto desc = SocArchDescriptor(tt::ARCH::BLACKHOLE);
     EXPECT_EQ(desc.get_worker_grid_size(), blackhole::TENSIX_GRID_SIZE);
 }
 
@@ -253,12 +254,12 @@ TEST(SocArchDescriptor, GetGridSizeFromPath) {
 
 // Test invalid arch throws.
 TEST(SocArchDescriptor, InvalidArchThrows) {
-    EXPECT_THROW(SocArchDescriptor::create(tt::ARCH::Invalid), std::runtime_error);
+    EXPECT_THROW(SocArchDescriptor{tt::ARCH::Invalid}, error::UmdException<error::RuntimeError>);
 }
 
 // Test invalid YAML path throws.
 TEST(SocArchDescriptor, InvalidPathThrows) {
-    EXPECT_THROW(SocArchDescriptor::create("/nonexistent/path.yaml"), std::runtime_error);
+    EXPECT_THROW(SocArchDescriptor("/nonexistent/path.yaml"), error::UmdException<error::RuntimeError>);
 }
 
 // Test calculate_grid_size utility.
@@ -276,7 +277,7 @@ TEST(SocArchDescriptor, CalculateGridSize) {
 
 // Test Blackhole derived data.
 TEST(SocArchDescriptor, BlackholeDRAMChannelMap) {
-    auto desc = SocArchDescriptor::create(tt::ARCH::BLACKHOLE);
+    auto desc = SocArchDescriptor(tt::ARCH::BLACKHOLE);
 
     EXPECT_EQ(desc.get_dram_cores().size(), blackhole::NUM_DRAM_BANKS);
     for (size_t channel = 0; channel < desc.get_dram_cores().size(); channel++) {
@@ -293,21 +294,21 @@ TEST(SocArchDescriptor, BlackholeDRAMChannelMap) {
 
 // Test Wormhole: no security and no L2CPU cores.
 TEST(SocArchDescriptor, WormholeNoSecurityNoL2CPU) {
-    auto desc = SocArchDescriptor::create(tt::ARCH::WORMHOLE_B0);
+    auto desc = SocArchDescriptor(tt::ARCH::WORMHOLE_B0);
     EXPECT_TRUE(desc.get_security_cores().empty());
     EXPECT_TRUE(desc.get_l2cpu_cores().empty());
 }
 
 // Test Blackhole: has security and L2CPU cores.
 TEST(SocArchDescriptor, BlackholeHasSecurityAndL2CPU) {
-    auto desc = SocArchDescriptor::create(tt::ARCH::BLACKHOLE);
+    auto desc = SocArchDescriptor(tt::ARCH::BLACKHOLE);
     EXPECT_FALSE(desc.get_security_cores().empty());
     EXPECT_FALSE(desc.get_l2cpu_cores().empty());
 }
 
 // Test Blackhole simulation 1x2 YAML descriptor.
 TEST(SocArchDescriptor, BlackholeSimulation1x2) {
-    auto desc = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("blackhole_simulation_1x2.yaml"));
+    auto desc = SocArchDescriptor(test_utils::GetSocDescAbsPath("blackhole_simulation_1x2.yaml"));
 
     EXPECT_EQ(desc.get_arch(), tt::ARCH::BLACKHOLE);
     EXPECT_EQ(desc.get_grid_size(), tt_xy_pair(2, 2));
@@ -350,7 +351,7 @@ TEST(SocArchDescriptor, BlackholeSimulation1x2) {
 
 // Test Quasar simulation 1x1 YAML descriptor.
 TEST(SocArchDescriptor, QuasarSimulation1x1) {
-    auto desc = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("quasar_simulation_1x1.yaml"));
+    auto desc = SocArchDescriptor(test_utils::GetSocDescAbsPath("quasar_simulation_1x1.yaml"));
 
     EXPECT_EQ(desc.get_arch(), tt::ARCH::QUASAR);
     EXPECT_EQ(desc.get_grid_size(), tt_xy_pair(1, 3));
@@ -384,7 +385,7 @@ TEST(SocArchDescriptor, QuasarSimulation1x1) {
 
 // Test Wormhole B0 1x1 YAML descriptor.
 TEST(SocArchDescriptor, WormholeB01x1) {
-    auto desc = SocArchDescriptor::create(test_utils::GetSocDescAbsPath("wormhole_b0_1x1.yaml"));
+    auto desc = SocArchDescriptor(test_utils::GetSocDescAbsPath("wormhole_b0_1x1.yaml"));
 
     EXPECT_EQ(desc.get_arch(), tt::ARCH::WORMHOLE_B0);
     EXPECT_EQ(desc.get_grid_size(), tt_xy_pair(10, 12));
@@ -429,6 +430,6 @@ TEST(SocArchDescriptor, WormholeB01x1) {
 // Test all available YAML descriptors can be loaded.
 TEST(SocArchDescriptor, AllSocDescriptors) {
     for (const std::string& soc_desc_yaml : test_utils::GetAllSocDescs()) {
-        EXPECT_NO_THROW(SocArchDescriptor::create(soc_desc_yaml)) << "Failed to load: " << soc_desc_yaml;
+        EXPECT_NO_THROW(SocArchDescriptor{soc_desc_yaml}) << "Failed to load: " << soc_desc_yaml;
     }
 }

--- a/tests/baremetal/test_soc_descriptor.cpp
+++ b/tests/baremetal/test_soc_descriptor.cpp
@@ -559,7 +559,8 @@ TEST(SocDescriptor, WormholeNOC1Cores) {
         {.noc_translation_enabled = true, .harvesting_masks = harvesting_masks});
 
     SocDescriptor soc_desc_arch(
-        tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true, .harvesting_masks = harvesting_masks});
+        std::make_shared<SocArchDescriptor>(tt::ARCH::WORMHOLE_B0),
+        {.noc_translation_enabled = true, .harvesting_masks = harvesting_masks});
 
     const std::vector<CoreCoord> tensix_cores_noc1_yaml = soc_desc_yaml.get_cores(CoreType::TENSIX, CoordSystem::NOC1);
     const std::vector<CoreCoord> tensix_cores_noc1_arch = soc_desc_arch.get_cores(CoreType::TENSIX, CoordSystem::NOC1);
@@ -611,7 +612,8 @@ TEST(SocDescriptor, BlackholeNOC1Cores) {
         {.noc_translation_enabled = true, .harvesting_masks = harvesting_masks});
 
     SocDescriptor soc_desc_arch(
-        tt::ARCH::BLACKHOLE, {.noc_translation_enabled = true, .harvesting_masks = harvesting_masks});
+        std::make_shared<SocArchDescriptor>(tt::ARCH::BLACKHOLE),
+        {.noc_translation_enabled = true, .harvesting_masks = harvesting_masks});
 
     const std::vector<CoreCoord> tensix_cores_noc1_yaml = soc_desc_yaml.get_cores(CoreType::TENSIX, CoordSystem::NOC1);
     const std::vector<CoreCoord> tensix_cores_noc1_arch = soc_desc_arch.get_cores(CoreType::TENSIX, CoordSystem::NOC1);
@@ -656,7 +658,8 @@ TEST(SocDescriptor, SocDescriptorWormholeNoSecurityCores) {
 
     EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::SECURITY).size(), 0);
 
-    SocDescriptor soc_desc_arch(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
+    SocDescriptor soc_desc_arch(
+        std::make_shared<SocArchDescriptor>(tt::ARCH::WORMHOLE_B0), {.noc_translation_enabled = true});
 
     EXPECT_EQ(soc_desc_arch.get_cores(CoreType::SECURITY).size(), 0);
 }
@@ -669,7 +672,7 @@ TEST(SocDescriptor, SocDescriptorBlackholeSecurity) {
     EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::SECURITY).size(), 1);
 
     SocDescriptor soc_desc_arch(
-        tt::ARCH::BLACKHOLE,
+        std::make_shared<SocArchDescriptor>(tt::ARCH::BLACKHOLE),
         {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}});
 
     EXPECT_EQ(soc_desc_arch.get_cores(CoreType::SECURITY).size(), 1);
@@ -682,7 +685,8 @@ TEST(SocDescriptor, SocDescriptorWormholeNoL2CPUCores) {
 
     EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::L2CPU).size(), 0);
 
-    SocDescriptor soc_desc_arch(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
+    SocDescriptor soc_desc_arch(
+        std::make_shared<SocArchDescriptor>(tt::ARCH::WORMHOLE_B0), {.noc_translation_enabled = true});
 
     EXPECT_EQ(soc_desc_arch.get_cores(CoreType::L2CPU).size(), 0);
 }
@@ -695,7 +699,7 @@ TEST(SocDescriptor, SocDescriptorBlackholeL2CPU) {
     EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::L2CPU).size(), 4);
 
     SocDescriptor soc_desc_arch(
-        tt::ARCH::BLACKHOLE,
+        std::make_shared<SocArchDescriptor>(tt::ARCH::BLACKHOLE),
         {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}});
 
     EXPECT_EQ(soc_desc_arch.get_cores(CoreType::L2CPU).size(), 4);
@@ -732,7 +736,8 @@ TEST(SocDescriptor, SocDescriptorWormholeNoDispatchCores) {
 
     EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::DISPATCH).size(), 0);
 
-    SocDescriptor soc_desc_arch(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
+    SocDescriptor soc_desc_arch(
+        std::make_shared<SocArchDescriptor>(tt::ARCH::WORMHOLE_B0), {.noc_translation_enabled = true});
 
     EXPECT_EQ(soc_desc_arch.get_cores(CoreType::DISPATCH).size(), 0);
 }
@@ -745,7 +750,7 @@ TEST(SocDescriptor, SocDescriptorBlackholeNoDispatchCores) {
     EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::DISPATCH).size(), 0);
 
     SocDescriptor soc_desc_arch(
-        tt::ARCH::BLACKHOLE,
+        std::make_shared<SocArchDescriptor>(tt::ARCH::BLACKHOLE),
         {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}});
 
     EXPECT_EQ(soc_desc_arch.get_cores(CoreType::DISPATCH).size(), 0);

--- a/tests/baremetal/test_soc_descriptor.cpp
+++ b/tests/baremetal/test_soc_descriptor.cpp
@@ -18,6 +18,7 @@
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/coordinates/coordinate_manager.hpp"
+#include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
@@ -32,7 +33,9 @@ constexpr size_t example_eth_harvesting_mask = (1 << 8) | (1 << 5);
 
 // Test soc descriptor API for Wormhole when there is no harvesting.
 TEST(SocDescriptor, SocDescriptorWormholeNoHarvesting) {
-    SocDescriptor soc_desc(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"), {.noc_translation_enabled = true});
+    SocDescriptor soc_desc(
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml")),
+        {.noc_translation_enabled = true});
 
     const std::vector<tt_xy_pair> wormhole_tensix_cores = wormhole::TENSIX_CORES_NOC0;
 
@@ -51,7 +54,9 @@ TEST(SocDescriptor, SocDescriptorWormholeNoHarvesting) {
 
 // Test soc descriptor API for getting DRAM cores.
 TEST(SocDescriptor, SocDescriptorWormholeDRAM) {
-    SocDescriptor soc_desc(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"), {.noc_translation_enabled = true});
+    SocDescriptor soc_desc(
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml")),
+        {.noc_translation_enabled = true});
 
     const std::vector<std::vector<CoreCoord>> dram_cores = soc_desc.get_dram_cores();
 
@@ -68,7 +73,7 @@ TEST(SocDescriptor, SocDescriptorWormholeOneRowHarvesting) {
     const HarvestingMasks harvesting_masks = {.tensix_harvesting_mask = (1 << 0)};
 
     SocDescriptor soc_desc(
-        test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"),
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml")),
         {.noc_translation_enabled = true, .harvesting_masks = harvesting_masks});
 
     const std::vector<CoreCoord> tensix_cores = soc_desc.get_cores(CoreType::TENSIX);
@@ -97,7 +102,8 @@ TEST(SocDescriptor, SocDescriptorWormholeOneRowHarvesting) {
 // Test ETH translation from logical to noc0 coordinates.
 TEST(SocDescriptor, SocDescriptorWormholeETHLogicalToNOC0) {
     const SocDescriptor soc_desc(
-        test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"), {.noc_translation_enabled = true});
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml")),
+        {.noc_translation_enabled = true});
 
     const std::vector<tt_xy_pair>& wormhole_eth_cores = wormhole::ETH_CORES_NOC0;
     const uint32_t num_eth_channels = soc_desc.get_num_eth_channels();
@@ -119,7 +125,9 @@ TEST(SocDescriptor, SocDescriptorWormholeETHLogicalToNOC0) {
 }
 
 TEST(SocDescriptor, SocDescriptorDRAMChannels) {
-    SocDescriptor soc_desc(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"), {.noc_translation_enabled = true});
+    SocDescriptor soc_desc(
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml")),
+        {.noc_translation_enabled = true});
 
     int num_dram_channels = soc_desc.get_num_dram_channels();
 
@@ -153,7 +161,7 @@ TEST(SocDescriptor, SocDescriptorBlackholeETHHarvesting) {
         const HarvestingMasks harvesting_masks = {.eth_harvesting_mask = eth_harvesting_mask};
 
         SocDescriptor soc_desc(
-            test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml"),
+            std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
             {.noc_translation_enabled = true, .harvesting_masks = harvesting_masks});
 
         const std::vector<CoreCoord> eth_cores = soc_desc.get_cores(CoreType::ETH);
@@ -186,7 +194,8 @@ TEST(SocDescriptor, SocDescriptorBlackholeETHHarvesting) {
 // Test soc descriptor API for Blackhole when there is no harvesting.
 TEST(SocDescriptor, SocDescriptorBlackholeNoHarvesting) {
     SocDescriptor soc_desc(
-        test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"), {.noc_translation_enabled = true});
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml")),
+        {.noc_translation_enabled = true});
 
     const std::vector<tt_xy_pair> blackhole_tensix_cores = blackhole::TENSIX_CORES_NOC0;
 
@@ -211,7 +220,7 @@ TEST(SocDescriptor, SocDescriptorBlackholeOneRowHarvesting) {
     const HarvestingMasks harvesting_masks = {.tensix_harvesting_mask = 1};
 
     SocDescriptor soc_desc(
-        test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"),
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml")),
         {.noc_translation_enabled = true, .harvesting_masks = harvesting_masks});
 
     const std::vector<CoreCoord> tensix_cores = soc_desc.get_cores(CoreType::TENSIX);
@@ -244,7 +253,8 @@ TEST(SocDescriptor, SocDescriptorBlackholeOneRowHarvesting) {
 // Test soc descriptor API for getting DRAM cores.
 TEST(SocDescriptor, SocDescriptorBlackholeDRAM) {
     SocDescriptor soc_desc(
-        test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"), {.noc_translation_enabled = true});
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml")),
+        {.noc_translation_enabled = true});
 
     const std::vector<std::vector<CoreCoord>> dram_cores = soc_desc.get_dram_cores();
 
@@ -265,7 +275,7 @@ TEST(SocDescriptor, SocDescriptorBlackholeDRAMHarvesting) {
     const HarvestingMasks harvesting_masks = {.tensix_harvesting_mask = 0, .dram_harvesting_mask = 1};
 
     SocDescriptor soc_desc(
-        test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"),
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml")),
         {.noc_translation_enabled = true, .harvesting_masks = harvesting_masks});
 
     const std::vector<CoreCoord> tensix_cores = soc_desc.get_cores(CoreType::TENSIX);
@@ -299,7 +309,8 @@ TEST(SocDescriptor, SocDescriptorBlackholeDRAMHarvesting) {
 
 TEST(SocDescriptor, CustomSocDescriptor) {
     SocDescriptor soc_desc(
-        test_utils::GetSocDescAbsPath("blackhole_simulation_1x2.yaml"), {.noc_translation_enabled = true});
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_simulation_1x2.yaml")),
+        {.noc_translation_enabled = true});
 
     const CoreCoord tensix_core_01 = CoreCoord(0, 1, CoreType::TENSIX, CoordSystem::NOC0);
     const CoreCoord tensix_core_01_logical = soc_desc.translate_coord_to(tensix_core_01, CoordSystem::LOGICAL);
@@ -344,7 +355,9 @@ TEST(SocDescriptor, CustomSocDescriptor) {
 }
 
 TEST(SocDescriptor, SocDescriptorWormholeMultipleCoordinateSystems) {
-    SocDescriptor soc_desc(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"), {.noc_translation_enabled = true});
+    SocDescriptor soc_desc(
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml")),
+        {.noc_translation_enabled = true});
 
     const std::vector<tt_xy_pair> cores_noc0 = wormhole::TENSIX_CORES_NOC0;
 
@@ -366,7 +379,8 @@ TEST(SocDescriptor, SocDescriptorWormholeMultipleCoordinateSystems) {
 
 TEST(SocDescriptor, SocDescriptorBlackholeMultipleCoordinateSystems) {
     SocDescriptor soc_desc(
-        test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"), {.noc_translation_enabled = true});
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml")),
+        {.noc_translation_enabled = true});
 
     const std::vector<tt_xy_pair> cores_noc0 = blackhole::TENSIX_CORES_NOC0;
 
@@ -389,7 +403,7 @@ TEST(SocDescriptor, SocDescriptorBlackholeMultipleCoordinateSystems) {
 TEST(SocDescriptor, SocDescriptorWormholeNoLogicalForHarvestedCores) {
     const HarvestingMasks harvesting_masks = {.tensix_harvesting_mask = 1};
     SocDescriptor soc_desc(
-        test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"),
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml")),
         {.noc_translation_enabled = true, .harvesting_masks = harvesting_masks});
 
     EXPECT_THROW(soc_desc.get_harvested_cores(CoreType::TENSIX, CoordSystem::LOGICAL), std::runtime_error);
@@ -402,7 +416,7 @@ TEST(SocDescriptor, SocDescriptorWormholeNoLogicalForHarvestedCores) {
 TEST(SocDescriptor, SocDescriptorBlackholeNoLogicalForHarvestedCores) {
     const HarvestingMasks harvesting_masks = {.tensix_harvesting_mask = 1};
     SocDescriptor soc_desc(
-        test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"),
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml")),
         {.noc_translation_enabled = true, .harvesting_masks = harvesting_masks});
 
     EXPECT_THROW(soc_desc.get_harvested_cores(CoreType::TENSIX, CoordSystem::LOGICAL), std::runtime_error);
@@ -417,7 +431,7 @@ TEST(SocDescriptor, NocTranslation) {
     {
         const HarvestingMasks harvesting_masks = {.tensix_harvesting_mask = 1};
         SocDescriptor soc_desc(
-            test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"),
+            std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml")),
             {.noc_translation_enabled = false, .harvesting_masks = harvesting_masks});
 
         const CoreCoord tensix_core = CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::NOC0);
@@ -429,7 +443,7 @@ TEST(SocDescriptor, NocTranslation) {
     {
         const HarvestingMasks harvesting_masks = {.tensix_harvesting_mask = 1};
         SocDescriptor soc_desc(
-            test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml"),
+            std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch_no_eth.yaml")),
             {.noc_translation_enabled = true, .harvesting_masks = harvesting_masks});
 
         const CoreCoord tensix_core = CoreCoord(2, 2, CoreType::TENSIX, CoordSystem::NOC0);
@@ -442,18 +456,18 @@ TEST(SocDescriptor, NocTranslation) {
 TEST(SocDescriptor, BoardBasedPCIE) {
     // Expect invalid configuration to throw an exception.
     EXPECT_ANY_THROW(SocDescriptor soc_desc(
-        test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml"),
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
         {.noc_translation_enabled = true,
          .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask, .pcie_harvesting_mask = 0x1},
          .board_type = BoardType::P150}));
     EXPECT_ANY_THROW(SocDescriptor soc_desc(
-        test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml"),
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
         {.noc_translation_enabled = true,
          .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask},
          .board_type = BoardType::P300,
          .asic_location = 0}));
     EXPECT_ANY_THROW(SocDescriptor soc_desc(
-        test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml"),
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
         {.noc_translation_enabled = true,
          .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask},
          .board_type = BoardType::P300,
@@ -461,7 +475,7 @@ TEST(SocDescriptor, BoardBasedPCIE) {
 
     {
         SocDescriptor soc_desc(
-            test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml"),
+            std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
             {.noc_translation_enabled = true,
              .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask, .pcie_harvesting_mask = 0x1},
              .board_type = BoardType::P100});
@@ -473,7 +487,7 @@ TEST(SocDescriptor, BoardBasedPCIE) {
 
     {
         SocDescriptor soc_desc(
-            test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml"),
+            std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
             {.noc_translation_enabled = true,
              .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask, .pcie_harvesting_mask = 0x2},
              .board_type = BoardType::P150});
@@ -485,7 +499,7 @@ TEST(SocDescriptor, BoardBasedPCIE) {
 
     {
         SocDescriptor soc_desc(
-            test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml"),
+            std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
             {.noc_translation_enabled = true,
              .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask, .pcie_harvesting_mask = 0x2},
              .board_type = BoardType::P300,
@@ -498,7 +512,7 @@ TEST(SocDescriptor, BoardBasedPCIE) {
 
     {
         SocDescriptor soc_desc(
-            test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml"),
+            std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
             {.noc_translation_enabled = true,
              .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask, .pcie_harvesting_mask = 0x1},
              .board_type = BoardType::P300,
@@ -512,7 +526,7 @@ TEST(SocDescriptor, BoardBasedPCIE) {
     // If board type is not provided, just pass through what was described by the soc descriptor.
     EXPECT_EQ(
         SocDescriptor(
-            test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml"),
+            std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
             {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}})
             .get_cores(CoreType::PCIE)
             .size(),
@@ -541,7 +555,7 @@ TEST(SocDescriptor, WormholeNOC1Cores) {
     // clang-format on
 
     SocDescriptor soc_desc_yaml(
-        test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"),
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml")),
         {.noc_translation_enabled = true, .harvesting_masks = harvesting_masks});
 
     SocDescriptor soc_desc_arch(
@@ -593,7 +607,7 @@ TEST(SocDescriptor, BlackholeNOC1Cores) {
     // clang-format on
 
     SocDescriptor soc_desc_yaml(
-        test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml"),
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
         {.noc_translation_enabled = true, .harvesting_masks = harvesting_masks});
 
     SocDescriptor soc_desc_arch(
@@ -629,13 +643,16 @@ TEST(SocDescriptor, AllSocDescriptors) {
         HarvestingMasks harvesting_masks = {
             .eth_harvesting_mask = (arch == tt::ARCH::BLACKHOLE) ? example_eth_harvesting_mask : 0};
 
-        SocDescriptor soc_desc(soc_desc_yaml, {.noc_translation_enabled = true, .harvesting_masks = harvesting_masks});
+        SocDescriptor soc_desc(
+            std::make_shared<SocArchDescriptor>(soc_desc_yaml),
+            {.noc_translation_enabled = true, .harvesting_masks = harvesting_masks});
     }
 }
 
 TEST(SocDescriptor, SocDescriptorWormholeNoSecurityCores) {
     SocDescriptor soc_desc_yaml(
-        test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"), {.noc_translation_enabled = true});
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml")),
+        {.noc_translation_enabled = true});
 
     EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::SECURITY).size(), 0);
 
@@ -646,7 +663,7 @@ TEST(SocDescriptor, SocDescriptorWormholeNoSecurityCores) {
 
 TEST(SocDescriptor, SocDescriptorBlackholeSecurity) {
     SocDescriptor soc_desc_yaml(
-        test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml"),
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
         {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}});
 
     EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::SECURITY).size(), 1);
@@ -660,7 +677,8 @@ TEST(SocDescriptor, SocDescriptorBlackholeSecurity) {
 
 TEST(SocDescriptor, SocDescriptorWormholeNoL2CPUCores) {
     SocDescriptor soc_desc_yaml(
-        test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"), {.noc_translation_enabled = true});
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml")),
+        {.noc_translation_enabled = true});
 
     EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::L2CPU).size(), 0);
 
@@ -671,7 +689,7 @@ TEST(SocDescriptor, SocDescriptorWormholeNoL2CPUCores) {
 
 TEST(SocDescriptor, SocDescriptorBlackholeL2CPU) {
     SocDescriptor soc_desc_yaml(
-        test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml"),
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
         {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}});
 
     EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::L2CPU).size(), 4);
@@ -685,31 +703,32 @@ TEST(SocDescriptor, SocDescriptorBlackholeL2CPU) {
 
 TEST(SocDescriptor, SerializeSimulatorBlackhole) {
     const SocDescriptor& soc_descriptor = SocDescriptor(
-        test_utils::GetSocDescAbsPath("blackhole_simulation_1x2.yaml"),
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_simulation_1x2.yaml")),
         {.noc_translation_enabled = false, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}});
 
     std::filesystem::path file_path = soc_descriptor.serialize_to_file();
     SocDescriptor soc(
-        file_path.string(),
+        std::make_shared<SocArchDescriptor>(file_path.string()),
         {.noc_translation_enabled = soc_descriptor.noc_translation_enabled,
          .harvesting_masks = soc_descriptor.harvesting_masks});
 }
 
 TEST(SocDescriptor, SerializeSimulatorQuasar) {
     const SocDescriptor& soc_descriptor = SocDescriptor(
-        test_utils::GetSocDescAbsPath("quasar_simulation_1x1.yaml"),
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("quasar_simulation_1x1.yaml")),
         {.noc_translation_enabled = false, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}});
 
     std::filesystem::path file_path = soc_descriptor.serialize_to_file();
     SocDescriptor soc(
-        file_path.string(),
+        std::make_shared<SocArchDescriptor>(file_path.string()),
         {.noc_translation_enabled = soc_descriptor.noc_translation_enabled,
          .harvesting_masks = soc_descriptor.harvesting_masks});
 }
 
 TEST(SocDescriptor, SocDescriptorWormholeNoDispatchCores) {
     SocDescriptor soc_desc_yaml(
-        test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml"), {.noc_translation_enabled = true});
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("wormhole_b0_8x10.yaml")),
+        {.noc_translation_enabled = true});
 
     EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::DISPATCH).size(), 0);
 
@@ -720,7 +739,7 @@ TEST(SocDescriptor, SocDescriptorWormholeNoDispatchCores) {
 
 TEST(SocDescriptor, SocDescriptorBlackholeNoDispatchCores) {
     SocDescriptor soc_desc_yaml(
-        test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml"),
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")),
         {.noc_translation_enabled = true, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}});
 
     EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::DISPATCH).size(), 0);
@@ -734,7 +753,8 @@ TEST(SocDescriptor, SocDescriptorBlackholeNoDispatchCores) {
 
 TEST(SocDescriptor, SocDescriptorQuasarNoDispatchCores) {
     SocDescriptor soc_desc_yaml(
-        test_utils::GetSocDescAbsPath("quasar_32_arch.yaml"), {.noc_translation_enabled = true});
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("quasar_32_arch.yaml")),
+        {.noc_translation_enabled = true});
 
     EXPECT_EQ(soc_desc_yaml.get_cores(CoreType::DISPATCH).size(), 0);
 }

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <cstdint>
 #include <initializer_list>
+#include <memory>
 #include <numeric>
 #include <set>
 #include <string>
@@ -17,6 +18,7 @@
 #include "tests/test_utils/device_test_utils.hpp"
 #include "tests/wormhole/test_wh_common.hpp"
 #include "umd/device/cluster.hpp"
+#include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -170,7 +172,7 @@ void run_data_mover_test(
 
 // L1 to L1.
 TEST(GalaxyDataMovement, TwoChipMoveData1) {
-    SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
+    SocDescriptor sdesc(std::make_shared<SocArchDescriptor>(tt::ARCH::WORMHOLE_B0), {.noc_translation_enabled = true});
 
     tt_multichip_core_addr sender_core(4, CoreCoord(18, 18, CoreType::TENSIX, CoordSystem::TRANSLATED), 0x5000);
     tt_multichip_core_addr receiver_core(5, CoreCoord(25, 27, CoreType::TENSIX, CoordSystem::TRANSLATED), 0x6000);
@@ -183,7 +185,7 @@ TEST(GalaxyDataMovement, TwoChipMoveData1) {
 
 // L1 to Dram.
 TEST(GalaxyDataMovement, TwoChipMoveData2) {
-    SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
+    SocDescriptor sdesc(std::make_shared<SocArchDescriptor>(tt::ARCH::WORMHOLE_B0), {.noc_translation_enabled = true});
 
     tt_multichip_core_addr sender_core(1, CoreCoord(19, 20, CoreType::TENSIX, CoordSystem::TRANSLATED), 0x30000);
     tt_multichip_core_addr receiver_core(6, CoreCoord(5, 0, CoreType::DRAM, CoordSystem::TRANSLATED), 0x0);
@@ -196,7 +198,7 @@ TEST(GalaxyDataMovement, TwoChipMoveData2) {
 
 // Dram to L1.
 TEST(GalaxyDataMovement, TwoChipMoveData3) {
-    SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
+    SocDescriptor sdesc(std::make_shared<SocArchDescriptor>(tt::ARCH::WORMHOLE_B0), {.noc_translation_enabled = true});
 
     tt_multichip_core_addr sender_core(8, CoreCoord(5, 9, CoreType::DRAM, CoordSystem::TRANSLATED), 0x90000);
     tt_multichip_core_addr receiver_core(21, CoreCoord(18, 25, CoreType::TENSIX, CoordSystem::TRANSLATED), 0x5200);
@@ -209,7 +211,7 @@ TEST(GalaxyDataMovement, TwoChipMoveData3) {
 
 // Dram to Dram.
 TEST(GalaxyDataMovement, TwoChipMoveData4) {
-    SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
+    SocDescriptor sdesc(std::make_shared<SocArchDescriptor>(tt::ARCH::WORMHOLE_B0), {.noc_translation_enabled = true});
 
     tt_multichip_core_addr sender_core(7, CoreCoord(0, 6, CoreType::DRAM, CoordSystem::TRANSLATED), 0x300000);
     tt_multichip_core_addr receiver_core(19, CoreCoord(0, 0, CoreType::DRAM, CoordSystem::TRANSLATED), 0x300000);
@@ -286,7 +288,7 @@ void run_data_broadcast_test(
 
 // L1 to L1 single chip.
 TEST(GalaxyDataMovement, BroadcastData1) {
-    SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
+    SocDescriptor sdesc(std::make_shared<SocArchDescriptor>(tt::ARCH::WORMHOLE_B0), {.noc_translation_enabled = true});
 
     tt_multichip_core_addr sender_core(4, CoreCoord(18, 18, CoreType::TENSIX, CoordSystem::TRANSLATED), 0x5000);
     std::vector<tt_multichip_core_addr> receiver_cores;
@@ -299,7 +301,7 @@ TEST(GalaxyDataMovement, BroadcastData1) {
 
 // L1 to L1 multi chip.
 TEST(GalaxyDataMovement, BroadcastData2) {
-    SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
+    SocDescriptor sdesc(std::make_shared<SocArchDescriptor>(tt::ARCH::WORMHOLE_B0), {.noc_translation_enabled = true});
 
     tt_multichip_core_addr sender_core(12, CoreCoord(18, 18, CoreType::TENSIX, CoordSystem::TRANSLATED), 0x5000);
     std::vector<tt_multichip_core_addr> receiver_cores;
@@ -341,7 +343,7 @@ TEST(GalaxyDataMovement, BroadcastData2) {
 
 // Dram to L1.
 TEST(GalaxyDataMovement, BroadcastData3) {
-    SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
+    SocDescriptor sdesc(std::make_shared<SocArchDescriptor>(tt::ARCH::WORMHOLE_B0), {.noc_translation_enabled = true});
 
     tt_multichip_core_addr sender_core(10, CoreCoord(0, 0, CoreType::DRAM, CoordSystem::TRANSLATED), 0x20000);
     std::vector<tt_multichip_core_addr> receiver_cores;
@@ -359,7 +361,7 @@ TEST(GalaxyDataMovement, BroadcastData3) {
 
 // L1 to Dram.
 TEST(GalaxyDataMovement, BroadcastData4) {
-    SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
+    SocDescriptor sdesc(std::make_shared<SocArchDescriptor>(tt::ARCH::WORMHOLE_B0), {.noc_translation_enabled = true});
 
     tt_multichip_core_addr sender_core(17, CoreCoord(24, 24, CoreType::TENSIX, CoordSystem::TRANSLATED), 0x20000);
     std::vector<tt_multichip_core_addr> receiver_cores;
@@ -381,7 +383,7 @@ TEST(GalaxyDataMovement, BroadcastData4) {
 
 // Dram to Dram.
 TEST(GalaxyDataMovement, BroadcastData5) {
-    SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
+    SocDescriptor sdesc(std::make_shared<SocArchDescriptor>(tt::ARCH::WORMHOLE_B0), {.noc_translation_enabled = true});
 
     tt_multichip_core_addr sender_core(31, CoreCoord(19, 19, CoreType::TENSIX, CoordSystem::TRANSLATED), 0x20000);
     std::vector<tt_multichip_core_addr> receiver_cores;
@@ -400,7 +402,7 @@ TEST(GalaxyDataMovement, BroadcastData5) {
 // L1 to L1 cores on many chips
 // TODO: Failing with mismatch.
 TEST(GalaxyDataMovement, DISABLED_BroadcastData6) {
-    SocDescriptor sdesc(tt::ARCH::WORMHOLE_B0, {.noc_translation_enabled = true});
+    SocDescriptor sdesc(std::make_shared<SocArchDescriptor>(tt::ARCH::WORMHOLE_B0), {.noc_translation_enabled = true});
     tt_multichip_core_addr sender_core(1, CoreCoord(18, 18, CoreType::TENSIX, CoordSystem::TRANSLATED), 0x5000);
     std::vector<tt_multichip_core_addr> receiver_cores;
     for (int i = 2; i < 33; ++i) {

--- a/tests/simulation/device_fixture.hpp
+++ b/tests/simulation/device_fixture.hpp
@@ -10,11 +10,13 @@
 #include <nng/protocol/pipeline0/pull.h>
 #include <nng/protocol/pipeline0/push.h>
 
+#include <memory>
 #include <stdexcept>
 
 #include "tests/test_utils/fetch_local_files.hpp"
 #include "umd/device/simulation/rtl_simulation_chip.hpp"
 #include "umd/device/simulation/simulation_chip.hpp"
+#include "umd/device/soc_arch_descriptor.hpp"
 
 namespace tt::umd {
 
@@ -27,7 +29,7 @@ protected:
             throw std::runtime_error(
                 "You need to define TT_UMD_SIMULATOR that will point to simulator path. eg. build/versim-wormhole-b0");
         }
-        auto soc_descriptor_path = SimulationChip::get_soc_descriptor_path_from_simulator_path(simulator_path);
+        std::string soc_descriptor_path = SimulationChip::get_soc_descriptor_path_from_simulator_path(simulator_path);
         auto soc_descriptor = SocDescriptor(soc_descriptor_path);
         device = SimulationChip::create(simulator_path, soc_descriptor, 0, 1);
         device->start_device();

--- a/tests/simulation/device_fixture.hpp
+++ b/tests/simulation/device_fixture.hpp
@@ -17,6 +17,7 @@
 #include "umd/device/simulation/rtl_simulation_chip.hpp"
 #include "umd/device/simulation/simulation_chip.hpp"
 #include "umd/device/soc_arch_descriptor.hpp"
+#include "umd/device/soc_descriptor.hpp"
 
 namespace tt::umd {
 
@@ -30,8 +31,9 @@ protected:
                 "You need to define TT_UMD_SIMULATOR that will point to simulator path. eg. build/versim-wormhole-b0");
         }
         std::string soc_descriptor_path = SimulationChip::get_soc_descriptor_path_from_simulator_path(simulator_path);
-        auto soc_descriptor = SocDescriptor(soc_descriptor_path);
-        device = SimulationChip::create(simulator_path, soc_descriptor, 0, 1);
+        std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(soc_descriptor_path);
+        SocDescriptor soc_descriptor = SocDescriptor(sad);
+        device = SimulationChip::create(simulator_path, soc_descriptor, 0, 1);  // TODO
         device->start_device();
     }
 

--- a/tests/simulation/device_fixture.hpp
+++ b/tests/simulation/device_fixture.hpp
@@ -31,9 +31,8 @@ protected:
                 "You need to define TT_UMD_SIMULATOR that will point to simulator path. eg. build/versim-wormhole-b0");
         }
         std::string soc_descriptor_path = SimulationChip::get_soc_descriptor_path_from_simulator_path(simulator_path);
-        std::shared_ptr<SocArchDescriptor> sad = std::make_shared<SocArchDescriptor>(soc_descriptor_path);
-        SocDescriptor soc_descriptor = SocDescriptor(sad);
-        device = SimulationChip::create(simulator_path, soc_descriptor, 0, 1);  // TODO
+        device = SimulationChip::create(
+            simulator_path, SocDescriptor(std::make_shared<SocArchDescriptor>(soc_descriptor_path)), 0, 1);
         device->start_device();
     }
 

--- a/tests/unified/multiprocess.cpp
+++ b/tests/unified/multiprocess.cpp
@@ -231,7 +231,7 @@ TEST(Multiprocess, WorkloadVSMonitor) {
         tt_device->set_power_state(true);
         tt_device->init_tt_device();
 
-        SocDescriptor soc_desc = SocDescriptor(tt_device->get_arch(), tt_device->get_chip_info());
+        const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
         CoreCoord arc_core = soc_desc.get_cores(CoreType::ARC, CoordSystem::TRANSLATED)[0];
 
         std::cout << "Running only reads for low level monitor cluster, without device start " << std::endl;
@@ -257,7 +257,7 @@ TEST(Multiprocess, LongLivedMonitor) {
         tt_device->set_power_state(true);
         tt_device->init_tt_device();
 
-        SocDescriptor soc_desc = SocDescriptor(tt_device->get_arch(), tt_device->get_chip_info());
+        const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
         CoreCoord arc_core = soc_desc.get_cores(CoreType::ARC, CoordSystem::TRANSLATED)[0];
 
         std::cout << "Running only reads for low level monitor cluster, without device start " << std::endl;
@@ -357,7 +357,7 @@ TEST(Multiprocess, DMAWriteReadRaceCondition) {
             tt_device->set_power_state(true);
             tt_device->init_tt_device();
 
-            SocDescriptor soc_desc = SocDescriptor(tt_device->get_arch(), tt_device->get_chip_info());
+            const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
             CoreCoord tensix_core = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
 
             // Create unique data pattern for this process.
@@ -432,7 +432,7 @@ TEST(Multiprocess, DMAWriteReadRaceConditionProcessIsolation) {
             tt_device->set_power_state(true);
             tt_device->init_tt_device();
 
-            SocDescriptor soc_desc = SocDescriptor(tt_device->get_arch(), tt_device->get_chip_info());
+            const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
             CoreCoord tensix_core = soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
 
             // Create unique data pattern for this process.

--- a/tests/wormhole/test_remote_communication_wh.cpp
+++ b/tests/wormhole/test_remote_communication_wh.cpp
@@ -106,7 +106,7 @@ TEST(RemoteCommunicationWormhole, BasicRemoteCommunicationIO) {
 // This test verifies that chunking works correctly when sysmem_manager is nullptr.
 TEST(RemoteCommunicationWormhole, LargeTransferNoSysmem) {
     // Discover cluster topology.
-    auto [cluster_desc, _] = TopologyDiscovery::discover(TopologyDiscoveryOptions{});
+    auto [cluster_desc, devices] = TopologyDiscovery::discover(TopologyDiscoveryOptions{});
 
     // Find a remote chip.
     std::optional<ChipId> remote_chip_id;
@@ -121,23 +121,10 @@ TEST(RemoteCommunicationWormhole, LargeTransferNoSysmem) {
         GTEST_SKIP() << "No remote chips found. Test requires at least one remote chip. Skipping test.";
     }
 
-    ChipId local_chip_id = cluster_desc->get_closest_mmio_capable_chip(*remote_chip_id);
-    int physical_device_id = cluster_desc->get_chips_with_mmio().at(local_chip_id);
-    std::unique_ptr<TTDevice> local_tt_device = TTDevice::create(physical_device_id);
-    local_tt_device->set_power_state(true);
-    local_tt_device->init_tt_device();
-
-    SocDescriptor local_soc_descriptor = SocDescriptor(local_tt_device->get_arch(), local_tt_device->get_chip_info());
-    EthCoord target_chip = cluster_desc->get_chip_locations().at(*remote_chip_id);
-    auto remote_communication = RemoteCommunication::create_remote_communication(
-        local_tt_device.get(), target_chip, nullptr);  // nullptr for sysmem_manager
-    remote_communication->set_remote_transfer_ethernet_cores(
-        local_soc_descriptor.get_eth_xy_pairs_for_channels(cluster_desc->get_active_eth_channels(local_chip_id)));
-    std::unique_ptr<TTDevice> remote_tt_device = TTDevice::create(std::move(remote_communication));
-    remote_tt_device->init_tt_device();
+    TTDevice* remote_tt_device = devices.at(remote_chip_id.value()).get();
+    const SocDescriptor& remote_soc_desc = remote_tt_device->get_soc_descriptor();
 
     // Get a tensix core to test on.
-    SocDescriptor remote_soc_desc(remote_tt_device->get_arch(), remote_tt_device->get_chip_info());
     auto tensix_core = *remote_soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED).begin();
     tt_xy_pair tensix_core_xy = tt_xy_pair(tensix_core.x, tensix_core.y);
 
@@ -175,6 +162,4 @@ TEST(RemoteCommunicationWormhole, LargeTransferNoSysmem) {
         ASSERT_EQ(data_to_write[i], data_read[i]) << "Data mismatch at index " << i << ": expected 0x" << std::hex
                                                   << data_to_write[i] << " but got 0x" << data_read[i];
     }
-
-    local_tt_device->set_power_state(false);
 }

--- a/tests/wormhole/test_remote_communication_wh.cpp
+++ b/tests/wormhole/test_remote_communication_wh.cpp
@@ -162,4 +162,5 @@ TEST(RemoteCommunicationWormhole, LargeTransferNoSysmem) {
         ASSERT_EQ(data_to_write[i], data_read[i]) << "Data mismatch at index " << i << ": expected 0x" << std::hex
                                                   << data_to_write[i] << " but got 0x" << data_read[i];
     }
+    remote_tt_device->get_remote_communication()->get_local_device()->set_power_state(false);
 }


### PR DESCRIPTION
### Issue
#1716 #1163

### Description
Clean up SocDescriptor constructors. SocDescriptor should only be constructable with a SocArchDescriptor and runtime info, the reason being to promote sharing SocArchDescriptors between individual SocDescriptors, something that will be implemented in a follow-up PR.

The PR also goes through each individual SocDescriptor construction and removes ones deemed unnecessary since the introduction of SocDescriptors in TTDevice, saving up memory.

### List of the changes
- Remove default. arch and YAML constructors of SocDescriptor. The only one remaining requires an existing SocArchDescriptor.
- Move private `format_node()` helper from SocDescriptor to SocArchDescriptor where it is used, remove include.
- Change SocArchDescriptor builder method `create` to be a constructor. This class does not need a builder method as it will not be inherited from.
- Remove unnecessary creation of duplicate SocDescriptors by using the one owned by TTDevice.

### Testing
CI

### API Changes
There are API changes in this PR:
- tt-metal: https://github.com/tenstorrent/tt-metal/pull/43472/changes (already merged)