### PR TITLE
device/cluster.cpp: restore sw_emule_chip.hpp include

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -33,6 +33,9 @@
 #include "umd/device/chip/local_chip.hpp"
 #include "umd/device/chip/mock_chip.hpp"
 #include "umd/device/chip/remote_chip.hpp"
+#ifdef TT_UMD_BUILD_EMULE
+#include "umd/device/chip/sw_emule_chip.hpp"
+#endif
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/cluster.hpp"


### PR DESCRIPTION
### Issue
(Link to Github issue(s))

### Description
PR #2536 (eb757f1e, "Cleaning up includes with IWYU") removed `#include "umd/device/chip/sw_emule_chip.hpp"` from cluster.cpp but left the SWEmuleChip usage under `#ifdef TT_UMD_BUILD_EMULE`

Builds with `-DTT_METAL_USE_EMULE=ON` (which sets TT_UMD_BUILD_EMULE) fail with:

    cluster.cpp:191:33: error: use of undeclared identifier 'SWEmuleChip'

Re-add the include, gated on the same macro that gates the usage.

### Testing
Clean tt-emule/tt-metal build passes

### API Changes
N/A