### PR TITLE
SimulationTlbManager: dummy 4GB TLB for Quasar

### DIFF
--- a/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -55,6 +56,11 @@ public:
 private:
     SimulationTlbAllocator allocator_;
     TlbWindowFactory factory_;
+
+    // Monotonic TLB id handed out for architectures that bypass the allocator
+    // (Quasar). Always increases — never reused — so TlbHandle::get_tlb_id()
+    // is unique across the lifetime of the manager.
+    std::atomic<int> next_bypass_tlb_id_{0};
 };
 
 }  // namespace tt::umd

--- a/device/chip_helpers/simulation_tlb_allocator.cpp
+++ b/device/chip_helpers/simulation_tlb_allocator.cpp
@@ -144,11 +144,10 @@ void SimulationTlbAllocator::initialize_architecture_config() {
 
     } else {
         // Intentional: architectures like QUASAR construct SimulationTlbManager
-        // but bypass this allocator entirely (allocate_default_tlb_window
-        // short-circuits to a fixed dummy index without ever calling
-        // allocate_tlb_index). Leaving every pool empty is the signal that
-        // allocator-driven addressing is not in use; clients can detect this
-        // via has_configured_pools().
+        // but bypass this allocator entirely (SimulationTlbManager::
+        // allocate_tlb_window short-circuits to the factory without ever
+        // calling allocate_tlb_index). Leaving every pool empty is the signal
+        // that allocator-driven addressing is not in use.
         log_debug(
             LogUMD,
             fmt::format(

--- a/device/chip_helpers/simulation_tlb_manager.cpp
+++ b/device/chip_helpers/simulation_tlb_manager.cpp
@@ -26,6 +26,15 @@ SimulationTlbManager::SimulationTlbManager(
 std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_tlb_window(
     tlb_data config, const TlbMapping mapping, const size_t tlb_size) {
     ZoneScopedC(tracy::Color::Cyan);
+
+    // Quasar's TLB topology isn't finalized: bypass the allocator and hand back
+    // a dummy 4GB window. The simulator's communicator handles real I/O, so the
+    // window doesn't need a real index, address, or size.
+    if (allocator_.get_architecture() == tt::ARCH::QUASAR) {
+        static constexpr size_t SIZE_4GB = 4ULL * 1024 * 1024 * 1024;
+        return factory_(&allocator_, /*tlb_id=*/0, SIZE_4GB, mapping, config);
+    }
+
     int tlb_index = allocator_.allocate_tlb_index(tlb_size);
     if (tlb_index == -1) {
         UMD_THROW(error::RuntimeError, "No available TLB of requested size.");
@@ -39,11 +48,6 @@ std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_tlb_window(
 std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
     static constexpr size_t SIZE_2MB = 2 * 1024 * 1024;
     static constexpr size_t SIZE_16MB = 16 * 1024 * 1024;
-    // Quasar has no real TLBs; the communicator handles all I/O underneath.
-    // The size here is a dummy value — it just needs to be large enough so that
-    // TlbWindow::validate doesn't reject any valid access (size 0 would cause
-    // division by zero in RtlSimTlbHandle::configure).
-    static constexpr size_t SIZE_4GB = 4ULL * 1024 * 1024 * 1024;
     const tt::ARCH architecture = allocator_.get_architecture();
     switch (architecture) {
         case tt::ARCH::BLACKHOLE:
@@ -51,7 +55,7 @@ std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
         case tt::ARCH::WORMHOLE_B0:
             return allocate_tlb_window({}, TlbMapping::WC, SIZE_16MB);
         case tt::ARCH::QUASAR:
-            return factory_(&allocator_, 0, SIZE_4GB, TlbMapping::WC, {});
+            return allocate_tlb_window({}, TlbMapping::WC, /*tlb_size=*/0);
         default:
             log_debug(
                 LogUMD,

--- a/device/chip_helpers/simulation_tlb_manager.cpp
+++ b/device/chip_helpers/simulation_tlb_manager.cpp
@@ -29,10 +29,12 @@ std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_tlb_window(
 
     // Quasar's TLB topology isn't finalized: bypass the allocator and hand back
     // a dummy 4GB window. The simulator's communicator handles real I/O, so the
-    // window doesn't need a real index, address, or size.
+    // window doesn't need a real index, address, or size — but the tlb id still
+    // has to be unique per allocation so TLBManager bookkeeping (keyed by
+    // get_tlb_id) doesn't collide.
     if (allocator_.get_architecture() == tt::ARCH::QUASAR) {
         static constexpr size_t SIZE_4GB = 4ULL * 1024 * 1024 * 1024;
-        return factory_(&allocator_, /*tlb_id=*/0, SIZE_4GB, mapping, config);
+        return factory_(&allocator_, next_bypass_tlb_id_++, SIZE_4GB, mapping, config);
     }
 
     int tlb_index = allocator_.allocate_tlb_index(tlb_size);

--- a/device/pcie/tt_sim_tlb_handle.cpp
+++ b/device/pcie/tt_sim_tlb_handle.cpp
@@ -70,6 +70,12 @@ void TTSimTlbHandle::configure(const tlb_data& new_config) {
     // Get architecture from allocator to determine correct offsets.
     tt::ARCH architecture = get_arch();
 
+    // Quasar has no real TLB registers to program — the communicator handles
+    // all I/O directly, so configure is a no-op beyond storing tlb_config_.
+    if (architecture == tt::ARCH::QUASAR) {
+        return;
+    }
+
     log_debug(
         LogUMD,
         "Configured simulation TLB {} ({}) address 0x{:x} reg_addr 0x{:x} ({} bytes) with local_offset: {}, x_end: {}, "


### PR DESCRIPTION
### Issue

Stacked on #2538. Refs Quasar TLB enablement (#450 / #2317).

### Description

`Cluster::configure_tlb` / `SimulationTlbManager::allocate_tlb_window` both fail on Quasar today: the allocator has no pools for it, so any allocation request returns -1 and we throw "No available TLB of requested size." The cached-window path in the TTDevice ctor only worked because it bypassed the allocator with a hard-coded factory call inside `allocate_default_tlb_window`.

Quasar's real TLB topology isn't finalized, and the simulator's communicator handles all I/O regardless of TLB programming, so the allocation just needs to succeed and return a non-zero TLB. This PR unifies the bypass: any Quasar allocation hands back a dummy 4GB window directly via the factory, with no index/address/size lookup against the allocator.

### List of the changes

- `SimulationTlbManager::allocate_tlb_window`: short-circuit on Quasar, call the factory directly with `tlb_id=0` and `size=4GB`. The allocator is untouched for Quasar.
- `SimulationTlbManager::allocate_default_tlb_window`: drop the bespoke Quasar factory call; route Quasar through the regular `allocate_tlb_window` path now that it handles Quasar.
- `TTSimTlbHandle::configure`: early-return on Quasar so we don't try to write a TLB config register at the (zeroed) `tlb_reg_addr_`.
- Update the comment in `SimulationTlbAllocator::initialize_architecture_config` to point at the new bypass site.

### Testing

- `cmake --build build` clean.
- `baremetal_tests --gtest_filter='SimulationTlbAllocator.*'` — 13/13 pass.
- `pre-commit run --all-files` clean.

### API Changes

None.