### PR TITLE
Throw when passing custom ClusterDescriptor for SILICON cluster

### DIFF
--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -96,13 +96,12 @@ struct ClusterOptions {
      * Used to constrain Cluster by specifying which chips should be present.
      * For chip_type == ChipType::MOCK, used to specify list of mock chips.
      * Uses logical IDs.
+     * This has no effect on SILICON chip type, use TT_VISIBLE_DEVICES instead.
      */
     std::unordered_set<ChipId> target_devices;
 
     /**
-     * If not passed, topology discovery will be ran and ClusterDescriptor will be constructed. If passed, and chip
-     * type is SILICON, the constructor will throw if cluster_descriptor configuration shows chips which don't exist on
-     * the system.
+     * Only used for SIMULATION and MOCK chip types. Throws an error if passed for SILICON.
      */
     ClusterDescriptor* cluster_descriptor = nullptr;
 

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -744,7 +744,7 @@ private:
         const std::string& soc_desc_path, ChipId chip_id, ChipType chip_type, ClusterDescriptor* cluster_desc);
 
     void add_chip(const ChipId& chip_id, const ChipType& chip_type, std::unique_ptr<Chip> chip);
-    void construct_cluster(const uint32_t& num_host_mem_ch_per_mmio_device, const ChipType& chip_type);
+    void construct_cluster(const ChipType& chip_type);
 
     // State variables.
     std::set<ChipId> all_chip_ids_;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -136,7 +136,7 @@ void Cluster::log_pci_device_summary() {
     log_info(LogUMD, "KMD version: {}", kmd_version);
 }
 
-void Cluster::construct_cluster(const uint32_t& num_host_mem_ch_per_mmio_device, const ChipType& chip_type) {
+void Cluster::construct_cluster(const ChipType& chip_type) {
     ZoneScopedC(tracy::Color::DarkGreen);
     // TODO: work on removing this member altogether. Currently assumes all have the same arch.
     arch_name = chips_.empty() ? tt::ARCH::Invalid : chips_.begin()->second->get_soc_descriptor().arch;
@@ -404,7 +404,7 @@ Cluster::Cluster(ClusterOptions options) {  // NOLINT(performance-unnecessary-va
                 std::move(tt_device)));
     }
 
-    construct_cluster(options.num_host_mem_ch_per_mmio_device.value(), options.chip_type);
+    construct_cluster(options.chip_type);
     log_info(LogUMD, "Cluster constructor completed.");
 }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -319,9 +319,7 @@ Cluster::Cluster(ClusterOptions options) {  // NOLINT(performance-unnecessary-va
     switch (options.chip_type) {
         case ChipType::SILICON: {
             if (options.cluster_descriptor != nullptr) {
-                cluster_desc = ClusterDescriptor::create_constrained_cluster_descriptor(
-                    options.cluster_descriptor, options.target_devices);
-                break;
+                UMD_THROW(error::RuntimeError, "Cannot pass a custom ClusterDescriptor for SILICON chip type.");
             }
 
             auto [desc, devices] = TopologyDiscovery::discover(

--- a/tests/api/test_tt_visible_devices.cpp
+++ b/tests/api/test_tt_visible_devices.cpp
@@ -277,22 +277,7 @@ TEST_F(TestTTVisibleDevices, DifferentConstructors) {
         umd_cluster.reset();
     }
 
-    // 3. Constructor taking cluster descriptor based on which to create cluster.
-    // This could be cluster descriptor cached from previous runtime, or with some custom modifications.
-    // You can just create a cluster descriptor and serialize it to file, or fetch a cluster descriptor from already
-    // created Cluster class.
-    std::filesystem::path cluster_path1 = Cluster::create_cluster_descriptor()->serialize_to_file();
-    umd_cluster = std::make_unique<Cluster>();
-    umd_cluster->get_cluster_description()->serialize_to_file();
-    umd_cluster.reset();
-
-    std::unique_ptr<ClusterDescriptor> cluster_desc = ClusterDescriptor::create_from_yaml(cluster_path1);
-    umd_cluster = std::make_unique<Cluster>(ClusterOptions{
-        .cluster_descriptor = cluster_desc.get(),
-    });
-    umd_cluster.reset();
-
-    // 4. Create mock chips is set to true in order to create mock chips for the devices in the cluster descriptor.
+    // 3. Create mock chips is set to true in order to create mock chips for the devices in the cluster descriptor.
     umd_cluster = std::make_unique<Cluster>(ClusterOptions{
         .chip_type = ChipType::MOCK,
         .target_devices = {0},


### PR DESCRIPTION
### Issue
#1716

### Description
Remove the feature of passing custom ClusterDescriptors for constructing SILICON chips. This is a problematic feature because there is no easy way to check or map what has been passed, with the potential problem of UMD creating invalid objects for silicon, causing crashes and UB. Additionally, this is transitively a blocker from removing SocDescriptor from Chip. A SocDescriptor needs an existing TTDevice to be constructed, but they're only constructed in Chip which already requires a SocDescriptor. The case when a custom ClusterDescriptor is passed, discovery and TTDevice creation is skipped (as a part of the feature), causing this inverse relationship when creating Chips. 

### List of the changes
- Throw when passing custom ClusterDescriptor for SILICON cluster.
- Document changes in ClusterOptions.
- Remove test case.
- Remove unused param num_host_mem_channels in construct_cluster()

### Testing
CI, removing features

### API Changes
This PR has API changes:
- tt-metal: https://github.com/tenstorrent/tt-metal/pull/43571 (already merged)