### PR TITLE
Disable exalens tests on n300

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -251,7 +251,8 @@ jobs:
         test-group: [
           {runs-on: tt-ubuntu-2204-p150b-stable},
           {runs-on: tt-ubuntu-2204-n150-stable},
-          {runs-on: tt-ubuntu-2204-n300-stable},
+          # TODO: Re-enable once exalens tests NOC0 hang bug is resolved.
+          # {runs-on: tt-ubuntu-2204-n300-stable},
         ]
         ubuntu-docker-version: [
           'ubuntu-22.04',

--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -251,7 +251,7 @@ jobs:
         test-group: [
           {runs-on: tt-ubuntu-2204-p150b-stable},
           {runs-on: tt-ubuntu-2204-n150-stable},
-          # TODO: Re-enable once exalens tests NOC0 hang bug is resolved.
+          # TODO(#2981): Re-enable once exalens tests NOC0 hang bug is resolved.
           # {runs-on: tt-ubuntu-2204-n300-stable},
         ]
         ubuntu-docker-version: [


### PR DESCRIPTION
### Issue
#2981

### Description
Temporarily disable exalens tests on n300 due to NOC0 hang bug during discovery in exalens tests. Pending investigation.

