### PR TITLE
Remove unused include in RemoteChip

### DIFF
--- a/device/api/umd/device/chip/remote_chip.hpp
+++ b/device/api/umd/device/chip/remote_chip.hpp
@@ -12,9 +12,6 @@
 #include <unordered_set>
 
 #include "umd/device/chip/chip.hpp"
-// TODO : tt-metal uses SysmemBuffer transitively through this header. Remove once tt-metal includes it directly.
-// Link to issue: https://github.com/tenstorrent/tt-umd/issues/2437.
-#include "umd/device/chip_helpers/sysmem_buffer.hpp"
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"


### PR DESCRIPTION
### Issue
Closes #2437

### Description
Remove unused SysmemBuffer include in RemoteChip.

### Testing
build passes

### API Changes
This PR has no API changes.
