### PR TITLE
Expose export_dmabuf on LocalChip and Cluster (4/4)

### DIFF
--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -63,6 +63,8 @@ public:
     void dma_read_from_device(void* dst, size_t size, CoreCoord core, uint64_t addr) override;
     void dma_multicast_write(void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) override;
 
+    int export_dmabuf(CoreCoord core, uint64_t addr, size_t size, uint64_t ordering);
+
     void wait_for_non_mmio_flush() override;
 
     void l1_membar(const std::unordered_set<CoreCoord>& cores = {}) override;

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -516,6 +516,30 @@ public:
      */
     TlbWindow* get_static_tlb_window(const ChipId chip, const CoreCoord core);
 
+    /**
+     * Allocate a dedicated TLB window aimed at (chip, core, addr), export it as a dma-buf for
+     * peer-to-peer PCIe DMA, and return an fd the caller owns.
+     * - The caller must close() the returned fd when done; this releases the kmd-side pin and,
+     *   once the last export on the window is released, returns the window to the allocation pool.
+     * - A dedicated window is always allocated (never a shared/static one), so there is no
+     *   reconfigure hazard with other TLB users.
+     * - `size` is the exported length, not a TLB window size: the underlying window is rounded up
+     *   internally to the smallest per-arch size class that can cover [addr, addr + size), so
+     *   callers need not know the arch's valid window sizes. The dma-buf is exactly `size` bytes.
+     * - `addr` and `size` must both be host-page-aligned; the kmd rejects an unaligned export
+     *   offset or length with -EINVAL.
+     *
+     * @param chip Chip to target.
+     * @param core Core to target.
+     * @param addr Address within the core the window should map to. Must be page-aligned.
+     * @param size Bytes to export. Must be non-zero and page-aligned. The returned dma-buf is
+     *             exactly this long, which is the length a peer registers its MR with.
+     * @param ordering Ordering mode for the TLB.
+     * @return dma-buf file descriptor; the caller owns it and must close() it when done.
+     */
+    int export_dmabuf(
+        const ChipId chip, const CoreCoord core, uint64_t addr, size_t size, uint64_t ordering = tlb_data::Relaxed);
+
     //---------- Functions for synchronization and memory barriers.
 
     /**

--- a/device/api/umd/device/cluster.hpp
+++ b/device/api/umd/device/cluster.hpp
@@ -517,24 +517,17 @@ public:
     TlbWindow* get_static_tlb_window(const ChipId chip, const CoreCoord core);
 
     /**
-     * Allocate a dedicated TLB window aimed at (chip, core, addr), export it as a dma-buf for
-     * peer-to-peer PCIe DMA, and return an fd the caller owns.
-     * - The caller must close() the returned fd when done; this releases the kmd-side pin and,
-     *   once the last export on the window is released, returns the window to the allocation pool.
-     * - A dedicated window is always allocated (never a shared/static one), so there is no
-     *   reconfigure hazard with other TLB users.
-     * - `size` is the exported length, not a TLB window size: the underlying window is rounded up
-     *   internally to the smallest per-arch size class that can cover [addr, addr + size), so
-     *   callers need not know the arch's valid window sizes. The dma-buf is exactly `size` bytes.
-     * - `addr` and `size` must both be host-page-aligned; the kmd rejects an unaligned export
-     *   offset or length with -EINVAL.
+     * Export the memory at (chip, core, addr) as a dma-buf for peer-to-peer PCIe DMA, and return
+     * an fd the caller owns.
+     * - The caller must close() the returned fd when done to release the underlying resources.
+     * - `addr` and `size` must both be host-page-aligned.
      *
      * @param chip Chip to target.
      * @param core Core to target.
-     * @param addr Address within the core the window should map to. Must be page-aligned.
+     * @param addr Address within the core to export. Must be page-aligned.
      * @param size Bytes to export. Must be non-zero and page-aligned. The returned dma-buf is
      *             exactly this long, which is the length a peer registers its MR with.
-     * @param ordering Ordering mode for the TLB.
+     * @param ordering Ordering mode for the export.
      * @return dma-buf file descriptor; the caller owns it and must close() it when done.
      */
     int export_dmabuf(

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -299,6 +299,10 @@ void LocalChip::dma_read_from_device(void* dst, size_t size, CoreCoord core, uin
     tt_device_->dma_read_from_device(dst, size, core, addr, get_selected_noc_id());
 }
 
+int LocalChip::export_dmabuf(CoreCoord core, uint64_t addr, size_t size, uint64_t ordering) {
+    return tt_device_->export_dmabuf(core, addr, size, ordering, get_selected_noc_id());
+}
+
 void LocalChip::dma_multicast_write(void* src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr) {
     tt_device_->dma_multicast_write(src, size, core_start, core_end, addr, get_selected_noc_id());
 }

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -900,6 +900,10 @@ TlbWindow* Cluster::get_static_tlb_window(const ChipId chip, const CoreCoord cor
     return get_tlb_manager(chip)->get_tlb_window(translated_core);
 }
 
+int Cluster::export_dmabuf(const ChipId chip, const CoreCoord core, uint64_t addr, size_t size, uint64_t ordering) {
+    return get_local_chip(chip)->export_dmabuf(core, addr, size, ordering);
+}
+
 std::map<int, int> Cluster::get_clocks() {
     std::map<int, int> clock_freq_map;
     for (auto& chip_id : local_chip_ids_) {

--- a/tests/unified/test_tlb.cpp
+++ b/tests/unified/test_tlb.cpp
@@ -2,12 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <fcntl.h>
 #include <gtest/gtest.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <stdexcept>
 #include <vector>
 
 #include "tests/test_utils/device_test_utils.hpp"
@@ -23,9 +26,11 @@
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/tlb.hpp"
 #include "umd/device/types/xy_pair.hpp"
+#include "umd/device/utils/kmd_versions.hpp"
 #include "umd/device/utils/mmio_timeout_config.hpp"
 #include "umd/device/utils/semver.hpp"
 #include "umd/device/utils/timeouts.hpp"
+#include "utils.hpp"
 
 using namespace tt;
 using namespace tt::umd;
@@ -91,6 +96,45 @@ TEST_F(TestTlb, TestTlbWindowAllocateNew) {
 
         value_check++;
     }
+}
+
+TEST_F(TestTlb, TestClusterExportDmabuf) {
+    if (PCIDevice::read_kmd_version() < KMD_TLB_DMABUF_EXPORT) {
+        GTEST_SKIP() << "KMD version " << PCIDevice::read_kmd_version().str() << " is below required "
+                     << KMD_TLB_DMABUF_EXPORT.str();
+    }
+
+    if (!tt::umd::utils::has_any_active_rdma_port()) {
+        GTEST_SKIP() << "No active RDMA NIC (RoCE/InfiniBand) found under /sys/class/infiniband.";
+    }
+
+    const ChipId chip = 0;
+    const uint64_t two_mb_size = 1 << 21;
+
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+
+    std::vector<CoreCoord> tensix_cores =
+        cluster->get_soc_descriptor(chip).get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
+    ASSERT_FALSE(tensix_cores.empty());
+    CoreCoord core = tensix_cores.front();
+
+    int fd = cluster->export_dmabuf(chip, core, 0, two_mb_size);
+    EXPECT_GE(fd, 0);
+    EXPECT_GE(fcntl(fd, F_GETFD), 0);
+    close(fd);
+
+    // An address that is page-aligned but not TLB-window-aligned exercises TlbWindow's
+    // offset_from_aligned_addr translation: the window's NOC base is rounded down to a size-aligned
+    // boundary, so the export starts `addr % window_size` bytes into the window, not at its base.
+    const uint64_t page_size = static_cast<uint64_t>(getpagesize());
+    fd = cluster->export_dmabuf(chip, core, page_size, page_size);
+    EXPECT_GE(fd, 0);
+    EXPECT_GE(fcntl(fd, F_GETFD), 0);
+    close(fd);
+
+    // Misaligned requests are rejected up front, before a window is allocated or an ioctl issued.
+    EXPECT_THROW(cluster->export_dmabuf(chip, core, 1, page_size), std::runtime_error);
+    EXPECT_THROW(cluster->export_dmabuf(chip, core, 0, page_size + 1), std::runtime_error);
 }
 
 TEST_F(TestTlb, TestTlbWindowReuse) {


### PR DESCRIPTION
Description
Part 4 of 4 splitting #3063 into a stack (kmdlib -> pcidevice -> ttdevice -> cluster). Stacked on PR 3/4, completes the feature. No behavior change versus #3063, and the cumulative diff of this PR against main is byte for byte identical to #3063.

List of the changes
Added LocalChip::export_dmabuf and Cluster::export_dmabuf as thin propagators
export_dmabuf is intentionally only on LocalChip, not the Chip base class, since the export wraps a PCIe aperture that a remote chip does not have. Cluster::export_dmabuf goes through get_local_chip, which already rejects a non-local chip id
Added TestClusterExportDmabuf in tests/unified/test_tlb.cpp

Testing
Using TEMP test from rdma_testing/* on branch ajovanovic/rdma_testing_tools, paired sources run at the same time on bh-glx6u-18 and bh-glx6u-22
CI

API Changes
This PR has API changes. New public methods LocalChip::export_dmabuf and Cluster::export_dmabuf