### PR TITLE
Simulation: add SimulationClient, the slim client-facing host handle

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -141,6 +141,7 @@ target_sources(
         # so always built. This lets its unit tests run in the no-card baremetal CI lane
         # (TT_UMD_BUILD_SIMULATION=OFF).
         simulation/simulation_server_socket.cpp
+        simulation/simulation_client.cpp
 )
 
 if(TT_UMD_BUILD_SIMULATION)
@@ -252,6 +253,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/types/risc_type.hpp
                 api/umd/device/simulation/simulation_chip.hpp
                 api/umd/device/simulation/simulation_connector.hpp
+                api/umd/device/simulation/simulation_client.hpp
                 api/umd/device/simulation/simulation_host.hpp
                 api/umd/device/simulation/tt_sim_communicator.hpp
                 api/umd/device/simulation/rtl_sim_communicator.hpp

--- a/device/api/umd/device/simulation/simulation_client.hpp
+++ b/device/api/umd/device/simulation/simulation_client.hpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <filesystem>
+#include <memory>
+
+namespace tt::umd {
+
+// The client-facing handle to a simulation host ("the card"), reached over its per-chip UNIX
+// socket. Deliberately slim for now: just the session handshake -- attach() connects, detach()
+// closes. It grows operation-by-operation as the server work lands (device description, memory
+// access, TLB, sysmem, run/reset, ...), at which point TTSimTTDevice's client-mode dispatch is
+// rebound from its throwing stubs onto these calls. No simulation build needed (asio is a core
+// dependency), mirroring SimulationSocket on the host side.
+//
+// The asio transport is held behind a pImpl so this header stays free of asio (a private
+// dependency of the library) -- see Impl in the .cpp.
+class SimulationClient {
+public:
+    explicit SimulationClient(std::filesystem::path socket_path);
+    ~SimulationClient();
+
+    SimulationClient(const SimulationClient&) = delete;
+    SimulationClient& operator=(const SimulationClient&) = delete;
+
+    // Connects to the host socket; throws if no live host is reachable at the path. Idempotent
+    // once connected.
+    void attach();
+    // Closes the connection; idempotent.
+    void detach();
+
+private:
+    std::filesystem::path socket_path_;
+
+    // Holds the asio transport (io_context + connected socket). Defined in the .cpp so asio
+    // stays out of this header; owns the connection fd (RAII).
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace tt::umd

--- a/device/simulation/simulation_client.cpp
+++ b/device/simulation/simulation_client.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/simulation/simulation_client.hpp"
+
+#include <fmt/format.h>
+#include <sys/un.h>  // sockaddr_un::sun_path, for the path-length guard
+
+#include <asio.hpp>
+#include <system_error>
+
+#include "umd/device/utils/error.hpp"
+
+namespace tt::umd {
+
+namespace {
+
+using stream_protocol = asio::local::stream_protocol;
+
+// Builds an endpoint for a pathname socket, throwing if the path is too long for sockaddr_un.
+// asio's endpoint(path) would itself throw on overflow, but with a less actionable message.
+// Named distinctly from SimulationServerSocket's equivalent helper: both files are always built
+// and share a unity-build translation unit, where two anonymous-namespace make_endpoint()s
+// would collide.
+stream_protocol::endpoint make_client_endpoint(const std::filesystem::path& path) {
+    if (path.string().size() >= sizeof(sockaddr_un::sun_path)) {
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format(
+                "Simulation host socket path is too long ({} >= {}): {}",
+                path.string().size(),
+                sizeof(sockaddr_un::sun_path),
+                path.string()));
+    }
+    return stream_protocol::endpoint(path.string());
+}
+
+}  // namespace
+
+// The asio transport, kept out of the header (see SimulationClient::Impl forward declaration).
+struct SimulationClient::Impl {
+    asio::io_context io;
+    stream_protocol::socket socket{io};
+};
+
+SimulationClient::SimulationClient(std::filesystem::path socket_path) :
+    socket_path_(std::move(socket_path)), impl_(std::make_unique<Impl>()) {}
+
+SimulationClient::~SimulationClient() { detach(); }
+
+void SimulationClient::attach() {
+    if (impl_->socket.is_open()) {
+        return;  // Already attached.
+    }
+
+    std::error_code ec;
+    impl_->socket.connect(make_client_endpoint(socket_path_), ec);
+    if (ec) {
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format("Failed to connect to simulation host socket at {}: {}", socket_path_.string(), ec.message()));
+    }
+}
+
+void SimulationClient::detach() {
+    if (!impl_->socket.is_open()) {
+        return;
+    }
+    // ec suppresses exceptions so close() still runs even if shutdown() fails (e.g. the peer
+    // already dropped the connection); the file descriptor release is what must be guaranteed.
+    std::error_code ec;
+    impl_->socket.shutdown(stream_protocol::socket::shutdown_both, ec);
+    impl_->socket.close(ec);
+}
+
+}  // namespace tt::umd

--- a/tests/baremetal/CMakeLists.txt
+++ b/tests/baremetal/CMakeLists.txt
@@ -8,9 +8,10 @@ set(BAREMETAL_TESTS_SRCS
     test_long_jump.cpp
     test_notification_mechanism.cpp
     test_cluster.cpp
-    # SimulationServerSocket has no simulation deps (always compiled), so its tests need no card and
-    # no simulation build -- they run in the no-card baremetal CI lane.
+    # SimulationServerSocket and SimulationClient have no simulation deps (always compiled), so
+    # their tests need no card and no simulation build -- they run in the no-card baremetal CI lane.
     test_simulation_server_socket.cpp
+    test_simulation_client.cpp
 )
 
 add_executable(baremetal_tests ${BAREMETAL_TESTS_SRCS})

--- a/tests/baremetal/test_simulation_client.cpp
+++ b/tests/baremetal/test_simulation_client.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <filesystem>
+#include <string>
+
+#include "simulation/simulation_server_socket.hpp"
+#include "umd/device/simulation/simulation_client.hpp"
+
+using namespace tt::umd;
+
+namespace {
+
+class SimulationClientTest : public ::testing::Test {
+protected:
+    // Clear any stale socket file (e.g. from a previous crashed run on PID reuse) so bind() and
+    // connect() start from a clean path, mirroring the SimulationServerSocket tests. The PID in the
+    // name keeps parallel test binaries from colliding.
+    void SetUp() override { std::filesystem::remove(path_); }
+
+    void TearDown() override { std::filesystem::remove(path_); }
+
+    std::filesystem::path path_ =
+        std::filesystem::temp_directory_path() / ("tt-umd-sim-client-test-" + std::to_string(::getpid()) + ".sock");
+};
+
+}  // namespace
+
+// attach() connects to a live host's socket; detach() closes and is idempotent.
+TEST_F(SimulationClientTest, AttachesToLiveHostThenDetaches) {
+    auto server = SimulationServerSocket::create(path_);  // Binds + listens => a live host at path_.
+
+    SimulationClient client(path_);
+    EXPECT_NO_THROW(client.attach());
+    EXPECT_NO_THROW(client.detach());
+    EXPECT_NO_THROW(client.detach());  // Idempotent.
+}
+
+// With no host bound at the path, attach() fails loudly rather than silently producing a
+// half-connected client.
+TEST_F(SimulationClientTest, AttachThrowsWhenNoHost) {
+    SimulationClient client(path_);
+    EXPECT_THROW(client.attach(), std::exception);
+}
+
+// The destructor releases the connection even if detach() was never called.
+TEST_F(SimulationClientTest, DestructorDetaches) {
+    auto server = SimulationServerSocket::create(path_);
+
+    {
+        SimulationClient client(path_);
+        EXPECT_NO_THROW(client.attach());
+    }
+}


### PR DESCRIPTION
### Issue
Part of #2792. Stacked on #2940 (renames `SimulationSocket` → `SimulationServerSocket`); builds on the merged `SimulationConnector`/socket work.

### Description
Adds `SimulationClient` — the slim, always-built client-facing handle to a simulation host, reached over its per-chip UNIX socket. `attach()` connects, `detach()` closes; no request protocol yet. Grows operation-by-operation as the server work lands, at which point `TTSimTTDevice`'s client-mode dispatch is rebound onto these calls. The asio transport is held behind a pImpl so the public header stays asio-free (mirroring `SimulationServerSocket`).

### Testing
`SimulationClientTest` (3 tests) passes in the no-card baremetal lane; build + pre-commit clean.

### API Changes
New public header `umd/device/simulation/simulation_client.hpp` (`SimulationClient`).