### PR TITLE
Use GetSocDescAbsPath for ClusterWH. OneDramOneTensixNoEthSocDesc test

### DIFF
--- a/tests/wormhole/test_cluster_wh.cpp
+++ b/tests/wormhole/test_cluster_wh.cpp
@@ -65,7 +65,7 @@ static void set_barrier_params(Cluster& cluster) {
 
 TEST(ClusterWH, OneDramOneTensixNoEthSocDesc) {
     std::unique_ptr<Cluster> umd_cluster = test_utils::make_default_test_cluster(ClusterOptions{
-        .sdesc_path = "tests/soc_descs/wormhole_b0_one_dram_one_tensix_no_eth.yaml",
+        .sdesc_path = test_utils::GetSocDescAbsPath("wormhole_b0_one_dram_one_tensix_no_eth.yaml"),
     });
 }
 


### PR DESCRIPTION
### Issue
None

### Description
`ClusterWH.OneDramOneTensixNoEthSocDesc` fails when running in upstream container where compile and runtime paths differ. Other tests do not see this issue due to using `test_utils::GetSocDescAbsPath`

```
[ RUN      ] ClusterWH.OneDramOneTensixNoEthSocDesc
2026-06-22 13:15:35.543 | info     |             UMD | Cluster constructor started. (cluster.cpp:348)
unknown file: Failure
C++ exception with description "SocDescriptor file does not exist at path: tests/soc_descs/wormhole_b0_one_dram_one_tensix_no_eth.yaml
Location: /work/tt_metal/third_party/umd/device/soc_arch_descriptor.cpp:89
```

### List of the changes
Use GetSocDescAbsPath for ClusterWH.OneDramOneTensix test

### Testing
(Comment on CI testing or Manual testing steps that were performed to prove this change does what you intend it to do.)

### API Changes
This PR has (no) API changes.
