### PR TITLE
Reduce fetch-depth for metal in ttsim CI

### DIFF
--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -43,8 +43,7 @@ jobs:
           path: tt-metal
           repository: tenstorrent/tt-metal
           submodules: recursive
-          fetch-depth: 500  # Need enough history for `git describe`
-          fetch-tags: true  # Need tags for `git describe`
+          fetch-depth: 1
 
       - name: Checkout UMD
         uses: actions/checkout@v6
@@ -52,6 +51,7 @@ jobs:
           # Clone directly into tt-metal directory for umd
           path: tt-metal/tt_metal/third_party/umd
           submodules: recursive
+          fetch-depth: 1
 
       - name: Get ttsim version
         id: get-ttsim-version

--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -11,14 +11,14 @@ on:
         required: true
         description: 'The timeout for the job in minutes'
         type: number
-        default: 30
+        default: 60
   workflow_call:
     inputs:
       timeout:
         required: false
         description: 'The timeout for the job in minutes'
         type: number
-        default: 30
+        default: 60
 
 jobs:
   build-and-run-ttsim:
@@ -43,7 +43,6 @@ jobs:
           path: tt-metal
           repository: tenstorrent/tt-metal
           submodules: recursive
-          fetch-depth: 1
 
       - name: Checkout UMD
         uses: actions/checkout@v6
@@ -51,7 +50,6 @@ jobs:
           # Clone directly into tt-metal directory for umd
           path: tt-metal/tt_metal/third_party/umd
           submodules: recursive
-          fetch-depth: 1
 
       - name: Get ttsim version
         id: get-ttsim-version


### PR DESCRIPTION
### Issue
/

### Description
Reduce fetch-depth for metal in ttsim CI. Fetching tt-metal can take up to 4 minutes. This PR aims to reduce the time spent fetching tt-metal in ttsim CI. Raise ttsim test job timeout to 60 minutes.
