### PR TITLE
Make UMD simulation socket serving opt-in

### DIFF
--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -113,6 +113,13 @@ struct ClusterOptions {
     std::filesystem::path simulator_directory = "";
 
     /**
+     * Host SIMULATION chip type only: expose simulated chips over per-chip sockets so other
+     * processes can attach as clients. Disabled by default so ordinary in-process simulator runs
+     * remain private and can run independently in parallel.
+     */
+    bool serve_simulation_devices_over_sockets = false;
+
+    /**
      * Host SIMULATION chip type only: optional callback invoked when a client sends SHUTDOWN over a
      * chip's socket, so a long-running host (e.g. the sim_server tool) can be stopped in-band. It is
      * fixed when the host starts serving and must only signal (be non-blocking) and be safe to call

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -634,7 +634,7 @@ Cluster::Cluster(ClusterOptions options) {
 #endif  // TT_UMD_BUILD_SIMULATION
 
 #ifdef TT_UMD_BUILD_SIMULATION
-    if (options.chip_type == ChipType::SIMULATION) {
+    if (options.chip_type == ChipType::SIMULATION && options.serve_simulation_devices_over_sockets) {
         serve_simulation_devices_over_sockets(options.simulator_directory, options.simulation_shutdown_handler);
     }
 #endif  // TT_UMD_BUILD_SIMULATION

--- a/tests/api/test_simulation_connector.cpp
+++ b/tests/api/test_simulation_connector.cpp
@@ -247,6 +247,9 @@ TEST(SimulationConnector, HostAndClientClustersShareDeviceMemory) {
     ClusterOptions host_options;
     host_options.chip_type = ChipType::SIMULATION;
     host_options.simulator_directory = simulator_path;
+    // Publishing per-chip sockets is opt-in (off by default so ordinary in-process runs stay
+    // private); this test is specifically the host/client-over-socket path, so it opts in.
+    host_options.serve_simulation_devices_over_sockets = true;
     Cluster host_cluster(host_options);
 
     ClusterOptions client_options;


### PR DESCRIPTION
### Issue
All of our local ttsim workflows are broken
 
### Description
The recent UMD simulation-server path made every `ChipType::SIMULATION` host publish per-chip Unix sockets by default, so ordinary `TT_METAL_SIMULATOR=/path/libttsim.so` test processes now collide on fixed paths such as `/tmp/tt-umd-sim-0.sock`; in parallel simulator runs this causes all but one process to fail during `Cluster` setup with "A live simulation server already exists", breaking standard ttsim regression workflows.

### List of the changes
This change adds an explicit `ClusterOptions::serve_simulation_devices_over_sockets` flag defaulting to false and gates socket publishing on that option, restoring the previous default contract that `.so` simulator runs are private in-process devices while preserving the ability for a dedicated shared-simulation/server workflow to opt in. Publishing a cross-process IPC endpoint is a specialized mode, not a safe default for normal tests or applications; users that need process isolation or external attachment should request that behavior explicitly, and heavier full-system attachment workflows remain better served by the existing qemu-based path.

### Testing
Local ttsim test with run_metal_tests.py

### API Changes
Adds public serve_simulation_devices_over_sockets flag.