### PR TITLE
Fix false-positive NOC hangs from the per-op MMIO timeout

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -251,8 +251,7 @@ jobs:
         test-group: [
           {runs-on: tt-ubuntu-2204-p150b-stable},
           {runs-on: tt-ubuntu-2204-n150-stable},
-          # TODO(#2981): Re-enable once exalens tests NOC0 hang bug is resolved.
-          # {runs-on: tt-ubuntu-2204-n300-stable},
+          {runs-on: tt-ubuntu-2204-n300-stable},
         ]
         ubuntu-docker-version: [
           'ubuntu-22.04',

--- a/device/api/umd/device/pcie/silicon_tlb_window.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_window.hpp
@@ -88,7 +88,7 @@ public:
     // Wires the per-op MMIO timeout: on a single-op overrun hang_check is consulted for the window's
     // currently configured NOC. Returning true means that NOC is hung (the transfer aborts with
     // DeviceTimeoutError); false means it is healthy (a slow-but-completing op is not a false positive).
-    // When empty (the default), an overrun aborts outright.
+    // When empty (the default), overruns are treated as false alarms and never abort on time alone.
     void set_io_timeout_hang_check(const std::function<bool(NocId)>& hang_check) override;
 
     // Reconfigures the window and refreshes the cached timeout callback, since the NOC may have changed.
@@ -100,8 +100,9 @@ private:
     // Rebuilds io_timeout_callback_ (an OpTimeoutGuard is_false_alarm callback) for the window's currently
     // configured NOC: true means "healthy, false positive" so the overrun is ignored, false confirms it.
     // The NOC is read from the live TLB config, so this must be called whenever the config or hang check
-    // changes (construction, configure(), set_io_timeout_hang_check()). Leaves an empty callback when no
-    // hang check is wired, which makes an overrun abort.
+    // changes (construction, configure(), set_io_timeout_hang_check()). When no hang check is wired it
+    // installs a callback that always reports a false alarm, so a bare per-op timeout never aborts on
+    // time alone (avoids false-positive NOC hangs; see #2981).
     void update_io_timeout_callback();
 
     // Custom device memcpy. This is only safe for memory-like regions on the device (Tensix L1, DRAM, ARC CSM).

--- a/device/api/umd/device/utils/timeouts.hpp
+++ b/device/api/umd/device/utils/timeouts.hpp
@@ -10,11 +10,13 @@ namespace tt::umd::timeout {
 inline constexpr auto NON_MMIO_RW_TIMEOUT = std::chrono::milliseconds(5'000);
 
 // Default per-op budget for a single host-side MMIO (TLB-mapped) transfer, overridable at runtime via
-// MmioTimeoutConfig::set_op_timeout. A healthy MMIO op is microseconds, but on a contended/virtualized
-// host (e.g. a viommu CI runner) a single op can take several ms; 10 ms sits above that floor so the
-// hang-detector veto's own probe read completes and a slow-but-healthy op continues, while staying well
-// below the ~700 ms latency of a read on a hung NOC so genuine hangs are still caught promptly.
-inline constexpr auto MMIO_OP_TIMEOUT = std::chrono::milliseconds(10);
+// MmioTimeoutConfig::set_op_timeout. A healthy MMIO op is microseconds; 2 ms sits well above that yet far
+// below the ~700 ms latency of a read on a hung NOC, so genuine hangs are still caught promptly. A slow-
+// but-healthy op that overruns this budget is not aborted: on a window with a hang detector the overrun is
+// vetoed once the liveness probe reads a healthy value, and on a window without one every overrun is
+// treated as a false alarm (see SiliconTlbWindow). This makes the budget robust to a low value even on a
+// contended/virtualized host (e.g. a viommu CI runner) where a single op can take several ms.
+inline constexpr auto MMIO_OP_TIMEOUT = std::chrono::milliseconds(2);
 
 inline constexpr auto ARC_MESSAGE_TIMEOUT = std::chrono::milliseconds(1'000);
 // ARC clears the interrupt trigger bit quickly; this just guards against concurrent

--- a/device/pcie/silicon_tlb_window.cpp
+++ b/device/pcie/silicon_tlb_window.cpp
@@ -83,7 +83,12 @@ void SiliconTlbWindow::configure(const tlb_data &new_config) {
 
 void SiliconTlbWindow::update_io_timeout_callback() {
     if (!hang_check_) {
-        io_timeout_callback_ = {};
+        // No hang check wired: default to treating every overrun as a false alarm so a bare per-op
+        // timeout never aborts on time alone. Without a detector there is nothing to distinguish a slow
+        // op from a hung one, and aborting on time alone produces false-positive NOC hangs (see #2981).
+        // The probe window relies on this: it reads the value out and lets is_noc_hung() judge it against
+        // HANG_READ_VALUE, rather than inferring a hang from a probe-read timeout.
+        io_timeout_callback_ = []() -> bool { return true; };
         return;
     }
     // The live TLB config's noc_sel is whatever the last (re)configure selected, so it identifies the

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -418,15 +418,12 @@ void TTDevice::set_hang_detector(std::unique_ptr<HangDetector> hang_detector) {
     auto window_lock = std::make_shared<std::mutex>();
     hang_detector_->set_noc_reg_reader([window, window_lock](tt_xy_pair core, uint64_t addr, NocId noc) -> uint32_t {
         std::lock_guard<std::mutex> lock(*window_lock);
+        // The probe window has no hang check wired, so an overrun is treated as a false alarm and the read
+        // completes rather than throwing; a hung NOC surfaces as HANG_READ_VALUE in `value`. A
+        // DeviceTimeoutError propagating out of the probe read is therefore not expected — let it surface
+        // rather than silently masking it as a hang.
         uint32_t value = 0;
-        try {
-            window->read_block_reconfigure(&value, core, addr, sizeof(value), noc);
-        } catch (const error::UmdException<error::DeviceTimeoutError> &) {
-            // The probe window has no hang check wired, so an overrun is treated as a false alarm and the
-            // read completes rather than throwing; a hung NOC surfaces as HANG_READ_VALUE in `value`. This
-            // catch is a defensive fallback in case a timeout ever does propagate.
-            return HANG_READ_VALUE;
-        }
+        window->read_block_reconfigure(&value, core, addr, sizeof(value), noc);
         return value;
     });
 }

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -422,7 +422,9 @@ void TTDevice::set_hang_detector(std::unique_ptr<HangDetector> hang_detector) {
         try {
             window->read_block_reconfigure(&value, core, addr, sizeof(value), noc);
         } catch (const error::UmdException<error::DeviceTimeoutError> &) {
-            // The probe read carries its own per-op budget; an overrun means the NOC is hung.
+            // The probe window has no hang check wired, so an overrun is treated as a false alarm and the
+            // read completes rather than throwing; a hung NOC surfaces as HANG_READ_VALUE in `value`. This
+            // catch is a defensive fallback in case a timeout ever does propagate.
             return HANG_READ_VALUE;
         }
         return value;


### PR DESCRIPTION
### Issue
Closes #2981

### Description
The per-op MMIO timeout (#2629) reported false-positive NOC hangs on healthy devices whenever the budget was set low (e.g. exalens' 2 ms). Two mechanisms were at play. First, a TLB window with no hang detector wired left an empty timeout callback, so any overrun aborted with `DeviceTimeoutError` on time alone — nothing distinguished a slow-but-healthy op from a genuinely hung one. Second, the hang-detector's own NOC-liveness probe reads through exactly such a no-hang-check window; when the budget sat below the probe read's latency the probe itself timed out and was interpreted as a hang, so a healthy device threw `NocHangError` during device init.

The fix defaults a no-hang-check window to treating every overrun as a false alarm, so a bare per-op timeout never aborts on time alone and the probe read completes and is judged by value (`HANG_READ_VALUE`) rather than by elapsed time. With the probe no longer time-sensitive, the default budget no longer needs headroom for it, so it is lowered back to 2 ms, and the probe reader no longer swallows a `DeviceTimeoutError` as a hang.

### List of the changes
- `SiliconTlbWindow`: with no hang detector wired, default the I/O-timeout callback to always-false-alarm (was empty) so an overrun is not aborted on time alone.
- Lower the default per-op MMIO budget from 10 ms to 2 ms.
- Hang-detector probe reader: drop the `catch` that returned `HANG_READ_VALUE` on `DeviceTimeoutError`; let an unexpected probe timeout surface instead of being reported as a hang.
- Update the related doc comments.

### Testing
CI

### API Changes
This PR has no API changes.
