### PR TITLE
Remove tt-ubuntu-2204-wh-glx-6u-viommu-stable

### DIFF
--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -168,8 +168,6 @@ jobs:
             'merge_group|*|tt-ubuntu-2204-bh-loudbox-viommu-stable' \
             'merge_group|ASan|tt-ubuntu-2204-bh-loudbox-stable' \
             'merge_group|TSan|tt-ubuntu-2204-bh-loudbox-stable' \
-            'pull_request|*|tt-ubuntu-2204-wh-glx-6u-*' \
-            'merge_group|*|tt-ubuntu-2204-wh-glx-6u-*' \
             'pull_request|*|tt-ubuntu-2204-p100a-*' \
             'merge_group|*|tt-ubuntu-2204-p100a-*' \
             '*|*|tt-ubuntu-2204-wh-glx-6u-stable' \

--- a/.github/workflows/build-and-run-all-tests.yml
+++ b/.github/workflows/build-and-run-all-tests.yml
@@ -154,7 +154,7 @@ jobs:
         # - P300-viommu is a shared pool of 3 P300 machines.
         # - bh-loudbox is a single machine in CIv2. It also has an additional problem where
         #   it actually has a ~20min startup time for viommu variant, so this one can be really slow.
-        # - The wh-glx-6u is also one machine, but not yet fully proven, so don't want to block merge queue with it.
+        # - wh-glx-6u has been unavailable since July 2026.
         # - p100a is similar to p150, and the pool can get bogged down; only run it on main to keep
         #   PR/merge queue runtime down.
         # - g13blx01 is the Blackhole Galaxy machine. It is fully disabled on all events for now as
@@ -172,6 +172,8 @@ jobs:
             'merge_group|*|tt-ubuntu-2204-wh-glx-6u-*' \
             'pull_request|*|tt-ubuntu-2204-p100a-*' \
             'merge_group|*|tt-ubuntu-2204-p100a-*' \
+            '*|*|tt-ubuntu-2204-wh-glx-6u-stable' \
+            '*|*|tt-ubuntu-2204-wh-glx-6u-viommu-stable' \
             '*|*|g13blx01' \
             '*|TSan|ubuntu-22.04' \
           )


### PR DESCRIPTION
Remove tt-ubuntu-2204-wh-glx-6u-viommu-stable and tt-ubuntu-2204-wh-glx-6u-stable due to unavailability.