### PR TITLE
Remove noc_multicast from WormholeTTDevice

### DIFF
--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -48,9 +48,6 @@ public:
 
     EthTrainingStatus read_eth_core_training_status(tt_xy_pair eth_core) override;
 
-    void noc_multicast_write(
-        const void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) override;
-
     using TTDevice::noc_multicast_write;
     void noc_multicast_write(const void *src, size_t size, uint64_t addr) override;
 

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -416,31 +416,6 @@ void WormholeTTDevice::retrain_dram_core(const uint32_t dram_channel) {
     UMD_THROW(error::RuntimeError, "DRAM retraining is not supported on WormholeTTDevice.");
 }
 
-void WormholeTTDevice::noc_multicast_write(
-    const void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr) {
-    ZoneScopedC(tracy::Color::Orange);
-    if (!is_remote_tt_device) {
-        TTDevice::noc_multicast_write(src, size, core_start, core_end, addr);
-        return;
-    }
-
-    // TODO: implement multicast over remote communication.
-    // For now, fall back to unicast over the non-harvested TENSIX cores reported by the soc descriptor
-    // that fall inside the multicast range, matching hardware multicast behavior.
-    //
-    // Coordinates may be in TRANSLATED or NOC0 space; pick the coord system from core_start since the
-    // two ranges don't overlap.
-    const CoordSystem coord_system =
-        (core_start.x >= wormhole::tensix_translated_coordinate_start_x) ? CoordSystem::TRANSLATED : CoordSystem::NOC0;
-    for (const auto &core : get_soc_descriptor().get_cores(CoreType::TENSIX, coord_system)) {
-        if (core.x < core_start.x || core.x > core_end.x || core.y < core_start.y || core.y > core_end.y) {
-            continue;
-        }
-        log_trace(LogUMD, "noc_multicast_write fallback unicast to TENSIX core at ({}, {})", core.x, core.y);
-        write_to_device(src, xy_pair(core.x, core.y), addr, size);
-    }
-}
-
 void WormholeTTDevice::noc_multicast_write(const void *src, size_t size, uint64_t addr) {
     // Same range is used for NOC0 and NOC1.
     // Note that when multicasting in translated space, you have to skip harvested rows. So we can just always use NOC0


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2521

### Description
So in paralel to my huge stack of multicast PRs, Nenad worked on device protocol changes. Due to this, I messed up a bit when rebasing at one moment, so I mistakenly left the WormholeTTDevice::noc_multicast_write. This one shouldn't exist, all should go though TTDevice::noc_multicast_write

This PR added this function https://github.com/tenstorrent/tt-umd/pull/2537
Probably got intertwined with https://github.com/tenstorrent/tt-umd/pull/2418
and this PR should've probably changed the wormhole one instead of this one https://github.com/tenstorrent/tt-umd/pull/2572

In anycase, my intention was not to have two separate implementations of this function.

### List of the changes
- Remove WormholeTTDevice::noc_multicast_write

### Testing
The existing tests, which I added as part of the work in referenced issue, should cover this codepath

### API Changes
This PR has no API changes over general interfaces
