### PR TITLE
Simulation: decide host/client role from simulator_path

### DIFF
--- a/device/api/umd/device/simulation/simulation_connector.hpp
+++ b/device/api/umd/device/simulation/simulation_connector.hpp
@@ -25,15 +25,13 @@ struct SimulationConnectorOptions {
     int num_host_mem_channels = 0;
 };
 
-// Entry point for opening simulated devices, mirroring silicon TopologyDiscovery. It scans the
-// well-known socket folder and decides, per device, whether to be the host or a client:
-//   - no live socket  -> create a host device (the direct in-process backend / hot path) which
-//                        binds + serves its socket;
-//   - live socket     -> create a socket-backed client device that attaches to the host.
-//
-// Socket-first: binding the socket is the host-vs-client arbiter. A client device attaches to the
-// host over the socket via SimulationClient (slim today -- just connect/disconnect; device-op
-// forwarding lands as that API grows).
+// Entry point for opening simulated devices, mirroring silicon TopologyDiscovery. The role is
+// decided purely from what simulator_directory points at -- no socket bind-race:
+//   - a ".so" file            -> host running the TTSim backend; binds + serves its socket;
+//   - a directory of per-chip -> client: one socket-backed device per socket in the directory,
+//     simulation sockets          each attaching to a live host and sourcing its SoC descriptor
+//                                 (and backend kind) from that host over the wire;
+//   - any other directory     -> host running the RTL backend from that build directory.
 class SimulationConnector {
 public:
     static std::map<ChipId, std::unique_ptr<TTDevice>> discover(const SimulationConnectorOptions& options);

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -44,11 +44,12 @@ public:
     static std::unique_ptr<RtlSimulationTTDevice> create(
         const std::filesystem::path& simulator_directory, int num_host_mem_channels = 0);
 
-    // Builds a client-mode device that attaches to a live host and sources its SoC descriptor from
-    // the host over the socket (see the .cpp); discovery uses this when a host already owns the
-    // socket.
+    // Builds a client-mode device from device identity the connector already fetched over the
+    // socket (build_soc_descriptor(device_info)); discovery uses this for a client that talks to a
+    // live host. The connector owns the single GET_DEVICE_INFO fetch (it needs the backend kind to
+    // pick this class), so it passes the result in rather than having this re-fetch it.
     static std::unique_ptr<RtlSimulationTTDevice> create_client(
-        ChipId chip_id, std::unique_ptr<SimulationClient> client);
+        ChipId chip_id, std::unique_ptr<SimulationClient> client, const SimulationServerDeviceInfo& device_info);
 
     void wait_arc_core_start(const std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT) override;
     std::chrono::milliseconds wait_eth_core_training(

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -57,10 +57,12 @@ public:
         int num_host_mem_channels = 0,
         bool copy_sim_binary = false);
 
-    // Builds a client-mode device that attaches to a live host and sources its SoC descriptor from
-    // the host over the socket (see the .cpp); discovery uses this when a host already owns the
-    // socket.
-    static std::unique_ptr<TTSimTTDevice> create_client(ChipId chip_id, std::unique_ptr<SimulationClient> client);
+    // Builds a client-mode device from device identity the connector already fetched over the
+    // socket (build_soc_descriptor(device_info)); discovery uses this for a client that talks to a
+    // live host. The connector owns the single GET_DEVICE_INFO fetch (it needs the backend kind to
+    // pick this class), so it passes the result in rather than having this re-fetch it.
+    static std::unique_ptr<TTSimTTDevice> create_client(
+        ChipId chip_id, std::unique_ptr<SimulationClient> client, const SimulationServerDeviceInfo &device_info);
 
     // Configure this chip's outbound iATU (NOC->host) the silicon way: iATU register writes via BAR2.
     // The simulator decodes these into its iATU model and honors them at DMA egress, so the chip's DMA

--- a/device/simulation/simulation_connector.cpp
+++ b/device/simulation/simulation_connector.cpp
@@ -4,45 +4,70 @@
 
 #include "umd/device/simulation/simulation_connector.hpp"
 
+#include <fmt/format.h>
+
+#include <filesystem>
+#include <map>
 #include <memory>
+#include <system_error>
+#include <tt-logger/tt-logger.hpp>
 #include <utility>
 
 #include "simulation/simulation_server_socket.hpp"
 #include "umd/device/simulation/simulation_client.hpp"
+#include "umd/device/simulation/simulation_device_identity.hpp"
+#include "umd/device/simulation/simulation_server_protocol.hpp"
 #include "umd/device/tt_device/rtl_simulation_tt_device.hpp"
 #include "umd/device/tt_device/tt_sim_tt_device.hpp"
+#include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
 
 namespace {
 
-// Builds the device for one simulated chip. The backend (TTSim .so vs RTL directory) is chosen by
-// the simulator path; the host-vs-client role is decided by who owns the socket:
-//   - socket == nullptr: a live host already serves this chip, so attach as a client that reaches
-//     it over the socket via SimulationClient (slim today -- just connect/disconnect; device-op
-//     forwarding lands as the API grows). The client runs no backend, so the only backend-specific
-//     bit is which device class describes it.
-//   - socket != nullptr: we are the host; bring up the in-process backend (the direct hot path) and
-//     hand it the socket to own and expose.
-// The two backends don't share a common factory return type that carries adopt_socket, so dispatch
-// on the concrete device here.
-std::unique_ptr<TTDevice> create_simulation_device(
-    const std::filesystem::path& simulator_directory,
-    ChipId chip_id,
-    int num_host_mem_channels,
-    const std::filesystem::path& socket_path,
-    std::unique_ptr<SimulationServerSocket> socket) {
-    const bool is_ttsim = simulator_directory.extension() == ".so";
+// The role a UMD process takes for a given simulator_path -- decided purely from what the path is,
+// with no socket bind-race:
+//   - a ".so" file                 -> host running the TTSim backend for that library;
+//   - a directory holding per-chip  -> client: a host already serves there, so attach to each
+//     simulation sockets               socket in it (one device per socket), sourcing device
+//                                      identity from the host over the wire;
+//   - any other directory          -> host running the RTL backend from that build directory.
+enum class Role { HOST_TTSIM, HOST_RTL, CLIENT };
 
-    if (socket == nullptr) {
-        auto client = std::make_unique<SimulationClient>(socket_path);
-        if (is_ttsim) {
-            return TTSimTTDevice::create_client(chip_id, std::move(client));
-        }
-        return RtlSimulationTTDevice::create_client(chip_id, std::move(client));
+// The role and, for CLIENT, the sockets found in the directory -- returned together so discover()
+// doesn't scan the directory a second time. The second scan would also be a TOCTOU race: if the host
+// exited between the two scans, the role would still be CLIENT but discover() would build zero
+// devices from a now-empty listing and return silently.
+struct Classification {
+    Role role;
+    std::map<ChipId, std::filesystem::path> sockets;
+};
+
+Classification classify(const std::filesystem::path& simulator_path) {
+    std::error_code ec;
+    if (std::filesystem::is_regular_file(simulator_path, ec) && simulator_path.extension() == ".so") {
+        return {Role::HOST_TTSIM, {}};
     }
+    UMD_ASSERT(
+        std::filesystem::is_directory(simulator_path, ec),
+        error::RuntimeError,
+        fmt::format("Simulator path is neither a .so file nor a directory: {}", simulator_path.string()));
+    // A directory that holds per-chip simulation sockets means a host is already serving there, so
+    // attach as a client; any other directory is an RTL build we host.
+    auto sockets = SimulationServerSocket::sockets_in_directory(simulator_path);
+    if (sockets.empty()) {
+        return {Role::HOST_RTL, {}};
+    }
+    return {Role::CLIENT, std::move(sockets)};
+}
 
-    if (is_ttsim) {
+// Host path: bring up the in-process backend (the direct hot path) and hand it the socket to serve.
+std::unique_ptr<TTDevice> make_host_device(
+    Role role,
+    const std::filesystem::path& simulator_directory,
+    int num_host_mem_channels,
+    std::unique_ptr<SimulationServerSocket> socket) {
+    if (role == Role::HOST_TTSIM) {
         auto device = TTSimTTDevice::create(simulator_directory, num_host_mem_channels);
         device->adopt_socket(std::move(socket));
         return device;
@@ -52,20 +77,66 @@ std::unique_ptr<TTDevice> create_simulation_device(
     return device;
 }
 
+// Client path: build the device class the host reports over the wire. A client runs no local
+// backend, so the class mostly just names the device; the backend kind still comes from the host so
+// the right class is instantiated (and so this stays correct if the classes diverge).
+std::unique_ptr<TTDevice> make_client_device(
+    ChipId chip_id, std::unique_ptr<SimulationClient> client, const SimulationServerDeviceInfo& info) {
+    switch (info.backend_type) {
+        case SimulationBackendType::TTSim:
+            return TTSimTTDevice::create_client(chip_id, std::move(client), info);
+        case SimulationBackendType::Rtl:
+            return RtlSimulationTTDevice::create_client(chip_id, std::move(client), info);
+    }
+    // A value outside the enum means a corrupt/incompatible reply from the host; fail loudly rather
+    // than silently defaulting to a backend class.
+    UMD_THROW(
+        error::RuntimeError,
+        fmt::format("Host reported an unknown simulation backend kind ({})", static_cast<int>(info.backend_type)));
+}
+
 }  // namespace
 
 std::map<ChipId, std::unique_ptr<TTDevice>> SimulationConnector::discover(const SimulationConnectorOptions& options) {
     std::map<ChipId, std::unique_ptr<TTDevice>> devices;
+    const std::filesystem::path& simulator_path = options.simulator_directory;
 
-    // Single-chip for now. Socket-first: try to claim the path; success => we are the host.
+    const Classification classification = classify(simulator_path);
+
+    if (classification.role == Role::CLIENT) {
+        // Multi-chip: one client device per per-chip socket in the directory (enumerated by
+        // classify()). Chip ids come from the socket names, so they match the host's. A failure on
+        // one socket (a dead or wedged host) only skips that chip -- it must not abort attaching to
+        // the healthy ones.
+        for (const auto& [chip_id, socket_file] : classification.sockets) {
+            try {
+                auto client = std::make_unique<SimulationClient>(socket_file);
+                // The connector owns the single GET_DEVICE_INFO fetch: it needs the backend type to
+                // pick the device class, and passes the fetched identity into create_client so it is
+                // not fetched again.
+                const SimulationServerDeviceInfo info = fetch_device_info_from_host(*client);
+                devices.emplace(chip_id, make_client_device(chip_id, std::move(client), info));
+            } catch (const std::exception& e) {
+                log_warning(
+                    LogUMD, "Skipping simulation socket {} (chip {}): {}", socket_file.string(), chip_id, e.what());
+            }
+        }
+        // Every socket was present but none answered -- surface it rather than returning an empty,
+        // successful-looking cluster.
+        UMD_ASSERT(
+            !devices.empty(),
+            error::RuntimeError,
+            fmt::format("No reachable simulation hosts among the sockets in {}", simulator_path.string()));
+        return devices;
+    }
+
+    // Host: single chip for now. Claim the per-chip socket -- create() throws if a live host
+    // already owns it (two hosts cannot serve the same chip) -- and serve it.
     const ChipId chip_id = 0;
-    const std::filesystem::path socket_path = SimulationServerSocket::default_socket_path(chip_id);
-    std::unique_ptr<SimulationServerSocket> socket = SimulationServerSocket::try_create(socket_path);
-
+    auto socket = SimulationServerSocket::create(SimulationServerSocket::default_socket_path(chip_id));
     devices.emplace(
         chip_id,
-        create_simulation_device(
-            options.simulator_directory, chip_id, options.num_host_mem_channels, socket_path, std::move(socket)));
+        make_host_device(classification.role, simulator_path, options.num_host_mem_channels, std::move(socket)));
     return devices;
 }
 

--- a/device/simulation/simulation_server_socket.cpp
+++ b/device/simulation/simulation_server_socket.cpp
@@ -9,8 +9,12 @@
 
 #include <asio.hpp>
 #include <atomic>
+#include <charconv>
+#include <map>
 #include <memory>
 #include <mutex>
+#include <string>
+#include <string_view>
 #include <system_error>
 #include <thread>
 #include <vector>
@@ -332,6 +336,55 @@ std::filesystem::path SimulationServerSocket::default_socket_path(ChipId chip_id
     // single host. The socket dir is assumed trusted: the path is predictable and the socket
     // is world-writable (see bind_and_listen), so any local user can connect to or squat it.
     return std::filesystem::temp_directory_path() / fmt::format("tt-umd-sim-{}.sock", chip_id);
+}
+
+std::optional<ChipId> SimulationServerSocket::chip_id_from_socket_path(const std::filesystem::path& socket_path) {
+    // Inverse of default_socket_path()'s "tt-umd-sim-<chip_id>.sock". Kept next to it so the naming
+    // convention lives in exactly one place.
+    constexpr std::string_view prefix = "tt-umd-sim-";
+    constexpr std::string_view suffix = ".sock";
+    const std::string filename = socket_path.filename().string();
+    const std::string_view name = filename;
+    if (name.size() <= prefix.size() + suffix.size() || name.substr(0, prefix.size()) != prefix ||
+        name.substr(name.size() - suffix.size()) != suffix) {
+        return std::nullopt;
+    }
+    const std::string_view digits = name.substr(prefix.size(), name.size() - prefix.size() - suffix.size());
+    // Reject a leading zero (except the lone "0") so "tt-umd-sim-0.sock" and "tt-umd-sim-00.sock"
+    // can't both parse to chip 0 and silently collide in a directory listing.
+    if (digits.size() > 1 && digits.front() == '0') {
+        return std::nullopt;
+    }
+    // from_chars doesn't throw and rejects signs/whitespace/junk; require it to consume every digit.
+    int chip_id = 0;
+    const auto [ptr, ec] = std::from_chars(digits.data(), digits.data() + digits.size(), chip_id);
+    if (ec != std::errc{} || ptr != digits.data() + digits.size()) {
+        return std::nullopt;
+    }
+    return static_cast<ChipId>(chip_id);
+}
+
+std::map<ChipId, std::filesystem::path> SimulationServerSocket::sockets_in_directory(
+    const std::filesystem::path& directory) {
+    std::map<ChipId, std::filesystem::path> sockets;
+    // directory_iterator(dir, ec) sets ec if the path is not a directory or cannot be read; in
+    // either case there are no per-chip sockets to report (the caller then classifies it as a host
+    // build, not a client socket directory), so return empty rather than silently proceeding.
+    std::error_code ec;
+    std::filesystem::directory_iterator it(directory, ec);
+    if (ec) {
+        return sockets;
+    }
+    for (const auto& entry : it) {
+        std::error_code sock_ec;
+        if (!entry.is_socket(sock_ec)) {
+            continue;
+        }
+        if (const std::optional<ChipId> chip_id = chip_id_from_socket_path(entry.path())) {
+            sockets.emplace(*chip_id, entry.path());
+        }
+    }
+    return sockets;
 }
 
 }  // namespace tt::umd

--- a/device/simulation/simulation_server_socket.hpp
+++ b/device/simulation/simulation_server_socket.hpp
@@ -7,7 +7,9 @@
 #include <cstdint>
 #include <filesystem>
 #include <functional>
+#include <map>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "umd/device/types/cluster_descriptor_types.hpp"
@@ -72,6 +74,18 @@ public:
     // <temp_dir>/tt-umd-sim-<chip_id>.sock, under the system temp directory. No uid in the
     // name: one shared socket per chip that any user may attach to.
     static std::filesystem::path default_socket_path(ChipId chip_id = 0);
+
+    // Inverse of default_socket_path()'s naming: pulls the chip id out of a socket file *name*
+    // (tt-umd-sim-<chip_id>.sock). Returns nullopt when the name doesn't match the convention, so a
+    // client enumerating a directory can pick out exactly the per-chip simulation sockets.
+    static std::optional<ChipId> chip_id_from_socket_path(const std::filesystem::path& socket_path);
+
+    // The per-chip simulation sockets present in a directory: {chip_id -> socket file}, keyed and
+    // ordered by chip id. Only AF_UNIX sockets whose names match the default_socket_path()
+    // convention are included; everything else in the directory is ignored. Empty if the path is
+    // not a directory or holds no such sockets. This is how a client turns a socket directory into
+    // the set of hosts to attach to.
+    static std::map<ChipId, std::filesystem::path> sockets_in_directory(const std::filesystem::path& directory);
 
 private:
     // Non-throwing; only initializes members. Binding happens in bind_and_listen(), driven by

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -68,15 +68,18 @@ std::unique_ptr<RtlSimulationTTDevice> RtlSimulationTTDevice::create(
 }
 
 std::unique_ptr<RtlSimulationTTDevice> RtlSimulationTTDevice::create_client(
-    ChipId chip_id, std::unique_ptr<SimulationClient> client) {
+    ChipId chip_id, std::unique_ptr<SimulationClient> client, const SimulationServerDeviceInfo& device_info) {
     UMD_ASSERT(
         client != nullptr,
         error::RuntimeError,
         "Client-mode RtlSimulationTTDevice requires a non-null SimulationClient.");
-    // Source the device identity from the host over the socket -- a client does not read a local
-    // simulator build.
-    const SimulationServerDeviceInfo info = fetch_device_info_from_host(*client);
-    SocDescriptor soc_descriptor = build_soc_descriptor(info);
+    UMD_ASSERT(
+        device_info.status == 0,
+        error::RuntimeError,
+        fmt::format("Cannot build a client device from failed device info (status {}).", device_info.status));
+    // The connector already fetched the device identity over the socket (it needed the backend type
+    // to pick this class); build the SoC descriptor from it -- a client does not read a local build.
+    SocDescriptor soc_descriptor = build_soc_descriptor(device_info);
     // make_unique can't reach the private client-mode constructor; this static factory can via new.
     return std::unique_ptr<RtlSimulationTTDevice>(
         new RtlSimulationTTDevice(soc_descriptor, chip_id, std::move(client)));

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -75,13 +75,17 @@ std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create_for_chip(
         simulator_directory, soc_descriptor, chip_id, copy_sim_binary, num_host_mem_channels);
 }
 
-std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create_client(ChipId chip_id, std::unique_ptr<SimulationClient> client) {
+std::unique_ptr<TTSimTTDevice> TTSimTTDevice::create_client(
+    ChipId chip_id, std::unique_ptr<SimulationClient> client, const SimulationServerDeviceInfo& device_info) {
     UMD_ASSERT(
         client != nullptr, error::RuntimeError, "Client-mode TTSimTTDevice requires a non-null SimulationClient.");
-    // Source the device identity from the host over the socket -- a client does not read a local
-    // simulator build.
-    const SimulationServerDeviceInfo info = fetch_device_info_from_host(*client);
-    SocDescriptor soc_descriptor = build_soc_descriptor(info);
+    UMD_ASSERT(
+        device_info.status == 0,
+        error::RuntimeError,
+        fmt::format("Cannot build a client device from failed device info (status {}).", device_info.status));
+    // The connector already fetched the device identity over the socket (it needed the backend type
+    // to pick this class); build the SoC descriptor from it -- a client does not read a local build.
+    SocDescriptor soc_descriptor = build_soc_descriptor(device_info);
     // make_unique can't reach the private client-mode constructor; this static factory can via new.
     return std::unique_ptr<TTSimTTDevice>(new TTSimTTDevice(soc_descriptor, chip_id, std::move(client)));
 }

--- a/tests/api/test_simulation_connector.cpp
+++ b/tests/api/test_simulation_connector.cpp
@@ -52,19 +52,13 @@ TEST(SimulationConnector, CreatesHostDeviceAndExposesSocket) {
     EXPECT_FALSE(std::filesystem::exists(socket));  // torn down with the device
 }
 
-// When a live host already holds the socket, discovery takes the client/attach path. Here it must
-// still surface an error rather than hosting, because the client device reads its SoC descriptor
-// from the (invalid) simulator directory and fails. This exercises the host-vs-client arbiter's
-// client branch without a simulator.
-TEST(SimulationConnector, ThrowsWhenClientCreationFailsAgainstLiveHost) {
-    const std::filesystem::path socket = SimulationServerSocket::default_socket_path(0);
-    auto host = SimulationServerSocket::try_create(socket);
-    if (host == nullptr) {
-        GTEST_SKIP() << "A live simulation host already holds " << socket << "; skipping.";
-    }
-
+// discover() decides the role from what simulator_directory points at (a .so file hosts TTSim, a
+// directory of sockets is a client, any other directory hosts RTL). A path that is neither a .so
+// file nor a directory is unrecognized and must fail loudly rather than silently mis-hosting. No
+// simulator needed -- this exercises the path classifier's rejection branch.
+TEST(SimulationConnector, ThrowsOnUnrecognizedSimulatorPath) {
     SimulationConnectorOptions options;
-    options.simulator_directory = "unused";  // client creation reads the SoC descriptor from here and throws.
+    options.simulator_directory = "/nonexistent/neither-a-so-nor-a-directory";
     EXPECT_THROW(SimulationConnector::discover(options), std::exception);
 }
 
@@ -177,9 +171,10 @@ TEST(SimulationConnector, HostServesDeviceInfoOverSocket) {
     EXPECT_EQ(info.pcie_harvesting_mask, soc.harvesting_masks.pcie_harvesting_mask);
 }
 
-// End to end through the client device: a second open() against a live host yields a client-mode
-// device whose read_from_device/write_to_device marshal over the socket. What the client writes
-// the host sees, and what the host writes the client reads back. Requires TT_UMD_SIMULATOR.
+// End to end through the client device: hosting from the .so and then discovering the socket
+// *directory* yields a client-mode device whose read_from_device/write_to_device marshal over the
+// socket. What the client writes the host sees, and what the host writes the client reads back.
+// Requires TT_UMD_SIMULATOR.
 TEST(SimulationConnector, ClientDeviceReadsAndWritesOverSocket) {
     const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
     if (simulator_path == nullptr) {
@@ -194,17 +189,20 @@ TEST(SimulationConnector, ClientDeviceReadsAndWritesOverSocket) {
         }
     }
 
-    SimulationConnectorOptions options;
-    options.simulator_directory = simulator_path;
+    SimulationConnectorOptions host_options;
+    host_options.simulator_directory = simulator_path;
 
-    // First open becomes the host; the second sees the live host and attaches as a client device.
-    auto host_devices = SimulationConnector::discover(options);
+    // The .so path hosts and publishes its per-chip socket; pointing discovery at that socket's
+    // directory takes the client path, attaching one client device per socket.
+    auto host_devices = SimulationConnector::discover(host_options);
     ASSERT_EQ(host_devices.size(), 1u);
     TTDevice* host = host_devices.at(0).get();
     ASSERT_NE(host, nullptr);
 
-    auto client_devices = SimulationConnector::discover(options);
-    ASSERT_EQ(client_devices.size(), 1u);
+    SimulationConnectorOptions client_options;
+    client_options.simulator_directory = socket.parent_path();
+    auto client_devices = SimulationConnector::discover(client_options);
+    ASSERT_EQ(client_devices.count(0), 1u);
     TTDevice* client = client_devices.at(0).get();
     ASSERT_NE(client, nullptr);
 

--- a/tests/baremetal/test_simulation_server_socket.cpp
+++ b/tests/baremetal/test_simulation_server_socket.cpp
@@ -229,3 +229,64 @@ TEST(SimulationServerSocket, DefaultSocketPathIsPerChip) {
 TEST(SimulationServerSocket, DefaultSocketPathIsAbsolute) {
     EXPECT_TRUE(SimulationServerSocket::default_socket_path(0).is_absolute());
 }
+
+// chip_id_from_socket_path is the inverse of default_socket_path's naming; it must accept exactly
+// the tt-umd-sim-<id>.sock convention and reject anything else.
+TEST(SimulationServerSocket, ChipIdFromSocketPathParsesConvention) {
+    auto id0 = SimulationServerSocket::chip_id_from_socket_path("tt-umd-sim-0.sock");
+    ASSERT_TRUE(id0.has_value());
+    EXPECT_EQ(*id0, 0);
+
+    auto id7 = SimulationServerSocket::chip_id_from_socket_path("/some/dir/tt-umd-sim-7.sock");
+    ASSERT_TRUE(id7.has_value());
+    EXPECT_EQ(*id7, 7);
+
+    // Round-trips default_socket_path().
+    auto id3 = SimulationServerSocket::chip_id_from_socket_path(SimulationServerSocket::default_socket_path(3));
+    ASSERT_TRUE(id3.has_value());
+    EXPECT_EQ(*id3, 3);
+
+    // Non-matching names yield nullopt (not a wrong id).
+    EXPECT_FALSE(SimulationServerSocket::chip_id_from_socket_path("foo.sock").has_value());
+    EXPECT_FALSE(SimulationServerSocket::chip_id_from_socket_path("tt-umd-sim-.sock").has_value());
+    EXPECT_FALSE(SimulationServerSocket::chip_id_from_socket_path("tt-umd-sim-x.sock").has_value());
+    EXPECT_FALSE(SimulationServerSocket::chip_id_from_socket_path("tt-umd-sim-1.txt").has_value());
+
+    // Leading zeros are rejected so "-0" and "-00" can't both map to chip 0 and collide.
+    EXPECT_FALSE(SimulationServerSocket::chip_id_from_socket_path("tt-umd-sim-00.sock").has_value());
+    EXPECT_FALSE(SimulationServerSocket::chip_id_from_socket_path("tt-umd-sim-01.sock").has_value());
+}
+
+// sockets_in_directory returns exactly the per-chip AF_UNIX sockets, keyed by chip id, ignoring
+// non-sockets and sockets that don't match the naming convention.
+TEST(SimulationServerSocket, SocketsInDirectoryPicksPerChipSockets) {
+    namespace fs = std::filesystem;
+    const fs::path dir = fs::temp_directory_path() / ("tt-umd-sim-dir-" + std::to_string(::getpid()));
+    fs::remove_all(dir);
+    fs::create_directories(dir);
+
+    leave_stale_socket(dir / "tt-umd-sim-0.sock");                   // per-chip socket -> included
+    leave_stale_socket(dir / "tt-umd-sim-2.sock");                   // per-chip socket -> included
+    leave_stale_socket(dir / "unrelated.sock");                      // socket, wrong name -> excluded
+    { std::ofstream(dir / "tt-umd-sim-9.sock") << "not a socket"; }  // right name, not a socket -> excluded
+
+    const auto sockets = SimulationServerSocket::sockets_in_directory(dir);
+    EXPECT_EQ(sockets.size(), 2u);
+    ASSERT_EQ(sockets.count(0), 1u);
+    ASSERT_EQ(sockets.count(2), 1u);
+    EXPECT_EQ(sockets.at(0), dir / "tt-umd-sim-0.sock");
+    EXPECT_EQ(sockets.at(2), dir / "tt-umd-sim-2.sock");
+
+    fs::remove_all(dir);
+}
+
+TEST(SimulationServerSocket, SocketsInDirectoryEmptyWhenNoneOrNotADir) {
+    namespace fs = std::filesystem;
+    EXPECT_TRUE(SimulationServerSocket::sockets_in_directory("/nonexistent/tt-umd-xyz").empty());
+
+    const fs::path dir = fs::temp_directory_path() / ("tt-umd-sim-empty-" + std::to_string(::getpid()));
+    fs::remove_all(dir);
+    fs::create_directories(dir);
+    EXPECT_TRUE(SimulationServerSocket::sockets_in_directory(dir).empty());
+    fs::remove_all(dir);
+}


### PR DESCRIPTION
### Issue
Part of #2677 (simulation server process). Until now a UMD process decided whether it was the simulation *host* or a *client* by a runtime socket bind-race (first to bind the per-chip socket wins). This PR makes the role a deterministic function of `simulator_path`. Stacked on #3019.

### Description
`SimulationConnector::discover()` now classifies `simulator_directory` and picks the role from what it points at — no bind-race:

- a `.so` file → **host** running the TTSim backend;
- a directory holding per-chip simulation sockets (`tt-umd-sim-<id>.sock`) → **client**: one device per socket in it, each attaching to a live host;
- any other directory → **host** running the RTL backend.

Client-vs-RTL is disambiguated by directory contents: a directory is a client target iff it contains AF_UNIX sockets matching the naming convention.

The **client path is multi-chip**: it enumerates the per-chip sockets and builds one client device per socket, with chip ids parsed from the socket names (so they match the host's). The connector performs the single `GET_DEVICE_INFO` fetch — it needs the served **backend kind** (from #3019) to instantiate the matching device class — and passes the fetched identity into `create_client()`, which no longer fetches it itself.

The **host path** claims its socket with `create()`: a live owner for the same chip is now a hard error rather than a silent demotion to client (role is decided by the path, so two hosts for one chip is a real conflict).

### List of the changes
- `SimulationConnector::discover()` — rewritten to a path classifier (`.so` / socket-dir / RTL-dir) with a multi-chip client path; host claims the socket via `create()`.
- `create_client()` (TTSim + RTL) — takes the connector-fetched `SimulationServerDeviceInfo` instead of fetching `GET_DEVICE_INFO` itself.
- `SimulationServerSocket::chip_id_from_socket_path()` — inverse of `default_socket_path()`'s naming.
- `SimulationServerSocket::sockets_in_directory()` — the per-chip sockets in a directory, keyed by chip id (AF_UNIX + name-matched).
- Review hardening: `chip_id_from_socket_path` parses via `std::from_chars`/`std::string_view` and rejects leading-zero names so `-0`/`-00` can't collide; `classify()` returns the sockets it enumerated so `discover()` doesn't re-scan (closing a TOCTOU that would otherwise return zero devices silently) and skips a dead socket per-chip with a warning instead of aborting the whole attach; the internal path-kind enum uses UPPER_SNAKE.
- Tests: `chip_id_from_socket_path` + `sockets_in_directory` unit-tested in the no-card baremetal lane; e2e connector tests updated to the path-based model (client discovered by pointing at the socket directory; obsolete "live-socket ⇒ client" test replaced with a path-classification test).

### Testing
Build + pre-commit clean; no-card lanes pass (179 baremetal, incl. the new socket-naming/enumeration tests; api protocol + identity + the path-classification test). The e2e connector tests run in the simulation CI lane (`TT_UMD_SIMULATOR`).

### API Changes
`TTSimTTDevice::create_client` / `RtlSimulationTTDevice::create_client` take an extra `const SimulationServerDeviceInfo&` (the connector fetches device identity once and passes it in). `SimulationServerSocket` gains `chip_id_from_socket_path()` and `sockets_in_directory()`. All internal to the simulation subsystem.