### PR TITLE
Replace TLB window memcpy with 8/4-byte streaming stores (no AVX)

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -76,6 +76,7 @@ target_sources(
         chip_helpers/sysmem_buffer.cpp
         chip_helpers/tlb_manager.cpp
         pcie/tlb_window.cpp
+        pcie/device_memcpy.cpp
         pcie/silicon_tlb_window.cpp
         pcie/silicon_tlb_handle.cpp
         cluster.cpp
@@ -200,6 +201,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/logging/config.hpp
                 api/umd/device/utils/lock_manager.hpp
                 api/umd/device/utils/kmd_versions.hpp
+                api/umd/device/pcie/device_memcpy.hpp
                 api/umd/device/pcie/pci_device.hpp
                 api/umd/device/pcie/pci_ids.h
                 api/umd/device/pcie/tlb_handle.hpp

--- a/device/api/umd/device/pcie/device_memcpy.hpp
+++ b/device/api/umd/device/pcie/device_memcpy.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+
+namespace tt::umd {
+
+/**
+ * Streaming memcpy for writes targeting device memory mapped through a TLB window.
+ *
+ * Standard memcpy (glibc) can emit overlapping stores to the same address, which causes
+ * double writes when the destination is device memory. This routine guarantees each
+ * destination address is written exactly once.
+ *
+ * Uses explicit 8-byte and 4-byte volatile stores for the aligned middle, with byte
+ * stores for any sub-word leading/trailing portion. The Blackhole PCIe controller
+ * supports sub-DWORD writes natively, so no read-modify-write is required for the
+ * unaligned bytes.
+ */
+void streaming_memcpy_to_device(volatile void* dest, const void* src, std::size_t size);
+
+/**
+ * Streaming memcpy for reads from device memory mapped through a TLB window.
+ *
+ * Uses explicit 8-byte and 4-byte volatile loads for the aligned middle, with byte
+ * loads for any sub-word leading/trailing portion. Each device address is read at
+ * most once.
+ */
+void streaming_memcpy_from_device(void* dest, const volatile void* src, std::size_t size);
+
+}  // namespace tt::umd

--- a/device/api/umd/device/pcie/silicon_tlb_window.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_window.hpp
@@ -81,7 +81,7 @@ private:
     // which glibc's memcpy may perform when unrolling. This affects from and to device.
     // 2. syseng#3487 WH GDDR5 controller has a bug when 1-byte writes are temporarily adjacent
     // to 2-byte writes. We avoid ever performing a 1-byte write to the device. This only affects to device.
-    static void memcpy_from_device(void* dest, const void* src, std::size_t num_bytes);
+    static void memcpy_from_device(void* dest, const volatile void* src, std::size_t num_bytes);
     static void memcpy_to_device(void* dest, const void* src, std::size_t num_bytes);
 
     void write_regs(volatile uint32_t* dest, const uint32_t* src, uint32_t word_len);

--- a/device/pcie/device_memcpy.cpp
+++ b/device/pcie/device_memcpy.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/pcie/device_memcpy.hpp"
+
+#include <cstdint>
+#include <cstring>
+
+namespace tt::umd {
+
+void streaming_memcpy_to_device(volatile void* dest, const void* src, std::size_t size) {
+    auto* d = static_cast<volatile std::uint8_t*>(dest);
+    auto* s = static_cast<const std::uint8_t*>(src);
+
+    // Phase 0: Align destination to 4 bytes using byte-wide volatile stores.
+    while (size > 0 && (reinterpret_cast<std::uintptr_t>(d) % 4) != 0) {
+        *d++ = *s++;
+        size--;
+    }
+
+    // Phase 1: If destination is 4-byte but not 8-byte aligned, emit one 4-byte store
+    // to reach 8-byte alignment before the bulk 8-byte loop.
+    if (size >= 4 && (reinterpret_cast<std::uintptr_t>(d) % 8) != 0) {
+        std::uint32_t tmp;
+        std::memcpy(&tmp, s, sizeof(tmp));
+        *reinterpret_cast<volatile std::uint32_t*>(d) = tmp;
+        d += 4;
+        s += 4;
+        size -= 4;
+    }
+
+    // Phase 2: 8-byte volatile stores for the aligned middle.
+    while (size >= 8) {
+        std::uint64_t tmp;
+        std::memcpy(&tmp, s, sizeof(tmp));
+        *reinterpret_cast<volatile std::uint64_t*>(d) = tmp;
+        d += 8;
+        s += 8;
+        size -= 8;
+    }
+
+    // Phase 3: Trailing 4-byte chunk, if any.
+    if (size >= 4) {
+        std::uint32_t tmp;
+        std::memcpy(&tmp, s, sizeof(tmp));
+        *reinterpret_cast<volatile std::uint32_t*>(d) = tmp;
+        d += 4;
+        s += 4;
+        size -= 4;
+    }
+
+    // Phase 4: Trailing bytes (0-3) using byte-wide volatile stores.
+    while (size > 0) {
+        *d++ = *s++;
+        size--;
+    }
+}
+
+void streaming_memcpy_from_device(void* dest, const volatile void* src, std::size_t size) {
+    auto* d = static_cast<std::uint8_t*>(dest);
+    auto* s = static_cast<const volatile std::uint8_t*>(src);
+
+    // Phase 0: Align source to 4 bytes using byte-wide volatile loads.
+    while (size > 0 && (reinterpret_cast<std::uintptr_t>(s) % 4) != 0) {
+        *d++ = *s++;
+        size--;
+    }
+
+    // Phase 1: If source is 4-byte but not 8-byte aligned, emit one 4-byte load
+    // to reach 8-byte alignment before the bulk 8-byte loop.
+    if (size >= 4 && (reinterpret_cast<std::uintptr_t>(s) % 8) != 0) {
+        std::uint32_t tmp = *reinterpret_cast<const volatile std::uint32_t*>(s);
+        std::memcpy(d, &tmp, sizeof(tmp));
+        d += 4;
+        s += 4;
+        size -= 4;
+    }
+
+    // Phase 2: 8-byte volatile loads for the aligned middle.
+    while (size >= 8) {
+        std::uint64_t tmp = *reinterpret_cast<const volatile std::uint64_t*>(s);
+        std::memcpy(d, &tmp, sizeof(tmp));
+        d += 8;
+        s += 8;
+        size -= 8;
+    }
+
+    // Phase 3: Trailing 4-byte chunk, if any.
+    if (size >= 4) {
+        std::uint32_t tmp = *reinterpret_cast<const volatile std::uint32_t*>(s);
+        std::memcpy(d, &tmp, sizeof(tmp));
+        d += 4;
+        s += 4;
+        size -= 4;
+    }
+
+    // Phase 4: Trailing bytes (0-3) using byte-wide volatile loads.
+    while (size > 0) {
+        *d++ = *s++;
+        size--;
+    }
+}
+
+}  // namespace tt::umd

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <utility>
 
+#include "umd/device/pcie/device_memcpy.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/tlb_handle.hpp"
 #include "umd/device/types/arch.hpp"
@@ -110,32 +111,31 @@ void SiliconTlbWindow::read_register(uint64_t offset, void *data, size_t size) {
 }
 
 void SiliconTlbWindow::write_block(uint64_t offset, const void *data, size_t size) {
-    auto *src = static_cast<const uint32_t *>(data);
     auto *dst = reinterpret_cast<volatile uint32_t *>(tlb_handle->get_base() + get_total_offset(offset));
 
     validate(offset, size);
 
     if (tlb_handle->get_arch() == tt::ARCH::WORMHOLE_B0) {
-        memcpy_to_device((void *)dst, src, size);
+        memcpy_to_device((void *)dst, data, size);
     } else {
-        memcpy((void *)dst, (void *)src, size);
+        streaming_memcpy_to_device(dst, data, size);
     }
 }
 
 void SiliconTlbWindow::read_block(uint64_t offset, void *data, size_t size) {
-    const void *src = tlb_handle->get_base() + get_total_offset(offset);
+    const volatile void *src = tlb_handle->get_base() + get_total_offset(offset);
 
     validate(offset, size);
 
     if (tlb_handle->get_arch() == tt::ARCH::WORMHOLE_B0) {
         memcpy_from_device(data, src, size);
     } else {
-        memcpy(data, src, size);
+        streaming_memcpy_from_device(data, src, size);
     }
 }
 
-void SiliconTlbWindow::memcpy_from_device(void *dest, const void *src, std::size_t num_bytes) {
-    typedef std::uint32_t copy_t;
+void SiliconTlbWindow::memcpy_from_device(void *dest, const volatile void *src, std::size_t num_bytes) {
+    using copy_t = std::uint32_t;
 
     // Start by aligning the source (device) pointer.
     const volatile copy_t *sp;
@@ -144,7 +144,7 @@ void SiliconTlbWindow::memcpy_from_device(void *dest, const void *src, std::size
     unsigned int src_misalignment = src_addr % sizeof(copy_t);
 
     if (src_misalignment != 0) {
-        sp = reinterpret_cast<copy_t *>(src_addr - src_misalignment);
+        sp = reinterpret_cast<volatile copy_t *>(src_addr - src_misalignment);
 
         copy_t tmp = *sp++;
 
@@ -157,13 +157,13 @@ void SiliconTlbWindow::memcpy_from_device(void *dest, const void *src, std::size
         sp = static_cast<const volatile copy_t *>(src);
     }
 
-    // Copy the source-aligned middle.
-    copy_t *dp = static_cast<copy_t *>(dest);
+    // Copy the source-aligned middle using streaming loads (single read per device address).
     std::size_t num_words = num_bytes / sizeof(copy_t);
+    std::size_t middle_bytes = num_words * sizeof(copy_t);
+    streaming_memcpy_from_device(dest, sp, middle_bytes);
 
-    for (std::size_t i = 0; i < num_words; i++) {
-        *dp++ = *sp++;
-    }
+    auto *dp = static_cast<char *>(dest) + middle_bytes;
+    sp += num_words;
 
     // Finally copy any sub-word trailer.
     auto trailing_len = num_bytes % sizeof(copy_t);
@@ -174,7 +174,7 @@ void SiliconTlbWindow::memcpy_from_device(void *dest, const void *src, std::size
 }
 
 void SiliconTlbWindow::memcpy_to_device(void *dest, const void *src, std::size_t num_bytes) {
-    typedef std::uint32_t copy_t;
+    using copy_t = std::uint32_t;
 
     // Start by aligning the destination (device) pointer. If needed, do RMW to fix up the
     // first partial word.
@@ -201,13 +201,13 @@ void SiliconTlbWindow::memcpy_to_device(void *dest, const void *src, std::size_t
         dp = static_cast<copy_t *>(dest);
     }
 
-    // Copy the destination-aligned middle.
-    const copy_t *sp = static_cast<const copy_t *>(src);
+    // Copy the destination-aligned middle using streaming stores (single write per device address).
     std::size_t num_words = num_bytes / sizeof(copy_t);
+    std::size_t middle_bytes = num_words * sizeof(copy_t);
+    streaming_memcpy_to_device(dp, src, middle_bytes);
 
-    for (std::size_t i = 0; i < num_words; i++) {
-        *dp++ = *sp++;
-    }
+    dp += num_words;
+    auto *sp = static_cast<const char *>(src) + middle_bytes;
 
     // Finally copy any sub-word trailer, again RMW on the destination.
     auto trailing_len = num_bytes % sizeof(copy_t);

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -510,6 +510,46 @@ TEST(SiliconDriverBH, DISABLED_VirtualCoordinateBroadcast) {  // same problem as
     cluster.close_device();
 }
 
+TEST(SiliconDriverBH, DebugDoubleWrite) {
+    // NOC register that counts the number of posted write requests received by a core.
+    // Streaming stores go through write-combining BAR and generate posted PCIe writes.
+    constexpr uint64_t NIU_SLV_POSTED_WR_REQ_RECEIVED = 0xffb202e0;
+
+    Cluster cluster;
+    set_barrier_params(cluster);
+    test_utils::safe_test_cluster_start(&cluster);
+
+    auto chip_id = *cluster.get_target_mmio_device_ids().begin();
+    auto tensix_core = cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX).at(0);
+
+    uint64_t addr = 0;
+    uint32_t data = 1;
+    uint32_t counter = 0;
+
+    uint32_t base_reg_val;
+    cluster.read_from_device_reg(&base_reg_val, chip_id, tensix_core, NIU_SLV_POSTED_WR_REQ_RECEIVED, sizeof(uint32_t));
+
+    for (uint32_t i = 0; i < 100000; i++) {
+        cluster.write_to_device(&data, sizeof(data), chip_id, tensix_core, addr);
+        counter++;
+
+        uint32_t reg_val;
+        cluster.read_from_device_reg(&reg_val, chip_id, tensix_core, NIU_SLV_POSTED_WR_REQ_RECEIVED, sizeof(uint32_t));
+
+        uint32_t diff = reg_val - base_reg_val;
+
+        ASSERT_EQ(counter, diff);
+
+        uint32_t data_check = 0;
+        cluster.read_from_device(&data_check, chip_id, tensix_core, addr, sizeof(data));
+
+        EXPECT_EQ(static_cast<uint32_t>(data_check), static_cast<uint32_t>(data));
+
+        data++;
+    }
+    cluster.close_device();
+}
+
 // Verifies that all ETH channels are classified as either active/idle.
 TEST(ClusterBH, TotalNumberOfEthCores) {
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();


### PR DESCRIPTION
### Issue
closing https://github.com/tenstorrent/tt-umd/issues/1265
closing #68
closing #791

### Description

Alternative to #2357 / #2455 that does not use AVX2/SSE intrinsics. Same
single-write-per-address contract, but the aligned middle uses plain 8-byte
and 4-byte volatile stores instead of `_mm256_stream_si256` / `_mm_stream_si32`.

#2357 was reverted in #2430 due to issues observed with the AVX path, and the
re-land attempt in #2455 has been hitting similar problems. Switching the
aligned middle to scalar 8/4-byte stores keeps the no-double-write property —
the actual correctness requirement on device memory mapped through a TLB
window — while removing the AVX/non-temporal codepath entirely.

#### Background

glibc's `memcpy` can emit overlapping stores, which corrupts data on device
memory mapped through TLB windows because each store is a separate PCIe write
transaction. The streaming copy routines added here issue each destination
address exactly once.

### List of the changes

- Add `device_memcpy.hpp` / `device_memcpy.cpp` with `streaming_memcpy_to_device`
  and `streaming_memcpy_from_device`. Phases:
  - Byte-wide volatile stores/loads to align to 4 bytes
  - One 4-byte volatile store/load if needed to reach 8-byte alignment
  - 8-byte volatile stores/loads for the bulk
  - Optional 4-byte tail
  - Byte-wide tail
- Replace `memcpy` in `write_block`/`read_block` for non-Wormhole architectures
  with the streaming functions.
- WH-specific `memcpy_to_device` / `memcpy_from_device`: replace the
  word-by-word aligned-middle loop with the streaming functions.
- `SiliconTlbWindow::memcpy_from_device` signature updated to take
  `const volatile void*` (private static, internal only).
- Add `DebugDoubleWrite` test in `test_cluster_bh.cpp` that checks the NIU
  posted-write counter to verify each `write_to_device` produces exactly one
  PCIe write.

### Testing

CI. The new `DebugDoubleWrite` test directly validates the no-double-write
property on Blackhole.

### API Changes

No public API changes.