### PR TITLE
Change set_power_state() TTDevice API to use PowerState enum

### DIFF
--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -129,6 +129,14 @@ public:
     };
 
     /**
+     * @brief Defines the requested power domain state for the device.
+     */
+    enum class PowerState {
+        BUSY,  ///< Claims all power domains, requesting maximum performance.
+        IDLE,  ///< Releases power domains, allowing the device to enter lower power states.
+    };
+
+    /**
      * Check if the PCIe communication is hung.
      *
      * Reads a known register over BAR and compares the result against the hang
@@ -371,12 +379,13 @@ public:
     FirmwareInfoProvider *get_firmware_info_provider() const;
 
     /**
-     * Request full power domains from KMD (busy=true) or release them (busy=false).
-     * No-op for remote devices and on KMD versions older than 2.6.0.
+     * @brief Requests a hardware power domain state change.
      *
-     * @param busy true to claim all power domains, false to release them.
+     * Claims or releases full power domains. No-op for remote devices.
+     *
+     * @param state The requested power state (BUSY or IDLE).
      */
-    virtual void set_power_state(bool busy);
+    virtual void set_power_state(PowerState state, NocId noc_id = NocId::DEFAULT_NOC);
 
     /**
      * Set the device clock (AICLK) state by sending the corresponding power-state request to device

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -69,7 +69,7 @@ LocalChip::LocalChip(
     tlb_manager_(std::move(tlb_manager)),
     sysmem_manager_(std::move(sysmem_manager)),
     tt_device_(std::move(tt_device)) {
-    tt_device_->set_power_state(true);
+    tt_device_->set_power_state(TTDevice::PowerState::BUSY);
     wait_chip_to_be_ready();
     if (tlb_manager_ != nullptr) {
         initialize_default_chip_mutexes();
@@ -79,7 +79,7 @@ LocalChip::LocalChip(
 LocalChip::~LocalChip() {
     // Deconstruct the LocalChip in the right order.
     // TODO: Use intializers in constructor to avoid having to explicitly declare the order of destruction.
-    tt_device_->set_power_state(false);
+    tt_device_->set_power_state(TTDevice::PowerState::IDLE);
     cached_wc_tlb_window.reset();
     cached_uc_tlb_window.reset();
     sysmem_manager_.reset();

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -182,7 +182,7 @@ void TopologyDiscovery::get_connected_devices() {
                 "file descriptors.");
         } else {
             // set_power_state is currently a no-op until https://github.com/tenstorrent/tt-umd/issues/2531 is resolved.
-            tt_device->set_power_state(true);
+            tt_device->set_power_state(TTDevice::PowerState::BUSY);
         }
         if (tt_device->get_arch() != get_topology_arch()) {
             log_warning(

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -273,11 +273,11 @@ RemoteCommunication *TTDevice::get_remote_communication() {
     return get_remote_interface()->get_remote_communication();
 }
 
-void TTDevice::set_power_state(bool busy) {
+void TTDevice::set_power_state(TTDevice::PowerState state, NocId /*noc_id*/) {
     if (is_remote_tt_device || !pcie_capabilities_) {
         return;
     }
-    get_pci_device()->set_power_state(busy);
+    get_pci_device()->set_power_state(state == TTDevice::PowerState::BUSY);
 }
 
 void TTDevice::set_clock_state(DevicePowerState /*state*/) {

--- a/nanobind/py_api_tt_device.cpp
+++ b/nanobind/py_api_tt_device.cpp
@@ -232,6 +232,10 @@ void bind_tt_device(nb::module_ &m) {
         .value("Throw", TTDevice::HangAction::THROW)
         .value("ReturnValue", TTDevice::HangAction::RETURN);
 
+    nb::enum_<TTDevice::PowerState>(tt_device_class, "PowerState")
+        .value("BUSY", TTDevice::PowerState::BUSY)
+        .value("IDLE", TTDevice::PowerState::IDLE);
+
     tt_device_class
         .def_static(
             "create",
@@ -243,7 +247,12 @@ void bind_tt_device(nb::module_ &m) {
             nb::arg("soc_arch_descriptor") = nullptr,
             nb::rv_policy::take_ownership,
             release_gil())
-        .def("set_power_state", &TTDevice::set_power_state, nb::arg("busy"), release_gil())
+        .def(
+            "set_power_state",
+            &TTDevice::set_power_state,
+            nb::arg("state"),
+            nb::arg("noc_id") = NocId::DEFAULT_NOC,
+            release_gil())
         .def(
             "init_tt_device",
             &TTDevice::init_tt_device,

--- a/nanobind/tests/test_py_soc_descriptor.py
+++ b/nanobind/tests/test_py_soc_descriptor.py
@@ -19,7 +19,7 @@ class TestSocDescriptor(unittest.TestCase):
         # Test with all available devices
         for pci_id in pci_ids:
             dev = tt_umd.TTDevice.create(pci_id)
-            dev.set_power_state(True)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.BUSY)
             dev.init_tt_device()
 
             print(f"\n=== Testing SocDescriptor on device {pci_id} ===")
@@ -95,7 +95,7 @@ class TestSocDescriptor(unittest.TestCase):
             all_cores = soc_descriptor.get_all_cores()
             print(f"Total cores: {len(all_cores)}")
             print(f"First 5 cores: {[str(c) for c in all_cores[:5]]}")
-            dev.set_power_state(False)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.IDLE)
 
     def test_translate_coord_to(self):
         """Test translate_coord_to method with both overloads."""
@@ -106,7 +106,7 @@ class TestSocDescriptor(unittest.TestCase):
 
         for pci_id in pci_ids:
             dev = tt_umd.TTDevice.create(pci_id)
-            dev.set_power_state(True)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.BUSY)
             dev.init_tt_device()
 
             print(f"\n=== Testing translate_coord_to on device {pci_id} ===")
@@ -118,7 +118,7 @@ class TestSocDescriptor(unittest.TestCase):
             )
             if len(tensix_cores) == 0:
                 print("No TENSIX cores found. Skipping translate_coord_to test.")
-                dev.set_power_state(False)
+                dev.set_power_state(tt_umd.TTDevice.PowerState.IDLE)
                 continue
 
             # Test first overload: translate_coord_to(CoreCoord, CoordSystem)
@@ -164,7 +164,7 @@ class TestSocDescriptor(unittest.TestCase):
                     target_coord_sys,
                     f"Translated core should have coord_system {target_coord_sys}",
                 )
-            dev.set_power_state(False)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.IDLE)
 
 
 if __name__ == "__main__":

--- a/nanobind/tests/test_py_spi_tt_device.py
+++ b/nanobind/tests/test_py_spi_tt_device.py
@@ -42,7 +42,7 @@ def setup_spi_test_devices():
     ):
         if cluster_descriptor.is_chip_mmio_capable(chip):
             umd_tt_devices[chip] = tt_umd.TTDevice.create(chip_to_mmio_map[chip])
-            umd_tt_devices[chip].set_power_state(True)
+            umd_tt_devices[chip].set_power_state(tt_umd.TTDevice.PowerState.BUSY)
             umd_tt_devices[chip].init_tt_device()
         else:
             closest_mmio = cluster_descriptor.get_closest_mmio_capable_chip(chip)

--- a/nanobind/tests/test_py_telemetry.py
+++ b/nanobind/tests/test_py_telemetry.py
@@ -16,7 +16,7 @@ class TestTelemetry(unittest.TestCase):
         # Test telemetry for all available devices
         for pci_id in pci_ids:
             dev = tt_umd.TTDevice.create(pci_id)
-            dev.set_power_state(True)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.BUSY)
             dev.init_tt_device()
             tel_reader = dev.get_arc_telemetry_reader()
             tag = int(tt_umd.TelemetryTag.ASIC_TEMPERATURE)
@@ -24,7 +24,7 @@ class TestTelemetry(unittest.TestCase):
                 f"Device {pci_id} - Telemetry reading for asic temperature: ",
                 tel_reader.read_entry(tag),
             )
-            dev.set_power_state(False)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.IDLE)
 
     def test_remote_telemetry(self):
         cluster_descriptor, umd_tt_devices = tt_umd.TopologyDiscovery.discover()
@@ -46,7 +46,7 @@ class TestTelemetry(unittest.TestCase):
         # Test SMBUS telemetry for all available devices
         for pci_id in pci_ids:
             dev = tt_umd.TTDevice.create(pci_id)
-            dev.set_power_state(True)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.BUSY)
             dev.init_tt_device()
 
             # Only test SMBUS telemetry on wormhole devices
@@ -59,7 +59,7 @@ class TestTelemetry(unittest.TestCase):
                         tt_umd.wormhole.TelemetryTag.ASIC_TEMPERATURE
                     )
                     print(f"Device {pci_id} - SMBUS telemetry ASIC temperature: {temp}")
-            dev.set_power_state(False)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.IDLE)
 
     def test_gddr_telemetry(self):
         """Test GDDR telemetry (temperatures, errors, status) for DRAM monitoring."""
@@ -70,7 +70,7 @@ class TestTelemetry(unittest.TestCase):
 
         for pci_id in pci_ids:
             dev = tt_umd.TTDevice.create(pci_id)
-            dev.set_power_state(True)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.BUSY)
             dev.init_tt_device()
 
             fw_info = tt_umd.FirmwareInfoProvider.create_firmware_info_provider(dev)
@@ -85,14 +85,14 @@ class TestTelemetry(unittest.TestCase):
                 print(
                     f"Device {pci_id} - Skipping detailed GDDR telemetry (not Blackhole, arch={dev.get_arch()})"
                 )
-                dev.set_power_state(False)
+                dev.set_power_state(tt_umd.TTDevice.PowerState.IDLE)
                 continue
 
             # Test aggregated GDDR telemetry
             gddr_telemetry = fw_info.get_aggregated_dram_telemetry()
             if gddr_telemetry is None:
                 print(f"Device {pci_id} - GDDR telemetry not available")
-                dev.set_power_state(False)
+                dev.set_power_state(tt_umd.TTDevice.PowerState.IDLE)
                 continue
 
             # Test max DRAM temperature
@@ -127,4 +127,4 @@ class TestTelemetry(unittest.TestCase):
                         f"top={module_telemetry.dram_temperature_top}C "
                         f"bottom={module_telemetry.dram_temperature_bottom}C"
                     )
-            dev.set_power_state(False)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.IDLE)

--- a/nanobind/tests/test_py_tt_device.py
+++ b/nanobind/tests/test_py_tt_device.py
@@ -15,7 +15,7 @@ class TestTTDevice(unittest.TestCase):
 
         for pci_id in pci_ids:
             dev = tt_umd.TTDevice.create(pci_id)
-            dev.set_power_state(True)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.BUSY)
             dev.init_tt_device()
             print(
                 f"TTDevice id {pci_id} has arch {dev.get_arch()} and board id {dev.get_board_id()}"
@@ -155,7 +155,7 @@ class TestTTDevice(unittest.TestCase):
             # device data.
             with self.assertRaises(BufferError):
                 dev.noc_read(0, tensix_core.x, tensix_core.y, 0x300, bytes(buffer_size))
-            dev.set_power_state(False)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.IDLE)
 
     def test_dma_tt_device(self):
         pci_ids = tt_umd.PCIDevice.enumerate_devices()
@@ -166,11 +166,11 @@ class TestTTDevice(unittest.TestCase):
 
         for pci_id in pci_ids:
             dev = tt_umd.TTDevice.create(pci_id)
-            dev.set_power_state(True)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.BUSY)
             dev.init_tt_device()
             if dev.is_remote():
                 print(f"Skipping remote device {pci_id} for DMA test")
-                dev.set_power_state(False)
+                dev.set_power_state(tt_umd.TTDevice.PowerState.IDLE)
                 continue
 
             # On Blackhole, dma_read_from_device is not supported; fall back to noc_read.
@@ -270,7 +270,7 @@ class TestTTDevice(unittest.TestCase):
             # rejected with a BufferError.
             with self.assertRaises(BufferError):
                 read_fn(0, tensix_core.x, tensix_core.y, 0x300, bytes(buffer_size))
-            dev.set_power_state(False)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.IDLE)
 
     def test_remote_tt_device(self):
         cluster_descriptor, umd_tt_devices = tt_umd.TopologyDiscovery.discover()
@@ -320,7 +320,7 @@ class TestTTDevice(unittest.TestCase):
 
         for dev_id in pci_ids:
             dev = tt_umd.TTDevice.create(dev_id)
-            dev.set_power_state(True)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.BUSY)
             dev.init_tt_device()
             arch = dev.get_arch()
             print(f"Testing arc_msg on device {dev_id} with arch {arch}")
@@ -340,7 +340,7 @@ class TestTTDevice(unittest.TestCase):
                 f"arc_msg result: exit_code={exit_code:#x}, return_3={return_3:#x}, return_4={return_4:#x}"
             )
             self.assertEqual(exit_code, 0, "arc_msg should succeed")
-            dev.set_power_state(False)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.IDLE)
 
     def test_arc_msg_test_increment(self):
         """TEST (0x90) increments arg0 and returns it. Call twice to verify arg passing and return values."""
@@ -351,7 +351,7 @@ class TestTTDevice(unittest.TestCase):
 
         for dev_id in pci_ids:
             dev = tt_umd.TTDevice.create(dev_id)
-            dev.set_power_state(True)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.BUSY)
             dev.init_tt_device()
             arch = dev.get_arch()
             print(f"Testing arc_msg TEST increment on device {dev_id} with arch {arch}")
@@ -378,7 +378,7 @@ class TestTTDevice(unittest.TestCase):
             print(f"Call 2: exit_code={exit_code:#x}, return_3={return_3:#x}")
             self.assertEqual(exit_code, 0)
             self.assertEqual(return_3, expected_value)
-            dev.set_power_state(False)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.IDLE)
 
     def test_get_chip_info(self):
         """Test get_chip_info method."""
@@ -389,7 +389,7 @@ class TestTTDevice(unittest.TestCase):
 
         for pci_id in pci_ids:
             dev = tt_umd.TTDevice.create(pci_id)
-            dev.set_power_state(True)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.BUSY)
             dev.init_tt_device()
 
             chip_info = dev.get_chip_info()
@@ -414,7 +414,7 @@ class TestTTDevice(unittest.TestCase):
             print(
                 f"    l2cpu_harvesting_mask: {chip_info.harvesting_masks.l2cpu_harvesting_mask}"
             )
-            dev.set_power_state(False)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.IDLE)
 
     def test_use_noc1(self):
         """Test use_noc1 static method."""
@@ -430,7 +430,7 @@ class TestTTDevice(unittest.TestCase):
         # Perform basic read/write operations to verify use_noc1 works
         for pci_id in pci_ids:
             dev = tt_umd.TTDevice.create(pci_id)
-            dev.set_power_state(True)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.BUSY)
             dev.init_tt_device()
             print(
                 f"TTDevice id {pci_id} has arch {dev.get_arch()} and board id {dev.get_board_id()}"
@@ -455,7 +455,7 @@ class TestTTDevice(unittest.TestCase):
                 read_data, test_data, "Read data should match written data"
             )
             dev.noc_write(tensix_core.x, tensix_core.y, 0x200, original_data)  # Restore
-            dev.set_power_state(False)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.IDLE)
 
         tt_umd.set_thread_noc_id(tt_umd.NocId.NOC0)
         print("Set thread NocId back to NOC0")
@@ -500,12 +500,12 @@ class TestTTDevice(unittest.TestCase):
 
         for pci_id in pci_ids:
             dev = tt_umd.TTDevice.create(pci_id)
-            dev.set_power_state(True)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.BUSY)
             dev.init_tt_device()
 
             if dev.is_remote():
                 print(f"Skipping remote device {pci_id}")
-                dev.set_power_state(False)
+                dev.set_power_state(tt_umd.TTDevice.PowerState.IDLE)
                 continue
 
             # A healthy device should return False for all hang checks.
@@ -519,4 +519,4 @@ class TestTTDevice(unittest.TestCase):
                     )
                 )
 
-            dev.set_power_state(False)
+            dev.set_power_state(tt_umd.TTDevice.PowerState.IDLE)

--- a/tests/api/test_arc_telemetry.cpp
+++ b/tests/api/test_arc_telemetry.cpp
@@ -30,7 +30,7 @@ TEST(TestTelemetry, BasicTelemetry) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
         if (tt_device->get_firmware_version() < FirmwareBundleVersion(18, 4, 0)) {
             log_warning(
@@ -49,7 +49,7 @@ TEST(TestTelemetry, BasicTelemetry) {
         const uint64_t board_id = ((uint64_t)board_id_high << 32) | (board_id_low);
         EXPECT_NO_THROW(get_board_type_from_board_id(board_id));
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }
 
@@ -58,7 +58,7 @@ TEST(TestTelemetry, TelemetryEntryAvailable) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
         ArcTelemetryReader* arc_telemetry_reader = tt_device->get_arc_telemetry_reader();
 
@@ -68,7 +68,7 @@ TEST(TestTelemetry, TelemetryEntryAvailable) {
         // Blackhole tag table is still not finalized, but we are probably never going to have 200 tags.
         EXPECT_FALSE(arc_telemetry_reader->is_entry_available(200));
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }
 

--- a/tests/api/test_firmware_info_provider.cpp
+++ b/tests/api/test_firmware_info_provider.cpp
@@ -81,7 +81,7 @@ public:
         std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
         for (int pci_device_id : pci_device_ids) {
             auto tt_device = TTDevice::create(pci_device_id);
-            tt_device->set_power_state(true);
+            tt_device->set_power_state(TTDevice::PowerState::BUSY);
             tt_device->init_tt_device();
             ASSERT_NE(tt_device->get_firmware_info_provider(), nullptr);
             tt_devices_.push_back(std::move(tt_device));
@@ -90,7 +90,7 @@ public:
 
     void TearDown() override {
         for (auto& tt_device : tt_devices_) {
-            tt_device->set_power_state(false);
+            tt_device->set_power_state(TTDevice::PowerState::IDLE);
         }
     }
 
@@ -754,7 +754,7 @@ TEST_F(TestFirmwareInfoProvider, RuntimeTelemetryBufferAddressAndSize) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
         FirmwareInfoProvider* fw_info = tt_device->get_firmware_info_provider();
@@ -774,6 +774,6 @@ TEST_F(TestFirmwareInfoProvider, RuntimeTelemetryBufferAddressAndSize) {
             EXPECT_TRUE(size.has_value());
             EXPECT_TRUE(address.has_value());
         }
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -38,7 +38,7 @@ TEST(ApiSysmemManager, BasicIO) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
 
         // Initializes system memory with one channel.
         std::unique_ptr<SysmemManager> sysmem = std::make_unique<SiliconSysmemManager>(tt_device.get(), 1);
@@ -65,7 +65,7 @@ TEST(ApiSysmemManager, BasicIO) {
         sysmem->read_from_sysmem(0, data_read.data(), 0x100, data_read.size() * sizeof(uint32_t));
         EXPECT_EQ(data_write, data_read);
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }
 

--- a/tests/api/test_tlb_manager.cpp
+++ b/tests/api/test_tlb_manager.cpp
@@ -45,7 +45,7 @@ TEST_F(ApiTLBManager, ManualTLBConfiguration) {
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
         const size_t tlb_tensix_size = tt_device->get_arch() == tt::ARCH::WORMHOLE_B0 ? (1 << 20) : (1 << 21);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
         std::unique_ptr<TLBManager> tlb_manager = std::make_unique<TLBManager>(tt_device.get());
@@ -66,6 +66,6 @@ TEST_F(ApiTLBManager, ManualTLBConfiguration) {
         TlbWindow* window = tlb_manager->get_tlb_window(any_worker_translated_core);
         window->write_register(SAFE_IO_L1_ADDRESS, buffer_to_write.data(), buffer_to_write.size());
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -41,7 +41,7 @@ TEST(ApiTTDeviceTest, BasicTTDeviceIO) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
         const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
@@ -58,7 +58,7 @@ TEST(ApiTTDeviceTest, BasicTTDeviceIO) {
 
         data_read = std::vector<uint32_t>(data_write.size(), 0);
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }
 
@@ -71,7 +71,7 @@ TEST(ApiTTDeviceTest, TTDeviceRegIO) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
         uint64_t address = tt_device->get_architecture_implementation()->get_debug_reg_addr();
 
@@ -89,7 +89,7 @@ TEST(ApiTTDeviceTest, TTDeviceRegIO) {
         ASSERT_EQ(data_write1, data_read);
         data_read = std::vector<uint32_t>(data_write0.size(), 0);
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }
 
@@ -98,7 +98,7 @@ TEST(ApiTTDeviceTest, TTDeviceRegUnalignedThrows) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
         const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
@@ -112,7 +112,7 @@ TEST(ApiTTDeviceTest, TTDeviceRegUnalignedThrows) {
         EXPECT_ANY_THROW(tt_device->write_to_device_reg(&buf, tensix_core, SAFE_IO_L1_ADDRESS, 5));
         EXPECT_ANY_THROW(tt_device->read_from_device_reg(&buf, tensix_core, SAFE_IO_L1_ADDRESS, 5));
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }
 
@@ -120,7 +120,7 @@ TEST(ApiTTDeviceTest, TTDeviceGetBoardType) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
         BoardType board_type = tt_device->get_board_type();
@@ -130,7 +130,7 @@ TEST(ApiTTDeviceTest, TTDeviceGetBoardType) {
             board_type == BoardType::P150 || board_type == BoardType::P300 || board_type == BoardType::UBB ||
             board_type == BoardType::UBB_BLACKHOLE);
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }
 
@@ -145,7 +145,7 @@ TEST(ApiTTDeviceTest, TTDeviceMultipleThreadsIO) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
         const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
 
@@ -184,7 +184,7 @@ TEST(ApiTTDeviceTest, TTDeviceMultipleThreadsIO) {
         thread0.join();
         thread1.join();
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }
 
@@ -252,7 +252,7 @@ TEST(ApiTTDeviceTest, MulticastIO) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
         for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
@@ -283,7 +283,7 @@ TEST(ApiTTDeviceTest, MulticastIO) {
             }
         }
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }
 
@@ -294,7 +294,7 @@ TEST(ApiTTDeviceTest, BroadcastIO) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
         const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
@@ -324,7 +324,7 @@ TEST(ApiTTDeviceTest, BroadcastIO) {
                                             << " should have received the broadcast write.";
         }
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }
 
@@ -332,7 +332,7 @@ TEST(ApiTTDeviceTest, UninitializedError) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
 
         // These methods should work without initialization.
         EXPECT_NO_THROW(tt_device->get_arc_core());

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -381,7 +381,7 @@ TEST(ApiTTDeviceTest, UninitializedIO) {
     std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
         CoreCoord tensix_core = tt_device->get_soc_descriptor().get_cores(tt::CoreType::TENSIX).at(0);
@@ -390,7 +390,7 @@ TEST(ApiTTDeviceTest, UninitializedIO) {
         tt_device.reset();
 
         tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         using err = error::UmdException<error::UnresolvableCoordinateError>;
 
         const uint32_t value = 0xAABB;

--- a/tests/api/test_warm_reset.cpp
+++ b/tests/api/test_warm_reset.cpp
@@ -111,7 +111,7 @@ TEST_P(WarmResetParamTest, DISABLED_SafeApiHandlesReset) {
 
     for (int pci_device_id : pci_device_ids) {
         tt_devices[pci_device_id] = TTDevice::create(pci_device_id, IODeviceType::PCIe, true);
-        tt_devices[pci_device_id]->set_power_state(true);
+        tt_devices[pci_device_id]->set_power_state(TTDevice::PowerState::BUSY);
 
         tt_devices[pci_device_id]->init_tt_device();
 
@@ -185,7 +185,7 @@ TEST(WarmResetTest, DISABLED_SafeApiMultiThreaded) {
 
     for (int pci_device_id : pci_device_ids) {
         tt_devices[pci_device_id] = TTDevice::create(pci_device_id, IODeviceType::PCIe, true);
-        tt_devices[pci_device_id]->set_power_state(true);
+        tt_devices[pci_device_id]->set_power_state(TTDevice::PowerState::BUSY);
 
         tt_devices[pci_device_id]->init_tt_device();
 
@@ -245,7 +245,7 @@ TEST(WarmResetTest, DISABLED_SafeApiMultiProcess) {
 
             for (int pci_device_id : pci_device_ids) {
                 tt_devices[pci_device_id] = TTDevice::create(pci_device_id, IODeviceType::PCIe, true);
-                tt_devices[pci_device_id]->set_power_state(true);
+                tt_devices[pci_device_id]->set_power_state(TTDevice::PowerState::BUSY);
 
                 tt_devices[pci_device_id]->init_tt_device();
 

--- a/tests/blackhole/test_arc_messages_bh.cpp
+++ b/tests/blackhole/test_arc_messages_bh.cpp
@@ -24,7 +24,7 @@ TEST(BlackholeArcMessages, BlackholeArcMessagesBasic) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
 
         std::unique_ptr<ArcMessenger> bh_arc_messenger = ArcMessenger::create_arc_messenger(tt_device.get());
 
@@ -34,7 +34,7 @@ TEST(BlackholeArcMessages, BlackholeArcMessagesBasic) {
             ASSERT_EQ(response, 0);
         }
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }
 
@@ -43,7 +43,7 @@ TEST(BlackholeArcMessages, BlackholeArcMessageArgPassing) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
 
         std::unique_ptr<ArcMessenger> bh_arc_messenger = ArcMessenger::create_arc_messenger(tt_device.get());
 
@@ -57,7 +57,7 @@ TEST(BlackholeArcMessages, BlackholeArcMessageArgPassing) {
         ASSERT_FALSE(return_values.empty());
         EXPECT_EQ(return_values[0], random_arg + 1);
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }
 
@@ -66,7 +66,7 @@ TEST(BlackholeArcMessages, BlackholeArcMessageReturnValues) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
 
         std::unique_ptr<ArcMessenger> bh_arc_messenger = ArcMessenger::create_arc_messenger(tt_device.get());
 
@@ -78,7 +78,7 @@ TEST(BlackholeArcMessages, BlackholeArcMessageReturnValues) {
         ASSERT_FALSE(return_values.empty());
         EXPECT_GT(return_values[0], 0u);
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }
 
@@ -89,7 +89,7 @@ TEST(BlackholeArcMessages, BlackholeArcMessageHigherAIClock) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
         std::unique_ptr<ArcMessenger> bh_arc_messenger = ArcMessenger::create_arc_messenger(tt_device.get());
@@ -114,7 +114,7 @@ TEST(BlackholeArcMessages, BlackholeArcMessageHigherAIClock) {
 
         EXPECT_EQ(aiclk, blackhole::AICLK_IDLE_VAL);
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }
 
@@ -125,7 +125,7 @@ TEST(BlackholeArcMessages, MultipleThreadsArcMessages) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
         std::thread thread0([&]() {
@@ -148,6 +148,6 @@ TEST(BlackholeArcMessages, MultipleThreadsArcMessages) {
         thread0.join();
         thread1.join();
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }

--- a/tests/blackhole/test_chip_info_bh.cpp
+++ b/tests/blackhole/test_chip_info_bh.cpp
@@ -21,7 +21,7 @@ TEST(BlackholeChipInfo, BasicChipInfo) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
         const ChipInfo chip_info = tt_device->get_chip_info();
@@ -49,6 +49,6 @@ TEST(BlackholeChipInfo, BasicChipInfo) {
             }
         }
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }

--- a/tests/hang_detection/test_warm_reset_after_noc_hang.cpp
+++ b/tests/hang_detection/test_warm_reset_after_noc_hang.cpp
@@ -68,7 +68,7 @@ TEST_F(WarmResetAfterNocHangTest, TTDeviceWarmResetAfterNocHang) {
     std::vector<uint8_t> readback_data(data.size(), 0);
 
     std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_ids.at(0));
-    tt_device->set_power_state(true);
+    tt_device->set_power_state(TTDevice::PowerState::BUSY);
     tt_device->init_tt_device();
 
     const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
@@ -100,7 +100,7 @@ TEST_F(WarmResetAfterNocHangTest, TTDeviceWarmResetAfterNocHang) {
     tt_device.reset();
 
     tt_device = TTDevice::create(pci_device_ids.at(0));
-    tt_device->set_power_state(true);
+    tt_device->set_power_state(TTDevice::PowerState::BUSY);
     tt_device->init_tt_device();
 
     tt_device->write_to_device(zero_data.data(), tensix_core, SAFE_IO_L1_ADDRESS, zero_data.size());
@@ -111,5 +111,5 @@ TEST_F(WarmResetAfterNocHangTest, TTDeviceWarmResetAfterNocHang) {
 
     ASSERT_EQ(data, readback_data);
 
-    tt_device->set_power_state(false);
+    tt_device->set_power_state(TTDevice::PowerState::IDLE);
 }

--- a/tests/unified/multiprocess.cpp
+++ b/tests/unified/multiprocess.cpp
@@ -228,7 +228,7 @@ TEST(Multiprocess, WorkloadVSMonitor) {
     auto low_level_monitor_thread = std::thread([&] {
         std::cout << "Creating low level monitor cluster" << std::endl;
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_ids.at(0));
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
         const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
@@ -240,7 +240,7 @@ TEST(Multiprocess, WorkloadVSMonitor) {
             tt_device->read_from_device(&example_read, arc_core, 0x8003042C, sizeof(uint32_t));
         }
         std::cout << "Destroying low level monitor cluster" << std::endl;
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     });
 
     workload_thread.join();
@@ -254,7 +254,7 @@ TEST(Multiprocess, LongLivedMonitor) {
     auto low_level_monitor_thread = std::thread([&] {
         std::cout << "Creating low level monitor cluster" << std::endl;
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_ids.at(0));
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
         const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
@@ -266,7 +266,7 @@ TEST(Multiprocess, LongLivedMonitor) {
             tt_device->read_from_device(&example_read, arc_core, 0x8003042C, sizeof(uint32_t));
         }
         std::cout << "Destroying low level monitor cluster" << std::endl;
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     });
 
     for (int i = 0; i < NUM_PARALLEL; i++) {
@@ -354,7 +354,7 @@ TEST(Multiprocess, DMAWriteReadRaceCondition) {
 
             // Each process creates its own TTDevice object with the same PCIDevice.
             std::unique_ptr<TTDevice> tt_device = TTDevice::create(test_device_id);
-            tt_device->set_power_state(true);
+            tt_device->set_power_state(TTDevice::PowerState::BUSY);
             tt_device->init_tt_device();
 
             const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
@@ -396,7 +396,7 @@ TEST(Multiprocess, DMAWriteReadRaceCondition) {
 
             std::cout << "Process " << process_id << ": Completed " << num_iterations << " DMA operations successfully"
                       << std::endl;
-            tt_device->set_power_state(false);
+            tt_device->set_power_state(TTDevice::PowerState::IDLE);
         }));
     }
 
@@ -429,7 +429,7 @@ TEST(Multiprocess, DISABLED_DMAWriteReadRaceConditionProcessIsolation) {
 
             // Each process creates its own TTDevice object with the same PCIDevice.
             std::unique_ptr<TTDevice> tt_device = TTDevice::create(test_device_id);
-            tt_device->set_power_state(true);
+            tt_device->set_power_state(TTDevice::PowerState::BUSY);
             tt_device->init_tt_device();
 
             const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();

--- a/tests/wormhole/test_arc_telemetry_wh.cpp
+++ b/tests/wormhole/test_arc_telemetry_wh.cpp
@@ -15,7 +15,7 @@ TEST(WormholeTelemetry, BasicWormholeTelemetry) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
         std::unique_ptr<ArcTelemetryReader> blackhole_arc_telemetry_reader =
@@ -28,7 +28,7 @@ TEST(WormholeTelemetry, BasicWormholeTelemetry) {
         const uint64_t board_id = ((uint64_t)board_id_high << 32) | (board_id_low);
         EXPECT_NO_THROW(get_board_type_from_board_id(board_id));
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }
 
@@ -37,7 +37,7 @@ TEST(WormholeTelemetry, WormholeTelemetryEntryAvailable) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
         std::unique_ptr<ArcTelemetryReader> telemetry =
@@ -49,7 +49,7 @@ TEST(WormholeTelemetry, WormholeTelemetryEntryAvailable) {
 
         EXPECT_FALSE(telemetry->is_entry_available(wormhole::LegacyTelemetryTag::NUMBER_OF_TAGS));
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }
 
@@ -58,7 +58,7 @@ TEST(TestTelemetry, CompareTwoTelemetryValues) {
 
     for (int pci_device_id : pci_device_ids) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
-        tt_device->set_power_state(true);
+        tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
         ArcTelemetryReader* arc_telemetry_reader = tt_device->get_arc_telemetry_reader();
 
@@ -81,6 +81,6 @@ TEST(TestTelemetry, CompareTwoTelemetryValues) {
             arc_telemetry_reader->read_entry(TelemetryTag::ETH_FW_VERSION),
             smbus_telemetry_reader->read_entry(wormhole::LegacyTelemetryTag::ETH_FW_VERSION));
 
-        tt_device->set_power_state(false);
+        tt_device->set_power_state(TTDevice::PowerState::IDLE);
     }
 }

--- a/tests/wormhole/test_remote_communication_wh.cpp
+++ b/tests/wormhole/test_remote_communication_wh.cpp
@@ -163,5 +163,5 @@ TEST(RemoteCommunicationWormhole, LargeTransferNoSysmem) {
         ASSERT_EQ(data_to_write[i], data_read[i]) << "Data mismatch at index " << i << ": expected 0x" << std::hex
                                                   << data_to_write[i] << " but got 0x" << data_read[i];
     }
-    remote_tt_device->get_remote_communication()->get_local_device()->set_power_state(false);
+    remote_tt_device->get_remote_communication()->get_local_device()->set_power_state(TTDevice::PowerState::IDLE);
 }


### PR DESCRIPTION
### Issue
#2863 

### Description
Replace the bool-based power state API on TTDevice with a proper enum, per the UMD Base API migration epic and the tt_device_doxy.hpp reference.

### List of the changes
 - Added TTDevice::PowerState enum class (BUSY, IDLE) matching the reference API spec
 - Changed TTDevice::set_power_state signature from (bool busy) to (PowerState state, NocId noc_id = NocId::DEFAULT_NOC)
 - Implementation still maps to PCIDevice::set_power_state(bool), since DeviceFirmware does not exist yet; noc_id is accepted but currently unused, matching the proposed API shape
 - Migrated all callers off the bool API: local_chip.cpp, topology_discovery.cpp
 - Exposed TTDevice::PowerState in the Python bindings (nanobind) and updated the set_power_state binding
 - Updated all test call sites (tests/api, tests/blackhole, tests/wormhole, tests/unified, tests/hang_detection) to use TTDevice::PowerState::BUSY / IDLE

### Testing
CI.

### API Changes
This PR has API changes.
