### PR TITLE
Fail fast jobs in merge queue

### DIFF
--- a/.github/workflows/build-and-run-all-tests-multiple-builds.yml
+++ b/.github/workflows/build-and-run-all-tests-multiple-builds.yml
@@ -145,6 +145,38 @@ jobs:
       log-params: |
         echo build-and-run-all-tests-multiple-builds - build-types: ${{ inputs.build-types }}
 
+  # Fail-fast watchers for the merge queue: cancel the workflow run as soon as any build fails,
+  # so the queue gets a failure verdict without waiting for the slowest build to finish.
+  # One watcher per build job by design — a single watcher with multi-job `needs` would wait
+  # for every need to reach a terminal state before evaluating `if: failure()`, defeating the
+  # purpose. Restricted to merge_group; PRs keep running so devs see all failures at once.
+  fail-fast-release:
+    if: failure() && github.event_name == 'merge_group'
+    needs: [build-release]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
+
+  fail-fast-asan:
+    if: failure() && github.event_name == 'merge_group'
+    needs: [build-asan]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
+
+  fail-fast-tsan:
+    if: failure() && github.event_name == 'merge_group'
+    needs: [build-tsan]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
+
   # Single leaf check that can be required in branch rulesets.
   # Treats skipped jobs as passing (expected on pull_request), fails on failure or cancellation.
   all-builds-passed:

--- a/.github/workflows/build-and-run-all-tests-multiple-builds.yml
+++ b/.github/workflows/build-and-run-all-tests-multiple-builds.yml
@@ -145,38 +145,6 @@ jobs:
       log-params: |
         echo build-and-run-all-tests-multiple-builds - build-types: ${{ inputs.build-types }}
 
-  # Fail-fast watchers for the merge queue: cancel the workflow run as soon as any build fails,
-  # so the queue gets a failure verdict without waiting for the slowest build to finish.
-  # One watcher per build job by design — a single watcher with multi-job `needs` would wait
-  # for every need to reach a terminal state before evaluating `if: failure()`, defeating the
-  # purpose. Restricted to merge_group; PRs keep running so devs see all failures at once.
-  fail-fast-release:
-    if: failure() && github.event_name == 'merge_group'
-    needs: [build-release]
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
-
-  fail-fast-asan:
-    if: failure() && github.event_name == 'merge_group'
-    needs: [build-asan]
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
-
-  fail-fast-tsan:
-    if: failure() && github.event_name == 'merge_group'
-    needs: [build-tsan]
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
-
   # Single leaf check that can be required in branch rulesets.
   # Treats skipped jobs as passing (expected on pull_request), fails on failure or cancellation.
   all-builds-passed:

--- a/.github/workflows/build-and-run-all-tests-multiple-builds.yml
+++ b/.github/workflows/build-and-run-all-tests-multiple-builds.yml
@@ -28,6 +28,16 @@ on:
   push:
     branches: ["main"]
 
+# Granted to all jobs that don't declare their own `permissions:` block.
+# `actions: write` is required so the merge-queue fail-fast watchers (inside
+# build-and-run-all-tests.yml) can call the cancel-workflow API.
+# `contents: read` and `packages: read` mirror the GitHub-default set the
+# build/test reusable workflows rely on (checkout, ghcr.io image pulls).
+permissions:
+  contents: read
+  actions: write
+  packages: read
+
 jobs:
   # Ensure the Docker image for CI exists. If the Dockerfile (or its
   # install scripts) changed on this branch the image is rebuilt and pushed

--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -155,7 +155,10 @@ jobs:
     secrets: inherit
     needs: [build-tests, generate-test-matrix]
     strategy:
-      fail-fast: false
+      # Cancel sibling cards on first failure only in the merge queue, where time-to-verdict
+      # matters more than seeing every card's result. PR/push runs keep fail-fast off so devs
+      # see whether a failure is card-specific or general.
+      fail-fast: ${{ inputs.triggering-event == 'merge_group' }}
       matrix:
         test-group: ${{ fromJson(needs.generate-test-matrix.outputs.test-groups) }}
         ubuntu-docker-version: ['ubuntu-22.04']
@@ -182,7 +185,7 @@ jobs:
     secrets: inherit
     needs: build-tests
     strategy:
-      fail-fast: false
+      fail-fast: ${{ inputs.triggering-event == 'merge_group' }}
       matrix:
         test-group: [
           {runs-on: tt-ubuntu-2204-p150b-stable},
@@ -210,7 +213,7 @@ jobs:
     secrets: inherit
     needs: build-tests
     strategy:
-      fail-fast: false
+      fail-fast: ${{ inputs.triggering-event == 'merge_group' }}
       matrix:
         test-group: [
           {runs-on: tt-ubuntu-2204-p150b-stable},
@@ -242,3 +245,62 @@ jobs:
       build-type: ${{ inputs.build-type }}
       timeout: 20
       image-tag: ${{ inputs.docker-image-tag || 'latest' }}
+
+  # Fail-fast watchers for the merge queue: cancel the workflow run as soon as any test job
+  # here fails. A workflow_call shares run_id with its caller, so this cancellation propagates
+  # up to the sibling top-level builds (Release/ASan/TSan), giving end-to-end fail-fast.
+  # One watcher per job by design — a single watcher with multi-job `needs` would wait for
+  # every need to settle before evaluating `if: failure()`, defeating the purpose.
+  fail-fast-build-tests:
+    if: failure() && inputs.triggering-event == 'merge_group'
+    needs: [build-tests]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
+
+  fail-fast-test-all:
+    if: failure() && inputs.triggering-event == 'merge_group'
+    needs: [test-all]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
+
+  fail-fast-ttsim:
+    if: failure() && inputs.triggering-event == 'merge_group'
+    needs: [run-ttsim-tests]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
+
+  fail-fast-tooling:
+    if: failure() && inputs.triggering-event == 'merge_group'
+    needs: [run-tooling-tests]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
+
+  fail-fast-exalens:
+    if: failure() && inputs.triggering-event == 'merge_group'
+    needs: [run-exalens-tests]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
+
+  fail-fast-tracy:
+    if: failure() && inputs.triggering-event == 'merge_group'
+    needs: [run-tracy]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description
Done similarly to how metal does it.
The problem is that we have a dedicated job to report status. However, it waits for all jobs to complete, meaning if one of the jobs fails .

Example: https://github.com/tenstorrent/tt-umd/actions/runs/25545688541

### List of the changes
- Added failfast jobs scoped on merge-queue event and Release/asan/tsan
- These jobs will cancel the whole run earlier if one of the jobs within fails, speeding up the merge queue in total

### Testing
Hard to test without merging it and seeing live how merge queue behaves.

### API Changes
There are no API changes in this PR.
