### PR TITLE
Use tt_kmd_lib for setting power state and KMD API version

### DIFF
--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -321,7 +321,7 @@ public:
      * Set the power state of this device via the KMD power API (requires KMD >= 2.6.0).
      * When busy is true, all power domains are requested (max AI clock, PHY wakeup, Tensix and L2CPU enabled).
      * When busy is false, all power flags are released, allowing the device to enter a low-power idle state.
-     * Has no effect on KMD versions older than 2.6.0.
+     * Has no effect on KMD versions older than 2.6.0. Has no effect on non-Blackhole devices.
      *
      * @param busy true to request full power, false to release power flags.
      */

--- a/device/api/umd/device/tt_kmd_lib/tt_kmd_lib.h
+++ b/device/api/umd/device/tt_kmd_lib/tt_kmd_lib.h
@@ -388,6 +388,31 @@ int tt_tlb_map(tt_device_t* dev, tt_tlb_t* tlb, tt_noc_addr_config_t* config);
  */
 int tt_tlb_map_unicast(tt_device_t* dev, tt_tlb_t* tlb, uint8_t x, uint8_t y, uint64_t addr);
 
+/**
+ * @brief Power flags for use with tt_device_set_power_state().
+ */
+#define TT_POWER_FLAG_MAX_AI_CLK (1U << 0)       /**< 1=Max AI Clock,  0=Min AI Clock */
+#define TT_POWER_FLAG_MRISC_PHY_WAKEUP (1U << 1) /**< 1=PHY Wakeup,    0=PHY Powerdown */
+#define TT_POWER_FLAG_TENSIX_ENABLE (1U << 2)    /**< 1=Enable Tensix, 0=Clock Gate Tensix */
+#define TT_POWER_FLAG_L2CPU_ENABLE (1U << 3)     /**< 1=Enable L2CPU,  0=Clock Gate L2CPU */
+
+/**
+ * @brief Set per-client power state requirements for this device file descriptor.
+ *
+ * Declares the power requirements of this file descriptor to the driver.
+ * The driver aggregates requirements across all open file descriptors,
+ * applying bitwise OR for power_flags. When the file descriptor is closed,
+ * its contribution is removed.
+ *
+ * Opening the device with O_APPEND opts out of legacy mode, allowing the
+ * device to enter low-power idle states when no client holds power flags.
+ *
+ * @param dev        Device handle
+ * @param power_flags Bitmask of TT_POWER_FLAG_* values
+ * @return 0 on success, negative error code on failure
+ */
+int tt_device_set_power_state(tt_device_t* dev, uint16_t power_flags);
+
 #ifdef __cplusplus
 }
 #endif

--- a/device/api/umd/device/tt_kmd_lib/tt_kmd_lib.h
+++ b/device/api/umd/device/tt_kmd_lib/tt_kmd_lib.h
@@ -391,10 +391,12 @@ int tt_tlb_map_unicast(tt_device_t* dev, tt_tlb_t* tlb, uint8_t x, uint8_t y, ui
 /**
  * @brief Power flags for use with tt_device_set_power_state().
  */
-#define TT_POWER_FLAG_MAX_AI_CLK (1U << 0)       /**< 1=Max AI Clock,  0=Min AI Clock */
-#define TT_POWER_FLAG_MRISC_PHY_WAKEUP (1U << 1) /**< 1=PHY Wakeup,    0=PHY Powerdown */
-#define TT_POWER_FLAG_TENSIX_ENABLE (1U << 2)    /**< 1=Enable Tensix, 0=Clock Gate Tensix */
-#define TT_POWER_FLAG_L2CPU_ENABLE (1U << 3)     /**< 1=Enable L2CPU,  0=Clock Gate L2CPU */
+enum tt_power_flags {
+    TT_POWER_FLAG_MAX_AI_CLK = (1U << 0),       /**< 1=Max AI Clock,  0=Min AI Clock */
+    TT_POWER_FLAG_MRISC_PHY_WAKEUP = (1U << 1), /**< 1=PHY Wakeup,    0=PHY Powerdown */
+    TT_POWER_FLAG_TENSIX_ENABLE = (1U << 2),    /**< 1=Enable Tensix, 0=Clock Gate Tensix */
+    TT_POWER_FLAG_L2CPU_ENABLE = (1U << 3)      /**< 1=Enable L2CPU,  0=Clock Gate L2CPU */
+};
 
 /**
  * @brief Set per-client power state requirements for this device file descriptor.

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -449,18 +449,15 @@ PCIDevice::PCIDevice(int pci_device_number) :
                 pci_device_number));
     }
 
-    tenstorrent_get_driver_info driver_info{};
-    driver_info.in.output_size_bytes = sizeof(driver_info.out);
-    if (ioctl(pci_device_file_desc, TENSTORRENT_IOCTL_GET_DRIVER_INFO, &driver_info) == -1) {
-        UMD_THROW(error::RuntimeError, "TENSTORRENT_IOCTL_GET_DRIVER_INFO failed.");
-    }
+    uint64_t driver_api_version = 0;
+    tt_driver_get_attr(tt_device_handle, tt_driver_attr::TT_DRIVER_API_VERSION, &driver_api_version);
 
     log_debug(
         LogUMD,
-        "Opened PCI device {}; KMD version: {}; API: {}; IOMMU: {}",
+        "Opened PCI device {}; KMD version: {} (API version: {}); IOMMU: {}",
         pci_device_num,
         kmd_version.to_string(),
-        driver_info.out.driver_version,
+        driver_api_version,
         iommu_enabled ? "enabled" : "disabled");
 
     UMD_ASSERT(

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -1076,8 +1076,7 @@ void PCIDevice::set_power_state(bool busy) {
 
     int ret = tt_device_set_power_state(tt_device_handle, power_flags);
     if (ret != 0) {
-        log_warning(
-            LogUMD, "TENSTORRENT_IOCTL_SET_POWER_STATE failed on device {}: {}", pci_device_num, strerror(-ret));
+        log_warning(LogUMD, "Setting power state failed on device {}: {}", pci_device_num, strerror(-ret));
     }
 }
 

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -1071,20 +1071,13 @@ void PCIDevice::set_power_state(bool busy) {
         return;
     }
 
-    tenstorrent_power_state power_state{};
-    power_state.argsz = sizeof(power_state);
-    power_state.validity = TT_POWER_VALIDITY(4, 0);
+    uint16_t power_flags =
+        busy ? TT_POWER_FLAG_MRISC_PHY_WAKEUP | TT_POWER_FLAG_TENSIX_ENABLE | TT_POWER_FLAG_L2CPU_ENABLE : 0;
 
-    if (busy) {
-        power_state.power_flags =
-            TT_POWER_FLAG_MRISC_PHY_WAKEUP | TT_POWER_FLAG_TENSIX_ENABLE | TT_POWER_FLAG_L2CPU_ENABLE;
-    } else {
-        power_state.power_flags = 0;
-    }
-
-    if (ioctl(pci_device_file_desc, TENSTORRENT_IOCTL_SET_POWER_STATE, &power_state) == -1) {
+    int ret = tt_device_set_power_state(tt_device_handle, power_flags);
+    if (ret != 0) {
         log_warning(
-            LogUMD, "TENSTORRENT_IOCTL_SET_POWER_STATE failed on device {}: {}", pci_device_num, strerror(errno));
+            LogUMD, "TENSTORRENT_IOCTL_SET_POWER_STATE failed on device {}: {}", pci_device_num, strerror(-ret));
     }
 }
 

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -1071,10 +1071,12 @@ void PCIDevice::set_power_state(bool busy) {
         return;
     }
 
-    uint16_t power_flags =
-        busy ? TT_POWER_FLAG_MRISC_PHY_WAKEUP | TT_POWER_FLAG_TENSIX_ENABLE | TT_POWER_FLAG_L2CPU_ENABLE : 0;
+    constexpr uint16_t not_busy_flags = 0;
+    constexpr uint16_t busy_flags =
+        TT_POWER_FLAG_MRISC_PHY_WAKEUP | TT_POWER_FLAG_L2CPU_ENABLE | TT_POWER_FLAG_TENSIX_ENABLE;
+    uint16_t flags = busy ? busy_flags : not_busy_flags;
 
-    int ret = tt_device_set_power_state(tt_device_handle, power_flags);
+    int ret = tt_device_set_power_state(tt_device_handle, flags);
     if (ret != 0) {
         log_warning(LogUMD, "Setting power state failed on device {}: {}", pci_device_num, strerror(-ret));
     }

--- a/device/tt_kmd_lib/tt_kmd_lib.c
+++ b/device/tt_kmd_lib/tt_kmd_lib.c
@@ -514,3 +514,17 @@ int tt_tlb_map_unicast(tt_device_t* dev, tt_tlb_t* tlb, uint8_t x, uint8_t y, ui
 
     return 0;
 }
+
+int tt_device_set_power_state(tt_device_t* dev, uint16_t power_flags) {
+    struct tenstorrent_power_state ps = {0};
+    ps.argsz = sizeof(ps);
+    ps.flags = 0;
+    ps.validity = TT_POWER_VALIDITY(4, 0);
+    ps.power_flags = power_flags;
+
+    if (ioctl(dev->fd, TENSTORRENT_IOCTL_SET_POWER_STATE, &ps) != 0) {
+        return -errno;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Issue
#2749 

### Description
Use tt_kmd_lib for setting power state and KMD API version

### List of the changes
- Added `tt_device_set_power_state()`
- Changed `PCIDevice::set_power_state()` to use kmd-lib.
- Changed `PCIDevice` ctor to use kmd-lib for KMD API version.

### Testing
CI

### API Changes
This PR has API changes in tt_kmd_lib.