### PR TITLE
Optimize tooling tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -135,16 +135,11 @@ jobs:
       - name: Run UMD tools
         shell: bash
         run: |
-          ${{ env.BUILD_OUTPUT_DIR }}/tools/umd/telemetry --count 1000
+          ${{ env.BUILD_OUTPUT_DIR }}/tools/umd/telemetry --count 10
           ${{ env.BUILD_OUTPUT_DIR }}/tools/umd/topology
           ${{ env.BUILD_OUTPUT_DIR }}/tools/umd/harvesting
           ${{ env.BUILD_OUTPUT_DIR }}/tools/umd/system_health
-          # warm_reset is expected to return 1 on no devices.
-          if [[ "${{ inputs.arch }}" == "baremetal" ]]; then
-            ${{ env.BUILD_OUTPUT_DIR }}/tools/umd/warm_reset || [ $? -eq 1 ]
-          else
-            ${{ env.BUILD_OUTPUT_DIR }}/tools/umd/warm_reset
-          fi
+          # warm_reset is skipped here; it is covered by unit tests.
           ${{ env.BUILD_OUTPUT_DIR }}/tools/umd/tlb_virus
 
       - name: Install wheel and run pytest


### PR DESCRIPTION
### Issue
Slower than needed tests on our main queue

### Description
Main issue is that on 6u the telemetry was generating 1000 * 32 logs, spamming the output.
Also warm reset tool was taking a lot of time

### List of the changes
- Don't test warm reset tool
- Telemetry tool run for 10 iterations

### Testing
CI run on this PR is faster

### API Changes
There are no API changes in this PR.
