### PR TITLE
Add use_safe_api option to TopologyDiscoveryOptions

### DIFF
--- a/device/api/umd/device/topology/topology_discovery_options.hpp
+++ b/device/api/umd/device/topology/topology_discovery_options.hpp
@@ -88,5 +88,12 @@ struct TopologyDiscoveryOptions {
     // to opt out of KMD legacy mode (KMD >= 2.6.0), allowing idle power reduction.
     // Default is false (high-power / legacy mode) to preserve backward compatibility.
     bool low_power = false;
+
+    /**
+     * @brief If true, TTDevice instances created during discovery will use the safe API
+     * (forwarded as the use_safe_api argument to TTDevice::create).
+     * Defaults to false.
+     */
+    bool use_safe_api = false;
 };
 }  // namespace tt::umd

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -134,7 +134,7 @@ void TopologyDiscovery::get_connected_devices() {
     }
 
     for (auto& device_id : local_device_ids) {
-        std::unique_ptr<TTDevice> tt_device = TTDevice::create(device_id, io_device_type);
+        std::unique_ptr<TTDevice> tt_device = TTDevice::create(device_id, io_device_type, options.use_safe_api);
         if (!options.low_power) {
             // Low power mode is temporarily disabled. See https://github.com/tenstorrent/tt-umd/issues/2531.
             log_warning(

--- a/nanobind/py_api_topology_discovery.cpp
+++ b/nanobind/py_api_topology_discovery.cpp
@@ -140,7 +140,8 @@ void bind_topology_discovery(nb::module_& m) {
         .def_rw("wait_on_ethernet_link_training", &TopologyDiscoveryOptions::wait_on_ethernet_link_training)
         .def_rw("perform_6u_eth_retrain", &TopologyDiscoveryOptions::perform_6u_eth_retrain)
         // Low power mode is temporarily disabled. See https://github.com/tenstorrent/tt-umd/issues/2531.
-        .def_rw("low_power", &TopologyDiscoveryOptions::low_power);
+        .def_rw("low_power", &TopologyDiscoveryOptions::low_power)
+        .def_rw("use_safe_api", &TopologyDiscoveryOptions::use_safe_api);
 
     nb::class_<TopologyDiscovery>(m, "TopologyDiscovery")
         .def_static(


### PR DESCRIPTION
### Issue
(No linked GitHub issue)

### Description
Introduce a `use_safe_api` option in `TopologyDiscoveryOptions` to allow the use of a safer API when creating `TTDevice` instances during topology discovery.

### List of the changes
- Added `use_safe_api` boolean option to `TopologyDiscoveryOptions`.
- Updated `TTDevice::create` calls to utilize the `use_safe_api` option.
- Exposed `use_safe_api` in the Python API for `TopologyDiscoveryOptions`.

### Testing
Manual testing conducted to verify the functionality of the new option.

### API Changes
This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link

