### PR TITLE
Expose firmware bundle version in ClusterDescriptor

### DIFF
--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -486,6 +486,7 @@ std::unique_ptr<ClusterDescriptor> TopologyDiscovery::fill_cluster_descriptor_in
     }
     cluster_desc->io_device_type = io_device_type;
     cluster_desc->eth_fw_version = expected_eth_fw_version;
+    cluster_desc->fw_bundle_version = first_fw_bundle_version;
     cluster_desc->merge_cluster_ids();
 
     cluster_desc->fill_chips_grouped_by_closest_mmio();


### PR DESCRIPTION
### Issue
[DCAMP-255: Improve FW consistency check on physical validation test](https://tenstorrent.atlassian.net/browse/DCAMP-255)

### Description
The firmware bundle version tracked internally by `TopologyDiscovery` during device discovery is not exposed in the `ClusterDescriptor`, preventing downstream consumers from validating firmware bundle consistency across multi-node clusters.

### List of the changes
- Populate `cluster_desc->fw_bundle_version` with `first_fw_bundle_version`
- Follows the same pattern as the existing `eth_fw_version` exposure
- No functional changes to UMD behavior

The `fw_bundle_version` field in `ClusterDescriptor` already exists and was previously kept empty. This change simply populates it with data that was already being computed.

This change will enable upcoming updates to tt-metal cluster validation tests based on the same ticket linked here.
