### PR TITLE
Simulation: serve device identity (GET_DEVICE_INFO) over the socket

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -160,6 +160,7 @@ if(TT_UMD_BUILD_SIMULATION)
             simulation/simulation_chip.cpp
             simulation/simulation_connector.cpp
             simulation/simulation_server_protocol.cpp
+            simulation/simulation_device_identity.cpp
             simulation/simulation_host.cpp
             simulation/tt_sim_communicator.cpp
             simulation/rtl_sim_communicator.cpp
@@ -267,6 +268,8 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/simulation/simulation_chip.hpp
                 api/umd/device/simulation/simulation_connector.hpp
                 api/umd/device/simulation/simulation_client.hpp
+                api/umd/device/simulation/simulation_device_identity.hpp
+                api/umd/device/simulation/simulation_server_protocol.hpp
                 api/umd/device/simulation/simulation_host.hpp
                 api/umd/device/simulation/tt_sim_communicator.hpp
                 api/umd/device/simulation/rtl_sim_communicator.hpp

--- a/device/api/umd/device/simulation/simulation_device_identity.hpp
+++ b/device/api/umd/device/simulation/simulation_device_identity.hpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "umd/device/simulation/simulation_client.hpp"
+#include "umd/device/simulation/simulation_server_protocol.hpp"
+#include "umd/device/soc_descriptor.hpp"
+
+namespace tt::umd {
+
+// Bridges a SocDescriptor and the GET_DEVICE_INFO wire message, so a client can rebuild the host's
+// device identity without a local simulator build.
+
+// Host side: package this device's SocDescriptor into a wire message, so a client can receive it
+// and build its own matching SocDescriptor. backend_type records which simulator the host runs.
+SimulationServerDeviceInfo describe_device(const SocDescriptor& soc_descriptor, SimulationBackendType backend_type);
+
+// Client side: build a SocDescriptor from a wire message served by the host.
+SocDescriptor build_soc_descriptor(const SimulationServerDeviceInfo& device_info);
+
+// Client side: request the host's device identity over the socket.
+SimulationServerDeviceInfo fetch_device_info_from_host(SimulationClient& client);
+
+}  // namespace tt::umd

--- a/device/api/umd/device/simulation/simulation_server_protocol.hpp
+++ b/device/api/umd/device/simulation/simulation_server_protocol.hpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 namespace tt::umd {
@@ -26,6 +27,14 @@ namespace tt::umd {
 enum class SimulationServerCommand : int8_t {
     Read = 0,
     Write = 1,
+    GetDeviceInfo = 2,
+};
+
+// Which simulator the host runs; mirrors wire::SimulationBackendType. Served as part of the device
+// identity so a client can build the matching device class without a local simulator build.
+enum class SimulationBackendType : int8_t {
+    TTSim = 0,
+    Rtl = 1,
 };
 
 // A device-memory access request addressed by (core x/y, address, size).
@@ -47,16 +56,40 @@ struct SimulationServerResponse {
     std::vector<uint8_t> data;
 };
 
+// Device identity a host serves in reply to a GetDeviceInfo request; mirrors
+// wire::SimulationServerDeviceInfo. Everything a client needs to build a matching SocDescriptor.
+struct SimulationServerDeviceInfo {
+    // 0 on success; nonzero signals a host-side failure (e.g. the host had no YAML to serve).
+    int32_t status = 0;
+    // tt::ARCH value of the served device.
+    int32_t arch = 0;
+    // Which simulator the host runs, so the client instantiates the matching device class.
+    SimulationBackendType backend_type = SimulationBackendType::TTSim;
+    // Full text of the host's SoC descriptor YAML file, so the client can build a matching one.
+    std::string soc_descriptor_yaml;
+    // Whether the host applies NOC translation.
+    bool noc_translation_enabled = false;
+    // Per-chip harvesting masks (logical-coordinate bitmasks; see HarvestingMasks).
+    uint32_t tensix_harvesting_mask = 0;
+    uint32_t dram_harvesting_mask = 0;
+    uint32_t eth_harvesting_mask = 0;
+    uint32_t l2cpu_harvesting_mask = 0;
+    uint32_t pcie_harvesting_mask = 0;
+};
+
 // Serialize a message to a FlatBuffers payload.
 std::vector<uint8_t> encode(const SimulationServerRequest& request);
 std::vector<uint8_t> encode(const SimulationServerResponse& response);
+std::vector<uint8_t> encode(const SimulationServerDeviceInfo& device_info);
 
 // Parse a message back from a FlatBuffers payload. The buffer is verified against the schema
 // before any field is read (it comes off a socket, so it may be malformed or truncated); a bad
 // or empty buffer throws error::RuntimeError rather than risking an out-of-bounds read.
 SimulationServerRequest decode_request(const uint8_t* data, size_t size);
 SimulationServerResponse decode_response(const uint8_t* data, size_t size);
+SimulationServerDeviceInfo decode_device_info(const uint8_t* data, size_t size);
 SimulationServerRequest decode_request(const std::vector<uint8_t>& bytes);
 SimulationServerResponse decode_response(const std::vector<uint8_t>& bytes);
+SimulationServerDeviceInfo decode_device_info(const std::vector<uint8_t>& bytes);
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -44,10 +44,11 @@ public:
     static std::unique_ptr<RtlSimulationTTDevice> create(
         const std::filesystem::path& simulator_directory, int num_host_mem_channels = 0);
 
-    // Builds a client-mode device that attaches to a live host (see the .cpp for how the SoC
-    // descriptor is sourced); discovery uses this when a host already owns the socket.
+    // Builds a client-mode device that attaches to a live host and sources its SoC descriptor from
+    // the host over the socket (see the .cpp); discovery uses this when a host already owns the
+    // socket.
     static std::unique_ptr<RtlSimulationTTDevice> create_client(
-        const std::filesystem::path& simulator_directory, ChipId chip_id, std::unique_ptr<SimulationClient> client);
+        ChipId chip_id, std::unique_ptr<SimulationClient> client);
 
     void wait_arc_core_start(const std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT) override;
     std::chrono::milliseconds wait_eth_core_training(
@@ -60,6 +61,8 @@ public:
     RtlSimCommunicator* get_communicator() { return communicator_.get(); }
 
 protected:
+    SimulationBackendType backend_type() const override { return SimulationBackendType::Rtl; }
+
     std::unique_ptr<TlbWindow> create_tlb_window(
         int tlb_index, size_t size, TlbMapping mapping, tlb_data config) override;
     void tile_read_bytes(tt_xy_pair core, uint64_t addr, void* mem_ptr, size_t size) override;

--- a/device/api/umd/device/tt_device/simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/simulation_tt_device.hpp
@@ -14,6 +14,7 @@
 #include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
+#include "umd/device/simulation/simulation_server_protocol.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/tlb.hpp"
@@ -111,6 +112,10 @@ protected:
     // read_from_device/write_to_device translate the CoreCoord once (via
     // translate_chip_coord_to_translated) before dispatching, so the `core` handed to every hook
     // below is already a TRANSLATED coordinate -- do not translate it again.
+
+    // Which simulator this device runs (TTSim vs RTL). Served as part of the device identity so a
+    // remote client can build the matching device class.
+    virtual SimulationBackendType backend_type() const = 0;
 
     // Direct tile (NOC unicast) access through the backend communicator.
     virtual void tile_read_bytes(tt_xy_pair core, uint64_t addr, void* mem_ptr, size_t size) = 0;

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -57,10 +57,10 @@ public:
         int num_host_mem_channels = 0,
         bool copy_sim_binary = false);
 
-    // Builds a client-mode device that attaches to a live host (see the .cpp for how the SoC
-    // descriptor is sourced); discovery uses this when a host already owns the socket.
-    static std::unique_ptr<TTSimTTDevice> create_client(
-        const std::filesystem::path &simulator_directory, ChipId chip_id, std::unique_ptr<SimulationClient> client);
+    // Builds a client-mode device that attaches to a live host and sources its SoC descriptor from
+    // the host over the socket (see the .cpp); discovery uses this when a host already owns the
+    // socket.
+    static std::unique_ptr<TTSimTTDevice> create_client(ChipId chip_id, std::unique_ptr<SimulationClient> client);
 
     void wait_arc_core_start(const std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT) override;
     std::chrono::milliseconds wait_eth_core_training(
@@ -86,6 +86,8 @@ public:
     uint64_t bar4_base = 0;
 
 protected:
+    SimulationBackendType backend_type() const override { return SimulationBackendType::TTSim; }
+
     std::unique_ptr<TlbWindow> create_tlb_window(
         int tlb_index, size_t size, TlbMapping mapping, tlb_data config) override;
     void tile_read_bytes(tt_xy_pair core, uint64_t addr, void *mem_ptr, size_t size) override;

--- a/device/simulation/simulation_connector.cpp
+++ b/device/simulation/simulation_connector.cpp
@@ -37,9 +37,9 @@ std::unique_ptr<TTDevice> create_simulation_device(
     if (socket == nullptr) {
         auto client = std::make_unique<SimulationClient>(socket_path);
         if (is_ttsim) {
-            return TTSimTTDevice::create_client(simulator_directory, chip_id, std::move(client));
+            return TTSimTTDevice::create_client(chip_id, std::move(client));
         }
-        return RtlSimulationTTDevice::create_client(simulator_directory, chip_id, std::move(client));
+        return RtlSimulationTTDevice::create_client(chip_id, std::move(client));
     }
 
     if (is_ttsim) {

--- a/device/simulation/simulation_device_identity.cpp
+++ b/device/simulation/simulation_device_identity.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/simulation/simulation_device_identity.hpp"
+
+#include <fmt/format.h>
+#include <unistd.h>  // write, close (temp-file materialization via mkstemps)
+
+#include <cerrno>
+#include <cstdlib>  // mkstemps
+#include <cstring>  // strerror, strlen
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <vector>
+
+#include "umd/device/simulation/simulation_client.hpp"
+#include "umd/device/soc_arch_descriptor.hpp"
+#include "umd/device/utils/error.hpp"
+
+namespace tt::umd {
+
+namespace {
+
+// A temp file that removes itself on destruction (best-effort), so callers don't leak it on a
+// throw between creation and cleanup.
+struct ScopedTempFile {
+    std::filesystem::path path;
+
+    ~ScopedTempFile() {
+        std::error_code ec;
+        std::filesystem::remove(path, ec);
+    }
+};
+
+// Materialize `contents` to a unique temp file ending in `suffix` (mkstemps avoids name races).
+ScopedTempFile write_temp_file(const std::string& contents, const char* suffix) {
+    const std::string name_template =
+        (std::filesystem::temp_directory_path() / (std::string("tt-umd-sim-socdesc-XXXXXX") + suffix)).string();
+    std::vector<char> path_buf(name_template.begin(), name_template.end());
+    path_buf.push_back('\0');
+    const int fd = ::mkstemps(path_buf.data(), static_cast<int>(std::strlen(suffix)));
+    UMD_ASSERT(
+        fd >= 0,
+        error::RuntimeError,
+        fmt::format("Failed to create a temp SoC descriptor file: {}", std::strerror(errno)));
+    const ssize_t written = ::write(fd, contents.data(), contents.size());
+    ::close(fd);
+    UMD_ASSERT(
+        written == static_cast<ssize_t>(contents.size()),
+        error::RuntimeError,
+        fmt::format("Failed to write temp file {}", path_buf.data()));
+    return ScopedTempFile{std::filesystem::path(path_buf.data())};
+}
+
+}  // namespace
+
+SimulationServerDeviceInfo describe_device(const SocDescriptor& soc_descriptor, SimulationBackendType backend_type) {
+    const std::string& yaml_path = soc_descriptor.get_arch_descriptor().get_device_descriptor_file_path();
+    UMD_ASSERT(
+        !yaml_path.empty(),
+        error::RuntimeError,
+        "Cannot serve device info: the SoC descriptor was not built from a YAML file.");
+
+    std::ifstream in(yaml_path);
+    UMD_ASSERT(in.good(), error::RuntimeError, fmt::format("Failed to open SoC descriptor YAML at {}", yaml_path));
+    std::stringstream buffer;
+    buffer << in.rdbuf();
+
+    SimulationServerDeviceInfo info;
+    info.status = 0;
+    info.arch = static_cast<int32_t>(soc_descriptor.arch);
+    info.backend_type = backend_type;
+    info.soc_descriptor_yaml = buffer.str();
+    info.noc_translation_enabled = soc_descriptor.noc_translation_enabled;
+    info.tensix_harvesting_mask = soc_descriptor.harvesting_masks.tensix_harvesting_mask;
+    info.dram_harvesting_mask = soc_descriptor.harvesting_masks.dram_harvesting_mask;
+    info.eth_harvesting_mask = soc_descriptor.harvesting_masks.eth_harvesting_mask;
+    info.l2cpu_harvesting_mask = soc_descriptor.harvesting_masks.l2cpu_harvesting_mask;
+    info.pcie_harvesting_mask = soc_descriptor.harvesting_masks.pcie_harvesting_mask;
+    return info;
+}
+
+SocDescriptor build_soc_descriptor(const SimulationServerDeviceInfo& device_info) {
+    // SocArchDescriptor constructs only from a path, so materialize the served YAML to a unique temp
+    // file, build from it, and let RAII remove it -- including if construction or the arch check
+    // below throws. The descriptor reads the YAML eagerly, so the file isn't needed afterwards.
+    const ScopedTempFile yaml_file = write_temp_file(device_info.soc_descriptor_yaml, ".yaml");
+
+    ChipInfo chip_info{};
+    chip_info.noc_translation_enabled = device_info.noc_translation_enabled;
+    chip_info.harvesting_masks.tensix_harvesting_mask = device_info.tensix_harvesting_mask;
+    chip_info.harvesting_masks.dram_harvesting_mask = device_info.dram_harvesting_mask;
+    chip_info.harvesting_masks.eth_harvesting_mask = device_info.eth_harvesting_mask;
+    chip_info.harvesting_masks.l2cpu_harvesting_mask = device_info.l2cpu_harvesting_mask;
+    chip_info.harvesting_masks.pcie_harvesting_mask = device_info.pcie_harvesting_mask;
+
+    SocDescriptor soc_descriptor(std::make_shared<SocArchDescriptor>(yaml_file.path.string()), chip_info);
+
+    // The arch is transported explicitly (not just implied by the YAML) so a mismatch between the
+    // served YAML and the served arch value is caught here rather than silently producing a
+    // descriptor that disagrees with what the host reported.
+    UMD_ASSERT(
+        static_cast<int32_t>(soc_descriptor.arch) == device_info.arch,
+        error::RuntimeError,
+        fmt::format(
+            "Device-info arch ({}) does not match SoC-descriptor YAML arch ({})",
+            device_info.arch,
+            static_cast<int32_t>(soc_descriptor.arch)));
+
+    return soc_descriptor;
+}
+
+SimulationServerDeviceInfo fetch_device_info_from_host(SimulationClient& client) {
+    client.attach();  // idempotent; safe if already attached
+    SimulationServerRequest request;
+    request.command = SimulationServerCommand::GetDeviceInfo;
+    const SimulationServerDeviceInfo info = decode_device_info(client.transact(encode(request)));
+    UMD_ASSERT(
+        info.status == 0,
+        error::RuntimeError,
+        fmt::format("Remote simulation host failed to serve device info (status {})", info.status));
+    return info;
+}
+
+}  // namespace tt::umd

--- a/device/simulation/simulation_server_protocol.cpp
+++ b/device/simulation/simulation_server_protocol.cpp
@@ -55,6 +55,24 @@ std::vector<uint8_t> encode(const SimulationServerResponse& response) {
     return to_bytes(builder);
 }
 
+std::vector<uint8_t> encode(const SimulationServerDeviceInfo& device_info) {
+    flatbuffers::FlatBufferBuilder builder;
+    auto yaml = builder.CreateString(device_info.soc_descriptor_yaml);
+    builder.Finish(wire::CreateSimulationServerDeviceInfo(
+        builder,
+        device_info.status,
+        device_info.arch,
+        static_cast<wire::SimulationBackendType>(device_info.backend_type),
+        yaml,
+        device_info.noc_translation_enabled,
+        device_info.tensix_harvesting_mask,
+        device_info.dram_harvesting_mask,
+        device_info.eth_harvesting_mask,
+        device_info.l2cpu_harvesting_mask,
+        device_info.pcie_harvesting_mask));
+    return to_bytes(builder);
+}
+
 SimulationServerRequest decode_request(const uint8_t* data, size_t size) {
     const auto* fb = verify_and_get_root<wire::SimulationServerRequest>(data, size, "request");
     SimulationServerRequest request;
@@ -79,12 +97,34 @@ SimulationServerResponse decode_response(const uint8_t* data, size_t size) {
     return response;
 }
 
+SimulationServerDeviceInfo decode_device_info(const uint8_t* data, size_t size) {
+    const auto* fb = verify_and_get_root<wire::SimulationServerDeviceInfo>(data, size, "device info");
+    SimulationServerDeviceInfo info;
+    info.status = fb->status();
+    info.arch = fb->arch();
+    info.backend_type = static_cast<SimulationBackendType>(fb->backend_type());
+    if (fb->soc_descriptor_yaml() != nullptr) {
+        info.soc_descriptor_yaml = fb->soc_descriptor_yaml()->str();
+    }
+    info.noc_translation_enabled = fb->noc_translation_enabled();
+    info.tensix_harvesting_mask = fb->tensix_harvesting_mask();
+    info.dram_harvesting_mask = fb->dram_harvesting_mask();
+    info.eth_harvesting_mask = fb->eth_harvesting_mask();
+    info.l2cpu_harvesting_mask = fb->l2cpu_harvesting_mask();
+    info.pcie_harvesting_mask = fb->pcie_harvesting_mask();
+    return info;
+}
+
 SimulationServerRequest decode_request(const std::vector<uint8_t>& bytes) {
     return decode_request(bytes.data(), bytes.size());
 }
 
 SimulationServerResponse decode_response(const std::vector<uint8_t>& bytes) {
     return decode_response(bytes.data(), bytes.size());
+}
+
+SimulationServerDeviceInfo decode_device_info(const std::vector<uint8_t>& bytes) {
+    return decode_device_info(bytes.data(), bytes.size());
 }
 
 }  // namespace tt::umd

--- a/device/simulation/simulation_server_protocol.fbs
+++ b/device/simulation/simulation_server_protocol.fbs
@@ -22,6 +22,14 @@ namespace wire;
 enum SimulationServerCommand : byte {
     READ = 0,
     WRITE = 1,
+    GET_DEVICE_INFO = 2,
+}
+
+// Which simulator the host runs; served in the device identity so a client can build the matching
+// device class without a local simulator build.
+enum SimulationBackendType : byte {
+    TTSIM = 0,
+    RTL = 1,
 }
 
 // A device-memory access addressed by (core x/y, address, size). For WRITE, `data` carries the
@@ -41,6 +49,22 @@ table SimulationServerRequest {
 table SimulationServerResponse {
     status : int32;
     data : [ubyte];
+}
+
+// Device identity served in response to a GET_DEVICE_INFO request. Carries everything a client
+// needs to build a SocDescriptor matching the host's without reading a local simulator build:
+// the arch, the full SoC-descriptor YAML text, and the per-chip harvesting masks.
+table SimulationServerDeviceInfo {
+    status : int32;
+    arch : int32;
+    backend_type : SimulationBackendType;
+    soc_descriptor_yaml : string;
+    noc_translation_enabled : bool;
+    tensix_harvesting_mask : uint32;
+    dram_harvesting_mask : uint32;
+    eth_harvesting_mask : uint32;
+    l2cpu_harvesting_mask : uint32;
+    pcie_harvesting_mask : uint32;
 }
 
 // flatc requires a single root_type; the codec reads both messages uniformly via GetRoot<T>, so

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -22,6 +22,7 @@
 #include "umd/device/simulation/rtl_sim_communicator.hpp"
 #include "umd/device/simulation/simulation_chip.hpp"
 #include "umd/device/simulation/simulation_client.hpp"
+#include "umd/device/simulation/simulation_device_identity.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -67,15 +68,15 @@ std::unique_ptr<RtlSimulationTTDevice> RtlSimulationTTDevice::create(
 }
 
 std::unique_ptr<RtlSimulationTTDevice> RtlSimulationTTDevice::create_client(
-    const std::filesystem::path& simulator_directory, ChipId chip_id, std::unique_ptr<SimulationClient> client) {
+    ChipId chip_id, std::unique_ptr<SimulationClient> client) {
     UMD_ASSERT(
         client != nullptr,
         error::RuntimeError,
         "Client-mode RtlSimulationTTDevice requires a non-null SimulationClient.");
-    // The SoC descriptor is read straight from the local simulator build -- the same files the
-    // host used -- so the client can describe the device without loading or running a simulator.
-    auto soc_desc_path = SimulationChip::get_soc_descriptor_path_from_simulator_path(simulator_directory);
-    SocDescriptor soc_descriptor = SocDescriptor(std::make_shared<SocArchDescriptor>(soc_desc_path));
+    // Source the device identity from the host over the socket -- a client does not read a local
+    // simulator build.
+    const SimulationServerDeviceInfo info = fetch_device_info_from_host(*client);
+    SocDescriptor soc_descriptor = build_soc_descriptor(info);
     // make_unique can't reach the private client-mode constructor; this static factory can via new.
     return std::unique_ptr<RtlSimulationTTDevice>(
         new RtlSimulationTTDevice(soc_descriptor, chip_id, std::move(client)));

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -17,6 +17,7 @@
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/simulation/simulation_client.hpp"
+#include "umd/device/simulation/simulation_device_identity.hpp"
 #include "umd/device/simulation/simulation_server_protocol.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/types/arch.hpp"
@@ -53,6 +54,19 @@ void SimulationTTDevice::adopt_socket(std::unique_ptr<SimulationServerSocket> so
 
 std::vector<uint8_t> SimulationTTDevice::handle_request(const std::vector<uint8_t>& request_bytes) {
     const SimulationServerRequest request = decode_request(request_bytes);
+
+    // GetDeviceInfo returns a different wire message (SimulationServerDeviceInfo) than the
+    // read/write skeleton below (SimulationServerResponse), so it is handled up front.
+    if (request.command == SimulationServerCommand::GetDeviceInfo) {
+        try {
+            return encode(describe_device(get_soc_descriptor(), backend_type()));
+        } catch (const std::exception& e) {
+            log_warning(tt::LogUMD, "Simulation host failed to serve device info: {}", e.what());
+            SimulationServerDeviceInfo info;
+            info.status = -1;
+            return encode(info);
+        }
+    }
 
     // The client already translated the coordinate (translation is stateless and client-side), so
     // pass it through verbatim as LITERAL -- the shared read/write skeleton must not translate

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -24,6 +24,7 @@
 #include "umd/device/pcie/tt_sim_tlb_window.hpp"
 #include "umd/device/simulation/simulation_chip.hpp"
 #include "umd/device/simulation/simulation_client.hpp"
+#include "umd/device/simulation/simulation_device_identity.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/types/arch.hpp"
@@ -74,21 +75,13 @@ std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create_for_chip(
         simulator_directory, soc_descriptor, chip_id, copy_sim_binary, num_host_mem_channels);
 }
 
-std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create_client(
-    const std::filesystem::path& simulator_directory, ChipId chip_id, std::unique_ptr<SimulationClient> client) {
+std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create_client(ChipId chip_id, std::unique_ptr<SimulationClient> client) {
     UMD_ASSERT(
         client != nullptr, error::RuntimeError, "Client-mode TTSimTTDevice requires a non-null SimulationClient.");
-    // The SoC descriptor is read straight from the local simulator build -- the same files the
-    // host used -- so the client can describe the device without loading or running the .so.
-    auto soc_desc_path = SimulationChip::get_soc_descriptor_path_from_simulator_path(simulator_directory);
-    tt::ARCH arch = SocDescriptor::get_arch_from_soc_descriptor_path(soc_desc_path);
-    ChipInfo chip_info{};
-    if (arch == tt::ARCH::BLACKHOLE) {
-        // Same default ETH harvesting mask as create_for_chip(): BH SocDescriptor construction
-        // rejects an empty mask, so apply it here too. Keep in sync with create_for_chip().
-        chip_info.harvesting_masks.eth_harvesting_mask = 0x120;
-    }
-    SocDescriptor soc_descriptor = SocDescriptor(std::make_shared<SocArchDescriptor>(soc_desc_path), chip_info);
+    // Source the device identity from the host over the socket -- a client does not read a local
+    // simulator build.
+    const SimulationServerDeviceInfo info = fetch_device_info_from_host(*client);
+    SocDescriptor soc_descriptor = build_soc_descriptor(info);
     // make_unique can't reach the private client-mode constructor; this static factory can via new.
     return std::unique_ptr<TTSimTTDevice>(new TTSimTTDevice(soc_descriptor, chip_id, std::move(client)));
 }

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -25,6 +25,7 @@ if(TT_UMD_BUILD_SIMULATION)
     list(APPEND API_TESTS_SRCS test_ttsim_device_io.cpp)
     list(APPEND API_TESTS_SRCS test_simulation_connector.cpp)
     list(APPEND API_TESTS_SRCS test_simulation_server_protocol.cpp)
+    list(APPEND API_TESTS_SRCS test_simulation_device_identity.cpp)
 endif()
 
 add_executable(api_tests ${API_TESTS_SRCS})

--- a/tests/api/test_simulation_connector.cpp
+++ b/tests/api/test_simulation_connector.cpp
@@ -133,6 +133,50 @@ TEST(SimulationConnector, HostServesClientMemoryOverSocket) {
     EXPECT_EQ(readback, pattern2);
 }
 
+// The host serves its full device identity over the socket; a client reads it back and it matches
+// the host's live SoC descriptor field for field (serialization/deserialization through the socket).
+// Requires TT_UMD_SIMULATOR.
+TEST(SimulationConnector, HostServesDeviceInfoOverSocket) {
+    const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
+    if (simulator_path == nullptr) {
+        GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
+    }
+
+    const std::filesystem::path socket = SimulationServerSocket::default_socket_path(0);
+    {
+        auto probe = SimulationServerSocket::try_create(socket);
+        if (probe == nullptr) {
+            GTEST_SKIP() << "A live simulation host already holds " << socket << "; skipping.";
+        }
+    }
+
+    SimulationConnectorOptions options;
+    options.simulator_directory = simulator_path;
+    auto devices = SimulationConnector::discover(options);
+    ASSERT_EQ(devices.size(), 1u);
+    TTDevice* host = devices.at(0).get();
+    ASSERT_NE(host, nullptr);
+    const SocDescriptor& soc = host->get_soc_descriptor();
+
+    SimulationClient client(socket);
+    client.attach();
+    SimulationServerRequest info_request;
+    info_request.command = SimulationServerCommand::GetDeviceInfo;
+    const SimulationServerDeviceInfo info = decode_device_info(client.transact(encode(info_request)));
+
+    EXPECT_EQ(info.status, 0);
+    EXPECT_EQ(info.arch, static_cast<int32_t>(soc.arch));
+    const bool is_ttsim = std::filesystem::path(simulator_path).extension() == ".so";
+    EXPECT_EQ(info.backend_type, is_ttsim ? SimulationBackendType::TTSim : SimulationBackendType::Rtl);
+    EXPECT_FALSE(info.soc_descriptor_yaml.empty());
+    EXPECT_EQ(info.noc_translation_enabled, soc.noc_translation_enabled);
+    EXPECT_EQ(info.tensix_harvesting_mask, soc.harvesting_masks.tensix_harvesting_mask);
+    EXPECT_EQ(info.dram_harvesting_mask, soc.harvesting_masks.dram_harvesting_mask);
+    EXPECT_EQ(info.eth_harvesting_mask, soc.harvesting_masks.eth_harvesting_mask);
+    EXPECT_EQ(info.l2cpu_harvesting_mask, soc.harvesting_masks.l2cpu_harvesting_mask);
+    EXPECT_EQ(info.pcie_harvesting_mask, soc.harvesting_masks.pcie_harvesting_mask);
+}
+
 // End to end through the client device: a second open() against a live host yields a client-mode
 // device whose read_from_device/write_to_device marshal over the socket. What the client writes
 // the host sees, and what the host writes the client reads back. Requires TT_UMD_SIMULATOR.

--- a/tests/api/test_simulation_device_identity.cpp
+++ b/tests/api/test_simulation_device_identity.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "tests/test_utils/fetch_local_files.hpp"
+#include "umd/device/simulation/simulation_device_identity.hpp"
+#include "umd/device/soc_descriptor.hpp"
+
+using namespace tt;
+using namespace tt::umd;
+
+// describe_device(soc) -> build_soc_descriptor(info) reproduces a translation-equivalent
+// descriptor: same arch, same grid size, same harvesting masks.
+//
+// Uses a Blackhole descriptor because DRAM/ETH harvesting are only supported on Blackhole
+// (see CoordinateManager::assert_coordinate_manager_constructor); this lets the test exercise
+// non-default values for all five harvesting mask fields, not just tensix.
+TEST(SimulationDeviceIdentity, DescribeThenRebuildMatches) {
+    ChipInfo chip_info{};
+    chip_info.harvesting_masks.tensix_harvesting_mask = 0x1;
+    chip_info.harvesting_masks.dram_harvesting_mask = 0x2;
+    chip_info.harvesting_masks.eth_harvesting_mask = 0x120;
+    chip_info.harvesting_masks.l2cpu_harvesting_mask = 0x4;
+    chip_info.harvesting_masks.pcie_harvesting_mask = 0x1;
+    SocDescriptor original(
+        std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")), chip_info);
+
+    const SimulationServerDeviceInfo info = describe_device(original, SimulationBackendType::TTSim);
+    EXPECT_EQ(info.status, 0);
+    EXPECT_EQ(info.backend_type, SimulationBackendType::TTSim);
+    EXPECT_FALSE(info.soc_descriptor_yaml.empty());
+    EXPECT_EQ(info.tensix_harvesting_mask, 0x1u);
+
+    const SocDescriptor rebuilt = build_soc_descriptor(info);
+    EXPECT_EQ(rebuilt.arch, original.arch);
+    EXPECT_EQ(rebuilt.get_arch_descriptor().get_grid_size(), original.get_arch_descriptor().get_grid_size());
+    EXPECT_EQ(rebuilt.harvesting_masks.tensix_harvesting_mask, original.harvesting_masks.tensix_harvesting_mask);
+    EXPECT_EQ(rebuilt.harvesting_masks.dram_harvesting_mask, original.harvesting_masks.dram_harvesting_mask);
+    EXPECT_EQ(rebuilt.harvesting_masks.eth_harvesting_mask, original.harvesting_masks.eth_harvesting_mask);
+    EXPECT_EQ(rebuilt.harvesting_masks.l2cpu_harvesting_mask, original.harvesting_masks.l2cpu_harvesting_mask);
+    EXPECT_EQ(rebuilt.harvesting_masks.pcie_harvesting_mask, original.harvesting_masks.pcie_harvesting_mask);
+}

--- a/tests/api/test_simulation_server_protocol.cpp
+++ b/tests/api/test_simulation_server_protocol.cpp
@@ -93,3 +93,39 @@ TEST(SimulationServerProtocol, DecodeTruncatedBufferThrows) {
 
     EXPECT_THROW(decode_request(encoded), std::exception);
 }
+
+// GET_DEVICE_INFO round-trips arch, YAML text, and harvesting masks.
+TEST(SimulationServerProtocol, DeviceInfoSerializationRoundTrip) {
+    SimulationServerDeviceInfo info;
+    info.status = 0;
+    info.arch = 2;  // arbitrary tt::ARCH value
+    info.backend_type = SimulationBackendType::Rtl;
+    info.soc_descriptor_yaml = "arch: wormhole_b0\ngrid: [10, 12]\n";
+    info.noc_translation_enabled = false;
+    info.tensix_harvesting_mask = 0x5;
+    info.dram_harvesting_mask = 0x0;
+    info.eth_harvesting_mask = 0x120;
+    info.l2cpu_harvesting_mask = 0x0;
+    info.pcie_harvesting_mask = 0x3;
+
+    const SimulationServerDeviceInfo decoded = decode_device_info(encode(info));
+
+    EXPECT_EQ(decoded.status, info.status);
+    EXPECT_EQ(decoded.arch, info.arch);
+    EXPECT_EQ(decoded.backend_type, info.backend_type);
+    EXPECT_EQ(decoded.soc_descriptor_yaml, info.soc_descriptor_yaml);
+    EXPECT_EQ(decoded.noc_translation_enabled, info.noc_translation_enabled);
+    EXPECT_EQ(decoded.tensix_harvesting_mask, info.tensix_harvesting_mask);
+    EXPECT_EQ(decoded.dram_harvesting_mask, info.dram_harvesting_mask);
+    EXPECT_EQ(decoded.eth_harvesting_mask, info.eth_harvesting_mask);
+    EXPECT_EQ(decoded.l2cpu_harvesting_mask, info.l2cpu_harvesting_mask);
+    EXPECT_EQ(decoded.pcie_harvesting_mask, info.pcie_harvesting_mask);
+}
+
+// The GetDeviceInfo command survives a request round-trip.
+TEST(SimulationServerProtocol, GetDeviceInfoRequestRoundTrip) {
+    SimulationServerRequest request;
+    request.command = SimulationServerCommand::GetDeviceInfo;
+    const SimulationServerRequest decoded = decode_request(encode(request));
+    EXPECT_EQ(decoded.command, SimulationServerCommand::GetDeviceInfo);
+}


### PR DESCRIPTION
### Issue
Part of #2677 (simulation server process). A client-mode device currently reads its SoC descriptor from a local simulator build. This PR lets the host serve its device identity over the socket so a client can build a matching `SocDescriptor` with no local build — the prerequisite for deciding the host/client role purely from `simulator_path` (next PR). Stacked on #3014.

### Description
Adds one request command (`GET_DEVICE_INFO`) and one response message (`SimulationServerDeviceInfo`) to the wire protocol, carrying the arch, the **backend kind (TTSim/RTL)**, the full SoC-descriptor YAML text, `noc_translation_enabled`, and all five harvesting masks (tensix/dram/eth/l2cpu/pcie).

The served backend kind lets a client instantiate the matching device class — the prerequisite for the next PR, which decides the host/client role purely from `simulator_path` (a client's path is a socket *directory* that no longer carries the `.so` hint, so the class comes off the wire instead).

A small always-paired bridge translates between a `SocDescriptor` and that message:
- `describe_device()` (host): reads the descriptor's source YAML and captures its arch + masks.
- `build_soc_descriptor()` (client): materializes the served YAML to a temp file (the only way to construct `SocArchDescriptor`), applies the masks via `ChipInfo`, and asserts the YAML-derived arch matches the served arch.

The host answers `GET_DEVICE_INFO` from `get_soc_descriptor()` (read-only; no `device_lock`, before the read/write skeleton). `create_client()` (TTSim + RTL) now fetches the identity over the attached client and builds its descriptor from the wire instead of from `get_soc_descriptor_path_from_simulator_path()`; it no longer takes a `simulator_directory`.

Coordinate model is unchanged: the client still translates coordinates client-side, and the faithful descriptor round-trip is what keeps that translation correct.

### List of the changes
- `simulation_server_protocol.{fbs,hpp,cpp}` — `GET_DEVICE_INFO` command + `SimulationServerDeviceInfo` message (incl. `backend_kind`) + codec.
- `SimulationTTDevice::backend_kind()` — pure virtual returning the device's simulator kind (TTSim/RTL), overridden per device; the host fills the served `backend_kind` from it.
- `simulation_device_identity.{hpp,cpp}` (new) — `describe_device` / `build_soc_descriptor` / `fetch_device_info`.
- `simulation_tt_device.cpp` — `handle_request` serves `GET_DEVICE_INFO`.
- `tt_sim_tt_device` / `rtl_simulation_tt_device` — `create_client` sourced from the wire; drops `simulator_directory`.
- `simulation_connector.cpp` — updated `create_client` call sites.
- Tests: protocol round-trip + `SimulationDeviceIdentity` describe→rebuild fidelity (incl. masks); CI-gated e2e extended to fetch device info.

### Testing
Build + pre-commit clean; no-card sim unit suites pass (`SimulationServerProtocol.*` + `SimulationDeviceIdentity.*`, 9/9). The e2e runs in the simulation CI lane (`TT_UMD_SIMULATOR`).

### API Changes
`TTSimTTDevice::create_client` / `RtlSimulationTTDevice::create_client` drop the `simulator_directory` parameter (internal factories; the client now builds its descriptor from the wire). Otherwise internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
