### PR TITLE
Implement RemoteProtocol's write to core range

### DIFF
--- a/device/api/umd/device/tt_device/protocol/remote_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/remote_protocol.hpp
@@ -9,9 +9,9 @@
 #include <cstdint>
 #include <memory>
 
+#include "umd/device/tt_device/ethernet_broadcast.hpp"
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/remote_interface.hpp"
-#include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
@@ -43,6 +43,7 @@ public:
 
 private:
     std::unique_ptr<RemoteCommunication> remote_communication_;
+    std::unique_ptr<EthernetBroadcast> ethernet_broadcast_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/remote_communication.hpp
+++ b/device/api/umd/device/tt_device/remote_communication.hpp
@@ -71,6 +71,8 @@ public:
     // large transfers).
     void set_sysmem_manager(SysmemManager* sysmem_manager);
 
+    bool has_sysmem_manager() const;
+
 protected:
     void update_active_eth_core_idx();
 

--- a/device/tt_device/protocol/remote_protocol.cpp
+++ b/device/tt_device/protocol/remote_protocol.cpp
@@ -6,15 +6,22 @@
 
 #include "umd/device/tt_device/protocol/remote_protocol.hpp"
 
+#include <tt-logger/tt-logger.hpp>
 #include <utility>
 
+#include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/tt_device/ethernet_broadcast.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 
 namespace tt::umd {
 
 RemoteProtocol::RemoteProtocol(std::unique_ptr<RemoteCommunication> remote_communication) :
-    remote_communication_(std::move(remote_communication)) {}
+    remote_communication_(std::move(remote_communication)) {
+    if (remote_communication_->has_sysmem_manager()) {
+        ethernet_broadcast_ = std::make_unique<EthernetBroadcast>(remote_communication_.get());
+    }
+}
 
 void RemoteProtocol::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     remote_communication_->write_to_non_mmio(core, mem_ptr, addr, size);
@@ -24,8 +31,54 @@ void RemoteProtocol::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t a
     remote_communication_->read_non_mmio(core, mem_ptr, addr, size);
 }
 
-bool RemoteProtocol::write_to_core_range(const void*, tt_xy_pair, tt_xy_pair, uint64_t, uint32_t, NocId) {
-    return false;
+bool RemoteProtocol::write_to_core_range(
+    const void* mem_ptr, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t address, uint32_t size_in_bytes, NocId noc_id) {
+    if (ethernet_broadcast_ == nullptr) {
+        return false;
+    }
+
+    const bool use_translated_coords = core_start.x >= wormhole::tensix_translated_coordinate_start_x;
+
+    std::set<uint32_t> rows_to_exclude;
+    std::set<uint32_t> columns_to_exclude;
+
+    if (!use_translated_coords) {
+        // NOC0 coordinates: only the full tensix grid is supported.
+        if (core_start.x > 1 || core_start.y > 1 || core_end.x < 9 || core_end.y < 11) {
+            log_debug(
+                LogUMD,
+                "broadcast_write_to_tensix: partial NOC0 ranges not supported for ethernet broadcast, falling back to "
+                "unicast");
+            return false;
+        }
+        // Always filter out the non-TENSIX cores.
+        rows_to_exclude = {0, 6};
+        columns_to_exclude = {0, 5};
+    } else {
+        // Always filter out the non-TENSIX cores.
+        rows_to_exclude = {16, 17};
+        columns_to_exclude = {16, 17};
+        // Translated coordinates: exclude loop indices for any translated address outside [core_start, core_end].
+        for (auto translated_x = wormhole::translated_coordinate_start_x;
+             translated_x < wormhole::translated_coordinate_start_x + wormhole::GRID_SIZE.x;
+             ++translated_x) {
+            if (translated_x < core_start.x || translated_x > core_end.x) {
+                columns_to_exclude.insert(translated_x);
+            }
+        }
+        for (auto translated_y = wormhole::translated_coordinate_start_y;
+             translated_y < wormhole::translated_coordinate_start_y + wormhole::GRID_SIZE.y;
+             ++translated_y) {
+            if (translated_y < core_start.y || translated_y > core_end.y) {
+                rows_to_exclude.insert(translated_y);
+            }
+        }
+    }
+
+    ethernet_broadcast_->broadcast_write_to_cluster(
+        mem_ptr, size_in_bytes, address, {}, rows_to_exclude, columns_to_exclude, use_translated_coords);
+
+    return true;
 }
 
 int RemoteProtocol::get_mmio_id() { return remote_communication_->get_local_device()->get_communication_device_id(); }

--- a/device/tt_device/protocol/remote_protocol.cpp
+++ b/device/tt_device/protocol/remote_protocol.cpp
@@ -13,12 +13,14 @@
 #include "umd/device/tt_device/ethernet_broadcast.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
 
 namespace tt::umd {
 
 RemoteProtocol::RemoteProtocol(std::unique_ptr<RemoteCommunication> remote_communication) :
     remote_communication_(std::move(remote_communication)) {
-    if (remote_communication_->has_sysmem_manager()) {
+    if (remote_communication_->has_sysmem_manager() &&
+        remote_communication_->get_local_device()->get_arch() == tt::ARCH::WORMHOLE_B0) {
         ethernet_broadcast_ = std::make_unique<EthernetBroadcast>(remote_communication_.get());
     }
 }
@@ -44,6 +46,7 @@ bool RemoteProtocol::write_to_core_range(
 
     if (!use_translated_coords) {
         // NOC0 coordinates: only the full tensix grid is supported.
+        // Tensix grid is in range 1,1 to 9,11 as defined in wormhole_implementation.hpp.
         if (core_start.x > 1 || core_start.y > 1 || core_end.x < 9 || core_end.y < 11) {
             log_debug(
                 LogUMD,
@@ -55,6 +58,15 @@ bool RemoteProtocol::write_to_core_range(
         rows_to_exclude = {0, 6};
         columns_to_exclude = {0, 5};
     } else {
+        // Translated coordinates only land correctly when NOC translation is enabled; otherwise the translated grid
+        // is meaningless. Fall back to unicast rather than broadcasting to the wrong cores.
+        if (!remote_communication_->get_local_device()->get_noc_translation_enabled()) {
+            log_debug(
+                LogUMD,
+                "write_to_core_range: NOC translation is not enabled, translated ethernet broadcast not supported, "
+                "falling back to unicast");
+            return false;
+        }
         // Always filter out the non-TENSIX cores.
         rows_to_exclude = {16, 17};
         columns_to_exclude = {16, 17};

--- a/device/tt_device/protocol/remote_protocol.cpp
+++ b/device/tt_device/protocol/remote_protocol.cpp
@@ -34,7 +34,12 @@ void RemoteProtocol::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t a
 }
 
 bool RemoteProtocol::write_to_core_range(
-    const void* mem_ptr, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t address, uint32_t size_in_bytes, NocId noc_id) {
+    const void* mem_ptr,
+    tt_xy_pair core_start,
+    tt_xy_pair core_end,
+    uint64_t address,
+    uint32_t size_in_bytes,
+    NocId noc_id) {
     if (ethernet_broadcast_ == nullptr) {
         return false;
     }

--- a/device/tt_device/protocol/remote_protocol.cpp
+++ b/device/tt_device/protocol/remote_protocol.cpp
@@ -18,12 +18,7 @@
 namespace tt::umd {
 
 RemoteProtocol::RemoteProtocol(std::unique_ptr<RemoteCommunication> remote_communication) :
-    remote_communication_(std::move(remote_communication)) {
-    if (remote_communication_->has_sysmem_manager() &&
-        remote_communication_->get_local_device()->get_arch() == tt::ARCH::WORMHOLE_B0) {
-        ethernet_broadcast_ = std::make_unique<EthernetBroadcast>(remote_communication_.get());
-    }
-}
+    remote_communication_(std::move(remote_communication)) {}
 
 void RemoteProtocol::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     remote_communication_->write_to_non_mmio(core, mem_ptr, addr, size);
@@ -40,6 +35,13 @@ bool RemoteProtocol::write_to_core_range(
     uint64_t address,
     uint32_t size_in_bytes,
     NocId noc_id) {
+    // Construct EthernetBroadcast lazily on the first use. During the constructor the sysmem might not be set yet.
+    if (ethernet_broadcast_ == nullptr && remote_communication_->has_sysmem_manager() &&
+        remote_communication_->get_local_device()->get_arch() == tt::ARCH::WORMHOLE_B0) {
+        ethernet_broadcast_ = std::make_unique<EthernetBroadcast>(remote_communication_.get());
+    }
+
+    // If it is still not constructor, report failure by returning false.
     if (ethernet_broadcast_ == nullptr) {
         return false;
     }
@@ -55,7 +57,7 @@ bool RemoteProtocol::write_to_core_range(
         if (core_start.x > 1 || core_start.y > 1 || core_end.x < 9 || core_end.y < 11) {
             log_debug(
                 LogUMD,
-                "broadcast_write_to_tensix: partial NOC0 ranges not supported for ethernet broadcast, falling back to "
+                "write_to_core_range: partial NOC0 range not supported for ethernet broadcast, falling back to "
                 "unicast");
             return false;
         }

--- a/device/tt_device/remote_communication.cpp
+++ b/device/tt_device/remote_communication.cpp
@@ -49,6 +49,8 @@ TTDevice* RemoteCommunication::get_local_device() { return local_tt_device_; }
 
 void RemoteCommunication::set_sysmem_manager(SysmemManager* sysmem_manager) { sysmem_manager_ = sysmem_manager; }
 
+bool RemoteCommunication::has_sysmem_manager() const { return sysmem_manager_ != nullptr; }
+
 tt_xy_pair RemoteCommunication::get_remote_transfer_ethernet_core() {
     if (remote_transfer_eth_cores_.size() > 8) {
         // We cannot use more than 8 cores for umd access in one direction. Thats because of the available buffering in

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -914,6 +914,96 @@ TEST(SiliconDriverWH, EthernetBroadcastSingleRemotePerChip) {
     cluster.close_device();
 }
 
+TEST(SiliconDriverWH, DeviceProtocolWriteCoreRange) {
+    // Broadcast to a partial tensix grid via DeviceProtocol::write_to_core_range and verify that
+    // cores inside the range received the data while cores outside still hold zeros.
+    Cluster cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    set_barrier_params(cluster);
+    auto mmio_devices = cluster.get_target_mmio_device_ids();
+
+    test_utils::safe_test_cluster_start(&cluster);
+
+    auto remote_devices = cluster.get_target_remote_device_ids();
+    if (remote_devices.empty()) {
+        cluster.close_device();
+        GTEST_SKIP() << "SiliconDriverWH.DeviceProtocolWriteCoreRange skipped: no remote devices found";
+    }
+
+    auto eth_version = cluster.get_ethernet_firmware_version();
+    bool virtual_bcast_supported = (eth_version >= SemVer(6, 8, 0) || eth_version == SemVer(6, 7, 241)) &&
+                                   cluster.get_soc_descriptor(*mmio_devices.begin()).noc_translation_enabled;
+    if (!virtual_bcast_supported) {
+        cluster.close_device();
+        GTEST_SKIP() << "SiliconDriverWH.DeviceProtocolWriteCoreRange skipped: ethernet version does not support "
+                        "Virtual Coordinate Broadcast or NOC translation is not enabled";
+    }
+
+    std::vector<uint32_t> broadcast_sizes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
+    uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
+
+    // Partial range: first half of tensix columns and rows in translated coordinates.
+    const tt_xy_pair core_start = {
+        wormhole::tensix_translated_coordinate_start_x, wormhole::tensix_translated_coordinate_start_y};
+    const tt_xy_pair core_end = {
+        wormhole::tensix_translated_coordinate_start_x + wormhole::TENSIX_GRID_SIZE.x / 2 - 1,
+        wormhole::tensix_translated_coordinate_start_y + wormhole::TENSIX_GRID_SIZE.y / 2 - 1};
+
+    for (auto chip_id : remote_devices) {
+        RemoteChip* remote_chip = cluster.get_remote_chip(chip_id);
+        DeviceProtocol* protocol = remote_chip->get_tt_device()->get_device_protocol();
+        const auto& sdesc = cluster.get_soc_descriptor(chip_id);
+        const auto& tensix_cores = sdesc.get_cores(CoreType::TENSIX);
+
+        for (const auto& size : broadcast_sizes) {
+            std::vector<uint32_t> vector_to_write(size);
+            std::vector<uint32_t> zeros(size, 0);
+            for (uint32_t i = 0; i < size; i++) {
+                vector_to_write[i] = i + 1;
+            }
+
+            // Clear all tensix cores before the broadcast.
+            for (const CoreCoord& core : tensix_cores) {
+                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(uint32_t), chip_id, core, address);
+            }
+            cluster.wait_for_non_mmio_flush(chip_id);
+
+            bool hw_broadcast = protocol->write_to_core_range(
+                vector_to_write.data(), core_start, core_end, address, vector_to_write.size() * sizeof(uint32_t), NocId::NOC0);
+            ASSERT_TRUE(hw_broadcast) << "Expected hardware broadcast to succeed for chip " << chip_id << " size "
+                                      << size;
+            cluster.wait_for_non_mmio_flush(chip_id);
+
+            for (const CoreCoord& core : tensix_cores) {
+                const CoreCoord translated = sdesc.translate_coord_to(core, CoordSystem::TRANSLATED);
+                const bool in_range = translated.x >= core_start.x && translated.x <= core_end.x &&
+                                      translated.y >= core_start.y && translated.y <= core_end.y;
+
+                std::vector<uint32_t> readback_vec;
+                test_utils::read_data_from_device(
+                    cluster, readback_vec, chip_id, core, address, size * sizeof(uint32_t));
+
+                if (in_range) {
+                    ASSERT_EQ(vector_to_write, readback_vec)
+                        << "Core " << core.str() << " (translated " << translated.str()
+                        << ") is inside range and should have written data for size " << size;
+                } else {
+                    ASSERT_EQ(zeros, readback_vec) << "Core " << core.str() << " (translated " << translated.str()
+                                                   << ") is outside range and should still be zero for size " << size;
+                }
+            }
+        }
+
+        // Final cleanup.
+        std::vector<uint32_t> zeros_cleanup(broadcast_sizes.back(), 0);
+        for (const CoreCoord& core : tensix_cores) {
+            cluster.write_to_device(
+                zeros_cleanup.data(), zeros_cleanup.size() * sizeof(uint32_t), chip_id, core, address);
+        }
+        cluster.wait_for_non_mmio_flush(chip_id);
+    }
+    cluster.close_device();
+}
+
 TEST(SiliconDriverWH, LargeAddressTlb) {
     Cluster cluster;
 

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -968,7 +968,12 @@ TEST(SiliconDriverWH, DeviceProtocolWriteCoreRange) {
             cluster.wait_for_non_mmio_flush(chip_id);
 
             bool hw_broadcast = protocol->write_to_core_range(
-                vector_to_write.data(), core_start, core_end, address, vector_to_write.size() * sizeof(uint32_t), NocId::NOC0);
+                vector_to_write.data(),
+                core_start,
+                core_end,
+                address,
+                vector_to_write.size() * sizeof(uint32_t),
+                NocId::NOC0);
             ASSERT_TRUE(hw_broadcast) << "Expected hardware broadcast to succeed for chip " << chip_id << " size "
                                       << size;
             cluster.wait_for_non_mmio_flush(chip_id);


### PR DESCRIPTION
### Issue
#2521 

### Description
Further prepare usage of EthernetBroadcast by adding it to remote protocol

### List of the changes
- RemoteProtocol now holds EthernetBroadcast instance
- Will return false if it is not available for broadcast
- implement a test for this path

### Testing
Wrote a dedicated test to test this functionality

### API Changes
This PR has API changes RemoteProtocol now implements write_to_core_range
