### PR TITLE
Fix logging in pytests

### DIFF
--- a/device/api/umd/device/logging/config.hpp
+++ b/device/api/umd/device/logging/config.hpp
@@ -37,4 +37,12 @@ enum class level {
  */
 void set_level(level lvl);
 
+/**
+ * @brief Returns the current global logging level.
+ *
+ * Reads the level from the underlying logger registry. Intended for tests
+ * that need to save/restore the level around calls to set_level().
+ */
+level get_level();
+
 }  // namespace tt::umd::logging

--- a/device/logging/config.cpp
+++ b/device/logging/config.cpp
@@ -40,6 +40,30 @@ spdlog::level::level_enum to_spdlog_level(level lvl) {
     return spdlog::level::info;  // fallback
 }
 
+/// Inverse of to_spdlog_level.
+level from_spdlog_level(spdlog::level::level_enum lvl) {
+    switch (lvl) {
+        case spdlog::level::trace:
+            return level::trace;
+        case spdlog::level::debug:
+            return level::debug;
+        case spdlog::level::info:
+            return level::info;
+        case spdlog::level::warn:
+            return level::warn;
+        case spdlog::level::err:
+            return level::error;
+        case spdlog::level::critical:
+            return level::critical;
+        case spdlog::level::off:
+            return level::off;
+        default:
+            return level::info;
+    }
+}
+
 void set_level(level lvl) { ::tt::LoggerRegistry::instance().set_level(to_spdlog_level(lvl)); }
+
+level get_level() { return from_spdlog_level(::tt::LoggerRegistry::instance().get(::tt::LogUMD)->level()); }
 
 }  // namespace tt::umd::logging

--- a/nanobind/py_api_logging.cpp
+++ b/nanobind/py_api_logging.cpp
@@ -34,4 +34,11 @@ void bind_logging(nb::module_ &m) {
         nb::arg("lvl"),
         release_gil(),
         "Sets the global logging level. Messages with severity levels lower than this level will not be logged.");
+
+    logging_module.def(
+        "get_level",
+        &get_level,
+        release_gil(),
+        "Returns the current global logging level. Pair with set_level() to save/restore the level "
+        "around code that needs to temporarily change verbosity.");
 }

--- a/nanobind/tests/test_py_logging.py
+++ b/nanobind/tests/test_py_logging.py
@@ -6,6 +6,21 @@
 """Tests for Python bindings of UMD logging configuration."""
 
 import pytest
+import tt_umd
+
+
+@pytest.fixture(autouse=True)
+def _restore_log_level():
+    """Save the global logging level and restore it after each test.
+
+    set_level() is process-global, so a test that ends with Level.Off would
+    silence all subsequent tests' C++ logs. Snapshotting before and restoring
+    after keeps tests independent.
+    """
+    saved = tt_umd.logging.get_level()
+    # Note that the way pytest fixtures work, you should put initialization code before the yield and cleanup code after. The test will run at the point of the yield statement.
+    yield
+    tt_umd.logging.set_level(saved)
 
 
 def test_logging_level_enum():


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description
I noticed we're missing a lot of logs in our pytests, even though we are passing `-s` when running from the workflow.
The culprit was peculiar, we actually ran tests which tested the logging feature, but it didn't end up cleaning after itself, leaving the logs off.

### List of the changes
- Add get_level to match the set_level in our utility related to logging
- Set fixture in python tests so that it performs cleanup such that it returns level of logging.

### Testing
This run now shows UMD logs properly: https://github.com/tenstorrent/tt-umd/actions/runs/25799717303/job/75786782716?pr=2628

### API Changes
There are no API changes in this PR.
