### PR TITLE
Reduce some log_infos to log_debug

### DIFF
--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -272,7 +272,7 @@ bool SiliconSysmemManager::pin_or_map_hugepages() {
             std::tie(noc_address, physical_address) = pci_device_->map_hugepage_to_noc(mapping, actual_size);
             uint64_t expected_noc_address = pcie_base_ + (ch * hugepage_size);
 
-            log_info(LogUMD, "Mapped hugepage {:#x} to NOC address {:#x}", physical_address, noc_address);
+            log_debug(LogUMD, "Mapped hugepage {:#x} to NOC address {:#x}", physical_address, noc_address);
             // Note that the truncated page is the final one, so there is no need to
             // give expected_noc_address special treatment for a subsequent page.
             if (noc_address != expected_noc_address) {
@@ -331,13 +331,11 @@ bool SiliconSysmemManager::init_iommu(uint32_t num_fake_mem_channels) {
         iommu_mapping_size = size;
     }
 
-    log_info(LogUMD, "Initializing iommu for sysmem (size: {:#x}).", iommu_mapping_size);
-
     if (!pci_device_->is_iommu_enabled()) {
         UMD_THROW(error::RuntimeError, "IOMMU is required for sysmem without hugepages.");
     }
 
-    log_info(LogUMD, "Allocating sysmem for IOMMU (size: {:#x}).", iommu_mapping_size);
+    log_debug(LogUMD, "Allocating sysmem for IOMMU (size: {:#x}).", iommu_mapping_size);
     iommu_mapping = mmap_with_hugepage_fallback(size);
 
     if (iommu_mapping == MAP_FAILED) {
@@ -388,7 +386,7 @@ bool SiliconSysmemManager::pin_or_map_iommu() {
         UMD_THROW(error::RuntimeError, "Proceeding could lead to undefined behavior");
     }
 
-    log_info(LogUMD, "Mapped sysmem without hugepages to IOVA {:#x}; NOC address {:#x}", iova, *noc_address);
+    log_debug(LogUMD, "Mapped sysmem without hugepages to IOVA {:#x}; NOC address {:#x}", iova, *noc_address);
 
     for (size_t ch = 0; ch < hugepage_mapping_per_channel.size(); ch++) {
         uint64_t device_io_address = iova + ch * HUGEPAGE_REGION_SIZE;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -262,7 +262,7 @@ SocDescriptor Cluster::construct_soc_descriptor(
         chip_info.asic_location = cluster_desc->get_asic_location(chip_id);
     }
 
-    log_info(
+    log_debug(
         LogUMD,
         "Harvesting masks for Chip {}: Tensix: {:#x} DRAM: {:#x} ETH: {:#x} PCIe: {:#x} L2CPU: {:#x}",
         chip_id,


### PR DESCRIPTION
### Issue
Slack thread

### Description
In general, avoid having log_info per chip during cluster construction. This leads to a lot of spam in case of 6u galaxy.

### List of the changes
- hugepage and iommu logs reduced to log_debug
- Harvesting per chip reported in log_debug instead of log_info

### Testing
Log without this change has ~62k lines: https://productionresultssa15.blob.core.windows.net/actions-results/205aba87-ac12-435a-befc-3fdf061413e8/workflow-job-run-594cb06c-2727-5d4e-b984-6a0d4599675d/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-05-18T10%3A35%3A17Z&sig=UjErhqaxg49DIlg9QujZg3YKnUWLTbqmp0k6DEHORdo%3D&ske=2026-05-18T13%3A18%3A43Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-05-18T09%3A18%3A43Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-05-18T10%3A25%3A12Z&sv=2025-11-05

Log with this change has ~56k lines: https://productionresultssa16.blob.core.windows.net/actions-results/e3b05fae-22a4-473a-9c95-f0a51b34f4c9/workflow-job-run-451bc6c9-1c16-5db2-a4a0-b6fec654f692/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-05-18T15%3A19%3A29Z&sig=PPaJaUgvpT1ODY2FYtUp7EFKrTEJXmu%2BfP4ZO7dCDpM%3D&ske=2026-05-18T17%3A18%3A57Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-05-18T13%3A18%3A57Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-05-18T15%3A09%3A24Z&sv=2025-11-05

### API Changes
There are no API changes in this PR.
