### PR TITLE
Populate compile cache for ASan and TSan

### DIFF
--- a/.github/workflows/populate-cache-tests.yml
+++ b/.github/workflows/populate-cache-tests.yml
@@ -16,8 +16,8 @@ on:
 
 permissions:
   contents: read
+  actions: write
   packages: read
-
 jobs:
   # Ensure the Docker image for CI exists. If the Dockerfile (or its install scripts) changed on
   # this branch the image is rebuilt and pushed with a content-hash tag. Otherwise the existing

--- a/.github/workflows/populate-cache-tests.yml
+++ b/.github/workflows/populate-cache-tests.yml
@@ -1,0 +1,57 @@
+# Populate the sccache with ASan and TSan build artifacts.
+#
+# Only the main branch may write to the GHA sccache (see SCCACHE_GHA_RW_MODE in build-tests.yml),
+# and the sanitizer builds are not part of the push-to-main test run - on main only Release builds
+# (build-and-run-all-tests-multiple-builds.yml). That leaves ASan/TSan compiling cold in the merge
+# queue, where they are required checks and TSan costs ~10x runtime. This workflow builds them on
+# every push to main purely so the compile results land in the shared cache and the merge-queue
+# runs start warm.
+
+name: Populate cache with ASan and TSan builds
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  # Ensure the Docker image for CI exists. If the Dockerfile (or its install scripts) changed on
+  # this branch the image is rebuilt and pushed with a content-hash tag. Otherwise the existing
+  # image is reused.
+  ensure-image:
+    name: Ensure Docker image
+    permissions:
+      packages: write
+    secrets: inherit
+    uses: ./.github/workflows/docker-image.yml
+    with:
+      docker-version: ubuntu-22.04
+
+  # One build per sanitizer. build-tracy: true mirrors what build-and-run-all-tests.yml compiles in
+  # the merge queue, so both the plain and the Tracy-enabled object files get cached. The wheel is
+  # skipped: build-tests.yml forces sanitizer wheels back to Release, so it would only duplicate
+  # cache entries the Release build on main already populates.
+  populate-cache:
+    name: "Populate cache (${{ matrix.build-type }})"
+    needs: ensure-image
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - build-type: ASan
+            timeout: 45
+          - build-type: TSan
+            timeout: 45
+    secrets: inherit
+    uses: ./.github/workflows/build-tests.yml
+    with:
+      ubuntu-docker-version: ubuntu-22.04
+      build-type: ${{ matrix.build-type }}
+      timeout: ${{ matrix.timeout }}
+      build-tracy: true
+      build-wheel: true
+      image-tag: ${{ needs.ensure-image.outputs.image-tag }}


### PR DESCRIPTION
### Issue
#2970

### Description
Populate compile cache for ASan and TSan on push to main.