### PR TITLE
Support wh_x2 (N300) multichip ttsim

### DIFF
--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -97,6 +97,14 @@ jobs:
           fileName: "libttsim_qsr.so"
           out-file-path: /tmp/ttsim-qsr
 
+      - name: Download ttsim binary (wh_x2)
+        uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f  # v1.13
+        with:
+          repository: tenstorrent/ttsim
+          tag: ${{ steps.get-ttsim-version.outputs.ttsim-version }}
+          fileName: "libttsim_wh_x2.so"
+          out-file-path: /tmp/ttsim-wh-x2
+
       - name: Build tt-metal
         run: |
           cd tt-metal
@@ -112,13 +120,16 @@ jobs:
       - name: Prepare sim paths
         run: |
           echo "Preparing sim paths"
-          mkdir -p sim_wh sim_bh sim_qsr
+          mkdir -p sim_wh sim_bh sim_qsr sim_wh_x2
           mv /tmp/ttsim-wh/libttsim_wh.so sim_wh/libttsim.so
           mv /tmp/ttsim-bh/libttsim_bh.so sim_bh/libttsim.so
           mv /tmp/ttsim-qsr/libttsim_qsr.so sim_qsr/libttsim.so
+          mv /tmp/ttsim-wh-x2/libttsim_wh_x2.so sim_wh_x2/libttsim.so
           cp $TT_METAL_HOME/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml sim_wh/soc_descriptor.yaml
           cp $TT_METAL_HOME/tt_metal/soc_descriptors/blackhole_140_arch.yaml sim_bh/soc_descriptor.yaml
           cp tt-metal/tt_metal/third_party/umd/tests/soc_descs/quasar_32_arch.yaml sim_qsr/soc_descriptor.yaml
+          # wh_x2 is two Wormhole chips; reuse the per-chip Wormhole soc descriptor.
+          cp $TT_METAL_HOME/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml sim_wh_x2/soc_descriptor.yaml
 
       - name: Build UMD api_tests with simulation support
         run: |
@@ -187,6 +198,25 @@ jobs:
         timeout-minutes: 1
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_qsr/libttsim.so
+        run: |
+          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
+
+      # wh_x2 is the N300 multichip simulator (chip 0 MMIO gateway + chip 1 remote over
+      # simulated eth). The N300 cluster descriptor makes the cluster enumerate both chips,
+      # so the standard device-IO fixtures run across the gateway and the remote chip.
+      - name: Run UMD TestDeviceIOFixture on tt-sim wormhole x2
+        timeout-minutes: 1
+        env:
+          TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_wh_x2/libttsim.so
+          TT_UMD_CLUSTER_DESCRIPTOR: wormhole_N300.yaml
+        run: |
+          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
+
+      - name: Run UMD TTSimDeviceIOFixture on tt-sim wormhole x2
+        timeout-minutes: 1
+        env:
+          TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_wh_x2/libttsim.so
+          TT_UMD_CLUSTER_DESCRIPTOR: wormhole_N300.yaml
         run: |
           tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
 

--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -130,6 +130,10 @@ jobs:
           cp tt-metal/tt_metal/third_party/umd/tests/soc_descs/quasar_32_arch.yaml sim_qsr/soc_descriptor.yaml
           # wh_x2 is two Wormhole chips; reuse the per-chip Wormhole soc descriptor.
           cp $TT_METAL_HOME/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml sim_wh_x2/soc_descriptor.yaml
+          # Place the N300 cluster descriptor beside the simulator; UMD auto-discovers it (like soc_descriptor.yaml)
+          # and enumerates both the MMIO gateway and the remote chip. Without it, the sim is a single MMIO chip.
+          cp tt-metal/tt_metal/third_party/umd/tests/cluster_descriptor_examples/wormhole_N300.yaml \
+            sim_wh_x2/cluster_descriptor.yaml
 
       - name: Build UMD api_tests with simulation support
         run: |
@@ -202,13 +206,13 @@ jobs:
           tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
 
       # wh_x2 is the N300 multichip simulator (chip 0 MMIO gateway + chip 1 remote over
-      # simulated eth). The N300 cluster descriptor makes the cluster enumerate both chips,
-      # so the standard device-IO fixtures run across the gateway and the remote chip.
+      # simulated eth). The cluster_descriptor.yaml placed beside the simulator (see "Prepare sim paths")
+      # makes UMD enumerate both chips, so the standard device-IO fixtures run across the gateway and
+      # the remote chip.
       - name: Run UMD TestDeviceIOFixture on tt-sim wormhole x2
         timeout-minutes: 1
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_wh_x2/libttsim.so
-          TT_UMD_CLUSTER_DESCRIPTOR: wormhole_N300.yaml
         run: |
           tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
 
@@ -216,7 +220,6 @@ jobs:
         timeout-minutes: 1
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_wh_x2/libttsim.so
-          TT_UMD_CLUSTER_DESCRIPTOR: wormhole_N300.yaml
         run: |
           tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
 

--- a/device/api/umd/device/chip/remote_chip.hpp
+++ b/device/api/umd/device/chip/remote_chip.hpp
@@ -66,8 +66,6 @@ public:
     void dma_write_to_device(const void* src, size_t size, CoreCoord core, uint64_t addr) override;
     void dma_read_from_device(void* dst, size_t size, CoreCoord core, uint64_t addr) override;
     void dma_multicast_write(void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
-    void noc_multicast_write(
-        const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
 
     void wait_for_non_mmio_flush() override;
 

--- a/device/api/umd/device/chip/remote_chip.hpp
+++ b/device/api/umd/device/chip/remote_chip.hpp
@@ -39,10 +39,7 @@ public:
      */
     static std::unique_ptr<RemoteChip> create(std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip);
     static std::unique_ptr<RemoteChip> create_for_simulation(
-        std::unique_ptr<TTDevice> remote_tt_device,
-        Chip* local_chip,
-        SocDescriptor soc_descriptor,
-        ChipInfo chip_info);
+        std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip, SocDescriptor soc_descriptor, ChipInfo chip_info);
 
     bool is_mmio_capable() const override;
 
@@ -87,10 +84,7 @@ public:
 private:
     RemoteChip(Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_device);
     RemoteChip(
-        Chip* local_chip,
-        std::unique_ptr<TTDevice> remote_tt_device,
-        SocDescriptor soc_descriptor,
-        ChipInfo chip_info);
+        Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_device, SocDescriptor soc_descriptor, ChipInfo chip_info);
 
     Chip* local_chip_;
     RemoteCommunication* remote_communication_;

--- a/device/api/umd/device/chip/remote_chip.hpp
+++ b/device/api/umd/device/chip/remote_chip.hpp
@@ -39,7 +39,7 @@ public:
      */
     static std::unique_ptr<RemoteChip> create(std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip);
     static std::unique_ptr<RemoteChip> create_for_simulation(
-        std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip, SocDescriptor soc_descriptor, ChipInfo chip_info);
+        std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip, ChipInfo chip_info);
 
     bool is_mmio_capable() const override;
 
@@ -50,7 +50,7 @@ public:
     SysmemManager* get_sysmem_manager() override;
     TLBManager* get_tlb_manager() override;
 
-    const SocDescriptor& get_soc_descriptor() const override { return soc_descriptor_; }
+    const SocDescriptor& get_soc_descriptor() const override { return tt_device_->get_soc_descriptor(); }
 
     void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) override;
     void set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) override;
@@ -83,13 +83,11 @@ public:
 
 private:
     RemoteChip(Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_device);
-    RemoteChip(
-        Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_device, SocDescriptor soc_descriptor, ChipInfo chip_info);
+    RemoteChip(Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_device, ChipInfo chip_info);
 
     Chip* local_chip_;
     RemoteCommunication* remote_communication_;
 
-    SocDescriptor soc_descriptor_;
     std::unique_ptr<TTDevice> tt_device_ = nullptr;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/chip/remote_chip.hpp
+++ b/device/api/umd/device/chip/remote_chip.hpp
@@ -25,7 +25,7 @@ struct EthCoord;
 }  // namespace tt
 
 namespace tt::umd {
-class LocalChip;
+class Chip;
 class RemoteCommunication;
 class SocDescriptor;
 
@@ -37,7 +37,12 @@ public:
      * @param local_chip The local chip to be used for communication to this remote chip.
      * @return A unique pointer to the created RemoteChip instance.
      */
-    static std::unique_ptr<RemoteChip> create(std::unique_ptr<TTDevice> remote_tt_device, LocalChip* local_chip);
+    static std::unique_ptr<RemoteChip> create(std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip);
+    static std::unique_ptr<RemoteChip> create_for_simulation(
+        std::unique_ptr<TTDevice> remote_tt_device,
+        Chip* local_chip,
+        SocDescriptor soc_descriptor,
+        ChipInfo chip_info);
 
     bool is_mmio_capable() const override;
 
@@ -48,7 +53,7 @@ public:
     SysmemManager* get_sysmem_manager() override;
     TLBManager* get_tlb_manager() override;
 
-    const SocDescriptor& get_soc_descriptor() const override { return tt_device_->get_soc_descriptor(); }
+    const SocDescriptor& get_soc_descriptor() const override { return soc_descriptor_; }
 
     void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) override;
     void set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) override;
@@ -64,6 +69,8 @@ public:
     void dma_write_to_device(const void* src, size_t size, CoreCoord core, uint64_t addr) override;
     void dma_read_from_device(void* dst, size_t size, CoreCoord core, uint64_t addr) override;
     void dma_multicast_write(void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
+    void noc_multicast_write(
+        const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
 
     void wait_for_non_mmio_flush() override;
 
@@ -78,11 +85,17 @@ public:
     RemoteCommunication* get_remote_communication();
 
 private:
-    RemoteChip(LocalChip* local_chip, std::unique_ptr<TTDevice> remote_tt_device);
+    RemoteChip(Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_device);
+    RemoteChip(
+        Chip* local_chip,
+        std::unique_ptr<TTDevice> remote_tt_device,
+        SocDescriptor soc_descriptor,
+        ChipInfo chip_info);
 
-    LocalChip* local_chip_;
+    Chip* local_chip_;
     RemoteCommunication* remote_communication_;
 
+    SocDescriptor soc_descriptor_;
     std::unique_ptr<TTDevice> tt_device_ = nullptr;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -721,6 +721,13 @@ private:
         int num_host_mem_channels,
         const std::filesystem::path& simulator_directory,
         std::unique_ptr<TTDevice> tt_device = nullptr);
+#ifdef TT_UMD_BUILD_SIMULATION
+    // Builds the RemoteChip for a non-MMIO chip in a multichip ttsim cluster. A simulated remote chip has no
+    // ARC/topology discovery, so its RemoteCommunication and TTDevice (carrying the cluster-derived SocDescriptor
+    // and ChipInfo) are constructed here against the MMIO gateway.
+    std::unique_ptr<RemoteChip> create_simulation_remote_chip(
+        ChipId chip_id, ClusterDescriptor* cluster_desc, SocDescriptor soc_desc);
+#endif  // TT_UMD_BUILD_SIMULATION
     SocDescriptor construct_soc_descriptor(
         const std::string& soc_desc_path, ChipId chip_id, ChipType chip_type, ClusterDescriptor* cluster_desc);
 

--- a/device/api/umd/device/simulation/simulation_chip.hpp
+++ b/device/api/umd/device/simulation/simulation_chip.hpp
@@ -38,6 +38,9 @@ class SocDescriptor;
 class SimulationChip : public Chip {
 public:
     static std::string get_soc_descriptor_path_from_simulator_path(const std::filesystem::path& simulator_path);
+    // An optional cluster_descriptor.yaml beside the simulator describes a (possibly multichip) topology.
+    // Returns the path where it would live; the file is not required to exist.
+    static std::string get_cluster_descriptor_path_from_simulator_path(const std::filesystem::path& simulator_path);
 
     static std::unique_ptr<SimulationChip> create(
         const std::filesystem::path& simulator_directory,

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -91,9 +91,12 @@ public:
         bool use_safe_api = false,
         const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor = nullptr);
 
+    // A remote TTDevice is normally initialized over ARC (init_tt_device), which constructs its SocDescriptor.
+    // Simulated remote chips have no ARC to probe, so the caller may supply the full descriptor via soc_descriptor.
     static std::unique_ptr<TTDevice> create(
         std::unique_ptr<RemoteCommunication> remote_communication,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor = nullptr);
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor = nullptr,
+        std::optional<SocDescriptor> soc_descriptor = std::nullopt);
 
     virtual ~TTDevice() = default;
 

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -79,6 +79,7 @@ private:
         const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
     friend std::unique_ptr<TTDevice> TTDevice::create(
         std::unique_ptr<RemoteCommunication> remote_communication,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
+        std::optional<SocDescriptor> soc_descriptor);
 };
 }  // namespace tt::umd

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -39,27 +39,26 @@ std::unique_ptr<RemoteChip> RemoteChip::create(std::unique_ptr<TTDevice> remote_
 }
 
 std::unique_ptr<RemoteChip> RemoteChip::create_for_simulation(
-    std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip, SocDescriptor soc_descriptor, ChipInfo chip_info) {
+    std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip, ChipInfo chip_info) {
     ZoneScopedC(tracy::Color::DarkGreen);
     UMD_ASSERT(
         remote_tt_device != nullptr, error::RuntimeError, "RemoteTTDevice passed to RemoteChip must not be null.");
     UMD_ASSERT(local_chip != nullptr, error::RuntimeError, "Local chip passed to RemoteChip must not be null.");
-    return std::unique_ptr<RemoteChip>(
-        new RemoteChip(local_chip, std::move(remote_tt_device), std::move(soc_descriptor), chip_info));
+    // The remote TTDevice for a simulated chip is never run through init_tt_device() (it has no ARC to probe), so
+    // its SocDescriptor is supplied to TTDevice::create() instead. get_soc_descriptor() can then keep delegating
+    // to the TTDevice like every other chip.
+    return std::unique_ptr<RemoteChip>(new RemoteChip(local_chip, std::move(remote_tt_device), chip_info));
 }
 
 RemoteChip::RemoteChip(Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_device) :
-    Chip(remote_tt_device->get_chip_info(), remote_tt_device->get_arch()),
-    local_chip_(local_chip),
-    soc_descriptor_(remote_tt_device->get_soc_descriptor()) {
+    Chip(remote_tt_device->get_chip_info(), remote_tt_device->get_arch()), local_chip_(local_chip) {
     remote_communication_ = remote_tt_device->get_remote_communication();
     tt_device_ = std::move(remote_tt_device);
     wait_chip_to_be_ready();
 }
 
-RemoteChip::RemoteChip(
-    Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_device, SocDescriptor soc_descriptor, ChipInfo chip_info) :
-    Chip(chip_info, soc_descriptor.arch), local_chip_(local_chip), soc_descriptor_(std::move(soc_descriptor)) {
+RemoteChip::RemoteChip(Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_device, ChipInfo chip_info) :
+    Chip(chip_info, remote_tt_device->get_soc_descriptor().arch), local_chip_(local_chip) {
     remote_communication_ = remote_tt_device->get_remote_communication();
     tt_device_ = std::move(remote_tt_device);
 }

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -39,10 +39,7 @@ std::unique_ptr<RemoteChip> RemoteChip::create(std::unique_ptr<TTDevice> remote_
 }
 
 std::unique_ptr<RemoteChip> RemoteChip::create_for_simulation(
-    std::unique_ptr<TTDevice> remote_tt_device,
-    Chip* local_chip,
-    SocDescriptor soc_descriptor,
-    ChipInfo chip_info) {
+    std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip, SocDescriptor soc_descriptor, ChipInfo chip_info) {
     ZoneScopedC(tracy::Color::DarkGreen);
     UMD_ASSERT(
         remote_tt_device != nullptr, error::RuntimeError, "RemoteTTDevice passed to RemoteChip must not be null.");
@@ -61,10 +58,7 @@ RemoteChip::RemoteChip(Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_dev
 }
 
 RemoteChip::RemoteChip(
-    Chip* local_chip,
-    std::unique_ptr<TTDevice> remote_tt_device,
-    SocDescriptor soc_descriptor,
-    ChipInfo chip_info) :
+    Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_device, SocDescriptor soc_descriptor, ChipInfo chip_info) :
     Chip(chip_info, soc_descriptor.arch), local_chip_(local_chip), soc_descriptor_(std::move(soc_descriptor)) {
     remote_communication_ = remote_tt_device->get_remote_communication();
     tt_device_ = std::move(remote_tt_device);

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -112,22 +112,6 @@ void RemoteChip::dma_multicast_write(void* src, size_t size, CoreCoord core_star
     UMD_THROW(error::RuntimeError, "RemoteChip::dma_multicast_write is not available for this chip.");
 }
 
-void RemoteChip::noc_multicast_write(
-    const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) {
-    if (core_start.core_type != CoreType::TENSIX || core_end.core_type != CoreType::TENSIX) {
-        UMD_THROW(error::RuntimeError, "noc_multicast_write is only supported for Tensix cores.");
-    }
-    const tt_xy_pair translated_start = get_soc_descriptor().translate_chip_coord_to_translated(core_start);
-    const tt_xy_pair translated_end = get_soc_descriptor().translate_chip_coord_to_translated(core_end);
-    for (const auto& core : get_soc_descriptor().get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)) {
-        if (core.x < translated_start.x || core.x > translated_end.x || core.y < translated_start.y ||
-            core.y > translated_end.y) {
-            continue;
-        }
-        write_to_device(CoreCoord(core.x, core.y, CoreType::TENSIX, CoordSystem::TRANSLATED), src, addr, size);
-    }
-}
-
 void RemoteChip::wait_for_non_mmio_flush() { remote_communication_->wait_for_non_mmio_flush(); }
 
 void RemoteChip::l1_membar(const std::unordered_set<CoreCoord>& cores) { wait_for_non_mmio_flush(); }

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -12,8 +12,10 @@
 #include <utility>
 
 #include "tracy.hpp"
-#include "umd/device/chip/local_chip.hpp"
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
+#ifdef TT_UMD_BUILD_SIMULATION
+#include "umd/device/simulation/simulation_chip.hpp"
+#endif
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
@@ -28,19 +30,44 @@ namespace tt::umd {
 
 static_assert(!std::is_abstract<RemoteChip>(), "RemoteChip must be non-abstract.");
 
-std::unique_ptr<RemoteChip> RemoteChip::create(std::unique_ptr<TTDevice> remote_tt_device, LocalChip* local_chip) {
+std::unique_ptr<RemoteChip> RemoteChip::create(std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip) {
     ZoneScopedC(tracy::Color::DarkGreen);
     UMD_ASSERT(
         remote_tt_device != nullptr, error::RuntimeError, "RemoteTTDevice passed to RemoteChip must not be null.");
-    UMD_ASSERT(local_chip != nullptr, error::RuntimeError, "LocalChip passed to RemoteChip must not be null.");
+    UMD_ASSERT(local_chip != nullptr, error::RuntimeError, "Local chip passed to RemoteChip must not be null.");
     return std::unique_ptr<RemoteChip>(new RemoteChip(local_chip, std::move(remote_tt_device)));
 }
 
-RemoteChip::RemoteChip(LocalChip* local_chip, std::unique_ptr<TTDevice> remote_tt_device) :
-    Chip(remote_tt_device->get_chip_info(), remote_tt_device->get_arch()), local_chip_(local_chip) {
+std::unique_ptr<RemoteChip> RemoteChip::create_for_simulation(
+    std::unique_ptr<TTDevice> remote_tt_device,
+    Chip* local_chip,
+    SocDescriptor soc_descriptor,
+    ChipInfo chip_info) {
+    ZoneScopedC(tracy::Color::DarkGreen);
+    UMD_ASSERT(
+        remote_tt_device != nullptr, error::RuntimeError, "RemoteTTDevice passed to RemoteChip must not be null.");
+    UMD_ASSERT(local_chip != nullptr, error::RuntimeError, "Local chip passed to RemoteChip must not be null.");
+    return std::unique_ptr<RemoteChip>(
+        new RemoteChip(local_chip, std::move(remote_tt_device), std::move(soc_descriptor), chip_info));
+}
+
+RemoteChip::RemoteChip(Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_device) :
+    Chip(remote_tt_device->get_chip_info(), remote_tt_device->get_arch()),
+    local_chip_(local_chip),
+    soc_descriptor_(remote_tt_device->get_soc_descriptor()) {
     remote_communication_ = remote_tt_device->get_remote_communication();
     tt_device_ = std::move(remote_tt_device);
     wait_chip_to_be_ready();
+}
+
+RemoteChip::RemoteChip(
+    Chip* local_chip,
+    std::unique_ptr<TTDevice> remote_tt_device,
+    SocDescriptor soc_descriptor,
+    ChipInfo chip_info) :
+    Chip(chip_info, soc_descriptor.arch), local_chip_(local_chip), soc_descriptor_(std::move(soc_descriptor)) {
+    remote_communication_ = remote_tt_device->get_remote_communication();
+    tt_device_ = std::move(remote_tt_device);
 }
 
 bool RemoteChip::is_mmio_capable() const { return false; }
@@ -49,6 +76,11 @@ void RemoteChip::start_device(uint32_t dram_membar_subchannel) {}
 
 void RemoteChip::close_device() {
     ZoneScopedC(tracy::Color::DarkRed);
+#ifdef TT_UMD_BUILD_SIMULATION
+    if (dynamic_cast<SimulationChip*>(local_chip_) != nullptr) {
+        return;
+    }
+#endif
     // Investigating https://github.com/tenstorrent/tt-metal/issues/25377 found that closing device that was already put
     // in LONG_IDLE by tt-smi reset would hang
     if ((uint32_t)local_chip_->get_clock() != local_chip_->get_tt_device()->get_min_clock_freq()) {
@@ -87,6 +119,22 @@ void RemoteChip::dma_multicast_write(void* src, size_t size, CoreCoord core_star
     UMD_THROW(error::RuntimeError, "RemoteChip::dma_multicast_write is not available for this chip.");
 }
 
+void RemoteChip::noc_multicast_write(
+    const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) {
+    if (core_start.core_type != CoreType::TENSIX || core_end.core_type != CoreType::TENSIX) {
+        UMD_THROW(error::RuntimeError, "noc_multicast_write is only supported for Tensix cores.");
+    }
+    const tt_xy_pair translated_start = get_soc_descriptor().translate_chip_coord_to_translated(core_start);
+    const tt_xy_pair translated_end = get_soc_descriptor().translate_chip_coord_to_translated(core_end);
+    for (const auto& core : get_soc_descriptor().get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)) {
+        if (core.x < translated_start.x || core.x > translated_end.x || core.y < translated_start.y ||
+            core.y > translated_end.y) {
+            continue;
+        }
+        write_to_device(CoreCoord(core.x, core.y, CoreType::TENSIX, CoordSystem::TRANSLATED), src, addr, size);
+    }
+}
+
 void RemoteChip::wait_for_non_mmio_flush() { remote_communication_->wait_for_non_mmio_flush(); }
 
 void RemoteChip::l1_membar(const std::unordered_set<CoreCoord>& cores) { wait_for_non_mmio_flush(); }
@@ -97,7 +145,14 @@ void RemoteChip::dram_membar(const std::unordered_set<uint32_t>& channels, uint3
     wait_for_non_mmio_flush();
 }
 
-void RemoteChip::deassert_risc_resets() { local_chip_->deassert_risc_resets(); }
+void RemoteChip::deassert_risc_resets() {
+#ifdef TT_UMD_BUILD_SIMULATION
+    if (dynamic_cast<SimulationChip*>(local_chip_) != nullptr) {
+        return;
+    }
+#endif
+    local_chip_->deassert_risc_resets();
+}
 
 int RemoteChip::get_clock() { return tt_device_->get_clock(); }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -390,6 +390,22 @@ Cluster::Cluster(ClusterOptions options) {
         case ChipType::SWEMULE:
         case ChipType::SIMULATION: {
             if (options.cluster_descriptor == nullptr) {
+#ifdef TT_UMD_BUILD_SIMULATION
+                // A ttsim .so may ship a cluster_descriptor.yaml beside it describing a real (possibly multichip)
+                // topology, mirroring the soc_descriptor.yaml convention. When present, use it; otherwise fall
+                // through to the mock single-chip descriptor below (unchanged behaviour).
+                if (options.chip_type == ChipType::SIMULATION && options.simulator_directory.extension() == ".so") {
+                    std::string cluster_desc_path =
+                        SimulationChip::get_cluster_descriptor_path_from_simulator_path(options.simulator_directory);
+                    if (std::filesystem::exists(cluster_desc_path)) {
+                        std::unique_ptr<ClusterDescriptor> full_cluster_desc =
+                            ClusterDescriptor::create_from_yaml(cluster_desc_path);
+                        cluster_desc = ClusterDescriptor::create_constrained_cluster_descriptor(
+                            full_cluster_desc.get(), options.target_devices);
+                        break;
+                    }
+                }
+#endif
                 // If no custom descriptor is provided, in case of mock or simulation chip type, we create a mock
                 // cluster descriptor from passed target devices.
                 auto arch = tt::ARCH::WORMHOLE_B0;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -232,16 +232,18 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
             remote_communication->set_remote_transfer_ethernet_cores(
                 gateway_chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(
                     cluster_desc->get_active_eth_channels(gateway_id), CoordSystem::TRANSLATED));
-            auto remote_tt_device = TTDevice::create(std::move(remote_communication));
-
             ChipInfo chip_info;
             chip_info.noc_translation_enabled = soc_desc.noc_translation_enabled;
             chip_info.harvesting_masks = soc_desc.harvesting_masks;
             chip_info.board_type = cluster_desc->get_board_type(chip_id);
             chip_info.board_id = cluster_desc->get_board_id_for_chip(chip_id);
             chip_info.asic_location = cluster_desc->get_asic_location(chip_id);
-            return RemoteChip::create_for_simulation(
-                std::move(remote_tt_device), gateway_chip, std::move(soc_desc), chip_info);
+
+            // The simulated remote chip has no ARC, so hand its SocDescriptor to the remote TTDevice directly
+            // instead of letting init_tt_device construct one.
+            auto remote_tt_device =
+                TTDevice::create(std::move(remote_communication), /*soc_arch_descriptor=*/nullptr, std::move(soc_desc));
+            return RemoteChip::create_for_simulation(std::move(remote_tt_device), gateway_chip, chip_info);
         }
         log_info(LogUMD, "Creating Simulation device");
         return SimulationChip::create(

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1004,9 +1004,12 @@ void Cluster::broadcast_tensix_risc_reset_to_cluster(uint32_t reg_value) {
 
 void Cluster::set_power_state(DevicePowerState device_state) {
     for (auto& [_, chip] : chips_) {
-        if (chip->is_mmio_capable()) {
-            chip->set_power_state(device_state);
+        // ttsim remote chips cannot service ARC messages; skip power state transitions for them. Silicon remote chips
+        // are still handled over ethernet as before.
+        if (options_.chip_type == ChipType::SIMULATION && !chip->is_mmio_capable()) {
+            continue;
         }
+        chip->set_power_state(device_state);
     }
 }
 
@@ -1022,9 +1025,12 @@ void Cluster::deassert_resets_and_set_power_state() {
     // MT Initial BH - ARC messages not supported in Blackhole.
     if (arch_name != tt::ARCH::BLACKHOLE && arch_name != tt::ARCH::QUASAR) {
         for (const ChipId& chip : all_chip_ids_) {
-            if (get_chip(chip)->is_mmio_capable()) {
-                get_chip(chip)->enable_ethernet_queue();
+            // ttsim remote chips cannot service ARC messages; skip enabling their ethernet queue. Silicon remote chips
+            // are still initialized over ethernet as before.
+            if (options_.chip_type == ChipType::SIMULATION && !get_chip(chip)->is_mmio_capable()) {
+                continue;
             }
+            get_chip(chip)->enable_ethernet_queue();
         }
     }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -220,6 +220,29 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     }
     if (chip_type == ChipType::SIMULATION) {
 #ifdef TT_UMD_BUILD_SIMULATION
+        if (simulator_directory.extension() == ".so" && !cluster_desc->is_chip_mmio_capable(chip_id)) {
+            ChipId gateway_id = cluster_desc->get_closest_mmio_capable_chip(chip_id);
+            Chip* gateway_chip = get_chip(gateway_id);
+            SysmemManager* sysmem_manager = gateway_chip->get_sysmem_manager();
+            if (sysmem_manager != nullptr && sysmem_manager->get_num_host_mem_channels() == 0) {
+                sysmem_manager = nullptr;
+            }
+            auto remote_communication = RemoteCommunication::create_remote_communication(
+                gateway_chip->get_tt_device(), cluster_desc->get_chip_location(chip_id), sysmem_manager);
+            remote_communication->set_remote_transfer_ethernet_cores(
+                gateway_chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(
+                    cluster_desc->get_active_eth_channels(gateway_id), CoordSystem::TRANSLATED));
+            auto remote_tt_device = TTDevice::create(std::move(remote_communication));
+
+            ChipInfo chip_info;
+            chip_info.noc_translation_enabled = soc_desc.noc_translation_enabled;
+            chip_info.harvesting_masks = soc_desc.harvesting_masks;
+            chip_info.board_type = cluster_desc->get_board_type(chip_id);
+            chip_info.board_id = cluster_desc->get_board_id_for_chip(chip_id);
+            chip_info.asic_location = cluster_desc->get_asic_location(chip_id);
+            return RemoteChip::create_for_simulation(
+                std::move(remote_tt_device), gateway_chip, std::move(soc_desc), chip_info);
+        }
         log_info(LogUMD, "Creating Simulation device");
         return SimulationChip::create(
             simulator_directory, soc_desc, chip_id, cluster_desc->get_number_of_chips(), num_host_mem_channels);
@@ -332,9 +355,7 @@ void Cluster::add_chip(const ChipId& chip_id, const ChipType& chip_type, std::un
         error::RuntimeError,
         fmt::format("Chip with id {} already exists in cluster. Cannot add another chip with the same id.", chip_id));
     all_chip_ids_.insert(chip_id);
-    // All non silicon chip types are considered local chips.
-    if (chip_type == ChipType::SIMULATION || chip_type == ChipType::SWEMULE ||
-        cluster_desc->is_chip_mmio_capable(chip_id)) {
+    if (chip_type == ChipType::SWEMULE || cluster_desc->is_chip_mmio_capable(chip_id)) {
         local_chip_ids_.insert(chip_id);
     } else {
         remote_chip_ids_.insert(chip_id);
@@ -983,7 +1004,9 @@ void Cluster::broadcast_tensix_risc_reset_to_cluster(uint32_t reg_value) {
 
 void Cluster::set_power_state(DevicePowerState device_state) {
     for (auto& [_, chip] : chips_) {
-        chip->set_power_state(device_state);
+        if (chip->is_mmio_capable()) {
+            chip->set_power_state(device_state);
+        }
     }
 }
 
@@ -999,7 +1022,9 @@ void Cluster::deassert_resets_and_set_power_state() {
     // MT Initial BH - ARC messages not supported in Blackhole.
     if (arch_name != tt::ARCH::BLACKHOLE && arch_name != tt::ARCH::QUASAR) {
         for (const ChipId& chip : all_chip_ids_) {
-            get_chip(chip)->enable_ethernet_queue();
+            if (get_chip(chip)->is_mmio_capable()) {
+                get_chip(chip)->enable_ethernet_queue();
+            }
         }
     }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -198,6 +198,36 @@ void Cluster::construct_cluster(const uint32_t& num_host_mem_ch_per_mmio_device,
     }
 }
 
+#ifdef TT_UMD_BUILD_SIMULATION
+std::unique_ptr<RemoteChip> Cluster::create_simulation_remote_chip(
+    ChipId chip_id, ClusterDescriptor* cluster_desc, SocDescriptor soc_desc) {
+    ChipId gateway_id = cluster_desc->get_closest_mmio_capable_chip(chip_id);
+    Chip* gateway_chip = get_chip(gateway_id);
+    SysmemManager* sysmem_manager = gateway_chip->get_sysmem_manager();
+    if (sysmem_manager != nullptr && sysmem_manager->get_num_host_mem_channels() == 0) {
+        sysmem_manager = nullptr;
+    }
+    auto remote_communication = RemoteCommunication::create_remote_communication(
+        gateway_chip->get_tt_device(), cluster_desc->get_chip_location(chip_id), sysmem_manager);
+    remote_communication->set_remote_transfer_ethernet_cores(
+        gateway_chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(
+            cluster_desc->get_active_eth_channels(gateway_id), CoordSystem::TRANSLATED));
+
+    ChipInfo chip_info;
+    chip_info.noc_translation_enabled = soc_desc.noc_translation_enabled;
+    chip_info.harvesting_masks = soc_desc.harvesting_masks;
+    chip_info.board_type = cluster_desc->get_board_type(chip_id);
+    chip_info.board_id = cluster_desc->get_board_id_for_chip(chip_id);
+    chip_info.asic_location = cluster_desc->get_asic_location(chip_id);
+
+    // The simulated remote chip has no ARC, so hand its SocDescriptor to the remote TTDevice directly
+    // instead of letting init_tt_device construct one.
+    auto remote_tt_device =
+        TTDevice::create(std::move(remote_communication), /*soc_arch_descriptor=*/nullptr, std::move(soc_desc));
+    return RemoteChip::create_for_simulation(std::move(remote_tt_device), gateway_chip, chip_info);
+}
+#endif  // TT_UMD_BUILD_SIMULATION
+
 std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     ChipId chip_id,
     const ChipType& chip_type,
@@ -221,29 +251,7 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     if (chip_type == ChipType::SIMULATION) {
 #ifdef TT_UMD_BUILD_SIMULATION
         if (simulator_directory.extension() == ".so" && !cluster_desc->is_chip_mmio_capable(chip_id)) {
-            ChipId gateway_id = cluster_desc->get_closest_mmio_capable_chip(chip_id);
-            Chip* gateway_chip = get_chip(gateway_id);
-            SysmemManager* sysmem_manager = gateway_chip->get_sysmem_manager();
-            if (sysmem_manager != nullptr && sysmem_manager->get_num_host_mem_channels() == 0) {
-                sysmem_manager = nullptr;
-            }
-            auto remote_communication = RemoteCommunication::create_remote_communication(
-                gateway_chip->get_tt_device(), cluster_desc->get_chip_location(chip_id), sysmem_manager);
-            remote_communication->set_remote_transfer_ethernet_cores(
-                gateway_chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(
-                    cluster_desc->get_active_eth_channels(gateway_id), CoordSystem::TRANSLATED));
-            ChipInfo chip_info;
-            chip_info.noc_translation_enabled = soc_desc.noc_translation_enabled;
-            chip_info.harvesting_masks = soc_desc.harvesting_masks;
-            chip_info.board_type = cluster_desc->get_board_type(chip_id);
-            chip_info.board_id = cluster_desc->get_board_id_for_chip(chip_id);
-            chip_info.asic_location = cluster_desc->get_asic_location(chip_id);
-
-            // The simulated remote chip has no ARC, so hand its SocDescriptor to the remote TTDevice directly
-            // instead of letting init_tt_device construct one.
-            auto remote_tt_device =
-                TTDevice::create(std::move(remote_communication), /*soc_arch_descriptor=*/nullptr, std::move(soc_desc));
-            return RemoteChip::create_for_simulation(std::move(remote_tt_device), gateway_chip, chip_info);
+            return create_simulation_remote_chip(chip_id, cluster_desc, std::move(soc_desc));
         }
         log_info(LogUMD, "Creating Simulation device");
         return SimulationChip::create(

--- a/device/simulation/simulation_chip.cpp
+++ b/device/simulation/simulation_chip.cpp
@@ -36,6 +36,12 @@ std::string SimulationChip::get_soc_descriptor_path_from_simulator_path(const st
                                                  : (simulator_path / "soc_descriptor.yaml");
 }
 
+std::string SimulationChip::get_cluster_descriptor_path_from_simulator_path(
+    const std::filesystem::path& simulator_path) {
+    return (simulator_path.extension() == ".so") ? (simulator_path.parent_path() / "cluster_descriptor.yaml")
+                                                 : (simulator_path / "cluster_descriptor.yaml");
+}
+
 SimulationChip::SimulationChip(
     const std::filesystem::path& simulator_directory,
     const SocDescriptor& soc_descriptor,

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -482,7 +482,11 @@ ChipInfo TTDevice::get_chip_info() {
 
 uint32_t TTDevice::get_max_clock_freq() { return get_firmware_info_provider()->get_max_clock_freq(); }
 
-void TTDevice::advance_device_execution() {}
+void TTDevice::advance_device_execution() {
+    if (remote_capabilities_ != nullptr) {
+        remote_capabilities_->get_remote_communication()->get_local_device()->advance_device_execution();
+    }
+}
 
 uint32_t TTDevice::get_risc_reset_state(tt_xy_pair core) {
     uint32_t tensix_risc_state;

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -191,14 +191,19 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
 
 std::unique_ptr<TTDevice> TTDevice::create(
     std::unique_ptr<RemoteCommunication> remote_communication,
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
+    std::optional<SocDescriptor> soc_descriptor) {
     ZoneScopedC(tracy::Color::DarkGreen);
     UMD_ASSERT(remote_communication != nullptr, error::RuntimeError, "RemoteCommunication pointer cannot be null.");
     tt::ARCH arch = remote_communication->get_local_device()->get_arch();
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: {
-            return std::unique_ptr<WormholeTTDevice>(
+            auto device = std::unique_ptr<WormholeTTDevice>(
                 new WormholeTTDevice(std::move(remote_communication), soc_arch_descriptor));
+            if (soc_descriptor.has_value()) {
+                device->set_soc_descriptor(std::move(*soc_descriptor));
+            }
+            return device;
         }
         default:
             UMD_THROW(

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -201,7 +201,8 @@ std::unique_ptr<TTDevice> TTDevice::create(
             auto device = std::unique_ptr<WormholeTTDevice>(
                 new WormholeTTDevice(std::move(remote_communication), soc_arch_descriptor));
             if (soc_descriptor.has_value()) {
-                device->set_soc_descriptor(std::move(*soc_descriptor));
+                // set_soc_descriptor takes a const ref and copies internally, so no std::move here.
+                device->set_soc_descriptor(*soc_descriptor);
             }
             return device;
         }

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <vector>
 
+#include "test_utils/fetch_local_files.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
 
@@ -60,8 +61,27 @@ inline std::unique_ptr<Cluster> make_default_test_cluster(ClusterOptions options
     }
     if (const char* sim_path = std::getenv("TT_UMD_SIMULATOR")) {
         options.chip_type = ChipType::SIMULATION;
-        options.target_devices = {0};
         options.simulator_directory = std::filesystem::path(sim_path);
+
+        // A multichip simulator (e.g. wh_x2) needs a real cluster descriptor to expose
+        // its topology -- the auto-generated mock descriptor marks every chip MMIO and
+        // has no eth links, so a remote chip would never be enumerated. When
+        // TT_UMD_CLUSTER_DESCRIPTOR names a descriptor (a filename under
+        // tests/cluster_descriptor_examples/), load it and target all of its chips.
+        // Without it, behaviour is unchanged: a single MMIO chip 0.
+        if (const char* desc_name = std::getenv("TT_UMD_CLUSTER_DESCRIPTOR")) {
+            // Static lifetime: Cluster stores the options (including this pointer), and
+            // the descriptor selection is constant for the whole test process.
+            static std::unique_ptr<ClusterDescriptor> sim_cluster_desc =
+                ClusterDescriptor::create_from_yaml(GetClusterDescAbsPath(desc_name));
+            options.cluster_descriptor = sim_cluster_desc.get();
+            options.target_devices.clear();
+            for (tt::ChipId chip : sim_cluster_desc->get_all_chips()) {
+                options.target_devices.insert(chip);
+            }
+        } else {
+            options.target_devices = {0};
+        }
     }
     return std::make_unique<Cluster>(options);
 }

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -15,7 +15,6 @@
 #include <string>
 #include <vector>
 
-#include "test_utils/fetch_local_files.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
 
@@ -61,27 +60,8 @@ inline std::unique_ptr<Cluster> make_default_test_cluster(ClusterOptions options
     }
     if (const char* sim_path = std::getenv("TT_UMD_SIMULATOR")) {
         options.chip_type = ChipType::SIMULATION;
+        options.target_devices = {0};
         options.simulator_directory = std::filesystem::path(sim_path);
-
-        // A multichip simulator (e.g. wh_x2) needs a real cluster descriptor to expose
-        // its topology -- the auto-generated mock descriptor marks every chip MMIO and
-        // has no eth links, so a remote chip would never be enumerated. When
-        // TT_UMD_CLUSTER_DESCRIPTOR names a descriptor (a filename under
-        // tests/cluster_descriptor_examples/), load it and target all of its chips.
-        // Without it, behaviour is unchanged: a single MMIO chip 0.
-        if (const char* desc_name = std::getenv("TT_UMD_CLUSTER_DESCRIPTOR")) {
-            // Static lifetime: Cluster stores the options (including this pointer), and
-            // the descriptor selection is constant for the whole test process.
-            static std::unique_ptr<ClusterDescriptor> sim_cluster_desc =
-                ClusterDescriptor::create_from_yaml(GetClusterDescAbsPath(desc_name));
-            options.cluster_descriptor = sim_cluster_desc.get();
-            options.target_devices.clear();
-            for (tt::ChipId chip : sim_cluster_desc->get_all_chips()) {
-                options.target_devices.insert(chip);
-            }
-        } else {
-            options.target_devices = {0};
-        }
     }
     return std::make_unique<Cluster>(options);
 }


### PR DESCRIPTION
### Issue
Part of #2679. Tracked by #2832.

### Description
UMD's ttsim path assumed a `libttsim.so` exposes a single MMIO chip, so a multichip simulator like the wh_x2 (N300) only ever surfaced chip 0. This PR enumerates the full N300 topology — the MMIO gateway (chip 0) and the remote chip (chip 1) over simulated ethernet — so device IO runs across both.

Most changes follow from a *simulated* remote chip not being like a silicon one:

- **No ARC.** A silicon remote chip is brought up over ARC during topology discovery (which gives it its `SocDescriptor`/chip info and lets it service power/eth-queue/reset messages). The simulated one has none of that, so its `SocDescriptor` is supplied to the remote `TTDevice` at creation and ARC-only steps are skipped in simulation mode. Silicon remote-over-eth is unchanged.
- **Clock.** `advance_device_execution()` on a remote `TTDevice` forwards to its gateway device, so polling the remote chip still advances the simulator clock.
- **Topology.** The mock descriptor marks every chip MMIO with no eth links, so a remote chip would never appear. UMD now discovers an optional `cluster_descriptor.yaml` beside the `.so` (like `soc_descriptor.yaml`); without it, behaviour is unchanged.

### List of the changes
- Enumerate non-MMIO simulation chips as remote chips routed through the MMIO gateway.
- Provide the `SocDescriptor` to the remote sim `TTDevice` at creation; `RemoteChip::get_soc_descriptor()` delegates to the device.
- Skip ARC-only steps (power state, ethernet-queue enable, close, reset) for simulated remote chips.
- Forward `advance_device_execution()` from a remote `TTDevice` to its gateway device.
- Discover an optional `cluster_descriptor.yaml` from the simulator directory.
- Extract simulation remote-chip construction into a `Cluster` helper.
- CI: exercise the wh_x2 (N300) ttsim.

### Testing
CI

### API Changes
`TTDevice::create` gains an optional `SocDescriptor` (defaulted; silicon callers unaffected). `RemoteChip` gains `create_for_simulation`. New `SimulationChip::get_cluster_descriptor_path_from_simulator_path`. Needs careful UMD review to confirm no existing assumptions are broken.