### PR TITLE
ci: fail-fast watchers fire on cancelled (timeout) needs

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -282,7 +282,9 @@ jobs:
   # One watcher per job by design — a single watcher with multi-job `needs` would wait for
   # every need to settle before evaluating `if: failure()`, defeating the purpose.
   fail-fast-build-tests:
-    if: failure() && inputs.triggering-event == 'merge_group'
+    if: |
+      always() && inputs.triggering-event == 'merge_group' &&
+      contains(fromJSON('["failure", "cancelled"]'), needs.build-tests.result)
     needs: [build-tests]
     runs-on: ubuntu-latest
     permissions:
@@ -291,7 +293,9 @@ jobs:
       - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
 
   fail-fast-test-all:
-    if: failure() && inputs.triggering-event == 'merge_group'
+    if: |
+      always() && inputs.triggering-event == 'merge_group' &&
+      contains(fromJSON('["failure", "cancelled"]'), needs.test-all.result)
     needs: [test-all]
     runs-on: ubuntu-latest
     permissions:
@@ -300,7 +304,9 @@ jobs:
       - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
 
   fail-fast-ttsim:
-    if: failure() && inputs.triggering-event == 'merge_group'
+    if: |
+      always() && inputs.triggering-event == 'merge_group' &&
+      contains(fromJSON('["failure", "cancelled"]'), needs.run-ttsim-tests.result)
     needs: [run-ttsim-tests]
     runs-on: ubuntu-latest
     permissions:
@@ -309,7 +315,9 @@ jobs:
       - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
 
   fail-fast-tooling:
-    if: failure() && inputs.triggering-event == 'merge_group'
+    if: |
+      always() && inputs.triggering-event == 'merge_group' &&
+      contains(fromJSON('["failure", "cancelled"]'), needs.run-tooling-tests.result)
     needs: [run-tooling-tests]
     runs-on: ubuntu-latest
     permissions:
@@ -318,7 +326,9 @@ jobs:
       - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
 
   fail-fast-exalens:
-    if: failure() && inputs.triggering-event == 'merge_group'
+    if: |
+      always() && inputs.triggering-event == 'merge_group' &&
+      contains(fromJSON('["failure", "cancelled"]'), needs.run-exalens-tests.result)
     needs: [run-exalens-tests]
     runs-on: ubuntu-latest
     permissions:
@@ -327,7 +337,9 @@ jobs:
       - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
 
   fail-fast-tracy:
-    if: failure() && inputs.triggering-event == 'merge_group'
+    if: |
+      always() && inputs.triggering-event == 'merge_group' &&
+      contains(fromJSON('["failure", "cancelled"]'), needs.run-tracy.result)
     needs: [run-tracy]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
### Issue

Closes #2718.

### Description

The fail-fast watchers in `build-and-run-all-tests.yml` used `if: failure() && triggering-event == 'merge_group'` to cancel the sibling matrix when a test job failed. GitHub Actions reports a `timeout-minutes` expiry as `cancelled`, not `failure`, and `failure()` does not return true for cancelled needs — so a job timeout (e.g. the ttsim job hitting its 30 min cap, as seen on PR #2714's queue attempts) would not trigger the early cancel, and the rest of the matrix kept running to completion. The aggregator job `all-builds-passed` eventually catches the cancelled state, so the merge queue still rejected the run, but ~25 minutes of sibling CI compute was wasted per attempt.

This PR broadens each watcher's `if` to also fire on `cancelled`.

### List of the changes

- `.github/workflows/build-and-run-all-tests.yml`: each of the six `fail-fast-*` jobs now uses `always() && triggering-event == 'merge_group' && contains(fromJSON('["failure", "cancelled"]'), needs.<job>.result)`. `always()` is required so the watcher is not skipped when its needs job is cancelled; the `contains()` filter keeps it from firing on success/skipped.

### Testing

CI

### API Changes

None.