### PR TITLE
TTSim: enable 4GB TLB allocation through BAR4 on Blackhole

### DIFF
--- a/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
@@ -25,7 +25,7 @@ class architecture_implementation;
  */
 class SimulationTlbAllocator {
 public:
-    SimulationTlbAllocator(uint64_t bar0_base, const architecture_implementation* arch_impl);
+    SimulationTlbAllocator(uint64_t bar0_base, const architecture_implementation* arch_impl, uint64_t bar4_base = 0);
 
     /**
      * Allocate the smallest TLB whose size class is >= the requested size. If no
@@ -81,6 +81,7 @@ private:
     TlbSizeClass* find_size_class_for_index(int tlb_index);
 
     uint64_t bar0_base_ = 0;
+    uint64_t bar4_base_ = 0;
     const architecture_implementation* arch_impl_ = nullptr;
     tt::ARCH architecture_;
     size_t tlb_reg_size_bytes_ = 8;  // Default to Wormhole size.

--- a/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
@@ -37,6 +37,7 @@ public:
     SimulationTlbManager(
         TTDevice* tt_device,
         uint64_t bar0_base,
+        uint64_t bar4_base,
         const architecture_implementation* arch_impl,
         TlbWindowFactory factory);
 

--- a/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
@@ -34,12 +34,14 @@ using TlbWindowFactory = std::function<std::unique_ptr<TlbWindow>(
 
 class SimulationTlbManager : public TLBManager {
 public:
+    // bar4_base is trailing with a default of 0 so callers that don't use the 4GB-TLB BAR4
+    // path (Wormhole, RTL sim, and any downstream that predates this parameter) keep working.
     SimulationTlbManager(
         TTDevice* tt_device,
         uint64_t bar0_base,
-        uint64_t bar4_base,
         const architecture_implementation* arch_impl,
-        TlbWindowFactory factory);
+        TlbWindowFactory factory,
+        uint64_t bar4_base = 0);
 
     std::unique_ptr<TlbWindow> allocate_tlb_window(
         tlb_data config, const TlbMapping mapping = TlbMapping::WC, const size_t tlb_size = 0) override;

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -85,6 +85,7 @@ public:
     TLBManager *get_tlb_manager() override;
 
     uint64_t bar0_base = 0;
+    uint64_t bar4_base = 0;
 
 protected:
     void retrain_dram_core(const uint32_t dram_channel) override;

--- a/device/chip_helpers/simulation_tlb_allocator.cpp
+++ b/device/chip_helpers/simulation_tlb_allocator.cpp
@@ -16,8 +16,9 @@
 
 namespace tt::umd {
 
-SimulationTlbAllocator::SimulationTlbAllocator(uint64_t bar0_base, const architecture_implementation* arch_impl) :
-    bar0_base_(bar0_base), arch_impl_(arch_impl) {
+SimulationTlbAllocator::SimulationTlbAllocator(
+    uint64_t bar0_base, const architecture_implementation* arch_impl, uint64_t bar4_base) :
+    bar0_base_(bar0_base), bar4_base_(bar4_base), arch_impl_(arch_impl) {
     initialize_architecture_config();
 }
 
@@ -68,10 +69,11 @@ uint64_t SimulationTlbAllocator::get_tlb_address_from_index(int tlb_index) {
         UMD_THROW(error::RuntimeError, fmt::format("Invalid simulation TLB index {}.", tlb_index));
     }
 
-    // BH 4GB TLBs live in BAR4, not BAR0; this path doesn't yet support them.
+    // BH 4GB TLBs live in BAR4, not BAR0. Each 4GB slot occupies its own region in
+    // BAR4, in TLB-index order starting from the FOUR_GB pool's start_index.
     if (architecture_ == tt::ARCH::BLACKHOLE && sc == &size_classes_[FOUR_GB]) {
-        UMD_THROW(
-            error::RuntimeError, "4GB TLBs in Blackhole are not currently supported in simulation TLB allocation.");
+        uint64_t slot = static_cast<uint64_t>(tlb_index) - sc->start_index;
+        return bar4_base_ + slot * sc->size;
     }
 
     // Size classes are laid out contiguously in BAR0; sum the sizes of all classes

--- a/device/chip_helpers/simulation_tlb_manager.cpp
+++ b/device/chip_helpers/simulation_tlb_manager.cpp
@@ -18,9 +18,9 @@ namespace tt::umd {
 SimulationTlbManager::SimulationTlbManager(
     TTDevice* tt_device,
     uint64_t bar0_base,
-    uint64_t bar4_base,
     const architecture_implementation* arch_impl,
-    TlbWindowFactory factory) :
+    TlbWindowFactory factory,
+    uint64_t bar4_base) :
     TLBManager(tt_device), allocator_(bar0_base, arch_impl, bar4_base), factory_(std::move(factory)) {}
 
 std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_tlb_window(

--- a/device/chip_helpers/simulation_tlb_manager.cpp
+++ b/device/chip_helpers/simulation_tlb_manager.cpp
@@ -16,8 +16,12 @@
 namespace tt::umd {
 
 SimulationTlbManager::SimulationTlbManager(
-    TTDevice* tt_device, uint64_t bar0_base, const architecture_implementation* arch_impl, TlbWindowFactory factory) :
-    TLBManager(tt_device), allocator_(bar0_base, arch_impl), factory_(std::move(factory)) {}
+    TTDevice* tt_device,
+    uint64_t bar0_base,
+    uint64_t bar4_base,
+    const architecture_implementation* arch_impl,
+    TlbWindowFactory factory) :
+    TLBManager(tt_device), allocator_(bar0_base, arch_impl, bar4_base), factory_(std::move(factory)) {}
 
 std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_tlb_window(
     tlb_data config, const TlbMapping mapping, const size_t tlb_size) {

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -108,7 +108,6 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
     tlb_manager_ = std::make_unique<SimulationTlbManager>(
         this,
         /*bar0_base=*/0,
-        /*bar4_base=*/0,
         architecture_impl_.get(),
         [comm = communicator_.get()](
             SimulationTlbManager* mgr, int id, size_t sz, TlbMapping map, tlb_data cfg) -> std::unique_ptr<TlbWindow> {

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -108,6 +108,7 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
     tlb_manager_ = std::make_unique<SimulationTlbManager>(
         this,
         /*bar0_base=*/0,
+        /*bar4_base=*/0,
         architecture_impl_.get(),
         [comm = communicator_.get()](
             SimulationTlbManager* mgr, int id, size_t sz, TlbMapping map, tlb_data cfg) -> std::unique_ptr<TlbWindow> {

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -105,13 +105,13 @@ TTSimTTDevice::TTSimTTDevice(
     tlb_manager_ = std::make_unique<SimulationTlbManager>(
         this,
         bar0_base,
-        bar4_base,
         architecture_impl_.get(),
         [comm = communicator_.get()](
             SimulationTlbManager* mgr, int id, size_t sz, TlbMapping map, tlb_data cfg) -> std::unique_ptr<TlbWindow> {
             auto handle = TTSimTlbHandle::create(mgr, comm, id, sz, map);
             return std::make_unique<TTSimTlbWindow>(std::move(handle), comm, cfg);
-        });
+        },
+        bar4_base);
     cached_tlb_window_ = tlb_manager_->allocate_default_tlb_window();
 }
 

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -87,7 +87,10 @@ TTSimTTDevice::TTSimTTDevice(
         bar0_base |= uint64_t(communicator_->pci_config_read32(0, 0x14)) << 32;
         bar0_base &= ~15ull;  // ignore attributes, just obtain the physical address
 
-        // Compute physical address of BAR4 from PCI config registers (Blackhole 4GB TLBs live here).
+        // BAR4 is a 64-bit memory BAR; its base address is split across two PCI config
+        // registers — 0x20 holds the low 32 bits, 0x24 holds the high 32 bits. The low 4 bits
+        // of the low register encode BAR attributes (memory vs IO, prefetchable, 64-bit width)
+        // and are masked off to leave the physical address.
         bar4_base = communicator_->pci_config_read32(0, 0x20);
         bar4_base |= uint64_t(communicator_->pci_config_read32(0, 0x24)) << 32;
         bar4_base &= ~15ull;

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -87,6 +87,11 @@ TTSimTTDevice::TTSimTTDevice(
         bar0_base |= uint64_t(communicator_->pci_config_read32(0, 0x14)) << 32;
         bar0_base &= ~15ull;  // ignore attributes, just obtain the physical address
 
+        // Compute physical address of BAR4 from PCI config registers (Blackhole 4GB TLBs live here).
+        bar4_base = communicator_->pci_config_read32(0, 0x20);
+        bar4_base |= uint64_t(communicator_->pci_config_read32(0, 0x24)) << 32;
+        bar4_base &= ~15ull;
+
         if (libttsim_pci_device_id == TT_WORMHOLE_PCI_DEVICE_ID) {
             tlb_region_size_ = 16 * 1024 * 1024;
         } else {
@@ -97,6 +102,7 @@ TTSimTTDevice::TTSimTTDevice(
     tlb_manager_ = std::make_unique<SimulationTlbManager>(
         this,
         bar0_base,
+        bar4_base,
         architecture_impl_.get(),
         [comm = communicator_.get()](
             SimulationTlbManager* mgr, int id, size_t sz, TlbMapping map, tlb_data cfg) -> std::unique_ptr<TlbWindow> {

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -755,7 +755,8 @@ void bind_tt_device(nb::module_ &m) {
         .def("get_clock", &TTSimTTDevice::get_clock, release_gil(), "Get the clock frequency.")
         .def(
             "get_min_clock_freq", &TTSimTTDevice::get_min_clock_freq, release_gil(), "Get the minimum clock frequency.")
-        .def_rw("bar0_base", &TTSimTTDevice::bar0_base, "Base address for BAR0.");
+        .def_rw("bar0_base", &TTSimTTDevice::bar0_base, "Base address for BAR0.")
+        .def_rw("bar4_base", &TTSimTTDevice::bar4_base, "Base address for BAR4.");
 
     nb::class_<RtlSimulationTTDevice, TTDevice>(m, "RtlSimulationTTDevice")
         .def_static(

--- a/tests/api/test_ttsim_device_io.cpp
+++ b/tests/api/test_ttsim_device_io.cpp
@@ -24,6 +24,7 @@
 #include "umd/device/tt_device/tt_sim_tt_device.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/tlb.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
@@ -413,14 +414,14 @@ TEST_F(TTSimDeviceIOFixture, FourGBTlbBar4PathRoundTrip) {
 
     // Write through the 4GB window (hits BAR4), read back through both the direct API and the
     // same 4GB window — all three views must agree.
-    tlb_window->write_block_reconfigure(write_data.data(), core, addr, data_size);
+    tlb_window->write_block_reconfigure(write_data.data(), core, addr, data_size, NocId::NOC0);
 
     std::vector<uint8_t> direct_read(data_size, 0);
     tt_device->get_communicator()->tile_read_bytes(core.x, core.y, addr, direct_read.data(), data_size);
     EXPECT_EQ(write_data, direct_read) << "tile_rd_bytes disagrees with 4GB-TLB write";
 
     std::vector<uint8_t> tlb_read(data_size, 0);
-    tlb_window->read_block_reconfigure(tlb_read.data(), core, addr, data_size);
+    tlb_window->read_block_reconfigure(tlb_read.data(), core, addr, data_size, NocId::NOC0);
     EXPECT_EQ(write_data, tlb_read) << "4GB-TLB read disagrees with 4GB-TLB write";
 }
 
@@ -445,14 +446,14 @@ TEST_F(TTSimDeviceIOFixture, FourGBTlbBar4PathDramRoundTrip) {
     constexpr uint64_t addr = 0x1000;
     auto write_data = make_pattern(data_size, [](size_t i) { return (i * 13 + 5) % 256; });
 
-    tlb_window->write_block_reconfigure(write_data.data(), core, addr, data_size);
+    tlb_window->write_block_reconfigure(write_data.data(), core, addr, data_size, NocId::NOC0);
 
     std::vector<uint8_t> direct_read(data_size, 0);
     tt_device->get_communicator()->tile_read_bytes(core.x, core.y, addr, direct_read.data(), data_size);
     EXPECT_EQ(write_data, direct_read) << "tile_rd_bytes disagrees with 4GB-TLB write to DRAM";
 
     std::vector<uint8_t> tlb_read(data_size, 0);
-    tlb_window->read_block_reconfigure(tlb_read.data(), core, addr, data_size);
+    tlb_window->read_block_reconfigure(tlb_read.data(), core, addr, data_size, NocId::NOC0);
     EXPECT_EQ(write_data, tlb_read) << "4GB-TLB read disagrees with 4GB-TLB write to DRAM";
 }
 

--- a/tests/api/test_ttsim_device_io.cpp
+++ b/tests/api/test_ttsim_device_io.cpp
@@ -15,12 +15,16 @@
 #include <string>
 #include <vector>
 
+#include "umd/device/chip_helpers/tlb_manager.hpp"
+#include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/simulation_device_factory.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/tt_device/tt_sim_tt_device.hpp"
+#include "umd/device/types/arch.hpp"
 #include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/tlb.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
@@ -380,6 +384,44 @@ TEST_F(TTSimDeviceIOFixture, RepeatedWriteReadCycles) {
         tt_device->get_communicator()->tile_read_bytes(core.x, core.y, addr, direct_read_zeros.data(), data_size);
         EXPECT_EQ(zeros, direct_read_zeros) << "Direct read of zeros mismatch at loop " << loop;
     }
+}
+
+// ---------------------------------------------------------------------------
+// 4GB TLB (BAR4) path — Blackhole only
+// ---------------------------------------------------------------------------
+
+// Allocate a 4GB TLB window explicitly. On Blackhole this is mapped through BAR4
+// rather than BAR0, exercising SimulationTlbManager::get_tlb_address_from_index's
+// BAR4 branch and the simulator's BAR4 TLB-translation path.
+TEST_F(TTSimDeviceIOFixture, FourGBTlbBar4PathRoundTrip) {
+    const SocDescriptor& soc = tt_device->get_soc_descriptor();
+    if (soc.arch != tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP() << "4GB TLBs only exist on Blackhole; skipping for arch " << tt::arch_to_str(soc.arch);
+    }
+
+    auto tensix_cores = soc.get_cores(CoreType::TENSIX);
+    const tt_xy_pair core = soc.translate_coord_to(tensix_cores.at(0), CoordSystem::TRANSLATED);
+
+    constexpr size_t SIZE_4GB = 4ULL * 1024ULL * 1024ULL * 1024ULL;
+    auto tlb_window = tt_device->get_tlb_manager()->allocate_tlb_window({}, TlbMapping::WC, SIZE_4GB);
+    ASSERT_NE(tlb_window, nullptr) << "Failed to allocate a 4GB TLB window on Blackhole";
+    EXPECT_EQ(tlb_window->get_size(), SIZE_4GB);
+
+    constexpr size_t data_size = 1024;
+    constexpr uint64_t addr = 0x1000;
+    auto write_data = make_pattern(data_size, [](size_t i) { return (i * 7 + 11) % 256; });
+
+    // Write through the 4GB window (hits BAR4), read back through both the direct API and the
+    // same 4GB window — all three views must agree.
+    tlb_window->write_block_reconfigure(write_data.data(), core, addr, data_size);
+
+    std::vector<uint8_t> direct_read(data_size, 0);
+    tt_device->get_communicator()->tile_read_bytes(core.x, core.y, addr, direct_read.data(), data_size);
+    EXPECT_EQ(write_data, direct_read) << "tile_rd_bytes disagrees with 4GB-TLB write";
+
+    std::vector<uint8_t> tlb_read(data_size, 0);
+    tlb_window->read_block_reconfigure(tlb_read.data(), core, addr, data_size);
+    EXPECT_EQ(write_data, tlb_read) << "4GB-TLB read disagrees with 4GB-TLB write";
 }
 
 }  // namespace tt::umd

--- a/tests/api/test_ttsim_device_io.cpp
+++ b/tests/api/test_ttsim_device_io.cpp
@@ -424,4 +424,36 @@ TEST_F(TTSimDeviceIOFixture, FourGBTlbBar4PathRoundTrip) {
     EXPECT_EQ(write_data, tlb_read) << "4GB-TLB read disagrees with 4GB-TLB write";
 }
 
+// Same BAR4 path, but targeting a DRAM tile. The 4GB TLB resolves to a NOC (x,y) address
+// independent of tile type, so this confirms the BAR4 route reaches DRAM as well as Tensix.
+TEST_F(TTSimDeviceIOFixture, FourGBTlbBar4PathDramRoundTrip) {
+    const SocDescriptor& soc = tt_device->get_soc_descriptor();
+    if (soc.arch != tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP() << "4GB TLBs only exist on Blackhole; skipping for arch " << tt::arch_to_str(soc.arch);
+    }
+
+    auto dram_cores = soc.get_cores(CoreType::DRAM);
+    ASSERT_FALSE(dram_cores.empty()) << "No DRAM cores in SOC descriptor";
+    const tt_xy_pair core = soc.translate_coord_to(dram_cores.at(0), CoordSystem::TRANSLATED);
+
+    constexpr size_t SIZE_4GB = 4ULL * 1024ULL * 1024ULL * 1024ULL;
+    auto tlb_window = tt_device->get_tlb_manager()->allocate_tlb_window({}, TlbMapping::WC, SIZE_4GB);
+    ASSERT_NE(tlb_window, nullptr) << "Failed to allocate a 4GB TLB window on Blackhole";
+    EXPECT_EQ(tlb_window->get_size(), SIZE_4GB);
+
+    constexpr size_t data_size = 1024;
+    constexpr uint64_t addr = 0x1000;
+    auto write_data = make_pattern(data_size, [](size_t i) { return (i * 13 + 5) % 256; });
+
+    tlb_window->write_block_reconfigure(write_data.data(), core, addr, data_size);
+
+    std::vector<uint8_t> direct_read(data_size, 0);
+    tt_device->get_communicator()->tile_read_bytes(core.x, core.y, addr, direct_read.data(), data_size);
+    EXPECT_EQ(write_data, direct_read) << "tile_rd_bytes disagrees with 4GB-TLB write to DRAM";
+
+    std::vector<uint8_t> tlb_read(data_size, 0);
+    tlb_window->read_block_reconfigure(tlb_read.data(), core, addr, data_size);
+    EXPECT_EQ(write_data, tlb_read) << "4GB-TLB read disagrees with 4GB-TLB write to DRAM";
+}
+
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue
On Blackhole, the 4GB TLBs are mapped through BAR4 (not BAR0 like the 2MB TLBs). `SimulationTlbManager::get_tlb_address_from_index()` had a `UMD_THROW("4GB TLBs in Blackhole are not currently supported in simulation TLB allocation.")` for any 4GB index, so any caller that allocated a 4GB TLB window would crash the moment `TTSimTlbHandle` tried to compute its base address. The bookkeeping (8 slots starting at index 202) was already in place — only the address computation and the BAR4 base were missing.

Pairs with [ttsim-private#350](https://github.com/tenstorrent/ttsim-private/pull/350), which adds the matching BAR4 decode on the simulator side. Both halves are needed end-to-end.

### Description
Plumb a `bar4_base` through `SimulationTlbManager`. `TTSimTTDevice` reads it from PCI config registers `0x20`/`0x24` (mirroring how `bar0_base` is read from `0x10`/`0x14`) and passes it in. `RtlSimulationTTDevice` passes `0` since RTL sim does not use this path.

`get_tlb_address_from_index()` for a 4GB index now returns `bar4_base + (tlb_index - tlb_4gb_start_index_) * 4GB`, matching the layout the simulator expects (each 4GB slot gets its own contiguous 4GB region in BAR4, in TLB-index order).

The simulator side ([ttsim-private#350](https://github.com/tenstorrent/ttsim-private/pull/350)) decodes BAR4 reads/writes by computing `tlb_index = 202 + (offset >> 32)` and looking up the matching TLB config slot. With both halves in place, allocating and using a 4GB TLB window on Blackhole now round-trips through BAR4 end-to-end.

### List of the changes
- `device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp`: add `bar4_base` ctor parameter and `bar4_base_` member; update doxygen on `get_tlb_address_from_index` to reflect that 4GB TLBs return a BAR4 address.
- `device/chip_helpers/simulation_tlb_manager.cpp`: replace the `UMD_THROW` for 4GB indices with `bar4_base_ + slot * tlb_4gb_size_`.
- `device/api/umd/device/tt_device/tt_sim_tt_device.hpp`, `device/tt_device/tt_sim_tt_device.cpp`: add `bar4_base` field, read from PCI config space, pass to `SimulationTlbManager`.
- `device/tt_device/rtl_simulation_tt_device.cpp`: pass `/*bar4_base=*/0`.
- `nanobind/py_api_tt_device.cpp`: expose `bar4_base` alongside `bar0_base`.
- `tests/api/test_ttsim_device_io.cpp`: add `TTSimDeviceIOFixture.FourGBTlbBar4PathRoundTrip` — allocates a 4GB TLB window, writes via `write_block_reconfigure` (which goes out over BAR4), verifies via `tile_rd_bytes` (direct sim API) and a TLB read-back. Skipped on non-Blackhole.

### Testing
- Locally ran the full `TTSimDeviceIOFixture` against `sim_bh/libttsim.so` built from [ttsim-private#350](https://github.com/tenstorrent/ttsim-private/pull/350): all 13 tests pass, including the new one.
- Existing tests are unaffected; the only behaviour change for current callers is that a 4GB allocation no longer throws.
- `pre-commit run --all-files` passes.

### API Changes
- `SimulationTlbManager` constructor gains a `bar4_base` parameter (positional, between `bar0_base` and `arch_impl`). Both call sites in this repo are updated.
- `TTSimTTDevice::bar4_base` is a new public field, exposed to Python via nanobind alongside `bar0_base`.
