### PR TITLE
Add fix for harvested core issue

### DIFF
--- a/nanobind/tests/test_py_tt_device.py
+++ b/nanobind/tests/test_py_tt_device.py
@@ -293,8 +293,15 @@ class TestTTDevice(unittest.TestCase):
                     f"Remote device {chip} should be remote",
                 )
 
-            val = umd_tt_devices[chip].noc_read32(9, 0, 0)
-            print(f"Read value from device, core 9,0 addr 0x0: {val}")
+            tt_device = umd_tt_devices[chip]
+            soc_descriptor = tt_umd.SocDescriptor(tt_device)
+            tensix_core = soc_descriptor.get_cores(
+                tt_umd.CoreType.TENSIX, tt_umd.CoordSystem.TRANSLATED
+            )[0]
+            val = tt_device.noc_read32(tensix_core.x, tensix_core.y, 0)
+            print(
+                f"Read value from device {chip}, core {tensix_core.x},{tensix_core.y} addr 0x0: {val}"
+            )
 
     def test_read_kmd_version(self):
         # Test reading KMD version


### PR DESCRIPTION
### Issue
#3000 

### Description
`test_remote_tt_device` hardcoded `noc_read32(9, 0, 0)`, which is a DRAM endpoint on NOC0. On SKUs where that bank is harvested (e.g. Blackhole p100 → `d9-0`), the read hits a dead endpoint and aborts with `DeviceTimeoutError`. Now it reads a live Tensix core sourced from the SoC descriptor, matching the other tests in the file.

### List of the changes
- `test_remote_tt_device`: replace hardcoded `noc_read32(9, 0, 0)` with a core from `SocDescriptor.get_cores(CoreType.TENSIX, CoordSystem.TRANSLATED)[0]` (excludes harvested cores).

### Testing
CI (green on p100a, which previously failed this test).

### API Changes
This PR has no API changes.
