### PR TITLE
Move common simulation device methods into SimulationTTDevice

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -151,6 +151,7 @@ if(TT_UMD_BUILD_SIMULATION)
             simulation/simulation_host.cpp
             simulation/tt_sim_communicator.cpp
             simulation/rtl_sim_communicator.cpp
+            tt_device/simulation_tt_device.cpp
             tt_device/rtl_simulation_tt_device.cpp
             tt_device/tt_sim_tt_device.cpp
             chip_helpers/simulation_tlb_allocator.cpp

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -52,46 +52,17 @@ public:
     void read_from_device(void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) override;
     void write_to_device(const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) override;
 
-    void dma_d2h(void* dst, uint32_t src, size_t size) override;
-    void dma_d2h_zero_copy(void* dst, uint32_t src, size_t size) override;
-    void dma_h2d(uint32_t dst, const void* src, size_t size) override;
-    void dma_h2d_zero_copy(uint32_t dst, const void* src, size_t size) override;
-    void read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
-    void write_to_arc_apb(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
-    void read_from_arc_csm(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
-    void write_to_arc_csm(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
     void wait_arc_core_start(const std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT) override;
     std::chrono::milliseconds wait_eth_core_training(
         const tt_xy_pair eth_core, const std::chrono::milliseconds timeout_ms = timeout::ETH_TRAINING_TIMEOUT) override;
     EthTrainingStatus read_eth_core_training_status(tt_xy_pair eth_core) override;
-    uint32_t get_clock() override;
-    uint32_t get_min_clock_freq() override;
-    bool get_noc_translation_enabled() override;
-    void dma_multicast_write(
-        void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
 
     void assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs) override;
     void deassert_risc_reset(tt_xy_pair core, const RiscType selected_riscs, bool staggered_start) override;
 
-    void noc_multicast_write(
-        const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
-
-    using TTDevice::noc_multicast_write;
-    void noc_multicast_write(const void* src, size_t size, uint64_t addr) override;
-
     RtlSimCommunicator* get_communicator() { return communicator_.get(); }
 
-    SimulationSysmemManager* get_sysmem_manager() override { return sysmem_manager_.get(); }
-
     std::unique_ptr<TlbWindow> get_io_window(tlb_data config, TlbMapping mapping, size_t size) override;
-
-    SimulationTlbAllocator* get_tlb_allocator() { return tlb_allocator_.get(); }
-
-    // Takes ownership of the serving socket that exposes this device (created by discovery).
-    void adopt_socket(std::unique_ptr<SimulationServerSocket> socket);
-
-protected:
-    void retrain_dram_core(const uint32_t dram_channel) override;
 
 private:
     // Client-mode constructor: this device does not own a simulator; it forwards device operations
@@ -114,9 +85,5 @@ private:
     std::unique_ptr<SimulationClient> client_;
 
     std::unique_ptr<RtlSimCommunicator> communicator_;
-
-    // Exposes this device on disk as a UNIX socket ("the card"), so other UMD clients can find
-    // it. The host keeps its own direct fast path; the socket is for remote clients.
-    std::unique_ptr<SimulationServerSocket> socket_;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/simulation_tt_device.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <filesystem>
 #include <memory>
 #include <mutex>
@@ -12,11 +14,13 @@
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 
 class SimulationSysmemManager;
 class SimulationTlbAllocator;
+class SimulationServerSocket;
 class TlbWindow;
 
 // Common base class for the simulation TTDevice backends (TTSimTTDevice and RtlSimulationTTDevice).
@@ -28,10 +32,41 @@ class TlbWindow;
 // are unrelated `final` classes with no common base, so each derived device keeps its own
 // concretely-typed communicator.
 class SimulationTTDevice : public TTDevice {
+public:
+    ~SimulationTTDevice() override;
+
+    // Takes ownership of the serving socket that exposes this device (created by discovery).
+    void adopt_socket(std::unique_ptr<SimulationServerSocket> socket);
+
+    // --- TTDevice overrides whose behavior is identical across both simulation backends ---
+    void dma_d2h(void* dst, uint32_t src, size_t size) override;
+    void dma_d2h_zero_copy(void* dst, uint32_t src, size_t size) override;
+    void dma_h2d(uint32_t dst, const void* src, size_t size) override;
+    void dma_h2d_zero_copy(uint32_t dst, const void* src, size_t size) override;
+    void read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
+    void write_to_arc_apb(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
+    void read_from_arc_csm(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
+    void write_to_arc_csm(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
+    uint32_t get_clock() override;
+    uint32_t get_min_clock_freq() override;
+    bool get_noc_translation_enabled() override;
+    void dma_multicast_write(
+        void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
+
+    void noc_multicast_write(
+        const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
+    using TTDevice::noc_multicast_write;
+    void noc_multicast_write(const void* src, size_t size, uint64_t addr) override;
+
+    SimulationSysmemManager* get_sysmem_manager() override { return sysmem_manager_.get(); }
+
+    SimulationTlbAllocator* get_tlb_allocator() { return tlb_allocator_.get(); }
+
 protected:
     SimulationTTDevice(
-        const std::filesystem::path& simulator_directory, std::unique_ptr<SimulationSysmemManager> sysmem_manager) :
-        simulator_directory_(simulator_directory), sysmem_manager_(std::move(sysmem_manager)) {}
+        const std::filesystem::path& simulator_directory, std::unique_ptr<SimulationSysmemManager> sysmem_manager);
+
+    void retrain_dram_core(const uint32_t dram_channel) override;
 
     // Client-mode constructor: the device does not own a local simulator, so it has no simulator
     // directory or sysmem manager -- those live on the remote host reached over the socket.
@@ -42,6 +77,10 @@ protected:
     std::unique_ptr<SimulationSysmemManager> sysmem_manager_;
     std::shared_ptr<SimulationTlbAllocator> tlb_allocator_;
     std::unique_ptr<TlbWindow> cached_tlb_window_ = nullptr;
+
+    // Exposes this device on disk as a UNIX socket ("the card"), so other UMD clients can find it.
+    // The host keeps its own direct in-process fast path; the socket is for remote clients.
+    std::unique_ptr<SimulationServerSocket> socket_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -65,32 +65,14 @@ public:
     void read_from_device(void *mem_ptr, CoreCoord core, uint64_t addr, size_t size) override;
     void write_to_device(const void *mem_ptr, CoreCoord core, uint64_t addr, size_t size) override;
 
-    void dma_d2h(void *dst, uint32_t src, size_t size) override;
-    void dma_d2h_zero_copy(void *dst, uint32_t src, size_t size) override;
-    void dma_h2d(uint32_t dst, const void *src, size_t size) override;
-    void dma_h2d_zero_copy(uint32_t dst, const void *src, size_t size) override;
-    void read_from_arc_apb(void *mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
-    void write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
-    void read_from_arc_csm(void *mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
-    void write_to_arc_csm(const void *mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
     void wait_arc_core_start(const std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT) override;
     std::chrono::milliseconds wait_eth_core_training(
         const tt_xy_pair eth_core, const std::chrono::milliseconds timeout_ms = timeout::ETH_TRAINING_TIMEOUT) override;
     EthTrainingStatus read_eth_core_training_status(tt_xy_pair eth_core) override;
-    uint32_t get_clock() override;
-    uint32_t get_min_clock_freq() override;
-    bool get_noc_translation_enabled() override;
     ChipInfo get_chip_info() override;
-    void dma_multicast_write(
-        void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
 
     void close_device();
     void start_device();
-    void noc_multicast_write(
-        const void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
-
-    using TTDevice::noc_multicast_write;
-    void noc_multicast_write(const void *src, size_t size, uint64_t addr) override;
 
     void assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs) override;
     void deassert_risc_reset(tt_xy_pair core, const RiscType selected_riscs, bool staggered_start) override;
@@ -103,20 +85,10 @@ public:
      */
     TTSimCommunicator *get_communicator() { return communicator_.get(); }
 
-    SimulationSysmemManager *get_sysmem_manager() override { return sysmem_manager_.get(); }
-
     std::unique_ptr<TlbWindow> get_io_window(tlb_data config, TlbMapping mapping, size_t size) override;
-
-    SimulationTlbAllocator *get_tlb_allocator() { return tlb_allocator_.get(); }
-
-    // Takes ownership of the serving socket that exposes this device (created by discovery).
-    void adopt_socket(std::unique_ptr<SimulationServerSocket> socket);
 
     uint64_t bar0_base = 0;
     uint64_t bar4_base = 0;
-
-protected:
-    void retrain_dram_core(const uint32_t dram_channel) override;
 
 private:
     // Client-mode constructor: this device does not own a simulator (.so); it forwards device
@@ -143,11 +115,6 @@ private:
     uint32_t tlb_region_size_ = 0;
     std::unique_ptr<TTSimCommunicator> communicator_;
     ChipId chip_id_;
-
-    // Exposes this device on disk as a UNIX socket ("the card"), so other UMD clients can find
-    // it. The host keeps its own direct in-process fast path; the socket is for remote clients.
-    std::unique_ptr<SimulationServerSocket> socket_;
-
     uint32_t libttsim_pci_device_id;
 };
 }  // namespace tt::umd

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -203,10 +203,6 @@ RtlSimulationTTDevice::~RtlSimulationTTDevice() {
     }
 }
 
-void RtlSimulationTTDevice::adopt_socket(std::unique_ptr<SimulationServerSocket> socket) {
-    socket_ = std::move(socket);
-}
-
 void RtlSimulationTTDevice::write_to_device(const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) {
     if (client_) {
         UMD_THROW(
@@ -339,40 +335,6 @@ void RtlSimulationTTDevice::deassert_risc_reset(tt_xy_pair core, const RiscType 
     }
 }
 
-void RtlSimulationTTDevice::dma_d2h(void* dst, uint32_t src, size_t size) {
-    UMD_THROW(error::RuntimeError, "dma_d2h() not supported for RTL simulation.");
-}
-
-void RtlSimulationTTDevice::dma_d2h_zero_copy(void* dst, uint32_t src, size_t size) {
-    UMD_THROW(error::RuntimeError, "dma_d2h_zero_copy() not supported for RTL simulation.");
-}
-
-void RtlSimulationTTDevice::dma_h2d(uint32_t dst, const void* src, size_t size) {
-    UMD_THROW(error::RuntimeError, "dma_h2d() not supported for RTL simulation.");
-}
-
-void RtlSimulationTTDevice::dma_h2d_zero_copy(uint32_t dst, const void* src, size_t size) {
-    UMD_THROW(error::RuntimeError, "dma_h2d_zero_copy() not supported for RTL simulation.");
-}
-
-void RtlSimulationTTDevice::read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) {
-    UMD_THROW(error::RuntimeError, "read_from_arc_apb() not supported for RTL simulation.");
-}
-
-void RtlSimulationTTDevice::write_to_arc_apb(
-    const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) {
-    UMD_THROW(error::RuntimeError, "write_to_arc_apb() not supported for RTL simulation.");
-}
-
-void RtlSimulationTTDevice::read_from_arc_csm(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) {
-    UMD_THROW(error::RuntimeError, "read_from_arc_csm() not supported for RTL simulation.");
-}
-
-void RtlSimulationTTDevice::write_to_arc_csm(
-    const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) {
-    UMD_THROW(error::RuntimeError, "write_to_arc_csm() not supported for RTL simulation.");
-}
-
 void RtlSimulationTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeout_ms) {
     // RTL simulation doesn't have ARC cores in the same way.
 }
@@ -386,39 +348,6 @@ std::chrono::milliseconds RtlSimulationTTDevice::wait_eth_core_training(
 EthTrainingStatus RtlSimulationTTDevice::read_eth_core_training_status(tt_xy_pair eth_core) {
     // RTL simulation doesn't require Ethernet training.
     return EthTrainingStatus::SUCCESS;
-}
-
-uint32_t RtlSimulationTTDevice::get_clock() {
-    // RTL simulation does not have an ARC processor, so clock frequency is not available.
-    UMD_THROW(error::RuntimeError, "get_clock() not supported for RTL simulation.");
-}
-
-uint32_t RtlSimulationTTDevice::get_min_clock_freq() {
-    // RTL simulation does not have an ARC processor, so clock frequency is not available.
-    UMD_THROW(error::RuntimeError, "get_min_clock_freq() not supported for RTL simulation.");
-}
-
-bool RtlSimulationTTDevice::get_noc_translation_enabled() {
-    // NOC address translation is not available in RTL simulation.
-    return false;
-}
-
-void RtlSimulationTTDevice::dma_multicast_write(
-    void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) {
-    UMD_THROW(error::RuntimeError, "dma_multicast_write() not supported for RTL simulation.");
-}
-
-void RtlSimulationTTDevice::retrain_dram_core(const uint32_t dram_channel) {
-    UMD_THROW(error::RuntimeError, "DRAM retraining is not supported in RTL simulation device.");
-}
-
-void RtlSimulationTTDevice::noc_multicast_write(
-    const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) {
-    multicast_write_via_unicast(src, size, core_start, core_end, addr);
-}
-
-void RtlSimulationTTDevice::noc_multicast_write(const void* src, size_t size, uint64_t addr) {
-    UMD_THROW(error::RuntimeError, "NOC multicast write is not supported in RTL simulation device.");
 }
 
 }  // namespace tt::umd

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/tt_device/simulation_tt_device.hpp"
+
+#include "simulation/simulation_server_socket.hpp"
+#include "umd/device/utils/error.hpp"
+
+namespace tt::umd {
+
+// The constructor and destructor are defined out-of-line so that socket_
+// (unique_ptr<SimulationServerSocket>) is constructed/destroyed where the type is complete; the
+// public header only forward-declares SimulationServerSocket.
+SimulationTTDevice::SimulationTTDevice(
+    const std::filesystem::path& simulator_directory, std::unique_ptr<SimulationSysmemManager> sysmem_manager) :
+    simulator_directory_(simulator_directory), sysmem_manager_(std::move(sysmem_manager)) {}
+
+SimulationTTDevice::~SimulationTTDevice() = default;
+
+void SimulationTTDevice::adopt_socket(std::unique_ptr<SimulationServerSocket> socket) { socket_ = std::move(socket); }
+
+bool SimulationTTDevice::get_noc_translation_enabled() {
+    // Simulation backends operate on logical/virtual coordinates end-to-end; NOC translation is never
+    // applied.
+    return false;
+}
+
+void SimulationTTDevice::noc_multicast_write(
+    const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) {
+    multicast_write_via_unicast(src, size, core_start, core_end, addr);
+}
+
+void SimulationTTDevice::noc_multicast_write(const void* src, size_t size, uint64_t addr) {
+    UMD_THROW(error::RuntimeError, "NOC multicast write is not supported for simulation devices.");
+}
+
+void SimulationTTDevice::dma_d2h(void* dst, uint32_t src, size_t size) {
+    UMD_THROW(error::RuntimeError, "DMA operations are not supported for simulation devices.");
+}
+
+void SimulationTTDevice::dma_d2h_zero_copy(void* dst, uint32_t src, size_t size) {
+    UMD_THROW(error::RuntimeError, "DMA operations are not supported for simulation devices.");
+}
+
+void SimulationTTDevice::dma_h2d(uint32_t dst, const void* src, size_t size) {
+    UMD_THROW(error::RuntimeError, "DMA operations are not supported for simulation devices.");
+}
+
+void SimulationTTDevice::dma_h2d_zero_copy(uint32_t dst, const void* src, size_t size) {
+    UMD_THROW(error::RuntimeError, "DMA operations are not supported for simulation devices.");
+}
+
+void SimulationTTDevice::dma_multicast_write(
+    void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) {
+    UMD_THROW(error::RuntimeError, "DMA multicast write is not supported for simulation devices.");
+}
+
+void SimulationTTDevice::read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) {
+    UMD_THROW(error::RuntimeError, "ARC APB access is not supported for simulation devices.");
+}
+
+void SimulationTTDevice::write_to_arc_apb(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) {
+    UMD_THROW(error::RuntimeError, "ARC APB access is not supported for simulation devices.");
+}
+
+void SimulationTTDevice::read_from_arc_csm(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) {
+    UMD_THROW(error::RuntimeError, "ARC CSM access is not supported for simulation devices.");
+}
+
+void SimulationTTDevice::write_to_arc_csm(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) {
+    UMD_THROW(error::RuntimeError, "ARC CSM access is not supported for simulation devices.");
+}
+
+uint32_t SimulationTTDevice::get_clock() {
+    UMD_THROW(error::RuntimeError, "Getting clock is not supported for simulation devices.");
+}
+
+uint32_t SimulationTTDevice::get_min_clock_freq() {
+    UMD_THROW(error::RuntimeError, "Getting minimum clock frequency is not supported for simulation devices.");
+}
+
+void SimulationTTDevice::retrain_dram_core(const uint32_t dram_channel) {
+    UMD_THROW(error::RuntimeError, "DRAM retraining is not supported for simulation devices.");
+}
+
+}  // namespace tt::umd

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -233,8 +233,6 @@ TTSimTTDevice::~TTSimTTDevice() {
     }
 }
 
-void TTSimTTDevice::adopt_socket(std::unique_ptr<SimulationServerSocket> socket) { socket_ = std::move(socket); }
-
 void TTSimTTDevice::start_device() {}
 
 void TTSimTTDevice::close_device() {
@@ -355,38 +353,6 @@ void TTSimTTDevice::advance_device_execution() {
     }
 }
 
-void TTSimTTDevice::dma_d2h(void* dst, uint32_t src, size_t size) {
-    UMD_THROW(error::RuntimeError, "DMA operations are not supported in TTSim simulation device.");
-}
-
-void TTSimTTDevice::dma_d2h_zero_copy(void* dst, uint32_t src, size_t size) {
-    UMD_THROW(error::RuntimeError, "DMA operations are not supported in TTSim simulation device.");
-}
-
-void TTSimTTDevice::dma_h2d(uint32_t dst, const void* src, size_t size) {
-    UMD_THROW(error::RuntimeError, "DMA operations are not supported in TTSim simulation device.");
-}
-
-void TTSimTTDevice::dma_h2d_zero_copy(uint32_t dst, const void* src, size_t size) {
-    UMD_THROW(error::RuntimeError, "DMA operations are not supported in TTSim simulation device.");
-}
-
-void TTSimTTDevice::read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) {
-    UMD_THROW(error::RuntimeError, "ARC APB access is not supported in TTSim simulation device.");
-}
-
-void TTSimTTDevice::write_to_arc_apb(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) {
-    UMD_THROW(error::RuntimeError, "ARC APB access is not supported in TTSim simulation device.");
-}
-
-void TTSimTTDevice::read_from_arc_csm(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) {
-    UMD_THROW(error::RuntimeError, "ARC CSM access is not supported in TTSim simulation device.");
-}
-
-void TTSimTTDevice::write_to_arc_csm(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) {
-    UMD_THROW(error::RuntimeError, "ARC CSM access is not supported in TTSim simulation device.");
-}
-
 void TTSimTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeout_ms) {
     UMD_THROW(error::RuntimeError, "Waiting for ARC core start is not supported in TTSim simulation device.");
 }
@@ -400,19 +366,6 @@ EthTrainingStatus TTSimTTDevice::read_eth_core_training_status(tt_xy_pair eth_co
     UMD_THROW(error::RuntimeError, "Reading ETH core training status is not supported in TTSim simulation device.");
 }
 
-uint32_t TTSimTTDevice::get_clock() {
-    UMD_THROW(error::RuntimeError, "Getting clock is not supported in TTSim simulation device.");
-}
-
-uint32_t TTSimTTDevice::get_min_clock_freq() {
-    UMD_THROW(error::RuntimeError, "Getting minimum clock frequency is not supported in TTSim simulation device.");
-}
-
-bool TTSimTTDevice::get_noc_translation_enabled() {
-    // TTSim operates on logical/virtual coordinates end-to-end; NOC translation is never applied.
-    return false;
-}
-
 ChipInfo TTSimTTDevice::get_chip_info() {
     // No firmware_info_provider on the simulator; mirror the defaults used inside
     // TTSimTTDevice::create(). BH SocDescriptor construction rejects an empty eth_harvesting_mask
@@ -423,11 +376,6 @@ ChipInfo TTSimTTDevice::get_chip_info() {
         chip_info.harvesting_masks.eth_harvesting_mask = 0x120;
     }
     return chip_info;
-}
-
-void TTSimTTDevice::dma_multicast_write(
-    void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) {
-    UMD_THROW(error::RuntimeError, "DMA multicast write not supported for TTSim simulation device.");
 }
 
 void TTSimTTDevice::initialize_sysmem_functions() {
@@ -467,19 +415,6 @@ void TTSimTTDevice::pci_dma_write_bytes(uint64_t paddr, const void* p, uint32_t 
     }
     const uint16_t channel = static_cast<uint16_t>(paddr / (1ULL << 30));
     sim_mgr->write_to_sysmem(channel, p, paddr % (1ULL << 30), size);
-}
-
-void TTSimTTDevice::retrain_dram_core(const uint32_t dram_channel) {
-    UMD_THROW(error::RuntimeError, "DRAM retraining is not supported in TTSim device.");
-}
-
-void TTSimTTDevice::noc_multicast_write(
-    const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) {
-    multicast_write_via_unicast(src, size, core_start, core_end, addr);
-}
-
-void TTSimTTDevice::noc_multicast_write(const void* src, size_t size, uint64_t addr) {
-    UMD_THROW(error::RuntimeError, "NOC multicast write is not supported in TTSim simulation device.");
 }
 
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue
Part of #2865

### Description
Second step toward a common implementation for the RTL and TTSim simulation `TTDevice` backends, stacked on #2913. Moves the behavior that is identical across `TTSimTTDevice` and `RtlSimulationTTDevice` up into the `SimulationTTDevice` base. Backend-divergent behavior stays in the derived classes and is unified in follow-up PRs.

### List of the changes
- Move into `SimulationTTDevice`: the DMA and ARC APB/CSM throw-stubs, `get_clock`, `get_min_clock_freq`, `dma_multicast_write`, `retrain_dram_core`, both `noc_multicast_write` overloads (grid form delegates to `multicast_write_via_unicast`), `get_noc_translation_enabled`, the `get_sysmem_manager`/`get_tlb_allocator` accessors, and `adopt_socket` together with the `socket_` member.
- Define the base constructor and destructor out-of-line so the forward-declared `SimulationServerSocket` only needs to be complete in the implementation file.
- Unify the "not supported" error messages and remove the now-redundant overrides from the derived classes.

### Testing
CI

### API Changes
None.