### PR TITLE
fix(ci): use tt-exalens CI image and clear toolchain variables for kernel builds

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -214,7 +214,14 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}:${{ inputs.image-tag }}
+      # Use tt-exalens own CI image as it has everything pre-installed.
+      image: ghcr.io/tenstorrent/tt-exalens/tt-exalens-ci-${{ inputs.ubuntu-docker-version }}:latest
+
+    env:
+      # Clear the workflow-level CC/CXX (clang-20): that toolchain only exists in the
+      # tt-umd image.
+      CC: ""
+      CXX: ""
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Unblocking CI with small fix for tt-exalens tests.