### PR TITLE
Migrate register accesses to the aligned UC register API

### DIFF
--- a/device/topology/topology_discovery_wormhole.cpp
+++ b/device/topology/topology_discovery_wormhole.cpp
@@ -244,7 +244,7 @@ void TopologyDiscoveryWormhole::retrain_eth_cores() {
                 log_debug(
                     LogUMD, "Retraining ETH core {} on device {}, attempt {}.", eth_core.str(), asic_id, attempt + 1);
                 uint32_t trigger_val = wormhole::ETH_TRIGGER_RETRAIN_VAL;
-                tt_device->write_to_device(
+                tt_device->write_to_device_reg(
                     &trigger_val, translated_eth_core, wormhole::ETH_RETRAIN_ADDR, sizeof(uint32_t));
                 all_eth_cores_trained = false;
             }

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -267,7 +267,7 @@ void BlackholeTTDevice::read_from_arc_apb(void *mem_ptr, uint64_t arc_addr_offse
         return;
     }
     if (!is_arc_available_over_axi()) {
-        read_from_device(
+        read_from_device_reg(
             mem_ptr, get_arc_core(), architecture_impl_->get_arc_apb_noc_base_address() + arc_addr_offset, size);
         return;
     }
@@ -290,7 +290,7 @@ void BlackholeTTDevice::write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_
         return;
     }
     if (!is_arc_available_over_axi()) {
-        write_to_device(
+        write_to_device_reg(
             mem_ptr, get_arc_core(), architecture_impl_->get_arc_apb_noc_base_address() + arc_addr_offset, size);
         return;
     }

--- a/device/tt_device/hang_detection/hang_detector_implementation.cpp
+++ b/device/tt_device/hang_detection/hang_detector_implementation.cpp
@@ -18,10 +18,10 @@ HangDetectorImplementation::HangDetectorImplementation(
     pcie_interface_(dynamic_cast<PcieInterface*>(protocol)),
     is_mmio_protocol_(!dynamic_cast<RemoteInterface*>(protocol)),
     arch_impl_(arch_impl),
-    // Default reader: plain protocol read. A higher layer may override it via set_noc_reg_reader().
+    // Default reader: plain protocol register read. A higher layer may override it via set_noc_reg_reader().
     noc_reg_reader_([this](tt_xy_pair core, uint64_t addr, NocId noc) -> uint32_t {
         uint32_t value = 0;
-        protocol_->read_data(&value, core, addr, sizeof(value), noc);
+        protocol_->read_ctrl(&value, core, addr, sizeof(value), noc);
         return value;
     }) {}
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -649,7 +649,7 @@ void TTDevice::advance_device_execution() {}
 
 uint32_t TTDevice::get_risc_reset_state(tt_xy_pair core) {
     uint32_t tensix_risc_state;
-    read_from_device(&tensix_risc_state, core, architecture_impl_->get_tensix_soft_reset_addr(), sizeof(uint32_t));
+    read_from_device_reg(&tensix_risc_state, core, architecture_impl_->get_tensix_soft_reset_addr(), sizeof(uint32_t));
 
     return tensix_risc_state;
 }
@@ -657,7 +657,7 @@ uint32_t TTDevice::get_risc_reset_state(tt_xy_pair core) {
 uint32_t TTDevice::get_risc_reset_state(CoreCoord core) { return get_risc_reset_state(resolve_coordinate(core)); }
 
 void TTDevice::set_risc_reset_state(tt_xy_pair core, const uint32_t risc_flags) {
-    write_to_device(&risc_flags, core, architecture_impl_->get_tensix_soft_reset_addr(), sizeof(uint32_t));
+    write_to_device_reg(&risc_flags, core, architecture_impl_->get_tensix_soft_reset_addr(), sizeof(uint32_t));
     tt_driver_atomics::sfence();
 }
 

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -182,7 +182,7 @@ void WormholeTTDevice::read_from_arc_apb(void *mem_ptr, uint64_t arc_addr_offset
         UMD_THROW(error::RuntimeError, "Address is out of ARC APB address range.");
     }
     if (is_remote_tt_device) {
-        read_from_device(
+        read_from_device_reg(
             mem_ptr, get_arc_core(), architecture_impl_->get_arc_apb_noc_base_address() + arc_addr_offset, size);
         return;
     }
@@ -205,7 +205,7 @@ void WormholeTTDevice::write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_o
         UMD_THROW(error::RuntimeError, "Address is out of ARC APB address range.");
     }
     if (is_remote_tt_device) {
-        write_to_device(
+        write_to_device_reg(
             mem_ptr, get_arc_core(), architecture_impl_->get_arc_apb_noc_base_address() + arc_addr_offset, size);
         return;
     }
@@ -304,7 +304,7 @@ std::chrono::milliseconds WormholeTTDevice::wait_eth_core_training(
 
 EthTrainingStatus WormholeTTDevice::read_eth_core_training_status(tt_xy_pair eth_core) {
     uint32_t retrain_status;
-    read_from_device(&retrain_status, eth_core, wormhole::ETH_RETRAIN_ADDR, sizeof(uint32_t));
+    read_from_device_reg(&retrain_status, eth_core, wormhole::ETH_RETRAIN_ADDR, sizeof(uint32_t));
     // If core is in retrain state, then training status is not valid as the training is ongoing.
     // If the core is put in retrain state, we have to wait for the retrain state to clear before making sense out of
     // the training status.
@@ -313,14 +313,14 @@ EthTrainingStatus WormholeTTDevice::read_eth_core_training_status(tt_xy_pair eth
         return EthTrainingStatus::IN_PROGRESS;
     }
     uint32_t training_status;
-    read_from_device(&training_status, eth_core, wormhole::ETH_TRAIN_STATUS_ADDR, sizeof(uint32_t));
+    read_from_device_reg(&training_status, eth_core, wormhole::ETH_TRAIN_STATUS_ADDR, sizeof(uint32_t));
     log_trace(LogUMD, "Training status for core {} is {}", eth_core.str(), training_status);
 
     if (training_status == static_cast<uint32_t>(EthTrainingStatus::FAIL)) {
         // Training can fail due to various reasons, but what we mostly care about is to detect whether this is
         // unconnected eth link or if the training truly failed on a connected eth link.
         uint32_t link_err_status;
-        read_from_device(&link_err_status, eth_core, wormhole::ETH_LINK_ERR_STATUS_ADDR, sizeof(uint32_t));
+        read_from_device_reg(&link_err_status, eth_core, wormhole::ETH_LINK_ERR_STATUS_ADDR, sizeof(uint32_t));
         log_trace(LogUMD, "Link error status for core {} is {}", eth_core.str(), link_err_status);
         if (link_err_status >= wormhole::ETH_LINK_UNUSED_ERROR_CODE_RANGE_START) {
             return EthTrainingStatus::NOT_CONNECTED;

--- a/tests/api/test_noc.cpp
+++ b/tests/api/test_noc.cpp
@@ -698,11 +698,11 @@ TEST_F(TestNoc, BlackholeRouterOnlyNoc1TranslatedCoords) {
         const tt_xy_pair& translated = it->second;
 
         uint32_t noc_node_id_val;
-        device->read_from_device(&noc_node_id_val, translated, noc_node_id_reg_addr, sizeof(noc_node_id_val));
+        device->read_from_device_reg(&noc_node_id_val, translated, noc_node_id_reg_addr, sizeof(noc_node_id_val));
         const auto [x, y] = extract_coords_from_reg(noc_node_id_val);
 
         uint32_t noc_translated_id_val;
-        device->read_from_device(
+        device->read_from_device_reg(
             &noc_translated_id_val, translated, noc_translated_id_reg_addr, sizeof(noc_translated_id_val));
         const auto [translated_x, translated_y] = extract_coords_from_reg(noc_translated_id_val);
 

--- a/tests/api/test_noc.cpp
+++ b/tests/api/test_noc.cpp
@@ -181,7 +181,7 @@ public:
             cluster_->get_tt_device(chip)->get_architecture_implementation()->get_noc_node_translated_id_offset();
 
         uint32_t noc_translated_id_val;
-        cluster_->get_tt_device(chip)->read_from_device(
+        cluster_->get_tt_device(chip)->read_from_device_reg(
             &noc_translated_id_val, core, noc_translated_id_reg_addr, sizeof(noc_translated_id_val));
 
         return extract_coords_from_reg(noc_translated_id_val);

--- a/tools/system_health.cpp
+++ b/tools/system_health.cpp
@@ -199,7 +199,8 @@ int main(int argc, char* argv[]) {
 
             read_vec.resize(1);
             static constexpr std::uint32_t RETRAIN_COUNT_ADDR = 0x1EDC;  // wormhole
-            cluster->read_from_device(read_vec.data(), chip_id, translated_coord, RETRAIN_COUNT_ADDR, sizeof(uint32_t));
+            cluster->read_from_device_reg(
+                read_vec.data(), chip_id, translated_coord, RETRAIN_COUNT_ADDR, sizeof(uint32_t));
             eth_ss << " eth channel " << std::dec << (uint32_t)chan << " " << logical_coord.at(chan).str();
 
             std::string connection_type = get_connector_str(cluster.get(), chip_id, unique_chip_id, chan, board_type);


### PR DESCRIPTION
### Issue
#2860

### Description
Register accesses were going through the device memory API (`read_from_device`/`write_to_device`), which becomes incorrect once those windows switch to write-combine in #2859. This migrates the register call sites (reset/status CSRs and the ARC APB register bus) to `read_from_device_reg`/`write_to_device_reg` (UC, Strict, 4-byte aligned). Bulk memory and firmware-published values stay on the memory API. Unblocks #2859.

### List of the changes
- Migrated register accesses to the `*_reg` API: tensix soft-reset, hang-detector NOC reads, ARC APB paths, ETH retrain/training/link-error regs, retrain-count in `system_health`, and the NOC reg reads in `test_noc`.
- Left on the memory API: ARC CSM, message queue, telemetry, SPI, bulk transfers, firmware-published values, and the simulator reset paths.

### Testing
CI

### API Changes
None.