### PR TITLE
Add TTDevice/PcieProtocol export_dmabuf plumbing (3/4)

### DIFF
--- a/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 
 #include "umd/device/types/noc_id.hpp"
+#include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 
@@ -41,6 +42,22 @@ public:
      * @return int NUMA node ID, or -1 if the system is non-NUMA.
      */
     virtual int get_numa_node() const = 0;
+
+    /**
+     * @brief Exports (core, addr) as a dma-buf fd for peer-to-peer PCIe DMA, backed by a dedicated
+     * TLB window.
+     *
+     * Temporary: this is not part of the Base API spec. It lives here only until the spec covers
+     * dma-buf export; move it at that point.
+     *
+     * @param core Core to target.
+     * @param addr Address within the core to aim the exported region at; must be page-aligned.
+     * @param size Number of bytes to export; must be page-aligned and non-zero.
+     * @param ordering Ordering mode for the TLB window backing the export.
+     * @param noc_id NOC to route the exported traffic over.
+     * @return int The dma-buf fd; the caller owns it and must close() it.
+     */
+    virtual int export_dmabuf(tt_xy_pair core, uint64_t addr, size_t size, uint64_t ordering, NocId noc_id) = 0;
 
     /**
      * @brief Registers the callback consulted on an IO-op timeout to distinguish a hung NOC from a

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -56,6 +56,7 @@ public:
     void bar_write32(uint32_t addr, uint32_t data) override;
     uint32_t bar_read32(uint32_t addr) override;
     int get_numa_node() const override;
+    int export_dmabuf(tt_xy_pair core, uint64_t addr, size_t size, uint64_t ordering, NocId noc_id) override;
     void set_io_timeout_callback(const std::function<bool(NocId)>& hang_check) override;
 
     // DmaInterface.

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -490,6 +490,24 @@ public:
     virtual std::unique_ptr<TlbWindow> get_io_window(
         tlb_data config, TlbMapping mapping = TlbMapping::WC, size_t size = 0);
 
+    /**
+     * Export a NOC-addressable region as a dma-buf file descriptor for peer-to-peer PCIe DMA.
+     * Requires a PCIe-attached device. See PcieInterface::export_dmabuf for the full contract; the
+     * caller owns the returned fd and must close() it.
+     *
+     * @param core Core to target.
+     * @param addr Address within the core to aim the exported region at; must be page-aligned.
+     * @param size Number of bytes to export; must be page-aligned and non-zero.
+     * @param ordering Ordering mode for the TLB window backing the export.
+     * @param noc_id NOC to route the exported traffic over.
+     */
+    virtual int export_dmabuf(
+        CoreCoord core,
+        uint64_t addr,
+        size_t size,
+        uint64_t ordering = tlb_data::Relaxed,
+        NocId noc_id = NocId::DEFAULT_NOC);
+
     static void set_sigbus_safe_handler(bool set_safe_handler);
 
     /**

--- a/device/common/utils.hpp
+++ b/device/common/utils.hpp
@@ -11,6 +11,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <optional>
 #include <string>
 #include <thread>
@@ -78,6 +80,46 @@ inline bool is_integer_string(const std::string& str) {
 inline bool is_bdf_string(const std::string& str) {
     return (str.find(':') != std::string::npos || str.find('.') != std::string::npos) &&
            (str.find_first_not_of("0123456789abcdefABCDEF.:") == std::string::npos);
+}
+
+// Coarse, host-wide check for whether any RDMA-capable port (RoCE or InfiniBand) is currently up,
+// by scanning /sys/class/infiniband/*/ports/*/state for a port whose state name is ACTIVE.
+inline bool has_any_active_rdma_port() {
+    static const std::filesystem::path infiniband_class_path = "/sys/class/infiniband";
+    std::error_code ec;
+    if (!std::filesystem::is_directory(infiniband_class_path, ec)) {
+        return false;
+    }
+
+    for (const auto& device_entry : std::filesystem::directory_iterator(infiniband_class_path, ec)) {
+        const std::filesystem::path ports_path = device_entry.path() / "ports";
+        if (!std::filesystem::is_directory(ports_path, ec)) {
+            continue;
+        }
+
+        for (const auto& port_entry : std::filesystem::directory_iterator(ports_path, ec)) {
+            std::ifstream state_file(port_entry.path() / "state");
+            std::string state_line;
+            if (!state_file.is_open() || !std::getline(state_file, state_line)) {
+                continue;
+            }
+
+            // Format is "<n>: <NAME>", e.g. "4: ACTIVE".
+            const size_t colon = state_line.find(':');
+            if (colon == std::string::npos) {
+                continue;
+            }
+            std::string state_name = state_line.substr(colon + 1);
+            state_name.erase(0, state_name.find_first_not_of(" \t"));
+            state_name.erase(state_name.find_last_not_of(" \t\r\n") + 1);
+
+            if (state_name == "ACTIVE") {
+                return true;
+            }
+        }
+    }
+
+    return false;
 }
 
 // This ENV variable is used to specify visible devices for BOTH PCIe and JTAG interfaces depending on which one is

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -6,6 +6,9 @@
 
 #include "umd/device/tt_device/protocol/pcie_protocol.hpp"
 
+#include <fmt/format.h>
+#include <unistd.h>
+
 #include <algorithm>
 #include <cstring>
 #include <mutex>
@@ -13,6 +16,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/pcie/pci_device.hpp"
@@ -169,6 +173,82 @@ uint32_t PcieProtocol::bar_read32(uint32_t addr) {
 PCIDevice* PcieProtocol::get_pci_device() { return pci_device_.get(); }
 
 int PcieProtocol::get_numa_node() const { return pci_device_->get_numa_node(); }
+
+int PcieProtocol::export_dmabuf(tt_xy_pair core, uint64_t addr, size_t size, uint64_t ordering, NocId noc_id) {
+    // Nothing can consume this fd without an active RDMA NIC on the host, so check for one before
+    // any window is allocated or an ioctl issued, same as the alignment checks below.
+    UMD_ASSERT(
+        tt::umd::utils::has_any_active_rdma_port(),
+        error::RuntimeError,
+        "Exporting a TLB window as a dma-buf requires an active RDMA NIC (RoCE or InfiniBand) on this host to "
+        "consume it, but no port in the ACTIVE state was found under /sys/class/infiniband.");
+
+    UMD_ASSERT(
+        ordering == tlb_data::Strict || ordering == tlb_data::Posted || ordering == tlb_data::Relaxed,
+        error::RuntimeError,
+        "Invalid ordering specified in PcieProtocol::export_dmabuf");
+
+    // Alignment is checked before any window is allocated. The offset handed to the driver is the
+    // window's distance from its size-aligned base, i.e. addr % window_size, and the driver requires
+    // both that offset and the length to be page-aligned.
+    const uint64_t page_size = static_cast<uint64_t>(getpagesize());
+    UMD_ASSERT(size != 0, error::RuntimeError, "Cannot export a dma-buf of size 0.");
+    UMD_ASSERT(
+        addr % page_size == 0,
+        error::RuntimeError,
+        fmt::format("Address {:#x} must be aligned to the host page size ({} bytes) to be exported.", addr, page_size));
+    UMD_ASSERT(
+        size % page_size == 0,
+        error::RuntimeError,
+        fmt::format("Size {} must be a multiple of the host page size ({} bytes) to be exported.", size, page_size));
+
+    // A window's NOC base must be size-aligned, so a window of class W aimed at addr starts at
+    // addr & ~(W-1) and therefore reaches only W - (addr % W) bytes past addr. Pick the smallest
+    // class that still covers [addr, addr + size). get_tlb_sizes() is ascending.
+    const std::vector<size_t>& size_classes = pci_device_->get_architecture_implementation()->get_tlb_sizes();
+    size_t window_size = 0;
+    for (const size_t candidate : size_classes) {
+        if (size <= candidate - (addr % candidate)) {
+            window_size = candidate;
+            break;
+        }
+    }
+    UMD_ASSERT(
+        window_size != 0,
+        error::RuntimeError,
+        fmt::format(
+            "No TLB window size can cover {} bytes at address {:#x}; the largest is {} bytes and its base must be "
+            "size-aligned. Use a smaller size or a more aligned address.",
+            size,
+            addr,
+            size_classes.back()));
+
+    // A window's NOC base is size-aligned, so the window is aimed at the aligned address at or below
+    // addr and the export starts the remaining distance into it.
+    const uint64_t window_offset = addr % window_size;
+
+    tlb_data config{};
+    config.local_offset = addr - window_offset;
+    config.x_end = core.x;
+    config.y_end = core.y;
+    config.noc_sel = static_cast<uint64_t>(noc_id);
+    config.ordering = ordering;
+    config.static_vc = pci_device_->get_architecture_implementation()->get_static_vc();
+
+    log_debug(
+        LogUMD,
+        "Exporting {} bytes at {:#x} on core {} as a dma-buf via a {} byte TLB window (offset {:#x} into the window).",
+        size,
+        addr,
+        core.str(),
+        window_size,
+        window_offset);
+
+    // A dedicated window on purpose, never one of the cached ones: it must not alias a window that
+    // other traffic could reconfigure while the export is live. PCIDevice allocates it, configures
+    // it, exports it and releases it; the driver keeps it pinned for the lifetime of the fd.
+    return pci_device_->export_tlb_dmabuf(window_size, config, window_offset, size);
+}
 
 bool PcieProtocol::dma_write(const void* src, uint64_t dst_addr, size_t size, tt_xy_pair core, NocId noc_id) {
     // const_cast is safe here: dma_transfer only reads from the buffer in H2D direction (memcpy into DMA buffer).

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -174,6 +174,10 @@ PCIDevice* PcieProtocol::get_pci_device() { return pci_device_.get(); }
 
 int PcieProtocol::get_numa_node() const { return pci_device_->get_numa_node(); }
 
+// A TLB window's NOC base must be size-aligned, so the window aimed at addr sits at the size-aligned
+// address at or below addr; the smallest window that still covers [addr, addr + size) is selected.
+// The offset handed to the driver is addr's distance from that base, and both offset and size must
+// be page-aligned.
 int PcieProtocol::export_dmabuf(tt_xy_pair core, uint64_t addr, size_t size, uint64_t ordering, NocId noc_id) {
     // Nothing can consume this fd without an active RDMA NIC on the host, so check for one before
     // any window is allocated or an ioctl issued, same as the alignment checks below.
@@ -188,9 +192,6 @@ int PcieProtocol::export_dmabuf(tt_xy_pair core, uint64_t addr, size_t size, uin
         error::RuntimeError,
         "Invalid ordering specified in PcieProtocol::export_dmabuf");
 
-    // Alignment is checked before any window is allocated. The offset handed to the driver is the
-    // window's distance from its size-aligned base, i.e. addr % window_size, and the driver requires
-    // both that offset and the length to be page-aligned.
     const uint64_t page_size = static_cast<uint64_t>(getpagesize());
     UMD_ASSERT(size != 0, error::RuntimeError, "Cannot export a dma-buf of size 0.");
     UMD_ASSERT(
@@ -202,9 +203,6 @@ int PcieProtocol::export_dmabuf(tt_xy_pair core, uint64_t addr, size_t size, uin
         error::RuntimeError,
         fmt::format("Size {} must be a multiple of the host page size ({} bytes) to be exported.", size, page_size));
 
-    // A window's NOC base must be size-aligned, so a window of class W aimed at addr starts at
-    // addr & ~(W-1) and therefore reaches only W - (addr % W) bytes past addr. Pick the smallest
-    // class that still covers [addr, addr + size). get_tlb_sizes() is ascending.
     const std::vector<size_t>& size_classes = pci_device_->get_architecture_implementation()->get_tlb_sizes();
     size_t window_size = 0;
     for (const size_t candidate : size_classes) {
@@ -223,8 +221,6 @@ int PcieProtocol::export_dmabuf(tt_xy_pair core, uint64_t addr, size_t size, uin
             addr,
             size_classes.back()));
 
-    // A window's NOC base is size-aligned, so the window is aimed at the aligned address at or below
-    // addr and the export starts the remaining distance into it.
     const uint64_t window_offset = addr % window_size;
 
     tlb_data config{};
@@ -244,9 +240,8 @@ int PcieProtocol::export_dmabuf(tt_xy_pair core, uint64_t addr, size_t size, uin
         window_size,
         window_offset);
 
-    // A dedicated window on purpose, never one of the cached ones: it must not alias a window that
-    // other traffic could reconfigure while the export is live. PCIDevice allocates it, configures
-    // it, exports it and releases it; the driver keeps it pinned for the lifetime of the fd.
+    // Dedicated window (not a cached one): must not alias a window other traffic could reconfigure
+    // while the export is live.
     return pci_device_->export_tlb_dmabuf(window_size, config, window_offset, size);
 }
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -742,6 +742,13 @@ void TTDevice::multicast_write_via_unicast(
     }
 }
 
+int TTDevice::export_dmabuf(CoreCoord core, uint64_t addr, size_t size, uint64_t ordering, NocId noc_id) {
+    if (is_remote_tt_device) {
+        UMD_THROW(error::RuntimeError, "Exporting a dma-buf is not supported for remote device.");
+    }
+    return get_pcie_interface()->export_dmabuf(resolve_coordinate(core, noc_id), addr, size, ordering, noc_id);
+}
+
 void TTDevice::dma_write_to_device(const void *src, size_t size, CoreCoord core, uint64_t addr, NocId noc_id) {
     ZoneScopedC(tracy::Color::MediumPurple);
     if (is_remote_tt_device) {


### PR DESCRIPTION
Description
Part 3 of 4 splitting #3063 into a stack (kmdlib -> pcidevice -> ttdevice -> cluster). Stacked on PR 2/4. No behavior change versus #3063.

List of the changes
 - Added has_any_active_rdma_port in device/common/utils.hpp, which scans /sys/class/infiniband for a port in the ACTIVE state
 - Added PcieProtocol::export_dmabuf, declared as a new pure virtual on PcieInterface, which validates the request, picks the smallest per-arch TLB window size class that covers the requested range, and builds the TLB configuration
 - Added TTDevice::export_dmabuf, which resolves the coordinate, rejects remote devices, and forwards to the PCIe interface

Testing
CI

API Changes
This PR has API changes. New public method TTDevice::export_dmabuf, and a new pure virtual PcieInterface::export_dmabuf implemented by PcieProtocol