### PR TITLE
Simulation server: design doc + per-chip SimulationSocket (first slice)

### DIFF
--- a/docs/SIMULATION_SERVER_PROCESS.md
+++ b/docs/SIMULATION_SERVER_PROCESS.md
@@ -5,7 +5,7 @@
 This document frames the problem and lays out the design decisions we need to make to run
 the simulator **persistently, as a server process** — decoupled from the lifetime of any
 single UMD client. It is meant to drive a design discussion, not to prescribe a final
-implementation. Each major section ends with the **decision(s)** the room needs to settle.
+implementation.
 
 ---
 
@@ -27,36 +27,29 @@ and any process can open/share it. The card's lifetime is independent of any use
 
 ## 2. Where we are today
 
-UMD has two simulator backends, both behind the same stack
-(`Cluster → SimulationChip → TTDevice → communicator`):
+UMD has two simulator backends:
 
 | | **TTSim** | **RTL / emu** |
 |---|---|---|
-| Locality | in-process (`libttsim.so` via `dlopen`) | out-of-process (UMD spawns `{sim_dir}/run.sh`) |
-| Transport | direct function-pointer calls | **nng** socket (TCP) + **FlatBuffers** protocol |
-| Multi-client | n/a | none — see below |
+| Locality | runs **inside** the UMD process | runs as a **separate process** that UMD launches |
+| Transport | direct in-process calls | a socket connection with a message protocol |
+| Multi-client | not applicable | not supported — see below |
 
-**The key reality check (verified in code):** the current RTL model is *inverted* from a
-"card."
+**The key reality check:** the current out-of-process (RTL) model is *inverted* from a "card."
 
-- **UMD is the nng listener (server); the simulator dials *into* UMD.**
-  (`SimulationHost::init()` listens; the spawned `run.sh` connects back via a random TCP port
-  advertised in `NNG_SOCKET_ADDR`.)
-- **The transport is `nng_pair1` — strictly 1:1.** It cannot serve N clients.
-- **Lifetime is hard-coupled:** `~RtlSimulationTTDevice` → `communicator_->shutdown()` sends
-  `DEVICE_COMMAND_EXIT`, which kills the simulator.
+- **UMD acts as the server and the simulator connects back into UMD** — the opposite of a card
+  that exists on its own and is opened by software.
+- **The connection is strictly point-to-point** — it can serve exactly one client.
+- **Lifetime is hard-coupled:** the simulator is shut down when the owning UMD client goes
+  away.
 
 So "make it a server" is really **three coupled changes**, none optional:
 
-1. **Invert the roles** — the simulator (or a broker in front of it) becomes the
-   listener/"card"; UMD becomes a dialing client.
-2. **Replace `pair1`** with per-client accepted connections (this single change underwrites
-   fan-out, per-connection response ordering, *and* crash detection).
-3. **Move process ownership out of UMD** — client teardown must send `DETACH`, not `EXIT`.
-
-> **Discussion anchor:** everything below assumes we accept this inversion. If we don't, the
-> rest doesn't hold together. **Decision 0: do we agree the simulator process becomes the
-> server/owner, and UMD becomes a client?**
+1. **Invert the roles** — the simulator (or a broker in front of it) becomes the "card"; UMD
+   becomes a client that connects to it.
+2. **Allow many clients** — move from a single point-to-point connection to one that accepts
+   multiple clients (this is also what lets us notice when a client disconnects or crashes).
+3. **Move ownership out of UMD** — a client going away must no longer tear the device down.
 
 ## 3. Scope
 
@@ -64,67 +57,53 @@ So "make it a server" is really **three coupled changes**, none optional:
 backend can run as a shared, persistent server. They differ only in how much work it takes to
 get there:
 
-- **RTL/emu** is already out-of-process and socket-based, so the server is a direct extension
-  of the existing `SimulationHost`/nng/FlatBuffers stack (1:1 → N:1) — the smaller lift.
-- **TTSim** is in-process today (`libttsim.so` via `dlopen`), so making it a server means
-  introducing an IPC boundary underneath `TTSimCommunicator`. This carries a perf penalty
-  (in-process calls → cross-process) and requires solving the TLB-register hazard (§6.3) — a
-  larger lift, but in scope, not optional.
+- **RTL/emu** already runs out-of-process over a socket, so the server is a direct extension
+  of what exists today — the smaller lift.
+- **TTSim** runs inside the UMD process today, so making it a server means introducing a
+  process boundary where there is none. This carries a performance cost (in-process calls
+  become cross-process) — a larger lift, but in scope, not optional.
 
-Both backends should sit behind the **same** client device class and protocol so the server
-model is uniform; the backend difference stays below the socket, invisible to clients.
+Both backends should sit behind the **same** client-facing path so the server model is
+uniform; the backend difference stays below the connection, invisible to clients.
 
 ---
 
 ## 4. Surfacing & discovery (the "KMD analog")
 
-Surface each simulated chip as a **unix domain socket file in a folder** — discovered by
-scanning the folder, mirroring `PCIDevice::enumerate_devices()` scanning `/dev/tenstorrent/`.
+Surface each simulated device as a **file in a well-known folder** — one file per device,
+discovered by scanning the folder. This mirrors how KMD exposes silicon devices for
+enumeration.
 
-- **Folder:** default `$XDG_RUNTIME_DIR/tt-sim/` (fallback `/tmp/tt-sim-$UID/`, mode `0700`),
-  env/option overridable. Per-UID namespacing gives permissions for free.
-- **Filename** encodes identity for cheap pre-attach filtering (advisory cache; the socket
-  handshake is authoritative): a `server_instance` id grouping one cluster's chips, plus
-  arch / board / chip-NN. e.g. `tt-sim-<instance>-wormhole_b0-n300-chip00.sock`.
-- **Liveness:** never trust file existence/mtime. Authoritative check = non-blocking
-  `connect()` (`ECONNREFUSED` ⇒ stale tombstone) + a `flock` sentinel for race-free reclaim;
-  a PID/boot-id file is a secondary diagnostic hint (guards against recycled PIDs).
-- **Integration:** add a `SimulationTopologyDiscovery` that scans the folder and queries each
-  socket, returning `(ClusterDescriptor, tt_devices)` — exactly parallel to silicon's
-  `TopologyDiscovery::discover()`. The existing `tt_devices` reuse path in `Cluster::Cluster`
-  then works unchanged.
-
-> **Decisions:** folder location & whether it's configurable; filename grammar; whether we
-> also keep TCP (remote/distributed sim) alongside unix sockets.
+- **Folder.** A well-known, per-user location (so devices of different users don't collide).
+- **Identity.** Each file's name carries enough identity — which device/cluster it belongs to,
+  its architecture — for a client to choose a device before connecting.
+- **Liveness.** A file may be left behind after a server dies, so a file's *existence* does not
+  prove a server is alive behind it. A client confirms liveness before relying on a device,
+  and a stale leftover can be safely reclaimed. (This is the equivalent of "is the card really
+  there?" — a filename alone can't guarantee it, the way an enumerated silicon device does.)
+- **Discovery component.** We need a **`SimulationTopologyDiscovery`** that scans the folder,
+  determines which devices are live, and produces the discovered devices and the cluster
+  topology — mirroring how silicon discovery works — so the rest of cluster setup is unchanged.
 
 ---
 
 ## 5. The client/UMD side
 
-Keep the client path **as close to the silicon `LocalChip` path as possible.**
+In the server model the client path is **uniform: UMD always attaches to a server.** There is
+no per-call "spawn vs connect" mode — opening a simulated device always means connecting to a
+server and attaching, the same single path for both backends. This keeps the client close to
+the silicon device-open path, which likewise just *opens* an already-present device.
 
-- **One device class over two communicator backings** (the silicon pattern: `LocalChip` over
-  different PciDevice/JTAG backings). Inject a *connecting* communicator
-  (`RtlSimClientCommunicator`) vs the spawning one. **Avoid** a `bool connect_mode` flag
-  littering the constructor.
-- **Keep `ChipType::SIMULATION`.** Attach-vs-spawn is a transport *mode*, not a new device
-  family — a new ChipType would fork every `== SIMULATION` check in `cluster.cpp`.
-- **Attach ≠ initialize.** Today *all* init is pulled into TTDevice **construction** +
-  spawn/`start_sim`; `SimulationChip::start_device()` is already a no-op (conveniently correct
-  for attach). Split it explicitly:
-  - `INIT`/`START` + power-on resets run **once, at card creation** — never per client.
-  - New read-only `ATTACH`/`HELLO` (returns arch, SocDescriptor, BAR bases, channel count,
-    reset/power state, serialized `ClusterDescriptor`; bumps a refcount) and `DETACH`
-    (decrements; never tears down). Replaces the current `EXIT`-as-ready-ack hack.
-  - **Hard rule:** a default `Cluster(SIMULATION attach)` + `start_device()` must issue
-    **zero state-mutating commands.** "Opening an already-up card doesn't reset it."
-- **Server is the single source of truth for topology/identity.** Clients *read* the
-  `ClusterDescriptor` from the server (reuse `ClusterDescriptor::serialize()` /
-  `create_from_yaml_content()`) instead of synthesizing it via `create_mock_cluster`. This is
-  mandatory for handoff — every client must see identical device shape.
-
-> **Decisions:** new `SimulationClientTTDevice` vs refactor `RtlSimulationTTDevice`;
-> `ClusterOptions` attach fields (socket folder / explicit socket / `attach_to_server` flag).
+- **Attach ≠ initialize.** Today initialization happens as part of launching the simulator. In
+  the server model, one-time init and power-on reset happen **once, at card creation** — never
+  per client. A client only ever performs a **non-mutating** attach: opening the device issues
+  no state-changing operations ("opening an already-up card doesn't reset it").
+- **Server is the single source of truth for topology/identity.** On attach the client *reads*
+  the device's identity and cluster topology from the server rather than synthesizing its own —
+  mandatory for handoff, so every client sees an identical device shape.
+- **Legacy spawn-and-own stays separate.** Today's coupled behavior (UMD launches and owns the
+  simulator directly, one-to-one) remains available unchanged for back-compat; it is not
+  folded into the attaching client (see §6.1).
 
 ---
 
@@ -133,68 +112,71 @@ Keep the client path **as close to the silicon `LocalChip` path as possible.**
 The simulator runs as a **persistent server process that *is* the device** ("the card"): it
 owns all device state and outlives any individual UMD client. UMD instances are clients that
 **attach** to it, do work, and **detach** — exactly the relationship a process has with a
-silicon card sitting in a PCIe slot. Below we work through the four questions that decide the
-shape of this: how the server is created, how UMD connects, who tears it down, and which KMD
-responsibilities the server must take on to look like silicon.
+silicon card sitting in a PCIe slot. Below we work through the questions that decide the
+shape of this: how the server is created, how UMD connects, who tears it down, and how a
+client gets a clean slate.
 
 ### 6.1 Lifetime: how is the server created?
 
-The card's existence must be **independent of any client's lifetime** — that is the whole
-point (shareability + state handoff). The open question is *who brings it up and when*:
+UMD always attaches to a server (§5); the card's existence is **independent of any client's
+lifetime** — that is the whole point (shareability + state handoff). What varies is only *how
+the server comes to exist* when a client wants to attach:
 
-- **Offline (created out-of-band, recommended default).** The server is started explicitly —
-  by a person, a CI step, or a service — *before* any UMD process runs, and stays up across
-  many attach/detach cycles. This is the faithful silicon model (the card is already powered
-  and enumerated before software touches it) and the only one that cleanly supports
-  state handoff between separate UMD processes.
-- **During UMD startup (lazy, opt-in).** For single-process/dev convenience, the first UMD
-  client that finds no server may bring one up. This preserves today's "just run the binary"
-  workflow, but the spawned server must still be **owned independently** of that client (it
-  does not die when that client exits) — otherwise we are back to lifetime coupling.
+- **Created offline (recommended default).** The server is started out-of-band — by a person,
+  a CI step, or a service — *before* any UMD process runs, and stays up across many
+  attach/detach cycles. This is the faithful silicon model (the card is already powered and
+  enumerated before software touches it) and the one that cleanly supports state handoff
+  between separate UMD processes.
+- **Spawned on demand if not active.** If a client goes to attach and finds no live server, it
+  brings one up and then attaches. The spawned server must be **owned independently** of the
+  client that triggered it — it does not die when that client exits, otherwise we are back to
+  lifetime coupling.
+- **Legacy mode (back-compat).** Today's behavior — UMD launches and owns the simulator
+  directly (one-to-one, coupled lifetime, no server) — remains available as a transition path
+  for anyone not yet on the server model.
 
-The invariant under both: **creating the device (one-time power-on init/reset of state) is
-distinct from a client attaching.** The card is initialized once, by whoever creates it;
-every client — including the first — only attaches and never re-initializes state.
-
-> **Decision:** offline-by-default, with lazy startup-spawn as an opt-in convenience? And in
-> the lazy case, what owns the spawned server so it isn't tied to the spawning client?
+The invariant across all of these: **creating the device (one-time power-on init/reset) is
+distinct from a client attaching.** The card is initialized once, by whoever creates it; every
+client — including the first — only attaches and never re-initializes state.
 
 ### 6.2 How UMD connects to the server
 
 Connecting should mirror how UMD opens a silicon device:
 
-- **Discovery.** Devices are surfaced as endpoints in a well-known location (a folder of
-  per-device sockets) — the analog of KMD exposing cards under `/dev/tenstorrent`. UMD
-  **scans** that location to enumerate available simulated devices, honoring the same
-  device-selection semantics it already uses for silicon.
-- **Open = attach.** UMD picks a device and connects to its endpoint. The attach is a
-  **non-mutating** handshake: UMD learns the device's identity and topology *from the server*
-  and bumps a reference count — it does not reset or re-initialize anything.
-- **Liveness.** A listed endpoint may be stale (server gone); UMD treats a successful
-  connection as the proof of liveness, the same way opening a chardev confirms a real device.
+- **Discovery.** Devices are surfaced in a well-known folder (§4) — the analog of how KMD
+  exposes silicon cards for discovery. UMD scans that folder to enumerate available simulated
+  devices, honoring the same device-selection semantics it already uses for silicon.
+- **Open = attach.** UMD picks a device and attaches to it. The attach is a **non-mutating**
+  handshake: UMD learns the device's identity and topology *from the server* and registers
+  itself — it does not reset or re-initialize anything.
+- **Liveness.** A listed device may be stale (server gone); UMD treats a successful attach as
+  the proof of liveness, the same way opening a silicon device confirms it is really there.
 
 The net effect: from UMD's perspective "find a simulated device and open it" looks the same as
-"enumerate PCIe devices and open one" — which is what keeps the client path close to silicon.
-
-> **Decision:** where does the discovery folder live, and how is a device named/selected
-> within it?
+finding and opening a silicon device — which is what keeps the client path close to silicon.
 
 ### 6.3 Who kills the server?
 
 Because the card's lifetime is decoupled from clients, **a client detaching or exiting must
-never tear the server down** (this is the key change from today, where a client's destructor
-kills the simulator). Teardown becomes a deliberate act of whoever *owns* the card:
+never tear the server down** (this is the key change from today, where a client going away
+kills the simulator). Two separate concerns decide what happens.
+
+**Teardown triggers — when the card decides to shut down:**
 
 - **Explicit stop** — the owner (person/CI/service that created it) shuts it down when done.
   Natural fit for the offline model.
 - **Policy-based** — e.g. linger for a grace period after the last client detaches, then exit;
   or stay up indefinitely for a long-lived shared card. A bounded linger keeps CI from leaking
   server processes while still surviving the brief gap during a process-to-process handoff.
-- **Crashed clients** are detected (their connection drops) and detached automatically — they
-  decrement the reference count but never bring the card down.
 
-> **Decision:** explicit-owner teardown, a linger policy, or both (different defaults for
-> interactive vs CI)? What is the default linger?
+**Client accounting — keeping an honest count of who is attached:**
+
+The card tracks how many clients are attached, because the policies above depend on knowing
+when the last one leaves. A clean exit detaches and releases its reference; a **crashed**
+client never sends that detach, so the server detects the dropped connection and releases the
+reference on its behalf. Crash detection is *only* bookkeeping — a crash is treated exactly
+like a clean detach (release one reference, nothing more), so it neither leaks a reference
+(keeping the card alive forever) nor wrongly brings the card down.
 
 ### 6.4 Resetting to a clean slate
 
@@ -215,7 +197,3 @@ The important property either way: a reset is **destructive and shared** — it 
 that *all* currently attached clients are using. So it must be an explicit, privileged action
 (requested by the owner, or by a client that knowingly opts in), and it cannot be the quiet
 default behavior of opening the device.
-
-> **Decision:** do we need in-place reset, or is "restart the server for a clean slate" enough?
-> Who is allowed to trigger a reset, and what is the contract for other clients that are
-> attached when it happens (forcibly detached, notified, or silently see reset state)?

--- a/docs/SIMULATION_SERVER_PROCESS.md
+++ b/docs/SIMULATION_SERVER_PROCESS.md
@@ -125,3 +125,73 @@ Keep the client path **as close to the silicon `LocalChip` path as possible.**
 
 > **Decisions:** new `SimulationClientTTDevice` vs refactor `RtlSimulationTTDevice`;
 > `ClusterOptions` attach fields (socket folder / explicit socket / `attach_to_server` flag).
+
+---
+
+## 6. Proposed solution & architecture
+
+The simulator runs as a **persistent server process that *is* the device** ("the card"): it
+owns all device state and outlives any individual UMD client. UMD instances are clients that
+**attach** to it, do work, and **detach** — exactly the relationship a process has with a
+silicon card sitting in a PCIe slot. Below we work through the four questions that decide the
+shape of this: how the server is created, how UMD connects, who tears it down, and which KMD
+responsibilities the server must take on to look like silicon.
+
+### 6.1 Lifetime: how is the server created?
+
+The card's existence must be **independent of any client's lifetime** — that is the whole
+point (shareability + state handoff). The open question is *who brings it up and when*:
+
+- **Offline (created out-of-band, recommended default).** The server is started explicitly —
+  by a person, a CI step, or a service — *before* any UMD process runs, and stays up across
+  many attach/detach cycles. This is the faithful silicon model (the card is already powered
+  and enumerated before software touches it) and the only one that cleanly supports
+  state handoff between separate UMD processes.
+- **During UMD startup (lazy, opt-in).** For single-process/dev convenience, the first UMD
+  client that finds no server may bring one up. This preserves today's "just run the binary"
+  workflow, but the spawned server must still be **owned independently** of that client (it
+  does not die when that client exits) — otherwise we are back to lifetime coupling.
+
+The invariant under both: **creating the device (one-time power-on init/reset of state) is
+distinct from a client attaching.** The card is initialized once, by whoever creates it;
+every client — including the first — only attaches and never re-initializes state.
+
+> **Decision:** offline-by-default, with lazy startup-spawn as an opt-in convenience? And in
+> the lazy case, what owns the spawned server so it isn't tied to the spawning client?
+
+### 6.2 How UMD connects to the server
+
+Connecting should mirror how UMD opens a silicon device:
+
+- **Discovery.** Devices are surfaced as endpoints in a well-known location (a folder of
+  per-device sockets) — the analog of KMD exposing cards under `/dev/tenstorrent`. UMD
+  **scans** that location to enumerate available simulated devices, honoring the same
+  device-selection semantics it already uses for silicon.
+- **Open = attach.** UMD picks a device and connects to its endpoint. The attach is a
+  **non-mutating** handshake: UMD learns the device's identity and topology *from the server*
+  and bumps a reference count — it does not reset or re-initialize anything.
+- **Liveness.** A listed endpoint may be stale (server gone); UMD treats a successful
+  connection as the proof of liveness, the same way opening a chardev confirms a real device.
+
+The net effect: from UMD's perspective "find a simulated device and open it" looks the same as
+"enumerate PCIe devices and open one" — which is what keeps the client path close to silicon.
+
+> **Decision:** where does the discovery folder live, and how is a device named/selected
+> within it?
+
+### 6.3 Who kills the server?
+
+Because the card's lifetime is decoupled from clients, **a client detaching or exiting must
+never tear the server down** (this is the key change from today, where a client's destructor
+kills the simulator). Teardown becomes a deliberate act of whoever *owns* the card:
+
+- **Explicit stop** — the owner (person/CI/service that created it) shuts it down when done.
+  Natural fit for the offline model.
+- **Policy-based** — e.g. linger for a grace period after the last client detaches, then exit;
+  or stay up indefinitely for a long-lived shared card. A bounded linger keeps CI from leaking
+  server processes while still surviving the brief gap during a process-to-process handoff.
+- **Crashed clients** are detected (their connection drops) and detached automatically — they
+  decrement the reference count but never bring the card down.
+
+> **Decision:** explicit-owner teardown, a linger policy, or both (different defaults for
+> interactive vs CI)? What is the default linger?

--- a/docs/SIMULATION_SERVER_PROCESS.md
+++ b/docs/SIMULATION_SERVER_PROCESS.md
@@ -1,0 +1,271 @@
+# Simulation Server Process — Design Discussion
+
+**Status:** Draft for discussion · **Issue:** [#2677](https://github.com/tenstorrent/tt-umd/issues/2677)
+
+This document frames the problem and lays out the design decisions we need to make to run
+the simulator **persistently, as a server process** — decoupled from the lifetime of any
+single UMD client. It is meant to drive a design discussion, not to prescribe a final
+implementation. Each major section ends with the **decision(s)** the room needs to settle.
+
+---
+
+## 1. Why
+
+Today a simulated device lives and dies with the UMD process that created it. We want it to
+behave like silicon instead:
+
+- **Shareable across processes.** Multiple UMD threads/processes attach to the *same*
+  simulated device concurrently. Motivating case: **tt-triage** attaching to inspect a
+  device that a workload is already running on.
+- **Persistent state across clients (handoff).** One UMD client runs, mutates device state
+  (L1, DRAM, registers, reset state…), and exits; a **later, separate** UMD process attaches
+  and continues from exactly that state. The device is the source of truth; clients are
+  ephemeral.
+
+This is precisely the silicon contract: the card sits in a PCIe slot, **KMD** enumerates it,
+and any process can open/share it. The card's lifetime is independent of any user process.
+
+## 2. Where we are today
+
+UMD has two simulator backends, both behind the same stack
+(`Cluster → SimulationChip → TTDevice → communicator`):
+
+| | **TTSim** | **RTL / emu** |
+|---|---|---|
+| Locality | in-process (`libttsim.so` via `dlopen`) | out-of-process (UMD spawns `{sim_dir}/run.sh`) |
+| Transport | direct function-pointer calls | **nng** socket (TCP) + **FlatBuffers** protocol |
+| Multi-client | n/a | none — see below |
+
+**The key reality check (verified in code):** the current RTL model is *inverted* from a
+"card."
+
+- **UMD is the nng listener (server); the simulator dials *into* UMD.**
+  (`SimulationHost::init()` listens; the spawned `run.sh` connects back via a random TCP port
+  advertised in `NNG_SOCKET_ADDR`.)
+- **The transport is `nng_pair1` — strictly 1:1.** It cannot serve N clients.
+- **Lifetime is hard-coupled:** `~RtlSimulationTTDevice` → `communicator_->shutdown()` sends
+  `DEVICE_COMMAND_EXIT`, which kills the simulator.
+
+So "make it a server" is really **three coupled changes**, none optional:
+
+1. **Invert the roles** — the simulator (or a broker in front of it) becomes the
+   listener/"card"; UMD becomes a dialing client.
+2. **Replace `pair1`** with per-client accepted connections (this single change underwrites
+   fan-out, per-connection response ordering, *and* crash detection).
+3. **Move process ownership out of UMD** — client teardown must send `DETACH`, not `EXIT`.
+
+> **Discussion anchor:** everything below assumes we accept this inversion. If we don't, the
+> rest doesn't hold together. **Decision 0: do we agree the simulator process becomes the
+> server/owner, and UMD becomes a client?**
+
+## 3. Scope
+
+- **RTL/emu is the primary target** — already out-of-process and socket-based, so the server
+  is an extension of the existing `SimulationHost`/nng/FlatBuffers stack (1:1 → N:1).
+- **TTSim** can be offered later as an opt-in server mode reusing the same client device
+  class, but pays an IPC penalty (in-process calls → cross-process) and carries a TLB hazard
+  (§6.3). **Proposal: ship RTL-only first; keep TTSim single-client/in-process initially.**
+
+---
+
+## 4. Surfacing & discovery (the "KMD analog")
+
+Surface each simulated chip as a **unix domain socket file in a folder** — discovered by
+scanning the folder, mirroring `PCIDevice::enumerate_devices()` scanning `/dev/tenstorrent/`.
+
+- **Folder:** default `$XDG_RUNTIME_DIR/tt-sim/` (fallback `/tmp/tt-sim-$UID/`, mode `0700`),
+  env/option overridable. Per-UID namespacing gives permissions for free.
+- **Filename** encodes identity for cheap pre-attach filtering (advisory cache; the socket
+  handshake is authoritative): a `server_instance` id grouping one cluster's chips, plus
+  arch / board / chip-NN. e.g. `tt-sim-<instance>-wormhole_b0-n300-chip00.sock`.
+- **Liveness:** never trust file existence/mtime. Authoritative check = non-blocking
+  `connect()` (`ECONNREFUSED` ⇒ stale tombstone) + a `flock` sentinel for race-free reclaim;
+  a PID/boot-id file is a secondary diagnostic hint (guards against recycled PIDs).
+- **Integration:** add a `SimulationTopologyDiscovery` that scans the folder and queries each
+  socket, returning `(ClusterDescriptor, tt_devices)` — exactly parallel to silicon's
+  `TopologyDiscovery::discover()`. The existing `tt_devices` reuse path in `Cluster::Cluster`
+  then works unchanged.
+
+> **Decisions:** folder location & whether it's configurable; filename grammar; whether we
+> also keep TCP (remote/distributed sim) alongside unix sockets.
+
+---
+
+## 5. The client/UMD side
+
+Keep the client path **as close to the silicon `LocalChip` path as possible.**
+
+- **One device class over two communicator backings** (the silicon pattern: `LocalChip` over
+  different PciDevice/JTAG backings). Inject a *connecting* communicator
+  (`RtlSimClientCommunicator`) vs the spawning one. **Avoid** a `bool connect_mode` flag
+  littering the constructor.
+- **Keep `ChipType::SIMULATION`.** Attach-vs-spawn is a transport *mode*, not a new device
+  family — a new ChipType would fork every `== SIMULATION` check in `cluster.cpp`.
+- **Attach ≠ initialize.** Today *all* init is pulled into TTDevice **construction** +
+  spawn/`start_sim`; `SimulationChip::start_device()` is already a no-op (conveniently correct
+  for attach). Split it explicitly:
+  - `INIT`/`START` + power-on resets run **once, at card creation** — never per client.
+  - New read-only `ATTACH`/`HELLO` (returns arch, SocDescriptor, BAR bases, channel count,
+    reset/power state, serialized `ClusterDescriptor`; bumps a refcount) and `DETACH`
+    (decrements; never tears down). Replaces the current `EXIT`-as-ready-ack hack.
+  - **Hard rule:** a default `Cluster(SIMULATION attach)` + `start_device()` must issue
+    **zero state-mutating commands.** "Opening an already-up card doesn't reset it."
+- **Server is the single source of truth for topology/identity.** Clients *read* the
+  `ClusterDescriptor` from the server (reuse `ClusterDescriptor::serialize()` /
+  `create_from_yaml_content()`) instead of synthesizing it via `create_mock_cluster`. This is
+  mandatory for handoff — every client must see identical device shape.
+
+> **Decisions:** new `SimulationClientTTDevice` vs refactor `RtlSimulationTTDevice`;
+> `ClusterOptions` attach fields (socket folder / explicit socket / `attach_to_server` flag).
+
+---
+
+## 6. The hard problems (need explicit decisions)
+
+### 6.1 Sysmem / host-memory DMA with N clients — *the crux*
+
+Host sysmem is a **UMD-process-local anonymous `mmap`** today (`SimulationSysmemManager`), and
+simulator-initiated DMA (`AXI_RAM_*` notifications) is serviced against *that one client's*
+address space. With N clients, the shared device cannot answer **"whose sysmem?"**
+
+- **Recommended — sysmem becomes server-resident shared state.** The PCIe/sysmem address
+  space is a resource of the card (like L1/DRAM). Device DMA resolves *entirely inside the
+  server* — no client round-trip, no "which client," no reentrancy deadlock — and it enables
+  handoff. Silicon-faithful (sysmem = pinned, IOMMU-mapped host DRAM).
+  - Cost: client `read/write_to_sysmem` becomes an IPC round-trip (loses today's zero-copy).
+  - Refinement to prototype: `shm_open`/`memfd` backing mapped by *both* server and client to
+    recover zero-copy while keeping the server authoritative.
+  - Needs server-arbitrated channel/PCIe-base allocation (the KMD-allocates-IOVA analog).
+- **Rejected — keep sysmem client-local + route DMA to the owning client.** Requires the sim
+  core to resolve client identity from a bus address (deep sim change), reintroduces a
+  callback-reentrancy deadlock, and breaks handoff (in-flight DMA to a dead client).
+
+> **Decision:** server-resident sysmem — proxy-everything (simple/correct/slower) vs `shm`
+> zero-copy fast path?
+
+### 6.2 Clock ownership
+
+Device time is global; a client calling `advance_clock` / `libttsim_clock` affects all
+clients.
+
+- **Recommended — the server owns a free-running clock by default.** The card runs
+  continuously; clients observe asynchronously (the only model where tt-triage peeking at a
+  *running* workload makes sense). Expose `CLOCK_ADVANCE`/`PAUSE` only as a privileged/global
+  op.
+- **Risk:** existing single-client flows likely depend on lock-step `write → advance N →
+  read` determinism. Provide a **single-client stepped/deterministic mode** (when exactly one
+  client is attached, or it holds an advertised "clock-owner" lease); the contract degrades to
+  free-running the moment a second client attaches.
+
+> **Decision:** default to free-running? **Action:** audit existing sim tests for hidden
+> dependence on synchronous `advance_clock`.
+
+### 6.3 TTSim TLB registers (TTSim-only)
+
+On **TTSim WH/BH**, `TTSimTlbHandle::configure` programs *authoritative device TLB registers*
+via BAR0 with a reprogram-per-access pattern that is only safe under the in-process
+`device_lock_`. Two concurrent clients would stomp each other. **Fix:** server owns TLB
+allocation, or per-access reprogram+access becomes one atomic server-side command. (RTL is
+unaffected — its TLB config is pure client-side address arithmetic, never latched in the
+device.)
+
+### 6.4 Concurrency semantics
+
+**Recommended — match silicon: per-command atomicity, no multi-command/cross-client
+transactions.** A single server-side command loop (one device-owner thread draining a queue,
+fed by per-client readers) gives this for free and avoids the DMA-callback reentrancy
+deadlock a lock-based design would hit. The per-process `device_lock_` is **not** sufficient
+cross-client — serialization moves server-side. Don't offer client-held device-wide locks
+(diverges from silicon; lets one client wedge a shared card).
+
+---
+
+## 7. Lifetime & ownership
+
+- **Who starts it:** a standalone `tt-sim-server` daemon (= the card), fronted by a thin
+  `tt-sim-launcher` that does race-free create-or-attach under a per-name `flock`, waits for
+  socket readiness, and cleans up stale tombstones. Keep **lazy auto-spawn opt-in**
+  (`TT_SIM_AUTOSPAWN=1`) so today's one-binary dev/CI workflow survives migration. systemd
+  socket-activation is the most KMD-like option and worth documenting for a shared lab sim,
+  but can't be the baseline (environment constraints).
+- **Who reaps it:** **connection-death-driven refcount + configurable linger.** Default
+  `linger=infinite` for the daemon/handoff path; bounded linger (~30–60s) for autospawn/CI so
+  RTL processes don't leak while still surviving test-to-test handoff. **Reject** instant
+  refcount-to-zero kill (breaks handoff, races). Crashed clients: connection-close = implicit
+  detach (primary signal); heartbeat/lease as backstop for half-open connections.
+- **Orphans:** the server unlinks its own socket+PID on clean exit; tombstones (hard kill) are
+  reclaimed only by the launcher under the folder lock.
+
+> **Decisions:** daemon + launcher vs lazy-spawn default; teardown policy & default linger;
+> who is responsible for the device's initial reset/power state on creation.
+
+---
+
+## 8. Protocol changes (`simulation_device.fbs`)
+
+- **Add:** `ATTACH`/`ATTACH_REPLY` (versioned handshake + device facts + serialized
+  `ClusterDescriptor` + server-assigned client id), `DETACH`, `GET_DEVICE_INFO`,
+  `SYSMEM_READ`/`SYSMEM_WRITE` (§6.1), `BARRIER`/flush-ack (membar = "wait for my outstanding
+  write acks"), privileged `CLOCK_ADVANCE`/`PAUSE`, a generic `ERROR`/status field, a
+  per-client monotonic `request_id`.
+- **Remove:** the per-client `START` and the `EXIT`-as-ready-ack hack; `EXIT`/destroy becomes
+  launcher/SIGTERM-only.
+- **Versioning is mandatory.** There is already an in-tree op-code **tag collision**
+  (`simulation_device.fbs:14-17`, AXI notifications vs NEO_DM resets) to resolve, plus
+  **cross-repo coordination** with the simulator release — `run.sh` must implement the
+  listener/server side.
+
+---
+
+## 9. State ownership audit (what breaks handoff if left client-side)
+
+**Must move to the server (authoritative, mutable):** simulator core (already, RTL); host
+sysmem backing + RAM callbacks (§6.1); TTSim TLB programming/allocation (§6.3); cross-process
+serialization (replaces in-process `device_lock_`); reset/power state ownership.
+
+**Re-fetch on attach (read-only — query, never set):** arch, SocDescriptor (validate, don't
+impose), BAR0/BAR4 bases, `tlb_region_size_`, `libttsim_pci_device_id`, num host channels,
+current reset/power state.
+
+**Keep client-local (connection bookkeeping):** notification thread + command queue, the
+(now-dialing) socket, RTL TLB allocator/window/config, per-client lock, selected NOC id
+(carried per-command — verify the wire protocol carries it per op).
+
+---
+
+## 10. Proposed phasing
+
+1. **Protocol + role inversion + transport.** Unix socket in a folder; `pair1` → per-client
+   connections; split `RtlSimCommunicator::initialize()` into spawn-side vs dial-side; add
+   `ATTACH`/`DETACH`; stop sending `EXIT` on client teardown.
+   *Interim de-risking option:* a **UMD-side broker** (UMD owns a server process; sim stays a
+   1:1 dialer behind it) delivers N:1 with **zero simulator changes**, then later collapses
+   into the sim.
+2. **Server-resident sysmem (§6.1)** — the correctness gate for real handoff.
+3. **Discovery + Cluster integration** — `SimulationTopologyDiscovery`, `ClusterOptions`
+   attach fields, `SimulationClientTTDevice`, server-served `ClusterDescriptor`.
+4. **Lifetime tooling** — `tt-sim-server` + `tt-sim-launcher`, refcount/linger, stale cleanup.
+5. **Clock policy (§6.2)** — free-running default + single-client stepped lease; audit tests.
+6. **TTSim-as-server (optional, later)** — TLB ownership fix (§6.3) + IPC under TTSimCommunicator.
+
+---
+
+## 11. Decisions to make in this meeting
+
+0. Do we accept the **role inversion** (simulator = server/owner, UMD = client)? (§2)
+1. **Sysmem:** server-resident — proxy-everything vs `shm` zero-copy fast path? (§6.1)
+2. **Clock:** default free-running? Who audits existing tests for `advance_clock` dependence? (§6.2)
+3. **Lifetime:** explicit daemon+launcher vs lazy-spawn default; teardown policy & default
+   linger; who owns the device's initial reset/power state. (§7)
+4. **Transport:** unix-socket-only, or keep TCP for remote sim? Drop nng for raw sockets? (§4, §2)
+5. **Scope/order:** RTL-only first with TTSim deferred? Build the **broker** interim first? (§3, §10)
+6. **Cross-repo:** who owns the simulator-side (`run.sh`) server implementation and the
+   protocol version contract? (§8)
+
+## Open questions (lower priority / follow-up)
+
+- Multi-user folder permissions — is cross-user attach ever wanted? (per-UID folder forbids
+  it by default).
+- Sim crash mid-handoff = state lost (no silicon equivalent). Snapshot/checkpoint desirable,
+  or accept "restart fresh" for v1?
+- Heartbeat/lease TTL vs RTL command latency (avoid false-positive reaping of a busy client).

--- a/docs/SIMULATION_SERVER_PROCESS.md
+++ b/docs/SIMULATION_SERVER_PROCESS.md
@@ -251,6 +251,10 @@ multi-client sharing requires. The capability surface:
 - **Device memory access.** Read and write device memory addressed by (endpoint, address,
   size) — core-local memory, DRAM, registers, and multicast writes. This is the bulk of the
   traffic.
+- **TLB windows (NOC translation).** Allocate, configure (aim a window at an endpoint), and
+  free NOC translation windows through which device access is routed. The window state lives in
+  the server, but the API **exposes TLB handling** so the client manages windows the same way it
+  does on silicon; windows are a per-session resource.
 - **Host memory (sysmem).** A client **allocates** a host-visible memory region through the API
   (and frees it), then reads/writes it; the server provides the backing and a device-visible
   address so the device can transfer to and from it. Allocation is a **runtime** operation, not
@@ -281,3 +285,51 @@ Cross-cutting properties of the API:
 - **Request/response** — synchronous from the client's point of view.
 - **Backend-agnostic** — identical for RTL and TTSim; the backend difference stays below the
   API.
+
+---
+
+## 9. Implementation: client/server code split
+
+*(Unlike the sections above, this one is about code, so it names concrete components.)*
+
+The existing simulation stack is `Cluster → SimulationChip → TTDevice (sim) → communicator →
+backend`. Splitting it across the connection follows one rule: **device state and one-time
+device bring-up move to the server; the consumer-facing device API, stateless translation, and
+per-client connection bookkeeping stay on the client.** Litmus test — if it must survive a
+client exiting (handoff), it's server-side; if it's per-client or pure computation, it's
+client-side.
+
+### Moves to the server ("the card")
+
+- **The backend and the code that drives it** — the backend-facing half of the communicator
+  (loading/calling the TTSim `.so`, or managing the RTL sim process and its socket). This
+  becomes the server's internals.
+- **Device state** — L1/DRAM/registers/reset state; inherent to the backend.
+- **Sysmem backing** — `SimulationSysmemManager`'s memory and the device's host-memory access
+  path. Allocated **per session** at the server, since sysmem is a runtime API operation (§8).
+- **TLB window state** — `SimulationTlbAllocator` / TLB programming. The window state (and, for
+  TTSim, the real TLB registers) lives in the server; the client drives allocation/configuration
+  through the exposed TLB API (§8) rather than managing windows locally.
+- **One-time init/start, reset, and power-state ownership** — runs once at creation.
+- **Cross-client serialization** — today's in-process device lock becomes a server concern (one
+  stateful backend, many clients).
+- **Device-description authority** — arch, SoC descriptor, cluster topology: fixed at server
+  creation and reported to clients on attach (the client only reads them).
+
+### Stays on the client ("UMD")
+
+- **`Cluster` and the `Chip`/`TTDevice` API surface** UMD consumers call. Same interface — only
+  the implementation changes to forward operations over the connection.
+- **Coordinate translation** (`CoreCoord` → NOC) and address computation — stateless; stays
+  client-side using the server-provided descriptor (keeps the client close to silicon).
+- **A connecting communicator** — the client half that turns device operations into API
+  requests, owns the session, correlates responses, and notices disconnects.
+- **The client's local copy of identity/topology** — read from the server on attach (not
+  authored), used for translation.
+- **Per-session sysmem handles** — the allocation lives server-side; the client holds the
+  reference / device-visible address.
+- **Per-session TLB window handles** — the window state is server-side; the client allocates and
+  configures windows via the TLB API (§8) and holds the references.
+
+The target shape: the client collapses into a **thin adapter** mapping the existing device
+operations onto API calls, so UMD consumers see no change.

--- a/docs/SIMULATION_SERVER_PROCESS.md
+++ b/docs/SIMULATION_SERVER_PROCESS.md
@@ -195,3 +195,27 @@ kills the simulator). Teardown becomes a deliberate act of whoever *owns* the ca
 
 > **Decision:** explicit-owner teardown, a linger policy, or both (different defaults for
 > interactive vs CI)? What is the default linger?
+
+### 6.4 Resetting to a clean slate
+
+Persisting state across attach/detach is the default (it's what enables handoff), but a client
+will sometimes want a **fresh device** — power-on defaults, nothing left over from a previous
+run. Because state lives in the server, "clean slate" is a deliberate, separate action, never
+a side effect of attaching (this preserves the **attach ≠ initialize** rule from §6.1).
+
+Two granularities, which can coexist:
+
+- **Restart the server** — tear the card down and create a new one. The simplest, most
+  total clean slate; it's just teardown (§6.3) followed by create (§6.1).
+- **Reset in place** — an explicit operation on a *running* server that re-runs the one-time
+  power-on init/reset and returns device state to defaults, without dropping the process or
+  forcing every client to reconnect.
+
+The important property either way: a reset is **destructive and shared** — it wipes the state
+that *all* currently attached clients are using. So it must be an explicit, privileged action
+(requested by the owner, or by a client that knowingly opts in), and it cannot be the quiet
+default behavior of opening the device.
+
+> **Decision:** do we need in-place reset, or is "restart the server for a clean slate" enough?
+> Who is allowed to trigger a reset, and what is the contract for other clients that are
+> attached when it happens (forcibly detached, notified, or silently see reset state)?

--- a/docs/SIMULATION_SERVER_PROCESS.md
+++ b/docs/SIMULATION_SERVER_PROCESS.md
@@ -3,8 +3,9 @@
 **Status:** Draft for discussion · **Issue:** [#2677](https://github.com/tenstorrent/tt-umd/issues/2677)
 
 This document frames the problem and lays out the design decisions we need to make to run
-the simulator **persistently, as a server process** — decoupled from the lifetime of any
-single UMD client. It is meant to drive a design discussion, not to prescribe a final
+the simulator as a **shared, hosted device** — one UMD process (the **host**) owns the
+simulator and serves other UMD clients, so the device is decoupled from the lifetime of any
+single *non-owner* client. It is meant to drive a design discussion, not to prescribe a final
 implementation.
 
 ---
@@ -22,8 +23,12 @@ behave like silicon instead:
   and continues from exactly that state. The device is the source of truth; clients are
   ephemeral.
 
-This is precisely the silicon contract: the card sits in a PCIe slot, **KMD** enumerates it,
-and any process can open/share it. The card's lifetime is independent of any user process.
+This is the silicon contract: the card sits in a PCIe slot, **KMD** enumerates it, and any
+process can open/share it. We approximate it with a **host UMD process** that owns the
+simulator and serves other UMD clients over a local socket. The device's lifetime is therefore
+tied to that **host** process — but independent of every *non-owner* client: clients attach,
+share, and hand off freely while the host stays up. (Full silicon-faithful, host-independent
+lifetime — surviving the host's exit — is explicitly out of scope for now; see §6 and §7.)
 
 ## 2. Where we are today
 
@@ -45,30 +50,48 @@ UMD has two simulator backends:
 
 So "make it a server" is really **three coupled changes**, none optional:
 
-1. **Invert the roles** — the simulator (or a broker in front of it) becomes the "card"; UMD
-   becomes a client that connects to it.
+1. **Invert the roles** — one UMD process (the **host**) owns the simulator and *is* the "card";
+   other UMD processes become clients that connect to it.
 2. **Allow many clients** — move from a single point-to-point connection to one that accepts
    multiple clients (this is also what lets us notice when a client disconnects or crashes).
-3. **Move ownership out of UMD** — a client going away must no longer tear the device down.
+3. **Decouple the device from non-owner clients** — a *non-owner* client going away must no
+   longer tear the device down; only the host's exit ends the device.
 
 ## 3. Scope
 
 **Both simulation backends — RTL/emu and TTSim — are targets.** The end state is that either
-backend can run as a shared, persistent server. They differ only in how much work it takes to
-get there:
+backend can be hosted by a UMD process and shared with other clients. The new work — a
+**client-facing socket API** in front of the device — is the **same for both backends**; the
+backend stays exactly where it sits today *relative to the host UMD process*:
 
-- **RTL/emu** already runs out-of-process over a socket, so the server is a direct extension
-  of what exists today — the smaller lift.
-- **TTSim** runs inside the UMD process today, so making it a server means introducing a
-  process boundary where there is none. This carries a performance cost (in-process calls
-  become cross-process) — a larger lift, but in scope, not optional.
+- **RTL/emu** already runs as a separate process the host UMD launches and talks to over a
+  socket; that stays an internal detail of the host.
+- **TTSim** runs in-process; under this model it **stays in-process to the host** — we do *not*
+  introduce a new boundary inside it. The host keeps its native fast path; only **remote
+  clients** reach the device cross-process, over the client-facing socket.
 
-Both backends should sit behind the **same** client-facing path so the server model is
-uniform; the backend difference stays below the connection, invisible to clients.
+So the performance cost (in-process calls becoming cross-process) is paid by **remote clients**,
+for either backend, and never by the host for its own access. Both backends sit behind the
+**same** client-facing path so the model is uniform; the backend difference stays below the
+connection, invisible to clients.
+
+**Initial scope (first iteration).** We build this incrementally. The first iteration targets a
+**single server at a fixed socket location**: opening either attaches to the host already at
+that path or, if none is live, creates it and becomes the host (**open-or-attach**). The
+connect-probe at the fixed path *is* the create-vs-attach decision; liveness is simply whether
+that socket is connectable, and a stale socket is reclaimed (refused → unlink → bind). Surfacing
+still happens — the host binds a socket — but at a fixed path, so this **defers multi-device
+discovery (§4)**: no folder scan, no filename-encoded identity, no enumeration, because the
+location is known and singular. Multi-device discovery and richer device selection (§4) are
+follow-on work.
 
 ---
 
 ## 4. Surfacing & discovery (the "KMD analog")
+
+> **Future work — out of scope for the first iteration**, which uses a single server at a fixed
+> socket location with no discovery (see *Initial scope* in §3). This section records the
+> eventual multi-device model.
 
 Surface each simulated device as a **file in a well-known folder** — one file per device,
 discovered by scanning the folder. This mirrors how KMD exposes silicon devices for
@@ -77,8 +100,8 @@ enumeration.
 - **Folder.** A well-known, per-user location (so devices of different users don't collide).
 - **Identity.** Each file's name carries enough identity — which device/cluster it belongs to,
   its architecture — for a client to choose a device before connecting.
-- **Liveness.** A file may be left behind after a server dies, so a file's *existence* does not
-  prove a server is alive behind it. A client confirms liveness before relying on a device,
+- **Liveness.** A file may be left behind after a host dies, so a file's *existence* does not
+  prove a host is alive behind it. A client confirms liveness before relying on a device,
   and a stale leftover can be safely reclaimed. (This is the equivalent of "is the card really
   there?" — a filename alone can't guarantee it, the way an enumerated silicon device does.)
 - **Discovery component.** We need a **`SimulationTopologyDiscovery`** that scans the folder,
@@ -89,73 +112,96 @@ enumeration.
 
 ## 5. The client/UMD side
 
-In the server model the client path is **uniform: UMD always attaches to a server.** There is
-no per-call "spawn vs connect" mode — opening a simulated device always means connecting to a
-server and attaching, the same single path for both backends. This keeps the client close to
-the silicon device-open path, which likewise just *opens* an already-present device.
+Opening a simulated device is a **single, uniform call** for the consumer. Under the hood it
+resolves to one of two roles, decided by whether a **live host** already exists for that device
+(§4 liveness):
 
-- **Attach ≠ initialize.** Today initialization happens as part of launching the simulator. In
-  the server model, one-time init and power-on reset happen **once, at card creation** — never
-  per client. A client only ever performs a **non-mutating** attach: opening the device issues
-  no state-changing operations ("opening an already-up card doesn't reset it").
-- **Server is the single source of truth for topology/identity.** On attach the client *reads*
-  the device's identity and cluster topology from the server rather than synthesizing its own —
+- **No live host → this process becomes the host.** It creates the device, runs one-time init,
+  and starts serving the socket API — *and* then uses the device normally, like any client.
+- **Live host exists → this process attaches as a client** over the socket.
+
+This keeps the client close to the silicon device-open path, which likewise just *opens* an
+already-present device — the create-vs-attach decision is invisible to the consumer.
+
+- **Open modes.** Most callers want **open-or-create** (above). A triage-style caller wants
+  **attach-only** — fail if no live host exists — so it inspects a running device and never
+  accidentally spawns one.
+- **Attach ≠ initialize (for clients).** One-time init and power-on reset happen **once**, when
+  the **host** creates the device — never on a client attach. A client only ever performs a
+  **non-mutating** attach: it issues no state-changing operations ("opening an already-up card
+  doesn't reset it"). The host is the sole initializer.
+- **Host is the single source of truth for topology/identity.** On attach a client *reads* the
+  device's identity and cluster topology from the host rather than synthesizing its own —
   mandatory for handoff, so every client sees an identical device shape.
-- **Legacy spawn-and-own stays separate.** Today's coupled behavior (UMD launches and owns the
-  simulator directly, one-to-one) remains available unchanged for back-compat; it is not
-  folded into the attaching client (see §6.1).
+- **Non-serving (legacy) mode.** A process can also open the device purely locally — no socket,
+  serving nobody — which is behaviorally today's one-to-one path. This is just the host model
+  with no clients, not a separate architecture; kept for back-compat and the simplest runs.
 
 ---
 
 ## 6. Proposed solution & architecture
 
-The simulator runs as a **persistent server process that *is* the device** ("the card"): it
-owns all device state and outlives any individual UMD client. UMD instances are clients that
-**attach** to it, do work, and **detach** — exactly the relationship a process has with a
-silicon card sitting in a PCIe slot. This section covers how a client connects; §7 covers the
-server's lifecycle (starting, stopping, clean slate) and §8 the API.
+One **host UMD process** owns the simulator and *is* the device ("the card"): it holds all
+device state, runs the backend, and serves other UMD processes over a **UNIX domain socket**.
+Crucially, the host reaches the device **directly, in-process** — calling the backend (e.g. the
+TTSim `.so`) with no socket and no serialization — so the owning process keeps the fastest
+possible path; the socket exists **only** for remote clients, who pay the cross-process cost.
+There is no separate broker or bespoke server binary — the host is an ordinary UMD process that,
+on opening a device for which no live host exists, also starts serving. A host launched purely
+to serve (by a person, a CI step, or a service) — doing no workload of its own — *is* a
+"dedicated simulator server," via the same code path. Other UMD processes are clients that
+**attach**, do work, and **detach**. The device's lifetime is tied to the host process (§7);
+cross-host persistence is out of scope for now. This section covers how a client connects; §7
+covers lifecycle (starting and stopping) and §8 the API.
 
-### 6.1 How UMD connects to the server
+### 6.1 How UMD opens a device
 
-Connecting should mirror how UMD opens a silicon device:
+Opening mirrors how UMD opens a silicon device, with the create-vs-attach decision (§5) made
+under the hood:
 
 - **Discovery.** Devices are surfaced in a well-known folder (§4) — the analog of how KMD
   exposes silicon cards for discovery. UMD scans that folder to enumerate available simulated
   devices, honoring the same device-selection semantics it already uses for silicon.
-- **Open = attach.** UMD picks a device and attaches to it. The attach is a **non-mutating**
-  handshake: UMD learns the device's identity and topology *from the server* and registers
-  itself — it does not reset or re-initialize anything.
-- **Liveness.** A listed device may be stale (server gone); UMD treats a successful attach as
-  the proof of liveness, the same way opening a silicon device confirms it is really there.
+- **Open (create or attach).** UMD picks a device. If no live host serves it, this process
+  **becomes the host** — creates the device, initializes once, and binds the UNIX socket. If a
+  live host exists, UMD **attaches** to it: a **non-mutating** handshake where UMD learns the
+  device's identity and topology *from the host* and registers itself, resetting nothing. A
+  caller may request **attach-only** to require an existing host (triage) or **open-or-create**
+  (the default).
+- **Liveness.** A listed device may be stale (host gone); UMD treats a successful attach as the
+  proof of liveness, the same way opening a silicon device confirms it is really there. A stale
+  entry is reclaimed and, under open-or-create, replaced by a freshly hosted device.
 
 The net effect: from UMD's perspective "find a simulated device and open it" looks the same as
 finding and opening a silicon device — which is what keeps the client path close to silicon.
 
 ---
 
-## 7. Starting & stopping the server
+## 7. Starting & stopping the host
 
-The card's lifetime is **independent of any client** — that is the whole point (shareability +
-state handoff). This section covers how the server comes into existence, how it goes away, and
-how a client can demand a fresh one.
+The device's lifetime is tied to the **host** process — independent of every *non-owner*
+client, but not of the host (shareability holds always; handoff holds while the host is up).
+This section covers how the host comes into existence and how it goes away.
 
-### 7.1 Starting the server
+### 7.1 Starting the host
 
-The server is brought up **explicitly** — there is no auto-spawn:
+There is no separate spawn step: the host comes into existence as the **first open-or-create**
+of a device for which no live host exists (§5, §6.1).
 
-- **Created explicitly by an owner.** It is started out-of-band — by a person, a CI step, or a
-  service — *before* any UMD process attaches, and stays up across many attach/detach cycles.
-  This is the faithful silicon model (the card is already powered and enumerated before
-  software touches it) and the one that cleanly supports state handoff between separate UMD
-  processes. The owner is simply whoever created it.
-- **Legacy mode (back-compat).** Today's behavior — UMD launches and owns the simulator
-  directly (one-to-one, coupled lifetime, no server) — remains available as a transition path
-  for anyone not yet on the server model.
+- **The first opener becomes the host.** Whoever opens a device that has no live host creates
+  it, initializes it once, binds the UNIX socket, and serves from then on. The "owner" is simply
+  that process. A host stays up across many attach/detach cycles by *non-owner* clients.
+- **A dedicated server is just a host with no workload.** Launching a UMD process — by a
+  person, a CI step, or a service — whose only job is to open-or-create the device and idle
+  gives you a long-lived shared "card," through the exact same path. This is the closest
+  analog to silicon (powered and enumerated before software touches it).
+- **Non-serving runs.** A process may also open the device without serving (no socket) — today's
+  one-to-one behavior — for back-compat and the simplest runs (§5).
 
-**What creating a server takes.** Creation fully specifies *what device this is*. Everything
-here is fixed **once, at creation**, and then **served to every client** on attach — clients
-read it, never supply it. This is what makes the server the single source of truth and keeps
-every client's view identical, which handoff depends on.
+**What creating the device takes.** The creating (host) process fully specifies *what device
+this is*. Everything here is fixed **once, at creation**, and then **served to every client** on
+attach — clients read it, never supply it. This is what makes the host the single source of
+truth and keeps every client's view identical, which handoff depends on.
 
 - **Which simulator to run** — the backend (RTL/emu or TTSim) and the specific simulator build
   to bring up. *(Open: whether this is part of the create request itself or a property of the
@@ -178,85 +224,70 @@ publish the device's discovery entry under its minted identity, and only then be
 attaches — a client never sees a half-initialized card. This is the one-time init that the
 **attach ≠ initialize** rule (§5) keeps separate from every client's attach.
 
-### 7.2 Stopping the server
+### 7.2 Stopping the host
 
-Because the card's lifetime is decoupled from clients, **a client detaching or exiting must
-never tear the server down** (this is the key change from today, where a client going away
-kills the simulator). Stopping is its own action, exposed **in the UMD API and callable by any
-client** — it is a shared capability, not restricted to the creator.
+The key change from today: **a non-owner client detaching or exiting must never tear the device
+down** (today a client going away kills the simulator). The device goes away only when the
+**host** does.
 
 **Teardown triggers — when the card shuts down:**
 
-- **Explicit stop** — any client asks the server to shut down, through the UMD API.
-- **Policy-based** — e.g. linger for a grace period after the last client detaches, then exit;
-  or stay up indefinitely for a long-lived shared card. A bounded linger keeps CI from leaking
-  server processes while still surviving the brief gap during a process-to-process handoff.
+- **Host exit** — the host process exiting (its own workload finishes) or crashing tears the
+  device down. This is the primary teardown path, and the source of the lifetime coupling: no
+  ownership transfer, so when the host is gone the device is gone.
+- **Explicit stop** — a shutdown request through the UMD API. *(Open: because the host may be
+  running its own workload, whether a non-owner client may force the host to stop — versus the
+  host being the only one that decides — is to be decided.)*
+- **Policy-based** — for a serving host with no workload of its own, e.g. linger for a grace
+  period after the last client detaches, then exit; or stay up indefinitely. A bounded linger
+  keeps CI from leaking host processes while still surviving the brief gap during a
+  process-to-process handoff.
 
 **Behavior with clients still attached — to be decided.** What a stop should do when clients
 are still attached (graceful drain, forceful, or refuse-if-busy) is left open for a later
 discussion. Regardless of the choice, a client whose card disappears must **surface an error,
 not hang** (the same contract as a silicon card that vanishes).
 
-**Cleanup.** A graceful stop removes the device's discovery entry and tears down the backend,
-leaving the folder clean. An unclean exit (crash / hard kill) leaves a stale entry, reclaimed
-by the **liveness** mechanism (§4) — so the two paths are complementary.
+**Cleanup.** A graceful host exit removes the device's discovery entry and tears down the
+backend, leaving the folder clean. An unclean exit (crash / hard kill) leaves a stale entry,
+reclaimed by the **liveness** mechanism (§4) — so the two paths are complementary.
 
-**State.** Stopping the server **destroys all device state** — the card powers off. This is
-distinct from a clean-slate *reset* (§7.3), which keeps the server running and only resets
-state. Stopping a server that is already gone is a clean no-op.
+**State.** Host exit **destroys all device state** — the card powers off. Stopping a host that
+is already gone is a clean no-op.
 
-**Client accounting.** The card tracks how many clients are attached, because the policy above
-depends on knowing when the last one leaves. A clean exit detaches and releases its reference;
-a **crashed** client never sends that detach, so the server detects the dropped connection and
-releases the reference on its behalf. Crash detection is *only* bookkeeping — a crash is
-treated exactly like a clean detach (release one reference, nothing more), so it neither leaks
-a reference (keeping the card alive forever) nor wrongly brings the card down.
-
-### 7.3 Resetting to a clean slate
-
-Persisting state across attach/detach is the default (it's what enables handoff), but a client
-will sometimes want a **fresh device** — power-on defaults, nothing left over from a previous
-run. Because state lives in the server, "clean slate" is a deliberate, separate action, never a
-side effect of attaching (this preserves the **attach ≠ initialize** rule from §5).
-
-Two granularities, which can coexist:
-
-- **Restart the server** — tear the card down and create a new one. The simplest, most total
-  clean slate; it's just stopping (§7.2) followed by starting (§7.1).
-- **Reset in place** — an explicit operation on a *running* server that re-runs the one-time
-  power-on init/reset and returns device state to defaults, without dropping the process or
-  forcing every client to reconnect.
-
-The important property either way: a reset is **destructive and shared** — it wipes the state
-that *all* currently attached clients are using. So it must be an explicit action (requested by
-a client that knowingly opts in), and it cannot be the quiet default behavior of opening the
-device.
+**Client accounting.** The host tracks how many clients are attached, because the linger policy
+depends on knowing when the last one leaves. A clean detach releases the client's reference; a
+**crashed** client never sends that detach, so the host detects the dropped socket connection
+and releases the reference on its behalf. Crash detection is *only* bookkeeping — a crash is
+treated exactly like a clean detach (release one reference, nothing more). Note this accounting
+governs the linger policy, **not** the device's life: the device still dies if the *host* exits,
+regardless of attached-client count.
 
 ---
 
-## 8. The UMD ↔ server API
+## 8. The UMD ↔ host API
 
-The API is the contract every client uses to talk to the card. Guiding principle: it should
-expose the **same device operations UMD already performs against silicon**, so the client
-stays a thin pass-through and the path stays close to silicon — *plus* the session verbs that
-multi-client sharing requires. The capability surface:
+The API is the contract every client uses to talk to the card over the **UNIX domain socket**.
+Guiding principle: it should expose the **same device operations UMD already performs against
+silicon**, so the client stays a thin pass-through and the path stays close to silicon — *plus*
+the session verbs that multi-client sharing requires. The capability surface:
 
 - **Session.** Attach and detach. Attach is **non-mutating**: it registers the client and
   returns the device description (below); detach releases it. These verbs are what make
   multi-client access and reference-counting (§7.2) work.
 - **Device description / identity.** A query — answered at attach — for architecture, board,
   cluster topology, and memory layout: everything a client must *read* rather than assume.
-  This is what makes the server the single source of truth and keeps every client's view
+  This is what makes the host the single source of truth and keeps every client's view
   identical (required for handoff).
 - **Device memory access.** Read and write device memory addressed by (endpoint, address,
   size) — core-local memory, DRAM, registers, and multicast writes. This is the bulk of the
   traffic.
 - **TLB windows (NOC translation).** Allocate, configure (aim a window at an endpoint), and
   free NOC translation windows through which device access is routed. The window state lives in
-  the server, but the API **exposes TLB handling** so the client manages windows the same way it
+  the host, but the API **exposes TLB handling** so the client manages windows the same way it
   does on silicon; windows are a per-session resource.
 - **Host memory (sysmem).** A client **allocates** a host-visible memory region through the API
-  (and frees it), then reads/writes it; the server provides the backing and a device-visible
+  (and frees it), then reads/writes it; the host provides the backing and a device-visible
   address so the device can transfer to and from it. Allocation is a **runtime** operation, not
   fixed at creation — mirroring how host memory is pinned on demand on silicon. These regions
   are a **per-session** resource, released when the client detaches; unlike device memory they
@@ -264,11 +295,11 @@ multi-client sharing requires. The capability surface:
 - **Run / reset control.** Assert/deassert core resets and start execution. These are normal
   operations a client may issue while attached; what's special is only that *attaching* never
   implicitly resets (§5).
-- **Execution / time.** Because the clock is server-owned and free-running, advancing time is a
-  server concern, not a per-client knob; any stepped/deterministic mode is a global operation.
+- **Execution / time.** Because the clock is host-owned and free-running, advancing time is a
+  host concern, not a per-client knob; any stepped/deterministic mode is a global operation.
   This group is simulation-specific and has no silicon analog.
-- **Management / clean slate.** Reset-to-clean-slate (§7.3) and shutdown (§7.2) — kept distinct
-  from normal per-client operations because they affect *all* attached clients.
+- **Management.** Shutdown (§7.2) — kept distinct from normal per-client operations because it
+  affects *all* attached clients.
 
 Explicit ordering/synchronization (memory barriers) is intentionally **not** part of the API:
 operations apply synchronously and in order before the response returns, so there is nothing to
@@ -276,7 +307,13 @@ flush — the simulator's memory barriers are already no-ops today.
 
 Cross-cutting properties of the API:
 
-- **Per-client sessions** — the server attributes every operation to a client, so it can
+- **The host is not a client of its own API.** This API and its UNIX socket are the **remote
+  path only**. The host reaches the device **directly, in-process** — calling the backend (e.g.
+  the TTSim `.so`) with no socket and no serialization — so the owning process keeps the
+  fastest possible path. The same backend operations are reachable two ways: directly (host)
+  and over the socket (clients); the socket layer just marshals remote requests into those same
+  operations.
+- **Per-client sessions** — the host attributes every operation to a client, so it can
   reference-count and notice disconnects.
 - **Per-operation atomicity, no cross-client transactions** — each operation completes
   atomically against shared state, but no client can lock the card across multiple operations.
@@ -288,48 +325,68 @@ Cross-cutting properties of the API:
 
 ---
 
-## 9. Implementation: client/server code split
+## 9. Implementation: client/host code split
 
 *(Unlike the sections above, this one is about code, so it names concrete components.)*
 
 The existing simulation stack is `Cluster → SimulationChip → TTDevice (sim) → communicator →
-backend`. Splitting it across the connection follows one rule: **device state and one-time
-device bring-up move to the server; the consumer-facing device API, stateless translation, and
-per-client connection bookkeeping stay on the client.** Litmus test — if it must survive a
-client exiting (handoff), it's server-side; if it's per-client or pure computation, it's
-client-side.
+backend`. The split introduces a **seam at the communicator**: everything *above* it — the
+device API surface and stateless translation — runs unchanged in **every** process, host and
+client alike. *Below* the seam the communicator has **two backings**:
 
-### Moves to the server ("the card")
+- **Direct backing (host).** Calls the backend in-process — loads/calls the TTSim `.so`, or
+  drives the RTL sim process — with no socket and no serialization. This is the host's own fast
+  path (§6, §8).
+- **Socket backing (client).** Marshals the same device operations into API requests over the
+  UNIX socket to the host, correlates responses, and notices disconnects.
+
+The host process contains **both**: the shared device API on top (for its own workload, using
+the direct backing) *and* the host-only internals below (backend, device state, and the serving
+layer that exposes the socket backing to remote clients). A pure client process contains only
+the shared API plus the socket backing.
+
+Litmus test — if it must survive a *non-owner* client exiting, it's a **host internal**; if it's
+the consumer API or pure computation, it runs **in every process**; if it's per-connection
+bookkeeping, it's **per client**.
+
+### Host internals ("the card") — present only in the host process
 
 - **The backend and the code that drives it** — the backend-facing half of the communicator
-  (loading/calling the TTSim `.so`, or managing the RTL sim process and its socket). This
-  becomes the server's internals.
+  (loading/calling the TTSim `.so`, or managing the RTL sim process and its socket).
+- **The serving layer** — accepts client connections on the UNIX socket and dispatches their
+  requests into the same backend operations the host calls directly.
 - **Device state** — L1/DRAM/registers/reset state; inherent to the backend.
 - **Sysmem backing** — `SimulationSysmemManager`'s memory and the device's host-memory access
-  path. Allocated **per session** at the server, since sysmem is a runtime API operation (§8).
+  path. Allocated **per session** at the host, since sysmem is a runtime API operation (§8).
 - **TLB window state** — `SimulationTlbAllocator` / TLB programming. The window state (and, for
-  TTSim, the real TLB registers) lives in the server; the client drives allocation/configuration
+  TTSim, the real TLB registers) lives in the host; clients drive allocation/configuration
   through the exposed TLB API (§8) rather than managing windows locally.
-- **One-time init/start, reset, and power-state ownership** — runs once at creation.
-- **Cross-client serialization** — today's in-process device lock becomes a server concern (one
-  stateful backend, many clients).
-- **Device-description authority** — arch, SoC descriptor, cluster topology: fixed at server
-  creation and reported to clients on attach (the client only reads them).
+- **One-time init/start and power-state ownership** — runs once, when the host creates the
+  device.
+- **Cross-client serialization** — today's in-process device lock becomes a host concern (one
+  stateful backend, the host's own access plus many clients).
+- **Device-description authority** — arch, SoC descriptor, cluster topology: fixed at creation
+  and reported to clients on attach (clients only read them).
 
-### Stays on the client ("UMD")
+### Runs in every process ("UMD")
 
-- **`Cluster` and the `Chip`/`TTDevice` API surface** UMD consumers call. Same interface — only
-  the implementation changes to forward operations over the connection.
-- **Coordinate translation** (`CoreCoord` → NOC) and address computation — stateless; stays
-  client-side using the server-provided descriptor (keeps the client close to silicon).
-- **A connecting communicator** — the client half that turns device operations into API
-  requests, owns the session, correlates responses, and notices disconnects.
-- **The client's local copy of identity/topology** — read from the server on attach (not
-  authored), used for translation.
-- **Per-session sysmem handles** — the allocation lives server-side; the client holds the
+- **`Cluster` and the `Chip`/`TTDevice` API surface** UMD consumers call. Same interface;
+  underneath, the communicator uses the direct backing (host) or the socket backing (client).
+- **Coordinate translation** (`CoreCoord` → NOC) and address computation — stateless; uses the
+  device descriptor (host-authored, client-read) — keeps the path close to silicon.
+- **The local copy of identity/topology** — authored by the host at creation; read by clients
+  on attach; used for translation.
+
+### Per client only
+
+- **The socket backing of the communicator** — owns the session, correlates responses, and
+  notices disconnects. Absent in a pure-host (no-workload) configuration that issues no device
+  ops of its own.
+- **Per-session sysmem handles** — the allocation lives in the host; the client holds the
   reference / device-visible address.
-- **Per-session TLB window handles** — the window state is server-side; the client allocates and
+- **Per-session TLB window handles** — the window state is in the host; the client allocates and
   configures windows via the TLB API (§8) and holds the references.
 
-The target shape: the client collapses into a **thin adapter** mapping the existing device
-operations onto API calls, so UMD consumers see no change.
+The target shape: a remote client collapses into a **thin adapter** mapping the existing device
+operations onto socket API calls, while the host runs those same operations directly — so UMD
+consumers see no change either way.

--- a/docs/SIMULATION_SERVER_PROCESS.md
+++ b/docs/SIMULATION_SERVER_PROCESS.md
@@ -192,11 +192,10 @@ client** — it is a shared capability, not restricted to the creator.
   or stay up indefinitely for a long-lived shared card. A bounded linger keeps CI from leaking
   server processes while still surviving the brief gap during a process-to-process handoff.
 
-**Behavior with clients still attached.** The proposed default is a **graceful drain** — stop
-accepting new attaches, tell attached clients the card is going away, allow a short grace
-window to detach, then exit — with a **hard stop** always available as a fallback. Either way,
-a client whose card disappears must **surface an error, not hang** (the same contract as a
-silicon card that vanishes).
+**Behavior with clients still attached — to be decided.** What a stop should do when clients
+are still attached (graceful drain, forceful, or refuse-if-busy) is left open for a later
+discussion. Regardless of the choice, a client whose card disappears must **surface an error,
+not hang** (the same contract as a silicon card that vanishes).
 
 **Cleanup.** A graceful stop removes the device's discovery entry and tears down the backend,
 leaving the folder clean. An unclean exit (crash / hard kill) leaves a stale entry, reclaimed

--- a/docs/SIMULATION_SERVER_PROCESS.md
+++ b/docs/SIMULATION_SERVER_PROCESS.md
@@ -112,34 +112,10 @@ the silicon device-open path, which likewise just *opens* an already-present dev
 The simulator runs as a **persistent server process that *is* the device** ("the card"): it
 owns all device state and outlives any individual UMD client. UMD instances are clients that
 **attach** to it, do work, and **detach** — exactly the relationship a process has with a
-silicon card sitting in a PCIe slot. Below we work through the questions that decide the
-shape of this: how the server is created, how UMD connects, who tears it down, and how a
-client gets a clean slate.
+silicon card sitting in a PCIe slot. This section covers how a client connects; §7 covers the
+server's lifecycle (starting, stopping, clean slate) and §8 the API.
 
-### 6.1 Lifetime: how is the server created?
-
-UMD always attaches to a server (§5); the card's existence is **independent of any client's
-lifetime** — that is the whole point (shareability + state handoff). What varies is only *how
-the server comes to exist* when a client wants to attach:
-
-- **Created offline (recommended default).** The server is started out-of-band — by a person,
-  a CI step, or a service — *before* any UMD process runs, and stays up across many
-  attach/detach cycles. This is the faithful silicon model (the card is already powered and
-  enumerated before software touches it) and the one that cleanly supports state handoff
-  between separate UMD processes.
-- **Spawned on demand if not active.** If a client goes to attach and finds no live server, it
-  brings one up and then attaches. The spawned server must be **owned independently** of the
-  client that triggered it — it does not die when that client exits, otherwise we are back to
-  lifetime coupling.
-- **Legacy mode (back-compat).** Today's behavior — UMD launches and owns the simulator
-  directly (one-to-one, coupled lifetime, no server) — remains available as a transition path
-  for anyone not yet on the server model.
-
-The invariant across all of these: **creating the device (one-time power-on init/reset) is
-distinct from a client attaching.** The card is initialized once, by whoever creates it; every
-client — including the first — only attaches and never re-initializes state.
-
-### 6.2 How UMD connects to the server
+### 6.1 How UMD connects to the server
 
 Connecting should mirror how UMD opens a silicon device:
 
@@ -155,45 +131,154 @@ Connecting should mirror how UMD opens a silicon device:
 The net effect: from UMD's perspective "find a simulated device and open it" looks the same as
 finding and opening a silicon device — which is what keeps the client path close to silicon.
 
-### 6.3 Who kills the server?
+---
+
+## 7. Starting & stopping the server
+
+The card's lifetime is **independent of any client** — that is the whole point (shareability +
+state handoff). This section covers how the server comes into existence, how it goes away, and
+how a client can demand a fresh one.
+
+### 7.1 Starting the server
+
+The server is brought up **explicitly** — there is no auto-spawn:
+
+- **Created explicitly by an owner.** It is started out-of-band — by a person, a CI step, or a
+  service — *before* any UMD process attaches, and stays up across many attach/detach cycles.
+  This is the faithful silicon model (the card is already powered and enumerated before
+  software touches it) and the one that cleanly supports state handoff between separate UMD
+  processes. The owner is simply whoever created it.
+- **Legacy mode (back-compat).** Today's behavior — UMD launches and owns the simulator
+  directly (one-to-one, coupled lifetime, no server) — remains available as a transition path
+  for anyone not yet on the server model.
+
+**What creating a server takes.** Creation fully specifies *what device this is*. Everything
+here is fixed **once, at creation**, and then **served to every client** on attach — clients
+read it, never supply it. This is what makes the server the single source of truth and keeps
+every client's view identical, which handoff depends on.
+
+- **Which simulator to run** — the backend (RTL/emu or TTSim) and the specific simulator build
+  to bring up. *(Open: whether this is part of the create request itself or a property of the
+  launching environment.)*
+- **The device shape** — architecture and board, the SoC descriptor (core layout / memory
+  map), and the cluster topology (how many chips, their interconnect, harvesting). This can be
+  given **minimally** (architecture + chip count, the rest defaulted) or **explicitly** (a full
+  descriptor for a custom cluster).
+- **Where it is surfaced** — the discovery folder (§4) the device is published into, so clients
+  can find it.
+
+Host memory (sysmem) is deliberately *not* a creation parameter — clients allocate it at
+runtime through the API (§8).
+
+**Identity** is **minted by the simulator** at creation (not supplied by the creator) and
+reported to clients on attach.
+
+**Readiness.** Creation means: bring up the backend, run the one-time power-on init/reset,
+publish the device's discovery entry under its minted identity, and only then begin accepting
+attaches — a client never sees a half-initialized card. This is the one-time init that the
+**attach ≠ initialize** rule (§5) keeps separate from every client's attach.
+
+### 7.2 Stopping the server
 
 Because the card's lifetime is decoupled from clients, **a client detaching or exiting must
 never tear the server down** (this is the key change from today, where a client going away
-kills the simulator). Two separate concerns decide what happens.
+kills the simulator). Stopping is its own action, exposed **in the UMD API and callable by any
+client** — it is a shared capability, not restricted to the creator.
 
-**Teardown triggers — when the card decides to shut down:**
+**Teardown triggers — when the card shuts down:**
 
-- **Explicit stop** — the owner (person/CI/service that created it) shuts it down when done.
-  Natural fit for the offline model.
+- **Explicit stop** — any client asks the server to shut down, through the UMD API.
 - **Policy-based** — e.g. linger for a grace period after the last client detaches, then exit;
   or stay up indefinitely for a long-lived shared card. A bounded linger keeps CI from leaking
   server processes while still surviving the brief gap during a process-to-process handoff.
 
-**Client accounting — keeping an honest count of who is attached:**
+**Behavior with clients still attached.** The proposed default is a **graceful drain** — stop
+accepting new attaches, tell attached clients the card is going away, allow a short grace
+window to detach, then exit — with a **hard stop** always available as a fallback. Either way,
+a client whose card disappears must **surface an error, not hang** (the same contract as a
+silicon card that vanishes).
 
-The card tracks how many clients are attached, because the policies above depend on knowing
-when the last one leaves. A clean exit detaches and releases its reference; a **crashed**
-client never sends that detach, so the server detects the dropped connection and releases the
-reference on its behalf. Crash detection is *only* bookkeeping — a crash is treated exactly
-like a clean detach (release one reference, nothing more), so it neither leaks a reference
-(keeping the card alive forever) nor wrongly brings the card down.
+**Cleanup.** A graceful stop removes the device's discovery entry and tears down the backend,
+leaving the folder clean. An unclean exit (crash / hard kill) leaves a stale entry, reclaimed
+by the **liveness** mechanism (§4) — so the two paths are complementary.
 
-### 6.4 Resetting to a clean slate
+**State.** Stopping the server **destroys all device state** — the card powers off. This is
+distinct from a clean-slate *reset* (§7.3), which keeps the server running and only resets
+state. Stopping a server that is already gone is a clean no-op.
+
+**Client accounting.** The card tracks how many clients are attached, because the policy above
+depends on knowing when the last one leaves. A clean exit detaches and releases its reference;
+a **crashed** client never sends that detach, so the server detects the dropped connection and
+releases the reference on its behalf. Crash detection is *only* bookkeeping — a crash is
+treated exactly like a clean detach (release one reference, nothing more), so it neither leaks
+a reference (keeping the card alive forever) nor wrongly brings the card down.
+
+### 7.3 Resetting to a clean slate
 
 Persisting state across attach/detach is the default (it's what enables handoff), but a client
 will sometimes want a **fresh device** — power-on defaults, nothing left over from a previous
-run. Because state lives in the server, "clean slate" is a deliberate, separate action, never
-a side effect of attaching (this preserves the **attach ≠ initialize** rule from §6.1).
+run. Because state lives in the server, "clean slate" is a deliberate, separate action, never a
+side effect of attaching (this preserves the **attach ≠ initialize** rule from §5).
 
 Two granularities, which can coexist:
 
-- **Restart the server** — tear the card down and create a new one. The simplest, most
-  total clean slate; it's just teardown (§6.3) followed by create (§6.1).
+- **Restart the server** — tear the card down and create a new one. The simplest, most total
+  clean slate; it's just stopping (§7.2) followed by starting (§7.1).
 - **Reset in place** — an explicit operation on a *running* server that re-runs the one-time
   power-on init/reset and returns device state to defaults, without dropping the process or
   forcing every client to reconnect.
 
 The important property either way: a reset is **destructive and shared** — it wipes the state
-that *all* currently attached clients are using. So it must be an explicit, privileged action
-(requested by the owner, or by a client that knowingly opts in), and it cannot be the quiet
-default behavior of opening the device.
+that *all* currently attached clients are using. So it must be an explicit action (requested by
+a client that knowingly opts in), and it cannot be the quiet default behavior of opening the
+device.
+
+---
+
+## 8. The UMD ↔ server API
+
+The API is the contract every client uses to talk to the card. Guiding principle: it should
+expose the **same device operations UMD already performs against silicon**, so the client
+stays a thin pass-through and the path stays close to silicon — *plus* the session verbs that
+multi-client sharing requires. The capability surface:
+
+- **Session.** Attach and detach. Attach is **non-mutating**: it registers the client and
+  returns the device description (below); detach releases it. These verbs are what make
+  multi-client access and reference-counting (§7.2) work.
+- **Device description / identity.** A query — answered at attach — for architecture, board,
+  cluster topology, and memory layout: everything a client must *read* rather than assume.
+  This is what makes the server the single source of truth and keeps every client's view
+  identical (required for handoff).
+- **Device memory access.** Read and write device memory addressed by (endpoint, address,
+  size) — core-local memory, DRAM, registers, and multicast writes. This is the bulk of the
+  traffic.
+- **Host memory (sysmem).** A client **allocates** a host-visible memory region through the API
+  (and frees it), then reads/writes it; the server provides the backing and a device-visible
+  address so the device can transfer to and from it. Allocation is a **runtime** operation, not
+  fixed at creation — mirroring how host memory is pinned on demand on silicon. These regions
+  are a **per-session** resource, released when the client detaches; unlike device memory they
+  do not persist across handoff.
+- **Run / reset control.** Assert/deassert core resets and start execution. These are normal
+  operations a client may issue while attached; what's special is only that *attaching* never
+  implicitly resets (§5).
+- **Execution / time.** Because the clock is server-owned and free-running, advancing time is a
+  server concern, not a per-client knob; any stepped/deterministic mode is a global operation.
+  This group is simulation-specific and has no silicon analog.
+- **Management / clean slate.** Reset-to-clean-slate (§7.3) and shutdown (§7.2) — kept distinct
+  from normal per-client operations because they affect *all* attached clients.
+
+Explicit ordering/synchronization (memory barriers) is intentionally **not** part of the API:
+operations apply synchronously and in order before the response returns, so there is nothing to
+flush — the simulator's memory barriers are already no-ops today.
+
+Cross-cutting properties of the API:
+
+- **Per-client sessions** — the server attributes every operation to a client, so it can
+  reference-count and notice disconnects.
+- **Per-operation atomicity, no cross-client transactions** — each operation completes
+  atomically against shared state, but no client can lock the card across multiple operations.
+  This matches silicon, where individual accesses are atomic but there is no cross-process
+  transaction guarantee.
+- **Request/response** — synchronous from the client's point of view.
+- **Backend-agnostic** — identical for RTL and TTSim; the backend difference stays below the
+  API.

--- a/docs/SIMULATION_SERVER_PROCESS.md
+++ b/docs/SIMULATION_SERVER_PROCESS.md
@@ -60,11 +60,19 @@ So "make it a server" is really **three coupled changes**, none optional:
 
 ## 3. Scope
 
-- **RTL/emu is the primary target** — already out-of-process and socket-based, so the server
-  is an extension of the existing `SimulationHost`/nng/FlatBuffers stack (1:1 → N:1).
-- **TTSim** can be offered later as an opt-in server mode reusing the same client device
-  class, but pays an IPC penalty (in-process calls → cross-process) and carries a TLB hazard
-  (§6.3). **Proposal: ship RTL-only first; keep TTSim single-client/in-process initially.**
+**Both simulation backends — RTL/emu and TTSim — are targets.** The end state is that either
+backend can run as a shared, persistent server. They differ only in how much work it takes to
+get there:
+
+- **RTL/emu** is already out-of-process and socket-based, so the server is a direct extension
+  of the existing `SimulationHost`/nng/FlatBuffers stack (1:1 → N:1) — the smaller lift.
+- **TTSim** is in-process today (`libttsim.so` via `dlopen`), so making it a server means
+  introducing an IPC boundary underneath `TTSimCommunicator`. This carries a perf penalty
+  (in-process calls → cross-process) and requires solving the TLB-register hazard (§6.3) — a
+  larger lift, but in scope, not optional.
+
+Both backends should sit behind the **same** client device class and protocol so the server
+model is uniform; the backend difference stays below the socket, invisible to clients.
 
 ---
 
@@ -117,155 +125,3 @@ Keep the client path **as close to the silicon `LocalChip` path as possible.**
 
 > **Decisions:** new `SimulationClientTTDevice` vs refactor `RtlSimulationTTDevice`;
 > `ClusterOptions` attach fields (socket folder / explicit socket / `attach_to_server` flag).
-
----
-
-## 6. The hard problems (need explicit decisions)
-
-### 6.1 Sysmem / host-memory DMA with N clients — *the crux*
-
-Host sysmem is a **UMD-process-local anonymous `mmap`** today (`SimulationSysmemManager`), and
-simulator-initiated DMA (`AXI_RAM_*` notifications) is serviced against *that one client's*
-address space. With N clients, the shared device cannot answer **"whose sysmem?"**
-
-- **Recommended — sysmem becomes server-resident shared state.** The PCIe/sysmem address
-  space is a resource of the card (like L1/DRAM). Device DMA resolves *entirely inside the
-  server* — no client round-trip, no "which client," no reentrancy deadlock — and it enables
-  handoff. Silicon-faithful (sysmem = pinned, IOMMU-mapped host DRAM).
-  - Cost: client `read/write_to_sysmem` becomes an IPC round-trip (loses today's zero-copy).
-  - Refinement to prototype: `shm_open`/`memfd` backing mapped by *both* server and client to
-    recover zero-copy while keeping the server authoritative.
-  - Needs server-arbitrated channel/PCIe-base allocation (the KMD-allocates-IOVA analog).
-- **Rejected — keep sysmem client-local + route DMA to the owning client.** Requires the sim
-  core to resolve client identity from a bus address (deep sim change), reintroduces a
-  callback-reentrancy deadlock, and breaks handoff (in-flight DMA to a dead client).
-
-> **Decision:** server-resident sysmem — proxy-everything (simple/correct/slower) vs `shm`
-> zero-copy fast path?
-
-### 6.2 Clock ownership
-
-Device time is global; a client calling `advance_clock` / `libttsim_clock` affects all
-clients.
-
-- **Recommended — the server owns a free-running clock by default.** The card runs
-  continuously; clients observe asynchronously (the only model where tt-triage peeking at a
-  *running* workload makes sense). Expose `CLOCK_ADVANCE`/`PAUSE` only as a privileged/global
-  op.
-- **Risk:** existing single-client flows likely depend on lock-step `write → advance N →
-  read` determinism. Provide a **single-client stepped/deterministic mode** (when exactly one
-  client is attached, or it holds an advertised "clock-owner" lease); the contract degrades to
-  free-running the moment a second client attaches.
-
-> **Decision:** default to free-running? **Action:** audit existing sim tests for hidden
-> dependence on synchronous `advance_clock`.
-
-### 6.3 TTSim TLB registers (TTSim-only)
-
-On **TTSim WH/BH**, `TTSimTlbHandle::configure` programs *authoritative device TLB registers*
-via BAR0 with a reprogram-per-access pattern that is only safe under the in-process
-`device_lock_`. Two concurrent clients would stomp each other. **Fix:** server owns TLB
-allocation, or per-access reprogram+access becomes one atomic server-side command. (RTL is
-unaffected — its TLB config is pure client-side address arithmetic, never latched in the
-device.)
-
-### 6.4 Concurrency semantics
-
-**Recommended — match silicon: per-command atomicity, no multi-command/cross-client
-transactions.** A single server-side command loop (one device-owner thread draining a queue,
-fed by per-client readers) gives this for free and avoids the DMA-callback reentrancy
-deadlock a lock-based design would hit. The per-process `device_lock_` is **not** sufficient
-cross-client — serialization moves server-side. Don't offer client-held device-wide locks
-(diverges from silicon; lets one client wedge a shared card).
-
----
-
-## 7. Lifetime & ownership
-
-- **Who starts it:** a standalone `tt-sim-server` daemon (= the card), fronted by a thin
-  `tt-sim-launcher` that does race-free create-or-attach under a per-name `flock`, waits for
-  socket readiness, and cleans up stale tombstones. Keep **lazy auto-spawn opt-in**
-  (`TT_SIM_AUTOSPAWN=1`) so today's one-binary dev/CI workflow survives migration. systemd
-  socket-activation is the most KMD-like option and worth documenting for a shared lab sim,
-  but can't be the baseline (environment constraints).
-- **Who reaps it:** **connection-death-driven refcount + configurable linger.** Default
-  `linger=infinite` for the daemon/handoff path; bounded linger (~30–60s) for autospawn/CI so
-  RTL processes don't leak while still surviving test-to-test handoff. **Reject** instant
-  refcount-to-zero kill (breaks handoff, races). Crashed clients: connection-close = implicit
-  detach (primary signal); heartbeat/lease as backstop for half-open connections.
-- **Orphans:** the server unlinks its own socket+PID on clean exit; tombstones (hard kill) are
-  reclaimed only by the launcher under the folder lock.
-
-> **Decisions:** daemon + launcher vs lazy-spawn default; teardown policy & default linger;
-> who is responsible for the device's initial reset/power state on creation.
-
----
-
-## 8. Protocol changes (`simulation_device.fbs`)
-
-- **Add:** `ATTACH`/`ATTACH_REPLY` (versioned handshake + device facts + serialized
-  `ClusterDescriptor` + server-assigned client id), `DETACH`, `GET_DEVICE_INFO`,
-  `SYSMEM_READ`/`SYSMEM_WRITE` (§6.1), `BARRIER`/flush-ack (membar = "wait for my outstanding
-  write acks"), privileged `CLOCK_ADVANCE`/`PAUSE`, a generic `ERROR`/status field, a
-  per-client monotonic `request_id`.
-- **Remove:** the per-client `START` and the `EXIT`-as-ready-ack hack; `EXIT`/destroy becomes
-  launcher/SIGTERM-only.
-- **Versioning is mandatory.** There is already an in-tree op-code **tag collision**
-  (`simulation_device.fbs:14-17`, AXI notifications vs NEO_DM resets) to resolve, plus
-  **cross-repo coordination** with the simulator release — `run.sh` must implement the
-  listener/server side.
-
----
-
-## 9. State ownership audit (what breaks handoff if left client-side)
-
-**Must move to the server (authoritative, mutable):** simulator core (already, RTL); host
-sysmem backing + RAM callbacks (§6.1); TTSim TLB programming/allocation (§6.3); cross-process
-serialization (replaces in-process `device_lock_`); reset/power state ownership.
-
-**Re-fetch on attach (read-only — query, never set):** arch, SocDescriptor (validate, don't
-impose), BAR0/BAR4 bases, `tlb_region_size_`, `libttsim_pci_device_id`, num host channels,
-current reset/power state.
-
-**Keep client-local (connection bookkeeping):** notification thread + command queue, the
-(now-dialing) socket, RTL TLB allocator/window/config, per-client lock, selected NOC id
-(carried per-command — verify the wire protocol carries it per op).
-
----
-
-## 10. Proposed phasing
-
-1. **Protocol + role inversion + transport.** Unix socket in a folder; `pair1` → per-client
-   connections; split `RtlSimCommunicator::initialize()` into spawn-side vs dial-side; add
-   `ATTACH`/`DETACH`; stop sending `EXIT` on client teardown.
-   *Interim de-risking option:* a **UMD-side broker** (UMD owns a server process; sim stays a
-   1:1 dialer behind it) delivers N:1 with **zero simulator changes**, then later collapses
-   into the sim.
-2. **Server-resident sysmem (§6.1)** — the correctness gate for real handoff.
-3. **Discovery + Cluster integration** — `SimulationTopologyDiscovery`, `ClusterOptions`
-   attach fields, `SimulationClientTTDevice`, server-served `ClusterDescriptor`.
-4. **Lifetime tooling** — `tt-sim-server` + `tt-sim-launcher`, refcount/linger, stale cleanup.
-5. **Clock policy (§6.2)** — free-running default + single-client stepped lease; audit tests.
-6. **TTSim-as-server (optional, later)** — TLB ownership fix (§6.3) + IPC under TTSimCommunicator.
-
----
-
-## 11. Decisions to make in this meeting
-
-0. Do we accept the **role inversion** (simulator = server/owner, UMD = client)? (§2)
-1. **Sysmem:** server-resident — proxy-everything vs `shm` zero-copy fast path? (§6.1)
-2. **Clock:** default free-running? Who audits existing tests for `advance_clock` dependence? (§6.2)
-3. **Lifetime:** explicit daemon+launcher vs lazy-spawn default; teardown policy & default
-   linger; who owns the device's initial reset/power state. (§7)
-4. **Transport:** unix-socket-only, or keep TCP for remote sim? Drop nng for raw sockets? (§4, §2)
-5. **Scope/order:** RTL-only first with TTSim deferred? Build the **broker** interim first? (§3, §10)
-6. **Cross-repo:** who owns the simulator-side (`run.sh`) server implementation and the
-   protocol version contract? (§8)
-
-## Open questions (lower priority / follow-up)
-
-- Multi-user folder permissions — is cross-user attach ever wanted? (per-UID folder forbids
-  it by default).
-- Sim crash mid-handoff = state lost (no silicon equivalent). Snapshot/checkpoint desirable,
-  or accept "restart fresh" for v1?
-- Heartbeat/lease TTL vs RTL command latency (avoid false-positive reaping of a busy client).


### PR DESCRIPTION
### Issue
Part of #2677. First implementation slice of #2792.

### Description
Reworks the simulation-server design discussion around a **host-owns-the-sim** model: one UMD process (the host) owns the simulator and serves other UMD clients over a UNIX socket, while keeping a direct in-process fast path for its own access. The first iteration is scoped to a single server at a fixed location (multi-device discovery deferred).

Adds the first implementation slice: `SimulationSocket`, which surfaces a simulated device on disk as a per-chip UNIX socket ("the card"). The sim TTDevices create it at the end of bring-up and tear it down on teardown; the in-process fast path is unchanged.

### List of the changes
- docs: rework `docs/SIMULATION_SERVER_PROCESS.md` — drop clean-slate reset; host-owns-sim model; UNIX-socket exposure with a direct in-process fast path; scope the first iteration to a single server at a fixed location; mark discovery (§4) as future.
- Add `SimulationSocket`: binds a per-chip UNIX socket (`<tmp>/tt-umd-sim-<uid>-<chip_id>.sock`), reclaims a stale socket, refuses when a live owner holds the path, drains connections with a stub accept loop, and closes/unlinks on destruction.
- Wire `SimulationSocket` into `TTSimTTDevice` and `RtlSimulationTTDevice` (created at end of bring-up, destroyed on teardown).
- Tests: `test_simulation_socket.cpp` — 6 unit tests + 1 simulator-gated integration test.

### Testing
- `SimulationSocket` unit tests (6) + `SimulationSocketIntegration` (requires `TT_UMD_SIMULATOR`) pass against the TTSim `libttsim.so`.
- Full TTSim device-IO suite passes — confirms the in-process hot path is unchanged.
- RTL wiring is compile-verified (no RTL simulator available locally; exercised in CI).

### API Changes
- New public header `umd/device/simulation/simulation_socket.hpp` (class `SimulationSocket`).
- No changes to existing public APIs.
