### PR TITLE
Use Cluster as pointer in tests

### DIFF
--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -787,11 +787,11 @@ TEST(TestDeviceIO, SmnReadWriteRoundTrip) {
  * dma_read_from_device is used. On other architectures, the standard read_from_device
  * path is used instead.
  */
-void read_data_based_on_architecture(Cluster& cluster, CoreCoord core, void* mem_ptr, uint64_t address, size_t size) {
-    if (cluster.get_tt_device(0)->get_arch() == tt::ARCH::WORMHOLE_B0) {
-        cluster.dma_read_from_device(mem_ptr, size, 0, core, address);
+void read_data_based_on_architecture(Cluster* cluster, CoreCoord core, void* mem_ptr, uint64_t address, size_t size) {
+    if (cluster->get_tt_device(0)->get_arch() == tt::ARCH::WORMHOLE_B0) {
+        cluster->dma_read_from_device(mem_ptr, size, 0, core, address);
     } else {
-        cluster.read_from_device(mem_ptr, 0, core, address, size);
+        cluster->read_from_device(mem_ptr, 0, core, address, size);
     }
 }
 
@@ -801,10 +801,9 @@ void read_data_based_on_architecture(Cluster& cluster, CoreCoord core, void* mem
  */
 TEST(TestDeviceIO, DMA1) {
     const ChipId chip = 0;
-    std::unique_ptr<Cluster> cluster_ptr = test_utils::make_default_test_cluster();
-    Cluster& cluster = *cluster_ptr;
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
-    auto& soc_descriptor = cluster.get_soc_descriptor(chip);
+    auto& soc_descriptor = cluster->get_soc_descriptor(chip);
     size_t dram_count = soc_descriptor.get_num_dram_channels();
     std::vector<CoreCoord> dram_cores;
     dram_cores.reserve(dram_count);
@@ -824,7 +823,7 @@ TEST(TestDeviceIO, DMA1) {
         std::vector<uint8_t> pattern(buf_size);
         test_utils::fill_with_random_bytes(pattern.data(), pattern.size());
 
-        cluster.dma_write_to_device(pattern.data(), pattern.size(), chip, core, 0x0);
+        cluster->dma_write_to_device(pattern.data(), pattern.size(), chip, core, 0x0);
 
         patterns.push_back(pattern);
     }
@@ -834,7 +833,7 @@ TEST(TestDeviceIO, DMA1) {
         auto core = dram_cores[i];
         std::vector<uint8_t> readback(buf_size, 0x0);
 
-        read_data_based_on_architecture(cluster, core, readback.data(), 0x0, readback.size());
+        read_data_based_on_architecture(cluster.get(), core, readback.data(), 0x0, readback.size());
 
         EXPECT_EQ(patterns[i], readback) << "Mismatch for core " << core.str() << " addr=0x0"
                                          << " size=" << std::dec << readback.size();
@@ -850,10 +849,9 @@ TEST(TestDeviceIO, DMA1) {
  */
 TEST(TestDeviceIO, DMA2) {
     const ChipId chip = 0;
-    std::unique_ptr<Cluster> cluster_ptr = test_utils::make_default_test_cluster();
-    Cluster& cluster = *cluster_ptr;
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
-    auto& soc_descriptor = cluster.get_soc_descriptor(chip);
+    auto& soc_descriptor = cluster->get_soc_descriptor(chip);
     size_t dram_count = 1;
     std::vector<CoreCoord> dram_cores;
     dram_cores.reserve(dram_count);
@@ -893,7 +891,7 @@ TEST(TestDeviceIO, DMA2) {
             test_utils::fill_with_random_bytes(pattern.data(), pattern.size());
 
             // Perform the DMA write.
-            cluster.dma_write_to_device(pattern.data(), pattern.size(), chip, core, addr);
+            cluster->dma_write_to_device(pattern.data(), pattern.size(), chip, core, addr);
 
             // Store the operation details for verification.
             write_ops.push_back({core, addr, pattern});
@@ -903,7 +901,7 @@ TEST(TestDeviceIO, DMA2) {
         for (const auto& op : write_ops) {
             std::vector<uint8_t> readback(op.data.size());
 
-            read_data_based_on_architecture(cluster, op.core, readback.data(), op.address, readback.size());
+            read_data_based_on_architecture(cluster.get(), op.core, readback.data(), op.address, readback.size());
 
             // Verify the data.
             EXPECT_EQ(op.data, readback) << "Mismatch for core " << op.core.str() << " addr=0x" << std::hex
@@ -929,7 +927,7 @@ TEST(TestDeviceIO, DMA2) {
             test_utils::fill_with_random_bytes(pattern.data(), pattern.size());
 
             // Perform the DMA write.
-            cluster.write_to_device(pattern.data(), pattern.size(), chip, dram_core, addr);
+            cluster->write_to_device(pattern.data(), pattern.size(), chip, dram_core, addr);
 
             // Store the operation details for verification.
             write_ops.push_back({dram_core, addr, pattern});
@@ -939,18 +937,18 @@ TEST(TestDeviceIO, DMA2) {
         // But before that we must set a dram membar which is not conflicting with the write and read we're doing.
         // The DRAM buffer written will always start at 0x0, and we can set barrier after the maximum buffer size.
         auto default_l1_address_params =
-            cluster.get_tt_device(chip)->get_architecture_implementation()->get_l1_address_params();
-        cluster.set_barrier_address_params(
+            cluster->get_tt_device(chip)->get_architecture_implementation()->get_l1_address_params();
+        cluster->set_barrier_address_params(
             {default_l1_address_params.tensix_l1_barrier_base,
              default_l1_address_params.eth_l1_barrier_base,
              MAX_BUF_SIZE});
-        cluster.dram_membar(chip);
+        cluster->dram_membar(chip);
 
         // Now, read back the patterns we wrote to DRAM and verify them.
         for (const auto& op : write_ops) {
             std::vector<uint8_t> readback(op.data.size());
 
-            read_data_based_on_architecture(cluster, op.core, readback.data(), op.address, readback.size());
+            read_data_based_on_architecture(cluster.get(), op.core, readback.data(), op.address, readback.size());
 
             // Verify the data.
             EXPECT_EQ(op.data, readback) << "Mismatch for core " << op.core.str() << " addr=0x" << std::hex

--- a/tests/blackhole/test_cluster_bh.cpp
+++ b/tests/blackhole/test_cluster_bh.cpp
@@ -33,38 +33,37 @@ using namespace tt::umd;
 
 constexpr std::uint32_t DRAM_BARRIER_BASE = 0;
 
-static void set_barrier_params(Cluster& cluster) {
+static void set_barrier_params(Cluster* cluster) {
     // Populate address map and NOC parameters that the driver needs for memory barriers and remote transactions.
-    cluster.set_barrier_address_params(
+    cluster->set_barrier_address_params(
         {l1_mem::address_map::L1_BARRIER_BASE, eth_l1_mem::address_map::ERISC_BARRIER_BASE, DRAM_BARRIER_BASE});
 }
 
 TEST(SiliconDriverBH, CreateDestroy) {
     DeviceParams default_params;
     for (int i = 0; i < 50; i++) {
-        auto cluster_ptr = test_utils::make_default_test_cluster();
-        Cluster& cluster = *cluster_ptr;
-        set_barrier_params(cluster);
-        test_utils::safe_test_cluster_start(&cluster);
-        cluster.close_device();
+        std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+        set_barrier_params(cluster.get());
+        test_utils::safe_test_cluster_start(cluster.get());
+        cluster->close_device();
     }
 }
 
 TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
-    auto cluster_ptr = test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
-    Cluster& cluster = *cluster_ptr;
-    set_barrier_params(cluster);
+    std::unique_ptr<Cluster> cluster =
+        test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    set_barrier_params(cluster.get());
 
     // Do this only for a single chip to speed up the test.
-    auto chip_id = *cluster.get_target_mmio_device_ids().begin();
-    auto& sdesc = cluster.get_soc_descriptor(chip_id);
+    auto chip_id = *cluster->get_target_mmio_device_ids().begin();
+    auto& sdesc = cluster->get_soc_descriptor(chip_id);
     for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
         // Statically mapping a 2MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
-        cluster.configure_tlb(
+        cluster->configure_tlb(
             chip_id, core, tt::umd::blackhole::STATIC_TLB_SIZE, l1_mem::address_map::NCRISC_FIRMWARE_BASE);
     }
 
-    test_utils::safe_test_cluster_start(&cluster);
+    test_utils::safe_test_cluster_start(cluster.get());
 
     std::vector<uint32_t> unaligned_sizes = {3, 14, 21, 255, 362, 430, 1022, 1023, 1025};
     for (const auto& size : unaligned_sizes) {
@@ -74,34 +73,33 @@ TEST(SiliconDriverBH, UnalignedStaticTLB_RW) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (int loop = 0; loop < 50; loop++) {
             for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
-                cluster.write_to_device(write_vec.data(), size, chip_id, core, address);
-                cluster.wait_for_non_mmio_flush();
-                cluster.read_from_device(readback_vec.data(), chip_id, core, address, size);
+                cluster->write_to_device(write_vec.data(), size, chip_id, core, address);
+                cluster->wait_for_non_mmio_flush();
+                cluster->read_from_device(readback_vec.data(), chip_id, core, address, size);
                 ASSERT_EQ(readback_vec, write_vec);
                 readback_vec = std::vector<uint8_t>(size, 0);
-                cluster.write_to_sysmem(write_vec.data(), size, 0, 0, 0);
-                cluster.read_from_sysmem(readback_vec.data(), 0, 0, size, 0);
+                cluster->write_to_sysmem(write_vec.data(), size, 0, 0, 0);
+                cluster->read_from_sysmem(readback_vec.data(), 0, 0, size, 0);
                 ASSERT_EQ(readback_vec, write_vec);
                 readback_vec = std::vector<uint8_t>(size, 0);
-                cluster.wait_for_non_mmio_flush();
+                cluster->wait_for_non_mmio_flush();
             }
             address += 0x20;
         }
     }
-    cluster.close_device();
+    cluster->close_device();
 }
 
 TEST(SiliconDriverBH, StaticTLB_RW) {
-    auto cluster_ptr = test_utils::make_default_test_cluster();
-    Cluster& cluster = *cluster_ptr;
-    set_barrier_params(cluster);
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+    set_barrier_params(cluster.get());
 
     // Do this only for a single chip to speed up the test.
-    auto chip_id = *cluster.get_target_mmio_device_ids().begin();
-    auto& sdesc = cluster.get_soc_descriptor(chip_id);
+    auto chip_id = *cluster->get_target_mmio_device_ids().begin();
+    auto& sdesc = cluster->get_soc_descriptor(chip_id);
     for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
         // Statically mapping a 2MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
-        cluster.configure_tlb(
+        cluster->configure_tlb(
             chip_id, core, tt::umd::blackhole::STATIC_TLB_SIZE, l1_mem::address_map::NCRISC_FIRMWARE_BASE);
     }
 
@@ -113,37 +111,36 @@ TEST(SiliconDriverBH, StaticTLB_RW) {
     // Stress-test TLB stability by exercising one chip 100 times at different statically mapped addresses.
     for (int loop = 0; loop < 100; loop++) {
         for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
-            cluster.write_to_device(
+            cluster->write_to_device(
                 vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), chip_id, core, address);
             // Barrier to ensure that all writes over ethernet were commited.
-            cluster.wait_for_non_mmio_flush();
-            test_utils::read_data_from_device(cluster, readback_vec, chip_id, core, address, 40);
+            cluster->wait_for_non_mmio_flush();
+            test_utils::read_data_from_device(cluster.get(), readback_vec, chip_id, core, address, 40);
             ASSERT_EQ(vector_to_write, readback_vec)
                 << "Vector read back from core " << core.str() << " does not match what was written";
-            cluster.wait_for_non_mmio_flush();
-            cluster.write_to_device(
+            cluster->wait_for_non_mmio_flush();
+            cluster->write_to_device(
                 zeros.data(),
                 zeros.size() * sizeof(std::uint32_t),
                 chip_id,
                 core,
                 address);  // Clear any written data
-            cluster.wait_for_non_mmio_flush();
+            cluster->wait_for_non_mmio_flush();
             readback_vec = {};
         }
         address += 0x20;  // Increment by uint32_t size for each write
     }
-    cluster.close_device();
+    cluster->close_device();
 }
 
 TEST(SiliconDriverBH, DynamicTLB_RW) {
     // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for
     // each transaction
-    auto cluster_ptr = test_utils::make_default_test_cluster();
-    Cluster& cluster = *cluster_ptr;
-    set_barrier_params(cluster);
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+    set_barrier_params(cluster.get());
 
-    auto chip_id = *cluster.get_target_mmio_device_ids().begin();
-    auto& sdesc = cluster.get_soc_descriptor(chip_id);
+    auto chip_id = *cluster->get_target_mmio_device_ids().begin();
+    auto& sdesc = cluster->get_soc_descriptor(chip_id);
 
     std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -153,16 +150,16 @@ TEST(SiliconDriverBH, DynamicTLB_RW) {
     // Stress-test TLB stability by exercising one chip 100 times at different statically mapped addresses.
     for (int loop = 0; loop < 100; loop++) {
         for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
-            cluster.write_to_device(
+            cluster->write_to_device(
                 vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), chip_id, core, address);
             // Barrier to ensure that all writes over ethernet were commited.
-            cluster.wait_for_non_mmio_flush();
-            test_utils::read_data_from_device(cluster, readback_vec, chip_id, core, address, 40);
+            cluster->wait_for_non_mmio_flush();
+            test_utils::read_data_from_device(cluster.get(), readback_vec, chip_id, core, address, 40);
             ASSERT_EQ(vector_to_write, readback_vec)
                 << "Vector read back from core " << core.str() << " does not match what was written";
-            cluster.wait_for_non_mmio_flush();
-            cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
-            cluster.wait_for_non_mmio_flush();
+            cluster->wait_for_non_mmio_flush();
+            cluster->write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+            cluster->wait_for_non_mmio_flush();
             readback_vec = {};
         }
         address += 0x20;  // Increment by uint32_t size for each write
@@ -177,22 +174,22 @@ TEST(SiliconDriverBH, DynamicTLB_RW) {
         for (int ch = 0; ch < NUM_CHANNELS; ch++) {
             std::vector<CoreCoord> chan = sdesc.get_dram_cores().at(ch);
             CoreCoord subchan = chan.at(0);
-            cluster.write_to_device(
+            cluster->write_to_device(
                 vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), chip_id, subchan, address);
-            cluster.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
-            test_utils::read_data_from_device(cluster, readback_vec, chip_id, subchan, address, 40);
+            cluster->wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
+            test_utils::read_data_from_device(cluster.get(), readback_vec, chip_id, subchan, address, 40);
             ASSERT_EQ(vector_to_write, readback_vec)
                 << "Vector read back from core " << subchan.x << "-" << subchan.y << "does not match what was written";
-            cluster.wait_for_non_mmio_flush();
-            cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, subchan, address);
-            cluster.wait_for_non_mmio_flush();
+            cluster->wait_for_non_mmio_flush();
+            cluster->write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, subchan, address);
+            cluster->wait_for_non_mmio_flush();
             readback_vec = {};
             address += 0x20;  // Increment by uint32_t size for each write
         }
     }
     printf("Target DRAM completed\n");
 
-    cluster.close_device();
+    cluster->close_device();
 }
 
 // TODO(#2485): Re-enable. Writes and reads are not synchronized so they can land on the device out of order; broke
@@ -200,20 +197,19 @@ TEST(SiliconDriverBH, DynamicTLB_RW) {
 TEST(SiliconDriverBH, DISABLED_MultiThreadedDevice) {
     // Have 2 threads read and write from a single device concurrently
     // All transactions go through a single Dynamic TLB. We want to make sure this is thread/process safe.
-    auto cluster_ptr = test_utils::make_default_test_cluster();
-    Cluster& cluster = *cluster_ptr;
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
-    set_barrier_params(cluster);
+    set_barrier_params(cluster.get());
 
     std::thread th1 = std::thread([&] {
         std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (int loop = 0; loop < 100; loop++) {
-            for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
-                cluster.write_to_device(
+            for (const CoreCoord& core : cluster->get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
+                cluster->write_to_device(
                     vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), 0, core, address);
-                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 40);
+                test_utils::read_data_from_device(cluster.get(), readback_vec, 0, core, address, 40);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.str() << " does not match what was written";
                 readback_vec = {};
@@ -226,12 +222,12 @@ TEST(SiliconDriverBH, DISABLED_MultiThreadedDevice) {
         std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = 0x30000000;
-        for (const std::vector<CoreCoord>& core_ls : cluster.get_soc_descriptor(0).get_dram_cores()) {
+        for (const std::vector<CoreCoord>& core_ls : cluster->get_soc_descriptor(0).get_dram_cores()) {
             for (int loop = 0; loop < 100; loop++) {
                 for (const CoreCoord& core : core_ls) {
-                    cluster.write_to_device(
+                    cluster->write_to_device(
                         vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), 0, core, address);
-                    test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 40);
+                    test_utils::read_data_from_device(cluster.get(), readback_vec, 0, core, address, 40);
                     ASSERT_EQ(vector_to_write, readback_vec)
                         << "Vector read back from core " << core.str() << " does not match what was written";
                     readback_vec = {};
@@ -243,7 +239,7 @@ TEST(SiliconDriverBH, DISABLED_MultiThreadedDevice) {
 
     th1.join();
     th2.join();
-    cluster.close_device();
+    cluster->close_device();
 }
 
 TEST(SiliconDriverBH, MultiThreadedMemBar) {
@@ -253,38 +249,37 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
 
     // Memory barrier flags get sent to address 0 for all channels in this test.
     uint32_t base_addr = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
-    auto cluster_ptr = test_utils::make_default_test_cluster();
-    Cluster& cluster = *cluster_ptr;
-    set_barrier_params(cluster);
-    for (auto chip_id : cluster.get_target_device_ids()) {
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+    set_barrier_params(cluster.get());
+    for (auto chip_id : cluster->get_target_device_ids()) {
         // Iterate over devices and only setup static TLBs for functional worker cores.
-        auto& sdesc = cluster.get_soc_descriptor(chip_id);
+        auto& sdesc = cluster->get_soc_descriptor(chip_id);
         for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
             // Statically mapping a 2MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
-            cluster.configure_tlb(chip_id, core, tt::umd::blackhole::STATIC_TLB_SIZE, base_addr);
+            cluster->configure_tlb(chip_id, core, tt::umd::blackhole::STATIC_TLB_SIZE, base_addr);
         }
     }
 
     std::vector<uint32_t> readback_membar_vec = {};
-    for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
+    for (const CoreCoord& core : cluster->get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
         test_utils::read_data_from_device(
-            cluster, readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4);
+            cluster.get(), readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all workers
         readback_membar_vec = {};
     }
 
-    for (int chan = 0; chan < cluster.get_soc_descriptor(0).get_num_dram_channels(); chan++) {
-        CoreCoord core = cluster.get_soc_descriptor(0).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
-        test_utils::read_data_from_device(cluster, readback_membar_vec, 0, core, 0, 4);
+    for (int chan = 0; chan < cluster->get_soc_descriptor(0).get_num_dram_channels(); chan++) {
+        CoreCoord core = cluster->get_soc_descriptor(0).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+        test_utils::read_data_from_device(cluster.get(), readback_membar_vec, 0, core, 0, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all DRAM
         readback_membar_vec = {};
     }
 
-    for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::ETH)) {
+    for (const CoreCoord& core : cluster->get_soc_descriptor(0).get_cores(CoreType::ETH)) {
         test_utils::read_data_from_device(
-            cluster, readback_membar_vec, 0, core, eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4);
+            cluster.get(), readback_membar_vec, 0, core, eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0),
             187);  // Ensure that memory barriers were correctly initialized on all ethernet cores
@@ -306,13 +301,13 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     std::thread th1 = std::thread([&] {
         std::uint32_t address = base_addr;
         for (int loop = 0; loop < 50; loop++) {
-            for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster->get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 std::vector<uint32_t> readback_vec = {};
-                cluster.write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), 0, core, address);
-                cluster.l1_membar(0, {core});
-                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec1.size());
+                cluster->write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), 0, core, address);
+                cluster->l1_membar(0, {core});
+                test_utils::read_data_from_device(cluster.get(), readback_vec, 0, core, address, 4 * vec1.size());
                 ASSERT_EQ(readback_vec, vec1);
-                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address);
+                cluster->write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address);
                 readback_vec = {};
             }
         }
@@ -321,13 +316,13 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     std::thread th2 = std::thread([&] {
         std::uint32_t address = base_addr + vec1.size() * 4;
         for (int loop = 0; loop < 50; loop++) {
-            for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster->get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 std::vector<uint32_t> readback_vec = {};
-                cluster.write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), 0, core, address);
-                cluster.l1_membar(0, {core});
-                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec2.size());
+                cluster->write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), 0, core, address);
+                cluster->l1_membar(0, {core});
+                test_utils::read_data_from_device(cluster.get(), readback_vec, 0, core, address, 4 * vec2.size());
                 ASSERT_EQ(readback_vec, vec2);
-                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address);
+                cluster->write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address);
                 readback_vec = {};
             }
         }
@@ -336,23 +331,23 @@ TEST(SiliconDriverBH, MultiThreadedMemBar) {
     th1.join();
     th2.join();
 
-    for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
+    for (const CoreCoord& core : cluster->get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
         test_utils::read_data_from_device(
-            cluster, readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4);
+            cluster.get(), readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers end up in the correct sate for workers
         readback_membar_vec = {};
     }
 
-    for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::ETH)) {
+    for (const CoreCoord& core : cluster->get_soc_descriptor(0).get_cores(CoreType::ETH)) {
         test_utils::read_data_from_device(
-            cluster, readback_membar_vec, 0, core, eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4);
+            cluster.get(), readback_membar_vec, 0, core, eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0),
             187);  // Ensure that memory barriers end up in the correct sate for ethernet cores
         readback_membar_vec = {};
     }
-    cluster.close_device();
+    cluster->close_device();
 }
 
 // Regression test for the no-double-store property of write_to_device on TLB-mapped
@@ -369,40 +364,40 @@ TEST(SiliconDriverBH, WriteCountMatchesPostedWrites) {
     constexpr uint64_t NIU_SLV_POSTED_WR_REQ_RECEIVED = 0xffb202e0;
     constexpr uint32_t kNumWrites = 100000;
 
-    auto cluster_ptr = test_utils::make_default_test_cluster();
-    Cluster& cluster = *cluster_ptr;
-    set_barrier_params(cluster);
-    test_utils::safe_test_cluster_start(&cluster);
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+    set_barrier_params(cluster.get());
+    test_utils::safe_test_cluster_start(cluster.get());
 
-    auto chip_id = *cluster.get_target_mmio_device_ids().begin();
-    auto tensix_core = cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX).at(0);
+    auto chip_id = *cluster->get_target_mmio_device_ids().begin();
+    auto tensix_core = cluster->get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX).at(0);
 
     uint64_t addr = 0;
     uint32_t data = 1;
     uint32_t counter = 0;
 
     uint32_t base_reg_val;
-    cluster.read_from_device_reg(&base_reg_val, chip_id, tensix_core, NIU_SLV_POSTED_WR_REQ_RECEIVED, sizeof(uint32_t));
+    cluster->read_from_device_reg(
+        &base_reg_val, chip_id, tensix_core, NIU_SLV_POSTED_WR_REQ_RECEIVED, sizeof(uint32_t));
 
     for (uint32_t i = 0; i < kNumWrites; i++) {
-        cluster.write_to_device(&data, sizeof(data), chip_id, tensix_core, addr);
+        cluster->write_to_device(&data, sizeof(data), chip_id, tensix_core, addr);
         counter++;
 
         uint32_t reg_val;
-        cluster.read_from_device_reg(&reg_val, chip_id, tensix_core, NIU_SLV_POSTED_WR_REQ_RECEIVED, sizeof(uint32_t));
+        cluster->read_from_device_reg(&reg_val, chip_id, tensix_core, NIU_SLV_POSTED_WR_REQ_RECEIVED, sizeof(uint32_t));
 
         uint32_t diff = reg_val - base_reg_val;
 
         ASSERT_EQ(counter, diff);
 
         uint32_t data_check = 0;
-        cluster.read_from_device(&data_check, chip_id, tensix_core, addr, sizeof(data));
+        cluster->read_from_device(&data_check, chip_id, tensix_core, addr, sizeof(data));
 
         EXPECT_EQ(static_cast<uint32_t>(data_check), static_cast<uint32_t>(data));
 
         data++;
     }
-    cluster.close_device();
+    cluster->close_device();
 }
 
 // Verifies that all ETH channels are classified as either active/idle.
@@ -451,12 +446,12 @@ TEST(SiliconDriverBH, VirtualCoordinateBroadcast) {
     // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly, and that
     // a broadcast targeting one core type does not leak writes to the other.
     // Blackhole has no ERISC firmware broadcast, so this exercises the SW fallback in broadcast_write_to_cluster.
-    auto cluster_ptr = test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
-    Cluster& cluster = *cluster_ptr;
-    set_barrier_params(cluster);
-    auto mmio_devices = cluster.get_target_mmio_device_ids();
+    std::unique_ptr<Cluster> cluster =
+        test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    set_barrier_params(cluster.get());
+    auto mmio_devices = cluster->get_target_mmio_device_ids();
 
-    test_utils::safe_test_cluster_start(&cluster);
+    test_utils::safe_test_cluster_start(cluster.get());
 
     std::vector<uint32_t> broadcast_sizes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
     uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
@@ -472,19 +467,19 @@ TEST(SiliconDriverBH, VirtualCoordinateBroadcast) {
 
     // Pre-zero tensix L1 and DRAM at the test address so the "not written" assertions have a known baseline.
     std::vector<uint32_t> initial_zeros(broadcast_sizes.back(), 0);
-    for (auto chip_id : cluster.get_target_device_ids()) {
-        for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
-            cluster.write_to_device(
+    for (auto chip_id : cluster->get_target_device_ids()) {
+        for (const CoreCoord& core : cluster->get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+            cluster->write_to_device(
                 initial_zeros.data(), initial_zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
         }
-        for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+        for (int chan = 0; chan < cluster->get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
             const CoreCoord core =
-                cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
-            cluster.write_to_device(
+                cluster->get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+            cluster->write_to_device(
                 initial_zeros.data(), initial_zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
         }
     }
-    cluster.wait_for_non_mmio_flush();
+    cluster->wait_for_non_mmio_flush();
 
     for (const auto& size : broadcast_sizes) {
         std::vector<uint32_t> vector_to_write(size);
@@ -495,15 +490,15 @@ TEST(SiliconDriverBH, VirtualCoordinateBroadcast) {
             zeros[i] = 0;
         }
         // Broadcast to Tensix.
-        cluster.broadcast_write_to_cluster(
+        cluster->broadcast_write_to_cluster(
             vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude, true);
-        cluster.wait_for_non_mmio_flush();
+        cluster->wait_for_non_mmio_flush();
 
-        for (auto chip_id : cluster.get_target_device_ids()) {
+        for (auto chip_id : cluster->get_target_device_ids()) {
             // Tensix cores received the broadcast; zero them out.
-            for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster->get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
                 const CoreCoord translated_core =
-                    cluster.get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
+                    cluster->get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
                 if (rows_to_exclude.find(translated_core.y) != rows_to_exclude.end()) {
                     continue;
                 }
@@ -511,28 +506,28 @@ TEST(SiliconDriverBH, VirtualCoordinateBroadcast) {
                     continue;
                 }
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                    cluster.get(), readback_vec, chip_id, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from chip " << chip_id << " core " << core.str()
                     << " does not match what was broadcasted for size " << size;
-                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+                cluster->write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
                 readback_vec = {};
             }
             // DRAM cores must NOT have been written by the tensix broadcast.
-            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < cluster->get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
-                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                    cluster->get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                    cluster.get(), readback_vec, chip_id, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(zeros, readback_vec) << "DRAM core " << chip_id << " " << core.str()
                                                << " was modified by tensix broadcast for size " << size;
                 readback_vec = {};
             }
         }
-        cluster.wait_for_non_mmio_flush();
+        cluster->wait_for_non_mmio_flush();
 
         // Broadcast to DRAM.
-        cluster.broadcast_write_to_cluster(
+        cluster->broadcast_write_to_cluster(
             vector_to_write.data(),
             vector_to_write.size() * 4,
             address,
@@ -540,24 +535,24 @@ TEST(SiliconDriverBH, VirtualCoordinateBroadcast) {
             rows_to_exclude_for_dram_broadcast,
             cols_to_exclude_for_dram_broadcast,
             true);
-        cluster.wait_for_non_mmio_flush();
+        cluster->wait_for_non_mmio_flush();
 
-        for (auto chip_id : cluster.get_target_device_ids()) {
+        for (auto chip_id : cluster->get_target_device_ids()) {
             // DRAM cores received the broadcast.
-            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < cluster->get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
-                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                    cluster->get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                    cluster.get(), readback_vec, chip_id, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from DRAM core " << chip_id << " " << core.str()
                     << " does not match what was broadcasted for size " << size;
                 readback_vec = {};
             }
             // Tensix cores must NOT have been written by the DRAM broadcast.
-            for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster->get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
                 const CoreCoord translated_core =
-                    cluster.get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
+                    cluster->get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
                 if (rows_to_exclude.find(translated_core.y) != rows_to_exclude.end()) {
                     continue;
                 }
@@ -565,19 +560,19 @@ TEST(SiliconDriverBH, VirtualCoordinateBroadcast) {
                     continue;
                 }
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                    cluster.get(), readback_vec, chip_id, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(zeros, readback_vec) << "Tensix core " << chip_id << " " << core.str()
                                                << " was modified by DRAM broadcast for size " << size;
                 readback_vec = {};
             }
             // Zero DRAM so the next iteration starts clean.
-            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < cluster->get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
-                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
-                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+                    cluster->get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                cluster->write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
             }
         }
-        cluster.wait_for_non_mmio_flush();
+        cluster->wait_for_non_mmio_flush();
     }
-    cluster.close_device();
+    cluster->close_device();
 }

--- a/tests/galaxy/test_galaxy_common.cpp
+++ b/tests/galaxy/test_galaxy_common.cpp
@@ -12,26 +12,27 @@
 #include "umd/device/soc_descriptor.hpp"
 
 void move_data(
-    Cluster& device, tt_multichip_core_addr sender_core, tt_multichip_core_addr receiver_core, uint32_t size) {
+    Cluster* device, tt_multichip_core_addr sender_core, tt_multichip_core_addr receiver_core, uint32_t size) {
     std::vector<uint32_t> readback_vec = {};
     test_utils::read_data_from_device(
         device,
         readback_vec,
         sender_core.chip,
-        device.get_soc_descriptor(sender_core.chip).get_coord_at(sender_core.core, sender_core.core.coord_system),
+        device->get_soc_descriptor(sender_core.chip).get_coord_at(sender_core.core, sender_core.core.coord_system),
         sender_core.addr,
         size);
-    device.write_to_device(
+    device->write_to_device(
         readback_vec.data(),
         readback_vec.size() * sizeof(std::uint32_t),
         receiver_core.chip,
-        device.get_soc_descriptor(receiver_core.chip).get_coord_at(receiver_core.core, receiver_core.core.coord_system),
+        device->get_soc_descriptor(receiver_core.chip)
+            .get_coord_at(receiver_core.core, receiver_core.core.coord_system),
         receiver_core.addr);
-    device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
+    device->wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 }
 
 void broadcast_data(
-    Cluster& device,
+    Cluster* device,
     tt_multichip_core_addr sender_core,
     const std::vector<tt_multichip_core_addr>& receiver_cores,
     uint32_t size) {
@@ -40,17 +41,17 @@ void broadcast_data(
         device,
         readback_vec,
         sender_core.chip,
-        device.get_soc_descriptor(sender_core.chip).get_coord_at(sender_core.core, sender_core.core.coord_system),
+        device->get_soc_descriptor(sender_core.chip).get_coord_at(sender_core.core, sender_core.core.coord_system),
         sender_core.addr,
         size);
     for (const auto& receiver_core : receiver_cores) {
-        device.write_to_device(
+        device->write_to_device(
             readback_vec.data(),
             readback_vec.size() * sizeof(std::uint32_t),
             receiver_core.chip,
-            device.get_soc_descriptor(receiver_core.chip)
+            device->get_soc_descriptor(receiver_core.chip)
                 .get_coord_at(receiver_core.core, receiver_core.core.coord_system),
             receiver_core.addr);
     }
-    device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
+    device->wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 }

--- a/tests/galaxy/test_galaxy_common.hpp
+++ b/tests/galaxy/test_galaxy_common.hpp
@@ -43,11 +43,11 @@ struct tt_multichip_core_addr {
 // SIMPLE DATAMOVEMENT API BASED ON UMD
 // send one contiguous chunk of data from one sender core to a receiver core
 void move_data(
-    Cluster& device, tt_multichip_core_addr sender_core, tt_multichip_core_addr receiver_core, uint32_t size);
+    Cluster* device, tt_multichip_core_addr sender_core, tt_multichip_core_addr receiver_core, uint32_t size);
 
 // send one contiguous chunk of data to a vector of receiver cores
 void broadcast_data(
-    Cluster& device,
+    Cluster* device,
     tt_multichip_core_addr sender_core,
     const std::vector<tt_multichip_core_addr>& receiver_cores,
     uint32_t size);

--- a/tests/galaxy/test_umd_concurrent_threads.cpp
+++ b/tests/galaxy/test_umd_concurrent_threads.cpp
@@ -58,14 +58,13 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
             << "Target chip on thread 2 " << chip << " is not in the Galaxy cluster";
     }
 
-    auto device_ptr = test_utils::make_default_test_cluster(ClusterOptions{
+    std::unique_ptr<Cluster> device = test_utils::make_default_test_cluster(ClusterOptions{
         .target_devices = all_devices,
     });
-    Cluster& device = *device_ptr;
 
-    test::utils::set_barrier_params(device);
+    test::utils::set_barrier_params(device.get());
 
-    test_utils::safe_test_cluster_start(&device);
+    test_utils::safe_test_cluster_start(device.get());
 
     // Test.
     std::vector<uint32_t> vector_to_write_th1 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -76,8 +75,8 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
         std::uint32_t write_size = vector_to_write_th1.size() * 4;
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (const auto& chip : target_devices_th1) {
-            for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
-                device.write_to_device(
+            for (const CoreCoord& core : device->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
+                device->write_to_device(
                     vector_to_write_th1.data(),
                     vector_to_write_th1.size() * sizeof(std::uint32_t),
                     chip,
@@ -85,10 +84,10 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
                     address);
             }
         }
-        device.wait_for_non_mmio_flush();
+        device->wait_for_non_mmio_flush();
         for (auto& chip : target_devices_th1) {
-            for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
-                test_utils::read_data_from_device(device, readback_vec, chip, core, address, write_size);
+            for (const CoreCoord& core : device->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
+                test_utils::read_data_from_device(device.get(), readback_vec, chip, core, address, write_size);
                 EXPECT_EQ(vector_to_write_th1, readback_vec)
                     << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 readback_vec = {};
@@ -101,8 +100,8 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
         std::uint32_t write_size = vector_to_write_th2.size() * 4;
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (const auto& chip : target_devices_th2) {
-            for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
-                device.write_to_device(
+            for (const CoreCoord& core : device->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
+                device->write_to_device(
                     vector_to_write_th2.data(),
                     vector_to_write_th2.size() * sizeof(std::uint32_t),
                     chip,
@@ -110,10 +109,10 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
                     address);
             }
         }
-        device.wait_for_non_mmio_flush();
+        device->wait_for_non_mmio_flush();
         for (const auto& chip : target_devices_th2) {
-            for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
-                test_utils::read_data_from_device(device, readback_vec, chip, core, address, write_size);
+            for (const CoreCoord& core : device->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
+                test_utils::read_data_from_device(device.get(), readback_vec, chip, core, address, write_size);
                 EXPECT_EQ(vector_to_write_th2, readback_vec)
                     << "Vector read back from core " << core.x << "-" << core.y << "does not match what was written";
                 readback_vec = {};
@@ -123,7 +122,7 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsL1) {
 
     th1.join();
     th2.join();
-    device.close_device();
+    device->close_device();
 }
 
 TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
@@ -154,14 +153,13 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
             << "Target chip on thread 2 " << chip << " is not in the Galaxy cluster";
     }
 
-    auto device_ptr = test_utils::make_default_test_cluster(ClusterOptions{
+    std::unique_ptr<Cluster> device = test_utils::make_default_test_cluster(ClusterOptions{
         .target_devices = all_devices,
     });
-    Cluster& device = *device_ptr;
 
-    test::utils::set_barrier_params(device);
+    test::utils::set_barrier_params(device.get());
 
-    test_utils::safe_test_cluster_start(&device);
+    test_utils::safe_test_cluster_start(device.get());
 
     // Test.
     std::vector<uint32_t> vector_to_write = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
@@ -171,15 +169,15 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = 0x4000000;
         for (const auto& chip : target_devices_th1) {
-            for (const CoreCoord& core : device.get_soc_descriptor(0).get_cores(CoreType::DRAM)) {
-                device.write_to_device(
+            for (const CoreCoord& core : device->get_soc_descriptor(0).get_cores(CoreType::DRAM)) {
+                device->write_to_device(
                     vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), chip, core, address);
             }
         }
-        device.wait_for_non_mmio_flush();
+        device->wait_for_non_mmio_flush();
         for (const auto& chip : target_devices_th1) {
-            for (const CoreCoord& core : device.get_soc_descriptor(0).get_cores(CoreType::DRAM)) {
-                test_utils::read_data_from_device(device, readback_vec, chip, core, address, write_size);
+            for (const CoreCoord& core : device->get_soc_descriptor(0).get_cores(CoreType::DRAM)) {
+                test_utils::read_data_from_device(device.get(), readback_vec, chip, core, address, write_size);
                 EXPECT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from dram core " << core.str() << " does not match what was written";
                 readback_vec = {};
@@ -191,15 +189,15 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = 0x5000000;
         for (const auto& chip : target_devices_th2) {
-            for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
-                device.write_to_device(
+            for (const CoreCoord& core : device->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
+                device->write_to_device(
                     vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), chip, core, address);
             }
         }
-        device.wait_for_non_mmio_flush();
+        device->wait_for_non_mmio_flush();
         for (const auto& chip : target_devices_th2) {
-            for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
-                test_utils::read_data_from_device(device, readback_vec, chip, core, address, write_size);
+            for (const CoreCoord& core : device->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
+                test_utils::read_data_from_device(device.get(), readback_vec, chip, core, address, write_size);
                 EXPECT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from dram core " << core.str() << " does not match what was written";
                 readback_vec = {};
@@ -209,18 +207,17 @@ TEST(GalaxyConcurrentThreads, WriteToAllChipsDram) {
 
     th1.join();
     th2.join();
-    device.close_device();
+    device->close_device();
 }
 
 TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
     // Galaxy Setup.
     std::shared_ptr<ClusterDescriptor> cluster_desc = Cluster::create_cluster_descriptor();
-    auto device_ptr = test_utils::make_default_test_cluster();
-    Cluster& device = *device_ptr;
+    std::unique_ptr<Cluster> device = test_utils::make_default_test_cluster();
     std::unordered_set<ChipId> target_devices = cluster_desc->get_all_chips();
-    test::utils::set_barrier_params(device);
+    test::utils::set_barrier_params(device.get());
 
-    test_utils::safe_test_cluster_start(&device);
+    test_utils::safe_test_cluster_start(device.get());
 
     // Test.
     std::vector<uint32_t> small_vector = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -230,14 +227,14 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
         ChipId mmio_chip = cluster_desc->get_chips_with_mmio().begin()->first;
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = 0x0;
-        device.write_to_device(
+        device->write_to_device(
             large_vector.data(),
             large_vector.size() * sizeof(std::uint32_t),
             mmio_chip,
             CoreCoord(0, 0, CoreType::DRAM, CoordSystem::NOC0),
             address);
         test_utils::read_data_from_device(
-            device,
+            device.get(),
             readback_vec,
             mmio_chip,
             CoreCoord(0, 0, CoreType::DRAM, CoordSystem::NOC0),
@@ -252,15 +249,16 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (const auto& chip : target_devices) {
-            for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
-                device.write_to_device(
+            for (const CoreCoord& core : device->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
+                device->write_to_device(
                     small_vector.data(), small_vector.size() * sizeof(std::uint32_t), chip, core, address);
             }
         }
-        device.wait_for_non_mmio_flush();
+        device->wait_for_non_mmio_flush();
         for (const auto& chip : target_devices) {
-            for (const CoreCoord& core : device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
-                test_utils::read_data_from_device(device, readback_vec, chip, core, address, small_vector.size() * 4);
+            for (const CoreCoord& core : device->get_soc_descriptor(chip).get_cores(CoreType::TENSIX)) {
+                test_utils::read_data_from_device(
+                    device.get(), readback_vec, chip, core, address, small_vector.size() * 4);
                 EXPECT_EQ(small_vector, readback_vec)
                     << "Vector read back from core " << core.str() << " does not match what was written";
                 readback_vec = {};
@@ -270,5 +268,5 @@ TEST(GalaxyConcurrentThreads, PushInputsWhileSignalingCluster) {
 
     th1.join();
     th2.join();
-    device.close_device();
+    device->close_device();
 }

--- a/tests/galaxy/test_umd_remote_api.cpp
+++ b/tests/galaxy/test_umd_remote_api.cpp
@@ -27,12 +27,11 @@
 using namespace tt::umd;
 
 void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
-    auto device_ptr = test_utils::make_default_test_cluster();
-    Cluster& device = *device_ptr;
+    std::unique_ptr<Cluster> device = test_utils::make_default_test_cluster();
 
-    test::utils::set_barrier_params(device);
+    test::utils::set_barrier_params(device.get());
 
-    test_utils::safe_test_cluster_start(&device);
+    test_utils::safe_test_cluster_start(device.get());
 
     // Test.
     std::vector<uint32_t> vector_to_write(vector_size);
@@ -42,28 +41,28 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
 
     std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
 
-    for (const auto& chip : device.get_target_device_ids()) {
+    for (const auto& chip : device->get_target_device_ids()) {
         std::vector<float> write_bw;
         std::vector<float> read_bw;
         for (int loop = 0; loop < 10; loop++) {
             std::vector<CoreCoord> target_cores;
             if (dram_write) {
-                target_cores = device.get_soc_descriptor(chip).get_cores(CoreType::DRAM);
+                target_cores = device->get_soc_descriptor(chip).get_cores(CoreType::DRAM);
             } else {
-                target_cores = device.get_soc_descriptor(chip).get_cores(CoreType::TENSIX);
+                target_cores = device->get_soc_descriptor(chip).get_cores(CoreType::TENSIX);
             }
             for (const CoreCoord& core : target_cores) {
                 auto start = std::chrono::high_resolution_clock::now();
-                device.write_to_device(
+                device->write_to_device(
                     vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), chip, core, address);
-                device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
+                device->wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
                 auto end = std::chrono::high_resolution_clock::now();
                 auto duration = double(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
                 write_bw.push_back(float((write_size / (1024 * 1024 * 1024)) / (duration / 1e6)));
                 // std::cout << "  chip " << chip << " core " << target_core.str() << " " << duration << std::endl;
 
                 start = std::chrono::high_resolution_clock::now();
-                test_utils::read_data_from_device(device, readback_vec, chip, core, address, write_size);
+                test_utils::read_data_from_device(device.get(), readback_vec, chip, core, address, write_size);
                 end = std::chrono::high_resolution_clock::now();
                 duration = double(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
                 // std::cout << " read chip " << chip << " core " << target_core.str()<< " " << duration << std::endl;
@@ -85,7 +84,7 @@ void run_remote_read_write_test(uint32_t vector_size, bool dram_write) {
         //  std::reduce(read_bw.begin(), read_bw.end()) / read_bw.size() << " GB/s" << std::endl;
     }
 
-    device.close_device();
+    device->close_device();
 }
 
 // write and read back 10 uint32_t to L1 of every worker core on every chip in the cluster
@@ -116,9 +115,8 @@ TEST(GalaxyBasicReadWrite, LargeRemoteDramBlockReadWrite) { run_remote_read_writ
 
 void run_data_mover_test(
     uint32_t vector_size, tt_multichip_core_addr sender_core, tt_multichip_core_addr receiver_core) {
-    auto device_ptr = test_utils::make_default_test_cluster();
-    Cluster& device = *device_ptr;
-    auto target_devices = device.get_target_device_ids();
+    std::unique_ptr<Cluster> device = test_utils::make_default_test_cluster();
+    auto target_devices = device->get_target_device_ids();
 
     // Verify that sender chip and receiver chip are in the cluster.
     auto it = target_devices.find(sender_core.chip);
@@ -129,9 +127,9 @@ void run_data_mover_test(
     ASSERT_TRUE(it != target_devices.end())
         << "Receiver core is on chip " << sender_core.chip << " which is not in the Galaxy cluster";
 
-    test::utils::set_barrier_params(device);
+    test::utils::set_barrier_params(device.get());
 
-    test_utils::safe_test_cluster_start(&device);
+    test_utils::safe_test_cluster_start(device.get());
 
     // Test.
     std::vector<uint32_t> vector_to_write(vector_size);
@@ -141,17 +139,17 @@ void run_data_mover_test(
 
     std::vector<float> send_bw;
     // Set up data in sender core.
-    device.write_to_device(
+    device->write_to_device(
         vector_to_write.data(),
         vector_to_write.size() * sizeof(std::uint32_t),
         sender_core.chip,
         sender_core.core,
         sender_core.addr);
-    device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
+    device->wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 
     // Send data from sender core to receiver core.
     auto start = std::chrono::high_resolution_clock::now();
-    move_data(device, sender_core, receiver_core, write_size);
+    move_data(device.get(), sender_core, receiver_core, write_size);
     auto end = std::chrono::high_resolution_clock::now();
     auto duration = double(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
     send_bw.push_back(float((write_size / (1024 * 1024 * 1024)) / (duration / 1e6)));
@@ -159,7 +157,7 @@ void run_data_mover_test(
 
     // Verify data is correct in receiver core.
     test_utils::read_data_from_device(
-        device, readback_vec, receiver_core.chip, receiver_core.core, receiver_core.addr, write_size);
+        device.get(), readback_vec, receiver_core.chip, receiver_core.core, receiver_core.addr, write_size);
     EXPECT_EQ(vector_to_write, readback_vec)
         << "Vector read back from core " << receiver_core.str() << " does not match what was written";
 
@@ -169,7 +167,7 @@ void run_data_mover_test(
     // std::reduce(send_bw.begin(), send_bw.end()) / send_bw.size() << " GB/s" <<
     // std::endl;
 
-    device.close_device();
+    device->close_device();
 }
 
 // L1 to L1.
@@ -228,9 +226,8 @@ void run_data_broadcast_test(
     uint32_t vector_size,
     tt_multichip_core_addr sender_core,
     const std::vector<tt_multichip_core_addr>& receiver_cores) {
-    auto device_ptr = test_utils::make_default_test_cluster();
-    Cluster& device = *device_ptr;
-    auto target_devices = device.get_target_device_ids();
+    std::unique_ptr<Cluster> device = test_utils::make_default_test_cluster();
+    auto target_devices = device->get_target_device_ids();
 
     // Verify that sender chip and receiver chip are in the cluster.
     auto it = target_devices.find(sender_core.chip);
@@ -243,9 +240,9 @@ void run_data_broadcast_test(
             << "Receiver core is on chip " << sender_core.chip << " which is not in the Galaxy cluster";
     }
 
-    test::utils::set_barrier_params(device);
+    test::utils::set_barrier_params(device.get());
 
-    test_utils::safe_test_cluster_start(&device);
+    test_utils::safe_test_cluster_start(device.get());
 
     // Test.
     std::vector<uint32_t> vector_to_write(vector_size);
@@ -255,17 +252,17 @@ void run_data_broadcast_test(
 
     std::vector<float> send_bw;
     //  Set up data in sender core.
-    device.write_to_device(
+    device->write_to_device(
         vector_to_write.data(),
         vector_to_write.size() * sizeof(std::uint32_t),
         sender_core.chip,
         sender_core.core,
         sender_core.addr);
-    device.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
+    device->wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 
     // Send data from sender core to receiver core.
     auto start = std::chrono::high_resolution_clock::now();
-    broadcast_data(device, sender_core, receiver_cores, write_size);
+    broadcast_data(device.get(), sender_core, receiver_cores, write_size);
     auto end = std::chrono::high_resolution_clock::now();
     auto duration = double(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
     send_bw.push_back(float((write_size / (1024 * 1024 * 1024)) / (duration / 1e6)));
@@ -274,7 +271,7 @@ void run_data_broadcast_test(
     // Verify data is correct in receiver core.
     for (const auto& receiver_core : receiver_cores) {
         test_utils::read_data_from_device(
-            device, readback_vec, receiver_core.chip, receiver_core.core, receiver_core.addr, write_size);
+            device.get(), readback_vec, receiver_core.chip, receiver_core.core, receiver_core.addr, write_size);
         EXPECT_EQ(vector_to_write, readback_vec)
             << "Vector read back from core " << receiver_core.str() << " does not match what was written";
         readback_vec = {};
@@ -286,7 +283,7 @@ void run_data_broadcast_test(
     // std::reduce(send_bw.begin(), send_bw.end()) / send_bw.size() << " GB/s" <<
     // std::endl;
 
-    device.close_device();
+    device->close_device();
 }
 
 // L1 to L1 single chip.

--- a/tests/galaxy/test_umd_remote_api_stability.cpp
+++ b/tests/galaxy/test_umd_remote_api_stability.cpp
@@ -58,7 +58,7 @@ TEST_F(WormholeGalaxyStabilityTestFixture, MixedRemoteTransfers) {
     std::vector<remote_transfer_sample_t> command_history;
     try {
         RunMixedTransfersUniformDistributions(
-            *this->cluster,
+            this->cluster.get(),
             100000 * scale_number_of_tests,
             seed,
             transfer_type_weights_t{.write = 0.40, .read = 0.4},
@@ -86,7 +86,7 @@ TEST_F(WormholeGalaxyStabilityTestFixture, DISABLED_MultithreadedMixedRemoteTran
     assert(cluster != nullptr);
     std::thread t1([&]() {
         RunMixedTransfersUniformDistributions(
-            *cluster,
+            cluster.get(),
             50000 * scale_number_of_tests,
             0,
             transfer_type_weights_t{.write = 0.50, .read = 0.50},
@@ -106,7 +106,7 @@ TEST_F(WormholeGalaxyStabilityTestFixture, DISABLED_MultithreadedMixedRemoteTran
     });
     std::thread t2([&]() {
         RunMixedTransfersUniformDistributions(
-            *cluster,
+            cluster.get(),
             50000 * scale_number_of_tests,
             100,
             transfer_type_weights_t{.write = 0.25, .read = 0.50},
@@ -126,7 +126,7 @@ TEST_F(WormholeGalaxyStabilityTestFixture, DISABLED_MultithreadedMixedRemoteTran
     });
     std::thread t3([&]() {
         RunMixedTransfersUniformDistributions(
-            *cluster,
+            cluster.get(),
             50000 * scale_number_of_tests,
             23,
             transfer_type_weights_t{.write = 0.5, .read = 0.25},
@@ -146,7 +146,7 @@ TEST_F(WormholeGalaxyStabilityTestFixture, DISABLED_MultithreadedMixedRemoteTran
     });
     std::thread t4([&]() {
         RunMixedTransfersUniformDistributions(
-            *cluster,
+            cluster.get(),
             100000 * scale_number_of_tests,
             99,
             transfer_type_weights_t{.write = 0.1, .read = 0.1},

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -76,10 +76,10 @@ static inline void size_buffer_to_capacity(std::vector<T>& data_buf, std::size_t
 }
 
 static inline void read_data_from_device(
-    Cluster& cluster, std::vector<uint32_t>& vec, ChipId chip_id, CoreCoord core, uint64_t addr, uint32_t size) {
+    Cluster* cluster, std::vector<uint32_t>& vec, ChipId chip_id, CoreCoord core, uint64_t addr, uint32_t size) {
     size_buffer_to_capacity(vec, size);
     // Use architecture-specific read method: DMA for WORMHOLE_B0, regular read for others (including Blackhole).
-    cluster.read_from_device(vec.data(), chip_id, core, addr, size);
+    cluster->read_from_device(vec.data(), chip_id, core, addr, size);
 }
 
 inline void fill_with_random_bytes(uint8_t* data, size_t n) {

--- a/tests/test_utils/stimulus_generators.hpp
+++ b/tests/test_utils/stimulus_generators.hpp
@@ -388,7 +388,7 @@ int bytes_to_words(int num_bytes) {
 }
 
 static inline void dispatch_remote_transfer_command(
-    Cluster& driver, remote_transfer_sample_t const& command, std::vector<uint32_t>& payload) {
+    Cluster* cluster, remote_transfer_sample_t const& command, std::vector<uint32_t>& payload) {
     auto resize_payload = [](std::vector<uint32_t>& payload, int size_in_bytes) {
         payload.resize(bytes_to_words<uint32_t>(size_in_bytes));
     };
@@ -398,7 +398,7 @@ static inline void dispatch_remote_transfer_command(
             write_transfer_sample_t const& command_args = std::get<write_transfer_sample_t>(std::get<1>(command));
             assert(command_args.size_in_bytes >= sizeof(uint32_t));
             resize_payload(payload, command_args.size_in_bytes);
-            driver.write_to_device(
+            cluster->write_to_device(
                 payload.data(),
                 bytes_to_words<uint32_t>(command_args.size_in_bytes),
                 command_args.destination.first,
@@ -409,7 +409,7 @@ static inline void dispatch_remote_transfer_command(
             read_transfer_sample_t const& command_args = std::get<read_transfer_sample_t>(std::get<1>(command));
             assert(command_args.size_in_bytes >= sizeof(uint32_t));
             resize_payload(payload, command_args.size_in_bytes);
-            driver.read_from_device(
+            cluster->read_from_device(
                 payload.data(),
                 command_args.destination.first,
                 command_args.destination.second,
@@ -442,8 +442,8 @@ static void print_command_executable_code(remote_transfer_sample_t const& comman
             emit_payload_resize_string(command_args.size_in_bytes, sizeof(uint32_t));
             std::cout << "cluster->write_to_device(payload.data(), len, destination, " << command_args.address << "\");"
                       << std::endl;
-            // driver.write_to_device(payload.data(), command_args.size, command_args.destination, command_args.address,
-            // false, false);
+            // cluster->write_to_device(payload.data(), command_args.size, command_args.destination,
+            // command_args.address, false, false);
         } break;
         case RemoteTransferType::READ: {
             read_transfer_sample_t const& command_args = std::get<read_transfer_sample_t>(std::get<1>(command));
@@ -452,7 +452,7 @@ static void print_command_executable_code(remote_transfer_sample_t const& comman
             emit_payload_resize_string(command_args.size_in_bytes, sizeof(uint32_t));
             std::cout << "cluster->read_from_device(payload.data(), destination, " << command_args.address << ", "
                       << command_args.size_in_bytes << "\");" << std::endl;
-            // driver.read_from_device(payload.data(), command_args.destination, command_args.address,
+            // cluster->read_from_device(payload.data(), command_args.destination, command_args.address,
             // command_args.size);
         } break;
         default:
@@ -487,7 +487,7 @@ template <
     template <typename>
     class READ_SIZE_DISTR_T>
 void RunMixedTransfers(
-    Cluster& cluster,
+    Cluster* cluster,
     int num_samples,
     int seed,
 
@@ -561,9 +561,9 @@ static inline WriteCommandGenerator<
     std::uniform_int_distribution,
     transfer_size_t,
     std::uniform_int_distribution>
-build_dummy_write_command_generator(Cluster& cluster) {
-    ClusterDescriptor* cluster_desc = cluster.get_cluster_description();
-    SocDescriptor const& soc_desc = cluster.get_soc_descriptor(0);
+build_dummy_write_command_generator(Cluster* cluster) {
+    ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
+    SocDescriptor const& soc_desc = cluster->get_soc_descriptor(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
     auto dest_generator = ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int_distribution>(
         0,
@@ -586,9 +586,9 @@ static inline ReadCommandGenerator<
     std::uniform_int_distribution,
     transfer_size_t,
     std::uniform_int_distribution>
-build_dummy_read_command_generator(Cluster& cluster) {
-    ClusterDescriptor* cluster_desc = cluster.get_cluster_description();
-    SocDescriptor const& soc_desc = cluster.get_soc_descriptor(0);
+build_dummy_read_command_generator(Cluster* cluster) {
+    ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
+    SocDescriptor const& soc_desc = cluster->get_soc_descriptor(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
     auto dest_generator = ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int_distribution>(
         0,
@@ -614,7 +614,7 @@ template <
     template <typename>
     class UNROLL_COUNT_GENERATOR_T>
 void RunMixedTransfersUniformDistributions(
-    Cluster& cluster,
+    Cluster* cluster,
     int num_samples,
     int seed,
 
@@ -628,8 +628,8 @@ void RunMixedTransfersUniformDistributions(
 
     bool record_command_history = false,
     std::vector<remote_transfer_sample_t>* command_history = nullptr) {
-    ClusterDescriptor* cluster_desc = cluster.get_cluster_description();
-    SocDescriptor const& soc_desc = cluster.get_soc_descriptor(0);
+    ClusterDescriptor* cluster_desc = cluster->get_cluster_description();
+    SocDescriptor const& soc_desc = cluster->get_soc_descriptor(0);
     std::vector<destination_t> core_index_to_location = generate_core_index_locations(*cluster_desc, soc_desc);
 
     auto dest_generator = ConstrainedTemplateTemplateGenerator<destination_t, int, std::uniform_int_distribution>(

--- a/tests/unified/multiprocess.cpp
+++ b/tests/unified/multiprocess.cpp
@@ -77,7 +77,7 @@ static void test_read_write_all_tensix_cores_impl(
         for (const CoreCoord& core : cluster->get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
             cluster->write_to_device(vector_to_write.data(), data_size, 0, core, address);
             cluster->l1_membar(0, {core});
-            test_utils::read_data_from_device(*cluster, readback_vec, 0, core, address, data_size);
+            test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, data_size);
             ASSERT_EQ(vector_to_write, readback_vec)
                 << "Vector read back from core " << core.str() << " does not match what was written";
             readback_vec.clear();

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -839,23 +839,24 @@ TEST(SiliconDriverWH, EthernetBroadcastSingleRemotePerChip) {
     // and verify the data is read back correctly.
     // Note: this test intentionally only covers the tensix branch. The DRAM branch (the virtual-column 0/5
     // split logic in broadcast_write_to_cluster) is already exercised by VirtualCoordinateBroadcastPerChip.
-    Cluster cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
-    set_barrier_params(cluster);
-    auto mmio_devices = cluster.get_target_mmio_device_ids();
+    std::unique_ptr<Cluster> cluster =
+        test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    set_barrier_params(cluster.get());
+    auto mmio_devices = cluster->get_target_mmio_device_ids();
 
-    test_utils::safe_test_cluster_start(&cluster);
+    test_utils::safe_test_cluster_start(cluster.get());
 
-    auto remote_devices = cluster.get_target_remote_device_ids();
+    auto remote_devices = cluster->get_target_remote_device_ids();
     if (remote_devices.empty()) {
-        cluster.close_device();
+        cluster->close_device();
         GTEST_SKIP() << "SiliconDriverWH.EthernetBroadcastSingleRemotePerChip skipped: no remote devices found";
     }
 
-    auto eth_version = cluster.get_ethernet_firmware_version();
+    auto eth_version = cluster->get_ethernet_firmware_version();
     bool virtual_bcast_supported = (eth_version >= SemVer(6, 8, 0) || eth_version == SemVer(6, 7, 241)) &&
-                                   cluster.get_soc_descriptor(*mmio_devices.begin()).noc_translation_enabled;
+                                   cluster->get_soc_descriptor(*mmio_devices.begin()).noc_translation_enabled;
     if (!virtual_bcast_supported) {
-        cluster.close_device();
+        cluster->close_device();
         GTEST_SKIP() << "SiliconDriverWH.EthernetBroadcastSingleRemotePerChip skipped: ethernet version does not "
                         "support Virtual Coordinate Broadcast or NOC translation is not enabled";
     }
@@ -868,7 +869,7 @@ TEST(SiliconDriverWH, EthernetBroadcastSingleRemotePerChip) {
     std::set<uint32_t> cols_to_exclude = {16, 17, 20};
 
     for (auto chip_id : remote_devices) {
-        RemoteChip* remote_chip = cluster.get_remote_chip(chip_id);
+        RemoteChip* remote_chip = cluster->get_remote_chip(chip_id);
         EthernetBroadcast eth_broadcast(remote_chip->get_remote_communication());
 
         for (const auto& size : broadcast_sizes) {
@@ -888,11 +889,11 @@ TEST(SiliconDriverWH, EthernetBroadcastSingleRemotePerChip) {
                 rows_to_exclude,
                 cols_to_exclude,
                 true);
-            cluster.wait_for_non_mmio_flush(chip_id);
+            cluster->wait_for_non_mmio_flush(chip_id);
 
-            for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster->get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
                 const CoreCoord translated_core =
-                    cluster.get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
+                    cluster->get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
                 if (rows_to_exclude.find(translated_core.y) != rows_to_exclude.end()) {
                     continue;
                 }
@@ -900,11 +901,11 @@ TEST(SiliconDriverWH, EthernetBroadcastSingleRemotePerChip) {
                     continue;
                 }
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * sizeof(uint32_t));
+                    cluster.get(), readback_vec, chip_id, core, address, vector_to_write.size() * sizeof(uint32_t));
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from chip " << chip_id << " core " << core.str()
                     << " does not match what was broadcasted for size " << size;
-                cluster.write_to_device(
+                cluster->write_to_device(
                     zeros.data(),
                     zeros.size() * sizeof(std::uint32_t),
                     chip_id,
@@ -913,31 +914,32 @@ TEST(SiliconDriverWH, EthernetBroadcastSingleRemotePerChip) {
                 readback_vec = {};
             }
         }
-        cluster.wait_for_non_mmio_flush(chip_id);
+        cluster->wait_for_non_mmio_flush(chip_id);
     }
-    cluster.close_device();
+    cluster->close_device();
 }
 
 TEST(SiliconDriverWH, DeviceProtocolWriteCoreRange) {
     // Broadcast to a partial tensix grid via DeviceProtocol::write_to_core_range and verify that
     // cores inside the range received the data while cores outside still hold zeros.
-    Cluster cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
-    set_barrier_params(cluster);
-    auto mmio_devices = cluster.get_target_mmio_device_ids();
+    std::unique_ptr<Cluster> cluster =
+        test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    set_barrier_params(cluster.get());
+    auto mmio_devices = cluster->get_target_mmio_device_ids();
 
-    test_utils::safe_test_cluster_start(&cluster);
+    test_utils::safe_test_cluster_start(cluster.get());
 
-    auto remote_devices = cluster.get_target_remote_device_ids();
+    auto remote_devices = cluster->get_target_remote_device_ids();
     if (remote_devices.empty()) {
-        cluster.close_device();
+        cluster->close_device();
         GTEST_SKIP() << "SiliconDriverWH.DeviceProtocolWriteCoreRange skipped: no remote devices found";
     }
 
-    auto eth_version = cluster.get_ethernet_firmware_version();
+    auto eth_version = cluster->get_ethernet_firmware_version();
     bool virtual_bcast_supported = (eth_version >= SemVer(6, 8, 0) || eth_version == SemVer(6, 7, 241)) &&
-                                   cluster.get_soc_descriptor(*mmio_devices.begin()).noc_translation_enabled;
+                                   cluster->get_soc_descriptor(*mmio_devices.begin()).noc_translation_enabled;
     if (!virtual_bcast_supported) {
-        cluster.close_device();
+        cluster->close_device();
         GTEST_SKIP() << "SiliconDriverWH.DeviceProtocolWriteCoreRange skipped: ethernet version does not support "
                         "Virtual Coordinate Broadcast or NOC translation is not enabled";
     }
@@ -953,9 +955,9 @@ TEST(SiliconDriverWH, DeviceProtocolWriteCoreRange) {
         wormhole::tensix_translated_coordinate_start_y + wormhole::TENSIX_GRID_SIZE.y / 2 - 1};
 
     for (auto chip_id : remote_devices) {
-        RemoteChip* remote_chip = cluster.get_remote_chip(chip_id);
+        RemoteChip* remote_chip = cluster->get_remote_chip(chip_id);
         DeviceProtocol* protocol = remote_chip->get_tt_device()->get_device_protocol();
-        const auto& sdesc = cluster.get_soc_descriptor(chip_id);
+        const auto& sdesc = cluster->get_soc_descriptor(chip_id);
         const auto& tensix_cores = sdesc.get_cores(CoreType::TENSIX);
 
         for (const auto& size : broadcast_sizes) {
@@ -967,9 +969,9 @@ TEST(SiliconDriverWH, DeviceProtocolWriteCoreRange) {
 
             // Clear all tensix cores before the broadcast.
             for (const CoreCoord& core : tensix_cores) {
-                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(uint32_t), chip_id, core, address);
+                cluster->write_to_device(zeros.data(), zeros.size() * sizeof(uint32_t), chip_id, core, address);
             }
-            cluster.wait_for_non_mmio_flush(chip_id);
+            cluster->wait_for_non_mmio_flush(chip_id);
 
             bool hw_broadcast = protocol->write_to_core_range(
                 vector_to_write.data(),
@@ -980,7 +982,7 @@ TEST(SiliconDriverWH, DeviceProtocolWriteCoreRange) {
                 NocId::NOC0);
             ASSERT_TRUE(hw_broadcast) << "Expected hardware broadcast to succeed for chip " << chip_id << " size "
                                       << size;
-            cluster.wait_for_non_mmio_flush(chip_id);
+            cluster->wait_for_non_mmio_flush(chip_id);
 
             for (const CoreCoord& core : tensix_cores) {
                 const CoreCoord translated = sdesc.translate_coord_to(core, CoordSystem::TRANSLATED);
@@ -989,7 +991,7 @@ TEST(SiliconDriverWH, DeviceProtocolWriteCoreRange) {
 
                 std::vector<uint32_t> readback_vec;
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, size * sizeof(uint32_t));
+                    cluster.get(), readback_vec, chip_id, core, address, size * sizeof(uint32_t));
 
                 if (in_range) {
                     ASSERT_EQ(vector_to_write, readback_vec)
@@ -1005,12 +1007,12 @@ TEST(SiliconDriverWH, DeviceProtocolWriteCoreRange) {
         // Final cleanup.
         std::vector<uint32_t> zeros_cleanup(broadcast_sizes.back(), 0);
         for (const CoreCoord& core : tensix_cores) {
-            cluster.write_to_device(
+            cluster->write_to_device(
                 zeros_cleanup.data(), zeros_cleanup.size() * sizeof(uint32_t), chip_id, core, address);
         }
-        cluster.wait_for_non_mmio_flush(chip_id);
+        cluster->wait_for_non_mmio_flush(chip_id);
     }
-    cluster.close_device();
+    cluster->close_device();
 }
 
 TEST(SiliconDriverWH, LargeAddressTlb) {

--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -57,9 +57,9 @@ static const std::vector<tt_xy_pair> ETH_CORES_TRANSLATION_ON = {
 static const std::vector<uint32_t> T6_X_TRANSLATED_LOCATIONS = {18, 19, 20, 21, 22, 23, 24, 25};
 static const std::vector<uint32_t> T6_Y_TRANSLATED_LOCATIONS = {18, 19, 20, 21, 22, 23, 24, 25, 26, 27};
 
-static void set_barrier_params(Cluster& cluster) {
+static void set_barrier_params(Cluster* cluster) {
     // Populate address map and NOC parameters that the driver needs for memory barriers and remote transactions.
-    cluster.set_barrier_address_params(
+    cluster->set_barrier_address_params(
         {l1_mem::address_map::L1_BARRIER_BASE, eth_l1_mem::address_map::ERISC_BARRIER_BASE, DRAM_BARRIER_BASE});
 }
 
@@ -80,36 +80,34 @@ TEST(SiliconDriverWH, CreateDestroy) {
 
 TEST(SiliconDriverWH, CustomSocDesc) {
     // Initialize the driver with a 1x1 descriptor and explictly do not perform harvesting.
-    auto cluster_ptr = test_utils::make_default_test_cluster(ClusterOptions{
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster(ClusterOptions{
         .sdesc_path = test_utils::GetSocDescAbsPath("wormhole_b0_1x1.yaml"),
     });
-    Cluster& cluster = *cluster_ptr;
-    for (const auto& chip : cluster.get_target_device_ids()) {
+    for (const auto& chip : cluster->get_target_device_ids()) {
         ASSERT_EQ(
-            cluster.get_tt_device(chip)->get_soc_descriptor().get_cores(CoreType::TENSIX).size() +
-                cluster.get_tt_device(chip)->get_soc_descriptor().get_harvested_cores(CoreType::TENSIX).size(),
+            cluster->get_tt_device(chip)->get_soc_descriptor().get_cores(CoreType::TENSIX).size() +
+                cluster->get_tt_device(chip)->get_soc_descriptor().get_harvested_cores(CoreType::TENSIX).size(),
             1)
             << "Expected 1x1 SOC descriptor to be used in TTDevice.";
         ASSERT_EQ(
-            cluster.get_soc_descriptor(chip).get_cores(CoreType::TENSIX).size() +
-                cluster.get_soc_descriptor(chip).get_harvested_cores(CoreType::TENSIX).size(),
+            cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX).size() +
+                cluster->get_soc_descriptor(chip).get_harvested_cores(CoreType::TENSIX).size(),
             1)
             << "Expected 1x1 SOC descriptor to be unmodified by driver.";
     }
 }
 
 TEST(SiliconDriverWH, HarvestingRuntime) {
-    auto cluster_ptr = test_utils::make_default_test_cluster();
-    Cluster& cluster = *cluster_ptr;
-    set_barrier_params(cluster);
-    auto mmio_devices = cluster.get_target_mmio_device_ids();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+    set_barrier_params(cluster.get());
+    auto mmio_devices = cluster->get_target_mmio_device_ids();
 
     // Iterate over MMIO devices and only setup static TLBs for worker cores.
     for (auto chip_id : mmio_devices) {
-        auto& sdesc = cluster.get_soc_descriptor(chip_id);
+        auto& sdesc = cluster->get_soc_descriptor(chip_id);
         for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
             // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
-            cluster.configure_tlb(
+            cluster->configure_tlb(
                 chip_id, core, tt::umd::wormhole::STATIC_TLB_SIZE, l1_mem::address_map::NCRISC_FIRMWARE_BASE);
         }
     }
@@ -119,44 +117,44 @@ TEST(SiliconDriverWH, HarvestingRuntime) {
     std::vector<uint32_t> readback_vec = {};
     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-    for (auto chip_id : cluster.get_target_device_ids()) {
+    for (auto chip_id : cluster->get_target_device_ids()) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         std::uint32_t dynamic_write_address = 0x40000000;
         for (int loop = 0; loop < 100;
              loop++) {  // Write to each core a 100 times at different statically mapped addresses
-            for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
-                cluster.write_to_device(
+            for (const CoreCoord& core : cluster->get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+                cluster->write_to_device(
                     vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), chip_id, core, address);
-                cluster.write_to_device(
+                cluster->write_to_device(
                     vector_to_write.data(),
                     vector_to_write.size() * sizeof(std::uint32_t),
                     chip_id,
                     core,
                     dynamic_write_address);
-                cluster.wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
+                cluster->wait_for_non_mmio_flush();  // Barrier to ensure that all writes over ethernet were commited
 
-                test_utils::read_data_from_device(cluster, readback_vec, chip_id, core, address, 40);
+                test_utils::read_data_from_device(cluster.get(), readback_vec, chip_id, core, address, 40);
                 test_utils::read_data_from_device(
-                    cluster, dynamic_readback_vec, chip_id, core, dynamic_write_address, 40);
+                    cluster.get(), dynamic_readback_vec, chip_id, core, dynamic_write_address, 40);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.str() << " does not match what was written";
                 ASSERT_EQ(vector_to_write, dynamic_readback_vec)
                     << "Vector read back from core " << core.str() << " does not match what was written";
-                cluster.wait_for_non_mmio_flush();
+                cluster->wait_for_non_mmio_flush();
 
-                cluster.write_to_device(
+                cluster->write_to_device(
                     zeros.data(),
                     zeros.size() * sizeof(std::uint32_t),
                     chip_id,
                     core,
                     dynamic_write_address);  // Clear any written data
-                cluster.write_to_device(
+                cluster->write_to_device(
                     zeros.data(),
                     zeros.size() * sizeof(std::uint32_t),
                     chip_id,
                     core,
                     address);  // Clear any written data
-                cluster.wait_for_non_mmio_flush();
+                cluster->wait_for_non_mmio_flush();
                 readback_vec = {};
                 dynamic_readback_vec = {};
             }
@@ -164,24 +162,24 @@ TEST(SiliconDriverWH, HarvestingRuntime) {
             dynamic_write_address += 0x20;
         }
     }
-    cluster.close_device();
+    cluster->close_device();
 }
 
 TEST(SiliconDriverWH, UnalignedStaticTLB_RW) {
-    auto cluster_ptr = test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
-    Cluster& cluster = *cluster_ptr;
-    set_barrier_params(cluster);
+    std::unique_ptr<Cluster> cluster =
+        test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    set_barrier_params(cluster.get());
 
     // Do this only for a single chip to speed up the test.
-    auto chip_id = *cluster.get_target_mmio_device_ids().begin();
-    auto& sdesc = cluster.get_soc_descriptor(chip_id);
+    auto chip_id = *cluster->get_target_mmio_device_ids().begin();
+    auto& sdesc = cluster->get_soc_descriptor(chip_id);
     for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
         // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
-        cluster.configure_tlb(
+        cluster->configure_tlb(
             chip_id, core, tt::umd::wormhole::STATIC_TLB_SIZE, l1_mem::address_map::NCRISC_FIRMWARE_BASE);
     }
 
-    test_utils::safe_test_cluster_start(&cluster);
+    test_utils::safe_test_cluster_start(cluster.get());
 
     std::vector<uint32_t> unaligned_sizes = {3, 14, 21, 255, 362, 430, 1022, 1023, 1025};
     for (const auto& size : unaligned_sizes) {
@@ -191,34 +189,33 @@ TEST(SiliconDriverWH, UnalignedStaticTLB_RW) {
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (int loop = 0; loop < 50; loop++) {
             for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
-                cluster.write_to_device(write_vec.data(), size, chip_id, core, address);
-                cluster.wait_for_non_mmio_flush();
-                cluster.read_from_device(readback_vec.data(), chip_id, core, address, size);
+                cluster->write_to_device(write_vec.data(), size, chip_id, core, address);
+                cluster->wait_for_non_mmio_flush();
+                cluster->read_from_device(readback_vec.data(), chip_id, core, address, size);
                 ASSERT_EQ(readback_vec, write_vec);
                 readback_vec = std::vector<uint8_t>(size, 0);
-                cluster.write_to_sysmem(write_vec.data(), size, 0, 0, 0);
-                cluster.read_from_sysmem(readback_vec.data(), 0, 0, size, 0);
+                cluster->write_to_sysmem(write_vec.data(), size, 0, 0, 0);
+                cluster->read_from_sysmem(readback_vec.data(), 0, 0, size, 0);
                 ASSERT_EQ(readback_vec, write_vec);
                 readback_vec = std::vector<uint8_t>(size, 0);
-                cluster.wait_for_non_mmio_flush();
+                cluster->wait_for_non_mmio_flush();
             }
             address += 0x20;
         }
     }
-    cluster.close_device();
+    cluster->close_device();
 }
 
 TEST(SiliconDriverWH, StaticTLB_RW) {
-    auto cluster_ptr = test_utils::make_default_test_cluster();
-    Cluster& cluster = *cluster_ptr;
-    set_barrier_params(cluster);
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+    set_barrier_params(cluster.get());
 
     // Do this only for a single chip to speed up the test.
-    auto chip_id = *cluster.get_target_mmio_device_ids().begin();
-    auto& sdesc = cluster.get_soc_descriptor(chip_id);
+    auto chip_id = *cluster->get_target_mmio_device_ids().begin();
+    auto& sdesc = cluster->get_soc_descriptor(chip_id);
     for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
         // Statically mapping a 1MB TLB to this core, starting from address NCRISC_FIRMWARE_BASE.
-        cluster.configure_tlb(
+        cluster->configure_tlb(
             chip_id, core, tt::umd::wormhole::STATIC_TLB_SIZE, l1_mem::address_map::NCRISC_FIRMWARE_BASE);
     }
 
@@ -230,37 +227,36 @@ TEST(SiliconDriverWH, StaticTLB_RW) {
     // Stress-test TLB stability by exercising one chip 100 times at different statically mapped addresses.
     for (int loop = 0; loop < 100; loop++) {
         for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
-            cluster.write_to_device(
+            cluster->write_to_device(
                 vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), chip_id, core, address);
             // Barrier to ensure that all writes over ethernet were commited.
-            cluster.wait_for_non_mmio_flush();
-            test_utils::read_data_from_device(cluster, readback_vec, chip_id, core, address, 40);
+            cluster->wait_for_non_mmio_flush();
+            test_utils::read_data_from_device(cluster.get(), readback_vec, chip_id, core, address, 40);
             ASSERT_EQ(vector_to_write, readback_vec)
                 << "Vector read back from core " << core.str() << " does not match what was written";
-            cluster.wait_for_non_mmio_flush();
-            cluster.write_to_device(
+            cluster->wait_for_non_mmio_flush();
+            cluster->write_to_device(
                 zeros.data(),
                 zeros.size() * sizeof(std::uint32_t),
                 chip_id,
                 core,
                 address);  // Clear any written data
-            cluster.wait_for_non_mmio_flush();
+            cluster->wait_for_non_mmio_flush();
             readback_vec = {};
         }
         address += 0x20;  // Increment by uint32_t size for each write
     }
-    cluster.close_device();
+    cluster->close_device();
 }
 
 TEST(SiliconDriverWH, DynamicTLB_RW) {
     // Don't use any static TLBs in this test. All writes go through a dynamic TLB that needs to be reconfigured for
     // each transaction
-    auto cluster_ptr = test_utils::make_default_test_cluster();
-    Cluster& cluster = *cluster_ptr;
-    set_barrier_params(cluster);
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+    set_barrier_params(cluster.get());
 
-    auto chip_id = *cluster.get_target_mmio_device_ids().begin();
-    auto& sdesc = cluster.get_soc_descriptor(chip_id);
+    auto chip_id = *cluster->get_target_mmio_device_ids().begin();
+    auto& sdesc = cluster->get_soc_descriptor(chip_id);
 
     std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     std::vector<uint32_t> zeros = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -270,21 +266,21 @@ TEST(SiliconDriverWH, DynamicTLB_RW) {
     // Stress-test TLB stability by exercising one chip 100 times at different statically mapped addresses.
     for (int loop = 0; loop < 100; loop++) {
         for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
-            cluster.write_to_device(
+            cluster->write_to_device(
                 vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), chip_id, core, address);
             // Barrier to ensure that all writes over ethernet were commited.
-            cluster.wait_for_non_mmio_flush();
-            test_utils::read_data_from_device(cluster, readback_vec, chip_id, core, address, 40);
+            cluster->wait_for_non_mmio_flush();
+            test_utils::read_data_from_device(cluster.get(), readback_vec, chip_id, core, address, 40);
             ASSERT_EQ(vector_to_write, readback_vec)
                 << "Vector read back from core " << core.str() << " does not match what was written";
-            cluster.wait_for_non_mmio_flush();
-            cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
-            cluster.wait_for_non_mmio_flush();
+            cluster->wait_for_non_mmio_flush();
+            cluster->write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+            cluster->wait_for_non_mmio_flush();
             readback_vec = {};
         }
         address += 0x20;  // Increment by uint32_t size for each write
     }
-    cluster.close_device();
+    cluster->close_device();
 }
 
 // TODO(#2485): Re-enable. Writes and reads are not synchronized so they can land on the device out of order; broke
@@ -292,19 +288,18 @@ TEST(SiliconDriverWH, DynamicTLB_RW) {
 TEST(SiliconDriverWH, DISABLED_MultiThreadedDevice) {
     // Have 2 threads read and write from a single device concurrently
     // All transactions go through a single Dynamic TLB. We want to make sure this is thread/process safe.
-    auto cluster_ptr = test_utils::make_default_test_cluster();
-    Cluster& cluster = *cluster_ptr;
-    set_barrier_params(cluster);
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+    set_barrier_params(cluster.get());
 
     std::thread th1 = std::thread([&] {
         std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = l1_mem::address_map::NCRISC_FIRMWARE_BASE;
         for (int loop = 0; loop < 100; loop++) {
-            for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
-                cluster.write_to_device(
+            for (const CoreCoord& core : cluster->get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
+                cluster->write_to_device(
                     vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), 0, core, address);
-                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 40);
+                test_utils::read_data_from_device(cluster.get(), readback_vec, 0, core, address, 40);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from core " << core.str() << " does not match what was written";
                 readback_vec = {};
@@ -317,12 +312,12 @@ TEST(SiliconDriverWH, DISABLED_MultiThreadedDevice) {
         std::vector<uint32_t> vector_to_write = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         std::vector<uint32_t> readback_vec = {};
         std::uint32_t address = 0x30000000;
-        for (const std::vector<CoreCoord>& core_ls : cluster.get_soc_descriptor(0).get_dram_cores()) {
+        for (const std::vector<CoreCoord>& core_ls : cluster->get_soc_descriptor(0).get_dram_cores()) {
             for (int loop = 0; loop < 100; loop++) {
                 for (const CoreCoord& core : core_ls) {
-                    cluster.write_to_device(
+                    cluster->write_to_device(
                         vector_to_write.data(), vector_to_write.size() * sizeof(std::uint32_t), 0, core, address);
-                    test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 40);
+                    test_utils::read_data_from_device(cluster.get(), readback_vec, 0, core, address, 40);
                     ASSERT_EQ(vector_to_write, readback_vec)
                         << "Vector read back from core " << core.str() << " does not match what was written";
                     readback_vec = {};
@@ -334,7 +329,7 @@ TEST(SiliconDriverWH, DISABLED_MultiThreadedDevice) {
 
     th1.join();
     th2.join();
-    cluster.close_device();
+    cluster->close_device();
 }
 
 TEST(SiliconDriverWH, MultiThreadedMemBar) {
@@ -345,40 +340,39 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     // Memory barrier flags get sent to address 0 for all channels in this test.
     uint32_t base_addr = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
 
-    auto cluster_ptr = test_utils::make_default_test_cluster();
-    Cluster& cluster = *cluster_ptr;
-    set_barrier_params(cluster);
-    auto mmio_devices = cluster.get_target_mmio_device_ids();
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+    set_barrier_params(cluster.get());
+    auto mmio_devices = cluster->get_target_mmio_device_ids();
 
     // Iterate over MMIO devices and only setup static TLBs for worker cores.
     for (auto chip_id : mmio_devices) {
-        auto& sdesc = cluster.get_soc_descriptor(chip_id);
+        auto& sdesc = cluster->get_soc_descriptor(chip_id);
         for (const CoreCoord& core : sdesc.get_cores(CoreType::TENSIX)) {
             // Statically mapping a 1MB TLB to this core, starting from address DATA_BUFFER_SPACE_BASE.
-            cluster.configure_tlb(chip_id, core, tt::umd::wormhole::STATIC_TLB_SIZE, base_addr);
+            cluster->configure_tlb(chip_id, core, tt::umd::wormhole::STATIC_TLB_SIZE, base_addr);
         }
     }
 
     std::vector<uint32_t> readback_membar_vec = {};
-    for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
+    for (const CoreCoord& core : cluster->get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
         test_utils::read_data_from_device(
-            cluster, readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4);
+            cluster.get(), readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all workers
         readback_membar_vec = {};
     }
 
-    for (int chan = 0; chan < cluster.get_soc_descriptor(0).get_num_dram_channels(); chan++) {
-        CoreCoord core = cluster.get_soc_descriptor(0).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
-        test_utils::read_data_from_device(cluster, readback_membar_vec, 0, core, 0, 4);
+    for (int chan = 0; chan < cluster->get_soc_descriptor(0).get_num_dram_channels(); chan++) {
+        CoreCoord core = cluster->get_soc_descriptor(0).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+        test_utils::read_data_from_device(cluster.get(), readback_membar_vec, 0, core, 0, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers were correctly initialized on all DRAM
         readback_membar_vec = {};
     }
 
-    for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::ETH)) {
+    for (const CoreCoord& core : cluster->get_soc_descriptor(0).get_cores(CoreType::ETH)) {
         test_utils::read_data_from_device(
-            cluster, readback_membar_vec, 0, core, eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4);
+            cluster.get(), readback_membar_vec, 0, core, eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0),
             187);  // Ensure that memory barriers were correctly initialized on all ethernet cores
@@ -400,13 +394,13 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     std::thread th1 = std::thread([&] {
         std::uint32_t address = base_addr;
         for (int loop = 0; loop < 50; loop++) {
-            for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster->get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 std::vector<uint32_t> readback_vec = {};
-                cluster.write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), 0, core, address);
-                cluster.l1_membar(0, {core});
-                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec1.size());
+                cluster->write_to_device(vec1.data(), vec1.size() * sizeof(std::uint32_t), 0, core, address);
+                cluster->l1_membar(0, {core});
+                test_utils::read_data_from_device(cluster.get(), readback_vec, 0, core, address, 4 * vec1.size());
                 ASSERT_EQ(readback_vec, vec1);
-                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address);
+                cluster->write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address);
                 readback_vec = {};
             }
         }
@@ -415,13 +409,13 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     std::thread th2 = std::thread([&] {
         std::uint32_t address = base_addr + vec1.size() * 4;
         for (int loop = 0; loop < 50; loop++) {
-            for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster->get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
                 std::vector<uint32_t> readback_vec = {};
-                cluster.write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), 0, core, address);
-                cluster.l1_membar(0, {core});
-                test_utils::read_data_from_device(cluster, readback_vec, 0, core, address, 4 * vec2.size());
+                cluster->write_to_device(vec2.data(), vec2.size() * sizeof(std::uint32_t), 0, core, address);
+                cluster->l1_membar(0, {core});
+                test_utils::read_data_from_device(cluster.get(), readback_vec, 0, core, address, 4 * vec2.size());
                 ASSERT_EQ(readback_vec, vec2);
-                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address);
+                cluster->write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), 0, core, address);
                 readback_vec = {};
             }
         }
@@ -430,33 +424,33 @@ TEST(SiliconDriverWH, MultiThreadedMemBar) {
     th1.join();
     th2.join();
 
-    for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
+    for (const CoreCoord& core : cluster->get_soc_descriptor(0).get_cores(CoreType::TENSIX)) {
         test_utils::read_data_from_device(
-            cluster, readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4);
+            cluster.get(), readback_membar_vec, 0, core, l1_mem::address_map::L1_BARRIER_BASE, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0), 187);  // Ensure that memory barriers end up in the correct sate for workers
         readback_membar_vec = {};
     }
 
-    for (const CoreCoord& core : cluster.get_soc_descriptor(0).get_cores(CoreType::ETH)) {
+    for (const CoreCoord& core : cluster->get_soc_descriptor(0).get_cores(CoreType::ETH)) {
         test_utils::read_data_from_device(
-            cluster, readback_membar_vec, 0, core, eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4);
+            cluster.get(), readback_membar_vec, 0, core, eth_l1_mem::address_map::ERISC_BARRIER_BASE, 4);
         ASSERT_EQ(
             readback_membar_vec.at(0),
             187);  // Ensure that memory barriers end up in the correct sate for ethernet cores
         readback_membar_vec = {};
     }
-    cluster.close_device();
+    cluster->close_device();
 }
 
 TEST(SiliconDriverWH, BroadcastWrite) {
     // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly, and that
     // a broadcast targeting one core type does not leak writes to the other.
-    auto cluster_ptr = test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
-    Cluster& cluster = *cluster_ptr;
-    set_barrier_params(cluster);
+    std::unique_ptr<Cluster> cluster =
+        test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    set_barrier_params(cluster.get());
 
-    test_utils::safe_test_cluster_start(&cluster);
+    test_utils::safe_test_cluster_start(cluster.get());
     std::vector<uint32_t> broadcast_sizes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
     uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
     // This excludes DRAM and ETH banks in noc0 coords.
@@ -468,19 +462,19 @@ TEST(SiliconDriverWH, BroadcastWrite) {
 
     // Pre-zero tensix L1 and DRAM at the test address so the "not written" assertions have a known baseline.
     std::vector<uint32_t> initial_zeros(broadcast_sizes.back(), 0);
-    for (auto chip_id : cluster.get_target_device_ids()) {
-        for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
-            cluster.write_to_device(
+    for (auto chip_id : cluster->get_target_device_ids()) {
+        for (const CoreCoord& core : cluster->get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+            cluster->write_to_device(
                 initial_zeros.data(), initial_zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
         }
-        for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+        for (int chan = 0; chan < cluster->get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
             const CoreCoord core =
-                cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
-            cluster.write_to_device(
+                cluster->get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+            cluster->write_to_device(
                 initial_zeros.data(), initial_zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
         }
     }
-    cluster.wait_for_non_mmio_flush();
+    cluster->wait_for_non_mmio_flush();
 
     for (const auto& size : broadcast_sizes) {
         std::vector<uint32_t> vector_to_write(size);
@@ -491,39 +485,39 @@ TEST(SiliconDriverWH, BroadcastWrite) {
             zeros[i] = 0;
         }
         // Broadcast to Tensix.
-        cluster.broadcast_write_to_cluster(
+        cluster->broadcast_write_to_cluster(
             vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude, false);
-        cluster.wait_for_non_mmio_flush();
+        cluster->wait_for_non_mmio_flush();
 
-        for (auto chip_id : cluster.get_target_device_ids()) {
+        for (auto chip_id : cluster->get_target_device_ids()) {
             // Tensix cores received the broadcast; zero them out.
-            for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster->get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
                 if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
                     continue;
                 }
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                    cluster.get(), readback_vec, chip_id, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from chip " << chip_id << " core " << core.str()
                     << " does not match what was broadcasted for size " << size;
-                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+                cluster->write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
                 readback_vec = {};
             }
             // DRAM cores must NOT have been written by the tensix broadcast.
-            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < cluster->get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
-                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                    cluster->get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                    cluster.get(), readback_vec, chip_id, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(zeros, readback_vec) << "DRAM core " << chip_id << " " << core.str()
                                                << " was modified by tensix broadcast for size " << size;
                 readback_vec = {};
             }
         }
-        cluster.wait_for_non_mmio_flush();
+        cluster->wait_for_non_mmio_flush();
 
         // Broadcast to DRAM.
-        cluster.broadcast_write_to_cluster(
+        cluster->broadcast_write_to_cluster(
             vector_to_write.data(),
             vector_to_write.size() * 4,
             address,
@@ -531,52 +525,52 @@ TEST(SiliconDriverWH, BroadcastWrite) {
             rows_to_exclude_for_dram_broadcast,
             cols_to_exclude_for_dram_broadcast,
             false);
-        cluster.wait_for_non_mmio_flush();
+        cluster->wait_for_non_mmio_flush();
 
-        for (auto chip_id : cluster.get_target_device_ids()) {
+        for (auto chip_id : cluster->get_target_device_ids()) {
             // DRAM cores received the broadcast.
-            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < cluster->get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
-                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                    cluster->get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                    cluster.get(), readback_vec, chip_id, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from DRAM core " << chip_id << " " << core.str()
                     << " does not match what was broadcasted for size " << size;
                 readback_vec = {};
             }
             // Tensix cores must NOT have been written by the DRAM broadcast.
-            for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster->get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
                 if (rows_to_exclude.find(core.y) != rows_to_exclude.end()) {
                     continue;
                 }
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                    cluster.get(), readback_vec, chip_id, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(zeros, readback_vec) << "Tensix core " << chip_id << " " << core.str()
                                                << " was modified by DRAM broadcast for size " << size;
                 readback_vec = {};
             }
             // Zero DRAM so the next iteration starts clean.
-            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < cluster->get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
-                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
-                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+                    cluster->get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                cluster->write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
             }
         }
-        cluster.wait_for_non_mmio_flush();
+        cluster->wait_for_non_mmio_flush();
     }
-    cluster.close_device();
+    cluster->close_device();
 }
 
 TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
     // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly, and that
     // a broadcast targeting one core type does not leak writes to the other.
-    auto cluster_ptr = test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
-    Cluster& cluster = *cluster_ptr;
-    set_barrier_params(cluster);
-    auto mmio_devices = cluster.get_target_mmio_device_ids();
+    std::unique_ptr<Cluster> cluster =
+        test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    set_barrier_params(cluster.get());
+    auto mmio_devices = cluster->get_target_mmio_device_ids();
 
-    test_utils::safe_test_cluster_start(&cluster);
+    test_utils::safe_test_cluster_start(cluster.get());
 
     std::vector<uint32_t> broadcast_sizes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
     uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
@@ -590,19 +584,19 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
 
     // Pre-zero tensix L1 and DRAM at the test address so the "not written" assertions have a known baseline.
     std::vector<uint32_t> initial_zeros(broadcast_sizes.back(), 0);
-    for (auto chip_id : cluster.get_target_device_ids()) {
-        for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
-            cluster.write_to_device(
+    for (auto chip_id : cluster->get_target_device_ids()) {
+        for (const CoreCoord& core : cluster->get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+            cluster->write_to_device(
                 initial_zeros.data(), initial_zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
         }
-        for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+        for (int chan = 0; chan < cluster->get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
             const CoreCoord core =
-                cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
-            cluster.write_to_device(
+                cluster->get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+            cluster->write_to_device(
                 initial_zeros.data(), initial_zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
         }
     }
-    cluster.wait_for_non_mmio_flush();
+    cluster->wait_for_non_mmio_flush();
 
     for (const auto& size : broadcast_sizes) {
         std::vector<uint32_t> vector_to_write(size);
@@ -613,15 +607,15 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
             zeros[i] = 0;
         }
         // Broadcast to Tensix.
-        cluster.broadcast_write_to_cluster(
+        cluster->broadcast_write_to_cluster(
             vector_to_write.data(), vector_to_write.size() * 4, address, {}, rows_to_exclude, cols_to_exclude, true);
-        cluster.wait_for_non_mmio_flush();
+        cluster->wait_for_non_mmio_flush();
 
-        for (auto chip_id : cluster.get_target_device_ids()) {
+        for (auto chip_id : cluster->get_target_device_ids()) {
             // Tensix cores received the broadcast; zero them out.
-            for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster->get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
                 const CoreCoord translated_core =
-                    cluster.get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
+                    cluster->get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
                 if (rows_to_exclude.find(translated_core.y) != rows_to_exclude.end()) {
                     continue;
                 }
@@ -629,28 +623,28 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
                     continue;
                 }
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                    cluster.get(), readback_vec, chip_id, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from chip " << chip_id << " core " << core.str()
                     << " does not match what was broadcasted for size " << size;
-                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+                cluster->write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
                 readback_vec = {};
             }
             // DRAM cores must NOT have been written by the tensix broadcast.
-            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < cluster->get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
-                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                    cluster->get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                    cluster.get(), readback_vec, chip_id, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(zeros, readback_vec) << "DRAM core " << chip_id << " " << core.str()
                                                << " was modified by tensix broadcast for size " << size;
                 readback_vec = {};
             }
         }
-        cluster.wait_for_non_mmio_flush();
+        cluster->wait_for_non_mmio_flush();
 
         // Broadcast to DRAM.
-        cluster.broadcast_write_to_cluster(
+        cluster->broadcast_write_to_cluster(
             vector_to_write.data(),
             vector_to_write.size() * 4,
             address,
@@ -658,24 +652,24 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
             rows_to_exclude_for_dram_broadcast,
             cols_to_exclude_for_dram_broadcast,
             true);
-        cluster.wait_for_non_mmio_flush();
+        cluster->wait_for_non_mmio_flush();
 
-        for (auto chip_id : cluster.get_target_device_ids()) {
+        for (auto chip_id : cluster->get_target_device_ids()) {
             // DRAM cores received the broadcast.
-            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < cluster->get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
-                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                    cluster->get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                    cluster.get(), readback_vec, chip_id, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from DRAM core " << chip_id << " " << core.str()
                     << " does not match what was broadcasted for size " << size;
                 readback_vec = {};
             }
             // Tensix cores must NOT have been written by the DRAM broadcast.
-            for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster->get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
                 const CoreCoord translated_core =
-                    cluster.get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
+                    cluster->get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
                 if (rows_to_exclude.find(translated_core.y) != rows_to_exclude.end()) {
                     continue;
                 }
@@ -683,32 +677,32 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcast) {
                     continue;
                 }
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                    cluster.get(), readback_vec, chip_id, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(zeros, readback_vec) << "Tensix core " << chip_id << " " << core.str()
                                                << " was modified by DRAM broadcast for size " << size;
                 readback_vec = {};
             }
             // Zero DRAM so the next iteration starts clean.
-            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < cluster->get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
-                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
-                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+                    cluster->get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                cluster->write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
             }
         }
-        cluster.wait_for_non_mmio_flush();
+        cluster->wait_for_non_mmio_flush();
     }
-    cluster.close_device();
+    cluster->close_device();
 }
 
 TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
     // Broadcast multiple vectors to tensix and dram grid. Verify broadcasted data is read back correctly, and that
     // a broadcast targeting one core type does not leak writes to the other.
-    auto cluster_ptr = test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
-    Cluster& cluster = *cluster_ptr;
-    set_barrier_params(cluster);
-    auto mmio_devices = cluster.get_target_mmio_device_ids();
+    std::unique_ptr<Cluster> cluster =
+        test_utils::make_default_test_cluster(ClusterOptions{.num_host_mem_ch_per_mmio_device = 1});
+    set_barrier_params(cluster.get());
+    auto mmio_devices = cluster->get_target_mmio_device_ids();
 
-    test_utils::safe_test_cluster_start(&cluster);
+    test_utils::safe_test_cluster_start(cluster.get());
 
     std::vector<uint32_t> broadcast_sizes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
     uint32_t address = l1_mem::address_map::DATA_BUFFER_SPACE_BASE;
@@ -722,21 +716,21 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
 
     // Pre-zero tensix L1 and DRAM on every chip so the "not written" assertions have a known baseline.
     std::vector<uint32_t> initial_zeros(broadcast_sizes.back(), 0);
-    for (auto chip_id : cluster.get_target_device_ids()) {
-        for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
-            cluster.write_to_device(
+    for (auto chip_id : cluster->get_target_device_ids()) {
+        for (const CoreCoord& core : cluster->get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+            cluster->write_to_device(
                 initial_zeros.data(), initial_zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
         }
-        for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+        for (int chan = 0; chan < cluster->get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
             const CoreCoord core =
-                cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
-            cluster.write_to_device(
+                cluster->get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+            cluster->write_to_device(
                 initial_zeros.data(), initial_zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
         }
     }
-    cluster.wait_for_non_mmio_flush();
+    cluster->wait_for_non_mmio_flush();
 
-    for (auto chip_id : cluster.get_target_device_ids()) {
+    for (auto chip_id : cluster->get_target_device_ids()) {
         for (const auto& size : broadcast_sizes) {
             std::vector<uint32_t> vector_to_write(size);
             std::vector<uint32_t> zeros(size);
@@ -746,11 +740,11 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
                 zeros[i] = 0;
             }
 
-            std::set<ChipId> chips_to_exclude = cluster.get_target_device_ids();
+            std::set<ChipId> chips_to_exclude = cluster->get_target_device_ids();
             chips_to_exclude.erase(chip_id);
 
             // Broadcast to Tensix.
-            cluster.broadcast_write_to_cluster(
+            cluster->broadcast_write_to_cluster(
                 vector_to_write.data(),
                 vector_to_write.size() * 4,
                 address,
@@ -758,12 +752,12 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
                 rows_to_exclude,
                 cols_to_exclude,
                 true);
-            cluster.wait_for_non_mmio_flush();
+            cluster->wait_for_non_mmio_flush();
 
             // Tensix cores received the broadcast; zero them out.
-            for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster->get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
                 const CoreCoord translated_core =
-                    cluster.get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
+                    cluster->get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
                 if (rows_to_exclude.find(translated_core.y) != rows_to_exclude.end()) {
                     continue;
                 }
@@ -771,27 +765,27 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
                     continue;
                 }
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                    cluster.get(), readback_vec, chip_id, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from chip " << chip_id << " core " << core.str()
                     << " does not match what was broadcasted for size " << size;
-                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+                cluster->write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
                 readback_vec = {};
             }
             // DRAM cores must NOT have been written by the tensix broadcast.
-            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < cluster->get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
-                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                    cluster->get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                    cluster.get(), readback_vec, chip_id, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(zeros, readback_vec) << "DRAM core " << chip_id << " " << core.str()
                                                << " was modified by tensix broadcast for size " << size;
                 readback_vec = {};
             }
-            cluster.wait_for_non_mmio_flush();
+            cluster->wait_for_non_mmio_flush();
 
             // Broadcast to DRAM.
-            cluster.broadcast_write_to_cluster(
+            cluster->broadcast_write_to_cluster(
                 vector_to_write.data(),
                 vector_to_write.size() * 4,
                 address,
@@ -799,23 +793,23 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
                 rows_to_exclude_for_dram_broadcast,
                 cols_to_exclude_for_dram_broadcast,
                 true);
-            cluster.wait_for_non_mmio_flush();
+            cluster->wait_for_non_mmio_flush();
 
             // DRAM cores received the broadcast.
-            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < cluster->get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
-                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                    cluster->get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                    cluster.get(), readback_vec, chip_id, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(vector_to_write, readback_vec)
                     << "Vector read back from DRAM core " << chip_id << " " << core.str()
                     << " does not match what was broadcasted for size " << size;
                 readback_vec = {};
             }
             // Tensix cores must NOT have been written by the DRAM broadcast.
-            for (const CoreCoord& core : cluster.get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
+            for (const CoreCoord& core : cluster->get_soc_descriptor(chip_id).get_cores(CoreType::TENSIX)) {
                 const CoreCoord translated_core =
-                    cluster.get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
+                    cluster->get_soc_descriptor(chip_id).translate_coord_to(core, CoordSystem::TRANSLATED);
                 if (rows_to_exclude.find(translated_core.y) != rows_to_exclude.end()) {
                     continue;
                 }
@@ -823,21 +817,21 @@ TEST(SiliconDriverWH, VirtualCoordinateBroadcastPerChip) {
                     continue;
                 }
                 test_utils::read_data_from_device(
-                    cluster, readback_vec, chip_id, core, address, vector_to_write.size() * 4);
+                    cluster.get(), readback_vec, chip_id, core, address, vector_to_write.size() * 4);
                 ASSERT_EQ(zeros, readback_vec) << "Tensix core " << chip_id << " " << core.str()
                                                << " was modified by DRAM broadcast for size " << size;
                 readback_vec = {};
             }
             // Zero DRAM so the next iteration starts clean.
-            for (int chan = 0; chan < cluster.get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
+            for (int chan = 0; chan < cluster->get_soc_descriptor(chip_id).get_num_dram_channels(); chan++) {
                 const CoreCoord core =
-                    cluster.get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
-                cluster.write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
+                    cluster->get_soc_descriptor(chip_id).get_dram_core_for_channel(chan, 0, CoordSystem::TRANSLATED);
+                cluster->write_to_device(zeros.data(), zeros.size() * sizeof(std::uint32_t), chip_id, core, address);
             }
-            cluster.wait_for_non_mmio_flush();
+            cluster->wait_for_non_mmio_flush();
         }
     }
-    cluster.close_device();
+    cluster->close_device();
 }
 
 TEST(SiliconDriverWH, EthernetBroadcastSingleRemotePerChip) {
@@ -1020,12 +1014,11 @@ TEST(SiliconDriverWH, DeviceProtocolWriteCoreRange) {
 }
 
 TEST(SiliconDriverWH, LargeAddressTlb) {
-    auto cluster_ptr = test_utils::make_default_test_cluster();
-    Cluster& cluster = *cluster_ptr;
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
-    const CoreCoord ARC_CORE = cluster.get_soc_descriptor(0).get_cores(CoreType::ARC).at(0);
+    const CoreCoord ARC_CORE = cluster->get_soc_descriptor(0).get_cores(CoreType::ARC).at(0);
 
-    set_barrier_params(cluster);
+    set_barrier_params(cluster.get());
 
     // Address of the reset unit in ARC core:
     uint64_t arc_reset_noc = 0x880030000ULL;
@@ -1034,7 +1027,7 @@ TEST(SiliconDriverWH, LargeAddressTlb) {
     uint64_t scratch_offset = 0x60;
 
     // Map a TLB to the reset unit in ARC core:
-    cluster.configure_tlb(0, ARC_CORE, tt::umd::wormhole::STATIC_TLB_SIZE, arc_reset_noc);
+    cluster->configure_tlb(0, ARC_CORE, tt::umd::wormhole::STATIC_TLB_SIZE, arc_reset_noc);
 
     // Address of the scratch register in the reset unit:
     uint64_t addr = arc_reset_noc + scratch_offset;
@@ -1044,13 +1037,13 @@ TEST(SiliconDriverWH, LargeAddressTlb) {
     uint32_t value2 = 0;
 
     // Read the scratch register via BAR0:
-    value0 = cluster.get_chip(0)->get_tt_device()->bar_read32(0x1ff30060);
+    value0 = cluster->get_chip(0)->get_tt_device()->bar_read32(0x1ff30060);
 
     // Read the scratch register via the TLB:
-    cluster.read_from_device(&value1, 0, ARC_CORE, addr, sizeof(uint32_t));
+    cluster->read_from_device(&value1, 0, ARC_CORE, addr, sizeof(uint32_t));
 
     // Read the scratch register via a different TLB, different code path:
-    cluster.read_from_device(&value2, 0, ARC_CORE, addr, sizeof(uint32_t));
+    cluster->read_from_device(&value2, 0, ARC_CORE, addr, sizeof(uint32_t));
 
     // Mask off lower 16 bits; FW changes these dynamically:
     value0 &= 0xffff0000;
@@ -1069,17 +1062,16 @@ TEST(SiliconDriverWH, LargeAddressTlb) {
  */
 TEST(TestDeviceIO, DMA3) {
     const ChipId chip = 0;
-    auto cluster_ptr = test_utils::make_default_test_cluster();
-    Cluster& cluster = *cluster_ptr;
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
 
-    CoreCoord eth_core = cluster.get_soc_descriptor(chip).get_cores(CoreType::ETH)[0];
+    CoreCoord eth_core = cluster->get_soc_descriptor(chip).get_cores(CoreType::ETH)[0];
 
     size_t buf_size = 768;
 
     std::vector<uint8_t> zeros(buf_size, 1);
-    cluster.write_to_device(zeros.data(), zeros.size(), chip, eth_core, 254304);
+    cluster->write_to_device(zeros.data(), zeros.size(), chip, eth_core, 254304);
     std::vector<uint8_t> readback_zeros(buf_size, 0xFF);
-    cluster.read_from_device(readback_zeros.data(), chip, eth_core, 254304, readback_zeros.size());
+    cluster->read_from_device(readback_zeros.data(), chip, eth_core, 254304, readback_zeros.size());
     EXPECT_EQ(zeros, readback_zeros) << "Mismatch zeros for core " << eth_core.str() << " addr=0x0"
                                      << " size=" << std::dec << readback_zeros.size();
 
@@ -1088,10 +1080,10 @@ TEST(TestDeviceIO, DMA3) {
         pattern[i] = i % 256;
     }
 
-    cluster.dma_write_to_device(pattern.data(), pattern.size(), chip, eth_core, 254304);
+    cluster->dma_write_to_device(pattern.data(), pattern.size(), chip, eth_core, 254304);
 
     std::vector<uint8_t> readback(buf_size, 1);
-    cluster.read_from_device(readback.data(), chip, eth_core, 254304, readback.size());
+    cluster->read_from_device(readback.data(), chip, eth_core, 254304, readback.size());
 
     EXPECT_EQ(pattern, readback) << "Mismatch for core " << eth_core.str() << " addr=0x0"
                                  << " size=" << std::dec << readback.size();

--- a/tests/wormhole/test_umd_remote_api_stability.cpp
+++ b/tests/wormhole/test_umd_remote_api_stability.cpp
@@ -57,7 +57,7 @@ TEST_F(WormholeNebulaX2TestFixture, MixedRemoteTransfersMediumSmall) {
     try {
         assert(cluster != nullptr);
         RunMixedTransfersUniformDistributions(
-            *cluster,
+            cluster.get(),
             100000 * scale_number_of_tests,
             0,
             transfer_type_weights_t{.write = 0.25, .read = 0.25},
@@ -89,7 +89,7 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersMediumSmall
     std::vector<remote_transfer_sample_t> command_history3;
     std::thread t1([&]() {
         RunMixedTransfersUniformDistributions(
-            *cluster,
+            cluster.get(),
             100000 * scale_number_of_tests,
             0,
             transfer_type_weights_t{.write = 0.50, .read = 0.50},
@@ -109,7 +109,7 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersMediumSmall
     });
     std::thread t2([&]() {
         RunMixedTransfersUniformDistributions(
-            *cluster,
+            cluster.get(),
             100000 * scale_number_of_tests,
             100,
             transfer_type_weights_t{.write = 0.25, .read = 0.50},
@@ -129,7 +129,7 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersMediumSmall
     });
     std::thread t3([&]() {
         RunMixedTransfersUniformDistributions(
-            *cluster,
+            cluster.get(),
             100000 * scale_number_of_tests,
             23,
             transfer_type_weights_t{.write = 0.5, .read = 0.25},
@@ -149,7 +149,7 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersMediumSmall
     });
     std::thread t4([&]() {
         RunMixedTransfersUniformDistributions(
-            *cluster,
+            cluster.get(),
             100000 * scale_number_of_tests,
             99,
             transfer_type_weights_t{.write = 1.0, .read = 0.0},
@@ -181,7 +181,7 @@ TEST_F(WormholeNebulaX2TestFixture, MixedRemoteTransfersLarge) {
     std::vector<remote_transfer_sample_t> command_history;
     try {
         RunMixedTransfersUniformDistributions(
-            *cluster,
+            cluster.get(),
             10000 * scale_number_of_tests,
             0,
             transfer_type_weights_t{.write = 0.15, .read = 0.15},
@@ -221,12 +221,12 @@ TEST_F(WormholeNebulaX2TestFixture, WritesOnlyNormalDistributionMean10kStd3kMinS
 
     try {
         RunMixedTransfers(
-            *cluster,
+            cluster.get(),
             10000 * scale_number_of_tests,
             0,
             transfer_type_weights_t{.write = 1., .read = 0.},
             WriteCommandGenerator(dest_generator, address_generator, write_size_generator),
-            build_dummy_read_command_generator(*cluster),
+            build_dummy_read_command_generator(cluster.get()),
             // Set to true if you want to emit the command history code to command line.
             false,
             &command_history);
@@ -245,7 +245,7 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLMS) {
     std::vector<remote_transfer_sample_t> command_history3;
     std::thread t1([&]() {
         RunMixedTransfersUniformDistributions(
-            *cluster,
+            cluster.get(),
             100000 * scale_number_of_tests,
             0,
             transfer_type_weights_t{.write = 0.50, .read = 0.50},
@@ -265,7 +265,7 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLMS) {
     });
     std::thread t2([&]() {
         RunMixedTransfersUniformDistributions(
-            *cluster,
+            cluster.get(),
             100000 * scale_number_of_tests,
             100,
             transfer_type_weights_t{.write = 0.25, .read = 0.50},
@@ -285,7 +285,7 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLMS) {
     });
     std::thread t3([&]() {
         RunMixedTransfersUniformDistributions(
-            *cluster,
+            cluster.get(),
             100000 * scale_number_of_tests,
             23,
             transfer_type_weights_t{.write = 0.5, .read = 0.25},
@@ -305,7 +305,7 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLMS) {
     });
     std::thread t4([&]() {
         RunMixedTransfersUniformDistributions(
-            *cluster,
+            cluster.get(),
             100000 * scale_number_of_tests,
             99,
             transfer_type_weights_t{.write = 1.0, .read = 0.0},
@@ -357,35 +357,35 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLargeWrites
 
     std::thread write_cmds_thread1([&]() {
         RunMixedTransfers(
-            *cluster,
+            cluster.get(),
             10000 * scale_number_of_tests,
             0,
             transfer_type_weights_t{.write = 1., .read = 0.},
             WriteCommandGenerator(dest_generator, address_generator, write_size_generator),
-            build_dummy_read_command_generator(*cluster),
+            build_dummy_read_command_generator(cluster.get()),
             // Set to true if you want to emit the command history code to command line.
             false,
             &command_history0);
     });
     std::thread write_cmds_thread2([&]() {
         RunMixedTransfers(
-            *cluster,
+            cluster.get(),
             10000 * scale_number_of_tests,
             0,
             transfer_type_weights_t{.write = 1., .read = 0.},
             WriteCommandGenerator(dest_generator, address_generator, write_size_generator),
-            build_dummy_read_command_generator(*cluster),
+            build_dummy_read_command_generator(cluster.get()),
             // Set to true if you want to emit the command history code to command line.
             false,
             &command_history0);
     });
     std::thread read_cmd_threads1([&]() {
         RunMixedTransfers(
-            *cluster,
+            cluster.get(),
             10000 * scale_number_of_tests,
             0,
             transfer_type_weights_t{.write = 0, .read = 1.},
-            build_dummy_write_command_generator(*cluster),
+            build_dummy_write_command_generator(cluster.get()),
             ReadCommandGenerator(dest_generator, address_generator, read_size_generator),
             // Set to true if you want to emit the command history code to command line.
             false,
@@ -393,11 +393,11 @@ TEST_F(WormholeNebulaX2TestFixture, MultithreadedMixedRemoteTransfersLargeWrites
     });
     std::thread read_cmd_threads2([&]() {
         RunMixedTransfers(
-            *cluster,
+            cluster.get(),
             10000 * scale_number_of_tests,
             0,
             transfer_type_weights_t{.write = 0, .read = 1.},
-            build_dummy_write_command_generator(*cluster),
+            build_dummy_write_command_generator(cluster.get()),
             ReadCommandGenerator(dest_generator, address_generator, read_size_generator),
             // Set to true if you want to emit the command history code to command line.
             false,

--- a/tests/wormhole/test_wh_common.hpp
+++ b/tests/wormhole/test_wh_common.hpp
@@ -19,9 +19,9 @@ constexpr std::uint32_t DRAM_BARRIER_BASE = 0;
 
 namespace tt::umd::test::utils {
 
-static void set_barrier_params(Cluster& cluster) {
+static void set_barrier_params(Cluster* cluster) {
     // Populate address map and NOC parameters that the driver needs for memory barriers and remote transactions.
-    cluster.set_barrier_address_params(
+    cluster->set_barrier_address_params(
         {l1_mem::address_map::L1_BARRIER_BASE, eth_l1_mem::address_map::ERISC_BARRIER_BASE, DRAM_BARRIER_BASE});
 }
 
@@ -54,7 +54,7 @@ protected:
         assert(cluster != nullptr);
         assert(cluster->get_cluster_description()->get_number_of_chips() == get_detected_num_chips());
 
-        set_barrier_params(*cluster);
+        set_barrier_params(cluster.get());
 
         test_utils::safe_test_cluster_start(cluster.get());
 


### PR DESCRIPTION
### Issue
#2785 

### Description
As a follow up to the last fix to tests I did, stop using Cluster as reference in our tests.

### List of the changes
- Switch all cluster usages in our tests to pointers

### Testing
No testing, code builds.
No functional changes

### API Changes
This PR has no API changes.
