### PR TITLE
Unify simulation read/write_from_device behind I/O hooks

### DIFF
--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -49,9 +49,6 @@ public:
     static std::unique_ptr<RtlSimulationTTDevice> create_client(
         const std::filesystem::path& simulator_directory, ChipId chip_id, std::unique_ptr<SimulationClient> client);
 
-    void read_from_device(void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) override;
-    void write_to_device(const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) override;
-
     void wait_arc_core_start(const std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT) override;
     std::chrono::milliseconds wait_eth_core_training(
         const tt_xy_pair eth_core, const std::chrono::milliseconds timeout_ms = timeout::ETH_TRAINING_TIMEOUT) override;
@@ -65,8 +62,18 @@ public:
 protected:
     std::unique_ptr<TlbWindow> create_tlb_window(
         int tlb_index, size_t size, TlbMapping mapping, tlb_data config) override;
+    void tile_read_bytes(tt_xy_pair core, uint64_t addr, void* mem_ptr, size_t size) override;
+    void tile_write_bytes(tt_xy_pair core, uint64_t addr, const void* mem_ptr, size_t size) override;
+    bool handle_special_read(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
+    bool handle_special_write(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
 
 private:
+    // System NOC (SMN) fast path (Quasar only). `core` is a TRANSLATED coordinate; returns true when
+    // the access was routed over the system NOC. These back handle_special_read/write and can grow to
+    // dispatch additional special cases later.
+    bool smn_read(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size);
+    bool smn_write(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size);
+
     // Client-mode constructor: this device does not own a simulator; it forwards device operations
     // to a remote host through client. Reached only via create_client(), which validates the
     // arguments before construction.

--- a/device/api/umd/device/tt_device/simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/simulation_tt_device.hpp
@@ -14,6 +14,7 @@
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/tlb.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
@@ -37,6 +38,9 @@ public:
     void adopt_socket(std::unique_ptr<SimulationServerSocket> socket);
 
     // --- TTDevice overrides whose behavior is identical across both simulation backends ---
+    void read_from_device(void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) override;
+    void write_to_device(const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) override;
+
     void dma_d2h(void* dst, uint32_t src, size_t size) override;
     void dma_d2h_zero_copy(void* dst, uint32_t src, size_t size) override;
     void dma_h2d(uint32_t dst, const void* src, size_t size) override;
@@ -82,6 +86,32 @@ protected:
     // Construct the backend-specific TlbHandle + TlbWindow for an already-allocated TLB index.
     virtual std::unique_ptr<TlbWindow> create_tlb_window(
         int tlb_index, size_t size, TlbMapping mapping, tlb_data config) = 0;
+
+    // --- read/write_from_device hooks ---
+    //
+    // read_from_device/write_to_device translate the CoreCoord once (via
+    // translate_chip_coord_to_translated) before dispatching, so the `core` handed to every hook
+    // below is already a TRANSLATED coordinate -- do not translate it again.
+
+    // Direct tile (NOC unicast) access through the backend communicator.
+    virtual void tile_read_bytes(tt_xy_pair core, uint64_t addr, void* mem_ptr, size_t size) = 0;
+    virtual void tile_write_bytes(tt_xy_pair core, uint64_t addr, const void* mem_ptr, size_t size) = 0;
+
+    virtual bool is_device_closed() { return false; }
+
+    // Backend-specific fast paths handled entirely outside the cached-TLB / tile path. Return true if
+    // the access was fully handled (and nothing further should run).
+    virtual bool handle_special_read(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) { return false; }
+
+    virtual bool handle_special_write(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
+        return false;
+    }
+
+    // Whether read/write should route through cached_tlb_window_.
+    virtual bool should_use_cached_tlb_window() { return cached_tlb_window_ != nullptr; }
+
+    // Post-read clocking hook.
+    virtual void after_read() {}
 
     std::recursive_mutex device_lock;
     std::filesystem::path simulator_directory_;

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -62,9 +62,6 @@ public:
     static std::unique_ptr<TTSimTTDevice> create_client(
         const std::filesystem::path &simulator_directory, ChipId chip_id, std::unique_ptr<SimulationClient> client);
 
-    void read_from_device(void *mem_ptr, CoreCoord core, uint64_t addr, size_t size) override;
-    void write_to_device(const void *mem_ptr, CoreCoord core, uint64_t addr, size_t size) override;
-
     void wait_arc_core_start(const std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT) override;
     std::chrono::milliseconds wait_eth_core_training(
         const tt_xy_pair eth_core, const std::chrono::milliseconds timeout_ms = timeout::ETH_TRAINING_TIMEOUT) override;
@@ -91,8 +88,21 @@ public:
 protected:
     std::unique_ptr<TlbWindow> create_tlb_window(
         int tlb_index, size_t size, TlbMapping mapping, tlb_data config) override;
+    void tile_read_bytes(tt_xy_pair core, uint64_t addr, void *mem_ptr, size_t size) override;
+    void tile_write_bytes(tt_xy_pair core, uint64_t addr, const void *mem_ptr, size_t size) override;
+    bool is_device_closed() override;
+    bool handle_special_read(void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
+    bool handle_special_write(const void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) override;
+    bool should_use_cached_tlb_window() override;
+    void after_read() override;
 
 private:
+    // DRAM teleport fast path, gated on TT_SIMULATOR_DRAM_TELEPORT. `core` is a TRANSLATED
+    // coordinate; returns true when the access was serviced against the backend DRAM model. These
+    // back handle_special_read/write and can grow to dispatch additional special cases later.
+    bool special_dram_read(void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size);
+    bool special_dram_write(const void *mem_ptr, tt_xy_pair core, uint64_t addr, size_t size);
+
     // Client-mode constructor: this device does not own a simulator (.so); it forwards device
     // operations to a remote host through client. Reached only via create_client(), which
     // validates the arguments before construction.

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -168,56 +168,41 @@ RtlSimulationTTDevice::~RtlSimulationTTDevice() {
     }
 }
 
-void RtlSimulationTTDevice::write_to_device(const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) {
-    if (client_) {
-        UMD_THROW(
-            error::RuntimeError,
-            "Client-mode RtlSimulationTTDevice device I/O is not available yet (SimulationClient has no "
-            "read/write).");
-    }
-    std::lock_guard<std::recursive_mutex> lock(device_lock);
-    xy_pair translated_core = get_soc_descriptor().translate_chip_coord_to_translated(core);
-    log_debug(
-        tt::LogEmulationDriver, "Device writing {} bytes to l1_dest {} in core {}", size, addr, translated_core.str());
-
-    NocId noc_id = get_selected_noc_id();
-    validate_noc_for_arch(noc_id, get_soc_descriptor().arch);
-
-    if (noc_id == NocId::SYSTEM_NOC) {
-        communicator_->smn_tile_write_bytes(translated_core.x, translated_core.y, addr, mem_ptr, size);
-        return;
-    }
-
-    if (cached_tlb_window_) {
-        cached_tlb_window_->write_block_reconfigure(mem_ptr, translated_core, addr, size, get_selected_noc_id());
-    } else {
-        communicator_->tile_write_bytes(translated_core.x, translated_core.y, addr, mem_ptr, size);
-    }
+void RtlSimulationTTDevice::tile_read_bytes(tt_xy_pair core, uint64_t addr, void* mem_ptr, size_t size) {
+    communicator_->tile_read_bytes(core.x, core.y, addr, mem_ptr, size);
 }
 
-void RtlSimulationTTDevice::read_from_device(void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) {
-    if (client_) {
-        UMD_THROW(
-            error::RuntimeError,
-            "Client-mode RtlSimulationTTDevice device I/O is not available yet (SimulationClient has no "
-            "read/write).");
-    }
-    std::lock_guard<std::recursive_mutex> lock(device_lock);
-    xy_pair translated_core = get_soc_descriptor().translate_chip_coord_to_translated(core);
+void RtlSimulationTTDevice::tile_write_bytes(tt_xy_pair core, uint64_t addr, const void* mem_ptr, size_t size) {
+    communicator_->tile_write_bytes(core.x, core.y, addr, mem_ptr, size);
+}
 
+bool RtlSimulationTTDevice::handle_special_read(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
+    return smn_read(mem_ptr, core, addr, size);
+}
+
+bool RtlSimulationTTDevice::handle_special_write(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
+    return smn_write(mem_ptr, core, addr, size);
+}
+
+bool RtlSimulationTTDevice::smn_read(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
     NocId noc_id = get_selected_noc_id();
     validate_noc_for_arch(noc_id, get_soc_descriptor().arch);
-
     if (noc_id == NocId::SYSTEM_NOC) {
-        communicator_->smn_tile_read_bytes(translated_core.x, translated_core.y, addr, mem_ptr, size);
-        return;
+        communicator_->smn_tile_read_bytes(core.x, core.y, addr, mem_ptr, size);
+        return true;
     }
+    return false;
+}
 
-    if (cached_tlb_window_) {
-        cached_tlb_window_->read_block_reconfigure(mem_ptr, translated_core, addr, size, get_selected_noc_id());
-    } else {
-        communicator_->tile_read_bytes(translated_core.x, translated_core.y, addr, mem_ptr, size);
+bool RtlSimulationTTDevice::smn_write(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
+    log_debug(tt::LogEmulationDriver, "Device writing {} bytes to l1_dest {} in core {}", size, addr, core.str());
+    NocId noc_id = get_selected_noc_id();
+    validate_noc_for_arch(noc_id, get_soc_descriptor().arch);
+    if (noc_id == NocId::SYSTEM_NOC) {
+        communicator_->smn_tile_write_bytes(core.x, core.y, addr, mem_ptr, size);
+        return true;
     }
+    return false;
 }
 
 void RtlSimulationTTDevice::assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs) {

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -6,11 +6,14 @@
 
 #include <tt-logger/tt-logger.hpp>
 
+#include "noc_access.hpp"
 #include "simulation/simulation_server_socket.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
+#include "umd/device/soc_descriptor.hpp"
 #include "umd/device/types/arch.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/tlb.hpp"
 #include "umd/device/utils/error.hpp"
 
@@ -26,6 +29,47 @@ SimulationTTDevice::SimulationTTDevice(
 SimulationTTDevice::~SimulationTTDevice() = default;
 
 void SimulationTTDevice::adopt_socket(std::unique_ptr<SimulationServerSocket> socket) { socket_ = std::move(socket); }
+
+void SimulationTTDevice::write_to_device(const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) {
+    // Client-mode devices run no local backend (tlb_allocator_/communicator_ are never built), so
+    // device I/O is unavailable. Fail loudly instead of dereferencing a null communicator_.
+    UMD_ASSERT(
+        tlb_allocator_ != nullptr, error::RuntimeError, "Client-mode simulation device I/O is not available yet.");
+    if (is_device_closed()) {
+        return;
+    }
+    std::lock_guard<std::recursive_mutex> lock(device_lock);
+    xy_pair translated_core = get_soc_descriptor().translate_chip_coord_to_translated(core);
+    if (handle_special_write(mem_ptr, translated_core, addr, size)) {
+        return;
+    }
+    if (should_use_cached_tlb_window()) {
+        cached_tlb_window_->write_block_reconfigure(mem_ptr, translated_core, addr, size, get_selected_noc_id());
+    } else {
+        tile_write_bytes(translated_core, addr, mem_ptr, size);
+    }
+}
+
+void SimulationTTDevice::read_from_device(void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) {
+    // Client-mode devices run no local backend (tlb_allocator_/communicator_ are never built), so
+    // device I/O is unavailable. Fail loudly instead of dereferencing a null communicator_.
+    UMD_ASSERT(
+        tlb_allocator_ != nullptr, error::RuntimeError, "Client-mode simulation device I/O is not available yet.");
+    if (is_device_closed()) {
+        return;
+    }
+    std::lock_guard<std::recursive_mutex> lock(device_lock);
+    xy_pair translated_core = get_soc_descriptor().translate_chip_coord_to_translated(core);
+    if (handle_special_read(mem_ptr, translated_core, addr, size)) {
+        return;
+    }
+    if (should_use_cached_tlb_window()) {
+        cached_tlb_window_->read_block_reconfigure(mem_ptr, translated_core, addr, size, get_selected_noc_id());
+    } else {
+        tile_read_bytes(translated_core, addr, mem_ptr, size);
+    }
+    after_read();
+}
 
 void SimulationTTDevice::init_tlb_allocator(uint64_t bar0_base) {
     tlb_allocator_ = std::make_shared<SimulationTlbAllocator>(bar0_base, architecture_impl_.get());

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -211,61 +211,62 @@ void TTSimTTDevice::close_device() {
     communicator_->shutdown();
 }
 
-void TTSimTTDevice::write_to_device(const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) {
-    if (client_) {
-        UMD_THROW(
-            error::RuntimeError,
-            "Client-mode TTSimTTDevice device I/O is not available yet (SimulationClient has no read/write).");
-    }
-    if (communicator_->is_closed()) {
-        return;
-    }
-    std::lock_guard<std::recursive_mutex> lock(device_lock);
-    xy_pair translated_core = get_soc_descriptor().translate_chip_coord_to_translated(core);
-    if (sim_dram_teleport_enabled()) {
-        if (get_soc_descriptor().is_core_of_type(translated_core, CoreType::DRAM, CoordSystem::TRANSLATED)) {
-            if (communicator_->dram_write_bytes(translated_core.x, translated_core.y, addr, mem_ptr, size)) {
-                return;
-            }
-            communicator_->tile_write_bytes(translated_core.x, translated_core.y, addr, mem_ptr, size);
-            return;
-        }
-    }
-    if (get_arch() != tt::ARCH::QUASAR && cached_tlb_window_) {
-        cached_tlb_window_->write_block_reconfigure(mem_ptr, translated_core, addr, size, get_selected_noc_id());
-    } else {
-        communicator_->tile_write_bytes(translated_core.x, translated_core.y, addr, mem_ptr, size);
-    }
+void TTSimTTDevice::tile_read_bytes(tt_xy_pair core, uint64_t addr, void* mem_ptr, size_t size) {
+    communicator_->tile_read_bytes(core.x, core.y, addr, mem_ptr, size);
 }
 
-void TTSimTTDevice::read_from_device(void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) {
-    if (client_) {
-        UMD_THROW(
-            error::RuntimeError,
-            "Client-mode TTSimTTDevice device I/O is not available yet (SimulationClient has no read/write).");
-    }
-    if (communicator_->is_closed()) {
-        return;
-    }
-    std::lock_guard<std::recursive_mutex> lock(device_lock);
-    xy_pair translated_core = get_soc_descriptor().translate_chip_coord_to_translated(core);
-    if (sim_dram_teleport_enabled()) {
-        if (get_soc_descriptor().is_core_of_type(translated_core, CoreType::DRAM, CoordSystem::TRANSLATED)) {
-            if (!communicator_->dram_read_bytes(translated_core.x, translated_core.y, addr, mem_ptr, size)) {
-                communicator_->tile_read_bytes(translated_core.x, translated_core.y, addr, mem_ptr, size);
-            }
-            communicator_->advance_clock(10);
-            return;
-        }
-    }
-    if (get_arch() != tt::ARCH::QUASAR && cached_tlb_window_) {
-        cached_tlb_window_->read_block_reconfigure(mem_ptr, translated_core, addr, size, get_selected_noc_id());
-    } else {
-        communicator_->tile_read_bytes(translated_core.x, translated_core.y, addr, mem_ptr, size);
-    }
+void TTSimTTDevice::tile_write_bytes(tt_xy_pair core, uint64_t addr, const void* mem_ptr, size_t size) {
+    communicator_->tile_write_bytes(core.x, core.y, addr, mem_ptr, size);
+}
+
+bool TTSimTTDevice::is_device_closed() { return communicator_->is_closed(); }
+
+bool TTSimTTDevice::should_use_cached_tlb_window() {
+    return get_arch() != tt::ARCH::QUASAR && cached_tlb_window_ != nullptr;
+}
+
+void TTSimTTDevice::after_read() {
     // Ideally we would not auto-clock on reads at all, but some clocking is required to avoid hangs
-    // in the absence of an API reliably called from all spin loops polling the device
+    // in the absence of an API reliably called from all spin loops polling the device.
     communicator_->advance_clock(1);
+}
+
+bool TTSimTTDevice::handle_special_write(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
+    return special_dram_write(mem_ptr, core, addr, size);
+}
+
+bool TTSimTTDevice::handle_special_read(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
+    return special_dram_read(mem_ptr, core, addr, size);
+}
+
+bool TTSimTTDevice::special_dram_write(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
+    if (!sim_dram_teleport_enabled()) {
+        return false;
+    }
+    if (!get_soc_descriptor().is_core_of_type(core, CoreType::DRAM, CoordSystem::TRANSLATED)) {
+        return false;
+    }
+    if (communicator_->dram_write_bytes(core.x, core.y, addr, mem_ptr, size)) {
+        return true;
+    }
+    communicator_->tile_write_bytes(core.x, core.y, addr, mem_ptr, size);
+    return true;
+}
+
+bool TTSimTTDevice::special_dram_read(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size) {
+    if (!sim_dram_teleport_enabled()) {
+        return false;
+    }
+    if (!get_soc_descriptor().is_core_of_type(core, CoreType::DRAM, CoordSystem::TRANSLATED)) {
+        return false;
+    }
+    if (!communicator_->dram_read_bytes(core.x, core.y, addr, mem_ptr, size)) {
+        communicator_->tile_read_bytes(core.x, core.y, addr, mem_ptr, size);
+    }
+    // Side effect: this path advances the simulation clock by 10 cycles (rather than the single
+    // cycle after_read() applies), and it returns before after_read() would otherwise run.
+    communicator_->advance_clock(10);
+    return true;
 }
 
 void TTSimTTDevice::assert_risc_reset(tt_xy_pair core, const RiscType selected_riscs) {


### PR DESCRIPTION
### Issue
Part of #2865

### Description
Final step toward a common implementation for the RTL and TTSim simulation `TTDevice` backends, stacked on #2916. Unifies `read_from_device` / `write_to_device`: the shared skeleton moves into `SimulationTTDevice`, with backend specifics expressed through a small set of virtual hooks.

### List of the changes
- Move the `read_from_device` / `write_to_device` skeleton into `SimulationTTDevice`: closed-check, lock, coordinate translation, special-case fast path, cached-window-or-tile dispatch, and post-read clock. The `CoreCoord` is translated once via `translate_chip_coord_to_translated` and the translated coordinate is handed to the hooks.
- Add hooks: pure-virtual `tile_read_bytes` / `tile_write_bytes`, plus defaulted `is_device_closed`, `handle_special_read` / `handle_special_write`, `should_use_cached_tlb_window`, and `after_read`.
- `RtlSimulationTTDevice` overrides the special-case hooks for `SYSTEM_NOC`; `TTSimTTDevice` overrides them for DRAM teleport and also overrides the closed-check, the QUASAR cached-window exclusion, and the post-read auto-clock.

### Testing
CI

### API Changes
None.