### PR TITLE
Simulation: route the Cluster SIMULATION path through SimulationConnector

### DIFF
--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -727,6 +727,11 @@ private:
     // and ChipInfo) are constructed here against the MMIO gateway.
     std::unique_ptr<RemoteChip> create_simulation_remote_chip(
         ChipId chip_id, ClusterDescriptor* cluster_desc, const SocDescriptor& soc_desc);
+
+    // Host simulation Cluster only: exposes each simulation chip's device on its per-chip socket so a
+    // separate client process (a Cluster pointed at the socket directory) can attach and drive it. A
+    // no-op for a client Cluster. Called once from the constructor after the chips are built.
+    void serve_simulation_devices_over_sockets(const std::filesystem::path& simulator_directory);
 #endif  // TT_UMD_BUILD_SIMULATION
     SocDescriptor construct_soc_descriptor(
         const std::string& soc_desc_path, ChipId chip_id, ChipType chip_type, ClusterDescriptor* cluster_desc);

--- a/device/api/umd/device/simulation/simulation_connector.hpp
+++ b/device/api/umd/device/simulation/simulation_connector.hpp
@@ -34,6 +34,11 @@ struct SimulationConnectorOptions {
 //   - any other directory     -> host running the RTL backend from that build directory.
 class SimulationConnector {
 public:
+    // Host vs client, decided from simulator_directory (the two host backends collapse to Host).
+    // Exposed so callers (e.g. Cluster) can branch on the role without duplicating the path logic.
+    enum class Role { Host, Client };
+    static Role role_for(const std::filesystem::path& simulator_directory);
+
     static std::map<ChipId, std::unique_ptr<TTDevice>> discover(const SimulationConnectorOptions& options);
 };
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "hugepage.hpp"
+#include "simulation/simulation_server_socket.hpp"
 #include "tracy.hpp"
 #include "umd/device/chip/local_chip.hpp"
 #include "umd/device/chip/mock_chip.hpp"
@@ -48,6 +49,9 @@
 #include "umd/device/cluster_descriptor.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/simulation/simulation_chip.hpp"
+#include "umd/device/simulation/simulation_client.hpp"
+#include "umd/device/simulation/simulation_connector.hpp"
+#include "umd/device/simulation/simulation_device_identity.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/topology/topology_discovery.hpp"
 #include "umd/device/topology/topology_discovery_options.hpp"
@@ -249,6 +253,12 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     }
     if (chip_type == ChipType::SIMULATION) {
 #ifdef TT_UMD_BUILD_SIMULATION
+        if (tt_device != nullptr) {
+            // A device the connector already created (client mode): wrap it rather than building a
+            // new backend. Its SoC descriptor was sourced over the socket, so read it back.
+            SocDescriptor device_soc = tt_device->get_soc_descriptor();
+            return std::make_unique<SimulationChip>(simulator_directory, device_soc, chip_id, std::move(tt_device));
+        }
         if (simulator_directory.extension() == ".so" && cluster_desc->is_chip_remote(chip_id)) {
             return create_simulation_remote_chip(chip_id, cluster_desc, soc_desc);
         }
@@ -396,6 +406,62 @@ Cluster::Cluster(ClusterOptions options) {
         case ChipType::MOCK:
         case ChipType::SWEMULE:
         case ChipType::SIMULATION: {
+#ifdef TT_UMD_BUILD_SIMULATION
+            // Client simulation Cluster: simulator_directory is a directory of live host sockets, not
+            // a local build. Reconstruct the ClusterDescriptor from the host over the socket, then
+            // let the connector attach one client device per socket (populating tt_devices, which the
+            // chip loop wraps in SimulationChips).
+            if (options.chip_type == ChipType::SIMULATION &&
+                SimulationConnector::role_for(options.simulator_directory) == SimulationConnector::Role::Client) {
+                const std::map<ChipId, std::filesystem::path> sockets =
+                    SimulationServerSocket::sockets_in_directory(options.simulator_directory);
+                UMD_ASSERT(
+                    !sockets.empty(),
+                    error::RuntimeError,
+                    fmt::format(
+                        "No simulation sockets found in {}; nothing to attach to.",
+                        options.simulator_directory.string()));
+
+                // Fetch the topology from one host. Empty YAML => the host has no cluster descriptor,
+                // so build a mock from the served device info (mirrors the host's own mock fallback).
+                SimulationClient probe(sockets.begin()->second);
+                const std::string yaml = fetch_cluster_descriptor_yaml(probe);
+                std::unique_ptr<ClusterDescriptor> served;
+                if (!yaml.empty()) {
+                    served = ClusterDescriptor::create_from_yaml_content(yaml);
+                } else {
+                    const SimulationServerDeviceInfo info = fetch_device_info_from_host(probe);
+                    std::unordered_set<ChipId> chip_ids;
+                    for (const auto& [id, socket_path] : sockets) {
+                        chip_ids.insert(id);
+                    }
+                    served = ClusterDescriptor::create_mock_cluster(
+                        chip_ids, static_cast<tt::ARCH>(info.arch), info.noc_translation_enabled);
+                }
+                cluster_desc =
+                    ClusterDescriptor::create_constrained_cluster_descriptor(served.get(), options.target_devices);
+
+                SimulationConnectorOptions connector_options;
+                connector_options.simulator_directory = options.simulator_directory;
+                connector_options.num_host_mem_channels =
+                    static_cast<int>(options.num_host_mem_ch_per_mmio_device.value_or(0));
+                tt_devices = SimulationConnector::discover(connector_options);
+
+                // Every chip the topology names must have a socket-backed device (single-chip today;
+                // a multichip host will publish one socket per chip). Fail clearly rather than later
+                // trying to build a local backend for a chip that has no socket.
+                for (const ChipId reconciled_chip_id : cluster_desc->get_all_chips()) {
+                    UMD_ASSERT(
+                        tt_devices.count(reconciled_chip_id) != 0,
+                        error::RuntimeError,
+                        fmt::format(
+                            "Cluster descriptor names chip {} but no simulation socket for it was found in {}.",
+                            reconciled_chip_id,
+                            options.simulator_directory.string()));
+                }
+                break;
+            }
+#endif
             if (options.cluster_descriptor == nullptr) {
 #ifdef TT_UMD_BUILD_SIMULATION
                 // A ttsim .so may ship a cluster_descriptor.yaml beside it describing a real (possibly multichip)
@@ -567,6 +633,12 @@ Cluster::Cluster(ClusterOptions options) {
     }
 #endif  // TT_UMD_BUILD_SIMULATION
 
+#ifdef TT_UMD_BUILD_SIMULATION
+    if (options.chip_type == ChipType::SIMULATION) {
+        serve_simulation_devices_over_sockets(options.simulator_directory);
+    }
+#endif  // TT_UMD_BUILD_SIMULATION
+
     construct_cluster(options.num_host_mem_ch_per_mmio_device.value(), options.chip_type);
     // Overwrite with the final (possibly mutated) options: sdesc_path may have been
     // resolved and num_host_mem_ch_per_mmio_device auto-detected above.
@@ -575,6 +647,24 @@ Cluster::Cluster(ClusterOptions options) {
 }
 
 #ifdef TT_UMD_BUILD_SIMULATION
+void Cluster::serve_simulation_devices_over_sockets(const std::filesystem::path& simulator_directory) {
+    // A client Cluster skips this: its simulator_directory is a socket directory (not a .so/RTL
+    // build), so role_for returns Client. On the host, expose each simulation chip's device on its
+    // per-chip socket so a separate client process (a Cluster pointed at the socket directory) can
+    // attach and drive it. Each device serves device-memory I/O plus GET_DEVICE_INFO and
+    // GET_CLUSTER_DESCRIPTOR (handle_request); create() throws if a live host already holds a chip's
+    // socket.
+    if (SimulationConnector::role_for(simulator_directory) != SimulationConnector::Role::Host) {
+        return;
+    }
+    for (const auto& [chip_id, chip] : chips_) {
+        if (auto* sim_device = dynamic_cast<SimulationTTDevice*>(chip->get_tt_device())) {
+            sim_device->adopt_socket(
+                SimulationServerSocket::create(SimulationServerSocket::default_socket_path(chip_id)));
+        }
+    }
+}
+
 // Passthroughs to libttsim_switch_register_fabric_* -- allow tt-metal fabric
 // init to wire mock multichip topologies under craq-sim.
 

--- a/device/simulation/simulation_connector.cpp
+++ b/device/simulation/simulation_connector.cpp
@@ -32,21 +32,21 @@ namespace {
 //     simulation sockets               socket in it (one device per socket), sourcing device
 //                                      identity from the host over the wire;
 //   - any other directory          -> host running the RTL backend from that build directory.
-enum class Role { HOST_TTSIM, HOST_RTL, CLIENT };
+enum class PathKind { HOST_TTSIM, HOST_RTL, CLIENT };
 
-// The role and, for CLIENT, the sockets found in the directory -- returned together so discover()
-// doesn't scan the directory a second time. The second scan would also be a TOCTOU race: if the host
-// exited between the two scans, the role would still be CLIENT but discover() would build zero
-// devices from a now-empty listing and return silently.
+// The path kind and, for CLIENT, the sockets found in the directory -- returned together so
+// discover() doesn't scan the directory a second time. The second scan would also be a TOCTOU race:
+// if the host exited between the two scans, the kind would still be CLIENT but discover() would
+// build zero devices from a now-empty listing and return silently.
 struct Classification {
-    Role role;
+    PathKind kind;
     std::map<ChipId, std::filesystem::path> sockets;
 };
 
 Classification classify(const std::filesystem::path& simulator_path) {
     std::error_code ec;
     if (std::filesystem::is_regular_file(simulator_path, ec) && simulator_path.extension() == ".so") {
-        return {Role::HOST_TTSIM, {}};
+        return {PathKind::HOST_TTSIM, {}};
     }
     UMD_ASSERT(
         std::filesystem::is_directory(simulator_path, ec),
@@ -56,18 +56,18 @@ Classification classify(const std::filesystem::path& simulator_path) {
     // attach as a client; any other directory is an RTL build we host.
     auto sockets = SimulationServerSocket::sockets_in_directory(simulator_path);
     if (sockets.empty()) {
-        return {Role::HOST_RTL, {}};
+        return {PathKind::HOST_RTL, {}};
     }
-    return {Role::CLIENT, std::move(sockets)};
+    return {PathKind::CLIENT, std::move(sockets)};
 }
 
 // Host path: bring up the in-process backend (the direct hot path) and hand it the socket to serve.
 std::unique_ptr<TTDevice> make_host_device(
-    Role role,
+    PathKind role,
     const std::filesystem::path& simulator_directory,
     int num_host_mem_channels,
     std::unique_ptr<SimulationServerSocket> socket) {
-    if (role == Role::HOST_TTSIM) {
+    if (role == PathKind::HOST_TTSIM) {
         auto device = TTSimTTDevice::create(simulator_directory, num_host_mem_channels);
         device->adopt_socket(std::move(socket));
         return device;
@@ -97,13 +97,18 @@ std::unique_ptr<TTDevice> make_client_device(
 
 }  // namespace
 
+SimulationConnector::Role SimulationConnector::role_for(const std::filesystem::path& simulator_directory) {
+    // The two host backends collapse to Host for callers that only care host-vs-client.
+    return classify(simulator_directory).kind == PathKind::CLIENT ? Role::Client : Role::Host;
+}
+
 std::map<ChipId, std::unique_ptr<TTDevice>> SimulationConnector::discover(const SimulationConnectorOptions& options) {
     std::map<ChipId, std::unique_ptr<TTDevice>> devices;
     const std::filesystem::path& simulator_path = options.simulator_directory;
 
     const Classification classification = classify(simulator_path);
 
-    if (classification.role == Role::CLIENT) {
+    if (classification.kind == PathKind::CLIENT) {
         // Multi-chip: one client device per per-chip socket in the directory (enumerated by
         // classify()). Chip ids come from the socket names, so they match the host's. A failure on
         // one socket (a dead or wedged host) only skips that chip -- it must not abort attaching to
@@ -136,7 +141,7 @@ std::map<ChipId, std::unique_ptr<TTDevice>> SimulationConnector::discover(const 
     auto socket = SimulationServerSocket::create(SimulationServerSocket::default_socket_path(chip_id));
     devices.emplace(
         chip_id,
-        make_host_device(classification.role, simulator_path, options.num_host_mem_channels, std::move(socket)));
+        make_host_device(classification.kind, simulator_path, options.num_host_mem_channels, std::move(socket)));
     return devices;
 }
 

--- a/tests/api/test_simulation_connector.cpp
+++ b/tests/api/test_simulation_connector.cpp
@@ -10,11 +10,13 @@
 #include <vector>
 
 #include "simulation/simulation_server_socket.hpp"
+#include "umd/device/cluster.hpp"
 #include "umd/device/simulation/simulation_client.hpp"
 #include "umd/device/simulation/simulation_connector.hpp"
 #include "umd/device/simulation/simulation_server_protocol.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/cluster_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 
 using namespace tt::umd;
@@ -223,4 +225,47 @@ TEST(SimulationConnector, ClientDeviceReadsAndWritesOverSocket) {
     std::vector<uint8_t> client_readback(from_host.size());
     client->read_from_device(client_readback.data(), tensix, addr2, from_host.size());
     EXPECT_EQ(client_readback, from_host);
+}
+
+// End to end at the Cluster level: one Cluster hosts from the .so (serving a per-chip socket); a
+// second Cluster pointed at the socket *directory* attaches as a client, reconstructs the topology
+// over the wire, and cluster-level I/O crosses the socket. Requires TT_UMD_SIMULATOR.
+TEST(SimulationConnector, HostAndClientClustersShareDeviceMemory) {
+    const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
+    if (simulator_path == nullptr) {
+        GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
+    }
+
+    const std::filesystem::path socket0 = SimulationServerSocket::default_socket_path(0);
+    {
+        auto probe = SimulationServerSocket::try_create(socket0);
+        if (probe == nullptr) {
+            GTEST_SKIP() << "A live simulation host already holds " << socket0 << "; skipping.";
+        }
+    }
+
+    ClusterOptions host_options;
+    host_options.chip_type = ChipType::SIMULATION;
+    host_options.simulator_directory = simulator_path;
+    Cluster host_cluster(host_options);
+
+    ClusterOptions client_options;
+    client_options.chip_type = ChipType::SIMULATION;
+    client_options.simulator_directory = socket0.parent_path();  // the socket directory => client role
+    Cluster client_cluster(client_options);
+
+    // The client reconstructed the same chips the host serves.
+    EXPECT_EQ(client_cluster.get_target_device_ids(), host_cluster.get_target_device_ids());
+
+    const tt::ChipId chip = 0;
+    const SocDescriptor& soc = host_cluster.get_soc_descriptor(chip);
+    const CoreCoord tensix = soc.get_cores(tt::CoreType::TENSIX).at(0);
+    constexpr uint64_t addr = 0x1000;
+
+    // Host writes through its Cluster; the client reads the same location back over the socket.
+    const std::vector<uint8_t> pattern = {0xDE, 0xAD, 0xBE, 0xEF, 0x11, 0x22, 0x33, 0x44};
+    host_cluster.write_to_device(pattern.data(), pattern.size(), chip, tensix, addr);
+    std::vector<uint8_t> readback(pattern.size());
+    client_cluster.read_from_device(readback.data(), chip, tensix, addr, pattern.size());
+    EXPECT_EQ(readback, pattern);
 }


### PR DESCRIPTION
### Issue
Part of #2677 (simulation server process). Wires the host/client role decision (built in #3020) up to the `Cluster` level, so opening a simulation `Cluster` becomes a host or a client depending on `simulator_directory`. Stacked on the cluster-descriptor-over-socket PR.

### Description
`Cluster(ChipType::SIMULATION)` now branches on `SimulationConnector::role_for(simulator_directory)`:

- **Host** (`.so` file / RTL directory): keeps the existing multichip in-process device creation, and **additionally exposes each simulation chip's device on its per-chip socket** (`adopt_socket`) so a separate client process can attach and drive it. Multichip host behaviour is unchanged — this only adds socket serving; each device serves device-memory I/O plus `GET_DEVICE_INFO` / `GET_CLUSTER_DESCRIPTOR`.
- **Client** (a directory of `tt-umd-sim-<id>.sock` sockets): reconstructs the `ClusterDescriptor` over the socket (`GET_CLUSTER_DESCRIPTOR`; empty ⇒ a mock built from the served device info), then `SimulationConnector::discover()` attaches one client device per socket. The chip loop wraps each connector-created device in a `SimulationChip` instead of building a backend.

Ownership seam: the connector owns simulation device creation + `SocDescriptor`; `Cluster` owns the `ClusterDescriptor` and `Chip` wrapping.

**Scope:** exercised single-chip. A multichip host (one process publishing N sockets with remote-over-sim-eth routing) is deferred and not built here; the client reconstruction already handles N chips, and a reconciliation guard throws if the served topology names a chip with no socket.

### List of the changes
- `SimulationConnector` — public `Role { Host, Client }` + `role_for()`, so `Cluster` branches without duplicating the path classifier (internal enum renamed to `PathKind`).
- `cluster.{hpp,cpp}` — SIMULATION path: client reconstructs topology over the socket + attaches via the connector; host exposes each chip on its socket via an extracted `Cluster::serve_simulation_devices_over_sockets()` method; `construct_chip_from_cluster` wraps a connector-provided device.
- Tests: CI-gated `HostAndClientClustersShareDeviceMemory` (host Cluster from `.so`, client Cluster from the socket directory, cluster-level write/read across the socket).

### Testing
Build + pre-commit clean; 182 baremetal + all sim unit suites pass. The Cluster-level e2e and the other connector e2e tests run in the simulation CI lane (`TT_UMD_SIMULATOR`).

### API Changes
`SimulationConnector` gains `Role` + `role_for()`. Simulation-internal otherwise.

### Rebased onto #2955 (multichip ttsim)
#2955 is now in `main` and this PR has been rebased onto it. Both edit the SIMULATION block of the chip-construction path; resolved by the ordering inside the block (client wrap first, then #2955's host remote/gateway logic):
```cpp
if (tt_device != nullptr) { /* this PR: client — wrap the connector-created device */ }
if (simulator_directory.extension() == ".so" && cluster_desc->is_chip_remote(chip_id))
    return create_simulation_remote_chip(...);   // #2955: host remote chip
return SimulationChip::create(...);              // host gateway
```
For the host `tt_device` is null, so #2955's remote/gateway logic runs unchanged; for the client `tt_device` is non-null and gets wrapped. `add_chip` is edited only by #2955, so its version applies as-is — no conflict there.

Behavior note (no code change needed for single-chip): post-#2955 the host's remote chips are `RemoteChip`s backed by a remote `TTDevice`, not a `SimulationTTDevice`, so the adopt-socket post-pass here `dynamic_cast`s them away and only the **gateway** serves a socket. Exposing remote chips over sockets so a multichip *client* can fully attach is the deferred multichip-over-sockets work, and #2955's gateway+remotes model is what should define how it's done — best built after #2955 lands, not guessed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
