### PR TITLE
Support wh_x2 (N300) multichip ttsim

### DIFF
--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -75,6 +75,14 @@ jobs:
           fileName: "libttsim_qsr.so"
           out-file-path: /tmp/ttsim-qsr
 
+      - name: Download ttsim binary (wh_x2)
+        uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f  # v1.13
+        with:
+          repository: tenstorrent/ttsim
+          tag: ${{ steps.get-ttsim-version.outputs.ttsim-version }}
+          fileName: "libttsim_wh_x2.so"
+          out-file-path: /tmp/ttsim-wh-x2
+
       - name: Build tt-metal
         run: |
           cd tt-metal
@@ -90,13 +98,20 @@ jobs:
       - name: Prepare sim paths
         run: |
           echo "Preparing sim paths"
-          mkdir -p sim_wh sim_bh sim_qsr
+          mkdir -p sim_wh sim_bh sim_qsr sim_wh_x2
           mv /tmp/ttsim-wh/libttsim_wh.so sim_wh/libttsim.so
           mv /tmp/ttsim-bh/libttsim_bh.so sim_bh/libttsim.so
           mv /tmp/ttsim-qsr/libttsim_qsr.so sim_qsr/libttsim.so
+          mv /tmp/ttsim-wh-x2/libttsim_wh_x2.so sim_wh_x2/libttsim.so
           cp $TT_METAL_HOME/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml sim_wh/soc_descriptor.yaml
           cp $TT_METAL_HOME/tt_metal/soc_descriptors/blackhole_140_arch.yaml sim_bh/soc_descriptor.yaml
           cp tt-metal/tt_metal/third_party/umd/tests/soc_descs/quasar_32_arch.yaml sim_qsr/soc_descriptor.yaml
+          # wh_x2 is two Wormhole chips; reuse the per-chip Wormhole soc descriptor.
+          cp $TT_METAL_HOME/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml sim_wh_x2/soc_descriptor.yaml
+          # Place the N300 cluster descriptor beside the simulator; UMD auto-discovers it (like soc_descriptor.yaml)
+          # and enumerates both the MMIO gateway and the remote chip. Without it, the sim is a single MMIO chip.
+          cp tt-metal/tt_metal/third_party/umd/tests/cluster_descriptor_examples/wormhole_N300.yaml \
+            sim_wh_x2/cluster_descriptor.yaml
 
       - name: Build UMD api_tests and microbenchmark with simulation support
         run: |
@@ -165,6 +180,24 @@ jobs:
         timeout-minutes: 1
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_qsr/libttsim.so
+        run: |
+          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
+
+      # wh_x2 is the N300 multichip simulator (chip 0 MMIO gateway + chip 1 remote over
+      # simulated eth). The cluster_descriptor.yaml placed beside the simulator (see "Prepare sim paths")
+      # makes UMD enumerate both chips, so the standard device-IO fixtures run across the gateway and
+      # the remote chip.
+      - name: Run UMD TestDeviceIOFixture on tt-sim wormhole x2
+        timeout-minutes: 1
+        env:
+          TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_wh_x2/libttsim.so
+        run: |
+          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
+
+      - name: Run UMD TTSimDeviceIOFixture on tt-sim wormhole x2
+        timeout-minutes: 1
+        env:
+          TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_wh_x2/libttsim.so
         run: |
           tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
 

--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -79,7 +79,7 @@ jobs:
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f  # v1.13
         with:
           repository: tenstorrent/ttsim
-          tag: ${{ steps.get-ttsim-version.outputs.ttsim-version }}
+          latest: true
           fileName: "libttsim_wh_x2.so"
           out-file-path: /tmp/ttsim-wh-x2
 

--- a/device/api/umd/device/chip/remote_chip.hpp
+++ b/device/api/umd/device/chip/remote_chip.hpp
@@ -38,6 +38,8 @@ public:
      * @return A unique pointer to the created RemoteChip instance.
      */
     static std::unique_ptr<RemoteChip> create(std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip);
+    static std::unique_ptr<RemoteChip> create_for_simulation(
+        std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip, ChipInfo chip_info);
 
     bool is_mmio_capable() const override;
 
@@ -79,9 +81,14 @@ public:
 
 private:
     RemoteChip(Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_device);
+    RemoteChip(Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_device, ChipInfo chip_info);
 
     Chip* local_chip_;
     RemoteCommunication* remote_communication_;
+
+    // True when this remote chip is simulated (constructed via create_for_simulation). A simulated remote chip has
+    // no ARC, so ARC-dependent steps (reset/power) are skipped.
+    bool is_simulation_ = false;
 
     std::unique_ptr<TTDevice> tt_device_ = nullptr;
 };

--- a/device/api/umd/device/chip/remote_chip.hpp
+++ b/device/api/umd/device/chip/remote_chip.hpp
@@ -38,8 +38,13 @@ public:
      * @return A unique pointer to the created RemoteChip instance.
      */
     static std::unique_ptr<RemoteChip> create(std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip);
+#ifdef TT_UMD_BUILD_SIMULATION
+    // Simulation-only factory for a simulated remote chip (no ARC to probe), matching
+    // TTDevice::create_simulation_remote. Compiled in only for simulation builds so the simulation-specific
+    // construction path is not exposed in silicon builds.
     static std::unique_ptr<RemoteChip> create_for_simulation(
         std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip, ChipInfo chip_info);
+#endif  // TT_UMD_BUILD_SIMULATION
 
     bool is_mmio_capable() const override;
 

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -721,6 +721,13 @@ private:
         int num_host_mem_channels,
         const std::filesystem::path& simulator_directory,
         std::unique_ptr<TTDevice> tt_device = nullptr);
+#ifdef TT_UMD_BUILD_SIMULATION
+    // Builds the RemoteChip for a non-MMIO chip in a multichip ttsim cluster. A simulated remote chip has no
+    // ARC/topology discovery, so its RemoteCommunication and TTDevice (carrying the cluster-derived SocDescriptor
+    // and ChipInfo) are constructed here against the MMIO gateway.
+    std::unique_ptr<RemoteChip> create_simulation_remote_chip(
+        ChipId chip_id, ClusterDescriptor* cluster_desc, const SocDescriptor& soc_desc);
+#endif  // TT_UMD_BUILD_SIMULATION
     SocDescriptor construct_soc_descriptor(
         const std::string& soc_desc_path, ChipId chip_id, ChipType chip_type, ClusterDescriptor* cluster_desc);
 

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -35,17 +35,25 @@ std::unique_ptr<RemoteChip> RemoteChip::create(std::unique_ptr<TTDevice> remote_
     return std::unique_ptr<RemoteChip>(new RemoteChip(local_chip, std::move(remote_tt_device)));
 }
 
+#ifdef TT_UMD_BUILD_SIMULATION
 std::unique_ptr<RemoteChip> RemoteChip::create_for_simulation(
     std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip, ChipInfo chip_info) {
     ZoneScopedC(tracy::Color::DarkGreen);
     UMD_ASSERT(
         remote_tt_device != nullptr, error::RuntimeError, "RemoteTTDevice passed to RemoteChip must not be null.");
     UMD_ASSERT(local_chip != nullptr, error::RuntimeError, "Local chip passed to RemoteChip must not be null.");
+    // RemoteChip methods dereference remote_communication_ (e.g. wait_for_non_mmio_flush), so the remote TTDevice
+    // must carry a RemoteCommunication; otherwise the constructed chip would crash on first use.
+    UMD_ASSERT(
+        remote_tt_device->get_remote_communication() != nullptr,
+        error::RuntimeError,
+        "RemoteTTDevice passed to RemoteChip::create_for_simulation must have a RemoteCommunication.");
     // The remote TTDevice for a simulated chip is never run through init_tt_device() (it has no ARC to probe), so
     // its SocDescriptor is supplied to TTDevice::create() instead. get_soc_descriptor() can then keep delegating
     // to the TTDevice like every other chip.
     return std::unique_ptr<RemoteChip>(new RemoteChip(local_chip, std::move(remote_tt_device), chip_info));
 }
+#endif  // TT_UMD_BUILD_SIMULATION
 
 RemoteChip::RemoteChip(Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_device) :
     Chip(remote_tt_device->get_chip_info(), remote_tt_device->get_arch()), local_chip_(local_chip) {

--- a/device/chip/remote_chip.cpp
+++ b/device/chip/remote_chip.cpp
@@ -12,7 +12,6 @@
 #include <utility>
 
 #include "tracy.hpp"
-#include "umd/device/chip/local_chip.hpp"
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
@@ -36,11 +35,29 @@ std::unique_ptr<RemoteChip> RemoteChip::create(std::unique_ptr<TTDevice> remote_
     return std::unique_ptr<RemoteChip>(new RemoteChip(local_chip, std::move(remote_tt_device)));
 }
 
+std::unique_ptr<RemoteChip> RemoteChip::create_for_simulation(
+    std::unique_ptr<TTDevice> remote_tt_device, Chip* local_chip, ChipInfo chip_info) {
+    ZoneScopedC(tracy::Color::DarkGreen);
+    UMD_ASSERT(
+        remote_tt_device != nullptr, error::RuntimeError, "RemoteTTDevice passed to RemoteChip must not be null.");
+    UMD_ASSERT(local_chip != nullptr, error::RuntimeError, "Local chip passed to RemoteChip must not be null.");
+    // The remote TTDevice for a simulated chip is never run through init_tt_device() (it has no ARC to probe), so
+    // its SocDescriptor is supplied to TTDevice::create() instead. get_soc_descriptor() can then keep delegating
+    // to the TTDevice like every other chip.
+    return std::unique_ptr<RemoteChip>(new RemoteChip(local_chip, std::move(remote_tt_device), chip_info));
+}
+
 RemoteChip::RemoteChip(Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_device) :
     Chip(remote_tt_device->get_chip_info(), remote_tt_device->get_arch()), local_chip_(local_chip) {
     remote_communication_ = remote_tt_device->get_remote_communication();
     tt_device_ = std::move(remote_tt_device);
     wait_chip_to_be_ready();
+}
+
+RemoteChip::RemoteChip(Chip* local_chip, std::unique_ptr<TTDevice> remote_tt_device, ChipInfo chip_info) :
+    Chip(chip_info, remote_tt_device->get_soc_descriptor().arch), local_chip_(local_chip), is_simulation_(true) {
+    remote_communication_ = remote_tt_device->get_remote_communication();
+    tt_device_ = std::move(remote_tt_device);
 }
 
 bool RemoteChip::is_mmio_capable() const { return false; }
@@ -49,6 +66,9 @@ void RemoteChip::start_device(uint32_t dram_membar_subchannel) {}
 
 void RemoteChip::close_device() {
     ZoneScopedC(tracy::Color::DarkRed);
+    if (is_simulation_) {
+        return;
+    }
     // Investigating https://github.com/tenstorrent/tt-metal/issues/25377 found that closing device that was already put
     // in LONG_IDLE by tt-smi reset would hang
     if ((uint32_t)local_chip_->get_clock() != local_chip_->get_tt_device()->get_min_clock_freq()) {
@@ -97,7 +117,12 @@ void RemoteChip::dram_membar(const std::unordered_set<uint32_t>& channels, uint3
     wait_for_non_mmio_flush();
 }
 
-void RemoteChip::deassert_risc_resets() { local_chip_->deassert_risc_resets(); }
+void RemoteChip::deassert_risc_resets() {
+    if (is_simulation_) {
+        return;
+    }
+    local_chip_->deassert_risc_resets();
+}
 
 int RemoteChip::get_clock() { return tt_device_->get_clock(); }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1049,8 +1049,10 @@ void Cluster::broadcast_tensix_risc_reset_to_cluster(uint32_t reg_value) {
 
 void Cluster::set_clock_state(DevicePowerState device_state) {
     for (auto& [_, chip] : chips_) {
-        // ttsim remote chips cannot service ARC messages; skip power state transitions for them. Silicon remote chips
-        // are still handled over ethernet as before.
+        // No ttsim chip can service ARC messages, not even the gateway (a SimulationChip, whose is_mmio_capable()
+        // is also false), so skip power state transitions for every chip in a simulation cluster. This is
+        // deliberately not keyed on remote_chip_ids_: the gateway must be skipped too. Silicon chips are handled
+        // over ARC/ethernet as before.
         if (options_.chip_type == ChipType::SIMULATION && !chip->is_mmio_capable()) {
             continue;
         }
@@ -1070,8 +1072,10 @@ void Cluster::deassert_resets_and_set_clock_state() {
     // MT Initial BH - ARC messages not supported in Blackhole.
     if (arch_name != tt::ARCH::BLACKHOLE && arch_name != tt::ARCH::QUASAR) {
         for (const ChipId& chip : all_chip_ids_) {
-            // ttsim remote chips cannot service ARC messages; skip enabling their ethernet queue. Silicon remote chips
-            // are still initialized over ethernet as before.
+            // No ttsim chip can service ARC messages, not even the gateway (a SimulationChip, whose
+            // is_mmio_capable() is also false), so skip enabling the ethernet queue for every chip in a simulation
+            // cluster. This is deliberately not keyed on remote_chip_ids_: the gateway must be skipped too. Silicon
+            // chips are initialized over ARC/ethernet as before.
             if (options_.chip_type == ChipType::SIMULATION && !get_chip(chip)->is_mmio_capable()) {
                 continue;
             }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -198,6 +198,35 @@ void Cluster::construct_cluster(const uint32_t& num_host_mem_ch_per_mmio_device,
     }
 }
 
+#ifdef TT_UMD_BUILD_SIMULATION
+std::unique_ptr<RemoteChip> Cluster::create_simulation_remote_chip(
+    ChipId chip_id, ClusterDescriptor* cluster_desc, const SocDescriptor& soc_desc) {
+    ChipId gateway_id = cluster_desc->get_closest_mmio_capable_chip(chip_id);
+    Chip* gateway_chip = get_chip(gateway_id);
+    SysmemManager* sysmem_manager = gateway_chip->get_sysmem_manager();
+    if (sysmem_manager != nullptr && sysmem_manager->get_num_host_mem_channels() == 0) {
+        sysmem_manager = nullptr;
+    }
+    auto remote_communication = RemoteCommunication::create_remote_communication(
+        gateway_chip->get_tt_device(), cluster_desc->get_chip_location(chip_id), sysmem_manager);
+    remote_communication->set_remote_transfer_ethernet_cores(
+        gateway_chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(
+            cluster_desc->get_active_eth_channels(gateway_id), CoordSystem::TRANSLATED));
+
+    ChipInfo chip_info;
+    chip_info.noc_translation_enabled = soc_desc.noc_translation_enabled;
+    chip_info.harvesting_masks = soc_desc.harvesting_masks;
+    chip_info.board_type = cluster_desc->get_board_type(chip_id);
+    chip_info.board_id = cluster_desc->get_board_id_for_chip(chip_id);
+    chip_info.asic_location = cluster_desc->get_asic_location(chip_id);
+
+    // The simulated remote chip has no ARC, so hand its SocDescriptor to the remote TTDevice directly
+    // instead of letting init_tt_device construct one.
+    auto remote_tt_device = TTDevice::create_simulation_remote(std::move(remote_communication), soc_desc);
+    return RemoteChip::create_for_simulation(std::move(remote_tt_device), gateway_chip, chip_info);
+}
+#endif  // TT_UMD_BUILD_SIMULATION
+
 std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     ChipId chip_id,
     const ChipType& chip_type,
@@ -220,6 +249,9 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     }
     if (chip_type == ChipType::SIMULATION) {
 #ifdef TT_UMD_BUILD_SIMULATION
+        if (simulator_directory.extension() == ".so" && cluster_desc->is_chip_remote(chip_id)) {
+            return create_simulation_remote_chip(chip_id, cluster_desc, soc_desc);
+        }
         log_info(LogUMD, "Creating Simulation device");
         return SimulationChip::create(
             simulator_directory, soc_desc, chip_id, cluster_desc->get_number_of_chips(), num_host_mem_channels);
@@ -332,9 +364,7 @@ void Cluster::add_chip(const ChipId& chip_id, const ChipType& chip_type, std::un
         error::RuntimeError,
         fmt::format("Chip with id {} already exists in cluster. Cannot add another chip with the same id.", chip_id));
     all_chip_ids_.insert(chip_id);
-    // All non silicon chip types are considered local chips.
-    if (chip_type == ChipType::SIMULATION || chip_type == ChipType::SWEMULE ||
-        cluster_desc->is_chip_mmio_capable(chip_id)) {
+    if (chip_type == ChipType::SWEMULE || cluster_desc->is_chip_mmio_capable(chip_id)) {
         local_chip_ids_.insert(chip_id);
     } else {
         remote_chip_ids_.insert(chip_id);
@@ -1019,6 +1049,11 @@ void Cluster::broadcast_tensix_risc_reset_to_cluster(uint32_t reg_value) {
 
 void Cluster::set_clock_state(DevicePowerState device_state) {
     for (auto& [_, chip] : chips_) {
+        // ttsim remote chips cannot service ARC messages; skip power state transitions for them. Silicon remote chips
+        // are still handled over ethernet as before.
+        if (options_.chip_type == ChipType::SIMULATION && !chip->is_mmio_capable()) {
+            continue;
+        }
         chip->set_clock_state(device_state);
     }
 }
@@ -1035,6 +1070,11 @@ void Cluster::deassert_resets_and_set_clock_state() {
     // MT Initial BH - ARC messages not supported in Blackhole.
     if (arch_name != tt::ARCH::BLACKHOLE && arch_name != tt::ARCH::QUASAR) {
         for (const ChipId& chip : all_chip_ids_) {
+            // ttsim remote chips cannot service ARC messages; skip enabling their ethernet queue. Silicon remote chips
+            // are still initialized over ethernet as before.
+            if (options_.chip_type == ChipType::SIMULATION && !get_chip(chip)->is_mmio_capable()) {
+                continue;
+            }
             get_chip(chip)->enable_ethernet_queue();
         }
     }

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -645,7 +645,11 @@ ChipInfo TTDevice::get_chip_info() {
 
 uint32_t TTDevice::get_max_clock_freq() { return get_firmware_info_provider()->get_max_clock_freq(); }
 
-void TTDevice::advance_device_execution() {}
+void TTDevice::advance_device_execution() {
+    if (remote_capabilities_ != nullptr) {
+        remote_capabilities_->get_remote_communication()->get_local_device()->advance_device_execution();
+    }
+}
 
 uint32_t TTDevice::get_risc_reset_state(tt_xy_pair core) {
     uint32_t tensix_risc_state;


### PR DESCRIPTION
### Issue
Part of #2679, tracked by #2832. Split out of #2808; builds on #2954. Final integration slice.

### Description
Enumerate the full N300 topology for a multichip ttsim `.so` - the MMIO gateway (chip 0) and the remote chip (chip 1) over simulated ethernet - so device IO runs across both. A simulated remote chip has no ARC, so it is built via `Cluster::create_simulation_remote_chip` with its `SocDescriptor`/`ChipInfo` supplied directly and ARC-only steps (power state, ethernet-queue enable, close, reset) skipped in simulation mode; `advance_device_execution()` forwards to the gateway. Silicon remote-over-eth is unchanged.

### List of the changes
- Enumerate non-MMIO simulation chips as remote chips routed through the MMIO gateway (`create_for_simulation`, `create_simulation_remote_chip`).
- Skip ARC-only steps for simulated remote chips.
- Forward `advance_device_execution()` from a remote `TTDevice` to its gateway.
- CI: exercise the wh_x2 (N300) ttsim.

### Testing
CI

### API Changes
`RemoteChip` gains `create_for_simulation`.

Follow-up: the simulator-path helpers can be relocated out of `SimulationChip` to drop the remaining `TT_UMD_BUILD_SIMULATION` guards, once the base-API rework that would remove `SimulationChip` lands.
