### PR TITLE
Switch P300 CI runner from bh-gh-07 to P300-viommu

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -107,7 +107,7 @@ jobs:
         # Note on the machines:
         # To avoid contention on single machines, we blacklist PR runs, and merge queue runs on Asan and Tsan,
         # as these are unlikely to be the only failures. We also don't need both hugepage and viommu runs.
-        # - P300-viommu is a dedicated P300 single machine.
+        # - P300-viommu is a shared pool of 3 P300 machines.
         # - bh-loudbox is a single machine in CIv2. It also has an additional problem where
         #   it actually has a ~20min startup time for viommu variant, so this one can be really slow.
         # - The wh-glx-6u is also one machine, but not yet fully proven, so don't want to block merge queue with it.

--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -66,7 +66,7 @@ jobs:
         id: define
         run: |
           # TODO: tt-ubuntu-2204-p100a-stable to be added when available
-          # bh-gh-07 is a P300 runner
+          # P300-viommu is a P300 runner
           CARDS=$(cat <<'EOF'
           [
             {"arch": "wormhole_b0", "card": "tt-ubuntu-2204-n150-stable"},
@@ -81,7 +81,7 @@ jobs:
             {"arch": "wormhole_b0", "card": "6u"},
             {"arch": "wormhole_b0", "card": "tt-ubuntu-2204-wh-glx-6u-stable"},
             {"arch": "wormhole_b0", "card": "tt-ubuntu-2204-wh-glx-6u-viommu-stable"},
-            {"arch": "blackhole",   "card": "bh-gh-07"},
+            {"arch": "blackhole",   "card": "P300-viommu"},
             {"arch": "blackhole",   "card": "tt-ubuntu-2204-bh-loudbox-stable"},
             {"arch": "blackhole",   "card": "tt-ubuntu-2204-bh-loudbox-viommu-stable"},
             {"arch": "baremetal",   "card": "ubuntu-22.04"}
@@ -107,8 +107,7 @@ jobs:
         # Note on the machines:
         # To avoid contention on single machines, we blacklist PR runs, and merge queue runs on Asan and Tsan,
         # as these are unlikely to be the only failures. We also don't need both hugepage and viommu runs.
-        # - bh-gh-07 is a dedicated P300 single machine. TEMPORARILY DISABLED via the
-        #   '*|*|bh-gh-07' entry below; offline/flaky, see #2991. Remove to re-enable.
+        # - P300-viommu is a dedicated P300 single machine.
         # - bh-loudbox is a single machine in CIv2. It also has an additional problem where
         #   it actually has a ~20min startup time for viommu variant, so this one can be really slow.
         # - The wh-glx-6u is also one machine, but not yet fully proven, so don't want to block merge queue with it.
@@ -123,10 +122,9 @@ jobs:
             'merge_group|TSan|tt-ubuntu-2204-bh-loudbox-stable' \
             'pull_request|*|tt-ubuntu-2204-wh-glx-6u-*' \
             'merge_group|*|tt-ubuntu-2204-wh-glx-6u-*' \
-            'pull_request|*|bh-gh-07' \
-            'merge_group|ASan|bh-gh-07' \
-            'merge_group|TSan|bh-gh-07' \
-            '*|*|bh-gh-07' \
+            'pull_request|*|P300-viommu' \
+            'merge_group|ASan|P300-viommu' \
+            'merge_group|TSan|P300-viommu' \
             'pull_request|*|tt-ubuntu-2204-p100a-*' \
             'merge_group|*|tt-ubuntu-2204-p100a-*' \
           )

--- a/.github/workflows/test-runner.yaml
+++ b/.github/workflows/test-runner.yaml
@@ -28,7 +28,7 @@ jobs:
           tt-ubuntu-2204-n300-llmbox-viommu-stable,
           tt-ubuntu-2204-p150b-stable,
           tt-ubuntu-2204-p150b-viommu-stable,
-          bh-gh-07,
+          P300-viommu,
           tt-ubuntu-2204-bh-loudbox-viommu-stable]
 
     name: Check runner
@@ -91,7 +91,7 @@ jobs:
           tt-ubuntu-2204-n300-llmbox-viommu-stable,
           tt-ubuntu-2204-p150b-stable,
           tt-ubuntu-2204-p150b-viommu-stable,
-          bh-gh-07,
+          P300-viommu,
           tt-ubuntu-2204-bh-loudbox-viommu-stable]
         image: [tt-umd-ci-ubuntu-22.04, tt-umd-ci-ubuntu-24.04]
 


### PR DESCRIPTION
## What

Replace the hardcoded `bh-gh-07` runner label with `P300-viommu` across the CI workflows:

- `.github/workflows/test-runner.yaml` — host and docker runner check matrices
- `.github/workflows/build-and-run-all-tests.yml` — card list, comments, and blacklist entries

## Why

`bh-gh-07` was the ad-hoc machine name for the P300 runner and had been temporarily fully disabled because it was offline/flaky (#2991). `P300-viommu` is the working replacement (shared pool of 3 P300 runners)

## Reviewer notes

- The `'*|*|bh-gh-07'` full-disable blacklist entry (the #2991 temporary disable) is **dropped**, so the new runner actually runs. Keeping it renamed would have left `P300-viommu` disabled in every context.
- The standard single-machine contention blacklist entries (`pull_request|*`, `merge_group|ASan`, `merge_group|TSan`) are retained and renamed to `P300-viommu`.
- The `P300-viommu` label must match exactly what is registered in GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)