### PR TITLE
Expose DeviceTimeoutError to Python

### DIFF
--- a/nanobind/py_api_error.cpp
+++ b/nanobind/py_api_error.cpp
@@ -9,6 +9,8 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
+#include <chrono>
+
 #include "umd/device/tt_device/tt_device_error.hpp"
 #include "umd/device/utils/error.hpp"
 
@@ -29,6 +31,19 @@ void bind_error(nb::module_ &m) {
 
     // Base exception class.
     static nb::exception<UmdBaseException> umd_base_exception(error_module, "UmdBaseException");
+
+    // DeviceTimeoutError: a critical, catchable exception so Python callers can recover from a host-side
+    // MMIO timeout rather than crash. It is thrown wrapped as UmdException<DeviceTimeoutError>; registering
+    // it after the base, as a UmdBaseException subclass, makes its translator take precedence, so both
+    // `except error.DeviceTimeoutError` and `except error.UmdBaseException` catch it.
+    nb::exception<UmdException<DeviceTimeoutError>>(error_module, "DeviceTimeoutError", umd_base_exception);
+    error_module.def(
+        "raise_device_timeout_error_for_testing",
+        []() {
+            UMD_THROW(DeviceTimeoutError, "store", 4, std::chrono::nanoseconds(0), std::chrono::milliseconds(0), 0, 0);
+        },
+        release_gil(),
+        "Raise a DeviceTimeoutError from C++ to verify it propagates to Python.");
 
     // NoData struct for errors without metadata.
     nb::class_<NoData>(error_module, "NoData").def(nb::init<>(), release_gil());

--- a/nanobind/tests/test_py_tt_device.py
+++ b/nanobind/tests/test_py_tt_device.py
@@ -465,6 +465,19 @@ class TestTTDevice(unittest.TestCase):
         # Verify the message passed through
         self.assertIn("This is a test exception from C++", str(cm.exception))
 
+    def test_device_timeout_exception_type_binding(self):
+        """
+        Verifies that the C++ DeviceTimeoutError maps to a Python type that can be caught
+        specifically, and is also catchable as the base UmdBaseException.
+        """
+        # It can be caught as its own specific type.
+        with self.assertRaises(tt_umd.error.DeviceTimeoutError):
+            tt_umd.error.raise_device_timeout_error_for_testing()
+
+        # It is a subclass of the base UMD exception, so the base catches it too.
+        with self.assertRaises(tt_umd.error.UmdBaseException):
+            tt_umd.error.raise_device_timeout_error_for_testing()
+
     def test_hang_detection_api(self):
         """Verify HangAction enum and hang detection methods on a healthy device."""
         # Enum is reachable and has distinct members.


### PR DESCRIPTION
### Issue

#1673

### Description

`DeviceTimeoutError` is the host-side MMIO per-op timeout exception. It was not exposed to the Python bindings, so a Python caller could not catch it specifically — a timeout would surface only as the generic base exception (or crash the host). This exposes it as a catchable Python exception so callers can recover gracefully.

It is thrown wrapped as `UmdException<DeviceTimeoutError>`. Registering it as a Python exception after the base `error.UmdBaseException` (and as a subclass of it) makes its translator take precedence, so both `except error.DeviceTimeoutError` and `except error.UmdBaseException` catch it. This mirrors the existing `SigbusError` binding.

### List of the changes

- Register `tt::umd::error::DeviceTimeoutError` as a catchable Python exception (`error.DeviceTimeoutError`, a subclass of `error.UmdBaseException`) in `py_api_error.cpp`.
- Add a `error.raise_device_timeout_error_for_testing()` helper to verify propagation, mirroring `raise_sigbus_error_for_testing`.
- Add a unit test asserting the exception is catchable both as `error.DeviceTimeoutError` and as `error.UmdBaseException`.

### Testing

CI

### API Changes

- New Python exception `tt_umd.error.DeviceTimeoutError` (subclass of `tt_umd.error.UmdBaseException`).
- New test-only helper `tt_umd.error.raise_device_timeout_error_for_testing()`.