### PR TITLE
Remove ethernet broadcast's dependancy on Cluster and Chip

### DIFF
--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -17,7 +17,6 @@
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
-#include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -25,7 +24,6 @@
 #include "umd/device/utils/robust_mutex.hpp"
 
 namespace tt::umd {
-class RemoteCommunication;
 class SocDescriptor;
 class SysmemManager;
 class TLBManager;
@@ -77,9 +75,6 @@ public:
     void dma_read_from_device(void* dst, size_t size, CoreCoord core, uint64_t addr) override;
     void dma_multicast_write(void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
 
-    void ethernet_broadcast_write(
-        const void* src, uint64_t core_dest, uint32_t size, std::vector<int> broadcast_header);
-
     void wait_for_non_mmio_flush() override;
 
     void l1_membar(const std::unordered_set<CoreCoord>& cores = {}) override;
@@ -98,14 +93,11 @@ private:
         SocDescriptor soc_descriptor,
         std::unique_ptr<TTDevice> tt_device,
         std::unique_ptr<TLBManager> tlb_manager,
-        std::unique_ptr<SysmemManager> sysmem_manager,
-        std::unique_ptr<RemoteCommunication> remote_communication);
+        std::unique_ptr<SysmemManager> sysmem_manager);
 
     std::unique_ptr<TLBManager> tlb_manager_;
     std::unique_ptr<SysmemManager> sysmem_manager_;
     LockManager lock_manager_;
-    // Used only for ethernet broadcast to all remote chips.
-    std::unique_ptr<RemoteCommunication> remote_communication_;
 
     // unique_lock is RAII, so if this member holds an object, the RobustMutex is locked, if it is empty, the
     // RobustMutex is unlocked.

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -27,6 +27,7 @@
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/topology/topology_discovery.hpp"
 #include "umd/device/topology/topology_discovery_options.hpp"
+#include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
@@ -767,6 +768,7 @@ private:
     std::set<ChipId> remote_chip_ids_;
     std::set<ChipId> local_chip_ids_;
     std::unordered_map<ChipId, std::unique_ptr<Chip>> chips_;
+    std::unordered_map<ChipId, std::unique_ptr<RemoteCommunication>> remote_communications_;
     tt::ARCH arch_name;
 
     std::unique_ptr<ClusterDescriptor> cluster_desc;

--- a/device/api/umd/device/cluster_descriptor.hpp
+++ b/device/api/umd/device/cluster_descriptor.hpp
@@ -232,11 +232,6 @@ public:
      */
     std::set<uint32_t> get_idle_eth_channels(ChipId chip_id);
 
-    /**
-     * Galaxy specific function.
-     */
-    ChipId get_shelf_local_physical_chip_coords(ChipId virtual_coord);
-
     uint8_t get_asic_location(ChipId chip_id) const;
 
     IODeviceType get_io_device_type() const;

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -28,7 +28,6 @@
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
 #include "umd/device/soc_descriptor.hpp"
-#include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_types.hpp"
@@ -75,7 +74,6 @@ std::unique_ptr<LocalChip> LocalChip::create(
     std::unique_ptr<TTDevice> tt_device, const SocDescriptor& soc_descriptor, int num_host_mem_channels) {
     std::unique_ptr<TLBManager> tlb_manager = nullptr;
     std::unique_ptr<SysmemManager> sysmem_manager = nullptr;
-    std::unique_ptr<RemoteCommunication> remote_communication = nullptr;
 
     // The variables below are only needed when using PCIe.
     // JTAG(currently the only communication protocol other than PCIe) has no use of them.
@@ -83,29 +81,19 @@ std::unique_ptr<LocalChip> LocalChip::create(
         tlb_manager = std::make_unique<TLBManager>(tt_device.get());
         sysmem_manager = std::make_unique<SiliconSysmemManager>(tt_device.get(), num_host_mem_channels);
     }
-    // Note that the eth_coord is not important here since this is only used for eth broadcasting.
-    SysmemManager* sysmem_ptr =
-        (sysmem_manager != nullptr && sysmem_manager->get_num_host_mem_channels() > 0) ? sysmem_manager.get() : nullptr;
-    remote_communication = RemoteCommunication::create_remote_communication(tt_device.get(), {0, 0, 0, 0}, sysmem_ptr);
 
-    return std::unique_ptr<LocalChip>(new LocalChip(
-        soc_descriptor,
-        std::move(tt_device),
-        std::move(tlb_manager),
-        std::move(sysmem_manager),
-        std::move(remote_communication)));
+    return std::unique_ptr<LocalChip>(
+        new LocalChip(soc_descriptor, std::move(tt_device), std::move(tlb_manager), std::move(sysmem_manager)));
 }
 
 LocalChip::LocalChip(
     SocDescriptor soc_descriptor,
     std::unique_ptr<TTDevice> tt_device,
     std::unique_ptr<TLBManager> tlb_manager,
-    std::unique_ptr<SysmemManager> sysmem_manager,
-    std::unique_ptr<RemoteCommunication> remote_communication) :
+    std::unique_ptr<SysmemManager> sysmem_manager) :
     Chip(tt_device->get_chip_info(), std::move(soc_descriptor)),
     tlb_manager_(std::move(tlb_manager)),
     sysmem_manager_(std::move(sysmem_manager)),
-    remote_communication_(std::move(remote_communication)),
     tt_device_(std::move(tt_device)) {
     tt_device_->set_power_state(true);
     wait_chip_to_be_ready();
@@ -120,7 +108,6 @@ LocalChip::~LocalChip() {
     tt_device_->set_power_state(false);
     cached_wc_tlb_window.reset();
     cached_uc_tlb_window.reset();
-    remote_communication_.reset();
     sysmem_manager_.reset();
     tlb_manager_.reset();
     tt_device_.reset();
@@ -405,39 +392,11 @@ void LocalChip::read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_sr
     tlb_window->read_register(reg_src - tlb_window->get_base_address(), dest, size);
 }
 
-void LocalChip::ethernet_broadcast_write(
-    const void* src, uint64_t core_dest, uint32_t size, std::vector<int> broadcast_header) {
-    // Depending on the device type, the implementation may vary.
-    // Currently JTAG doesn't support remote communication.
-    if (!remote_communication_) {
-        UMD_THROW(
-            error::RuntimeError,
-            fmt::format(
-                "Ethernet remote transfer is currently not supported for {} devices.",
-                DeviceTypeToString.at(tt_device_->get_communication_device_type())));
-    }
+void LocalChip::wait_for_non_mmio_flush() {}
 
-    // target_chip and target_core are ignored when broadcast is enabled.
-    remote_communication_->write_to_non_mmio({0, 0}, src, core_dest, size, true, std::move(broadcast_header));
-}
+void LocalChip::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>&) {}
 
-void LocalChip::wait_for_non_mmio_flush() {
-    if (remote_communication_) {
-        remote_communication_->wait_for_non_mmio_flush();
-    }
-}
-
-void LocalChip::set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) {
-    // Set cores to be used by the broadcast communication.
-    remote_communication_->set_remote_transfer_ethernet_cores(
-        get_soc_descriptor().translate_coords_to_xy_pair(cores, CoordSystem::TRANSLATED));
-}
-
-void LocalChip::set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) {
-    // Set cores to be used by the broadcast communication.
-    remote_communication_->set_remote_transfer_ethernet_cores(
-        get_soc_descriptor().get_eth_xy_pairs_for_channels(channels, CoordSystem::TRANSLATED));
-}
+void LocalChip::set_remote_transfer_ethernet_cores(const std::set<uint32_t>&) {}
 
 std::unique_lock<RobustMutex> LocalChip::acquire_mutex(const std::string& mutex_name, int pci_device_id) {
     return lock_manager_.acquire_mutex(mutex_name, pci_device_id);

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -641,8 +641,8 @@ std::unordered_map<ChipId, std::vector<std::vector<int>>>& Cluster::get_ethernet
         for (const auto& chip : all_chip_ids_) {
             if (chips_to_exclude.find(chip) == chips_to_exclude.end()) {
                 // Get shelf local physical chip id included in broadcast.
-                ChipId physical_chip_id = cluster_desc->get_shelf_local_physical_chip_coords(chip);
                 EthCoord eth_coords = cluster_desc->get_chip_locations().at(chip);
+                ChipId physical_chip_id = 8 * eth_coords.x + eth_coords.y;
                 // Rack word to be set in header.
                 uint32_t rack_word = eth_coords.rack >> 2;
                 // Rack byte to be set in header.

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -223,9 +223,18 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
                 cluster_desc->get_cluster_io_device_type());
         }
 
+        SysmemManager* sysmem_ptr = chip->get_sysmem_manager();
+        if (sysmem_ptr != nullptr && sysmem_ptr->get_num_host_mem_channels() == 0) {
+            sysmem_ptr = nullptr;
+        }
+        remote_communications_[chip_id] =
+            RemoteCommunication::create_remote_communication(chip->get_tt_device(), {0, 0, 0, 0}, sysmem_ptr);
+
         if (cluster_desc->get_arch(chip_id) == tt::ARCH::WORMHOLE_B0) {
             // Remote transfer currently supported only for wormhole.
-            chip->set_remote_transfer_ethernet_cores(cluster_desc->get_active_eth_channels(chip_id));
+            remote_communications_[chip_id]->set_remote_transfer_ethernet_cores(
+                chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(
+                    cluster_desc->get_active_eth_channels(chip_id), CoordSystem::TRANSLATED));
         }
         return chip;
     } else {
@@ -423,7 +432,9 @@ void Cluster::configure_active_ethernet_cores_for_mmio_device(
         }
     }
     // Local chips hold communication primitives for broadcasting, so we have to set this up for them as well.
-    get_local_chip(mmio_chip)->set_remote_transfer_ethernet_cores(active_eth_cores_per_chip);
+    remote_communications_.at(mmio_chip)->set_remote_transfer_ethernet_cores(
+        get_local_chip(mmio_chip)->get_soc_descriptor().translate_coords_to_xy_pair(
+            active_eth_cores_per_chip, CoordSystem::TRANSLATED));
 }
 
 std::set<ChipId> Cluster::get_target_device_ids() { return all_chip_ids_; }
@@ -526,7 +537,9 @@ void Cluster::refresh_cluster_description() {
     for (const ChipId chip_id : local_chip_ids_) {
         if (cluster_desc->get_arch(chip_id) == tt::ARCH::WORMHOLE_B0) {
             const std::set<uint32_t> active_channels = cluster_desc->get_active_eth_channels(chip_id);
-            get_local_chip(chip_id)->set_remote_transfer_ethernet_cores(active_channels);
+            remote_communications_.at(chip_id)->set_remote_transfer_ethernet_cores(
+                get_local_chip(chip_id)->get_soc_descriptor().get_eth_xy_pairs_for_channels(
+                    active_channels, CoordSystem::TRANSLATED));
             for (const ChipId remote_chip_id : remote_chip_ids_) {
                 if (cluster_desc->get_closest_mmio_capable_chip(remote_chip_id) == chip_id) {
                     get_remote_chip(remote_chip_id)->set_remote_transfer_ethernet_cores(active_channels);
@@ -626,6 +639,9 @@ void Cluster::wait_for_non_mmio_flush(const ChipId chip_id) { get_chip(chip_id)-
 void Cluster::wait_for_non_mmio_flush() {
     for (auto& [chip_id, chip] : chips_) {
         chip->wait_for_non_mmio_flush();
+    }
+    for (auto& [chip_id, remote_comm] : remote_communications_) {
+        remote_comm->wait_for_non_mmio_flush();
     }
 }
 
@@ -777,7 +793,8 @@ void Cluster::ethernet_broadcast_write(
             header.at(4) = use_translated_coords * 0x8000;  // Reset row/col exclusion masks
             header.at(4) |= row_exclusion_mask;
             header.at(4) |= col_exclusion_mask;
-            get_local_chip(mmio_group.first)->ethernet_broadcast_write(mem_ptr, address, size_in_bytes, header);
+            remote_communications_.at(mmio_group.first)
+                ->write_to_non_mmio({0, 0}, mem_ptr, address, size_in_bytes, true, header);
         }
     }
 }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -223,15 +223,14 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
                 cluster_desc->get_cluster_io_device_type());
         }
 
-        SysmemManager* sysmem_ptr = chip->get_sysmem_manager();
-        if (sysmem_ptr != nullptr && sysmem_ptr->get_num_host_mem_channels() == 0) {
-            sysmem_ptr = nullptr;
-        }
-        remote_communications_[chip_id] =
-            RemoteCommunication::create_remote_communication(chip->get_tt_device(), {0, 0, 0, 0}, sysmem_ptr);
-
         if (cluster_desc->get_arch(chip_id) == tt::ARCH::WORMHOLE_B0) {
             // Remote transfer currently supported only for wormhole.
+            SysmemManager* sysmem_ptr = chip->get_sysmem_manager();
+            if (sysmem_ptr != nullptr && sysmem_ptr->get_num_host_mem_channels() == 0) {
+                sysmem_ptr = nullptr;
+            }
+            remote_communications_[chip_id] =
+                RemoteCommunication::create_remote_communication(chip->get_tt_device(), {0, 0, 0, 0}, sysmem_ptr);
             remote_communications_[chip_id]->set_remote_transfer_ethernet_cores(
                 chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(
                     cluster_desc->get_active_eth_channels(chip_id), CoordSystem::TRANSLATED));
@@ -423,6 +422,11 @@ Cluster::Cluster(ClusterOptions options) {  // NOLINT(performance-unnecessary-va
 
 void Cluster::configure_active_ethernet_cores_for_mmio_device(
     ChipId mmio_chip, const std::unordered_set<CoreCoord>& active_eth_cores_per_chip) {
+    // Remote communication is only set up on architectures that support it (currently Wormhole). On other
+    // architectures there is nothing to configure for remote ethernet transfers.
+    if (remote_communications_.find(mmio_chip) == remote_communications_.end()) {
+        return;
+    }
     // The ethernet cores that should be used for remote transfer are set in the RemoteCommunication structure.
     // This structure is used by remote chips. So we need to find all remote chips that use the passed in mmio_chip,
     // and set the active ethernet cores for them.

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -662,6 +662,8 @@ std::unordered_map<ChipId, std::vector<std::vector<int>>>& Cluster::get_ethernet
             if (chips_to_exclude.find(chip) == chips_to_exclude.end()) {
                 // Get shelf local physical chip id included in broadcast.
                 EthCoord eth_coords = cluster_desc->get_chip_locations().at(chip);
+                // Legacy way of calculating the chip's place in the grid, dating back from older Galaxy
+                // configurations.
                 ChipId physical_chip_id = 8 * eth_coords.x + eth_coords.y;
                 // Rack word to be set in header.
                 uint32_t rack_word = eth_coords.rack >> 2;

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -933,19 +933,6 @@ const std::unordered_map<ChipId, EthCoord> &ClusterDescriptor::get_chip_location
 // TODO: implement this for Blackhole and old Wormhole configurations.
 const std::unordered_map<ChipId, uint64_t> &ClusterDescriptor::get_chip_unique_ids() const { return chip_unique_ids; }
 
-ChipId ClusterDescriptor::get_shelf_local_physical_chip_coords(ChipId virtual_coord) {
-    UMD_ASSERT(
-        !this->chip_locations.empty(),
-        error::RuntimeError,
-        "Getting physical chip coordinates is only valid for systems where chips have coordinates");
-    // NoC 0 coordinates of chip inside a single rack. Calculated based on Galaxy topology.
-    // See:
-    // https://yyz-gitlab.local.tenstorrent.com/tenstorrent/budabackend/-/wikis/uploads/23e7a5168f38dfb706f9887fde78cb03/image.png
-    int x = get_chip_locations().at(virtual_coord).x;
-    int y = get_chip_locations().at(virtual_coord).y;
-    return 8 * x + y;
-}
-
 // Return map, but filter by enabled active chips.
 const std::unordered_map<ChipId, ChipId> &ClusterDescriptor::get_chips_with_mmio() const { return chips_with_mmio; }
 


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description
In further preparation to extract EthernetBroadcast out of Cluster, remove some of the dependencies of broadcast_write_to_cluster and ethernet_broadcast_write functions.

### List of the changes
- Remove get_shelf_local_physical_chip_coords's only usage, and it's definition in cluster_descriptor
- Make ethernet broadcast use RemoteCommunication directly.
- That also means that LocalChip doesn't need RemoteCommunication anymore, so remove it from there, and keep it in Cluster

### Testing
Existing CI tests should cover this codepath

### API Changes
get_shelf_local_physical_chip_coords removed from ClusterDescriptor and ethernet_broadcast removed from LocalChip
