### PR TITLE
Align SocArchDescriptor with Base API spec (#2874)

### DIFF
--- a/device/api/umd/device/soc_arch_descriptor.hpp
+++ b/device/api/umd/device/soc_arch_descriptor.hpp
@@ -38,11 +38,18 @@ struct CoreDescriptor {
 // per-chip runtime state like harvesting masks or NOC translation settings.
 class SocArchDescriptor {
 public:
+    virtual ~SocArchDescriptor() = default;
+
     // Create from architecture enum (uses hardcoded constants).
     SocArchDescriptor(tt::ARCH arch);
 
     // Create from a YAML SoC descriptor file.
     SocArchDescriptor(const std::string& soc_descriptor_path);
+
+    // Populates the descriptor with the topology data selected at construction (architecture
+    // constants or the YAML file) and rebuilds the derived data. Called by the constructors;
+    // exposed as a virtual hook so future TTDeviceModel compositions can override population.
+    virtual void init();
 
     // Helpers for extracting info from a YAML descriptor file without fully constructing.
     static tt::ARCH get_arch_from_path(const std::string& soc_descriptor_path);
@@ -64,7 +71,7 @@ public:
 
     const std::vector<tt_xy_pair>& get_eth_cores() const { return eth_cores_; }
 
-    const std::vector<tt_xy_pair>& get_arc_cores() const { return arc_cores_; }
+    const std::vector<tt_xy_pair>& get_firmware_cores() const { return firmware_cores_; }
 
     const std::vector<tt_xy_pair>& get_pcie_cores() const { return pcie_cores_; }
 
@@ -139,7 +146,7 @@ private:
     std::vector<tt_xy_pair> tensix_cores_;
     std::vector<std::vector<tt_xy_pair>> dram_cores_;
     std::vector<tt_xy_pair> eth_cores_;
-    std::vector<tt_xy_pair> arc_cores_;
+    std::vector<tt_xy_pair> firmware_cores_;
     std::vector<tt_xy_pair> pcie_cores_;
     std::vector<tt_xy_pair> router_cores_;
     std::vector<tt_xy_pair> security_cores_;

--- a/device/api/umd/device/soc_arch_descriptor.hpp
+++ b/device/api/umd/device/soc_arch_descriptor.hpp
@@ -47,8 +47,11 @@ public:
     SocArchDescriptor(const std::string& soc_descriptor_path);
 
     // Populates the descriptor with the topology data selected at construction (architecture
-    // constants or the YAML file) and rebuilds the derived data. Called by the constructors;
-    // exposed as a virtual hook so future TTDeviceModel compositions can override population.
+    // constants or the YAML file) and rebuilds the derived data. The constructors invoke it
+    // non-virtually (virtual dispatch does not reach derived overrides during base construction),
+    // so it always runs this class' population. It is virtual to reserve an override point for
+    // future TTDeviceModel compositions, which would invoke init() explicitly on a fully
+    // constructed object rather than rely on the base constructor.
     virtual void init();
 
     // Helpers for extracting info from a YAML descriptor file without fully constructing.

--- a/device/soc_arch_descriptor.cpp
+++ b/device/soc_arch_descriptor.cpp
@@ -24,12 +24,14 @@ namespace tt::umd {
 
 SocArchDescriptor::SocArchDescriptor(tt::ARCH arch_enum) {
     arch_ = arch_enum;
-    init();
+    // Explicit non-virtual call: dispatch during construction always resolves to this class, and
+    // qualifying makes that intent clear (see the init() declaration).
+    SocArchDescriptor::init();
 }
 
 SocArchDescriptor::SocArchDescriptor(const std::string& soc_descriptor_path) {
     device_descriptor_file_path_ = soc_descriptor_path;
-    init();
+    SocArchDescriptor::init();
 }
 
 void SocArchDescriptor::init() {
@@ -39,7 +41,7 @@ void SocArchDescriptor::init() {
         std::ifstream soc_descriptor_file(device_descriptor_file_path_);
         if (soc_descriptor_file.fail()) {
             UMD_THROW(
-                error::RuntimeError, "SocDescriptor file does not exist at path: " + device_descriptor_file_path_);
+                error::RuntimeError, "SoC descriptor file does not exist at path: " + device_descriptor_file_path_);
         }
         soc_descriptor_file.close();
         YAML::Node device_descriptor_yaml = YAML::LoadFile(device_descriptor_file_path_);
@@ -50,7 +52,6 @@ void SocArchDescriptor::init() {
 
     switch (arch_) {
         case tt::ARCH::WORMHOLE_B0:
-            arch_ = tt::ARCH::WORMHOLE_B0;
             grid_size_ = wormhole::GRID_SIZE;
             tensix_cores_ = wormhole::TENSIX_CORES_NOC0;
             dram_cores_ = wormhole::DRAM_CORES_NOC0;
@@ -67,7 +68,6 @@ void SocArchDescriptor::init() {
             noc0_y_to_noc1_y_ = wormhole::NOC0_Y_TO_NOC1_Y;
             break;
         case tt::ARCH::BLACKHOLE:
-            arch_ = tt::ARCH::BLACKHOLE;
             grid_size_ = blackhole::GRID_SIZE;
             tensix_cores_ = blackhole::TENSIX_CORES_NOC0;
             dram_cores_ = blackhole::DRAM_CORES_NOC0;
@@ -84,7 +84,6 @@ void SocArchDescriptor::init() {
             noc0_y_to_noc1_y_ = blackhole::NOC0_Y_TO_NOC1_Y;
             break;
         case tt::ARCH::QUASAR:
-            arch_ = tt::ARCH::QUASAR;
             grid_size_ = grendel::GRID_SIZE;
             tensix_cores_ = grendel::TENSIX_CORES_NOC0;
             dram_cores_ = grendel::DRAM_CORES_NOC0;

--- a/device/soc_arch_descriptor.cpp
+++ b/device/soc_arch_descriptor.cpp
@@ -23,14 +23,39 @@
 namespace tt::umd {
 
 SocArchDescriptor::SocArchDescriptor(tt::ARCH arch_enum) {
-    switch (arch_enum) {
+    arch_ = arch_enum;
+    init();
+}
+
+SocArchDescriptor::SocArchDescriptor(const std::string& soc_descriptor_path) {
+    device_descriptor_file_path_ = soc_descriptor_path;
+    init();
+}
+
+void SocArchDescriptor::init() {
+    // When constructed from a YAML descriptor the file path is set; otherwise populate from the
+    // hardcoded architecture constants selected by arch_.
+    if (!device_descriptor_file_path_.empty()) {
+        std::ifstream soc_descriptor_file(device_descriptor_file_path_);
+        if (soc_descriptor_file.fail()) {
+            UMD_THROW(
+                error::RuntimeError, "SocDescriptor file does not exist at path: " + device_descriptor_file_path_);
+        }
+        soc_descriptor_file.close();
+        YAML::Node device_descriptor_yaml = YAML::LoadFile(device_descriptor_file_path_);
+        load_from_yaml(device_descriptor_yaml);
+        build_derived_data();
+        return;
+    }
+
+    switch (arch_) {
         case tt::ARCH::WORMHOLE_B0:
             arch_ = tt::ARCH::WORMHOLE_B0;
             grid_size_ = wormhole::GRID_SIZE;
             tensix_cores_ = wormhole::TENSIX_CORES_NOC0;
             dram_cores_ = wormhole::DRAM_CORES_NOC0;
             eth_cores_ = wormhole::ETH_CORES_NOC0;
-            arc_cores_ = wormhole::ARC_CORES_NOC0;
+            firmware_cores_ = wormhole::ARC_CORES_NOC0;
             pcie_cores_ = wormhole::PCIE_CORES_NOC0;
             router_cores_ = wormhole::ROUTER_CORES_NOC0;
             security_cores_ = wormhole::SECURITY_CORES_NOC0;
@@ -47,7 +72,7 @@ SocArchDescriptor::SocArchDescriptor(tt::ARCH arch_enum) {
             tensix_cores_ = blackhole::TENSIX_CORES_NOC0;
             dram_cores_ = blackhole::DRAM_CORES_NOC0;
             eth_cores_ = blackhole::ETH_CORES_NOC0;
-            arc_cores_ = blackhole::ARC_CORES_NOC0;
+            firmware_cores_ = blackhole::ARC_CORES_NOC0;
             pcie_cores_ = blackhole::PCIE_CORES_NOC0;
             router_cores_ = blackhole::ROUTER_CORES_NOC0;
             security_cores_ = blackhole::SECURITY_CORES_NOC0;
@@ -64,7 +89,7 @@ SocArchDescriptor::SocArchDescriptor(tt::ARCH arch_enum) {
             tensix_cores_ = grendel::TENSIX_CORES_NOC0;
             dram_cores_ = grendel::DRAM_CORES_NOC0;
             eth_cores_ = grendel::ETH_CORES_NOC0;
-            arc_cores_ = grendel::ARC_CORES_NOC0;
+            firmware_cores_ = grendel::ARC_CORES_NOC0;
             pcie_cores_ = grendel::PCIE_CORES_NOC0;
             router_cores_ = grendel::ROUTER_CORES_NOC0;
             security_cores_ = grendel::SECURITY_CORES_NOC0;
@@ -80,19 +105,6 @@ SocArchDescriptor::SocArchDescriptor(tt::ARCH arch_enum) {
             UMD_THROW(error::RuntimeError, "Invalid architecture for creating SocArchDescriptor.");
     }
 
-    build_derived_data();
-}
-
-SocArchDescriptor::SocArchDescriptor(const std::string& soc_descriptor_path) {
-    std::ifstream soc_descriptor_file(soc_descriptor_path);
-    if (soc_descriptor_file.fail()) {
-        UMD_THROW(error::RuntimeError, "SocDescriptor file does not exist at path: " + soc_descriptor_path);
-    }
-    soc_descriptor_file.close();
-    YAML::Node device_descriptor_yaml = YAML::LoadFile(soc_descriptor_path);
-
-    device_descriptor_file_path_ = soc_descriptor_path;
-    load_from_yaml(device_descriptor_yaml);
     build_derived_data();
 }
 
@@ -124,9 +136,9 @@ void SocArchDescriptor::build_derived_data() {
     ethernet_core_channel_map_.clear();
 
     // Build core descriptor map.
-    for (const auto& arc_core : arc_cores_) {
+    for (const auto& firmware_core : firmware_cores_) {
         CoreDescriptor core_descriptor;
-        core_descriptor.coord = arc_core;
+        core_descriptor.coord = firmware_core;
         core_descriptor.type = CoreType::ARC;
         cores_.insert({core_descriptor.coord, core_descriptor});
     }
@@ -262,7 +274,8 @@ void SocArchDescriptor::load_from_yaml(YAML::Node& device_descriptor_yaml) {
     pcie_cores_ =
         SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["pcie"].as<std::vector<std::string>>());
     eth_cores_ = SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["eth"].as<std::vector<std::string>>());
-    arc_cores_ = SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["arc"].as<std::vector<std::string>>());
+    firmware_cores_ =
+        SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["arc"].as<std::vector<std::string>>());
     router_cores_ =
         SocArchDescriptor::convert_to_tt_xy_pair(device_descriptor_yaml["router_only"].as<std::vector<std::string>>());
 

--- a/device/soc_descriptor.cpp
+++ b/device/soc_descriptor.cpp
@@ -128,7 +128,7 @@ void SocDescriptor::init_from_arch_descriptor(const ChipInfo &chip_info) {
 void SocDescriptor::create_coordinate_manager(const BoardType board_type, const uint8_t asic_location) {
     const auto &dram_cores = arch_desc_->get_dram_cores();
     const tt_xy_pair dram_grid_size = tt_xy_pair(dram_cores.size(), dram_cores.empty() ? 0 : dram_cores[0].size());
-    tt_xy_pair arc_grid_size = SocArchDescriptor::calculate_grid_size(arch_desc_->get_arc_cores());
+    tt_xy_pair arc_grid_size = SocArchDescriptor::calculate_grid_size(arch_desc_->get_firmware_cores());
     tt_xy_pair pcie_grid_size = SocArchDescriptor::calculate_grid_size(arch_desc_->get_pcie_cores());
 
     std::vector<tt_xy_pair> dram_cores_unpacked;
@@ -169,7 +169,7 @@ void SocDescriptor::create_coordinate_manager(const BoardType board_type, const 
         dram_cores_unpacked,
         arch_desc_->get_eth_cores(),
         arc_grid_size,
-        arch_desc_->get_arc_cores(),
+        arch_desc_->get_firmware_cores(),
         pcie_grid_size,
         arch_desc_->get_pcie_cores(),
         arch_desc_->get_router_cores(),

--- a/nanobind/py_api_soc_descriptor.cpp
+++ b/nanobind/py_api_soc_descriptor.cpp
@@ -94,7 +94,7 @@ void bind_soc_descriptor(nb::module_ &m) {
         .def_prop_ro("tensix_cores", &SocArchDescriptor::get_tensix_cores, release_gil())
         .def_prop_ro("dram_cores", &SocArchDescriptor::get_dram_cores, release_gil())
         .def_prop_ro("eth_cores", &SocArchDescriptor::get_eth_cores, release_gil())
-        .def_prop_ro("arc_cores", &SocArchDescriptor::get_arc_cores, release_gil())
+        .def_prop_ro("firmware_cores", &SocArchDescriptor::get_firmware_cores, release_gil())
         .def_prop_ro("pcie_cores", &SocArchDescriptor::get_pcie_cores, release_gil())
         .def_prop_ro("router_cores", &SocArchDescriptor::get_router_cores, release_gil())
         .def_prop_ro("security_cores", &SocArchDescriptor::get_security_cores, release_gil())

--- a/tests/baremetal/test_soc_arch_descriptor.cpp
+++ b/tests/baremetal/test_soc_arch_descriptor.cpp
@@ -36,8 +36,8 @@ TEST(SocArchDescriptor, WormholeFromArch) {
     EXPECT_EQ(desc.get_dram_cores().size(), wormhole::DRAM_CORES_NOC0.size());
     EXPECT_EQ(desc.get_eth_cores().size(), wormhole::ETH_CORES_NOC0.size());
     EXPECT_EQ(desc.get_eth_cores(), wormhole::ETH_CORES_NOC0);
-    EXPECT_EQ(desc.get_arc_cores().size(), wormhole::ARC_CORES_NOC0.size());
-    EXPECT_EQ(desc.get_arc_cores(), wormhole::ARC_CORES_NOC0);
+    EXPECT_EQ(desc.get_firmware_cores().size(), wormhole::ARC_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_firmware_cores(), wormhole::ARC_CORES_NOC0);
     EXPECT_EQ(desc.get_pcie_cores().size(), wormhole::PCIE_CORES_NOC0.size());
     EXPECT_EQ(desc.get_pcie_cores(), wormhole::PCIE_CORES_NOC0);
     EXPECT_EQ(desc.get_router_cores().size(), wormhole::ROUTER_CORES_NOC0.size());
@@ -60,7 +60,7 @@ TEST(SocArchDescriptor, BlackholeFromArch) {
     EXPECT_EQ(desc.get_dram_cores().size(), blackhole::DRAM_CORES_NOC0.size());
     EXPECT_EQ(desc.get_eth_cores().size(), blackhole::ETH_CORES_NOC0.size());
     EXPECT_EQ(desc.get_eth_cores(), blackhole::ETH_CORES_NOC0);
-    EXPECT_EQ(desc.get_arc_cores().size(), blackhole::ARC_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_firmware_cores().size(), blackhole::ARC_CORES_NOC0.size());
     EXPECT_EQ(desc.get_pcie_cores().size(), blackhole::PCIE_CORES_NOC0.size());
     EXPECT_EQ(desc.get_worker_l1_size(), blackhole::TENSIX_L1_SIZE);
     EXPECT_EQ(desc.get_eth_l1_size(), blackhole::ETH_L1_SIZE);
@@ -92,7 +92,7 @@ TEST(SocArchDescriptor, WormholeFromYaml) {
     EXPECT_EQ(desc.get_tensix_cores().size(), wormhole::TENSIX_CORES_NOC0.size());
     EXPECT_EQ(desc.get_dram_cores().size(), wormhole::DRAM_CORES_NOC0.size());
     EXPECT_EQ(desc.get_eth_cores().size(), wormhole::ETH_CORES_NOC0.size());
-    EXPECT_EQ(desc.get_arc_cores().size(), wormhole::ARC_CORES_NOC0.size());
+    EXPECT_EQ(desc.get_firmware_cores().size(), wormhole::ARC_CORES_NOC0.size());
     EXPECT_EQ(desc.get_pcie_cores().size(), wormhole::PCIE_CORES_NOC0.size());
     EXPECT_FALSE(desc.get_device_descriptor_file_path().empty());
 }
@@ -116,7 +116,7 @@ TEST(SocArchDescriptor, WormholeArchAndYamlConsistency) {
     EXPECT_EQ(from_arch.get_grid_size(), from_yaml.get_grid_size());
     EXPECT_EQ(from_arch.get_tensix_cores(), from_yaml.get_tensix_cores());
     EXPECT_EQ(from_arch.get_eth_cores(), from_yaml.get_eth_cores());
-    EXPECT_EQ(from_arch.get_arc_cores(), from_yaml.get_arc_cores());
+    EXPECT_EQ(from_arch.get_firmware_cores(), from_yaml.get_firmware_cores());
     EXPECT_EQ(from_arch.get_pcie_cores(), from_yaml.get_pcie_cores());
     EXPECT_EQ(from_arch.get_router_cores(), from_yaml.get_router_cores());
     EXPECT_EQ(from_arch.get_worker_l1_size(), from_yaml.get_worker_l1_size());
@@ -138,7 +138,7 @@ TEST(SocArchDescriptor, BlackholeArchAndYamlConsistency) {
     EXPECT_EQ(from_arch.get_arch(), from_yaml.get_arch());
     EXPECT_EQ(from_arch.get_grid_size(), from_yaml.get_grid_size());
     EXPECT_EQ(from_arch.get_tensix_cores(), from_yaml.get_tensix_cores());
-    EXPECT_EQ(from_arch.get_arc_cores(), from_yaml.get_arc_cores());
+    EXPECT_EQ(from_arch.get_firmware_cores(), from_yaml.get_firmware_cores());
     EXPECT_EQ(from_arch.get_pcie_cores(), from_yaml.get_pcie_cores());
     EXPECT_EQ(from_arch.get_worker_l1_size(), from_yaml.get_worker_l1_size());
     EXPECT_EQ(from_arch.get_eth_l1_size(), from_yaml.get_eth_l1_size());
@@ -155,9 +155,10 @@ TEST(SocArchDescriptor, WormholeDerivedCoresMap) {
     auto desc = SocArchDescriptor(tt::ARCH::WORMHOLE_B0);
 
     // Total cores in the map should equal sum of all core type vectors.
-    size_t expected_total = desc.get_tensix_cores().size() + desc.get_eth_cores().size() + desc.get_arc_cores().size() +
-                            desc.get_pcie_cores().size() + desc.get_router_cores().size() +
-                            desc.get_security_cores().size() + desc.get_l2cpu_cores().size();
+    size_t expected_total = desc.get_tensix_cores().size() + desc.get_eth_cores().size() +
+                            desc.get_firmware_cores().size() + desc.get_pcie_cores().size() +
+                            desc.get_router_cores().size() + desc.get_security_cores().size() +
+                            desc.get_l2cpu_cores().size();
     for (const auto& channel : desc.get_dram_cores()) {
         expected_total += channel.size();
     }
@@ -180,7 +181,7 @@ TEST(SocArchDescriptor, WormholeDerivedCoresMap) {
     }
 
     // Verify ARC cores.
-    for (const auto& core : desc.get_arc_cores()) {
+    for (const auto& core : desc.get_firmware_cores()) {
         auto it = desc.get_cores().find(core);
         ASSERT_NE(it, desc.get_cores().end());
         EXPECT_EQ(it->second.type, CoreType::ARC);
@@ -328,7 +329,7 @@ TEST(SocArchDescriptor, BlackholeSimulation1x2) {
     EXPECT_EQ(desc.get_router_cores()[0], tt_xy_pair(0, 0));
 
     // No ARC, PCIe, ETH cores.
-    EXPECT_TRUE(desc.get_arc_cores().empty());
+    EXPECT_TRUE(desc.get_firmware_cores().empty());
     EXPECT_TRUE(desc.get_pcie_cores().empty());
     EXPECT_TRUE(desc.get_eth_cores().empty());
 
@@ -370,7 +371,7 @@ TEST(SocArchDescriptor, QuasarSimulation1x1) {
     EXPECT_EQ(desc.get_router_cores()[0], tt_xy_pair(0, 2));
 
     // No ARC, PCIe, ETH cores.
-    EXPECT_TRUE(desc.get_arc_cores().empty());
+    EXPECT_TRUE(desc.get_firmware_cores().empty());
     EXPECT_TRUE(desc.get_pcie_cores().empty());
     EXPECT_TRUE(desc.get_eth_cores().empty());
 
@@ -404,8 +405,8 @@ TEST(SocArchDescriptor, WormholeB01x1) {
     EXPECT_EQ(desc.get_eth_cores().size(), 16);
 
     // 1 ARC core: (0,10).
-    ASSERT_EQ(desc.get_arc_cores().size(), 1);
-    EXPECT_EQ(desc.get_arc_cores()[0], tt_xy_pair(0, 10));
+    ASSERT_EQ(desc.get_firmware_cores().size(), 1);
+    EXPECT_EQ(desc.get_firmware_cores()[0], tt_xy_pair(0, 10));
 
     // 1 PCIe core: (0,3).
     ASSERT_EQ(desc.get_pcie_cores().size(), 1);


### PR DESCRIPTION
### Issue
Closes #2874

### Description
Aligns `SocArchDescriptor` with the Base API specification so it can slot into the future `TTDeviceModel` composition. The firmware-core accessor is renamed to match the spec, and the class gains a virtual `init()` hook. The class stays concrete for now (option B); the pure-virtual / per-arch subclass form is deferred until `TTDeviceModel` lands.

### List of the changes
- Rename `get_arc_cores()`/`arc_cores_` to `get_firmware_cores()`/`firmware_cores_` and update all consumers (`SocDescriptor`, nanobind binding, tests).
- Add a virtual destructor and a virtual `init()` that holds the topology population; both constructors delegate to it, so the class remains instantiable and all existing call sites are unchanged.

### Testing
CI

### API Changes
- `SocArchDescriptor::get_arc_cores()` renamed to `get_firmware_cores()`.
- nanobind property `arc_cores` renamed to `firmware_cores`.
- `SocArchDescriptor` gains a virtual destructor and a virtual `init()` method.