### PR TITLE
ci(ttsim): run tt-metal Quasar Bmm test against tt-sim quasar

### DIFF
--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -190,6 +190,17 @@ jobs:
         run: |
           tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
 
+      - name: Run tt-metal on tt-sim quasar
+        timeout-minutes: 5
+        env:
+          TT_METAL_SIMULATOR_HOME: ${{ github.workspace }}/sim_qsr
+          TT_METAL_SIMULATOR: ${{ github.workspace }}/sim_qsr/libttsim.so
+          TT_METAL_SLOW_DISPATCH_MODE: 1
+        run: |
+          cd tt-metal
+          ./build/test/tt_metal/unit_tests_legacy \
+            --gtest_filter="QuasarMeshDeviceSingleCardFixture.BmmMultinode"
+
       # Galaxy tests can be a bit longer, should run on the order of minutes.
       - name: Run tt-metal C++ unit test on tt-sim galaxy wormhole_b0
         timeout-minutes: 5


### PR DESCRIPTION
### Issue

Closes #2725.

### Description
`.github/workflows/run-ttsim-tests.yml` already builds tt-metal and runs WH/BH tt-metal binaries against TTSim, but the tt-metal Quasar surface wasn't exercised — only the UMD `TestDeviceIOFixture` / `TTSimDeviceIOFixture` lanes covered Quasar.

This adds a step that runs tt-metal's `QuasarMeshDeviceSingleCardFixture.BmmMultinode` from `unit_tests_legacy` against the existing `sim_qsr/libttsim.so`. The test was purpose-built for multi-neo emu/sim builds (per its in-source comment in `tests/tt_metal/tt_metal/test_bmm.cpp`), and the Quasar fixture only gates on `arch == QUASAR` — no simulator-vs-hardware gating — so the existing Quasar TTSim setup is sufficient.

### List of the changes
- `.github/workflows/run-ttsim-tests.yml`: added a `Run tt-metal on tt-sim quasar` step after the existing Quasar UMD test steps. Invokes `./build/test/tt_metal/unit_tests_legacy --gtest_filter="QuasarMeshDeviceSingleCardFixture.BmmMultinode"` with `TT_METAL_SIMULATOR` / `TT_METAL_SIMULATOR_HOME` / `TT_METAL_SLOW_DISPATCH_MODE` pointed at `sim_qsr`. 5-minute timeout (matching the galaxy steps).

### Testing
CI

### API Changes
None.