### PR TITLE
Add CI regression checking workflow

### DIFF
--- a/.github/workflows/build-and-run-all-benchmarks.yml
+++ b/.github/workflows/build-and-run-all-benchmarks.yml
@@ -81,3 +81,11 @@ jobs:
       ubuntu-docker-version: ${{ matrix.ubuntu-docker-version}}
       card: ${{ matrix.test-group.card}}
       baseline-run-id: ${{ inputs.baseline-run-id }}
+
+  # Regression check against in-repo baselines.yaml (median of N main runs +
+  # per-case tolerance). Runs in parallel with analyze-results, which answers a
+  # different question (drift vs. the single latest main run).
+  regression-check:
+    secrets: inherit
+    needs: run-benchmarks
+    uses: ./.github/workflows/regression-check.yml

--- a/.github/workflows/build-and-run-all-benchmarks.yml
+++ b/.github/workflows/build-and-run-all-benchmarks.yml
@@ -89,4 +89,8 @@ jobs:
     secrets: inherit
     needs: run-benchmarks
     if: ${{ !cancelled() && needs.run-benchmarks.result != 'skipped' }}
+    permissions:
+      contents: read
+      packages: read
+      actions: read
     uses: ./.github/workflows/regression-check.yml

--- a/.github/workflows/build-and-run-all-benchmarks.yml
+++ b/.github/workflows/build-and-run-all-benchmarks.yml
@@ -88,4 +88,5 @@ jobs:
   regression-check:
     secrets: inherit
     needs: run-benchmarks
+    if: ${{ !cancelled() && needs.run-benchmarks.result != 'skipped' }}
     uses: ./.github/workflows/regression-check.yml

--- a/.github/workflows/regression-check.yml
+++ b/.github/workflows/regression-check.yml
@@ -65,14 +65,22 @@ jobs:
       - name: Summarize regressions
         run: |
           . /tmp/venv/bin/activate
+          # Capture exit code without aborting — summarize_regressions.py exits 1
+          # when a gated case breaches, but we still want the step summary and
+          # log output published before the step fails.
+          set +e
           python3 tests/microbenchmark/tools/summarize_regressions.py \
             --current "${RESULTS_DIR}" \
             --baselines tests/microbenchmark/expected/baselines.yaml \
             --output "${SUMMARY_PATH}"
-          cat "${SUMMARY_PATH}" >> "${GITHUB_STEP_SUMMARY}"
-          # Also echo to job log so the table is greppable from the run page
-          echo "----- regression summary -----"
-          cat "${SUMMARY_PATH}"
+          rc=$?
+          set -e
+          if [ -f "${SUMMARY_PATH}" ]; then
+            cat "${SUMMARY_PATH}" >> "${GITHUB_STEP_SUMMARY}"
+            echo "----- regression summary -----"
+            cat "${SUMMARY_PATH}"
+          fi
+          exit "${rc}"
 
       - name: Upload regression summary artifact
         if: always()

--- a/.github/workflows/regression-check.yml
+++ b/.github/workflows/regression-check.yml
@@ -5,7 +5,7 @@
 # tolerances, and emits a coarse cross-arch summary plus per-(test, arch) detail
 # sections to $GITHUB_STEP_SUMMARY.
 #
-# Pilot: soft alerts only — the job always exits 0.
+# Pilot: soft by default, but can hard-fail when gate: true breaches.
 name: Regression check against in-repo baseline
 
 on:
@@ -22,8 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository }}/tt-umd-ci-ubuntu-24.04:latest
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout regression tooling

--- a/.github/workflows/regression-check.yml
+++ b/.github/workflows/regression-check.yml
@@ -20,6 +20,11 @@ jobs:
   regression-check:
     name: Regression summary vs baselines.yaml
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read   # actions/checkout
+      packages: read   # pull ghcr.io container image
+      actions: read    # actions/download-artifact API access
     container:
       image: ghcr.io/${{ github.repository }}/tt-umd-ci-ubuntu-24.04:latest
 
@@ -82,7 +87,7 @@ jobs:
 
       - name: Upload regression summary artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: regression-summary
           path: ${{ env.SUMMARY_PATH }}

--- a/.github/workflows/regression-check.yml
+++ b/.github/workflows/regression-check.yml
@@ -35,8 +35,24 @@ jobs:
             tests/microbenchmark/tools/analyze_results.py
           sparse-checkout-cone-mode: false
 
+      # Container is Ubuntu 24.04 (PEP 668-enforced); install into a venv to
+      # match the pattern in analyze_results.yml.
+      - name: Install python3-venv
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends python3-venv
+
+      - name: Create and activate virtual environment
+        run: |
+          python3 -m venv /tmp/venv
+          . /tmp/venv/bin/activate
+          echo "PATH=$PATH" >> $GITHUB_ENV
+          echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
+
       - name: Install python dependencies
-        run: python3 -m pip install --no-cache-dir pandas psutil pyyaml tabulate
+        run: |
+          . /tmp/venv/bin/activate
+          python3 -m pip install --no-cache-dir pandas psutil pyyaml tabulate
 
       - name: Download all benchmark JSON artifacts
         uses: actions/download-artifact@v8
@@ -48,6 +64,7 @@ jobs:
 
       - name: Summarize regressions
         run: |
+          . /tmp/venv/bin/activate
           python3 tests/microbenchmark/tools/summarize_regressions.py \
             --current "${RESULTS_DIR}" \
             --baselines tests/microbenchmark/expected/baselines.yaml \

--- a/.github/workflows/regression-check.yml
+++ b/.github/workflows/regression-check.yml
@@ -1,0 +1,66 @@
+# Regression check against in-repo baselines.yaml.
+# Complementary to analyze_results.yml (which diffs current run vs the single
+# latest main run). This workflow compares against the median of N main runs
+# stored in tests/microbenchmark/expected/baselines.yaml, applies per-case
+# tolerances, and emits a coarse cross-arch summary plus per-(test, arch) detail
+# sections to $GITHUB_STEP_SUMMARY.
+#
+# Pilot: soft alerts only — the job always exits 0.
+name: Regression check against in-repo baseline
+
+on:
+  workflow_call:
+    # No inputs — downloads benchmark-json-* artifacts from the parent run.
+
+env:
+  RESULTS_DIR: /tmp/all-arch-results
+  SUMMARY_PATH: /tmp/regression_summary.md
+
+jobs:
+  regression-check:
+    name: Regression summary vs baselines.yaml
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}/tt-umd-ci-ubuntu-24.04:latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout regression tooling
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            tests/microbenchmark/expected/baselines.yaml
+            tests/microbenchmark/tools/summarize_regressions.py
+            tests/microbenchmark/tools/analyze_results.py
+          sparse-checkout-cone-mode: false
+
+      - name: Install python dependencies
+        run: python3 -m pip install --no-cache-dir pandas psutil pyyaml tabulate
+
+      - name: Download all benchmark JSON artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: benchmark-json-*
+          path: ${{ env.RESULTS_DIR }}
+          merge-multiple: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summarize regressions
+        run: |
+          python3 tests/microbenchmark/tools/summarize_regressions.py \
+            --current "${RESULTS_DIR}" \
+            --baselines tests/microbenchmark/expected/baselines.yaml \
+            --output "${SUMMARY_PATH}"
+          cat "${SUMMARY_PATH}" >> "${GITHUB_STEP_SUMMARY}"
+          # Also echo to job log so the table is greppable from the run page
+          echo "----- regression summary -----"
+          cat "${SUMMARY_PATH}"
+
+      - name: Upload regression summary artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: regression-summary
+          path: ${{ env.SUMMARY_PATH }}
+          if-no-files-found: warn

--- a/tests/microbenchmark/expected/baselines.yaml
+++ b/tests/microbenchmark/expected/baselines.yaml
@@ -2,8 +2,14 @@
 # Calibrated from 30 successful main runs of build-and-run-all-benchmarks.yml.
 # To refresh: tests/microbenchmark/tools/refresh_baselines.py --runs 30
 #
-# Pilot scope: ClusterConstructor only. Other suites (TLB, PCIe DMA, IOMMU,
-# Ethernet I/O) will be onboarded once the pipeline is validated end-to-end.
+# Pilot scope: ClusterConstructor + TLB_Tensix_Unicast_v_Multicast. Other suites
+# (TLB_DRAM, PCIe DMA, IOMMU, Ethernet I/O) will be onboarded once the pipeline
+# is validated end-to-end.
+#
+# Note on per-arch case sets: TLB_Tensix_Unicast_v_Multicast varies its core
+# count by arch (72 cores on n150, 64 on n300, 120 on p150b), so each case
+# entry contains a single arch — the cell totals in the summary table will
+# differ per arch, which is expected.
 #
 # Schema:
 #   <bench_title>:
@@ -16,7 +22,7 @@
 metadata:
   calibrated_at: "2026-05-11"
   calibrated_from_runs: 30
-  notes: "Pilot — soft alerts only. ClusterConstructor only."
+  notes: "Pilot — soft alerts only. ClusterConstructor + TLB_Tensix_Unicast_v_Multicast."
 
 ClusterConstructor:
   default:
@@ -27,3 +33,185 @@ ClusterConstructor:
     BH p150b: { median_throughput: 104.1, tolerance_pct: 49 }
     WH n150: { median_throughput: 161.9, tolerance_pct: 15 }
     WH n300: { median_throughput: 36.76, tolerance_pct: 20 }
+
+TLB_Tensix_Unicast_v_Multicast:
+  "Multicast, 120 cores, 1 bytes":
+    BH p150b: { median_throughput: 1.827e+06, tolerance_pct: 32 }
+  "Multicast, 120 cores, 1024 bytes":
+    BH p150b: { median_throughput: 3.665e+08, tolerance_pct: 5 }
+  "Multicast, 120 cores, 1048576 bytes":
+    BH p150b: { median_throughput: 4.206e+08, tolerance_pct: 5 }
+  "Multicast, 120 cores, 131072 bytes":
+    BH p150b: { median_throughput: 4.204e+08, tolerance_pct: 5 }
+  "Multicast, 120 cores, 16384 bytes":
+    BH p150b: { median_throughput: 4.182e+08, tolerance_pct: 5 }
+  "Multicast, 120 cores, 2 bytes":
+    BH p150b: { median_throughput: 3.653e+06, tolerance_pct: 20 }
+  "Multicast, 120 cores, 2048 bytes":
+    BH p150b: { median_throughput: 3.928e+08, tolerance_pct: 5 }
+  "Multicast, 120 cores, 262144 bytes":
+    BH p150b: { median_throughput: 4.208e+08, tolerance_pct: 5 }
+  "Multicast, 120 cores, 32768 bytes":
+    BH p150b: { median_throughput: 4.196e+08, tolerance_pct: 5 }
+  "Multicast, 120 cores, 4 bytes":
+    BH p150b: { median_throughput: 7.307e+06, tolerance_pct: 12 }
+  "Multicast, 120 cores, 4096 bytes":
+    BH p150b: { median_throughput: 4.065e+08, tolerance_pct: 5 }
+  "Multicast, 120 cores, 524288 bytes":
+    BH p150b: { median_throughput: 4.206e+08, tolerance_pct: 5 }
+  "Multicast, 120 cores, 65536 bytes":
+    BH p150b: { median_throughput: 4.209e+08, tolerance_pct: 5 }
+  "Multicast, 120 cores, 8 bytes":
+    BH p150b: { median_throughput: 1.461e+07, tolerance_pct: 13 }
+  "Multicast, 120 cores, 8192 bytes":
+    BH p150b: { median_throughput: 4.136e+08, tolerance_pct: 5 }
+  "Multicast, 64 cores, 1 bytes":
+    WH n300: { median_throughput: 4.738e+05, tolerance_pct: 30 }
+  "Multicast, 64 cores, 1024 bytes":
+    WH n300: { median_throughput: 4.206e+08, tolerance_pct: 9 }
+  "Multicast, 64 cores, 1048576 bytes":
+    WH n300: { median_throughput: 4.86e+08, tolerance_pct: 7 }
+  "Multicast, 64 cores, 131072 bytes":
+    WH n300: { median_throughput: 4.856e+08, tolerance_pct: 5 }
+  "Multicast, 64 cores, 16384 bytes":
+    WH n300: { median_throughput: 4.817e+08, tolerance_pct: 5 }
+  "Multicast, 64 cores, 2 bytes":
+    WH n300: { median_throughput: 9.427e+05, tolerance_pct: 29 }
+  "Multicast, 64 cores, 2048 bytes":
+    WH n300: { median_throughput: 4.509e+08, tolerance_pct: 5 }
+  "Multicast, 64 cores, 262144 bytes":
+    WH n300: { median_throughput: 4.859e+08, tolerance_pct: 5 }
+  "Multicast, 64 cores, 32768 bytes":
+    WH n300: { median_throughput: 4.839e+08, tolerance_pct: 5 }
+  "Multicast, 64 cores, 4 bytes":
+    WH n300: { median_throughput: 4.702e+06, tolerance_pct: 58 }
+  "Multicast, 64 cores, 4096 bytes":
+    WH n300: { median_throughput: 4.678e+08, tolerance_pct: 5 }
+  "Multicast, 64 cores, 524288 bytes":
+    WH n300: { median_throughput: 4.86e+08, tolerance_pct: 6 }
+  "Multicast, 64 cores, 65536 bytes":
+    WH n300: { median_throughput: 4.85e+08, tolerance_pct: 5 }
+  "Multicast, 64 cores, 8 bytes":
+    WH n300: { median_throughput: 9.674e+06, tolerance_pct: 57 }
+  "Multicast, 64 cores, 8192 bytes":
+    WH n300: { median_throughput: 4.768e+08, tolerance_pct: 5 }
+  "Multicast, 72 cores, 1 bytes":
+    WH n150: { median_throughput: 4.389e+05, tolerance_pct: 20 }
+  "Multicast, 72 cores, 1024 bytes":
+    WH n150: { median_throughput: 3.796e+08, tolerance_pct: 5 }
+  "Multicast, 72 cores, 1048576 bytes":
+    WH n150: { median_throughput: 4.32e+08, tolerance_pct: 5 }
+  "Multicast, 72 cores, 131072 bytes":
+    WH n150: { median_throughput: 4.317e+08, tolerance_pct: 5 }
+  "Multicast, 72 cores, 16384 bytes":
+    WH n150: { median_throughput: 4.288e+08, tolerance_pct: 5 }
+  "Multicast, 72 cores, 2 bytes":
+    WH n150: { median_throughput: 8.413e+05, tolerance_pct: 21 }
+  "Multicast, 72 cores, 2048 bytes":
+    WH n150: { median_throughput: 4.041e+08, tolerance_pct: 5 }
+  "Multicast, 72 cores, 262144 bytes":
+    WH n150: { median_throughput: 4.319e+08, tolerance_pct: 5 }
+  "Multicast, 72 cores, 32768 bytes":
+    WH n150: { median_throughput: 4.305e+08, tolerance_pct: 5 }
+  "Multicast, 72 cores, 4 bytes":
+    WH n150: { median_throughput: 4.308e+06, tolerance_pct: 37 }
+  "Multicast, 72 cores, 4096 bytes":
+    WH n150: { median_throughput: 4.176e+08, tolerance_pct: 5 }
+  "Multicast, 72 cores, 524288 bytes":
+    WH n150: { median_throughput: 4.32e+08, tolerance_pct: 5 }
+  "Multicast, 72 cores, 65536 bytes":
+    WH n150: { median_throughput: 4.314e+08, tolerance_pct: 5 }
+  "Multicast, 72 cores, 8 bytes":
+    WH n150: { median_throughput: 8.626e+06, tolerance_pct: 36 }
+  "Multicast, 72 cores, 8192 bytes":
+    WH n150: { median_throughput: 4.254e+08, tolerance_pct: 5 }
+  "Unicast, 120 cores, 1 bytes":
+    BH p150b: { median_throughput: 1.884e+04, tolerance_pct: 57 }
+  "Unicast, 120 cores, 1024 bytes":
+    BH p150b: { median_throughput: 1.745e+07, tolerance_pct: 57 }
+  "Unicast, 120 cores, 1048576 bytes":
+    BH p150b: { median_throughput: 4.746e+07, tolerance_pct: 5 }
+  "Unicast, 120 cores, 131072 bytes":
+    BH p150b: { median_throughput: 4.689e+07, tolerance_pct: 5 }
+  "Unicast, 120 cores, 16384 bytes":
+    BH p150b: { median_throughput: 4.207e+07, tolerance_pct: 5 }
+  "Unicast, 120 cores, 2 bytes":
+    BH p150b: { median_throughput: 4.16e+04, tolerance_pct: 52 }
+  "Unicast, 120 cores, 2048 bytes":
+    BH p150b: { median_throughput: 2.284e+07, tolerance_pct: 7 }
+  "Unicast, 120 cores, 262144 bytes":
+    BH p150b: { median_throughput: 4.73e+07, tolerance_pct: 5 }
+  "Unicast, 120 cores, 32768 bytes":
+    BH p150b: { median_throughput: 4.475e+07, tolerance_pct: 5 }
+  "Unicast, 120 cores, 4 bytes":
+    BH p150b: { median_throughput: 8.42e+04, tolerance_pct: 47 }
+  "Unicast, 120 cores, 4096 bytes":
+    BH p150b: { median_throughput: 3.092e+07, tolerance_pct: 5 }
+  "Unicast, 120 cores, 524288 bytes":
+    BH p150b: { median_throughput: 4.729e+07, tolerance_pct: 5 }
+  "Unicast, 120 cores, 65536 bytes":
+    BH p150b: { median_throughput: 4.62e+07, tolerance_pct: 5 }
+  "Unicast, 120 cores, 8 bytes":
+    BH p150b: { median_throughput: 1.687e+05, tolerance_pct: 45 }
+  "Unicast, 120 cores, 8192 bytes":
+    BH p150b: { median_throughput: 3.755e+07, tolerance_pct: 5 }
+  "Unicast, 64 cores, 1 bytes":
+    WH n300: { median_throughput: 7599, tolerance_pct: 43 }
+  "Unicast, 64 cores, 1024 bytes":
+    WH n300: { median_throughput: 2.181e+07, tolerance_pct: 46 }
+  "Unicast, 64 cores, 1048576 bytes":
+    WH n300: { median_throughput: 3.518e+07, tolerance_pct: 8 }
+  "Unicast, 64 cores, 131072 bytes":
+    WH n300: { median_throughput: 3.517e+07, tolerance_pct: 8 }
+  "Unicast, 64 cores, 16384 bytes":
+    WH n300: { median_throughput: 3.46e+07, tolerance_pct: 8 }
+  "Unicast, 64 cores, 2 bytes":
+    WH n300: { median_throughput: 1.51e+04, tolerance_pct: 42 }
+  "Unicast, 64 cores, 2048 bytes":
+    WH n300: { median_throughput: 3.008e+07, tolerance_pct: 7 }
+  "Unicast, 64 cores, 262144 bytes":
+    WH n300: { median_throughput: 3.519e+07, tolerance_pct: 7 }
+  "Unicast, 64 cores, 32768 bytes":
+    WH n300: { median_throughput: 3.501e+07, tolerance_pct: 8 }
+  "Unicast, 64 cores, 4 bytes":
+    WH n300: { median_throughput: 7.456e+04, tolerance_pct: 93 }
+  "Unicast, 64 cores, 4096 bytes":
+    WH n300: { median_throughput: 3.245e+07, tolerance_pct: 7 }
+  "Unicast, 64 cores, 524288 bytes":
+    WH n300: { median_throughput: 3.521e+07, tolerance_pct: 8 }
+  "Unicast, 64 cores, 65536 bytes":
+    WH n300: { median_throughput: 3.51e+07, tolerance_pct: 7 }
+  "Unicast, 64 cores, 8 bytes":
+    WH n300: { median_throughput: 1.513e+05, tolerance_pct: 91 }
+  "Unicast, 64 cores, 8192 bytes":
+    WH n300: { median_throughput: 3.378e+07, tolerance_pct: 10 }
+  "Unicast, 72 cores, 1 bytes":
+    WH n150: { median_throughput: 6278, tolerance_pct: 25 }
+  "Unicast, 72 cores, 1024 bytes":
+    WH n150: { median_throughput: 1.709e+07, tolerance_pct: 40 }
+  "Unicast, 72 cores, 1048576 bytes":
+    WH n150: { median_throughput: 3.108e+07, tolerance_pct: 5 }
+  "Unicast, 72 cores, 131072 bytes":
+    WH n150: { median_throughput: 3.107e+07, tolerance_pct: 5 }
+  "Unicast, 72 cores, 16384 bytes":
+    WH n150: { median_throughput: 3.055e+07, tolerance_pct: 5 }
+  "Unicast, 72 cores, 2 bytes":
+    WH n150: { median_throughput: 1.243e+04, tolerance_pct: 27 }
+  "Unicast, 72 cores, 2048 bytes":
+    WH n150: { median_throughput: 2.657e+07, tolerance_pct: 5 }
+  "Unicast, 72 cores, 262144 bytes":
+    WH n150: { median_throughput: 3.11e+07, tolerance_pct: 5 }
+  "Unicast, 72 cores, 32768 bytes":
+    WH n150: { median_throughput: 3.089e+07, tolerance_pct: 5 }
+  "Unicast, 72 cores, 4 bytes":
+    WH n150: { median_throughput: 6.042e+04, tolerance_pct: 37 }
+  "Unicast, 72 cores, 4096 bytes":
+    WH n150: { median_throughput: 2.865e+07, tolerance_pct: 5 }
+  "Unicast, 72 cores, 524288 bytes":
+    WH n150: { median_throughput: 3.112e+07, tolerance_pct: 5 }
+  "Unicast, 72 cores, 65536 bytes":
+    WH n150: { median_throughput: 3.102e+07, tolerance_pct: 5 }
+  "Unicast, 72 cores, 8 bytes":
+    WH n150: { median_throughput: 1.194e+05, tolerance_pct: 38 }
+  "Unicast, 72 cores, 8192 bytes":
+    WH n150: { median_throughput: 2.99e+07, tolerance_pct: 5 }

--- a/tests/microbenchmark/expected/baselines.yaml
+++ b/tests/microbenchmark/expected/baselines.yaml
@@ -1,0 +1,29 @@
+# tests/microbenchmark/expected/baselines.yaml
+# Calibrated from 30 successful main runs of build-and-run-all-benchmarks.yml.
+# To refresh: tests/microbenchmark/tools/refresh_baselines.py --runs 30
+#
+# Pilot scope: ClusterConstructor only. Other suites (TLB, PCIe DMA, IOMMU,
+# Ethernet I/O) will be onboarded once the pipeline is validated end-to-end.
+#
+# Schema:
+#   <bench_title>:
+#     <case_name>:
+#       <arch_label>:
+#         median_throughput: float       # ops/s (batch / median_elapsed)
+#         tolerance_pct: float           # symmetric +-%; alert if |delta%| > this
+#         gate: bool (optional)          # Phase 2 hard gates; preserved on refresh
+
+metadata:
+  calibrated_at: "2026-05-11"
+  calibrated_from_runs: 30
+  notes: "Pilot — soft alerts only. ClusterConstructor only."
+
+ClusterConstructor:
+  default:
+    BH p150b: { median_throughput: 119.5, tolerance_pct: 45 }
+    WH n150: { median_throughput: 138.3, tolerance_pct: 30 }
+    WH n300: { median_throughput: 41.16, tolerance_pct: 16 }
+  from sdesc:
+    BH p150b: { median_throughput: 104.1, tolerance_pct: 49 }
+    WH n150: { median_throughput: 161.9, tolerance_pct: 15 }
+    WH n300: { median_throughput: 36.76, tolerance_pct: 20 }

--- a/tests/microbenchmark/expected/baselines.yaml
+++ b/tests/microbenchmark/expected/baselines.yaml
@@ -18,8 +18,14 @@
 #         median_throughput: float       # ops/s (batch / median_elapsed)
 #         tolerance_pct: float           # symmetric +-%; alert if |delta%| > this
 #         gate: bool (optional)          # Phase 2 hard gates; preserved on refresh
+#
+# Tolerance policy: small-payload cases run on shared CI hardware show high
+# run-to-run variance, so some rows have tolerance_pct >= 50. Treat these as
+# informational only — never set `gate: true` on a row with tolerance_pct > 30.
+# Once dedicated benchmark hardware lands, and hopefully we have more stable measurements, tolerances should tighten.
 
 metadata:
+  schema_version: 1
   calibrated_at: "2026-05-11"
   calibrated_from_runs: 30
   notes: "Pilot — soft alerts only. ClusterConstructor + TLB_Tensix_Unicast_v_Multicast."

--- a/tests/microbenchmark/tools/compare_to_baseline.py
+++ b/tests/microbenchmark/tools/compare_to_baseline.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Local wrapper around `summarize_regressions.py`.
+
+Run benchmarks locally (with `UMD_MICROBENCHMARK_RESULTS_PATH` set so the C++
+exporter actually writes JSON), then point this script at the resulting
+directory and your arch to get a markdown regression report against the
+in-repo `baselines.yaml`.
+
+Example:
+
+    export UMD_MICROBENCHMARK_RESULTS_PATH=/tmp/umd-bench
+    mkdir -p "$UMD_MICROBENCHMARK_RESULTS_PATH"
+    ./build/tests/microbenchmark/microbenchmark_tests \\
+        --gtest_filter='MicrobenchmarkTLB.CompareMulticastandUnicast'
+
+    python3 tests/microbenchmark/tools/compare_to_baseline.py --arch 'WH n150'
+
+The summary is printed to stdout. Exit code is 1 if any `gate: true` case in
+`baselines.yaml` breached as DOWN/CRIT (same gating rule as the CI workflow);
+0 otherwise.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from summarize_regressions import (  # noqa: E402
+    ARCH_PATTERNS,
+    read_arch_results,
+    render_summary,
+)
+
+KNOWN_ARCH_LABELS = [label for label, _ in ARCH_PATTERNS]
+BASELINES_DEFAULT = Path(__file__).resolve().parents[1] / "expected" / "baselines.yaml"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--results",
+        type=Path,
+        default=os.environ.get("UMD_MICROBENCHMARK_RESULTS_PATH"),
+        help=(
+            "Directory holding local <title>.json files. "
+            "Defaults to $UMD_MICROBENCHMARK_RESULTS_PATH."
+        ),
+    )
+    p.add_argument(
+        "--arch",
+        required=True,
+        choices=KNOWN_ARCH_LABELS,
+        help="Arch label to compare against (must match a key in baselines.yaml).",
+    )
+    p.add_argument(
+        "--baselines",
+        type=Path,
+        default=BASELINES_DEFAULT,
+        help=f"Path to baselines.yaml (default: {BASELINES_DEFAULT}).",
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional path to also write the markdown summary to.",
+    )
+    args = p.parse_args()
+
+    if args.results is None:
+        sys.exit(
+            "No results path. Either pass --results or set "
+            "UMD_MICROBENCHMARK_RESULTS_PATH before running the benchmarks."
+        )
+    if not args.results.is_dir():
+        sys.exit(f"--results is not a directory: {args.results}")
+    if not args.baselines.is_file():
+        sys.exit(f"--baselines is not a file: {args.baselines}")
+
+    with open(args.baselines) as f:
+        baselines = yaml.safe_load(f) or {}
+
+    per_arch = read_arch_results(args.results, args.arch)
+    if not per_arch:
+        sys.exit(
+            f"No usable JSON results found under {args.results}. Did the run "
+            f"produce <title>.json files? (Check UMD_MICROBENCHMARK_RESULTS_PATH.)"
+        )
+
+    # render_summary expects { arch_label: { test_title: { case_name: ... } } }.
+    # For local mode we only have one arch — the table renders with a single column.
+    current = {args.arch: per_arch}
+    markdown, gated_breaches, missing_gated = render_summary(current, baselines)
+
+    print(markdown)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(markdown)
+
+    if missing_gated:
+        print(
+            f"\nWARN: {len(missing_gated)} gated case(s) missing from this run "
+            f"on {args.arch}.",
+            file=sys.stderr,
+        )
+        for title, case, arch in missing_gated:
+            print(f"  - {title} :: {case} :: {arch}", file=sys.stderr)
+    if gated_breaches:
+        print(
+            f"\nFAIL: {len(gated_breaches)} gated case(s) breached tolerance "
+            f"on {args.arch}.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/microbenchmark/tools/refresh_baselines.py
+++ b/tests/microbenchmark/tools/refresh_baselines.py
@@ -145,9 +145,16 @@ def collect_samples(repo: str, runs: list[dict], token: str) -> dict:
                     med = result.get("median(elapsed)")
                     batch = result.get("batch")
                     unit = result.get("unit") or "byte"
-                    if med and batch and case is not None:
-                        samples[arch][title][case].append(batch / med)
-                        units[arch][title][case] = unit
+                    if case is None or med is None or batch is None:
+                        continue
+                    if med == 0 or batch == 0:
+                        print(
+                            f"WARN: skipping {arch}/{title}/{case}: med={med} batch={batch}",
+                            file=sys.stderr,
+                        )
+                        continue
+                    samples[arch][title][case].append(batch / med)
+                    units[arch][title][case] = unit
     return samples, units
 
 

--- a/tests/microbenchmark/tools/refresh_baselines.py
+++ b/tests/microbenchmark/tools/refresh_baselines.py
@@ -188,9 +188,10 @@ def render_yaml(
     existing_gates: dict,
     runs_used: int,
     workflow: str,
-) -> tuple[str, list]:
-    """Render baselines.yaml content. Returns (text, diff_lines)."""
+) -> tuple[str, list, list]:
+    """Render baselines.yaml content. Returns (text, diff_lines, low_sample_lines)."""
     diff_lines: list[str] = []
+    low_sample_lines: list[str] = []
     out = io.StringIO()
 
     out.write(f"# tests/microbenchmark/expected/baselines.yaml\n")
@@ -244,6 +245,10 @@ def render_yaml(
                         f"  {title} :: {case} :: {arch}: "
                         f"tolerance {old_tolerance:g}% -> {tolerance_pct:g}%"
                     )
+                if len(series) < MIN_SAMPLES_FOR_RELIABLE:
+                    low_sample_lines.append(
+                        f"  {title} :: {case} :: {arch}: {len(series)} sample(s)"
+                    )
                 out.write(
                     f"    {_yaml_escape(arch)}: "
                     f"{{ median_throughput: {median_thr:.4g}, "
@@ -251,7 +256,7 @@ def render_yaml(
                 )
         out.write("\n")
 
-    return out.getvalue(), diff_lines
+    return out.getvalue(), diff_lines, low_sample_lines
 
 
 def _yaml_escape(s: str) -> str:
@@ -330,7 +335,7 @@ def main() -> int:
     output_path = args.output.resolve()
 
     existing_gates = load_existing_gates(output_path)
-    yaml_text, diff_lines = render_yaml(
+    yaml_text, diff_lines, low_sample_lines = render_yaml(
         samples, existing_gates, len(runs), args.workflow
     )
 
@@ -351,6 +356,15 @@ def main() -> int:
             "\n(No tolerance shifts > 5 percentage points vs existing YAML.)",
             file=sys.stderr,
         )
+
+    if low_sample_lines:
+        print(
+            f"\n{len(low_sample_lines)} case(s) calibrated from fewer than "
+            f"{MIN_SAMPLES_FOR_RELIABLE} samples (review before committing):",
+            file=sys.stderr,
+        )
+        for line in low_sample_lines:
+            print(line, file=sys.stderr)
 
     return 0
 

--- a/tests/microbenchmark/tools/refresh_baselines.py
+++ b/tests/microbenchmark/tools/refresh_baselines.py
@@ -5,13 +5,17 @@
 benchmarks workflow.
 
 Per (test, case, arch) tuple, collects throughput samples across runs,
-computes the median and the sample standard deviation, and writes:
+computes the median and the median absolute deviation (MAD), and writes:
     median_throughput = median(samples)
-    tolerance_pct     = max(5, ceil(3 * stdev_pct))
+    tolerance_pct     = max(5, ceil(4.5 * mad_pct))
 
-Three-sigma covers ~99.7% of a normal distribution; the 5% floor stops
-near-deterministic tests from getting a 0% tolerance that would alert on
-rounding noise; ceil keeps tolerance slightly wider rather than tighter.
+MAD is the median of |sample - median|. It is robust to single-run
+outliers — one noisy CI run shifts MAD by at most one rank, whereas it
+would inflate stdev disproportionately because stdev squares deviations.
+The K=4.5 factor gives ~99.7% coverage of a normal distribution. 
+The 5% floor stops near-deterministic tests from getting a 0% tolerance
+ that would alert on rounding noise; ceil keeps tolerance slightly wider
+   rather than tighter.
 
 Existing `gate: true` flags in the YAML are preserved across refreshes —
 the refresh tool should never silently un-gate a case.
@@ -49,6 +53,9 @@ from summarize_regressions import arch_label_from_artifact  # noqa: E402
 REPO_DEFAULT = "tenstorrent/tt-umd"
 MIN_SAMPLES_FOR_RELIABLE = 10
 TOLERANCE_FLOOR_PCT = 5
+# Multiplier on MAD-as-percent for the tolerance band. 4.5 gives ~99.7%
+# coverage of a normal distribution.
+MAD_K = 4.5
 
 
 # --- GitHub API access -----------------------------------------------------------
@@ -170,14 +177,16 @@ def derive_baseline_entry(samples: list[float]) -> tuple[float, float, str]:
         suffix = f"  # only {len(samples)} samples — tolerance may be too tight/loose"
     else:
         suffix = ""
-    median_thr = statistics.median(samples)
+    median_throughput = statistics.median(samples)
     if len(samples) < 2:
-        # Can't compute stdev with one sample — use the floor.
-        return median_thr, float(TOLERANCE_FLOOR_PCT), suffix
-    stdev_thr = statistics.stdev(samples)
-    stdev_pct = stdev_thr / median_thr * 100 if median_thr else 0.0
-    tolerance_pct = max(TOLERANCE_FLOOR_PCT, math.ceil(3 * stdev_pct))
-    return median_thr, float(tolerance_pct), suffix
+        # No spread to measure with one sample — use the floor.
+        return median_throughput, float(TOLERANCE_FLOOR_PCT), suffix
+    # Robust spread: median of absolute deviations from the median, expressed
+    # as a percentage of the median so the tolerance is unit-agnostic.
+    mad = statistics.median(abs(s - median_throughput) for s in samples)
+    mad_pct = mad / median_throughput * 100 if median_throughput else 0.0
+    tolerance_pct = max(TOLERANCE_FLOOR_PCT, math.ceil(MAD_K * mad_pct))
+    return median_throughput, float(tolerance_pct), suffix
 
 
 # --- YAML rendering --------------------------------------------------------------

--- a/tests/microbenchmark/tools/refresh_baselines.py
+++ b/tests/microbenchmark/tools/refresh_baselines.py
@@ -320,14 +320,16 @@ def main() -> int:
             "No samples collected — workflow may not produce benchmark-json-* artifacts."
         )
 
-    existing_gates = load_existing_gates(args.output)
+    output_path = args.output.resolve()
+
+    existing_gates = load_existing_gates(output_path)
     yaml_text, diff_lines = render_yaml(
         samples, existing_gates, len(runs), args.workflow
     )
 
-    args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(yaml_text)
-    print(f"Wrote {args.output}", file=sys.stderr)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(yaml_text)
+    print(f"Wrote {output_path}", file=sys.stderr)
 
     if diff_lines:
         print(

--- a/tests/microbenchmark/tools/refresh_baselines.py
+++ b/tests/microbenchmark/tools/refresh_baselines.py
@@ -1,0 +1,350 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Refresh `baselines.yaml` from the last N successful main runs of the
+benchmarks workflow.
+
+Per (test, case, arch) tuple, collects throughput samples across runs,
+computes the median and the sample standard deviation, and writes:
+    median_throughput = median(samples)
+    tolerance_pct     = max(5, ceil(3 * stdev_pct))
+
+Three-sigma covers ~99.7% of a normal distribution; the 5% floor stops
+near-deterministic tests from getting a 0% tolerance that would alert on
+rounding noise; ceil keeps tolerance slightly wider rather than tighter.
+
+Existing `gate: true` flags in the YAML are preserved across refreshes —
+the refresh tool should never silently un-gate a case.
+
+Usage:
+    GH_TOKEN=ghp_... python3 refresh_baselines.py \\
+        --workflow build-and-run-all-benchmarks.yml \\
+        --runs 30 \\
+        --output tests/microbenchmark/expected/baselines.yaml
+
+After the script writes the YAML, review the diff and submit it as a PR.
+"""
+
+import argparse
+import io
+import json
+import math
+import os
+import statistics
+import sys
+import urllib.error
+import urllib.request
+import zipfile
+from collections import defaultdict
+from datetime import date
+from pathlib import Path
+
+import yaml
+
+# Reuse the canonical arch label mapping from summarize_regressions.py so the
+# arch keys in baselines.yaml stay consistent across both tools.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from summarize_regressions import arch_label_from_artifact  # noqa: E402
+
+REPO_DEFAULT = "tenstorrent/tt-umd"
+MIN_SAMPLES_FOR_RELIABLE = 10
+TOLERANCE_FLOOR_PCT = 5
+
+
+# --- GitHub API access -----------------------------------------------------------
+
+
+class _NoAuthRedirect(urllib.request.HTTPRedirectHandler):
+    """Don't forward Authorization header to the artifact's presigned blob URL."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return urllib.request.Request(newurl, method=req.get_method())
+
+
+def _opener():
+    return urllib.request.build_opener(_NoAuthRedirect())
+
+
+def _gh_get(url: str, token: str, raw: bool = False):
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+        },
+    )
+    with _opener().open(req) as r:
+        return r.read() if raw else json.load(r)
+
+
+def list_recent_main_runs(repo: str, workflow: str, n: int, token: str) -> list[dict]:
+    url = (
+        f"https://api.github.com/repos/{repo}/actions/workflows/{workflow}/runs"
+        f"?branch=main&status=success&per_page={n}"
+    )
+    return _gh_get(url, token)["workflow_runs"][:n]
+
+
+def list_artifacts(repo: str, run_id: int, token: str) -> list[dict]:
+    url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/artifacts?per_page=100"
+    return _gh_get(url, token)["artifacts"]
+
+
+def download_artifact(repo: str, artifact_id: int, token: str) -> bytes:
+    return _gh_get(
+        f"https://api.github.com/repos/{repo}/actions/artifacts/{artifact_id}/zip",
+        token,
+        raw=True,
+    )
+
+
+# --- Sample collection -----------------------------------------------------------
+
+
+def collect_samples(repo: str, runs: list[dict], token: str) -> dict:
+    """Walk each run's benchmark-json-* artifacts, return:
+    { arch_label: { test_title: { case_name: [throughput, throughput, ...] } } }
+    """
+    samples: dict = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
+    units: dict = defaultdict(
+        lambda: defaultdict(dict)
+    )  # arch -> title -> case -> unit
+    for r in runs:
+        sha = r["head_sha"][:8]
+        print(f"  run {r['id']} sha={sha}", file=sys.stderr)
+        try:
+            arts = list_artifacts(repo, r["id"], token)
+        except urllib.error.HTTPError as e:
+            print(f"    skip: {e}", file=sys.stderr)
+            continue
+        bench_arts = [a for a in arts if a["name"].startswith("benchmark-json-")]
+        for a in bench_arts:
+            arch = arch_label_from_artifact(a["name"])
+            if arch is None:
+                continue
+            try:
+                zb = download_artifact(repo, a["id"], token)
+            except urllib.error.HTTPError as e:
+                print(f"    artifact {a['name']}: {e}", file=sys.stderr)
+                continue
+            z = zipfile.ZipFile(io.BytesIO(zb))
+            # Latest-wins per title (handles timestamped subdirs).
+            by_title: dict[str, str] = {}
+            for n in sorted(z.namelist()):
+                if not n.endswith(".json"):
+                    continue
+                title = n.split("/")[-1][: -len(".json")]
+                if title == "machine_host_spec":
+                    continue
+                by_title[title] = n
+            for title, path in by_title.items():
+                with z.open(path) as f:
+                    data = json.load(f)
+                for result in data.get("results", []):
+                    case = result.get("name")
+                    med = result.get("median(elapsed)")
+                    batch = result.get("batch")
+                    unit = result.get("unit") or "byte"
+                    if med and batch and case is not None:
+                        samples[arch][title][case].append(batch / med)
+                        units[arch][title][case] = unit
+    return samples, units
+
+
+# --- Tolerance derivation --------------------------------------------------------
+
+
+def derive_baseline_entry(samples: list[float]) -> tuple[float, float, str]:
+    """Return (median_throughput, tolerance_pct, comment).
+
+    `comment` is a free-text annotation (may be empty) for the YAML.
+    """
+    if len(samples) < MIN_SAMPLES_FOR_RELIABLE:
+        suffix = f"  # only {len(samples)} samples — tolerance may be too tight/loose"
+    else:
+        suffix = ""
+    median_thr = statistics.median(samples)
+    if len(samples) < 2:
+        # Can't compute stdev with one sample — use the floor.
+        return median_thr, float(TOLERANCE_FLOOR_PCT), suffix
+    stdev_thr = statistics.stdev(samples)
+    stdev_pct = stdev_thr / median_thr * 100 if median_thr else 0.0
+    tolerance_pct = max(TOLERANCE_FLOOR_PCT, math.ceil(3 * stdev_pct))
+    return median_thr, float(tolerance_pct), suffix
+
+
+# --- YAML rendering --------------------------------------------------------------
+
+
+def render_yaml(
+    samples: dict,
+    existing_gates: dict,
+    runs_used: int,
+    workflow: str,
+) -> tuple[str, list]:
+    """Render baselines.yaml content. Returns (text, diff_lines)."""
+    diff_lines: list[str] = []
+    out = io.StringIO()
+
+    out.write(f"# tests/microbenchmark/expected/baselines.yaml\n")
+    out.write(f"# Calibrated from {runs_used} successful main runs of {workflow}.\n")
+    out.write(
+        "# To refresh: tests/microbenchmark/tools/refresh_baselines.py --runs 30\n"
+    )
+    out.write("#\n")
+    out.write("# Schema:\n")
+    out.write("#   <bench_title>:\n")
+    out.write("#     <case_name>:\n")
+    out.write("#       <arch_label>:\n")
+    out.write(
+        "#         median_throughput: float       # ops/s (batch / median_elapsed)\n"
+    )
+    out.write(
+        "#         tolerance_pct: float           # symmetric +-%; alert if |delta%| > this\n"
+    )
+    out.write(
+        "#         gate: bool (optional)          # Phase 2 hard gates; preserved on refresh\n"
+    )
+    out.write("\n")
+    out.write("metadata:\n")
+    out.write(f'  calibrated_at: "{date.today().isoformat()}"\n')
+    out.write(f"  calibrated_from_runs: {runs_used}\n")
+    out.write('  notes: "Pilot — soft alerts only."\n')
+    out.write("\n")
+
+    # Deterministic ordering: tests alphabetical, archs alphabetical within case.
+    all_titles = sorted({title for arch in samples for title in samples[arch]})
+    for title in all_titles:
+        out.write(f"{title}:\n")
+        # cases that appear in any arch for this title
+        all_cases: set = set()
+        for arch in samples:
+            all_cases.update(samples[arch].get(title, {}).keys())
+        for case in sorted(all_cases):
+            out.write(f"  {_yaml_escape(case)}:\n")
+            archs_for_case = sorted(
+                arch for arch in samples if case in samples[arch].get(title, {})
+            )
+            for arch in archs_for_case:
+                series = samples[arch][title][case]
+                median_thr, tolerance_pct, suffix = derive_baseline_entry(series)
+                gate = existing_gates.get((title, case, arch), False)
+                gate_str = ", gate: true" if gate else ""
+                # Track tolerance shift vs existing YAML for review.
+                old_tolerance = existing_gates.get(("__tolerance__", title, case, arch))
+                if old_tolerance is not None and abs(tolerance_pct - old_tolerance) > 5:
+                    diff_lines.append(
+                        f"  {title} :: {case} :: {arch}: "
+                        f"tolerance {old_tolerance:g}% -> {tolerance_pct:g}%"
+                    )
+                out.write(
+                    f"    {_yaml_escape(arch)}: "
+                    f"{{ median_throughput: {median_thr:.4g}, "
+                    f"tolerance_pct: {tolerance_pct:g}{gate_str} }}{suffix}\n"
+                )
+        out.write("\n")
+
+    return out.getvalue(), diff_lines
+
+
+def _yaml_escape(s: str) -> str:
+    """Wrap a string in quotes if it contains characters that confuse YAML."""
+    if any(c in s for c in ":#,&*!|>'\"%@`{}[]\n") or s.strip() != s:
+        return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    return s
+
+
+def load_existing_gates(path: Path) -> dict:
+    """Read existing YAML to preserve `gate: true` flags and capture old tolerances."""
+    state: dict = {}
+    if not path.exists():
+        return state
+    with open(path) as f:
+        data = yaml.safe_load(f) or {}
+    for title, cases in data.items():
+        if title == "metadata":
+            continue
+        if not isinstance(cases, dict):
+            continue
+        for case_name, arch_entries in cases.items():
+            if not isinstance(arch_entries, dict):
+                continue
+            for arch, entry in arch_entries.items():
+                if not isinstance(entry, dict):
+                    continue
+                if entry.get("gate") is True:
+                    state[(title, case_name, arch)] = True
+                tol = entry.get("tolerance_pct")
+                if tol is not None:
+                    state[("__tolerance__", title, case_name, arch)] = float(tol)
+    return state
+
+
+# --- Main ------------------------------------------------------------------------
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--repo", default=REPO_DEFAULT, help="owner/repo, default tenstorrent/tt-umd"
+    )
+    p.add_argument(
+        "--workflow",
+        default="build-and-run-all-benchmarks.yml",
+        help="Workflow file name (basename, .yml extension).",
+    )
+    p.add_argument("--runs", type=int, default=30, help="Number of main runs to use.")
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=Path("tests/microbenchmark/expected/baselines.yaml"),
+        help="Where to write the refreshed YAML.",
+    )
+    args = p.parse_args()
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        sys.exit("Set GH_TOKEN (or GITHUB_TOKEN) in the environment.")
+
+    print(
+        f"Fetching last {args.runs} successful main runs of {args.workflow}...",
+        file=sys.stderr,
+    )
+    runs = list_recent_main_runs(args.repo, args.workflow, args.runs, token)
+    if not runs:
+        sys.exit("No successful runs found.")
+    print(f"Got {len(runs)} runs. Downloading benchmark artifacts...", file=sys.stderr)
+    samples, _units = collect_samples(args.repo, runs, token)
+    if not samples:
+        sys.exit(
+            "No samples collected — workflow may not produce benchmark-json-* artifacts."
+        )
+
+    existing_gates = load_existing_gates(args.output)
+    yaml_text, diff_lines = render_yaml(
+        samples, existing_gates, len(runs), args.workflow
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(yaml_text)
+    print(f"Wrote {args.output}", file=sys.stderr)
+
+    if diff_lines:
+        print(
+            "\nTolerances that shifted by more than 5 percentage points "
+            "(review before committing):",
+            file=sys.stderr,
+        )
+        for line in diff_lines:
+            print(line, file=sys.stderr)
+    else:
+        print(
+            "\n(No tolerance shifts > 5 percentage points vs existing YAML.)",
+            file=sys.stderr,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/microbenchmark/tools/summarize_regressions.py
+++ b/tests/microbenchmark/tools/summarize_regressions.py
@@ -59,11 +59,8 @@ def collect_current_results(current_dir: Path) -> dict:
 
     Returns: { arch_label: { test_title: { case_name: { "throughput": float, "unit": str } } } }
 
-    Handles both layouts the C++ exporter may produce:
-      - flat:        <artifact>/<title>.json
-      - timestamped: <artifact>/<YYYY-MM-DDTHH-MM-SS>/<title>.json
-    If multiple timestamped subdirs exist (multi-iteration runs), the
-    lexicographically-latest one wins; this matches "most recent iteration".
+    The C++ exporter writes flat `<artifact>/<title>.json` files (see
+    `microbenchmark_utils.hpp::export_results`).
     """
     results: dict = defaultdict(lambda: defaultdict(dict))
     for artifact_dir in sorted(current_dir.iterdir()):
@@ -78,14 +75,10 @@ def collect_current_results(current_dir: Path) -> dict:
                 file=sys.stderr,
             )
             continue
-        # Latest-wins per title (handles timestamped subdirs).
-        by_title: dict[str, Path] = {}
-        for p in sorted(artifact_dir.rglob("*.json")):
-            title = p.stem
+        for path in sorted(artifact_dir.glob("*.json")):
+            title = path.stem
             if title == "machine_host_spec":
                 continue
-            by_title[title] = p
-        for title, path in by_title.items():
             with open(path) as f:
                 data = json.load(f)
             for r in data.get("results", []):

--- a/tests/microbenchmark/tools/summarize_regressions.py
+++ b/tests/microbenchmark/tools/summarize_regressions.py
@@ -74,8 +74,15 @@ def collect_current_results(current_dir: Path) -> dict:
             title = path.stem
             if title == "machine_host_spec":
                 continue
-            with open(path) as f:
-                data = json.load(f)
+            try:
+                with open(path) as f:
+                    data = json.load(f)
+            except (json.JSONDecodeError, OSError) as e:
+                print(
+                    f"WARN: skipping {arch}/{title}: cannot read JSON ({e})",
+                    file=sys.stderr,
+                )
+                continue
             for r in data.get("results", []):
                 case = r.get("name")
                 med = r.get("median(elapsed)")

--- a/tests/microbenchmark/tools/summarize_regressions.py
+++ b/tests/microbenchmark/tools/summarize_regressions.py
@@ -19,9 +19,14 @@ script is complementary, not a replacement.
 
 import argparse
 import json
+import re
 import sys
 from collections import defaultdict
 from pathlib import Path
+
+# nanobench renders unset floating-point fields as bare `-nan`/`nan`, which
+# Python's json parser rejects (it only accepts the capitalized `NaN`).
+_NAN_RE = re.compile(r"-?\bnan\b")
 
 import yaml
 
@@ -48,9 +53,53 @@ def arch_label_from_artifact(name: str) -> str | None:
 # --- Data collection -------------------------------------------------------------
 
 
+def read_arch_results(json_dir: Path, arch_label: str = "(unknown)") -> dict:
+    """Read every `<title>.json` file directly inside `json_dir` and return
+    per-test/per-case throughputs for a single arch.
+
+    Returns: { test_title: { case_name: { "throughput": float, "unit": str } } }
+
+    `arch_label` is only used for diagnostic warnings. This is the per-arch
+    building block used both by the CI walker (`collect_current_results`) and
+    by `compare_to_baseline.py` for local runs.
+    """
+    per_arch: dict = defaultdict(dict)
+    for path in sorted(json_dir.glob("*.json")):
+        title = path.stem
+        if title == "machine_host_spec":
+            continue
+        try:
+            text = _NAN_RE.sub("NaN", path.read_text())
+            data = json.loads(text)
+        except (json.JSONDecodeError, OSError) as e:
+            print(
+                f"WARN: skipping {arch_label}/{title}: cannot read JSON ({e})",
+                file=sys.stderr,
+            )
+            continue
+        for r in data.get("results", []):
+            case = r.get("name")
+            med = r.get("median(elapsed)")
+            batch = r.get("batch")
+            unit = r.get("unit") or "byte"
+            if case is None or med is None or batch is None:
+                continue
+            if med == 0 or batch == 0:
+                print(
+                    f"WARN: skipping {arch_label}/{title}/{case}: med={med} batch={batch}",
+                    file=sys.stderr,
+                )
+                continue
+            per_arch[title][case] = {
+                "throughput": batch / med,
+                "unit": unit,
+            }
+    return per_arch
+
+
 def collect_current_results(current_dir: Path) -> dict:
-    """Walk `current_dir` looking for `benchmark-json-*` subdirs and harvest
-    per-case throughputs.
+    """Walk `current_dir` looking for `benchmark-json-*` subdirs (one per
+    arch) and harvest per-case throughputs.
 
     Returns: { arch_label: { test_title: { case_name: { "throughput": float, "unit": str } } } }
 
@@ -70,36 +119,7 @@ def collect_current_results(current_dir: Path) -> dict:
                 file=sys.stderr,
             )
             continue
-        for path in sorted(artifact_dir.glob("*.json")):
-            title = path.stem
-            if title == "machine_host_spec":
-                continue
-            try:
-                with open(path) as f:
-                    data = json.load(f)
-            except (json.JSONDecodeError, OSError) as e:
-                print(
-                    f"WARN: skipping {arch}/{title}: cannot read JSON ({e})",
-                    file=sys.stderr,
-                )
-                continue
-            for r in data.get("results", []):
-                case = r.get("name")
-                med = r.get("median(elapsed)")
-                batch = r.get("batch")
-                unit = r.get("unit") or "byte"
-                if case is None or med is None or batch is None:
-                    continue
-                if med == 0 or batch == 0:
-                    print(
-                        f"WARN: skipping {arch}/{title}/{case}: med={med} batch={batch}",
-                        file=sys.stderr,
-                    )
-                    continue
-                results[arch][title][case] = {
-                    "throughput": batch / med,
-                    "unit": unit,
-                }
+        results[arch] = read_arch_results(artifact_dir, arch)
     return results
 
 

--- a/tests/microbenchmark/tools/summarize_regressions.py
+++ b/tests/microbenchmark/tools/summarize_regressions.py
@@ -113,6 +113,20 @@ def classify(
 
 # --- Rendering -------------------------------------------------------------------
 
+# Hybrid emoji + ASCII labels. The Step Summary tab renders the emoji as a
+# colored glyph; the raw job log and `grep` still match the ASCII suffix. OK
+# stays plain — no need to call attention to passing cases.
+STATUS_DECORATION = {
+    "OK": "OK",
+    "UP": "🟢 UP",
+    "DOWN": "🟡 DOWN",
+    "CRIT": "🔴 CRIT",
+}
+
+
+def decorate_status(status: str) -> str:
+    return STATUS_DECORATION.get(status, status)
+
 
 def format_cell(counts: dict, total: int) -> str:
     """Build the coarse-table cell string from per-status counts."""
@@ -121,11 +135,11 @@ def format_cell(counts: dict, total: int) -> str:
         return f"OK ({total}/{total})"
     parts = []
     if crit:
-        parts.append(f"{crit} CRIT")
+        parts.append(f"{crit} {decorate_status('CRIT')}")
     if down:
-        parts.append(f"{down} DOWN")
+        parts.append(f"{down} {decorate_status('DOWN')}")
     if up:
-        parts.append(f"{up} UP")
+        parts.append(f"{up} {decorate_status('UP')}")
     return ", ".join(parts) + f" (of {total})"
 
 
@@ -149,7 +163,7 @@ def render_detail_subtable(title: str, rows: list) -> str:
         lines.append(
             f"| {case} | {format_throughput(cur, unit_arg)} | "
             f"{format_throughput(base, unit_arg)} | "
-            f"{dpct:+.2f}% | ±{tol:g}% | {status} |"
+            f"{dpct:+.2f}% | ±{tol:g}% | {decorate_status(status)} |"
         )
     if len(rows) > DETAIL_TRUNCATION_LIMIT:
         lines.append("")
@@ -335,7 +349,8 @@ def render_summary(current: dict, baselines: dict) -> tuple[str, list]:
         lines.append("|------|------|------|:-------|---:|----------:|")
         for title, case, arch, status, dpct, tol in gated_breaches:
             lines.append(
-                f"| {title} | {case} | {arch} | {status} | {dpct:+.2f}% | ±{tol:g}% |"
+                f"| {title} | {case} | {arch} | {decorate_status(status)} | "
+                f"{dpct:+.2f}% | ±{tol:g}% |"
             )
 
     return "\n".join(lines) + "\n", gated_breaches
@@ -395,7 +410,8 @@ def main() -> int:
         )
         for title, case, arch, status, dpct, tol in gated_breaches:
             print(
-                f"  - {title} :: {case} :: {arch}: {status} {dpct:+.2f}% (tol ±{tol:g}%)",
+                f"  - {title} :: {case} :: {arch}: {decorate_status(status)} "
+                f"{dpct:+.2f}% (tol ±{tol:g}%)",
                 file=sys.stderr,
             )
         return 1

--- a/tests/microbenchmark/tools/summarize_regressions.py
+++ b/tests/microbenchmark/tools/summarize_regressions.py
@@ -114,10 +114,8 @@ def classify(
 # --- Rendering -------------------------------------------------------------------
 
 
-def format_cell(counts: dict, total: int, missing: bool) -> str:
+def format_cell(counts: dict, total: int) -> str:
     """Build the coarse-table cell string from per-status counts."""
-    if missing:
-        return "— (no result)"
     crit, down, up = counts.get("CRIT", 0), counts.get("DOWN", 0), counts.get("UP", 0)
     if crit + down + up == 0:
         return f"OK ({total}/{total})"
@@ -216,8 +214,8 @@ def render_summary(current: dict, baselines: dict) -> tuple[str, list]:
     calibrated_from_runs = meta.get("calibrated_from_runs", "unknown")
 
     # Tests come from baselines (so a missing-from-baseline test is visible but
-    # never alerts). Sort: tests with breaches first, then alphabetical.
-    test_titles = sorted(k for k in baselines if k != "metadata")
+    # never alerts).
+    test_titles = [k for k in baselines if k != "metadata"]
     archs = set()
     for title in test_titles:
         for case_entry in baselines[title].values():
@@ -231,7 +229,6 @@ def render_summary(current: dict, baselines: dict) -> tuple[str, list]:
         for arch in arch_order:
             counts = {"OK": 0, "UP": 0, "DOWN": 0, "CRIT": 0}
             breached, stable = [], []
-            missing = False
 
             arch_results = current.get(arch, {}).get(title, {})
             # Tests in baselines.yaml define which cases we evaluate. A new case
@@ -303,7 +300,7 @@ def render_summary(current: dict, baselines: dict) -> tuple[str, list]:
                 row.append(f"— ({tag})")
             else:
                 total = sum(counts.values())
-                row.append(format_cell(counts, total, missing=False))
+                row.append(format_cell(counts, total))
         lines.append("| " + " | ".join(row) + " |")
 
     # Detail sections, in the same order as the coarse table.

--- a/tests/microbenchmark/tools/summarize_regressions.py
+++ b/tests/microbenchmark/tools/summarize_regressions.py
@@ -25,11 +25,6 @@ from pathlib import Path
 
 import yaml
 
-# Throughput formatting reused from analyze_results.py — single source of truth
-# for the "batch / median(elapsed)" → human string conversion.
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-from analyze_results import format_throughput  # noqa: E402
-
 # --- Arch label canonicalization -------------------------------------------------
 # Artifact names look like:
 #   benchmark-json-wormhole_b0-tt-ubuntu-2204-n150-viommu-stable-ubuntu-22.04
@@ -86,11 +81,18 @@ def collect_current_results(current_dir: Path) -> dict:
                 med = r.get("median(elapsed)")
                 batch = r.get("batch")
                 unit = r.get("unit") or "byte"
-                if med and batch and case is not None:
-                    results[arch][title][case] = {
-                        "throughput": batch / med,
-                        "unit": unit,
-                    }
+                if case is None or med is None or batch is None:
+                    continue
+                if med == 0 or batch == 0:
+                    print(
+                        f"WARN: skipping {arch}/{title}/{case}: med={med} batch={batch}",
+                        file=sys.stderr,
+                    )
+                    continue
+                results[arch][title][case] = {
+                    "throughput": batch / med,
+                    "unit": unit,
+                }
     return results
 
 
@@ -153,6 +155,11 @@ def render_detail_subtable(title: str, rows: list) -> str:
     `rows` is a list of (case_name, current_thr, baseline_thr, delta_pct,
     tolerance_pct, status, unit) tuples, presumed already sorted.
     """
+    # there is function import from sumarize_regressions.py → refresh_baselines.py so dont want unnecessary module imports
+    # in this case from analyze_results.py, that is the reason for this local import here
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from analyze_results import format_throughput
+
     lines = [f"**{title} ({len(rows)})**", ""]
     lines.append("| Case | Current | Baseline | Δ% | Tolerance | Status |")
     lines.append("|------|--------:|---------:|---:|----------:|:-------|")

--- a/tests/microbenchmark/tools/summarize_regressions.py
+++ b/tests/microbenchmark/tools/summarize_regressions.py
@@ -230,12 +230,17 @@ def render_detail_section(
     return "\n".join(lines)
 
 
-def render_summary(current: dict, baselines: dict) -> tuple[str, list]:
-    """Top-level renderer. Returns (markdown document, gated_breaches).
+def render_summary(current: dict, baselines: dict) -> tuple[str, list, list]:
+    """Top-level renderer. Returns (markdown document, gated_breaches, missing_gated).
 
     `gated_breaches` is a list of (title, case, arch, status, dpct, tol) for
     cases that breached tolerance AND carry `gate: true` in baselines.yaml —
     the caller exits non-zero when this list is non-empty.
+
+    `missing_gated` is a list of (title, case, arch) for gated cases present
+    in baselines.yaml but absent from this run's JSON (whole-arch missing or
+    per-case missing). Surfaced as a warning so a partial benchmark run can't
+    be confused with a clean one; does not fail the job.
     """
     meta = baselines.get("metadata") or {}
     calibrated_at = meta.get("calibrated_at", "unknown date")
@@ -253,6 +258,7 @@ def render_summary(current: dict, baselines: dict) -> tuple[str, list]:
     # Per-(test, arch): collect (counts, breached_rows, stable_rows).
     cell_state: dict = {}
     gated_breaches: list = []
+    missing_gated: list = []
     for title in test_titles:
         for arch in arch_order:
             counts = {"OK": 0, "UP": 0, "DOWN": 0, "CRIT": 0}
@@ -272,12 +278,15 @@ def render_summary(current: dict, baselines: dict) -> tuple[str, list]:
                 cell_state[(title, arch)] = (counts, breached, stable, "no baseline")
                 continue
             if not arch_results:
+                for case_name, baseline_entry in cases_with_baseline.items():
+                    if baseline_entry.get("gate") is True:
+                        missing_gated.append((title, case_name, arch))
                 cell_state[(title, arch)] = (counts, breached, stable, "no result")
                 continue
             for case_name, baseline_entry in cases_with_baseline.items():
                 if case_name not in arch_results:
-                    # Case is in baselines.yaml but missing from this run's JSON.
-                    # Treat as missing; counts toward "no result" if all missing.
+                    if baseline_entry.get("gate") is True:
+                        missing_gated.append((title, case_name, arch))
                     continue
                 current_entry = arch_results[case_name]
                 current_thr = current_entry["throughput"]
@@ -360,7 +369,27 @@ def render_summary(current: dict, baselines: dict) -> tuple[str, list]:
                 f"{dpct:+.2f}% | ±{tol:g}% |"
             )
 
-    return "\n".join(lines) + "\n", gated_breaches
+    if missing_gated:
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+        lines.append(
+            f"### Missing gated cases — not failing the job ({len(missing_gated)})"
+        )
+        lines.append("")
+        lines.append(
+            "_Cases below carry `gate: true` in baselines.yaml but produced no "
+            "result in this run. A partial benchmark run (e.g. binary crashed "
+            "mid-suite) will surface here; an intentional case rename/removal "
+            "will too, until the next baseline refresh._"
+        )
+        lines.append("")
+        lines.append("| Test | Case | Arch |")
+        lines.append("|------|------|------|")
+        for title, case, arch in missing_gated:
+            lines.append(f"| {title} | {case} | {arch} |")
+
+    return "\n".join(lines) + "\n", gated_breaches, missing_gated
 
 
 # --- Main ------------------------------------------------------------------------
@@ -412,9 +441,17 @@ def main() -> int:
         )
         return 1
 
-    summary, gated_breaches = render_summary(current, baselines)
+    summary, gated_breaches, missing_gated = render_summary(current, baselines)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(summary)
+    if missing_gated:
+        print(
+            f"WARN: {len(missing_gated)} gated case(s) missing from this run "
+            f"(see Missing gated cases section).",
+            file=sys.stderr,
+        )
+        for title, case, arch in missing_gated:
+            print(f"  - {title} :: {case} :: {arch}", file=sys.stderr)
     # Soft alerts (non-gated breaches) never fail; cases with `gate: true` in
     # baselines.yaml fail the job when they breach DOWN or CRIT.
     if gated_breaches:

--- a/tests/microbenchmark/tools/summarize_regressions.py
+++ b/tests/microbenchmark/tools/summarize_regressions.py
@@ -193,11 +193,18 @@ def render_detail_section(
         )
         lines.append(f"_Stable cases not shown: {names}._")
     else:
-        # Use the typical tolerance (median across stable cases) for the footer.
-        tols = sorted(r[4] for r in stable)
-        typical = tols[len(tols) // 2]
+        # Tolerances can vary widely within a single suite (e.g. 5% on a clean
+        # 1 MiB transfer vs 40% on a noisy 1-byte one), so quoting a single
+        # number would misrepresent most cases. Show the span instead.
+        tols = [r[4] for r in stable]
+        tol_min, tol_max = min(tols), max(tols)
+        span = (
+            f"±{tol_min:g}%"
+            if tol_min == tol_max
+            else f"±{tol_min:g}% to ±{tol_max:g}%"
+        )
         lines.append(
-            f"_Stable: {len(stable)} of {n_total} cases within ±{typical:g}%._"
+            f"_Stable: {len(stable)} of {n_total} cases within tolerance ({span} per-case)._"
         )
     return "\n".join(lines)
 

--- a/tests/microbenchmark/tools/summarize_regressions.py
+++ b/tests/microbenchmark/tools/summarize_regressions.py
@@ -214,8 +214,13 @@ def render_detail_section(
     return "\n".join(lines)
 
 
-def render_summary(current: dict, baselines: dict) -> str:
-    """Top-level renderer. Returns the full markdown document."""
+def render_summary(current: dict, baselines: dict) -> tuple[str, list]:
+    """Top-level renderer. Returns (markdown document, gated_breaches).
+
+    `gated_breaches` is a list of (title, case, arch, status, dpct, tol) for
+    cases that breached tolerance AND carry `gate: true` in baselines.yaml —
+    the caller exits non-zero when this list is non-empty.
+    """
     meta = baselines.get("metadata") or {}
     calibrated_at = meta.get("calibrated_at", "unknown date")
     calibrated_from_runs = meta.get("calibrated_from_runs", "unknown")
@@ -231,6 +236,7 @@ def render_summary(current: dict, baselines: dict) -> str:
 
     # Per-(test, arch): collect (counts, breached_rows, stable_rows).
     cell_state: dict = {}
+    gated_breaches: list = []
     for title in test_titles:
         for arch in arch_order:
             counts = {"OK": 0, "UP": 0, "DOWN": 0, "CRIT": 0}
@@ -278,6 +284,13 @@ def render_summary(current: dict, baselines: dict) -> str:
                     stable.append(row)
                 else:
                     breached.append(row)
+                    if baseline_entry.get("gate") is True and status in {
+                        "DOWN",
+                        "CRIT",
+                    }:
+                        gated_breaches.append(
+                            (title, case_name, arch, status, dpct, tolerance_pct)
+                        )
             tag = None if (counts["OK"] + len(breached)) > 0 else "no result"
             cell_state[(title, arch)] = (counts, breached, stable, tag)
 
@@ -318,7 +331,20 @@ def render_summary(current: dict, baselines: dict) -> str:
         lines.append("---")
         lines.extend(detail_chunks)
 
-    return "\n".join(lines) + "\n"
+    if gated_breaches:
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+        lines.append(f"### Gated breaches — failing the job ({len(gated_breaches)})")
+        lines.append("")
+        lines.append("| Test | Case | Arch | Status | Δ% | Tolerance |")
+        lines.append("|------|------|------|:-------|---:|----------:|")
+        for title, case, arch, status, dpct, tol in gated_breaches:
+            lines.append(
+                f"| {title} | {case} | {arch} | {status} | {dpct:+.2f}% | ±{tol:g}% |"
+            )
+
+    return "\n".join(lines) + "\n", gated_breaches
 
 
 # --- Main ------------------------------------------------------------------------
@@ -356,10 +382,22 @@ def main() -> int:
 
     current = collect_current_results(args.current)
 
-    summary = render_summary(current, baselines)
+    summary, gated_breaches = render_summary(current, baselines)
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(summary)
-    # Soft-alert pilot: always exit 0.
+    # Soft alerts (non-gated breaches) never fail; cases with `gate: true` in
+    # baselines.yaml fail the job when they breach DOWN or CRIT.
+    if gated_breaches:
+        print(
+            f"FAIL: {len(gated_breaches)} gated case(s) breached tolerance.",
+            file=sys.stderr,
+        )
+        for title, case, arch, status, dpct, tol in gated_breaches:
+            print(
+                f"  - {title} :: {case} :: {arch}: {status} {dpct:+.2f}% (tol ±{tol:g}%)",
+                file=sys.stderr,
+            )
+        return 1
     return 0
 
 

--- a/tests/microbenchmark/tools/summarize_regressions.py
+++ b/tests/microbenchmark/tools/summarize_regressions.py
@@ -369,19 +369,26 @@ def main() -> int:
     )
     args = p.parse_args()
 
-    if not args.current.is_dir():
-        sys.exit(f"--current is not a directory: {args.current}")
-    if not args.baselines.is_file():
-        sys.exit(f"--baselines is not a file: {args.baselines}")
+    try:
+        current_path = args.current.resolve(strict=True)
+        baselines_path = args.baselines.resolve(strict=True)
+    except FileNotFoundError as e:
+        sys.exit(f"input path does not exist: {e.filename}")
+    output_path = args.output.resolve()
 
-    with open(args.baselines) as f:
+    if not current_path.is_dir():
+        sys.exit(f"--current is not a directory: {current_path}")
+    if not baselines_path.is_file():
+        sys.exit(f"--baselines is not a file: {baselines_path}")
+
+    with open(baselines_path) as f:
         baselines = yaml.safe_load(f) or {}
 
-    current = collect_current_results(args.current)
+    current = collect_current_results(current_path)
 
     summary, gated_breaches = render_summary(current, baselines)
-    args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(summary)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(summary)
     # Soft alerts (non-gated breaches) never fail; cases with `gate: true` in
     # baselines.yaml fail the job when they breach DOWN or CRIT.
     if gated_breaches:

--- a/tests/microbenchmark/tools/summarize_regressions.py
+++ b/tests/microbenchmark/tools/summarize_regressions.py
@@ -13,9 +13,6 @@ case's throughput against a stored `median_throughput` from
   2. Per-(test, arch) detail sections for cells with at least one breach,
      listing only the breached cases.
 
-See the design plan for the rationale around counts-only cells, status codes,
-and detail-only-on-breach formatting.
-
 Sister workflow: `analyze_results.py` (per-arch drift-from-latest-main). This
 script is complementary, not a replacement.
 """

--- a/tests/microbenchmark/tools/summarize_regressions.py
+++ b/tests/microbenchmark/tools/summarize_regressions.py
@@ -405,6 +405,13 @@ def main() -> int:
 
     current = collect_current_results(current_path)
 
+    if not current:
+        print(
+            f"FAIL: no benchmark results collected from {current_path}.",
+            file=sys.stderr,
+        )
+        return 1
+
     summary, gated_breaches = render_summary(current, baselines)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(summary)

--- a/tests/microbenchmark/tools/summarize_regressions.py
+++ b/tests/microbenchmark/tools/summarize_regressions.py
@@ -1,0 +1,367 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-architecture regression summary against an in-repo baseline.
+
+Reads benchmark JSON artifacts produced by `run-benchmarks.yml` (one artifact
+directory per architecture, each containing nanobench JSONs) and compares each
+case's throughput against a stored `median_throughput` from
+`tests/microbenchmark/expected/baselines.yaml`. Emits markdown with:
+
+  1. A coarse cross-arch table (one row per test, one column per arch),
+     reporting only breach counts per severity tier — never an aggregated Δ%.
+  2. Per-(test, arch) detail sections for cells with at least one breach,
+     listing only the breached cases.
+
+See the design plan for the rationale around counts-only cells, status codes,
+and detail-only-on-breach formatting.
+
+Sister workflow: `analyze_results.py` (per-arch drift-from-latest-main). This
+script is complementary, not a replacement.
+"""
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import yaml
+
+# Throughput formatting reused from analyze_results.py — single source of truth
+# for the "batch / median(elapsed)" → human string conversion.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from analyze_results import format_throughput  # noqa: E402
+
+# --- Arch label canonicalization -------------------------------------------------
+# Artifact names look like:
+#   benchmark-json-wormhole_b0-tt-ubuntu-2204-n150-viommu-stable-ubuntu-22.04
+# We canonicalize to short labels matching the keys in baselines.yaml.
+# Substring match keeps this robust to minor variations (e.g. -iter1 suffixes).
+ARCH_PATTERNS = [
+    ("WH n150", ["n150"]),
+    ("WH n300", ["n300"]),
+    ("BH p150b", ["p150b"]),
+]
+
+
+def arch_label_from_artifact(name: str) -> str | None:
+    """Return canonical arch label (e.g. "WH n150") or None if unrecognized."""
+    for label, needles in ARCH_PATTERNS:
+        if all(n in name for n in needles):
+            return label
+    return None
+
+
+# --- Data collection -------------------------------------------------------------
+
+
+def collect_current_results(current_dir: Path) -> dict:
+    """Walk `current_dir` looking for `benchmark-json-*` subdirs and harvest
+    per-case throughputs.
+
+    Returns: { arch_label: { test_title: { case_name: { "throughput": float, "unit": str } } } }
+
+    Handles both layouts the C++ exporter may produce:
+      - flat:        <artifact>/<title>.json
+      - timestamped: <artifact>/<YYYY-MM-DDTHH-MM-SS>/<title>.json
+    If multiple timestamped subdirs exist (multi-iteration runs), the
+    lexicographically-latest one wins; this matches "most recent iteration".
+    """
+    results: dict = defaultdict(lambda: defaultdict(dict))
+    for artifact_dir in sorted(current_dir.iterdir()):
+        if not artifact_dir.is_dir():
+            continue
+        if not artifact_dir.name.startswith("benchmark-json-"):
+            continue
+        arch = arch_label_from_artifact(artifact_dir.name)
+        if arch is None:
+            print(
+                f"WARN: cannot derive arch label from artifact {artifact_dir.name}; skipping",
+                file=sys.stderr,
+            )
+            continue
+        # Latest-wins per title (handles timestamped subdirs).
+        by_title: dict[str, Path] = {}
+        for p in sorted(artifact_dir.rglob("*.json")):
+            title = p.stem
+            if title == "machine_host_spec":
+                continue
+            by_title[title] = p
+        for title, path in by_title.items():
+            with open(path) as f:
+                data = json.load(f)
+            for r in data.get("results", []):
+                case = r.get("name")
+                med = r.get("median(elapsed)")
+                batch = r.get("batch")
+                unit = r.get("unit") or "byte"
+                if med and batch and case is not None:
+                    results[arch][title][case] = {
+                        "throughput": batch / med,
+                        "unit": unit,
+                    }
+    return results
+
+
+# --- Classification --------------------------------------------------------------
+
+
+def classify(
+    current_thr: float, baseline_thr: float, tolerance_pct: float
+) -> tuple[str, float]:
+    """Return (status, signed Δ%). Δ% = (current − baseline) / baseline × 100."""
+    delta_pct = (current_thr - baseline_thr) / baseline_thr * 100.0
+    if abs(delta_pct) <= tolerance_pct:
+        return "OK", delta_pct
+    if delta_pct > tolerance_pct:
+        return "UP", delta_pct
+    if delta_pct < -2 * tolerance_pct:
+        return "CRIT", delta_pct
+    return "DOWN", delta_pct
+
+
+# --- Rendering -------------------------------------------------------------------
+
+
+def format_cell(counts: dict, total: int, missing: bool) -> str:
+    """Build the coarse-table cell string from per-status counts."""
+    if missing:
+        return "— (no result)"
+    crit, down, up = counts.get("CRIT", 0), counts.get("DOWN", 0), counts.get("UP", 0)
+    if crit + down + up == 0:
+        return f"OK ({total}/{total})"
+    parts = []
+    if crit:
+        parts.append(f"{crit} CRIT")
+    if down:
+        parts.append(f"{down} DOWN")
+    if up:
+        parts.append(f"{up} UP")
+    return ", ".join(parts) + f" (of {total})"
+
+
+# Width of the truncation for detail subtables — see plan §"Detail section rules".
+DETAIL_TRUNCATION_LIMIT = 10
+
+
+def render_detail_subtable(title: str, rows: list) -> str:
+    """Render a markdown table for one direction of breaches.
+
+    `rows` is a list of (case_name, current_thr, baseline_thr, delta_pct,
+    tolerance_pct, status, unit) tuples, presumed already sorted.
+    """
+    lines = [f"**{title} ({len(rows)})**", ""]
+    lines.append("| Case | Current | Baseline | Δ% | Tolerance | Status |")
+    lines.append("|------|--------:|---------:|---:|----------:|:-------|")
+    shown = rows[:DETAIL_TRUNCATION_LIMIT]
+    for case, cur, base, dpct, tol, status, unit in shown:
+        # format_throughput hides the "byte" pseudo-unit; pass through other units
+        unit_arg = None if unit == "byte" else unit
+        lines.append(
+            f"| {case} | {format_throughput(cur, unit_arg)} | "
+            f"{format_throughput(base, unit_arg)} | "
+            f"{dpct:+.2f}% | ±{tol:g}% | {status} |"
+        )
+    if len(rows) > DETAIL_TRUNCATION_LIMIT:
+        lines.append("")
+        lines.append(
+            f"… and {len(rows) - DETAIL_TRUNCATION_LIMIT} more cases beyond the threshold."
+        )
+    return "\n".join(lines)
+
+
+def render_detail_section(
+    test_title: str,
+    arch: str,
+    breached: list,
+    stable: list,
+) -> str:
+    """Render the full detail block for one breaching (test, arch) cell."""
+    n_breach = len(breached)
+    n_total = n_breach + len(stable)
+    lines = [
+        "",
+        f"### {test_title} on {arch} — {n_breach} of {n_total} cases outside tolerance",
+        "",
+    ]
+    slowdowns = [r for r in breached if r[3] < 0]
+    speedups = [r for r in breached if r[3] > 0]
+    slowdowns.sort(key=lambda r: r[3])  # most negative first
+    speedups.sort(key=lambda r: -r[3])  # most positive first
+    if slowdowns:
+        lines.append(render_detail_subtable("Slowdowns", slowdowns))
+        lines.append("")
+    if speedups:
+        lines.append(render_detail_subtable("Speedups", speedups))
+        lines.append("")
+    # Footer: list stable cases if there are few; otherwise summarize the count.
+    if not stable:
+        pass
+    elif len(stable) <= 3:
+        names = ", ".join(
+            f"{name} (Δ = {dpct:+.2f}%, within ±{tol:g}%)"
+            for name, _cur, _base, dpct, tol, _st, _unit in stable
+        )
+        lines.append(f"_Stable cases not shown: {names}._")
+    else:
+        # Use the typical tolerance (median across stable cases) for the footer.
+        tols = sorted(r[4] for r in stable)
+        typical = tols[len(tols) // 2]
+        lines.append(
+            f"_Stable: {len(stable)} of {n_total} cases within ±{typical:g}%._"
+        )
+    return "\n".join(lines)
+
+
+def render_summary(current: dict, baselines: dict) -> str:
+    """Top-level renderer. Returns the full markdown document."""
+    meta = baselines.get("metadata") or {}
+    calibrated_at = meta.get("calibrated_at", "unknown date")
+    calibrated_from_runs = meta.get("calibrated_from_runs", "unknown")
+
+    # Tests come from baselines (so a missing-from-baseline test is visible but
+    # never alerts). Sort: tests with breaches first, then alphabetical.
+    test_titles = sorted(k for k in baselines if k != "metadata")
+    archs = set()
+    for title in test_titles:
+        for case_entry in baselines[title].values():
+            archs.update(case_entry.keys())
+    arch_order = sorted(archs)
+
+    # Per-(test, arch): collect (counts, breached_rows, stable_rows).
+    cell_state: dict = {}
+    for title in test_titles:
+        for arch in arch_order:
+            counts = {"OK": 0, "UP": 0, "DOWN": 0, "CRIT": 0}
+            breached, stable = [], []
+            missing = False
+
+            arch_results = current.get(arch, {}).get(title, {})
+            # Tests in baselines.yaml define which cases we evaluate. A new case
+            # in CI that's not in baselines is informational and skipped here
+            # (added in next refresh). A baseline case missing from CI marks
+            # the cell as "no result".
+            cases_with_baseline = {
+                case_name: case_entry[arch]
+                for case_name, case_entry in baselines[title].items()
+                if arch in case_entry
+            }
+            if not cases_with_baseline:
+                cell_state[(title, arch)] = (counts, breached, stable, "no baseline")
+                continue
+            if not arch_results:
+                cell_state[(title, arch)] = (counts, breached, stable, "no result")
+                continue
+            for case_name, baseline_entry in cases_with_baseline.items():
+                if case_name not in arch_results:
+                    # Case is in baselines.yaml but missing from this run's JSON.
+                    # Treat as missing; counts toward "no result" if all missing.
+                    continue
+                current_entry = arch_results[case_name]
+                current_thr = current_entry["throughput"]
+                unit = current_entry["unit"]
+                baseline_thr = baseline_entry["median_throughput"]
+                tolerance_pct = baseline_entry["tolerance_pct"]
+                status, dpct = classify(current_thr, baseline_thr, tolerance_pct)
+                row = (
+                    case_name,
+                    current_thr,
+                    baseline_thr,
+                    dpct,
+                    tolerance_pct,
+                    status,
+                    unit,
+                )
+                counts[status] += 1
+                if status == "OK":
+                    stable.append(row)
+                else:
+                    breached.append(row)
+            tag = None if (counts["OK"] + len(breached)) > 0 else "no result"
+            cell_state[(title, arch)] = (counts, breached, stable, tag)
+
+    # Build coarse table.
+    header_cols = ["Test"] + arch_order
+    lines = [
+        "## UMD perf regression check vs in-repo baseline",
+        "",
+        f"_Baseline: median of last {calibrated_from_runs} successful main runs "
+        f"(calibrated {calibrated_at})._",
+        "",
+        "| " + " | ".join(header_cols) + " |",
+        "|" + "|".join(["---"] * len(header_cols)) + "|",
+    ]
+    for title in test_titles:
+        row = [title]
+        for arch in arch_order:
+            counts, breached, stable, tag = cell_state[(title, arch)]
+            if tag in {"no baseline", "no result"}:
+                row.append(f"— ({tag})")
+            else:
+                total = sum(counts.values())
+                row.append(format_cell(counts, total, missing=False))
+        lines.append("| " + " | ".join(row) + " |")
+
+    # Detail sections, in the same order as the coarse table.
+    detail_chunks = []
+    for title in test_titles:
+        for arch in arch_order:
+            counts, breached, stable, tag = cell_state[(title, arch)]
+            if breached:
+                detail_chunks.append(
+                    render_detail_section(title, arch, breached, stable)
+                )
+
+    if detail_chunks:
+        lines.append("")
+        lines.append("---")
+        lines.extend(detail_chunks)
+
+    return "\n".join(lines) + "\n"
+
+
+# --- Main ------------------------------------------------------------------------
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--current",
+        type=Path,
+        required=True,
+        help="Directory containing per-arch `benchmark-json-*` subdirs (this CI run).",
+    )
+    p.add_argument(
+        "--baselines",
+        type=Path,
+        required=True,
+        help="Path to in-repo baselines.yaml.",
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Output markdown file path.",
+    )
+    args = p.parse_args()
+
+    if not args.current.is_dir():
+        sys.exit(f"--current is not a directory: {args.current}")
+    if not args.baselines.is_file():
+        sys.exit(f"--baselines is not a file: {args.baselines}")
+
+    with open(args.baselines) as f:
+        baselines = yaml.safe_load(f) or {}
+
+    current = collect_current_results(args.current)
+
+    summary = render_summary(current, baselines)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(summary)
+    # Soft-alert pilot: always exit 0.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/microbenchmark/tools/summarize_regressions.py
+++ b/tests/microbenchmark/tools/summarize_regressions.py
@@ -115,8 +115,6 @@ def classify(
         return "OK", delta_pct
     if delta_pct > tolerance_pct:
         return "UP", delta_pct
-    if delta_pct < -2 * tolerance_pct:
-        return "CRIT", delta_pct
     return "DOWN", delta_pct
 
 
@@ -128,8 +126,7 @@ def classify(
 STATUS_DECORATION = {
     "OK": "OK",
     "UP": "🟢 UP",
-    "DOWN": "🟡 DOWN",
-    "CRIT": "🔴 CRIT",
+    "DOWN": "🔴 DOWN",
 }
 
 
@@ -139,12 +136,10 @@ def decorate_status(status: str) -> str:
 
 def format_cell(counts: dict, total: int) -> str:
     """Build the coarse-table cell string from per-status counts."""
-    crit, down, up = counts.get("CRIT", 0), counts.get("DOWN", 0), counts.get("UP", 0)
-    if crit + down + up == 0:
+    down, up = counts.get("DOWN", 0), counts.get("UP", 0)
+    if down + up == 0:
         return f"OK ({total}/{total})"
     parts = []
-    if crit:
-        parts.append(f"{crit} {decorate_status('CRIT')}")
     if down:
         parts.append(f"{down} {decorate_status('DOWN')}")
     if up:
@@ -268,7 +263,7 @@ def render_summary(current: dict, baselines: dict) -> tuple[str, list, list]:
     missing_gated: list = []
     for title in test_titles:
         for arch in arch_order:
-            counts = {"OK": 0, "UP": 0, "DOWN": 0, "CRIT": 0}
+            counts = {"OK": 0, "UP": 0, "DOWN": 0}
             breached, stable = [], []
 
             arch_results = current.get(arch, {}).get(title, {})
@@ -315,10 +310,7 @@ def render_summary(current: dict, baselines: dict) -> tuple[str, list, list]:
                     stable.append(row)
                 else:
                     breached.append(row)
-                    if baseline_entry.get("gate") is True and status in {
-                        "DOWN",
-                        "CRIT",
-                    }:
+                    if baseline_entry.get("gate") is True and status == "DOWN":
                         gated_breaches.append(
                             (title, case_name, arch, status, dpct, tolerance_pct)
                         )
@@ -460,7 +452,7 @@ def main() -> int:
         for title, case, arch in missing_gated:
             print(f"  - {title} :: {case} :: {arch}", file=sys.stderr)
     # Soft alerts (non-gated breaches) never fail; cases with `gate: true` in
-    # baselines.yaml fail the job when they breach DOWN or CRIT.
+    # baselines.yaml fail the job when they breach DOWN.
     if gated_breaches:
         print(
             f"FAIL: {len(gated_breaches)} gated case(s) breached tolerance.",


### PR DESCRIPTION
### Issue
#1533 

### Description
Adds a CI workflow that compares each benchmark run against an in-repo baseline (median + tolerance per case/arch) and surfaces regressions on the run page. Pilot is soft-alert by default; a per-entry gate: true flag escalates a case to a hard job failure when needed.

### List of the changes
 - New workflow regression-check.yml — compares each run against baselines.yaml, writes a summary to the run page, uploads a regression-summary artifact.
 - Wired into build-and-run-all-benchmarks.yml to run alongside analyze_results.yml.
 - New baselines.yaml — median throughput + tolerance per (test, case, arch). Pilot scope: ClusterConstructor and TLB_Tensix_Unicast_v_Multicast on n150 / n300 / p150b. Supports gate: true for hard gating.
 - New summarize_regressions.py — renders the cross-arch table and per-cell detail sections; exits non-zero on gated breaches.
 - New refresh_baselines.py — local tool that recalibrates baselines.yaml from the last N successful main runs. Per case: median_throughput = median(samples) and tolerance_pct = max(5, ceil(3 · stdev_pct)) (three-sigma rule with a 5% floor); existing gate: true flags are preserved.


### Testing
 - CI
 - Manual checks of data gathered by refresh_baselines.py
 - Reviewing compared data

### API Changes
There are no API changes in this PR.
