### PR TITLE
Simulation: client attach + open-or-attach default (discovery)

### DIFF
--- a/device/api/umd/device/simulation/simulation_topology_discovery.hpp
+++ b/device/api/umd/device/simulation/simulation_topology_discovery.hpp
@@ -22,6 +22,11 @@ struct SimulationTopologyDiscoveryOptions {
     // attaching to a live host the topology comes from the host instead.
     std::shared_ptr<ClusterDescriptor> cluster_descriptor;
     int num_host_mem_channels = 0;
+
+    // Default (false): open-or-attach — attach to a live host if one exists, otherwise host.
+    // When true: explicitly stand up a *separate* host at a process-unique path, never attaching
+    // to (or colliding with) an existing one — for callers that want their own independent sim.
+    bool create_new_server = false;
 };
 
 // Entry point for opening simulated devices, mirroring silicon TopologyDiscovery. It scans the

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -52,6 +52,12 @@ public:
     static std::unique_ptr<TTSimTTDevice> create_for_chip(
         const std::filesystem::path &simulator_directory, ChipId chip_id, bool copy_sim_binary = false);
 
+    // Creates a *client* device that attaches to a live host's socket and forwards device I/O
+    // over it (rather than driving the .so directly). The SoC descriptor is loaded locally from
+    // simulator_directory; the socket carries only device operations.
+    static std::unique_ptr<TTSimTTDevice> create_client(
+        const std::filesystem::path &simulator_directory, ChipId chip_id = 0);
+
     void read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
     void write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
 
@@ -110,6 +116,15 @@ protected:
     void retrain_dram_core(const uint32_t dram_channel) override;
 
 private:
+    // Tag for the client-mode constructor (attaches to a host socket; no .so backend).
+    struct ClientTag {};
+
+    TTSimTTDevice(const SocDescriptor &soc_descriptor, ChipId chip_id, int client_fd, ClientTag);
+
+    // Client mode: forward a device read/write over the socket to the host.
+    void forward_read(void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size);
+    void forward_write(const void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size);
+
     void initialize_sysmem_functions();
     void pci_dma_read_bytes(uint64_t paddr, void *p, uint32_t size);
     void pci_dma_write_bytes(uint64_t paddr, const void *p, uint32_t size);
@@ -126,7 +141,10 @@ private:
     // it. The host keeps its own direct in-process fast path; the socket is for remote clients.
     std::unique_ptr<SimulationSocket> socket_;
 
-    uint32_t libttsim_pci_device_id;
+    // >= 0 in client mode: the connected socket this device forwards device I/O over.
+    int client_fd_ = -1;
+
+    uint32_t libttsim_pci_device_id = 0;
 
     std::shared_ptr<SimulationTlbAllocator> tlb_allocator_;
     std::unique_ptr<TlbWindow> cached_tlb_window_ = nullptr;

--- a/device/simulation/simulation_server_api.cpp
+++ b/device/simulation/simulation_server_api.cpp
@@ -5,6 +5,7 @@
 #include "umd/device/simulation/simulation_server_api.hpp"
 
 #include <flatbuffers/flatbuffers.h>
+#include <sys/socket.h>
 #include <unistd.h>
 
 #include <cerrno>
@@ -19,7 +20,7 @@ namespace {
 bool write_all(int fd, const uint8_t* buf, size_t n) {
     size_t offset = 0;
     while (offset < n) {
-        ssize_t written = ::write(fd, buf + offset, n - offset);
+        ssize_t written = ::send(fd, buf + offset, n - offset, MSG_NOSIGNAL);
         if (written < 0) {
             if (errno == EINTR) {
                 continue;

--- a/device/simulation/simulation_topology_discovery.cpp
+++ b/device/simulation/simulation_topology_discovery.cpp
@@ -4,13 +4,13 @@
 
 #include "umd/device/simulation/simulation_topology_discovery.hpp"
 
-#include <fmt/format.h>
+#include <unistd.h>
 
+#include <string>
 #include <utility>
 
 #include "umd/device/simulation/simulation_socket.hpp"
 #include "umd/device/tt_device/tt_sim_tt_device.hpp"
-#include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
 
@@ -20,17 +20,22 @@ std::map<ChipId, std::unique_ptr<TTDevice>> SimulationTopologyDiscovery::discove
 
     // Single-chip for now. Socket-first: try to claim the path; success => we are the host.
     const ChipId chip_id = 0;
-    const std::filesystem::path socket_path = SimulationSocket::default_socket_path(chip_id);
+    std::filesystem::path socket_path = SimulationSocket::default_socket_path(chip_id);
+    if (options.create_new_server) {
+        // Process-unique path so this host is independent: it never attaches to, nor collides with,
+        // a host already at the well-known path.
+        socket_path.replace_extension();
+        socket_path += "-" + std::to_string(::getpid()) + ".sock";
+    }
 
     std::unique_ptr<SimulationSocket> socket = SimulationSocket::try_create(socket_path);
     if (socket == nullptr) {
-        // A live host already serves this device. The client/attach path lands in a later PR.
-        UMD_THROW(
-            error::RuntimeError,
-            fmt::format(
-                "Attaching to an existing simulation host is not implemented yet; a live socket "
-                "already exists at: {}",
-                socket_path.string()));
+        // A live host already serves this device: attach as a client that forwards device I/O over
+        // the socket into the host's sim (the default open-or-attach behavior). create_new_server
+        // uses a process-unique path, so it does not reach here.
+        std::unique_ptr<TTDevice> client = TTSimTTDevice::create_client(options.simulator_directory, chip_id);
+        devices.emplace(chip_id, std::move(client));
+        return devices;
     }
 
     // We are the host: bring up the backend (the direct in-process hot path), then serve clients

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -4,7 +4,13 @@
 
 #include "umd/device/tt_device/tt_sim_tt_device.hpp"
 
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cerrno>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <functional>
 #include <string>
@@ -72,6 +78,22 @@ std::vector<uint8_t> unpack_words_to_bytes(const std::vector<uint32_t>& words, u
     return bytes;
 }
 
+// Connects to a UNIX socket at path, returning the connected fd or -1.
+int connect_unix(const std::filesystem::path& path) {
+    int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    std::strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        ::close(fd);
+        return -1;
+    }
+    return fd;
+}
+
 }  // namespace
 
 std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create(
@@ -92,6 +114,75 @@ std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create_for_chip(
     }
     SocDescriptor soc_descriptor = SocDescriptor(std::make_shared<SocArchDescriptor>(soc_desc_path), chip_info);
     return std::make_unique<TTSimTTDevice>(simulator_directory, soc_descriptor, chip_id, copy_sim_binary, 0);
+}
+
+std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create_client(
+    const std::filesystem::path& simulator_directory, ChipId chip_id) {
+    auto soc_desc_path = SimulationChip::get_soc_descriptor_path_from_simulator_path(simulator_directory);
+    tt::ARCH arch = SocDescriptor::get_arch_from_soc_descriptor_path(soc_desc_path);
+    ChipInfo chip_info{};
+    if (arch == tt::ARCH::BLACKHOLE) {
+        chip_info.harvesting_masks.eth_harvesting_mask = 0x120;
+    }
+    SocDescriptor soc_descriptor = SocDescriptor(std::make_shared<SocArchDescriptor>(soc_desc_path), chip_info);
+
+    const std::filesystem::path socket_path = SimulationSocket::default_socket_path(chip_id);
+    int fd = connect_unix(socket_path);
+    if (fd < 0) {
+        UMD_THROW(error::RuntimeError, "Failed to connect to simulation host socket at " + socket_path.string());
+    }
+    // Non-mutating attach handshake: register with the host and confirm it is serving.
+    Message attach;
+    attach.type = MessageType::AttachRequest;
+    if (!send_framed(fd, encode(attach)) || !recv_framed(fd)) {
+        ::close(fd);
+        UMD_THROW(error::RuntimeError, "Simulation host attach handshake failed at " + socket_path.string());
+    }
+    return std::unique_ptr<TTSimTTDevice>(new TTSimTTDevice(soc_descriptor, chip_id, fd, ClientTag{}));
+}
+
+TTSimTTDevice::TTSimTTDevice(const SocDescriptor& soc_descriptor, ChipId chip_id, int client_fd, ClientTag) :
+    chip_id_(chip_id),
+    sysmem_manager_(std::make_unique<SimulationSysmemManager>(0, soc_descriptor.arch)),
+    client_fd_(client_fd) {
+    set_soc_descriptor(soc_descriptor);
+    arch = soc_descriptor.arch;
+    architecture_impl_ = architecture_implementation::create(soc_descriptor.arch);
+}
+
+void TTSimTTDevice::forward_read(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
+    std::lock_guard<std::recursive_mutex> lock(device_lock);
+    Message req;
+    req.type = MessageType::DeviceOp;
+    req.op.command = SIM_CMD_READ;
+    req.op.endpoint = {static_cast<uint32_t>(core.x), static_cast<uint32_t>(core.y)};
+    req.op.address = addr;
+    req.op.size = static_cast<uint32_t>(size);
+    if (!send_framed(client_fd_, encode(req))) {
+        UMD_THROW(error::RuntimeError, "Simulation client read: send failed.");
+    }
+    auto resp = recv_framed(client_fd_);
+    if (!resp) {
+        UMD_THROW(error::RuntimeError, "Simulation client read: host disconnected.");
+    }
+    const Message out = decode(*resp);
+    const std::vector<uint8_t> bytes = unpack_words_to_bytes(out.op.data, static_cast<uint32_t>(size));
+    std::memcpy(mem_ptr, bytes.data(), size);
+}
+
+void TTSimTTDevice::forward_write(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
+    std::lock_guard<std::recursive_mutex> lock(device_lock);
+    Message req;
+    req.type = MessageType::DeviceOp;
+    req.op.command = SIM_CMD_WRITE;
+    req.op.endpoint = {static_cast<uint32_t>(core.x), static_cast<uint32_t>(core.y)};
+    req.op.address = addr;
+    req.op.size = static_cast<uint32_t>(size);
+    const std::vector<uint8_t> bytes(static_cast<const uint8_t*>(mem_ptr), static_cast<const uint8_t*>(mem_ptr) + size);
+    req.op.data = pack_bytes_to_words(bytes);
+    if (!send_framed(client_fd_, encode(req)) || !recv_framed(client_fd_)) {
+        UMD_THROW(error::RuntimeError, "Simulation client write failed.");
+    }
 }
 
 TTSimTTDevice::TTSimTTDevice(
@@ -193,6 +284,12 @@ std::unique_ptr<TlbWindow> TTSimTTDevice::get_io_window(tlb_data config, TlbMapp
 }
 
 TTSimTTDevice::~TTSimTTDevice() {
+    if (client_fd_ >= 0) {
+        // Client mode: closing the socket is the detach signal (the host sees EOF); no backend to
+        // tear down here.
+        ::close(client_fd_);
+        return;
+    }
     // Stop serving (and remove the socket) before tearing the backend down.
     socket_.reset();
     communicator_->shutdown();
@@ -252,11 +349,18 @@ std::vector<uint8_t> TTSimTTDevice::handle_request(const std::vector<uint8_t>& r
 void TTSimTTDevice::start_device() {}
 
 void TTSimTTDevice::close_device() {
+    if (client_fd_ >= 0) {
+        return;  // The connection is torn down in the destructor; no backend to close.
+    }
     communicator_->mark_closed();
     communicator_->shutdown();
 }
 
 void TTSimTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
+    if (client_fd_ >= 0) {
+        forward_write(mem_ptr, core, addr, size);
+        return;
+    }
     if (communicator_->is_closed()) {
         return;
     }
@@ -278,6 +382,10 @@ void TTSimTTDevice::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64
 }
 
 void TTSimTTDevice::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
+    if (client_fd_ >= 0) {
+        forward_read(mem_ptr, core, addr, size);
+        return;
+    }
     if (communicator_->is_closed()) {
         return;
     }
@@ -341,6 +449,15 @@ void TTSimTTDevice::deassert_risc_reset(tt_xy_pair core, const RiscType selected
 }
 
 void TTSimTTDevice::advance_device_execution() {
+    if (client_fd_ >= 0) {
+        std::lock_guard<std::recursive_mutex> lock(device_lock);
+        Message req;
+        req.type = MessageType::AdvanceExecutionRequest;
+        if (send_framed(client_fd_, encode(req))) {
+            recv_framed(client_fd_);
+        }
+        return;
+    }
     // Simulator clocking is driven synchronously from the calling thread to keep the simulation
     // deterministic. A background clock thread would race with reads/writes and produce
     // non-reproducible runs, so we advance the clock here instead.

--- a/tests/api/test_simulation_topology_discovery.cpp
+++ b/tests/api/test_simulation_topology_discovery.cpp
@@ -66,6 +66,39 @@ TEST(SimulationTopologyDiscovery, CreatesHostDeviceAndExposesSocket) {
     EXPECT_FALSE(std::filesystem::exists(socket));  // torn down with the device
 }
 
+// Integration: a second discover() (live socket present) attaches as a client and shares the
+// host's sim — a value written through the host device is read back through the client device.
+// Requires TT_UMD_SIMULATOR.
+TEST(SimulationTopologyDiscovery, SecondDiscoverAttachesAndSharesSim) {
+    const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
+    if (simulator_path == nullptr) {
+        GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
+    }
+
+    std::filesystem::remove(SimulationSocket::default_socket_path(0));
+
+    SimulationTopologyDiscoveryOptions options;
+    options.simulator_directory = simulator_path;
+
+    auto host_devices = SimulationTopologyDiscovery::discover(options);
+    ASSERT_EQ(host_devices.size(), 1u);
+    auto client_devices = SimulationTopologyDiscovery::discover(options);  // live socket -> client
+    ASSERT_EQ(client_devices.size(), 1u);
+
+    TTDevice* host = host_devices.at(0).get();
+    TTDevice* client = client_devices.at(0).get();
+
+    const SocDescriptor& soc = host->get_soc_descriptor();
+    const tt_xy_pair core =
+        soc.translate_coord_to(soc.get_cores(tt::CoreType::TENSIX).at(0), tt::CoordSystem::TRANSLATED);
+
+    const uint32_t value = 0x12345678;
+    host->write_to_device(&value, core, 0x140, sizeof(value));
+    uint32_t read_back = 0;
+    client->read_from_device(&read_back, core, 0x140, sizeof(read_back));
+    EXPECT_EQ(read_back, value);
+}
+
 // Integration: the discovered host serves the API over its socket — a raw protocol client
 // attaches, advances execution, writes a word, and reads it back. Requires TT_UMD_SIMULATOR.
 TEST(SimulationTopologyDiscovery, HostServesApiOverSocket) {


### PR DESCRIPTION
### Issue
Part of #2795 (client device + open-or-attach). Stacked on the host-serving PR (#2804).

### Description
Makes a second UMD that finds a live host **attach and share its sim** (the default), instead of failing — and lets a caller explicitly stand up its own server.

- **Open-or-attach (default):** `SimulationTopologyDiscovery::discover()` — live socket → create a **client device** that forwards device I/O over the socket into the host's sim; no socket → create the host (as before).
- **Client device = `TTSimTTDevice` client mode** (no parallel class): `TTSimTTDevice::create_client(...)` loads the SoC descriptor **locally** from `simulator_directory` and forwards `read`/`write`/`advance` over the socket; `assert`/`deassert_risc_reset` compose from read/write. One class, two backings (direct `.so` vs socket).
- **`create_new_server` option:** stands up a *separate* independent host at a process-unique path — never attaches to / collides with an existing one.
- **Hardening:** `SimulationSocket` removes only the socket file it actually bound (no longer deletes a live host's file when `try_create` returns null); framed transport uses `MSG_NOSIGNAL` so a client disconnect can't SIGPIPE the host.

### List of the changes
- `tt_sim_tt_device.{hpp,cpp}`: client mode (`create_client`, `forward_read`/`forward_write`, client-aware ctor / `close_device` / dtor).
- `simulation_topology_discovery.{hpp,cpp}`: open-or-attach default + `create_new_server`.
- `simulation_socket.{hpp,cpp}`: `owns_socket_file_` guard.
- `simulation_server_api.cpp`: `MSG_NOSIGNAL`.
- Tests: `SecondDiscoverAttachesAndSharesSim` (host writes → client reads back over the socket).

### Testing
- `SimulationTopologyDiscovery` (incl. the attach round-trip), `SimulationSocket`, `SimulationServerApi`, full TTSim device-IO suite pass against the qsr `libttsim.so` (37/37 runnable; 2 pre-existing skips); pre-commit clean.
- `create_new_server`'s two-hosts-in-one-process path isn't auto-tested (the qsr `.so` doesn't support two instances per process — same limit as `TwoDevicesIndependentIO`); it's exercised cross-process in real use.

### API Changes
- `TTSimTTDevice::create_client(...)`; `SimulationTopologyDiscoveryOptions::create_new_server`.
