### PR TITLE
Add timeout on membar

### DIFF
--- a/device/api/umd/device/utils/timeouts.hpp
+++ b/device/api/umd/device/utils/timeouts.hpp
@@ -28,6 +28,9 @@ inline constexpr auto ARC_POST_RESET_TIMEOUT = std::chrono::milliseconds(1'000);
 inline constexpr auto ARC_LONG_POST_RESET_TIMEOUT = std::chrono::milliseconds(300'000);
 
 inline constexpr auto DRAM_TRAINING_TIMEOUT = std::chrono::milliseconds(300'000);
+// A working core echoes the barrier value back in well under a millisecond, so 1 s is enough even on
+// a loaded host, and a core that never echoes it fails in 1 s instead of hanging.
+inline constexpr auto MEMBAR_SYNC_TIMEOUT = std::chrono::milliseconds(1'000);
 inline constexpr auto ETH_QUEUE_ENABLE_TIMEOUT = std::chrono::milliseconds(30'000);
 inline constexpr auto ETH_TRAINING_TIMEOUT = std::chrono::milliseconds(900'000);
 inline constexpr auto ETH_STARTUP_TIMEOUT = std::chrono::milliseconds(10'000);

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -37,6 +37,7 @@
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/timeouts.hpp"
+#include "utils.hpp"
 
 namespace tt::umd {
 
@@ -413,6 +414,7 @@ void LocalChip::set_membar_flag(
         write_to_device(core, barrier_val_vec.data(), barrier_addr, barrier_val_vec.size() * sizeof(uint32_t));
     }
     tt_driver_atomics::sfence();  // Ensure that all writes in the Host WC buffer are flushed
+    const auto start = std::chrono::steady_clock::now();
     while (cores_synced.size() != cores.size()) {
         for (const auto& core : cores) {
             if (cores_synced.find(core) == cores_synced.end()) {
@@ -420,12 +422,23 @@ void LocalChip::set_membar_flag(
                 read_from_device(core, &readback_val, barrier_addr, sizeof(std::uint32_t));
                 if (readback_val == barrier_value) {
                     cores_synced.insert(core);
-                } else {
-                    log_trace(
-                        LogUMD,
-                        "Waiting for core {} to recieve mem bar flag {} in function",
-                        core.str(),
-                        barrier_value);
+                } else if (utils::check_timeout(start, timeout::MEMBAR_SYNC_TIMEOUT)) {
+                    // Report the value actually read. A core that answers but returns corrupted data
+                    // (e.g. a DRAM channel that trained with a dead byte lane) never converges, and the
+                    // readback is what identifies it.
+                    UMD_THROW(
+                        error::RuntimeError,
+                        fmt::format(
+                            "Memory barrier timed out after {} ms on device {} core {} at {:#x}: expected {:#x}, "
+                            "read {:#x}. {} of {} core(s) synced.",
+                            timeout::MEMBAR_SYNC_TIMEOUT.count(),
+                            tt_device_->get_pci_device()->get_device_num(),
+                            core.str(),
+                            barrier_addr,
+                            barrier_value,
+                            readback_val,
+                            cores_synced.size(),
+                            cores.size()));
                 }
             }
         }

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -432,7 +432,7 @@ void LocalChip::set_membar_flag(
                             "Memory barrier timed out after {} ms on device {} core {} at {:#x}: expected {:#x}, "
                             "read {:#x}. {} of {} core(s) synced.",
                             timeout::MEMBAR_SYNC_TIMEOUT.count(),
-                            tt_device_->get_pci_device()->get_device_num(),
+                            tt_device_->get_communication_device_id(),
                             core.str(),
                             barrier_addr,
                             barrier_value,


### PR DESCRIPTION
### Issue
#3111 

### Description
This pull request introduces a timeout mechanism for memory barrier synchronization in the `LocalChip::set_membar_flag` method, enhancing error handling and preventing indefinite hangs when cores fail to synchronize. The key changes are as follows:

### List of the changes

**Timeouts and Synchronization Improvements:**

* Added `MEMBAR_SYNC_TIMEOUT` (1 second) to `timeouts.hpp` to limit how long the system waits for a core to echo the memory barrier value, preventing hangs if a core fails to respond.
* In `LocalChip::set_membar_flag`, implemented a timeout check using `utils::check_timeout` and the new `MEMBAR_SYNC_TIMEOUT`. If a core doesn't synchronize in time, the code now throws a detailed runtime error, including diagnostic information about the core and the value read.

**Code Maintenance:**

* Included the `utils.hpp` header in `local_chip.cpp` to support the new timeout utility function.

### Testing
Manually on faulty BH Galaxy

### API Changes
/
