### PR TITLE
[Quasar] Add QuasarCoordinateManager (identity translated mapping)

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -110,6 +110,7 @@ target_sources(
         soc_descriptor.cpp
         coordinates/wormhole_coordinate_manager.cpp
         coordinates/blackhole_coordinate_manager.cpp
+        coordinates/quasar_coordinate_manager.cpp
         arc/arc_telemetry_reader.cpp
         arc/wormhole_arc_telemetry_reader.cpp
         arc/blackhole_arc_telemetry_reader.cpp
@@ -183,6 +184,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/arc/wormhole_arc_messenger.hpp
                 api/umd/device/arc/wormhole_arc_telemetry_reader.hpp
                 api/umd/device/coordinates/blackhole_coordinate_manager.hpp
+                api/umd/device/coordinates/quasar_coordinate_manager.hpp
                 api/umd/device/arch/blackhole_implementation.hpp
                 api/umd/device/chip/chip.hpp
                 api/umd/device/chip/local_chip.hpp

--- a/device/api/umd/device/coordinates/quasar_coordinate_manager.hpp
+++ b/device/api/umd/device/coordinates/quasar_coordinate_manager.hpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "umd/device/arch/grendel_implementation.hpp"
+#include "umd/device/coordinates/coordinate_manager.hpp"
+#include "umd/device/types/xy_pair.hpp"
+
+namespace tt {
+struct HarvestingMasks;
+}  // namespace tt
+
+namespace tt::umd {
+
+// TODO (#2494): Quasar silicon NOC translation tables are not yet finalized.
+// Until they are, this manager maps every core's NOC0 coordinate to itself in
+// the TRANSLATED system. This is sufficient for simulation, where the SOC
+// descriptor YAML supplies the actual NOC0 layout. Replace the fill_* overrides
+// with real Quasar translated-coordinate logic once the hardware spec is known.
+class QuasarCoordinateManager : public CoordinateManager {
+public:
+    QuasarCoordinateManager(
+        const bool noc_translation_enabled,
+        HarvestingMasks harvesting_masks,
+        const tt_xy_pair& tensix_grid_size,
+        const std::vector<tt_xy_pair>& tensix_cores,
+        const tt_xy_pair& dram_grid_size,
+        const std::vector<tt_xy_pair>& dram_cores,
+        const std::vector<tt_xy_pair>& eth_cores,
+        const tt_xy_pair& arc_grid_size,
+        const std::vector<tt_xy_pair>& arc_cores,
+        const tt_xy_pair& pcie_grid_size,
+        const std::vector<tt_xy_pair>& pcie_cores,
+        const std::vector<tt_xy_pair>& router_cores,
+        const std::vector<tt_xy_pair>& security_cores,
+        const std::vector<tt_xy_pair>& l2cpu_cores,
+        const std::vector<tt_xy_pair>& dispatch_cores,
+        const std::vector<uint32_t>& noc0_x_to_noc1_x = {},
+        const std::vector<uint32_t>& noc0_y_to_noc1_y = {});
+
+protected:
+    void fill_tensix_noc0_translated_mapping() override;
+    void fill_dram_noc0_translated_mapping() override;
+    void fill_eth_noc0_translated_mapping() override;
+    void fill_pcie_noc0_translated_mapping() override;
+    void fill_arc_noc0_translated_mapping() override;
+
+    tt_xy_pair get_tensix_grid_size() const override;
+};
+
+}  // namespace tt::umd

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -547,7 +547,12 @@ std::unique_ptr<ClusterDescriptor> ClusterDescriptor::create_mock_cluster(
         case tt::ARCH::WORMHOLE_B0:
             board_type = BoardType::N150;
             break;
-        case tt::ARCH::QUASAR:  // TODO (#450): Add Quasar configuration
+        case tt::ARCH::QUASAR:
+            // TODO (#450): Add Quasar configuration. Until the hardware spec is finalized
+            // we leave all harvesting masks at 0 rather than borrowing Blackhole's silicon
+            // example, which doesn't apply to Quasar's ETH layout.
+            board_type = BoardType::UNKNOWN;
+            break;
         case tt::ARCH::BLACKHOLE:
             board_type = BoardType::UNKNOWN;
             // Example value from silicon machine.

--- a/device/coordinates/coordinate_manager.cpp
+++ b/device/coordinates/coordinate_manager.cpp
@@ -13,9 +13,11 @@
 
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
+#include "umd/device/arch/grendel_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/coordinates/blackhole_coordinate_manager.hpp"
 #include "umd/device/coordinates/coordinate_manager.hpp"
+#include "umd/device/coordinates/quasar_coordinate_manager.hpp"
 #include "umd/device/coordinates/wormhole_coordinate_manager.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/utils/common.hpp"
@@ -676,7 +678,29 @@ std::shared_ptr<CoordinateManager> CoordinateManager::create_coordinate_manager(
                 {},
                 wormhole::NOC0_X_TO_NOC1_X,
                 wormhole::NOC0_Y_TO_NOC1_Y);
-        case tt::ARCH::QUASAR:  // TODO (#450): Add Quasar configuration
+        case tt::ARCH::QUASAR: {
+            // TODO (#2494): Replace grendel::DISPATCH_CORES_NOC0 ({}) with real Quasar dispatch locations
+            // once finalized, and revisit translated-coordinate tables in QuasarCoordinateManager.
+            return create_coordinate_manager(
+                arch,
+                noc_translation_enabled,
+                harvesting_masks,
+                grendel::TENSIX_GRID_SIZE,
+                grendel::TENSIX_CORES_NOC0,
+                grendel::DRAM_GRID_SIZE,
+                flatten_vector(grendel::DRAM_CORES_NOC0),
+                grendel::ETH_CORES_NOC0,
+                grendel::ARC_GRID_SIZE,
+                grendel::ARC_CORES_NOC0,
+                grendel::PCIE_GRID_SIZE,
+                grendel::PCIE_CORES_NOC0,
+                grendel::ROUTER_CORES_NOC0,
+                grendel::SECURITY_CORES_NOC0,
+                grendel::L2CPU_CORES_NOC0,
+                grendel::DISPATCH_CORES_NOC0,
+                grendel::NOC0_X_TO_NOC1_X,
+                grendel::NOC0_Y_TO_NOC1_Y);
+        }
         case tt::ARCH::BLACKHOLE: {
             return create_coordinate_manager(
                 arch,
@@ -743,7 +767,27 @@ std::shared_ptr<CoordinateManager> CoordinateManager::create_coordinate_manager(
                 dispatch_cores,
                 noc0_x_to_noc1_x,
                 noc0_y_to_noc1_y);
-        case tt::ARCH::QUASAR:  // TODO (#450): Add Quasar configuration
+        case tt::ARCH::QUASAR:
+            // TODO (#2494): QuasarCoordinateManager currently maps NOC0 -> TRANSLATED as identity.
+            // Replace with real Quasar NOC translation tables once the hardware spec is finalized.
+            return std::make_shared<QuasarCoordinateManager>(
+                noc_translation_enabled,
+                harvesting_masks,
+                tensix_grid_size,
+                tensix_cores,
+                dram_grid_size,
+                dram_cores,
+                eth_cores,
+                arc_grid_size,
+                arc_cores,
+                pcie_grid_size,
+                pcie_cores,
+                router_cores,
+                security_cores,
+                l2cpu_cores,
+                dispatch_cores,
+                noc0_x_to_noc1_x,
+                noc0_y_to_noc1_y);
         case tt::ARCH::BLACKHOLE:
             return std::make_shared<BlackholeCoordinateManager>(
                 noc_translation_enabled,

--- a/device/coordinates/quasar_coordinate_manager.cpp
+++ b/device/coordinates/quasar_coordinate_manager.cpp
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/coordinates/quasar_coordinate_manager.hpp"
+
+#include "umd/device/types/cluster_descriptor_types.hpp"
+
+namespace tt::umd {
+
+QuasarCoordinateManager::QuasarCoordinateManager(
+    const bool noc_translation_enabled,
+    HarvestingMasks harvesting_masks,
+    const tt_xy_pair& tensix_grid_size,
+    const std::vector<tt_xy_pair>& tensix_cores,
+    const tt_xy_pair& dram_grid_size,
+    const std::vector<tt_xy_pair>& dram_cores,
+    const std::vector<tt_xy_pair>& eth_cores,
+    const tt_xy_pair& arc_grid_size,
+    const std::vector<tt_xy_pair>& arc_cores,
+    const tt_xy_pair& pcie_grid_size,
+    const std::vector<tt_xy_pair>& pcie_cores,
+    const std::vector<tt_xy_pair>& router_cores,
+    const std::vector<tt_xy_pair>& security_cores,
+    const std::vector<tt_xy_pair>& l2cpu_cores,
+    const std::vector<tt_xy_pair>& dispatch_cores,
+    const std::vector<uint32_t>& noc0_x_to_noc1_x,
+    const std::vector<uint32_t>& noc0_y_to_noc1_y) :
+    CoordinateManager(
+        noc_translation_enabled,
+        harvesting_masks,
+        tensix_grid_size,
+        tensix_cores,
+        dram_grid_size,
+        dram_cores,
+        eth_cores,
+        arc_grid_size,
+        arc_cores,
+        pcie_grid_size,
+        pcie_cores,
+        router_cores,
+        security_cores,
+        l2cpu_cores,
+        dispatch_cores,
+        noc0_x_to_noc1_x,
+        noc0_y_to_noc1_y) {
+    initialize();
+}
+
+// TODO (#2494): Replace identity translated mappings with real Quasar NOC
+// translation once the hardware spec is finalized.
+void QuasarCoordinateManager::fill_tensix_noc0_translated_mapping() { fill_tensix_default_noc0_translated_mapping(); }
+
+void QuasarCoordinateManager::fill_dram_noc0_translated_mapping() { fill_dram_default_noc0_translated_mapping(); }
+
+void QuasarCoordinateManager::fill_eth_noc0_translated_mapping() { fill_eth_default_noc0_translated_mapping(); }
+
+void QuasarCoordinateManager::fill_pcie_noc0_translated_mapping() { fill_pcie_default_noc0_translated_mapping(); }
+
+void QuasarCoordinateManager::fill_arc_noc0_translated_mapping() { fill_arc_default_noc0_translated_mapping(); }
+
+tt_xy_pair QuasarCoordinateManager::get_tensix_grid_size() const {
+    return {tensix_grid_size.x, tensix_grid_size.y - get_num_harvested(harvesting_masks.tensix_harvesting_mask)};
+}
+
+}  // namespace tt::umd

--- a/tests/baremetal/CMakeLists.txt
+++ b/tests/baremetal/CMakeLists.txt
@@ -2,6 +2,7 @@ set(BAREMETAL_TESTS_SRCS
     test_cluster_descriptor_offline.cpp
     test_core_coord_translation_wh.cpp
     test_core_coord_translation_bh.cpp
+    test_core_coord_translation_quasar.cpp
     test_soc_arch_descriptor.cpp
     test_soc_descriptor.cpp
     test_long_jump.cpp

--- a/tests/baremetal/test_core_coord_translation_quasar.cpp
+++ b/tests/baremetal/test_core_coord_translation_quasar.cpp
@@ -1,0 +1,230 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <set>
+#include <stdexcept>
+#include <vector>
+
+#include "umd/device/arch/grendel_implementation.hpp"
+#include "umd/device/coordinates/coordinate_manager.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/common.hpp"
+
+using namespace tt;
+using namespace tt::umd;
+
+// QuasarCoordinateManager currently maps every NOC0 coordinate to itself in
+// the TRANSLATED system (see #2494). These tests assert that identity mapping
+// for every core type the manager handles, plus the logical/NOC0/NOC1 and
+// harvesting plumbing inherited from CoordinateManager.
+
+namespace {
+
+// Checks that NOC0 -> TRANSLATED is an identity on (x, y). The placeholder
+// Quasar arch constants have overlapping NOC0 entries across core types
+// (e.g. {9, 2} is in both TENSIX_CORES_NOC0 and DRAM_CORES_NOC0), so the
+// looked-up TRANSLATED core_type is not guaranteed to match the requested
+// one — but the coordinate identity is what QuasarCoordinateManager actually
+// promises.
+void expect_identity_translated_for_cores(
+    const std::shared_ptr<CoordinateManager>& cm, const std::vector<tt_xy_pair>& cores_noc0, CoreType core_type) {
+    for (const tt_xy_pair& core_noc0 : cores_noc0) {
+        const CoreCoord noc0(core_noc0.x, core_noc0.y, core_type, CoordSystem::NOC0);
+        const CoreCoord translated = cm->translate_coord_to(noc0, CoordSystem::TRANSLATED);
+        EXPECT_EQ(translated.x, core_noc0.x);
+        EXPECT_EQ(translated.y, core_noc0.y);
+        EXPECT_EQ(translated.coord_system, CoordSystem::TRANSLATED);
+    }
+}
+
+}  // namespace
+
+// With no harvesting, the logical grid covers all TENSIX_GRID_SIZE cores in
+// row-major order and every NOC0 coordinate maps to itself in TRANSLATED.
+TEST(CoordinateManager, CoordinateManagerQuasarNoHarvesting) {
+    std::shared_ptr<CoordinateManager> cm = CoordinateManager::create_coordinate_manager(tt::ARCH::QUASAR, true);
+
+    const tt_xy_pair grid = grendel::TENSIX_GRID_SIZE;
+    EXPECT_EQ(cm->get_grid_size(CoreType::TENSIX).x, grid.x);
+    EXPECT_EQ(cm->get_grid_size(CoreType::TENSIX).y, grid.y);
+
+    for (size_t y = 0; y < grid.y; y++) {
+        for (size_t x = 0; x < grid.x; x++) {
+            const CoreCoord logical(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
+            const CoreCoord noc0 = cm->translate_coord_to(logical, CoordSystem::NOC0);
+            const CoreCoord translated = cm->translate_coord_to(logical, CoordSystem::TRANSLATED);
+            const tt_xy_pair expected_noc0 = grendel::TENSIX_CORES_NOC0[y * grid.x + x];
+
+            EXPECT_EQ(noc0.x, expected_noc0.x);
+            EXPECT_EQ(noc0.y, expected_noc0.y);
+            EXPECT_EQ(translated.x, noc0.x);
+            EXPECT_EQ(translated.y, noc0.y);
+        }
+    }
+}
+
+// Harvesting the first NOC0 row shifts the top-left logical core onto the
+// second NOC0 row of TENSIX_CORES_NOC0.
+TEST(CoordinateManager, CoordinateManagerQuasarTopLeftCoreHarvested) {
+    const size_t tensix_harvesting_mask = (1 << 0);
+    std::shared_ptr<CoordinateManager> cm = CoordinateManager::create_coordinate_manager(
+        tt::ARCH::QUASAR, true, {.tensix_harvesting_mask = tensix_harvesting_mask});
+
+    const tt_xy_pair grid = cm->get_grid_size(CoreType::TENSIX);
+    EXPECT_EQ(grid.x, grendel::TENSIX_GRID_SIZE.x);
+    EXPECT_EQ(grid.y, grendel::TENSIX_GRID_SIZE.y - 1);
+
+    const CoreCoord logical(0, 0, CoreType::TENSIX, CoordSystem::LOGICAL);
+    const CoreCoord noc0 = cm->translate_coord_to(logical, CoordSystem::NOC0);
+    const tt_xy_pair expected_noc0 = grendel::TENSIX_CORES_NOC0[grendel::TENSIX_GRID_SIZE.x];
+    EXPECT_EQ(noc0.x, expected_noc0.x);
+    EXPECT_EQ(noc0.y, expected_noc0.y);
+
+    const CoreCoord translated = cm->translate_coord_to(logical, CoordSystem::TRANSLATED);
+    EXPECT_EQ(translated.x, noc0.x);
+    EXPECT_EQ(translated.y, noc0.y);
+}
+
+// Logical <-> NOC0 must be a bijection on the unharvested grid for every
+// possible tensix harvesting mask.
+TEST(CoordinateManager, CoordinateManagerQuasarLogicalNOC0Mapping) {
+    const size_t num_rows = grendel::TENSIX_GRID_SIZE.y;
+
+    for (size_t harvesting = 0; harvesting < (1u << num_rows); harvesting++) {
+        std::shared_ptr<CoordinateManager> cm = CoordinateManager::create_coordinate_manager(
+            tt::ARCH::QUASAR, true, {.tensix_harvesting_mask = harvesting});
+
+        const size_t num_harvested = CoordinateManager::get_num_harvested(harvesting);
+        const tt_xy_pair grid = grendel::TENSIX_GRID_SIZE;
+
+        std::set<CoreCoord> noc0_seen;
+        for (size_t y = 0; y < grid.y - num_harvested; y++) {
+            for (size_t x = 0; x < grid.x; x++) {
+                const CoreCoord logical(x, y, CoreType::TENSIX, CoordSystem::LOGICAL);
+                const CoreCoord noc0 = cm->translate_coord_to(logical, CoordSystem::NOC0);
+                EXPECT_EQ(noc0_seen.count(noc0), 0u);
+                noc0_seen.insert(noc0);
+
+                const CoreCoord back = cm->translate_coord_to(noc0, CoordSystem::LOGICAL);
+                EXPECT_EQ(back, logical);
+            }
+        }
+        EXPECT_EQ(noc0_seen.size(), grid.x * (grid.y - num_harvested));
+    }
+}
+
+// Even rows hidden from the logical grid by tensix harvesting still get an
+// identity TRANSLATED entry, since Quasar's fill_tensix_noc0_translated_mapping
+// delegates to the base-class identity default.
+TEST(CoordinateManager, CoordinateManagerQuasarTensixTranslatedMappingHarvested) {
+    const size_t tensix_harvesting_mask = (1 << 0) | (1 << 2);
+    std::shared_ptr<CoordinateManager> cm = CoordinateManager::create_coordinate_manager(
+        tt::ARCH::QUASAR, true, {.tensix_harvesting_mask = tensix_harvesting_mask});
+
+    expect_identity_translated_for_cores(cm, grendel::TENSIX_CORES_NOC0, CoreType::TENSIX);
+}
+
+// DRAM, ETH, ARC, PCIE all use identity NOC0 -> TRANSLATED on Quasar.
+TEST(CoordinateManager, CoordinateManagerQuasarIdentityTranslatedNonTensix) {
+    std::shared_ptr<CoordinateManager> cm = CoordinateManager::create_coordinate_manager(tt::ARCH::QUASAR, true);
+
+    expect_identity_translated_for_cores(cm, grendel::DRAM_LOCATIONS, CoreType::DRAM);
+    expect_identity_translated_for_cores(cm, grendel::ETH_CORES_NOC0, CoreType::ETH);
+    expect_identity_translated_for_cores(cm, grendel::ARC_CORES_NOC0, CoreType::ARC);
+    expect_identity_translated_for_cores(cm, grendel::PCIE_CORES_NOC0, CoreType::PCIE);
+}
+
+// DRAM logical(channel, subchannel) -> NOC0 follows grendel::DRAM_CORES_NOC0.
+TEST(CoordinateManager, CoordinateManagerQuasarDRAMLogicalNOC0Mapping) {
+    std::shared_ptr<CoordinateManager> cm = CoordinateManager::create_coordinate_manager(tt::ARCH::QUASAR, true);
+
+    for (size_t ch = 0; ch < grendel::DRAM_CORES_NOC0.size(); ch++) {
+        for (size_t sub = 0; sub < grendel::DRAM_CORES_NOC0[ch].size(); sub++) {
+            const CoreCoord logical(ch, sub, CoreType::DRAM, CoordSystem::LOGICAL);
+            const CoreCoord noc0 = cm->translate_coord_to(logical, CoordSystem::NOC0);
+            EXPECT_EQ(noc0.x, grendel::DRAM_CORES_NOC0[ch][sub].x);
+            EXPECT_EQ(noc0.y, grendel::DRAM_CORES_NOC0[ch][sub].y);
+        }
+    }
+}
+
+// ETH logical(0, channel) -> NOC0 follows grendel::ETH_CORES_NOC0.
+TEST(CoordinateManager, CoordinateManagerQuasarETHLogicalNOC0Mapping) {
+    std::shared_ptr<CoordinateManager> cm = CoordinateManager::create_coordinate_manager(tt::ARCH::QUASAR, true);
+
+    for (size_t ch = 0; ch < grendel::ETH_CORES_NOC0.size(); ch++) {
+        const CoreCoord logical(0, ch, CoreType::ETH, CoordSystem::LOGICAL);
+        const CoreCoord noc0 = cm->translate_coord_to(logical, CoordSystem::NOC0);
+        EXPECT_EQ(noc0.x, grendel::ETH_CORES_NOC0[ch].x);
+        EXPECT_EQ(noc0.y, grendel::ETH_CORES_NOC0[ch].y);
+    }
+}
+
+// DRAM harvesting is rejected by the base CoordinateManager outside Blackhole.
+TEST(CoordinateManager, CoordinateManagerQuasarDRAMHarvestingThrows) {
+    EXPECT_THROW(
+        CoordinateManager::create_coordinate_manager(tt::ARCH::QUASAR, true, {.dram_harvesting_mask = 0x1}),
+        std::runtime_error);
+}
+
+// ETH harvesting is rejected by the base CoordinateManager outside Blackhole.
+TEST(CoordinateManager, CoordinateManagerQuasarETHHarvestingThrows) {
+    EXPECT_THROW(
+        CoordinateManager::create_coordinate_manager(tt::ARCH::QUASAR, true, {.eth_harvesting_mask = 0x1}),
+        std::runtime_error);
+}
+
+// NOC0 <-> NOC1 round-trip uses grendel::NOC0_X_TO_NOC1_X / NOC0_Y_TO_NOC1_Y.
+TEST(CoordinateManager, CoordinateManagerQuasarNoc1Noc0Mapping) {
+    std::shared_ptr<CoordinateManager> cm = CoordinateManager::create_coordinate_manager(tt::ARCH::QUASAR, true);
+
+    auto check_round_trip = [&cm](const std::vector<tt_xy_pair>& cores, CoreType core_type) {
+        for (const tt_xy_pair& core_noc0 : cores) {
+            const CoreCoord noc0(core_noc0.x, core_noc0.y, core_type, CoordSystem::NOC0);
+            const CoreCoord noc1 = cm->translate_coord_to(noc0, CoordSystem::NOC1);
+            EXPECT_EQ(noc1.x, grendel::NOC0_X_TO_NOC1_X[core_noc0.x]);
+            EXPECT_EQ(noc1.y, grendel::NOC0_Y_TO_NOC1_Y[core_noc0.y]);
+
+            const CoreCoord noc0_back = cm->translate_coord_to(noc1, CoordSystem::NOC0);
+            EXPECT_EQ(noc0_back.x, core_noc0.x);
+            EXPECT_EQ(noc0_back.y, core_noc0.y);
+        }
+    };
+
+    check_round_trip(grendel::TENSIX_CORES_NOC0, CoreType::TENSIX);
+    check_round_trip(grendel::DRAM_LOCATIONS, CoreType::DRAM);
+    check_round_trip(grendel::ETH_CORES_NOC0, CoreType::ETH);
+    check_round_trip(grendel::ARC_CORES_NOC0, CoreType::ARC);
+    check_round_trip(grendel::PCIE_CORES_NOC0, CoreType::PCIE);
+}
+
+// With noc_translation_enabled=false the base manager still installs the
+// identity NOC0 -> TRANSLATED defaults, so TRANSLATED lookups stay valid.
+TEST(CoordinateManager, CoordinateManagerQuasarNoNocTranslation) {
+    std::shared_ptr<CoordinateManager> cm = CoordinateManager::create_coordinate_manager(tt::ARCH::QUASAR, false);
+
+    expect_identity_translated_for_cores(cm, grendel::TENSIX_CORES_NOC0, CoreType::TENSIX);
+    expect_identity_translated_for_cores(cm, grendel::DRAM_LOCATIONS, CoreType::DRAM);
+    expect_identity_translated_for_cores(cm, grendel::ETH_CORES_NOC0, CoreType::ETH);
+    expect_identity_translated_for_cores(cm, grendel::ARC_CORES_NOC0, CoreType::ARC);
+    expect_identity_translated_for_cores(cm, grendel::PCIE_CORES_NOC0, CoreType::PCIE);
+}
+
+// get_harvesting_masks should round-trip whatever tensix mask was passed in.
+TEST(CoordinateManager, CoordinateManagerQuasarHarvestingMaskRoundTrip) {
+    const size_t num_rows = grendel::TENSIX_GRID_SIZE.y;
+    for (size_t harvesting = 0; harvesting < (1u << num_rows); harvesting++) {
+        std::shared_ptr<CoordinateManager> cm = CoordinateManager::create_coordinate_manager(
+            tt::ARCH::QUASAR, true, {.tensix_harvesting_mask = harvesting});
+        EXPECT_EQ(cm->get_harvesting_masks().tensix_harvesting_mask, harvesting);
+    }
+}

--- a/tests/baremetal/test_soc_descriptor.cpp
+++ b/tests/baremetal/test_soc_descriptor.cpp
@@ -718,9 +718,11 @@ TEST(SocDescriptor, SerializeSimulatorBlackhole) {
 }
 
 TEST(SocDescriptor, SerializeSimulatorQuasar) {
+    // Quasar does not support ETH harvesting (the CoordinateManager rejects a non-zero
+    // eth_harvesting_mask on any non-Blackhole arch), so use the all-zero default here.
     const SocDescriptor& soc_descriptor = SocDescriptor(
         std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("quasar_simulation_1x1.yaml")),
-        {.noc_translation_enabled = false, .harvesting_masks = {.eth_harvesting_mask = example_eth_harvesting_mask}});
+        {.noc_translation_enabled = false});
 
     std::filesystem::path file_path = soc_descriptor.serialize_to_file();
     SocDescriptor soc(


### PR DESCRIPTION
### Issue
#2494

### Description
Quasar previously fell through to `BlackholeCoordinateManager` in both `CoordinateManager::create_coordinate_manager` factory overloads. The arch-enum-only path used `blackhole::*` core constants for Quasar; the cores-vector path instantiated a `BlackholeCoordinateManager` directly. In simulation, the YAML-supplied NOC0 cores do get wired in (via the cores-vector overload), but Blackhole's `fill_eth_noc0_translated_mapping` and `fill_pcie_noc0_translated_mapping` apply Blackhole-specific translated-coordinate offsets, and `assert_coordinate_manager_constructor` enforces Blackhole-specific ETH harvesting rules. Either can produce missing TRANSLATED entries or spurious assert failures on Quasar inputs.

This PR introduces `QuasarCoordinateManager` as its own subclass of `CoordinateManager`, wires it into both factory overloads, and pulls the arch-enum-only path onto `grendel::*` constants. The translated-coordinate fill overrides delegate to the base-class identity defaults, which is correct for current Quasar simulation usage (SOC descriptor YAML supplies NOC0 directly) and a known placeholder for silicon — tracked in #2494.

### List of the changes
- New `device/api/umd/device/coordinates/quasar_coordinate_manager.hpp`
- New `device/coordinates/quasar_coordinate_manager.cpp` (identity overrides for tensix / dram / eth / pcie / arc `fill_*_noc0_translated_mapping`)
- `device/coordinates/coordinate_manager.cpp`: split `QUASAR` out of the `BLACKHOLE` fallthrough in both `create_coordinate_manager` overloads; use `grendel::*` constants on the arch-enum-only path
- `device/CMakeLists.txt`: register new `.cpp` and the public `.hpp`

### Testing
- `cmake --build build` clean
- `pre-commit run --all-files` clean
- Manually traced `quasar_simulation_2x3.yaml` cores (TENSIX `[0-1, 1-1]`, DRAM `[1-0],[0-0]`, DISPATCH `[1-2]`) through the new manager and confirmed all get identity TRANSLATED entries via the base-class default helpers

### API Changes
New public header `umd/device/coordinates/quasar_coordinate_manager.hpp` exposing `QuasarCoordinateManager`. No changes to existing API surface.