### PR TITLE
Make HangDetector NOC register read injectable

### DIFF
--- a/device/api/umd/device/tt_device/hang_detection/hang_detector.hpp
+++ b/device/api/umd/device/tt_device/hang_detection/hang_detector.hpp
@@ -20,14 +20,9 @@ class PcieInterface;
 enum class NocId : uint8_t;
 
 /**
- * Reads a single 32-bit NOC register at (core, addr) over the given NOC and returns its value.
- *
- * This is the injection seam for the NOC liveness probe. By default HangDetector reads through its
- * DeviceProtocol, which is all the stock hang check needs. A higher layer (e.g. TTDevice) can swap in
- * its own reader via set_noc_reg_reader() — for instance one that probes through a dedicated, separately
- * locked window so the check stays safe to call from inside a timed-out memcpy. Crucially, the window and
- * any lock live in the injected reader, NOT in HangDetector: HangDetector stays unaware of anything below
- * the protocol level (no TlbWindow, no locks).
+ * Reads a 32-bit NOC register at (core, addr) over the given NOC and returns its value.
+ * Injection point for the HangDetector NOC liveness read; defaults to a DeviceProtocol-based
+ * reader and can be overridden via set_noc_reg_reader().
  */
 using NocRegReader = std::function<uint32_t(tt_xy_pair core, uint64_t addr, NocId noc)>;
 
@@ -52,9 +47,8 @@ public:
     std::optional<bool> is_pcie_hung(uint32_t data_read = HANG_READ_VALUE);
     std::optional<bool> is_noc_hung(NocId noc);
 
-    // Overrides how the NOC liveness register is read (see NocRegReader). Passing an empty function is
-    // ignored, so the default protocol-based reader always stays in place. Intended for a higher layer
-    // that owns a dedicated probe window and its lock.
+    // Overrides the NOC liveness register reader (see NocRegReader). An empty function is ignored,
+    // so the default protocol-based reader stays in place.
     void set_noc_reg_reader(NocRegReader reader);
 
 protected:

--- a/device/api/umd/device/tt_device/hang_detection/hang_detector.hpp
+++ b/device/api/umd/device/tt_device/hang_detection/hang_detector.hpp
@@ -6,16 +6,30 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <optional>
 
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/types/noc_id.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 
 class DeviceProtocol;
 class PcieInterface;
 enum class NocId : uint8_t;
+
+/**
+ * Reads a single 32-bit NOC register at (core, addr) over the given NOC and returns its value.
+ *
+ * This is the injection seam for the NOC liveness probe. By default HangDetector reads through its
+ * DeviceProtocol, which is all the stock hang check needs. A higher layer (e.g. TTDevice) can swap in
+ * its own reader via set_noc_reg_reader() — for instance one that probes through a dedicated, separately
+ * locked window so the check stays safe to call from inside a timed-out memcpy. Crucially, the window and
+ * any lock live in the injected reader, NOT in HangDetector: HangDetector stays unaware of anything below
+ * the protocol level (no TlbWindow, no locks).
+ */
+using NocRegReader = std::function<uint32_t(tt_xy_pair core, uint64_t addr, NocId noc)>;
 
 /**
  * HangDetector checks whether the device hardware is hung.
@@ -38,6 +52,11 @@ public:
     std::optional<bool> is_pcie_hung(uint32_t data_read = HANG_READ_VALUE);
     std::optional<bool> is_noc_hung(NocId noc);
 
+    // Overrides how the NOC liveness register is read (see NocRegReader). Passing an empty function is
+    // ignored, so the default protocol-based reader always stays in place. Intended for a higher layer
+    // that owns a dedicated probe window and its lock.
+    void set_noc_reg_reader(NocRegReader reader);
+
 protected:
     HangDetector(DeviceProtocol* protocol, architecture_implementation* arch_impl);
 
@@ -46,6 +65,10 @@ protected:
     PcieInterface* get_pcie_interface() const { return pcie_interface_; }
 
     architecture_implementation* get_arch_impl() const { return arch_impl_; }
+
+    // Reads a 32-bit NOC register through the configured NocRegReader. Arch-specific variants compute the
+    // (core, addr) for their hang-check register and route the actual read through here.
+    uint32_t read_noc_reg(tt_xy_pair core, uint64_t addr, NocId noc);
 
 private:
     // Arch-specific implementations.
@@ -56,6 +79,7 @@ private:
     PcieInterface* pcie_interface_;
     bool is_mmio_protocol_;
     architecture_implementation* arch_impl_;
+    NocRegReader noc_reg_reader_;
 };
 
 }  // namespace tt::umd

--- a/device/tt_device/hang_detection/blackhole_hang_detector.cpp
+++ b/device/tt_device/hang_detection/blackhole_hang_detector.cpp
@@ -10,7 +10,6 @@
 
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
-#include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/noc_id.hpp"
@@ -29,9 +28,7 @@ uint32_t BlackholeHangDetector::read_hang_check_reg_via_noc(NocId noc) {
     tt_xy_pair core = get_hang_check_core(noc);
     uint64_t addr = get_arch_impl()->get_noc_reg_base(CoreType::PCIE, static_cast<uint32_t>(noc)) +
                     get_arch_impl()->get_noc_node_id_offset();
-    uint32_t value = 0;
-    get_protocol()->read_from_device(&value, core, addr, sizeof(value), noc);
-    return value;
+    return read_noc_reg(core, addr, noc);
 }
 
 tt_xy_pair BlackholeHangDetector::get_hang_check_core(NocId noc) const {

--- a/device/tt_device/hang_detection/hang_detector.cpp
+++ b/device/tt_device/hang_detection/hang_detector.cpp
@@ -17,7 +17,23 @@ HangDetector::HangDetector(DeviceProtocol* protocol, architecture_implementation
     protocol_(protocol),
     pcie_interface_(dynamic_cast<PcieInterface*>(protocol)),
     is_mmio_protocol_(!dynamic_cast<RemoteInterface*>(protocol)),
-    arch_impl_(arch_impl) {}
+    arch_impl_(arch_impl),
+    // Default reader: plain protocol read. A higher layer may override it via set_noc_reg_reader().
+    noc_reg_reader_([this](tt_xy_pair core, uint64_t addr, NocId noc) -> uint32_t {
+        uint32_t value = 0;
+        protocol_->read_from_device(&value, core, addr, sizeof(value), noc);
+        return value;
+    }) {}
+
+void HangDetector::set_noc_reg_reader(NocRegReader reader) {
+    if (reader) {
+        noc_reg_reader_ = std::move(reader);
+    }
+}
+
+uint32_t HangDetector::read_noc_reg(tt_xy_pair core, uint64_t addr, NocId noc) {
+    return noc_reg_reader_(core, addr, noc);
+}
 
 std::optional<bool> HangDetector::is_pcie_hung(uint32_t data_read) {
     if (data_read != HANG_READ_VALUE) {

--- a/device/tt_device/hang_detection/wormhole_hang_detector.cpp
+++ b/device/tt_device/hang_detection/wormhole_hang_detector.cpp
@@ -10,7 +10,6 @@
 
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
-#include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/noc_id.hpp"
@@ -28,9 +27,7 @@ uint32_t WormholeHangDetector::read_hang_check_reg_via_noc(NocId noc) {
     tt_xy_pair core = get_hang_check_core(noc);
     uint64_t addr = get_arch_impl()->get_noc_reg_base(CoreType::ARC, static_cast<uint32_t>(noc)) +
                     get_arch_impl()->get_noc_node_id_offset();
-    uint32_t value = 0;
-    get_protocol()->read_from_device(&value, core, addr, sizeof(value), noc);
-    return value;
+    return read_noc_reg(core, addr, noc);
 }
 
 tt_xy_pair WormholeHangDetector::get_hang_check_core(NocId noc) {


### PR DESCRIPTION
### Issue

#1673

### Description

Structural prep extracted from #2629, addressing review feedback that HangDetector should stay unaware of anything below the protocol level (no TlbWindow, no locks).

HangDetector now reads its NOC liveness register through an injectable `NocRegReader`, defaulting to the current protocol-based read. A higher layer can override it via `set_noc_reg_reader()` with a reader that owns its own probe window and lock, keeping that knowledge out of HangDetector. The override consumer lands later with the per-op MMIO timeout work. Behavior is unchanged.

### List of the changes

- Add `NocRegReader` and a `set_noc_reg_reader()` override hook to `HangDetector`; default reader reads via `DeviceProtocol`.
- Route `BlackholeHangDetector` / `WormholeHangDetector` NOC reads through a new protected `read_noc_reg()`; drop their now-unused `device_protocol.hpp` include.

### Testing

CI

### API Changes

- New `tt::umd::NocRegReader` typedef and `HangDetector::set_noc_reg_reader()` method.
