### PR TITLE
Simulation: BDF multi-MMIO TTSim driver + P300 (bh_x2) CI

### DIFF
--- a/.github/workflows/run-ttsim-tests.yml
+++ b/.github/workflows/run-ttsim-tests.yml
@@ -67,6 +67,14 @@ jobs:
           fileName: "libttsim_bh.so"
           out-file-path: /tmp/ttsim-bh
 
+      - name: Download ttsim binary (bh_x2)
+        uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f  # v1.13
+        with:
+          repository: tenstorrent/ttsim
+          latest: true
+          fileName: "libttsim_bh_x2.so"
+          out-file-path: /tmp/ttsim-bh-x2
+
       - name: Download ttsim binary (qsr)
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f  # v1.13
         with:
@@ -98,11 +106,12 @@ jobs:
       - name: Prepare sim paths
         run: |
           echo "Preparing sim paths"
-          mkdir -p sim_wh sim_bh sim_qsr sim_wh_x2
+          mkdir -p sim_wh sim_bh sim_qsr sim_wh_x2 sim_bh_x2
           mv /tmp/ttsim-wh/libttsim_wh.so sim_wh/libttsim.so
           mv /tmp/ttsim-bh/libttsim_bh.so sim_bh/libttsim.so
           mv /tmp/ttsim-qsr/libttsim_qsr.so sim_qsr/libttsim.so
           mv /tmp/ttsim-wh-x2/libttsim_wh_x2.so sim_wh_x2/libttsim.so
+          mv /tmp/ttsim-bh-x2/libttsim_bh_x2.so sim_bh_x2/libttsim.so
           cp $TT_METAL_HOME/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml sim_wh/soc_descriptor.yaml
           cp $TT_METAL_HOME/tt_metal/soc_descriptors/blackhole_140_arch.yaml sim_bh/soc_descriptor.yaml
           cp tt-metal/tt_metal/third_party/umd/tests/soc_descs/quasar_32_arch.yaml sim_qsr/soc_descriptor.yaml
@@ -112,6 +121,12 @@ jobs:
           # and enumerates both the MMIO gateway and the remote chip. Without it, the sim is a single MMIO chip.
           cp tt-metal/tt_metal/third_party/umd/tests/cluster_descriptor_examples/wormhole_N300.yaml \
             sim_wh_x2/cluster_descriptor.yaml
+          # bh_x2 is two Blackhole chips; reuse the per-chip Blackhole soc descriptor.
+          cp $TT_METAL_HOME/tt_metal/soc_descriptors/blackhole_140_arch.yaml sim_bh_x2/soc_descriptor.yaml
+          # Place the P300 cluster descriptor beside the simulator; UMD auto-discovers it (like soc_descriptor.yaml)
+          # and enumerates both MMIO chips. Without it, the sim is a single MMIO chip.
+          cp tt-metal/tt_metal/third_party/umd/tests/cluster_descriptor_examples/blackhole_P300_both_mmio.yaml \
+            sim_bh_x2/cluster_descriptor.yaml
 
       - name: Build UMD api_tests and microbenchmark with simulation support
         run: |
@@ -166,6 +181,25 @@ jobs:
         timeout-minutes: 1
         env:
           TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh/libttsim.so
+        run: |
+          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
+
+      # bh_x2 is the P300 multichip simulator (both Blackhole chips MMIO-capable). The
+      # cluster_descriptor.yaml placed beside the simulator (see "Prepare sim paths") makes UMD
+      # enumerate both chips, so the standard device-IO fixtures run across both MMIO chips and the
+      # simulated inter-chip eth links. The P300 host-DMA routing programs the outbound iATU via BAR2,
+      # which the stable ttsim release models.
+      - name: Run UMD TestDeviceIOFixture on tt-sim blackhole x2
+        timeout-minutes: 1
+        env:
+          TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh_x2/libttsim.so
+        run: |
+          tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.*"
+
+      - name: Run UMD TTSimDeviceIOFixture on tt-sim blackhole x2
+        timeout-minutes: 1
+        env:
+          TT_UMD_SIMULATOR: ${{ github.workspace }}/sim_bh_x2/libttsim.so
         run: |
           tt-metal/tt_metal/third_party/umd/build/test/umd/api/api_tests --gtest_filter="TTSimDeviceIOFixture.*"
 

--- a/device/api/umd/device/simulation/tt_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/tt_sim_communicator.hpp
@@ -31,7 +31,10 @@ public:
      *   for legacy single-chip consumers.
      */
     TTSimCommunicator(
-        const std::filesystem::path &simulator_directory, bool copy_sim_binary = false, uint32_t chip_id = 0);
+        const std::filesystem::path &simulator_directory,
+        bool copy_sim_binary = false,
+        uint32_t chip_id = 0,
+        uint32_t num_chips = 1);
 
     /**
      * Destructor that properly cleans up library handles and file descriptors.
@@ -157,6 +160,12 @@ private:
     void close_simulator_binary();
     void load_simulator_library(const std::filesystem::path &path);
 
+    // Error-path cleanup for the shared-dlopen init paths. Called with s_shared_init_mutex_ held when
+    // symbol resolution throws before this communicator commits (bumps s_shared_refcount_). If this call
+    // performed the fresh dlopen (refcount still 0), releases s_shared_handle_ so it does not leak and a
+    // retry starts clean; if a prior communicator already owns it (refcount > 0), leaves it alone.
+    void release_uncommitted_shared_handle();
+
     // In multichip mode, selects this communicator's chip before an I/O call.
     void select_chip_if_needed();
 
@@ -193,7 +202,15 @@ private:
     // True when the loaded .so supports the multichip ABI and this
     // communicator is using the shared dlopen path.
     bool multichip_mode_ = false;
+    // True when the .so has NO multichip ABI but the cluster has >1 chip: all communicators share one
+    // dlopen and each chip is addressed by its PCI device (BDF) rather than libttsim_select_device_by_id.
+    bool shared_bdf_mode_ = false;
+
+    // Both modes use the single shared dlopen (s_shared_handle_) + refcount.
+    bool uses_shared_handle() const { return multichip_mode_ || shared_bdf_mode_; }
+
     uint32_t chip_id_ = 0;
+    uint32_t num_chips_ = 1;
     static void *s_shared_handle_;
     static int s_shared_refcount_;
     static bool s_sim_initialized_;

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -39,7 +39,8 @@ public:
         const SocDescriptor &soc_descriptor,
         ChipId chip_id,
         bool copy_sim_binary = false,
-        int num_host_mem_channels = 0);
+        int num_host_mem_channels = 0,
+        size_t num_chips = 1);
 
     ~TTSimTTDevice();
 

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -14,10 +14,12 @@
 
 #include <cerrno>
 #include <cstring>
+#include <filesystem>
 #include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <utility>
 
+#include "umd/device/simulation/simulation_chip.hpp"
 #include "umd/device/utils/error.hpp"
 
 // NOLINTBEGIN.
@@ -42,8 +44,11 @@ std::mutex TTSimCommunicator::s_shared_init_mutex_;
 std::mutex TTSimCommunicator::device_lock_;
 
 TTSimCommunicator::TTSimCommunicator(
-    const std::filesystem::path &simulator_directory, bool copy_sim_binary, uint32_t chip_id) :
-    simulator_directory_(simulator_directory), copy_sim_binary_(copy_sim_binary), chip_id_(chip_id) {}
+    const std::filesystem::path &simulator_directory, bool copy_sim_binary, uint32_t chip_id, uint32_t num_chips) :
+    simulator_directory_(simulator_directory),
+    copy_sim_binary_(copy_sim_binary),
+    chip_id_(chip_id),
+    num_chips_(num_chips) {}
 
 TTSimCommunicator::~TTSimCommunicator() {
     // Unregister from the process-global DMA routing tables first. The shared simulator may still be
@@ -62,7 +67,7 @@ TTSimCommunicator::~TTSimCommunicator() {
             callback_instance_ = nullptr;
         }
     }
-    if (multichip_mode_) {
+    if (uses_shared_handle()) {
         // Shared dlopen -- decrement refcount. When last communicator
         // destructs, call libttsim_exit (which the deferred shutdown()
         // path didn't call), then dlclose. The simulator is process-global,
@@ -77,9 +82,29 @@ TTSimCommunicator::~TTSimCommunicator() {
             s_sim_initialized_ = false;
         }
     } else if (libttsim_handle_) {
-        dlclose(libttsim_handle_);
+        // If initialize() threw after aliasing s_shared_handle_ (the probe keeps that handle) but
+        // before committing to a shared-handle mode, libttsim_handle_ may equal s_shared_handle_. It is
+        // owned by the shared-refcount path; dlclosing it here would leave other communicators with a
+        // dangling s_shared_handle_.
+        std::lock_guard<std::mutex> lock(s_shared_init_mutex_);
+        if (libttsim_handle_ != s_shared_handle_) {
+            dlclose(libttsim_handle_);
+        }
     }
     close_simulator_binary();
+}
+
+void TTSimCommunicator::release_uncommitted_shared_handle() {
+    // Called with s_shared_init_mutex_ held, on the symbol-resolution error path before this
+    // communicator commits (bumps s_shared_refcount_). device_lock_ serializes initialize() across
+    // communicators, so a non-zero refcount here means a prior communicator already committed and owns
+    // the handle -- leave it alone. A zero refcount means this call performed the fresh dlopen: release
+    // it so it does not leak and a retry starts from a clean s_shared_handle_.
+    libttsim_handle_ = nullptr;
+    if (s_shared_refcount_ == 0 && s_shared_handle_) {
+        dlclose(s_shared_handle_);
+        s_shared_handle_ = nullptr;
+    }
 }
 
 void TTSimCommunicator::initialize() {
@@ -121,24 +146,29 @@ void TTSimCommunicator::initialize() {
         // s_shared_handle_ is guaranteed non-null here (set in probe above or by a prior communicator).
         libttsim_handle_ = s_shared_handle_;
 
-        // Resolve all required multichip symbols via DLSYM_FUNCTION (throws on missing).
-        DLSYM_FUNCTION(libttsim_init)
-        DLSYM_FUNCTION(libttsim_exit)
-        DLSYM_FUNCTION(libttsim_pci_config_rd32)
-        DLSYM_FUNCTION(libttsim_pci_mem_rd_bytes)
-        DLSYM_FUNCTION(libttsim_pci_mem_wr_bytes)
-        DLSYM_FUNCTION(libttsim_tile_rd_bytes)
-        DLSYM_FUNCTION(libttsim_tile_wr_bytes)
-        DLSYM_FUNCTION(libttsim_clock)
-        DLSYM_FUNCTION(libttsim_set_pci_dma_mem_callbacks)
-        DLSYM_FUNCTION(libttsim_create_device_by_id)
-        DLSYM_FUNCTION(libttsim_select_device_by_id)
-        DLSYM_FUNCTION(libttsim_clock_all_devices)
-        DLSYM_FUNCTION(libttsim_switch_reset)
-        DLSYM_FUNCTION(libttsim_switch_register)
-        DLSYM_FUNCTION(libttsim_switch_drain)
-        DLSYM_FUNCTION(libttsim_configure_eth_link_virtual)
-        DLSYM_FUNCTION(libttsim_switch_register_peer)
+        try {
+            // Resolve all required multichip symbols via DLSYM_FUNCTION (throws on missing).
+            DLSYM_FUNCTION(libttsim_init)
+            DLSYM_FUNCTION(libttsim_exit)
+            DLSYM_FUNCTION(libttsim_pci_config_rd32)
+            DLSYM_FUNCTION(libttsim_pci_mem_rd_bytes)
+            DLSYM_FUNCTION(libttsim_pci_mem_wr_bytes)
+            DLSYM_FUNCTION(libttsim_tile_rd_bytes)
+            DLSYM_FUNCTION(libttsim_tile_wr_bytes)
+            DLSYM_FUNCTION(libttsim_clock)
+            DLSYM_FUNCTION(libttsim_set_pci_dma_mem_callbacks)
+            DLSYM_FUNCTION(libttsim_create_device_by_id)
+            DLSYM_FUNCTION(libttsim_select_device_by_id)
+            DLSYM_FUNCTION(libttsim_clock_all_devices)
+            DLSYM_FUNCTION(libttsim_switch_reset)
+            DLSYM_FUNCTION(libttsim_switch_register)
+            DLSYM_FUNCTION(libttsim_switch_drain)
+            DLSYM_FUNCTION(libttsim_configure_eth_link_virtual)
+            DLSYM_FUNCTION(libttsim_switch_register_peer)
+        } catch (...) {
+            release_uncommitted_shared_handle();
+            throw;
+        }
 
         // Optional extension symbols -- resolved with raw dlsym and allowed to be
         // nullptr.  These are newer additions to the libttsim ABI that not all .so
@@ -163,6 +193,49 @@ void TTSimCommunicator::initialize() {
         // not attempt to decrement a refcount that was never incremented.
         multichip_mode_ = true;
         s_shared_refcount_++;
+        return;
+    }
+
+    // No multichip ABI, but a *self-describing multi-MMIO* simulator: one libttsim .so image hosts
+    // several PCIe chips, addressed by PCI device (BDF) + per-device BAR window. All chips share a single
+    // dlopen (one shared per-chip state array). This is the BDF host-enumeration path
+    // (docs/multichip/ARCHITECTURE.md) -- no select_device_by_id, no virtual eth switch (the simulator
+    // routes inter-chip eth internally).
+    //
+    // The signal is a cluster_descriptor.yaml shipped beside the .so (e.g. P300 bh_x2): the .so declares
+    // the topology it hosts. A plain multi-chip cluster that replicates a *single-chip* .so per chip
+    // (e.g. galaxy wormhole, driven by an external mock cluster desc) has no such file -- it must keep
+    // the per-chip isolated dlopen (legacy memfd path below) so each chip is its own simulator process.
+    const bool self_describing_multi_mmio =
+        num_chips_ > 1 &&
+        std::filesystem::exists(SimulationChip::get_cluster_descriptor_path_from_simulator_path(simulator_directory_));
+    if (self_describing_multi_mmio) {
+        std::lock_guard<std::mutex> init_lock(s_shared_init_mutex_);
+        if (!s_shared_handle_) {
+            s_shared_handle_ = dlopen(simulator_directory_.c_str(), RTLD_LAZY);
+            if (!s_shared_handle_) {
+                UMD_THROW(error::RuntimeError, fmt::format("Failed to dlopen simulator library: {}", dlerror()));
+            }
+        }
+        libttsim_handle_ = s_shared_handle_;
+        try {
+            DLSYM_FUNCTION(libttsim_init)
+            DLSYM_FUNCTION(libttsim_exit)
+            DLSYM_FUNCTION(libttsim_pci_config_rd32)
+            DLSYM_FUNCTION(libttsim_pci_mem_rd_bytes)
+            DLSYM_FUNCTION(libttsim_pci_mem_wr_bytes)
+            DLSYM_FUNCTION(libttsim_tile_rd_bytes)
+            DLSYM_FUNCTION(libttsim_tile_wr_bytes)
+            DLSYM_FUNCTION(libttsim_clock)
+            DLSYM_FUNCTION(libttsim_set_pci_dma_mem_callbacks)
+        } catch (...) {
+            release_uncommitted_shared_handle();
+            throw;
+        }
+        shared_bdf_mode_ = true;
+        s_shared_refcount_++;
+        log_info(
+            tt::LogEmulationDriver, "TTSim BDF multichip mode (chip_id={}, shared dlopen, per-device BARs)", chip_id_);
         return;
     }
 
@@ -192,6 +265,16 @@ void TTSimCommunicator::start_sim() {
         dev_handle_ = pfn_libttsim_create_device_by_id_(chip_id_, /*chip_x=*/int(chip_id_), /*chip_y=*/0);
         return;
     }
+    if (shared_bdf_mode_) {
+        // Shared dlopen: initialize the simulator exactly once. Chips are addressed by
+        // BDF, so there is no per-chip registration call.
+        std::lock_guard<std::mutex> init_lock(s_shared_init_mutex_);
+        if (!s_sim_initialized_) {
+            pfn_libttsim_init_();
+            s_sim_initialized_ = true;
+        }
+        return;
+    }
     pfn_libttsim_init_();
 }
 
@@ -204,7 +287,7 @@ void TTSimCommunicator::shutdown() {
         return;
     }
     log_info(tt::LogEmulationDriver, "Sending exit signal to remote...");
-    if (multichip_mode_) {
+    if (uses_shared_handle()) {
         // Defer libttsim_exit until the last communicator destructs (handled
         // by refcount in the destructor's shared-handle close path). The
         // simulator is process-global; calling exit per chip would be wrong.
@@ -267,10 +350,18 @@ void TTSimCommunicator::pci_mem_write_bytes(uint64_t paddr, const void *data, ui
 
 uint32_t TTSimCommunicator::pci_config_read32(uint32_t bus_device_function, uint32_t offset) {
     std::lock_guard<std::mutex> lock(device_lock_);
-    // pci_config_read32 reads compile-time constants; no chip selection needed.
-    // But we still select for consistency and future-proofing.
-    select_chip_if_needed();
-    return pfn_libttsim_pci_config_rd32_(bus_device_function, offset);
+    // In BDF mode there is no select_device_by_id: this chip's PCI device is named by
+    // its BDF (device field = chip_id), so each chip reads its own per-device BAR bases.
+    // Callers pass bus_device_function 0 ("this device"); we fill in the device field.
+    uint32_t bdf = bus_device_function;
+    if (shared_bdf_mode_) {
+        // BDF: function[2:0], device[7:3], bus[15:8]. The device field is only 5 bits, so chip_id >= 32
+        // would silently overflow into the bus field and misroute. Fail loudly instead.
+        UMD_ASSERT(chip_id_ < 32, error::RuntimeError, "BDF device field is 5 bits; chip_id must be < 32 in BDF mode.");
+        bdf |= (chip_id_ << 3);
+    }
+    select_chip_if_needed();  // no-op outside the multichip-ABI mode
+    return pfn_libttsim_pci_config_rd32_(bdf, offset);
 }
 
 void TTSimCommunicator::advance_clock(uint32_t n_clocks) {
@@ -394,6 +485,14 @@ void TTSimCommunicator::set_pcie_dma_mem_callbacks(
                     MAX_DMA_DEVICES));
             dma_ranges_[dma_range_count_++] = {host_base, host_size, this};
         }
+    }
+    // The DMA callbacks are process-global, and libttsim forbids (re)registering them
+    // once the simulator is running. With one shared simulator across chips, only the
+    // first chip -- which runs libttsim_init in start_sim() -- registers them, before
+    // init. Later chips just record their callback (last-writer-wins, the pre-existing
+    // single-instance limitation) and skip the now-illegal re-registration.
+    if (uses_shared_handle() && s_sim_initialized_) {
+        return;
     }
     pfn_libttsim_set_pci_dma_mem_callbacks_(pci_dma_mem_rd_bytes_wrapper, pci_dma_mem_wr_bytes_wrapper);
 }

--- a/device/tt_device/simulation_device_factory.cpp
+++ b/device/tt_device/simulation_device_factory.cpp
@@ -28,7 +28,7 @@ std::unique_ptr<TTDevice> create_simulation_tt_device(
     int num_host_mem_channels) {
     if (simulator_directory.extension() == ".so") {
         return std::make_unique<TTSimTTDevice>(
-            simulator_directory, soc_descriptor, chip_id, num_chips > 1, num_host_mem_channels);
+            simulator_directory, soc_descriptor, chip_id, num_chips > 1, num_host_mem_channels, num_chips);
     }
     log_info(tt::LogEmulationDriver, "Instantiating RTL simulation device");
     return std::make_unique<RtlSimulationTTDevice>(simulator_directory, soc_descriptor, chip_id, num_host_mem_channels);

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -91,19 +91,21 @@ TTSimTTDevice::TTSimTTDevice(
     const SocDescriptor& soc_descriptor,
     ChipId chip_id,
     bool copy_sim_binary,
-    int num_host_mem_channels) :
+    int num_host_mem_channels,
+    size_t num_chips) :
     // Each chip gets a distinct host base derived from chip_id, so its outbound-iATU DMA routes to its
     // own host window by address (see configure_iatu_region / SimulationSysmemManager).
     SimulationTTDevice(
         simulator_directory,
         std::make_unique<SimulationSysmemManager>(
             num_host_mem_channels, soc_descriptor.arch, static_cast<uint32_t>(chip_id))),
-    // Pass chip_id to the communicator. If the loaded .so supports the multichip
-    // multichip ABI (libttsim_create_device_by_id + libttsim_select_device_by_id),
-    // the communicator will auto-detect at initialize() time and switch to
-    // shared-dlopen mode regardless of copy_sim_binary.
-    communicator_(
-        std::make_unique<TTSimCommunicator>(simulator_directory, copy_sim_binary, static_cast<uint32_t>(chip_id))),
+    // Pass chip_id and num_chips to the communicator. If the .so supports the multichip
+    // ABI (libttsim_create_device_by_id + libttsim_select_device_by_id), the communicator
+    // auto-detects at initialize() and uses select_device_by_id. Otherwise, for a
+    // multi-chip cluster (num_chips > 1) it uses shared-dlopen BDF mode: one libttsim
+    // image addressed per-chip by PCI device. Single-chip keeps the legacy path.
+    communicator_(std::make_unique<TTSimCommunicator>(
+        simulator_directory, copy_sim_binary, static_cast<uint32_t>(chip_id), static_cast<uint32_t>(num_chips))),
     chip_id_(chip_id) {
     set_soc_descriptor(soc_descriptor);
     // Populate the base-class arch field from the soc descriptor. TTSim does not go through

--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -552,11 +552,6 @@ TEST_F(TestDeviceIOFixture, SysmemReadWrite) {
         GTEST_SKIP() << "Skipping the test for quasar since Sysmem is not supported yet.";
     }
 
-    constexpr auto mmio_chip_id = 0;
-    const auto pci_cores = cluster->get_soc_descriptor(mmio_chip_id).get_cores(CoreType::PCIE);
-    const auto pcie_core = pci_cores.at(0);
-    const auto base_address = cluster->get_pcie_base_addr_from_device(mmio_chip_id);
-
     auto random_address_between = [&](uint64_t lo, uint64_t hi) -> uint64_t {
         static std::random_device rd;
         static std::mt19937_64 gen(rd());
@@ -568,103 +563,120 @@ TEST_F(TestDeviceIOFixture, SysmemReadWrite) {
         test_utils::safe_test_cluster_start(cluster.get());
     }
 
-    for (uint32_t channel = 0; channel < channels_to_test; channel++) {
-        uint8_t* sysmem = static_cast<uint8_t*>(cluster->host_dma_address(mmio_chip_id, 0, channel));
+    // Exercise every MMIO chip's sysmem, not just chip 0. On a multi-MMIO simulator (e.g. P300 / bh_x2)
+    // this is what actually validates the host-DMA routing model: each chip's DMA must land in *its own*
+    // host window. Each chip fills its host buffer with a chip-distinct pattern, so a misrouted DMA
+    // (landing in another chip's window, or aliasing host_base 0) would surface as a readback mismatch.
+    const auto mmio_chips = cluster->get_target_mmio_device_ids();
+    for (const ChipId mmio_chip_id : mmio_chips) {
+        const auto pci_cores = cluster->get_soc_descriptor(mmio_chip_id).get_cores(CoreType::PCIE);
+        const auto pcie_core = pci_cores.at(0);
+        const auto base_address = cluster->get_pcie_base_addr_from_device(mmio_chip_id);
 
-        ASSERT_NE(sysmem, nullptr);
+        // Distinct per-chip sentinel so a misrouted DMA (landing in another chip's window, or aliasing
+        // host_base 0) surfaces as a readback mismatch instead of coincidentally matching.
+        const uint32_t chip_pattern = 0xDEAD'BEEFu + static_cast<uint32_t>(mmio_chip_id);
 
-        if (is_simulation_test()) {
-            // The simulation path only exercises offset 0x0. Fill just one (first) page for that case.
-            constexpr size_t SIM_FILL_SIZE = 0x1000;
-            for (size_t i = 0; i < SIM_FILL_SIZE; i++) {
-                sysmem[i] = i % 256;
-            }
-        } else {
-            test_utils::fill_with_random_bytes(sysmem, ONE_GIG);
-        }
+        for (uint32_t channel = 0; channel < channels_to_test; channel++) {
+            uint8_t* sysmem = static_cast<uint8_t*>(cluster->host_dma_address(/*offset=*/0, mmio_chip_id, channel));
 
-        std::vector<uint64_t> test_offsets;
-        if (is_simulation_test()) {
-            test_offsets = {0x0};
-        } else {
-            test_offsets = {
-                0x0,
-                (ONE_GIG / 4) - 0x1000,
-                (ONE_GIG / 4) - 0x0004,
-                (ONE_GIG / 4),
-                (ONE_GIG / 4) + 0x0004,
-                (ONE_GIG / 4) + 0x1000,
-                (ONE_GIG / 2) - 0x1000,
-                (ONE_GIG / 2) - 0x0004,
-                (ONE_GIG / 2),
-                (ONE_GIG / 2) + 0x0004,
-                (ONE_GIG / 2) + 0x1000,
-                (ONE_GIG - 0x1000),
-                (ONE_GIG - 0x0004),
-            };
-            for (size_t i = 0; i < 8192; ++i) {
-                uint64_t address = random_address_between(0, ONE_GIG);
-                test_offsets.push_back(address);
-            }
-        }
+            ASSERT_NE(sysmem, nullptr);
 
-        // Read test - read the sysmem at the various offsets.
-        for (uint64_t test_offset : test_offsets) {
-            uint64_t aligned_offset = (test_offset / ALIGNMENT) * ALIGNMENT;
-            uint64_t device_offset = aligned_offset + channel * ONE_GIG;
-            uint64_t noc_addr = base_address + device_offset;
-            uint32_t expected = 0;
-            uint32_t value = 0;
-
-            std::memcpy(&expected, &sysmem[aligned_offset], sizeof(uint32_t));
-
-            cluster->read_from_device(&value, mmio_chip_id, pcie_core, noc_addr, sizeof(uint32_t));
-
-            if (!is_simulation_test() && value != expected) {
-                std::stringstream error_msg;
-                const bool is_vm = test_utils::is_virtual_machine();
-                const bool has_iommu = test_utils::is_iommu_available();
-                error_msg << "Sysmem read mismatch at channel " << channel << ", offset 0x" << std::hex
-                          << aligned_offset << std::dec << " (NOC addr 0x" << std::hex << noc_addr << std::dec << ")"
-                          << "\n  Configuration: " << (is_vm ? "VM" : "Bare Metal")
-                          << ", IOMMU: " << (has_iommu ? "Enabled" : "Disabled") << ", Channels: " << channels
-                          << "\n  Expected: 0x" << std::hex << expected << ", Got: 0x" << value << std::dec;
-
-                if (is_vm && has_iommu) {
-                    error_msg << "\n"
-                              << "\n  - VM with IOMMU detected: This is likely a DMA mapping limit issue"
-                              << "\n  - FIX: On the HOST machine, add this kernel boot parameter:"
-                              << "\n      vfio_iommu_type1.dma_entry_limit=4294967295"
-                              << "\n  - After adding the parameter, reboot the HOST (not just the VM)"
-                              << "\n  - Check host dmesg for IO page faults"
-                              << "\n  - Failure at offset >= 255MB strongly indicates dma_entry_limit issue";
+            if (is_simulation_test()) {
+                // Sim only reads offset 0x0 (test_offsets == {0x0}); fill just the first page rather than a
+                // byte-at-a-time 1 GiB loop, which is slow and can time out CI.
+                for (size_t i = 0; i + sizeof(chip_pattern) <= 0x1000; i += sizeof(chip_pattern)) {
+                    std::memcpy(&sysmem[i], &chip_pattern, sizeof(chip_pattern));
                 }
-
-                FAIL() << error_msg.str();
             } else {
-                EXPECT_EQ(value, expected)
-                    << "Sysmem read mismatch at channel " << channel << ", offset 0x" << std::hex << aligned_offset
-                    << std::dec << " (NOC addr 0x" << std::hex << noc_addr << std::dec << ")\n"
-                    << "Expected: 0x" << std::hex << expected << ", Got: 0x" << value << std::dec;
+                test_utils::fill_with_random_bytes(sysmem, ONE_GIG);
             }
-        }
 
-        // Write test - zero out the sysmem at the various offsets.
-        for (uint64_t test_offset : test_offsets) {
-            uint64_t aligned_offset = (test_offset / ALIGNMENT) * ALIGNMENT;
-            uint64_t device_offset = aligned_offset + channel * ONE_GIG;
-            uint64_t noc_addr = base_address + device_offset;
-            uint32_t value = 0;
-            cluster->write_to_device(&value, sizeof(uint32_t), mmio_chip_id, pcie_core, noc_addr);
-            cluster->read_from_device(&value, mmio_chip_id, pcie_core, noc_addr, sizeof(uint32_t));
-        }
+            std::vector<uint64_t> test_offsets;
+            if (is_simulation_test()) {
+                test_offsets = {0x0};
+            } else {
+                test_offsets = {
+                    0x0,
+                    (ONE_GIG / 4) - 0x1000,
+                    (ONE_GIG / 4) - 0x0004,
+                    (ONE_GIG / 4),
+                    (ONE_GIG / 4) + 0x0004,
+                    (ONE_GIG / 4) + 0x1000,
+                    (ONE_GIG / 2) - 0x1000,
+                    (ONE_GIG / 2) - 0x0004,
+                    (ONE_GIG / 2),
+                    (ONE_GIG / 2) + 0x0004,
+                    (ONE_GIG / 2) + 0x1000,
+                    (ONE_GIG - 0x1000),
+                    (ONE_GIG - 0x0004),
+                };
+                for (size_t i = 0; i < 8192; ++i) {
+                    // Upper bound is inclusive; cap so an aligned 4-byte read stays inside the 1 GiB channel.
+                    uint64_t address = random_address_between(0, ONE_GIG - sizeof(uint32_t));
+                    test_offsets.push_back(address);
+                }
+            }
 
-        // Write test verification - read the sysmem at the various offsets and verify that each has been zeroed.
-        for (uint64_t test_offset : test_offsets) {
-            uint64_t aligned_offset = (test_offset / ALIGNMENT) * ALIGNMENT;
-            uint32_t value = 0xffffffff;
-            std::memcpy(&value, &sysmem[aligned_offset], sizeof(uint32_t));
-            EXPECT_EQ(value, 0);
+            // Read test - read the sysmem at the various offsets.
+            for (uint64_t test_offset : test_offsets) {
+                uint64_t aligned_offset = (test_offset / ALIGNMENT) * ALIGNMENT;
+                uint64_t device_offset = aligned_offset + channel * ONE_GIG;
+                uint64_t noc_addr = base_address + device_offset;
+                uint32_t expected = 0;
+                uint32_t value = 0;
+
+                std::memcpy(&expected, &sysmem[aligned_offset], sizeof(uint32_t));
+
+                cluster->read_from_device(&value, mmio_chip_id, pcie_core, noc_addr, sizeof(uint32_t));
+
+                if (!is_simulation_test() && value != expected) {
+                    std::stringstream error_msg;
+                    const bool is_vm = test_utils::is_virtual_machine();
+                    const bool has_iommu = test_utils::is_iommu_available();
+                    error_msg << "Sysmem read mismatch at channel " << channel << ", offset 0x" << std::hex
+                              << aligned_offset << std::dec << " (NOC addr 0x" << std::hex << noc_addr << std::dec
+                              << ")"
+                              << "\n  Configuration: " << (is_vm ? "VM" : "Bare Metal")
+                              << ", IOMMU: " << (has_iommu ? "Enabled" : "Disabled") << ", Channels: " << channels
+                              << "\n  Expected: 0x" << std::hex << expected << ", Got: 0x" << value << std::dec;
+
+                    if (is_vm && has_iommu) {
+                        error_msg << "\n"
+                                  << "\n  - VM with IOMMU detected: This is likely a DMA mapping limit issue"
+                                  << "\n  - FIX: On the HOST machine, add this kernel boot parameter:"
+                                  << "\n      vfio_iommu_type1.dma_entry_limit=4294967295"
+                                  << "\n  - After adding the parameter, reboot the HOST (not just the VM)"
+                                  << "\n  - Check host dmesg for IO page faults"
+                                  << "\n  - Failure at offset >= 255MB strongly indicates dma_entry_limit issue";
+                    }
+
+                    FAIL() << error_msg.str();
+                } else {
+                    EXPECT_EQ(value, expected)
+                        << "Sysmem read mismatch at channel " << channel << ", offset 0x" << std::hex << aligned_offset
+                        << std::dec << " (NOC addr 0x" << std::hex << noc_addr << std::dec << ")\n"
+                        << "Expected: 0x" << std::hex << expected << ", Got: 0x" << value << std::dec;
+                }
+            }
+
+            // Write test - zero out the sysmem at the various offsets.
+            for (uint64_t test_offset : test_offsets) {
+                uint64_t aligned_offset = (test_offset / ALIGNMENT) * ALIGNMENT;
+                uint64_t device_offset = aligned_offset + channel * ONE_GIG;
+                uint64_t noc_addr = base_address + device_offset;
+                uint32_t value = 0;
+                cluster->write_to_device(&value, sizeof(uint32_t), mmio_chip_id, pcie_core, noc_addr);
+                cluster->read_from_device(&value, mmio_chip_id, pcie_core, noc_addr, sizeof(uint32_t));
+            }
+
+            // Write test verification - read the sysmem at the various offsets and verify that each has been zeroed.
+            for (uint64_t test_offset : test_offsets) {
+                uint64_t aligned_offset = (test_offset / ALIGNMENT) * ALIGNMENT;
+                uint32_t value = 0xffffffff;
+                std::memcpy(&value, &sysmem[aligned_offset], sizeof(uint32_t));
+                EXPECT_EQ(value, 0);
+            }
         }
     }
 }

--- a/tests/test_utils/device_test_utils.hpp
+++ b/tests/test_utils/device_test_utils.hpp
@@ -72,6 +72,9 @@ inline std::unique_ptr<Cluster> make_default_test_cluster(ClusterOptions options
         options.num_host_mem_ch_per_mmio_device = needs_sysmem ? get_num_host_ch_for_test() : 0UL;
     }
     if (const char* sim_path = std::getenv("TT_UMD_SIMULATOR")) {
+        // A multichip simulator's topology is auto-discovered by the Cluster from a cluster_descriptor.yaml
+        // placed beside the .so (see SimulationChip::get_cluster_descriptor_path_from_simulator_path); no
+        // test-side env var is needed.
         options = get_default_sim_cluster_options(sim_path, std::nullopt, std::move(options));
     }
     return std::make_unique<Cluster>(options);


### PR DESCRIPTION
### Issue
Part of #2679, tracked by #2832. Split out of #2825; builds on #2985.

### Description
Drive a multi-MMIO multi-chip TTSim (e.g. the Blackhole P300 — two MMIO chips). With no multichip ABI but a >1-chip cluster, all chips share one dlopen and are addressed by PCI device (BDF) + per-device BAR window — the host-enumeration model — so no new ttsim ABI is needed. Combined with the iATU host-DMA routing (#2985), each chip's DMA lands in its own host window by address alone.

### List of the changes
- `TTSimCommunicator`: shared-dlopen BDF mode for a >1-chip cluster addressed by PCI device; BDF device-field fill-in in `pci_config_read32`; shared init/refcount/teardown.
- Thread `num_chips` through `TTSimTTDevice` and `create_simulation_tt_device`.
- CI: add the bh_x2 (P300) lane; `SysmemReadWrite` exercises every MMIO chip with a chip-distinct pattern to catch DMA misrouting.

### Testing
CI

### API Changes
Additive and default-compatible: `TTSimCommunicator` and `TTSimTTDevice` gain a `num_chips` parameter (default 1).