### PR TITLE
Simulation: SimulationClient::transact (framed request/response)

### DIFF
--- a/device/api/umd/device/simulation/simulation_client.hpp
+++ b/device/api/umd/device/simulation/simulation_client.hpp
@@ -4,20 +4,18 @@
 
 #pragma once
 
+#include <cstdint>
 #include <filesystem>
 #include <memory>
+#include <vector>
 
 namespace tt::umd {
 
-// The client-facing handle to a simulation host ("the card"), reached over its per-chip UNIX
-// socket. Deliberately slim for now: just the session handshake -- attach() connects, detach()
-// closes. It grows operation-by-operation as the server work lands (device description, memory
-// access, TLB, sysmem, run/reset, ...), at which point TTSimTTDevice's client-mode dispatch is
-// rebound from its throwing stubs onto these calls. No simulation build needed (asio is a core
-// dependency), mirroring SimulationSocket on the host side.
+// Client-facing handle to a simulation host ("the card") over its per-chip UNIX socket. transact()
+// moves opaque request/reply payloads; encoding lives in the simulation device that owns this
+// handle, so this always-built transport carries no protocol/FlatBuffers dependency.
 //
-// The asio transport is held behind a pImpl so this header stays free of asio (a private
-// dependency of the library) -- see Impl in the .cpp.
+// asio is held behind a pImpl so this header stays asio-free (see Impl in the .cpp).
 class SimulationClient {
 public:
     explicit SimulationClient(std::filesystem::path socket_path);
@@ -31,6 +29,11 @@ public:
     void attach();
     // Closes the connection; idempotent.
     void detach();
+
+    // Sends one length-prefixed request to the host and blocks for the length-prefixed reply,
+    // returning its opaque payload. Payloads are encoded/decoded by the caller (the protocol
+    // layer). Throws if not attached, or if the host disconnects or errors mid-exchange.
+    std::vector<uint8_t> transact(const std::vector<uint8_t>& request);
 
 private:
     std::filesystem::path socket_path_;

--- a/device/simulation/simulation_client.cpp
+++ b/device/simulation/simulation_client.cpp
@@ -10,6 +10,7 @@
 #include <asio.hpp>
 #include <system_error>
 
+#include "simulation/simulation_server_transport.hpp"
 #include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
@@ -61,6 +62,19 @@ void SimulationClient::attach() {
             error::RuntimeError,
             fmt::format("Failed to connect to simulation host socket at {}: {}", socket_path_.string(), ec.message()));
     }
+    // Ensure blocking mode (the transport uses blocking reads/writes); if that fails, fail loudly
+    // rather than report a half-attached client as connected.
+    impl_->socket.native_non_blocking(false, ec);
+    if (ec) {
+        std::error_code close_ec;
+        impl_->socket.close(close_ec);  // drop the half-open socket; is_open() -> false, so not "attached"
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format(
+                "Failed to set blocking mode on simulation host socket at {}: {}",
+                socket_path_.string(),
+                ec.message()));
+    }
 }
 
 void SimulationClient::detach() {
@@ -72,6 +86,16 @@ void SimulationClient::detach() {
     std::error_code ec;
     impl_->socket.shutdown(stream_protocol::socket::shutdown_both, ec);
     impl_->socket.close(ec);
+}
+
+std::vector<uint8_t> SimulationClient::transact(const std::vector<uint8_t>& request) {
+    if (!impl_->socket.is_open()) {
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format("Cannot transact with simulation host at {}: not attached", socket_path_.string()));
+    }
+    send_framed(impl_->socket, request);
+    return recv_framed(impl_->socket);
 }
 
 }  // namespace tt::umd

--- a/tests/baremetal/test_simulation_client.cpp
+++ b/tests/baremetal/test_simulation_client.cpp
@@ -5,8 +5,10 @@
 #include <gtest/gtest.h>
 #include <unistd.h>
 
+#include <cstdint>
 #include <filesystem>
 #include <string>
+#include <vector>
 
 #include "simulation/simulation_server_socket.hpp"
 #include "umd/device/simulation/simulation_client.hpp"
@@ -55,4 +57,48 @@ TEST_F(SimulationClientTest, DestructorDetaches) {
         SimulationClient client(path_);
         EXPECT_NO_THROW(client.attach());
     }
+}
+
+// End to end over the socket: transact() returns the host's reply, not the request it sent (the
+// handler answers with a fixed payload, so the reply provably comes from the host).
+TEST_F(SimulationClientTest, TransactReturnsHostReply) {
+    auto server = SimulationServerSocket::create(path_);
+    server->serve([](const std::vector<uint8_t>&) { return std::vector<uint8_t>{0xDE, 0xAD, 0xBE, 0xEF}; });
+    SimulationClient client(path_);
+    client.attach();
+
+    EXPECT_EQ(client.transact({0x01, 0x02, 0x03}), (std::vector<uint8_t>{0xDE, 0xAD, 0xBE, 0xEF}));
+}
+
+// One attached client carries many request/reply turns (here the host echoes each request back).
+TEST_F(SimulationClientTest, TransactHandlesSequentialRequests) {
+    auto server = SimulationServerSocket::create(path_);
+    server->serve([](const std::vector<uint8_t>& request) { return request; });
+    SimulationClient client(path_);
+    client.attach();
+
+    for (uint8_t i = 0; i < 5; ++i) {
+        const std::vector<uint8_t> request = {i, static_cast<uint8_t>(i + 1)};
+        EXPECT_EQ(client.transact(request), request);
+    }
+}
+
+// transact() before attach() fails loudly rather than touching a closed socket.
+TEST_F(SimulationClientTest, TransactThrowsWhenNotAttached) {
+    SimulationClient client(path_);
+    EXPECT_THROW(client.transact({0x01}), std::exception);
+}
+
+// If the host goes away while attached, transact() surfaces an error (and does not raise SIGPIPE
+// writing to the dead peer) rather than hanging or crashing.
+TEST_F(SimulationClientTest, TransactThrowsAfterHostGone) {
+    SimulationClient client(path_);
+    {
+        auto server = SimulationServerSocket::create(path_);
+        server->serve([](const std::vector<uint8_t>& request) { return request; });
+        client.attach();
+        EXPECT_EQ(client.transact({0x7F}), (std::vector<uint8_t>{0x7F}));  // works while the host is up
+    }                                                                      // host destroyed here
+
+    EXPECT_THROW(client.transact({0x01}), std::exception);
 }


### PR DESCRIPTION
### Issue
Part of #2677 (simulation server process). Grows the client transport (#2902) from attach/detach to a full request/response turn, so it can carry device operations. Stacked on #2984.

### Description
Adds `SimulationClient::transact(request) -> reply`: sends one framed request over the connected socket and blocks for the framed reply, via the shared transport (#2969). `attach()` clears any non-blocking flag asio leaves on the socket so the transport's synchronous reads/writes block as intended.

Kept **protocol-agnostic** (opaque payloads in/out), like `SimulationServerSocket`: device operations are encoded/decoded *above* this handle, in the simulation-gated device that owns it, so `SimulationClient` stays always-built and FlatBuffers-free. This is also what lets the client-mode device dispatch be rebound onto `transact()` in a follow-up.

Pairs with the serving loop (#2984): `client.transact` ↔ server `recv_framed → handler → send_framed`, both over framed opaque payloads.

### List of the changes
- `device/api/umd/device/simulation/simulation_client.hpp`, `device/simulation/simulation_client.cpp` — `transact()` (framed request/response over the socket via the shared transport); blocking-mode set on `attach()`.
- `tests/baremetal/test_simulation_client.cpp` — 4 end-to-end tests (real client ↔ serving socket): fixed-reply round-trip, sequential requests, transact-before-attach throws, transact-after-host-gone throws.

### Testing
`SimulationClientTest` (7, 4 new) pass in the no-card baremetal lane; build + pre-commit clean.

### API Changes
`SimulationClient` gains a `transact()` method (existing public header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
