### PR TITLE
Guard methods that will segfault on uninitialized TTDevice

### DIFF
--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -94,7 +94,7 @@ public:
      * @brief Controls what happens when a hang is confirmed.
      */
     enum class HangAction {
-        THROW,   ///< Throw std::runtime_error (default).
+        THROW,   ///< Throw an exception (depending on type of hang) (default).
         RETURN,  ///< Return instead of throwing.
     };
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -463,10 +463,7 @@ protected:
     int communication_device_id_ = -1;
     std::unique_ptr<architecture_implementation> architecture_impl_;
     tt::ARCH arch = tt::ARCH::Invalid;
-    std::unique_ptr<ArcMessenger> arc_messenger_ = nullptr;
     LockManager lock_manager;
-    std::unique_ptr<ArcTelemetryReader> telemetry = nullptr;
-    std::unique_ptr<FirmwareInfoProvider> firmware_info_provider = nullptr;
 
     TTDevice() = default;
     TTDevice(
@@ -498,6 +495,9 @@ private:
     void probe_arc();
 
     std::optional<SocDescriptor> soc_descriptor_ = std::nullopt;
+    std::unique_ptr<ArcMessenger> arc_messenger_ = nullptr;
+    std::unique_ptr<ArcTelemetryReader> telemetry = nullptr;
+    std::unique_ptr<FirmwareInfoProvider> firmware_info_provider = nullptr;
     std::unique_ptr<DeviceProtocol> device_protocol_;
     std::unique_ptr<HangDetector> hang_detector_;
     PcieInterface *pcie_capabilities_ = nullptr;

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -141,20 +141,22 @@ ChipInfo BlackholeTTDevice::get_chip_info() {
     ChipInfo chip_info = TTDevice::get_chip_info();
     chip_info.harvesting_masks.tensix_harvesting_mask = CoordinateManager::shuffle_tensix_harvesting_mask(
         tt::ARCH::BLACKHOLE,
-        telemetry->is_entry_available(TelemetryTag::ENABLED_TENSIX_COL)
-            ? (~telemetry->read_entry(TelemetryTag::ENABLED_TENSIX_COL) & 0x3FFF)
+        get_arc_telemetry_reader()->is_entry_available(TelemetryTag::ENABLED_TENSIX_COL)
+            ? (~get_arc_telemetry_reader()->read_entry(TelemetryTag::ENABLED_TENSIX_COL) & 0x3FFF)
             : 0);
-    chip_info.harvesting_masks.dram_harvesting_mask = telemetry->is_entry_available(TelemetryTag::ENABLED_GDDR)
-                                                          ? (~telemetry->read_entry(TelemetryTag::ENABLED_GDDR) & 0xFF)
-                                                          : 0;
+    chip_info.harvesting_masks.dram_harvesting_mask =
+        get_arc_telemetry_reader()->is_entry_available(TelemetryTag::ENABLED_GDDR)
+            ? (~get_arc_telemetry_reader()->read_entry(TelemetryTag::ENABLED_GDDR) & 0xFF)
+            : 0;
 
-    chip_info.harvesting_masks.eth_harvesting_mask = telemetry->is_entry_available(TelemetryTag::ENABLED_ETH)
-                                                         ? (~telemetry->read_entry(TelemetryTag::ENABLED_ETH) & 0x3FFF)
-                                                         : 0;
+    chip_info.harvesting_masks.eth_harvesting_mask =
+        get_arc_telemetry_reader()->is_entry_available(TelemetryTag::ENABLED_ETH)
+            ? (~get_arc_telemetry_reader()->read_entry(TelemetryTag::ENABLED_ETH) & 0x3FFF)
+            : 0;
 
     chip_info.harvesting_masks.pcie_harvesting_mask = 0;
-    if (telemetry->is_entry_available(TelemetryTag::PCIE_USAGE)) {
-        uint32_t pcie_usage = telemetry->read_entry(TelemetryTag::PCIE_USAGE);
+    if (get_arc_telemetry_reader()->is_entry_available(TelemetryTag::PCIE_USAGE)) {
+        uint32_t pcie_usage = get_arc_telemetry_reader()->read_entry(TelemetryTag::PCIE_USAGE);
 
         uint32_t pcie0_usage = pcie_usage & 0x3;
         uint32_t pcie1_usage = (pcie_usage >> 2) & 0x3;
@@ -171,9 +173,9 @@ ChipInfo BlackholeTTDevice::get_chip_info() {
     }
 
     chip_info.harvesting_masks.l2cpu_harvesting_mask = 0;
-    if (telemetry->is_entry_available(TelemetryTag::ENABLED_L2CPU)) {
+    if (get_arc_telemetry_reader()->is_entry_available(TelemetryTag::ENABLED_L2CPU)) {
         chip_info.harvesting_masks.l2cpu_harvesting_mask = CoordinateManager::shuffle_l2cpu_harvesting_mask(
-            tt::ARCH::BLACKHOLE, telemetry->read_entry(TelemetryTag::ENABLED_L2CPU));
+            tt::ARCH::BLACKHOLE, get_arc_telemetry_reader()->read_entry(TelemetryTag::ENABLED_L2CPU));
     }
 
     return chip_info;
@@ -203,8 +205,8 @@ void BlackholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds time
 }
 
 uint32_t BlackholeTTDevice::get_clock() {
-    if (telemetry->is_entry_available(TelemetryTag::AICLK)) {
-        return telemetry->read_entry(TelemetryTag::AICLK);
+    if (get_arc_telemetry_reader()->is_entry_available(TelemetryTag::AICLK)) {
+        return get_arc_telemetry_reader()->read_entry(TelemetryTag::AICLK);
     }
 
     UMD_THROW(error::RuntimeError, "AICLK telemetry not available for Blackhole device.");

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -380,11 +380,26 @@ void TTDevice::bar_write32(uint32_t addr, uint32_t data) { return get_pcie_inter
 
 uint32_t TTDevice::bar_read32(uint32_t addr) { return get_pcie_interface()->bar_read32(addr); }
 
-ArcMessenger *TTDevice::get_arc_messenger() const { return arc_messenger_.get(); }
+ArcMessenger *TTDevice::get_arc_messenger() const {
+    if (arc_messenger_ == nullptr) {
+        UMD_THROW(error::UninitializedDeviceError, *this);
+    }
+    return arc_messenger_.get();
+}
 
-ArcTelemetryReader *TTDevice::get_arc_telemetry_reader() const { return telemetry.get(); }
+ArcTelemetryReader *TTDevice::get_arc_telemetry_reader() const {
+    if (telemetry == nullptr) {
+        UMD_THROW(error::UninitializedDeviceError, *this);
+    }
+    return telemetry.get();
+}
 
-FirmwareInfoProvider *TTDevice::get_firmware_info_provider() const { return firmware_info_provider.get(); }
+FirmwareInfoProvider *TTDevice::get_firmware_info_provider() const {
+    if (firmware_info_provider == nullptr) {
+        UMD_THROW(error::UninitializedDeviceError, *this);
+    }
+    return firmware_info_provider.get();
+}
 
 FirmwareBundleVersion TTDevice::get_firmware_version() { return get_firmware_info_provider()->get_firmware_version(); }
 

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -131,7 +131,7 @@ void WormholeTTDevice::configure_iatu_region(size_t region, uint64_t target, siz
     bar_write32(architecture_impl_->get_arc_csm_bar0_mailbox_offset() + 1 * 4, dest_bar_lo);
     bar_write32(architecture_impl_->get_arc_csm_bar0_mailbox_offset() + 2 * 4, dest_bar_hi);
     bar_write32(architecture_impl_->get_arc_csm_bar0_mailbox_offset() + 3 * 4, region_size);
-    arc_messenger_->send_message(
+    get_arc_messenger()->send_message(
         wormhole::ARC_MSG_COMMON_PREFIX | architecture_impl_->get_arc_message_setup_iatu_for_peer_to_peer(), {0, 0});
 
     // Print what just happened.

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -310,11 +310,46 @@ TEST(ApiTTDeviceTest, UninitializedError) {
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
         tt_device->set_power_state(true);
-        EXPECT_THROW(tt_device->get_chip_info(), error::UmdException<error::UninitializedDeviceError>);
-        EXPECT_THROW(tt_device->get_soc_descriptor(), error::UmdException<error::UninitializedDeviceError>);
+
+        // These methods should work without initialization.
+        EXPECT_NO_THROW(tt_device->get_arc_core());
+        EXPECT_NO_THROW(tt_device->get_arch());
+        EXPECT_NO_THROW(tt_device->get_architecture_implementation());
+        EXPECT_NO_THROW(tt_device->get_min_clock_freq());
+        EXPECT_NO_THROW(tt_device->is_remote());
+        EXPECT_NO_THROW(tt_device->get_refclk_counter());
+        EXPECT_NO_THROW(tt_device->get_communication_device_id());
+        EXPECT_NO_THROW(tt_device->get_communication_device_type());
+
+        using err = error::UmdException<error::UninitializedDeviceError>;
+        EXPECT_THROW(tt_device->get_chip_info(), err);
+        EXPECT_THROW(tt_device->get_soc_descriptor(), err);
+        EXPECT_THROW(tt_device->get_arc_messenger(), err);
+        EXPECT_THROW(tt_device->get_arc_telemetry_reader(), err);
+        EXPECT_THROW(tt_device->get_firmware_info_provider(), err);
+        EXPECT_THROW(tt_device->get_board_id(), err);
+        EXPECT_THROW(tt_device->get_board_type(), err);
+        EXPECT_THROW(tt_device->get_asic_location(), err);
+        EXPECT_THROW(tt_device->get_asic_temperature(), err);
+        EXPECT_THROW(tt_device->get_clock(), err);
+        EXPECT_THROW(tt_device->get_max_clock_freq(), err);
+        EXPECT_THROW(tt_device->get_firmware_version(), err);
+
         // Initialize device.
         ASSERT_NO_THROW(tt_device->init_tt_device());
+
+        // These methods should work only after successful initialization.
         EXPECT_NO_THROW(tt_device->get_chip_info());
         EXPECT_NO_THROW(tt_device->get_soc_descriptor());
+        EXPECT_NO_THROW(tt_device->get_arc_messenger());
+        EXPECT_NO_THROW(tt_device->get_arc_telemetry_reader());
+        EXPECT_NO_THROW(tt_device->get_firmware_info_provider());
+        EXPECT_NO_THROW(tt_device->get_board_id());
+        EXPECT_NO_THROW(tt_device->get_board_type());
+        EXPECT_NO_THROW(tt_device->get_asic_location());
+        EXPECT_NO_THROW(tt_device->get_asic_temperature());
+        EXPECT_NO_THROW(tt_device->get_clock());
+        EXPECT_NO_THROW(tt_device->get_max_clock_freq());
+        EXPECT_NO_THROW(tt_device->get_firmware_version());
     }
 }


### PR DESCRIPTION
### Issue
/

### Description
Guard methods that will segfault on uninitialized TTDevice

### List of the changes
- Added guards for getters of ArcMessenger, ArcTelemetryReader and FirmwareInfoProvider.
- Changed all direct accesses to these objects to getters in TTDevices.
- Moved these objects from protected to private.
- Added test `ApiTTDeviceTest.UninitializedError` to enforce policy.

### Testing
CI, new test `ApiTTDeviceTest.UninitializedError`

### API Changes
This PR has no API changes.
