### PR TITLE
Fix quasar TTsim IO

### DIFF
--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -120,7 +120,7 @@ TTSimTTDevice::~TTSimTTDevice() { communicator_->shutdown(); }
 
 void TTSimTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     std::lock_guard<std::recursive_mutex> lock(device_lock);
-    if (cached_tlb_window_) {
+    if (get_arch() != tt::ARCH::QUASAR && cached_tlb_window_) {
         cached_tlb_window_->write_block_reconfigure(mem_ptr, core, addr, size, get_selected_noc_id());
     } else {
         communicator_->tile_write_bytes(core.x, core.y, addr, mem_ptr, size);
@@ -129,7 +129,7 @@ void TTSimTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64
 
 void TTSimTTDevice::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     std::lock_guard<std::recursive_mutex> lock(device_lock);
-    if (cached_tlb_window_) {
+    if (get_arch() != tt::ARCH::QUASAR && cached_tlb_window_) {
         cached_tlb_window_->read_block_reconfigure(mem_ptr, core, addr, size, get_selected_noc_id());
     } else {
         communicator_->tile_read_bytes(core.x, core.y, addr, mem_ptr, size);


### PR DESCRIPTION
### Issue
The UMD `write_to_device` / `read_from_device` TLB path was being taken on Quasar, but Quasar TTsim does not yet implement TLBs (related to #2643), so any Quasar simulator IO through `TTSimTTDevice` failed.

### Description
Skip the cached-TLB path on Quasar in `TTSimTTDevice::write_to_device` and `read_from_device`, falling back to direct `tile_write_bytes` / `tile_read_bytes` until simulator TLB support lands.

CI coverage for Quasar ttsim is added in a separate PR.

### List of the changes
- `device/tt_device/tt_sim_tt_device.cpp`: gate `cached_tlb_window_` usage on `get_arch() != tt::ARCH::QUASAR` in both `write_to_device` and `read_from_device`.

### Testing
Tested locally against `libttsim_qsr.so` — `TestDeviceIOFixture.*` and `TTSimDeviceIOFixture.*` no longer fail on the Quasar simulator.

### API Changes
There are no API changes in this PR.