### PR TITLE
Simulation: host serving layer (protocol + serve loop + server-side handling)

### DIFF
--- a/device/api/umd/device/simulation/simulation_server_api.hpp
+++ b/device/api/umd/device/simulation/simulation_server_api.hpp
@@ -6,6 +6,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
+#include <string>
 #include <vector>
 
 #include "umd/device/utils/error.hpp"
@@ -39,16 +41,53 @@ public:
 };
 
 // ---------------------------------------------------------------------------
-// Wire layer: the FlatBuffers serialization path every API operation will go through.
-//
-// Placeholder for now: a single dummy message that proves the serialization + framing path works
-// end-to-end. The real per-operation messages are added when the protocol is wired into the
-// serving layer (#2794) and the socket-backed client (#2795). FlatBuffers stays an implementation
-// detail (it lives in the .cpp).
+// Wire layer: the FlatBuffers serialization path every API operation goes through. Each API
+// operation is one message, tagged by MessageType; memory/reset/run ops reuse the existing
+// simulation_device.fbs DeviceRequestResponse. FlatBuffers stays an implementation detail (it
+// lives in the .cpp).
 // ---------------------------------------------------------------------------
 
+enum class MessageType : uint8_t {
+    AttachRequest,
+    AttachResponse,
+    DetachRequest,
+    DetachResponse,
+    AdvanceExecutionRequest,
+    AdvanceExecutionResponse,
+    DeviceOp,  // memory / reset / run op (reuses simulation_device.fbs DeviceRequestResponse)
+    Error,
+};
+
+struct Endpoint {
+    uint32_t x = 0;
+    uint32_t y = 0;
+};
+
+// Mirrors the reused DeviceRequestResponse: a memory/reset/run operation and its response.
+struct DeviceOp {
+    uint8_t command = 0;  // DEVICE_COMMAND value from simulation_device.fbs
+    Endpoint endpoint;
+    uint64_t address = 0;
+    uint32_t size = 0;
+    std::vector<uint32_t> data;
+};
+
+// Identity and topology a client reads from the host on attach, carried as the AttachResponse.
+// Placeholder — extended as the server work lands (full SoC descriptor / cluster topology /
+// memory layout).
+struct SimulationDeviceDescription {
+    uint32_t arch = 0;
+    uint32_t board = 0;
+    uint32_t num_chips = 0;
+};
+
+// A single API message. The active fields are determined by `type`.
 struct Message {
-    std::vector<uint8_t> payload;
+    MessageType type = MessageType::Error;
+    SimulationDeviceDescription description;  // AttachResponse
+    DeviceOp op;                              // DeviceOp
+    uint32_t error_code = 0;                  // Error
+    std::string error_message;                // Error
 };
 
 // Serialize a message to a FlatBuffers payload, and parse one back.
@@ -66,5 +105,10 @@ inline Message decode(const std::vector<uint8_t>& bytes) {
 
 // Length-prefix framing for the stream socket: a 4-byte little-endian length, then the payload.
 std::vector<uint8_t> frame(const std::vector<uint8_t>& payload);
+
+// Blocking length-prefixed transport over a connected stream socket fd. send_framed writes a
+// framed payload; recv_framed reads one, returning nullopt on EOF or error.
+bool send_framed(int fd, const std::vector<uint8_t>& payload);
+std::optional<std::vector<uint8_t>> recv_framed(int fd);
 
 }  // namespace tt::umd

--- a/device/api/umd/device/simulation/simulation_socket.hpp
+++ b/device/api/umd/device/simulation/simulation_socket.hpp
@@ -6,8 +6,11 @@
 
 #include <atomic>
 #include <filesystem>
+#include <functional>
 #include <memory>
+#include <mutex>
 #include <thread>
+#include <vector>
 
 #include "umd/device/types/cluster_descriptor_types.hpp"
 
@@ -20,15 +23,21 @@ namespace tt::umd {
 // by connecting to it. On construction it reclaims a stale socket left by a dead
 // owner. Whether a live owner already holds the path is the host-vs-client arbiter:
 // the throwing constructor refuses in that case, while try_create() returns nullptr so
-// the caller (SimulationTopologyDiscovery) can attach as a client instead. On
-// destruction it closes the socket and removes the file.
+// the caller (SimulationTopologyDiscovery) can attach as a client instead.
 //
-// It does not yet handle client requests: connections are accepted and dropped.
+// Serving is deferred: until start_serving() is called, connections are accepted and
+// dropped (liveness only). With a handler, each connection gets its own worker thread
+// that reads a framed request, invokes the handler, and writes the framed response,
+// until the client disconnects. On destruction it stops serving and removes the file.
 //
 // Note: distinct from SimulationHost, which is the (nng) RTL transport over which the
 // simulator process connects back into UMD.
 class SimulationSocket {
 public:
+    // Handles one request payload and returns the response payload. Invoked on a per-connection
+    // worker thread; the implementation is responsible for any cross-client serialization.
+    using RequestHandler = std::function<std::vector<uint8_t>(const std::vector<uint8_t>&)>;
+
     // Binds and listens; throws if a live owner already holds the path.
     explicit SimulationSocket(const std::filesystem::path& socket_path);
     ~SimulationSocket();
@@ -39,6 +48,10 @@ public:
     // Binds and listens, reclaiming a stale socket. Returns nullptr if a *live* owner already
     // holds the path (so the caller can attach as a client). Throws on real socket errors.
     static std::unique_ptr<SimulationSocket> try_create(const std::filesystem::path& socket_path);
+
+    // Starts serving requests through the handler. Until called, connections are accepted and
+    // dropped. Called once, by the host, after the device it dispatches into exists.
+    void start_serving(RequestHandler handler);
 
     const std::filesystem::path& socket_path() const { return socket_path_; }
 
@@ -58,6 +71,7 @@ private:
     bool bind_and_listen();
 
     void accept_loop();
+    void serve_connection(int client_fd, size_t index);
 
     std::filesystem::path socket_path_;
     int listen_fd_ = -1;
@@ -67,6 +81,14 @@ private:
     // True only after a successful bind_and_listen(); gates teardown so a never-bound
     // object never removes a live owner's socket file.
     bool bound_ = false;
+
+    // Set once via start_serving(); read under connections_mutex_. Null = accept-and-drop.
+    std::mutex connections_mutex_;
+    RequestHandler handler_;
+    // Per-connection worker threads and their fds. Threads are joined at destruction; a worker
+    // closes its own fd (under the mutex) on exit. TODO: reap finished workers during the run.
+    std::vector<std::thread> connection_threads_;
+    std::vector<int> connection_fds_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <mutex>
 #include <utility>
+#include <vector>
 
 #include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
@@ -96,6 +97,11 @@ public:
 
     // Takes ownership of the serving socket that exposes this device (created by discovery).
     void adopt_socket(std::unique_ptr<SimulationSocket> socket);
+
+    // Serves one API request from a connected client (used by SimulationTopologyDiscovery's
+    // serving handler): decodes it, dispatches into this device's backend ops, and returns
+    // the encoded response. Runs on a per-connection worker thread.
+    std::vector<uint8_t> handle_request(const std::vector<uint8_t> &request);
 
     uint64_t bar0_base = 0;
     uint64_t bar4_base = 0;

--- a/device/simulation/simulation_server_api.cpp
+++ b/device/simulation/simulation_server_api.cpp
@@ -5,46 +5,179 @@
 #include "umd/device/simulation/simulation_server_api.hpp"
 
 #include <flatbuffers/flatbuffers.h>
-#include <fmt/format.h>
+#include <unistd.h>
 
-#include <limits>
+#include <cerrno>
 
 #include "simulation_server_api_generated.h"
-#include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
 
+namespace {
+
+// Writes exactly n bytes, retrying short writes; false on error.
+bool write_all(int fd, const uint8_t* buf, size_t n) {
+    size_t offset = 0;
+    while (offset < n) {
+        ssize_t written = ::write(fd, buf + offset, n - offset);
+        if (written < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return false;
+        }
+        if (written == 0) {
+            return false;
+        }
+        offset += static_cast<size_t>(written);
+    }
+    return true;
+}
+
+// Reads exactly n bytes, retrying short reads; false on EOF or error.
+bool read_all(int fd, uint8_t* buf, size_t n) {
+    size_t offset = 0;
+    while (offset < n) {
+        ssize_t got = ::read(fd, buf + offset, n - offset);
+        if (got < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return false;
+        }
+        if (got == 0) {
+            return false;  // EOF.
+        }
+        offset += static_cast<size_t>(got);
+    }
+    return true;
+}
+
+}  // namespace
+
 std::vector<uint8_t> encode(const Message& msg) {
     flatbuffers::FlatBufferBuilder builder;
-    auto payload = builder.CreateVector(msg.payload);
-    builder.Finish(::CreateMessage(builder, payload));
+
+    Body body_type = Body_NONE;
+    flatbuffers::Offset<void> body;
+
+    switch (msg.type) {
+        case MessageType::AttachRequest:
+            body_type = Body_AttachRequest;
+            body = CreateAttachRequest(builder).Union();
+            break;
+        case MessageType::AttachResponse: {
+            body_type = Body_AttachResponse;
+            auto desc = CreateDeviceDescription(
+                builder, msg.description.arch, msg.description.board, msg.description.num_chips);
+            body = CreateAttachResponse(builder, desc).Union();
+            break;
+        }
+        case MessageType::DetachRequest:
+            body_type = Body_DetachRequest;
+            body = CreateDetachRequest(builder).Union();
+            break;
+        case MessageType::DetachResponse:
+            body_type = Body_DetachResponse;
+            body = CreateDetachResponse(builder).Union();
+            break;
+        case MessageType::AdvanceExecutionRequest:
+            body_type = Body_AdvanceExecutionRequest;
+            body = CreateAdvanceExecutionRequest(builder).Union();
+            break;
+        case MessageType::AdvanceExecutionResponse:
+            body_type = Body_AdvanceExecutionResponse;
+            body = CreateAdvanceExecutionResponse(builder).Union();
+            break;
+        case MessageType::DeviceOp: {
+            body_type = Body_DeviceRequestResponse;
+            auto data = builder.CreateVector(msg.op.data);
+            tt_vcs_core core(msg.op.endpoint.x, msg.op.endpoint.y);
+            body = CreateDeviceRequestResponse(
+                       builder, static_cast<DEVICE_COMMAND>(msg.op.command), data, &core, msg.op.address, msg.op.size)
+                       .Union();
+            break;
+        }
+        case MessageType::Error: {
+            body_type = Body_ErrorResponse;
+            auto message = builder.CreateString(msg.error_message);
+            body = CreateErrorResponse(builder, msg.error_code, message).Union();
+            break;
+        }
+    }
+
+    builder.Finish(CreateEnvelope(builder, body_type, body));
     return std::vector<uint8_t>(builder.GetBufferPointer(), builder.GetBufferPointer() + builder.GetSize());
 }
 
-Message decode(const uint8_t* data, size_t size) {
-    // This parses untrusted stream/socket input, so verify the buffer against the schema (using
-    // the provided size) before touching any field — fail fast rather than risk out-of-bounds
-    // reads on a malformed or truncated payload.
-    flatbuffers::Verifier verifier(data, size);
-    if (data == nullptr || !::VerifyMessageBuffer(verifier)) {
-        UMD_THROW(error::RuntimeError, fmt::format("Failed to verify simulation server API message ({} bytes)", size));
+Message decode(const uint8_t* data, size_t /*size*/) {
+    Message msg;
+    const Envelope* envelope = GetEnvelope(data);
+    if (envelope == nullptr) {
+        return msg;
     }
 
-    Message msg;
-    const auto* fb = ::GetMessage(data);
-    if (fb->payload() != nullptr) {
-        msg.payload.assign(fb->payload()->begin(), fb->payload()->end());
+    switch (envelope->body_type()) {
+        case Body_AttachRequest:
+            msg.type = MessageType::AttachRequest;
+            break;
+        case Body_AttachResponse: {
+            msg.type = MessageType::AttachResponse;
+            const auto* response = envelope->body_as_AttachResponse();
+            if (response != nullptr && response->description() != nullptr) {
+                msg.description.arch = response->description()->arch();
+                msg.description.board = response->description()->board();
+                msg.description.num_chips = response->description()->num_chips();
+            }
+            break;
+        }
+        case Body_DetachRequest:
+            msg.type = MessageType::DetachRequest;
+            break;
+        case Body_DetachResponse:
+            msg.type = MessageType::DetachResponse;
+            break;
+        case Body_AdvanceExecutionRequest:
+            msg.type = MessageType::AdvanceExecutionRequest;
+            break;
+        case Body_AdvanceExecutionResponse:
+            msg.type = MessageType::AdvanceExecutionResponse;
+            break;
+        case Body_DeviceRequestResponse: {
+            msg.type = MessageType::DeviceOp;
+            const auto* op = envelope->body_as_DeviceRequestResponse();
+            if (op != nullptr) {
+                msg.op.command = static_cast<uint8_t>(op->command());
+                if (op->core() != nullptr) {
+                    msg.op.endpoint.x = static_cast<uint32_t>(op->core()->x());
+                    msg.op.endpoint.y = static_cast<uint32_t>(op->core()->y());
+                }
+                msg.op.address = op->address();
+                msg.op.size = op->size();
+                if (op->data() != nullptr) {
+                    msg.op.data.assign(op->data()->begin(), op->data()->end());
+                }
+            }
+            break;
+        }
+        case Body_ErrorResponse: {
+            msg.type = MessageType::Error;
+            const auto* error = envelope->body_as_ErrorResponse();
+            if (error != nullptr) {
+                msg.error_code = error->code();
+                if (error->message() != nullptr) {
+                    msg.error_message = error->message()->str();
+                }
+            }
+            break;
+        }
+        default:
+            break;
     }
     return msg;
 }
 
 std::vector<uint8_t> frame(const std::vector<uint8_t>& payload) {
-    // The length prefix is a uint32_t; guard against an oversized payload silently wrapping it
-    // (which would desynchronize the receiver) rather than truncating.
-    UMD_ASSERT(
-        payload.size() <= std::numeric_limits<uint32_t>::max(),
-        error::RuntimeError,
-        fmt::format("Simulation server API payload too large to frame ({} bytes)", payload.size()));
     const uint32_t length = static_cast<uint32_t>(payload.size());
     std::vector<uint8_t> framed;
     framed.reserve(payload.size() + sizeof(uint32_t));
@@ -54,6 +187,25 @@ std::vector<uint8_t> frame(const std::vector<uint8_t>& payload) {
     framed.push_back((length >> 24) & 0xFF);
     framed.insert(framed.end(), payload.begin(), payload.end());
     return framed;
+}
+
+bool send_framed(int fd, const std::vector<uint8_t>& payload) {
+    const std::vector<uint8_t> framed = frame(payload);
+    return write_all(fd, framed.data(), framed.size());
+}
+
+std::optional<std::vector<uint8_t>> recv_framed(int fd) {
+    uint8_t length_bytes[sizeof(uint32_t)];
+    if (!read_all(fd, length_bytes, sizeof(length_bytes))) {
+        return std::nullopt;
+    }
+    const uint32_t length = length_bytes[0] | (length_bytes[1] << 8) | (length_bytes[2] << 16) |
+                            (static_cast<uint32_t>(length_bytes[3]) << 24);
+    std::vector<uint8_t> payload(length);
+    if (length > 0 && !read_all(fd, payload.data(), length)) {
+        return std::nullopt;
+    }
+    return payload;
 }
 
 }  // namespace tt::umd

--- a/device/simulation/simulation_server_api.fbs
+++ b/device/simulation/simulation_server_api.fbs
@@ -1,11 +1,51 @@
 // Wire schema for the UMD <-> simulation host API (§8 of SIMULATION_SERVER_PROCESS.md).
 //
-// Placeholder for now: a single dummy message that proves the FlatBuffers serialization path
-// works end-to-end. The real API messages (session, memory ops, ...) are added here when the
-// protocol is wired into the serving layer (#2794) and the socket-backed client (#2795).
+// Reuses the existing simulation_device.fbs building blocks: DeviceRequestResponse (and its
+// tt_vcs_core / DEVICE_COMMAND) already model a memory/reset/run op, so memory access reuses it
+// directly. Only the genuinely new messages (session + structured device description) are added.
 
-table Message {
-    payload : [ubyte];
+include "simulation_device.fbs";
+
+table DeviceDescription {
+    arch : uint32;
+    board : uint32;
+    num_chips : uint32;
+    // TODO: full SoC descriptor / cluster topology / memory layout, as the server work lands.
 }
 
-root_type Message;
+table AttachRequest {}
+
+table AttachResponse {
+    description : DeviceDescription;
+}
+
+table DetachRequest {}
+
+table DetachResponse {}
+
+table AdvanceExecutionRequest {}
+
+table AdvanceExecutionResponse {}
+
+table ErrorResponse {
+    code : uint32;
+    message : string;
+}
+
+// One message per API operation. DeviceRequestResponse (reused) covers memory/reset/run ops.
+union Body {
+    AttachRequest,
+    AttachResponse,
+    DetachRequest,
+    DetachResponse,
+    AdvanceExecutionRequest,
+    AdvanceExecutionResponse,
+    DeviceRequestResponse,
+    ErrorResponse,
+}
+
+table Envelope {
+    body : Body;
+}
+
+root_type Envelope;

--- a/device/simulation/simulation_socket.cpp
+++ b/device/simulation/simulation_socket.cpp
@@ -13,8 +13,11 @@
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
+#include <optional>
 #include <system_error>
+#include <utility>
 
+#include "umd/device/simulation/simulation_server_api.hpp"
 #include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
@@ -188,6 +191,11 @@ bool SimulationSocket::bind_and_listen() {
     return true;
 }
 
+void SimulationSocket::start_serving(RequestHandler handler) {
+    std::lock_guard<std::mutex> lock(connections_mutex_);
+    handler_ = std::move(handler);
+}
+
 SimulationSocket::~SimulationSocket() {
     // Only a successfully-bound owner tears down and removes the file. A never-bound object
     // (try_create() lost to a live owner and returned nullptr) must not delete the live
@@ -205,6 +213,24 @@ SimulationSocket::~SimulationSocket() {
     if (accept_thread_.joinable()) {
         accept_thread_.join();
     }
+
+    // Unblock any worker stuck in a read, then join them. Workers close their own fd on exit
+    // (under the mutex), so we only shut down fds still marked open. The lock is released before
+    // joining so workers can take it to close.
+    {
+        std::lock_guard<std::mutex> lock(connections_mutex_);
+        for (int fd : connection_fds_) {
+            if (fd >= 0) {
+                ::shutdown(fd, SHUT_RDWR);
+            }
+        }
+    }
+    for (std::thread& worker : connection_threads_) {
+        if (worker.joinable()) {
+            worker.join();
+        }
+    }
+
     if (listen_fd_ >= 0) {
         ::close(listen_fd_);
         listen_fd_ = -1;
@@ -241,12 +267,36 @@ void SimulationSocket::accept_loop() {
         }
         if (fds[0].revents & POLLIN) {
             int client_fd = ::accept(listen_fd_, nullptr, nullptr);
-            if (client_fd >= 0) {
-                // No request handling yet (owner-only): accept and drop the connection.
-                ::close(client_fd);
+            if (client_fd < 0) {
+                continue;
             }
+            std::lock_guard<std::mutex> lock(connections_mutex_);
+            if (!handler_) {
+                // Not serving yet (owner-only / pre-start_serving): accept and drop.
+                ::close(client_fd);
+                continue;
+            }
+            const size_t index = connection_fds_.size();
+            connection_fds_.push_back(client_fd);
+            connection_threads_.emplace_back([this, client_fd, index] { serve_connection(client_fd, index); });
         }
     }
+}
+
+void SimulationSocket::serve_connection(int client_fd, size_t index) {
+    while (running_) {
+        std::optional<std::vector<uint8_t>> request = recv_framed(client_fd);
+        if (!request) {
+            break;  // Client disconnected or error.
+        }
+        const std::vector<uint8_t> response = handler_(*request);
+        if (!send_framed(client_fd, response)) {
+            break;
+        }
+    }
+    std::lock_guard<std::mutex> lock(connections_mutex_);
+    ::close(client_fd);
+    connection_fds_[index] = -1;
 }
 
 std::filesystem::path SimulationSocket::default_socket_path(ChipId chip_id) {

--- a/device/simulation/simulation_topology_discovery.cpp
+++ b/device/simulation/simulation_topology_discovery.cpp
@@ -33,10 +33,13 @@ std::map<ChipId, std::unique_ptr<TTDevice>> SimulationTopologyDiscovery::discove
                 socket_path.string()));
     }
 
-    // We are the host: bring up the backend (the direct in-process hot path) and hand it the
-    // socket to own and expose.
+    // We are the host: bring up the backend (the direct in-process hot path), then serve clients
+    // by dispatching their requests into that backend, and hand the device the socket to own.
     std::unique_ptr<TTSimTTDevice> device =
         TTSimTTDevice::create(options.simulator_directory, options.num_host_mem_channels);
+    TTSimTTDevice* device_ptr = device.get();
+    socket->start_serving(
+        [device_ptr](const std::vector<uint8_t>& request) { return device_ptr->handle_request(request); });
     device->adopt_socket(std::move(socket));
 
     devices.emplace(chip_id, std::move(device));

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -22,6 +22,7 @@
 #include "umd/device/pcie/tt_sim_tlb_handle.hpp"
 #include "umd/device/pcie/tt_sim_tlb_window.hpp"
 #include "umd/device/simulation/simulation_chip.hpp"
+#include "umd/device/simulation/simulation_server_api.hpp"
 #include "umd/device/simulation/simulation_socket.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"
 #include "umd/device/soc_descriptor.hpp"
@@ -47,6 +48,28 @@ bool sim_dram_teleport_enabled() {
         return value == "1" || value == "true" || value == "TRUE" || value == "on" || value == "ON";
     }();
     return enabled;
+}
+
+// DEVICE_COMMAND values from simulation_device.fbs, reused by the host API for memory ops.
+constexpr uint8_t SIM_CMD_WRITE = 0;
+constexpr uint8_t SIM_CMD_READ = 1;
+
+// The host API reuses DeviceRequestResponse, whose payload is a uint32 vector. These pack a byte
+// buffer into that representation and back (little-endian within each word).
+std::vector<uint32_t> pack_bytes_to_words(const std::vector<uint8_t>& bytes) {
+    std::vector<uint32_t> words((bytes.size() + 3) / 4, 0);
+    for (size_t i = 0; i < bytes.size(); ++i) {
+        words[i / 4] |= static_cast<uint32_t>(bytes[i]) << (8 * (i % 4));
+    }
+    return words;
+}
+
+std::vector<uint8_t> unpack_words_to_bytes(const std::vector<uint32_t>& words, uint32_t size) {
+    std::vector<uint8_t> bytes(size, 0);
+    for (uint32_t i = 0; i < size && (i / 4) < words.size(); ++i) {
+        bytes[i] = (words[i / 4] >> (8 * (i % 4))) & 0xFF;
+    }
+    return bytes;
 }
 
 }  // namespace
@@ -176,6 +199,55 @@ TTSimTTDevice::~TTSimTTDevice() {
 }
 
 void TTSimTTDevice::adopt_socket(std::unique_ptr<SimulationSocket> socket) { socket_ = std::move(socket); }
+
+std::vector<uint8_t> TTSimTTDevice::handle_request(const std::vector<uint8_t>& request) {
+    const Message req = decode(request);
+    Message resp;
+    switch (req.type) {
+        case MessageType::AttachRequest:
+            resp.type = MessageType::AttachResponse;
+            resp.description.arch = static_cast<uint32_t>(arch);
+            resp.description.board = 0;
+            resp.description.num_chips = 1;
+            break;
+        case MessageType::DetachRequest:
+            resp.type = MessageType::DetachResponse;
+            break;
+        case MessageType::AdvanceExecutionRequest:
+            advance_device_execution();
+            resp.type = MessageType::AdvanceExecutionResponse;
+            break;
+        case MessageType::DeviceOp: {
+            const tt_xy_pair core(req.op.endpoint.x, req.op.endpoint.y);
+            if (req.op.command == SIM_CMD_READ) {
+                std::vector<uint8_t> buffer(req.op.size, 0);
+                read_from_device(buffer.data(), core, req.op.address, req.op.size);
+                resp.type = MessageType::DeviceOp;
+                resp.op.command = SIM_CMD_READ;
+                resp.op.endpoint = req.op.endpoint;
+                resp.op.address = req.op.address;
+                resp.op.size = req.op.size;
+                resp.op.data = pack_bytes_to_words(buffer);
+            } else if (req.op.command == SIM_CMD_WRITE) {
+                const std::vector<uint8_t> buffer = unpack_words_to_bytes(req.op.data, req.op.size);
+                write_to_device(buffer.data(), core, req.op.address, req.op.size);
+                resp.type = MessageType::DeviceOp;
+                resp.op.command = SIM_CMD_WRITE;
+            } else {
+                resp.type = MessageType::Error;
+                resp.error_code = 2;
+                resp.error_message = "unsupported device command";
+            }
+            break;
+        }
+        default:
+            resp.type = MessageType::Error;
+            resp.error_code = 1;
+            resp.error_message = "unsupported request";
+            break;
+    }
+    return encode(resp);
+}
 
 void TTSimTTDevice::start_device() {}
 

--- a/tests/api/test_simulation_server_api.cpp
+++ b/tests/api/test_simulation_server_api.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 #include "umd/device/simulation/simulation_server_api.hpp"
 
@@ -36,14 +38,78 @@ TEST(SimulationServerApi, ClientCanImplementAndCallTheContract) {
     EXPECT_FALSE(client.attached());
 }
 
-// The dummy message proves the FlatBuffers serialization path works end-to-end.
-TEST(SimulationServerApiWire, MessageRoundTrip) {
+namespace {
+constexpr uint8_t CMD_WRITE = 0;  // DEVICE_COMMAND values from simulation_device.fbs.
+constexpr uint8_t CMD_READ = 1;
+}  // namespace
+
+TEST(SimulationServerApiWire, DeviceOpReadRequestRoundTrip) {
     Message msg;
-    msg.payload = {0xde, 0xad, 0xbe, 0xef};
+    msg.type = MessageType::DeviceOp;
+    msg.op.command = CMD_READ;
+    msg.op.endpoint = {2, 3};
+    msg.op.address = 0x1000;
+    msg.op.size = 64;
 
     const Message out = decode(encode(msg));
 
-    EXPECT_EQ(out.payload, msg.payload);
+    EXPECT_EQ(out.type, MessageType::DeviceOp);
+    EXPECT_EQ(out.op.command, CMD_READ);
+    EXPECT_EQ(out.op.endpoint.x, 2u);
+    EXPECT_EQ(out.op.endpoint.y, 3u);
+    EXPECT_EQ(out.op.address, 0x1000u);
+    EXPECT_EQ(out.op.size, 64u);
+}
+
+TEST(SimulationServerApiWire, DeviceOpWriteCarriesData) {
+    Message msg;
+    msg.type = MessageType::DeviceOp;
+    msg.op.command = CMD_WRITE;
+    msg.op.endpoint = {1, 1};
+    msg.op.address = 0x2000;
+    msg.op.data = {0xdeadbeef, 0x12345678, 0x0};
+
+    const Message out = decode(encode(msg));
+
+    EXPECT_EQ(out.type, MessageType::DeviceOp);
+    EXPECT_EQ(out.op.command, CMD_WRITE);
+    EXPECT_EQ(out.op.data, std::vector<uint32_t>({0xdeadbeef, 0x12345678, 0x0}));
+}
+
+TEST(SimulationServerApiWire, AttachResponseCarriesDeviceDescription) {
+    Message msg;
+    msg.type = MessageType::AttachResponse;
+    msg.description = {/*arch=*/5, /*board=*/2, /*num_chips=*/4};
+
+    const Message out = decode(encode(msg));
+
+    EXPECT_EQ(out.type, MessageType::AttachResponse);
+    EXPECT_EQ(out.description.arch, 5u);
+    EXPECT_EQ(out.description.board, 2u);
+    EXPECT_EQ(out.description.num_chips, 4u);
+}
+
+TEST(SimulationServerApiWire, ErrorRoundTrip) {
+    Message msg;
+    msg.type = MessageType::Error;
+    msg.error_code = 7;
+    msg.error_message = "boom";
+
+    const Message out = decode(encode(msg));
+
+    EXPECT_EQ(out.type, MessageType::Error);
+    EXPECT_EQ(out.error_code, 7u);
+    EXPECT_EQ(out.error_message, "boom");
+}
+
+TEST(SimulationServerApiWire, AdvanceExecutionRoundTrip) {
+    Message request;
+    request.type = MessageType::AdvanceExecutionRequest;
+    EXPECT_EQ(decode(encode(request)).type, MessageType::AdvanceExecutionRequest);
+
+    Message response;
+    response.type = MessageType::AdvanceExecutionResponse;
+    EXPECT_EQ(decode(encode(response)).type, MessageType::AdvanceExecutionResponse);
 }
 
 TEST(SimulationServerApiWire, FramePrependsLittleEndianLength) {
@@ -55,4 +121,19 @@ TEST(SimulationServerApiWire, FramePrependsLittleEndianLength) {
     const uint32_t len = framed[0] | (framed[1] << 8) | (framed[2] << 16) | (uint32_t(framed[3]) << 24);
     EXPECT_EQ(len, payload.size());
     EXPECT_EQ(std::vector<uint8_t>(framed.begin() + 4, framed.end()), payload);
+}
+
+TEST(SimulationServerApiWire, FramedSendRecvOverSocketpair) {
+    int fds[2];
+    ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+    const std::vector<uint8_t> payload = {9, 8, 7, 6};
+    ASSERT_TRUE(send_framed(fds[0], payload));
+    const auto received = recv_framed(fds[1]);
+
+    ASSERT_TRUE(received.has_value());
+    EXPECT_EQ(*received, payload);
+
+    ::close(fds[0]);
+    ::close(fds[1]);
 }

--- a/tests/api/test_simulation_topology_discovery.cpp
+++ b/tests/api/test_simulation_topology_discovery.cpp
@@ -3,15 +3,44 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
 
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 
+#include "umd/device/simulation/simulation_server_api.hpp"
 #include "umd/device/simulation/simulation_socket.hpp"
 #include "umd/device/simulation/simulation_topology_discovery.hpp"
+#include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 
 using namespace tt::umd;
+
+namespace {
+
+int connect_fd(const std::filesystem::path& path) {
+    int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    std::strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        ::close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+constexpr uint8_t CMD_WRITE = 0;  // DEVICE_COMMAND values from simulation_device.fbs.
+constexpr uint8_t CMD_READ = 1;
+
+}  // namespace
 
 // Integration: with no live host, discovery creates a host device that binds + exposes its
 // socket, and tears it down with the device. Requires TT_UMD_SIMULATOR.
@@ -35,4 +64,60 @@ TEST(SimulationTopologyDiscovery, CreatesHostDeviceAndExposesSocket) {
     }
 
     EXPECT_FALSE(std::filesystem::exists(socket));  // torn down with the device
+}
+
+// Integration: the discovered host serves the API over its socket — a raw protocol client
+// attaches, advances execution, writes a word, and reads it back. Requires TT_UMD_SIMULATOR.
+TEST(SimulationTopologyDiscovery, HostServesApiOverSocket) {
+    const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
+    if (simulator_path == nullptr) {
+        GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
+    }
+
+    const std::filesystem::path socket = SimulationSocket::default_socket_path(0);
+    std::filesystem::remove(socket);
+
+    SimulationTopologyDiscoveryOptions options;
+    options.simulator_directory = simulator_path;
+    auto devices = SimulationTopologyDiscovery::discover(options);
+    ASSERT_EQ(devices.size(), 1u);
+
+    const SocDescriptor& soc = devices.at(0)->get_soc_descriptor();
+    const tt_xy_pair core =
+        soc.translate_coord_to(soc.get_cores(tt::CoreType::TENSIX).at(0), tt::CoordSystem::TRANSLATED);
+
+    const int fd = connect_fd(socket);
+    ASSERT_GE(fd, 0);
+
+    Message attach;
+    attach.type = MessageType::AttachRequest;
+    ASSERT_TRUE(send_framed(fd, encode(attach)));
+    auto attach_resp = recv_framed(fd);
+    ASSERT_TRUE(attach_resp.has_value());
+    EXPECT_EQ(decode(*attach_resp).type, MessageType::AttachResponse);
+
+    Message write;
+    write.type = MessageType::DeviceOp;
+    write.op.command = CMD_WRITE;
+    write.op.endpoint = {static_cast<uint32_t>(core.x), static_cast<uint32_t>(core.y)};
+    write.op.address = 0x100;
+    write.op.size = 4;
+    write.op.data = {0xcafebabe};
+    ASSERT_TRUE(send_framed(fd, encode(write)));
+    ASSERT_TRUE(recv_framed(fd).has_value());
+
+    Message read;
+    read.type = MessageType::DeviceOp;
+    read.op.command = CMD_READ;
+    read.op.endpoint = write.op.endpoint;
+    read.op.address = 0x100;
+    read.op.size = 4;
+    ASSERT_TRUE(send_framed(fd, encode(read)));
+    auto read_resp = recv_framed(fd);
+    ASSERT_TRUE(read_resp.has_value());
+    const Message out = decode(*read_resp);
+    ASSERT_FALSE(out.op.data.empty());
+    EXPECT_EQ(out.op.data[0], 0xcafebabeu);
+
+    ::close(fd);
 }

--- a/tests/baremetal/test_simulation_socket.cpp
+++ b/tests/baremetal/test_simulation_socket.cpp
@@ -11,6 +11,7 @@
 #include <filesystem>
 #include <string>
 
+#include "umd/device/simulation/simulation_server_api.hpp"
 #include "umd/device/simulation/simulation_socket.hpp"
 
 using namespace tt::umd;
@@ -36,6 +37,22 @@ bool can_connect(const std::filesystem::path& path) {
     bool ok = ::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0;
     ::close(fd);
     return ok;
+}
+
+// Connects to a UNIX socket at path, returning the connected fd or -1.
+int connect_fd(const std::filesystem::path& path) {
+    int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    std::strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        ::close(fd);
+        return -1;
+    }
+    return fd;
 }
 
 // Binds a UNIX socket to path then closes it without listening, leaving a stale
@@ -124,6 +141,30 @@ TEST(SimulationSocket, TryCreateReclaimsStaleSocket) {
     EXPECT_NE(host, nullptr);  // stale leftover reclaimed
     EXPECT_TRUE(can_connect(path));
 
+    std::filesystem::remove(path);
+}
+
+TEST(SimulationSocket, StartServingHandlesRequests) {
+    const std::filesystem::path path = unique_socket_path(7);
+    std::filesystem::remove(path);
+
+    auto server = SimulationSocket::try_create(path);
+    ASSERT_NE(server, nullptr);
+    // Handler reverses the request bytes, so the response is distinguishable from a plain echo.
+    server->start_serving(
+        [](const std::vector<uint8_t>& request) { return std::vector<uint8_t>(request.rbegin(), request.rend()); });
+
+    const int fd = connect_fd(path);
+    ASSERT_GE(fd, 0);
+
+    const std::vector<uint8_t> request = {1, 2, 3, 4};
+    ASSERT_TRUE(send_framed(fd, request));
+    const auto response = recv_framed(fd);
+
+    ASSERT_TRUE(response.has_value());
+    EXPECT_EQ(*response, std::vector<uint8_t>({4, 3, 2, 1}));
+
+    ::close(fd);
     std::filesystem::remove(path);
 }
 


### PR DESCRIPTION
### Issue
Part of #2794 (host serving layer). Stacked on the API-scaffold PR (#2802).

### Description
The simulation host now serves the API end-to-end — the real messages are defined **and handled** server-side (no API without handling).

- **Protocol**: reuses `DeviceRequestResponse`/`tt_vcs_core` (via `include`) for memory/reset/run ops, adds session (`Attach`/`Detach`) + a structured `DeviceDescription` under one `Envelope` union; `encode`/`decode` + framing.
- **Transport**: `send_framed`/`recv_framed` over a connected stream fd (4-byte LE length prefix).
- **Serving loop**: `SimulationSocket` takes a `RequestHandler` and spawns a worker thread per connection (`recv → handler → send` until disconnect; workers joined on shutdown); no handler keeps the accept-and-drop behavior.
- **Server-side handling**: `TTSimTTDevice` constructs its socket with a handler that dispatches each request into its own backend ops — `Attach` → device description; `DeviceOp` READ/WRITE → `read`/`write_to_device` — the same ops the host calls directly. Serving is stopped before the backend is torn down.

### List of the changes
- `simulation_server_api.{fbs,hpp,cpp}`: real message set, `encode`/`decode`, `frame`, `send_framed`/`recv_framed`.
- `simulation_socket.{hpp,cpp}`: optional `RequestHandler`, per-connection worker threads + clean shutdown.
- `tt_sim_tt_device.{hpp,cpp}`: the request handler that dispatches into backend ops; teardown stops serving first.
- Tests: serialization round-trips, framed transport over a socketpair, serving through a handler, and a simulator-gated integration test where a raw client attaches + writes + reads back over the socket.

### Testing
- `SimulationServerApi*` + `SimulationSocket*` pass, incl. the integration tests against the qsr `libttsim.so`; full TTSim suite unaffected; pre-commit clean.

### API Changes
- `SimulationSocket` gains an optional `RequestHandler` constructor arg (default null = unchanged).
- `simulation_server_api.hpp` gains the real message types + transport helpers.

### Follow-up
- Client device + open-or-attach (#2795): the socket-backed `TTDevice` that forwards via this protocol, so a second UMD attaches instead of failing.
- Grow the API incrementally — each new op = a message in `simulation_server_api` + its handling here.
