### PR TITLE
Add PCIDevice::export_tlb_dmabuf and version gating (2/4)

### DIFF
--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -333,6 +333,32 @@ public:
     static bool is_arch_agnostic_reset_supported();
 
     /**
+     * Checks if exporting a TLB window as a dma-buf is supported: requires both a KMD version that
+     * implements the export and a running kernel new enough for the dma-buf infrastructure it
+     * relies on (Linux 5.8+).
+     */
+    static bool is_tlb_dmabuf_export_supported();
+
+    /**
+     * Allocate a dedicated TLB window, configure it per @p config, and export a range of it as a
+     * dma-buf file descriptor for peer-to-peer PCIe DMA (e.g. import into an RDMA NIC via
+     * ibv_reg_dmabuf_mr()). Traffic routes onto the NOC according to @p config.
+     *
+     * The returned fd is the unit of ownership and is self-sufficient: exporting pins the window
+     * and the device by refcount, so the fd stays valid after this call releases the window, and
+     * across closing this device or even device removal. The window returns to the allocation pool
+     * only once the last export on it is released. The caller owns the fd and must close() it.
+     *
+     * @param window_size Size of the TLB window to allocate; must be a size this architecture
+     *                    supports, and must be large enough to cover @p offset + @p size.
+     * @param config NOC configuration for the window. config.local_offset must be aligned to
+     *               @p window_size, since a window's NOC base is size-aligned.
+     * @param offset Page-aligned byte offset within the window at which the export begins.
+     * @param size Page-aligned byte count to export; must be nonzero.
+     */
+    int export_tlb_dmabuf(size_t window_size, const tlb_data &config, uint64_t offset, uint64_t size);
+
+    /**
      * Set the power state of this device via the KMD power API (requires KMD >= 2.6.0).
      * When busy is true, all power domains are requested (max AI clock, PHY wakeup, Tensix and L2CPU enabled).
      * When busy is false, all power flags are released, allowing the device to enter a low-power idle state.

--- a/device/api/umd/device/utils/kmd_versions.hpp
+++ b/device/api/umd/device/utils/kmd_versions.hpp
@@ -41,4 +41,18 @@ inline constexpr SemVer KMD_TLBS = SemVer(1, 34, 0);
  * while application connections remain active.
  */
 inline constexpr SemVer KMD_POWER_STATE = SemVer(2, 6, 0);
+
+/**
+ * KMD version 2.10.0 introduced the TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF IOCTL, which exports an
+ * allocated and configured TLB window as a Linux dma-buf fd for peer-to-peer PCIe DMA (e.g. RDMA
+ * NIC import via ibv_reg_dmabuf_mr()).
+ */
+inline constexpr SemVer KMD_TLB_DMABUF_EXPORT = SemVer(2, 10, 0, 1);
+
+/**
+ * TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF also requires the running kernel itself to be new enough
+ * (Linux 5.8+), independent of the KMD version, since the ioctl relies on dma-buf facilities
+ * introduced in that release.
+ */
+inline constexpr SemVer MIN_KERNEL_TLB_DMABUF_EXPORT = SemVer(5, 8, 0);
 }  // namespace tt::umd

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -999,6 +999,77 @@ tt::ARCH PCIDevice::get_pcie_arch() {
 
 bool PCIDevice::is_arch_agnostic_reset_supported() { return PCIDevice::read_kmd_version() >= KMD_ARCH_AGNOSTIC_RESET; }
 
+bool PCIDevice::is_tlb_dmabuf_export_supported() {
+    return PCIDevice::read_kmd_version() >= KMD_TLB_DMABUF_EXPORT &&
+           PCIDevice::read_kernel_version() >= MIN_KERNEL_TLB_DMABUF_EXPORT;
+}
+
+int PCIDevice::export_tlb_dmabuf(
+    const size_t window_size, const tlb_data &config, const uint64_t offset, const uint64_t size) {
+    UMD_ASSERT(
+        is_tlb_dmabuf_export_supported(),
+        error::RuntimeError,
+        fmt::format(
+            "Exporting a TLB window as a dma-buf requires KMD {} or newer and kernel {} or newer, but this system "
+            "runs KMD {} and kernel {}.",
+            KMD_TLB_DMABUF_EXPORT.str(),
+            MIN_KERNEL_TLB_DMABUF_EXPORT.str(),
+            read_kmd_version().str(),
+            read_kernel_version().str()));
+
+    // This follows the driver's documented export sequence directly (ALLOCATE_TLB, CONFIGURE_TLB,
+    // EXPORT_TLB_DMABUF, FREE_TLB) rather than going through TlbHandle/TlbWindow.
+    tt_tlb_t *tlb = nullptr;
+    int ret = tt_tlb_alloc(tt_device_handle, window_size, TT_MMIO_CACHE_MODE_WC, &tlb);
+    if (ret != 0) {
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format(
+                "Failed to allocate a {} byte TLB window to export as a dma-buf: {}", window_size, strerror(-ret)));
+    }
+
+    // No TlbHandle owns this window, so every path below releases it explicitly. Any new exit added
+    // here must do the same, or the window leaks out of the allocation pool until the process exits.
+    tt_noc_addr_config_t noc_config{};
+    noc_config.addr = config.local_offset;
+    noc_config.x_end = static_cast<uint16_t>(config.x_end);
+    noc_config.y_end = static_cast<uint16_t>(config.y_end);
+    noc_config.x_start = static_cast<uint16_t>(config.x_start);
+    noc_config.y_start = static_cast<uint16_t>(config.y_start);
+    noc_config.noc = static_cast<uint8_t>(config.noc_sel);
+    noc_config.mcast = static_cast<uint8_t>(config.mcast);
+    noc_config.ordering = static_cast<uint8_t>(config.ordering);
+    noc_config.static_vc = static_cast<uint8_t>(config.static_vc);
+
+    ret = tt_tlb_map(tt_device_handle, tlb, &noc_config);
+    if (ret != 0) {
+        tt_tlb_free(tt_device_handle, tlb);
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format(
+                "Failed to configure TLB window for a dma-buf export at NOC address {:#x} on core ({}, {}): {}",
+                config.local_offset,
+                config.x_end,
+                config.y_end,
+                strerror(-ret)));
+    }
+
+    int fd = -1;
+    ret = tt_tlb_export_dmabuf(tt_device_handle, tlb, offset, size, &fd);
+    if (ret != 0) {
+        tt_tlb_free(tt_device_handle, tlb);
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format(
+                "Failed to export TLB window as a dma-buf (offset {:#x}, size {}): {}", offset, size, strerror(-ret)));
+    }
+
+    // Released on success as well: the driver keeps the window pinned for as long as the fd is open.
+    tt_tlb_free(tt_device_handle, tlb);
+
+    return fd;
+}
+
 void PCIDevice::set_power_state(bool busy) {
     if (arch != tt::ARCH::BLACKHOLE) {
         return;

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -1004,6 +1004,8 @@ bool PCIDevice::is_tlb_dmabuf_export_supported() {
            PCIDevice::read_kernel_version() >= MIN_KERNEL_TLB_DMABUF_EXPORT;
 }
 
+// Follows the driver's documented export sequence directly (ALLOCATE_TLB, CONFIGURE_TLB,
+// EXPORT_TLB_DMABUF, FREE_TLB) rather than going through TlbHandle/TlbWindow.
 int PCIDevice::export_tlb_dmabuf(
     const size_t window_size, const tlb_data &config, const uint64_t offset, const uint64_t size) {
     UMD_ASSERT(
@@ -1017,8 +1019,6 @@ int PCIDevice::export_tlb_dmabuf(
             read_kmd_version().str(),
             read_kernel_version().str()));
 
-    // This follows the driver's documented export sequence directly (ALLOCATE_TLB, CONFIGURE_TLB,
-    // EXPORT_TLB_DMABUF, FREE_TLB) rather than going through TlbHandle/TlbWindow.
     tt_tlb_t *tlb = nullptr;
     int ret = tt_tlb_alloc(tt_device_handle, window_size, TT_MMIO_CACHE_MODE_WC, &tlb);
     if (ret != 0) {


### PR DESCRIPTION
Description
Part 2 of 4 splitting #3063 into a stack (kmdlib -> pcidevice -> ttdevice -> cluster). Stacked on PR 1/4. No behavior change versus #3063.

List of the changes
Added KMD_TLB_DMABUF_EXPORT and MIN_KERNEL_TLB_DMABUF_EXPORT version constants
Added PCIDevice::read_kernel_version and PCIDevice::is_tlb_dmabuf_export_supported
Added PCIDevice::export_tlb_dmabuf, which runs the driver documented sequence directly (allocate TLB, configure via CONFIGURE_TLB, export, free), independent of TlbHandle/TlbWindow since an exported window is never read or written by the host

Testing
CI
Builds clean standalone, verified device/all links with only PR 1/4 and this layer applied

API Changes
This PR has API changes. New public methods PCIDevice::read_kernel_version, PCIDevice::is_tlb_dmabuf_export_supported, PCIDevice::export_tlb_dmabuf