### PR TITLE
Move membars into TTDevice

### DIFF
--- a/device/api/umd/device/chip/chip.hpp
+++ b/device/api/umd/device/chip/chip.hpp
@@ -135,11 +135,6 @@ public:
     // TODO: To be moved to private implementation once methods are moved to chip.
     void enable_ethernet_queue(const std::chrono::milliseconds timeout_ms = timeout::ETH_QUEUE_ENABLE_TIMEOUT);
 
-    // TODO: This should be private, once enough stuff is moved inside chip.
-    // Probably also moved to LocalChip.
-    DeviceDramAddressParams dram_address_params;
-    DeviceL1AddressParams l1_address_params;
-
 protected:
     void wait_chip_to_be_ready();
 

--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -113,13 +113,8 @@ private:
 
     void initialize_tlb_manager();
     void initialize_default_chip_mutexes();
-    void initialize_membars(uint32_t dram_subchannel);
 
     void init_pcie_iatus();
-
-    void set_membar_flag(
-        const std::vector<CoreCoord>& cores, const uint32_t barrier_value, const uint32_t barrier_addr);
-    void insert_host_to_device_barrier(const std::vector<CoreCoord>& cores, const uint32_t barrier_addr);
 
     std::unique_ptr<TTDevice> tt_device_ = nullptr;
 

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -68,6 +68,14 @@ public:
 
     void noc_multicast_write(void* src, size_t size, uint64_t addr) override;
 
+    void l1_membar(const std::unordered_set<CoreCoord>& cores) override {}
+
+    void dram_membar(const std::unordered_set<CoreCoord>& cores) override {}
+
+    void dram_membar(const std::unordered_set<uint32_t>& channels, uint32_t subchannel = 0) override {}
+
+    void initialize_membars(uint32_t dram_subchannel) override {}
+
     RtlSimCommunicator* get_communicator() { return communicator_.get(); }
 
     SimulationSysmemManager* get_sysmem_manager() override { return sysmem_manager_.get(); }

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -13,6 +13,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 #include <utility>
 
 #include "tt_device_error.hpp"
@@ -32,6 +33,7 @@
 #include "umd/device/tt_device/protocol/remote_interface.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/cluster_types.hpp"
 #include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/noc_id.hpp"
@@ -211,6 +213,33 @@ public:
      * @param addr address on the device where data will be written
      */
     virtual void noc_multicast_write(void *src, size_t size, uint64_t addr) = 0;
+
+    /**
+     * Insert an L1 memory barrier on the given cores (or all L1-bearing cores if empty).
+     * Default impl runs the PCIe set/reset-flag barrier dance using the MEM_BARRIER interprocess mutex.
+     * Simulator backends override to no-op.
+     */
+    virtual void l1_membar(const std::unordered_set<CoreCoord> &cores);
+
+    /**
+     * Insert a DRAM memory barrier on the given cores (or all DRAM cores if empty).
+     */
+    virtual void dram_membar(const std::unordered_set<CoreCoord> &cores);
+
+    /**
+     * Insert a DRAM memory barrier on the given channels (or all channels if empty).
+     */
+    virtual void dram_membar(const std::unordered_set<uint32_t> &channels, uint32_t subchannel = 0);
+
+    /**
+     * Configure the host-to-device barrier flag addresses. Forwarded from Chip::set_barrier_address_params.
+     */
+    void set_barrier_address_params(const BarrierAddressParams &barrier_address_params);
+
+    /**
+     * Initialize all membar flags (TENSIX/ETH L1, DRAM) to RESET. Called from LocalChip::start_device.
+     */
+    virtual void initialize_membars(uint32_t dram_subchannel);
 
     /**
      * Read function that will send read message to the ARC core APB peripherals.
@@ -496,6 +525,12 @@ protected:
     LockManager lock_manager;
     std::unique_ptr<ArcTelemetryReader> telemetry = nullptr;
     std::unique_ptr<FirmwareInfoProvider> firmware_info_provider = nullptr;
+    DeviceL1AddressParams l1_address_params_{};
+    DeviceDramAddressParams dram_address_params_{};
+
+    void set_membar_flag(
+        const std::vector<CoreCoord> &cores, const uint32_t barrier_value, const uint32_t barrier_addr);
+    void insert_host_to_device_barrier(const std::vector<CoreCoord> &cores, const uint32_t barrier_addr);
 
     TTDevice();
     TTDevice(std::unique_ptr<architecture_implementation> architecture_impl);

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -66,6 +66,14 @@ public:
 
     void noc_multicast_write(void *src, size_t size, uint64_t addr) override;
 
+    void l1_membar(const std::unordered_set<CoreCoord> &cores) override {}
+
+    void dram_membar(const std::unordered_set<CoreCoord> &cores) override {}
+
+    void dram_membar(const std::unordered_set<uint32_t> &channels, uint32_t subchannel = 0) override {}
+
+    void initialize_membars(uint32_t dram_subchannel) override {}
+
     void send_tensix_risc_reset(tt_xy_pair translated_core, const TensixSoftResetOptions &soft_resets) override;
     void send_tensix_risc_reset(const TensixSoftResetOptions &soft_resets) override;
     void assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs) override;

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -42,21 +42,15 @@ Chip::Chip(const ChipInfo chip_info, SocDescriptor soc_descriptor) :
 
 SocDescriptor& Chip::get_soc_descriptor() { return soc_descriptor_; }
 
-// TODO: This will be moved to LocalChip.
-void Chip::set_default_params(ARCH arch) {
-    auto architecture_implementation = architecture_implementation::create(arch);
-
-    // Default initialize l1_address_params based on detected arch.
-    l1_address_params = architecture_implementation->get_l1_address_params();
-
-    // Default initialize dram_address_params.
-    dram_address_params = {0u};
+void Chip::set_default_params(ARCH /*arch*/) {
+    // Address params now live on TTDevice; default-initialized there from architecture_impl_.
 }
 
 void Chip::set_barrier_address_params(const BarrierAddressParams& barrier_address_params) {
-    l1_address_params.tensix_l1_barrier_base = barrier_address_params.tensix_l1_barrier_base;
-    l1_address_params.eth_l1_barrier_base = barrier_address_params.eth_l1_barrier_base;
-    dram_address_params.DRAM_BARRIER_BASE = barrier_address_params.dram_barrier_base;
+    TTDevice* tt_device = get_tt_device();
+    if (tt_device != nullptr) {
+        tt_device->set_barrier_address_params(barrier_address_params);
+    }
 }
 
 const ChipInfo& Chip::get_chip_info() { return chip_info_; }

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -139,31 +139,8 @@ void LocalChip::initialize_default_chip_mutexes() {
         lock_manager_.initialize_mutex(MutexType::REMOTE_ARC_MSG, pci_device_id);
     }
 
-    // Initialize interprocess mutexes to make host -> device memory barriers atomic.
-    lock_manager_.initialize_mutex(MutexType::MEM_BARRIER, pci_device_id);
-
     // Initialize mutex guarding initialized chips.
     lock_manager_.initialize_mutex(MutexType::CHIP_IN_USE, pci_device_id);
-}
-
-void LocalChip::initialize_membars(uint32_t dram_subchannel) {
-    ZoneScopedC(tracy::Color::DarkGreen);
-    set_membar_flag(
-        soc_descriptor_.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED),
-        MemBarFlag::RESET,
-        l1_address_params.tensix_l1_barrier_base);
-    set_membar_flag(
-        soc_descriptor_.get_cores(CoreType::ETH, CoordSystem::TRANSLATED),
-        MemBarFlag::RESET,
-        l1_address_params.eth_l1_barrier_base);
-
-    std::vector<CoreCoord> dram_cores_vector = {};
-    dram_cores_vector.reserve(soc_descriptor_.get_num_dram_channels());
-    for (std::uint32_t dram_idx = 0; dram_idx < soc_descriptor_.get_num_dram_channels(); dram_idx++) {
-        dram_cores_vector.push_back(
-            soc_descriptor_.get_dram_core_for_channel(dram_idx, dram_subchannel, CoordSystem::TRANSLATED));
-    }
-    set_membar_flag(dram_cores_vector, MemBarFlag::RESET, dram_address_params.DRAM_BARRIER_BASE);
 }
 
 TTDevice* LocalChip::get_tt_device() { return tt_device_.get(); }
@@ -189,7 +166,7 @@ void LocalChip::start_device(uint32_t dram_membar_subchannel) {
         // If this is supported by the newer KMD, UMD doesn't have to program the iatu.
         init_pcie_iatus();
     }
-    initialize_membars(dram_membar_subchannel);
+    tt_device_->initialize_membars(dram_membar_subchannel);
 }
 
 void LocalChip::close_device() {
@@ -469,112 +446,12 @@ void LocalChip::init_pcie_iatus() {
     }
 }
 
-void LocalChip::set_membar_flag(
-    const std::vector<CoreCoord>& cores, const uint32_t barrier_value, const uint32_t barrier_addr) {
-    tt_driver_atomics::sfence();  // Ensure that writes before this do not get reordered
-    std::unordered_set<CoreCoord> cores_synced = {};
-    std::vector<uint32_t> barrier_val_vec = {barrier_value};
-    for (const auto& core : cores) {
-        write_to_device(core, barrier_val_vec.data(), barrier_addr, barrier_val_vec.size() * sizeof(uint32_t));
-    }
-    tt_driver_atomics::sfence();  // Ensure that all writes in the Host WC buffer are flushed
-    while (cores_synced.size() != cores.size()) {
-        for (const auto& core : cores) {
-            if (cores_synced.find(core) == cores_synced.end()) {
-                uint32_t readback_val;
-                read_from_device(core, &readback_val, barrier_addr, sizeof(std::uint32_t));
-                if (readback_val == barrier_value) {
-                    cores_synced.insert(core);
-                } else {
-                    log_trace(
-                        LogUMD,
-                        "Waiting for core {} to recieve mem bar flag {} in function",
-                        core.str(),
-                        barrier_value);
-                }
-            }
-        }
-    }
-    // Ensure that reads or writes after this do not get reordered.
-    // Reordering can cause races where data gets transferred before the barrier has returned.
-    tt_driver_atomics::mfence();
-}
+void LocalChip::l1_membar(const std::unordered_set<CoreCoord>& cores) { tt_device_->l1_membar(cores); }
 
-void LocalChip::insert_host_to_device_barrier(const std::vector<CoreCoord>& cores, const uint32_t barrier_addr) {
-    // Ensure that this memory barrier is atomic across processes/threads.
-    auto lock = lock_manager_.acquire_mutex(MutexType::MEM_BARRIER, tt_device_->get_pci_device()->get_device_num());
-    set_membar_flag(cores, MemBarFlag::SET, barrier_addr);
-    set_membar_flag(cores, MemBarFlag::RESET, barrier_addr);
-}
-
-void LocalChip::l1_membar(const std::unordered_set<CoreCoord>& cores) {
-    const bool include_dram_in_l1_membar = soc_descriptor_.arch == tt::ARCH::BLACKHOLE;
-    if (!cores.empty()) {
-        // Insert barrier on specific cores with L1.
-        std::vector<CoreCoord> workers_to_sync = {};
-        std::vector<CoreCoord> eth_to_sync = {};
-        std::vector<CoreCoord> dram_to_sync = {};
-
-        for (const auto& core : cores) {
-            auto core_from_soc = soc_descriptor_.get_coord_at(core, core.coord_system);
-            if (core_from_soc.core_type == CoreType::TENSIX) {
-                workers_to_sync.push_back(core);
-            } else if (core_from_soc.core_type == CoreType::ETH) {
-                eth_to_sync.push_back(core);
-            } else if (include_dram_in_l1_membar && core_from_soc.core_type == CoreType::DRAM) {
-                dram_to_sync.push_back(core);
-            } else {
-                UMD_THROW(error::RuntimeError, "Can only insert an L1 Memory barrier on Tensix or Ethernet cores.");
-            }
-        }
-        insert_host_to_device_barrier(workers_to_sync, l1_address_params.tensix_l1_barrier_base);
-        insert_host_to_device_barrier(eth_to_sync, l1_address_params.eth_l1_barrier_base);
-        if (include_dram_in_l1_membar) {
-            insert_host_to_device_barrier(dram_to_sync, dram_address_params.DRAM_BARRIER_BASE);
-        }
-    } else {
-        // Insert barrier on all cores with L1.
-        insert_host_to_device_barrier(
-            soc_descriptor_.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED),
-            l1_address_params.tensix_l1_barrier_base);
-        insert_host_to_device_barrier(
-            soc_descriptor_.get_cores(CoreType::ETH, CoordSystem::TRANSLATED), l1_address_params.eth_l1_barrier_base);
-        if (include_dram_in_l1_membar) {
-            insert_host_to_device_barrier(
-                soc_descriptor_.get_cores(CoreType::DRAM, CoordSystem::TRANSLATED),
-                dram_address_params.DRAM_BARRIER_BASE);
-        }
-    }
-}
-
-void LocalChip::dram_membar(const std::unordered_set<CoreCoord>& cores) {
-    if (!cores.empty()) {
-        for (const auto& core : cores) {
-            UMD_ASSERT(
-                soc_descriptor_.get_coord_at(core, core.coord_system).core_type == CoreType::DRAM,
-                error::RuntimeError,
-                "Can only insert a DRAM Memory barrier on DRAM cores.");
-        }
-        std::vector<CoreCoord> dram_cores_vector = std::vector<CoreCoord>(cores.begin(), cores.end());
-        insert_host_to_device_barrier(dram_cores_vector, dram_address_params.DRAM_BARRIER_BASE);
-    } else {
-        // Insert Barrier on all DRAM Cores.
-        std::vector<CoreCoord> dram_cores_vector = {};
-        dram_cores_vector.reserve(soc_descriptor_.get_num_dram_channels());
-        for (std::uint32_t dram_idx = 0; dram_idx < soc_descriptor_.get_num_dram_channels(); dram_idx++) {
-            dram_cores_vector.push_back(
-                soc_descriptor_.get_dram_core_for_channel(dram_idx, 0, CoordSystem::TRANSLATED));
-        }
-        insert_host_to_device_barrier(dram_cores_vector, dram_address_params.DRAM_BARRIER_BASE);
-    }
-}
+void LocalChip::dram_membar(const std::unordered_set<CoreCoord>& cores) { tt_device_->dram_membar(cores); }
 
 void LocalChip::dram_membar(const std::unordered_set<uint32_t>& channels, uint32_t subchannel) {
-    std::unordered_set<CoreCoord> dram_cores_to_sync = {};
-    for (const auto& chan : channels) {
-        dram_cores_to_sync.insert(soc_descriptor_.get_dram_core_for_channel(chan, subchannel, CoordSystem::TRANSLATED));
-    }
-    dram_membar(dram_cores_to_sync);
+    tt_device_->dram_membar(channels, subchannel);
 }
 
 void LocalChip::deassert_risc_resets() {

--- a/device/simulation/simulation_chip.cpp
+++ b/device/simulation/simulation_chip.cpp
@@ -147,11 +147,13 @@ void SimulationChip::noc_multicast_write(
 
 void SimulationChip::wait_for_non_mmio_flush() {}
 
-void SimulationChip::l1_membar(const std::unordered_set<CoreCoord>& cores) {}
+void SimulationChip::l1_membar(const std::unordered_set<CoreCoord>& cores) { tt_device_->l1_membar(cores); }
 
-void SimulationChip::dram_membar(const std::unordered_set<uint32_t>& channels, uint32_t subchannel) {}
+void SimulationChip::dram_membar(const std::unordered_set<uint32_t>& channels, uint32_t subchannel) {
+    tt_device_->dram_membar(channels, subchannel);
+}
 
-void SimulationChip::dram_membar(const std::unordered_set<CoreCoord>& cores) {}
+void SimulationChip::dram_membar(const std::unordered_set<CoreCoord>& cores) { tt_device_->dram_membar(cores); }
 
 void SimulationChip::deassert_risc_resets() {}
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -61,12 +61,14 @@ TTDevice::TTDevice(
     communication_device_type_(IODeviceType::PCIe),
     communication_device_id_(pci_device->get_device_num()),
     architecture_impl_(std::move(architecture_impl)),
-    arch(architecture_impl_->get_architecture()) {
+    arch(architecture_impl_->get_architecture()),
+    l1_address_params_(architecture_impl_->get_l1_address_params()) {
     auto pcie_protocol = std::make_unique<PcieProtocol>(std::move(pci_device), use_safe_api);
     pcie_capabilities_ = pcie_protocol.get();
     device_protocol_ = std::move(pcie_protocol);
-    // Initialize PCIe DMA mutex through LockManager for cross-process synchronization.
+    // Initialize cross-process mutexes through LockManager.
     lock_manager.initialize_mutex(MutexType::PCIE_DMA, communication_device_id_, communication_device_type_);
+    lock_manager.initialize_mutex(MutexType::MEM_BARRIER, communication_device_id_, communication_device_type_);
     if (use_safe_api) {
         set_sigbus_safe_handler(true);
     }
@@ -79,7 +81,8 @@ TTDevice::TTDevice(
     communication_device_type_(IODeviceType::JTAG),
     communication_device_id_(jlink_id),
     architecture_impl_(std::move(architecture_impl)),
-    arch(architecture_impl_->get_architecture()) {
+    arch(architecture_impl_->get_architecture()),
+    l1_address_params_(architecture_impl_->get_l1_address_params()) {
     auto jtag_protocol = std::make_unique<JtagProtocol>(std::move(jtag_device), jlink_id);
     jtag_capabilities_ = jtag_protocol.get();
     device_protocol_ = std::move(jtag_protocol);
@@ -91,7 +94,8 @@ TTDevice::TTDevice(
     communication_device_type_(remote_communication->get_local_device()->get_communication_device_type()),
     communication_device_id_(remote_communication->get_local_device()->get_communication_device_id()),
     architecture_impl_(std::move(architecture_impl)),
-    arch(architecture_impl_->get_architecture()) {
+    arch(architecture_impl_->get_architecture()),
+    l1_address_params_(architecture_impl_->get_l1_address_params()) {
     auto remote_protocol = std::make_unique<RemoteProtocol>(std::move(remote_communication));
     remote_capabilities_ = remote_protocol.get();
     device_protocol_ = std::move(remote_protocol);
@@ -100,7 +104,9 @@ TTDevice::TTDevice(
 TTDevice::TTDevice() = default;
 
 TTDevice::TTDevice(std::unique_ptr<architecture_implementation> architecture_impl) :
-    architecture_impl_(std::move(architecture_impl)), arch(architecture_impl_->get_architecture()) {}
+    architecture_impl_(std::move(architecture_impl)),
+    arch(architecture_impl_->get_architecture()),
+    l1_address_params_(architecture_impl_->get_l1_address_params()) {}
 
 void TTDevice::probe_arc() {
     uint32_t dummy;
@@ -494,6 +500,142 @@ void TTDevice::noc_multicast_write(void *src, size_t size, CoreCoord core_start,
         soc_desc.translate_chip_coord_to_translated(core_start),
         soc_desc.translate_chip_coord_to_translated(core_end),
         addr);
+}
+
+void TTDevice::set_barrier_address_params(const BarrierAddressParams &barrier_address_params) {
+    l1_address_params_.tensix_l1_barrier_base = barrier_address_params.tensix_l1_barrier_base;
+    l1_address_params_.eth_l1_barrier_base = barrier_address_params.eth_l1_barrier_base;
+    dram_address_params_.DRAM_BARRIER_BASE = barrier_address_params.dram_barrier_base;
+}
+
+void TTDevice::set_membar_flag(
+    const std::vector<CoreCoord> &cores, const uint32_t barrier_value, const uint32_t barrier_addr) {
+    tt_driver_atomics::sfence();  // Ensure that writes before this do not get reordered
+    std::unordered_set<CoreCoord> cores_synced = {};
+    std::vector<uint32_t> barrier_val_vec = {barrier_value};
+    for (const auto &core : cores) {
+        write_to_device(barrier_val_vec.data(), core, barrier_addr, barrier_val_vec.size() * sizeof(uint32_t));
+    }
+    tt_driver_atomics::sfence();  // Ensure that all writes in the Host WC buffer are flushed
+    while (cores_synced.size() != cores.size()) {
+        for (const auto &core : cores) {
+            if (cores_synced.find(core) == cores_synced.end()) {
+                uint32_t readback_val;
+                read_from_device(&readback_val, core, barrier_addr, sizeof(std::uint32_t));
+                if (readback_val == barrier_value) {
+                    cores_synced.insert(core);
+                } else {
+                    log_trace(
+                        LogUMD,
+                        "Waiting for core {} to recieve mem bar flag {} in function",
+                        core.str(),
+                        barrier_value);
+                }
+            }
+        }
+    }
+    // Ensure that reads or writes after this do not get reordered.
+    // Reordering can cause races where data gets transferred before the barrier has returned.
+    tt_driver_atomics::mfence();
+}
+
+void TTDevice::insert_host_to_device_barrier(const std::vector<CoreCoord> &cores, const uint32_t barrier_addr) {
+    // Ensure that this memory barrier is atomic across processes/threads.
+    auto lock =
+        lock_manager.acquire_mutex(MutexType::MEM_BARRIER, communication_device_id_, communication_device_type_);
+    set_membar_flag(cores, MemBarFlag::SET, barrier_addr);
+    set_membar_flag(cores, MemBarFlag::RESET, barrier_addr);
+}
+
+void TTDevice::l1_membar(const std::unordered_set<CoreCoord> &cores) {
+    const SocDescriptor &soc_desc = get_soc_descriptor();
+    const bool include_dram_in_l1_membar = soc_desc.arch == tt::ARCH::BLACKHOLE;
+    if (!cores.empty()) {
+        // Insert barrier on specific cores with L1.
+        std::vector<CoreCoord> workers_to_sync = {};
+        std::vector<CoreCoord> eth_to_sync = {};
+        std::vector<CoreCoord> dram_to_sync = {};
+
+        for (const auto &core : cores) {
+            auto core_from_soc = soc_desc.get_coord_at(core, core.coord_system);
+            if (core_from_soc.core_type == CoreType::TENSIX) {
+                workers_to_sync.push_back(core);
+            } else if (core_from_soc.core_type == CoreType::ETH) {
+                eth_to_sync.push_back(core);
+            } else if (include_dram_in_l1_membar && core_from_soc.core_type == CoreType::DRAM) {
+                dram_to_sync.push_back(core);
+            } else {
+                UMD_THROW(error::RuntimeError, "Can only insert an L1 Memory barrier on Tensix or Ethernet cores.");
+            }
+        }
+        insert_host_to_device_barrier(workers_to_sync, l1_address_params_.tensix_l1_barrier_base);
+        insert_host_to_device_barrier(eth_to_sync, l1_address_params_.eth_l1_barrier_base);
+        if (include_dram_in_l1_membar) {
+            insert_host_to_device_barrier(dram_to_sync, dram_address_params_.DRAM_BARRIER_BASE);
+        }
+    } else {
+        // Insert barrier on all cores with L1.
+        insert_host_to_device_barrier(
+            soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED), l1_address_params_.tensix_l1_barrier_base);
+        insert_host_to_device_barrier(
+            soc_desc.get_cores(CoreType::ETH, CoordSystem::TRANSLATED), l1_address_params_.eth_l1_barrier_base);
+        if (include_dram_in_l1_membar) {
+            insert_host_to_device_barrier(
+                soc_desc.get_cores(CoreType::DRAM, CoordSystem::TRANSLATED), dram_address_params_.DRAM_BARRIER_BASE);
+        }
+    }
+}
+
+void TTDevice::dram_membar(const std::unordered_set<CoreCoord> &cores) {
+    const SocDescriptor &soc_desc = get_soc_descriptor();
+    if (!cores.empty()) {
+        for (const auto &core : cores) {
+            UMD_ASSERT(
+                soc_desc.get_coord_at(core, core.coord_system).core_type == CoreType::DRAM,
+                error::RuntimeError,
+                "Can only insert a DRAM Memory barrier on DRAM cores.");
+        }
+        std::vector<CoreCoord> dram_cores_vector = std::vector<CoreCoord>(cores.begin(), cores.end());
+        insert_host_to_device_barrier(dram_cores_vector, dram_address_params_.DRAM_BARRIER_BASE);
+    } else {
+        // Insert Barrier on all DRAM Cores.
+        std::vector<CoreCoord> dram_cores_vector = {};
+        dram_cores_vector.reserve(soc_desc.get_num_dram_channels());
+        for (std::uint32_t dram_idx = 0; dram_idx < soc_desc.get_num_dram_channels(); dram_idx++) {
+            dram_cores_vector.push_back(soc_desc.get_dram_core_for_channel(dram_idx, 0, CoordSystem::TRANSLATED));
+        }
+        insert_host_to_device_barrier(dram_cores_vector, dram_address_params_.DRAM_BARRIER_BASE);
+    }
+}
+
+void TTDevice::dram_membar(const std::unordered_set<uint32_t> &channels, uint32_t subchannel) {
+    const SocDescriptor &soc_desc = get_soc_descriptor();
+    std::unordered_set<CoreCoord> dram_cores_to_sync = {};
+    for (const auto &chan : channels) {
+        dram_cores_to_sync.insert(soc_desc.get_dram_core_for_channel(chan, subchannel, CoordSystem::TRANSLATED));
+    }
+    dram_membar(dram_cores_to_sync);
+}
+
+void TTDevice::initialize_membars(uint32_t dram_subchannel) {
+    ZoneScopedC(tracy::Color::DarkGreen);
+    const SocDescriptor &soc_desc = get_soc_descriptor();
+    set_membar_flag(
+        soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED),
+        MemBarFlag::RESET,
+        l1_address_params_.tensix_l1_barrier_base);
+    set_membar_flag(
+        soc_desc.get_cores(CoreType::ETH, CoordSystem::TRANSLATED),
+        MemBarFlag::RESET,
+        l1_address_params_.eth_l1_barrier_base);
+
+    std::vector<CoreCoord> dram_cores_vector = {};
+    dram_cores_vector.reserve(soc_desc.get_num_dram_channels());
+    for (std::uint32_t dram_idx = 0; dram_idx < soc_desc.get_num_dram_channels(); dram_idx++) {
+        dram_cores_vector.push_back(
+            soc_desc.get_dram_core_for_channel(dram_idx, dram_subchannel, CoordSystem::TRANSLATED));
+    }
+    set_membar_flag(dram_cores_vector, MemBarFlag::RESET, dram_address_params_.DRAM_BARRIER_BASE);
 }
 
 void TTDevice::dma_write_to_device(const void *src, size_t size, tt_xy_pair core, uint64_t addr) {


### PR DESCRIPTION
### Issue
Closes #2700. Part of #2679.

### Description
Push the L1/DRAM memory-barrier dance from `LocalChip` down to `TTDevice`, where backend variance belongs. `LocalChip` becomes a thin delegation; `SimulationChip` delegates to sim TTDevice no-ops.

**Silicon side.** `TTDevice` owns `l1_address_params_` / `dram_address_params_` (default-initialized from `architecture_impl_->get_l1_address_params()` in the PCIe/JTAG/Remote constructors). New virtuals `l1_membar`, `dram_membar` (both overloads), and `initialize_membars(uint32_t)` do the real set/reset-flag barrier dance using `this->write_to_device` / `this->read_from_device` (already virtual) plus a `MEM_BARRIER` interprocess mutex via TTDevice's existing `lock_manager`. The PCIe constructor now initializes `MEM_BARRIER` (alongside the already-existing `PCIE_DMA`). `Chip::set_barrier_address_params` now forwards to `tt_device_->set_barrier_address_params(...)`; `Chip`'s `l1_address_params` / `dram_address_params` members are gone.

**Sim side.** `TTSimTTDevice` and `RtlSimulationTTDevice` get explicit no-op overrides of `l1_membar` / `dram_membar` / `initialize_membars`. `SimulationChip::l1_membar` / `dram_membar` delegate to `tt_device_->...` (which lands on the no-op overrides).

`LocalChip`'s `l1_membar` / `dram_membar` become single-line delegations to `tt_device_`. `set_membar_flag`, `insert_host_to_device_barrier`, and `initialize_membars` are removed from LocalChip. `start_device` calls `tt_device_->initialize_membars(subchannel)`. `MEM_BARRIER` mutex initialization is removed from `LocalChip::initialize_default_chip_mutexes` — TTDevice owns it now.

### Behavior change
Membar barrier writes/reads now route through `TTDevice::write_to_device` / `read_from_device` (which use `PcieProtocol`'s cached TLB with `tlb_data::Strict` ordering) instead of `LocalChip`'s `cached_wc_tlb_window` (Relaxed). Strict is correctness-preserving; perf impact is negligible on this non-hot path.

### List of the changes
- `device/api/umd/device/tt_device/tt_device.hpp` + `device/tt_device/tt_device.cpp` — new virtuals, helpers, members; `MEM_BARRIER` mutex init in PCIe ctor; `<unordered_set>` and `cluster_types.hpp` includes.
- `device/api/umd/device/tt_device/tt_sim_tt_device.hpp` + `rtl_simulation_tt_device.hpp` — explicit no-op overrides of the four membar-related methods.
- `device/api/umd/device/chip/chip.hpp` + `device/chip/chip.cpp` — removed `l1_address_params` / `dram_address_params` members; `set_barrier_address_params` forwards to `tt_device_`; `set_default_params` is now a no-op.
- `device/api/umd/device/chip/local_chip.hpp` + `device/chip/local_chip.cpp` — `l1_membar` / `dram_membar` become single-line delegations. Removed `set_membar_flag`, `insert_host_to_device_barrier`, `initialize_membars` declarations and bodies. `start_device` calls `tt_device_->initialize_membars(...)`. `MEM_BARRIER` removed from `initialize_default_chip_mutexes`.
- `device/simulation/simulation_chip.cpp` — `l1_membar` / `dram_membar` delegations (already in place from the prior sim-side commit, retained).

### Testing
- `cmake --build build` with `TT_UMD_BUILD_SIMULATION=ON` — clean.
- `pre-commit run --all-files` — clean.
- Reviewer: please run PCIe membar-touching suites (Wormhole, Blackhole) and `tests/simulation/test_simulation_device.cpp` against both `.so` and RTL backends.

### API Changes
- New `TTDevice::set_barrier_address_params(const BarrierAddressParams&)` public method.
- New `TTDevice::initialize_membars(uint32_t)` public virtual method.
- `Chip::l1_address_params` and `Chip::dram_address_params` public members removed. Read/write callers should go through `TTDevice` (via `Chip::get_tt_device()`) or use the existing `Chip::set_barrier_address_params` setter.
