### PR TITLE
Temporarily default ~RtlSimTlbHandle to avoid use-after-free at teardown

### DIFF
--- a/device/api/umd/device/pcie/rtl_sim_tlb_handle.hpp
+++ b/device/api/umd/device/pcie/rtl_sim_tlb_handle.hpp
@@ -27,7 +27,12 @@ public:
     static std::unique_ptr<RtlSimTlbHandle> create(
         SimulationTlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping);
 
-    ~RtlSimTlbHandle() noexcept;
+    // TODO: Restore the `free_tlb()` call here once the Metal teardown order is fixed.
+    // Currently, Metal's destruction order can destroy the SimulationTlbAllocator before the
+    // RtlSimTlbHandles that reference it, so calling free_tlb() from this destructor would
+    // dereference an already-destroyed allocator. Defaulting the destructor is a temporary
+    // workaround until Metal's shutdown sequence is corrected.
+    ~RtlSimTlbHandle() noexcept override = default;
 
     void configure(const tlb_data& new_config) override;
 

--- a/device/pcie/rtl_sim_tlb_handle.cpp
+++ b/device/pcie/rtl_sim_tlb_handle.cpp
@@ -44,8 +44,6 @@ std::unique_ptr<RtlSimTlbHandle> RtlSimTlbHandle::create(
     return std::unique_ptr<RtlSimTlbHandle>(new RtlSimTlbHandle(allocator, tlb_id, size, mapping));
 }
 
-RtlSimTlbHandle::~RtlSimTlbHandle() noexcept { RtlSimTlbHandle::free_tlb(); }
-
 void RtlSimTlbHandle::configure(const tlb_data& new_config) {
     tlb_config_ = new_config;
     tlb_config_.local_offset = new_config.local_offset / tlb_size_;


### PR DESCRIPTION
### Issue
Tracking issue: #2625

### Description
`~RtlSimTlbHandle` calls `free_tlb()`, which dereferences the `SimulationTlbAllocator*` member. In tt-metal teardown paths the `SimulationTlbAllocator` can be destroyed before the outstanding `RtlSimTlbHandle` instances, so the destructor ends up calling into an already-destroyed allocator (use-after-free).

This PR is a temporary workaround: default the destructor and leave a TODO explaining why. The cleanup call should be restored once Metal's shutdown sequence is corrected.

The equivalent TTSim handle (`TTSimTlbHandle`) currently uses `= default` for its destructor and has the same risk; that path is tracked in the same follow-up issue (#2625).

### List of the changes
- `device/api/umd/device/pcie/rtl_sim_tlb_handle.hpp`: change `~RtlSimTlbHandle()` to `noexcept override = default` with a TODO comment explaining the workaround.
- `device/pcie/rtl_sim_tlb_handle.cpp`: remove the out-of-line destructor definition (now defaulted in the header).

### Testing
- `cmake --build build` clean.
- `pre-commit run --all-files` clean.

### API Changes
There are no API changes in this PR.