### PR TITLE
tests: add RISC reset mask coverage to test_risc_program (sim-only)

### DIFF
--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -960,3 +960,47 @@ TEST(TestDramMembar, StartDeviceDramMembarSubchannel) {
     // start_device is a no-op for mock chips, but this verifies the API compiles and is callable.
     EXPECT_NO_THROW(cluster.start_device({.init_device = true, .dram_membar_subchannel = 1}));
 }
+
+// Stress-size loopback: write/read increasing power-of-two payloads on a Tensix core
+// (up to 1 MB) and a DRAM core (up to 1 GB). Sim-only until silicon coverage is added;
+// the equivalent SimulationChip-level test still lives in tests/simulation/.
+TEST_F(TestDeviceIOFixture, LoopbackStressSize) {
+    if (!is_simulation()) {
+        GTEST_SKIP() << "LoopbackStressSize is currently sim-only.";
+    }
+
+    std::unique_ptr<Cluster> cluster = make_cluster();
+
+    constexpr uint64_t addr = 0x0;
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<uint32_t> dis(0, 100);
+
+    auto run_sweep = [&](ChipId chip_id, const CoreCoord& core, uint32_t max_shift) {
+        for (uint32_t shift = 2; shift <= max_shift; ++shift) {
+            const size_t size_bytes = size_t{1} << shift;
+            std::vector<uint32_t> wdata(size_bytes / sizeof(uint32_t));
+            for (auto& v : wdata) {
+                v = dis(gen);
+            }
+            std::vector<uint32_t> rdata(wdata.size(), 0);
+
+            cluster->write_to_device(wdata.data(), wdata.size() * sizeof(uint32_t), chip_id, core, addr);
+            cluster->read_from_device(rdata.data(), chip_id, core, addr, rdata.size() * sizeof(uint32_t));
+
+            ASSERT_EQ(wdata, rdata) << "Mismatch on core " << core.str() << " with size " << size_bytes;
+        }
+    };
+
+    for (auto chip_id : cluster->get_target_device_ids()) {
+        const SocDescriptor& soc_desc = cluster->get_soc_descriptor(chip_id);
+
+        const auto& tensix_cores = soc_desc.get_cores(CoreType::TENSIX);
+        ASSERT_FALSE(tensix_cores.empty());
+        run_sweep(chip_id, tensix_cores[0], 20);  // 2^20 = 1 MB
+
+        const auto& dram_cores = soc_desc.get_cores(CoreType::DRAM);
+        ASSERT_FALSE(dram_cores.empty());
+        run_sweep(chip_id, dram_cores[0], 30);  // 2^30 = 1 GB
+    }
+}

--- a/tests/api/test_risc_program.cpp
+++ b/tests/api/test_risc_program.cpp
@@ -316,15 +316,15 @@ TEST(TestRiscProgram, StartDeviceWithValidRiscProgram) {
     cluster->close_device();
 }
 
-// Exercises a variety of RiscType masks (ALL_TENSIX, ALL_NEO_DMS, custom DM bitmask)
-// through the Cluster API. Sim-only for now: silicon coverage for these masks would
-// require an arch-specific RISC program to validate liveness; this only confirms the
-// API accepts the masks without throwing. Originally lived in
-// tests/simulation/test_simulation_device.cpp (SimpleApiTest).
-TEST(TestRiscProgram, AssertDeassertRiscMasks) {
+// Mirrors SimpleApiTest from tests/simulation/test_simulation_device.cpp:
+// a basic write/read loopback on the first TENSIX core followed by assert/deassert
+// of a variety of RiscType masks (ALL_TENSIX, ALL_NEO_DMS, BRISC, custom DM bitmask).
+// Sim-only: silicon liveness validation would require an arch-specific RISC program;
+// this only confirms the API accepts the masks without throwing.
+TEST(TestRiscProgram, SimpleApiTest) {
     const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
     if (simulator_path == nullptr) {
-        GTEST_SKIP() << "AssertDeassertRiscMasks is currently sim-only.";
+        GTEST_SKIP() << "SimpleApiTest is currently sim-only.";
     }
 
     std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{
@@ -336,6 +336,13 @@ TEST(TestRiscProgram, AssertDeassertRiscMasks) {
     for (auto chip_id : cluster->get_target_device_ids()) {
         const SocDescriptor& soc_desc = cluster->get_soc_descriptor(chip_id);
         const CoreCoord core = soc_desc.get_cores(CoreType::TENSIX)[0];
+
+        std::vector<uint32_t> wdata = {1, 2, 3, 4, 5};
+        std::vector<uint32_t> rdata(wdata.size(), 0);
+
+        cluster->write_to_device(wdata.data(), wdata.size() * sizeof(uint32_t), chip_id, core, 0x100);
+        cluster->read_from_device(rdata.data(), chip_id, core, 0x100, rdata.size() * sizeof(uint32_t));
+        ASSERT_EQ(wdata, rdata);
 
         cluster->assert_risc_reset(chip_id, core, RiscType::ALL_TENSIX);
         cluster->assert_risc_reset(chip_id, core, RiscType::ALL_NEO_DMS);

--- a/tests/api/test_risc_program.cpp
+++ b/tests/api/test_risc_program.cpp
@@ -8,7 +8,9 @@
 
 #include <array>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <memory>
 #include <optional>
 #include <set>
@@ -312,4 +314,36 @@ TEST(TestRiscProgram, StartDeviceWithValidRiscProgram) {
     }
 
     cluster->close_device();
+}
+
+// Exercises a variety of RiscType masks (ALL_TENSIX, ALL_NEO_DMS, custom DM bitmask)
+// through the Cluster API. Sim-only for now: silicon coverage for these masks would
+// require an arch-specific RISC program to validate liveness; this only confirms the
+// API accepts the masks without throwing. Originally lived in
+// tests/simulation/test_simulation_device.cpp (SimpleApiTest).
+TEST(TestRiscProgram, AssertDeassertRiscMasks) {
+    const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
+    if (simulator_path == nullptr) {
+        GTEST_SKIP() << "AssertDeassertRiscMasks is currently sim-only.";
+    }
+
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{
+        .chip_type = ChipType::SIMULATION,
+        .target_devices = {0},
+        .simulator_directory = std::filesystem::path(simulator_path),
+    });
+
+    for (auto chip_id : cluster->get_target_device_ids()) {
+        const SocDescriptor& soc_desc = cluster->get_soc_descriptor(chip_id);
+        const CoreCoord core = soc_desc.get_cores(CoreType::TENSIX)[0];
+
+        cluster->assert_risc_reset(chip_id, core, RiscType::ALL_TENSIX);
+        cluster->assert_risc_reset(chip_id, core, RiscType::ALL_NEO_DMS);
+        cluster->deassert_risc_reset(chip_id, core, RiscType::BRISC, /*staggered_start=*/true);
+        cluster->deassert_risc_reset(chip_id, core, RiscType::ALL_NEO_DMS, /*staggered_start=*/true);
+
+        const RiscType example_dm_cores = RiscType::DM0 | RiscType::DM1 | RiscType::DM7;
+        cluster->assert_risc_reset(chip_id, core, example_dm_cores);
+        cluster->deassert_risc_reset(chip_id, core, example_dm_cores, /*staggered_start=*/true);
+    }
 }


### PR DESCRIPTION
### Issue
N/A — coverage migration from `tests/simulation/`.

### Description
Mirrors `SimpleApiTest` from `tests/simulation/test_simulation_device.cpp`
through the `Cluster` API: a write/read loopback on the first TENSIX core
followed by `assert_risc_reset` / `deassert_risc_reset` with a variety of
`RiscType` masks (`ALL_TENSIX`, `ALL_NEO_DMS`, `BRISC`, and a custom
`DM0|DM1|DM7` bitmask).

Sim-only via `GTEST_SKIP()` when `TT_UMD_SIMULATOR` is unset — the test
only verifies that the API accepts the masks without throwing; silicon
liveness validation would need an arch-specific RISC program, which is out
of scope here.

`tests/simulation/test_simulation_device.cpp` is **not deleted** — the
tt-umd-simulators consumer still depends on it for the SimulationChip-level
test target.

### List of the changes
- `tests/api/test_risc_program.cpp`: add `TEST(TestRiscProgram, SimpleApiTest)` plus `<cstdlib>` / `<filesystem>` includes for the env-var check and simulator path.

### Testing
- `cmake --build build --target api_tests` passes.
- `pre-commit run --files tests/api/test_risc_program.cpp` passes.

### API Changes
None.

---

Stacked on top of #2618. Targets `pjanevski/loopback-stress-size-api`.