### PR TITLE
Move supported firmware static methods out of FirmwareInfoProvider

### DIFF
--- a/device/api/umd/device/firmware/firmware_info_provider.hpp
+++ b/device/api/umd/device/firmware/firmware_info_provider.hpp
@@ -31,7 +31,7 @@ class TTDevice;
  * and DRAM training status.
  *
  */
-class FirmwareInfoProvider final {
+class FirmwareInfoProvider {
 public:
     static std::unique_ptr<FirmwareInfoProvider> create_firmware_info_provider(TTDevice* tt_device);
 
@@ -40,16 +40,6 @@ public:
     ~FirmwareInfoProvider() = default;
 
     FirmwareBundleVersion get_firmware_version() const;
-
-    static FirmwareBundleVersion get_minimum_compatible_firmware_version(tt::ARCH arch);
-
-    /**
-     * This function should capture latest firmware version that is supported by the UMD.
-     * It is used to verify that the firmware running on the device is not newer than what UMD supports.
-     * The function is meant to change on every FW release, so we can keep track of supported features
-     * from new FW versions.
-     */
-    static FirmwareBundleVersion get_latest_supported_firmware_version(tt::ARCH arch);
 
     uint64_t get_board_id() const;
 

--- a/device/api/umd/device/firmware/firmware_utils.hpp
+++ b/device/api/umd/device/firmware/firmware_utils.hpp
@@ -21,6 +21,10 @@ namespace tt::umd {
 class TTDevice;
 class SocDescriptor;
 
+FirmwareBundleVersion get_minimum_compatible_firmware_version(tt::ARCH arch);
+
+FirmwareBundleVersion get_latest_supported_firmware_version(tt::ARCH arch);
+
 FirmwareBundleVersion get_firmware_version_util(TTDevice* tt_device);
 
 SemVer get_tt_flash_version_from_telemetry(const uint32_t telemetry_data);

--- a/device/firmware/firmware_info_provider.cpp
+++ b/device/firmware/firmware_info_provider.cpp
@@ -329,23 +329,6 @@ template std::optional<uint16_t> FirmwareInfoProvider::read_scalar<uint16_t>(Fir
 
 FirmwareBundleVersion FirmwareInfoProvider::get_firmware_version() const { return firmware_version; }
 
-/* static */ FirmwareBundleVersion FirmwareInfoProvider::get_latest_supported_firmware_version(tt::ARCH arch) {
-    return FirmwareBundleVersion(19, 7, 1);
-}
-
-/* static */ FirmwareBundleVersion FirmwareInfoProvider::get_minimum_compatible_firmware_version(tt::ARCH arch) {
-    switch (arch) {
-        case tt::ARCH::WORMHOLE_B0: {
-            return FirmwareBundleVersion(18, 3, 0);
-        }
-        case tt::ARCH::BLACKHOLE: {
-            return FirmwareBundleVersion(18, 5, 0);
-        }
-        default:
-            UMD_THROW(error::RuntimeError, "Unsupported architecture for firmware info provider.");
-    }
-}
-
 uint64_t FirmwareInfoProvider::get_board_id() const {
     uint32_t high = read_scalar<uint32_t>(FirmwareFeature::BOARD_ID_HIGH).value_or(0);
     uint32_t low = read_scalar<uint32_t>(FirmwareFeature::BOARD_ID_LOW).value_or(0);

--- a/device/firmware/firmware_utils.cpp
+++ b/device/firmware/firmware_utils.cpp
@@ -34,6 +34,21 @@
 
 namespace tt::umd {
 
+FirmwareBundleVersion get_latest_supported_firmware_version(tt::ARCH arch) { return FirmwareBundleVersion(19, 7, 1); }
+
+FirmwareBundleVersion get_minimum_compatible_firmware_version(tt::ARCH arch) {
+    switch (arch) {
+        case tt::ARCH::WORMHOLE_B0: {
+            return FirmwareBundleVersion(18, 3, 0);
+        }
+        case tt::ARCH::BLACKHOLE: {
+            return FirmwareBundleVersion(18, 5, 0);
+        }
+        default:
+            UMD_THROW(error::RuntimeError, "Unsupported architecture for firmware info provider.");
+    }
+}
+
 FirmwareBundleVersion get_firmware_version_util(TTDevice* tt_device) {
     if (tt_device->get_arch() == tt::ARCH::WORMHOLE_B0) {
         SmBusArcTelemetryReader smbus_reader(tt_device);

--- a/device/topology/topology_discovery.cpp
+++ b/device/topology/topology_discovery.cpp
@@ -573,10 +573,8 @@ void TopologyDiscovery::verify_fw_bundle_version(TTDevice* tt_device, uint64_t a
     const tt::ARCH arch = tt_device->get_arch();
     first_fw_bundle_version = fw_bundle_version;
     log_info(LogUMD, "Established firmware bundle version: {}", fw_bundle_version.to_string());
-    FirmwareBundleVersion minimum_compatible_fw_bundle_version =
-        FirmwareInfoProvider::get_minimum_compatible_firmware_version(arch);
-    FirmwareBundleVersion latest_supported_fw_bundle_version =
-        FirmwareInfoProvider::get_latest_supported_firmware_version(arch);
+    FirmwareBundleVersion minimum_compatible_fw_bundle_version = get_minimum_compatible_firmware_version(arch);
+    FirmwareBundleVersion latest_supported_fw_bundle_version = get_latest_supported_firmware_version(arch);
     log_debug(
         LogUMD,
         "System firmware bundle version: {}. UMD supported firmware bundle versions: {} - {}.{}",

--- a/nanobind/py_api_telemetry.cpp
+++ b/nanobind/py_api_telemetry.cpp
@@ -13,6 +13,7 @@
 #include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/arc/smbus_arc_telemetry_reader.hpp"
 #include "umd/device/firmware/firmware_info_provider.hpp"
+#include "umd/device/firmware/firmware_utils.hpp"
 #include "umd/device/types/gddr_telemetry.hpp"
 #include "umd/device/types/telemetry.hpp"
 #include "umd/device/types/wormhole_telemetry.hpp"
@@ -242,18 +243,19 @@ void bind_telemetry(nb::module_& m) {
         .def("get_eth_retrain_status", &FirmwareInfoProvider::get_eth_retrain_status, release_gil())
         .def("get_eth_link_status", &FirmwareInfoProvider::get_eth_link_status, release_gil())
         .def_static(
-            "get_minimum_compatible_firmware_version",
-            &FirmwareInfoProvider::get_minimum_compatible_firmware_version,
-            nb::arg("arch"),
-            release_gil())
-        .def_static(
-            "get_latest_supported_firmware_version",
-            &FirmwareInfoProvider::get_latest_supported_firmware_version,
-            nb::arg("arch"),
-            release_gil())
-        .def_static(
             "create_firmware_info_provider",
             &FirmwareInfoProvider::create_firmware_info_provider,
             nb::arg("tt_device"),
             release_gil());
+
+    m.def(
+        "get_minimum_compatible_firmware_version",
+        &get_minimum_compatible_firmware_version,
+        nb::arg("arch"),
+        release_gil());
+    m.def(
+        "get_latest_supported_firmware_version",
+        &get_latest_supported_firmware_version,
+        nb::arg("arch"),
+        release_gil());
 }

--- a/tests/api/test_firmware_info_provider.cpp
+++ b/tests/api/test_firmware_info_provider.cpp
@@ -102,8 +102,8 @@ private:
 
 TEST(TestFirmwareInfoProviderStatic, StaticVersionInfo) {
     // Test static methods that don't need a device.
-    FirmwareBundleVersion wh_min = FirmwareInfoProvider::get_minimum_compatible_firmware_version(tt::ARCH::WORMHOLE_B0);
-    FirmwareBundleVersion bh_min = FirmwareInfoProvider::get_minimum_compatible_firmware_version(tt::ARCH::BLACKHOLE);
+    FirmwareBundleVersion wh_min = get_minimum_compatible_firmware_version(tt::ARCH::WORMHOLE_B0);
+    FirmwareBundleVersion bh_min = get_minimum_compatible_firmware_version(tt::ARCH::BLACKHOLE);
 
     log_info(tt::LogUMD, "WH min compatible FW: {}", wh_min.to_string());
     log_info(tt::LogUMD, "BH min compatible FW: {}", bh_min.to_string());
@@ -111,9 +111,8 @@ TEST(TestFirmwareInfoProviderStatic, StaticVersionInfo) {
     EXPECT_EQ(wh_min, FW_VERSION_18_3);
     EXPECT_EQ(bh_min, FW_VERSION_18_5);
 
-    FirmwareBundleVersion wh_latest =
-        FirmwareInfoProvider::get_latest_supported_firmware_version(tt::ARCH::WORMHOLE_B0);
-    FirmwareBundleVersion bh_latest = FirmwareInfoProvider::get_latest_supported_firmware_version(tt::ARCH::BLACKHOLE);
+    FirmwareBundleVersion wh_latest = get_latest_supported_firmware_version(tt::ARCH::WORMHOLE_B0);
+    FirmwareBundleVersion bh_latest = get_latest_supported_firmware_version(tt::ARCH::BLACKHOLE);
 
     log_info(tt::LogUMD, "WH latest supported FW: {}", wh_latest.to_string());
     log_info(tt::LogUMD, "BH latest supported FW: {}", bh_latest.to_string());


### PR DESCRIPTION
### Issue
#2876 

### Description
Move supported firmware static methods out of FirmwareInfoProvider to match base API spec.

### List of the changes
- Move supported firmware static methods out of FirmwareInfoProvider.
- Remove final specifier from FirmwareInfoProvider.
- Update Python bindings.

### Testing
CI

### API Changes
This PR has API changes.
