### PR TITLE
Fix minor TSAN issue

### DIFF
--- a/device/api/umd/device/utils/robust_mutex.hpp
+++ b/device/api/umd/device/utils/robust_mutex.hpp
@@ -7,6 +7,7 @@
 #include <pthread.h>
 #include <sys/types.h>
 
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -70,8 +71,10 @@ private:
     struct pthread_mutex_wrapper {
         pthread_mutex_t mutex;
         uint64_t initialized;
-        pid_t owner_tid;  // TID of the thread holding the lock, 0 if no owner
-        pid_t owner_pid;  // PID of the thread holding the lock, 0 if no owner
+        // Owner TID/PID are read without holding the mutex (see probe_lock), so they must be atomic.
+        // std::atomic<pid_t> is lock-free and layout-compatible with pid_t, safe to use in shared memory.
+        std::atomic<pid_t> owner_tid;  // TID of the thread holding the lock, 0 if no owner
+        std::atomic<pid_t> owner_pid;  // PID of the thread holding the lock, 0 if no owner
     };
 
     // Closes the mutex, doesn't remove the backing mutex file.

--- a/device/api/umd/device/utils/robust_mutex.hpp
+++ b/device/api/umd/device/utils/robust_mutex.hpp
@@ -80,7 +80,7 @@ private:
     };
 
     static_assert(
-        __atomic_always_lock_free(sizeof(pid_t), 0),
+        __atomic_always_lock_free(sizeof(pid_t), nullptr),
         "owner_tid/owner_pid must be lock-free for cross-process shared-memory use");
 
     // Closes the mutex, doesn't remove the backing mutex file.

--- a/device/api/umd/device/utils/robust_mutex.hpp
+++ b/device/api/umd/device/utils/robust_mutex.hpp
@@ -7,7 +7,6 @@
 #include <pthread.h>
 #include <sys/types.h>
 
-#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -71,11 +70,18 @@ private:
     struct pthread_mutex_wrapper {
         pthread_mutex_t mutex;
         uint64_t initialized;
-        // Owner TID/PID are read without holding the mutex (see probe_lock), so they must be atomic.
-        // std::atomic<pid_t> is lock-free and layout-compatible with pid_t, safe to use in shared memory.
-        std::atomic<pid_t> owner_tid;  // TID of the thread holding the lock, 0 if no owner
-        std::atomic<pid_t> owner_pid;  // PID of the thread holding the lock, 0 if no owner
+        // Owner TID/PID are read without holding the mutex (see probe_lock), so accesses must be atomic.
+        // The wrapper lives in mmap'd shared memory and its C++ object lifetime is never started
+        // (no placement-new), so std::atomic members would technically be UB. Instead we keep these as
+        // plain pid_t and use the compiler's __atomic_* builtins at every access site; the builtins
+        // operate on raw memory, are recognized as atomic by TSAN, and require no C++ object lifetime.
+        pid_t owner_tid;  // TID of the thread holding the lock, 0 if no owner
+        pid_t owner_pid;  // PID of the thread holding the lock, 0 if no owner
     };
+
+    static_assert(
+        __atomic_always_lock_free(sizeof(pid_t), 0),
+        "owner_tid/owner_pid must be lock-free for cross-process shared-memory use");
 
     // Closes the mutex, doesn't remove the backing mutex file.
     void close_mutex() noexcept;

--- a/device/utils/robust_mutex.cpp
+++ b/device/utils/robust_mutex.cpp
@@ -351,8 +351,8 @@ void RobustMutex::initialize_pthread_mutex_first_use() {
     // we need to set this flag.
     mutex_wrapper_ptr_->initialized = INITIALIZED_FLAG;
     // Initialize owner TID and PID to 0 (no owner).
-    mutex_wrapper_ptr_->owner_tid = 0;
-    mutex_wrapper_ptr_->owner_pid = 0;
+    mutex_wrapper_ptr_->owner_tid.store(0, std::memory_order_relaxed);
+    mutex_wrapper_ptr_->owner_pid.store(0, std::memory_order_relaxed);
 }
 
 size_t RobustMutex::get_file_size(int fd) {
@@ -386,8 +386,8 @@ void RobustMutex::close_mutex() noexcept {
 }
 
 void RobustMutex::record_acquisition() {
-    mutex_wrapper_ptr_->owner_tid = static_cast<pid_t>(::syscall(SYS_gettid));
-    mutex_wrapper_ptr_->owner_pid = getpid();
+    mutex_wrapper_ptr_->owner_tid.store(static_cast<pid_t>(::syscall(SYS_gettid)), std::memory_order_relaxed);
+    mutex_wrapper_ptr_->owner_pid.store(getpid(), std::memory_order_relaxed);
     tsan_annotate_mutex_acquire(mutex_name_);
 }
 
@@ -395,8 +395,8 @@ void RobustMutex::unlock() {
     tsan_annotate_mutex_release(mutex_name_);
 
     // Clear the owner TID and PID before unlocking.
-    mutex_wrapper_ptr_->owner_tid = 0;
-    mutex_wrapper_ptr_->owner_pid = 0;
+    mutex_wrapper_ptr_->owner_tid.store(0, std::memory_order_relaxed);
+    mutex_wrapper_ptr_->owner_pid.store(0, std::memory_order_relaxed);
     int err = pthread_mutex_unlock(&(mutex_wrapper_ptr_->mutex));
     if (err != 0) {
         UMD_THROW(
@@ -432,7 +432,11 @@ std::optional<std::pair<pid_t, pid_t>> RobustMutex::probe_lock(std::chrono::seco
         record_acquisition();
         return std::nullopt;
     } else if (lock_res == EBUSY || lock_res == ETIMEDOUT) {
-        return std::make_pair(mutex_wrapper_ptr_->owner_pid, mutex_wrapper_ptr_->owner_tid);
+        // Best-effort snapshot of the current owner; we do not hold the mutex here, so use relaxed
+        // atomic loads to avoid a data race with record_acquisition()/unlock() on the owner.
+        return std::make_pair(
+            mutex_wrapper_ptr_->owner_pid.load(std::memory_order_relaxed),
+            mutex_wrapper_ptr_->owner_tid.load(std::memory_order_relaxed));
     } else {
         UMD_THROW(
             error::RuntimeError,

--- a/device/utils/robust_mutex.cpp
+++ b/device/utils/robust_mutex.cpp
@@ -351,8 +351,8 @@ void RobustMutex::initialize_pthread_mutex_first_use() {
     // we need to set this flag.
     mutex_wrapper_ptr_->initialized = INITIALIZED_FLAG;
     // Initialize owner TID and PID to 0 (no owner).
-    mutex_wrapper_ptr_->owner_tid.store(0, std::memory_order_relaxed);
-    mutex_wrapper_ptr_->owner_pid.store(0, std::memory_order_relaxed);
+    __atomic_store_n(&mutex_wrapper_ptr_->owner_tid, 0, __ATOMIC_RELAXED);
+    __atomic_store_n(&mutex_wrapper_ptr_->owner_pid, 0, __ATOMIC_RELAXED);
 }
 
 size_t RobustMutex::get_file_size(int fd) {
@@ -386,8 +386,8 @@ void RobustMutex::close_mutex() noexcept {
 }
 
 void RobustMutex::record_acquisition() {
-    mutex_wrapper_ptr_->owner_tid.store(static_cast<pid_t>(::syscall(SYS_gettid)), std::memory_order_relaxed);
-    mutex_wrapper_ptr_->owner_pid.store(getpid(), std::memory_order_relaxed);
+    __atomic_store_n(&mutex_wrapper_ptr_->owner_tid, static_cast<pid_t>(::syscall(SYS_gettid)), __ATOMIC_RELAXED);
+    __atomic_store_n(&mutex_wrapper_ptr_->owner_pid, getpid(), __ATOMIC_RELAXED);
     tsan_annotate_mutex_acquire(mutex_name_);
 }
 
@@ -395,8 +395,8 @@ void RobustMutex::unlock() {
     tsan_annotate_mutex_release(mutex_name_);
 
     // Clear the owner TID and PID before unlocking.
-    mutex_wrapper_ptr_->owner_tid.store(0, std::memory_order_relaxed);
-    mutex_wrapper_ptr_->owner_pid.store(0, std::memory_order_relaxed);
+    __atomic_store_n(&mutex_wrapper_ptr_->owner_tid, 0, __ATOMIC_RELAXED);
+    __atomic_store_n(&mutex_wrapper_ptr_->owner_pid, 0, __ATOMIC_RELAXED);
     int err = pthread_mutex_unlock(&(mutex_wrapper_ptr_->mutex));
     if (err != 0) {
         UMD_THROW(
@@ -435,8 +435,8 @@ std::optional<std::pair<pid_t, pid_t>> RobustMutex::probe_lock(std::chrono::seco
         // Best-effort snapshot of the current owner; we do not hold the mutex here, so use relaxed
         // atomic loads to avoid a data race with record_acquisition()/unlock() on the owner.
         return std::make_pair(
-            mutex_wrapper_ptr_->owner_pid.load(std::memory_order_relaxed),
-            mutex_wrapper_ptr_->owner_tid.load(std::memory_order_relaxed));
+            __atomic_load_n(&mutex_wrapper_ptr_->owner_pid, __ATOMIC_RELAXED),
+            __atomic_load_n(&mutex_wrapper_ptr_->owner_tid, __ATOMIC_RELAXED));
     } else {
         UMD_THROW(
             error::RuntimeError,


### PR DESCRIPTION
### Issue
Issue surfaced in https://github.com/tenstorrent/tt-umd/actions/runs/25943685410/job/76267416794
Fixes https://github.com/tenstorrent/tt-umd/issues/2661

### Description
This is a very hard to hit issue, and very unimportant, but TSAN tests could potentially fail like in the linked run.
Applying a clauded change to fix this issue.

### List of the changes
- Use std::atomic for reading and writing pid and tid of the owner of mutex, used mostly for debugging purposes.

### Testing
Unfortunately this is very hard to hit, and I have high confidence in the fix.
It's not on a critical path, so if it happens again in CI we can revisit the fix.

### API Changes
There are no API changes in this PR.
