### PR TITLE
Simulation: bound SimulationClient exchanges with a socket timeout

### DIFF
--- a/device/api/umd/device/simulation/simulation_client.hpp
+++ b/device/api/umd/device/simulation/simulation_client.hpp
@@ -4,10 +4,13 @@
 
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 #include <filesystem>
 #include <memory>
 #include <vector>
+
+#include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
 
@@ -18,7 +21,10 @@ namespace tt::umd {
 // asio is held behind a pImpl so this header stays asio-free (see Impl in the .cpp).
 class SimulationClient {
 public:
-    explicit SimulationClient(std::filesystem::path socket_path);
+    // timeout bounds each blocking send/recv on the socket, so transact() fails with an error
+    // instead of hanging forever if the host is reachable (connect succeeds) but not answering.
+    explicit SimulationClient(
+        std::filesystem::path socket_path, std::chrono::milliseconds timeout = timeout::SIMULATION_SOCKET_TIMEOUT);
     ~SimulationClient();
 
     SimulationClient(const SimulationClient&) = delete;
@@ -37,6 +43,7 @@ public:
 
 private:
     std::filesystem::path socket_path_;
+    std::chrono::milliseconds timeout_;
 
     // Holds the asio transport (io_context + connected socket). Defined in the .cpp so asio
     // stays out of this header; owns the connection fd (RAII).

--- a/device/api/umd/device/utils/timeouts.hpp
+++ b/device/api/umd/device/utils/timeouts.hpp
@@ -9,6 +9,13 @@
 namespace tt::umd::timeout {
 inline constexpr auto NON_MMIO_RW_TIMEOUT = std::chrono::milliseconds(5'000);
 
+// Per-operation budget for a SimulationClient exchange over the host socket: how long transact()
+// waits on the reply before giving up. Guards against a host that is bound but not yet (or no
+// longer) serving -- a client can connect (the listen backlog accepts it) and would otherwise block
+// forever waiting for a response. Generous, since it also covers a slow backend bring-up; a genuine
+// per-request round trip is far quicker.
+inline constexpr auto SIMULATION_SOCKET_TIMEOUT = std::chrono::milliseconds(30'000);
+
 // Default per-op budget for a single host-side MMIO (TLB-mapped) transfer, overridable at runtime via
 // MmioTimeoutConfig::set_op_timeout. A healthy MMIO op is microseconds; 2 ms sits well above that yet far
 // below the ~700 ms latency of a read on a hung NOC, so genuine hangs are still caught promptly. A slow-

--- a/device/simulation/simulation_client.cpp
+++ b/device/simulation/simulation_client.cpp
@@ -5,9 +5,12 @@
 #include "umd/device/simulation/simulation_client.hpp"
 
 #include <fmt/format.h>
+#include <poll.h>    // poll(), to bound the wait on the socket
 #include <sys/un.h>  // sockaddr_un::sun_path, for the path-length guard
 
 #include <asio.hpp>
+#include <cerrno>
+#include <chrono>
 #include <system_error>
 
 #include "simulation/simulation_server_transport.hpp"
@@ -37,6 +40,55 @@ stream_protocol::endpoint make_client_endpoint(const std::filesystem::path& path
     return stream_protocol::endpoint(path.string());
 }
 
+// Wait up to `timeout` for the socket to be ready for `events` (POLLIN/POLLOUT), throwing on
+// timeout or error. This bounds the exchange: the transport does blocking reads/writes, and asio's
+// synchronous read masks SO_RCVTIMEO (on EAGAIN it polls untimed and retries), so an explicit
+// poll() is what actually stops transact() from hanging forever on a host that accepted the
+// connection (the listen backlog does that even before it serves) but never answers.
+void wait_for_socket(
+    int fd, short events, std::chrono::milliseconds timeout, const std::filesystem::path& path, const char* what) {
+    struct pollfd pfd = {};
+    pfd.fd = fd;
+    pfd.events = events;
+    int rc = 0;
+    do {
+        rc = ::poll(&pfd, 1, static_cast<int>(timeout.count()));
+    } while (rc < 0 && errno == EINTR);
+    UMD_ASSERT(
+        rc >= 0, error::RuntimeError, fmt::format("poll() on simulation host socket at {} failed", path.string()));
+    UMD_ASSERT(
+        rc != 0,
+        error::RuntimeError,
+        fmt::format(
+            "Timed out after {} ms waiting to {} on simulation host at {} (host reachable but not responding)",
+            timeout.count(),
+            what,
+            path.string()));
+    // poll() reports the fd "ready" for reasons other than `events` too. A hard error (POLLERR/
+    // POLLNVAL) means the send/recv that follows can only fail, so surface it here with the poll
+    // state rather than let it come back as a murkier transport error. POLLHUP alone (peer closed,
+    // no data) is likewise not readiness; but POLLHUP *with* POLLIN is -- there may be buffered
+    // bytes to read before EOF -- so we gate on `events` being set rather than rejecting POLLHUP.
+    if (pfd.revents & (POLLERR | POLLNVAL)) {
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format(
+                "Socket error while waiting to {} on simulation host at {} (poll revents=0x{:x})",
+                what,
+                path.string(),
+                static_cast<unsigned>(pfd.revents)));
+    }
+    if (!(pfd.revents & events)) {
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format(
+                "Simulation host at {} closed the connection before we could {} (poll revents=0x{:x})",
+                path.string(),
+                what,
+                static_cast<unsigned>(pfd.revents)));
+    }
+}
+
 }  // namespace
 
 // The asio transport, kept out of the header (see SimulationClient::Impl forward declaration).
@@ -45,8 +97,8 @@ struct SimulationClient::Impl {
     stream_protocol::socket socket{io};
 };
 
-SimulationClient::SimulationClient(std::filesystem::path socket_path) :
-    socket_path_(std::move(socket_path)), impl_(std::make_unique<Impl>()) {}
+SimulationClient::SimulationClient(std::filesystem::path socket_path, std::chrono::milliseconds timeout) :
+    socket_path_(std::move(socket_path)), timeout_(timeout), impl_(std::make_unique<Impl>()) {}
 
 SimulationClient::~SimulationClient() { detach(); }
 
@@ -94,7 +146,12 @@ std::vector<uint8_t> SimulationClient::transact(const std::vector<uint8_t>& requ
             error::RuntimeError,
             fmt::format("Cannot transact with simulation host at {}: not attached", socket_path_.string()));
     }
+    const int fd = impl_->socket.native_handle();
+    wait_for_socket(fd, POLLOUT, timeout_, socket_path_, "send the request");
     send_framed(impl_->socket, request);
+    // Bound the wait for the host to start replying -- the hang this guards against is a host that
+    // accepted the connection but never answers.
+    wait_for_socket(fd, POLLIN, timeout_, socket_path_, "receive the reply");
     return recv_framed(impl_->socket);
 }
 

--- a/tests/baremetal/test_simulation_client.cpp
+++ b/tests/baremetal/test_simulation_client.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <unistd.h>
 
+#include <chrono>
 #include <cstdint>
 #include <filesystem>
 #include <string>
@@ -57,6 +58,17 @@ TEST_F(SimulationClientTest, DestructorDetaches) {
         SimulationClient client(path_);
         EXPECT_NO_THROW(client.attach());
     }
+}
+
+// A host that is bound but not yet serving (serve() not called) still accepts the connection via
+// the listen backlog, then never answers. transact() must time out and throw rather than block
+// forever waiting for a reply.
+TEST_F(SimulationClientTest, TransactTimesOutWhenHostNotServing) {
+    auto server = SimulationServerSocket::create(path_);  // bound + connectable, but serve() not called
+
+    SimulationClient client(path_, std::chrono::milliseconds(300));
+    ASSERT_NO_THROW(client.attach());
+    EXPECT_THROW(client.transact({0x01, 0x02, 0x03}), std::exception);
 }
 
 // End to end over the socket: transact() returns the host's reply, not the request it sent (the


### PR DESCRIPTION
### Issue
Part of #2677 (simulation server). Follow-up to a review comment on #3020: a client that connects to a host which is **bound but not yet (or no longer) serving** is accepted by the listen backlog, then blocks **forever** in `transact()` waiting for a reply that never arrives — there was no timeout anywhere on the client path. Independent of the sim-server PR stack (`SimulationClient` is already on `main`), so this targets `main` directly.

### Description
`SimulationClient` gains a timeout (default `timeout::SIMULATION_SOCKET_TIMEOUT` = 30s, overridable via the constructor). It's enforced with an explicit `poll()` before each send and before the recv in `transact()`, so a host that accepts the connection but never answers makes `transact()` throw a clear error instead of hanging.

`poll()` rather than `SO_RCVTIMEO`: asio's **synchronous** read masks the socket-level timeout — on `EAGAIN` it does an *untimed* `poll` and retries — so `SO_RCVTIMEO` never surfaces as an error (verified: the socket-option approach still hung). `poll()` with the timeout reliably bounds the wait without touching the shared blocking transport.

### List of the changes
- `timeouts.hpp` — `SIMULATION_SOCKET_TIMEOUT` (30s default).
- `SimulationClient` — constructor takes a `std::chrono::milliseconds timeout`; `transact()` `poll()`s (POLLOUT before send, POLLIN before recv) and throws on timeout.
- `tests/baremetal/test_simulation_client.cpp` — `TransactTimesOutWhenHostNotServing`: a bound-but-not-serving host makes `transact()` throw within the timeout instead of hanging.

### Testing
Build + pre-commit clean; baremetal `SimulationClientTest.*` pass (8/8), including the new timeout test which returns promptly (no hang).

### API Changes
`SimulationClient` constructor gains an optional `std::chrono::milliseconds timeout` (defaulted). Otherwise internal.


### Scope
The timeout bounds the **start** of each exchange — the `poll()` fires before the send and before the first byte of the reply — which is exactly the hang this fixes (a host that accepts the connection but never begins answering). It does **not** bound a host that starts a reply and then stalls **mid-frame**: `recv_framed()`/`send_framed()` then block in `asio::read`/`write`. Fully bounding the whole framed transfer needs a deadline threaded into the shared `send_framed`/`recv_framed` transport (which the server blocks on indefinitely by design) and is tracked as a follow-up in #3101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
