### PR TITLE
Restore sw_emule_chip.hpp include + CI guard for TT_UMD_BUILD_EMULE

### DIFF
--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -282,49 +282,6 @@ jobs:
             ${{ env.TT_UMD_DIR }}/build/*umd-python*.${{ matrix.image.package }}
           if-no-files-found: error
 
-  build-emule:
-    # Guards the TT_UMD_BUILD_EMULE=ON code path so IWYU sweeps and other
-    # refactors that don't run with this flag can't silently break it again
-    # (see https://github.com/tenstorrent/tt-umd/pull/2536). Single config
-    # is sufficient — the matrix-wide build already covers compiler /
-    # distro permutations.
-    timeout-minutes: ${{ fromJSON(inputs.timeout || '15') }}
-    needs: ensure-ubuntu-2204-image
-    name: Build umd with TT_UMD_BUILD_EMULE=ON
-    runs-on: tt-ubuntu-2204-large-stable
-    container:
-      image: >-
-        harbor.ci.tenstorrent.net/ghcr.io/${{ github.repository }}/tt-umd-ci-ubuntu-22.04:${{
-        needs.ensure-ubuntu-2204-image.outputs.image-tag }}
-
-    steps:
-      - name: Checkout tt-umd
-        uses: actions/checkout@v6
-        with:
-          path: ${{ env.TT_UMD_DIR }}
-          submodules: recursive
-
-      - name: Checkout tt-emule
-        uses: actions/checkout@v6
-        with:
-          repository: tenstorrent/tt-emule
-          path: tt-emule
-          ref: main
-          fetch-depth: 1
-
-      - name: Build with TT_UMD_BUILD_EMULE=ON
-        run: |
-          export CC=clang-20
-          export CXX=clang++-20
-          cd ${{ env.TT_UMD_DIR_SHELL }}
-          cmake -B ${{ env.BUILD_OUTPUT_DIR }} -G Ninja \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DTT_UMD_BUILD_TESTS=OFF \
-              -DTT_UMD_BUILD_SIMULATION=ON \
-              -DTT_UMD_BUILD_EMULE=ON \
-              -DTT_EMULE_PATH=$GITHUB_WORKSPACE/tt-emule
-          cmake --build ${{ env.BUILD_OUTPUT_DIR }}
-
   build-manylinux-wheels:
     # Due to parsing bug, fromJSON is used to convert string to number.
     # In pull_request or push events, the input context is not available, stating the default again here.

--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -282,6 +282,49 @@ jobs:
             ${{ env.TT_UMD_DIR }}/build/*umd-python*.${{ matrix.image.package }}
           if-no-files-found: error
 
+  build-emule:
+    # Guards the TT_UMD_BUILD_EMULE=ON code path so IWYU sweeps and other
+    # refactors that don't run with this flag can't silently break it again
+    # (see https://github.com/tenstorrent/tt-umd/pull/2536). Single config
+    # is sufficient — the matrix-wide build already covers compiler /
+    # distro permutations.
+    timeout-minutes: ${{ fromJSON(inputs.timeout || '15') }}
+    needs: ensure-ubuntu-2204-image
+    name: Build umd with TT_UMD_BUILD_EMULE=ON
+    runs-on: tt-ubuntu-2204-large-stable
+    container:
+      image: >-
+        harbor.ci.tenstorrent.net/ghcr.io/${{ github.repository }}/tt-umd-ci-ubuntu-22.04:${{
+        needs.ensure-ubuntu-2204-image.outputs.image-tag }}
+
+    steps:
+      - name: Checkout tt-umd
+        uses: actions/checkout@v6
+        with:
+          path: ${{ env.TT_UMD_DIR }}
+          submodules: recursive
+
+      - name: Checkout tt-emule
+        uses: actions/checkout@v6
+        with:
+          repository: tenstorrent/tt-emule
+          path: tt-emule
+          ref: main
+          fetch-depth: 1
+
+      - name: Build with TT_UMD_BUILD_EMULE=ON
+        run: |
+          export CC=clang-20
+          export CXX=clang++-20
+          cd ${{ env.TT_UMD_DIR_SHELL }}
+          cmake -B ${{ env.BUILD_OUTPUT_DIR }} -G Ninja \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DTT_UMD_BUILD_TESTS=OFF \
+              -DTT_UMD_BUILD_SIMULATION=ON \
+              -DTT_UMD_BUILD_EMULE=ON \
+              -DTT_EMULE_PATH=$GITHUB_WORKSPACE/tt-emule
+          cmake --build ${{ env.BUILD_OUTPUT_DIR }}
+
   build-manylinux-wheels:
     # Due to parsing bug, fromJSON is used to convert string to number.
     # In pull_request or push events, the input context is not available, stating the default again here.

--- a/device/api/umd/device/chip/sw_emule_chip.hpp
+++ b/device/api/umd/device/chip/sw_emule_chip.hpp
@@ -33,7 +33,7 @@ public:
 
     // Chip lifecycle — no-ops.
     bool is_mmio_capable() const override;
-    void start_device() override;
+    void start_device(uint32_t dram_membar_subchannel = 0) override;
     void close_device() override;
 
     // Hardware accessors — not applicable.
@@ -61,7 +61,7 @@ public:
     void wait_for_non_mmio_flush() override;
     void l1_membar(const std::unordered_set<CoreCoord>& cores = {}) override;
     void dram_membar(const std::unordered_set<CoreCoord>& cores = {}) override;
-    void dram_membar(const std::unordered_set<uint32_t>& channels) override;
+    void dram_membar(const std::unordered_set<uint32_t>& channels, uint32_t subchannel = 0) override;
     void send_tensix_risc_reset(CoreCoord core, const TensixSoftResetOptions& soft_resets) override;
     void send_tensix_risc_reset(const TensixSoftResetOptions& soft_resets) override;
     void deassert_risc_resets() override;

--- a/device/chip/sw_emule_chip.cpp
+++ b/device/chip/sw_emule_chip.cpp
@@ -121,7 +121,7 @@ void SWEmuleChip::dma_read_from_device(void* dst, size_t size, CoreCoord core, u
 
 bool SWEmuleChip::is_mmio_capable() const { return false; }
 
-void SWEmuleChip::start_device() {}
+void SWEmuleChip::start_device(uint32_t) {}
 
 void SWEmuleChip::close_device() {}
 
@@ -159,7 +159,7 @@ void SWEmuleChip::l1_membar(const std::unordered_set<CoreCoord>&) {}
 
 void SWEmuleChip::dram_membar(const std::unordered_set<CoreCoord>&) {}
 
-void SWEmuleChip::dram_membar(const std::unordered_set<uint32_t>&) {}
+void SWEmuleChip::dram_membar(const std::unordered_set<uint32_t>&, uint32_t) {}
 
 void SWEmuleChip::send_tensix_risc_reset(CoreCoord, const TensixSoftResetOptions&) {}
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -34,6 +34,10 @@
 #include "umd/device/chip/local_chip.hpp"
 #include "umd/device/chip/mock_chip.hpp"
 #include "umd/device/chip/remote_chip.hpp"
+// SWEmuleChip is only referenced inside `#ifdef TT_UMD_BUILD_EMULE`. IWYU
+// runs without that flag set so it can't see the use; mark the include to
+// stop future IWYU sweeps from deleting it again (see #2536).
+#include "umd/device/chip/sw_emule_chip.hpp"  // IWYU pragma: keep
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/cluster.hpp"


### PR DESCRIPTION
## Summary

#2536 (IWYU includes cleanup) removed `#include "umd/device/chip/sw_emule_chip.hpp"` from `device/cluster.cpp`. The use of `SWEmuleChip` is guarded by `#ifdef TT_UMD_BUILD_EMULE`:

```cpp
if (chip_type == ChipType::SWEMULE) {
#ifdef TT_UMD_BUILD_EMULE
    return std::make_unique<SWEmuleChip>(soc_desc);
#else
    throw std::runtime_error(...);
#endif
}
```

IWYU ran with the default `TT_UMD_BUILD_EMULE=OFF`, so the `SWEmuleChip` reference was invisible to it and the include was flagged as unused and deleted. Any downstream consumer building with `TT_UMD_BUILD_EMULE=ON` now hits:

```
cluster.cpp:191: error: use of undeclared identifier 'SWEmuleChip'
```

This wasn't caught upstream because none of the existing build-device matrix entries enable `TT_UMD_BUILD_EMULE`. `TT_UMD_BUILD_ALL=ON` does not pull it in either — emule is intentionally an opt-in build because it needs `TT_EMULE_PATH` to point at a tt-emule checkout.

## Changes

1. **`device/cluster.cpp`** — re-add the include, tagged `// IWYU pragma: keep` so future IWYU sweeps leave it in place even when the build configuration they ran under doesn't define `TT_UMD_BUILD_EMULE`.

2. **`.github/workflows/build-device.yml`** — new `build-emule` job that:
   - Runs in parallel with the existing `build` matrix.
   - Checks out tt-emule from `tenstorrent/tt-emule@main` alongside tt-umd.
   - Configures with `-DTT_UMD_BUILD_EMULE=ON -DTT_EMULE_PATH=$GITHUB_WORKSPACE/tt-emule -DTT_UMD_BUILD_SIMULATION=ON -DCMAKE_BUILD_TYPE=Release` on ubuntu-22.04 + clang-20.
   - Builds the full umd library; any regression on the emule path now fails PR checks.

   Single config is sufficient — the existing `build` matrix already covers cross-compiler / cross-distro permutations for the non-emule paths.

## Why this matters

`SWEmuleChip` is the integration point for [tenstorrent/tt-emule](https://github.com/tenstorrent/tt-emule), the host-side software emulator for Tenstorrent device-level APIs. Without the emule path compiling, the tt-emule project (and tt-mlir D2M tests running through it) can't link against umd.

## Test plan

- [ ] `build-emule` job runs on this PR and is green.
- [ ] Existing `build` matrix stays green.
- [ ] Downstream: tt-emule's `pr-d2m-regression.yml` builds tt-metal with `-DTT_METAL_USE_EMULE=ON` against an umd that includes this fix and gets past `cluster.cpp:191`.
