### PR TITLE
Align JtagInterface with BaseApi spec

### DIFF
--- a/device/api/umd/device/tt_device/protocol/jtag_interface.hpp
+++ b/device/api/umd/device/tt_device/protocol/jtag_interface.hpp
@@ -5,18 +5,32 @@
  */
 #pragma once
 
+#include <cstdint>
+
 namespace tt::umd {
 
-class JtagDevice;
-
 /**
- * JtagInterface defines JTAG-specific operations beyond the basic DeviceProtocol.
+ * @brief JTAG-specific device access: memory-mapped register I/O.
+
+ * Exposes operations that are only meaningful for JTAG-connected devices.
  */
 class JtagInterface {
 public:
     virtual ~JtagInterface() = default;
 
-    virtual JtagDevice* get_jtag_device() = 0;
+    /**
+     * @brief Writes a 32-bit value to a memory mapped relative device address.
+     * @param addr  Memory-mapped region relative address.
+     * @param data The 32-bit value to write.
+     */
+    virtual void mmio_write32(uint32_t addr, uint32_t data) = 0;
+
+    /**
+     * @brief Reads a 32-bit value from a memory mapped relative device address.
+     * @param addr Memory-mapped region relative address.
+     * @return uint32_t The value read.
+     */
+    virtual uint32_t mmio_read32(uint32_t addr) = 0;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/protocol/jtag_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/jtag_protocol.hpp
@@ -37,7 +37,8 @@ public:
     int get_mmio_id() override;
 
     // JtagInterface.
-    JtagDevice* get_jtag_device() override;
+    void mmio_write32(uint32_t addr, uint32_t data) override;
+    uint32_t mmio_read32(uint32_t addr) override;
 
 private:
     std::unique_ptr<JtagDevice> jtag_device_;

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -21,7 +21,6 @@
 #include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/firmware/firmware_info_provider.hpp"
-#include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
 #include "umd/device/soc_arch_descriptor.hpp"
@@ -109,7 +108,6 @@ public:
 
     architecture_implementation *get_architecture_implementation();
     PCIDevice *get_pci_device();
-    JtagDevice *get_jtag_device();
     RemoteCommunication *get_remote_communication();
 
     DeviceProtocol *get_device_protocol();

--- a/device/arc/blackhole_arc_message_queue.cpp
+++ b/device/arc/blackhole_arc_message_queue.cpp
@@ -10,13 +10,11 @@
 #include <chrono>
 #include <cstdlib>
 #include <memory>
-#include <optional>
 #include <string>
 #include <vector>
 
 #include "noc_access.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
-#include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/utils/error.hpp"
@@ -152,9 +150,9 @@ std::unique_ptr<BlackholeArcMessageQueue> BlackholeArcMessageQueue::get_blackhol
 
     uint64_t queue_control_block;
     if (tt_device->get_communication_device_type() == IODeviceType::JTAG) {
-        queue_control_block = tt_device->get_jtag_device()->read32_axi(0, queue_control_block_addr).value();
+        queue_control_block = tt_device->get_jtag_interface()->mmio_read32(queue_control_block_addr);
         queue_control_block |=
-            ((uint64_t)tt_device->get_jtag_device()->read32_axi(0, queue_control_block_addr + 4).value() << 32);
+            ((uint64_t)tt_device->get_jtag_interface()->mmio_read32(queue_control_block_addr + 4) << 32);
     } else {
         tt_device->read_from_device(
             &queue_control_block, arc_core, queue_control_block_addr, sizeof(uint64_t), get_selected_noc_id());

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -138,7 +138,7 @@ bool BlackholeTTDevice::get_noc_translation_enabled() {
 
     if (get_communication_device_type() == IODeviceType::JTAG) {
         // Target arc core.
-        niu_cfg = get_jtag_device()->read32_axi(0, blackhole::NIU_CFG_NOC0_ARC_ADDR).value();
+        niu_cfg = get_jtag_interface()->mmio_read32(blackhole::NIU_CFG_NOC0_ARC_ADDR);
     } else {
         niu_cfg = bar_read32(addr);
     }
@@ -256,13 +256,12 @@ void BlackholeTTDevice::read_from_arc_apb(void *mem_ptr, uint64_t arc_addr_offse
         UMD_THROW(error::RuntimeError, "Address is out of ARC XBAR address range.");
     }
     if (communication_device_type_ == IODeviceType::JTAG) {
-        get_jtag_device()->read(
-            communication_device_id_,
+        get_device_protocol()->read_ctrl(
             mem_ptr,
-            blackhole::ARC_CORES_NOC0[0].x,
-            blackhole::ARC_CORES_NOC0[0].y,
+            blackhole::ARC_CORES_NOC0[0],
             blackhole::ARC_NOC_XBAR_ADDRESS_START + arc_addr_offset,
-            sizeof(uint32_t));
+            sizeof(uint32_t),
+            NocId::DEFAULT_NOC);
         return;
     }
     if (!is_arc_available_over_axi()) {
@@ -279,13 +278,12 @@ void BlackholeTTDevice::write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_
         UMD_THROW(error::RuntimeError, "Address is out of ARC XBAR address range.");
     }
     if (communication_device_type_ == IODeviceType::JTAG) {
-        get_jtag_device()->write(
-            communication_device_id_,
+        get_device_protocol()->write_ctrl(
             mem_ptr,
-            blackhole::ARC_CORES_NOC0[0].x,
-            blackhole::ARC_CORES_NOC0[0].y,
+            blackhole::ARC_CORES_NOC0[0],
             blackhole::ARC_NOC_XBAR_ADDRESS_START + arc_addr_offset,
-            sizeof(uint32_t));
+            sizeof(uint32_t),
+            NocId::DEFAULT_NOC);
         return;
     }
     if (!is_arc_available_over_axi()) {

--- a/device/tt_device/protocol/jtag_protocol.cpp
+++ b/device/tt_device/protocol/jtag_protocol.cpp
@@ -6,6 +6,8 @@
 
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
 
+#include <fmt/format.h>
+
 #include <utility>
 
 #include "umd/device/jtag/jtag_device.hpp"
@@ -40,8 +42,19 @@ bool JtagProtocol::write_to_core_range(const void*, tt_xy_pair, tt_xy_pair, uint
 
 int JtagProtocol::get_mmio_id() { return mmio_id_; }
 
-void JtagProtocol::mmio_write32(uint32_t addr, uint32_t data) { jtag_device_->write32_axi(mmio_id_, addr, data); }
+void JtagProtocol::mmio_write32(uint32_t addr, uint32_t data) {
+    validate_register_access(addr, sizeof(uint32_t));
+    jtag_device_->write32_axi(mmio_id_, addr, data);
+}
 
-uint32_t JtagProtocol::mmio_read32(uint32_t addr) { return jtag_device_->read32_axi(mmio_id_, addr).value(); }
+uint32_t JtagProtocol::mmio_read32(uint32_t addr) {
+    validate_register_access(addr, sizeof(uint32_t));
+    std::optional<uint32_t> data = jtag_device_->read32_axi(mmio_id_, addr);
+    if (!data.has_value()) {
+        UMD_THROW(
+            error::RuntimeError, fmt::format("Failed to read 32-bit MMIO value at address 0x{:x} over JTAG.", addr));
+    }
+    return data.value();
+}
 
 }  // namespace tt::umd

--- a/device/tt_device/protocol/jtag_protocol.cpp
+++ b/device/tt_device/protocol/jtag_protocol.cpp
@@ -40,6 +40,8 @@ bool JtagProtocol::write_to_core_range(const void*, tt_xy_pair, tt_xy_pair, uint
 
 int JtagProtocol::get_mmio_id() { return mmio_id_; }
 
-JtagDevice* JtagProtocol::get_jtag_device() { return jtag_device_.get(); }
+void JtagProtocol::mmio_write32(uint32_t addr, uint32_t data) { jtag_device_->write32_axi(mmio_id_, addr, data); }
+
+uint32_t JtagProtocol::mmio_read32(uint32_t addr) { return jtag_device_->read32_axi(mmio_id_, addr).value(); }
 
 }  // namespace tt::umd

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -247,7 +247,7 @@ std::unique_ptr<TTDevice> TTDevice::create_simulation_remote(
 
 architecture_implementation *TTDevice::get_architecture_implementation() { return architecture_impl_.get(); }
 
-// The nullptr check for capabilities in the APIs get_pci_device, get_jtag_device and get_remote_communication
+// The nullptr check for capabilities in the APIs get_pci_device and get_remote_communication
 // exists for backward compatibility — these APIs are expected to return nullptr when a capability is unavailable.
 // Throwing an exception would break existing behavior and require significant changes across client code.
 // This approach is intended as a temporary measure until the API is updated to use tl::expected or std::optional,
@@ -257,13 +257,6 @@ PCIDevice *TTDevice::get_pci_device() {
         return nullptr;
     }
     return get_pcie_interface()->get_pci_device();
-}
-
-JtagDevice *TTDevice::get_jtag_device() {
-    if (!jtag_capabilities_) {
-        return nullptr;
-    }
-    return get_jtag_interface()->get_jtag_device();
 }
 
 RemoteCommunication *TTDevice::get_remote_communication() {

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -183,13 +183,12 @@ void WormholeTTDevice::read_from_arc_apb(void *mem_ptr, uint64_t arc_addr_offset
         return;
     }
     if (communication_device_type_ == IODeviceType::JTAG) {
-        get_jtag_device()->read(
-            communication_device_id_,
+        get_device_protocol()->read_ctrl(
             mem_ptr,
-            wormhole::ARC_CORES_NOC0[0].x,
-            wormhole::ARC_CORES_NOC0[0].y,
+            wormhole::ARC_CORES_NOC0[0],
             architecture_impl_->get_arc_apb_noc_base_address() + arc_addr_offset,
-            sizeof(uint32_t));
+            sizeof(uint32_t),
+            NocId::DEFAULT_NOC);
         return;
     }
     auto result = bar_read32(wormhole::ARC_APB_BAR0_XBAR_OFFSET_START + arc_addr_offset);
@@ -206,13 +205,12 @@ void WormholeTTDevice::write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_o
         return;
     }
     if (communication_device_type_ == IODeviceType::JTAG) {
-        get_jtag_device()->write(
-            communication_device_id_,
+        get_device_protocol()->write_ctrl(
             mem_ptr,
-            wormhole::ARC_CORES_NOC0[0].x,
-            wormhole::ARC_CORES_NOC0[0].y,
+            wormhole::ARC_CORES_NOC0[0],
             architecture_impl_->get_arc_apb_noc_base_address() + arc_addr_offset,
-            sizeof(uint32_t));
+            sizeof(uint32_t),
+            NocId::DEFAULT_NOC);
         return;
     }
     bar_write32(
@@ -229,13 +227,12 @@ void WormholeTTDevice::read_from_arc_csm(void *mem_ptr, uint64_t arc_addr_offset
         return;
     }
     if (communication_device_type_ == IODeviceType::JTAG) {
-        get_jtag_device()->read(
-            communication_device_id_,
+        get_device_protocol()->read_ctrl(
             mem_ptr,
-            wormhole::ARC_CORES_NOC0[0].x,
-            wormhole::ARC_CORES_NOC0[0].y,
+            wormhole::ARC_CORES_NOC0[0],
             architecture_impl_->get_arc_csm_noc_base_address() + arc_addr_offset,
-            sizeof(uint32_t));
+            sizeof(uint32_t),
+            NocId::DEFAULT_NOC);
         return;
     }
     auto result = bar_read32(wormhole::ARC_CSM_BAR0_XBAR_OFFSET_START + arc_addr_offset);
@@ -252,13 +249,12 @@ void WormholeTTDevice::write_to_arc_csm(const void *mem_ptr, uint64_t arc_addr_o
         return;
     }
     if (communication_device_type_ == IODeviceType::JTAG) {
-        get_jtag_device()->write(
-            communication_device_id_,
+        get_device_protocol()->write_ctrl(
             mem_ptr,
-            wormhole::ARC_CORES_NOC0[0].x,
-            wormhole::ARC_CORES_NOC0[0].y,
+            wormhole::ARC_CORES_NOC0[0],
             architecture_impl_->get_arc_csm_noc_base_address() + arc_addr_offset,
-            sizeof(uint32_t));
+            sizeof(uint32_t),
+            NocId::DEFAULT_NOC);
         return;
     }
     bar_write32(


### PR DESCRIPTION
### Issue
#2881

### Description
JtagInterface previously exposed the internal JtagDevice via get_jtag_device(). Updated it to match the Base API Specification, exposing mmio_write32/mmio_read32 for direct memory-mapped register access instead.

### List of the changes
 - Removed JtagInterface::get_jtag_device(), added mmio_write32(addr, data) and mmio_read32(addr)
 - Implemented the new methods in JtagProtocol via JtagDevice write32_axi/read32_axi
 - Removed TTDevice::get_jtag_device()
 - Updated affected call sites 

### Testing
CI.

### API Changes
This PR has  API changes.
