### PR TITLE
Retrain DRAM cores on BIST failure

### DIFF
--- a/device/firmware/firmware_info_provider.cpp
+++ b/device/firmware/firmware_info_provider.cpp
@@ -523,10 +523,10 @@ std::vector<DramTrainingStatus> FirmwareInfoProvider::get_dram_training_status(u
     bool is_legacy_wormhole =
         tt_device->get_arch() == ARCH::WORMHOLE_B0 && firmware_version <= FirmwareBundleVersion(18, 3, 0);
 
-    // BIST status is reported in the upper 16 bits of GDDR_STATUS starting with FW 19.7.0. Older
-    // firmware leaves those bits zero, so only inspect them when the firmware is new enough; this also
-    // excludes all Wormhole firmware, which never reaches the 19.x line.
-    bool check_bist = firmware_version >= FirmwareBundleVersion(19, 7, 0);
+    // BIST status is reported in the upper 16 bits of GDDR_STATUS starting with FW 19.7.0. Only
+    // Blackhole has GDDR and reports BIST status here, so gate on the architecture as well as the
+    // firmware version. Older firmware leaves those bits zero.
+    bool check_bist = tt_device->get_arch() == ARCH::BLACKHOLE && firmware_version >= FirmwareBundleVersion(19, 7, 0);
 
     return is_legacy_wormhole ? get_legacy_wormhole_dram_statuses(telemetry_data.value(), num_dram_channels)
                               : get_modern_dram_statuses(telemetry_data.value(), num_dram_channels, check_bist);

--- a/device/firmware/firmware_info_provider.cpp
+++ b/device/firmware/firmware_info_provider.cpp
@@ -461,27 +461,52 @@ static std::vector<DramTrainingStatus> get_legacy_wormhole_dram_statuses(
     return statuses;
 }
 
-// Modern format: Each channel gets two bits in the 32-bit value (16 bits used).
+// Decode a single channel's 2-bit field. The lower bit reports completion and the higher bit reports
+// the error. This layout is shared by the training half ([15:0]) and the BIST half ([31:16]) of the
+// GDDR_STATUS telemetry tag.
+static DramTrainingStatus decode_dram_status_bits(uint8_t two_bits) {
+    switch (two_bits & 0x3) {
+        case 0b01:
+            return DramTrainingStatus::SUCCESS;
+        case 0b10:
+        case 0b11:
+            return DramTrainingStatus::FAIL;
+        default:  // 0b00
+            return DramTrainingStatus::IN_PROGRESS;
+    }
+}
+
+// Modern format: Each channel gets two bits in the 32-bit value.
 // The lower bits are for lower channels.
 // Lower of the two bits reports the training status and higher of the two bits reports the training error.
 // Example: 0b 00 00 00 00 00 00 01 10
 // would mean that only channel 0 is trained, channel 1 has the error and other channels are not trained
 // and don't have errors. If some channel is harvested the bits are always going to be zero.
-static std::vector<DramTrainingStatus> get_modern_dram_statuses(uint32_t telemetry_data, uint32_t num_channels) {
+//
+// As of FW 19.7.0 the GDDR BIST status is reported in the upper 16 bits using the same per-channel
+// layout, shifted by 16 (bit [16 + 2*channel] = BIST complete, bit [17 + 2*channel] = BIST failed).
+// When check_bist is set, a channel is SUCCESS only if both training and BIST passed, and FAIL if
+// either failed, so that a BIST failure also triggers a directed retrain.
+static std::vector<DramTrainingStatus> get_modern_dram_statuses(
+    uint32_t telemetry_data, uint32_t num_channels, bool check_bist) {
     std::vector<DramTrainingStatus> statuses;
     for (uint32_t channel = 0; channel < num_channels; ++channel) {
-        uint8_t status = (telemetry_data >> (channel * 2)) & 0x3;
-        switch (status) {
-            case 0b01:
-                statuses.push_back(DramTrainingStatus::SUCCESS);
-                break;
-            case 0b10:
-            case 0b11:
-                statuses.push_back(DramTrainingStatus::FAIL);
-                break;
-            default:  // 0b00
-                statuses.push_back(DramTrainingStatus::IN_PROGRESS);
-                break;
+        DramTrainingStatus training = decode_dram_status_bits((telemetry_data >> (channel * 2)) & 0x3);
+
+        if (!check_bist) {
+            statuses.push_back(training);
+            continue;
+        }
+
+        DramTrainingStatus bist = decode_dram_status_bits((telemetry_data >> (16 + channel * 2)) & 0x3);
+
+        // Require both training and BIST to pass for SUCCESS; fail (and retrain) if either failed.
+        if (training == DramTrainingStatus::FAIL || bist == DramTrainingStatus::FAIL) {
+            statuses.push_back(DramTrainingStatus::FAIL);
+        } else if (training == DramTrainingStatus::SUCCESS && bist == DramTrainingStatus::SUCCESS) {
+            statuses.push_back(DramTrainingStatus::SUCCESS);
+        } else {
+            statuses.push_back(DramTrainingStatus::IN_PROGRESS);
         }
     }
     return statuses;
@@ -498,8 +523,13 @@ std::vector<DramTrainingStatus> FirmwareInfoProvider::get_dram_training_status(u
     bool is_legacy_wormhole =
         tt_device->get_arch() == ARCH::WORMHOLE_B0 && firmware_version <= FirmwareBundleVersion(18, 3, 0);
 
+    // BIST status is reported in the upper 16 bits of GDDR_STATUS starting with FW 19.7.0. Older
+    // firmware leaves those bits zero, so only inspect them when the firmware is new enough; this also
+    // excludes all Wormhole firmware, which never reaches the 19.x line.
+    bool check_bist = firmware_version >= FirmwareBundleVersion(19, 7, 0);
+
     return is_legacy_wormhole ? get_legacy_wormhole_dram_statuses(telemetry_data.value(), num_dram_channels)
-                              : get_modern_dram_statuses(telemetry_data.value(), num_dram_channels);
+                              : get_modern_dram_statuses(telemetry_data.value(), num_dram_channels, check_bist);
 }
 
 static bool gddr_telemetry_tags_available(TTDevice* tt_device) {


### PR DESCRIPTION
### Issue

#2199

### Description

As of FW 19.7.0 the GDDR `BIST` status is reported in the upper 16 bits of the `GDDR_STATUS` telemetry tag (`[31:16]`), while the GDDR training status stays in the lower 16 bits (`[15:0]`). A channel can train successfully yet fail `BIST`, in which case it should be retrained rather than reported as healthy. This change folds a `BIST` failure into the per-channel `DramTrainingStatus`, so the existing `TTDevice::wait_dram_channel_training` retrain loop issues a directed retrain on `BIST` failure as well, not just on a training failure.

### List of the changes

- Decode the `BIST` half (`[31:16]`) of `GDDR_STATUS` alongside the training half (`[15:0]`), which share the same per-channel 2-bit layout.
- Report a channel as `SUCCESS` only when both training and `BIST` pass, and as `FAIL` if either fails (which triggers the existing directed retrain).
- Gate `BIST` inspection on Blackhole (the only architecture with GDDR `BIST` status) and FW `>= 19.7.0`, so other architectures and older firmware (which leaves `[31:16]` zero) keep the current training-only behavior.

### Testing

CI

### API Changes

None