### PR TITLE
Consolidate NOC multicast fallback implementations

### DIFF
--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -53,9 +53,6 @@ public:
 
     EthTrainingStatus read_eth_core_training_status(tt_xy_pair eth_core) override;
 
-    using TTDevice::noc_multicast_write;
-    void noc_multicast_write(const void *src, size_t size, uint64_t addr, NocId noc_id = NocId::DEFAULT_NOC) override;
-
 protected:
     BlackholeTTDevice(
         std::unique_ptr<PCIDevice> pci_device,

--- a/device/api/umd/device/tt_device/simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/simulation_tt_device.hpp
@@ -65,12 +65,10 @@ public:
     void noc_multicast_write(
         const void* src,
         size_t size,
-        tt_xy_pair core_start,
-        tt_xy_pair core_end,
+        CoreCoord core_start,
+        CoreCoord core_end,
         uint64_t addr,
         NocId noc_id = NocId::DEFAULT_NOC) override;
-    using TTDevice::noc_multicast_write;
-    void noc_multicast_write(const void* src, size_t size, uint64_t addr, NocId noc_id = NocId::DEFAULT_NOC) override;
 
     SimulationSysmemManager* get_sysmem_manager() override { return sysmem_manager_.get(); }
 

--- a/device/api/umd/device/tt_device/simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/simulation_tt_device.hpp
@@ -69,6 +69,7 @@ public:
         CoreCoord core_end,
         uint64_t addr,
         NocId noc_id = NocId::DEFAULT_NOC) override;
+    void noc_multicast_write(const void* src, size_t size, uint64_t addr, NocId noc_id) override;
 
     SimulationSysmemManager* get_sysmem_manager() override { return sysmem_manager_.get(); }
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -225,13 +225,6 @@ public:
     virtual void noc_multicast_write(
         const void *src,
         size_t size,
-        tt_xy_pair core_start,
-        tt_xy_pair core_end,
-        uint64_t addr,
-        NocId noc_id = NocId::DEFAULT_NOC);
-    virtual void noc_multicast_write(
-        const void *src,
-        size_t size,
         CoreCoord core_start,
         CoreCoord core_end,
         uint64_t addr,
@@ -244,8 +237,7 @@ public:
      * @param size number of bytes
      * @param addr address on the device where data will be written
      */
-    virtual void noc_multicast_write(
-        const void *src, size_t size, uint64_t addr, NocId noc_id = NocId::DEFAULT_NOC) = 0;
+    virtual void noc_multicast_write(const void *src, size_t size, uint64_t addr, NocId noc_id = NocId::DEFAULT_NOC);
 
     /**
      * Read function that will send read message to the ARC core APB peripherals.
@@ -560,8 +552,8 @@ protected:
     void multicast_write_via_unicast(
         const void *src,
         size_t size,
-        tt_xy_pair core_start,
-        tt_xy_pair core_end,
+        CoreCoord core_start,
+        CoreCoord core_end,
         uint64_t addr,
         NocId noc_id = NocId::DEFAULT_NOC);
 

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -50,9 +50,6 @@ public:
 
     EthTrainingStatus read_eth_core_training_status(tt_xy_pair eth_core) override;
 
-    using TTDevice::noc_multicast_write;
-    void noc_multicast_write(const void *src, size_t size, uint64_t addr, NocId noc_id = NocId::DEFAULT_NOC) override;
-
     ~WormholeTTDevice() override = default;
 
 protected:

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -354,16 +354,6 @@ void BlackholeTTDevice::retrain_dram_core(const uint32_t dram_channel) {
     }
 }
 
-void BlackholeTTDevice::noc_multicast_write(const void *src, size_t size, uint64_t addr, NocId noc_id) {
-    UMD_ASSERT(
-        get_chip_info().noc_translation_enabled,
-        error::RuntimeError,
-        "Multicast not implemented for BH devices without NOC translation enabled.");
-    auto [start, end] =
-        get_soc_descriptor().get_bounding_rectangle(is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0);
-    noc_multicast_write(src, size, start, end, addr);
-}
-
 void BlackholeTTDevice::set_arc_coordinate() {
     arc_core_noc0 = blackhole::get_arc_core(BlackholeTTDevice::get_noc_translation_enabled(), /*use_noc1=*/false);
     arc_core_noc1 = blackhole::get_arc_core(BlackholeTTDevice::get_noc_translation_enabled(), /*use_noc1=*/true);

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -126,12 +126,8 @@ bool SimulationTTDevice::get_noc_translation_enabled() {
 }
 
 void SimulationTTDevice::noc_multicast_write(
-    const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) {
+    const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr, NocId noc_id) {
     multicast_write_via_unicast(src, size, core_start, core_end, addr);
-}
-
-void SimulationTTDevice::noc_multicast_write(const void* src, size_t size, uint64_t addr, NocId noc_id) {
-    UMD_THROW(error::RuntimeError, "NOC multicast write is not supported for simulation devices.");
 }
 
 void SimulationTTDevice::dma_d2h(void* dst, uint32_t src, size_t size) {

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -127,7 +127,13 @@ bool SimulationTTDevice::get_noc_translation_enabled() {
 
 void SimulationTTDevice::noc_multicast_write(
     const void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr, NocId noc_id) {
-    multicast_write_via_unicast(src, size, core_start, core_end, addr);
+    multicast_write_via_unicast(src, size, core_start, core_end, addr, noc_id);
+}
+
+void SimulationTTDevice::noc_multicast_write(const void* src, size_t size, uint64_t addr, NocId noc_id) {
+    auto [start, end] =
+        get_soc_descriptor().get_bounding_rectangle(is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0);
+    noc_multicast_write(src, size, start, end, addr, noc_id);
 }
 
 void SimulationTTDevice::dma_d2h(void* dst, uint32_t src, size_t size) {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -692,19 +692,21 @@ void TTDevice::deassert_risc_reset(CoreCoord core, const RiscType selected_riscs
 tt_xy_pair TTDevice::get_arc_core() const { return is_selected_noc1() ? arc_core_noc1 : arc_core_noc0; }
 
 void TTDevice::noc_multicast_write(
-    const void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) {
+    const void *src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr, NocId noc_id) {
     ZoneScopedC(tracy::Color::Orange);
+    xy_pair translated_start = resolve_coordinate(core_start);
+    xy_pair translated_end = resolve_coordinate(core_end);
     bool multicast_success =
-        device_protocol_->write_to_core_range(src, core_start, core_end, addr, size, get_selected_noc_id());
+        device_protocol_->write_to_core_range(src, translated_start, translated_end, addr, size, get_selected_noc_id());
 
     log_debug(
         LogUMD,
         "Multicast on {} chip write to cores ({}, {}) - ({}, {}) {}",
         is_remote_tt_device ? "remote" : "local",
-        core_start.x,
-        core_start.y,
-        core_end.x,
-        core_end.y,
+        translated_start.x,
+        translated_start.y,
+        translated_end.x,
+        translated_end.y,
         multicast_success ? "succeeded" : "fell back to unicast");
 
     // We need to flush the writes in case of remote communication.
@@ -716,71 +718,25 @@ void TTDevice::noc_multicast_write(
         return;
     }
 
-    // Following is the fallback mechanism for multicast to a remote device.
-    // Coordinates may be in translated or NOC0 space; we check both since their ranges don't overlap.
-    // In translated space, non-harvested TENSIX rows occupy a prefix of the TENSIX translated rect.
-    // In NOC0 space, we look up the core in TENSIX_CORES_NOC0 and check its row against the mask.
-    const uint32_t tensix_harvesting_mask = get_chip_info().harvesting_masks.tensix_harvesting_mask;
-
-    uint32_t num_harvested = 0;
-    for (uint32_t mask = tensix_harvesting_mask; mask; mask >>= 1) {
-        num_harvested += mask & 1;
+    multicast_write_via_unicast(src, size, core_start, core_end, addr, noc_id);
+    if (is_remote_tt_device) {
+        get_remote_communication()->wait_for_non_mmio_flush();
     }
-    const uint32_t num_active_rows = wormhole::TENSIX_GRID_SIZE.y - num_harvested;
-
-    auto is_active_tensix = [&](uint32_t x, uint32_t y) -> bool {
-        // Translated space: non-harvested TENSIX rows are the first num_active_rows rows of the rect.
-        if (x >= wormhole::tensix_translated_coordinate_start_x &&
-            x < wormhole::tensix_translated_coordinate_start_x + wormhole::TENSIX_GRID_SIZE.x &&
-            y >= wormhole::tensix_translated_coordinate_start_y &&
-            y < wormhole::tensix_translated_coordinate_start_y + num_active_rows) {
-            return true;
-        }
-        // NOC0 space: find the core in TENSIX_CORES_NOC0 and check whether its row is harvested.
-        const tt_xy_pair coord{x, y};
-        auto it = std::find(wormhole::TENSIX_CORES_NOC0.begin(), wormhole::TENSIX_CORES_NOC0.end(), coord);
-        if (it == wormhole::TENSIX_CORES_NOC0.end()) {
-            return false;
-        }
-        const size_t row = (it - wormhole::TENSIX_CORES_NOC0.begin()) / wormhole::TENSIX_GRID_SIZE.x;
-        return (tensix_harvesting_mask & (1u << row)) == 0;
-    };
-
-    for (uint32_t x = core_start.x; x <= core_end.x; ++x) {
-        for (uint32_t y = core_start.y; y <= core_end.y; ++y) {
-            log_trace(
-                LogUMD,
-                "noc_multicast_write fallback unicast to core at ({}, {}) is_tensix {}",
-                x,
-                y,
-                is_active_tensix(x, y));
-            if (is_active_tensix(x, y)) {
-                write_to_device(src, xy_pair(x, y), addr, size);
-            }
-        }
-    }
-    get_remote_communication()->wait_for_non_mmio_flush();
 }
 
-void TTDevice::noc_multicast_write(
-    const void *src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr, NocId noc_id) {
-    noc_multicast_write(
-        src, size, resolve_coordinate(core_start), resolve_coordinate(core_end), addr, get_selected_noc_id());
+void TTDevice::noc_multicast_write(const void *src, size_t size, uint64_t addr, NocId noc_id) {
+    UMD_ASSERT(
+        get_chip_info().noc_translation_enabled,
+        error::RuntimeError,
+        "Multicast not implemented for devices without NOC translation enabled.");
+    auto [start, end] =
+        get_soc_descriptor().get_bounding_rectangle(is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0);
+    noc_multicast_write(src, size, start, end, addr);
 }
 
 void TTDevice::multicast_write_via_unicast(
-    const void *src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) {
-    // No hardware multicast on simulation backends; fall back to per-core unicast.
-    // TODO: investigate proper multicast support for simulations so we can remove this workaround.
-    for (uint32_t x = core_start.x; x <= core_end.x; ++x) {
-        for (uint32_t y = core_start.y; y <= core_end.y; ++y) {
-            // BLACKHOLE: x==8 is ARC/L2CPU and x==9 is GDDR, not actual Tensix cores.
-            if (arch == tt::ARCH::BLACKHOLE && (x == 8 || x == 9)) {
-                continue;
-            }
-            write_to_device(src, tt_xy_pair{x, y}, addr, size);
-        }
-    }
+    const void *src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr, NocId noc_id) {
+    // TODO REWRITE
 }
 
 void TTDevice::dma_write_to_device(const void *src, size_t size, tt_xy_pair core, uint64_t addr, NocId noc_id) {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -739,17 +739,16 @@ void TTDevice::noc_multicast_write(const void *src, size_t size, uint64_t addr, 
 
 void TTDevice::multicast_write_via_unicast(
     const void *src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr, NocId noc_id) {
-    const SocDescriptor &soc_descriptor = get_soc_descriptor();
-
-    // Compute the enclosing rectangle in the TRANSLATED coordinate space.
-    CoreCoord translated_start = soc_descriptor.translate_coord_to(core_start, CoordSystem::TRANSLATED);
-    CoreCoord translated_end = soc_descriptor.translate_coord_to(core_end, CoordSystem::TRANSLATED);
+    CoreCoord translated_start = resolve_coordinate(core_start);
+    CoreCoord translated_end = resolve_coordinate(core_end);
     size_t x_min = std::min(translated_start.x, translated_end.x);
     size_t x_max = std::max(translated_start.x, translated_end.x);
     size_t y_min = std::min(translated_start.y, translated_end.y);
     size_t y_max = std::max(translated_start.y, translated_end.y);
 
     // Iterate over all non-harvested tensix cores and unicast to those falling inside the rectangle.
+    // We use the TRANSLATED coord space as NOC multicast is not available without NOC translation.
+    const SocDescriptor &soc_descriptor = get_soc_descriptor();
     for (const CoreCoord &core : soc_descriptor.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)) {
         if (core.x >= x_min && core.x <= x_max && core.y >= y_min && core.y <= y_max) {
             write_to_device(src, core, addr, size, noc_id);

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -734,7 +734,7 @@ void TTDevice::noc_multicast_write(const void *src, size_t size, uint64_t addr, 
         "Multicast not implemented for devices without NOC translation enabled.");
     auto [start, end] =
         get_soc_descriptor().get_bounding_rectangle(is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0);
-    noc_multicast_write(src, size, start, end, addr);
+    noc_multicast_write(src, size, start, end, addr, noc_id);
 }
 
 void TTDevice::multicast_write_via_unicast(

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -6,6 +6,7 @@
 
 #include <fmt/format.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -693,21 +694,23 @@ tt_xy_pair TTDevice::get_arc_core() const { return is_selected_noc1() ? arc_core
 
 void TTDevice::noc_multicast_write(
     const void *src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr, NocId noc_id) {
+    UMD_ASSERT(
+        get_chip_info().noc_translation_enabled,
+        error::RuntimeError,
+        "Multicast not implemented for devices without NOC translation enabled.");
     ZoneScopedC(tracy::Color::Orange);
     xy_pair translated_start = resolve_coordinate(core_start);
     xy_pair translated_end = resolve_coordinate(core_end);
     bool multicast_success =
         device_protocol_->write_to_core_range(src, translated_start, translated_end, addr, size, get_selected_noc_id());
 
-    log_debug(
+    log_trace(
         LogUMD,
-        "Multicast on {} chip write to cores ({}, {}) - ({}, {}) {}",
+        "Multicast on {} chip write to cores {} - {} {}",
         is_remote_tt_device ? "remote" : "local",
-        translated_start.x,
-        translated_start.y,
-        translated_end.x,
-        translated_end.y,
-        multicast_success ? "succeeded" : "fell back to unicast");
+        translated_start.str(),
+        translated_end.str(),
+        multicast_success ? "succeeded" : "failed, running unicast fallback.");
 
     // We need to flush the writes in case of remote communication.
     if (multicast_success && is_remote_tt_device) {
@@ -736,7 +739,22 @@ void TTDevice::noc_multicast_write(const void *src, size_t size, uint64_t addr, 
 
 void TTDevice::multicast_write_via_unicast(
     const void *src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr, NocId noc_id) {
-    // TODO REWRITE
+    const SocDescriptor &soc_descriptor = get_soc_descriptor();
+
+    // Compute the enclosing rectangle in the TRANSLATED coordinate space.
+    CoreCoord translated_start = soc_descriptor.translate_coord_to(core_start, CoordSystem::TRANSLATED);
+    CoreCoord translated_end = soc_descriptor.translate_coord_to(core_end, CoordSystem::TRANSLATED);
+    size_t x_min = std::min(translated_start.x, translated_end.x);
+    size_t x_max = std::max(translated_start.x, translated_end.x);
+    size_t y_min = std::min(translated_start.y, translated_end.y);
+    size_t y_max = std::max(translated_start.y, translated_end.y);
+
+    // Iterate over all non-harvested tensix cores and unicast to those falling inside the rectangle.
+    for (const CoreCoord &core : soc_descriptor.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED)) {
+        if (core.x >= x_min && core.x <= x_max && core.y >= y_min && core.y <= y_max) {
+            write_to_device(src, core, addr, size, noc_id);
+        }
+    }
 }
 
 void TTDevice::dma_write_to_device(const void *src, size_t size, tt_xy_pair core, uint64_t addr, NocId noc_id) {

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -448,16 +448,6 @@ void WormholeTTDevice::retrain_dram_core(const uint32_t dram_channel) {
     UMD_THROW(error::RuntimeError, "DRAM retraining is not supported on WormholeTTDevice.");
 }
 
-void WormholeTTDevice::noc_multicast_write(const void *src, size_t size, uint64_t addr, NocId noc_id) {
-    // Same range is used for NOC0 and NOC1.
-    // Note that when multicasting in translated space, you have to skip harvested rows. So we can just always use NOC0
-    // coords for broadcasting, since these are always the same and guaranteed to land at all TENSIX cores.
-
-    auto [start, end] =
-        get_soc_descriptor().get_bounding_rectangle(is_selected_noc1() ? CoordSystem::NOC1 : CoordSystem::NOC0);
-    noc_multicast_write(src, size, start, end, addr);
-}
-
 void WormholeTTDevice::set_arc_coordinate() {
     arc_core_noc0 = wormhole::ARC_CORES_NOC0[0];
     arc_core_noc1 = tt_xy_pair(

--- a/tests/api/test_device_io.cpp
+++ b/tests/api/test_device_io.cpp
@@ -384,7 +384,7 @@ TEST_P(TestMulticastWriteFixture, TestMulticastWrite) {
                 v++;
             }
 
-            const tt_xy_pair multicast_coord =
+            const CoreCoord multicast_coord =
                 soc_desc.translate_coord_to(core, use_noc0 ? CoordSystem::NOC0 : CoordSystem::TRANSLATED);
             if (full_grid) {
                 log_info(LogUMD, "Multicast to full grid from coord {} on chip {}", multicast_coord.str(), chip_id);


### PR DESCRIPTION
### Issue
#2911

### Description
Consolidate NOC multicast fallback implementations and remove xy_pair versions `noc_multicast_write()`

### List of the changes
- Removed xy_pair versions of `noc_multicast_write()`.
- Remove all duplicate multicast fallback implementation, merge to `noc_multicast_via_unicast()`.
- Multicast on silicon chips without NOC translation is not available.
- Multicast fallback interprets coordinates only in TRANSLATED coord. system.

### Testing
CI, Multicast tests pass.

### API Changes
This PR has API changes.
