### PR TITLE
Remove tlb manager from Sysmem manager

### DIFF
--- a/device/api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
@@ -12,7 +12,7 @@
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 
 namespace tt::umd {
-class TLBManager;
+class TTDevice;
 
 // Don't use the top 256MB of the 4th hugepage region on WH.  Two reasons:
 // 1. There are PCIE PHY registers at the top
@@ -21,7 +21,7 @@ static constexpr size_t HUGEPAGE_CHANNEL_3_SIZE_LIMIT = 768 * (1 << 20);
 
 class SiliconSysmemManager : public SysmemManager {
 public:
-    SiliconSysmemManager(TLBManager* tlb_manager, uint32_t num_host_mem_channels);
+    SiliconSysmemManager(TTDevice* tt_device, uint32_t num_host_mem_channels);
     ~SiliconSysmemManager() override;
 
     bool pin_or_map_sysmem_to_device() override;

--- a/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
@@ -9,12 +9,12 @@
 #include <memory>
 #include <optional>
 
-#include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
-class TLBManager;
+class PCIDevice;
+class TTDevice;
 
 /**
  * SysmemBuffer class should represent the resource of the HOST memory that is visible to the device.
@@ -46,12 +46,13 @@ public:
      *                          |<--- buffer_size -->|
      *                  |<----- mapped_buffer_size ----->|
      *
-     * @param tlb_manager Pointer to the TLBManager that manages the TLB entries for this buffer.
+     * @param tt_device Pointer to the TTDevice. Used directly for DMA transfers, and to access the underlying
+     * PCIDevice for mapping/unmapping and TLB allocation.
      * @param buffer_va Pointer to the virtual address of the buffer in the process address space.
      * @param buffer_size Size of the buffer requested by the user.
      * @param map_to_noc If true, the buffer will be mapped to be accessible over NOC from device.
      */
-    SysmemBuffer(TLBManager* tlb_manager, void* buffer_va, size_t buffer_size, bool map_to_noc = false);
+    SysmemBuffer(TTDevice* tt_device, void* buffer_va, size_t buffer_size, bool map_to_noc = false);
     ~SysmemBuffer();
 
     /**
@@ -118,7 +119,8 @@ private:
 
     TlbWindow* get_cached_tlb_window();
 
-    TLBManager* tlb_manager_;
+    PCIDevice* pci_device_;
+    TTDevice* tt_device_;
 
     // Virtual address in process addr space.
     void* buffer_va_;

--- a/device/api/umd/device/chip_helpers/sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_manager.hpp
@@ -20,7 +20,7 @@ enum class ARCH;
 }  // namespace tt
 
 namespace tt::umd {
-class TLBManager;
+class PCIDevice;
 class TTDevice;
 
 class SysmemManager {
@@ -61,7 +61,7 @@ public:
 protected:
     virtual bool init_sysmem(uint32_t num_host_mem_channels) = 0;
 
-    TLBManager* tlb_manager_ = nullptr;
+    PCIDevice* pci_device_ = nullptr;
     TTDevice* tt_device_ = nullptr;
     // TODO: Properly initialize for SimulationSysmemManager.
     uint64_t pcie_base_ = 0;

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -81,7 +81,7 @@ std::unique_ptr<LocalChip> LocalChip::create(
     // JTAG(currently the only communication protocol other than PCIe) has no use of them.
     if (tt_device->get_pci_device() != nullptr) {
         tlb_manager = std::make_unique<TLBManager>(tt_device.get());
-        sysmem_manager = std::make_unique<SiliconSysmemManager>(tlb_manager.get(), num_host_mem_channels);
+        sysmem_manager = std::make_unique<SiliconSysmemManager>(tt_device.get(), num_host_mem_channels);
     }
     // Note that the eth_coord is not important here since this is only used for eth broadcasting.
     SysmemManager* sysmem_ptr =

--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -86,6 +86,7 @@ static void *mmap_with_hugepage_fallback(size_t size) {
 SiliconSysmemManager::SiliconSysmemManager(TTDevice *tt_device, uint32_t num_host_mem_channels) {
     tt_device_ = tt_device;
     pci_device_ = tt_device->get_pci_device();
+    UMD_ASSERT(pci_device_ != nullptr, error::RuntimeError, "PCI device not available in TTDevice.");
     pcie_base_ = get_pcie_base_for_arch(pci_device_->get_arch());
     UMD_ASSERT(
         num_host_mem_channels <= 4,

--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -127,20 +127,20 @@ void SiliconSysmemManager::unpin_or_unmap_sysmem() {
         iommu_mapping = nullptr;
     } else {
         for (int ch = 0; ch < hugepage_mapping_per_channel.size(); ch++) {
-            auto &HugepageMapping = hugepage_mapping_per_channel[ch];
-            if (HugepageMapping.physical_address && pci_device_->is_mapping_buffer_to_noc_supported()) {
+            auto &hugepage_mapping = hugepage_mapping_per_channel[ch];
+            if (hugepage_mapping.physical_address && pci_device_->is_mapping_buffer_to_noc_supported()) {
                 // This will unmap the hugepage if it was mapped through kmd.
                 // This is a hack for the 4th hugepage channel which is limited to 768MB.
                 size_t actual_size = (pci_device_->get_arch() == tt::ARCH::WORMHOLE_B0 && ch == 3)
                                          ? HUGEPAGE_CHANNEL_3_SIZE_LIMIT
-                                         : HugepageMapping.mapping_size;
-                pci_device_->unmap_for_dma(HugepageMapping.mapping, actual_size);
+                                         : hugepage_mapping.mapping_size;
+                pci_device_->unmap_for_dma(hugepage_mapping.mapping, actual_size);
             }
-            if (HugepageMapping.mapping) {
+            if (hugepage_mapping.mapping) {
                 // Note that we mmap full hugepage, but don't map it filly to NOC.
                 // So the hack for 4th hugepage channel is not present in this branch.
-                TracyFreeN(HugepageMapping.mapping, "Hugepage");
-                munmap(HugepageMapping.mapping, HugepageMapping.mapping_size);
+                TracyFreeN(hugepage_mapping.mapping, "Hugepage");
+                munmap(hugepage_mapping.mapping, hugepage_mapping.mapping_size);
             }
         }
     }

--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -29,7 +29,6 @@
 #include "hugepage.hpp"
 #include "tracy.hpp"
 #include "umd/device/chip_helpers/sysmem_buffer.hpp"
-#include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
@@ -84,10 +83,10 @@ static void *mmap_with_hugepage_fallback(size_t size) {
     return addr;
 }
 
-SiliconSysmemManager::SiliconSysmemManager(TLBManager *tlb_manager, uint32_t num_host_mem_channels) {
-    tlb_manager_ = tlb_manager;
-    tt_device_ = tlb_manager_->get_tt_device();
-    pcie_base_ = get_pcie_base_for_arch(tlb_manager->get_tt_device()->get_arch());
+SiliconSysmemManager::SiliconSysmemManager(TTDevice *tt_device, uint32_t num_host_mem_channels) {
+    tt_device_ = tt_device;
+    pci_device_ = tt_device->get_pci_device();
+    pcie_base_ = get_pcie_base_for_arch(pci_device_->get_arch());
     UMD_ASSERT(
         num_host_mem_channels <= 4,
         error::RuntimeError,
@@ -98,7 +97,7 @@ SiliconSysmemManager::SiliconSysmemManager(TLBManager *tlb_manager, uint32_t num
 
 bool SiliconSysmemManager::pin_or_map_sysmem_to_device() {
     ZoneScopedC(tracy::Color::Yellow);
-    if (tt_device_->get_pci_device()->is_iommu_enabled()) {
+    if (pci_device_->is_iommu_enabled()) {
         return pin_or_map_iommu();
     } else {
         return pin_or_map_hugepages();
@@ -109,7 +108,7 @@ SiliconSysmemManager::~SiliconSysmemManager() { SiliconSysmemManager::unpin_or_u
 
 bool SiliconSysmemManager::init_sysmem(uint32_t num_host_mem_channels) {
     ZoneScopedC(tracy::Color::Yellow);
-    if (tt_device_->get_pci_device()->is_iommu_enabled()) {
+    if (pci_device_->is_iommu_enabled()) {
         return init_iommu(num_host_mem_channels);
     } else {
         return init_hugepages(num_host_mem_channels);
@@ -129,14 +128,13 @@ void SiliconSysmemManager::unpin_or_unmap_sysmem() {
     } else {
         for (int ch = 0; ch < hugepage_mapping_per_channel.size(); ch++) {
             auto &HugepageMapping = hugepage_mapping_per_channel[ch];
-            if (HugepageMapping.physical_address &&
-                tt_device_->get_pci_device()->is_mapping_buffer_to_noc_supported()) {
+            if (HugepageMapping.physical_address && pci_device_->is_mapping_buffer_to_noc_supported()) {
                 // This will unmap the hugepage if it was mapped through kmd.
                 // This is a hack for the 4th hugepage channel which is limited to 768MB.
-                size_t actual_size = (tt_device_->get_arch() == tt::ARCH::WORMHOLE_B0 && ch == 3)
+                size_t actual_size = (pci_device_->get_arch() == tt::ARCH::WORMHOLE_B0 && ch == 3)
                                          ? HUGEPAGE_CHANNEL_3_SIZE_LIMIT
                                          : HugepageMapping.mapping_size;
-                tt_device_->get_pci_device()->unmap_for_dma(HugepageMapping.mapping, actual_size);
+                pci_device_->unmap_for_dma(HugepageMapping.mapping, actual_size);
             }
             if (HugepageMapping.mapping) {
                 // Note that we mmap full hugepage, but don't map it filly to NOC.
@@ -161,18 +159,18 @@ bool SiliconSysmemManager::init_hugepages(uint32_t num_host_mem_channels) {
     // application might try to use the channels it asked for.  We should
     // just fail early since the error message will be actionable instead of
     // a segfault or memory corruption.
-    uint16_t pcie_device_id = tt_device_->get_pci_device()->get_pci_device_id();
-    uint32_t pcie_revision = tt_device_->get_pci_device()->get_pci_revision();
+    uint16_t pcie_device_id = pci_device_->get_pci_device_id();
+    uint32_t pcie_revision = pci_device_->get_pci_revision();
     num_host_mem_channels = get_available_num_host_mem_channels(num_host_mem_channels, pcie_device_id, pcie_revision);
 
     log_debug(
         LogUMD,
         "Using {} Hugepages/NumHostMemChannels for PCIDevice {}",
         num_host_mem_channels,
-        tt_device_->get_pci_device()->get_device_num());
+        pci_device_->get_device_num());
 
     const size_t hugepage_size = HUGEPAGE_REGION_SIZE;
-    auto physical_device_id = tt_device_->get_pci_device()->get_device_num();
+    auto physical_device_id = pci_device_->get_device_num();
 
     std::string hugepage_dir = find_hugepage_dir(hugepage_size);
     if (hugepage_dir.empty()) {
@@ -255,7 +253,7 @@ bool SiliconSysmemManager::init_hugepages(uint32_t num_host_mem_channels) {
 }
 
 bool SiliconSysmemManager::pin_or_map_hugepages() {
-    auto physical_device_id = tt_device_->get_pci_device()->get_device_num();
+    auto physical_device_id = pci_device_->get_device_num();
 
     bool success = true;
 
@@ -263,15 +261,14 @@ bool SiliconSysmemManager::pin_or_map_hugepages() {
     for (int ch = 0; ch < hugepage_mapping_per_channel.size(); ch++) {
         void *mapping = hugepage_mapping_per_channel.at(ch).mapping;
         size_t hugepage_size = hugepage_mapping_per_channel.at(ch).mapping_size;
-        size_t actual_size = (tt_device_->get_arch() == tt::ARCH::WORMHOLE_B0 && ch == 3)
+        size_t actual_size = (pci_device_->get_arch() == tt::ARCH::WORMHOLE_B0 && ch == 3)
                                  ? HUGEPAGE_CHANNEL_3_SIZE_LIMIT
                                  : hugepage_size;
-        bool map_buffer_to_noc = tt_device_->get_pci_device()->is_mapping_buffer_to_noc_supported();
+        bool map_buffer_to_noc = pci_device_->is_mapping_buffer_to_noc_supported();
         uint64_t physical_address;
         uint64_t noc_address;
         if (map_buffer_to_noc) {
-            std::tie(noc_address, physical_address) =
-                tt_device_->get_pci_device()->map_hugepage_to_noc(mapping, actual_size);
+            std::tie(noc_address, physical_address) = pci_device_->map_hugepage_to_noc(mapping, actual_size);
             uint64_t expected_noc_address = pcie_base_ + (ch * hugepage_size);
 
             log_info(LogUMD, "Mapped hugepage {:#x} to NOC address {:#x}", physical_address, noc_address);
@@ -284,7 +281,7 @@ bool SiliconSysmemManager::pin_or_map_hugepages() {
                     "behavior");
             }
         } else {
-            physical_address = tt_device_->get_pci_device()->map_for_hugepage(mapping, actual_size);
+            physical_address = pci_device_->map_for_hugepage(mapping, actual_size);
         }
 
         if (physical_address == 0) {
@@ -325,10 +322,9 @@ bool SiliconSysmemManager::init_iommu(uint32_t num_fake_mem_channels) {
 
     constexpr size_t carveout_size = HUGEPAGE_REGION_SIZE - HUGEPAGE_CHANNEL_3_SIZE_LIMIT;  // 1GB - 768MB = 256MB
     const size_t size = num_fake_mem_channels * HUGEPAGE_REGION_SIZE;
-    TTDevice *tt_device_ = tlb_manager_->get_tt_device();
 
     // Caclulate the size of the mapping in order to avoid overlap with PCIE registers on WH.
-    if (tt_device_->get_arch() == tt::ARCH::WORMHOLE_B0 && num_fake_mem_channels == 4) {
+    if (pci_device_->get_arch() == tt::ARCH::WORMHOLE_B0 && num_fake_mem_channels == 4) {
         iommu_mapping_size = (num_fake_mem_channels == 4) ? (size - carveout_size) : size;
     } else {
         iommu_mapping_size = size;
@@ -336,7 +332,7 @@ bool SiliconSysmemManager::init_iommu(uint32_t num_fake_mem_channels) {
 
     log_info(LogUMD, "Initializing iommu for sysmem (size: {:#x}).", iommu_mapping_size);
 
-    if (!tt_device_->get_pci_device()->is_iommu_enabled()) {
+    if (!pci_device_->is_iommu_enabled()) {
         UMD_THROW(error::RuntimeError, "IOMMU is required for sysmem without hugepages.");
     }
 
@@ -358,7 +354,7 @@ bool SiliconSysmemManager::init_iommu(uint32_t num_fake_mem_channels) {
     // Support for more than 1GB host memory accessible per device, via channels.
     for (size_t ch = 0; ch < num_fake_mem_channels; ch++) {
         uint8_t *fake_mapping = static_cast<uint8_t *>(iommu_mapping) + ch * HUGEPAGE_REGION_SIZE;
-        size_t actual_size = (tt_device_->get_arch() == tt::ARCH::WORMHOLE_B0 && ch == 3)
+        size_t actual_size = (pci_device_->get_arch() == tt::ARCH::WORMHOLE_B0 && ch == 3)
                                  ? HUGEPAGE_CHANNEL_3_SIZE_LIMIT
                                  : HUGEPAGE_REGION_SIZE;
         hugepage_mapping_per_channel[ch] = {fake_mapping, actual_size, 0};
@@ -373,7 +369,7 @@ bool SiliconSysmemManager::pin_or_map_iommu() {
         return true;
     }
 
-    bool map_buffer_to_noc = tt_device_->get_pci_device()->is_mapping_buffer_to_noc_supported();
+    bool map_buffer_to_noc = pci_device_->is_mapping_buffer_to_noc_supported();
 
     sysmem_buffer_ = map_sysmem_buffer(iommu_mapping, iommu_mapping_size, map_buffer_to_noc);
     uint64_t iova = sysmem_buffer_->get_device_io_addr();
@@ -426,7 +422,7 @@ std::unique_ptr<SysmemBuffer> SiliconSysmemManager::allocate_sysmem_buffer(
 std::unique_ptr<SysmemBuffer> SiliconSysmemManager::map_sysmem_buffer(
     void *buffer, size_t sysmem_buffer_size, const bool map_to_noc) {
     log_debug(LogUMD, "Mapping sysmem buffer to NOC: {:#x}", sysmem_buffer_size);
-    return std::make_unique<SysmemBuffer>(tlb_manager_, buffer, sysmem_buffer_size, map_to_noc);
+    return std::make_unique<SysmemBuffer>(tt_device_, buffer, sysmem_buffer_size, map_to_noc);
 }
 
 }  // namespace tt::umd

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -34,6 +34,7 @@ SysmemBuffer::SysmemBuffer(TTDevice* tt_device, void* buffer_va, size_t buffer_s
     buffer_va_(buffer_va),
     mapped_buffer_size_(buffer_size),
     buffer_size_(buffer_size) {
+    UMD_ASSERT(pci_device_ != nullptr, error::RuntimeError, "PCI device not available in TTDevice.");
     align_address_and_size();
     if (map_to_noc) {
         std::tie(noc_addr_, device_io_addr_) = pci_device_->map_buffer_to_noc(buffer_va_, mapped_buffer_size_);

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -19,7 +19,6 @@
 #include "noc_access.hpp"
 #include "tracy.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
-#include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
 #include "umd/device/pcie/tlb_handle.hpp"
@@ -29,14 +28,17 @@
 
 namespace tt::umd {
 
-SysmemBuffer::SysmemBuffer(TLBManager* tlb_manager, void* buffer_va, size_t buffer_size, bool map_to_noc) :
-    tlb_manager_(tlb_manager), buffer_va_(buffer_va), mapped_buffer_size_(buffer_size), buffer_size_(buffer_size) {
+SysmemBuffer::SysmemBuffer(TTDevice* tt_device, void* buffer_va, size_t buffer_size, bool map_to_noc) :
+    pci_device_(tt_device->get_pci_device()),
+    tt_device_(tt_device),
+    buffer_va_(buffer_va),
+    mapped_buffer_size_(buffer_size),
+    buffer_size_(buffer_size) {
     align_address_and_size();
-    PCIDevice* pci_device = tlb_manager->get_tt_device()->get_pci_device();
     if (map_to_noc) {
-        std::tie(noc_addr_, device_io_addr_) = pci_device->map_buffer_to_noc(buffer_va_, mapped_buffer_size_);
+        std::tie(noc_addr_, device_io_addr_) = pci_device_->map_buffer_to_noc(buffer_va_, mapped_buffer_size_);
     } else {
-        device_io_addr_ = pci_device->map_for_dma(buffer_va_, mapped_buffer_size_);
+        device_io_addr_ = pci_device_->map_for_dma(buffer_va_, mapped_buffer_size_);
         noc_addr_ = std::nullopt;
     }
     TracyAllocN(buffer_va_, mapped_buffer_size_, "SysmemBuffer");
@@ -44,14 +46,13 @@ SysmemBuffer::SysmemBuffer(TLBManager* tlb_manager, void* buffer_va, size_t buff
 
 void SysmemBuffer::dma_write_to_device(const size_t offset, size_t size, const tt_xy_pair core, uint64_t addr) {
     ZoneScopedC(tracy::Color::Yellow);
-    TTDevice* tt_device_ = tlb_manager_->get_tt_device();
 
-    if (tt_device_->get_pci_device()->get_dma_buffer().buffer == nullptr) {
+    if (pci_device_->get_dma_buffer().buffer == nullptr) {
         UMD_THROW(
             error::RuntimeError,
             fmt::format(
                 "DMA buffer is not allocated on PCI device {}, PCIe DMA operations not supported.",
-                tt_device_->get_pci_device()->get_device_num()));
+                pci_device_->get_device_num()));
     }
 
     validate(offset);
@@ -69,11 +70,11 @@ void SysmemBuffer::dma_write_to_device(const size_t offset, size_t size, const t
     config.y_end = core.y;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = tlb_data::Relaxed;
-    config.static_vc = tlb_manager_->get_tt_device()->get_architecture_implementation()->get_static_vc();
+    config.static_vc = pci_device_->get_architecture_implementation()->get_static_vc();
     TlbWindow* tlb_window = get_cached_tlb_window();
     tlb_window->configure(config);
 
-    auto axi_address_base = tt_device_->get_architecture_implementation()
+    auto axi_address_base = pci_device_->get_architecture_implementation()
                                 ->get_tlb_configuration(tlb_window->handle_ref().get_tlb_id())
                                 .tlb_offset;
     const size_t tlb_handle_size = tlb_window->handle_ref().get_size();
@@ -102,14 +103,13 @@ void SysmemBuffer::dma_write_to_device(const size_t offset, size_t size, const t
 
 void SysmemBuffer::dma_read_from_device(const size_t offset, size_t size, const tt_xy_pair core, uint64_t addr) {
     ZoneScopedC(tracy::Color::Yellow);
-    TTDevice* tt_device_ = tlb_manager_->get_tt_device();
 
-    if (tt_device_->get_pci_device()->get_dma_buffer().buffer == nullptr) {
+    if (pci_device_->get_dma_buffer().buffer == nullptr) {
         UMD_THROW(
             error::RuntimeError,
             fmt::format(
                 "DMA buffer is not allocated on PCI device {}, PCIe DMA operations not supported.",
-                tt_device_->get_pci_device()->get_device_num()));
+                pci_device_->get_device_num()));
     }
 
     validate(offset);
@@ -126,12 +126,12 @@ void SysmemBuffer::dma_read_from_device(const size_t offset, size_t size, const 
     config.y_end = core.y;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = tlb_data::Relaxed;
-    config.static_vc = tlb_manager_->get_tt_device()->get_architecture_implementation()->get_static_vc();
+    config.static_vc = pci_device_->get_architecture_implementation()->get_static_vc();
 
     TlbWindow* tlb_window = get_cached_tlb_window();
     tlb_window->configure(config);
 
-    auto axi_address_base = tt_device_->get_architecture_implementation()
+    auto axi_address_base = pci_device_->get_architecture_implementation()
                                 ->get_tlb_configuration(tlb_window->handle_ref().get_tlb_id())
                                 .tlb_offset;
     const size_t tlb_handle_size = tlb_window->handle_ref().get_size();
@@ -160,7 +160,7 @@ void SysmemBuffer::dma_read_from_device(const size_t offset, size_t size, const 
 SysmemBuffer::~SysmemBuffer() {
     TracyFreeN(buffer_va_, "SysmemBuffer");
     try {
-        tlb_manager_->get_tt_device()->get_pci_device()->unmap_for_dma(buffer_va_, mapped_buffer_size_);
+        pci_device_->unmap_for_dma(buffer_va_, mapped_buffer_size_);
     } catch (...) {
         log_warning(
             LogUMD, "Failed to unmap sysmem buffer (size: {:#x}, IOVA: {:#x}).", mapped_buffer_size_, device_io_addr_);
@@ -194,10 +194,8 @@ void SysmemBuffer::validate(const size_t offset) const {
 
 TlbWindow* SysmemBuffer::get_cached_tlb_window() {
     if (cached_tlb_window == nullptr) {
-        cached_tlb_window =
-            std::make_unique<SiliconTlbWindow>(tlb_manager_->get_tt_device()->get_pci_device()->allocate_tlb(
-                tlb_manager_->get_tt_device()->get_architecture_implementation()->get_cached_tlb_size(),
-                TlbMapping::WC));
+        cached_tlb_window = std::make_unique<SiliconTlbWindow>(pci_device_->allocate_tlb(
+            pci_device_->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::WC));
         return cached_tlb_window.get();
     }
     return cached_tlb_window.get();

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -19,7 +19,6 @@
 #include "umd/device/chip_helpers/silicon_sysmem_manager.hpp"
 #include "umd/device/chip_helpers/sysmem_buffer.hpp"
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
-#include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/soc_descriptor.hpp"
@@ -40,10 +39,8 @@ TEST(ApiSysmemManager, BasicIO) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
         tt_device->set_power_state(true);
 
-        std::unique_ptr<TLBManager> tlb_manager = std::make_unique<TLBManager>(tt_device.get());
-
         // Initializes system memory with one channel.
-        std::unique_ptr<SysmemManager> sysmem = std::make_unique<SiliconSysmemManager>(tlb_manager.get(), 1);
+        std::unique_ptr<SysmemManager> sysmem = std::make_unique<SiliconSysmemManager>(tt_device.get(), 1);
 
         sysmem->pin_or_map_sysmem_to_device();
 


### PR DESCRIPTION
### Issue


### Description
This is a simple search and replace to remove SysmemManager's dependancy on TLBManager.

### List of the changes
- Pass TTDevice instead of TLBManager to SysmemManager and SysmemBuffer
- use pci_device member instead of tt_device->get_pci_device()
- use tt_device member instead of tlb_manager->get_tt_device() 

### Testing
No testing, code builds

### API Changes
This PR has API changes on sysmem manager
