### PR TITLE
wormhole: fix ARC telemetry address rebase

### DIFF
--- a/device/arc/wormhole_arc_telemetry_reader.cpp
+++ b/device/arc/wormhole_arc_telemetry_reader.cpp
@@ -24,24 +24,23 @@ WormholeArcTelemetryReader::WormholeArcTelemetryReader(TTDevice* tt_device) : Ar
 }
 
 void WormholeArcTelemetryReader::get_telemetry_address() {
-    static constexpr uint64_t noc_telemetry_offset = 0x810000000;
-    uint32_t telemetry_table_addr_offset;
+    uint32_t telemetry_table_arc_addr;
     tt_device->read_from_device(
-        &telemetry_table_addr_offset,
+        &telemetry_table_arc_addr,
         arc_core,
         wormhole::ARC_NOC_RESET_UNIT_BASE_ADDR + wormhole::NOC_NODEID_X_0,
         sizeof(uint32_t));
 
-    telemetry_table_addr = telemetry_table_addr_offset + noc_telemetry_offset;
+    telemetry_table_addr = telemetry_table_arc_addr + wormhole::ARC_NOC_ADDRESS_START;
 
-    uint32_t telemetry_values_addr_offset;
+    uint32_t telemetry_values_arc_addr;
     tt_device->read_from_device(
-        &telemetry_values_addr_offset,
+        &telemetry_values_arc_addr,
         arc_core,
         wormhole::ARC_NOC_RESET_UNIT_BASE_ADDR + wormhole::NOC_NODEID_Y_0,
         sizeof(uint32_t));
 
-    telemetry_values_addr = telemetry_values_addr_offset + noc_telemetry_offset;
+    telemetry_values_addr = telemetry_values_arc_addr + wormhole::ARC_NOC_ADDRESS_START;
 }
 
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue
/

### Description
NOC_NODEID_X_0/Y_0 in the reset unit hold the telemetry table/data addresses as seen by the ARC CPU (full addresses within its CSM region), not CSM-relative offsets. Rebasing them with ARC_CSM_OFFSET_NOC (0x810000000) double-counted the CSM base, landing 0x10000000 past the real data.

Because Wormhole firmware still supports legacy telemetry, UMD would fall back to that instead of erroring, masking the error.

### List of the changes
Add ARC_NOC_ADDRESS_START (0x800000000) instead to convert the ARC-CPU address into NoC space. Matches WormholeB0/ARCTile/Telemetry.md and the tt-kmd interpretation (is_fw_ready_for_telemetry / is_range_within_csm).

### Testing
Tested by Micah on ttsim-qemu

### API Changes
This PR has (no) API changes.