### PR TITLE
Hardcode earlier TTSIm version

### DIFF
--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -71,6 +71,9 @@ jobs:
             TTSIM_VERSION="v1.0.0"
           fi
           echo "Extracted ttsim version: $TTSIM_VERSION"
+          # TODO: Temporarily hardcoded to v1.5.8 because the newest version has an issue and tests don't pass.
+          TTSIM_VERSION="v1.5.8"
+          echo "Using ttsim version: $TTSIM_VERSION"
           echo "ttsim-version=$TTSIM_VERSION" >> $GITHUB_OUTPUT
 
       - name: Download ttsim binary (wh)


### PR DESCRIPTION
### Issue
Failing tests on newest runs: https://github.com/tenstorrent/tt-umd/actions/runs/25995615435/job/76409480020?pr=2567

### Description
Seems like there is some sort of a regression in the newest ttsim (or an improvement we didn't integrate)

### List of the changes
- Hardcode temporarily ttsim version to 1.5.8

### Testing
No testing, but here's a passing run on main branch with this version: https://github.com/tenstorrent/tt-umd/actions/runs/25938895541/job/76251280249

### API Changes
There are no API changes in this PR.
