### PR TITLE
adds get_ethernet_firmware_version to ClusterDescriptor

### DIFF
--- a/device/api/umd/device/cluster_descriptor.hpp
+++ b/device/api/umd/device/cluster_descriptor.hpp
@@ -255,6 +255,8 @@ public:
 
     IODeviceType get_cluster_io_device_type() const { return io_device_type; }
 
+    std::optional<SemVer> get_ethernet_firmware_version() const { return eth_fw_version; };
+
 private:
     int get_ethernet_link_coord_distance(const EthCoord &location_a, const EthCoord &location_b) const;
 


### PR DESCRIPTION
### Issue
tt-metal [43899](https://github.com/tenstorrent/tt-metal/pull/43899)

### Description
allow for migration off `tt::umd::Cluster` to `tt::umd::TTDevice`

### List of the changes
added a getter: `ClusterDescriptor:: get_ethernet_firmware_version`

### Testing
Successfully tested on internal cluster with tt-metal

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [https://github.com/tenstorrent/tt-metal/pull/43899] (If breaking change) tt_metal approved PR pointing to this branch: link
