### PR TITLE
Exclusive / non-blocking device-open policy (#2841)

### DIFF
--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -162,8 +162,12 @@ public:
      * sysfs, and maps device memory region(s) into the process address space.
      *
      * @param pci_device_number     N in /dev/tenstorrent/N
+     * @param exclusive             When true, open the device with O_EXCL to take exclusive
+     *                              ownership (waiting, interruptibly, until the device is idle).
+     *                              When false (default), open shared but wait if another process
+     *                              currently holds the device exclusively.
      */
-    PCIDevice(int pci_device_number);
+    PCIDevice(int pci_device_number, bool exclusive = false);
 
     /**
      * PCIDevice destructor.

--- a/device/api/umd/device/topology/topology_discovery_options.hpp
+++ b/device/api/umd/device/topology/topology_discovery_options.hpp
@@ -95,5 +95,13 @@ struct TopologyDiscoveryOptions {
      * Defaults to false.
      */
     bool use_safe_api = false;
+
+    /**
+     * @brief If true, devices are opened exclusively (O_EXCL), taking exclusive ownership and
+     * waiting (interruptibly) until any current owner releases the device. Matches the KMD
+     * exclusive-open contract (tt-kmd#241) used by tools such as tt-flash for flash + reset.
+     * Defaults to false.
+     */
+    bool open_devices_exclusively = false;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -80,7 +80,8 @@ private:
         int device_number,
         IODeviceType device_type,
         bool use_safe_api,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
+        bool exclusive);
 
     static constexpr uint64_t ATU_OFFSET_IN_BH_BAR2 = 0x1000;
     std::set<size_t> iatu_regions_;

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -80,6 +80,8 @@ public:
      *                     Available only for PCIe I/O device type. (default: false)
      * @param soc_arch_descriptor Shared pointer to the SoC architecture descriptor.
      *                            If nullptr, a default descriptor will be used. (default: nullptr)
+     * @param exclusive    When true, open the underlying PCIe device with O_EXCL to take exclusive
+     *                     ownership. Available only for PCIe I/O device type. (default: false)
      *
      * @return std::unique_ptr<TTDevice> A unique pointer to the created TTDevice instance.
      *
@@ -89,7 +91,8 @@ public:
         int device_number,
         IODeviceType device_type = IODeviceType::PCIe,
         bool use_safe_api = false,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor = nullptr);
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor = nullptr,
+        bool exclusive = false);
 
     static std::unique_ptr<TTDevice> create(
         std::unique_ptr<RemoteCommunication> remote_communication,

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -78,7 +78,8 @@ private:
         int device_number,
         IODeviceType device_type,
         bool use_safe_api,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
+        bool exclusive);
     friend std::unique_ptr<TTDevice> TTDevice::create(
         std::unique_ptr<RemoteCommunication> remote_communication,
         const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -375,18 +375,52 @@ std::optional<int> PCIDevice::get_pci_device_id(int umd_logical_id) {
     return enumerated_ids[umd_logical_id];
 }
 
-static int open_pci_device(const std::string &device_path) {
+static int open_pci_device(const std::string &device_path, bool exclusive = false) {
     // O_APPEND is temporarily disabled to investigate NOC1 issues. See
     // https://github.com/tenstorrent/tt-umd/issues/2531.
-    int flags = O_RDWR | O_CLOEXEC;
+    //
+    // KMD (tt-kmd#241) exposes O_EXCL exclusive-open semantics on the chardev:
+    //   O_RDWR                       -> -EBUSY while another fd holds O_EXCL
+    //   O_RDWR | O_EXCL              -> blocks (interruptibly) until idle, then takes ownership
+    //   O_RDWR | O_EXCL | O_NONBLOCK -> -EAGAIN if not immediately acquirable
+    // We open non-blocking first and only fall back to a blocking wait when the
+    // device is actually in use, so the common case stays silent and fast.
+    int base_flags = O_RDWR | O_CLOEXEC;
+    if (exclusive) {
+        base_flags |= O_EXCL;
+    }
+
     log_debug(LogUMD, fmt::format("Opening device {} in legacy mode regarding device power.", device_path));
-    return open(device_path.c_str(), flags);
+
+    // Fast path: try non-blocking. Stay silent on success.
+    int fd = open(device_path.c_str(), base_flags | O_NONBLOCK);
+    if (fd == -1 && (errno == EAGAIN || errno == EBUSY)) {
+        // Held by another owner (or, when we requested O_EXCL, still busy). EAGAIN and
+        // EBUSY are handled identically: warn once, then block (interruptibly) until idle.
+        log_warning(LogUMD, "Device {} is in use by another process; waiting for it to become available.", device_path);
+        fd = open(device_path.c_str(), base_flags);  // blocking, interruptible (no O_NONBLOCK)
+    }
+
+    if (fd == -1) {
+        // Any other errno, or failure of the blocking re-open (including EINTR) -> fail fast.
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format("Failed to open device {}: {} (errno {}).", device_path, strerror(errno), errno));
+    }
+
+    // Normalize the descriptor: clear O_NONBLOCK so the fast path and the blocking path
+    // return fds with identical flag state (UMD only uses the fd for ioctl/mmap).
+    int fl = fcntl(fd, F_GETFL);
+    if (fl != -1) {
+        fcntl(fd, F_SETFL, fl & ~O_NONBLOCK);
+    }
+    return fd;
 }
 
-PCIDevice::PCIDevice(int pci_device_number) :
+PCIDevice::PCIDevice(int pci_device_number, bool exclusive) :
     device_path(fmt::format("/dev/tenstorrent/{}", pci_device_number)),
     pci_device_num(pci_device_number),
-    pci_device_file_desc(open_pci_device(device_path)),
+    pci_device_file_desc(open_pci_device(device_path, exclusive)),
     info(read_device_info(pci_device_file_desc)),
     numa_node(read_sysfs<int>(info, "numa_node", -1)),  // default to -1 if not found
     revision(read_sysfs<int>(info, "revision")),
@@ -913,11 +947,13 @@ void PCIDevice::send_reset_ioctl_to_devices(
 }
 
 uint8_t PCIDevice::read_command_byte(const int pci_device_num) {
-    int fd = open_pci_device(fmt::format("/dev/tenstorrent/{}", pci_device_num));
-    if (fd == -1) {
+    int fd;
+    try {
+        fd = open_pci_device(fmt::format("/dev/tenstorrent/{}", pci_device_num));
+    } catch (const std::exception &e) {
         UMD_THROW(
             error::RuntimeError,
-            fmt::format("Could not open file descriptor for PCI device number {}.", pci_device_num));
+            fmt::format("Could not open file descriptor for PCI device number {}: {}", pci_device_num, e.what()));
     }
     auto device_info = read_device_info(fd);
 

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -152,8 +152,8 @@ void TopologyDiscovery::get_connected_devices() {
     }
 
     for (auto& device_id : local_device_ids) {
-        std::unique_ptr<TTDevice> tt_device =
-            TTDevice::create(device_id, io_device_type, options.use_safe_api, soc_arch_descriptor_);
+        std::unique_ptr<TTDevice> tt_device = TTDevice::create(
+            device_id, io_device_type, options.use_safe_api, soc_arch_descriptor_, options.open_devices_exclusively);
         if (options.low_power) {
             // Low power mode is temporarily disabled. See https://github.com/tenstorrent/tt-umd/issues/2531.
             log_warning(

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -148,7 +148,8 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     int device_number,
     IODeviceType device_type,
     bool use_safe_api,
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
+    bool exclusive) {
     ZoneScopedC(tracy::Color::DarkGreen);
     UMD_ASSERT(
         (!use_safe_api) || (device_type == IODeviceType::PCIe),
@@ -172,7 +173,7 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
         }
     }
 
-    auto pci_device = std::make_unique<PCIDevice>(device_number);
+    auto pci_device = std::make_unique<PCIDevice>(device_number, exclusive);
     arch = pci_device->get_arch();
 
     switch (arch) {

--- a/nanobind/py_api_topology_discovery.cpp
+++ b/nanobind/py_api_topology_discovery.cpp
@@ -141,7 +141,8 @@ void bind_topology_discovery(nb::module_& m) {
         .def_rw("perform_6u_eth_retrain", &TopologyDiscoveryOptions::perform_6u_eth_retrain)
         // Low power mode is temporarily disabled. See https://github.com/tenstorrent/tt-umd/issues/2531.
         .def_rw("low_power", &TopologyDiscoveryOptions::low_power)
-        .def_rw("use_safe_api", &TopologyDiscoveryOptions::use_safe_api);
+        .def_rw("use_safe_api", &TopologyDiscoveryOptions::use_safe_api)
+        .def_rw("open_devices_exclusively", &TopologyDiscoveryOptions::open_devices_exclusively);
 
     nb::class_<TopologyDiscovery>(m, "TopologyDiscovery")
         .def_static(

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -220,11 +220,12 @@ void bind_tt_device(nb::module_ &m) {
         .def_static(
             "create",
             static_cast<std::unique_ptr<TTDevice> (*)(
-                int, IODeviceType, bool, const std::shared_ptr<SocArchDescriptor> &)>(&TTDevice::create),
+                int, IODeviceType, bool, const std::shared_ptr<SocArchDescriptor> &, bool)>(&TTDevice::create),
             nb::arg("device_number"),
             nb::arg("device_type") = IODeviceType::PCIe,
             nb::arg("use_safe_api") = true,
             nb::arg("soc_arch_descriptor") = nullptr,
+            nb::arg("exclusive") = false,
             nb::rv_policy::take_ownership,
             release_gil())
         .def("set_power_state", &TTDevice::set_power_state, nb::arg("busy"), release_gil())


### PR DESCRIPTION
### Issue
Closes #2841. [tt-kmd#241](https://github.com/tenstorrent/tt-kmd/pull/241) adds `O_EXCL` semantics to `/dev/tenstorrent/N` so a tool can hold a device across a flash + reset. UMD opened with a fixed `O_RDWR | O_CLOEXEC` and could neither request exclusive ownership nor coexist with a process holding one.

### Description
`open_pci_device` follows the new KMD contract: try non-blocking first and stay silent on success; on `EAGAIN`/`EBUSY` log one warning and re-open blocking (interruptible) to wait for ownership; any other `errno`, including a failed blocking re-open, throws instead of returning `-1`. An opt-in `exclusive` flag adds `O_EXCL` and is plumbed through topology-discovery options, following the existing `use_safe_api` pattern. Every new parameter defaults to today's behaviour.

### List of the changes
- `pci_device.cpp`: the non-blocking-then-blocking policy plus an `exclusive` parameter; `O_NONBLOCK` is cleared on success so both paths return identically-flagged descriptors; `read_command_byte` wraps the open to keep its device-number context against the new throw contract.
- `TopologyDiscoveryOptions::open_devices_exclusively`, forwarded through `TTDevice::create` down to `PCIDevice`.
- Python bindings for both.

### Testing
CI.

### API Changes
Additive, all defaulted: `TopologyDiscoveryOptions::open_devices_exclusively`, a trailing `bool exclusive = false` on `TTDevice::create` and `PCIDevice(int)`, and the corresponding Python arguments.