### PR TITLE
Disable flaky test

### DIFF
--- a/tests/api/test_warm_reset.cpp
+++ b/tests/api/test_warm_reset.cpp
@@ -810,7 +810,8 @@ static void terminate_processes(std::initializer_list<pid_t> pids) {
     }
 }
 
-TEST(WarmResetTest, StaleFileDescriptorClusterRecovery) {
+// Flaky test, warm reset has a probability of failure.
+TEST(WarmResetTest, DISABLED_StaleFileDescriptorClusterRecovery) {
     if constexpr (utils::is_arm_platform()) {
         GTEST_SKIP() << "Warm reset is disabled on ARM64 due to instability.";
     }


### PR DESCRIPTION
This pull request disables a flaky test in the `test_warm_reset.cpp` file to improve test reliability. The test `StaleFileDescriptorClusterRecovery` is now marked as disabled due to its probabilistic failure rate.

Test reliability improvements:
  * Disabled the `StaleFileDescriptorClusterRecovery` test by renaming it to `DISABLED_StaleFileDescriptorClusterRecovery`, as warm reset has a probability of failure and the test is considered flaky.
