### PR TITLE
[CI fixture] Re-merge failing test commits onto rebased target

### DIFF
--- a/README.emu.md
+++ b/README.emu.md
@@ -26,7 +26,7 @@ location later.
 `export TENSIX_EMULATION_ROOT=/proj_soc/mlausin/emu_buda/ws_buda_1/tensix_emulation_targets`
 
 Contents of `TENSIX_EMULATION_ROOT`:
-```bash 
+```bash
 targets/tensix_2x2_1dram_BH/zcui.work - Zebu model of 2x2 grid with 2 tensix and 1 dram endpoint
 zebu/include - contains header files for zebu wrapper library
 zebu/lib - contains zebu wrapper library
@@ -40,7 +40,7 @@ https://yyz-tensix-gitlab.local.tenstorrent.com/tensix-hw/tensix_emulation
 ## Machines:
 Current setup is using machines in austin for compiling hw/sw and
 running emulation:
-```bash 
+```bash
 aus-rv-l-7 # used for compiling hw/sw
 aus-rv-zebu-03 # used for running emulation
 ```
@@ -52,14 +52,14 @@ To compile and run UMD with emulation device, you need to use a
 container. This container is located in
 `umd/emulation_rocky8.def`
 To build the container, run:
-```bash 
+```bash
 apptainer build emulation_rocky8.sif emulation_rocky8.def
 ```
 To run the container:
 ```bash
-# to compile sw on aus-rv-l-7, start container with: 
+# to compile sw on aus-rv-l-7, start container with:
 apptainer shell -s /usr/bin/bash -B /tools_soc/,/tools_vendor/,/site/lsf/,/site/zebu/,/proj_soc/ emulation_rocky8.sif
-# to run emu on aus-rv-zebu-03, start container with: 
+# to run emu on aus-rv-zebu-03, start container with:
 apptainer shell -s /usr/bin/bash -B /tools_soc/,/tools_vendor/,/site/lsf/,/site/zebu/,/proj_soc/,/zebu/ emulation_rocky8.sif
 ```
 
@@ -126,7 +126,7 @@ make EMULATION_DEVICE_EN=1 wave-view-emu # open waveforms in verdi(inside vnc se
 
 ## RTL device diagram
 This shows curent RTL device setup for emulation. It is a 2x2 grid with
-2 tensix, 1 AXI and 1 dram endpoin and these are connected using NOC. Dram endpoint has 2 AXI ports, 
+2 tensix, 1 AXI and 1 dram endpoin and these are connected using NOC. Dram endpoint has 2 AXI ports,
 one is connected to NOC0 other to NOC1, and these connect to AXI crossbar to merge trafic before
 connecting to memory model.
 
@@ -192,4 +192,5 @@ source ${TENSIX_EMULATION_ROOT}/zebu/scripts/env.bash
 cd build/rundir_zebu
 ZEBU_PHYSICAL_LOCATION=U0.M0=U0.M3 ./build/test/loader/tests/test_pybuda_ram --emulation --arch wormhole_b0 --netlist /proj_soc/mlausin/emu_buda/ws_buda_1/BudaBackEnd/loader/tests/net_basic/ram.yaml --device-desc ../../device/emulation_1x1_arch.yaml --num-pushes 128 |& tee emu.log
 ```
+Test change for GitLab CI verification
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -57,7 +57,6 @@
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/semver.hpp"
 
-namespace tt::umd {
 class TlbWindow;
 
 struct routing_cmd_t {


### PR DESCRIPTION
**Do not merge manually unless coordinated with tt-umd-simulators CI work.**

**Contains a DELIBERATE SYNTAX ERROR in `device/cluster.cpp`** — this PR exists
to exercise the failure-reporting path of the tt-umd-simulators `polling_agent_mr`
workflow.

Re-merges the rebased "failing change" test commits onto the rebased
`tt-umd-simulators/failed-gitlab-ci-test-branch` target so the polling agent has a
real PR event to discover for the red-path scenario.

Replaces the equivalent flow from the old `dzivanovic/*` test branches. Tracked
via tt-umd-simulators MR !92 and issue #53:

- MR  : https://yyz-gitlab.local.tenstorrent.com/tensix/tt-umd-simulators/-/merge_requests/92
- Issue: https://yyz-gitlab.local.tenstorrent.com/tensix/tt-umd-simulators/-/issues/53

The downstream build_umd job is **expected to fail at compile time** when this PR
is merged. That's the point — we're validating that the failure flows through to
the GitHub check / Slack notification correctly.