### PR TITLE
[do not merge] SWEmuleChip: wire up a real SimulationSysmemManager for host-facing addressing

### DIFF
--- a/device/api/umd/device/chip/sw_emule_chip.hpp
+++ b/device/api/umd/device/chip/sw_emule_chip.hpp
@@ -22,6 +22,8 @@ class L1Pool;
 
 namespace tt::umd {
 
+class SimulationSysmemManager;
+
 /// SWEmuleChip extends Chip with real memory-backed I/O.
 ///
 /// Worker L1 regions are allocated from a single contiguous L1Pool
@@ -116,6 +118,11 @@ private:
     uint64_t dram_bank_size_;
 
     SocDescriptor soc_descriptor_;
+
+    // Host-facing (PCIe) address resolution — an existing, already-upstream UMD class (also used
+    // by TTSimTTDevice), not emule-specific. No host-memory channels to pre-reserve (SWEmuleChip
+    // has no hugepage concept), so 0.
+    std::unique_ptr<SimulationSysmemManager> sysmem_manager_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
@@ -50,6 +50,11 @@ public:
     bool write_mapped_buffer(uint64_t device_io_addr, const void* src, uint32_t size);
     bool read_mapped_buffer(uint64_t device_io_addr, void* dst, uint32_t size);
 
+    // Same lookup as write/read_mapped_buffer, but returns the host pointer directly instead of
+    // performing the copy — for callers (e.g. tt-emule's NOC address resolver) whose contract is
+    // to resolve an address to a pointer once and let the caller memcpy. Returns nullptr on a miss.
+    void* get_mapped_host_ptr(uint64_t device_io_addr, uint32_t size);
+
 protected:
     bool init_sysmem(uint32_t num_host_mem_channels) override;
 

--- a/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
@@ -58,7 +58,9 @@ public:
     // kernel's in-place read/write. The pointer is valid only while the mapped buffer stays
     // mapped: the caller must not retain it across an unpin_or_unmap_sysmem()/SysmemBuffer
     // teardown. The registry lock guards the lookup, not the returned pointer's lifetime.
-    void* get_mapped_host_ptr(uint64_t device_io_addr, uint32_t size);
+    // This is a pure address translation — the caller owns the access length (the returned bare
+    // pointer carries none); the bounded copies write/read_mapped_buffer are where a size is checked.
+    void* get_mapped_host_ptr(uint64_t device_io_addr);
 
 protected:
     bool init_sysmem(uint32_t num_host_mem_channels) override;

--- a/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
@@ -50,9 +50,14 @@ public:
     bool write_mapped_buffer(uint64_t device_io_addr, const void* src, uint32_t size);
     bool read_mapped_buffer(uint64_t device_io_addr, void* dst, uint32_t size);
 
-    // Same lookup as write/read_mapped_buffer, but returns the host pointer directly instead of
-    // performing the copy — for callers (e.g. tt-emule's NOC address resolver) whose contract is
-    // to resolve an address to a pointer once and let the caller memcpy. Returns nullptr on a miss.
+    // Zero-copy address→host-pointer lookup (nullptr on a miss). Unlike
+    // write/read_mapped_buffer, which copy, this returns the mapping directly for in-place
+    // access. emule needs it: its NOC address resolver (__emule_resolve_noc_addr) maps a
+    // host-facing (PCIe) NOC address to a host pointer the emulated kernel dereferences
+    // directly — the way silicon's NOC reaches host memory — and a copy cannot back the
+    // kernel's in-place read/write. The pointer is valid only while the mapped buffer stays
+    // mapped: the caller must not retain it across an unpin_or_unmap_sysmem()/SysmemBuffer
+    // teardown. The registry lock guards the lookup, not the returned pointer's lifetime.
     void* get_mapped_host_ptr(uint64_t device_io_addr, uint32_t size);
 
 protected:

--- a/device/chip/sw_emule_chip.cpp
+++ b/device/chip/sw_emule_chip.cpp
@@ -5,6 +5,7 @@
 #include "umd/device/chip/sw_emule_chip.hpp"
 
 #include <algorithm>
+#include <cassert>
 #include <cstring>
 #include <set>
 #include <stdexcept>
@@ -14,6 +15,7 @@
 
 #include "tt_emule/device.hpp"
 #include "tt_emule/l1_pool.hpp"
+#include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
 #include "umd/device/soc_descriptor.hpp"
 
 namespace tt::umd {
@@ -22,7 +24,9 @@ namespace tt::umd {
 SWEmuleChip::~SWEmuleChip() = default;
 
 SWEmuleChip::SWEmuleChip(const SocDescriptor& soc_descriptor) :
-    Chip(soc_descriptor.arch), soc_descriptor_(soc_descriptor) {
+    Chip(soc_descriptor.arch),
+    soc_descriptor_(soc_descriptor),
+    sysmem_manager_(std::make_unique<SimulationSysmemManager>(/*num_host_mem_channels=*/0, soc_descriptor.arch)) {
     auto& soc = get_soc_descriptor();
 
     l1_size_ = soc.worker_l1_size;
@@ -31,6 +35,11 @@ SWEmuleChip::SWEmuleChip(const SocDescriptor& soc_descriptor) :
     // offsets up to 1 GB within a 2 GB bank, so capping below bank size causes
     // writes to segfault.  Overcommit means only touched pages use physical RAM.
     dram_bank_size_ = soc.dram_bank_size;
+    // A real on-chip DRAM offset can't structurally exceed its own bank's capacity, so it can
+    // never reach __emule_resolve_noc_addr's pcie_base_ threshold (which routes >= addresses to
+    // SimulationSysmemManager instead of the core map) — documents that margin rather than
+    // resting on it implicitly.
+    assert(dram_bank_size_ < SysmemManager::get_pcie_base_for_arch(soc_descriptor.arch));
 
     // One slot per Tensix core (all coord namings for a worker resolve to one Core, and
     // only WORKER cores use the pool), so num_tensix is an exact bound — no padding. The
@@ -141,7 +150,7 @@ void SWEmuleChip::close_device() {}
 
 TTDevice* SWEmuleChip::get_tt_device() { return nullptr; }
 
-SysmemManager* SWEmuleChip::get_sysmem_manager() { return nullptr; }
+SysmemManager* SWEmuleChip::get_sysmem_manager() { return sysmem_manager_.get(); }
 
 TLBManager* SWEmuleChip::get_tlb_manager() { return nullptr; }
 

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -132,6 +132,15 @@ bool SimulationSysmemManager::read_mapped_buffer(uint64_t device_io_addr, void* 
     return true;
 }
 
+void* SimulationSysmemManager::get_mapped_host_ptr(uint64_t device_io_addr, uint32_t size) {
+    std::lock_guard<std::mutex> lock(registry_->mutex);
+    auto b = find_mapped_buffer_locked(device_io_addr, size);
+    if (!b.has_value()) {
+        return nullptr;
+    }
+    return static_cast<uint8_t*>(b->buffer) + (device_io_addr - b->device_io_addr);
+}
+
 std::unique_ptr<SysmemBuffer> SimulationSysmemManager::allocate_sysmem_buffer(
     size_t sysmem_buffer_size, const bool map_to_noc) {
     void* mapping =

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -132,9 +132,12 @@ bool SimulationSysmemManager::read_mapped_buffer(uint64_t device_io_addr, void* 
     return true;
 }
 
-void* SimulationSysmemManager::get_mapped_host_ptr(uint64_t device_io_addr, uint32_t size) {
+void* SimulationSysmemManager::get_mapped_host_ptr(uint64_t device_io_addr) {
     std::lock_guard<std::mutex> lock(registry_->mutex);
-    auto b = find_mapped_buffer_locked(device_io_addr, size);
+    // Pure address translation: locate the buffer holding this device IO address (1-byte
+    // membership) and return the in-place host pointer. The caller owns the access length, so no
+    // range is validated here — read_mapped_buffer/write_mapped_buffer are where a size is checked.
+    auto b = find_mapped_buffer_locked(device_io_addr, 1);
     if (!b.has_value()) {
         return nullptr;
     }

--- a/tests/api/test_simulation_sysmem_manager.cpp
+++ b/tests/api/test_simulation_sysmem_manager.cpp
@@ -181,6 +181,40 @@ TEST_P(ApiSimulationSysmemManagerByArch, WriteReadThroughMappedBuffer) {
     EXPECT_EQ(0, std::memcmp(buffer->get_buffer_va(), pattern.data(), pattern.size()));
 }
 
+// get_mapped_host_ptr resolves a device_io_addr to the in-place host pointer (zero-copy),
+// at the correct within-buffer offset, and returns nullptr for an unmapped address. This is
+// the accessor emule's NOC resolver uses to reach host sysmem in place.
+TEST_P(ApiSimulationSysmemManagerByArch, GetMappedHostPtrResolvesOffsetAndMiss) {
+    auto sysmem = std::make_unique<SimulationSysmemManager>(1, GetParam());
+
+    const size_t buffer_size = 4096;
+    auto buffer = sysmem->allocate_sysmem_buffer(buffer_size);
+    ASSERT_NE(buffer, nullptr);
+    const uint64_t device_addr = buffer->get_device_io_addr();
+    ASSERT_GT(device_addr, 0u);
+
+    // Base address resolves to the buffer VA; an interior address to VA + offset.
+    void* base_ptr = sysmem->get_mapped_host_ptr(device_addr, 1);
+    ASSERT_NE(base_ptr, nullptr);
+    EXPECT_EQ(base_ptr, buffer->get_buffer_va());
+
+    const uint64_t kOffset = 128;
+    void* mid_ptr = sysmem->get_mapped_host_ptr(device_addr + kOffset, 1);
+    ASSERT_NE(mid_ptr, nullptr);
+    EXPECT_EQ(mid_ptr, static_cast<uint8_t*>(buffer->get_buffer_va()) + kOffset);
+
+    // The pointer aliases the backing (zero-copy): a write through it is visible via read_mapped_buffer.
+    std::vector<uint8_t> pattern = {0x11, 0x22, 0x33, 0x44};
+    std::memcpy(base_ptr, pattern.data(), pattern.size());
+    std::vector<uint8_t> readback(pattern.size(), 0);
+    ASSERT_TRUE(sysmem->read_mapped_buffer(device_addr, readback.data(), readback.size()));
+    EXPECT_EQ(pattern, readback);
+
+    // A miss (address in no mapped buffer) returns nullptr.
+    EXPECT_EQ(sysmem->get_mapped_host_ptr(/*device_io_addr=*/1, 1), nullptr);
+    EXPECT_EQ(sysmem->get_mapped_host_ptr(device_addr + buffer_size, 1), nullptr);
+}
+
 TEST_P(ApiSimulationSysmemManagerByArch, MultipleMappedBuffersAreIndependent) {
     auto sysmem = std::make_unique<SimulationSysmemManager>(1, GetParam());
 

--- a/tests/api/test_simulation_sysmem_manager.cpp
+++ b/tests/api/test_simulation_sysmem_manager.cpp
@@ -194,12 +194,12 @@ TEST_P(ApiSimulationSysmemManagerByArch, GetMappedHostPtrResolvesOffsetAndMiss) 
     ASSERT_GT(device_addr, 0u);
 
     // Base address resolves to the buffer VA; an interior address to VA + offset.
-    void* base_ptr = sysmem->get_mapped_host_ptr(device_addr, 1);
+    void* base_ptr = sysmem->get_mapped_host_ptr(device_addr);
     ASSERT_NE(base_ptr, nullptr);
     EXPECT_EQ(base_ptr, buffer->get_buffer_va());
 
     const uint64_t kOffset = 128;
-    void* mid_ptr = sysmem->get_mapped_host_ptr(device_addr + kOffset, 1);
+    void* mid_ptr = sysmem->get_mapped_host_ptr(device_addr + kOffset);
     ASSERT_NE(mid_ptr, nullptr);
     EXPECT_EQ(mid_ptr, static_cast<uint8_t*>(buffer->get_buffer_va()) + kOffset);
 
@@ -210,9 +210,10 @@ TEST_P(ApiSimulationSysmemManagerByArch, GetMappedHostPtrResolvesOffsetAndMiss) 
     ASSERT_TRUE(sysmem->read_mapped_buffer(device_addr, readback.data(), readback.size()));
     EXPECT_EQ(pattern, readback);
 
-    // A miss (address in no mapped buffer) returns nullptr.
-    EXPECT_EQ(sysmem->get_mapped_host_ptr(/*device_io_addr=*/1, 1), nullptr);
-    EXPECT_EQ(sysmem->get_mapped_host_ptr(device_addr + buffer_size, 1), nullptr);
+    // A miss (address in no mapped buffer) returns nullptr — derived from the buffer's own bounds:
+    // one byte below its start, and one past its end.
+    EXPECT_EQ(sysmem->get_mapped_host_ptr(device_addr - 1), nullptr);
+    EXPECT_EQ(sysmem->get_mapped_host_ptr(device_addr + buffer_size), nullptr);
 }
 
 TEST_P(ApiSimulationSysmemManagerByArch, MultipleMappedBuffersAreIndependent) {


### PR DESCRIPTION
### Issue
Part of the tt-emule software-emulator host-facing socket bring-up (companions: tt-metal #51107,
tt-emule-blaze #155). No standalone tt-umd issue.

### Description
`[do not merge]` — staging/reference edition (base `emule-umd-delta`), the umd the emulator builds
and verifies against; the upstream (main-based) counterpart is #3076. This is the final slice of the
software-emulated-chip work: it wires `SWEmuleChip` up to a real `SimulationSysmemManager` so a
device-IO address at/above `pcie_base` resolves to a **host-mapped** buffer — the substrate that lets
an emulated kernel reach host sysmem the way silicon's NOC does (the H2D/D2H host-fed socket path).
The earlier emule-chip slices (DRAM per-channel backing, worker-L1 pool sizing, RISC-reset-broadcast
skip) already live in the base and are not part of this change.

### List of the changes
- `SWEmuleChip` owns a `SimulationSysmemManager` (`num_host_mem_channels = 0`); `get_sysmem_manager()`
  now returns it instead of `nullptr`.
- New `SimulationSysmemManager::get_mapped_host_ptr(device_io_addr, size)` — a **zero-copy** lookup
  that returns the host mapping directly (vs the copying `write/read_mapped_buffer`), so the emule
  NOC resolver can dereference host sysmem in place; documents its lifetime contract (valid only
  while the buffer stays mapped; the registry lock guards the lookup, not the pointer).
- Constructor assert `dram_bank_size_ < get_pcie_base_for_arch(arch)` — a structural guarantee that a
  real on-chip DRAM offset can never reach the host-facing `pcie_base` threshold.
- New `api_tests` case `GetMappedHostPtrResolvesOffsetAndMiss` (offset resolve, zero-copy aliasing,
  miss → `nullptr`).

### Testing
`api_tests` pass on Wormhole B0 + Blackhole (incl. the new `get_mapped_host_ptr` case; 19/19). Part
of the staging edition the emule runner builds/verifies green (p150 `--gate` 452/0, loudbox 15/15).

### API Changes
This PR has API changes: adds public `SimulationSysmemManager::get_mapped_host_ptr`; `SWEmuleChip::get_sysmem_manager()`
now returns a live manager rather than `nullptr`.
