### PR TITLE
Create DmaInterface per Base API Specification

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -245,6 +245,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/tt_device/simulation_device_factory.hpp
                 api/umd/device/tt_device/protocol/device_protocol.hpp
                 api/umd/device/tt_device/protocol/pcie_interface.hpp
+                api/umd/device/tt_device/protocol/dma_interface.hpp
                 api/umd/device/tt_device/protocol/pcie_protocol.hpp
                 api/umd/device/tt_device/protocol/jtag_interface.hpp
                 api/umd/device/tt_device/protocol/jtag_protocol.hpp

--- a/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
@@ -7,10 +7,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <memory>
 #include <optional>
 
-#include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
@@ -124,8 +122,6 @@ private:
      */
     void validate(const size_t offset) const;
 
-    TlbWindow* get_cached_tlb_window();
-
     PCIDevice* pci_device_;
     TTDevice* tt_device_;
 
@@ -148,8 +144,6 @@ private:
     // Address that is used on the NOC to access the buffer.  NOC target must be
     // the PCIE core that is connected to the host and this address.
     std::optional<uint64_t> noc_addr_;
-
-    std::unique_ptr<TlbWindow> cached_tlb_window = nullptr;
 
     std::function<void()> unmap_callback_;
 };

--- a/device/api/umd/device/tt_device/protocol/dma_interface.hpp
+++ b/device/api/umd/device/tt_device/protocol/dma_interface.hpp
@@ -1,0 +1,110 @@
+/*
+ * SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "umd/device/types/noc_id.hpp"
+#include "umd/device/types/xy_pair.hpp"
+
+namespace tt::umd {
+
+/**
+ * @brief DMA transfer operations between host and device memory.
+ *
+ * Two transfer modes:
+ * - Bounce buffer: copies through an internal pinned staging buffer. Returns false if DMA is
+ *   unavailable, letting the caller fall back.
+ * - Zero-copy: operates directly on caller-managed pinned memory identified by IOVA, bypassing
+ *   the staging buffer.
+ *
+ * All core coordinates are tt_xy_pair: raw (x, y) with no translation.
+ */
+class DmaInterface {
+public:
+    virtual ~DmaInterface() = default;
+
+    /**
+     * @brief Device-to-Host DMA via internal staging buffer.
+     * @param dst Pointer to the destination host buffer.
+     * @param src_addr Source address on the target core.
+     * @param size Number of bytes to transfer.
+     * @param core Source core coordinates.
+     * @param noc_id NOC to route through.
+     * @return true on success; false if DMA is unavailable.
+     */
+    [[nodiscard]] virtual bool dma_read(void* dst, uint64_t src_addr, size_t size, tt_xy_pair core, NocId noc_id) = 0;
+
+    /**
+     * @brief Host-to-Device DMA via internal staging buffer.
+     * @param src Pointer to the source host memory.
+     * @param dst_addr Destination address on the target core.
+     * @param size Number of bytes to transfer.
+     * @param core Target core coordinates.
+     * @param noc_id NOC to route through.
+     * @return true on success; false if DMA is unavailable.
+     */
+    [[nodiscard]] virtual bool dma_write(
+        const void* src, uint64_t dst_addr, size_t size, tt_xy_pair core, NocId noc_id) = 0;
+
+    /**
+     * @brief Multicast Host-to-Device DMA via internal staging buffer.
+     * @param src Pointer to the source host memory.
+     * @param dst_addr Destination address on the target cores.
+     * @param size Number of bytes to transfer.
+     * @param core_start Top-left core of the multicast rectangle.
+     * @param core_end Bottom-right core of the multicast rectangle.
+     * @param noc_id NOC to route through.
+     * @return true on success; false if DMA is unavailable.
+     */
+    [[nodiscard]] virtual bool dma_multicast_write(
+        const void* src, uint64_t dst_addr, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, NocId noc_id) = 0;
+
+    /**
+     * @brief Zero-copy Device-to-Host DMA into caller-managed pinned memory.
+     * @param dst_iova IOVA of the destination pinned host memory buffer.
+     * @param src_addr Source address on the target core.
+     * @param size Number of bytes to transfer.
+     * @param core Source core coordinates.
+     * @param noc_id NOC to route through.
+     * @return true on success; false if DMA is unavailable.
+     */
+    virtual bool dma_read_zero_copy(
+        uint64_t dst_iova, uint64_t src_addr, size_t size, tt_xy_pair core, NocId noc_id) = 0;
+
+    /**
+     * @brief Zero-copy Host-to-Device DMA from caller-managed pinned memory.
+     * @param src_iova IOVA of the source pinned host memory buffer.
+     * @param dst_addr Destination address on the target core.
+     * @param size Number of bytes to transfer.
+     * @param core Target core coordinates.
+     * @param noc_id NOC to route through.
+     * @return true on success; false if DMA is unavailable.
+     */
+    virtual bool dma_write_zero_copy(
+        uint64_t src_iova, uint64_t dst_addr, size_t size, tt_xy_pair core, NocId noc_id) = 0;
+
+    /**
+     * @brief Zero-copy multicast Host-to-Device DMA from caller-managed pinned memory.
+     * @param src_iova IOVA of the source pinned host memory buffer.
+     * @param dst_addr Destination address on the target cores.
+     * @param size Number of bytes to transfer.
+     * @param core_start Top-left core of the multicast rectangle.
+     * @param core_end Bottom-right core of the multicast rectangle.
+     * @param noc_id NOC to route through.
+     * @return true on success; false if DMA is unavailable.
+     */
+    virtual bool dma_multicast_write_zero_copy(
+        uint64_t src_iova,
+        uint64_t dst_addr,
+        size_t size,
+        tt_xy_pair core_start,
+        tt_xy_pair core_end,
+        NocId noc_id) = 0;
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/tt_device/protocol/dma_interface.hpp
+++ b/device/api/umd/device/tt_device/protocol/dma_interface.hpp
@@ -21,8 +21,6 @@ namespace tt::umd {
  *   unavailable, letting the caller fall back.
  * - Zero-copy: operates directly on caller-managed pinned memory identified by IOVA, bypassing
  *   the staging buffer.
- *
- * All core coordinates are tt_xy_pair: raw (x, y) with no translation.
  */
 class DmaInterface {
 public:

--- a/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
@@ -20,7 +20,7 @@ class PCIDevice;
  * PcieInterface defines PCIe-specific operations beyond the basic DeviceProtocol.
  *
  * This includes BAR register access, NOC multicast writes, and direct access to the underlying
- * PCIDevice. DMA transfers live in DmaInterface.
+ * PCIDevice.
  */
 class PcieInterface {
 public:

--- a/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
@@ -19,24 +19,14 @@ class PCIDevice;
 /**
  * PcieInterface defines PCIe-specific operations beyond the basic DeviceProtocol.
  *
- * This includes DMA transfers, BAR register access, NOC multicast writes, and
- * direct access to the underlying PCIDevice.
+ * This includes BAR register access, NOC multicast writes, and direct access to the underlying
+ * PCIDevice. DMA transfers live in DmaInterface.
  */
 class PcieInterface {
 public:
     virtual ~PcieInterface() = default;
 
     virtual PCIDevice* get_pci_device() = 0;
-
-    // Return true on success, false if DMA is unavailable.
-    [[nodiscard]] virtual bool dma_write_to_device(
-        const void* src, size_t size, tt_xy_pair core, uint64_t addr, NocId noc_id) = 0;
-    // Return true on success, false if DMA is unavailable.
-    [[nodiscard]] virtual bool dma_read_from_device(
-        void* dst, size_t size, tt_xy_pair core, uint64_t addr, NocId noc_id) = 0;
-    // Return true on success, false if DMA is unavailable.
-    [[nodiscard]] virtual bool dma_multicast_write(
-        void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) = 0;
 
     virtual void dma_d2h(void* dst, uint32_t src, size_t size) = 0;
     virtual void dma_d2h_zero_copy(void* dst, uint32_t src, size_t size) = 0;

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -13,6 +13,7 @@
 #include <optional>
 
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
+#include "umd/device/tt_device/protocol/dma_interface.hpp"
 #include "umd/device/tt_device/protocol/pcie_dma/dma_transfer.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
 #include "umd/device/types/arch.hpp"
@@ -29,12 +30,13 @@ class TlbWindow;
 struct tlb_data;
 
 /**
- * PcieProtocol implements DeviceProtocol and PcieInterface for PCIe-connected devices.
+ * PcieProtocol implements DeviceProtocol, PcieInterface, and DmaInterface for PCIe-connected
+ * devices.
  *
  * Provides PCIe-based device I/O including DMA transfers, register access,
  * and multicast writes.
  */
-class PcieProtocol : public DeviceProtocol, public PcieInterface {
+class PcieProtocol : public DeviceProtocol, public PcieInterface, public DmaInterface {
 public:
     explicit PcieProtocol(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api = false);
 
@@ -53,12 +55,6 @@ public:
     // PcieInterface.
     void set_io_timeout_callback(const std::function<bool(NocId)>& hang_check) override;
     PCIDevice* get_pci_device() override;
-    [[nodiscard]] bool dma_write_to_device(
-        const void* src, size_t size, tt_xy_pair core, uint64_t addr, NocId noc_id) override;
-    [[nodiscard]] bool dma_read_from_device(
-        void* dst, size_t size, tt_xy_pair core, uint64_t addr, NocId noc_id) override;
-    [[nodiscard]] bool dma_multicast_write(
-        void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) override;
     void dma_d2h(void* dst, uint32_t src, size_t size) override;
     void dma_d2h_zero_copy(void* dst, uint32_t src, size_t size) override;
     void dma_h2d(uint32_t dst, const void* src, size_t size) override;
@@ -67,6 +63,19 @@ public:
         const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) override;
     void bar_write32(uint32_t addr, uint32_t data) override;
     uint32_t bar_read32(uint32_t addr) override;
+
+    // DmaInterface.
+    [[nodiscard]] bool dma_read(void* dst, uint64_t src_addr, size_t size, tt_xy_pair core, NocId noc_id) override;
+    [[nodiscard]] bool dma_write(
+        const void* src, uint64_t dst_addr, size_t size, tt_xy_pair core, NocId noc_id) override;
+    [[nodiscard]] bool dma_multicast_write(
+        const void* src, uint64_t dst_addr, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, NocId noc_id)
+        override;
+    bool dma_read_zero_copy(uint64_t dst_iova, uint64_t src_addr, size_t size, tt_xy_pair core, NocId noc_id) override;
+    bool dma_write_zero_copy(uint64_t src_iova, uint64_t dst_addr, size_t size, tt_xy_pair core, NocId noc_id) override;
+    bool dma_multicast_write_zero_copy(
+        uint64_t src_iova, uint64_t dst_addr, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, NocId noc_id)
+        override;
 
 private:
     TlbWindow* get_cached_tlb_window();
@@ -82,6 +91,7 @@ private:
     tlb_data create_dma_tlb_config(
         uint64_t addr, tt_xy_pair core_end, NocId noc_id, std::optional<tt_xy_pair> core_start = std::nullopt);
     bool dma_transfer(void* buffer, size_t size, uint64_t addr, tlb_data config, DmaDirection direction);
+    bool dma_transfer_zero_copy(uint64_t iova, size_t size, uint64_t addr, tlb_data config, DmaDirection direction);
 
     template <bool safe>
     void write_data_impl(const void* mem_ptr, tt_xy_pair core, uint64_t addr, size_t size, NocId noc_id);

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -49,6 +49,7 @@ class ArcMessenger;
 class ArcTelemetryReader;
 class RemoteCommunication;
 class SimulationSysmemManager;
+class DmaInterface;
 class JtagDevice;
 class JtagInterface;
 class PCIDevice;
@@ -115,6 +116,7 @@ public:
 
     DeviceProtocol *get_device_protocol();
     PcieInterface *get_pcie_interface();
+    DmaInterface *get_dma_interface();
     JtagInterface *get_jtag_interface();
     RemoteInterface *get_remote_interface();
 
@@ -578,6 +580,7 @@ private:
     std::unique_ptr<DeviceProtocol> device_protocol_;
     std::unique_ptr<HangDetector> hang_detector_;
     PcieInterface *pcie_capabilities_ = nullptr;
+    DmaInterface *dma_capabilities_ = nullptr;
     JtagInterface *jtag_capabilities_ = nullptr;
     RemoteInterface *remote_capabilities_ = nullptr;
 };

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -116,7 +116,6 @@ public:
 
     DeviceProtocol *get_device_protocol();
     PcieInterface *get_pcie_interface();
-    DmaInterface *get_dma_interface();
     JtagInterface *get_jtag_interface();
     RemoteInterface *get_remote_interface();
 
@@ -499,6 +498,32 @@ public:
         NocId noc_id = NocId::DEFAULT_NOC);
 
     /**
+     * Zero-copy Device-to-Host DMA into caller-managed pinned memory, bypassing the internal
+     * staging buffer. Unlike dma_read_from_device, there is no non-DMA fallback: this throws if
+     * DMA is unavailable.
+     *
+     * @param dst_iova IOVA of the destination pinned host memory buffer.
+     * @param src_addr source address on the target core.
+     * @param size number of bytes
+     * @param core source core coordinates
+     */
+    virtual void dma_read_zero_copy(
+        uint64_t dst_iova, uint64_t src_addr, size_t size, CoreCoord core, NocId noc_id = NocId::DEFAULT_NOC);
+
+    /**
+     * Zero-copy Host-to-Device DMA from caller-managed pinned memory, bypassing the internal
+     * staging buffer. Unlike dma_write_to_device, there is no non-DMA fallback: this throws if
+     * DMA is unavailable.
+     *
+     * @param src_iova IOVA of the source pinned host memory buffer.
+     * @param dst_addr destination address on the target core.
+     * @param size number of bytes
+     * @param core target core coordinates
+     */
+    virtual void dma_write_zero_copy(
+        uint64_t src_iova, uint64_t dst_addr, size_t size, CoreCoord core, NocId noc_id = NocId::DEFAULT_NOC);
+
+    /**
      * Read the training status of the given ETH core.
      *
      * @param eth_core ETH core to read the training status for.
@@ -571,6 +596,8 @@ private:
     void assign_soc_arch_descriptor(const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
 
     xy_pair resolve_coordinate(CoreCoord core, NocId noc_id) const;
+
+    DmaInterface *get_dma_interface();
 
     std::shared_ptr<SocArchDescriptor> soc_arch_descriptor_ = nullptr;
     std::optional<SocDescriptor> soc_descriptor_ = std::nullopt;

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -17,7 +17,6 @@
 
 #include "tracy.hpp"
 #include "umd/device/pcie/pci_device.hpp"
-#include "umd/device/tt_device/protocol/dma_interface.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/utils/error.hpp"
 
@@ -69,14 +68,7 @@ void SysmemBuffer::dma_write_to_device(const size_t offset, size_t size, const t
     // proper coordinates.
     // core = translate_chip_coord_virtual_to_translated(core);
 
-    bool success = tt_device_->get_dma_interface()->dma_write_zero_copy(
-        get_device_io_addr(offset), addr, size, core, get_selected_noc_id());
-    UMD_ASSERT(
-        success,
-        error::RuntimeError,
-        fmt::format(
-            "DMA write to device failed: DMA buffer is not allocated on PCI device {}.",
-            pci_device_->get_device_num()));
+    tt_device_->dma_write_zero_copy(get_device_io_addr(offset), addr, size, core, get_selected_noc_id());
 }
 
 void SysmemBuffer::dma_read_from_device(const size_t offset, size_t size, const tt_xy_pair core, uint64_t addr) {
@@ -89,14 +81,7 @@ void SysmemBuffer::dma_read_from_device(const size_t offset, size_t size, const 
     // proper coordinates.
     // core = translate_chip_coord_virtual_to_translated(core);
 
-    bool success = tt_device_->get_dma_interface()->dma_read_zero_copy(
-        get_device_io_addr(offset), addr, size, core, get_selected_noc_id());
-    UMD_ASSERT(
-        success,
-        error::RuntimeError,
-        fmt::format(
-            "DMA read from device failed: DMA buffer is not allocated on PCI device {}.",
-            pci_device_->get_device_num()));
+    tt_device_->dma_read_zero_copy(get_device_io_addr(offset), addr, size, core, get_selected_noc_id());
 }
 
 SysmemBuffer::~SysmemBuffer() {

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -7,24 +7,18 @@
 #include <fmt/format.h>
 #include <unistd.h>
 
-#include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <memory>
 #include <optional>
 #include <string>
 #include <tt-logger/tt-logger.hpp>
 #include <tuple>
 #include <utility>
 
-#include "noc_access.hpp"
 #include "tracy.hpp"
-#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/pcie/pci_device.hpp"
-#include "umd/device/pcie/silicon_tlb_window.hpp"
-#include "umd/device/pcie/tlb_handle.hpp"
+#include "umd/device/tt_device/protocol/dma_interface.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
-#include "umd/device/types/tlb.hpp"
 #include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
@@ -68,114 +62,41 @@ SysmemBuffer::SysmemBuffer(
 void SysmemBuffer::dma_write_to_device(const size_t offset, size_t size, const tt_xy_pair core, uint64_t addr) {
     ZoneScopedC(tracy::Color::Yellow);
 
-    if (pci_device_->get_dma_buffer().buffer == nullptr) {
-        UMD_THROW(
-            error::RuntimeError,
-            fmt::format(
-                "DMA buffer is not allocated on PCI device {}, PCIe DMA operations not supported.",
-                pci_device_->get_device_num()));
-    }
-
     validate(offset);
-
-    const uint8_t* buffer = reinterpret_cast<const uint8_t*>(get_device_io_addr(offset));
 
     // TODO: these are chip functions, figure out how to have these
     // inside sysmem buffer, or we keep API as it is and make application send
     // proper coordinates.
     // core = translate_chip_coord_virtual_to_translated(core);
 
-    tlb_data config{};
-    config.local_offset = addr;
-    config.x_end = core.x;
-    config.y_end = core.y;
-    config.noc_sel = is_selected_noc1() ? 1 : 0;
-    config.ordering = tlb_data::Relaxed;
-    config.static_vc = pci_device_->get_architecture_implementation()->get_static_vc();
-    TlbWindow* tlb_window = get_cached_tlb_window();
-    tlb_window->configure(config);
-
-    auto axi_address_base = pci_device_->get_architecture_implementation()
-                                ->get_tlb_configuration(tlb_window->handle_ref().get_tlb_id())
-                                .tlb_offset;
-    const size_t tlb_handle_size = tlb_window->handle_ref().get_size();
-
-    // In order to properly initiate DMA transfer, we need to calculate the offset into the TLB window
-    // based on the target address. Bitwise operations work in this case since all our TLB windows are power-of-two
-    // sized.
-    auto axi_address = axi_address_base + (addr & (tlb_handle_size - 1));
-
-    while (size > 0) {
-        auto tlb_size = tlb_window->get_size();
-
-        size_t transfer_size = std::min({size, tlb_size});
-
-        tt_device_->dma_h2d_zero_copy(axi_address, buffer, transfer_size);
-
-        size -= transfer_size;
-        addr += transfer_size;
-        buffer += transfer_size;
-
-        config.local_offset = addr;
-        tlb_window->configure(config);
-        axi_address = axi_address_base + (addr - (addr & ~(tlb_handle_size - 1)));
-    }
+    bool success = tt_device_->get_dma_interface()->dma_write_zero_copy(
+        get_device_io_addr(offset), addr, size, core, get_selected_noc_id());
+    UMD_ASSERT(
+        success,
+        error::RuntimeError,
+        fmt::format(
+            "DMA write to device failed: DMA buffer is not allocated on PCI device {}.",
+            pci_device_->get_device_num()));
 }
 
 void SysmemBuffer::dma_read_from_device(const size_t offset, size_t size, const tt_xy_pair core, uint64_t addr) {
     ZoneScopedC(tracy::Color::Yellow);
 
-    if (pci_device_->get_dma_buffer().buffer == nullptr) {
-        UMD_THROW(
-            error::RuntimeError,
-            fmt::format(
-                "DMA buffer is not allocated on PCI device {}, PCIe DMA operations not supported.",
-                pci_device_->get_device_num()));
-    }
-
     validate(offset);
-    uint8_t* buffer = reinterpret_cast<uint8_t*>(get_device_io_addr(offset));
 
     // TODO: these are chip functions, figure out how to have these
     // inside sysmem buffer, or we keep API as it is and make application send
     // proper coordinates.
     // core = translate_chip_coord_virtual_to_translated(core);
 
-    tlb_data config{};
-    config.local_offset = addr;
-    config.x_end = core.x;
-    config.y_end = core.y;
-    config.noc_sel = is_selected_noc1() ? 1 : 0;
-    config.ordering = tlb_data::Relaxed;
-    config.static_vc = pci_device_->get_architecture_implementation()->get_static_vc();
-
-    TlbWindow* tlb_window = get_cached_tlb_window();
-    tlb_window->configure(config);
-
-    auto axi_address_base = pci_device_->get_architecture_implementation()
-                                ->get_tlb_configuration(tlb_window->handle_ref().get_tlb_id())
-                                .tlb_offset;
-    const size_t tlb_handle_size = tlb_window->handle_ref().get_size();
-
-    // In order to properly initiate DMA transfer, we need to calculate the offset into the TLB window
-    // based on the target address. Bitwise operations work in this case since all our TLB windows are power-of-two
-    // sized.
-    auto axi_address = axi_address_base + (addr & (tlb_handle_size - 1));
-
-    while (size > 0) {
-        auto tlb_size = tlb_window->get_size();
-        size_t transfer_size = std::min({size, tlb_size});
-
-        tt_device_->dma_d2h_zero_copy(buffer, axi_address, transfer_size);
-
-        size -= transfer_size;
-        addr += transfer_size;
-        buffer += transfer_size;
-
-        config.local_offset = addr;
-        tlb_window->configure(config);
-        axi_address = axi_address_base + (addr - (addr & ~(tlb_handle_size - 1)));
-    }
+    bool success = tt_device_->get_dma_interface()->dma_read_zero_copy(
+        get_device_io_addr(offset), addr, size, core, get_selected_noc_id());
+    UMD_ASSERT(
+        success,
+        error::RuntimeError,
+        fmt::format(
+            "DMA read from device failed: DMA buffer is not allocated on PCI device {}.",
+            pci_device_->get_device_num()));
 }
 
 SysmemBuffer::~SysmemBuffer() {
@@ -218,15 +139,6 @@ void SysmemBuffer::validate(const size_t offset) const {
             error::RuntimeError,
             fmt::format("Offset {:#x} is out of bounds for SysmemBuffer of size {:#x}", offset, buffer_size_));
     }
-}
-
-TlbWindow* SysmemBuffer::get_cached_tlb_window() {
-    if (cached_tlb_window == nullptr) {
-        cached_tlb_window = std::make_unique<SiliconTlbWindow>(pci_device_->allocate_tlb(
-            pci_device_->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::WC));
-        return cached_tlb_window.get();
-    }
-    return cached_tlb_window.get();
 }
 
 }  // namespace tt::umd

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -168,21 +168,48 @@ uint32_t PcieProtocol::bar_read32(uint32_t addr) {
 
 PCIDevice* PcieProtocol::get_pci_device() { return pci_device_.get(); }
 
-bool PcieProtocol::dma_write_to_device(const void* src, size_t size, tt_xy_pair core, uint64_t addr, NocId noc_id) {
+bool PcieProtocol::dma_write(const void* src, uint64_t dst_addr, size_t size, tt_xy_pair core, NocId noc_id) {
     // const_cast is safe here: dma_transfer only reads from the buffer in H2D direction (memcpy into DMA buffer).
     // dma_transfer uses void* to handle both H2D (read) and D2H (write) in a single function.
     // TODO: Split dma_transfer into separate H2D/D2H functions to remove this cast.
     return dma_transfer(
-        const_cast<void*>(src), size, addr, create_dma_tlb_config(addr, core, noc_id), DmaDirection::H2D);  // NOLINT
+        const_cast<void*>(src),  // NOLINT
+        size,
+        dst_addr,
+        create_dma_tlb_config(dst_addr, core, noc_id),
+        DmaDirection::H2D);
 }
 
-bool PcieProtocol::dma_read_from_device(void* dst, size_t size, tt_xy_pair core, uint64_t addr, NocId noc_id) {
-    return dma_transfer(dst, size, addr, create_dma_tlb_config(addr, core, noc_id), DmaDirection::D2H);
+bool PcieProtocol::dma_read(void* dst, uint64_t src_addr, size_t size, tt_xy_pair core, NocId noc_id) {
+    return dma_transfer(dst, size, src_addr, create_dma_tlb_config(src_addr, core, noc_id), DmaDirection::D2H);
 }
 
 bool PcieProtocol::dma_multicast_write(
-    void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) {
-    return dma_transfer(src, size, addr, create_dma_tlb_config(addr, core_end, noc_id, core_start), DmaDirection::H2D);
+    const void* src, uint64_t dst_addr, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, NocId noc_id) {
+    return dma_transfer(
+        const_cast<void*>(src),  // NOLINT
+        size,
+        dst_addr,
+        create_dma_tlb_config(dst_addr, core_end, noc_id, core_start),
+        DmaDirection::H2D);
+}
+
+bool PcieProtocol::dma_read_zero_copy(
+    uint64_t dst_iova, uint64_t src_addr, size_t size, tt_xy_pair core, NocId noc_id) {
+    return dma_transfer_zero_copy(
+        dst_iova, size, src_addr, create_dma_tlb_config(src_addr, core, noc_id), DmaDirection::D2H);
+}
+
+bool PcieProtocol::dma_write_zero_copy(
+    uint64_t src_iova, uint64_t dst_addr, size_t size, tt_xy_pair core, NocId noc_id) {
+    return dma_transfer_zero_copy(
+        src_iova, size, dst_addr, create_dma_tlb_config(dst_addr, core, noc_id), DmaDirection::H2D);
+}
+
+bool PcieProtocol::dma_multicast_write_zero_copy(
+    uint64_t src_iova, uint64_t dst_addr, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, NocId noc_id) {
+    return dma_transfer_zero_copy(
+        src_iova, size, dst_addr, create_dma_tlb_config(dst_addr, core_end, noc_id, core_start), DmaDirection::H2D);
 }
 
 // Creates a TLB config for DMA transfers. Parameters are named core_end/core_start to match
@@ -241,6 +268,47 @@ bool PcieProtocol::dma_transfer(void* buffer, size_t size, uint64_t addr, tlb_da
         size -= transfer_size;
         addr += transfer_size;
         buf += transfer_size;
+
+        config.local_offset = addr;
+        tlb_window->configure(config);
+        axi_address = axi_address_base + (addr - (addr & ~(tlb_handle_size - 1)));
+    }
+
+    return true;
+}
+
+bool PcieProtocol::dma_transfer_zero_copy(
+    uint64_t iova, size_t size, uint64_t addr, tlb_data config, DmaDirection direction) {
+    std::scoped_lock lock(dma_mutex_);
+    DmaBuffer& dma_buffer = pci_device_->get_dma_buffer();
+
+    if (dma_buffer.buffer == nullptr) {
+        log_warning(LogUMD, "DMA buffer was not allocated for PCI device {}.", pci_device_->get_device_num());
+        return false;
+    }
+
+    TlbWindow* tlb_window = get_cached_dma_tlb_window(config);
+
+    auto axi_address_base = pci_device_->get_architecture_implementation()
+                                ->get_tlb_configuration(tlb_window->handle_ref().get_tlb_id())
+                                .tlb_offset;
+
+    const size_t tlb_handle_size = tlb_window->handle_ref().get_size();
+    auto axi_address = axi_address_base + (addr - (addr & ~(tlb_handle_size - 1)));
+
+    while (size > 0) {
+        auto tlb_size = tlb_window->get_size();
+        size_t transfer_size = std::min(size, tlb_size);
+
+        if (direction == DmaDirection::H2D) {
+            dma_h2d_transfer(static_cast<uint32_t>(axi_address), iova, transfer_size);
+        } else {
+            dma_d2h_transfer(iova, static_cast<uint32_t>(axi_address), transfer_size);
+        }
+
+        size -= transfer_size;
+        addr += transfer_size;
+        iova += transfer_size;
 
         config.local_offset = addr;
         tlb_window->configure(config);

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -811,6 +811,36 @@ void TTDevice::dma_multicast_write(
     noc_multicast_write(src, size, core_start, core_end, addr, noc_id);
 }
 
+void TTDevice::dma_read_zero_copy(uint64_t dst_iova, uint64_t src_addr, size_t size, CoreCoord core, NocId noc_id) {
+    ZoneScopedC(tracy::Color::MediumPurple);
+    if (is_remote_tt_device) {
+        UMD_THROW(error::RuntimeError, "DMA zero-copy read not supported for remote device.");
+    }
+    auto pcie_dma_lock =
+        lock_manager.acquire_mutex(MutexType::PCIE_DMA, communication_device_id_, communication_device_type_);
+
+    bool dma_success =
+        get_dma_interface()->dma_read_zero_copy(dst_iova, src_addr, size, resolve_coordinate(core, noc_id), noc_id);
+    if (!dma_success) {
+        UMD_THROW(error::RuntimeError, "DMA zero-copy read requires a functional DMA interface.");
+    }
+}
+
+void TTDevice::dma_write_zero_copy(uint64_t src_iova, uint64_t dst_addr, size_t size, CoreCoord core, NocId noc_id) {
+    ZoneScopedC(tracy::Color::MediumPurple);
+    if (is_remote_tt_device) {
+        UMD_THROW(error::RuntimeError, "DMA zero-copy write not supported for remote device.");
+    }
+    auto pcie_dma_lock =
+        lock_manager.acquire_mutex(MutexType::PCIE_DMA, communication_device_id_, communication_device_type_);
+
+    bool dma_success =
+        get_dma_interface()->dma_write_zero_copy(src_iova, dst_addr, size, resolve_coordinate(core, noc_id), noc_id);
+    if (!dma_success) {
+        UMD_THROW(error::RuntimeError, "DMA zero-copy write requires a functional DMA interface.");
+    }
+}
+
 void TTDevice::dma_d2h(void *dst, uint32_t src, size_t size) { get_pcie_interface()->dma_d2h(dst, src, size); }
 
 void TTDevice::dma_h2d(uint32_t dst, const void *src, size_t size) { get_pcie_interface()->dma_h2d(dst, src, size); }

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -822,7 +822,7 @@ void TTDevice::dma_read_zero_copy(uint64_t dst_iova, uint64_t src_addr, size_t s
     bool dma_success =
         get_dma_interface()->dma_read_zero_copy(dst_iova, src_addr, size, resolve_coordinate(core, noc_id), noc_id);
     if (!dma_success) {
-        UMD_THROW(error::RuntimeError, "DMA zero-copy read requires a functional DMA interface.");
+        UMD_THROW(error::RuntimeError, "DMA zero-copy read failed: no DMA buffer allocated for this device.");
     }
 }
 
@@ -837,7 +837,7 @@ void TTDevice::dma_write_zero_copy(uint64_t src_iova, uint64_t dst_addr, size_t 
     bool dma_success =
         get_dma_interface()->dma_write_zero_copy(src_iova, dst_addr, size, resolve_coordinate(core, noc_id), noc_id);
     if (!dma_success) {
-        UMD_THROW(error::RuntimeError, "DMA zero-copy write requires a functional DMA interface.");
+        UMD_THROW(error::RuntimeError, "DMA zero-copy write failed: no DMA buffer allocated for this device.");
     }
 }
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -31,6 +31,7 @@
 #include "umd/device/tt_device/blackhole_tt_device.hpp"
 #include "umd/device/tt_device/hang_detection/hang_detector.hpp"
 #include "umd/device/tt_device/hang_detection/hang_detector_implementation.hpp"
+#include "umd/device/tt_device/protocol/dma_interface.hpp"
 #include "umd/device/tt_device/protocol/jtag_interface.hpp"
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
@@ -76,6 +77,7 @@ TTDevice::TTDevice(
 
     auto pcie_protocol = std::make_unique<PcieProtocol>(std::move(pci_device), use_safe_api);
     pcie_capabilities_ = pcie_protocol.get();
+    dma_capabilities_ = pcie_protocol.get();
     device_protocol_ = std::move(pcie_protocol);
     // Initialize PCIe DMA mutex through LockManager for cross-process synchronization.
     lock_manager.initialize_mutex(MutexType::PCIE_DMA, communication_device_id_, communication_device_type_);
@@ -366,6 +368,13 @@ PcieInterface *TTDevice::get_pcie_interface() {
         UMD_THROW(error::RuntimeError, "PCIe interface is not available for this device.");
     }
     return pcie_capabilities_;
+}
+
+DmaInterface *TTDevice::get_dma_interface() {
+    if (!dma_capabilities_) {
+        UMD_THROW(error::RuntimeError, "DMA interface is not available for this device.");
+    }
+    return dma_capabilities_;
 }
 
 JtagInterface *TTDevice::get_jtag_interface() {
@@ -751,8 +760,7 @@ void TTDevice::dma_write_to_device(const void *src, size_t size, CoreCoord core,
         lock_manager.acquire_mutex(MutexType::PCIE_DMA, communication_device_id_, communication_device_type_);
 
     // Returns true if DMA transfer succeeded, false if DMA is not available.
-    bool dma_success =
-        get_pcie_interface()->dma_write_to_device(src, size, resolve_coordinate(core, noc_id), addr, noc_id);
+    bool dma_success = get_dma_interface()->dma_write(src, addr, size, resolve_coordinate(core, noc_id), noc_id);
     if (dma_success) {
         return;
     }
@@ -771,8 +779,7 @@ void TTDevice::dma_read_from_device(void *dst, size_t size, CoreCoord core, uint
         lock_manager.acquire_mutex(MutexType::PCIE_DMA, communication_device_id_, communication_device_type_);
 
     // Returns true if DMA transfer succeeded, false if DMA is not available.
-    bool dma_success =
-        get_pcie_interface()->dma_read_from_device(dst, size, resolve_coordinate(core, noc_id), addr, noc_id);
+    bool dma_success = get_dma_interface()->dma_read(dst, addr, size, resolve_coordinate(core, noc_id), noc_id);
     if (dma_success) {
         return;
     }
@@ -792,8 +799,8 @@ void TTDevice::dma_multicast_write(
         lock_manager.acquire_mutex(MutexType::PCIE_DMA, communication_device_id_, communication_device_type_);
 
     // Returns true if DMA transfer succeeded, false if DMA is not available.
-    bool dma_success = get_pcie_interface()->dma_multicast_write(
-        src, size, resolve_coordinate(core_start, noc_id), resolve_coordinate(core_end, noc_id), addr, noc_id);
+    bool dma_success = get_dma_interface()->dma_multicast_write(
+        src, addr, size, resolve_coordinate(core_start, noc_id), resolve_coordinate(core_end, noc_id), noc_id);
 
     if (dma_success) {
         return;


### PR DESCRIPTION
### Issue
#2880

### Description
DMA transfers were bundled into PcieInterface, preventing reuse across different transports. Introduce a standalone DmaInterface (bounce-buffer dma_read/dma_write/dma_multicast_write plus zero-copy variants) matching the Base API spec exactly, implemented by PcieProtocol alongside DeviceProtocol and PcieInterface.

Migrate SysmemBuffer's DMA transfers onto the new interface: it previously duplicated TLB/AXI-address resolution and called the raw-address zero-copy primitives directly, which only worked for PCIe. It now resolves through DmaInterface's zero-copy methods.

### List of the changes
 - Create DmaInterface matching the Base API spec exactly (bounce-buffer + zero-copy DMA), implemented by PcieProtocol
 - Remove the 3 core DMA methods from PcieInterface, now covered by DmaInterface
 - Migrate SysmemBuffer's DMA transfers onto DmaInterface's zero-copy methods, dropping its duplicated address resolution
 - Add TTDevice::dma_read_zero_copy/dma_write_zero_copy matching the spec, used by SysmemBuffer

### Testing
CI.

### API Changes
This PR has API changes.
