### PR TITLE
Change set_clock_state() TTDevice API to use PowerState enum and remove SHORT_IDLE

### DIFF
--- a/device/api/umd/device/arch/architecture_implementation.hpp
+++ b/device/api/umd/device/arch/architecture_implementation.hpp
@@ -37,7 +37,6 @@ public:
     virtual uint32_t get_arc_message_arc_get_harvesting() const = 0;
     virtual uint32_t get_arc_message_arc_go_busy() const = 0;
     virtual uint32_t get_arc_message_arc_go_long_idle() const = 0;
-    virtual uint32_t get_arc_message_arc_go_short_idle() const = 0;
     virtual uint32_t get_arc_message_deassert_riscv_reset() const = 0;
     virtual uint32_t get_arc_message_get_aiclk() const = 0;
     virtual uint32_t get_arc_message_setup_iatu_for_peer_to_peer() const = 0;

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -58,7 +58,6 @@ enum class arc_message_type {
     NOP = 0x11,  // Do nothing
     GET_AICLK = 0x34,
     ARC_GO_BUSY = 0x52,
-    ARC_GO_SHORT_IDLE = 0x53,
     ARC_GO_LONG_IDLE = 0x54,
     ARC_GET_HARVESTING = 0x57,
     SET_ETH_DRAM_TRAINED_STATUS = 0x58,
@@ -346,10 +345,6 @@ public:
 
     uint32_t get_arc_message_arc_go_long_idle() const override {
         return static_cast<uint32_t>(blackhole::arc_message_type::ARC_GO_LONG_IDLE);
-    }
-
-    uint32_t get_arc_message_arc_go_short_idle() const override {
-        return static_cast<uint32_t>(blackhole::arc_message_type::ARC_GO_SHORT_IDLE);
     }
 
     uint32_t get_arc_message_deassert_riscv_reset() const override {

--- a/device/api/umd/device/arch/grendel_implementation.hpp
+++ b/device/api/umd/device/arch/grendel_implementation.hpp
@@ -58,7 +58,6 @@ enum class arc_message_type {
     NOP = 0x11,  // Do nothing
     GET_AICLK = 0x34,
     ARC_GO_BUSY = 0x52,
-    ARC_GO_SHORT_IDLE = 0x53,
     ARC_GO_LONG_IDLE = 0x54,
     ARC_GET_HARVESTING = 0x57,
     SET_ETH_DRAM_TRAINED_STATUS = 0x58,
@@ -337,10 +336,6 @@ public:
 
     uint32_t get_arc_message_arc_go_long_idle() const override {
         return static_cast<uint32_t>(grendel::arc_message_type::ARC_GO_LONG_IDLE);
-    }
-
-    uint32_t get_arc_message_arc_go_short_idle() const override {
-        return static_cast<uint32_t>(grendel::arc_message_type::ARC_GO_SHORT_IDLE);
     }
 
     uint32_t get_arc_message_deassert_riscv_reset() const override {

--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -105,7 +105,6 @@ enum class arc_message_type {
     GET_SMBUS_TELEMETRY_ADDR = 0x2C,
     GET_AICLK = 0x34,
     ARC_GO_BUSY = 0x52,
-    ARC_GO_SHORT_IDLE = 0x53,
     ARC_GO_LONG_IDLE = 0x54,
     ARC_GET_HARVESTING = 0x57,
     SET_ETH_DRAM_TRAINED_STATUS = 0x58,
@@ -384,10 +383,6 @@ public:
 
     uint32_t get_arc_message_arc_go_long_idle() const override {
         return static_cast<uint32_t>(wormhole::arc_message_type::ARC_GO_LONG_IDLE);
-    }
-
-    uint32_t get_arc_message_arc_go_short_idle() const override {
-        return static_cast<uint32_t>(wormhole::arc_message_type::ARC_GO_SHORT_IDLE);
     }
 
     uint32_t get_arc_message_deassert_riscv_reset() const override {

--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -34,7 +34,7 @@ public:
 
     uint32_t get_min_clock_freq() override;
 
-    void set_clock_state(DevicePowerState state) override;
+    void set_clock_state(PowerState state, NocId noc_id = NocId::DEFAULT_NOC) override;
 
     bool get_noc_translation_enabled() override;
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -33,7 +33,6 @@
 #include "umd/device/tt_device/protocol/remote_interface.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
-#include "umd/device/types/cluster_types.hpp"
 #include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/noc_id.hpp"
@@ -388,12 +387,14 @@ public:
     virtual void set_power_state(PowerState state, NocId noc_id = NocId::DEFAULT_NOC);
 
     /**
-     * Set the device clock (AICLK) state by sending the corresponding power-state request to device
-     * and waiting for the clock to settle at the expected frequency.
+     * @brief Sets the device clock frequency.
      *
-     * @param state Target clock state (BUSY, SHORT_IDLE or LONG_IDLE).
+     * Controls the AICLK frequency the device runs at. Distinct from
+     * set_power_state(), which manages hardware power domains.
+     *
+     * @param state The target clock state (BUSY = max frequency, IDLE = min frequency).
      */
-    virtual void set_clock_state(DevicePowerState state);
+    virtual void set_clock_state(PowerState state, NocId noc_id = NocId::DEFAULT_NOC);
 
     virtual uint32_t get_clock() = 0;
 
@@ -554,7 +555,7 @@ protected:
     // Polls AICLK until it reaches the frequency expected for `power_state`, or logs a warning and
     // returns on timeout.
     void wait_for_aiclk_value(
-        DevicePowerState power_state, const std::chrono::milliseconds timeout_ms = timeout::AICLK_TIMEOUT);
+        PowerState power_state, const std::chrono::milliseconds timeout_ms = timeout::AICLK_TIMEOUT);
 
     virtual uint32_t get_max_dram_retrain_attempts() const { return 0; }
 

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -31,7 +31,7 @@ public:
 
     uint32_t get_min_clock_freq() override;
 
-    void set_clock_state(DevicePowerState state) override;
+    void set_clock_state(PowerState state, NocId noc_id = NocId::DEFAULT_NOC) override;
 
     bool get_noc_translation_enabled() override;
 
@@ -71,7 +71,7 @@ protected:
 
 private:
     // Builds the ARC message (with the common prefix) that requests the given clock state.
-    uint32_t get_power_state_arc_msg(DevicePowerState state);
+    uint32_t get_power_state_arc_msg(PowerState state);
 
     friend std::unique_ptr<TTDevice> TTDevice::create(
         int device_number,

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -169,7 +169,8 @@ void Chip::advance_device_execution() {
 
 void Chip::set_clock_state(DevicePowerState state) {
     if (auto* tt_device = get_tt_device()) {
-        tt_device->set_clock_state(state);
+        tt_device->set_clock_state(
+            state == DevicePowerState::BUSY ? TTDevice::PowerState::BUSY : TTDevice::PowerState::IDLE);
     }
 }
 

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -231,15 +231,14 @@ uint32_t BlackholeTTDevice::get_clock() {
 
 uint32_t BlackholeTTDevice::get_min_clock_freq() { return blackhole::AICLK_IDLE_VAL; }
 
-void BlackholeTTDevice::set_clock_state(DevicePowerState state) {
+void BlackholeTTDevice::set_clock_state(TTDevice::PowerState state, NocId /*noc_id*/) {
     ZoneScoped;
     int exit_code = 0;
     switch (state) {
-        case DevicePowerState::BUSY:
+        case TTDevice::PowerState::BUSY:
             exit_code = get_arc_messenger()->send_message((uint32_t)blackhole::ArcMessageType::AICLK_GO_BUSY);
             break;
-        case DevicePowerState::LONG_IDLE:
-        case DevicePowerState::SHORT_IDLE:
+        case TTDevice::PowerState::IDLE:
             exit_code = get_arc_messenger()->send_message((uint32_t)blackhole::ArcMessageType::AICLK_GO_LONG_IDLE);
             break;
         default:

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -280,23 +280,20 @@ void TTDevice::set_power_state(TTDevice::PowerState state, NocId /*noc_id*/) {
     get_pci_device()->set_power_state(state == TTDevice::PowerState::BUSY);
 }
 
-void TTDevice::set_clock_state(DevicePowerState /*state*/) {
+void TTDevice::set_clock_state(TTDevice::PowerState /*state*/, NocId /*noc_id*/) {
     // No-op by default. Backends with a controllable clock (Wormhole, Blackhole) override this to
     // drive AICLK via ARC; backends without one (e.g. simulation) keep the no-op.
 }
 
-void TTDevice::wait_for_aiclk_value(DevicePowerState power_state, const std::chrono::milliseconds timeout_ms) {
+void TTDevice::wait_for_aiclk_value(TTDevice::PowerState power_state, const std::chrono::milliseconds timeout_ms) {
     uint32_t target_aiclk = 0;
     switch (power_state) {
-        case DevicePowerState::BUSY:
+        case TTDevice::PowerState::BUSY:
             target_aiclk = get_max_clock_freq();
             break;
-        case DevicePowerState::LONG_IDLE:
+        case TTDevice::PowerState::IDLE:
             target_aiclk = get_min_clock_freq();
             break;
-        case DevicePowerState::SHORT_IDLE:
-            log_warning(LogUMD, "Skipping AICLK settle wait for SHORT_IDLE clock state.");
-            return;
         default:
             UMD_THROW(error::RuntimeError, "Invalid power state specified for AICLK wait.");
     }

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -111,19 +111,15 @@ uint32_t WormholeTTDevice::get_clock() {
 
 uint32_t WormholeTTDevice::get_min_clock_freq() { return wormhole::AICLK_IDLE_VAL; }
 
-uint32_t WormholeTTDevice::get_power_state_arc_msg(DevicePowerState state) {
+uint32_t WormholeTTDevice::get_power_state_arc_msg(TTDevice::PowerState state) {
     uint32_t msg = wormhole::ARC_MSG_COMMON_PREFIX;
     switch (state) {
-        case BUSY: {
+        case TTDevice::PowerState::BUSY: {
             msg |= get_architecture_implementation()->get_arc_message_arc_go_busy();
             break;
         }
-        case LONG_IDLE: {
+        case TTDevice::PowerState::IDLE: {
             msg |= get_architecture_implementation()->get_arc_message_arc_go_long_idle();
-            break;
-        }
-        case SHORT_IDLE: {
-            msg |= get_architecture_implementation()->get_arc_message_arc_go_short_idle();
             break;
         }
         default:
@@ -132,7 +128,7 @@ uint32_t WormholeTTDevice::get_power_state_arc_msg(DevicePowerState state) {
     return msg;
 }
 
-void WormholeTTDevice::set_clock_state(DevicePowerState state) {
+void WormholeTTDevice::set_clock_state(TTDevice::PowerState state, NocId /*noc_id*/) {
     ZoneScoped;
     uint32_t msg = get_power_state_arc_msg(state);
     int exit_code = get_arc_messenger()->send_message(msg, {0, 0});


### PR DESCRIPTION
### Issue
Followup from #2862

### Description
Issue above was done before precise api spec was specified, so followup to match it exactly.

### List of the changes
 - Changed TTDevice::set_clock_state signature from (DevicePowerState state) to (PowerState state, NocId noc_id = NocId::DEFAULT_NOC)
 - Updated WormholeTTDevice::set_clock_state, WormholeTTDevice::get_power_state_arc_msg, and BlackholeTTDevice::set_clock_state overrides to the new signature and enum
 - Updated TTDevice::wait_for_aiclk_value to take PowerState instead of DevicePowerState (BUSY = max clock, IDLE = min clock)
 - Chip::set_clock_state(DevicePowerState state) public API left unchanged; now converts at the boundary before calling into TTDevice (BUSY to PowerState::BUSY, SHORT_IDLE/LONG_IDLE to PowerState::IDLE)
 - Removed the now-dead get_arc_message_arc_go_short_idle() virtual method and ARC_GO_SHORT_IDLE enum value


### Testing
CI.

### API Changes
This PR has API changes.
