### PR TITLE
Simulation: serve the cluster descriptor over the socket

### DIFF
--- a/device/api/umd/device/simulation/simulation_device_identity.hpp
+++ b/device/api/umd/device/simulation/simulation_device_identity.hpp
@@ -4,14 +4,18 @@
 
 #pragma once
 
+#include <filesystem>
+#include <string>
+
 #include "umd/device/simulation/simulation_client.hpp"
 #include "umd/device/simulation/simulation_server_protocol.hpp"
 #include "umd/device/soc_descriptor.hpp"
 
 namespace tt::umd {
 
-// Bridges a SocDescriptor and the GET_DEVICE_INFO wire message, so a client can rebuild the host's
-// device identity without a local simulator build.
+// Bridges the simulator's metadata (SoC descriptor, cluster descriptor) and the GET_DEVICE_INFO /
+// GET_CLUSTER_DESCRIPTOR wire messages, so a client can rebuild the host's device identity and
+// topology without a local simulator build.
 
 // Host side: package this device's SocDescriptor into a wire message, so a client can receive it
 // and build its own matching SocDescriptor. backend_type records which simulator the host runs.
@@ -22,5 +26,13 @@ SocDescriptor build_soc_descriptor(const SimulationServerDeviceInfo& device_info
 
 // Client side: request the host's device identity over the socket.
 SimulationServerDeviceInfo fetch_device_info_from_host(SimulationClient& client);
+
+// Host side: read the simulator build's cluster-descriptor YAML as a wire message. Returns an empty
+// `yaml` when the build ships no cluster_descriptor.yaml (the client then falls back to a mock).
+SimulationServerClusterDescriptor describe_cluster(const std::filesystem::path& simulator_directory);
+
+// Client side: request the host's cluster-descriptor YAML over an already-attached client. Attaches
+// the client if needed; throws on a nonzero status. Empty string means the host has no descriptor.
+std::string fetch_cluster_descriptor_yaml(SimulationClient& client);
 
 }  // namespace tt::umd

--- a/device/api/umd/device/simulation/simulation_server_protocol.hpp
+++ b/device/api/umd/device/simulation/simulation_server_protocol.hpp
@@ -28,6 +28,7 @@ enum class SimulationServerCommand : int8_t {
     Read = 0,
     Write = 1,
     GetDeviceInfo = 2,
+    GetClusterDescriptor = 3,
 };
 
 // Which simulator the host runs; mirrors wire::SimulationBackendType. Served as part of the device
@@ -77,10 +78,21 @@ struct SimulationServerDeviceInfo {
     uint32_t pcie_harvesting_mask = 0;
 };
 
+// Cluster topology a host serves in reply to a GetClusterDescriptor request; mirrors
+// wire::SimulationServerClusterDescriptor.
+struct SimulationServerClusterDescriptor {
+    // 0 on success; nonzero signals a host-side failure.
+    int32_t status = 0;
+    // The host's cluster-descriptor YAML text, so the client can rebuild the full ClusterDescriptor.
+    // Empty when the host has no cluster descriptor (client falls back to a mock from the device info).
+    std::string yaml;
+};
+
 // Serialize a message to a FlatBuffers payload.
 std::vector<uint8_t> encode(const SimulationServerRequest& request);
 std::vector<uint8_t> encode(const SimulationServerResponse& response);
 std::vector<uint8_t> encode(const SimulationServerDeviceInfo& device_info);
+std::vector<uint8_t> encode(const SimulationServerClusterDescriptor& cluster_descriptor);
 
 // Parse a message back from a FlatBuffers payload. The buffer is verified against the schema
 // before any field is read (it comes off a socket, so it may be malformed or truncated); a bad
@@ -88,8 +100,10 @@ std::vector<uint8_t> encode(const SimulationServerDeviceInfo& device_info);
 SimulationServerRequest decode_request(const uint8_t* data, size_t size);
 SimulationServerResponse decode_response(const uint8_t* data, size_t size);
 SimulationServerDeviceInfo decode_device_info(const uint8_t* data, size_t size);
+SimulationServerClusterDescriptor decode_cluster_descriptor(const uint8_t* data, size_t size);
 SimulationServerRequest decode_request(const std::vector<uint8_t>& bytes);
 SimulationServerResponse decode_response(const std::vector<uint8_t>& bytes);
 SimulationServerDeviceInfo decode_device_info(const std::vector<uint8_t>& bytes);
+SimulationServerClusterDescriptor decode_cluster_descriptor(const std::vector<uint8_t>& bytes);
 
 }  // namespace tt::umd

--- a/device/simulation/simulation_device_identity.cpp
+++ b/device/simulation/simulation_device_identity.cpp
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <vector>
 
+#include "umd/device/simulation/simulation_chip.hpp"
 #include "umd/device/simulation/simulation_client.hpp"
 #include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/utils/error.hpp"
@@ -123,6 +124,47 @@ SimulationServerDeviceInfo fetch_device_info_from_host(SimulationClient& client)
         error::RuntimeError,
         fmt::format("Remote simulation host failed to serve device info (status {})", info.status));
     return info;
+}
+
+SimulationServerClusterDescriptor describe_cluster(const std::filesystem::path& simulator_directory) {
+    SimulationServerClusterDescriptor cluster_descriptor;
+    cluster_descriptor.status = 0;
+
+    const std::string yaml_path = SimulationChip::get_cluster_descriptor_path_from_simulator_path(simulator_directory);
+    // A simulator build need not ship a cluster_descriptor.yaml; an empty yaml tells the client to
+    // fall back to a mock built from the device info, mirroring the host's own mock fallback.
+    // Distinguish "definitely absent" from "couldn't tell": if exists() itself errors (permission/
+    // IO), surface it rather than silently serving an empty descriptor as if the file were absent.
+    std::error_code ec;
+    const bool yaml_exists = std::filesystem::exists(yaml_path, ec);
+    UMD_ASSERT(
+        !ec,
+        error::RuntimeError,
+        fmt::format("Failed to check for cluster descriptor at {}: {}", yaml_path, ec.message()));
+    if (!yaml_exists) {
+        return cluster_descriptor;
+    }
+
+    std::ifstream in(yaml_path);
+    UMD_ASSERT(in.good(), error::RuntimeError, fmt::format("Failed to open cluster descriptor YAML at {}", yaml_path));
+    std::stringstream buffer;
+    buffer << in.rdbuf();
+    cluster_descriptor.yaml = buffer.str();
+    return cluster_descriptor;
+}
+
+std::string fetch_cluster_descriptor_yaml(SimulationClient& client) {
+    client.attach();  // idempotent; safe if already attached
+    SimulationServerRequest request;
+    request.command = SimulationServerCommand::GetClusterDescriptor;
+    const SimulationServerClusterDescriptor cluster_descriptor =
+        decode_cluster_descriptor(client.transact(encode(request)));
+    UMD_ASSERT(
+        cluster_descriptor.status == 0,
+        error::RuntimeError,
+        fmt::format(
+            "Remote simulation host failed to serve cluster descriptor (status {})", cluster_descriptor.status));
+    return cluster_descriptor.yaml;
 }
 
 }  // namespace tt::umd

--- a/device/simulation/simulation_server_protocol.cpp
+++ b/device/simulation/simulation_server_protocol.cpp
@@ -73,6 +73,13 @@ std::vector<uint8_t> encode(const SimulationServerDeviceInfo& device_info) {
     return to_bytes(builder);
 }
 
+std::vector<uint8_t> encode(const SimulationServerClusterDescriptor& cluster_descriptor) {
+    flatbuffers::FlatBufferBuilder builder;
+    auto yaml = builder.CreateString(cluster_descriptor.yaml);
+    builder.Finish(wire::CreateSimulationServerClusterDescriptor(builder, cluster_descriptor.status, yaml));
+    return to_bytes(builder);
+}
+
 SimulationServerRequest decode_request(const uint8_t* data, size_t size) {
     const auto* fb = verify_and_get_root<wire::SimulationServerRequest>(data, size, "request");
     SimulationServerRequest request;
@@ -115,6 +122,16 @@ SimulationServerDeviceInfo decode_device_info(const uint8_t* data, size_t size) 
     return info;
 }
 
+SimulationServerClusterDescriptor decode_cluster_descriptor(const uint8_t* data, size_t size) {
+    const auto* fb = verify_and_get_root<wire::SimulationServerClusterDescriptor>(data, size, "cluster descriptor");
+    SimulationServerClusterDescriptor cluster_descriptor;
+    cluster_descriptor.status = fb->status();
+    if (fb->yaml() != nullptr) {
+        cluster_descriptor.yaml = fb->yaml()->str();
+    }
+    return cluster_descriptor;
+}
+
 SimulationServerRequest decode_request(const std::vector<uint8_t>& bytes) {
     return decode_request(bytes.data(), bytes.size());
 }
@@ -125,6 +142,10 @@ SimulationServerResponse decode_response(const std::vector<uint8_t>& bytes) {
 
 SimulationServerDeviceInfo decode_device_info(const std::vector<uint8_t>& bytes) {
     return decode_device_info(bytes.data(), bytes.size());
+}
+
+SimulationServerClusterDescriptor decode_cluster_descriptor(const std::vector<uint8_t>& bytes) {
+    return decode_cluster_descriptor(bytes.data(), bytes.size());
 }
 
 }  // namespace tt::umd

--- a/device/simulation/simulation_server_protocol.fbs
+++ b/device/simulation/simulation_server_protocol.fbs
@@ -23,6 +23,7 @@ enum SimulationServerCommand : byte {
     READ = 0,
     WRITE = 1,
     GET_DEVICE_INFO = 2,
+    GET_CLUSTER_DESCRIPTOR = 3,
 }
 
 // Which simulator the host runs; served in the device identity so a client can build the matching
@@ -65,6 +66,14 @@ table SimulationServerDeviceInfo {
     eth_harvesting_mask : uint32;
     l2cpu_harvesting_mask : uint32;
     pcie_harvesting_mask : uint32;
+}
+
+// Cluster topology served in response to a GET_CLUSTER_DESCRIPTOR request. `yaml` is the host's
+// cluster-descriptor YAML text so a client can rebuild the full ClusterDescriptor; empty means the
+// host has no cluster descriptor (the client falls back to a mock built from the device info).
+table SimulationServerClusterDescriptor {
+    status : int32;
+    yaml : string;
 }
 
 // flatc requires a single root_type; the codec reads both messages uniformly via GetRoot<T>, so

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -68,6 +68,19 @@ std::vector<uint8_t> SimulationTTDevice::handle_request(const std::vector<uint8_
         }
     }
 
+    // GetClusterDescriptor also returns its own wire message; serve the build's cluster-descriptor
+    // YAML (empty when the build ships none) so a client can rebuild the full topology.
+    if (request.command == SimulationServerCommand::GetClusterDescriptor) {
+        try {
+            return encode(describe_cluster(simulator_directory_));
+        } catch (const std::exception& e) {
+            log_warning(tt::LogUMD, "Simulation host failed to serve cluster descriptor: {}", e.what());
+            SimulationServerClusterDescriptor cluster_descriptor;
+            cluster_descriptor.status = -1;
+            return encode(cluster_descriptor);
+        }
+    }
+
     // The client already translated the coordinate (translation is stateless and client-side), so
     // pass it through verbatim as LITERAL -- the shared read/write skeleton must not translate
     // again. CoreCoord defaults to CoreType::UNSPECIFIED + CoordSystem::LITERAL.

--- a/tests/api/test_simulation_device_identity.cpp
+++ b/tests/api/test_simulation_device_identity.cpp
@@ -3,8 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <unistd.h>
 
+#include <filesystem>
+#include <fstream>
 #include <memory>
+#include <string>
 
 #include "tests/test_utils/fetch_local_files.hpp"
 #include "umd/device/simulation/simulation_device_identity.hpp"
@@ -43,4 +47,39 @@ TEST(SimulationDeviceIdentity, DescribeThenRebuildMatches) {
     EXPECT_EQ(rebuilt.harvesting_masks.eth_harvesting_mask, original.harvesting_masks.eth_harvesting_mask);
     EXPECT_EQ(rebuilt.harvesting_masks.l2cpu_harvesting_mask, original.harvesting_masks.l2cpu_harvesting_mask);
     EXPECT_EQ(rebuilt.harvesting_masks.pcie_harvesting_mask, original.harvesting_masks.pcie_harvesting_mask);
+}
+
+// describe_cluster() reads the build's cluster_descriptor.yaml from the simulator directory, so both
+// cases below need a scratch directory. The fixture owns its lifecycle (unique per process, created
+// fresh and removed after each test) so the tests only differ in what they put in it.
+class DescribeClusterTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        dir_ = std::filesystem::temp_directory_path() / ("tt-umd-sim-clusterdesc-" + std::to_string(::getpid()));
+        std::filesystem::remove_all(dir_);
+        std::filesystem::create_directories(dir_);
+    }
+
+    void TearDown() override { std::filesystem::remove_all(dir_); }
+
+    std::filesystem::path dir_;
+};
+
+// describe_cluster reads the build's cluster_descriptor.yaml text (dir/cluster_descriptor.yaml for a
+// directory simulator path) so a client can reconstruct the topology.
+TEST_F(DescribeClusterTest, ReadsYamlWhenPresent) {
+    const std::string yaml = "chips:\n  0: [0, 0, 0, 0]\nethernet_connections: []\n";
+    { std::ofstream(dir_ / "cluster_descriptor.yaml") << yaml; }
+
+    const SimulationServerClusterDescriptor described = describe_cluster(dir_);
+    EXPECT_EQ(described.status, 0);
+    EXPECT_EQ(described.yaml, yaml);
+}
+
+// When the build ships no cluster_descriptor.yaml, describe_cluster returns an empty yaml (status 0),
+// the signal for a client to fall back to a mock descriptor.
+TEST_F(DescribeClusterTest, EmptyWhenNoYaml) {
+    const SimulationServerClusterDescriptor described = describe_cluster(dir_);
+    EXPECT_EQ(described.status, 0);
+    EXPECT_TRUE(described.yaml.empty());
 }

--- a/tests/api/test_simulation_server_protocol.cpp
+++ b/tests/api/test_simulation_server_protocol.cpp
@@ -129,3 +129,31 @@ TEST(SimulationServerProtocol, GetDeviceInfoRequestRoundTrip) {
     const SimulationServerRequest decoded = decode_request(encode(request));
     EXPECT_EQ(decoded.command, SimulationServerCommand::GetDeviceInfo);
 }
+
+// The cluster-descriptor message round-trips its status and YAML text.
+TEST(SimulationServerProtocol, ClusterDescriptorRoundTrip) {
+    SimulationServerClusterDescriptor cluster_descriptor;
+    cluster_descriptor.status = 0;
+    cluster_descriptor.yaml = "chips:\n  0: [0, 0, 0, 0]\nethernet_connections: []\n";
+
+    const SimulationServerClusterDescriptor decoded = decode_cluster_descriptor(encode(cluster_descriptor));
+
+    EXPECT_EQ(decoded.status, cluster_descriptor.status);
+    EXPECT_EQ(decoded.yaml, cluster_descriptor.yaml);
+}
+
+// An empty YAML (the host has no cluster descriptor) round-trips as empty, not null.
+TEST(SimulationServerProtocol, ClusterDescriptorEmptyYamlRoundTrip) {
+    SimulationServerClusterDescriptor cluster_descriptor;  // status 0, empty yaml
+    const SimulationServerClusterDescriptor decoded = decode_cluster_descriptor(encode(cluster_descriptor));
+    EXPECT_EQ(decoded.status, 0);
+    EXPECT_TRUE(decoded.yaml.empty());
+}
+
+// The GetClusterDescriptor command survives a request round-trip.
+TEST(SimulationServerProtocol, GetClusterDescriptorRequestRoundTrip) {
+    SimulationServerRequest request;
+    request.command = SimulationServerCommand::GetClusterDescriptor;
+    const SimulationServerRequest decoded = decode_request(encode(request));
+    EXPECT_EQ(decoded.command, SimulationServerCommand::GetClusterDescriptor);
+}


### PR DESCRIPTION
### Issue
Part of #2677 (simulation server process). A client-mode simulation Cluster needs the host's topology (which chips, how they're wired) but has no local build to read it from. This serves the cluster descriptor over the socket, the way #3019 serves the SoC descriptor. Stacked on #3020.

### Description
Adds a `GET_CLUSTER_DESCRIPTOR` request command and a `SimulationServerClusterDescriptor { status, yaml }` response message. The host serves its build's `cluster_descriptor.yaml` **text** (resolved via `get_cluster_descriptor_path_from_simulator_path`); an **empty** `yaml` (status 0) means the build ships no cluster descriptor — the signal for a client to fall back to a mock built from the served device info, mirroring the host's own mock fallback. `handle_request` answers it read-only, alongside `GET_DEVICE_INFO`.

The identity bridge gains `describe_cluster()` (host: read the YAML file) and `fetch_cluster_descriptor_yaml()` (client: request it), mirroring the device-info helpers.

### List of the changes
- `simulation_server_protocol.{fbs,hpp,cpp}` — `GET_CLUSTER_DESCRIPTOR` command + `SimulationServerClusterDescriptor` message + codec.
- `simulation_device_identity.{hpp,cpp}` — `describe_cluster()` / `fetch_cluster_descriptor_yaml()`.
- `simulation_tt_device.cpp` — `handle_request` serves `GET_CLUSTER_DESCRIPTOR`.
- Tests: cluster-descriptor round-trip (incl. empty YAML) + `GET_CLUSTER_DESCRIPTOR` request round-trip; `describe_cluster` present/absent-file unit tests via a `DescribeClusterTest` gtest fixture.

### Testing
Build + pre-commit clean; no-card sim unit suites pass (`SimulationServerProtocol.*` 11, `SimulationDeviceIdentity.*` 3).

### API Changes
Internal to the simulation subsystem: new wire message + two bridge helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
