### PR TITLE
Fix SysmemReadWrite test to fill only the first page in simulation mode

### DIFF
--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -577,7 +577,9 @@ TEST_F(TestDeviceIOFixture, SysmemReadWrite) {
         ASSERT_NE(sysmem, nullptr);
 
         if (is_simulation_test()) {
-            for (size_t i = 0; i < ONE_GIG; i++) {
+            // The simulation path only exercises offset 0x0. Fill just one (first) page for that case.
+            constexpr size_t SIM_FILL_SIZE = 0x1000;
+            for (size_t i = 0; i < SIM_FILL_SIZE; i++) {
                 sysmem[i] = i % 256;
             }
         } else {


### PR DESCRIPTION
### Issue
#2935

### Description
Fixes occasional CI timeouts in TestDeviceIOFixture.SysmemReadWrite on the ttsim runner. The simulation path filled a full 1 GB buffer byte by byte but only reads offset 0. The sim path now fills only the first page.

### List of the changes
 - In the simulation branch, fill only the first page instead of the full 1 GB, keeping the same pattern for the bytes actually read. Silicon path unchanged.

### Testing
Local runs and CI.

### API Changes
This PR has no API changes.
