### PR TITLE
Remove misleading "newer than latest supported firmware" warning

### DIFF
--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -574,13 +574,10 @@ void TopologyDiscovery::verify_fw_bundle_version(TTDevice* tt_device, uint64_t a
     log_info(LogUMD, "Established firmware bundle version: {}", fw_bundle_version.to_string());
     FirmwareBundleVersion minimum_compatible_fw_bundle_version =
         FirmwareInfoProvider::get_minimum_compatible_firmware_version(arch);
-    FirmwareBundleVersion latest_supported_fw_bundle_version =
-        FirmwareInfoProvider::get_latest_supported_firmware_version(arch);
     log_debug(
         LogUMD,
-        "UMD supported firmware bundle versions: {} - {}",
-        minimum_compatible_fw_bundle_version.to_string(),
-        latest_supported_fw_bundle_version.to_string());
+        "UMD minimum compatible firmware bundle version: {}",
+        minimum_compatible_fw_bundle_version.to_string());
 
     if (fw_bundle_version < minimum_compatible_fw_bundle_version) {
         auto err = UMD_THROW_OR_RETURN(
@@ -593,16 +590,6 @@ void TopologyDiscovery::verify_fw_bundle_version(TTDevice* tt_device, uint64_t a
         log_warning(LogUMD, err.message());
         health_errors[asic_id].push_back(std::move(err));
         return;
-    }
-
-    if (fw_bundle_version > latest_supported_fw_bundle_version) {
-        log_info(
-            LogUMD,
-            "Firmware bundle version {} on the system is newer than the latest fully tested version {} for {} "
-            "architecture. Newest features may not be supported.",
-            fw_bundle_version.to_string(),
-            latest_supported_fw_bundle_version.to_string(),
-            arch_to_str(arch));
     }
 }
 


### PR DESCRIPTION
## Summary

`TopologyDiscovery::verify_fw_bundle_version` logged a warning whenever the on-system firmware bundle version was newer than the value returned by `FirmwareInfoProvider::get_latest_supported_firmware_version(arch)`.

That "latest supported" version is a **hardcoded constant** ([`firmware_info_provider.cpp:322`](https://github.com/tenstorrent/tt-umd/blob/main/device/firmware/firmware_info_provider.cpp#L322)) that lags behind reality, so the warning fired spuriously on perfectly up-to-date firmware and was misleading to users. We have seen several customers confused by this.

## Changes

- Drop the `get_latest_supported_firmware_version` lookup and the `fw_bundle_version > latest_supported_fw_bundle_version` warning block in `verify_fw_bundle_version`.
- Trim the accompanying `log_debug` to report only the minimum compatible version.
- The **minimum compatible version** check (the meaningful gate, which produces a real `UnsupportedCMFWError`) is retained unchanged.

The `FirmwareInfoProvider::get_latest_supported_firmware_version` function itself is left in place; after this change it has no remaining callers in the repo, so it could be removed in a follow-up if desired.

Recommend aligning with @sbansalTT on [Golden Version work](https://github.com/tenstorrent/tt-sw-manifest) to have an always-recent reference to the latest stable/tested FW & System SW packages if this is needed within tt-umd. 