### PR TITLE
Simulation: UPPER_SNAKE the simulation enum class values

### DIFF
--- a/device/api/umd/device/simulation/simulation_server_protocol.hpp
+++ b/device/api/umd/device/simulation/simulation_server_protocol.hpp
@@ -25,25 +25,25 @@ namespace tt::umd {
 
 // Direction of a device-memory access; mirrors wire::SimulationServerCommand in the schema.
 enum class SimulationServerCommand : int8_t {
-    Read = 0,
-    Write = 1,
-    GetDeviceInfo = 2,
-    GetClusterDescriptor = 3,
+    READ = 0,
+    WRITE = 1,
+    GET_DEVICE_INFO = 2,
+    GET_CLUSTER_DESCRIPTOR = 3,
     // Asks the host to shut down gracefully; the host acks with a SimulationServerResponse then tears
     // down (closing every client connection). A host that didn't opt in acks as a no-op.
-    Shutdown = 4,
+    SHUTDOWN = 4,
 };
 
 // Which simulator the host runs; mirrors wire::SimulationBackendType. Served as part of the device
 // identity so a client can build the matching device class without a local simulator build.
 enum class SimulationBackendType : int8_t {
-    TTSim = 0,
-    Rtl = 1,
+    TTSIM = 0,
+    RTL = 1,
 };
 
 // A device-memory access request addressed by (core x/y, address, size).
 struct SimulationServerRequest {
-    SimulationServerCommand command = SimulationServerCommand::Read;
+    SimulationServerCommand command = SimulationServerCommand::READ;
     uint32_t x = 0;
     uint32_t y = 0;
     uint64_t address = 0;
@@ -68,7 +68,7 @@ struct SimulationServerDeviceInfo {
     // tt::ARCH value of the served device.
     int32_t arch = 0;
     // Which simulator the host runs, so the client instantiates the matching device class.
-    SimulationBackendType backend_type = SimulationBackendType::TTSim;
+    SimulationBackendType backend_type = SimulationBackendType::TTSIM;
     // Full text of the host's SoC descriptor YAML file, so the client can build a matching one.
     std::string soc_descriptor_yaml;
     // Whether the host applies NOC translation.

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -62,7 +62,7 @@ public:
     RtlSimCommunicator* get_communicator() { return communicator_.get(); }
 
 protected:
-    SimulationBackendType backend_type() const override { return SimulationBackendType::Rtl; }
+    SimulationBackendType backend_type() const override { return SimulationBackendType::RTL; }
 
     std::unique_ptr<TlbWindow> create_tlb_window(
         int tlb_index, size_t size, TlbMapping mapping, tlb_data config) override;

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -94,7 +94,7 @@ public:
     uint64_t bar4_base = 0;
 
 protected:
-    SimulationBackendType backend_type() const override { return SimulationBackendType::TTSim; }
+    SimulationBackendType backend_type() const override { return SimulationBackendType::TTSIM; }
 
     std::unique_ptr<TlbWindow> create_tlb_window(
         int tlb_index, size_t size, TlbMapping mapping, tlb_data config) override;

--- a/device/simulation/simulation_connector.cpp
+++ b/device/simulation/simulation_connector.cpp
@@ -84,9 +84,9 @@ std::unique_ptr<TTDevice> make_host_device(
 std::unique_ptr<TTDevice> make_client_device(
     ChipId chip_id, std::unique_ptr<SimulationClient> client, const SimulationServerDeviceInfo& info) {
     switch (info.backend_type) {
-        case SimulationBackendType::TTSim:
+        case SimulationBackendType::TTSIM:
             return TTSimTTDevice::create_client(chip_id, std::move(client), info);
-        case SimulationBackendType::Rtl:
+        case SimulationBackendType::RTL:
             return RtlSimulationTTDevice::create_client(chip_id, std::move(client), info);
     }
     // A value outside the enum means a corrupt/incompatible reply from the host; fail loudly rather

--- a/device/simulation/simulation_device_identity.cpp
+++ b/device/simulation/simulation_device_identity.cpp
@@ -117,7 +117,7 @@ SocDescriptor build_soc_descriptor(const SimulationServerDeviceInfo& device_info
 SimulationServerDeviceInfo fetch_device_info_from_host(SimulationClient& client) {
     client.attach();  // idempotent; safe if already attached
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::GetDeviceInfo;
+    request.command = SimulationServerCommand::GET_DEVICE_INFO;
     const SimulationServerDeviceInfo info = decode_device_info(client.transact(encode(request)));
     UMD_ASSERT(
         info.status == 0,
@@ -156,7 +156,7 @@ SimulationServerClusterDescriptor describe_cluster(const std::filesystem::path& 
 std::string fetch_cluster_descriptor_yaml(SimulationClient& client) {
     client.attach();  // idempotent; safe if already attached
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::GetClusterDescriptor;
+    request.command = SimulationServerCommand::GET_CLUSTER_DESCRIPTOR;
     const SimulationServerClusterDescriptor cluster_descriptor =
         decode_cluster_descriptor(client.transact(encode(request)));
     UMD_ASSERT(

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -63,7 +63,7 @@ std::vector<uint8_t> SimulationTTDevice::handle_request(
 
     // GetDeviceInfo returns a different wire message (SimulationServerDeviceInfo) than the
     // read/write skeleton below (SimulationServerResponse), so it is handled up front.
-    if (request.command == SimulationServerCommand::GetDeviceInfo) {
+    if (request.command == SimulationServerCommand::GET_DEVICE_INFO) {
         try {
             return encode(describe_device(get_soc_descriptor(), backend_type()));
         } catch (const std::exception& e) {
@@ -76,7 +76,7 @@ std::vector<uint8_t> SimulationTTDevice::handle_request(
 
     // GetClusterDescriptor also returns its own wire message; serve the build's cluster-descriptor
     // YAML (empty when the build ships none) so a client can rebuild the full topology.
-    if (request.command == SimulationServerCommand::GetClusterDescriptor) {
+    if (request.command == SimulationServerCommand::GET_CLUSTER_DESCRIPTOR) {
         try {
             return encode(describe_cluster(simulator_directory_));
         } catch (const std::exception& e) {
@@ -92,7 +92,7 @@ std::vector<uint8_t> SimulationTTDevice::handle_request(
     // ack. The handler was fixed before serving started, so it is read here without locking; it must
     // only signal -- it must not tear down from this serving thread. The ack is sent before any
     // teardown, and this serving thread hits EOF and is joined during that teardown.
-    if (request.command == SimulationServerCommand::Shutdown) {
+    if (request.command == SimulationServerCommand::SHUTDOWN) {
         if (shutdown_handler) {
             shutdown_handler();
         }
@@ -107,11 +107,11 @@ std::vector<uint8_t> SimulationTTDevice::handle_request(
     SimulationServerResponse response;
     try {
         switch (request.command) {
-            case SimulationServerCommand::Read:
+            case SimulationServerCommand::READ:
                 response.data.resize(request.size);
                 read_from_device(response.data.data(), core, request.address, request.size);
                 break;
-            case SimulationServerCommand::Write:
+            case SimulationServerCommand::WRITE:
                 UMD_ASSERT(
                     request.data.size() >= request.size,
                     error::RuntimeError,
@@ -202,7 +202,7 @@ void SimulationTTDevice::client_write(CoreCoord core, uint64_t addr, const void*
         fmt::format("Remote write size {} exceeds the protocol maximum of {} bytes", size, UINT32_MAX));
     const xy_pair translated_core = get_soc_descriptor().translate_chip_coord_to_translated(core);
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::Write;
+    request.command = SimulationServerCommand::WRITE;
     request.x = static_cast<uint32_t>(translated_core.x);
     request.y = static_cast<uint32_t>(translated_core.y);
     request.address = addr;
@@ -227,7 +227,7 @@ void SimulationTTDevice::client_read(CoreCoord core, uint64_t addr, void* mem_pt
         fmt::format("Remote read size {} exceeds the protocol maximum of {} bytes", size, UINT32_MAX));
     const xy_pair translated_core = get_soc_descriptor().translate_chip_coord_to_translated(core);
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::Read;
+    request.command = SimulationServerCommand::READ;
     request.x = static_cast<uint32_t>(translated_core.x);
     request.y = static_cast<uint32_t>(translated_core.y);
     request.address = addr;

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -63,7 +63,7 @@ std::vector<uint8_t> SimulationTTDevice::handle_request(
 
     // GetDeviceInfo returns a different wire message (SimulationServerDeviceInfo) than the
     // read/write skeleton below (SimulationServerResponse), so it is handled up front.
-    if (request.command == SimulationServerCommand::GetDeviceInfo) {
+    if (request.command == SimulationServerCommand::GET_DEVICE_INFO) {
         try {
             return encode(describe_device(get_soc_descriptor(), backend_type()));
         } catch (const std::exception& e) {
@@ -76,7 +76,7 @@ std::vector<uint8_t> SimulationTTDevice::handle_request(
 
     // GetClusterDescriptor also returns its own wire message; serve the build's cluster-descriptor
     // YAML (empty when the build ships none) so a client can rebuild the full topology.
-    if (request.command == SimulationServerCommand::GetClusterDescriptor) {
+    if (request.command == SimulationServerCommand::GET_CLUSTER_DESCRIPTOR) {
         try {
             return encode(describe_cluster(simulator_directory_));
         } catch (const std::exception& e) {
@@ -92,7 +92,7 @@ std::vector<uint8_t> SimulationTTDevice::handle_request(
     // ack. The handler was fixed before serving started, so it is read here without locking; it must
     // only signal -- it must not tear down from this serving thread. The ack is sent before any
     // teardown, and this serving thread hits EOF and is joined during that teardown.
-    if (request.command == SimulationServerCommand::Shutdown) {
+    if (request.command == SimulationServerCommand::SHUTDOWN) {
         if (shutdown_handler) {
             shutdown_handler();
         }
@@ -107,11 +107,11 @@ std::vector<uint8_t> SimulationTTDevice::handle_request(
     SimulationServerResponse response;
     try {
         switch (request.command) {
-            case SimulationServerCommand::Read:
+            case SimulationServerCommand::READ:
                 response.data.resize(request.size);
                 read_from_device(response.data.data(), core, request.address, request.size);
                 break;
-            case SimulationServerCommand::Write:
+            case SimulationServerCommand::WRITE:
                 UMD_ASSERT(
                     request.data.size() >= request.size,
                     error::RuntimeError,
@@ -203,7 +203,7 @@ void SimulationTTDevice::client_write(CoreCoord core, uint64_t addr, const void*
     const xy_pair translated_core =
         get_soc_descriptor().translate_chip_coord_to_translated(core, get_selected_noc_id());
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::Write;
+    request.command = SimulationServerCommand::WRITE;
     request.x = static_cast<uint32_t>(translated_core.x);
     request.y = static_cast<uint32_t>(translated_core.y);
     request.address = addr;
@@ -229,7 +229,7 @@ void SimulationTTDevice::client_read(CoreCoord core, uint64_t addr, void* mem_pt
     const xy_pair translated_core =
         get_soc_descriptor().translate_chip_coord_to_translated(core, get_selected_noc_id());
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::Read;
+    request.command = SimulationServerCommand::READ;
     request.x = static_cast<uint32_t>(translated_core.x);
     request.y = static_cast<uint32_t>(translated_core.y);
     request.address = addr;

--- a/docs/SIMULATION_SERVER.md
+++ b/docs/SIMULATION_SERVER.md
@@ -1,9 +1,12 @@
 # Simulation Server
 
-UMD can run against a *simulated* device instead of real hardware. The **simulation server** lets one
-process **host** a simulated device and have other UMD processes **attach** to it and drive it exactly
-as they would a real cluster. That way a single running simulation can be shared by several processes
-at once, instead of each process spinning up its own.
+UMD can run against a *simulated* device instead of real hardware, using
+[ttsim](https://github.com/tenstorrent/ttsim) (a `libttsim.so` for a given architecture) or an RTL
+simulator build. The **simulation server** lets one process **host** a simulated device and have other
+UMD processes **attach** to it and drive it exactly as they would a real cluster.
+
+Without it each process gets its own independent simulation, so two processes never see each other's
+writes.
 
 ## Host and client
 
@@ -15,6 +18,18 @@ You don't pick a role explicitly — UMD decides it from what you point it at:
 
 A host and its clients run on the same machine and communicate over per-chip sockets kept in that
 server's directory (see [Where things live](#where-things-live)).
+
+### Any UMD process can be the host
+
+Hosting is a `Cluster` option, not something special to the tool:
+
+```cpp
+options.serve_simulation_devices_over_sockets = true;   // default: false
+```
+
+It is **off by default**, so an ordinary simulator run — a UMD or tt-metal test pointed at a
+`libttsim.so` — hosts a private in-process simulation and publishes nothing. `sim_server` is just a
+host that sets the flag and stays alive.
 
 ```mermaid
 flowchart TB
@@ -86,11 +101,21 @@ flowchart TB
    1        0      live    blackhole/ttsim  /tmp/tt-umd-sim-server-1/tt-umd-sim-0.sock
    ```
 
-3. **Use it from your program.** Open a UMD cluster in simulation mode pointed at a server's socket
-   directory (the `SOCKET`'s parent above, e.g. `/tmp/tt-umd-sim-server-0`). UMD sees the live
-   sockets there, attaches as a client, and from then on you use the cluster exactly as you would
-   against real hardware — reading and writing device memory and so on. Your program's code is the
-   same whether it runs on hardware or against a shared simulation.
+3. **Use it from your program.** Point UMD at the server *directory* (the `SOCKET`'s parent above,
+   e.g. `/tmp/tt-umd-sim-server-0`) instead of at a simulator. UMD sees the live sockets, attaches as
+   a client, and from then on you drive the cluster exactly as you would real hardware. There is no
+   separate "connect" call — the path you pass is what makes you a client.
+
+   Wherever you would name a `libttsim.so` — `TT_UMD_SIMULATOR`, `TT_METAL_SIMULATOR`, or
+   `ClusterOptions::simulator_directory` — name the server directory instead. So an existing test runs
+   against a server with no code change:
+
+   ```
+   TT_UMD_SIMULATOR=/tmp/tt-umd-sim-server-0 \
+     ./build/test/umd/api/api_tests --gtest_filter="TestDeviceIOFixture.RegReadWrite"
+   ```
+
+   There is no Python entry point today.
 
 4. **Stop the server.**
 
@@ -208,10 +233,11 @@ client — there is no separate "connect" call.
 
 Each simulated chip is exposed as a socket in its server's directory. The host answers device
 operations and describes the cluster topology over that socket; a client forwards its operations to
-the host and applies the replies, so on the client side the device behaves like any other. Stopping a
-server tears it down cleanly and closes its client connections, so a client's in-flight or next
-operation fails with a clear "server stopped" error instead of hanging — letting the client notice
-and exit gracefully.
+the host and applies the replies, so on the client side the device behaves like any other.
+
+Stopping a server does **not** stop its clients — it closes their connections, so a client's next
+operation fails with a clear "server stopped" error instead of hanging, and the client decides what to
+do. Each process is started and stopped on its own.
 
 ## Good to know
 
@@ -220,5 +246,7 @@ and exit gracefully.
   it wants (from `sim_server list`).
 - **Clients fail cleanly.** If the server goes away, a client's next operation raises a clear error
   rather than hanging.
-- **Shared on the machine.** Any user on the same machine can attach to a running server — the sockets
-  are shared, not private to one user.
+- **Shared on the machine.** The sockets are world-writable (`srw-rw-rw-`), so any user can attach —
+  which is also why `kill` goes over the socket rather than by signal.
+- **Sysmem is not carried over the socket.** Device memory and registers work from a client; sysmem
+  access crashes (`TestDeviceIOFixture.SysmemReadWrite` segfaults in client mode).

--- a/docs/SIMULATION_SERVER.md
+++ b/docs/SIMULATION_SERVER.md
@@ -1,0 +1,224 @@
+# Simulation Server
+
+UMD can run against a *simulated* device instead of real hardware. The **simulation server** lets one
+process **host** a simulated device and have other UMD processes **attach** to it and drive it exactly
+as they would a real cluster. That way a single running simulation can be shared by several processes
+at once, instead of each process spinning up its own.
+
+## Host and client
+
+You don't pick a role explicitly — UMD decides it from what you point it at:
+
+- Point it at a **simulator** → your process is the **host**: it runs the simulation and serves it.
+- Point it at the **directory where a running server keeps its sockets** → your process is a
+  **client**: it attaches to the host and uses the simulation without running one itself.
+
+A host and its clients run on the same machine and communicate over per-chip sockets kept in that
+server's directory (see [Where things live](#where-things-live)).
+
+```mermaid
+flowchart TB
+  subgraph server["a server · /tmp/tt-umd-sim-server-0"]
+    host["host process<br/>runs the simulation"]
+    sock(["tt-umd-sim-0.sock"])
+    host --- sock
+  end
+  c1["client<br/>your UMD program"] -->|attach| sock
+  c2["client"] -->|attach| sock
+  c3["client"] -->|attach| sock
+```
+
+### More than one server
+
+Each host gets its **own directory** for its sockets, so several servers can run on one machine at
+the same time without stepping on each other — even if they serve the same chip ids. You point a
+client at the directory of whichever server you want to attach to. `sim_server list` shows them all,
+each with an **index** you use to refer to it.
+
+```mermaid
+flowchart TB
+  subgraph s0["server 0 · /tmp/tt-umd-sim-server-0"]
+    h0["host · simulator A"]
+    k0(["tt-umd-sim-0.sock"])
+    h0 --- k0
+  end
+  subgraph s1["server 1 · /tmp/tt-umd-sim-server-1"]
+    h1["host · simulator B"]
+    k1(["tt-umd-sim-0.sock"])
+    h1 --- k1
+  end
+  ca["client"] -->|attach| k0
+  cb["client"] -->|attach| k1
+```
+
+## The flow
+
+1. **Start a server.** Launch a host in the background with the `sim_server.sh` wrapper:
+
+   ```
+   sim_server.sh start <simulator>
+   ```
+
+   It brings the simulation up in a freshly allocated server directory and returns once the sockets
+   are actually serving — printing the host pid, that directory, and where its log went, e.g.
+   `sim_server up: pid 12345, serving /tmp/tt-umd-sim-server-0, log /tmp/sim_server-tt-umd-sim-server-0.log`.
+   Other processes can now attach. Start another server the same way and it gets its own directory
+   (`.../tt-umd-sim-server-1`).
+
+   The `sim_server` binary itself runs in the foreground: `sim_server start <simulator>` serves until
+   you stop it with `Ctrl-C`, `SIGTERM`, or `sim_server kill`. That is handy when you want the host
+   in a terminal you are watching. The wrapper is what adds the backgrounding, the per-server log,
+   and the check that startup actually succeeded; every other subcommand it forwards to the binary
+   untouched, so `sim_server.sh list` and `sim_server list` are the same thing.
+
+2. **See what's running.**
+
+   ```
+   sim_server list
+   ```
+
+   Lists the open servers. Each row is one chip of one server: the server index, the chip id,
+   whether it is reachable, its arch/backend, and the socket it is served on.
+
+   ```
+   SERVER   CHIP   STATE   ARCH             SOCKET
+   0        0      live    blackhole/ttsim  /tmp/tt-umd-sim-server-0/tt-umd-sim-0.sock
+   1        0      live    blackhole/ttsim  /tmp/tt-umd-sim-server-1/tt-umd-sim-0.sock
+   ```
+
+3. **Use it from your program.** Open a UMD cluster in simulation mode pointed at a server's socket
+   directory (the `SOCKET`'s parent above, e.g. `/tmp/tt-umd-sim-server-0`). UMD sees the live
+   sockets there, attaches as a client, and from then on you use the cluster exactly as you would
+   against real hardware — reading and writing device memory and so on. Your program's code is the
+   same whether it runs on hardware or against a shared simulation.
+
+4. **Stop the server.**
+
+   ```
+   sim_server kill <server>
+   ```
+
+   `<server>` is the index shown by `sim_server list`. This shuts that host down and disconnects its
+   clients.
+
+   A host that shuts down this way removes its own directory. One that was killed or crashed cannot,
+   so it leaves a directory behind — `list` shows it as `unreachable`. Clear those out with:
+
+   ```
+   sim_server.sh prune
+   ```
+
+   It removes the directories and logs of servers that no longer answer, and leaves live ones alone.
+
+At a glance, over the life of one server:
+
+```mermaid
+sequenceDiagram
+  participant Tool as sim_server.sh
+  participant Host as host (sim_server start)
+  participant Dir as server directory
+  participant Client as client (Cluster)
+  Tool->>Host: start a simulator, in the background
+  Host->>Dir: create dir + bind tt-umd-sim-0.sock
+  Host-->>Tool: "server directory: ..." once serving
+  Note over Client,Dir: later, a separate process
+  Client->>Dir: open the sockets in the directory
+  Client->>Host: attach, then read / write
+  Host-->>Client: replies (device memory, topology)
+  Tool->>Host: kill the server (SHUTDOWN over socket)
+  Host->>Dir: remove sockets + directory
+  Host--xClient: closed → "server stopped"
+```
+
+## Connecting from code
+
+Attaching to a running server is the same code path as opening real hardware — you point UMD at that
+server's socket directory instead of picking a role. There are two levels you can enter at.
+
+### At the Cluster level
+
+The usual entry point. Construct a `Cluster` in simulation mode pointed at a server's socket
+directory; UMD sees the live sockets, attaches to each as a client, and hands you a cluster you drive
+exactly as you would silicon.
+
+```cpp
+#include "umd/device/cluster.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+
+using namespace tt::umd;
+
+ClusterOptions options;
+options.chip_type = ChipType::SIMULATION;
+options.simulator_directory = "/tmp/tt-umd-sim-server-0";  // a server's directory (from `list`)
+Cluster cluster(options);
+
+// From here the cluster behaves like any other -- the same code runs against
+// hardware or against a shared simulation.
+for (ChipId chip : cluster.get_target_device_ids()) {
+    // Pick something to access -- here the first Tensix core, at address 0x1000.
+    const CoreCoord core = cluster.get_soc_descriptor(chip).get_cores(CoreType::TENSIX).at(0);
+    const uint64_t addr = 0x1000;
+
+    uint32_t value = 0;
+    cluster.read_from_device(&value, chip, core, addr, sizeof(value));
+}
+```
+
+### At the discovery level
+
+One level down. `SimulationConnector::discover()` is the step `Cluster` runs for you: it attaches to
+each per-chip socket in the directory and returns the client devices, keyed by the same chip ids the
+host serves. Enter here when you want the devices directly rather than a full cluster. (This is
+simulation's discovery entry point; the silicon `TopologyDiscovery` path is not involved.)
+
+```cpp
+#include "umd/device/simulation/simulation_connector.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+
+using namespace tt::umd;
+
+SimulationConnectorOptions options;
+options.simulator_directory = "/tmp/tt-umd-sim-server-0";  // same server directory
+std::map<ChipId, std::unique_ptr<TTDevice>> devices = SimulationConnector::discover(options);
+
+// Each device is a client already attached to the running host.
+for (auto& [chip_id, device] : devices) {
+    // use `device` directly, or hand it to higher-level UMD code
+}
+```
+
+In both cases the target is the server directory, and pointing at it is what makes your process a
+client — there is no separate "connect" call.
+
+## Where things live
+
+- **Server directories.** One per running server, under the system temporary directory (`/tmp` on
+  Linux), named `tt-umd-sim-server-<index>`. The index counts up from 0; each `start` claims the
+  lowest free one.
+- **Sockets.** One per chip, inside that server's directory, named `tt-umd-sim-<chip_id>.sock`. A
+  server directory *is* what a client points at, and what `sim_server list` scans — there is no
+  central registry, just the directories present on disk. When a server shuts down it removes its
+  sockets and its (now-empty) directory.
+- **Server logs.** Started through `sim_server.sh`, a host is detached from your terminal and its
+  output goes to a per-server log in the temporary directory, named after the server directory:
+  `sim_server-tt-umd-sim-server-<index>.log`. Check it if a server did not come up. Started directly
+  with `sim_server start`, the host runs in the foreground and logs to your terminal.
+
+## What happens under the hood
+
+Each simulated chip is exposed as a socket in its server's directory. The host answers device
+operations and describes the cluster topology over that socket; a client forwards its operations to
+the host and applies the replies, so on the client side the device behaves like any other. Stopping a
+server tears it down cleanly and closes its client connections, so a client's in-flight or next
+operation fails with a clear "server stopped" error instead of hanging — letting the client notice
+and exit gracefully.
+
+## Good to know
+
+- **Multiple servers coexist.** Each host has its own directory, so you can run several simulators on
+  one machine at once — including two of the same chip id. Point each client at the server directory
+  it wants (from `sim_server list`).
+- **Clients fail cleanly.** If the server goes away, a client's next operation raises a clear error
+  rather than hanging.
+- **Shared on the machine.** Any user on the same machine can attach to a running server — the sockets
+  are shared, not private to one user.

--- a/tests/api/test_simulation_connector.cpp
+++ b/tests/api/test_simulation_connector.cpp
@@ -94,7 +94,7 @@ TEST(SimulationConnector, HostServesClientMemoryOverSocket) {
     // Host writes directly; the client reads the same location over the socket.
     host->write_to_device(pattern.data(), tensix, addr, pattern.size());
     SimulationServerRequest read_req;
-    read_req.command = SimulationServerCommand::Read;
+    read_req.command = SimulationServerCommand::READ;
     read_req.x = static_cast<uint32_t>(noc.x);
     read_req.y = static_cast<uint32_t>(noc.y);
     read_req.address = addr;
@@ -107,7 +107,7 @@ TEST(SimulationConnector, HostServesClientMemoryOverSocket) {
     const std::vector<uint8_t> pattern2 = {0x55, 0x66, 0x77, 0x88};
     constexpr uint64_t addr2 = 0x2000;
     SimulationServerRequest write_req;
-    write_req.command = SimulationServerCommand::Write;
+    write_req.command = SimulationServerCommand::WRITE;
     write_req.x = static_cast<uint32_t>(noc.x);
     write_req.y = static_cast<uint32_t>(noc.y);
     write_req.address = addr2;
@@ -145,13 +145,13 @@ TEST(SimulationConnector, HostServesDeviceInfoOverSocket) {
     SimulationClient client(socket);
     client.attach();
     SimulationServerRequest info_request;
-    info_request.command = SimulationServerCommand::GetDeviceInfo;
+    info_request.command = SimulationServerCommand::GET_DEVICE_INFO;
     const SimulationServerDeviceInfo info = decode_device_info(client.transact(encode(info_request)));
 
     EXPECT_EQ(info.status, 0);
     EXPECT_EQ(info.arch, static_cast<int32_t>(soc.arch));
     const bool is_ttsim = std::filesystem::path(simulator_path).extension() == ".so";
-    EXPECT_EQ(info.backend_type, is_ttsim ? SimulationBackendType::TTSim : SimulationBackendType::Rtl);
+    EXPECT_EQ(info.backend_type, is_ttsim ? SimulationBackendType::TTSIM : SimulationBackendType::RTL);
     EXPECT_FALSE(info.soc_descriptor_yaml.empty());
     EXPECT_EQ(info.noc_translation_enabled, soc.noc_translation_enabled);
     EXPECT_EQ(info.tensix_harvesting_mask, soc.harvesting_masks.tensix_harvesting_mask);

--- a/tests/api/test_simulation_connector.cpp
+++ b/tests/api/test_simulation_connector.cpp
@@ -92,7 +92,7 @@ TEST(SimulationConnector, HostServesClientMemoryOverSocket) {
     // Host writes directly; the client reads the same location over the socket.
     host->write_to_device(pattern.data(), tensix, addr, pattern.size());
     SimulationServerRequest read_req;
-    read_req.command = SimulationServerCommand::Read;
+    read_req.command = SimulationServerCommand::READ;
     read_req.x = static_cast<uint32_t>(noc.x);
     read_req.y = static_cast<uint32_t>(noc.y);
     read_req.address = addr;
@@ -105,7 +105,7 @@ TEST(SimulationConnector, HostServesClientMemoryOverSocket) {
     const std::vector<uint8_t> pattern2 = {0x55, 0x66, 0x77, 0x88};
     constexpr uint64_t addr2 = 0x2000;
     SimulationServerRequest write_req;
-    write_req.command = SimulationServerCommand::Write;
+    write_req.command = SimulationServerCommand::WRITE;
     write_req.x = static_cast<uint32_t>(noc.x);
     write_req.y = static_cast<uint32_t>(noc.y);
     write_req.address = addr2;
@@ -143,13 +143,13 @@ TEST(SimulationConnector, HostServesDeviceInfoOverSocket) {
     SimulationClient client(socket);
     client.attach();
     SimulationServerRequest info_request;
-    info_request.command = SimulationServerCommand::GetDeviceInfo;
+    info_request.command = SimulationServerCommand::GET_DEVICE_INFO;
     const SimulationServerDeviceInfo info = decode_device_info(client.transact(encode(info_request)));
 
     EXPECT_EQ(info.status, 0);
     EXPECT_EQ(info.arch, static_cast<int32_t>(soc.arch));
     const bool is_ttsim = std::filesystem::path(simulator_path).extension() == ".so";
-    EXPECT_EQ(info.backend_type, is_ttsim ? SimulationBackendType::TTSim : SimulationBackendType::Rtl);
+    EXPECT_EQ(info.backend_type, is_ttsim ? SimulationBackendType::TTSIM : SimulationBackendType::RTL);
     EXPECT_FALSE(info.soc_descriptor_yaml.empty());
     EXPECT_EQ(info.noc_translation_enabled, soc.noc_translation_enabled);
     EXPECT_EQ(info.tensix_harvesting_mask, soc.harvesting_masks.tensix_harvesting_mask);

--- a/tests/api/test_simulation_device_identity.cpp
+++ b/tests/api/test_simulation_device_identity.cpp
@@ -33,9 +33,9 @@ TEST(SimulationDeviceIdentity, DescribeThenRebuildMatches) {
     SocDescriptor original(
         std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")), chip_info);
 
-    const SimulationServerDeviceInfo info = describe_device(original, SimulationBackendType::TTSim);
+    const SimulationServerDeviceInfo info = describe_device(original, SimulationBackendType::TTSIM);
     EXPECT_EQ(info.status, 0);
-    EXPECT_EQ(info.backend_type, SimulationBackendType::TTSim);
+    EXPECT_EQ(info.backend_type, SimulationBackendType::TTSIM);
     EXPECT_FALSE(info.soc_descriptor_yaml.empty());
     EXPECT_EQ(info.tensix_harvesting_mask, 0x1u);
 

--- a/tests/api/test_simulation_server_protocol.cpp
+++ b/tests/api/test_simulation_server_protocol.cpp
@@ -15,7 +15,7 @@ using namespace tt::umd;
 // A read request carries the access geometry and no payload; encode -> decode reproduces it.
 TEST(SimulationServerProtocol, ReadRequestRoundTrip) {
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::Read;
+    request.command = SimulationServerCommand::READ;
     request.x = 3;
     request.y = 5;
     request.address = 0x1000'2000'3000'4000ULL;
@@ -23,7 +23,7 @@ TEST(SimulationServerProtocol, ReadRequestRoundTrip) {
 
     const SimulationServerRequest decoded = decode_request(encode(request));
 
-    EXPECT_EQ(decoded.command, SimulationServerCommand::Read);
+    EXPECT_EQ(decoded.command, SimulationServerCommand::READ);
     EXPECT_EQ(decoded.x, request.x);
     EXPECT_EQ(decoded.y, request.y);
     EXPECT_EQ(decoded.address, request.address);
@@ -34,7 +34,7 @@ TEST(SimulationServerProtocol, ReadRequestRoundTrip) {
 // A write request carries its payload; encode -> decode reproduces geometry and bytes.
 TEST(SimulationServerProtocol, WriteRequestRoundTrip) {
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::Write;
+    request.command = SimulationServerCommand::WRITE;
     request.x = 1;
     request.y = 2;
     request.address = 0xDEAD'BEEFULL;
@@ -43,7 +43,7 @@ TEST(SimulationServerProtocol, WriteRequestRoundTrip) {
 
     const SimulationServerRequest decoded = decode_request(encode(request));
 
-    EXPECT_EQ(decoded.command, SimulationServerCommand::Write);
+    EXPECT_EQ(decoded.command, SimulationServerCommand::WRITE);
     EXPECT_EQ(decoded.x, request.x);
     EXPECT_EQ(decoded.y, request.y);
     EXPECT_EQ(decoded.address, request.address);
@@ -85,7 +85,7 @@ TEST(SimulationServerProtocol, DecodeEmptyBufferThrows) {
 // verification instead of reading out of bounds.
 TEST(SimulationServerProtocol, DecodeTruncatedBufferThrows) {
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::Read;
+    request.command = SimulationServerCommand::READ;
     request.size = 64;
     std::vector<uint8_t> encoded = encode(request);
     ASSERT_GT(encoded.size(), 4u);
@@ -99,7 +99,7 @@ TEST(SimulationServerProtocol, DeviceInfoSerializationRoundTrip) {
     SimulationServerDeviceInfo info;
     info.status = 0;
     info.arch = 2;  // arbitrary tt::ARCH value
-    info.backend_type = SimulationBackendType::Rtl;
+    info.backend_type = SimulationBackendType::RTL;
     info.soc_descriptor_yaml = "arch: wormhole_b0\ngrid: [10, 12]\n";
     info.noc_translation_enabled = false;
     info.tensix_harvesting_mask = 0x5;
@@ -125,9 +125,9 @@ TEST(SimulationServerProtocol, DeviceInfoSerializationRoundTrip) {
 // The GetDeviceInfo command survives a request round-trip.
 TEST(SimulationServerProtocol, GetDeviceInfoRequestRoundTrip) {
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::GetDeviceInfo;
+    request.command = SimulationServerCommand::GET_DEVICE_INFO;
     const SimulationServerRequest decoded = decode_request(encode(request));
-    EXPECT_EQ(decoded.command, SimulationServerCommand::GetDeviceInfo);
+    EXPECT_EQ(decoded.command, SimulationServerCommand::GET_DEVICE_INFO);
 }
 
 // The cluster-descriptor message round-trips its status and YAML text.
@@ -153,15 +153,15 @@ TEST(SimulationServerProtocol, ClusterDescriptorEmptyYamlRoundTrip) {
 // The GetClusterDescriptor command survives a request round-trip.
 TEST(SimulationServerProtocol, GetClusterDescriptorRequestRoundTrip) {
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::GetClusterDescriptor;
+    request.command = SimulationServerCommand::GET_CLUSTER_DESCRIPTOR;
     const SimulationServerRequest decoded = decode_request(encode(request));
-    EXPECT_EQ(decoded.command, SimulationServerCommand::GetClusterDescriptor);
+    EXPECT_EQ(decoded.command, SimulationServerCommand::GET_CLUSTER_DESCRIPTOR);
 }
 
 // The Shutdown command survives a request round-trip (its reply is a plain SimulationServerResponse).
 TEST(SimulationServerProtocol, ShutdownRequestRoundTrip) {
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::Shutdown;
+    request.command = SimulationServerCommand::SHUTDOWN;
     const SimulationServerRequest decoded = decode_request(encode(request));
-    EXPECT_EQ(decoded.command, SimulationServerCommand::Shutdown);
+    EXPECT_EQ(decoded.command, SimulationServerCommand::SHUTDOWN);
 }

--- a/tools/sim_server.cpp
+++ b/tools/sim_server.cpp
@@ -198,7 +198,7 @@ int cmd_list() {
                 arch = fmt::format(
                     "{}/{}",
                     tt::arch_to_str(static_cast<tt::ARCH>(info.arch)),
-                    info.backend_type == SimulationBackendType::TTSim ? "ttsim" : "rtl");
+                    info.backend_type == SimulationBackendType::TTSIM ? "ttsim" : "rtl");
             } catch (const std::exception&) {
                 // Socket file present but no live host answering -> stale/unreachable.
             }
@@ -229,7 +229,7 @@ int cmd_kill(int server_index) {
         SimulationClient client(socket_path);
         client.attach();
         SimulationServerRequest request;
-        request.command = SimulationServerCommand::Shutdown;
+        request.command = SimulationServerCommand::SHUTDOWN;
         const SimulationServerResponse response = decode_response(client.transact(encode(request)));
         if (response.status != 0) {
             log_error(tt::LogUMD, "Server {} did not acknowledge shutdown (status {}).", server_index, response.status);

--- a/tools/sim_server.cpp
+++ b/tools/sim_server.cpp
@@ -56,7 +56,7 @@ std::string probe_socket(const std::filesystem::path& socket_path) {
         return fmt::format(
             "{}/{}",
             tt::arch_to_str(static_cast<tt::ARCH>(info.arch)),
-            info.backend_type == SimulationBackendType::TTSim ? "ttsim" : "rtl");
+            info.backend_type == SimulationBackendType::TTSIM ? "ttsim" : "rtl");
     } catch (const std::exception&) {
         return "";  // socket file present, but no live host answering
     }
@@ -141,7 +141,7 @@ int cmd_kill(int server_index) {
     SimulationClient client(it->sockets.begin()->second);
     client.attach();
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::Shutdown;
+    request.command = SimulationServerCommand::SHUTDOWN;
     const SimulationServerResponse response = decode_response(client.transact(encode(request)));
     if (response.status != 0) {
         log_error(tt::LogUMD, "Server {} did not acknowledge shutdown (status {}).", server_index, response.status);


### PR DESCRIPTION
### Issue
Part of #2677 (simulation server). @nbuncicTT has repeatedly asked, across the simulation epic, for the enum classes to use `UPPER_SNAKE_CASE`. This does that rename in one place, on top of the stack, so it covers every value — including `Read`/`Write`/`GetDeviceInfo` which already merged to `main` (#2967/#3019) and so can't be fixed inside the still-open stacked PRs.

### Description
Renames the C++ enum-class values to `UPPER_SNAKE_CASE`:
- `SimulationServerCommand`: `Read`/`Write`/`GetDeviceInfo`/`GetClusterDescriptor`/`Shutdown` → `READ`/`WRITE`/`GET_DEVICE_INFO`/`GET_CLUSTER_DESCRIPTOR`/`SHUTDOWN`.
- `SimulationBackendType`: `TTSim`/`Rtl` → `TTSIM`/`RTL`.

This is a **value-name-only** rename: the enum types, their underlying integer values, and the wire format are unchanged. The `.fbs` wire schema was already `UPPER_SNAKE`, so the C++ now matches it. `protocol.cpp` casts between the C++ and wire enums by value (no value-name references), so the wire (de)serialization is untouched.

### List of the changes
- `simulation_server_protocol.hpp` — the two enum definitions.
- All qualified usages across `device/`, `tools/`, `tests/` (`SimulationServerCommand::*`, `SimulationBackendType::*`).

### Testing
Build + pre-commit clean; simulation unit suites pass (`SimulationServerProtocol`/`SimulationDeviceIdentity`/`SimulationServerSocket`/`SimulationClient`). No behavior change.

### API Changes
Enum-class value names only (`tt::umd::SimulationServerCommand`, `tt::umd::SimulationBackendType`). Simulation-internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
