### PR TITLE
Trim PcieInterface to Base API Specification

### DIFF
--- a/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
@@ -6,6 +6,9 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
+
+#include "umd/device/types/noc_id.hpp"
 
 namespace tt::umd {
 
@@ -38,6 +41,19 @@ public:
      * @return int NUMA node ID, or -1 if the system is non-NUMA.
      */
     virtual int get_numa_node() const = 0;
+
+    /**
+     * @brief Registers the callback consulted on an IO-op timeout to distinguish a hung NOC from a
+     * slow one.
+     *
+     * Temporary: this is an implementation detail rather than
+     * something the Base API spec should own. It lives here only until we align api
+     * with TTDeviceModel; move/remove it at that point.
+     *
+     * @param hang_check Callback invoked with the NOC id of the in-flight op; an empty callback
+     * disables hang detection.
+     */
+    virtual void set_io_timeout_callback(const std::function<bool(NocId)>& hang_check) = 0;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
@@ -5,43 +5,39 @@
  */
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
-#include <functional>
-
-#include "umd/device/types/noc_id.hpp"
-#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 
-class PCIDevice;
-
 /**
- * PcieInterface defines PCIe-specific operations beyond the basic DeviceProtocol.
+ * @brief PCIe-specific device access: BAR register I/O and NUMA topology.
  *
- * This includes BAR register access, NOC multicast writes, and direct access to the underlying
- * PCIDevice.
+ * Exposes operations that are only meaningful for PCIe-connected devices.
+ * Available from @ref TTDeviceModel when the active transport is PCIe.
  */
 class PcieInterface {
 public:
     virtual ~PcieInterface() = default;
 
-    virtual PCIDevice* get_pci_device() = 0;
-
-    virtual void dma_d2h(void* dst, uint32_t src, size_t size) = 0;
-    virtual void dma_d2h_zero_copy(void* dst, uint32_t src, size_t size) = 0;
-    virtual void dma_h2d(uint32_t dst, const void* src, size_t size) = 0;
-    virtual void dma_h2d_zero_copy(uint32_t dst, const void* src, size_t size) = 0;
-
-    virtual void noc_multicast_write(
-        const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) = 0;
-
+    /**
+     * @brief Writes a 32-bit value to a BAR-relative device address.
+     * @param addr BAR-relative address.
+     * @param data The 32-bit value to write.
+     */
     virtual void bar_write32(uint32_t addr, uint32_t data) = 0;
+
+    /**
+     * @brief Reads a 32-bit value from a BAR-relative device address.
+     * @param addr BAR-relative address.
+     * @return uint32_t The value read.
+     */
     virtual uint32_t bar_read32(uint32_t addr) = 0;
 
-    // Sets the hang check invoked on an IO-op timeout: returns true if the in-flight NOC is hung (abort),
-    // false to continue.
-    virtual void set_io_timeout_callback(const std::function<bool(NocId)>& hang_check) = 0;
+    /**
+     * @brief Returns the NUMA node associated with this PCIe device.
+     * @return int NUMA node ID, or -1 if the system is non-NUMA.
+     */
+    virtual int get_numa_node() const = 0;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
@@ -13,7 +13,7 @@ namespace tt::umd {
  * @brief PCIe-specific device access: BAR register I/O and NUMA topology.
  *
  * Exposes operations that are only meaningful for PCIe-connected devices.
- * Available from @ref TTDeviceModel when the active transport is PCIe.
+ * Available from TTDevice::get_pcie_interface() when the active transport is PCIe.
  */
 class PcieInterface {
 public:

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -56,6 +56,7 @@ public:
     void bar_write32(uint32_t addr, uint32_t data) override;
     uint32_t bar_read32(uint32_t addr) override;
     int get_numa_node() const override;
+    void set_io_timeout_callback(const std::function<bool(NocId)>& hang_check) override;
 
     // DmaInterface.
     [[nodiscard]] bool dma_read(void* dst, uint64_t src_addr, size_t size, tt_xy_pair core, NocId noc_id) override;
@@ -72,7 +73,7 @@ public:
 
     // Not part of any Base API interface: internal PCIe plumbing reached by TTDevice via the
     // concrete PcieProtocol rather than through PcieInterface/DmaInterface.
-    void set_io_timeout_callback(const std::function<bool(NocId)>& hang_check);
+    // TODO: delete this along with TTDevice::get_pci_device() once callers go through PcieInterface only.
     PCIDevice* get_pci_device();
 
 private:

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -53,16 +53,9 @@ public:
     int get_mmio_id() override;
 
     // PcieInterface.
-    void set_io_timeout_callback(const std::function<bool(NocId)>& hang_check) override;
-    PCIDevice* get_pci_device() override;
-    void dma_d2h(void* dst, uint32_t src, size_t size) override;
-    void dma_d2h_zero_copy(void* dst, uint32_t src, size_t size) override;
-    void dma_h2d(uint32_t dst, const void* src, size_t size) override;
-    void dma_h2d_zero_copy(uint32_t dst, const void* src, size_t size) override;
-    void noc_multicast_write(
-        const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) override;
     void bar_write32(uint32_t addr, uint32_t data) override;
     uint32_t bar_read32(uint32_t addr) override;
+    int get_numa_node() const override;
 
     // DmaInterface.
     [[nodiscard]] bool dma_read(void* dst, uint64_t src_addr, size_t size, tt_xy_pair core, NocId noc_id) override;
@@ -77,6 +70,11 @@ public:
         uint64_t src_iova, uint64_t dst_addr, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, NocId noc_id)
         override;
 
+    // Not part of any Base API interface: internal PCIe plumbing reached by TTDevice via the
+    // concrete PcieProtocol rather than through PcieInterface/DmaInterface.
+    void set_io_timeout_callback(const std::function<bool(NocId)>& hang_check);
+    PCIDevice* get_pci_device();
+
 private:
     TlbWindow* get_cached_tlb_window();
     TlbWindow* get_cached_dma_tlb_window(tlb_data config);
@@ -86,6 +84,9 @@ private:
 
     void dma_d2h_transfer(uint64_t dst, uint32_t src, size_t size);
     void dma_h2d_transfer(uint32_t dst, uint64_t src, size_t size);
+
+    void noc_multicast_write(
+        const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id);
 
     enum class DmaDirection { H2D, D2H };
     tlb_data create_dma_tlb_config(

--- a/device/api/umd/device/tt_device/simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/simulation_tt_device.hpp
@@ -57,10 +57,6 @@ public:
     void write_to_device(
         const void* mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id = NocId::DEFAULT_NOC) override;
 
-    void dma_d2h(void* dst, uint32_t src, size_t size) override;
-    void dma_d2h_zero_copy(void* dst, uint32_t src, size_t size) override;
-    void dma_h2d(uint32_t dst, const void* src, size_t size) override;
-    void dma_h2d_zero_copy(uint32_t dst, const void* src, size_t size) override;
     void read_from_arc_apb(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
     void write_to_arc_apb(const void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;
     void read_from_arc_csm(void* mem_ptr, uint64_t arc_addr_offset, [[maybe_unused]] size_t size) override;

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -52,6 +52,7 @@ class JtagDevice;
 class JtagInterface;
 class PCIDevice;
 class PcieInterface;
+class PcieProtocol;
 class RemoteInterface;
 class TLBManager;
 enum class NocId : uint8_t;
@@ -163,46 +164,6 @@ public:
      * @throws std::runtime_error if a confirmed hang is detected and action is Throw.
      */
     bool is_noc_hung(NocId noc, HangAction action = HangAction::THROW);
-
-    /**
-     * DMA transfer from device to host.
-     *
-     * @param dst destination buffer
-     * @param src AXI address corresponding to inbound PCIe TLB window; src % 4 == 0
-     * @param size number of bytes
-     * @throws std::runtime_error if the DMA transfer fails
-     */
-    virtual void dma_d2h(void *dst, uint32_t src, size_t size);
-
-    /**
-     * DMA transfer from device to host.
-     *
-     * @param dst destination buffer
-     * @param src AXI address corresponding to inbound PCIe TLB window; src % 4 == 0
-     * @param size number of bytes
-     * @throws std::runtime_error if the DMA transfer fails
-     */
-    virtual void dma_d2h_zero_copy(void *dst, uint32_t src, size_t size);
-
-    /**
-     * DMA transfer from host to device.
-     *
-     * @param dst AXI address corresponding to inbound PCIe TLB window; dst % 4 == 0
-     * @param src source buffer
-     * @param size number of bytes
-     * @throws std::runtime_error if the DMA transfer fails
-     */
-    virtual void dma_h2d(uint32_t dst, const void *src, size_t size);
-
-    /**
-     * DMA transfer from host to device.
-     *
-     * @param dst AXI address corresponding to inbound PCIe TLB window; dst % 4 == 0
-     * @param src source buffer
-     * @param size number of bytes
-     * @throws std::runtime_error if the DMA transfer fails
-     */
-    virtual void dma_h2d_zero_copy(uint32_t dst, const void *src, size_t size);
 
     // Read/write functions that always use same TLB entry. This is not supposed to be used
     // on any code path that is performance critical. It is used to read/write the data needed
@@ -616,6 +577,7 @@ private:
     std::unique_ptr<HangDetector> hang_detector_;
     PcieInterface *pcie_capabilities_ = nullptr;
     DmaInterface *dma_capabilities_ = nullptr;
+    PcieProtocol *pcie_protocol_ = nullptr;
     JtagInterface *jtag_capabilities_ = nullptr;
     RemoteInterface *remote_capabilities_ = nullptr;
 };

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -178,6 +178,57 @@ public:
     virtual void write_to_device_reg(
         const void *mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id = NocId::DEFAULT_NOC);
 
+    virtual void dma_write_to_device(
+        const void *src, size_t size, CoreCoord core, uint64_t addr, NocId noc_id = NocId::DEFAULT_NOC);
+
+    virtual void dma_read_from_device(
+        void *dst, size_t size, CoreCoord core, uint64_t addr, NocId noc_id = NocId::DEFAULT_NOC);
+
+    /**
+     * DMA multicast write function that writes data to multiple cores on the NOC grid. Similar to noc_multicast_write
+     * but uses DMA for better performance. Multicast writes data to a grid of cores. Cores must be specified in the
+     * translated coordinate system so that the write lands on the intended cores.
+     *
+     * @param src pointer to memory from which the data is sent
+     * @param size number of bytes
+     * @param core_start starting core coordinates (x,y) of the multicast write
+     * @param core_end ending core coordinates (x,y) of the multicast write
+     * @param addr address on the device where data will be written
+     */
+    virtual void dma_multicast_write(
+        void *src,
+        size_t size,
+        CoreCoord core_start,
+        CoreCoord core_end,
+        uint64_t addr,
+        NocId noc_id = NocId::DEFAULT_NOC);
+
+    /**
+     * Zero-copy Device-to-Host DMA into caller-managed pinned memory, bypassing the internal
+     * staging buffer. Unlike dma_read_from_device, there is no non-DMA fallback: this throws if
+     * DMA is unavailable.
+     *
+     * @param dst_iova IOVA of the destination pinned host memory buffer.
+     * @param src_addr source address on the target core.
+     * @param size number of bytes
+     * @param core source core coordinates
+     */
+    virtual void dma_read_zero_copy(
+        uint64_t dst_iova, uint64_t src_addr, size_t size, CoreCoord core, NocId noc_id = NocId::DEFAULT_NOC);
+
+    /**
+     * Zero-copy Host-to-Device DMA from caller-managed pinned memory, bypassing the internal
+     * staging buffer. Unlike dma_write_to_device, there is no non-DMA fallback: this throws if
+     * DMA is unavailable.
+     *
+     * @param src_iova IOVA of the source pinned host memory buffer.
+     * @param dst_addr destination address on the target core.
+     * @param size number of bytes
+     * @param core target core coordinates
+     */
+    virtual void dma_write_zero_copy(
+        uint64_t src_iova, uint64_t dst_addr, size_t size, CoreCoord core, NocId noc_id = NocId::DEFAULT_NOC);
+
     /**
      * NOC multicast write function that will write data to multiple cores on NOC grid. Multicast writes data to a grid
      * of cores. Ideally cores should be in translated coordinate system. Putting cores in translated coordinate systems
@@ -439,58 +490,7 @@ public:
     virtual std::unique_ptr<TlbWindow> get_io_window(
         tlb_data config, TlbMapping mapping = TlbMapping::WC, size_t size = 0);
 
-    virtual void dma_write_to_device(
-        const void *src, size_t size, CoreCoord core, uint64_t addr, NocId noc_id = NocId::DEFAULT_NOC);
-
-    virtual void dma_read_from_device(
-        void *dst, size_t size, CoreCoord core, uint64_t addr, NocId noc_id = NocId::DEFAULT_NOC);
-
     static void set_sigbus_safe_handler(bool set_safe_handler);
-
-    /**
-     * DMA multicast write function that writes data to multiple cores on the NOC grid. Similar to noc_multicast_write
-     * but uses DMA for better performance. Multicast writes data to a grid of cores. Cores must be specified in the
-     * translated coordinate system so that the write lands on the intended cores.
-     *
-     * @param src pointer to memory from which the data is sent
-     * @param size number of bytes
-     * @param core_start starting core coordinates (x,y) of the multicast write
-     * @param core_end ending core coordinates (x,y) of the multicast write
-     * @param addr address on the device where data will be written
-     */
-    virtual void dma_multicast_write(
-        void *src,
-        size_t size,
-        CoreCoord core_start,
-        CoreCoord core_end,
-        uint64_t addr,
-        NocId noc_id = NocId::DEFAULT_NOC);
-
-    /**
-     * Zero-copy Device-to-Host DMA into caller-managed pinned memory, bypassing the internal
-     * staging buffer. Unlike dma_read_from_device, there is no non-DMA fallback: this throws if
-     * DMA is unavailable.
-     *
-     * @param dst_iova IOVA of the destination pinned host memory buffer.
-     * @param src_addr source address on the target core.
-     * @param size number of bytes
-     * @param core source core coordinates
-     */
-    virtual void dma_read_zero_copy(
-        uint64_t dst_iova, uint64_t src_addr, size_t size, CoreCoord core, NocId noc_id = NocId::DEFAULT_NOC);
-
-    /**
-     * Zero-copy Host-to-Device DMA from caller-managed pinned memory, bypassing the internal
-     * staging buffer. Unlike dma_write_to_device, there is no non-DMA fallback: this throws if
-     * DMA is unavailable.
-     *
-     * @param src_iova IOVA of the source pinned host memory buffer.
-     * @param dst_addr destination address on the target core.
-     * @param size number of bytes
-     * @param core target core coordinates
-     */
-    virtual void dma_write_zero_copy(
-        uint64_t src_iova, uint64_t dst_addr, size_t size, CoreCoord core, NocId noc_id = NocId::DEFAULT_NOC);
 
     /**
      * Read the training status of the given ETH core.

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -168,6 +168,8 @@ uint32_t PcieProtocol::bar_read32(uint32_t addr) {
 
 PCIDevice* PcieProtocol::get_pci_device() { return pci_device_.get(); }
 
+int PcieProtocol::get_numa_node() const { return pci_device_->get_numa_node(); }
+
 bool PcieProtocol::dma_write(const void* src, uint64_t dst_addr, size_t size, tt_xy_pair core, NocId noc_id) {
     // const_cast is safe here: dma_transfer only reads from the buffer in H2D direction (memcpy into DMA buffer).
     // dma_transfer uses void* to handle both H2D (read) and D2H (write) in a single function.
@@ -327,44 +329,6 @@ TlbWindow* PcieProtocol::get_cached_dma_tlb_window(tlb_data config) {
 
     cached_dma_tlb_window_->configure(config);
     return cached_dma_tlb_window_.get();
-}
-
-// TODO: These public DMA methods are locked for safety since they can be called directly by
-// consumers. The goal is to make the protocol class lockless and push synchronization to
-// higher-level components. dma_transfer() calls the private _transfer methods directly to
-// avoid lock contention.
-void PcieProtocol::dma_d2h(void* dst, uint32_t src, size_t size) {
-    std::scoped_lock lock(dma_mutex_);
-    DmaBuffer& dma_buffer = pci_device_->get_dma_buffer();
-
-    if (size > dma_buffer.size) {
-        UMD_THROW(error::RuntimeError, "DMA size exceeds buffer size.");
-    }
-
-    dma_d2h_transfer(dma_buffer.buffer_pa, src, size);
-    std::memcpy(dst, dma_buffer.buffer, size);
-}
-
-void PcieProtocol::dma_d2h_zero_copy(void* dst, uint32_t src, size_t size) {
-    std::scoped_lock lock(dma_mutex_);
-    dma_d2h_transfer(reinterpret_cast<uint64_t>(dst), src, size);
-}
-
-void PcieProtocol::dma_h2d(uint32_t dst, const void* src, size_t size) {
-    std::scoped_lock lock(dma_mutex_);
-    DmaBuffer& dma_buffer = pci_device_->get_dma_buffer();
-
-    if (size > dma_buffer.size) {
-        UMD_THROW(error::RuntimeError, "DMA size exceeds buffer size.");
-    }
-
-    std::memcpy(dma_buffer.buffer, src, size);
-    dma_h2d_transfer(dst, dma_buffer.buffer_pa, size);
-}
-
-void PcieProtocol::dma_h2d_zero_copy(uint32_t dst, const void* src, size_t size) {
-    std::scoped_lock lock(dma_mutex_);
-    dma_h2d_transfer(dst, reinterpret_cast<uint64_t>(src), size);
 }
 
 void PcieProtocol::dma_d2h_transfer(const uint64_t dst, const uint32_t src, const size_t size) {

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -313,22 +313,6 @@ void SimulationTTDevice::noc_multicast_write(const void* src, size_t size, uint6
     noc_multicast_write(src, size, start, end, addr, noc_id);
 }
 
-void SimulationTTDevice::dma_d2h(void* dst, uint32_t src, size_t size) {
-    UMD_THROW(error::RuntimeError, "DMA operations are not supported for simulation devices.");
-}
-
-void SimulationTTDevice::dma_d2h_zero_copy(void* dst, uint32_t src, size_t size) {
-    UMD_THROW(error::RuntimeError, "DMA operations are not supported for simulation devices.");
-}
-
-void SimulationTTDevice::dma_h2d(uint32_t dst, const void* src, size_t size) {
-    UMD_THROW(error::RuntimeError, "DMA operations are not supported for simulation devices.");
-}
-
-void SimulationTTDevice::dma_h2d_zero_copy(uint32_t dst, const void* src, size_t size) {
-    UMD_THROW(error::RuntimeError, "DMA operations are not supported for simulation devices.");
-}
-
 void SimulationTTDevice::dma_multicast_write(
     void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr, NocId noc_id) {
     UMD_THROW(error::RuntimeError, "DMA multicast write is not supported for simulation devices.");

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -78,6 +78,7 @@ TTDevice::TTDevice(
     auto pcie_protocol = std::make_unique<PcieProtocol>(std::move(pci_device), use_safe_api);
     pcie_capabilities_ = pcie_protocol.get();
     dma_capabilities_ = pcie_protocol.get();
+    pcie_protocol_ = pcie_protocol.get();
     device_protocol_ = std::move(pcie_protocol);
     // Initialize PCIe DMA mutex through LockManager for cross-process synchronization.
     lock_manager.initialize_mutex(MutexType::PCIE_DMA, communication_device_id_, communication_device_type_);
@@ -258,7 +259,7 @@ PCIDevice *TTDevice::get_pci_device() {
     if (!pcie_capabilities_) {
         return nullptr;
     }
-    return get_pcie_interface()->get_pci_device();
+    return pcie_protocol_->get_pci_device();
 }
 
 RemoteCommunication *TTDevice::get_remote_communication() {
@@ -432,14 +433,13 @@ void TTDevice::set_hang_detector(std::unique_ptr<HangDetector> hang_detector) {
     // A null detector disables hang detection: clear any previously wired callback and stop before
     // dereferencing it below.
     if (hang_detector_ == nullptr) {
-        pcie_capabilities_->set_io_timeout_callback({});
+        pcie_protocol_->set_io_timeout_callback({});
         return;
     }
 
     // Route a single-op memcpy overrun to a NOC liveness check on the in-flight op's NOC: a hung NOC
     // aborts the transfer with DeviceTimeoutError; a healthy NOC lets it continue.
-    pcie_capabilities_->set_io_timeout_callback(
-        [this](NocId noc) -> bool { return is_noc_hung(noc, HangAction::RETURN); });
+    pcie_protocol_->set_io_timeout_callback([this](NocId noc) -> bool { return is_noc_hung(noc, HangAction::RETURN); });
 
     // The liveness check runs from inside a timed-out memcpy that holds io_lock_, so it must read through a
     // dedicated, separately-locked window rather than the protocol's cached window. The window and lock live
@@ -829,18 +829,6 @@ void TTDevice::dma_write_zero_copy(uint64_t src_iova, uint64_t dst_addr, size_t 
     if (!dma_success) {
         UMD_THROW(error::RuntimeError, "DMA zero-copy write failed: no DMA buffer allocated for this device.");
     }
-}
-
-void TTDevice::dma_d2h(void *dst, uint32_t src, size_t size) { get_pcie_interface()->dma_d2h(dst, src, size); }
-
-void TTDevice::dma_h2d(uint32_t dst, const void *src, size_t size) { get_pcie_interface()->dma_h2d(dst, src, size); }
-
-void TTDevice::dma_d2h_zero_copy(void *dst, uint32_t src, size_t size) {
-    get_pcie_interface()->dma_d2h_zero_copy(dst, src, size);
-}
-
-void TTDevice::dma_h2d_zero_copy(uint32_t dst, const void *src, size_t size) {
-    get_pcie_interface()->dma_h2d_zero_copy(dst, src, size);
 }
 
 const SocDescriptor &TTDevice::get_soc_descriptor() const {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -433,13 +433,14 @@ void TTDevice::set_hang_detector(std::unique_ptr<HangDetector> hang_detector) {
     // A null detector disables hang detection: clear any previously wired callback and stop before
     // dereferencing it below.
     if (hang_detector_ == nullptr) {
-        pcie_protocol_->set_io_timeout_callback({});
+        pcie_capabilities_->set_io_timeout_callback({});
         return;
     }
 
     // Route a single-op memcpy overrun to a NOC liveness check on the in-flight op's NOC: a hung NOC
     // aborts the transfer with DeviceTimeoutError; a healthy NOC lets it continue.
-    pcie_protocol_->set_io_timeout_callback([this](NocId noc) -> bool { return is_noc_hung(noc, HangAction::RETURN); });
+    pcie_capabilities_->set_io_timeout_callback(
+        [this](NocId noc) -> bool { return is_noc_hung(noc, HangAction::RETURN); });
 
     // The liveness check runs from inside a timed-out memcpy that holds io_lock_, so it must read through a
     // dedicated, separately-locked window rather than the protocol's cached window. The window and lock live


### PR DESCRIPTION
### Issue
#2879

### Description
PcieInterface bundled BAR I/O, NUMA topology, direct PCIDevice access, NOC multicast writes, and raw-address DMA, making it hard to use individual capabilities independently. Trim it down to exactly bar_write32/bar_read32/get_numa_node per the Base API Specification. (Temporary set_io_timeout_callback left in it until TTDeviceModel is created, and left PCIDevice* in PcieProtocol, to be removed with followup PR).

### List of the changes
 - Trim PcieInterface to bar_write32, bar_read32, get_numa_node
 - Move get_pci_device, noc_multicast_write off PcieInterface onto PcieProtocol directly, reached from TTDevice via a new PcieProtocol* pointer
 - Remove dma_d2h/dma_h2d/dma_d2h_zero_copy/dma_h2d_zero_copy outright (TTDevice, PcieProtocol, SimulationTTDevice) - no call sites left in tt-umd or tt-metal, no entry in the Base API mapping table

### Testing
CI.

### API Changes
 - PcieInterface no longer exposes get_pci_device, noc_multicast_write, or any DMA methods
 - TTDevice no longer exposes dma_d2h, dma_h2d, dma_d2h_zero_copy, dma_h2d_zero_copy
