### PR TITLE
Warm reset with remote IO failure recovery

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -120,6 +120,7 @@ target_sources(
         arc/spi_tt_device.cpp
         noc_access.cpp
         warm_reset.cpp
+        warm_reset_with_recovery.cpp
         types/xy_pair.cpp
         utils/lock_manager.cpp
         utils/robust_mutex.cpp
@@ -211,6 +212,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/pcie/rtl_sim_tlb_window.hpp
                 api/umd/device/pcie/rtl_sim_tlb_handle.hpp
                 api/umd/device/warm_reset.hpp
+                api/umd/device/warm_reset_with_recovery.hpp
                 api/umd/device/utils/semver.hpp
                 api/umd/device/utils/robust_mutex.hpp
                 api/umd/device/cluster_descriptor.hpp

--- a/device/api/umd/device/warm_reset_with_recovery.hpp
+++ b/device/api/umd/device/warm_reset_with_recovery.hpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include "umd/device/utils/timeouts.hpp"
+
+namespace tt::umd {
+
+// Wraps WarmReset entry points with a follow-up TopologyDiscovery::discover() and retries
+// the whole sequence if discovery fails. This works around transient post-reset states
+// (e.g. an ETH core that never recovers its heartbeat) which can leave the board in a
+// state that only another reset can clear.
+//
+// Each method returns true if a (reset, discovery) attempt eventually succeeds, false
+// otherwise. If the underlying warm reset itself fails, the methods bail immediately
+// without retrying because such failures (no devices, ARM platform) do not recover by
+// retrying.
+class WarmResetWithRecovery {
+public:
+    static bool warm_reset(
+        int max_attempts = 3,
+        bool reset_m3 = false,
+        bool secondary_bus_reset = true,
+        std::chrono::milliseconds m3_delay = timeout::WARM_RESET_M3_TIMEOUT);
+
+    static bool warm_reset_chip_id(
+        const std::vector<int>& chip_ids = {},
+        int max_attempts = 3,
+        bool reset_m3 = false,
+        bool secondary_bus_reset = true,
+        std::chrono::milliseconds m3_delay = timeout::WARM_RESET_M3_TIMEOUT);
+
+    static bool warm_reset_pci_bdfs(
+        const std::vector<std::string>& pci_bdfs = {},
+        int max_attempts = 3,
+        bool reset_m3 = false,
+        bool secondary_bus_reset = true,
+        std::chrono::milliseconds m3_delay = timeout::WARM_RESET_M3_TIMEOUT);
+
+    static bool ubb_warm_reset(
+        int max_attempts = 3, std::chrono::milliseconds timeout_ms = timeout::UBB_WARM_RESET_TIMEOUT);
+};
+
+}  // namespace tt::umd

--- a/device/warm_reset_with_recovery.cpp
+++ b/device/warm_reset_with_recovery.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/umd/device/warm_reset_with_recovery.hpp"
+
+#include <algorithm>
+#include <exception>
+#include <functional>
+#include <tt-logger/tt-logger.hpp>
+
+#include "umd/device/topology/topology_discovery.hpp"
+#include "umd/device/warm_reset.hpp"
+
+namespace tt::umd {
+
+namespace {
+
+bool reset_then_discover(int max_attempts, const std::function<bool()>& do_reset) {
+    max_attempts = std::max(max_attempts, 1);
+
+    for (int attempt = 1; attempt <= max_attempts; ++attempt) {
+        log_info(tt::LogUMD, "Warm reset attempt {} of {}.", attempt, max_attempts);
+
+        if (!do_reset()) {
+            log_error(tt::LogUMD, "Warm reset failed on attempt {} of {}.", attempt, max_attempts);
+            return false;
+        }
+
+        try {
+            TopologyDiscovery::discover({});
+            log_info(tt::LogUMD, "Topology discovery succeeded on attempt {}.", attempt);
+            return true;
+        } catch (const std::exception& e) {
+            log_warning(
+                tt::LogUMD, "Topology discovery failed on attempt {} of {}: {}", attempt, max_attempts, e.what());
+        }
+    }
+
+    log_error(tt::LogUMD, "Warm reset with recovery exhausted all {} attempts.", max_attempts);
+    return false;
+}
+
+}  // namespace
+
+bool WarmResetWithRecovery::warm_reset(
+    int max_attempts, bool reset_m3, bool secondary_bus_reset, std::chrono::milliseconds m3_delay) {
+    return reset_then_discover(
+        max_attempts, [&]() { return WarmReset::warm_reset({}, reset_m3, secondary_bus_reset, m3_delay); });
+}
+
+bool WarmResetWithRecovery::warm_reset_chip_id(
+    const std::vector<int>& chip_ids,
+    int max_attempts,
+    bool reset_m3,
+    bool secondary_bus_reset,
+    std::chrono::milliseconds m3_delay) {
+    return reset_then_discover(max_attempts, [&]() {
+        return WarmReset::warm_reset_chip_id(chip_ids, reset_m3, secondary_bus_reset, m3_delay);
+    });
+}
+
+bool WarmResetWithRecovery::warm_reset_pci_bdfs(
+    const std::vector<std::string>& pci_bdfs,
+    int max_attempts,
+    bool reset_m3,
+    bool secondary_bus_reset,
+    std::chrono::milliseconds m3_delay) {
+    return reset_then_discover(max_attempts, [&]() {
+        return WarmReset::warm_reset_pci_bdfs(pci_bdfs, reset_m3, secondary_bus_reset, m3_delay);
+    });
+}
+
+bool WarmResetWithRecovery::ubb_warm_reset(int max_attempts, std::chrono::milliseconds timeout_ms) {
+    return reset_then_discover(max_attempts, [&]() { return WarmReset::ubb_warm_reset(timeout_ms); });
+}
+
+}  // namespace tt::umd

--- a/nanobind/py_api_warm_reset.cpp
+++ b/nanobind/py_api_warm_reset.cpp
@@ -8,6 +8,7 @@
 #include <nanobind/stl/vector.h>
 
 #include "umd/device/warm_reset.hpp"
+#include "umd/device/warm_reset_with_recovery.hpp"
 
 namespace nb = nanobind;
 // Releases Python's Global Interpreter Lock (GIL) for the duration of the C++ call,
@@ -61,4 +62,26 @@ void bind_warm_reset(nb::module_ &m) {
             nb::arg("timeout_s") = 100.0,
             release_gil(),
             "Perform a UBB warm reset with specified timeout in seconds.");
+
+    // WarmResetWithRecovery class binding. Each method runs WarmReset followed by a
+    // TopologyDiscovery::discover(); if discovery fails, another warm reset is performed
+    // and the sequence is retried up to max_attempts times.
+    nb::class_<WarmResetWithRecovery>(m, "WarmResetWithRecovery")
+        .def_static(
+            "warm_reset",
+            &WarmResetWithRecovery::warm_reset,
+            nb::arg("max_attempts") = 3,
+            nb::arg("reset_m3") = false,
+            nb::arg("secondary_bus_reset") = true,
+            nb::arg("m3_delay_s") = 20.0,
+            release_gil(),
+            "Perform a warm reset on all enumerated devices and verify with topology discovery. "
+            "Retries the (reset, discovery) sequence up to max_attempts times if discovery fails.")
+        .def_static(
+            "ubb_warm_reset",
+            &WarmResetWithRecovery::ubb_warm_reset,
+            nb::arg("max_attempts") = 3,
+            nb::arg("timeout_s") = 100.0,
+            release_gil(),
+            "Perform a UBB warm reset and verify with topology discovery. Retries on discovery failure.");
 }

--- a/nanobind/tests/test_py_no_eth_map_reset.py
+++ b/nanobind/tests/test_py_no_eth_map_reset.py
@@ -66,15 +66,15 @@ class TestNoEthMapReset(unittest.TestCase):
 
         # Perform appropriate warm reset
         if is_wormhole_ubb and not kmd_supports_reset:
-            print("Executing UBB warm reset...")
-            tt_umd.WarmReset.ubb_warm_reset()
+            print("Executing UBB warm reset with recovery...")
+            tt_umd.WarmResetWithRecovery.ubb_warm_reset()
         else:
             should_perform_secondary_bus_reset = not is_wormhole_ubb
             print(
-                f"Executing standard warm reset, with secondary bus reset: {should_perform_secondary_bus_reset}"
+                f"Executing standard warm reset with recovery, with secondary bus reset: {should_perform_secondary_bus_reset}"
             )
-            tt_umd.WarmReset.warm_reset(
-                pci_ids, secondary_bus_reset=should_perform_secondary_bus_reset
+            tt_umd.WarmResetWithRecovery.warm_reset(
+                secondary_bus_reset=should_perform_secondary_bus_reset
             )
 
         reset_time = time.time() - reset_start

--- a/nanobind/tests/test_py_warm_reset.py
+++ b/nanobind/tests/test_py_warm_reset.py
@@ -40,15 +40,15 @@ class TestWarmReset(unittest.TestCase):
 
         # In case KMD still doesn't support arch agnostic reset, and in case of UBB, we have to call special UBB warm reset
         if is_wormhole_ubb and not kmd_supports_reset:
-            print("Executing UBB warm reset...")
-            tt_umd.WarmReset.ubb_warm_reset()
+            print("Executing UBB warm reset with recovery...")
+            tt_umd.WarmResetWithRecovery.ubb_warm_reset()
         else:
             should_perform_secondary_bus_reset = not is_wormhole_ubb
             print(
-                f"Executing standard warm reset, with secondary bus reset: {should_perform_secondary_bus_reset}"
+                f"Executing standard warm reset with recovery, with secondary bus reset: {should_perform_secondary_bus_reset}"
             )
-            tt_umd.WarmReset.warm_reset(
-                pci_ids, secondary_bus_reset=should_perform_secondary_bus_reset
+            tt_umd.WarmResetWithRecovery.warm_reset(
+                secondary_bus_reset=should_perform_secondary_bus_reset
             )
 
         # Verify that the device is back online

--- a/tests/api/test_hang_detection.cpp
+++ b/tests/api/test_hang_detection.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "device/api/umd/device/warm_reset.hpp"
+#include "device/api/umd/device/warm_reset_with_recovery.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/cluster.hpp"
@@ -75,7 +76,7 @@ protected:
         int pci_device_id = tt_device_->get_pci_device()->get_device_num();
         tt_device_.reset();
         soc_desc_.reset();
-        WarmReset::warm_reset();
+        WarmResetWithRecovery::warm_reset();
 
         auto cluster = std::make_unique<Cluster>();
         EXPECT_FALSE(cluster->get_target_device_ids().empty()) << "No chips present after warm reset.";

--- a/tests/api/test_warm_reset.cpp
+++ b/tests/api/test_warm_reset.cpp
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "device/api/umd/device/warm_reset.hpp"
+#include "device/api/umd/device/warm_reset_with_recovery.hpp"
 #include "tests/test_utils/pipe_communication.hpp"
 #include "tests/test_utils/test_api_common.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
@@ -114,7 +115,7 @@ TEST(WarmResetTest, DISABLED_TTDeviceWarmResetAfterNocHang) {
         EXPECT_THROW(tt_device->is_pcie_hung(), std::runtime_error);
     }
 
-    WarmReset::warm_reset();
+    WarmResetWithRecovery::warm_reset();
 
     // After a warm reset, topology discovery must be performed to detect available chips.
     // Creating a Cluster triggers this discovery process, which is why a Cluster is instantiated here,
@@ -190,7 +191,7 @@ TEST_P(WarmResetParamTest, DISABLED_SafeApiHandlesReset) {
 
     std::thread background_reset_thread([&]() {
         std::this_thread::sleep_for(std::chrono::microseconds(delay_us));
-        WarmReset::warm_reset();
+        WarmResetWithRecovery::warm_reset();
     });
 
     auto start_time = std::chrono::steady_clock::now();
@@ -283,7 +284,7 @@ TEST(WarmResetTest, DISABLED_SafeApiMultiThreaded) {
 
     // Trigger the reset after a small delay.
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    WarmReset::warm_reset();
+    WarmResetWithRecovery::warm_reset();
 
     t1.join();
     t2.join();
@@ -345,7 +346,7 @@ TEST(WarmResetTest, DISABLED_SafeApiMultiProcess) {
 
     // Parent triggers the reset that affects ALL windows on that PCIe link.
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    WarmReset::warm_reset();
+    WarmResetWithRecovery::warm_reset();
 
     for (pid_t p : pids) {
         int status;
@@ -381,7 +382,7 @@ TEST(WarmResetTest, GalaxyWarmResetScratch) {
             write_test_data);
     }
 
-    WarmReset::ubb_warm_reset();
+    WarmResetWithRecovery::ubb_warm_reset();
 
     cluster.reset();
 
@@ -430,7 +431,7 @@ TEST(WarmResetTest, ClusterWarmReset) {
         EXPECT_THROW(hanged_tt_device->is_pcie_hung(), std::runtime_error);
     }
 
-    WarmReset::warm_reset();
+    WarmResetWithRecovery::warm_reset();
 
     cluster.reset();
 
@@ -493,7 +494,7 @@ TEST_P(ClusterWarmResetScratchMethodTest, ClusterWarmResetScratch) {
 
     switch (GetParam()) {
         case WarmResetMethod::PCI_DEVICE_IDS:
-            WarmReset::warm_reset();
+            WarmResetWithRecovery::warm_reset();
             break;
         case WarmResetMethod::CHIP_IDS: {
             std::vector<int> chip_ids;
@@ -501,7 +502,7 @@ TEST_P(ClusterWarmResetScratchMethodTest, ClusterWarmResetScratch) {
             for (auto& id : cluster->get_target_mmio_device_ids()) {
                 chip_ids.push_back(id);
             }
-            WarmReset::warm_reset_chip_id(chip_ids);
+            WarmResetWithRecovery::warm_reset_chip_id(chip_ids);
             break;
         }
         case WarmResetMethod::PCI_BDFS: {
@@ -511,7 +512,7 @@ TEST_P(ClusterWarmResetScratchMethodTest, ClusterWarmResetScratch) {
             for (const auto& [id, info] : pci_device_info) {
                 pci_bdfs.push_back(info.pci_bdf);
             }
-            WarmReset::warm_reset_pci_bdfs(pci_bdfs);
+            WarmResetWithRecovery::warm_reset_pci_bdfs(pci_bdfs);
             break;
         }
     }

--- a/tools/warm_reset.cpp
+++ b/tools/warm_reset.cpp
@@ -19,7 +19,7 @@ int main(int argc, char* argv[]) {
         "warm_reset", "Perform warm reset on Tenstorrent devices. For reseting 6U, apply the --6u flag.");
 
     options.add_options()("6u", "Perform 6U warm reset.", cxxopts::value<bool>()->default_value("false"))(
-        "retry",
+        "max-attempts",
         "Maximum number of warm-reset + topology-discovery attempts. If discovery fails after "
         "a reset, another reset is performed. Default is 1 (no retry).",
         cxxopts::value<int>()->default_value("1"))("h,help", "Print usage");
@@ -33,7 +33,7 @@ int main(int argc, char* argv[]) {
 
     try {
         const bool is_6u_reset = result["6u"].as<bool>();
-        const int max_attempts = result["retry"].as<int>();
+        const int max_attempts = result["max-attempts"].as<int>();
 
         log_info(
             tt::LogUMD,

--- a/tools/warm_reset.cpp
+++ b/tools/warm_reset.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "umd/device/warm_reset.hpp"
-
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
@@ -11,10 +9,8 @@
 #include <exception>
 #include <iostream>
 #include <tt-logger/tt-logger.hpp>
-#include <vector>
 
-#include "common.hpp"
-#include "umd/device/topology/topology_discovery.hpp"
+#include "umd/device/warm_reset_with_recovery.hpp"
 
 using namespace tt::umd;
 
@@ -23,7 +19,10 @@ int main(int argc, char* argv[]) {
         "warm_reset", "Perform warm reset on Tenstorrent devices. For reseting 6U, apply the --6u flag.");
 
     options.add_options()("6u", "Perform 6U warm reset.", cxxopts::value<bool>()->default_value("false"))(
-        "h,help", "Print usage");
+        "retry",
+        "Maximum number of warm-reset + topology-discovery attempts. If discovery fails after "
+        "a reset, another reset is performed. Default is 1 (no retry).",
+        cxxopts::value<int>()->default_value("1"))("h,help", "Print usage");
 
     auto result = options.parse(argc, argv);
 
@@ -32,26 +31,25 @@ int main(int argc, char* argv[]) {
         return 0;
     }
 
-    bool reset_result = false;
-
     try {
         const bool is_6u_reset = result["6u"].as<bool>();
-        if (is_6u_reset) {
-            log_info(tt::LogUMD, "Performing 6U warm reset...");
-            reset_result = WarmReset::ubb_warm_reset();
-        } else {
-            log_info(tt::LogUMD, "Performing warm reset on all available devices...");
-            reset_result = WarmReset::warm_reset();
-        }
+        const int max_attempts = result["retry"].as<int>();
 
-        if (reset_result) {
-            log_info(tt::LogUMD, "Warm reset completed successfully. Running Topology discovery...");
-        } else {
-            log_error(tt::LogUMD, "Warm reset failed. Exiting.");
+        log_info(
+            tt::LogUMD,
+            "Performing {} warm reset with up to {} attempt(s)...",
+            is_6u_reset ? "6U" : "standard",
+            max_attempts);
+
+        const bool ok = is_6u_reset ? WarmResetWithRecovery::ubb_warm_reset(max_attempts)
+                                    : WarmResetWithRecovery::warm_reset(max_attempts);
+
+        if (!ok) {
+            log_error(tt::LogUMD, "Warm reset failed after {} attempt(s). Exiting.", max_attempts);
             return 1;
         }
-        TopologyDiscovery::discover({});
-        log_info(tt::LogUMD, "Topology discovery completed successfully.");
+
+        log_info(tt::LogUMD, "Warm reset and topology discovery completed successfully.");
     } catch (const std::exception& e) {
         log_error(tt::LogUMD, "Error during warm reset: {}", e.what());
         return 1;


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2599

### Description
Related to long standing issue that we know of, where erisc can be stuck after warm reset. This should fix our ci runs.

### List of the changes
- Implement WarmReset with recovery, which will run warm reset a couple of times
- Expose in nanobind
- Make all our CI tests use this new class to avoid CI issues
- Adapt the warm_reset tool to have the option to use this

### Testing
This is a test of 100 iterations of warm reset, hopefully shows up that this class does fix some issues: https://github.com/tenstorrent/tt-umd/actions/runs/25800112547
Note: For some reason, it seems exceptionally hard to repro that issue at the moment. I made a test case locally which returned heartbeat stuck on first try of topo discovery only. Confirmed locally that the attempt 2 was called inside python test. I expect it to work on our CI as well.

### API Changes
This PR has API changes:, introduces a new warm reset class
