### PR TITLE
Do not attempt to use TLBs on QSR

### DIFF
--- a/device/chip_helpers/simulation_tlb_manager.cpp
+++ b/device/chip_helpers/simulation_tlb_manager.cpp
@@ -58,8 +58,6 @@ std::unique_ptr<TlbWindow> SimulationTlbManager::allocate_default_tlb_window() {
             return allocate_tlb_window({}, TlbMapping::WC, SIZE_2MB);
         case tt::ARCH::WORMHOLE_B0:
             return allocate_tlb_window({}, TlbMapping::WC, SIZE_16MB);
-        case tt::ARCH::QUASAR:
-            return allocate_tlb_window({}, TlbMapping::WC, /*tlb_size=*/0);
         default:
             log_debug(
                 LogUMD,


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/ttsim-private/issues/367

### Description
Fix regression causing all tests to fail on QSR ttsim.

### List of the changes
Do not attempt to use TLBs that are not yet implemented in sim.

### Testing
Tested locally in my Linux/aarch64 VM on my Mac using `TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_legacy --gtest_filter=QuasarMeshDeviceSingleCardFixture.SingleDmL1Write` on QSR ttsim

### API Changes
(When making API changes, don't merge this PR until tt_metal and tt_debuda PRs are approved.)
(Then merge this PR, change the client PRs to point to UMD main, and then merge them.)
(Remove this line if untrue) There are no API changes in this PR.
(Remove following lines if untrue) This PR has API changes:
- [ ] (If breaking change) tt_metal approved PR pointing to this branch: link
- [ ] (If breaking change) tt_debuda approved PR pointing to this branch: link
