### PR TITLE
Remove TT_UMD_BUILD_SIMULATION guards from source code

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -195,16 +195,9 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
 #endif
     }
     if (chip_type == ChipType::SIMULATION) {
-#ifdef TT_UMD_BUILD_SIMULATION
         log_info(LogUMD, "Creating Simulation device");
         return SimulationChip::create(
             simulator_directory, soc_desc, chip_id, cluster_desc->get_number_of_chips(), num_host_mem_channels);
-#else
-        UMD_THROW(
-            error::RuntimeError,
-            "Simulation device is not supported in this build. Set '-DTT_UMD_BUILD_SIMULATION=ON' during cmake "
-            "configuration to enable simulation device.");
-#endif
     }
 
     if (cluster_desc->is_chip_mmio_capable(chip_id)) {
@@ -309,9 +302,8 @@ void Cluster::add_chip(const ChipId& chip_id, const ChipType& chip_type, std::un
     chips_.emplace(chip_id, std::move(chip));
 }
 
-// Options is intentionally taken by value because it may be mutated when TT_UMD_BUILD_SIMULATION is enabled.
-// NOLINT is needed because clang-tidy cannot see the mutation when simulation is compiled out.
-Cluster::Cluster(ClusterOptions options) {  // NOLINT(performance-unnecessary-value-param)
+// Options is intentionally taken by value because it may be mutated below for simulation chips.
+Cluster::Cluster(ClusterOptions options) {
     ZoneScopedNC("Cluster::Cluster", tracy::Color::DarkGreen);
     log_info(LogUMD, "Cluster constructor started.");
     options_ = options;
@@ -335,7 +327,6 @@ Cluster::Cluster(ClusterOptions options) {  // NOLINT(performance-unnecessary-va
                 // If no custom descriptor is provided, in case of mock or simulation chip type, we create a mock
                 // cluster descriptor from passed target devices.
                 auto arch = tt::ARCH::WORMHOLE_B0;
-#ifdef TT_UMD_BUILD_SIMULATION
                 if (options.chip_type == ChipType::SIMULATION) {
                     if (options.sdesc_path.empty()) {
                         options.sdesc_path =
@@ -343,7 +334,6 @@ Cluster::Cluster(ClusterOptions options) {  // NOLINT(performance-unnecessary-va
                     }
                     arch = SocDescriptor::get_arch_from_soc_descriptor_path(options.sdesc_path);
                 }
-#endif
                 // Noc translation is enabled for mock chips and for ttsim simulation, but disabled for versim/vcs
                 // simulation.
                 bool is_ttsim_simulation =

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -693,8 +693,7 @@ void bind_tt_device(nb::module_ &m) {
             "Get firmware bundle version from SPI (Blackhole only). "
             "Returns raw 32-bit value with format [component][major][minor][patch] (each 8 bits).");
 
-#ifdef TT_UMD_BUILD_SIMULATION
-    // Add simulation TTDevice factory binding - must be inside TT_UMD_BUILD_SIMULATION guard.
+    // Add simulation TTDevice factory binding.
     m.def(
         "create_simulation_tt_device",
         &create_simulation_tt_device,
@@ -796,7 +795,6 @@ void bind_tt_device(nb::module_ &m) {
             nb::rv_policy::reference_internal,
             release_gil(),
             "Get the SocDescriptor associated with this RTL simulation device.");
-#endif
 
     m.def(
         "create_remote_tt_device",


### PR DESCRIPTION
### Issue
The `#ifdef TT_UMD_BUILD_SIMULATION` guards in `device/cluster.cpp` and `nanobind/py_api_tt_device.cpp` mixed build-configuration into the source code while the CMake side already gates simulation compilation.

### Description
Drop the `TT_UMD_BUILD_SIMULATION` preprocessor checks from the C++ sources. The option is still defined and used by CMake (`CMakeLists.txt`, `device/CMakeLists.txt`, `nanobind/CMakeLists.txt`, `third_party/CMakeLists.txt`, `tests/...`) to gate simulation sources, third-party dependencies, and test executables.

Note: with this change, `cluster.cpp` and the nanobind bindings reference simulation symbols (`SimulationChip::create`, `SimulationChip::get_soc_descriptor_path_from_simulator_path`, the Python simulation TTDevice factories) unconditionally. Builds with `TT_UMD_BUILD_SIMULATION=OFF` will therefore fail to link these translation units. If `OFF` is a supported configuration, the CMake side should be adjusted to always compile the relevant simulation sources.

### List of the changes
- `device/cluster.cpp`: drop the `#ifdef TT_UMD_BUILD_SIMULATION` / `#else` branches in `construct_chip_from_cluster` and inside `Cluster::Cluster`; remove the now-stale `NOLINT(performance-unnecessary-value-param)` and update the by-value comment.
- `nanobind/py_api_tt_device.cpp`: drop the `#ifdef TT_UMD_BUILD_SIMULATION` block wrapping the simulation TTDevice and Python factory bindings.

### Testing
- `cmake --build build` (config with `TT_UMD_BUILD_SIMULATION=ON`) — clean build, all targets link.
- `pre-commit run --all-files` — passes.

### API Changes
There are no API changes in this PR.
