### PR TITLE
Add new CI machines

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -79,7 +79,10 @@ jobs:
             {"arch": "blackhole",   "card": "tt-ubuntu-2204-p150b-stable"},
             {"arch": "blackhole",   "card": "tt-ubuntu-2204-p150b-viommu-stable"},
             {"arch": "wormhole_b0", "card": "6u"},
+            {"arch": "wormhole_b0", "card": "tt-ubuntu-2204-wh-glx-6u-stable"},
+            {"arch": "wormhole_b0", "card": "tt-ubuntu-2204-wh-glx-6u-viommu-stable"},
             {"arch": "blackhole",   "card": "bh-gh-07"},
+            {"arch": "blackhole",   "card": "tt-ubuntu-2204-bh-loudbox-stable"},
             {"arch": "blackhole",   "card": "tt-ubuntu-2204-bh-loudbox-viommu-stable"},
             {"arch": "baremetal",   "card": "ubuntu-22.04"}
           ]
@@ -89,8 +92,9 @@ jobs:
 
   # Central blacklist for matrix entries that should not run under certain conditions.
   # Each entry is a pipe-delimited "triggering-event|build-type|card" triple.
-  # Use "*" in the build-type field to match any build type for that event/card.
-  # To extend: add entries to the echo below.
+  # Each field supports: exact match, "*" wildcard (any value), or a trailing "*" for
+  # prefix match (e.g. "tt-ubuntu-2204-wh-glx-6u-*" blocks all wh-glx-6u variants).
+  # To extend: add entries to the jq invocation below.
   # Note: This can also easily extend to include ubuntu-docker-version or other parameters.
   blacklist:
     name: Define test blacklist
@@ -100,10 +104,22 @@ jobs:
     steps:
       - name: Define blacklist entries
         id: define
+        # Note on the machines:
+        # To avoid contention on single machines, we blacklist PR runs, and merge queue runs on Asan and Tsan,
+        # as these are unlikely to be the only failures. We also don't need both hugepage and viommu runs.
+        # - bh-gh-07 is a dedicated P300 single machine.
+        # - bh-loudbox is a single machine in CIv2. It also has an additional problem where
+        #   it actually has a ~20min startup time for viommu variant, so this one can be really slow.
+        # - The wh-glx-6u is also one machine, but not yet fully proven, so don't want to block merge queue with it.
+        # On main, just run all of them since we are not that critical about runtime and want to maximize coverage.
         run: |
           ENTRIES=$(jq -cn '$ARGS.positional' --args \
-            'pull_request|*|tt-ubuntu-2204-bh-loudbox-viommu-stable' \
+            'pull_request|*|tt-ubuntu-2204-bh-loudbox-*' \
             'merge_group|*|tt-ubuntu-2204-bh-loudbox-viommu-stable' \
+            'merge_group|ASan|tt-ubuntu-2204-bh-loudbox-stable' \
+            'merge_group|TSan|tt-ubuntu-2204-bh-loudbox-stable' \
+            'pull_request|*|tt-ubuntu-2204-wh-glx-6u-*' \
+            'merge_group|*|tt-ubuntu-2204-wh-glx-6u-*' \
             'pull_request|*|bh-gh-07' \
             'merge_group|ASan|bh-gh-07' \
             'merge_group|TSan|bh-gh-07' \
@@ -131,12 +147,15 @@ jobs:
             --argjson blacklist "$BLACKLIST" \
             --arg event "$TRIGGERING_EVENT" \
             --arg buildType "$BUILD_TYPE" \
-            '[.[] | select(
-                ($event + "|" + $buildType + "|" + .card) as $exact |
-                ($event + "|*|" + .card) as $wildcard |
-                ($blacklist | index($exact)) == null and
-                ($blacklist | index($wildcard)) == null
-            )]')
+            'def matchP(v; p):
+               if (p | endswith("*")) then v | startswith(p | rtrimstr("*"))
+               else v == p end;
+             [.[] | . as $c | select(
+                ($blacklist | any(
+                  split("|") as $p |
+                  matchP($event; $p[0]) and matchP($buildType; $p[1]) and matchP($c.card; $p[2])
+                )) | not
+             )]')
           echo "test-groups=$FILTERED" >> $GITHUB_OUTPUT
           echo "Filtered test matrix for trigger ($TRIGGERING_EVENT) build-type ($BUILD_TYPE):"
           echo "$FILTERED" | jq -r '.[] | "  \(.arch) | \(.card)"'


### PR DESCRIPTION
### Issue


### Description
Finally we have a functional 6u in CIv2

### List of the changes
- Add CIv2 6u machines. Run them only on main, since they are not yet fully tested. We do still have our dedicated 6u machine which will run on merge queue.
- Add bh-loudbox variant without viommu. This one doesn't have a long startup time like its viommu counterpart, so we can run it on merge queue

### Testing
The Generate filtered test matrix should produce the right values, but this can be checked only after this one is merged.

### API Changes
There are no API changes in this PR.
