### PR TITLE
Revert heartbeat timeout

### DIFF
--- a/device/api/umd/device/utils/timeouts.hpp
+++ b/device/api/umd/device/utils/timeouts.hpp
@@ -18,7 +18,9 @@ inline constexpr auto DRAM_TRAINING_TIMEOUT = std::chrono::milliseconds(300'000)
 inline constexpr auto ETH_QUEUE_ENABLE_TIMEOUT = std::chrono::milliseconds(30'000);
 inline constexpr auto ETH_TRAINING_TIMEOUT = std::chrono::milliseconds(900'000);
 inline constexpr auto ETH_STARTUP_TIMEOUT = std::chrono::milliseconds(10'000);
-inline constexpr auto ETH_HEARTBEAT_TIMEOUT = std::chrono::milliseconds(5);
+// Note: This was formerly 5ms, and it made some of our tests fail even when ETH was running.
+// If adjusting, stress test using our whole test suite to see if the timeout is sufficient.
+inline constexpr auto ETH_HEARTBEAT_TIMEOUT = std::chrono::milliseconds(50);
 
 inline constexpr auto AICLK_TIMEOUT = std::chrono::milliseconds(100);
 


### PR DESCRIPTION
### Issue
#2599 
Aftermath of https://github.com/tenstorrent/tt-umd/pull/2433

### Description
In related PR, eth heartbeat timeout was changed. Reverting back to original value for now to stailize tests.

### List of the changes
- Change timeout back to 50 ms per core
- Add a note

### Testing
No specific testing, but tests on this branch shouldn't have this failure

### API Changes
There are no API changes in this PR.
