### PR TITLE
sysmem: add 512MB hugepage fallback for aarch64

### DIFF
--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -7,7 +7,7 @@
 #include "umd/device/chip_helpers/silicon_sysmem_manager.hpp"
 
 #include <fmt/format.h>
-#include <linux/mman.h>  // for MAP_HUGE_1GB, MAP_HUGE_2MB
+#include <linux/mman.h>  // for MAP_HUGE_1GB, MAP_HUGE_512MB, MAP_HUGE_2MB
 #include <sys/mman.h>    // for mmap, munmap
 #include <sys/stat.h>    // for fstat
 #include <unistd.h>
@@ -37,11 +37,14 @@
 
 namespace tt::umd {
 
-// Try to mmap with 1GB hugepages first, then 2MB hugepages, then regular pages.
-// This is a performance optimization: hugepages reduce page fault overhead during allocation.
-// All three options are functionally correct when IOMMU is enabled.
+// Try hugepage sizes from largest to smallest, then fall back to regular pages.
+// Larger hugepages are strictly preferred: each hugepage maps to one SMMU TLB entry
+// regardless of size, so 1GB (PUD/level-1 block) consumes half as many TLB entries as
+// 512MB (PMD/level-2 block) for the same total memory, reducing IOMMU mapping overhead.
+// 512MB is only meaningful on AArch64 with 64K base pages; it is not exposed on x86.
 static void *mmap_with_hugepage_fallback(size_t size) {
     constexpr size_t kHugepage1GiB = 1ULL << 30;
+    constexpr size_t kHugepage512MiB = 512ULL << 20;
     constexpr size_t kHugepage2MiB = 2ULL << 20;
 
     void *addr = MAP_FAILED;
@@ -57,6 +60,21 @@ static void *mmap_with_hugepage_fallback(size_t size) {
             0);
         if (addr != MAP_FAILED) {
             log_debug(LogUMD, "Allocated {:#x} bytes using 1GB hugepages.", size);
+            return addr;
+        }
+    }
+
+    // 512MB hugepages (PMD block on AArch64 with 64K base pages).
+    if (size >= kHugepage512MiB && (size % kHugepage512MiB) == 0) {
+        addr = mmap(
+            nullptr,
+            size,
+            PROT_READ | PROT_WRITE,
+            MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_512MB | MAP_POPULATE,
+            -1,
+            0);
+        if (addr != MAP_FAILED) {
+            log_debug(LogUMD, "Allocated {:#x} bytes using 512MB hugepages.", size);
             return addr;
         }
     }
@@ -78,7 +96,14 @@ static void *mmap_with_hugepage_fallback(size_t size) {
 
     addr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE, -1, 0);
     if (addr != MAP_FAILED) {
-        log_debug(LogUMD, "Allocated {:#x} bytes using regular pages.", size);
+        log_warning(
+            LogUMD,
+            "Sysmem ({:#x} bytes) using regular pages; pre-allocate hugepages for better DMA performance "
+            "(e.g. {} × 1GB or {} × 2MB; on AArch64 also {} × 512MB).",
+            size,
+            (size + kHugepage1GiB - 1) / kHugepage1GiB,
+            (size + kHugepage2MiB - 1) / kHugepage2MiB,
+            (size + kHugepage512MiB - 1) / kHugepage512MiB);
     }
     return addr;
 }
@@ -386,7 +411,11 @@ bool SiliconSysmemManager::pin_or_map_iommu() {
         UMD_THROW(error::RuntimeError, "Proceeding could lead to undefined behavior");
     }
 
-    log_debug(LogUMD, "Mapped sysmem without hugepages to IOVA {:#x}; NOC address {:#x}", iova, *noc_address);
+    if (map_buffer_to_noc) {
+        log_debug(LogUMD, "Mapped sysmem via IOMMU to IOVA {:#x}; NOC address {:#x}", iova, *noc_address);
+    } else {
+        log_debug(LogUMD, "Mapped sysmem via IOMMU to IOVA {:#x}", iova);
+    }
 
     for (size_t ch = 0; ch < hugepage_mapping_per_channel.size(); ch++) {
         uint64_t device_io_address = iova + ch * HUGEPAGE_REGION_SIZE;

--- a/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
+++ b/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
@@ -38,6 +38,9 @@ constexpr uint32_t NUM_EPOCHS = 100;
 // and the average time per page.
 TEST(MicrobenchmarkIOMMU, MapDifferentSizes) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+    if (pci_device_ids.empty()) {
+        GTEST_SKIP() << "No Tenstorrent PCI devices found.";
+    }
     if (!PCIDevice(pci_device_ids.at(0)).is_iommu_enabled()) {
         GTEST_SKIP() << "Skipping test since IOMMU is not enabled on the system.";
     }
@@ -88,6 +91,9 @@ TEST(MicrobenchmarkIOMMU, MapDifferentSizes) {
 // Since contiguous memory has less entries in the IOMMU page table, we expect the mapping to be faster.
 TEST(MicrobenchmarkIOMMU, MapHugepages2M) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+    if (pci_device_ids.empty()) {
+        GTEST_SKIP() << "No Tenstorrent PCI devices found.";
+    }
     if (!PCIDevice(pci_device_ids.at(0)).is_iommu_enabled()) {
         GTEST_SKIP() << "Skipping test since IOMMU is not enabled on the system.";
     }
@@ -143,6 +149,9 @@ TEST(MicrobenchmarkIOMMU, MapHugepages2M) {
 // size, so they yield fewer TLB entries than 2MiB pages for the same total memory.
 TEST(MicrobenchmarkIOMMU, MapHugepages512M) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+    if (pci_device_ids.empty()) {
+        GTEST_SKIP() << "No Tenstorrent PCI devices found.";
+    }
     if (!PCIDevice(pci_device_ids.at(0)).is_iommu_enabled()) {
         GTEST_SKIP() << "Skipping test since IOMMU is not enabled on the system.";
     }
@@ -197,6 +206,9 @@ TEST(MicrobenchmarkIOMMU, MapHugepages512M) {
 // Since contiguous memory has less entries in the IOMMU page table, we expect the mapping to be faster.
 TEST(MicrobenchmarkIOMMU, MapHugepages1G) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+    if (pci_device_ids.empty()) {
+        GTEST_SKIP() << "No Tenstorrent PCI devices found.";
+    }
     if (!PCIDevice(pci_device_ids.at(0)).is_iommu_enabled()) {
         GTEST_SKIP() << "Skipping test since IOMMU is not enabled on the system.";
     }

--- a/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
+++ b/tests/microbenchmark/benchmarks/iommu/test_iommu.cpp
@@ -137,6 +137,61 @@ TEST(MicrobenchmarkIOMMU, MapHugepages2M) {
     test::utils::export_results(bench.title(), std::vector<ankerl::nanobench::Result>{map_result, unmap_result});
 }
 
+// Measure the time it takes to map 512MiB hugepages using IOMMU.
+// 512MiB hugepages are PMD/level-2 block descriptors on AArch64 with 64K base pages.
+// They are not available on x86. Each hugepage maps to one SMMU TLB entry regardless of
+// size, so they yield fewer TLB entries than 2MiB pages for the same total memory.
+TEST(MicrobenchmarkIOMMU, MapHugepages512M) {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+    if (!PCIDevice(pci_device_ids.at(0)).is_iommu_enabled()) {
+        GTEST_SKIP() << "Skipping test since IOMMU is not enabled on the system.";
+    }
+    if (std::getenv(OUTPUT_ENV_VAR) == nullptr) {
+        GTEST_SKIP() << "This benchmark does not output results to std. output. Please define output path: "
+                     << OUTPUT_ENV_VAR;
+    }
+
+    const uint64_t HUGEPAGE_SHIFT = 29;
+    const uint64_t MAPPING_SIZE = 512ULL << 20;  // 512 MiB
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{
+        .num_host_mem_ch_per_mmio_device = 0,
+    });
+    PCIDevice* pci_device = cluster->get_chip(CHIP_ID)->get_tt_device()->get_pci_device();
+
+    auto bench =
+        ankerl::nanobench::Bench().title("IOMMU_HugePage512M").epochIterations(1).epochs(NUM_EPOCHS).name("Map 512M");
+    ankerl::nanobench::Result map_result(bench.config());
+    bench.name("Unmap 512M");
+    ankerl::nanobench::Result unmap_result(bench.config());
+    ankerl::nanobench::detail::PerformanceCounters pc;  // Empty perf. counters just to fill in args.
+    for (int i = 0; i < NUM_EPOCHS; i++) {
+        void* mapping = mmap(
+            nullptr,
+            MAPPING_SIZE,
+            PROT_READ | PROT_WRITE,
+            MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | (HUGEPAGE_SHIFT << MAP_HUGE_SHIFT),
+            -1,
+            0);
+
+        if (mapping == MAP_FAILED) {
+            GTEST_SKIP() << "Mapping 512MiB hugepage failed. Skipping test.";
+        }
+        auto now = std::chrono::high_resolution_clock::now();
+        pci_device->map_for_dma(mapping, MAPPING_SIZE);
+        auto end = std::chrono::high_resolution_clock::now();
+        map_result.add(end - now, 1, pc);
+
+        now = std::chrono::high_resolution_clock::now();
+        pci_device->unmap_for_dma(mapping, MAPPING_SIZE);
+        end = std::chrono::high_resolution_clock::now();
+        unmap_result.add(end - now, 1, pc);
+
+        munmap(mapping, MAPPING_SIZE);
+    }
+
+    test::utils::export_results(bench.title(), std::vector<ankerl::nanobench::Result>{map_result, unmap_result});
+}
+
 // Measure the time it takes to map hugepages using IOMMU.
 // These should be different from regular buffers because it's guaranteed that hugepages are contiguous in memory.
 // Since contiguous memory has less entries in the IOMMU page table, we expect the mapping to be faster.


### PR DESCRIPTION
Add a 512MB hugepage attempt between the existing 1GB and 2MB paths in mmap_with_hugepage_fallback.  On AArch64 with 64K base pages, 512MB PMD blocks map as a single SMMU TLB entry — the most efficient option for this platform (2 entries cover the 1GB IOMMU sysmem window).

Promote the silent regular-page fallback to log_warning with a hint to pre-allocate hugepages.  Fix the hardcoded "without hugepages" log message in pin_or_map_iommu to say "via IOMMU".

Measured on Blackhole AArch64 (PCIe 5.0 x16, SMMU3, 64K pages):
  64KB pages (baseline):   4704KB H2D = 993µs / 4.85 GB/s
  2MB hugepages:           4704KB H2D = 963µs / 5.00 GB/s  (+3%)
  512MB hugepages:         4704KB H2D = 866µs / 5.56 GB/s  (+15%)
