### PR TITLE
Remove non-Semver get_eth_fw_version() from FirmwareInfoProvider

### DIFF
--- a/device/api/umd/device/firmware/firmware_info_provider.hpp
+++ b/device/api/umd/device/firmware/firmware_info_provider.hpp
@@ -53,11 +53,7 @@ public:
 
     uint64_t get_board_id() const;
 
-    std::optional<uint32_t> get_eth_fw_version() const;
-
-    // TODO: remove semver suffix from this function when client code is changed to use SemVer directly.
-    // Remove version of the function that returns uint32_t accordingly.
-    std::optional<SemVer> get_eth_fw_version_semver() const;
+    std::optional<SemVer> get_eth_fw_version() const;
 
     std::optional<SemVer> get_gddr_fw_version() const;
 

--- a/device/firmware/firmware_info_provider.cpp
+++ b/device/firmware/firmware_info_provider.cpp
@@ -352,12 +352,8 @@ uint64_t FirmwareInfoProvider::get_board_id() const {
     return (static_cast<uint64_t>(high) << 32) | low;
 }
 
-std::optional<uint32_t> FirmwareInfoProvider::get_eth_fw_version() const {
-    return read_scalar<uint32_t>(FirmwareFeature::ETH_FW_VERSION);
-}
-
-std::optional<SemVer> FirmwareInfoProvider::get_eth_fw_version_semver() const {
-    auto tag_value = get_eth_fw_version();
+std::optional<SemVer> FirmwareInfoProvider::get_eth_fw_version() const {
+    auto tag_value = read_scalar<uint32_t>(FirmwareFeature::ETH_FW_VERSION);
     if (!tag_value.has_value()) {
         return std::nullopt;
     }

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -630,7 +630,7 @@ bool TopologyDiscovery::verify_eth_core_fw_version(TTDevice* tt_device, uint64_t
 
     bool eth_fw_problem = false;
     if (!expected_eth_fw_version.has_value()) {
-        expected_eth_fw_version = tt_device->get_firmware_info_provider()->get_eth_fw_version_semver();
+        expected_eth_fw_version = tt_device->get_firmware_info_provider()->get_eth_fw_version();
         if (expected_eth_fw_version.has_value()) {
             log_debug(LogUMD, "Expected ETH FW version from telemetry: {}", expected_eth_fw_version->to_string());
         } else {

--- a/tests/api/test_firmware_info_provider.cpp
+++ b/tests/api/test_firmware_info_provider.cpp
@@ -245,7 +245,7 @@ TEST_F(TestFirmwareInfoProvider, EthFirmwareVersion) {
         tt::ARCH arch = tt_device->get_arch();
         FirmwareBundleVersion fw_version = fw_info->get_firmware_version();
 
-        std::optional<SemVer> eth_fw_version_semver = fw_info->get_eth_fw_version_semver();
+        std::optional<SemVer> eth_fw_version_semver = fw_info->get_eth_fw_version();
 
         log_info(
             tt::LogUMD,


### PR DESCRIPTION
### Issue
related to #2876 

### Description
Remove non-Semver get_eth_fw_version() from FirmwareInfoProvider

### Testing
CI

### API Changes
This PR has API changes.
