### PR TITLE
Tooling test adjustment

### DIFF
--- a/.github/workflows/run-tooling-tests.yml
+++ b/.github/workflows/run-tooling-tests.yml
@@ -71,25 +71,8 @@ jobs:
       - name: Install UMD wheel
         run: pip install tt_umd-*.whl --force-reinstall
 
-      # Textual provides App.run_test(headless=True) for testing TUIs without a real terminal.
-      # This discovers devices via UMD, initializes the tt-smi backend and app, renders one
-      # frame in headless mode, then quits — exercising the full startup path on real hardware.
+      # tt-smi -ls runs full UMD discovery (using tt-smi's own TopologyDiscoveryOptions)
+      # and the full backend init (telemetry, firmware, board info), prints the board list,
+      # and exits non-interactively. Picks up any future tt-smi option changes automatically.
       - name: Run tt-smi
-        run: |
-          python3 - << 'EOF'
-          import asyncio
-          from tt_umd import TopologyDiscovery
-          from tt_smi.frontend import TTSMI
-          from tt_smi.backend import TTSMIBackend
-
-          cluster_descriptor, devices = TopologyDiscovery.discover()
-          backend = TTSMIBackend(devices=devices, umd_cluster_descriptor=cluster_descriptor, pretty_output=False)
-          app = TTSMI(backend=backend)
-
-          async def run():
-              async with app.run_test(headless=True) as pilot:
-                  await pilot.press("q")
-
-          asyncio.run(asyncio.wait_for(run(), timeout=60))
-          print("tt-smi ran successfully")
-          EOF
+        run: tt-smi -ls


### PR DESCRIPTION
### Issue


### Description
Motivation was that on some of the runs I realised that topology discovery options are differing from the original ones used by tt-smi

### List of the changes
- Don't use custom code, just call tt-smi -ls

### Testing
Introduced a fake failure here, expecting it to fail, it is based on this branch: https://github.com/tenstorrent/tt-umd/actions/runs/25829071197

### API Changes
There are no API changes in this PR.
