### PR TITLE
Cluster: discover ttsim cluster descriptor from simulator directory

### DIFF
--- a/device/api/umd/device/simulation/simulation_chip.hpp
+++ b/device/api/umd/device/simulation/simulation_chip.hpp
@@ -38,6 +38,9 @@ class SocDescriptor;
 class SimulationChip : public Chip {
 public:
     static std::string get_soc_descriptor_path_from_simulator_path(const std::filesystem::path& simulator_path);
+    // An optional cluster_descriptor.yaml beside the simulator describes a (possibly multichip) topology.
+    // Returns the path where it would live; the file is not required to exist.
+    static std::string get_cluster_descriptor_path_from_simulator_path(const std::filesystem::path& simulator_path);
 
     static std::unique_ptr<SimulationChip> create(
         const std::filesystem::path& simulator_directory,

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -367,6 +367,30 @@ Cluster::Cluster(ClusterOptions options) {
         case ChipType::SWEMULE:
         case ChipType::SIMULATION: {
             if (options.cluster_descriptor == nullptr) {
+#ifdef TT_UMD_BUILD_SIMULATION
+                // A ttsim .so may ship a cluster_descriptor.yaml beside it describing a real (possibly multichip)
+                // topology, mirroring the soc_descriptor.yaml convention. When present, use it; otherwise fall
+                // through to the mock single-chip descriptor below (unchanged behaviour).
+                const bool is_ttsim_build =
+                    (options.chip_type == ChipType::SIMULATION && options.simulator_directory.extension() == ".so");
+                const std::string cluster_desc_path =
+                    is_ttsim_build
+                        ? SimulationChip::get_cluster_descriptor_path_from_simulator_path(options.simulator_directory)
+                        : "";
+
+                if (is_ttsim_build && std::filesystem::exists(cluster_desc_path)) {
+                    // Resolve the simulator's soc_descriptor.yaml as well, so the per-chip SocDescriptors built
+                    // below are populated from the simulator-provided data instead of a default arch descriptor
+                    // (matches the fallback path's sdesc_path resolution).
+                    if (options.sdesc_path.empty()) {
+                        options.sdesc_path =
+                            SimulationChip::get_soc_descriptor_path_from_simulator_path(options.simulator_directory);
+                    }
+                    cluster_desc = ClusterDescriptor::create_constrained_cluster_descriptor(
+                        ClusterDescriptor::create_from_yaml(cluster_desc_path).get(), options.target_devices);
+                    break;
+                }
+#endif
                 // If no custom descriptor is provided, in case of mock or simulation chip type, we create a mock
                 // cluster descriptor from passed target devices.
                 auto arch = tt::ARCH::WORMHOLE_B0;

--- a/device/simulation/simulation_chip.cpp
+++ b/device/simulation/simulation_chip.cpp
@@ -36,6 +36,12 @@ std::string SimulationChip::get_soc_descriptor_path_from_simulator_path(const st
                                                  : (simulator_path / "soc_descriptor.yaml");
 }
 
+std::string SimulationChip::get_cluster_descriptor_path_from_simulator_path(
+    const std::filesystem::path& simulator_path) {
+    return (simulator_path.extension() == ".so") ? (simulator_path.parent_path() / "cluster_descriptor.yaml")
+                                                 : (simulator_path / "cluster_descriptor.yaml");
+}
+
 SimulationChip::SimulationChip(
     const std::filesystem::path& simulator_directory,
     const SocDescriptor& soc_descriptor,


### PR DESCRIPTION
### Issue
Part of #2679, tracked by #2832. Split out of #2808; builds on #2953.
#1288 

### Description
Discover an optional `cluster_descriptor.yaml` beside a ttsim `.so` (mirroring the `soc_descriptor.yaml` convention) and build a constrained `ClusterDescriptor` from it. When the file is present, the simulator's `soc_descriptor.yaml` is also resolved so each chip's `SocDescriptor` is built from simulator-provided data rather than a default arch descriptor. Behaviour is unchanged when the file is absent.

### List of the changes
- Add `SimulationChip::get_cluster_descriptor_path_from_simulator_path`.
- `Cluster` reads an optional `cluster_descriptor.yaml` beside the simulator `.so`, resolving the sim's `soc_descriptor.yaml` for per-chip `SocDescriptor`s when it does.

### Testing
CI

### API Changes
New `SimulationChip::get_cluster_descriptor_path_from_simulator_path`.