### PR TITLE
Centralize 16/32-bit device stores/loads in device_memcpy

### DIFF
--- a/device/pcie/device_memcpy.cpp
+++ b/device/pcie/device_memcpy.cpp
@@ -13,6 +13,22 @@
 
 namespace tt::umd {
 
+void write16_to_device(volatile void* dest, std::uint16_t value) {
+    *reinterpret_cast<volatile std::uint16_t*>(dest) = value;
+}
+
+void write32_to_device(volatile void* dest, std::uint32_t value) {
+    *reinterpret_cast<volatile std::uint32_t*>(dest) = value;
+}
+
+std::uint16_t read16_from_device(const volatile void* src) {
+    return *reinterpret_cast<const volatile std::uint16_t*>(src);
+}
+
+std::uint32_t read32_from_device(const volatile void* src) {
+    return *reinterpret_cast<const volatile std::uint32_t*>(src);
+}
+
 void memcpy_to_device(volatile void* dest, const void* src, std::size_t size) {
     auto* d = static_cast<volatile std::uint8_t*>(dest);
     auto* s = static_cast<const std::uint8_t*>(src);

--- a/device/pcie/device_memcpy.hpp
+++ b/device/pcie/device_memcpy.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
 namespace tt::umd {
 
@@ -37,5 +38,16 @@ void memcpy_to_device(volatile void* dest, const void* src, std::size_t size);
  * Handles arbitrary alignment and size.
  */
 void memcpy_from_device(void* dest, const volatile void* src, std::size_t size);
+
+/**
+ * Single-DWORD/word scalar transfers to/from TLB-mapped device memory. Centralizing these
+ * here (alongside the bulk memcpy routines) keeps every TLB-touching store/load behind a
+ * single set of primitives that future improvements (per-op timeouts, instrumentation,
+ * etc.) can wrap uniformly.
+ */
+void write16_to_device(volatile void* dest, std::uint16_t value);
+void write32_to_device(volatile void* dest, std::uint32_t value);
+std::uint16_t read16_from_device(const volatile void* src);
+std::uint32_t read32_from_device(const volatile void* src);
 
 }  // namespace tt::umd

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -16,7 +16,6 @@
 #include <cstring>
 #include <functional>
 #include <memory>
-#include <string>
 #include <utility>
 
 #include "device_memcpy.hpp"
@@ -72,22 +71,22 @@ SiliconTlbWindow::SiliconTlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_
 
 void SiliconTlbWindow::write16(uint64_t offset, uint16_t value) {
     validate(offset, sizeof(uint16_t));
-    *reinterpret_cast<volatile uint16_t *>(tlb_handle->get_base() + get_total_offset(offset)) = value;
+    write16_to_device(tlb_handle->get_base() + get_total_offset(offset), value);
 }
 
 uint16_t SiliconTlbWindow::read16(uint64_t offset) {
     validate(offset, sizeof(uint16_t));
-    return *reinterpret_cast<volatile uint16_t *>(tlb_handle->get_base() + get_total_offset(offset));
+    return read16_from_device(tlb_handle->get_base() + get_total_offset(offset));
 }
 
 void SiliconTlbWindow::write32(uint64_t offset, uint32_t value) {
     validate(offset, sizeof(uint32_t));
-    *reinterpret_cast<volatile uint32_t *>(tlb_handle->get_base() + get_total_offset(offset)) = value;
+    write32_to_device(tlb_handle->get_base() + get_total_offset(offset), value);
 }
 
 uint32_t SiliconTlbWindow::read32(uint64_t offset) {
     validate(offset, sizeof(uint32_t));
-    return *reinterpret_cast<volatile uint32_t *>(tlb_handle->get_base() + get_total_offset(offset));
+    return read32_from_device(tlb_handle->get_base() + get_total_offset(offset));
 }
 
 void SiliconTlbWindow::write_register(uint64_t offset, const void *data, size_t size) {
@@ -222,16 +221,16 @@ void SiliconTlbWindow::memcpy_to_device(void *dest, const void *src, std::size_t
 
 void SiliconTlbWindow::write_regs(volatile uint32_t *dest, const uint32_t *src, uint32_t word_len) {
     while (word_len-- != 0) {
-        *dest++ = *src++;
+        write32_to_device(dest++, *src++);
     }
 }
 
 void SiliconTlbWindow::read_regs(void *src_reg, uint32_t word_len, void *data) {
-    const volatile uint32_t *src = reinterpret_cast<uint32_t *>(src_reg);
-    uint32_t *dest = reinterpret_cast<uint32_t *>(data);
+    auto *src = static_cast<const volatile uint32_t *>(src_reg);
+    auto *dest = reinterpret_cast<uint32_t *>(data);
 
     while (word_len-- != 0) {
-        uint32_t temp = *src++;
+        uint32_t temp = read32_from_device(src++);
         memcpy(dest++, &temp, sizeof(temp));
     }
 }


### PR DESCRIPTION
### Issue
Prep for #2629 — the per-op MMIO timeout there only wraps the bulk `memcpy_{to,from}_device` path. Single-word `write32`/`read32`/`write_register` etc. stay inlined inside `SiliconTlbWindow` and bypass the wrapper.

### Description
Add `write{16,32}_to_device` / `read{16,32}_from_device` helpers next to the existing `memcpy_{to,from}_device` in `device/pcie/device_memcpy.{hpp,cpp}`, and route `SiliconTlbWindow::{write,read}{16,32}` plus the `write_regs` / `read_regs` loops through them. Every TLB-touching scalar access now sits behind a single set of primitives, so a future cross-cutting wrapper (per-op timeout from #2629, instrumentation, fault injection, …) can be applied uniformly to scalar and bulk paths.

The WH RMW bulk memcpy variants stay in `SiliconTlbWindow` — they reshape the existing AVX2 path's edges rather than adding new stores.

No behavior change.

### List of the changes
- `device/pcie/device_memcpy.{hpp,cpp}`: add `write16_to_device`, `write32_to_device`, `read16_from_device`, `read32_from_device`.
- `device/pcie/silicon_tlb_window.cpp`: `write16`/`read16`/`write32`/`read32` and the inner loops of `write_regs`/`read_regs` now call the new helpers; prune an unused `<string>` include.

### Testing
- `cmake --build build` clean.
- `pre-commit run --all-files` clean.
- Non-hardware tests pass (`umd_misc_tests`, `test_utils_tests`).

### API Changes
- New public symbols: `tt::umd::write16_to_device`, `tt::umd::write32_to_device`, `tt::umd::read16_from_device`, `tt::umd::read32_from_device`.
