### PR TITLE
Add basic ttsim microbenchmark tests

### DIFF
--- a/tests/microbenchmark/CMakeLists.txt
+++ b/tests/microbenchmark/CMakeLists.txt
@@ -4,6 +4,7 @@ set(MICROBENCHMARK_SRC_FILES
     benchmarks/open_cluster/test_open_cluster.cpp
     benchmarks/ethernet_io/test_ethernet_io.cpp
     benchmarks/iommu/test_iommu.cpp
+    benchmarks/simulator/test_simulator.cpp
 )
 add_executable(umd_microbenchmark ${MICROBENCHMARK_SRC_FILES})
 target_link_libraries(

--- a/tests/microbenchmark/benchmarks/open_cluster/test_open_cluster.cpp
+++ b/tests/microbenchmark/benchmarks/open_cluster/test_open_cluster.cpp
@@ -6,8 +6,6 @@
 #include <nanobench.h>
 
 #include <chrono>
-#include <cstdlib>
-#include <filesystem>
 #include <map>
 #include <memory>
 #include <string>
@@ -45,29 +43,6 @@ TEST(MicrobenchmarkOpenCluster, ClusterConstructor) {
 
     options.sdesc_path = test_utils::get_soc_descriptor_path(arch);
     bench.name("from sdesc").run([&] {
-        std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(options);
-        ankerl::nanobench::doNotOptimizeAway(cluster);
-    });
-    test::utils::export_results(bench);
-}
-
-TEST(MicrobenchmarkOpenClusterSim, ClusterConstructor) {
-    const char* sim_path = std::getenv("TT_UMD_SIMULATOR");
-    if (sim_path == nullptr) {
-        GTEST_SKIP() << "TT_UMD_SIMULATOR not set; skipping simulator startup benchmark.";
-    }
-
-    ClusterOptions options;
-    options.chip_type = ChipType::SIMULATION;
-    options.target_devices = {0};
-    options.simulator_directory = std::filesystem::path(sim_path);
-    options.num_host_mem_ch_per_mmio_device = 0;
-
-    auto bench = ankerl::nanobench::Bench()
-                     .maxEpochTime(std::chrono::seconds(30))
-                     .title("ClusterConstructorSim")
-                     .unit("cluster");
-    bench.name("default").run([&] {
         std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(options);
         ankerl::nanobench::doNotOptimizeAway(cluster);
     });

--- a/tests/microbenchmark/benchmarks/open_cluster/test_open_cluster.cpp
+++ b/tests/microbenchmark/benchmarks/open_cluster/test_open_cluster.cpp
@@ -6,6 +6,8 @@
 #include <nanobench.h>
 
 #include <chrono>
+#include <cstdlib>
+#include <filesystem>
 #include <map>
 #include <memory>
 #include <string>
@@ -43,6 +45,29 @@ TEST(MicrobenchmarkOpenCluster, ClusterConstructor) {
 
     options.sdesc_path = test_utils::get_soc_descriptor_path(arch);
     bench.name("from sdesc").run([&] {
+        std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(options);
+        ankerl::nanobench::doNotOptimizeAway(cluster);
+    });
+    test::utils::export_results(bench);
+}
+
+TEST(MicrobenchmarkOpenClusterSim, ClusterConstructor) {
+    const char* sim_path = std::getenv("TT_UMD_SIMULATOR");
+    if (sim_path == nullptr) {
+        GTEST_SKIP() << "TT_UMD_SIMULATOR not set; skipping simulator startup benchmark.";
+    }
+
+    ClusterOptions options;
+    options.chip_type = ChipType::SIMULATION;
+    options.target_devices = {0};
+    options.simulator_directory = std::filesystem::path(sim_path);
+    options.num_host_mem_ch_per_mmio_device = 0;
+
+    auto bench = ankerl::nanobench::Bench()
+                     .maxEpochTime(std::chrono::seconds(30))
+                     .title("ClusterConstructorSim")
+                     .unit("cluster");
+    bench.name("default").run([&] {
         std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(options);
         ankerl::nanobench::doNotOptimizeAway(cluster);
     });

--- a/tests/microbenchmark/benchmarks/simulator/test_simulator.cpp
+++ b/tests/microbenchmark/benchmarks/simulator/test_simulator.cpp
@@ -44,7 +44,7 @@ protected:
     ClusterOptions sim_options() const {
         ClusterOptions options;
         options.chip_type = ChipType::SIMULATION;
-        options.target_devices = {0};
+        options.target_devices = {CHIP_ID};
         options.simulator_directory = std::filesystem::path(sim_path_);
         options.num_host_mem_ch_per_mmio_device = 0;
         return options;

--- a/tests/microbenchmark/benchmarks/simulator/test_simulator.cpp
+++ b/tests/microbenchmark/benchmarks/simulator/test_simulator.cpp
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Microbenchmarks that run against the TTSim functional simulator (see tenstorrent/ttsim).
+
+#include <fmt/base.h>
+#include <gtest/gtest.h>
+#include <nanobench.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+#include <vector>
+
+#include "common/microbenchmark_utils.hpp"
+#include "umd/device/cluster.hpp"
+#include "umd/device/soc_descriptor.hpp"
+#include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+
+using namespace tt;
+using namespace tt::umd;
+using namespace tt::umd::test::utils;
+
+namespace {
+
+constexpr ChipId CHIP_ID = 0;
+constexpr uint64_t ADDRESS = 0x0;
+constexpr size_t TRANSFER_SIZE = 4 * ONE_KIB;
+
+class MicrobenchmarkSim : public ::testing::Test {
+protected:
+    void SetUp() override {
+        sim_path_ = std::getenv("TT_UMD_SIMULATOR");
+        if (sim_path_ == nullptr) {
+            GTEST_SKIP() << "TT_UMD_SIMULATOR not set; skipping simulator microbenchmark.";
+        }
+    }
+
+    ClusterOptions sim_options() const {
+        ClusterOptions options;
+        options.chip_type = ChipType::SIMULATION;
+        options.target_devices = {0};
+        options.simulator_directory = std::filesystem::path(sim_path_);
+        options.num_host_mem_ch_per_mmio_device = 0;
+        return options;
+    }
+
+    const char* sim_path_ = nullptr;
+};
+
+}  // namespace
+
+TEST_F(MicrobenchmarkSim, ClusterConstructor) {
+    ClusterOptions options = sim_options();
+    auto bench = ankerl::nanobench::Bench()
+                     .epochs(100)
+                     .maxEpochTime(std::chrono::seconds(30))
+                     .title("ClusterConstructorSim")
+                     .unit("cluster");
+    bench.name("default").run([&] {
+        std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(options);
+        ankerl::nanobench::doNotOptimizeAway(cluster);
+    });
+    test::utils::export_results(bench);
+}
+
+TEST_F(MicrobenchmarkSim, DeviceIO) {
+    std::unique_ptr<Cluster> cluster = std::make_unique<Cluster>(sim_options());
+    const CoreCoord tensix_core = cluster->get_soc_descriptor(CHIP_ID).get_cores(CoreType::TENSIX).at(0);
+
+    std::vector<uint8_t> pattern(TRANSFER_SIZE, 0xAB);
+    std::vector<uint8_t> readback(TRANSFER_SIZE);
+    auto bench = ankerl::nanobench::Bench().title("DeviceIOSim").unit("byte").epochs(50);
+    bench.batch(TRANSFER_SIZE).name(fmt::format("write, {} bytes", TRANSFER_SIZE)).run([&] {
+        cluster->write_to_device(pattern.data(), pattern.size(), CHIP_ID, tensix_core, ADDRESS);
+    });
+    bench.batch(TRANSFER_SIZE).name(fmt::format("read, {} bytes", TRANSFER_SIZE)).run([&] {
+        cluster->read_from_device(readback.data(), CHIP_ID, tensix_core, ADDRESS, TRANSFER_SIZE);
+    });
+    test::utils::export_results(bench);
+}


### PR DESCRIPTION
### Issue
#2603

### Description
Add basic cluster open and read/write microbenchmark for TTSim.

### List of the changes
 - Added two tests under microbenchmark/simulator/test_simulator.cpp

### Testing
Manual testing on remote machine.

### API Changes
This PR has no API changes.
