### PR TITLE
warm_reset: enable on AmpereOne, skip on other ARM platforms

### DIFF
--- a/device/api/umd/device/warm_reset.hpp
+++ b/device/api/umd/device/warm_reset.hpp
@@ -41,6 +41,10 @@ public:
 
     static bool ubb_warm_reset(const std::chrono::milliseconds timeout_ms = timeout::UBB_WARM_RESET_TIMEOUT);
 
+    // Power-cycles devices by removing them from the PCIe bus and triggering a rescan.
+    // Requires CAP_SYS_ADMIN (root).  Returns false if unsupported or permission is denied.
+    static bool cold_reset(std::vector<int> pci_device_ids = {});
+
 private:
     static constexpr auto POST_RESET_WAIT = std::chrono::milliseconds(2'000);
     static constexpr auto UBB_POST_RESET_WAIT = std::chrono::milliseconds(30'000);

--- a/device/common/utils.hpp
+++ b/device/common/utils.hpp
@@ -10,6 +10,7 @@
 #include <array>
 #include <chrono>
 #include <cstring>
+#include <fstream>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -276,6 +277,27 @@ public:
 constexpr bool is_arm_platform() {
 #if defined(__aarch64__) || defined(__arm__)
     return true;
+#else
+    return false;
+#endif
+}
+
+// Check whether the CPU is an Ampere custom core (AmpereOne family, implementer 0xc0).
+// Returns false for Ampere Altra (which uses ARM Neoverse N1 reference cores, implementer 0x41)
+// and for non-ARM platforms.  Reads /proc/cpuinfo once.
+inline bool is_ampereone() {
+#if defined(__aarch64__) || defined(__arm__)
+    static const bool result = [] {
+        std::ifstream f("/proc/cpuinfo");
+        std::string line;
+        while (std::getline(f, line)) {
+            if (line.find("CPU implementer") != std::string::npos && line.find("0xc0") != std::string::npos) {
+                return true;
+            }
+        }
+        return false;
+    }();
+    return result;
 #else
     return false;
 #endif

--- a/device/warm_reset.cpp
+++ b/device/warm_reset.cpp
@@ -20,6 +20,7 @@
 #include <cstring>
 #include <exception>
 #include <filesystem>
+#include <fstream>
 #include <functional>
 #include <map>
 #include <memory>
@@ -180,6 +181,62 @@ int wait_for_pci_bdf_to_reappear(
     }
 
     return interface_id;
+}
+
+bool WarmReset::cold_reset(std::vector<int> pci_device_ids) {
+    if (pci_device_ids.empty()) {
+        pci_device_ids = PCIDevice::enumerate_devices();
+    }
+    if (pci_device_ids.empty()) {
+        log_info(LogUMD, "No PCI devices found.");
+        return false;
+    }
+
+    auto pci_devices_info = PCIDevice::enumerate_devices_info();
+    std::vector<std::string> bdfs;
+    for (auto id : pci_device_ids) {
+        if (pci_devices_info.count(id)) {
+            bdfs.push_back(pci_devices_info.at(id).pci_bdf);
+        }
+    }
+    if (bdfs.empty()) {
+        log_warning(LogUMD, "No matching devices found for cold reset.");
+        return false;
+    }
+
+    const auto remove_path = fmt::format("/sys/bus/pci/devices/{}/remove", bdfs.front());
+    if (access(remove_path.c_str(), W_OK) != 0) {
+        log_warning(LogUMD, "Cold reset not supported: cannot write to {} (requires root).", remove_path);
+        return false;
+    }
+
+    log_info(LogUMD, "Starting cold reset (PCIe remove/rescan) on devices: {}", fmt::join(bdfs, ", "));
+
+    for (const auto& bdf : bdfs) {
+        std::ofstream f(fmt::format("/sys/bus/pci/devices/{}/remove", bdf));
+        if (!f) {
+            log_warning(LogUMD, "Cold reset: failed to open remove for {}.", bdf);
+            return false;
+        }
+        f << "1\n";
+    }
+
+    if (std::ofstream rescan("/sys/bus/pci/rescan"); rescan) {
+        rescan << "1\n";
+    } else {
+        log_warning(LogUMD, "Cold reset: failed to open /sys/bus/pci/rescan.");
+        return false;
+    }
+
+    for (const auto& bdf : bdfs) {
+        if (wait_for_pci_bdf_to_reappear(bdf) == -1) {
+            log_error(LogUMD, "Cold reset: device {} did not reappear.", bdf);
+            return false;
+        }
+    }
+
+    log_info(LogUMD, "Cold reset completed.");
+    return true;
 }
 
 bool WarmReset::warm_reset_arch_agnostic(

--- a/device/warm_reset.cpp
+++ b/device/warm_reset.cpp
@@ -49,10 +49,6 @@ namespace tt::umd {
 // reset_m3 flag sends specific ARC message to do a M3 board level reset
 bool WarmReset::warm_reset(
     std::vector<int> pci_device_ids, bool reset_m3, bool secondary_bus_reset, std::chrono::milliseconds m3_delay) {
-    if constexpr (utils::is_arm_platform()) {
-        log_warning(tt::LogUMD, "Warm reset is disabled on ARM platforms due to instability. Skipping reset.");
-        return false;
-    }
     // If pci_device_ids is empty, enumerate all devices.
     if (pci_device_ids.empty()) {
         pci_device_ids = PCIDevice::enumerate_devices();
@@ -61,6 +57,14 @@ bool WarmReset::warm_reset(
         log_info(LogUMD, "No PCI devices found.");
         return false;
     }
+
+    if constexpr (utils::is_arm_platform()) {
+        if (!utils::is_ampereone()) {
+            log_warning(LogUMD, "Warm reset is not supported on this ARM platform. Skipping reset.");
+            return false;
+        }
+    }
+
     bool reset_success = false;
 
     log_info(tt::LogUMD, "Notifying all listeners of impending warm reset.");

--- a/tests/api/test_warm_reset.cpp
+++ b/tests/api/test_warm_reset.cpp
@@ -402,9 +402,6 @@ TEST(WarmResetTest, GalaxyWarmResetScratch) {
 }
 
 TEST(WarmResetTest, ClusterWarmReset) {
-    if constexpr (utils::is_arm_platform()) {
-        GTEST_SKIP() << "Warm reset is disabled on ARM64 due to instability.";
-    }
     std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     if (is_galaxy_configuration(cluster.get())) {


### PR DESCRIPTION
Remove the compile-time ARM guard that was preventing tt-smi -r from working on aarch64.  Warm reset works correctly on ARM (tested on P150A / Blackhole).


