### PR TITLE
Simulation: serve device memory over the socket (host handler)

### DIFF
--- a/device/api/umd/device/tt_device/simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/simulation_tt_device.hpp
@@ -9,6 +9,7 @@
 #include <filesystem>
 #include <memory>
 #include <mutex>
+#include <vector>
 
 #include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
@@ -133,6 +134,15 @@ protected:
     // Exposes this device on disk as a UNIX socket ("the card"), so other UMD clients can find it.
     // The host keeps its own direct in-process fast path; the socket is for remote clients.
     std::unique_ptr<SimulationServerSocket> socket_;
+
+private:
+    // Serves one socket request against this host device: decodes the wire request, runs it
+    // through read_from_device/write_to_device -- the client has already translated coordinates,
+    // so they are passed as LITERAL (no re-translation) -- and encodes the reply. Runs on the
+    // socket's connection threads; read/write take device_lock, so concurrent host + client
+    // access is serialized. The socket layer stays protocol-agnostic; this is where the protocol
+    // is (de)serialized.
+    std::vector<uint8_t> handle_request(const std::vector<uint8_t>& request_bytes);
 };
 
 }  // namespace tt::umd

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -4,6 +4,8 @@
 
 #include "umd/device/tt_device/simulation_tt_device.hpp"
 
+#include <fmt/format.h>
+
 #include <tt-logger/tt-logger.hpp>
 
 #include "noc_access.hpp"
@@ -11,6 +13,7 @@
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
+#include "umd/device/simulation/simulation_server_protocol.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -28,7 +31,51 @@ SimulationTTDevice::SimulationTTDevice(
 
 SimulationTTDevice::~SimulationTTDevice() = default;
 
-void SimulationTTDevice::adopt_socket(std::unique_ptr<SimulationServerSocket> socket) { socket_ = std::move(socket); }
+void SimulationTTDevice::adopt_socket(std::unique_ptr<SimulationServerSocket> socket) {
+    socket_ = std::move(socket);
+    // Begin serving remote clients now that the backend is up.
+    socket_->serve([this](const std::vector<uint8_t>& request_bytes) { return handle_request(request_bytes); });
+}
+
+std::vector<uint8_t> SimulationTTDevice::handle_request(const std::vector<uint8_t>& request_bytes) {
+    const SimulationServerRequest request = decode_request(request_bytes);
+
+    // The client already translated the coordinate (translation is stateless and client-side), so
+    // pass it through verbatim as LITERAL -- the shared read/write skeleton must not translate
+    // again. CoreCoord defaults to CoreType::UNSPECIFIED + CoordSystem::LITERAL.
+    const CoreCoord core{request.x, request.y};
+
+    SimulationServerResponse response;
+    try {
+        switch (request.command) {
+            case SimulationServerCommand::Read:
+                response.data.resize(request.size);
+                read_from_device(response.data.data(), core, request.address, request.size);
+                break;
+            case SimulationServerCommand::Write:
+                UMD_ASSERT(
+                    request.data.size() >= request.size,
+                    error::RuntimeError,
+                    fmt::format(
+                        "Write request payload ({} bytes) is smaller than its size field ({})",
+                        request.data.size(),
+                        request.size));
+                write_to_device(request.data.data(), core, request.address, request.size);
+                break;
+            default:
+                UMD_THROW(
+                    error::RuntimeError,
+                    fmt::format("Unknown simulation server command {}", static_cast<int>(request.command)));
+        }
+    } catch (const std::exception& e) {
+        // A failed op surfaces to the client as a nonzero status rather than dropping the
+        // connection, mirroring how a silicon access error is reported rather than fatal.
+        log_warning(tt::LogUMD, "Simulation host failed to serve a client request: {}", e.what());
+        response.status = -1;
+        response.data.clear();
+    }
+    return encode(response);
+}
 
 void SimulationTTDevice::write_to_device(
     const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id) {

--- a/tests/api/test_simulation_connector.cpp
+++ b/tests/api/test_simulation_connector.cpp
@@ -4,12 +4,18 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <cstdlib>
 #include <filesystem>
+#include <vector>
 
 #include "simulation/simulation_server_socket.hpp"
+#include "umd/device/simulation/simulation_client.hpp"
 #include "umd/device/simulation/simulation_connector.hpp"
+#include "umd/device/simulation/simulation_server_protocol.hpp"
+#include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/core_coordinates.hpp"
 
 using namespace tt::umd;
 
@@ -59,4 +65,69 @@ TEST(SimulationConnector, ThrowsWhenLiveHostAlreadyExists) {
     SimulationConnectorOptions options;
     options.simulator_directory = "unused";  // discover() throws before it is touched.
     EXPECT_THROW(SimulationConnector::discover(options), std::exception);
+}
+
+// End to end: the host device serves device-memory requests over its socket. A client (same
+// process here) reads back what the host wrote, and a client write is visible to the host --
+// exercising handle_request + the protocol + the transport against a real backend. Coordinates
+// are translated client-side and passed through the host verbatim. Requires TT_UMD_SIMULATOR.
+TEST(SimulationConnector, HostServesClientMemoryOverSocket) {
+    const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
+    if (simulator_path == nullptr) {
+        GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
+    }
+
+    const std::filesystem::path socket = SimulationServerSocket::default_socket_path(0);
+    {
+        auto probe = SimulationServerSocket::try_create(socket);
+        if (probe == nullptr) {
+            GTEST_SKIP() << "A live simulation host already holds " << socket << "; skipping.";
+        }
+    }
+
+    SimulationConnectorOptions options;
+    options.simulator_directory = simulator_path;
+    auto devices = SimulationConnector::discover(options);
+    ASSERT_EQ(devices.size(), 1u);
+    TTDevice* host = devices.at(0).get();
+    ASSERT_NE(host, nullptr);
+
+    const SocDescriptor& soc = host->get_soc_descriptor();
+    const CoreCoord tensix = soc.get_cores(tt::CoreType::TENSIX).at(0);
+    // Client-side translation: what the client puts on the wire, passed through the host as-is.
+    const tt_xy_pair noc = soc.translate_chip_coord_to_translated(tensix);
+    constexpr uint64_t addr = 0x1000;
+    const std::vector<uint8_t> pattern = {0xDE, 0xAD, 0xBE, 0xEF, 0x11, 0x22, 0x33, 0x44};
+
+    SimulationClient client(socket);
+    client.attach();
+
+    // Host writes directly; the client reads the same location over the socket.
+    host->write_to_device(pattern.data(), tensix, addr, pattern.size());
+    SimulationServerRequest read_req;
+    read_req.command = SimulationServerCommand::Read;
+    read_req.x = static_cast<uint32_t>(noc.x);
+    read_req.y = static_cast<uint32_t>(noc.y);
+    read_req.address = addr;
+    read_req.size = static_cast<uint32_t>(pattern.size());
+    const SimulationServerResponse read_resp = decode_response(client.transact(encode(read_req)));
+    EXPECT_EQ(read_resp.status, 0);
+    EXPECT_EQ(read_resp.data, pattern);
+
+    // The client writes over the socket; the host sees it directly.
+    const std::vector<uint8_t> pattern2 = {0x55, 0x66, 0x77, 0x88};
+    constexpr uint64_t addr2 = 0x2000;
+    SimulationServerRequest write_req;
+    write_req.command = SimulationServerCommand::Write;
+    write_req.x = static_cast<uint32_t>(noc.x);
+    write_req.y = static_cast<uint32_t>(noc.y);
+    write_req.address = addr2;
+    write_req.size = static_cast<uint32_t>(pattern2.size());
+    write_req.data = pattern2;
+    const SimulationServerResponse write_resp = decode_response(client.transact(encode(write_req)));
+    EXPECT_EQ(write_resp.status, 0);
+
+    std::vector<uint8_t> readback(pattern2.size());
+    host->read_from_device(readback.data(), tensix, addr2, pattern2.size());
+    EXPECT_EQ(readback, pattern2);
 }


### PR DESCRIPTION
### Issue
Part of #2677 (simulation server process). Connects the serving socket (#2984) to the host device's backend so remote clients can read/write device memory. Stacked on #2986. Builds on the merged SimulationTTDevice I/O hooks (#2917).

### Description
`SimulationTTDevice::handle_request(bytes) → bytes` is the host-side seam:
- `decode_request` → build a `CoreCoord` in LITERAL (the client already translated the coordinate, so the shared skeleton must not translate again) → run through the base `read_from_device`/`write_to_device`, so device memory goes through the ttsim device's **TLB window**, identical to the host's own I/O (the #2917 hooks) → `encode` the reply.
- A failed op returns a nonzero status rather than dropping the connection, mirroring how a silicon access error is reported.

`adopt_socket()` installs this handler via `SimulationServerSocket::serve()` once the backend is up. Safe against teardown: the derived destructors `socket_.reset()` (joining the serving threads) before tearing the backend down, so no handler runs against a half-destroyed device.

Coordinate translation is **client-side** (stateless, via the SoC descriptor); the host passes the received coordinate through verbatim. The socket/client layers stay protocol-agnostic; this is where the protocol is (de)serialized on the host.

### List of the changes
- `device/api/umd/device/tt_device/simulation_tt_device.hpp`, `device/tt_device/simulation_tt_device.cpp` — `handle_request`; `adopt_socket` starts serving.
- `tests/api/test_simulation_connector.cpp` — CI-gated e2e (`HostServesClientMemoryOverSocket`): in-process client reads what the host wrote and writes what the host reads back, over the socket.

### Testing
Build + pre-commit clean; no-card sim suites pass. `HostServesClientMemoryOverSocket` runs in the simulation CI lane (`TT_UMD_SIMULATOR`).

### API Changes
None (internal). `SimulationTTDevice` gains a private `handle_request`; `adopt_socket` now serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
