### PR TITLE
EthernetBroadcast implementation for Single Remote

### DIFF
--- a/device/api/umd/device/tt_device/ethernet_broadcast.hpp
+++ b/device/api/umd/device/tt_device/ethernet_broadcast.hpp
@@ -28,6 +28,11 @@ public:
         const std::unordered_map<ChipId, ChipId>& chip_to_mmio_chip,
         const std::unordered_map<ChipId, RemoteCommunication*>& mmio_remote_comms);
 
+    // A constructor variant to be used for a single remote chip.
+    // Note that the chips_to_exclude parameter should be empty in case this EthernetBroadcast is used for a single
+    // remote chip.
+    EthernetBroadcast(RemoteCommunication* mmio_remote_comms);
+
     void broadcast_write_to_cluster(
         const void* mem_ptr,
         uint32_t size_in_bytes,

--- a/device/api/umd/device/tt_device/ethernet_broadcast.hpp
+++ b/device/api/umd/device/tt_device/ethernet_broadcast.hpp
@@ -76,6 +76,8 @@ private:
     std::unordered_map<ChipId, std::vector<std::vector<int>>>& get_ethernet_broadcast_headers(
         const std::set<ChipId>& chips_to_exclude);
 
+    bool single_remote_chip_ = false;
+
     std::unordered_map<ChipId, EthCoord> chip_locations_;
     std::unordered_map<ChipId, ChipId> chip_to_mmio_chip_;
     std::unordered_map<ChipId, RemoteCommunication*> mmio_remote_comms_;

--- a/device/api/umd/device/tt_device/remote_communication.hpp
+++ b/device/api/umd/device/tt_device/remote_communication.hpp
@@ -67,6 +67,10 @@ public:
     // Which core is used for remote communication can change.
     tt_xy_pair get_remote_transfer_ethernet_core();
 
+    // Sets the sysmem manager used for host-DRAM-backed transfers (required for broadcasts and used to speed up
+    // large transfers).
+    void set_sysmem_manager(SysmemManager* sysmem_manager);
+
 protected:
     void update_active_eth_core_idx();
 

--- a/device/api/umd/device/tt_device/remote_communication.hpp
+++ b/device/api/umd/device/tt_device/remote_communication.hpp
@@ -60,6 +60,8 @@ public:
 
     TTDevice* get_local_device();
 
+    virtual std::optional<EthCoord> get_target_eth_coord() = 0;
+
     // Get the active eth core that will be used for the next remote communication.
     // Which core is used for remote communication can change.
     tt_xy_pair get_remote_transfer_ethernet_core();

--- a/device/api/umd/device/tt_device/remote_communication.hpp
+++ b/device/api/umd/device/tt_device/remote_communication.hpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <set>
 #include <unordered_set>
 #include <vector>

--- a/device/api/umd/device/tt_device/remote_communication_legacy_firmware.hpp
+++ b/device/api/umd/device/tt_device/remote_communication_legacy_firmware.hpp
@@ -43,6 +43,8 @@ public:
 
     void wait_for_non_mmio_flush(const std::chrono::milliseconds timeout_ms = timeout::NON_MMIO_RW_TIMEOUT) override;
 
+    std::optional<EthCoord> get_target_eth_coord() override;
+
 private:
     EthCoord target_chip;
     bool large_transfer_warning_printed_ = false;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -250,7 +250,20 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
         return chip;
     } else {
         ChipId gateway_id = cluster_desc->get_closest_mmio_capable_chip(chip_id);
-        return RemoteChip::create(std::move(tt_device), get_local_chip(gateway_id));
+        LocalChip* gateway_chip = get_local_chip(gateway_id);
+        if (tt_device != nullptr) {
+            if (RemoteCommunication* remote_communication = tt_device->get_remote_communication()) {
+                SysmemManager* sysmem_ptr = gateway_chip->get_sysmem_manager();
+                if (sysmem_ptr != nullptr && sysmem_ptr->get_num_host_mem_channels() == 0) {
+                    sysmem_ptr = nullptr;
+                }
+                // Remote communications created during topology discovery start without one, since sysmem
+                // managers don't exist yet at that point; the owning Cluster wires in the gateway's sysmem manager
+                // afterwards.
+                remote_communication->set_sysmem_manager(sysmem_ptr);
+            }
+        }
+        return RemoteChip::create(std::move(tt_device), gateway_chip);
     }
 }
 

--- a/device/tt_device/ethernet_broadcast.cpp
+++ b/device/tt_device/ethernet_broadcast.cpp
@@ -60,7 +60,9 @@ EthernetBroadcast::EthernetBroadcast(RemoteCommunication* mmio_remote_comms) :
     EthernetBroadcast(
         std::unordered_map<ChipId, EthCoord>{{0, mmio_remote_comms->get_target_eth_coord().value()}},
         std::unordered_map<ChipId, ChipId>{{0, 0}},
-        std::unordered_map<ChipId, RemoteCommunication*>{{0, mmio_remote_comms}}) {}
+        std::unordered_map<ChipId, RemoteCommunication*>{{0, mmio_remote_comms}}) {
+    single_remote_chip_ = true;
+}
 
 void EthernetBroadcast::refresh(
     const std::unordered_map<ChipId, EthCoord>& chip_locations,
@@ -275,6 +277,14 @@ void EthernetBroadcast::broadcast_write_to_cluster(
     std::set<uint32_t>& rows_to_exclude,
     std::set<uint32_t>& columns_to_exclude,
     bool use_translated_coords) {
+    // The single-remote variant synthesizes a target with ChipId 0, so excluding any chip here (including 0)
+    // would silently turn the broadcast into a no-op. Enforce the documented "chips_to_exclude must be empty"
+    // contract rather than letting it misbehave silently.
+    UMD_ASSERT(
+        !single_remote_chip_ || chips_to_exclude.empty(),
+        error::RuntimeError,
+        "chips_to_exclude must be empty when EthernetBroadcast is constructed for a single remote chip.");
+
     std::set<uint32_t> rows_to_exclude_virtual;
     std::set<uint32_t> cols_to_exclude_virtual;
     adjust_coordinates_for_ethernet_broadcast(

--- a/device/tt_device/ethernet_broadcast.cpp
+++ b/device/tt_device/ethernet_broadcast.cpp
@@ -54,6 +54,14 @@ EthernetBroadcast::EthernetBroadcast(
     const std::unordered_map<ChipId, RemoteCommunication*>& mmio_remote_comms) :
     chip_locations_(chip_locations), chip_to_mmio_chip_(chip_to_mmio_chip), mmio_remote_comms_(mmio_remote_comms) {}
 
+// Note that the structures don't rely in any way on ChipIds being correct, the important thing is to pass the
+// correct EthCoord for the remote chip.
+EthernetBroadcast::EthernetBroadcast(RemoteCommunication* mmio_remote_comms) :
+    EthernetBroadcast(
+        std::unordered_map<ChipId, EthCoord>{{0, mmio_remote_comms->get_target_eth_coord().value()}},
+        std::unordered_map<ChipId, ChipId>{{0, 0}},
+        std::unordered_map<ChipId, RemoteCommunication*>{{0, mmio_remote_comms}}) {}
+
 void EthernetBroadcast::refresh(
     const std::unordered_map<ChipId, EthCoord>& chip_locations,
     const std::unordered_map<ChipId, ChipId>& chip_to_mmio_chip,

--- a/device/tt_device/remote_communication.cpp
+++ b/device/tt_device/remote_communication.cpp
@@ -47,6 +47,8 @@ void RemoteCommunication::set_remote_transfer_ethernet_cores(
 
 TTDevice* RemoteCommunication::get_local_device() { return local_tt_device_; }
 
+void RemoteCommunication::set_sysmem_manager(SysmemManager* sysmem_manager) { sysmem_manager_ = sysmem_manager; }
+
 tt_xy_pair RemoteCommunication::get_remote_transfer_ethernet_core() {
     if (remote_transfer_eth_cores_.size() > 8) {
         // We cannot use more than 8 cores for umd access in one direction. Thats because of the available buffering in

--- a/device/tt_device/remote_communication_legacy_firmware.cpp
+++ b/device/tt_device/remote_communication_legacy_firmware.cpp
@@ -50,6 +50,8 @@ RemoteCommunicationLegacyFirmware::RemoteCommunicationLegacyFirmware(
     TTDevice* local_tt_device, EthCoord target_chip, SysmemManager* sysmem_manager) :
     RemoteCommunication(local_tt_device, sysmem_manager), target_chip(target_chip) {}
 
+std::optional<EthCoord> RemoteCommunicationLegacyFirmware::get_target_eth_coord() { return target_chip; }
+
 /*
  *
  *                                       NON_MMIO_MUTEX Usage

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -833,6 +833,8 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
 TEST(SiliconDriverWH, EthernetBroadcastSingleRemotePerChip) {
     // For each remote chip, broadcast a vector to its tensix grid using EthernetBroadcastSingleRemote
     // and verify the data is read back correctly.
+    // Note: this test intentionally only covers the tensix branch. The DRAM branch (the virtual-column 0/5
+    // split logic in broadcast_write_to_cluster) is already exercised by VirtualCoordinateBroadcastPerChip.
     Cluster cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
     set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -24,6 +24,7 @@
 #include "umd/device/chip/chip.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/soc_descriptor.hpp"
+#include "umd/device/tt_device/ethernet_broadcast.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -829,6 +829,88 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
     cluster.close_device();
 }
 
+TEST(SiliconDriverWH, EthernetBroadcastSingleRemotePerChip) {
+    // For each remote chip, broadcast a vector to its tensix grid using EthernetBroadcastSingleRemote
+    // and verify the data is read back correctly.
+    Cluster cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    set_barrier_params(cluster);
+    auto mmio_devices = cluster.get_target_mmio_device_ids();
+
+    test_utils::safe_test_cluster_start(&cluster);
+
+    auto remote_devices = cluster.get_target_remote_device_ids();
+    if (remote_devices.empty()) {
+        cluster.close_device();
+        GTEST_SKIP() << "SiliconDriverWH.EthernetBroadcastSingleRemotePerChip skipped: no remote devices found";
+    }
+
+    auto eth_version = cluster.get_ethernet_firmware_version();
+    bool virtual_bcast_supported = (eth_version >= SemVer(6, 8, 0) || eth_version == SemVer(6, 7, 241)) &&
+                                   cluster.get_soc_descriptor(*mmio_devices.begin()).noc_translation_enabled;
+    if (!virtual_bcast_supported) {
+        cluster.close_device();
+        GTEST_SKIP() << "SiliconDriverWH.EthernetBroadcastSingleRemotePerChip skipped: ethernet version does not "
+                        "support Virtual Coordinate Broadcast or NOC translation is not enabled";
+    }
+
+    std::vector<uint32_t> broadcast_sizes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
+    uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
+    // This excludes DRAM and ETH banks (positioned in 16, 17 on both rows and columns) and some tensix rows and columns
+    // in translated space.
+    std::set<uint32_t> rows_to_exclude = {16, 17, 20, 22, 26, 27};
+    std::set<uint32_t> cols_to_exclude = {16, 17, 20};
+
+    for (auto chip_id : remote_devices) {
+        RemoteChip* remote_chip = cluster.get_remote_chip(chip_id);
+        EthernetBroadcast eth_broadcast(remote_chip->get_remote_communication());
+
+        for (const auto& size : broadcast_sizes) {
+            std::vector<uint32_t> vector_to_write(size);
+            std::vector<uint32_t> zeros(size);
+            std::vector<uint32_t> readback_vec = {};
+            for (int i = 0; i < size; i++) {
+                vector_to_write[i] = i;
+                zeros[i] = 0;
+            }
+
+            eth_broadcast.broadcast_write_to_cluster(
+                vector_to_write.data(),
+                vector_to_write.size() * sizeof(uint32_t),
+                address,
+                {},
+                rows_to_exclude,
+                cols_to_exclude,
+                true);
+            cluster.wait_for_non_mmio_flush(chip_id);
+
+            for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+                const CoreCoord translated_core =
+                    cluster.get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
+                if (rows_to_exclude.find(translated_core.y) != rows_to_exclude.end()) {
+                    continue;
+                }
+                if (cols_to_exclude.find(translated_core.x) != cols_to_exclude.end()) {
+                    continue;
+                }
+                test_utils::read_data_from_device(
+                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * sizeof(uint32_t));
+                ASSERT_EQ(vector_to_write, readback_vec)
+                    << "Vector read back from chip " << chip_id << " core " << core.str()
+                    << " does not match what was broadcasted for size " << size;
+                cluster.write_to_device(
+                    zeros.data(),
+                    zeros.size() * sizeof(std::uint32_t),
+                    chip_id,
+                    core,
+                    address);  // Clear any written data
+                readback_vec = {};
+            }
+        }
+        cluster.wait_for_non_mmio_flush(chip_id);
+    }
+    cluster.close_device();
+}
+
 TEST(SiliconDriverWH, LargeAddressTlb) {
     Cluster cluster;
 


### PR DESCRIPTION
### Issue
#2521 

### Description
This PR modifies extracted EthernetBroadcast functionality, so that it is adapted for use towards a single remote chip

### List of the changes
- Implement a version of EthernetBroadcast constructor which is made so it works only towards one remote chip
- Write a dedicated test just for that

### Testing
Added a test to test the new functionality

### API Changes
This PR has API changes, adds EthernetBroadcast API for single RemoteChip
