### PR TITLE
Blacklist some bh-gh runs to speed up merge queue

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -88,9 +88,10 @@ jobs:
           echo "entries=$(echo "$CARDS" | jq -c .)" >> $GITHUB_OUTPUT
 
   # Central blacklist for matrix entries that should not run under certain conditions.
-  # Each entry is a pipe-delimited "triggering-event|card" pair.
+  # Each entry is a pipe-delimited "triggering-event|build-type|card" triple.
+  # Use "*" in the build-type field to match any build type for that event/card.
   # To extend: add entries to the echo below.
-  # Note: This can also easily extend to include build-type or ubuntu-docker-version or other parameters.
+  # Note: This can also easily extend to include ubuntu-docker-version or other parameters.
   blacklist:
     name: Define test blacklist
     runs-on: ubuntu-latest
@@ -101,8 +102,11 @@ jobs:
         id: define
         run: |
           ENTRIES=$(jq -cn '$ARGS.positional' --args \
-            'pull_request|tt-ubuntu-2204-bh-loudbox-viommu-stable' \
-            'merge_group|tt-ubuntu-2204-bh-loudbox-viommu-stable' \
+            'pull_request|*|tt-ubuntu-2204-bh-loudbox-viommu-stable' \
+            'merge_group|*|tt-ubuntu-2204-bh-loudbox-viommu-stable' \
+            'pull_request|*|bh-gh-07' \
+            'merge_group|ASan|bh-gh-07' \
+            'merge_group|TSan|bh-gh-07' \
           )
           echo "entries=$ENTRIES" >> $GITHUB_OUTPUT
 
@@ -121,13 +125,20 @@ jobs:
           CARDS: ${{ needs.cards.outputs.entries }}
           BLACKLIST: ${{ needs.blacklist.outputs.entries }}
           TRIGGERING_EVENT: ${{ inputs.triggering-event }}
+          BUILD_TYPE: ${{ inputs.build-type }}
         run: |
           FILTERED=$(echo "$CARDS" | jq -c \
             --argjson blacklist "$BLACKLIST" \
             --arg event "$TRIGGERING_EVENT" \
-            '[.[] | select(($event + "|" + .card) as $key | ($blacklist | index($key)) == null)]')
+            --arg buildType "$BUILD_TYPE" \
+            '[.[] | select(
+                ($event + "|" + $buildType + "|" + .card) as $exact |
+                ($event + "|*|" + .card) as $wildcard |
+                ($blacklist | index($exact)) == null and
+                ($blacklist | index($wildcard)) == null
+            )]')
           echo "test-groups=$FILTERED" >> $GITHUB_OUTPUT
-          echo "Filtered test matrix for trigger ($TRIGGERING_EVENT):"
+          echo "Filtered test matrix for trigger ($TRIGGERING_EVENT) build-type ($BUILD_TYPE):"
           echo "$FILTERED" | jq -r '.[] | "  \(.arch) | \(.card)"'
 
   build-tests:


### PR DESCRIPTION
### Issue
Merge queue is slow

### Description
bh-gh-07 is an only machine. Reduce its load by running it only on one job in merge queue. Skip it for PR as well, as it is rare for this machine only to fail.

### List of the changes
- Introduced infra for blacklisting based on build-type
- Added entry for bhgh07 for everything except merge-queue Release.

### Testing
I'll have to look at all the jobs once this gets into merge queue, to verify.
Update: I've looked at the jobs on merge queue and can verify they're generated properly

### API Changes
There are no API changes in this PR.
