### PR TITLE
Default num channels in tests

### DIFF
--- a/tests/api/test_arc_telemetry.cpp
+++ b/tests/api/test_arc_telemetry.cpp
@@ -73,7 +73,7 @@ TEST(TestTelemetry, TelemetryEntryAvailable) {
 }
 
 TEST(TestTelemetry, RemoteTelemetry) {
-    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> umd_cluster = test_utils::make_default_test_cluster();
     auto remote_chips = umd_cluster->get_target_remote_device_ids();
     if (remote_chips.empty()) {
         GTEST_SKIP() << "No remote devices found in cluster.";

--- a/tests/api/test_arc_telemetry.cpp
+++ b/tests/api/test_arc_telemetry.cpp
@@ -11,6 +11,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <vector>
 
+#include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/chip/remote_chip.hpp"
 #include "umd/device/cluster.hpp"

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 
+#include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
 #include "umd/device/soc_descriptor.hpp"

--- a/tests/api/test_chip.cpp
+++ b/tests/api/test_chip.cpp
@@ -27,7 +27,7 @@ using namespace tt::umd;
 
 // TODO: Once default auto TLB setup is in, check it is setup properly.
 TEST(ApiChipTest, DISABLED_ManualTLBConfiguration) {
-    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> umd_cluster = test_utils::make_default_test_cluster();
 
     // Expect to throw for remote chip for any worker core.
     auto remote_chips = umd_cluster->get_target_remote_device_ids();
@@ -70,7 +70,7 @@ TEST(ApiChipTest, DISABLED_ManualTLBConfiguration) {
 
 // TODO: Move to test_chip.
 TEST(ApiChipTest, SimpleAPIShowcase) {
-    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> umd_cluster = test_utils::make_default_test_cluster();
 
     ChipId chip_id = umd_cluster->get_cluster_description()->get_chips_with_mmio().begin()->first;
 
@@ -83,7 +83,7 @@ TEST(ApiChipTest, SimpleAPIShowcase) {
 // // This tests puts a specific core into reset and then deasserts it using default deassert value
 // // It reads back the risc reset reg to validate
 // TEST(ApiChipTest, DeassertRiscResetOnCore) {
-//     std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
+//     std::unique_ptr<Cluster> umd_cluster = test_utils::make_default_test_cluster();
 
 //     tt_cxy_pair chip_core_coord = get_tensix_chip_core_coord(umd_cluster);
 
@@ -102,7 +102,7 @@ TEST(ApiChipTest, SimpleAPIShowcase) {
 // // This tests puts a specific core into reset and then specifies a legal deassert value
 // // It reads back the risc reset reg to validate
 // TEST(ApiChipTest, SpecifyLegalDeassertRiscResetOnCore) {
-//     std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
+//     std::unique_ptr<Cluster> umd_cluster = test_utils::make_default_test_cluster();
 
 //     tt_cxy_pair chip_core_coord = get_tensix_chip_core_coord(umd_cluster);
 
@@ -120,7 +120,7 @@ TEST(ApiChipTest, SimpleAPIShowcase) {
 // // // This tests puts a specific core into reset and then specifies an illegal deassert value
 // // // It reads back the risc reset reg to validate that reset reg is in a legal state
 // TEST(ApiChipTest, SpecifyIllegalDeassertRiscResetOnCore) {
-//     std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
+//     std::unique_ptr<Cluster> umd_cluster = test_utils::make_default_test_cluster();
 
 //     tt_cxy_pair chip_core_coord = get_tensix_chip_core_coord(umd_cluster);
 

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -16,6 +16,7 @@
 #include <utility>
 #include <vector>
 
+#include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/test_api_common.hpp"
 #include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -46,7 +46,7 @@ using namespace tt::umd;
 TEST(ApiClusterTest, OpenAllSiliconChips) { std::unique_ptr<Cluster> umd_cluster = make_cluster_for_test(); }
 
 TEST(TestCluster, PrintAllSiliconChipsAllCores) {
-    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> umd_cluster = test_utils::make_default_test_cluster();
 
     for (ChipId chip : umd_cluster->get_target_device_ids()) {
         std::cout << "Chip " << chip << std::endl;
@@ -86,7 +86,7 @@ TEST(TestCluster, PrintAllSiliconChipsAllCores) {
 }
 
 TEST(TestCluster, TestClusterAICLKControl) {
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     auto get_expected_clock_val = [&cluster](ChipId chip_id, bool busy) {
         tt::ARCH arch = cluster->get_cluster_description()->get_arch(chip_id);
@@ -116,12 +116,12 @@ TEST(TestCluster, TestClusterAICLKControl) {
 }
 
 TEST(TestCluster, RefreshClusterDescriptionDoesNotThrow) {
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
     EXPECT_NO_THROW(cluster->refresh_cluster_description());
 }
 
 TEST(TestCluster, GetEthernetFirmware) {
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     // BoardType P100 doesn't have eth cores.
     std::optional<SemVer> eth_version;
@@ -162,7 +162,7 @@ TEST(TestCluster, TestDifferentPowerModes) {
     }
 
     {
-        std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+        std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
         for (ChipId chip_id : cluster->get_target_device_ids()) {
             TTDevice* tt_device = cluster->get_tt_device(chip_id);
             ArcTelemetryReader* telemetry_reader = tt_device->get_arc_telemetry_reader();

--- a/tests/api/test_cluster.cpp
+++ b/tests/api/test_cluster.cpp
@@ -43,7 +43,9 @@ using namespace tt::umd;
 // Galaxy.
 
 // This test should be one line only.
-TEST(ApiClusterTest, OpenAllSiliconChips) { std::unique_ptr<Cluster> umd_cluster = make_cluster_for_test(); }
+TEST(ApiClusterTest, OpenAllSiliconChips) {
+    std::unique_ptr<Cluster> umd_cluster = test_utils::make_default_test_cluster();
+}
 
 TEST(TestCluster, PrintAllSiliconChipsAllCores) {
     std::unique_ptr<Cluster> umd_cluster = test_utils::make_default_test_cluster();

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 #include <vector>
 
+#include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -314,7 +314,7 @@ TEST(TestClusterDescriptor, VerifyStandardTopology) {
 // chip. This is needed because of eth id readouts for Blackhole that don't take harvesting
 // into acount. This test verifies that both for Wormhole and Blackhole.
 TEST(TestClusterDescriptor, TestClusterLogicalETHChannelsConnectivity) {
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
 

--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -304,7 +304,8 @@ TEST_P(TestMulticastWriteFixture, TestMulticastWrite) {
     // TODO: sysmem_enabled parameter to be added in the following PR.
     auto [use_noc0, full_grid] = GetParam();
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{.num_host_mem_ch_per_mmio_device = 0});
+    std::unique_ptr<Cluster> cluster =
+        test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 0});
 
     constexpr uint64_t address = SAFE_IO_L1_ADDRESS;
     constexpr size_t num_words = 10;
@@ -458,7 +459,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(ClusterReadWriteL1Test, ReadWriteL1) {
     ClusterOptions options = GetParam();
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(options);
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster(options);
 
     if (options.chip_type == ChipType::SIMULATION) {
         cluster->start_device({.init_device = true});

--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -801,7 +801,8 @@ void read_data_based_on_architecture(Cluster& cluster, CoreCoord core, void* mem
  */
 TEST(TestDeviceIO, DMA1) {
     const ChipId chip = 0;
-    Cluster cluster;
+    std::unique_ptr<Cluster> cluster_ptr = test_utils::make_default_test_cluster();
+    Cluster& cluster = *cluster_ptr;
 
     auto& soc_descriptor = cluster.get_soc_descriptor(chip);
     size_t dram_count = soc_descriptor.get_num_dram_channels();
@@ -849,7 +850,8 @@ TEST(TestDeviceIO, DMA1) {
  */
 TEST(TestDeviceIO, DMA2) {
     const ChipId chip = 0;
-    Cluster cluster;
+    std::unique_ptr<Cluster> cluster_ptr = test_utils::make_default_test_cluster();
+    Cluster& cluster = *cluster_ptr;
 
     auto& soc_descriptor = cluster.get_soc_descriptor(chip);
     size_t dram_count = 1;

--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -458,7 +458,7 @@ INSTANTIATE_TEST_SUITE_P(
     });
 
 TEST_P(ClusterReadWriteL1Test, ReadWriteL1) {
-    ClusterOptions options = GetParam();
+    const ClusterOptions& options = GetParam();
     std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster(options);
 
     if (options.chip_type == ChipType::SIMULATION) {

--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -65,7 +65,7 @@ class TestDeviceIOFixture : public ::testing::TestWithParam<CoreType> {};
 
 TEST_P(TestDeviceIOFixture, SimpleIOAllTargets) {
     const CoreType core_type = GetParam();
-    std::unique_ptr<Cluster> umd_cluster = make_cluster_for_test();
+    std::unique_ptr<Cluster> umd_cluster = test_utils::make_default_test_cluster();
 
     // Initialize random data.
     size_t data_size = 1024;
@@ -109,7 +109,7 @@ TEST_P(TestDeviceIOFixture, SimpleIOAllTargets) {
 
 TEST_P(TestDeviceIOFixture, RemoteFlush) {
     const CoreType core_type = GetParam();
-    std::unique_ptr<Cluster> umd_cluster = make_cluster_for_test();
+    std::unique_ptr<Cluster> umd_cluster = test_utils::make_default_test_cluster();
 
     const ClusterDescriptor* cluster_desc = umd_cluster->get_cluster_description();
 
@@ -152,7 +152,7 @@ TEST_P(TestDeviceIOFixture, RemoteFlush) {
 
 TEST_P(TestDeviceIOFixture, SimpleIOSpecificDevices) {
     const CoreType core_type = GetParam();
-    std::unique_ptr<Cluster> umd_cluster = make_cluster_for_test(ClusterOptions{
+    std::unique_ptr<Cluster> umd_cluster = test_utils::make_default_test_cluster(ClusterOptions{
         .target_devices = {0},
     });
 
@@ -201,7 +201,8 @@ TEST_P(TestDeviceIOFixture, DynamicTLB_RW) {
     // to be reconfigured for each transaction
     const CoreType core_type = GetParam();
 
-    std::unique_ptr<Cluster> cluster = make_cluster_for_test(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    std::unique_ptr<Cluster> cluster =
+        test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
 
     std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -242,7 +243,7 @@ TEST_P(TestDeviceIOFixture, DynamicTLB_RW) {
 }
 
 TEST_F(TestDeviceIOFixture, TestDmaMulticastWrite) {
-    std::unique_ptr<Cluster> cluster = make_cluster_for_test();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     if (cluster->get_tt_device(0)->get_arch() == tt::ARCH::BLACKHOLE) {
         GTEST_SKIP() << "DMA multicast write is not supported on Blackhole architecture.";
@@ -543,7 +544,7 @@ TEST_F(TestDeviceIOFixture, SysmemReadWrite) {
     }
 
     std::unique_ptr<Cluster> cluster =
-        make_cluster_for_test(ClusterOptions{.num_host_mem_ch_per_mmio_device = channels});
+        test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = channels});
     if (cluster->get_soc_descriptor(0).arch == tt::ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping the test for quasar since Sysmem is not supported yet.";
     }
@@ -664,7 +665,7 @@ TEST_F(TestDeviceIOFixture, SysmemReadWrite) {
 }
 
 TEST_F(TestDeviceIOFixture, RegReadWrite) {
-    std::unique_ptr<Cluster> cluster = make_cluster_for_test();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     const CoreCoord tensix_core = cluster->get_soc_descriptor(0).get_cores(CoreType::TENSIX)[0];
 
@@ -709,7 +710,7 @@ TEST_F(TestDeviceIOFixture, RegReadWrite) {
 }
 
 TEST_F(TestDeviceIOFixture, WriteDataReadReg) {
-    std::unique_ptr<Cluster> cluster = make_cluster_for_test();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     const CoreCoord tensix_core = cluster->get_soc_descriptor(0).get_cores(CoreType::TENSIX)[0];
 
@@ -753,7 +754,7 @@ TEST(TestDeviceIO, SmnReadWriteRoundTrip) {
         GTEST_SKIP() << "SMN is only available on the RTL simulator.";
     }
 
-    std::unique_ptr<Cluster> cluster = make_cluster_for_test();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
     cluster->start_device({.init_device = true});
 
     TTDevice* tt_device = cluster->get_tt_device(0);
@@ -991,7 +992,7 @@ TEST(TestDramMembar, StartDeviceDramMembarSubchannel) {
 // Stress-size loopback: write/read increasing power-of-two payloads on a Tensix core
 // (up to 1 MB) and a DRAM core (up to 256 MB).
 TEST_F(TestDeviceIOFixture, DISABLED_LoopbackStressSize) {
-    std::unique_ptr<Cluster> cluster = make_cluster_for_test();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     const uint32_t seed = std::random_device{}();
     GTEST_LOG_(INFO) << "LoopbackStressSize RNG seed = " << seed;

--- a/tests/api/test_hang_detection.cpp
+++ b/tests/api/test_hang_detection.cpp
@@ -14,6 +14,7 @@
 
 #include "device/api/umd/device/warm_reset.hpp"
 #include "device/api/umd/device/warm_reset_with_recovery.hpp"
+#include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/cluster.hpp"

--- a/tests/api/test_hang_detection.cpp
+++ b/tests/api/test_hang_detection.cpp
@@ -80,7 +80,7 @@ protected:
         soc_desc_.reset();
         WarmResetWithRecovery::warm_reset();
 
-        auto cluster = std::make_unique<Cluster>();
+        auto cluster = test_utils::make_default_test_cluster();
         EXPECT_FALSE(cluster->get_target_device_ids().empty()) << "No chips present after warm reset.";
         cluster.reset();
 

--- a/tests/api/test_jtag.cpp
+++ b/tests/api/test_jtag.cpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 
+#include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/jtag/jtag.hpp"
 #include "umd/device/jtag/jtag_device.hpp"

--- a/tests/api/test_jtag.cpp
+++ b/tests/api/test_jtag.cpp
@@ -218,7 +218,7 @@ TEST(ApiJtagClusterTest, JtagClusterIOTest) {
     }
 
     std::unique_ptr<Cluster> umd_cluster =
-        std::make_unique<Cluster>(ClusterOptions{.io_device_type = IODeviceType::JTAG});
+        test_utils::make_default_test_cluster(ClusterOptions{.io_device_type = IODeviceType::JTAG});
 
     // Initialize random data.
     size_t data_size = 10;

--- a/tests/api/test_noc.cpp
+++ b/tests/api/test_noc.cpp
@@ -39,7 +39,7 @@ using namespace tt::umd;
 
 class TestNoc : public ::testing::Test {
 public:
-    void SetUp() override { cluster_ = std::make_unique<Cluster>(); }
+    void SetUp() override { cluster_ = test_utils::make_default_test_cluster(); }
 
     void verify_noc_id_cores_via_other_noc(
         ChipId chip, CoreType core_type, CoordSystem this_noc, bool use_harvested_cores) {

--- a/tests/api/test_noc.cpp
+++ b/tests/api/test_noc.cpp
@@ -21,6 +21,7 @@
 #include <variant>
 #include <vector>
 
+#include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/cluster.hpp"

--- a/tests/api/test_risc_program.cpp
+++ b/tests/api/test_risc_program.cpp
@@ -278,7 +278,8 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::ValuesIn(ClusterAssertDeassertRiscsTest::generate_all_risc_cores_combinations()));
 
 TEST(TestRiscProgram, StartDeviceWithValidRiscProgram) {
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    std::unique_ptr<Cluster> cluster =
+        test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
     constexpr uint64_t write_address = 0x1000;
 
     test_utils::safe_test_cluster_start(cluster.get());

--- a/tests/api/test_risc_program.cpp
+++ b/tests/api/test_risc_program.cpp
@@ -324,7 +324,7 @@ TEST(TestRiscProgram, SimpleApiTest) {
         GTEST_SKIP() << "SimpleApiTest is currently sim-only.";
     }
 
-    std::unique_ptr<Cluster> cluster = make_cluster_for_test();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     for (auto chip_id : cluster->get_target_device_ids()) {
         const SocDescriptor& soc_desc = cluster->get_soc_descriptor(chip_id);

--- a/tests/api/test_risc_program.cpp
+++ b/tests/api/test_risc_program.cpp
@@ -36,8 +36,7 @@ using namespace tt::umd;
 // this program is explained in the GENERATE_ASSEMBLY_FOR_TESTS.md file.
 TEST(TestRiscProgram, DeassertResetBrisc) {
     // The test has large transfers to remote chip, so system memory significantly speeds up the test.
-    std::unique_ptr<Cluster> cluster =
-        std::make_unique<Cluster>(ClusterOptions{.num_host_mem_ch_per_mmio_device = get_num_host_ch_for_test()});
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster(ClusterOptions{}, /*needs_sysmem=*/true);
 
     constexpr uint32_t a_variable_value = 0x87654000;
     constexpr uint64_t a_variable_address = 0x10000;
@@ -89,8 +88,7 @@ TEST(TestRiscProgram, DeassertResetBrisc) {
 
 TEST(TestRiscProgram, DeassertResetWithCounterBrisc) {
     // The test has large transfers to remote chip, so system memory significantly speeds up the test.
-    std::unique_ptr<Cluster> cluster =
-        std::make_unique<Cluster>(ClusterOptions{.num_host_mem_ch_per_mmio_device = get_num_host_ch_for_test()});
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster(ClusterOptions{}, /*needs_sysmem=*/true);
 
     // TODO: remove this check when it is figured out what is happening with Blackhole version of this test.
     if (cluster->get_tt_device(0)->get_arch() == tt::ARCH::BLACKHOLE) {
@@ -160,8 +158,7 @@ TEST(TestRiscProgram, DeassertResetWithCounterBrisc) {
 
 TEST_P(ClusterAssertDeassertRiscsTest, TriscNcriscAssertDeassertTest) {
     // The test has large transfers to remote chip, so system memory significantly speeds up the test.
-    std::unique_ptr<Cluster> cluster =
-        std::make_unique<Cluster>(ClusterOptions{.num_host_mem_ch_per_mmio_device = get_num_host_ch_for_test()});
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster(ClusterOptions{}, /*needs_sysmem=*/true);
 
     // TODO: remove this check when it is figured out what is happening with Blackhole version of this test.
     if (cluster->get_tt_device(0)->get_arch() == tt::ARCH::BLACKHOLE) {

--- a/tests/api/test_risc_program.cpp
+++ b/tests/api/test_risc_program.cpp
@@ -19,6 +19,7 @@
 
 #include "test_utils/assembly_programs_for_tests.hpp"
 #include "test_utils/setup_risc_cores.hpp"
+#include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/test_api_common.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -22,7 +22,7 @@
 using namespace tt::umd;
 
 TEST(TestSocDescriptor, SocDescriptorSerialize) {
-    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> umd_cluster = test_utils::make_default_test_cluster();
 
     for (auto chip_id : umd_cluster->get_target_device_ids()) {
         const SocDescriptor& soc_descriptor = umd_cluster->get_soc_descriptor(chip_id);
@@ -36,7 +36,7 @@ TEST(TestSocDescriptor, SocDescriptorSerialize) {
 }
 
 TEST(TestSocDescriptor, LiteralCoordSystem) {
-    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> umd_cluster = test_utils::make_default_test_cluster();
 
     for (auto chip_id : umd_cluster->get_target_device_ids()) {
         const SocDescriptor& soc_descriptor = umd_cluster->get_soc_descriptor(chip_id);

--- a/tests/api/test_soc_descriptor.cpp
+++ b/tests/api/test_soc_descriptor.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -82,7 +82,7 @@ TEST(ApiSysmemManager, SysmemBuffers) {
         GTEST_SKIP() << "Skipping test for Blackhole, as PCIE DMA is not supported on Blackhole.";
     }
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     const ChipId mmio_chip = *cluster->get_target_mmio_device_ids().begin();
 
@@ -140,7 +140,7 @@ TEST(ApiSysmemManager, SysmemBufferUnaligned) {
         GTEST_SKIP() << "Skipping test for Blackhole, as PCIE DMA is not supported on Blackhole.";
     }
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     const ChipId mmio_chip = *cluster->get_target_mmio_device_ids().begin();
 
@@ -200,7 +200,7 @@ TEST(ApiSysmemManager, SysmemBufferFunctions) {
         GTEST_SKIP() << "Skipping test since IOMMU is not enabled.";
     }
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     const ChipId mmio_chip = *cluster->get_target_mmio_device_ids().begin();
 
@@ -229,7 +229,7 @@ TEST(ApiSysmemManager, SysmemBufferNocAddress) {
         GTEST_SKIP() << "Skipping test since KMD doesn't support noc address mapping.";
     }
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     const ChipId mmio_chip = *cluster->get_target_mmio_device_ids().begin();
 

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -15,6 +15,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/chip/chip.hpp"
 #include "umd/device/chip_helpers/silicon_sysmem_manager.hpp"
 #include "umd/device/chip_helpers/sysmem_buffer.hpp"

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -167,8 +167,7 @@ TEST(ApiTTDeviceTest, TTDeviceMultipleThreadsIO) {
 
 TEST(ApiTTDeviceTest, TestRemoteTTDevice) {
     // The test does large transfers to remote chip, so system memory significantly speeds up the tests.
-    std::unique_ptr<Cluster> cluster =
-        std::make_unique<Cluster>(ClusterOptions{.num_host_mem_ch_per_mmio_device = get_num_host_ch_for_test()});
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster(ClusterOptions{}, /*needs_sysmem=*/true);
 
     ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
 

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -15,6 +15,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/test_api_common.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/chip/chip.hpp"

--- a/tests/api/test_tt_visible_devices.cpp
+++ b/tests/api/test_tt_visible_devices.cpp
@@ -271,7 +271,7 @@ TEST_F(TestTTVisibleDevices, DifferentConstructors) {
         tt::ARCH device_arch = Cluster::create_cluster_descriptor()->get_arch(0);
         // You can add a custom soc descriptor here.
         std::string sdesc_path = test_utils::get_soc_descriptor_path(device_arch);
-        umd_cluster = std::make_unique<Cluster>(ClusterOptions{
+        umd_cluster = test_utils::make_default_test_cluster(ClusterOptions{
             .sdesc_path = sdesc_path,
         });
         umd_cluster.reset();

--- a/tests/api/test_tt_visible_devices.cpp
+++ b/tests/api/test_tt_visible_devices.cpp
@@ -78,7 +78,7 @@ TEST_F(TestTTVisibleDevices, OpenChipsById) {
         }
 
         // Make sure that Cluster construction is without exceptions.
-        std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+        std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
         if (!target_device_ids.empty()) {
             // If target_device_ids is empty, then full cluster will be created, so skip the check.
@@ -139,7 +139,7 @@ TEST_F(TestTTVisibleDevices, OpenChipsByBDF) {
         }
 
         // Make sure that Cluster construction is without exceptions.
-        std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+        std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
         // Check that the cluster has the expected number of chips.
         auto actual_pci_device_ids = cluster->get_target_mmio_device_ids();
@@ -149,7 +149,7 @@ TEST_F(TestTTVisibleDevices, OpenChipsByBDF) {
 
 TEST_F(TestTTVisibleDevices, OpenChipsByBDFWormhole6U) {
     // Get all available PCI devices and their BDF addresses.
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     if (cluster->get_tt_device(0)->get_board_type() != BoardType::UBB_WORMHOLE) {
         GTEST_SKIP() << "This test is intended to be run on Wormhole 6U systems only.";
@@ -162,7 +162,7 @@ TEST_F(TestTTVisibleDevices, OpenChipsByBDFWormhole6U) {
     }
 
     // Make sure that Cluster construction is without exceptions.
-    std::unique_ptr<Cluster> cluster_tt_visible_devices = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster_tt_visible_devices = test_utils::make_default_test_cluster();
 
     // Check that the cluster has the expected number of chips.
     auto actual_pci_device_ids = cluster_tt_visible_devices->get_target_mmio_device_ids();
@@ -171,7 +171,7 @@ TEST_F(TestTTVisibleDevices, OpenChipsByBDFWormhole6U) {
 
 TEST_F(TestTTVisibleDevices, OpenChipsByBDFWormhole6USameChip) {
     // Get all available PCI devices and their BDF addresses.
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     if (cluster->get_tt_device(0)->get_board_type() != BoardType::UBB_WORMHOLE) {
         GTEST_SKIP() << "This test is intended to be run on Wormhole 6U systems only.";
@@ -185,7 +185,7 @@ TEST_F(TestTTVisibleDevices, OpenChipsByBDFWormhole6USameChip) {
     }
 
     // Make sure that Cluster construction is without exceptions.
-    std::unique_ptr<Cluster> cluster_tt_visible_devices = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster_tt_visible_devices = test_utils::make_default_test_cluster();
 
     // Check that the cluster has the expected number of chips, which is 1 because of the BDF being the lowest out of
     // all chips on galaxy, which is at the same time represented by logical ID 0.
@@ -195,7 +195,7 @@ TEST_F(TestTTVisibleDevices, OpenChipsByBDFWormhole6USameChip) {
 
 TEST_F(TestTTVisibleDevices, OpenChipsByBDFWormhole6UPattern) {
     // Get all available PCI devices and their BDF addresses.
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     if (cluster->get_tt_device(0)->get_board_type() != BoardType::UBB_WORMHOLE) {
         GTEST_SKIP() << "This test is intended to be run on Wormhole 6U systems only.";
@@ -208,7 +208,7 @@ TEST_F(TestTTVisibleDevices, OpenChipsByBDFWormhole6UPattern) {
     }
 
     // Make sure that Cluster construction is without exceptions.
-    std::unique_ptr<Cluster> cluster_tt_visible_devices = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster_tt_visible_devices = test_utils::make_default_test_cluster();
 
     // Check that the cluster has the expected number of chips. By pattern in TT_VISIBLE_DEVICES, we should select full
     // tray of chips, which is 8 chips in total.
@@ -241,7 +241,7 @@ TEST_F(TestTTVisibleDevices, OpenChipsByIdException) {
 TEST_F(TestTTVisibleDevices, LogicalIdMatchesEnumerateDevicesOrder) {
     std::vector<int> enumerated_ids = PCIDevice::enumerate_devices();
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     // Verify that for each logical ID i, the PCI device behind it matches
     // the i-th device returned by enumerate_devices() (which is BDF-sorted).
@@ -262,7 +262,7 @@ TEST_F(TestTTVisibleDevices, DifferentConstructors) {
     std::unique_ptr<Cluster> umd_cluster;
 
     // 1. Simplest constructor. Creates Cluster with all the chips available.
-    umd_cluster = std::make_unique<Cluster>();
+    umd_cluster = test_utils::make_default_test_cluster();
     bool chips_available = !umd_cluster->get_target_device_ids().empty();
     umd_cluster.reset();
 

--- a/tests/api/test_warm_reset.cpp
+++ b/tests/api/test_warm_reset.cpp
@@ -30,6 +30,7 @@
 
 #include "device/api/umd/device/warm_reset.hpp"
 #include "device/api/umd/device/warm_reset_with_recovery.hpp"
+#include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/pipe_communication.hpp"
 #include "tests/test_utils/test_api_common.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"

--- a/tests/api/test_warm_reset.cpp
+++ b/tests/api/test_warm_reset.cpp
@@ -90,7 +90,7 @@ TEST(WarmResetTest, DISABLED_TTDeviceWarmResetAfterNocHang) {
         GTEST_SKIP() << "Skipping test on ARM64 due to instability.";
     }
 
-    auto cluster = std::make_unique<Cluster>();
+    auto cluster = test_utils::make_default_test_cluster();
     if (is_galaxy_configuration(cluster.get())) {
         GTEST_SKIP() << "Skipping test calling warm_reset() on Galaxy configurations.";
     }
@@ -121,7 +121,7 @@ TEST(WarmResetTest, DISABLED_TTDeviceWarmResetAfterNocHang) {
     // After a warm reset, topology discovery must be performed to detect available chips.
     // Creating a Cluster triggers this discovery process, which is why a Cluster is instantiated here,
     // even though this is a TTDevice test.
-    cluster = std::make_unique<Cluster>();
+    cluster = test_utils::make_default_test_cluster();
 
     EXPECT_FALSE(cluster->get_target_device_ids().empty()) << "No chips present after reset.";
 
@@ -357,7 +357,7 @@ TEST(WarmResetTest, DISABLED_SafeApiMultiProcess) {
 }
 
 TEST(WarmResetTest, GalaxyWarmResetScratch) {
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
     static constexpr uint32_t DEFAULT_VALUE_IN_SCRATCH_REGISTER = 0;
 
     if (!is_galaxy_configuration(cluster.get())) {
@@ -387,7 +387,7 @@ TEST(WarmResetTest, GalaxyWarmResetScratch) {
 
     cluster.reset();
 
-    cluster = std::make_unique<Cluster>();
+    cluster = test_utils::make_default_test_cluster();
 
     for (auto& chip_id : cluster->get_target_mmio_device_ids()) {
         auto tt_device = cluster->get_chip(chip_id)->get_tt_device();
@@ -405,7 +405,7 @@ TEST(WarmResetTest, ClusterWarmReset) {
     if constexpr (utils::is_arm_platform()) {
         GTEST_SKIP() << "Warm reset is disabled on ARM64 due to instability.";
     }
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     if (is_galaxy_configuration(cluster.get())) {
         GTEST_SKIP() << "Skipping test calling warm_reset() on Galaxy configurations.";
@@ -436,7 +436,7 @@ TEST(WarmResetTest, ClusterWarmReset) {
 
     cluster.reset();
 
-    cluster = std::make_unique<Cluster>();
+    cluster = test_utils::make_default_test_cluster();
 
     EXPECT_FALSE(cluster->get_target_device_ids().empty()) << "No chips present after reset.";
 
@@ -473,7 +473,7 @@ enum class WarmResetMethod { PCI_DEVICE_IDS, CHIP_IDS, PCI_BDFS };
 class ClusterWarmResetScratchMethodTest : public testing::TestWithParam<WarmResetMethod> {};
 
 TEST_P(ClusterWarmResetScratchMethodTest, ClusterWarmResetScratch) {
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     if (cluster->get_target_device_ids().empty()) {
         GTEST_SKIP() << "No chips present on the system. Skipping test.";
@@ -520,7 +520,7 @@ TEST_P(ClusterWarmResetScratchMethodTest, ClusterWarmResetScratch) {
 
     cluster.reset();
 
-    cluster = std::make_unique<Cluster>();
+    cluster = test_utils::make_default_test_cluster();
     chip_id = *cluster->get_target_device_ids().begin();
     tt_device = cluster->get_chip(chip_id)->get_tt_device();
 

--- a/tests/baremetal/test_cluster.cpp
+++ b/tests/baremetal/test_cluster.cpp
@@ -17,7 +17,7 @@ using namespace tt::umd;
 
 // This test is used that cluster can be created in a baremetal environment.
 TEST(TestClusterBaremetal, BasicClusterAPI) {
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     EXPECT_EQ(cluster->get_target_device_ids().size(), 0);
     EXPECT_EQ(cluster->get_target_mmio_device_ids().size(), 0);

--- a/tests/baremetal/test_cluster.cpp
+++ b/tests/baremetal/test_cluster.cpp
@@ -10,6 +10,7 @@
 #include <set>
 #include <string>
 
+#include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/cluster.hpp"
 
 using namespace tt::umd;

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -42,7 +42,8 @@ static void set_barrier_params(Cluster& cluster) {
 TEST(SiliconDriverBH, CreateDestroy) {
     DeviceParams default_params;
     for (int i = 0; i < 50; i++) {
-        Cluster cluster;
+        auto cluster_ptr = test_utils::make_default_test_cluster();
+        Cluster& cluster = *cluster_ptr;
         set_barrier_params(cluster);
         test_utils::safe_test_cluster_start(&cluster);
         cluster.close_device();
@@ -50,7 +51,8 @@ TEST(SiliconDriverBH, CreateDestroy) {
 }
 
 TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
-    Cluster cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    auto cluster_ptr = test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    Cluster& cluster = *cluster_ptr;
     set_barrier_params(cluster);
 
     // Do this only for a single chip to speed up the test.
@@ -90,7 +92,8 @@ TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
 }
 
 TEST(SiliconDriverBH, StaticTLB_RW) {
-    Cluster cluster;
+    auto cluster_ptr = test_utils::make_default_test_cluster();
+    Cluster& cluster = *cluster_ptr;
     set_barrier_params(cluster);
 
     // Do this only for a single chip to speed up the test.
@@ -135,7 +138,8 @@ TEST(SiliconDriverBH, StaticTLB_RW) {
 TEST(SiliconDriverBH, DynamicTLB_RW) {
     // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for
     // each transaction
-    Cluster cluster;
+    auto cluster_ptr = test_utils::make_default_test_cluster();
+    Cluster& cluster = *cluster_ptr;
     set_barrier_params(cluster);
 
     auto chip_id = *cluster.get_target_mmio_device_ids().begin();
@@ -196,7 +200,8 @@ TEST(SiliconDriverBH, DynamicTLB_RW) {
 TEST(SiliconDriverBH, DISABLED_MultiThreadedDevice) {
     // Have 2 threads read and write from a single device concurrently
     // All transactions go through a single Dynamic TLB. We want to make sure this is thread/process safe.
-    Cluster cluster;
+    auto cluster_ptr = test_utils::make_default_test_cluster();
+    Cluster& cluster = *cluster_ptr;
 
     set_barrier_params(cluster);
 
@@ -248,7 +253,8 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
 
     // Memory barrier flags get sent to address 0 for all channels in this test.
     uint32_t base_addr = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
-    Cluster cluster;
+    auto cluster_ptr = test_utils::make_default_test_cluster();
+    Cluster& cluster = *cluster_ptr;
     set_barrier_params(cluster);
     for (auto chip_id : cluster.get_target_device_ids()) {
         // Iterate over devices and only setup static TLBs for functional worker cores.
@@ -363,7 +369,8 @@ TEST(SiliconDriverBH, WriteCountMatchesPostedWrites) {
     constexpr uint64_t NIU_SLV_POSTED_WR_REQ_RECEIVED = 0xffb202e0;
     constexpr uint32_t kNumWrites = 100000;
 
-    Cluster cluster;
+    auto cluster_ptr = test_utils::make_default_test_cluster();
+    Cluster& cluster = *cluster_ptr;
     set_barrier_params(cluster);
     test_utils::safe_test_cluster_start(&cluster);
 
@@ -444,7 +451,8 @@ TEST(SiliconDriverBH, VirtualCoordinateBroadcast) {
     // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly, and that
     // a broadcast targeting one core type does not leak writes to the other.
     // Blackhole has no ERISC firmware broadcast, so this exercises the SW fallback in broadcast_write_to_cluster.
-    Cluster cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    auto cluster_ptr = test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    Cluster& cluster = *cluster_ptr;
     set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
 

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -400,7 +400,7 @@ TEST(SiliconDriverBH, WriteCountMatchesPostedWrites) {
 
 // Verifies that all ETH channels are classified as either active/idle.
 TEST(ClusterBH, TotalNumberOfEthCores) {
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     const uint32_t num_eth_cores = cluster->get_soc_descriptor(0).get_cores(CoreType::ETH).size();
 
@@ -412,7 +412,7 @@ TEST(ClusterBH, TotalNumberOfEthCores) {
 }
 
 TEST(ClusterBH, PCIECores) {
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     for (ChipId chip : cluster->get_target_device_ids()) {
         const auto& pcie_cores = cluster->get_soc_descriptor(chip).get_cores(CoreType::PCIE);
@@ -428,7 +428,7 @@ TEST(ClusterBH, PCIECores) {
 }
 
 TEST(ClusterBH, L2CPUCores) {
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     for (ChipId chip : cluster->get_target_device_ids()) {
         const auto& l2cpu_cores = cluster->get_soc_descriptor(chip).get_cores(CoreType::L2CPU);

--- a/tests/galaxy/test_umd_concurrent_threads.cpp
+++ b/tests/galaxy/test_umd_concurrent_threads.cpp
@@ -58,9 +58,10 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
             << "Target chip on thread 2 " << chip << " is not in the Galaxy cluster";
     }
 
-    Cluster device(ClusterOptions{
+    auto device_ptr = test_utils::make_default_test_cluster(ClusterOptions{
         .target_devices = all_devices,
     });
+    Cluster& device = *device_ptr;
 
     test::utils::set_barrier_params(device);
 
@@ -153,9 +154,10 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
             << "Target chip on thread 2 " << chip << " is not in the Galaxy cluster";
     }
 
-    Cluster device(ClusterOptions{
+    auto device_ptr = test_utils::make_default_test_cluster(ClusterOptions{
         .target_devices = all_devices,
     });
+    Cluster& device = *device_ptr;
 
     test::utils::set_barrier_params(device);
 
@@ -213,7 +215,8 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
 TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
     // Galaxy Setup.
     std::shared_ptr<ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
-    Cluster device;
+    auto device_ptr = test_utils::make_default_test_cluster();
+    Cluster& device = *device_ptr;
     std::unordered_set<ChipId> target_devices = cluster_desc->get_all_chips();
     test::utils::set_barrier_params(device);
 

--- a/tests/galaxy/test_umd_concurrent_threads.cpp
+++ b/tests/galaxy/test_umd_concurrent_threads.cpp
@@ -31,7 +31,7 @@ using namespace tt::umd;
 
 // Have 2 threads read and write to all cores on the Galaxy.
 TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
-    auto cluster = std::make_unique<Cluster>();
+    auto cluster = test_utils::make_default_test_cluster();
 
     // Galaxy Setup.
     std::shared_ptr<ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
@@ -126,7 +126,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
 }
 
 TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
-    auto cluster = std::make_unique<Cluster>();
+    auto cluster = test_utils::make_default_test_cluster();
 
     // Galaxy Setup.
     std::shared_ptr<ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -27,7 +27,8 @@
 using namespace tt::umd;
 
 void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
-    Cluster device;
+    auto device_ptr = test_utils::make_default_test_cluster();
+    Cluster& device = *device_ptr;
 
     test::utils::set_barrier_params(device);
 
@@ -115,7 +116,8 @@ TEST(GalaxyBasicReadWrite, LargeRemoteDramBlockReadWrite) { run_remote_read_writ
 
 void run_data_mover_test(
     uint32_t vector_size, tt_multichip_core_addr sender_core, tt_multichip_core_addr receiver_core) {
-    Cluster device;
+    auto device_ptr = test_utils::make_default_test_cluster();
+    Cluster& device = *device_ptr;
     auto target_devices = device.get_target_device_ids();
 
     // Verify that sender chip and receiver chip are in the cluster.
@@ -226,7 +228,8 @@ void run_data_broadcast_test(
     uint32_t vector_size,
     tt_multichip_core_addr sender_core,
     const std::vector<tt_multichip_core_addr>& receiver_cores) {
-    Cluster device;
+    auto device_ptr = test_utils::make_default_test_cluster();
+    Cluster& device = *device_ptr;
     auto target_devices = device.get_target_device_ids();
 
     // Verify that sender chip and receiver chip are in the cluster.

--- a/tests/microbenchmark/benchmarks/ethernet_io/test_ethernet_io.cpp
+++ b/tests/microbenchmark/benchmarks/ethernet_io/test_ethernet_io.cpp
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "common/microbenchmark_utils.hpp"
+#include "test_utils/device_test_utils.hpp"
 #include "test_utils/test_api_common.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/soc_descriptor.hpp"

--- a/tests/microbenchmark/benchmarks/ethernet_io/test_ethernet_io.cpp
+++ b/tests/microbenchmark/benchmarks/ethernet_io/test_ethernet_io.cpp
@@ -47,8 +47,7 @@ TEST(MicrobenchmarkEthernetIO, DRAM) {
         2 * ONE_MIB,
         4 * ONE_MIB,
         8 * ONE_MIB};
-    std::unique_ptr<Cluster> cluster =
-        std::make_unique<Cluster>(ClusterOptions{.num_host_mem_ch_per_mmio_device = get_num_host_ch_for_test()});
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster(ClusterOptions{}, /*needs_sysmem=*/true);
 
     if (cluster->get_target_remote_device_ids().empty()) {
         GTEST_SKIP() << "No ETH connected devices found in the cluster, skipping benchmark.";
@@ -78,8 +77,7 @@ TEST(MicrobenchmarkEthernetIO, Tensix) {
     const uint64_t ADDRESS = 0x0;
     const std::vector<size_t> BATCH_SIZES = {
         1, 2, 4, 8, 1 * ONE_KIB, 2 * ONE_KIB, 4 * ONE_KIB, 8 * ONE_KIB, 1 * ONE_MIB};
-    std::unique_ptr<Cluster> cluster =
-        std::make_unique<Cluster>(ClusterOptions{.num_host_mem_ch_per_mmio_device = get_num_host_ch_for_test()});
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster(ClusterOptions{}, /*needs_sysmem=*/true);
 
     if (cluster->get_target_remote_device_ids().empty()) {
         GTEST_SKIP() << "No ETH connected devices found in the cluster, skipping benchmark.";
@@ -109,8 +107,7 @@ TEST(MicrobenchmarkEthernetIO, Ethernet) {
     const uint64_t ADDRESS = 0x20000;  // 128 KiB
     const std::vector<size_t> BATCH_SIZES = {
         1, 2, 4, 8, 1 * ONE_KIB, 2 * ONE_KIB, 4 * ONE_KIB, 8 * ONE_KIB, 128 * ONE_KIB};
-    std::unique_ptr<Cluster> cluster =
-        std::make_unique<Cluster>(ClusterOptions{.num_host_mem_ch_per_mmio_device = get_num_host_ch_for_test()});
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster(ClusterOptions{}, /*needs_sysmem=*/true);
 
     if (cluster->get_target_remote_device_ids().empty()) {
         GTEST_SKIP() << "No ETH connected devices found in the cluster, skipping benchmark.";

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -17,7 +17,7 @@
 using namespace tt;
 using namespace tt::umd;
 
-namespace test_utils {
+namespace tt::umd::test_utils {
 
 template <typename T>
 static inline void size_buffer_to_capacity(std::vector<T>& data_buf, std::size_t size_in_bytes) {
@@ -64,4 +64,4 @@ inline bool is_virtual_machine() {
     return false;
 }
 
-}  // namespace test_utils
+}  // namespace tt::umd::test_utils

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -6,7 +6,11 @@
 #include <fmt/ranges.h>
 
 #include <cstdint>
+#include <cstdlib>
+#include <filesystem>
 #include <fstream>
+#include <memory>
+#include <optional>
 #include <random>
 #include <string>
 #include <vector>
@@ -18,6 +22,49 @@ using namespace tt;
 using namespace tt::umd;
 
 namespace tt::umd::test_utils {
+
+// Returns true if the system has remote (Ethernet-connected) chips, i.e. an N300 board.
+inline bool has_remote_chips() {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+    if (pci_device_ids.empty()) {
+        return false;
+    }
+    std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_ids[0]);
+    tt_device->init_tt_device();
+
+    auto board_type = tt_device->get_board_type();
+    return board_type == tt::BoardType::N300;
+}
+
+// Number of host memory channels a test needs to also reach remote chips: 1 when remote chips are
+// present, 0 for local-only configurations.
+inline uint32_t get_num_host_ch_for_test() { return has_remote_chips() ? 1UL : 0UL; }
+
+// Canonical way to create a Cluster in tests.
+//
+// The ClusterOptions default for num_host_mem_ch_per_mmio_device is std::nullopt, which makes the
+// Cluster auto-determine the number of host memory channels. That value is often larger than 0 and
+// allocating those channels noticeably slows tests down. Tests that don't care about host memory
+// channels should go through this helper, which defaults them when the caller didn't set them:
+//   - needs_sysmem == false (default): 0 channels (fastest).
+//   - needs_sysmem == true: get_num_host_ch_for_test(), i.e. 0 for local-only configs and 1 when
+//     remote chips are present (so the test can reach them).
+// Tests that need a specific number can pass it via `options.num_host_mem_ch_per_mmio_device` and
+// it is honored as-is.
+//
+// If TT_UMD_SIMULATOR is set, the chip type, target devices, and simulator directory are overridden
+// to target the simulator.
+inline std::unique_ptr<Cluster> make_default_test_cluster(ClusterOptions options = {}, bool needs_sysmem = false) {
+    if (!options.num_host_mem_ch_per_mmio_device.has_value()) {
+        options.num_host_mem_ch_per_mmio_device = needs_sysmem ? get_num_host_ch_for_test() : 0UL;
+    }
+    if (const char* sim_path = std::getenv("TT_UMD_SIMULATOR")) {
+        options.chip_type = ChipType::SIMULATION;
+        options.target_devices = {0};
+        options.simulator_directory = std::filesystem::path(sim_path);
+    }
+    return std::make_unique<Cluster>(options);
+}
 
 template <typename T>
 static inline void size_buffer_to_capacity(std::vector<T>& data_buf, std::size_t size_in_bytes) {
@@ -51,7 +98,9 @@ inline std::string convert_to_comma_separated_string(const std::unordered_set<in
     return fmt::format("{}", fmt::join(devices, ","));
 }
 
-inline bool is_iommu_available() { return Cluster().get_tt_device(0)->get_pci_device()->is_iommu_enabled(); }
+inline bool is_iommu_available() {
+    return make_default_test_cluster()->get_tt_device(0)->get_pci_device()->is_iommu_enabled();
+}
 
 inline bool is_virtual_machine() {
     std::ifstream cpuinfo("/proc/cpuinfo");

--- a/tests/test_utils/fetch_local_files.hpp
+++ b/tests/test_utils/fetch_local_files.hpp
@@ -12,7 +12,7 @@
 
 #include "umd/device/types/arch.hpp"
 
-namespace test_utils {
+namespace tt::umd::test_utils {
 
 inline std::string GetAbsPath(const std::string& relative_path) {
 #ifdef UMD_TESTS_ROOT_PATH
@@ -97,4 +97,4 @@ inline std::string get_soc_descriptor_path(tt::ARCH arch) {
     }
 }
 
-}  // namespace test_utils
+}  // namespace tt::umd::test_utils

--- a/tests/test_utils/setup_risc_cores.hpp
+++ b/tests/test_utils/setup_risc_cores.hpp
@@ -11,7 +11,7 @@
 using namespace tt;
 using namespace tt::umd;
 
-namespace test_utils {
+namespace tt::umd::test_utils {
 
 inline void safe_test_cluster_start(Cluster* cluster) {
     static RobustMutex mtx("safe_test_cluster_start");
@@ -78,4 +78,4 @@ inline void safe_test_cluster_start(Cluster* cluster) {
     cluster->start_device({});
 }
 
-}  // namespace test_utils
+}  // namespace tt::umd::test_utils

--- a/tests/test_utils/test_api_common.hpp
+++ b/tests/test_utils/test_api_common.hpp
@@ -94,20 +94,6 @@ inline bool is_galaxy_configuration(Cluster* cluster) {
             cluster->get_cluster_description()->get_board_type(0) == tt::BoardType::UBB_BLACKHOLE);
 }
 
-inline bool has_remote_chips() {
-    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    if (pci_device_ids.empty()) {
-        return false;
-    }
-    std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_ids[0]);
-    tt_device->init_tt_device();
-
-    auto board_type = tt_device->get_board_type();
-    return board_type == tt::BoardType::N300;
-}
-
-inline uint32_t get_num_host_ch_for_test() { return has_remote_chips() ? 1UL : 0UL; }
-
 // Returns the top-left (lowest x, lowest y) and bottom-right (highest x, highest y) TENSIX cores
 // in translated coordinates for the given SoC descriptor.
 inline std::vector<CoreCoord> get_tensix_corners(const SocDescriptor& soc_desc) {
@@ -138,15 +124,3 @@ constexpr uint64_t SAFE_IO_L1_ADDRESS = 0x1000;
 // True when the test should run against a simulator, indicated by TT_UMD_SIMULATOR
 // pointing at the simulator binary directory.
 inline bool is_simulation_test() { return std::getenv("TT_UMD_SIMULATOR") != nullptr; }
-
-// Creates a Cluster for an API test. If TT_UMD_SIMULATOR is set the chip_type,
-// target_devices, and simulator_directory fields of `options` are overridden to
-// target the simulator; otherwise `options` is used as-is (default = silicon).
-inline std::unique_ptr<Cluster> make_cluster_for_test(ClusterOptions options = {}) {
-    if (const char* sim_path = std::getenv("TT_UMD_SIMULATOR")) {
-        options.chip_type = ChipType::SIMULATION;
-        options.target_devices = {0};
-        options.simulator_directory = std::filesystem::path(sim_path);
-    }
-    return std::make_unique<Cluster>(options);
-}

--- a/tests/unified/multiprocess.cpp
+++ b/tests/unified/multiprocess.cpp
@@ -184,7 +184,7 @@ TEST(Multiprocess, MultipleThreadsMultipleClustersOpenClose) {
     for (int i = 0; i < NUM_PARALLEL; i++) {
         threads.push_back(std::thread([&, i] {
             std::unique_ptr<Cluster> cluster =
-                std::make_unique<Cluster>(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+                test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
             std::cout << "Setting up risc cores and starting cluster " << i << std::endl;
             test_utils::safe_test_cluster_start(cluster.get());
             std::cout << "Running IO for cluster " << i << std::endl;

--- a/tests/unified/multiprocess.cpp
+++ b/tests/unified/multiprocess.cpp
@@ -116,7 +116,7 @@ TEST(Multiprocess, MultipleClusters) {
     std::vector<std::unique_ptr<Cluster>> clusters;
     for (int i = 0; i < NUM_PARALLEL; i++) {
         std::cout << "Creating cluster " << i << std::endl;
-        clusters.push_back(std::make_unique<Cluster>());
+        clusters.push_back(test_utils::make_default_test_cluster());
     }
     for (int i = 0; i < NUM_PARALLEL; i++) {
         std::cout << "Running IO for cluster " << i << std::endl;
@@ -127,7 +127,7 @@ TEST(Multiprocess, MultipleClusters) {
 
 // Multiple threads use single cluster for IO.
 TEST(Multiprocess, MultipleThreadsSingleCluster) {
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
     std::vector<std::thread> threads;
     threads.reserve(NUM_PARALLEL);
     for (int i = 0; i < NUM_PARALLEL; i++) {
@@ -149,7 +149,7 @@ TEST(Multiprocess, MultipleThreadsMultipleClustersCreation) {
     for (int i = 0; i < NUM_PARALLEL; i++) {
         threads.push_back(std::thread([&, i] {
             std::cout << "Create cluster " << i << std::endl;
-            std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+            std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
             cluster = nullptr;
         }));
     }
@@ -165,7 +165,7 @@ TEST(Multiprocess, MultipleThreadsMultipleClustersRunning) {
     for (int i = 0; i < NUM_PARALLEL; i++) {
         threads.push_back(std::thread([&, i] {
             std::cout << "Creating cluster " << i << std::endl;
-            std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+            std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
             std::cout << "Running IO for cluster " << i << std::endl;
             test_read_write_all_tensix_cores_with_reserved_bytes_at_start(cluster.get(), i);
             std::cout << "Finished IO for cluster " << i << std::endl;
@@ -203,7 +203,7 @@ TEST(Multiprocess, WorkloadVSMonitor) {
 
     auto workload_thread = std::thread([&] {
         std::cout << "Creating workload cluster" << std::endl;
-        std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+        std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
         std::cout << "Running IO for workload cluster" << std::endl;
         test_read_write_all_tensix_cores_with_reserved_bytes_at_start(cluster.get(), 0);
         std::cout << "Finished IO for workload cluster" << std::endl;
@@ -211,7 +211,7 @@ TEST(Multiprocess, WorkloadVSMonitor) {
 
     auto monitor_thread = std::thread([&] {
         std::cout << "Creating monitor cluster" << std::endl;
-        std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+        std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
         std::cout << "Running only reads for monitor cluster" << std::endl;
         for (int loop = 0; loop < NUM_LOOPS; loop++) {
             uint32_t example_read;
@@ -271,7 +271,7 @@ TEST(Multiprocess, LongLivedMonitor) {
 
     for (int i = 0; i < NUM_PARALLEL; i++) {
         std::cout << "Creating cluster " << i << std::endl;
-        std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+        std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
         std::cout << "Running IO for cluster " << i << std::endl;
         test_read_write_all_tensix_cores_with_reserved_bytes_at_start(cluster.get(), i);
         std::cout << "Finished IO for cluster " << i << std::endl;
@@ -285,7 +285,7 @@ TEST(Multiprocess, ClusterAndTTDeviceTest) {
     const uint64_t address_thread1 = address_thread0 + 0x100;
     const uint32_t num_loops = 1000;
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     for (ChipId chip : cluster->get_target_mmio_device_ids()) {
         TTDevice* tt_device = cluster->get_tt_device(chip);

--- a/tests/unified/test_tlb.cpp
+++ b/tests/unified/test_tlb.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"

--- a/tests/unified/test_tlb.cpp
+++ b/tests/unified/test_tlb.cpp
@@ -40,7 +40,7 @@ TEST(TestTlb, TestTlbWindowAllocateNew) {
     const ChipId chip = 0;
     const uint64_t two_mb_size = 1 << 21;
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     uint32_t val = 0;
     std::vector<CoreCoord> tensix_cores =
@@ -86,7 +86,7 @@ TEST(TestTlb, TestTlbWindowReuse) {
     const ChipId chip = 0;
     const uint64_t two_mb_size = 1 << 21;
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     uint32_t val = 0;
     std::vector<CoreCoord> tensix_cores =
@@ -143,7 +143,7 @@ TEST(TestTlb, DISABLED_TestTlbWindowReadRegister) {
     const uint64_t tlb_base = 0xFFA00000;
     const uint64_t noc_node_id_tlb_offset = 0x12002C;
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     PCIDevice* pci_device = cluster->get_tt_device(0)->get_pci_device();
 
@@ -184,7 +184,7 @@ TEST(TestTlb, TestTlbWindowReadWrite) {
     const ChipId chip = 0;
     const uint64_t two_mb_size = 1 << 21;
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     const std::vector<CoreCoord> tensix_cores =
         cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
@@ -228,7 +228,7 @@ TEST(TestTlb, TestTlbWindowReadWrite16) {
     const ChipId chip = 0;
     const uint64_t two_mb_size = 1 << 21;
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     const std::vector<CoreCoord> tensix_cores =
         cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
@@ -297,7 +297,7 @@ TEST(TestTlb, TestTlbWrite16DoesNotCorruptAdjacentData) {
     const ChipId chip = 0;
     const uint64_t two_mb_size = 1 << 21;
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     const std::vector<CoreCoord> tensix_cores =
         cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
@@ -351,7 +351,7 @@ TEST(TestTlb, TestTlbOffsetReadWrite) {
     const uint64_t two_mb = 1 << 21;
     const uint64_t one_mb = 1 << 20;
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     const std::vector<CoreCoord> tensix_cores =
         cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
@@ -414,7 +414,7 @@ TEST(TestTlb, TestTlbAccessOutofBounds) {
     const uint64_t two_mb = 1 << 21;
     const uint64_t one_mb = 1 << 20;
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     const std::vector<CoreCoord> tensix_cores =
         cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
@@ -461,7 +461,7 @@ TEST(TestTlb, TestTlbAccessOutofBounds) {
 }
 
 TEST(TestTlb, TLBStaticTensix) {
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     const size_t tlb_size = cluster->get_tt_device(0)->get_arch() == tt::ARCH::WORMHOLE_B0 ? (1 << 20) : (1 << 21);
 

--- a/tests/wormhole/test_arc_messages_wh.cpp
+++ b/tests/wormhole/test_arc_messages_wh.cpp
@@ -27,7 +27,7 @@
 using namespace tt::umd;
 
 TEST(WormholeArcMessages, WormholeArcMessagesHarvesting) {
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     for (uint32_t chip_id : cluster->get_target_device_ids()) {
         TTDevice* tt_device = cluster->get_tt_device(chip_id);
@@ -52,7 +52,7 @@ TEST(WormholeArcMessages, WormholeArcMessagesHarvesting) {
 TEST(WormholeArcMessages, WormholeArcMessagesAICLK) {
     const uint32_t ms_sleep = 2000;
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     std::set<tt::ChipId> target_chips = cluster->get_target_device_ids();
     std::unordered_map<uint32_t, TTDevice*> tt_devices;
@@ -95,7 +95,7 @@ TEST(WormholeArcMessages, WormholeArcMessagesAICLK) {
 }
 
 TEST(WormholeArcMessages, MultipleThreadsArcMessages) {
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     const uint32_t num_loops = 1000;
 

--- a/tests/wormhole/test_arc_messages_wh.cpp
+++ b/tests/wormhole/test_arc_messages_wh.cpp
@@ -13,6 +13,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/arc/arc_messenger.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -72,7 +72,7 @@ TEST(SiliconDriverWH, OneDramOneTensixNoEthSocDesc) {
 TEST(SiliconDriverWH, CreateDestroy) {
     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting.
     for (int i = 0; i < 50; i++) {
-        Cluster cluster(ClusterOptions{
+        auto cluster = test_utils::make_default_test_cluster(ClusterOptions{
             .sdesc_path = test_utils::GetSocDescAbsPath("wormhole_b0_1x1.yaml"),
         });
     }
@@ -80,9 +80,10 @@ TEST(SiliconDriverWH, CreateDestroy) {
 
 TEST(SiliconDriverWH, CustomSocDesc) {
     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting.
-    Cluster cluster(ClusterOptions{
+    auto cluster_ptr = test_utils::make_default_test_cluster(ClusterOptions{
         .sdesc_path = test_utils::GetSocDescAbsPath("wormhole_b0_1x1.yaml"),
     });
+    Cluster& cluster = *cluster_ptr;
     for (const auto& chip : cluster.get_target_device_ids()) {
         ASSERT_EQ(
             cluster.get_tt_device(chip)->get_soc_descriptor().get_cores(CoreType::TENSIX).size() +
@@ -98,7 +99,8 @@ TEST(SiliconDriverWH, CustomSocDesc) {
 }
 
 TEST(SiliconDriverWH, HarvestingRuntime) {
-    Cluster cluster(ClusterOptions{});
+    auto cluster_ptr = test_utils::make_default_test_cluster();
+    Cluster& cluster = *cluster_ptr;
     set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
 
@@ -166,7 +168,8 @@ TEST(SiliconDriverWH, HarvestingRuntime) {
 }
 
 TEST(SiliconDriverWH, UnalignedStaticTLB_RW) {
-    Cluster cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    auto cluster_ptr = test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    Cluster& cluster = *cluster_ptr;
     set_barrier_params(cluster);
 
     // Do this only for a single chip to speed up the test.
@@ -206,7 +209,8 @@ TEST(SiliconDriverWH, UnalignedStaticTLB_RW) {
 }
 
 TEST(SiliconDriverWH, StaticTLB_RW) {
-    Cluster cluster;
+    auto cluster_ptr = test_utils::make_default_test_cluster();
+    Cluster& cluster = *cluster_ptr;
     set_barrier_params(cluster);
 
     // Do this only for a single chip to speed up the test.
@@ -251,7 +255,8 @@ TEST(SiliconDriverWH, StaticTLB_RW) {
 TEST(SiliconDriverWH, DynamicTLB_RW) {
     // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for
     // each transaction
-    Cluster cluster;
+    auto cluster_ptr = test_utils::make_default_test_cluster();
+    Cluster& cluster = *cluster_ptr;
     set_barrier_params(cluster);
 
     auto chip_id = *cluster.get_target_mmio_device_ids().begin();
@@ -287,7 +292,8 @@ TEST(SiliconDriverWH, DynamicTLB_RW) {
 TEST(SiliconDriverWH, DISABLED_MultiThreadedDevice) {
     // Have 2 threads read and write from a single device concurrently
     // All transactions go through a single Dynamic TLB. We want to make sure this is thread/process safe.
-    Cluster cluster;
+    auto cluster_ptr = test_utils::make_default_test_cluster();
+    Cluster& cluster = *cluster_ptr;
     set_barrier_params(cluster);
 
     std::thread th1 = std::thread([&] {
@@ -339,7 +345,8 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     // Memory barrier flags get sent to address 0 for all channels in this test.
     uint32_t base_addr = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
 
-    Cluster cluster;
+    auto cluster_ptr = test_utils::make_default_test_cluster();
+    Cluster& cluster = *cluster_ptr;
     set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
 
@@ -445,7 +452,8 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
 TEST(SiliconDriverWH, BroadcastWrite) {
     // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly, and that
     // a broadcast targeting one core type does not leak writes to the other.
-    Cluster cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    auto cluster_ptr = test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    Cluster& cluster = *cluster_ptr;
     set_barrier_params(cluster);
 
     test_utils::safe_test_cluster_start(&cluster);
@@ -563,7 +571,8 @@ TEST(SiliconDriverWH, BroadcastWrite) {
 TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
     // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly, and that
     // a broadcast targeting one core type does not leak writes to the other.
-    Cluster cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    auto cluster_ptr = test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    Cluster& cluster = *cluster_ptr;
     set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
 
@@ -694,7 +703,8 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
 TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
     // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly, and that
     // a broadcast targeting one core type does not leak writes to the other.
-    Cluster cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    auto cluster_ptr = test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    Cluster& cluster = *cluster_ptr;
     set_barrier_params(cluster);
     auto mmio_devices = cluster.get_target_mmio_device_ids();
 
@@ -915,7 +925,8 @@ TEST(SiliconDriverWH, EthernetBroadcastSingleRemotePerChip) {
 }
 
 TEST(SiliconDriverWH, LargeAddressTlb) {
-    Cluster cluster;
+    auto cluster_ptr = test_utils::make_default_test_cluster();
+    Cluster& cluster = *cluster_ptr;
 
     const CoreCoord ARC_CORE = cluster.get_soc_descriptor(0).get_cores(CoreType::ARC).at(0);
 
@@ -963,7 +974,8 @@ TEST(SiliconDriverWH, LargeAddressTlb) {
  */
 TEST(TestDeviceIO, DMA3) {
     const ChipId chip = 0;
-    Cluster cluster;
+    auto cluster_ptr = test_utils::make_default_test_cluster();
+    Cluster& cluster = *cluster_ptr;
 
     CoreCoord eth_core = cluster.get_soc_descriptor(chip).get_cores(CoreType::ETH)[0];
 

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -64,7 +64,7 @@ static void set_barrier_params(Cluster& cluster) {
 }
 
 TEST(SiliconDriverWH, OneDramOneTensixNoEthSocDesc) {
-    std::unique_ptr<Cluster> umd_cluster = std::make_unique<Cluster>(ClusterOptions{
+    std::unique_ptr<Cluster> umd_cluster = test_utils::make_default_test_cluster(ClusterOptions{
         .sdesc_path = "tests/soc_descs/wormhole_b0_one_dram_one_tensix_no_eth.yaml",
     });
 }

--- a/tests/wormhole/test_remote_communication_wh.cpp
+++ b/tests/wormhole/test_remote_communication_wh.cpp
@@ -38,7 +38,7 @@ TEST(RemoteCommunicationWormhole, BasicRemoteCommunicationIO) {
     const uint64_t address0 = 0x1000;
     const uint64_t address1 = 0x2000;
 
-    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
     ChipId mmio_chip_id = *cluster->get_target_mmio_device_ids().begin();
     LocalChip* local_chip = cluster->get_local_chip(mmio_chip_id);

--- a/tests/wormhole/test_remote_communication_wh.cpp
+++ b/tests/wormhole/test_remote_communication_wh.cpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 
+#include "tests/test_utils/device_test_utils.hpp"
 #include "umd/device/chip/local_chip.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"

--- a/tests/wormhole/test_wh_common.hpp
+++ b/tests/wormhole/test_wh_common.hpp
@@ -5,6 +5,7 @@
 #pragma once
 #include <gtest/gtest.h>
 
+#include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/fetch_local_files.hpp"
 #include "tests/test_utils/setup_risc_cores.hpp"
 #include "tests/test_utils/stimulus_generators.hpp"

--- a/tests/wormhole/test_wh_common.hpp
+++ b/tests/wormhole/test_wh_common.hpp
@@ -50,7 +50,7 @@ protected:
             GTEST_SKIP() << "Test is skipped due to incorrect number of chips";
         }
 
-        cluster = std::make_unique<Cluster>(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+        cluster = test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
         assert(cluster != nullptr);
         assert(cluster->get_cluster_description()->get_number_of_chips() == get_detected_num_chips());
 


### PR DESCRIPTION
### Issue
#2785 

### Description
After default was changed in ClusterOptions, changing the default used in tests.
This PR should show significant speedup.

### List of the changes
I put this as one PR not to prolong merging into main, as all components of this PR are very very simple. If this diff is too big to look at, you can look at individual commits to verify nothing significantly changed.
- Defined make_default_test_cluster, moved from one header file to another
- All tests which construct Cluster, now go through this new function

### Testing
TBD, will post updated timings.
Run on this branch with full suite of tests: https://github.com/tenstorrent/tt-umd/actions/runs/27231087695
One of the latest main run to compare: https://github.com/tenstorrent/tt-umd/actions/runs/27167672834
One of the older main runs to compare: https://github.com/tenstorrent/tt-umd/actions/runs/26852403497

| Machine | main | this PR | old main |
|--------|----------|-----|-----|
| n150 hugepages | 3m24s | 3m30s | 3m26s |
| n150 viommu | 5m24s | 4m8s | 3m58s |
| n300 viommu | 9m5s | 7m16s | 5m33s |
| llmbox viommu | 14m38s | 7m5s | 7m1s |
| 6u VM hugepages | 5m59s | 6m5s | 5m46s |
| 6u VM viommu | 25m+ | 17m34s | 16m2s |
| 6u bare viommu | 11m9s | 5m5s | 5m11s |


### API Changes
This PR has no API changes.
