### PR TITLE
Move broadcast fallback implementation in Cluster

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1012,6 +1012,14 @@ void Cluster::broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOption
         // Nowhere to broadcast to.
         return;
     }
+    // If ethernet broadcast is not supported, do it one by one.
+    if (!use_ethernet_broadcast) {
+        for (auto& chip_id : all_chip_ids_) {
+            get_chip(chip_id)->send_tensix_risc_reset(soft_resets);
+        }
+        return;
+    }
+
     auto valid = soft_resets & ALL_TENSIX_SOFT_RESET;
     uint32_t valid_val = (std::underlying_type<TensixSoftResetOptions>::type)valid;
     std::set<ChipId> chips_to_exclude = {};

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -753,63 +753,27 @@ void Cluster::ethernet_broadcast_write(
     const std::set<uint32_t>& rows_to_exclude,
     std::set<uint32_t>& cols_to_exclude,
     bool use_translated_coords) {
-    if (use_ethernet_broadcast) {
-        // Broadcast through ERISC core supported.
-        std::unordered_map<ChipId, std::vector<std::vector<int>>>& broadcast_headers =
-            get_ethernet_broadcast_headers(chips_to_exclude);
-        // Apply row and column exclusion mask explictly. Placing this here if we want to cache the higher level
-        // broadcast headers on future/
-        std::uint32_t row_exclusion_mask = 0;
-        std::uint32_t col_exclusion_mask = 0;
-        for (const auto& row : rows_to_exclude) {
-            row_exclusion_mask |= 1 << row;
-        }
+    // Broadcast through ERISC core supported.
+    std::unordered_map<ChipId, std::vector<std::vector<int>>>& broadcast_headers =
+        get_ethernet_broadcast_headers(chips_to_exclude);
+    // Apply row and column exclusion mask explictly. Placing this here if we want to cache the higher level
+    // broadcast headers on future/
+    std::uint32_t row_exclusion_mask = 0;
+    std::uint32_t col_exclusion_mask = 0;
+    for (const auto& row : rows_to_exclude) {
+        row_exclusion_mask |= 1 << row;
+    }
 
-        for (const auto& col : cols_to_exclude) {
-            col_exclusion_mask |= 1 << (16 + col);
-        }
-        // Write broadcast block to device.
-        for (auto& mmio_group : broadcast_headers) {
-            for (auto& header : mmio_group.second) {
-                header.at(4) = use_translated_coords * 0x8000;  // Reset row/col exclusion masks
-                header.at(4) |= row_exclusion_mask;
-                header.at(4) |= col_exclusion_mask;
-                get_local_chip(mmio_group.first)->ethernet_broadcast_write(mem_ptr, address, size_in_bytes, header);
-            }
-        }
-    } else {
-        // Broadcast not supported. Implement this at the software level as a for loop.
-        // TODO: temporary until the fallback mechanism is moved out in the following PR. Only
-        // broadcast to TENSIX and DRAM cores (matching the supported destinations of the ERISC FW
-        // broadcast). The row/col exclusion masks are bit positions in NOC0 space when
-        // use_translated_coords is false, or in virtual space when true — iterate each core type
-        // in the coord system that matches the exclusion semantics so ETH/ARC/PCIe stay untouched.
-        const CoordSystem iter_coord_system = use_translated_coords ? CoordSystem::TRANSLATED : CoordSystem::NOC0;
-        for (const auto& chip : all_chip_ids_) {
-            if (chips_to_exclude.find(chip) != chips_to_exclude.end()) {
-                continue;
-            }
-            const SocDescriptor& soc = get_soc_descriptor(chip);
-            for (const CoreCoord core : soc.get_cores(CoreType::TENSIX, iter_coord_system)) {
-                uint32_t row_key = core.y;
-                uint32_t col_key = core.x;
-                if (use_translated_coords) {
-                    row_key = wormhole::TRANSLATED_TO_VIRTUAL_Y.at(core.y - wormhole::translated_coordinate_start_y);
-                    col_key = wormhole::TRANSLATED_TO_VIRTUAL_X.at(core.x - wormhole::translated_coordinate_start_x);
-                }
-                if (cols_to_exclude.find(col_key) == cols_to_exclude.end() &&
-                    rows_to_exclude.find(row_key) == rows_to_exclude.end()) {
-                    write_to_device(mem_ptr, size_in_bytes, chip, core, address);
-                }
-            }
-            // DRAM cores have translated coords equal to their NOC0 coords on Wormhole, which also
-            // coincide with their virtual coords, so no remapping is needed.
-            for (const CoreCoord core : soc.get_cores(CoreType::DRAM, iter_coord_system)) {
-                if (cols_to_exclude.find(core.x) == cols_to_exclude.end() &&
-                    rows_to_exclude.find(core.y) == rows_to_exclude.end()) {
-                    write_to_device(mem_ptr, size_in_bytes, chip, core, address);
-                }
-            }
+    for (const auto& col : cols_to_exclude) {
+        col_exclusion_mask |= 1 << (16 + col);
+    }
+    // Write broadcast block to device.
+    for (auto& mmio_group : broadcast_headers) {
+        for (auto& header : mmio_group.second) {
+            header.at(4) = use_translated_coords * 0x8000;  // Reset row/col exclusion masks
+            header.at(4) |= row_exclusion_mask;
+            header.at(4) |= col_exclusion_mask;
+            get_local_chip(mmio_group.first)->ethernet_broadcast_write(mem_ptr, address, size_in_bytes, header);
         }
     }
 }
@@ -883,6 +847,43 @@ void Cluster::broadcast_write_to_cluster(
     std::set<uint32_t>& rows_to_exclude,
     std::set<uint32_t>& columns_to_exclude,
     bool use_translated_coords) {
+    if (!use_ethernet_broadcast) {
+        // Broadcast not supported. Implement this at the software level as a for loop.
+        // TODO: temporary until the fallback mechanism is moved out in the following PR. Only
+        // broadcast to TENSIX and DRAM cores (matching the supported destinations of the ERISC FW
+        // broadcast). The row/col exclusion masks are bit positions in NOC0 space when
+        // use_translated_coords is false, or in virtual space when true — iterate each core type
+        // in the coord system that matches the exclusion semantics so ETH/ARC/PCIe stay untouched.
+        const CoordSystem iter_coord_system = use_translated_coords ? CoordSystem::TRANSLATED : CoordSystem::NOC0;
+        for (const auto& chip : all_chip_ids_) {
+            if (chips_to_exclude.find(chip) != chips_to_exclude.end()) {
+                continue;
+            }
+            const SocDescriptor& soc = get_soc_descriptor(chip);
+            for (const CoreCoord core : soc.get_cores(CoreType::TENSIX, iter_coord_system)) {
+                uint32_t row_key = core.y;
+                uint32_t col_key = core.x;
+                if (use_translated_coords) {
+                    row_key = wormhole::TRANSLATED_TO_VIRTUAL_Y.at(core.y - wormhole::translated_coordinate_start_y);
+                    col_key = wormhole::TRANSLATED_TO_VIRTUAL_X.at(core.x - wormhole::translated_coordinate_start_x);
+                }
+                if (cols_to_exclude.find(col_key) == cols_to_exclude.end() &&
+                    rows_to_exclude.find(row_key) == rows_to_exclude.end()) {
+                    write_to_device(mem_ptr, size_in_bytes, chip, core, address);
+                }
+            }
+            // DRAM cores have translated coords equal to their NOC0 coords on Wormhole, which also
+            // coincide with their virtual coords, so no remapping is needed.
+            for (const CoreCoord core : soc.get_cores(CoreType::DRAM, iter_coord_system)) {
+                if (cols_to_exclude.find(core.x) == cols_to_exclude.end() &&
+                    rows_to_exclude.find(core.y) == rows_to_exclude.end()) {
+                    write_to_device(mem_ptr, size_in_bytes, chip, core, address);
+                }
+            }
+        }
+        return;
+    }
+
     if (arch_name != tt::ARCH::WORMHOLE_B0) {
         UMD_THROW(error::RuntimeError, "Broadcast write is only supported on Wormhole architecture.");
     }
@@ -1026,14 +1027,6 @@ void Cluster::broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOption
         // Nowhere to broadcast to.
         return;
     }
-    // If ethernet broadcast is not supported, do it one by one.
-    if (!use_ethernet_broadcast) {
-        for (auto& chip_id : all_chip_ids_) {
-            get_chip(chip_id)->send_tensix_risc_reset(soft_resets);
-        }
-        return;
-    }
-
     auto valid = soft_resets & ALL_TENSIX_SOFT_RESET;
     uint32_t valid_val = (std::underlying_type<TensixSoftResetOptions>::type)valid;
     std::set<ChipId> chips_to_exclude = {};

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -856,6 +856,15 @@ void Cluster::broadcast_write_to_cluster(
             if (chips_to_exclude.find(chip) != chips_to_exclude.end()) {
                 continue;
             }
+            // Note that DRAM cores on Wormhole are mistakenly still reported as NOC0 even when TRANSLATED coordinates
+            // are requested, so we need to manually adjust the exclusion list to include NOC0 coordinates of DRAM cores
+            // if they're requested in translated space.
+            if (columns_to_exclude.find(16) != columns_to_exclude.end() && use_translated_coords) {
+                columns_to_exclude.insert(0);
+            }
+            if (columns_to_exclude.find(17) != columns_to_exclude.end() && use_translated_coords) {
+                columns_to_exclude.insert(5);
+            }
             for (const CoreType core_type : {CoreType::TENSIX, CoreType::DRAM}) {
                 for (const CoreCoord core : get_soc_descriptor(chip).get_cores(
                          core_type, use_translated_coords ? CoordSystem::TRANSLATED : CoordSystem::NOC0)) {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -849,35 +849,20 @@ void Cluster::broadcast_write_to_cluster(
     bool use_translated_coords) {
     if (!use_ethernet_broadcast) {
         // Broadcast not supported. Implement this at the software level as a for loop.
-        // TODO: temporary until the fallback mechanism is moved out in the following PR. Only
-        // broadcast to TENSIX and DRAM cores (matching the supported destinations of the ERISC FW
+        // Only broadcast to TENSIX and DRAM cores (matching the supported destinations of the ERISC FW
         // broadcast). The row/col exclusion masks are bit positions in NOC0 space when
-        // use_translated_coords is false, or in virtual space when true — iterate each core type
-        // in the coord system that matches the exclusion semantics so ETH/ARC/PCIe stay untouched.
-        const CoordSystem iter_coord_system = use_translated_coords ? CoordSystem::TRANSLATED : CoordSystem::NOC0;
+        // use_translated_coords is false, or in translated space when true.
         for (const auto& chip : all_chip_ids_) {
             if (chips_to_exclude.find(chip) != chips_to_exclude.end()) {
                 continue;
             }
-            const SocDescriptor& soc = get_soc_descriptor(chip);
-            for (const CoreCoord core : soc.get_cores(CoreType::TENSIX, iter_coord_system)) {
-                uint32_t row_key = core.y;
-                uint32_t col_key = core.x;
-                if (use_translated_coords) {
-                    row_key = wormhole::TRANSLATED_TO_VIRTUAL_Y.at(core.y - wormhole::translated_coordinate_start_y);
-                    col_key = wormhole::TRANSLATED_TO_VIRTUAL_X.at(core.x - wormhole::translated_coordinate_start_x);
-                }
-                if (cols_to_exclude.find(col_key) == cols_to_exclude.end() &&
-                    rows_to_exclude.find(row_key) == rows_to_exclude.end()) {
-                    write_to_device(mem_ptr, size_in_bytes, chip, core, address);
-                }
-            }
-            // DRAM cores have translated coords equal to their NOC0 coords on Wormhole, which also
-            // coincide with their virtual coords, so no remapping is needed.
-            for (const CoreCoord core : soc.get_cores(CoreType::DRAM, iter_coord_system)) {
-                if (cols_to_exclude.find(core.x) == cols_to_exclude.end() &&
-                    rows_to_exclude.find(core.y) == rows_to_exclude.end()) {
-                    write_to_device(mem_ptr, size_in_bytes, chip, core, address);
+            for (const CoreType core_type : {CoreType::TENSIX, CoreType::DRAM}) {
+                for (const CoreCoord core : get_soc_descriptor(chip).get_cores(
+                         core_type, use_translated_coords ? CoordSystem::TRANSLATED : CoordSystem::NOC0)) {
+                    if (columns_to_exclude.find(core.x) == columns_to_exclude.end() &&
+                        rows_to_exclude.find(core.y) == rows_to_exclude.end()) {
+                        write_to_device(mem_ptr, size_in_bytes, chip, core, address);
+                    }
                 }
             }
         }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -856,14 +856,16 @@ void Cluster::broadcast_write_to_cluster(
             if (chips_to_exclude.find(chip) != chips_to_exclude.end()) {
                 continue;
             }
-            // Note that DRAM cores on Wormhole are mistakenly still reported as NOC0 even when TRANSLATED coordinates
-            // are requested, so we need to manually adjust the exclusion list to include NOC0 coordinates of DRAM cores
-            // if they're requested in translated space.
-            if (columns_to_exclude.find(16) != columns_to_exclude.end() && use_translated_coords) {
-                columns_to_exclude.insert(0);
-            }
-            if (columns_to_exclude.find(17) != columns_to_exclude.end() && use_translated_coords) {
-                columns_to_exclude.insert(5);
+            if (use_translated_coords && arch_name == tt::ARCH::WORMHOLE_B0) {
+                // Note that DRAM cores on Wormhole are mistakenly still reported as NOC0 even when TRANSLATED
+                // coordinates are requested, so we need to manually adjust the exclusion list to include NOC0
+                // coordinates of DRAM cores if they're requested in translated space.
+                if (columns_to_exclude.find(16) != columns_to_exclude.end()) {
+                    columns_to_exclude.insert(0);
+                }
+                if (columns_to_exclude.find(17) != columns_to_exclude.end()) {
+                    columns_to_exclude.insert(5);
+                }
             }
             for (const CoreType core_type : {CoreType::TENSIX, CoreType::DRAM}) {
                 for (const CoreCoord core : get_soc_descriptor(chip).get_cores(
@@ -1036,15 +1038,13 @@ void Cluster::broadcast_tensix_risc_reset_to_cluster(const TensixSoftResetOption
     std::set<uint32_t> columns_to_exclude;
     if (arch_name == tt::ARCH::BLACKHOLE) {
         if (use_translated_coords_for_eth_broadcast) {
-            rows_to_exclude = {0, 1};
-            columns_to_exclude = {0, 8, 9};
-        } else {
             // PCIE and ETH are on these rows in translated space.
-            // Note: But the algorithm won't ever try even writing to them, since ethernet broadcast is disabled for
-            // blackhole.
             rows_to_exclude = {24, 25};
             // DRAM is on these columns in translated space.
             columns_to_exclude = {17, 18};
+        } else {
+            rows_to_exclude = {0, 1};
+            columns_to_exclude = {0, 8, 9};
         }
     } else if (arch_name == tt::ARCH::WORMHOLE_B0) {
         if (use_translated_coords_for_eth_broadcast) {

--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -703,13 +703,13 @@ TEST_F(TestDeviceIOFixture, RegReadWrite) {
         uint32_t readback_value = 0;
         cluster->read_from_device_reg(&readback_value, 0, tensix_core, addr, sizeof(readback_value));
 
-        EXPECT_EQ(value, readback_value);
+        ASSERT_EQ(value, readback_value);
 
         if (addr + 4 < l1_size) {
             // Ensure that the garbage value is still there.
             uint32_t readback = 0;
             cluster->read_from_device_reg(&readback, 0, tensix_core, addr + 4, sizeof(readback));
-            EXPECT_EQ(0xDEADBEEF, readback);
+            ASSERT_EQ(0xDEADBEEF, readback);
         }
 
         value += 4;
@@ -737,14 +737,14 @@ TEST_F(TestDeviceIOFixture, WriteDataReadReg) {
     cluster->read_from_device(
         readback_vec.data(), 0, tensix_core, SAFE_IO_L1_ADDRESS, readback_vec.size() * sizeof(uint32_t));
 
-    EXPECT_EQ(write_data_l1, readback_vec);
+    ASSERT_EQ(write_data_l1, readback_vec);
 
     for (size_t i = 0; i < test_size / 4; i++) {
         uint32_t readback_value = 0;
         cluster->read_from_device_reg(
             &readback_value, 0, tensix_core, SAFE_IO_L1_ADDRESS + i * 4, sizeof(readback_value));
 
-        EXPECT_EQ(write_data_l1[i], readback_value);
+        ASSERT_EQ(write_data_l1[i], readback_value);
     }
 }
 

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -438,3 +438,138 @@ TEST(ClusterBH, L2CPUCores) {
         EXPECT_EQ(l2cpu_cores.size() + harvested_l2cpu_cores.size(), 4);
     }
 }
+
+// Unlike WH, which can support both untranslated and translated coordinate spaces, on BH these spaces are overlapping.
+TEST(SiliconDriverBH, VirtualCoordinateBroadcast) {
+    // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly, and that
+    // a broadcast targeting one core type does not leak writes to the other.
+    // Blackhole has no ERISC firmware broadcast, so this exercises the SW fallback in broadcast_write_to_cluster.
+    Cluster cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    set_barrier_params(cluster);
+    auto mmio_devices = cluster.get_target_mmio_device_ids();
+
+    test_utils::safe_test_cluster_start(&cluster);
+
+    std::vector<uint32_t> broadcast_sizes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
+    uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
+    // For BH the broadcast falls back to a per-chip SW loop. Exclude DRAM translated cols (17, 18) plus a couple of
+    // tensix rows/cols (translated cols 1..7, 10..16; rows 2..11) for selective filtering.
+    std::set<uint32_t> rows_to_exclude = {4, 6};
+    std::set<uint32_t> cols_to_exclude = {3, 11, 17, 18};
+    // Exclude all tensix translated columns (1..7, 10..16) so only DRAM (translated cols 17..18) receives the
+    // broadcast.
+    std::set<uint32_t> rows_to_exclude_for_dram_broadcast = {
+        24, 25};  // Exclude ETH and PCIE rows for the DRAM broadcast
+    std::set<uint32_t> cols_to_exclude_for_dram_broadcast = {1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13, 14, 15, 16};
+
+    // Pre-zero tensix L1 and DRAM at the test address so the "not written" assertions have a known baseline.
+    std::vector<uint32_t> initial_zeros(broadcast_sizes.back(), 0);
+    for (auto chip_id : cluster.get_target_device_ids()) {
+        for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+            cluster.write_to_device(
+                initial_zeros.data(), initial_zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+        }
+        for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+            const CoreCoord core =
+                cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+            cluster.write_to_device(
+                initial_zeros.data(), initial_zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+        }
+    }
+    cluster.wait_for_non_mmio_flush();
+
+    for (const auto& size : broadcast_sizes) {
+        std::vector<uint32_t> vector_to_write(size);
+        std::vector<uint32_t> zeros(size);
+        std::vector<uint32_t> readback_vec = {};
+        for (int i = 0; i < size; i++) {
+            vector_to_write[i] = i;
+            zeros[i] = 0;
+        }
+        // Broadcast to Tensix.
+        cluster.broadcast_write_to_cluster(
+            vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude, true);
+        cluster.wait_for_non_mmio_flush();
+
+        for (auto chip_id : cluster.get_target_device_ids()) {
+            // Tensix cores received the broadcast; zero them out.
+            for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+                const CoreCoord translated_core =
+                    cluster.get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
+                if (rows_to_exclude.find(translated_core.y) != rows_to_exclude.end()) {
+                    continue;
+                }
+                if (cols_to_exclude.find(translated_core.x) != cols_to_exclude.end()) {
+                    continue;
+                }
+                test_utils::read_data_from_device(
+                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from chip " << chip_id << " core " << core.str()
+                    << " does not match what was broadcasted for size " << size;
+                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+                readback_vec = {};
+            }
+            // DRAM cores must NOT have been written by the tensix broadcast.
+            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+                const CoreCoord core =
+                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                test_utils::read_data_from_device(
+                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                ASSERT_EQ(zeros, readback_vec) << "DRAM core " << chip_id << " " << core.str()
+                                               << " was modified by tensix broadcast for size " << size;
+                readback_vec = {};
+            }
+        }
+        cluster.wait_for_non_mmio_flush();
+
+        // Broadcast to DRAM.
+        cluster.broadcast_write_to_cluster(
+            vector_to_write.data(),
+            vector_to_write.size() * 4,
+            address,
+            {},
+            rows_to_exclude_for_dram_broadcast,
+            cols_to_exclude_for_dram_broadcast,
+            true);
+        cluster.wait_for_non_mmio_flush();
+
+        for (auto chip_id : cluster.get_target_device_ids()) {
+            // DRAM cores received the broadcast.
+            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+                const CoreCoord core =
+                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                test_utils::read_data_from_device(
+                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from DRAM core " << chip_id << " " << core.str()
+                    << " does not match what was broadcasted for size " << size;
+                readback_vec = {};
+            }
+            // Tensix cores must NOT have been written by the DRAM broadcast.
+            for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+                const CoreCoord translated_core =
+                    cluster.get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
+                if (rows_to_exclude.find(translated_core.y) != rows_to_exclude.end()) {
+                    continue;
+                }
+                if (cols_to_exclude.find(translated_core.x) != cols_to_exclude.end()) {
+                    continue;
+                }
+                test_utils::read_data_from_device(
+                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                ASSERT_EQ(zeros, readback_vec) << "Tensix core " << chip_id << " " << core.str()
+                                               << " was modified by DRAM broadcast for size " << size;
+                readback_vec = {};
+            }
+            // Zero DRAM so the next iteration starts clean.
+            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+                const CoreCoord core =
+                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+            }
+        }
+        cluster.wait_for_non_mmio_flush();
+    }
+    cluster.close_device();
+}

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -437,7 +437,8 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
 }
 
 TEST(SiliconDriverWH, BroadcastWrite) {
-    // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly.
+    // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly, and that
+    // a broadcast targeting one core type does not leak writes to the other.
     Cluster cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
     set_barrier_params(cluster);
 
@@ -451,6 +452,22 @@ TEST(SiliconDriverWH, BroadcastWrite) {
     std::set<uint32_t> rows_to_exclude_for_dram_broadcast = {};
     std::set<uint32_t> cols_to_exclude_for_dram_broadcast = {1, 2, 3, 4, 6, 7, 8, 9};
 
+    // Pre-zero tensix L1 and DRAM at the test address so the "not written" assertions have a known baseline.
+    std::vector<uint32_t> initial_zeros(broadcast_sizes.back(), 0);
+    for (auto chip_id : cluster.get_target_device_ids()) {
+        for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+            cluster.write_to_device(
+                initial_zeros.data(), initial_zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+        }
+        for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+            const CoreCoord core =
+                cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+            cluster.write_to_device(
+                initial_zeros.data(), initial_zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+        }
+    }
+    cluster.wait_for_non_mmio_flush();
+
     for (const auto& size : broadcast_sizes) {
         std::vector<uint32_t> vector_to_write(size);
         std::vector<uint32_t> zeros(size);
@@ -463,6 +480,34 @@ TEST(SiliconDriverWH, BroadcastWrite) {
         cluster.broadcast_write_to_cluster(
             vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude, false);
         cluster.wait_for_non_mmio_flush();
+
+        for (auto chip_id : cluster.get_target_device_ids()) {
+            // Tensix cores received the broadcast; zero them out.
+            for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+                if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
+                    continue;
+                }
+                test_utils::read_data_from_device(
+                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from chip " << chip_id << " core " << core.str()
+                    << " does not match what was broadcasted for size " << size;
+                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+                readback_vec = {};
+            }
+            // DRAM cores must NOT have been written by the tensix broadcast.
+            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+                const CoreCoord core =
+                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                test_utils::read_data_from_device(
+                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                ASSERT_EQ(zeros, readback_vec) << "DRAM core " << chip_id << " " << core.str()
+                                               << " was modified by tensix broadcast for size " << size;
+                readback_vec = {};
+            }
+        }
+        cluster.wait_for_non_mmio_flush();
+
         // Broadcast to DRAM.
         cluster.broadcast_write_to_cluster(
             vector_to_write.data(),
@@ -475,23 +520,7 @@ TEST(SiliconDriverWH, BroadcastWrite) {
         cluster.wait_for_non_mmio_flush();
 
         for (auto chip_id : cluster.get_target_device_ids()) {
-            for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
-                if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
-                    continue;
-                }
-                test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
-                ASSERT_EQ(vector_to_write, readback_vec)
-                    << "Vector read back from chip " << chip_id << " core " << core.str()
-                    << " does not match what was broadcasted for size " << size;
-                cluster.write_to_device(
-                    zeros.data(),
-                    zeros.size() * sizeof(std::uint32_t),
-                    chip_id,
-                    core,
-                    address);  // Clear any written data
-                readback_vec = {};
-            }
+            // DRAM cores received the broadcast.
             for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
                     cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
@@ -500,23 +529,34 @@ TEST(SiliconDriverWH, BroadcastWrite) {
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from DRAM core " << chip_id << " " << core.str()
                     << " does not match what was broadcasted for size " << size;
-                cluster.write_to_device(
-                    zeros.data(),
-                    zeros.size() * sizeof(std::uint32_t),
-                    chip_id,
-                    core,
-                    address);  // Clear any written data
                 readback_vec = {};
             }
+            // Tensix cores must NOT have been written by the DRAM broadcast.
+            for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+                if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
+                    continue;
+                }
+                test_utils::read_data_from_device(
+                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                ASSERT_EQ(zeros, readback_vec) << "Tensix core " << chip_id << " " << core.str()
+                                               << " was modified by DRAM broadcast for size " << size;
+                readback_vec = {};
+            }
+            // Zero DRAM so the next iteration starts clean.
+            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+                const CoreCoord core =
+                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+            }
         }
-        // Wait for data to be cleared before writing next block.
         cluster.wait_for_non_mmio_flush();
     }
     cluster.close_device();
 }
 
 TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
-    // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly.
+    // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly, and that
+    // a broadcast targeting one core type does not leak writes to the other.
     Cluster cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
     set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
@@ -533,6 +573,22 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
     std::set<uint32_t> rows_to_exclude_for_dram_broadcast = {};
     std::set<uint32_t> cols_to_exclude_for_dram_broadcast = {18, 19, 20, 21, 22, 23, 24, 25};
 
+    // Pre-zero tensix L1 and DRAM at the test address so the "not written" assertions have a known baseline.
+    std::vector<uint32_t> initial_zeros(broadcast_sizes.back(), 0);
+    for (auto chip_id : cluster.get_target_device_ids()) {
+        for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+            cluster.write_to_device(
+                initial_zeros.data(), initial_zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+        }
+        for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+            const CoreCoord core =
+                cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+            cluster.write_to_device(
+                initial_zeros.data(), initial_zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+        }
+    }
+    cluster.wait_for_non_mmio_flush();
+
     for (const auto& size : broadcast_sizes) {
         std::vector<uint32_t> vector_to_write(size);
         std::vector<uint32_t> zeros(size);
@@ -545,18 +601,9 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
         cluster.broadcast_write_to_cluster(
             vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude, true);
         cluster.wait_for_non_mmio_flush();
-        // Broadcast to DRAM.
-        cluster.broadcast_write_to_cluster(
-            vector_to_write.data(),
-            vector_to_write.size() * 4,
-            address,
-            {},
-            rows_to_exclude_for_dram_broadcast,
-            cols_to_exclude_for_dram_broadcast,
-            true);
-        cluster.wait_for_non_mmio_flush();
 
         for (auto chip_id : cluster.get_target_device_ids()) {
+            // Tensix cores received the broadcast; zero them out.
             for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
                 const CoreCoord translated_core =
                     cluster.get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
@@ -571,14 +618,35 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from chip " << chip_id << " core " << core.str()
                     << " does not match what was broadcasted for size " << size;
-                cluster.write_to_device(
-                    zeros.data(),
-                    zeros.size() * sizeof(std::uint32_t),
-                    chip_id,
-                    core,
-                    address);  // Clear any written data
+                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
                 readback_vec = {};
             }
+            // DRAM cores must NOT have been written by the tensix broadcast.
+            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+                const CoreCoord core =
+                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                test_utils::read_data_from_device(
+                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                ASSERT_EQ(zeros, readback_vec) << "DRAM core " << chip_id << " " << core.str()
+                                               << " was modified by tensix broadcast for size " << size;
+                readback_vec = {};
+            }
+        }
+        cluster.wait_for_non_mmio_flush();
+
+        // Broadcast to DRAM.
+        cluster.broadcast_write_to_cluster(
+            vector_to_write.data(),
+            vector_to_write.size() * 4,
+            address,
+            {},
+            rows_to_exclude_for_dram_broadcast,
+            cols_to_exclude_for_dram_broadcast,
+            true);
+        cluster.wait_for_non_mmio_flush();
+
+        for (auto chip_id : cluster.get_target_device_ids()) {
+            // DRAM cores received the broadcast.
             for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
                     cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
@@ -587,23 +655,39 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from DRAM core " << chip_id << " " << core.str()
                     << " does not match what was broadcasted for size " << size;
-                cluster.write_to_device(
-                    zeros.data(),
-                    zeros.size() * sizeof(std::uint32_t),
-                    chip_id,
-                    core,
-                    address);  // Clear any written data
                 readback_vec = {};
             }
+            // Tensix cores must NOT have been written by the DRAM broadcast.
+            for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+                const CoreCoord translated_core =
+                    cluster.get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
+                if (rows_to_exclude.find(translated_core.y) != rows_to_exclude.end()) {
+                    continue;
+                }
+                if (cols_to_exclude.find(translated_core.x) != cols_to_exclude.end()) {
+                    continue;
+                }
+                test_utils::read_data_from_device(
+                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                ASSERT_EQ(zeros, readback_vec) << "Tensix core " << chip_id << " " << core.str()
+                                               << " was modified by DRAM broadcast for size " << size;
+                readback_vec = {};
+            }
+            // Zero DRAM so the next iteration starts clean.
+            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+                const CoreCoord core =
+                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+            }
         }
-        // Wait for data to be cleared before writing next block.
         cluster.wait_for_non_mmio_flush();
     }
     cluster.close_device();
 }
 
 TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
-    // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly.
+    // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly, and that
+    // a broadcast targeting one core type does not leak writes to the other.
     Cluster cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
     set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
@@ -619,6 +703,22 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
     // This excludes all tensix columns 18-25 in translated space.
     std::set<uint32_t> rows_to_exclude_for_dram_broadcast = {};
     std::set<uint32_t> cols_to_exclude_for_dram_broadcast = {18, 19, 20, 21, 22, 23, 24, 25};
+
+    // Pre-zero tensix L1 and DRAM on every chip so the "not written" assertions have a known baseline.
+    std::vector<uint32_t> initial_zeros(broadcast_sizes.back(), 0);
+    for (auto chip_id : cluster.get_target_device_ids()) {
+        for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+            cluster.write_to_device(
+                initial_zeros.data(), initial_zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+        }
+        for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+            const CoreCoord core =
+                cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+            cluster.write_to_device(
+                initial_zeros.data(), initial_zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+        }
+    }
+    cluster.wait_for_non_mmio_flush();
 
     for (auto chip_id : cluster.get_target_device_ids()) {
         for (const auto& size : broadcast_sizes) {
@@ -644,17 +744,7 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
                 true);
             cluster.wait_for_non_mmio_flush();
 
-            // Broadcast to DRAM.
-            cluster.broadcast_write_to_cluster(
-                vector_to_write.data(),
-                vector_to_write.size() * 4,
-                address,
-                chips_to_exclude,
-                rows_to_exclude_for_dram_broadcast,
-                cols_to_exclude_for_dram_broadcast,
-                true);
-            cluster.wait_for_non_mmio_flush();
-
+            // Tensix cores received the broadcast; zero them out.
             for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
                 const CoreCoord translated_core =
                     cluster.get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
@@ -669,14 +759,33 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from chip " << chip_id << " core " << core.str()
                     << " does not match what was broadcasted for size " << size;
-                cluster.write_to_device(
-                    zeros.data(),
-                    zeros.size() * sizeof(std::uint32_t),
-                    chip_id,
-                    core,
-                    address);  // Clear any written data
+                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
                 readback_vec = {};
             }
+            // DRAM cores must NOT have been written by the tensix broadcast.
+            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+                const CoreCoord core =
+                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                test_utils::read_data_from_device(
+                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                ASSERT_EQ(zeros, readback_vec) << "DRAM core " << chip_id << " " << core.str()
+                                               << " was modified by tensix broadcast for size " << size;
+                readback_vec = {};
+            }
+            cluster.wait_for_non_mmio_flush();
+
+            // Broadcast to DRAM.
+            cluster.broadcast_write_to_cluster(
+                vector_to_write.data(),
+                vector_to_write.size() * 4,
+                address,
+                chips_to_exclude,
+                rows_to_exclude_for_dram_broadcast,
+                cols_to_exclude_for_dram_broadcast,
+                true);
+            cluster.wait_for_non_mmio_flush();
+
+            // DRAM cores received the broadcast.
             for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
                     cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
@@ -685,17 +794,32 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from DRAM core " << chip_id << " " << core.str()
                     << " does not match what was broadcasted for size " << size;
-                cluster.write_to_device(
-                    zeros.data(),
-                    zeros.size() * sizeof(std::uint32_t),
-                    chip_id,
-                    core,
-                    address);  // Clear any written data
                 readback_vec = {};
             }
+            // Tensix cores must NOT have been written by the DRAM broadcast.
+            for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+                const CoreCoord translated_core =
+                    cluster.get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
+                if (rows_to_exclude.find(translated_core.y) != rows_to_exclude.end()) {
+                    continue;
+                }
+                if (cols_to_exclude.find(translated_core.x) != cols_to_exclude.end()) {
+                    continue;
+                }
+                test_utils::read_data_from_device(
+                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                ASSERT_EQ(zeros, readback_vec) << "Tensix core " << chip_id << " " << core.str()
+                                               << " was modified by DRAM broadcast for size " << size;
+                readback_vec = {};
+            }
+            // Zero DRAM so the next iteration starts clean.
+            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+                const CoreCoord core =
+                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+            }
+            cluster.wait_for_non_mmio_flush();
         }
-        // Wait for data to be cleared before writing next block.
-        cluster.wait_for_non_mmio_flush();
     }
     cluster.close_device();
 }


### PR DESCRIPTION
### Issue
#2521 

### Description
Move fallback mechanism to the top. This is in preparation to extract EthernetBroadcast specific functionality out of the Cluster. This fallback will be left in Cluster

### List of the changes
- Move broadcast fallback implementation to the beginning of broadcast_write_to_cluster, from inside ethernet_broadcast_write function
- Let Blackhole case now fall through to this code.

### Testing
Existing CI tests should cover this path

### API Changes
There are no API changes in this PR.
