### PR TITLE
RemoteChip: accept Chip* base instead of LocalChip*

### DIFF
--- a/device/api/umd/device/chip/remote_chip.hpp
+++ b/device/api/umd/device/chip/remote_chip.hpp
@@ -25,7 +25,7 @@ struct EthCoord;
 }  // namespace tt
 
 namespace tt::umd {
-class LocalChip;
+class Chip;
 class RemoteCommunication;
 class SocDescriptor;
 
@@ -37,7 +37,7 @@ public:
      * @param local_chip The local chip to be used for communication to this remote chip.
      * @return A unique pointer to the created RemoteChip instance.
      */
-    static std::unique_ptr<RemoteChip> create(std::unique_ptr<TTDevice> remote_tt_device, LocalChip* local_chip);
+    static std::unique_ptr<RemoteChip> create(std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip);
 
     bool is_mmio_capable() const override;
 
@@ -78,9 +78,9 @@ public:
     RemoteCommunication* get_remote_communication();
 
 private:
-    RemoteChip(LocalChip* local_chip, std::unique_ptr<TTDevice> remote_tt_device);
+    RemoteChip(Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_device);
 
-    LocalChip* local_chip_;
+    Chip* local_chip_;
     RemoteCommunication* remote_communication_;
 
     std::unique_ptr<TTDevice> tt_device_ = nullptr;

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -28,15 +28,15 @@ namespace tt::umd {
 
 static_assert(!std::is_abstract<RemoteChip>(), "RemoteChip must be non-abstract.");
 
-std::unique_ptr<RemoteChip> RemoteChip::create(std::unique_ptr<TTDevice> remote_tt_device, LocalChip* local_chip) {
+std::unique_ptr<RemoteChip> RemoteChip::create(std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip) {
     ZoneScopedC(tracy::Color::DarkGreen);
     UMD_ASSERT(
         remote_tt_device != nullptr, error::RuntimeError, "RemoteTTDevice passed to RemoteChip must not be null.");
-    UMD_ASSERT(local_chip != nullptr, error::RuntimeError, "LocalChip passed to RemoteChip must not be null.");
+    UMD_ASSERT(local_chip != nullptr, error::RuntimeError, "Local chip passed to RemoteChip must not be null.");
     return std::unique_ptr<RemoteChip>(new RemoteChip(local_chip, std::move(remote_tt_device)));
 }
 
-RemoteChip::RemoteChip(LocalChip* local_chip, std::unique_ptr<TTDevice> remote_tt_device) :
+RemoteChip::RemoteChip(Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_device) :
     Chip(remote_tt_device->get_chip_info(), remote_tt_device->get_arch()), local_chip_(local_chip) {
     remote_communication_ = remote_tt_device->get_remote_communication();
     tt_device_ = std::move(remote_tt_device);


### PR DESCRIPTION
### Issue
Part of #2679, tracked by #2832. Split out of #2808.

### Description
Widen `RemoteChip`'s gateway pointer from `LocalChip*` to `Chip*` so a `RemoteChip` can sit behind any `Chip` (e.g. a `SimulationChip` gateway), not only a `LocalChip`. Behaviour-preserving: all uses go through `Chip` virtuals and existing callers pass a `LocalChip*` which is-a `Chip*`.

### List of the changes
- `RemoteChip::create`, its constructor, and the `local_chip_` member take `Chip*` instead of `LocalChip*`.

### Testing
CI

### API Changes
`RemoteChip::create` parameter type widened from `LocalChip*` to `Chip*`.
