### PR TITLE
Share SimulationTlbAllocator via shared_ptr with sim TLB handles

### DIFF
--- a/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp
@@ -29,7 +29,7 @@ class architecture_implementation;
  * that creates the appropriate TlbHandle + TlbWindow combination.
  */
 using TlbWindowFactory = std::function<std::unique_ptr<TlbWindow>(
-    SimulationTlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping, tlb_data config)>;
+    std::shared_ptr<SimulationTlbAllocator> allocator, int tlb_id, size_t size, TlbMapping mapping, tlb_data config)>;
 
 class SimulationTlbManager : public TLBManager {
 public:
@@ -51,10 +51,13 @@ public:
      */
     std::unique_ptr<TlbWindow> allocate_default_tlb_window();
 
-    SimulationTlbAllocator& get_allocator() { return allocator_; }
+    SimulationTlbAllocator& get_allocator() { return *allocator_; }
 
 private:
-    SimulationTlbAllocator allocator_;
+    // Held as shared_ptr so TlbHandles can co-own the allocator and outlive the
+    // manager — required because Metal's destruction order can destroy the
+    // manager before the handles that still reference its allocator.
+    std::shared_ptr<SimulationTlbAllocator> allocator_;
     TlbWindowFactory factory_;
 
     // Monotonic TLB id handed out for architectures that bypass the allocator

--- a/device/api/umd/device/pcie/rtl_sim_tlb_handle.hpp
+++ b/device/api/umd/device/pcie/rtl_sim_tlb_handle.hpp
@@ -25,22 +25,22 @@ enum TlbMapping : uint8_t;
 class RtlSimTlbHandle : public TlbHandle {
 public:
     static std::unique_ptr<RtlSimTlbHandle> create(
-        SimulationTlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping);
+        std::shared_ptr<SimulationTlbAllocator> allocator, int tlb_id, size_t size, TlbMapping mapping);
 
-    ~RtlSimTlbHandle() noexcept;
+    ~RtlSimTlbHandle() noexcept override;
 
     void configure(const tlb_data& new_config) override;
 
-    SimulationTlbAllocator* get_tlb_allocator() const { return allocator_; }
+    SimulationTlbAllocator* get_tlb_allocator() const { return allocator_.get(); }
 
     tt::ARCH get_arch() const override;
 
 private:
-    RtlSimTlbHandle(SimulationTlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping);
+    RtlSimTlbHandle(std::shared_ptr<SimulationTlbAllocator> allocator, int tlb_id, size_t size, TlbMapping mapping);
 
     void free_tlb() noexcept override;
 
-    SimulationTlbAllocator* allocator_;
+    std::shared_ptr<SimulationTlbAllocator> allocator_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/pcie/tt_sim_tlb_handle.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_handle.hpp
@@ -28,24 +28,24 @@ public:
      * This bypasses the hardware constructor and sets up simulation state.
      */
     static std::unique_ptr<TTSimTlbHandle> create(
-        SimulationTlbAllocator* allocator,
+        std::shared_ptr<SimulationTlbAllocator> allocator,
         class TTSimCommunicator* communicator,
         int tlb_id,
         size_t size,
         const TlbMapping tlb_mapping);
 
-    ~TTSimTlbHandle() noexcept override = default;
+    ~TTSimTlbHandle() noexcept override;
 
     void configure(const tlb_data& new_config) override;
 
-    SimulationTlbAllocator* get_tlb_allocator() const { return allocator_; }
+    SimulationTlbAllocator* get_tlb_allocator() const { return allocator_.get(); }
 
     tt::ARCH get_arch() const override;
 
 private:
     // Private constructor to enforce use of create() factory method.
     TTSimTlbHandle(
-        SimulationTlbAllocator* allocator,
+        std::shared_ptr<SimulationTlbAllocator> allocator,
         class TTSimCommunicator* communicator,
         int tlb_id,
         size_t size,
@@ -53,7 +53,7 @@ private:
 
     void free_tlb() noexcept override;
 
-    SimulationTlbAllocator* allocator_;
+    std::shared_ptr<SimulationTlbAllocator> allocator_;
     class TTSimCommunicator* sim_communicator_;
     uint64_t tlb_reg_addr_ = 0;
 };

--- a/device/chip_helpers/simulation_tlb_manager.cpp
+++ b/device/chip_helpers/simulation_tlb_manager.cpp
@@ -21,7 +21,9 @@ SimulationTlbManager::SimulationTlbManager(
     const architecture_implementation* arch_impl,
     TlbWindowFactory factory,
     uint64_t bar4_base) :
-    TLBManager(tt_device), allocator_(bar0_base, arch_impl, bar4_base), factory_(std::move(factory)) {}
+    TLBManager(tt_device),
+    allocator_(std::make_shared<SimulationTlbAllocator>(bar0_base, arch_impl, bar4_base)),
+    factory_(std::move(factory)) {}
 
 std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_tlb_window(
     tlb_data config, const TlbMapping mapping, const size_t tlb_size) {
@@ -32,25 +34,25 @@ std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_tlb_window(
     // window doesn't need a real index, address, or size — but the tlb id still
     // has to be unique per allocation so TLBManager bookkeeping (keyed by
     // get_tlb_id) doesn't collide.
-    if (allocator_.get_architecture() == tt::ARCH::QUASAR) {
+    if (allocator_->get_architecture() == tt::ARCH::QUASAR) {
         static constexpr size_t SIZE_4GB = 4ULL * 1024 * 1024 * 1024;
-        return factory_(&allocator_, next_bypass_tlb_id_++, SIZE_4GB, mapping, config);
+        return factory_(allocator_, next_bypass_tlb_id_++, SIZE_4GB, mapping, config);
     }
 
-    int tlb_index = allocator_.allocate_tlb_index(tlb_size);
+    int tlb_index = allocator_->allocate_tlb_index(tlb_size);
     if (tlb_index == -1) {
         UMD_THROW(error::RuntimeError, "No available TLB of requested size.");
     }
 
-    size_t actual_tlb_size = allocator_.get_tlb_size_from_index(tlb_index);
+    size_t actual_tlb_size = allocator_->get_tlb_size_from_index(tlb_index);
 
-    return factory_(&allocator_, tlb_index, actual_tlb_size, mapping, config);
+    return factory_(allocator_, tlb_index, actual_tlb_size, mapping, config);
 }
 
 std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
     static constexpr size_t SIZE_2MB = 2 * 1024 * 1024;
     static constexpr size_t SIZE_16MB = 16 * 1024 * 1024;
-    const tt::ARCH architecture = allocator_.get_architecture();
+    const tt::ARCH architecture = allocator_->get_architecture();
     switch (architecture) {
         case tt::ARCH::BLACKHOLE:
             return allocate_tlb_window({}, TlbMapping::WC, SIZE_2MB);

--- a/device/pcie/rtl_sim_tlb_handle.cpp
+++ b/device/pcie/rtl_sim_tlb_handle.cpp
@@ -16,8 +16,9 @@
 
 namespace tt::umd {
 
-RtlSimTlbHandle::RtlSimTlbHandle(SimulationTlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping) :
-    allocator_(allocator) {
+RtlSimTlbHandle::RtlSimTlbHandle(
+    std::shared_ptr<SimulationTlbAllocator> allocator, int tlb_id, size_t size, TlbMapping mapping) :
+    allocator_(std::move(allocator)) {
     tlb_id_ = tlb_id;
     tlb_size_ = size;
     tlb_mapping_ = mapping;
@@ -40,8 +41,8 @@ RtlSimTlbHandle::RtlSimTlbHandle(SimulationTlbAllocator* allocator, int tlb_id, 
 }
 
 std::unique_ptr<RtlSimTlbHandle> RtlSimTlbHandle::create(
-    SimulationTlbAllocator* allocator, int tlb_id, size_t size, TlbMapping mapping) {
-    return std::unique_ptr<RtlSimTlbHandle>(new RtlSimTlbHandle(allocator, tlb_id, size, mapping));
+    std::shared_ptr<SimulationTlbAllocator> allocator, int tlb_id, size_t size, TlbMapping mapping) {
+    return std::unique_ptr<RtlSimTlbHandle>(new RtlSimTlbHandle(std::move(allocator), tlb_id, size, mapping));
 }
 
 RtlSimTlbHandle::~RtlSimTlbHandle() noexcept { RtlSimTlbHandle::free_tlb(); }

--- a/device/pcie/tt_sim_tlb_handle.cpp
+++ b/device/pcie/tt_sim_tlb_handle.cpp
@@ -22,12 +22,12 @@
 namespace tt::umd {
 
 TTSimTlbHandle::TTSimTlbHandle(
-    SimulationTlbAllocator* allocator,
+    std::shared_ptr<SimulationTlbAllocator> allocator,
     TTSimCommunicator* communicator,
     int tlb_id,
     size_t size,
     const TlbMapping tlb_mapping) :
-    allocator_(allocator), sim_communicator_(communicator) {
+    allocator_(std::move(allocator)), sim_communicator_(communicator) {
     tlb_id_ = tlb_id;
     tlb_size_ = size;
     tlb_mapping_ = tlb_mapping;
@@ -51,13 +51,16 @@ TTSimTlbHandle::TTSimTlbHandle(
 }
 
 std::unique_ptr<TTSimTlbHandle> TTSimTlbHandle::create(
-    SimulationTlbAllocator* allocator,
+    std::shared_ptr<SimulationTlbAllocator> allocator,
     TTSimCommunicator* communicator,
     int tlb_id,
     size_t size,
     const TlbMapping tlb_mapping) {
-    return std::unique_ptr<TTSimTlbHandle>(new TTSimTlbHandle(allocator, communicator, tlb_id, size, tlb_mapping));
+    return std::unique_ptr<TTSimTlbHandle>(
+        new TTSimTlbHandle(std::move(allocator), communicator, tlb_id, size, tlb_mapping));
 }
+
+TTSimTlbHandle::~TTSimTlbHandle() noexcept { TTSimTlbHandle::free_tlb(); }
 
 void TTSimTlbHandle::configure(const tlb_data& new_config) {
     tlb_config_ = new_config;

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -109,9 +109,10 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
         this,
         /*bar0_base=*/0,
         architecture_impl_.get(),
-        [comm = communicator_.get()](SimulationTlbAllocator* alloc, int id, size_t sz, TlbMapping map, tlb_data cfg)
+        [comm = communicator_.get()](
+            std::shared_ptr<SimulationTlbAllocator> alloc, int id, size_t sz, TlbMapping map, tlb_data cfg)
             -> std::unique_ptr<TlbWindow> {
-            auto handle = RtlSimTlbHandle::create(alloc, id, sz, map);
+            auto handle = RtlSimTlbHandle::create(std::move(alloc), id, sz, map);
             return std::make_unique<RtlSimTlbWindow>(std::move(handle), comm, cfg);
         });
     cached_tlb_window_ = tlb_manager_->allocate_default_tlb_window();

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -106,9 +106,10 @@ TTSimTTDevice::TTSimTTDevice(
         this,
         bar0_base,
         architecture_impl_.get(),
-        [comm = communicator_.get()](SimulationTlbAllocator* alloc, int id, size_t sz, TlbMapping map, tlb_data cfg)
+        [comm = communicator_.get()](
+            std::shared_ptr<SimulationTlbAllocator> alloc, int id, size_t sz, TlbMapping map, tlb_data cfg)
             -> std::unique_ptr<TlbWindow> {
-            auto handle = TTSimTlbHandle::create(alloc, comm, id, sz, map);
+            auto handle = TTSimTlbHandle::create(std::move(alloc), comm, id, sz, map);
             return std::make_unique<TTSimTlbWindow>(std::move(handle), comm, cfg);
         },
         bar4_base);


### PR DESCRIPTION
### Issue
Alternative fix prototype for #2625. Companion to the temporary workaround in #2626.

### Description
The simulation TLB allocator currently lives by value inside `SimulationTlbManager`, and `RtlSimTlbHandle` / `TTSimTlbHandle` hold a raw back-pointer to it. tt-metal's destruction order can destroy the manager (and therefore the allocator) before the outstanding handles, so the destructor's `free_tlb()` call dereferences an already-destroyed allocator (use-after-free).

This prototype shares ownership of the allocator via `std::shared_ptr` between the manager and every `TlbHandle`. The allocator now lives as long as either the manager or any outstanding handle does, so the destructor-time `free_tlb()` call is always safe regardless of Metal's teardown order.

**Trade-off vs. #2626:** the workaround in #2626 simply skips `free_tlb()` on destruction (leaking the TLB index until the process exits). This prototype fixes the root cause but changes the ownership model and touches more files.

Opening as draft for discussion before deciding which approach to land.

### List of the changes
- `device/api/umd/device/chip_helpers/simulation_tlb_manager.hpp`: `allocator_` is now `std::shared_ptr<SimulationTlbAllocator>`; `TlbWindowFactory` signature takes a `shared_ptr`.
- `device/chip_helpers/simulation_tlb_manager.cpp`: heap-allocate the allocator via `std::make_shared`; thread `shared_ptr` through to the factory.
- `device/api/umd/device/pcie/rtl_sim_tlb_handle.hpp` + `device/pcie/rtl_sim_tlb_handle.cpp`: ctor + factory take `shared_ptr`; member is `shared_ptr`; `get_tlb_allocator()` still returns raw `T*`; `~RtlSimTlbHandle()` restored to call `free_tlb()`.
- `device/api/umd/device/pcie/tt_sim_tlb_handle.hpp` + `device/pcie/tt_sim_tlb_handle.cpp`: same shared_ptr changes; `~TTSimTlbHandle()` is no longer `= default` and now calls `free_tlb()` (previously dead code).
- `device/tt_device/tt_sim_tt_device.cpp`, `device/tt_device/rtl_simulation_tt_device.cpp`: lambda factories updated to the new signature.

### Testing
- `cmake --build build` clean.
- `pre-commit run --all-files` clean.
- `baremetal_tests --gtest_filter='SimulationTlbAllocator.*'` — 13 / 13 pass.

### API Changes
- `SimulationTlbManager::TlbWindowFactory` signature: first param is now `std::shared_ptr<SimulationTlbAllocator>` instead of raw pointer. Affects any downstream that constructs its own factory.
- `RtlSimTlbHandle::create` / `TTSimTlbHandle::create` first param: `std::shared_ptr<SimulationTlbAllocator>` instead of raw pointer.
- `get_tlb_allocator()` on both handles still returns raw `SimulationTlbAllocator*` (via `.get()`), so non-owning callers are unaffected.