### PR TITLE
Simulation TTDevice foundation: extend sim TTDevice factory

### DIFF
--- a/device/api/umd/device/tt_device/simulation_device_factory.hpp
+++ b/device/api/umd/device/tt_device/simulation_device_factory.hpp
@@ -4,11 +4,15 @@
 
 #pragma once
 
+#include <cstddef>
 #include <filesystem>
 #include <memory>
 
+#include "umd/device/types/cluster_descriptor_types.hpp"
+
 namespace tt::umd {
 
+class SocDescriptor;
 class TTDevice;
 
 /**
@@ -23,5 +27,20 @@ class TTDevice;
  */
 std::unique_ptr<TTDevice> create_simulation_tt_device(
     const std::filesystem::path &simulator_path, int num_host_mem_channels = 0, bool copy_sim_binary = false);
+
+/**
+ * Same as above, but uses a caller-provided SocDescriptor and ChipId instead of deriving them
+ * from the simulator path. copy_sim_binary is derived from num_chips > 1 (needed when multiple
+ * TTSim instances run in the same process).
+ *
+ * Intended for use from SimulationChip::create and Cluster::construct_chip_from_cluster, where
+ * the SocDescriptor is already known.
+ */
+std::unique_ptr<TTDevice> create_simulation_tt_device(
+    const std::filesystem::path &simulator_directory,
+    const SocDescriptor &soc_descriptor,
+    ChipId chip_id,
+    size_t num_chips,
+    int num_host_mem_channels = 0);
 
 }  // namespace tt::umd

--- a/device/simulation/simulation_chip.cpp
+++ b/device/simulation/simulation_chip.cpp
@@ -10,10 +10,10 @@
 #include <tt-logger/tt-logger.hpp>
 
 #include "tracy.hpp"
+#include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/soc_descriptor.hpp"
-#include "umd/device/tt_device/rtl_simulation_tt_device.hpp"
-#include "umd/device/tt_device/tt_sim_tt_device.hpp"
+#include "umd/device/tt_device/simulation_device_factory.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/utils/error.hpp"
@@ -26,15 +26,8 @@ std::unique_ptr<SimulationChip> SimulationChip::create(
     ChipId chip_id,
     size_t num_chips,
     int num_host_mem_channels) {
-    std::unique_ptr<TTDevice> tt_device;
-    if (simulator_directory.extension() == ".so") {
-        tt_device = std::make_unique<TTSimTTDevice>(
-            simulator_directory, soc_descriptor, chip_id, num_chips > 1, num_host_mem_channels);
-    } else {
-        log_info(tt::LogEmulationDriver, "Instantiating RTL simulation device");
-        tt_device = std::make_unique<RtlSimulationTTDevice>(
-            simulator_directory, soc_descriptor, chip_id, num_host_mem_channels);
-    }
+    auto tt_device =
+        create_simulation_tt_device(simulator_directory, soc_descriptor, chip_id, num_chips, num_host_mem_channels);
     return std::make_unique<SimulationChip>(simulator_directory, soc_descriptor, chip_id, std::move(tt_device));
 }
 

--- a/device/tt_device/simulation_device_factory.cpp
+++ b/device/tt_device/simulation_device_factory.cpp
@@ -4,6 +4,9 @@
 
 #include "umd/device/tt_device/simulation_device_factory.hpp"
 
+#include <tt-logger/tt-logger.hpp>
+
+#include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/rtl_simulation_tt_device.hpp"
 #include "umd/device/tt_device/tt_sim_tt_device.hpp"
 
@@ -15,6 +18,20 @@ std::unique_ptr<TTDevice> create_simulation_tt_device(
         return TTSimTTDevice::create(simulator_path, num_host_mem_channels, copy_sim_binary);
     }
     return RtlSimulationTTDevice::create(simulator_path, num_host_mem_channels);
+}
+
+std::unique_ptr<TTDevice> create_simulation_tt_device(
+    const std::filesystem::path &simulator_directory,
+    const SocDescriptor &soc_descriptor,
+    ChipId chip_id,
+    size_t num_chips,
+    int num_host_mem_channels) {
+    if (simulator_directory.extension() == ".so") {
+        return std::make_unique<TTSimTTDevice>(
+            simulator_directory, soc_descriptor, chip_id, num_chips > 1, num_host_mem_channels);
+    }
+    log_info(tt::LogEmulationDriver, "Instantiating RTL simulation device");
+    return std::make_unique<RtlSimulationTTDevice>(simulator_directory, soc_descriptor, chip_id, num_host_mem_channels);
 }
 
 }  // namespace tt::umd

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -697,7 +697,8 @@ void bind_tt_device(nb::module_ &m) {
     // Add simulation TTDevice factory binding - must be inside TT_UMD_BUILD_SIMULATION guard.
     m.def(
         "create_simulation_tt_device",
-        &create_simulation_tt_device,
+        static_cast<std::unique_ptr<TTDevice> (*)(const std::filesystem::path &, int, bool)>(
+            &create_simulation_tt_device),
         nb::arg("simulator_path"),
         nb::arg("num_host_mem_channels") = 0,
         nb::arg("copy_sim_binary") = false,


### PR DESCRIPTION
### Issue
Closes #2696. Part of #2679.

### Description
Foundation work for merging `SimulationChip` into `LocalChip` by pushing backend variance into the `TTDevice` layer.

Make SimulationChip call into create_simulation_tt_device so logic around tt_device creation is hidden in the lower layer. In the future, this function should accept runtime options and know which TTDevice to create.

### List of the changes

- Add another create_simulation_tt_device function which is called from SimulationChip
- Make SimulationChip call into newly added function

### Testing

CI

### API Changes
/
