### PR TITLE
Move noc_multicast_write into TTDevice

### DIFF
--- a/device/api/umd/device/simulation/simulation_chip.hpp
+++ b/device/api/umd/device/simulation/simulation_chip.hpp
@@ -76,8 +76,6 @@ public:
     void dma_write_to_device(const void* src, size_t size, CoreCoord core, uint64_t addr) override;
     void dma_multicast_write(void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
     void dma_read_from_device(void* dst, size_t size, CoreCoord core, uint64_t addr) override;
-    void noc_multicast_write(
-        const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
 
     void wait_for_non_mmio_flush() override;
 

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -63,6 +63,9 @@ public:
     void assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs) override;
     void deassert_risc_reset(tt_xy_pair core, const RiscType selected_riscs, bool staggered_start) override;
 
+    void noc_multicast_write(
+        const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
+
     void noc_multicast_write(const void* src, size_t size, uint64_t addr) override;
 
     RtlSimCommunicator* get_communicator() { return communicator_.get(); }

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -66,6 +66,7 @@ public:
     void noc_multicast_write(
         const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
 
+    using TTDevice::noc_multicast_write;
     void noc_multicast_write(const void* src, size_t size, uint64_t addr) override;
 
     RtlSimCommunicator* get_communicator() { return communicator_.get(); }

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -509,6 +509,12 @@ protected:
 
     virtual void retrain_dram_core(const uint32_t dram_channel) = 0;
 
+    // Emulates a NOC multicast write by issuing a unicast write_to_device to every core in the
+    // [core_start, core_end] grid. Simulation backends have no hardware multicast, so they delegate
+    // their noc_multicast_write override here instead of duplicating the fallback loop.
+    void multicast_write_via_unicast(
+        const void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr);
+
     virtual uint32_t get_max_dram_retrain_attempts() const { return 0; }
 
     void set_hang_detector(std::unique_ptr<HangDetector> hang_detector) { hang_detector_ = std::move(hang_detector); }

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -73,6 +73,9 @@ public:
 
     void close_device();
     void start_device();
+    void noc_multicast_write(
+        const void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
+
     void noc_multicast_write(const void *src, size_t size, uint64_t addr) override;
 
     void assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs) override;

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -76,6 +76,7 @@ public:
     void noc_multicast_write(
         const void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
 
+    using TTDevice::noc_multicast_write;
     void noc_multicast_write(const void *src, size_t size, uint64_t addr) override;
 
     void assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs) override;

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -550,21 +550,6 @@ void LocalChip::noc_multicast_write(
     if (core_start.core_type != CoreType::TENSIX || core_end.core_type != CoreType::TENSIX) {
         UMD_THROW(error::RuntimeError, "noc_multicast_write is only supported for Tensix cores.");
     }
-
-    // Multicast write relies on PCIe-specific TLB operations; ensure the communication device is PCIe.
-    if (tt_device_->get_communication_device_type() != IODeviceType::PCIe) {
-        UMD_THROW(error::RuntimeError, "noc_multicast_write is only supported on PCIe devices.");
-    }
-
-    std::lock_guard<std::mutex> lock(wc_tlb_lock);
-
-    get_cached_wc_tlb_window()->noc_multicast_write_reconfigure(
-        src,
-        size,
-        get_soc_descriptor().translate_chip_coord_to_translated(core_start),
-        get_soc_descriptor().translate_chip_coord_to_translated(core_end),
-        addr,
-        get_selected_noc_id(),
-        tlb_data::Relaxed);
+    tt_device_->noc_multicast_write(src, size, core_start, core_end, addr);
 }
 }  // namespace tt::umd

--- a/device/simulation/simulation_chip.cpp
+++ b/device/simulation/simulation_chip.cpp
@@ -107,21 +107,7 @@ void SimulationChip::noc_multicast_write(
     if (core_start.core_type != CoreType::TENSIX || core_end.core_type != CoreType::TENSIX) {
         UMD_THROW(error::RuntimeError, "noc_multicast_write is only supported for Tensix cores.");
     }
-    // TODO: investigate how to do multicast in Simulation, both RTL sim and TTSim.
-    // Until then, do individual writes to each core in the range.
-    const tt_xy_pair translated_start = get_soc_descriptor().translate_chip_coord_to_translated(core_start);
-    const tt_xy_pair translated_end = get_soc_descriptor().translate_chip_coord_to_translated(core_end);
-    for (uint32_t x = translated_start.x; x <= translated_end.x; ++x) {
-        for (uint32_t y = translated_start.y; y <= translated_end.y; ++y) {
-            // Since we are doing set of unicasts, we must skip cores that are not actual Tensix cores.
-            // These are in columns where x = 8 (ARC core, L2CPU) and x = 9 (GDDR).
-            // TODO: investigate proper multicast support for simulations so we can remove this workaround.
-            if (get_soc_descriptor().arch == tt::ARCH::BLACKHOLE && (x == 8 || x == 9)) {
-                continue;
-            }
-            write_to_device(CoreCoord(x, y, core_start.core_type, CoordSystem::TRANSLATED), src, addr, size);
-        }
-    }
+    tt_device_->noc_multicast_write(src, size, core_start, core_end, addr);
 }
 
 void SimulationChip::wait_for_non_mmio_flush() {}

--- a/device/simulation/simulation_chip.cpp
+++ b/device/simulation/simulation_chip.cpp
@@ -101,15 +101,6 @@ void SimulationChip::dma_multicast_write(
     UMD_THROW(error::RuntimeError, "dma_multicast_write is not supported in SimulationChip.");
 }
 
-void SimulationChip::noc_multicast_write(
-    const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) {
-    // TODO: Support other core types once needed.
-    if (core_start.core_type != CoreType::TENSIX || core_end.core_type != CoreType::TENSIX) {
-        UMD_THROW(error::RuntimeError, "noc_multicast_write is only supported for Tensix cores.");
-    }
-    tt_device_->noc_multicast_write(src, size, core_start, core_end, addr);
-}
-
 void SimulationChip::wait_for_non_mmio_flush() {}
 
 void SimulationChip::l1_membar(const std::unordered_set<CoreCoord>& cores) {}

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -336,6 +336,21 @@ void RtlSimulationTTDevice::retrain_dram_core(const uint32_t dram_channel) {
     UMD_THROW(error::RuntimeError, "DRAM retraining is not supported in RTL simulation device.");
 }
 
+void RtlSimulationTTDevice::noc_multicast_write(
+    const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) {
+    // RTL sim has no hardware multicast; fall back to per-core unicast.
+    // TODO: investigate proper multicast support for simulations so we can remove this workaround.
+    for (uint32_t x = core_start.x; x <= core_end.x; ++x) {
+        for (uint32_t y = core_start.y; y <= core_end.y; ++y) {
+            // BLACKHOLE: x==8 is ARC/L2CPU and x==9 is GDDR, not actual Tensix cores.
+            if (arch == tt::ARCH::BLACKHOLE && (x == 8 || x == 9)) {
+                continue;
+            }
+            write_to_device(src, tt_xy_pair{x, y}, addr, size);
+        }
+    }
+}
+
 void RtlSimulationTTDevice::noc_multicast_write(const void* src, size_t size, uint64_t addr) {
     UMD_THROW(error::RuntimeError, "NOC multicast write is not supported in RTL simulation device.");
 }

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -338,17 +338,7 @@ void RtlSimulationTTDevice::retrain_dram_core(const uint32_t dram_channel) {
 
 void RtlSimulationTTDevice::noc_multicast_write(
     const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) {
-    // RTL sim has no hardware multicast; fall back to per-core unicast.
-    // TODO: investigate proper multicast support for simulations so we can remove this workaround.
-    for (uint32_t x = core_start.x; x <= core_end.x; ++x) {
-        for (uint32_t y = core_start.y; y <= core_end.y; ++y) {
-            // BLACKHOLE: x==8 is ARC/L2CPU and x==9 is GDDR, not actual Tensix cores.
-            if (arch == tt::ARCH::BLACKHOLE && (x == 8 || x == 9)) {
-                continue;
-            }
-            write_to_device(src, tt_xy_pair{x, y}, addr, size);
-        }
-    }
+    multicast_write_via_unicast(src, size, core_start, core_end, addr);
 }
 
 void RtlSimulationTTDevice::noc_multicast_write(const void* src, size_t size, uint64_t addr) {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -636,6 +636,21 @@ void TTDevice::noc_multicast_write(
         addr);
 }
 
+void TTDevice::multicast_write_via_unicast(
+    const void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) {
+    // No hardware multicast on simulation backends; fall back to per-core unicast.
+    // TODO: investigate proper multicast support for simulations so we can remove this workaround.
+    for (uint32_t x = core_start.x; x <= core_end.x; ++x) {
+        for (uint32_t y = core_start.y; y <= core_end.y; ++y) {
+            // BLACKHOLE: x==8 is ARC/L2CPU and x==9 is GDDR, not actual Tensix cores.
+            if (arch == tt::ARCH::BLACKHOLE && (x == 8 || x == 9)) {
+                continue;
+            }
+            write_to_device(src, tt_xy_pair{x, y}, addr, size);
+        }
+    }
+}
+
 void TTDevice::dma_write_to_device(const void *src, size_t size, tt_xy_pair core, uint64_t addr) {
     ZoneScopedC(tracy::Color::MediumPurple);
     if (is_remote_tt_device) {

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -390,6 +390,21 @@ void TTSimTTDevice::retrain_dram_core(const uint32_t dram_channel) {
     UMD_THROW(error::RuntimeError, "DRAM retraining is not supported in TTSim device.");
 }
 
+void TTSimTTDevice::noc_multicast_write(
+    const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) {
+    // TTSim has no hardware multicast; fall back to per-core unicast.
+    // TODO: investigate proper multicast support for simulations so we can remove this workaround.
+    for (uint32_t x = core_start.x; x <= core_end.x; ++x) {
+        for (uint32_t y = core_start.y; y <= core_end.y; ++y) {
+            // BLACKHOLE: x==8 is ARC/L2CPU and x==9 is GDDR, not actual Tensix cores.
+            if (arch == tt::ARCH::BLACKHOLE && (x == 8 || x == 9)) {
+                continue;
+            }
+            write_to_device(src, tt_xy_pair{x, y}, addr, size);
+        }
+    }
+}
+
 void TTSimTTDevice::noc_multicast_write(const void* src, size_t size, uint64_t addr) {
     UMD_THROW(error::RuntimeError, "NOC multicast write is not supported in TTSim simulation device.");
 }

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -392,17 +392,7 @@ void TTSimTTDevice::retrain_dram_core(const uint32_t dram_channel) {
 
 void TTSimTTDevice::noc_multicast_write(
     const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) {
-    // TTSim has no hardware multicast; fall back to per-core unicast.
-    // TODO: investigate proper multicast support for simulations so we can remove this workaround.
-    for (uint32_t x = core_start.x; x <= core_end.x; ++x) {
-        for (uint32_t y = core_start.y; y <= core_end.y; ++y) {
-            // BLACKHOLE: x==8 is ARC/L2CPU and x==9 is GDDR, not actual Tensix cores.
-            if (arch == tt::ARCH::BLACKHOLE && (x == 8 || x == 9)) {
-                continue;
-            }
-            write_to_device(src, tt_xy_pair{x, y}, addr, size);
-        }
-    }
+    multicast_write_via_unicast(src, size, core_start, core_end, addr);
 }
 
 void TTSimTTDevice::noc_multicast_write(const void* src, size_t size, uint64_t addr) {


### PR DESCRIPTION
### Issue
Closes #2699. Part of #2679.

### Description
Push `noc_multicast_write` variance from the chip layer into `TTDevice`, so `LocalChip` and `SimulationChip` both reduce to thin delegations.

This is a PR that is pushing everything into TTDevice layer so Chip class stays unchanged for every backend.

### List of the changes

- Override noc_multicast_write in sim classes
- Make SimulationChip call into TTDevice layer

### Testing

CI

### API Changes
/
