### PR TITLE
Move "newer than the latest fully tested version" from warning to debug

### DIFF
--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -578,9 +578,16 @@ void TopologyDiscovery::verify_fw_bundle_version(TTDevice* tt_device, uint64_t a
         FirmwareInfoProvider::get_latest_supported_firmware_version(arch);
     log_debug(
         LogUMD,
-        "UMD supported firmware bundle versions: {} - {}",
+        "System firmware bundle version: {}. UMD supported firmware bundle versions: {} - {}.{}",
+        fw_bundle_version.to_string(),
         minimum_compatible_fw_bundle_version.to_string(),
-        latest_supported_fw_bundle_version.to_string());
+        latest_supported_fw_bundle_version.to_string(),
+        fw_bundle_version > latest_supported_fw_bundle_version
+            ? fmt::format(
+                  " Firmware bundle version is newer than the latest fully tested version for {} architecture. Newest "
+                  "features may not be supported.",
+                  arch_to_str(arch))
+            : "");
 
     if (fw_bundle_version < minimum_compatible_fw_bundle_version) {
         auto err = UMD_THROW_OR_RETURN(
@@ -593,16 +600,6 @@ void TopologyDiscovery::verify_fw_bundle_version(TTDevice* tt_device, uint64_t a
         log_warning(LogUMD, err.message());
         health_errors[asic_id].push_back(std::move(err));
         return;
-    }
-
-    if (fw_bundle_version > latest_supported_fw_bundle_version) {
-        log_info(
-            LogUMD,
-            "Firmware bundle version {} on the system is newer than the latest fully tested version {} for {} "
-            "architecture. Newest features may not be supported.",
-            fw_bundle_version.to_string(),
-            latest_supported_fw_bundle_version.to_string(),
-            arch_to_str(arch));
     }
 }
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2947

### Description
Per popular request, reducing the level of this log so it is not confusing for somebody using the newest code on the newest system.

### List of the changes
- Merge the existing log_debug listing fw versions, and the log_info printing the warning about newer FW than fully tested and supported one.

### Testing
Observed on the local machine:
> 2026-06-29 18:00:41.335 | debug    |             UMD | System firmware bundle version: 19.5.0. UMD supported firmware bundle versions: 18.3.0 - 19.2.1. Firmware bundle version is newer than the latest fully tested version for wormhole_b0 architecture. Newest features may not be supported. (topology_discovery.cpp:579)

### API Changes
This PR has no API changes.
