### PR TITLE
Fix truncation of telemetry_table_addr to uint32_t

### DIFF
--- a/device/arc/arc_telemetry_reader.cpp
+++ b/device/arc/arc_telemetry_reader.cpp
@@ -52,7 +52,7 @@ void ArcTelemetryReader::initialize_telemetry() {
 
     // We offset the tag_table_address by 2 * sizeof(uint32_t) to skip the first two uint32_t values,
     // which are version and entry count. For representaiton look at telemetry.h
-    uint32_t tag_table_address = telemetry_table_addr + 2 * sizeof(uint32_t);
+    uint64_t tag_table_address = telemetry_table_addr + 2 * sizeof(uint32_t);
     std::vector<TelemetryTagEntry> telemetry_tag_entries(entry_count);
     tt_device->read_from_device(
         telemetry_tag_entries.data(), arc_core, tag_table_address, entry_count * sizeof(TelemetryTagEntry));


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2782

### Description
Address math was truncating a uint64_t down to a uint32_t.

### List of the changes
Change local variable to uint64_t so value doesn't get truncated.

### Testing
@micahwhiteTT has tested this locally

### API Changes
This PR has (no) API changes.
