### PR TITLE
Add exabox workflow

### DIFF
--- a/.github/docker_install_common.sh
+++ b/.github/docker_install_common.sh
@@ -31,10 +31,11 @@ apt-get update && apt-get install -y \
     xxd \
     rpm \
     dpkg-dev \
-    fakeroot
+    fakeroot \
+    jq
 
 # Install Python dependencies
-python3 -m pip install --no-cache-dir pytest pyyaml
+python3 -m pip install --no-cache-dir pytest pyyaml tt-smi
 
 # gcc-11 should be available only for ubuntu 22 and not 20
 if apt-cache show gcc-11 > /dev/null 2>&1; then

--- a/.github/docker_install_common.sh
+++ b/.github/docker_install_common.sh
@@ -86,10 +86,13 @@ grep -q '^StrictModes no' /etc/ssh/sshd_config || echo "StrictModes no" >> /etc/
 
 # OpenMPI with ULFM — must match the exabox runner's launch agent path
 # (/opt/openmpi-v5.0.7-ulfm/bin/prted). Same package metal installs for multihost.
+# SHA256 pinned for supply-chain integrity of the GitHub release artifact.
 OMPI_DEB_URL="https://github.com/tenstorrent/ompi/releases/download/v5.0.7/openmpi-ulfm_5.0.7-1_amd64.deb"
+OMPI_DEB_SHA256="954e872d9105e8bf8c31368ff7a5db8670a3d549e2e7eb1ab6072cffcae7984d"
 OMPI_DEB_FILE="$(basename "$OMPI_DEB_URL")"
 OMPI_TMP="$(mktemp -d)"
 wget -q -O "${OMPI_TMP}/${OMPI_DEB_FILE}" "${OMPI_DEB_URL}"
+echo "${OMPI_DEB_SHA256}  ${OMPI_TMP}/${OMPI_DEB_FILE}" | sha256sum -c -
 apt-get install -y --no-install-recommends "${OMPI_TMP}/${OMPI_DEB_FILE}"
 rm -rf "${OMPI_TMP}"
 test -x /opt/openmpi-v5.0.7-ulfm/bin/prted

--- a/.github/docker_install_common.sh
+++ b/.github/docker_install_common.sh
@@ -70,3 +70,15 @@ apt install -y clang-format-20 && \
 
 # Install clang-tidy-20
 apt-get install -y clang-tidy-20
+
+# OpenSSH server for TTOP / multihost MPI workers (mpirun SSHes into this image).
+# Keep config tweaks after the apt install so openssh-server does not overwrite them.
+apt-get install -y --no-install-recommends openssh-server sudo
+if ! id -u user >/dev/null 2>&1; then
+    adduser --uid 1001 --shell /bin/bash --disabled-password --gecos "" user
+fi
+usermod -aG sudo user
+echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+chmod 0440 /etc/sudoers.d/user
+mkdir -p /run/sshd
+grep -q '^StrictModes no' /etc/ssh/sshd_config || echo "StrictModes no" >> /etc/ssh/sshd_config

--- a/.github/docker_install_common.sh
+++ b/.github/docker_install_common.sh
@@ -82,3 +82,13 @@ echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
 chmod 0440 /etc/sudoers.d/user
 mkdir -p /run/sshd
 grep -q '^StrictModes no' /etc/ssh/sshd_config || echo "StrictModes no" >> /etc/ssh/sshd_config
+
+# OpenMPI with ULFM — must match the exabox runner's launch agent path
+# (/opt/openmpi-v5.0.7-ulfm/bin/prted). Same package metal installs for multihost.
+OMPI_DEB_URL="https://github.com/tenstorrent/ompi/releases/download/v5.0.7/openmpi-ulfm_5.0.7-1_amd64.deb"
+OMPI_DEB_FILE="$(basename "$OMPI_DEB_URL")"
+OMPI_TMP="$(mktemp -d)"
+wget -q -O "${OMPI_TMP}/${OMPI_DEB_FILE}" "${OMPI_DEB_URL}"
+apt-get install -y --no-install-recommends "${OMPI_TMP}/${OMPI_DEB_FILE}"
+rm -rf "${OMPI_TMP}"
+test -x /opt/openmpi-v5.0.7-ulfm/bin/prted

--- a/.github/workflows/run-hang-detection-tests.yml
+++ b/.github/workflows/run-hang-detection-tests.yml
@@ -1,28 +1,31 @@
-# Destructive NOC hang / MMIO-timeout tests.
-# Runs automatically every night on a set of cards, and can also be
-# triggered manually from the Actions tab ("Run workflow"), picking the card to run on.
-name: Run hang detection tests
+# Build UMD and run an arbitrary test command on exabox (sc1 / sc4 / sc16).
+# Trigger from the Actions tab: pick hardware, paste a test command, and run.
+name: Run tests on exabox
 
 on:
-  schedule:
-    # Run nightly at 1 AM UTC.
-    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
-      card:
-        description: 'Card/runner to run the destructive hang tests on'
+      hardware:
+        description: >-
+          Exabox hardware to allocate (sc1 = 1 Galaxy, sc4 = 4-Galaxy quad,
+          sc16 = 16-Galaxy SC16).
         required: true
         type: choice
-        default: tt-ubuntu-2204-n150-stable
+        default: sc1
         options:
-          - tt-ubuntu-2204-n150-stable
-          - tt-ubuntu-2204-n300-stable
-          - tt-ubuntu-2204-p150b-stable
-          - P300-viommu
-          - tt-ubuntu-2204-wh-glx-6u-stable
-          - 6u
+          - sc1
+          - sc4
+          - sc16
+      test-command:
+        description: >-
+          Shell command to run after the cluster is up. The runner has mpirun
+          configured (hostfile /etc/ttop/hostfile). Artifacts live under
+          /home/user/tt-umd on every worker (and on the runner). Example:
+          mpirun --pernode bash -lc 'cd /home/user/tt-umd && ./build/test/umd/api/api_tests'
+        required: true
+        type: string
       build-type:
-        description: 'CMake build type'
+        description: CMake build type
         required: true
         default: Release
         type: choice
@@ -33,7 +36,7 @@ on:
           - ASan
           - TSan
       ubuntu-docker-version:
-        description: 'Ubuntu docker image version to build and run in'
+        description: Ubuntu docker image version to build and use as worker image
         required: true
         default: ubuntu-22.04
         type: choice
@@ -41,106 +44,276 @@ on:
           - ubuntu-22.04
           - ubuntu-24.04
       timeout:
-        description: 'Per-job timeout in minutes'
+        description: Per-job timeout in minutes (build and run)
         required: true
-        default: 30
+        default: 120
         type: number
+      build-wheel:
+        description: Also build and install the Python wheel on workers
+        required: false
+        default: false
+        type: boolean
 
-# Defaults below (via `github.event.inputs.* || '...'`) are used for the nightly scheduled run.
-# Manual dispatch overrides them with the chosen values.
+permissions:
+  id-token: write
+  contents: read
+
 env:
-  TEST_OUTPUT_DIR: ./build/test
   ARTIFACT_NAME: >-
-    build-artifacts-${{ github.event.inputs.ubuntu-docker-version || 'ubuntu-22.04'
-    }}-${{ github.event.inputs.build-type || 'Release' }}
+    build-artifacts-${{ inputs.ubuntu-docker-version }}-${{ inputs.build-type }}
+  WHEEL_ARTIFACT_NAME: >-
+    wheel-artifact-${{ inputs.ubuntu-docker-version }}-${{ inputs.build-type }}
+  ALLOCATION_NAME: ci-umd-${{ github.run_id }}-${{ inputs.hardware }}
 
 jobs:
   build:
     secrets: inherit
     uses: ./.github/workflows/build-tests.yml
     with:
-      ubuntu-docker-version: ${{ github.event.inputs.ubuntu-docker-version || 'ubuntu-22.04' }}
-      build-type: ${{ github.event.inputs.build-type || 'Release' }}
-      timeout: ${{ fromJSON(github.event.inputs.timeout || '30') }}
-      build-targets: hang_detection_tests
-      build-wheel: false
+      ubuntu-docker-version: ${{ inputs.ubuntu-docker-version }}
+      build-type: ${{ inputs.build-type }}
+      timeout: ${{ fromJSON(inputs.timeout) }}
+      build-wheel: ${{ inputs.build-wheel }}
 
   run:
-    name: Run hang_detection_tests (${{ matrix.card }})
+    name: Run on exabox (${{ inputs.hardware }})
     needs: build
-    timeout-minutes: ${{ fromJSON(github.event.inputs.timeout || '30') }}
-    strategy:
-      fail-fast: false
-      # Manual dispatch runs on the single chosen card; the nightly schedule fans out
-      # across the default card set (n150, n300, p150, p300, glx).
-      matrix:
-        card: >-
-          ${{ fromJSON(github.event_name == 'schedule' && '[
-          "tt-ubuntu-2204-n150-stable",
-          "tt-ubuntu-2204-n300-stable",
-          "tt-ubuntu-2204-p150b-stable",
-          "P300-viommu",
-          "tt-ubuntu-2204-wh-glx-6u-stable"
-          ]' || format('["{0}"]', github.event.inputs.card)) }}
+    timeout-minutes: ${{ fromJSON(inputs.timeout) }}
     runs-on:
-      - ${{ matrix.card }}
-    container:
-      image: >-
-        ghcr.io/${{ github.repository }}/tt-umd-ci-${{
-        github.event.inputs.ubuntu-docker-version || 'ubuntu-22.04' }}:latest
-      options: --device /dev/tenstorrent
-      volumes:
-        - /dev/hugepages:/dev/hugepages
-        - /dev/hugepages-1G:/dev/hugepages-1G
-        - /etc/udev/rules.d:/etc/udev/rules.d
-        - /lib/modules:/lib/modules
-        - /opt/tt_metal_infra/provisioning/provisioning_env:/opt/tt_metal_infra/provisioning/provisioning_env
-
-    env:
-      LD_LIBRARY_PATH: ./build/lib
+      - exabox-multihost-with-nfs
 
     steps:
-      - name: Cleanup workspace directory from previous runs
-        run: |
-          echo "Cleaning up working directory from previous runs: $(pwd)"
-          rm -rf *
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-      - name: Use build artifacts
+      - name: Resolve allocation spec for ${{ inputs.hardware }}
+        id: sku
+        run: |
+          case "${{ inputs.hardware }}" in
+            sc1)
+              cat <<'EOF' > /tmp/allocation_spec.yaml
+          allocationType: Count
+          count: 1
+          EOF
+              ;;
+            sc4)
+              cat <<'EOF' > /tmp/allocation_spec.yaml
+          allocationType: Count
+          count: 4
+          topologyKeys:
+            - exabox.tenstorrent.com/quad
+          EOF
+              ;;
+            sc16)
+              cat <<'EOF' > /tmp/allocation_spec.yaml
+          allocationType: Count
+          count: 16
+          topologyKeys:
+            - exabox.tenstorrent.com/SC16
+          EOF
+              ;;
+            *)
+              echo "::error::Unknown hardware '${{ inputs.hardware }}'"
+              exit 1
+              ;;
+          esac
+          {
+            echo "allocation_spec<<EOF"
+            cat /tmp/allocation_spec.yaml
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved allocation spec for ${{ inputs.hardware }}:"
+          cat /tmp/allocation_spec.yaml
+
+
+      - name: Fetch environment SSH setup script from tt-metal
+        # ttop-create-environment shells into GITHUB_WORKSPACE and runs
+        # .github/scripts/environment-ssh-setup.sh from this repo's tree.
+        uses: actions/checkout@v4
+        with:
+          repository: tenstorrent/tt-metal
+          sparse-checkout: |
+            .github/scripts/environment-ssh-setup.sh
+          sparse-checkout-cone-mode: false
+          path: _tt-metal
+          persist-credentials: false
+
+      - name: Install environment SSH setup script
+        run: |
+          mkdir -p .github/scripts
+          cp _tt-metal/.github/scripts/environment-ssh-setup.sh .github/scripts/
+          chmod +x .github/scripts/environment-ssh-setup.sh
+
+      - name: Create allocation
+        id: allocation
+        uses: tenstorrent/tt-metal/.github/actions/ttop-create-allocation@main
+        timeout-minutes: 120
+        with:
+          allocationName: ${{ env.ALLOCATION_NAME }}
+          namespace: ttop-ci
+          spec: ${{ steps.sku.outputs.allocation_spec }}
+
+      - name: Get allocation configs
+        uses: tenstorrent/tt-metal/.github/actions/ttop-get-allocation-data@main
+        with:
+          allocationName: ${{ env.ALLOCATION_NAME }}
+          allocationNamespace: ttop-ci
+
+      - name: Create test environment
+        uses: tenstorrent/tt-metal/.github/actions/ttop-create-environment@main
+        timeout-minutes: 30
+        with:
+          environmentName: ${{ env.ALLOCATION_NAME }}
+          allocationName: ${{ env.ALLOCATION_NAME }}
+          allocationNamespace: ttop-ci
+          workerRepository: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}
+          workerTag: latest
+          useDevHostMount: "true"
+          sharedVolumeEnabled: "true"
+          path: /etc/ttop
+
+      - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:
           name: ${{ env.ARTIFACT_NAME }}
+          path: /ci/artifacts
 
-      - name: Untar build artifacts
-        shell: bash
-        run: tar xvf artifact.tar
+      - name: Download wheel artifact
+        if: ${{ inputs.build-wheel }}
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ env.WHEEL_ARTIFACT_NAME }}
+          path: /ci/artifacts
 
-      - name: Run hang detection tests
+      - name: Unpack artifacts onto workers
         run: |
-          ${{ env.TEST_OUTPUT_DIR }}/umd/hang_detection/hang_detection_tests
+          set -euo pipefail
 
-  notify-slack:
-    name: 📢 Notify #tt-umd-ci on failure
-    runs-on: ubuntu-latest
-    needs: [build, run]
-    # One message per nightly run, only when the build or any card failed.
-    # Scheduled runs only — manual dispatch is for interactive testing and
-    # shouldn't ping the channel.
-    if: failure() && github.event_name == 'schedule'
-    steps:
-      - name: Send Slack notification
+          rm -rf /ci/tt-umd
+          cp -r "$GITHUB_WORKSPACE" /ci/tt-umd
+
+          BUILD_ARCHIVE=/ci/artifacts/artifact.tar
+          if [ ! -f "$BUILD_ARCHIVE" ]; then
+            echo "ERROR: expected $BUILD_ARCHIVE"
+            ls -R /ci/artifacts
+            exit 1
+          fi
+
+          # Local copy on the runner (handy for commands that launch from here).
+          sudo rm -rf /home/user/tt-umd
+          sudo mkdir -p /home/user
+          sudo chown "$(id -u):$(id -g)" /home/user
+          cp -r /ci/tt-umd /home/user/
+          tar xf "$BUILD_ARCHIVE" -C /home/user/tt-umd
+
+          # Fan out source + build to every allocated host via NFS + mpirun.
+          mpirun --pernode bash -lc 'rm -rf /home/user/tt-umd && cp -r /ci/tt-umd /home/user/'
+          mpirun --pernode tar xf "$BUILD_ARCHIVE" -C /home/user/tt-umd
+
+          if [ "${{ inputs.build-wheel }}" = "true" ]; then
+            shopt -s nullglob globstar
+            wheels=(/ci/artifacts/tt_umd-*.whl /ci/artifacts/**/tt_umd-*.whl)
+            if [ ${#wheels[@]} -eq 0 ]; then
+              echo "ERROR: build-wheel requested but no tt_umd-*.whl under /ci/artifacts"
+              ls -R /ci/artifacts
+              exit 1
+            fi
+            echo "Installing wheel: ${wheels[0]}"
+            mpirun --pernode bash -lc "python3 -m pip install --force-reinstall '${wheels[0]}'"
+          fi
+
+      - name: Reset cards and validate cluster
+        working-directory: /tmp
+        timeout-minutes: 45
         run: |
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          cat << EOF > /tmp/slack_message.txt
-          🚨 Nightly hang detection tests failed
+          set -euo pipefail
+          MAX_RECOVERY_ATTEMPTS=10
+          SYSTEM_HEALTH=/home/user/tt-umd/build/tools/umd/system_health
+          export LD_LIBRARY_PATH=/home/user/tt-umd/build/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 
-          The build or one or more cards failed the destructive NOC hang / warm-reset tests.
+          echo "--- Pre-check: tt-smi visibility on all hosts ---"
+          mpirun --pernode --tag-output \
+            bash -lc '
+              snapshot=$(tt-smi --snapshot_no_tty --snapshot)
+              driver=$(jq -r ".host_info.Driver // \"unknown\"" <<< "$snapshot")
+              tt_smi=$(jq -r ".host_sw_vers.tt_smi // \"unknown\"" <<< "$snapshot")
+              echo "$(hostname): Driver=${driver} tt_smi=${tt_smi}"
+            ' || true
 
-          Run: ${RUN_URL}
-          EOF
+          run_system_health() {
+            mpirun --pernode --tag-output -x LD_LIBRARY_PATH \
+              bash -lc "cd /home/user/tt-umd && '${SYSTEM_HEALTH}'"
+          }
 
-          jq -n --arg msg "$(cat /tmp/slack_message.txt)" \
-            '{report: $msg}' > /tmp/payload.json
+          for attempt in $(seq 1 "$MAX_RECOVERY_ATTEMPTS"); do
+            echo "=== Recovery attempt $attempt of $MAX_RECOVERY_ATTEMPTS ==="
+            reset_success=false
+            validation_success=false
 
-          curl -X POST "${{ secrets.TT_UMD_CI_SLACK_WEBHOOK_URL }}" \
-            -H "Content-Type: application/json" \
-            -d @/tmp/payload.json
+            echo "--- Resetting cards with tt-smi ---"
+            if mpirun --pernode tt-smi -glx_reset; then
+              reset_success=true
+            else
+              echo "WARNING: -glx_reset failed on attempt $attempt, trying tt-smi -r"
+              if mpirun --pernode tt-smi -r; then
+                reset_success=true
+              else
+                echo "WARNING: Reset failed on attempt $attempt"
+              fi
+            fi
+
+            if [ "$reset_success" = true ]; then
+              echo "--- Sleeping 5s after reset to allow links/services to settle ---"
+              sleep 5
+
+              echo "--- Running UMD system_health ---"
+              if run_system_health; then
+                validation_success=true
+              else
+                echo "WARNING: system_health failed on attempt $attempt"
+              fi
+            else
+              echo "WARNING: Skipping system_health because reset failed on attempt $attempt"
+            fi
+
+            if [ "$reset_success" = true ] && [ "$validation_success" = true ]; then
+              echo "SUCCESS: Reset and system_health passed on attempt $attempt"
+              exit 0
+            fi
+
+            if [ "$attempt" -lt "$MAX_RECOVERY_ATTEMPTS" ]; then
+              echo "Sleeping 30s before retry..."
+              sleep 30
+            fi
+          done
+
+          echo "ERROR: Recovery failed after $MAX_RECOVERY_ATTEMPTS attempts"
+          exit 1
+
+      - name: Run test command
+        id: run-test
+        working-directory: /home/user/tt-umd
+        # Pass via env to avoid shell injection from workflow_dispatch input.
+        env:
+          TEST_COMMAND: ${{ inputs.test-command }}
+        run: |
+          set -euo pipefail
+          echo "Running test command:"
+          echo "$TEST_COMMAND"
+          eval "$TEST_COMMAND"
+
+      - name: Delete test environment
+        if: always()
+        uses: tenstorrent/tt-metal/.github/actions/ttop-delete-environment@main
+        with:
+          environmentName: ${{ env.ALLOCATION_NAME }}
+          namespace: ttop-ci
+
+      - name: Delete allocation
+        if: always()
+        uses: tenstorrent/tt-metal/.github/actions/ttop-delete-allocation@main
+        with:
+          allocationName: ${{ env.ALLOCATION_NAME }}
+          namespace: ttop-ci

--- a/.github/workflows/run-hang-detection-tests.yml
+++ b/.github/workflows/run-hang-detection-tests.yml
@@ -163,13 +163,15 @@ jobs:
           allocationNamespace: ttop-ci
 
       - name: Create test environment
+        # Worker must provide /usr/sbin/sshd. tt-umd-ci does not; use the
+        # orchestration SSH host image. Test binaries are still fanned out via NFS.
         uses: tenstorrent/tt-metal/.github/actions/ttop-create-environment@main
         timeout-minutes: 30
         with:
           environmentName: ${{ env.ALLOCATION_NAME }}
           allocationName: ${{ env.ALLOCATION_NAME }}
           allocationNamespace: ttop-ci
-          workerRepository: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}
+          workerRepository: ghcr.io/tenstorrent/tt-orchestration/ttop-ssh-host
           workerTag: latest
           useDevHostMount: "true"
           sharedVolumeEnabled: "true"

--- a/.github/workflows/run-hang-detection-tests.yml
+++ b/.github/workflows/run-hang-detection-tests.yml
@@ -1,6 +1,6 @@
 # Build UMD and run an arbitrary test command on exabox (sc1 / sc4 / sc16).
 # Trigger from the Actions tab: pick hardware, paste a test command, and run.
-name: Run tests on exabox
+name: Run hang detection tests on exabox
 
 on:
   workflow_dispatch:

--- a/.github/workflows/run-hang-detection-tests.yml
+++ b/.github/workflows/run-hang-detection-tests.yml
@@ -56,6 +56,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  packages: write
 
 env:
   ARTIFACT_NAME: >-
@@ -65,7 +66,17 @@ env:
   ALLOCATION_NAME: ci-umd-${{ github.run_id }}-${{ inputs.hardware }}
 
 jobs:
+  ensure-docker-image:
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker-image.yml
+    with:
+      docker-version: ${{ inputs.ubuntu-docker-version }}
+
   build:
+    needs: ensure-docker-image
     secrets: inherit
     uses: ./.github/workflows/build-tests.yml
     with:
@@ -73,10 +84,11 @@ jobs:
       build-type: ${{ inputs.build-type }}
       timeout: ${{ fromJSON(inputs.timeout) }}
       build-wheel: ${{ inputs.build-wheel }}
+      image-tag: ${{ needs.ensure-docker-image.outputs.image-tag }}
 
   run:
     name: Run on exabox (${{ inputs.hardware }})
-    needs: build
+    needs: [ensure-docker-image, build]
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
     runs-on:
       - exabox-multihost-with-nfs
@@ -163,16 +175,14 @@ jobs:
           allocationNamespace: ttop-ci
 
       - name: Create test environment
-        # Worker must provide /usr/sbin/sshd. tt-umd-ci does not; use the
-        # orchestration SSH host image. Test binaries are still fanned out via NFS.
         uses: tenstorrent/tt-metal/.github/actions/ttop-create-environment@main
         timeout-minutes: 30
         with:
           environmentName: ${{ env.ALLOCATION_NAME }}
           allocationName: ${{ env.ALLOCATION_NAME }}
           allocationNamespace: ttop-ci
-          workerRepository: ghcr.io/tenstorrent/tt-orchestration/ttop-ssh-host
-          workerTag: latest
+          workerRepository: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}
+          workerTag: ${{ needs.ensure-docker-image.outputs.image-tag }}
           useDevHostMount: "true"
           sharedVolumeEnabled: "true"
           path: /etc/ttop

--- a/.github/workflows/run-hang-detection-tests.yml
+++ b/.github/workflows/run-hang-detection-tests.yml
@@ -1,30 +1,28 @@
-# Build UMD and run an arbitrary test command on exabox (sc1 / sc4 / sc16).
-# Trigger from the Actions tab: pick hardware, paste a test command, and run.
-name: Run hang detection tests on exabox
+# Destructive NOC hang / MMIO-timeout tests.
+# Runs automatically every night on a set of cards, and can also be
+# triggered manually from the Actions tab ("Run workflow"), picking the card to run on.
+name: Run hang detection tests
 
 on:
+  schedule:
+    # Run nightly at 1 AM UTC.
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
-      hardware:
-        description: >-
-          Exabox hardware to allocate (sc1 = 1 Galaxy, sc4 = 4-Galaxy quad,
-          sc16 = 16-Galaxy SC16).
+      card:
+        description: 'Card/runner to run the destructive hang tests on'
         required: true
         type: choice
-        default: sc1
+        default: tt-ubuntu-2204-n150-stable
         options:
-          - sc1
-          - sc4
-          - sc16
-      test-command:
-        description: >-
-          Shell command run on every allocated host via mpirun --pernode
-          (cwd /home/user/tt-umd, LD_LIBRARY_PATH includes build/lib). Example:
-          ./build/test/umd/galaxy/unit_tests_glx
-        required: true
-        type: string
+          - tt-ubuntu-2204-n150-stable
+          - tt-ubuntu-2204-n300-stable
+          - tt-ubuntu-2204-p150b-stable
+          - P300-viommu
+          - tt-ubuntu-2204-wh-glx-6u-stable
+          - 6u
       build-type:
-        description: CMake build type
+        description: 'CMake build type'
         required: true
         default: Release
         type: choice
@@ -35,7 +33,7 @@ on:
           - ASan
           - TSan
       ubuntu-docker-version:
-        description: Ubuntu docker image version to build and use as worker image
+        description: 'Ubuntu docker image version to build and run in'
         required: true
         default: ubuntu-22.04
         type: choice
@@ -43,292 +41,106 @@ on:
           - ubuntu-22.04
           - ubuntu-24.04
       timeout:
-        description: Per-job timeout in minutes (build and run)
+        description: 'Per-job timeout in minutes'
         required: true
-        default: 120
+        default: 30
         type: number
-      build-wheel:
-        description: Also build and install the Python wheel on workers
-        required: false
-        default: false
-        type: boolean
 
-permissions:
-  id-token: write
-  contents: read
-  packages: write
-
+# Defaults below (via `github.event.inputs.* || '...'`) are used for the nightly scheduled run.
+# Manual dispatch overrides them with the chosen values.
 env:
+  TEST_OUTPUT_DIR: ./build/test
   ARTIFACT_NAME: >-
-    build-artifacts-${{ inputs.ubuntu-docker-version }}-${{ inputs.build-type }}
-  WHEEL_ARTIFACT_NAME: >-
-    wheel-artifact-${{ inputs.ubuntu-docker-version }}-${{ inputs.build-type }}
-  ALLOCATION_NAME: ci-umd-${{ github.run_id }}-${{ inputs.hardware }}
+    build-artifacts-${{ github.event.inputs.ubuntu-docker-version || 'ubuntu-22.04'
+    }}-${{ github.event.inputs.build-type || 'Release' }}
 
 jobs:
-  ensure-docker-image:
-    secrets: inherit
-    permissions:
-      contents: read
-      packages: write
-    uses: ./.github/workflows/docker-image.yml
-    with:
-      docker-version: ${{ inputs.ubuntu-docker-version }}
-
   build:
-    needs: ensure-docker-image
     secrets: inherit
     uses: ./.github/workflows/build-tests.yml
     with:
-      ubuntu-docker-version: ${{ inputs.ubuntu-docker-version }}
-      build-type: ${{ inputs.build-type }}
-      timeout: ${{ fromJSON(inputs.timeout) }}
-      build-wheel: ${{ inputs.build-wheel }}
-      image-tag: ${{ needs.ensure-docker-image.outputs.image-tag }}
+      ubuntu-docker-version: ${{ github.event.inputs.ubuntu-docker-version || 'ubuntu-22.04' }}
+      build-type: ${{ github.event.inputs.build-type || 'Release' }}
+      timeout: ${{ fromJSON(github.event.inputs.timeout || '30') }}
+      build-targets: hang_detection_tests
+      build-wheel: false
 
   run:
-    name: Run on exabox (${{ inputs.hardware }})
-    needs: [ensure-docker-image, build]
-    timeout-minutes: ${{ fromJSON(inputs.timeout) }}
+    name: Run hang_detection_tests (${{ matrix.card }})
+    needs: build
+    timeout-minutes: ${{ fromJSON(github.event.inputs.timeout || '30') }}
+    strategy:
+      fail-fast: false
+      # Manual dispatch runs on the single chosen card; the nightly schedule fans out
+      # across the default card set (n150, n300, p150, p300, glx).
+      matrix:
+        card: >-
+          ${{ fromJSON(github.event_name == 'schedule' && '[
+          "tt-ubuntu-2204-n150-stable",
+          "tt-ubuntu-2204-n300-stable",
+          "tt-ubuntu-2204-p150b-stable",
+          "P300-viommu",
+          "tt-ubuntu-2204-wh-glx-6u-stable"
+          ]' || format('["{0}"]', github.event.inputs.card)) }}
     runs-on:
-      - exabox-multihost-with-nfs
+      - ${{ matrix.card }}
+    container:
+      image: >-
+        ghcr.io/${{ github.repository }}/tt-umd-ci-${{
+        github.event.inputs.ubuntu-docker-version || 'ubuntu-22.04' }}:latest
+      options: --device /dev/tenstorrent
+      volumes:
+        - /dev/hugepages:/dev/hugepages
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /etc/udev/rules.d:/etc/udev/rules.d
+        - /lib/modules:/lib/modules
+        - /opt/tt_metal_infra/provisioning/provisioning_env:/opt/tt_metal_infra/provisioning/provisioning_env
+
+    env:
+      LD_LIBRARY_PATH: ./build/lib
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Resolve allocation spec for ${{ inputs.hardware }}
-        id: sku
+      - name: Cleanup workspace directory from previous runs
         run: |
-          case "${{ inputs.hardware }}" in
-            sc1)
-              cat <<'EOF' > /tmp/allocation_spec.yaml
-          allocationType: Count
-          count: 1
-          EOF
-              ;;
-            sc4)
-              cat <<'EOF' > /tmp/allocation_spec.yaml
-          allocationType: Count
-          count: 4
-          topologyKeys:
-            - exabox.tenstorrent.com/quad
-          EOF
-              ;;
-            sc16)
-              cat <<'EOF' > /tmp/allocation_spec.yaml
-          allocationType: Count
-          count: 16
-          topologyKeys:
-            - exabox.tenstorrent.com/SC16
-          EOF
-              ;;
-            *)
-              echo "::error::Unknown hardware '${{ inputs.hardware }}'"
-              exit 1
-              ;;
-          esac
-          {
-            echo "allocation_spec<<EOF"
-            cat /tmp/allocation_spec.yaml
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-          echo "Resolved allocation spec for ${{ inputs.hardware }}:"
-          cat /tmp/allocation_spec.yaml
+          echo "Cleaning up working directory from previous runs: $(pwd)"
+          rm -rf *
 
-
-      - name: Fetch ttop helpers from tt-metal
-        # metal's ttop-*@main composites resolve ./.github/actions/ttop-await-resource
-        # and .github/scripts/environment-ssh-setup.sh against THIS workspace.
-        uses: actions/checkout@v4
-        with:
-          repository: tenstorrent/tt-metal
-          sparse-checkout: |
-            .github/scripts/environment-ssh-setup.sh
-            .github/actions/ttop-await-resource
-          sparse-checkout-cone-mode: false
-          path: _tt-metal
-          persist-credentials: false
-
-      - name: Install ttop helpers from tt-metal
-        run: |
-          mkdir -p .github/scripts .github/actions
-          cp _tt-metal/.github/scripts/environment-ssh-setup.sh .github/scripts/
-          chmod +x .github/scripts/environment-ssh-setup.sh
-          cp -R _tt-metal/.github/actions/ttop-await-resource .github/actions/
-
-      - name: Create allocation
-        id: allocation
-        uses: tenstorrent/tt-metal/.github/actions/ttop-create-allocation@main
-        timeout-minutes: 120
-        with:
-          allocationName: ${{ env.ALLOCATION_NAME }}
-          namespace: ttop-ci
-          spec: ${{ steps.sku.outputs.allocation_spec }}
-
-      - name: Get allocation configs
-        uses: tenstorrent/tt-metal/.github/actions/ttop-get-allocation-data@main
-        with:
-          allocationName: ${{ env.ALLOCATION_NAME }}
-          allocationNamespace: ttop-ci
-
-      - name: Create test environment
-        uses: tenstorrent/tt-metal/.github/actions/ttop-create-environment@main
-        timeout-minutes: 30
-        with:
-          environmentName: ${{ env.ALLOCATION_NAME }}
-          allocationName: ${{ env.ALLOCATION_NAME }}
-          allocationNamespace: ttop-ci
-          workerRepository: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}
-          workerTag: ${{ needs.ensure-docker-image.outputs.image-tag }}
-          useDevHostMount: "true"
-          sharedVolumeEnabled: "true"
-          path: /etc/ttop
-
-      - name: Download build artifacts
+      - name: Use build artifacts
         uses: actions/download-artifact@v8
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          path: /ci/artifacts
 
-      - name: Download wheel artifact
-        if: ${{ inputs.build-wheel }}
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ env.WHEEL_ARTIFACT_NAME }}
-          path: /ci/artifacts
+      - name: Untar build artifacts
+        shell: bash
+        run: tar xvf artifact.tar
 
-      - name: Unpack artifacts onto workers
+      - name: Run hang detection tests
         run: |
-          set -euo pipefail
+          ${{ env.TEST_OUTPUT_DIR }}/umd/hang_detection/hang_detection_tests
 
-          rm -rf /ci/tt-umd
-          cp -r "$GITHUB_WORKSPACE" /ci/tt-umd
-
-          BUILD_ARCHIVE=/ci/artifacts/artifact.tar
-          if [ ! -f "$BUILD_ARCHIVE" ]; then
-            echo "ERROR: expected $BUILD_ARCHIVE"
-            ls -R /ci/artifacts
-            exit 1
-          fi
-
-          # Local copy on the runner (handy for commands that launch from here).
-          sudo rm -rf /home/user/tt-umd
-          sudo mkdir -p /home/user
-          sudo chown "$(id -u):$(id -g)" /home/user
-          cp -r /ci/tt-umd /home/user/
-          tar xf "$BUILD_ARCHIVE" -C /home/user/tt-umd
-
-          # Fan out source + build to every allocated host via NFS + mpirun.
-          mpirun --pernode bash -lc 'rm -rf /home/user/tt-umd && cp -r /ci/tt-umd /home/user/'
-          mpirun --pernode tar xf "$BUILD_ARCHIVE" -C /home/user/tt-umd
-
-          if [ "${{ inputs.build-wheel }}" = "true" ]; then
-            shopt -s nullglob globstar
-            wheels=(/ci/artifacts/tt_umd-*.whl /ci/artifacts/**/tt_umd-*.whl)
-            if [ ${#wheels[@]} -eq 0 ]; then
-              echo "ERROR: build-wheel requested but no tt_umd-*.whl under /ci/artifacts"
-              ls -R /ci/artifacts
-              exit 1
-            fi
-            echo "Installing wheel: ${wheels[0]}"
-            mpirun --pernode bash -lc "python3 -m pip install --force-reinstall '${wheels[0]}'"
-          fi
-
-      - name: Reset cards and validate cluster
-        working-directory: /tmp
-        timeout-minutes: 45
+  notify-slack:
+    name: 📢 Notify #tt-umd-ci on failure
+    runs-on: ubuntu-latest
+    needs: [build, run]
+    # One message per nightly run, only when the build or any card failed.
+    # Scheduled runs only — manual dispatch is for interactive testing and
+    # shouldn't ping the channel.
+    if: failure() && github.event_name == 'schedule'
+    steps:
+      - name: Send Slack notification
         run: |
-          set -euo pipefail
-          MAX_RECOVERY_ATTEMPTS=10
-          SYSTEM_HEALTH=/home/user/tt-umd/build/tools/umd/system_health
-          export LD_LIBRARY_PATH=/home/user/tt-umd/build/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          cat << EOF > /tmp/slack_message.txt
+          🚨 Nightly hang detection tests failed
 
-          echo "--- Pre-check: tt-smi visibility on all hosts ---"
-          mpirun --pernode --tag-output \
-            bash -lc '
-              snapshot=$(tt-smi --snapshot_no_tty --snapshot)
-              driver=$(jq -r ".host_info.Driver // \"unknown\"" <<< "$snapshot")
-              tt_smi=$(jq -r ".host_sw_vers.tt_smi // \"unknown\"" <<< "$snapshot")
-              echo "$(hostname): Driver=${driver} tt_smi=${tt_smi}"
-            ' || true
+          The build or one or more cards failed the destructive NOC hang / warm-reset tests.
 
-          run_system_health() {
-            mpirun --pernode --tag-output -x LD_LIBRARY_PATH \
-              bash -lc "cd /home/user/tt-umd && '${SYSTEM_HEALTH}'"
-          }
+          Run: ${RUN_URL}
+          EOF
 
-          for attempt in $(seq 1 "$MAX_RECOVERY_ATTEMPTS"); do
-            echo "=== Recovery attempt $attempt of $MAX_RECOVERY_ATTEMPTS ==="
-            reset_success=false
-            validation_success=false
+          jq -n --arg msg "$(cat /tmp/slack_message.txt)" \
+            '{report: $msg}' > /tmp/payload.json
 
-            echo "--- Resetting cards with tt-smi ---"
-            if mpirun --pernode tt-smi -glx_reset; then
-              reset_success=true
-            else
-              echo "WARNING: -glx_reset failed on attempt $attempt, trying tt-smi -r"
-              if mpirun --pernode tt-smi -r; then
-                reset_success=true
-              else
-                echo "WARNING: Reset failed on attempt $attempt"
-              fi
-            fi
-
-            if [ "$reset_success" = true ]; then
-              echo "--- Sleeping 5s after reset to allow links/services to settle ---"
-              sleep 5
-
-              echo "--- Running UMD system_health ---"
-              if run_system_health; then
-                validation_success=true
-              else
-                echo "WARNING: system_health failed on attempt $attempt"
-              fi
-            else
-              echo "WARNING: Skipping system_health because reset failed on attempt $attempt"
-            fi
-
-            if [ "$reset_success" = true ] && [ "$validation_success" = true ]; then
-              echo "SUCCESS: Reset and system_health passed on attempt $attempt"
-              exit 0
-            fi
-
-            if [ "$attempt" -lt "$MAX_RECOVERY_ATTEMPTS" ]; then
-              echo "Sleeping 30s before retry..."
-              sleep 30
-            fi
-          done
-
-          echo "ERROR: Recovery failed after $MAX_RECOVERY_ATTEMPTS attempts"
-          exit 1
-
-      - name: Run test command
-        id: run-test
-        # Pass via env to avoid shell injection from workflow_dispatch input.
-        # mpirun --pernode is applied here so callers only supply the per-host command.
-        env:
-          TEST_COMMAND: ${{ inputs.test-command }}
-          LD_LIBRARY_PATH: /home/user/tt-umd/build/lib
-        run: |
-          set -euo pipefail
-          echo "Running on every host via mpirun --pernode:"
-          echo "$TEST_COMMAND"
-          mpirun --pernode --tag-output -x LD_LIBRARY_PATH -x TEST_COMMAND \
-            bash -lc 'cd /home/user/tt-umd && eval "$TEST_COMMAND"'
-
-      - name: Delete test environment
-        if: always()
-        uses: tenstorrent/tt-metal/.github/actions/ttop-delete-environment@main
-        with:
-          environmentName: ${{ env.ALLOCATION_NAME }}
-          namespace: ttop-ci
-
-      - name: Delete allocation
-        if: always()
-        uses: tenstorrent/tt-metal/.github/actions/ttop-delete-allocation@main
-        with:
-          allocationName: ${{ env.ALLOCATION_NAME }}
-          namespace: ttop-ci
+          curl -X POST "${{ secrets.TT_UMD_CI_SLACK_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d @/tmp/payload.json

--- a/.github/workflows/run-hang-detection-tests.yml
+++ b/.github/workflows/run-hang-detection-tests.yml
@@ -18,10 +18,9 @@ on:
           - sc16
       test-command:
         description: >-
-          Shell command to run after the cluster is up. The runner has mpirun
-          configured (hostfile /etc/ttop/hostfile). Artifacts live under
-          /home/user/tt-umd on every worker (and on the runner). Example:
-          mpirun --pernode bash -lc 'cd /home/user/tt-umd && ./build/test/umd/api/api_tests'
+          Shell command run on every allocated host via mpirun --pernode
+          (cwd /home/user/tt-umd, LD_LIBRARY_PATH includes build/lib). Example:
+          ./build/test/umd/galaxy/unit_tests_glx
         required: true
         type: string
       build-type:
@@ -294,15 +293,17 @@ jobs:
 
       - name: Run test command
         id: run-test
-        working-directory: /home/user/tt-umd
         # Pass via env to avoid shell injection from workflow_dispatch input.
+        # mpirun --pernode is applied here so callers only supply the per-host command.
         env:
           TEST_COMMAND: ${{ inputs.test-command }}
+          LD_LIBRARY_PATH: /home/user/tt-umd/build/lib
         run: |
           set -euo pipefail
-          echo "Running test command:"
+          echo "Running on every host via mpirun --pernode:"
           echo "$TEST_COMMAND"
-          eval "$TEST_COMMAND"
+          mpirun --pernode --tag-output -x LD_LIBRARY_PATH -x TEST_COMMAND \
+            bash -lc 'cd /home/user/tt-umd && eval "$TEST_COMMAND"'
 
       - name: Delete test environment
         if: always()

--- a/.github/workflows/run-hang-detection-tests.yml
+++ b/.github/workflows/run-hang-detection-tests.yml
@@ -127,23 +127,25 @@ jobs:
           cat /tmp/allocation_spec.yaml
 
 
-      - name: Fetch environment SSH setup script from tt-metal
-        # ttop-create-environment shells into GITHUB_WORKSPACE and runs
-        # .github/scripts/environment-ssh-setup.sh from this repo's tree.
+      - name: Fetch ttop helpers from tt-metal
+        # metal's ttop-*@main composites resolve ./.github/actions/ttop-await-resource
+        # and .github/scripts/environment-ssh-setup.sh against THIS workspace.
         uses: actions/checkout@v4
         with:
           repository: tenstorrent/tt-metal
           sparse-checkout: |
             .github/scripts/environment-ssh-setup.sh
+            .github/actions/ttop-await-resource
           sparse-checkout-cone-mode: false
           path: _tt-metal
           persist-credentials: false
 
-      - name: Install environment SSH setup script
+      - name: Install ttop helpers from tt-metal
         run: |
-          mkdir -p .github/scripts
+          mkdir -p .github/scripts .github/actions
           cp _tt-metal/.github/scripts/environment-ssh-setup.sh .github/scripts/
           chmod +x .github/scripts/environment-ssh-setup.sh
+          cp -R _tt-metal/.github/actions/ttop-await-resource .github/actions/
 
       - name: Create allocation
         id: allocation

--- a/.github/workflows/run-tests-on-exabox.yml
+++ b/.github/workflows/run-tests-on-exabox.yml
@@ -1,0 +1,324 @@
+# Build UMD and run an arbitrary test command on exabox (sc1 / sc4 / sc16).
+# Trigger from the Actions tab: pick hardware, paste a test command, and run.
+name: Run tests on exabox
+
+on:
+  workflow_dispatch:
+    inputs:
+      hardware:
+        description: >-
+          Exabox hardware to allocate (sc1 = 1 Galaxy, sc4 = 4-Galaxy quad,
+          sc16 = 16-Galaxy SC16).
+        required: true
+        type: choice
+        default: sc1
+        options:
+          - sc1
+          - sc4
+          - sc16
+      test-command:
+        description: >-
+          Shell command to run after the cluster is up. The runner has mpirun
+          configured (hostfile /etc/ttop/hostfile). Artifacts live under
+          /home/user/tt-umd on every worker (and on the runner). Example:
+          mpirun --pernode bash -lc 'cd /home/user/tt-umd && ./build/test/umd/api/api_tests'
+        required: true
+        type: string
+      build-type:
+        description: CMake build type
+        required: true
+        default: Release
+        type: choice
+        options:
+          - Release
+          - RelWithDebInfo
+          - Debug
+          - ASan
+          - TSan
+      ubuntu-docker-version:
+        description: Ubuntu docker image version to build and use as worker image
+        required: true
+        default: ubuntu-22.04
+        type: choice
+        options:
+          - ubuntu-22.04
+          - ubuntu-24.04
+      timeout:
+        description: Per-job timeout in minutes (build and run)
+        required: true
+        default: 120
+        type: number
+      build-wheel:
+        description: Also build and install the Python wheel on workers
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  id-token: write
+  contents: read
+
+# Inline SKU allocation specs (mirrors tt-metal .github/sku_config.yaml bh_sc{1,4,16}).
+# Kept in-workflow so UMD does not need a full sku_config + extract script.
+env:
+  ARTIFACT_NAME: >-
+    build-artifacts-${{ inputs.ubuntu-docker-version }}-${{ inputs.build-type }}
+  WHEEL_ARTIFACT_NAME: >-
+    wheel-artifact-${{ inputs.ubuntu-docker-version }}-${{ inputs.build-type }}
+  ALLOCATION_NAME: ci-umd-${{ github.run_id }}-${{ inputs.hardware }}
+
+jobs:
+  build:
+    secrets: inherit
+    uses: ./.github/workflows/build-tests.yml
+    with:
+      ubuntu-docker-version: ${{ inputs.ubuntu-docker-version }}
+      build-type: ${{ inputs.build-type }}
+      timeout: ${{ fromJSON(inputs.timeout) }}
+      build-wheel: ${{ inputs.build-wheel }}
+
+  run:
+    name: Run on exabox (${{ inputs.hardware }})
+    needs: build
+    timeout-minutes: ${{ fromJSON(inputs.timeout) }}
+    runs-on:
+      - exabox-multihost-with-nfs
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Resolve allocation spec for ${{ inputs.hardware }}
+        id: sku
+        # Specs mirror tt-metal .github/sku_config.yaml entries bh_sc1 / bh_sc4 / bh_sc16.
+        # Heredoc bodies sit at the run-block indent so Actions' common-indent strip
+        # leaves a clean YAML document (including nested list indentation).
+        run: |
+          case "${{ inputs.hardware }}" in
+            sc1)
+              cat <<'EOF' > /tmp/allocation_spec.yaml
+          allocationType: Count
+          count: 1
+          EOF
+              ;;
+            sc4)
+              cat <<'EOF' > /tmp/allocation_spec.yaml
+          allocationType: Count
+          count: 4
+          topologyKeys:
+            - exabox.tenstorrent.com/quad
+          EOF
+              ;;
+            sc16)
+              cat <<'EOF' > /tmp/allocation_spec.yaml
+          allocationType: Count
+          count: 16
+          topologyKeys:
+            - exabox.tenstorrent.com/SC16
+          EOF
+              ;;
+            *)
+              echo "::error::Unknown hardware '${{ inputs.hardware }}'"
+              exit 1
+              ;;
+          esac
+          {
+            echo "allocation_spec<<EOF"
+            cat /tmp/allocation_spec.yaml
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved allocation spec for ${{ inputs.hardware }}:"
+          cat /tmp/allocation_spec.yaml
+
+
+      - name: Fetch environment SSH setup script from tt-metal
+        # ttop-create-environment shells into GITHUB_WORKSPACE and runs
+        # .github/scripts/environment-ssh-setup.sh from this repo's tree.
+        uses: actions/checkout@v4
+        with:
+          repository: tenstorrent/tt-metal
+          sparse-checkout: |
+            .github/scripts/environment-ssh-setup.sh
+          sparse-checkout-cone-mode: false
+          path: _tt-metal
+          persist-credentials: false
+
+      - name: Install environment SSH setup script
+        run: |
+          mkdir -p .github/scripts
+          cp _tt-metal/.github/scripts/environment-ssh-setup.sh .github/scripts/
+          chmod +x .github/scripts/environment-ssh-setup.sh
+
+      - name: Create allocation
+        id: allocation
+        uses: tenstorrent/tt-metal/.github/actions/ttop-create-allocation@main
+        timeout-minutes: 120
+        with:
+          allocationName: ${{ env.ALLOCATION_NAME }}
+          namespace: ttop-ci
+          spec: ${{ steps.sku.outputs.allocation_spec }}
+
+      - name: Get allocation configs
+        uses: tenstorrent/tt-metal/.github/actions/ttop-get-allocation-data@main
+        with:
+          allocationName: ${{ env.ALLOCATION_NAME }}
+          allocationNamespace: ttop-ci
+
+      - name: Create test environment
+        uses: tenstorrent/tt-metal/.github/actions/ttop-create-environment@main
+        timeout-minutes: 30
+        with:
+          environmentName: ${{ env.ALLOCATION_NAME }}
+          allocationName: ${{ env.ALLOCATION_NAME }}
+          allocationNamespace: ttop-ci
+          workerRepository: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}
+          workerTag: latest
+          useDevHostMount: "true"
+          sharedVolumeEnabled: "true"
+          path: /etc/ttop
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: /ci/artifacts
+
+      - name: Download wheel artifact
+        if: ${{ inputs.build-wheel }}
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ env.WHEEL_ARTIFACT_NAME }}
+          path: /ci/artifacts
+
+      - name: Unpack artifacts onto workers
+        run: |
+          set -euo pipefail
+
+          rm -rf /ci/tt-umd
+          cp -r "$GITHUB_WORKSPACE" /ci/tt-umd
+
+          BUILD_ARCHIVE=/ci/artifacts/artifact.tar
+          if [ ! -f "$BUILD_ARCHIVE" ]; then
+            echo "ERROR: expected $BUILD_ARCHIVE"
+            ls -R /ci/artifacts
+            exit 1
+          fi
+
+          # Local copy on the runner (handy for commands that launch from here).
+          sudo rm -rf /home/user/tt-umd
+          sudo mkdir -p /home/user
+          sudo chown "$(id -u):$(id -g)" /home/user
+          cp -r /ci/tt-umd /home/user/
+          tar xf "$BUILD_ARCHIVE" -C /home/user/tt-umd
+
+          # Fan out source + build to every allocated host via NFS + mpirun.
+          mpirun --pernode bash -lc 'rm -rf /home/user/tt-umd && cp -r /ci/tt-umd /home/user/'
+          mpirun --pernode tar xf "$BUILD_ARCHIVE" -C /home/user/tt-umd
+
+          if [ "${{ inputs.build-wheel }}" = "true" ]; then
+            shopt -s nullglob globstar
+            wheels=(/ci/artifacts/tt_umd-*.whl /ci/artifacts/**/tt_umd-*.whl)
+            if [ ${#wheels[@]} -eq 0 ]; then
+              echo "ERROR: build-wheel requested but no tt_umd-*.whl under /ci/artifacts"
+              ls -R /ci/artifacts
+              exit 1
+            fi
+            echo "Installing wheel: ${wheels[0]}"
+            mpirun --pernode bash -lc "python3 -m pip install --force-reinstall '${wheels[0]}'"
+          fi
+
+      - name: Reset cards and validate cluster
+        working-directory: /tmp
+        timeout-minutes: 45
+        run: |
+          set -euo pipefail
+          MAX_RECOVERY_ATTEMPTS=10
+          SYSTEM_HEALTH=/home/user/tt-umd/build/tools/umd/system_health
+          export LD_LIBRARY_PATH=/home/user/tt-umd/build/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+
+          echo "--- Pre-check: tt-smi visibility on all hosts ---"
+          mpirun --pernode --tag-output \
+            bash -lc '
+              snapshot=$(tt-smi --snapshot_no_tty --snapshot)
+              driver=$(jq -r ".host_info.Driver // \"unknown\"" <<< "$snapshot")
+              tt_smi=$(jq -r ".host_sw_vers.tt_smi // \"unknown\"" <<< "$snapshot")
+              echo "$(hostname): Driver=${driver} tt_smi=${tt_smi}"
+            ' || true
+
+          run_system_health() {
+            mpirun --pernode --tag-output -x LD_LIBRARY_PATH \
+              bash -lc "cd /home/user/tt-umd && '${SYSTEM_HEALTH}'"
+          }
+
+          for attempt in $(seq 1 "$MAX_RECOVERY_ATTEMPTS"); do
+            echo "=== Recovery attempt $attempt of $MAX_RECOVERY_ATTEMPTS ==="
+            reset_success=false
+            validation_success=false
+
+            echo "--- Resetting cards with tt-smi ---"
+            if mpirun --pernode tt-smi -glx_reset; then
+              reset_success=true
+            else
+              echo "WARNING: -glx_reset failed on attempt $attempt, trying tt-smi -r"
+              if mpirun --pernode tt-smi -r; then
+                reset_success=true
+              else
+                echo "WARNING: Reset failed on attempt $attempt"
+              fi
+            fi
+
+            if [ "$reset_success" = true ]; then
+              echo "--- Sleeping 5s after reset to allow links/services to settle ---"
+              sleep 5
+
+              echo "--- Running UMD system_health ---"
+              if run_system_health; then
+                validation_success=true
+              else
+                echo "WARNING: system_health failed on attempt $attempt"
+              fi
+            else
+              echo "WARNING: Skipping system_health because reset failed on attempt $attempt"
+            fi
+
+            if [ "$reset_success" = true ] && [ "$validation_success" = true ]; then
+              echo "SUCCESS: Reset and system_health passed on attempt $attempt"
+              exit 0
+            fi
+
+            if [ "$attempt" -lt "$MAX_RECOVERY_ATTEMPTS" ]; then
+              echo "Sleeping 30s before retry..."
+              sleep 30
+            fi
+          done
+
+          echo "ERROR: Recovery failed after $MAX_RECOVERY_ATTEMPTS attempts"
+          exit 1
+
+      - name: Run test command
+        id: run-test
+        working-directory: /home/user/tt-umd
+        # Pass via env to avoid shell injection from workflow_dispatch input.
+        env:
+          TEST_COMMAND: ${{ inputs.test-command }}
+        run: |
+          set -euo pipefail
+          echo "Running test command:"
+          echo "$TEST_COMMAND"
+          eval "$TEST_COMMAND"
+
+      - name: Delete test environment
+        if: always()
+        uses: tenstorrent/tt-metal/.github/actions/ttop-delete-environment@main
+        with:
+          environmentName: ${{ env.ALLOCATION_NAME }}
+          namespace: ttop-ci
+
+      - name: Delete allocation
+        if: always()
+        uses: tenstorrent/tt-metal/.github/actions/ttop-delete-allocation@main
+        with:
+          allocationName: ${{ env.ALLOCATION_NAME }}
+          namespace: ttop-ci

--- a/.github/workflows/run-tests-on-exabox.yml
+++ b/.github/workflows/run-tests-on-exabox.yml
@@ -163,13 +163,15 @@ jobs:
           allocationNamespace: ttop-ci
 
       - name: Create test environment
+        # Worker must provide /usr/sbin/sshd. tt-umd-ci does not; use the
+        # orchestration SSH host image. Test binaries are still fanned out via NFS.
         uses: tenstorrent/tt-metal/.github/actions/ttop-create-environment@main
         timeout-minutes: 30
         with:
           environmentName: ${{ env.ALLOCATION_NAME }}
           allocationName: ${{ env.ALLOCATION_NAME }}
           allocationNamespace: ttop-ci
-          workerRepository: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}
+          workerRepository: ghcr.io/tenstorrent/tt-orchestration/ttop-ssh-host
           workerTag: latest
           useDevHostMount: "true"
           sharedVolumeEnabled: "true"

--- a/.github/workflows/run-tests-on-exabox.yml
+++ b/.github/workflows/run-tests-on-exabox.yml
@@ -58,8 +58,6 @@ permissions:
   id-token: write
   contents: read
 
-# Inline SKU allocation specs (mirrors tt-metal .github/sku_config.yaml bh_sc{1,4,16}).
-# Kept in-workflow so UMD does not need a full sku_config + extract script.
 env:
   ARTIFACT_NAME: >-
     build-artifacts-${{ inputs.ubuntu-docker-version }}-${{ inputs.build-type }}
@@ -92,9 +90,6 @@ jobs:
 
       - name: Resolve allocation spec for ${{ inputs.hardware }}
         id: sku
-        # Specs mirror tt-metal .github/sku_config.yaml entries bh_sc1 / bh_sc4 / bh_sc16.
-        # Heredoc bodies sit at the run-block indent so Actions' common-indent strip
-        # leaves a clean YAML document (including nested list indentation).
         run: |
           case "${{ inputs.hardware }}" in
             sc1)

--- a/.github/workflows/run-tests-on-exabox.yml
+++ b/.github/workflows/run-tests-on-exabox.yml
@@ -56,6 +56,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  packages: write
 
 env:
   ARTIFACT_NAME: >-
@@ -65,7 +66,17 @@ env:
   ALLOCATION_NAME: ci-umd-${{ github.run_id }}-${{ inputs.hardware }}
 
 jobs:
+  ensure-docker-image:
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker-image.yml
+    with:
+      docker-version: ${{ inputs.ubuntu-docker-version }}
+
   build:
+    needs: ensure-docker-image
     secrets: inherit
     uses: ./.github/workflows/build-tests.yml
     with:
@@ -73,10 +84,11 @@ jobs:
       build-type: ${{ inputs.build-type }}
       timeout: ${{ fromJSON(inputs.timeout) }}
       build-wheel: ${{ inputs.build-wheel }}
+      image-tag: ${{ needs.ensure-docker-image.outputs.image-tag }}
 
   run:
     name: Run on exabox (${{ inputs.hardware }})
-    needs: build
+    needs: [ensure-docker-image, build]
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
     runs-on:
       - exabox-multihost-with-nfs
@@ -163,16 +175,14 @@ jobs:
           allocationNamespace: ttop-ci
 
       - name: Create test environment
-        # Worker must provide /usr/sbin/sshd. tt-umd-ci does not; use the
-        # orchestration SSH host image. Test binaries are still fanned out via NFS.
         uses: tenstorrent/tt-metal/.github/actions/ttop-create-environment@main
         timeout-minutes: 30
         with:
           environmentName: ${{ env.ALLOCATION_NAME }}
           allocationName: ${{ env.ALLOCATION_NAME }}
           allocationNamespace: ttop-ci
-          workerRepository: ghcr.io/tenstorrent/tt-orchestration/ttop-ssh-host
-          workerTag: latest
+          workerRepository: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}
+          workerTag: ${{ needs.ensure-docker-image.outputs.image-tag }}
           useDevHostMount: "true"
           sharedVolumeEnabled: "true"
           path: /etc/ttop

--- a/.github/workflows/run-tests-on-exabox.yml
+++ b/.github/workflows/run-tests-on-exabox.yml
@@ -18,10 +18,9 @@ on:
           - sc16
       test-command:
         description: >-
-          Shell command to run after the cluster is up. The runner has mpirun
-          configured (hostfile /etc/ttop/hostfile). Artifacts live under
-          /home/user/tt-umd on every worker (and on the runner). Example:
-          mpirun --pernode bash -lc 'cd /home/user/tt-umd && ./build/test/umd/api/api_tests'
+          Shell command run on every allocated host via mpirun --pernode
+          (cwd /home/user/tt-umd, LD_LIBRARY_PATH includes build/lib). Example:
+          ./build/test/umd/galaxy/unit_tests_glx
         required: true
         type: string
       build-type:
@@ -294,15 +293,17 @@ jobs:
 
       - name: Run test command
         id: run-test
-        working-directory: /home/user/tt-umd
         # Pass via env to avoid shell injection from workflow_dispatch input.
+        # mpirun --pernode is applied here so callers only supply the per-host command.
         env:
           TEST_COMMAND: ${{ inputs.test-command }}
+          LD_LIBRARY_PATH: /home/user/tt-umd/build/lib
         run: |
           set -euo pipefail
-          echo "Running test command:"
+          echo "Running on every host via mpirun --pernode:"
           echo "$TEST_COMMAND"
-          eval "$TEST_COMMAND"
+          mpirun --pernode --tag-output -x LD_LIBRARY_PATH -x TEST_COMMAND \
+            bash -lc 'cd /home/user/tt-umd && eval "$TEST_COMMAND"'
 
       - name: Delete test environment
         if: always()

--- a/.github/workflows/run-tests-on-exabox.yml
+++ b/.github/workflows/run-tests-on-exabox.yml
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -140,11 +140,13 @@ jobs:
 
 
       - name: Fetch ttop helpers from tt-metal
-        # metal's ttop-*@main composites resolve ./.github/actions/ttop-await-resource
+        # metal's ttop-* composites resolve ./.github/actions/ttop-await-resource
         # and .github/scripts/environment-ssh-setup.sh against THIS workspace.
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: tenstorrent/tt-metal
+          # Keep in sync with the pinned SHA on the ttop-* uses: lines below.
+          ref: 0b0d71bbee030c636a7fff7054de29f3a68e093e
           sparse-checkout: |
             .github/scripts/environment-ssh-setup.sh
             .github/actions/ttop-await-resource
@@ -161,7 +163,7 @@ jobs:
 
       - name: Create allocation
         id: allocation
-        uses: tenstorrent/tt-metal/.github/actions/ttop-create-allocation@main
+        uses: tenstorrent/tt-metal/.github/actions/ttop-create-allocation@0b0d71bbee030c636a7fff7054de29f3a68e093e
         timeout-minutes: 120
         with:
           allocationName: ${{ env.ALLOCATION_NAME }}
@@ -169,13 +171,13 @@ jobs:
           spec: ${{ steps.sku.outputs.allocation_spec }}
 
       - name: Get allocation configs
-        uses: tenstorrent/tt-metal/.github/actions/ttop-get-allocation-data@main
+        uses: tenstorrent/tt-metal/.github/actions/ttop-get-allocation-data@0b0d71bbee030c636a7fff7054de29f3a68e093e
         with:
           allocationName: ${{ env.ALLOCATION_NAME }}
           allocationNamespace: ttop-ci
 
       - name: Create test environment
-        uses: tenstorrent/tt-metal/.github/actions/ttop-create-environment@main
+        uses: tenstorrent/tt-metal/.github/actions/ttop-create-environment@0b0d71bbee030c636a7fff7054de29f3a68e093e
         timeout-minutes: 30
         with:
           environmentName: ${{ env.ALLOCATION_NAME }}
@@ -307,8 +309,9 @@ jobs:
 
       - name: Run test command
         id: run-test
-        # Pass via env to avoid shell injection from workflow_dispatch input.
-        # mpirun --pernode is applied here so callers only supply the per-host command.
+        # TEST_COMMAND is expanded by this job's shell into the remote bash -lc
+        # string (trusted workflow_dispatch). No eval — the remote shell runs the
+        # command text directly. mpirun --pernode wraps it for every host.
         env:
           TEST_COMMAND: ${{ inputs.test-command }}
           LD_LIBRARY_PATH: /home/user/tt-umd/build/lib
@@ -316,19 +319,19 @@ jobs:
           set -euo pipefail
           echo "Running on every host via mpirun --pernode:"
           echo "$TEST_COMMAND"
-          mpirun --pernode --tag-output -x LD_LIBRARY_PATH -x TEST_COMMAND \
-            bash -lc 'cd /home/user/tt-umd && eval "$TEST_COMMAND"'
+          mpirun --pernode --tag-output -x LD_LIBRARY_PATH \
+            bash -lc "cd /home/user/tt-umd && $TEST_COMMAND"
 
       - name: Delete test environment
         if: always()
-        uses: tenstorrent/tt-metal/.github/actions/ttop-delete-environment@main
+        uses: tenstorrent/tt-metal/.github/actions/ttop-delete-environment@0b0d71bbee030c636a7fff7054de29f3a68e093e
         with:
           environmentName: ${{ env.ALLOCATION_NAME }}
           namespace: ttop-ci
 
       - name: Delete allocation
         if: always()
-        uses: tenstorrent/tt-metal/.github/actions/ttop-delete-allocation@main
+        uses: tenstorrent/tt-metal/.github/actions/ttop-delete-allocation@0b0d71bbee030c636a7fff7054de29f3a68e093e
         with:
           allocationName: ${{ env.ALLOCATION_NAME }}
           namespace: ttop-ci

--- a/.github/workflows/run-tests-on-exabox.yml
+++ b/.github/workflows/run-tests-on-exabox.yml
@@ -127,23 +127,25 @@ jobs:
           cat /tmp/allocation_spec.yaml
 
 
-      - name: Fetch environment SSH setup script from tt-metal
-        # ttop-create-environment shells into GITHUB_WORKSPACE and runs
-        # .github/scripts/environment-ssh-setup.sh from this repo's tree.
+      - name: Fetch ttop helpers from tt-metal
+        # metal's ttop-*@main composites resolve ./.github/actions/ttop-await-resource
+        # and .github/scripts/environment-ssh-setup.sh against THIS workspace.
         uses: actions/checkout@v4
         with:
           repository: tenstorrent/tt-metal
           sparse-checkout: |
             .github/scripts/environment-ssh-setup.sh
+            .github/actions/ttop-await-resource
           sparse-checkout-cone-mode: false
           path: _tt-metal
           persist-credentials: false
 
-      - name: Install environment SSH setup script
+      - name: Install ttop helpers from tt-metal
         run: |
-          mkdir -p .github/scripts
+          mkdir -p .github/scripts .github/actions
           cp _tt-metal/.github/scripts/environment-ssh-setup.sh .github/scripts/
           chmod +x .github/scripts/environment-ssh-setup.sh
+          cp -R _tt-metal/.github/actions/ttop-await-resource .github/actions/
 
       - name: Create allocation
         id: allocation


### PR DESCRIPTION
### Issue
[(Link to Github issue)](https://github.com/tenstorrent/tt-umd/issues/3089)

### Description
Add exabox testing workflow in order to run tests on cluster in Markham

### List of the changes

1. New workflow that runs on exabox cluster
2. Added installation of openssh server and openmpi in order to trigger tests on multiple galaxies at once
3. Add a user that sshs into machines

### Testing
Running test on sc1 (single galaxy): [job](https://github.com/tenstorrent/tt-umd/actions/runs/30345985442)
### API Changes
This PR has no API changes.
