### PR TITLE
Add getter for TDP limit

### DIFF
--- a/device/api/umd/device/firmware/firmware_info_provider.hpp
+++ b/device/api/umd/device/firmware/firmware_info_provider.hpp
@@ -138,11 +138,8 @@ public:
     std::optional<double> get_thm_limit_shutdown() const;
 
     /*
-     * Get the TDP limit currently enforced by the TDP throttler, in watts.
-     * Firmware initializes this to the board's default TDP limit from the SPI firmware table and
-     * updates it whenever the limit is changed at runtime, so it reflects the active limit rather
-     * than a static ceiling (despite the TDP_LIMIT_MAX telemetry tag it is read from).
-     * @returns Active TDP limit [W]
+     * Get TDP limit in watts.
+     * @returns TDP limit [W]
      */
     std::optional<uint32_t> get_tdp_limit() const;
 
@@ -236,6 +233,7 @@ private:
     static FirmwareFeatures create_wormhole_18_8_base();
     static FirmwareFeatures create_wormhole_19_9_base();
     static FirmwareFeatures create_blackhole_18_8_base();
+    static FirmwareFeatures create_blackhole_19_8_base();
     static FirmwareFeatures create_blackhole_19_9_base();
 
     // Engine methods for reading and transforming telemetry data.

--- a/device/api/umd/device/firmware/firmware_info_provider.hpp
+++ b/device/api/umd/device/firmware/firmware_info_provider.hpp
@@ -138,6 +138,15 @@ public:
     std::optional<double> get_thm_limit_shutdown() const;
 
     /*
+     * Get the TDP limit currently enforced by the TDP throttler, in watts.
+     * Firmware initializes this to the board's default TDP limit from the SPI firmware table and
+     * updates it whenever the limit is changed at runtime, so it reflects the active limit rather
+     * than a static ceiling (despite the TDP_LIMIT_MAX telemetry tag it is read from).
+     * @returns Active TDP limit [W]
+     */
+    std::optional<uint32_t> get_tdp_limit() const;
+
+    /*
      * Get board power limit in watts.
      * @returns Board power limit [W]
      */

--- a/device/api/umd/device/firmware/firmware_telemetry_mapping.hpp
+++ b/device/api/umd/device/firmware/firmware_telemetry_mapping.hpp
@@ -110,6 +110,7 @@ enum class FirmwareFeature {
     TDC,
     VCORE,
     TDC_LIMIT_MAX,
+    TDP_LIMIT_MAX,
     BOARD_POWER_LIMIT,
 
     // Cooling & thermal management.

--- a/device/firmware/firmware_info_provider.cpp
+++ b/device/firmware/firmware_info_provider.cpp
@@ -201,11 +201,10 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
     return map;
 }
 
-// Wormhole 18.8-19.8: StandardTag base with StandardTag MAX_CLOCK_FREQ.
+// Wormhole 18.8-19.8: same as 18.4, except MAX_CLOCK_FREQ moves from SMBus to a telemetry tag.
 /* static */ FirmwareFeatures FirmwareInfoProvider::create_wormhole_18_8_base() {
-    FirmwareFeatures map = create_18_4_new_telemetry_base();
+    FirmwareFeatures map = create_wormhole_18_4_base();
     map[FirmwareFeature::MAX_CLOCK_FREQ] = {TelemetryTag::AICLK_LIMIT_MAX, LinearTransform{}};
-    map[FirmwareFeature::TDP_LIMIT_MAX] = {TelemetryTag::TDP_LIMIT_MAX, LinearTransform{}};
     return map;
 }
 

--- a/device/firmware/firmware_info_provider.cpp
+++ b/device/firmware/firmware_info_provider.cpp
@@ -105,6 +105,7 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
         {FirmwareFeature::TDC,               {TelemetryTag::TDC, LinearTransform{}}},
         {FirmwareFeature::VCORE,             {TelemetryTag::VCORE, LinearTransform{}}},
         {FirmwareFeature::TDC_LIMIT_MAX,     {TelemetryTag::TDC_LIMIT_MAX, LinearTransform{}}},
+        {FirmwareFeature::TDP_LIMIT_MAX,     {TelemetryTag::TDP_LIMIT_MAX, LinearTransform{}}},
         {FirmwareFeature::BOARD_POWER_LIMIT, {TelemetryTag::BOARD_POWER_LIMIT, LinearTransform{}}},
         {FirmwareFeature::FAN_SPEED,         {TelemetryTag::FAN_SPEED, LinearTransform{}}},
         {FirmwareFeature::FAN_RPM,           {TelemetryTag::FAN_RPM, LinearTransform{}}},
@@ -155,6 +156,7 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
         {FirmwareFeature::TDC, {WormholeTag::TDC, LinearTransform{0, 0xFFFF, 1.0, 0.0}}},
         {FirmwareFeature::VCORE, {WormholeTag::VCORE, LinearTransform{}}},
         {FirmwareFeature::TDC_LIMIT_MAX, {FixedValue{0}, NotAvailable{}}},
+        {FirmwareFeature::TDP_LIMIT_MAX, {FixedValue{0}, NotAvailable{}}},
         {FirmwareFeature::BOARD_POWER_LIMIT, {FixedValue{0}, NotAvailable{}}},
         {FirmwareFeature::FAN_SPEED, {WormholeTag::FAN_SPEED, LinearTransform{}}},
         {FirmwareFeature::FAN_RPM, {FixedValue{0}, NotAvailable{}}},
@@ -673,6 +675,10 @@ std::optional<double> FirmwareInfoProvider::get_current_max_dram_temperature() c
 std::optional<double> FirmwareInfoProvider::get_thm_limit_shutdown() const {
     // Stored as a plain integer in degrees Celsius.
     return read_scalar<double>(FirmwareFeature::THM_LIMIT_SHUTDOWN);
+}
+
+std::optional<uint32_t> FirmwareInfoProvider::get_tdp_limit() const {
+    return read_scalar<uint32_t>(FirmwareFeature::TDP_LIMIT_MAX);
 }
 
 std::optional<uint32_t> FirmwareInfoProvider::get_board_power_limit() const {

--- a/device/firmware/firmware_info_provider.cpp
+++ b/device/firmware/firmware_info_provider.cpp
@@ -189,18 +189,6 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
     return map;
 }
 
-// Blackhole 18.5-18.7: StandardTag base, but fixed AICLK and no ETH support.
-/* static */ FirmwareFeatures FirmwareInfoProvider::create_blackhole_18_5_base() {
-    FirmwareFeatures map = create_18_4_new_telemetry_base();
-    map[FirmwareFeature::MAX_CLOCK_FREQ] = {FixedValue{blackhole::AICLK_BUSY_VAL}, LinearTransform{}};
-    // ETH_FW_VERSION telemetry tag exists but firmware doesn't implement it on Blackhole.
-    map[FirmwareFeature::ETH_FW_VERSION] = {FixedValue{0}, NotAvailable{}};
-    // ETH_LIVE_STATUS tag exists but always returns zeros on Blackhole prior to 19.9.
-    map[FirmwareFeature::ETH_HEARTBEAT_STATUS] = {FixedValue{0}, NotAvailable{}};
-    map[FirmwareFeature::ETH_RETRAIN_STATUS] = {FixedValue{0}, NotAvailable{}};
-    return map;
-}
-
 // Wormhole 18.8-19.8: same as 18.4, except MAX_CLOCK_FREQ moves from SMBus to a telemetry tag.
 /* static */ FirmwareFeatures FirmwareInfoProvider::create_wormhole_18_8_base() {
     FirmwareFeatures map = create_wormhole_18_4_base();
@@ -216,15 +204,22 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
     return map;
 }
 
-// Blackhole 18.8-19.7: StandardTag base with StandardTag MAX_CLOCK_FREQ, no ETH support.
-/* static */ FirmwareFeatures FirmwareInfoProvider::create_blackhole_18_8_base() {
+// Blackhole 18.5-18.7: StandardTag base, but fixed AICLK and no ETH support.
+/* static */ FirmwareFeatures FirmwareInfoProvider::create_blackhole_18_5_base() {
     FirmwareFeatures map = create_18_4_new_telemetry_base();
-    map[FirmwareFeature::MAX_CLOCK_FREQ] = {TelemetryTag::AICLK_LIMIT_MAX, LinearTransform{}};
+    map[FirmwareFeature::MAX_CLOCK_FREQ] = {FixedValue{blackhole::AICLK_BUSY_VAL}, LinearTransform{}};
     // ETH_FW_VERSION telemetry tag exists but firmware doesn't implement it on Blackhole.
     map[FirmwareFeature::ETH_FW_VERSION] = {FixedValue{0}, NotAvailable{}};
     // ETH_LIVE_STATUS tag exists but always returns zeros on Blackhole prior to 19.9.
     map[FirmwareFeature::ETH_HEARTBEAT_STATUS] = {FixedValue{0}, NotAvailable{}};
     map[FirmwareFeature::ETH_RETRAIN_STATUS] = {FixedValue{0}, NotAvailable{}};
+    return map;
+}
+
+// Blackhole 18.8-19.7: same as 18.5, except MAX_CLOCK_FREQ moves from a fixed value to a telemetry tag.
+/* static */ FirmwareFeatures FirmwareInfoProvider::create_blackhole_18_8_base() {
+    FirmwareFeatures map = create_blackhole_18_5_base();
+    map[FirmwareFeature::MAX_CLOCK_FREQ] = {TelemetryTag::AICLK_LIMIT_MAX, LinearTransform{}};
     return map;
 }
 

--- a/device/firmware/firmware_info_provider.cpp
+++ b/device/firmware/firmware_info_provider.cpp
@@ -67,8 +67,10 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
         case ARCH::BLACKHOLE:
             if (fw_version <= FirmwareBundleVersion(18, 7, 0)) {
                 return create_blackhole_18_5_base();
-            } else if (fw_version < FirmwareBundleVersion(19, 9, 0)) {
+            } else if (fw_version < FirmwareBundleVersion(19, 8, 0)) {
                 return create_blackhole_18_8_base();
+            } else if (fw_version < FirmwareBundleVersion(19, 9, 0)) {
+                return create_blackhole_19_8_base();
             }
             return create_blackhole_19_9_base();
         default:
@@ -105,7 +107,7 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
         {FirmwareFeature::TDC,               {TelemetryTag::TDC, LinearTransform{}}},
         {FirmwareFeature::VCORE,             {TelemetryTag::VCORE, LinearTransform{}}},
         {FirmwareFeature::TDC_LIMIT_MAX,     {TelemetryTag::TDC_LIMIT_MAX, LinearTransform{}}},
-        {FirmwareFeature::TDP_LIMIT_MAX,     {TelemetryTag::TDP_LIMIT_MAX, LinearTransform{}}},
+        {FirmwareFeature::TDP_LIMIT_MAX,     {FixedValue{0}, NotAvailable{}}},
         {FirmwareFeature::BOARD_POWER_LIMIT, {TelemetryTag::BOARD_POWER_LIMIT, LinearTransform{}}},
         {FirmwareFeature::FAN_SPEED,         {TelemetryTag::FAN_SPEED, LinearTransform{}}},
         {FirmwareFeature::FAN_RPM,           {TelemetryTag::FAN_RPM, LinearTransform{}}},
@@ -182,6 +184,8 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
 /* static */ FirmwareFeatures FirmwareInfoProvider::create_wormhole_18_4_base() {
     FirmwareFeatures map = create_18_4_new_telemetry_base();
     map[FirmwareFeature::MAX_CLOCK_FREQ] = {SmBusTag{WormholeTag::AICLK}, LinearTransform{16, 0xFFFF, 1.0, 0.0}};
+    // Wormhole publishes the TDP limit from the new telemetry onwards.
+    map[FirmwareFeature::TDP_LIMIT_MAX] = {TelemetryTag::TDP_LIMIT_MAX, LinearTransform{}};
     return map;
 }
 
@@ -201,6 +205,7 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
 /* static */ FirmwareFeatures FirmwareInfoProvider::create_wormhole_18_8_base() {
     FirmwareFeatures map = create_18_4_new_telemetry_base();
     map[FirmwareFeature::MAX_CLOCK_FREQ] = {TelemetryTag::AICLK_LIMIT_MAX, LinearTransform{}};
+    map[FirmwareFeature::TDP_LIMIT_MAX] = {TelemetryTag::TDP_LIMIT_MAX, LinearTransform{}};
     return map;
 }
 
@@ -212,7 +217,7 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
     return map;
 }
 
-// Blackhole 18.8-19.8: StandardTag base with StandardTag MAX_CLOCK_FREQ, no ETH support.
+// Blackhole 18.8-19.7: StandardTag base with StandardTag MAX_CLOCK_FREQ, no ETH support.
 /* static */ FirmwareFeatures FirmwareInfoProvider::create_blackhole_18_8_base() {
     FirmwareFeatures map = create_18_4_new_telemetry_base();
     map[FirmwareFeature::MAX_CLOCK_FREQ] = {TelemetryTag::AICLK_LIMIT_MAX, LinearTransform{}};
@@ -224,9 +229,16 @@ FirmwareInfoProvider::FirmwareInfoProvider(TTDevice* tt_device) :
     return map;
 }
 
+// Blackhole >= 19.8: firmware gains the adjustable TDP limit and publishes it.
+/* static */ FirmwareFeatures FirmwareInfoProvider::create_blackhole_19_8_base() {
+    FirmwareFeatures map = create_blackhole_18_8_base();
+    map[FirmwareFeature::TDP_LIMIT_MAX] = {TelemetryTag::TDP_LIMIT_MAX, LinearTransform{}};
+    return map;
+}
+
 // Blackhole >= 19.9: ETH_LIVE_STATUS becomes available (upper 16 = link, lower 16 = heartbeat).
 /* static */ FirmwareFeatures FirmwareInfoProvider::create_blackhole_19_9_base() {
-    FirmwareFeatures map = create_blackhole_18_8_base();
+    FirmwareFeatures map = create_blackhole_19_8_base();
     map[FirmwareFeature::ETH_HEARTBEAT_STATUS] = {TelemetryTag::ETH_LIVE_STATUS, LinearTransform{0, 0xFFFF}};
     map[FirmwareFeature::ETH_LINK_STATUS] = {TelemetryTag::ETH_LIVE_STATUS, LinearTransform{16, 0xFFFF}};
     return map;

--- a/nanobind/py_api_telemetry.cpp
+++ b/nanobind/py_api_telemetry.cpp
@@ -234,6 +234,7 @@ void bind_telemetry(nb::module_& m) {
         .def("get_dram_speed", &FirmwareInfoProvider::get_dram_speed, release_gil())
         .def("get_current_max_dram_temperature", &FirmwareInfoProvider::get_current_max_dram_temperature, release_gil())
         .def("get_thm_limit_shutdown", &FirmwareInfoProvider::get_thm_limit_shutdown, release_gil())
+        .def("get_tdp_limit", &FirmwareInfoProvider::get_tdp_limit, release_gil())
         .def("get_board_power_limit", &FirmwareInfoProvider::get_board_power_limit, release_gil())
         .def("get_thm_limit_throttle", &FirmwareInfoProvider::get_thm_limit_throttle, release_gil())
         .def("get_therm_trip_count", &FirmwareInfoProvider::get_therm_trip_count, release_gil())

--- a/tests/api/test_firmware_info_provider.cpp
+++ b/tests/api/test_firmware_info_provider.cpp
@@ -617,7 +617,7 @@ TEST_F(TestFirmwareInfoProvider, TdpLimit) {
         FirmwareBundleVersion fw_version = fw_info->get_firmware_version();
         bool expect_available = tt_device->get_arch() == tt::ARCH::BLACKHOLE
                                     ? fw_version >= FirmwareBundleVersion(19, 8, 0)
-                                    : fw_version > FW_VERSION_18_3;
+                                    : fw_version >= FW_VERSION_18_4;
         if (!expect_available) {
             EXPECT_FALSE(tdp_limit.has_value());
             continue;

--- a/tests/api/test_firmware_info_provider.cpp
+++ b/tests/api/test_firmware_info_provider.cpp
@@ -622,7 +622,7 @@ TEST_F(TestFirmwareInfoProvider, TdpLimit) {
             EXPECT_FALSE(tdp_limit.has_value());
             continue;
         }
-
+        EXPECT_TRUE(tdp_limit.has_value());
         // Firmware seeds this from the board's SPI firmware table and keeps it inside the TDP
         // throttler's [50, 500] W range. A zero means the board never configured a limit.
         if (tdp_limit.has_value() && tdp_limit.value() != 0) {

--- a/tests/api/test_firmware_info_provider.cpp
+++ b/tests/api/test_firmware_info_provider.cpp
@@ -606,6 +606,22 @@ TEST_F(TestFirmwareInfoProvider, BoardPowerLimit) {
     }
 }
 
+TEST_F(TestFirmwareInfoProvider, TdpLimit) {
+    for (const auto& tt_device : get_tt_devices()) {
+        auto* fw_info = tt_device->get_firmware_info_provider();
+
+        auto tdp_limit = fw_info->get_tdp_limit();
+        log_info(tt::LogUMD, "tdp_limit={} W", opt_str(tdp_limit));
+
+        // Firmware seeds this from the board's SPI firmware table and keeps it inside the TDP
+        // throttler's [50, 500] W range. A zero means the board never configured a limit.
+        if (tdp_limit.has_value() && tdp_limit.value() != 0) {
+            EXPECT_GE(tdp_limit.value(), 50u);
+            EXPECT_LE(tdp_limit.value(), 500u);
+        }
+    }
+}
+
 TEST_F(TestFirmwareInfoProvider, ThermTripCount) {
     for (const auto& tt_device : get_tt_devices()) {
         auto* fw_info = tt_device->get_firmware_info_provider();

--- a/tests/api/test_firmware_info_provider.cpp
+++ b/tests/api/test_firmware_info_provider.cpp
@@ -613,6 +613,16 @@ TEST_F(TestFirmwareInfoProvider, TdpLimit) {
         auto tdp_limit = fw_info->get_tdp_limit();
         log_info(tt::LogUMD, "tdp_limit={} W", opt_str(tdp_limit));
 
+        // Wormhole publishes the limit from 18.4 on, Blackhole from 19.8 on.
+        FirmwareBundleVersion fw_version = fw_info->get_firmware_version();
+        bool expect_available = tt_device->get_arch() == tt::ARCH::BLACKHOLE
+                                    ? fw_version >= FirmwareBundleVersion(19, 8, 0)
+                                    : fw_version > FW_VERSION_18_3;
+        if (!expect_available) {
+            EXPECT_FALSE(tdp_limit.has_value());
+            continue;
+        }
+
         // Firmware seeds this from the board's SPI firmware table and keeps it inside the TDP
         // throttler's [50, 500] W range. A zero means the board never configured a limit.
         if (tdp_limit.has_value() && tdp_limit.value() != 0) {

--- a/tools/telemetry.cpp
+++ b/tools/telemetry.cpp
@@ -14,6 +14,7 @@
 #include <iomanip>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <sstream>
 #include <stdexcept>
@@ -45,10 +46,11 @@ std::string run_default_telemetry(tt::ChipId chip_id, FirmwareInfoProvider* firm
     uint32_t tdp = firmware_info_provider->get_tdp().value_or(0);
     uint32_t tdc = firmware_info_provider->get_tdc().value_or(0);
     uint32_t vcore = firmware_info_provider->get_vcore().value_or(0);
+    std::optional<uint32_t> tdp_limit = firmware_info_provider->get_tdp_limit();
 
     return fmt::format(
         "Chip ID {} - Chip {:.2f} °C, Board {:.2f} °C, AICLK {} MHz, AXICLK {} MHz, ARCCLK {} MHz, "
-        "TDP {} W, TDC {} A, VCORE {} mV",
+        "TDP {}/{} W, TDC {} A, VCORE {} mV",
         chip_id,
         asic_temperature,
         board_temperature,
@@ -56,6 +58,7 @@ std::string run_default_telemetry(tt::ChipId chip_id, FirmwareInfoProvider* firm
         axiclk,
         arcclk,
         tdp,
+        tdp_limit.has_value() ? std::to_string(tdp_limit.value()) : "N/A",
         tdc,
         vcore);
 }


### PR DESCRIPTION
### Issue
#3097 

### Description
This pull request adds support for reporting the TDP limit to the firmware telemetry API, including device detection, Python bindings, and tests. It ensures that the TDP limit is available for Wormhole devices from firmware version 18.4 onwards and for Blackhole devices from version 19.8 onwards. The telemetry tool output is also updated to display the TDP limit when available.

### List of the changes

**Firmware telemetry and API enhancements:**

* Added a new method `get_tdp_limit()` to `FirmwareInfoProvider` and exposed it to the Python API, allowing retrieval of the TDP limit in watts.
* Updated firmware feature mappings and static constructors to support the TDP limit for Wormhole (from 18.4) and Blackhole (from 19.8) architectures, including a new `FirmwareFeature::TDP_LIMIT_MAX` and a new `create_blackhole_19_8_base()` method.

### Testing

* Added a new test to verify correct reporting of the TDP limit, including version-dependent availability and value range checks.

### API Changes
/
