### PR TITLE
Make P150 multi-chip cluster descs 2-col harvested

### DIFF
--- a/tests/cluster_descriptor_examples/blackhole_4xP150.yaml
+++ b/tests/cluster_descriptor_examples/blackhole_4xP150.yaml
@@ -102,28 +102,28 @@ io_device_type: PCIe
 harvesting:
   0:
     noc_translation: true
-    harvest_mask: 0
+    harvest_mask: 192
     dram_harvesting_mask: 0
     eth_harvesting_mask: 288
     pcie_harvesting_mask: 2
     l2cpu_harvesting_mask: 0
   1:
     noc_translation: true
-    harvest_mask: 0
+    harvest_mask: 192
     dram_harvesting_mask: 0
     eth_harvesting_mask: 288
     pcie_harvesting_mask: 2
     l2cpu_harvesting_mask: 0
   2:
     noc_translation: true
-    harvest_mask: 0
+    harvest_mask: 192
     dram_harvesting_mask: 0
     eth_harvesting_mask: 288
     pcie_harvesting_mask: 2
     l2cpu_harvesting_mask: 0
   3:
     noc_translation: true
-    harvest_mask: 0
+    harvest_mask: 192
     dram_harvesting_mask: 0
     eth_harvesting_mask: 288
     pcie_harvesting_mask: 2

--- a/tests/cluster_descriptor_examples/blackhole_8xP150.yaml
+++ b/tests/cluster_descriptor_examples/blackhole_8xP150.yaml
@@ -134,56 +134,56 @@ io_device_type: PCIe
 harvesting:
   0:
     noc_translation: true
-    harvest_mask: 0
+    harvest_mask: 192
     dram_harvesting_mask: 0
     eth_harvesting_mask: 288
     pcie_harvesting_mask: 2
     l2cpu_harvesting_mask: 0
   1:
     noc_translation: true
-    harvest_mask: 0
+    harvest_mask: 192
     dram_harvesting_mask: 0
     eth_harvesting_mask: 288
     pcie_harvesting_mask: 2
     l2cpu_harvesting_mask: 0
   2:
     noc_translation: true
-    harvest_mask: 0
+    harvest_mask: 192
     dram_harvesting_mask: 0
     eth_harvesting_mask: 288
     pcie_harvesting_mask: 2
     l2cpu_harvesting_mask: 0
   3:
     noc_translation: true
-    harvest_mask: 0
+    harvest_mask: 192
     dram_harvesting_mask: 0
     eth_harvesting_mask: 288
     pcie_harvesting_mask: 2
     l2cpu_harvesting_mask: 0
   4:
     noc_translation: true
-    harvest_mask: 0
+    harvest_mask: 192
     dram_harvesting_mask: 0
     eth_harvesting_mask: 288
     pcie_harvesting_mask: 2
     l2cpu_harvesting_mask: 0
   5:
     noc_translation: true
-    harvest_mask: 0
+    harvest_mask: 192
     dram_harvesting_mask: 0
     eth_harvesting_mask: 288
     pcie_harvesting_mask: 2
     l2cpu_harvesting_mask: 0
   6:
     noc_translation: true
-    harvest_mask: 0
+    harvest_mask: 192
     dram_harvesting_mask: 0
     eth_harvesting_mask: 288
     pcie_harvesting_mask: 2
     l2cpu_harvesting_mask: 0
   7:
     noc_translation: true
-    harvest_mask: 0
+    harvest_mask: 192
     dram_harvesting_mask: 0
     eth_harvesting_mask: 288
     pcie_harvesting_mask: 2


### PR DESCRIPTION
### Issue
Closes #2826

### Description
Commit 3c739083 updated the single-chip `blackhole_P150.yaml` example to be 2-column harvested (`harvest_mask: 192`), since P150 now requires two columns harvested. The multi-chip P150 cluster descriptor examples were not updated and still had `harvest_mask: 0`.

### List of the changes
Set `harvest_mask` to 192 for all chips in `tests/cluster_descriptor_examples/blackhole_4xP150.yaml` and `tests/cluster_descriptor_examples/blackhole_8xP150.yaml`.

### Testing
CI

### API Changes
There are no API changes in this PR.