### PR TITLE
feat(sim/multichip): rebase nkapreTT multichip UMD support onto main

### DIFF
--- a/device/api/umd/device/chip/chip.hpp
+++ b/device/api/umd/device/chip/chip.hpp
@@ -114,6 +114,7 @@ public:
     virtual void set_power_state(DevicePowerState state);
     virtual int get_clock() = 0;
     virtual int get_numa_node() = 0;
+    void advance_device_execution();
 
     // Advance the chip by one clock cycle. Delegates to the underlying TTDevice, which
     // is a no-op for chips without a controllable clock and drives the simulator clock

--- a/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
@@ -6,6 +6,10 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <mutex>
+#include <optional>
+#include <utility>
+#include <vector>
 
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 
@@ -24,6 +28,9 @@ public:
 
     void unpin_or_unmap_sysmem() override;
 
+    void write_to_sysmem(uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) override;
+    void read_from_sysmem(uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) override;
+
     std::unique_ptr<SysmemBuffer> allocate_sysmem_buffer(
         size_t sysmem_buffer_size, const bool map_to_noc = false) override;
 
@@ -34,8 +41,21 @@ protected:
     bool init_sysmem(uint32_t num_host_mem_channels) override;
 
 private:
+    struct MappedBuffer {
+        uint64_t base = 0;
+        void* buffer = nullptr;
+        size_t size = 0;
+    };
+
+    std::optional<MappedBuffer> find_mapped_buffer(uint64_t base, uint32_t size);
+    void remove_mapped_buffer(uint64_t base);
+
     uint8_t* system_memory_ = nullptr;
     size_t system_memory_size_ = 0;
+    uint64_t next_mapped_buffer_base_ = 0;
+    std::vector<MappedBuffer> mapped_buffers_;
+    std::vector<std::pair<void*, size_t>> owned_allocations_;
+    std::mutex mapped_buffers_mutex_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
@@ -9,6 +9,9 @@
 #include <memory>
 #include <optional>
 
+#include <functional>
+
+#include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
@@ -53,6 +56,12 @@ public:
      * @param map_to_noc If true, the buffer will be mapped to be accessible over NOC from device.
      */
     SysmemBuffer(TTDevice* tt_device, void* buffer_va, size_t buffer_size, bool map_to_noc = false);
+    SysmemBuffer(
+        void* buffer_va,
+        size_t buffer_size,
+        uint64_t device_io_addr,
+        std::optional<uint64_t> noc_addr = std::nullopt,
+        std::function<void()> unmap_callback = {});
     ~SysmemBuffer();
 
     /**
@@ -143,6 +152,8 @@ private:
     std::optional<uint64_t> noc_addr_;
 
     std::unique_ptr<TlbWindow> cached_tlb_window = nullptr;
+
+    std::function<void()> unmap_callback_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/simulation/tt_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/tt_sim_communicator.hpp
@@ -183,6 +183,7 @@ private:
     // v3.5 multi-chip ABI. Resolved via dlsym; nullptr if .so is legacy single-chip.
     void *(*pfn_libttsim_create_device_by_id_)(uint32_t chip_id, int chip_x, int chip_y) = nullptr;
     void  (*pfn_libttsim_select_device_by_id_)(uint32_t chip_id) = nullptr;
+    void  (*pfn_libttsim_clock_devices_)(uint32_t n_clocks) = nullptr;
 
     // v3.5 commit #6 — eth-MAC wiring.
     void *dev_handle_ = nullptr;

--- a/device/api/umd/device/simulation/tt_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/tt_sim_communicator.hpp
@@ -26,9 +26,17 @@ public:
      * Constructor for TTSimCommunicator.
      *
      * @param simulator_directory Path to the simulator binary/directory
-     * @param copy_sim_binary If true, copy the simulator binary to memory for security
+     * @param copy_sim_binary If true, copy the simulator binary to memory for
+     *   security AND the loaded .so doesn't support the v3.5 chip-id ABI. If
+     *   the .so exports libttsim_create_device_by_id, v3.5 shared-library
+     *   mode is auto-enabled at initialize() time, ignoring this flag.
+     * @param chip_id Logical chip ID (0..N-1) within the cluster. Only used
+     *   in v3.5 multichip mode (per docs/v3_5_umd_patch_sketch.md). Default 0
+     *   for legacy single-chip consumers.
      */
-    TTSimCommunicator(const std::filesystem::path &simulator_directory, bool copy_sim_binary = false);
+    TTSimCommunicator(const std::filesystem::path &simulator_directory,
+                      bool copy_sim_binary = false,
+                      uint32_t chip_id = 0);
 
     /**
      * Destructor that properly cleans up library handles and file descriptors.
@@ -120,6 +128,13 @@ public:
 
     void start_sim();
 
+    // v3.5 commit #6 — eth-MAC wiring.
+    void *get_dev_handle() const { return dev_handle_; }
+    void switch_reset();
+    void register_eth_endpoint(uint32_t eth_tile_id, uint64_t mac);
+    void switch_drain();
+    void register_peer(uint32_t eth_tile_id, void* peer_dev, uint32_t peer_tile_id);
+
 private:
     // Library management.
     void create_simulator_binary();
@@ -141,6 +156,17 @@ private:
     // Flag to indicate if binary should be copied to memory.
     bool copy_sim_binary_;
 
+    // v3.5 multi-chip mode: when v3.5 symbols are present in the .so, all
+    // TTSimCommunicators sharing the same simulator_directory_ share one
+    // dlopen (held via s_shared_handle_ + refcounted via s_shared_refcount_).
+    // Each communicator records its chip_id_ and calls
+    // libttsim_select_device_by_id(chip_id_) before every I/O.
+    bool v3_5_multichip_mode_ = false;
+    uint32_t chip_id_ = 0;
+    static void *s_shared_handle_;
+    static int s_shared_refcount_;
+    static std::mutex s_shared_init_mutex_;
+
     // Function pointers to simulator library functions.
     void (*pfn_libttsim_init_)() = nullptr;
     void (*pfn_libttsim_exit_)() = nullptr;
@@ -153,6 +179,18 @@ private:
     void (*pfn_libttsim_set_pci_dma_mem_callbacks_)(
         void (*pfn_pci_dma_mem_rd_bytes)(uint64_t paddr, void *p, uint32_t size),
         void (*pfn_pci_dma_mem_wr_bytes)(uint64_t paddr, const void *p, uint32_t size)) = nullptr;
+
+    // v3.5 multi-chip ABI. Resolved via dlsym; nullptr if .so is legacy single-chip.
+    void *(*pfn_libttsim_create_device_by_id_)(uint32_t chip_id, int chip_x, int chip_y) = nullptr;
+    void  (*pfn_libttsim_select_device_by_id_)(uint32_t chip_id) = nullptr;
+
+    // v3.5 commit #6 — eth-MAC wiring.
+    void *dev_handle_ = nullptr;
+    void (*pfn_libttsim_switch_reset_)(void) = nullptr;
+    void (*pfn_libttsim_switch_register_)(void *dev, uint32_t tile_id, uint64_t mac) = nullptr;
+    void (*pfn_libttsim_configure_eth_link_virtual_)(void *dev, uint32_t tile_id, uint64_t local_mac) = nullptr;
+    void (*pfn_libttsim_switch_register_peer_)(void *dev, uint32_t tile_id, void *peer_dev, uint32_t peer_tile_id) = nullptr;
+    void (*pfn_libttsim_switch_drain_)(void) = nullptr;
 
     // Stored callbacks for DMA memory operations.
     std::function<void(uint64_t, void *, uint32_t)> pci_dma_mem_rd_bytes_callback_;

--- a/device/api/umd/device/simulation/tt_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/tt_sim_communicator.hpp
@@ -78,6 +78,14 @@ public:
     void tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size);
 
     /**
+     * Fast simulator-only DRAM access. Returns false when the loaded simulator
+     * does not export the direct DRAM ABI, allowing callers to fall back to the
+     * normal tile/TLB path.
+     */
+    bool dram_read_bytes(uint32_t x, uint32_t y, uint64_t addr, void *data, uint32_t size);
+    bool dram_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size);
+
+    /**
      * Read data from PCI memory.
      *
      * @param paddr Physical address
@@ -175,6 +183,10 @@ private:
     void (*pfn_libttsim_pci_mem_wr_bytes_)(uint64_t paddr, const void *p, uint32_t size) = nullptr;
     void (*pfn_libttsim_tile_rd_bytes_)(uint32_t x, uint32_t y, uint64_t addr, void *p, uint32_t size) = nullptr;
     void (*pfn_libttsim_tile_wr_bytes_)(uint32_t x, uint32_t y, uint64_t addr, const void *p, uint32_t size) = nullptr;
+    void (*pfn_libttsim_dram_rd_bytes_by_id_)(uint32_t chip_id, uint32_t dram_channel, uint64_t addr, void *p, uint32_t size) = nullptr;
+    void (*pfn_libttsim_dram_wr_bytes_by_id_)(uint32_t chip_id, uint32_t dram_channel, uint64_t addr, const void *p, uint32_t size) = nullptr;
+    void (*pfn_libttsim_dram_core_rd_bytes_by_id_)(uint32_t chip_id, uint32_t x, uint32_t y, uint64_t addr, void *p, uint32_t size) = nullptr;
+    void (*pfn_libttsim_dram_core_wr_bytes_by_id_)(uint32_t chip_id, uint32_t x, uint32_t y, uint64_t addr, const void *p, uint32_t size) = nullptr;
     void (*pfn_libttsim_clock_)(uint32_t n_clocks) = nullptr;
     void (*pfn_libttsim_set_pci_dma_mem_callbacks_)(
         void (*pfn_pci_dma_mem_rd_bytes)(uint64_t paddr, void *p, uint32_t size),

--- a/device/api/umd/device/simulation/tt_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/tt_sim_communicator.hpp
@@ -204,8 +204,10 @@ private:
     static void pci_dma_mem_rd_bytes_wrapper(uint64_t paddr, void *p, uint32_t size);
     static void pci_dma_mem_wr_bytes_wrapper(uint64_t paddr, const void *p, uint32_t size);
 
-    // Thread safety.
-    mutable std::mutex device_lock_;
+    // Thread safety. In v3.5 shared-dlopen mode, libttsim_select_device_by_id()
+    // and the following libttsim I/O call must be serialized across all
+    // communicators because the active device selector is process-global.
+    static std::mutex device_lock_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/simulation/tt_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/tt_sim_communicator.hpp
@@ -183,7 +183,7 @@ private:
     // v3.5 multi-chip ABI. Resolved via dlsym; nullptr if .so is legacy single-chip.
     void *(*pfn_libttsim_create_device_by_id_)(uint32_t chip_id, int chip_x, int chip_y) = nullptr;
     void  (*pfn_libttsim_select_device_by_id_)(uint32_t chip_id) = nullptr;
-    void  (*pfn_libttsim_clock_devices_)(uint32_t n_clocks) = nullptr;
+    void  (*pfn_libttsim_clock_all_devices_)(uint32_t n_cycles) = nullptr;
 
     // v3.5 commit #6 — eth-MAC wiring.
     void *dev_handle_ = nullptr;

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -64,6 +64,8 @@ public:
     void dma_multicast_write(
         void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
 
+    void close_device();
+    void start_device();
     void noc_multicast_write(void *src, size_t size, uint64_t addr) override;
 
     void send_tensix_risc_reset(tt_xy_pair translated_core, const TensixSoftResetOptions &soft_resets) override;

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -6,7 +6,16 @@
 
 #include <fmt/format.h>
 #include <sys/mman.h>  // for mmap, munmap
+#include <sys/stat.h>  // for fstat
+#include <unistd.h>
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
@@ -21,6 +30,16 @@ enum class ARCH;
 }  // namespace tt
 
 namespace tt::umd {
+
+namespace {
+
+constexpr uint64_t kHostMemChannelSize = 1ULL << 30;
+
+uint64_t align_up(uint64_t value, uint64_t alignment) {
+    return (value + alignment - 1) & ~(alignment - 1);
+}
+
+}  // namespace
 
 SimulationSysmemManager::SimulationSysmemManager(uint32_t num_host_mem_channels, tt::ARCH arch) {
     pcie_base_ = get_pcie_base_for_arch(arch);
@@ -52,6 +71,7 @@ bool SimulationSysmemManager::init_sysmem(uint32_t num_host_mem_channels) {
     UMD_ASSERT(system_memory_ != MAP_FAILED, error::RuntimeError, "system_memory mmap() failed");
     madvise(system_memory_, total_size, MADV_HUGEPAGE);
     system_memory_size_ = total_size;
+    next_mapped_buffer_base_ = total_size;
 
     for (int i = 0; i < num_host_mem_channels; i++) {
         size_t channel_size = (i == 3 && num_host_mem_channels == 4) ? (768 * (1ULL << 20)) : (1ULL << 30);
@@ -68,6 +88,14 @@ SimulationSysmemManager::~SimulationSysmemManager() { SimulationSysmemManager::u
 
 void SimulationSysmemManager::unpin_or_unmap_sysmem() {
     ZoneScopedC(tracy::Color::Yellow);
+    {
+        std::lock_guard<std::mutex> lock(mapped_buffers_mutex_);
+        mapped_buffers_.clear();
+    }
+    for (const auto& [allocation, allocation_size] : owned_allocations_) {
+        munmap(allocation, allocation_size);
+    }
+    owned_allocations_.clear();
     hugepage_mapping_per_channel.clear();
     if (system_memory_ != nullptr) {
         munmap(system_memory_, system_memory_size_);
@@ -76,14 +104,88 @@ void SimulationSysmemManager::unpin_or_unmap_sysmem() {
     }
 }
 
+std::optional<SimulationSysmemManager::MappedBuffer> SimulationSysmemManager::find_mapped_buffer(
+    uint64_t base, uint32_t size) {
+    for (const auto& mapped_buffer : mapped_buffers_) {
+        if (base >= mapped_buffer.base && base + size <= mapped_buffer.base + mapped_buffer.size) {
+            return mapped_buffer;
+        }
+    }
+    return std::nullopt;
+}
+
+void SimulationSysmemManager::remove_mapped_buffer(uint64_t base) {
+    std::lock_guard<std::mutex> lock(mapped_buffers_mutex_);
+    mapped_buffers_.erase(
+        std::remove_if(
+            mapped_buffers_.begin(),
+            mapped_buffers_.end(),
+            [base](const MappedBuffer& mapped_buffer) { return mapped_buffer.base == base; }),
+        mapped_buffers_.end());
+}
+
+void SimulationSysmemManager::write_to_sysmem(
+    uint16_t channel, const void* src, uint64_t sysmem_dest, uint32_t size) {
+    const uint64_t base = static_cast<uint64_t>(channel) * kHostMemChannelSize + sysmem_dest;
+    {
+        std::lock_guard<std::mutex> lock(mapped_buffers_mutex_);
+        auto mapped_buffer = find_mapped_buffer(base, size);
+        if (mapped_buffer.has_value()) {
+            std::memcpy(
+                static_cast<uint8_t*>(mapped_buffer->buffer) + (base - mapped_buffer->base), src, size);
+            return;
+        }
+    }
+
+    SysmemManager::write_to_sysmem(channel, src, sysmem_dest, size);
+}
+
+void SimulationSysmemManager::read_from_sysmem(
+    uint16_t channel, void* dest, uint64_t sysmem_src, uint32_t size) {
+    const uint64_t base = static_cast<uint64_t>(channel) * kHostMemChannelSize + sysmem_src;
+    {
+        std::lock_guard<std::mutex> lock(mapped_buffers_mutex_);
+        auto mapped_buffer = find_mapped_buffer(base, size);
+        if (mapped_buffer.has_value()) {
+            std::memcpy(
+                dest, static_cast<uint8_t*>(mapped_buffer->buffer) + (base - mapped_buffer->base), size);
+            return;
+        }
+    }
+
+    SysmemManager::read_from_sysmem(channel, dest, sysmem_src, size);
+}
+
 std::unique_ptr<SysmemBuffer> SimulationSysmemManager::allocate_sysmem_buffer(
     size_t sysmem_buffer_size, const bool map_to_noc) {
-    return nullptr;
+    void* mapping =
+        mmap(nullptr, sysmem_buffer_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE, -1, 0);
+    TT_ASSERT(mapping != MAP_FAILED, "Simulation sysmem buffer mmap() failed");
+    owned_allocations_.push_back({mapping, sysmem_buffer_size});
+    return map_sysmem_buffer(mapping, sysmem_buffer_size, map_to_noc);
 }
 
 std::unique_ptr<SysmemBuffer> SimulationSysmemManager::map_sysmem_buffer(
-    void* buffer, size_t sysmem_buffer_size, const bool map_to_noc) {
-    return nullptr;
+    void *buffer, size_t sysmem_buffer_size, const bool map_to_noc) {
+    static const auto page_size = sysconf(_SC_PAGESIZE);
+    const uint64_t mapped_size = align_up(sysmem_buffer_size, page_size);
+
+    uint64_t mapped_base = 0;
+    {
+        std::lock_guard<std::mutex> lock(mapped_buffers_mutex_);
+        mapped_base = align_up(next_mapped_buffer_base_, page_size);
+        next_mapped_buffer_base_ = mapped_base + mapped_size;
+        mapped_buffers_.push_back({mapped_base, buffer, sysmem_buffer_size});
+    }
+
+    const uint64_t device_io_addr = pcie_base_ + mapped_base;
+    std::optional<uint64_t> noc_addr = map_to_noc ? std::optional<uint64_t>(device_io_addr) : std::nullopt;
+    return std::make_unique<SysmemBuffer>(
+        buffer,
+        sysmem_buffer_size,
+        device_io_addr,
+        noc_addr,
+        [this, mapped_base]() { remove_mapped_buffer(mapped_base); });
 }
 
 }  // namespace tt::umd

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <tuple>
+#include <utility>
 
 #include "noc_access.hpp"
 #include "tracy.hpp"
@@ -43,6 +44,22 @@ SysmemBuffer::SysmemBuffer(TTDevice* tt_device, void* buffer_va, size_t buffer_s
         noc_addr_ = std::nullopt;
     }
     TracyAllocN(buffer_va_, mapped_buffer_size_, "SysmemBuffer");
+}
+
+SysmemBuffer::SysmemBuffer(
+    void* buffer_va,
+    size_t buffer_size,
+    uint64_t device_io_addr,
+    std::optional<uint64_t> noc_addr,
+    std::function<void()> unmap_callback) :
+    tlb_manager_(nullptr),
+    buffer_va_(buffer_va),
+    mapped_buffer_size_(buffer_size),
+    buffer_size_(buffer_size),
+    device_io_addr_(device_io_addr),
+    noc_addr_(noc_addr),
+    unmap_callback_(std::move(unmap_callback)) {
+    align_address_and_size();
 }
 
 void SysmemBuffer::dma_write_to_device(const size_t offset, size_t size, const tt_xy_pair core, uint64_t addr) {
@@ -160,6 +177,13 @@ void SysmemBuffer::dma_read_from_device(const size_t offset, size_t size, const 
 
 SysmemBuffer::~SysmemBuffer() {
     TracyFreeN(buffer_va_, "SysmemBuffer");
+    if (unmap_callback_) {
+        unmap_callback_();
+        return;
+    }
+    if (tlb_manager_ == nullptr) {
+        return;
+    }
     try {
         pci_device_->unmap_for_dma(buffer_va_, mapped_buffer_size_);
     } catch (...) {

--- a/device/chip_helpers/tlb_manager.cpp
+++ b/device/chip_helpers/tlb_manager.cpp
@@ -45,6 +45,8 @@ void TLBManager::configure_tlb(tt_xy_pair core, size_t tlb_size, uint64_t addres
     config.static_vc = get_tt_device()->get_architecture_implementation()->get_static_vc();
     std::unique_ptr<TlbWindow> tlb_window = allocate_tlb_window(config, TlbMapping::WC, tlb_size);
 
+    auto pci_device = tt_device_->get_pci_device();
+    int device_num = pci_device ? pci_device->get_device_num() : -1;
     log_debug(
         LogUMD,
         "Configured TLB window for chip: {} core: {} size: {} address: {} ordering: {} tlb_id: {}",
@@ -86,6 +88,8 @@ bool TLBManager::is_tlb_mapped(tt_xy_pair core, uint64_t address, uint32_t size_
     return tlb_window->get_base_address() <= address &&
            address + size_in_bytes <= tlb_window->get_base_address() + tlb_window->get_size();
 }
+
+
 
 tlb_configuration TLBManager::get_tlb_configuration(tt_xy_pair core) {
     UMD_ASSERT(is_tlb_mapped(core), error::RuntimeError, fmt::format("TLB not mapped for core: {}", core.str()));

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/umd/device/cluster.hpp"
+#include "umd/device/simulation/tt_sim_chip.hpp"
+#include "umd/device/tt_device/tt_sim_tt_device.hpp"
+#include "umd/device/simulation/tt_sim_communicator.hpp"
 
 #include <fmt/format.h>
 #include <fmt/ranges.h>
@@ -406,6 +409,53 @@ Cluster::Cluster(ClusterOptions options) {  // NOLINT(performance-unnecessary-va
                 options.num_host_mem_ch_per_mmio_device.value(),
                 options.simulator_directory,
                 std::move(tt_device)));
+    }
+
+    // -------------------------------------------------------------------
+    // v3.5 commit #6 — eth-MAC wiring pre-pass.
+    // For SIMULATION ChipType with v3.5-aware libttsim, populate the magic
+    // switch routing table and pre-write peer DEST_MAC into each eth tile.
+    // See craq-sim-multichip/docs/v3_5_commit6_eth_mac_wiring.md.
+    // -------------------------------------------------------------------
+    if (options.chip_type == ChipType::SIMULATION &&
+        options.simulator_directory.extension() == ".so") {
+        auto get_comm = [&](ChipId cid) -> tt::umd::TTSimCommunicator* {
+            auto it = chips_.find(cid);
+            if (it == chips_.end()) return nullptr;
+            auto* sim_chip = dynamic_cast<tt::umd::TTSimChip*>(it->second.get());
+            if (!sim_chip) return nullptr;
+            auto* sim_tt = dynamic_cast<tt::umd::TTSimTTDevice*>(sim_chip->get_tt_device());
+            return sim_tt ? sim_tt->get_communicator() : nullptr;
+        };
+        auto eth_sim_mac = [](ChipId cid, int chan) -> uint64_t {
+            return 0x021E52000000ULL | (uint64_t(cid & 0xFF) << 8) | uint64_t(chan & 0xFF);
+        };
+        // Switch reset via any communicator (singleton, process-global).
+        if (!chips_.empty()) {
+            ChipId c0 = cluster_desc->get_chips_local_first(cluster_desc->get_all_chips()).front();
+            if (auto* c = get_comm(c0)) c->switch_reset();
+        }
+        const auto& eth_conns = cluster_desc->get_ethernet_connections();
+        for (const auto& [chip_a, chan_map] : eth_conns) {
+            for (const auto& [chan_a, remote] : chan_map) {
+                ChipId chip_b = std::get<0>(remote);
+                int       chan_b = std::get<1>(remote);
+                if (chip_a >= chip_b) continue;
+                auto* ca = get_comm(chip_a);
+                auto* cb = get_comm(chip_b);
+                if (!ca || !cb) continue;
+                uint64_t mac_a = eth_sim_mac(chip_a, chan_a);
+                uint64_t mac_b = eth_sim_mac(chip_b, chan_b);
+                ca->register_eth_endpoint(uint32_t(chan_a), mac_a);
+                cb->register_eth_endpoint(uint32_t(chan_b), mac_b);
+                // Wire peer info for source-aware routing (BH BCAST/MCAST MAC).
+                ca->register_peer(uint32_t(chan_a), cb->get_dev_handle(), uint32_t(chan_b));
+                cb->register_peer(uint32_t(chan_b), ca->get_dev_handle(), uint32_t(chan_a));
+                log_info(tt::LogEmulationDriver,
+                    "TTSim eth: {}:ch{} mac={:#014x}  <->  {}:ch{} mac={:#014x}",
+                    chip_a, chan_a, mac_a, chip_b, chan_b, mac_b);
+            }
+        }
     }
 
     construct_cluster(options.num_host_mem_ch_per_mmio_device.value(), options.chip_type);

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -110,6 +110,14 @@ void TTSimCommunicator::initialize() {
         DLSYM_FUNCTION(libttsim_pci_mem_wr_bytes)
         DLSYM_FUNCTION(libttsim_tile_rd_bytes)
         DLSYM_FUNCTION(libttsim_tile_wr_bytes)
+        pfn_libttsim_dram_rd_bytes_by_id_ = (decltype(pfn_libttsim_dram_rd_bytes_by_id_))dlsym(
+            libttsim_handle_, "libttsim_dram_rd_bytes_by_id");
+        pfn_libttsim_dram_wr_bytes_by_id_ = (decltype(pfn_libttsim_dram_wr_bytes_by_id_))dlsym(
+            libttsim_handle_, "libttsim_dram_wr_bytes_by_id");
+        pfn_libttsim_dram_core_rd_bytes_by_id_ = (decltype(pfn_libttsim_dram_core_rd_bytes_by_id_))dlsym(
+            libttsim_handle_, "libttsim_dram_core_rd_bytes_by_id");
+        pfn_libttsim_dram_core_wr_bytes_by_id_ = (decltype(pfn_libttsim_dram_core_wr_bytes_by_id_))dlsym(
+            libttsim_handle_, "libttsim_dram_core_wr_bytes_by_id");
         DLSYM_FUNCTION(libttsim_clock)
         DLSYM_FUNCTION(libttsim_set_pci_dma_mem_callbacks)
         DLSYM_FUNCTION(libttsim_create_device_by_id)
@@ -183,6 +191,24 @@ void TTSimCommunicator::tile_read_bytes(uint32_t x, uint32_t y, uint64_t addr, v
     std::lock_guard<std::mutex> lock(device_lock_);
     SELECT_CHIP_IF_NEEDED();
     pfn_libttsim_tile_rd_bytes_(x, y, addr, data, size);
+}
+
+bool TTSimCommunicator::dram_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size) {
+    if (!v3_5_multichip_mode_ || pfn_libttsim_dram_core_wr_bytes_by_id_ == nullptr) {
+        return false;
+    }
+    std::lock_guard<std::mutex> lock(device_lock_);
+    pfn_libttsim_dram_core_wr_bytes_by_id_(chip_id_, x, y, addr, data, size);
+    return true;
+}
+
+bool TTSimCommunicator::dram_read_bytes(uint32_t x, uint32_t y, uint64_t addr, void *data, uint32_t size) {
+    if (!v3_5_multichip_mode_ || pfn_libttsim_dram_core_rd_bytes_by_id_ == nullptr) {
+        return false;
+    }
+    std::lock_guard<std::mutex> lock(device_lock_);
+    pfn_libttsim_dram_core_rd_bytes_by_id_(chip_id_, x, y, addr, data, size);
+    return true;
 }
 
 void TTSimCommunicator::pci_mem_read_bytes(uint64_t paddr, void *data, uint32_t size) {

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -113,7 +113,7 @@ void TTSimCommunicator::initialize() {
         DLSYM_FUNCTION(libttsim_set_pci_dma_mem_callbacks)
         DLSYM_FUNCTION(libttsim_create_device_by_id)
         DLSYM_FUNCTION(libttsim_select_device_by_id)
-        DLSYM_FUNCTION(libttsim_clock_devices)
+        DLSYM_FUNCTION(libttsim_clock_all_devices)
         DLSYM_FUNCTION(libttsim_switch_reset)
         DLSYM_FUNCTION(libttsim_switch_register)
         DLSYM_FUNCTION(libttsim_switch_drain)
@@ -206,13 +206,13 @@ uint32_t TTSimCommunicator::pci_config_read32(uint32_t bus_device_function, uint
 
 void TTSimCommunicator::advance_clock(uint32_t n_clocks) {
     std::lock_guard<std::mutex> lock(device_lock_);
-    if (v3_5_multichip_mode_ && pfn_libttsim_clock_devices_) {
+    if (v3_5_multichip_mode_ && pfn_libttsim_clock_all_devices_) {
         // v3.5-#8: in shared-dlopen multichip mode, tick ALL chips together so
         // cross-chip eth handshakes converge (chip A waiting on a packet from chip B
         // would otherwise stall — only the chip being read gets advanced).
-        // libttsim_clock_devices drains the eth switch internally in sort order, so
-        // we do not need a separate switch_drain call here.
-        pfn_libttsim_clock_devices_(n_clocks);
+        // libttsim_clock_all_devices walks the simulator chip_id registry internally
+        // and drains the eth switch in sort order, so no extra switch_drain call.
+        pfn_libttsim_clock_all_devices_(n_clocks);
         return;
     }
     SELECT_CHIP_IF_NEEDED();

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -31,11 +31,36 @@
 
 namespace tt::umd {
 
-TTSimCommunicator::TTSimCommunicator(const std::filesystem::path &simulator_directory, bool copy_sim_binary) :
-    simulator_directory_(simulator_directory), copy_sim_binary_(copy_sim_binary) {}
+// v3.5 multi-chip shared-library state. When the loaded libttsim.so exports
+// libttsim_create_device_by_id + libttsim_select_device_by_id, all
+// TTSimCommunicators share a single dlopen of the .so so they also share its
+// process-global state (eth_switch routing table, Device* registry).
+void *TTSimCommunicator::s_shared_handle_ = nullptr;
+int   TTSimCommunicator::s_shared_refcount_ = 0;
+std::mutex TTSimCommunicator::s_shared_init_mutex_;
+
+TTSimCommunicator::TTSimCommunicator(const std::filesystem::path &simulator_directory,
+                                     bool copy_sim_binary,
+                                     uint32_t chip_id) :
+    simulator_directory_(simulator_directory),
+    copy_sim_binary_(copy_sim_binary),
+    chip_id_(chip_id) {}
 
 TTSimCommunicator::~TTSimCommunicator() {
-    if (libttsim_handle_) {
+    if (v3_5_multichip_mode_) {
+        // Shared dlopen — decrement refcount. When last communicator
+        // destructs, call libttsim_exit (which the deferred shutdown()
+        // path didn't call), then dlclose. The simulator is process-global,
+        // so libttsim_exit should run exactly once.
+        std::lock_guard<std::mutex> lock(s_shared_init_mutex_);
+        if (--s_shared_refcount_ == 0 && s_shared_handle_) {
+            if (pfn_libttsim_exit_) {
+                pfn_libttsim_exit_();
+            }
+            dlclose(s_shared_handle_);
+            s_shared_handle_ = nullptr;
+        }
+    } else if (libttsim_handle_) {
         dlclose(libttsim_handle_);
     }
     close_simulator_binary();
@@ -44,6 +69,59 @@ TTSimCommunicator::~TTSimCommunicator() {
 void TTSimCommunicator::initialize() {
     std::lock_guard<std::mutex> lock(device_lock_);
 
+    // Probe the .so for v3.5 multichip ABI symbols. We do this before
+    // committing to memfd-vs-direct dlopen because the shared-library path
+    // skips memfd entirely (multiple chips share one dlopen).
+    bool v3_5_supported = false;
+    {
+        // Temporarily dlopen just to check symbols; close after probe.
+        void *probe = dlopen(simulator_directory_.c_str(), RTLD_LAZY | RTLD_NOLOAD);
+        if (!probe) {
+            // RTLD_NOLOAD fails if not yet loaded — that's fine, do a fresh probe.
+            probe = dlopen(simulator_directory_.c_str(), RTLD_LAZY);
+        }
+        if (probe) {
+            v3_5_supported = dlsym(probe, "libttsim_create_device_by_id") != nullptr
+                          && dlsym(probe, "libttsim_select_device_by_id") != nullptr;
+            // Close only if we did the fresh open. RTLD_NOLOAD doesn't bump refcount
+            // beyond existing, but to be safe always close our probe handle.
+            dlclose(probe);
+        }
+    }
+
+    if (v3_5_supported) {
+        v3_5_multichip_mode_ = true;
+        log_info(tt::LogEmulationDriver,
+                 "TTSim v3.5 multichip mode enabled (chip_id={}, shared dlopen)", chip_id_);
+        std::lock_guard<std::mutex> init_lock(s_shared_init_mutex_);
+        if (!s_shared_handle_) {
+            s_shared_handle_ = dlopen(simulator_directory_.c_str(), RTLD_LAZY);
+            if (!s_shared_handle_) {
+                TT_THROW("Failed to dlopen simulator library (shared): {}", dlerror());
+            }
+        }
+        s_shared_refcount_++;
+        libttsim_handle_ = s_shared_handle_;
+        DLSYM_FUNCTION(libttsim_init)
+        DLSYM_FUNCTION(libttsim_exit)
+        DLSYM_FUNCTION(libttsim_pci_config_rd32)
+        DLSYM_FUNCTION(libttsim_pci_mem_rd_bytes)
+        DLSYM_FUNCTION(libttsim_pci_mem_wr_bytes)
+        DLSYM_FUNCTION(libttsim_tile_rd_bytes)
+        DLSYM_FUNCTION(libttsim_tile_wr_bytes)
+        DLSYM_FUNCTION(libttsim_clock)
+        DLSYM_FUNCTION(libttsim_set_pci_dma_mem_callbacks)
+        DLSYM_FUNCTION(libttsim_create_device_by_id)
+        DLSYM_FUNCTION(libttsim_select_device_by_id)
+        DLSYM_FUNCTION(libttsim_switch_reset)
+        DLSYM_FUNCTION(libttsim_switch_register)
+        DLSYM_FUNCTION(libttsim_switch_drain)
+        DLSYM_FUNCTION(libttsim_configure_eth_link_virtual)
+        DLSYM_FUNCTION(libttsim_switch_register_peer)
+        return;
+    }
+
+    // Legacy path: per-chip memfd + dlopen.
     if (copy_sim_binary_) {
         create_simulator_binary();
         copy_simulator_binary();
@@ -56,43 +134,78 @@ void TTSimCommunicator::initialize() {
 
 void TTSimCommunicator::start_sim() {
     std::lock_guard<std::mutex> lock(device_lock_);
+    if (v3_5_multichip_mode_) {
+        // libttsim_init only on the first communicator. Subsequent
+        // communicators register their chip into the shared registry.
+        std::lock_guard<std::mutex> init_lock(s_shared_init_mutex_);
+        static bool s_init_called = false;
+        if (!s_init_called) {
+            pfn_libttsim_init_();
+            s_init_called = true;
+        }
+        // Register this chip in the shared chip_id registry.
+        // v3.5 commit #6: capture Device* handle for later eth-MAC registration.
+        dev_handle_ = pfn_libttsim_create_device_by_id_(
+            chip_id_, /*chip_x=*/int(chip_id_), /*chip_y=*/0);
+        return;
+    }
     pfn_libttsim_init_();
 }
 
 void TTSimCommunicator::shutdown() {
     std::lock_guard<std::mutex> lock(device_lock_);
     log_info(tt::LogEmulationDriver, "Sending exit signal to remote...");
+    if (v3_5_multichip_mode_) {
+        // Defer libttsim_exit until the last communicator destructs (handled
+        // by refcount in the destructor's shared-handle close path). The
+        // simulator is process-global; calling exit per chip would be wrong.
+        return;
+    }
     pfn_libttsim_exit_();
 }
+
+// v3.5: in multi-chip mode, every I/O entry point first selects the right
+// chip via libttsim_select_device_by_id(chip_id_) under the held device_lock_.
+// The shared libttsim's internal recursive_mutex provides defense-in-depth.
+#define SELECT_CHIP_IF_NEEDED() \
+    do { if (v3_5_multichip_mode_) pfn_libttsim_select_device_by_id_(chip_id_); } while (0)
 
 void TTSimCommunicator::tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size) {
     std::lock_guard<std::mutex> lock(device_lock_);
     log_debug(tt::LogUMD, "Device writing {} bytes to l1_dest {} in core ({},{})", size, addr, x, y);
+    SELECT_CHIP_IF_NEEDED();
     pfn_libttsim_tile_wr_bytes_(x, y, addr, data, size);
 }
 
 void TTSimCommunicator::tile_read_bytes(uint32_t x, uint32_t y, uint64_t addr, void *data, uint32_t size) {
     std::lock_guard<std::mutex> lock(device_lock_);
+    SELECT_CHIP_IF_NEEDED();
     pfn_libttsim_tile_rd_bytes_(x, y, addr, data, size);
 }
 
 void TTSimCommunicator::pci_mem_read_bytes(uint64_t paddr, void *data, uint32_t size) {
     std::lock_guard<std::mutex> lock(device_lock_);
+    SELECT_CHIP_IF_NEEDED();
     pfn_libttsim_pci_mem_rd_bytes_(paddr, data, size);
 }
 
 void TTSimCommunicator::pci_mem_write_bytes(uint64_t paddr, const void *data, uint32_t size) {
     std::lock_guard<std::mutex> lock(device_lock_);
+    SELECT_CHIP_IF_NEEDED();
     pfn_libttsim_pci_mem_wr_bytes_(paddr, data, size);
 }
 
 uint32_t TTSimCommunicator::pci_config_read32(uint32_t bus_device_function, uint32_t offset) {
     std::lock_guard<std::mutex> lock(device_lock_);
+    // pci_config_read32 reads compile-time constants; no chip selection needed.
+    // But we still select for consistency and future-proofing.
+    SELECT_CHIP_IF_NEEDED();
     return pfn_libttsim_pci_config_rd32_(bus_device_function, offset);
 }
 
 void TTSimCommunicator::advance_clock(uint32_t n_clocks) {
     std::lock_guard<std::mutex> lock(device_lock_);
+    SELECT_CHIP_IF_NEEDED();
     pfn_libttsim_clock_(n_clocks);
 }
 
@@ -194,6 +307,42 @@ void TTSimCommunicator::load_simulator_library(const std::filesystem::path &path
     DLSYM_FUNCTION(libttsim_tile_wr_bytes)
     DLSYM_FUNCTION(libttsim_clock)
     DLSYM_FUNCTION(libttsim_set_pci_dma_mem_callbacks)
+}
+
+// v3.5 commit #6 — eth-MAC wiring methods. All no-ops in legacy single-chip mode.
+
+void TTSimCommunicator::switch_reset() {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    if (v3_5_multichip_mode_ && pfn_libttsim_switch_reset_) {
+        pfn_libttsim_switch_reset_();
+    }
+}
+
+void TTSimCommunicator::register_eth_endpoint(uint32_t eth_tile_id, uint64_t mac) {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    if (!v3_5_multichip_mode_ || !dev_handle_) return;
+    // Prefer configure_eth_link_virtual: sets link_mode=Virtual + writes
+    // link-up sentinel + registers MAC. Falls back to switch_register if
+    // configure_eth_link_virtual is not exported.
+    if (pfn_libttsim_configure_eth_link_virtual_) {
+        pfn_libttsim_configure_eth_link_virtual_(dev_handle_, eth_tile_id, mac);
+    } else if (pfn_libttsim_switch_register_) {
+        pfn_libttsim_switch_register_(dev_handle_, eth_tile_id, mac);
+    }
+}
+
+
+void TTSimCommunicator::register_peer(uint32_t eth_tile_id, void* peer_dev, uint32_t peer_tile_id) {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    if (!v3_5_multichip_mode_ || !dev_handle_ || !pfn_libttsim_switch_register_peer_) return;
+    pfn_libttsim_switch_register_peer_(dev_handle_, eth_tile_id, peer_dev, peer_tile_id);
+}
+
+void TTSimCommunicator::switch_drain() {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    if (v3_5_multichip_mode_ && pfn_libttsim_switch_drain_) {
+        pfn_libttsim_switch_drain_();
+    }
 }
 
 void TTSimCommunicator::close_simulator_binary() {

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -38,6 +38,7 @@ namespace tt::umd {
 void *TTSimCommunicator::s_shared_handle_ = nullptr;
 int   TTSimCommunicator::s_shared_refcount_ = 0;
 std::mutex TTSimCommunicator::s_shared_init_mutex_;
+std::mutex TTSimCommunicator::device_lock_;
 
 TTSimCommunicator::TTSimCommunicator(const std::filesystem::path &simulator_directory,
                                      bool copy_sim_binary,

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -113,6 +113,7 @@ void TTSimCommunicator::initialize() {
         DLSYM_FUNCTION(libttsim_set_pci_dma_mem_callbacks)
         DLSYM_FUNCTION(libttsim_create_device_by_id)
         DLSYM_FUNCTION(libttsim_select_device_by_id)
+        DLSYM_FUNCTION(libttsim_clock_devices)
         DLSYM_FUNCTION(libttsim_switch_reset)
         DLSYM_FUNCTION(libttsim_switch_register)
         DLSYM_FUNCTION(libttsim_switch_drain)
@@ -205,6 +206,15 @@ uint32_t TTSimCommunicator::pci_config_read32(uint32_t bus_device_function, uint
 
 void TTSimCommunicator::advance_clock(uint32_t n_clocks) {
     std::lock_guard<std::mutex> lock(device_lock_);
+    if (v3_5_multichip_mode_ && pfn_libttsim_clock_devices_) {
+        // v3.5-#8: in shared-dlopen multichip mode, tick ALL chips together so
+        // cross-chip eth handshakes converge (chip A waiting on a packet from chip B
+        // would otherwise stall — only the chip being read gets advanced).
+        // libttsim_clock_devices drains the eth switch internally in sort order, so
+        // we do not need a separate switch_drain call here.
+        pfn_libttsim_clock_devices_(n_clocks);
+        return;
+    }
     SELECT_CHIP_IF_NEEDED();
     pfn_libttsim_clock_(n_clocks);
 }

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -389,6 +389,8 @@ void TTDevice::wait_for_non_mmio_flush() {
     get_remote_interface()->get_remote_communication()->wait_for_non_mmio_flush();
 }
 
+void TTDevice::advance_device_execution() {}
+
 bool TTDevice::is_remote() { return is_remote_tt_device; }
 
 int TTDevice::get_communication_device_id() const { return communication_device_id_; }

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -5,9 +5,11 @@
 #include "umd/device/tt_device/tt_sim_tt_device.hpp"
 
 #include <algorithm>
+#include <cstdlib>
 #include <filesystem>
 #include <functional>
 #include <string>
+#include <string_view>
 #include <tt-logger/tt-logger.hpp>
 #include <type_traits>
 #include <utility>
@@ -32,6 +34,28 @@
 namespace tt::umd {
 
 static_assert(!std::is_abstract<TTSimTTDevice>(), "TTSimChip must be non-abstract.");
+
+namespace {
+
+bool sim_dram_teleport_enabled() {
+    const char* env = std::getenv("TT_METAL_SIMULATOR_DRAM_TELEPORT");
+    if (env == nullptr) {
+        return false;
+    }
+    std::string_view value(env);
+    return value == "1" || value == "true" || value == "TRUE" || value == "on" || value == "ON";
+}
+
+bool is_translated_dram_core(const SocDescriptor& soc_descriptor, tt_xy_pair core) {
+    for (const auto& dram_core : soc_descriptor.get_cores(CoreType::DRAM, CoordSystem::TRANSLATED)) {
+        if (dram_core.x == core.x && dram_core.y == core.y) {
+            return true;
+        }
+    }
+    return false;
+}
+
+}  // namespace
 
 std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create(
     const std::filesystem::path& simulator_directory, int num_host_mem_channels, bool copy_sim_binary) {
@@ -156,6 +180,15 @@ void TTSimTTDevice::close_device() { communicator_->shutdown(); }
 
 void TTSimTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     std::lock_guard<std::recursive_mutex> lock(device_lock);
+    if (sim_dram_teleport_enabled()) {
+        if (is_translated_dram_core(soc_descriptor_, core)) {
+            if (communicator_->dram_write_bytes(core.x, core.y, addr, mem_ptr, size)) {
+                return;
+            }
+            communicator_->tile_write_bytes(core.x, core.y, addr, mem_ptr, size);
+            return;
+        }
+    }
     if (get_arch() != tt::ARCH::QUASAR && cached_tlb_window_) {
         cached_tlb_window_->write_block_reconfigure(mem_ptr, core, addr, size, get_selected_noc_id());
     } else {
@@ -165,6 +198,15 @@ void TTSimTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64
 
 void TTSimTTDevice::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     std::lock_guard<std::recursive_mutex> lock(device_lock);
+    if (sim_dram_teleport_enabled()) {
+        if (is_translated_dram_core(soc_descriptor_, core)) {
+            if (!communicator_->dram_read_bytes(core.x, core.y, addr, mem_ptr, size)) {
+                communicator_->tile_read_bytes(core.x, core.y, addr, mem_ptr, size);
+            }
+            communicator_->advance_clock(10);
+            return;
+        }
+    }
     if (get_arch() != tt::ARCH::QUASAR && cached_tlb_window_) {
         cached_tlb_window_->read_block_reconfigure(mem_ptr, core, addr, size, get_selected_noc_id());
     } else {

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -150,6 +150,10 @@ std::unique_ptr<TlbWindow> TTSimTTDevice::get_io_window(tlb_data config, TlbMapp
 
 TTSimTTDevice::~TTSimTTDevice() { communicator_->shutdown(); }
 
+void TTSimTTDevice::start_device() {}
+
+void TTSimTTDevice::close_device() { communicator_->shutdown(); }
+
 void TTSimTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     std::lock_guard<std::recursive_mutex> lock(device_lock);
     if (get_arch() != tt::ARCH::QUASAR && cached_tlb_window_) {

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -55,7 +55,12 @@ TTSimTTDevice::TTSimTTDevice(
     ChipId chip_id,
     bool copy_sim_binary,
     int num_host_mem_channels) :
-    communicator_(std::make_unique<TTSimCommunicator>(simulator_directory, copy_sim_binary)),
+    // Pass chip_id to the communicator. If the loaded .so supports the v3.5
+    // multichip ABI (libttsim_create_device_by_id + libttsim_select_device_by_id),
+    // the communicator will auto-detect at initialize() time and switch to
+    // shared-dlopen mode regardless of copy_sim_binary.
+    communicator_(std::make_unique<TTSimCommunicator>(
+        simulator_directory, copy_sim_binary, static_cast<uint32_t>(chip_id))),
     simulator_directory_(simulator_directory),
     chip_id_(chip_id),
     sysmem_manager_(std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)) {

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -55,6 +55,7 @@ TTSimTTDevice::TTSimTTDevice(
     ChipId chip_id,
     bool copy_sim_binary,
     int num_host_mem_channels) :
+    TTDevice(architecture_implementation::create(soc_descriptor.arch)),
     // Pass chip_id to the communicator. If the loaded .so supports the v3.5
     // multichip ABI (libttsim_create_device_by_id + libttsim_select_device_by_id),
     // the communicator will auto-detect at initialize() time and switch to


### PR DESCRIPTION
## Summary

- Rebases 6 commits from `nkapreTT/tt-umd:nkapre/multichip` onto `tenstorrent/tt-umd` main, resolving conflicts against UMD refactoring (Writer class removal, TlbManager renames, `construct_cluster` API changes)
- Enables multi-chip simulation via a single shared `libttsim.so` dlopen with eth-MAC routing pre-pass
- Adds simulation DRAM teleport path (env var `TT_METAL_SIMULATOR_DRAM_TELEPORT`) for high-bandwidth inter-chip traffic
- Companion to: `tenstorrent/tt-metal` PR for `ridvan/nkapre-multichip-metal`

## Key changes (6 commits, +549/-13)

### `feat(sim): multichip via single libttsim dlopen + eth-MAC pre-pass`
- `device/cluster.cpp`: adds eth-MAC routing table setup via `register_eth_endpoint`/`register_peer` before `construct_cluster` when using simulation `.so` mode
- Enables multi-device coordination through a single shared simulator instance

### `feat(sim/v3.5-#8/9): advance_clock ticks all chips`
- `tt_sim_communicator`: `libttsim_clock_devices`/`libttsim_clock_all_devices` API used to advance all simulated chips together during polling

### `fix(sim/v3.5-#16): serialize shared-dlopen I/O and static TLB writes`
- `device_lock_` changed from `mutable` instance variable to `static` class variable in `TTSimCommunicator` — required for correct serialization when multiple `Cluster` instances share one dlopen'd `libttsim.so`

### `feat(sim): support mapped simulation sysmem buffers`
- `simulation_sysmem_manager.cpp/hpp`: implements `map_sysmem_buffer` (was stub returning nullptr) using `mmap`/`munmap`; adds proper destructor cleanup with mutex lock
- `sysmem_buffer.cpp/hpp`: adds new `SysmemBuffer` constructor for externally-managed memory with unmap callback; null-checks for `tlb_manager_` and `unmap_callback_`

### `feat(sim/v3.5-#21): route DRAM teleport through coordinate ABI`
- `tt_sim_tt_device.cpp/hpp`: `start_device()`, `close_device()` implementations; DRAM teleport check via `TT_METAL_SIMULATOR_DRAM_TELEPORT` env var; `sim_dram_teleport_enabled()` and `is_translated_dram_core()` helpers

## Notes for reviewers

- All conflicts arose from main's refactoring since nkapreTT forked: `Writer` class removal, `TTSimTlbManager` → `SimulationTlbAllocator` rename, `construct_cluster` signature change
- `device/api/umd/device/chip_helpers/tt_sim_tlb_manager.hpp`, `tt_io.hpp`, and `tt_sim_tlb_manager.cpp` were `git rm`'d — they were deleted/superseded in main
- `device_lock_` static mutex is intentional: multiple Cluster instances in the same process (multi-chip sim) must serialize I/O through the shared dlopen'd `.so`
- DRAM teleport is opt-in via env var; disabled by default, zero impact on existing code paths

## Test plan

- [ ] Single-chip simulator tests unaffected (env var off by default)
- [ ] craq-sim multichip CCL sweep passes with this UMD
- [ ] `tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh` passes
- [ ] `tt_sim_communicator` serialization: concurrent multi-Cluster simulation stable

## CI Status

| Workflow | Status |
|---|---|
| Merge Gate | ![merge-gate](https://github.com/tenstorrent/tt-umd/actions/workflows/merge-gate.yaml/badge.svg?branch=ridvan/nkapre-multichip-umd) |