### PR TITLE
Unify simulation get_io_window behind a create_tlb_window hook

### DIFF
--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -62,7 +62,9 @@ public:
 
     RtlSimCommunicator* get_communicator() { return communicator_.get(); }
 
-    std::unique_ptr<TlbWindow> get_io_window(tlb_data config, TlbMapping mapping, size_t size) override;
+protected:
+    std::unique_ptr<TlbWindow> create_tlb_window(
+        int tlb_index, size_t size, TlbMapping mapping, tlb_data config) override;
 
 private:
     // Client-mode constructor: this device does not own a simulator; it forwards device operations

--- a/device/api/umd/device/tt_device/simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/simulation_tt_device.hpp
@@ -14,6 +14,7 @@
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/tlb.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
@@ -23,13 +24,10 @@ class SimulationTlbAllocator;
 class SimulationServerSocket;
 class TlbWindow;
 
-// Common base class for the simulation TTDevice backends (TTSimTTDevice and RtlSimulationTTDevice).
-// It is introduced as an intermediary in the class hierarchy and owns the state that is shared by
-// both backends. The behavior that operates on this state still lives in the derived classes for now
-// and will be migrated into this base incrementally.
+// Common base class for the simulation TTDevice backends. It sits as an intermediary in the class
+// hierarchy and owns the state shared by the derived simulation devices.
 //
-// The backend communicator is intentionally NOT owned here: TTSimCommunicator and RtlSimCommunicator
-// are unrelated `final` classes with no common base, so each derived device keeps its own
+// The backend communicator is intentionally not owned here; each derived device keeps its own
 // concretely-typed communicator.
 class SimulationTTDevice : public TTDevice {
 public:
@@ -62,6 +60,8 @@ public:
 
     SimulationTlbAllocator* get_tlb_allocator() { return tlb_allocator_.get(); }
 
+    std::unique_ptr<TlbWindow> get_io_window(tlb_data config, TlbMapping mapping, size_t size) override;
+
 protected:
     SimulationTTDevice(
         const std::filesystem::path& simulator_directory, std::unique_ptr<SimulationSysmemManager> sysmem_manager);
@@ -71,6 +71,17 @@ protected:
     // Client-mode constructor: the device does not own a local simulator, so it has no simulator
     // directory or sysmem manager -- those live on the remote host reached over the socket.
     SimulationTTDevice() = default;
+
+    // Build tlb_allocator_ once the backend knows its BAR0 base (0 for RTL, PCI-probed for TTSim).
+    void init_tlb_allocator(uint64_t bar0_base);
+    // Allocate the cached default TLB window for the current arch. Must be invoked from the derived
+    // constructor once its communicator exists, since it reaches the backend through the virtual
+    // create_tlb_window() hook.
+    void setup_cached_tlb_window();
+
+    // Construct the backend-specific TlbHandle + TlbWindow for an already-allocated TLB index.
+    virtual std::unique_ptr<TlbWindow> create_tlb_window(
+        int tlb_index, size_t size, TlbMapping mapping, tlb_data config) = 0;
 
     std::recursive_mutex device_lock;
     std::filesystem::path simulator_directory_;

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -85,10 +85,12 @@ public:
      */
     TTSimCommunicator *get_communicator() { return communicator_.get(); }
 
-    std::unique_ptr<TlbWindow> get_io_window(tlb_data config, TlbMapping mapping, size_t size) override;
-
     uint64_t bar0_base = 0;
     uint64_t bar4_base = 0;
+
+protected:
+    std::unique_ptr<TlbWindow> create_tlb_window(
+        int tlb_index, size_t size, TlbMapping mapping, tlb_data config) override;
 
 private:
     // Client-mode constructor: this device does not own a simulator (.so); it forwards device

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -144,48 +144,13 @@ void RtlSimulationTTDevice::initialize_backend(int num_host_mem_channels) {
 
     communicator_->initialize();
 
-    tlb_allocator_ = std::make_shared<SimulationTlbAllocator>(/*bar0_base=*/0, architecture_impl_.get());
-
-    // Allocate the cached default TLB window. Quasar has no real TLBs; the communicator handles
-    // all I/O underneath. The 4GB size for Quasar is a dummy value — it just needs to be large
-    // enough so that TlbWindow::validate doesn't reject any valid access (size 0 would cause
-    // division by zero in RtlSimTlbHandle::configure).
-    static constexpr size_t SIZE_2MB = 2 * 1024 * 1024;
-    static constexpr size_t SIZE_16MB = 16 * 1024 * 1024;
-    static constexpr size_t SIZE_4GB = 4ULL * 1024 * 1024 * 1024;
-    switch (arch) {
-        case tt::ARCH::BLACKHOLE:
-            cached_tlb_window_ = RtlSimulationTTDevice::get_io_window({}, TlbMapping::WC, SIZE_2MB);
-            break;
-        case tt::ARCH::WORMHOLE_B0:
-            cached_tlb_window_ = RtlSimulationTTDevice::get_io_window({}, TlbMapping::WC, SIZE_16MB);
-            break;
-        case tt::ARCH::QUASAR:
-            cached_tlb_window_ = RtlSimulationTTDevice::get_io_window({}, TlbMapping::WC, SIZE_4GB);
-            break;
-        default:
-            log_debug(
-                LogUMD,
-                "Architecture {} does not support TLB allocation, leaving cached_tlb_window_ null.",
-                tt::arch_to_str(arch));
-            break;
-    }
+    init_tlb_allocator(/*bar0_base=*/0);
+    setup_cached_tlb_window();
 }
 
-std::unique_ptr<TlbWindow> RtlSimulationTTDevice::get_io_window(tlb_data config, TlbMapping mapping, size_t size) {
-    if (client_) {
-        // Client mode runs no backend, so tlb_allocator_/communicator_ are never constructed. Fail
-        // loudly instead of dereferencing them; client-mode device I/O is not available yet.
-        UMD_THROW(error::RuntimeError, "Client-mode RtlSimulationTTDevice does not support TLB windows yet.");
-    }
-    int tlb_index = tlb_allocator_->allocate_tlb_index(size);
-    if (tlb_index == -1) {
-        UMD_THROW(error::RuntimeError, "No available TLB of requested size.");
-    }
-    // QUASAR bypasses the bitmap allocator (pools are empty by design); pass the requested
-    // size through, since get_tlb_size_from_index has no pool to look up for the bypass index.
-    size_t actual_size = (get_arch() == tt::ARCH::QUASAR) ? size : tlb_allocator_->get_tlb_size_from_index(tlb_index);
-    auto handle = RtlSimTlbHandle::create(tlb_allocator_, tlb_index, actual_size, mapping);
+std::unique_ptr<TlbWindow> RtlSimulationTTDevice::create_tlb_window(
+    int tlb_index, size_t size, TlbMapping mapping, tlb_data config) {
+    auto handle = RtlSimTlbHandle::create(tlb_allocator_, tlb_index, size, mapping);
     return std::make_unique<RtlSimTlbWindow>(std::move(handle), communicator_.get(), config);
 }
 

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -4,7 +4,14 @@
 
 #include "umd/device/tt_device/simulation_tt_device.hpp"
 
+#include <tt-logger/tt-logger.hpp>
+
 #include "simulation/simulation_server_socket.hpp"
+#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
+#include "umd/device/pcie/tlb_window.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/tlb.hpp"
 #include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
@@ -19,6 +26,53 @@ SimulationTTDevice::SimulationTTDevice(
 SimulationTTDevice::~SimulationTTDevice() = default;
 
 void SimulationTTDevice::adopt_socket(std::unique_ptr<SimulationServerSocket> socket) { socket_ = std::move(socket); }
+
+void SimulationTTDevice::init_tlb_allocator(uint64_t bar0_base) {
+    tlb_allocator_ = std::make_shared<SimulationTlbAllocator>(bar0_base, architecture_impl_.get());
+}
+
+void SimulationTTDevice::setup_cached_tlb_window() {
+    // Quasar has no real TLBs; the communicator handles all I/O underneath. The 4GB size for Quasar is
+    // a dummy value -- it just needs to be large enough so that TlbWindow::validate doesn't reject any
+    // valid access (size 0 would cause division by zero in the TLB handle configure).
+    static constexpr size_t SIZE_2MB = 2 * 1024 * 1024;
+    static constexpr size_t SIZE_16MB = 16 * 1024 * 1024;
+    static constexpr size_t SIZE_4GB = 4ULL * 1024 * 1024 * 1024;
+    switch (arch) {
+        case tt::ARCH::BLACKHOLE:
+            cached_tlb_window_ = get_io_window({}, TlbMapping::WC, SIZE_2MB);
+            break;
+        case tt::ARCH::WORMHOLE_B0:
+            cached_tlb_window_ = get_io_window({}, TlbMapping::WC, SIZE_16MB);
+            break;
+        case tt::ARCH::QUASAR:
+            cached_tlb_window_ = get_io_window({}, TlbMapping::WC, SIZE_4GB);
+            break;
+        default:
+            log_debug(
+                LogUMD,
+                "Architecture {} does not support TLB allocation, leaving cached_tlb_window_ null.",
+                tt::arch_to_str(arch));
+            break;
+    }
+}
+
+std::unique_ptr<TlbWindow> SimulationTTDevice::get_io_window(tlb_data config, TlbMapping mapping, size_t size) {
+    // tlb_allocator_ is only built by init_tlb_allocator(), which the client-mode path never calls
+    // (it runs no local backend). Fail loudly instead of dereferencing a null allocator.
+    UMD_ASSERT(
+        tlb_allocator_ != nullptr,
+        error::RuntimeError,
+        "TLB allocator is not initialized; get_io_window is unavailable (e.g. in client mode).");
+    int tlb_index = tlb_allocator_->allocate_tlb_index(size);
+    if (tlb_index == -1) {
+        UMD_THROW(error::RuntimeError, "No available TLB of requested size.");
+    }
+    // QUASAR bypasses the bitmap allocator (pools are empty by design); pass the requested size
+    // through, since get_tlb_size_from_index has no pool to look up for the bypass index.
+    size_t actual_size = (get_arch() == tt::ARCH::QUASAR) ? size : tlb_allocator_->get_tlb_size_from_index(tlb_index);
+    return create_tlb_window(tlb_index, actual_size, mapping, config);
+}
 
 bool SimulationTTDevice::get_noc_translation_enabled() {
     // Simulation backends operate on logical/virtual coordinates end-to-end; NOC translation is never

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -158,32 +158,8 @@ void TTSimTTDevice::initialize_backend() {
         }
     }
 
-    tlb_allocator_ = std::make_shared<SimulationTlbAllocator>(bar0_base, architecture_impl_.get());
-
-    // Allocate the cached default TLB window. Quasar has no real TLBs; the communicator handles
-    // all I/O underneath. The 4GB size for Quasar is a dummy value -- it just needs to be large
-    // enough so that TlbWindow::validate doesn't reject any valid access (size 0 would cause
-    // division by zero in TLB handle configure).
-    static constexpr size_t SIZE_2MB = 2 * 1024 * 1024;
-    static constexpr size_t SIZE_16MB = 16 * 1024 * 1024;
-    static constexpr size_t SIZE_4GB = 4ULL * 1024 * 1024 * 1024;
-    switch (arch) {
-        case tt::ARCH::BLACKHOLE:
-            cached_tlb_window_ = TTSimTTDevice::get_io_window({}, TlbMapping::WC, SIZE_2MB);
-            break;
-        case tt::ARCH::WORMHOLE_B0:
-            cached_tlb_window_ = TTSimTTDevice::get_io_window({}, TlbMapping::WC, SIZE_16MB);
-            break;
-        case tt::ARCH::QUASAR:
-            cached_tlb_window_ = TTSimTTDevice::get_io_window({}, TlbMapping::WC, SIZE_4GB);
-            break;
-        default:
-            log_debug(
-                LogUMD,
-                "Architecture {} does not support TLB allocation, leaving cached_tlb_window_ null.",
-                tt::arch_to_str(arch));
-            break;
-    }
+    init_tlb_allocator(bar0_base);
+    setup_cached_tlb_window();
 }
 
 TTSimTTDevice::TTSimTTDevice(
@@ -201,20 +177,9 @@ TTSimTTDevice::TTSimTTDevice(
     setup_();
 }
 
-std::unique_ptr<TlbWindow> TTSimTTDevice::get_io_window(tlb_data config, TlbMapping mapping, size_t size) {
-    if (client_) {
-        // Client mode runs no backend, so tlb_allocator_/communicator_ are never constructed. Fail
-        // loudly instead of dereferencing them; client-mode device I/O is not available yet.
-        UMD_THROW(error::RuntimeError, "Client-mode TTSimTTDevice does not support TLB windows yet.");
-    }
-    int tlb_index = tlb_allocator_->allocate_tlb_index(size);
-    if (tlb_index == -1) {
-        UMD_THROW(error::RuntimeError, "No available TLB of requested size.");
-    }
-    // QUASAR bypasses the bitmap allocator (pools are empty by design); pass the requested
-    // size through, since get_tlb_size_from_index has no pool to look up for the bypass index.
-    size_t actual_size = (get_arch() == tt::ARCH::QUASAR) ? size : tlb_allocator_->get_tlb_size_from_index(tlb_index);
-    auto handle = TTSimTlbHandle::create(tlb_allocator_, communicator_.get(), tlb_index, actual_size, mapping);
+std::unique_ptr<TlbWindow> TTSimTTDevice::create_tlb_window(
+    int tlb_index, size_t size, TlbMapping mapping, tlb_data config) {
+    auto handle = TTSimTlbHandle::create(tlb_allocator_, communicator_.get(), tlb_index, size, mapping);
     return std::make_unique<TTSimTlbWindow>(std::move(handle), communicator_.get(), config);
 }
 


### PR DESCRIPTION
### Issue
Part of #2865

### Description
Third step toward a common implementation for the RTL and TTSim simulation `TTDevice` backends, stacked on #2914. This PR unifies the TLB window setup. The `get_io_window` logic (TLB index allocation, size resolution, QUASAR bypass) and the constructor TLB helpers move into `SimulationTTDevice`; the only backend-specific part — building the concrete `TlbHandle`/`TlbWindow` — is delegated to a new `create_tlb_window` hook.

### List of the changes
- Move `get_io_window` into `SimulationTTDevice`, delegating handle/window construction to a new pure-virtual `create_tlb_window` hook.
- Add `init_tlb_allocator(bar0_base)` and `setup_cached_tlb_window()` helpers to the base; derived constructors call these instead of duplicating the allocator setup and the per-arch cached-window switch.
- Implement `create_tlb_window` in `TTSimTTDevice` (passes the communicator to the handle) and `RtlSimulationTTDevice`.

### Testing
CI

### API Changes
None.