### PR TITLE
Add DeviceTimeoutError exception type

### DIFF
--- a/device/api/umd/device/utils/error.hpp
+++ b/device/api/umd/device/utils/error.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 
@@ -40,6 +43,59 @@ struct RuntimeError : public UmdError<NoData> {
 class SigbusError : public std::runtime_error {
 public:
     explicit SigbusError(const std::string& message) : std::runtime_error(message) {}
+};
+
+/**
+ * @brief Structured metadata for a host-side MMIO operation that overran its budget.
+ *
+ * Carries the timing and progress context of the timed-out transfer. operation is an owned
+ * std::string, so callers may pass temporaries safely. The IO routine that timed out is
+ * recoverable from the exception's captured stack trace, so it is not duplicated here.
+ */
+struct DeviceTimeoutData {
+    std::string operation;                ///< The individual op that overran (e.g. "store").
+    std::uint32_t op_bytes = 0;           ///< Size in bytes of the single op that overran.
+    std::chrono::nanoseconds delta{0};    ///< Wall-clock time the op actually took.
+    std::chrono::milliseconds budget{0};  ///< Configured per-op budget that was exceeded.
+    std::size_t bytes_remaining = 0;      ///< Bytes still to transfer when the budget elapsed.
+    std::size_t total_bytes = 0;          ///< Total bytes of the overall transfer.
+};
+
+/**
+ * @brief Error raised when a host-side MMIO operation exceeds its configured wall-clock budget.
+ *
+ * Distinct from SigbusError: SigbusError indicates the platform's PCIe completion timeout fired
+ * (a hardware-detected fault), whereas DeviceTimeoutError indicates a software budget elapsed —
+ * typically because writes were piling up against a slow or dead NOC before SIGBUS could fire.
+ * Keeping them separate lets callers branch on retry policy.
+ */
+struct DeviceTimeoutError : public UmdError<DeviceTimeoutData> {
+    DeviceTimeoutError(
+        const std::string& operation,
+        std::uint32_t op_bytes,
+        std::chrono::nanoseconds delta,
+        std::chrono::milliseconds budget,
+        std::size_t bytes_remaining,
+        std::size_t total_bytes) :
+        UmdError<DeviceTimeoutData>(
+            format_message(operation, op_bytes, delta, budget, bytes_remaining, total_bytes),
+            DeviceTimeoutData{operation, op_bytes, delta, budget, bytes_remaining, total_bytes}) {}
+
+private:
+    static std::string format_message(
+        const std::string& operation,
+        std::uint32_t op_bytes,
+        std::chrono::nanoseconds delta,
+        std::chrono::milliseconds budget,
+        std::size_t bytes_remaining,
+        std::size_t total_bytes) {
+        // Report in microseconds: the budget is in whole ms but a sub-ms overrun (or a 0 ms budget)
+        // would otherwise truncate to "took 0 ms", under-reporting the elapsed time for diagnostics.
+        const auto delta_us = std::chrono::duration_cast<std::chrono::microseconds>(delta).count();
+        return "MMIO per-op timeout: " + std::to_string(op_bytes) + "B " + operation + " took " +
+               std::to_string(delta_us) + " us (budget=" + std::to_string(budget.count()) + " ms), " +
+               std::to_string(bytes_remaining) + " of " + std::to_string(total_bytes) + " bytes remaining.";
+    }
 };
 
 }  // namespace tt::umd::error


### PR DESCRIPTION
### Issue

#1673

### Description

Adds `DeviceTimeoutError`, a structured exception for host-side MMIO operations that overrun a wall-clock budget. It is the dependency leaf of the per-op MMIO timeout work (#2629) — split out into its own PR so the timeout mechanism can stack on top of it.

`DeviceTimeoutError` is distinct from `SigbusError`: `SigbusError` signals the platform PCIe completion timeout (a hardware-detected fault), whereas `DeviceTimeoutError` signals that a software per-op budget elapsed — typically because writes were piling up against a slow or dead NOC before SIGBUS could fire. Keeping them as separate types lets callers branch on retry policy.

There are no throwers yet; this PR only introduces the type and its metadata.

### List of the changes

- New `tt::umd::error::DeviceTimeoutData` struct carrying the timing/progress context of a timed-out transfer (function name, operation, op bytes, elapsed time, configured budget, bytes remaining, total bytes).
- New `tt::umd::error::DeviceTimeoutError : public UmdError<DeviceTimeoutData>`, with a formatted message derived from that metadata.

### Testing

CI

### API Changes

- New exception type `tt::umd::error::DeviceTimeoutError`.
- New metadata struct `tt::umd::error::DeviceTimeoutData`.