### PR TITLE
TLBManager::configure_tlb: align recorded base on actual window size

### DIFF
--- a/device/chip_helpers/tlb_manager.cpp
+++ b/device/chip_helpers/tlb_manager.cpp
@@ -56,7 +56,13 @@ void TLBManager::configure_tlb(tt_xy_pair core, size_t tlb_size, uint64_t addres
         ordering,
         tlb_window->handle_ref().get_tlb_id());
 
-    tlb_config_map_.insert({tlb_window->handle_ref().get_tlb_id(), (address / tlb_size) * tlb_size});
+    // Use the actual allocated window size, not the caller-provided tlb_size, to
+    // page-align the recorded base address. The caller may pass tlb_size = 0 to
+    // mean "any size that fits"; in that case allocate_tlb_window picks one,
+    // and dividing by the original argument here would be a divide-by-zero
+    // (SIGFPE on Linux).
+    const size_t window_size = tlb_window->handle_ref().get_size();
+    tlb_config_map_.insert({tlb_window->handle_ref().get_tlb_id(), (address / window_size) * window_size});
     map_core_to_tlb_.insert({core, tlb_window->handle_ref().get_tlb_id()});
     tlb_windows_.insert({tlb_window->handle_ref().get_tlb_id(), std::move(tlb_window)});
 }


### PR DESCRIPTION
### Issue

`Cluster::configure_tlb` / `TLBManager::configure_tlb` SIGFPE (integer divide-by-zero) when called with `tlb_size = 0`. The crash is on the bookkeeping line at `tlb_manager.cpp:59`:

    tlb_config_map_.insert({..., (address / tlb_size) * tlb_size});

### Description

`tlb_size = 0` is a valid input — the base `TLBManager::allocate_tlb_window` treats it as "any size that fits" and iterates the architecture's TLB pool until something allocates. The window comes back with a real, non-zero size. But the bookkeeping line further down was still using the caller's original argument, dividing by 0 if they hadn't pinned a specific size.

Fix: take the size off the just-allocated `TlbWindow`'s handle for the page-alignment math, since that's the size the window actually has.

### List of the changes

- `device/chip_helpers/tlb_manager.cpp`: read `tlb_window->handle_ref().get_size()` after `allocate_tlb_window` and use it for the `(address / size) * size` alignment recorded in `tlb_config_map_`.

### Testing

- `cmake --build build` clean.
- `api_tests --gtest_filter='*TLBManager*'` (`ApiTLBManager.ManualTLBConfiguration`) passes.
- `pre-commit run --all-files` clean.

### API Changes

None.