### PR TITLE
Simulation: SHUTDOWN command for graceful host shutdown over the socket

### DIFF
--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <map>
 #include <memory>
 #include <optional>
@@ -110,6 +111,14 @@ struct ClusterOptions {
      * This parameter is used only for SIMULATION chip type.
      */
     std::filesystem::path simulator_directory = "";
+
+    /**
+     * Host SIMULATION chip type only: optional callback invoked when a client sends SHUTDOWN over a
+     * chip's socket, so a long-running host (e.g. the sim_server tool) can be stopped in-band. It is
+     * fixed when the host starts serving and must only signal (be non-blocking) and be safe to call
+     * more than once. Empty means SHUTDOWN is acknowledged as a no-op.
+     */
+    std::function<void()> simulation_shutdown_handler;
 
     /**
      * I/O device type to use for the cluster.
@@ -731,7 +740,8 @@ private:
     // Host simulation Cluster only: exposes each simulation chip's device on its per-chip socket so a
     // separate client process (a Cluster pointed at the socket directory) can attach and drive it. A
     // no-op for a client Cluster. Called once from the constructor after the chips are built.
-    void serve_simulation_devices_over_sockets(const std::filesystem::path& simulator_directory);
+    void serve_simulation_devices_over_sockets(
+        const std::filesystem::path& simulator_directory, const std::function<void()>& shutdown_handler);
 #endif  // TT_UMD_BUILD_SIMULATION
     SocDescriptor construct_soc_descriptor(
         const std::string& soc_desc_path, ChipId chip_id, ChipType chip_type, ClusterDescriptor* cluster_desc);

--- a/device/api/umd/device/simulation/simulation_server_protocol.hpp
+++ b/device/api/umd/device/simulation/simulation_server_protocol.hpp
@@ -29,6 +29,9 @@ enum class SimulationServerCommand : int8_t {
     Write = 1,
     GetDeviceInfo = 2,
     GetClusterDescriptor = 3,
+    // Asks the host to shut down gracefully; the host acks with a SimulationServerResponse then tears
+    // down (closing every client connection). A host that didn't opt in acks as a no-op.
+    Shutdown = 4,
 };
 
 // Which simulator the host runs; mirrors wire::SimulationBackendType. Served as part of the device

--- a/device/api/umd/device/tt_device/simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/simulation_tt_device.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -37,8 +38,18 @@ class SimulationTTDevice : public TTDevice {
 public:
     ~SimulationTTDevice() override;
 
-    // Takes ownership of the serving socket that exposes this device (created by discovery).
-    void adopt_socket(std::unique_ptr<SimulationServerSocket> socket);
+    // Takes ownership of the serving socket that exposes this device (created by discovery) and
+    // begins serving. An optional shutdown_handler is invoked when a client sends SHUTDOWN: a
+    // dedicated server (e.g. the sim_server tool) passes one to signal its main thread to exit and
+    // tear this device down; a host that passes none acks SHUTDOWN as a no-op, so a simulation
+    // embedded in another program can't be torn down by a stray client. The handler is fixed here,
+    // before serving starts, and never mutated afterwards -- so it needs no locking.
+    //
+    // The handler runs on a serving thread and MUST be non-blocking -- it must only signal (set a
+    // flag / notify a condition variable / write a self-pipe); tearing down from within it would
+    // join the serving threads from one of them and deadlock. It must also be safe to call more than
+    // once and concurrently: every attached client that sends SHUTDOWN invokes it.
+    void adopt_socket(std::unique_ptr<SimulationServerSocket> socket, std::function<void()> shutdown_handler = {});
 
     // --- TTDevice overrides whose behavior is identical across both simulation backends ---
     void read_from_device(
@@ -160,7 +171,8 @@ private:
     // socket's connection threads; read/write take device_lock, so concurrent host + client
     // access is serialized. The socket layer stays protocol-agnostic; this is where the protocol
     // is (de)serialized.
-    std::vector<uint8_t> handle_request(const std::vector<uint8_t>& request_bytes);
+    std::vector<uint8_t> handle_request(
+        const std::vector<uint8_t>& request_bytes, const std::function<void()>& shutdown_handler);
 
     // The device serves one of two disjoint roles; read_from_device/write_to_device dispatch on
     // this rather than a bare client_ null-check so the intent is named at the call site.

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -635,7 +635,7 @@ Cluster::Cluster(ClusterOptions options) {
 
 #ifdef TT_UMD_BUILD_SIMULATION
     if (options.chip_type == ChipType::SIMULATION) {
-        serve_simulation_devices_over_sockets(options.simulator_directory);
+        serve_simulation_devices_over_sockets(options.simulator_directory, options.simulation_shutdown_handler);
     }
 #endif  // TT_UMD_BUILD_SIMULATION
 
@@ -647,20 +647,22 @@ Cluster::Cluster(ClusterOptions options) {
 }
 
 #ifdef TT_UMD_BUILD_SIMULATION
-void Cluster::serve_simulation_devices_over_sockets(const std::filesystem::path& simulator_directory) {
+void Cluster::serve_simulation_devices_over_sockets(
+    const std::filesystem::path& simulator_directory, const std::function<void()>& shutdown_handler) {
     // A client Cluster skips this: its simulator_directory is a socket directory (not a .so/RTL
     // build), so role_for returns Client. On the host, expose each simulation chip's device on its
     // per-chip socket so a separate client process (a Cluster pointed at the socket directory) can
     // attach and drive it. Each device serves device-memory I/O plus GET_DEVICE_INFO and
     // GET_CLUSTER_DESCRIPTOR (handle_request); create() throws if a live host already holds a chip's
-    // socket.
+    // socket. The optional shutdown_handler (e.g. from the sim_server tool) is handed to each device
+    // so a client's SHUTDOWN can signal the owner to stop.
     if (SimulationConnector::role_for(simulator_directory) != SimulationConnector::Role::Host) {
         return;
     }
     for (const auto& [chip_id, chip] : chips_) {
         if (auto* sim_device = dynamic_cast<SimulationTTDevice*>(chip->get_tt_device())) {
             sim_device->adopt_socket(
-                SimulationServerSocket::create(SimulationServerSocket::default_socket_path(chip_id)));
+                SimulationServerSocket::create(SimulationServerSocket::default_socket_path(chip_id)), shutdown_handler);
         }
     }
 }

--- a/device/simulation/simulation_server_protocol.fbs
+++ b/device/simulation/simulation_server_protocol.fbs
@@ -24,6 +24,7 @@ enum SimulationServerCommand : byte {
     WRITE = 1,
     GET_DEVICE_INFO = 2,
     GET_CLUSTER_DESCRIPTOR = 3,
+    SHUTDOWN = 4,
 }
 
 // Which simulator the host runs; served in the device identity so a client can build the matching

--- a/device/simulation/simulation_server_transport.cpp
+++ b/device/simulation/simulation_server_transport.cpp
@@ -41,10 +41,24 @@ void write_exact(stream_protocol::socket& socket, const uint8_t* data, size_t n,
 void read_exact(stream_protocol::socket& socket, uint8_t* data, size_t n, const char* what) {
     std::error_code ec;
     asio::read(socket, asio::buffer(data, n), ec);
-    if (ec) {
-        UMD_THROW(
-            error::RuntimeError, fmt::format("Simulation server transport failed to read {}: {}", what, ec.message()));
+    if (!ec) {
+        return;
     }
+    // A clean peer close (EOF) or reset means the remote end went away -- for a client blocked in
+    // transact(), that is most often the host being stopped. Surface a distinct, clearly-worded
+    // error so callers can tell "the server stopped" apart from a genuine I/O failure and unwind
+    // gracefully. (On the host side, this is also the normal end-of-session when a client
+    // disconnects, and the serving thread already treats it as such.)
+    if (ec == asio::error::eof || ec == asio::error::connection_reset) {
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format(
+                "Simulation server transport peer closed the connection while reading {} -- the remote "
+                "end (e.g. a stopped simulation host) has gone away",
+                what));
+    }
+    UMD_THROW(
+        error::RuntimeError, fmt::format("Simulation server transport failed to read {}: {}", what, ec.message()));
 }
 
 }  // namespace

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -46,13 +46,19 @@ void SimulationTTDevice::detach_client() {
     }
 }
 
-void SimulationTTDevice::adopt_socket(std::unique_ptr<SimulationServerSocket> socket) {
+void SimulationTTDevice::adopt_socket(
+    std::unique_ptr<SimulationServerSocket> socket, std::function<void()> shutdown_handler) {
     socket_ = std::move(socket);
-    // Begin serving remote clients now that the backend is up.
-    socket_->serve([this](const std::vector<uint8_t>& request_bytes) { return handle_request(request_bytes); });
+    // Begin serving remote clients now that the backend is up. The shutdown handler is captured into
+    // the request handler here, before serving starts, so it is fixed for the socket's lifetime and
+    // the serving threads read it without synchronization.
+    socket_->serve([this, shutdown_handler = std::move(shutdown_handler)](const std::vector<uint8_t>& request_bytes) {
+        return handle_request(request_bytes, shutdown_handler);
+    });
 }
 
-std::vector<uint8_t> SimulationTTDevice::handle_request(const std::vector<uint8_t>& request_bytes) {
+std::vector<uint8_t> SimulationTTDevice::handle_request(
+    const std::vector<uint8_t>& request_bytes, const std::function<void()>& shutdown_handler) {
     const SimulationServerRequest request = decode_request(request_bytes);
 
     // GetDeviceInfo returns a different wire message (SimulationServerDeviceInfo) than the
@@ -79,6 +85,18 @@ std::vector<uint8_t> SimulationTTDevice::handle_request(const std::vector<uint8_
             cluster_descriptor.status = -1;
             return encode(cluster_descriptor);
         }
+    }
+
+    // Shutdown: invoke the opt-in handler (a dedicated server passes one to adopt_socket() to signal
+    // its main thread to exit and tear down; an embedded host passes none, making this a no-op) and
+    // ack. The handler was fixed before serving started, so it is read here without locking; it must
+    // only signal -- it must not tear down from this serving thread. The ack is sent before any
+    // teardown, and this serving thread hits EOF and is joined during that teardown.
+    if (request.command == SimulationServerCommand::Shutdown) {
+        if (shutdown_handler) {
+            shutdown_handler();
+        }
+        return encode(SimulationServerResponse{});  // status 0
     }
 
     // The client already translated the coordinate (translation is stateless and client-side), so

--- a/tests/api/test_simulation_server_protocol.cpp
+++ b/tests/api/test_simulation_server_protocol.cpp
@@ -157,3 +157,11 @@ TEST(SimulationServerProtocol, GetClusterDescriptorRequestRoundTrip) {
     const SimulationServerRequest decoded = decode_request(encode(request));
     EXPECT_EQ(decoded.command, SimulationServerCommand::GetClusterDescriptor);
 }
+
+// The Shutdown command survives a request round-trip (its reply is a plain SimulationServerResponse).
+TEST(SimulationServerProtocol, ShutdownRequestRoundTrip) {
+    SimulationServerRequest request;
+    request.command = SimulationServerCommand::Shutdown;
+    const SimulationServerRequest decoded = decode_request(encode(request));
+    EXPECT_EQ(decoded.command, SimulationServerCommand::Shutdown);
+}

--- a/tests/baremetal/test_simulation_server_transport.cpp
+++ b/tests/baremetal/test_simulation_server_transport.cpp
@@ -7,6 +7,7 @@
 #include <asio.hpp>
 #include <cstdint>
 #include <exception>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -74,6 +75,22 @@ TEST_F(SimulationServerTransportTest, RecvThrowsWhenPeerCloses) {
     a_.close();
 
     EXPECT_THROW(recv_framed(b_), std::exception);
+}
+
+// A clean peer close (e.g. a stopped simulation host) surfaces a *distinct*, clearly-worded error --
+// not the generic read-failure message -- so a client blocked in transact() can tell the server was
+// stopped from a real I/O error and unwind gracefully.
+TEST_F(SimulationServerTransportTest, RecvReportsPeerCloseDistinctly) {
+    a_.close();
+
+    try {
+        recv_framed(b_);
+        FAIL() << "recv_framed should have thrown on peer close";
+    } catch (const std::exception& e) {
+        const std::string message = e.what();
+        EXPECT_NE(message.find("closed the connection"), std::string::npos) << "message was: " << message;
+        EXPECT_NE(message.find("gone away"), std::string::npos) << "message was: " << message;
+    }
 }
 
 // A message cut short (header promises more than is delivered, then the peer goes away) fails


### PR DESCRIPTION
### Issue
Part of #2677 (simulation server process). To manage long-running simulation hosts (a follow-up `sim_server` tool with start/list/kill), a host needs to be stoppable **in-band over its socket** rather than by PID/signal: the per-chip socket is deliberately world-writable and cross-user, while a signal is same-uid only — so only a socket message reaches exactly the set of processes that can reach the server. Stacked on #3025.

### Description
Adds a `SHUTDOWN` command to the wire protocol and the host-side hook + client-side error to make graceful shutdown work end to end.

- **Wire:** `SHUTDOWN` added to `SimulationServerCommand`; acked with a plain `SimulationServerResponse` (no new message table).
- **Host:** the shutdown handler is passed into `SimulationTTDevice::adopt_socket(socket, handler)` and captured before serving starts — immutable, so no setter, no member, no lock. `handle_request` invokes it on `SHUTDOWN` and acks. A host that passes none acks as a **no-op**, so a simulation embedded in another program can't be torn down by a stray client. The handler must only *signal* — it runs on a serving thread, so tearing down there would self-join the serving threads and deadlock; a dedicated server signals its main thread to exit, which then drops the `Cluster` for a graceful teardown. It must also be safe to call more than once, since every attached client that sends SHUTDOWN invokes it.
- **Client (graceful failure):** `recv_framed` now maps a clean peer close (EOF / connection reset) to a **distinct, clearly-worded error** ("…the remote end (e.g. a stopped simulation host) has gone away") instead of the generic read-failure message, so a client blocked in / next calling `transact()` when the host is stopped fails with an unmistakable exception and unwinds gracefully. On teardown the host cleanly closes every client connection, so all attached clients get this error on their blocked/next call.

### List of the changes
- `simulation_server_protocol.{fbs,hpp}` — `SHUTDOWN` command.
- `simulation_tt_device.{hpp,cpp}` — `adopt_socket()` takes an optional shutdown handler, captured into the serving lambda before the accept loop starts (no member/mutex); `handle_request` SHUTDOWN branch invokes it and acks (no-op if none).
- `cluster.{hpp,cpp}` — `ClusterOptions::simulation_shutdown_handler`, plumbed through `serve_simulation_devices_over_sockets()` into `adopt_socket()`.
- `simulation_server_transport.cpp` — `recv_framed` distinct peer-close error.
- Tests: `SHUTDOWN` request round-trip (protocol lane); `recv_framed` reports a peer close distinctly (always-built transport lane).

### Testing
Build + pre-commit clean; 180 baremetal + 12 protocol tests pass. End-to-end shutdown (via the follow-up tool) is CI-gated.

### API Changes
`SimulationTTDevice::adopt_socket()` gains an optional `std::function<void()>` shutdown handler; `ClusterOptions::simulation_shutdown_handler` added; `SimulationServerCommand::Shutdown` added. Simulation-internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
