### PR TITLE
tests: share make_cluster_for_test / is_simulation_test helpers

### DIFF
--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -16,6 +16,7 @@
 #include <utility>
 #include <vector>
 
+#include "tests/test_utils/test_api_common.hpp"
 #include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
@@ -41,7 +42,7 @@ using namespace tt::umd;
 // Galaxy.
 
 // This test should be one line only.
-TEST(ApiClusterTest, OpenAllSiliconChips) { std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>(); }
+TEST(ApiClusterTest, OpenAllSiliconChips) { std::unique_ptr<Cluster> umd_cluster = make_cluster_for_test(); }
 
 TEST(TestCluster, PrintAllSiliconChipsAllCores) {
     std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();

--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -59,27 +59,11 @@ std::vector<ClusterOptions> get_cluster_options_for_param_test() {
     return options;
 }
 
-class TestDeviceIOFixture : public ::testing::TestWithParam<CoreType> {
-protected:
-    static constexpr const char* TT_UMD_SIMULATOR_ENV = "TT_UMD_SIMULATOR";
-
-    // Creates a Cluster with the given options, overriding chip_type/target_devices/simulator_directory
-    // to use simulation when TT_UMD_SIMULATOR is set.
-    std::unique_ptr<Cluster> make_cluster(ClusterOptions options = {}) {
-        if (const char* sim_path = std::getenv(TT_UMD_SIMULATOR_ENV)) {
-            options.chip_type = ChipType::SIMULATION;
-            options.target_devices = {0};
-            options.simulator_directory = std::filesystem::path(sim_path);
-        }
-        return std::make_unique<Cluster>(options);
-    }
-
-    bool is_simulation() const { return std::getenv(TT_UMD_SIMULATOR_ENV) != nullptr; }
-};
+class TestDeviceIOFixture : public ::testing::TestWithParam<CoreType> {};
 
 TEST_P(TestDeviceIOFixture, SimpleIOAllTargets) {
     const CoreType core_type = GetParam();
-    std::unique_ptr<Cluster> umd_cluster = make_cluster();
+    std::unique_ptr<Cluster> umd_cluster = make_cluster_for_test();
 
     // Initialize random data.
     size_t data_size = 1024;
@@ -123,7 +107,7 @@ TEST_P(TestDeviceIOFixture, SimpleIOAllTargets) {
 
 TEST_P(TestDeviceIOFixture, RemoteFlush) {
     const CoreType core_type = GetParam();
-    std::unique_ptr<Cluster> umd_cluster = make_cluster();
+    std::unique_ptr<Cluster> umd_cluster = make_cluster_for_test();
 
     const ClusterDescriptor* cluster_desc = umd_cluster->get_cluster_description();
 
@@ -166,7 +150,7 @@ TEST_P(TestDeviceIOFixture, RemoteFlush) {
 
 TEST_P(TestDeviceIOFixture, SimpleIOSpecificDevices) {
     const CoreType core_type = GetParam();
-    std::unique_ptr<Cluster> umd_cluster = make_cluster(ClusterOptions{
+    std::unique_ptr<Cluster> umd_cluster = make_cluster_for_test(ClusterOptions{
         .target_devices = {0},
     });
 
@@ -215,7 +199,7 @@ TEST_P(TestDeviceIOFixture, DynamicTLB_RW) {
     // to be reconfigured for each transaction
     const CoreType core_type = GetParam();
 
-    std::unique_ptr<Cluster> cluster = make_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    std::unique_ptr<Cluster> cluster = make_cluster_for_test(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
 
     std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -256,13 +240,13 @@ TEST_P(TestDeviceIOFixture, DynamicTLB_RW) {
 }
 
 TEST_F(TestDeviceIOFixture, TestDmaMulticastWrite) {
-    std::unique_ptr<Cluster> cluster = make_cluster();
+    std::unique_ptr<Cluster> cluster = make_cluster_for_test();
 
     if (cluster->get_tt_device(0)->get_arch() == tt::ARCH::BLACKHOLE) {
         GTEST_SKIP() << "DMA multicast write is not supported on Blackhole architecture.";
     }
 
-    if (is_simulation()) {
+    if (is_simulation_test()) {
         GTEST_SKIP() << "DMA multicast write is not supported in simulation.";
     }
 
@@ -546,7 +530,7 @@ TEST_F(TestDeviceIOFixture, SysmemReadWrite) {
 
     uint32_t channels;
     uint32_t channels_to_test;
-    if (is_simulation()) {
+    if (is_simulation_test()) {
         channels = 4;
         channels_to_test = 1;
     } else {
@@ -556,7 +540,8 @@ TEST_F(TestDeviceIOFixture, SysmemReadWrite) {
         channels_to_test = channels;
     }
 
-    std::unique_ptr<Cluster> cluster = make_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = channels});
+    std::unique_ptr<Cluster> cluster =
+        make_cluster_for_test(ClusterOptions{.num_host_mem_ch_per_mmio_device = channels});
     constexpr auto mmio_chip_id = 0;
     const auto pci_cores = cluster->get_soc_descriptor(mmio_chip_id).get_cores(CoreType::PCIE);
     const auto pcie_core = pci_cores.at(0);
@@ -569,7 +554,7 @@ TEST_F(TestDeviceIOFixture, SysmemReadWrite) {
         return dis(gen);
     };
 
-    if (!is_simulation()) {
+    if (!is_simulation_test()) {
         test_utils::safe_test_cluster_start(cluster.get());
     }
 
@@ -578,7 +563,7 @@ TEST_F(TestDeviceIOFixture, SysmemReadWrite) {
 
         ASSERT_NE(sysmem, nullptr);
 
-        if (is_simulation()) {
+        if (is_simulation_test()) {
             for (size_t i = 0; i < ONE_GIG; i++) {
                 sysmem[i] = i % 256;
             }
@@ -587,7 +572,7 @@ TEST_F(TestDeviceIOFixture, SysmemReadWrite) {
         }
 
         std::vector<uint64_t> test_offsets;
-        if (is_simulation()) {
+        if (is_simulation_test()) {
             test_offsets = {0x0};
         } else {
             test_offsets = {
@@ -623,7 +608,7 @@ TEST_F(TestDeviceIOFixture, SysmemReadWrite) {
 
             cluster->read_from_device(&value, mmio_chip_id, pcie_core, noc_addr, sizeof(uint32_t));
 
-            if (!is_simulation() && value != expected) {
+            if (!is_simulation_test() && value != expected) {
                 std::stringstream error_msg;
                 const bool is_vm = test_utils::is_virtual_machine();
                 const bool has_iommu = test_utils::is_iommu_available();
@@ -673,7 +658,7 @@ TEST_F(TestDeviceIOFixture, SysmemReadWrite) {
 }
 
 TEST_F(TestDeviceIOFixture, RegReadWrite) {
-    std::unique_ptr<Cluster> cluster = make_cluster();
+    std::unique_ptr<Cluster> cluster = make_cluster_for_test();
 
     const CoreCoord tensix_core = cluster->get_soc_descriptor(0).get_cores(CoreType::TENSIX)[0];
 
@@ -718,7 +703,7 @@ TEST_F(TestDeviceIOFixture, RegReadWrite) {
 }
 
 TEST_F(TestDeviceIOFixture, WriteDataReadReg) {
-    std::unique_ptr<Cluster> cluster = make_cluster();
+    std::unique_ptr<Cluster> cluster = make_cluster_for_test();
 
     const CoreCoord tensix_core = cluster->get_soc_descriptor(0).get_cores(CoreType::TENSIX)[0];
 

--- a/tests/test_utils/test_api_common.hpp
+++ b/tests/test_utils/test_api_common.hpp
@@ -9,6 +9,9 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
 #include <stdexcept>
 #include <vector>
 
@@ -132,3 +135,19 @@ class ClusterReadWriteL1Test : public ::testing::TestWithParam<ClusterOptions> {
 // by ARC firmware (doppler throttle state), so tests must start at or above this address.
 // In some cases you also have to be careful about not overwriting the membar address.
 constexpr uint64_t SAFE_IO_L1_ADDRESS = 0x1000;
+
+// True when the test should run against a simulator, indicated by TT_UMD_SIMULATOR
+// pointing at the simulator binary directory.
+inline bool is_simulation_test() { return std::getenv("TT_UMD_SIMULATOR") != nullptr; }
+
+// Creates a Cluster for an API test. If TT_UMD_SIMULATOR is set the chip_type,
+// target_devices, and simulator_directory fields of `options` are overridden to
+// target the simulator; otherwise `options` is used as-is (default = silicon).
+inline std::unique_ptr<Cluster> make_cluster_for_test(ClusterOptions options = {}) {
+    if (const char* sim_path = std::getenv("TT_UMD_SIMULATOR")) {
+        options.chip_type = ChipType::SIMULATION;
+        options.target_devices = {0};
+        options.simulator_directory = std::filesystem::path(sim_path);
+    }
+    return std::make_unique<Cluster>(options);
+}


### PR DESCRIPTION
### Issue
N/A — refactor extracted from #2618 so the helpers can land independently.

### Description
The silicon-or-simulation `Cluster` construction pattern used in
`TestDeviceIOFixture` is moved into shared inline helpers in
`tests/test_utils/test_api_common.hpp`:

- `is_simulation_test()` — true when `TT_UMD_SIMULATOR` is set.
- `make_cluster_for_test(ClusterOptions = {})` — when `TT_UMD_SIMULATOR`
  is set the `chip_type`, `target_devices`, and `simulator_directory`
  fields are overridden; otherwise the options are used as-is (silicon
  by default).

`TestDeviceIOFixture` no longer carries its own copy of these helpers
and its call sites delegate to the shared ones.
`ApiClusterTest.OpenAllSiliconChips` now goes through
`make_cluster_for_test()` too, so the same test binary picks up the
simulator when the env var is set.

### List of the changes
- `tests/test_utils/test_api_common.hpp`: add `is_simulation_test()` and `make_cluster_for_test(ClusterOptions)`.
- `tests/api/test_device_io.cpp`: remove `TestDeviceIOFixture::make_cluster` / `is_simulation` / `TT_UMD_SIMULATOR_ENV`; call sites use the shared helpers.
- `tests/api/test_cluster.cpp`: `OpenAllSiliconChips` uses `make_cluster_for_test()`; adds the include.

### Testing
- `cmake --build build --target api_tests` passes.
- `pre-commit run --files <changed files>` passes.

### API Changes
None.