### PR TITLE
TTDevice: allow supplying SocDescriptor at remote create()

### DIFF
--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -91,9 +91,14 @@ public:
         bool use_safe_api = false,
         const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor = nullptr);
 
+    // A remote TTDevice is normally initialized over ARC (init_tt_device), which constructs its SocDescriptor.
+    // Simulated remote chips have no ARC to probe, so the caller may supply the full descriptor via soc_descriptor.
+    // TODO: temporary - the soc_descriptor parameter should be removed once ttsim provides a mocked ARC that can
+    // serve the SocDescriptor the same way silicon does.
     static std::unique_ptr<TTDevice> create(
         std::unique_ptr<RemoteCommunication> remote_communication,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor = nullptr);
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor = nullptr,
+        std::optional<SocDescriptor> soc_descriptor = std::nullopt);
 
     virtual ~TTDevice() = default;
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -91,14 +91,19 @@ public:
         bool use_safe_api = false,
         const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor = nullptr);
 
-    // A remote TTDevice is normally initialized over ARC (init_tt_device), which constructs its SocDescriptor.
-    // Simulated remote chips have no ARC to probe, so the caller may supply the full descriptor via soc_descriptor.
-    // TODO: temporary - the soc_descriptor parameter should be removed once ttsim provides a mocked ARC that can
-    // serve the SocDescriptor the same way silicon does.
     static std::unique_ptr<TTDevice> create(
         std::unique_ptr<RemoteCommunication> remote_communication,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor = nullptr,
-        std::optional<SocDescriptor> soc_descriptor = std::nullopt);
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor = nullptr);
+
+#ifdef TT_UMD_BUILD_SIMULATION
+    // A remote TTDevice is normally initialized over ARC (init_tt_device), which constructs its SocDescriptor.
+    // Simulated remote chips have no ARC to probe, so the caller supplies the full descriptor directly. This is a
+    // dedicated factory (compiled in only for simulation builds) rather than an overload of the silicon create()
+    // above, so the simulation-only flow stays fully separated from the silicon path.
+    // TODO: temporary - remove once ttsim provides a mocked ARC that can serve the SocDescriptor like silicon does.
+    static std::unique_ptr<TTDevice> create_simulation_remote(
+        std::unique_ptr<RemoteCommunication> remote_communication, const SocDescriptor &soc_descriptor);
+#endif  // TT_UMD_BUILD_SIMULATION
 
     virtual ~TTDevice() = default;
 

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -78,6 +78,7 @@ private:
         const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
     friend std::unique_ptr<TTDevice> TTDevice::create(
         std::unique_ptr<RemoteCommunication> remote_communication,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
+        std::optional<SocDescriptor> soc_descriptor);
 };
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -78,7 +78,10 @@ private:
         const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
     friend std::unique_ptr<TTDevice> TTDevice::create(
         std::unique_ptr<RemoteCommunication> remote_communication,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
-        std::optional<SocDescriptor> soc_descriptor);
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
+#ifdef TT_UMD_BUILD_SIMULATION
+    friend std::unique_ptr<TTDevice> TTDevice::create_simulation_remote(
+        std::unique_ptr<RemoteCommunication> remote_communication, const SocDescriptor &soc_descriptor);
+#endif  // TT_UMD_BUILD_SIMULATION
 };
 }  // namespace tt::umd

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -193,14 +193,20 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
 
 std::unique_ptr<TTDevice> TTDevice::create(
     std::unique_ptr<RemoteCommunication> remote_communication,
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
+    std::optional<SocDescriptor> soc_descriptor) {
     ZoneScopedC(tracy::Color::DarkGreen);
     UMD_ASSERT(remote_communication != nullptr, error::RuntimeError, "RemoteCommunication pointer cannot be null.");
     tt::ARCH arch = remote_communication->get_local_device()->get_arch();
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: {
-            return std::unique_ptr<WormholeTTDevice>(
+            auto device = std::unique_ptr<WormholeTTDevice>(
                 new WormholeTTDevice(std::move(remote_communication), soc_arch_descriptor));
+            if (soc_descriptor.has_value()) {
+                // set_soc_descriptor takes a const ref and copies internally, so no std::move here.
+                device->set_soc_descriptor(*soc_descriptor);
+            }
+            return device;
         }
         default:
             UMD_THROW(

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -193,19 +193,41 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
 
 std::unique_ptr<TTDevice> TTDevice::create(
     std::unique_ptr<RemoteCommunication> remote_communication,
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
-    std::optional<SocDescriptor> soc_descriptor) {
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
     ZoneScopedC(tracy::Color::DarkGreen);
     UMD_ASSERT(remote_communication != nullptr, error::RuntimeError, "RemoteCommunication pointer cannot be null.");
     tt::ARCH arch = remote_communication->get_local_device()->get_arch();
     switch (arch) {
+        case tt::ARCH::WORMHOLE_B0:
+            return std::unique_ptr<WormholeTTDevice>(
+                new WormholeTTDevice(std::move(remote_communication), soc_arch_descriptor));
+        default:
+            UMD_THROW(
+                error::RuntimeError,
+                fmt::format("Remote TTDevice creation is not supported for {} architecture.", arch_to_str(arch)));
+    }
+}
+
+#ifdef TT_UMD_BUILD_SIMULATION
+std::unique_ptr<TTDevice> TTDevice::create_simulation_remote(
+    std::unique_ptr<RemoteCommunication> remote_communication, const SocDescriptor &soc_descriptor) {
+    ZoneScopedC(tracy::Color::DarkGreen);
+    UMD_ASSERT(remote_communication != nullptr, error::RuntimeError, "RemoteCommunication pointer cannot be null.");
+    tt::ARCH arch = remote_communication->get_local_device()->get_arch();
+    UMD_ASSERT(
+        soc_descriptor.arch == arch,
+        error::RuntimeError,
+        fmt::format(
+            "Supplied SocDescriptor arch ({}) does not match the remote device arch ({}).",
+            arch_to_str(soc_descriptor.arch),
+            arch_to_str(arch)));
+    switch (arch) {
         case tt::ARCH::WORMHOLE_B0: {
             auto device = std::unique_ptr<WormholeTTDevice>(
-                new WormholeTTDevice(std::move(remote_communication), soc_arch_descriptor));
-            if (soc_descriptor.has_value()) {
-                // set_soc_descriptor takes a const ref and copies internally, so no std::move here.
-                device->set_soc_descriptor(*soc_descriptor);
-            }
+                new WormholeTTDevice(std::move(remote_communication), /*soc_arch_descriptor=*/nullptr));
+            // This device is never run through init_tt_device() (no ARC to probe), so construct_soc_descriptor()
+            // never overwrites the descriptor set here; set_soc_descriptor keeps the assign-exactly-once invariant.
+            device->set_soc_descriptor(soc_descriptor);
             return device;
         }
         default:
@@ -214,6 +236,7 @@ std::unique_ptr<TTDevice> TTDevice::create(
                 fmt::format("Remote TTDevice creation is not supported for {} architecture.", arch_to_str(arch)));
     }
 }
+#endif  // TT_UMD_BUILD_SIMULATION
 
 architecture_implementation *TTDevice::get_architecture_implementation() { return architecture_impl_.get(); }
 


### PR DESCRIPTION
### Issue
Part of #2679, tracked by #2832. Split out of #2808; builds on #2952.

### Description
Add an optional, defaulted `SocDescriptor` to the remote `TTDevice::create()` overload. A remote `TTDevice` is normally initialized over ARC, which constructs its `SocDescriptor`; simulated remote chips have no ARC to probe, so the caller can supply the descriptor directly. Silicon callers are unaffected. The parameter is temporary and should be removed once ttsim provides a mocked ARC.

### List of the changes
- `TTDevice::create` (remote overload) gains an optional `SocDescriptor`, applied via `set_soc_descriptor` when set.

### Testing
CI

### API Changes
`TTDevice::create` (remote overload) gains a defaulted optional `SocDescriptor` parameter; existing callers unaffected.
