### PR TITLE
Display ARC SMC Init status in ArcStartupError

### DIFF
--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -258,7 +258,8 @@ inline constexpr uint32_t ARC_FW_INT_VAL = 65536;
 inline constexpr uint32_t ARC_MSG_RESPONSE_OK_LIMIT = 240;
 
 inline constexpr uint32_t SCRATCH_RAM_0 = ARC_RESET_UNIT_OFFSET + 0x400;
-inline constexpr uint32_t SCRATCH_RAM_2 = ARC_RESET_UNIT_OFFSET + 0x408;
+inline constexpr uint32_t SCRATCH_RAM_2 = ARC_RESET_UNIT_OFFSET + 0x408;   // BOOT_STATUS
+inline constexpr uint32_t SCRATCH_RAM_3 = ARC_RESET_UNIT_OFFSET + 0x410;   // ERROR_STATUS0
 inline constexpr uint32_t SCRATCH_RAM_10 = ARC_RESET_UNIT_OFFSET + 0x428;  // SPI buffer info
 inline constexpr uint32_t SCRATCH_RAM_12 = ARC_RESET_UNIT_OFFSET + 0x430;
 inline constexpr uint32_t SCRATCH_RAM_13 = ARC_RESET_UNIT_OFFSET + 0x434;

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -10,14 +10,12 @@
 #include <cstdint>
 #include <iterator>
 #include <optional>
-#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/types/arch.hpp"
-#include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/tlb.hpp"
 #include "umd/device/types/xy_pair.hpp"
@@ -259,7 +257,8 @@ inline constexpr uint32_t ARC_MSG_RESPONSE_OK_LIMIT = 240;
 
 inline constexpr uint32_t SCRATCH_RAM_0 = ARC_RESET_UNIT_OFFSET + 0x400;
 inline constexpr uint32_t SCRATCH_RAM_2 = ARC_RESET_UNIT_OFFSET + 0x408;   // BOOT_STATUS
-inline constexpr uint32_t SCRATCH_RAM_3 = ARC_RESET_UNIT_OFFSET + 0x410;   // ERROR_STATUS0
+inline constexpr uint32_t SCRATCH_RAM_4 = ARC_RESET_UNIT_OFFSET + 0x410;   // ERROR_STATUS0
+inline constexpr uint32_t SCRATCH_RAM_5 = ARC_RESET_UNIT_OFFSET + 0x418;   // ERROR_STATUS1
 inline constexpr uint32_t SCRATCH_RAM_10 = ARC_RESET_UNIT_OFFSET + 0x428;  // SPI buffer info
 inline constexpr uint32_t SCRATCH_RAM_12 = ARC_RESET_UNIT_OFFSET + 0x430;
 inline constexpr uint32_t SCRATCH_RAM_13 = ARC_RESET_UNIT_OFFSET + 0x434;

--- a/device/api/umd/device/tt_device/tt_device_error.hpp
+++ b/device/api/umd/device/tt_device/tt_device_error.hpp
@@ -39,6 +39,7 @@ struct ArcStartupData : public DeviceCoreData {
     uint32_t scratch_status = 0;
     uint32_t postcode = 0;
     std::optional<uint32_t> message_id = std::nullopt;
+    std::optional<uint32_t> smc_init_status = std::nullopt;
 };
 
 struct ArcStartupError : UmdError<ArcStartupData> {
@@ -48,7 +49,8 @@ struct ArcStartupError : UmdError<ArcStartupData> {
         xy_pair arc_core,
         uint32_t scratch_status,
         uint32_t postcode,
-        std::optional<uint32_t> message_id = std::nullopt);
+        std::optional<uint32_t> message_id = std::nullopt,
+        std::optional<uint32_t> smc_init_status = std::nullopt);
     ArcStartupError(
         const TTDevice& tt_device,
         NocId noc_id,
@@ -56,7 +58,8 @@ struct ArcStartupError : UmdError<ArcStartupData> {
         uint32_t scratch_status,
         uint32_t postcode,
         std::chrono::milliseconds timeout,
-        std::optional<uint32_t> message_id = std::nullopt);
+        std::optional<uint32_t> message_id = std::nullopt,
+        std::optional<uint32_t> smc_init_status = std::nullopt);
 };
 
 struct NocHangData : TTDeviceData {

--- a/device/api/umd/device/types/blackhole_arc.hpp
+++ b/device/api/umd/device/types/blackhole_arc.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 #include <string_view>
 #include <unordered_map>
 
@@ -71,5 +72,28 @@ inline const std::unordered_map<SMCInitStageFlags, std::string_view> SMC_INIT_ST
     {INIT_STAGE_MRISC_LOAD, "MRISC load failure"},
     {INIT_STAGE_GDDR_TRAIN, "GDDR training failure"},
 };
+
+// Interprets the smc_init_status bitmask and returns a comma-separated string of
+// active failure descriptions. Bit N corresponds to SMCInitStageFlags value N.
+// Returns "No errors" if no bits are set.
+inline std::string interpret_smc_init_status(uint32_t smc_init_status) {
+    std::string result;
+    for (uint8_t bit = 0; bit < 32; ++bit) {
+        if (!((smc_init_status >> bit) & 1u)) {
+            continue;
+        }
+        if (!result.empty()) {
+            result += ", ";
+        }
+        auto flag = static_cast<SMCInitStageFlags>(bit);
+        auto it = SMC_INIT_STAGE_INTERPRETATION.find(flag);
+        if (it != SMC_INIT_STAGE_INTERPRETATION.end()) {
+            result += it->second;
+        } else {
+            result += "unknown bit " + std::to_string(bit);
+        }
+    }
+    return result.empty() ? "No errors" : result;
+}
 
 }  // namespace tt::umd::blackhole

--- a/device/api/umd/device/types/blackhole_arc.hpp
+++ b/device/api/umd/device/types/blackhole_arc.hpp
@@ -56,7 +56,6 @@ enum BlackholeArcMessageQueueIndex : uint8_t {
     APPLICATION = 3,
 };
 
-// SMC init stages.
 enum SMCInitStageFlags : uint8_t {
     INIT_STAGE_REGULATOR = 0,
     INIT_STAGE_CABLE_FAULT = 1,

--- a/device/api/umd/device/types/blackhole_arc.hpp
+++ b/device/api/umd/device/types/blackhole_arc.hpp
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <cstdint>
+#include <string_view>
+#include <unordered_map>
 
 namespace tt::umd::blackhole {
 
@@ -51,6 +53,23 @@ enum BlackholeArcMessageQueueIndex : uint8_t {
     MONITORING = 1,
     TOOLS = 2,
     APPLICATION = 3,
+};
+
+// SMC init stages.
+enum SMCInitStageFlags : uint8_t {
+    INIT_STAGE_REGULATOR = 0,
+    INIT_STAGE_CABLE_FAULT = 1,
+    INIT_STAGE_TENSIX = 2,
+    INIT_STAGE_MRISC_LOAD = 3,
+    INIT_STAGE_GDDR_TRAIN = 4,
+};
+
+inline const std::unordered_map<SMCInitStageFlags, std::string_view> SMC_INIT_STAGE_INTERPRETATION = {
+    {INIT_STAGE_REGULATOR, "Regulator init failure"},
+    {INIT_STAGE_CABLE_FAULT, "Cable fault"},
+    {INIT_STAGE_TENSIX, "Tensix initialization failure"},
+    {INIT_STAGE_MRISC_LOAD, "MRISC load failure"},
+    {INIT_STAGE_GDDR_TRAIN, "GDDR training failure"},
 };
 
 }  // namespace tt::umd::blackhole

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -198,8 +198,7 @@ void BlackholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds time
     const bool arc_core_started = utils::poll_until(
         [this, &arc_boot_status, &arc_postcode]() {
             read_from_arc_apb(&arc_boot_status, blackhole::SCRATCH_RAM_2, sizeof arc_boot_status);
-            read_from_arc_apb(
-                &arc_postcode, architecture_impl_->get_arc_reset_scratch_offset(), sizeof arc_boot_status);
+            read_from_arc_apb(&arc_postcode, architecture_impl_->get_arc_reset_scratch_offset(), sizeof arc_postcode);
             return (arc_boot_status & 0x7) == 0x5;
         },
         timeout_ms,

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -184,14 +184,15 @@ ChipInfo BlackholeTTDevice::get_chip_info() {
 void BlackholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeout_ms) {
     uint32_t arc_boot_status = 0;
     uint32_t arc_postcode = 0;
+    uint32_t arc_error_status0 = 0;
 
     constexpr auto busy_poll_window = std::chrono::microseconds(1000);
     constexpr auto poll_interval = std::chrono::microseconds(10);
     const bool arc_core_started = utils::poll_until(
         [this, &arc_boot_status, &arc_postcode]() {
-            read_from_arc_apb(&arc_boot_status, blackhole::SCRATCH_RAM_2, sizeof(arc_boot_status));
+            read_from_arc_apb(&arc_boot_status, blackhole::SCRATCH_RAM_2, sizeof arc_boot_status);
             read_from_arc_apb(
-                &arc_postcode, architecture_impl_->get_arc_reset_scratch_offset(), sizeof(arc_boot_status));
+                &arc_postcode, architecture_impl_->get_arc_reset_scratch_offset(), sizeof arc_boot_status);
             return (arc_boot_status & 0x7) == 0x5;
         },
         timeout_ms,
@@ -199,8 +200,17 @@ void BlackholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds time
         poll_interval);
 
     if (!arc_core_started) {
+        read_from_arc_apb(&arc_error_status0, blackhole::SCRATCH_RAM_3, sizeof arc_error_status0);
         UMD_THROW(
-            error::ArcStartupError, *this, get_selected_noc_id(), arc_core, arc_boot_status, arc_postcode, timeout_ms);
+            error::ArcStartupError,
+            *this,
+            get_selected_noc_id(),
+            arc_core,
+            arc_boot_status,
+            arc_postcode,
+            timeout_ms,
+            /*message_id=*/std::nullopt,
+            arc_error_status0);
     }
 }
 

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -206,7 +206,7 @@ void BlackholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds time
         poll_interval);
 
     if (!arc_core_started) {
-        read_from_arc_apb(&arc_error_status0, blackhole::SCRATCH_RAM_3, sizeof arc_error_status0);
+        read_from_arc_apb(&arc_error_status0, blackhole::SCRATCH_RAM_4, sizeof arc_error_status0);
         UMD_THROW(
             error::ArcStartupError,
             *this,

--- a/device/tt_device/tt_device_error.cpp
+++ b/device/tt_device/tt_device_error.cpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/blackhole_arc.hpp"
 #include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/noc_id.hpp"
 
@@ -52,7 +53,11 @@ ArcStartupError::ArcStartupError(
             scratch_status,
             postcode,
             message_id.has_value() ? fmt::format(", message_id={:#x}", message_id.value()) : "",
-            smc_init_status.has_value() ? fmt::format(", smc_init_status={:#x}", smc_init_status.value()) : ""),
+            smc_init_status.has_value() ? fmt::format(
+                                              ", smc_init_status={:#x} ({})",
+                                              smc_init_status.value(),
+                                              blackhole::interpret_smc_init_status(smc_init_status.value()))
+                                        : ""),
         {{{tt_device}, arc_core, noc_id}, scratch_status, postcode, message_id, smc_init_status}) {}
 
 ArcStartupError::ArcStartupError(

--- a/device/tt_device/tt_device_error.cpp
+++ b/device/tt_device/tt_device_error.cpp
@@ -42,16 +42,18 @@ ArcStartupError::ArcStartupError(
     xy_pair arc_core,
     uint32_t scratch_status,
     uint32_t postcode,
-    std::optional<uint32_t> message_id) :
+    std::optional<uint32_t> message_id,
+    std::optional<uint32_t> smc_init_status) :
     UmdError<ArcStartupData>(
         fmt::format(
-            "ARC startup error at core {} over {}: scratch_status={:#x}, postcode={:#x}{}",
+            "ARC startup error at core {} over {}: scratch_status={:#x}, postcode={:#x}{}{}",
             arc_core.str(),
             noc_to_str(noc_id),
             scratch_status,
             postcode,
-            message_id.has_value() ? fmt::format(", message_id={:#x}", message_id.value()) : ""),
-        {{{tt_device}, arc_core, noc_id}, scratch_status, postcode, message_id}) {}
+            message_id.has_value() ? fmt::format(", message_id={:#x}", message_id.value()) : "",
+            smc_init_status.has_value() ? fmt::format(", smc_init_status={:#x}", smc_init_status.value()) : ""),
+        {{{tt_device}, arc_core, noc_id}, scratch_status, postcode, message_id, smc_init_status}) {}
 
 ArcStartupError::ArcStartupError(
     const TTDevice& tt_device,
@@ -60,7 +62,8 @@ ArcStartupError::ArcStartupError(
     uint32_t scratch_status,
     uint32_t postcode,
     std::chrono::milliseconds timeout,
-    std::optional<uint32_t> message_id) :
+    std::optional<uint32_t> message_id,
+    std::optional<uint32_t> smc_init_status) :
     ArcStartupError(tt_device, noc_id, arc_core, scratch_status, postcode, message_id) {
     message().append(fmt::format(" (Timed out after {} ms)", timeout.count()));
 }

--- a/device/tt_device/tt_device_error.cpp
+++ b/device/tt_device/tt_device_error.cpp
@@ -69,7 +69,7 @@ ArcStartupError::ArcStartupError(
     std::chrono::milliseconds timeout,
     std::optional<uint32_t> message_id,
     std::optional<uint32_t> smc_init_status) :
-    ArcStartupError(tt_device, noc_id, arc_core, scratch_status, postcode, message_id) {
+    ArcStartupError(tt_device, noc_id, arc_core, scratch_status, postcode, message_id, smc_init_status) {
     message().append(fmt::format(" (Timed out after {} ms)", timeout.count()));
 }
 


### PR DESCRIPTION
### Issue
#2526 

### Description
Display ARC SMC Init status in ArcStartupError. Implemented in CMFW 19.11, ARC firmware now provides flags that give more details when ARC startup failed. These are now surfaced in ArcStartupError.

### List of the changes
- Added SMC init status to ArcStartupError.
- Added interpretation for bits of ERROR_STATUS0.

### Testing
CI

### API Changes
This PR has (no) API changes.
