### PR TITLE
Clarify sysmem NOC address mismatch errors (likely stale process)

### DIFF
--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -303,8 +303,10 @@ bool SiliconSysmemManager::pin_or_map_hugepages() {
             if (noc_address != expected_noc_address) {
                 log_warning(
                     LogUMD,
-                    "NOC address of a hugepage does not match the expected address. Proceeding could lead to undefined "
-                    "behavior");
+                    "NOC address of a hugepage does not match the expected address. This usually means another "
+                    "process is already holding the sysmem NOC address space UMD requires (often a stale or crashed "
+                    "process from a previous run). To fix this, find and kill the other processes using the "
+                    "Tenstorrent device(s), then retry. Proceeding could lead to undefined behavior.");
             }
         } else {
             physical_address = pci_device_->map_for_hugepage(mapping, actual_size);
@@ -407,8 +409,23 @@ bool SiliconSysmemManager::pin_or_map_iommu() {
         // If this happens, it means that something else is using the address
         // space that UMD typically uses.  Historically, this would have crashed
         // or done something inscrutable.  Now it is just an error.
-        log_error(LogUMD, "Expected NOC address: {:#x}, but got {:#x}", pcie_base_, *noc_address);
-        UMD_THROW(error::RuntimeError, "Proceeding could lead to undefined behavior");
+        //
+        // The usual cause is a stale process (a leftover/crashed run) that still
+        // holds a sysmem mapping at the NOC base address, so this process gets
+        // bumped to a different address. The fix is to find and kill those
+        // processes, then retry.
+        log_error(
+            LogUMD,
+            "Expected sysmem to be mapped at NOC address {:#x}, but it was mapped at {:#x}. This usually means "
+            "another process is already holding the sysmem NOC address space UMD requires (often a stale or "
+            "crashed process from a previous run). To fix this, find and kill the other processes using the "
+            "Tenstorrent device(s), then retry.",
+            pcie_base_,
+            *noc_address);
+        UMD_THROW(
+            error::RuntimeError,
+            "Sysmem mapped at unexpected NOC address (likely a stale process holding sysmem); proceeding could "
+            "lead to undefined behavior");
     }
 
     if (map_buffer_to_noc) {


### PR DESCRIPTION
### Issue

N/A

### Description

When sysmem is mapped at an unexpected NOC address, the cause is almost always another process on the machine — often a stale or crashed run from a previous job — still holding the sysmem NOC address space UMD requires, so the current process gets bumped to a different address. The previous log messages just said `Proceeding could lead to undefined behavior` without naming the likely cause or the remedy (kill the offending processes), which made these failures hard to diagnose in the field.

This PR rewords both the hard error in `pin_or_map_iommu()` and the warning in `pin_or_map_hugepages()` to explain the likely cause and tell the user to find and kill the other processes using the Tenstorrent device(s), then retry. No behavior change beyond the log/exception text (and the extra context now included in the hugepage warning).

### List of the changes

- `pin_or_map_iommu()`: the `log_error` and the `UMD_THROW` message now explain that an unexpected NOC address usually means another (often stale/crashed) process holds the sysmem NOC address space, and instruct the user to kill those processes and retry.
- `pin_or_map_hugepages()`: the mismatch `log_warning` now reports the channel and the actual vs. expected NOC addresses (previously it printed neither) and carries the same stale-process explanation and remedy.

### Testing

CI

### API Changes

None.