### PR TITLE
Measure deviation between ci runs for ttsim

### DIFF
--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -11,20 +11,20 @@ on:
         required: true
         description: 'The timeout for the job in minutes'
         type: number
-        default: 30
+        default: 60
   workflow_call:
     inputs:
       timeout:
         required: false
         description: 'The timeout for the job in minutes'
         type: number
-        default: 30
+        default: 60
 
 jobs:
   build-and-run-ttsim:
     # Due to parsing bug, fromJSON is used to convert string to number.
     # In pull_request or push events, the input context is not available, stating the default again here.
-    timeout-minutes: ${{ fromJSON(inputs.timeout || '30') }}
+    timeout-minutes: ${{ fromJSON(inputs.timeout || '60') }}
 
     name: Build and test ttsim with newest UMD
     runs-on: tt-ubuntu-2204-large-stable
@@ -124,84 +124,110 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release
           cmake --build tt-metal/tt_metal/third_party/umd/build --target api_tests umd_microbenchmark
 
-      # Following single card tests should be really fast, only a couple of seconds each, so we set a short timeout for
-      # them and if they time out, it indicates some issue with the simulator setup rather than an actual test failure.
-      - name: Run tt-sim wormhole tests
-        timeout-minutes: 1
+      # DIAGNOSTIC: each test step is wrapped in a 7× loop so we can characterize
+      # within-run (same commit, same runner) variance for every ttsim test step.
+      # Each iteration emits ITER_BEGIN / ITER_END markers; their log timestamps
+      # (ms-precision) can be parsed from the run logs to compute per-iteration
+      # durations. Revert the loops once the variance baseline is collected.
+      - name: Run tt-sim wormhole tests (7x)
+        timeout-minutes: 3
         run: |
           export TT_METAL_SIMULATOR=$(pwd)/sim_wh/libttsim.so
-          TT_METAL_SLOW_DISPATCH_MODE=1 $TT_METAL_HOME/build/programming_examples/metal_example_add_2_integers_in_riscv
+          export TT_METAL_SLOW_DISPATCH_MODE=1
+          BIN="$TT_METAL_HOME/build/programming_examples/metal_example_add_2_integers_in_riscv"
+          for i in $(seq 1 7); do
+            echo "ITER_BEGIN tt-sim-wh-tests $i"
+            "$BIN"
+            echo "ITER_END   tt-sim-wh-tests $i"
+          done
 
-      - name: Run tt-sim blackhole tests
-        timeout-minutes: 1
+      - name: Run tt-sim blackhole tests (7x)
+        timeout-minutes: 3
         run: |
           export TT_METAL_SIMULATOR=$(pwd)/sim_bh/libttsim.so
-          TT_METAL_SLOW_DISPATCH_MODE=1 $TT_METAL_HOME/build/programming_examples/metal_example_add_2_integers_in_riscv
+          export TT_METAL_SLOW_DISPATCH_MODE=1
+          BIN="$TT_METAL_HOME/build/programming_examples/metal_example_add_2_integers_in_riscv"
+          for i in $(seq 1 7); do
+            echo "ITER_BEGIN tt-sim-bh-tests $i"
+            "$BIN"
+            echo "ITER_END   tt-sim-bh-tests $i"
+          done
 
-      - name: Run UMD TestDeviceIOFixture on tt-sim wormhole
-        timeout-minutes: 1
+      - name: Run UMD TestDeviceIOFixture on tt-sim wormhole (7x)
+        timeout-minutes: 3
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_wh/libttsim.so
         run: |
-          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
+          for i in $(seq 1 7); do
+            echo "ITER_BEGIN TestDeviceIOFixture-wh $i"
+            tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
+            echo "ITER_END   TestDeviceIOFixture-wh $i"
+          done
 
-      - name: Run UMD TestDeviceIOFixture on tt-sim blackhole
-        timeout-minutes: 1
+      - name: Run UMD TestDeviceIOFixture on tt-sim blackhole (7x)
+        timeout-minutes: 3
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh/libttsim.so
         run: |
-          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
+          for i in $(seq 1 7); do
+            echo "ITER_BEGIN TestDeviceIOFixture-bh $i"
+            tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
+            echo "ITER_END   TestDeviceIOFixture-bh $i"
+          done
 
-      - name: Run UMD TTSimDeviceIOFixture on tt-sim wormhole
-        timeout-minutes: 1
+      - name: Run UMD TTSimDeviceIOFixture on tt-sim wormhole (7x)
+        timeout-minutes: 3
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_wh/libttsim.so
         run: |
-          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
+          for i in $(seq 1 7); do
+            echo "ITER_BEGIN TTSimDeviceIOFixture-wh $i"
+            tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
+            echo "ITER_END   TTSimDeviceIOFixture-wh $i"
+          done
 
-      - name: Run UMD TTSimDeviceIOFixture on tt-sim blackhole
-        timeout-minutes: 1
+      - name: Run UMD TTSimDeviceIOFixture on tt-sim blackhole (7x)
+        timeout-minutes: 3
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh/libttsim.so
         run: |
-          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
+          for i in $(seq 1 7); do
+            echo "ITER_BEGIN TTSimDeviceIOFixture-bh $i"
+            tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
+            echo "ITER_END   TTSimDeviceIOFixture-bh $i"
+          done
 
-      # ClusterConstructor benchmark on simulator establishes the regression-detection
-      # baseline; numbers will eventually be re-collected on real hardware once stable
-      # device runners are available.
-      #
+      # ClusterConstructor microbenchmark — 7× to match the diagnostic above.
       # Each invocation produces its own timestamped subdirectory under
-      # UMD_MICROBENCHMARK_RESULTS_PATH (handled in microbenchmark_utils.hpp), so
-      # running the binary N× back-to-back lets us observe within-run variance
-      # (process-startup / dlopen / fs-cache jitter) separately from across-commit
-      # drift. Sleep 1s between iterations to avoid same-second timestamp collision.
-      - name: Run UMD open_cluster microbenchmark on tt-sim wormhole (3x)
-        timeout-minutes: 5
+      # UMD_MICROBENCHMARK_RESULTS_PATH (handled in microbenchmark_utils.hpp).
+      # Sleep 1s between iterations to avoid same-second timestamp collisions.
+      - name: Run UMD open_cluster microbenchmark on tt-sim wormhole (7x)
+        timeout-minutes: 10
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_wh/libttsim.so
           UMD_MICROBENCHMARK_RESULTS_PATH: ${{ github.workspace }}/microbench-results/sim_wh
         run: |
           mkdir -p "$UMD_MICROBENCHMARK_RESULTS_PATH"
-          for i in 1 2 3; do
-            echo "::group::ClusterConstructor wh iteration $i"
+          for i in $(seq 1 7); do
+            echo "ITER_BEGIN ClusterConstructor-wh $i"
             tt-metal/tt_metal/third_party/umd/build/test/umd/microbenchmark/umd_microbenchmark \
               --gtest_filter="MicrobenchmarkOpenCluster.ClusterConstructor"
-            echo "::endgroup::"
+            echo "ITER_END   ClusterConstructor-wh $i"
             sleep 1
           done
 
-      - name: Run UMD open_cluster microbenchmark on tt-sim blackhole (3x)
-        timeout-minutes: 5
+      - name: Run UMD open_cluster microbenchmark on tt-sim blackhole (7x)
+        timeout-minutes: 10
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh/libttsim.so
           UMD_MICROBENCHMARK_RESULTS_PATH: ${{ github.workspace }}/microbench-results/sim_bh
         run: |
           mkdir -p "$UMD_MICROBENCHMARK_RESULTS_PATH"
-          for i in 1 2 3; do
-            echo "::group::ClusterConstructor bh iteration $i"
+          for i in $(seq 1 7); do
+            echo "ITER_BEGIN ClusterConstructor-bh $i"
             tt-metal/tt_metal/third_party/umd/build/test/umd/microbenchmark/umd_microbenchmark \
               --gtest_filter="MicrobenchmarkOpenCluster.ClusterConstructor"
-            echo "::endgroup::"
+            echo "ITER_END   ClusterConstructor-bh $i"
             sleep 1
           done
 
@@ -214,8 +240,8 @@ jobs:
           if-no-files-found: warn
 
       # Galaxy tests can be a bit longer, should run on the order of minutes.
-      - name: Run tt-metal C++ unit test on tt-sim galaxy wormhole_b0
-        timeout-minutes: 5
+      - name: Run tt-metal C++ unit test on tt-sim galaxy wormhole_b0 (7x)
+        timeout-minutes: 12
         env:
           TT_METAL_SIMULATOR_HOME: ${{ github.workspace }}/sim_wh
           TT_METAL_SIMULATOR: ${{ github.workspace }}/sim_wh/libttsim.so
@@ -226,11 +252,15 @@ jobs:
           cd tt-metal
           export TT_METAL_MOCK_CLUSTER_DESC_PATH="${TT_METAL_TESTS_DIR}/6u_cluster_desc.yaml"
           echo "Running C++ unit tests for wormhole_b0..."
-          ./build/test/tt_metal/unit_tests_api --gtest_filter="*StreamRegWrite*"
-          ./build/test/tt_metal/unit_tests_api --gtest_filter="*InlineWrite*"
+          for i in $(seq 1 7); do
+            echo "ITER_BEGIN galaxy-wh $i"
+            ./build/test/tt_metal/unit_tests_api --gtest_filter="*StreamRegWrite*"
+            ./build/test/tt_metal/unit_tests_api --gtest_filter="*InlineWrite*"
+            echo "ITER_END   galaxy-wh $i"
+          done
 
-      - name: Run tt-metal C++ unit test on tt-sim galaxy blackhole
-        timeout-minutes: 5
+      - name: Run tt-metal C++ unit test on tt-sim galaxy blackhole (7x)
+        timeout-minutes: 14
         env:
           TT_METAL_SIMULATOR_HOME: ${{ github.workspace }}/sim_bh
           TT_METAL_SIMULATOR: ${{ github.workspace }}/sim_bh/libttsim.so
@@ -241,5 +271,9 @@ jobs:
           cd tt-metal
           export TT_METAL_MOCK_CLUSTER_DESC_PATH="${TT_METAL_TESTS_DIR}/bh_6u_cluster_desc.yaml"
           echo "Running C++ unit tests for blackhole..."
-          ./build/test/tt_metal/unit_tests_api --gtest_filter="*StreamRegWrite*"
-          ./build/test/tt_metal/unit_tests_api --gtest_filter="*InlineWrite*"
+          for i in $(seq 1 7); do
+            echo "ITER_BEGIN galaxy-bh $i"
+            ./build/test/tt_metal/unit_tests_api --gtest_filter="*StreamRegWrite*"
+            ./build/test/tt_metal/unit_tests_api --gtest_filter="*InlineWrite*"
+            echo "ITER_END   galaxy-bh $i"
+          done

--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -122,7 +122,7 @@ jobs:
             -DTT_UMD_ENABLE_CLANG_TIDY=OFF \
             -DTT_UMD_ENABLE_TRACY=OFF \
             -DCMAKE_BUILD_TYPE=Release
-          cmake --build tt-metal/tt_metal/third_party/umd/build --target api_tests
+          cmake --build tt-metal/tt_metal/third_party/umd/build --target api_tests umd_microbenchmark
 
       # Following single card tests should be really fast, only a couple of seconds each, so we set a short timeout for
       # them and if they time out, it indicates some issue with the simulator setup rather than an actual test failure.
@@ -165,6 +165,53 @@ jobs:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh/libttsim.so
         run: |
           tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
+
+      # ClusterConstructor benchmark on simulator establishes the regression-detection
+      # baseline; numbers will eventually be re-collected on real hardware once stable
+      # device runners are available.
+      #
+      # Each invocation produces its own timestamped subdirectory under
+      # UMD_MICROBENCHMARK_RESULTS_PATH (handled in microbenchmark_utils.hpp), so
+      # running the binary N× back-to-back lets us observe within-run variance
+      # (process-startup / dlopen / fs-cache jitter) separately from across-commit
+      # drift. Sleep 1s between iterations to avoid same-second timestamp collision.
+      - name: Run UMD open_cluster microbenchmark on tt-sim wormhole (3x)
+        timeout-minutes: 5
+        env:
+          TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_wh/libttsim.so
+          UMD_MICROBENCHMARK_RESULTS_PATH: ${{ github.workspace }}/microbench-results/sim_wh
+        run: |
+          mkdir -p "$UMD_MICROBENCHMARK_RESULTS_PATH"
+          for i in 1 2 3; do
+            echo "::group::ClusterConstructor wh iteration $i"
+            tt-metal/tt_metal/third_party/umd/build/test/umd/microbenchmark/umd_microbenchmark \
+              --gtest_filter="MicrobenchmarkOpenCluster.ClusterConstructor"
+            echo "::endgroup::"
+            sleep 1
+          done
+
+      - name: Run UMD open_cluster microbenchmark on tt-sim blackhole (3x)
+        timeout-minutes: 5
+        env:
+          TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh/libttsim.so
+          UMD_MICROBENCHMARK_RESULTS_PATH: ${{ github.workspace }}/microbench-results/sim_bh
+        run: |
+          mkdir -p "$UMD_MICROBENCHMARK_RESULTS_PATH"
+          for i in 1 2 3; do
+            echo "::group::ClusterConstructor bh iteration $i"
+            tt-metal/tt_metal/third_party/umd/build/test/umd/microbenchmark/umd_microbenchmark \
+              --gtest_filter="MicrobenchmarkOpenCluster.ClusterConstructor"
+            echo "::endgroup::"
+            sleep 1
+          done
+
+      - name: Upload microbenchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: umd-microbenchmark-results
+          path: ${{ github.workspace }}/microbench-results
+          if-no-files-found: warn
 
       # Galaxy tests can be a bit longer, should run on the order of minutes.
       - name: Run tt-metal C++ unit test on tt-sim galaxy wormhole_b0

--- a/tests/microbenchmark/benchmarks/open_cluster/test_open_cluster.cpp
+++ b/tests/microbenchmark/benchmarks/open_cluster/test_open_cluster.cpp
@@ -6,6 +6,8 @@
 #include <nanobench.h>
 
 #include <chrono>
+#include <cstdlib>
+#include <filesystem>
 #include <map>
 #include <memory>
 #include <string>
@@ -25,28 +27,59 @@ enum class ARCH;
 using namespace tt::umd;
 using namespace tt::umd::test::utils;
 
+namespace {
+constexpr const char* TT_UMD_SIMULATOR_ENV = "TT_UMD_SIMULATOR";
+
+bool is_simulation() { return std::getenv(TT_UMD_SIMULATOR_ENV) != nullptr; }
+
+// Mirrors TestDeviceIOFixture::make_cluster in tests/api/test_device_io.cpp:
+// when TT_UMD_SIMULATOR points at a ttsim .so, switch the cluster to
+// ChipType::SIMULATION so the same benchmark body runs against the simulator.
+ClusterOptions make_default_options() {
+    ClusterOptions options;
+    if (const char* sim_path = std::getenv(TT_UMD_SIMULATOR_ENV)) {
+        options.chip_type = ChipType::SIMULATION;
+        options.target_devices = {0};
+        options.simulator_directory = std::filesystem::path(sim_path);
+    }
+    return options;
+}
+}  // namespace
+
 // Measure the time it takes to open/construct a Cluster object with default ClusterOptions.
 TEST(MicrobenchmarkOpenCluster, ClusterConstructor) {
-    auto devices_info = PCIDevice::enumerate_devices_info();
-    ASSERT_FALSE(devices_info.empty());
-    tt::ARCH arch = devices_info.begin()->second.get_arch();
-    ClusterOptions options;
-    options.sdesc_path = test_utils::get_soc_descriptor_path(arch);
+    ClusterOptions default_options = make_default_options();
+    ClusterOptions options_with_sdesc = default_options;
+
+    if (is_simulation()) {
+        // ttsim convention: soc_descriptor.yaml lives next to libttsim.so.
+        const auto& sim_dir = default_options.simulator_directory;
+        options_with_sdesc.sdesc_path =
+            ((sim_dir.extension() == ".so" ? sim_dir.parent_path() : sim_dir) / "soc_descriptor.yaml").string();
+    } else {
+        auto devices_info = PCIDevice::enumerate_devices_info();
+        ASSERT_FALSE(devices_info.empty());
+        tt::ARCH arch = devices_info.begin()->second.get_arch();
+        options_with_sdesc.sdesc_path = test_utils::get_soc_descriptor_path(arch);
+    }
 
     auto bench =
         ankerl::nanobench::Bench().maxEpochTime(std::chrono::seconds(30)).title("ClusterConstructor").unit("cluster");
     bench.name("default").run([&] {
-        std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+        std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(default_options);
         ankerl::nanobench::doNotOptimizeAway(cluster);
     });
     bench.name("from sdesc").run([&] {
-        std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(options);
+        std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(options_with_sdesc);
         ankerl::nanobench::doNotOptimizeAway(cluster);
     });
     test::utils::export_results(bench);
 }
 
 TEST(MicrobenchmarkOpenCluster, TopologyDiscovery) {
+    if (is_simulation()) {
+        GTEST_SKIP() << "TopologyDiscovery is silicon-only; skipping under TT_UMD_SIMULATOR.";
+    }
     auto bench =
         ankerl::nanobench::Bench().maxEpochTime(std::chrono::seconds(30)).title("TopologyDiscovery").unit("discovery");
     bench.name("default").run([&] {

--- a/tests/microbenchmark/common/microbenchmark_utils.hpp
+++ b/tests/microbenchmark/common/microbenchmark_utils.hpp
@@ -5,9 +5,14 @@
 #pragma once
 #include <nanobench.h>
 
+#include <chrono>
+#include <ctime>
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
+#include <sstream>
+#include <string>
 
 using namespace ankerl::nanobench;
 
@@ -19,16 +24,32 @@ inline constexpr size_t ONE_KIB = 1 << 10;
 inline constexpr size_t ONE_MIB = 1 << 20;
 inline constexpr size_t ONE_GIB = 1 << 30;
 
+// Single timestamp shared across all benches in one process invocation, so all
+// JSON/HTML artifacts from a given run land in the same subdirectory.
+inline const std::string& get_run_timestamp() {
+    static const std::string ts = [] {
+        auto now = std::chrono::system_clock::now();
+        std::time_t t = std::chrono::system_clock::to_time_t(now);
+        std::tm tm = *std::localtime(&t);
+        std::ostringstream oss;
+        oss << std::put_time(&tm, "%Y-%m-%dT%H-%M-%S");
+        return oss.str();
+    }();
+    return ts;
+}
+
 inline void export_results(const std::string& title, std::vector<Result> const& results) {
     const char* results_path = std::getenv(OUTPUT_ENV_VAR);
     if (results_path == nullptr) {
         std::cout << OUTPUT_ENV_VAR << " not set. Results will not exported." << std::endl;
         return;
     }
-    std::filesystem::path filepath = std::filesystem::path(results_path) / (title + ".json");
+    std::filesystem::path results_dir = std::filesystem::path(results_path) / get_run_timestamp();
+    std::filesystem::create_directories(results_dir);
+    std::filesystem::path filepath = results_dir / (title + ".json");
     std::ofstream file(filepath);
     ankerl::nanobench::render(ankerl::nanobench::templates::json(), results, file);
-    std::filesystem::path html_filepath = std::filesystem::path(results_path) / (title + ".html");
+    std::filesystem::path html_filepath = results_dir / (title + ".html");
     std::ofstream html_file(html_filepath);
     ankerl::nanobench::render(ankerl::nanobench::templates::htmlBoxplot(), results, html_file);
 }

--- a/tests/microbenchmark/tools/compare_runs.py
+++ b/tests/microbenchmark/tools/compare_runs.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compare two timestamped microbenchmark runs in a results directory.
+
+The C++ exporter writes each run into a subdirectory named after the run's
+start time (e.g. `microbench-results/2026-05-08T14-22-31/ClusterConstructor.json`).
+This script picks two such subdirectories — by default the two most recent —
+and prints the relative throughput change per benchmark case using the same
+diff logic as analyze_results.py.
+
+Sign convention matches analyze_results.py: `Difference %` is
+`(new - baseline) / baseline * 100`, so positive means the new run is faster.
+
+Usage:
+    # Default: most recent run vs. previous one
+    python compare_runs.py microbench-results/
+
+    # Pin either side explicitly
+    python compare_runs.py microbench-results/ \\
+        --new 2026-05-08T15-04-12 --baseline 2026-05-08T14-22-31
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Reuse the per-benchmark diff logic from analyze_results.py.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from analyze_results import process_benchmark  # noqa: E402
+
+
+def list_runs(root: Path) -> list[Path]:
+    """Return run subdirectories that contain at least one JSON result, sorted oldest-first."""
+    runs = [p for p in root.iterdir() if p.is_dir() and any(p.glob("*.json"))]
+    # Timestamps in the filename format `%Y-%m-%dT%H-%M-%S` sort lexicographically by time.
+    runs.sort(key=lambda p: p.name)
+    return runs
+
+
+def resolve_run(
+    root: Path, name: str | None, fallback_index: int, runs: list[Path]
+) -> Path:
+    if name is None:
+        if not runs:
+            sys.exit(f"No timestamped runs found under {root}")
+        if len(runs) + fallback_index < 0:
+            sys.exit(
+                f"Need at least {-fallback_index} run(s) under {root} to auto-resolve, found {len(runs)}"
+            )
+        return runs[fallback_index]
+    candidate = root / name
+    if not candidate.is_dir():
+        sys.exit(f"Run not found: {candidate}")
+    return candidate
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare two UMD microbenchmark runs.")
+    parser.add_argument(
+        "results_dir",
+        type=Path,
+        help="Directory containing timestamped run subdirectories (UMD_MICROBENCHMARK_RESULTS_PATH).",
+    )
+    parser.add_argument(
+        "--new",
+        dest="new",
+        help="Run directory name treated as the new measurement. Defaults to the most recent.",
+    )
+    parser.add_argument(
+        "--baseline",
+        dest="baseline",
+        help="Run directory name treated as the baseline to compare against. "
+        "Defaults to the second-most-recent.",
+    )
+    args = parser.parse_args()
+
+    if not args.results_dir.is_dir():
+        sys.exit(f"Not a directory: {args.results_dir}")
+
+    runs = list_runs(args.results_dir)
+    new_run = resolve_run(args.results_dir, args.new, -1, runs)
+    baseline_run = resolve_run(args.results_dir, args.baseline, -2, runs)
+
+    if new_run == baseline_run:
+        sys.exit(f"--new and --baseline resolve to the same run: {new_run.name}")
+
+    print(f"New:      {new_run.name}")
+    print(f"Baseline: {baseline_run.name}")
+
+    new_jsons = sorted(
+        p for p in new_run.glob("*.json") if p.name != "machine_host_spec.json"
+    )
+    if not new_jsons:
+        sys.exit(f"No benchmark JSONs in {new_run}")
+
+    for json_path in new_jsons:
+        baseline_path = baseline_run / json_path.name
+        if not baseline_path.exists():
+            print(
+                f"\n## {json_path.stem}\n\n(no matching file in {baseline_run.name}, skipping)"
+            )
+            continue
+        # process_benchmark's first arg is the "new" run, second is the baseline
+        # (it computes (new - baseline) / baseline). Match analyze_results.py exactly.
+        df = process_benchmark(json_path, baseline_path)
+        print(f"\n## {json_path.stem}\n")
+        print(df.to_markdown(index=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Enhance run-ttsim-tests.yml to include UMD microbenchmark tests for both wormhole and blackhole simulators.
- Implement microbenchmark utilities to manage result timestamps and export benchmarks.
- Introduce compare_runs.py script for analyzing differences between timestamped benchmark results.
- Update test_open_cluster.cpp to support simulation environments and improve benchmark options.

### Issue
(Link to Github issue(s))

### Description
(Add freeform description.)

### List of the changes
(Itemized list of all the changes.)

### Testing
(Comment on CI testing or Manual testing touching this change.)

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
