### PR TITLE
[tt-emule] Skip risc-reset register broadcast for SWEMULE chips

### DIFF
--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -576,6 +576,12 @@ std::set<ChipId> Cluster::get_target_mmio_device_ids() { return local_chip_ids_;
 std::set<ChipId> Cluster::get_target_remote_device_ids() { return remote_chip_ids_; }
 
 void Cluster::assert_risc_reset() {
+    // SW-emule cores have no register backing, so the soft-reset register broadcast would land
+    // out of L1. The reset is a no-op for emule (cf. the per-chip deassert_risc_resets() override).
+    if (options_.chip_type == ChipType::SWEMULE) {
+        return;
+    }
+
     // Workaround for quasar. Broadcast reset is not supported for quasar so we need to
     // loop all chips and issues the reset separately.
     if (arch_name == tt::ARCH::QUASAR) {
@@ -591,6 +597,11 @@ void Cluster::assert_risc_reset() {
 }
 
 void Cluster::deassert_risc_reset() {
+    // SW-emule cores have no register backing; the deassert broadcast is a no-op for emule.
+    if (options_.chip_type == ChipType::SWEMULE) {
+        return;
+    }
+
     // Workaround for quasar. Broadcast reset is not supported for quasar so we need to
     // loop all chips and issues the reset separately.
     if (arch_name == tt::ARCH::QUASAR) {


### PR DESCRIPTION
### Issue
N/A

### Description
#2552 removed the per-chip `send_tensix_risc_reset()` dispatch (which `SWEmuleChip` overrode as a no-op) and made the cluster-wide `Cluster::assert_risc_reset()` / `deassert_risc_reset()` unconditionally broadcast a write to the Tensix soft-reset MMIO register `0xFFB121B0` .

This breaks the software-emulation (`SWEMULE`) device. An emule Core is L1-only (~1.43 MB, no register/MMIO backing), so `SWEmuleChip::write_to_device` routes the soft-reset broadcast into `Core::l1_ptr(0xFFB121B0)`, whose bounds check (`offset >= l1_size_`) `abort()`s with `[EMULE] Core::l1_ptr OOB ... offset=0xffb121b0`. Because the broadcast is issued from `start_device` → `deassert_resets_and_set_power_state` → `assert_risc_reset`, every emule run `SIGABRT`s at device-open, before any kernel executes.

### List of the changes
 - `device/cluster.cpp`, 1Cluster::assert_risc_reset()1: early return when `options_.chip_type == ChipType::SWEMULE`, placed before the `arch_name == tt::ARCH::QUASAR` workaround.
  - `device/cluster.cpp`, `Cluster::deassert_risc_reset()`: same early return for `ChipType::SWEMULE`, before the QUASAR workaround.
  - Added explanatory comments on both branches noting emule cores have no register backing and the reset is a no-op

### Testing

Toggled the change and ran the following test in metal (available on the branch `smeydanshahiTT/tt-emule`). Note this test verifies behaviour around reserving a number of pages in a CB:
`$ROOT/tt-metal/build_emule/test/tt_metal/unit_tests_api --gtest_filter="MeshDeviceFixture.CB_Reservation_*"`

With change present:
```
[==========] 3 tests from 1 test suite ran. (16374 ms total)
[  PASSED  ] 3 tests.
```

With change commented out: 
```
[----------] 3 tests from MeshDeviceFixture
[ RUN      ] MeshDeviceFixture.CB_Reservation_Overflow_SanityCheck
2026-06-17 14:49:12.784 | info     |           Metal | Disabling multi-erisc mode with simulator/mock target device (rtoptions.cpp:345)
2026-06-17 14:49:12.785 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:228)
2026-06-17 14:49:12.785 | warning  |          Device | Using emulated device mode with memory-backed I/O (tt_cluster.cpp:254)
2026-06-17 14:49:12.785 | info     |             UMD | Cluster constructor started. (cluster.cpp:335)
2026-06-17 14:49:12.960 | info     |             UMD | Cluster constructor completed. (cluster.cpp:507)
2026-06-17 14:49:12.961 | info     |             UMD | Starting devices in cluster (cluster.cpp:1010)
[EMULE] Core::l1_ptr OOB: role=WORKER coord=(18,18) offset=0xffb121b0 size=0x16e000
Aborted (core dumped)
```

### API Changes
This PR has no API changes.
