### PR TITLE
Rename DeviceProtocol methods

### DIFF
--- a/device/api/umd/device/tt_device/protocol/device_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/device_protocol.hpp
@@ -14,37 +14,79 @@
 namespace tt::umd {
 
 /**
- * DeviceProtocol is the base interface for all device communication protocols.
+ * @brief Uniform device I/O interface across all transports.
  *
- * Each concrete protocol (PCIe, JTAG, Remote/Ethernet) implements this interface,
- * providing a uniform way to perform basic device I/O regardless of the underlying
- * transport.
+ * Implemented by each transport (PCIe, JTAG, Remote/Ethernet) to provide
+ * data and control path operations. Data operations are optimized for
+ * throughput. Control operations are optimized for ordered transactions.
  *
  */
 class DeviceProtocol {
 public:
     virtual ~DeviceProtocol() = default;
 
-    virtual void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) = 0;
-    virtual void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) = 0;
+    /**
+     * @brief Reads a block of data from a device core into a host buffer, suited for bulk data transfers.
+     * @param dst Pointer to the destination host buffer.
+     * @param core Target core coordinates.
+     * @param addr Device address on the target core.
+     * @param size Number of bytes to read.
+     * @param noc_id NOC to route through.
+     */
+    virtual void read_data(void* dst, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) = 0;
 
-    virtual void write_to_device_reg(
-        const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) = 0;
-    virtual void read_from_device_reg(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) = 0;
+    /**
+     * @brief Writes a block of host data to a device core, suited for bulk data transfers.
+     * @param src Pointer to the source host memory.
+     * @param core Target core coordinates.
+     * @param addr Device address on the target core.
+     * @param size Number of bytes to write.
+     * @param noc_id NOC to route through.
+     */
+    virtual void write_data(const void* src, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) = 0;
 
-    // [[nodiscard]] tells the compiler that the return value should not be ignored.
-    // This ensures the caller handles the software fallback
-    // if the hardware does not support multicast.
-    // @return true if the hardware multicast was performed, false if the caller must do a software unicast fallback.
+    /**
+     * @brief Reads data from a device core into a host buffer, suited for register and control transactions.
+     * @param dst Pointer to the destination host buffer.
+     * @param core Target core coordinates.
+     * @param addr Device address on the target core.
+     * @param size Number of bytes to read.
+     * @param noc_id NOC to route through.
+     */
+    virtual void read_ctrl(void* dst, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) = 0;
+
+    /**
+     * @brief Writes host data to a device core, suited for register and control transactions.
+     * @param src Pointer to the source host memory.
+     * @param core Target core coordinates.
+     * @param addr Device address on the target core.
+     * @param size Number of bytes to write.
+     * @param noc_id NOC to route through.
+     */
+    virtual void write_ctrl(const void* src, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) = 0;
+
+    /**
+     * @brief Writes data to a range of cores via hardware multicast, if supported.
+     *
+     * Not all transports support hardware multicast. The caller must check the
+     * return value to handle unsupported cases.
+     *
+     * @param src Pointer to the source host memory.
+     * @param core_start First core in the multicast rectangle.
+     * @param core_end Last core in the multicast rectangle.
+     * @param addr Device address on each target core.
+     * @param size Number of bytes to write.
+     * @param noc_id NOC to route through.
+     * @return true if the hardware performed the multicast; false if the caller
+     *         must fall back to software unicast.
+     */
     [[nodiscard]] virtual bool write_to_core_range(
-        const void* mem_ptr,
-        tt_xy_pair core_start,
-        tt_xy_pair core_end,
-        uint64_t addr,
-        uint32_t size,
-        NocId noc_id) = 0;
+        const void* src, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, size_t size, NocId noc_id) = 0;
 
-    // Returns the MMIO device ID, used to uniquely identify both the device and its associated protocol instance.
+    /**
+     * @brief Returns the MMIO device ID, identifying both the device and its protocol instance.
+     * @return int The MMIO device identifier.
+     */
     virtual int get_mmio_id() = 0;
 };
 

--- a/device/api/umd/device/tt_device/protocol/jtag_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/jtag_protocol.hpp
@@ -27,12 +27,12 @@ public:
     ~JtagProtocol() override;
 
     // DeviceProtocol interface.
-    void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
-    void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
-    void write_to_device_reg(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
-    void read_from_device_reg(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
+    void write_data(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
+    void read_data(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
+    void write_ctrl(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
+    void read_ctrl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
     bool write_to_core_range(
-        const void* mem_ptr, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, uint32_t size, NocId noc_id)
+        const void* mem_ptr, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, size_t size, NocId noc_id)
         override;
     int get_mmio_id() override;
 

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -41,12 +41,12 @@ public:
     ~PcieProtocol() override;
 
     // DeviceProtocol interface.
-    void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
-    void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
-    void write_to_device_reg(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
-    void read_from_device_reg(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
+    void write_data(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
+    void read_data(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
+    void write_ctrl(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
+    void read_ctrl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
     bool write_to_core_range(
-        const void* mem_ptr, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, uint32_t size, NocId noc_id)
+        const void* mem_ptr, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, size_t size, NocId noc_id)
         override;
     int get_mmio_id() override;
 
@@ -84,9 +84,9 @@ private:
     bool dma_transfer(void* buffer, size_t size, uint64_t addr, tlb_data config, DmaDirection direction);
 
     template <bool safe>
-    void write_to_device_impl(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id);
+    void write_data_impl(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id);
     template <bool safe>
-    void read_from_device_impl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id);
+    void read_data_impl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id);
 
     // Offset used to access NOC2AXI config + ARC specific memory (ICCM + CSM + APB).
     static constexpr uint32_t BAR0_OFFSET = 0x1FD00000;

--- a/device/api/umd/device/tt_device/protocol/remote_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/remote_protocol.hpp
@@ -30,12 +30,12 @@ public:
     ~RemoteProtocol() override = default;
 
     // DeviceProtocol interface.
-    void write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
-    void read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
-    void write_to_device_reg(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
-    void read_from_device_reg(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
+    void write_data(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
+    void read_data(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
+    void write_ctrl(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
+    void read_ctrl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) override;
     bool write_to_core_range(
-        const void* mem_ptr, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, uint32_t size, NocId noc_id)
+        const void* mem_ptr, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, size_t size, NocId noc_id)
         override;
     int get_mmio_id() override;
 

--- a/device/tt_device/hang_detection/hang_detector_implementation.cpp
+++ b/device/tt_device/hang_detection/hang_detector_implementation.cpp
@@ -21,7 +21,7 @@ HangDetectorImplementation::HangDetectorImplementation(
     // Default reader: plain protocol read. A higher layer may override it via set_noc_reg_reader().
     noc_reg_reader_([this](tt_xy_pair core, uint64_t addr, NocId noc) -> uint32_t {
         uint32_t value = 0;
-        protocol_->read_from_device(&value, core, addr, sizeof(value), noc);
+        protocol_->read_data(&value, core, addr, sizeof(value), noc);
         return value;
     }) {}
 

--- a/device/tt_device/protocol/jtag_protocol.cpp
+++ b/device/tt_device/protocol/jtag_protocol.cpp
@@ -18,25 +18,25 @@ JtagProtocol::JtagProtocol(std::unique_ptr<JtagDevice> jtag_device, uint8_t jlin
 
 JtagProtocol::~JtagProtocol() = default;
 
-void JtagProtocol::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+void JtagProtocol::write_data(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     jtag_device_->write(mmio_id_, mem_ptr, core.x, core.y, addr, size, static_cast<uint8_t>(noc_id));
 }
 
-void JtagProtocol::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+void JtagProtocol::read_data(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     jtag_device_->read(mmio_id_, mem_ptr, core.x, core.y, addr, size, static_cast<uint8_t>(noc_id));
 }
 
-void JtagProtocol::write_to_device_reg(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+void JtagProtocol::write_ctrl(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     validate_register_access(addr, size);
-    write_to_device(mem_ptr, core, addr, size, noc_id);
+    write_data(mem_ptr, core, addr, size, noc_id);
 }
 
-void JtagProtocol::read_from_device_reg(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+void JtagProtocol::read_ctrl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     validate_register_access(addr, size);
-    read_from_device(mem_ptr, core, addr, size, noc_id);
+    read_data(mem_ptr, core, addr, size, noc_id);
 }
 
-bool JtagProtocol::write_to_core_range(const void*, tt_xy_pair, tt_xy_pair, uint64_t, uint32_t, NocId) { return false; }
+bool JtagProtocol::write_to_core_range(const void*, tt_xy_pair, tt_xy_pair, uint64_t, size_t, NocId) { return false; }
 
 int JtagProtocol::get_mmio_id() { return mmio_id_; }
 

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -72,27 +72,26 @@ TlbWindow* PcieProtocol::get_cached_tlb_window() {
     return cached_tlb_window_.get();
 }
 
-void PcieProtocol::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+void PcieProtocol::write_data(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     std::lock_guard<std::mutex> lock(io_lock_);
     if (use_safe_api_) {
-        write_to_device_impl<true>(mem_ptr, core, addr, size, noc_id);
+        write_data_impl<true>(mem_ptr, core, addr, size, noc_id);
     } else {
-        write_to_device_impl<false>(mem_ptr, core, addr, size, noc_id);
+        write_data_impl<false>(mem_ptr, core, addr, size, noc_id);
     }
 }
 
-void PcieProtocol::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+void PcieProtocol::read_data(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     std::lock_guard<std::mutex> lock(io_lock_);
     if (use_safe_api_) {
-        read_from_device_impl<true>(mem_ptr, core, addr, size, noc_id);
+        read_data_impl<true>(mem_ptr, core, addr, size, noc_id);
     } else {
-        read_from_device_impl<false>(mem_ptr, core, addr, size, noc_id);
+        read_data_impl<false>(mem_ptr, core, addr, size, noc_id);
     }
 }
 
 template <bool safe>
-void PcieProtocol::write_to_device_impl(
-    const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+void PcieProtocol::write_data_impl(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     // The cached window carries the per-op MMIO timeout veto (built from its configured NOC + the wired
     // hang check); see SiliconTlbWindow. The reconfigure call sets the NOC before the transfer runs.
     if constexpr (safe) {
@@ -103,7 +102,7 @@ void PcieProtocol::write_to_device_impl(
 }
 
 template <bool safe>
-void PcieProtocol::read_from_device_impl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+void PcieProtocol::read_data_impl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     if constexpr (safe) {
         get_cached_tlb_window()->safe_read_block_reconfigure(mem_ptr, core, addr, size, noc_id);
     } else {
@@ -111,7 +110,7 @@ void PcieProtocol::read_from_device_impl(void* mem_ptr, tt_xy_pair core, uint64_
     }
 }
 
-void PcieProtocol::write_to_device_reg(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+void PcieProtocol::write_ctrl(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     validate_register_access(addr, size);
     std::lock_guard<std::mutex> lock(io_lock_);
     if (use_safe_api_) {
@@ -121,7 +120,7 @@ void PcieProtocol::write_to_device_reg(const void* mem_ptr, tt_xy_pair core, uin
     }
 }
 
-void PcieProtocol::read_from_device_reg(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+void PcieProtocol::read_ctrl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     validate_register_access(addr, size);
     std::lock_guard<std::mutex> lock(io_lock_);
     if (use_safe_api_) {
@@ -132,7 +131,7 @@ void PcieProtocol::read_from_device_reg(void* mem_ptr, tt_xy_pair core, uint64_t
 }
 
 bool PcieProtocol::write_to_core_range(
-    const void* mem_ptr, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, uint32_t size, NocId noc_id) {
+    const void* mem_ptr, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, size_t size, NocId noc_id) {
     noc_multicast_write(mem_ptr, size, core_start, core_end, addr, noc_id);
     return true;
 }

--- a/device/tt_device/protocol/remote_protocol.cpp
+++ b/device/tt_device/protocol/remote_protocol.cpp
@@ -21,23 +21,22 @@ namespace tt::umd {
 RemoteProtocol::RemoteProtocol(std::unique_ptr<RemoteCommunication> remote_communication) :
     remote_communication_(std::move(remote_communication)) {}
 
-void RemoteProtocol::write_to_device(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+void RemoteProtocol::write_data(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     remote_communication_->write_to_non_mmio(core, mem_ptr, addr, size);
 }
 
-void RemoteProtocol::read_from_device(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+void RemoteProtocol::read_data(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     remote_communication_->read_non_mmio(core, mem_ptr, addr, size);
 }
 
-void RemoteProtocol::write_to_device_reg(
-    const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+void RemoteProtocol::write_ctrl(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     validate_register_access(addr, size);
-    write_to_device(mem_ptr, core, addr, size, noc_id);
+    write_data(mem_ptr, core, addr, size, noc_id);
 }
 
-void RemoteProtocol::read_from_device_reg(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
+void RemoteProtocol::read_ctrl(void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id) {
     validate_register_access(addr, size);
-    read_from_device(mem_ptr, core, addr, size, noc_id);
+    read_data(mem_ptr, core, addr, size, noc_id);
 }
 
 bool RemoteProtocol::write_to_core_range(
@@ -45,7 +44,7 @@ bool RemoteProtocol::write_to_core_range(
     tt_xy_pair core_start,
     tt_xy_pair core_end,
     uint64_t address,
-    uint32_t size_in_bytes,
+    size_t size_in_bytes,
     NocId noc_id) {
     // Construct EthernetBroadcast lazily on the first use. During the constructor the sysmem might not be set yet.
     if (ethernet_broadcast_ == nullptr && remote_communication_->has_sysmem_manager() &&

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -490,25 +490,25 @@ std::unique_ptr<TlbWindow> TTDevice::get_io_window(tlb_data config, TlbMapping m
 void TTDevice::read_from_device(void *mem_ptr, CoreCoord core, uint64_t addr, size_t size) {
     ZoneScopedC(tracy::Color::Orange);
 
-    device_protocol_->read_from_device(mem_ptr, resolve_coordinate(core), addr, size, get_selected_noc_id());
+    device_protocol_->read_data(mem_ptr, resolve_coordinate(core), addr, size, get_selected_noc_id());
 }
 
 void TTDevice::write_to_device(const void *mem_ptr, CoreCoord core, uint64_t addr, size_t size) {
     ZoneScopedC(tracy::Color::Orange);
 
-    device_protocol_->write_to_device(mem_ptr, resolve_coordinate(core), addr, size, get_selected_noc_id());
+    device_protocol_->write_data(mem_ptr, resolve_coordinate(core), addr, size, get_selected_noc_id());
 }
 
 void TTDevice::read_from_device_reg(void *mem_ptr, CoreCoord core, uint64_t addr, size_t size) {
     ZoneScopedC(tracy::Color::Orange);
 
-    device_protocol_->read_from_device_reg(mem_ptr, resolve_coordinate(core), addr, size, get_selected_noc_id());
+    device_protocol_->read_ctrl(mem_ptr, resolve_coordinate(core), addr, size, get_selected_noc_id());
 }
 
 void TTDevice::write_to_device_reg(const void *mem_ptr, CoreCoord core, uint64_t addr, size_t size) {
     ZoneScopedC(tracy::Color::Orange);
 
-    device_protocol_->write_to_device_reg(mem_ptr, resolve_coordinate(core), addr, size, get_selected_noc_id());
+    device_protocol_->write_ctrl(mem_ptr, resolve_coordinate(core), addr, size, get_selected_noc_id());
 }
 
 void TTDevice::configure_iatu_region(size_t region, uint64_t target, size_t region_size) {


### PR DESCRIPTION
### Issue
#2871

### Description
Renamed the four DeviceProtocol I/O methods to match the Base API Specification and aligned the interface header with the spec.

### List of the changes
 - Renamed write_to_device to write_data
 - Renamed read_from_device to read_data
 - Renamed write_to_device_reg to write_ctrl
 - Renamed read_from_device_reg to read_ctrl
 - Updated implementations in PcieProtocol, JtagProtocol, RemoteProtocol and all call sites
 - Renamed private Pcie helpers write_to_device_impl and read_from_device_impl to write_data_impl and read_data_impl
 - Added spec doc comments
 - Widened write_to_core_range size parameter from uint32_t to size_t to match the spec. The sole caller TTDevice::noc_multicast_write already holds a size_t, so this removes a narrowing conversion at the call site


### Testing
CI.

### API Changes
This PR has API changes.
