### PR TITLE
[CI fixture] Re-merge working test commits onto rebased target

### DIFF
--- a/README.emu.md
+++ b/README.emu.md
@@ -26,7 +26,7 @@ location later.
 `export TENSIX_EMULATION_ROOT=/proj_soc/mlausin/emu_buda/ws_buda_1/tensix_emulation_targets`
 
 Contents of `TENSIX_EMULATION_ROOT`:
-```bash 
+```bash
 targets/tensix_2x2_1dram_BH/zcui.work - Zebu model of 2x2 grid with 2 tensix and 1 dram endpoint
 zebu/include - contains header files for zebu wrapper library
 zebu/lib - contains zebu wrapper library
@@ -40,7 +40,7 @@ https://yyz-tensix-gitlab.local.tenstorrent.com/tensix-hw/tensix_emulation
 ## Machines:
 Current setup is using machines in austin for compiling hw/sw and
 running emulation:
-```bash 
+```bash
 aus-rv-l-7 # used for compiling hw/sw
 aus-rv-zebu-03 # used for running emulation
 ```
@@ -52,14 +52,14 @@ To compile and run UMD with emulation device, you need to use a
 container. This container is located in
 `umd/emulation_rocky8.def`
 To build the container, run:
-```bash 
+```bash
 apptainer build emulation_rocky8.sif emulation_rocky8.def
 ```
 To run the container:
 ```bash
-# to compile sw on aus-rv-l-7, start container with: 
+# to compile sw on aus-rv-l-7, start container with:
 apptainer shell -s /usr/bin/bash -B /tools_soc/,/tools_vendor/,/site/lsf/,/site/zebu/,/proj_soc/ emulation_rocky8.sif
-# to run emu on aus-rv-zebu-03, start container with: 
+# to run emu on aus-rv-zebu-03, start container with:
 apptainer shell -s /usr/bin/bash -B /tools_soc/,/tools_vendor/,/site/lsf/,/site/zebu/,/proj_soc/,/zebu/ emulation_rocky8.sif
 ```
 
@@ -126,7 +126,7 @@ make EMULATION_DEVICE_EN=1 wave-view-emu # open waveforms in verdi(inside vnc se
 
 ## RTL device diagram
 This shows curent RTL device setup for emulation. It is a 2x2 grid with
-2 tensix, 1 AXI and 1 dram endpoin and these are connected using NOC. Dram endpoint has 2 AXI ports, 
+2 tensix, 1 AXI and 1 dram endpoin and these are connected using NOC. Dram endpoint has 2 AXI ports,
 one is connected to NOC0 other to NOC1, and these connect to AXI crossbar to merge trafic before
 connecting to memory model.
 
@@ -192,4 +192,5 @@ source ${TENSIX_EMULATION_ROOT}/zebu/scripts/env.bash
 cd build/rundir_zebu
 ZEBU_PHYSICAL_LOCATION=U0.M0=U0.M3 ./build/test/loader/tests/test_pybuda_ram --emulation --arch wormhole_b0 --netlist /proj_soc/mlausin/emu_buda/ws_buda_1/BudaBackEnd/loader/tests/net_basic/ram.yaml --device-desc ../../device/emulation_1x1_arch.yaml --num-pushes 128 |& tee emu.log
 ```
+Test change for GitLab CI verification
 

--- a/README.md
+++ b/README.md
@@ -273,3 +273,5 @@ There is an automated workflow for creating releases. It is triggered by merging
 You can change the VERSION as part of another PR or as an isolated PR. Please also update the CHANGELOG with the exact version you are changeing to.
 
 Once the PR is merged, a draft Release will be created with the generated changelog and artifacts. Please review it and publish it using the tag which exactly matches the version of the release.
+
+Test change for GitLab CI verification


### PR DESCRIPTION
**Do not merge manually unless coordinated with tt-umd-simulators CI work.**

CI fixture for the `tt-umd-simulators` repo's `polling_agent_mr` workflow.

Re-merges the rebased "working change" test commits onto the rebased
`tt-umd-simulators/gitlab-ci-test-branch` target so the polling agent has a real
PR event to discover for the green-path scenario.

Replaces the equivalent flow from the old `dzivanovic/*` test branches. Tracked
via tt-umd-simulators MR !92 and issue #53:

- MR  : https://yyz-gitlab.local.tenstorrent.com/tensix/tt-umd-simulators/-/merge_requests/92
- Issue: https://yyz-gitlab.local.tenstorrent.com/tensix/tt-umd-simulators/-/issues/53

Changes are README-only — the build is expected to succeed when this PR is merged.