### PR TITLE
feat(sim): P300 multi-MMIO TTSim — BDF enumeration + outbound-iATU host-DMA routing

### DIFF
--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -203,16 +203,11 @@ jobs:
 
       # bh_x2 is the P300 multichip simulator (both Blackhole chips MMIO-capable). The P300
       # cluster descriptor makes the cluster enumerate both chips, so the standard device-IO
-      # fixtures run across both MMIO chips and the simulated inter-chip eth links.
-      #
-      # continue-on-error: the P300 host-DMA routing programs the outbound iATU via BAR2, which is
-      # only modeled by ttsim builds with the multichip iATU support. The currently pinned ttsim
-      # release does not yet honor those writes (it throws UnimplementedFunctionality), so these
-      # steps are advisory until that ttsim ships. Verified passing locally against a ttsim built
-      # from the multichip branch. Remove continue-on-error once the pinned ttsim models the iATU.
+      # fixtures run across both MMIO chips and the simulated inter-chip eth links. The P300
+      # host-DMA routing programs the outbound iATU via BAR2, which the stable ttsim release
+      # models; verified locally against a ttsim built from the multichip branch.
       - name: Run UMD TestDeviceIOFixture on tt-sim blackhole x2
         timeout-minutes: 1
-        continue-on-error: true
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh_x2/libttsim.so
           TT_UMD_CLUSTER_DESCRIPTOR: blackhole_P300_both_mmio.yaml
@@ -221,7 +216,6 @@ jobs:
 
       - name: Run UMD TTSimDeviceIOFixture on tt-sim blackhole x2
         timeout-minutes: 1
-        continue-on-error: true
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh_x2/libttsim.so
           TT_UMD_CLUSTER_DESCRIPTOR: blackhole_P300_both_mmio.yaml

--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -130,6 +130,10 @@ jobs:
           cp tt-metal/tt_metal/third_party/umd/tests/soc_descs/quasar_32_arch.yaml sim_qsr/soc_descriptor.yaml
           # bh_x2 is two Blackhole chips; reuse the per-chip Blackhole soc descriptor.
           cp $TT_METAL_HOME/tt_metal/soc_descriptors/blackhole_140_arch.yaml sim_bh_x2/soc_descriptor.yaml
+          # Place the P300 cluster descriptor beside the simulator; UMD auto-discovers it (like soc_descriptor.yaml)
+          # and enumerates both MMIO chips. Without it, the sim is a single MMIO chip.
+          cp tt-metal/tt_metal/third_party/umd/tests/cluster_descriptor_examples/blackhole_P300_both_mmio.yaml \
+            sim_bh_x2/cluster_descriptor.yaml
 
       - name: Build UMD api_tests with simulation support
         run: |
@@ -201,16 +205,15 @@ jobs:
         run: |
           tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
 
-      # bh_x2 is the P300 multichip simulator (both Blackhole chips MMIO-capable). The P300
-      # cluster descriptor makes the cluster enumerate both chips, so the standard device-IO
-      # fixtures run across both MMIO chips and the simulated inter-chip eth links. The P300
-      # host-DMA routing programs the outbound iATU via BAR2, which the stable ttsim release
-      # models; verified locally against a ttsim built from the multichip branch.
+      # bh_x2 is the P300 multichip simulator (both Blackhole chips MMIO-capable). The
+      # cluster_descriptor.yaml placed beside the simulator (see "Prepare sim paths") makes UMD
+      # enumerate both chips, so the standard device-IO fixtures run across both MMIO chips and the
+      # simulated inter-chip eth links. The P300 host-DMA routing programs the outbound iATU via BAR2,
+      # which the stable ttsim release models; verified locally against a ttsim built from the multichip branch.
       - name: Run UMD TestDeviceIOFixture on tt-sim blackhole x2
         timeout-minutes: 1
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh_x2/libttsim.so
-          TT_UMD_CLUSTER_DESCRIPTOR: blackhole_P300_both_mmio.yaml
         run: |
           tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
 
@@ -218,7 +221,6 @@ jobs:
         timeout-minutes: 1
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh_x2/libttsim.so
-          TT_UMD_CLUSTER_DESCRIPTOR: blackhole_P300_both_mmio.yaml
         run: |
           tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
 

--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -204,8 +204,15 @@ jobs:
       # bh_x2 is the P300 multichip simulator (both Blackhole chips MMIO-capable). The P300
       # cluster descriptor makes the cluster enumerate both chips, so the standard device-IO
       # fixtures run across both MMIO chips and the simulated inter-chip eth links.
+      #
+      # continue-on-error: the P300 host-DMA routing programs the outbound iATU via BAR2, which is
+      # only modeled by ttsim builds with the multichip iATU support. The currently pinned ttsim
+      # release does not yet honor those writes (it throws UnimplementedFunctionality), so these
+      # steps are advisory until that ttsim ships. Verified passing locally against a ttsim built
+      # from the multichip branch. Remove continue-on-error once the pinned ttsim models the iATU.
       - name: Run UMD TestDeviceIOFixture on tt-sim blackhole x2
         timeout-minutes: 1
+        continue-on-error: true
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh_x2/libttsim.so
           TT_UMD_CLUSTER_DESCRIPTOR: blackhole_P300_both_mmio.yaml
@@ -214,6 +221,7 @@ jobs:
 
       - name: Run UMD TTSimDeviceIOFixture on tt-sim blackhole x2
         timeout-minutes: 1
+        continue-on-error: true
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh_x2/libttsim.so
           TT_UMD_CLUSTER_DESCRIPTOR: blackhole_P300_both_mmio.yaml

--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -89,6 +89,14 @@ jobs:
           fileName: "libttsim_bh.so"
           out-file-path: /tmp/ttsim-bh
 
+      - name: Download ttsim binary (bh_x2)
+        uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f  # v1.13
+        with:
+          repository: tenstorrent/ttsim
+          tag: ${{ steps.get-ttsim-version.outputs.ttsim-version }}
+          fileName: "libttsim_bh_x2.so"
+          out-file-path: /tmp/ttsim-bh-x2
+
       - name: Download ttsim binary (qsr)
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f  # v1.13
         with:
@@ -112,13 +120,16 @@ jobs:
       - name: Prepare sim paths
         run: |
           echo "Preparing sim paths"
-          mkdir -p sim_wh sim_bh sim_qsr
+          mkdir -p sim_wh sim_bh sim_qsr sim_bh_x2
           mv /tmp/ttsim-wh/libttsim_wh.so sim_wh/libttsim.so
           mv /tmp/ttsim-bh/libttsim_bh.so sim_bh/libttsim.so
           mv /tmp/ttsim-qsr/libttsim_qsr.so sim_qsr/libttsim.so
+          mv /tmp/ttsim-bh-x2/libttsim_bh_x2.so sim_bh_x2/libttsim.so
           cp $TT_METAL_HOME/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml sim_wh/soc_descriptor.yaml
           cp $TT_METAL_HOME/tt_metal/soc_descriptors/blackhole_140_arch.yaml sim_bh/soc_descriptor.yaml
           cp tt-metal/tt_metal/third_party/umd/tests/soc_descs/quasar_32_arch.yaml sim_qsr/soc_descriptor.yaml
+          # bh_x2 is two Blackhole chips; reuse the per-chip Blackhole soc descriptor.
+          cp $TT_METAL_HOME/tt_metal/soc_descriptors/blackhole_140_arch.yaml sim_bh_x2/soc_descriptor.yaml
 
       - name: Build UMD api_tests with simulation support
         run: |
@@ -187,6 +198,25 @@ jobs:
         timeout-minutes: 1
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_qsr/libttsim.so
+        run: |
+          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
+
+      # bh_x2 is the P300 multichip simulator (both Blackhole chips MMIO-capable). The P300
+      # cluster descriptor makes the cluster enumerate both chips, so the standard device-IO
+      # fixtures run across both MMIO chips and the simulated inter-chip eth links.
+      - name: Run UMD TestDeviceIOFixture on tt-sim blackhole x2
+        timeout-minutes: 1
+        env:
+          TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh_x2/libttsim.so
+          TT_UMD_CLUSTER_DESCRIPTOR: blackhole_P300_both_mmio.yaml
+        run: |
+          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
+
+      - name: Run UMD TTSimDeviceIOFixture on tt-sim blackhole x2
+        timeout-minutes: 1
+        env:
+          TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh_x2/libttsim.so
+          TT_UMD_CLUSTER_DESCRIPTOR: blackhole_P300_both_mmio.yaml
         run: |
           tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
 

--- a/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
@@ -21,8 +21,20 @@ namespace tt::umd {
 
 class SimulationSysmemManager : public SysmemManager {
 public:
-    SimulationSysmemManager(uint32_t num_host_mem_channels, tt::ARCH arch);
+    SimulationSysmemManager(uint32_t num_host_mem_channels, tt::ARCH arch, uint32_t chip_id = 0);
     ~SimulationSysmemManager() override;
+
+    // Per-chip host base for this chip's sysmem. On silicon each chip's pinned host memory lives at a
+    // distinct host physical address; UMD programs that address into the chip's outbound iATU as the
+    // region target, and the chip's DMA resolves there purely by address (no per-chip "magic"). We
+    // model that by giving chip N a distinct host base (N * kPerChipHostStride) and using it as the
+    // hugepage physical_address (= iATU target). The simulator's host-side DMA router (dma_route) then
+    // routes by which chip's [host_base, host_base + kPerChipHostStride) window contains the address.
+    static constexpr uint64_t kPerChipHostStride = 1ULL << 36;  // 64 GiB; >> per-chip sysmem, non-overlapping
+
+    uint64_t get_host_base() const { return host_base_; }
+
+    uint64_t get_host_region_size() const { return kPerChipHostStride; }
 
     bool pin_or_map_sysmem_to_device() override;
 
@@ -76,6 +88,7 @@ private:
 
     uint8_t* system_memory_ = nullptr;
     size_t system_memory_size_ = 0;
+    uint64_t host_base_ = 0;  // this chip's distinct host-physical base (= chip_id * kPerChipHostStride)
     std::vector<std::pair<void*, size_t>> owned_allocations_;
     std::shared_ptr<MappedBufferRegistry> registry_;
 };

--- a/device/api/umd/device/simulation/simulation_chip.hpp
+++ b/device/api/umd/device/simulation/simulation_chip.hpp
@@ -38,6 +38,9 @@ class SocDescriptor;
 class SimulationChip : public Chip {
 public:
     static std::string get_soc_descriptor_path_from_simulator_path(const std::filesystem::path& simulator_path);
+    // An optional cluster_descriptor.yaml beside the simulator describes a (possibly multichip) topology.
+    // Returns the path where it would live; the file is not required to exist.
+    static std::string get_cluster_descriptor_path_from_simulator_path(const std::filesystem::path& simulator_path);
 
     static std::unique_ptr<SimulationChip> create(
         const std::filesystem::path& simulator_directory,

--- a/device/api/umd/device/simulation/tt_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/tt_sim_communicator.hpp
@@ -6,6 +6,7 @@
 
 #include <sys/types.h>
 
+#include <array>
 #include <cstdint>
 #include <filesystem>
 #include <functional>
@@ -250,14 +251,25 @@ private:
     std::function<void(uint64_t, void *, uint32_t)> pci_dma_mem_rd_bytes_callback_;
     std::function<void(uint64_t, const void *, uint32_t)> pci_dma_mem_wr_bytes_callback_;
 
-    // Known limitation: callback_instance_ is process-global; in multichip mode,
-    // only the last chip to call set_pcie_dma_mem_callbacks receives correct DMA
-    // callbacks.  Fix requires libttsim ABI change to support per-chip context pointer.
+    // Per-MMIO-device DMA routing. Each MMIO device has its own host sysmem, so a sysmem
+    // DMA must reach the originating device's callback -- e.g. an eth tunnel staging a
+    // remote chip's FW reads it from its MMIO peer's sysmem, not whichever device happened
+    // to register last. The sim tags each DMA paddr with the current chip
+    // (paddr / kPerDevicePaddrStride, matching the BAR path in libttsim_pci_mem_rd_bytes),
+    // so the wrapper decodes the device and routes to dma_instances_[device]. The within-
+    // device offset is always << the stride. callback_instance_ stays as the device-0 /
+    // single-device fallback (untagged paddr decodes to device 0).
+    static constexpr uint64_t kPerDevicePaddrStride = 0x1000000000ull;  // 64GiB; matches libttsim PER_DEVICE_PADDR_STRIDE
+    static constexpr std::size_t kMaxDmaDevices = 32;
     static TTSimCommunicator *callback_instance_;
+    static std::array<TTSimCommunicator *, kMaxDmaDevices> dma_instances_;
 
     // Static wrapper functions for C-style callbacks.
     static void pci_dma_mem_rd_bytes_wrapper(uint64_t paddr, void *p, uint32_t size);
     static void pci_dma_mem_wr_bytes_wrapper(uint64_t paddr, const void *p, uint32_t size);
+    // Decode the originating device from a tagged DMA paddr (strips the device stride in
+    // place) and return its communicator, falling back to callback_instance_.
+    static TTSimCommunicator *dma_route(uint64_t &paddr);
 
     // Thread safety. In multichip shared-dlopen mode, libttsim_select_device_by_id()
     // and the following libttsim I/O call must be serialized across all

--- a/device/api/umd/device/simulation/tt_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/tt_sim_communicator.hpp
@@ -130,7 +130,9 @@ public:
      */
     void set_pcie_dma_mem_callbacks(
         std::function<void(uint64_t, void *, uint32_t)> pfn_pci_dma_mem_rd_bytes,
-        std::function<void(uint64_t, const void *, uint32_t)> pfn_pci_dma_mem_wr_bytes);
+        std::function<void(uint64_t, const void *, uint32_t)> pfn_pci_dma_mem_wr_bytes,
+        uint64_t host_base = 0,
+        uint64_t host_size = 0);
 
     void start_sim();
 
@@ -200,8 +202,10 @@ private:
     // model in docs/multichip/ARCHITECTURE.md. No libttsim_select_device_by_id; the
     // device is carried in the PCI config BDF and in the per-device BAR physical address.
     bool shared_bdf_mode_ = false;
+
     // Both modes use the single shared dlopen (s_shared_handle_) + refcount.
     bool uses_shared_handle() const { return multichip_mode_ || shared_bdf_mode_; }
+
     uint32_t chip_id_ = 0;
     uint32_t num_chips_ = 1;
     static void *s_shared_handle_;
@@ -251,25 +255,29 @@ private:
     std::function<void(uint64_t, void *, uint32_t)> pci_dma_mem_rd_bytes_callback_;
     std::function<void(uint64_t, const void *, uint32_t)> pci_dma_mem_wr_bytes_callback_;
 
-    // Per-MMIO-device DMA routing. Each MMIO device has its own host sysmem, and each chip's
-    // outbound iATU maps its (identical) NOC sysmem window onto that chip's own hugepage. The
-    // sim models that iATU on the chip side: it translates each sysmem DMA to the originating
-    // chip's host region (paddr + chip * stride). So here on the host side of the bus we route
-    // purely by the resulting *address* -- device = paddr / kPerDevicePaddrStride -> the owning
-    // device's callback (dma_instances_[device]) -- exactly like the BAR path in
-    // libttsim_pci_mem_rd_bytes. No chip id crosses the callback; the address already carries the
-    // iATU's per-device targeting. The within-window offset is always << the stride.
-    // callback_instance_ stays as the device-0 / single-device fallback.
-    static constexpr uint64_t kPerDevicePaddrStride = 0x1000000000ull;  // 64GiB; matches libttsim PER_DEVICE_PADDR_STRIDE
+    // Host-side DMA routing by address range. Each MMIO chip's outbound iATU (programmed by UMD via
+    // BAR2, honored by the sim) maps the chip's NOC sysmem window onto that chip's distinct host base.
+    // So a sysmem DMA arrives here carrying a real host address; we find the owning chip by which
+    // registered window [host_base, host_base+size) contains it -- exactly as a host/OS routes a DMA by
+    // which pinned region the address falls in. No chip id crosses the bus; the address alone targets.
+    // callback_instance_ stays as the single-device / unregistered fallback.
+    struct DmaHostRange {
+        uint64_t host_base = 0;
+        uint64_t host_size = 0;
+        TTSimCommunicator *inst = nullptr;
+    };
+
     static constexpr std::size_t kMaxDmaDevices = 32;
     static TTSimCommunicator *callback_instance_;
-    static std::array<TTSimCommunicator *, kMaxDmaDevices> dma_instances_;
+    static std::array<DmaHostRange, kMaxDmaDevices> dma_ranges_;
+    static std::size_t dma_range_count_;
+    static std::mutex dma_ranges_mutex_;
 
     // Static wrapper functions for C-style callbacks.
     static void pci_dma_mem_rd_bytes_wrapper(uint64_t paddr, void *p, uint32_t size);
     static void pci_dma_mem_wr_bytes_wrapper(uint64_t paddr, const void *p, uint32_t size);
-    // Decode the originating device from a tagged DMA paddr (strips the device stride in
-    // place) and return its communicator, falling back to callback_instance_.
+    // Find the chip whose registered host window contains paddr, rebase paddr to the within-window
+    // offset, and return its communicator. Falls back to callback_instance_ if no window matches.
     static TTSimCommunicator *dma_route(uint64_t &paddr);
 
     // Thread safety. In multichip shared-dlopen mode, libttsim_select_device_by_id()

--- a/device/api/umd/device/simulation/tt_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/tt_sim_communicator.hpp
@@ -30,7 +30,10 @@ public:
      *   for legacy single-chip consumers.
      */
     TTSimCommunicator(
-        const std::filesystem::path &simulator_directory, bool copy_sim_binary = false, uint32_t chip_id = 0);
+        const std::filesystem::path &simulator_directory,
+        bool copy_sim_binary = false,
+        uint32_t chip_id = 0,
+        uint32_t num_chips = 1);
 
     /**
      * Destructor that properly cleans up library handles and file descriptors.
@@ -190,7 +193,16 @@ private:
     // True when the loaded .so supports the multichip ABI and this
     // communicator is using the shared dlopen path.
     bool multichip_mode_ = false;
+    // True when the .so has NO multichip ABI but the cluster has >1 chip: all
+    // communicators share a single dlopen (so the simulator's per-chip state array is
+    // shared) and each chip is addressed by its PCI device (BDF) -- the host-enumeration
+    // model in docs/multichip/ARCHITECTURE.md. No libttsim_select_device_by_id; the
+    // device is carried in the PCI config BDF and in the per-device BAR physical address.
+    bool shared_bdf_mode_ = false;
+    // Both modes use the single shared dlopen (s_shared_handle_) + refcount.
+    bool uses_shared_handle() const { return multichip_mode_ || shared_bdf_mode_; }
     uint32_t chip_id_ = 0;
+    uint32_t num_chips_ = 1;
     static void *s_shared_handle_;
     static int s_shared_refcount_;
     static bool s_sim_initialized_;

--- a/device/api/umd/device/simulation/tt_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/tt_sim_communicator.hpp
@@ -251,14 +251,15 @@ private:
     std::function<void(uint64_t, void *, uint32_t)> pci_dma_mem_rd_bytes_callback_;
     std::function<void(uint64_t, const void *, uint32_t)> pci_dma_mem_wr_bytes_callback_;
 
-    // Per-MMIO-device DMA routing. Each MMIO device has its own host sysmem, so a sysmem
-    // DMA must reach the originating device's callback -- e.g. an eth tunnel staging a
-    // remote chip's FW reads it from its MMIO peer's sysmem, not whichever device happened
-    // to register last. The sim tags each DMA paddr with the current chip
-    // (paddr / kPerDevicePaddrStride, matching the BAR path in libttsim_pci_mem_rd_bytes),
-    // so the wrapper decodes the device and routes to dma_instances_[device]. The within-
-    // device offset is always << the stride. callback_instance_ stays as the device-0 /
-    // single-device fallback (untagged paddr decodes to device 0).
+    // Per-MMIO-device DMA routing. Each MMIO device has its own host sysmem, and each chip's
+    // outbound iATU maps its (identical) NOC sysmem window onto that chip's own hugepage. The
+    // sim models that iATU on the chip side: it translates each sysmem DMA to the originating
+    // chip's host region (paddr + chip * stride). So here on the host side of the bus we route
+    // purely by the resulting *address* -- device = paddr / kPerDevicePaddrStride -> the owning
+    // device's callback (dma_instances_[device]) -- exactly like the BAR path in
+    // libttsim_pci_mem_rd_bytes. No chip id crosses the callback; the address already carries the
+    // iATU's per-device targeting. The within-window offset is always << the stride.
+    // callback_instance_ stays as the device-0 / single-device fallback.
     static constexpr uint64_t kPerDevicePaddrStride = 0x1000000000ull;  // 64GiB; matches libttsim PER_DEVICE_PADDR_STRIDE
     static constexpr std::size_t kMaxDmaDevices = 32;
     static TTSimCommunicator *callback_instance_;

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -35,7 +35,8 @@ public:
         const SocDescriptor &soc_descriptor,
         ChipId chip_id,
         bool copy_sim_binary = false,
-        int num_host_mem_channels = 0);
+        int num_host_mem_channels = 0,
+        size_t num_chips = 1);
     ~TTSimTTDevice();
 
     static std::unique_ptr<TTSimTTDevice> create(

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -53,6 +53,11 @@ public:
     void read_from_device(void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
     void write_to_device(const void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
 
+    // Configure this chip's outbound iATU (NOC->host) the silicon way: iATU register writes via BAR2.
+    // The simulator decodes these into its iATU model and honors them at DMA egress, so the chip's DMA
+    // resolves to this chip's distinct host base (configured as the region target) purely by address.
+    void configure_iatu_region(size_t region, uint64_t target, size_t region_size) override;
+
     void dma_d2h(void *dst, uint32_t src, size_t size) override;
     void dma_d2h_zero_copy(void *dst, uint32_t src, size_t size) override;
     void dma_h2d(uint32_t dst, const void *src, size_t size) override;

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -32,8 +32,12 @@ uint64_t align_up(uint64_t value, uint64_t alignment) { return (value + alignmen
 
 }  // namespace
 
-SimulationSysmemManager::SimulationSysmemManager(uint32_t num_host_mem_channels, tt::ARCH arch) {
+SimulationSysmemManager::SimulationSysmemManager(uint32_t num_host_mem_channels, tt::ARCH arch, uint32_t chip_id) {
+    // pcie_base_ is the chip-side NOC sysmem-window base (fixed per arch; used for buffers' NOC addresses).
+    // host_base_ is this chip's distinct host-physical base -- what UMD programs as the outbound-iATU
+    // region target, so each chip's DMA lands in its own host window with no per-chip tag at egress.
     pcie_base_ = get_pcie_base_for_arch(arch);
+    host_base_ = uint64_t(chip_id) * kPerChipHostStride;
     registry_ = std::make_shared<MappedBufferRegistry>();
     SimulationSysmemManager::init_sysmem(num_host_mem_channels);
 }
@@ -72,8 +76,11 @@ bool SimulationSysmemManager::init_sysmem(uint32_t num_host_mem_channels) {
 
     for (int i = 0; i < num_host_mem_channels; i++) {
         size_t channel_size = (i == 3 && num_host_mem_channels == 4) ? (768 * (1ULL << 20)) : (1ULL << 30);
+        // physical_address is this chip's host base for the channel -- what UMD programs as the outbound
+        // iATU region target (host_base_ is per-chip distinct). The chip-side NOC sysmem-window address is
+        // separate (get_pcie_base_addr_from_device), so the iATU maps NOC-window offset -> this host base.
         hugepage_mapping_per_channel.push_back(
-            {system_memory_ + i * (1ULL << 30), channel_size, pcie_base_ + i * (1ULL << 30)});
+            {system_memory_ + i * (1ULL << 30), channel_size, host_base_ + i * (1ULL << 30)});
     }
 
     return true;

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -367,6 +367,24 @@ Cluster::Cluster(ClusterOptions options) {
         case ChipType::SWEMULE:
         case ChipType::SIMULATION: {
             if (options.cluster_descriptor == nullptr) {
+#ifdef TT_UMD_BUILD_SIMULATION
+                // A ttsim .so may ship a cluster_descriptor.yaml beside it describing a real (possibly multichip)
+                // topology, mirroring the soc_descriptor.yaml convention. When present, use it and target every
+                // chip it declares (e.g. both MMIO chips of a P300); otherwise fall through to the mock
+                // single-chip descriptor below (unchanged behaviour).
+                if (options.chip_type == ChipType::SIMULATION && options.simulator_directory.extension() == ".so") {
+                    std::string cluster_desc_path =
+                        SimulationChip::get_cluster_descriptor_path_from_simulator_path(options.simulator_directory);
+                    if (std::filesystem::exists(cluster_desc_path)) {
+                        std::unique_ptr<ClusterDescriptor> full_cluster_desc =
+                            ClusterDescriptor::create_from_yaml(cluster_desc_path);
+                        options.target_devices = full_cluster_desc->get_all_chips();
+                        cluster_desc = ClusterDescriptor::create_constrained_cluster_descriptor(
+                            full_cluster_desc.get(), options.target_devices);
+                        break;
+                    }
+                }
+#endif
                 // If no custom descriptor is provided, in case of mock or simulation chip type, we create a mock
                 // cluster descriptor from passed target devices.
                 auto arch = tt::ARCH::WORMHOLE_B0;

--- a/device/simulation/simulation_chip.cpp
+++ b/device/simulation/simulation_chip.cpp
@@ -36,6 +36,12 @@ std::string SimulationChip::get_soc_descriptor_path_from_simulator_path(const st
                                                  : (simulator_path / "soc_descriptor.yaml");
 }
 
+std::string SimulationChip::get_cluster_descriptor_path_from_simulator_path(
+    const std::filesystem::path& simulator_path) {
+    return (simulator_path.extension() == ".so") ? (simulator_path.parent_path() / "cluster_descriptor.yaml")
+                                                 : (simulator_path / "cluster_descriptor.yaml");
+}
+
 SimulationChip::SimulationChip(
     const std::filesystem::path& simulator_directory,
     const SocDescriptor& soc_descriptor,

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -179,9 +179,7 @@ void TTSimCommunicator::initialize() {
         shared_bdf_mode_ = true;
         s_shared_refcount_++;
         log_info(
-            tt::LogEmulationDriver,
-            "TTSim BDF multichip mode (chip_id={}, shared dlopen, per-device BARs)",
-            chip_id_);
+            tt::LogEmulationDriver, "TTSim BDF multichip mode (chip_id={}, shared dlopen, per-device BARs)", chip_id_);
         return;
     }
 
@@ -301,7 +299,7 @@ uint32_t TTSimCommunicator::pci_config_read32(uint32_t bus_device_function, uint
     // Callers pass bus_device_function 0 ("this device"); we fill in the device field.
     uint32_t bdf = bus_device_function;
     if (shared_bdf_mode_) {
-        bdf |= (chip_id_ << 3); // BDF: function[2:0], device[7:3], bus[15:8]
+        bdf |= (chip_id_ << 3);  // BDF: function[2:0], device[7:3], bus[15:8]
     }
     select_chip_if_needed();  // no-op outside the multichip-ABI mode
     return pfn_libttsim_pci_config_rd32_(bdf, offset);
@@ -323,17 +321,27 @@ void TTSimCommunicator::advance_clock(uint32_t n_clocks) {
 }
 
 TTSimCommunicator *TTSimCommunicator::callback_instance_ = nullptr;
-std::array<TTSimCommunicator *, TTSimCommunicator::kMaxDmaDevices> TTSimCommunicator::dma_instances_{};
+std::array<TTSimCommunicator::DmaHostRange, TTSimCommunicator::kMaxDmaDevices> TTSimCommunicator::dma_ranges_{};
+std::size_t TTSimCommunicator::dma_range_count_ = 0;
+std::mutex TTSimCommunicator::dma_ranges_mutex_;
 
-// Decode the originating MMIO device from a sim-tagged sysmem DMA paddr and return its
-// communicator plus the within-device offset. The sim adds device * kPerDevicePaddrStride
-// (see libttsim_pci_dma_mem_{rd,wr}_bytes); strip it and look the device up. Falls back to
-// callback_instance_ for the single-device / legacy path (device 0, no registered entry).
+// Route a sysmem DMA to the owning MMIO chip by host address: the address the chip emits already went
+// through its outbound iATU (UMD-programmed target = that chip's distinct host base), so we just find
+// the registered host window [host_base, host_base+size) that contains it -- exactly as a host routes a
+// DMA by which pinned region the physical address falls in. Rebase paddr to the within-window offset (so
+// the per-chip callback sees an offset relative to its own host base, like the single-device case) and
+// return the owning communicator. Falls back to callback_instance_ when no window matches (single
+// device, or an address outside any registered region).
 TTSimCommunicator *TTSimCommunicator::dma_route(uint64_t &paddr) {
-    uint32_t device = static_cast<uint32_t>(paddr / kPerDevicePaddrStride);
-    paddr -= static_cast<uint64_t>(device) * kPerDevicePaddrStride;
-    TTSimCommunicator *inst = (device < kMaxDmaDevices) ? dma_instances_[device] : nullptr;
-    return inst ? inst : callback_instance_;
+    std::lock_guard<std::mutex> lock(dma_ranges_mutex_);
+    for (std::size_t i = 0; i < dma_range_count_; i++) {
+        const DmaHostRange &r = dma_ranges_[i];
+        if (paddr >= r.host_base && paddr - r.host_base < r.host_size) {
+            paddr -= r.host_base;
+            return r.inst;
+        }
+    }
+    return callback_instance_;
 }
 
 void TTSimCommunicator::pci_dma_mem_rd_bytes_wrapper(uint64_t paddr, void *p, uint32_t size) {
@@ -352,15 +360,29 @@ void TTSimCommunicator::pci_dma_mem_wr_bytes_wrapper(uint64_t paddr, const void 
 
 void TTSimCommunicator::set_pcie_dma_mem_callbacks(
     std::function<void(uint64_t, void *, uint32_t)> pfn_pci_dma_mem_rd_bytes,
-    std::function<void(uint64_t, const void *, uint32_t)> pfn_pci_dma_mem_wr_bytes) {
+    std::function<void(uint64_t, const void *, uint32_t)> pfn_pci_dma_mem_wr_bytes,
+    uint64_t host_base,
+    uint64_t host_size) {
     std::lock_guard<std::mutex> lock(device_lock_);
     pci_dma_mem_rd_bytes_callback_ = std::move(pfn_pci_dma_mem_rd_bytes);
     pci_dma_mem_wr_bytes_callback_ = std::move(pfn_pci_dma_mem_wr_bytes);
     callback_instance_ = this;
-    // Register this device for per-device DMA routing (dma_route()). chip_id_ is the BDF
-    // device index in multi-MMIO mode, so the sim's paddr tag (g_current_chip_id) lands here.
-    if (chip_id_ < kMaxDmaDevices) {
-        dma_instances_[chip_id_] = this;
+    // Register this chip's host window for address-range DMA routing (dma_route()). The chip's outbound
+    // iATU targets this window, so DMAs land here by address alone -- no per-chip tag. host_size==0
+    // (legacy / single-device) registers nothing and relies on the callback_instance_ fallback.
+    if (host_size != 0) {
+        std::lock_guard<std::mutex> ranges_lock(dma_ranges_mutex_);
+        bool updated = false;
+        for (std::size_t i = 0; i < dma_range_count_; i++) {
+            if (dma_ranges_[i].inst == this) {  // re-registration: update in place
+                dma_ranges_[i] = {host_base, host_size, this};
+                updated = true;
+                break;
+            }
+        }
+        if (!updated && dma_range_count_ < kMaxDmaDevices) {
+            dma_ranges_[dma_range_count_++] = {host_base, host_size, this};
+        }
     }
     // The DMA callbacks are process-global, and libttsim forbids (re)registering them
     // once the simulator is running. With one shared simulator across chips, only the

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -343,6 +343,14 @@ void TTSimCommunicator::set_pcie_dma_mem_callbacks(
     pci_dma_mem_rd_bytes_callback_ = std::move(pfn_pci_dma_mem_rd_bytes);
     pci_dma_mem_wr_bytes_callback_ = std::move(pfn_pci_dma_mem_wr_bytes);
     callback_instance_ = this;
+    // The DMA callbacks are process-global, and libttsim forbids (re)registering them
+    // once the simulator is running. With one shared simulator across chips, only the
+    // first chip -- which runs libttsim_init in start_sim() -- registers them, before
+    // init. Later chips just record their callback (last-writer-wins, the pre-existing
+    // single-instance limitation) and skip the now-illegal re-registration.
+    if (uses_shared_handle() && s_sim_initialized_) {
+        return;
+    }
     pfn_libttsim_set_pci_dma_mem_callbacks_(pci_dma_mem_rd_bytes_wrapper, pci_dma_mem_wr_bytes_wrapper);
 }
 

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -323,16 +323,30 @@ void TTSimCommunicator::advance_clock(uint32_t n_clocks) {
 }
 
 TTSimCommunicator *TTSimCommunicator::callback_instance_ = nullptr;
+std::array<TTSimCommunicator *, TTSimCommunicator::kMaxDmaDevices> TTSimCommunicator::dma_instances_{};
+
+// Decode the originating MMIO device from a sim-tagged sysmem DMA paddr and return its
+// communicator plus the within-device offset. The sim adds device * kPerDevicePaddrStride
+// (see libttsim_pci_dma_mem_{rd,wr}_bytes); strip it and look the device up. Falls back to
+// callback_instance_ for the single-device / legacy path (device 0, no registered entry).
+TTSimCommunicator *TTSimCommunicator::dma_route(uint64_t &paddr) {
+    uint32_t device = static_cast<uint32_t>(paddr / kPerDevicePaddrStride);
+    paddr -= static_cast<uint64_t>(device) * kPerDevicePaddrStride;
+    TTSimCommunicator *inst = (device < kMaxDmaDevices) ? dma_instances_[device] : nullptr;
+    return inst ? inst : callback_instance_;
+}
 
 void TTSimCommunicator::pci_dma_mem_rd_bytes_wrapper(uint64_t paddr, void *p, uint32_t size) {
-    if (callback_instance_ && callback_instance_->pci_dma_mem_rd_bytes_callback_) {
-        callback_instance_->pci_dma_mem_rd_bytes_callback_(paddr, p, size);
+    TTSimCommunicator *inst = dma_route(paddr);
+    if (inst && inst->pci_dma_mem_rd_bytes_callback_) {
+        inst->pci_dma_mem_rd_bytes_callback_(paddr, p, size);
     }
 }
 
 void TTSimCommunicator::pci_dma_mem_wr_bytes_wrapper(uint64_t paddr, const void *p, uint32_t size) {
-    if (callback_instance_ && callback_instance_->pci_dma_mem_wr_bytes_callback_) {
-        callback_instance_->pci_dma_mem_wr_bytes_callback_(paddr, p, size);
+    TTSimCommunicator *inst = dma_route(paddr);
+    if (inst && inst->pci_dma_mem_wr_bytes_callback_) {
+        inst->pci_dma_mem_wr_bytes_callback_(paddr, p, size);
     }
 }
 
@@ -343,6 +357,11 @@ void TTSimCommunicator::set_pcie_dma_mem_callbacks(
     pci_dma_mem_rd_bytes_callback_ = std::move(pfn_pci_dma_mem_rd_bytes);
     pci_dma_mem_wr_bytes_callback_ = std::move(pfn_pci_dma_mem_wr_bytes);
     callback_instance_ = this;
+    // Register this device for per-device DMA routing (dma_route()). chip_id_ is the BDF
+    // device index in multi-MMIO mode, so the sim's paddr tag (g_current_chip_id) lands here.
+    if (chip_id_ < kMaxDmaDevices) {
+        dma_instances_[chip_id_] = this;
+    }
     // The DMA callbacks are process-global, and libttsim forbids (re)registering them
     // once the simulator is running. With one shared simulator across chips, only the
     // first chip -- which runs libttsim_init in start_sim() -- registers them, before

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -49,6 +49,22 @@ TTSimCommunicator::TTSimCommunicator(
     num_chips_(num_chips) {}
 
 TTSimCommunicator::~TTSimCommunicator() {
+    // Unregister from the process-global DMA routing tables first. The shared simulator may still be
+    // alive (other chips not yet destructed) and could emit a DMA; leaving a stale entry/callback
+    // pointing at this freed communicator would route into freed memory (use-after-free).
+    {
+        std::lock_guard<std::mutex> ranges_lock(dma_ranges_mutex_);
+        for (std::size_t i = 0; i < dma_range_count_; i++) {
+            if (dma_ranges_[i].inst == this) {
+                dma_ranges_[i] = dma_ranges_[dma_range_count_ - 1];  // compact: move last into the hole
+                dma_ranges_[--dma_range_count_] = {};
+                break;
+            }
+        }
+        if (callback_instance_ == this) {
+            callback_instance_ = nullptr;
+        }
+    }
     if (uses_shared_handle()) {
         // Shared dlopen -- decrement refcount. When last communicator
         // destructs, call libttsim_exit (which the deferred shutdown()
@@ -64,7 +80,14 @@ TTSimCommunicator::~TTSimCommunicator() {
             s_sim_initialized_ = false;
         }
     } else if (libttsim_handle_) {
-        dlclose(libttsim_handle_);
+        // If initialize() threw after aliasing s_shared_handle_ (the probe keeps that handle) but
+        // before committing to a shared-handle mode, libttsim_handle_ may equal s_shared_handle_. It is
+        // owned by the shared-refcount path; dlclosing it here would leave other communicators with a
+        // dangling s_shared_handle_.
+        std::lock_guard<std::mutex> lock(s_shared_init_mutex_);
+        if (libttsim_handle_ != s_shared_handle_) {
+            dlclose(libttsim_handle_);
+        }
     }
     close_simulator_binary();
 }
@@ -299,7 +322,10 @@ uint32_t TTSimCommunicator::pci_config_read32(uint32_t bus_device_function, uint
     // Callers pass bus_device_function 0 ("this device"); we fill in the device field.
     uint32_t bdf = bus_device_function;
     if (shared_bdf_mode_) {
-        bdf |= (chip_id_ << 3);  // BDF: function[2:0], device[7:3], bus[15:8]
+        // BDF: function[2:0], device[7:3], bus[15:8]. The device field is only 5 bits, so chip_id >= 32
+        // would silently overflow into the bus field and misroute. Fail loudly instead.
+        UMD_ASSERT(chip_id_ < 32, error::RuntimeError, "BDF device field is 5 bits; chip_id must be < 32 in BDF mode.");
+        bdf |= (chip_id_ << 3);
     }
     select_chip_if_needed();  // no-op outside the multichip-ABI mode
     return pfn_libttsim_pci_config_rd32_(bdf, offset);
@@ -366,22 +392,27 @@ void TTSimCommunicator::set_pcie_dma_mem_callbacks(
     std::lock_guard<std::mutex> lock(device_lock_);
     pci_dma_mem_rd_bytes_callback_ = std::move(pfn_pci_dma_mem_rd_bytes);
     pci_dma_mem_wr_bytes_callback_ = std::move(pfn_pci_dma_mem_wr_bytes);
-    callback_instance_ = this;
-    // Register this chip's host window for address-range DMA routing (dma_route()). The chip's outbound
-    // iATU targets this window, so DMAs land here by address alone -- no per-chip tag. host_size==0
-    // (legacy / single-device) registers nothing and relies on the callback_instance_ fallback.
-    if (host_size != 0) {
+    // callback_instance_ and dma_ranges_ are both read by dma_route() under dma_ranges_mutex_, so they
+    // must be written under that same mutex (not device_lock_) to avoid a data race with DMA callbacks.
+    {
         std::lock_guard<std::mutex> ranges_lock(dma_ranges_mutex_);
-        bool updated = false;
-        for (std::size_t i = 0; i < dma_range_count_; i++) {
-            if (dma_ranges_[i].inst == this) {  // re-registration: update in place
-                dma_ranges_[i] = {host_base, host_size, this};
-                updated = true;
-                break;
+        callback_instance_ = this;
+        // Register this chip's host window for address-range DMA routing (dma_route()). The chip's
+        // outbound iATU targets this window, so DMAs land here by address alone -- no per-chip tag.
+        // host_size==0 (legacy / single-device) registers nothing and relies on the callback_instance_
+        // fallback.
+        if (host_size != 0) {
+            bool updated = false;
+            for (std::size_t i = 0; i < dma_range_count_; i++) {
+                if (dma_ranges_[i].inst == this) {  // re-registration: update in place
+                    dma_ranges_[i] = {host_base, host_size, this};
+                    updated = true;
+                    break;
+                }
             }
-        }
-        if (!updated && dma_range_count_ < kMaxDmaDevices) {
-            dma_ranges_[dma_range_count_++] = {host_base, host_size, this};
+            if (!updated && dma_range_count_ < kMaxDmaDevices) {
+                dma_ranges_[dma_range_count_++] = {host_base, host_size, this};
+            }
         }
     }
     // The DMA callbacks are process-global, and libttsim forbids (re)registering them

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -42,11 +42,14 @@ std::mutex TTSimCommunicator::s_shared_init_mutex_;
 std::mutex TTSimCommunicator::device_lock_;
 
 TTSimCommunicator::TTSimCommunicator(
-    const std::filesystem::path &simulator_directory, bool copy_sim_binary, uint32_t chip_id) :
-    simulator_directory_(simulator_directory), copy_sim_binary_(copy_sim_binary), chip_id_(chip_id) {}
+    const std::filesystem::path &simulator_directory, bool copy_sim_binary, uint32_t chip_id, uint32_t num_chips) :
+    simulator_directory_(simulator_directory),
+    copy_sim_binary_(copy_sim_binary),
+    chip_id_(chip_id),
+    num_chips_(num_chips) {}
 
 TTSimCommunicator::~TTSimCommunicator() {
-    if (multichip_mode_) {
+    if (uses_shared_handle()) {
         // Shared dlopen -- decrement refcount. When last communicator
         // destructs, call libttsim_exit (which the deferred shutdown()
         // path didn't call), then dlclose. The simulator is process-global,
@@ -150,6 +153,38 @@ void TTSimCommunicator::initialize() {
         return;
     }
 
+    // No multichip ABI, but a multi-chip cluster: share a single dlopen so all chips
+    // live in one libttsim process image (one shared per-chip state array), and address
+    // each chip by its PCI device (BDF) + per-device BAR window. This is the BDF
+    // host-enumeration path (docs/multichip/ARCHITECTURE.md) -- no select_device_by_id,
+    // no virtual eth switch (the simulator routes inter-chip eth internally).
+    if (num_chips_ > 1) {
+        std::lock_guard<std::mutex> init_lock(s_shared_init_mutex_);
+        if (!s_shared_handle_) {
+            s_shared_handle_ = dlopen(simulator_directory_.c_str(), RTLD_LAZY);
+            if (!s_shared_handle_) {
+                UMD_THROW(error::RuntimeError, fmt::format("Failed to dlopen simulator library: {}", dlerror()));
+            }
+        }
+        libttsim_handle_ = s_shared_handle_;
+        DLSYM_FUNCTION(libttsim_init)
+        DLSYM_FUNCTION(libttsim_exit)
+        DLSYM_FUNCTION(libttsim_pci_config_rd32)
+        DLSYM_FUNCTION(libttsim_pci_mem_rd_bytes)
+        DLSYM_FUNCTION(libttsim_pci_mem_wr_bytes)
+        DLSYM_FUNCTION(libttsim_tile_rd_bytes)
+        DLSYM_FUNCTION(libttsim_tile_wr_bytes)
+        DLSYM_FUNCTION(libttsim_clock)
+        DLSYM_FUNCTION(libttsim_set_pci_dma_mem_callbacks)
+        shared_bdf_mode_ = true;
+        s_shared_refcount_++;
+        log_info(
+            tt::LogEmulationDriver,
+            "TTSim BDF multichip mode (chip_id={}, shared dlopen, per-device BARs)",
+            chip_id_);
+        return;
+    }
+
     // Legacy path: per-chip memfd + dlopen.
     if (copy_sim_binary_) {
         create_simulator_binary();
@@ -176,6 +211,16 @@ void TTSimCommunicator::start_sim() {
         dev_handle_ = pfn_libttsim_create_device_by_id_(chip_id_, /*chip_x=*/int(chip_id_), /*chip_y=*/0);
         return;
     }
+    if (shared_bdf_mode_) {
+        // Shared dlopen: initialize the simulator exactly once. Chips are addressed by
+        // BDF, so there is no per-chip registration call.
+        std::lock_guard<std::mutex> init_lock(s_shared_init_mutex_);
+        if (!s_sim_initialized_) {
+            pfn_libttsim_init_();
+            s_sim_initialized_ = true;
+        }
+        return;
+    }
     pfn_libttsim_init_();
 }
 
@@ -188,7 +233,7 @@ void TTSimCommunicator::shutdown() {
         return;
     }
     log_info(tt::LogEmulationDriver, "Sending exit signal to remote...");
-    if (multichip_mode_) {
+    if (uses_shared_handle()) {
         // Defer libttsim_exit until the last communicator destructs (handled
         // by refcount in the destructor's shared-handle close path). The
         // simulator is process-global; calling exit per chip would be wrong.
@@ -251,10 +296,15 @@ void TTSimCommunicator::pci_mem_write_bytes(uint64_t paddr, const void *data, ui
 
 uint32_t TTSimCommunicator::pci_config_read32(uint32_t bus_device_function, uint32_t offset) {
     std::lock_guard<std::mutex> lock(device_lock_);
-    // pci_config_read32 reads compile-time constants; no chip selection needed.
-    // But we still select for consistency and future-proofing.
-    select_chip_if_needed();
-    return pfn_libttsim_pci_config_rd32_(bus_device_function, offset);
+    // In BDF mode there is no select_device_by_id: this chip's PCI device is named by
+    // its BDF (device field = chip_id), so each chip reads its own per-device BAR bases.
+    // Callers pass bus_device_function 0 ("this device"); we fill in the device field.
+    uint32_t bdf = bus_device_function;
+    if (shared_bdf_mode_) {
+        bdf |= (chip_id_ << 3); // BDF: function[2:0], device[7:3], bus[15:8]
+    }
+    select_chip_if_needed();  // no-op outside the multichip-ABI mode
+    return pfn_libttsim_pci_config_rd32_(bdf, offset);
 }
 
 void TTSimCommunicator::advance_clock(uint32_t n_clocks) {

--- a/device/tt_device/simulation_device_factory.cpp
+++ b/device/tt_device/simulation_device_factory.cpp
@@ -28,7 +28,7 @@ std::unique_ptr<TTDevice> create_simulation_tt_device(
     int num_host_mem_channels) {
     if (simulator_directory.extension() == ".so") {
         return std::make_unique<TTSimTTDevice>(
-            simulator_directory, soc_descriptor, chip_id, num_chips > 1, num_host_mem_channels);
+            simulator_directory, soc_descriptor, chip_id, num_chips > 1, num_host_mem_channels, num_chips);
     }
     log_info(tt::LogEmulationDriver, "Instantiating RTL simulation device");
     return std::make_unique<RtlSimulationTTDevice>(simulator_directory, soc_descriptor, chip_id, num_host_mem_channels);

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -165,12 +165,12 @@ TTSimTTDevice::TTSimTTDevice(
     // (WH channel 3 is 768 MiB, the rest 1 GiB); configure_iatu_region keeps the region base on the
     // fixed 1 GiB channel grid (matching SimulationSysmemManager's placement) and uses region_size only
     // to bound the limit, so a sub-1-GiB channel still starts at the right NOC offset.
-    // Only program the outbound iATU in the multi-MMIO case (num_chips > 1), where address-based DMA
-    // routing needs each chip's NOC window mapped onto its distinct host base. A single-chip sim has one
-    // host window at base 0, so routing degenerates to a no-op and the legacy DMA path already works --
-    // and the single-chip libttsim builds do not model the BAR2 outbound iATU (they throw
-    // UnimplementedFunctionality on these register writes), so issuing them would regress single-chip.
-    if (num_chips > 1 && (arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE)) {
+    //
+    // Programmed uniformly for single- and multi-chip: a single-chip sim simply has host_base 0, so
+    // the mapping is an identity and routing degenerates to a no-op -- the init path is identical
+    // regardless of num_chips. Requires a libttsim that models the BAR2 outbound iATU (WH, and BH as
+    // of the multichip work), which is the behaviour of the stable simulator release.
+    if (arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE) {
         size_t nch = sysmem_manager_->get_num_host_mem_channels();
         for (size_t ch = 0; ch < nch; ch++) {
             HugepageMapping m = sysmem_manager_->get_hugepage_mapping(ch);

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -161,14 +161,15 @@ TTSimTTDevice::TTSimTTDevice(
     // Program this chip's outbound iATU exactly as UMD does on silicon (LocalChip::init_pcie_iatus):
     // one region per host-mem channel, mapping the NOC sysmem window onto this chip's distinct host
     // base. The simulator honors the iATU at DMA egress, so each chip's DMA lands in its own host
-    // window by address alone -- no per-chip tag. Use a uniform 1 GiB region stride so region `ch`
-    // maps NOC-window offset ch*1GiB -> this chip's host base + ch*1GiB (matches SimulationSysmemManager).
+    // window by address alone -- no per-chip tag. region_size is the channel's actual mapping size
+    // (WH channel 3 is 768 MiB, the rest 1 GiB); configure_iatu_region keeps the region base on the
+    // fixed 1 GiB channel grid (matching SimulationSysmemManager's placement) and uses region_size only
+    // to bound the limit, so a sub-1-GiB channel still starts at the right NOC offset.
     if (arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE) {
-        constexpr uint64_t kChannelStride = 1ULL << 30;
         size_t nch = sysmem_manager_->get_num_host_mem_channels();
         for (size_t ch = 0; ch < nch; ch++) {
             HugepageMapping m = sysmem_manager_->get_hugepage_mapping(ch);
-            configure_iatu_region(ch, m.physical_address, kChannelStride);
+            configure_iatu_region(ch, m.physical_address, m.mapping_size);
         }
     }
 }
@@ -374,8 +375,20 @@ void TTSimTTDevice::configure_iatu_region(size_t region, uint64_t target, size_t
     uint64_t bar2_base = communicator_->pci_config_read32(0, 0x18);
     bar2_base |= uint64_t(communicator_->pci_config_read32(0, 0x1C)) << 32;
     bar2_base &= ~15ull;  // strip BAR type/attribute bits, leaving the physical address
-    const uint64_t base = uint64_t(region) * region_size;  // region offset within the NOC sysmem window
+    // Channels sit on a fixed 1 GiB NOC-window grid (matching SimulationSysmemManager's placement),
+    // independent of region_size. region_size is the channel's actual mapping size and only bounds the
+    // limit: keeping base on the grid means a sub-1-GiB channel (WH channel 3 = 768 MiB) still starts at
+    // the right NOC offset (region * 1 GiB) while mapping only its backed range.
+    constexpr uint64_t kChannelStride = 1ULL << 30;
+    const uint64_t base = uint64_t(region) * kChannelStride;  // region offset within the NOC sysmem window
     const uint64_t limit = base + region_size - 1;
+    // limit and base are written as 32-bit registers (limit hi shares base hi). This holds only while the
+    // top of the region stays within 4 GiB; assert rather than silently truncate if stride/channel count
+    // ever grows past that.
+    UMD_ASSERT(
+        limit < (1ULL << 32),
+        error::RuntimeError,
+        "iATU region exceeds 32-bit base/limit; extend the iATU register writes to cover the high bits.");
     const uint64_t iatu = bar2_base + iatu_bar2_off + uint64_t(region) * 0x200;
     auto wr = [&](uint64_t off, uint32_t val) { communicator_->pci_mem_write_bytes(iatu + off, &val, sizeof(val)); };
     wr(0x04, 0);                       // region_ctrl_2: disable while (re)programming the region

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -165,7 +165,12 @@ TTSimTTDevice::TTSimTTDevice(
     // (WH channel 3 is 768 MiB, the rest 1 GiB); configure_iatu_region keeps the region base on the
     // fixed 1 GiB channel grid (matching SimulationSysmemManager's placement) and uses region_size only
     // to bound the limit, so a sub-1-GiB channel still starts at the right NOC offset.
-    if (arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE) {
+    // Only program the outbound iATU in the multi-MMIO case (num_chips > 1), where address-based DMA
+    // routing needs each chip's NOC window mapped onto its distinct host base. A single-chip sim has one
+    // host window at base 0, so routing degenerates to a no-op and the legacy DMA path already works --
+    // and the single-chip libttsim builds do not model the BAR2 outbound iATU (they throw
+    // UnimplementedFunctionality on these register writes), so issuing them would regress single-chip.
+    if (num_chips > 1 && (arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE)) {
         size_t nch = sysmem_manager_->get_num_host_mem_channels();
         for (size_t ch = 0; ch < nch; ch++) {
             HugepageMapping m = sysmem_manager_->get_hugepage_mapping(ch);

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -86,7 +86,8 @@ TTSimTTDevice::TTSimTTDevice(
         simulator_directory, copy_sim_binary, static_cast<uint32_t>(chip_id), static_cast<uint32_t>(num_chips))),
     simulator_directory_(simulator_directory),
     chip_id_(chip_id),
-    sysmem_manager_(std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)) {
+    sysmem_manager_(std::make_unique<SimulationSysmemManager>(
+        num_host_mem_channels, soc_descriptor.arch, static_cast<uint32_t>(chip_id))) {
     set_soc_descriptor(soc_descriptor);
     // Populate the base-class arch field from the soc descriptor. TTSim does not go through
     // init_tt_device() (no PCI probe), so without this arch stays tt::ARCH::Invalid and downstream
@@ -155,6 +156,20 @@ TTSimTTDevice::TTSimTTDevice(
                 "Architecture {} does not support TLB allocation, leaving cached_tlb_window_ null.",
                 tt::arch_to_str(arch));
             break;
+    }
+
+    // Program this chip's outbound iATU exactly as UMD does on silicon (LocalChip::init_pcie_iatus):
+    // one region per host-mem channel, mapping the NOC sysmem window onto this chip's distinct host
+    // base. The simulator honors the iATU at DMA egress, so each chip's DMA lands in its own host
+    // window by address alone -- no per-chip tag. Use a uniform 1 GiB region stride so region `ch`
+    // maps NOC-window offset ch*1GiB -> this chip's host base + ch*1GiB (matches SimulationSysmemManager).
+    if (arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE) {
+        constexpr uint64_t kChannelStride = 1ULL << 30;
+        size_t nch = sysmem_manager_->get_num_host_mem_channels();
+        for (size_t ch = 0; ch < nch; ch++) {
+            HugepageMapping m = sysmem_manager_->get_hugepage_mapping(ch);
+            configure_iatu_region(ch, m.physical_address, kChannelStride);
+        }
     }
 }
 
@@ -349,10 +364,40 @@ void TTSimTTDevice::dma_multicast_write(
     UMD_THROW(error::RuntimeError, "DMA multicast write not supported for TTSim simulation device.");
 }
 
+void TTSimTTDevice::configure_iatu_region(size_t region, uint64_t target, size_t region_size) {
+    // Configure the outbound iATU the silicon way: iATU register writes via BAR2 (BH writes these
+    // directly on real HW at ATU_OFFSET_IN_BH_BAR2=0x1000; WH models its iATU regs at 0x1200). We issue
+    // the same register sequence through the simulator's BAR2 MMIO path; the sim decodes it into the
+    // modeled outbound iATU and honors it at DMA egress. `target` is this chip's host base for the
+    // region (per-chip distinct); `base` is the region's offset within the chip's NOC sysmem window.
+    const uint64_t iatu_bar2_off = (arch == tt::ARCH::BLACKHOLE) ? 0x1000 : 0x1200;
+    uint64_t bar2_base = communicator_->pci_config_read32(0, 0x18);
+    bar2_base |= uint64_t(communicator_->pci_config_read32(0, 0x1C)) << 32;
+    bar2_base &= ~15ull;  // strip BAR type/attribute bits, leaving the physical address
+    const uint64_t base = uint64_t(region) * region_size;  // region offset within the NOC sysmem window
+    const uint64_t limit = base + region_size - 1;
+    const uint64_t iatu = bar2_base + iatu_bar2_off + uint64_t(region) * 0x200;
+    auto wr = [&](uint64_t off, uint32_t val) { communicator_->pci_mem_write_bytes(iatu + off, &val, sizeof(val)); };
+    wr(0x04, 0);                       // region_ctrl_2: disable while (re)programming the region
+    wr(0x00, 0);                       // region_ctrl_1
+    wr(0x08, uint32_t(base));          // base lo
+    wr(0x0c, uint32_t(base >> 32));    // base hi
+    wr(0x10, uint32_t(limit));         // limit (low 32b; upper bits share base hi)
+    wr(0x14, uint32_t(target));        // target lo
+    wr(0x18, uint32_t(target >> 32));  // target hi
+    wr(0x04, 1u << 31);                // region_ctrl_2 = REGION_EN, written last so the sim validates a complete region
+}
+
 void TTSimTTDevice::initialize_sysmem_functions() {
+    // Register this chip's distinct host window [host_base, host_base+size) so the simulator's host-side
+    // DMA router (dma_route) routes each chip's DMA by address range -- the chip emits a host address
+    // (via its outbound iATU), and the host finds the owning chip by which window contains it.
+    auto* sim_mgr = static_cast<SimulationSysmemManager*>(sysmem_manager_.get());
     communicator_->set_pcie_dma_mem_callbacks(
         [this](uint64_t a, void* p, uint32_t s) { pci_dma_read_bytes(a, p, s); },
-        [this](uint64_t a, const void* p, uint32_t s) { pci_dma_write_bytes(a, p, s); });
+        [this](uint64_t a, const void* p, uint32_t s) { pci_dma_write_bytes(a, p, s); },
+        sim_mgr->get_host_base(),
+        sim_mgr->get_host_region_size());
 }
 
 void TTSimTTDevice::pci_dma_read_bytes(uint64_t paddr, void* p, uint32_t size) {

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -75,13 +75,15 @@ TTSimTTDevice::TTSimTTDevice(
     const SocDescriptor& soc_descriptor,
     ChipId chip_id,
     bool copy_sim_binary,
-    int num_host_mem_channels) :
-    // Pass chip_id to the communicator. If the loaded .so supports the multichip
-    // multichip ABI (libttsim_create_device_by_id + libttsim_select_device_by_id),
-    // the communicator will auto-detect at initialize() time and switch to
-    // shared-dlopen mode regardless of copy_sim_binary.
-    communicator_(
-        std::make_unique<TTSimCommunicator>(simulator_directory, copy_sim_binary, static_cast<uint32_t>(chip_id))),
+    int num_host_mem_channels,
+    size_t num_chips) :
+    // Pass chip_id and num_chips to the communicator. If the .so supports the multichip
+    // ABI (libttsim_create_device_by_id + libttsim_select_device_by_id), the communicator
+    // auto-detects at initialize() and uses select_device_by_id. Otherwise, for a
+    // multi-chip cluster (num_chips > 1) it uses shared-dlopen BDF mode: one libttsim
+    // image addressed per-chip by PCI device. Single-chip keeps the legacy path.
+    communicator_(std::make_unique<TTSimCommunicator>(
+        simulator_directory, copy_sim_binary, static_cast<uint32_t>(chip_id), static_cast<uint32_t>(num_chips))),
     simulator_directory_(simulator_directory),
     chip_id_(chip_id),
     sysmem_manager_(std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)) {

--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -555,11 +555,6 @@ TEST_F(TestDeviceIOFixture, SysmemReadWrite) {
         GTEST_SKIP() << "Skipping the test for quasar since Sysmem is not supported yet.";
     }
 
-    constexpr auto mmio_chip_id = 0;
-    const auto pci_cores = cluster->get_soc_descriptor(mmio_chip_id).get_cores(CoreType::PCIE);
-    const auto pcie_core = pci_cores.at(0);
-    const auto base_address = cluster->get_pcie_base_addr_from_device(mmio_chip_id);
-
     auto random_address_between = [&](uint64_t lo, uint64_t hi) -> uint64_t {
         static std::random_device rd;
         static std::mt19937_64 gen(rd());
@@ -571,101 +566,116 @@ TEST_F(TestDeviceIOFixture, SysmemReadWrite) {
         test_utils::safe_test_cluster_start(cluster.get());
     }
 
-    for (uint32_t channel = 0; channel < channels_to_test; channel++) {
-        uint8_t* sysmem = static_cast<uint8_t*>(cluster->host_dma_address(mmio_chip_id, 0, channel));
+    // Exercise every MMIO chip's sysmem, not just chip 0. On a multi-MMIO simulator (e.g. P300 / bh_x2)
+    // this is what actually validates the host-DMA routing model: each chip's DMA must land in *its own*
+    // host window. Each chip fills its host buffer with a chip-distinct pattern, so a misrouted DMA
+    // (landing in another chip's window, or aliasing host_base 0) would surface as a readback mismatch.
+    const std::set<ChipId> mmio_chips = cluster->get_target_mmio_device_ids();
+    for (const ChipId mmio_chip_id : mmio_chips) {
+        const auto pci_cores = cluster->get_soc_descriptor(mmio_chip_id).get_cores(CoreType::PCIE);
+        const auto pcie_core = pci_cores.at(0);
+        const auto base_address = cluster->get_pcie_base_addr_from_device(mmio_chip_id);
 
-        ASSERT_NE(sysmem, nullptr);
+        // Distinct per-chip pattern offset so chip 1's data never coincides with chip 0's.
+        const size_t chip_pattern_bias = static_cast<size_t>(mmio_chip_id) * 131;
 
-        if (is_simulation_test()) {
-            for (size_t i = 0; i < ONE_GIG; i++) {
-                sysmem[i] = i % 256;
-            }
-        } else {
-            test_utils::fill_with_random_bytes(sysmem, ONE_GIG);
-        }
+        for (uint32_t channel = 0; channel < channels_to_test; channel++) {
+            uint8_t* sysmem = static_cast<uint8_t*>(cluster->host_dma_address(/*offset=*/0, mmio_chip_id, channel));
 
-        std::vector<uint64_t> test_offsets;
-        if (is_simulation_test()) {
-            test_offsets = {0x0};
-        } else {
-            test_offsets = {
-                0x0,
-                (ONE_GIG / 4) - 0x1000,
-                (ONE_GIG / 4) - 0x0004,
-                (ONE_GIG / 4),
-                (ONE_GIG / 4) + 0x0004,
-                (ONE_GIG / 4) + 0x1000,
-                (ONE_GIG / 2) - 0x1000,
-                (ONE_GIG / 2) - 0x0004,
-                (ONE_GIG / 2),
-                (ONE_GIG / 2) + 0x0004,
-                (ONE_GIG / 2) + 0x1000,
-                (ONE_GIG - 0x1000),
-                (ONE_GIG - 0x0004),
-            };
-            for (size_t i = 0; i < 8192; ++i) {
-                uint64_t address = random_address_between(0, ONE_GIG);
-                test_offsets.push_back(address);
-            }
-        }
+            ASSERT_NE(sysmem, nullptr);
 
-        // Read test - read the sysmem at the various offsets.
-        for (uint64_t test_offset : test_offsets) {
-            uint64_t aligned_offset = (test_offset / ALIGNMENT) * ALIGNMENT;
-            uint64_t device_offset = aligned_offset + channel * ONE_GIG;
-            uint64_t noc_addr = base_address + device_offset;
-            uint32_t expected = 0;
-            uint32_t value = 0;
-
-            std::memcpy(&expected, &sysmem[aligned_offset], sizeof(uint32_t));
-
-            cluster->read_from_device(&value, mmio_chip_id, pcie_core, noc_addr, sizeof(uint32_t));
-
-            if (!is_simulation_test() && value != expected) {
-                std::stringstream error_msg;
-                const bool is_vm = test_utils::is_virtual_machine();
-                const bool has_iommu = test_utils::is_iommu_available();
-                error_msg << "Sysmem read mismatch at channel " << channel << ", offset 0x" << std::hex
-                          << aligned_offset << std::dec << " (NOC addr 0x" << std::hex << noc_addr << std::dec << ")"
-                          << "\n  Configuration: " << (is_vm ? "VM" : "Bare Metal")
-                          << ", IOMMU: " << (has_iommu ? "Enabled" : "Disabled") << ", Channels: " << channels
-                          << "\n  Expected: 0x" << std::hex << expected << ", Got: 0x" << value << std::dec;
-
-                if (is_vm && has_iommu) {
-                    error_msg << "\n"
-                              << "\n  - VM with IOMMU detected: This is likely a DMA mapping limit issue"
-                              << "\n  - FIX: On the HOST machine, add this kernel boot parameter:"
-                              << "\n      vfio_iommu_type1.dma_entry_limit=4294967295"
-                              << "\n  - After adding the parameter, reboot the HOST (not just the VM)"
-                              << "\n  - Check host dmesg for IO page faults"
-                              << "\n  - Failure at offset >= 255MB strongly indicates dma_entry_limit issue";
+            if (is_simulation_test()) {
+                for (size_t i = 0; i < ONE_GIG; i++) {
+                    sysmem[i] = static_cast<uint8_t>((i + chip_pattern_bias) % 256);
                 }
-
-                FAIL() << error_msg.str();
             } else {
-                EXPECT_EQ(value, expected)
-                    << "Sysmem read mismatch at channel " << channel << ", offset 0x" << std::hex << aligned_offset
-                    << std::dec << " (NOC addr 0x" << std::hex << noc_addr << std::dec << ")\n"
-                    << "Expected: 0x" << std::hex << expected << ", Got: 0x" << value << std::dec;
+                test_utils::fill_with_random_bytes(sysmem, ONE_GIG);
             }
-        }
 
-        // Write test - zero out the sysmem at the various offsets.
-        for (uint64_t test_offset : test_offsets) {
-            uint64_t aligned_offset = (test_offset / ALIGNMENT) * ALIGNMENT;
-            uint64_t device_offset = aligned_offset + channel * ONE_GIG;
-            uint64_t noc_addr = base_address + device_offset;
-            uint32_t value = 0;
-            cluster->write_to_device(&value, sizeof(uint32_t), mmio_chip_id, pcie_core, noc_addr);
-            cluster->read_from_device(&value, mmio_chip_id, pcie_core, noc_addr, sizeof(uint32_t));
-        }
+            std::vector<uint64_t> test_offsets;
+            if (is_simulation_test()) {
+                test_offsets = {0x0};
+            } else {
+                test_offsets = {
+                    0x0,
+                    (ONE_GIG / 4) - 0x1000,
+                    (ONE_GIG / 4) - 0x0004,
+                    (ONE_GIG / 4),
+                    (ONE_GIG / 4) + 0x0004,
+                    (ONE_GIG / 4) + 0x1000,
+                    (ONE_GIG / 2) - 0x1000,
+                    (ONE_GIG / 2) - 0x0004,
+                    (ONE_GIG / 2),
+                    (ONE_GIG / 2) + 0x0004,
+                    (ONE_GIG / 2) + 0x1000,
+                    (ONE_GIG - 0x1000),
+                    (ONE_GIG - 0x0004),
+                };
+                for (size_t i = 0; i < 8192; ++i) {
+                    uint64_t address = random_address_between(0, ONE_GIG);
+                    test_offsets.push_back(address);
+                }
+            }
 
-        // Write test verification - read the sysmem at the various offsets and verify that each has been zeroed.
-        for (uint64_t test_offset : test_offsets) {
-            uint64_t aligned_offset = (test_offset / ALIGNMENT) * ALIGNMENT;
-            uint32_t value = 0xffffffff;
-            std::memcpy(&value, &sysmem[aligned_offset], sizeof(uint32_t));
-            EXPECT_EQ(value, 0);
+            // Read test - read the sysmem at the various offsets.
+            for (uint64_t test_offset : test_offsets) {
+                uint64_t aligned_offset = (test_offset / ALIGNMENT) * ALIGNMENT;
+                uint64_t device_offset = aligned_offset + channel * ONE_GIG;
+                uint64_t noc_addr = base_address + device_offset;
+                uint32_t expected = 0;
+                uint32_t value = 0;
+
+                std::memcpy(&expected, &sysmem[aligned_offset], sizeof(uint32_t));
+
+                cluster->read_from_device(&value, mmio_chip_id, pcie_core, noc_addr, sizeof(uint32_t));
+
+                if (!is_simulation_test() && value != expected) {
+                    std::stringstream error_msg;
+                    const bool is_vm = test_utils::is_virtual_machine();
+                    const bool has_iommu = test_utils::is_iommu_available();
+                    error_msg << "Sysmem read mismatch at channel " << channel << ", offset 0x" << std::hex
+                              << aligned_offset << std::dec << " (NOC addr 0x" << std::hex << noc_addr << std::dec
+                              << ")"
+                              << "\n  Configuration: " << (is_vm ? "VM" : "Bare Metal")
+                              << ", IOMMU: " << (has_iommu ? "Enabled" : "Disabled") << ", Channels: " << channels
+                              << "\n  Expected: 0x" << std::hex << expected << ", Got: 0x" << value << std::dec;
+
+                    if (is_vm && has_iommu) {
+                        error_msg << "\n"
+                                  << "\n  - VM with IOMMU detected: This is likely a DMA mapping limit issue"
+                                  << "\n  - FIX: On the HOST machine, add this kernel boot parameter:"
+                                  << "\n      vfio_iommu_type1.dma_entry_limit=4294967295"
+                                  << "\n  - After adding the parameter, reboot the HOST (not just the VM)"
+                                  << "\n  - Check host dmesg for IO page faults"
+                                  << "\n  - Failure at offset >= 255MB strongly indicates dma_entry_limit issue";
+                    }
+
+                    FAIL() << error_msg.str();
+                } else {
+                    EXPECT_EQ(value, expected)
+                        << "Sysmem read mismatch at channel " << channel << ", offset 0x" << std::hex << aligned_offset
+                        << std::dec << " (NOC addr 0x" << std::hex << noc_addr << std::dec << ")\n"
+                        << "Expected: 0x" << std::hex << expected << ", Got: 0x" << value << std::dec;
+                }
+            }
+
+            // Write test - zero out the sysmem at the various offsets.
+            for (uint64_t test_offset : test_offsets) {
+                uint64_t aligned_offset = (test_offset / ALIGNMENT) * ALIGNMENT;
+                uint64_t device_offset = aligned_offset + channel * ONE_GIG;
+                uint64_t noc_addr = base_address + device_offset;
+                uint32_t value = 0;
+                cluster->write_to_device(&value, sizeof(uint32_t), mmio_chip_id, pcie_core, noc_addr);
+                cluster->read_from_device(&value, mmio_chip_id, pcie_core, noc_addr, sizeof(uint32_t));
+            }
+
+            // Write test verification - read the sysmem at the various offsets and verify that each has been zeroed.
+            for (uint64_t test_offset : test_offsets) {
+                uint64_t aligned_offset = (test_offset / ALIGNMENT) * ALIGNMENT;
+                uint32_t value = 0xffffffff;
+                std::memcpy(&value, &sysmem[aligned_offset], sizeof(uint32_t));
+                EXPECT_EQ(value, 0);
+            }
         }
     }
 }

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -15,7 +15,6 @@
 #include <string>
 #include <vector>
 
-#include "test_utils/fetch_local_files.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
 
@@ -61,27 +60,11 @@ inline std::unique_ptr<Cluster> make_default_test_cluster(ClusterOptions options
     }
     if (const char* sim_path = std::getenv("TT_UMD_SIMULATOR")) {
         options.chip_type = ChipType::SIMULATION;
+        options.target_devices = {0};
         options.simulator_directory = std::filesystem::path(sim_path);
-
-        // A multichip simulator (e.g. wh_x2, bh_x2) needs a real cluster descriptor to expose
-        // its topology -- the auto-generated mock descriptor marks every chip MMIO and
-        // has no eth links, so a remote chip would never be enumerated. When
-        // TT_UMD_CLUSTER_DESCRIPTOR names a descriptor (a filename under
-        // tests/cluster_descriptor_examples/), load it and target all of its chips.
-        // Without it, behaviour is unchanged: a single MMIO chip 0.
-        if (const char* desc_name = std::getenv("TT_UMD_CLUSTER_DESCRIPTOR")) {
-            // Static lifetime: Cluster stores the options (including this pointer), and
-            // the descriptor selection is constant for the whole test process.
-            static std::unique_ptr<ClusterDescriptor> sim_cluster_desc =
-                ClusterDescriptor::create_from_yaml(GetClusterDescAbsPath(desc_name));
-            options.cluster_descriptor = sim_cluster_desc.get();
-            options.target_devices.clear();
-            for (tt::ChipId chip : sim_cluster_desc->get_all_chips()) {
-                options.target_devices.insert(chip);
-            }
-        } else {
-            options.target_devices = {0};
-        }
+        // A multichip simulator's topology is auto-discovered by the Cluster from a cluster_descriptor.yaml
+        // placed beside the .so (see SimulationChip::get_cluster_descriptor_path_from_simulator_path); no
+        // test-side env var is needed.
     }
     return std::make_unique<Cluster>(options);
 }

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <vector>
 
+#include "test_utils/fetch_local_files.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
 
@@ -60,8 +61,27 @@ inline std::unique_ptr<Cluster> make_default_test_cluster(ClusterOptions options
     }
     if (const char* sim_path = std::getenv("TT_UMD_SIMULATOR")) {
         options.chip_type = ChipType::SIMULATION;
-        options.target_devices = {0};
         options.simulator_directory = std::filesystem::path(sim_path);
+
+        // A multichip simulator (e.g. wh_x2, bh_x2) needs a real cluster descriptor to expose
+        // its topology -- the auto-generated mock descriptor marks every chip MMIO and
+        // has no eth links, so a remote chip would never be enumerated. When
+        // TT_UMD_CLUSTER_DESCRIPTOR names a descriptor (a filename under
+        // tests/cluster_descriptor_examples/), load it and target all of its chips.
+        // Without it, behaviour is unchanged: a single MMIO chip 0.
+        if (const char* desc_name = std::getenv("TT_UMD_CLUSTER_DESCRIPTOR")) {
+            // Static lifetime: Cluster stores the options (including this pointer), and
+            // the descriptor selection is constant for the whole test process.
+            static std::unique_ptr<ClusterDescriptor> sim_cluster_desc =
+                ClusterDescriptor::create_from_yaml(GetClusterDescAbsPath(desc_name));
+            options.cluster_descriptor = sim_cluster_desc.get();
+            options.target_devices.clear();
+            for (tt::ChipId chip : sim_cluster_desc->get_all_chips()) {
+                options.target_devices.insert(chip);
+            }
+        } else {
+            options.target_devices = {0};
+        }
     }
     return std::make_unique<Cluster>(options);
 }


### PR DESCRIPTION
### Issue
/

### Description
Adds support for driving a multi-MMIO multi-chip TTSim — a simulator config where more than one chip is MMIO-capable, such as the Blackhole P300 (two MMIO Blackhole chips). Until now the TTSim path assumed a single MMIO device, so a P300 cluster could not be enumerated or driven.

The harder part is host DMA: with one shared simulator image serving both chips, a sysmem DMA callback fires process-globally, so we need to land each chip's DMA in that chip's own host memory. We model this exactly the way silicon does, rather than inventing a sim-only side channel: each chip's sysmem sits at a distinct host base, UMD programs the chip's outbound iATU (over BAR2) to map its NOC sysmem window onto that base, and a DMA is then routed to the owning chip purely by the host address it carries — no per-chip tag crosses the bus.

Doing it this way means no new ttsim ABI is required: the device dimension already exists in the stable ABI (the BDF arg to `pci_config_rd32` and the physical address to `pci_mem_*`), so each chip is simply addressed by its PCI device and its per-device BAR window.

### List of the changes
- Shared-dlopen BDF mode in `TTSimCommunicator`: chips addressed by per-device BAR; init and DMA callbacks run once on the first chip.
- Outbound-iATU host-DMA routing: per-chip host base, iATU programmed via BAR2, `dma_route` routes by host-address window. Programmed uniformly for single- and multi-chip.
- `RemoteChip`/cluster plumbing to construct simulation chips, threading `num_chips` through.
- Robustness fixes in the routing path (teardown unregister, `callback_instance_` race, BDF/iATU range asserts).
- CI: bh_x2 (P300) lane; `SysmemReadWrite` covers all MMIO chips.

### Testing
Verified locally against a ttsim built from the multichip branch: single-chip WH/BH and bh_x2 P300 pass (both chips enumerate, P300 eth topology parses, per-chip DMA routes correctly). Requires a ttsim modeling the BAR2 outbound iATU (stable release).

### API Changes
None public. `TTSimCommunicator` / `TTSimTTDevice` gain a `num_chips` parameter (default 1).