### PR TITLE
AICLK target tolerance

### DIFF
--- a/device/api/umd/device/utils/common.hpp
+++ b/device/api/umd/device/utils/common.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cmath>
 #include <memory>
 #include <string>
 #include <vector>
@@ -23,4 +24,9 @@ static inline std::string to_lower(const std::string& str) {
     std::string res = str;
     std::transform(res.begin(), res.end(), res.begin(), ::tolower);
     return res;
+}
+
+// Returns true if value is within the given percentage of reference.
+static inline bool is_within_percentage(double value, double reference, double percentage) {
+    return std::abs(value - reference) <= std::abs(reference) * (percentage / 100.0);
 }

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -25,10 +25,16 @@
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/telemetry.hpp"
 #include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/common.hpp"
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
+
+namespace {
+// AICLK rarely settles on the exact target; accept any value within this percentage of the target.
+constexpr double AICLK_TOLERANCE_PERCENT = 5.0;
+}  // namespace
 
 Chip::Chip(tt::ARCH arch) { set_default_params(arch); }
 
@@ -224,6 +230,15 @@ void Chip::wait_for_aiclk_value(
     }
     uint32_t aiclk = tt_device->get_clock();
     while (aiclk != target_aiclk) {
+        if (is_within_percentage(aiclk, target_aiclk, AICLK_TOLERANCE_PERCENT)) {
+            log_warning(
+                LogUMD,
+                "AICLK settled at {} MHz, within {}% of the requested {} MHz but not an exact match. Proceeding.",
+                aiclk,
+                AICLK_TOLERANCE_PERCENT,
+                target_aiclk);
+            return;
+        }
         auto end = std::chrono::steady_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
         if (duration.count() > timeout_ms.count()) {

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -31,10 +31,8 @@
 
 namespace tt::umd {
 
-namespace {
 // AICLK rarely settles on the exact target; accept any value within this percentage of the target.
 constexpr double AICLK_TOLERANCE_PERCENT = 5.0;
-}  // namespace
 
 Chip::Chip(tt::ARCH arch) { set_default_params(arch); }
 


### PR DESCRIPTION
### Issue
closes https://github.com/tenstorrent/tt-umd/issues/2663

### Description
Don't wait and send warnings if AICLK is close to the target.

### List of the changes
- Add a generic is_within_percentage
- Check if value is within AICLK_TOLERANCE_PERCENT, and don't wait any longer if it is.

### Testing
No testing

### API Changes
This PR has no API changes.
