### PR TITLE
Simulation: UMD<->host API protocol scaffold

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -4,27 +4,34 @@ set(POSITION_INDEPENDENT_CODE ON)
 include(CheckFunctionExists)
 
 if(TT_UMD_BUILD_SIMULATION)
-    set(FBS_FILE ${PROJECT_SOURCE_DIR}/device/simulation/simulation_device.fbs)
-    get_filename_component(FBS_FILE_NAME ${FBS_FILE} NAME_WLE)
-    set(FBS_GENERATED_HEADER "${CMAKE_CURRENT_BINARY_DIR}/${FBS_FILE_NAME}_generated.h")
+    set(FBS_FILES
+        ${PROJECT_SOURCE_DIR}/device/simulation/simulation_device.fbs
+        ${PROJECT_SOURCE_DIR}/device/simulation/simulation_server_api.fbs
+    )
     set(FBS_DEPENDS "")
     if(TARGET flatc)
         set(FBS_DEPENDS flatc)
     endif()
-    add_custom_command(
-        OUTPUT
-            ${FBS_GENERATED_HEADER}
-        COMMAND
-            flatc --cpp -o "${CMAKE_CURRENT_BINARY_DIR}" ${FBS_FILE}
-        DEPENDS
-            ${FBS_DEPENDS}
-            ${FBS_FILE}
-        COMMENT "Generating FlatBuffers header ${FBS_GENERATED_HEADER}"
-        VERBATIM
-    )
+    set(FBS_GENERATED_HEADERS "")
+    foreach(FBS_FILE ${FBS_FILES})
+        get_filename_component(FBS_FILE_NAME ${FBS_FILE} NAME_WLE)
+        set(FBS_GENERATED_HEADER "${CMAKE_CURRENT_BINARY_DIR}/${FBS_FILE_NAME}_generated.h")
+        add_custom_command(
+            OUTPUT
+                ${FBS_GENERATED_HEADER}
+            COMMAND
+                flatc --cpp -I "${PROJECT_SOURCE_DIR}/device/simulation" -o "${CMAKE_CURRENT_BINARY_DIR}" ${FBS_FILE}
+            DEPENDS
+                ${FBS_DEPENDS}
+                ${FBS_FILE}
+            COMMENT "Generating FlatBuffers header ${FBS_GENERATED_HEADER}"
+            VERBATIM
+        )
+        list(APPEND FBS_GENERATED_HEADERS ${FBS_GENERATED_HEADER})
+    endforeach()
 
-    # Add FlatBuffers header to the code analysis target
-    add_custom_target(umd_device_generated_files DEPENDS ${FBS_GENERATED_HEADER})
+    # Add FlatBuffers headers to the code analysis target
+    add_custom_target(umd_device_generated_files DEPENDS ${FBS_GENERATED_HEADERS})
     add_dependencies(umd_all_generated_files umd_device_generated_files)
 endif()
 
@@ -147,6 +154,7 @@ if(TT_UMD_BUILD_SIMULATION)
         PRIVATE
             simulation/simulation_chip.cpp
             simulation/simulation_topology_discovery.cpp
+            simulation/simulation_server_api.cpp
             simulation/simulation_host.cpp
             simulation/tt_sim_communicator.cpp
             simulation/rtl_sim_communicator.cpp
@@ -158,7 +166,7 @@ if(TT_UMD_BUILD_SIMULATION)
             pcie/tt_sim_tlb_handle.cpp
             pcie/rtl_sim_tlb_window.cpp
             pcie/rtl_sim_tlb_handle.cpp
-            ${FBS_GENERATED_HEADER}
+            ${FBS_GENERATED_HEADERS}
     )
     target_compile_definitions(tt-umd PUBLIC TT_UMD_BUILD_SIMULATION)
 endif()
@@ -251,6 +259,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/simulation/simulation_chip.hpp
                 api/umd/device/simulation/simulation_socket.hpp
                 api/umd/device/simulation/simulation_topology_discovery.hpp
+                api/umd/device/simulation/simulation_server_api.hpp
                 api/umd/device/simulation/simulation_host.hpp
                 api/umd/device/simulation/tt_sim_communicator.hpp
                 api/umd/device/simulation/rtl_sim_communicator.hpp

--- a/device/api/umd/device/simulation/simulation_server_api.hpp
+++ b/device/api/umd/device/simulation/simulation_server_api.hpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "umd/device/utils/error.hpp"
+
+namespace tt::umd {
+
+// The single place that defines the UMD <-> simulation host API: the operations a UMD client
+// calls against a simulation host ("the card"). For now it carries just the session handshake; it
+// grows to mirror the device operations UMD performs against silicon as the server work lands, so
+// the client stays a thin pass-through. See docs/SIMULATION_SERVER_PROCESS.md (§8).
+//
+// This is intentionally just the contract. Implementations come in later issues: the host-side
+// dispatch (#2794) and the socket-backed client (#2795). Extend this interface here as new
+// operations are needed — it is the one definition point clients call into.
+class SimulationServerApi {
+public:
+    virtual ~SimulationServerApi() = default;
+
+    // Session. attach registers the client (non-mutating); detach releases it.
+    virtual void attach() = 0;
+    virtual void detach() = 0;
+
+    // TODO: define the rest of the surface here as the server work lands (§8):
+    //   - device description / identity (topology + memory layout)
+    //   - device memory access (read / write / multicast)
+    //   - TLB windows (allocate / configure / free)
+    //   - host memory / sysmem (allocate / free / access)
+    //   - run / reset control
+    //   - execution / time
+    //   - management (shutdown)
+};
+
+// ---------------------------------------------------------------------------
+// Wire layer: the FlatBuffers serialization path every API operation will go through.
+//
+// Placeholder for now: a single dummy message that proves the serialization + framing path works
+// end-to-end. The real per-operation messages are added when the protocol is wired into the
+// serving layer (#2794) and the socket-backed client (#2795). FlatBuffers stays an implementation
+// detail (it lives in the .cpp).
+// ---------------------------------------------------------------------------
+
+struct Message {
+    std::vector<uint8_t> payload;
+};
+
+// Serialize a message to a FlatBuffers payload, and parse one back.
+std::vector<uint8_t> encode(const Message& msg);
+Message decode(const uint8_t* data, size_t size);
+
+inline Message decode(const std::vector<uint8_t>& bytes) {
+    // An empty buffer can never be a valid message; forwarding bytes.data() (which may be null)
+    // would push the empty/invalid case down to the verifier, so reject it here.
+    if (bytes.empty()) {
+        UMD_THROW(error::RuntimeError, "Cannot decode an empty simulation server API buffer");
+    }
+    return decode(bytes.data(), bytes.size());
+}
+
+// Length-prefix framing for the stream socket: a 4-byte little-endian length, then the payload.
+std::vector<uint8_t> frame(const std::vector<uint8_t>& payload);
+
+}  // namespace tt::umd

--- a/device/simulation/simulation_server_api.cpp
+++ b/device/simulation/simulation_server_api.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/simulation/simulation_server_api.hpp"
+
+#include <flatbuffers/flatbuffers.h>
+#include <fmt/format.h>
+
+#include <limits>
+
+#include "simulation_server_api_generated.h"
+#include "umd/device/utils/error.hpp"
+
+namespace tt::umd {
+
+std::vector<uint8_t> encode(const Message& msg) {
+    flatbuffers::FlatBufferBuilder builder;
+    auto payload = builder.CreateVector(msg.payload);
+    builder.Finish(::CreateMessage(builder, payload));
+    return std::vector<uint8_t>(builder.GetBufferPointer(), builder.GetBufferPointer() + builder.GetSize());
+}
+
+Message decode(const uint8_t* data, size_t size) {
+    // This parses untrusted stream/socket input, so verify the buffer against the schema (using
+    // the provided size) before touching any field — fail fast rather than risk out-of-bounds
+    // reads on a malformed or truncated payload.
+    flatbuffers::Verifier verifier(data, size);
+    if (data == nullptr || !::VerifyMessageBuffer(verifier)) {
+        UMD_THROW(error::RuntimeError, fmt::format("Failed to verify simulation server API message ({} bytes)", size));
+    }
+
+    Message msg;
+    const auto* fb = ::GetMessage(data);
+    if (fb->payload() != nullptr) {
+        msg.payload.assign(fb->payload()->begin(), fb->payload()->end());
+    }
+    return msg;
+}
+
+std::vector<uint8_t> frame(const std::vector<uint8_t>& payload) {
+    // The length prefix is a uint32_t; guard against an oversized payload silently wrapping it
+    // (which would desynchronize the receiver) rather than truncating.
+    UMD_ASSERT(
+        payload.size() <= std::numeric_limits<uint32_t>::max(),
+        error::RuntimeError,
+        fmt::format("Simulation server API payload too large to frame ({} bytes)", payload.size()));
+    const uint32_t length = static_cast<uint32_t>(payload.size());
+    std::vector<uint8_t> framed;
+    framed.reserve(payload.size() + sizeof(uint32_t));
+    framed.push_back(length & 0xFF);
+    framed.push_back((length >> 8) & 0xFF);
+    framed.push_back((length >> 16) & 0xFF);
+    framed.push_back((length >> 24) & 0xFF);
+    framed.insert(framed.end(), payload.begin(), payload.end());
+    return framed;
+}
+
+}  // namespace tt::umd

--- a/device/simulation/simulation_server_api.fbs
+++ b/device/simulation/simulation_server_api.fbs
@@ -1,0 +1,11 @@
+// Wire schema for the UMD <-> simulation host API (§8 of SIMULATION_SERVER_PROCESS.md).
+//
+// Placeholder for now: a single dummy message that proves the FlatBuffers serialization path
+// works end-to-end. The real API messages (session, memory ops, ...) are added here when the
+// protocol is wired into the serving layer (#2794) and the socket-backed client (#2795).
+
+table Message {
+    payload : [ubyte];
+}
+
+root_type Message;

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -25,6 +25,7 @@ set(API_TESTS_SRCS
 if(TT_UMD_BUILD_SIMULATION)
     list(APPEND API_TESTS_SRCS test_ttsim_device_io.cpp)
     list(APPEND API_TESTS_SRCS test_simulation_topology_discovery.cpp)
+    list(APPEND API_TESTS_SRCS test_simulation_server_api.cpp)
 endif()
 
 add_executable(api_tests ${API_TESTS_SRCS})

--- a/tests/api/test_simulation_server_api.cpp
+++ b/tests/api/test_simulation_server_api.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include "umd/device/simulation/simulation_server_api.hpp"
+
+using namespace tt::umd;
+
+namespace {
+
+// A trivial implementation, demonstrating that a client can be written against the API contract.
+// Stands in for the real socket-backed client (#2795) until it lands.
+class FakeSimulationServerClient : public SimulationServerApi {
+public:
+    void attach() override { attached_ = true; }
+
+    void detach() override { attached_ = false; }
+
+    bool attached() const { return attached_; }
+
+private:
+    bool attached_ = false;
+};
+
+}  // namespace
+
+TEST(SimulationServerApi, ClientCanImplementAndCallTheContract) {
+    FakeSimulationServerClient client;
+
+    client.attach();
+    EXPECT_TRUE(client.attached());
+
+    client.detach();
+    EXPECT_FALSE(client.attached());
+}
+
+// The dummy message proves the FlatBuffers serialization path works end-to-end.
+TEST(SimulationServerApiWire, MessageRoundTrip) {
+    Message msg;
+    msg.payload = {0xde, 0xad, 0xbe, 0xef};
+
+    const Message out = decode(encode(msg));
+
+    EXPECT_EQ(out.payload, msg.payload);
+}
+
+TEST(SimulationServerApiWire, FramePrependsLittleEndianLength) {
+    const std::vector<uint8_t> payload = {1, 2, 3, 4, 5};
+
+    const std::vector<uint8_t> framed = frame(payload);
+
+    ASSERT_EQ(framed.size(), payload.size() + 4);
+    const uint32_t len = framed[0] | (framed[1] << 8) | (framed[2] << 16) | (uint32_t(framed[3]) << 24);
+    EXPECT_EQ(len, payload.size());
+    EXPECT_EQ(std::vector<uint8_t>(framed.begin() + 4, framed.end()), payload);
+}


### PR DESCRIPTION
### Issue
Part of #2793 (define the UMD ↔ host API). Stacked on the `SimulationTopologyDiscovery` PR (#2811).

### Description
Defines the simulation host API in **one place** and proves the serialization path works, with **no wiring yet** — that follows in a later PR (serving #2794, client #2795).

- `SimulationServerApi` — the interface a UMD client calls into (session + memory access, with the rest of §8 as TODO placeholders to grow).
- The FlatBuffers serialization path every API op will go through: `encode`/`decode` + length-prefix `frame`, with FlatBuffers kept an implementation detail (in the `.cpp`).
- The wire layer currently carries a **single placeholder message** that exercises the path end-to-end; real per-operation messages replace it when the protocol is wired in.

### List of the changes
- Add `simulation_server_api.fbs` (placeholder `Message`) + generalize the FlatBuffers codegen to handle multiple schemas.
- Add `simulation_server_api.hpp` (interface + `Message` + `encode`/`decode`/`frame`) and `simulation_server_api.cpp`.
- Tests: a fake client implementing the contract, a serialization round-trip, and a framing check.

### Testing
CI

### API Changes
- New public header `umd/device/simulation/simulation_server_api.hpp`.
- No changes to existing public APIs.
