### PR TITLE
Fix for 6U failing

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -120,8 +120,6 @@ jobs:
             'merge_group|*|tt-ubuntu-2204-bh-loudbox-viommu-stable' \
             'merge_group|ASan|tt-ubuntu-2204-bh-loudbox-stable' \
             'merge_group|TSan|tt-ubuntu-2204-bh-loudbox-stable' \
-            'pull_request|*|6u' \
-            'merge_group|*|6u' \
             'pull_request|*|tt-ubuntu-2204-wh-glx-6u-*' \
             'merge_group|*|tt-ubuntu-2204-wh-glx-6u-*' \
             'pull_request|*|bh-gh-07' \
@@ -228,8 +226,7 @@ jobs:
           {runs-on: tt-ubuntu-2204-n150-stable},
           {runs-on: tt-ubuntu-2204-n300-stable},
           {runs-on: tt-ubuntu-2204-n300-llmbox-stable},
-          # TODO: 6u temporarily disabled — machine compromised
-          # {runs-on: 6u},
+          {runs-on: 6u},
         ]
         ubuntu-docker-version: [
           'ubuntu-22.04',

--- a/device/api/umd/device/utils/timeouts.hpp
+++ b/device/api/umd/device/utils/timeouts.hpp
@@ -10,6 +10,10 @@ namespace tt::umd::timeout {
 inline constexpr auto NON_MMIO_RW_TIMEOUT = std::chrono::milliseconds(5'000);
 
 inline constexpr auto ARC_MESSAGE_TIMEOUT = std::chrono::milliseconds(1'000);
+// ARC clears the interrupt trigger bit quickly; this just guards against concurrent
+// processes/threads opening clusters, which causes KMD to send ARC messages that
+// may leave the trigger bit set momentarily.
+inline constexpr auto ARC_TRIGGER_CLEAR_TIMEOUT = std::chrono::milliseconds(5);
 inline constexpr auto ARC_STARTUP_TIMEOUT = std::chrono::milliseconds(300'000);
 inline constexpr auto ARC_POST_RESET_TIMEOUT = std::chrono::milliseconds(1'000);
 inline constexpr auto ARC_LONG_POST_RESET_TIMEOUT = std::chrono::milliseconds(300'000);

--- a/device/arc/wormhole_arc_messenger.cpp
+++ b/device/arc/wormhole_arc_messenger.cpp
@@ -17,6 +17,7 @@
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/lock_manager.hpp"
+#include "umd/device/utils/timeouts.hpp"
 #include "utils.hpp"
 
 namespace tt::umd {
@@ -92,10 +93,10 @@ uint32_t WormholeArcMessenger::send_message(
     while (misc & (1 << 16)) {
         utils::check_timeout(
             trigger_start,
-            timeout_ms,
+            timeout::ARC_TRIGGER_CLEAR_TIMEOUT,
             fmt::format(
                 "Timed out after waiting {} ms for ARC to clear trigger bit on device {}",
-                timeout_ms.count(),
+                timeout::ARC_TRIGGER_CLEAR_TIMEOUT.count(),
                 tt_device->get_communication_device_id()));
         tt_device->read_from_arc_apb(&misc, wormhole::ARC_RESET_ARC_MISC_CNTL_OFFSET, sizeof(uint32_t));
     }

--- a/device/arc/wormhole_arc_messenger.cpp
+++ b/device/arc/wormhole_arc_messenger.cpp
@@ -87,15 +87,21 @@ uint32_t WormholeArcMessenger::send_message(
     tt_device->wait_for_non_mmio_flush();
 
     uint32_t misc;
+    auto trigger_start = std::chrono::steady_clock::now();
     tt_device->read_from_arc_apb(&misc, wormhole::ARC_RESET_ARC_MISC_CNTL_OFFSET, sizeof(uint32_t));
-
-    if (misc & (1 << 16)) {
-        log_error(LogUMD, "trigger_fw_int failed on device {}", tt_device->get_communication_device_id());
-        return 1;
-    } else {
-        uint32_t val_wr = misc | (1 << 16);
-        tt_device->write_to_arc_apb(&val_wr, wormhole::ARC_RESET_ARC_MISC_CNTL_OFFSET, sizeof(uint32_t));
+    while (misc & (1 << 16)) {
+        utils::check_timeout(
+            trigger_start,
+            timeout_ms,
+            fmt::format(
+                "Timed out after waiting {} ms for ARC to clear trigger bit on device {}",
+                timeout_ms.count(),
+                tt_device->get_communication_device_id()));
+        tt_device->read_from_arc_apb(&misc, wormhole::ARC_RESET_ARC_MISC_CNTL_OFFSET, sizeof(uint32_t));
     }
+
+    uint32_t val_wr = misc | (1 << 16);
+    tt_device->write_to_arc_apb(&val_wr, wormhole::ARC_RESET_ARC_MISC_CNTL_OFFSET, sizeof(uint32_t));
 
     uint32_t status = 0xbadbad;
     auto start = std::chrono::steady_clock::now();


### PR DESCRIPTION
### Issue
#2834 

### Description
The PR introduces a fix for the way the ARC interrupt is being read - previously it has been read once - and now it is read multiple times until the timeout is met or if the bit is cleared before the timeout has exceeded.

Note: More details are given on issue #2834 why this fix is suitable.

### List of the changes
- Added timed polling mechanism instead of hard-fail on first read for ARC interrupt status.

### Testing
Manual

### API Changes
/
