### PR TITLE
Disable heartbeat check on BH

### DIFF
--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -265,7 +265,8 @@ void TopologyDiscovery::discover_remote_devices() {
                 continue;
             }
 
-            if (!eth_heartbeat_running(tt_device, eth_core)) {
+            // TODO: Temporary - heartbeat check disabled for Blackhole.
+            if (tt_device->get_arch() != ARCH::BLACKHOLE && !eth_heartbeat_running(tt_device, eth_core)) {
                 auto err = UMD_THROW_OR_RETURN(
                     options.eth_fw_heartbeat_failure == TopologyDiscoveryOptions::Action::THROW,
                     error::RuntimeError,


### PR DESCRIPTION
### Issue
After #2433 
#2612 

### Description
Heartbeat check was reverted, but there is still some issue related to how tt-metal runs tests.
Disabling until we figure out the issue, to unblock umd bump

### List of the changes
- Skip check altogether in case of blackhole.

### Testing
Current umd bump has failing runs: https://github.com/tenstorrent/tt-metal/actions/runs/25497455199/job/74844090826
This should be a passing run with this branch: https://github.com/tenstorrent/tt-metal/actions/runs/25727039683

### API Changes
There are no API changes in this PR.
