### PR TITLE
write_to_core_range for PCIProtocol

### DIFF
--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -100,7 +100,11 @@ void PcieProtocol::read_from_device_impl(void* mem_ptr, tt_xy_pair core, uint64_
     }
 }
 
-bool PcieProtocol::write_to_core_range(const void*, tt_xy_pair, tt_xy_pair, uint64_t, uint32_t, NocId) { return false; }
+bool PcieProtocol::write_to_core_range(
+    const void* mem_ptr, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, uint32_t size, NocId noc_id) {
+    noc_multicast_write(mem_ptr, size, core_start, core_end, addr, noc_id);
+    return true;
+}
 
 int PcieProtocol::get_mmio_id() { return pci_device_->get_pci_device_id(); }
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -537,25 +537,24 @@ tt_xy_pair TTDevice::get_arc_core() const { return is_selected_noc1() ? arc_core
 void TTDevice::noc_multicast_write(
     const void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) {
     ZoneScopedC(tracy::Color::Orange);
-    if (!is_remote_tt_device) {
-        get_pcie_interface()->noc_multicast_write(src, size, core_start, core_end, addr, get_selected_noc_id());
-        return;
-    }
-
-    bool broadcast_success =
-        device_protocol_->write_to_core_range(src, core_start, core_end, addr, size, get_selected_noc_id());
+    bool multicast_success = device_protocol_->write_to_core_range(src, core_start, core_end, addr, size, get_selected_noc_id());
 
     log_debug(
         LogUMD,
-        "Remote multicast write to cores ({}, {}) - ({}, {}) {}",
+        "Multicast on {} chip write to cores ({}, {}) - ({}, {}) {}",
+        is_remote_tt_device ? "remote" : "local",
         core_start.x,
         core_start.y,
         core_end.x,
         core_end.y,
-        broadcast_success ? "succeeded" : "fell back to unicast");
+        multicast_success ? "succeeded" : "fell back to unicast");
 
-    if (broadcast_success) {
+    // We need to flush the writes in case of remote communication.
+    if (multicast_success && is_remote_tt_device) {
         get_remote_communication()->wait_for_non_mmio_flush();
+    }
+
+    if (multicast_success) {
         return;
     }
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -537,7 +537,8 @@ tt_xy_pair TTDevice::get_arc_core() const { return is_selected_noc1() ? arc_core
 void TTDevice::noc_multicast_write(
     const void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) {
     ZoneScopedC(tracy::Color::Orange);
-    bool multicast_success = device_protocol_->write_to_core_range(src, core_start, core_end, addr, size, get_selected_noc_id());
+    bool multicast_success =
+        device_protocol_->write_to_core_range(src, core_start, core_end, addr, size, get_selected_noc_id());
 
     log_debug(
         LogUMD,


### PR DESCRIPTION
### Issue
Related to #2521 

### Description
Unifies multicast to just call write_to_core_range in case of both local and remote chips.

### List of the changes
- Implement write_to_core_ranges to just call noc_multicast
- Adjust TTDevice::noc_multicast_write given that now you can always try calling write_to_core_range

### Testing
There's already an exhaustive multicast write test.

### API Changes
This PR has API changes, implements write_to_core_ranges for pci protocol
