### PR TITLE
Simulation: UMD↔host wire protocol — messages + codec

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -4,27 +4,34 @@ set(POSITION_INDEPENDENT_CODE ON)
 include(CheckFunctionExists)
 
 if(TT_UMD_BUILD_SIMULATION)
-    set(FBS_FILE ${PROJECT_SOURCE_DIR}/device/simulation/simulation_device.fbs)
-    get_filename_component(FBS_FILE_NAME ${FBS_FILE} NAME_WLE)
-    set(FBS_GENERATED_HEADER "${CMAKE_CURRENT_BINARY_DIR}/${FBS_FILE_NAME}_generated.h")
+    set(FBS_FILES
+        ${PROJECT_SOURCE_DIR}/device/simulation/simulation_device.fbs
+        ${PROJECT_SOURCE_DIR}/device/simulation/simulation_server_protocol.fbs
+    )
     set(FBS_DEPENDS "")
     if(TARGET flatc)
         set(FBS_DEPENDS flatc)
     endif()
-    add_custom_command(
-        OUTPUT
-            ${FBS_GENERATED_HEADER}
-        COMMAND
-            flatc --cpp -o "${CMAKE_CURRENT_BINARY_DIR}" ${FBS_FILE}
-        DEPENDS
-            ${FBS_DEPENDS}
-            ${FBS_FILE}
-        COMMENT "Generating FlatBuffers header ${FBS_GENERATED_HEADER}"
-        VERBATIM
-    )
+    set(FBS_GENERATED_HEADERS "")
+    foreach(FBS_FILE ${FBS_FILES})
+        get_filename_component(FBS_FILE_NAME ${FBS_FILE} NAME_WLE)
+        set(FBS_GENERATED_HEADER "${CMAKE_CURRENT_BINARY_DIR}/${FBS_FILE_NAME}_generated.h")
+        add_custom_command(
+            OUTPUT
+                ${FBS_GENERATED_HEADER}
+            COMMAND
+                flatc --cpp -o "${CMAKE_CURRENT_BINARY_DIR}" ${FBS_FILE}
+            DEPENDS
+                ${FBS_DEPENDS}
+                ${FBS_FILE}
+            COMMENT "Generating FlatBuffers header ${FBS_GENERATED_HEADER}"
+            VERBATIM
+        )
+        list(APPEND FBS_GENERATED_HEADERS ${FBS_GENERATED_HEADER})
+    endforeach()
 
-    # Add FlatBuffers header to the code analysis target
-    add_custom_target(umd_device_generated_files DEPENDS ${FBS_GENERATED_HEADER})
+    # Add FlatBuffers headers to the code analysis target
+    add_custom_target(umd_device_generated_files DEPENDS ${FBS_GENERATED_HEADERS})
     add_dependencies(umd_all_generated_files umd_device_generated_files)
 endif()
 
@@ -149,6 +156,7 @@ if(TT_UMD_BUILD_SIMULATION)
         PRIVATE
             simulation/simulation_chip.cpp
             simulation/simulation_connector.cpp
+            simulation/simulation_server_protocol.cpp
             simulation/simulation_host.cpp
             simulation/tt_sim_communicator.cpp
             simulation/rtl_sim_communicator.cpp
@@ -161,7 +169,7 @@ if(TT_UMD_BUILD_SIMULATION)
             pcie/tt_sim_tlb_handle.cpp
             pcie/rtl_sim_tlb_window.cpp
             pcie/rtl_sim_tlb_handle.cpp
-            ${FBS_GENERATED_HEADER}
+            ${FBS_GENERATED_HEADERS}
     )
     target_compile_definitions(tt-umd PUBLIC TT_UMD_BUILD_SIMULATION)
 endif()

--- a/device/api/umd/device/simulation/simulation_server_protocol.hpp
+++ b/device/api/umd/device/simulation/simulation_server_protocol.hpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace tt::umd {
+
+// The one place that defines the UMD <-> simulation host wire protocol: the messages a UMD
+// client exchanges with a simulation host ("the card") over its per-chip UNIX socket, plus the
+// helpers that (de)serialize them. See simulation_server_protocol.fbs for the schema.
+//
+// Scope today is device-memory access -- the bulk of the traffic. It grows one message at a time
+// as the server work lands (session/attach, TLB windows, sysmem, run/reset, ...), at which point
+// the socket-backed client and the host serving layer marshal their operations through here.
+//
+// FlatBuffers stays an implementation detail (it lives in the .cpp); callers see only these plain
+// structs and free functions. Stream framing (length-prefixing messages on the socket) is a
+// transport concern and lives with the socket send/recv helpers, not here.
+
+// Direction of a device-memory access; mirrors wire::SimulationServerCommand in the schema.
+enum class SimulationServerCommand : int8_t {
+    Read = 0,
+    Write = 1,
+};
+
+// A device-memory access request addressed by (core x/y, address, size).
+struct SimulationServerRequest {
+    SimulationServerCommand command = SimulationServerCommand::Read;
+    uint32_t x = 0;
+    uint32_t y = 0;
+    uint64_t address = 0;
+    uint32_t size = 0;
+    // Bytes to write (length == size) for Write; empty for Read.
+    std::vector<uint8_t> data;
+};
+
+// The response to a SimulationServerRequest.
+struct SimulationServerResponse {
+    // 0 on success; nonzero signals a host-side failure.
+    int32_t status = 0;
+    // Bytes read (length == size on success) for Read; empty for Write.
+    std::vector<uint8_t> data;
+};
+
+// Serialize a message to a FlatBuffers payload.
+std::vector<uint8_t> encode(const SimulationServerRequest& request);
+std::vector<uint8_t> encode(const SimulationServerResponse& response);
+
+// Parse a message back from a FlatBuffers payload. The buffer is verified against the schema
+// before any field is read (it comes off a socket, so it may be malformed or truncated); a bad
+// or empty buffer throws error::RuntimeError rather than risking an out-of-bounds read.
+SimulationServerRequest decode_request(const uint8_t* data, size_t size);
+SimulationServerResponse decode_response(const uint8_t* data, size_t size);
+SimulationServerRequest decode_request(const std::vector<uint8_t>& bytes);
+SimulationServerResponse decode_response(const std::vector<uint8_t>& bytes);
+
+}  // namespace tt::umd

--- a/device/simulation/simulation_server_protocol.cpp
+++ b/device/simulation/simulation_server_protocol.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/simulation/simulation_server_protocol.hpp"
+
+#include <flatbuffers/flatbuffers.h>
+#include <fmt/format.h>
+
+#include "simulation_server_protocol_generated.h"
+#include "umd/device/utils/error.hpp"
+
+namespace tt::umd {
+
+namespace {
+
+// Verifies a FlatBuffers payload against schema table T (the buffer is untrusted socket input, so
+// this must run before any field access) and returns the parsed root. Throws on an empty, null,
+// or malformed/truncated buffer.
+template <typename T>
+const T* verify_and_get_root(const uint8_t* data, size_t size, const char* what) {
+    flatbuffers::Verifier verifier(data, size);
+    if (data == nullptr || !verifier.VerifyBuffer<T>(nullptr)) {
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format("Failed to verify simulation server protocol {} message ({} bytes)", what, size));
+    }
+    return flatbuffers::GetRoot<T>(data);
+}
+
+std::vector<uint8_t> to_bytes(const flatbuffers::FlatBufferBuilder& builder) {
+    return std::vector<uint8_t>(builder.GetBufferPointer(), builder.GetBufferPointer() + builder.GetSize());
+}
+
+}  // namespace
+
+std::vector<uint8_t> encode(const SimulationServerRequest& request) {
+    flatbuffers::FlatBufferBuilder builder;
+    auto data = builder.CreateVector(request.data);
+    builder.Finish(wire::CreateSimulationServerRequest(
+        builder,
+        static_cast<wire::SimulationServerCommand>(request.command),
+        request.x,
+        request.y,
+        request.address,
+        request.size,
+        data));
+    return to_bytes(builder);
+}
+
+std::vector<uint8_t> encode(const SimulationServerResponse& response) {
+    flatbuffers::FlatBufferBuilder builder;
+    auto data = builder.CreateVector(response.data);
+    builder.Finish(wire::CreateSimulationServerResponse(builder, response.status, data));
+    return to_bytes(builder);
+}
+
+SimulationServerRequest decode_request(const uint8_t* data, size_t size) {
+    const auto* fb = verify_and_get_root<wire::SimulationServerRequest>(data, size, "request");
+    SimulationServerRequest request;
+    request.command = static_cast<SimulationServerCommand>(fb->command());
+    request.x = fb->x();
+    request.y = fb->y();
+    request.address = fb->address();
+    request.size = fb->size();
+    if (fb->data() != nullptr) {
+        request.data.assign(fb->data()->begin(), fb->data()->end());
+    }
+    return request;
+}
+
+SimulationServerResponse decode_response(const uint8_t* data, size_t size) {
+    const auto* fb = verify_and_get_root<wire::SimulationServerResponse>(data, size, "response");
+    SimulationServerResponse response;
+    response.status = fb->status();
+    if (fb->data() != nullptr) {
+        response.data.assign(fb->data()->begin(), fb->data()->end());
+    }
+    return response;
+}
+
+SimulationServerRequest decode_request(const std::vector<uint8_t>& bytes) {
+    return decode_request(bytes.data(), bytes.size());
+}
+
+SimulationServerResponse decode_response(const std::vector<uint8_t>& bytes) {
+    return decode_response(bytes.data(), bytes.size());
+}
+
+}  // namespace tt::umd

--- a/device/simulation/simulation_server_protocol.fbs
+++ b/device/simulation/simulation_server_protocol.fbs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Wire schema for the UMD <-> simulation host protocol: the request/response messages a UMD
+// client exchanges with a simulation host ("the card") over its per-chip UNIX socket.
+//
+// This first step covers device-memory access -- the bulk of the traffic. A single request/
+// response pair carries a read or a write, selected by `command`. The op set grows one message
+// at a time as the server work lands (session/attach, TLB windows, sysmem, run/reset, ...).
+//
+// FlatBuffers is an implementation detail: only simulation_server_protocol.cpp includes the
+// generated header. Callers use the plain C++ structs and encode()/decode_*() in
+// simulation_server_protocol.hpp.
+//
+// Generated types live in the `wire` namespace so they never collide with the hand-written
+// tt::umd structs of the same name. A single-level namespace keeps the generated header clean
+// under clang-tidy (nested namespaces would trip modernize-concat-nested-namespaces).
+namespace wire;
+
+// Direction of a device-memory access.
+enum SimulationServerCommand : byte {
+    READ = 0,
+    WRITE = 1,
+}
+
+// A device-memory access addressed by (core x/y, address, size). For WRITE, `data` carries the
+// bytes to write (length == size); for READ it is empty (the size field states how many bytes to
+// read back).
+table SimulationServerRequest {
+    command : SimulationServerCommand;
+    x : uint32;
+    y : uint32;
+    address : uint64;
+    size : uint32;
+    data : [ubyte];
+}
+
+// The matching response. `status` is 0 on success and nonzero on a host-side failure. For READ,
+// `data` carries the bytes read (length == size on success); for WRITE it is empty.
+table SimulationServerResponse {
+    status : int32;
+    data : [ubyte];
+}
+
+// flatc requires a single root_type; the codec reads both messages uniformly via GetRoot<T>, so
+// the choice of which one is "root" is immaterial.
+root_type SimulationServerRequest;

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -24,6 +24,7 @@ set(API_TESTS_SRCS
 if(TT_UMD_BUILD_SIMULATION)
     list(APPEND API_TESTS_SRCS test_ttsim_device_io.cpp)
     list(APPEND API_TESTS_SRCS test_simulation_connector.cpp)
+    list(APPEND API_TESTS_SRCS test_simulation_server_protocol.cpp)
 endif()
 
 add_executable(api_tests ${API_TESTS_SRCS})

--- a/tests/api/test_simulation_server_protocol.cpp
+++ b/tests/api/test_simulation_server_protocol.cpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <exception>
+#include <vector>
+
+#include "umd/device/simulation/simulation_server_protocol.hpp"
+
+using namespace tt::umd;
+
+// A read request carries the access geometry and no payload; encode -> decode reproduces it.
+TEST(SimulationServerProtocol, ReadRequestRoundTrip) {
+    SimulationServerRequest request;
+    request.command = SimulationServerCommand::Read;
+    request.x = 3;
+    request.y = 5;
+    request.address = 0x1000'2000'3000'4000ULL;
+    request.size = 256;
+
+    const SimulationServerRequest decoded = decode_request(encode(request));
+
+    EXPECT_EQ(decoded.command, SimulationServerCommand::Read);
+    EXPECT_EQ(decoded.x, request.x);
+    EXPECT_EQ(decoded.y, request.y);
+    EXPECT_EQ(decoded.address, request.address);
+    EXPECT_EQ(decoded.size, request.size);
+    EXPECT_TRUE(decoded.data.empty());
+}
+
+// A write request carries its payload; encode -> decode reproduces geometry and bytes.
+TEST(SimulationServerProtocol, WriteRequestRoundTrip) {
+    SimulationServerRequest request;
+    request.command = SimulationServerCommand::Write;
+    request.x = 1;
+    request.y = 2;
+    request.address = 0xDEAD'BEEFULL;
+    request.data = {0x11, 0x22, 0x33, 0x44, 0x55};
+    request.size = static_cast<uint32_t>(request.data.size());
+
+    const SimulationServerRequest decoded = decode_request(encode(request));
+
+    EXPECT_EQ(decoded.command, SimulationServerCommand::Write);
+    EXPECT_EQ(decoded.x, request.x);
+    EXPECT_EQ(decoded.y, request.y);
+    EXPECT_EQ(decoded.address, request.address);
+    EXPECT_EQ(decoded.size, request.size);
+    EXPECT_EQ(decoded.data, request.data);
+}
+
+// A read response carries the bytes read and a success status.
+TEST(SimulationServerProtocol, ReadResponseRoundTrip) {
+    SimulationServerResponse response;
+    response.status = 0;
+    response.data = {0xAA, 0xBB, 0xCC};
+
+    const SimulationServerResponse decoded = decode_response(encode(response));
+
+    EXPECT_EQ(decoded.status, 0);
+    EXPECT_EQ(decoded.data, response.data);
+}
+
+// A failed response carries a nonzero status and no payload.
+TEST(SimulationServerProtocol, ErrorResponseRoundTrip) {
+    SimulationServerResponse response;
+    response.status = -5;
+
+    const SimulationServerResponse decoded = decode_response(encode(response));
+
+    EXPECT_EQ(decoded.status, -5);
+    EXPECT_TRUE(decoded.data.empty());
+}
+
+// An empty buffer can never be a valid message; decoding it fails rather than reading nothing.
+TEST(SimulationServerProtocol, DecodeEmptyBufferThrows) {
+    const std::vector<uint8_t> empty;
+    EXPECT_THROW(decode_request(empty), std::exception);
+    EXPECT_THROW(decode_response(empty), std::exception);
+}
+
+// A truncated payload (a valid message cut short, as a partial socket read would produce) fails
+// verification instead of reading out of bounds.
+TEST(SimulationServerProtocol, DecodeTruncatedBufferThrows) {
+    SimulationServerRequest request;
+    request.command = SimulationServerCommand::Read;
+    request.size = 64;
+    std::vector<uint8_t> encoded = encode(request);
+    ASSERT_GT(encoded.size(), 4u);
+    encoded.resize(encoded.size() / 2);  // chop it in half
+
+    EXPECT_THROW(decode_request(encoded), std::exception);
+}


### PR DESCRIPTION
### Issue
Part of #2677 (simulation server process). First slice of #2793 (define the UMD ↔ host API: protocol + capability surface). Builds on the merged SimulationClient / SimulationServerSocket / SimulationConnector work.

### Description
Adds the UMD ↔ simulation-host wire protocol: the request/response messages a client exchanges with a host ("the card") over its per-chip UNIX socket, plus a thin C++ codec. This is the contract both sides compile against; it wires neither side yet (the socket-backed client and the host serving layer are follow-ups).

Scope is intentionally narrow: one message pair for device-memory access — the bulk of the traffic — discriminated by a READ/WRITE command. The op set grows one message at a time as the server work lands (session/attach, TLB, sysmem, run/reset, …).

- FlatBuffers stays an implementation detail: generated types live in the `wire` namespace and only the .cpp includes the generated header; callers see plain structs.
- Stream framing is a transport concern, deliberately left out — it lands with the socket send/recv helpers.

### List of the changes
- New `simulation_server_protocol.{fbs,hpp,cpp}` — wire schema, public structs (`SimulationServerCommand/Request/Response`), and the FlatBuffers codec.
- New `tests/api/test_simulation_server_protocol.cpp` — 6 round-trip / malformed tests.
- `device/CMakeLists.txt` (multi-.fbs codegen + codec source), `tests/api/CMakeLists.txt` (register test). Both simulation-gated.

### Testing
`SimulationServerProtocol` (6 tests) pass; build + pre-commit clean.

### API Changes
New public header `umd/device/simulation/simulation_server_protocol.hpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
