### PR TITLE
Add ARM builds

### DIFF
--- a/.github/ubuntu-24.04-arm.Dockerfile
+++ b/.github/ubuntu-24.04-arm.Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV OS_CODENAME=noble
+
+COPY docker_install_common.sh /docker_install_common.sh
+RUN chmod +x /docker_install_common.sh && /docker_install_common.sh

--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -48,6 +48,15 @@ jobs:
     with:
       docker-version: ubuntu-24.04
 
+  ensure-ubuntu-2404-arm-image:
+    name: Ensure ubuntu-24.04-arm Docker image
+    permissions:
+      packages: write
+    secrets: inherit
+    uses: ./.github/workflows/docker-image.yml
+    with:
+      docker-version: ubuntu-24.04-arm
+
   ensure-fedora-39-image:
     name: Ensure fedora-39 Docker image
     permissions:
@@ -70,7 +79,7 @@ jobs:
     # Due to parsing bug, fromJSON is used to convert string to number.
     # In pull_request or push events, the input context is not available, stating the default again here.
     timeout-minutes: ${{ fromJSON(inputs.timeout || '15') }}
-    needs: [ensure-ubuntu-2204-image, ensure-ubuntu-2404-image, ensure-fedora-39-image]
+    needs: [ensure-ubuntu-2204-image, ensure-ubuntu-2404-image, ensure-ubuntu-2404-arm-image, ensure-fedora-39-image]
     strategy:
       fail-fast: false
       matrix:
@@ -81,6 +90,8 @@ jobs:
           # Note: Clang-13 is obsolete on Ubuntu 24.04, we're intentionally skipping it.
           {distro: ubuntu-24.04, compiler-c: clang-20, compiler-cpp: clang++-20, package: deb},
           {distro: ubuntu-24.04, compiler-c: gcc-11, compiler-cpp: g++-11, package: deb},
+          # Arm64 build, built natively on an arm runner.
+          {distro: ubuntu-24.04-arm, compiler-c: clang-20, compiler-cpp: clang++-20, package: deb},
           # Note: Fedora 39 default is GCC 13, and 11 is obsolete.
           {distro: fedora-39, compiler-c: gcc-13, compiler-cpp: g++-13, package: rpm},
           # Note: Fedora 39 default is Clang 17, and it is not trivial to install clang-20.
@@ -96,7 +107,8 @@ jobs:
     name: >-
       Build device${{ matrix.image.use_release_flags && ' (release flags)' || '' }}
       on ${{ matrix.image.distro }} with ${{ matrix.image.compiler-c }}
-    runs-on: tt-ubuntu-2204-large-stable
+    # Arm variants must build natively on an arm runner; everything else uses the standard x86 runner.
+    runs-on: ${{ matrix.image.distro == 'ubuntu-24.04-arm' && 'ubuntu-24.04-arm' || 'tt-ubuntu-2204-large-stable' }}
     env:
       # CI runners may lack invariant TSC support (required by Tracy for high-res timestamps).
       # This skips Tracy's runtime TSC check to prevent initialization failures during build.
@@ -107,7 +119,9 @@ jobs:
         matrix.image.distro }}:${{
         matrix.image.distro == 'ubuntu-22.04' && needs.ensure-ubuntu-2204-image.outputs.image-tag ||
         matrix.image.distro == 'ubuntu-24.04' && needs.ensure-ubuntu-2404-image.outputs.image-tag ||
-        needs.ensure-fedora-39-image.outputs.image-tag }}
+        matrix.image.distro == 'ubuntu-24.04-arm' && needs.ensure-ubuntu-2404-arm-image.outputs.image-tag ||
+        matrix.image.distro == 'fedora-39' && needs.ensure-fedora-39-image.outputs.image-tag ||
+        'latest' }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -114,8 +114,15 @@ jobs:
       # This skips Tracy's runtime TSC check to prevent initialization failures during build.
       TRACY_NO_INVARIANT_CHECK: 1
     container:
+      # Arm jobs run on GitHub-hosted runners, which can't resolve the internal
+      # Harbor mirror, so they pull directly from ghcr.io (same as test-packages).
+      # x86 jobs run on self-hosted runners and use the Harbor pull-through cache.
       image: >-
-        harbor.ci.tenstorrent.net/ghcr.io/${{ github.repository }}/tt-umd-ci-${{
+        ${{
+        matrix.image.distro == 'ubuntu-24.04-arm'
+        && 'ghcr.io'
+        || 'harbor.ci.tenstorrent.net/ghcr.io'
+        }}/${{ github.repository }}/tt-umd-ci-${{
         matrix.image.distro }}:${{
         matrix.image.distro == 'ubuntu-22.04' && needs.ensure-ubuntu-2204-image.outputs.image-tag ||
         matrix.image.distro == 'ubuntu-24.04' && needs.ensure-ubuntu-2404-image.outputs.image-tag ||

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,7 +26,10 @@ on:
 jobs:
   ensure:
     name: Ensure image (${{ inputs.docker-version }})
-    runs-on: ubuntu-22.04
+    # Arm variants (-arm / -aarch64 suffix) must be built natively on an arm runner.
+    runs-on: >-
+      ${{ (endsWith(inputs.docker-version, '-arm') || endsWith(inputs.docker-version, '-aarch64'))
+      && 'ubuntu-24.04-arm' || 'ubuntu-22.04' }}
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
     permissions:
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,7 +239,8 @@ jobs:
 
   build-cpp-artifacts:
     name: Build C++ Artifacts on ${{ matrix.image.distro }} with ${{ matrix.image.compiler-c }}
-    runs-on: tt-ubuntu-2204-large-stable
+    # Arm variants build natively on an arm runner; everything else uses the standard x86 runner.
+    runs-on: ${{ matrix.image.distro == 'ubuntu-24.04-arm' && 'ubuntu-24.04-arm' || 'tt-ubuntu-2204-large-stable' }}
     needs: prepare-release
     timeout-minutes: 30
     strategy:
@@ -248,6 +249,8 @@ jobs:
         image: [
           {distro: ubuntu-22.04, compiler-c: clang-20, compiler-cpp: clang++-20, package: DEB, package_ext: deb},
           {distro: ubuntu-24.04, compiler-c: clang-20, compiler-cpp: clang++-20, package: DEB, package_ext: deb},
+          # Arm64 build, built natively on an arm runner.
+          {distro: ubuntu-24.04-arm, compiler-c: clang-20, compiler-cpp: clang++-20, package: DEB, package_ext: deb},
           {distro: fedora-39, compiler-c: clang-17, compiler-cpp: clang++-17, package: RPM, package_ext: rpm},
         ]
     container:
@@ -431,6 +434,7 @@ jobs:
             ### System Packages (.deb / .rpm)
             - **Ubuntu 22.04**: DEB packages are attached under Assets
             - **Ubuntu 24.04**: DEB packages are attached under Assets
+            - **Ubuntu 24.04 (arm64)**: DEB packages are attached under Assets
             - **Fedora 39**: RPM packages are attached under Assets
             - Includes: `umd-runtime`, `umd-dev` and `umd-python` packages
 


### PR DESCRIPTION
### Issue
#2450 

### Description
Adds arm support using default github ARM ubuntu images.
Doesn't run any test on ARM.

### List of the changes
- Add ARM dockerfile variant.
- In case of using this new dockerfile, use github default runner instead of TT runner
- Wire up this new dockerfile as another variant for build-device
- Also during release, build .deb packages for ARM

### Testing
This PR changes workflows, so if they work on this PR, it means the change is working.
Haven't tested the release process though.

### API Changes
This PR has no API changes.
