### PR TITLE
ttsim CI: run UMD api_tests on Blackhole simulator

### DIFF
--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -145,10 +145,24 @@ jobs:
         run: |
           tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
 
+      - name: Run UMD TestDeviceIOFixture on tt-sim blackhole
+        timeout-minutes: 1
+        env:
+          TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh/libttsim.so
+        run: |
+          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
+
       - name: Run UMD TTSimDeviceIOFixture on tt-sim wormhole
         timeout-minutes: 1
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_wh/libttsim.so
+        run: |
+          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
+
+      - name: Run UMD TTSimDeviceIOFixture on tt-sim blackhole
+        timeout-minutes: 1
+        env:
+          TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh/libttsim.so
         run: |
           tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
 


### PR DESCRIPTION
### Issue
TTSim CI was already downloading both `libttsim_wh.so` and `libttsim_bh.so` and exercising tt-metal examples / unit tests on both archs, but the UMD `api_tests` (`TestDeviceIOFixture` and `TTSimDeviceIOFixture`) only ran against the wormhole simulator. That left the Blackhole TTSim path uncovered for UMD-level tests.

### Description
Both fixtures are arch-agnostic — `TTSimDeviceIOFixture` builds a `TTSimTTDevice` from `TT_UMD_SIMULATOR` and uses `SocDescriptor` Tensix cores; `TestDeviceIOFixture` builds a `Cluster` with `simulator_directory` and likewise reads cores from the SoC descriptor. The arch is selected by the `soc_descriptor.yaml` placed next to `libttsim.so` in `sim_wh/` / `sim_bh/`, both of which the workflow already prepares. So adding BH coverage is a workflow-only change.

### List of the changes
- `.github/workflows/run-ttsim-tests.yml`: add two new steps that run `TestDeviceIOFixture.*` and `TTSimDeviceIOFixture.*` against `sim_bh/libttsim.so`, mirroring the existing wormhole steps.

### Testing
- This PR's own CI exercises the new steps.
- Existing wormhole steps are unchanged.

### API Changes
There are no API changes in this PR.