### PR TITLE
init arc/eth on ttsim device without cluster descriptor

### DIFF
--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -743,13 +743,14 @@ private:
         SocDescriptor& soc_desc,
         int num_host_mem_channels,
         const std::filesystem::path& simulator_directory,
+        bool initialize_simulation_from_firmware,
         std::unique_ptr<TTDevice> tt_device = nullptr);
 #ifdef TT_UMD_BUILD_SIMULATION
-    // Builds the RemoteChip for a non-MMIO chip in a multichip ttsim cluster. A simulated remote chip has no
-    // ARC/topology discovery, so its RemoteCommunication and TTDevice (carrying the cluster-derived SocDescriptor
-    // and ChipInfo) are constructed here against the MMIO gateway.
+    // Builds the RemoteChip for a non-MMIO chip in a multichip ttsim cluster. Its RemoteCommunication and TTDevice
+    // are constructed here against the MMIO gateway; firmware initialization is optional so explicitly supplied
+    // mock descriptors can remain authoritative.
     std::unique_ptr<RemoteChip> create_simulation_remote_chip(
-        ChipId chip_id, ClusterDescriptor* cluster_desc, const SocDescriptor& soc_desc);
+        ChipId chip_id, ClusterDescriptor* cluster_desc, const SocDescriptor& soc_desc, bool initialize_from_firmware);
 
     // Host simulation Cluster only: exposes each simulation chip's device on its per-chip socket so a
     // separate client process (a Cluster pointed at the socket directory) can attach and drive it. A

--- a/device/api/umd/device/simulation/tt_sim_communicator.hpp
+++ b/device/api/umd/device/simulation/tt_sim_communicator.hpp
@@ -34,7 +34,8 @@ public:
         const std::filesystem::path &simulator_directory,
         bool copy_sim_binary = false,
         uint32_t chip_id = 0,
-        uint32_t num_chips = 1);
+        uint32_t num_chips = 1,
+        bool force_shared_bdf_mode = false);
 
     /**
      * Destructor that properly cleans up library handles and file descriptors.
@@ -109,6 +110,9 @@ public:
      * @return 32-bit value read from configuration space
      */
     uint32_t pci_config_read32(uint32_t bus_device_function, uint32_t offset);
+
+    // Enumerate consecutive host-visible PCI functions exposed by the loaded simulator.
+    uint32_t get_num_mmio_devices();
 
     /**
      * Advance the simulator clock.
@@ -211,6 +215,7 @@ private:
 
     uint32_t chip_id_ = 0;
     uint32_t num_chips_ = 1;
+    bool force_shared_bdf_mode_ = false;
     static void *s_shared_handle_;
     static int s_shared_refcount_;
     static bool s_sim_initialized_;

--- a/device/api/umd/device/topology/topology_discovery.hpp
+++ b/device/api/umd/device/topology/topology_discovery.hpp
@@ -46,6 +46,13 @@ public:
         IODeviceType io_device_type = IODeviceType::PCIe,
         const std::string& soc_descriptor_path = "");
 
+    static std::pair<std::unique_ptr<ClusterDescriptor>, std::map<ChipId, std::unique_ptr<TTDevice>>>
+    discover_from_local_devices(
+        std::map<ChipId, std::unique_ptr<TTDevice>> local_devices,
+        const TopologyDiscoveryOptions& options = {},
+        IODeviceType io_device_type = IODeviceType::PCIe,
+        const std::string& soc_descriptor_path = "");
+
     virtual ~TopologyDiscovery() = default;
 
 protected:

--- a/device/api/umd/device/topology/topology_discovery.hpp
+++ b/device/api/umd/device/topology/topology_discovery.hpp
@@ -36,6 +36,16 @@ public:
         IODeviceType io_device_type = IODeviceType::PCIe,
         const std::string& soc_descriptor_path = "");
 
+    // Run topology discovery starting from an already initialized local device. This is used by
+    // backends which do not have an OS enumeration interface, but expose the same ARC/Ethernet
+    // topology information as a silicon TTDevice.
+    static std::pair<std::unique_ptr<ClusterDescriptor>, std::map<ChipId, std::unique_ptr<TTDevice>>>
+    discover_from_local_device(
+        std::unique_ptr<TTDevice> local_device,
+        const TopologyDiscoveryOptions& options = {},
+        IODeviceType io_device_type = IODeviceType::PCIe,
+        const std::string& soc_descriptor_path = "");
+
     virtual ~TopologyDiscovery() = default;
 
 protected:
@@ -49,11 +59,19 @@ protected:
         IODeviceType io_device_type = IODeviceType::PCIe,
         const std::string& soc_descriptor_path = "");
 
+    static std::unique_ptr<TopologyDiscovery> create_topology_discovery(
+        tt::ARCH arch,
+        const TopologyDiscoveryOptions& options,
+        IODeviceType io_device_type,
+        const std::string& soc_descriptor_path);
+
     virtual tt::ARCH get_topology_arch() const = 0;
 
     std::unique_ptr<ClusterDescriptor> create_ethernet_map();
 
     void get_connected_devices();
+
+    void add_initialized_local_device(std::unique_ptr<TTDevice> tt_device);
 
     void discover_remote_devices();
 

--- a/device/api/umd/device/tt_device/simulation_device_factory.hpp
+++ b/device/api/umd/device/tt_device/simulation_device_factory.hpp
@@ -41,6 +41,7 @@ std::unique_ptr<TTDevice> create_simulation_tt_device(
     const SocDescriptor &soc_descriptor,
     ChipId chip_id,
     size_t num_chips,
-    int num_host_mem_channels = 0);
+    int num_host_mem_channels = 0,
+    bool force_shared_bdf_mode = false);
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/simulation_tt_device.hpp
@@ -56,6 +56,10 @@ public:
         void* mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id = NocId::DEFAULT_NOC) override;
     void write_to_device(
         const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id = NocId::DEFAULT_NOC) override;
+    void read_from_device_reg(
+        void* mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id = NocId::DEFAULT_NOC) override;
+    void write_to_device_reg(
+        const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id = NocId::DEFAULT_NOC) override;
 
     void dma_d2h(void* dst, uint32_t src, size_t size) override;
     void dma_d2h_zero_copy(void* dst, uint32_t src, size_t size) override;

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -413,6 +413,7 @@ public:
     bool is_remote();
 
     void init_tt_device(std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT);
+    void init_tt_device_for_simulation_remote(std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT);
 
     uint64_t get_refclk_counter();
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -425,8 +425,7 @@ public:
 
     void init_tt_device(std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT);
     void init_tt_device_for_simulation(
-        bool preserve_soc_descriptor = false,
-        std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT);
+        bool preserve_soc_descriptor = false, std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT);
 
     uint64_t get_refclk_counter();
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -413,7 +413,9 @@ public:
     bool is_remote();
 
     void init_tt_device(std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT);
-    void init_tt_device_for_simulation_remote(std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT);
+    void init_tt_device_for_simulation(
+        bool preserve_soc_descriptor = false,
+        std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT);
 
     uint64_t get_refclk_counter();
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -424,6 +424,7 @@ public:
     bool is_remote();
 
     void init_tt_device(std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT);
+    void init_tt_device_for_simulation_remote(std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT);
 
     uint64_t get_refclk_counter();
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -424,7 +424,9 @@ public:
     bool is_remote();
 
     void init_tt_device(std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT);
-    void init_tt_device_for_simulation_remote(std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT);
+    void init_tt_device_for_simulation(
+        bool preserve_soc_descriptor = false,
+        std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT);
 
     uint64_t get_refclk_counter();
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -414,8 +414,7 @@ public:
 
     void init_tt_device(std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT);
     void init_tt_device_for_simulation(
-        bool preserve_soc_descriptor = false,
-        std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT);
+        bool preserve_soc_descriptor = false, std::chrono::milliseconds timeout_ms = timeout::ARC_STARTUP_TIMEOUT);
 
     uint64_t get_refclk_counter();
 

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -91,6 +91,7 @@ public:
      * @return Pointer to TTSimCommunicator
      */
     TTSimCommunicator *get_communicator() { return communicator_.get(); }
+
     uint32_t get_num_mmio_devices() { return communicator_->get_num_mmio_devices(); }
 
     uint64_t bar0_base = 0;

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -40,7 +40,8 @@ public:
         ChipId chip_id,
         bool copy_sim_binary = false,
         int num_host_mem_channels = 0,
-        size_t num_chips = 1);
+        size_t num_chips = 1,
+        bool force_shared_bdf_mode = false);
 
     ~TTSimTTDevice();
 
@@ -90,6 +91,7 @@ public:
      * @return Pointer to TTSimCommunicator
      */
     TTSimCommunicator *get_communicator() { return communicator_.get(); }
+    uint32_t get_num_mmio_devices() { return communicator_->get_num_mmio_devices(); }
 
     uint64_t bar0_base = 0;
     uint64_t bar4_base = 0;

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -75,6 +75,7 @@ public:
         CoreCoord eth_core, const std::chrono::milliseconds timeout_ms = timeout::ETH_TRAINING_TIMEOUT) override;
     EthTrainingStatus read_eth_core_training_status(CoreCoord eth_core) override;
     ChipInfo get_chip_info() override;
+    bool get_noc_translation_enabled() override;
 
     void close_device();
     void start_device();

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -504,11 +504,16 @@ Cluster::Cluster(ClusterOptions options) {
                     break;
                 }
 
-                if (is_ttsim_build) {
-                    if (options.sdesc_path.empty()) {
-                        options.sdesc_path =
-                            SimulationChip::get_soc_descriptor_path_from_simulator_path(options.simulator_directory);
-                    }
+                if (is_ttsim_build && options.sdesc_path.empty()) {
+                    options.sdesc_path =
+                        SimulationChip::get_soc_descriptor_path_from_simulator_path(options.simulator_directory);
+                }
+                // Quasar does not expose ARC or Ethernet firmware yet, so there is no device topology to query.
+                // Fall through to the existing mock descriptor construction below.
+                const bool discover_ttsim_topology = is_ttsim_build && SocDescriptor::get_arch_from_soc_descriptor_path(
+                                                                           options.sdesc_path) != tt::ARCH::QUASAR;
+
+                if (discover_ttsim_topology) {
                     const int bootstrap_host_mem_channels =
                         static_cast<int>(options.num_host_mem_ch_per_mmio_device.value_or(MAX_HOST_MEM_CHANNELS));
                     auto local_device =

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -206,7 +206,7 @@ void Cluster::construct_cluster(const uint32_t& num_host_mem_ch_per_mmio_device,
 
 #ifdef TT_UMD_BUILD_SIMULATION
 std::unique_ptr<RemoteChip> Cluster::create_simulation_remote_chip(
-    ChipId chip_id, ClusterDescriptor* cluster_desc, const SocDescriptor& soc_desc) {
+    ChipId chip_id, ClusterDescriptor* cluster_desc, const SocDescriptor& soc_desc, bool initialize_from_firmware) {
     ChipId gateway_id = cluster_desc->get_closest_mmio_capable_chip(chip_id);
     Chip* gateway_chip = get_chip(gateway_id);
     SysmemManager* sysmem_manager = gateway_chip->get_sysmem_manager();
@@ -220,7 +220,9 @@ std::unique_ptr<RemoteChip> Cluster::create_simulation_remote_chip(
             cluster_desc->get_active_eth_channels(gateway_id), CoordSystem::TRANSLATED));
 
     auto remote_tt_device = TTDevice::create_simulation_remote(std::move(remote_communication), soc_desc);
-    remote_tt_device->init_tt_device_for_simulation(/*preserve_soc_descriptor=*/true);
+    if (initialize_from_firmware) {
+        remote_tt_device->init_tt_device_for_simulation(/*preserve_soc_descriptor=*/true);
+    }
     ChipInfo chip_info;
     chip_info.noc_translation_enabled = soc_desc.noc_translation_enabled;
     chip_info.harvesting_masks = soc_desc.harvesting_masks;
@@ -238,6 +240,7 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     SocDescriptor& soc_desc,
     int num_host_mem_channels,
     const std::filesystem::path& simulator_directory,
+    bool initialize_simulation_from_firmware,
     std::unique_ptr<TTDevice> tt_device) {
     if (chip_type == ChipType::MOCK) {
         return std::make_unique<MockChip>(soc_desc);
@@ -277,7 +280,7 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
             return std::make_unique<SimulationChip>(simulator_directory, device_soc, chip_id, std::move(tt_device));
         }
         if (simulator_directory.extension() == ".so" && cluster_desc->is_chip_remote(chip_id)) {
-            return create_simulation_remote_chip(chip_id, cluster_desc, soc_desc);
+            return create_simulation_remote_chip(chip_id, cluster_desc, soc_desc, initialize_simulation_from_firmware);
         }
         log_info(LogUMD, "Creating Simulation device");
         return SimulationChip::create(
@@ -407,6 +410,9 @@ Cluster::Cluster(ClusterOptions options) {
     // A second assignment at the end captures any mutations made during construction
     // (sdesc_path resolution, num_host_mem_ch_per_mmio_device auto-detect).
     options_ = options;
+    // An explicitly supplied descriptor is authoritative and preserves the legacy mock-descriptor behavior:
+    // do not probe ARC or discover Ethernet state from simulated firmware.
+    const bool initialize_simulation_from_firmware = options.cluster_descriptor == nullptr;
     std::map<ChipId, std::unique_ptr<TTDevice>> tt_devices;
     switch (options.chip_type) {
         case ChipType::SILICON: {
@@ -630,6 +636,7 @@ Cluster::Cluster(ClusterOptions options) {
                 soc_desc,
                 options.num_host_mem_ch_per_mmio_device.value(),
                 options.simulator_directory,
+                initialize_simulation_from_firmware,
                 std::move(tt_device)));
     }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -508,7 +508,7 @@ Cluster::Cluster(ClusterOptions options) {
                             SimulationChip::get_soc_descriptor_path_from_simulator_path(options.simulator_directory);
                     }
                     const int bootstrap_host_mem_channels =
-                        static_cast<int>(options.num_host_mem_ch_per_mmio_device.value_or(1));
+                        static_cast<int>(options.num_host_mem_ch_per_mmio_device.value_or(MAX_HOST_MEM_CHANNELS));
                     auto local_device =
                         create_simulation_tt_device(options.simulator_directory, bootstrap_host_mem_channels);
                     local_device->init_tt_device_for_simulation();

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -225,6 +225,7 @@ std::unique_ptr<RemoteChip> Cluster::create_simulation_remote_chip(
     chip_info.noc_translation_enabled = soc_desc.noc_translation_enabled;
     chip_info.harvesting_masks = soc_desc.harvesting_masks;
     chip_info.board_type = cluster_desc->get_board_type(chip_id);
+    chip_info.board_id = cluster_desc->get_board_id_for_chip(chip_id);
     chip_info.asic_location = cluster_desc->get_asic_location(chip_id);
     return RemoteChip::create_for_simulation(std::move(remote_tt_device), gateway_chip, chip_info);
 }
@@ -265,6 +266,7 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
                 ChipInfo chip_info;
                 chip_info.noc_translation_enabled = soc_desc.noc_translation_enabled;
                 chip_info.harvesting_masks = soc_desc.harvesting_masks;
+                chip_info.board_id = cluster_desc->get_board_id_for_chip(chip_id);
                 chip_info.board_type = cluster_desc->get_board_type(chip_id);
                 chip_info.asic_location = cluster_desc->get_asic_location(chip_id);
                 return RemoteChip::create_for_simulation(std::move(tt_device), gateway_chip, chip_info);

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -37,6 +37,7 @@
 // The code that uses these types is guarded by #ifdef TT_UMD_BUILD_SIMULATION below.
 #ifdef TT_UMD_BUILD_SIMULATION
 #include "umd/device/simulation/tt_sim_communicator.hpp"
+#include "umd/device/tt_device/simulation_device_factory.hpp"
 #include "umd/device/tt_device/tt_sim_tt_device.hpp"
 #endif  // TT_UMD_BUILD_SIMULATION
 // SWEmuleChip is only referenced inside `#ifdef TT_UMD_BUILD_EMULE`. IWYU
@@ -219,7 +220,7 @@ std::unique_ptr<RemoteChip> Cluster::create_simulation_remote_chip(
             cluster_desc->get_active_eth_channels(gateway_id), CoordSystem::TRANSLATED));
 
     auto remote_tt_device = TTDevice::create_simulation_remote(std::move(remote_communication), soc_desc);
-    remote_tt_device->init_tt_device_for_simulation_remote();
+    remote_tt_device->init_tt_device_for_simulation(/*preserve_soc_descriptor=*/true);
     ChipInfo chip_info;
     chip_info.noc_translation_enabled = soc_desc.noc_translation_enabled;
     chip_info.harvesting_masks = soc_desc.harvesting_masks;
@@ -252,6 +253,22 @@ std::unique_ptr<Chip> Cluster::construct_chip_from_cluster(
     if (chip_type == ChipType::SIMULATION) {
 #ifdef TT_UMD_BUILD_SIMULATION
         if (tt_device != nullptr) {
+            if (cluster_desc->is_chip_remote(chip_id)) {
+                ChipId gateway_id = cluster_desc->get_closest_mmio_capable_chip(chip_id);
+                Chip* gateway_chip = get_chip(gateway_id);
+                SysmemManager* sysmem_manager = gateway_chip->get_sysmem_manager();
+                if (sysmem_manager != nullptr && sysmem_manager->get_num_host_mem_channels() == 0) {
+                    sysmem_manager = nullptr;
+                }
+                tt_device->get_remote_communication()->set_sysmem_manager(sysmem_manager);
+
+                ChipInfo chip_info;
+                chip_info.noc_translation_enabled = soc_desc.noc_translation_enabled;
+                chip_info.harvesting_masks = soc_desc.harvesting_masks;
+                chip_info.board_type = cluster_desc->get_board_type(chip_id);
+                chip_info.asic_location = cluster_desc->get_asic_location(chip_id);
+                return RemoteChip::create_for_simulation(std::move(tt_device), gateway_chip, chip_info);
+            }
             // A device the connector already created (client mode): wrap it rather than building a
             // new backend. Its SoC descriptor was sourced over the socket, so read it back.
             SocDescriptor device_soc = tt_device->get_soc_descriptor();
@@ -482,6 +499,24 @@ Cluster::Cluster(ClusterOptions options) {
                     }
                     cluster_desc = ClusterDescriptor::create_constrained_cluster_descriptor(
                         ClusterDescriptor::create_from_yaml(cluster_desc_path).get(), options.target_devices);
+                    break;
+                }
+
+                if (is_ttsim_build) {
+                    if (options.sdesc_path.empty()) {
+                        options.sdesc_path =
+                            SimulationChip::get_soc_descriptor_path_from_simulator_path(options.simulator_directory);
+                    }
+                    const int bootstrap_host_mem_channels =
+                        static_cast<int>(options.num_host_mem_ch_per_mmio_device.value_or(1));
+                    auto local_device =
+                        create_simulation_tt_device(options.simulator_directory, bootstrap_host_mem_channels);
+                    local_device->init_tt_device_for_simulation();
+                    std::tie(cluster_desc, tt_devices) = TopologyDiscovery::discover_from_local_device(
+                        std::move(local_device),
+                        options.topology_discovery_options,
+                        options.io_device_type,
+                        options.sdesc_path);
                     break;
                 }
 #endif

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -514,11 +514,45 @@ Cluster::Cluster(ClusterOptions options) {
                     auto local_device =
                         create_simulation_tt_device(options.simulator_directory, bootstrap_host_mem_channels);
                     local_device->init_tt_device_for_simulation();
-                    std::tie(cluster_desc, tt_devices) = TopologyDiscovery::discover_from_local_device(
-                        std::move(local_device),
-                        options.topology_discovery_options,
-                        options.io_device_type,
-                        options.sdesc_path);
+                    auto* ttsim_device = dynamic_cast<TTSimTTDevice*>(local_device.get());
+                    UMD_ASSERT(
+                        ttsim_device != nullptr,
+                        error::RuntimeError,
+                        "A .so simulator path did not create a TTSimTTDevice.");
+                    const uint32_t num_mmio_devices = ttsim_device->get_num_mmio_devices();
+                    UMD_ASSERT(
+                        num_mmio_devices > 0,
+                        error::RuntimeError,
+                        "TTSim did not expose any host-visible PCI devices.");
+
+                    if (num_mmio_devices == 1) {
+                        std::tie(cluster_desc, tt_devices) = TopologyDiscovery::discover_from_local_device(
+                            std::move(local_device),
+                            options.topology_discovery_options,
+                            options.io_device_type,
+                            options.sdesc_path);
+                    } else {
+                        const SocDescriptor bootstrap_soc_descriptor = local_device->get_soc_descriptor();
+                        local_device.reset();
+
+                        std::map<ChipId, std::unique_ptr<TTDevice>> local_devices;
+                        for (ChipId chip_id = 0; chip_id < static_cast<ChipId>(num_mmio_devices); ++chip_id) {
+                            auto device = create_simulation_tt_device(
+                                options.simulator_directory,
+                                bootstrap_soc_descriptor,
+                                chip_id,
+                                num_mmio_devices,
+                                bootstrap_host_mem_channels,
+                                /*force_shared_bdf_mode=*/true);
+                            device->init_tt_device_for_simulation();
+                            local_devices.emplace(chip_id, std::move(device));
+                        }
+                        std::tie(cluster_desc, tt_devices) = TopologyDiscovery::discover_from_local_devices(
+                            std::move(local_devices),
+                            options.topology_discovery_options,
+                            options.io_device_type,
+                            options.sdesc_path);
+                    }
                     break;
                 }
 #endif

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -218,16 +218,13 @@ std::unique_ptr<RemoteChip> Cluster::create_simulation_remote_chip(
         gateway_chip->get_soc_descriptor().get_eth_xy_pairs_for_channels(
             cluster_desc->get_active_eth_channels(gateway_id), CoordSystem::TRANSLATED));
 
+    auto remote_tt_device = TTDevice::create_simulation_remote(std::move(remote_communication), soc_desc);
+    remote_tt_device->init_tt_device_for_simulation_remote();
     ChipInfo chip_info;
     chip_info.noc_translation_enabled = soc_desc.noc_translation_enabled;
     chip_info.harvesting_masks = soc_desc.harvesting_masks;
     chip_info.board_type = cluster_desc->get_board_type(chip_id);
-    chip_info.board_id = cluster_desc->get_board_id_for_chip(chip_id);
     chip_info.asic_location = cluster_desc->get_asic_location(chip_id);
-
-    // The simulated remote chip has no ARC, so hand its SocDescriptor to the remote TTDevice directly
-    // instead of letting init_tt_device construct one.
-    auto remote_tt_device = TTDevice::create_simulation_remote(std::move(remote_communication), soc_desc);
     return RemoteChip::create_for_simulation(std::move(remote_tt_device), gateway_chip, chip_info);
 }
 #endif  // TT_UMD_BUILD_SIMULATION

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -212,9 +212,9 @@ void TTSimCommunicator::initialize() {
     // (e.g. galaxy wormhole, driven by an external mock cluster desc) has no such file -- it must keep
     // the per-chip isolated dlopen (legacy memfd path below) so each chip is its own simulator process.
     const bool self_describing_multi_mmio =
-        num_chips_ > 1 &&
-        (force_shared_bdf_mode_ ||
-         std::filesystem::exists(SimulationChip::get_cluster_descriptor_path_from_simulator_path(simulator_directory_)));
+        num_chips_ > 1 && (force_shared_bdf_mode_ ||
+                           std::filesystem::exists(
+                               SimulationChip::get_cluster_descriptor_path_from_simulator_path(simulator_directory_)));
     if (self_describing_multi_mmio) {
         std::lock_guard<std::mutex> init_lock(s_shared_init_mutex_);
         if (!s_shared_handle_) {

--- a/device/simulation/tt_sim_communicator.cpp
+++ b/device/simulation/tt_sim_communicator.cpp
@@ -44,11 +44,16 @@ std::mutex TTSimCommunicator::s_shared_init_mutex_;
 std::mutex TTSimCommunicator::device_lock_;
 
 TTSimCommunicator::TTSimCommunicator(
-    const std::filesystem::path &simulator_directory, bool copy_sim_binary, uint32_t chip_id, uint32_t num_chips) :
+    const std::filesystem::path &simulator_directory,
+    bool copy_sim_binary,
+    uint32_t chip_id,
+    uint32_t num_chips,
+    bool force_shared_bdf_mode) :
     simulator_directory_(simulator_directory),
     copy_sim_binary_(copy_sim_binary),
     chip_id_(chip_id),
-    num_chips_(num_chips) {}
+    num_chips_(num_chips),
+    force_shared_bdf_mode_(force_shared_bdf_mode) {}
 
 TTSimCommunicator::~TTSimCommunicator() {
     // Unregister from the process-global DMA routing tables first. The shared simulator may still be
@@ -208,7 +213,8 @@ void TTSimCommunicator::initialize() {
     // the per-chip isolated dlopen (legacy memfd path below) so each chip is its own simulator process.
     const bool self_describing_multi_mmio =
         num_chips_ > 1 &&
-        std::filesystem::exists(SimulationChip::get_cluster_descriptor_path_from_simulator_path(simulator_directory_));
+        (force_shared_bdf_mode_ ||
+         std::filesystem::exists(SimulationChip::get_cluster_descriptor_path_from_simulator_path(simulator_directory_)));
     if (self_describing_multi_mmio) {
         std::lock_guard<std::mutex> init_lock(s_shared_init_mutex_);
         if (!s_shared_handle_) {
@@ -362,6 +368,19 @@ uint32_t TTSimCommunicator::pci_config_read32(uint32_t bus_device_function, uint
     }
     select_chip_if_needed();  // no-op outside the multichip-ABI mode
     return pfn_libttsim_pci_config_rd32_(bdf, offset);
+}
+
+uint32_t TTSimCommunicator::get_num_mmio_devices() {
+    std::lock_guard<std::mutex> lock(device_lock_);
+    uint32_t count = 0;
+    for (uint32_t device = 0; device < 32; ++device) {
+        const uint32_t bdf = device << 3;
+        if (pfn_libttsim_pci_config_rd32_(bdf, 0) == 0xFFFFFFFFu) {
+            break;
+        }
+        ++count;
+    }
+    return count;
 }
 
 void TTSimCommunicator::advance_clock(uint32_t n_clocks) {

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -493,7 +493,8 @@ std::unique_ptr<ClusterDescriptor> TopologyDiscovery::fill_cluster_descriptor_in
 
         cluster_desc->chip_unique_ids.emplace(chip_id, current_device_asic_id);
 
-        if (io_device_type == IODeviceType::PCIe && !tt_device->is_remote()) {
+        if (io_device_type == IODeviceType::PCIe && !tt_device->is_remote() &&
+            tt_device->get_pci_device() != nullptr) {
             cluster_desc->chip_pci_bdfs.emplace(chip_id, tt_device->get_pci_device()->get_device_info().pci_bdf);
         }
 

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -508,8 +508,7 @@ std::unique_ptr<ClusterDescriptor> TopologyDiscovery::fill_cluster_descriptor_in
 
         cluster_desc->chip_unique_ids.emplace(chip_id, current_device_asic_id);
 
-        if (io_device_type == IODeviceType::PCIe && !tt_device->is_remote() &&
-            tt_device->get_pci_device() != nullptr) {
+        if (io_device_type == IODeviceType::PCIe && !tt_device->is_remote() && tt_device->get_pci_device() != nullptr) {
             cluster_desc->chip_pci_bdfs.emplace(chip_id, tt_device->get_pci_device()->get_device_info().pci_bdf);
         }
 

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -77,6 +77,14 @@ std::unique_ptr<TopologyDiscovery> TopologyDiscovery::create_topology_discovery(
             UMD_THROW(error::RuntimeError, "Unsupported device type for topology discovery.");
     }
 
+    return create_topology_discovery(current_arch, options, io_device_type, soc_descriptor_path);
+}
+
+std::unique_ptr<TopologyDiscovery> TopologyDiscovery::create_topology_discovery(
+    tt::ARCH current_arch,
+    const TopologyDiscoveryOptions& options,
+    IODeviceType io_device_type,
+    const std::string& soc_descriptor_path) {
     std::shared_ptr<SocArchDescriptor> soc_arch_descriptor = nullptr;
     if (soc_descriptor_path.empty()) {
         soc_arch_descriptor = std::make_shared<SocArchDescriptor>(current_arch);
@@ -86,7 +94,7 @@ std::unique_ptr<TopologyDiscovery> TopologyDiscovery::create_topology_discovery(
             UMD_THROW(
                 error::RuntimeError,
                 fmt::format(
-                    "Architecture {} in SocArchDescriptor file on path {} does not match architecture {} on silicon.",
+                    "Architecture {} in SocArchDescriptor file on path {} does not match device architecture {}.",
                     arch_to_str(soc_arch_descriptor->get_arch()),
                     soc_descriptor_path,
                     arch_to_str(current_arch)));
@@ -138,6 +146,30 @@ std::pair<std::unique_ptr<ClusterDescriptor>, std::map<ChipId, std::unique_ptr<T
     return std::make_pair(std::move(cluster_desc), std::move(devices));
 }
 
+std::pair<std::unique_ptr<ClusterDescriptor>, std::map<ChipId, std::unique_ptr<TTDevice>>>
+TopologyDiscovery::discover_from_local_device(
+    std::unique_ptr<TTDevice> local_device,
+    const TopologyDiscoveryOptions& options,
+    IODeviceType io_device_type,
+    const std::string& soc_descriptor_path) {
+    ZoneScopedC(tracy::Color::DarkGreen);
+    UMD_ASSERT(local_device != nullptr, error::RuntimeError, "Topology discovery requires a local device.");
+
+    std::map<ChipId, std::unique_ptr<TTDevice>> devices;
+    std::unique_ptr<TopologyDiscovery> td = TopologyDiscovery::create_topology_discovery(
+        local_device->get_arch(), options, io_device_type, soc_descriptor_path);
+    td->add_initialized_local_device(std::move(local_device));
+    td->retrain_eth_cores();
+    td->discover_remote_devices();
+    std::unique_ptr<ClusterDescriptor> cluster_desc = td->fill_cluster_descriptor_info();
+
+    for (auto& [unique_id, device] : td->devices) {
+        ChipId chip_id = td->asic_id_to_chip_id[unique_id];
+        devices[chip_id] = std::move(device);
+    }
+    return std::make_pair(std::move(cluster_desc), std::move(devices));
+}
+
 bool TopologyDiscovery::init_device(TTDevice* tt_device, ChipId chip_id, const std::chrono::milliseconds timeout) {
     try {
         tt_device->init_tt_device(timeout);
@@ -152,6 +184,37 @@ bool TopologyDiscovery::init_device(TTDevice* tt_device, ChipId chip_id, const s
         return false;
     }
     return true;
+}
+
+void TopologyDiscovery::add_initialized_local_device(std::unique_ptr<TTDevice> tt_device) {
+    UMD_ASSERT(tt_device != nullptr, error::RuntimeError, "Cannot add a null device to topology discovery.");
+    UMD_ASSERT(
+        tt_device->get_arch() == get_topology_arch(),
+        error::RuntimeError,
+        fmt::format(
+            "Local device architecture {} does not match topology architecture {}.",
+            arch_to_str(tt_device->get_arch()),
+            arch_to_str(get_topology_arch())));
+
+    const ChipId chip_id = get_next_chip_id();
+    init_first_device(tt_device.get());
+    if (options.wait_on_ethernet_link_training) {
+        wait_eth_cores_training(tt_device.get());
+    }
+
+    const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
+    for (const CoreCoord& eth_core : soc_desc.get_cores(CoreType::ETH)) {
+        const uint64_t board_id = get_local_board_id(tt_device.get(), eth_core);
+        if (board_id != 0) {
+            board_ids.insert(board_id);
+            break;
+        }
+    }
+
+    const uint64_t asic_id = get_asic_id(tt_device.get());
+    devices_to_discover.emplace(asic_id, std::move(tt_device));
+    asic_id_to_chip_id.emplace(asic_id, chip_id);
+    log_debug(LogUMD, "Added initialized local device with ASIC ID: {}", asic_id);
 }
 
 void TopologyDiscovery::get_connected_devices() {

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -152,13 +152,28 @@ TopologyDiscovery::discover_from_local_device(
     const TopologyDiscoveryOptions& options,
     IODeviceType io_device_type,
     const std::string& soc_descriptor_path) {
+    std::map<ChipId, std::unique_ptr<TTDevice>> local_devices;
+    local_devices.emplace(0, std::move(local_device));
+    return discover_from_local_devices(std::move(local_devices), options, io_device_type, soc_descriptor_path);
+}
+
+std::pair<std::unique_ptr<ClusterDescriptor>, std::map<ChipId, std::unique_ptr<TTDevice>>>
+TopologyDiscovery::discover_from_local_devices(
+    std::map<ChipId, std::unique_ptr<TTDevice>> local_devices,
+    const TopologyDiscoveryOptions& options,
+    IODeviceType io_device_type,
+    const std::string& soc_descriptor_path) {
     ZoneScopedC(tracy::Color::DarkGreen);
-    UMD_ASSERT(local_device != nullptr, error::RuntimeError, "Topology discovery requires a local device.");
+    UMD_ASSERT(!local_devices.empty(), error::RuntimeError, "Topology discovery requires at least one local device.");
+    UMD_ASSERT(
+        local_devices.begin()->second != nullptr, error::RuntimeError, "Topology discovery received a null device.");
 
     std::map<ChipId, std::unique_ptr<TTDevice>> devices;
     std::unique_ptr<TopologyDiscovery> td = TopologyDiscovery::create_topology_discovery(
-        local_device->get_arch(), options, io_device_type, soc_descriptor_path);
-    td->add_initialized_local_device(std::move(local_device));
+        local_devices.begin()->second->get_arch(), options, io_device_type, soc_descriptor_path);
+    for (auto& [chip_id, local_device] : local_devices) {
+        td->add_initialized_local_device(std::move(local_device));
+    }
     td->retrain_eth_cores();
     td->discover_remote_devices();
     std::unique_ptr<ClusterDescriptor> cluster_desc = td->fill_cluster_descriptor_info();

--- a/device/tt_device/hang_detection/hang_detector_implementation.cpp
+++ b/device/tt_device/hang_detection/hang_detector_implementation.cpp
@@ -16,7 +16,7 @@ HangDetectorImplementation::HangDetectorImplementation(
     DeviceProtocol* protocol, architecture_implementation* arch_impl) :
     protocol_(protocol),
     pcie_interface_(dynamic_cast<PcieInterface*>(protocol)),
-    is_mmio_protocol_(!dynamic_cast<RemoteInterface*>(protocol)),
+    is_mmio_protocol_(protocol != nullptr && !dynamic_cast<RemoteInterface*>(protocol)),
     arch_impl_(arch_impl),
     // Default reader: plain protocol register read. A higher layer may override it via set_noc_reg_reader().
     noc_reg_reader_([this](tt_xy_pair core, uint64_t addr, NocId noc) -> uint32_t {

--- a/device/tt_device/simulation_device_factory.cpp
+++ b/device/tt_device/simulation_device_factory.cpp
@@ -25,10 +25,17 @@ std::unique_ptr<TTDevice> create_simulation_tt_device(
     const SocDescriptor &soc_descriptor,
     ChipId chip_id,
     size_t num_chips,
-    int num_host_mem_channels) {
+    int num_host_mem_channels,
+    bool force_shared_bdf_mode) {
     if (simulator_directory.extension() == ".so") {
         return std::make_unique<TTSimTTDevice>(
-            simulator_directory, soc_descriptor, chip_id, num_chips > 1, num_host_mem_channels, num_chips);
+            simulator_directory,
+            soc_descriptor,
+            chip_id,
+            num_chips > 1,
+            num_host_mem_channels,
+            num_chips,
+            force_shared_bdf_mode);
     }
     log_info(tt::LogEmulationDriver, "Instantiating RTL simulation device");
     return std::make_unique<RtlSimulationTTDevice>(simulator_directory, soc_descriptor, chip_id, num_host_mem_channels);

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -36,8 +36,11 @@ namespace {
 class SimulationHangDetector final : public HangDetector {
 protected:
     uint32_t read_hang_check_reg_via_bar() override { return 0; }
+
     uint32_t read_hang_check_reg_via_noc(NocId /*noc*/) override { return 0; }
+
     bool is_bus_available() override { return true; }
+
     bool is_noc_available() override { return true; }
 };
 
@@ -176,8 +179,7 @@ void SimulationTTDevice::read_from_device(void* mem_ptr, CoreCoord core, uint64_
     }
 }
 
-void SimulationTTDevice::read_from_device_reg(
-    void* mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id) {
+void SimulationTTDevice::read_from_device_reg(void* mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id) {
     read_from_device(mem_ptr, core, addr, size, noc_id);
 }
 

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -23,6 +23,7 @@
 #include "umd/device/simulation/simulation_device_identity.hpp"
 #include "umd/device/simulation/simulation_server_protocol.hpp"
 #include "umd/device/soc_descriptor.hpp"
+#include "umd/device/tt_device/hang_detection/hang_detector.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/tlb.hpp"
@@ -30,14 +31,30 @@
 
 namespace tt::umd {
 
+namespace {
+
+class SimulationHangDetector final : public HangDetector {
+protected:
+    uint32_t read_hang_check_reg_via_bar() override { return 0; }
+    uint32_t read_hang_check_reg_via_noc(NocId /*noc*/) override { return 0; }
+    bool is_bus_available() override { return true; }
+    bool is_noc_available() override { return true; }
+};
+
+}  // namespace
+
 // The constructor and destructor are defined out-of-line so that socket_
 // (unique_ptr<SimulationServerSocket>) is constructed/destroyed where the type is complete; the
 // public header only forward-declares SimulationServerSocket.
 SimulationTTDevice::SimulationTTDevice(
     const std::filesystem::path& simulator_directory, std::unique_ptr<SimulationSysmemManager> sysmem_manager) :
-    simulator_directory_(simulator_directory), sysmem_manager_(std::move(sysmem_manager)) {}
+    simulator_directory_(simulator_directory), sysmem_manager_(std::move(sysmem_manager)) {
+    set_hang_detector(std::make_unique<SimulationHangDetector>());
+}
 
-SimulationTTDevice::SimulationTTDevice(std::unique_ptr<SimulationClient> client) : client_(std::move(client)) {}
+SimulationTTDevice::SimulationTTDevice(std::unique_ptr<SimulationClient> client) : client_(std::move(client)) {
+    set_hang_detector(std::make_unique<SimulationHangDetector>());
+}
 
 SimulationTTDevice::~SimulationTTDevice() = default;
 
@@ -157,6 +174,16 @@ void SimulationTTDevice::read_from_device(void* mem_ptr, CoreCoord core, uint64_
     } else {
         host_read(core, addr, mem_ptr, size);
     }
+}
+
+void SimulationTTDevice::read_from_device_reg(
+    void* mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id) {
+    read_from_device(mem_ptr, core, addr, size, noc_id);
+}
+
+void SimulationTTDevice::write_to_device_reg(
+    const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id) {
+    write_to_device(mem_ptr, core, addr, size, noc_id);
 }
 
 void SimulationTTDevice::host_write(CoreCoord core, uint64_t addr, const void* mem_ptr, size_t size) {
@@ -337,20 +364,32 @@ void SimulationTTDevice::dma_multicast_write(
     UMD_THROW(error::RuntimeError, "DMA multicast write is not supported for simulation devices.");
 }
 
-void SimulationTTDevice::read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) {
-    UMD_THROW(error::RuntimeError, "ARC APB access is not supported for simulation devices.");
+void SimulationTTDevice::read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, size_t size) {
+    const std::vector<CoreCoord> arc_cores = get_soc_descriptor().get_cores(CoreType::ARC);
+    UMD_ASSERT(!arc_cores.empty(), error::RuntimeError, "Simulation SoC descriptor has no ARC core.");
+    read_from_device(
+        mem_ptr, arc_cores.front(), architecture_impl_->get_arc_apb_noc_base_address() + arc_addr_offset, size);
 }
 
-void SimulationTTDevice::write_to_arc_apb(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) {
-    UMD_THROW(error::RuntimeError, "ARC APB access is not supported for simulation devices.");
+void SimulationTTDevice::write_to_arc_apb(const void* mem_ptr, uint64_t arc_addr_offset, size_t size) {
+    const std::vector<CoreCoord> arc_cores = get_soc_descriptor().get_cores(CoreType::ARC);
+    UMD_ASSERT(!arc_cores.empty(), error::RuntimeError, "Simulation SoC descriptor has no ARC core.");
+    write_to_device(
+        mem_ptr, arc_cores.front(), architecture_impl_->get_arc_apb_noc_base_address() + arc_addr_offset, size);
 }
 
-void SimulationTTDevice::read_from_arc_csm(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) {
-    UMD_THROW(error::RuntimeError, "ARC CSM access is not supported for simulation devices.");
+void SimulationTTDevice::read_from_arc_csm(void* mem_ptr, uint64_t arc_addr_offset, size_t size) {
+    const std::vector<CoreCoord> arc_cores = get_soc_descriptor().get_cores(CoreType::ARC);
+    UMD_ASSERT(!arc_cores.empty(), error::RuntimeError, "Simulation SoC descriptor has no ARC core.");
+    read_from_device(
+        mem_ptr, arc_cores.front(), architecture_impl_->get_arc_csm_noc_base_address() + arc_addr_offset, size);
 }
 
-void SimulationTTDevice::write_to_arc_csm(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) {
-    UMD_THROW(error::RuntimeError, "ARC CSM access is not supported for simulation devices.");
+void SimulationTTDevice::write_to_arc_csm(const void* mem_ptr, uint64_t arc_addr_offset, size_t size) {
+    const std::vector<CoreCoord> arc_cores = get_soc_descriptor().get_cores(CoreType::ARC);
+    UMD_ASSERT(!arc_cores.empty(), error::RuntimeError, "Simulation SoC descriptor has no ARC core.");
+    write_to_device(
+        mem_ptr, arc_cores.front(), architecture_impl_->get_arc_csm_noc_base_address() + arc_addr_offset, size);
 }
 
 uint32_t SimulationTTDevice::get_clock() {

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -14,6 +14,9 @@
 #include "noc_access.hpp"
 #include "simulation/simulation_server_socket.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/blackhole_implementation.hpp"
+#include "umd/device/arch/grendel_implementation.hpp"
+#include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/simulation/simulation_client.hpp"
@@ -355,7 +358,19 @@ uint32_t SimulationTTDevice::get_clock() {
 }
 
 uint32_t SimulationTTDevice::get_min_clock_freq() {
-    UMD_THROW(error::RuntimeError, "Getting minimum clock frequency is not supported for simulation devices.");
+    switch (arch) {
+        case tt::ARCH::WORMHOLE_B0:
+            return wormhole::AICLK_IDLE_VAL;
+        case tt::ARCH::BLACKHOLE:
+            return blackhole::AICLK_IDLE_VAL;
+        case tt::ARCH::QUASAR:
+            return grendel::AICLK_IDLE_VAL;
+        default:
+            UMD_THROW(
+                error::RuntimeError,
+                fmt::format(
+                    "Getting minimum clock frequency is not supported for simulation arch {}.", arch_to_str(arch)));
+    }
 }
 
 void SimulationTTDevice::retrain_dram_core(const uint32_t dram_channel) {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -421,7 +421,9 @@ bool TTDevice::is_pcie_hung(std::uint32_t data_read, TTDevice::HangAction action
     }
     auto result = hang_detector_->is_bus_hung(data_read);
     if (!result.has_value()) {
-        log_warning(LogUMD, "Bus hang detection is not supported for this device.");
+        if (!is_remote_tt_device) {
+            log_warning(LogUMD, "Bus hang detection is not supported for this device.");
+        }
         return false;
     }
     if (result.value()) {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -719,10 +719,13 @@ tt_xy_pair TTDevice::get_arc_core() const { return is_selected_noc1() ? arc_core
 
 void TTDevice::noc_multicast_write(
     const void *src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr, NocId noc_id) {
-    UMD_ASSERT(
-        get_chip_info().noc_translation_enabled,
-        error::RuntimeError,
-        "Multicast not implemented for devices without NOC translation enabled.");
+    if (!get_chip_info().noc_translation_enabled) {
+        multicast_write_via_unicast(src, size, core_start, core_end, addr, noc_id);
+        if (is_remote_tt_device) {
+            get_remote_communication()->wait_for_non_mmio_flush();
+        }
+        return;
+    }
     ZoneScopedC(tracy::Color::Orange);
     xy_pair translated_start = resolve_coordinate(core_start, noc_id);
     xy_pair translated_end = resolve_coordinate(core_end, noc_id);
@@ -753,10 +756,6 @@ void TTDevice::noc_multicast_write(
 }
 
 void TTDevice::noc_multicast_write(const void *src, size_t size, uint64_t addr, NocId noc_id) {
-    UMD_ASSERT(
-        get_chip_info().noc_translation_enabled,
-        error::RuntimeError,
-        "Multicast not implemented for devices without NOC translation enabled.");
     auto [start, end] =
         get_soc_descriptor().get_bounding_rectangle((noc_id == NocId::NOC0) ? CoordSystem::NOC0 : CoordSystem::NOC1);
     noc_multicast_write(src, size, start, end, addr, noc_id);

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -155,6 +155,11 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
 
 void TTDevice::init_tt_device_for_simulation(bool preserve_soc_descriptor, const std::chrono::milliseconds timeout_ms) {
     ZoneScopedC(tracy::Color::DarkGreen);
+    // Quasar simulation does not expose ARC or Ethernet firmware yet. Keep initialization as a no-op until those
+    // interfaces exist; its SocDescriptor is already supplied by the simulation construction path.
+    if (arch == tt::ARCH::QUASAR) {
+        return;
+    }
     probe_arc();
     wait_arc_core_start(timeout_ms);
     arc_messenger_ = ArcMessenger::create_arc_messenger(this);

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -155,8 +155,7 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     construct_soc_descriptor(soc_arch_descriptor_);
 }
 
-void TTDevice::init_tt_device_for_simulation(
-    bool preserve_soc_descriptor, const std::chrono::milliseconds timeout_ms) {
+void TTDevice::init_tt_device_for_simulation(bool preserve_soc_descriptor, const std::chrono::milliseconds timeout_ms) {
     ZoneScopedC(tracy::Color::DarkGreen);
     probe_arc();
     wait_arc_core_start(timeout_ms);

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -713,10 +713,13 @@ tt_xy_pair TTDevice::get_arc_core() const { return is_selected_noc1() ? arc_core
 
 void TTDevice::noc_multicast_write(
     const void *src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr, NocId noc_id) {
-    UMD_ASSERT(
-        get_chip_info().noc_translation_enabled,
-        error::RuntimeError,
-        "Multicast not implemented for devices without NOC translation enabled.");
+    if (!get_chip_info().noc_translation_enabled) {
+        multicast_write_via_unicast(src, size, core_start, core_end, addr, noc_id);
+        if (is_remote_tt_device) {
+            get_remote_communication()->wait_for_non_mmio_flush();
+        }
+        return;
+    }
     ZoneScopedC(tracy::Color::Orange);
     xy_pair translated_start = resolve_coordinate(core_start, noc_id);
     xy_pair translated_end = resolve_coordinate(core_end, noc_id);
@@ -747,10 +750,6 @@ void TTDevice::noc_multicast_write(
 }
 
 void TTDevice::noc_multicast_write(const void *src, size_t size, uint64_t addr, NocId noc_id) {
-    UMD_ASSERT(
-        get_chip_info().noc_translation_enabled,
-        error::RuntimeError,
-        "Multicast not implemented for devices without NOC translation enabled.");
     auto [start, end] =
         get_soc_descriptor().get_bounding_rectangle((noc_id == NocId::NOC0) ? CoordSystem::NOC0 : CoordSystem::NOC1);
     noc_multicast_write(src, size, start, end, addr, noc_id);

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -153,8 +153,7 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     construct_soc_descriptor(soc_arch_descriptor_);
 }
 
-void TTDevice::init_tt_device_for_simulation(
-    bool preserve_soc_descriptor, const std::chrono::milliseconds timeout_ms) {
+void TTDevice::init_tt_device_for_simulation(bool preserve_soc_descriptor, const std::chrono::milliseconds timeout_ms) {
     ZoneScopedC(tracy::Color::DarkGreen);
     probe_arc();
     wait_arc_core_start(timeout_ms);

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -415,7 +415,9 @@ bool TTDevice::is_pcie_hung(std::uint32_t data_read, TTDevice::HangAction action
     }
     auto result = hang_detector_->is_bus_hung(data_read);
     if (!result.has_value()) {
-        log_warning(LogUMD, "Bus hang detection is not supported for this device.");
+        if (!is_remote_tt_device) {
+            log_warning(LogUMD, "Bus hang detection is not supported for this device.");
+        }
         return false;
     }
     if (result.value()) {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -153,17 +153,24 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     construct_soc_descriptor(soc_arch_descriptor_);
 }
 
-void TTDevice::init_tt_device_for_simulation_remote(const std::chrono::milliseconds timeout_ms) {
+void TTDevice::init_tt_device_for_simulation(
+    bool preserve_soc_descriptor, const std::chrono::milliseconds timeout_ms) {
     ZoneScopedC(tracy::Color::DarkGreen);
     probe_arc();
     wait_arc_core_start(timeout_ms);
     arc_messenger_ = ArcMessenger::create_arc_messenger(this);
     telemetry = ArcTelemetryReader::create_arc_telemetry_reader(this, timeout_ms);
     firmware_info_provider = FirmwareInfoProvider::create_firmware_info_provider(this);
-    // Simulation remotes are seeded from the cluster descriptor before init. Keep that descriptor
-    // authoritative for harvesting/topology, while still bringing up ARC/FW services.
-    if (!soc_descriptor_.has_value()) {
-        construct_soc_descriptor(soc_arch_descriptor_);
+    // Descriptor-backed simulation remotes are seeded before init and may need to preserve that
+    // topology metadata. A bootstrap device without a cluster descriptor instead reconstructs its
+    // SocDescriptor from firmware, matching silicon initialization.
+    if (!preserve_soc_descriptor || !soc_descriptor_.has_value()) {
+        std::shared_ptr<SocArchDescriptor> descriptor = soc_arch_descriptor_;
+        if (descriptor == nullptr && soc_descriptor_.has_value() &&
+            !soc_descriptor_->device_descriptor_file_path.empty()) {
+            descriptor = std::make_shared<SocArchDescriptor>(soc_descriptor_->device_descriptor_file_path);
+        }
+        construct_soc_descriptor(descriptor);
     }
 }
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -157,6 +157,11 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
 
 void TTDevice::init_tt_device_for_simulation(bool preserve_soc_descriptor, const std::chrono::milliseconds timeout_ms) {
     ZoneScopedC(tracy::Color::DarkGreen);
+    // Quasar simulation does not expose ARC or Ethernet firmware yet. Keep initialization as a no-op until those
+    // interfaces exist; its SocDescriptor is already supplied by the simulation construction path.
+    if (arch == tt::ARCH::QUASAR) {
+        return;
+    }
     probe_arc();
     wait_arc_core_start(timeout_ms);
     arc_messenger_ = ArcMessenger::create_arc_messenger(this);

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -155,6 +155,20 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     construct_soc_descriptor(soc_arch_descriptor_);
 }
 
+void TTDevice::init_tt_device_for_simulation_remote(const std::chrono::milliseconds timeout_ms) {
+    ZoneScopedC(tracy::Color::DarkGreen);
+    probe_arc();
+    wait_arc_core_start(timeout_ms);
+    arc_messenger_ = ArcMessenger::create_arc_messenger(this);
+    telemetry = ArcTelemetryReader::create_arc_telemetry_reader(this, timeout_ms);
+    firmware_info_provider = FirmwareInfoProvider::create_firmware_info_provider(this);
+    // Simulation remotes are seeded from the cluster descriptor before init. Keep that descriptor
+    // authoritative for harvesting/topology, while still bringing up ARC/FW services.
+    if (!soc_descriptor_.has_value()) {
+        construct_soc_descriptor(soc_arch_descriptor_);
+    }
+}
+
 /* static */ std::unique_ptr<TTDevice> TTDevice::create(
     int device_number,
     IODeviceType device_type,
@@ -230,12 +244,16 @@ std::unique_ptr<TTDevice> TTDevice::create_simulation_remote(
             "Supplied SocDescriptor arch ({}) does not match the remote device arch ({}).",
             arch_to_str(soc_descriptor.arch),
             arch_to_str(arch)));
+    std::shared_ptr<SocArchDescriptor> soc_arch_descriptor =
+        soc_descriptor.device_descriptor_file_path.empty()
+            ? std::make_shared<SocArchDescriptor>(soc_descriptor.arch)
+            : std::make_shared<SocArchDescriptor>(soc_descriptor.device_descriptor_file_path);
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: {
             auto device = std::unique_ptr<WormholeTTDevice>(
-                new WormholeTTDevice(std::move(remote_communication), /*soc_arch_descriptor=*/nullptr));
-            // This device is never run through init_tt_device() (no ARC to probe), so construct_soc_descriptor()
-            // never overwrites the descriptor set here; set_soc_descriptor keeps the assign-exactly-once invariant.
+                new WormholeTTDevice(std::move(remote_communication), soc_arch_descriptor));
+            // Seed the simulation-backed descriptor before ARC/FW init; the later reconstruction reuses the same
+            // YAML-backed SocArchDescriptor so downstream metadata loaders keep a valid device descriptor path.
             device->set_soc_descriptor(soc_descriptor);
             return device;
         }
@@ -634,6 +652,12 @@ uint8_t TTDevice::get_asic_location() { return get_firmware_info_provider()->get
 
 ChipInfo TTDevice::get_chip_info() {
     if (firmware_info_provider == nullptr) {
+        if (soc_descriptor_.has_value()) {
+            ChipInfo chip_info;
+            chip_info.noc_translation_enabled = soc_descriptor_->noc_translation_enabled;
+            chip_info.harvesting_masks = soc_descriptor_->harvesting_masks;
+            return chip_info;
+        }
         UMD_THROW(error::UninitializedDeviceError, *this);
     }
     ChipInfo chip_info;

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -153,6 +153,20 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     construct_soc_descriptor(soc_arch_descriptor_);
 }
 
+void TTDevice::init_tt_device_for_simulation_remote(const std::chrono::milliseconds timeout_ms) {
+    ZoneScopedC(tracy::Color::DarkGreen);
+    probe_arc();
+    wait_arc_core_start(timeout_ms);
+    arc_messenger_ = ArcMessenger::create_arc_messenger(this);
+    telemetry = ArcTelemetryReader::create_arc_telemetry_reader(this, timeout_ms);
+    firmware_info_provider = FirmwareInfoProvider::create_firmware_info_provider(this);
+    // Simulation remotes are seeded from the cluster descriptor before init. Keep that descriptor
+    // authoritative for harvesting/topology, while still bringing up ARC/FW services.
+    if (!soc_descriptor_.has_value()) {
+        construct_soc_descriptor(soc_arch_descriptor_);
+    }
+}
+
 /* static */ std::unique_ptr<TTDevice> TTDevice::create(
     int device_number,
     IODeviceType device_type,
@@ -228,12 +242,16 @@ std::unique_ptr<TTDevice> TTDevice::create_simulation_remote(
             "Supplied SocDescriptor arch ({}) does not match the remote device arch ({}).",
             arch_to_str(soc_descriptor.arch),
             arch_to_str(arch)));
+    std::shared_ptr<SocArchDescriptor> soc_arch_descriptor =
+        soc_descriptor.device_descriptor_file_path.empty()
+            ? std::make_shared<SocArchDescriptor>(soc_descriptor.arch)
+            : std::make_shared<SocArchDescriptor>(soc_descriptor.device_descriptor_file_path);
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: {
             auto device = std::unique_ptr<WormholeTTDevice>(
-                new WormholeTTDevice(std::move(remote_communication), /*soc_arch_descriptor=*/nullptr));
-            // This device is never run through init_tt_device() (no ARC to probe), so construct_soc_descriptor()
-            // never overwrites the descriptor set here; set_soc_descriptor keeps the assign-exactly-once invariant.
+                new WormholeTTDevice(std::move(remote_communication), soc_arch_descriptor));
+            // Seed the simulation-backed descriptor before ARC/FW init; the later reconstruction reuses the same
+            // YAML-backed SocArchDescriptor so downstream metadata loaders keep a valid device descriptor path.
             device->set_soc_descriptor(soc_descriptor);
             return device;
         }
@@ -628,6 +646,12 @@ uint8_t TTDevice::get_asic_location() { return get_firmware_info_provider()->get
 
 ChipInfo TTDevice::get_chip_info() {
     if (firmware_info_provider == nullptr) {
+        if (soc_descriptor_.has_value()) {
+            ChipInfo chip_info;
+            chip_info.noc_translation_enabled = soc_descriptor_->noc_translation_enabled;
+            chip_info.harvesting_masks = soc_descriptor_->harvesting_masks;
+            return chip_info;
+        }
         UMD_THROW(error::UninitializedDeviceError, *this);
     }
     ChipInfo chip_info;

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -155,17 +155,24 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     construct_soc_descriptor(soc_arch_descriptor_);
 }
 
-void TTDevice::init_tt_device_for_simulation_remote(const std::chrono::milliseconds timeout_ms) {
+void TTDevice::init_tt_device_for_simulation(
+    bool preserve_soc_descriptor, const std::chrono::milliseconds timeout_ms) {
     ZoneScopedC(tracy::Color::DarkGreen);
     probe_arc();
     wait_arc_core_start(timeout_ms);
     arc_messenger_ = ArcMessenger::create_arc_messenger(this);
     telemetry = ArcTelemetryReader::create_arc_telemetry_reader(this, timeout_ms);
     firmware_info_provider = FirmwareInfoProvider::create_firmware_info_provider(this);
-    // Simulation remotes are seeded from the cluster descriptor before init. Keep that descriptor
-    // authoritative for harvesting/topology, while still bringing up ARC/FW services.
-    if (!soc_descriptor_.has_value()) {
-        construct_soc_descriptor(soc_arch_descriptor_);
+    // Descriptor-backed simulation remotes are seeded before init and may need to preserve that
+    // topology metadata. A bootstrap device without a cluster descriptor instead reconstructs its
+    // SocDescriptor from firmware, matching silicon initialization.
+    if (!preserve_soc_descriptor || !soc_descriptor_.has_value()) {
+        std::shared_ptr<SocArchDescriptor> descriptor = soc_arch_descriptor_;
+        if (descriptor == nullptr && soc_descriptor_.has_value() &&
+            !soc_descriptor_->device_descriptor_file_path.empty()) {
+            descriptor = std::make_shared<SocArchDescriptor>(soc_descriptor_->device_descriptor_file_path);
+        }
+        construct_soc_descriptor(descriptor);
     }
 }
 

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -382,8 +382,7 @@ std::chrono::milliseconds TTSimTTDevice::wait_eth_core_training(
 EthTrainingStatus TTSimTTDevice::read_eth_core_training_status(CoreCoord eth_core) {
     if (arch != tt::ARCH::WORMHOLE_B0) {
         uint32_t port_status;
-        const uint32_t port_status_addr =
-            blackhole::BOOT_RESULTS_ADDR + offsetof(blackhole::eth_status_t, port_status);
+        const uint32_t port_status_addr = blackhole::BOOT_RESULTS_ADDR + offsetof(blackhole::eth_status_t, port_status);
         read_from_device(&port_status, eth_core, port_status_addr, sizeof(port_status));
         return static_cast<EthTrainingStatus>(port_status);
     }
@@ -412,8 +411,7 @@ ChipInfo TTSimTTDevice::get_chip_info() {
     if (arch == tt::ARCH::WORMHOLE_B0) {
         std::vector<uint32_t> arc_msg_return_values = {0};
         const uint32_t ret_code = get_arc_messenger()->send_message(
-            wormhole::ARC_MSG_COMMON_PREFIX |
-                get_architecture_implementation()->get_arc_message_arc_get_harvesting(),
+            wormhole::ARC_MSG_COMMON_PREFIX | get_architecture_implementation()->get_arc_message_arc_get_harvesting(),
             arc_msg_return_values,
             {0, 0});
         UMD_ASSERT(

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -100,7 +100,8 @@ TTSimTTDevice::TTSimTTDevice(
     ChipId chip_id,
     bool copy_sim_binary,
     int num_host_mem_channels,
-    size_t num_chips) :
+    size_t num_chips,
+    bool force_shared_bdf_mode) :
     // Each chip gets a distinct host base derived from chip_id, so its outbound-iATU DMA routes to its
     // own host window by address (see configure_iatu_region / SimulationSysmemManager).
     SimulationTTDevice(
@@ -113,7 +114,11 @@ TTSimTTDevice::TTSimTTDevice(
     // multi-chip cluster (num_chips > 1) it uses shared-dlopen BDF mode: one libttsim
     // image addressed per-chip by PCI device. Single-chip keeps the legacy path.
     communicator_(std::make_unique<TTSimCommunicator>(
-        simulator_directory, copy_sim_binary, static_cast<uint32_t>(chip_id), static_cast<uint32_t>(num_chips))),
+        simulator_directory,
+        copy_sim_binary,
+        static_cast<uint32_t>(chip_id),
+        static_cast<uint32_t>(num_chips),
+        force_shared_bdf_mode)),
     chip_id_(chip_id) {
     communication_device_type_ = IODeviceType::PCIe;
     communication_device_id_ = chip_id;

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -15,9 +15,12 @@
 #include <vector>
 
 #include "simulation/simulation_server_socket.hpp"
+#include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
+#include "umd/device/coordinates/coordinate_manager.hpp"
 #include "umd/device/pcie/pci_ids.h"
 #include "umd/device/pcie/tt_sim_tlb_handle.hpp"
 #include "umd/device/pcie/tt_sim_tlb_window.hpp"
@@ -27,8 +30,10 @@
 #include "umd/device/simulation/tt_sim_communicator.hpp"
 #include "umd/device/soc_descriptor.hpp"
 #include "umd/device/types/arch.hpp"
+#include "umd/device/types/blackhole_eth.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/tlb.hpp"
+#include "umd/device/types/wormhole_eth.hpp"
 #include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
@@ -110,6 +115,8 @@ TTSimTTDevice::TTSimTTDevice(
     communicator_(std::make_unique<TTSimCommunicator>(
         simulator_directory, copy_sim_binary, static_cast<uint32_t>(chip_id), static_cast<uint32_t>(num_chips))),
     chip_id_(chip_id) {
+    communication_device_type_ = IODeviceType::PCIe;
+    communication_device_id_ = chip_id;
     set_soc_descriptor(soc_descriptor);
     // Populate the base-class arch field from the soc descriptor. TTSim does not go through
     // init_tt_device() (no PCI probe), so without this arch stays tt::ARCH::Invalid and downstream
@@ -187,6 +194,8 @@ void TTSimTTDevice::initialize_backend() {
 TTSimTTDevice::TTSimTTDevice(
     const SocDescriptor& soc_descriptor, ChipId chip_id, std::unique_ptr<SimulationClient> client) :
     SimulationTTDevice(std::move(client)), chip_id_(chip_id) {
+    communication_device_type_ = IODeviceType::PCIe;
+    communication_device_id_ = chip_id;
     set_soc_descriptor(soc_descriptor);
     arch = soc_descriptor.arch;
     architecture_impl_ = architecture_implementation::create(soc_descriptor.arch);
@@ -342,26 +351,96 @@ void TTSimTTDevice::advance_device_execution() {
 }
 
 void TTSimTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeout_ms) {
-    UMD_THROW(error::RuntimeError, "Waiting for ARC core start is not supported in TTSim simulation device.");
+    // TTSim starts firmware as part of backend initialization, before this TTDevice is returned.
 }
 
 std::chrono::milliseconds TTSimTTDevice::wait_eth_core_training(
     CoreCoord eth_core, const std::chrono::milliseconds timeout_ms) {
-    UMD_THROW(error::RuntimeError, "Waiting for ETH core training is not supported in TTSim simulation device.");
+    const auto start = std::chrono::steady_clock::now();
+    auto duration = std::chrono::milliseconds(0);
+    while (read_eth_core_training_status(eth_core) == EthTrainingStatus::IN_PROGRESS) {
+        duration = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
+        UMD_ASSERT(
+            duration <= timeout_ms,
+            error::RuntimeError,
+            fmt::format("ETH training timed out after {} ms on core {}.", timeout_ms.count(), eth_core.str()));
+    }
+    return duration;
 }
 
 EthTrainingStatus TTSimTTDevice::read_eth_core_training_status(CoreCoord eth_core) {
-    UMD_THROW(error::RuntimeError, "Reading ETH core training status is not supported in TTSim simulation device.");
+    if (arch == tt::ARCH::BLACKHOLE) {
+        uint32_t port_status;
+        const uint32_t port_status_addr =
+            blackhole::BOOT_RESULTS_ADDR + offsetof(blackhole::eth_status_t, port_status);
+        read_from_device(&port_status, eth_core, port_status_addr, sizeof(port_status));
+        return static_cast<EthTrainingStatus>(port_status);
+    }
+
+    uint32_t retrain_status;
+    read_from_device_reg(&retrain_status, eth_core, wormhole::ETH_RETRAIN_ADDR, sizeof(retrain_status));
+    if (retrain_status == wormhole::ETH_TRIGGER_RETRAIN_VAL) {
+        return EthTrainingStatus::IN_PROGRESS;
+    }
+
+    uint32_t training_status;
+    read_from_device_reg(&training_status, eth_core, wormhole::ETH_TRAIN_STATUS_ADDR, sizeof(training_status));
+    if (training_status == static_cast<uint32_t>(EthTrainingStatus::FAIL)) {
+        uint32_t link_error_status;
+        read_from_device_reg(
+            &link_error_status, eth_core, wormhole::ETH_LINK_ERR_STATUS_ADDR, sizeof(link_error_status));
+        if (link_error_status >= wormhole::ETH_LINK_UNUSED_ERROR_CODE_RANGE_START) {
+            return EthTrainingStatus::NOT_CONNECTED;
+        }
+    }
+    return static_cast<EthTrainingStatus>(training_status);
 }
 
 ChipInfo TTSimTTDevice::get_chip_info() {
-    // No firmware_info_provider on the simulator; mirror the defaults used inside
-    // TTSimTTDevice::create(). BH SocDescriptor construction rejects an empty eth_harvesting_mask
-    // ("Exactly 2 or 14 ETH cores should be harvested on full Blackhole"), so apply the same 0x120
-    // default here. Keep in sync with create() above.
-    ChipInfo chip_info{};
-    if (arch == tt::ARCH::BLACKHOLE) {
-        chip_info.harvesting_masks.eth_harvesting_mask = 0x120;
+    ChipInfo chip_info = TTDevice::get_chip_info();
+    if (arch == tt::ARCH::WORMHOLE_B0) {
+        std::vector<uint32_t> arc_msg_return_values = {0};
+        const uint32_t ret_code = get_arc_messenger()->send_message(
+            wormhole::ARC_MSG_COMMON_PREFIX |
+                get_architecture_implementation()->get_arc_message_arc_get_harvesting(),
+            arc_msg_return_values,
+            {0, 0});
+        UMD_ASSERT(
+            ret_code == 0,
+            error::RuntimeError,
+            fmt::format("Failed to get harvesting masks with exit code: {}", ret_code));
+        chip_info.harvesting_masks.tensix_harvesting_mask =
+            CoordinateManager::shuffle_tensix_harvesting_mask(tt::ARCH::WORMHOLE_B0, arc_msg_return_values[0]);
+        return chip_info;
+    }
+
+    ArcTelemetryReader* telemetry_reader = get_arc_telemetry_reader();
+    chip_info.harvesting_masks.tensix_harvesting_mask = CoordinateManager::shuffle_tensix_harvesting_mask(
+        tt::ARCH::BLACKHOLE,
+        telemetry_reader->is_entry_available(TelemetryTag::ENABLED_TENSIX_COL)
+            ? (~telemetry_reader->read_entry(TelemetryTag::ENABLED_TENSIX_COL) & 0x3FFF)
+            : 0);
+    chip_info.harvesting_masks.dram_harvesting_mask =
+        telemetry_reader->is_entry_available(TelemetryTag::ENABLED_GDDR)
+            ? (~telemetry_reader->read_entry(TelemetryTag::ENABLED_GDDR) & 0xFF)
+            : 0;
+    chip_info.harvesting_masks.eth_harvesting_mask =
+        telemetry_reader->is_entry_available(TelemetryTag::ENABLED_ETH)
+            ? (~telemetry_reader->read_entry(TelemetryTag::ENABLED_ETH) & 0x3FFF)
+            : 0;
+    if (telemetry_reader->is_entry_available(TelemetryTag::PCIE_USAGE)) {
+        const uint32_t pcie_usage = telemetry_reader->read_entry(TelemetryTag::PCIE_USAGE);
+        constexpr uint32_t PCIE_USAGE_ENDPOINT = 1;
+        if ((pcie_usage & 0x3) != PCIE_USAGE_ENDPOINT) {
+            chip_info.harvesting_masks.pcie_harvesting_mask |= 0x1;
+        }
+        if (((pcie_usage >> 2) & 0x3) != PCIE_USAGE_ENDPOINT) {
+            chip_info.harvesting_masks.pcie_harvesting_mask |= 0x2;
+        }
+    }
+    if (telemetry_reader->is_entry_available(TelemetryTag::ENABLED_L2CPU)) {
+        chip_info.harvesting_masks.l2cpu_harvesting_mask = CoordinateManager::shuffle_l2cpu_harvesting_mask(
+            tt::ARCH::BLACKHOLE, telemetry_reader->read_entry(TelemetryTag::ENABLED_L2CPU));
     }
     return chip_info;
 }

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -354,6 +354,12 @@ void TTSimTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeout_
     // TTSim starts firmware as part of backend initialization, before this TTDevice is returned.
 }
 
+bool TTSimTTDevice::get_noc_translation_enabled() {
+    // Blackhole TTSim accepts translated NOC coordinates at its host API. Wormhole TTSim continues
+    // to operate directly on NOC0 coordinates.
+    return arch == tt::ARCH::BLACKHOLE || arch == tt::ARCH::WORMHOLE_B0;
+}
+
 std::chrono::milliseconds TTSimTTDevice::wait_eth_core_training(
     CoreCoord eth_core, const std::chrono::milliseconds timeout_ms) {
     const auto start = std::chrono::steady_clock::now();

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -369,7 +369,7 @@ std::chrono::milliseconds TTSimTTDevice::wait_eth_core_training(
 }
 
 EthTrainingStatus TTSimTTDevice::read_eth_core_training_status(CoreCoord eth_core) {
-    if (arch == tt::ARCH::BLACKHOLE) {
+    if (arch != tt::ARCH::WORMHOLE_B0) {
         uint32_t port_status;
         const uint32_t port_status_addr =
             blackhole::BOOT_RESULTS_ADDR + offsetof(blackhole::eth_status_t, port_status);
@@ -411,6 +411,10 @@ ChipInfo TTSimTTDevice::get_chip_info() {
             fmt::format("Failed to get harvesting masks with exit code: {}", ret_code));
         chip_info.harvesting_masks.tensix_harvesting_mask =
             CoordinateManager::shuffle_tensix_harvesting_mask(tt::ARCH::WORMHOLE_B0, arc_msg_return_values[0]);
+        return chip_info;
+    }
+
+    if (arch != tt::ARCH::BLACKHOLE) {
         return chip_info;
     }
 

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -28,6 +28,9 @@
 #include "umd/device/tt_device/hang_detection/wormhole_hang_detector.hpp"
 #include "umd/device/tt_device/protocol/remote_interface.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
+#ifdef TT_UMD_BUILD_SIMULATION
+#include "umd/device/tt_device/simulation_tt_device.hpp"
+#endif
 #include "umd/device/tt_device/tt_device_error.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
@@ -70,6 +73,14 @@ WormholeTTDevice::WormholeTTDevice(
 }
 
 bool WormholeTTDevice::get_noc_translation_enabled() {
+#ifdef TT_UMD_BUILD_SIMULATION
+    if (is_remote()) {
+        TTDevice* gateway_device = get_remote_interface()->get_remote_communication()->get_local_device();
+        if (dynamic_cast<SimulationTTDevice*>(gateway_device) != nullptr) {
+            return gateway_device->get_noc_translation_enabled();
+        }
+    }
+#endif
     uint32_t niu_cfg = 0x0;
     constexpr uint32_t ARC_APB_NIU_0_OFFSET = 0x50000;
     constexpr uint32_t NIU_CFG_0_OFFSET = 0x100;

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -75,8 +75,8 @@ WormholeTTDevice::WormholeTTDevice(
 bool WormholeTTDevice::get_noc_translation_enabled() {
 #ifdef TT_UMD_BUILD_SIMULATION
     if (is_remote()) {
-        TTDevice* gateway_device = get_remote_interface()->get_remote_communication()->get_local_device();
-        if (dynamic_cast<SimulationTTDevice*>(gateway_device) != nullptr) {
+        TTDevice *gateway_device = get_remote_interface()->get_remote_communication()->get_local_device();
+        if (dynamic_cast<SimulationTTDevice *>(gateway_device) != nullptr) {
             return gateway_device->get_noc_translation_enabled();
         }
     }


### PR DESCRIPTION
### Description
This pull request introduces several improvements and new features for simulation device support and topology discovery, as well as enhancements to device register access and simulation device initialization. The main focus is on enabling topology discovery starting from an already-initialized simulation device, improving simulation device register access, and providing more accurate simulation device behavior. Behavior is unchanged when a cluster descriptor is passed.

### List of the changes

**Simulation device and topology discovery enhancements:**

* Added a new static method `TopologyDiscovery::discover_from_local_device` that allows topology discovery to begin from an already-initialized local device, which is essential for simulation and backends without OS device enumeration. Supporting methods such as `add_initialized_local_device` and `create_topology_discovery` were also introduced. [[1]](diffhunk://#diff-745853b66c9301ff1459255757a5fa84128f7e01f3564823b05924bde2fe04f8R39-R48) [[2]](diffhunk://#diff-745853b66c9301ff1459255757a5fa84128f7e01f3564823b05924bde2fe04f8R62-R75) [[3]](diffhunk://#diff-539c05723aa71ef8ffff4cf0f8eed4a9c900fd5d2bcd1dd632d86d2d6285e4f0R79-R86) [[4]](diffhunk://#diff-539c05723aa71ef8ffff4cf0f8eed4a9c900fd5d2bcd1dd632d86d2d6285e4f0R148-R171) [[5]](diffhunk://#diff-539c05723aa71ef8ffff4cf0f8eed4a9c900fd5d2bcd1dd632d86d2d6285e4f0R188-R218)
* Updated the simulation build flow in `Cluster::Cluster` to use the new `discover_from_local_device` method, initializing the simulation device and passing it to topology discovery.

**Simulation device register and memory access:**

* Implemented `read_from_device_reg` and `write_to_device_reg` in `SimulationTTDevice`, which delegate to the existing device read/write methods, enabling register access for simulation devices. [[1]](diffhunk://#diff-2fbddc65f4395d38e9645ba395d517c3f564b458f6d438cbb71fbab199ee6f96R59-R62) [[2]](diffhunk://#diff-7ae0b9e85d1aaf0b6e3d839480bea987d4c64733128174a416bf7ff247ae66f6R179-R188)
* Updated ARC APB and CSM register access methods in `SimulationTTDevice` to actually perform register reads/writes using the SoC descriptor, instead of throwing errors, improving simulation fidelity.

**Simulation device initialization and hang detection:**

* Added `init_tt_device_for_simulation` to `TTDevice` and ensured simulation devices set up a no-op hang detector, preventing errors from hang detection logic in simulation. [[1]](diffhunk://#diff-58a2231bd0578162c6f39e09858b7c8ea22e41ac24eb770a999a0355ac69c591R416-R418) [[2]](diffhunk://#diff-7ae0b9e85d1aaf0b6e3d839480bea987d4c64733128174a416bf7ff247ae66f6R17-R57)
* Integrated the new simulation device initialization flow into chip construction and remote chip creation logic in the cluster, ensuring correct device setup for both local and remote simulation chips. [[1]](diffhunk://#diff-ca95f78d8d9bce89552686931843a3572b94971a5ee2f9d03ca07d84ec0ede45R221-L229) [[2]](diffhunk://#diff-ca95f78d8d9bce89552686931843a3572b94971a5ee2f9d03ca07d84ec0ede45R255-R275)

**Other improvements and bug fixes:**

* Improved the logic for determining MMIO protocol in `HangDetectorImplementation` to avoid false positives when the protocol is null.
* Fixed a minor issue in cluster descriptor population to only record PCI BDFs when a PCI device is present.
* Provided architecture-specific minimum clock frequency values for simulation devices, improving simulation accuracy.

These changes collectively make simulation device support more robust, enable new simulation workflows, and improve the accuracy and maintainability of the simulation backend.


### Testing
tt-metal tests that failed with ttsim now pass
