### PR TITLE
Fix Quasar segmentation fault

### DIFF
--- a/device/api/umd/device/chip/mock_chip.hpp
+++ b/device/api/umd/device/chip/mock_chip.hpp
@@ -59,6 +59,12 @@ public:
 
     void deassert_risc_resets() override;
 
+    RiscType get_risc_reset_state(CoreCoord core) override;
+    void assert_risc_reset(CoreCoord core, const RiscType selected_riscs) override;
+    void deassert_risc_reset(CoreCoord core, const RiscType selected_riscs, bool staggered_start) override;
+    void assert_risc_reset(const RiscType selected_riscs) override;
+    void deassert_risc_reset(const RiscType selected_riscs, bool staggered_start) override;
+
     void set_power_state(DevicePowerState state) override;
     int get_clock() override;
     int get_numa_node() override;

--- a/device/chip/mock_chip.cpp
+++ b/device/chip/mock_chip.cpp
@@ -75,6 +75,16 @@ void MockChip::dram_membar(const std::unordered_set<uint32_t>& channels, uint32_
 
 void MockChip::deassert_risc_resets() {}
 
+RiscType MockChip::get_risc_reset_state(CoreCoord core) { return RiscType::NONE; }
+
+void MockChip::assert_risc_reset(CoreCoord core, const RiscType selected_riscs) {}
+
+void MockChip::deassert_risc_reset(CoreCoord core, const RiscType selected_riscs, bool staggered_start) {}
+
+void MockChip::assert_risc_reset(const RiscType selected_riscs) {}
+
+void MockChip::deassert_risc_reset(const RiscType selected_riscs, bool staggered_start) {}
+
 void MockChip::set_power_state(DevicePowerState state) {}
 
 int MockChip::get_clock() { return 0; }

--- a/tests/baremetal/test_cluster_descriptor_offline.cpp
+++ b/tests/baremetal/test_cluster_descriptor_offline.cpp
@@ -423,6 +423,30 @@ TEST(ApiMockClusterTest, CreateMockClustersFromAllDescriptors) {
     }
 }
 
+// Recreates tt-metal's device-init codepath on a mock cluster for every descriptor: construct the
+// mock Cluster and run start_device(init_device=true), as MeshDevice::create does.
+TEST(ApiMockClusterTest, StartDeviceFromAllDescriptors) {
+    for (const auto& descriptor_file : test_utils::GetAllClusterDescs()) {
+        log_info(LogUMD, "Starting mock cluster from: {}", descriptor_file);
+
+        std::unique_ptr<ClusterDescriptor> cluster_desc;
+        ASSERT_NO_THROW(cluster_desc = ClusterDescriptor::create_from_yaml(descriptor_file))
+            << "Failed to load cluster descriptor from: " << descriptor_file;
+        ASSERT_NE(cluster_desc, nullptr) << "Cluster descriptor is null for: " << descriptor_file;
+
+        std::unique_ptr<Cluster> mock_cluster;
+        ASSERT_NO_THROW(
+            mock_cluster = std::make_unique<Cluster>(
+                ClusterOptions{.chip_type = ChipType::MOCK, .cluster_descriptor = cluster_desc.get()}))
+            << "Failed to create mock cluster for: " << descriptor_file;
+        ASSERT_NE(mock_cluster, nullptr) << "Mock cluster is null for: " << descriptor_file;
+
+        // Same init the tt-metal runtime runs (start_driver forces init_device = true).
+        EXPECT_NO_THROW(mock_cluster->start_device({.init_device = true}))
+            << "start_device failed for mock cluster: " << descriptor_file;
+    }
+}
+
 TEST(RefreshClusterDescriptionTest, ThrowsForNonSiliconChipType) {
     auto cluster_desc = ClusterDescriptor::create_from_yaml(test_utils::GetClusterDescAbsPath("wormhole_N150.yaml"));
     Cluster cluster(ClusterOptions{.chip_type = ChipType::MOCK, .cluster_descriptor = cluster_desc.get()});

--- a/tests/test_utils/fetch_local_files.hpp
+++ b/tests/test_utils/fetch_local_files.hpp
@@ -56,6 +56,7 @@ inline std::vector<std::string> GetAllClusterDescs() {
              "wormhole_N300.yaml",
              "wormhole_N300_jtag.yaml",
              "wormhole_N300_pci_bdf.yaml",
+             "quasar_Q1.yaml",
          }) {
         cluster_desc_names.push_back(GetClusterDescAbsPath(cluster_desc_name));
     }


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2760

### Description
An issue was raised specifically for quasar Mock, because only that mock called one of assert deassert variants after  https://github.com/tenstorrent/tt-umd/pull/2722

### List of the changes
- Add a test that fails on current UMD main
- Fix by overriding functions in MockChip

### Testing
Failure on this PR after first commit, proving the test works:https://github.com/tenstorrent/tt-umd/actions/runs/26765716659/job/78902436018?pr=2759
On the current commit it obviously works.
tt-metal pipeline passing with this commit: https://github.com/tenstorrent/tt-metal/actions/runs/26770847604

### API Changes
This PR has no API changes.
