### PR TITLE
Update ClusterOptions in MicrobenchmarkOpenCluster test

### DIFF
--- a/tests/microbenchmark/benchmarks/open_cluster/test_open_cluster.cpp
+++ b/tests/microbenchmark/benchmarks/open_cluster/test_open_cluster.cpp
@@ -30,15 +30,18 @@ TEST(MicrobenchmarkOpenCluster, ClusterConstructor) {
     auto devices_info = PCIDevice::enumerate_devices_info();
     ASSERT_FALSE(devices_info.empty());
     tt::ARCH arch = devices_info.begin()->second.get_arch();
+
     ClusterOptions options;
-    options.sdesc_path = test_utils::get_soc_descriptor_path(arch);
+    options.num_host_mem_ch_per_mmio_device = 0;
 
     auto bench =
         ankerl::nanobench::Bench().maxEpochTime(std::chrono::seconds(30)).title("ClusterConstructor").unit("cluster");
     bench.name("default").run([&] {
-        std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>();
+        std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(options);
         ankerl::nanobench::doNotOptimizeAway(cluster);
     });
+
+    options.sdesc_path = test_utils::get_soc_descriptor_path(arch);
     bench.name("from sdesc").run([&] {
         std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(options);
         ankerl::nanobench::doNotOptimizeAway(cluster);


### PR DESCRIPTION
### Issue
N/A

### Description
Since #2731 changed the `ClusterOptions` default for `num_host_mem_ch_per_mmio_device`
from `0` to `std::nullopt`, the `MicrobenchmarkOpenCluster.ClusterConstructor` benchmark
started auto-allocating host memory channels (hugepage mapping) in the constructor. This
dominated the measured time and regressed the benchmark.
This restores the benchmark to measuring pure Cluster construction cost by setting the
field explicitly to `0`.

### List of the changes
- Set `options.num_host_mem_ch_per_mmio_device = 0` and construct both the `default` and
  `from sdesc` bench cases from this single `ClusterOptions`.

### Testing
 - Manually on bgd-lab-06

### API Changes
This PR has no API changes.