### PR TITLE
Fix BH NOC1 ETH harvested mapping for translated space

### DIFF
--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -225,17 +225,31 @@ CoreCoord SocDescriptor::translate_chip_coord_to_translated_coord(const CoreCoor
         return translate_coord_to(core, is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0);
     }
 
-    // For ROUTER_ONLY cores, the translated coordinate space differs depending on
-    // whether the NOC0 or NOC1 network is used. Use the NOC1 -> TRANSLATED mapping
-    // from ROUTER_NOC1_TO_TRANSLATED_BLACKHOLE so that accesses over the NOC1
-    // network resolve to the correct tile.
-    if ((arch == tt::ARCH::BLACKHOLE) && (core.core_type == CoreType::ROUTER_ONLY) && is_selected_noc1()) {
-        CoreCoord noc1_core = translate_coord_to(core, CoordSystem::NOC1);
-        CoreCoord translated_noc1_core = CoreCoord(
-            ROUTER_NOC1_TO_TRANSLATED_BLACKHOLE.at(static_cast<tt_xy_pair>(noc1_core)),
-            CoreType::ROUTER_ONLY,
-            CoordSystem::TRANSLATED);
-        return translated_noc1_core;
+    // Blackhole-specific workaround: ROUTER_ONLY and harvested ETH cores need
+    // special translation when using NOC1.
+    if ((arch == tt::ARCH::BLACKHOLE) && is_selected_noc1()) {
+        // For ROUTER_ONLY cores, the translated coordinate space differs depending on
+        // whether the NOC0 or NOC1 network is used. Use the NOC1 -> TRANSLATED mapping
+        // from ROUTER_NOC1_TO_TRANSLATED_BLACKHOLE so that accesses over the NOC1
+        // network resolve to the correct tile.
+        if (core.core_type == CoreType::ROUTER_ONLY) {
+            CoreCoord noc1_core = translate_coord_to(core, CoordSystem::NOC1);
+            return CoreCoord(
+                ROUTER_NOC1_TO_TRANSLATED_BLACKHOLE.at(static_cast<tt_xy_pair>(noc1_core)),
+                CoreType::ROUTER_ONLY,
+                CoordSystem::TRANSLATED);
+        }
+
+        // Harvested ETH cores on Blackhole use identity mapping (TRANSLATED = NOC0), which is wrong
+        // on NOC1 because the translation table routes identity coordinates to the wrong tile.
+        // Fix: flip x only, keep y as-is, so the NOC1 translation resolves to the correct ETH core.
+        if (core.core_type == CoreType::ETH) {
+            CoreCoord noc0_core = translate_coord_to(core, CoordSystem::NOC0);
+            const auto harvested_eth = get_harvested_cores(CoreType::ETH, CoordSystem::NOC0);
+            if (std::find(harvested_eth.begin(), harvested_eth.end(), noc0_core) != harvested_eth.end()) {
+                return CoreCoord(grid_size.x - 1 - noc0_core.x, noc0_core.y, CoreType::ETH, CoordSystem::TRANSLATED);
+            }
+        }
     }
 
     // Wormhole-specific workaround: For DRAM, ARC, and PCIe cores, the translated coordinate system

--- a/tests/api/test_noc.cpp
+++ b/tests/api/test_noc.cpp
@@ -417,11 +417,9 @@ TEST_P(TestNocValidity, VerifyNocTranslationHostSide) {
         GTEST_SKIP() << "NOC_ID_LOGICAL register reports incorrect translated coordinates for ROUTER_ONLY";
     }
 
-    // Skip ETH (NOC1) and PCIe (both NOCs) on Blackhole for harvested cores - well known problem:
+    // Skip PCIe (both NOCs) on Blackhole for harvested cores - well known problem:
     // - PCIe: https://github.com/tenstorrent/tt-umd/issues/826
-    // - ETH: https://github.com/tenstorrent/tt-umd/issues/825
-    if (arch == ARCH::BLACKHOLE && use_harvested_cores &&
-        ((core_type == CoreType::ETH && noc == CoordSystem::NOC1) || core_type == CoreType::PCIE)) {
+    if (arch == ARCH::BLACKHOLE && use_harvested_cores && core_type == CoreType::PCIE) {
         GTEST_SKIP() << "Mapping on device side does not correlate correctly to the mapping on host side";
     }
 


### PR DESCRIPTION
### Issue
#825 

### Description
This pull request introduces a Blackhole-architecture-specific workaround for coordinate translation of harvested `ETH` cores in the `SocDescriptor` logic. It ensures that harvested `ETH` cores are mapped correctly when using the NOC1 network, addressing previously known translation issues. Additionally, the test suite is updated to reflect these fixes by removing the ETH core skip condition for harvested cores on Blackhole.

### List of the changes
* Added a workaround for harvested `ETH` cores on Blackhole when using NOC1: now flips the x-coordinate to ensure correct mapping, fixing the previously incorrect identity mapping.
* Modified `tests/api/test_noc.cpp` to no longer skip harvested `ETH` cores on Blackhole for NOC1 in the translation verification test, since the device-side mapping is now correct.

### Testing
Manual via tt-exalens

### API Changes
/
