### PR TITLE
feat(sim): core multichip support via shared dlopen, eth-MAC wiring, DRAM teleport

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -158,7 +158,7 @@ if(TT_UMD_BUILD_SIMULATION)
             pcie/rtl_sim_tlb_handle.cpp
             ${FBS_GENERATED_HEADER}
     )
-    target_compile_definitions(tt-umd PRIVATE TT_UMD_BUILD_SIMULATION)
+    target_compile_definitions(tt-umd PUBLIC TT_UMD_BUILD_SIMULATION)
 endif()
 
 if(TT_UMD_BUILD_EMULE)

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -264,6 +264,14 @@ public:
     void configure_active_ethernet_cores_for_mmio_device(
         ChipId mmio_chip, const std::unordered_set<CoreCoord>& active_eth_cores_per_chip);
 
+#ifdef TT_UMD_BUILD_SIMULATION
+    // Passthroughs to libttsim_switch_register_fabric_* for wiring mock
+    // multichip fabric topologies under craq-sim v3.5.  Only available when
+    // the library is built with TT_UMD_BUILD_SIMULATION=ON.
+    void register_sim_fabric_endpoint_direction(ChipId chip_id, uint32_t eth_tile_id, uint32_t direction);
+    void register_sim_fabric_node_id(ChipId chip_id, uint32_t mesh_id, uint32_t fabric_chip_id);
+#endif  // TT_UMD_BUILD_SIMULATION
+
     //---------- Start and stop the device and tensix cores.
 
     /**

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -266,7 +266,7 @@ public:
 
 #ifdef TT_UMD_BUILD_SIMULATION
     // Passthroughs to libttsim_switch_register_fabric_* for wiring mock
-    // multichip fabric topologies under craq-sim v3.5.  Only available when
+    // multichip fabric topologies under craq-sim.  Only available when
     // the library is built with TT_UMD_BUILD_SIMULATION=ON.
     void register_sim_fabric_endpoint_direction(ChipId chip_id, uint32_t eth_tile_id, uint32_t direction);
     void register_sim_fabric_node_id(ChipId chip_id, uint32_t mesh_id, uint32_t fabric_chip_id);

--- a/device/api/umd/device/simulation/tt_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/tt_sim_communicator.hpp
@@ -22,11 +22,11 @@ public:
      *
      * @param simulator_directory Path to the simulator binary/directory
      * @param copy_sim_binary If true, copy the simulator binary to memory for
-     *   security AND the loaded .so doesn't support the v3.5 chip-id ABI. If
-     *   the .so exports libttsim_create_device_by_id, v3.5 shared-library
+     *   security AND the loaded .so doesn't support the multichip ABI. If
+     *   the .so exports libttsim_create_device_by_id, multichip shared-library
      *   mode is auto-enabled at initialize() time, ignoring this flag.
      * @param chip_id Logical chip ID (0..N-1) within the cluster. Only used
-     *   in v3.5 multichip mode (per docs/v3_5_umd_patch_sketch.md). Default 0
+     *   in multichip mode. Default 0
      *   for legacy single-chip consumers.
      */
     TTSimCommunicator(
@@ -130,7 +130,7 @@ public:
 
     void start_sim();
 
-    // v3.5 eth-MAC wiring: returns the libttsim Device* handle for peer registration.
+    // Multichip eth-MAC wiring: returns the libttsim Device* handle for peer registration.
     void *get_dev_handle() const { return dev_handle_; }
 
     void switch_reset();
@@ -142,6 +142,7 @@ public:
 
     // Mark device as closed; further I/O calls become no-ops.
     void mark_closed() { closed_ = true; }
+
     bool is_closed() const { return closed_; }
 
 private:
@@ -152,6 +153,9 @@ private:
     void secure_simulator_binary();
     void close_simulator_binary();
     void load_simulator_library(const std::filesystem::path &path);
+
+    // In multichip mode, selects this communicator's chip before an I/O call.
+    void select_chip_if_needed();
 
     // Dynamic library handle.
     void *libttsim_handle_ = nullptr;
@@ -166,9 +170,9 @@ private:
     bool copy_sim_binary_;
 
     // --------------------------------------------------------------------------
-    // v3.5 multichip model
+    // Multichip model
     //
-    // When the loaded libttsim.so exports the v3.5 ABI (libttsim_create_device_by_id,
+    // When the loaded libttsim.so exports the multichip ABI (libttsim_create_device_by_id,
     // libttsim_select_device_by_id, etc.), all TTSimCommunicators in the process
     // share a single dlopen of the .so via s_shared_handle_ (refcounted by
     // s_shared_refcount_).  This gives them a common process-global state: the
@@ -183,9 +187,9 @@ private:
     // at boot time.  See the #ifdef TT_UMD_BUILD_SIMULATION block there.
     // --------------------------------------------------------------------------
 
-    // True when the loaded .so supports the v3.5 multichip ABI and this
+    // True when the loaded .so supports the multichip ABI and this
     // communicator is using the shared dlopen path.
-    bool v3_5_multichip_mode_ = false;
+    bool multichip_mode_ = false;
     uint32_t chip_id_ = 0;
     static void *s_shared_handle_;
     static int s_shared_refcount_;
@@ -213,12 +217,12 @@ private:
         void (*pfn_pci_dma_mem_rd_bytes)(uint64_t paddr, void *p, uint32_t size),
         void (*pfn_pci_dma_mem_wr_bytes)(uint64_t paddr, const void *p, uint32_t size)) = nullptr;
 
-    // v3.5 multi-chip ABI. Resolved via dlsym; nullptr if .so is legacy single-chip.
+    // Multichip ABI. Resolved via dlsym; nullptr if .so is legacy single-chip.
     void *(*pfn_libttsim_create_device_by_id_)(uint32_t chip_id, int chip_x, int chip_y) = nullptr;
     void (*pfn_libttsim_select_device_by_id_)(uint32_t chip_id) = nullptr;
     void (*pfn_libttsim_clock_all_devices_)(uint32_t n_cycles) = nullptr;
 
-    // v3.5 eth-MAC wiring function pointers.
+    // Multichip eth-MAC wiring function pointers.
     void *dev_handle_ = nullptr;
     void (*pfn_libttsim_switch_reset_)() = nullptr;
     void (*pfn_libttsim_switch_register_)(void *dev, uint32_t tile_id, uint64_t mac) = nullptr;
@@ -243,7 +247,7 @@ private:
     static void pci_dma_mem_rd_bytes_wrapper(uint64_t paddr, void *p, uint32_t size);
     static void pci_dma_mem_wr_bytes_wrapper(uint64_t paddr, const void *p, uint32_t size);
 
-    // Thread safety. In v3.5 shared-dlopen mode, libttsim_select_device_by_id()
+    // Thread safety. In multichip shared-dlopen mode, libttsim_select_device_by_id()
     // and the following libttsim I/O call must be serialized across all
     // communicators because the active device selector is process-global.
     // NOTE: Also serializes legacy single-chip mode -- multiple independent legacy

--- a/device/api/umd/device/simulation/tt_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/tt_sim_communicator.hpp
@@ -13,22 +13,24 @@
 
 namespace tt::umd {
 
-/**
- * TTSimCommunicator handles low-level communication with the TTSim .so library.
- * It manages dynamic library loading, function pointer resolution, and provides
- * thread-safe access to simulator functions.
- *
- * This class can be used independently of TTSimTTDevice for direct simulator communication.
- */
+// Thin C++ wrapper around the libttsim.so dynamic library.
+// Handles dlopen/dlsym, per-chip device selection, and thread-safe I/O.
 class TTSimCommunicator final {
 public:
     /**
      * Constructor for TTSimCommunicator.
      *
      * @param simulator_directory Path to the simulator binary/directory
-     * @param copy_sim_binary If true, copy the simulator binary to memory for security
+     * @param copy_sim_binary If true, copy the simulator binary to memory for
+     *   security AND the loaded .so doesn't support the v3.5 chip-id ABI. If
+     *   the .so exports libttsim_create_device_by_id, v3.5 shared-library
+     *   mode is auto-enabled at initialize() time, ignoring this flag.
+     * @param chip_id Logical chip ID (0..N-1) within the cluster. Only used
+     *   in v3.5 multichip mode (per docs/v3_5_umd_patch_sketch.md). Default 0
+     *   for legacy single-chip consumers.
      */
-    TTSimCommunicator(const std::filesystem::path &simulator_directory, bool copy_sim_binary = false);
+    TTSimCommunicator(
+        const std::filesystem::path &simulator_directory, bool copy_sim_binary = false, uint32_t chip_id = 0);
 
     /**
      * Destructor that properly cleans up library handles and file descriptors.
@@ -68,6 +70,14 @@ public:
      * @param size Number of bytes to write
      */
     void tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size);
+
+    /**
+     * Fast simulator-only DRAM access. Returns false when the loaded simulator
+     * does not export the direct DRAM ABI, allowing callers to fall back to the
+     * normal tile/TLB path.
+     */
+    bool dram_read_bytes(uint32_t x, uint32_t y, uint64_t addr, void *data, uint32_t size);
+    bool dram_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size);
 
     /**
      * Read data from PCI memory.
@@ -120,6 +130,20 @@ public:
 
     void start_sim();
 
+    // v3.5 eth-MAC wiring: returns the libttsim Device* handle for peer registration.
+    void *get_dev_handle() const { return dev_handle_; }
+
+    void switch_reset();
+    void register_eth_endpoint(uint32_t eth_tile_id, uint64_t mac);
+    void switch_drain();
+    void register_peer(uint32_t eth_tile_id, void *peer_dev, uint32_t peer_tile_id);
+    void register_fabric_node_id(uint32_t mesh_id, uint32_t chip_id);
+    void register_fabric_endpoint_direction(uint32_t eth_tile_id, uint32_t direction);
+
+    // Mark device as closed; further I/O calls become no-ops.
+    void mark_closed() { closed_ = true; }
+    bool is_closed() const { return closed_; }
+
 private:
     // Library management.
     void create_simulator_binary();
@@ -141,6 +165,33 @@ private:
     // Flag to indicate if binary should be copied to memory.
     bool copy_sim_binary_;
 
+    // --------------------------------------------------------------------------
+    // v3.5 multichip model
+    //
+    // When the loaded libttsim.so exports the v3.5 ABI (libttsim_create_device_by_id,
+    // libttsim_select_device_by_id, etc.), all TTSimCommunicators in the process
+    // share a single dlopen of the .so via s_shared_handle_ (refcounted by
+    // s_shared_refcount_).  This gives them a common process-global state: the
+    // Device* registry, the virtual eth_switch routing table, and the clock.
+    //
+    // Per-chip I/O works by calling libttsim_select_device_by_id(chip_id_) under
+    // device_lock_ before each read/write/clock call.  The lock serializes all
+    // communicators so the select+I/O pair is atomic.
+    //
+    // The eth-switch pre-pass in Cluster::Cluster (cluster.cpp) wires up MAC
+    // addresses and peer handles so that firmware sees correctly routed neighbours
+    // at boot time.  See the #ifdef TT_UMD_BUILD_SIMULATION block there.
+    // --------------------------------------------------------------------------
+
+    // True when the loaded .so supports the v3.5 multichip ABI and this
+    // communicator is using the shared dlopen path.
+    bool v3_5_multichip_mode_ = false;
+    uint32_t chip_id_ = 0;
+    static void *s_shared_handle_;
+    static int s_shared_refcount_;
+    static bool s_sim_initialized_;
+    static std::mutex s_shared_init_mutex_;
+
     // Function pointers to simulator library functions.
     void (*pfn_libttsim_init_)() = nullptr;
     void (*pfn_libttsim_exit_)() = nullptr;
@@ -149,24 +200,58 @@ private:
     void (*pfn_libttsim_pci_mem_wr_bytes_)(uint64_t paddr, const void *p, uint32_t size) = nullptr;
     void (*pfn_libttsim_tile_rd_bytes_)(uint32_t x, uint32_t y, uint64_t addr, void *p, uint32_t size) = nullptr;
     void (*pfn_libttsim_tile_wr_bytes_)(uint32_t x, uint32_t y, uint64_t addr, const void *p, uint32_t size) = nullptr;
+    void (*pfn_libttsim_dram_rd_bytes_by_id_)(
+        uint32_t chip_id, uint32_t dram_channel, uint64_t addr, void *p, uint32_t size) = nullptr;
+    void (*pfn_libttsim_dram_wr_bytes_by_id_)(
+        uint32_t chip_id, uint32_t dram_channel, uint64_t addr, const void *p, uint32_t size) = nullptr;
+    void (*pfn_libttsim_dram_core_rd_bytes_by_id_)(
+        uint32_t chip_id, uint32_t x, uint32_t y, uint64_t addr, void *p, uint32_t size) = nullptr;
+    void (*pfn_libttsim_dram_core_wr_bytes_by_id_)(
+        uint32_t chip_id, uint32_t x, uint32_t y, uint64_t addr, const void *p, uint32_t size) = nullptr;
     void (*pfn_libttsim_clock_)(uint32_t n_clocks) = nullptr;
     void (*pfn_libttsim_set_pci_dma_mem_callbacks_)(
         void (*pfn_pci_dma_mem_rd_bytes)(uint64_t paddr, void *p, uint32_t size),
         void (*pfn_pci_dma_mem_wr_bytes)(uint64_t paddr, const void *p, uint32_t size)) = nullptr;
 
+    // v3.5 multi-chip ABI. Resolved via dlsym; nullptr if .so is legacy single-chip.
+    void *(*pfn_libttsim_create_device_by_id_)(uint32_t chip_id, int chip_x, int chip_y) = nullptr;
+    void (*pfn_libttsim_select_device_by_id_)(uint32_t chip_id) = nullptr;
+    void (*pfn_libttsim_clock_all_devices_)(uint32_t n_cycles) = nullptr;
+
+    // v3.5 eth-MAC wiring function pointers.
+    void *dev_handle_ = nullptr;
+    void (*pfn_libttsim_switch_reset_)() = nullptr;
+    void (*pfn_libttsim_switch_register_)(void *dev, uint32_t tile_id, uint64_t mac) = nullptr;
+    void (*pfn_libttsim_configure_eth_link_virtual_)(void *dev, uint32_t tile_id, uint64_t local_mac) = nullptr;
+    void (*pfn_libttsim_switch_register_peer_)(void *dev, uint32_t tile_id, void *peer_dev, uint32_t peer_tile_id) =
+        nullptr;
+    void (*pfn_libttsim_switch_register_fabric_node_id_)(void *dev, uint32_t mesh_id, uint32_t chip_id) = nullptr;
+    void (*pfn_libttsim_switch_register_fabric_endpoint_direction_)(void *dev, uint32_t tile_id, uint32_t direction) =
+        nullptr;
+    void (*pfn_libttsim_switch_drain_)() = nullptr;
+
     // Stored callbacks for DMA memory operations.
     std::function<void(uint64_t, void *, uint32_t)> pci_dma_mem_rd_bytes_callback_;
     std::function<void(uint64_t, const void *, uint32_t)> pci_dma_mem_wr_bytes_callback_;
 
-    // Static instance pointer for callback wrappers.
+    // Known limitation: callback_instance_ is process-global; in multichip mode,
+    // only the last chip to call set_pcie_dma_mem_callbacks receives correct DMA
+    // callbacks.  Fix requires libttsim ABI change to support per-chip context pointer.
     static TTSimCommunicator *callback_instance_;
 
     // Static wrapper functions for C-style callbacks.
     static void pci_dma_mem_rd_bytes_wrapper(uint64_t paddr, void *p, uint32_t size);
     static void pci_dma_mem_wr_bytes_wrapper(uint64_t paddr, const void *p, uint32_t size);
 
-    // Thread safety.
-    mutable std::mutex device_lock_;
+    // Thread safety. In v3.5 shared-dlopen mode, libttsim_select_device_by_id()
+    // and the following libttsim I/O call must be serialized across all
+    // communicators because the active device selector is process-global.
+    // NOTE: Also serializes legacy single-chip mode -- multiple independent legacy
+    // TTSim instances in one process will contend for this lock.
+    static std::mutex device_lock_;
+
+    // Set in close_device() to prevent further I/O after shutdown.
+    bool closed_ = false;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/soc_descriptor.hpp
+++ b/device/api/umd/device/soc_descriptor.hpp
@@ -64,6 +64,9 @@ public:
     std::string serialize() const;
     std::filesystem::path serialize_to_file(const std::filesystem::path& dest_file = "") const;
 
+    // Returns true when `core` (given in `coord_system`) matches any core of `core_type`.
+    bool is_core_of_type(const tt_xy_pair& core, CoreType core_type, CoordSystem coord_system) const;
+
     std::vector<CoreCoord> get_cores(
         const CoreType core_type,
         const CoordSystem coord_system = CoordSystem::NOC0,

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -42,6 +42,12 @@ public:
     static std::unique_ptr<TTSimTTDevice> create(
         const std::filesystem::path &simulator_directory, int num_host_mem_channels = 0, bool copy_sim_binary = false);
 
+    // Overload for multichip testing: create a device with an explicit chip_id
+    // so callers can open two devices with distinct IDs (chip 0 and chip 1) and
+    // verify that I/O on one does not affect the other.
+    static std::unique_ptr<TTSimTTDevice> create(
+        const std::filesystem::path &simulator_directory, ChipId chip_id, bool copy_sim_binary = false);
+
     void read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
     void write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
 

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -64,6 +64,8 @@ public:
     void dma_multicast_write(
         void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
 
+    void close_device();
+    void start_device();
     void noc_multicast_write(void *src, size_t size, uint64_t addr) override;
 
     void send_tensix_risc_reset(tt_xy_pair translated_core, const TensixSoftResetOptions &soft_resets) override;

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -42,10 +42,12 @@ public:
     static std::unique_ptr<TTSimTTDevice> create(
         const std::filesystem::path &simulator_directory, int num_host_mem_channels = 0, bool copy_sim_binary = false);
 
-    // Overload for multichip testing: create a device with an explicit chip_id
+    // Factory for multichip testing: create a device with an explicit chip_id
     // so callers can open two devices with distinct IDs (chip 0 and chip 1) and
     // verify that I/O on one does not affect the other.
-    static std::unique_ptr<TTSimTTDevice> create(
+    // Named distinctly from create() because ChipId is an alias for int, which
+    // would otherwise produce a duplicate signature.
+    static std::unique_ptr<TTSimTTDevice> create_for_chip(
         const std::filesystem::path &simulator_directory, ChipId chip_id, bool copy_sim_binary = false);
 
     void read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -324,6 +324,10 @@ void Cluster::add_chip(const ChipId& chip_id, const ChipType& chip_type, std::un
 Cluster::Cluster(ClusterOptions options) {
     ZoneScopedNC("Cluster::Cluster", tracy::Color::DarkGreen);
     log_info(LogUMD, "Cluster constructor started.");
+    // Store options early so that options_ is populated if the constructor throws.
+    // A second assignment at the end captures any mutations made during construction
+    // (sdesc_path resolution, num_host_mem_ch_per_mmio_device auto-detect).
+    options_ = options;
     std::map<ChipId, std::unique_ptr<TTDevice>> tt_devices;
     switch (options.chip_type) {
         case ChipType::SILICON: {
@@ -488,9 +492,8 @@ Cluster::Cluster(ClusterOptions options) {
 #endif  // TT_UMD_BUILD_SIMULATION
 
     construct_cluster(options.num_host_mem_ch_per_mmio_device.value(), options.chip_type);
-    // Move options_ after construct_cluster. The destructor does not read options_,
-    // so if the constructor throws between here and the end, the default-initialized
-    // options_ is harmless.
+    // Overwrite with the final (possibly mutated) options: sdesc_path may have been
+    // resolved and num_host_mem_ch_per_mmio_device auto-detected above.
     options_ = std::move(options);
     log_info(LogUMD, "Cluster constructor completed.");
 }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -34,6 +34,13 @@
 #include "umd/device/chip/local_chip.hpp"
 #include "umd/device/chip/mock_chip.hpp"
 #include "umd/device/chip/remote_chip.hpp"
+// Simulation-specific headers -- only needed when TT_UMD_BUILD_SIMULATION is set.
+// The code that uses these types is guarded by #ifdef TT_UMD_BUILD_SIMULATION below.
+#ifdef TT_UMD_BUILD_SIMULATION
+#include "umd/device/simulation/tt_sim_chip.hpp"
+#include "umd/device/simulation/tt_sim_communicator.hpp"
+#include "umd/device/tt_device/tt_sim_tt_device.hpp"
+#endif  // TT_UMD_BUILD_SIMULATION
 // SWEmuleChip is only referenced inside `#ifdef TT_UMD_BUILD_EMULE`. IWYU
 // runs without that flag set so it can't see the use; mark the include to
 // stop future IWYU sweeps from deleting it again (see #2536).
@@ -314,11 +321,9 @@ void Cluster::add_chip(const ChipId& chip_id, const ChipType& chip_type, std::un
 }
 
 // Options is intentionally taken by value because it may be mutated when TT_UMD_BUILD_SIMULATION is enabled.
-// NOLINT is needed because clang-tidy cannot see the mutation when simulation is compiled out.
-Cluster::Cluster(ClusterOptions options) {  // NOLINT(performance-unnecessary-value-param)
+Cluster::Cluster(ClusterOptions options) {
     ZoneScopedNC("Cluster::Cluster", tracy::Color::DarkGreen);
     log_info(LogUMD, "Cluster constructor started.");
-    options_ = options;
     std::map<ChipId, std::unique_ptr<TTDevice>> tt_devices;
     switch (options.chip_type) {
         case ChipType::SILICON: {
@@ -408,9 +413,128 @@ Cluster::Cluster(ClusterOptions options) {  // NOLINT(performance-unnecessary-va
                 std::move(tt_device)));
     }
 
+#ifdef TT_UMD_BUILD_SIMULATION
+    // -------------------------------------------------------------------
+    // v3.5 eth-MAC wiring pre-pass.
+    // For SIMULATION ChipType with v3.5-aware libttsim, populate the virtual
+    // switch routing table and pre-write peer DEST_MAC into each eth tile so
+    // that firmware sees correctly wired neighbours at boot time.
+    // -------------------------------------------------------------------
+    if (options.chip_type == ChipType::SIMULATION && options.simulator_directory.extension() == ".so") {
+        // Walk chips_ and return the TTSimCommunicator for a given chip.
+        auto get_comm = [&](ChipId cid) -> tt::umd::TTSimCommunicator* {
+            auto it = chips_.find(cid);
+            if (it == chips_.end()) {
+                return nullptr;
+            }
+            auto* sim_chip = dynamic_cast<tt::umd::TTSimChip*>(it->second.get());
+            if (!sim_chip) {
+                return nullptr;
+            }
+            auto* sim_tt = dynamic_cast<tt::umd::TTSimTTDevice*>(sim_chip->get_tt_device());
+            return sim_tt ? sim_tt->get_communicator() : nullptr;
+        };
+        // Deterministic per-(chip, channel) MAC: top byte is OUI, next byte
+        // encodes chip_id, bottom byte encodes channel.
+        auto eth_sim_mac = [](ChipId cid, int chan) -> uint64_t {
+            UMD_ASSERT(
+                cid <= 0xFF && chan <= 0xFF,
+                error::RuntimeError,
+                fmt::format("MAC encoding overflow: chip_id {} channel {}", cid, chan));
+            return 0x021E52000000ULL | (uint64_t(cid & 0xFF) << 8) | uint64_t(chan & 0xFF);
+        };
+        // Reset the virtual switch once (singleton, process-global state).
+        if (!chips_.empty()) {
+            ChipId c0 = cluster_desc->get_chips_local_first(cluster_desc->get_all_chips()).front();
+            if (auto* c = get_comm(c0)) {
+                c->switch_reset();
+            }
+        }
+        // For every connected eth pair (chip_a:chan_a <-> chip_b:chan_b),
+        // register MACs and peer handles.  Process each undirected edge once
+        // (chip_a < chip_b) to avoid double-registration.
+        const auto& eth_conns = cluster_desc->get_ethernet_connections();
+        for (const auto& [chip_a, chan_map] : eth_conns) {
+            for (const auto& [chan_a, remote] : chan_map) {
+                ChipId chip_b = std::get<0>(remote);
+                int chan_b = std::get<1>(remote);
+                if (chip_a >= chip_b) {
+                    continue;
+                }
+                auto* ca = get_comm(chip_a);
+                auto* cb = get_comm(chip_b);
+                if (!ca || !cb) {
+                    continue;
+                }
+                uint64_t mac_a = eth_sim_mac(chip_a, chan_a);
+                uint64_t mac_b = eth_sim_mac(chip_b, chan_b);
+                ca->register_eth_endpoint(uint32_t(chan_a), mac_a);
+                cb->register_eth_endpoint(uint32_t(chan_b), mac_b);
+                // Wire bidirectional peer info for source-aware routing (BH BCAST/MCAST MAC).
+                ca->register_peer(uint32_t(chan_a), cb->get_dev_handle(), uint32_t(chan_b));
+                cb->register_peer(uint32_t(chan_b), ca->get_dev_handle(), uint32_t(chan_a));
+                log_info(
+                    tt::LogEmulationDriver,
+                    "TTSim eth: {}:ch{} mac={:#014x}  <->  {}:ch{} mac={:#014x}",
+                    chip_a,
+                    chan_a,
+                    mac_a,
+                    chip_b,
+                    chan_b,
+                    mac_b);
+            }
+        }
+    }
+#endif  // TT_UMD_BUILD_SIMULATION
+
     construct_cluster(options.num_host_mem_ch_per_mmio_device.value(), options.chip_type);
+    // Move options_ after construct_cluster. The destructor does not read options_,
+    // so if the constructor throws between here and the end, the default-initialized
+    // options_ is harmless.
+    options_ = std::move(options);
     log_info(LogUMD, "Cluster constructor completed.");
 }
+
+#ifdef TT_UMD_BUILD_SIMULATION
+// Passthroughs to libttsim_switch_register_fabric_* -- allow tt-metal fabric
+// init to wire mock multichip topologies under craq-sim v3.5.
+
+void Cluster::register_sim_fabric_endpoint_direction(ChipId chip_id, uint32_t eth_tile_id, uint32_t direction) {
+    auto it = chips_.find(chip_id);
+    if (it == chips_.end()) {
+        return;
+    }
+    auto* sim_chip = dynamic_cast<TTSimChip*>(it->second.get());
+    if (!sim_chip) {
+        return;
+    }
+    auto* sim_tt = dynamic_cast<TTSimTTDevice*>(sim_chip->get_tt_device());
+    if (!sim_tt) {
+        return;
+    }
+    if (auto* communicator = sim_tt->get_communicator()) {
+        communicator->register_fabric_endpoint_direction(eth_tile_id, direction);
+    }
+}
+
+void Cluster::register_sim_fabric_node_id(ChipId chip_id, uint32_t mesh_id, uint32_t fabric_chip_id) {
+    auto chip_it = chips_.find(chip_id);
+    if (chip_it == chips_.end()) {
+        return;
+    }
+    auto* sim_chip = dynamic_cast<TTSimChip*>(chip_it->second.get());
+    if (!sim_chip) {
+        return;
+    }
+    auto* sim_tt = dynamic_cast<TTSimTTDevice*>(sim_chip->get_tt_device());
+    if (!sim_tt) {
+        return;
+    }
+    if (auto* communicator = sim_tt->get_communicator()) {
+        communicator->register_fabric_node_id(mesh_id, fabric_chip_id);
+    }
+}
+#endif  // TT_UMD_BUILD_SIMULATION
 
 void Cluster::configure_active_ethernet_cores_for_mmio_device(
     ChipId mmio_chip, const std::unordered_set<CoreCoord>& active_eth_cores_per_chip) {

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -415,8 +415,8 @@ Cluster::Cluster(ClusterOptions options) {
 
 #ifdef TT_UMD_BUILD_SIMULATION
     // -------------------------------------------------------------------
-    // v3.5 eth-MAC wiring pre-pass.
-    // For SIMULATION ChipType with v3.5-aware libttsim, populate the virtual
+    // Multichip eth-MAC wiring pre-pass.
+    // For SIMULATION ChipType with multichip-aware libttsim, populate the virtual
     // switch routing table and pre-write peer DEST_MAC into each eth tile so
     // that firmware sees correctly wired neighbours at boot time.
     // -------------------------------------------------------------------
@@ -497,7 +497,7 @@ Cluster::Cluster(ClusterOptions options) {
 
 #ifdef TT_UMD_BUILD_SIMULATION
 // Passthroughs to libttsim_switch_register_fabric_* -- allow tt-metal fabric
-// init to wire mock multichip topologies under craq-sim v3.5.
+// init to wire mock multichip topologies under craq-sim.
 
 void Cluster::register_sim_fabric_endpoint_direction(ChipId chip_id, uint32_t eth_tile_id, uint32_t direction) {
     auto it = chips_.find(chip_id);

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -445,9 +445,9 @@ Cluster::Cluster(ClusterOptions options) {
         };
         // Reset the virtual switch once (singleton, process-global state).
         if (!chips_.empty()) {
-            ChipId c0 = cluster_desc->get_chips_local_first(cluster_desc->get_all_chips()).front();
-            if (auto* c = get_comm(c0)) {
-                c->switch_reset();
+            ChipId first_chip_id = cluster_desc->get_chips_local_first(cluster_desc->get_all_chips()).front();
+            if (auto* first_chip_comm = get_comm(first_chip_id)) {
+                first_chip_comm->switch_reset();
             }
         }
         // For every connected eth pair (chip_a:chan_a <-> chip_b:chan_b),
@@ -461,18 +461,18 @@ Cluster::Cluster(ClusterOptions options) {
                 if (chip_a >= chip_b) {
                     continue;
                 }
-                auto* ca = get_comm(chip_a);
-                auto* cb = get_comm(chip_b);
-                if (!ca || !cb) {
+                auto* comm_a = get_comm(chip_a);
+                auto* comm_b = get_comm(chip_b);
+                if (!comm_a || !comm_b) {
                     continue;
                 }
                 uint64_t mac_a = eth_sim_mac(chip_a, chan_a);
                 uint64_t mac_b = eth_sim_mac(chip_b, chan_b);
-                ca->register_eth_endpoint(uint32_t(chan_a), mac_a);
-                cb->register_eth_endpoint(uint32_t(chan_b), mac_b);
+                comm_a->register_eth_endpoint(uint32_t(chan_a), mac_a);
+                comm_b->register_eth_endpoint(uint32_t(chan_b), mac_b);
                 // Wire bidirectional peer info for source-aware routing (BH BCAST/MCAST MAC).
-                ca->register_peer(uint32_t(chan_a), cb->get_dev_handle(), uint32_t(chan_b));
-                cb->register_peer(uint32_t(chan_b), ca->get_dev_handle(), uint32_t(chan_a));
+                comm_a->register_peer(uint32_t(chan_a), comm_b->get_dev_handle(), uint32_t(chan_b));
+                comm_b->register_peer(uint32_t(chan_b), comm_a->get_dev_handle(), uint32_t(chan_a));
                 log_info(
                     tt::LogEmulationDriver,
                     "TTSim eth: {}:ch{} mac={:#014x}  <->  {}:ch{} mac={:#014x}",

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -31,11 +31,36 @@
 
 namespace tt::umd {
 
-TTSimCommunicator::TTSimCommunicator(const std::filesystem::path &simulator_directory, bool copy_sim_binary) :
-    simulator_directory_(simulator_directory), copy_sim_binary_(copy_sim_binary) {}
+// v3.5 multi-chip shared-library state. When the loaded libttsim.so exports
+// libttsim_create_device_by_id + libttsim_select_device_by_id, all
+// TTSimCommunicators share a single dlopen of the .so so they also share its
+// process-global state (eth_switch routing table, Device* registry).
+void *TTSimCommunicator::s_shared_handle_ = nullptr;
+int TTSimCommunicator::s_shared_refcount_ = 0;
+bool TTSimCommunicator::s_sim_initialized_ = false;
+std::mutex TTSimCommunicator::s_shared_init_mutex_;
+std::mutex TTSimCommunicator::device_lock_;
+
+TTSimCommunicator::TTSimCommunicator(
+    const std::filesystem::path &simulator_directory, bool copy_sim_binary, uint32_t chip_id) :
+    simulator_directory_(simulator_directory), copy_sim_binary_(copy_sim_binary), chip_id_(chip_id) {}
 
 TTSimCommunicator::~TTSimCommunicator() {
-    if (libttsim_handle_) {
+    if (v3_5_multichip_mode_) {
+        // Shared dlopen -- decrement refcount. When last communicator
+        // destructs, call libttsim_exit (which the deferred shutdown()
+        // path didn't call), then dlclose. The simulator is process-global,
+        // so libttsim_exit should run exactly once.
+        std::lock_guard<std::mutex> lock(s_shared_init_mutex_);
+        if (--s_shared_refcount_ == 0 && s_shared_handle_) {
+            if (pfn_libttsim_exit_) {
+                pfn_libttsim_exit_();
+            }
+            dlclose(s_shared_handle_);
+            s_shared_handle_ = nullptr;
+            s_sim_initialized_ = false;
+        }
+    } else if (libttsim_handle_) {
         dlclose(libttsim_handle_);
     }
     close_simulator_binary();
@@ -44,6 +69,88 @@ TTSimCommunicator::~TTSimCommunicator() {
 void TTSimCommunicator::initialize() {
     std::lock_guard<std::mutex> lock(device_lock_);
 
+    // Probe the .so for v3.5 multichip ABI symbols. We do this before
+    // committing to memfd-vs-direct dlopen because the shared-library path
+    // skips memfd entirely (multiple chips share one dlopen).
+    //
+    // If the shared handle already exists, use it for the probe directly
+    // to avoid dlopen/dlclose running global constructors/destructors.
+    bool v3_5_supported = false;
+    {
+        std::lock_guard<std::mutex> init_lock(s_shared_init_mutex_);
+        if (s_shared_handle_) {
+            // Already loaded by another communicator -- probe in-place.
+            v3_5_supported = dlsym(s_shared_handle_, "libttsim_create_device_by_id") != nullptr &&
+                             dlsym(s_shared_handle_, "libttsim_select_device_by_id") != nullptr;
+        } else {
+            // Fresh load: open, probe, and keep the handle if v3.5 is supported
+            // to avoid a wasteful close+reopen cycle.
+            void *probe = dlopen(simulator_directory_.c_str(), RTLD_LAZY);
+            if (probe) {
+                v3_5_supported = dlsym(probe, "libttsim_create_device_by_id") != nullptr &&
+                                 dlsym(probe, "libttsim_select_device_by_id") != nullptr;
+                if (v3_5_supported) {
+                    // Keep this handle as the shared handle.
+                    s_shared_handle_ = probe;
+                } else {
+                    dlclose(probe);
+                }
+            }
+        }
+    }
+
+    if (v3_5_supported) {
+        log_info(tt::LogEmulationDriver, "TTSim v3.5 multichip mode enabled (chip_id={}, shared dlopen)", chip_id_);
+        std::lock_guard<std::mutex> init_lock(s_shared_init_mutex_);
+        // s_shared_handle_ is guaranteed non-null here (set in probe above or by a prior communicator).
+        libttsim_handle_ = s_shared_handle_;
+
+        // Resolve all required v3.5 symbols via DLSYM_FUNCTION (throws on missing).
+        DLSYM_FUNCTION(libttsim_init)
+        DLSYM_FUNCTION(libttsim_exit)
+        DLSYM_FUNCTION(libttsim_pci_config_rd32)
+        DLSYM_FUNCTION(libttsim_pci_mem_rd_bytes)
+        DLSYM_FUNCTION(libttsim_pci_mem_wr_bytes)
+        DLSYM_FUNCTION(libttsim_tile_rd_bytes)
+        DLSYM_FUNCTION(libttsim_tile_wr_bytes)
+        DLSYM_FUNCTION(libttsim_clock)
+        DLSYM_FUNCTION(libttsim_set_pci_dma_mem_callbacks)
+        DLSYM_FUNCTION(libttsim_create_device_by_id)
+        DLSYM_FUNCTION(libttsim_select_device_by_id)
+        DLSYM_FUNCTION(libttsim_clock_all_devices)
+        DLSYM_FUNCTION(libttsim_switch_reset)
+        DLSYM_FUNCTION(libttsim_switch_register)
+        DLSYM_FUNCTION(libttsim_switch_drain)
+        DLSYM_FUNCTION(libttsim_configure_eth_link_virtual)
+        DLSYM_FUNCTION(libttsim_switch_register_peer)
+
+        // Optional extension symbols -- resolved with raw dlsym and allowed to be
+        // nullptr.  These are newer additions to the libttsim ABI that not all .so
+        // builds export yet; callers check for nullptr before use.
+        pfn_libttsim_dram_rd_bytes_by_id_ = reinterpret_cast<decltype(pfn_libttsim_dram_rd_bytes_by_id_)>(
+            dlsym(libttsim_handle_, "libttsim_dram_rd_bytes_by_id"));
+        pfn_libttsim_dram_wr_bytes_by_id_ = reinterpret_cast<decltype(pfn_libttsim_dram_wr_bytes_by_id_)>(
+            dlsym(libttsim_handle_, "libttsim_dram_wr_bytes_by_id"));
+        pfn_libttsim_dram_core_rd_bytes_by_id_ = reinterpret_cast<decltype(pfn_libttsim_dram_core_rd_bytes_by_id_)>(
+            dlsym(libttsim_handle_, "libttsim_dram_core_rd_bytes_by_id"));
+        pfn_libttsim_dram_core_wr_bytes_by_id_ = reinterpret_cast<decltype(pfn_libttsim_dram_core_wr_bytes_by_id_)>(
+            dlsym(libttsim_handle_, "libttsim_dram_core_wr_bytes_by_id"));
+        pfn_libttsim_switch_register_fabric_node_id_ =
+            reinterpret_cast<decltype(pfn_libttsim_switch_register_fabric_node_id_)>(
+                dlsym(libttsim_handle_, "libttsim_switch_register_fabric_node_id"));
+        pfn_libttsim_switch_register_fabric_endpoint_direction_ =
+            reinterpret_cast<decltype(pfn_libttsim_switch_register_fabric_endpoint_direction_)>(
+                dlsym(libttsim_handle_, "libttsim_switch_register_fabric_endpoint_direction"));
+
+        // Only commit to v3.5 mode and bump refcount after ALL symbol resolution
+        // has succeeded.  If a DLSYM_FUNCTION above throws, the destructor will
+        // not attempt to decrement a refcount that was never incremented.
+        v3_5_multichip_mode_ = true;
+        s_shared_refcount_++;
+        return;
+    }
+
+    // Legacy path: per-chip memfd + dlopen.
     if (copy_sim_binary_) {
         create_simulator_binary();
         copy_simulator_binary();
@@ -56,43 +163,105 @@ void TTSimCommunicator::initialize() {
 
 void TTSimCommunicator::start_sim() {
     std::lock_guard<std::mutex> lock(device_lock_);
+    if (v3_5_multichip_mode_) {
+        // libttsim_init only on the first communicator. Subsequent
+        // communicators register their chip into the shared registry.
+        std::lock_guard<std::mutex> init_lock(s_shared_init_mutex_);
+        if (!s_sim_initialized_) {
+            pfn_libttsim_init_();
+            s_sim_initialized_ = true;
+        }
+        // Register this chip in the shared chip_id registry.
+        // v3.5 commit #6: capture Device* handle for later eth-MAC registration.
+        dev_handle_ = pfn_libttsim_create_device_by_id_(chip_id_, /*chip_x=*/int(chip_id_), /*chip_y=*/0);
+        return;
+    }
     pfn_libttsim_init_();
 }
 
 void TTSimCommunicator::shutdown() {
     std::lock_guard<std::mutex> lock(device_lock_);
     log_info(tt::LogEmulationDriver, "Sending exit signal to remote...");
+    if (v3_5_multichip_mode_) {
+        // Defer libttsim_exit until the last communicator destructs (handled
+        // by refcount in the destructor's shared-handle close path). The
+        // simulator is process-global; calling exit per chip would be wrong.
+        return;
+    }
     pfn_libttsim_exit_();
 }
+
+// v3.5: in multi-chip mode, every I/O entry point first selects the right
+// chip via libttsim_select_device_by_id(chip_id_) under the held device_lock_.
+// The shared libttsim's internal recursive_mutex provides defense-in-depth.
+#define SELECT_CHIP_IF_NEEDED()                                                \
+    do {                                                                       \
+        if (v3_5_multichip_mode_) pfn_libttsim_select_device_by_id_(chip_id_); \
+    } while (0)
 
 void TTSimCommunicator::tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size) {
     std::lock_guard<std::mutex> lock(device_lock_);
     log_debug(tt::LogUMD, "Device writing {} bytes to l1_dest {} in core ({},{})", size, addr, x, y);
+    SELECT_CHIP_IF_NEEDED();
     pfn_libttsim_tile_wr_bytes_(x, y, addr, data, size);
 }
 
 void TTSimCommunicator::tile_read_bytes(uint32_t x, uint32_t y, uint64_t addr, void *data, uint32_t size) {
     std::lock_guard<std::mutex> lock(device_lock_);
+    SELECT_CHIP_IF_NEEDED();
     pfn_libttsim_tile_rd_bytes_(x, y, addr, data, size);
+}
+
+bool TTSimCommunicator::dram_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size) {
+    if (!v3_5_multichip_mode_ || pfn_libttsim_dram_core_wr_bytes_by_id_ == nullptr) {
+        return false;
+    }
+    std::lock_guard<std::mutex> lock(device_lock_);
+    pfn_libttsim_dram_core_wr_bytes_by_id_(chip_id_, x, y, addr, data, size);
+    return true;
+}
+
+bool TTSimCommunicator::dram_read_bytes(uint32_t x, uint32_t y, uint64_t addr, void *data, uint32_t size) {
+    if (!v3_5_multichip_mode_ || pfn_libttsim_dram_core_rd_bytes_by_id_ == nullptr) {
+        return false;
+    }
+    std::lock_guard<std::mutex> lock(device_lock_);
+    pfn_libttsim_dram_core_rd_bytes_by_id_(chip_id_, x, y, addr, data, size);
+    return true;
 }
 
 void TTSimCommunicator::pci_mem_read_bytes(uint64_t paddr, void *data, uint32_t size) {
     std::lock_guard<std::mutex> lock(device_lock_);
+    SELECT_CHIP_IF_NEEDED();
     pfn_libttsim_pci_mem_rd_bytes_(paddr, data, size);
 }
 
 void TTSimCommunicator::pci_mem_write_bytes(uint64_t paddr, const void *data, uint32_t size) {
     std::lock_guard<std::mutex> lock(device_lock_);
+    SELECT_CHIP_IF_NEEDED();
     pfn_libttsim_pci_mem_wr_bytes_(paddr, data, size);
 }
 
 uint32_t TTSimCommunicator::pci_config_read32(uint32_t bus_device_function, uint32_t offset) {
     std::lock_guard<std::mutex> lock(device_lock_);
+    // pci_config_read32 reads compile-time constants; no chip selection needed.
+    // But we still select for consistency and future-proofing.
+    SELECT_CHIP_IF_NEEDED();
     return pfn_libttsim_pci_config_rd32_(bus_device_function, offset);
 }
 
 void TTSimCommunicator::advance_clock(uint32_t n_clocks) {
     std::lock_guard<std::mutex> lock(device_lock_);
+    if (v3_5_multichip_mode_ && pfn_libttsim_clock_all_devices_) {
+        // v3.5-#8: in shared-dlopen multichip mode, tick ALL chips together so
+        // cross-chip eth handshakes converge (chip A waiting on a packet from chip B
+        // would otherwise stall -- only the chip being read gets advanced).
+        // libttsim_clock_all_devices walks the simulator chip_id registry internally
+        // and drains the eth switch in sort order, so no extra switch_drain call.
+        pfn_libttsim_clock_all_devices_(n_clocks);
+        return;
+    }
+    SELECT_CHIP_IF_NEEDED();
     pfn_libttsim_clock_(n_clocks);
 }
 
@@ -194,6 +363,61 @@ void TTSimCommunicator::load_simulator_library(const std::filesystem::path &path
     DLSYM_FUNCTION(libttsim_tile_wr_bytes)
     DLSYM_FUNCTION(libttsim_clock)
     DLSYM_FUNCTION(libttsim_set_pci_dma_mem_callbacks)
+}
+
+// v3.5 eth-MAC wiring methods. All no-ops in legacy single-chip mode.
+
+void TTSimCommunicator::switch_reset() {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    if (v3_5_multichip_mode_ && pfn_libttsim_switch_reset_) {
+        pfn_libttsim_switch_reset_();
+    }
+}
+
+void TTSimCommunicator::register_eth_endpoint(uint32_t eth_tile_id, uint64_t mac) {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    if (!v3_5_multichip_mode_ || !dev_handle_) {
+        return;
+    }
+    // Prefer configure_eth_link_virtual: sets link_mode=Virtual + writes
+    // link-up sentinel + registers MAC. Falls back to switch_register if
+    // configure_eth_link_virtual is not exported.
+    if (pfn_libttsim_configure_eth_link_virtual_) {
+        pfn_libttsim_configure_eth_link_virtual_(dev_handle_, eth_tile_id, mac);
+    } else if (pfn_libttsim_switch_register_) {
+        pfn_libttsim_switch_register_(dev_handle_, eth_tile_id, mac);
+    }
+}
+
+void TTSimCommunicator::register_peer(uint32_t eth_tile_id, void *peer_dev, uint32_t peer_tile_id) {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    if (!v3_5_multichip_mode_ || !dev_handle_ || !pfn_libttsim_switch_register_peer_ || !peer_dev) {
+        return;
+    }
+    pfn_libttsim_switch_register_peer_(dev_handle_, eth_tile_id, peer_dev, peer_tile_id);
+}
+
+void TTSimCommunicator::register_fabric_node_id(uint32_t mesh_id, uint32_t chip_id) {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    if (!v3_5_multichip_mode_ || !dev_handle_ || !pfn_libttsim_switch_register_fabric_node_id_) {
+        return;
+    }
+    pfn_libttsim_switch_register_fabric_node_id_(dev_handle_, mesh_id, chip_id);
+}
+
+void TTSimCommunicator::register_fabric_endpoint_direction(uint32_t eth_tile_id, uint32_t direction) {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    if (!v3_5_multichip_mode_ || !dev_handle_ || !pfn_libttsim_switch_register_fabric_endpoint_direction_) {
+        return;
+    }
+    pfn_libttsim_switch_register_fabric_endpoint_direction_(dev_handle_, eth_tile_id, direction);
+}
+
+void TTSimCommunicator::switch_drain() {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    if (v3_5_multichip_mode_ && pfn_libttsim_switch_drain_) {
+        pfn_libttsim_switch_drain_();
+    }
 }
 
 void TTSimCommunicator::close_simulator_binary() {

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -31,7 +31,7 @@
 
 namespace tt::umd {
 
-// v3.5 multi-chip shared-library state. When the loaded libttsim.so exports
+// Multichip shared-library state. When the loaded libttsim.so exports
 // libttsim_create_device_by_id + libttsim_select_device_by_id, all
 // TTSimCommunicators share a single dlopen of the .so so they also share its
 // process-global state (eth_switch routing table, Device* registry).
@@ -46,7 +46,7 @@ TTSimCommunicator::TTSimCommunicator(
     simulator_directory_(simulator_directory), copy_sim_binary_(copy_sim_binary), chip_id_(chip_id) {}
 
 TTSimCommunicator::~TTSimCommunicator() {
-    if (v3_5_multichip_mode_) {
+    if (multichip_mode_) {
         // Shared dlopen -- decrement refcount. When last communicator
         // destructs, call libttsim_exit (which the deferred shutdown()
         // path didn't call), then dlclose. The simulator is process-global,
@@ -69,27 +69,27 @@ TTSimCommunicator::~TTSimCommunicator() {
 void TTSimCommunicator::initialize() {
     std::lock_guard<std::mutex> lock(device_lock_);
 
-    // Probe the .so for v3.5 multichip ABI symbols. We do this before
+    // Probe the .so for multichip ABI symbols. We do this before
     // committing to memfd-vs-direct dlopen because the shared-library path
     // skips memfd entirely (multiple chips share one dlopen).
     //
     // If the shared handle already exists, use it for the probe directly
     // to avoid dlopen/dlclose running global constructors/destructors.
-    bool v3_5_supported = false;
+    bool multichip_supported = false;
     {
         std::lock_guard<std::mutex> init_lock(s_shared_init_mutex_);
         if (s_shared_handle_) {
             // Already loaded by another communicator -- probe in-place.
-            v3_5_supported = dlsym(s_shared_handle_, "libttsim_create_device_by_id") != nullptr &&
-                             dlsym(s_shared_handle_, "libttsim_select_device_by_id") != nullptr;
+            multichip_supported = dlsym(s_shared_handle_, "libttsim_create_device_by_id") != nullptr &&
+                                  dlsym(s_shared_handle_, "libttsim_select_device_by_id") != nullptr;
         } else {
-            // Fresh load: open, probe, and keep the handle if v3.5 is supported
+            // Fresh load: open, probe, and keep the handle if multichip is supported
             // to avoid a wasteful close+reopen cycle.
             void *probe = dlopen(simulator_directory_.c_str(), RTLD_LAZY);
             if (probe) {
-                v3_5_supported = dlsym(probe, "libttsim_create_device_by_id") != nullptr &&
-                                 dlsym(probe, "libttsim_select_device_by_id") != nullptr;
-                if (v3_5_supported) {
+                multichip_supported = dlsym(probe, "libttsim_create_device_by_id") != nullptr &&
+                                      dlsym(probe, "libttsim_select_device_by_id") != nullptr;
+                if (multichip_supported) {
                     // Keep this handle as the shared handle.
                     s_shared_handle_ = probe;
                 } else {
@@ -99,13 +99,13 @@ void TTSimCommunicator::initialize() {
         }
     }
 
-    if (v3_5_supported) {
-        log_info(tt::LogEmulationDriver, "TTSim v3.5 multichip mode enabled (chip_id={}, shared dlopen)", chip_id_);
+    if (multichip_supported) {
+        log_info(tt::LogEmulationDriver, "TTSim multichip mode enabled (chip_id={}, shared dlopen)", chip_id_);
         std::lock_guard<std::mutex> init_lock(s_shared_init_mutex_);
         // s_shared_handle_ is guaranteed non-null here (set in probe above or by a prior communicator).
         libttsim_handle_ = s_shared_handle_;
 
-        // Resolve all required v3.5 symbols via DLSYM_FUNCTION (throws on missing).
+        // Resolve all required multichip symbols via DLSYM_FUNCTION (throws on missing).
         DLSYM_FUNCTION(libttsim_init)
         DLSYM_FUNCTION(libttsim_exit)
         DLSYM_FUNCTION(libttsim_pci_config_rd32)
@@ -142,10 +142,10 @@ void TTSimCommunicator::initialize() {
             reinterpret_cast<decltype(pfn_libttsim_switch_register_fabric_endpoint_direction_)>(
                 dlsym(libttsim_handle_, "libttsim_switch_register_fabric_endpoint_direction"));
 
-        // Only commit to v3.5 mode and bump refcount after ALL symbol resolution
+        // Only commit to multichip mode and bump refcount after ALL symbol resolution
         // has succeeded.  If a DLSYM_FUNCTION above throws, the destructor will
         // not attempt to decrement a refcount that was never incremented.
-        v3_5_multichip_mode_ = true;
+        multichip_mode_ = true;
         s_shared_refcount_++;
         return;
     }
@@ -163,7 +163,7 @@ void TTSimCommunicator::initialize() {
 
 void TTSimCommunicator::start_sim() {
     std::lock_guard<std::mutex> lock(device_lock_);
-    if (v3_5_multichip_mode_) {
+    if (multichip_mode_) {
         // libttsim_init only on the first communicator. Subsequent
         // communicators register their chip into the shared registry.
         std::lock_guard<std::mutex> init_lock(s_shared_init_mutex_);
@@ -172,7 +172,7 @@ void TTSimCommunicator::start_sim() {
             s_sim_initialized_ = true;
         }
         // Register this chip in the shared chip_id registry.
-        // v3.5 commit #6: capture Device* handle for later eth-MAC registration.
+        // Capture Device* handle for later eth-MAC registration.
         dev_handle_ = pfn_libttsim_create_device_by_id_(chip_id_, /*chip_x=*/int(chip_id_), /*chip_y=*/0);
         return;
     }
@@ -182,7 +182,7 @@ void TTSimCommunicator::start_sim() {
 void TTSimCommunicator::shutdown() {
     std::lock_guard<std::mutex> lock(device_lock_);
     log_info(tt::LogEmulationDriver, "Sending exit signal to remote...");
-    if (v3_5_multichip_mode_) {
+    if (multichip_mode_) {
         // Defer libttsim_exit until the last communicator destructs (handled
         // by refcount in the destructor's shared-handle close path). The
         // simulator is process-global; calling exit per chip would be wrong.
@@ -191,29 +191,30 @@ void TTSimCommunicator::shutdown() {
     pfn_libttsim_exit_();
 }
 
-// v3.5: in multi-chip mode, every I/O entry point first selects the right
-// chip via libttsim_select_device_by_id(chip_id_) under the held device_lock_.
+// Multichip mode: every I/O entry point first selects the right chip via
+// libttsim_select_device_by_id(chip_id_) under the held device_lock_.
 // The shared libttsim's internal recursive_mutex provides defense-in-depth.
-#define SELECT_CHIP_IF_NEEDED()                                                \
-    do {                                                                       \
-        if (v3_5_multichip_mode_) pfn_libttsim_select_device_by_id_(chip_id_); \
-    } while (0)
+void TTSimCommunicator::select_chip_if_needed() {
+    if (multichip_mode_) {
+        pfn_libttsim_select_device_by_id_(chip_id_);
+    }
+}
 
 void TTSimCommunicator::tile_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size) {
     std::lock_guard<std::mutex> lock(device_lock_);
     log_debug(tt::LogUMD, "Device writing {} bytes to l1_dest {} in core ({},{})", size, addr, x, y);
-    SELECT_CHIP_IF_NEEDED();
+    select_chip_if_needed();
     pfn_libttsim_tile_wr_bytes_(x, y, addr, data, size);
 }
 
 void TTSimCommunicator::tile_read_bytes(uint32_t x, uint32_t y, uint64_t addr, void *data, uint32_t size) {
     std::lock_guard<std::mutex> lock(device_lock_);
-    SELECT_CHIP_IF_NEEDED();
+    select_chip_if_needed();
     pfn_libttsim_tile_rd_bytes_(x, y, addr, data, size);
 }
 
 bool TTSimCommunicator::dram_write_bytes(uint32_t x, uint32_t y, uint64_t addr, const void *data, uint32_t size) {
-    if (!v3_5_multichip_mode_ || pfn_libttsim_dram_core_wr_bytes_by_id_ == nullptr) {
+    if (!multichip_mode_ || pfn_libttsim_dram_core_wr_bytes_by_id_ == nullptr) {
         return false;
     }
     std::lock_guard<std::mutex> lock(device_lock_);
@@ -222,7 +223,7 @@ bool TTSimCommunicator::dram_write_bytes(uint32_t x, uint32_t y, uint64_t addr, 
 }
 
 bool TTSimCommunicator::dram_read_bytes(uint32_t x, uint32_t y, uint64_t addr, void *data, uint32_t size) {
-    if (!v3_5_multichip_mode_ || pfn_libttsim_dram_core_rd_bytes_by_id_ == nullptr) {
+    if (!multichip_mode_ || pfn_libttsim_dram_core_rd_bytes_by_id_ == nullptr) {
         return false;
     }
     std::lock_guard<std::mutex> lock(device_lock_);
@@ -232,13 +233,13 @@ bool TTSimCommunicator::dram_read_bytes(uint32_t x, uint32_t y, uint64_t addr, v
 
 void TTSimCommunicator::pci_mem_read_bytes(uint64_t paddr, void *data, uint32_t size) {
     std::lock_guard<std::mutex> lock(device_lock_);
-    SELECT_CHIP_IF_NEEDED();
+    select_chip_if_needed();
     pfn_libttsim_pci_mem_rd_bytes_(paddr, data, size);
 }
 
 void TTSimCommunicator::pci_mem_write_bytes(uint64_t paddr, const void *data, uint32_t size) {
     std::lock_guard<std::mutex> lock(device_lock_);
-    SELECT_CHIP_IF_NEEDED();
+    select_chip_if_needed();
     pfn_libttsim_pci_mem_wr_bytes_(paddr, data, size);
 }
 
@@ -246,14 +247,14 @@ uint32_t TTSimCommunicator::pci_config_read32(uint32_t bus_device_function, uint
     std::lock_guard<std::mutex> lock(device_lock_);
     // pci_config_read32 reads compile-time constants; no chip selection needed.
     // But we still select for consistency and future-proofing.
-    SELECT_CHIP_IF_NEEDED();
+    select_chip_if_needed();
     return pfn_libttsim_pci_config_rd32_(bus_device_function, offset);
 }
 
 void TTSimCommunicator::advance_clock(uint32_t n_clocks) {
     std::lock_guard<std::mutex> lock(device_lock_);
-    if (v3_5_multichip_mode_ && pfn_libttsim_clock_all_devices_) {
-        // v3.5-#8: in shared-dlopen multichip mode, tick ALL chips together so
+    if (multichip_mode_ && pfn_libttsim_clock_all_devices_) {
+        // In shared-dlopen multichip mode, tick ALL chips together so
         // cross-chip eth handshakes converge (chip A waiting on a packet from chip B
         // would otherwise stall -- only the chip being read gets advanced).
         // libttsim_clock_all_devices walks the simulator chip_id registry internally
@@ -261,7 +262,7 @@ void TTSimCommunicator::advance_clock(uint32_t n_clocks) {
         pfn_libttsim_clock_all_devices_(n_clocks);
         return;
     }
-    SELECT_CHIP_IF_NEEDED();
+    select_chip_if_needed();
     pfn_libttsim_clock_(n_clocks);
 }
 
@@ -365,18 +366,18 @@ void TTSimCommunicator::load_simulator_library(const std::filesystem::path &path
     DLSYM_FUNCTION(libttsim_set_pci_dma_mem_callbacks)
 }
 
-// v3.5 eth-MAC wiring methods. All no-ops in legacy single-chip mode.
+// Multichip eth-MAC wiring methods. All no-ops in legacy single-chip mode.
 
 void TTSimCommunicator::switch_reset() {
     std::lock_guard<std::mutex> lock(device_lock_);
-    if (v3_5_multichip_mode_ && pfn_libttsim_switch_reset_) {
+    if (multichip_mode_ && pfn_libttsim_switch_reset_) {
         pfn_libttsim_switch_reset_();
     }
 }
 
 void TTSimCommunicator::register_eth_endpoint(uint32_t eth_tile_id, uint64_t mac) {
     std::lock_guard<std::mutex> lock(device_lock_);
-    if (!v3_5_multichip_mode_ || !dev_handle_) {
+    if (!multichip_mode_ || !dev_handle_) {
         return;
     }
     // Prefer configure_eth_link_virtual: sets link_mode=Virtual + writes
@@ -391,7 +392,7 @@ void TTSimCommunicator::register_eth_endpoint(uint32_t eth_tile_id, uint64_t mac
 
 void TTSimCommunicator::register_peer(uint32_t eth_tile_id, void *peer_dev, uint32_t peer_tile_id) {
     std::lock_guard<std::mutex> lock(device_lock_);
-    if (!v3_5_multichip_mode_ || !dev_handle_ || !pfn_libttsim_switch_register_peer_ || !peer_dev) {
+    if (!multichip_mode_ || !dev_handle_ || !pfn_libttsim_switch_register_peer_ || !peer_dev) {
         return;
     }
     pfn_libttsim_switch_register_peer_(dev_handle_, eth_tile_id, peer_dev, peer_tile_id);
@@ -399,7 +400,7 @@ void TTSimCommunicator::register_peer(uint32_t eth_tile_id, void *peer_dev, uint
 
 void TTSimCommunicator::register_fabric_node_id(uint32_t mesh_id, uint32_t chip_id) {
     std::lock_guard<std::mutex> lock(device_lock_);
-    if (!v3_5_multichip_mode_ || !dev_handle_ || !pfn_libttsim_switch_register_fabric_node_id_) {
+    if (!multichip_mode_ || !dev_handle_ || !pfn_libttsim_switch_register_fabric_node_id_) {
         return;
     }
     pfn_libttsim_switch_register_fabric_node_id_(dev_handle_, mesh_id, chip_id);
@@ -407,7 +408,7 @@ void TTSimCommunicator::register_fabric_node_id(uint32_t mesh_id, uint32_t chip_
 
 void TTSimCommunicator::register_fabric_endpoint_direction(uint32_t eth_tile_id, uint32_t direction) {
     std::lock_guard<std::mutex> lock(device_lock_);
-    if (!v3_5_multichip_mode_ || !dev_handle_ || !pfn_libttsim_switch_register_fabric_endpoint_direction_) {
+    if (!multichip_mode_ || !dev_handle_ || !pfn_libttsim_switch_register_fabric_endpoint_direction_) {
         return;
     }
     pfn_libttsim_switch_register_fabric_endpoint_direction_(dev_handle_, eth_tile_id, direction);
@@ -415,7 +416,7 @@ void TTSimCommunicator::register_fabric_endpoint_direction(uint32_t eth_tile_id,
 
 void TTSimCommunicator::switch_drain() {
     std::lock_guard<std::mutex> lock(device_lock_);
-    if (v3_5_multichip_mode_ && pfn_libttsim_switch_drain_) {
+    if (multichip_mode_ && pfn_libttsim_switch_drain_) {
         pfn_libttsim_switch_drain_();
     }
 }

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -181,6 +181,12 @@ void TTSimCommunicator::start_sim() {
 
 void TTSimCommunicator::shutdown() {
     std::lock_guard<std::mutex> lock(device_lock_);
+    // Guard against double-shutdown: close_device() calls mark_closed() then
+    // shutdown(); the destructor also calls shutdown(). Without this check the
+    // destructor would call pfn_libttsim_exit_() a second time.
+    if (closed_) {
+        return;
+    }
     log_info(tt::LogEmulationDriver, "Sending exit signal to remote...");
     if (multichip_mode_) {
         // Defer libttsim_exit until the last communicator destructs (handled

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -426,9 +426,9 @@ std::vector<CoreCoord> SocDescriptor::translate_coordinates(
     return translated_cores;
 }
 
-bool SocDescriptor::is_core_of_type(const tt_xy_pair& core, CoreType core_type, CoordSystem coord_system) const {
-    const auto& cores = get_cores(core_type, coord_system);
-    return std::any_of(cores.begin(), cores.end(), [&core](const auto& c) { return c.x == core.x && c.y == core.y; });
+bool SocDescriptor::is_core_of_type(const tt_xy_pair &core, CoreType core_type, CoordSystem coord_system) const {
+    const auto &cores = get_cores(core_type, coord_system);
+    return std::any_of(cores.begin(), cores.end(), [&core](const auto &c) { return c.x == core.x && c.y == core.y; });
 }
 
 std::vector<CoreCoord> SocDescriptor::get_cores(

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -7,6 +7,7 @@
 #include <fmt/format.h>
 #include <yaml-cpp/yaml.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -423,6 +424,11 @@ std::vector<CoreCoord> SocDescriptor::translate_coordinates(
         translated_cores.push_back(translate_coord_to(core, coord_system));
     }
     return translated_cores;
+}
+
+bool SocDescriptor::is_core_of_type(const tt_xy_pair& core, CoreType core_type, CoordSystem coord_system) const {
+    const auto& cores = get_cores(core_type, coord_system);
+    return std::any_of(cores.begin(), cores.end(), [&core](const auto& c) { return c.x == core.x && c.y == core.y; });
 }
 
 std::vector<CoreCoord> SocDescriptor::get_cores(

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -4,7 +4,6 @@
 
 #include "umd/device/tt_device/tt_sim_tt_device.hpp"
 
-#include <algorithm>
 #include <cstdlib>
 #include <filesystem>
 #include <functional>
@@ -48,13 +47,6 @@ bool sim_dram_teleport_enabled() {
         return value == "1" || value == "true" || value == "TRUE" || value == "on" || value == "ON";
     }();
     return enabled;
-}
-
-bool is_translated_dram_core(const SocDescriptor& soc_descriptor, tt_xy_pair core) {
-    const auto& dram_cores = soc_descriptor.get_cores(CoreType::DRAM, CoordSystem::TRANSLATED);
-    return std::any_of(dram_cores.begin(), dram_cores.end(), [&core](const auto& dram_core) {
-        return dram_core.x == core.x && dram_core.y == core.y;
-    });
 }
 
 }  // namespace
@@ -189,7 +181,7 @@ void TTSimTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64
     }
     std::lock_guard<std::recursive_mutex> lock(device_lock);
     if (sim_dram_teleport_enabled()) {
-        if (is_translated_dram_core(get_soc_descriptor(), core)) {
+        if (get_soc_descriptor().is_core_of_type(core, CoreType::DRAM, CoordSystem::TRANSLATED)) {
             if (communicator_->dram_write_bytes(core.x, core.y, addr, mem_ptr, size)) {
                 return;
             }
@@ -210,7 +202,7 @@ void TTSimTTDevice::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t ad
     }
     std::lock_guard<std::recursive_mutex> lock(device_lock);
     if (sim_dram_teleport_enabled()) {
-        if (is_translated_dram_core(get_soc_descriptor(), core)) {
+        if (get_soc_descriptor().is_core_of_type(core, CoreType::DRAM, CoordSystem::TRANSLATED)) {
             if (!communicator_->dram_read_bytes(core.x, core.y, addr, mem_ptr, size)) {
                 communicator_->tile_read_bytes(core.x, core.y, addr, mem_ptr, size);
             }

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -5,9 +5,11 @@
 #include "umd/device/tt_device/tt_sim_tt_device.hpp"
 
 #include <algorithm>
+#include <cstdlib>
 #include <filesystem>
 #include <functional>
 #include <string>
+#include <string_view>
 #include <tt-logger/tt-logger.hpp>
 #include <type_traits>
 #include <utility>
@@ -33,6 +35,30 @@ namespace tt::umd {
 
 static_assert(!std::is_abstract<TTSimTTDevice>(), "TTSimChip must be non-abstract.");
 
+namespace {
+
+bool sim_dram_teleport_enabled() {
+    // Cache the result since this is called on every device read/write.
+    static const bool enabled = [] {
+        const char* env = std::getenv("TT_METAL_SIMULATOR_DRAM_TELEPORT");
+        if (env == nullptr) {
+            return false;
+        }
+        std::string_view value(env);
+        return value == "1" || value == "true" || value == "TRUE" || value == "on" || value == "ON";
+    }();
+    return enabled;
+}
+
+bool is_translated_dram_core(const SocDescriptor& soc_descriptor, tt_xy_pair core) {
+    const auto& dram_cores = soc_descriptor.get_cores(CoreType::DRAM, CoordSystem::TRANSLATED);
+    return std::any_of(dram_cores.begin(), dram_cores.end(), [&core](const auto& dram_core) {
+        return dram_core.x == core.x && dram_core.y == core.y;
+    });
+}
+
+}  // namespace
+
 std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create(
     const std::filesystem::path& simulator_directory, int num_host_mem_channels, bool copy_sim_binary) {
     auto soc_desc_path = SimulationChip::get_soc_descriptor_path_from_simulator_path(simulator_directory);
@@ -55,7 +81,13 @@ TTSimTTDevice::TTSimTTDevice(
     ChipId chip_id,
     bool copy_sim_binary,
     int num_host_mem_channels) :
-    communicator_(std::make_unique<TTSimCommunicator>(simulator_directory, copy_sim_binary)),
+    TTDevice(architecture_implementation::create(soc_descriptor.arch)),
+    // Pass chip_id to the communicator. If the loaded .so supports the v3.5
+    // multichip ABI (libttsim_create_device_by_id + libttsim_select_device_by_id),
+    // the communicator will auto-detect at initialize() time and switch to
+    // shared-dlopen mode regardless of copy_sim_binary.
+    communicator_(
+        std::make_unique<TTSimCommunicator>(simulator_directory, copy_sim_binary, static_cast<uint32_t>(chip_id))),
     simulator_directory_(simulator_directory),
     chip_id_(chip_id),
     sysmem_manager_(std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)) {
@@ -88,7 +120,7 @@ TTSimTTDevice::TTSimTTDevice(
         bar0_base &= ~15ull;  // ignore attributes, just obtain the physical address
 
         // BAR4 is a 64-bit memory BAR; its base address is split across two PCI config
-        // registers — 0x20 holds the low 32 bits, 0x24 holds the high 32 bits. The low 4 bits
+        // registers -- 0x20 holds the low 32 bits, 0x24 holds the high 32 bits. The low 4 bits
         // of the low register encode BAR attributes (memory vs IO, prefetchable, 64-bit width)
         // and are masked off to leave the physical address.
         bar4_base = communicator_->pci_config_read32(0, 0x20);
@@ -105,7 +137,7 @@ TTSimTTDevice::TTSimTTDevice(
     tlb_allocator_ = std::make_shared<SimulationTlbAllocator>(bar0_base, architecture_impl_.get());
 
     // Allocate the cached default TLB window. Quasar has no real TLBs; the communicator handles
-    // all I/O underneath. The 4GB size for Quasar is a dummy value — it just needs to be large
+    // all I/O underneath. The 4GB size for Quasar is a dummy value -- it just needs to be large
     // enough so that TlbWindow::validate doesn't reject any valid access (size 0 would cause
     // division by zero in TLB handle configure).
     static constexpr size_t SIZE_2MB = 2 * 1024 * 1024;
@@ -144,8 +176,27 @@ std::unique_ptr<TlbWindow> TTSimTTDevice::get_io_window(tlb_data config, TlbMapp
 
 TTSimTTDevice::~TTSimTTDevice() { communicator_->shutdown(); }
 
+void TTSimTTDevice::start_device() {}
+
+void TTSimTTDevice::close_device() {
+    communicator_->mark_closed();
+    communicator_->shutdown();
+}
+
 void TTSimTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
+    if (communicator_->is_closed()) {
+        return;
+    }
     std::lock_guard<std::recursive_mutex> lock(device_lock);
+    if (sim_dram_teleport_enabled()) {
+        if (is_translated_dram_core(get_soc_descriptor(), core)) {
+            if (communicator_->dram_write_bytes(core.x, core.y, addr, mem_ptr, size)) {
+                return;
+            }
+            communicator_->tile_write_bytes(core.x, core.y, addr, mem_ptr, size);
+            return;
+        }
+    }
     if (get_arch() != tt::ARCH::QUASAR && cached_tlb_window_) {
         cached_tlb_window_->write_block_reconfigure(mem_ptr, core, addr, size, get_selected_noc_id());
     } else {
@@ -154,7 +205,19 @@ void TTSimTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64
 }
 
 void TTSimTTDevice::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
+    if (communicator_->is_closed()) {
+        return;
+    }
     std::lock_guard<std::recursive_mutex> lock(device_lock);
+    if (sim_dram_teleport_enabled()) {
+        if (is_translated_dram_core(get_soc_descriptor(), core)) {
+            if (!communicator_->dram_read_bytes(core.x, core.y, addr, mem_ptr, size)) {
+                communicator_->tile_read_bytes(core.x, core.y, addr, mem_ptr, size);
+            }
+            communicator_->advance_clock(10);
+            return;
+        }
+    }
     if (get_arch() != tt::ARCH::QUASAR && cached_tlb_window_) {
         cached_tlb_window_->read_block_reconfigure(mem_ptr, core, addr, size, get_selected_noc_id());
     } else {

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -53,6 +53,11 @@ bool sim_dram_teleport_enabled() {
 
 std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create(
     const std::filesystem::path& simulator_directory, int num_host_mem_channels, bool copy_sim_binary) {
+    return TTSimTTDevice::create(simulator_directory, /* chip_id= */ static_cast<ChipId>(0), copy_sim_binary);
+}
+
+std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create(
+    const std::filesystem::path& simulator_directory, ChipId chip_id, bool copy_sim_binary) {
     auto soc_desc_path = SimulationChip::get_soc_descriptor_path_from_simulator_path(simulator_directory);
     tt::ARCH arch = SocDescriptor::get_arch_from_soc_descriptor_path(soc_desc_path);
     ChipInfo chip_info{};
@@ -63,8 +68,7 @@ std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create(
         chip_info.harvesting_masks.eth_harvesting_mask = 0x120;
     }
     SocDescriptor soc_descriptor = SocDescriptor(std::make_shared<SocArchDescriptor>(soc_desc_path), chip_info);
-    return std::make_unique<TTSimTTDevice>(
-        simulator_directory, soc_descriptor, 0, copy_sim_binary, num_host_mem_channels);
+    return std::make_unique<TTSimTTDevice>(simulator_directory, soc_descriptor, chip_id, copy_sim_binary, 0);
 }
 
 TTSimTTDevice::TTSimTTDevice(

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -40,7 +40,7 @@ namespace {
 bool sim_dram_teleport_enabled() {
     // Cache the result since this is called on every device read/write.
     static const bool enabled = [] {
-        const char* env = std::getenv("TT_METAL_SIMULATOR_DRAM_TELEPORT");
+        const char* env = std::getenv("TT_SIMULATOR_DRAM_TELEPORT");
         if (env == nullptr) {
             return false;
         }
@@ -82,7 +82,7 @@ TTSimTTDevice::TTSimTTDevice(
     bool copy_sim_binary,
     int num_host_mem_channels) :
     TTDevice(architecture_implementation::create(soc_descriptor.arch)),
-    // Pass chip_id to the communicator. If the loaded .so supports the v3.5
+    // Pass chip_id to the communicator. If the loaded .so supports the multichip
     // multichip ABI (libttsim_create_device_by_id + libttsim_select_device_by_id),
     // the communicator will auto-detect at initialize() time and switch to
     // shared-dlopen mode regardless of copy_sim_binary.

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -53,10 +53,10 @@ bool sim_dram_teleport_enabled() {
 
 std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create(
     const std::filesystem::path& simulator_directory, int num_host_mem_channels, bool copy_sim_binary) {
-    return TTSimTTDevice::create(simulator_directory, /* chip_id= */ static_cast<ChipId>(0), copy_sim_binary);
+    return TTSimTTDevice::create_for_chip(simulator_directory, /* chip_id= */ static_cast<ChipId>(0), copy_sim_binary);
 }
 
-std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create(
+std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create_for_chip(
     const std::filesystem::path& simulator_directory, ChipId chip_id, bool copy_sim_binary) {
     auto soc_desc_path = SimulationChip::get_soc_descriptor_path_from_simulator_path(simulator_directory);
     tt::ARCH arch = SocDescriptor::get_arch_from_soc_descriptor_path(soc_desc_path);

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -8,6 +8,7 @@ set(API_TESTS_SRCS
     test_tlb_manager.cpp
     test_sysmem_manager.cpp
     test_simulation_sysmem_manager.cpp
+    test_sim_multichip.cpp
     test_tt_device.cpp
     test_spi_tt_device.cpp
     test_noc.cpp

--- a/tests/api/test_sim_multichip.cpp
+++ b/tests/api/test_sim_multichip.cpp
@@ -39,7 +39,7 @@ class IsCoreOfTypeTest : public ::testing::TestWithParam<ARCH> {};
 
 TEST_P(IsCoreOfTypeTest, DramCoreIsIdentifiedCorrectly) {
     const ARCH arch = GetParam();
-    const std::string sdesc_path = get_soc_descriptor_path(arch);
+    const std::string sdesc_path = test_utils::get_soc_descriptor_path(arch);
     SocDescriptor soc(std::make_shared<SocArchDescriptor>(sdesc_path));
 
     // Every core returned by get_cores(DRAM, TRANSLATED) must satisfy is_core_of_type.
@@ -55,7 +55,7 @@ TEST_P(IsCoreOfTypeTest, DramCoreIsIdentifiedCorrectly) {
 
 TEST_P(IsCoreOfTypeTest, TensixCoreIsNotDram) {
     const ARCH arch = GetParam();
-    const std::string sdesc_path = get_soc_descriptor_path(arch);
+    const std::string sdesc_path = test_utils::get_soc_descriptor_path(arch);
     SocDescriptor soc(std::make_shared<SocArchDescriptor>(sdesc_path));
 
     auto tensix_cores = soc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
@@ -72,7 +72,7 @@ TEST_P(IsCoreOfTypeTest, TensixCoreIsNotDram) {
 
 TEST_P(IsCoreOfTypeTest, EthCoreIsIdentifiedCorrectly) {
     const ARCH arch = GetParam();
-    const std::string sdesc_path = get_soc_descriptor_path(arch);
+    const std::string sdesc_path = test_utils::get_soc_descriptor_path(arch);
     SocDescriptor soc(std::make_shared<SocArchDescriptor>(sdesc_path));
 
     auto eth_cores = soc.get_cores(CoreType::ETH, CoordSystem::TRANSLATED);

--- a/tests/api/test_sim_multichip.cpp
+++ b/tests/api/test_sim_multichip.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -114,10 +114,13 @@ TEST_P(IsCoreOfTypeTest, GarbageXYIsNotAnyKnownType) {
     EXPECT_FALSE(soc.is_core_of_type(garbage, CoreType::PCIE, CoordSystem::TRANSLATED));
 }
 
+// QUASAR is included because is_core_of_type's DRAM-teleport path in
+// tt_sim_tt_device.cpp special-cases it, and a quasar_simulation_1x1.yaml
+// descriptor is available in the repo.
 INSTANTIATE_TEST_SUITE_P(
     AllArchs,
     IsCoreOfTypeTest,
-    ::testing::Values(ARCH::WORMHOLE_B0, ARCH::BLACKHOLE),
+    ::testing::Values(ARCH::WORMHOLE_B0, ARCH::BLACKHOLE, ARCH::QUASAR),
     [](const ::testing::TestParamInfo<ARCH>& info) { return arch_to_str(info.param); });
 
 // ---------------------------------------------------------------------------
@@ -139,24 +142,6 @@ protected:
     const char* simulator_path_ = nullptr;
 };
 
-// Verify that two communicators targeting different chip IDs can be
-// constructed from the same simulator directory. In multichip mode they
-// share a single dlopen handle (refcount = 2).
-TEST_F(TTSimCommunicatorTest, TwoCommunicatorsShareHandle) {
-    // chip_id 0 and 1 -- does not need a real multi-chip sim binary;
-    // the constructor merely stores chip_id, actual multichip detection
-    // happens in initialize() which we skip here to avoid needing a
-    // live simulator.
-    TTSimCommunicator comm_0(simulator_path_, /* copy_sim_binary= */ false, /* chip_id= */ 0);
-    TTSimCommunicator comm_1(simulator_path_, /* copy_sim_binary= */ false, /* chip_id= */ 1);
-
-    // Both communicators exist without throwing.
-    // If the .so supports multichip ABI, initialize() would set them up
-    // with shared dlopen. Without calling initialize() we just verify
-    // construction is safe.
-    SUCCEED();
-}
-
 // Verify that TTSimTTDevice::create produces a non-null device.
 TEST_F(TTSimCommunicatorTest, CreateSimDevice) {
     auto device = TTSimTTDevice::create(simulator_path_);
@@ -166,41 +151,47 @@ TEST_F(TTSimCommunicatorTest, CreateSimDevice) {
     EXPECT_NE(soc.arch, ARCH::Invalid);
 }
 
-// Verify that constructing two TTSimCommunicator instances with the SAME
-// simulator path but different chip_ids does not crash on destruction.
-// This exercises the shared dlopen refcount (2 -> 1 -> 0).
-TEST_F(TTSimCommunicatorTest, SharedDlopenRefcount) {
-    {
-        TTSimCommunicator comm_a(simulator_path_, /* copy_sim_binary= */ false, /* chip_id= */ 0);
-        TTSimCommunicator comm_b(simulator_path_, /* copy_sim_binary= */ false, /* chip_id= */ 1);
-        // Both alive; shared refcount should be 2.
-    }
-    // Both destroyed; refcount should have gone 2 -> 1 -> 0 without crash.
-    SUCCEED();
-}
-
-// Create a TTSimTTDevice, close it, then verify that close_device() can be
-// called again without crashing (idempotency via closed_ flag).
-TEST_F(TTSimCommunicatorTest, IOAfterCloseIsSafe) {
+// Verify that write_to_device after close_device() is a no-op (closed_ guard).
+// Also verifies that a second close_device() and the destructor do not
+// double-call pfn_libttsim_exit_ (shutdown() honours closed_).
+TEST_F(TTSimCommunicatorTest, WriteAfterCloseIsNoOp) {
     auto device = TTSimTTDevice::create(simulator_path_);
     ASSERT_NE(device, nullptr);
 
+    const auto& soc = device->get_soc_descriptor();
+    auto dram_cores = soc.get_cores(CoreType::DRAM, CoordSystem::TRANSLATED);
+    if (dram_cores.empty()) {
+        GTEST_SKIP() << "No DRAM cores; cannot run I/O test.";
+    }
+
+    tt_xy_pair target{dram_cores[0].x, dram_cores[0].y};
+
+    // Write a sentinel before close.
+    uint32_t sentinel = 0xCAFEBABE;
+    device->write_to_device(&sentinel, target, 0, sizeof(sentinel));
+
     device->close_device();
 
-    // A second close should not crash.
+    // write_to_device after close must not crash (closed_ guard makes it a no-op).
+    uint32_t after_close = 0xDEADBEEF;
+    EXPECT_NO_THROW(device->write_to_device(&after_close, target, 0, sizeof(after_close)));
+
+    // A second close_device() must not crash either (shutdown() checks closed_).
     EXPECT_NO_THROW(device->close_device());
+    // Destructor also calls shutdown() — again honoured by the closed_ guard.
 }
 
-// Two TTSimTTDevice instances writing and reading back independently.
-// This implicitly exercises select_chip_if_needed for each I/O call.
+// Two TTSimTTDevice instances with distinct chip_ids writing and reading back
+// independently. Exercises select_chip_if_needed for each I/O call.
 TEST_F(TTSimCommunicatorTest, TwoDevicesIndependentIO) {
-    auto dev_0 = TTSimTTDevice::create(simulator_path_);
+    // Use the chip_id overload so the two devices target different simulated chips.
+    auto dev_0 = TTSimTTDevice::create(simulator_path_, /* chip_id= */ static_cast<ChipId>(0));
     ASSERT_NE(dev_0, nullptr);
 
     // If the simulator binary is single-chip, we cannot open a second device.
     std::unique_ptr<TTSimTTDevice> dev_1;
     try {
-        dev_1 = TTSimTTDevice::create(simulator_path_);
+        dev_1 = TTSimTTDevice::create(simulator_path_, /* chip_id= */ static_cast<ChipId>(1));
     } catch (const std::exception&) {
         GTEST_SKIP() << "Simulator does not support multiple devices; skipping multi-device I/O test.";
     }

--- a/tests/api/test_sim_multichip.cpp
+++ b/tests/api/test_sim_multichip.cpp
@@ -185,13 +185,13 @@ TEST_F(TTSimCommunicatorTest, WriteAfterCloseIsNoOp) {
 // independently. Exercises select_chip_if_needed for each I/O call.
 TEST_F(TTSimCommunicatorTest, TwoDevicesIndependentIO) {
     // Use the chip_id overload so the two devices target different simulated chips.
-    auto dev_0 = TTSimTTDevice::create(simulator_path_, /* chip_id= */ static_cast<ChipId>(0));
+    auto dev_0 = TTSimTTDevice::create_for_chip(simulator_path_, /* chip_id= */ static_cast<ChipId>(0));
     ASSERT_NE(dev_0, nullptr);
 
     // If the simulator binary is single-chip, we cannot open a second device.
     std::unique_ptr<TTSimTTDevice> dev_1;
     try {
-        dev_1 = TTSimTTDevice::create(simulator_path_, /* chip_id= */ static_cast<ChipId>(1));
+        dev_1 = TTSimTTDevice::create_for_chip(simulator_path_, /* chip_id= */ static_cast<ChipId>(1));
     } catch (const std::exception&) {
         GTEST_SKIP() << "Simulator does not support multiple devices; skipping multi-device I/O test.";
     }

--- a/tests/api/test_sim_multichip.cpp
+++ b/tests/api/test_sim_multichip.cpp
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the simulation multichip core infrastructure:
+// - SocDescriptor::is_core_of_type (moved from a local helper in tt_sim_tt_device.cpp)
+// - TTSimCommunicator shared dlopen / select_chip_if_needed patterns
+//
+// The SocDescriptor tests run on any CI host (no hardware required).
+// The communicator tests require TT_UMD_SIMULATOR and are skipped otherwise.
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+
+#include "tests/test_utils/fetch_local_files.hpp"
+#include "umd/device/soc_arch_descriptor.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/xy_pair.hpp"
+
+#ifdef TT_UMD_BUILD_SIMULATION
+#include "umd/device/simulation/tt_sim_communicator.hpp"
+#include "umd/device/tt_device/tt_sim_tt_device.hpp"
+#endif
+
+using namespace tt;
+using namespace tt::umd;
+
+// ---------------------------------------------------------------------------
+// SocDescriptor::is_core_of_type
+// ---------------------------------------------------------------------------
+
+class IsCoreOfTypeTest : public ::testing::TestWithParam<ARCH> {};
+
+TEST_P(IsCoreOfTypeTest, DramCoreIsIdentifiedCorrectly) {
+    const ARCH arch = GetParam();
+    const std::string sdesc_path = get_soc_descriptor_path(arch);
+    SocDescriptor soc(std::make_shared<SocArchDescriptor>(sdesc_path));
+
+    // Every core returned by get_cores(DRAM, TRANSLATED) must satisfy is_core_of_type.
+    auto dram_cores = soc.get_cores(CoreType::DRAM, CoordSystem::TRANSLATED);
+    ASSERT_FALSE(dram_cores.empty()) << "Expected at least one DRAM core for arch " << arch_to_str(arch);
+
+    for (const auto& core : dram_cores) {
+        tt_xy_pair xy{core.x, core.y};
+        EXPECT_TRUE(soc.is_core_of_type(xy, CoreType::DRAM, CoordSystem::TRANSLATED))
+            << "DRAM core (" << xy.x << ", " << xy.y << ") not recognized by is_core_of_type";
+    }
+}
+
+TEST_P(IsCoreOfTypeTest, TensixCoreIsNotDram) {
+    const ARCH arch = GetParam();
+    const std::string sdesc_path = get_soc_descriptor_path(arch);
+    SocDescriptor soc(std::make_shared<SocArchDescriptor>(sdesc_path));
+
+    auto tensix_cores = soc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
+    if (tensix_cores.empty()) {
+        GTEST_SKIP() << "No TENSIX cores for arch " << arch_to_str(arch);
+    }
+
+    for (const auto& core : tensix_cores) {
+        tt_xy_pair xy{core.x, core.y};
+        EXPECT_FALSE(soc.is_core_of_type(xy, CoreType::DRAM, CoordSystem::TRANSLATED))
+            << "TENSIX core (" << xy.x << ", " << xy.y << ") wrongly identified as DRAM";
+    }
+}
+
+TEST_P(IsCoreOfTypeTest, EthCoreIsIdentifiedCorrectly) {
+    const ARCH arch = GetParam();
+    const std::string sdesc_path = get_soc_descriptor_path(arch);
+    SocDescriptor soc(std::make_shared<SocArchDescriptor>(sdesc_path));
+
+    auto eth_cores = soc.get_cores(CoreType::ETH, CoordSystem::TRANSLATED);
+    if (eth_cores.empty()) {
+        GTEST_SKIP() << "No ETH cores for arch " << arch_to_str(arch);
+    }
+
+    for (const auto& core : eth_cores) {
+        tt_xy_pair xy{core.x, core.y};
+        EXPECT_TRUE(soc.is_core_of_type(xy, CoreType::ETH, CoordSystem::TRANSLATED))
+            << "ETH core (" << xy.x << ", " << xy.y << ") not recognized by is_core_of_type";
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllArchs,
+    IsCoreOfTypeTest,
+    ::testing::Values(ARCH::WORMHOLE_B0, ARCH::BLACKHOLE),
+    [](const ::testing::TestParamInfo<ARCH>& info) { return arch_to_str(info.param); });
+
+// ---------------------------------------------------------------------------
+// TTSimCommunicator: shared dlopen and chip selection
+// These tests require a running simulator (TT_UMD_SIMULATOR env var).
+// ---------------------------------------------------------------------------
+
+#ifdef TT_UMD_BUILD_SIMULATION
+
+class TTSimCommunicatorTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        simulator_path_ = std::getenv("TT_UMD_SIMULATOR");
+        if (simulator_path_ == nullptr) {
+            GTEST_SKIP() << "TT_UMD_SIMULATOR is not set. Skipping communicator tests.";
+        }
+    }
+
+    const char* simulator_path_ = nullptr;
+};
+
+// Verify that two communicators targeting different chip IDs can be
+// constructed from the same simulator directory. In multichip mode they
+// share a single dlopen handle (refcount = 2).
+TEST_F(TTSimCommunicatorTest, TwoCommunicatorsShareHandle) {
+    // chip_id 0 and 1 -- does not need a real multi-chip sim binary;
+    // the constructor merely stores chip_id, actual multichip detection
+    // happens in initialize() which we skip here to avoid needing a
+    // live simulator.
+    TTSimCommunicator comm_0(simulator_path_, /* copy_sim_binary= */ false, /* chip_id= */ 0);
+    TTSimCommunicator comm_1(simulator_path_, /* copy_sim_binary= */ false, /* chip_id= */ 1);
+
+    // Both communicators exist without throwing.
+    // If the .so supports multichip ABI, initialize() would set them up
+    // with shared dlopen. Without calling initialize() we just verify
+    // construction is safe.
+    SUCCEED();
+}
+
+// Verify that TTSimTTDevice::create produces a non-null device.
+TEST_F(TTSimCommunicatorTest, CreateSimDevice) {
+    auto device = TTSimTTDevice::create(simulator_path_);
+    ASSERT_NE(device, nullptr);
+    // The device should have a valid soc descriptor.
+    const auto& soc = device->get_soc_descriptor();
+    EXPECT_NE(soc.arch, ARCH::Invalid);
+}
+
+#endif  // TT_UMD_BUILD_SIMULATION

--- a/tests/api/test_sim_multichip.cpp
+++ b/tests/api/test_sim_multichip.cpp
@@ -87,6 +87,20 @@ TEST_P(IsCoreOfTypeTest, EthCoreIsIdentifiedCorrectly) {
     }
 }
 
+TEST_P(IsCoreOfTypeTest, GarbageXYIsNotAnyKnownType) {
+    const ARCH arch = GetParam();
+    const std::string sdesc_path = test_utils::get_soc_descriptor_path(arch);
+    SocDescriptor soc(std::make_shared<SocArchDescriptor>(sdesc_path));
+
+    // Use an absurdly large coordinate that cannot belong to any real core.
+    tt_xy_pair garbage{9999, 9999};
+    EXPECT_FALSE(soc.is_core_of_type(garbage, CoreType::DRAM, CoordSystem::TRANSLATED));
+    EXPECT_FALSE(soc.is_core_of_type(garbage, CoreType::TENSIX, CoordSystem::TRANSLATED));
+    EXPECT_FALSE(soc.is_core_of_type(garbage, CoreType::ETH, CoordSystem::TRANSLATED));
+    EXPECT_FALSE(soc.is_core_of_type(garbage, CoreType::ARC, CoordSystem::TRANSLATED));
+    EXPECT_FALSE(soc.is_core_of_type(garbage, CoreType::PCIE, CoordSystem::TRANSLATED));
+}
+
 INSTANTIATE_TEST_SUITE_P(
     AllArchs,
     IsCoreOfTypeTest,
@@ -137,6 +151,76 @@ TEST_F(TTSimCommunicatorTest, CreateSimDevice) {
     // The device should have a valid soc descriptor.
     const auto& soc = device->get_soc_descriptor();
     EXPECT_NE(soc.arch, ARCH::Invalid);
+}
+
+// Verify that constructing two TTSimCommunicator instances with the SAME
+// simulator path but different chip_ids does not crash on destruction.
+// This exercises the shared dlopen refcount (2 -> 1 -> 0).
+TEST_F(TTSimCommunicatorTest, SharedDlopenRefcount) {
+    {
+        TTSimCommunicator comm_a(simulator_path_, /* copy_sim_binary= */ false, /* chip_id= */ 0);
+        TTSimCommunicator comm_b(simulator_path_, /* copy_sim_binary= */ false, /* chip_id= */ 1);
+        // Both alive; shared refcount should be 2.
+    }
+    // Both destroyed; refcount should have gone 2 -> 1 -> 0 without crash.
+    SUCCEED();
+}
+
+// Create a TTSimTTDevice, close it, then verify that close_device() can be
+// called again without crashing (idempotency via closed_ flag).
+TEST_F(TTSimCommunicatorTest, IOAfterCloseIsSafe) {
+    auto device = TTSimTTDevice::create(simulator_path_);
+    ASSERT_NE(device, nullptr);
+
+    device->close_device();
+
+    // A second close should not crash.
+    EXPECT_NO_THROW(device->close_device());
+}
+
+// Two TTSimTTDevice instances writing and reading back independently.
+// This implicitly exercises select_chip_if_needed for each I/O call.
+TEST_F(TTSimCommunicatorTest, TwoDevicesIndependentIO) {
+    auto dev_0 = TTSimTTDevice::create(simulator_path_);
+    ASSERT_NE(dev_0, nullptr);
+
+    // If the simulator binary is single-chip, we cannot open a second device.
+    std::unique_ptr<TTSimTTDevice> dev_1;
+    try {
+        dev_1 = TTSimTTDevice::create(simulator_path_);
+    } catch (const std::exception&) {
+        GTEST_SKIP() << "Simulator does not support multiple devices; skipping multi-device I/O test.";
+    }
+    ASSERT_NE(dev_1, nullptr);
+
+    const auto& soc_0 = dev_0->get_soc_descriptor();
+    auto dram_cores = soc_0.get_cores(CoreType::DRAM, CoordSystem::TRANSLATED);
+    if (dram_cores.empty()) {
+        GTEST_SKIP() << "No DRAM cores; cannot run I/O test.";
+    }
+
+    tt_xy_pair target{dram_cores[0].x, dram_cores[0].y};
+
+    // Write a pattern to device 0.
+    uint32_t pattern_0 = 0xDEAD0000;
+    dev_0->write_to_device(&pattern_0, target, 0, sizeof(pattern_0));
+
+    // Write a different pattern to device 1 at the same address.
+    uint32_t pattern_1 = 0xBEEF0001;
+    dev_1->write_to_device(&pattern_1, target, 0, sizeof(pattern_1));
+
+    // Read back from device 0 — should still see pattern_0.
+    uint32_t readback_0 = 0;
+    dev_0->read_from_device(&readback_0, target, 0, sizeof(readback_0));
+    EXPECT_EQ(readback_0, pattern_0);
+
+    // Read back from device 1 — should see pattern_1.
+    uint32_t readback_1 = 0;
+    dev_1->read_from_device(&readback_1, target, 0, sizeof(readback_1));
+    EXPECT_EQ(readback_1, pattern_1);
+
+    dev_0->close_device();
+    dev_1->close_device();
 }
 
 #endif  // TT_UMD_BUILD_SIMULATION

--- a/tests/api/test_sim_multichip.cpp
+++ b/tests/api/test_sim_multichip.cpp
@@ -35,12 +35,25 @@ using namespace tt::umd;
 // SocDescriptor::is_core_of_type
 // ---------------------------------------------------------------------------
 
+// Return a ChipInfo that satisfies per-arch harvesting constraints so that
+// SocDescriptor construction does not throw.
+//
+// Blackhole: BlackholeCoordinateManager requires exactly 2 or NUM_ETH_CHANNELS
+// ETH cores harvested on a full grid.  Use the minimal valid case (2 channels).
+static ChipInfo make_valid_chip_info(ARCH arch) {
+    ChipInfo info{};
+    if (arch == ARCH::BLACKHOLE) {
+        info.harvesting_masks.eth_harvesting_mask = 0x3;  // harvest channels 0 & 1
+    }
+    return info;
+}
+
 class IsCoreOfTypeTest : public ::testing::TestWithParam<ARCH> {};
 
 TEST_P(IsCoreOfTypeTest, DramCoreIsIdentifiedCorrectly) {
     const ARCH arch = GetParam();
     const std::string sdesc_path = test_utils::get_soc_descriptor_path(arch);
-    SocDescriptor soc(std::make_shared<SocArchDescriptor>(sdesc_path));
+    SocDescriptor soc(std::make_shared<SocArchDescriptor>(sdesc_path), make_valid_chip_info(arch));
 
     // Every core returned by get_cores(DRAM, TRANSLATED) must satisfy is_core_of_type.
     auto dram_cores = soc.get_cores(CoreType::DRAM, CoordSystem::TRANSLATED);
@@ -56,7 +69,7 @@ TEST_P(IsCoreOfTypeTest, DramCoreIsIdentifiedCorrectly) {
 TEST_P(IsCoreOfTypeTest, TensixCoreIsNotDram) {
     const ARCH arch = GetParam();
     const std::string sdesc_path = test_utils::get_soc_descriptor_path(arch);
-    SocDescriptor soc(std::make_shared<SocArchDescriptor>(sdesc_path));
+    SocDescriptor soc(std::make_shared<SocArchDescriptor>(sdesc_path), make_valid_chip_info(arch));
 
     auto tensix_cores = soc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
     if (tensix_cores.empty()) {
@@ -73,7 +86,7 @@ TEST_P(IsCoreOfTypeTest, TensixCoreIsNotDram) {
 TEST_P(IsCoreOfTypeTest, EthCoreIsIdentifiedCorrectly) {
     const ARCH arch = GetParam();
     const std::string sdesc_path = test_utils::get_soc_descriptor_path(arch);
-    SocDescriptor soc(std::make_shared<SocArchDescriptor>(sdesc_path));
+    SocDescriptor soc(std::make_shared<SocArchDescriptor>(sdesc_path), make_valid_chip_info(arch));
 
     auto eth_cores = soc.get_cores(CoreType::ETH, CoordSystem::TRANSLATED);
     if (eth_cores.empty()) {
@@ -90,7 +103,7 @@ TEST_P(IsCoreOfTypeTest, EthCoreIsIdentifiedCorrectly) {
 TEST_P(IsCoreOfTypeTest, GarbageXYIsNotAnyKnownType) {
     const ARCH arch = GetParam();
     const std::string sdesc_path = test_utils::get_soc_descriptor_path(arch);
-    SocDescriptor soc(std::make_shared<SocArchDescriptor>(sdesc_path));
+    SocDescriptor soc(std::make_shared<SocArchDescriptor>(sdesc_path), make_valid_chip_info(arch));
 
     // Use an absurdly large coordinate that cannot belong to any real core.
     tt_xy_pair garbage{9999, 9999};


### PR DESCRIPTION
## Summary

Split from #2694. Core multichip simulation support:

- **Shared dlopen**: v3.5 libttsim ABI with process-global `s_shared_handle_` and per-chip `libttsim_select_device`. Probe reuses existing handle; flags/refcount deferred until all dlsym calls succeed.
- **Eth-MAC wiring pre-pass**: Deterministic MAC assignment and bidirectional peer registration in Cluster constructor for virtual switch routing. Includes MAC overflow assert (`cid <= 0xFF && chan <= 0xFF`).
- **DRAM teleport**: Coordinate-based `libttsim_dram_core_{rd,wr}_bytes_by_id` with `TT_UMD_SIM_DRAM_TELEPORT` env var gating.
- **Closed-guard pattern**: `mark_closed()`/`is_closed()` on communicator; `close_device()` on TTSimTTDevice.
- **Fabric registration**: `register_sim_fabric_endpoint_direction` and `register_sim_fabric_node_id` passthroughs under `#ifdef TT_UMD_BUILD_SIMULATION`.

### Review fixes applied (from #2694)
1. Replaced class docstring with concise comment
2. Added multichip model documentation block
3. Documented `v3_5_multichip_mode_` purpose
4. Documented `device_lock_` legacy serialization limitation
5. Fixed probe to reuse `s_shared_handle_` instead of double-dlopen
6. Deferred `v3_5_multichip_mode_` and `s_shared_refcount_++` until after ALL dlsym calls
7. Added ABI tiering comment block (required vs optional symbols)
8. Added `!peer_dev` guard in `register_peer`
9. Added MAC overflow assert in eth-MAC wiring
10. Moved `options_ = std::move(options)` after `construct_cluster()`
11. Documented `callback_instance_` as known limitation
12. Added `closed_` member with `mark_closed()`/`is_closed()`
13. Removed `// NOLINT(performance-unnecessary-value-param)` annotation

## Test plan
- [ ] Build with `TT_UMD_BUILD_SIMULATION=ON`
- [ ] Verify single-chip simulation still works
- [ ] Verify multichip simulation with v3.5 libttsim
- [ ] Verify DRAM teleport with `TT_UMD_SIM_DRAM_TELEPORT=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)