### PR TITLE
Manylinux ARM build

### DIFF
--- a/.github/manylinux-aarch64.Dockerfile
+++ b/.github/manylinux-aarch64.Dockerfile
@@ -1,0 +1,23 @@
+FROM quay.io/pypa/manylinux_2_28_aarch64
+# (AlmaLinux 8 based)
+# Built wheels are also expected to be compatible with other distros using glibc 2.28 or later, including:
+#     Debian 10+
+#     Ubuntu 18.10+ (includes 20.04 LTS)
+#     Fedora 29+
+#     CentOS/RHEL 8+
+
+# Hack for CIv2 - fix mirror URLs
+RUN FILES=(/etc/yum.repos.d/*.repo) && \
+  sed --in-place -e 's/^mirrorlist=/# mirrorlist=/g' -e 's/^# baseurl=/baseurl=/' "${FILES[@]}" || true
+
+# Install system dependencies matching docker_install_common.sh but using DNF
+# This includes all the dependencies needed for building tt-umd
+RUN dnf install -y \
+    ninja-build \
+    hwloc-devel \
+    vim-common \
+    && dnf clean all
+
+# Set up environment variables for building
+ENV CC=/opt/rh/gcc-toolset-14/root/bin/gcc
+ENV CXX=/opt/rh/gcc-toolset-14/root/bin/g++

--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -75,6 +75,15 @@ jobs:
     with:
       docker-version: manylinux
 
+  ensure-manylinux-aarch64-image:
+    name: Ensure manylinux-aarch64 Docker image
+    permissions:
+      packages: write
+    secrets: inherit
+    uses: ./.github/workflows/docker-image.yml
+    with:
+      docker-version: manylinux-aarch64
+
   build:
     # Due to parsing bug, fromJSON is used to convert string to number.
     # In pull_request or push events, the input context is not available, stating the default again here.
@@ -307,10 +316,15 @@ jobs:
     # Due to parsing bug, fromJSON is used to convert string to number.
     # In pull_request or push events, the input context is not available, stating the default again here.
     timeout-minutes: ${{ fromJSON(inputs.timeout || '15') }}
-    needs: ensure-manylinux-image
+    needs: [ensure-manylinux-image, ensure-manylinux-aarch64-image]
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, aarch64]
 
-    name: Build umd manylinux wheel
-    runs-on: tt-ubuntu-2204-large-stable
+    name: Build umd manylinux wheel (${{ matrix.arch }})
+    # aarch64 wheels build natively on an arm runner (no QEMU emulation needed).
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'tt-ubuntu-2204-large-stable' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -328,10 +342,16 @@ jobs:
       - name: Build manylinux wheels
         shell: bash
         env:
-          # Use custom manylinux Docker image with all dependencies pre-installed
+          # Only build wheels for the runner's native architecture.
+          CIBW_ARCHS: ${{ matrix.arch }}
+          # Use custom manylinux Docker images with all dependencies pre-installed.
+          # cibuildwheel picks the image matching the architecture being built.
           CIBW_MANYLINUX_X86_64_IMAGE: >-
             ghcr.io/${{ github.repository }}/tt-umd-ci-manylinux:${{
             needs.ensure-manylinux-image.outputs.image-tag }}
+          CIBW_MANYLINUX_AARCH64_IMAGE: >-
+            ghcr.io/${{ github.repository }}/tt-umd-ci-manylinux-aarch64:${{
+            needs.ensure-manylinux-aarch64-image.outputs.image-tag }}
           # This command will be executed for each wheel build to verify that the wheel is functional.
           CIBW_TEST_COMMAND: 'python -c "import tt_umd"'
         run: |
@@ -345,7 +365,7 @@ jobs:
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: manylinux-wheel-artifact
+          name: manylinux-wheel-artifact-${{ matrix.arch }}
           path: |
             ${{ env.WHEEL_OUTPUT_DIR }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,10 +294,15 @@ jobs:
           if-no-files-found: error
 
   build-python-wheels:
-    name: Build Python Wheel (manylinux)
-    runs-on: tt-ubuntu-2204-large-stable
+    name: Build Python Wheel (manylinux ${{ matrix.arch }})
     needs: prepare-release
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, aarch64]
+    # aarch64 wheels build natively on an arm runner (no QEMU emulation needed).
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'tt-ubuntu-2204-large-stable' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -315,8 +320,12 @@ jobs:
       - name: Build manylinux wheels
         shell: bash
         env:
-          # Use custom manylinux Docker image with all dependencies pre-installed
+          # Only build wheels for the runner's native architecture.
+          CIBW_ARCHS: ${{ matrix.arch }}
+          # Use custom manylinux Docker images with all dependencies pre-installed.
+          # cibuildwheel picks the image matching the architecture being built.
           CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/tenstorrent/tt-umd/tt-umd-ci-manylinux:latest
+          CIBW_MANYLINUX_AARCH64_IMAGE: ghcr.io/tenstorrent/tt-umd/tt-umd-ci-manylinux-aarch64:latest
           # This command will be executed for each wheel build to verify that the wheel is functional.
           CIBW_TEST_COMMAND: 'python -c "import tt_umd"'
         run: |
@@ -330,7 +339,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
-          name: tt-umd-v${{ needs.prepare-release.outputs.version }}-manylinux-wheels
+          name: tt-umd-v${{ needs.prepare-release.outputs.version }}-manylinux-wheels-${{ matrix.arch }}
           path: ${{ env.WHEEL_OUTPUT_DIR }}
 
   publish-to-testpypi:
@@ -349,7 +358,8 @@ jobs:
       - name: Download all the wheels
         uses: actions/download-artifact@v8
         with:
-          name: tt-umd-v${{ needs.prepare-release.outputs.version }}-manylinux-wheels
+          pattern: tt-umd-v${{ needs.prepare-release.outputs.version }}-manylinux-wheels-*
+          merge-multiple: true
           path: dist/
 
       - name: Publish distribution 📦 to TestPyPI
@@ -374,7 +384,8 @@ jobs:
       - name: Download all the wheels
         uses: actions/download-artifact@v8
         with:
-          name: tt-umd-v${{ needs.prepare-release.outputs.version }}-manylinux-wheels
+          pattern: tt-umd-v${{ needs.prepare-release.outputs.version }}-manylinux-wheels-*
+          merge-multiple: true
           path: dist/
 
       - name: Publish distribution 📦 to PyPI
@@ -439,7 +450,7 @@ jobs:
             - Includes: `umd-runtime`, `umd-dev` and `umd-python` packages
 
             ### Python Wheels
-            - **manylinux_2_28 wheels** for Python 3.9-3.13 (x86_64)
+            - **manylinux_2_28 wheels** for Python 3.9-3.13 (x86_64 and aarch64)
             - Compatible with Ubuntu 20.04+, RHEL 8+, and other modern Linux distributions
             - Includes Python bindings for tt-umd
             - PyPI: https://pypi.org/project/tt-umd/


### PR DESCRIPTION
### Issue
#2450 

### Description
Add python builds on ARM through manylinux ARM image

### List of the changes
- Add manylinux ARM image
- Adjust CIBW to build with both
- Also adjust release yaml

### Testing
The summary shows cibuildwheel built the aarch variants: https://github.com/tenstorrent/tt-umd/actions/runs/26781500514?pr=2764#summary-78946951924

### API Changes
This PR has no API changes.
