### PR TITLE
Expose additional ClusterDescriptor accessors in the Python API

### DIFF
--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -1390,4 +1390,6 @@ std::optional<uint8_t> ClusterDescriptor::get_tray_id(ChipId chip_id) const {
     return arch_impl->get_ubb_tray_id(get_bus_id(chip_id));
 }
 
+const std::unordered_map<ChipId, uint16_t> &ClusterDescriptor::get_chip_to_bus_id() const { return chip_to_bus_id; }
+
 }  // namespace tt::umd

--- a/nanobind/py_api_topology_discovery.cpp
+++ b/nanobind/py_api_topology_discovery.cpp
@@ -90,6 +90,29 @@ void bind_topology_discovery(nb::module_& m) {
             nb::arg("chip_id"),
             release_gil(),
             "Returns the tray id (1..4) for UBB boards, or None for non-UBB / unknown.")
+        .def(
+            "get_chip_pci_bdfs",
+            &ClusterDescriptor::get_chip_pci_bdfs,
+            release_gil(),
+            "Map of ChipId -> PCI BDF string (e.g. \"0000:41:00.0\"). "
+            "Only contains entries for MMIO-capable chips.")
+        .def(
+            "get_chip_to_bus_id",
+            &ClusterDescriptor::get_chip_to_bus_id,
+            release_gil(),
+            "Map of ChipId -> PCI bus id (uint16, e.g. 0x41).")
+        .def(
+            "get_bus_id",
+            &ClusterDescriptor::get_bus_id,
+            nb::arg("chip_id"),
+            release_gil(),
+            "Returns the PCI bus id (uint16) for the given chip, or 0 if unknown.")
+        .def(
+            "get_asic_location",
+            &ClusterDescriptor::get_asic_location,
+            nb::arg("chip_id"),
+            release_gil(),
+            "Returns the ASIC location index within the chip's board (uint8), or 0 if unknown.")
         .def("get_unhealthy_devices", &ClusterDescriptor::get_unhealthy_devices, release_gil())
         .def_static(
             "create_constrained_cluster_descriptor",


### PR DESCRIPTION
### Issue
(No linked issue)

### Description
Split out of #2606 per review feedback. Exposes additional `ClusterDescriptor` accessors in the Python API so tooling can consume PCI / ASIC location data from the cluster descriptor instead of hardcoding it across projects.

### List of the changes
- Added out-of-line C++ definition for `ClusterDescriptor::get_chip_to_bus_id` (declaration was already in the header).
- Exposed `get_chip_pci_bdfs`, `get_chip_to_bus_id`, `get_bus_id` and `get_asic_location` in the Python API via nanobind.

### Testing
- Local `cmake --build build` clean.
- `pre-commit run --all-files` clean.

### API Changes
This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link