### PR TITLE
Pin TLB static_vc class/buddy by direction on Blackhole

### DIFF
--- a/device/api/umd/device/arch/architecture_tlbs.hpp
+++ b/device/api/umd/device/arch/architecture_tlbs.hpp
@@ -39,11 +39,18 @@ struct ArchitectureTlbs {
     // Whether static_vc should be used for window configuration.
     bool use_static_vc;
 
+    // Whether a window picks its virtual channel through its own configuration, rather than the
+    // architecture wiring one up for it.
+    bool static_vc_is_configurable;
+
     uint32_t static_cfg_addr;
     uint64_t cfg_reg_size_bytes;
 
     // Configuration of the window at the given index.
     tlb_configuration get_configuration(uint32_t tlb_index) const;
+
+    // The virtual channel to configure a window with, given what that window will carry.
+    tlb_static_vc get_static_vc(TlbVcDirection direction) const;
 };
 
 const ArchitectureTlbs& get_architecture_tlbs(const tt::ARCH arch);

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -38,7 +38,10 @@ inline constexpr auto TLB_2M_OFFSET = tlb_offsets{
     .linked = 72,
     .static_vc = 73,
     // missing .stream_header
-    .static_vc_end = 75};
+    .static_vc_end = 75,
+    .static_vc_buddy = 75,
+    .static_vc_class = 76,
+    .static_vc_class_end = 78};
 
 inline constexpr auto TLB_4G_OFFSET = tlb_offsets{
     .local_offset = 0,
@@ -52,7 +55,10 @@ inline constexpr auto TLB_4G_OFFSET = tlb_offsets{
     .linked = 61,
     .static_vc = 62,
     // missing .stream_header
-    .static_vc_end = 64};
+    .static_vc_end = 64,
+    .static_vc_buddy = 64,
+    .static_vc_class = 65,
+    .static_vc_class_end = 67};
 
 enum class arc_message_type {
     NOP = 0x11,  // Do nothing
@@ -499,7 +505,10 @@ public:
 
     size_t get_cached_tlb_size() const override { return blackhole::STATIC_TLB_SIZE; }
 
-    bool get_static_vc() const override { return false; }  // False due to a known HW issue.
+    // Gates static VC on the persistent-TLB path (configure_tlb), where a single window services both
+    // reads and writes -- a shared static VC there crashes the host. The cached data/register/DMA
+    // paths reconfigure per op and instead pin the static VC by direction via set_static_vc().
+    bool get_static_vc() const override { return false; }
 
     std::optional<uint8_t> get_ubb_tray_id(uint16_t bus_id) const override {
         const uint16_t bus_high = static_cast<uint16_t>(bus_id & 0xF0);

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -38,7 +38,9 @@ inline constexpr auto TLB_2M_OFFSET = tlb_offsets{
     .linked = 72,
     .static_vc = 73,
     // missing .stream_header
-    .static_vc_end = 75};
+    .static_vc_buddy = 75,
+    .static_vc_class = 76,
+    .static_vc_class_end = 78};
 
 inline constexpr auto TLB_4G_OFFSET = tlb_offsets{
     .local_offset = 0,
@@ -52,7 +54,9 @@ inline constexpr auto TLB_4G_OFFSET = tlb_offsets{
     .linked = 61,
     .static_vc = 62,
     // missing .stream_header
-    .static_vc_end = 64};
+    .static_vc_buddy = 64,
+    .static_vc_class = 65,
+    .static_vc_class_end = 67};
 
 enum class arc_message_type {
     NOP = 0x11,  // Do nothing

--- a/device/api/umd/device/arch/grendel_implementation.hpp
+++ b/device/api/umd/device/arch/grendel_implementation.hpp
@@ -38,7 +38,10 @@ inline constexpr auto TLB_2M_OFFSET = tlb_offsets{
     .linked = 72,
     .static_vc = 73,
     // missing .stream_header
-    .static_vc_end = 75};
+    .static_vc_end = 75,
+    .static_vc_buddy = 75,
+    .static_vc_class = 76,
+    .static_vc_class_end = 78};
 
 inline constexpr auto TLB_4G_OFFSET = tlb_offsets{
     .local_offset = 0,
@@ -52,7 +55,10 @@ inline constexpr auto TLB_4G_OFFSET = tlb_offsets{
     .linked = 61,
     .static_vc = 62,
     // missing .stream_header
-    .static_vc_end = 64};
+    .static_vc_end = 64,
+    .static_vc_buddy = 64,
+    .static_vc_class = 65,
+    .static_vc_class_end = 67};
 
 enum class arc_message_type {
     NOP = 0x11,  // Do nothing

--- a/device/api/umd/device/arch/grendel_implementation.hpp
+++ b/device/api/umd/device/arch/grendel_implementation.hpp
@@ -38,7 +38,9 @@ inline constexpr auto TLB_2M_OFFSET = tlb_offsets{
     .linked = 72,
     .static_vc = 73,
     // missing .stream_header
-    .static_vc_end = 75};
+    .static_vc_buddy = 75,
+    .static_vc_class = 76,
+    .static_vc_class_end = 78};
 
 inline constexpr auto TLB_4G_OFFSET = tlb_offsets{
     .local_offset = 0,
@@ -52,7 +54,9 @@ inline constexpr auto TLB_4G_OFFSET = tlb_offsets{
     .linked = 61,
     .static_vc = 62,
     // missing .stream_header
-    .static_vc_end = 64};
+    .static_vc_buddy = 64,
+    .static_vc_class = 65,
+    .static_vc_class_end = 67};
 
 enum class arc_message_type {
     NOP = 0x11,  // Do nothing

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -138,6 +138,7 @@ protected:
         tt_xy_pair core_end,
         NocId noc_id,
         uint64_t ordering,
+        TlbVcDirection direction,
         bool mcast = false,
         tt_xy_pair core_start = {}) const;
 

--- a/device/api/umd/device/pcie/tlb_window.hpp
+++ b/device/api/umd/device/pcie/tlb_window.hpp
@@ -149,6 +149,7 @@ protected:
         tt_xy_pair core_end,
         NocId noc_id,
         uint64_t ordering,
+        TlbVcDirection direction,
         bool mcast = false,
         tt_xy_pair core_start = {}) const;
 

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -28,6 +28,7 @@ namespace tt::umd {
 class PCIDevice;
 class TlbWindow;
 struct tlb_data;
+enum class TlbVcDirection;
 
 /**
  * PcieProtocol implements DeviceProtocol, PcieInterface, and DmaInterface for PCIe-connected
@@ -93,7 +94,11 @@ private:
 
     enum class DmaDirection { H2D, D2H };
     tlb_data create_dma_tlb_config(
-        uint64_t addr, tt_xy_pair core_end, NocId noc_id, std::optional<tt_xy_pair> core_start = std::nullopt);
+        uint64_t addr,
+        tt_xy_pair core_end,
+        NocId noc_id,
+        TlbVcDirection direction,
+        std::optional<tt_xy_pair> core_start = std::nullopt);
     bool dma_transfer(void* buffer, size_t size, uint64_t addr, tlb_data config, DmaDirection direction);
     bool dma_transfer_zero_copy(uint64_t iova, size_t size, uint64_t addr, tlb_data config, DmaDirection direction);
 

--- a/device/api/umd/device/types/tlb.hpp
+++ b/device/api/umd/device/types/tlb.hpp
@@ -9,6 +9,8 @@
 #include <stdexcept>
 #include <utility>
 
+#include "umd/device/types/arch.hpp"
+
 namespace tt::umd {
 
 struct tlb_offsets {
@@ -23,6 +25,21 @@ struct tlb_offsets {
     uint32_t linked;
     uint32_t static_vc;
     uint32_t static_vc_end;
+    // Per-TLB pin of the NoC virtual channel buddy bit and class bits, used when static_vc is set.
+    // Only defined on architectures that expose them as configuration bits (Blackhole/Grendel).
+    // Wormhole's PCIe tile hardwires the equivalent in hardware regardless of config, so these
+    // offsets are left unset (0) there and no buddy/class bits are packed.
+    uint32_t static_vc_buddy;
+    uint32_t static_vc_class;
+    uint32_t static_vc_class_end;
+};
+
+// Direction of a TLB transaction, used to pin the static VC so reads and writes never share a
+// virtual channel (a single static VC carrying both crashes the host on Blackhole).
+enum class TlbVcDirection {
+    UnicastWrite,
+    UnicastRead,
+    MulticastWrite,
 };
 
 struct tlb_data {
@@ -36,6 +53,8 @@ struct tlb_data {
     uint64_t ordering = 0;
     uint64_t linked = 0;
     uint64_t static_vc = 0;
+    uint64_t static_vc_buddy = 0;
+    uint64_t static_vc_class = 0;
 
     // Orderings.
     static constexpr uint64_t Relaxed = 0;
@@ -45,6 +64,13 @@ struct tlb_data {
     bool check(const tlb_offsets &offset) const;
     std::pair<std::uint64_t, std::uint64_t> apply_offset(const tlb_offsets &offset) const;
 };
+
+// Populates the static VC fields of `config` for the given architecture and transaction direction.
+// Blackhole/Grendel expose buddy/class as config bits, so they are pinned by direction (write=buddy0,
+// read=buddy1, multicast=class 0b10, unicast=class 0b00) to keep reads and writes on separate static
+// VCs. Wormhole hardwires the equivalent in hardware, so only static_vc is set there. Architectures
+// that do not use static VC are left on dynamic VC (static_vc=0).
+void set_static_vc(tlb_data &config, tt::ARCH arch, TlbVcDirection direction);
 
 struct tlb_configuration {
     uint64_t size;

--- a/device/api/umd/device/types/tlb.hpp
+++ b/device/api/umd/device/types/tlb.hpp
@@ -23,6 +23,26 @@ struct tlb_offsets {
     uint32_t linked;
     uint32_t static_vc;
     uint32_t static_vc_end;
+    uint32_t static_vc_buddy;
+    uint32_t static_vc_class;
+    uint32_t static_vc_class_end;
+};
+
+// What a TLB window will carry. A window carrying a single direction can be given a virtual channel
+// of its own, so reads and writes never share one. BIDIRECTIONAL is for windows that stay
+// configured across both.
+enum class TlbVcDirection {
+    UNICAST_WRITE,
+    UNICAST_READ,
+    MULTICAST_WRITE,
+    BIDIRECTIONAL,
+};
+
+// The virtual channel a TLB window is configured to use.
+struct tlb_static_vc {
+    uint64_t static_vc = 0;
+    uint64_t static_vc_buddy = 0;
+    uint64_t static_vc_class = 0;
 };
 
 struct tlb_data {
@@ -36,11 +56,15 @@ struct tlb_data {
     uint64_t ordering = 0;
     uint64_t linked = 0;
     uint64_t static_vc = 0;
+    uint64_t static_vc_buddy = 0;
+    uint64_t static_vc_class = 0;
 
     // Orderings.
     static constexpr uint64_t Relaxed = 0;
     static constexpr uint64_t Strict = 1;
     static constexpr uint64_t Posted = 2;
+
+    void set_static_vc(const tlb_static_vc &vc);
 
     bool check(const tlb_offsets &offset) const;
     std::pair<std::uint64_t, std::uint64_t> apply_offset(const tlb_offsets &offset) const;

--- a/device/arch/architecture_tlbs.cpp
+++ b/device/arch/architecture_tlbs.cpp
@@ -39,6 +39,22 @@ tlb_configuration ArchitectureTlbs::get_configuration(const uint32_t tlb_index) 
     UMD_THROW(error::RuntimeError, fmt::format("No TLB window with index {}.", tlb_index));
 }
 
+tlb_static_vc ArchitectureTlbs::get_static_vc(const TlbVcDirection direction) const {
+    if (!static_vc_is_configurable || direction == TlbVcDirection::BIDIRECTIONAL) {
+        // Nothing left to choose: either the architecture wires the channel up itself, or the window
+        // carries both directions and so cannot be given one of its own.
+        return {.static_vc = use_static_vc};
+    }
+
+    // Reads and writes go to different buddies so that neither can be reordered behind the other,
+    // and multicast writes get a class of their own.
+    return {
+        .static_vc = 1,
+        .static_vc_buddy = direction == TlbVcDirection::UNICAST_READ ? 1ULL : 0ULL,
+        .static_vc_class = direction == TlbVcDirection::MULTICAST_WRITE ? 0b10ULL : 0b00ULL,
+    };
+}
+
 const ArchitectureTlbs& get_architecture_tlbs(const tt::ARCH arch) {
     static const ArchitectureTlbs wormhole_tlbs = {
         .size_classes =
@@ -68,6 +84,9 @@ const ArchitectureTlbs& get_architecture_tlbs(const tt::ARCH arch) {
              }},
         .cached_window_size = wormhole::STATIC_TLB_SIZE,
         .use_static_vc = true,
+        // The Wormhole PCIe tile hardwires the virtual channels, keeping reads and writes apart
+        // without a window having to ask for it.
+        .static_vc_is_configurable = false,
         .static_cfg_addr = wormhole::STATIC_TLB_CFG_ADDR,
         .cfg_reg_size_bytes = wormhole::TLB_CFG_REG_SIZE_BYTES,
     };
@@ -91,8 +110,10 @@ const ArchitectureTlbs& get_architecture_tlbs(const tt::ARCH arch) {
                  .register_layout = blackhole::TLB_4G_OFFSET,
              }},
         .cached_window_size = blackhole::STATIC_TLB_SIZE,
-        // False due to a known HW issue.
+        // A window that carries both reads and writes on one static VC crashes the host, so windows
+        // that cannot pick a direction stay on a dynamic VC.
         .use_static_vc = false,
+        .static_vc_is_configurable = true,
         .static_cfg_addr = blackhole::STATIC_TLB_CFG_ADDR,
         .cfg_reg_size_bytes = blackhole::TLB_CFG_REG_SIZE_BYTES,
     };
@@ -117,6 +138,7 @@ const ArchitectureTlbs& get_architecture_tlbs(const tt::ARCH arch) {
              }},
         .cached_window_size = grendel::STATIC_TLB_SIZE,
         .use_static_vc = true,
+        .static_vc_is_configurable = true,
         .static_cfg_addr = grendel::STATIC_TLB_CFG_ADDR,
         .cfg_reg_size_bytes = grendel::TLB_CFG_REG_SIZE_BYTES,
     };

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -326,7 +326,8 @@ void LocalChip::write_to_device_reg(CoreCoord core, const void* src, uint64_t re
     config.y_end = translated_core.y;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = tlb_data::Strict;
-    config.static_vc = get_tt_device()->get_architecture_implementation()->get_static_vc();
+    set_static_vc(
+        config, get_tt_device()->get_architecture_implementation()->get_architecture(), TlbVcDirection::UnicastWrite);
     TlbWindow* tlb_window = get_cached_uc_tlb_window();
     tlb_window->configure(config);
 
@@ -357,7 +358,8 @@ void LocalChip::read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_sr
     config.y_end = translated_core.y;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = tlb_data::Strict;
-    config.static_vc = get_tt_device()->get_architecture_implementation()->get_static_vc();
+    set_static_vc(
+        config, get_tt_device()->get_architecture_implementation()->get_architecture(), TlbVcDirection::UnicastRead);
     TlbWindow* tlb_window = get_cached_uc_tlb_window();
     tlb_window->configure(config);
 

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -328,7 +328,8 @@ void LocalChip::write_to_device_reg(CoreCoord core, const void* src, uint64_t re
     config.y_end = translated_core.y;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = tlb_data::Strict;
-    config.static_vc = get_architecture_tlbs(get_tt_device()->get_arch()).use_static_vc;
+    config.set_static_vc(
+        get_architecture_tlbs(get_tt_device()->get_arch()).get_static_vc(TlbVcDirection::UNICAST_WRITE));
     TlbWindow* tlb_window = get_cached_uc_tlb_window();
     tlb_window->configure(config);
 
@@ -359,7 +360,8 @@ void LocalChip::read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_sr
     config.y_end = translated_core.y;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = tlb_data::Strict;
-    config.static_vc = get_architecture_tlbs(get_tt_device()->get_arch()).use_static_vc;
+    config.set_static_vc(
+        get_architecture_tlbs(get_tt_device()->get_arch()).get_static_vc(TlbVcDirection::UNICAST_READ));
     TlbWindow* tlb_window = get_cached_uc_tlb_window();
     tlb_window->configure(config);
 

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -91,7 +91,7 @@ void SysmemBuffer::dma_write_to_device(const size_t offset, size_t size, const t
     config.y_end = core.y;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = tlb_data::Relaxed;
-    config.static_vc = pci_device_->get_architecture_implementation()->get_static_vc();
+    set_static_vc(config, pci_device_->get_arch(), TlbVcDirection::UnicastWrite);
     TlbWindow* tlb_window = get_cached_tlb_window();
     tlb_window->configure(config);
 
@@ -147,8 +147,7 @@ void SysmemBuffer::dma_read_from_device(const size_t offset, size_t size, const 
     config.y_end = core.y;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = tlb_data::Relaxed;
-    config.static_vc = pci_device_->get_architecture_implementation()->get_static_vc();
-
+    set_static_vc(config, pci_device_->get_arch(), TlbVcDirection::UnicastRead);
     TlbWindow* tlb_window = get_cached_tlb_window();
     tlb_window->configure(config);
 

--- a/device/pcie/rtl_sim_tlb_handle.cpp
+++ b/device/pcie/rtl_sim_tlb_handle.cpp
@@ -54,6 +54,8 @@ void RtlSimTlbHandle::configure(const tlb_data& new_config) {
     // These fields are not used for RTL sim.
     tlb_config_.ordering = 0;
     tlb_config_.static_vc = 0;
+    tlb_config_.static_vc_buddy = 0;
+    tlb_config_.static_vc_class = 0;
 
     log_debug(
         LogUMD,

--- a/device/pcie/rtl_sim_tlb_handle.cpp
+++ b/device/pcie/rtl_sim_tlb_handle.cpp
@@ -53,6 +53,8 @@ void RtlSimTlbHandle::configure(const tlb_data& new_config) {
     // These fields are not used for RTL sim.
     tlb_config_.ordering = 0;
     tlb_config_.static_vc = 0;
+    tlb_config_.static_vc_buddy = 0;
+    tlb_config_.static_vc_class = 0;
 
     log_debug(
         LogUMD,

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -25,14 +25,20 @@ TlbWindow::TlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config) :
 }
 
 tlb_data TlbWindow::make_tlb_config(
-    uint64_t addr, tt_xy_pair core_end, NocId noc_id, uint64_t ordering, bool mcast, tt_xy_pair core_start) const {
+    uint64_t addr,
+    tt_xy_pair core_end,
+    NocId noc_id,
+    uint64_t ordering,
+    TlbVcDirection direction,
+    bool mcast,
+    tt_xy_pair core_start) const {
     tlb_data config{};
     config.local_offset = addr;
     config.x_end = core_end.x;
     config.y_end = core_end.y;
     config.noc_sel = static_cast<uint64_t>(noc_id);
     config.ordering = ordering;
-    config.static_vc = handle_ref().get_arch() != tt::ARCH::BLACKHOLE;
+    set_static_vc(config, handle_ref().get_arch(), direction);
     if (mcast) {
         config.mcast = true;
         config.x_start = core_start.x;
@@ -56,7 +62,7 @@ void TlbWindow::transfer_and_reconfigure(tlb_data config, buffer_pointer buffer,
 void TlbWindow::read_block_reconfigure(
     void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
     transfer_and_reconfigure(
-        make_tlb_config(addr, core, noc_id, ordering),
+        make_tlb_config(addr, core, noc_id, ordering, TlbVcDirection::UnicastRead),
         static_cast<uint8_t*>(mem_ptr),
         size,
         [this](uint8_t* buf, size_t sz) { read_block(0, buf, sz); });
@@ -65,7 +71,7 @@ void TlbWindow::read_block_reconfigure(
 void TlbWindow::read_register_reconfigure(
     void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
     transfer_and_reconfigure(
-        make_tlb_config(addr, core, noc_id, ordering),
+        make_tlb_config(addr, core, noc_id, ordering, TlbVcDirection::UnicastRead),
         static_cast<uint8_t*>(mem_ptr),
         size,
         [this](uint8_t* buf, size_t sz) { read_register(0, buf, sz); });
@@ -74,7 +80,7 @@ void TlbWindow::read_register_reconfigure(
 void TlbWindow::write_block_reconfigure(
     const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
     transfer_and_reconfigure(
-        make_tlb_config(addr, core, noc_id, ordering),
+        make_tlb_config(addr, core, noc_id, ordering, TlbVcDirection::UnicastWrite),
         static_cast<const uint8_t*>(mem_ptr),
         size,
         [this](const uint8_t* buf, size_t sz) { write_block(0, buf, sz); });
@@ -83,7 +89,7 @@ void TlbWindow::write_block_reconfigure(
 void TlbWindow::write_register_reconfigure(
     const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
     transfer_and_reconfigure(
-        make_tlb_config(addr, core, noc_id, ordering),
+        make_tlb_config(addr, core, noc_id, ordering, TlbVcDirection::UnicastWrite),
         static_cast<const uint8_t*>(mem_ptr),
         size,
         [this](const uint8_t* buf, size_t sz) { write_register(0, buf, sz); });
@@ -98,7 +104,7 @@ void TlbWindow::noc_multicast_write_reconfigure(
     NocId noc_id,
     uint64_t ordering) {
     transfer_and_reconfigure(
-        make_tlb_config(addr, core_end, noc_id, ordering, true, core_start),
+        make_tlb_config(addr, core_end, noc_id, ordering, TlbVcDirection::MulticastWrite, true, core_start),
         static_cast<const uint8_t*>(src),
         size,
         [this](const uint8_t* buf, size_t sz) { write_block(0, buf, sz); });

--- a/device/pcie/tlb_window.cpp
+++ b/device/pcie/tlb_window.cpp
@@ -11,6 +11,7 @@
 #include <stdexcept>
 #include <utility>
 
+#include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/pcie/tlb_handle.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/io_window_config.hpp"
@@ -38,14 +39,20 @@ TlbWindow::TlbWindow(std::unique_ptr<TlbHandle> handle, const tlb_data config) :
 }
 
 tlb_data TlbWindow::make_tlb_config(
-    uint64_t addr, tt_xy_pair core_end, NocId noc_id, uint64_t ordering, bool mcast, tt_xy_pair core_start) const {
+    uint64_t addr,
+    tt_xy_pair core_end,
+    NocId noc_id,
+    uint64_t ordering,
+    TlbVcDirection direction,
+    bool mcast,
+    tt_xy_pair core_start) const {
     tlb_data config{};
     config.local_offset = addr;
     config.x_end = core_end.x;
     config.y_end = core_end.y;
     config.noc_sel = static_cast<uint64_t>(noc_id);
     config.ordering = ordering;
-    config.static_vc = handle_ref().get_arch() != tt::ARCH::BLACKHOLE;
+    config.set_static_vc(get_architecture_tlbs(handle_ref().get_arch()).get_static_vc(direction));
     if (mcast) {
         config.mcast = true;
         config.x_start = core_start.x;
@@ -69,7 +76,7 @@ void TlbWindow::transfer_and_reconfigure(tlb_data config, buffer_pointer buffer,
 void TlbWindow::read_block_reconfigure(
     void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
     transfer_and_reconfigure(
-        make_tlb_config(addr, core, noc_id, ordering),
+        make_tlb_config(addr, core, noc_id, ordering, TlbVcDirection::UNICAST_READ),
         static_cast<uint8_t*>(mem_ptr),
         size,
         [this](uint8_t* buf, size_t sz) { read_block(0, buf, sz); });
@@ -78,7 +85,7 @@ void TlbWindow::read_block_reconfigure(
 void TlbWindow::read_register_reconfigure(
     void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
     transfer_and_reconfigure(
-        make_tlb_config(addr, core, noc_id, ordering),
+        make_tlb_config(addr, core, noc_id, ordering, TlbVcDirection::UNICAST_READ),
         static_cast<uint8_t*>(mem_ptr),
         size,
         [this](uint8_t* buf, size_t sz) { read_register(0, buf, sz); });
@@ -87,7 +94,7 @@ void TlbWindow::read_register_reconfigure(
 void TlbWindow::write_block_reconfigure(
     const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
     transfer_and_reconfigure(
-        make_tlb_config(addr, core, noc_id, ordering),
+        make_tlb_config(addr, core, noc_id, ordering, TlbVcDirection::UNICAST_WRITE),
         static_cast<const uint8_t*>(mem_ptr),
         size,
         [this](const uint8_t* buf, size_t sz) { write_block(0, buf, sz); });
@@ -96,7 +103,7 @@ void TlbWindow::write_block_reconfigure(
 void TlbWindow::write_register_reconfigure(
     const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id, uint64_t ordering) {
     transfer_and_reconfigure(
-        make_tlb_config(addr, core, noc_id, ordering),
+        make_tlb_config(addr, core, noc_id, ordering, TlbVcDirection::UNICAST_WRITE),
         static_cast<const uint8_t*>(mem_ptr),
         size,
         [this](const uint8_t* buf, size_t sz) { write_register(0, buf, sz); });
@@ -111,7 +118,7 @@ void TlbWindow::noc_multicast_write_reconfigure(
     NocId noc_id,
     uint64_t ordering) {
     transfer_and_reconfigure(
-        make_tlb_config(addr, core_end, noc_id, ordering, true, core_start),
+        make_tlb_config(addr, core_end, noc_id, ordering, TlbVcDirection::MULTICAST_WRITE, true, core_start),
         static_cast<const uint8_t*>(src),
         size,
         [this](const uint8_t* buf, size_t sz) { write_block(0, buf, sz); });
@@ -167,6 +174,7 @@ void TlbWindow::configure(const TargetIoWindowConfig& config, IoOrdering orderin
         mcast ? config.core_end.value() : config.core_start,
         config.noc.value(),
         static_cast<uint64_t>(ordering),
+        TlbVcDirection::BIDIRECTIONAL,
         mcast,
         config.core_start));
 }

--- a/device/pcie/tt_sim_tlb_handle.cpp
+++ b/device/pcie/tt_sim_tlb_handle.cpp
@@ -66,9 +66,11 @@ void TTSimTlbHandle::configure(const tlb_data& new_config) {
     tlb_config_ = new_config;
     tlb_config_.local_offset = new_config.local_offset / tlb_size_;
 
-    // These fields are not supported for TTSim, so we set it to 0.
+    // These fields are not supported for TTSim, so we set them to 0.
     tlb_config_.ordering = 0;
     tlb_config_.static_vc = 0;
+    tlb_config_.static_vc_buddy = 0;
+    tlb_config_.static_vc_class = 0;
 
     // Get architecture from allocator to determine correct offsets.
     tt::ARCH architecture = get_arch();

--- a/device/pcie/tt_sim_tlb_handle.cpp
+++ b/device/pcie/tt_sim_tlb_handle.cpp
@@ -65,9 +65,11 @@ void TTSimTlbHandle::configure(const tlb_data& new_config) {
     tlb_config_ = new_config;
     tlb_config_.local_offset = new_config.local_offset / tlb_size_;
 
-    // These fields are not supported for TTSim, so we set it to 0.
+    // These fields are not supported for TTSim, so we set them to 0.
     tlb_config_.ordering = 0;
     tlb_config_.static_vc = 0;
+    tlb_config_.static_vc_buddy = 0;
+    tlb_config_.static_vc_class = 0;
 
     // Get architecture from allocator to determine correct offsets.
     tt::ARCH architecture = get_arch();

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -197,7 +197,7 @@ tlb_data PcieProtocol::create_dma_tlb_config(
     config.y_end = core_end.y;
     config.noc_sel = static_cast<uint64_t>(noc_id);
     config.ordering = tlb_data::Relaxed;
-    config.static_vc = pci_device_->get_architecture_implementation()->get_static_vc();
+    // static_vc is pinned by direction in dma_transfer() via set_static_vc().
     if (core_start) {
         config.x_start = core_start->x;
         config.y_start = core_start->y;
@@ -214,6 +214,14 @@ bool PcieProtocol::dma_transfer(void* buffer, size_t size, uint64_t addr, tlb_da
         log_warning(LogUMD, "DMA buffer was not allocated for PCI device {}.", pci_device_->get_device_num());
         return false;
     }
+
+    // For DMA the TLB direction matches the data-flow direction: H2D writes into the device tile,
+    // D2H reads from it. Pin the static VC accordingly so reads and writes stay on separate VCs.
+    const TlbVcDirection vc_direction =
+        (direction == DmaDirection::H2D)
+            ? (config.mcast ? TlbVcDirection::MulticastWrite : TlbVcDirection::UnicastWrite)
+            : TlbVcDirection::UnicastRead;
+    set_static_vc(config, pci_device_->get_arch(), vc_direction);
 
     uint8_t* buf = static_cast<uint8_t*>(buffer);
     size_t dmabuf_size = dma_buffer.size;

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -260,12 +260,17 @@ bool PcieProtocol::dma_write(const void* src, uint64_t dst_addr, size_t size, tt
         const_cast<void*>(src),  // NOLINT
         size,
         dst_addr,
-        create_dma_tlb_config(dst_addr, core, noc_id),
+        create_dma_tlb_config(dst_addr, core, noc_id, TlbVcDirection::UNICAST_WRITE),
         DmaDirection::H2D);
 }
 
 bool PcieProtocol::dma_read(void* dst, uint64_t src_addr, size_t size, tt_xy_pair core, NocId noc_id) {
-    return dma_transfer(dst, size, src_addr, create_dma_tlb_config(src_addr, core, noc_id), DmaDirection::D2H);
+    return dma_transfer(
+        dst,
+        size,
+        src_addr,
+        create_dma_tlb_config(src_addr, core, noc_id, TlbVcDirection::UNICAST_READ),
+        DmaDirection::D2H);
 }
 
 bool PcieProtocol::dma_multicast_write(
@@ -274,26 +279,38 @@ bool PcieProtocol::dma_multicast_write(
         const_cast<void*>(src),  // NOLINT
         size,
         dst_addr,
-        create_dma_tlb_config(dst_addr, core_end, noc_id, core_start),
+        create_dma_tlb_config(dst_addr, core_end, noc_id, TlbVcDirection::MULTICAST_WRITE, core_start),
         DmaDirection::H2D);
 }
 
 bool PcieProtocol::dma_read_zero_copy(
     uint64_t dst_iova, uint64_t src_addr, size_t size, tt_xy_pair core, NocId noc_id) {
     return dma_transfer_zero_copy(
-        dst_iova, size, src_addr, create_dma_tlb_config(src_addr, core, noc_id), DmaDirection::D2H);
+        dst_iova,
+        size,
+        src_addr,
+        create_dma_tlb_config(src_addr, core, noc_id, TlbVcDirection::UNICAST_READ),
+        DmaDirection::D2H);
 }
 
 bool PcieProtocol::dma_write_zero_copy(
     uint64_t src_iova, uint64_t dst_addr, size_t size, tt_xy_pair core, NocId noc_id) {
     return dma_transfer_zero_copy(
-        src_iova, size, dst_addr, create_dma_tlb_config(dst_addr, core, noc_id), DmaDirection::H2D);
+        src_iova,
+        size,
+        dst_addr,
+        create_dma_tlb_config(dst_addr, core, noc_id, TlbVcDirection::UNICAST_WRITE),
+        DmaDirection::H2D);
 }
 
 bool PcieProtocol::dma_multicast_write_zero_copy(
     uint64_t src_iova, uint64_t dst_addr, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, NocId noc_id) {
     return dma_transfer_zero_copy(
-        src_iova, size, dst_addr, create_dma_tlb_config(dst_addr, core_end, noc_id, core_start), DmaDirection::H2D);
+        src_iova,
+        size,
+        dst_addr,
+        create_dma_tlb_config(dst_addr, core_end, noc_id, TlbVcDirection::MULTICAST_WRITE, core_start),
+        DmaDirection::H2D);
 }
 
 // Creates a TLB config for DMA transfers. Parameters are named core_end/core_start to match
@@ -301,14 +318,14 @@ bool PcieProtocol::dma_multicast_write_zero_copy(
 // (the target core). When core_start is provided, the transfer becomes a multicast to the
 // core range [core_start, core_end].
 tlb_data PcieProtocol::create_dma_tlb_config(
-    uint64_t addr, tt_xy_pair core_end, NocId noc_id, std::optional<tt_xy_pair> core_start) {
+    uint64_t addr, tt_xy_pair core_end, NocId noc_id, TlbVcDirection direction, std::optional<tt_xy_pair> core_start) {
     tlb_data config{};
     config.local_offset = addr;
     config.x_end = core_end.x;
     config.y_end = core_end.y;
     config.noc_sel = static_cast<uint64_t>(noc_id);
     config.ordering = tlb_data::Relaxed;
-    config.static_vc = get_architecture_tlbs(pci_device_->get_arch()).use_static_vc;
+    config.set_static_vc(get_architecture_tlbs(pci_device_->get_arch()).get_static_vc(direction));
     if (core_start) {
         config.x_start = core_start->x;
         config.y_start = core_start->y;

--- a/device/types/tlb.cpp
+++ b/device/types/tlb.cpp
@@ -8,9 +8,31 @@
 #include <string>
 #include <utility>
 
+#include "umd/device/types/arch.hpp"
 #include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
+
+void set_static_vc(tlb_data &config, tt::ARCH arch, TlbVcDirection direction) {
+    switch (arch) {
+        case tt::ARCH::BLACKHOLE:
+        case tt::ARCH::QUASAR:
+            // Buddy/class are configurable; pin them by direction so reads (buddy=1) and writes
+            // (buddy=0) never share a static VC. Multicast requests must use class 0b10.
+            config.static_vc = 1;
+            config.static_vc_buddy = (direction == TlbVcDirection::UnicastRead) ? 1 : 0;
+            config.static_vc_class = (direction == TlbVcDirection::MulticastWrite) ? 0b10 : 0b00;
+            break;
+        case tt::ARCH::WORMHOLE_B0:
+            // The Wormhole PCIe tile hardwires buddy/class (buddy=0 writes, buddy=1 reads,
+            // class 0b10 multicast, 0b00 unicast) regardless of config, so only enable static_vc.
+            config.static_vc = 1;
+            break;
+        default:
+            config.static_vc = 0;
+            break;
+    }
+}
 
 bool tlb_data::check(const tlb_offsets &offset) const {
     return (local_offset > ((1ULL << (offset.x_end - offset.local_offset)) - 1)) |
@@ -22,7 +44,9 @@ bool tlb_data::check(const tlb_offsets &offset) const {
            (mcast > ((1ULL << (offset.ordering - offset.mcast)) - 1)) |
            (ordering > ((1ULL << (offset.linked - offset.ordering)) - 1)) |
            (linked > ((1ULL << (offset.static_vc - offset.linked)) - 1)) |
-           (static_vc > ((1ULL << (offset.static_vc_end - offset.static_vc)) - 1));
+           (static_vc > ((1ULL << (offset.static_vc_end - offset.static_vc)) - 1)) |
+           (static_vc_buddy > ((1ULL << (offset.static_vc_class - offset.static_vc_buddy)) - 1)) |
+           (static_vc_class > ((1ULL << (offset.static_vc_class_end - offset.static_vc_class)) - 1));
 }
 
 // Helper lambda to handle bit packing.
@@ -56,6 +80,8 @@ std::pair<std::uint64_t, std::uint64_t> tlb_data::apply_offset(const tlb_offsets
     pack_bits(lower, upper, ordering, offset.ordering);
     pack_bits(lower, upper, linked, offset.linked);
     pack_bits(lower, upper, static_vc, offset.static_vc);
+    pack_bits(lower, upper, static_vc_buddy, offset.static_vc_buddy);
+    pack_bits(lower, upper, static_vc_class, offset.static_vc_class);
 
     return std::make_pair(lower, upper);
 }

--- a/device/types/tlb.cpp
+++ b/device/types/tlb.cpp
@@ -12,7 +12,17 @@
 
 namespace tt::umd {
 
+void tlb_data::set_static_vc(const tlb_static_vc &vc) {
+    static_vc = vc.static_vc;
+    static_vc_buddy = vc.static_vc_buddy;
+    static_vc_class = vc.static_vc_class;
+}
+
 bool tlb_data::check(const tlb_offsets &offset) const {
+    // Architectures that configure the buddy and class bits place them directly above static_vc, so
+    // static_vc_buddy is what terminates static_vc there; the rest declare static_vc_end for it.
+    const uint32_t static_vc_end = offset.static_vc_buddy != 0 ? offset.static_vc_buddy : offset.static_vc_end;
+
     return (local_offset > ((1ULL << (offset.x_end - offset.local_offset)) - 1)) |
            (x_end > ((1ULL << (offset.y_end - offset.x_end)) - 1)) |
            (y_end > ((1ULL << (offset.x_start - offset.y_end)) - 1)) |
@@ -22,7 +32,9 @@ bool tlb_data::check(const tlb_offsets &offset) const {
            (mcast > ((1ULL << (offset.ordering - offset.mcast)) - 1)) |
            (ordering > ((1ULL << (offset.linked - offset.ordering)) - 1)) |
            (linked > ((1ULL << (offset.static_vc - offset.linked)) - 1)) |
-           (static_vc > ((1ULL << (offset.static_vc_end - offset.static_vc)) - 1));
+           (static_vc > ((1ULL << (static_vc_end - offset.static_vc)) - 1)) |
+           (static_vc_buddy > ((1ULL << (offset.static_vc_class - offset.static_vc_buddy)) - 1)) |
+           (static_vc_class > ((1ULL << (offset.static_vc_class_end - offset.static_vc_class)) - 1));
 }
 
 // Helper lambda to handle bit packing.
@@ -56,6 +68,8 @@ std::pair<std::uint64_t, std::uint64_t> tlb_data::apply_offset(const tlb_offsets
     pack_bits(lower, upper, ordering, offset.ordering);
     pack_bits(lower, upper, linked, offset.linked);
     pack_bits(lower, upper, static_vc, offset.static_vc);
+    pack_bits(lower, upper, static_vc_buddy, offset.static_vc_buddy);
+    pack_bits(lower, upper, static_vc_class, offset.static_vc_class);
 
     return std::make_pair(lower, upper);
 }


### PR DESCRIPTION
### Issue
Closes #2735

### Description
**Goal: bring Blackhole to parity with Wormhole so the memory barrier works on Blackhole too.** The membar — and any ordering-dependent host→device sequence — needs writes to a tile to stay ordered on the NoC. Wormhole gets this for free: its PCIe tile hardwires static VC with reads and writes on separate virtual channels, and the barrier works there. Blackhole runs its cached host TLBs on dynamic VC, where the NoC can reorder two writes to the same tile once they leave the PCIe tile — the suspected root of the Blackhole ordering/membar issues in #2735.

Static VC was left off on Blackhole because turning it on crashed the host: a single static VC carrying both reads and writes hits a hardware bug.

This PR makes Blackhole mimic Wormhole: pin the static VC by direction — writes on buddy 0, reads on buddy 1, multicast writes on class `0b10` — so reads and writes never share a VC. That dodges the crash while restoring the same write ordering Wormhole has, so the barrier behaves on Blackhole as it does on Wormhole. These are exactly the values the Wormhole PCIe tile hardwires.

**Scope:** only the windows that are reconfigured per op and can therefore commit to a direction — the cached data, register and DMA windows. A window that stays configured across both reads and writes asks for `BIDIRECTIONAL` and keeps the architecture default, so the persistent-TLB path remains on dynamic VC on Blackhole and cannot re-trigger the crash. Wormhole hardwires buddy/class in hardware, so only `static_vc` is set there; the TTSim/RTL-sim backends do not model static VC, so those fields are stripped in their TLB handles.

### List of the changes
- Add `static_vc_buddy`/`static_vc_class` to `tlb_data` and the Blackhole/Grendel `tlb_offsets`, and pack them in `apply_offset`/`check`.
- Add a `TlbVcDirection` enum and `ArchitectureTlbs::get_static_vc()`, which returns the static VC settings for an architecture and direction.
- Route the cached data (`make_tlb_config`), register and DMA paths through it by direction; persistent and dma-buf-export windows keep the architecture default.
- Strip the buddy/class fields in the TTSim/RTL-sim TLB handles, which do not model static VC.

### Testing
CI

### API Changes
Additive only: new `static_vc_buddy`/`static_vc_class` fields and a `set_static_vc()` setter on `tlb_data`, a new `TlbVcDirection` enum and `tlb_static_vc` struct in `types/tlb.hpp`, and a `static_vc_is_configurable` field plus `get_static_vc()` on `ArchitectureTlbs`.
