### PR TITLE
pcie: add portable SIMD memcpy paths for non-x86 (GCC/Clang)

### DIFF
--- a/device/pcie/device_memcpy.cpp
+++ b/device/pcie/device_memcpy.cpp
@@ -91,6 +91,64 @@ void memcpy_to_device(volatile void* dest, const void* src, std::size_t size) {
     }
 
     d = reinterpret_cast<volatile std::uint8_t*>(d_simd);
+
+#elif defined(__GNUC__)
+    // GCC/Clang non-x86: vector extensions + __builtin_memcpy (LDP/STP on AArch64).
+    // Clang gets non-temporal stores (STNP); GCC falls back to regular stores.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast).
+    auto* d_wide = const_cast<std::uint8_t*>(static_cast<const volatile std::uint8_t*>(d));
+
+    typedef std::uint8_t __attribute__((vector_size(32), aligned(1))) v32;
+    typedef std::uint8_t __attribute__((vector_size(16), aligned(1))) v16;
+    constexpr std::size_t prefetch_distance = 2048;
+
+    // Phase 1: 256-byte blocks (8 x 32-byte stores).
+    while (size >= 256) {
+        for (int j = 0; j < 8; ++j) {
+            __builtin_prefetch(s + prefetch_distance, 0, 0);
+            v32 chunk;
+            __builtin_memcpy(&chunk, s, 32);
+#if __has_builtin(__builtin_nontemporal_store)
+            __builtin_nontemporal_store(chunk, reinterpret_cast<v32*>(d_wide));
+#else
+            __builtin_memcpy(d_wide, &chunk, 32);
+#endif
+            s += 32;
+            d_wide += 32;
+        }
+        size -= 256;
+    }
+
+    // Phase 2: Remaining 32-byte chunks.
+    while (size >= 32) {
+        __builtin_prefetch(s + prefetch_distance, 0, 0);
+        v32 chunk;
+        __builtin_memcpy(&chunk, s, 32);
+#if __has_builtin(__builtin_nontemporal_store)
+        __builtin_nontemporal_store(chunk, reinterpret_cast<v32*>(d_wide));
+#else
+        __builtin_memcpy(d_wide, &chunk, 32);
+#endif
+        s += 32;
+        d_wide += 32;
+        size -= 32;
+    }
+
+    // Phase 3: Remaining 16-byte chunk.
+    if (size >= 16) {
+        v16 chunk;
+        __builtin_memcpy(&chunk, s, 16);
+#if __has_builtin(__builtin_nontemporal_store)
+        __builtin_nontemporal_store(chunk, reinterpret_cast<v16*>(d_wide));
+#else
+        __builtin_memcpy(d_wide, &chunk, 16);
+#endif
+        s += 16;
+        d_wide += 16;
+        size -= 16;
+    }
+
+    d = reinterpret_cast<volatile std::uint8_t*>(d_wide);
 #endif
 
     // Phase 4: Remaining 4-byte chunks.
@@ -172,6 +230,51 @@ void memcpy_from_device(void* dest, const volatile void* src, std::size_t size) 
     }
 
     s = reinterpret_cast<const volatile std::uint8_t*>(s_simd);
+
+#elif defined(__GNUC__)
+    // GCC/Clang non-x86: vector extensions + __builtin_memcpy (LDP/STP on AArch64).
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast).
+    auto* s_wide = const_cast<std::uint8_t*>(static_cast<const volatile std::uint8_t*>(s));
+
+    typedef std::uint8_t __attribute__((vector_size(32), aligned(1))) v32;
+    typedef std::uint8_t __attribute__((vector_size(16), aligned(1))) v16;
+    constexpr std::size_t prefetch_distance = 2048;
+
+    // Phase 1: 256-byte blocks (8 x 32-byte loads).
+    while (size >= 256) {
+        for (int j = 0; j < 8; ++j) {
+            __builtin_prefetch(s_wide + prefetch_distance, 0, 0);
+            v32 chunk;
+            __builtin_memcpy(&chunk, s_wide, 32);
+            __builtin_memcpy(d, &chunk, 32);
+            s_wide += 32;
+            d += 32;
+        }
+        size -= 256;
+    }
+
+    // Phase 2: Remaining 32-byte chunks.
+    while (size >= 32) {
+        __builtin_prefetch(s_wide + prefetch_distance, 0, 0);
+        v32 chunk;
+        __builtin_memcpy(&chunk, s_wide, 32);
+        __builtin_memcpy(d, &chunk, 32);
+        s_wide += 32;
+        d += 32;
+        size -= 32;
+    }
+
+    // Phase 3: Remaining 16-byte chunk.
+    if (size >= 16) {
+        v16 chunk;
+        __builtin_memcpy(&chunk, s_wide, 16);
+        __builtin_memcpy(d, &chunk, 16);
+        s_wide += 16;
+        d += 16;
+        size -= 16;
+    }
+
+    s = reinterpret_cast<const volatile std::uint8_t*>(s_wide);
 #endif
 
     // Phase 4: Remaining 4-byte chunks.

--- a/device/pcie/device_memcpy.cpp
+++ b/device/pcie/device_memcpy.cpp
@@ -93,22 +93,44 @@ void memcpy_to_device(volatile void* dest, const void* src, std::size_t size) {
     d = reinterpret_cast<volatile std::uint8_t*>(d_simd);
 
 #elif defined(__GNUC__)
-    // GCC/Clang non-x86: vector extensions + __builtin_memcpy (LDP/STP on AArch64).
-    // Clang gets non-temporal stores (STNP); GCC falls back to regular stores.
+    // Like the x86 path, these wide stores are not volatile — compiler reordering is
+    // bounded by the Phase 0/4/5 volatile loops. On Clang, __builtin_nontemporal_store
+    // lowers to STNP (weakly ordered on AArch64), so a release fence is inserted after
+    // Phases 1-3 to ensure all NT stores retire before Phase 4/5 volatile writes or any
+    // subsequent caller doorbell write. GCC uses regular STP stores (strongly ordered).
+
+    // Further align destination to 16 bytes: STP Q / STNP Q to Device/UC memory (PCIe BAR)
+    // require 16-byte-aligned addresses; Phase 0 only guaranteed 4-byte alignment.
+    while (size >= 4 && (reinterpret_cast<std::uintptr_t>(d) % 16) != 0) {
+        std::uint32_t tmp;
+        std::memcpy(&tmp, s, sizeof(tmp));
+        *reinterpret_cast<volatile std::uint32_t*>(d) = tmp;
+        d += 4;
+        s += 4;
+        size -= 4;
+    }
+
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast).
     auto* d_wide = const_cast<std::uint8_t*>(static_cast<const volatile std::uint8_t*>(d));
 
+    // aligned(1) does not suppress STNP: Clang emits ldp q1,q0 / stnp q1,q0 regardless
+    // of the alignment attribute (verified via objdump on AArch64 with Clang 22).
     typedef std::uint8_t __attribute__((vector_size(32), aligned(1))) v32;
     typedef std::uint8_t __attribute__((vector_size(16), aligned(1))) v16;
+    // 2 KB ahead: hides ~100 ns AArch64 DRAM latency at typical PCIe DMA write rates.
     constexpr std::size_t prefetch_distance = 2048;
 
     // Phase 1: 256-byte blocks (8 x 32-byte stores).
+    // The prefetch is issued once per 32-byte chunk (not hoisted to the outer loop) so
+    // that after unrolling the compiler issues 8 prfm instructions covering 8 distinct
+    // cache lines (+2048..+2272 bytes ahead). Hoisting to one prefetch per 256-byte block
+    // would fetch only a single cache line ahead, leaving the other 7 uncovered.
     while (size >= 256) {
         for (int j = 0; j < 8; ++j) {
             __builtin_prefetch(s + prefetch_distance, 0, 0);
             v32 chunk;
             __builtin_memcpy(&chunk, s, 32);
-#if __has_builtin(__builtin_nontemporal_store)
+#if defined(__clang__)
             __builtin_nontemporal_store(chunk, reinterpret_cast<v32*>(d_wide));
 #else
             __builtin_memcpy(d_wide, &chunk, 32);
@@ -124,7 +146,7 @@ void memcpy_to_device(volatile void* dest, const void* src, std::size_t size) {
         __builtin_prefetch(s + prefetch_distance, 0, 0);
         v32 chunk;
         __builtin_memcpy(&chunk, s, 32);
-#if __has_builtin(__builtin_nontemporal_store)
+#if defined(__clang__)
         __builtin_nontemporal_store(chunk, reinterpret_cast<v32*>(d_wide));
 #else
         __builtin_memcpy(d_wide, &chunk, 32);
@@ -138,7 +160,7 @@ void memcpy_to_device(volatile void* dest, const void* src, std::size_t size) {
     if (size >= 16) {
         v16 chunk;
         __builtin_memcpy(&chunk, s, 16);
-#if __has_builtin(__builtin_nontemporal_store)
+#if defined(__clang__)
         __builtin_nontemporal_store(chunk, reinterpret_cast<v16*>(d_wide));
 #else
         __builtin_memcpy(d_wide, &chunk, 16);
@@ -148,6 +170,11 @@ void memcpy_to_device(volatile void* dest, const void* src, std::size_t size) {
         size -= 16;
     }
 
+    // DMB ISH: ensure all STNP stores above are globally visible before Phase 4/5
+    // volatile writes and before the function returns to the caller.
+#if defined(__clang__)
+    __atomic_thread_fence(__ATOMIC_RELEASE);
+#endif
     d = reinterpret_cast<volatile std::uint8_t*>(d_wide);
 #endif
 
@@ -233,11 +260,23 @@ void memcpy_from_device(void* dest, const volatile void* src, std::size_t size) 
 
 #elif defined(__GNUC__)
     // GCC/Clang non-x86: vector extensions + __builtin_memcpy (LDP/STP on AArch64).
+
+    // Further align source to 16 bytes: LDR Q / LDP Q from Device/UC memory (PCIe BAR)
+    // require 16-byte-aligned addresses; Phase 0 only guaranteed 4-byte alignment.
+    while (size >= 4 && (reinterpret_cast<std::uintptr_t>(s) % 16) != 0) {
+        std::uint32_t tmp = *reinterpret_cast<const volatile std::uint32_t*>(s);
+        std::memcpy(d, &tmp, sizeof(tmp));
+        d += 4;
+        s += 4;
+        size -= 4;
+    }
+
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast).
     auto* s_wide = const_cast<std::uint8_t*>(static_cast<const volatile std::uint8_t*>(s));
 
     typedef std::uint8_t __attribute__((vector_size(32), aligned(1))) v32;
     typedef std::uint8_t __attribute__((vector_size(16), aligned(1))) v16;
+    // 2 KB ahead: hides ~100 ns AArch64 DRAM latency at typical PCIe DMA read rates.
     constexpr std::size_t prefetch_distance = 2048;
 
     // Phase 1: 256-byte blocks (8 x 32-byte loads).

--- a/device/pcie/device_memcpy.hpp
+++ b/device/pcie/device_memcpy.hpp
@@ -19,6 +19,10 @@ namespace tt::umd {
  * On x86_64: bulk transfers use AVX2 unaligned loads/stores (VMOVDQU 256-bit), with
  * 16-byte (SSE), 4-byte and byte-wide tails.
  *
+ * On non-x86 with GCC/Clang (e.g. AArch64): uses vector extensions for
+ * 32/16-byte wide stores; Clang gets non-temporal stores (STNP on AArch64)
+ * with 2 KB software prefetch.
+ *
  * On other architectures: falls back to explicit 4-byte and byte-wide volatile stores.
  *
  * Handles arbitrary alignment and size — leading/trailing bytes smaller than a DWORD are
@@ -32,6 +36,9 @@ void memcpy_to_device(volatile void* dest, const void* src, std::size_t size);
  *
  * On x86_64: bulk transfers use AVX2 unaligned loads/stores (VMOVDQU 256-bit), with
  * 16-byte (SSE), 4-byte and byte-wide tails.
+ *
+ * On non-x86 with GCC/Clang (e.g. AArch64): uses vector extensions for
+ * 32/16-byte wide loads/stores (LDP/STP on AArch64) with 2 KB prefetch.
  *
  * On other architectures: falls back to explicit 4-byte and byte-wide volatile loads.
  *

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -4,6 +4,7 @@ set(API_TESTS_SRCS
     test_cluster.cpp
     test_soc_descriptor.cpp
     test_device_io.cpp
+    test_device_memcpy.cpp
     test_risc_program.cpp
     test_tlb_manager.cpp
     test_sysmem_manager.cpp

--- a/tests/api/test_device_memcpy.cpp
+++ b/tests/api/test_device_memcpy.cpp
@@ -32,59 +32,29 @@ constexpr size_t kGuardBytes = 64;
 constexpr uint8_t kGuardFill = 0xAB;
 constexpr uint8_t kSrcFill = 0x42;
 
-// Verify that memcpy_to_device writes exactly the right bytes and leaves
-// everything outside [dst_offset, dst_offset+size) untouched.
-void check_to_device(size_t size, size_t dst_offset, size_t src_offset) {
+// Verify that fn(dst, src, size) writes exactly the right bytes to dst and
+// leaves everything outside [dst_offset, dst_offset+size) untouched.
+// fn receives raw (void*, const void*, size_t) and is responsible for any
+// volatile casts needed by the underlying memcpy_to/from_device call.
+template <typename Fn>
+void check_memcpy(const char* label, Fn fn, size_t size, size_t dst_offset, size_t src_offset) {
     std::vector<uint8_t> src_buf(src_offset + size + kGuardBytes, 0);
     std::vector<uint8_t> dst_buf(dst_offset + size + kGuardBytes, kGuardFill);
 
     // Recognisable pattern that wraps to catch byte-swaps.
-    for (size_t i = 0; i < size; ++i) {
+    for (size_t i = 0; i < size; ++i)
         src_buf[src_offset + i] = static_cast<uint8_t>(kSrcFill + i);
-    }
 
-    volatile void* dst = reinterpret_cast<volatile void*>(dst_buf.data() + dst_offset);
-    const void* src = src_buf.data() + src_offset;
-    memcpy_to_device(dst, src, size);
+    fn(dst_buf.data() + dst_offset, src_buf.data() + src_offset, size);
 
-    for (size_t i = 0; i < size; ++i) {
+    for (size_t i = 0; i < size; ++i)
         ASSERT_EQ(dst_buf[dst_offset + i], src_buf[src_offset + i])
-            << "to_device mismatch at byte " << i
+            << label << " mismatch at byte " << i
             << " (size=" << size << " dst_off=" << dst_offset << " src_off=" << src_offset << ")";
-    }
-    for (size_t i = 0; i < dst_offset; ++i) {
-        ASSERT_EQ(dst_buf[i], kGuardFill) << "to_device underrun at " << i;
-    }
-    for (size_t i = dst_offset + size; i < dst_buf.size(); ++i) {
-        ASSERT_EQ(dst_buf[i], kGuardFill) << "to_device overrun at " << i;
-    }
-}
-
-// Verify that memcpy_from_device reads exactly the right bytes and leaves
-// everything outside [dst, dst+size) untouched.
-void check_from_device(size_t size, size_t src_offset, size_t dst_offset) {
-    std::vector<uint8_t> src_buf(src_offset + size + kGuardBytes, 0);
-    std::vector<uint8_t> dst_buf(dst_offset + size + kGuardBytes, kGuardFill);
-
-    for (size_t i = 0; i < size; ++i) {
-        src_buf[src_offset + i] = static_cast<uint8_t>(kSrcFill + i);
-    }
-
-    const volatile void* src = reinterpret_cast<const volatile void*>(src_buf.data() + src_offset);
-    void* dst = dst_buf.data() + dst_offset;
-    memcpy_from_device(dst, src, size);
-
-    for (size_t i = 0; i < size; ++i) {
-        ASSERT_EQ(dst_buf[dst_offset + i], src_buf[src_offset + i])
-            << "from_device mismatch at byte " << i
-            << " (size=" << size << " src_off=" << src_offset << " dst_off=" << dst_offset << ")";
-    }
-    for (size_t i = 0; i < dst_offset; ++i) {
-        ASSERT_EQ(dst_buf[i], kGuardFill) << "from_device underrun at " << i;
-    }
-    for (size_t i = dst_offset + size; i < dst_buf.size(); ++i) {
-        ASSERT_EQ(dst_buf[i], kGuardFill) << "from_device overrun at " << i;
-    }
+    for (size_t i = 0; i < dst_offset; ++i)
+        ASSERT_EQ(dst_buf[i], kGuardFill) << label << " underrun at " << i;
+    for (size_t i = dst_offset + size; i < dst_buf.size(); ++i)
+        ASSERT_EQ(dst_buf[i], kGuardFill) << label << " overrun at " << i;
 }
 
 }  // namespace
@@ -104,12 +74,18 @@ class DeviceMemcpyFromDevice : public ::testing::TestWithParam<MemcpyParam> {};
 
 TEST_P(DeviceMemcpyToDevice, Correctness) {
     const auto& p = GetParam();
-    check_to_device(p.size, p.dst_off, p.src_off);
+    check_memcpy(
+        "to_device",
+        [](void* d, const void* s, size_t n) { memcpy_to_device(static_cast<volatile void*>(d), s, n); },
+        p.size, p.dst_off, p.src_off);
 }
 
 TEST_P(DeviceMemcpyFromDevice, Correctness) {
     const auto& p = GetParam();
-    check_from_device(p.size, p.src_off, p.dst_off);
+    check_memcpy(
+        "from_device",
+        [](void* d, const void* s, size_t n) { memcpy_from_device(d, static_cast<const volatile void*>(s), n); },
+        p.size, p.dst_off, p.src_off);
 }
 
 // clang-format off

--- a/tests/api/test_device_memcpy.cpp
+++ b/tests/api/test_device_memcpy.cpp
@@ -17,9 +17,8 @@
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <cstdint>
-#include <numeric>
+#include <string>
 #include <vector>
 
 #include "pcie/device_memcpy.hpp"
@@ -130,11 +129,19 @@ static const MemcpyParam kCases[] = {
     {64,   1, 0}, {64,   2, 0}, {64,   3, 0},
     {256,  1, 0}, {256,  2, 0}, {256,  3, 0},
     {1024, 1, 0}, {1024, 3, 0},
+    // --- 4-byte-aligned but 16-byte-misaligned: triggers GNUC 16-byte alignment loop ---
+    {256,  4, 0}, {256,  8, 0}, {256, 12, 0},
+    {1024, 4, 0}, {1024, 8, 0}, {1024, 12, 0},
     // --- Unaligned source ---
     {64,   0, 1}, {64,   0, 2}, {64,   0, 3},
     {256,  0, 1}, {1024, 0, 3},
+    // --- 4-byte-aligned but 16-byte-misaligned source ---
+    {256,  0, 4}, {256,  0, 8}, {256,  0, 12},
+    {1024, 0, 4}, {1024, 0, 12},
     // --- Both unaligned ---
     {64,   1, 3}, {256,  3, 1}, {1024, 2, 3},
+    // --- Both 16-byte-misaligned ---
+    {256,  4, 8}, {1024, 8, 4},
 };
 // clang-format on
 

--- a/tests/api/test_device_memcpy.cpp
+++ b/tests/api/test_device_memcpy.cpp
@@ -13,7 +13,7 @@
 //   Phase 2 — remaining 32-byte chunks
 //   Phase 3 — remaining 16-byte chunk
 //   Phase 4 — remaining 4-byte chunks
-//   Phase 5 — trailing 1–3 bytes
+//   Phase 5 — trailing 1–3 bytes.
 
 #include <gtest/gtest.h>
 
@@ -42,19 +42,23 @@ void check_memcpy(const char* label, Fn fn, size_t size, size_t dst_offset, size
     std::vector<uint8_t> dst_buf(dst_offset + size + kGuardBytes, kGuardFill);
 
     // Recognisable pattern that wraps to catch byte-swaps.
-    for (size_t i = 0; i < size; ++i)
+    for (size_t i = 0; i < size; ++i) {
         src_buf[src_offset + i] = static_cast<uint8_t>(kSrcFill + i);
+    }
 
     fn(dst_buf.data() + dst_offset, src_buf.data() + src_offset, size);
 
-    for (size_t i = 0; i < size; ++i)
+    for (size_t i = 0; i < size; ++i) {
         ASSERT_EQ(dst_buf[dst_offset + i], src_buf[src_offset + i])
-            << label << " mismatch at byte " << i
-            << " (size=" << size << " dst_off=" << dst_offset << " src_off=" << src_offset << ")";
-    for (size_t i = 0; i < dst_offset; ++i)
+            << label << " mismatch at byte " << i << " (size=" << size << " dst_off=" << dst_offset
+            << " src_off=" << src_offset << ")";
+    }
+    for (size_t i = 0; i < dst_offset; ++i) {
         ASSERT_EQ(dst_buf[i], kGuardFill) << label << " underrun at " << i;
-    for (size_t i = dst_offset + size; i < dst_buf.size(); ++i)
+    }
+    for (size_t i = dst_offset + size; i < dst_buf.size(); ++i) {
         ASSERT_EQ(dst_buf[i], kGuardFill) << label << " overrun at " << i;
+    }
 }
 
 }  // namespace
@@ -70,6 +74,7 @@ struct MemcpyParam {
 };
 
 class DeviceMemcpyToDevice : public ::testing::TestWithParam<MemcpyParam> {};
+
 class DeviceMemcpyFromDevice : public ::testing::TestWithParam<MemcpyParam> {};
 
 TEST_P(DeviceMemcpyToDevice, Correctness) {
@@ -77,7 +82,9 @@ TEST_P(DeviceMemcpyToDevice, Correctness) {
     check_memcpy(
         "to_device",
         [](void* d, const void* s, size_t n) { memcpy_to_device(static_cast<volatile void*>(d), s, n); },
-        p.size, p.dst_off, p.src_off);
+        p.size,
+        p.dst_off,
+        p.src_off);
 }
 
 TEST_P(DeviceMemcpyFromDevice, Correctness) {
@@ -85,7 +92,9 @@ TEST_P(DeviceMemcpyFromDevice, Correctness) {
     check_memcpy(
         "from_device",
         [](void* d, const void* s, size_t n) { memcpy_from_device(d, static_cast<const volatile void*>(s), n); },
-        p.size, p.dst_off, p.src_off);
+        p.size,
+        p.dst_off,
+        p.src_off);
 }
 
 // clang-format off

--- a/tests/api/test_device_memcpy.cpp
+++ b/tests/api/test_device_memcpy.cpp
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Off-device correctness tests for memcpy_to_device / memcpy_from_device.
+//
+// These tests exercise all internal phases using a heap buffer as a
+// stand-in for device MMIO (volatile void*). No hardware is required.
+//
+// Phase coverage:
+//   Phase 0 — byte-by-byte alignment of the destination to 4 bytes
+//   Phase 1 — bulk 256-byte blocks (AVX2 on x86; STNP Q pairs on AArch64)
+//   Phase 2 — remaining 32-byte chunks
+//   Phase 3 — remaining 16-byte chunk
+//   Phase 4 — remaining 4-byte chunks
+//   Phase 5 — trailing 1–3 bytes
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <vector>
+
+#include "pcie/device_memcpy.hpp"
+
+using namespace tt::umd;
+
+namespace {
+
+// Pad on each side to catch over-reads / over-writes.
+constexpr size_t kGuardBytes = 64;
+constexpr uint8_t kGuardFill = 0xAB;
+constexpr uint8_t kSrcFill = 0x42;
+
+// Verify that memcpy_to_device writes exactly the right bytes and leaves
+// everything outside [dst_offset, dst_offset+size) untouched.
+void check_to_device(size_t size, size_t dst_offset, size_t src_offset) {
+    std::vector<uint8_t> src_buf(src_offset + size + kGuardBytes, 0);
+    std::vector<uint8_t> dst_buf(dst_offset + size + kGuardBytes, kGuardFill);
+
+    // Recognisable pattern that wraps to catch byte-swaps.
+    for (size_t i = 0; i < size; ++i) {
+        src_buf[src_offset + i] = static_cast<uint8_t>(kSrcFill + i);
+    }
+
+    volatile void* dst = reinterpret_cast<volatile void*>(dst_buf.data() + dst_offset);
+    const void* src = src_buf.data() + src_offset;
+    memcpy_to_device(dst, src, size);
+
+    for (size_t i = 0; i < size; ++i) {
+        ASSERT_EQ(dst_buf[dst_offset + i], src_buf[src_offset + i])
+            << "to_device mismatch at byte " << i
+            << " (size=" << size << " dst_off=" << dst_offset << " src_off=" << src_offset << ")";
+    }
+    for (size_t i = 0; i < dst_offset; ++i) {
+        ASSERT_EQ(dst_buf[i], kGuardFill) << "to_device underrun at " << i;
+    }
+    for (size_t i = dst_offset + size; i < dst_buf.size(); ++i) {
+        ASSERT_EQ(dst_buf[i], kGuardFill) << "to_device overrun at " << i;
+    }
+}
+
+// Verify that memcpy_from_device reads exactly the right bytes and leaves
+// everything outside [dst, dst+size) untouched.
+void check_from_device(size_t size, size_t src_offset, size_t dst_offset) {
+    std::vector<uint8_t> src_buf(src_offset + size + kGuardBytes, 0);
+    std::vector<uint8_t> dst_buf(dst_offset + size + kGuardBytes, kGuardFill);
+
+    for (size_t i = 0; i < size; ++i) {
+        src_buf[src_offset + i] = static_cast<uint8_t>(kSrcFill + i);
+    }
+
+    const volatile void* src = reinterpret_cast<const volatile void*>(src_buf.data() + src_offset);
+    void* dst = dst_buf.data() + dst_offset;
+    memcpy_from_device(dst, src, size);
+
+    for (size_t i = 0; i < size; ++i) {
+        ASSERT_EQ(dst_buf[dst_offset + i], src_buf[src_offset + i])
+            << "from_device mismatch at byte " << i
+            << " (size=" << size << " src_off=" << src_offset << " dst_off=" << dst_offset << ")";
+    }
+    for (size_t i = 0; i < dst_offset; ++i) {
+        ASSERT_EQ(dst_buf[i], kGuardFill) << "from_device underrun at " << i;
+    }
+    for (size_t i = dst_offset + size; i < dst_buf.size(); ++i) {
+        ASSERT_EQ(dst_buf[i], kGuardFill) << "from_device overrun at " << i;
+    }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Parameterised correctness: {size, dst_misalignment, src_misalignment}
+// ---------------------------------------------------------------------------
+
+struct MemcpyParam {
+    size_t size;
+    size_t dst_off;
+    size_t src_off;
+};
+
+class DeviceMemcpyToDevice : public ::testing::TestWithParam<MemcpyParam> {};
+class DeviceMemcpyFromDevice : public ::testing::TestWithParam<MemcpyParam> {};
+
+TEST_P(DeviceMemcpyToDevice, Correctness) {
+    const auto& p = GetParam();
+    check_to_device(p.size, p.dst_off, p.src_off);
+}
+
+TEST_P(DeviceMemcpyFromDevice, Correctness) {
+    const auto& p = GetParam();
+    check_from_device(p.size, p.src_off, p.dst_off);
+}
+
+// clang-format off
+static const MemcpyParam kCases[] = {
+    // --- Phase 5 only (< 4 bytes, no 4B store) ---
+    {1, 0, 0}, {2, 0, 0}, {3, 0, 0},
+    // --- Phase 4 tail (4-byte stores, no SIMD) ---
+    {4, 0, 0}, {5, 0, 0}, {7, 0, 0}, {8, 0, 0}, {12, 0, 0}, {15, 0, 0},
+    // --- Phase 3 (16-byte chunk) ---
+    {16, 0, 0}, {17, 0, 0}, {19, 0, 0}, {31, 0, 0},
+    // --- Phase 2 (32-byte chunks) ---
+    {32, 0, 0}, {33, 0, 0}, {47, 0, 0}, {63, 0, 0}, {64, 0, 0},
+    // --- Phase 1 (bulk 256-byte blocks) ---
+    {256, 0, 0}, {257, 0, 0}, {512, 0, 0}, {768, 0, 0},
+    {1024, 0, 0}, {4096, 0, 0}, {16384, 0, 0},
+    // --- Unaligned destination: triggers Phase 0 byte-alignment loop ---
+    {64,   1, 0}, {64,   2, 0}, {64,   3, 0},
+    {256,  1, 0}, {256,  2, 0}, {256,  3, 0},
+    {1024, 1, 0}, {1024, 3, 0},
+    // --- Unaligned source ---
+    {64,   0, 1}, {64,   0, 2}, {64,   0, 3},
+    {256,  0, 1}, {1024, 0, 3},
+    // --- Both unaligned ---
+    {64,   1, 3}, {256,  3, 1}, {1024, 2, 3},
+};
+// clang-format on
+
+INSTANTIATE_TEST_SUITE_P(
+    AllPhasesAndAlignments,
+    DeviceMemcpyToDevice,
+    ::testing::ValuesIn(kCases),
+    [](const ::testing::TestParamInfo<MemcpyParam>& info) {
+        return "sz" + std::to_string(info.param.size) + "_d" + std::to_string(info.param.dst_off) + "_s" +
+               std::to_string(info.param.src_off);
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    AllPhasesAndAlignments,
+    DeviceMemcpyFromDevice,
+    ::testing::ValuesIn(kCases),
+    [](const ::testing::TestParamInfo<MemcpyParam>& info) {
+        return "sz" + std::to_string(info.param.size) + "_d" + std::to_string(info.param.dst_off) + "_s" +
+               std::to_string(info.param.src_off);
+    });


### PR DESCRIPTION
Add wide load/store paths to memcpy_to_device and memcpy_from_device using GCC vector extensions (__attribute__((vector_size))) and __builtin_memcpy.  On AArch64 this lowers to LDP/STP (NEON load/store pairs), issuing each device address exactly once.

For writes (to_device), Clang's __builtin_nontemporal_store produces STNP (non-temporal store pair) which bypasses the CPU cache so data goes straight to the PCIe write buffer.  GCC falls back to regular STP.  A 2 KB software prefetch hides source DRAM latency.

For reads (from_device), both compilers emit LDP/STP + PRFM prefetch.

Guard restructured from __has_builtin(__builtin_nontemporal_store) (Clang-only) to defined(__GNUC__) so both GCC and Clang get the wide path, with the non-temporal store conditional kept inside the block.

82 off-device correctness tests covering all internal phases (alignment, 32/16/4/1-byte tails, 256-byte bulk blocks) and several dst/src misalignment combinations.