### PR TITLE
Add reset function to tt-kmd-lib

### DIFF
--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -295,7 +295,14 @@ public:
     static uint8_t read_command_byte(const int pci_device_num);
 
     /**
-     * Reset device via ioctl.
+     * @brief Resets the specified Tenstorrent PCIe devices.
+     *
+     * @param pci_target_devices A set of PCI device identifiers to be reset.
+     *                          Each identifier uniquely identifies a device on the PCI bus.
+     * @param flag The type of reset operation to perform on the target devices.
+     *
+     * @note This is a blocking operation that may take time to complete depending
+     *       on the number of devices and the reset type.
      */
     static void reset_devices(const std::unordered_set<int> &pci_target_devices, TenstorrentResetDevice flag);
 

--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -297,7 +297,7 @@ public:
     /**
      * Reset device via ioctl.
      */
-    static void reset_device_ioctl(const std::unordered_set<int> &pci_target_devices, TenstorrentResetDevice flag);
+    static void reset_devices(const std::unordered_set<int> &pci_target_devices, TenstorrentResetDevice flag);
 
     /**
      * Temporary function which allows us to support both ways of mapping buffers during the transition period.

--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -297,14 +297,16 @@ public:
     /**
      * @brief Resets the specified Tenstorrent PCIe devices.
      *
-     * @param pci_target_devices A set of PCI device identifiers to be reset.
+     * @param pci_target_devices A set of PCI device identifiers to be reset. (/dev/tenstorrent/N)
      *                          Each identifier uniquely identifies a device on the PCI bus.
      * @param flag The type of reset operation to perform on the target devices.
+     * @param ignore_failures Ignore any failures when sending reset ioctls.
      *
      * @note This is a blocking operation that may take time to complete depending
      *       on the number of devices and the reset type.
      */
-    static void reset_devices(const std::unordered_set<int> &pci_target_devices, TenstorrentResetDevice flag);
+    static void send_reset_ioctl_to_devices(
+        const std::unordered_set<int> &pci_target_devices, TenstorrentResetDevice flag, bool ignore_failures = true);
 
     /**
      * Temporary function which allows us to support both ways of mapping buffers during the transition period.

--- a/device/api/umd/device/tt_kmd_lib/tt_kmd_lib.h
+++ b/device/api/umd/device/tt_kmd_lib/tt_kmd_lib.h
@@ -8,8 +8,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "umd/device/pcie/pci_ids.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -387,6 +385,15 @@ int tt_tlb_map(tt_device_t* dev, tt_tlb_t* tlb, tt_noc_addr_config_t* config);
  * @return 0 on success, error code on failure
  */
 int tt_tlb_map_unicast(tt_device_t* dev, tt_tlb_t* tlb, uint8_t x, uint8_t y, uint64_t addr);
+
+/**
+ * @brief Reset the given device. The device handle will be invalidated after a successful reset.
+ *
+ * @param dev Device handle; may be NULL for API version query
+ * @param flags Reset flags.
+ * @return 0 on success, error code on failure
+ */
+int tt_device_reset(tt_device_t* dev, uint32_t reset_flags);
 
 #ifdef __cplusplus
 }

--- a/device/api/umd/device/tt_kmd_lib/tt_kmd_lib.h
+++ b/device/api/umd/device/tt_kmd_lib/tt_kmd_lib.h
@@ -389,9 +389,9 @@ int tt_tlb_map_unicast(tt_device_t* dev, tt_tlb_t* tlb, uint8_t x, uint8_t y, ui
 /**
  * @brief Reset the given device. The device handle will be invalidated after a successful reset.
  *
- * @param dev Device handle; may be NULL for API version query
- * @param flags Reset flags.
- * @return 0 on success, error code on failure
+ * @param dev Device handle; must not be NULL
+ * @param reset_flags Reset flags.
+ * @return 0 on success, negative error code on failure
  */
 int tt_device_reset(tt_device_t* dev, uint32_t reset_flags);
 

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -197,21 +197,21 @@ PciDeviceInfo PCIDevice::read_device_info(int fd) {
         get_physical_slot_for_pcie_bdf(pci_bdf)};
 }
 
-static void reset_device_ioctl(int device_id, uint32_t flags) {
+static void send_reset_ioctl(int device_id, uint32_t flags) {
     log_debug(tt::LogUMD, "Attempting to reset PCI device ID {} with flags {}", device_id, flags);
     std::string device_path = fmt::format("/dev/tenstorrent/{}", device_id);
     tt_device_t *dev = nullptr;
     int err = tt_device_open(device_path.c_str(), &dev, O_RDWR | O_CLOEXEC | O_APPEND);
     if (err != 0) {
-        log_error(LogUMD, "Failed to open device {} on path {} with error: {}", device_id, device_path, strerror(-err));
-        return;
+        UMD_THROW(error::RuntimeError, fmt::format("Failed to open device {}: {}", device_id, strerror(-err)));
     }
 
     err = tt_device_reset(dev, flags);
     if (err != 0) {
         UMD_THROW(
             error::RuntimeError,
-            fmt::format("Reset failed on device {} with flags {}: {}", device_id, flags, strerror(-err)));
+            fmt::format(
+                "Sending reset command failed on device {} with flags {:#x}: {}", device_id, flags, strerror(-err)));
     }
 }
 
@@ -896,7 +896,8 @@ void PCIDevice::configure_tlb(const uint32_t tlb_index, const tlb_data &tlb_conf
         tlb_config.static_vc);
 }
 
-void PCIDevice::reset_devices(const std::unordered_set<int> &pci_target_devices, TenstorrentResetDevice flag) {
+void PCIDevice::send_reset_ioctl_to_devices(
+    const std::unordered_set<int> &pci_target_devices, TenstorrentResetDevice flags, bool ignore_failures) {
     for (int n : PCIDevice::enumerate_devices()) {
         // Since TT_VISIBLE_DEVICES and pci_target_devices filtering is decoupled now, we need
         // to check if the device is in the pci_target_devices set.
@@ -904,11 +905,12 @@ void PCIDevice::reset_devices(const std::unordered_set<int> &pci_target_devices,
             continue;
         }
         try {
-            reset_device_ioctl(n, static_cast<uint32_t>(flag));
-        } catch (const std::exception &e) {
-            log_error(tt::LogUMD, "Reset failed: {}", e.what());
-        } catch (...) {
-            log_error(tt::LogUMD, "Reset failed with unknown error.");
+            send_reset_ioctl(n, static_cast<uint32_t>(flags));
+        } catch (error::UmdBaseException &e) {
+            if (!ignore_failures) {
+                throw;
+            }
+            log_error(LogUMD, "Sending reset ioctl to device {} failed: {}", n, e.what());
         }
     }
 }

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -205,36 +205,27 @@ static void reset_device_ioctl(const std::unordered_set<int> &pci_target_devices
             continue;
         }
 
-        log_debug(tt::LogUMD, "Issuing reset ioctl on PCI device ID {} with flags {}", n, flags);
-        int fd = open(fmt::format("/dev/tenstorrent/{}", n).c_str(), O_RDWR | O_CLOEXEC | O_APPEND);
-        if (fd == -1) {
+        log_debug(tt::LogUMD, "Attempting to reset PCI device ID {} with flags {}", n, flags);
+        std::string device_path = fmt::format("/dev/tenstorrent/{}", n);
+        tt_device_t *dev = nullptr;
+        int err = tt_device_open(device_path.c_str(), &dev, O_RDWR | O_CLOEXEC | O_APPEND);
+        if (err != 0) {
+            log_error(LogUMD, "Failed to open device {} on path {} with error: {}", n, device_path, strerror(err));
             continue;
         }
 
         try {
-            tenstorrent_reset_device reset_info{};
-
-            reset_info.in.output_size_bytes = sizeof(reset_info.out);
-            reset_info.in.flags = flags;
-
-            reset_info.out.output_size_bytes = 0;
-            reset_info.out.result = 0;
-            if (ioctl(fd, TENSTORRENT_IOCTL_RESET_DEVICE, &reset_info) == -1) {
+            int err = tt_device_reset(dev, flags);
+            if (err != 0) {
                 UMD_THROW(
                     error::RuntimeError,
-                    fmt::format(
-                        "TENSTORRENT_IOCTL_RESET_DEVICE failed on device {} with flags {}: {}",
-                        n,
-                        flags,
-                        strerror(errno)));
+                    fmt::format("Reset failed on device {} with flags {}: {}", n, flags, strerror(errno)));
             }
         } catch (const std::exception &e) {
-            log_error(tt::LogUMD, "Reset IOCTL failed: {}", e.what());
+            log_error(tt::LogUMD, "Reset failed: {}", e.what());
         } catch (...) {
-            log_error(tt::LogUMD, "Reset IOCTL failed with unknown error.");
+            log_error(tt::LogUMD, "Reset failed with unknown error.");
         }
-
-        close(fd);
     }
 }
 

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -197,35 +197,21 @@ PciDeviceInfo PCIDevice::read_device_info(int fd) {
         get_physical_slot_for_pcie_bdf(pci_bdf)};
 }
 
-static void reset_device_ioctl(const std::unordered_set<int> &pci_target_devices, uint32_t flags) {
-    for (int n : PCIDevice::enumerate_devices()) {
-        // Since TT_VISIBLE_DEVICES and pci_target_devices filtering is decoupled now, we need
-        // to check if the device is in the pci_target_devices set.
-        if (!pci_target_devices.empty() && pci_target_devices.find(n) == pci_target_devices.end()) {
-            continue;
-        }
+static void reset_device_ioctl(int device_id, uint32_t flags) {
+    log_debug(tt::LogUMD, "Attempting to reset PCI device ID {} with flags {}", device_id, flags);
+    std::string device_path = fmt::format("/dev/tenstorrent/{}", device_id);
+    tt_device_t *dev = nullptr;
+    int err = tt_device_open(device_path.c_str(), &dev, O_RDWR | O_CLOEXEC | O_APPEND);
+    if (err != 0) {
+        log_error(LogUMD, "Failed to open device {} on path {} with error: {}", device_id, device_path, strerror(err));
+        return;
+    }
 
-        log_debug(tt::LogUMD, "Attempting to reset PCI device ID {} with flags {}", n, flags);
-        std::string device_path = fmt::format("/dev/tenstorrent/{}", n);
-        tt_device_t *dev = nullptr;
-        int err = tt_device_open(device_path.c_str(), &dev, O_RDWR | O_CLOEXEC | O_APPEND);
-        if (err != 0) {
-            log_error(LogUMD, "Failed to open device {} on path {} with error: {}", n, device_path, strerror(err));
-            continue;
-        }
-
-        try {
-            int err = tt_device_reset(dev, flags);
-            if (err != 0) {
-                UMD_THROW(
-                    error::RuntimeError,
-                    fmt::format("Reset failed on device {} with flags {}: {}", n, flags, strerror(errno)));
-            }
-        } catch (const std::exception &e) {
-            log_error(tt::LogUMD, "Reset failed: {}", e.what());
-        } catch (...) {
-            log_error(tt::LogUMD, "Reset failed with unknown error.");
-        }
+    err = tt_device_reset(dev, flags);
+    if (err != 0) {
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format("Reset failed on device {} with flags {}: {}", device_id, flags, strerror(errno)));
     }
 }
 
@@ -910,8 +896,22 @@ void PCIDevice::configure_tlb(const uint32_t tlb_index, const tlb_data &tlb_conf
         tlb_config.static_vc);
 }
 
-void PCIDevice::reset_device_ioctl(const std::unordered_set<int> &pci_target_devices, TenstorrentResetDevice flag) {
-    umd::reset_device_ioctl(pci_target_devices, static_cast<uint32_t>(flag));
+void PCIDevice::reset_devices(const std::unordered_set<int> &pci_target_devices, TenstorrentResetDevice flag) {
+    for (int n : PCIDevice::enumerate_devices()) {
+        // Since TT_VISIBLE_DEVICES and pci_target_devices filtering is decoupled now, we need
+        // to check if the device is in the pci_target_devices set.
+        if (!pci_target_devices.empty() && pci_target_devices.find(n) == pci_target_devices.end()) {
+            log_warning(LogUMD, "Device requested for reset: {} not found.", n);
+            continue;
+        }
+        try {
+            reset_device_ioctl(n, static_cast<uint32_t>(flag));
+        } catch (const std::exception &e) {
+            log_error(tt::LogUMD, "Reset failed: {}", e.what());
+        } catch (...) {
+            log_error(tt::LogUMD, "Reset failed with unknown error.");
+        }
+    }
 }
 
 uint8_t PCIDevice::read_command_byte(const int pci_device_num) {

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -203,7 +203,7 @@ static void reset_device_ioctl(int device_id, uint32_t flags) {
     tt_device_t *dev = nullptr;
     int err = tt_device_open(device_path.c_str(), &dev, O_RDWR | O_CLOEXEC | O_APPEND);
     if (err != 0) {
-        log_error(LogUMD, "Failed to open device {} on path {} with error: {}", device_id, device_path, strerror(err));
+        log_error(LogUMD, "Failed to open device {} on path {} with error: {}", device_id, device_path, strerror(-err));
         return;
     }
 
@@ -211,7 +211,7 @@ static void reset_device_ioctl(int device_id, uint32_t flags) {
     if (err != 0) {
         UMD_THROW(
             error::RuntimeError,
-            fmt::format("Reset failed on device {} with flags {}: {}", device_id, flags, strerror(errno)));
+            fmt::format("Reset failed on device {} with flags {}: {}", device_id, flags, strerror(-err)));
     }
 }
 
@@ -901,7 +901,6 @@ void PCIDevice::reset_devices(const std::unordered_set<int> &pci_target_devices,
         // Since TT_VISIBLE_DEVICES and pci_target_devices filtering is decoupled now, we need
         // to check if the device is in the pci_target_devices set.
         if (!pci_target_devices.empty() && pci_target_devices.find(n) == pci_target_devices.end()) {
-            log_warning(LogUMD, "Device requested for reset: {} not found.", n);
             continue;
         }
         try {

--- a/device/tt_kmd_lib/tt_kmd_lib.c
+++ b/device/tt_kmd_lib/tt_kmd_lib.c
@@ -514,3 +514,23 @@ int tt_tlb_map_unicast(tt_device_t* dev, tt_tlb_t* tlb, uint8_t x, uint8_t y, ui
 
     return 0;
 }
+
+int tt_device_reset(tt_device_t* dev, uint32_t reset_flags) {
+    struct tenstorrent_reset_device reset_info = {0};
+
+    if (dev == NULL) {
+        return -ENODEV;
+    }
+
+    reset_info.in.output_size_bytes = sizeof(reset_info.out);
+    reset_info.in.flags = reset_flags;
+
+    reset_info.out.output_size_bytes = 0;
+    reset_info.out.result = 0;
+
+    if (ioctl(dev->fd, TENSTORRENT_IOCTL_RESET_DEVICE, &reset_info) != 0) {
+        return -errno;
+    }
+
+    return tt_device_close(dev);
+}

--- a/device/warm_reset.cpp
+++ b/device/warm_reset.cpp
@@ -40,6 +40,7 @@
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/tt_device/tt_device_error.hpp"
 #include "umd/device/types/arch.hpp"
+#include "umd/device/utils/error.hpp"
 #include "umd/device/utils/timeouts.hpp"
 #include "utils.hpp"
 
@@ -204,13 +205,13 @@ bool WarmReset::warm_reset_arch_agnostic(
     }
     log_info(tt::LogUMD, "Starting reset on devices: {}", fmt::join(device_infos, ", "));
     if (secondary_bus_reset) {
-        PCIDevice::reset_devices(pci_device_id_set, TenstorrentResetDevice::RESET_PCIE_LINK);
+        PCIDevice::send_reset_ioctl_to_devices(pci_device_id_set, TenstorrentResetDevice::RESET_PCIE_LINK);
     }
 
     if (reset_m3) {
-        PCIDevice::reset_devices(pci_device_id_set, TenstorrentResetDevice::ASIC_DMC_RESET);
+        PCIDevice::send_reset_ioctl_to_devices(pci_device_id_set, TenstorrentResetDevice::ASIC_DMC_RESET);
     } else {
-        PCIDevice::reset_devices(pci_device_id_set, TenstorrentResetDevice::ASIC_RESET);
+        PCIDevice::send_reset_ioctl_to_devices(pci_device_id_set, TenstorrentResetDevice::ASIC_RESET);
     }
 
     // Calculate post-reset wait time: use provided M3 timeout if M3 reset, otherwise scale based on device count
@@ -233,13 +234,13 @@ bool WarmReset::warm_reset_arch_agnostic(
         }
     }
 
-    PCIDevice::reset_devices(pci_device_id_set, TenstorrentResetDevice::POST_RESET);
+    PCIDevice::send_reset_ioctl_to_devices(pci_device_id_set, TenstorrentResetDevice::POST_RESET);
     return true;
 }
 
 bool WarmReset::warm_reset_blackhole_legacy(std::vector<int> pci_device_ids) {
     std::unordered_set<int> pci_device_ids_set(pci_device_ids.begin(), pci_device_ids.end());
-    PCIDevice::reset_devices(pci_device_ids_set, TenstorrentResetDevice::CONFIG_WRITE);
+    PCIDevice::send_reset_ioctl_to_devices(pci_device_ids_set, TenstorrentResetDevice::CONFIG_WRITE);
 
     std::map<int, bool> reset_bits;
 
@@ -286,7 +287,7 @@ bool WarmReset::warm_reset_blackhole_legacy(std::vector<int> pci_device_ids) {
     if (all_reset_bits_set) {
         log_info(tt::LogUMD, "Reset successfully completed.");
     }
-    PCIDevice::reset_devices(pci_device_ids_set, TenstorrentResetDevice::RESTORE_STATE);
+    PCIDevice::send_reset_ioctl_to_devices(pci_device_ids_set, TenstorrentResetDevice::RESTORE_STATE);
     return all_reset_bits_set;
 }
 
@@ -297,7 +298,7 @@ bool WarmReset::warm_reset_wormhole_legacy(std::vector<int> pci_device_ids, bool
     static constexpr uint32_t MSG_TYPE_TRIGGER_RESET = 0x56 | wormhole::ARC_MSG_COMMON_PREFIX;
 
     std::unordered_set<int> pci_device_ids_set(pci_device_ids.begin(), pci_device_ids.end());
-    PCIDevice::reset_devices(pci_device_ids_set, TenstorrentResetDevice::RESET_PCIE_LINK);
+    PCIDevice::send_reset_ioctl_to_devices(pci_device_ids_set, TenstorrentResetDevice::RESET_PCIE_LINK);
 
     std::vector<std::unique_ptr<TTDevice>> tt_devices;
     tt_devices.reserve(pci_device_ids.size());
@@ -343,7 +344,7 @@ bool WarmReset::warm_reset_wormhole_legacy(std::vector<int> pci_device_ids, bool
     std::vector<uint64_t> refclk_current;
     refclk_current.reserve(pci_device_ids.size());
 
-    PCIDevice::reset_devices(pci_device_ids_set, TenstorrentResetDevice::RESTORE_STATE);
+    PCIDevice::send_reset_ioctl_to_devices(pci_device_ids_set, TenstorrentResetDevice::RESTORE_STATE);
 
     for (const auto& tt_device : tt_devices) {
         refclk_current.emplace_back(tt_device->get_refclk_counter());

--- a/device/warm_reset.cpp
+++ b/device/warm_reset.cpp
@@ -204,13 +204,13 @@ bool WarmReset::warm_reset_arch_agnostic(
     }
     log_info(tt::LogUMD, "Starting reset on devices: {}", fmt::join(device_infos, ", "));
     if (secondary_bus_reset) {
-        PCIDevice::reset_device_ioctl(pci_device_id_set, TenstorrentResetDevice::RESET_PCIE_LINK);
+        PCIDevice::reset_devices(pci_device_id_set, TenstorrentResetDevice::RESET_PCIE_LINK);
     }
 
     if (reset_m3) {
-        PCIDevice::reset_device_ioctl(pci_device_id_set, TenstorrentResetDevice::ASIC_DMC_RESET);
+        PCIDevice::reset_devices(pci_device_id_set, TenstorrentResetDevice::ASIC_DMC_RESET);
     } else {
-        PCIDevice::reset_device_ioctl(pci_device_id_set, TenstorrentResetDevice::ASIC_RESET);
+        PCIDevice::reset_devices(pci_device_id_set, TenstorrentResetDevice::ASIC_RESET);
     }
 
     // Calculate post-reset wait time: use provided M3 timeout if M3 reset, otherwise scale based on device count
@@ -233,13 +233,13 @@ bool WarmReset::warm_reset_arch_agnostic(
         }
     }
 
-    PCIDevice::reset_device_ioctl(pci_device_id_set, TenstorrentResetDevice::POST_RESET);
+    PCIDevice::reset_devices(pci_device_id_set, TenstorrentResetDevice::POST_RESET);
     return true;
 }
 
 bool WarmReset::warm_reset_blackhole_legacy(std::vector<int> pci_device_ids) {
     std::unordered_set<int> pci_device_ids_set(pci_device_ids.begin(), pci_device_ids.end());
-    PCIDevice::reset_device_ioctl(pci_device_ids_set, TenstorrentResetDevice::CONFIG_WRITE);
+    PCIDevice::reset_devices(pci_device_ids_set, TenstorrentResetDevice::CONFIG_WRITE);
 
     std::map<int, bool> reset_bits;
 
@@ -286,7 +286,7 @@ bool WarmReset::warm_reset_blackhole_legacy(std::vector<int> pci_device_ids) {
     if (all_reset_bits_set) {
         log_info(tt::LogUMD, "Reset successfully completed.");
     }
-    PCIDevice::reset_device_ioctl(pci_device_ids_set, TenstorrentResetDevice::RESTORE_STATE);
+    PCIDevice::reset_devices(pci_device_ids_set, TenstorrentResetDevice::RESTORE_STATE);
     return all_reset_bits_set;
 }
 
@@ -297,7 +297,7 @@ bool WarmReset::warm_reset_wormhole_legacy(std::vector<int> pci_device_ids, bool
     static constexpr uint32_t MSG_TYPE_TRIGGER_RESET = 0x56 | wormhole::ARC_MSG_COMMON_PREFIX;
 
     std::unordered_set<int> pci_device_ids_set(pci_device_ids.begin(), pci_device_ids.end());
-    PCIDevice::reset_device_ioctl(pci_device_ids_set, TenstorrentResetDevice::RESET_PCIE_LINK);
+    PCIDevice::reset_devices(pci_device_ids_set, TenstorrentResetDevice::RESET_PCIE_LINK);
 
     std::vector<std::unique_ptr<TTDevice>> tt_devices;
     tt_devices.reserve(pci_device_ids.size());
@@ -343,7 +343,7 @@ bool WarmReset::warm_reset_wormhole_legacy(std::vector<int> pci_device_ids, bool
     std::vector<uint64_t> refclk_current;
     refclk_current.reserve(pci_device_ids.size());
 
-    PCIDevice::reset_device_ioctl(pci_device_ids_set, TenstorrentResetDevice::RESTORE_STATE);
+    PCIDevice::reset_devices(pci_device_ids_set, TenstorrentResetDevice::RESTORE_STATE);
 
     for (const auto& tt_device : tt_devices) {
         refclk_current.emplace_back(tt_device->get_refclk_counter());


### PR DESCRIPTION
### Issue
Starts #2749

### Description
Add reset functionality to tt-kmd-lib, removing the need for a direct ioctl call in PciDevice.

### List of the changes
- Introduce `tt_device_reset()` to tt-kmd-lib.
- Replace ioctl call in `PciDevice` with kmd lib function.
- Rename method to `send_reset_ioctl_to_devices()`, move loop.

### Testing
CI

### API Changes
This PR has API changes.
