### PR TITLE
emule: SWEmuleChip host-memory stack (SysmemManager + TLB)

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -68,6 +68,7 @@ target_sources(
         chip/mock_chip.cpp
         chip/remote_chip.cpp
         $<$<BOOL:${TT_UMD_BUILD_EMULE}>:chip/sw_emule_chip.cpp>
+        $<$<BOOL:${TT_UMD_BUILD_EMULE}>:chip_helpers/emule_tlb.cpp>
         chip_helpers/sysmem_manager.cpp
         chip_helpers/simulation_sysmem_manager.cpp
         chip_helpers/silicon_sysmem_manager.cpp

--- a/device/api/umd/device/chip/sw_emule_chip.hpp
+++ b/device/api/umd/device/chip/sw_emule_chip.hpp
@@ -116,6 +116,15 @@ private:
     uint64_t dram_bank_size_;
 
     SocDescriptor soc_descriptor_;
+
+    // Host-visible system memory model. emule reuses SimulationSysmemManager
+    // (mmap-backed, no PCIe/IOMMU) so PinnedMemory / H2D-D2H sockets can map a
+    // host buffer to a device IO / NOC address (pcie_base_ + arena offset).
+    std::unique_ptr<SysmemManager> sysmem_manager_;
+
+    // Static per-core TLB windows for the host→device-L1 writer path (sockets).
+    // Routes write_block/read_block to this chip's tt_emule::Core storage.
+    std::unique_ptr<TLBManager> tlb_manager_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/emule_tlb.hpp
+++ b/device/api/umd/device/chip_helpers/emule_tlb.hpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "umd/device/chip_helpers/tlb_manager.hpp"
+#include "umd/device/pcie/tlb_handle.hpp"
+#include "umd/device/pcie/tlb_window.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/types/tlb.hpp"
+
+namespace tt::umd {
+
+class SWEmuleChip;
+
+// emule host-side device-memory access, modeled on the SimulationChip TLB stack
+// but routed to SWEmuleChip's tt_emule::Core storage instead of a real (or
+// simulated) MMIO window. Needed because host↔device paths that go through the
+// static-TLB writer on Blackhole (e.g. H2DSocket::init_receiver_tlb) call
+// get_tlb_manager()->get_tlb_window(core)->write_block(...), which the emule
+// chip previously answered with nullptr.
+
+// No real MMIO mapping. Carries a large power-of-two window size so TlbWindow's
+// alignment math (local_offset & ~(size-1)) never truncates a device L1 address.
+class EmuleTlbHandle : public TlbHandle {
+public:
+    EmuleTlbHandle(tt::ARCH arch, size_t size, int tlb_id);
+
+    void configure(const tlb_data& new_config) override;
+    tt::ARCH get_arch() const override;
+
+private:
+    void free_tlb() noexcept override {}
+
+    tt::ARCH arch_;
+};
+
+// Routes all access to the SWEmuleChip's tt_emule::Core at the window's currently
+// configured (x_end, y_end) TRANSLATED core, address get_base_address() + offset.
+// This composes with the base-class *_reconfigure paths, which mutate the config
+// (via configure()) and then call block(0, ...).
+class EmuleTlbWindow : public TlbWindow {
+public:
+    EmuleTlbWindow(std::unique_ptr<TlbHandle> handle, SWEmuleChip* chip, const tlb_data config = {});
+
+    void write16(uint64_t offset, uint16_t value) override;
+    uint16_t read16(uint64_t offset) override;
+    void write32(uint64_t offset, uint32_t value) override;
+    uint32_t read32(uint64_t offset) override;
+    void write_register(uint64_t offset, const void* data, size_t size) override;
+    void read_register(uint64_t offset, void* data, size_t size) override;
+    void write_block(uint64_t offset, const void* data, size_t size) override;
+    void read_block(uint64_t offset, void* data, size_t size) override;
+    void safe_write16(uint64_t offset, uint16_t value) override;
+    uint16_t safe_read16(uint64_t offset) override;
+
+private:
+    CoreCoord target_core() const;
+    uint64_t target_addr(uint64_t offset) const;
+
+    SWEmuleChip* chip_;
+};
+
+// Pre-populates one full-address-space window per TENSIX core (Blackhole
+// statically maps the entire device address space, so get_tlb_window(core) is
+// expected to already have a window). Built with a null TTDevice — only the
+// map-backed get_tlb_window / is_tlb_mapped paths are used.
+class EmuleTlbManager : public TLBManager {
+public:
+    explicit EmuleTlbManager(SWEmuleChip* chip);
+
+private:
+    SWEmuleChip* chip_;
+    int next_tlb_id_ = 0;
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
@@ -50,6 +50,12 @@ public:
     bool write_mapped_buffer(uint64_t device_io_addr, const void* src, uint32_t size);
     bool read_mapped_buffer(uint64_t device_io_addr, void* dst, uint32_t size);
 
+    // Resolve a device IO address (pcie_base_ + arena offset) to the host pointer
+    // of the buffer that covers it, or nullptr on a miss. Used by the emule kernel
+    // runner to route NOC reads/writes that target host sysmem (PinnedMemory /
+    // H2D-D2H sockets) to the mapped host buffer.
+    uint8_t* resolve_host_ptr(uint64_t device_io_addr, uint32_t size) override;
+
 protected:
     bool init_sysmem(uint32_t num_host_mem_channels) override;
 

--- a/device/api/umd/device/chip_helpers/sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_manager.hpp
@@ -58,6 +58,11 @@ public:
 
     static uint64_t get_pcie_base_for_arch(tt::ARCH arch);
 
+    // Resolve a device IO address to a host pointer for managers that back sysmem
+    // with host memory (e.g. SimulationSysmemManager under emule). Returns nullptr
+    // by default (silicon managers map to real device IO, not a host pointer).
+    virtual uint8_t* resolve_host_ptr(uint64_t /*device_io_addr*/, uint32_t /*size*/) { return nullptr; }
+
 protected:
     virtual bool init_sysmem(uint32_t num_host_mem_channels) = 0;
 

--- a/device/chip/sw_emule_chip.cpp
+++ b/device/chip/sw_emule_chip.cpp
@@ -14,6 +14,8 @@
 
 #include "tt_emule/device.hpp"
 #include "tt_emule/l1_pool.hpp"
+#include "umd/device/chip_helpers/emule_tlb.hpp"
+#include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
 #include "umd/device/soc_descriptor.hpp"
 
 namespace tt::umd {
@@ -39,6 +41,16 @@ SWEmuleChip::SWEmuleChip(const SocDescriptor& soc_descriptor) :
     size_t num_tensix = soc.get_cores(tt::CoreType::TENSIX).size();
     size_t pool_size = (num_tensix > 0 ? num_tensix : 128);  // 128 = WH/BH fallback if SOC reports 0
     worker_pool_ = std::make_unique<tt_emule::L1Pool>(pool_size);
+
+    // A single 1 GB host-memory channel is ample — PinnedMemory / socket buffers
+    // are KB-MB and the mmap is overcommitted (only touched pages use RAM). Gives
+    // PinnedMemory / H2D-D2H sockets a working map_sysmem_buffer on emule.
+    sysmem_manager_ = std::make_unique<SimulationSysmemManager>(/*num_host_mem_channels=*/1, soc.arch);
+
+    // Static per-core TLB windows (host→device-L1 writer path). Blackhole
+    // statically maps the whole device address space, so get_tlb_window(core)
+    // must already return a window for any TENSIX core the host writes.
+    tlb_manager_ = std::make_unique<EmuleTlbManager>(this);
 }
 
 // One physical backing per DRAM CHANNEL. A channel is fronted by several NOC endpoint
@@ -141,9 +153,9 @@ void SWEmuleChip::close_device() {}
 
 TTDevice* SWEmuleChip::get_tt_device() { return nullptr; }
 
-SysmemManager* SWEmuleChip::get_sysmem_manager() { return nullptr; }
+SysmemManager* SWEmuleChip::get_sysmem_manager() { return sysmem_manager_.get(); }
 
-TLBManager* SWEmuleChip::get_tlb_manager() { return nullptr; }
+TLBManager* SWEmuleChip::get_tlb_manager() { return tlb_manager_.get(); }
 
 // --- Host memory (no-ops) ---
 

--- a/device/chip_helpers/emule_tlb.cpp
+++ b/device/chip_helpers/emule_tlb.cpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/chip_helpers/emule_tlb.hpp"
+
+#include <cstring>
+
+#include "umd/device/chip/sw_emule_chip.hpp"
+#include "umd/device/soc_descriptor.hpp"
+
+namespace tt::umd {
+
+// Larger than any device L1/DRAM address and a power of two, so TlbWindow's
+// alignment (local_offset & ~(size-1)) leaves the full address in the
+// sub-alignment remainder — the window never truncates or splits an access.
+static constexpr size_t kEmuleTlbWindowSize = size_t(1) << 40;
+
+// --- EmuleTlbHandle ---
+
+EmuleTlbHandle::EmuleTlbHandle(tt::ARCH arch, size_t size, int tlb_id) : arch_(arch) {
+    tlb_size_ = size;
+    tlb_id_ = tlb_id;
+    tlb_mapping_ = TlbMapping::WC;
+}
+
+void EmuleTlbHandle::configure(const tlb_data& new_config) { tlb_config_ = new_config; }
+
+tt::ARCH EmuleTlbHandle::get_arch() const { return arch_; }
+
+// --- EmuleTlbWindow ---
+
+EmuleTlbWindow::EmuleTlbWindow(std::unique_ptr<TlbHandle> handle, SWEmuleChip* chip, const tlb_data config) :
+    TlbWindow(std::move(handle), config), chip_(chip) {}
+
+CoreCoord EmuleTlbWindow::target_core() const {
+    const tlb_data& cfg = handle_ref().get_config();
+    // TLB configs carry TRANSLATED core coords (see TLBManager::configure_tlb);
+    // SWEmuleChip::write_to_device keys tt_emule::Core storage on that raw (x,y).
+    return CoreCoord(
+        static_cast<size_t>(cfg.x_end), static_cast<size_t>(cfg.y_end), CoreType::TENSIX, CoordSystem::TRANSLATED);
+}
+
+uint64_t EmuleTlbWindow::target_addr(uint64_t offset) const { return get_base_address() + offset; }
+
+void EmuleTlbWindow::write_block(uint64_t offset, const void* data, size_t size) {
+    validate(offset, size);
+    chip_->write_to_device(target_core(), data, target_addr(offset), size);
+}
+
+void EmuleTlbWindow::read_block(uint64_t offset, void* data, size_t size) {
+    validate(offset, size);
+    chip_->read_from_device(target_core(), data, target_addr(offset), size);
+}
+
+void EmuleTlbWindow::write32(uint64_t offset, uint32_t value) { write_block(offset, &value, sizeof(value)); }
+
+uint32_t EmuleTlbWindow::read32(uint64_t offset) {
+    uint32_t value = 0;
+    read_block(offset, &value, sizeof(value));
+    return value;
+}
+
+void EmuleTlbWindow::write16(uint64_t offset, uint16_t value) { write_block(offset, &value, sizeof(value)); }
+
+uint16_t EmuleTlbWindow::read16(uint64_t offset) {
+    uint16_t value = 0;
+    read_block(offset, &value, sizeof(value));
+    return value;
+}
+
+void EmuleTlbWindow::write_register(uint64_t offset, const void* data, size_t size) {
+    write_block(offset, data, size);
+}
+
+void EmuleTlbWindow::read_register(uint64_t offset, void* data, size_t size) { read_block(offset, data, size); }
+
+void EmuleTlbWindow::safe_write16(uint64_t offset, uint16_t value) { write16(offset, value); }
+
+uint16_t EmuleTlbWindow::safe_read16(uint64_t offset) { return read16(offset); }
+
+// --- EmuleTlbManager ---
+
+EmuleTlbManager::EmuleTlbManager(SWEmuleChip* chip) : TLBManager(nullptr), chip_(chip) {
+    const SocDescriptor& soc = chip->get_soc_descriptor();
+    for (const CoreCoord& core : soc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)) {
+        const int tlb_id = next_tlb_id_++;
+        tlb_data config{};
+        config.local_offset = 0;
+        config.x_end = core.x;
+        config.y_end = core.y;
+
+        auto handle = std::make_unique<EmuleTlbHandle>(soc.arch, kEmuleTlbWindowSize, tlb_id);
+        auto window = std::make_unique<EmuleTlbWindow>(std::move(handle), chip_, config);
+
+        tlb_config_map_.insert({tlb_id, 0});
+        map_core_to_tlb_.insert({tt_xy_pair(core.x, core.y), tlb_id});
+        tlb_windows_.insert({tlb_id, std::move(window)});
+    }
+}
+
+}  // namespace tt::umd

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -132,6 +132,15 @@ bool SimulationSysmemManager::read_mapped_buffer(uint64_t device_io_addr, void* 
     return true;
 }
 
+uint8_t* SimulationSysmemManager::resolve_host_ptr(uint64_t device_io_addr, uint32_t size) {
+    std::lock_guard<std::mutex> lock(registry_->mutex);
+    auto b = find_mapped_buffer_locked(device_io_addr, size);
+    if (!b.has_value()) {
+        return nullptr;
+    }
+    return static_cast<uint8_t*>(b->buffer) + (device_io_addr - b->device_io_addr);
+}
+
 std::unique_ptr<SysmemBuffer> SimulationSysmemManager::allocate_sysmem_buffer(
     size_t sysmem_buffer_size, const bool map_to_noc) {
     void* mapping =


### PR DESCRIPTION
## What

Give `SWEmuleChip` a working host-memory stack so PinnedMemory / H2D-D2H socket ops function under the emule software emulator. Foundation for the blaze migration op bring-up (host↔device DMA).

Two commits:
1. **`SimulationSysmemManager::resolve_host_ptr`** — maps a device IO address (`pcie_base_ + arena offset`) back to the covering mapped buffer's host pointer (reuses `find_mapped_buffer_locked`). Virtual on `SysmemManager` (default `nullptr`). Lets the kernel runner route NOC reads/writes that target host sysmem to the mapped host buffer.
2. **Wire SysmemManager + TLB into `SWEmuleChip`** — `get_sysmem_manager()`/`get_tlb_manager()` returned `nullptr` (PinnedMemory threw at setup; `get_tlb_window` segfaulted). Now: `SimulationSysmemManager(1 channel, arch)` (mmap-backed, no PCIe) + a new `EmuleTlb{Handle,Window,Manager}` stack that routes host→device-L1 `write_block`/`read_block` to this chip's `tt_emule::Core` storage (one full-address-space window per TENSIX core, TRANSLATED coords, since BH maps statically and `get_tlb_window` is non-virtual). Guarded by `TT_UMD_BUILD_EMULE`.

## Base

Emule-specific work atop the blaze tt-metal umd **pin** (`fa06d8d2`). The PR base branch `xchin/emule-blaze-umd-pin` is a marker at that pin so the diff is exactly these two commits. (The older `emule-blaze-metal-umd` line is stale — based on `e85ef957`, it predates `SimulationSysmemManager`, so it can't host this work.)

## Reusable

The SysmemManager + TLB stack is reusable by **any** PinnedMemory / socket op, not just migration.

## Status

Draft — emule-specific downstream change against the pin; opened for review/record. Paired with the tt-metal runner sysmem-hook PR (which bumps the umd submodule to this branch).
