### PR TITLE
Simulation: make socket serving opt-in in SimulationConnector

### DIFF
--- a/device/api/umd/device/simulation/simulation_connector.hpp
+++ b/device/api/umd/device/simulation/simulation_connector.hpp
@@ -20,9 +20,15 @@ struct SimulationConnectorOptions {
     // The simulator build to host: a TTSim .so (when the path ends in .so) or an RTL simulator
     // directory. The backend is selected from the path, mirroring the simulation device factory.
     std::filesystem::path simulator_directory;
-    // Host path only: the directory this server serves its per-chip sockets in. Empty means
-    // allocate a fresh one (allocate_server_directory), so distinct hosts never collide; set it to
-    // serve in a specific directory (e.g. one the caller pre-allocated to report to the user).
+    // Host path only: publish each simulated chip over a per-chip socket so other processes can
+    // attach as clients. Disabled by default so a direct discover() call yields private in-process
+    // devices (the hot path) -- opt in only for a shared-simulation/server workflow. Ignored on the
+    // client path (attaching to a live host is always over sockets).
+    bool serve_over_sockets = false;
+    // Host path only: the directory this server serves its per-chip sockets in (when
+    // serve_over_sockets is set). Empty means allocate a fresh one (allocate_server_directory), so
+    // distinct hosts never collide; set it to serve in a specific directory (e.g. one the caller
+    // pre-allocated to report to the user).
     std::filesystem::path server_directory;
     // Connectivity/topology used to configure the simulator on the host path. Optional; when
     // attaching to a live host the topology comes from the host instead.

--- a/device/simulation/simulation_connector.cpp
+++ b/device/simulation/simulation_connector.cpp
@@ -62,7 +62,9 @@ Classification classify(const std::filesystem::path& simulator_path) {
     return {PathKind::CLIENT, std::move(sockets)};
 }
 
-// Host path: bring up the in-process backend (the direct hot path) and hand it the socket to serve.
+// Host path: bring up the in-process backend (the direct hot path). A null socket means serving is
+// off, so the device stays a private in-process host; a non-null socket is adopted so clients can
+// attach.
 std::unique_ptr<TTDevice> make_host_device(
     PathKind role,
     const std::filesystem::path& simulator_directory,
@@ -70,11 +72,15 @@ std::unique_ptr<TTDevice> make_host_device(
     std::unique_ptr<SimulationServerSocket> socket) {
     if (role == PathKind::HOST_TTSIM) {
         auto device = TTSimTTDevice::create(simulator_directory, num_host_mem_channels);
-        device->adopt_socket(std::move(socket));
+        if (socket) {
+            device->adopt_socket(std::move(socket));
+        }
         return device;
     }
     auto device = RtlSimulationTTDevice::create(simulator_directory, num_host_mem_channels);
-    device->adopt_socket(std::move(socket));
+    if (socket) {
+        device->adopt_socket(std::move(socket));
+    }
     return device;
 }
 
@@ -151,15 +157,18 @@ std::map<ChipId, std::unique_ptr<TTDevice>> SimulationConnector::discover(const 
         return devices;
     }
 
-    // Host: single chip for now. Serve in a dedicated server directory -- the caller's, or a fresh
-    // one -- so two hosts never collide even when they serve the same chip id. create() throws if a
-    // live host already owns this chip's socket in that directory.
-    const std::filesystem::path server_directory = options.server_directory.empty()
-                                                       ? SimulationServerSocket::allocate_server_directory()
-                                                       : options.server_directory;
+    // Host: single chip for now. Serving over sockets is opt-in: by default the host device stays
+    // private in-process (the direct hot path). When requested, serve in a dedicated server
+    // directory -- the caller's, or a fresh one -- so two hosts never collide even when they serve
+    // the same chip id; create() throws if a live host already owns this chip's socket there.
     const ChipId chip_id = 0;
-    auto socket =
-        SimulationServerSocket::create(SimulationServerSocket::default_socket_path(server_directory, chip_id));
+    std::unique_ptr<SimulationServerSocket> socket;
+    if (options.serve_over_sockets) {
+        const std::filesystem::path server_directory = options.server_directory.empty()
+                                                           ? SimulationServerSocket::allocate_server_directory()
+                                                           : options.server_directory;
+        socket = SimulationServerSocket::create(SimulationServerSocket::default_socket_path(server_directory, chip_id));
+    }
     devices.emplace(
         chip_id,
         make_host_device(classification.kind, simulator_path, options.num_host_mem_channels, std::move(socket)));

--- a/tests/api/test_simulation_connector.cpp
+++ b/tests/api/test_simulation_connector.cpp
@@ -37,6 +37,7 @@ TEST(SimulationConnector, CreatesHostDeviceAndExposesSocket) {
 
     SimulationConnectorOptions options;
     options.simulator_directory = simulator_path;
+    options.serve_over_sockets = true;  // this test exercises the socket-serving host path
     options.server_directory = server_directory;
 
     {
@@ -48,6 +49,33 @@ TEST(SimulationConnector, CreatesHostDeviceAndExposesSocket) {
 
     EXPECT_FALSE(std::filesystem::exists(socket));                  // torn down with the device
     EXPECT_FALSE(std::filesystem::is_directory(server_directory));  // and its now-empty directory removed
+}
+
+// With serving off (the default), discover() still creates a working host device, but it is private
+// in-process: no socket is published, so nothing else can attach. This is the direct-use entry point
+// into the TTDevice layer for callers that don't want cross-process IPC. Requires TT_UMD_SIMULATOR.
+TEST(SimulationConnector, CreatesPrivateHostDeviceWhenNotServing) {
+    const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
+    if (simulator_path == nullptr) {
+        GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
+    }
+
+    // No server directory is claimed when serving is off; if the connector wrongly served, it would
+    // land here, so assert this stays empty.
+    const std::filesystem::path server_directory = SimulationServerSocket::allocate_server_directory();
+    const std::filesystem::path socket = SimulationServerSocket::default_socket_path(server_directory, 0);
+
+    SimulationConnectorOptions options;
+    options.simulator_directory = simulator_path;
+    // serve_over_sockets defaults to false: a private in-process host, no socket published.
+    options.server_directory = server_directory;
+
+    auto devices = SimulationConnector::discover(options);
+    ASSERT_EQ(devices.size(), 1u);
+    EXPECT_NE(devices.at(0), nullptr);              // a usable host device...
+    EXPECT_FALSE(std::filesystem::exists(socket));  // ...that published no socket
+
+    std::filesystem::remove(server_directory);
 }
 
 // discover() decides the role from what simulator_directory points at (a .so file hosts TTSim, a
@@ -75,6 +103,7 @@ TEST(SimulationConnector, HostServesClientMemoryOverSocket) {
 
     SimulationConnectorOptions options;
     options.simulator_directory = simulator_path;
+    options.serve_over_sockets = true;  // this test exercises the socket-serving host path
     options.server_directory = server_directory;
     auto devices = SimulationConnector::discover(options);
     ASSERT_EQ(devices.size(), 1u);
@@ -135,6 +164,7 @@ TEST(SimulationConnector, HostServesDeviceInfoOverSocket) {
 
     SimulationConnectorOptions options;
     options.simulator_directory = simulator_path;
+    options.serve_over_sockets = true;  // this test exercises the socket-serving host path
     options.server_directory = server_directory;
     auto devices = SimulationConnector::discover(options);
     ASSERT_EQ(devices.size(), 1u);
@@ -175,6 +205,7 @@ TEST(SimulationConnector, ClientDeviceReadsAndWritesOverSocket) {
 
     SimulationConnectorOptions host_options;
     host_options.simulator_directory = simulator_path;
+    host_options.serve_over_sockets = true;  // this test exercises the socket-serving host path
     host_options.server_directory = server_directory;
 
     // The .so path hosts and publishes its per-chip socket; pointing discovery at that server's

--- a/tests/api/test_simulation_connector.cpp
+++ b/tests/api/test_simulation_connector.cpp
@@ -35,6 +35,7 @@ TEST(SimulationConnector, CreatesHostDeviceAndExposesSocket) {
 
     SimulationConnectorOptions options;
     options.simulator_directory = simulator_path;
+    options.serve_over_sockets = true;  // this test exercises the socket-serving host path
     options.server_directory = server_directory;
 
     {
@@ -46,6 +47,33 @@ TEST(SimulationConnector, CreatesHostDeviceAndExposesSocket) {
 
     EXPECT_FALSE(std::filesystem::exists(socket));                  // torn down with the device
     EXPECT_FALSE(std::filesystem::is_directory(server_directory));  // and its now-empty directory removed
+}
+
+// With serving off (the default), discover() still creates a working host device, but it is private
+// in-process: no socket is published, so nothing else can attach. This is the direct-use entry point
+// into the TTDevice layer for callers that don't want cross-process IPC. Requires TT_UMD_SIMULATOR.
+TEST(SimulationConnector, CreatesPrivateHostDeviceWhenNotServing) {
+    const char* simulator_path = std::getenv("TT_UMD_SIMULATOR");
+    if (simulator_path == nullptr) {
+        GTEST_SKIP() << "TT_UMD_SIMULATOR is not set.";
+    }
+
+    // No server directory is claimed when serving is off; if the connector wrongly served, it would
+    // land here, so assert this stays empty.
+    const std::filesystem::path server_directory = SimulationServerSocket::allocate_server_directory();
+    const std::filesystem::path socket = SimulationServerSocket::default_socket_path(server_directory, 0);
+
+    SimulationConnectorOptions options;
+    options.simulator_directory = simulator_path;
+    // serve_over_sockets defaults to false: a private in-process host, no socket published.
+    options.server_directory = server_directory;
+
+    auto devices = SimulationConnector::discover(options);
+    ASSERT_EQ(devices.size(), 1u);
+    EXPECT_NE(devices.at(0), nullptr);              // a usable host device...
+    EXPECT_FALSE(std::filesystem::exists(socket));  // ...that published no socket
+
+    std::filesystem::remove(server_directory);
 }
 
 // discover() decides the role from what simulator_directory points at (a .so file hosts TTSim, a
@@ -73,6 +101,7 @@ TEST(SimulationConnector, HostServesClientMemoryOverSocket) {
 
     SimulationConnectorOptions options;
     options.simulator_directory = simulator_path;
+    options.serve_over_sockets = true;  // this test exercises the socket-serving host path
     options.server_directory = server_directory;
     auto devices = SimulationConnector::discover(options);
     ASSERT_EQ(devices.size(), 1u);
@@ -133,6 +162,7 @@ TEST(SimulationConnector, HostServesDeviceInfoOverSocket) {
 
     SimulationConnectorOptions options;
     options.simulator_directory = simulator_path;
+    options.serve_over_sockets = true;  // this test exercises the socket-serving host path
     options.server_directory = server_directory;
     auto devices = SimulationConnector::discover(options);
     ASSERT_EQ(devices.size(), 1u);
@@ -173,6 +203,7 @@ TEST(SimulationConnector, ClientDeviceReadsAndWritesOverSocket) {
 
     SimulationConnectorOptions host_options;
     host_options.simulator_directory = simulator_path;
+    host_options.serve_over_sockets = true;  // this test exercises the socket-serving host path
     host_options.server_directory = server_directory;
 
     // The .so path hosts and publishes its per-chip socket; pointing discovery at that server's


### PR DESCRIPTION
### Issue
Part of #2677 (simulation server process). `SimulationConnector::discover()` is the TTDevice-layer entry point for simulated devices — it returns the `TTDevice`s directly and can be used without a `Cluster`. Its host path, however, always published a per-chip socket, so a direct `discover()` call always incurred cross-process IPC even when the caller just wanted a private in-process simulator.

### Description
Adds `SimulationConnectorOptions::serve_over_sockets` (default **false**) and gates socket creation on the host path behind it:

- **off (default)** — the host device stays a private in-process simulator (the direct hot path); no socket is published, so nothing else can attach.
- **on** — the host publishes its per-chip socket (in a fresh or caller-supplied server directory) so other processes can attach as clients.

This mirrors the `Cluster`-level `serve_simulation_devices_over_sockets` policy (#3112) one layer down, so callers can use the connector directly both with and without sockets. The client path is unaffected — attaching to a live host is always over sockets.

`Cluster` is intentionally left routing its host path through its own code (not `discover()`); unifying the two is tracked separately in #3081.

### List of the changes
- `SimulationConnectorOptions::serve_over_sockets` (new, default false) — documented as host-path only.
- `SimulationConnector::discover()` host branch only creates + serves a socket when the flag is set; otherwise builds a plain in-process host device.
- `make_host_device()` tolerates a null socket (skips `adopt_socket`), so the device stays private.
- Connector e2e tests that exercise the socket-serving host path opt in (`serve_over_sockets = true`); new `CreatesPrivateHostDeviceWhenNotServing` covers the default no-socket path.

### Testing
Build + pre-commit clean. Simulation unit tests pass; the `TT_UMD_SIMULATOR`-gated connector integration tests (including the new one) skip cleanly without a simulator and exercise both the serving and private paths when one is present.

### API Changes
Adds `SimulationConnectorOptions::serve_over_sockets` (default false).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
