### PR TITLE
Pin patchelf>=0.17 in wheel build to fix corrupted RPATH

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -239,7 +239,7 @@ jobs:
           echo "Setting up virtual environment..."
           python3 -m venv .venv
           source .venv/bin/activate
-          python -m pip install --upgrade pip wheel auditwheel
+          python -m pip install --upgrade pip wheel auditwheel "patchelf>=0.17"
           echo "Compiling the code..."
           # Override CMAKE_BUILD_TYPE to Release for sanitizer builds to avoid symbol conflicts with Python
           # Python interpreters are not built with sanitizers, so TSAN/ASAN wheels cannot be loaded


### PR DESCRIPTION
### Issue
#3151

### Description
Fixes ImportError libhwloc so cannot open shared object file, seen when importing tt_umd in the pytest job in run-tests.yml and the unittest job in run-exalens-tests.yml. Root cause is patchelf 0.14.3 corrupting the DT_RPATH entry when auditwheel repair rewrites the wheel extension module, so the vendored libhwloc so is unfindable at import time even though it is correctly bundled in the wheel.

### List of the changes
 - Pin patchelf>=0.17 alongside auditwheel in the wheel build step in build-tests.yml

### Testing
CI

### API Changes
This PR has no API changes.
