### PR TITLE
Simulation: serve client requests on the host socket

### DIFF
--- a/device/simulation/simulation_server_socket.cpp
+++ b/device/simulation/simulation_server_socket.cpp
@@ -8,10 +8,14 @@
 #include <sys/un.h>  // sockaddr_un::sun_path, for the path-length guard
 
 #include <asio.hpp>
+#include <atomic>
 #include <memory>
+#include <mutex>
 #include <system_error>
 #include <thread>
+#include <vector>
 
+#include "simulation/simulation_server_transport.hpp"
 #include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
@@ -42,6 +46,20 @@ struct SimulationServerSocket::Impl {
     asio::io_context io;
     stream_protocol::acceptor acceptor{io};
     std::thread io_thread;
+
+    // Per-connection serving state, held only while a handler is set. Finished connections (peer
+    // disconnected, flagged by the serving thread) are reaped so this doesn't grow unbounded across
+    // connect/disconnect cycles. Guarded: registered/reaped on the io_thread, torn down on the
+    // destructor thread.
+    struct Connection {
+        std::shared_ptr<stream_protocol::socket> socket;
+        std::thread thread;
+        std::shared_ptr<std::atomic<bool>> finished;
+    };
+
+    std::mutex connections_mutex;
+    std::vector<Connection> connections;
+    bool stopping = false;
 };
 
 SimulationServerSocket::SimulationServerSocket(const std::filesystem::path& socket_path) :
@@ -52,6 +70,8 @@ std::unique_ptr<SimulationServerSocket> SimulationServerSocket::try_create(const
     if (!socket->bind_and_listen()) {
         return nullptr;
     }
+    // Bound and connectable now (presence/liveness); serving begins when serve() is called with a
+    // handler bound to the owner's backend.
     return socket;
 }
 
@@ -64,14 +84,79 @@ std::unique_ptr<SimulationServerSocket> SimulationServerSocket::create(const std
     return socket;
 }
 
+void SimulationServerSocket::serve(RequestHandler request_handler) {
+    UMD_ASSERT(bound_, error::RuntimeError, "serve() called on a simulation server socket that is not bound.");
+    UMD_ASSERT(
+        static_cast<bool>(request_handler), error::RuntimeError, "serve() requires a non-empty request handler.");
+    UMD_ASSERT(
+        !impl_->io_thread.joinable(),
+        error::RuntimeError,
+        "serve() called on a simulation server socket already serving.");
+
+    // Install the handler before the accept loop starts, so it is set before any connection
+    // thread reads it -- no mutation of request_handler_ once the io_thread is running.
+    request_handler_ = std::move(request_handler);
+    do_accept();
+    impl_->io_thread = std::thread([this] { impl_->io.run(); });
+}
+
 void SimulationServerSocket::do_accept() {
     auto sock = std::make_shared<stream_protocol::socket>(impl_->io);
     impl_->acceptor.async_accept(*sock, [this, sock](const std::error_code& ec) {
-        // A non-aborted error or io_context::stop() (teardown) ends the loop; otherwise
-        // drop this connection (liveness only) and re-arm.
+        // A non-aborted error or io_context::stop() (teardown) ends the loop.
         if (ec) {
             return;
         }
+
+        // Serve the connection on its own thread until the peer disconnects. do_accept only runs
+        // while serving, so request_handler_ is always set here.
+        // asio leaves accepted sockets non-blocking (for async I/O); the serving thread does
+        // synchronous, blocking transport reads/writes on it, so clear that flag first. If that
+        // fails, the blocking reads/writes would error immediately -- drop this connection cleanly
+        // and keep accepting rather than spawn a thread that can't serve.
+        std::error_code block_ec;
+        sock->native_non_blocking(false, block_ec);
+        if (block_ec) {
+            do_accept();
+            return;
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(impl_->connections_mutex);
+            // A connection accepted during teardown is simply dropped (sock released here).
+            if (!impl_->stopping) {
+                // Reap connections whose serving thread has already exited (peer disconnected), so
+                // the bookkeeping doesn't grow without bound across connect/disconnect cycles.
+                for (auto it = impl_->connections.begin(); it != impl_->connections.end();) {
+                    if (it->finished->load()) {
+                        if (it->thread.joinable()) {
+                            it->thread.join();
+                        }
+                        it = impl_->connections.erase(it);
+                    } else {
+                        ++it;
+                    }
+                }
+
+                // Capture the handler by copy so the thread never touches `this`; keep `sock`
+                // alive so the socket stays open for the whole session; set `finished` on exit so
+                // this connection can be reaped above.
+                auto finished = std::make_shared<std::atomic<bool>>(false);
+                std::thread thread([handler = request_handler_, sock, finished] {
+                    try {
+                        while (true) {
+                            send_framed(*sock, handler(recv_framed(*sock)));
+                        }
+                    } catch (const std::exception&) {
+                        // Peer disconnected (recv_framed threw on EOF) or a socket error: the
+                        // session ends. Teardown joins this thread; the socket closes with `sock`.
+                    }
+                    finished->store(true);
+                });
+                impl_->connections.push_back({sock, std::move(thread), finished});
+            }
+        }
+
         do_accept();
     });
 }
@@ -199,8 +284,7 @@ bool SimulationServerSocket::bind_and_listen() {
             fmt::format("Failed to listen on simulation server socket at {}: {}", socket_path_.string(), ec.message()));
     }
 
-    do_accept();
-    impl_->io_thread = std::thread([this] { impl_->io.run(); });
+    // Bound and connectable (liveness) now; the accept loop and io_thread start in serve().
     bound_ = true;
     return true;
 }
@@ -213,6 +297,23 @@ SimulationServerSocket::~SimulationServerSocket() {
     if (!bound_) {
         return;
     }
+
+    // Stop serving: mark stopping (so a racing accept won't start a new session) and shut down
+    // every live connection so its serving thread, blocked in recv_framed, sees EOF and exits.
+    {
+        std::lock_guard<std::mutex> lock(impl_->connections_mutex);
+        impl_->stopping = true;
+        for (const auto& connection : impl_->connections) {
+            std::error_code ec;
+            connection.socket->shutdown(stream_protocol::socket::shutdown_both, ec);
+        }
+    }
+    for (auto& connection : impl_->connections) {
+        if (connection.thread.joinable()) {
+            connection.thread.join();
+        }
+    }
+
     // Wake the accept loop and let impl_->io.run() return; the acceptor fd is closed by the
     // acceptor's destructor (RAII) when impl_ is destroyed.
     impl_->io.stop();

--- a/device/simulation/simulation_server_socket.hpp
+++ b/device/simulation/simulation_server_socket.hpp
@@ -4,8 +4,11 @@
 
 #pragma once
 
+#include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <memory>
+#include <vector>
 
 #include "umd/device/types/cluster_descriptor_types.hpp"
 
@@ -20,7 +23,17 @@ namespace tt::umd {
 // sockets left by crashed owners are automatically reclaimed. On destruction the host closes
 // the socket and removes the file.
 //
-// It does not yet handle client requests: connections are accepted and dropped.
+// Request handling is split from binding, so the owner can claim the socket first and begin
+// serving only once its backend is ready (the handler dispatches into that backend, which does
+// not exist at bind time -- see the host device's adopt_socket()):
+//   - bind (try_create/create): the socket is bound and connectable -- pure presence/liveness --
+//     but accepts nothing until serve() is called.
+//   - serve(handler): starts the accept loop; each accepted connection is served on its own
+//     thread, which reads one length-prefixed request at a time (see simulation_server_transport),
+//     passes the opaque request bytes to the handler, and writes back the framed reply, until the
+//     peer disconnects. The socket layer stays protocol-agnostic (it moves opaque payloads); the
+//     handler owns encoding/decoding and dispatch. Because a client may share the host, the
+//     handler must be safe to call from multiple connection threads.
 //
 // Internal to the simulation subsystem (not part of the public UMD API). The asio transport
 // is held behind a pImpl so this header stays free of asio (a private dependency of the
@@ -30,18 +43,28 @@ namespace tt::umd {
 // simulator process connects back into UMD.
 class SimulationServerSocket {
 public:
+    // Serves a single connection: opaque request payload in, opaque reply payload out. Called on
+    // a per-connection thread; must be thread-safe if more than one client attaches.
+    using RequestHandler = std::function<std::vector<uint8_t>(const std::vector<uint8_t>&)>;
+
     ~SimulationServerSocket();
 
     SimulationServerSocket(const SimulationServerSocket&) = delete;
     SimulationServerSocket& operator=(const SimulationServerSocket&) = delete;
 
     // Binds and listens, reclaiming a stale socket. Returns nullptr if a *live* owner already
-    // holds the path (so the caller can attach as a client). Throws on real socket errors.
+    // holds the path (so the caller can attach as a client). Throws on real socket errors. The
+    // socket is presence-only (bound + connectable) until serve() installs a handler.
     static std::unique_ptr<SimulationServerSocket> try_create(const std::filesystem::path& socket_path);
 
     // Like try_create(), but throws (instead of returning nullptr) when a live owner already
     // holds the path. For callers that require ownership and have no client path to fall back to.
     static std::unique_ptr<SimulationServerSocket> create(const std::filesystem::path& socket_path);
+
+    // Starts serving accepted connections through request_handler (see the class comment). Call
+    // once, after the backend the handler dispatches into is ready. The handler is installed
+    // before the accept loop starts, so it is set before any connection thread reads it.
+    void serve(RequestHandler request_handler);
 
     const std::filesystem::path& socket_path() const { return socket_path_; }
 
@@ -55,18 +78,23 @@ private:
     // the try_create()/create() factories.
     explicit SimulationServerSocket(const std::filesystem::path& socket_path);
 
-    // Binds + listens + starts the accept loop. Returns false if a live owner holds the path;
-    // throws on real socket errors.
+    // Binds + listens (claims the path; connectable for liveness). Does not accept yet -- the
+    // accept loop starts in serve(). Returns false if a live owner holds the path; throws on real
+    // socket errors.
     bool bind_and_listen();
 
     // True if a listener is currently reachable at socket_path_.
     bool is_live();
 
-    // Re-arms the async accept; connections carry no requests yet (owner-only), so each
-    // accepted socket is dropped immediately.
+    // Re-arms the async accept; each accepted connection is handed to a serving thread. Only ever
+    // runs while serving (serve() started it), so request_handler_ is always set here.
     void do_accept();
 
     std::filesystem::path socket_path_;
+    // Opaque request/reply handler, installed by serve(). Empty until then: with no handler the
+    // accept loop never starts (serve() starts it), so the socket is presence-only -- it binds and
+    // is connectable for liveness, but accepts nothing.
+    RequestHandler request_handler_;
     // True only after a successful bind_and_listen(); gates teardown so a never-bound
     // object never removes a live owner's socket file.
     bool bound_ = false;

--- a/tests/baremetal/test_simulation_server_socket.cpp
+++ b/tests/baremetal/test_simulation_server_socket.cpp
@@ -7,14 +7,19 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#include <asio.hpp>
+#include <cstdint>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <vector>
 
 #include "simulation/simulation_server_socket.hpp"
+#include "simulation/simulation_server_transport.hpp"
 
 using namespace tt::umd;
+using stream_protocol = asio::local::stream_protocol;
 
 namespace {
 
@@ -36,6 +41,15 @@ bool can_connect(const std::filesystem::path& path) {
     bool ok = ::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0;
     ::close(fd);
     return ok;
+}
+
+// Connects an asio UNIX socket (blocking) to the server at path, for framed transport I/O. Shares
+// the caller's io_context; the socket closes on destruction.
+stream_protocol::socket connect_client(asio::io_context& io, const std::filesystem::path& path) {
+    stream_protocol::socket socket(io);
+    socket.connect(stream_protocol::endpoint(path.string()));
+    socket.native_non_blocking(false);
+    return socket;
 }
 
 // Binds a UNIX socket to path then closes it without listening, leaving a stale
@@ -124,6 +138,88 @@ TEST_F(SimulationServerSocketTest, RefusesToReclaimNonSocketFile) {
 
     EXPECT_THROW(SimulationServerSocket::try_create(path_), std::exception);
     EXPECT_TRUE(std::filesystem::exists(path_));  // the regular file was left untouched
+}
+
+// Inverts every byte, so a served reply is distinguishable from the request that produced it.
+std::vector<uint8_t> invert(const std::vector<uint8_t>& request) {
+    std::vector<uint8_t> reply = request;
+    for (uint8_t& byte : reply) {
+        byte = static_cast<uint8_t>(~byte);
+    }
+    return reply;
+}
+
+// With a handler, a framed request is served and the framed reply comes back transformed.
+TEST_F(SimulationServerSocketTest, ServesRequestsThroughHandler) {
+    auto server = SimulationServerSocket::create(path_);
+    server->serve(invert);
+    asio::io_context io;
+    stream_protocol::socket client = connect_client(io, path_);
+
+    const std::vector<uint8_t> request = {0x01, 0x02, 0x03};
+    send_framed(client, request);
+
+    EXPECT_EQ(recv_framed(client), invert(request));
+}
+
+// One connection carries many request/reply turns in sequence.
+TEST_F(SimulationServerSocketTest, HandlesSequentialRequestsOnOneConnection) {
+    auto server = SimulationServerSocket::create(path_);
+    server->serve([](const std::vector<uint8_t>& request) { return request; });
+    asio::io_context io;
+    stream_protocol::socket client = connect_client(io, path_);
+
+    for (uint8_t i = 0; i < 5; ++i) {
+        const std::vector<uint8_t> request = {i, static_cast<uint8_t>(i + 1)};
+        send_framed(client, request);
+        EXPECT_EQ(recv_framed(client), request);
+    }
+}
+
+// Two clients are served concurrently (a thread per connection); neither sees the other's data.
+TEST_F(SimulationServerSocketTest, SupportsMultipleClients) {
+    auto server = SimulationServerSocket::create(path_);
+    server->serve([](const std::vector<uint8_t>& request) { return request; });
+    asio::io_context io;
+    stream_protocol::socket first = connect_client(io, path_);
+    stream_protocol::socket second = connect_client(io, path_);
+
+    send_framed(first, {0xAA});
+    send_framed(second, {0xBB});
+    EXPECT_EQ(recv_framed(first), (std::vector<uint8_t>{0xAA}));
+    EXPECT_EQ(recv_framed(second), (std::vector<uint8_t>{0xBB}));
+}
+
+// Destroying the server while a client is still connected must not hang: the serving thread,
+// blocked in recv_framed, is unblocked and joined during teardown. The client then sees EOF.
+TEST_F(SimulationServerSocketTest, TearsDownCleanlyWithClientConnected) {
+    asio::io_context io;
+    stream_protocol::socket client(io);
+    {
+        auto server = SimulationServerSocket::create(path_);
+        server->serve([](const std::vector<uint8_t>& request) { return request; });
+        client = connect_client(io, path_);
+        // One round-trip so the serving thread is up and then blocked awaiting the next request.
+        send_framed(client, {0x42});
+        EXPECT_EQ(recv_framed(client), (std::vector<uint8_t>{0x42}));
+    }  // server destroyed here -- must join the blocked serving thread without hanging.
+
+    EXPECT_THROW(recv_framed(client), std::exception);  // the host shut the connection down
+}
+
+// A socket bound without a handler is presence-only -- connectable (liveness) but not accepting.
+// serve() installs the handler and starts accepting, so serving can begin after the backend is
+// ready. This is the path the host device uses (create the socket, then serve once up).
+TEST_F(SimulationServerSocketTest, ServesAfterDeferredServe) {
+    auto server = SimulationServerSocket::create(path_);  // presence-only: no handler yet
+    EXPECT_TRUE(can_connect(path_));                      // bound + connectable
+
+    server->serve([](const std::vector<uint8_t>& request) { return request; });  // echo
+
+    asio::io_context io;
+    stream_protocol::socket client = connect_client(io, path_);
+    send_framed(client, {0x07, 0x08});
+    EXPECT_EQ(recv_framed(client), (std::vector<uint8_t>{0x07, 0x08}));
 }
 
 TEST(SimulationServerSocket, DefaultSocketPathIsPerChip) {


### PR DESCRIPTION
### Issue
Part of #2677 (simulation server process). Wires the wire protocol (#2967 / #2793) and framed transport (#2969) into `SimulationServerSocket` so the host can serve client requests, not just indicate presence. Stacked on #2969.

### Description
`SimulationServerSocket` gains **`serve(RequestHandler)`** (`std::function<std::vector<uint8_t>(const std::vector<uint8_t>&)>`), which starts the accept loop; each accepted connection is served on its own thread running `recv_framed → handler → send_framed` until the peer disconnects.

**Serving is deliberately split from binding.** `try_create`/`create` only *bind* (claim the path, connectable for liveness); `serve()` is called later, once the owner's backend — which the handler dispatches into — is ready. The backend does not exist at `try_create` time, so a construction-time handler would have nothing to dispatch into; the host device binds its handler in `adopt_socket()` once the backend is up (see the follow-up host-wiring PR).

Design notes:
- **Protocol-agnostic:** the socket moves opaque payloads and calls the handler; decoding, dispatch, and encoding live in the handler (simulation-gated code). This keeps `SimulationServerSocket` always-built and FlatBuffers-free.
- **Per-connection blocking threads** reuse the #2969 transport and support multiple clients. The handler is installed *before* the accept loop starts, so no connection thread races on it.
- **Teardown** marks stopping (so a racing accept starts no new session), `shutdown()`s every live connection so its serving thread unblocks from `recv_framed`, joins the threads, then closes the acceptor.

Also folds in a small transport hardening (its own commit): `send_framed` uses `::send(..., MSG_NOSIGNAL)` so writing to a closed peer fails with `EPIPE` (a thrown error) rather than raising `SIGPIPE` — reachable now that the serving loop writes to remote clients.

### List of the changes
- `device/simulation/simulation_server_socket.{hpp,cpp}` — `serve(handler)`; accept loop moved out of `bind_and_listen` into `serve()`; `try_create`/`create` are path-only.
- `device/simulation/simulation_server_transport.cpp` — `send_framed` uses `MSG_NOSIGNAL`.
- `tests/baremetal/test_simulation_server_socket.cpp` — serving tests (serve-through-handler, sequential, multiple clients, clean teardown) + `ServesAfterDeferredServe` (presence-only → serve()).
- `tests/baremetal/test_simulation_server_transport.cpp` — send-to-closed-peer throws (SIGPIPE regression).

### Testing
`SimulationServerSocketTest` (14) and `SimulationServerTransport` (7) pass in the no-card baremetal lane; build + pre-commit clean.

### API Changes
None (internal `simulation/` header). `SimulationServerSocket` gains `serve()`; the factories are path-only.