### PR TITLE
Fix GTest component name

### DIFF
--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -106,7 +106,7 @@ jobs:
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
           echo "TT_METAL_RUNTIME_ROOT=$(pwd)" >> $GITHUB_ENV
           echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV
-          ./build_metal.sh --build-all --enable-ccache
+          ./build_metal.sh --build-all --build-umd-tests --enable-ccache
           cd ../
 
       - name: Prepare sim paths


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2727

### Description
Aftermath of #2188 
Seems like the google test packages aren't matched now between metal and umd.
We might consume UMD in metal better in the future, but for now this is the only fix.

### List of the changes
- Changed the workflow which builds tt_metal to catch this failure
- Fixed the naming to match the one in metal.

### Testing
Failing run after added additional check, on first commit only on this PR: https://github.com/tenstorrent/tt-umd/actions/runs/26519304422/job/78105479689?pr=2728
Passing after the fix: https://github.com/tenstorrent/tt-umd/actions/runs/26519589569/job/78106522121

### API Changes
This PR has (no) API changes.
