### PR TITLE
Releasing GIL in nanobind layer

### DIFF
--- a/nanobind/py_api_basic_types.cpp
+++ b/nanobind/py_api_basic_types.cpp
@@ -16,6 +16,7 @@
 #include "umd/device/utils/semver.hpp"
 
 namespace nb = nanobind;
+using release_gil = nb::call_guard<nb::gil_scoped_release>;
 
 using namespace tt;
 using namespace tt::umd;
@@ -26,19 +27,21 @@ void bind_basic_types(nb::module_ &m) {
         .value("NOC0", NocId::NOC0)
         .value("NOC1", NocId::NOC1)
         .value("SYSTEM_NOC", NocId::SYSTEM_NOC)
-        .def("__int__", [](NocId noc_id) { return static_cast<int>(noc_id); });
+        .def(
+            "__int__", [](NocId noc_id) { return static_cast<int>(noc_id); }, release_gil());
 
-    m.def("set_thread_noc_id", &tt::umd::set_thread_noc_id, nb::arg("noc_id"));
+    m.def("set_thread_noc_id", &tt::umd::set_thread_noc_id, nb::arg("noc_id"), release_gil());
 
     nb::class_<EthCoord>(m, "EthCoord")
-        .def(nb::init<>())
+        .def(nb::init<>(), release_gil())
         .def(
             nb::init<int, int, int, int, int>(),
             nb::arg("cluster_id"),
             nb::arg("x"),
             nb::arg("y"),
             nb::arg("rack"),
-            nb::arg("shelf"))
+            nb::arg("shelf"),
+            release_gil())
         .def_rw("cluster_id", &EthCoord::cluster_id)
         .def_rw("x", &EthCoord::x)
         .def_rw("y", &EthCoord::y)
@@ -46,19 +49,21 @@ void bind_basic_types(nb::module_ &m) {
         .def_rw("shelf", &EthCoord::shelf);
 
     nb::class_<tt::xy_pair>(m, "tt_xy_pair")
-        .def(nb::init<uint32_t, uint32_t>(), nb::arg("x"), nb::arg("y"))
+        .def(nb::init<uint32_t, uint32_t>(), nb::arg("x"), nb::arg("y"), release_gil())
         .def_ro("x", &tt_xy_pair::x)
         .def_ro("y", &tt_xy_pair::y)
-        .def("__str__", [](const tt_xy_pair &pair) { return fmt::format("({}, {})", pair.x, pair.y); });
+        .def(
+            "__str__", [](const tt_xy_pair &pair) { return fmt::format("({}, {})", pair.x, pair.y); }, release_gil());
 
     nb::enum_<tt::ARCH>(m, "ARCH")
         .value("WORMHOLE_B0", tt::ARCH::WORMHOLE_B0)
         .value("BLACKHOLE", tt::ARCH::BLACKHOLE)
         .value("QUASAR", tt::ARCH::QUASAR)
         .value("Invalid", tt::ARCH::Invalid)
-        .def("__str__", &tt::arch_to_str)
-        .def("__int__", [](tt::ARCH tag) { return static_cast<int>(tag); })
-        .def_static("from_str", &tt::arch_from_str, nb::arg("arch_str"));
+        .def("__str__", &tt::arch_to_str, release_gil())
+        .def(
+            "__int__", [](tt::ARCH tag) { return static_cast<int>(tag); }, release_gil())
+        .def_static("from_str", &tt::arch_from_str, nb::arg("arch_str"), release_gil());
 
     nb::enum_<RiscType>(m, "RiscType")
         .value("NONE", RiscType::NONE)
@@ -106,11 +111,16 @@ void bind_basic_types(nb::module_ &m) {
         .value("ALL_NEO_TRISCS", RiscType::ALL_NEO_TRISCS)
         .value("ALL_NEO_DMS", RiscType::ALL_NEO_DMS)
         .value("ALL_NEO", RiscType::ALL_NEO)
-        .def("__int__", [](RiscType rt) { return static_cast<uint64_t>(rt); })
-        .def("__str__", [](RiscType rt) { return RiscTypeToString(rt); })
-        .def("__or__", [](RiscType lhs, RiscType rhs) { return lhs | rhs; })
-        .def("__and__", [](RiscType lhs, RiscType rhs) { return lhs & rhs; })
-        .def("__invert__", [](RiscType rt) { return invert_selected_options(rt); });
+        .def(
+            "__int__", [](RiscType rt) { return static_cast<uint64_t>(rt); }, release_gil())
+        .def(
+            "__str__", [](RiscType rt) { return RiscTypeToString(rt); }, release_gil())
+        .def(
+            "__or__", [](RiscType lhs, RiscType rhs) { return lhs | rhs; }, release_gil())
+        .def(
+            "__and__", [](RiscType lhs, RiscType rhs) { return lhs & rhs; }, release_gil())
+        .def(
+            "__invert__", [](RiscType rt) { return invert_selected_options(rt); }, release_gil());
 
     nb::enum_<TensixSoftResetOptions>(m, "TensixSoftResetOptions")
         .value("NONE", TensixSoftResetOptions::NONE)
@@ -125,11 +135,16 @@ void bind_basic_types(nb::module_ &m) {
         .value("TENSIX_ASSERT_SOFT_RESET", TENSIX_ASSERT_SOFT_RESET)
         .value("TENSIX_DEASSERT_SOFT_RESET", TENSIX_DEASSERT_SOFT_RESET)
         .value("TENSIX_DEASSERT_SOFT_RESET_NO_STAGGER", TENSIX_DEASSERT_SOFT_RESET_NO_STAGGER)
-        .def("__int__", [](TensixSoftResetOptions opt) { return static_cast<uint32_t>(opt); })
-        .def("__str__", [](TensixSoftResetOptions opt) { return TensixSoftResetOptionsToString(opt); })
-        .def("__or__", [](TensixSoftResetOptions lhs, TensixSoftResetOptions rhs) { return lhs | rhs; })
-        .def("__and__", [](TensixSoftResetOptions lhs, TensixSoftResetOptions rhs) { return lhs & rhs; })
-        .def("__invert__", [](TensixSoftResetOptions opt) { return invert_selected_options(opt); });
+        .def(
+            "__int__", [](TensixSoftResetOptions opt) { return static_cast<uint32_t>(opt); }, release_gil())
+        .def(
+            "__str__", [](TensixSoftResetOptions opt) { return TensixSoftResetOptionsToString(opt); }, release_gil())
+        .def(
+            "__or__", [](TensixSoftResetOptions lhs, TensixSoftResetOptions rhs) { return lhs | rhs; }, release_gil())
+        .def(
+            "__and__", [](TensixSoftResetOptions lhs, TensixSoftResetOptions rhs) { return lhs & rhs; }, release_gil())
+        .def(
+            "__invert__", [](TensixSoftResetOptions opt) { return invert_selected_options(opt); }, release_gil());
 
     nb::enum_<tt::BoardType>(m, "BoardType")
         .value("E75", tt::BoardType::E75)
@@ -146,46 +161,58 @@ void bind_basic_types(nb::module_ &m) {
         .value("UBB_BLACKHOLE", tt::BoardType::UBB_BLACKHOLE)
         .value("QUASAR", tt::BoardType::QUASAR_BOARD)
         .value("UNKNOWN", tt::BoardType::UNKNOWN)
-        .def("__str__", &tt::board_type_to_string)
-        .def("__int__", [](tt::BoardType tag) { return static_cast<int>(tag); });
+        .def("__str__", &tt::board_type_to_string, release_gil())
+        .def(
+            "__int__", [](tt::BoardType tag) { return static_cast<int>(tag); }, release_gil());
 
     nb::class_<SemVer>(m, "SemVer")
-        .def(nb::init<>())
-        .def(nb::init<uint64_t, uint64_t, uint64_t>(), nb::arg("major"), nb::arg("minor"), nb::arg("patch"))
-        .def(nb::init<const std::string &>(), nb::arg("version_str"))
+        .def(nb::init<>(), release_gil())
+        .def(
+            nb::init<uint64_t, uint64_t, uint64_t>(),
+            nb::arg("major"),
+            nb::arg("minor"),
+            nb::arg("patch"),
+            release_gil())
+        .def(nb::init<const std::string &>(), nb::arg("version_str"), release_gil())
         .def_rw("major", &SemVer::major)
         .def_rw("minor", &SemVer::minor)
         .def_rw("patch", &SemVer::patch)
-        .def("to_string", &SemVer::to_string)
-        .def("__str__", &SemVer::to_string)
-        .def("__lt__", &SemVer::operator<)
-        .def("__le__", &SemVer::operator<=)
-        .def("__gt__", &SemVer::operator>)
-        .def("__ge__", &SemVer::operator>=)
-        .def("__eq__", &SemVer::operator==)
-        .def("__ne__", &SemVer::operator!=);
+        .def("to_string", &SemVer::to_string, release_gil())
+        .def("__str__", &SemVer::to_string, release_gil())
+        .def("__lt__", &SemVer::operator<, release_gil())
+        .def("__le__", &SemVer::operator<=, release_gil())
+        .def("__gt__", &SemVer::operator>, release_gil())
+        .def("__ge__", &SemVer::operator>=, release_gil())
+        .def("__eq__", &SemVer::operator==, release_gil())
+        .def("__ne__", &SemVer::operator!=, release_gil());
     // TODO: Remove after renaming in tt-exalens.
     m.attr("semver_t") = m.attr("SemVer");
 
     nb::class_<FirmwareBundleVersion>(m, "FirmwareBundleVersion")
-        .def(nb::init<>())
-        .def_static("from_firmware_bundle_tag", &FirmwareBundleVersion::from_firmware_bundle_tag, nb::arg("tag"))
-        .def(nb::init<uint64_t, uint64_t, uint64_t>(), nb::arg("major"), nb::arg("minor"), nb::arg("patch"))
-        .def(nb::init<const std::string &>(), nb::arg("version_str"))
+        .def(nb::init<>(), release_gil())
+        .def_static(
+            "from_firmware_bundle_tag", &FirmwareBundleVersion::from_firmware_bundle_tag, nb::arg("tag"), release_gil())
+        .def(
+            nb::init<uint64_t, uint64_t, uint64_t>(),
+            nb::arg("major"),
+            nb::arg("minor"),
+            nb::arg("patch"),
+            release_gil())
+        .def(nb::init<const std::string &>(), nb::arg("version_str"), release_gil())
         .def_rw("major", &SemVer::major)
         .def_rw("minor", &SemVer::minor)
         .def_rw("patch", &SemVer::patch)
-        .def("to_string", &FirmwareBundleVersion::to_string)
-        .def("__str__", &FirmwareBundleVersion::to_string)
-        .def("__lt__", &FirmwareBundleVersion::operator<)
-        .def("__le__", &FirmwareBundleVersion::operator<=)
-        .def("__gt__", &FirmwareBundleVersion::operator>)
-        .def("__ge__", &FirmwareBundleVersion::operator>=)
-        .def("__eq__", &FirmwareBundleVersion::operator==)
-        .def("__ne__", &FirmwareBundleVersion::operator!=);
+        .def("to_string", &FirmwareBundleVersion::to_string, release_gil())
+        .def("__str__", &FirmwareBundleVersion::to_string, release_gil())
+        .def("__lt__", &FirmwareBundleVersion::operator<, release_gil())
+        .def("__le__", &FirmwareBundleVersion::operator<=, release_gil())
+        .def("__gt__", &FirmwareBundleVersion::operator>, release_gil())
+        .def("__ge__", &FirmwareBundleVersion::operator>=, release_gil())
+        .def("__eq__", &FirmwareBundleVersion::operator==, release_gil())
+        .def("__ne__", &FirmwareBundleVersion::operator!=, release_gil());
 
     nb::class_<ChipInfo>(m, "ChipInfo")
-        .def(nb::init<>())
+        .def(nb::init<>(), release_gil())
         .def_rw("noc_translation_enabled", &ChipInfo::noc_translation_enabled)
         .def_rw("harvesting_masks", &ChipInfo::harvesting_masks)
         .def_rw("board_type", &ChipInfo::board_type)
@@ -193,7 +220,7 @@ void bind_basic_types(nb::module_ &m) {
         .def_rw("asic_location", &ChipInfo::asic_location);
 
     nb::class_<HarvestingMasks>(m, "HarvestingMasks")
-        .def(nb::init<>())
+        .def(nb::init<>(), release_gil())
         .def_rw("tensix_harvesting_mask", &HarvestingMasks::tensix_harvesting_mask)
         .def_rw("dram_harvesting_mask", &HarvestingMasks::dram_harvesting_mask)
         .def_rw("eth_harvesting_mask", &HarvestingMasks::eth_harvesting_mask)
@@ -201,10 +228,16 @@ void bind_basic_types(nb::module_ &m) {
         .def_rw("l2cpu_harvesting_mask", &HarvestingMasks::l2cpu_harvesting_mask);
 
     // Utility functions for BoardType.
-    m.def("board_type_to_string", &tt::board_type_to_string, nb::arg("board_type"), "Convert BoardType to string");
+    m.def(
+        "board_type_to_string",
+        &tt::board_type_to_string,
+        nb::arg("board_type"),
+        release_gil(),
+        "Convert BoardType to string");
     m.def(
         "board_type_from_string",
         &tt::board_type_from_string,
         nb::arg("board_type_str"),
+        release_gil(),
         "Convert string to BoardType");
 }

--- a/nanobind/py_api_basic_types.cpp
+++ b/nanobind/py_api_basic_types.cpp
@@ -26,8 +26,7 @@ void bind_basic_types(nb::module_ &m) {
         .value("NOC0", NocId::NOC0)
         .value("NOC1", NocId::NOC1)
         .value("SYSTEM_NOC", NocId::SYSTEM_NOC)
-        .def(
-            "__int__", [](NocId noc_id) { return static_cast<int>(noc_id); });
+        .def("__int__", [](NocId noc_id) { return static_cast<int>(noc_id); });
 
     m.def("set_thread_noc_id", &tt::umd::set_thread_noc_id, nb::arg("noc_id"));
 
@@ -50,8 +49,7 @@ void bind_basic_types(nb::module_ &m) {
         .def(nb::init<uint32_t, uint32_t>(), nb::arg("x"), nb::arg("y"))
         .def_ro("x", &tt_xy_pair::x)
         .def_ro("y", &tt_xy_pair::y)
-        .def(
-            "__str__", [](const tt_xy_pair &pair) { return fmt::format("({}, {})", pair.x, pair.y); });
+        .def("__str__", [](const tt_xy_pair &pair) { return fmt::format("({}, {})", pair.x, pair.y); });
 
     nb::enum_<tt::ARCH>(m, "ARCH")
         .value("WORMHOLE_B0", tt::ARCH::WORMHOLE_B0)
@@ -59,8 +57,7 @@ void bind_basic_types(nb::module_ &m) {
         .value("QUASAR", tt::ARCH::QUASAR)
         .value("Invalid", tt::ARCH::Invalid)
         .def("__str__", &tt::arch_to_str)
-        .def(
-            "__int__", [](tt::ARCH tag) { return static_cast<int>(tag); })
+        .def("__int__", [](tt::ARCH tag) { return static_cast<int>(tag); })
         .def_static("from_str", &tt::arch_from_str, nb::arg("arch_str"));
 
     nb::enum_<RiscType>(m, "RiscType")
@@ -109,16 +106,11 @@ void bind_basic_types(nb::module_ &m) {
         .value("ALL_NEO_TRISCS", RiscType::ALL_NEO_TRISCS)
         .value("ALL_NEO_DMS", RiscType::ALL_NEO_DMS)
         .value("ALL_NEO", RiscType::ALL_NEO)
-        .def(
-            "__int__", [](RiscType rt) { return static_cast<uint64_t>(rt); })
-        .def(
-            "__str__", [](RiscType rt) { return RiscTypeToString(rt); })
-        .def(
-            "__or__", [](RiscType lhs, RiscType rhs) { return lhs | rhs; })
-        .def(
-            "__and__", [](RiscType lhs, RiscType rhs) { return lhs & rhs; })
-        .def(
-            "__invert__", [](RiscType rt) { return invert_selected_options(rt); });
+        .def("__int__", [](RiscType rt) { return static_cast<uint64_t>(rt); })
+        .def("__str__", [](RiscType rt) { return RiscTypeToString(rt); })
+        .def("__or__", [](RiscType lhs, RiscType rhs) { return lhs | rhs; })
+        .def("__and__", [](RiscType lhs, RiscType rhs) { return lhs & rhs; })
+        .def("__invert__", [](RiscType rt) { return invert_selected_options(rt); });
 
     nb::enum_<TensixSoftResetOptions>(m, "TensixSoftResetOptions")
         .value("NONE", TensixSoftResetOptions::NONE)
@@ -133,16 +125,11 @@ void bind_basic_types(nb::module_ &m) {
         .value("TENSIX_ASSERT_SOFT_RESET", TENSIX_ASSERT_SOFT_RESET)
         .value("TENSIX_DEASSERT_SOFT_RESET", TENSIX_DEASSERT_SOFT_RESET)
         .value("TENSIX_DEASSERT_SOFT_RESET_NO_STAGGER", TENSIX_DEASSERT_SOFT_RESET_NO_STAGGER)
-        .def(
-            "__int__", [](TensixSoftResetOptions opt) { return static_cast<uint32_t>(opt); })
-        .def(
-            "__str__", [](TensixSoftResetOptions opt) { return TensixSoftResetOptionsToString(opt); })
-        .def(
-            "__or__", [](TensixSoftResetOptions lhs, TensixSoftResetOptions rhs) { return lhs | rhs; })
-        .def(
-            "__and__", [](TensixSoftResetOptions lhs, TensixSoftResetOptions rhs) { return lhs & rhs; })
-        .def(
-            "__invert__", [](TensixSoftResetOptions opt) { return invert_selected_options(opt); });
+        .def("__int__", [](TensixSoftResetOptions opt) { return static_cast<uint32_t>(opt); })
+        .def("__str__", [](TensixSoftResetOptions opt) { return TensixSoftResetOptionsToString(opt); })
+        .def("__or__", [](TensixSoftResetOptions lhs, TensixSoftResetOptions rhs) { return lhs | rhs; })
+        .def("__and__", [](TensixSoftResetOptions lhs, TensixSoftResetOptions rhs) { return lhs & rhs; })
+        .def("__invert__", [](TensixSoftResetOptions opt) { return invert_selected_options(opt); });
 
     nb::enum_<tt::BoardType>(m, "BoardType")
         .value("E75", tt::BoardType::E75)
@@ -160,16 +147,11 @@ void bind_basic_types(nb::module_ &m) {
         .value("QUASAR", tt::BoardType::QUASAR_BOARD)
         .value("UNKNOWN", tt::BoardType::UNKNOWN)
         .def("__str__", &tt::board_type_to_string)
-        .def(
-            "__int__", [](tt::BoardType tag) { return static_cast<int>(tag); });
+        .def("__int__", [](tt::BoardType tag) { return static_cast<int>(tag); });
 
     nb::class_<SemVer>(m, "SemVer")
         .def(nb::init<>())
-        .def(
-            nb::init<uint64_t, uint64_t, uint64_t>(),
-            nb::arg("major"),
-            nb::arg("minor"),
-            nb::arg("patch"))
+        .def(nb::init<uint64_t, uint64_t, uint64_t>(), nb::arg("major"), nb::arg("minor"), nb::arg("patch"))
         .def(nb::init<const std::string &>(), nb::arg("version_str"))
         .def_rw("major", &SemVer::major)
         .def_rw("minor", &SemVer::minor)
@@ -187,13 +169,8 @@ void bind_basic_types(nb::module_ &m) {
 
     nb::class_<FirmwareBundleVersion>(m, "FirmwareBundleVersion")
         .def(nb::init<>())
-        .def_static(
-            "from_firmware_bundle_tag", &FirmwareBundleVersion::from_firmware_bundle_tag, nb::arg("tag"))
-        .def(
-            nb::init<uint64_t, uint64_t, uint64_t>(),
-            nb::arg("major"),
-            nb::arg("minor"),
-            nb::arg("patch"))
+        .def_static("from_firmware_bundle_tag", &FirmwareBundleVersion::from_firmware_bundle_tag, nb::arg("tag"))
+        .def(nb::init<uint64_t, uint64_t, uint64_t>(), nb::arg("major"), nb::arg("minor"), nb::arg("patch"))
         .def(nb::init<const std::string &>(), nb::arg("version_str"))
         .def_rw("major", &SemVer::major)
         .def_rw("minor", &SemVer::minor)
@@ -224,11 +201,7 @@ void bind_basic_types(nb::module_ &m) {
         .def_rw("l2cpu_harvesting_mask", &HarvestingMasks::l2cpu_harvesting_mask);
 
     // Utility functions for BoardType.
-    m.def(
-        "board_type_to_string",
-        &tt::board_type_to_string,
-        nb::arg("board_type"),
-        "Convert BoardType to string");
+    m.def("board_type_to_string", &tt::board_type_to_string, nb::arg("board_type"), "Convert BoardType to string");
     m.def(
         "board_type_from_string",
         &tt::board_type_from_string,

--- a/nanobind/py_api_basic_types.cpp
+++ b/nanobind/py_api_basic_types.cpp
@@ -16,7 +16,6 @@
 #include "umd/device/utils/semver.hpp"
 
 namespace nb = nanobind;
-using release_gil = nb::call_guard<nb::gil_scoped_release>;
 
 using namespace tt;
 using namespace tt::umd;
@@ -28,20 +27,19 @@ void bind_basic_types(nb::module_ &m) {
         .value("NOC1", NocId::NOC1)
         .value("SYSTEM_NOC", NocId::SYSTEM_NOC)
         .def(
-            "__int__", [](NocId noc_id) { return static_cast<int>(noc_id); }, release_gil());
+            "__int__", [](NocId noc_id) { return static_cast<int>(noc_id); });
 
-    m.def("set_thread_noc_id", &tt::umd::set_thread_noc_id, nb::arg("noc_id"), release_gil());
+    m.def("set_thread_noc_id", &tt::umd::set_thread_noc_id, nb::arg("noc_id"));
 
     nb::class_<EthCoord>(m, "EthCoord")
-        .def(nb::init<>(), release_gil())
+        .def(nb::init<>())
         .def(
             nb::init<int, int, int, int, int>(),
             nb::arg("cluster_id"),
             nb::arg("x"),
             nb::arg("y"),
             nb::arg("rack"),
-            nb::arg("shelf"),
-            release_gil())
+            nb::arg("shelf"))
         .def_rw("cluster_id", &EthCoord::cluster_id)
         .def_rw("x", &EthCoord::x)
         .def_rw("y", &EthCoord::y)
@@ -49,21 +47,21 @@ void bind_basic_types(nb::module_ &m) {
         .def_rw("shelf", &EthCoord::shelf);
 
     nb::class_<tt::xy_pair>(m, "tt_xy_pair")
-        .def(nb::init<uint32_t, uint32_t>(), nb::arg("x"), nb::arg("y"), release_gil())
+        .def(nb::init<uint32_t, uint32_t>(), nb::arg("x"), nb::arg("y"))
         .def_ro("x", &tt_xy_pair::x)
         .def_ro("y", &tt_xy_pair::y)
         .def(
-            "__str__", [](const tt_xy_pair &pair) { return fmt::format("({}, {})", pair.x, pair.y); }, release_gil());
+            "__str__", [](const tt_xy_pair &pair) { return fmt::format("({}, {})", pair.x, pair.y); });
 
     nb::enum_<tt::ARCH>(m, "ARCH")
         .value("WORMHOLE_B0", tt::ARCH::WORMHOLE_B0)
         .value("BLACKHOLE", tt::ARCH::BLACKHOLE)
         .value("QUASAR", tt::ARCH::QUASAR)
         .value("Invalid", tt::ARCH::Invalid)
-        .def("__str__", &tt::arch_to_str, release_gil())
+        .def("__str__", &tt::arch_to_str)
         .def(
-            "__int__", [](tt::ARCH tag) { return static_cast<int>(tag); }, release_gil())
-        .def_static("from_str", &tt::arch_from_str, nb::arg("arch_str"), release_gil());
+            "__int__", [](tt::ARCH tag) { return static_cast<int>(tag); })
+        .def_static("from_str", &tt::arch_from_str, nb::arg("arch_str"));
 
     nb::enum_<RiscType>(m, "RiscType")
         .value("NONE", RiscType::NONE)
@@ -112,15 +110,15 @@ void bind_basic_types(nb::module_ &m) {
         .value("ALL_NEO_DMS", RiscType::ALL_NEO_DMS)
         .value("ALL_NEO", RiscType::ALL_NEO)
         .def(
-            "__int__", [](RiscType rt) { return static_cast<uint64_t>(rt); }, release_gil())
+            "__int__", [](RiscType rt) { return static_cast<uint64_t>(rt); })
         .def(
-            "__str__", [](RiscType rt) { return RiscTypeToString(rt); }, release_gil())
+            "__str__", [](RiscType rt) { return RiscTypeToString(rt); })
         .def(
-            "__or__", [](RiscType lhs, RiscType rhs) { return lhs | rhs; }, release_gil())
+            "__or__", [](RiscType lhs, RiscType rhs) { return lhs | rhs; })
         .def(
-            "__and__", [](RiscType lhs, RiscType rhs) { return lhs & rhs; }, release_gil())
+            "__and__", [](RiscType lhs, RiscType rhs) { return lhs & rhs; })
         .def(
-            "__invert__", [](RiscType rt) { return invert_selected_options(rt); }, release_gil());
+            "__invert__", [](RiscType rt) { return invert_selected_options(rt); });
 
     nb::enum_<TensixSoftResetOptions>(m, "TensixSoftResetOptions")
         .value("NONE", TensixSoftResetOptions::NONE)
@@ -136,15 +134,15 @@ void bind_basic_types(nb::module_ &m) {
         .value("TENSIX_DEASSERT_SOFT_RESET", TENSIX_DEASSERT_SOFT_RESET)
         .value("TENSIX_DEASSERT_SOFT_RESET_NO_STAGGER", TENSIX_DEASSERT_SOFT_RESET_NO_STAGGER)
         .def(
-            "__int__", [](TensixSoftResetOptions opt) { return static_cast<uint32_t>(opt); }, release_gil())
+            "__int__", [](TensixSoftResetOptions opt) { return static_cast<uint32_t>(opt); })
         .def(
-            "__str__", [](TensixSoftResetOptions opt) { return TensixSoftResetOptionsToString(opt); }, release_gil())
+            "__str__", [](TensixSoftResetOptions opt) { return TensixSoftResetOptionsToString(opt); })
         .def(
-            "__or__", [](TensixSoftResetOptions lhs, TensixSoftResetOptions rhs) { return lhs | rhs; }, release_gil())
+            "__or__", [](TensixSoftResetOptions lhs, TensixSoftResetOptions rhs) { return lhs | rhs; })
         .def(
-            "__and__", [](TensixSoftResetOptions lhs, TensixSoftResetOptions rhs) { return lhs & rhs; }, release_gil())
+            "__and__", [](TensixSoftResetOptions lhs, TensixSoftResetOptions rhs) { return lhs & rhs; })
         .def(
-            "__invert__", [](TensixSoftResetOptions opt) { return invert_selected_options(opt); }, release_gil());
+            "__invert__", [](TensixSoftResetOptions opt) { return invert_selected_options(opt); });
 
     nb::enum_<tt::BoardType>(m, "BoardType")
         .value("E75", tt::BoardType::E75)
@@ -161,58 +159,56 @@ void bind_basic_types(nb::module_ &m) {
         .value("UBB_BLACKHOLE", tt::BoardType::UBB_BLACKHOLE)
         .value("QUASAR", tt::BoardType::QUASAR_BOARD)
         .value("UNKNOWN", tt::BoardType::UNKNOWN)
-        .def("__str__", &tt::board_type_to_string, release_gil())
+        .def("__str__", &tt::board_type_to_string)
         .def(
-            "__int__", [](tt::BoardType tag) { return static_cast<int>(tag); }, release_gil());
+            "__int__", [](tt::BoardType tag) { return static_cast<int>(tag); });
 
     nb::class_<SemVer>(m, "SemVer")
-        .def(nb::init<>(), release_gil())
+        .def(nb::init<>())
         .def(
             nb::init<uint64_t, uint64_t, uint64_t>(),
             nb::arg("major"),
             nb::arg("minor"),
-            nb::arg("patch"),
-            release_gil())
-        .def(nb::init<const std::string &>(), nb::arg("version_str"), release_gil())
+            nb::arg("patch"))
+        .def(nb::init<const std::string &>(), nb::arg("version_str"))
         .def_rw("major", &SemVer::major)
         .def_rw("minor", &SemVer::minor)
         .def_rw("patch", &SemVer::patch)
-        .def("to_string", &SemVer::to_string, release_gil())
-        .def("__str__", &SemVer::to_string, release_gil())
-        .def("__lt__", &SemVer::operator<, release_gil())
-        .def("__le__", &SemVer::operator<=, release_gil())
-        .def("__gt__", &SemVer::operator>, release_gil())
-        .def("__ge__", &SemVer::operator>=, release_gil())
-        .def("__eq__", &SemVer::operator==, release_gil())
-        .def("__ne__", &SemVer::operator!=, release_gil());
+        .def("to_string", &SemVer::to_string)
+        .def("__str__", &SemVer::to_string)
+        .def("__lt__", &SemVer::operator<)
+        .def("__le__", &SemVer::operator<=)
+        .def("__gt__", &SemVer::operator>)
+        .def("__ge__", &SemVer::operator>=)
+        .def("__eq__", &SemVer::operator==)
+        .def("__ne__", &SemVer::operator!=);
     // TODO: Remove after renaming in tt-exalens.
     m.attr("semver_t") = m.attr("SemVer");
 
     nb::class_<FirmwareBundleVersion>(m, "FirmwareBundleVersion")
-        .def(nb::init<>(), release_gil())
+        .def(nb::init<>())
         .def_static(
-            "from_firmware_bundle_tag", &FirmwareBundleVersion::from_firmware_bundle_tag, nb::arg("tag"), release_gil())
+            "from_firmware_bundle_tag", &FirmwareBundleVersion::from_firmware_bundle_tag, nb::arg("tag"))
         .def(
             nb::init<uint64_t, uint64_t, uint64_t>(),
             nb::arg("major"),
             nb::arg("minor"),
-            nb::arg("patch"),
-            release_gil())
-        .def(nb::init<const std::string &>(), nb::arg("version_str"), release_gil())
+            nb::arg("patch"))
+        .def(nb::init<const std::string &>(), nb::arg("version_str"))
         .def_rw("major", &SemVer::major)
         .def_rw("minor", &SemVer::minor)
         .def_rw("patch", &SemVer::patch)
-        .def("to_string", &FirmwareBundleVersion::to_string, release_gil())
-        .def("__str__", &FirmwareBundleVersion::to_string, release_gil())
-        .def("__lt__", &FirmwareBundleVersion::operator<, release_gil())
-        .def("__le__", &FirmwareBundleVersion::operator<=, release_gil())
-        .def("__gt__", &FirmwareBundleVersion::operator>, release_gil())
-        .def("__ge__", &FirmwareBundleVersion::operator>=, release_gil())
-        .def("__eq__", &FirmwareBundleVersion::operator==, release_gil())
-        .def("__ne__", &FirmwareBundleVersion::operator!=, release_gil());
+        .def("to_string", &FirmwareBundleVersion::to_string)
+        .def("__str__", &FirmwareBundleVersion::to_string)
+        .def("__lt__", &FirmwareBundleVersion::operator<)
+        .def("__le__", &FirmwareBundleVersion::operator<=)
+        .def("__gt__", &FirmwareBundleVersion::operator>)
+        .def("__ge__", &FirmwareBundleVersion::operator>=)
+        .def("__eq__", &FirmwareBundleVersion::operator==)
+        .def("__ne__", &FirmwareBundleVersion::operator!=);
 
     nb::class_<ChipInfo>(m, "ChipInfo")
-        .def(nb::init<>(), release_gil())
+        .def(nb::init<>())
         .def_rw("noc_translation_enabled", &ChipInfo::noc_translation_enabled)
         .def_rw("harvesting_masks", &ChipInfo::harvesting_masks)
         .def_rw("board_type", &ChipInfo::board_type)
@@ -220,7 +216,7 @@ void bind_basic_types(nb::module_ &m) {
         .def_rw("asic_location", &ChipInfo::asic_location);
 
     nb::class_<HarvestingMasks>(m, "HarvestingMasks")
-        .def(nb::init<>(), release_gil())
+        .def(nb::init<>())
         .def_rw("tensix_harvesting_mask", &HarvestingMasks::tensix_harvesting_mask)
         .def_rw("dram_harvesting_mask", &HarvestingMasks::dram_harvesting_mask)
         .def_rw("eth_harvesting_mask", &HarvestingMasks::eth_harvesting_mask)
@@ -232,12 +228,10 @@ void bind_basic_types(nb::module_ &m) {
         "board_type_to_string",
         &tt::board_type_to_string,
         nb::arg("board_type"),
-        release_gil(),
         "Convert BoardType to string");
     m.def(
         "board_type_from_string",
         &tt::board_type_from_string,
         nb::arg("board_type_str"),
-        release_gil(),
         "Convert string to BoardType");
 }

--- a/nanobind/py_api_cluster.cpp
+++ b/nanobind/py_api_cluster.cpp
@@ -10,12 +10,13 @@
 #include "umd/device/topology/topology_discovery.hpp"
 
 namespace nb = nanobind;
+using release_gil = nb::call_guard<nb::gil_scoped_release>;
 
 using namespace tt::umd;
 
 void bind_cluster(nb::module_ &m) {
     nb::class_<Cluster>(m, "Cluster")
-        .def(nb::init<>())
-        .def("get_target_device_ids", &Cluster::get_target_device_ids)
-        .def("get_clocks", &Cluster::get_clocks);
+        .def(nb::init<>(), release_gil())
+        .def("get_target_device_ids", &Cluster::get_target_device_ids, release_gil())
+        .def("get_clocks", &Cluster::get_clocks, release_gil());
 }

--- a/nanobind/py_api_cluster.cpp
+++ b/nanobind/py_api_cluster.cpp
@@ -10,6 +10,11 @@
 #include "umd/device/topology/topology_discovery.hpp"
 
 namespace nb = nanobind;
+// Releases Python's Global Interpreter Lock (GIL) for the duration of the C++ call,
+// allowing other Python threads to run in parallel while this binding executes. Pass
+// release_gil() as a call guard to nb::class_::def() on methods that don't touch the
+// Python interpreter (e.g. blocking device I/O), so callers can drive UMD concurrently
+// from multiple Python threads.
 using release_gil = nb::call_guard<nb::gil_scoped_release>;
 
 using namespace tt::umd;

--- a/nanobind/py_api_error.cpp
+++ b/nanobind/py_api_error.cpp
@@ -13,6 +13,7 @@
 #include "umd/device/utils/error.hpp"
 
 namespace nb = nanobind;
+using release_gil = nb::call_guard<nb::gil_scoped_release>;
 
 using namespace tt;
 using namespace tt::umd;
@@ -25,17 +26,17 @@ void bind_error(nb::module_ &m) {
     static nb::exception<UmdBaseException> umd_base_exception(error_module, "UmdBaseException");
 
     // NoData struct for errors without metadata.
-    nb::class_<NoData>(error_module, "NoData").def(nb::init<>());
+    nb::class_<NoData>(error_module, "NoData").def(nb::init<>(), release_gil());
 
     // RuntimeError.
     nb::class_<RuntimeError>(error_module, "RuntimeError")
-        .def(nb::init<const std::string &>(), nb::arg("message"))
-        .def("message", nb::overload_cast<>(&RuntimeError::message, nb::const_), "Get the error message")
+        .def(nb::init<const std::string &>(), nb::arg("message"), release_gil())
+        .def("message", nb::overload_cast<>(&RuntimeError::message, nb::const_), release_gil(), "Get the error message")
         .def_prop_ro("data", nb::overload_cast<>(&RuntimeError::data, nb::const_), "Get the error data");
 
     // TTDeviceData.
     nb::class_<TTDeviceData>(error_module, "TTDeviceData")
-        .def(nb::init<>())
+        .def(nb::init<>(), release_gil())
         .def_rw("io_device_type", &TTDeviceData::io_device_type)
         .def_rw("chip_id", &TTDeviceData::chip_id)
         .def_rw("arch", &TTDeviceData::arch)
@@ -43,39 +44,44 @@ void bind_error(nb::module_ &m) {
 
     // DeviceCoreData.
     nb::class_<DeviceCoreData, TTDeviceData>(error_module, "DeviceCoreData")
-        .def(nb::init<>())
+        .def(nb::init<>(), release_gil())
         .def_rw("core", &DeviceCoreData::core)
         .def_rw("noc_id", &DeviceCoreData::noc_id);
 
     // ArcStartupData.
     nb::class_<ArcStartupData, DeviceCoreData>(error_module, "ArcStartupData")
-        .def(nb::init<>())
+        .def(nb::init<>(), release_gil())
         .def_rw("scratch_status", &ArcStartupData::scratch_status)
         .def_rw("postcode", &ArcStartupData::postcode)
         .def_rw("message_id", &ArcStartupData::message_id);
 
     // ArcStartupError.
     nb::class_<ArcStartupError>(error_module, "ArcStartupError")
-        .def("message", nb::overload_cast<>(&ArcStartupError::message, nb::const_), "Get the error message")
+        .def(
+            "message",
+            nb::overload_cast<>(&ArcStartupError::message, nb::const_),
+            release_gil(),
+            "Get the error message")
         .def_prop_ro("data", nb::overload_cast<>(&ArcStartupError::data, nb::const_), "Get the error data");
 
     // NocHangData.
     nb::class_<NocHangData, TTDeviceData>(error_module, "NocHangData")
-        .def(nb::init<>())
+        .def(nb::init<>(), release_gil())
         .def_rw("noc_id", &NocHangData::noc_id);
 
     // NocHangError.
     nb::class_<NocHangError>(error_module, "NocHangError")
-        .def("message", nb::overload_cast<>(&NocHangError::message, nb::const_), "Get the error message")
+        .def("message", nb::overload_cast<>(&NocHangError::message, nb::const_), release_gil(), "Get the error message")
         .def_prop_ro("data", nb::overload_cast<>(&NocHangError::data, nb::const_), "Get the error data");
 
     // PcieHangData.
     nb::class_<PcieHangData, TTDeviceData>(error_module, "PcieHangData")
-        .def(nb::init<>())
+        .def(nb::init<>(), release_gil())
         .def_rw("data_read", &PcieHangData::data_read);
 
     // PcieHangError.
     nb::class_<PcieHangError>(error_module, "PcieHangError")
-        .def("message", nb::overload_cast<>(&PcieHangError::message, nb::const_), "Get the error message")
+        .def(
+            "message", nb::overload_cast<>(&PcieHangError::message, nb::const_), release_gil(), "Get the error message")
         .def_prop_ro("data", nb::overload_cast<>(&PcieHangError::data, nb::const_), "Get the error data");
 }

--- a/nanobind/py_api_error.cpp
+++ b/nanobind/py_api_error.cpp
@@ -13,6 +13,11 @@
 #include "umd/device/utils/error.hpp"
 
 namespace nb = nanobind;
+// Releases Python's Global Interpreter Lock (GIL) for the duration of the C++ call,
+// allowing other Python threads to run in parallel while this binding executes. Pass
+// release_gil() as a call guard to nb::class_::def() on methods that don't touch the
+// Python interpreter (e.g. blocking device I/O), so callers can drive UMD concurrently
+// from multiple Python threads.
 using release_gil = nb::call_guard<nb::gil_scoped_release>;
 
 using namespace tt;

--- a/nanobind/py_api_logging.cpp
+++ b/nanobind/py_api_logging.cpp
@@ -7,6 +7,11 @@
 #include "umd/device/logging/config.hpp"
 
 namespace nb = nanobind;
+// Releases Python's Global Interpreter Lock (GIL) for the duration of the C++ call,
+// allowing other Python threads to run in parallel while this binding executes. Pass
+// release_gil() as a call guard to nb::class_::def() on methods that don't touch the
+// Python interpreter (e.g. blocking device I/O), so callers can drive UMD concurrently
+// from multiple Python threads.
 using release_gil = nb::call_guard<nb::gil_scoped_release>;
 
 using namespace tt::umd::logging;

--- a/nanobind/py_api_logging.cpp
+++ b/nanobind/py_api_logging.cpp
@@ -7,6 +7,7 @@
 #include "umd/device/logging/config.hpp"
 
 namespace nb = nanobind;
+using release_gil = nb::call_guard<nb::gil_scoped_release>;
 
 using namespace tt::umd::logging;
 
@@ -26,5 +27,6 @@ void bind_logging(nb::module_ &m) {
         "set_level",
         &set_level,
         nb::arg("lvl"),
+        release_gil(),
         "Sets the global logging level. Messages with severity levels lower than this level will not be logged.");
 }

--- a/nanobind/py_api_soc_descriptor.cpp
+++ b/nanobind/py_api_soc_descriptor.cpp
@@ -14,6 +14,11 @@
 #include "umd/device/types/core_coordinates.hpp"
 
 namespace nb = nanobind;
+// Releases Python's Global Interpreter Lock (GIL) for the duration of the C++ call,
+// allowing other Python threads to run in parallel while this binding executes. Pass
+// release_gil() as a call guard to nb::class_::def() on methods that don't touch the
+// Python interpreter (e.g. blocking device I/O), so callers can drive UMD concurrently
+// from multiple Python threads.
 using release_gil = nb::call_guard<nb::gil_scoped_release>;
 
 using namespace tt;

--- a/nanobind/py_api_soc_descriptor.cpp
+++ b/nanobind/py_api_soc_descriptor.cpp
@@ -14,6 +14,7 @@
 #include "umd/device/types/core_coordinates.hpp"
 
 namespace nb = nanobind;
+using release_gil = nb::call_guard<nb::gil_scoped_release>;
 
 using namespace tt;
 using namespace tt::umd;
@@ -34,8 +35,10 @@ void bind_soc_descriptor(nb::module_ &m) {
         .value("ETH", CoreType::ETH)
         .value("WORKER", CoreType::WORKER)
         .value("UNSPECIFIED", CoreType::UNSPECIFIED)
-        .def("__str__", [](CoreType ct) { return to_str(ct); })
-        .def("__repr__", [](CoreType ct) { return "CoreType." + to_str(ct); });
+        .def(
+            "__str__", [](CoreType ct) { return to_str(ct); }, release_gil())
+        .def(
+            "__repr__", [](CoreType ct) { return "CoreType." + to_str(ct); }, release_gil());
 
     // Bind CoordSystem enum.
     nb::enum_<CoordSystem>(m, "CoordSystem")
@@ -44,8 +47,10 @@ void bind_soc_descriptor(nb::module_ &m) {
         .value("TRANSLATED", CoordSystem::TRANSLATED)
         .value("NOC1", CoordSystem::NOC1)
         .value("LITERAL", CoordSystem::LITERAL)
-        .def("__str__", [](CoordSystem cs) { return to_str(cs); })
-        .def("__repr__", [](CoordSystem cs) { return "CoordSystem." + to_str(cs); });
+        .def(
+            "__str__", [](CoordSystem cs) { return to_str(cs); }, release_gil())
+        .def(
+            "__repr__", [](CoordSystem cs) { return "CoordSystem." + to_str(cs); }, release_gil());
 
     // Bind CoreCoord struct.
     nb::class_<CoreCoord>(m, "CoreCoord")
@@ -54,15 +59,17 @@ void bind_soc_descriptor(nb::module_ &m) {
             nb::arg("x"),
             nb::arg("y"),
             nb::arg("core_type"),
-            nb::arg("coord_system"))
+            nb::arg("coord_system"),
+            release_gil())
         .def_ro("x", &CoreCoord::x)
         .def_ro("y", &CoreCoord::y)
         .def_ro("core_type", &CoreCoord::core_type)
         .def_ro("coord_system", &CoreCoord::coord_system)
-        .def("__str__", &CoreCoord::str)
-        .def("__repr__", [](const CoreCoord &cc) { return cc.str(); })
-        .def("__eq__", &CoreCoord::operator==)
-        .def("__lt__", &CoreCoord::operator<);
+        .def("__str__", &CoreCoord::str, release_gil())
+        .def(
+            "__repr__", [](const CoreCoord &cc) { return cc.str(); }, release_gil())
+        .def("__eq__", &CoreCoord::operator==, release_gil())
+        .def("__lt__", &CoreCoord::operator<, release_gil());
 
     // Bind SocDescriptor class.
     nb::class_<SocDescriptor>(m, "SocDescriptor")
@@ -72,6 +79,7 @@ void bind_soc_descriptor(nb::module_ &m) {
                 new (soc_desc) SocDescriptor(tt_device.get_arch(), tt_device.get_chip_info());
             },
             nb::arg("tt_device"),
+            release_gil(),
             "Create a SocDescriptor from a TTDevice")
         .def(
             "get_cores",
@@ -79,22 +87,26 @@ void bind_soc_descriptor(nb::module_ &m) {
             nb::arg("core_type"),
             nb::arg("coord_system") = CoordSystem::NOC0,
             nb::arg("channel") = std::nullopt,
+            release_gil(),
             "Get all cores of a specific type in the specified coordinate system")
         .def(
             "get_harvested_cores",
             &SocDescriptor::get_harvested_cores,
             nb::arg("core_type"),
             nb::arg("coord_system") = CoordSystem::NOC0,
+            release_gil(),
             "Get all harvested cores of a specific type in the specified coordinate system")
         .def(
             "get_all_cores",
             &SocDescriptor::get_all_cores,
             nb::arg("coord_system") = CoordSystem::NOC0,
+            release_gil(),
             "Get all cores in the specified coordinate system")
         .def(
             "get_all_harvested_cores",
             &SocDescriptor::get_all_harvested_cores,
             nb::arg("coord_system") = CoordSystem::NOC0,
+            release_gil(),
             "Get all harvested cores in the specified coordinate system")
         .def(
             "serialize_to_file",
@@ -103,18 +115,21 @@ void bind_soc_descriptor(nb::module_ &m) {
                 return file_path.string();
             },
             nb::arg("dest_file") = "",
+            release_gil(),
             "Serialize the soc descriptor to a YAML file")
         .def(
             "get_eth_cores_for_channels",
             &SocDescriptor::get_eth_cores_for_channels,
             nb::arg("eth_channels"),
             nb::arg("coord_system") = CoordSystem::NOC0,
+            release_gil(),
             "Get ethernet cores for specified channels in the specified coordinate system")
         .def(
             "translate_coord_to",
             nb::overload_cast<const CoreCoord, const CoordSystem>(&SocDescriptor::translate_coord_to, nb::const_),
             nb::arg("core_coord"),
             nb::arg("coord_system"),
+            release_gil(),
             "Translate a CoreCoord to the specified coordinate system")
         .def(
             "translate_coord_to",
@@ -123,21 +138,25 @@ void bind_soc_descriptor(nb::module_ &m) {
             nb::arg("core_location"),
             nb::arg("input_coord_system"),
             nb::arg("target_coord_system"),
+            release_gil(),
             "Translate a tt_xy_pair from one coordinate system to another")
         .def(
             "translate_chip_coord_to_translated",
             &SocDescriptor::translate_chip_coord_to_translated,
             nb::arg("core"),
+            release_gil(),
             "Translate a chip coordinate to translated coordinate system in tt_xy_pair")
         .def(
             "translate_chip_coord_to_translated_coord",
             &SocDescriptor::translate_chip_coord_to_translated_coord,
             nb::arg("core"),
+            release_gil(),
             "Translate a chip coordinate to the correct pre-translation coordinates for device access")
         .def(
             "get_coord_at",
             &SocDescriptor::get_coord_at,
             nb::arg("core"),
             nb::arg("coord_system"),
+            release_gil(),
             "Get a CoreCoord at the given tt_xy_pair location in the specified coordinate system");
 }

--- a/nanobind/py_api_telemetry.cpp
+++ b/nanobind/py_api_telemetry.cpp
@@ -17,6 +17,11 @@
 #include "umd/device/types/wormhole_telemetry.hpp"
 
 namespace nb = nanobind;
+// Releases Python's Global Interpreter Lock (GIL) for the duration of the C++ call,
+// allowing other Python threads to run in parallel while this binding executes. Pass
+// release_gil() as a call guard to nb::class_::def() on methods that don't touch the
+// Python interpreter (e.g. blocking device I/O), so callers can drive UMD concurrently
+// from multiple Python threads.
 using release_gil = nb::call_guard<nb::gil_scoped_release>;
 
 using namespace tt::umd;

--- a/nanobind/py_api_telemetry.cpp
+++ b/nanobind/py_api_telemetry.cpp
@@ -17,6 +17,7 @@
 #include "umd/device/types/wormhole_telemetry.hpp"
 
 namespace nb = nanobind;
+using release_gil = nb::call_guard<nb::gil_scoped_release>;
 
 using namespace tt::umd;
 
@@ -77,7 +78,8 @@ void bind_telemetry(nb::module_& m) {
         .value("ETH_LIVE_STATUS", wormhole::LegacyTelemetryTag::ETH_LIVE_STATUS)
         .value("FW_BUNDLE_VERSION", wormhole::LegacyTelemetryTag::FW_BUNDLE_VERSION)
         .value("NUMBER_OF_TAGS", wormhole::LegacyTelemetryTag::NUMBER_OF_TAGS)
-        .def("__int__", [](wormhole::LegacyTelemetryTag tag) { return static_cast<int>(tag); });
+        .def(
+            "__int__", [](wormhole::LegacyTelemetryTag tag) { return static_cast<int>(tag); }, release_gil());
 
     // Universal telemetry tags for all archs for newer firmware.
     nb::enum_<TelemetryTag>(m, "TelemetryTag")
@@ -142,7 +144,8 @@ void bind_telemetry(nb::module_& m) {
         .value("AICLK_LIMIT_MAX", TelemetryTag::AICLK_LIMIT_MAX)
         .value("TDP_LIMIT_MAX", TelemetryTag::TDP_LIMIT_MAX)
         .value("NUMBER_OF_TAGS", TelemetryTag::NUMBER_OF_TAGS)
-        .def("__int__", [](TelemetryTag tag) { return static_cast<int>(tag); });
+        .def(
+            "__int__", [](TelemetryTag tag) { return static_cast<int>(tag); }, release_gil());
 
     nb::enum_<GddrModule>(m, "GddrModule", "GDDR module indices for Blackhole")
         .value("GDDR_0", GddrModule::GDDR_0)
@@ -153,7 +156,8 @@ void bind_telemetry(nb::module_& m) {
         .value("GDDR_5", GddrModule::GDDR_5)
         .value("GDDR_6", GddrModule::GDDR_6)
         .value("GDDR_7", GddrModule::GDDR_7)
-        .def("__int__", [](GddrModule gddr) { return static_cast<int>(gddr); });
+        .def(
+            "__int__", [](GddrModule gddr) { return static_cast<int>(gddr); }, release_gil());
 
     nb::class_<GddrModuleTelemetry>(m, "GddrModuleTelemetry", "Per-module GDDR telemetry (temp, errors, status).")
         .def_ro("dram_temperature_top", &GddrModuleTelemetry::dram_temperature_top)
@@ -174,58 +178,70 @@ void bind_telemetry(nb::module_& m) {
         });
 
     nb::class_<ArcTelemetryReader>(m, "ArcTelemetryReader")
-        .def("read_entry", &ArcTelemetryReader::read_entry, nb::arg("telemetry_tag"))
-        .def("is_entry_available", &ArcTelemetryReader::is_entry_available, nb::arg("telemetry_tag"));
+        .def("read_entry", &ArcTelemetryReader::read_entry, nb::arg("telemetry_tag"), release_gil())
+        .def("is_entry_available", &ArcTelemetryReader::is_entry_available, nb::arg("telemetry_tag"), release_gil());
 
     // SmBusArcTelemetryReader binding - for direct instantiation when SMBUS telemetry is needed.
     nb::class_<SmBusArcTelemetryReader, ArcTelemetryReader>(m, "SmBusArcTelemetryReader")
-        .def(nb::init<TTDevice*>(), nb::arg("tt_device"))
-        .def("read_entry", &SmBusArcTelemetryReader::read_entry, nb::arg("telemetry_tag"))
-        .def("is_entry_available", &SmBusArcTelemetryReader::is_entry_available, nb::arg("telemetry_tag"));
+        .def(nb::init<TTDevice*>(), nb::arg("tt_device"), release_gil())
+        .def("read_entry", &SmBusArcTelemetryReader::read_entry, nb::arg("telemetry_tag"), release_gil())
+        .def(
+            "is_entry_available",
+            &SmBusArcTelemetryReader::is_entry_available,
+            nb::arg("telemetry_tag"),
+            release_gil());
 
     nb::enum_<tt::DramTrainingStatus>(m, "DramTrainingStatus")
         .value("IN_PROGRESS", tt::DramTrainingStatus::IN_PROGRESS)
         .value("FAIL", tt::DramTrainingStatus::FAIL)
         .value("SUCCESS", tt::DramTrainingStatus::SUCCESS)
-        .def("__int__", [](tt::DramTrainingStatus status) { return static_cast<int>(status); });
+        .def(
+            "__int__", [](tt::DramTrainingStatus status) { return static_cast<int>(status); }, release_gil());
 
     nb::class_<FirmwareInfoProvider>(m, "FirmwareInfoProvider")
-        .def("get_firmware_version", &FirmwareInfoProvider::get_firmware_version)
-        .def("get_board_id", &FirmwareInfoProvider::get_board_id)
-        .def("get_eth_fw_version", &FirmwareInfoProvider::get_eth_fw_version)
-        .def("get_asic_location", &FirmwareInfoProvider::get_asic_location)
-        .def("get_aiclk", &FirmwareInfoProvider::get_aiclk)
-        .def("get_axiclk", &FirmwareInfoProvider::get_axiclk)
-        .def("get_arcclk", &FirmwareInfoProvider::get_arcclk)
-        .def("get_fan_speed", &FirmwareInfoProvider::get_fan_speed)
-        .def("get_tdp", &FirmwareInfoProvider::get_tdp)
-        .def("get_tdc", &FirmwareInfoProvider::get_tdc)
-        .def("get_vcore", &FirmwareInfoProvider::get_vcore)
-        .def("get_board_temperature", &FirmwareInfoProvider::get_board_temperature)
-        .def("get_dram_training_status", &FirmwareInfoProvider::get_dram_training_status, nb::arg("num_dram_channels"))
-        .def("get_max_clock_freq", &FirmwareInfoProvider::get_max_clock_freq)
-        .def("get_asic_location", &FirmwareInfoProvider::get_asic_location)
-        .def("get_heartbeat", &FirmwareInfoProvider::get_heartbeat)
-        .def("get_aggregated_dram_telemetry", &FirmwareInfoProvider::get_aggregated_dram_telemetry)
-        .def("get_dram_telemetry", &FirmwareInfoProvider::get_dram_telemetry, nb::arg("gddr_module"))
-        .def("get_dram_speed", &FirmwareInfoProvider::get_dram_speed)
-        .def("get_current_max_dram_temperature", &FirmwareInfoProvider::get_current_max_dram_temperature)
-        .def("get_thm_limit_shutdown", &FirmwareInfoProvider::get_thm_limit_shutdown)
-        .def("get_board_power_limit", &FirmwareInfoProvider::get_board_power_limit)
-        .def("get_thm_limit_throttle", &FirmwareInfoProvider::get_thm_limit_throttle)
-        .def("get_therm_trip_count", &FirmwareInfoProvider::get_therm_trip_count)
-        .def("get_eth_heartbeat_status", &FirmwareInfoProvider::get_eth_heartbeat_status)
-        .def("get_eth_retrain_status", &FirmwareInfoProvider::get_eth_retrain_status)
+        .def("get_firmware_version", &FirmwareInfoProvider::get_firmware_version, release_gil())
+        .def("get_board_id", &FirmwareInfoProvider::get_board_id, release_gil())
+        .def("get_eth_fw_version", &FirmwareInfoProvider::get_eth_fw_version, release_gil())
+        .def("get_asic_location", &FirmwareInfoProvider::get_asic_location, release_gil())
+        .def("get_aiclk", &FirmwareInfoProvider::get_aiclk, release_gil())
+        .def("get_axiclk", &FirmwareInfoProvider::get_axiclk, release_gil())
+        .def("get_arcclk", &FirmwareInfoProvider::get_arcclk, release_gil())
+        .def("get_fan_speed", &FirmwareInfoProvider::get_fan_speed, release_gil())
+        .def("get_tdp", &FirmwareInfoProvider::get_tdp, release_gil())
+        .def("get_tdc", &FirmwareInfoProvider::get_tdc, release_gil())
+        .def("get_vcore", &FirmwareInfoProvider::get_vcore, release_gil())
+        .def("get_board_temperature", &FirmwareInfoProvider::get_board_temperature, release_gil())
+        .def(
+            "get_dram_training_status",
+            &FirmwareInfoProvider::get_dram_training_status,
+            nb::arg("num_dram_channels"),
+            release_gil())
+        .def("get_max_clock_freq", &FirmwareInfoProvider::get_max_clock_freq, release_gil())
+        .def("get_asic_location", &FirmwareInfoProvider::get_asic_location, release_gil())
+        .def("get_heartbeat", &FirmwareInfoProvider::get_heartbeat, release_gil())
+        .def("get_aggregated_dram_telemetry", &FirmwareInfoProvider::get_aggregated_dram_telemetry, release_gil())
+        .def("get_dram_telemetry", &FirmwareInfoProvider::get_dram_telemetry, nb::arg("gddr_module"), release_gil())
+        .def("get_dram_speed", &FirmwareInfoProvider::get_dram_speed, release_gil())
+        .def("get_current_max_dram_temperature", &FirmwareInfoProvider::get_current_max_dram_temperature, release_gil())
+        .def("get_thm_limit_shutdown", &FirmwareInfoProvider::get_thm_limit_shutdown, release_gil())
+        .def("get_board_power_limit", &FirmwareInfoProvider::get_board_power_limit, release_gil())
+        .def("get_thm_limit_throttle", &FirmwareInfoProvider::get_thm_limit_throttle, release_gil())
+        .def("get_therm_trip_count", &FirmwareInfoProvider::get_therm_trip_count, release_gil())
+        .def("get_eth_heartbeat_status", &FirmwareInfoProvider::get_eth_heartbeat_status, release_gil())
+        .def("get_eth_retrain_status", &FirmwareInfoProvider::get_eth_retrain_status, release_gil())
         .def_static(
             "get_minimum_compatible_firmware_version",
             &FirmwareInfoProvider::get_minimum_compatible_firmware_version,
-            nb::arg("arch"))
+            nb::arg("arch"),
+            release_gil())
         .def_static(
             "get_latest_supported_firmware_version",
             &FirmwareInfoProvider::get_latest_supported_firmware_version,
-            nb::arg("arch"))
+            nb::arg("arch"),
+            release_gil())
         .def_static(
             "create_firmware_info_provider",
             &FirmwareInfoProvider::create_firmware_info_provider,
-            nb::arg("tt_device"));
+            nb::arg("tt_device"),
+            release_gil());
 }

--- a/nanobind/py_api_topology_discovery.cpp
+++ b/nanobind/py_api_topology_discovery.cpp
@@ -23,6 +23,11 @@
 #include "umd/device/types/communication_protocol.hpp"
 
 namespace nb = nanobind;
+// Releases Python's Global Interpreter Lock (GIL) for the duration of the C++ call,
+// allowing other Python threads to run in parallel while this binding executes. Pass
+// release_gil() as a call guard to nb::class_::def() on methods that don't touch the
+// Python interpreter (e.g. blocking device I/O), so callers can drive UMD concurrently
+// from multiple Python threads.
 using release_gil = nb::call_guard<nb::gil_scoped_release>;
 
 using namespace tt;

--- a/nanobind/py_api_topology_discovery.cpp
+++ b/nanobind/py_api_topology_discovery.cpp
@@ -23,6 +23,7 @@
 #include "umd/device/types/communication_protocol.hpp"
 
 namespace nb = nanobind;
+using release_gil = nb::call_guard<nb::gil_scoped_release>;
 
 using namespace tt;
 using namespace tt::umd;
@@ -33,36 +34,52 @@ std::unique_ptr<TTDevice> create_remote_wormhole_tt_device(
 
 void bind_topology_discovery(nb::module_& m) {
     nb::class_<ClusterDescriptor>(m, "ClusterDescriptor")
-        .def_static("create_from_yaml_content", &ClusterDescriptor::create_from_yaml_content, nb::arg("yaml_content"))
-        .def("get_all_chips", &ClusterDescriptor::get_all_chips)
-        .def("is_chip_mmio_capable", &ClusterDescriptor::is_chip_mmio_capable, nb::arg("chip_id"))
-        .def("is_chip_remote", &ClusterDescriptor::is_chip_remote, nb::arg("chip_id"))
-        .def("get_closest_mmio_capable_chip", &ClusterDescriptor::get_closest_mmio_capable_chip, nb::arg("chip"))
-        .def("get_chips_local_first", &ClusterDescriptor::get_chips_local_first, nb::arg("chips"))
-        .def("get_chip_locations", &ClusterDescriptor::get_chip_locations)
-        .def("get_chips_with_mmio", &ClusterDescriptor::get_chips_with_mmio)
-        .def("get_active_eth_channels", &ClusterDescriptor::get_active_eth_channels, nb::arg("chip_id"))
-        .def("get_ethernet_connections", &ClusterDescriptor::get_ethernet_connections)
-        .def("get_chip_unique_ids", &ClusterDescriptor::get_chip_unique_ids)
-        .def("get_io_device_type", &ClusterDescriptor::get_io_device_type)
+        .def_static(
+            "create_from_yaml_content",
+            &ClusterDescriptor::create_from_yaml_content,
+            nb::arg("yaml_content"),
+            release_gil())
+        .def("get_all_chips", &ClusterDescriptor::get_all_chips, release_gil())
+        .def("is_chip_mmio_capable", &ClusterDescriptor::is_chip_mmio_capable, nb::arg("chip_id"), release_gil())
+        .def("is_chip_remote", &ClusterDescriptor::is_chip_remote, nb::arg("chip_id"), release_gil())
+        .def(
+            "get_closest_mmio_capable_chip",
+            &ClusterDescriptor::get_closest_mmio_capable_chip,
+            nb::arg("chip"),
+            release_gil())
+        .def("get_chips_local_first", &ClusterDescriptor::get_chips_local_first, nb::arg("chips"), release_gil())
+        .def("get_chip_locations", &ClusterDescriptor::get_chip_locations, release_gil())
+        .def("get_chips_with_mmio", &ClusterDescriptor::get_chips_with_mmio, release_gil())
+        .def("get_active_eth_channels", &ClusterDescriptor::get_active_eth_channels, nb::arg("chip_id"), release_gil())
+        .def("get_ethernet_connections", &ClusterDescriptor::get_ethernet_connections, release_gil())
+        .def("get_chip_unique_ids", &ClusterDescriptor::get_chip_unique_ids, release_gil())
+        .def("get_io_device_type", &ClusterDescriptor::get_io_device_type, release_gil())
         .def(
             "serialize_to_file",
             [](const ClusterDescriptor& self, const std::string& dest_file) -> std::string {
                 std::filesystem::path file_path = self.serialize_to_file(dest_file);
                 return file_path.string();
             },
-            nb::arg("dest_file") = "")
+            nb::arg("dest_file") = "",
+            release_gil())
         .def(
             "get_arch",
             static_cast<tt::ARCH (ClusterDescriptor::*)(ChipId) const>(&ClusterDescriptor::get_arch),
-            nb::arg("chip_id"))
-        .def("get_board_type", &ClusterDescriptor::get_board_type, nb::arg("chip_id"), "Get board type for a chip")
+            nb::arg("chip_id"),
+            release_gil())
+        .def(
+            "get_board_type",
+            &ClusterDescriptor::get_board_type,
+            nb::arg("chip_id"),
+            release_gil(),
+            "Get board type for a chip")
         .def(
             "get_board_id_for_chip",
             &ClusterDescriptor::get_board_id_for_chip,
             nb::arg("chip"),
+            release_gil(),
             "Get board ID for a chip")
-        .def("get_unhealthy_devices", &ClusterDescriptor::get_unhealthy_devices);
+        .def("get_unhealthy_devices", &ClusterDescriptor::get_unhealthy_devices, release_gil());
 
     nb::class_<TopologyDiscoveryOptions> topology_discovery_options(m, "TopologyDiscoveryOptions");
 
@@ -70,7 +87,7 @@ void bind_topology_discovery(nb::module_& m) {
         .value("THROW", TopologyDiscoveryOptions::Action::THROW)
         .value("IGNORE", TopologyDiscoveryOptions::Action::IGNORE);
 
-    topology_discovery_options.def(nb::init<>())
+    topology_discovery_options.def(nb::init<>(), release_gil())
         .def_rw("cmfw_mismatch_action", &TopologyDiscoveryOptions::cmfw_mismatch_action)
         .def_rw("cmfw_unsupported_action", &TopologyDiscoveryOptions::cmfw_unsupported_action)
         .def_rw("eth_fw_mismatch_action", &TopologyDiscoveryOptions::eth_fw_mismatch_action)
@@ -93,12 +110,14 @@ void bind_topology_discovery(nb::module_& m) {
             },
             nb::arg("options") = TopologyDiscoveryOptions{},
             nb::arg("io_device_type") = IODeviceType::PCIe,
-            nb::arg("soc_descriptor_path") = "")
+            nb::arg("soc_descriptor_path") = "",
+            release_gil())
         .def_static(
             "discover",
             &TopologyDiscovery::discover,
             nb::arg("options") = TopologyDiscoveryOptions{},
             nb::arg("io_device_type") = IODeviceType::PCIe,
             nb::arg("soc_descriptor_path") = "",
+            release_gil(),
             "Discover topology and return both ClusterDescriptor and TTDevices");
 }

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -178,7 +178,10 @@ void bind_tt_device(nb::module_ &m) {
             [](TTDevice &self, uint32_t core_x, uint32_t core_y, uint64_t addr) -> uint32_t {
                 tt_xy_pair core = {core_x, core_y};
                 uint32_t value = 0;
-                self.read_from_device(&value, core, addr, sizeof(uint32_t));
+                {
+                    nb::gil_scoped_release release;
+                    self.read_from_device(&value, core, addr, sizeof(uint32_t));
+                }
                 return value;
             },
             nb::arg("core_x"),
@@ -189,7 +192,10 @@ void bind_tt_device(nb::module_ &m) {
             "noc_write32",
             [](TTDevice &self, uint32_t core_x, uint32_t core_y, uint64_t addr, uint32_t value) -> void {
                 tt_xy_pair core = {core_x, core_y};
-                self.write_to_device(&value, core, addr, sizeof(uint32_t));
+                {
+                    nb::gil_scoped_release release;
+                    self.write_to_device(&value, core, addr, sizeof(uint32_t));
+                }
             },
             nb::arg("core_x"),
             nb::arg("core_y"),
@@ -201,7 +207,10 @@ void bind_tt_device(nb::module_ &m) {
             [](TTDevice &self, uint32_t core_x, uint32_t core_y, uint64_t addr, size_t size) -> nb::bytes {
                 tt_xy_pair core = {core_x, core_y};
                 std::vector<uint8_t> buffer(size);
-                self.read_from_device(buffer.data(), core, addr, size);
+                {
+                    nb::gil_scoped_release release;
+                    self.read_from_device(buffer.data(), core, addr, size);
+                }
                 return nb::bytes(reinterpret_cast<const char *>(buffer.data()), buffer.size());
             },
             nb::arg("core_x"),
@@ -219,7 +228,10 @@ void bind_tt_device(nb::module_ &m) {
                 tt_xy_pair core = {core_x, core_y};
                 uint8_t *data_ptr = reinterpret_cast<uint8_t *>(buffer.data());
                 size_t data_size = buffer.size();
-                self.read_from_device(data_ptr, core, addr, data_size);
+                {
+                    nb::gil_scoped_release release;
+                    self.read_from_device(data_ptr, core, addr, data_size);
+                }
             },
             nb::arg("noc_id"),
             nb::arg("core_x"),
@@ -233,7 +245,10 @@ void bind_tt_device(nb::module_ &m) {
                 tt_xy_pair core = {core_x, core_y};
                 const char *data_ptr = data.c_str();
                 size_t data_size = data.size();
-                self.write_to_device(data_ptr, core, addr, data_size);
+                {
+                    nb::gil_scoped_release release;
+                    self.write_to_device(data_ptr, core, addr, data_size);
+                }
             },
             nb::arg("core_x"),
             nb::arg("core_y"),
@@ -242,12 +257,18 @@ void bind_tt_device(nb::module_ &m) {
             "Write arbitrary-length data to a core at the specified address")
         .def(
             "bar_read32",
-            &TTDevice::bar_read32,
+            [](TTDevice &self, uint32_t addr) -> uint32_t {
+                nb::gil_scoped_release release;
+                return self.bar_read32(addr);
+            },
             nb::arg("addr"),
             "Read a 32-bit value from the specified address on bar0")
         .def(
             "bar_write32",
-            &TTDevice::bar_write32,
+            [](TTDevice &self, uint32_t addr, uint32_t data) -> void {
+                nb::gil_scoped_release release;
+                self.bar_write32(addr, data);
+            },
             nb::arg("addr"),
             nb::arg("data"),
             "Write a 32-bit value to the specified address on bar0")
@@ -289,7 +310,10 @@ void bind_tt_device(nb::module_ &m) {
             [](TTDevice &self, uint32_t core_x, uint32_t core_y, uint64_t addr, size_t size) -> nb::bytes {
                 tt_xy_pair core = {core_x, core_y};
                 std::vector<uint8_t> buffer(size);
-                self.dma_read_from_device(buffer.data(), size, core, addr);
+                {
+                    nb::gil_scoped_release release;
+                    self.dma_read_from_device(buffer.data(), size, core, addr);
+                }
                 return nb::bytes(reinterpret_cast<const char *>(buffer.data()), buffer.size());
             },
             nb::arg("core_x"),
@@ -307,7 +331,10 @@ void bind_tt_device(nb::module_ &m) {
                 tt_xy_pair core = {core_x, core_y};
                 uint8_t *data_ptr = reinterpret_cast<uint8_t *>(buffer.data());
                 size_t data_size = buffer.size();
-                self.dma_read_from_device(data_ptr, data_size, core, addr);
+                {
+                    nb::gil_scoped_release release;
+                    self.dma_read_from_device(data_ptr, data_size, core, addr);
+                }
             },
             nb::arg("noc_id"),
             nb::arg("core_x"),
@@ -321,7 +348,10 @@ void bind_tt_device(nb::module_ &m) {
                 tt_xy_pair core = {core_x, core_y};
                 const char *data_ptr = data.c_str();
                 size_t data_size = data.size();
-                self.dma_write_to_device(data_ptr, data_size, core, addr);
+                {
+                    nb::gil_scoped_release release;
+                    self.dma_write_to_device(data_ptr, data_size, core, addr);
+                }
             },
             nb::arg("core_x"),
             nb::arg("core_y"),
@@ -345,8 +375,12 @@ void bind_tt_device(nb::module_ &m) {
                     msg_code = wormhole::ARC_MSG_COMMON_PREFIX | msg_code;
                 }
                 std::vector<uint32_t> return_values = {0, 0};
-                uint32_t exit_code = self.get_arc_messenger()->send_message(
-                    msg_code, return_values, args, std::chrono::milliseconds(timeout_ms));
+                uint32_t exit_code;
+                {
+                    nb::gil_scoped_release release;
+                    exit_code = self.get_arc_messenger()->send_message(
+                        msg_code, return_values, args, std::chrono::milliseconds(timeout_ms));
+                }
                 return std::make_tuple(exit_code, return_values[0], return_values[1]);
             },
             nb::arg("msg_code"),
@@ -377,8 +411,12 @@ void bind_tt_device(nb::module_ &m) {
                 }
                 std::vector<uint32_t> args = {arg0, arg1};
                 std::vector<uint32_t> return_values = {0, 0};
-                uint32_t exit_code = self.get_arc_messenger()->send_message(
-                    msg_code, return_values, args, std::chrono::milliseconds(timeout_ms));
+                uint32_t exit_code;
+                {
+                    nb::gil_scoped_release release;
+                    exit_code = self.get_arc_messenger()->send_message(
+                        msg_code, return_values, args, std::chrono::milliseconds(timeout_ms));
+                }
                 return std::make_tuple(exit_code, return_values[0], return_values[1]);
             },
             nb::arg("msg_code"),
@@ -409,8 +447,12 @@ void bind_tt_device(nb::module_ &m) {
                 }
                 std::vector<uint32_t> args = {arg0, arg1};
                 std::vector<uint32_t> return_values = {0, 0};
-                uint32_t exit_code = self.get_arc_messenger()->send_message(
-                    msg_code, return_values, args, std::chrono::milliseconds(timeout * 1000));
+                uint32_t exit_code;
+                {
+                    nb::gil_scoped_release release;
+                    exit_code = self.get_arc_messenger()->send_message(
+                        msg_code, return_values, args, std::chrono::milliseconds(timeout * 1000));
+                }
                 return std::make_tuple(exit_code, return_values[0], return_values[1]);
             },
             nb::arg("msg_code"),

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -142,8 +142,7 @@ void bind_tt_device(nb::module_ &m) {
         .def(
             "get_local_device",
             &RemoteCommunication::get_local_device,
-            nb::rv_policy::reference_internal,
-            release_gil())
+            nb::rv_policy::reference_internal)
         .def(
             "get_remote_transfer_ethernet_core",
             [](RemoteCommunication &self) -> std::tuple<int, int> {
@@ -179,8 +178,7 @@ void bind_tt_device(nb::module_ &m) {
         .def(
             "get_arc_telemetry_reader",
             &TTDevice::get_arc_telemetry_reader,
-            nb::rv_policy::reference_internal,
-            release_gil())
+            nb::rv_policy::reference_internal)
         .def("get_arch", &TTDevice::get_arch, release_gil())
         .def("get_board_id", &TTDevice::get_board_id, release_gil())
         .def("board_id", &TTDevice::get_board_id, release_gil())
@@ -193,13 +191,11 @@ void bind_tt_device(nb::module_ &m) {
         .def(
             "get_remote_communication",
             &TTDevice::get_remote_communication,
-            nb::rv_policy::reference_internal,
-            release_gil())
+            nb::rv_policy::reference_internal)
         .def(
             "get_firmware_info_provider",
             &TTDevice::get_firmware_info_provider,
-            nb::rv_policy::reference_internal,
-            release_gil())
+            nb::rv_policy::reference_internal)
         // Compatibility with luwen's API - these methods just return self.
         .def(
             "as_wh",
@@ -295,20 +291,16 @@ void bind_tt_device(nb::module_ &m) {
             "Write arbitrary-length data to a core at the specified address")
         .def(
             "bar_read32",
-            [](TTDevice &self, uint32_t addr) -> uint32_t {
-                nb::gil_scoped_release release;
-                return self.bar_read32(addr);
-            },
+            &TTDevice::bar_read32,
             nb::arg("addr"),
+            release_gil(),
             "Read a 32-bit value from the specified address on bar0")
         .def(
             "bar_write32",
-            [](TTDevice &self, uint32_t addr, uint32_t data) -> void {
-                nb::gil_scoped_release release;
-                self.bar_write32(addr, data);
-            },
+            &TTDevice::bar_write32,
             nb::arg("addr"),
             nb::arg("data"),
+            release_gil(),
             "Write a 32-bit value to the specified address on bar0")
         .def(
             "is_pcie_hung",
@@ -620,7 +612,6 @@ void bind_tt_device(nb::module_ &m) {
             "get_soc_descriptor",
             &TTSimTTDevice::get_soc_descriptor,
             nb::rv_policy::reference_internal,
-            release_gil(),
             "Get the SocDescriptor associated with this simulation device.")
 
         .def("get_clock", &TTSimTTDevice::get_clock, release_gil(), "Get the clock frequency.")

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -31,6 +31,7 @@
 #include "umd/device/types/tensix_soft_reset_options.hpp"
 #include "umd/device/utils/error.hpp"
 namespace nb = nanobind;
+using release_gil = nb::call_guard<nb::gil_scoped_release>;
 
 using namespace tt;
 using namespace tt::umd;
@@ -79,6 +80,7 @@ void bind_tt_device(nb::module_ &m) {
     m.def(
         "raise_sigbus_error_for_testing",
         []() { throw error::SigbusError("This is a test exception from C++"); },
+        release_gil(),
         "A helper function to verify SigbusError propagation");
 
     nb::class_<PciDeviceInfo>(m, "PciDeviceInfo")
@@ -91,23 +93,37 @@ void bind_tt_device(nb::module_ &m) {
         .def_ro("pci_device", &PciDeviceInfo::pci_device)
         .def_ro("pci_function", &PciDeviceInfo::pci_function)
         .def_ro("pci_bdf", &PciDeviceInfo::pci_bdf)
-        .def("get_arch", &PciDeviceInfo::get_arch);
+        .def("get_arch", &PciDeviceInfo::get_arch, release_gil());
 
     nb::class_<PCIDevice>(m, "PCIDevice")
-        .def(nb::init<int>())
+        .def(nb::init<int>(), release_gil())
         .def_static(
-            "enumerate_devices", []() { return PCIDevice::enumerate_devices(); }, "Enumerates PCI devices.")
+            "enumerate_devices",
+            []() { return PCIDevice::enumerate_devices(); },
+            release_gil(),
+            "Enumerates PCI devices.")
         .def_static(
             "enumerate_devices_info",
             []() { return PCIDevice::enumerate_devices_info(); },
+            release_gil(),
             "Enumerates PCI device information.")
-        .def("get_device_info", &PCIDevice::get_device_info)
-        .def("get_device_num", &PCIDevice::get_device_num)
-        .def_static("read_kmd_version", &PCIDevice::read_kmd_version, "Read KMD version installed on the system.")
-        .def_static("read_device_info", &PCIDevice::read_device_info, nb::arg("fd"), "Read PCI device information.")
+        .def("get_device_info", &PCIDevice::get_device_info, release_gil())
+        .def("get_device_num", &PCIDevice::get_device_num, release_gil())
+        .def_static(
+            "read_kmd_version",
+            &PCIDevice::read_kmd_version,
+            release_gil(),
+            "Read KMD version installed on the system.")
+        .def_static(
+            "read_device_info",
+            &PCIDevice::read_device_info,
+            nb::arg("fd"),
+            release_gil(),
+            "Read PCI device information.")
         .def_static(
             "is_arch_agnostic_reset_supported",
             &PCIDevice::is_arch_agnostic_reset_supported,
+            release_gil(),
             "Check if KMD supports arch agnostic reset.");
 
     nb::class_<RemoteCommunication>(m, "RemoteCommunication")
@@ -121,12 +137,20 @@ void bind_tt_device(nb::module_ &m) {
                 }
                 self.set_remote_transfer_ethernet_cores(xy_cores);
             },
-            nb::arg("cores"))
-        .def("get_local_device", &RemoteCommunication::get_local_device, nb::rv_policy::reference_internal)
-        .def("get_remote_transfer_ethernet_core", [](RemoteCommunication &self) -> std::tuple<int, int> {
-            tt_xy_pair core = self.get_remote_transfer_ethernet_core();
-            return std::make_tuple(core.x, core.y);
-        });
+            nb::arg("cores"),
+            release_gil())
+        .def(
+            "get_local_device",
+            &RemoteCommunication::get_local_device,
+            nb::rv_policy::reference_internal,
+            release_gil())
+        .def(
+            "get_remote_transfer_ethernet_core",
+            [](RemoteCommunication &self) -> std::tuple<int, int> {
+                tt_xy_pair core = self.get_remote_transfer_ethernet_core();
+                return std::make_tuple(core.x, core.y);
+            },
+            release_gil());
 
     auto tt_device_class = nb::class_<TTDevice>(m, "TTDevice");
 
@@ -141,27 +165,41 @@ void bind_tt_device(nb::module_ &m) {
             nb::arg("device_number"),
             nb::arg("device_type") = IODeviceType::PCIe,
             nb::arg("use_safe_api") = true,
-            nb::rv_policy::take_ownership)
-        .def("set_power_state", &TTDevice::set_power_state, nb::arg("busy"))
+            nb::rv_policy::take_ownership,
+            release_gil())
+        .def("set_power_state", &TTDevice::set_power_state, nb::arg("busy"), release_gil())
         .def(
             "init_tt_device",
             &TTDevice::init_tt_device,
             nb::arg("timeout_ms") = timeout::ARC_STARTUP_TIMEOUT,
-            nb::arg("soc_descriptor_path") = "")
-        .def("get_soc_descriptor", &TTDevice::get_soc_descriptor)
-        .def("get_chip_info", &TTDevice::get_chip_info)
-        .def("get_arc_telemetry_reader", &TTDevice::get_arc_telemetry_reader, nb::rv_policy::reference_internal)
-        .def("get_arch", &TTDevice::get_arch)
-        .def("get_board_id", &TTDevice::get_board_id)
-        .def("board_id", &TTDevice::get_board_id)
-        .def("get_board_type", &TTDevice::get_board_type)
-        .def("get_communication_device_type", &TTDevice::get_communication_device_type)
-        .def("get_communication_device_id", &TTDevice::get_communication_device_id)
-        .def("get_pci_device", &TTDevice::get_pci_device, nb::rv_policy::reference)
-        .def("get_noc_translation_enabled", &TTDevice::get_noc_translation_enabled)
-        .def("is_remote", &TTDevice::is_remote, "Returns true if this is a remote TTDevice")
-        .def("get_remote_communication", &TTDevice::get_remote_communication, nb::rv_policy::reference_internal)
-        .def("get_firmware_info_provider", &TTDevice::get_firmware_info_provider, nb::rv_policy::reference_internal)
+            nb::arg("soc_descriptor_path") = "",
+            release_gil())
+        .def("get_soc_descriptor", &TTDevice::get_soc_descriptor, release_gil())
+        .def("get_chip_info", &TTDevice::get_chip_info, release_gil())
+        .def(
+            "get_arc_telemetry_reader",
+            &TTDevice::get_arc_telemetry_reader,
+            nb::rv_policy::reference_internal,
+            release_gil())
+        .def("get_arch", &TTDevice::get_arch, release_gil())
+        .def("get_board_id", &TTDevice::get_board_id, release_gil())
+        .def("board_id", &TTDevice::get_board_id, release_gil())
+        .def("get_board_type", &TTDevice::get_board_type, release_gil())
+        .def("get_communication_device_type", &TTDevice::get_communication_device_type, release_gil())
+        .def("get_communication_device_id", &TTDevice::get_communication_device_id, release_gil())
+        .def("get_pci_device", &TTDevice::get_pci_device, nb::rv_policy::reference, release_gil())
+        .def("get_noc_translation_enabled", &TTDevice::get_noc_translation_enabled, release_gil())
+        .def("is_remote", &TTDevice::is_remote, release_gil(), "Returns true if this is a remote TTDevice")
+        .def(
+            "get_remote_communication",
+            &TTDevice::get_remote_communication,
+            nb::rv_policy::reference_internal,
+            release_gil())
+        .def(
+            "get_firmware_info_provider",
+            &TTDevice::get_firmware_info_provider,
+            nb::rv_policy::reference_internal,
+            release_gil())
         // Compatibility with luwen's API - these methods just return self.
         .def(
             "as_wh",
@@ -277,12 +315,14 @@ void bind_tt_device(nb::module_ &m) {
             &TTDevice::is_pcie_hung,
             nb::arg("data_read") = HANG_READ_VALUE,
             nb::arg("action") = TTDevice::HangAction::THROW,
+            release_gil(),
             "Check if the PCIe communication is hung.")
         .def(
             "is_noc_hung",
             &TTDevice::is_noc_hung,
             nb::arg("noc"),
             nb::arg("action") = TTDevice::HangAction::THROW,
+            release_gil(),
             "Check if the specified NOC is hung.")
         .def(
             "get_risc_reset_state",
@@ -292,6 +332,7 @@ void bind_tt_device(nb::module_ &m) {
             },
             nb::arg("core_x"),
             nb::arg("core_y"),
+            release_gil(),
             "Get the raw soft reset register value for a core in translated coordinates. "
             "The bit layout of this value corresponds to TensixSoftResetOptions.")
         .def(
@@ -303,6 +344,7 @@ void bind_tt_device(nb::module_ &m) {
             nb::arg("core_x"),
             nb::arg("core_y"),
             nb::arg("soft_reset_raw_value"),
+            release_gil(),
             "Set the raw soft reset register value for a core in translated coordinates. "
             "The bit layout of this value corresponds to TensixSoftResetOptions; do not pass RiscType bits here.")
         .def(
@@ -468,6 +510,7 @@ void bind_tt_device(nb::module_ &m) {
             [](TTDevice &device) { return SPITTDevice::create(&device); },
             nb::arg("device"),
             nb::rv_policy::take_ownership,
+            release_gil(),
             "Create an SPITTDevice for the given TTDevice (factory method that returns architecture-specific "
             "implementation)")
         .def(
@@ -475,7 +518,10 @@ void bind_tt_device(nb::module_ &m) {
             [](SPITTDevice &self, uint32_t addr, nb::bytearray data) -> void {
                 uint8_t *data_ptr = reinterpret_cast<uint8_t *>(data.data());
                 size_t data_size = data.size();
-                self.read(addr, data_ptr, data_size);
+                {
+                    nb::gil_scoped_release release;
+                    self.read(addr, data_ptr, data_size);
+                }
             },
             nb::arg("addr"),
             nb::arg("data"),
@@ -485,7 +531,10 @@ void bind_tt_device(nb::module_ &m) {
             [](SPITTDevice &self, uint32_t addr, nb::bytes data, bool skip_write_to_spi = false) -> void {
                 const char *data_ptr = data.c_str();
                 size_t data_size = data.size();
-                self.write(addr, reinterpret_cast<const uint8_t *>(data_ptr), data_size, skip_write_to_spi);
+                {
+                    nb::gil_scoped_release release;
+                    self.write(addr, reinterpret_cast<const uint8_t *>(data_ptr), data_size, skip_write_to_spi);
+                }
             },
             nb::arg("addr"),
             nb::arg("data"),
@@ -497,7 +546,10 @@ void bind_tt_device(nb::module_ &m) {
             [](SPITTDevice &self, uint32_t addr, nb::bytearray data, bool skip_write_to_spi = false) -> void {
                 uint8_t *data_ptr = reinterpret_cast<uint8_t *>(data.data());
                 size_t data_size = data.size();
-                self.write(addr, data_ptr, data_size, skip_write_to_spi);
+                {
+                    nb::gil_scoped_release release;
+                    self.write(addr, data_ptr, data_size, skip_write_to_spi);
+                }
             },
             nb::arg("addr"),
             nb::arg("data"),
@@ -507,6 +559,7 @@ void bind_tt_device(nb::module_ &m) {
         .def(
             "get_spi_fw_bundle_version",
             &SPITTDevice::get_spi_fw_bundle_version,
+            release_gil(),
             "Get firmware bundle version from SPI (Blackhole only). "
             "Returns raw 32-bit value with format [component][major][minor][patch] (each 8 bits).");
 
@@ -519,6 +572,7 @@ void bind_tt_device(nb::module_ &m) {
         nb::arg("num_host_mem_channels") = 0,
         nb::arg("copy_sim_binary") = false,
         nb::rv_policy::take_ownership,
+        release_gil(),
         "Creates a simulation TTDevice from a simulator path. "
         "If the path ends with '.so', creates a TTSimTTDevice (functional simulator). "
         "Otherwise, creates an RtlSimulationTTDevice (RTL simulator).");
@@ -530,6 +584,7 @@ void bind_tt_device(nb::module_ &m) {
             nb::arg("simulator_directory"),
             nb::arg("num_host_mem_channels") = 0,
             nb::arg("copy_sim_binary") = false,
+            release_gil(),
             "Creates a TTSimTTDevice for functional simulation communication.")
         .def(
             "send_tensix_risc_reset",
@@ -537,18 +592,21 @@ void bind_tt_device(nb::module_ &m) {
                 &TTSimTTDevice::send_tensix_risc_reset),
             nb::arg("translated_core"),
             nb::arg("soft_resets"),
+            release_gil(),
             "Send a Tensix RISC reset with specific soft reset options for a single core.")
         .def(
             "send_tensix_risc_reset_all",
             static_cast<void (TTSimTTDevice::*)(const TensixSoftResetOptions &)>(
                 &TTSimTTDevice::send_tensix_risc_reset),
             nb::arg("soft_resets"),
+            release_gil(),
             "Send a Tensix RISC reset with specific soft reset options for all cores.")
         .def(
             "assert_risc_reset",
             &TTSimTTDevice::assert_risc_reset,
             nb::arg("core"),
             nb::arg("selected_riscs"),
+            release_gil(),
             "Assert RISC reset for selected RISC cores on a given core.")
         .def(
             "deassert_risc_reset",
@@ -556,15 +614,18 @@ void bind_tt_device(nb::module_ &m) {
             nb::arg("core"),
             nb::arg("selected_riscs"),
             nb::arg("staggered_start") = false,
+            release_gil(),
             "Deassert RISC reset for selected RISC cores on a given core.")
         .def(
             "get_soc_descriptor",
             &TTSimTTDevice::get_soc_descriptor,
             nb::rv_policy::reference_internal,
+            release_gil(),
             "Get the SocDescriptor associated with this simulation device.")
 
-        .def("get_clock", &TTSimTTDevice::get_clock, "Get the clock frequency.")
-        .def("get_min_clock_freq", &TTSimTTDevice::get_min_clock_freq, "Get the minimum clock frequency.")
+        .def("get_clock", &TTSimTTDevice::get_clock, release_gil(), "Get the clock frequency.")
+        .def(
+            "get_min_clock_freq", &TTSimTTDevice::get_min_clock_freq, release_gil(), "Get the minimum clock frequency.")
         .def_rw("bar0_base", &TTSimTTDevice::bar0_base, "Base address for BAR0.");
 
     nb::class_<RtlSimulationTTDevice, TTDevice>(m, "RtlSimulationTTDevice")
@@ -573,6 +634,7 @@ void bind_tt_device(nb::module_ &m) {
             &RtlSimulationTTDevice::create,
             nb::arg("simulator_directory"),
             nb::arg("num_host_mem_channels") = 0,
+            release_gil(),
             "Creates an RtlSimulationTTDevice for RTL simulation communication.")
         .def(
             "send_tensix_risc_reset",
@@ -580,6 +642,7 @@ void bind_tt_device(nb::module_ &m) {
                 &RtlSimulationTTDevice::send_tensix_risc_reset),
             nb::arg("translated_core"),
             nb::arg("soft_resets"),
+            release_gil(),
             "Send a Tensix RISC reset with specific soft reset options for a single core. "
             "Only TENSIX_ASSERT_SOFT_RESET and TENSIX_DEASSERT_SOFT_RESET are valid options.")
         .def(
@@ -587,6 +650,7 @@ void bind_tt_device(nb::module_ &m) {
             &RtlSimulationTTDevice::assert_risc_reset,
             nb::arg("core"),
             nb::arg("selected_riscs"),
+            release_gil(),
             "Assert RISC reset for selected RISC cores on a given core.")
         .def(
             "deassert_risc_reset",
@@ -594,11 +658,13 @@ void bind_tt_device(nb::module_ &m) {
             nb::arg("core"),
             nb::arg("selected_riscs"),
             nb::arg("staggered_start") = false,
+            release_gil(),
             "Deassert RISC reset for selected RISC cores on a given core.")
         .def(
             "get_soc_descriptor",
             &RtlSimulationTTDevice::get_soc_descriptor,
             nb::rv_policy::reference_internal,
+            release_gil(),
             "Get the SocDescriptor associated with this RTL simulation device.");
 #endif
 
@@ -609,6 +675,7 @@ void bind_tt_device(nb::module_ &m) {
         nb::arg("cluster_descriptor"),
         nb::arg("remote_chip_id"),
         nb::rv_policy::take_ownership,
+        release_gil(),
         "Creates a remote TTDevice for communication with a remote chip.");
 
     // Keep the old name as an alias for backwards compatibility.
@@ -619,6 +686,7 @@ void bind_tt_device(nb::module_ &m) {
         nb::arg("cluster_descriptor"),
         nb::arg("remote_chip_id"),
         nb::rv_policy::take_ownership,
+        release_gil(),
         "Deprecated: use create_remote_tt_device instead.");
 
     m.def(
@@ -630,6 +698,7 @@ void bind_tt_device(nb::module_ &m) {
         nb::arg("x"),
         nb::arg("y"),
         nb::rv_policy::take_ownership,
+        release_gil(),
         "Creates a remote TTDevice for communication with a remote chip at (rack, shelf, x, y). "
         "Does not set remote transfer ethernet cores; caller must set them explicitly.");
 
@@ -643,5 +712,6 @@ void bind_tt_device(nb::module_ &m) {
         nb::arg("x"),
         nb::arg("y"),
         nb::rv_policy::take_ownership,
+        release_gil(),
         "Deprecated: use create_remote_tt_device_from_coord instead.");
 }

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -31,6 +31,13 @@
 #include "umd/device/types/tensix_soft_reset_options.hpp"
 #include "umd/device/utils/error.hpp"
 namespace nb = nanobind;
+// Releases Python's Global Interpreter Lock (GIL) for the duration of the C++ call,
+// allowing other Python threads to run in parallel while this binding executes. Pass
+// release_gil() as a call guard to nb::class_::def() on methods that don't touch the
+// Python interpreter (e.g. blocking device I/O), so callers can drive UMD concurrently
+// from multiple Python threads. Inside lambdas that need to keep the GIL for argument
+// marshalling, use a scoped nb::gil_scoped_release release; block around the native
+// call instead.
 using release_gil = nb::call_guard<nb::gil_scoped_release>;
 
 using namespace tt;

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -139,10 +139,7 @@ void bind_tt_device(nb::module_ &m) {
             },
             nb::arg("cores"),
             release_gil())
-        .def(
-            "get_local_device",
-            &RemoteCommunication::get_local_device,
-            nb::rv_policy::reference_internal)
+        .def("get_local_device", &RemoteCommunication::get_local_device, nb::rv_policy::reference_internal)
         .def(
             "get_remote_transfer_ethernet_core",
             [](RemoteCommunication &self) -> std::tuple<int, int> {
@@ -175,10 +172,7 @@ void bind_tt_device(nb::module_ &m) {
             release_gil())
         .def("get_soc_descriptor", &TTDevice::get_soc_descriptor, release_gil())
         .def("get_chip_info", &TTDevice::get_chip_info, release_gil())
-        .def(
-            "get_arc_telemetry_reader",
-            &TTDevice::get_arc_telemetry_reader,
-            nb::rv_policy::reference_internal)
+        .def("get_arc_telemetry_reader", &TTDevice::get_arc_telemetry_reader, nb::rv_policy::reference_internal)
         .def("get_arch", &TTDevice::get_arch, release_gil())
         .def("get_board_id", &TTDevice::get_board_id, release_gil())
         .def("board_id", &TTDevice::get_board_id, release_gil())
@@ -188,14 +182,8 @@ void bind_tt_device(nb::module_ &m) {
         .def("get_pci_device", &TTDevice::get_pci_device, nb::rv_policy::reference, release_gil())
         .def("get_noc_translation_enabled", &TTDevice::get_noc_translation_enabled, release_gil())
         .def("is_remote", &TTDevice::is_remote, release_gil(), "Returns true if this is a remote TTDevice")
-        .def(
-            "get_remote_communication",
-            &TTDevice::get_remote_communication,
-            nb::rv_policy::reference_internal)
-        .def(
-            "get_firmware_info_provider",
-            &TTDevice::get_firmware_info_provider,
-            nb::rv_policy::reference_internal)
+        .def("get_remote_communication", &TTDevice::get_remote_communication, nb::rv_policy::reference_internal)
+        .def("get_firmware_info_provider", &TTDevice::get_firmware_info_provider, nb::rv_policy::reference_internal)
         // Compatibility with luwen's API - these methods just return self.
         .def(
             "as_wh",

--- a/nanobind/py_api_warm_reset.cpp
+++ b/nanobind/py_api_warm_reset.cpp
@@ -10,6 +10,7 @@
 #include "umd/device/warm_reset.hpp"
 
 namespace nb = nanobind;
+using release_gil = nb::call_guard<nb::gil_scoped_release>;
 
 using namespace tt::umd;
 
@@ -23,6 +24,7 @@ void bind_warm_reset(nb::module_ &m) {
             nb::arg("reset_m3") = false,
             nb::arg("secondary_bus_reset") = true,  // default to true for backward compatibility
             nb::arg("m3_delay_s") = 20.0,
+            release_gil(),
             "Perform a warm reset of the device. reset_m3 flag sends specific ARC message to do a M3 board level "
             "reset. secondary_bus_reset flag performs a RESET_PCIE_LINK before issuing the ASIC reset. "
             "m3_delay_s is the post-reset wait time in seconds when reset_m3 is True (default 20s).")
@@ -33,6 +35,7 @@ void bind_warm_reset(nb::module_ &m) {
             nb::arg("reset_m3") = false,
             nb::arg("secondary_bus_reset") = true,
             nb::arg("m3_delay_s") = 20.0,
+            release_gil(),
             "Perform a warm reset of the device using chip IDs. reset_m3 flag sends specific ARC message to do a M3 "
             "board level reset. secondary_bus_reset flag performs a RESET_PCIE_LINK before issuing the ASIC reset. "
             "m3_delay_s is the post-reset wait time in seconds when reset_m3 is True (default 20s).")
@@ -43,6 +46,7 @@ void bind_warm_reset(nb::module_ &m) {
             nb::arg("reset_m3") = false,
             nb::arg("secondary_bus_reset") = true,
             nb::arg("m3_delay_s") = 20.0,
+            release_gil(),
             "Perform a warm reset of the device using PCI BDFs. reset_m3 flag sends specific ARC message to do a M3 "
             "board level reset. secondary_bus_reset flag performs a RESET_PCIE_LINK before issuing the ASIC reset. "
             "m3_delay_s is the post-reset wait time in seconds when reset_m3 is True (default 20s).")
@@ -50,5 +54,6 @@ void bind_warm_reset(nb::module_ &m) {
             "ubb_warm_reset",
             &WarmReset::ubb_warm_reset,
             nb::arg("timeout_s") = 100.0,
+            release_gil(),
             "Perform a UBB warm reset with specified timeout in seconds.");
 }

--- a/nanobind/py_api_warm_reset.cpp
+++ b/nanobind/py_api_warm_reset.cpp
@@ -10,6 +10,11 @@
 #include "umd/device/warm_reset.hpp"
 
 namespace nb = nanobind;
+// Releases Python's Global Interpreter Lock (GIL) for the duration of the C++ call,
+// allowing other Python threads to run in parallel while this binding executes. Pass
+// release_gil() as a call guard to nb::class_::def() on methods that don't touch the
+// Python interpreter (e.g. blocking device I/O), so callers can drive UMD concurrently
+// from multiple Python threads.
 using release_gil = nb::call_guard<nb::gil_scoped_release>;
 
 using namespace tt::umd;


### PR DESCRIPTION
There is no API change. This PR is introducing cpython GIL release in all API functions so that C++ code can be run in parallel.

Reading L1 memory on WH loudbox gets 4x perf improvement with these changes:
```
Number of devices: 8

=== L1 copy benchmark (sequential, all chips) ===
device 0 [local=True, mmio=0] copied 1499136 bytes in 0.001569s (911.06 MiB/s) sha256=55b27156f743...
device 1 [local=True, mmio=1] copied 1499136 bytes in 0.001308s (1093.32 MiB/s) sha256=e1c8a77f15c3...
device 2 [local=True, mmio=2] copied 1499136 bytes in 0.000809s (1766.99 MiB/s) sha256=42308ca3840d...
device 3 [local=True, mmio=3] copied 1499136 bytes in 0.000439s (3256.41 MiB/s) sha256=577dc2fa7585...
device 4 [local=False, mmio=0] copied 1499136 bytes in 0.410427s (3.48 MiB/s) sha256=87ac76b6fe08...
device 5 [local=False, mmio=3] copied 1499136 bytes in 0.388004s (3.68 MiB/s) sha256=5130797e8792...
device 6 [local=False, mmio=1] copied 1499136 bytes in 0.410720s (3.48 MiB/s) sha256=00b158b8d610...
device 7 [local=False, mmio=2] copied 1499136 bytes in 0.388260s (3.68 MiB/s) sha256=8b6b3b4392e3...
Sequential total: 11993088 bytes in 1.619436s (7.06 MiB/s)

=== L1 copy benchmark (parallel threads, one thread per MMIO) ===
mmio 0 devices [0, 4] copied 2998272 bytes in 0.415572s (6.88 MiB/s)
mmio 1 devices [1, 6] copied 2998272 bytes in 0.416971s (6.86 MiB/s)
mmio 2 devices [2, 7] copied 2998272 bytes in 0.393928s (7.26 MiB/s)
mmio 3 devices [3, 5] copied 2998272 bytes in 0.416061s (6.87 MiB/s)
Parallel total: 11993088 bytes in 0.420123s (27.22 MiB/s)
Data check: sequential and parallel L1 snapshots match for all devices.
```