### PR TITLE
Expose ETH hearbeat and link status

### DIFF
--- a/device/api/umd/device/firmware/firmware_info_provider.hpp
+++ b/device/api/umd/device/firmware/firmware_info_provider.hpp
@@ -153,7 +153,7 @@ public:
 
     /*
      * Get per-link ethernet heartbeat status.
-     * Only available on Wormhole for now; returns std::nullopt on Blackhole.
+     * Available on Wormhole (all versions) and Blackhole (firmware 19.9+); returns std::nullopt otherwise.
      * Vector indices align with ETH channels (i.e. logical coordinates, up to 16).
      * @returns Vector of bools (true = heartbeat active), or std::nullopt if unavailable.
      */
@@ -161,7 +161,7 @@ public:
 
     /*
      * Get per-link ethernet retrain status.
-     * Only available on Wormhole for now; returns std::nullopt on Blackhole.
+     * Only available on Wormhole with firmware prior to 19.9; returns std::nullopt otherwise.
      * Vector indices align with ETH channels (i.e. logical coordinates, up to 16).
      * @returns Vector of bools (true = link has been retrained), or std::nullopt if unavailable.
      */

--- a/device/api/umd/device/firmware/firmware_info_provider.hpp
+++ b/device/api/umd/device/firmware/firmware_info_provider.hpp
@@ -167,6 +167,14 @@ public:
      */
     std::optional<std::vector<bool>> get_eth_retrain_status() const;
 
+    /*
+     * Get per-link ethernet link status.
+     * Available on firmware 19.9+ for both Wormhole and Blackhole; returns std::nullopt otherwise.
+     * Vector indices align with ETH channels (i.e. logical coordinates, up to 16).
+     * @returns Vector of bools (true = link is up), or std::nullopt if unavailable.
+     */
+    std::optional<std::vector<bool>> get_eth_link_status() const;
+
     std::vector<DramTrainingStatus> get_dram_training_status(uint32_t num_dram_channels) const;
 
     uint32_t get_max_clock_freq() const;

--- a/device/api/umd/device/firmware/firmware_info_provider.hpp
+++ b/device/api/umd/device/firmware/firmware_info_provider.hpp
@@ -219,6 +219,7 @@ private:
     static FirmwareFeatures create_blackhole_18_5_base();
     static FirmwareFeatures create_wormhole_18_8_base();
     static FirmwareFeatures create_blackhole_18_8_base();
+    static FirmwareFeatures create_blackhole_19_9_base();
 
     // Engine methods for reading and transforming telemetry data.
     uint32_t read_raw_telemetry(const FeatureKey& key) const;

--- a/device/api/umd/device/firmware/firmware_info_provider.hpp
+++ b/device/api/umd/device/firmware/firmware_info_provider.hpp
@@ -218,6 +218,7 @@ private:
     static FirmwareFeatures create_wormhole_18_4_base();
     static FirmwareFeatures create_blackhole_18_5_base();
     static FirmwareFeatures create_wormhole_18_8_base();
+    static FirmwareFeatures create_wormhole_19_9_base();
     static FirmwareFeatures create_blackhole_18_8_base();
     static FirmwareFeatures create_blackhole_19_9_base();
 

--- a/device/api/umd/device/firmware/firmware_telemetry_mapping.hpp
+++ b/device/api/umd/device/firmware/firmware_telemetry_mapping.hpp
@@ -122,8 +122,12 @@ enum class FirmwareFeature {
     DDR_STATUS,
     HEARTBEAT,
 
+    // Ethernet status (all read from the ETH_LIVE_STATUS telemetry tag).
+    ETH_HEARTBEAT_STATUS,
+    ETH_RETRAIN_STATUS,
+    ETH_LINK_STATUS,
+
     // RAS (Reliability) & error counters.
-    ETH_LIVE_STATUS,
     THERM_TRIP_COUNT,
     GDDR_UNCORR_ERRS,
     GDDR_0_1_CORR_ERRS,

--- a/device/firmware/firmware_info_provider.cpp
+++ b/device/firmware/firmware_info_provider.cpp
@@ -131,7 +131,7 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
         {FirmwareFeature::BOARD_ID_HIGH, {WormholeTag::BOARD_ID_HIGH, LinearTransform{}}},
         {FirmwareFeature::BOARD_ID_LOW, {WormholeTag::BOARD_ID_LOW, LinearTransform{}}},
         {FirmwareFeature::ASIC_LOCATION, {FixedValue{0}, LinearTransform{}}},
-        {FirmwareFeature::ASIC_TEMPERATURE,  {WormholeTag::ASIC_TEMPERATURE,  LinearTransform{0, 0xFFFF,     1.0 / 16.0,    0.0}}},
+        {FirmwareFeature::ASIC_TEMPERATURE,  {WormholeTag::ASIC_TEMPERATURE,  LinearTransform{0, 0xFFFF, 1.0 / 16.0, 0.0}}},
         {FirmwareFeature::BOARD_TEMPERATURE, {WormholeTag::BOARD_TEMPERATURE, LinearTransform{0, 0xFFFFFFFF, 1.0 / 65536.0, 0.0}}},
         {FirmwareFeature::GDDR_0_1_TEMP, {FixedValue{0}, NotAvailable{}}},
         {FirmwareFeature::GDDR_2_3_TEMP, {FixedValue{0}, NotAvailable{}}},
@@ -630,6 +630,14 @@ std::optional<std::vector<bool>> FirmwareInfoProvider::get_eth_heartbeat_status(
     }
     uint32_t data = read_raw_telemetry(firmware_feature_map.at(FirmwareFeature::ETH_LIVE_STATUS).key);
     return parse_eth_status_bitmask(static_cast<uint16_t>(data & 0xFFFF));
+}
+
+std::optional<std::vector<bool>> FirmwareInfoProvider::get_eth_link_status() const {
+    if (!is_feature_available(FirmwareFeature::ETH_LIVE_STATUS)) {
+        return std::nullopt;
+    }
+    uint32_t data = read_raw_telemetry(firmware_feature_map.at(FirmwareFeature::ETH_LIVE_STATUS).key);
+    return parse_eth_status_bitmask(static_cast<uint16_t>((data >> 16) & 0xFFFF));
 }
 
 std::optional<std::vector<bool>> FirmwareInfoProvider::get_eth_retrain_status() const {

--- a/device/firmware/firmware_info_provider.cpp
+++ b/device/firmware/firmware_info_provider.cpp
@@ -63,8 +63,10 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
         case ARCH::BLACKHOLE:
             if (fw_version <= FirmwareBundleVersion(18, 7, 0)) {
                 return create_blackhole_18_5_base();
+            } else if (fw_version <= FirmwareBundleVersion(19, 8, 0)) {
+                return create_blackhole_18_8_base();
             }
-            return create_blackhole_18_8_base();
+            return create_blackhole_19_9_base();
         default:
             UMD_THROW(error::RuntimeError, "Unsupported architecture for telemetry feature map.");
     }
@@ -106,7 +108,9 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
         {FirmwareFeature::THM_LIMIT_SHUTDOWN,{TelemetryTag::THM_LIMIT_SHUTDOWN, LinearTransform{}}},
         {FirmwareFeature::DDR_STATUS,        {TelemetryTag::GDDR_STATUS, LinearTransform{}}},
         {FirmwareFeature::HEARTBEAT,         {TelemetryTag::TIMER_HEARTBEAT, LinearTransform{}}},
-        {FirmwareFeature::ETH_LIVE_STATUS,   {TelemetryTag::ETH_LIVE_STATUS, LinearTransform{}}},
+        {FirmwareFeature::ETH_HEARTBEAT_STATUS, {TelemetryTag::ETH_LIVE_STATUS, LinearTransform{}}},
+        {FirmwareFeature::ETH_RETRAIN_STATUS,   {TelemetryTag::ETH_LIVE_STATUS, LinearTransform{}}},
+        {FirmwareFeature::ETH_LINK_STATUS,      {FixedValue{0}, NotAvailable{}}},
         {FirmwareFeature::THERM_TRIP_COUNT,  {TelemetryTag::THERM_TRIP_COUNT, LinearTransform{}}},
         {FirmwareFeature::GDDR_UNCORR_ERRS,   {TelemetryTag::GDDR_UNCORR_ERRS, LinearTransform{}}},
         {FirmwareFeature::GDDR_0_1_CORR_ERRS, {TelemetryTag::GDDR_0_1_CORR_ERRS, LinearTransform{}}},
@@ -154,7 +158,9 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
         {FirmwareFeature::THM_LIMIT_SHUTDOWN, {FixedValue{0}, NotAvailable{}}},
         {FirmwareFeature::DDR_STATUS, {WormholeTag::DDR_STATUS, LinearTransform{}}},
         {FirmwareFeature::HEARTBEAT, {WormholeTag::ARC0_HEALTH, LinearTransform{}}},
-        {FirmwareFeature::ETH_LIVE_STATUS,    {WormholeTag::ETH_LIVE_STATUS, LinearTransform{}}},
+        {FirmwareFeature::ETH_HEARTBEAT_STATUS, {WormholeTag::ETH_LIVE_STATUS, LinearTransform{}}},
+        {FirmwareFeature::ETH_RETRAIN_STATUS,   {WormholeTag::ETH_LIVE_STATUS, LinearTransform{}}},
+        {FirmwareFeature::ETH_LINK_STATUS,      {FixedValue{0}, NotAvailable{}}},
         {FirmwareFeature::THERM_TRIP_COUNT, {FixedValue{0}, NotAvailable{}}},
         {FirmwareFeature::GDDR_UNCORR_ERRS, {FixedValue{0}, NotAvailable{}}},
         {FirmwareFeature::GDDR_0_1_CORR_ERRS, {FixedValue{0}, NotAvailable{}}},
@@ -179,8 +185,9 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
     map[FirmwareFeature::MAX_CLOCK_FREQ] = {FixedValue{blackhole::AICLK_BUSY_VAL}, LinearTransform{}};
     // ETH_FW_VERSION telemetry tag exists but firmware doesn't implement it on Blackhole.
     map[FirmwareFeature::ETH_FW_VERSION] = {FixedValue{0}, NotAvailable{}};
-    // ETH_LIVE_STATUS tag exists but always returns zeros on Blackhole.
-    map[FirmwareFeature::ETH_LIVE_STATUS] = {FixedValue{0}, NotAvailable{}};
+    // ETH_LIVE_STATUS tag exists but always returns zeros on Blackhole prior to 19.9.
+    map[FirmwareFeature::ETH_HEARTBEAT_STATUS] = {FixedValue{0}, NotAvailable{}};
+    map[FirmwareFeature::ETH_RETRAIN_STATUS] = {FixedValue{0}, NotAvailable{}};
     return map;
 }
 
@@ -191,14 +198,24 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
     return map;
 }
 
-// Blackhole > 18.7: StandardTag base with StandardTag MAX_CLOCK_FREQ, no ETH support.
+// Blackhole 18.8-19.8: StandardTag base with StandardTag MAX_CLOCK_FREQ, no ETH support.
 /* static */ FirmwareFeatures FirmwareInfoProvider::create_blackhole_18_8_base() {
     FirmwareFeatures map = create_18_4_new_telemetry_base();
     map[FirmwareFeature::MAX_CLOCK_FREQ] = {TelemetryTag::AICLK_LIMIT_MAX, LinearTransform{}};
     // ETH_FW_VERSION telemetry tag exists but firmware doesn't implement it on Blackhole.
     map[FirmwareFeature::ETH_FW_VERSION] = {FixedValue{0}, NotAvailable{}};
-    // ETH_LIVE_STATUS tag exists but always returns zeros on Blackhole.
-    map[FirmwareFeature::ETH_LIVE_STATUS] = {FixedValue{0}, NotAvailable{}};
+    // ETH_LIVE_STATUS tag exists but always returns zeros on Blackhole prior to 19.9.
+    map[FirmwareFeature::ETH_HEARTBEAT_STATUS] = {FixedValue{0}, NotAvailable{}};
+    map[FirmwareFeature::ETH_RETRAIN_STATUS] = {FixedValue{0}, NotAvailable{}};
+    return map;
+}
+
+// Blackhole >= 19.9: ETH_LIVE_STATUS becomes available (upper 16 = link, lower 16 = heartbeat).
+/* static */ FirmwareFeatures FirmwareInfoProvider::create_blackhole_19_9_base() {
+    FirmwareFeatures map = create_18_4_new_telemetry_base();
+    map[FirmwareFeature::MAX_CLOCK_FREQ] = {TelemetryTag::AICLK_LIMIT_MAX, LinearTransform{}};
+    map[FirmwareFeature::ETH_FW_VERSION] = {FixedValue{0}, NotAvailable{}};
+    map[FirmwareFeature::ETH_RETRAIN_STATUS] = {FixedValue{0}, NotAvailable{}};
     return map;
 }
 
@@ -625,26 +642,26 @@ std::optional<uint32_t> FirmwareInfoProvider::get_therm_trip_count() const {
 }
 
 std::optional<std::vector<bool>> FirmwareInfoProvider::get_eth_heartbeat_status() const {
-    if (!is_feature_available(FirmwareFeature::ETH_LIVE_STATUS)) {
+    if (!is_feature_available(FirmwareFeature::ETH_HEARTBEAT_STATUS)) {
         return std::nullopt;
     }
-    uint32_t data = read_raw_telemetry(firmware_feature_map.at(FirmwareFeature::ETH_LIVE_STATUS).key);
+    uint32_t data = read_raw_telemetry(firmware_feature_map.at(FirmwareFeature::ETH_HEARTBEAT_STATUS).key);
     return parse_eth_status_bitmask(static_cast<uint16_t>(data & 0xFFFF));
 }
 
 std::optional<std::vector<bool>> FirmwareInfoProvider::get_eth_link_status() const {
-    if (!is_feature_available(FirmwareFeature::ETH_LIVE_STATUS)) {
+    if (!is_feature_available(FirmwareFeature::ETH_LINK_STATUS)) {
         return std::nullopt;
     }
-    uint32_t data = read_raw_telemetry(firmware_feature_map.at(FirmwareFeature::ETH_LIVE_STATUS).key);
+    uint32_t data = read_raw_telemetry(firmware_feature_map.at(FirmwareFeature::ETH_LINK_STATUS).key);
     return parse_eth_status_bitmask(static_cast<uint16_t>((data >> 16) & 0xFFFF));
 }
 
 std::optional<std::vector<bool>> FirmwareInfoProvider::get_eth_retrain_status() const {
-    if (!is_feature_available(FirmwareFeature::ETH_LIVE_STATUS)) {
+    if (!is_feature_available(FirmwareFeature::ETH_RETRAIN_STATUS)) {
         return std::nullopt;
     }
-    uint32_t data = read_raw_telemetry(firmware_feature_map.at(FirmwareFeature::ETH_LIVE_STATUS).key);
+    uint32_t data = read_raw_telemetry(firmware_feature_map.at(FirmwareFeature::ETH_RETRAIN_STATUS).key);
     return parse_eth_status_bitmask(static_cast<uint16_t>((data >> 16) & 0xFFFF));
 }
 

--- a/device/firmware/firmware_info_provider.cpp
+++ b/device/firmware/firmware_info_provider.cpp
@@ -58,14 +58,14 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
                 return create_wormhole_18_3_base();
             } else if (fw_version <= FirmwareBundleVersion(18, 7, 0)) {
                 return create_wormhole_18_4_base();
-            } else if (fw_version <= FirmwareBundleVersion(19, 8, 0)) {
+            } else if (fw_version < FirmwareBundleVersion(19, 9, 0)) {
                 return create_wormhole_18_8_base();
             }
             return create_wormhole_19_9_base();
         case ARCH::BLACKHOLE:
             if (fw_version <= FirmwareBundleVersion(18, 7, 0)) {
                 return create_blackhole_18_5_base();
-            } else if (fw_version <= FirmwareBundleVersion(19, 8, 0)) {
+            } else if (fw_version < FirmwareBundleVersion(19, 9, 0)) {
                 return create_blackhole_18_8_base();
             }
             return create_blackhole_19_9_base();

--- a/device/firmware/firmware_info_provider.cpp
+++ b/device/firmware/firmware_info_provider.cpp
@@ -110,8 +110,8 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
         {FirmwareFeature::THM_LIMIT_SHUTDOWN,{TelemetryTag::THM_LIMIT_SHUTDOWN, LinearTransform{}}},
         {FirmwareFeature::DDR_STATUS,        {TelemetryTag::GDDR_STATUS, LinearTransform{}}},
         {FirmwareFeature::HEARTBEAT,         {TelemetryTag::TIMER_HEARTBEAT, LinearTransform{}}},
-        {FirmwareFeature::ETH_HEARTBEAT_STATUS, {TelemetryTag::ETH_LIVE_STATUS, LinearTransform{}}},
-        {FirmwareFeature::ETH_RETRAIN_STATUS,   {TelemetryTag::ETH_LIVE_STATUS, LinearTransform{}}},
+        {FirmwareFeature::ETH_HEARTBEAT_STATUS, {TelemetryTag::ETH_LIVE_STATUS, LinearTransform{0, 0xFFFF}}},
+        {FirmwareFeature::ETH_RETRAIN_STATUS,   {TelemetryTag::ETH_LIVE_STATUS, LinearTransform{16, 0xFFFF}}},
         {FirmwareFeature::ETH_LINK_STATUS,      {FixedValue{0}, NotAvailable{}}},
         {FirmwareFeature::THERM_TRIP_COUNT,  {TelemetryTag::THERM_TRIP_COUNT, LinearTransform{}}},
         {FirmwareFeature::GDDR_UNCORR_ERRS,   {TelemetryTag::GDDR_UNCORR_ERRS, LinearTransform{}}},
@@ -160,8 +160,8 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
         {FirmwareFeature::THM_LIMIT_SHUTDOWN, {FixedValue{0}, NotAvailable{}}},
         {FirmwareFeature::DDR_STATUS, {WormholeTag::DDR_STATUS, LinearTransform{}}},
         {FirmwareFeature::HEARTBEAT, {WormholeTag::ARC0_HEALTH, LinearTransform{}}},
-        {FirmwareFeature::ETH_HEARTBEAT_STATUS, {WormholeTag::ETH_LIVE_STATUS, LinearTransform{}}},
-        {FirmwareFeature::ETH_RETRAIN_STATUS,   {WormholeTag::ETH_LIVE_STATUS, LinearTransform{}}},
+        {FirmwareFeature::ETH_HEARTBEAT_STATUS, {WormholeTag::ETH_LIVE_STATUS, LinearTransform{0, 0xFFFF}}},
+        {FirmwareFeature::ETH_RETRAIN_STATUS,   {WormholeTag::ETH_LIVE_STATUS, LinearTransform{16, 0xFFFF}}},
         {FirmwareFeature::ETH_LINK_STATUS,      {FixedValue{0}, NotAvailable{}}},
         {FirmwareFeature::THERM_TRIP_COUNT, {FixedValue{0}, NotAvailable{}}},
         {FirmwareFeature::GDDR_UNCORR_ERRS, {FixedValue{0}, NotAvailable{}}},
@@ -204,7 +204,7 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
 /* static */ FirmwareFeatures FirmwareInfoProvider::create_wormhole_19_9_base() {
     FirmwareFeatures map = create_wormhole_18_8_base();
     map[FirmwareFeature::ETH_RETRAIN_STATUS] = {FixedValue{0}, NotAvailable{}};
-    map[FirmwareFeature::ETH_LINK_STATUS] = {TelemetryTag::ETH_LIVE_STATUS, LinearTransform{}};
+    map[FirmwareFeature::ETH_LINK_STATUS] = {TelemetryTag::ETH_LIVE_STATUS, LinearTransform{16, 0xFFFF}};
     return map;
 }
 
@@ -223,8 +223,8 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
 // Blackhole >= 19.9: ETH_LIVE_STATUS becomes available (upper 16 = link, lower 16 = heartbeat).
 /* static */ FirmwareFeatures FirmwareInfoProvider::create_blackhole_19_9_base() {
     FirmwareFeatures map = create_blackhole_18_8_base();
-    map[FirmwareFeature::ETH_HEARTBEAT_STATUS] = {TelemetryTag::ETH_LIVE_STATUS, LinearTransform{}};
-    map[FirmwareFeature::ETH_LINK_STATUS] = {TelemetryTag::ETH_LIVE_STATUS, LinearTransform{}};
+    map[FirmwareFeature::ETH_HEARTBEAT_STATUS] = {TelemetryTag::ETH_LIVE_STATUS, LinearTransform{0, 0xFFFF}};
+    map[FirmwareFeature::ETH_LINK_STATUS] = {TelemetryTag::ETH_LIVE_STATUS, LinearTransform{16, 0xFFFF}};
     return map;
 }
 
@@ -651,27 +651,27 @@ std::optional<uint32_t> FirmwareInfoProvider::get_therm_trip_count() const {
 }
 
 std::optional<std::vector<bool>> FirmwareInfoProvider::get_eth_heartbeat_status() const {
-    if (!is_feature_available(FirmwareFeature::ETH_HEARTBEAT_STATUS)) {
+    auto data = read_scalar<uint16_t>(FirmwareFeature::ETH_HEARTBEAT_STATUS);
+    if (!data.has_value()) {
         return std::nullopt;
     }
-    uint32_t data = read_raw_telemetry(firmware_feature_map.at(FirmwareFeature::ETH_HEARTBEAT_STATUS).key);
-    return parse_eth_status_bitmask(static_cast<uint16_t>(data & 0xFFFF));
+    return parse_eth_status_bitmask(data.value());
 }
 
 std::optional<std::vector<bool>> FirmwareInfoProvider::get_eth_link_status() const {
-    if (!is_feature_available(FirmwareFeature::ETH_LINK_STATUS)) {
+    auto data = read_scalar<uint16_t>(FirmwareFeature::ETH_LINK_STATUS);
+    if (!data.has_value()) {
         return std::nullopt;
     }
-    uint32_t data = read_raw_telemetry(firmware_feature_map.at(FirmwareFeature::ETH_LINK_STATUS).key);
-    return parse_eth_status_bitmask(static_cast<uint16_t>((data >> 16) & 0xFFFF));
+    return parse_eth_status_bitmask(data.value());
 }
 
 std::optional<std::vector<bool>> FirmwareInfoProvider::get_eth_retrain_status() const {
-    if (!is_feature_available(FirmwareFeature::ETH_RETRAIN_STATUS)) {
+    auto data = read_scalar<uint16_t>(FirmwareFeature::ETH_RETRAIN_STATUS);
+    if (!data.has_value()) {
         return std::nullopt;
     }
-    uint32_t data = read_raw_telemetry(firmware_feature_map.at(FirmwareFeature::ETH_RETRAIN_STATUS).key);
-    return parse_eth_status_bitmask(static_cast<uint16_t>((data >> 16) & 0xFFFF));
+    return parse_eth_status_bitmask(data.value());
 }
 
 }  // namespace tt::umd

--- a/device/firmware/firmware_info_provider.cpp
+++ b/device/firmware/firmware_info_provider.cpp
@@ -58,8 +58,10 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
                 return create_wormhole_18_3_base();
             } else if (fw_version <= FirmwareBundleVersion(18, 7, 0)) {
                 return create_wormhole_18_4_base();
+            } else if (fw_version <= FirmwareBundleVersion(19, 8, 0)) {
+                return create_wormhole_18_8_base();
             }
-            return create_wormhole_18_8_base();
+            return create_wormhole_19_9_base();
         case ARCH::BLACKHOLE:
             if (fw_version <= FirmwareBundleVersion(18, 7, 0)) {
                 return create_blackhole_18_5_base();
@@ -191,10 +193,18 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
     return map;
 }
 
-// Wormhole > 18.7: StandardTag base with StandardTag MAX_CLOCK_FREQ.
+// Wormhole 18.8-19.8: StandardTag base with StandardTag MAX_CLOCK_FREQ.
 /* static */ FirmwareFeatures FirmwareInfoProvider::create_wormhole_18_8_base() {
     FirmwareFeatures map = create_18_4_new_telemetry_base();
     map[FirmwareFeature::MAX_CLOCK_FREQ] = {TelemetryTag::AICLK_LIMIT_MAX, LinearTransform{}};
+    return map;
+}
+
+// Wormhole >= 19.9: ETH_LIVE_STATUS upper 16 bits change from retrain to link status.
+/* static */ FirmwareFeatures FirmwareInfoProvider::create_wormhole_19_9_base() {
+    FirmwareFeatures map = create_wormhole_18_8_base();
+    map[FirmwareFeature::ETH_RETRAIN_STATUS] = {FixedValue{0}, NotAvailable{}};
+    map[FirmwareFeature::ETH_LINK_STATUS] = {TelemetryTag::ETH_LIVE_STATUS, LinearTransform{}};
     return map;
 }
 
@@ -212,10 +222,9 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
 
 // Blackhole >= 19.9: ETH_LIVE_STATUS becomes available (upper 16 = link, lower 16 = heartbeat).
 /* static */ FirmwareFeatures FirmwareInfoProvider::create_blackhole_19_9_base() {
-    FirmwareFeatures map = create_18_4_new_telemetry_base();
-    map[FirmwareFeature::MAX_CLOCK_FREQ] = {TelemetryTag::AICLK_LIMIT_MAX, LinearTransform{}};
-    map[FirmwareFeature::ETH_FW_VERSION] = {FixedValue{0}, NotAvailable{}};
-    map[FirmwareFeature::ETH_RETRAIN_STATUS] = {FixedValue{0}, NotAvailable{}};
+    FirmwareFeatures map = create_blackhole_18_8_base();
+    map[FirmwareFeature::ETH_HEARTBEAT_STATUS] = {TelemetryTag::ETH_LIVE_STATUS, LinearTransform{}};
+    map[FirmwareFeature::ETH_LINK_STATUS] = {TelemetryTag::ETH_LIVE_STATUS, LinearTransform{}};
     return map;
 }
 

--- a/nanobind/py_api_telemetry.cpp
+++ b/nanobind/py_api_telemetry.cpp
@@ -238,6 +238,7 @@ void bind_telemetry(nb::module_& m) {
         .def("get_therm_trip_count", &FirmwareInfoProvider::get_therm_trip_count, release_gil())
         .def("get_eth_heartbeat_status", &FirmwareInfoProvider::get_eth_heartbeat_status, release_gil())
         .def("get_eth_retrain_status", &FirmwareInfoProvider::get_eth_retrain_status, release_gil())
+        .def("get_eth_link_status", &FirmwareInfoProvider::get_eth_link_status, release_gil())
         .def_static(
             "get_minimum_compatible_firmware_version",
             &FirmwareInfoProvider::get_minimum_compatible_firmware_version,

--- a/tests/api/test_firmware_info_provider.cpp
+++ b/tests/api/test_firmware_info_provider.cpp
@@ -604,12 +604,12 @@ TEST_F(TestFirmwareInfoProvider, EthHeartbeatStatus) {
         auto heartbeats = fw_info->get_eth_heartbeat_status();
 
         // Available on Wormhole (all versions) and Blackhole >= 19.9.
-        if (arch == tt::ARCH::BLACKHOLE && fw_version <= FirmwareBundleVersion(19, 8, 0)) {
+        if (arch == tt::ARCH::BLACKHOLE && fw_version < FirmwareBundleVersion(19, 9, 0)) {
             EXPECT_FALSE(heartbeats.has_value());
         }
 
         if (arch == tt::ARCH::WORMHOLE_B0 ||
-            (arch == tt::ARCH::BLACKHOLE && fw_version > FirmwareBundleVersion(19, 8, 0))) {
+            (arch == tt::ARCH::BLACKHOLE && fw_version >= FirmwareBundleVersion(19, 9, 0))) {
             EXPECT_TRUE(heartbeats.has_value());
             if (heartbeats.has_value()) {
                 EXPECT_EQ(heartbeats.value().size(), 16u);
@@ -627,11 +627,11 @@ TEST_F(TestFirmwareInfoProvider, EthRetrainStatus) {
         auto retrains = fw_info->get_eth_retrain_status();
 
         // Only available on Wormhole prior to 19.9.
-        if (arch == tt::ARCH::BLACKHOLE || fw_version > FirmwareBundleVersion(19, 8, 0)) {
+        if (arch == tt::ARCH::BLACKHOLE || fw_version >= FirmwareBundleVersion(19, 9, 0)) {
             EXPECT_FALSE(retrains.has_value());
         }
 
-        if (arch == tt::ARCH::WORMHOLE_B0 && fw_version <= FirmwareBundleVersion(19, 8, 0)) {
+        if (arch == tt::ARCH::WORMHOLE_B0 && fw_version < FirmwareBundleVersion(19, 9, 0)) {
             EXPECT_TRUE(retrains.has_value());
             if (retrains.has_value()) {
                 EXPECT_EQ(retrains.value().size(), 16u);
@@ -648,11 +648,11 @@ TEST_F(TestFirmwareInfoProvider, EthLinkStatus) {
         auto links = fw_info->get_eth_link_status();
 
         // Available on firmware >= 19.9 for both Wormhole and Blackhole.
-        if (fw_version <= FirmwareBundleVersion(19, 8, 0)) {
+        if (fw_version < FirmwareBundleVersion(19, 9, 0)) {
             EXPECT_FALSE(links.has_value());
         }
 
-        if (fw_version > FirmwareBundleVersion(19, 8, 0)) {
+        if (fw_version >= FirmwareBundleVersion(19, 9, 0)) {
             EXPECT_TRUE(links.has_value());
             if (links.has_value()) {
                 EXPECT_EQ(links.value().size(), 16u);

--- a/tests/api/test_firmware_info_provider.cpp
+++ b/tests/api/test_firmware_info_provider.cpp
@@ -600,14 +600,16 @@ TEST_F(TestFirmwareInfoProvider, EthHeartbeatStatus) {
         auto* fw_info = tt_device->get_firmware_info_provider();
 
         tt::ARCH arch = tt_device->get_arch();
+        auto fw_version = fw_info->get_firmware_version();
         auto heartbeats = fw_info->get_eth_heartbeat_status();
 
-        // Only available on Wormhole; Blackhole returns nullopt.
-        if (arch == tt::ARCH::BLACKHOLE) {
+        // Available on Wormhole (all versions) and Blackhole >= 19.9.
+        if (arch == tt::ARCH::BLACKHOLE && fw_version <= FirmwareBundleVersion(19, 8, 0)) {
             EXPECT_FALSE(heartbeats.has_value());
         }
 
-        if (arch == tt::ARCH::WORMHOLE_B0) {
+        if (arch == tt::ARCH::WORMHOLE_B0 ||
+            (arch == tt::ARCH::BLACKHOLE && fw_version > FirmwareBundleVersion(19, 8, 0))) {
             EXPECT_TRUE(heartbeats.has_value());
             if (heartbeats.has_value()) {
                 EXPECT_EQ(heartbeats.value().size(), 16u);
@@ -621,17 +623,39 @@ TEST_F(TestFirmwareInfoProvider, EthRetrainStatus) {
         auto* fw_info = tt_device->get_firmware_info_provider();
 
         tt::ARCH arch = tt_device->get_arch();
+        auto fw_version = fw_info->get_firmware_version();
         auto retrains = fw_info->get_eth_retrain_status();
 
-        // Only available on Wormhole; Blackhole returns nullopt.
-        if (arch == tt::ARCH::BLACKHOLE) {
+        // Only available on Wormhole prior to 19.9.
+        if (arch == tt::ARCH::BLACKHOLE || fw_version > FirmwareBundleVersion(19, 8, 0)) {
             EXPECT_FALSE(retrains.has_value());
         }
 
-        if (arch == tt::ARCH::WORMHOLE_B0) {
+        if (arch == tt::ARCH::WORMHOLE_B0 && fw_version <= FirmwareBundleVersion(19, 8, 0)) {
             EXPECT_TRUE(retrains.has_value());
             if (retrains.has_value()) {
                 EXPECT_EQ(retrains.value().size(), 16u);
+            }
+        }
+    }
+}
+
+TEST_F(TestFirmwareInfoProvider, EthLinkStatus) {
+    for (const auto& tt_device : get_tt_devices()) {
+        auto* fw_info = tt_device->get_firmware_info_provider();
+
+        auto fw_version = fw_info->get_firmware_version();
+        auto links = fw_info->get_eth_link_status();
+
+        // Available on firmware >= 19.9 for both Wormhole and Blackhole.
+        if (fw_version <= FirmwareBundleVersion(19, 8, 0)) {
+            EXPECT_FALSE(links.has_value());
+        }
+
+        if (fw_version > FirmwareBundleVersion(19, 8, 0)) {
+            EXPECT_TRUE(links.has_value());
+            if (links.has_value()) {
+                EXPECT_EQ(links.value().size(), 16u);
             }
         }
     }


### PR DESCRIPTION
### Issue
#2788 

### Description
This pull request adds support for reporting per-link Ethernet link and heartbeat status, while deprecating retrain status for newer FW versions.

### List of the changes
* Added a new method `get_eth_link_status()` to `FirmwareInfoProvider` that returns the per-link Ethernet link status as a vector of bools, available on firmware 19.9+ for both Wormhole and Blackhole.
* Updated the firmware feature mapping logic to distinguish between heartbeat, retrain, and link status, and to map them appropriately based on firmware version and architecture. This includes new static feature map constructors for Wormhole and Blackhole 19.9+.
* Refactored the handling of Ethernet status features, replacing the old `ETH_LIVE_STATUS` feature with three distinct features: `ETH_HEARTBEAT_STATUS`, `ETH_RETRAIN_STATUS`, and `ETH_LINK_STATUS`, and updated their usage throughout the codebase.


### Testing

* Added and updated unit tests to verify the correct availability and behavior of Ethernet heartbeat, retrain, and link status methods for different architectures and firmware versions, including a new test for `get_eth_link_status()`.

These changes ensure that Ethernet link status is accurately reported and accessible through the API for supported firmware versions, while maintaining backward compatibility and test coverage.

Manual

### API Changes
Added one API (get_eth_link_status).
