### PR TITLE
Simulation: client-mode simulation TTDevices over a slim SimulationClient

### DIFF
--- a/device/api/umd/device/simulation/simulation_connector.hpp
+++ b/device/api/umd/device/simulation/simulation_connector.hpp
@@ -31,8 +31,9 @@ struct SimulationConnectorOptions {
 //                        binds + serves its socket;
 //   - live socket     -> create a socket-backed client device that attaches to the host.
 //
-// Socket-first: binding the socket is the host-vs-client arbiter. The client/attach branch lands
-// in a later PR; for now a live socket is reported as an error.
+// Socket-first: binding the socket is the host-vs-client arbiter. A client device attaches to the
+// host over the socket via SimulationClient (slim today -- just connect/disconnect; device-op
+// forwarding lands as that API grows).
 class SimulationConnector {
 public:
     static std::map<ChipId, std::unique_ptr<TTDevice>> discover(const SimulationConnectorOptions& options);

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <mutex>
 
@@ -26,6 +27,7 @@ namespace tt::umd {
 class RtlSimCommunicator;
 class SimulationSysmemManager;
 class SimulationServerSocket;
+class SimulationClient;
 class SocDescriptor;
 class TlbWindow;
 
@@ -36,10 +38,16 @@ public:
         const SocDescriptor& soc_descriptor,
         ChipId chip_id,
         int num_host_mem_channels = 0);
+
     ~RtlSimulationTTDevice();
 
     static std::unique_ptr<RtlSimulationTTDevice> create(
         const std::filesystem::path& simulator_directory, int num_host_mem_channels = 0);
+
+    // Builds a client-mode device that attaches to a live host (see the .cpp for how the SoC
+    // descriptor is sourced); discovery uses this when a host already owns the socket.
+    static std::unique_ptr<RtlSimulationTTDevice> create_client(
+        const std::filesystem::path& simulator_directory, ChipId chip_id, std::unique_ptr<SimulationClient> client);
 
     void read_from_device(void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) override;
     void write_to_device(const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) override;
@@ -86,6 +94,25 @@ protected:
     void retrain_dram_core(const uint32_t dram_channel) override;
 
 private:
+    // Client-mode constructor: this device does not own a simulator; it forwards device operations
+    // to a remote host through client. Reached only via create_client(), which validates the
+    // arguments before construction.
+    RtlSimulationTTDevice(
+        const SocDescriptor& soc_descriptor, ChipId chip_id, std::unique_ptr<SimulationClient> client);
+
+    // Host-mode backend bring-up (communicator init, sysmem callbacks, TLB setup). Takes the
+    // host-mem channel count because the RAM callbacks need it.
+    void initialize_backend(int num_host_mem_channels);
+
+    // setup_ runs at construction, teardown_ at destruction -- the one real host-vs-client
+    // difference today: host mode drives the in-process RTL backend (communicator_), client mode
+    // drives the remote host (client_->attach()/detach()).
+    std::function<void()> setup_;
+    std::function<void()> teardown_;
+
+    // Set only in client mode; the remote host this device talks to. Null in host/local mode.
+    std::unique_ptr<SimulationClient> client_;
+
     std::unique_ptr<RtlSimCommunicator> communicator_;
     std::recursive_mutex device_lock;
 

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <mutex>
 
@@ -28,6 +29,7 @@ namespace tt::umd {
 class TTSimCommunicator;
 class SimulationSysmemManager;
 class SimulationServerSocket;
+class SimulationClient;
 class SocDescriptor;
 
 class TTSimTTDevice : public TTDevice {
@@ -38,6 +40,7 @@ public:
         ChipId chip_id,
         bool copy_sim_binary = false,
         int num_host_mem_channels = 0);
+
     ~TTSimTTDevice();
 
     static std::unique_ptr<TTSimTTDevice> create(
@@ -53,6 +56,11 @@ public:
         ChipId chip_id,
         int num_host_mem_channels = 0,
         bool copy_sim_binary = false);
+
+    // Builds a client-mode device that attaches to a live host (see the .cpp for how the SoC
+    // descriptor is sourced); discovery uses this when a host already owns the socket.
+    static std::unique_ptr<TTSimTTDevice> create_client(
+        const std::filesystem::path &simulator_directory, ChipId chip_id, std::unique_ptr<SimulationClient> client);
 
     void read_from_device(void *mem_ptr, CoreCoord core, uint64_t addr, size_t size) override;
     void write_to_device(const void *mem_ptr, CoreCoord core, uint64_t addr, size_t size) override;
@@ -111,9 +119,26 @@ protected:
     void retrain_dram_core(const uint32_t dram_channel) override;
 
 private:
+    // Client-mode constructor: this device does not own a simulator (.so); it forwards device
+    // operations to a remote host through client. Reached only via create_client(), which
+    // validates the arguments before construction.
+    TTSimTTDevice(const SocDescriptor &soc_descriptor, ChipId chip_id, std::unique_ptr<SimulationClient> client);
+
     void initialize_sysmem_functions();
     void pci_dma_read_bytes(uint64_t paddr, void *p, uint32_t size);
     void pci_dma_write_bytes(uint64_t paddr, const void *p, uint32_t size);
+
+    // Host-mode backend bring-up (.so init, PCI read, TLB setup).
+    void initialize_backend();
+
+    // setup_ runs at construction, teardown_ at destruction -- the one real host-vs-client
+    // difference today: host mode drives the in-process .so backend (communicator_), client mode
+    // drives the remote host (client_->attach()/detach()).
+    std::function<void()> setup_;
+    std::function<void()> teardown_;
+
+    // Set only in client mode; the remote host this device talks to. Null in host/local mode.
+    std::unique_ptr<SimulationClient> client_;
 
     uint32_t tlb_region_size_ = 0;
     std::unique_ptr<TTSimCommunicator> communicator_;

--- a/device/simulation/simulation_connector.cpp
+++ b/device/simulation/simulation_connector.cpp
@@ -4,16 +4,55 @@
 
 #include "umd/device/simulation/simulation_connector.hpp"
 
-#include <fmt/format.h>
-
+#include <memory>
 #include <utility>
 
 #include "simulation/simulation_server_socket.hpp"
+#include "umd/device/simulation/simulation_client.hpp"
 #include "umd/device/tt_device/rtl_simulation_tt_device.hpp"
 #include "umd/device/tt_device/tt_sim_tt_device.hpp"
-#include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
+
+namespace {
+
+// Builds the device for one simulated chip. The backend (TTSim .so vs RTL directory) is chosen by
+// the simulator path; the host-vs-client role is decided by who owns the socket:
+//   - socket == nullptr: a live host already serves this chip, so attach as a client that reaches
+//     it over the socket via SimulationClient (slim today -- just connect/disconnect; device-op
+//     forwarding lands as the API grows). The client runs no backend, so the only backend-specific
+//     bit is which device class describes it.
+//   - socket != nullptr: we are the host; bring up the in-process backend (the direct hot path) and
+//     hand it the socket to own and expose.
+// The two backends don't share a common factory return type that carries adopt_socket, so dispatch
+// on the concrete device here.
+std::unique_ptr<TTDevice> create_simulation_device(
+    const std::filesystem::path& simulator_directory,
+    ChipId chip_id,
+    int num_host_mem_channels,
+    const std::filesystem::path& socket_path,
+    std::unique_ptr<SimulationServerSocket> socket) {
+    const bool is_ttsim = simulator_directory.extension() == ".so";
+
+    if (socket == nullptr) {
+        auto client = std::make_unique<SimulationClient>(socket_path);
+        if (is_ttsim) {
+            return TTSimTTDevice::create_client(simulator_directory, chip_id, std::move(client));
+        }
+        return RtlSimulationTTDevice::create_client(simulator_directory, chip_id, std::move(client));
+    }
+
+    if (is_ttsim) {
+        auto device = TTSimTTDevice::create(simulator_directory, num_host_mem_channels);
+        device->adopt_socket(std::move(socket));
+        return device;
+    }
+    auto device = RtlSimulationTTDevice::create(simulator_directory, num_host_mem_channels);
+    device->adopt_socket(std::move(socket));
+    return device;
+}
+
+}  // namespace
 
 std::map<ChipId, std::unique_ptr<TTDevice>> SimulationConnector::discover(const SimulationConnectorOptions& options) {
     std::map<ChipId, std::unique_ptr<TTDevice>> devices;
@@ -21,36 +60,12 @@ std::map<ChipId, std::unique_ptr<TTDevice>> SimulationConnector::discover(const 
     // Single-chip for now. Socket-first: try to claim the path; success => we are the host.
     const ChipId chip_id = 0;
     const std::filesystem::path socket_path = SimulationServerSocket::default_socket_path(chip_id);
-
-    // The backend (TTSim .so vs RTL directory) is chosen by the simulator path, mirroring the
-    // simulation device factory; the host-vs-client role is chosen socket-first below.
-    const bool is_ttsim = options.simulator_directory.extension() == ".so";
-
     std::unique_ptr<SimulationServerSocket> socket = SimulationServerSocket::try_create(socket_path);
-    if (socket == nullptr) {
-        // A live host already serves this device. The client/attach path lands in a later PR.
-        UMD_THROW(
-            error::RuntimeError,
-            fmt::format(
-                "Attaching to an existing simulation host is not implemented yet; a live socket "
-                "already exists at: {}",
-                socket_path.string()));
-    }
 
-    // We are the host: bring up the backend (the direct in-process hot path) and hand it the
-    // socket to own and expose. The two backends don't share a common factory return type that
-    // carries adopt_socket, so dispatch on the concrete device here.
-    if (is_ttsim) {
-        std::unique_ptr<TTSimTTDevice> device =
-            TTSimTTDevice::create(options.simulator_directory, options.num_host_mem_channels);
-        device->adopt_socket(std::move(socket));
-        devices.emplace(chip_id, std::move(device));
-    } else {
-        std::unique_ptr<RtlSimulationTTDevice> device =
-            RtlSimulationTTDevice::create(options.simulator_directory, options.num_host_mem_channels);
-        device->adopt_socket(std::move(socket));
-        devices.emplace(chip_id, std::move(device));
-    }
+    devices.emplace(
+        chip_id,
+        create_simulation_device(
+            options.simulator_directory, chip_id, options.num_host_mem_channels, socket_path, std::move(socket)));
     return devices;
 }
 

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -21,6 +21,7 @@
 #include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/simulation/rtl_sim_communicator.hpp"
 #include "umd/device/simulation/simulation_chip.hpp"
+#include "umd/device/simulation/simulation_client.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/risc_type.hpp"
@@ -64,6 +65,21 @@ std::unique_ptr<RtlSimulationTTDevice> RtlSimulationTTDevice::create(
         simulator_directory, soc_descriptor, DEFAULT_CHIP_ID, num_host_mem_channels);
 }
 
+std::unique_ptr<RtlSimulationTTDevice> RtlSimulationTTDevice::create_client(
+    const std::filesystem::path& simulator_directory, ChipId chip_id, std::unique_ptr<SimulationClient> client) {
+    UMD_ASSERT(
+        client != nullptr,
+        error::RuntimeError,
+        "Client-mode RtlSimulationTTDevice requires a non-null SimulationClient.");
+    // The SoC descriptor is read straight from the local simulator build -- the same files the
+    // host used -- so the client can describe the device without loading or running a simulator.
+    auto soc_desc_path = SimulationChip::get_soc_descriptor_path_from_simulator_path(simulator_directory);
+    SocDescriptor soc_descriptor = SocDescriptor(std::make_shared<SocArchDescriptor>(soc_desc_path));
+    // make_unique can't reach the private client-mode constructor; this static factory can via new.
+    return std::unique_ptr<RtlSimulationTTDevice>(
+        new RtlSimulationTTDevice(soc_descriptor, chip_id, std::move(client)));
+}
+
 RtlSimulationTTDevice::RtlSimulationTTDevice(
     const std::filesystem::path& simulator_directory,
     const SocDescriptor& soc_descriptor,
@@ -77,6 +93,28 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
     architecture_impl_ = architecture_implementation::create(get_soc_descriptor().arch);
     arch = get_soc_descriptor().arch;
 
+    // Host/local mode: the lifecycle drives the in-process RTL backend (the communicator).
+    setup_ = [this, num_host_mem_channels] { initialize_backend(num_host_mem_channels); };
+    teardown_ = [this] { communicator_->shutdown(); };
+    setup_();
+}
+
+RtlSimulationTTDevice::RtlSimulationTTDevice(
+    const SocDescriptor& soc_descriptor, ChipId chip_id, std::unique_ptr<SimulationClient> client) :
+    client_(std::move(client)) {
+    set_soc_descriptor(soc_descriptor);
+    arch = soc_descriptor.arch;
+    architecture_impl_ = architecture_implementation::create(soc_descriptor.arch);
+
+    // Client mode: the lifecycle drives the remote host over the socket. read/write are not wired
+    // here -- the SimulationClient has no device I/O yet -- so those throw until the API grows.
+    // create_client() has already validated that client_ is non-null.
+    setup_ = [this] { client_->attach(); };
+    teardown_ = [this] { client_->detach(); };
+    setup_();
+}
+
+void RtlSimulationTTDevice::initialize_backend(int num_host_mem_channels) {
     // Register sysmem callbacks so the simulator can read/write host memory.
     if (num_host_mem_channels > 0) {
         SimulationSysmemManager* mgr = sysmem_manager_.get();
@@ -135,6 +173,11 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
 }
 
 std::unique_ptr<TlbWindow> RtlSimulationTTDevice::get_io_window(tlb_data config, TlbMapping mapping, size_t size) {
+    if (client_) {
+        // Client mode runs no backend, so tlb_allocator_/communicator_ are never constructed. Fail
+        // loudly instead of dereferencing them; client-mode device I/O is not available yet.
+        UMD_THROW(error::RuntimeError, "Client-mode RtlSimulationTTDevice does not support TLB windows yet.");
+    }
     int tlb_index = tlb_allocator_->allocate_tlb_index(size);
     if (tlb_index == -1) {
         UMD_THROW(error::RuntimeError, "No available TLB of requested size.");
@@ -149,7 +192,15 @@ std::unique_ptr<TlbWindow> RtlSimulationTTDevice::get_io_window(tlb_data config,
 RtlSimulationTTDevice::~RtlSimulationTTDevice() {
     // Stop serving (and remove the socket) before tearing the backend down.
     socket_.reset();
-    communicator_->shutdown();
+    // teardown_ is communicator_->shutdown() (host) or client_->detach() (client). The
+    // destructor is implicitly noexcept, so this is best-effort.
+    if (teardown_) {
+        try {
+            teardown_();
+        } catch (const std::exception& e) {
+            log_warning(tt::LogEmulationDriver, "RtlSimulationTTDevice teardown failed: {}", e.what());
+        }
+    }
 }
 
 void RtlSimulationTTDevice::adopt_socket(std::unique_ptr<SimulationServerSocket> socket) {
@@ -157,6 +208,12 @@ void RtlSimulationTTDevice::adopt_socket(std::unique_ptr<SimulationServerSocket>
 }
 
 void RtlSimulationTTDevice::write_to_device(const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) {
+    if (client_) {
+        UMD_THROW(
+            error::RuntimeError,
+            "Client-mode RtlSimulationTTDevice device I/O is not available yet (SimulationClient has no "
+            "read/write).");
+    }
     std::lock_guard<std::recursive_mutex> lock(device_lock);
     xy_pair translated_core = get_soc_descriptor().translate_chip_coord_to_translated(core);
     log_debug(
@@ -178,6 +235,12 @@ void RtlSimulationTTDevice::write_to_device(const void* mem_ptr, CoreCoord core,
 }
 
 void RtlSimulationTTDevice::read_from_device(void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) {
+    if (client_) {
+        UMD_THROW(
+            error::RuntimeError,
+            "Client-mode RtlSimulationTTDevice device I/O is not available yet (SimulationClient has no "
+            "read/write).");
+    }
     std::lock_guard<std::recursive_mutex> lock(device_lock);
     xy_pair translated_core = get_soc_descriptor().translate_chip_coord_to_translated(core);
 

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -23,6 +23,7 @@
 #include "umd/device/pcie/tt_sim_tlb_handle.hpp"
 #include "umd/device/pcie/tt_sim_tlb_window.hpp"
 #include "umd/device/simulation/simulation_chip.hpp"
+#include "umd/device/simulation/simulation_client.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/types/arch.hpp"
@@ -73,6 +74,25 @@ std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create_for_chip(
         simulator_directory, soc_descriptor, chip_id, copy_sim_binary, num_host_mem_channels);
 }
 
+std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create_client(
+    const std::filesystem::path& simulator_directory, ChipId chip_id, std::unique_ptr<SimulationClient> client) {
+    UMD_ASSERT(
+        client != nullptr, error::RuntimeError, "Client-mode TTSimTTDevice requires a non-null SimulationClient.");
+    // The SoC descriptor is read straight from the local simulator build -- the same files the
+    // host used -- so the client can describe the device without loading or running the .so.
+    auto soc_desc_path = SimulationChip::get_soc_descriptor_path_from_simulator_path(simulator_directory);
+    tt::ARCH arch = SocDescriptor::get_arch_from_soc_descriptor_path(soc_desc_path);
+    ChipInfo chip_info{};
+    if (arch == tt::ARCH::BLACKHOLE) {
+        // Same default ETH harvesting mask as create_for_chip(): BH SocDescriptor construction
+        // rejects an empty mask, so apply it here too. Keep in sync with create_for_chip().
+        chip_info.harvesting_masks.eth_harvesting_mask = 0x120;
+    }
+    SocDescriptor soc_descriptor = SocDescriptor(std::make_shared<SocArchDescriptor>(soc_desc_path), chip_info);
+    // make_unique can't reach the private client-mode constructor; this static factory can via new.
+    return std::unique_ptr<TTSimTTDevice>(new TTSimTTDevice(soc_descriptor, chip_id, std::move(client)));
+}
+
 TTSimTTDevice::TTSimTTDevice(
     const std::filesystem::path& simulator_directory,
     const SocDescriptor& soc_descriptor,
@@ -94,6 +114,13 @@ TTSimTTDevice::TTSimTTDevice(
     // consumers (e.g. tt-exalens constructing a SocDescriptor from the device) see the wrong arch.
     arch = soc_descriptor.arch;
     architecture_impl_ = architecture_implementation::create(soc_descriptor.arch);
+    // Host/local mode: the lifecycle drives the in-process .so backend (the communicator).
+    setup_ = [this] { initialize_backend(); };
+    teardown_ = [this] { communicator_->shutdown(); };
+    setup_();
+}
+
+void TTSimTTDevice::initialize_backend() {
     communicator_->initialize();
     initialize_sysmem_functions();
     communicator_->start_sim();
@@ -159,7 +186,27 @@ TTSimTTDevice::TTSimTTDevice(
     }
 }
 
+TTSimTTDevice::TTSimTTDevice(
+    const SocDescriptor& soc_descriptor, ChipId chip_id, std::unique_ptr<SimulationClient> client) :
+    client_(std::move(client)), chip_id_(chip_id) {
+    set_soc_descriptor(soc_descriptor);
+    arch = soc_descriptor.arch;
+    architecture_impl_ = architecture_implementation::create(soc_descriptor.arch);
+
+    // Client mode: the lifecycle drives the remote host over the socket. read/write are not wired
+    // here -- the SimulationClient has no device I/O yet -- so those throw until the API grows.
+    // create_client() has already validated that client_ is non-null.
+    setup_ = [this] { client_->attach(); };
+    teardown_ = [this] { client_->detach(); };
+    setup_();
+}
+
 std::unique_ptr<TlbWindow> TTSimTTDevice::get_io_window(tlb_data config, TlbMapping mapping, size_t size) {
+    if (client_) {
+        // Client mode runs no backend, so tlb_allocator_/communicator_ are never constructed. Fail
+        // loudly instead of dereferencing them; client-mode device I/O is not available yet.
+        UMD_THROW(error::RuntimeError, "Client-mode TTSimTTDevice does not support TLB windows yet.");
+    }
     int tlb_index = tlb_allocator_->allocate_tlb_index(size);
     if (tlb_index == -1) {
         UMD_THROW(error::RuntimeError, "No available TLB of requested size.");
@@ -174,7 +221,16 @@ std::unique_ptr<TlbWindow> TTSimTTDevice::get_io_window(tlb_data config, TlbMapp
 TTSimTTDevice::~TTSimTTDevice() {
     // Stop serving (and remove the socket) before tearing the backend down.
     socket_.reset();
-    communicator_->shutdown();
+    // teardown_ is communicator_->shutdown() (host) or client_->detach() (client). The
+    // destructor is implicitly noexcept, so this is best-effort -- a throw here would call
+    // std::terminate during unwinding.
+    if (teardown_) {
+        try {
+            teardown_();
+        } catch (const std::exception& e) {
+            log_warning(tt::LogEmulationDriver, "TTSimTTDevice teardown failed: {}", e.what());
+        }
+    }
 }
 
 void TTSimTTDevice::adopt_socket(std::unique_ptr<SimulationServerSocket> socket) { socket_ = std::move(socket); }
@@ -182,11 +238,21 @@ void TTSimTTDevice::adopt_socket(std::unique_ptr<SimulationServerSocket> socket)
 void TTSimTTDevice::start_device() {}
 
 void TTSimTTDevice::close_device() {
+    // Client mode has no local backend (communicator_); closing means dropping the host session.
+    if (client_) {
+        client_->detach();
+        return;
+    }
     communicator_->mark_closed();
     communicator_->shutdown();
 }
 
 void TTSimTTDevice::write_to_device(const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) {
+    if (client_) {
+        UMD_THROW(
+            error::RuntimeError,
+            "Client-mode TTSimTTDevice device I/O is not available yet (SimulationClient has no read/write).");
+    }
     if (communicator_->is_closed()) {
         return;
     }
@@ -209,6 +275,11 @@ void TTSimTTDevice::write_to_device(const void* mem_ptr, CoreCoord core, uint64_
 }
 
 void TTSimTTDevice::read_from_device(void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) {
+    if (client_) {
+        UMD_THROW(
+            error::RuntimeError,
+            "Client-mode TTSimTTDevice device I/O is not available yet (SimulationClient has no read/write).");
+    }
     if (communicator_->is_closed()) {
         return;
     }

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -238,9 +238,10 @@ void TTSimTTDevice::adopt_socket(std::unique_ptr<SimulationServerSocket> socket)
 void TTSimTTDevice::start_device() {}
 
 void TTSimTTDevice::close_device() {
-    // Client mode has no local backend (communicator_); closing means dropping the host session.
+    // Client mode has no local backend (communicator_) to close; the host session is dropped by
+    // client_->detach() in the destructor (idempotent), keeping teardown symmetric with
+    // RtlSimulationTTDevice, which has no close_device() override.
     if (client_) {
-        client_->detach();
         return;
     }
     communicator_->mark_closed();


### PR DESCRIPTION
### Issue
Part of #2677 (simulation server). Stacked on #2902 (`SimulationClient`, the slim client-facing host handle), which builds on the now-merged `SimulationConnector` work (#2811). First step toward the socket-backed client (#2795): make the connector construct a client device when a live host already owns the socket. Folding the shared client-mode logic into a common simulation-device base is tracked by #2865.

### Description
Today `SimulationConnector` throws when a live host already owns the chip's socket. This makes it construct a **client** simulation device instead, attaching to the host over the socket via `SimulationClient` (added in #2902) — for **both** backends (tt_sim `.so` and RTL).

- `TTSimTTDevice` and `RtlSimulationTTDevice` gain constructor-bound **lifecycle dispatch** (`setup_`/`teardown_` callables) — the genuine host-vs-client difference today: host mode drives the in-process backend (the communicator); client mode drives the remote host (`client_` attach/detach). `read_from_device`/`write_to_device` stay direct and throw in client mode until `SimulationClient` grows device I/O.
- `SimulationConnector` picks the backend by simulator path (`.so` → tt_sim, else RTL) and the host-vs-client role socket-first (via `SimulationServerSocket`), constructing a client device for either backend when a live host already owns the socket. The dispatch lives in a file-local `create_simulation_device()` helper.

Scope is intentionally narrow: this proves construction + connect/disconnect in both modes and both backends; client-mode device I/O throws until the API grows.

### List of the changes
- `TTSimTTDevice` & `RtlSimulationTTDevice`: constructor-bound `setup_`/`teardown_` dispatch, private client constructor + `create_client`, `initialize_backend()` extraction, best-effort destructor teardown, client-mode guards on `read`/`write`/`get_io_window`. In client mode `TTSimTTDevice::close_device()` returns early — the host session is dropped by the (idempotent) destructor `detach()`, keeping teardown symmetric with `RtlSimulationTTDevice` (which has no `close_device()` override).
- `SimulationConnector`: backend-aware (tt_sim vs RTL) host/client construction via a file-local `create_simulation_device()` helper.

### Testing
CI (simulation lane). Locally: `SimulationClientTest` (incl. `DestructorDetaches`), `SimulationServerSocketTest`, `SimulationTlbAllocator`, and the `ApiSimulationSysmemManager` suites pass; the simulator-backed `TTSimCommunicatorTest`/`SimulationConnector` tests run on CI (gated on `TT_UMD_SIMULATOR`).

### API Changes
- No changes to existing public APIs.
