### PR TITLE
Support simulator H2D/D2H socket sysmem

### DIFF
--- a/device/api/umd/device/chip/chip.hpp
+++ b/device/api/umd/device/chip/chip.hpp
@@ -103,6 +103,7 @@ public:
     virtual void set_power_state(DevicePowerState state);
     virtual int get_clock() = 0;
     virtual int get_numa_node() = 0;
+    void advance_device_execution();
 
     virtual int arc_msg(
         uint32_t msg_code,

--- a/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
@@ -4,6 +4,11 @@
 
 #pragma once
 
+#include <mutex>
+#include <optional>
+#include <utility>
+#include <vector>
+
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 
 namespace tt::umd {
@@ -17,6 +22,9 @@ public:
 
     void unpin_or_unmap_sysmem() override;
 
+    void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) override;
+    void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) override;
+
     std::unique_ptr<SysmemBuffer> allocate_sysmem_buffer(
         size_t sysmem_buffer_size, const bool map_to_noc = false) override;
 
@@ -27,8 +35,21 @@ protected:
     bool init_sysmem(uint32_t num_host_mem_channels) override;
 
 private:
+    struct MappedBuffer {
+        uint64_t base = 0;
+        void* buffer = nullptr;
+        size_t size = 0;
+    };
+
+    std::optional<MappedBuffer> find_mapped_buffer(uint64_t base, uint32_t size);
+    void remove_mapped_buffer(uint64_t base);
+
     uint8_t* system_memory_ = nullptr;
     size_t system_memory_size_ = 0;
+    uint64_t next_mapped_buffer_base_ = 0;
+    std::vector<MappedBuffer> mapped_buffers_;
+    std::vector<std::pair<void*, size_t>> owned_allocations_;
+    std::mutex mapped_buffers_mutex_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
@@ -7,6 +7,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <functional>
+#include <optional>
+
 #include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
@@ -48,6 +51,12 @@ public:
      * @param map_to_noc If true, the buffer will be mapped to be accessible over NOC from device.
      */
     SysmemBuffer(TLBManager* tlb_manager, void* buffer_va, size_t buffer_size, bool map_to_noc = false);
+    SysmemBuffer(
+        void* buffer_va,
+        size_t buffer_size,
+        uint64_t device_io_addr,
+        std::optional<uint64_t> noc_addr = std::nullopt,
+        std::function<void()> unmap_callback = {});
     ~SysmemBuffer();
 
     /**
@@ -137,6 +146,8 @@ private:
     std::optional<uint64_t> noc_addr_;
 
     std::unique_ptr<TlbWindow> cached_tlb_window = nullptr;
+
+    std::function<void()> unmap_callback_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -570,6 +570,8 @@ public:
      */
     void read_from_sysmem(void* mem_ptr, uint64_t addr, uint16_t channel, uint32_t size, ChipId src_device_id);
 
+    void advance_device_execution(ChipId device_id);
+
     /**
      * Query number of memory channels on Host device allocated for a specific device during initialization.
      *

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -343,6 +343,10 @@ public:
      */
     virtual EthTrainingStatus read_eth_core_training_status(tt_xy_pair eth_core) = 0;
 
+    // Advance one deterministic device tick when the backing device exposes a
+    // host-driven clock. Real silicon leaves this as a no-op.
+    virtual void advance_device_execution();
+
 protected:
     std::shared_ptr<PCIDevice> pci_device_;
     std::shared_ptr<JtagDevice> jtag_device_;

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -60,6 +60,7 @@ public:
 
     void close_device();
     void start_device();
+    void advance_device_execution() override;
 
     void send_tensix_risc_reset(tt_xy_pair translated_core, const TensixSoftResetOptions &soft_resets);
     void send_tensix_risc_reset(const TensixSoftResetOptions &soft_resets);

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -234,6 +234,12 @@ int Chip::arc_msg(
     return exit_code;
 }
 
+void Chip::advance_device_execution() {
+    if (auto* td = get_tt_device()) {
+        td->advance_device_execution();
+    }
+}
+
 void Chip::set_power_state(DevicePowerState state) {
     int exit_code = 0;
     if (soc_descriptor_.arch == tt::ARCH::WORMHOLE_B0) {

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -6,9 +6,12 @@
 
 #include <sys/mman.h>  // for mmap, munmap
 #include <sys/stat.h>  // for fstat
+#include <unistd.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -20,6 +23,16 @@
 #include "hugepage.hpp"
 
 namespace tt::umd {
+
+namespace {
+
+constexpr uint64_t kHostMemChannelSize = 1ULL << 30;
+
+uint64_t align_up(uint64_t value, uint64_t alignment) {
+    return (value + alignment - 1) & ~(alignment - 1);
+}
+
+}  // namespace
 
 SimulationSysmemManager::SimulationSysmemManager(uint32_t num_host_mem_channels, tt::ARCH arch) {
     pcie_base_ = get_pcie_base_for_arch(arch);
@@ -47,6 +60,7 @@ bool SimulationSysmemManager::init_sysmem(uint32_t num_host_mem_channels) {
         static_cast<uint8_t *>(mmap(nullptr, total_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
     TT_ASSERT(system_memory_ != MAP_FAILED, "system_memory mmap() failed");
     system_memory_size_ = total_size;
+    next_mapped_buffer_base_ = total_size;
 
     for (int i = 0; i < num_host_mem_channels; i++) {
         size_t channel_size = (i == 3 && num_host_mem_channels == 4) ? (768 * (1ULL << 20)) : (1ULL << 30);
@@ -62,6 +76,14 @@ bool SimulationSysmemManager::pin_or_map_sysmem_to_device() { return true; }
 SimulationSysmemManager::~SimulationSysmemManager() { SimulationSysmemManager::unpin_or_unmap_sysmem(); }
 
 void SimulationSysmemManager::unpin_or_unmap_sysmem() {
+    {
+        std::lock_guard<std::mutex> lock(mapped_buffers_mutex_);
+        mapped_buffers_.clear();
+    }
+    for (const auto& [allocation, allocation_size] : owned_allocations_) {
+        munmap(allocation, allocation_size);
+    }
+    owned_allocations_.clear();
     hugepage_mapping_per_channel.clear();
     if (system_memory_ != nullptr) {
         munmap(system_memory_, system_memory_size_);
@@ -70,14 +92,88 @@ void SimulationSysmemManager::unpin_or_unmap_sysmem() {
     }
 }
 
+std::optional<SimulationSysmemManager::MappedBuffer> SimulationSysmemManager::find_mapped_buffer(
+    uint64_t base, uint32_t size) {
+    for (const auto& mapped_buffer : mapped_buffers_) {
+        if (base >= mapped_buffer.base && base + size <= mapped_buffer.base + mapped_buffer.size) {
+            return mapped_buffer;
+        }
+    }
+    return std::nullopt;
+}
+
+void SimulationSysmemManager::remove_mapped_buffer(uint64_t base) {
+    std::lock_guard<std::mutex> lock(mapped_buffers_mutex_);
+    mapped_buffers_.erase(
+        std::remove_if(
+            mapped_buffers_.begin(),
+            mapped_buffers_.end(),
+            [base](const MappedBuffer& mapped_buffer) { return mapped_buffer.base == base; }),
+        mapped_buffers_.end());
+}
+
+void SimulationSysmemManager::write_to_sysmem(
+    uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) {
+    const uint64_t base = static_cast<uint64_t>(channel) * kHostMemChannelSize + sysmem_dest;
+    {
+        std::lock_guard<std::mutex> lock(mapped_buffers_mutex_);
+        auto mapped_buffer = find_mapped_buffer(base, size);
+        if (mapped_buffer.has_value()) {
+            std::memcpy(
+                static_cast<uint8_t*>(mapped_buffer->buffer) + (base - mapped_buffer->base), src, size);
+            return;
+        }
+    }
+
+    SysmemManager::write_to_sysmem(channel, src, sysmem_dest, size);
+}
+
+void SimulationSysmemManager::read_from_sysmem(
+    uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) {
+    const uint64_t base = static_cast<uint64_t>(channel) * kHostMemChannelSize + sysmem_src;
+    {
+        std::lock_guard<std::mutex> lock(mapped_buffers_mutex_);
+        auto mapped_buffer = find_mapped_buffer(base, size);
+        if (mapped_buffer.has_value()) {
+            std::memcpy(
+                dest, static_cast<uint8_t*>(mapped_buffer->buffer) + (base - mapped_buffer->base), size);
+            return;
+        }
+    }
+
+    SysmemManager::read_from_sysmem(channel, dest, sysmem_src, size);
+}
+
 std::unique_ptr<SysmemBuffer> SimulationSysmemManager::allocate_sysmem_buffer(
     size_t sysmem_buffer_size, const bool map_to_noc) {
-    return nullptr;
+    void* mapping =
+        mmap(nullptr, sysmem_buffer_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
+    TT_ASSERT(mapping != MAP_FAILED, "Simulation sysmem buffer mmap() failed");
+    owned_allocations_.push_back({mapping, sysmem_buffer_size});
+    return map_sysmem_buffer(mapping, sysmem_buffer_size, map_to_noc);
 }
 
 std::unique_ptr<SysmemBuffer> SimulationSysmemManager::map_sysmem_buffer(
     void *buffer, size_t sysmem_buffer_size, const bool map_to_noc) {
-    return nullptr;
+    static const auto page_size = sysconf(_SC_PAGESIZE);
+    const uint64_t mapped_size = align_up(sysmem_buffer_size, page_size);
+
+    uint64_t mapped_base = 0;
+    {
+        std::lock_guard<std::mutex> lock(mapped_buffers_mutex_);
+        mapped_base = align_up(next_mapped_buffer_base_, page_size);
+        next_mapped_buffer_base_ = mapped_base + mapped_size;
+        mapped_buffers_.push_back({mapped_base, buffer, sysmem_buffer_size});
+    }
+
+    const uint64_t device_io_addr = pcie_base_ + mapped_base;
+    std::optional<uint64_t> noc_addr = map_to_noc ? std::optional<uint64_t>(device_io_addr) : std::nullopt;
+    return std::make_unique<SysmemBuffer>(
+        buffer,
+        sysmem_buffer_size,
+        device_io_addr,
+        noc_addr,
+        [this, mapped_base]() { remove_mapped_buffer(mapped_base); });
 }
 
 }  // namespace tt::umd

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -11,6 +11,7 @@
 #include <optional>
 #include <tt-logger/tt-logger.hpp>
 #include <tuple>
+#include <utility>
 
 #include "assert.hpp"
 #include "noc_access.hpp"
@@ -29,6 +30,22 @@ SysmemBuffer::SysmemBuffer(TLBManager* tlb_manager, void* buffer_va, size_t buff
         device_io_addr_ = pci_device->map_for_dma(buffer_va_, mapped_buffer_size_);
         noc_addr_ = std::nullopt;
     }
+}
+
+SysmemBuffer::SysmemBuffer(
+    void* buffer_va,
+    size_t buffer_size,
+    uint64_t device_io_addr,
+    std::optional<uint64_t> noc_addr,
+    std::function<void()> unmap_callback) :
+    tlb_manager_(nullptr),
+    buffer_va_(buffer_va),
+    mapped_buffer_size_(buffer_size),
+    buffer_size_(buffer_size),
+    device_io_addr_(device_io_addr),
+    noc_addr_(noc_addr),
+    unmap_callback_(std::move(unmap_callback)) {
+    align_address_and_size();
 }
 
 void SysmemBuffer::dma_write_to_device(const size_t offset, size_t size, const tt_xy_pair core, uint64_t addr) {
@@ -141,6 +158,13 @@ void SysmemBuffer::dma_read_from_device(const size_t offset, size_t size, const 
 }
 
 SysmemBuffer::~SysmemBuffer() {
+    if (unmap_callback_) {
+        unmap_callback_();
+        return;
+    }
+    if (tlb_manager_ == nullptr) {
+        return;
+    }
     try {
         tlb_manager_->get_tt_device()->get_pci_device()->unmap_for_dma(buffer_va_, mapped_buffer_size_);
     } catch (...) {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -833,6 +833,8 @@ void Cluster::read_from_sysmem(void* mem_ptr, uint64_t addr, uint16_t channel, u
     get_chip(src_device_id)->read_from_sysmem(channel, mem_ptr, addr, size);
 }
 
+void Cluster::advance_device_execution(ChipId device_id) { get_chip(device_id)->advance_device_execution(); }
+
 void Cluster::l1_membar(const ChipId chip, const std::unordered_set<CoreCoord>& cores) {
     get_chip(chip)->l1_membar(cores);
 }

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -315,6 +315,8 @@ FirmwareBundleVersion TTDevice::get_firmware_version() { return get_firmware_inf
 
 void TTDevice::wait_for_non_mmio_flush() {}
 
+void TTDevice::advance_device_execution() {}
+
 bool TTDevice::is_remote() { return is_remote_tt_device; }
 
 int TTDevice::get_communication_device_id() const { return communication_device_id_; }

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -68,6 +68,12 @@ void TTSimTTDevice::start_device() {}
 
 void TTSimTTDevice::close_device() { communicator_->shutdown(); }
 
+void TTSimTTDevice::advance_device_execution() {
+    if (communicator_) {
+        communicator_->advance_clock(1);
+    }
+}
+
 void TTSimTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, uint32_t size) {
     std::lock_guard<std::recursive_mutex> lock(device_lock);
     if (architecture_impl_->get_architecture() != ARCH::WORMHOLE_B0 &&


### PR DESCRIPTION
## Summary
- Reserve simulator-visible host sysmem for H2D/D2H socket buffers.
- Add an explicit simulator progress hook, `advance_device_execution()`, so socket polling paths can advance tt-sim while waiting for device-side state changes.

## Motivation
- H2D/D2H sockets need memory that is visible from both host code and the simulated device. On silicon this is backed by real device/host memory plumbing; in tt-sim we need to reserve and route an equivalent sysmem window explicitly.
- Socket waits can otherwise deadlock in simulation: the host blocks or spins waiting for a socket state transition, but there is no independent hardware device progressing in the background. The progress hook lets the socket path pump the simulated device until the expected H2D/D2H state changes.
- The new API is intentionally not socket-specific semantically; it is a simulator execution/progress primitive used by the socket path because that is where the blocking wait appears.

## Notes
- Branch: `nkapre/h2d_d2h_blaze`
- Commit: `5058a96a Support simulator H2D/D2H socket sysmem`
- Opened as draft to make the UMD integration discussion easier before deciding whether this is the final API shape.

## Validation
- Downstream craq-sim / tt-blaze H2D/D2H socket path validation is expected before marking ready for review.