### PR TITLE
Skip TTSim device IO tests on Wormhole and Blackhole

### DIFF
--- a/tests/api/test_ttsim_device_io.cpp
+++ b/tests/api/test_ttsim_device_io.cpp
@@ -44,6 +44,12 @@ protected:
         }
         tt_device.reset(sim_device);
         device.release();  // NOLINT(bugprone-unused-return-value)
+
+        const tt::ARCH arch = tt_device->get_soc_descriptor().arch;
+        if (arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE) {
+            GTEST_SKIP() << "tile_wr_bytes/tile_rd_bytes are no longer supported on TTSim for arch "
+                         << tt::arch_to_str(arch);
+        }
     }
 
     void TearDown() override {


### PR DESCRIPTION
### Issue
tile_wr_bytes / tile_rd_bytes are no longer supported in TTSim on Wormhole and Blackhole, but TTSimDeviceIOFixture exercises them in every test, causing the suite to fail on those archs.

### Description
Skip every test in TTSimDeviceIOFixture when the simulator's arch is WORMHOLE_B0 or BLACKHOLE by issuing GTEST_SKIP() from the fixture's SetUp(). Quasar (the arch where these APIs are currently supported on TTSim) still runs the full suite.

### List of the changes
- tests/api/test_ttsim_device_io.cpp: in TTSimDeviceIOFixture::SetUp(), skip the test when soc_descriptor.arch is WORMHOLE_B0 or BLACKHOLE.

### Testing
Built api_tests locally with the change applied.

### API Changes
There are no API changes in this PR.