### PR TITLE
Reject device descriptors that index past core/NOC tables in CoordinateManager

### DIFF
--- a/device/coordinates/coordinate_manager.cpp
+++ b/device/coordinates/coordinate_manager.cpp
@@ -215,25 +215,11 @@ void CoordinateManager::translate_tensix_coords() {
     size_t grid_size_x = tensix_grid_size.x;
     size_t grid_size_y = tensix_grid_size.y;
 
-    if (grid_size_x != 0 && grid_size_y != 0 && tensix_cores.size() / grid_size_x < grid_size_y) {
-        UMD_THROW(
-            error::RuntimeError,
-            fmt::format(
-                "CoordinateManager: tensix core list size {} is smaller than declared grid {}x{}",
-                tensix_cores.size(),
-                grid_size_x,
-                grid_size_y));
-    }
-
     size_t logical_y = 0;
     for (size_t y = 0; y < grid_size_y; y++) {
         if (!(harvesting_masks.tensix_harvesting_mask & (1 << y))) {
             for (size_t x = 0; x < grid_size_x; x++) {
-                const size_t idx = y * grid_size_x + x;
-                if (idx >= tensix_cores.size()) {
-                    UMD_THROW(error::RuntimeError, "CoordinateManager: tensix core index out of range");
-                }
-                const tt_xy_pair& tensix_core = tensix_cores[idx];
+                const tt_xy_pair& tensix_core = tensix_cores.at(y * grid_size_x + x);
 
                 CoreCoord logical_coord = CoreCoord(x, logical_y, CoreType::TENSIX, CoordSystem::LOGICAL);
                 add_core_translation(logical_coord, tensix_core);
@@ -861,15 +847,12 @@ void CoordinateManager::add_noc1_to_noc0_mapping() {
 
     auto map_noc0_to_noc1_cores = [this](const std::vector<tt_xy_pair>& cores, CoreType core_type) {
         for (const tt_xy_pair& tensix_core : cores) {
-            if (tensix_core.x >= noc0_x_to_noc1_x.size() || tensix_core.y >= noc0_y_to_noc1_y.size()) {
-                UMD_THROW(
-                    error::RuntimeError,
-                    fmt::format(
-                        "CoordinateManager: NOC1 mapping index ({},{}) is out of range", tensix_core.x, tensix_core.y));
-            }
             add_core_translation(
                 CoreCoord(
-                    noc0_x_to_noc1_x[tensix_core.x], noc0_y_to_noc1_y[tensix_core.y], core_type, CoordSystem::NOC1),
+                    noc0_x_to_noc1_x.at(tensix_core.x),
+                    noc0_y_to_noc1_y.at(tensix_core.y),
+                    core_type,
+                    CoordSystem::NOC1),
                 tensix_core);
         }
     };

--- a/device/coordinates/coordinate_manager.cpp
+++ b/device/coordinates/coordinate_manager.cpp
@@ -215,8 +215,7 @@ void CoordinateManager::translate_tensix_coords() {
     size_t grid_size_x = tensix_grid_size.x;
     size_t grid_size_y = tensix_grid_size.y;
 
-    if (grid_size_x != 0 && grid_size_y != 0 &&
-        tensix_cores.size() / grid_size_x < grid_size_y) {
+    if (grid_size_x != 0 && grid_size_y != 0 && tensix_cores.size() / grid_size_x < grid_size_y) {
         UMD_THROW(
             error::RuntimeError,
             fmt::format(
@@ -866,9 +865,7 @@ void CoordinateManager::add_noc1_to_noc0_mapping() {
                 UMD_THROW(
                     error::RuntimeError,
                     fmt::format(
-                        "CoordinateManager: NOC1 mapping index ({},{}) is out of range",
-                        tensix_core.x,
-                        tensix_core.y));
+                        "CoordinateManager: NOC1 mapping index ({},{}) is out of range", tensix_core.x, tensix_core.y));
             }
             add_core_translation(
                 CoreCoord(

--- a/device/coordinates/coordinate_manager.cpp
+++ b/device/coordinates/coordinate_manager.cpp
@@ -215,11 +215,26 @@ void CoordinateManager::translate_tensix_coords() {
     size_t grid_size_x = tensix_grid_size.x;
     size_t grid_size_y = tensix_grid_size.y;
 
+    if (grid_size_x != 0 && grid_size_y != 0 &&
+        tensix_cores.size() / grid_size_x < grid_size_y) {
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format(
+                "CoordinateManager: tensix core list size {} is smaller than declared grid {}x{}",
+                tensix_cores.size(),
+                grid_size_x,
+                grid_size_y));
+    }
+
     size_t logical_y = 0;
     for (size_t y = 0; y < grid_size_y; y++) {
         if (!(harvesting_masks.tensix_harvesting_mask & (1 << y))) {
             for (size_t x = 0; x < grid_size_x; x++) {
-                const tt_xy_pair& tensix_core = tensix_cores[y * grid_size_x + x];
+                const size_t idx = y * grid_size_x + x;
+                if (idx >= tensix_cores.size()) {
+                    UMD_THROW(error::RuntimeError, "CoordinateManager: tensix core index out of range");
+                }
+                const tt_xy_pair& tensix_core = tensix_cores[idx];
 
                 CoreCoord logical_coord = CoreCoord(x, logical_y, CoreType::TENSIX, CoordSystem::LOGICAL);
                 add_core_translation(logical_coord, tensix_core);
@@ -847,6 +862,14 @@ void CoordinateManager::add_noc1_to_noc0_mapping() {
 
     auto map_noc0_to_noc1_cores = [this](const std::vector<tt_xy_pair>& cores, CoreType core_type) {
         for (const tt_xy_pair& tensix_core : cores) {
+            if (tensix_core.x >= noc0_x_to_noc1_x.size() || tensix_core.y >= noc0_y_to_noc1_y.size()) {
+                UMD_THROW(
+                    error::RuntimeError,
+                    fmt::format(
+                        "CoordinateManager: NOC1 mapping index ({},{}) is out of range",
+                        tensix_core.x,
+                        tensix_core.y));
+            }
             add_core_translation(
                 CoreCoord(
                     noc0_x_to_noc1_x[tensix_core.x], noc0_y_to_noc1_y[tensix_core.y], core_type, CoordSystem::NOC1),

--- a/tests/baremetal/test_core_coord_translation_wh.cpp
+++ b/tests/baremetal/test_core_coord_translation_wh.cpp
@@ -21,7 +21,6 @@
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/common.hpp"
-#include "umd/device/utils/error.hpp"
 
 using namespace tt;
 using namespace tt::umd;
@@ -448,7 +447,7 @@ TEST(CoordinateManager, CoordinateManagerRejectGridLargerThanCoreList) {
             std::vector<tt_xy_pair>{},
             std::vector<tt_xy_pair>{},
             std::vector<tt_xy_pair>{}),
-        tt::umd::error::UmdException<tt::umd::error::RuntimeError>);
+        std::out_of_range);
 }
 
 // Regression test that a core whose NOC0 coordinate exceeds the size of the
@@ -480,5 +479,5 @@ TEST(CoordinateManager, CoordinateManagerRejectNoc1IndexOutOfRange) {
             std::vector<tt_xy_pair>{},
             noc0_x_to_noc1_x,
             noc0_y_to_noc1_y),
-        tt::umd::error::UmdException<tt::umd::error::RuntimeError>);
+        std::out_of_range);
 }

--- a/tests/baremetal/test_core_coord_translation_wh.cpp
+++ b/tests/baremetal/test_core_coord_translation_wh.cpp
@@ -21,6 +21,7 @@
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/common.hpp"
+#include "umd/device/utils/error.hpp"
 
 using namespace tt;
 using namespace tt::umd;
@@ -420,4 +421,64 @@ TEST(CoordinateManager, CoordinateManagerWormholeNoc1Noc0Mapping) {
     check_noc0_noc1_mapping(wormhole::ETH_CORES_NOC0, ETH_CORES_NOC1, CoreType::ETH);
     check_noc0_noc1_mapping(wormhole::ARC_CORES_NOC0, ARC_CORES_NOC1, CoreType::ARC);
     check_noc0_noc1_mapping(wormhole::PCIE_CORES_NOC0, PCIE_CORES_NOC1, CoreType::PCIE);
+}
+
+// Regression: a device descriptor may declare a tensix grid that is larger than
+// the number of cores it provides. The flat loop index (y * grid_size_x + x) in
+// translate_tensix_coords() must not read past the end of the core list.
+TEST(CoordinateManager, CoordinateManagerRejectGridLargerThanCoreList) {
+    tt_xy_pair tensix_grid_size(2, 2);
+    std::vector<tt_xy_pair> tensix_cores{tt_xy_pair(0, 0), tt_xy_pair(0, 1)};  // only 2 of 4 cores
+
+    EXPECT_THROW(
+        CoordinateManager::create_coordinate_manager(
+            tt::ARCH::WORMHOLE_B0,
+            true,
+            tt::HarvestingMasks{},
+            tensix_grid_size,
+            tensix_cores,
+            tt_xy_pair(0, 0),
+            std::vector<tt_xy_pair>{},
+            std::vector<tt_xy_pair>{},
+            tt_xy_pair(0, 0),
+            std::vector<tt_xy_pair>{},
+            tt_xy_pair(0, 0),
+            std::vector<tt_xy_pair>{},
+            std::vector<tt_xy_pair>{},
+            std::vector<tt_xy_pair>{},
+            std::vector<tt_xy_pair>{},
+            std::vector<tt_xy_pair>{}),
+        tt::umd::error::UmdException<tt::umd::error::RuntimeError>);
+}
+
+// Regression test that a core whose NOC0 coordinate exceeds the size of the
+// NOC0->NOC1 translation table is rejected instead of reading past the vector.
+TEST(CoordinateManager, CoordinateManagerRejectNoc1IndexOutOfRange) {
+    tt_xy_pair tensix_grid_size(1, 1);
+    std::vector<tt_xy_pair> tensix_cores{tt_xy_pair(4, 0)};  // x exceeds the table width below
+
+    std::vector<uint32_t> noc0_x_to_noc1_x{0};  // width 1 < core x == 4
+    std::vector<uint32_t> noc0_y_to_noc1_y{0};
+
+    EXPECT_THROW(
+        CoordinateManager::create_coordinate_manager(
+            tt::ARCH::WORMHOLE_B0,
+            true,
+            tt::HarvestingMasks{},
+            tensix_grid_size,
+            tensix_cores,
+            tt_xy_pair(0, 0),
+            std::vector<tt_xy_pair>{},
+            std::vector<tt_xy_pair>{},
+            tt_xy_pair(0, 0),
+            std::vector<tt_xy_pair>{},
+            tt_xy_pair(0, 0),
+            std::vector<tt_xy_pair>{},
+            std::vector<tt_xy_pair>{},
+            std::vector<tt_xy_pair>{},
+            std::vector<tt_xy_pair>{},
+            std::vector<tt_xy_pair>{},
+            noc0_x_to_noc1_x,
+            noc0_y_to_noc1_y),
+        tt::umd::error::UmdException<tt::umd::error::RuntimeError>);
 }


### PR DESCRIPTION
### Issue
Fixes https://github.com/tenstorrent/tt-umd/issues/3154

### Description
Grid sizes, core coordinates, and NOC0->NOC1 translation tables all come from a device descriptor YAML. There was no invariant tying them together, so a descriptor could declare a tensix grid larger than its core list or a core whose NOC0 coordinate exceeds the translation table, causing an out-of-bounds heap read in CoordinateManager.

Add bounds validation before indexing:
- translate_tensix_coords(): reject a tensix grid larger than the number of provided cores, and bounds-check the flat loop index.
- add_noc1_to_noc0_mapping(): reject cores whose NOC0 coordinates exceed the size of the NOC0->NOC1 translation tables.

A crafted descriptor now produces a clean RuntimeError at descriptor parsing instead of a heap-buffer-overflow abort.

### List of the changes
- device/coordinates/coordinate_manager.cpp
  - guard in translate_tensix_coords() against an oversized tensix grid and against an out-of-range flat index
  - bounds check on tensix_core.x / tensix_core.y in add_noc1_to_noc0_mapping()
- tests/baremetal/test_core_coord_translation_wh.cpp
  - two focused gtests asserting the malformed descriptors are rejected with UmdException<RuntimeError>

### Testing
- Local (hardware-free): compiled coordinate_manager.cpp and the architecture coordinate-manager sources with clang and drove create_coordinate_manager() with the malformed inputs. Both new guards throw UmdException<RuntimeError>:
  - "tensix core list size N is smaller than declared grid WxH"
  - "NOC1 mapping index (X,Y) is out of range"
- Before the fix, the same driver does not reject the input and performs the out-of-bounds heap read.
- The two gtests cover the same paths and run in the baremetal CI lane.

### API Changes
This PR has no API changes.