### PR TITLE
Introduce SimulationTTDevice base and hoist shared simulation device members

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -225,6 +225,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/tt_device/tt_device.hpp
                 api/umd/device/tt_device/tt_device_error.hpp
                 api/umd/device/tt_device/wormhole_tt_device.hpp
+                api/umd/device/tt_device/simulation_tt_device.hpp
                 api/umd/device/tt_device/rtl_simulation_tt_device.hpp
                 api/umd/device/tt_device/tt_sim_tt_device.hpp
                 api/umd/device/tt_device/simulation_device_factory.hpp

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -16,7 +16,7 @@
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 #include "umd/device/simulation/rtl_sim_communicator.hpp"
 #include "umd/device/soc_descriptor.hpp"
-#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/simulation_tt_device.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/xy_pair.hpp"
@@ -31,7 +31,7 @@ class SimulationClient;
 class SocDescriptor;
 class TlbWindow;
 
-class RtlSimulationTTDevice : public TTDevice {
+class RtlSimulationTTDevice : public SimulationTTDevice {
 public:
     RtlSimulationTTDevice(
         const std::filesystem::path& simulator_directory,
@@ -114,12 +114,6 @@ private:
     std::unique_ptr<SimulationClient> client_;
 
     std::unique_ptr<RtlSimCommunicator> communicator_;
-    std::recursive_mutex device_lock;
-
-    std::filesystem::path simulator_directory_;
-    std::unique_ptr<SimulationSysmemManager> sysmem_manager_;
-    std::shared_ptr<SimulationTlbAllocator> tlb_allocator_;
-    std::unique_ptr<TlbWindow> cached_tlb_window_;
 
     // Exposes this device on disk as a UNIX socket ("the card"), so other UMD clients can find
     // it. The host keeps its own direct fast path; the socket is for remote clients.

--- a/device/api/umd/device/tt_device/simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/simulation_tt_device.hpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <filesystem>
+#include <memory>
+#include <mutex>
+
+#include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
+#include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
+#include "umd/device/pcie/tlb_window.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+
+namespace tt::umd {
+
+class SimulationSysmemManager;
+class SimulationTlbAllocator;
+class TlbWindow;
+
+// Common base class for the simulation TTDevice backends (TTSimTTDevice and RtlSimulationTTDevice).
+// It is introduced as an intermediary in the class hierarchy and owns the state that is shared by
+// both backends. The behavior that operates on this state still lives in the derived classes for now
+// and will be migrated into this base incrementally.
+//
+// The backend communicator is intentionally NOT owned here: TTSimCommunicator and RtlSimCommunicator
+// are unrelated `final` classes with no common base, so each derived device keeps its own
+// concretely-typed communicator.
+class SimulationTTDevice : public TTDevice {
+protected:
+    SimulationTTDevice(
+        const std::filesystem::path& simulator_directory, std::unique_ptr<SimulationSysmemManager> sysmem_manager) :
+        simulator_directory_(simulator_directory), sysmem_manager_(std::move(sysmem_manager)) {}
+
+    // Client-mode constructor: the device does not own a local simulator, so it has no simulator
+    // directory or sysmem manager -- those live on the remote host reached over the socket.
+    SimulationTTDevice() = default;
+
+    std::recursive_mutex device_lock;
+    std::filesystem::path simulator_directory_;
+    std::unique_ptr<SimulationSysmemManager> sysmem_manager_;
+    std::shared_ptr<SimulationTlbAllocator> tlb_allocator_;
+    std::unique_ptr<TlbWindow> cached_tlb_window_ = nullptr;
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -18,7 +18,7 @@
 #include "umd/device/simulation/simulation_host.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"
 #include "umd/device/soc_descriptor.hpp"
-#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/simulation_tt_device.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/xy_pair.hpp"
@@ -32,7 +32,7 @@ class SimulationServerSocket;
 class SimulationClient;
 class SocDescriptor;
 
-class TTSimTTDevice : public TTDevice {
+class TTSimTTDevice : public SimulationTTDevice {
 public:
     TTSimTTDevice(
         const std::filesystem::path &simulator_directory,
@@ -142,19 +142,12 @@ private:
 
     uint32_t tlb_region_size_ = 0;
     std::unique_ptr<TTSimCommunicator> communicator_;
-    std::recursive_mutex device_lock;
-
-    std::filesystem::path simulator_directory_;
     ChipId chip_id_;
-    std::unique_ptr<SimulationSysmemManager> sysmem_manager_;
 
     // Exposes this device on disk as a UNIX socket ("the card"), so other UMD clients can find
     // it. The host keeps its own direct in-process fast path; the socket is for remote clients.
     std::unique_ptr<SimulationServerSocket> socket_;
 
     uint32_t libttsim_pci_device_id;
-
-    std::shared_ptr<SimulationTlbAllocator> tlb_allocator_;
-    std::unique_ptr<TlbWindow> cached_tlb_window_ = nullptr;
 };
 }  // namespace tt::umd

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -85,9 +85,9 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
     const SocDescriptor& soc_descriptor,
     ChipId chip_id,
     int num_host_mem_channels) :
-    communicator_(std::make_unique<RtlSimCommunicator>(simulator_directory)),
-    simulator_directory_(simulator_directory),
-    sysmem_manager_(std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)) {
+    SimulationTTDevice(
+        simulator_directory, std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)),
+    communicator_(std::make_unique<RtlSimCommunicator>(simulator_directory)) {
     log_info(tt::LogEmulationDriver, "Instantiating RTL simulation TTDevice");
     set_soc_descriptor(soc_descriptor);
     architecture_impl_ = architecture_implementation::create(get_soc_descriptor().arch);

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -99,15 +99,15 @@ TTSimTTDevice::TTSimTTDevice(
     ChipId chip_id,
     bool copy_sim_binary,
     int num_host_mem_channels) :
+    SimulationTTDevice(
+        simulator_directory, std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)),
     // Pass chip_id to the communicator. If the loaded .so supports the multichip
     // multichip ABI (libttsim_create_device_by_id + libttsim_select_device_by_id),
     // the communicator will auto-detect at initialize() time and switch to
     // shared-dlopen mode regardless of copy_sim_binary.
     communicator_(
         std::make_unique<TTSimCommunicator>(simulator_directory, copy_sim_binary, static_cast<uint32_t>(chip_id))),
-    simulator_directory_(simulator_directory),
-    chip_id_(chip_id),
-    sysmem_manager_(std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)) {
+    chip_id_(chip_id) {
     set_soc_descriptor(soc_descriptor);
     // Populate the base-class arch field from the soc descriptor. TTSim does not go through
     // init_tt_device() (no PCI probe), so without this arch stays tt::ARCH::Invalid and downstream


### PR DESCRIPTION
### Issue
Part of #2865

### Description
First step toward a common implementation for the RTL and TTSim simulation `TTDevice` backends. Introduces a `SimulationTTDevice` intermediary base class and moves the member variables that were duplicated across `TTSimTTDevice` and `RtlSimulationTTDevice` into it. No behavior is moved yet — every method override stays in the derived classes, and follow-up PRs migrate the shared logic incrementally.

### List of the changes
- Add `SimulationTTDevice` (derives from `TTDevice`), owning the shared `device_lock`, `simulator_directory_`, `sysmem_manager_`, `tlb_allocator_`, and `cached_tlb_window_` members, and register its header in the installed `FILE_SET`.
- `TTSimTTDevice` and `RtlSimulationTTDevice` now derive from `SimulationTTDevice` and pass the shared state through the base constructor.
- The backend communicator stays concretely-typed in each derived class (the two communicators have no common base).

### Testing
CI

### API Changes
None.