### PR TITLE
Simulation: rename SimulationSocket to SimulationServerSocket

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -140,7 +140,7 @@ target_sources(
         # UNIX domain socket (asio, already a core dependency) + filesystem; no simulation deps,
         # so always built. This lets its unit tests run in the no-card baremetal CI lane
         # (TT_UMD_BUILD_SIMULATION=OFF).
-        simulation/simulation_socket.cpp
+        simulation/simulation_server_socket.cpp
 )
 
 if(TT_UMD_BUILD_SIMULATION)

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -25,7 +25,7 @@ namespace tt::umd {
 
 class RtlSimCommunicator;
 class SimulationSysmemManager;
-class SimulationSocket;
+class SimulationServerSocket;
 class SocDescriptor;
 class TlbWindow;
 
@@ -80,7 +80,7 @@ public:
     SimulationTlbAllocator* get_tlb_allocator() { return tlb_allocator_.get(); }
 
     // Takes ownership of the serving socket that exposes this device (created by discovery).
-    void adopt_socket(std::unique_ptr<SimulationSocket> socket);
+    void adopt_socket(std::unique_ptr<SimulationServerSocket> socket);
 
 protected:
     void retrain_dram_core(const uint32_t dram_channel) override;
@@ -96,6 +96,6 @@ private:
 
     // Exposes this device on disk as a UNIX socket ("the card"), so other UMD clients can find
     // it. The host keeps its own direct fast path; the socket is for remote clients.
-    std::unique_ptr<SimulationSocket> socket_;
+    std::unique_ptr<SimulationServerSocket> socket_;
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -27,7 +27,7 @@ namespace tt::umd {
 
 class TTSimCommunicator;
 class SimulationSysmemManager;
-class SimulationSocket;
+class SimulationServerSocket;
 class SocDescriptor;
 
 class TTSimTTDevice : public TTDevice {
@@ -102,7 +102,7 @@ public:
     SimulationTlbAllocator *get_tlb_allocator() { return tlb_allocator_.get(); }
 
     // Takes ownership of the serving socket that exposes this device (created by discovery).
-    void adopt_socket(std::unique_ptr<SimulationSocket> socket);
+    void adopt_socket(std::unique_ptr<SimulationServerSocket> socket);
 
     uint64_t bar0_base = 0;
     uint64_t bar4_base = 0;
@@ -125,7 +125,7 @@ private:
 
     // Exposes this device on disk as a UNIX socket ("the card"), so other UMD clients can find
     // it. The host keeps its own direct in-process fast path; the socket is for remote clients.
-    std::unique_ptr<SimulationSocket> socket_;
+    std::unique_ptr<SimulationServerSocket> socket_;
 
     uint32_t libttsim_pci_device_id;
 

--- a/device/simulation/simulation_connector.cpp
+++ b/device/simulation/simulation_connector.cpp
@@ -8,7 +8,7 @@
 
 #include <utility>
 
-#include "simulation/simulation_socket.hpp"
+#include "simulation/simulation_server_socket.hpp"
 #include "umd/device/tt_device/rtl_simulation_tt_device.hpp"
 #include "umd/device/tt_device/tt_sim_tt_device.hpp"
 #include "umd/device/utils/error.hpp"
@@ -20,13 +20,13 @@ std::map<ChipId, std::unique_ptr<TTDevice>> SimulationConnector::discover(const 
 
     // Single-chip for now. Socket-first: try to claim the path; success => we are the host.
     const ChipId chip_id = 0;
-    const std::filesystem::path socket_path = SimulationSocket::default_socket_path(chip_id);
+    const std::filesystem::path socket_path = SimulationServerSocket::default_socket_path(chip_id);
 
     // The backend (TTSim .so vs RTL directory) is chosen by the simulator path, mirroring the
     // simulation device factory; the host-vs-client role is chosen socket-first below.
     const bool is_ttsim = options.simulator_directory.extension() == ".so";
 
-    std::unique_ptr<SimulationSocket> socket = SimulationSocket::try_create(socket_path);
+    std::unique_ptr<SimulationServerSocket> socket = SimulationServerSocket::try_create(socket_path);
     if (socket == nullptr) {
         // A live host already serves this device. The client/attach path lands in a later PR.
         UMD_THROW(

--- a/device/simulation/simulation_server_socket.cpp
+++ b/device/simulation/simulation_server_socket.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "simulation/simulation_socket.hpp"
+#include "simulation/simulation_server_socket.hpp"
 
 #include <fmt/format.h>
 #include <sys/un.h>  // sockaddr_un::sun_path, for the path-length guard
@@ -37,25 +37,25 @@ stream_protocol::endpoint make_endpoint(const std::filesystem::path& path) {
 
 }  // namespace
 
-// The asio transport, kept out of the header (see SimulationSocket::Impl forward declaration).
-struct SimulationSocket::Impl {
+// The asio transport, kept out of the header (see SimulationServerSocket::Impl forward declaration).
+struct SimulationServerSocket::Impl {
     asio::io_context io;
     stream_protocol::acceptor acceptor{io};
     std::thread io_thread;
 };
 
-SimulationSocket::SimulationSocket(const std::filesystem::path& socket_path) :
+SimulationServerSocket::SimulationServerSocket(const std::filesystem::path& socket_path) :
     socket_path_(socket_path), impl_(std::make_unique<Impl>()) {}
 
-std::unique_ptr<SimulationSocket> SimulationSocket::try_create(const std::filesystem::path& socket_path) {
-    std::unique_ptr<SimulationSocket> socket(new SimulationSocket(socket_path));
+std::unique_ptr<SimulationServerSocket> SimulationServerSocket::try_create(const std::filesystem::path& socket_path) {
+    std::unique_ptr<SimulationServerSocket> socket(new SimulationServerSocket(socket_path));
     if (!socket->bind_and_listen()) {
         return nullptr;
     }
     return socket;
 }
 
-std::unique_ptr<SimulationSocket> SimulationSocket::create(const std::filesystem::path& socket_path) {
+std::unique_ptr<SimulationServerSocket> SimulationServerSocket::create(const std::filesystem::path& socket_path) {
     auto socket = try_create(socket_path);
     if (!socket) {
         UMD_THROW(
@@ -64,7 +64,7 @@ std::unique_ptr<SimulationSocket> SimulationSocket::create(const std::filesystem
     return socket;
 }
 
-void SimulationSocket::do_accept() {
+void SimulationServerSocket::do_accept() {
     auto sock = std::make_shared<stream_protocol::socket>(impl_->io);
     impl_->acceptor.async_accept(*sock, [this, sock](const std::error_code& ec) {
         // A non-aborted error or io_context::stop() (teardown) ends the loop; otherwise
@@ -76,7 +76,7 @@ void SimulationSocket::do_accept() {
     });
 }
 
-bool SimulationSocket::is_live() {
+bool SimulationServerSocket::is_live() {
     // is_live() is a predicate; a path too long to name a reachable listener can't have one,
     // so report not-live rather than letting make_endpoint() throw.
     if (socket_path_.string().size() >= sizeof(sockaddr_un::sun_path)) {
@@ -90,7 +90,7 @@ bool SimulationSocket::is_live() {
     return !ec;
 }
 
-bool SimulationSocket::bind_and_listen() {
+bool SimulationServerSocket::bind_and_listen() {
     if (socket_path_.has_parent_path()) {
         // A socket is only reachable cross-user if the directory holding it is too, so a
         // directory we create for it gets /tmp's semantics: 0777 + sticky bit. World rwx lets
@@ -205,7 +205,7 @@ bool SimulationSocket::bind_and_listen() {
     return true;
 }
 
-SimulationSocket::~SimulationSocket() {
+SimulationServerSocket::~SimulationServerSocket() {
     // Only a successfully-bound owner tears down and removes the file. A never-bound object
     // (try_create() lost to a live owner and returned nullptr) must not delete the live
     // owner's socket. The throwing ctor is safe either way: if bind_and_listen() throws,
@@ -225,7 +225,7 @@ SimulationSocket::~SimulationSocket() {
     std::filesystem::remove(socket_path_, ec);
 }
 
-std::filesystem::path SimulationSocket::default_socket_path(ChipId chip_id) {
+std::filesystem::path SimulationServerSocket::default_socket_path(ChipId chip_id) {
     // One shared socket per chip per machine, under the system temp directory: the name
     // carries no uid, so every process (any user) resolves the same path and attaches to the
     // single host. The socket dir is assumed trusted: the path is predictable and the socket

--- a/device/simulation/simulation_server_socket.hpp
+++ b/device/simulation/simulation_server_socket.hpp
@@ -28,20 +28,20 @@ namespace tt::umd {
 //
 // Note: distinct from SimulationHost, which is the (nng) RTL transport over which the
 // simulator process connects back into UMD.
-class SimulationSocket {
+class SimulationServerSocket {
 public:
-    ~SimulationSocket();
+    ~SimulationServerSocket();
 
-    SimulationSocket(const SimulationSocket&) = delete;
-    SimulationSocket& operator=(const SimulationSocket&) = delete;
+    SimulationServerSocket(const SimulationServerSocket&) = delete;
+    SimulationServerSocket& operator=(const SimulationServerSocket&) = delete;
 
     // Binds and listens, reclaiming a stale socket. Returns nullptr if a *live* owner already
     // holds the path (so the caller can attach as a client). Throws on real socket errors.
-    static std::unique_ptr<SimulationSocket> try_create(const std::filesystem::path& socket_path);
+    static std::unique_ptr<SimulationServerSocket> try_create(const std::filesystem::path& socket_path);
 
     // Like try_create(), but throws (instead of returning nullptr) when a live owner already
     // holds the path. For callers that require ownership and have no client path to fall back to.
-    static std::unique_ptr<SimulationSocket> create(const std::filesystem::path& socket_path);
+    static std::unique_ptr<SimulationServerSocket> create(const std::filesystem::path& socket_path);
 
     const std::filesystem::path& socket_path() const { return socket_path_; }
 
@@ -53,7 +53,7 @@ public:
 private:
     // Non-throwing; only initializes members. Binding happens in bind_and_listen(), driven by
     // the try_create()/create() factories.
-    explicit SimulationSocket(const std::filesystem::path& socket_path);
+    explicit SimulationServerSocket(const std::filesystem::path& socket_path);
 
     // Binds + listens + starts the accept loop. Returns false if a live owner holds the path;
     // throws on real socket errors.

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -12,7 +12,7 @@
 #include <utility>
 
 #include "noc_access.hpp"
-#include "simulation/simulation_socket.hpp"
+#include "simulation/simulation_server_socket.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
@@ -152,7 +152,9 @@ RtlSimulationTTDevice::~RtlSimulationTTDevice() {
     communicator_->shutdown();
 }
 
-void RtlSimulationTTDevice::adopt_socket(std::unique_ptr<SimulationSocket> socket) { socket_ = std::move(socket); }
+void RtlSimulationTTDevice::adopt_socket(std::unique_ptr<SimulationServerSocket> socket) {
+    socket_ = std::move(socket);
+}
 
 void RtlSimulationTTDevice::write_to_device(const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size) {
     std::lock_guard<std::recursive_mutex> lock(device_lock);

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -15,7 +15,7 @@
 #include <vector>
 
 #include "noc_access.hpp"
-#include "simulation/simulation_socket.hpp"
+#include "simulation/simulation_server_socket.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
@@ -177,7 +177,7 @@ TTSimTTDevice::~TTSimTTDevice() {
     communicator_->shutdown();
 }
 
-void TTSimTTDevice::adopt_socket(std::unique_ptr<SimulationSocket> socket) { socket_ = std::move(socket); }
+void TTSimTTDevice::adopt_socket(std::unique_ptr<SimulationServerSocket> socket) { socket_ = std::move(socket); }
 
 void TTSimTTDevice::start_device() {}
 

--- a/tests/api/test_simulation_connector.cpp
+++ b/tests/api/test_simulation_connector.cpp
@@ -7,7 +7,7 @@
 #include <cstdlib>
 #include <filesystem>
 
-#include "simulation/simulation_socket.hpp"
+#include "simulation/simulation_server_socket.hpp"
 #include "umd/device/simulation/simulation_connector.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 
@@ -21,13 +21,13 @@ TEST(SimulationConnector, CreatesHostDeviceAndExposesSocket) {
         GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
     }
 
-    const std::filesystem::path socket = SimulationSocket::default_socket_path(0);
+    const std::filesystem::path socket = SimulationServerSocket::default_socket_path(0);
     // discover() resolves this well-known machine-wide path internally, so the test can't point
     // it at a private one. Rather than blindly unlink it (which would clobber a host from a
     // concurrent run), probe with try_create: a live owner -> skip; otherwise we hold a fresh or
     // reclaimed socket, released here so discover() can bind it itself.
     {
-        auto probe = SimulationSocket::try_create(socket);
+        auto probe = SimulationServerSocket::try_create(socket);
         if (probe == nullptr) {
             GTEST_SKIP() << "A live simulation host already holds " << socket << "; skipping to avoid clobbering it.";
         }
@@ -50,8 +50,8 @@ TEST(SimulationConnector, CreatesHostDeviceAndExposesSocket) {
 // client/attach path as an error rather than trying to host. This exercises the host-vs-client
 // arbiter's throw branch without a simulator: discover() bails before TTSimTTDevice::create().
 TEST(SimulationConnector, ThrowsWhenLiveHostAlreadyExists) {
-    const std::filesystem::path socket = SimulationSocket::default_socket_path(0);
-    auto host = SimulationSocket::try_create(socket);
+    const std::filesystem::path socket = SimulationServerSocket::default_socket_path(0);
+    auto host = SimulationServerSocket::try_create(socket);
     if (host == nullptr) {
         GTEST_SKIP() << "A live simulation host already holds " << socket << "; skipping.";
     }

--- a/tests/baremetal/CMakeLists.txt
+++ b/tests/baremetal/CMakeLists.txt
@@ -8,9 +8,9 @@ set(BAREMETAL_TESTS_SRCS
     test_long_jump.cpp
     test_notification_mechanism.cpp
     test_cluster.cpp
-    # SimulationSocket has no simulation deps (always compiled), so its tests need no card and
+    # SimulationServerSocket has no simulation deps (always compiled), so its tests need no card and
     # no simulation build -- they run in the no-card baremetal CI lane.
-    test_simulation_socket.cpp
+    test_simulation_server_socket.cpp
 )
 
 add_executable(baremetal_tests ${BAREMETAL_TESTS_SRCS})

--- a/tests/baremetal/test_simulation_server_socket.cpp
+++ b/tests/baremetal/test_simulation_server_socket.cpp
@@ -12,7 +12,7 @@
 #include <fstream>
 #include <string>
 
-#include "simulation/simulation_socket.hpp"
+#include "simulation/simulation_server_socket.hpp"
 
 using namespace tt::umd;
 
@@ -55,7 +55,7 @@ void leave_stale_socket(const std::filesystem::path& path) {
 
 // Provides a fresh socket path that is removed before and after each test, so cases share a
 // fixed name without leaking sockets between runs.
-class SimulationSocketTest : public ::testing::Test {
+class SimulationServerSocketTest : public ::testing::Test {
 protected:
     void SetUp() override {
         path_ = test_socket_path();
@@ -69,39 +69,39 @@ protected:
 
 }  // namespace
 
-TEST_F(SimulationSocketTest, ExposesConnectableSocket) {
-    auto server = SimulationSocket::create(path_);
+TEST_F(SimulationServerSocketTest, ExposesConnectableSocket) {
+    auto server = SimulationServerSocket::create(path_);
 
     EXPECT_TRUE(std::filesystem::exists(path_));
     EXPECT_TRUE(can_connect(path_));
 }
 
-TEST_F(SimulationSocketTest, RemovesSocketOnDestruction) {
-    { auto server = SimulationSocket::create(path_); }
+TEST_F(SimulationServerSocketTest, RemovesSocketOnDestruction) {
+    { auto server = SimulationServerSocket::create(path_); }
 
     EXPECT_FALSE(std::filesystem::exists(path_));
     EXPECT_FALSE(can_connect(path_));
 }
 
-TEST_F(SimulationSocketTest, ReclaimsStaleSocketFile) {
+TEST_F(SimulationServerSocketTest, ReclaimsStaleSocketFile) {
     leave_stale_socket(path_);
     EXPECT_FALSE(can_connect(path_));
 
-    auto server = SimulationSocket::create(path_);
+    auto server = SimulationServerSocket::create(path_);
 
     EXPECT_TRUE(can_connect(path_));
 }
 
-TEST_F(SimulationSocketTest, ThrowsWhenLiveServerAlreadyExists) {
-    auto server = SimulationSocket::create(path_);
+TEST_F(SimulationServerSocketTest, ThrowsWhenLiveServerAlreadyExists) {
+    auto server = SimulationServerSocket::create(path_);
 
-    EXPECT_ANY_THROW(SimulationSocket::create(path_));
+    EXPECT_ANY_THROW(SimulationServerSocket::create(path_));
 }
 
-TEST_F(SimulationSocketTest, TryCreateReturnsNullWhenLiveHostExists) {
-    auto host = SimulationSocket::try_create(path_);
+TEST_F(SimulationServerSocketTest, TryCreateReturnsNullWhenLiveHostExists) {
+    auto host = SimulationServerSocket::try_create(path_);
     ASSERT_NE(host, nullptr);
-    EXPECT_EQ(SimulationSocket::try_create(path_), nullptr);  // live host -> null, no throw
+    EXPECT_EQ(SimulationServerSocket::try_create(path_), nullptr);  // live host -> null, no throw
 
     // The throwaway object from the failed try_create above must not remove the live
     // host's socket on destruction (ownership-gated teardown).
@@ -109,27 +109,27 @@ TEST_F(SimulationSocketTest, TryCreateReturnsNullWhenLiveHostExists) {
     EXPECT_TRUE(can_connect(path_));
 }
 
-TEST_F(SimulationSocketTest, TryCreateReclaimsStaleSocket) {
+TEST_F(SimulationServerSocketTest, TryCreateReclaimsStaleSocket) {
     leave_stale_socket(path_);
 
-    auto host = SimulationSocket::try_create(path_);
+    auto host = SimulationServerSocket::try_create(path_);
     EXPECT_NE(host, nullptr);  // stale leftover reclaimed
     EXPECT_TRUE(can_connect(path_));
 }
 
 // A non-socket file squatting the path also yields EADDRINUSE on bind; the reclaim path
 // must refuse to delete it instead of destroying unrelated data.
-TEST_F(SimulationSocketTest, RefusesToReclaimNonSocketFile) {
+TEST_F(SimulationServerSocketTest, RefusesToReclaimNonSocketFile) {
     { std::ofstream(path_) << "not a socket"; }
 
-    EXPECT_THROW(SimulationSocket::try_create(path_), std::exception);
+    EXPECT_THROW(SimulationServerSocket::try_create(path_), std::exception);
     EXPECT_TRUE(std::filesystem::exists(path_));  // the regular file was left untouched
 }
 
-TEST(SimulationSocket, DefaultSocketPathIsPerChip) {
-    EXPECT_NE(SimulationSocket::default_socket_path(0), SimulationSocket::default_socket_path(1));
+TEST(SimulationServerSocket, DefaultSocketPathIsPerChip) {
+    EXPECT_NE(SimulationServerSocket::default_socket_path(0), SimulationServerSocket::default_socket_path(1));
 }
 
-TEST(SimulationSocket, DefaultSocketPathIsAbsolute) {
-    EXPECT_TRUE(SimulationSocket::default_socket_path(0).is_absolute());
+TEST(SimulationServerSocket, DefaultSocketPathIsAbsolute) {
+    EXPECT_TRUE(SimulationServerSocket::default_socket_path(0).is_absolute());
 }


### PR DESCRIPTION
### Issue
Part of #2792. Follow-up to review feedback on #2902.

### Description
Pure rename, no behavior change: `SimulationSocket` → `SimulationServerSocket` (class + files). It's the socket *to the server* (the simulation host); the slim client handle in #2902 connects to it.

### Testing
Build, `SimulationServerSocket*` baremetal suite (9 tests), and pre-commit all pass.