### PR TITLE
Fix Quasar throw in Cluster assert/deassert risc reset

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -433,17 +433,20 @@ std::set<ChipId> Cluster::get_target_mmio_device_ids() { return local_chip_ids_;
 std::set<ChipId> Cluster::get_target_remote_device_ids() { return remote_chip_ids_; }
 
 void Cluster::assert_risc_reset() {
-    // Raise reset signal for all cores.
-    uint32_t reset_reg_value =
-        architecture_implementation::create(arch_name)->get_soft_reset_reg_value(RiscType::ALL_TENSIX);
+    // Raise reset signal for all cores. RiscType::ALL is the architecture-agnostic flag that each
+    // implementation maps to its own all-cores set (ALL_TENSIX for Tensix, ALL_NEO for NEO).
+    uint32_t reset_reg_value = architecture_implementation::create(arch_name)->get_soft_reset_reg_value(RiscType::ALL);
     broadcast_tensix_risc_reset_to_cluster(reset_reg_value);
 }
 
 void Cluster::deassert_risc_reset() {
-    // Lower the reset signal for BRISC only, with staggered start enabled.
+    // Lower the reset signal for the primary data-movement core only (BRISC on Tensix,
+    // DM0 on NEO), with staggered start enabled. The primary DM then brings up the others.
     auto arch_impl = architecture_implementation::create(arch_name);
-    uint32_t reset_reg_value = arch_impl->get_soft_reset_reg_value(RiscType::ALL_TENSIX & ~RiscType::BRISC) |
-                               arch_impl->get_soft_reset_staggered_start();
+    RiscType cores_under_reset = (arch_name == tt::ARCH::QUASAR) ? (RiscType::ALL_NEO & ~RiscType::DM0)
+                                                                 : (RiscType::ALL_TENSIX & ~RiscType::BRISC);
+    uint32_t reset_reg_value =
+        arch_impl->get_soft_reset_reg_value(cores_under_reset) | arch_impl->get_soft_reset_staggered_start();
     broadcast_tensix_risc_reset_to_cluster(reset_reg_value);
 }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -435,6 +435,12 @@ std::set<ChipId> Cluster::get_target_remote_device_ids() { return remote_chip_id
 void Cluster::assert_risc_reset() {
     // Raise reset signal for all cores. RiscType::ALL is the architecture-agnostic flag that each
     // implementation maps to its own all-cores set (ALL_TENSIX for Tensix, ALL_NEO for NEO).
+    if (cluster_desc->get_arch(0) == tt::ARCH::QUASAR) {
+        for (const auto& chip : all_chip_ids_) {
+ get_chip(chip)->assert_risc_reset(RiscType::ALL);
+        }
+       return;
+    }
     uint32_t reset_reg_value = architecture_implementation::create(arch_name)->get_soft_reset_reg_value(RiscType::ALL);
     broadcast_tensix_risc_reset_to_cluster(reset_reg_value);
 }
@@ -442,6 +448,14 @@ void Cluster::assert_risc_reset() {
 void Cluster::deassert_risc_reset() {
     // Lower the reset signal for the primary data-movement core only (BRISC on Tensix,
     // DM0 on NEO), with staggered start enabled. The primary DM then brings up the others.
+
+    if (cluster_desc->get_arch(0) == tt::ARCH::QUASAR) {
+        for (const auto& chip : all_chip_ids_) {
+ get_chip(chip)->deassert_risc_reset(RiscType::ALL, false);
+        }
+       return;
+    }
+
     auto arch_impl = architecture_implementation::create(arch_name);
     RiscType cores_under_reset = (arch_name == tt::ARCH::QUASAR) ? (RiscType::ALL_NEO & ~RiscType::DM0)
                                                                  : (RiscType::ALL_TENSIX & ~RiscType::BRISC);
@@ -1041,6 +1055,14 @@ void Cluster::broadcast_tensix_risc_reset_to_cluster(uint32_t reg_value) {
         // Nowhere to broadcast to.
         return;
     }
+
+    // If ethernet broadcast is not supported, do it one by one.
+    // if (!use_ethernet_broadcast) {
+    //     for (auto& chip_id : all_chip_ids_) {
+    //         get_chip(chip_id)->assert_risc_reset(reg_value);
+    //     }
+    //     return;
+    // }
 
     std::set<ChipId> chips_to_exclude = {};
     std::set<uint32_t> rows_to_exclude;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -433,9 +433,8 @@ std::set<ChipId> Cluster::get_target_mmio_device_ids() { return local_chip_ids_;
 std::set<ChipId> Cluster::get_target_remote_device_ids() { return remote_chip_ids_; }
 
 void Cluster::assert_risc_reset() {
-    // Raise reset signal for all cores. RiscType::ALL is the architecture-agnostic flag that each
-    // implementation maps to its own all-cores set (ALL_TENSIX for Tensix, ALL_NEO for NEO).
-
+    // Workaround for quasar. Broadcast reset is not supported for quasar so we need to
+    // loop all chips and issues the reset separately.
     if (arch_name == tt::ARCH::QUASAR) {
         for (const auto& chip : all_chip_ids_) {
             get_chip(chip)->assert_risc_reset(RiscType::ALL);
@@ -443,14 +442,14 @@ void Cluster::assert_risc_reset() {
         return;
     }
 
-    uint32_t reset_reg_value = architecture_implementation::create(arch_name)->get_soft_reset_reg_value(RiscType::ALL);
+    uint32_t reset_reg_value =
+        architecture_implementation::create(arch_name)->get_soft_reset_reg_value(RiscType::ALL_TENSIX);
     broadcast_tensix_risc_reset_to_cluster(reset_reg_value);
 }
 
 void Cluster::deassert_risc_reset() {
-    // Lower the reset signal for the primary data-movement core only (BRISC on Tensix,
-    // DM0 on NEO), with staggered start enabled. The primary DM then brings up the others.
-
+    // Workaround for quasar. Broadcast reset is not supported for quasar so we need to
+    // loop all chips and issues the reset separately.
     if (arch_name == tt::ARCH::QUASAR) {
         for (const auto& chip : all_chip_ids_) {
             get_chip(chip)->deassert_risc_reset(RiscType::ALL, false);

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -435,12 +435,14 @@ std::set<ChipId> Cluster::get_target_remote_device_ids() { return remote_chip_id
 void Cluster::assert_risc_reset() {
     // Raise reset signal for all cores. RiscType::ALL is the architecture-agnostic flag that each
     // implementation maps to its own all-cores set (ALL_TENSIX for Tensix, ALL_NEO for NEO).
-    if (cluster_desc->get_arch(0) == tt::ARCH::QUASAR) {
+
+    if (arch_name == tt::ARCH::QUASAR) {
         for (const auto& chip : all_chip_ids_) {
- get_chip(chip)->assert_risc_reset(RiscType::ALL);
+            get_chip(chip)->assert_risc_reset(RiscType::ALL);
         }
-       return;
+        return;
     }
+
     uint32_t reset_reg_value = architecture_implementation::create(arch_name)->get_soft_reset_reg_value(RiscType::ALL);
     broadcast_tensix_risc_reset_to_cluster(reset_reg_value);
 }
@@ -449,18 +451,16 @@ void Cluster::deassert_risc_reset() {
     // Lower the reset signal for the primary data-movement core only (BRISC on Tensix,
     // DM0 on NEO), with staggered start enabled. The primary DM then brings up the others.
 
-    if (cluster_desc->get_arch(0) == tt::ARCH::QUASAR) {
+    if (arch_name == tt::ARCH::QUASAR) {
         for (const auto& chip : all_chip_ids_) {
- get_chip(chip)->deassert_risc_reset(RiscType::ALL, false);
+            get_chip(chip)->deassert_risc_reset(RiscType::ALL, false);
         }
-       return;
+        return;
     }
 
     auto arch_impl = architecture_implementation::create(arch_name);
-    RiscType cores_under_reset = (arch_name == tt::ARCH::QUASAR) ? (RiscType::ALL_NEO & ~RiscType::DM0)
-                                                                 : (RiscType::ALL_TENSIX & ~RiscType::BRISC);
-    uint32_t reset_reg_value =
-        arch_impl->get_soft_reset_reg_value(cores_under_reset) | arch_impl->get_soft_reset_staggered_start();
+    uint32_t reset_reg_value = arch_impl->get_soft_reset_reg_value(RiscType::ALL_TENSIX & ~RiscType::BRISC) |
+                               arch_impl->get_soft_reset_staggered_start();
     broadcast_tensix_risc_reset_to_cluster(reset_reg_value);
 }
 
@@ -1055,14 +1055,6 @@ void Cluster::broadcast_tensix_risc_reset_to_cluster(uint32_t reg_value) {
         // Nowhere to broadcast to.
         return;
     }
-
-    // If ethernet broadcast is not supported, do it one by one.
-    // if (!use_ethernet_broadcast) {
-    //     for (auto& chip_id : all_chip_ids_) {
-    //         get_chip(chip_id)->assert_risc_reset(reg_value);
-    //     }
-    //     return;
-    // }
 
     std::set<ChipId> chips_to_exclude = {};
     std::set<uint32_t> rows_to_exclude;


### PR DESCRIPTION
### Issue

#2708 

### Description
`Cluster::assert_risc_reset` / `deassert_risc_reset` previously called `architecture_implementation::create(arch_name)->get_soft_reset_reg_value(RiscType::ALL_TENSIX)` unconditionally. On Quasar the implementation throws because `ALL_TENSIX` is not a valid mapping — Quasar uses `ALL_NEO` / `DM0` instead of `ALL_TENSIX` / `BRISC`. Broadcast reset is also not supported on Quasar.

This PR adds a Quasar-specific path that loops over all chips and delegates to the per-chip `assert_risc_reset(RiscType::ALL)` / `deassert_risc_reset(RiscType::ALL, false)`, where `RiscType::ALL` is the architecture-agnostic flag the Quasar implementation maps to `ALL_NEO`. The Wormhole/Blackhole broadcast path is unchanged.

### List of the changes
- `device/cluster.cpp`
  - `assert_risc_reset()`: on Quasar, loop over `all_chip_ids_` and call per-chip `assert_risc_reset(RiscType::ALL)`; otherwise keep the existing broadcast path using `ALL_TENSIX`.
  - `deassert_risc_reset()`: on Quasar, loop over `all_chip_ids_` and call per-chip `deassert_risc_reset(RiscType::ALL, false)`; otherwise keep the existing `ALL_TENSIX & ~BRISC | staggered_start` broadcast path.
  - Removed a stale commented-out `if (!use_ethernet_broadcast)` scaffold in `broadcast_tensix_risc_reset_to_cluster`.

### Testing
CI

### API Changes
None.