### PR TITLE
Simulation: model outbound-iATU host-DMA routing for TTSim

### DIFF
--- a/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
@@ -21,8 +21,20 @@ namespace tt::umd {
 
 class SimulationSysmemManager : public SysmemManager {
 public:
-    SimulationSysmemManager(uint32_t num_host_mem_channels, tt::ARCH arch);
+    SimulationSysmemManager(uint32_t num_host_mem_channels, tt::ARCH arch, uint32_t chip_id = 0);
     ~SimulationSysmemManager() override;
+
+    // Per-chip host base for this chip's sysmem. On silicon each chip's pinned host memory lives at a
+    // distinct host physical address; UMD programs that address into the chip's outbound iATU as the
+    // region target, and the chip's DMA resolves there purely by address (no per-chip "magic"). We
+    // model that by giving chip N a distinct host base (N * PER_CHIP_HOST_STRIDE) and using it as the
+    // hugepage physical_address (= iATU target). The simulator's host-side DMA router (dma_route) then
+    // routes by which chip's [host_base, host_base + PER_CHIP_HOST_STRIDE) window contains the address.
+    static constexpr uint64_t PER_CHIP_HOST_STRIDE = 1ULL << 36;  // 64 GiB; >> per-chip sysmem, non-overlapping
+
+    uint64_t get_host_base() const { return host_base_; }
+
+    uint64_t get_host_region_size() const { return PER_CHIP_HOST_STRIDE; }
 
     bool pin_or_map_sysmem_to_device() override;
 
@@ -76,6 +88,7 @@ private:
 
     uint8_t* system_memory_ = nullptr;
     size_t system_memory_size_ = 0;
+    uint64_t host_base_ = 0;  // this chip's distinct host-physical base (= chip_id * PER_CHIP_HOST_STRIDE)
     std::vector<std::pair<void*, size_t>> owned_allocations_;
     std::shared_ptr<MappedBufferRegistry> registry_;
 };

--- a/device/api/umd/device/simulation/tt_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/tt_sim_communicator.hpp
@@ -6,6 +6,7 @@
 
 #include <sys/types.h>
 
+#include <array>
 #include <cstdint>
 #include <filesystem>
 #include <functional>
@@ -126,7 +127,9 @@ public:
      */
     void set_pcie_dma_mem_callbacks(
         std::function<void(uint64_t, void *, uint32_t)> pfn_pci_dma_mem_rd_bytes,
-        std::function<void(uint64_t, const void *, uint32_t)> pfn_pci_dma_mem_wr_bytes);
+        std::function<void(uint64_t, const void *, uint32_t)> pfn_pci_dma_mem_wr_bytes,
+        uint64_t host_base = 0,
+        uint64_t host_size = 0);
 
     void start_sim();
 
@@ -238,14 +241,31 @@ private:
     std::function<void(uint64_t, void *, uint32_t)> pci_dma_mem_rd_bytes_callback_;
     std::function<void(uint64_t, const void *, uint32_t)> pci_dma_mem_wr_bytes_callback_;
 
-    // Known limitation: callback_instance_ is process-global; in multichip mode,
-    // only the last chip to call set_pcie_dma_mem_callbacks receives correct DMA
-    // callbacks.  Fix requires libttsim ABI change to support per-chip context pointer.
+    // Host-side DMA routing by address range. Each MMIO chip's outbound iATU (programmed by UMD via
+    // BAR2, honored by the sim) maps the chip's NOC sysmem window onto that chip's distinct host base.
+    // So a sysmem DMA arrives here carrying a real host address; we find the owning chip by which
+    // registered window [host_base, host_base+size) contains it -- exactly as a host/OS routes a DMA by
+    // which pinned region the address falls in. No chip id crosses the bus; the address alone targets.
+    // callback_instance_ stays as the single-device / unregistered fallback.
+    struct DmaHostRange {
+        uint64_t host_base = 0;
+        uint64_t host_size = 0;
+        TTSimCommunicator *inst = nullptr;
+    };
+
+    static constexpr std::size_t MAX_DMA_DEVICES = 32;
     static TTSimCommunicator *callback_instance_;
+    static std::array<DmaHostRange, MAX_DMA_DEVICES> dma_ranges_;
+    static std::size_t dma_range_count_;
+    static std::mutex dma_ranges_mutex_;
 
     // Static wrapper functions for C-style callbacks.
-    static void pci_dma_mem_rd_bytes_wrapper(uint64_t paddr, void *p, uint32_t size);
-    static void pci_dma_mem_wr_bytes_wrapper(uint64_t paddr, const void *p, uint32_t size);
+    static void pci_dma_mem_rd_bytes_wrapper(uint64_t physical_address, void *p, uint32_t size);
+    static void pci_dma_mem_wr_bytes_wrapper(uint64_t physical_address, const void *p, uint32_t size);
+    // Find the chip whose registered host window contains physical_address, rebase physical_address to
+    // the within-window offset, and return its communicator. Falls back to callback_instance_ if no
+    // window matches.
+    static TTSimCommunicator *dma_route(uint64_t &physical_address);
 
     // Thread safety. In multichip shared-dlopen mode, libttsim_select_device_by_id()
     // and the following libttsim I/O call must be serialized across all

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -62,6 +62,11 @@ public:
     static std::unique_ptr<TTSimTTDevice> create_client(
         const std::filesystem::path &simulator_directory, ChipId chip_id, std::unique_ptr<SimulationClient> client);
 
+    // Configure this chip's outbound iATU (NOC->host) the silicon way: iATU register writes via BAR2.
+    // The simulator decodes these into its iATU model and honors them at DMA egress, so the chip's DMA
+    // resolves to this chip's distinct host base (configured as the region target) purely by address.
+    void configure_iatu_region(size_t region, uint64_t target, size_t region_size) override;
+
     void wait_arc_core_start(const std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT) override;
     std::chrono::milliseconds wait_eth_core_training(
         CoreCoord eth_core, const std::chrono::milliseconds timeout_ms = timeout::ETH_TRAINING_TIMEOUT) override;

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -32,8 +32,12 @@ uint64_t align_up(uint64_t value, uint64_t alignment) { return (value + alignmen
 
 }  // namespace
 
-SimulationSysmemManager::SimulationSysmemManager(uint32_t num_host_mem_channels, tt::ARCH arch) {
+SimulationSysmemManager::SimulationSysmemManager(uint32_t num_host_mem_channels, tt::ARCH arch, uint32_t chip_id) {
+    // pcie_base_ is the chip-side NOC sysmem-window base (fixed per arch; used for buffers' NOC addresses).
+    // host_base_ is this chip's distinct host-physical base -- what UMD programs as the outbound-iATU
+    // region target, so each chip's DMA lands in its own host window with no per-chip tag at egress.
     pcie_base_ = get_pcie_base_for_arch(arch);
+    host_base_ = static_cast<uint64_t>(chip_id) * PER_CHIP_HOST_STRIDE;
     registry_ = std::make_shared<MappedBufferRegistry>();
     SimulationSysmemManager::init_sysmem(num_host_mem_channels);
 }
@@ -72,8 +76,11 @@ bool SimulationSysmemManager::init_sysmem(uint32_t num_host_mem_channels) {
 
     for (int i = 0; i < num_host_mem_channels; i++) {
         size_t channel_size = (i == 3 && num_host_mem_channels == 4) ? (768 * (1ULL << 20)) : (1ULL << 30);
+        // physical_address is this chip's host base for the channel -- what UMD programs as the outbound
+        // iATU region target (host_base_ is per-chip distinct). The chip-side NOC sysmem-window address is
+        // separate (get_pcie_base_addr_from_device), so the iATU maps NOC-window offset -> this host base.
         hugepage_mapping_per_channel.push_back(
-            {system_memory_ + i * (1ULL << 30), channel_size, pcie_base_ + i * (1ULL << 30)});
+            {system_memory_ + i * (1ULL << 30), channel_size, host_base_ + i * (1ULL << 30)});
     }
 
     return true;

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -46,6 +46,22 @@ TTSimCommunicator::TTSimCommunicator(
     simulator_directory_(simulator_directory), copy_sim_binary_(copy_sim_binary), chip_id_(chip_id) {}
 
 TTSimCommunicator::~TTSimCommunicator() {
+    // Unregister from the process-global DMA routing tables first. The shared simulator may still be
+    // alive (other chips not yet destructed) and could emit a DMA; leaving a stale entry/callback
+    // pointing at this freed communicator would route into freed memory (use-after-free).
+    {
+        std::lock_guard<std::mutex> ranges_lock(dma_ranges_mutex_);
+        for (std::size_t i = 0; i < dma_range_count_; i++) {
+            if (dma_ranges_[i].inst == this) {
+                dma_ranges_[i] = dma_ranges_[dma_range_count_ - 1];  // compact: move last into the hole
+                dma_ranges_[--dma_range_count_] = {};
+                break;
+            }
+        }
+        if (callback_instance_ == this) {
+            callback_instance_ = nullptr;
+        }
+    }
     if (multichip_mode_) {
         // Shared dlopen -- decrement refcount. When last communicator
         // destructs, call libttsim_exit (which the deferred shutdown()
@@ -273,26 +289,112 @@ void TTSimCommunicator::advance_clock(uint32_t n_clocks) {
 }
 
 TTSimCommunicator *TTSimCommunicator::callback_instance_ = nullptr;
+std::array<TTSimCommunicator::DmaHostRange, TTSimCommunicator::MAX_DMA_DEVICES> TTSimCommunicator::dma_ranges_{};
+std::size_t TTSimCommunicator::dma_range_count_ = 0;
+std::mutex TTSimCommunicator::dma_ranges_mutex_;
 
-void TTSimCommunicator::pci_dma_mem_rd_bytes_wrapper(uint64_t paddr, void *p, uint32_t size) {
-    if (callback_instance_ && callback_instance_->pci_dma_mem_rd_bytes_callback_) {
-        callback_instance_->pci_dma_mem_rd_bytes_callback_(paddr, p, size);
+// Route a sysmem DMA to the owning MMIO chip by host address: the address the chip emits already went
+// through its outbound iATU (UMD-programmed target = that chip's distinct host base), so we just find
+// the registered host window [host_base, host_base+size) that contains it -- exactly as a host routes a
+// DMA by which pinned region the physical address falls in. Rebase physical_address to the within-window
+// offset (so the per-chip callback sees an offset relative to its own host base, like the single-device
+// case) and return the owning communicator.
+//
+// With 0 or 1 window registered (legacy / single-device, host_base 0), an unmatched address is harmless
+// -- the mapping is an identity, so we fall back to callback_instance_. With more than one window
+// (multichip), an address matching no window means the simulator emitted an out-of-region outbound
+// address that never went through the iATU (e.g. a mapped-buffer arena IOVA, which sits above the
+// channel grid that the iATU covers). We cannot rebase it to the right chip, and silently falling back
+// would deliver it un-rebased to the wrong chip's sysmem. Hard-fail instead; extending iATU coverage to
+// the arena (or routing it explicitly) is the real fix, tracked separately.
+TTSimCommunicator *TTSimCommunicator::dma_route(uint64_t &physical_address) {
+    std::lock_guard<std::mutex> lock(dma_ranges_mutex_);
+    for (std::size_t i = 0; i < dma_range_count_; i++) {
+        const DmaHostRange &range = dma_ranges_[i];
+        if (physical_address >= range.host_base && (physical_address - range.host_base) < range.host_size) {
+            physical_address -= range.host_base;
+            return range.inst;
+        }
+    }
+    UMD_ASSERT(
+        dma_range_count_ <= 1,
+        error::RuntimeError,
+        fmt::format(
+            "TTSim multichip DMA to host address 0x{:x} matches no registered chip window ({} windows registered). "
+            "The simulator passed through an out-of-region outbound address (e.g. a mapped-buffer arena IOVA) that "
+            "the outbound iATU does not cover, so it cannot be routed to the owning chip.",
+            physical_address,
+            dma_range_count_));
+    return callback_instance_;
+}
+
+// Thread-safety note: dma_route() returns a communicator under dma_ranges_mutex_, then the callback is
+// dereferenced here outside the lock. This is safe because DMA callbacks only fire synchronously from
+// the owning chip's own thread while it drives the simulator (advance_clock / pci_mem_* under
+// device_lock_) -- a chip cannot be issuing a DMA and running its own ~TTSimCommunicator (which
+// unregisters the range under the same mutex) at the same time. No other thread holds a reference to
+// the returned instance across the call.
+void TTSimCommunicator::pci_dma_mem_rd_bytes_wrapper(uint64_t physical_address, void *p, uint32_t size) {
+    TTSimCommunicator *dma_cb = dma_route(physical_address);
+    if (dma_cb && dma_cb->pci_dma_mem_rd_bytes_callback_) {
+        dma_cb->pci_dma_mem_rd_bytes_callback_(physical_address, p, size);
     }
 }
 
-void TTSimCommunicator::pci_dma_mem_wr_bytes_wrapper(uint64_t paddr, const void *p, uint32_t size) {
-    if (callback_instance_ && callback_instance_->pci_dma_mem_wr_bytes_callback_) {
-        callback_instance_->pci_dma_mem_wr_bytes_callback_(paddr, p, size);
+void TTSimCommunicator::pci_dma_mem_wr_bytes_wrapper(uint64_t physical_address, const void *p, uint32_t size) {
+    TTSimCommunicator *dma_cb = dma_route(physical_address);
+    if (dma_cb && dma_cb->pci_dma_mem_wr_bytes_callback_) {
+        dma_cb->pci_dma_mem_wr_bytes_callback_(physical_address, p, size);
     }
 }
 
 void TTSimCommunicator::set_pcie_dma_mem_callbacks(
     std::function<void(uint64_t, void *, uint32_t)> pfn_pci_dma_mem_rd_bytes,
-    std::function<void(uint64_t, const void *, uint32_t)> pfn_pci_dma_mem_wr_bytes) {
+    std::function<void(uint64_t, const void *, uint32_t)> pfn_pci_dma_mem_wr_bytes,
+    uint64_t host_base,
+    uint64_t host_size) {
     std::lock_guard<std::mutex> lock(device_lock_);
     pci_dma_mem_rd_bytes_callback_ = std::move(pfn_pci_dma_mem_rd_bytes);
     pci_dma_mem_wr_bytes_callback_ = std::move(pfn_pci_dma_mem_wr_bytes);
-    callback_instance_ = this;
+    // callback_instance_ and dma_ranges_ are both read by dma_route() under dma_ranges_mutex_, so they
+    // must be written under that same mutex (not device_lock_) to avoid a data race with DMA callbacks.
+    {
+        std::lock_guard<std::mutex> ranges_lock(dma_ranges_mutex_);
+        callback_instance_ = this;
+        // Register this chip's host window for address-range DMA routing (dma_route()). The chip's
+        // outbound iATU targets this window, so DMAs land here by address alone -- no per-chip tag.
+        // Locate any window already registered for this instance so we can update or drop it in place.
+        std::size_t existing = dma_range_count_;
+        for (std::size_t i = 0; i < dma_range_count_; i++) {
+            if (dma_ranges_[i].inst == this) {
+                existing = i;
+                break;
+            }
+        }
+        if (host_size == 0) {
+            // host_size==0 (legacy / single-device) registers no window and relies on the
+            // callback_instance_ fallback. Drop any stale window this instance had registered, so a
+            // re-register with host_size==0 doesn't leave a dangling range that misroutes DMAs.
+            if (existing != dma_range_count_) {
+                dma_ranges_[existing] = dma_ranges_[dma_range_count_ - 1];  // compact: move last into the hole
+                dma_ranges_[--dma_range_count_] = {};
+            }
+        } else if (existing != dma_range_count_) {
+            dma_ranges_[existing] = {host_base, host_size, this};  // re-registration: update in place
+        } else {
+            // New window. Overflowing the table would silently drop this chip's window and let dma_route
+            // fall back to callback_instance_, delivering un-rebased host addresses to the wrong chip's
+            // sysmem -- silent corruption. Make it a hard error instead.
+            UMD_ASSERT(
+                dma_range_count_ < MAX_DMA_DEVICES,
+                error::RuntimeError,
+                fmt::format(
+                    "TTSim DMA host-range table full (MAX_DMA_DEVICES={}); cannot register another chip's "
+                    "host window for DMA routing.",
+                    MAX_DMA_DEVICES));
+            dma_ranges_[dma_range_count_++] = {host_base, host_size, this};
+        }
+    }
     pfn_libttsim_set_pci_dma_mem_callbacks_(pci_dma_mem_rd_bytes_wrapper, pci_dma_mem_wr_bytes_wrapper);
 }
 

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -99,8 +99,12 @@ TTSimTTDevice::TTSimTTDevice(
     ChipId chip_id,
     bool copy_sim_binary,
     int num_host_mem_channels) :
+    // Each chip gets a distinct host base derived from chip_id, so its outbound-iATU DMA routes to its
+    // own host window by address (see configure_iatu_region / SimulationSysmemManager).
     SimulationTTDevice(
-        simulator_directory, std::make_unique<SimulationSysmemManager>(num_host_mem_channels, soc_descriptor.arch)),
+        simulator_directory,
+        std::make_unique<SimulationSysmemManager>(
+            num_host_mem_channels, soc_descriptor.arch, static_cast<uint32_t>(chip_id))),
     // Pass chip_id to the communicator. If the loaded .so supports the multichip
     // multichip ABI (libttsim_create_device_by_id + libttsim_select_device_by_id),
     // the communicator will auto-detect at initialize() time and switch to
@@ -160,6 +164,26 @@ void TTSimTTDevice::initialize_backend() {
 
     init_tlb_allocator(bar0_base);
     setup_cached_tlb_window();
+
+    // Program this chip's outbound iATU exactly as UMD does on silicon (LocalChip::init_pcie_iatus):
+    // one region per host-mem channel, mapping the NOC sysmem window onto this chip's distinct host
+    // base. The simulator honors the iATU at DMA egress, so each chip's DMA lands in its own host
+    // window by address alone -- no per-chip tag. region_size is the channel's actual mapping size
+    // (WH channel 3 is 768 MiB, the rest 1 GiB); configure_iatu_region keeps the region base on the
+    // fixed 1 GiB channel grid (matching SimulationSysmemManager's placement) and uses region_size only
+    // to bound the limit, so a sub-1-GiB channel still starts at the right NOC offset.
+    //
+    // Programmed uniformly for single- and multi-chip: a single-chip sim simply has host_base 0, so
+    // the mapping is an identity and routing degenerates to a no-op -- the init path is identical
+    // regardless of num_chips. Requires a libttsim that models the BAR2 outbound iATU (WH, and BH as
+    // of the multichip work), which is the behaviour of the stable simulator release.
+    if (arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE) {
+        size_t nch = sysmem_manager_->get_num_host_mem_channels();
+        for (size_t ch = 0; ch < nch; ch++) {
+            HugepageMapping m = sysmem_manager_->get_hugepage_mapping(ch);
+            configure_iatu_region(ch, m.physical_address, m.mapping_size);
+        }
+    }
 }
 
 TTSimTTDevice::TTSimTTDevice(
@@ -347,10 +371,56 @@ ChipInfo TTSimTTDevice::get_chip_info() {
     return chip_info;
 }
 
+void TTSimTTDevice::configure_iatu_region(size_t region, uint64_t target, size_t region_size) {
+    // Configure the outbound iATU the silicon way: iATU register writes via BAR2 (BH writes these
+    // directly on real HW at ATU_OFFSET_IN_BH_BAR2=0x1000; WH models its iATU regs at 0x1200). We issue
+    // the same register sequence through the simulator's BAR2 MMIO path; the sim decodes it into the
+    // modeled outbound iATU and honors it at DMA egress. `target` is this chip's host base for the
+    // region (per-chip distinct); `base` is the region's offset within the chip's NOC sysmem window.
+    const uint64_t iatu_bar2_off = (arch == tt::ARCH::BLACKHOLE) ? 0x1000 : 0x1200;
+    uint64_t bar2_base = communicator_->pci_config_read32(0, 0x18);
+    bar2_base |= uint64_t(communicator_->pci_config_read32(0, 0x1C)) << 32;
+    bar2_base &= ~15ull;  // strip BAR type/attribute bits, leaving the physical address
+    // Channels sit on a fixed 1 GiB NOC-window grid (matching SimulationSysmemManager's placement),
+    // independent of region_size. region_size is the channel's actual mapping size and only bounds the
+    // limit: keeping base on the grid means a sub-1-GiB channel (WH channel 3 = 768 MiB) still starts at
+    // the right NOC offset (region * 1 GiB) while mapping only its backed range.
+    constexpr uint64_t CHANNEL_STRIDE = 1ULL << 30;
+    const uint64_t base = uint64_t(region) * CHANNEL_STRIDE;  // region offset within the NOC sysmem window
+    const uint64_t limit = base + region_size - 1;
+    // limit and base are written as 32-bit registers (limit hi shares base hi). This holds only while the
+    // top of the region stays within 4 GiB; assert rather than silently truncate if stride/channel count
+    // ever grows past that.
+    UMD_ASSERT(
+        limit < (1ULL << 32),
+        error::RuntimeError,
+        "iATU region exceeds 32-bit base/limit; extend the iATU register writes to cover the high bits.");
+    const uint64_t iatu = bar2_base + iatu_bar2_off + uint64_t(region) * 0x200;
+    auto wr = [&](uint64_t off, uint32_t val) { communicator_->pci_mem_write_bytes(iatu + off, &val, sizeof(val)); };
+    wr(0x04, 0);                       // region_ctrl_2: disable while (re)programming the region
+    wr(0x00, 0);                       // region_ctrl_1
+    wr(0x08, uint32_t(base));          // base lo
+    wr(0x0c, uint32_t(base >> 32));    // base hi
+    wr(0x10, uint32_t(limit));         // limit (low 32b; upper bits share base hi)
+    wr(0x14, uint32_t(target));        // target lo
+    wr(0x18, uint32_t(target >> 32));  // target hi
+    // Note: unlike BlackholeTTDevice::configure_iatu_region we do NOT write limit_hi (0x1c) or
+    // region_ctrl_3 (0x20): the deployed ttsim iATU model does not implement those register offsets
+    // (a write throws UnimplementedFunctionality). It's safe to omit them here -- the region top is
+    // asserted to stay within 4 GiB (limit_hi is always 0) and regions are programmed once at init, not
+    // reprogrammed, so there is no stale-high-bits hazard.
+    wr(0x04, 1u << 31);  // region_ctrl_2 = REGION_EN, written last so the sim validates a complete region
+}
+
 void TTSimTTDevice::initialize_sysmem_functions() {
+    // Register this chip's distinct host window [host_base, host_base+size) so the simulator's host-side
+    // DMA router (dma_route) routes each chip's DMA by address range -- the chip emits a host address
+    // (via its outbound iATU), and the host finds the owning chip by which window contains it.
     communicator_->set_pcie_dma_mem_callbacks(
         [this](uint64_t a, void* p, uint32_t s) { pci_dma_read_bytes(a, p, s); },
-        [this](uint64_t a, const void* p, uint32_t s) { pci_dma_write_bytes(a, p, s); });
+        [this](uint64_t a, const void* p, uint32_t s) { pci_dma_write_bytes(a, p, s); },
+        sysmem_manager_->get_host_base(),
+        sysmem_manager_->get_host_region_size());
 }
 
 void TTSimTTDevice::pci_dma_read_bytes(uint64_t paddr, void* p, uint32_t size) {


### PR DESCRIPTION
### Issue
Part of #2679, tracked by #2832. Split out of #2825; builds on #2954.

### Description
Model the TTSim host-DMA path the way silicon does: each simulation chip's sysmem sits at a distinct host base, UMD programs the chip's outbound iATU (via BAR2) to map its NOC sysmem window onto that base, and a sysmem DMA is routed to the owning chip purely by the host address it carries. Programmed uniformly for single- and multi-chip — a single-chip sim has host base 0, so the mapping is an identity and routing degenerates to a no-op. This lands the DMA/iATU model ahead of the multi-MMIO (P300) driver that will rely on it.

### List of the changes
- `SimulationSysmemManager`: per-chip host base (`chip_id * kPerChipHostStride`), used as the hugepage physical address (= outbound-iATU region target).
- `TTSimTTDevice`: program the outbound iATU via BAR2 (one region per host-mem channel) during backend bring-up; pass the chip's host window to the DMA callbacks.
- `TTSimCommunicator`: route sysmem DMA to the owning chip by host-address window (`dma_route`), and unregister the window at teardown.

### Testing
CI

### API Changes
Additive and default-compatible: `SimulationSysmemManager` gains an optional `chip_id` ctor arg; `TTSimCommunicator::set_pcie_dma_mem_callbacks` gains optional `host_base`/`host_size`. `TTSimTTDevice` overrides the existing `configure_iatu_region` base virtual.