### PR TITLE
Fix SCCache pollution between different build types

### DIFF
--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -165,8 +165,9 @@ jobs:
       # Enabled on push to main (the only branch that triggers a push event here)
       # and on manual dispatch when the input is set; skipped on PRs and merge queue.
       SCCACHE_GHA_ENABLED: ${{ github.event_name == 'push' || inputs.use-sccache }}
-      SCCACHE_GHA_VERSION: build-device-${{ matrix.image.distro }}-${{ matrix.image.compiler-c }}-\\
-        ${{ matrix.image.use_release_flags && '-release' || '' }}
+      SCCACHE_GHA_VERSION: >-
+        build-device-${{ matrix.image.distro }}-${{ matrix.image.compiler-c
+        }}${{ matrix.image.use_release_flags && '-release' || '' }}
       # Only the main branch may write to the sccache; all other branches read only.
       SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
     container:

--- a/.github/workflows/build-device.yml
+++ b/.github/workflows/build-device.yml
@@ -165,7 +165,8 @@ jobs:
       # Enabled on push to main (the only branch that triggers a push event here)
       # and on manual dispatch when the input is set; skipped on PRs and merge queue.
       SCCACHE_GHA_ENABLED: ${{ github.event_name == 'push' || inputs.use-sccache }}
-      SCCACHE_GHA_VERSION: 1
+      SCCACHE_GHA_VERSION: build-device-${{ matrix.image.distro }}-${{ matrix.image.compiler-c }}-\\
+        ${{ matrix.image.use_release_flags && '-release' || '' }}
       # Only the main branch may write to the sccache; all other branches read only.
       SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
     container:

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -93,7 +93,8 @@ env:
   NANOBIND_TEST_DIR: ./nanobind/tests
   # Env. vars related to SCCache:
   SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache }}
-  SCCACHE_GHA_VERSION: 1
+  SCCACHE_GHA_VERSION: build-tests-${{ inputs.build-type }}-${{ inputs.ubuntu-docker-version }}\\
+    ${{ matrix.use_tracy && '-tracy' || '' }})
   # Only the main branch may write to the sccache; all other branches read only.
   SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
 

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -93,8 +93,6 @@ env:
   NANOBIND_TEST_DIR: ./nanobind/tests
   # Env. vars related to SCCache:
   SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache }}
-  SCCACHE_GHA_VERSION: build-tests-${{ inputs.build-type }}-${{ inputs.ubuntu-docker-version }}\\
-    ${{ matrix.use_tracy && '-tracy' || '' }})
   # Only the main branch may write to the sccache; all other branches read only.
   SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
 
@@ -118,6 +116,9 @@ jobs:
       image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}:${{ inputs.image-tag }}
 
     env:
+      SCCACHE_GHA_VERSION: >-
+        build-tests-${{ inputs.build-type }}-${{ inputs.ubuntu-docker-version
+        }}${{ matrix.use_tracy && '-tracy' || '' }}
       # CI runners may lack invariant TSC support (required by Tracy for high-res timestamps).
       # This skips Tracy's runtime TSC check; harmless when Tracy is disabled.
       TRACY_NO_INVARIANT_CHECK: 1
@@ -201,6 +202,9 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}:${{ inputs.image-tag }}
+
+    env:
+      SCCACHE_GHA_VERSION: build-wheel-${{ inputs.build-type }}-${{ inputs.ubuntu-docker-version }}
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
### Issue
#3122 

### Description
Fix SCCache pollution between different build types.

### List of the changes
- Set SCCACHE_GHA_VERSION according to workflow, build type, compiler, distro, etc.

### Testing
CI

### API Changes
This PR has no API changes.
