### PR TITLE
Simulation: framed message transport over the host socket

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -148,6 +148,9 @@ target_sources(
         # (TT_UMD_BUILD_SIMULATION=OFF).
         simulation/simulation_server_socket.cpp
         simulation/simulation_client.cpp
+        # Length-prefixed message framing over the socket (uses asio, a core dependency; no
+        # FlatBuffers), so it is always built and unit-tested in the same no-card baremetal lane.
+        simulation/simulation_server_transport.cpp
 )
 
 if(TT_UMD_BUILD_SIMULATION)

--- a/device/simulation/simulation_server_transport.cpp
+++ b/device/simulation/simulation_server_transport.cpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "simulation/simulation_server_transport.hpp"
+
+#include <fmt/format.h>
+
+#include <array>
+#include <asio.hpp>
+#include <system_error>
+
+#include "umd/device/utils/error.hpp"
+
+namespace tt::umd {
+
+namespace {
+
+using stream_protocol = asio::local::stream_protocol;
+
+constexpr size_t FRAME_HEADER_SIZE = sizeof(uint32_t);
+
+// Upper bound on a single framed payload. The length prefix comes off an untrusted socket, so a
+// garbled or malicious peer could otherwise advertise up to 4 GiB and make recv_framed() attempt a
+// huge allocation. Cap it well below that at a size no legitimate device-memory transfer reaches;
+// anything larger is rejected before allocating.
+constexpr uint32_t MAX_FRAME_PAYLOAD_SIZE = 1u << 30;  // 1 GiB
+
+// asio::write/asio::read transfer exactly n bytes or set ec (short transfer on a closed peer, etc.);
+// convert any failure to a RuntimeError. asio sets MSG_NOSIGNAL on the send, so a closed peer is an
+// error here, never a SIGPIPE.
+void write_exact(stream_protocol::socket& socket, const uint8_t* data, size_t n, const char* what) {
+    std::error_code ec;
+    asio::write(socket, asio::buffer(data, n), ec);
+    if (ec) {
+        UMD_THROW(
+            error::RuntimeError, fmt::format("Simulation server transport failed to write {}: {}", what, ec.message()));
+    }
+}
+
+void read_exact(stream_protocol::socket& socket, uint8_t* data, size_t n, const char* what) {
+    std::error_code ec;
+    asio::read(socket, asio::buffer(data, n), ec);
+    if (ec) {
+        UMD_THROW(
+            error::RuntimeError, fmt::format("Simulation server transport failed to read {}: {}", what, ec.message()));
+    }
+}
+
+}  // namespace
+
+void send_framed(stream_protocol::socket& socket, const std::vector<uint8_t>& payload) {
+    // Bounded so the length always fits the uint32_t prefix and matches what recv_framed() will
+    // accept; anything larger is a programming error rather than a truncation.
+    UMD_ASSERT(
+        payload.size() <= MAX_FRAME_PAYLOAD_SIZE,
+        error::RuntimeError,
+        fmt::format(
+            "Simulation server transport payload too large to frame ({} bytes, max {})",
+            payload.size(),
+            MAX_FRAME_PAYLOAD_SIZE));
+    const uint32_t length = static_cast<uint32_t>(payload.size());
+    const std::array<uint8_t, FRAME_HEADER_SIZE> header = {
+        static_cast<uint8_t>(length & 0xFF),
+        static_cast<uint8_t>((length >> 8) & 0xFF),
+        static_cast<uint8_t>((length >> 16) & 0xFF),
+        static_cast<uint8_t>((length >> 24) & 0xFF),
+    };
+    // Write the header and payload separately so a large payload is not copied into a combined
+    // frame buffer first.
+    write_exact(socket, header.data(), header.size(), "frame header");
+    if (!payload.empty()) {
+        write_exact(socket, payload.data(), payload.size(), "frame payload");
+    }
+}
+
+std::vector<uint8_t> recv_framed(stream_protocol::socket& socket) {
+    std::array<uint8_t, FRAME_HEADER_SIZE> header;
+    read_exact(socket, header.data(), header.size(), "frame header");
+    const uint32_t length = static_cast<uint32_t>(header[0]) | (static_cast<uint32_t>(header[1]) << 8) |
+                            (static_cast<uint32_t>(header[2]) << 16) | (static_cast<uint32_t>(header[3]) << 24);
+
+    // Reject an implausible length from the untrusted prefix before allocating, so a bad peer
+    // can't drive a multi-GB allocation (or std::bad_alloc).
+    UMD_ASSERT(
+        length <= MAX_FRAME_PAYLOAD_SIZE,
+        error::RuntimeError,
+        fmt::format(
+            "Simulation server transport received an oversized frame ({} bytes, max {})",
+            length,
+            MAX_FRAME_PAYLOAD_SIZE));
+
+    std::vector<uint8_t> payload(length);
+    if (length > 0) {
+        read_exact(socket, payload.data(), length, "frame payload");
+    }
+    return payload;
+}
+
+}  // namespace tt::umd

--- a/device/simulation/simulation_server_transport.hpp
+++ b/device/simulation/simulation_server_transport.hpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <asio/local/stream_protocol.hpp>
+#include <cstdint>
+#include <vector>
+
+namespace tt::umd {
+
+// Framed message transport over a connected UNIX-domain stream socket.
+//
+// A SOCK_STREAM socket has no message boundaries, so each message is length-prefixed on the wire:
+// a 4-byte little-endian payload length, then the payload. send_framed() writes one framed
+// message; recv_framed() reads exactly one back, blocking until the whole payload has arrived.
+// This is what lets the protocol messages (simulation_server_protocol.hpp) travel intact between a
+// UMD client and a simulation host.
+//
+// I/O goes through asio::read/asio::write on the connected socket: they transfer exactly the
+// requested byte count (or fail), and on Linux asio sets MSG_NOSIGNAL, so writing to a closed peer
+// surfaces as a thrown error rather than raising SIGPIPE. The socket must be in blocking mode (its
+// owner clears any non-blocking flag asio leaves after connect/accept). Payloads are opaque here;
+// encoding/decoding is the protocol layer's job.
+//
+// Every failure (peer closed mid-message, oversized frame, socket error) throws error::RuntimeError.
+
+// Length-prefix and write one whole message to the socket.
+void send_framed(asio::local::stream_protocol::socket& socket, const std::vector<uint8_t>& payload);
+
+// Read exactly one length-prefixed message from the socket, blocking until it is complete.
+std::vector<uint8_t> recv_framed(asio::local::stream_protocol::socket& socket);
+
+}  // namespace tt::umd

--- a/tests/baremetal/CMakeLists.txt
+++ b/tests/baremetal/CMakeLists.txt
@@ -12,6 +12,7 @@ set(BAREMETAL_TESTS_SRCS
     # their tests need no card and no simulation build -- they run in the no-card baremetal CI lane.
     test_simulation_server_socket.cpp
     test_simulation_client.cpp
+    test_simulation_server_transport.cpp
 )
 
 add_executable(baremetal_tests ${BAREMETAL_TESTS_SRCS})

--- a/tests/baremetal/test_simulation_server_transport.cpp
+++ b/tests/baremetal/test_simulation_server_transport.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <asio.hpp>
+#include <cstdint>
+#include <exception>
+#include <thread>
+#include <vector>
+
+#include "simulation/simulation_server_transport.hpp"
+
+using namespace tt::umd;
+using stream_protocol = asio::local::stream_protocol;
+
+// A connected UNIX SOCK_STREAM pair (asio's local connect_pair), mirroring the framed client/host
+// connection without needing a bound socket path. Closing one end simulates a peer going away.
+class SimulationServerTransportTest : public ::testing::Test {
+protected:
+    void SetUp() override { asio::local::connect_pair(a_, b_); }
+
+    asio::io_context io_;
+    stream_protocol::socket a_{io_};
+    stream_protocol::socket b_{io_};
+};
+
+// A message sent on one end comes back whole on the other.
+TEST_F(SimulationServerTransportTest, SingleMessageRoundTrip) {
+    const std::vector<uint8_t> payload = {0x01, 0x02, 0x03, 0x04, 0x05};
+
+    send_framed(a_, payload);
+    EXPECT_EQ(recv_framed(b_), payload);
+}
+
+// Framing keeps message boundaries on a stream: two messages sent back-to-back are read back as
+// two distinct messages, not one merged blob.
+TEST_F(SimulationServerTransportTest, BackToBackMessagesPreserveBoundaries) {
+    const std::vector<uint8_t> first = {0xAA};
+    const std::vector<uint8_t> second = {0xBB, 0xCC, 0xDD};
+
+    send_framed(a_, first);
+    send_framed(a_, second);
+
+    EXPECT_EQ(recv_framed(b_), first);
+    EXPECT_EQ(recv_framed(b_), second);
+}
+
+// A zero-length payload is a valid frame (just the length prefix).
+TEST_F(SimulationServerTransportTest, EmptyPayloadRoundTrip) {
+    send_framed(a_, {});
+    EXPECT_TRUE(recv_framed(b_).empty());
+}
+
+// A payload larger than the socket buffer arrives across multiple reads. The send runs on a thread
+// because such a write can block until the reader drains the buffer.
+TEST_F(SimulationServerTransportTest, LargePayloadSpanningMultipleReads) {
+    std::vector<uint8_t> payload(1u << 20);
+    for (size_t i = 0; i < payload.size(); ++i) {
+        payload[i] = static_cast<uint8_t>(i);
+    }
+
+    std::thread sender([&] { send_framed(a_, payload); });
+    const std::vector<uint8_t> received = recv_framed(b_);
+    sender.join();
+
+    EXPECT_EQ(received, payload);
+}
+
+// If the peer closes at a message boundary (no message coming), recv surfaces an error rather than
+// blocking forever or returning a bogus empty message.
+TEST_F(SimulationServerTransportTest, RecvThrowsWhenPeerCloses) {
+    a_.close();
+
+    EXPECT_THROW(recv_framed(b_), std::exception);
+}
+
+// A message cut short (header promises more than is delivered, then the peer goes away) fails
+// instead of returning a partial payload.
+TEST_F(SimulationServerTransportTest, RecvThrowsOnTruncatedMessage) {
+    const uint8_t header[4] = {10, 0, 0, 0};  // claims a 10-byte payload
+    asio::write(a_, asio::buffer(header, sizeof(header)));
+    const uint8_t partial[3] = {1, 2, 3};  // but only 3 bytes follow
+    asio::write(a_, asio::buffer(partial, sizeof(partial)));
+    a_.close();
+
+    EXPECT_THROW(recv_framed(b_), std::exception);
+}
+
+// A header advertising an absurdly large payload is rejected at the length check, before recv
+// tries to allocate it -- an untrusted/garbled peer can't trigger a multi-GB allocation.
+TEST_F(SimulationServerTransportTest, RecvThrowsOnOversizedFrame) {
+    const uint8_t header[4] = {0xFF, 0xFF, 0xFF, 0xFF};  // ~4 GiB length prefix
+    asio::write(a_, asio::buffer(header, sizeof(header)));
+
+    EXPECT_THROW(recv_framed(b_), std::exception);
+}
+
+// Sending to a peer that has closed surfaces as a thrown error, not a SIGPIPE that kills the
+// process (asio sets MSG_NOSIGNAL on the write).
+TEST_F(SimulationServerTransportTest, SendToClosedPeerThrowsRatherThanRaisingSigpipe) {
+    b_.close();
+
+    EXPECT_THROW(send_framed(a_, {0x01, 0x02, 0x03}), std::exception);
+}


### PR DESCRIPTION
### Issue
Part of #2677 (simulation server process). The transport half of the UMD ↔ host socket path; pairs with the wire protocol from #2967 (merged to `main`).

### Description
Adds `send_framed()` / `recv_framed()`: move one length-prefixed message (a 4-byte little-endian length, then the payload) over a connected UNIX-domain stream socket. A `SOCK_STREAM` socket has no message boundaries, so this framing is what lets the protocol messages travel intact between a UMD client and a simulation host.

- I/O goes through `asio::read`/`asio::write` on the connected `asio::local::stream_protocol::socket` — exact-N transfers, and asio sets `MSG_NOSIGNAL` on Linux, so writing to a closed peer surfaces as a thrown error rather than raising `SIGPIPE`. The socket must be in blocking mode (its owner clears any non-blocking flag asio leaves after connect/accept).
- `recv_framed` rejects an oversized length prefix (`MAX_FRAME_PAYLOAD_SIZE`, 1 GiB) before allocating, so a garbled/untrusted peer can't drive a multi-GB allocation.
- Payloads are opaque — encoding/decoding is the protocol layer's job.

### List of the changes
- New `device/simulation/simulation_server_transport.{hpp,cpp}`.
- New `tests/baremetal/test_simulation_server_transport.cpp` — 8 tests (single / empty / back-to-back / >1 MB payloads, peer-close, truncated, oversized-frame, SIGPIPE-safe send), using `asio::local::connect_pair`.
- `device/CMakeLists.txt` (always-built source), `tests/baremetal/CMakeLists.txt` (register test). Always built — asio is a core dependency; no simulation deps.

### Testing
`SimulationServerTransport` (8 tests) pass in the no-card baremetal lane; build + pre-commit clean.

### API Changes
None (internal `simulation/` header, not part of the public UMD API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
