### PR TITLE
Add PCIDevice::read_kernel_version

### DIFF
--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -274,6 +274,12 @@ public:
     static SemVer read_kmd_version();
 
     /**
+     * Read the running Linux kernel version (from uname(2)'s release field), as major.minor.patch.
+     * The trailing distro suffix (e.g. "-91-generic") is dropped; only major/minor/patch are parsed.
+     */
+    static SemVer read_kernel_version();
+
+    /**
      * Allocate TLB resource from KMD.
      *
      * @param tlb_size Size of the TLB caller wants to allocate.

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -6,8 +6,9 @@
 
 #include <fcntl.h>  // for ::open
 #include <fmt/format.h>
-#include <sys/mman.h>  // for mmap, munmap
-#include <unistd.h>    // for ::close
+#include <sys/mman.h>     // for mmap, munmap
+#include <sys/utsname.h>  // for uname
+#include <unistd.h>       // for ::close
 
 #include <cerrno>
 #include <cstdint>
@@ -768,6 +769,20 @@ SemVer PCIDevice::read_kmd_version() {
     std::getline(file, version_str);
 
     return SemVer(version_str);
+}
+
+SemVer PCIDevice::read_kernel_version() {
+    struct utsname uts {};
+
+    if (uname(&uts) != 0) {
+        log_warning(LogUMD, "uname() failed: {}", strerror(errno));
+        return {0, 0, 0};
+    }
+
+    // uts.release looks like "5.15.0-91-generic"; SemVer's parser reads leading digits of each
+    // dot-separated field and stops at the first non-digit, so the "-91-generic" tail of the
+    // patch field is naturally dropped.
+    return SemVer(uts.release);
 }
 
 std::unique_ptr<TlbHandle> PCIDevice::allocate_tlb(const size_t tlb_size, const TlbMapping tlb_mapping) {


### PR DESCRIPTION
Description
Split out of the TLB dma-buf export stack (originally #3063, now split into PRs 3141, 3142, 3143, 3144). Kernel version detection is a generically useful primitive on its own, not specific to the dma-buf export feature, so it gets its own PR. Stacked on PR 3141.

List of the changes
Added PCIDevice::read_kernel_version, which reads the running Linux kernel version from uname(2)'s release field as major.minor.patch

Testing
CI
Builds clean standalone, verified device/all links with only PR 3141 and this layer applied

API Changes
This PR has API changes. New public method PCIDevice::read_kernel_version