### PR TITLE
Add get_tray_id method to ClusterDescriptor

### DIFF
--- a/device/api/umd/device/arch/architecture_implementation.hpp
+++ b/device/api/umd/device/arch/architecture_implementation.hpp
@@ -111,6 +111,10 @@ public:
 
     // Whether static_vc should be used for tlb configuration.
     virtual bool get_static_vc() const = 0;
+
+    // Map a PCI bus id to a UBB tray id (1..4). Returns std::nullopt for archs without UBB
+    // boards or when the bus id does not correspond to a known tray.
+    virtual std::optional<uint8_t> get_ubb_tray_id(uint16_t bus_id) const { return std::nullopt; }
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -4,10 +4,12 @@
 
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -323,6 +325,9 @@ inline constexpr uint64_t ETH_FW_PATCH_ADDR = 0x7CFBC;
 // whether NOC translation is enabled and if we want to use NOC0 or NOC1.
 tt_xy_pair get_arc_core(const bool noc_translation_enabled, const bool use_noc1);
 
+// High nibble of the PCI bus id (bus_id & 0xF0) for trays 1..4 on UBB Blackhole boards.
+inline constexpr std::array<uint16_t, 4> UBB_TRAY_BUS_IDS = {0x00, 0x40, 0xC0, 0x80};
+
 }  // namespace blackhole
 
 class blackhole_implementation : public architecture_implementation {
@@ -493,6 +498,15 @@ public:
     size_t get_cached_tlb_size() const override { return blackhole::STATIC_TLB_SIZE; }
 
     bool get_static_vc() const override { return false; }  // False due to a known HW issue.
+
+    std::optional<uint8_t> get_ubb_tray_id(uint16_t bus_id) const override {
+        const uint16_t bus_high = static_cast<uint16_t>(bus_id & 0xF0);
+        auto it = std::find(blackhole::UBB_TRAY_BUS_IDS.begin(), blackhole::UBB_TRAY_BUS_IDS.end(), bus_high);
+        if (it == blackhole::UBB_TRAY_BUS_IDS.end()) {
+            return std::nullopt;
+        }
+        return static_cast<uint8_t>(std::distance(blackhole::UBB_TRAY_BUS_IDS.begin(), it) + 1);
+    }
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -4,10 +4,12 @@
 
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -351,6 +353,9 @@ inline constexpr uint32_t SPI_PAGE_ERASE_SIZE = 0x1000;
 inline constexpr uint32_t SPI_ROM_SIZE = 1 << 24;
 inline constexpr uint32_t ARC_SPI_CHUNK_SIZE = SPI_PAGE_ERASE_SIZE;
 
+// High nibble of the PCI bus id (bus_id & 0xF0) for trays 1..4 on UBB Wormhole boards.
+inline constexpr std::array<uint16_t, 4> UBB_TRAY_BUS_IDS = {0xC0, 0x80, 0x00, 0x40};
+
 }  // namespace wormhole
 
 class wormhole_implementation : public architecture_implementation {
@@ -516,6 +521,15 @@ public:
     size_t get_cached_tlb_size() const override { return wormhole::STATIC_TLB_SIZE; }
 
     bool get_static_vc() const override { return true; }
+
+    std::optional<uint8_t> get_ubb_tray_id(uint16_t bus_id) const override {
+        const uint16_t bus_high = static_cast<uint16_t>(bus_id & 0xF0);
+        auto it = std::find(wormhole::UBB_TRAY_BUS_IDS.begin(), wormhole::UBB_TRAY_BUS_IDS.end(), bus_high);
+        if (it == wormhole::UBB_TRAY_BUS_IDS.end()) {
+            return std::nullopt;
+        }
+        return static_cast<uint8_t>(std::distance(wormhole::UBB_TRAY_BUS_IDS.begin(), it) + 1);
+    }
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/cluster_descriptor.hpp
+++ b/device/api/umd/device/cluster_descriptor.hpp
@@ -247,6 +247,8 @@ public:
 
     const std::unordered_map<ChipId, std::string> &get_chip_pci_bdfs() const;
 
+    uint8_t get_tray_id(ChipId chip_id) const;
+
     const std::vector<ChipId> &get_unhealthy_devices() const { return unhealthy_devices; }
 
     std::optional<SemVer> get_cluster_eth_fw_version() const { return eth_fw_version; }

--- a/device/api/umd/device/cluster_descriptor.hpp
+++ b/device/api/umd/device/cluster_descriptor.hpp
@@ -247,7 +247,7 @@ public:
 
     const std::unordered_map<ChipId, std::string> &get_chip_pci_bdfs() const;
 
-    uint8_t get_tray_id(ChipId chip_id) const;
+    std::optional<uint8_t> get_tray_id(ChipId chip_id) const;
 
     const std::vector<ChipId> &get_unhealthy_devices() const { return unhealthy_devices; }
 

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -8,7 +8,6 @@
 #include <yaml-cpp/yaml.h>
 
 #include <algorithm>
-#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -1379,28 +1378,16 @@ uint16_t ClusterDescriptor::get_bus_id(ChipId chip_id) const {
     return it->second;
 }
 
-const std::unordered_map<ChipId, uint16_t> &ClusterDescriptor::get_chip_to_bus_id() const { return chip_to_bus_id; }
-
-uint8_t ClusterDescriptor::get_tray_id(ChipId chip_id) const {
-    static const std::unordered_map<tt::ARCH, std::array<uint16_t, 4>> ubb_bus_ids = {
-        {tt::ARCH::WORMHOLE_B0, {0xC0, 0x80, 0x00, 0x40}},
-        {tt::ARCH::BLACKHOLE, {0x00, 0x40, 0xC0, 0x80}},
-    };
+std::optional<uint8_t> ClusterDescriptor::get_tray_id(ChipId chip_id) const {
     const BoardType board = get_board_type(chip_id);
     if (board != BoardType::UBB_WORMHOLE && board != BoardType::UBB_BLACKHOLE) {
-        return 0;
+        return std::nullopt;
     }
-    auto arch_it = ubb_bus_ids.find(get_arch(chip_id));
-    if (arch_it == ubb_bus_ids.end()) {
-        return 0;
+    auto arch_impl = architecture_implementation::create(get_arch(chip_id));
+    if (!arch_impl) {
+        return std::nullopt;
     }
-    const uint16_t bus_high = static_cast<uint16_t>(get_bus_id(chip_id) & 0xF0);
-    const auto &table = arch_it->second;
-    auto it = std::find(table.begin(), table.end(), bus_high);
-    if (it == table.end()) {
-        return 0;
-    }
-    return static_cast<uint8_t>(std::distance(table.begin(), it) + 1);
+    return arch_impl->get_ubb_tray_id(get_bus_id(chip_id));
 }
 
 }  // namespace tt::umd

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -8,6 +8,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -1376,6 +1377,30 @@ uint16_t ClusterDescriptor::get_bus_id(ChipId chip_id) const {
         return 0;
     }
     return it->second;
+}
+
+const std::unordered_map<ChipId, uint16_t> &ClusterDescriptor::get_chip_to_bus_id() const { return chip_to_bus_id; }
+
+uint8_t ClusterDescriptor::get_tray_id(ChipId chip_id) const {
+    static const std::unordered_map<tt::ARCH, std::array<uint16_t, 4>> ubb_bus_ids = {
+        {tt::ARCH::WORMHOLE_B0, {0xC0, 0x80, 0x00, 0x40}},
+        {tt::ARCH::BLACKHOLE, {0x00, 0x40, 0xC0, 0x80}},
+    };
+    const BoardType board = get_board_type(chip_id);
+    if (board != BoardType::UBB_WORMHOLE && board != BoardType::UBB_BLACKHOLE) {
+        return 0;
+    }
+    auto arch_it = ubb_bus_ids.find(get_arch(chip_id));
+    if (arch_it == ubb_bus_ids.end()) {
+        return 0;
+    }
+    const uint16_t bus_high = static_cast<uint16_t>(get_bus_id(chip_id) & 0xF0);
+    const auto &table = arch_it->second;
+    auto it = std::find(table.begin(), table.end(), bus_high);
+    if (it == table.end()) {
+        return 0;
+    }
+    return static_cast<uint8_t>(std::distance(table.begin(), it) + 1);
 }
 
 }  // namespace tt::umd

--- a/nanobind/py_api_topology_discovery.cpp
+++ b/nanobind/py_api_topology_discovery.cpp
@@ -85,35 +85,11 @@ void bind_topology_discovery(nb::module_& m) {
             release_gil(),
             "Get board ID for a chip")
         .def(
-            "get_chip_pci_bdfs",
-            &ClusterDescriptor::get_chip_pci_bdfs,
-            release_gil(),
-            "Map of ChipId -> PCI BDF string (e.g. \"0000:41:00.0\"). "
-            "Only contains entries for MMIO-capable chips.")
-        .def(
-            "get_chip_to_bus_id",
-            &ClusterDescriptor::get_chip_to_bus_id,
-            release_gil(),
-            "Map of ChipId -> PCI bus id (uint16, e.g. 0x41).")
-        .def(
-            "get_bus_id",
-            &ClusterDescriptor::get_bus_id,
-            nb::arg("chip_id"),
-            release_gil(),
-            "Returns the PCI bus id (uint16) for the given chip, or 0 if unknown.")
-        .def(
-            "get_asic_location",
-            &ClusterDescriptor::get_asic_location,
-            nb::arg("chip_id"),
-            release_gil(),
-            "Returns the ASIC location index within the chip's board (uint8), "
-            "or 0 if unknown.")
-        .def(
             "get_tray_id",
             &ClusterDescriptor::get_tray_id,
             nb::arg("chip_id"),
             release_gil(),
-            "Returns the tray id (1..4) for UBB boards, or 0 for non-UBB / unknown.")
+            "Returns the tray id (1..4) for UBB boards, or None for non-UBB / unknown.")
         .def("get_unhealthy_devices", &ClusterDescriptor::get_unhealthy_devices, release_gil())
         .def_static(
             "create_constrained_cluster_descriptor",

--- a/nanobind/py_api_topology_discovery.cpp
+++ b/nanobind/py_api_topology_discovery.cpp
@@ -84,6 +84,36 @@ void bind_topology_discovery(nb::module_& m) {
             nb::arg("chip"),
             release_gil(),
             "Get board ID for a chip")
+        .def(
+            "get_chip_pci_bdfs",
+            &ClusterDescriptor::get_chip_pci_bdfs,
+            release_gil(),
+            "Map of ChipId -> PCI BDF string (e.g. \"0000:41:00.0\"). "
+            "Only contains entries for MMIO-capable chips.")
+        .def(
+            "get_chip_to_bus_id",
+            &ClusterDescriptor::get_chip_to_bus_id,
+            release_gil(),
+            "Map of ChipId -> PCI bus id (uint16, e.g. 0x41).")
+        .def(
+            "get_bus_id",
+            &ClusterDescriptor::get_bus_id,
+            nb::arg("chip_id"),
+            release_gil(),
+            "Returns the PCI bus id (uint16) for the given chip, or 0 if unknown.")
+        .def(
+            "get_asic_location",
+            &ClusterDescriptor::get_asic_location,
+            nb::arg("chip_id"),
+            release_gil(),
+            "Returns the ASIC location index within the chip's board (uint8), "
+            "or 0 if unknown.")
+        .def(
+            "get_tray_id",
+            &ClusterDescriptor::get_tray_id,
+            nb::arg("chip_id"),
+            release_gil(),
+            "Returns the tray id (1..4) for UBB boards, or 0 for non-UBB / unknown.")
         .def("get_unhealthy_devices", &ClusterDescriptor::get_unhealthy_devices, release_gil())
         .def_static(
             "create_constrained_cluster_descriptor",


### PR DESCRIPTION
### Issue
(No linked issue)

### Description
Introduce the `get_tray_id` method in the `ClusterDescriptor` class to retrieve the tray ID for UBB boards based on the chip ID.

All tools should start using these exported data instead of hardcoding it across the projects.

### List of the changes
- Added `get_tray_id` method to `ClusterDescriptor`.
- Exposed `get_tray_id` in the Python API.

### Testing
Manual testing performed to ensure the new method returns correct tray IDs for UBB boards.

### API Changes
This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link

