### PR TITLE
Set releases not to be draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,7 +386,7 @@ jobs:
       contents: write
       packages: write
       id-token: write
-    needs: [prepare-release, build-cpp-artifacts, build-python-wheels, publish-to-testpypi]
+    needs: [prepare-release, build-cpp-artifacts, build-python-wheels, publish-to-testpypi, publish-to-pypi]
     outputs:
       upload_url: ${{ steps.release.outputs.upload_url }}
       release_url: ${{ steps.release.outputs.url }}
@@ -455,7 +455,13 @@ jobs:
   notify-completion:
     name: Notify Release Completion
     runs-on: ubuntu-22.04
-    needs: [prepare-release, create-release, build-cpp-artifacts, build-python-wheels, publish-to-testpypi]
+    needs:
+      - prepare-release
+      - create-release
+      - build-cpp-artifacts
+      - build-python-wheels
+      - publish-to-testpypi
+      - publish-to-pypi
     if: needs.create-release.result == 'success'
     steps:
       - name: Prepare Slack message
@@ -465,27 +471,21 @@ jobs:
           VERSION="${{ needs.prepare-release.outputs.version }}"
           REPO="${{ github.repository }}"
           RELEASE_URL="https://github.com/${REPO}/releases/tag/v${VERSION}"
-          DRAFT_RELEASE_URL="${{ needs.create-release.outputs.release_url }}"
-          echo "🔗 Draft Release URL: $DRAFT_RELEASE_URL"
+          PUBLISHED_RELEASE_URL="${{ needs.create-release.outputs.release_url }}"
+          echo "🔗 Published Release URL: $PUBLISHED_RELEASE_URL"
           echo "🔗 Release URL: $RELEASE_URL"
 
           # Create the message content using a here-document to avoid quote issues
           cat << EOF > /tmp/slack_message.txt
-          🚧 TT-UMD Draft Release Created!
+          🚀 TT-UMD Release Published!
 
-          Draft Release v${VERSION} has been successfully created!
-          When published, the release will be available at this link: ${RELEASE_URL}
+          Release v${VERSION} has been successfully published!
+          The release is available at: ${RELEASE_URL}
 
           📋 Release highlights from CHANGELOG:
           ${{ needs.prepare-release.outputs.version_changelog }}
 
-          ⚠️ Action Required:
-          The release is currently in DRAFT mode. Please:
-          1. Review the release notes and changelog
-          2. Verify all information is accurate
-          3. Publish the release when ready
-
-          🔗 Edit Release: ${DRAFT_RELEASE_URL}
+          🔗 View Release: ${PUBLISHED_RELEASE_URL}
 
           📋 Pull Requests in this release:
           ${{ needs.prepare-release.outputs.pr_summary }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -448,7 +448,7 @@ jobs:
             *This release was automatically generated when the VERSION file was updated.
             Release notes were extracted from CHANGELOG file.*
           files: ./final-assets/*
-          draft: true
+          draft: false
           prerelease: true
           make_latest: false
 


### PR DESCRIPTION
### Issue


### Description
Now that we have stable (pre-release) releases, don't publish them as draft.

### List of the changes
- set workflow not to generate draft releases

### Testing
I have no way to test this other than generating the full release. We'll see how it works

### API Changes
There are no API changes in this PR.
