### PR TITLE
Remove ancient Chip::enable_ethernet_queue method

### DIFF
--- a/device/api/umd/device/chip/chip.hpp
+++ b/device/api/umd/device/chip/chip.hpp
@@ -128,9 +128,6 @@ public:
     virtual void set_remote_transfer_ethernet_cores(const std::unordered_set<CoreCoord>& cores) = 0;
     virtual void set_remote_transfer_ethernet_cores(const std::set<uint32_t>& channels) = 0;
 
-    // TODO: To be moved to private implementation once methods are moved to chip.
-    void enable_ethernet_queue(const std::chrono::milliseconds timeout_ms = timeout::ETH_QUEUE_ENABLE_TIMEOUT);
-
     // TODO: This should be private, once enough stuff is moved inside chip.
     // Probably also moved to LocalChip.
     DeviceDramAddressParams dram_address_params;

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -84,26 +84,6 @@ void Chip::wait_dram_cores_training(const std::chrono::milliseconds timeout_ms) 
     }
 }
 
-void Chip::enable_ethernet_queue(const std::chrono::milliseconds timeout_ms) {
-    UMD_ASSERT(
-        get_soc_descriptor().arch != tt::ARCH::BLACKHOLE,
-        error::RuntimeError,
-        "enable_ethernet_queue is not supported on Blackhole architecture");
-    uint32_t msg_success = 0x0;
-    auto start = std::chrono::steady_clock::now();
-    while (msg_success != 1) {
-        if (std::chrono::steady_clock::now() - start > timeout_ms) {
-            UMD_THROW(
-                error::RuntimeError,
-                fmt::format(
-                    "Timed out after waiting {} milliseconds for for DRAM to finish training.", timeout_ms.count()));
-        }
-        if (arc_msg(0xaa58, true, {0xFFFF, 0xFFFF}, timeout::ARC_MESSAGE_TIMEOUT, &msg_success) == HANG_READ_VALUE) {
-            break;
-        }
-    }
-}
-
 RiscType Chip::get_risc_reset_state(CoreCoord core) {
     uint32_t soft_reset_current_state = get_tt_device()->get_risc_reset_state(core);
     return get_tt_device()->get_architecture_implementation()->get_soft_reset_risc_type(soft_reset_current_state);

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -1161,20 +1161,6 @@ void Cluster::deassert_resets_and_set_clock_state() {
         chip->deassert_risc_resets();
     }
 
-    // MT Initial BH - ARC messages not supported in Blackhole.
-    if (arch_name != tt::ARCH::BLACKHOLE && arch_name != tt::ARCH::QUASAR) {
-        for (const ChipId& chip : all_chip_ids_) {
-            // No ttsim chip can service ARC messages, not even the gateway (a SimulationChip, whose
-            // is_mmio_capable() is also false), so skip enabling the ethernet queue for every chip in a simulation
-            // cluster. This is deliberately not keyed on remote_chip_ids_: the gateway must be skipped too. Silicon
-            // chips are initialized over ARC/ethernet as before.
-            if (options_.chip_type == ChipType::SIMULATION && !get_chip(chip)->is_mmio_capable()) {
-                continue;
-            }
-            get_chip(chip)->enable_ethernet_queue();
-        }
-    }
-
     // Set clock state to busy.
     set_clock_state(DevicePowerState::BUSY);
 }


### PR DESCRIPTION
### Issue
#2747 

### Description
Remove ancient Chip::enable_ethernet_queue method. This method only checks that all DRAM cores are trained, which already happens in Chip ctors.

### Testing
CI

### API Changes
This PR has (no) API changes.
