### PR TITLE
Enabling aarch64 builds

### DIFF
--- a/.github/manylinux-aarch64.Dockerfile
+++ b/.github/manylinux-aarch64.Dockerfile
@@ -1,0 +1,23 @@
+FROM quay.io/pypa/manylinux_2_28_aarch64
+# (AlmaLinux 8 based, aarch64 / arm64)
+# Built wheels are also expected to be compatible with other distros using glibc 2.28 or later, including:
+#     Debian 10+
+#     Ubuntu 18.10+ (includes 20.04 LTS)
+#     Fedora 29+
+#     CentOS/RHEL 8+
+
+# Hack for CIv2 - fix mirror URLs
+RUN FILES=(/etc/yum.repos.d/*.repo) && \
+  sed --in-place -e 's/^mirrorlist=/# mirrorlist=/g' -e 's/^# baseurl=/baseurl=/' "${FILES[@]}" || true
+
+# Install system dependencies matching docker_install_common.sh but using DNF
+# This includes all the dependencies needed for building tt-umd
+RUN dnf install -y \
+    ninja-build \
+    hwloc-devel \
+    vim-common \
+    && dnf clean all
+
+# Set up environment variables for building
+ENV CC=/opt/rh/gcc-toolset-14/root/bin/gcc
+ENV CXX=/opt/rh/gcc-toolset-14/root/bin/g++

--- a/.github/workflows/build-and-run-all-tests-multiple-builds.yml
+++ b/.github/workflows/build-and-run-all-tests-multiple-builds.yml
@@ -42,8 +42,8 @@ jobs:
   # Ensure the Docker image for CI exists. If the Dockerfile (or its
   # install scripts) changed on this branch the image is rebuilt and pushed
   # with a content-hash tag.  Otherwise the existing image is reused.
-  ensure-image:
-    name: Ensure Docker image
+  ensure-x86-image:
+    name: Ensure x86_64 Docker image
     permissions:
       packages: write
     secrets: inherit
@@ -80,7 +80,7 @@ jobs:
 
   build-release:
     name: "Build and Test (Release)"
-    needs: [ensure-image, ensure-arm-image]
+    needs: [ensure-x86-image, ensure-arm-image]
     # Skipped: (none)
     if: >-
       github.event_name == 'pull_request' ||
@@ -93,7 +93,7 @@ jobs:
     with:
       build-type: Release
       timeout: 25
-      docker-image-tag: ${{ needs.ensure-image.outputs.image-tag }}
+      x86-docker-image-tag: ${{ needs.ensure-x86-image.outputs.image-tag }}
       arm-docker-image-tag: ${{ needs.ensure-arm-image.outputs.image-tag }}
       triggering-event: ${{ github.event_name }}
       log-params: |
@@ -101,7 +101,7 @@ jobs:
 
   build-asan:
     name: "Build and Test (ASan)"
-    needs: [ensure-image, ensure-arm-image]
+    needs: [ensure-x86-image, ensure-arm-image]
     # Skipped: pull_request, push
     if: >-
       github.event_name == 'merge_group' ||
@@ -112,7 +112,7 @@ jobs:
     with:
       build-type: ASan
       timeout: 25
-      docker-image-tag: ${{ needs.ensure-image.outputs.image-tag }}
+      x86-docker-image-tag: ${{ needs.ensure-x86-image.outputs.image-tag }}
       arm-docker-image-tag: ${{ needs.ensure-arm-image.outputs.image-tag }}
       triggering-event: ${{ github.event_name }}
       log-params: |
@@ -120,7 +120,7 @@ jobs:
 
   build-tsan:
     name: "Build and Test (TSan)"
-    needs: [ensure-image, ensure-arm-image]
+    needs: [ensure-x86-image, ensure-arm-image]
     # Skipped: pull_request, push
     if: >-
       github.event_name == 'merge_group' ||
@@ -131,7 +131,7 @@ jobs:
     with:
       build-type: TSan
       timeout: 50
-      docker-image-tag: ${{ needs.ensure-image.outputs.image-tag }}
+      x86-docker-image-tag: ${{ needs.ensure-x86-image.outputs.image-tag }}
       arm-docker-image-tag: ${{ needs.ensure-arm-image.outputs.image-tag }}
       triggering-event: ${{ github.event_name }}
       log-params: |
@@ -139,7 +139,7 @@ jobs:
 
   build-relwithdebinfo:
     name: "Build and Test (RelWithDebInfo)"
-    needs: [ensure-image, ensure-arm-image]
+    needs: [ensure-x86-image, ensure-arm-image]
     # Skipped: pull_request, merge_group, push
     if: >-
       github.event_name == 'workflow_dispatch' &&
@@ -149,7 +149,7 @@ jobs:
     with:
       build-type: RelWithDebInfo
       timeout: 25
-      docker-image-tag: ${{ needs.ensure-image.outputs.image-tag }}
+      x86-docker-image-tag: ${{ needs.ensure-x86-image.outputs.image-tag }}
       arm-docker-image-tag: ${{ needs.ensure-arm-image.outputs.image-tag }}
       triggering-event: ${{ github.event_name }}
       log-params: |
@@ -157,7 +157,7 @@ jobs:
 
   build-debug:
     name: "Build and Test (Debug)"
-    needs: [ensure-image, ensure-arm-image]
+    needs: [ensure-x86-image, ensure-arm-image]
     # Skipped: pull_request, merge_group, push
     if: >-
       github.event_name == 'workflow_dispatch' &&
@@ -167,7 +167,7 @@ jobs:
     with:
       build-type: Debug
       timeout: 50
-      docker-image-tag: ${{ needs.ensure-image.outputs.image-tag }}
+      x86-docker-image-tag: ${{ needs.ensure-x86-image.outputs.image-tag }}
       arm-docker-image-tag: ${{ needs.ensure-arm-image.outputs.image-tag }}
       triggering-event: ${{ github.event_name }}
       log-params: |

--- a/.github/workflows/build-and-run-all-tests-multiple-builds.yml
+++ b/.github/workflows/build-and-run-all-tests-multiple-builds.yml
@@ -51,6 +51,19 @@ jobs:
     with:
       docker-version: ubuntu-22.04
 
+  # Same as above, for the arm64 CI image. Built on the public ubuntu-24.04-arm
+  # runner; reuses the arch-neutral ubuntu-24.04 Dockerfile under an arm image name.
+  ensure-arm-image:
+    name: Ensure arm64 Docker image
+    permissions:
+      packages: write
+    secrets: inherit
+    uses: ./.github/workflows/docker-image.yml
+    with:
+      docker-version: ubuntu-24.04-arm
+      dockerfile: ubuntu-24.04
+      runner: ubuntu-24.04-arm
+
   # On pull_request, only Release should run. But GitHub applies the same required-status-check
   # rules to PRs and merge queues — if a check is required for merge_group it must also be
   # present on the PR. Skipped jobs count as passing, so all jobs are defined for all events
@@ -67,7 +80,7 @@ jobs:
 
   build-release:
     name: "Build and Test (Release)"
-    needs: ensure-image
+    needs: [ensure-image, ensure-arm-image]
     # Skipped: (none)
     if: >-
       github.event_name == 'pull_request' ||
@@ -81,13 +94,14 @@ jobs:
       build-type: Release
       timeout: 25
       docker-image-tag: ${{ needs.ensure-image.outputs.image-tag }}
+      arm-docker-image-tag: ${{ needs.ensure-arm-image.outputs.image-tag }}
       triggering-event: ${{ github.event_name }}
       log-params: |
         echo build-and-run-all-tests-multiple-builds - build-types: ${{ inputs.build-types }}
 
   build-asan:
     name: "Build and Test (ASan)"
-    needs: ensure-image
+    needs: [ensure-image, ensure-arm-image]
     # Skipped: pull_request, push
     if: >-
       github.event_name == 'merge_group' ||
@@ -99,13 +113,14 @@ jobs:
       build-type: ASan
       timeout: 25
       docker-image-tag: ${{ needs.ensure-image.outputs.image-tag }}
+      arm-docker-image-tag: ${{ needs.ensure-arm-image.outputs.image-tag }}
       triggering-event: ${{ github.event_name }}
       log-params: |
         echo build-and-run-all-tests-multiple-builds - build-types: ${{ inputs.build-types }}
 
   build-tsan:
     name: "Build and Test (TSan)"
-    needs: ensure-image
+    needs: [ensure-image, ensure-arm-image]
     # Skipped: pull_request, push
     if: >-
       github.event_name == 'merge_group' ||
@@ -117,13 +132,14 @@ jobs:
       build-type: TSan
       timeout: 50
       docker-image-tag: ${{ needs.ensure-image.outputs.image-tag }}
+      arm-docker-image-tag: ${{ needs.ensure-arm-image.outputs.image-tag }}
       triggering-event: ${{ github.event_name }}
       log-params: |
         echo build-and-run-all-tests-multiple-builds - build-types: ${{ inputs.build-types }}
 
   build-relwithdebinfo:
     name: "Build and Test (RelWithDebInfo)"
-    needs: ensure-image
+    needs: [ensure-image, ensure-arm-image]
     # Skipped: pull_request, merge_group, push
     if: >-
       github.event_name == 'workflow_dispatch' &&
@@ -134,13 +150,14 @@ jobs:
       build-type: RelWithDebInfo
       timeout: 25
       docker-image-tag: ${{ needs.ensure-image.outputs.image-tag }}
+      arm-docker-image-tag: ${{ needs.ensure-arm-image.outputs.image-tag }}
       triggering-event: ${{ github.event_name }}
       log-params: |
         echo build-and-run-all-tests-multiple-builds - build-types: ${{ inputs.build-types }}
 
   build-debug:
     name: "Build and Test (Debug)"
-    needs: ensure-image
+    needs: [ensure-image, ensure-arm-image]
     # Skipped: pull_request, merge_group, push
     if: >-
       github.event_name == 'workflow_dispatch' &&
@@ -151,6 +168,7 @@ jobs:
       build-type: Debug
       timeout: 50
       docker-image-tag: ${{ needs.ensure-image.outputs.image-tag }}
+      arm-docker-image-tag: ${{ needs.ensure-arm-image.outputs.image-tag }}
       triggering-event: ${{ github.event_name }}
       log-params: |
         echo build-and-run-all-tests-multiple-builds - build-types: ${{ inputs.build-types }}

--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -17,6 +17,13 @@ on:
         description: >-
           Content-hash tag produced by docker-image.yml.
           When empty or unset, downstream jobs use ":latest".
+      arm-docker-image-tag:
+        required: false
+        type: string
+        default: latest
+        description: >-
+          Content-hash tag for the arm64 (ubuntu-24.04-arm) CI image produced by
+          docker-image.yml. Used by the aarch64 build/test leg. Defaults to ":latest".
       log-params:
         required: false
         type: string
@@ -164,17 +171,30 @@ jobs:
     secrets: inherit
     strategy:
       fail-fast: false
+      # x86_64 builds on the internal large runner; arm64 builds on the public
+      # ubuntu-24.04-arm runner using the arm CI image. Tracy is x86-only (the
+      # Tracy smoke test runs on silicon, which arm doesn't have).
       matrix:
-        ubuntu-docker-version: [
-          'ubuntu-22.04',
-        ]
+        include:
+          - ubuntu-docker-version: ubuntu-22.04
+            runner: tt-ubuntu-2204-large-stable
+            exalens-runner: ubuntu-22.04
+            build-tracy: true
+            image-tag: ${{ inputs.docker-image-tag || 'latest' }}
+          - ubuntu-docker-version: ubuntu-24.04-arm
+            runner: ubuntu-24.04-arm
+            exalens-runner: ubuntu-24.04-arm
+            build-tracy: false
+            image-tag: ${{ inputs.arm-docker-image-tag || 'latest' }}
     uses: ./.github/workflows/build-tests.yml
     with:
-      ubuntu-docker-version: ${{ matrix.ubuntu-docker-version}}
+      ubuntu-docker-version: ${{ matrix.ubuntu-docker-version }}
+      runner: ${{ matrix.runner }}
+      exalens-runner: ${{ matrix.exalens-runner }}
       timeout: 15
       build-type: ${{ inputs.build-type }}
-      build-tracy: true
-      image-tag: ${{ inputs.docker-image-tag || 'latest' }}
+      build-tracy: ${{ matrix.build-tracy }}
+      image-tag: ${{ matrix.image-tag }}
       log-params: |
         ${{ inputs.log-params }}
         echo build-and-run-all-tests - build-type: ${{ inputs.build-type }}
@@ -201,6 +221,28 @@ jobs:
       log-level: ${{ inputs.log-level || 'info' }}
       build-type: ${{ inputs.build-type }}
       image-tag: ${{ inputs.docker-image-tag || 'latest' }}
+      log-params: |
+        ${{ inputs.log-params }}
+        echo build-and-run-all-tests - build-type: ${{ inputs.build-type }}
+        echo build-and-run-all-tests - timeout: ${{ inputs.timeout }}
+        echo build-and-run-all-tests - log-level: ${{ inputs.log-level }}
+
+  # aarch64 has no Tenstorrent silicon runner, so we run the hardware-free suite
+  # (the same one the x86 'baremetal' card runs: baremetal/test_utils/misc/pcie +
+  # wheel pytest) on the public ubuntu-24.04-arm runner with the arm CI image.
+  # Simulator coverage for arm lives in run-ttsim-tests.yml (ttsim job).
+  test-aarch64:
+    secrets: inherit
+    needs: build-tests
+    uses: ./.github/workflows/run-tests.yml
+    with:
+      arch: baremetal
+      ubuntu-docker-version: ubuntu-24.04-arm
+      card: ubuntu-24.04-arm
+      timeout: ${{ fromJSON(inputs.timeout) }}
+      log-level: ${{ inputs.log-level || 'info' }}
+      build-type: ${{ inputs.build-type }}
+      image-tag: ${{ inputs.arm-docker-image-tag || 'latest' }}
       log-params: |
         ${{ inputs.log-params }}
         echo build-and-run-all-tests - build-type: ${{ inputs.build-type }}
@@ -293,6 +335,15 @@ jobs:
   fail-fast-test-all:
     if: failure() && inputs.triggering-event == 'merge_group'
     needs: [test-all]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
+
+  fail-fast-test-aarch64:
+    if: failure() && inputs.triggering-event == 'merge_group'
+    needs: [test-aarch64]
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -10,20 +10,21 @@ on:
       timeout:
         required: true
         type: number
-      docker-image-tag:
+      x86-docker-image-tag:
         required: false
         type: string
         default: latest
         description: >-
-          Content-hash tag produced by docker-image.yml.
-          When empty or unset, downstream jobs use ":latest".
+          Tag name for the x86_64 CI image produced by docker-image.yml, used as
+          `:<tag>` in the image reference. Defaults to `latest`.
       arm-docker-image-tag:
         required: false
         type: string
         default: latest
         description: >-
-          Content-hash tag for the arm64 (ubuntu-24.04-arm) CI image produced by
-          docker-image.yml. Used by the aarch64 build/test leg. Defaults to ":latest".
+          Tag name for the arm64 (ubuntu-24.04-arm) CI image produced by
+          docker-image.yml, used as `:<tag>` in the image reference by the
+          aarch64 build/test leg. Defaults to `latest`.
       log-params:
         required: false
         type: string
@@ -180,7 +181,7 @@ jobs:
             runner: tt-ubuntu-2204-large-stable
             exalens-runner: ubuntu-22.04
             build-tracy: true
-            image-tag: ${{ inputs.docker-image-tag || 'latest' }}
+            image-tag: ${{ inputs.x86-docker-image-tag || 'latest' }}
           - ubuntu-docker-version: ubuntu-24.04-arm
             runner: ubuntu-24.04-arm
             exalens-runner: ubuntu-24.04-arm
@@ -220,7 +221,7 @@ jobs:
       timeout: ${{ fromJSON(inputs.timeout) }}
       log-level: ${{ inputs.log-level || 'info' }}
       build-type: ${{ inputs.build-type }}
-      image-tag: ${{ inputs.docker-image-tag || 'latest' }}
+      image-tag: ${{ inputs.x86-docker-image-tag || 'latest' }}
       log-params: |
         ${{ inputs.log-params }}
         echo build-and-run-all-tests - build-type: ${{ inputs.build-type }}
@@ -277,7 +278,7 @@ jobs:
       card: ${{ matrix.test-group.runs-on }}
       timeout: ${{ fromJSON(inputs.timeout) }}
       build-type: ${{ inputs.build-type }}
-      image-tag: ${{ inputs.docker-image-tag || 'latest' }}
+      image-tag: ${{ inputs.x86-docker-image-tag || 'latest' }}
       log-params: |
         ${{ inputs.log-params }}
         echo build-and-run-all-tests - build-type: ${{ inputs.build-type }}
@@ -318,7 +319,7 @@ jobs:
       ubuntu-docker-version: 'ubuntu-22.04'
       build-type: ${{ inputs.build-type }}
       timeout: 20
-      image-tag: ${{ inputs.docker-image-tag || 'latest' }}
+      image-tag: ${{ inputs.x86-docker-image-tag || 'latest' }}
 
   # Fail-fast watchers for the merge queue: cancel the workflow run as soon as any test job
   # here fails. A workflow_call shares run_id with its caller, so this cancellation propagates

--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -252,6 +252,8 @@ jobs:
   run-ttsim-tests:
     secrets: inherit
     uses: ./.github/workflows/run-ttsim-tests.yml
+    with:
+      arm-image-tag: ${{ inputs.arm-docker-image-tag || 'latest' }}
 
   run-tooling-tests:
     secrets: inherit

--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -179,19 +179,19 @@ jobs:
         include:
           - ubuntu-docker-version: ubuntu-22.04
             runner: tt-ubuntu-2204-large-stable
-            exalens-runner: ubuntu-22.04
+            build-exalens-kernels: true
             build-tracy: true
             image-tag: ${{ inputs.x86-docker-image-tag || 'latest' }}
           - ubuntu-docker-version: ubuntu-24.04-arm
             runner: ubuntu-24.04-arm
-            exalens-runner: ubuntu-24.04-arm
+            build-exalens-kernels: false
             build-tracy: false
             image-tag: ${{ inputs.arm-docker-image-tag || 'latest' }}
     uses: ./.github/workflows/build-tests.yml
     with:
       ubuntu-docker-version: ${{ matrix.ubuntu-docker-version }}
       runner: ${{ matrix.runner }}
-      exalens-runner: ${{ matrix.exalens-runner }}
+      build-exalens-kernels: ${{ matrix.build-exalens-kernels }}
       timeout: 15
       build-type: ${{ inputs.build-type }}
       build-tracy: ${{ matrix.build-tracy }}

--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -9,7 +9,7 @@ on:
         required: true
         description: 'The timeout for the job in minutes'
         type: number
-        default: 15
+        default: 20
   # Runs on all standard code-review and integration events: PR, merge queue, and post-merge on main.
   pull_request:
   merge_group:
@@ -114,7 +114,9 @@ jobs:
   build:
     # Due to parsing bug, fromJSON is used to convert string to number.
     # In pull_request or push events, the input context is not available, stating the default again here.
-    timeout-minutes: ${{ fromJSON(inputs.timeout || '15') }}
+    # 20 (not 15): the arm builds on the public runner are slower; the fedora-39-arm
+    # release-flags build (clang-tidy enabled) was hitting the 15-minute limit.
+    timeout-minutes: ${{ fromJSON(inputs.timeout || '20') }}
     needs:
       - ensure-ubuntu-2204-image
       - ensure-ubuntu-2404-image

--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -66,14 +66,72 @@ jobs:
     with:
       docker-version: manylinux
 
+  # arm64 CI images. Built on the public ubuntu-24.04-arm runner; the ubuntu/fedora
+  # ones reuse the arch-neutral x86 Dockerfiles under a distinct -arm image name.
+  ensure-ubuntu-2204-arm-image:
+    name: Ensure ubuntu-22.04-arm Docker image
+    permissions:
+      packages: write
+    secrets: inherit
+    uses: ./.github/workflows/docker-image.yml
+    with:
+      docker-version: ubuntu-22.04-arm
+      dockerfile: ubuntu-22.04
+      runner: ubuntu-24.04-arm
+
+  ensure-ubuntu-2404-arm-image:
+    name: Ensure ubuntu-24.04-arm Docker image
+    permissions:
+      packages: write
+    secrets: inherit
+    uses: ./.github/workflows/docker-image.yml
+    with:
+      docker-version: ubuntu-24.04-arm
+      dockerfile: ubuntu-24.04
+      runner: ubuntu-24.04-arm
+
+  ensure-fedora-39-arm-image:
+    name: Ensure fedora-39-arm Docker image
+    permissions:
+      packages: write
+    secrets: inherit
+    uses: ./.github/workflows/docker-image.yml
+    with:
+      docker-version: fedora-39-arm
+      dockerfile: fedora-39
+      runner: ubuntu-24.04-arm
+
+  ensure-manylinux-aarch64-image:
+    name: Ensure manylinux-aarch64 Docker image
+    permissions:
+      packages: write
+    secrets: inherit
+    uses: ./.github/workflows/docker-image.yml
+    with:
+      docker-version: manylinux-aarch64
+      runner: ubuntu-24.04-arm
+
   build:
     # Due to parsing bug, fromJSON is used to convert string to number.
     # In pull_request or push events, the input context is not available, stating the default again here.
     timeout-minutes: ${{ fromJSON(inputs.timeout || '15') }}
-    needs: [ensure-ubuntu-2204-image, ensure-ubuntu-2404-image, ensure-fedora-39-image]
+    needs:
+      - ensure-ubuntu-2204-image
+      - ensure-ubuntu-2404-image
+      - ensure-fedora-39-image
+      - ensure-ubuntu-2204-arm-image
+      - ensure-ubuntu-2404-arm-image
+      - ensure-fedora-39-arm-image
     strategy:
       fail-fast: false
+      # The image list (distro x compiler) is crossed with the arch dimension, so
+      # every x86 build configuration is mirrored on arm64. x86 builds on the
+      # internal runner via the harbor mirror; arm builds on the public
+      # ubuntu-24.04-arm runner pulling the -arm images directly from ghcr.
       matrix:
+        arch:
+          - {suffix: "", runner: tt-ubuntu-2204-large-stable, registry: "harbor.ci.tenstorrent.net/ghcr.io"}
+          - {suffix: "-arm", runner: ubuntu-24.04-arm, registry: "ghcr.io"}
         image: [
           {distro: ubuntu-22.04, compiler-c: clang-13, compiler-cpp: clang++-13, package: deb},
           {distro: ubuntu-22.04, compiler-c: clang-20, compiler-cpp: clang++-20, package: deb},
@@ -95,19 +153,27 @@ jobs:
 
     name: >-
       Build device${{ matrix.image.use_release_flags && ' (release flags)' || '' }}
-      on ${{ matrix.image.distro }} with ${{ matrix.image.compiler-c }}
-    runs-on: tt-ubuntu-2204-large-stable
+      on ${{ matrix.image.distro }}${{ matrix.arch.suffix }} with ${{ matrix.image.compiler-c }}
+    runs-on: ${{ matrix.arch.runner }}
     env:
       # CI runners may lack invariant TSC support (required by Tracy for high-res timestamps).
       # This skips Tracy's runtime TSC check to prevent initialization failures during build.
       TRACY_NO_INVARIANT_CHECK: 1
     container:
       image: >-
-        harbor.ci.tenstorrent.net/ghcr.io/${{ github.repository }}/tt-umd-ci-${{
-        matrix.image.distro }}:${{
-        matrix.image.distro == 'ubuntu-22.04' && needs.ensure-ubuntu-2204-image.outputs.image-tag ||
-        matrix.image.distro == 'ubuntu-24.04' && needs.ensure-ubuntu-2404-image.outputs.image-tag ||
-        needs.ensure-fedora-39-image.outputs.image-tag }}
+        ${{ matrix.arch.registry }}/${{ github.repository }}/tt-umd-ci-${{
+        matrix.image.distro }}${{ matrix.arch.suffix }}:${{
+        matrix.arch.suffix == '' && matrix.image.distro == 'ubuntu-22.04'
+        && needs.ensure-ubuntu-2204-image.outputs.image-tag ||
+        matrix.arch.suffix == '' && matrix.image.distro == 'ubuntu-24.04'
+        && needs.ensure-ubuntu-2404-image.outputs.image-tag ||
+        matrix.arch.suffix == '' && matrix.image.distro == 'fedora-39'
+        && needs.ensure-fedora-39-image.outputs.image-tag ||
+        matrix.arch.suffix == '-arm' && matrix.image.distro == 'ubuntu-22.04'
+        && needs.ensure-ubuntu-2204-arm-image.outputs.image-tag ||
+        matrix.arch.suffix == '-arm' && matrix.image.distro == 'ubuntu-24.04'
+        && needs.ensure-ubuntu-2404-arm-image.outputs.image-tag ||
+        needs.ensure-fedora-39-arm-image.outputs.image-tag }}
 
     steps:
       - uses: actions/checkout@v6
@@ -124,11 +190,12 @@ jobs:
           # exactly the same flags the release process would use.
           RELEASE_SUFFIX="${{ matrix.image.use_release_flags && '-release' || '' }}"
           # Build ID is common suffix, differentiating packages built per distro,
-          # compiler, and whether they used release cmake flags or not.
+          # arch, compiler, and whether they used release cmake flags or not.
           # This suffix should be used for all package artifacts so their names
           # don't overlap for different configurations.
-          # Example: PLATFORM_SUFFIX=ubuntu-24.04-clang-20-release
-          PLATFORM_SUFFIX="${{ matrix.image.distro }}-${{ matrix.image.compiler-c }}${RELEASE_SUFFIX}"
+          # Example: PLATFORM_SUFFIX=ubuntu-24.04-arm-clang-20-release
+          DISTRO_ARCH="${{ matrix.image.distro }}${{ matrix.arch.suffix }}"
+          PLATFORM_SUFFIX="${DISTRO_ARCH}-${{ matrix.image.compiler-c }}${RELEASE_SUFFIX}"
           echo "PLATFORM_SUFFIX=${PLATFORM_SUFFIX}" >> $GITHUB_ENV
 
       # Build with all components to verify the build passes.
@@ -286,10 +353,27 @@ jobs:
     # Due to parsing bug, fromJSON is used to convert string to number.
     # In pull_request or push events, the input context is not available, stating the default again here.
     timeout-minutes: ${{ fromJSON(inputs.timeout || '15') }}
-    needs: ensure-manylinux-image
+    needs: [ensure-manylinux-image, ensure-manylinux-aarch64-image]
 
-    name: Build umd manylinux wheel
-    runs-on: tt-ubuntu-2204-large-stable
+    # x86_64 wheels build on the internal runner; aarch64 wheels build natively on
+    # the public ubuntu-24.04-arm runner (no QEMU) using the manylinux-aarch64 image.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: tt-ubuntu-2204-large-stable
+            cibw-image: >-
+              ghcr.io/${{ github.repository }}/tt-umd-ci-manylinux:${{
+              needs.ensure-manylinux-image.outputs.image-tag }}
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+            cibw-image: >-
+              ghcr.io/${{ github.repository }}/tt-umd-ci-manylinux-aarch64:${{
+              needs.ensure-manylinux-aarch64-image.outputs.image-tag }}
+
+    name: Build umd manylinux wheel (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - uses: actions/checkout@v6
@@ -307,10 +391,11 @@ jobs:
       - name: Build manylinux wheels
         shell: bash
         env:
-          # Use custom manylinux Docker image with all dependencies pre-installed
-          CIBW_MANYLINUX_X86_64_IMAGE: >-
-            ghcr.io/${{ github.repository }}/tt-umd-ci-manylinux:${{
-            needs.ensure-manylinux-image.outputs.image-tag }}
+          # Select the arch to build and point cibuildwheel at the matching custom
+          # manylinux image (only the env var for the built arch is consulted).
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.arch == 'x86_64' && matrix.cibw-image || '' }}
+          CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.arch == 'aarch64' && matrix.cibw-image || '' }}
           # This command will be executed for each wheel build to verify that the wheel is functional.
           CIBW_TEST_COMMAND: 'python -c "import tt_umd"'
         run: |
@@ -324,30 +409,52 @@ jobs:
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: manylinux-wheel-artifact
+          name: manylinux-wheel-artifact-${{ matrix.arch }}
           path: |
             ${{ env.WHEEL_OUTPUT_DIR }}
 
   test-packages:
-    needs: [build, ensure-ubuntu-2204-image, ensure-ubuntu-2404-image, ensure-fedora-39-image]
+    needs:
+      - build
+      - ensure-ubuntu-2204-image
+      - ensure-ubuntu-2404-image
+      - ensure-fedora-39-image
+      - ensure-ubuntu-2204-arm-image
+      - ensure-ubuntu-2404-arm-image
+      - ensure-fedora-39-arm-image
     timeout-minutes: ${{ fromJSON(inputs.timeout || '15') }}
     strategy:
       fail-fast: false
+      # Each package config is tested on both arches. arm package tests install the
+      # arm .deb/.rpm in the arm CI image on the public ubuntu-24.04-arm runner.
       matrix:
+        arch:
+          - {suffix: "", runner: ubuntu-22.04}
+          - {suffix: "-arm", runner: ubuntu-24.04-arm}
         build: [
           {package: deb, distro: ubuntu-22.04, compiler-c: gcc-11},
           {package: deb, distro: ubuntu-24.04, compiler-c: gcc-11},
           {package: rpm, distro: fedora-39, compiler-c: gcc-13}
         ]
 
-    name: Test ${{ matrix.build.package }} package on ${{ matrix.build.distro }} with ${{ matrix.build.compiler-c }}
-    runs-on: ubuntu-22.04
+    name: >-
+      Test ${{ matrix.build.package }} package on
+      ${{ matrix.build.distro }}${{ matrix.arch.suffix }} with ${{ matrix.build.compiler-c }}
+    runs-on: ${{ matrix.arch.runner }}
     container:
       image: >-
-        ghcr.io/${{ github.repository }}/tt-umd-ci-${{ matrix.build.distro }}:${{
-        matrix.build.distro == 'ubuntu-22.04' && needs.ensure-ubuntu-2204-image.outputs.image-tag ||
-        matrix.build.distro == 'ubuntu-24.04' && needs.ensure-ubuntu-2404-image.outputs.image-tag ||
-        needs.ensure-fedora-39-image.outputs.image-tag }}
+        ghcr.io/${{ github.repository }}/tt-umd-ci-${{ matrix.build.distro }}${{ matrix.arch.suffix }}:${{
+        matrix.arch.suffix == '' && matrix.build.distro == 'ubuntu-22.04'
+        && needs.ensure-ubuntu-2204-image.outputs.image-tag ||
+        matrix.arch.suffix == '' && matrix.build.distro == 'ubuntu-24.04'
+        && needs.ensure-ubuntu-2404-image.outputs.image-tag ||
+        matrix.arch.suffix == '' && matrix.build.distro == 'fedora-39'
+        && needs.ensure-fedora-39-image.outputs.image-tag ||
+        matrix.arch.suffix == '-arm' && matrix.build.distro == 'ubuntu-22.04'
+        && needs.ensure-ubuntu-2204-arm-image.outputs.image-tag ||
+        matrix.arch.suffix == '-arm' && matrix.build.distro == 'ubuntu-24.04'
+        && needs.ensure-ubuntu-2404-arm-image.outputs.image-tag ||
+        needs.ensure-fedora-39-arm-image.outputs.image-tag }}
 
     steps:
       - uses: actions/checkout@v6
@@ -359,7 +466,8 @@ jobs:
         run: |
           # Note that BUILD ID doesn't include the option with the -release suffix
           # as the above matrix which builds packages. We test only one variant.
-          echo "PLATFORM_SUFFIX=${{ matrix.build.distro }}-${{ matrix.build.compiler-c }}" >> $GITHUB_ENV
+          DISTRO_ARCH="${{ matrix.build.distro }}${{ matrix.arch.suffix }}"
+          echo "PLATFORM_SUFFIX=${DISTRO_ARCH}-${{ matrix.build.compiler-c }}" >> $GITHUB_ENV
 
       - name: Download Packages Artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -203,6 +203,7 @@ jobs:
       # Build with all components to verify the build passes.
       # Release-flags builds mirror the flags used in release.yml to catch clang-tidy issues early.
       - name: Build All
+        shell: bash
         run: |
           cd ${{ env.TT_UMD_DIR_SHELL }}
           echo "Compiling the code..."

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -20,12 +20,19 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
     strategy:
       fail-fast: false
+      # `name` is the ghcr image suffix; `dockerfile` is the Dockerfile prefix.
+      # arm images reuse the arch-neutral x86 Dockerfiles (only manylinux-aarch64
+      # has its own) and build on the public ubuntu-24.04-arm runner.
       matrix:
         build: [
-          {name: ubuntu-22.04, runner: ubuntu-22.04},
-          {name: ubuntu-24.04, runner: ubuntu-24.04},
-          {name: fedora-39, runner: ubuntu-22.04},
-          {name: manylinux, runner: ubuntu-22.04},
+          {name: ubuntu-22.04, dockerfile: ubuntu-22.04, runner: ubuntu-22.04},
+          {name: ubuntu-24.04, dockerfile: ubuntu-24.04, runner: ubuntu-24.04},
+          {name: fedora-39, dockerfile: fedora-39, runner: ubuntu-22.04},
+          {name: manylinux, dockerfile: manylinux, runner: ubuntu-22.04},
+          {name: ubuntu-22.04-arm, dockerfile: ubuntu-22.04, runner: ubuntu-24.04-arm},
+          {name: ubuntu-24.04-arm, dockerfile: ubuntu-24.04, runner: ubuntu-24.04-arm},
+          {name: fedora-39-arm, dockerfile: fedora-39, runner: ubuntu-24.04-arm},
+          {name: manylinux-aarch64, dockerfile: manylinux-aarch64, runner: ubuntu-24.04-arm},
         ]
 
     name: Building docker image ${{ matrix.build.name }}
@@ -57,7 +64,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .github
-          file: .github/${{ matrix.build.name }}.Dockerfile
+          file: .github/${{ matrix.build.dockerfile }}.Dockerfile
           push: true
           build-args: |
             GIT_SHA=${{ github.sha }}

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -36,14 +36,15 @@ on:
         description: >-
           Runner to build on. Use an arm runner (e.g. "ubuntu-24.04-arm")
           together with an arm ubuntu-docker-version to produce arm64 builds.
-      exalens-runner:
+      build-exalens-kernels:
         required: false
-        type: string
-        default: ubuntu-22.04
+        type: boolean
+        default: true
         description: >-
-          Runner for the tt-exalens kernel build. The build (SFPI ships arm64
-          host binaries) works on arm, so the arm caller passes an arm runner
-          to verify tt-exalens builds against the arm-capable UMD.
+          Build the tt-exalens test kernels. Disabled for arm builds: tt-exalens
+          does not publish an arm64 CI image yet, there is no arm64 Tenstorrent
+          hardware to run the exalens tests on, and the kernel artifact is only
+          consumed by the (x86-only) exalens tests.
       image-tag:
         required: false
         type: string
@@ -77,6 +78,11 @@ on:
         description: 'Also build a Tracy-enabled variant'
         type: boolean
         default: false
+      build-exalens-kernels:
+        required: false
+        description: 'Build the tt-exalens test kernels'
+        type: boolean
+        default: true
 
 
 env:
@@ -225,9 +231,10 @@ jobs:
           path: ${{ env.WHEEL_OUTPUT_DIR }}
 
   build-exalens-kernels:
+    if: ${{ inputs.build-exalens-kernels }}
     name: Build tt-exalens kernels for tests
     timeout-minutes: 5
-    runs-on: ${{ inputs.exalens-runner || 'ubuntu-22.04' }}
+    runs-on: ubuntu-22.04
     container:
       # Use tt-exalens own CI image as it has everything pre-installed.
       image: ghcr.io/tenstorrent/tt-exalens/tt-exalens-ci-${{ inputs.ubuntu-docker-version }}:latest

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -29,6 +29,21 @@ on:
         description: >-
           When true, the build job runs an additional matrix entry with
           TT_UMD_ENABLE_TRACY=ON. The Tracy artifact uses a -tracy suffix.
+      runner:
+        required: false
+        type: string
+        default: tt-ubuntu-2204-large-stable
+        description: >-
+          Runner to build on. Use an arm runner (e.g. "ubuntu-24.04-arm")
+          together with an arm ubuntu-docker-version to produce arm64 builds.
+      exalens-runner:
+        required: false
+        type: string
+        default: ubuntu-22.04
+        description: >-
+          Runner for the tt-exalens kernel build. The build (SFPI ships arm64
+          host binaries) works on arm, so the arm caller passes an arm runner
+          to verify tt-exalens builds against the arm-capable UMD.
       image-tag:
         required: false
         type: string
@@ -93,7 +108,7 @@ jobs:
       matrix:
         use_tracy: ${{ fromJSON(inputs.build-tracy && '[false, true]' || '[false]') }}
 
-    runs-on: tt-ubuntu-2204-large-stable
+    runs-on: ${{ inputs.runner || 'tt-ubuntu-2204-large-stable' }}
     container:
       image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}:${{ inputs.image-tag }}
 
@@ -158,7 +173,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
 
     name: Build umd wheel on ${{ inputs.ubuntu-docker-version }}
-    runs-on: tt-ubuntu-2204-large-stable
+    runs-on: ${{ inputs.runner || 'tt-ubuntu-2204-large-stable' }}
     container:
       image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}:${{ inputs.image-tag }}
 
@@ -212,7 +227,7 @@ jobs:
   build-exalens-kernels:
     name: Build tt-exalens kernels for tests
     timeout-minutes: 5
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.exalens-runner || 'ubuntu-22.04' }}
     container:
       image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}:${{ inputs.image-tag }}
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,8 +10,26 @@ on:
         required: true
         type: string
         description: >-
-          Image variant name that matches the Dockerfile prefix,
-          e.g. "ubuntu-22.04", "ubuntu-24.04", "fedora-39", "manylinux".
+          Image variant name. Used as the ghcr image suffix
+          (tt-umd-ci-<docker-version>) and, unless `dockerfile` is set, also as
+          the Dockerfile prefix. e.g. "ubuntu-22.04", "ubuntu-24.04",
+          "fedora-39", "manylinux", "ubuntu-24.04-arm", "manylinux-aarch64".
+      dockerfile:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Dockerfile prefix to build from when it differs from `docker-version`.
+          Lets an arm image (e.g. docker-version "ubuntu-24.04-arm") reuse the
+          arch-neutral x86 Dockerfile (".github/ubuntu-24.04.Dockerfile") while
+          being pushed under a distinct image name. Defaults to `docker-version`.
+      runner:
+        required: false
+        type: string
+        default: ubuntu-22.04
+        description: >-
+          Runner to build the image on. Must match the target image arch:
+          use an arm runner (e.g. "ubuntu-24.04-arm") to produce arm64 images.
       timeout:
         required: false
         type: number
@@ -26,7 +44,7 @@ on:
 jobs:
   ensure:
     name: Ensure image (${{ inputs.docker-version }})
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
     permissions:
       packages: write
@@ -39,7 +57,7 @@ jobs:
       - name: Compute content hash
         id: hash
         run: |
-          DOCKERFILE=".github/${{ inputs.docker-version }}.Dockerfile"
+          DOCKERFILE=".github/${{ inputs.dockerfile != '' && inputs.dockerfile || inputs.docker-version }}.Dockerfile"
 
           # Collect the Dockerfile itself plus any scripts it COPYs
           FILES="$DOCKERFILE"
@@ -84,7 +102,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .github
-          file: .github/${{ inputs.docker-version }}.Dockerfile
+          file: .github/${{ inputs.dockerfile != '' && inputs.dockerfile || inputs.docker-version }}.Dockerfile
           push: true
           build-args: |
             GIT_SHA=${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,9 +299,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # nullglob so the loop is skipped (rather than running on a literal
+          # '*.ext') when cpack produced nothing; fail loudly in that case.
+          shopt -s nullglob
           ext="${{ matrix.image.package_ext }}"
           tag="${{ matrix.image.distro }}${{ matrix.arch.suffix }}"
-          for f in *."$ext"; do
+          pkgs=(*."$ext")
+          if [ "${#pkgs[@]}" -eq 0 ]; then
+            echo "ERROR: cpack produced no .$ext packages to namespace" >&2
+            exit 1
+          fi
+          for f in "${pkgs[@]}"; do
             mv "$f" "${f%.$ext}-${tag}.$ext"
           done
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,20 +238,28 @@ jobs:
           } >> $GITHUB_OUTPUT
 
   build-cpp-artifacts:
-    name: Build C++ Artifacts on ${{ matrix.image.distro }} with ${{ matrix.image.compiler-c }}
-    runs-on: tt-ubuntu-2204-large-stable
+    name: >-
+      Build C++ Artifacts on ${{ matrix.image.distro }}${{ matrix.arch.suffix }}
+      with ${{ matrix.image.compiler-c }}
+    runs-on: ${{ matrix.arch.runner }}
     needs: prepare-release
     timeout-minutes: 30
     strategy:
       fail-fast: false
+      # Each distro is built for both architectures. x86_64 builds on the internal
+      # runner; arm64 builds on the public ubuntu-24.04-arm runner with the -arm
+      # images (pushed to :latest on main by the CI image-ensure jobs).
       matrix:
+        arch:
+          - {suffix: "", runner: tt-ubuntu-2204-large-stable}
+          - {suffix: "-arm", runner: ubuntu-24.04-arm}
         image: [
           {distro: ubuntu-22.04, compiler-c: clang-20, compiler-cpp: clang++-20, package: DEB, package_ext: deb},
           {distro: ubuntu-24.04, compiler-c: clang-20, compiler-cpp: clang++-20, package: DEB, package_ext: deb},
           {distro: fedora-39, compiler-c: clang-17, compiler-cpp: clang++-17, package: RPM, package_ext: rpm},
         ]
     container:
-      image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ matrix.image.distro }}:latest
+      image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ matrix.image.distro }}${{ matrix.arch.suffix }}:latest
 
     env:
       CC: ${{ matrix.image.compiler-c }}
@@ -282,19 +290,48 @@ jobs:
         run: |
           cpack -G ${{ matrix.image.package }}
 
+      # cpack names packages tt_umd-<ver>-Linux-<component>.<ext> with no distro or
+      # arch, so packages from different distros/arches would otherwise collide when
+      # the release job flattens them into one folder. Embed distro+arch to keep
+      # every release asset uniquely named.
+      - name: Namespace packages by distro and arch
+        working-directory: ${{ env.BUILD_OUTPUT_DIR }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ext="${{ matrix.image.package_ext }}"
+          tag="${{ matrix.image.distro }}${{ matrix.arch.suffix }}"
+          for f in *."$ext"; do
+            mv "$f" "${f%.$ext}-${tag}.$ext"
+          done
+
       - name: Upload ${{ matrix.image.package }} packages
         uses: actions/upload-artifact@v7
         with:
-          name: tt-umd-packages-v${{ needs.prepare-release.outputs.version }}-${{ matrix.image.distro }}
+          name: >-
+            tt-umd-packages-v${{ needs.prepare-release.outputs.version
+            }}-${{ matrix.image.distro }}${{ matrix.arch.suffix }}
           path: |
             ${{ env.BUILD_OUTPUT_DIR }}/*.${{ matrix.image.package_ext }}
           if-no-files-found: error
 
   build-python-wheels:
-    name: Build Python Wheel (manylinux)
-    runs-on: tt-ubuntu-2204-large-stable
+    name: Build Python Wheel (manylinux ${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     needs: prepare-release
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      # x86_64 wheels build on the internal runner; aarch64 wheels build natively
+      # on the public ubuntu-24.04-arm runner (no QEMU).
+      matrix:
+        include:
+          - arch: x86_64
+            runner: tt-ubuntu-2204-large-stable
+            cibw-image: ghcr.io/${{ github.repository }}/tt-umd-ci-manylinux:latest
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+            cibw-image: ghcr.io/${{ github.repository }}/tt-umd-ci-manylinux-aarch64:latest
 
     steps:
       - uses: actions/checkout@v6
@@ -312,8 +349,11 @@ jobs:
       - name: Build manylinux wheels
         shell: bash
         env:
-          # Use custom manylinux Docker image with all dependencies pre-installed
-          CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/tenstorrent/tt-umd/tt-umd-ci-manylinux:latest
+          # Select the arch to build and point cibuildwheel at the matching custom
+          # manylinux image (only the env var for the built arch is consulted).
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.arch == 'x86_64' && matrix.cibw-image || '' }}
+          CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.arch == 'aarch64' && matrix.cibw-image || '' }}
           # This command will be executed for each wheel build to verify that the wheel is functional.
           CIBW_TEST_COMMAND: 'python -c "import tt_umd"'
         run: |
@@ -327,7 +367,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
-          name: tt-umd-v${{ needs.prepare-release.outputs.version }}-manylinux-wheels
+          name: tt-umd-v${{ needs.prepare-release.outputs.version }}-manylinux-${{ matrix.arch }}-wheels
           path: ${{ env.WHEEL_OUTPUT_DIR }}
 
   publish-to-testpypi:
@@ -346,7 +386,10 @@ jobs:
       - name: Download all the wheels
         uses: actions/download-artifact@v8
         with:
-          name: tt-umd-v${{ needs.prepare-release.outputs.version }}-manylinux-wheels
+          # Both arch wheel artifacts (manylinux-x86_64-wheels, manylinux-aarch64-wheels)
+          # merged into dist/.
+          pattern: tt-umd-v${{ needs.prepare-release.outputs.version }}-manylinux-*-wheels
+          merge-multiple: true
           path: dist/
 
       - name: Publish distribution 📦 to TestPyPI
@@ -371,7 +414,10 @@ jobs:
       - name: Download all the wheels
         uses: actions/download-artifact@v8
         with:
-          name: tt-umd-v${{ needs.prepare-release.outputs.version }}-manylinux-wheels
+          # Both arch wheel artifacts (manylinux-x86_64-wheels, manylinux-aarch64-wheels)
+          # merged into dist/.
+          pattern: tt-umd-v${{ needs.prepare-release.outputs.version }}-manylinux-*-wheels
+          merge-multiple: true
           path: dist/
 
       - name: Publish distribution 📦 to PyPI
@@ -429,13 +475,14 @@ jobs:
             Contains: Compiled C++ libraries, public headers, CMake config files, and dependencies.
 
             ### System Packages (.deb / .rpm)
-            - **Ubuntu 22.04**: DEB packages are attached under Assets
-            - **Ubuntu 24.04**: DEB packages are attached under Assets
-            - **Fedora 39**: RPM packages are attached under Assets
+            - **Ubuntu 22.04**: DEB packages are attached under Assets (x86_64 and aarch64)
+            - **Ubuntu 24.04**: DEB packages are attached under Assets (x86_64 and aarch64)
+            - **Fedora 39**: RPM packages are attached under Assets (x86_64 and aarch64)
             - Includes: `umd-runtime`, `umd-dev` and `umd-python` packages
+            - Package file names are suffixed with the distro and arch (e.g. `-ubuntu-24.04-arm`)
 
             ### Python Wheels
-            - **manylinux_2_28 wheels** for Python 3.9-3.13 (x86_64)
+            - **manylinux_2_28 wheels** for Python 3.9-3.13 (x86_64 and aarch64)
             - Compatible with Ubuntu 20.04+, RHEL 8+, and other modern Linux distributions
             - Includes Python bindings for tt-umd
             - PyPI: https://pypi.org/project/tt-umd/

--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -19,6 +19,13 @@ on:
         description: 'The timeout for the job in minutes'
         type: number
         default: 30
+      arm-image-tag:
+        required: false
+        type: string
+        default: latest
+        description: >-
+          Content-hash tag for the arm64 (ubuntu-24.04-arm) CI image, used by the
+          aarch64 matrix leg. Defaults to ":latest".
 
 jobs:
   build-and-run-ttsim:
@@ -26,10 +33,33 @@ jobs:
     # In pull_request or push events, the input context is not available, stating the default again here.
     timeout-minutes: ${{ fromJSON(inputs.timeout || '30') }}
 
-    name: Build and test ttsim with newest UMD
-    runs-on: tt-ubuntu-2204-large-stable
+    name: Build and test ttsim with newest UMD (${{ matrix.arch }})
+    # One entry per architecture, sharing the same steps. The build-metal flag is
+    # the only behavioural switch: x86_64 builds tt-metal (verifying tt-metal
+    # builds against the newest UMD) and runs the tt-metal sim tests on top of
+    # UMD's own sim tests; aarch64 sets build-metal: false because tt-metal does
+    # not publish an arm64 dev image yet, so it only downloads the ttsim binaries,
+    # builds UMD api_tests and runs UMD's device-IO fixtures against the simulator.
+    # Once an arm64 tt-metal dev image exists, flip build-metal to true for aarch64.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: tt-ubuntu-2204-large-stable
+            image: ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest
+            ttsim-suffix: ""
+            umd-dir: tt-metal/tt_metal/third_party/umd
+            build-metal: true
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+            image: ghcr.io/${{ github.repository }}/tt-umd-ci-ubuntu-24.04-arm:${{ inputs.arm-image-tag || 'latest' }}
+            ttsim-suffix: "_aarch64"
+            umd-dir: umd
+            build-metal: false
+    runs-on: ${{ matrix.runner }}
     container:
-      image: ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest
+      image: ${{ matrix.image }}
       env:
         # TODO: Revisit the addition of these env vars https://github.com/tenstorrent/tt-metal/issues/20161
         TRACY_NO_INVARIANT_CHECK: 1
@@ -37,6 +67,7 @@ jobs:
 
     steps:
       - name: Checkout tt-metal repo
+        if: matrix.build-metal
         uses: actions/checkout@v6
         with:
           # Clone under tt-metal directory
@@ -49,55 +80,58 @@ jobs:
       - name: Checkout UMD
         uses: actions/checkout@v6
         with:
-          # Clone directly into tt-metal directory for umd
-          path: tt-metal/tt_metal/third_party/umd
+          # x86_64 nests UMD inside tt-metal so build_metal.sh picks up this branch;
+          # aarch64 checks it out standalone. matrix.umd-dir is used everywhere below.
+          path: ${{ matrix.umd-dir }}
           submodules: recursive
 
       - name: Get ttsim version
         id: get-ttsim-version
         run: |
-          # Extract the default ttsim-version value from tt-metal's ttsim.yaml
-          if [ -f "tt-metal/.github/workflows/ttsim.yaml" ]; then
-            TTSIM_VERSION=$(grep -A 5 "ttsim-version:" tt-metal/.github/workflows/ttsim.yaml \
-                      | grep "default:" \
-                      | sed 's/.*default: *"\?\([^"]*\)"\?.*/\1/' \
-                      | tr -d ' ')
-            if [ -z "$TTSIM_VERSION" ]; then
-              echo "Warning: Could not extract ttsim version from input default, using v1.0.0"
-              TTSIM_VERSION="v1.0.0"
-            fi
-          else
-            echo "Warning: ttsim.yaml not found, using v1.0.0"
+          # Pin the same ttsim version tt-metal uses (single source of truth) by
+          # reading the default from tt-metal's ttsim.yaml on main. This keeps the
+          # x86_64 and aarch64 legs on the same simulator.
+          TTSIM_VERSION=$(curl -fsSL \
+            https://raw.githubusercontent.com/tenstorrent/tt-metal/main/.github/workflows/ttsim.yaml \
+            | grep -A 5 "ttsim-version:" \
+            | grep "default:" \
+            | sed 's/.*default: *"\?\([^"]*\)"\?.*/\1/' \
+            | tr -d ' ' || true)
+          if [ -z "$TTSIM_VERSION" ]; then
+            echo "Warning: Could not extract ttsim version, using v1.0.0"
             TTSIM_VERSION="v1.0.0"
           fi
           echo "Extracted ttsim version: $TTSIM_VERSION"
           echo "ttsim-version=$TTSIM_VERSION" >> $GITHUB_OUTPUT
 
+      # The aarch64 simulator binaries carry an "_aarch64" suffix; matrix.ttsim-suffix
+      # selects the right asset per arch. All three land in /tmp/ttsim.
       - name: Download ttsim binary (wh)
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f  # v1.13
         with:
           repository: tenstorrent/ttsim
           tag: ${{ steps.get-ttsim-version.outputs.ttsim-version }}
-          fileName: "libttsim_wh.so"
-          out-file-path: /tmp/ttsim-wh
+          fileName: "libttsim_wh${{ matrix.ttsim-suffix }}.so"
+          out-file-path: /tmp/ttsim
 
       - name: Download ttsim binary (bh)
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f  # v1.13
         with:
           repository: tenstorrent/ttsim
           tag: ${{ steps.get-ttsim-version.outputs.ttsim-version }}
-          fileName: "libttsim_bh.so"
-          out-file-path: /tmp/ttsim-bh
+          fileName: "libttsim_bh${{ matrix.ttsim-suffix }}.so"
+          out-file-path: /tmp/ttsim
 
       - name: Download ttsim binary (qsr)
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f  # v1.13
         with:
           repository: tenstorrent/ttsim
           tag: ${{ steps.get-ttsim-version.outputs.ttsim-version }}
-          fileName: "libttsim_qsr.so"
-          out-file-path: /tmp/ttsim-qsr
+          fileName: "libttsim_qsr${{ matrix.ttsim-suffix }}.so"
+          out-file-path: /tmp/ttsim
 
       - name: Build tt-metal
+        if: matrix.build-metal
         run: |
           cd tt-metal
           export TT_METAL_HOME=$(pwd)
@@ -110,20 +144,31 @@ jobs:
           cd ../
 
       - name: Prepare sim paths
+        shell: bash
         run: |
+          set -euo pipefail
           echo "Preparing sim paths"
           mkdir -p sim_wh sim_bh sim_qsr
-          mv /tmp/ttsim-wh/libttsim_wh.so sim_wh/libttsim.so
-          mv /tmp/ttsim-bh/libttsim_bh.so sim_bh/libttsim.so
-          mv /tmp/ttsim-qsr/libttsim_qsr.so sim_qsr/libttsim.so
-          cp $TT_METAL_HOME/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml sim_wh/soc_descriptor.yaml
-          cp $TT_METAL_HOME/tt_metal/soc_descriptors/blackhole_140_arch.yaml sim_bh/soc_descriptor.yaml
-          cp tt-metal/tt_metal/third_party/umd/tests/soc_descs/quasar_32_arch.yaml sim_qsr/soc_descriptor.yaml
+          mv /tmp/ttsim/libttsim_wh${{ matrix.ttsim-suffix }}.so sim_wh/libttsim.so
+          mv /tmp/ttsim/libttsim_bh${{ matrix.ttsim-suffix }}.so sim_bh/libttsim.so
+          mv /tmp/ttsim/libttsim_qsr${{ matrix.ttsim-suffix }}.so sim_qsr/libttsim.so
+          # The ttsim binaries model the full grid. x86_64 sources the wh/bh
+          # descriptors from the tt-metal checkout (as before); aarch64 (no tt-metal)
+          # uses the equivalent full-grid descriptors from UMD's own tests/soc_descs
+          # (wormhole_b0_8x10 == wormhole_b0_80_arch, blackhole_140_arch is identical).
+          if [ "${{ matrix.build-metal }}" = "true" ]; then
+            cp "$TT_METAL_HOME/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml" sim_wh/soc_descriptor.yaml
+            cp "$TT_METAL_HOME/tt_metal/soc_descriptors/blackhole_140_arch.yaml" sim_bh/soc_descriptor.yaml
+          else
+            cp "${{ matrix.umd-dir }}/tests/soc_descs/wormhole_b0_8x10.yaml" sim_wh/soc_descriptor.yaml
+            cp "${{ matrix.umd-dir }}/tests/soc_descs/blackhole_140_arch.yaml" sim_bh/soc_descriptor.yaml
+          fi
+          cp "${{ matrix.umd-dir }}/tests/soc_descs/quasar_32_arch.yaml" sim_qsr/soc_descriptor.yaml
 
       - name: Build UMD api_tests with simulation support
         run: |
-          cmake -B tt-metal/tt_metal/third_party/umd/build -G Ninja \
-            -S tt-metal/tt_metal/third_party/umd \
+          cmake -B ${{ matrix.umd-dir }}/build -G Ninja \
+            -S ${{ matrix.umd-dir }} \
             -DTT_UMD_BUILD_TESTS=ON \
             -DTT_UMD_BUILD_SIMULATION=ON \
             -DTT_UMD_BUILD_PYTHON=OFF \
@@ -132,66 +177,70 @@ jobs:
             -DTT_UMD_ENABLE_CLANG_TIDY=OFF \
             -DTT_UMD_ENABLE_TRACY=OFF \
             -DCMAKE_BUILD_TYPE=Release
-          cmake --build tt-metal/tt_metal/third_party/umd/build --target api_tests
+          cmake --build ${{ matrix.umd-dir }}/build --target api_tests
 
       # Following single card tests should be really fast, only a couple of seconds each, so we set a short timeout for
       # them and if they time out, it indicates some issue with the simulator setup rather than an actual test failure.
       - name: Run tt-sim wormhole tests
+        if: matrix.build-metal
         timeout-minutes: 1
         run: |
           export TT_METAL_SIMULATOR=$(pwd)/sim_wh/libttsim.so
           TT_METAL_SLOW_DISPATCH_MODE=1 $TT_METAL_HOME/build/programming_examples/metal_example_add_2_integers_in_riscv
 
       - name: Run tt-sim blackhole tests
+        if: matrix.build-metal
         timeout-minutes: 1
         run: |
           export TT_METAL_SIMULATOR=$(pwd)/sim_bh/libttsim.so
           TT_METAL_SLOW_DISPATCH_MODE=1 $TT_METAL_HOME/build/programming_examples/metal_example_add_2_integers_in_riscv
 
+      # UMD's own simulator tests run on both architectures.
       - name: Run UMD TestDeviceIOFixture on tt-sim wormhole
         timeout-minutes: 1
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_wh/libttsim.so
         run: |
-          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
+          ${{ matrix.umd-dir }}/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
 
       - name: Run UMD TestDeviceIOFixture on tt-sim blackhole
         timeout-minutes: 1
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh/libttsim.so
         run: |
-          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
+          ${{ matrix.umd-dir }}/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
 
       - name: Run UMD TTSimDeviceIOFixture on tt-sim wormhole
         timeout-minutes: 1
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_wh/libttsim.so
         run: |
-          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
+          ${{ matrix.umd-dir }}/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
 
       - name: Run UMD TTSimDeviceIOFixture on tt-sim blackhole
         timeout-minutes: 1
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh/libttsim.so
         run: |
-          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
+          ${{ matrix.umd-dir }}/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
 
       - name: Run UMD TestDeviceIOFixture on tt-sim quasar
         timeout-minutes: 1
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_qsr/libttsim.so
         run: |
-          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
+          ${{ matrix.umd-dir }}/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
 
       - name: Run UMD TTSimDeviceIOFixture on tt-sim quasar
         timeout-minutes: 1
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_qsr/libttsim.so
         run: |
-          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
+          ${{ matrix.umd-dir }}/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
 
       # Galaxy tests can be a bit longer, should run on the order of minutes.
       - name: Run tt-metal C++ unit test on tt-sim galaxy wormhole_b0
+        if: matrix.build-metal
         timeout-minutes: 5
         env:
           TT_METAL_SIMULATOR_HOME: ${{ github.workspace }}/sim_wh
@@ -207,6 +256,7 @@ jobs:
           ./build/test/tt_metal/unit_tests_api --gtest_filter="*InlineWrite*"
 
       - name: Run tt-metal C++ unit test on tt-sim galaxy blackhole
+        if: matrix.build-metal
         timeout-minutes: 5
         env:
           TT_METAL_SIMULATOR_HOME: ${{ github.workspace }}/sim_bh

--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -85,12 +85,19 @@ jobs:
 
       - name: Get ttsim version
         id: get-ttsim-version
+        shell: bash
         run: |
-          # Pin the same ttsim version tt-metal uses (single source of truth) by
-          # reading the default from tt-metal's ttsim.yaml on main. This keeps the
-          # x86_64 and aarch64 legs on the same simulator.
-          TTSIM_VERSION=$(curl -fsSL \
-            https://raw.githubusercontent.com/tenstorrent/tt-metal/main/.github/workflows/ttsim.yaml \
+          # Pin the same ttsim version tt-metal uses (single source of truth).
+          # x86_64 reads it from the local tt-metal checkout; aarch64 has no
+          # tt-metal checkout so it fetches tt-metal's ttsim.yaml from main with
+          # wget (the UMD CI image ships wget, not curl).
+          if [ "${{ matrix.build-metal }}" = "true" ]; then
+            TTSIM_YAML=$(cat tt-metal/.github/workflows/ttsim.yaml 2>/dev/null || true)
+          else
+            TTSIM_YAML=$(wget -qO- \
+              https://raw.githubusercontent.com/tenstorrent/tt-metal/main/.github/workflows/ttsim.yaml || true)
+          fi
+          TTSIM_VERSION=$(printf '%s\n' "$TTSIM_YAML" \
             | grep -A 5 "ttsim-version:" \
             | grep "default:" \
             | sed 's/.*default: *"\?\([^"]*\)"\?.*/\1/' \

--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -24,8 +24,8 @@ on:
         type: string
         default: latest
         description: >-
-          Content-hash tag for the arm64 (ubuntu-24.04-arm) CI image, used by the
-          aarch64 matrix leg. Defaults to ":latest".
+          Tag name for the arm64 (ubuntu-24.04-arm) CI image, used as `:<tag>` in
+          the image reference by the aarch64 matrix leg. Defaults to `latest`.
 
 jobs:
   build-and-run-ttsim:
@@ -40,7 +40,8 @@ jobs:
     # UMD's own sim tests; aarch64 sets build-metal: false because tt-metal does
     # not publish an arm64 dev image yet, so it only downloads the ttsim binaries,
     # builds UMD api_tests and runs UMD's device-IO fixtures against the simulator.
-    # Once an arm64 tt-metal dev image exists, flip build-metal to true for aarch64.
+    # Once an arm64 tt-metal dev image exists, flip build-metal to true for aarch64
+    # (tracked in https://github.com/tenstorrent/tt-umd/issues/2744).
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -80,8 +80,6 @@ jobs:
       - name: Checkout UMD
         uses: actions/checkout@v6
         with:
-          # x86_64 nests UMD inside tt-metal so build_metal.sh picks up this branch;
-          # aarch64 checks it out standalone. matrix.umd-dir is used everywhere below.
           path: ${{ matrix.umd-dir }}
           submodules: recursive
 
@@ -104,8 +102,6 @@ jobs:
           echo "Extracted ttsim version: $TTSIM_VERSION"
           echo "ttsim-version=$TTSIM_VERSION" >> $GITHUB_OUTPUT
 
-      # The aarch64 simulator binaries carry an "_aarch64" suffix; matrix.ttsim-suffix
-      # selects the right asset per arch. All three land in /tmp/ttsim.
       - name: Download ttsim binary (wh)
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f  # v1.13
         with:


### PR DESCRIPTION
Extend CI to build/test/package aarch64 version.
Timeout increase is because arm builds last longer (we are using public CI machines).

@broskoTT, `Build umd manylinux wheel` got renamed into `Build umd manylinux wheel (x86_64)` and there is `Build umd manylinux wheel (aarch64)` version that we can include into required jobs.