### PR TITLE
Add read_from_device_reg() methods to TTDevice

### DIFF
--- a/device/api/umd/device/pcie/silicon_tlb_window.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_window.hpp
@@ -62,6 +62,10 @@ public:
         void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict)
         override;
 
+    void safe_read_register_reconfigure(
+        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict)
+        override;
+
     void safe_noc_multicast_write_reconfigure(
         void* dst,
         size_t size,

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -41,6 +41,11 @@ public:
     virtual void read_block_reconfigure(
         void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
 
+    // Register-oriented counterpart to read_block_reconfigure: reconfigures the window for (core, addr) and
+    // reads via the volatile register path (read_register) rather than a block copy. Ordering defaults to Strict.
+    virtual void read_register_reconfigure(
+        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
+
     virtual void write_block_reconfigure(
         const void* mem_ptr,
         tt_xy_pair core,
@@ -83,6 +88,9 @@ public:
         uint64_t ordering = tlb_data::Strict);
 
     virtual void safe_read_block_reconfigure(
+        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
+
+    virtual void safe_read_register_reconfigure(
         void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
 
     virtual void safe_noc_multicast_write_reconfigure(

--- a/device/api/umd/device/tt_device/protocol/device_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/device_protocol.hpp
@@ -27,6 +27,13 @@ public:
     virtual void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) = 0;
     virtual void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) = 0;
 
+    // Strict-ordered MMIO register read. Transports with a dedicated register aperture (PCIe) override
+    // this; the default falls back to a (relaxed) block read, which is the correct behaviour for transports
+    // that route registers as ordinary memory (e.g. remote/Ethernet).
+    virtual void read_from_device_reg(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+        read_from_device(mem_ptr, core, addr, size, noc_id);
+    }
+
     // [[nodiscard]] tells the compiler that the return value should not be ignored.
     // This ensures the caller handles the software fallback
     // if the hardware does not support multicast.

--- a/device/api/umd/device/tt_device/protocol/device_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/device_protocol.hpp
@@ -9,6 +9,7 @@
 
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
 
@@ -31,6 +32,7 @@ public:
     // this; the default falls back to a (relaxed) block read, which is the correct behaviour for transports
     // that route registers as ordinary memory (e.g. remote/Ethernet).
     virtual void read_from_device_reg(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+        validate_register_access(addr, size);
         read_from_device(mem_ptr, core, addr, size, noc_id);
     }
 

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -42,6 +42,7 @@ public:
     // DeviceProtocol interface.
     void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
     void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
+    void read_from_device_reg(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
     bool write_to_core_range(
         const void* mem_ptr, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, uint32_t size, NocId noc_id)
         override;
@@ -84,6 +85,8 @@ private:
     void write_to_device_impl(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id);
     template <bool safe>
     void read_from_device_impl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id);
+    template <bool safe>
+    void read_from_device_reg_impl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id);
 
     // Offset used to access NOC2AXI config + ARC specific memory (ICCM + CSM + APB).
     static constexpr uint32_t BAR0_OFFSET = 0x1FD00000;

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -10,7 +10,6 @@
 #include <cstdint>
 #include <filesystem>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -190,11 +189,10 @@ public:
     virtual void read_from_device(void *mem_ptr, CoreCoord core, uint64_t addr, size_t size);
     virtual void write_to_device(const void *mem_ptr, CoreCoord core, uint64_t addr, size_t size);
 
-    // Register read using Strict NOC ordering via a dedicated, cached UC TLB window. This mirrors
-    // LocalChip::read_from_device_reg for callers that hold only a TTDevice (e.g. tt-telemetry, which
-    // discovers bare TTDevices rather than constructing the Chip/Cluster layer). addr and size must be
-    // 4-byte aligned. On non-PCIe transports there is no MMIO register aperture, so this falls back to
-    // a (relaxed) block read, matching the behaviour of the Chip-layer register path.
+    // Strict-ordered MMIO register read for callers that hold only a TTDevice (e.g. tt-telemetry, which
+    // discovers bare TTDevices rather than constructing the Chip/Cluster layer). Thin forwarder to the
+    // device protocol layer, which picks the correct path per transport (PCIe: dedicated register read via
+    // a UC TLB window; others: relaxed block-read fallback). addr and size must be 4-byte aligned.
     virtual void read_from_device_reg(void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size);
     virtual void read_from_device_reg(void *mem_ptr, CoreCoord core, uint64_t addr, size_t size);
 
@@ -526,21 +524,12 @@ protected:
 private:
     void probe_arc();
 
-    // Lazily allocates (on first use) and returns the cached UC TLB window used by
-    // read_from_device_reg. Must only be called while holding uc_tlb_lock_.
-    TlbWindow *get_cached_uc_tlb_window();
-
     std::optional<SocDescriptor> soc_descriptor_ = std::nullopt;
     std::unique_ptr<DeviceProtocol> device_protocol_;
     std::unique_ptr<HangDetector> hang_detector_;
     PcieInterface *pcie_capabilities_ = nullptr;
     JtagInterface *jtag_capabilities_ = nullptr;
     RemoteInterface *remote_capabilities_ = nullptr;
-
-    // Dedicated UC TLB window + lock for register reads (read_from_device_reg). Kept separate from the
-    // block-read path so reconfiguring this window never races with block IO. Serialised by uc_tlb_lock_.
-    std::unique_ptr<TlbWindow> cached_uc_tlb_window_;
-    std::mutex uc_tlb_lock_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -188,6 +189,14 @@ public:
     virtual void write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size);
     virtual void read_from_device(void *mem_ptr, CoreCoord core, uint64_t addr, size_t size);
     virtual void write_to_device(const void *mem_ptr, CoreCoord core, uint64_t addr, size_t size);
+
+    // Register read using Strict NOC ordering via a dedicated, cached UC TLB window. This mirrors
+    // LocalChip::read_from_device_reg for callers that hold only a TTDevice (e.g. tt-telemetry, which
+    // discovers bare TTDevices rather than constructing the Chip/Cluster layer). addr and size must be
+    // 4-byte aligned. On non-PCIe transports there is no MMIO register aperture, so this falls back to
+    // a (relaxed) block read, matching the behaviour of the Chip-layer register path.
+    virtual void read_from_device_reg(void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size);
+    virtual void read_from_device_reg(void *mem_ptr, CoreCoord core, uint64_t addr, size_t size);
 
     /**
      * NOC multicast write function that will write data to multiple cores on NOC grid. Multicast writes data to a grid
@@ -517,12 +526,21 @@ protected:
 private:
     void probe_arc();
 
+    // Lazily allocates (on first use) and returns the cached UC TLB window used by
+    // read_from_device_reg. Must only be called while holding uc_tlb_lock_.
+    TlbWindow *get_cached_uc_tlb_window();
+
     std::optional<SocDescriptor> soc_descriptor_ = std::nullopt;
     std::unique_ptr<DeviceProtocol> device_protocol_;
     std::unique_ptr<HangDetector> hang_detector_;
     PcieInterface *pcie_capabilities_ = nullptr;
     JtagInterface *jtag_capabilities_ = nullptr;
     RemoteInterface *remote_capabilities_ = nullptr;
+
+    // Dedicated UC TLB window + lock for register reads (read_from_device_reg). Kept separate from the
+    // block-read path so reconfiguring this window never races with block IO. Serialised by uc_tlb_lock_.
+    std::unique_ptr<TlbWindow> cached_uc_tlb_window_;
+    std::mutex uc_tlb_lock_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/utils/error.hpp
+++ b/device/api/umd/device/utils/error.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 
@@ -43,3 +45,26 @@ public:
 };
 
 }  // namespace tt::umd::error
+
+namespace tt::umd {
+
+/**
+ * @brief Precondition guard for register (MMIO word) accesses.
+ *
+ * Device registers are read and written one 32-bit word at a time, so both the address and the
+ * transfer size must be 4-byte aligned; otherwise the word-granular access would silently truncate
+ * the size or read/write a misaligned location. This guard is replicated at every layer that exposes
+ * a register-read entry point (TTDevice, DeviceProtocol, TlbWindow) so that each layer validates its
+ * own inputs rather than trusting its caller, mirroring how TlbWindow::validate() is repeated in every
+ * primitive access.
+ */
+inline void validate_register_access(uint64_t addr, size_t size) {
+    if (size % sizeof(uint32_t) != 0) {
+        UMD_THROW(error::RuntimeError, "Size must be a multiple of 4 bytes.");
+    }
+    if (addr % sizeof(uint32_t) != 0) {
+        UMD_THROW(error::RuntimeError, "Register address must be 4-byte aligned.");
+    }
+}
+
+}  // namespace tt::umd

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -285,6 +285,11 @@ void SiliconTlbWindow::safe_read_block_reconfigure(
     execute_safe(&SiliconTlbWindow::read_block_reconfigure, mem_ptr, core, addr, size, noc_id, ordering);
 }
 
+void SiliconTlbWindow::safe_read_register_reconfigure(
+    void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    execute_safe(&SiliconTlbWindow::read_register_reconfigure, mem_ptr, core, addr, size, noc_id, ordering);
+}
+
 void SiliconTlbWindow::safe_noc_multicast_write_reconfigure(
     void *dst,
     size_t size,

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -13,6 +13,7 @@
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/tlb.hpp"
 #include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
 
@@ -51,6 +52,7 @@ void TlbWindow::read_block_reconfigure(
 
 void TlbWindow::read_register_reconfigure(
     void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    validate_register_access(addr, size);
     uint8_t* buffer_addr = static_cast<uint8_t*>(mem_ptr);
     tlb_data config{};
     config.local_offset = addr;

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -49,6 +49,32 @@ void TlbWindow::read_block_reconfigure(
     }
 }
 
+void TlbWindow::read_register_reconfigure(
+    void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    uint8_t* buffer_addr = static_cast<uint8_t*>(mem_ptr);
+    tlb_data config{};
+    config.local_offset = addr;
+    config.x_end = core.x;
+    config.y_end = core.y;
+    config.noc_sel = static_cast<uint64_t>(noc_id);
+    config.ordering = ordering;
+    config.static_vc = tlb_handle->get_arch() != tt::ARCH::BLACKHOLE;
+
+    while (size > 0) {
+        configure(config);
+        size_t tlb_size = get_size();
+        size_t transfer_size = std::min(size, tlb_size);
+
+        read_register(0, buffer_addr, transfer_size);
+
+        size -= transfer_size;
+        addr += transfer_size;
+        buffer_addr += transfer_size;
+
+        config.local_offset = addr;
+    }
+}
+
 void TlbWindow::write_block_reconfigure(
     const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
     const uint8_t* buffer_addr = static_cast<const uint8_t*>(mem_ptr);
@@ -157,6 +183,11 @@ void TlbWindow::safe_write_block_reconfigure(
 void TlbWindow::safe_read_block_reconfigure(
     void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
     read_block_reconfigure(mem_ptr, core, addr, size, noc_id, ordering);
+}
+
+void TlbWindow::safe_read_register_reconfigure(
+    void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    read_register_reconfigure(mem_ptr, core, addr, size, noc_id, ordering);
 }
 
 void TlbWindow::safe_noc_multicast_write_reconfigure(

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -81,6 +81,15 @@ void PcieProtocol::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t add
     }
 }
 
+void PcieProtocol::read_from_device_reg(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+    std::lock_guard<std::mutex> lock(io_lock_);
+    if (use_safe_api_) {
+        read_from_device_reg_impl<true>(mem_ptr, core, addr, size, noc_id);
+    } else {
+        read_from_device_reg_impl<false>(mem_ptr, core, addr, size, noc_id);
+    }
+}
+
 template <bool safe>
 void PcieProtocol::write_to_device_impl(
     const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
@@ -97,6 +106,17 @@ void PcieProtocol::read_from_device_impl(void* mem_ptr, tt_xy_pair core, uint64_
         get_cached_tlb_window()->safe_read_block_reconfigure(mem_ptr, core, addr, size, noc_id);
     } else {
         get_cached_tlb_window()->read_block_reconfigure(mem_ptr, core, addr, size, noc_id);
+    }
+}
+
+template <bool safe>
+void PcieProtocol::read_from_device_reg_impl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+    // Reuses the cached UC TLB window and io_lock_ (held by the caller); read_register_reconfigure builds the
+    // tlb_data (Strict ordering by default) and performs a volatile register read.
+    if constexpr (safe) {
+        get_cached_tlb_window()->safe_read_register_reconfigure(mem_ptr, core, addr, size, noc_id);
+    } else {
+        get_cached_tlb_window()->read_register_reconfigure(mem_ptr, core, addr, size, noc_id);
     }
 }
 

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -82,6 +82,7 @@ void PcieProtocol::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t add
 }
 
 void PcieProtocol::read_from_device_reg(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+    validate_register_access(addr, size);
     std::lock_guard<std::mutex> lock(io_lock_);
     if (use_safe_api_) {
         read_from_device_reg_impl<true>(mem_ptr, core, addr, size, noc_id);

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -303,6 +303,49 @@ void TTDevice::read_from_device(void *mem_ptr, CoreCoord core, uint64_t addr, si
     read_from_device(mem_ptr, soc_desc.translate_chip_coord_to_translated(core), addr, size);
 }
 
+TlbWindow *TTDevice::get_cached_uc_tlb_window() {
+    if (cached_uc_tlb_window_ == nullptr) {
+        cached_uc_tlb_window_ =
+            get_io_window(tlb_data{}, TlbMapping::UC, get_architecture_implementation()->get_cached_tlb_size());
+    }
+    return cached_uc_tlb_window_.get();
+}
+
+void TTDevice::read_from_device_reg(void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
+    if (size % sizeof(uint32_t) != 0) {
+        UMD_THROW(error::RuntimeError, "Size must be a multiple of 4 bytes.");
+    }
+    if (addr % sizeof(uint32_t) != 0) {
+        UMD_THROW(error::RuntimeError, "Register address must be 4-byte aligned.");
+    }
+
+    // No MMIO register aperture on non-PCIe transports; fall back to a block read, matching the
+    // Chip-layer register path (RemoteChip::read_from_device_reg also delegates to a block read).
+    if (get_communication_device_type() != IODeviceType::PCIe) {
+        read_from_device(mem_ptr, core, addr, size);
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(uc_tlb_lock_);
+
+    tlb_data config{};
+    config.local_offset = addr;
+    config.x_end = core.x;
+    config.y_end = core.y;
+    config.noc_sel = is_selected_noc1() ? 1 : 0;
+    config.ordering = tlb_data::Strict;
+    config.static_vc = get_architecture_implementation()->get_static_vc();
+
+    TlbWindow *tlb_window = get_cached_uc_tlb_window();
+    tlb_window->configure(config);
+    tlb_window->read_register(addr - tlb_window->get_base_address(), mem_ptr, size);
+}
+
+void TTDevice::read_from_device_reg(void *mem_ptr, CoreCoord core, uint64_t addr, size_t size) {
+    const SocDescriptor &soc_desc = get_soc_descriptor();
+    read_from_device_reg(mem_ptr, soc_desc.translate_chip_coord_to_translated(core), addr, size);
+}
+
 void TTDevice::write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     ZoneScopedC(tracy::Color::Orange);
     device_protocol_->write_to_device(mem_ptr, core, addr, size, get_selected_noc_id());

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -305,12 +305,7 @@ void TTDevice::read_from_device(void *mem_ptr, CoreCoord core, uint64_t addr, si
 
 void TTDevice::read_from_device_reg(void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     ZoneScopedC(tracy::Color::Orange);
-    if (size % sizeof(uint32_t) != 0) {
-        UMD_THROW(error::RuntimeError, "Size must be a multiple of 4 bytes.");
-    }
-    if (addr % sizeof(uint32_t) != 0) {
-        UMD_THROW(error::RuntimeError, "Register address must be 4-byte aligned.");
-    }
+    validate_register_access(addr, size);
     device_protocol_->read_from_device_reg(mem_ptr, core, addr, size, get_selected_noc_id());
 }
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -303,42 +303,15 @@ void TTDevice::read_from_device(void *mem_ptr, CoreCoord core, uint64_t addr, si
     read_from_device(mem_ptr, soc_desc.translate_chip_coord_to_translated(core), addr, size);
 }
 
-TlbWindow *TTDevice::get_cached_uc_tlb_window() {
-    if (cached_uc_tlb_window_ == nullptr) {
-        cached_uc_tlb_window_ =
-            get_io_window(tlb_data{}, TlbMapping::UC, get_architecture_implementation()->get_cached_tlb_size());
-    }
-    return cached_uc_tlb_window_.get();
-}
-
 void TTDevice::read_from_device_reg(void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
+    ZoneScopedC(tracy::Color::Orange);
     if (size % sizeof(uint32_t) != 0) {
         UMD_THROW(error::RuntimeError, "Size must be a multiple of 4 bytes.");
     }
     if (addr % sizeof(uint32_t) != 0) {
         UMD_THROW(error::RuntimeError, "Register address must be 4-byte aligned.");
     }
-
-    // No MMIO register aperture on non-PCIe transports; fall back to a block read, matching the
-    // Chip-layer register path (RemoteChip::read_from_device_reg also delegates to a block read).
-    if (get_communication_device_type() != IODeviceType::PCIe) {
-        read_from_device(mem_ptr, core, addr, size);
-        return;
-    }
-
-    std::lock_guard<std::mutex> lock(uc_tlb_lock_);
-
-    tlb_data config{};
-    config.local_offset = addr;
-    config.x_end = core.x;
-    config.y_end = core.y;
-    config.noc_sel = is_selected_noc1() ? 1 : 0;
-    config.ordering = tlb_data::Strict;
-    config.static_vc = get_architecture_implementation()->get_static_vc();
-
-    TlbWindow *tlb_window = get_cached_uc_tlb_window();
-    tlb_window->configure(config);
-    tlb_window->read_register(addr - tlb_window->get_base_address(), mem_ptr, size);
+    device_protocol_->read_from_device_reg(mem_ptr, core, addr, size, get_selected_noc_id());
 }
 
 void TTDevice::read_from_device_reg(void *mem_ptr, CoreCoord core, uint64_t addr, size_t size) {


### PR DESCRIPTION
### Issue
[Track and ETH_CTRL.ERR_STAT across Ethernet Cores (Blackhole)](https://github.com/tenstorrent/tt-telemetry/issues/230)

### Description
In order to read the ETH_CTRL.ERR_STAT register, `TTDevice` needs a method that reads from register space, which it currently does not have (`Chip` *does* have this, however, but we are not using that in telemetry).

### List of the changes
Added `read_from_device_reg` methods to `TTDevice`. These used a dedicated uncached TLB window (logic duplicated from elsewhere).


### Testing
Ran it on a Blackhole Galaxy, did not blow up.

### API Changes

Added the following methods to `TTDevice`:
```
virtual void read_from_device_reg(void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size);
virtual void read_from_device_reg(void *mem_ptr, CoreCoord core, uint64_t addr, size_t size);
```
