### PR TITLE
Add reconfigure version for registers

### DIFF
--- a/device/api/umd/device/pcie/silicon_tlb_window.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_window.hpp
@@ -62,6 +62,18 @@ public:
         void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict)
         override;
 
+    void safe_read_register_reconfigure(
+        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict)
+        override;
+
+    void safe_write_register_reconfigure(
+        const void* mem_ptr,
+        tt_xy_pair core,
+        uint64_t addr,
+        size_t size,
+        NocId noc_id,
+        uint64_t ordering = tlb_data::Strict) override;
+
     void safe_noc_multicast_write_reconfigure(
         const void* src,
         size_t size,

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -41,18 +41,7 @@ public:
     virtual void read_block_reconfigure(
         void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
 
-    virtual void read_register_reconfigure(
-        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
-
     virtual void write_block_reconfigure(
-        const void* mem_ptr,
-        tt_xy_pair core,
-        uint64_t addr,
-        size_t size,
-        NocId noc_id,
-        uint64_t ordering = tlb_data::Strict);
-
-    virtual void write_register_reconfigure(
         const void* mem_ptr,
         tt_xy_pair core,
         uint64_t addr,
@@ -66,6 +55,19 @@ public:
         tt_xy_pair core_start,
         tt_xy_pair core_end,
         uint64_t addr,
+        NocId noc_id,
+        uint64_t ordering = tlb_data::Strict);
+
+    // Register reconfigure methods perform 32-bit chunked transfers with strict ordering.
+    // Alignment enforcement is the caller's responsibility.
+    virtual void read_register_reconfigure(
+        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
+
+    virtual void write_register_reconfigure(
+        const void* mem_ptr,
+        tt_xy_pair core,
+        uint64_t addr,
+        size_t size,
         NocId noc_id,
         uint64_t ordering = tlb_data::Strict);
 

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -41,7 +41,18 @@ public:
     virtual void read_block_reconfigure(
         void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
 
+    virtual void read_register_reconfigure(
+        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
+
     virtual void write_block_reconfigure(
+        const void* mem_ptr,
+        tt_xy_pair core,
+        uint64_t addr,
+        size_t size,
+        NocId noc_id,
+        uint64_t ordering = tlb_data::Strict);
+
+    virtual void write_register_reconfigure(
         const void* mem_ptr,
         tt_xy_pair core,
         uint64_t addr,
@@ -85,6 +96,17 @@ public:
     virtual void safe_read_block_reconfigure(
         void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
 
+    virtual void safe_read_register_reconfigure(
+        void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering = tlb_data::Strict);
+
+    virtual void safe_write_register_reconfigure(
+        const void* mem_ptr,
+        tt_xy_pair core,
+        uint64_t addr,
+        size_t size,
+        NocId noc_id,
+        uint64_t ordering = tlb_data::Strict);
+
     virtual void safe_noc_multicast_write_reconfigure(
         const void* src,
         size_t size,
@@ -103,6 +125,17 @@ public:
 protected:
     void validate(uint64_t offset, size_t size) const;
     uint64_t get_total_offset(uint64_t offset) const;
+
+    tlb_data make_tlb_config(
+        uint64_t addr,
+        tt_xy_pair core_end,
+        NocId noc_id,
+        uint64_t ordering,
+        bool mcast = false,
+        tt_xy_pair core_start = {}) const;
+
+    template <typename buffer_pointer, typename io_operation>
+    void transfer_and_reconfigure(tlb_data config, buffer_pointer buffer, size_t size, io_operation op);
 
     std::unique_ptr<TlbHandle> tlb_handle;
     uint64_t offset_from_aligned_addr = 0;

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -134,11 +134,12 @@ protected:
         bool mcast = false,
         tt_xy_pair core_start = {}) const;
 
-    template <typename buffer_pointer, typename io_operation>
-    void transfer_and_reconfigure(tlb_data config, buffer_pointer buffer, size_t size, io_operation op);
-
     std::unique_ptr<TlbHandle> tlb_handle;
     uint64_t offset_from_aligned_addr = 0;
+
+private:
+    template <typename buffer_pointer, typename io_operation>
+    void transfer_and_reconfigure(tlb_data config, buffer_pointer buffer, size_t size, io_operation op);
 };
 
 }  // namespace tt::umd

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -285,6 +285,16 @@ void SiliconTlbWindow::safe_read_block_reconfigure(
     execute_safe(&SiliconTlbWindow::read_block_reconfigure, mem_ptr, core, addr, size, noc_id, ordering);
 }
 
+void SiliconTlbWindow::safe_read_register_reconfigure(
+    void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    execute_safe(&SiliconTlbWindow::read_register_reconfigure, mem_ptr, core, addr, size, noc_id, ordering);
+}
+
+void SiliconTlbWindow::safe_write_register_reconfigure(
+    const void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    execute_safe(&SiliconTlbWindow::write_register_reconfigure, mem_ptr, core, addr, size, noc_id, ordering);
+}
+
 void SiliconTlbWindow::safe_noc_multicast_write_reconfigure(
     const void *src,
     size_t size,

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -16,6 +16,35 @@
 
 namespace tt::umd {
 
+tlb_data TlbWindow::make_tlb_config(
+    uint64_t addr, tt_xy_pair core_end, NocId noc_id, uint64_t ordering, bool mcast, tt_xy_pair core_start) const {
+    tlb_data config{};
+    config.local_offset = addr;
+    config.x_end = core_end.x;
+    config.y_end = core_end.y;
+    config.noc_sel = static_cast<uint64_t>(noc_id);
+    config.ordering = ordering;
+    config.static_vc = handle_ref().get_arch() != tt::ARCH::BLACKHOLE;
+    if (mcast) {
+        config.mcast = true;
+        config.x_start = core_start.x;
+        config.y_start = core_start.y;
+    }
+    return config;
+}
+
+template <typename buffer_pointer, typename io_operation>
+void TlbWindow::transfer_and_reconfigure(tlb_data config, buffer_pointer buffer, size_t size, io_operation op) {
+    while (size > 0) {
+        configure(config);
+        size_t transfer_size = std::min(size, get_size());
+        op(buffer, transfer_size);
+        size -= transfer_size;
+        config.local_offset += transfer_size;
+        buffer += transfer_size;
+    }
+}
+
 TlbWindow::TlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config) : tlb_handle(std::move(handle)) {
     tlb_data aligned_config = config;
     aligned_config.local_offset = config.local_offset & ~(tlb_handle->get_size() - 1);
@@ -25,55 +54,38 @@ TlbWindow::TlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config) :
 
 void TlbWindow::read_block_reconfigure(
     void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    uint8_t* buffer_addr = static_cast<uint8_t*>(mem_ptr);
-    tlb_data config{};
-    config.local_offset = addr;
-    config.x_end = core.x;
-    config.y_end = core.y;
-    config.noc_sel = static_cast<uint64_t>(noc_id);
-    config.ordering = ordering;
-    config.static_vc = tlb_handle->get_arch() != tt::ARCH::BLACKHOLE;
+    transfer_and_reconfigure(
+        make_tlb_config(addr, core, noc_id, ordering),
+        static_cast<uint8_t*>(mem_ptr),
+        size,
+        [this](uint8_t* buf, size_t sz) { read_block(0, buf, sz); });
+}
 
-    while (size > 0) {
-        configure(config);
-        size_t tlb_size = get_size();
-        size_t transfer_size = std::min(size, tlb_size);
-
-        read_block(0, buffer_addr, transfer_size);
-
-        size -= transfer_size;
-        addr += transfer_size;
-        buffer_addr += transfer_size;
-
-        config.local_offset = addr;
-    }
+void TlbWindow::read_register_reconfigure(
+    void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    transfer_and_reconfigure(
+        make_tlb_config(addr, core, noc_id, ordering),
+        static_cast<uint8_t*>(mem_ptr),
+        size,
+        [this](uint8_t* buf, size_t sz) { read_register(0, buf, sz); });
 }
 
 void TlbWindow::write_block_reconfigure(
     const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
-    const uint8_t* buffer_addr = static_cast<const uint8_t*>(mem_ptr);
-    tlb_data config{};
-    config.local_offset = addr;
-    config.x_end = core.x;
-    config.y_end = core.y;
-    config.noc_sel = static_cast<uint64_t>(noc_id);
-    config.ordering = ordering;
-    config.static_vc = tlb_handle->get_arch() != tt::ARCH::BLACKHOLE;
+    transfer_and_reconfigure(
+        make_tlb_config(addr, core, noc_id, ordering),
+        static_cast<const uint8_t*>(mem_ptr),
+        size,
+        [this](const uint8_t* buf, size_t sz) { write_block(0, buf, sz); });
+}
 
-    while (size > 0) {
-        configure(config);
-        size_t tlb_size = get_size();
-
-        size_t transfer_size = std::min(size, tlb_size);
-
-        write_block(0, buffer_addr, transfer_size);
-
-        size -= transfer_size;
-        addr += transfer_size;
-        buffer_addr += transfer_size;
-
-        config.local_offset = addr;
-    }
+void TlbWindow::write_register_reconfigure(
+    const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    transfer_and_reconfigure(
+        make_tlb_config(addr, core, noc_id, ordering),
+        static_cast<const uint8_t*>(mem_ptr),
+        size,
+        [this](const uint8_t* buf, size_t sz) { write_register(0, buf, sz); });
 }
 
 void TlbWindow::noc_multicast_write_reconfigure(
@@ -84,32 +96,11 @@ void TlbWindow::noc_multicast_write_reconfigure(
     uint64_t addr,
     NocId noc_id,
     uint64_t ordering) {
-    const uint8_t* buffer_addr = static_cast<const uint8_t*>(src);
-    tlb_data config{};
-    config.local_offset = addr;
-    config.x_start = core_start.x;
-    config.y_start = core_start.y;
-    config.x_end = core_end.x;
-    config.y_end = core_end.y;
-    config.mcast = true;
-    config.noc_sel = static_cast<uint64_t>(noc_id);
-    config.ordering = ordering;
-    config.static_vc = tlb_handle->get_arch() != tt::ARCH::BLACKHOLE;
-
-    while (size > 0) {
-        configure(config);
-        size_t tlb_size = get_size();
-
-        size_t transfer_size = std::min(size, tlb_size);
-
-        write_block(0, buffer_addr, transfer_size);
-
-        size -= transfer_size;
-        addr += transfer_size;
-        buffer_addr += transfer_size;
-
-        config.local_offset = addr;
-    }
+    transfer_and_reconfigure(
+        make_tlb_config(addr, core_end, noc_id, ordering, true, core_start),
+        static_cast<const uint8_t*>(src),
+        size,
+        [this](const uint8_t* buf, size_t sz) { write_block(0, buf, sz); });
 }
 
 TlbHandle& TlbWindow::handle_ref() const { return *tlb_handle; }
@@ -157,6 +148,16 @@ void TlbWindow::safe_write_block_reconfigure(
 void TlbWindow::safe_read_block_reconfigure(
     void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
     read_block_reconfigure(mem_ptr, core, addr, size, noc_id, ordering);
+}
+
+void TlbWindow::safe_read_register_reconfigure(
+    void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    read_register_reconfigure(mem_ptr, core, addr, size, noc_id, ordering);
+}
+
+void TlbWindow::safe_write_register_reconfigure(
+    const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
+    write_register_reconfigure(mem_ptr, core, addr, size, noc_id, ordering);
 }
 
 void TlbWindow::safe_noc_multicast_write_reconfigure(

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -16,6 +16,13 @@
 
 namespace tt::umd {
 
+TlbWindow::TlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config) : tlb_handle(std::move(handle)) {
+    tlb_data aligned_config = config;
+    aligned_config.local_offset = config.local_offset & ~(tlb_handle->get_size() - 1);
+    tlb_handle->configure(aligned_config);
+    offset_from_aligned_addr = config.local_offset - (config.local_offset & ~(tlb_handle->get_size() - 1));
+}
+
 tlb_data TlbWindow::make_tlb_config(
     uint64_t addr, tt_xy_pair core_end, NocId noc_id, uint64_t ordering, bool mcast, tt_xy_pair core_start) const {
     tlb_data config{};
@@ -43,13 +50,6 @@ void TlbWindow::transfer_and_reconfigure(tlb_data config, buffer_pointer buffer,
         config.local_offset += transfer_size;
         buffer += transfer_size;
     }
-}
-
-TlbWindow::TlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config) : tlb_handle(std::move(handle)) {
-    tlb_data aligned_config = config;
-    aligned_config.local_offset = config.local_offset & ~(tlb_handle->get_size() - 1);
-    tlb_handle->configure(aligned_config);
-    offset_from_aligned_addr = config.local_offset - (config.local_offset & ~(tlb_handle->get_size() - 1));
 }
 
 void TlbWindow::read_block_reconfigure(

--- a/tests/unified/test_tlb.cpp
+++ b/tests/unified/test_tlb.cpp
@@ -4,10 +4,10 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "tests/test_utils/device_test_utils.hpp"
@@ -20,7 +20,9 @@
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/tlb.hpp"
+#include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/semver.hpp"
 
 using namespace tt;
@@ -490,5 +492,37 @@ TEST(TestTlb, TLBStaticTensix) {
 
     for (int i = 0; i < num_writes; i++) {
         EXPECT_EQ(readback[i], i);
+    }
+}
+
+TEST(TestTlb, TestRegisterReconfigureL1RoundTrip) {
+    if (!is_kmd_version_good()) {
+        GTEST_SKIP() << "Skipping test because of old KMD version. Required version of KMD is 1.34 or higher.";
+    }
+    const ChipId chip = 0;
+    const uint64_t one_mb = 1 << 20;
+    const uint64_t l1_start = 0x100;
+    const size_t test_size = (3 * one_mb / 2) - l1_start;
+    const size_t num_words = test_size / sizeof(uint32_t);
+
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+    PCIDevice* pci_device = cluster->get_tt_device(chip)->get_pci_device();
+    const auto& tensix_cores = cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
+
+    std::vector<uint32_t> pattern(num_words);
+    std::generate(pattern.begin(), pattern.end(), [i = uint32_t{0}]() mutable { return i++ * 0xDEAD0001; });
+
+    const auto cores_end = tensix_cores.begin() + std::min(size_t{4}, tensix_cores.size());
+    for (auto it = tensix_cores.begin(); it != cores_end; ++it) {
+        tt_xy_pair xy{it->x, it->y};
+
+        auto tlb_window = std::make_unique<SiliconTlbWindow>(pci_device->allocate_tlb(one_mb, TlbMapping::UC));
+
+        tlb_window->write_register_reconfigure(pattern.data(), xy, l1_start, test_size, NocId::NOC0);
+
+        std::vector<uint32_t> readback(num_words, 0);
+        tlb_window->read_register_reconfigure(readback.data(), xy, l1_start, test_size, NocId::NOC0);
+
+        EXPECT_EQ(readback, pattern) << "Mismatch on core " << it->str();
     }
 }

--- a/tests/unified/test_tlb.cpp
+++ b/tests/unified/test_tlb.cpp
@@ -500,14 +500,15 @@ TEST(TestTlb, TestRegisterReconfigureL1RoundTrip) {
         GTEST_SKIP() << "Skipping test because of old KMD version. Required version of KMD is 1.34 or higher.";
     }
     const ChipId chip = 0;
-    const uint64_t one_mb = 1 << 20;
     const uint64_t l1_start = 0x100;
-    const size_t test_size = (3 * one_mb / 2) - l1_start;
-    const size_t num_words = test_size / sizeof(uint32_t);
 
     std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
     PCIDevice* pci_device = cluster->get_tt_device(chip)->get_pci_device();
     const auto& tensix_cores = cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
+
+    const size_t num_words = ((1 << 20) + (1 << 17)) / sizeof(uint32_t);
+    const size_t test_size = num_words * sizeof(uint32_t);
+    const size_t tlb_size = 1 << 21;
 
     std::vector<uint32_t> pattern(num_words);
     std::generate(pattern.begin(), pattern.end(), [i = uint32_t{0}]() mutable { return i++ * 0xDEAD0001; });
@@ -516,7 +517,7 @@ TEST(TestTlb, TestRegisterReconfigureL1RoundTrip) {
     for (auto it = tensix_cores.begin(); it != cores_end; ++it) {
         tt_xy_pair xy{it->x, it->y};
 
-        auto tlb_window = std::make_unique<SiliconTlbWindow>(pci_device->allocate_tlb(one_mb, TlbMapping::UC));
+        auto tlb_window = std::make_unique<SiliconTlbWindow>(pci_device->allocate_tlb(tlb_size, TlbMapping::UC));
 
         tlb_window->write_register_reconfigure(pattern.data(), xy, l1_start, test_size, NocId::NOC0);
 


### PR DESCRIPTION
### Issue
#2819 

### Description
This pull request refactors and extends the `TlbWindow` and `SiliconTlbWindow` classes to add new register-level reconfiguration methods, and significantly simplifies the logic for reconfiguring and transferring memory blocks. The changes introduce reusable helper functions and improve maintainability by reducing code duplication.

### List of the changes

* Added new virtual methods to `TlbWindow` for register-level reconfiguration: `read_register_reconfigure`, `write_register_reconfigure`, and their safe variants. These are now also implemented in `SiliconTlbWindow`.

* Introduced a generic `transfer_and_reconfigure` template method and a `make_tlb_config` helper in `TlbWindow` to handle repeated reconfiguration and memory transfer logic, significantly reducing code duplication in block and register transfer methods.

* Updated all relevant methods in `TlbWindow` and `SiliconTlbWindow` to use the new helpers and to provide the new register-level reconfigure functionality.

### Testing
Manual

### API Changes
* Added APIs in TlbWindow for reconfigure read/write of regs
