### PR TITLE
Allow overriding x86 -march for Ivy Bridge hosts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,8 +142,10 @@ if(NOT DEFINED CMAKE_COMPILE_WARNING_AS_ERROR)
     set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 endif()
 
+set(TT_X86_MARCH "x86-64-v3" CACHE STRING "x86_64 architecture passed to -march")
+
 add_compile_options(
-    "$<$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},x86_64>:-march=x86-64-v3>"
+    "$<$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},x86_64>:-march=${TT_X86_MARCH}>"
     -Wall
     -Wno-sign-compare
 )


### PR DESCRIPTION
## Summary
- add TT_X86_MARCH CMake cache variable for x86_64 host builds
- keep the existing default at x86-64-v3 so modern hosts retain current optimizations
- allow older hosts to configure with -DTT_X86_MARCH=ivybridge

## Motivation
Ivy Bridge hosts support AVX but not the full x86-64-v3 baseline, so prebuilt/default host code can fault with illegal instructions. This keeps the optimized default while making source builds possible on older compatible hosts.