### PR TITLE
Simulation: give each host its own socket directory so multiple servers can coexist

### DIFF
--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -128,6 +128,13 @@ struct ClusterOptions {
     std::function<void()> simulation_shutdown_handler;
 
     /**
+     * Host SIMULATION chip type only: the directory this host serves its per-chip sockets in.
+     * Empty means allocate a fresh one, so distinct hosts on the same machine never collide; set it
+     * to serve in a specific directory (e.g. one the caller pre-allocated to report to the user).
+     */
+    std::filesystem::path simulator_server_directory = "";
+
+    /**
      * I/O device type to use for the cluster.
      * This determines how the cluster will communicate with the underlying hardware.
      */
@@ -748,7 +755,9 @@ private:
     // separate client process (a Cluster pointed at the socket directory) can attach and drive it. A
     // no-op for a client Cluster. Called once from the constructor after the chips are built.
     void serve_simulation_devices_over_sockets(
-        const std::filesystem::path& simulator_directory, const std::function<void()>& shutdown_handler);
+        const std::filesystem::path& simulator_directory,
+        const std::filesystem::path& simulator_server_directory,
+        const std::function<void()>& shutdown_handler);
 #endif  // TT_UMD_BUILD_SIMULATION
     SocDescriptor construct_soc_descriptor(
         const std::string& soc_desc_path, ChipId chip_id, ChipType chip_type, ClusterDescriptor* cluster_desc);

--- a/device/api/umd/device/simulation/simulation_connector.hpp
+++ b/device/api/umd/device/simulation/simulation_connector.hpp
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <map>
 #include <memory>
+#include <vector>
 
 #include "umd/device/types/cluster_descriptor_types.hpp"
 
@@ -19,15 +20,28 @@ struct SimulationConnectorOptions {
     // The simulator build to host: a TTSim .so (when the path ends in .so) or an RTL simulator
     // directory. The backend is selected from the path, mirroring the simulation device factory.
     std::filesystem::path simulator_directory;
+    // Host path only: the directory this server serves its per-chip sockets in. Empty means
+    // allocate a fresh one (allocate_server_directory), so distinct hosts never collide; set it to
+    // serve in a specific directory (e.g. one the caller pre-allocated to report to the user).
+    std::filesystem::path server_directory;
     // Connectivity/topology used to configure the simulator on the host path. Optional; when
     // attaching to a live host the topology comes from the host instead.
     std::shared_ptr<ClusterDescriptor> cluster_descriptor;
     int num_host_mem_channels = 0;
 };
 
+// One simulation server open on this machine, as seen by list_servers(): its index, the directory
+// it serves in, and the per-chip sockets present there ({chip_id -> socket path}).
+struct SimulationServerInfo {
+    int index = 0;
+    std::filesystem::path directory;
+    std::map<ChipId, std::filesystem::path> sockets;
+};
+
 // Entry point for opening simulated devices, mirroring silicon TopologyDiscovery. The role is
 // decided purely from what simulator_directory points at -- no socket bind-race:
-//   - a ".so" file            -> host running the TTSim backend; binds + serves its socket;
+//   - a ".so" file            -> host running the TTSim backend; serves its socket in a fresh
+//                                 server directory;
 //   - a directory of per-chip -> client: one socket-backed device per socket in the directory,
 //     simulation sockets          each attaching to a live host and sourcing its SoC descriptor
 //                                 (and backend kind) from that host over the wire;
@@ -40,6 +54,17 @@ public:
     static Role role_for(const std::filesystem::path& simulator_directory);
 
     static std::map<ChipId, std::unique_ptr<TTDevice>> discover(const SimulationConnectorOptions& options);
+
+    // Claims a fresh directory for one simulation server (the lowest free index) and returns it, so
+    // a caller can report the location before it starts serving there (pass it back as
+    // SimulationConnectorOptions::server_directory or ClusterOptions::simulator_server_directory).
+    // The claim is atomic, so racing starts get distinct directories.
+    static std::filesystem::path allocate_server_directory();
+
+    // The simulation servers currently open on this machine, ordered by index, discovered by
+    // scanning the well-known server directories (the same directories a client attaches to). Does
+    // not connect to them. Exposed for management tooling (list / kill) without opening devices.
+    static std::vector<SimulationServerInfo> list_servers();
 };
 
 }  // namespace tt::umd

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -635,7 +635,8 @@ Cluster::Cluster(ClusterOptions options) {
 
 #ifdef TT_UMD_BUILD_SIMULATION
     if (options.chip_type == ChipType::SIMULATION && options.serve_simulation_devices_over_sockets) {
-        serve_simulation_devices_over_sockets(options.simulator_directory, options.simulation_shutdown_handler);
+        serve_simulation_devices_over_sockets(
+            options.simulator_directory, options.simulator_server_directory, options.simulation_shutdown_handler);
     }
 #endif  // TT_UMD_BUILD_SIMULATION
 
@@ -648,7 +649,9 @@ Cluster::Cluster(ClusterOptions options) {
 
 #ifdef TT_UMD_BUILD_SIMULATION
 void Cluster::serve_simulation_devices_over_sockets(
-    const std::filesystem::path& simulator_directory, const std::function<void()>& shutdown_handler) {
+    const std::filesystem::path& simulator_directory,
+    const std::filesystem::path& simulator_server_directory,
+    const std::function<void()>& shutdown_handler) {
     // A client Cluster skips this: its simulator_directory is a socket directory (not a .so/RTL
     // build), so role_for returns Client. On the host, expose each simulation chip's device on its
     // per-chip socket so a separate client process (a Cluster pointed at the socket directory) can
@@ -659,10 +662,17 @@ void Cluster::serve_simulation_devices_over_sockets(
     if (SimulationConnector::role_for(simulator_directory) != SimulationConnector::Role::Host) {
         return;
     }
+    // Serve in a dedicated directory -- the caller's, or a fresh one -- so two hosts on the same
+    // machine never collide even when they serve the same chip id.
+    const std::filesystem::path server_directory = simulator_server_directory.empty()
+                                                       ? SimulationServerSocket::allocate_server_directory()
+                                                       : simulator_server_directory;
+    log_info(LogUMD, "Simulation host serving sockets in {}", server_directory.string());
     for (const auto& [chip_id, chip] : chips_) {
         if (auto* sim_device = dynamic_cast<SimulationTTDevice*>(chip->get_tt_device())) {
             sim_device->adopt_socket(
-                SimulationServerSocket::create(SimulationServerSocket::default_socket_path(chip_id)), shutdown_handler);
+                SimulationServerSocket::create(SimulationServerSocket::default_socket_path(server_directory, chip_id)),
+                shutdown_handler);
         }
     }
 }

--- a/device/simulation/simulation_connector.cpp
+++ b/device/simulation/simulation_connector.cpp
@@ -12,6 +12,7 @@
 #include <system_error>
 #include <tt-logger/tt-logger.hpp>
 #include <utility>
+#include <vector>
 
 #include "simulation/simulation_server_socket.hpp"
 #include "umd/device/simulation/simulation_client.hpp"
@@ -102,6 +103,21 @@ SimulationConnector::Role SimulationConnector::role_for(const std::filesystem::p
     return classify(simulator_directory).kind == PathKind::CLIENT ? Role::Client : Role::Host;
 }
 
+std::filesystem::path SimulationConnector::allocate_server_directory() {
+    return SimulationServerSocket::allocate_server_directory();
+}
+
+std::vector<SimulationServerInfo> SimulationConnector::list_servers() {
+    // Each server owns a directory under the system temp dir (see allocate_server_directory);
+    // scanning for those directories and the sockets in each yields every open server, and the
+    // chips it serves, without connecting to any.
+    std::vector<SimulationServerInfo> servers;
+    for (const auto& [index, directory] : SimulationServerSocket::list_server_directories()) {
+        servers.push_back({index, directory, SimulationServerSocket::sockets_in_directory(directory)});
+    }
+    return servers;
+}
+
 std::map<ChipId, std::unique_ptr<TTDevice>> SimulationConnector::discover(const SimulationConnectorOptions& options) {
     std::map<ChipId, std::unique_ptr<TTDevice>> devices;
     const std::filesystem::path& simulator_path = options.simulator_directory;
@@ -135,10 +151,15 @@ std::map<ChipId, std::unique_ptr<TTDevice>> SimulationConnector::discover(const 
         return devices;
     }
 
-    // Host: single chip for now. Claim the per-chip socket -- create() throws if a live host
-    // already owns it (two hosts cannot serve the same chip) -- and serve it.
+    // Host: single chip for now. Serve in a dedicated server directory -- the caller's, or a fresh
+    // one -- so two hosts never collide even when they serve the same chip id. create() throws if a
+    // live host already owns this chip's socket in that directory.
+    const std::filesystem::path server_directory = options.server_directory.empty()
+                                                       ? SimulationServerSocket::allocate_server_directory()
+                                                       : options.server_directory;
     const ChipId chip_id = 0;
-    auto socket = SimulationServerSocket::create(SimulationServerSocket::default_socket_path(chip_id));
+    auto socket =
+        SimulationServerSocket::create(SimulationServerSocket::default_socket_path(server_directory, chip_id));
     devices.emplace(
         chip_id,
         make_host_device(classification.kind, simulator_path, options.num_host_mem_channels, std::move(socket)));

--- a/device/simulation/simulation_server_socket.cpp
+++ b/device/simulation/simulation_server_socket.cpp
@@ -328,14 +328,104 @@ SimulationServerSocket::~SimulationServerSocket() {
     // filesystem_error would call std::terminate. Cleanup is best-effort.
     std::error_code ec;
     std::filesystem::remove(socket_path_, ec);
+    // Remove the server directory once its last socket is gone. remove() only deletes an empty
+    // directory, so a multi-chip host's directory survives until the last chip's socket is torn
+    // down, and a directory that still holds other files is left alone. Guarded to our own naming
+    // so we never touch an unrelated directory.
+    const std::filesystem::path server_directory = socket_path_.parent_path();
+    std::error_code temp_ec;
+    const std::filesystem::path temp = std::filesystem::temp_directory_path(temp_ec);
+    // Only ever remove a directory we could have allocated: our naming convention AND directly under
+    // the system temp dir. A caller may bind a socket at an arbitrary path that happens to match the
+    // naming (e.g. ~/tt-umd-sim-server-0/foo.sock); the parent-path check keeps teardown from rmdir'ing
+    // that. (remove() deletes only an empty directory, so this is already narrow, but not narrow enough.)
+    if (!temp_ec && server_directory.parent_path() == temp &&
+        server_index_from_directory_path(server_directory).has_value()) {
+        std::filesystem::remove(server_directory, ec);
+    }
 }
 
-std::filesystem::path SimulationServerSocket::default_socket_path(ChipId chip_id) {
-    // One shared socket per chip per machine, under the system temp directory: the name
-    // carries no uid, so every process (any user) resolves the same path and attaches to the
-    // single host. The socket dir is assumed trusted: the path is predictable and the socket
-    // is world-writable (see bind_and_listen), so any local user can connect to or squat it.
-    return std::filesystem::temp_directory_path() / fmt::format("tt-umd-sim-{}.sock", chip_id);
+namespace {
+// Naming convention for a server directory: <temp>/tt-umd-sim-server-<index>. Kept here so the
+// prefix lives in one place, shared by allocate/list/parse below.
+constexpr std::string_view kServerDirPrefix = "tt-umd-sim-server-";
+// Backstop on the index search in allocate_server_directory(); far above any real server count.
+constexpr int kMaxServerIndex = 4096;
+}  // namespace
+
+std::filesystem::path SimulationServerSocket::allocate_server_directory() {
+    const std::filesystem::path base = std::filesystem::temp_directory_path();
+    for (int index = 0; index < kMaxServerIndex; ++index) {
+        const std::filesystem::path dir = base / fmt::format("{}{}", kServerDirPrefix, index);
+        // create_directory returns true only when it actually creates the directory (mkdir is
+        // atomic), so the winner of a race claims the index and everyone else moves on. It returns
+        // false without setting ec when the directory already exists (taken) -- move to the next
+        // index; ec is set only on a real error (e.g. permissions, read-only fs), which we surface
+        // immediately rather than spin kMaxServerIndex times hiding it behind a generic message.
+        std::error_code ec;
+        if (std::filesystem::create_directory(dir, ec)) {
+            return dir;
+        }
+        UMD_ASSERT(
+            !ec,
+            error::RuntimeError,
+            fmt::format("Failed to create simulation server directory {}: {}", dir.string(), ec.message()));
+    }
+    UMD_THROW(
+        error::RuntimeError, fmt::format("Could not allocate a simulation server directory under {}", base.string()));
+}
+
+std::map<int, std::filesystem::path> SimulationServerSocket::list_server_directories() {
+    std::map<int, std::filesystem::path> servers;
+    std::error_code ec;
+    std::filesystem::directory_iterator it(std::filesystem::temp_directory_path(), ec);
+    if (ec) {
+        return servers;
+    }
+    for (const auto& entry : it) {
+        // Skip symlinks: the temp dir is world-writable, so a symlink named tt-umd-sim-server-<index>
+        // could otherwise make an arbitrary target enumerate as a server (is_directory() follows links).
+        std::error_code sym_ec;
+        if (entry.is_symlink(sym_ec)) {
+            continue;
+        }
+        std::error_code dir_ec;
+        if (!entry.is_directory(dir_ec)) {
+            continue;
+        }
+        if (const std::optional<int> index = server_index_from_directory_path(entry.path())) {
+            servers.emplace(*index, entry.path());
+        }
+    }
+    return servers;
+}
+
+std::optional<int> SimulationServerSocket::server_index_from_directory_path(const std::filesystem::path& directory) {
+    // Inverse of allocate_server_directory()'s "tt-umd-sim-server-<index>". Kept next to it so the
+    // naming convention lives in exactly one place.
+    const std::string name = directory.filename().string();
+    if (name.size() <= kServerDirPrefix.size() || name.compare(0, kServerDirPrefix.size(), kServerDirPrefix) != 0) {
+        return std::nullopt;
+    }
+    const std::string digits = name.substr(kServerDirPrefix.size());
+    // Require a plain run of digits so e.g. "tt-umd-sim-server-x" doesn't parse.
+    if (digits.empty() || digits.find_first_not_of("0123456789") != std::string::npos) {
+        return std::nullopt;
+    }
+    try {
+        return std::stoi(digits);
+    } catch (const std::exception&) {
+        return std::nullopt;  // out of int range
+    }
+}
+
+std::filesystem::path SimulationServerSocket::default_socket_path(
+    const std::filesystem::path& server_directory, ChipId chip_id) {
+    // One shared socket per chip inside the server's directory: the name carries no uid, so every
+    // process (any user) resolves the same path and attaches to the host. The directory is assumed
+    // trusted: the path is predictable and the socket is world-writable (see bind_and_listen), so
+    // any local user can connect to or squat it.
+    return server_directory / fmt::format("tt-umd-sim-{}.sock", chip_id);
 }
 
 std::optional<ChipId> SimulationServerSocket::chip_id_from_socket_path(const std::filesystem::path& socket_path) {

--- a/device/simulation/simulation_server_socket.hpp
+++ b/device/simulation/simulation_server_socket.hpp
@@ -17,7 +17,8 @@
 namespace tt::umd {
 
 // Manages a per-chip UNIX domain socket that represents a simulated device on disk
-// ("the card"). One socket per simulated chip.
+// ("the card"). One socket per simulated chip, kept in a per-server directory
+// (allocate_server_directory) so distinct hosts on the same machine never collide.
 //
 // The socket acts as a presence indicator: if a process can bind the path it becomes the
 // host; if a live host already exists, try_create() returns nullptr so the caller
@@ -70,10 +71,27 @@ public:
 
     const std::filesystem::path& socket_path() const { return socket_path_; }
 
-    // Deterministic per-chip socket path (the naming contract a client connects to):
-    // <temp_dir>/tt-umd-sim-<chip_id>.sock, under the system temp directory. No uid in the
-    // name: one shared socket per chip that any user may attach to.
-    static std::filesystem::path default_socket_path(ChipId chip_id = 0);
+    // Claims a fresh directory for one simulation server: <temp_dir>/tt-umd-sim-server-<index>,
+    // for the lowest index not already taken. Each server owns its own directory so two hosts
+    // never collide -- even when they serve overlapping chip ids, the sockets live in different
+    // directories. The claim is atomic (create_directory fails if the name exists), so racing
+    // hosts get distinct indices. Throws if no index is free. A client is then pointed at the
+    // returned directory.
+    static std::filesystem::path allocate_server_directory();
+
+    // The simulation server directories present under the system temp dir: {index -> directory},
+    // keyed and ordered by index. This is what a caller enumerating the machine's servers scans;
+    // sockets_in_directory() then lists the chips each one serves.
+    static std::map<int, std::filesystem::path> list_server_directories();
+
+    // Inverse of allocate_server_directory()'s naming: pulls the index out of a directory *name*
+    // (tt-umd-sim-server-<index>). Returns nullopt when the name doesn't match the convention.
+    static std::optional<int> server_index_from_directory_path(const std::filesystem::path& directory);
+
+    // Deterministic per-chip socket path inside a server directory (the naming contract a client
+    // connects to): <server_directory>/tt-umd-sim-<chip_id>.sock. No uid in the name: one shared
+    // socket per chip that any user may attach to.
+    static std::filesystem::path default_socket_path(const std::filesystem::path& server_directory, ChipId chip_id = 0);
 
     // Inverse of default_socket_path()'s naming: pulls the chip id out of a socket file *name*
     // (tt-umd-sim-<chip_id>.sock). Returns nullopt when the name doesn't match the convention, so a

--- a/tests/api/test_simulation_connector.cpp
+++ b/tests/api/test_simulation_connector.cpp
@@ -29,20 +29,13 @@ TEST(SimulationConnector, CreatesHostDeviceAndExposesSocket) {
         GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
     }
 
-    const std::filesystem::path socket = SimulationServerSocket::default_socket_path(0);
-    // discover() resolves this well-known machine-wide path internally, so the test can't point
-    // it at a private one. Rather than blindly unlink it (which would clobber a host from a
-    // concurrent run), probe with try_create: a live owner -> skip; otherwise we hold a fresh or
-    // reclaimed socket, released here so discover() can bind it itself.
-    {
-        auto probe = SimulationServerSocket::try_create(socket);
-        if (probe == nullptr) {
-            GTEST_SKIP() << "A live simulation host already holds " << socket << "; skipping to avoid clobbering it.";
-        }
-    }
+    // Each server gets its own directory, so a fresh one never collides with a concurrent run.
+    const std::filesystem::path server_directory = SimulationServerSocket::allocate_server_directory();
+    const std::filesystem::path socket = SimulationServerSocket::default_socket_path(server_directory, 0);
 
     SimulationConnectorOptions options;
     options.simulator_directory = simulator_path;
+    options.server_directory = server_directory;
 
     {
         auto devices = SimulationConnector::discover(options);
@@ -51,7 +44,8 @@ TEST(SimulationConnector, CreatesHostDeviceAndExposesSocket) {
         EXPECT_TRUE(std::filesystem::exists(socket));  // host exposed it
     }
 
-    EXPECT_FALSE(std::filesystem::exists(socket));  // torn down with the device
+    EXPECT_FALSE(std::filesystem::exists(socket));                  // torn down with the device
+    EXPECT_FALSE(std::filesystem::is_directory(server_directory));  // and its now-empty directory removed
 }
 
 // discover() decides the role from what simulator_directory points at (a .so file hosts TTSim, a
@@ -74,16 +68,12 @@ TEST(SimulationConnector, HostServesClientMemoryOverSocket) {
         GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
     }
 
-    const std::filesystem::path socket = SimulationServerSocket::default_socket_path(0);
-    {
-        auto probe = SimulationServerSocket::try_create(socket);
-        if (probe == nullptr) {
-            GTEST_SKIP() << "A live simulation host already holds " << socket << "; skipping.";
-        }
-    }
+    const std::filesystem::path server_directory = SimulationServerSocket::allocate_server_directory();
+    const std::filesystem::path socket = SimulationServerSocket::default_socket_path(server_directory, 0);
 
     SimulationConnectorOptions options;
     options.simulator_directory = simulator_path;
+    options.server_directory = server_directory;
     auto devices = SimulationConnector::discover(options);
     ASSERT_EQ(devices.size(), 1u);
     TTDevice* host = devices.at(0).get();
@@ -138,16 +128,12 @@ TEST(SimulationConnector, HostServesDeviceInfoOverSocket) {
         GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
     }
 
-    const std::filesystem::path socket = SimulationServerSocket::default_socket_path(0);
-    {
-        auto probe = SimulationServerSocket::try_create(socket);
-        if (probe == nullptr) {
-            GTEST_SKIP() << "A live simulation host already holds " << socket << "; skipping.";
-        }
-    }
+    const std::filesystem::path server_directory = SimulationServerSocket::allocate_server_directory();
+    const std::filesystem::path socket = SimulationServerSocket::default_socket_path(server_directory, 0);
 
     SimulationConnectorOptions options;
     options.simulator_directory = simulator_path;
+    options.server_directory = server_directory;
     auto devices = SimulationConnector::discover(options);
     ASSERT_EQ(devices.size(), 1u);
     TTDevice* host = devices.at(0).get();
@@ -183,18 +169,13 @@ TEST(SimulationConnector, ClientDeviceReadsAndWritesOverSocket) {
         GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
     }
 
-    const std::filesystem::path socket = SimulationServerSocket::default_socket_path(0);
-    {
-        auto probe = SimulationServerSocket::try_create(socket);
-        if (probe == nullptr) {
-            GTEST_SKIP() << "A live simulation host already holds " << socket << "; skipping.";
-        }
-    }
+    const std::filesystem::path server_directory = SimulationServerSocket::allocate_server_directory();
 
     SimulationConnectorOptions host_options;
     host_options.simulator_directory = simulator_path;
+    host_options.server_directory = server_directory;
 
-    // The .so path hosts and publishes its per-chip socket; pointing discovery at that socket's
+    // The .so path hosts and publishes its per-chip socket; pointing discovery at that server's
     // directory takes the client path, attaching one client device per socket.
     auto host_devices = SimulationConnector::discover(host_options);
     ASSERT_EQ(host_devices.size(), 1u);
@@ -202,7 +183,7 @@ TEST(SimulationConnector, ClientDeviceReadsAndWritesOverSocket) {
     ASSERT_NE(host, nullptr);
 
     SimulationConnectorOptions client_options;
-    client_options.simulator_directory = socket.parent_path();
+    client_options.simulator_directory = server_directory;
     auto client_devices = SimulationConnector::discover(client_options);
     ASSERT_EQ(client_devices.count(0), 1u);
     TTDevice* client = client_devices.at(0).get();
@@ -236,13 +217,7 @@ TEST(SimulationConnector, HostAndClientClustersShareDeviceMemory) {
         GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
     }
 
-    const std::filesystem::path socket0 = SimulationServerSocket::default_socket_path(0);
-    {
-        auto probe = SimulationServerSocket::try_create(socket0);
-        if (probe == nullptr) {
-            GTEST_SKIP() << "A live simulation host already holds " << socket0 << "; skipping.";
-        }
-    }
+    const std::filesystem::path server_directory = SimulationServerSocket::allocate_server_directory();
 
     ClusterOptions host_options;
     host_options.chip_type = ChipType::SIMULATION;
@@ -250,11 +225,12 @@ TEST(SimulationConnector, HostAndClientClustersShareDeviceMemory) {
     // Publishing per-chip sockets is opt-in (off by default so ordinary in-process runs stay
     // private); this test is specifically the host/client-over-socket path, so it opts in.
     host_options.serve_simulation_devices_over_sockets = true;
+    host_options.simulator_server_directory = server_directory;
     Cluster host_cluster(host_options);
 
     ClusterOptions client_options;
     client_options.chip_type = ChipType::SIMULATION;
-    client_options.simulator_directory = socket0.parent_path();  // the socket directory => client role
+    client_options.simulator_directory = server_directory;  // the server directory => client role
     Cluster client_cluster(client_options);
 
     // The client reconstructed the same chips the host serves.

--- a/tests/baremetal/test_simulation_server_socket.cpp
+++ b/tests/baremetal/test_simulation_server_socket.cpp
@@ -223,11 +223,66 @@ TEST_F(SimulationServerSocketTest, ServesAfterDeferredServe) {
 }
 
 TEST(SimulationServerSocket, DefaultSocketPathIsPerChip) {
-    EXPECT_NE(SimulationServerSocket::default_socket_path(0), SimulationServerSocket::default_socket_path(1));
+    const std::filesystem::path dir = "/tmp/tt-umd-sim-server-0";
+    EXPECT_NE(SimulationServerSocket::default_socket_path(dir, 0), SimulationServerSocket::default_socket_path(dir, 1));
 }
 
-TEST(SimulationServerSocket, DefaultSocketPathIsAbsolute) {
-    EXPECT_TRUE(SimulationServerSocket::default_socket_path(0).is_absolute());
+TEST(SimulationServerSocket, DefaultSocketPathIsInServerDirectory) {
+    const std::filesystem::path dir = "/tmp/tt-umd-sim-server-3";
+    EXPECT_EQ(SimulationServerSocket::default_socket_path(dir, 0).parent_path(), dir);
+}
+
+// allocate_server_directory hands each caller a distinct, freshly created directory, and each shows
+// up in list_server_directories keyed by the index parsed out of its name.
+TEST(SimulationServerSocket, AllocateServerDirectoryClaimsDistinctDirs) {
+    namespace fs = std::filesystem;
+    const fs::path a = SimulationServerSocket::allocate_server_directory();
+    const fs::path b = SimulationServerSocket::allocate_server_directory();
+    EXPECT_NE(a, b);
+    EXPECT_TRUE(fs::is_directory(a));
+    EXPECT_TRUE(fs::is_directory(b));
+
+    const auto index_a = SimulationServerSocket::server_index_from_directory_path(a);
+    ASSERT_TRUE(index_a.has_value());
+    EXPECT_EQ(SimulationServerSocket::list_server_directories().count(*index_a), 1u);
+
+    fs::remove(a);
+    fs::remove(b);
+}
+
+// list_server_directories must not follow a symlink: the temp dir is world-writable, so a link named
+// like a server directory (pointing anywhere) must not enumerate as a server.
+TEST(SimulationServerSocket, ListServerDirectoriesIgnoresSymlinks) {
+    namespace fs = std::filesystem;
+    const int index = 9042;  // distinctive, unlikely to collide with a live server
+    const fs::path link = fs::temp_directory_path() / ("tt-umd-sim-server-" + std::to_string(index));
+    const fs::path target = fs::temp_directory_path() / ("tt-umd-sim-symlink-target-" + std::to_string(::getpid()));
+    fs::remove(link);
+    fs::create_directory(target);
+    fs::create_directory_symlink(target, link);
+
+    EXPECT_EQ(SimulationServerSocket::list_server_directories().count(index), 0u);
+
+    fs::remove(link);
+    fs::remove(target);
+}
+
+// server_index_from_directory_path is the inverse of allocate_server_directory's naming; it must
+// accept exactly the tt-umd-sim-server-<index> convention and reject anything else.
+TEST(SimulationServerSocket, ServerIndexFromDirectoryPathParsesConvention) {
+    auto i0 = SimulationServerSocket::server_index_from_directory_path("tt-umd-sim-server-0");
+    ASSERT_TRUE(i0.has_value());
+    EXPECT_EQ(*i0, 0);
+
+    auto i7 = SimulationServerSocket::server_index_from_directory_path("/some/dir/tt-umd-sim-server-7");
+    ASSERT_TRUE(i7.has_value());
+    EXPECT_EQ(*i7, 7);
+
+    // Non-matching names yield nullopt.
+    EXPECT_FALSE(SimulationServerSocket::server_index_from_directory_path("tt-umd-sim-server-").has_value());
+    EXPECT_FALSE(SimulationServerSocket::server_index_from_directory_path("tt-umd-sim-server-x").has_value());
+    EXPECT_FALSE(SimulationServerSocket::server_index_from_directory_path("tt-umd-sim-0.sock").has_value());
+    EXPECT_FALSE(SimulationServerSocket::server_index_from_directory_path("foo").has_value());
 }
 
 // chip_id_from_socket_path is the inverse of default_socket_path's naming; it must accept exactly
@@ -242,7 +297,8 @@ TEST(SimulationServerSocket, ChipIdFromSocketPathParsesConvention) {
     EXPECT_EQ(*id7, 7);
 
     // Round-trips default_socket_path().
-    auto id3 = SimulationServerSocket::chip_id_from_socket_path(SimulationServerSocket::default_socket_path(3));
+    auto id3 = SimulationServerSocket::chip_id_from_socket_path(
+        SimulationServerSocket::default_socket_path("/tmp/tt-umd-sim-server-0", 3));
     ASSERT_TRUE(id3.has_value());
     EXPECT_EQ(*id3, 3);
 


### PR DESCRIPTION
> Supersedes #3051, which GitHub auto-closed during a stack reorder (its commit briefly became an ancestor of its old base). This PR carries the identical library-infra commit.

### Issue
Part of #2677 (simulation server process). Host mode hardcoded chip id 0 and derived the socket path from it alone (`<temp>/tt-umd-sim-0.sock`), so two hosts pointed at *different* simulators collided on the same socket — the second failed to start with "A live simulation server already exists". In practice that meant only one host simulator per machine. #3029 (the `SHUTDOWN` command) is merged into main. This is stacked on #3112 (which makes socket serving opt-in via `ClusterOptions::serve_simulation_devices_over_sockets`), since the per-server-directory serve path here interacts with that gate; the `sim_server` tool (#3030) stacks on top of this.

### Description
Each host now serves in its **own directory**, `<temp>/tt-umd-sim-server-<index>`, claimed atomically for the lowest free index, with the per-chip sockets (`tt-umd-sim-<chip>.sock`) kept inside it. Distinct servers get distinct directories — even when they serve the same chip id — and a client attaches by pointing at a specific server's directory. The directory is removed once its last socket is torn down (guarded to our own naming so it never touches an unrelated directory).

### List of the changes
- `SimulationServerSocket`: `allocate_server_directory()` (atomic, lowest-free-index), `list_server_directories()`, `server_index_from_directory_path()`; `default_socket_path()` now takes the server directory; the server directory is `rmdir`'d on teardown when its last socket goes.
- `SimulationConnector`: optional `SimulationConnectorOptions::server_directory` (empty ⇒ auto-allocate); `discover()` host path serves in it; `list_servers()` returns `std::vector<SimulationServerInfo>` (index + directory + per-chip sockets) for management tooling; `allocate_server_directory()` exposed publicly.
- `Cluster`: `ClusterOptions::simulator_server_directory` (empty ⇒ auto-allocate); host path serves there.

### Testing
- New baremetal coverage: distinct-directory allocation + listing, server-index parsing. 182/182 baremetal pass.
- Connector e2e tests updated to allocate a server directory (which also removes the need for the old probe/skip dance, since each run gets a unique directory); they compile and skip without `TT_UMD_SIMULATOR`.
- Build + pre-commit clean.

### API Changes
- `ClusterOptions::simulator_server_directory` — new, optional.
- `SimulationConnectorOptions::server_directory` — new, optional.
- `SimulationConnector::list_servers()` — new; returns `std::vector<SimulationServerInfo>`. New `SimulationConnector::allocate_server_directory()`.
- `SimulationServerSocket::default_socket_path()` now takes the server directory (internal header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
