### PR TITLE
Add per-op MMIO timeout for TLB-mapped device access

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -265,7 +265,6 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/utils/error_detail.hpp
                 api/umd/device/utils/error.hpp
                 api/umd/device/utils/mmio_timeout_config.hpp
-                api/umd/device/utils/op_budget_timer.hpp
                 api/umd/device/utils/op_timeout_guard.hpp
                 api/umd/device/utils/timeouts.hpp
                 api/umd/device/types/arch.hpp

--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -264,6 +264,9 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/utils/common.hpp
                 api/umd/device/utils/error_detail.hpp
                 api/umd/device/utils/error.hpp
+                api/umd/device/utils/mmio_timeout_config.hpp
+                api/umd/device/utils/op_budget_timer.hpp
+                api/umd/device/utils/op_timeout_guard.hpp
                 api/umd/device/utils/timeouts.hpp
                 api/umd/device/types/arch.hpp
                 api/umd/device/types/blackhole_arc.hpp

--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -107,10 +107,11 @@ private:
     TlbWindow* get_cached_wc_tlb_window();
     TlbWindow* get_cached_uc_tlb_window();
 
-    // Builds the per-op MMIO timeout veto for TLB-mapped transfers: on an overrun the configured hang
-    // check is consulted for the in-flight op's NOC. A hung NOC confirms the timeout (aborts with
-    // DeviceTimeoutError); a healthy NOC vetoes it so a slow-but-completing op is not a false positive.
-    std::function<bool()> make_io_timeout_callback();
+    // Builds the per-op MMIO timeout hang check installed on the cached TLB windows: given the in-flight
+    // op's NOC, returns whether that NOC is hung. SiliconTlbWindow turns this into the OpTimeoutGuard
+    // false-alarm veto (a hung NOC confirms the timeout; a healthy NOC lets a slow-but-completing op
+    // through). Reads through an independent, separately-locked window so it does not re-enter the TLB lock.
+    std::function<bool(NocId)> make_io_timeout_hang_check();
 
     std::unique_ptr<TlbWindow> cached_wc_tlb_window = nullptr;
     std::unique_ptr<TlbWindow> cached_uc_tlb_window = nullptr;

--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -105,6 +106,11 @@ private:
 
     TlbWindow* get_cached_wc_tlb_window();
     TlbWindow* get_cached_uc_tlb_window();
+
+    // Builds the per-op MMIO timeout veto for TLB-mapped transfers: on an overrun the configured hang
+    // check is consulted for the in-flight op's NOC. A hung NOC confirms the timeout (aborts with
+    // DeviceTimeoutError); a healthy NOC vetoes it so a slow-but-completing op is not a false positive.
+    std::function<bool()> make_io_timeout_callback();
 
     std::unique_ptr<TlbWindow> cached_wc_tlb_window = nullptr;
     std::unique_ptr<TlbWindow> cached_uc_tlb_window = nullptr;

--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -107,10 +107,6 @@ private:
     TlbWindow* get_cached_wc_tlb_window();
     TlbWindow* get_cached_uc_tlb_window();
 
-    // Builds the per-op MMIO timeout hang check installed on the cached TLB windows: given the in-flight
-    // op's NOC, returns whether that NOC is hung. SiliconTlbWindow turns this into the OpTimeoutGuard
-    // false-alarm veto (a hung NOC confirms the timeout; a healthy NOC lets a slow-but-completing op
-    // through). Reads through an independent, separately-locked window so it does not re-enter the TLB lock.
     std::function<bool(NocId)> make_io_timeout_hang_check();
 
     std::unique_ptr<TlbWindow> cached_wc_tlb_window = nullptr;

--- a/device/api/umd/device/pcie/rtl_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/rtl_sim_tlb_window.hpp
@@ -31,8 +31,9 @@ public:
     uint16_t read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
     void write32(uint64_t offset, uint32_t value, const std::function<bool()>& on_timeout = {}) override;
     uint32_t read32(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
-    void write_register(uint64_t offset, const void* data, size_t size) override;
-    void read_register(uint64_t offset, void* data, size_t size) override;
+    void write_register(
+        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
+    void read_register(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
     void write_block(
         uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
     void read_block(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;

--- a/device/api/umd/device/pcie/rtl_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/rtl_sim_tlb_window.hpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 
 #include "umd/device/pcie/tlb_window.hpp"
@@ -26,17 +27,18 @@ class RtlSimTlbWindow : public TlbWindow {
 public:
     RtlSimTlbWindow(std::unique_ptr<TlbHandle> handle, RtlSimCommunicator* communicator, const tlb_data config = {});
 
-    void write16(uint64_t offset, uint16_t value) override;
-    uint16_t read16(uint64_t offset) override;
-    void write32(uint64_t offset, uint32_t value) override;
-    uint32_t read32(uint64_t offset) override;
+    void write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout = {}) override;
+    uint16_t read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
+    void write32(uint64_t offset, uint32_t value, const std::function<bool()>& on_timeout = {}) override;
+    uint32_t read32(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
     void write_register(uint64_t offset, const void* data, size_t size) override;
     void read_register(uint64_t offset, void* data, size_t size) override;
-    void write_block(uint64_t offset, const void* data, size_t size) override;
-    void read_block(uint64_t offset, void* data, size_t size) override;
+    void write_block(
+        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
+    void read_block(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
 
-    void safe_write16(uint64_t offset, uint16_t value) override;
-    uint16_t safe_read16(uint64_t offset) override;
+    void safe_write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout = {}) override;
+    uint16_t safe_read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
 
 private:
     /**

--- a/device/api/umd/device/pcie/rtl_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/rtl_sim_tlb_window.hpp
@@ -27,19 +27,17 @@ class RtlSimTlbWindow : public TlbWindow {
 public:
     RtlSimTlbWindow(std::unique_ptr<TlbHandle> handle, RtlSimCommunicator* communicator, const tlb_data config = {});
 
-    void write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout = {}) override;
-    uint16_t read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
-    void write32(uint64_t offset, uint32_t value, const std::function<bool()>& on_timeout = {}) override;
-    uint32_t read32(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
-    void write_register(
-        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
-    void read_register(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
-    void write_block(
-        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
-    void read_block(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
+    void write16(uint64_t offset, uint16_t value) override;
+    uint16_t read16(uint64_t offset) override;
+    void write32(uint64_t offset, uint32_t value) override;
+    uint32_t read32(uint64_t offset) override;
+    void write_register(uint64_t offset, const void* data, size_t size) override;
+    void read_register(uint64_t offset, void* data, size_t size) override;
+    void write_block(uint64_t offset, const void* data, size_t size) override;
+    void read_block(uint64_t offset, void* data, size_t size) override;
 
-    void safe_write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout = {}) override;
-    uint16_t safe_read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
+    void safe_write16(uint64_t offset, uint16_t value) override;
+    uint16_t safe_read16(uint64_t offset) override;
 
 private:
     /**

--- a/device/api/umd/device/pcie/silicon_tlb_window.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_window.hpp
@@ -30,8 +30,9 @@ public:
     uint16_t read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
     void write32(uint64_t offset, uint32_t value, const std::function<bool()>& on_timeout = {}) override;
     uint32_t read32(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
-    void write_register(uint64_t offset, const void* data, size_t size) override;
-    void read_register(uint64_t offset, void* data, size_t size) override;
+    void write_register(
+        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
+    void read_register(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
     void write_block(
         uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
     void read_block(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
@@ -109,8 +110,9 @@ private:
     static void memcpy_to_device(
         void* dest, const void* src, std::size_t num_bytes, const std::function<bool()>& on_timeout);
 
-    void write_regs(volatile uint32_t* dest, const uint32_t* src, uint32_t word_len);
-    void read_regs(void* src_reg, uint32_t word_len, void* data);
+    void write_regs(
+        volatile uint32_t* dest, const uint32_t* src, uint32_t word_len, const std::function<bool()>& on_timeout = {});
+    void read_regs(void* src_reg, uint32_t word_len, void* data, const std::function<bool()>& on_timeout = {});
 
     template <typename Func, typename... Args>
     decltype(auto) execute_safe(Func&& func, Args&&... args);

--- a/device/api/umd/device/pcie/silicon_tlb_window.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_window.hpp
@@ -91,14 +91,18 @@ public:
     // When empty (the default), an overrun aborts outright.
     void set_io_timeout_hang_check(const std::function<bool(NocId)>& hang_check) override;
 
+    // Reconfigures the window and refreshes the cached timeout callback, since the NOC may have changed.
+    void configure(const tlb_data& new_config) override;
+
     static void set_sigbus_safe_handler(bool set_safe_handler);
 
 private:
-    // Builds the per-op timeout veto (an OpTimeoutGuard is_false_alarm callback) for the window's
-    // currently configured NOC: true means "healthy, false positive" so the overrun is ignored, false
-    // confirms it. Reads the NOC from the live TLB config, so it tracks whatever the last (re)configure
-    // selected. Returns an empty callback when no hang check is wired, which makes an overrun abort.
-    std::function<bool()> make_io_timeout_callback() const;
+    // Rebuilds io_timeout_callback_ (an OpTimeoutGuard is_false_alarm callback) for the window's currently
+    // configured NOC: true means "healthy, false positive" so the overrun is ignored, false confirms it.
+    // The NOC is read from the live TLB config, so this must be called whenever the config or hang check
+    // changes (construction, configure(), set_io_timeout_hang_check()). Leaves an empty callback when no
+    // hang check is wired, which makes an overrun abort.
+    void update_io_timeout_callback();
 
     // Custom device memcpy. This is only safe for memory-like regions on the device (Tensix L1, DRAM, ARC CSM).
     // Both routines assume that misaligned accesses are permitted on host memory.
@@ -120,6 +124,9 @@ private:
     decltype(auto) execute_safe(Func&& func, Args&&... args);
 
     std::function<bool(NocId)> hang_check_;
+    // Cached is_false_alarm callback bound to the currently configured NOC; refreshed by
+    // update_io_timeout_callback() so the IO paths need not rebuild it per call.
+    std::function<bool()> io_timeout_callback_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/pcie/silicon_tlb_window.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_window.hpp
@@ -24,12 +24,7 @@ class TlbHandle;
  */
 class SiliconTlbWindow : public TlbWindow {
 public:
-    // hang_check (optional) wires the per-op MMIO timeout: on a single-op overrun it is consulted for the
-    // window's currently configured NOC. Returning true means that NOC is hung (the transfer aborts with
-    // DeviceTimeoutError); false means it is healthy (a slow-but-completing op is not a false positive).
-    // When empty, an overrun aborts outright. See make_io_timeout_callback().
-    SiliconTlbWindow(
-        std::unique_ptr<TlbHandle> handle, const tlb_data config = {}, std::function<bool(NocId)> hang_check = {});
+    SiliconTlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config = {});
 
     // Implementation of memory access methods using direct pointer access.
     void write16(uint64_t offset, uint16_t value) override;
@@ -90,6 +85,10 @@ public:
         NocId noc_id,
         uint64_t ordering = tlb_data::Strict) override;
 
+    // Wires the per-op MMIO timeout: on a single-op overrun hang_check is consulted for the window's
+    // currently configured NOC. Returning true means that NOC is hung (the transfer aborts with
+    // DeviceTimeoutError); false means it is healthy (a slow-but-completing op is not a false positive).
+    // When empty (the default), an overrun aborts outright.
     void set_io_timeout_hang_check(const std::function<bool(NocId)>& hang_check) override;
 
     static void set_sigbus_safe_handler(bool set_safe_handler);

--- a/device/api/umd/device/pcie/silicon_tlb_window.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_window.hpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 
 #include "umd/device/pcie/tlb_handle.hpp"
@@ -25,30 +26,33 @@ public:
     SiliconTlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config = {});
 
     // Implementation of memory access methods using direct pointer access.
-    void write16(uint64_t offset, uint16_t value) override;
-    uint16_t read16(uint64_t offset) override;
-    void write32(uint64_t offset, uint32_t value) override;
-    uint32_t read32(uint64_t offset) override;
+    void write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout = {}) override;
+    uint16_t read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
+    void write32(uint64_t offset, uint32_t value, const std::function<bool()>& on_timeout = {}) override;
+    uint32_t read32(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
     void write_register(uint64_t offset, const void* data, size_t size) override;
     void read_register(uint64_t offset, void* data, size_t size) override;
-    void write_block(uint64_t offset, const void* data, size_t size) override;
-    void read_block(uint64_t offset, void* data, size_t size) override;
+    void write_block(
+        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
+    void read_block(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
 
-    void safe_write16(uint64_t offset, uint16_t value) override;
+    void safe_write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout = {}) override;
 
-    uint16_t safe_read16(uint64_t offset) override;
+    uint16_t safe_read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
 
-    void safe_write32(uint64_t offset, uint32_t value) override;
+    void safe_write32(uint64_t offset, uint32_t value, const std::function<bool()>& on_timeout = {}) override;
 
-    uint32_t safe_read32(uint64_t offset) override;
+    uint32_t safe_read32(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
 
     void safe_write_register(uint64_t offset, const void* data, size_t size) override;
 
     void safe_read_register(uint64_t offset, void* data, size_t size) override;
 
-    void safe_write_block(uint64_t offset, const void* data, size_t size) override;
+    void safe_write_block(
+        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
 
-    void safe_read_block(uint64_t offset, void* data, size_t size) override;
+    void safe_read_block(
+        uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
 
     void safe_write_block_reconfigure(
         const void* mem_ptr,
@@ -56,11 +60,17 @@ public:
         uint64_t addr,
         size_t size,
         NocId noc_id,
-        uint64_t ordering = tlb_data::Strict) override;
+        uint64_t ordering = tlb_data::Strict,
+        const std::function<bool()>& on_timeout = {}) override;
 
     void safe_read_block_reconfigure(
-        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict)
-        override;
+        void* mem_ptr,
+        tt_xy_pair core,
+        uint64_t addr,
+        size_t size,
+        NocId noc_id,
+        uint64_t ordering = tlb_data::Strict,
+        const std::function<bool()>& on_timeout = {}) override;
 
     void safe_read_register_reconfigure(
         void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict)
@@ -81,7 +91,8 @@ public:
         tt_xy_pair core_end,
         uint64_t addr,
         NocId noc_id,
-        uint64_t ordering = tlb_data::Strict) override;
+        uint64_t ordering = tlb_data::Strict,
+        const std::function<bool()>& on_timeout = {}) override;
 
     static void set_sigbus_safe_handler(bool set_safe_handler);
 
@@ -93,8 +104,10 @@ private:
     // which glibc's memcpy may perform when unrolling. This affects from and to device.
     // 2. syseng#3487 WH GDDR5 controller has a bug when 1-byte writes are temporarily adjacent
     // to 2-byte writes. We avoid ever performing a 1-byte write to the device. This only affects to device.
-    static void memcpy_from_device(void* dest, const volatile void* src, std::size_t num_bytes);
-    static void memcpy_to_device(void* dest, const void* src, std::size_t num_bytes);
+    static void memcpy_from_device(
+        void* dest, const volatile void* src, std::size_t num_bytes, const std::function<bool()>& on_timeout);
+    static void memcpy_to_device(
+        void* dest, const void* src, std::size_t num_bytes, const std::function<bool()>& on_timeout);
 
     void write_regs(volatile uint32_t* dest, const uint32_t* src, uint32_t word_len);
     void read_regs(void* src_reg, uint32_t word_len, void* data);

--- a/device/api/umd/device/pcie/silicon_tlb_window.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_window.hpp
@@ -11,6 +11,7 @@
 
 #include "umd/device/pcie/tlb_handle.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
+#include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/tlb.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
@@ -23,37 +24,38 @@ class TlbHandle;
  */
 class SiliconTlbWindow : public TlbWindow {
 public:
-    SiliconTlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config = {});
+    // hang_check (optional) wires the per-op MMIO timeout: on a single-op overrun it is consulted for the
+    // window's currently configured NOC. Returning true means that NOC is hung (the transfer aborts with
+    // DeviceTimeoutError); false means it is healthy (a slow-but-completing op is not a false positive).
+    // When empty, an overrun aborts outright. See make_io_timeout_callback().
+    SiliconTlbWindow(
+        std::unique_ptr<TlbHandle> handle, const tlb_data config = {}, std::function<bool(NocId)> hang_check = {});
 
     // Implementation of memory access methods using direct pointer access.
-    void write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout = {}) override;
-    uint16_t read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
-    void write32(uint64_t offset, uint32_t value, const std::function<bool()>& on_timeout = {}) override;
-    uint32_t read32(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
-    void write_register(
-        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
-    void read_register(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
-    void write_block(
-        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
-    void read_block(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
+    void write16(uint64_t offset, uint16_t value) override;
+    uint16_t read16(uint64_t offset) override;
+    void write32(uint64_t offset, uint32_t value) override;
+    uint32_t read32(uint64_t offset) override;
+    void write_register(uint64_t offset, const void* data, size_t size) override;
+    void read_register(uint64_t offset, void* data, size_t size) override;
+    void write_block(uint64_t offset, const void* data, size_t size) override;
+    void read_block(uint64_t offset, void* data, size_t size) override;
 
-    void safe_write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout = {}) override;
+    void safe_write16(uint64_t offset, uint16_t value) override;
 
-    uint16_t safe_read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
+    uint16_t safe_read16(uint64_t offset) override;
 
-    void safe_write32(uint64_t offset, uint32_t value, const std::function<bool()>& on_timeout = {}) override;
+    void safe_write32(uint64_t offset, uint32_t value) override;
 
-    uint32_t safe_read32(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
+    uint32_t safe_read32(uint64_t offset) override;
 
     void safe_write_register(uint64_t offset, const void* data, size_t size) override;
 
     void safe_read_register(uint64_t offset, void* data, size_t size) override;
 
-    void safe_write_block(
-        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
+    void safe_write_block(uint64_t offset, const void* data, size_t size) override;
 
-    void safe_read_block(
-        uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
+    void safe_read_block(uint64_t offset, void* data, size_t size) override;
 
     void safe_write_block_reconfigure(
         const void* mem_ptr,
@@ -61,17 +63,11 @@ public:
         uint64_t addr,
         size_t size,
         NocId noc_id,
-        uint64_t ordering = tlb_data::Strict,
-        const std::function<bool()>& on_timeout = {}) override;
+        uint64_t ordering = tlb_data::Strict) override;
 
     void safe_read_block_reconfigure(
-        void* mem_ptr,
-        tt_xy_pair core,
-        uint64_t addr,
-        size_t size,
-        NocId noc_id,
-        uint64_t ordering = tlb_data::Strict,
-        const std::function<bool()>& on_timeout = {}) override;
+        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict)
+        override;
 
     void safe_read_register_reconfigure(
         void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict)
@@ -92,12 +88,19 @@ public:
         tt_xy_pair core_end,
         uint64_t addr,
         NocId noc_id,
-        uint64_t ordering = tlb_data::Strict,
-        const std::function<bool()>& on_timeout = {}) override;
+        uint64_t ordering = tlb_data::Strict) override;
+
+    void set_io_timeout_hang_check(const std::function<bool(NocId)>& hang_check) override;
 
     static void set_sigbus_safe_handler(bool set_safe_handler);
 
 private:
+    // Builds the per-op timeout veto (an OpTimeoutGuard is_false_alarm callback) for the window's
+    // currently configured NOC: true means "healthy, false positive" so the overrun is ignored, false
+    // confirms it. Reads the NOC from the live TLB config, so it tracks whatever the last (re)configure
+    // selected. Returns an empty callback when no hang check is wired, which makes an overrun abort.
+    std::function<bool()> make_io_timeout_callback() const;
+
     // Custom device memcpy. This is only safe for memory-like regions on the device (Tensix L1, DRAM, ARC CSM).
     // Both routines assume that misaligned accesses are permitted on host memory.
     //
@@ -111,11 +114,13 @@ private:
         void* dest, const void* src, std::size_t num_bytes, const std::function<bool()>& on_timeout);
 
     void write_regs(
-        volatile uint32_t* dest, const uint32_t* src, uint32_t word_len, const std::function<bool()>& on_timeout = {});
-    void read_regs(void* src_reg, uint32_t word_len, void* data, const std::function<bool()>& on_timeout = {});
+        volatile uint32_t* dest, const uint32_t* src, uint32_t word_len, const std::function<bool()>& on_timeout);
+    void read_regs(void* src_reg, uint32_t word_len, void* data, const std::function<bool()>& on_timeout);
 
     template <typename Func, typename... Args>
     decltype(auto) execute_safe(Func&& func, Args&&... args);
+
+    std::function<bool(NocId)> hang_check_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -33,8 +33,10 @@ public:
     virtual uint16_t read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) = 0;
     virtual void write32(uint64_t offset, uint32_t value, const std::function<bool()>& on_timeout = {}) = 0;
     virtual uint32_t read32(uint64_t offset, const std::function<bool()>& on_timeout = {}) = 0;
-    virtual void write_register(uint64_t offset, const void* data, size_t size) = 0;
-    virtual void read_register(uint64_t offset, void* data, size_t size) = 0;
+    virtual void write_register(
+        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) = 0;
+    virtual void read_register(
+        uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) = 0;
     virtual void write_block(
         uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) = 0;
     virtual void read_block(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) = 0;

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 
 #include "umd/device/pcie/tlb_handle.hpp"
@@ -28,18 +29,25 @@ public:
     virtual ~TlbWindow() = default;
 
     // Pure virtual methods for memory access - to be implemented by derived classes.
-    virtual void write16(uint64_t offset, uint16_t value) = 0;
-    virtual uint16_t read16(uint64_t offset) = 0;
-    virtual void write32(uint64_t offset, uint32_t value) = 0;
-    virtual uint32_t read32(uint64_t offset) = 0;
+    virtual void write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout = {}) = 0;
+    virtual uint16_t read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) = 0;
+    virtual void write32(uint64_t offset, uint32_t value, const std::function<bool()>& on_timeout = {}) = 0;
+    virtual uint32_t read32(uint64_t offset, const std::function<bool()>& on_timeout = {}) = 0;
     virtual void write_register(uint64_t offset, const void* data, size_t size) = 0;
     virtual void read_register(uint64_t offset, void* data, size_t size) = 0;
-    virtual void write_block(uint64_t offset, const void* data, size_t size) = 0;
-    virtual void read_block(uint64_t offset, void* data, size_t size) = 0;
+    virtual void write_block(
+        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) = 0;
+    virtual void read_block(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) = 0;
 
     // Shared higher-level methods that use the virtual methods above.
     virtual void read_block_reconfigure(
-        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
+        void* mem_ptr,
+        tt_xy_pair core,
+        uint64_t addr,
+        size_t size,
+        NocId noc_id,
+        uint64_t ordering = tlb_data::Strict,
+        const std::function<bool()>& on_timeout = {});
 
     virtual void write_block_reconfigure(
         const void* mem_ptr,
@@ -47,7 +55,8 @@ public:
         uint64_t addr,
         size_t size,
         NocId noc_id,
-        uint64_t ordering = tlb_data::Strict);
+        uint64_t ordering = tlb_data::Strict,
+        const std::function<bool()>& on_timeout = {});
 
     virtual void noc_multicast_write_reconfigure(
         const void* src,
@@ -56,7 +65,8 @@ public:
         tt_xy_pair core_end,
         uint64_t addr,
         NocId noc_id,
-        uint64_t ordering = tlb_data::Strict);
+        uint64_t ordering = tlb_data::Strict,
+        const std::function<bool()>& on_timeout = {});
 
     // Register reconfigure methods perform 32-bit chunked transfers with strict ordering.
     // Alignment enforcement is the caller's responsibility.
@@ -71,21 +81,23 @@ public:
         NocId noc_id,
         uint64_t ordering = tlb_data::Strict);
 
-    virtual void safe_write16(uint64_t offset, uint16_t value) = 0;
+    virtual void safe_write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout = {}) = 0;
 
-    virtual uint16_t safe_read16(uint64_t offset) = 0;
+    virtual uint16_t safe_read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) = 0;
 
-    virtual void safe_write32(uint64_t offset, uint32_t value);
+    virtual void safe_write32(uint64_t offset, uint32_t value, const std::function<bool()>& on_timeout = {});
 
-    virtual uint32_t safe_read32(uint64_t offset);
+    virtual uint32_t safe_read32(uint64_t offset, const std::function<bool()>& on_timeout = {});
 
     virtual void safe_write_register(uint64_t offset, const void* data, size_t size);
 
     virtual void safe_read_register(uint64_t offset, void* data, size_t size);
 
-    virtual void safe_write_block(uint64_t offset, const void* data, size_t size);
+    virtual void safe_write_block(
+        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {});
 
-    virtual void safe_read_block(uint64_t offset, void* data, size_t size);
+    virtual void safe_read_block(
+        uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {});
 
     virtual void safe_write_block_reconfigure(
         const void* mem_ptr,
@@ -93,10 +105,17 @@ public:
         uint64_t addr,
         size_t size,
         NocId noc_id,
-        uint64_t ordering = tlb_data::Strict);
+        uint64_t ordering = tlb_data::Strict,
+        const std::function<bool()>& on_timeout = {});
 
     virtual void safe_read_block_reconfigure(
-        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
+        void* mem_ptr,
+        tt_xy_pair core,
+        uint64_t addr,
+        size_t size,
+        NocId noc_id,
+        uint64_t ordering = tlb_data::Strict,
+        const std::function<bool()>& on_timeout = {});
 
     virtual void safe_read_register_reconfigure(
         void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
@@ -116,7 +135,8 @@ public:
         tt_xy_pair core_end,
         uint64_t addr,
         NocId noc_id,
-        uint64_t ordering = tlb_data::Strict);
+        uint64_t ordering = tlb_data::Strict,
+        const std::function<bool()>& on_timeout = {});
 
     // Shared utility methods.
     TlbHandle& handle_ref() const;

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -126,7 +126,7 @@ public:
     // Shared utility methods.
     TlbHandle& handle_ref() const;
     size_t get_size() const;
-    void configure(const tlb_data& new_config);
+    virtual void configure(const tlb_data& new_config);
     uint64_t get_base_address() const;
 
 protected:

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -29,27 +29,18 @@ public:
     virtual ~TlbWindow() = default;
 
     // Pure virtual methods for memory access - to be implemented by derived classes.
-    virtual void write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout = {}) = 0;
-    virtual uint16_t read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) = 0;
-    virtual void write32(uint64_t offset, uint32_t value, const std::function<bool()>& on_timeout = {}) = 0;
-    virtual uint32_t read32(uint64_t offset, const std::function<bool()>& on_timeout = {}) = 0;
-    virtual void write_register(
-        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) = 0;
-    virtual void read_register(
-        uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) = 0;
-    virtual void write_block(
-        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) = 0;
-    virtual void read_block(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) = 0;
+    virtual void write16(uint64_t offset, uint16_t value) = 0;
+    virtual uint16_t read16(uint64_t offset) = 0;
+    virtual void write32(uint64_t offset, uint32_t value) = 0;
+    virtual uint32_t read32(uint64_t offset) = 0;
+    virtual void write_register(uint64_t offset, const void* data, size_t size) = 0;
+    virtual void read_register(uint64_t offset, void* data, size_t size) = 0;
+    virtual void write_block(uint64_t offset, const void* data, size_t size) = 0;
+    virtual void read_block(uint64_t offset, void* data, size_t size) = 0;
 
     // Shared higher-level methods that use the virtual methods above.
     virtual void read_block_reconfigure(
-        void* mem_ptr,
-        tt_xy_pair core,
-        uint64_t addr,
-        size_t size,
-        NocId noc_id,
-        uint64_t ordering = tlb_data::Strict,
-        const std::function<bool()>& on_timeout = {});
+        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
 
     virtual void write_block_reconfigure(
         const void* mem_ptr,
@@ -57,8 +48,7 @@ public:
         uint64_t addr,
         size_t size,
         NocId noc_id,
-        uint64_t ordering = tlb_data::Strict,
-        const std::function<bool()>& on_timeout = {});
+        uint64_t ordering = tlb_data::Strict);
 
     virtual void noc_multicast_write_reconfigure(
         const void* src,
@@ -67,8 +57,7 @@ public:
         tt_xy_pair core_end,
         uint64_t addr,
         NocId noc_id,
-        uint64_t ordering = tlb_data::Strict,
-        const std::function<bool()>& on_timeout = {});
+        uint64_t ordering = tlb_data::Strict);
 
     // Register reconfigure methods perform 32-bit chunked transfers with strict ordering.
     // Alignment enforcement is the caller's responsibility.
@@ -83,23 +72,21 @@ public:
         NocId noc_id,
         uint64_t ordering = tlb_data::Strict);
 
-    virtual void safe_write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout = {}) = 0;
+    virtual void safe_write16(uint64_t offset, uint16_t value) = 0;
 
-    virtual uint16_t safe_read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) = 0;
+    virtual uint16_t safe_read16(uint64_t offset) = 0;
 
-    virtual void safe_write32(uint64_t offset, uint32_t value, const std::function<bool()>& on_timeout = {});
+    virtual void safe_write32(uint64_t offset, uint32_t value);
 
-    virtual uint32_t safe_read32(uint64_t offset, const std::function<bool()>& on_timeout = {});
+    virtual uint32_t safe_read32(uint64_t offset);
 
     virtual void safe_write_register(uint64_t offset, const void* data, size_t size);
 
     virtual void safe_read_register(uint64_t offset, void* data, size_t size);
 
-    virtual void safe_write_block(
-        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {});
+    virtual void safe_write_block(uint64_t offset, const void* data, size_t size);
 
-    virtual void safe_read_block(
-        uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {});
+    virtual void safe_read_block(uint64_t offset, void* data, size_t size);
 
     virtual void safe_write_block_reconfigure(
         const void* mem_ptr,
@@ -107,17 +94,10 @@ public:
         uint64_t addr,
         size_t size,
         NocId noc_id,
-        uint64_t ordering = tlb_data::Strict,
-        const std::function<bool()>& on_timeout = {});
+        uint64_t ordering = tlb_data::Strict);
 
     virtual void safe_read_block_reconfigure(
-        void* mem_ptr,
-        tt_xy_pair core,
-        uint64_t addr,
-        size_t size,
-        NocId noc_id,
-        uint64_t ordering = tlb_data::Strict,
-        const std::function<bool()>& on_timeout = {});
+        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
 
     virtual void safe_read_register_reconfigure(
         void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
@@ -137,8 +117,11 @@ public:
         tt_xy_pair core_end,
         uint64_t addr,
         NocId noc_id,
-        uint64_t ordering = tlb_data::Strict,
-        const std::function<bool()>& on_timeout = {});
+        uint64_t ordering = tlb_data::Strict);
+
+    // Installs a per-op MMIO timeout hang check used by the timed memcpy path. No-op by default; only
+    // SiliconTlbWindow consults it (simulation windows do not run the timed path). See SiliconTlbWindow.
+    virtual void set_io_timeout_hang_check(const std::function<bool(NocId)>& hang_check) {}
 
     // Shared utility methods.
     TlbHandle& handle_ref() const;

--- a/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
@@ -33,8 +33,9 @@ public:
     uint16_t read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
     void write32(uint64_t offset, uint32_t value, const std::function<bool()>& on_timeout = {}) override;
     uint32_t read32(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
-    void write_register(uint64_t offset, const void* data, size_t size) override;
-    void read_register(uint64_t offset, void* data, size_t size) override;
+    void write_register(
+        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
+    void read_register(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
     void write_block(
         uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
     void read_block(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;

--- a/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
@@ -29,20 +29,18 @@ public:
     TTSimTlbWindow(std::unique_ptr<TlbHandle> handle, TTSimCommunicator* communicator, const tlb_data config = {});
 
     // Implementation of memory access methods using TTSimCommunicator.
-    void write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout = {}) override;
-    uint16_t read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
-    void write32(uint64_t offset, uint32_t value, const std::function<bool()>& on_timeout = {}) override;
-    uint32_t read32(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
-    void write_register(
-        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
-    void read_register(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
-    void write_block(
-        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
-    void read_block(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
+    void write16(uint64_t offset, uint16_t value) override;
+    uint16_t read16(uint64_t offset) override;
+    void write32(uint64_t offset, uint32_t value) override;
+    uint32_t read32(uint64_t offset) override;
+    void write_register(uint64_t offset, const void* data, size_t size) override;
+    void read_register(uint64_t offset, void* data, size_t size) override;
+    void write_block(uint64_t offset, const void* data, size_t size) override;
+    void read_block(uint64_t offset, void* data, size_t size) override;
 
-    void safe_write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout = {}) override;
+    void safe_write16(uint64_t offset, uint16_t value) override;
 
-    uint16_t safe_read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
+    uint16_t safe_read16(uint64_t offset) override;
 
 private:
     /**

--- a/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 
 #include "umd/device/pcie/tlb_window.hpp"
@@ -28,18 +29,19 @@ public:
     TTSimTlbWindow(std::unique_ptr<TlbHandle> handle, TTSimCommunicator* communicator, const tlb_data config = {});
 
     // Implementation of memory access methods using TTSimCommunicator.
-    void write16(uint64_t offset, uint16_t value) override;
-    uint16_t read16(uint64_t offset) override;
-    void write32(uint64_t offset, uint32_t value) override;
-    uint32_t read32(uint64_t offset) override;
+    void write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout = {}) override;
+    uint16_t read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
+    void write32(uint64_t offset, uint32_t value, const std::function<bool()>& on_timeout = {}) override;
+    uint32_t read32(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
     void write_register(uint64_t offset, const void* data, size_t size) override;
     void read_register(uint64_t offset, void* data, size_t size) override;
-    void write_block(uint64_t offset, const void* data, size_t size) override;
-    void read_block(uint64_t offset, void* data, size_t size) override;
+    void write_block(
+        uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
+    void read_block(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout = {}) override;
 
-    void safe_write16(uint64_t offset, uint16_t value) override;
+    void safe_write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout = {}) override;
 
-    uint16_t safe_read16(uint64_t offset) override;
+    uint16_t safe_read16(uint64_t offset, const std::function<bool()>& on_timeout = {}) override;
 
 private:
     /**

--- a/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
@@ -49,9 +49,8 @@ public:
     virtual void bar_write32(uint32_t addr, uint32_t data) = 0;
     virtual uint32_t bar_read32(uint32_t addr) = 0;
 
-    // Hook for the timed MMIO path: invoked (with the in-flight op's NOC) when a single op exceeds its
-    // per-op budget. Returns true if that NOC is confirmed hung (abort the transfer with
-    // DeviceTimeoutError), false to treat the slow op as a false positive and continue.
+    // Sets the hang check invoked on an IO-op timeout: returns true if the in-flight NOC is hung (abort),
+    // false to continue.
     virtual void set_io_timeout_callback(const std::function<bool(NocId)>& hang_check) = 0;
 };
 

--- a/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/xy_pair.hpp"
@@ -47,6 +48,11 @@ public:
 
     virtual void bar_write32(uint32_t addr, uint32_t data) = 0;
     virtual uint32_t bar_read32(uint32_t addr) = 0;
+
+    // Hook for the timed MMIO path: invoked (with the in-flight op's NOC) when a single op exceeds its
+    // per-op budget. Returns true if that NOC is confirmed hung (abort the transfer with
+    // DeviceTimeoutError), false to treat the slow op as a false positive and continue.
+    virtual void set_io_timeout_callback(const std::function<bool(NocId)>& hang_check) = 0;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -99,9 +99,8 @@ private:
     std::unique_ptr<TlbWindow> cached_tlb_window_;
     std::unique_ptr<TlbWindow> cached_dma_tlb_window_;
 
-    // Hang check forwarded per-call to the cached window's timed memcpy path. The in-flight op's NOC is
-    // bound into a per-call lambda at each I/O call site, so the check probes the right NOC. Empty until a
-    // HangDetector is wired in (see TTDevice::set_hang_detector); while empty, an overrun throws.
+    // Hang check consulted on an IO-op timeout; empty until a HangDetector is wired in (see
+    // TTDevice::set_hang_detector).
     std::function<bool(NocId)> hang_check_;
 };
 

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -50,6 +51,7 @@ public:
     int get_mmio_id() override;
 
     // PcieInterface.
+    void set_io_timeout_callback(const std::function<bool(NocId)>& hang_check) override;
     PCIDevice* get_pci_device() override;
     [[nodiscard]] bool dma_write_to_device(
         const void* src, size_t size, tt_xy_pair core, uint64_t addr, NocId noc_id) override;
@@ -96,6 +98,11 @@ private:
     std::mutex dma_mutex_;
     std::unique_ptr<TlbWindow> cached_tlb_window_;
     std::unique_ptr<TlbWindow> cached_dma_tlb_window_;
+
+    // Hang check forwarded per-call to the cached window's timed memcpy path. The in-flight op's NOC is
+    // bound into a per-call lambda at each I/O call site, so the check probes the right NOC. Empty until a
+    // HangDetector is wired in (see TTDevice::set_hang_detector); while empty, an overrun throws.
+    std::function<bool(NocId)> hang_check_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -517,7 +517,8 @@ protected:
 
     virtual uint32_t get_max_dram_retrain_attempts() const { return 0; }
 
-    void set_hang_detector(std::unique_ptr<HangDetector> hang_detector) { hang_detector_ = std::move(hang_detector); }
+    // Installs the hang detector and, on PCIe, wires it to the per-op MMIO timeout path.
+    void set_hang_detector(std::unique_ptr<HangDetector> hang_detector);
 
     bool is_remote_tt_device = false;
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -517,7 +517,6 @@ protected:
 
     virtual uint32_t get_max_dram_retrain_attempts() const { return 0; }
 
-    // Installs the hang detector and, on PCIe, wires it to the per-op MMIO timeout path.
     void set_hang_detector(std::unique_ptr<HangDetector> hang_detector);
 
     bool is_remote_tt_device = false;

--- a/device/api/umd/device/utils/mmio_timeout_config.hpp
+++ b/device/api/umd/device/utils/mmio_timeout_config.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+
+#include "umd/device/utils/timeouts.hpp"
+
+namespace tt::umd {
+
+/**
+ * @brief Runtime-configurable per-op budget for host-side MMIO (TLB-mapped) transfers.
+ *
+ * The per-op MMIO timeout is still being tuned, so the budget is settable at runtime via this small
+ * setter/getter instead of a constant. A programmatic setter (rather than an env var) is discoverable,
+ * strongly typed, testable, and does not leak across processes; callers set it explicitly from their
+ * code (or from Python). Once the right default settles this class can be deleted in favor of the
+ * timeout::MMIO_OP_TIMEOUT constant. Defaults to timeout::MMIO_OP_TIMEOUT.
+ */
+class MmioTimeoutConfig {
+public:
+    static void set_op_timeout(std::chrono::milliseconds timeout) {
+        op_timeout_ms_.store(timeout.count(), std::memory_order_relaxed);
+    }
+
+    static std::chrono::milliseconds get_op_timeout() {
+        return std::chrono::milliseconds(op_timeout_ms_.load(std::memory_order_relaxed));
+    }
+
+private:
+    inline static std::atomic<std::chrono::milliseconds::rep> op_timeout_ms_{timeout::MMIO_OP_TIMEOUT.count()};
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/utils/mmio_timeout_config.hpp
+++ b/device/api/umd/device/utils/mmio_timeout_config.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 
@@ -14,16 +15,15 @@ namespace tt::umd {
 /**
  * @brief Runtime-configurable per-op budget for host-side MMIO (TLB-mapped) transfers.
  *
- * The per-op MMIO timeout is still being tuned, so the budget is settable at runtime via this small
- * setter/getter instead of a constant. A programmatic setter (rather than an env var) is discoverable,
- * strongly typed, testable, and does not leak across processes; callers set it explicitly from their
- * code (or from Python). Once the right default settles this class can be deleted in favor of the
- * timeout::MMIO_OP_TIMEOUT constant. Defaults to timeout::MMIO_OP_TIMEOUT.
+ * Defaults to timeout::MMIO_OP_TIMEOUT; set_op_timeout overrides it at runtime. A non-positive budget
+ * disables the per-op MMIO timeout.
  */
 class MmioTimeoutConfig {
 public:
     static void set_op_timeout(std::chrono::milliseconds timeout) {
-        op_timeout_ms_.store(timeout.count(), std::memory_order_relaxed);
+        // Clamp non-positive budgets to 0 (disabled); a negative budget would otherwise make every op
+        // look over budget.
+        op_timeout_ms_.store(std::max<std::chrono::milliseconds::rep>(0, timeout.count()), std::memory_order_relaxed);
     }
 
     static std::chrono::milliseconds get_op_timeout() {

--- a/device/api/umd/device/utils/timeouts.hpp
+++ b/device/api/umd/device/utils/timeouts.hpp
@@ -10,10 +10,11 @@ namespace tt::umd::timeout {
 inline constexpr auto NON_MMIO_RW_TIMEOUT = std::chrono::milliseconds(5'000);
 
 // Default per-op budget for a single host-side MMIO (TLB-mapped) transfer, overridable at runtime via
-// MmioTimeoutConfig::set_op_timeout. A healthy 4-byte MMIO op is microseconds, but on a contended/
-// virtualized host a single op can stall for ~12 ms; 100 ms leaves ample margin over that while staying
-// well below the ~700 ms latency of a read on a hung NOC, so genuine hangs are still caught promptly.
-inline constexpr auto MMIO_OP_TIMEOUT = std::chrono::milliseconds(100);
+// MmioTimeoutConfig::set_op_timeout. A healthy MMIO op is microseconds. On the production path a longer
+// transient stall is absorbed by the hang-detector veto (a healthy NOC lets the op continue), so the
+// budget is kept tight to catch a genuinely hung NOC quickly. Paths that drive a TLB window without a
+// veto wired (e.g. raw SiliconTlbWindow in tests) should widen it via MmioTimeoutConfig.
+inline constexpr auto MMIO_OP_TIMEOUT = std::chrono::milliseconds(2);
 
 inline constexpr auto ARC_MESSAGE_TIMEOUT = std::chrono::milliseconds(1'000);
 // ARC clears the interrupt trigger bit quickly; this just guards against concurrent

--- a/device/api/umd/device/utils/timeouts.hpp
+++ b/device/api/umd/device/utils/timeouts.hpp
@@ -10,8 +10,10 @@ namespace tt::umd::timeout {
 inline constexpr auto NON_MMIO_RW_TIMEOUT = std::chrono::milliseconds(5'000);
 
 // Default per-op budget for a single host-side MMIO (TLB-mapped) transfer, overridable at runtime via
-// MmioTimeoutConfig::set_op_timeout. Set to 2 ms, the measured cost of a 4-byte MMIO op.
-inline constexpr auto MMIO_OP_TIMEOUT = std::chrono::milliseconds(2);
+// MmioTimeoutConfig::set_op_timeout. A healthy 4-byte MMIO op is microseconds, but on a contended/
+// virtualized host a single op can stall for ~12 ms; 100 ms leaves ample margin over that while staying
+// well below the ~700 ms latency of a read on a hung NOC, so genuine hangs are still caught promptly.
+inline constexpr auto MMIO_OP_TIMEOUT = std::chrono::milliseconds(100);
 
 inline constexpr auto ARC_MESSAGE_TIMEOUT = std::chrono::milliseconds(1'000);
 // ARC clears the interrupt trigger bit quickly; this just guards against concurrent

--- a/device/api/umd/device/utils/timeouts.hpp
+++ b/device/api/umd/device/utils/timeouts.hpp
@@ -9,6 +9,10 @@
 namespace tt::umd::timeout {
 inline constexpr auto NON_MMIO_RW_TIMEOUT = std::chrono::milliseconds(5'000);
 
+// Default per-op budget for a single host-side MMIO (TLB-mapped) transfer, overridable at runtime via
+// MmioTimeoutConfig::set_op_timeout. Set to 2 ms, the measured cost of a 4-byte MMIO op.
+inline constexpr auto MMIO_OP_TIMEOUT = std::chrono::milliseconds(2);
+
 inline constexpr auto ARC_MESSAGE_TIMEOUT = std::chrono::milliseconds(1'000);
 // ARC clears the interrupt trigger bit quickly; this just guards against concurrent
 // processes/threads opening clusters, which causes KMD to send ARC messages that

--- a/device/api/umd/device/utils/timeouts.hpp
+++ b/device/api/umd/device/utils/timeouts.hpp
@@ -10,11 +10,11 @@ namespace tt::umd::timeout {
 inline constexpr auto NON_MMIO_RW_TIMEOUT = std::chrono::milliseconds(5'000);
 
 // Default per-op budget for a single host-side MMIO (TLB-mapped) transfer, overridable at runtime via
-// MmioTimeoutConfig::set_op_timeout. A healthy MMIO op is microseconds. On the production path a longer
-// transient stall is absorbed by the hang-detector veto (a healthy NOC lets the op continue), so the
-// budget is kept tight to catch a genuinely hung NOC quickly. Paths that drive a TLB window without a
-// veto wired (e.g. raw SiliconTlbWindow in tests) should widen it via MmioTimeoutConfig.
-inline constexpr auto MMIO_OP_TIMEOUT = std::chrono::milliseconds(2);
+// MmioTimeoutConfig::set_op_timeout. A healthy MMIO op is microseconds, but on a contended/virtualized
+// host (e.g. a viommu CI runner) a single op can take several ms; 10 ms sits above that floor so the
+// hang-detector veto's own probe read completes and a slow-but-healthy op continues, while staying well
+// below the ~700 ms latency of a read on a hung NOC so genuine hangs are still caught promptly.
+inline constexpr auto MMIO_OP_TIMEOUT = std::chrono::milliseconds(10);
 
 inline constexpr auto ARC_MESSAGE_TIMEOUT = std::chrono::milliseconds(1'000);
 // ARC clears the interrupt trigger bit quickly; this just guards against concurrent

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -257,11 +257,11 @@ void LocalChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_des
 
     if (tlb_manager_->is_tlb_mapped(translated_core, l1_dest, size)) {
         TlbWindow* tlb_window = tlb_manager_->get_tlb_window(translated_core);
-        tlb_window->write_block(l1_dest - tlb_window->get_base_address(), src, size, make_io_timeout_callback());
+        tlb_window->write_block(l1_dest - tlb_window->get_base_address(), src, size);
     } else {
         std::lock_guard<std::mutex> lock(wc_tlb_lock);
         get_cached_wc_tlb_window()->write_block_reconfigure(
-            src, translated_core, l1_dest, size, get_selected_noc_id(), tlb_data::Relaxed, make_io_timeout_callback());
+            src, translated_core, l1_dest, size, get_selected_noc_id(), tlb_data::Relaxed);
     }
 }
 
@@ -283,11 +283,11 @@ void LocalChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, si
     }
     if (tlb_manager_->is_tlb_mapped(translated_core, l1_src, size)) {
         TlbWindow* tlb_window = tlb_manager_->get_tlb_window(translated_core);
-        tlb_window->read_block(l1_src - tlb_window->get_base_address(), dest, size, make_io_timeout_callback());
+        tlb_window->read_block(l1_src - tlb_window->get_base_address(), dest, size);
     } else {
         std::lock_guard<std::mutex> lock(wc_tlb_lock);
         get_cached_wc_tlb_window()->read_block_reconfigure(
-            dest, translated_core, l1_src, size, get_selected_noc_id(), tlb_data::Relaxed, make_io_timeout_callback());
+            dest, translated_core, l1_src, size, get_selected_noc_id(), tlb_data::Relaxed);
     }
 }
 
@@ -330,7 +330,7 @@ void LocalChip::write_to_device_reg(CoreCoord core, const void* src, uint64_t re
     TlbWindow* tlb_window = get_cached_uc_tlb_window();
     tlb_window->configure(config);
 
-    tlb_window->write_register(reg_dest - tlb_window->get_base_address(), src, size, make_io_timeout_callback());
+    tlb_window->write_register(reg_dest - tlb_window->get_base_address(), src, size);
 }
 
 void LocalChip::read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_src, uint32_t size) {
@@ -361,17 +361,15 @@ void LocalChip::read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_sr
     TlbWindow* tlb_window = get_cached_uc_tlb_window();
     tlb_window->configure(config);
 
-    tlb_window->read_register(reg_src - tlb_window->get_base_address(), dest, size, make_io_timeout_callback());
+    tlb_window->read_register(reg_src - tlb_window->get_base_address(), dest, size);
 }
 
-std::function<bool()> LocalChip::make_io_timeout_callback() {
-    // Consulted only on a per-op MMIO overrun (see OpTimeoutGuard), as the guard's false-alarm veto.
-    // Evaluate the NOC selection at call time so the check tracks the in-flight op's NOC. Returning true
-    // (NOC healthy, not hung) declares the overrun a false alarm and lets a slow-but-completing op
-    // through; returning false (NOC hung) confirms the timeout and aborts with DeviceTimeoutError. The
-    // hang check reads through an independent, separately-locked window, so it does not re-enter this
-    // op's TLB lock.
-    return [this]() -> bool { return !tt_device_->is_noc_hung(get_selected_noc_id(), TTDevice::HangAction::RETURN); };
+std::function<bool(NocId)> LocalChip::make_io_timeout_hang_check() {
+    // Installed on the cached TLB windows so the per-op MMIO timeout path can consult NOC liveness on an
+    // overrun (see SiliconTlbWindow / OpTimeoutGuard). Returns whether the given NOC is hung; the window
+    // turns that into the guard's false-alarm veto. The hang check reads through an independent,
+    // separately-locked window, so it does not re-enter this op's TLB lock.
+    return [this](NocId noc) -> bool { return tt_device_->is_noc_hung(noc, TTDevice::HangAction::RETURN); };
 }
 
 void LocalChip::wait_for_non_mmio_flush() {}
@@ -537,8 +535,11 @@ int LocalChip::get_numa_node() { return tt_device_->get_pci_device()->get_numa_n
 
 TlbWindow* LocalChip::get_cached_wc_tlb_window() {
     if (cached_wc_tlb_window == nullptr) {
-        cached_wc_tlb_window = std::make_unique<SiliconTlbWindow>(get_tt_device()->get_pci_device()->allocate_tlb(
-            get_tt_device()->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::WC));
+        cached_wc_tlb_window = std::make_unique<SiliconTlbWindow>(
+            get_tt_device()->get_pci_device()->allocate_tlb(
+                get_tt_device()->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::WC),
+            tlb_data{},
+            make_io_timeout_hang_check());
         return cached_wc_tlb_window.get();
     }
 
@@ -547,8 +548,11 @@ TlbWindow* LocalChip::get_cached_wc_tlb_window() {
 
 TlbWindow* LocalChip::get_cached_uc_tlb_window() {
     if (cached_uc_tlb_window == nullptr) {
-        cached_uc_tlb_window = std::make_unique<SiliconTlbWindow>(get_tt_device()->get_pci_device()->allocate_tlb(
-            get_tt_device()->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::UC));
+        cached_uc_tlb_window = std::make_unique<SiliconTlbWindow>(
+            get_tt_device()->get_pci_device()->allocate_tlb(
+                get_tt_device()->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::UC),
+            tlb_data{},
+            make_io_timeout_hang_check());
         return cached_uc_tlb_window.get();
     }
 

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -7,6 +7,7 @@
 #include <fmt/format.h>
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -256,11 +257,11 @@ void LocalChip::write_to_device(CoreCoord core, const void* src, uint64_t l1_des
 
     if (tlb_manager_->is_tlb_mapped(translated_core, l1_dest, size)) {
         TlbWindow* tlb_window = tlb_manager_->get_tlb_window(translated_core);
-        tlb_window->write_block(l1_dest - tlb_window->get_base_address(), src, size);
+        tlb_window->write_block(l1_dest - tlb_window->get_base_address(), src, size, make_io_timeout_callback());
     } else {
         std::lock_guard<std::mutex> lock(wc_tlb_lock);
         get_cached_wc_tlb_window()->write_block_reconfigure(
-            src, translated_core, l1_dest, size, get_selected_noc_id(), tlb_data::Relaxed);
+            src, translated_core, l1_dest, size, get_selected_noc_id(), tlb_data::Relaxed, make_io_timeout_callback());
     }
 }
 
@@ -282,11 +283,11 @@ void LocalChip::read_from_device(CoreCoord core, void* dest, uint64_t l1_src, si
     }
     if (tlb_manager_->is_tlb_mapped(translated_core, l1_src, size)) {
         TlbWindow* tlb_window = tlb_manager_->get_tlb_window(translated_core);
-        tlb_window->read_block(l1_src - tlb_window->get_base_address(), dest, size);
+        tlb_window->read_block(l1_src - tlb_window->get_base_address(), dest, size, make_io_timeout_callback());
     } else {
         std::lock_guard<std::mutex> lock(wc_tlb_lock);
         get_cached_wc_tlb_window()->read_block_reconfigure(
-            dest, translated_core, l1_src, size, get_selected_noc_id(), tlb_data::Relaxed);
+            dest, translated_core, l1_src, size, get_selected_noc_id(), tlb_data::Relaxed, make_io_timeout_callback());
     }
 }
 
@@ -329,7 +330,7 @@ void LocalChip::write_to_device_reg(CoreCoord core, const void* src, uint64_t re
     TlbWindow* tlb_window = get_cached_uc_tlb_window();
     tlb_window->configure(config);
 
-    tlb_window->write_register(reg_dest - tlb_window->get_base_address(), src, size);
+    tlb_window->write_register(reg_dest - tlb_window->get_base_address(), src, size, make_io_timeout_callback());
 }
 
 void LocalChip::read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_src, uint32_t size) {
@@ -360,7 +361,16 @@ void LocalChip::read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_sr
     TlbWindow* tlb_window = get_cached_uc_tlb_window();
     tlb_window->configure(config);
 
-    tlb_window->read_register(reg_src - tlb_window->get_base_address(), dest, size);
+    tlb_window->read_register(reg_src - tlb_window->get_base_address(), dest, size, make_io_timeout_callback());
+}
+
+std::function<bool()> LocalChip::make_io_timeout_callback() {
+    // Consulted only on a per-op MMIO overrun (see OpTimeoutGuard). Evaluate the NOC selection at call
+    // time so the check tracks the in-flight op's NOC. Returning true (NOC hung) confirms the timeout and
+    // aborts with DeviceTimeoutError; false (healthy) vetoes it so a slow-but-completing op is not a false
+    // positive. The hang check reads through an independent, separately-locked window, so it does not
+    // re-enter this op's TLB lock.
+    return [this]() -> bool { return tt_device_->is_noc_hung(get_selected_noc_id(), TTDevice::HangAction::RETURN); };
 }
 
 void LocalChip::wait_for_non_mmio_flush() {}

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -365,10 +365,6 @@ void LocalChip::read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_sr
 }
 
 std::function<bool(NocId)> LocalChip::make_io_timeout_hang_check() {
-    // Installed on the cached TLB windows so the per-op MMIO timeout path can consult NOC liveness on an
-    // overrun (see SiliconTlbWindow / OpTimeoutGuard). Returns whether the given NOC is hung; the window
-    // turns that into the guard's false-alarm veto. The hang check reads through an independent,
-    // separately-locked window, so it does not re-enter this op's TLB lock.
     return [this](NocId noc) -> bool { return tt_device_->is_noc_hung(noc, TTDevice::HangAction::RETURN); };
 }
 
@@ -535,11 +531,9 @@ int LocalChip::get_numa_node() { return tt_device_->get_pci_device()->get_numa_n
 
 TlbWindow* LocalChip::get_cached_wc_tlb_window() {
     if (cached_wc_tlb_window == nullptr) {
-        cached_wc_tlb_window = std::make_unique<SiliconTlbWindow>(
-            get_tt_device()->get_pci_device()->allocate_tlb(
-                get_tt_device()->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::WC),
-            tlb_data{},
-            make_io_timeout_hang_check());
+        cached_wc_tlb_window = std::make_unique<SiliconTlbWindow>(get_tt_device()->get_pci_device()->allocate_tlb(
+            get_tt_device()->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::WC));
+        cached_wc_tlb_window->set_io_timeout_hang_check(make_io_timeout_hang_check());
         return cached_wc_tlb_window.get();
     }
 
@@ -548,11 +542,9 @@ TlbWindow* LocalChip::get_cached_wc_tlb_window() {
 
 TlbWindow* LocalChip::get_cached_uc_tlb_window() {
     if (cached_uc_tlb_window == nullptr) {
-        cached_uc_tlb_window = std::make_unique<SiliconTlbWindow>(
-            get_tt_device()->get_pci_device()->allocate_tlb(
-                get_tt_device()->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::UC),
-            tlb_data{},
-            make_io_timeout_hang_check());
+        cached_uc_tlb_window = std::make_unique<SiliconTlbWindow>(get_tt_device()->get_pci_device()->allocate_tlb(
+            get_tt_device()->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::UC));
+        cached_uc_tlb_window->set_io_timeout_hang_check(make_io_timeout_hang_check());
         return cached_uc_tlb_window.get();
     }
 

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -365,12 +365,13 @@ void LocalChip::read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_sr
 }
 
 std::function<bool()> LocalChip::make_io_timeout_callback() {
-    // Consulted only on a per-op MMIO overrun (see OpTimeoutGuard). Evaluate the NOC selection at call
-    // time so the check tracks the in-flight op's NOC. Returning true (NOC hung) confirms the timeout and
-    // aborts with DeviceTimeoutError; false (healthy) vetoes it so a slow-but-completing op is not a false
-    // positive. The hang check reads through an independent, separately-locked window, so it does not
-    // re-enter this op's TLB lock.
-    return [this]() -> bool { return tt_device_->is_noc_hung(get_selected_noc_id(), TTDevice::HangAction::RETURN); };
+    // Consulted only on a per-op MMIO overrun (see OpTimeoutGuard), as the guard's false-alarm veto.
+    // Evaluate the NOC selection at call time so the check tracks the in-flight op's NOC. Returning true
+    // (NOC healthy, not hung) declares the overrun a false alarm and lets a slow-but-completing op
+    // through; returning false (NOC hung) confirms the timeout and aborts with DeviceTimeoutError. The
+    // hang check reads through an independent, separately-locked window, so it does not re-enter this
+    // op's TLB lock.
+    return [this]() -> bool { return !tt_device_->is_noc_hung(get_selected_noc_id(), TTDevice::HangAction::RETURN); };
 }
 
 void LocalChip::wait_for_non_mmio_flush() {}

--- a/device/chip_helpers/tlb_manager.cpp
+++ b/device/chip_helpers/tlb_manager.cpp
@@ -97,7 +97,14 @@ tlb_configuration TLBManager::get_tlb_configuration(tt_xy_pair core) {
 std::unique_ptr<TlbWindow> TLBManager::allocate_tlb_window(
     tlb_data config, const TlbMapping mapping, const size_t tlb_size) {
     ZoneScopedC(tracy::Color::Cyan);
-    return tt_device_->get_io_window(config, mapping, tlb_size);
+    std::unique_ptr<TlbWindow> tlb_window = tt_device_->get_io_window(config, mapping, tlb_size);
+    // Statically-mapped windows do device memory I/O, so they carry the same per-op MMIO timeout hang
+    // check as the cached windows (see SiliconTlbWindow). Set once at creation rather than per op, so the
+    // shared window's state is not mutated on the I/O path.
+    TTDevice* tt_device = tt_device_;
+    tlb_window->set_io_timeout_hang_check(
+        [tt_device](NocId noc) -> bool { return tt_device->is_noc_hung(noc, TTDevice::HangAction::RETURN); });
+    return tlb_window;
 }
 
 void TLBManager::clear_mapped_tlbs() {

--- a/device/pcie/device_memcpy.cpp
+++ b/device/pcie/device_memcpy.cpp
@@ -21,12 +21,10 @@ namespace tt::umd {
 
 namespace {
 
-// Builds the per-op timeout guard for the MMIO transfer routines: the configured budget plus the
-// optional liveness veto, with an overrun action that throws DeviceTimeoutError. `bytes_remaining` is
-// captured by reference so the error reflects how much was left when the stall fired.
-//
-// The veto must not re-enter the stalled op: it must not re-take its I/O lock or loop back into this
-// path, and any device I/O it does must go through an independent path (see on_timeout docs in the header).
+// Builds the per-op timeout guard for the MMIO transfer routines: the configured budget, the on_timeout
+// callback, and an overrun action that throws DeviceTimeoutError. `bytes_remaining` is captured by
+// reference so the error reflects how much was left when the stall fired. on_timeout must not re-enter
+// the stalled op (see the on_timeout docs in the header).
 auto make_mmio_timeout_guard(
     const char* op_verb,
     std::size_t total_bytes,

--- a/device/pcie/device_memcpy.cpp
+++ b/device/pcie/device_memcpy.cpp
@@ -4,8 +4,14 @@
 
 #include "device_memcpy.hpp"
 
+#include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <functional>
+
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/mmio_timeout_config.hpp"
+#include "umd/device/utils/op_timeout_guard.hpp"
 
 #if defined(__x86_64__) || defined(_M_X64)
 #include <immintrin.h>
@@ -13,42 +19,103 @@
 
 namespace tt::umd {
 
-void write16_to_device(volatile void* dest, std::uint16_t value) {
+namespace {
+
+// Builds the per-op timeout guard for the MMIO transfer routines: the configured budget plus the
+// optional liveness veto, with an overrun action that throws DeviceTimeoutError. `bytes_remaining` is
+// captured by reference so the error reflects how much was left when the stall fired.
+//
+// The veto must not re-enter the stalled op: it must not re-take its I/O lock or loop back into this
+// path, and any device I/O it does must go through an independent path (see on_timeout docs in the header).
+auto make_mmio_timeout_guard(
+    const char* op_verb,
+    std::size_t total_bytes,
+    const std::size_t& bytes_remaining,
+    const std::function<bool()>& on_timeout) {
+    const auto budget = MmioTimeoutConfig::get_op_timeout();
+    return OpTimeoutGuard(
+        budget,
+        on_timeout,
+        [op_verb, budget, total_bytes, &bytes_remaining](std::chrono::nanoseconds delta, std::uint32_t op_bytes) {
+            UMD_THROW(error::DeviceTimeoutError, op_verb, op_bytes, delta, budget, bytes_remaining, total_bytes);
+        });
+}
+
+}  // namespace
+
+// The single-word scalar transfers below get the same per-op budget as the bulk memcpy paths:
+// the volatile store/load is bracketed by a steady_clock sample and checked via the timeout guard, so
+// a slow-but-completing op (e.g. a ~700 ms read of a hung NOC register) trips the timeout instead of
+// silently returning. The check brackets each op, so it bounds a slow-but-completing access but cannot
+// preempt a CPU already stalled mid-access; SIGBUS covers only mapping invalidation (e.g. on reset),
+// not a stall.
+void write16_to_device(volatile void* dest, std::uint16_t value, const std::function<bool()>& on_timeout) {
+    std::size_t remaining = sizeof(value);
+    auto timer = make_mmio_timeout_guard("store", sizeof(value), remaining, on_timeout);
+    auto t = std::chrono::steady_clock::now();
     *reinterpret_cast<volatile std::uint16_t*>(dest) = value;
+    remaining = 0;
+    timer.record_and_check(t, sizeof(value));
 }
 
-void write32_to_device(volatile void* dest, std::uint32_t value) {
+void write32_to_device(volatile void* dest, std::uint32_t value, const std::function<bool()>& on_timeout) {
+    std::size_t remaining = sizeof(value);
+    auto timer = make_mmio_timeout_guard("store", sizeof(value), remaining, on_timeout);
+    auto t = std::chrono::steady_clock::now();
     *reinterpret_cast<volatile std::uint32_t*>(dest) = value;
+    remaining = 0;
+    timer.record_and_check(t, sizeof(value));
 }
 
-std::uint16_t read16_from_device(const volatile void* src) {
-    return *reinterpret_cast<const volatile std::uint16_t*>(src);
+std::uint16_t read16_from_device(const volatile void* src, const std::function<bool()>& on_timeout) {
+    std::size_t remaining = sizeof(std::uint16_t);
+    auto timer = make_mmio_timeout_guard("load", sizeof(std::uint16_t), remaining, on_timeout);
+    auto t = std::chrono::steady_clock::now();
+    std::uint16_t value = *reinterpret_cast<const volatile std::uint16_t*>(src);
+    remaining = 0;
+    timer.record_and_check(t, sizeof(value));
+    return value;
 }
 
-std::uint32_t read32_from_device(const volatile void* src) {
-    return *reinterpret_cast<const volatile std::uint32_t*>(src);
+std::uint32_t read32_from_device(const volatile void* src, const std::function<bool()>& on_timeout) {
+    std::size_t remaining = sizeof(std::uint32_t);
+    auto timer = make_mmio_timeout_guard("load", sizeof(std::uint32_t), remaining, on_timeout);
+    auto t = std::chrono::steady_clock::now();
+    std::uint32_t value = *reinterpret_cast<const volatile std::uint32_t*>(src);
+    remaining = 0;
+    timer.record_and_check(t, sizeof(value));
+    return value;
 }
 
-void memcpy_to_device(volatile void* dest, const void* src, std::size_t size) {
+void memcpy_to_device(volatile void* dest, const void* src, std::size_t size, const std::function<bool()>& on_timeout) {
+    const std::size_t original_size = size;
     auto* d = static_cast<volatile std::uint8_t*>(dest);
     auto* s = static_cast<const std::uint8_t*>(src);
 
+    auto timer = make_mmio_timeout_guard("store", original_size, size, on_timeout);
+
     // Phase 0: Align device destination to 4 bytes using byte-wide volatile stores.
     while (size > 0 && (reinterpret_cast<std::uintptr_t>(d) % 4) != 0) {
+        auto t = std::chrono::steady_clock::now();
         *d++ = *s++;
         size--;
+        timer.record_and_check(t, 1);
     }
 
 #if defined(__x86_64__) || defined(_M_X64)
-    // The AVX2 intrinsics below are not themselves volatile, so the compiler is free to
-    // reorder them relative to other non-volatile accesses. The volatile byte/4-byte loops
-    // in Phases 0/4/5 bound the reordering window for this function.
+    // The AVX2 intrinsics below are not themselves volatile. Each record_and_check() call
+    // is an opaque function call and therefore acts as a compiler barrier — it prevents
+    // the compiler from reordering the volatile-conceptual SIMD store around it. The
+    // bulk loop checks the timeout once per 256-byte block (after all 8 unrolled AVX2
+    // stores), keeping the store pipeline intact within a block. The explicit volatile
+    // loops in Phases 0/4/5 still bound the ordering for the byte/word tails.
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast).
     auto* d_simd = const_cast<std::uint8_t*>(static_cast<const volatile std::uint8_t*>(d));
 
     // Phase 1: Bulk 256-byte blocks (8 x 32-byte AVX2 unaligned stores).
     // After this loop, 0 <= size < 256; remaining bytes are handled by Phases 2-5.
     while (size >= 256) {
+        // Loads are from host memory (s) — no TLB access, not instrumented.
         __m256i v0 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s));
         __m256i v1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + 32));
         __m256i v2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + 64));
@@ -58,6 +125,11 @@ void memcpy_to_device(volatile void* dest, const void* src, std::size_t size) {
         __m256i v6 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + 192));
         __m256i v7 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + 224));
 
+        // All 8 stores go to TLB-mapped device memory. One timeout check after the
+        // whole 256-byte block keeps the AVX2 store pipeline intact while still
+        // detecting any stall — a single posted-write pile-up will stall the CPU
+        // mid-block and the check fires once the block completes.
+        auto t = std::chrono::steady_clock::now();
         _mm256_storeu_si256(reinterpret_cast<__m256i*>(d_simd), v0);
         _mm256_storeu_si256(reinterpret_cast<__m256i*>(d_simd + 32), v1);
         _mm256_storeu_si256(reinterpret_cast<__m256i*>(d_simd + 64), v2);
@@ -66,6 +138,7 @@ void memcpy_to_device(volatile void* dest, const void* src, std::size_t size) {
         _mm256_storeu_si256(reinterpret_cast<__m256i*>(d_simd + 160), v5);
         _mm256_storeu_si256(reinterpret_cast<__m256i*>(d_simd + 192), v6);
         _mm256_storeu_si256(reinterpret_cast<__m256i*>(d_simd + 224), v7);
+        timer.record_and_check(t, 256);
 
         d_simd += 256;
         s += 256;
@@ -75,7 +148,9 @@ void memcpy_to_device(volatile void* dest, const void* src, std::size_t size) {
     // Phase 2: Remaining 32-byte chunks.
     while (size >= 32) {
         __m256i v = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s));
+        auto t = std::chrono::steady_clock::now();
         _mm256_storeu_si256(reinterpret_cast<__m256i*>(d_simd), v);
+        timer.record_and_check(t, 32);
         d_simd += 32;
         s += 32;
         size -= 32;
@@ -84,7 +159,9 @@ void memcpy_to_device(volatile void* dest, const void* src, std::size_t size) {
     // Phase 3: Remaining 16-byte chunk.
     if (size >= 16) {
         __m128i v = _mm_loadu_si128(reinterpret_cast<const __m128i*>(s));
+        auto t = std::chrono::steady_clock::now();
         _mm_storeu_si128(reinterpret_cast<__m128i*>(d_simd), v);
+        timer.record_and_check(t, 16);
         d_simd += 16;
         s += 16;
         size -= 16;
@@ -182,7 +259,9 @@ void memcpy_to_device(volatile void* dest, const void* src, std::size_t size) {
     while (size >= 4) {
         std::uint32_t tmp;
         std::memcpy(&tmp, s, sizeof(tmp));
+        auto t = std::chrono::steady_clock::now();
         *reinterpret_cast<volatile std::uint32_t*>(d) = tmp;
+        timer.record_and_check(t, 4);
         d += 4;
         s += 4;
         size -= 4;
@@ -190,31 +269,45 @@ void memcpy_to_device(volatile void* dest, const void* src, std::size_t size) {
 
     // Phase 5: Trailing bytes (0-3) using byte-wide volatile stores.
     while (size > 0) {
+        auto t = std::chrono::steady_clock::now();
         *d++ = *s++;
         size--;
+        timer.record_and_check(t, 1);
     }
 }
 
-void memcpy_from_device(void* dest, const volatile void* src, std::size_t size) {
+void memcpy_from_device(
+    void* dest, const volatile void* src, std::size_t size, const std::function<bool()>& on_timeout) {
+    const std::size_t original_size = size;
     auto* d = static_cast<std::uint8_t*>(dest);
     auto* s = static_cast<const volatile std::uint8_t*>(src);
 
+    auto timer = make_mmio_timeout_guard("load", original_size, size, on_timeout);
+
     // Phase 0: Align device source to 4 bytes using byte-wide volatile loads.
     while (size > 0 && (reinterpret_cast<std::uintptr_t>(s) % 4) != 0) {
+        auto t = std::chrono::steady_clock::now();
         *d++ = *s++;
         size--;
+        timer.record_and_check(t, 1);
     }
 
 #if defined(__x86_64__) || defined(_M_X64)
-    // The AVX2 intrinsics below are not themselves volatile, so the compiler is free to
-    // reorder them relative to other non-volatile accesses. The volatile byte/4-byte loops
-    // in Phases 0/4/5 bound the reordering window for this function.
+    // See memcpy_to_device for the volatile-ordering / compiler-barrier reasoning.
+    // The bulk loop checks the timeout once per 256-byte block (after all 8 unrolled
+    // AVX2 loads), so the CPU can keep 8 non-posted PCIe reads in flight concurrently
+    // within a block. Coarser checks in the tail phases (1 per 32/16/4/byte op) keep
+    // detection responsive even at sub-256-byte granularity.
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast).
     auto* s_simd = const_cast<std::uint8_t*>(static_cast<const volatile std::uint8_t*>(s));
 
     // Phase 1: Bulk 256-byte blocks (8 x 32-byte AVX2 unaligned loads).
     // After this loop, 0 <= size < 256; remaining bytes are handled by Phases 2-5.
     while (size >= 256) {
+        // All 8 loads come from TLB-mapped device memory. One timeout check after the
+        // whole 256-byte block restores the 8-way non-posted-read pipeline (the CPU can
+        // have up to 8 reads outstanding concurrently) while still detecting any stall.
+        auto t = std::chrono::steady_clock::now();
         __m256i v0 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s_simd));
         __m256i v1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s_simd + 32));
         __m256i v2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s_simd + 64));
@@ -223,7 +316,9 @@ void memcpy_from_device(void* dest, const volatile void* src, std::size_t size) 
         __m256i v5 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s_simd + 160));
         __m256i v6 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s_simd + 192));
         __m256i v7 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s_simd + 224));
+        timer.record_and_check(t, 256);
 
+        // Stores go to host memory (d) — no TLB access, not instrumented.
         _mm256_storeu_si256(reinterpret_cast<__m256i*>(d), v0);
         _mm256_storeu_si256(reinterpret_cast<__m256i*>(d + 32), v1);
         _mm256_storeu_si256(reinterpret_cast<__m256i*>(d + 64), v2);
@@ -240,7 +335,9 @@ void memcpy_from_device(void* dest, const volatile void* src, std::size_t size) 
 
     // Phase 2: Remaining 32-byte chunks.
     while (size >= 32) {
+        auto t = std::chrono::steady_clock::now();
         __m256i v = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s_simd));
+        timer.record_and_check(t, 32);
         _mm256_storeu_si256(reinterpret_cast<__m256i*>(d), v);
         d += 32;
         s_simd += 32;
@@ -249,7 +346,9 @@ void memcpy_from_device(void* dest, const volatile void* src, std::size_t size) 
 
     // Phase 3: Remaining 16-byte chunk.
     if (size >= 16) {
+        auto t = std::chrono::steady_clock::now();
         __m128i v = _mm_loadu_si128(reinterpret_cast<const __m128i*>(s_simd));
+        timer.record_and_check(t, 16);
         _mm_storeu_si128(reinterpret_cast<__m128i*>(d), v);
         d += 16;
         s_simd += 16;
@@ -318,7 +417,9 @@ void memcpy_from_device(void* dest, const volatile void* src, std::size_t size) 
 
     // Phase 4: Remaining 4-byte chunks.
     while (size >= 4) {
+        auto t = std::chrono::steady_clock::now();
         std::uint32_t tmp = *reinterpret_cast<const volatile std::uint32_t*>(s);
+        timer.record_and_check(t, 4);
         std::memcpy(d, &tmp, sizeof(tmp));
         d += 4;
         s += 4;
@@ -327,8 +428,10 @@ void memcpy_from_device(void* dest, const volatile void* src, std::size_t size) 
 
     // Phase 5: Trailing bytes (0-3) using byte-wide volatile loads.
     while (size > 0) {
+        auto t = std::chrono::steady_clock::now();
         *d++ = *s++;
         size--;
+        timer.record_and_check(t, 1);
     }
 }
 

--- a/device/pcie/device_memcpy.hpp
+++ b/device/pcie/device_memcpy.hpp
@@ -30,8 +30,11 @@ namespace tt::umd {
  * written as individual byte-wide PCIe transactions (the Blackhole PCIe controller supports
  * sub-DWORD writes natively, so no read-modify-write is required).
  *
- * Each TLB-touching op is bounded by a per-op timeout; on overrun the optional on_timeout callback
- * decides whether to abort with tt::umd::error::DeviceTimeoutError (see the on_timeout doc above).
+ * Each TLB-touching op is bounded by a per-op timeout (MmioTimeoutConfig::get_op_timeout). The optional
+ * on_timeout callback is consulted only on an overrun: returning true marks the op a false alarm (healthy
+ * device) and the transfer continues; returning false — or omitting the callback — confirms the overrun
+ * and aborts with tt::umd::error::DeviceTimeoutError. on_timeout must not re-enter this path: it must not
+ * re-take the I/O lock, and any device probe it issues must go through an independent window.
  */
 void memcpy_to_device(
     volatile void* dest, const void* src, std::size_t size, const std::function<bool()>& on_timeout = {});
@@ -54,10 +57,9 @@ void memcpy_from_device(
     void* dest, const volatile void* src, std::size_t size, const std::function<bool()>& on_timeout = {});
 
 /**
- * Single-DWORD/word scalar transfers to/from TLB-mapped device memory. Each carries the same
- * optional per-op budget as the bulk memcpy routines: on overrun the behavior follows on_timeout
- * (no callback throws DeviceTimeoutError; see the on_timeout doc above). Centralizing them here keeps
- * every TLB-touching store/load behind a single set of timed primitives.
+ * Single-DWORD/word scalar transfers to/from TLB-mapped device memory. Each carries the same optional
+ * per-op budget as the bulk memcpy routines; the on_timeout contract matches memcpy_to_device. Centralizing
+ * them here keeps every TLB-touching store/load behind a single set of timed primitives.
  */
 void write16_to_device(volatile void* dest, std::uint16_t value, const std::function<bool()>& on_timeout = {});
 void write32_to_device(volatile void* dest, std::uint32_t value, const std::function<bool()>& on_timeout = {});

--- a/device/pcie/device_memcpy.hpp
+++ b/device/pcie/device_memcpy.hpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 
 namespace tt::umd {
 
@@ -28,8 +29,12 @@ namespace tt::umd {
  * Handles arbitrary alignment and size — leading/trailing bytes smaller than a DWORD are
  * written as individual byte-wide PCIe transactions (the Blackhole PCIe controller supports
  * sub-DWORD writes natively, so no read-modify-write is required).
+ *
+ * Each TLB-touching op is bounded by a per-op timeout; on overrun the optional on_timeout callback
+ * decides whether to abort with tt::umd::error::DeviceTimeoutError (see the on_timeout doc above).
  */
-void memcpy_to_device(volatile void* dest, const void* src, std::size_t size);
+void memcpy_to_device(
+    volatile void* dest, const void* src, std::size_t size, const std::function<bool()>& on_timeout = {});
 
 /**
  * memcpy for reads from device memory mapped through a TLB window.
@@ -42,19 +47,21 @@ void memcpy_to_device(volatile void* dest, const void* src, std::size_t size);
  *
  * On other architectures: falls back to explicit 4-byte and byte-wide volatile loads.
  *
- * Handles arbitrary alignment and size.
+ * Per-op timeout semantics match memcpy_to_device; the check falls between bulk blocks (not between
+ * individual loads), so the non-posted PCIe reads within a block still pipeline.
  */
-void memcpy_from_device(void* dest, const volatile void* src, std::size_t size);
+void memcpy_from_device(
+    void* dest, const volatile void* src, std::size_t size, const std::function<bool()>& on_timeout = {});
 
 /**
- * Single-DWORD/word scalar transfers to/from TLB-mapped device memory. Centralizing these
- * here (alongside the bulk memcpy routines) keeps every TLB-touching store/load behind a
- * single set of primitives that future improvements (per-op timeouts, instrumentation,
- * etc.) can wrap uniformly.
+ * Single-DWORD/word scalar transfers to/from TLB-mapped device memory. Each carries the same
+ * optional per-op budget as the bulk memcpy routines: on overrun the behavior follows on_timeout
+ * (no callback throws DeviceTimeoutError; see the on_timeout doc above). Centralizing them here keeps
+ * every TLB-touching store/load behind a single set of timed primitives.
  */
-void write16_to_device(volatile void* dest, std::uint16_t value);
-void write32_to_device(volatile void* dest, std::uint32_t value);
-std::uint16_t read16_from_device(const volatile void* src);
-std::uint32_t read32_from_device(const volatile void* src);
+void write16_to_device(volatile void* dest, std::uint16_t value, const std::function<bool()>& on_timeout = {});
+void write32_to_device(volatile void* dest, std::uint32_t value, const std::function<bool()>& on_timeout = {});
+std::uint16_t read16_from_device(const volatile void* src, const std::function<bool()>& on_timeout = {});
+std::uint32_t read32_from_device(const volatile void* src, const std::function<bool()>& on_timeout = {});
 
 }  // namespace tt::umd

--- a/device/pcie/rtl_sim_tlb_window.cpp
+++ b/device/pcie/rtl_sim_tlb_window.cpp
@@ -33,52 +33,38 @@ void RtlSimTlbWindow::translate_and_read(uint64_t offset, void* data, size_t siz
     communicator_->tile_read_bytes(config.x_end, config.y_end, device_addr, data, static_cast<uint32_t>(size));
 }
 
-void RtlSimTlbWindow::write16(uint64_t offset, uint16_t value, const std::function<bool()>& /*on_timeout*/) {
-    translate_and_write(offset, &value, sizeof(value));
-}
+void RtlSimTlbWindow::write16(uint64_t offset, uint16_t value) { translate_and_write(offset, &value, sizeof(value)); }
 
-uint16_t RtlSimTlbWindow::read16(uint64_t offset, const std::function<bool()>& /*on_timeout*/) {
+uint16_t RtlSimTlbWindow::read16(uint64_t offset) {
     uint16_t value = 0;
     translate_and_read(offset, &value, sizeof(value));
     return value;
 }
 
-void RtlSimTlbWindow::write32(uint64_t offset, uint32_t value, const std::function<bool()>& /*on_timeout*/) {
-    translate_and_write(offset, &value, sizeof(value));
-}
+void RtlSimTlbWindow::write32(uint64_t offset, uint32_t value) { translate_and_write(offset, &value, sizeof(value)); }
 
-uint32_t RtlSimTlbWindow::read32(uint64_t offset, const std::function<bool()>& /*on_timeout*/) {
+uint32_t RtlSimTlbWindow::read32(uint64_t offset) {
     uint32_t value = 0;
     translate_and_read(offset, &value, sizeof(value));
     return value;
 }
 
-void RtlSimTlbWindow::write_register(
-    uint64_t offset, const void* data, size_t size, const std::function<bool()>& /*on_timeout*/) {
+void RtlSimTlbWindow::write_register(uint64_t offset, const void* data, size_t size) {
     translate_and_write(offset, data, size);
 }
 
-void RtlSimTlbWindow::read_register(
-    uint64_t offset, void* data, size_t size, const std::function<bool()>& /*on_timeout*/) {
+void RtlSimTlbWindow::read_register(uint64_t offset, void* data, size_t size) {
     translate_and_read(offset, data, size);
 }
 
-void RtlSimTlbWindow::write_block(
-    uint64_t offset, const void* data, size_t size, const std::function<bool()>& /*on_timeout*/) {
+void RtlSimTlbWindow::write_block(uint64_t offset, const void* data, size_t size) {
     translate_and_write(offset, data, size);
 }
 
-void RtlSimTlbWindow::read_block(
-    uint64_t offset, void* data, size_t size, const std::function<bool()>& /*on_timeout*/) {
-    translate_and_read(offset, data, size);
-}
+void RtlSimTlbWindow::read_block(uint64_t offset, void* data, size_t size) { translate_and_read(offset, data, size); }
 
-void RtlSimTlbWindow::safe_write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout) {
-    write16(offset, value, on_timeout);
-}
+void RtlSimTlbWindow::safe_write16(uint64_t offset, uint16_t value) { write16(offset, value); }
 
-uint16_t RtlSimTlbWindow::safe_read16(uint64_t offset, const std::function<bool()>& on_timeout) {
-    return read16(offset, on_timeout);
-}
+uint16_t RtlSimTlbWindow::safe_read16(uint64_t offset) { return read16(offset); }
 
 }  // namespace tt::umd

--- a/device/pcie/rtl_sim_tlb_window.cpp
+++ b/device/pcie/rtl_sim_tlb_window.cpp
@@ -53,11 +53,13 @@ uint32_t RtlSimTlbWindow::read32(uint64_t offset, const std::function<bool()>& /
     return value;
 }
 
-void RtlSimTlbWindow::write_register(uint64_t offset, const void* data, size_t size) {
+void RtlSimTlbWindow::write_register(
+    uint64_t offset, const void* data, size_t size, const std::function<bool()>& /*on_timeout*/) {
     translate_and_write(offset, data, size);
 }
 
-void RtlSimTlbWindow::read_register(uint64_t offset, void* data, size_t size) {
+void RtlSimTlbWindow::read_register(
+    uint64_t offset, void* data, size_t size, const std::function<bool()>& /*on_timeout*/) {
     translate_and_read(offset, data, size);
 }
 

--- a/device/pcie/rtl_sim_tlb_window.cpp
+++ b/device/pcie/rtl_sim_tlb_window.cpp
@@ -4,6 +4,7 @@
 
 #include "umd/device/pcie/rtl_sim_tlb_window.hpp"
 
+#include <functional>
 #include <utility>
 
 #include "umd/device/pcie/rtl_sim_tlb_handle.hpp"
@@ -32,17 +33,21 @@ void RtlSimTlbWindow::translate_and_read(uint64_t offset, void* data, size_t siz
     communicator_->tile_read_bytes(config.x_end, config.y_end, device_addr, data, static_cast<uint32_t>(size));
 }
 
-void RtlSimTlbWindow::write16(uint64_t offset, uint16_t value) { translate_and_write(offset, &value, sizeof(value)); }
+void RtlSimTlbWindow::write16(uint64_t offset, uint16_t value, const std::function<bool()>& /*on_timeout*/) {
+    translate_and_write(offset, &value, sizeof(value));
+}
 
-uint16_t RtlSimTlbWindow::read16(uint64_t offset) {
+uint16_t RtlSimTlbWindow::read16(uint64_t offset, const std::function<bool()>& /*on_timeout*/) {
     uint16_t value = 0;
     translate_and_read(offset, &value, sizeof(value));
     return value;
 }
 
-void RtlSimTlbWindow::write32(uint64_t offset, uint32_t value) { translate_and_write(offset, &value, sizeof(value)); }
+void RtlSimTlbWindow::write32(uint64_t offset, uint32_t value, const std::function<bool()>& /*on_timeout*/) {
+    translate_and_write(offset, &value, sizeof(value));
+}
 
-uint32_t RtlSimTlbWindow::read32(uint64_t offset) {
+uint32_t RtlSimTlbWindow::read32(uint64_t offset, const std::function<bool()>& /*on_timeout*/) {
     uint32_t value = 0;
     translate_and_read(offset, &value, sizeof(value));
     return value;
@@ -56,14 +61,22 @@ void RtlSimTlbWindow::read_register(uint64_t offset, void* data, size_t size) {
     translate_and_read(offset, data, size);
 }
 
-void RtlSimTlbWindow::write_block(uint64_t offset, const void* data, size_t size) {
+void RtlSimTlbWindow::write_block(
+    uint64_t offset, const void* data, size_t size, const std::function<bool()>& /*on_timeout*/) {
     translate_and_write(offset, data, size);
 }
 
-void RtlSimTlbWindow::read_block(uint64_t offset, void* data, size_t size) { translate_and_read(offset, data, size); }
+void RtlSimTlbWindow::read_block(
+    uint64_t offset, void* data, size_t size, const std::function<bool()>& /*on_timeout*/) {
+    translate_and_read(offset, data, size);
+}
 
-void RtlSimTlbWindow::safe_write16(uint64_t offset, uint16_t value) { write16(offset, value); }
+void RtlSimTlbWindow::safe_write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout) {
+    write16(offset, value, on_timeout);
+}
 
-uint16_t RtlSimTlbWindow::safe_read16(uint64_t offset) { return read16(offset); }
+uint16_t RtlSimTlbWindow::safe_read16(uint64_t offset, const std::function<bool()>& on_timeout) {
+    return read16(offset, on_timeout);
+}
 
 }  // namespace tt::umd

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -69,24 +69,24 @@ struct ScopedJumpGuard {
 SiliconTlbWindow::SiliconTlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config) :
     TlbWindow(std::move(handle), config) {}
 
-void SiliconTlbWindow::write16(uint64_t offset, uint16_t value) {
+void SiliconTlbWindow::write16(uint64_t offset, uint16_t value, const std::function<bool()> &on_timeout) {
     validate(offset, sizeof(uint16_t));
-    write16_to_device(tlb_handle->get_base() + get_total_offset(offset), value);
+    write16_to_device(tlb_handle->get_base() + get_total_offset(offset), value, on_timeout);
 }
 
-uint16_t SiliconTlbWindow::read16(uint64_t offset) {
+uint16_t SiliconTlbWindow::read16(uint64_t offset, const std::function<bool()> &on_timeout) {
     validate(offset, sizeof(uint16_t));
-    return read16_from_device(tlb_handle->get_base() + get_total_offset(offset));
+    return read16_from_device(tlb_handle->get_base() + get_total_offset(offset), on_timeout);
 }
 
-void SiliconTlbWindow::write32(uint64_t offset, uint32_t value) {
+void SiliconTlbWindow::write32(uint64_t offset, uint32_t value, const std::function<bool()> &on_timeout) {
     validate(offset, sizeof(uint32_t));
-    write32_to_device(tlb_handle->get_base() + get_total_offset(offset), value);
+    write32_to_device(tlb_handle->get_base() + get_total_offset(offset), value, on_timeout);
 }
 
-uint32_t SiliconTlbWindow::read32(uint64_t offset) {
+uint32_t SiliconTlbWindow::read32(uint64_t offset, const std::function<bool()> &on_timeout) {
     validate(offset, sizeof(uint32_t));
-    return read32_from_device(tlb_handle->get_base() + get_total_offset(offset));
+    return read32_from_device(tlb_handle->get_base() + get_total_offset(offset), on_timeout);
 }
 
 void SiliconTlbWindow::write_register(uint64_t offset, const void *data, size_t size) {
@@ -109,31 +109,33 @@ void SiliconTlbWindow::read_register(uint64_t offset, void *data, size_t size) {
     read_regs((void *)src, n, (void *)dst);
 }
 
-void SiliconTlbWindow::write_block(uint64_t offset, const void *data, size_t size) {
+void SiliconTlbWindow::write_block(
+    uint64_t offset, const void *data, size_t size, const std::function<bool()> &on_timeout) {
     auto *dst = reinterpret_cast<volatile uint32_t *>(tlb_handle->get_base() + get_total_offset(offset));
 
     validate(offset, size);
 
     if (tlb_handle->get_arch() == tt::ARCH::WORMHOLE_B0) {
-        memcpy_to_device((void *)dst, data, size);
+        memcpy_to_device((void *)dst, data, size, on_timeout);
     } else {
-        umd::memcpy_to_device(dst, data, size);
+        umd::memcpy_to_device(dst, data, size, on_timeout);
     }
 }
 
-void SiliconTlbWindow::read_block(uint64_t offset, void *data, size_t size) {
+void SiliconTlbWindow::read_block(uint64_t offset, void *data, size_t size, const std::function<bool()> &on_timeout) {
     const volatile void *src = tlb_handle->get_base() + get_total_offset(offset);
 
     validate(offset, size);
 
     if (tlb_handle->get_arch() == tt::ARCH::WORMHOLE_B0) {
-        memcpy_from_device(data, src, size);
+        memcpy_from_device(data, src, size, on_timeout);
     } else {
-        umd::memcpy_from_device(data, src, size);
+        umd::memcpy_from_device(data, src, size, on_timeout);
     }
 }
 
-void SiliconTlbWindow::memcpy_from_device(void *dest, const volatile void *src, std::size_t num_bytes) {
+void SiliconTlbWindow::memcpy_from_device(
+    void *dest, const volatile void *src, std::size_t num_bytes, const std::function<bool()> &on_timeout) {
     using copy_t = std::uint32_t;
 
     // Start by aligning the source (device) pointer.
@@ -145,7 +147,9 @@ void SiliconTlbWindow::memcpy_from_device(void *dest, const volatile void *src, 
     if (src_misalignment != 0) {
         sp = reinterpret_cast<copy_t *>(src_addr - src_misalignment);
 
-        copy_t tmp = *sp++;
+        copy_t tmp;
+        umd::memcpy_from_device(&tmp, sp, sizeof(tmp), on_timeout);
+        sp++;
 
         auto leading_len = std::min(sizeof(tmp) - src_misalignment, num_bytes);
         memcpy(dest, reinterpret_cast<char *>(&tmp) + src_misalignment, leading_len);
@@ -159,7 +163,7 @@ void SiliconTlbWindow::memcpy_from_device(void *dest, const volatile void *src, 
     // Copy the source-aligned middle using non-overlapping wide loads.
     std::size_t num_words = num_bytes / sizeof(copy_t);
     std::size_t middle_bytes = num_words * sizeof(copy_t);
-    umd::memcpy_from_device(dest, sp, middle_bytes);
+    umd::memcpy_from_device(dest, sp, middle_bytes, on_timeout);
 
     auto *dp = static_cast<char *>(dest) + middle_bytes;
     sp += num_words;
@@ -167,12 +171,14 @@ void SiliconTlbWindow::memcpy_from_device(void *dest, const volatile void *src, 
     // Finally copy any sub-word trailer.
     auto trailing_len = num_bytes % sizeof(copy_t);
     if (trailing_len != 0) {
-        copy_t tmp = *sp;
+        copy_t tmp;
+        umd::memcpy_from_device(&tmp, sp, sizeof(tmp), on_timeout);
         memcpy(dp, &tmp, trailing_len);
     }
 }
 
-void SiliconTlbWindow::memcpy_to_device(void *dest, const void *src, std::size_t num_bytes) {
+void SiliconTlbWindow::memcpy_to_device(
+    void *dest, const void *src, std::size_t num_bytes, const std::function<bool()> &on_timeout) {
     using copy_t = std::uint32_t;
 
     // Start by aligning the destination (device) pointer. If needed, do RMW to fix up the
@@ -186,7 +192,8 @@ void SiliconTlbWindow::memcpy_to_device(void *dest, const void *src, std::size_t
         // Read-modify-write for the first dest element.
         dp = reinterpret_cast<copy_t *>(dest_addr - dest_misalignment);
 
-        copy_t tmp = *dp;
+        copy_t tmp;
+        umd::memcpy_from_device(&tmp, dp, sizeof(tmp), on_timeout);
 
         auto leading_len = std::min(sizeof(tmp) - dest_misalignment, num_bytes);
 
@@ -194,7 +201,8 @@ void SiliconTlbWindow::memcpy_to_device(void *dest, const void *src, std::size_t
         num_bytes -= leading_len;
         src = static_cast<const char *>(src) + leading_len;
 
-        *dp++ = tmp;
+        umd::memcpy_to_device(dp, &tmp, sizeof(tmp), on_timeout);
+        dp++;
 
     } else {
         dp = static_cast<copy_t *>(dest);
@@ -203,7 +211,7 @@ void SiliconTlbWindow::memcpy_to_device(void *dest, const void *src, std::size_t
     // Copy the destination-aligned middle using non-overlapping wide stores.
     std::size_t num_words = num_bytes / sizeof(copy_t);
     std::size_t middle_bytes = num_words * sizeof(copy_t);
-    umd::memcpy_to_device(dp, src, middle_bytes);
+    umd::memcpy_to_device(dp, src, middle_bytes, on_timeout);
 
     dp += num_words;
     auto *sp = static_cast<const char *>(src) + middle_bytes;
@@ -211,11 +219,12 @@ void SiliconTlbWindow::memcpy_to_device(void *dest, const void *src, std::size_t
     // Finally copy any sub-word trailer, again RMW on the destination.
     auto trailing_len = num_bytes % sizeof(copy_t);
     if (trailing_len != 0) {
-        copy_t tmp = *dp;
+        copy_t tmp;
+        umd::memcpy_from_device(&tmp, dp, sizeof(tmp), on_timeout);
 
         memcpy(&tmp, sp, trailing_len);
 
-        *dp++ = tmp;
+        umd::memcpy_to_device(dp, &tmp, sizeof(tmp), on_timeout);
     }
 }
 
@@ -247,17 +256,21 @@ decltype(auto) SiliconTlbWindow::execute_safe(Func &&func, Args &&...args) {
     }
 }
 
-void SiliconTlbWindow::safe_write16(uint64_t offset, uint16_t value) {
-    execute_safe(&SiliconTlbWindow::write16, offset, value);
+void SiliconTlbWindow::safe_write16(uint64_t offset, uint16_t value, const std::function<bool()> &on_timeout) {
+    execute_safe(&SiliconTlbWindow::write16, offset, value, on_timeout);
 }
 
-uint16_t SiliconTlbWindow::safe_read16(uint64_t offset) { return execute_safe(&SiliconTlbWindow::read16, offset); }
-
-void SiliconTlbWindow::safe_write32(uint64_t offset, uint32_t value) {
-    execute_safe(&SiliconTlbWindow::write32, offset, value);
+uint16_t SiliconTlbWindow::safe_read16(uint64_t offset, const std::function<bool()> &on_timeout) {
+    return execute_safe(&SiliconTlbWindow::read16, offset, on_timeout);
 }
 
-uint32_t SiliconTlbWindow::safe_read32(uint64_t offset) { return execute_safe(&SiliconTlbWindow::read32, offset); }
+void SiliconTlbWindow::safe_write32(uint64_t offset, uint32_t value, const std::function<bool()> &on_timeout) {
+    execute_safe(&SiliconTlbWindow::write32, offset, value, on_timeout);
+}
+
+uint32_t SiliconTlbWindow::safe_read32(uint64_t offset, const std::function<bool()> &on_timeout) {
+    return execute_safe(&SiliconTlbWindow::read32, offset, on_timeout);
+}
 
 void SiliconTlbWindow::safe_write_register(uint64_t offset, const void *data, size_t size) {
     execute_safe(&SiliconTlbWindow::write_register, offset, data, size);
@@ -267,22 +280,36 @@ void SiliconTlbWindow::safe_read_register(uint64_t offset, void *data, size_t si
     execute_safe(&SiliconTlbWindow::read_register, offset, data, size);
 }
 
-void SiliconTlbWindow::safe_write_block(uint64_t offset, const void *data, size_t size) {
-    execute_safe(&SiliconTlbWindow::write_block, offset, data, size);
+void SiliconTlbWindow::safe_write_block(
+    uint64_t offset, const void *data, size_t size, const std::function<bool()> &on_timeout) {
+    execute_safe(&SiliconTlbWindow::write_block, offset, data, size, on_timeout);
 }
 
-void SiliconTlbWindow::safe_read_block(uint64_t offset, void *data, size_t size) {
-    execute_safe(&SiliconTlbWindow::read_block, offset, data, size);
+void SiliconTlbWindow::safe_read_block(
+    uint64_t offset, void *data, size_t size, const std::function<bool()> &on_timeout) {
+    execute_safe(&SiliconTlbWindow::read_block, offset, data, size, on_timeout);
 }
 
 void SiliconTlbWindow::safe_write_block_reconfigure(
-    const void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    execute_safe(&SiliconTlbWindow::write_block_reconfigure, mem_ptr, core, addr, size, noc_id, ordering);
+    const void *mem_ptr,
+    tt_xy_pair core,
+    uint64_t addr,
+    size_t size,
+    NocId noc_id,
+    uint64_t ordering,
+    const std::function<bool()> &on_timeout) {
+    execute_safe(&SiliconTlbWindow::write_block_reconfigure, mem_ptr, core, addr, size, noc_id, ordering, on_timeout);
 }
 
 void SiliconTlbWindow::safe_read_block_reconfigure(
-    void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    execute_safe(&SiliconTlbWindow::read_block_reconfigure, mem_ptr, core, addr, size, noc_id, ordering);
+    void *mem_ptr,
+    tt_xy_pair core,
+    uint64_t addr,
+    size_t size,
+    NocId noc_id,
+    uint64_t ordering,
+    const std::function<bool()> &on_timeout) {
+    execute_safe(&SiliconTlbWindow::read_block_reconfigure, mem_ptr, core, addr, size, noc_id, ordering, on_timeout);
 }
 
 void SiliconTlbWindow::safe_read_register_reconfigure(
@@ -302,9 +329,18 @@ void SiliconTlbWindow::safe_noc_multicast_write_reconfigure(
     tt_xy_pair core_end,
     uint64_t addr,
     NocId noc_id,
-    uint64_t ordering) {
+    uint64_t ordering,
+    const std::function<bool()> &on_timeout) {
     execute_safe(
-        &SiliconTlbWindow::noc_multicast_write_reconfigure, src, size, core_start, core_end, addr, noc_id, ordering);
+        &SiliconTlbWindow::noc_multicast_write_reconfigure,
+        src,
+        size,
+        core_start,
+        core_end,
+        addr,
+        noc_id,
+        ordering,
+        on_timeout);
 }
 
 }  // namespace tt::umd

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -89,24 +89,26 @@ uint32_t SiliconTlbWindow::read32(uint64_t offset, const std::function<bool()> &
     return read32_from_device(tlb_handle->get_base() + get_total_offset(offset), on_timeout);
 }
 
-void SiliconTlbWindow::write_register(uint64_t offset, const void *data, size_t size) {
+void SiliconTlbWindow::write_register(
+    uint64_t offset, const void *data, size_t size, const std::function<bool()> &on_timeout) {
     size_t n = size / sizeof(uint32_t);
     auto *src = static_cast<const uint32_t *>(data);
     auto *dst = reinterpret_cast<volatile uint32_t *>(tlb_handle->get_base() + get_total_offset(offset));
 
     validate(offset, size);
 
-    write_regs(dst, src, n);
+    write_regs(dst, src, n, on_timeout);
 }
 
-void SiliconTlbWindow::read_register(uint64_t offset, void *data, size_t size) {
+void SiliconTlbWindow::read_register(
+    uint64_t offset, void *data, size_t size, const std::function<bool()> &on_timeout) {
     size_t n = size / sizeof(uint32_t);
     auto *src = reinterpret_cast<const volatile uint32_t *>(tlb_handle->get_base() + get_total_offset(offset));
     auto *dst = static_cast<uint32_t *>(data);
 
     validate(offset, size);
 
-    read_regs((void *)src, n, (void *)dst);
+    read_regs((void *)src, n, (void *)dst, on_timeout);
 }
 
 void SiliconTlbWindow::write_block(
@@ -228,18 +230,20 @@ void SiliconTlbWindow::memcpy_to_device(
     }
 }
 
-void SiliconTlbWindow::write_regs(volatile uint32_t *dest, const uint32_t *src, uint32_t word_len) {
+void SiliconTlbWindow::write_regs(
+    volatile uint32_t *dest, const uint32_t *src, uint32_t word_len, const std::function<bool()> &on_timeout) {
     while (word_len-- != 0) {
-        write32_to_device(dest++, *src++);
+        write32_to_device(dest++, *src++, on_timeout);
     }
 }
 
-void SiliconTlbWindow::read_regs(void *src_reg, uint32_t word_len, void *data) {
+void SiliconTlbWindow::read_regs(
+    void *src_reg, uint32_t word_len, void *data, const std::function<bool()> &on_timeout) {
     auto *src = static_cast<const volatile uint32_t *>(src_reg);
     auto *dest = reinterpret_cast<uint32_t *>(data);
 
     while (word_len-- != 0) {
-        uint32_t temp = read32_from_device(src++);
+        uint32_t temp = read32_from_device(src++, on_timeout);
         memcpy(dest++, &temp, sizeof(temp));
     }
 }
@@ -273,11 +277,11 @@ uint32_t SiliconTlbWindow::safe_read32(uint64_t offset, const std::function<bool
 }
 
 void SiliconTlbWindow::safe_write_register(uint64_t offset, const void *data, size_t size) {
-    execute_safe(&SiliconTlbWindow::write_register, offset, data, size);
+    execute_safe(&SiliconTlbWindow::write_register, offset, data, size, std::function<bool()>{});
 }
 
 void SiliconTlbWindow::safe_read_register(uint64_t offset, void *data, size_t size) {
-    execute_safe(&SiliconTlbWindow::read_register, offset, data, size);
+    execute_safe(&SiliconTlbWindow::read_register, offset, data, size, std::function<bool()>{});
 }
 
 void SiliconTlbWindow::safe_write_block(

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -66,9 +66,8 @@ struct ScopedJumpGuard {
     signal(SIGBUS, SIG_DFL);
 }
 
-SiliconTlbWindow::SiliconTlbWindow(
-    std::unique_ptr<TlbHandle> handle, const tlb_data config, std::function<bool(NocId)> hang_check) :
-    TlbWindow(std::move(handle), config), hang_check_(std::move(hang_check)) {}
+SiliconTlbWindow::SiliconTlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config) :
+    TlbWindow(std::move(handle), config) {}
 
 void SiliconTlbWindow::set_io_timeout_hang_check(const std::function<bool(NocId)> &hang_check) {
     hang_check_ = hang_check;

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -66,57 +66,72 @@ struct ScopedJumpGuard {
     signal(SIGBUS, SIG_DFL);
 }
 
-SiliconTlbWindow::SiliconTlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config) :
-    TlbWindow(std::move(handle), config) {}
+SiliconTlbWindow::SiliconTlbWindow(
+    std::unique_ptr<TlbHandle> handle, const tlb_data config, std::function<bool(NocId)> hang_check) :
+    TlbWindow(std::move(handle), config), hang_check_(std::move(hang_check)) {}
 
-void SiliconTlbWindow::write16(uint64_t offset, uint16_t value, const std::function<bool()> &on_timeout) {
+void SiliconTlbWindow::set_io_timeout_hang_check(const std::function<bool(NocId)> &hang_check) {
+    hang_check_ = hang_check;
+}
+
+std::function<bool()> SiliconTlbWindow::make_io_timeout_callback() const {
+    if (!hang_check_) {
+        return {};
+    }
+    // The live TLB config's noc_sel is whatever the last (re)configure selected, so it identifies the
+    // in-flight op's NOC. is_false_alarm semantics (OpTimeoutGuard): healthy NOC => true (ignore the
+    // overrun), hung NOC => false (confirm it and abort with DeviceTimeoutError).
+    const NocId noc = static_cast<NocId>(handle_ref().get_config().noc_sel);
+    auto hang_check = hang_check_;
+    return [hang_check, noc]() -> bool { return !hang_check(noc); };
+}
+
+void SiliconTlbWindow::write16(uint64_t offset, uint16_t value) {
     validate(offset, sizeof(uint16_t));
-    write16_to_device(tlb_handle->get_base() + get_total_offset(offset), value, on_timeout);
+    write16_to_device(tlb_handle->get_base() + get_total_offset(offset), value, make_io_timeout_callback());
 }
 
-uint16_t SiliconTlbWindow::read16(uint64_t offset, const std::function<bool()> &on_timeout) {
+uint16_t SiliconTlbWindow::read16(uint64_t offset) {
     validate(offset, sizeof(uint16_t));
-    return read16_from_device(tlb_handle->get_base() + get_total_offset(offset), on_timeout);
+    return read16_from_device(tlb_handle->get_base() + get_total_offset(offset), make_io_timeout_callback());
 }
 
-void SiliconTlbWindow::write32(uint64_t offset, uint32_t value, const std::function<bool()> &on_timeout) {
+void SiliconTlbWindow::write32(uint64_t offset, uint32_t value) {
     validate(offset, sizeof(uint32_t));
-    write32_to_device(tlb_handle->get_base() + get_total_offset(offset), value, on_timeout);
+    write32_to_device(tlb_handle->get_base() + get_total_offset(offset), value, make_io_timeout_callback());
 }
 
-uint32_t SiliconTlbWindow::read32(uint64_t offset, const std::function<bool()> &on_timeout) {
+uint32_t SiliconTlbWindow::read32(uint64_t offset) {
     validate(offset, sizeof(uint32_t));
-    return read32_from_device(tlb_handle->get_base() + get_total_offset(offset), on_timeout);
+    return read32_from_device(tlb_handle->get_base() + get_total_offset(offset), make_io_timeout_callback());
 }
 
-void SiliconTlbWindow::write_register(
-    uint64_t offset, const void *data, size_t size, const std::function<bool()> &on_timeout) {
+void SiliconTlbWindow::write_register(uint64_t offset, const void *data, size_t size) {
     size_t n = size / sizeof(uint32_t);
     auto *src = static_cast<const uint32_t *>(data);
     auto *dst = reinterpret_cast<volatile uint32_t *>(tlb_handle->get_base() + get_total_offset(offset));
 
     validate(offset, size);
 
-    write_regs(dst, src, n, on_timeout);
+    write_regs(dst, src, n, make_io_timeout_callback());
 }
 
-void SiliconTlbWindow::read_register(
-    uint64_t offset, void *data, size_t size, const std::function<bool()> &on_timeout) {
+void SiliconTlbWindow::read_register(uint64_t offset, void *data, size_t size) {
     size_t n = size / sizeof(uint32_t);
     auto *src = reinterpret_cast<const volatile uint32_t *>(tlb_handle->get_base() + get_total_offset(offset));
     auto *dst = static_cast<uint32_t *>(data);
 
     validate(offset, size);
 
-    read_regs((void *)src, n, (void *)dst, on_timeout);
+    read_regs((void *)src, n, (void *)dst, make_io_timeout_callback());
 }
 
-void SiliconTlbWindow::write_block(
-    uint64_t offset, const void *data, size_t size, const std::function<bool()> &on_timeout) {
+void SiliconTlbWindow::write_block(uint64_t offset, const void *data, size_t size) {
     auto *dst = reinterpret_cast<volatile uint32_t *>(tlb_handle->get_base() + get_total_offset(offset));
 
     validate(offset, size);
 
+    const std::function<bool()> on_timeout = make_io_timeout_callback();
     if (tlb_handle->get_arch() == tt::ARCH::WORMHOLE_B0) {
         memcpy_to_device((void *)dst, data, size, on_timeout);
     } else {
@@ -124,11 +139,12 @@ void SiliconTlbWindow::write_block(
     }
 }
 
-void SiliconTlbWindow::read_block(uint64_t offset, void *data, size_t size, const std::function<bool()> &on_timeout) {
+void SiliconTlbWindow::read_block(uint64_t offset, void *data, size_t size) {
     const volatile void *src = tlb_handle->get_base() + get_total_offset(offset);
 
     validate(offset, size);
 
+    const std::function<bool()> on_timeout = make_io_timeout_callback();
     if (tlb_handle->get_arch() == tt::ARCH::WORMHOLE_B0) {
         memcpy_from_device(data, src, size, on_timeout);
     } else {
@@ -260,60 +276,42 @@ decltype(auto) SiliconTlbWindow::execute_safe(Func &&func, Args &&...args) {
     }
 }
 
-void SiliconTlbWindow::safe_write16(uint64_t offset, uint16_t value, const std::function<bool()> &on_timeout) {
-    execute_safe(&SiliconTlbWindow::write16, offset, value, on_timeout);
+void SiliconTlbWindow::safe_write16(uint64_t offset, uint16_t value) {
+    execute_safe(&SiliconTlbWindow::write16, offset, value);
 }
 
-uint16_t SiliconTlbWindow::safe_read16(uint64_t offset, const std::function<bool()> &on_timeout) {
-    return execute_safe(&SiliconTlbWindow::read16, offset, on_timeout);
+uint16_t SiliconTlbWindow::safe_read16(uint64_t offset) { return execute_safe(&SiliconTlbWindow::read16, offset); }
+
+void SiliconTlbWindow::safe_write32(uint64_t offset, uint32_t value) {
+    execute_safe(&SiliconTlbWindow::write32, offset, value);
 }
 
-void SiliconTlbWindow::safe_write32(uint64_t offset, uint32_t value, const std::function<bool()> &on_timeout) {
-    execute_safe(&SiliconTlbWindow::write32, offset, value, on_timeout);
-}
-
-uint32_t SiliconTlbWindow::safe_read32(uint64_t offset, const std::function<bool()> &on_timeout) {
-    return execute_safe(&SiliconTlbWindow::read32, offset, on_timeout);
-}
+uint32_t SiliconTlbWindow::safe_read32(uint64_t offset) { return execute_safe(&SiliconTlbWindow::read32, offset); }
 
 void SiliconTlbWindow::safe_write_register(uint64_t offset, const void *data, size_t size) {
-    execute_safe(&SiliconTlbWindow::write_register, offset, data, size, std::function<bool()>{});
+    execute_safe(&SiliconTlbWindow::write_register, offset, data, size);
 }
 
 void SiliconTlbWindow::safe_read_register(uint64_t offset, void *data, size_t size) {
-    execute_safe(&SiliconTlbWindow::read_register, offset, data, size, std::function<bool()>{});
+    execute_safe(&SiliconTlbWindow::read_register, offset, data, size);
 }
 
-void SiliconTlbWindow::safe_write_block(
-    uint64_t offset, const void *data, size_t size, const std::function<bool()> &on_timeout) {
-    execute_safe(&SiliconTlbWindow::write_block, offset, data, size, on_timeout);
+void SiliconTlbWindow::safe_write_block(uint64_t offset, const void *data, size_t size) {
+    execute_safe(&SiliconTlbWindow::write_block, offset, data, size);
 }
 
-void SiliconTlbWindow::safe_read_block(
-    uint64_t offset, void *data, size_t size, const std::function<bool()> &on_timeout) {
-    execute_safe(&SiliconTlbWindow::read_block, offset, data, size, on_timeout);
+void SiliconTlbWindow::safe_read_block(uint64_t offset, void *data, size_t size) {
+    execute_safe(&SiliconTlbWindow::read_block, offset, data, size);
 }
 
 void SiliconTlbWindow::safe_write_block_reconfigure(
-    const void *mem_ptr,
-    tt_xy_pair core,
-    uint64_t addr,
-    size_t size,
-    NocId noc_id,
-    uint64_t ordering,
-    const std::function<bool()> &on_timeout) {
-    execute_safe(&SiliconTlbWindow::write_block_reconfigure, mem_ptr, core, addr, size, noc_id, ordering, on_timeout);
+    const void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    execute_safe(&SiliconTlbWindow::write_block_reconfigure, mem_ptr, core, addr, size, noc_id, ordering);
 }
 
 void SiliconTlbWindow::safe_read_block_reconfigure(
-    void *mem_ptr,
-    tt_xy_pair core,
-    uint64_t addr,
-    size_t size,
-    NocId noc_id,
-    uint64_t ordering,
-    const std::function<bool()> &on_timeout) {
-    execute_safe(&SiliconTlbWindow::read_block_reconfigure, mem_ptr, core, addr, size, noc_id, ordering, on_timeout);
+    void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    execute_safe(&SiliconTlbWindow::read_block_reconfigure, mem_ptr, core, addr, size, noc_id, ordering);
 }
 
 void SiliconTlbWindow::safe_read_register_reconfigure(
@@ -333,18 +331,9 @@ void SiliconTlbWindow::safe_noc_multicast_write_reconfigure(
     tt_xy_pair core_end,
     uint64_t addr,
     NocId noc_id,
-    uint64_t ordering,
-    const std::function<bool()> &on_timeout) {
+    uint64_t ordering) {
     execute_safe(
-        &SiliconTlbWindow::noc_multicast_write_reconfigure,
-        src,
-        size,
-        core_start,
-        core_end,
-        addr,
-        noc_id,
-        ordering,
-        on_timeout);
+        &SiliconTlbWindow::noc_multicast_write_reconfigure, src, size, core_start, core_end, addr, noc_id, ordering);
 }
 
 }  // namespace tt::umd

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -67,42 +67,51 @@ struct ScopedJumpGuard {
 }
 
 SiliconTlbWindow::SiliconTlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config) :
-    TlbWindow(std::move(handle), config) {}
+    TlbWindow(std::move(handle), config) {
+    update_io_timeout_callback();
+}
 
 void SiliconTlbWindow::set_io_timeout_hang_check(const std::function<bool(NocId)> &hang_check) {
     hang_check_ = hang_check;
+    update_io_timeout_callback();
 }
 
-std::function<bool()> SiliconTlbWindow::make_io_timeout_callback() const {
+void SiliconTlbWindow::configure(const tlb_data &new_config) {
+    TlbWindow::configure(new_config);
+    update_io_timeout_callback();
+}
+
+void SiliconTlbWindow::update_io_timeout_callback() {
     if (!hang_check_) {
-        return {};
+        io_timeout_callback_ = {};
+        return;
     }
     // The live TLB config's noc_sel is whatever the last (re)configure selected, so it identifies the
     // in-flight op's NOC. is_false_alarm semantics (OpTimeoutGuard): healthy NOC => true (ignore the
     // overrun), hung NOC => false (confirm it and abort with DeviceTimeoutError).
     const NocId noc = static_cast<NocId>(handle_ref().get_config().noc_sel);
     auto hang_check = hang_check_;
-    return [hang_check, noc]() -> bool { return !hang_check(noc); };
+    io_timeout_callback_ = [hang_check, noc]() -> bool { return !hang_check(noc); };
 }
 
 void SiliconTlbWindow::write16(uint64_t offset, uint16_t value) {
     validate(offset, sizeof(uint16_t));
-    write16_to_device(tlb_handle->get_base() + get_total_offset(offset), value, make_io_timeout_callback());
+    write16_to_device(tlb_handle->get_base() + get_total_offset(offset), value, io_timeout_callback_);
 }
 
 uint16_t SiliconTlbWindow::read16(uint64_t offset) {
     validate(offset, sizeof(uint16_t));
-    return read16_from_device(tlb_handle->get_base() + get_total_offset(offset), make_io_timeout_callback());
+    return read16_from_device(tlb_handle->get_base() + get_total_offset(offset), io_timeout_callback_);
 }
 
 void SiliconTlbWindow::write32(uint64_t offset, uint32_t value) {
     validate(offset, sizeof(uint32_t));
-    write32_to_device(tlb_handle->get_base() + get_total_offset(offset), value, make_io_timeout_callback());
+    write32_to_device(tlb_handle->get_base() + get_total_offset(offset), value, io_timeout_callback_);
 }
 
 uint32_t SiliconTlbWindow::read32(uint64_t offset) {
     validate(offset, sizeof(uint32_t));
-    return read32_from_device(tlb_handle->get_base() + get_total_offset(offset), make_io_timeout_callback());
+    return read32_from_device(tlb_handle->get_base() + get_total_offset(offset), io_timeout_callback_);
 }
 
 void SiliconTlbWindow::write_register(uint64_t offset, const void *data, size_t size) {
@@ -112,7 +121,7 @@ void SiliconTlbWindow::write_register(uint64_t offset, const void *data, size_t 
 
     validate(offset, size);
 
-    write_regs(dst, src, n, make_io_timeout_callback());
+    write_regs(dst, src, n, io_timeout_callback_);
 }
 
 void SiliconTlbWindow::read_register(uint64_t offset, void *data, size_t size) {
@@ -122,7 +131,7 @@ void SiliconTlbWindow::read_register(uint64_t offset, void *data, size_t size) {
 
     validate(offset, size);
 
-    read_regs((void *)src, n, (void *)dst, make_io_timeout_callback());
+    read_regs((void *)src, n, (void *)dst, io_timeout_callback_);
 }
 
 void SiliconTlbWindow::write_block(uint64_t offset, const void *data, size_t size) {
@@ -130,11 +139,10 @@ void SiliconTlbWindow::write_block(uint64_t offset, const void *data, size_t siz
 
     validate(offset, size);
 
-    const std::function<bool()> on_timeout = make_io_timeout_callback();
     if (tlb_handle->get_arch() == tt::ARCH::WORMHOLE_B0) {
-        memcpy_to_device((void *)dst, data, size, on_timeout);
+        memcpy_to_device((void *)dst, data, size, io_timeout_callback_);
     } else {
-        umd::memcpy_to_device(dst, data, size, on_timeout);
+        umd::memcpy_to_device(dst, data, size, io_timeout_callback_);
     }
 }
 
@@ -143,11 +151,10 @@ void SiliconTlbWindow::read_block(uint64_t offset, void *data, size_t size) {
 
     validate(offset, size);
 
-    const std::function<bool()> on_timeout = make_io_timeout_callback();
     if (tlb_handle->get_arch() == tt::ARCH::WORMHOLE_B0) {
-        memcpy_from_device(data, src, size, on_timeout);
+        memcpy_from_device(data, src, size, io_timeout_callback_);
     } else {
-        umd::memcpy_from_device(data, src, size, on_timeout);
+        umd::memcpy_from_device(data, src, size, io_timeout_callback_);
     }
 }
 

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -54,18 +54,12 @@ void TlbWindow::transfer_and_reconfigure(tlb_data config, buffer_pointer buffer,
 }
 
 void TlbWindow::read_block_reconfigure(
-    void* mem_ptr,
-    tt_xy_pair core,
-    uint64_t addr,
-    size_t size,
-    NocId noc_id,
-    uint64_t ordering,
-    const std::function<bool()>& on_timeout) {
+    void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
     transfer_and_reconfigure(
         make_tlb_config(addr, core, noc_id, ordering),
         static_cast<uint8_t*>(mem_ptr),
         size,
-        [this, &on_timeout](uint8_t* buf, size_t sz) { read_block(0, buf, sz, on_timeout); });
+        [this](uint8_t* buf, size_t sz) { read_block(0, buf, sz); });
 }
 
 void TlbWindow::read_register_reconfigure(
@@ -78,18 +72,12 @@ void TlbWindow::read_register_reconfigure(
 }
 
 void TlbWindow::write_block_reconfigure(
-    const void* mem_ptr,
-    tt_xy_pair core,
-    uint64_t addr,
-    size_t size,
-    NocId noc_id,
-    uint64_t ordering,
-    const std::function<bool()>& on_timeout) {
+    const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
     transfer_and_reconfigure(
         make_tlb_config(addr, core, noc_id, ordering),
         static_cast<const uint8_t*>(mem_ptr),
         size,
-        [this, &on_timeout](const uint8_t* buf, size_t sz) { write_block(0, buf, sz, on_timeout); });
+        [this](const uint8_t* buf, size_t sz) { write_block(0, buf, sz); });
 }
 
 void TlbWindow::write_register_reconfigure(
@@ -108,13 +96,12 @@ void TlbWindow::noc_multicast_write_reconfigure(
     tt_xy_pair core_end,
     uint64_t addr,
     NocId noc_id,
-    uint64_t ordering,
-    const std::function<bool()>& on_timeout) {
+    uint64_t ordering) {
     transfer_and_reconfigure(
         make_tlb_config(addr, core_end, noc_id, ordering, true, core_start),
         static_cast<const uint8_t*>(src),
         size,
-        [this, &on_timeout](const uint8_t* buf, size_t sz) { write_block(0, buf, sz, on_timeout); });
+        [this](const uint8_t* buf, size_t sz) { write_block(0, buf, sz); });
 }
 
 TlbHandle& TlbWindow::handle_ref() const { return *tlb_handle; }
@@ -140,13 +127,9 @@ uint64_t TlbWindow::get_base_address() const {
     return handle_ref().get_config().local_offset + offset_from_aligned_addr;
 }
 
-void TlbWindow::safe_write32(uint64_t offset, uint32_t value, const std::function<bool()>& on_timeout) {
-    write32(offset, value, on_timeout);
-}
+void TlbWindow::safe_write32(uint64_t offset, uint32_t value) { write32(offset, value); }
 
-uint32_t TlbWindow::safe_read32(uint64_t offset, const std::function<bool()>& on_timeout) {
-    return read32(offset, on_timeout);
-}
+uint32_t TlbWindow::safe_read32(uint64_t offset) { return read32(offset); }
 
 void TlbWindow::safe_write_register(uint64_t offset, const void* data, size_t size) {
     write_register(offset, data, size);
@@ -154,35 +137,18 @@ void TlbWindow::safe_write_register(uint64_t offset, const void* data, size_t si
 
 void TlbWindow::safe_read_register(uint64_t offset, void* data, size_t size) { read_register(offset, data, size); }
 
-void TlbWindow::safe_write_block(
-    uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout) {
-    write_block(offset, data, size, on_timeout);
-}
+void TlbWindow::safe_write_block(uint64_t offset, const void* data, size_t size) { write_block(offset, data, size); }
 
-void TlbWindow::safe_read_block(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout) {
-    read_block(offset, data, size, on_timeout);
-}
+void TlbWindow::safe_read_block(uint64_t offset, void* data, size_t size) { read_block(offset, data, size); }
 
 void TlbWindow::safe_write_block_reconfigure(
-    const void* mem_ptr,
-    tt_xy_pair core,
-    uint64_t addr,
-    size_t size,
-    NocId noc_id,
-    uint64_t ordering,
-    const std::function<bool()>& on_timeout) {
-    write_block_reconfigure(mem_ptr, core, addr, size, noc_id, ordering, on_timeout);
+    const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    write_block_reconfigure(mem_ptr, core, addr, size, noc_id, ordering);
 }
 
 void TlbWindow::safe_read_block_reconfigure(
-    void* mem_ptr,
-    tt_xy_pair core,
-    uint64_t addr,
-    size_t size,
-    NocId noc_id,
-    uint64_t ordering,
-    const std::function<bool()>& on_timeout) {
-    read_block_reconfigure(mem_ptr, core, addr, size, noc_id, ordering, on_timeout);
+    void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    read_block_reconfigure(mem_ptr, core, addr, size, noc_id, ordering);
 }
 
 void TlbWindow::safe_read_register_reconfigure(
@@ -202,9 +168,8 @@ void TlbWindow::safe_noc_multicast_write_reconfigure(
     tt_xy_pair core_end,
     uint64_t addr,
     NocId noc_id,
-    uint64_t ordering,
-    const std::function<bool()>& on_timeout) {
-    noc_multicast_write_reconfigure(src, size, core_start, core_end, addr, noc_id, ordering, on_timeout);
+    uint64_t ordering) {
+    noc_multicast_write_reconfigure(src, size, core_start, core_end, addr, noc_id, ordering);
 }
 
 }  // namespace tt::umd

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -5,6 +5,7 @@
 #include "umd/device/pcie/tlb_window.hpp"
 
 #include <algorithm>
+#include <functional>
 #include <memory>
 #include <stdexcept>
 #include <utility>
@@ -53,12 +54,18 @@ void TlbWindow::transfer_and_reconfigure(tlb_data config, buffer_pointer buffer,
 }
 
 void TlbWindow::read_block_reconfigure(
-    void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    void* mem_ptr,
+    tt_xy_pair core,
+    uint64_t addr,
+    size_t size,
+    NocId noc_id,
+    uint64_t ordering,
+    const std::function<bool()>& on_timeout) {
     transfer_and_reconfigure(
         make_tlb_config(addr, core, noc_id, ordering),
         static_cast<uint8_t*>(mem_ptr),
         size,
-        [this](uint8_t* buf, size_t sz) { read_block(0, buf, sz); });
+        [this, &on_timeout](uint8_t* buf, size_t sz) { read_block(0, buf, sz, on_timeout); });
 }
 
 void TlbWindow::read_register_reconfigure(
@@ -71,12 +78,18 @@ void TlbWindow::read_register_reconfigure(
 }
 
 void TlbWindow::write_block_reconfigure(
-    const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    const void* mem_ptr,
+    tt_xy_pair core,
+    uint64_t addr,
+    size_t size,
+    NocId noc_id,
+    uint64_t ordering,
+    const std::function<bool()>& on_timeout) {
     transfer_and_reconfigure(
         make_tlb_config(addr, core, noc_id, ordering),
         static_cast<const uint8_t*>(mem_ptr),
         size,
-        [this](const uint8_t* buf, size_t sz) { write_block(0, buf, sz); });
+        [this, &on_timeout](const uint8_t* buf, size_t sz) { write_block(0, buf, sz, on_timeout); });
 }
 
 void TlbWindow::write_register_reconfigure(
@@ -95,12 +108,13 @@ void TlbWindow::noc_multicast_write_reconfigure(
     tt_xy_pair core_end,
     uint64_t addr,
     NocId noc_id,
-    uint64_t ordering) {
+    uint64_t ordering,
+    const std::function<bool()>& on_timeout) {
     transfer_and_reconfigure(
         make_tlb_config(addr, core_end, noc_id, ordering, true, core_start),
         static_cast<const uint8_t*>(src),
         size,
-        [this](const uint8_t* buf, size_t sz) { write_block(0, buf, sz); });
+        [this, &on_timeout](const uint8_t* buf, size_t sz) { write_block(0, buf, sz, on_timeout); });
 }
 
 TlbHandle& TlbWindow::handle_ref() const { return *tlb_handle; }
@@ -126,9 +140,13 @@ uint64_t TlbWindow::get_base_address() const {
     return handle_ref().get_config().local_offset + offset_from_aligned_addr;
 }
 
-void TlbWindow::safe_write32(uint64_t offset, uint32_t value) { write32(offset, value); }
+void TlbWindow::safe_write32(uint64_t offset, uint32_t value, const std::function<bool()>& on_timeout) {
+    write32(offset, value, on_timeout);
+}
 
-uint32_t TlbWindow::safe_read32(uint64_t offset) { return read32(offset); }
+uint32_t TlbWindow::safe_read32(uint64_t offset, const std::function<bool()>& on_timeout) {
+    return read32(offset, on_timeout);
+}
 
 void TlbWindow::safe_write_register(uint64_t offset, const void* data, size_t size) {
     write_register(offset, data, size);
@@ -136,18 +154,35 @@ void TlbWindow::safe_write_register(uint64_t offset, const void* data, size_t si
 
 void TlbWindow::safe_read_register(uint64_t offset, void* data, size_t size) { read_register(offset, data, size); }
 
-void TlbWindow::safe_write_block(uint64_t offset, const void* data, size_t size) { write_block(offset, data, size); }
+void TlbWindow::safe_write_block(
+    uint64_t offset, const void* data, size_t size, const std::function<bool()>& on_timeout) {
+    write_block(offset, data, size, on_timeout);
+}
 
-void TlbWindow::safe_read_block(uint64_t offset, void* data, size_t size) { read_block(offset, data, size); }
+void TlbWindow::safe_read_block(uint64_t offset, void* data, size_t size, const std::function<bool()>& on_timeout) {
+    read_block(offset, data, size, on_timeout);
+}
 
 void TlbWindow::safe_write_block_reconfigure(
-    const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    write_block_reconfigure(mem_ptr, core, addr, size, noc_id, ordering);
+    const void* mem_ptr,
+    tt_xy_pair core,
+    uint64_t addr,
+    size_t size,
+    NocId noc_id,
+    uint64_t ordering,
+    const std::function<bool()>& on_timeout) {
+    write_block_reconfigure(mem_ptr, core, addr, size, noc_id, ordering, on_timeout);
 }
 
 void TlbWindow::safe_read_block_reconfigure(
-    void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    read_block_reconfigure(mem_ptr, core, addr, size, noc_id, ordering);
+    void* mem_ptr,
+    tt_xy_pair core,
+    uint64_t addr,
+    size_t size,
+    NocId noc_id,
+    uint64_t ordering,
+    const std::function<bool()>& on_timeout) {
+    read_block_reconfigure(mem_ptr, core, addr, size, noc_id, ordering, on_timeout);
 }
 
 void TlbWindow::safe_read_register_reconfigure(
@@ -167,8 +202,9 @@ void TlbWindow::safe_noc_multicast_write_reconfigure(
     tt_xy_pair core_end,
     uint64_t addr,
     NocId noc_id,
-    uint64_t ordering) {
-    noc_multicast_write_reconfigure(src, size, core_start, core_end, addr, noc_id, ordering);
+    uint64_t ordering,
+    const std::function<bool()>& on_timeout) {
+    noc_multicast_write_reconfigure(src, size, core_start, core_end, addr, noc_id, ordering, on_timeout);
 }
 
 }  // namespace tt::umd

--- a/device/pcie/tt_sim_tlb_window.cpp
+++ b/device/pcie/tt_sim_tlb_window.cpp
@@ -4,6 +4,7 @@
 
 #include "umd/device/pcie/tt_sim_tlb_window.hpp"
 
+#include <functional>
 #include <memory>
 #include <utility>
 
@@ -19,24 +20,24 @@ TTSimTlbWindow::TTSimTlbWindow(
     std::unique_ptr<TlbHandle> handle, TTSimCommunicator* communicator, const tlb_data config) :
     TlbWindow(std::move(handle), config), sim_communicator_(communicator) {}
 
-void TTSimTlbWindow::write16(uint64_t offset, uint16_t value) {
+void TTSimTlbWindow::write16(uint64_t offset, uint16_t value, const std::function<bool()>& /*on_timeout*/) {
     validate(offset, sizeof(uint16_t));
     sim_communicator_->pci_mem_write_bytes(get_physical_address(offset), &value, sizeof(uint16_t));
 }
 
-uint16_t TTSimTlbWindow::read16(uint64_t offset) {
+uint16_t TTSimTlbWindow::read16(uint64_t offset, const std::function<bool()>& /*on_timeout*/) {
     validate(offset, sizeof(uint16_t));
     uint16_t value = 0;
     sim_communicator_->pci_mem_read_bytes(get_physical_address(offset), &value, sizeof(uint16_t));
     return value;
 }
 
-void TTSimTlbWindow::write32(uint64_t offset, uint32_t value) {
+void TTSimTlbWindow::write32(uint64_t offset, uint32_t value, const std::function<bool()>& /*on_timeout*/) {
     validate(offset, sizeof(uint32_t));
     sim_communicator_->pci_mem_write_bytes(get_physical_address(offset), &value, sizeof(uint32_t));
 }
 
-uint32_t TTSimTlbWindow::read32(uint64_t offset) {
+uint32_t TTSimTlbWindow::read32(uint64_t offset, const std::function<bool()>& /*on_timeout*/) {
     validate(offset, sizeof(uint32_t));
     uint32_t value = 0;
     sim_communicator_->pci_mem_read_bytes(get_physical_address(offset), &value, sizeof(uint32_t));
@@ -53,12 +54,13 @@ void TTSimTlbWindow::read_register(uint64_t offset, void* data, size_t size) {
     sim_communicator_->pci_mem_read_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
 }
 
-void TTSimTlbWindow::write_block(uint64_t offset, const void* data, size_t size) {
+void TTSimTlbWindow::write_block(
+    uint64_t offset, const void* data, size_t size, const std::function<bool()>& /*on_timeout*/) {
     validate(offset, size);
     sim_communicator_->pci_mem_write_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
 }
 
-void TTSimTlbWindow::read_block(uint64_t offset, void* data, size_t size) {
+void TTSimTlbWindow::read_block(uint64_t offset, void* data, size_t size, const std::function<bool()>& /*on_timeout*/) {
     validate(offset, size);
     sim_communicator_->pci_mem_read_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
 }
@@ -69,8 +71,12 @@ uint64_t TTSimTlbWindow::get_physical_address(uint64_t offset) const {
     return reinterpret_cast<uint64_t>(tlb_handle->get_base()) + get_total_offset(offset);
 }
 
-void TTSimTlbWindow::safe_write16(uint64_t offset, uint16_t value) { write16(offset, value); }
+void TTSimTlbWindow::safe_write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout) {
+    write16(offset, value, on_timeout);
+}
 
-uint16_t TTSimTlbWindow::safe_read16(uint64_t offset) { return read16(offset); }
+uint16_t TTSimTlbWindow::safe_read16(uint64_t offset, const std::function<bool()>& on_timeout) {
+    return read16(offset, on_timeout);
+}
 
 }  // namespace tt::umd

--- a/device/pcie/tt_sim_tlb_window.cpp
+++ b/device/pcie/tt_sim_tlb_window.cpp
@@ -20,49 +20,46 @@ TTSimTlbWindow::TTSimTlbWindow(
     std::unique_ptr<TlbHandle> handle, TTSimCommunicator* communicator, const tlb_data config) :
     TlbWindow(std::move(handle), config), sim_communicator_(communicator) {}
 
-void TTSimTlbWindow::write16(uint64_t offset, uint16_t value, const std::function<bool()>& /*on_timeout*/) {
+void TTSimTlbWindow::write16(uint64_t offset, uint16_t value) {
     validate(offset, sizeof(uint16_t));
     sim_communicator_->pci_mem_write_bytes(get_physical_address(offset), &value, sizeof(uint16_t));
 }
 
-uint16_t TTSimTlbWindow::read16(uint64_t offset, const std::function<bool()>& /*on_timeout*/) {
+uint16_t TTSimTlbWindow::read16(uint64_t offset) {
     validate(offset, sizeof(uint16_t));
     uint16_t value = 0;
     sim_communicator_->pci_mem_read_bytes(get_physical_address(offset), &value, sizeof(uint16_t));
     return value;
 }
 
-void TTSimTlbWindow::write32(uint64_t offset, uint32_t value, const std::function<bool()>& /*on_timeout*/) {
+void TTSimTlbWindow::write32(uint64_t offset, uint32_t value) {
     validate(offset, sizeof(uint32_t));
     sim_communicator_->pci_mem_write_bytes(get_physical_address(offset), &value, sizeof(uint32_t));
 }
 
-uint32_t TTSimTlbWindow::read32(uint64_t offset, const std::function<bool()>& /*on_timeout*/) {
+uint32_t TTSimTlbWindow::read32(uint64_t offset) {
     validate(offset, sizeof(uint32_t));
     uint32_t value = 0;
     sim_communicator_->pci_mem_read_bytes(get_physical_address(offset), &value, sizeof(uint32_t));
     return value;
 }
 
-void TTSimTlbWindow::write_register(
-    uint64_t offset, const void* data, size_t size, const std::function<bool()>& /*on_timeout*/) {
+void TTSimTlbWindow::write_register(uint64_t offset, const void* data, size_t size) {
     validate(offset, size);
     sim_communicator_->pci_mem_write_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
 }
 
-void TTSimTlbWindow::read_register(
-    uint64_t offset, void* data, size_t size, const std::function<bool()>& /*on_timeout*/) {
+void TTSimTlbWindow::read_register(uint64_t offset, void* data, size_t size) {
     validate(offset, size);
     sim_communicator_->pci_mem_read_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
 }
 
-void TTSimTlbWindow::write_block(
-    uint64_t offset, const void* data, size_t size, const std::function<bool()>& /*on_timeout*/) {
+void TTSimTlbWindow::write_block(uint64_t offset, const void* data, size_t size) {
     validate(offset, size);
     sim_communicator_->pci_mem_write_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
 }
 
-void TTSimTlbWindow::read_block(uint64_t offset, void* data, size_t size, const std::function<bool()>& /*on_timeout*/) {
+void TTSimTlbWindow::read_block(uint64_t offset, void* data, size_t size) {
     validate(offset, size);
     sim_communicator_->pci_mem_read_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
 }
@@ -73,12 +70,8 @@ uint64_t TTSimTlbWindow::get_physical_address(uint64_t offset) const {
     return reinterpret_cast<uint64_t>(tlb_handle->get_base()) + get_total_offset(offset);
 }
 
-void TTSimTlbWindow::safe_write16(uint64_t offset, uint16_t value, const std::function<bool()>& on_timeout) {
-    write16(offset, value, on_timeout);
-}
+void TTSimTlbWindow::safe_write16(uint64_t offset, uint16_t value) { write16(offset, value); }
 
-uint16_t TTSimTlbWindow::safe_read16(uint64_t offset, const std::function<bool()>& on_timeout) {
-    return read16(offset, on_timeout);
-}
+uint16_t TTSimTlbWindow::safe_read16(uint64_t offset) { return read16(offset); }
 
 }  // namespace tt::umd

--- a/device/pcie/tt_sim_tlb_window.cpp
+++ b/device/pcie/tt_sim_tlb_window.cpp
@@ -44,12 +44,14 @@ uint32_t TTSimTlbWindow::read32(uint64_t offset, const std::function<bool()>& /*
     return value;
 }
 
-void TTSimTlbWindow::write_register(uint64_t offset, const void* data, size_t size) {
+void TTSimTlbWindow::write_register(
+    uint64_t offset, const void* data, size_t size, const std::function<bool()>& /*on_timeout*/) {
     validate(offset, size);
     sim_communicator_->pci_mem_write_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
 }
 
-void TTSimTlbWindow::read_register(uint64_t offset, void* data, size_t size) {
+void TTSimTlbWindow::read_register(
+    uint64_t offset, void* data, size_t size, const std::function<bool()>& /*on_timeout*/) {
     validate(offset, size);
     sim_communicator_->pci_mem_read_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
 }

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -55,14 +55,21 @@ PcieProtocol::PcieProtocol(std::unique_ptr<PCIDevice> pci_device, bool use_safe_
 
 PcieProtocol::~PcieProtocol() = default;
 
-void PcieProtocol::set_io_timeout_callback(const std::function<bool(NocId)>& hang_check) { hang_check_ = hang_check; }
+void PcieProtocol::set_io_timeout_callback(const std::function<bool(NocId)>& hang_check) {
+    hang_check_ = hang_check;
+    // The cached window may already exist if I/O ran before the hang detector was wired; keep it in sync.
+    if (cached_tlb_window_ != nullptr) {
+        cached_tlb_window_->set_io_timeout_hang_check(hang_check_);
+    }
+}
 
 TlbWindow* PcieProtocol::get_cached_tlb_window() {
     if (cached_tlb_window_ == nullptr) {
         cached_tlb_window_ = std::make_unique<SiliconTlbWindow>(
             pci_device_->allocate_tlb(
                 pci_device_->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::UC),
-            tlb_data{});
+            tlb_data{},
+            hang_check_);
     }
     return cached_tlb_window_.get();
 }
@@ -88,28 +95,21 @@ void PcieProtocol::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t add
 template <bool safe>
 void PcieProtocol::write_to_device_impl(
     const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
-    // on_timeout consults the wired hang check for this op's NOC. true (NOC hung) aborts with
-    // DeviceTimeoutError; false (healthy) continues. With no hang check wired yet, an overrun aborts
-    // outright, preserving the no-callback throw-by-default behavior.
-    auto on_timeout = [this, noc_id]() -> bool { return hang_check_ ? hang_check_(noc_id) : true; };
+    // The cached window carries the per-op MMIO timeout veto (built from its configured NOC + the wired
+    // hang check); see SiliconTlbWindow. The reconfigure call sets the NOC before the transfer runs.
     if constexpr (safe) {
-        get_cached_tlb_window()->safe_write_block_reconfigure(
-            mem_ptr, core, addr, size, noc_id, tlb_data::Strict, on_timeout);
+        get_cached_tlb_window()->safe_write_block_reconfigure(mem_ptr, core, addr, size, noc_id);
     } else {
-        get_cached_tlb_window()->write_block_reconfigure(
-            mem_ptr, core, addr, size, noc_id, tlb_data::Strict, on_timeout);
+        get_cached_tlb_window()->write_block_reconfigure(mem_ptr, core, addr, size, noc_id);
     }
 }
 
 template <bool safe>
 void PcieProtocol::read_from_device_impl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
-    auto on_timeout = [this, noc_id]() -> bool { return hang_check_ ? hang_check_(noc_id) : true; };
     if constexpr (safe) {
-        get_cached_tlb_window()->safe_read_block_reconfigure(
-            mem_ptr, core, addr, size, noc_id, tlb_data::Strict, on_timeout);
+        get_cached_tlb_window()->safe_read_block_reconfigure(mem_ptr, core, addr, size, noc_id);
     } else {
-        get_cached_tlb_window()->read_block_reconfigure(
-            mem_ptr, core, addr, size, noc_id, tlb_data::Strict, on_timeout);
+        get_cached_tlb_window()->read_block_reconfigure(mem_ptr, core, addr, size, noc_id);
     }
 }
 
@@ -144,13 +144,12 @@ int PcieProtocol::get_mmio_id() { return pci_device_->get_pci_device_id(); }
 void PcieProtocol::noc_multicast_write(
     const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) {
     std::lock_guard<std::mutex> lock(io_lock_);
-    auto on_timeout = [this, noc_id]() -> bool { return hang_check_ ? hang_check_(noc_id) : true; };
     if (use_safe_api_) {
         get_cached_tlb_window()->safe_noc_multicast_write_reconfigure(
-            src, size, core_start, core_end, addr, noc_id, tlb_data::Strict, on_timeout);
+            src, size, core_start, core_end, addr, noc_id, tlb_data::Strict);
     } else {
         get_cached_tlb_window()->noc_multicast_write_reconfigure(
-            src, size, core_start, core_end, addr, noc_id, tlb_data::Strict, on_timeout);
+            src, size, core_start, core_end, addr, noc_id, tlb_data::Strict);
     }
 }
 

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -65,11 +65,9 @@ void PcieProtocol::set_io_timeout_callback(const std::function<bool(NocId)>& han
 
 TlbWindow* PcieProtocol::get_cached_tlb_window() {
     if (cached_tlb_window_ == nullptr) {
-        cached_tlb_window_ = std::make_unique<SiliconTlbWindow>(
-            pci_device_->allocate_tlb(
-                pci_device_->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::UC),
-            tlb_data{},
-            hang_check_);
+        cached_tlb_window_ = std::make_unique<SiliconTlbWindow>(pci_device_->allocate_tlb(
+            pci_device_->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::UC));
+        cached_tlb_window_->set_io_timeout_hang_check(hang_check_);
     }
     return cached_tlb_window_.get();
 }

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -55,10 +55,14 @@ PcieProtocol::PcieProtocol(std::unique_ptr<PCIDevice> pci_device, bool use_safe_
 
 PcieProtocol::~PcieProtocol() = default;
 
+void PcieProtocol::set_io_timeout_callback(const std::function<bool(NocId)>& hang_check) { hang_check_ = hang_check; }
+
 TlbWindow* PcieProtocol::get_cached_tlb_window() {
     if (cached_tlb_window_ == nullptr) {
-        cached_tlb_window_ = std::make_unique<SiliconTlbWindow>(pci_device_->allocate_tlb(
-            pci_device_->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::UC));
+        cached_tlb_window_ = std::make_unique<SiliconTlbWindow>(
+            pci_device_->allocate_tlb(
+                pci_device_->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::UC),
+            tlb_data{});
     }
     return cached_tlb_window_.get();
 }
@@ -84,19 +88,28 @@ void PcieProtocol::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t add
 template <bool safe>
 void PcieProtocol::write_to_device_impl(
     const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+    // on_timeout consults the wired hang check for this op's NOC. true (NOC hung) aborts with
+    // DeviceTimeoutError; false (healthy) continues. With no hang check wired yet, an overrun aborts
+    // outright, preserving the no-callback throw-by-default behavior.
+    auto on_timeout = [this, noc_id]() -> bool { return hang_check_ ? hang_check_(noc_id) : true; };
     if constexpr (safe) {
-        get_cached_tlb_window()->safe_write_block_reconfigure(mem_ptr, core, addr, size, noc_id);
+        get_cached_tlb_window()->safe_write_block_reconfigure(
+            mem_ptr, core, addr, size, noc_id, tlb_data::Strict, on_timeout);
     } else {
-        get_cached_tlb_window()->write_block_reconfigure(mem_ptr, core, addr, size, noc_id);
+        get_cached_tlb_window()->write_block_reconfigure(
+            mem_ptr, core, addr, size, noc_id, tlb_data::Strict, on_timeout);
     }
 }
 
 template <bool safe>
 void PcieProtocol::read_from_device_impl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+    auto on_timeout = [this, noc_id]() -> bool { return hang_check_ ? hang_check_(noc_id) : true; };
     if constexpr (safe) {
-        get_cached_tlb_window()->safe_read_block_reconfigure(mem_ptr, core, addr, size, noc_id);
+        get_cached_tlb_window()->safe_read_block_reconfigure(
+            mem_ptr, core, addr, size, noc_id, tlb_data::Strict, on_timeout);
     } else {
-        get_cached_tlb_window()->read_block_reconfigure(mem_ptr, core, addr, size, noc_id);
+        get_cached_tlb_window()->read_block_reconfigure(
+            mem_ptr, core, addr, size, noc_id, tlb_data::Strict, on_timeout);
     }
 }
 
@@ -131,12 +144,13 @@ int PcieProtocol::get_mmio_id() { return pci_device_->get_pci_device_id(); }
 void PcieProtocol::noc_multicast_write(
     const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) {
     std::lock_guard<std::mutex> lock(io_lock_);
+    auto on_timeout = [this, noc_id]() -> bool { return hang_check_ ? hang_check_(noc_id) : true; };
     if (use_safe_api_) {
         get_cached_tlb_window()->safe_noc_multicast_write_reconfigure(
-            src, size, core_start, core_end, addr, noc_id, tlb_data::Strict);
+            src, size, core_start, core_end, addr, noc_id, tlb_data::Strict, on_timeout);
     } else {
         get_cached_tlb_window()->noc_multicast_write_reconfigure(
-            src, size, core_start, core_end, addr, noc_id, tlb_data::Strict);
+            src, size, core_start, core_end, addr, noc_id, tlb_data::Strict, on_timeout);
     }
 }
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -28,6 +28,7 @@
 #include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/blackhole_tt_device.hpp"
+#include "umd/device/tt_device/hang_detection/hang_detector.hpp"
 #include "umd/device/tt_device/protocol/jtag_interface.hpp"
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
@@ -303,6 +304,37 @@ bool TTDevice::is_noc_hung(NocId noc, TTDevice::HangAction action) {
         return true;
     }
     return false;
+}
+
+void TTDevice::set_hang_detector(std::unique_ptr<HangDetector> hang_detector) {
+    hang_detector_ = std::move(hang_detector);
+
+    // The per-op timed MMIO path is PCIe-specific, so the hang-check wiring only applies to PCIe devices.
+    if (pcie_capabilities_ == nullptr) {
+        return;
+    }
+
+    // Route a single-op memcpy overrun to a NOC liveness check on the in-flight op's NOC: a hung NOC
+    // aborts the transfer with DeviceTimeoutError; a healthy NOC lets it continue.
+    pcie_capabilities_->set_io_timeout_callback(
+        [this](NocId noc) -> bool { return is_noc_hung(noc, HangAction::RETURN); });
+
+    // The liveness check runs from inside a timed-out memcpy that holds io_lock_, so it must read through a
+    // dedicated, separately-locked window rather than the protocol's cached window. The window and lock live
+    // in the lambda's capture; HangDetector only sees the std::function and stays unaware of either.
+    auto window = std::shared_ptr<TlbWindow>(get_io_window({}, TlbMapping::UC));
+    auto window_lock = std::make_shared<std::mutex>();
+    hang_detector_->set_noc_reg_reader([window, window_lock](tt_xy_pair core, uint64_t addr, NocId noc) -> uint32_t {
+        std::lock_guard<std::mutex> lock(*window_lock);
+        uint32_t value = 0;
+        try {
+            window->read_block_reconfigure(&value, core, addr, sizeof(value), noc);
+        } catch (const error::UmdException<error::DeviceTimeoutError> &) {
+            // The probe read carries its own per-op budget; an overrun means the NOC is hung.
+            return HANG_READ_VALUE;
+        }
+        return value;
+    });
 }
 
 // This is only needed for the BH workaround in iatu_configure_peer_region since no arc.

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -314,6 +314,13 @@ void TTDevice::set_hang_detector(std::unique_ptr<HangDetector> hang_detector) {
         return;
     }
 
+    // A null detector disables hang detection: clear any previously wired callback and stop before
+    // dereferencing it below.
+    if (hang_detector_ == nullptr) {
+        pcie_capabilities_->set_io_timeout_callback({});
+        return;
+    }
+
     // Route a single-op memcpy overrun to a NOC liveness check on the in-flight op's NOC: a hung NOC
     // aborts the transfer with DeviceTimeoutError; a healthy NOC lets it continue.
     pcie_capabilities_->set_io_timeout_callback(

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -30,6 +30,7 @@
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/risc_type.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/mmio_timeout_config.hpp"
 namespace nb = nanobind;
 // Releases Python's Global Interpreter Lock (GIL) for the duration of the C++ call,
 // allowing other Python threads to run in parallel while this binding executes. Pass
@@ -144,6 +145,21 @@ void bind_tt_device(nb::module_ &m) {
         []() { throw error::SigbusError("This is a test exception from C++"); },
         release_gil(),
         "A helper function to verify SigbusError propagation");
+
+    // Runtime-configurable per-op MMIO (TLB-mapped) transfer budget. Lets a script tune the timeout
+    // explicitly (e.g. tighten it for latency-sensitive ops). Values are datetime.timedelta.
+    nb::class_<MmioTimeoutConfig>(m, "MmioTimeoutConfig")
+        .def_static(
+            "set_op_timeout",
+            &MmioTimeoutConfig::set_op_timeout,
+            nb::arg("timeout"),
+            release_gil(),
+            "Set the per-op MMIO transfer budget (datetime.timedelta).")
+        .def_static(
+            "get_op_timeout",
+            &MmioTimeoutConfig::get_op_timeout,
+            release_gil(),
+            "Get the current per-op MMIO transfer budget (datetime.timedelta).");
 
     nb::class_<PciDeviceInfo>(m, "PciDeviceInfo")
         .def_ro("vendor_id", &PciDeviceInfo::vendor_id)

--- a/tests/api/test_hang_detection.cpp
+++ b/tests/api/test_hang_detection.cpp
@@ -5,6 +5,7 @@
 #include <fmt/base.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <set>
@@ -29,6 +30,7 @@
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/mmio_timeout_config.hpp"
 #include "utils.hpp"
 
 using namespace tt;
@@ -63,8 +65,10 @@ protected:
     // Deliberately hangs the specified NOC by reading an address that causes the NOC transaction to
     // never complete. On WH, this targets a TDMA register on the tensix core. On BH, the tensix core
     // is first put into reset, then a read to a private tensix address is issued. Both approaches were
-    // empirically found by the tt-exalens team to reliably hang the NOC.
-    uint32_t hang_noc(tt_xy_pair tensix_core, NocId noc = NocId::NOC0) {
+    // empirically found by the tt-exalens team to reliably hang the NOC. Returns nothing: the read's
+    // value is meaningless here (and with the per-op MMIO timeout active the read aborts before it can
+    // return one) — the NOC is hung regardless. Callers verify the hang via is_noc_hung() / the timeout.
+    void hang_noc(tt_xy_pair tensix_core, NocId noc = NocId::NOC0) {
         uint32_t hang_read_value = 0;
         if (tt_device_->get_arch() == tt::ARCH::BLACKHOLE) {
             tt_device_->set_risc_reset_state(
@@ -72,9 +76,13 @@ protected:
                 tt_device_->get_architecture_implementation()->get_soft_reset_reg_value(RiscType::ALL_TENSIX));
         }
         NocIdSwitcher switcher(noc);
-        tt_device_->read_from_device(
-            &hang_read_value, tensix_core, noc_hang_addr(tt_device_->get_arch()), sizeof(hang_read_value));
-        return hang_read_value;
+        try {
+            tt_device_->read_from_device(
+                &hang_read_value, tensix_core, noc_hang_addr(tt_device_->get_arch()), sizeof(hang_read_value));
+        } catch (const error::UmdException<error::DeviceTimeoutError>&) {
+            // Once the per-op MMIO timeout is active, the hang-inducing read stalls past the
+            // default 100 ms budget and aborts before returning. The NOC is hung regardless.
+        }
     }
 
     void warm_reset_and_reinit() {
@@ -90,7 +98,7 @@ protected:
         init_device(pci_device_id);
     }
 
-private:
+protected:
     uint64_t noc_hang_addr(tt::ARCH arch) {
         switch (arch) {
             case tt::ARCH::WORMHOLE_B0:
@@ -166,6 +174,44 @@ TEST_P(NocHangDetectionTest, DISABLED_TestIsNocHungAPI) {
 
     EXPECT_FALSE(tt_device_->is_noc_hung(noc_to_hang, TTDevice::HangAction::RETURN))
         << "is_noc_hung() still true after warm reset.";
+}
+
+// Verifies the per-op MMIO timeout (PR #2629) on the memcpy read path and that it is runtime
+// configurable via MmioTimeoutConfig: once a NOC is hung its reads complete only after ~700 ms, so a
+// budget below that aborts the memcpy with DeviceTimeoutError (instead of letting ops pile up and grind
+// the host), while a budget above it lets the same read complete. Exercises two budgets to show usage.
+TEST_P(NocHangDetectionTest, DISABLED_PerOpTimeoutThrowsOnHungNoc) {
+    NocId noc_to_hang = GetParam();
+
+    if (tt_device_->get_arch() == tt::ARCH::BLACKHOLE && noc_to_hang == NocId::NOC0) {
+        GTEST_SKIP()
+            << "BH: Hanging NOC0 on BH can prevent warm reset from working and a host reboot is then necessary.";
+    }
+
+    tt_xy_pair tensix_core = soc_desc_->get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)[0];
+    hang_noc(tensix_core, noc_to_hang);
+
+    const auto original_budget = MmioTimeoutConfig::get_op_timeout();
+    uint32_t value = 0;
+    NocIdSwitcher switcher(noc_to_hang);
+
+    // Budget 1: tight (below the ~700 ms hung-read latency) — the memcpy read trips the per-op timeout.
+    MmioTimeoutConfig::set_op_timeout(std::chrono::milliseconds(100));
+    EXPECT_THROW(
+        tt_device_->read_from_device(&value, tensix_core, noc_hang_addr(tt_device_->get_arch()), sizeof(value)),
+        error::UmdException<error::DeviceTimeoutError>)
+        << "A read on the hung NOC should trip the 100 ms per-op budget.";
+
+    // Budget 2: generous (above the hung-read latency) — the same read completes without tripping.
+    MmioTimeoutConfig::set_op_timeout(std::chrono::milliseconds(5000));
+    EXPECT_NO_THROW(
+        tt_device_->read_from_device(&value, tensix_core, noc_hang_addr(tt_device_->get_arch()), sizeof(value)))
+        << "A 5 s per-op budget should outlast the hung-read latency.";
+
+    // Restore the process-global default so the change doesn't leak into other tests.
+    MmioTimeoutConfig::set_op_timeout(original_budget);
+
+    warm_reset_and_reinit();
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/api/test_tlb_manager.cpp
+++ b/tests/api/test_tlb_manager.cpp
@@ -22,12 +22,24 @@
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/tlb.hpp"
+#include "umd/device/utils/mmio_timeout_config.hpp"
+#include "umd/device/utils/timeouts.hpp"
 
 using namespace tt;
 using namespace tt::umd;
 
+// The TLBManager window here comes from get_io_window, which carries no hang-detector veto, so a single
+// MMIO op that stalls on a contended host would trip the tight default per-op budget and throw
+// DeviceTimeoutError. Widen the budget for the test and restore the default afterwards.
+class ApiTLBManager : public ::testing::Test {
+protected:
+    void SetUp() override { MmioTimeoutConfig::set_op_timeout(std::chrono::milliseconds(100)); }
+
+    void TearDown() override { MmioTimeoutConfig::set_op_timeout(timeout::MMIO_OP_TIMEOUT); }
+};
+
 // TODO: Once default auto TLB setup is in, check it is setup properly.
-TEST(ApiTLBManager, ManualTLBConfiguration) {
+TEST_F(ApiTLBManager, ManualTLBConfiguration) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
 
     for (int pci_device_id : pci_device_ids) {

--- a/tests/unified/test_tlb.cpp
+++ b/tests/unified/test_tlb.cpp
@@ -23,7 +23,9 @@
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/tlb.hpp"
 #include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/mmio_timeout_config.hpp"
 #include "umd/device/utils/semver.hpp"
+#include "umd/device/utils/timeouts.hpp"
 
 using namespace tt;
 using namespace tt::umd;
@@ -34,7 +36,18 @@ bool is_kmd_version_good() {
     return kmd_ver.major > 1 || (kmd_ver.major == 1 && kmd_ver.minor >= 34);
 }
 
-TEST(TestTlb, TestTlbWindowAllocateNew) {
+// Every TestTlb case drives a TLB window directly (raw SiliconTlbWindow / static TLB window), so the
+// op carries no hang-detector veto: a single MMIO transfer that stalls on a contended host would trip
+// the tight default per-op budget and throw DeviceTimeoutError. Widen the budget for the duration of
+// each test and restore the default afterwards so the override never leaks into other tests.
+class TestTlb : public ::testing::Test {
+protected:
+    void SetUp() override { MmioTimeoutConfig::set_op_timeout(std::chrono::milliseconds(100)); }
+
+    void TearDown() override { MmioTimeoutConfig::set_op_timeout(timeout::MMIO_OP_TIMEOUT); }
+};
+
+TEST_F(TestTlb, TestTlbWindowAllocateNew) {
     if (!is_kmd_version_good()) {
         GTEST_SKIP() << "Skipping test because of old KMD version. Required version of KMD is 1.34 or higher.";
     }
@@ -80,7 +93,7 @@ TEST(TestTlb, TestTlbWindowAllocateNew) {
     }
 }
 
-TEST(TestTlb, TestTlbWindowReuse) {
+TEST_F(TestTlb, TestTlbWindowReuse) {
     if (!is_kmd_version_good()) {
         GTEST_SKIP() << "Skipping test because of old KMD version. Required version of KMD is 1.34 or higher.";
     }
@@ -132,7 +145,7 @@ TEST(TestTlb, TestTlbWindowReuse) {
 }
 
 // TODO: debug this test failing on T3K.
-TEST(TestTlb, DISABLED_TestTlbWindowReadRegister) {
+TEST_F(TestTlb, DISABLED_TestTlbWindowReadRegister) {
     if (!is_kmd_version_good()) {
         GTEST_SKIP() << "Skipping test because of old KMD version. Required version of KMD is 1.34 or higher.";
     }
@@ -179,7 +192,7 @@ TEST(TestTlb, DISABLED_TestTlbWindowReadRegister) {
     }
 }
 
-TEST(TestTlb, TestTlbWindowReadWrite) {
+TEST_F(TestTlb, TestTlbWindowReadWrite) {
     if (!is_kmd_version_good()) {
         GTEST_SKIP() << "Skipping test because of old KMD version. Required version of KMD is 1.34 or higher.";
     }
@@ -223,7 +236,7 @@ TEST(TestTlb, TestTlbWindowReadWrite) {
     }
 }
 
-TEST(TestTlb, TestTlbWindowReadWrite16) {
+TEST_F(TestTlb, TestTlbWindowReadWrite16) {
     if (!is_kmd_version_good()) {
         GTEST_SKIP() << "Skipping test because of old KMD version. Required version of KMD is 1.34 or higher.";
     }
@@ -292,7 +305,7 @@ TEST(TestTlb, TestTlbWindowReadWrite16) {
     }
 }
 
-TEST(TestTlb, TestTlbWrite16DoesNotCorruptAdjacentData) {
+TEST_F(TestTlb, TestTlbWrite16DoesNotCorruptAdjacentData) {
     if (!is_kmd_version_good()) {
         GTEST_SKIP() << "Skipping test because of old KMD version. Required version of KMD is 1.34 or higher.";
     }
@@ -345,7 +358,7 @@ TEST(TestTlb, TestTlbWrite16DoesNotCorruptAdjacentData) {
     }
 }
 
-TEST(TestTlb, TestTlbOffsetReadWrite) {
+TEST_F(TestTlb, TestTlbOffsetReadWrite) {
     if (!is_kmd_version_good()) {
         GTEST_SKIP() << "Skipping test because of old KMD version. Required version of KMD is 1.34 or higher.";
     }
@@ -408,7 +421,7 @@ TEST(TestTlb, TestTlbOffsetReadWrite) {
     }
 }
 
-TEST(TestTlb, TestTlbAccessOutofBounds) {
+TEST_F(TestTlb, TestTlbAccessOutofBounds) {
     if (!is_kmd_version_good()) {
         GTEST_SKIP() << "Skipping test because of old KMD version. Required version of KMD is 1.34 or higher.";
     }
@@ -462,7 +475,7 @@ TEST(TestTlb, TestTlbAccessOutofBounds) {
     }
 }
 
-TEST(TestTlb, TLBStaticTensix) {
+TEST_F(TestTlb, TLBStaticTensix) {
     std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     const size_t tlb_size = cluster->get_tt_device(0)->get_arch() == tt::ARCH::WORMHOLE_B0 ? (1 << 20) : (1 << 21);
@@ -495,7 +508,7 @@ TEST(TestTlb, TLBStaticTensix) {
     }
 }
 
-TEST(TestTlb, TestRegisterReconfigureL1RoundTrip) {
+TEST_F(TestTlb, TestRegisterReconfigureL1RoundTrip) {
     if (!is_kmd_version_good()) {
         GTEST_SKIP() << "Skipping test because of old KMD version. Required version of KMD is 1.34 or higher.";
     }


### PR DESCRIPTION
### Issue

#1673

### Description

`memcpy_to_device` / `memcpy_from_device` store/load against TLB-mapped device memory with no liveness check. The existing SIGBUS guard (`SiliconTlbWindow::execute_safe`) only recovers when the platform PCIe completion timeout fires (a mapping/hardware fault), so it misses two cases: **slow degradation** (ops complete, just far slower — the host grinds) and **posted-write pile-up** (writes succeed locally into a dead device before back-pressure stalls the CPU).

This PR adds a **per-op wall-clock budget** to the TLB-touching transfer paths: each transfer constructs an `OpTimeoutGuard` (from #2842) with the per-op budget, an optional liveness veto, and an overrun action that throws `DeviceTimeoutError` (from #2840). On overrun the veto decides:

- **no veto, or veto reports the NOC hung** → throw `DeviceTimeoutError`;
- **veto reports the NOC healthy** → continue; the next op gets a fresh budget.

The veto consumer is `HangDetector`, wired by `TTDevice::set_hang_detector` (called from the Wormhole/Blackhole device constructors). The hang check is stored on the `SiliconTlbWindow` (via `set_io_timeout_hang_check`), which binds the in-flight NOC into the per-op veto. On PCIe the liveness check runs from inside the timed-out transfer, so it reads through a dedicated, separately-locked probe window owned by the injected reader lambda — it never re-takes the `io_lock_` the stalled op holds and never recurses into the timed path. Only single-op stalls are caught; total transfer time is not bounded, and the check cannot preempt a CPU already stalled mid-access (SIGBUS still covers mapping invalidation, e.g. on reset).

The default budget is `timeout::MMIO_OP_TIMEOUT` (**10 ms**, headroom over the multi-ms single-op latency seen on contended/virtualized hosts) and is configurable at runtime via `MmioTimeoutConfig::set_op_timeout`, also exposed to Python as `tt_umd.MmioTimeoutConfig`. The budget bounds a single op (a bulk block, finer in the tails), not the whole transfer.

### List of the changes

- **`MmioTimeoutConfig`** — runtime-configurable per-op budget (default `timeout::MMIO_OP_TIMEOUT` = 10 ms), exposed to Python; non-positive values disable the check.
- **device_memcpy** — `memcpy_to_device` / `memcpy_from_device` and the `write16`/`write32`/`read16`/`read32` scalar helpers take an optional `std::function<bool()> on_timeout`; a `make_mmio_timeout_guard` helper builds the `OpTimeoutGuard` whose overrun action throws `DeviceTimeoutError`. Existing callers compile unchanged.
- **TlbWindow** — new `set_io_timeout_hang_check`; `SiliconTlbWindow` stores the hang check, builds the per-op veto from it, and rebuilds on config changes. `LocalChip` installs it on its cached WC/UC windows and `PcieProtocol` on its cached window.
- **PcieProtocol / TTDevice** — `PcieInterface::set_io_timeout_callback` forwards the hang check to the cached window (no side-channel member); `TTDevice::set_hang_detector` wires the callback and, on PCIe, hands the hang detector a dedicated, separately-locked probe window owned by the injected lambda (with a null-detector guard).
- **Tests** — `tests/api/test_hang_detection.cpp` exercises the timeout on a hung NOC; `test_tlb` / `test_tlb_manager` drive TLB windows with no veto wired, so they widen the budget via `MmioTimeoutConfig` for each test and restore the default afterwards.

### Testing

CI

### API Changes

- New optional `on_timeout` (`std::function<bool()>`) parameter on `memcpy_to_device` / `memcpy_from_device` and the `write16`/`write32`/`read16`/`read32` device scalar helpers — existing call sites compile unchanged.
- New `TlbWindow::set_io_timeout_hang_check` and `PcieInterface::set_io_timeout_callback`.
- New `tt::umd::MmioTimeoutConfig` (`set_op_timeout` / `get_op_timeout`), also exposed to Python as `tt_umd.MmioTimeoutConfig`; default `tt::umd::timeout::MMIO_OP_TIMEOUT` = 10 ms.

Note: uses `OpTimeoutGuard` from #2842 and `DeviceTimeoutError` from #2840, both already on `main`.
