### PR TITLE
AICLK not reaching limit mediation

### DIFF
--- a/device/api/umd/device/types/telemetry.hpp
+++ b/device/api/umd/device/types/telemetry.hpp
@@ -70,7 +70,11 @@ enum TelemetryTag : uint8_t {
     ASIC_ID_LOW = 62,
     AICLK_LIMIT_MAX = 63,
     TDP_LIMIT_MAX = 64,
-    NUMBER_OF_TAGS = 65,
+    AICLK_ARB_MIN = 65,
+    AICLK_ARB_MAX = 66,
+    ENABLED_MIN_ARB = 67,
+    ENABLED_MAX_ARB = 68,
+    NUMBER_OF_TAGS = 69,
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/utils/timeouts.hpp
+++ b/device/api/umd/device/utils/timeouts.hpp
@@ -22,7 +22,7 @@ inline constexpr auto ETH_STARTUP_TIMEOUT = std::chrono::milliseconds(10'000);
 // If adjusting, stress test using our whole test suite to see if the timeout is sufficient.
 inline constexpr auto ETH_HEARTBEAT_TIMEOUT = std::chrono::milliseconds(50);
 
-inline constexpr auto AICLK_TIMEOUT = std::chrono::milliseconds(100);
+inline constexpr auto AICLK_TIMEOUT = std::chrono::milliseconds(200);
 
 inline constexpr auto WARM_RESET_M3_TIMEOUT = std::chrono::milliseconds(20'000);
 inline constexpr auto WARM_RESET_REAPPEAR_POLL_INTERVAL = std::chrono::milliseconds(100);

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -251,33 +251,33 @@ void Chip::wait_for_aiclk_value(
         auto end = std::chrono::steady_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
         if (duration.count() > timeout_ms.count()) {
+            auto* telemetry = tt_device->get_arc_telemetry_reader();
+            std::string arb_max_info;
+            if (telemetry != nullptr && telemetry->is_entry_available(TelemetryTag::AICLK_ARB_MAX)) {
+                const uint32_t arb_max = telemetry->read_entry(TelemetryTag::AICLK_ARB_MAX);
+                const uint32_t arb_freq = arb_max & 0xFFFF;
+                const uint32_t arb_idx = (arb_max >> 16) & 0xFFFF;
+                arb_max_info = fmt::format(", AICLK clamped by max-arbiter index {} at {} MHz", arb_idx, arb_freq);
+            }
             log_warning(
                 LogUMD,
                 "Waiting for AICLK value to settle failed on timeout after {}. Expected to see {}, last value "
                 "observed {}. This can be due to possible overheating of the chip or other issues. ASIC temperature: "
-                "{}",
+                "{}{}",
                 timeout_ms.count(),
                 target_aiclk,
                 aiclk,
-                tt_device->get_asic_temperature());
-            auto* telemetry = tt_device->get_arc_telemetry_reader();
-            if (telemetry != nullptr) {
-                if (telemetry->is_entry_available(TelemetryTag::UPDATE_TELEM_SPEED)) {
-                    const uint32_t update_telem_speed_ms = telemetry->read_entry(TelemetryTag::UPDATE_TELEM_SPEED);
-                    if (timeout_ms.count() <= update_telem_speed_ms) {
-                        log_warning(
-                            LogUMD,
-                            "AICLK timeout ({} ms) is not larger than the telemetry update interval ({} ms); the "
-                            "observed AICLK may be a stale telemetry value. Consider increasing AICLK_TIMEOUT.",
-                            timeout_ms.count(),
-                            update_telem_speed_ms);
-                    }
-                }
-                if (telemetry->is_entry_available(TelemetryTag::AICLK_ARB_MAX)) {
-                    const uint32_t arb_max = telemetry->read_entry(TelemetryTag::AICLK_ARB_MAX);
-                    const uint32_t arb_freq = arb_max & 0xFFFF;
-                    const uint32_t arb_idx = (arb_max >> 16) & 0xFFFF;
-                    log_warning(LogUMD, "AICLK is clamped by max-arbiter index {} at {} MHz.", arb_idx, arb_freq);
+                tt_device->get_asic_temperature(),
+                arb_max_info);
+            if (telemetry != nullptr && telemetry->is_entry_available(TelemetryTag::UPDATE_TELEM_SPEED)) {
+                const uint32_t update_telem_speed_ms = telemetry->read_entry(TelemetryTag::UPDATE_TELEM_SPEED);
+                if (timeout_ms.count() <= update_telem_speed_ms) {
+                    log_warning(
+                        LogUMD,
+                        "AICLK timeout ({} ms) is not larger than the telemetry update interval ({} ms); the "
+                        "observed AICLK may be a stale telemetry value. Consider increasing AICLK_TIMEOUT.",
+                        timeout_ms.count(),
+                        update_telem_speed_ms);
                 }
             }
             return;

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -23,6 +23,7 @@
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/blackhole_arc.hpp"
 #include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/telemetry.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/timeouts.hpp"
@@ -259,6 +260,26 @@ void Chip::wait_for_aiclk_value(
                 target_aiclk,
                 aiclk,
                 tt_device->get_asic_temperature());
+            auto* telemetry = tt_device->get_arc_telemetry_reader();
+            if (telemetry != nullptr) {
+                if (telemetry->is_entry_available(TelemetryTag::UPDATE_TELEM_SPEED)) {
+                    const uint32_t update_telem_speed_ms = telemetry->read_entry(TelemetryTag::UPDATE_TELEM_SPEED);
+                    if (timeout_ms.count() <= update_telem_speed_ms) {
+                        log_warning(
+                            LogUMD,
+                            "AICLK timeout ({} ms) is not larger than the telemetry update interval ({} ms); the "
+                            "observed AICLK may be a stale telemetry value. Consider increasing AICLK_TIMEOUT.",
+                            timeout_ms.count(),
+                            update_telem_speed_ms);
+                    }
+                }
+                if (telemetry->is_entry_available(TelemetryTag::AICLK_ARB_MAX)) {
+                    const uint32_t arb_max = telemetry->read_entry(TelemetryTag::AICLK_ARB_MAX);
+                    const uint32_t arb_freq = arb_max & 0xFFFF;
+                    const uint32_t arb_idx = (arb_max >> 16) & 0xFFFF;
+                    log_warning(LogUMD, "AICLK is clamped by max-arbiter index {} at {} MHz.", arb_idx, arb_freq);
+                }
+            }
             return;
         }
         aiclk = tt_device->get_clock();

--- a/nanobind/py_api_telemetry.cpp
+++ b/nanobind/py_api_telemetry.cpp
@@ -148,6 +148,10 @@ void bind_telemetry(nb::module_& m) {
         .value("ASIC_ID_LOW", TelemetryTag::ASIC_ID_LOW)
         .value("AICLK_LIMIT_MAX", TelemetryTag::AICLK_LIMIT_MAX)
         .value("TDP_LIMIT_MAX", TelemetryTag::TDP_LIMIT_MAX)
+        .value("AICLK_ARB_MIN", TelemetryTag::AICLK_ARB_MIN)
+        .value("AICLK_ARB_MAX", TelemetryTag::AICLK_ARB_MAX)
+        .value("ENABLED_MIN_ARB", TelemetryTag::ENABLED_MIN_ARB)
+        .value("ENABLED_MAX_ARB", TelemetryTag::ENABLED_MAX_ARB)
         .value("NUMBER_OF_TAGS", TelemetryTag::NUMBER_OF_TAGS)
         .def(
             "__int__", [](TelemetryTag tag) { return static_cast<int>(tag); }, release_gil());


### PR DESCRIPTION
### Issue
https://tenstorrent.atlassian.net/browse/DCAMP-186
#2663 

### Description
Per suggestion from the ticket:
Update timeout period, and update warning message to be more informative.

### List of the changes
- Raise timeout from 100 to 200ms, since 100ms is exactly the period for telemetry update. This makes sure that if you do some event, and then read for 200ms you're guaranteed to get at least one update after the event.
- log warning if timeout period is less than the update telemetry period.
- Log the value for AICLK_ARB_MAX in case AICLK didn't reach the final value.

### Testing
I've commented out the line which increases the AICLK, and got these warning messages:

```
2026-05-11 18:08:28.886 | warning  |             UMD | Waiting for AICLK value to settle failed on timeout after 10. Expected to see 1350, last value observed 800. This can be due to possible overheating of the chip or other issues. ASIC temperature: 56.686187744140625 (chip.cpp:254)
2026-05-11 18:08:28.886 | warning  |             UMD | AICLK timeout (10 ms) is not larger than the telemetry update interval (100 ms); the observed AICLK may be a stale telemetry value. Consider increasing AICLK_TIMEOUT. (chip.cpp:268)
2026-05-11 18:08:28.886 | warning  |             UMD | AICLK is clamped by max-arbiter index 0 at 1350 MHz. (chip.cpp:280)
```

### API Changes
There are no API changes in this PR.
