### PR TITLE
Disable Blackhole Galaxy (g13blx01) in CI

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -157,6 +157,8 @@ jobs:
         # - The wh-glx-6u is also one machine, but not yet fully proven, so don't want to block merge queue with it.
         # - p100a is similar to p150, and the pool can get bogged down; only run it on main to keep
         #   PR/merge queue runtime down.
+        # - g13blx01 is the Blackhole Galaxy machine. It is fully disabled on all events for now as
+        #   it has been causing CI problems; re-enable once the machine is stable (see #3070).
         # On main, just run all of them since we are not that critical about runtime and want to maximize coverage.
         run: |
           ENTRIES=$(jq -cn '$ARGS.positional' --args \
@@ -168,7 +170,7 @@ jobs:
             'merge_group|*|tt-ubuntu-2204-wh-glx-6u-*' \
             'pull_request|*|tt-ubuntu-2204-p100a-*' \
             'merge_group|*|tt-ubuntu-2204-p100a-*' \
-            '*|TSan|g13blx01' \
+            '*|*|g13blx01' \
           )
           echo "entries=$ENTRIES" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
### Issue
#3070

### Description
The Blackhole Galaxy machine (`g13blx01`) has been causing CI problems, so disable it in `build-and-run-all-tests.yml`.

### List of the changes
- Fully blacklist `g13blx01` (`*|*|g13blx01`) so it no longer runs on any event or build type. The card stays defined in the matrix, so re-enabling once the machine is stable is a one-line change.

### Testing
CI

### API Changes
None