### PR TITLE
Add TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF kmdlib wrapper (1/4)

### DIFF
--- a/device/api/umd/device/tt_kmd_lib/tt_kmd_lib.h
+++ b/device/api/umd/device/tt_kmd_lib/tt_kmd_lib.h
@@ -556,6 +556,27 @@ int tt_tlb_map(tt_device_t* dev, tt_tlb_t* tlb, tt_noc_addr_config_t* config);
 int tt_tlb_map_unicast(tt_device_t* dev, tt_tlb_t* tlb, uint8_t x, uint8_t y, uint64_t addr);
 
 /**
+ * @brief Export a TLB window as a dma-buf file descriptor for peer-to-peer PCIe DMA.
+ *
+ * The window must already be configured via `tt_tlb_map()` or `tt_tlb_map_unicast()`. The
+ * returned fd is self-sufficient: it pins the window (and device) by refcount, so it survives
+ * `tt_tlb_free()`, closing the device handle, and even device removal. The caller owns the fd
+ * and must close() it when done; the window is returned to the allocation pool only once the
+ * last export on it is released. Requires tt-kmd >= 2.10.0-rc1 and Linux 5.8+.
+ *
+ * The window must have been allocated on this same device handle; the driver checks that ownership.
+ *
+ * @param dev Device handle
+ * @param tlb TLB window handle from `tt_tlb_alloc()`
+ * @param offset Page-aligned byte offset within the window at which the export begins
+ * @param size Page-aligned byte count to export; must be nonzero and not run past the end of the
+ *             window
+ * @param out_fd On success, the dma-buf file descriptor
+ * @return 0 on success, error code on failure
+ */
+int tt_tlb_export_dmabuf(tt_device_t* dev, tt_tlb_t* tlb, uint64_t offset, uint64_t size, int* out_fd);
+
+/**
  * @brief Power flags for use with tt_device_set_power_state().
  */
 enum tt_power_flags {

--- a/device/pcie/ioctl.h
+++ b/device/pcie/ioctl.h
@@ -31,6 +31,7 @@
 #define TENSTORRENT_IOCTL_CONFIGURE_TLB		_IO(TENSTORRENT_IOCTL_MAGIC, 13)
 #define TENSTORRENT_IOCTL_SET_NOC_CLEANUP		_IO(TENSTORRENT_IOCTL_MAGIC, 14)
 #define TENSTORRENT_IOCTL_SET_POWER_STATE		_IO(TENSTORRENT_IOCTL_MAGIC, 15)
+#define TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF	_IO(TENSTORRENT_IOCTL_MAGIC, 16)
 
 // For tenstorrent_mapping.mapping_id. These are not array indices.
 #define TENSTORRENT_MAPPING_UNUSED		0
@@ -368,6 +369,53 @@ struct tenstorrent_power_state {
 #define TT_POWER_FLAG_TENSIX_ENABLE    (1U << 2) /* 1=Enable Tensix, 0=Clock Gate Tensix */
 #define TT_POWER_FLAG_L2CPU_ENABLE     (1U << 3) /* 1=Enable L2CPU,  0=Clock Gate L2CPU */
 	__u16 power_settings[14];
+};
+
+/**
+ * TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF - Export a TLB window as a dma-buf
+ *
+ * Wraps an already-allocated, already-configured TLB window in a dma-buf and
+ * returns a file descriptor for it. That fd can be handed to another
+ * device's driver (e.g. an RDMA NIC via ibv_reg_dmabuf_mr()) so the peer can
+ * perform peer-to-peer PCIe DMA directly into and out of the window. Traffic
+ * routes onto the NOC according to the window's CONFIGURE_TLB setup, with no
+ * Tenstorrent-CPU involvement on the data path.
+ *
+ * The export must be issued on the same file descriptor that allocated the
+ * window. offset and size must be page-aligned and lie within the window;
+ * size of 0 means to the end of the window.
+ *
+ * The fd is the unit of ownership and is self-sufficient. An export pins the
+ * window: FREE_TLB or close() of the owning fd does not return the window to
+ * the allocation pool while the export is live, so the window cannot be
+ * reallocated and reconfigured to redirect a live importer's DMA elsewhere on
+ * the NOC. The window is freed only once the dma-buf is released. This lets
+ * the export survive FREE_TLB, close() of the owning fd, and even device
+ * removal.
+ *
+ * Resetting the device under in-flight P2P DMA can wedge the host hard enough
+ * to require out-of-band recovery, and a pin-only importer cannot be revoked
+ * to prevent the in-flight DMA. RESET_DEVICE is therefore refused with
+ * -EBUSY while any export is live.
+ *
+ * This ioctl requires Linux 5.8+.
+ *
+ * @argsz: Must be sizeof(struct tenstorrent_export_tlb_dmabuf).
+ * @flags: Reserved for future use, must be 0.
+ * @tlb_id: A TLB window id returned by TENSTORRENT_IOCTL_ALLOCATE_TLB.
+ * @fd: OUT: the dma-buf file descriptor.
+ * @offset: Byte offset within the window at which the export begins; must be
+ *          page-aligned.
+ * @size: Number of bytes to export; 0 means to the end of the window. A
+ *        non-zero size must be a multiple of the page size.
+ */
+struct tenstorrent_export_tlb_dmabuf {
+	__u32 argsz;
+	__u32 flags;
+	__u32 tlb_id;
+	__s32 fd;
+	__u64 offset;
+	__u64 size;
 };
 
 #endif

--- a/device/tt_kmd_lib/tt_kmd_lib.c
+++ b/device/tt_kmd_lib/tt_kmd_lib.c
@@ -677,6 +677,34 @@ int tt_tlb_map_unicast(tt_device_t* dev, tt_tlb_t* tlb, uint8_t x, uint8_t y, ui
     return 0;
 }
 
+int tt_tlb_export_dmabuf(tt_device_t* dev, tt_tlb_t* tlb, uint64_t offset, uint64_t size, int* out_fd) {
+    if (dev == NULL || tlb == NULL || out_fd == NULL) {
+        return -EINVAL;
+    }
+
+    /* The driver rejects a zero size, an offset or size that is not page-aligned, or a range that
+     * runs past the end of the window. */
+    const uint64_t page_size = (uint64_t)getpagesize();
+    if (offset > tlb->size || (offset % page_size) != 0 || size == 0 || (size % page_size) != 0 ||
+        (offset + size) > tlb->size) {
+        return -EINVAL;
+    }
+
+    struct tenstorrent_export_tlb_dmabuf export_dmabuf = {0};
+    export_dmabuf.argsz = sizeof(export_dmabuf);
+    export_dmabuf.tlb_id = tlb->id;
+    export_dmabuf.offset = offset;
+    export_dmabuf.size = size;
+
+    if (ioctl(dev->fd, TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF, &export_dmabuf) != 0) {
+        return -errno;
+    }
+
+    *out_fd = export_dmabuf.fd;
+
+    return 0;
+}
+
 int tt_device_set_power_state(tt_device_t* dev, uint16_t power_flags) {
     struct tenstorrent_power_state ps = {0};
     ps.argsz = sizeof(ps);

--- a/device/tt_kmd_lib/tt_kmd_lib.c
+++ b/device/tt_kmd_lib/tt_kmd_lib.c
@@ -686,7 +686,7 @@ int tt_tlb_export_dmabuf(tt_device_t* dev, tt_tlb_t* tlb, uint64_t offset, uint6
      * runs past the end of the window. */
     const uint64_t page_size = (uint64_t)getpagesize();
     if (offset > tlb->size || (offset % page_size) != 0 || size == 0 || (size % page_size) != 0 ||
-        (offset + size) > tlb->size) {
+        size > (tlb->size - offset)) {
         return -EINVAL;
     }
 


### PR DESCRIPTION
Description
Part 1 of 4 splitting #3063 into a stack (kmdlib -> pcidevice -> ttdevice -> cluster) so it lands in smaller reviewable pieces. No behavior change versus #3063, this is a pure reordering of the same commits. Related to issue #2987.

List of the changes
Added TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF and its struct to the vendored kmd ioctl header
Added tt_tlb_export_dmabuf C shim in tt_kmd_lib

Testing
CI
Builds clean standalone, verified device/all links with only this layer applied

API Changes
This PR has API changes.