### PR TITLE
ci: fix ttsim cluster-desc paths after tt-metal submodule move

### DIFF
--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -198,7 +198,7 @@ jobs:
           TT_METAL_SIMULATOR: ${{ github.workspace }}/sim_wh/libttsim.so
           TT_METAL_SLOW_DISPATCH_MODE: 1
           TT_METAL_TESTS_DIR: >-
-            ${{ github.workspace }}/tt-metal/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors
+            ${{ github.workspace }}/tt-metal/tt_metal/third_party/tt-cluster-descriptors/wormhole/6u_cluster_desc
         run: |
           cd tt-metal
           export TT_METAL_MOCK_CLUSTER_DESC_PATH="${TT_METAL_TESTS_DIR}/6u_cluster_desc.yaml"
@@ -213,7 +213,7 @@ jobs:
           TT_METAL_SIMULATOR: ${{ github.workspace }}/sim_bh/libttsim.so
           TT_METAL_SLOW_DISPATCH_MODE: 1
           TT_METAL_TESTS_DIR: >-
-            ${{ github.workspace }}/tt-metal/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors
+            ${{ github.workspace }}/tt-metal/tt_metal/third_party/tt-cluster-descriptors/blackhole/bh_6u_cluster_desc
         run: |
           cd tt-metal
           export TT_METAL_MOCK_CLUSTER_DESC_PATH="${TT_METAL_TESTS_DIR}/bh_6u_cluster_desc.yaml"


### PR DESCRIPTION
## Problem

The `Run ttsim tests` workflow fails on the tt-sim galaxy steps with:

```
C++ exception: Cluster descriptor file does not exist at path:
.../tt-metal/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_cluster_desc.yaml
[  FAILED  ] MeshDeviceFixture.TensixDirectedStreamRegWriteRead
[  FAILED  ] MeshDeviceFixture.TensixIncrementStreamRegWrite
```

tt-metal [#47402](https://github.com/tenstorrent/tt-metal/pull/47402) (originally #47388) moved the mock cluster descriptors out of `tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/` and into the `tt-cluster-descriptors` submodule. Both tt-sim galaxy steps still pointed `TT_METAL_TESTS_DIR` at the now-deleted in-repo directory.

## Fix

Repoint `TT_METAL_TESTS_DIR` at the submodule root and use the new per-arch descriptor sub-paths, for **both** affected jobs:

| job | descriptor | new submodule path |
|---|---|---|
| `Run tt-metal C++ unit test on tt-sim galaxy wormhole_b0` | `6u_cluster_desc.yaml` | `wormhole/6u_cluster_desc/6u_cluster_desc.yaml` |
| `Run tt-metal C++ unit test on tt-sim galaxy blackhole` | `bh_6u_cluster_desc.yaml` | `blackhole/bh_6u_cluster_desc/bh_6u_cluster_desc.yaml` |

## Test
https://github.com/tenstorrent/tt-umd/actions/runs/28030984503