### PR TITLE
Add read-only host page pinning support

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -288,6 +288,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/types/communication_protocol.hpp
                 api/umd/device/types/core_coordinates.hpp
                 api/umd/device/types/gddr_telemetry.hpp
+                api/umd/device/types/host_memory.hpp
                 api/umd/device/types/telemetry.hpp
                 api/umd/device/types/tlb.hpp
                 api/umd/device/types/wormhole_dram.hpp

--- a/device/api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
@@ -32,7 +32,10 @@ public:
         size_t sysmem_buffer_size, const bool map_to_noc = false) override;
 
     std::unique_ptr<SysmemBuffer> map_sysmem_buffer(
-        void* buffer, size_t sysmem_buffer_size, const bool map_to_noc = false) override;
+        void* buffer,
+        size_t sysmem_buffer_size,
+        const bool map_to_noc = false,
+        DeviceBufferAccess access = DeviceBufferAccess::ReadWrite) override;
 
 protected:
     bool init_sysmem(uint32_t num_host_mem_channels) override;

--- a/device/api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/silicon_sysmem_manager.hpp
@@ -35,7 +35,7 @@ public:
         void* buffer,
         size_t sysmem_buffer_size,
         const bool map_to_noc = false,
-        DeviceBufferAccess access = DeviceBufferAccess::ReadWrite) override;
+        DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE) override;
 
 protected:
     bool init_sysmem(uint32_t num_host_mem_channels) override;

--- a/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
@@ -47,7 +47,7 @@ public:
         void* buffer,
         size_t sysmem_buffer_size,
         const bool map_to_noc = false,
-        DeviceBufferAccess access = DeviceBufferAccess::ReadWrite) override;
+        DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE) override;
 
     // Called by TTSimTTDevice::pci_dma_{read,write}_bytes when the simulator
     // fires a DMA callback with a raw device IO address (pcie_base_ + offset).

--- a/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_sysmem_manager.hpp
@@ -44,7 +44,10 @@ public:
         size_t sysmem_buffer_size, const bool map_to_noc = false) override;
 
     std::unique_ptr<SysmemBuffer> map_sysmem_buffer(
-        void* buffer, size_t sysmem_buffer_size, const bool map_to_noc = false) override;
+        void* buffer,
+        size_t sysmem_buffer_size,
+        const bool map_to_noc = false,
+        DeviceBufferAccess access = DeviceBufferAccess::ReadWrite) override;
 
     // Called by TTSimTTDevice::pci_dma_{read,write}_bytes when the simulator
     // fires a DMA callback with a raw device IO address (pcie_base_ + offset).

--- a/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 #include <optional>
 
+#include "umd/device/types/host_memory.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
@@ -51,13 +52,19 @@ public:
      * @param buffer_size Size of the buffer requested by the user.
      * @param map_to_noc If true, the buffer will be mapped to be accessible over NOC from device.
      */
-    SysmemBuffer(TTDevice* tt_device, void* buffer_va, size_t buffer_size, bool map_to_noc = false);
+    SysmemBuffer(
+        TTDevice* tt_device,
+        void* buffer_va,
+        size_t buffer_size,
+        bool map_to_noc = false,
+        DeviceBufferAccess access = DeviceBufferAccess::ReadWrite);
     SysmemBuffer(
         void* buffer_va,
         size_t buffer_size,
         uint64_t device_io_addr,
         std::optional<uint64_t> noc_addr = std::nullopt,
-        std::function<void()> unmap_callback = {});
+        std::function<void()> unmap_callback = {},
+        DeviceBufferAccess access = DeviceBufferAccess::ReadWrite);
     ~SysmemBuffer();
 
     /**
@@ -82,6 +89,8 @@ public:
     uint64_t get_device_io_addr(const size_t offset = 0) const;
 
     std::optional<uint64_t> get_noc_addr() const { return noc_addr_; }
+
+    DeviceBufferAccess get_device_access() const { return device_access_; }
 
     /**
      * Does zero copy DMA transfer to the device. Since the buffer is already mapped through KMD, this function
@@ -147,6 +156,7 @@ private:
     std::optional<uint64_t> noc_addr_;
 
     std::function<void()> unmap_callback_;
+    DeviceBufferAccess device_access_ = DeviceBufferAccess::ReadWrite;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_buffer.hpp
@@ -57,14 +57,14 @@ public:
         void* buffer_va,
         size_t buffer_size,
         bool map_to_noc = false,
-        DeviceBufferAccess access = DeviceBufferAccess::ReadWrite);
+        DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE);
     SysmemBuffer(
         void* buffer_va,
         size_t buffer_size,
         uint64_t device_io_addr,
         std::optional<uint64_t> noc_addr = std::nullopt,
         std::function<void()> unmap_callback = {},
-        DeviceBufferAccess access = DeviceBufferAccess::ReadWrite);
+        DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE);
     ~SysmemBuffer();
 
     /**
@@ -156,7 +156,7 @@ private:
     std::optional<uint64_t> noc_addr_;
 
     std::function<void()> unmap_callback_;
-    DeviceBufferAccess device_access_ = DeviceBufferAccess::ReadWrite;
+    DeviceBufferAccess device_access_ = DeviceBufferAccess::READ_WRITE;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/chip_helpers/sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_manager.hpp
@@ -52,7 +52,10 @@ public:
         size_t sysmem_buffer_size, const bool map_to_noc = false) = 0;
 
     virtual std::unique_ptr<SysmemBuffer> map_sysmem_buffer(
-        void* buffer, size_t sysmem_buffer_size, const bool map_to_noc = false) = 0;
+        void* buffer,
+        size_t sysmem_buffer_size,
+        const bool map_to_noc = false,
+        DeviceBufferAccess access = DeviceBufferAccess::ReadWrite) = 0;
 
     uint64_t get_pcie_base() const { return pcie_base_; }
 

--- a/device/api/umd/device/chip_helpers/sysmem_manager.hpp
+++ b/device/api/umd/device/chip_helpers/sysmem_manager.hpp
@@ -55,7 +55,13 @@ public:
         void* buffer,
         size_t sysmem_buffer_size,
         const bool map_to_noc = false,
-        DeviceBufferAccess access = DeviceBufferAccess::ReadWrite) = 0;
+        DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE) = 0;
+
+    /**
+     * @return whether this manager can pin host pages such that the device may read them but not write them,
+     * i.e. whether DeviceBufferAccess::READ_ONLY is enforceable for map_sysmem_buffer().
+     */
+    virtual bool is_read_only_page_pinning_supported() const;
 
     uint64_t get_pcie_base() const { return pcie_base_; }
 

--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -230,10 +230,11 @@ public:
      * Map a buffer so it is accessible by the device NOC.
      * @param buffer must be page-aligned
      * @param size must be a multiple of the page size
+     * @param device_access READ_ONLY requires is_read_only_page_pinning_supported()
      * @return uint64_t NOC address, uint64_t PA or IOVA
      */
     std::pair<uint64_t, uint64_t> map_buffer_to_noc(
-        void *buffer, size_t size, DeviceBufferAccess access = DeviceBufferAccess::ReadWrite);
+        void *buffer, size_t size, DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE);
 
     /**
      * Map a hugepage so it is accessible by the device NOC.
@@ -251,9 +252,10 @@ public:
      *
      * @param buffer must be page-aligned
      * @param size must be a multiple of the page size
+     * @param device_access READ_ONLY requires is_read_only_page_pinning_supported()
      * @return uint64_t PA (no IOMMU) or IOVA (with IOMMU) for use by the device
      */
-    uint64_t map_for_dma(void *buffer, size_t size, DeviceBufferAccess access = DeviceBufferAccess::ReadWrite);
+    uint64_t map_for_dma(void *buffer, size_t size, DeviceBufferAccess device_access = DeviceBufferAccess::READ_WRITE);
 
     /**
      * @return whether this device and KMD support device-read-only host mappings

--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -22,6 +22,7 @@
 #include "umd/device/pcie/silicon_tlb_handle.hpp"
 #include "umd/device/pcie/tlb_handle.hpp"
 #include "umd/device/types/arch.hpp"
+#include "umd/device/types/host_memory.hpp"
 #include "umd/device/types/tlb.hpp"
 #include "umd/device/utils/semver.hpp"
 
@@ -231,7 +232,8 @@ public:
      * @param size must be a multiple of the page size
      * @return uint64_t NOC address, uint64_t PA or IOVA
      */
-    std::pair<uint64_t, uint64_t> map_buffer_to_noc(void *buffer, size_t size);
+    std::pair<uint64_t, uint64_t> map_buffer_to_noc(
+        void *buffer, size_t size, DeviceBufferAccess access = DeviceBufferAccess::ReadWrite);
 
     /**
      * Map a hugepage so it is accessible by the device NOC.
@@ -251,7 +253,12 @@ public:
      * @param size must be a multiple of the page size
      * @return uint64_t PA (no IOMMU) or IOVA (with IOMMU) for use by the device
      */
-    uint64_t map_for_dma(void *buffer, size_t size);
+    uint64_t map_for_dma(void *buffer, size_t size, DeviceBufferAccess access = DeviceBufferAccess::ReadWrite);
+
+    /**
+     * @return whether this device and KMD support device-read-only host mappings
+     */
+    bool is_read_only_page_pinning_supported() const;
 
     /**
      * Access the device's DMA buffer.  This buffer is not guaranteed to exist.

--- a/device/api/umd/device/types/host_memory.hpp
+++ b/device/api/umd/device/types/host_memory.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace tt::umd {
+
+/**
+ * @brief Device permissions for a pinned host-memory mapping.
+ *
+ * ReadOnly prevents the device from writing the mapping. It does not restrict
+ * host access to the underlying virtual memory.
+ */
+enum class DeviceBufferAccess {
+    ReadWrite,
+    ReadOnly,
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/types/host_memory.hpp
+++ b/device/api/umd/device/types/host_memory.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/device/api/umd/device/types/host_memory.hpp
+++ b/device/api/umd/device/types/host_memory.hpp
@@ -9,12 +9,12 @@ namespace tt::umd {
 /**
  * @brief Device permissions for a pinned host-memory mapping.
  *
- * ReadOnly prevents the device from writing the mapping. It does not restrict
+ * READ_ONLY prevents the device from writing the mapping. It does not restrict
  * host access to the underlying virtual memory.
  */
 enum class DeviceBufferAccess {
-    ReadWrite,
-    ReadOnly,
+    READ_WRITE,
+    READ_ONLY,
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/utils/kmd_versions.hpp
+++ b/device/api/umd/device/utils/kmd_versions.hpp
@@ -43,6 +43,12 @@ inline constexpr SemVer KMD_TLBS = SemVer(1, 34, 0);
 inline constexpr SemVer KMD_POWER_STATE = SemVer(2, 6, 0);
 
 /**
+ * KMD version 2.9.0 introduced read-only page pinning. The IOMMU mapping permits device reads while faulting device
+ * writes, and allows device-readable mappings of read-only and shared file-backed memory.
+ */
+inline constexpr SemVer KMD_READ_ONLY_PAGE_PINNING = SemVer(2, 9, 0);
+
+/**
  * KMD version 2.10.0 introduced the TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF IOCTL, which exports an
  * allocated and configured TLB window as a Linux dma-buf fd for peer-to-peer PCIe DMA (e.g. RDMA
  * NIC import via ibv_reg_dmabuf_mr()).

--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -464,9 +464,9 @@ std::unique_ptr<SysmemBuffer> SiliconSysmemManager::allocate_sysmem_buffer(
 }
 
 std::unique_ptr<SysmemBuffer> SiliconSysmemManager::map_sysmem_buffer(
-    void *buffer, size_t sysmem_buffer_size, const bool map_to_noc) {
+    void *buffer, size_t sysmem_buffer_size, const bool map_to_noc, DeviceBufferAccess access) {
     log_debug(LogUMD, "Mapping sysmem buffer to NOC: {:#x}", sysmem_buffer_size);
-    return std::make_unique<SysmemBuffer>(tt_device_, buffer, sysmem_buffer_size, map_to_noc);
+    return std::make_unique<SysmemBuffer>(tt_device_, buffer, sysmem_buffer_size, map_to_noc, access);
 }
 
 }  // namespace tt::umd

--- a/device/chip_helpers/silicon_sysmem_manager.cpp
+++ b/device/chip_helpers/silicon_sysmem_manager.cpp
@@ -464,9 +464,9 @@ std::unique_ptr<SysmemBuffer> SiliconSysmemManager::allocate_sysmem_buffer(
 }
 
 std::unique_ptr<SysmemBuffer> SiliconSysmemManager::map_sysmem_buffer(
-    void *buffer, size_t sysmem_buffer_size, const bool map_to_noc, DeviceBufferAccess access) {
+    void *buffer, size_t sysmem_buffer_size, const bool map_to_noc, DeviceBufferAccess device_access) {
     log_debug(LogUMD, "Mapping sysmem buffer to NOC: {:#x}", sysmem_buffer_size);
-    return std::make_unique<SysmemBuffer>(tt_device_, buffer, sysmem_buffer_size, map_to_noc, access);
+    return std::make_unique<SysmemBuffer>(tt_device_, buffer, sysmem_buffer_size, map_to_noc, device_access);
 }
 
 }  // namespace tt::umd

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -164,7 +164,7 @@ std::unique_ptr<SysmemBuffer> SimulationSysmemManager::allocate_sysmem_buffer(
 }
 
 std::unique_ptr<SysmemBuffer> SimulationSysmemManager::map_sysmem_buffer(
-    void* buffer, size_t sysmem_buffer_size, const bool map_to_noc, DeviceBufferAccess access) {
+    void* buffer, size_t sysmem_buffer_size, const bool map_to_noc, DeviceBufferAccess device_access) {
     static const auto page_size = sysconf(_SC_PAGESIZE);
     const uint64_t mapped_size = align_up(sysmem_buffer_size, page_size);
 
@@ -200,7 +200,7 @@ std::unique_ptr<SysmemBuffer> SimulationSysmemManager::map_sysmem_buffer(
                     reg->buffers.end());
             }
         },
-        access);
+        device_access);
 }
 
 }  // namespace tt::umd

--- a/device/chip_helpers/simulation_sysmem_manager.cpp
+++ b/device/chip_helpers/simulation_sysmem_manager.cpp
@@ -164,7 +164,7 @@ std::unique_ptr<SysmemBuffer> SimulationSysmemManager::allocate_sysmem_buffer(
 }
 
 std::unique_ptr<SysmemBuffer> SimulationSysmemManager::map_sysmem_buffer(
-    void* buffer, size_t sysmem_buffer_size, const bool map_to_noc) {
+    void* buffer, size_t sysmem_buffer_size, const bool map_to_noc, DeviceBufferAccess access) {
     static const auto page_size = sysconf(_SC_PAGESIZE);
     const uint64_t mapped_size = align_up(sysmem_buffer_size, page_size);
 
@@ -183,7 +183,11 @@ std::unique_ptr<SysmemBuffer> SimulationSysmemManager::map_sysmem_buffer(
     // has already been destroyed (unpin_or_unmap_sysmem clears the registry).
     std::weak_ptr<MappedBufferRegistry> weak_reg = registry_;
     return std::make_unique<SysmemBuffer>(
-        buffer, sysmem_buffer_size, device_io_addr, noc_addr, [weak_reg, device_io_addr]() {
+        buffer,
+        sysmem_buffer_size,
+        device_io_addr,
+        noc_addr,
+        [weak_reg, device_io_addr]() {
             if (auto reg = weak_reg.lock()) {
                 std::lock_guard<std::mutex> lock(reg->mutex);
                 reg->buffers.erase(
@@ -195,7 +199,8 @@ std::unique_ptr<SysmemBuffer> SimulationSysmemManager::map_sysmem_buffer(
                         }),
                     reg->buffers.end());
             }
-        });
+        },
+        access);
 }
 
 }  // namespace tt::umd

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -23,13 +23,13 @@
 namespace tt::umd {
 
 SysmemBuffer::SysmemBuffer(
-    TTDevice* tt_device, void* buffer_va, size_t buffer_size, bool map_to_noc, DeviceBufferAccess access) :
+    TTDevice* tt_device, void* buffer_va, size_t buffer_size, bool map_to_noc, DeviceBufferAccess device_access) :
     pci_device_(tt_device->get_pci_device()),
     tt_device_(tt_device),
     buffer_va_(buffer_va),
     mapped_buffer_size_(buffer_size),
     buffer_size_(buffer_size),
-    device_access_(access) {
+    device_access_(device_access) {
     UMD_ASSERT(pci_device_ != nullptr, error::RuntimeError, "PCI device not available in TTDevice.");
     align_address_and_size();
     if (map_to_noc) {
@@ -48,7 +48,7 @@ SysmemBuffer::SysmemBuffer(
     uint64_t device_io_addr,
     std::optional<uint64_t> noc_addr,
     std::function<void()> unmap_callback,
-    DeviceBufferAccess access) :
+    DeviceBufferAccess device_access) :
     pci_device_(nullptr),
     tt_device_(nullptr),
     buffer_va_(buffer_va),
@@ -57,7 +57,7 @@ SysmemBuffer::SysmemBuffer(
     device_io_addr_(device_io_addr),
     noc_addr_(noc_addr),
     unmap_callback_(std::move(unmap_callback)),
-    device_access_(access) {
+    device_access_(device_access) {
     align_address_and_size();
     // Pair with TracyFreeN in the destructor so Tracy sees balanced alloc/free.
     TracyAllocN(buffer_va_, mapped_buffer_size_, "SysmemBuffer");
@@ -79,7 +79,7 @@ void SysmemBuffer::dma_write_to_device(const size_t offset, size_t size, const t
 void SysmemBuffer::dma_read_from_device(const size_t offset, size_t size, const tt_xy_pair core, uint64_t addr) {
     ZoneScopedC(tracy::Color::Yellow);
 
-    if (device_access_ == DeviceBufferAccess::ReadOnly) {
+    if (device_access_ == DeviceBufferAccess::READ_ONLY) {
         UMD_THROW(error::RuntimeError, "Cannot DMA from the device into a device-read-only host mapping.");
     }
 

--- a/device/chip_helpers/sysmem_buffer.cpp
+++ b/device/chip_helpers/sysmem_buffer.cpp
@@ -22,18 +22,21 @@
 
 namespace tt::umd {
 
-SysmemBuffer::SysmemBuffer(TTDevice* tt_device, void* buffer_va, size_t buffer_size, bool map_to_noc) :
+SysmemBuffer::SysmemBuffer(
+    TTDevice* tt_device, void* buffer_va, size_t buffer_size, bool map_to_noc, DeviceBufferAccess access) :
     pci_device_(tt_device->get_pci_device()),
     tt_device_(tt_device),
     buffer_va_(buffer_va),
     mapped_buffer_size_(buffer_size),
-    buffer_size_(buffer_size) {
+    buffer_size_(buffer_size),
+    device_access_(access) {
     UMD_ASSERT(pci_device_ != nullptr, error::RuntimeError, "PCI device not available in TTDevice.");
     align_address_and_size();
     if (map_to_noc) {
-        std::tie(noc_addr_, device_io_addr_) = pci_device_->map_buffer_to_noc(buffer_va_, mapped_buffer_size_);
+        std::tie(noc_addr_, device_io_addr_) =
+            pci_device_->map_buffer_to_noc(buffer_va_, mapped_buffer_size_, device_access_);
     } else {
-        device_io_addr_ = pci_device_->map_for_dma(buffer_va_, mapped_buffer_size_);
+        device_io_addr_ = pci_device_->map_for_dma(buffer_va_, mapped_buffer_size_, device_access_);
         noc_addr_ = std::nullopt;
     }
     TracyAllocN(buffer_va_, mapped_buffer_size_, "SysmemBuffer");
@@ -44,7 +47,8 @@ SysmemBuffer::SysmemBuffer(
     size_t buffer_size,
     uint64_t device_io_addr,
     std::optional<uint64_t> noc_addr,
-    std::function<void()> unmap_callback) :
+    std::function<void()> unmap_callback,
+    DeviceBufferAccess access) :
     pci_device_(nullptr),
     tt_device_(nullptr),
     buffer_va_(buffer_va),
@@ -52,7 +56,8 @@ SysmemBuffer::SysmemBuffer(
     buffer_size_(buffer_size),
     device_io_addr_(device_io_addr),
     noc_addr_(noc_addr),
-    unmap_callback_(std::move(unmap_callback)) {
+    unmap_callback_(std::move(unmap_callback)),
+    device_access_(access) {
     align_address_and_size();
     // Pair with TracyFreeN in the destructor so Tracy sees balanced alloc/free.
     TracyAllocN(buffer_va_, mapped_buffer_size_, "SysmemBuffer");
@@ -73,6 +78,10 @@ void SysmemBuffer::dma_write_to_device(const size_t offset, size_t size, const t
 
 void SysmemBuffer::dma_read_from_device(const size_t offset, size_t size, const tt_xy_pair core, uint64_t addr) {
     ZoneScopedC(tracy::Color::Yellow);
+
+    if (device_access_ == DeviceBufferAccess::ReadOnly) {
+        UMD_THROW(error::RuntimeError, "Cannot DMA from the device into a device-read-only host mapping.");
+    }
 
     validate(offset, size);
 

--- a/device/chip_helpers/sysmem_manager.cpp
+++ b/device/chip_helpers/sysmem_manager.cpp
@@ -10,6 +10,7 @@
 #include <tt-logger/tt-logger.hpp>
 
 #include "tracy.hpp"
+#include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/utils/error.hpp"
@@ -88,6 +89,11 @@ uint64_t SysmemManager::get_pcie_base_for_arch(tt::ARCH arch) {
 }
 
 size_t SysmemManager::get_num_host_mem_channels() const { return hugepage_mapping_per_channel.size(); }
+
+bool SysmemManager::is_read_only_page_pinning_supported() const {
+    // Managers without a PCI device behind them (simulation) cannot pin host pages at all.
+    return pci_device_ != nullptr && pci_device_->is_read_only_page_pinning_supported();
+}
 
 HugepageMapping SysmemManager::get_hugepage_mapping(size_t channel) const {
     if (hugepage_mapping_per_channel.size() <= channel) {

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -612,7 +612,8 @@ bool PCIDevice::is_read_only_page_pinning_supported() const {
     return is_iommu_enabled() && kmd_version >= KMD_READ_ONLY_PAGE_PINNING;
 }
 
-std::pair<uint64_t, uint64_t> PCIDevice::map_buffer_to_noc(void *buffer, size_t size, DeviceBufferAccess device_access) {
+std::pair<uint64_t, uint64_t> PCIDevice::map_buffer_to_noc(
+    void *buffer, size_t size, DeviceBufferAccess device_access) {
     if (kmd_version < KMD_MAP_TO_NOC) {
         UMD_THROW(error::RuntimeError, "KMD version must be at least 2.0.0 to use buffer with NOC mapping.");
     }

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -606,9 +606,17 @@ uint64_t PCIDevice::map_for_hugepage(void *buffer, size_t size) {
 
 bool PCIDevice::is_mapping_buffer_to_noc_supported() { return PCIDevice::read_kmd_version() >= KMD_MAP_TO_NOC; }
 
-std::pair<uint64_t, uint64_t> PCIDevice::map_buffer_to_noc(void *buffer, size_t size) {
+bool PCIDevice::is_read_only_page_pinning_supported() const {
+    return is_iommu_enabled() && PCIDevice::read_kmd_version() >= KMD_READ_ONLY_PAGE_PINNING;
+}
+
+std::pair<uint64_t, uint64_t> PCIDevice::map_buffer_to_noc(void *buffer, size_t size, DeviceBufferAccess access) {
     if (PCIDevice::read_kmd_version() < KMD_MAP_TO_NOC) {
         UMD_THROW(error::RuntimeError, "KMD version must be at least 2.0.0 to use buffer with NOC mapping.");
+    }
+    if (access == DeviceBufferAccess::ReadOnly && !is_read_only_page_pinning_supported()) {
+        UMD_THROW(
+            error::RuntimeError, "Device-read-only page pinning requires KMD 2.9.0 or newer and an active IOMMU.");
     }
 
     static const auto page_size = sysconf(_SC_PAGESIZE);
@@ -622,7 +630,10 @@ std::pair<uint64_t, uint64_t> PCIDevice::map_buffer_to_noc(void *buffer, size_t 
         UMD_THROW(error::RuntimeError, fmt::format("Cannot map buffer of size {} to NOC with IOMMU disabled.", size));
     }
 
-    const int flags = TT_DMA_FLAG_NOC;
+    int flags = TT_DMA_FLAG_NOC;
+    if (access == DeviceBufferAccess::ReadOnly) {
+        flags |= TT_DMA_FLAG_READ_ONLY;
+    }
 
     uint64_t physical_address = 0;
     uint64_t noc_address = 0;
@@ -699,11 +710,18 @@ std::pair<uint64_t, uint64_t> PCIDevice::map_hugepage_to_noc(void *hugepage, siz
     return {noc_address, physical_address};
 }
 
-uint64_t PCIDevice::map_for_dma(void *buffer, size_t size) {
+uint64_t PCIDevice::map_for_dma(void *buffer, size_t size, DeviceBufferAccess access) {
     static const auto page_size = sysconf(_SC_PAGESIZE);
 
     const uint64_t virtual_address = reinterpret_cast<uint64_t>(buffer);
-    const int flags = is_iommu_enabled() ? TT_DMA_FLAG_NONE : TT_DMA_FLAG_CONTIGUOUS;
+    int flags = is_iommu_enabled() ? TT_DMA_FLAG_NONE : TT_DMA_FLAG_CONTIGUOUS;
+    if (access == DeviceBufferAccess::ReadOnly) {
+        if (!is_read_only_page_pinning_supported()) {
+            UMD_THROW(
+                error::RuntimeError, "Device-read-only page pinning requires KMD 2.9.0 or newer and an active IOMMU.");
+        }
+        flags |= TT_DMA_FLAG_READ_ONLY;
+    }
 
     if (virtual_address % page_size != 0 || size % page_size != 0) {
         UMD_THROW(error::RuntimeError, "Buffer must be page-aligned with a size that is a multiple of the page size.");

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -612,11 +612,11 @@ bool PCIDevice::is_read_only_page_pinning_supported() const {
     return is_iommu_enabled() && kmd_version >= KMD_READ_ONLY_PAGE_PINNING;
 }
 
-std::pair<uint64_t, uint64_t> PCIDevice::map_buffer_to_noc(void *buffer, size_t size, DeviceBufferAccess access) {
+std::pair<uint64_t, uint64_t> PCIDevice::map_buffer_to_noc(void *buffer, size_t size, DeviceBufferAccess device_access) {
     if (kmd_version < KMD_MAP_TO_NOC) {
         UMD_THROW(error::RuntimeError, "KMD version must be at least 2.0.0 to use buffer with NOC mapping.");
     }
-    if (access == DeviceBufferAccess::ReadOnly && !is_read_only_page_pinning_supported()) {
+    if (device_access == DeviceBufferAccess::READ_ONLY && !is_read_only_page_pinning_supported()) {
         UMD_THROW(
             error::RuntimeError, "Device-read-only page pinning requires KMD 2.9.0 or newer and an active IOMMU.");
     }
@@ -633,7 +633,7 @@ std::pair<uint64_t, uint64_t> PCIDevice::map_buffer_to_noc(void *buffer, size_t 
     }
 
     int flags = TT_DMA_FLAG_NOC;
-    if (access == DeviceBufferAccess::ReadOnly) {
+    if (device_access == DeviceBufferAccess::READ_ONLY) {
         flags |= TT_DMA_FLAG_READ_ONLY;
     }
 
@@ -712,12 +712,12 @@ std::pair<uint64_t, uint64_t> PCIDevice::map_hugepage_to_noc(void *hugepage, siz
     return {noc_address, physical_address};
 }
 
-uint64_t PCIDevice::map_for_dma(void *buffer, size_t size, DeviceBufferAccess access) {
+uint64_t PCIDevice::map_for_dma(void *buffer, size_t size, DeviceBufferAccess device_access) {
     static const auto page_size = sysconf(_SC_PAGESIZE);
 
     const uint64_t virtual_address = reinterpret_cast<uint64_t>(buffer);
     int flags = is_iommu_enabled() ? TT_DMA_FLAG_NONE : TT_DMA_FLAG_CONTIGUOUS;
-    if (access == DeviceBufferAccess::ReadOnly) {
+    if (device_access == DeviceBufferAccess::READ_ONLY) {
         if (!is_read_only_page_pinning_supported()) {
             UMD_THROW(
                 error::RuntimeError, "Device-read-only page pinning requires KMD 2.9.0 or newer and an active IOMMU.");

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -613,7 +613,7 @@ bool PCIDevice::is_read_only_page_pinning_supported() const {
 }
 
 std::pair<uint64_t, uint64_t> PCIDevice::map_buffer_to_noc(void *buffer, size_t size, DeviceBufferAccess access) {
-    if (PCIDevice::read_kmd_version() < KMD_MAP_TO_NOC) {
+    if (kmd_version < KMD_MAP_TO_NOC) {
         UMD_THROW(error::RuntimeError, "KMD version must be at least 2.0.0 to use buffer with NOC mapping.");
     }
     if (access == DeviceBufferAccess::ReadOnly && !is_read_only_page_pinning_supported()) {
@@ -664,7 +664,7 @@ std::pair<uint64_t, uint64_t> PCIDevice::map_buffer_to_noc(void *buffer, size_t 
 }
 
 std::pair<uint64_t, uint64_t> PCIDevice::map_hugepage_to_noc(void *hugepage, size_t size) {
-    if (PCIDevice::read_kmd_version() < KMD_MAP_TO_NOC) {
+    if (kmd_version < KMD_MAP_TO_NOC) {
         UMD_THROW(error::RuntimeError, "KMD version must be at least 2.0.0 to use hugepages with NOC mapping.");
     }
 

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -607,7 +607,9 @@ uint64_t PCIDevice::map_for_hugepage(void *buffer, size_t size) {
 bool PCIDevice::is_mapping_buffer_to_noc_supported() { return PCIDevice::read_kmd_version() >= KMD_MAP_TO_NOC; }
 
 bool PCIDevice::is_read_only_page_pinning_supported() const {
-    return is_iommu_enabled() && PCIDevice::read_kmd_version() >= KMD_READ_ONLY_PAGE_PINNING;
+    // Use the version cached at construction: this is reached from the mapping path, once per pinned buffer, and
+    // read_kmd_version() re-opens and re-parses sysfs on every call.
+    return is_iommu_enabled() && kmd_version >= KMD_READ_ONLY_PAGE_PINNING;
 }
 
 std::pair<uint64_t, uint64_t> PCIDevice::map_buffer_to_noc(void *buffer, size_t size, DeviceBufferAccess access) {

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -2,8 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <fcntl.h>
 #include <gtest/gtest.h>
 #include <sys/mman.h>
+#include <unistd.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -27,6 +29,7 @@
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/utils/kmd_versions.hpp"
 
 using namespace tt;
 using namespace tt::umd;
@@ -277,6 +280,54 @@ TEST(ApiSysmemManager, SysmemBufferNocAddress) {
     std::unique_ptr<SysmemBuffer> sysmem_buffer2 = sysmem_manager->allocate_sysmem_buffer(one_mb, true);
     EXPECT_TRUE(sysmem_buffer2->get_noc_addr().has_value());
     EXPECT_GT(sysmem_buffer2->get_noc_addr().value(), cluster->get_pcie_base_addr_from_device(mmio_chip));
+}
+
+TEST(ApiSysmemManager, ReadOnlySharedFileMapping) {
+    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
+    if (pci_device_ids.empty()) {
+        GTEST_SKIP() << "No Tenstorrent PCI devices found.";
+    }
+
+    PCIDevice pci_device(pci_device_ids[0]);
+    if (!pci_device.is_iommu_enabled()) {
+        GTEST_SKIP() << "Device-read-only page pinning requires an active IOMMU.";
+    }
+    if (PCIDevice::read_kmd_version() < KMD_READ_ONLY_PAGE_PINNING) {
+        GTEST_SKIP() << "Device-read-only page pinning requires KMD " << KMD_READ_ONLY_PAGE_PINNING.str()
+                     << " or newer.";
+    }
+    if (!pci_device.is_mapping_buffer_to_noc_supported()) {
+        GTEST_SKIP() << "KMD does not support mapping host buffers to NOC.";
+    }
+
+    const size_t mapping_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    char file_name[] = "./tt_umd_read_only_pin_XXXXXX";
+    int writable_fd = mkstemp(file_name);
+    ASSERT_NE(writable_fd, -1);
+    ASSERT_EQ(ftruncate(writable_fd, mapping_size), 0);
+    ASSERT_EQ(close(writable_fd), 0);
+
+    int read_only_fd = open(file_name, O_RDONLY | O_CLOEXEC);
+    ASSERT_NE(read_only_fd, -1);
+    ASSERT_EQ(unlink(file_name), 0);
+
+    void* mapping = mmap(nullptr, mapping_size, PROT_READ, MAP_SHARED, read_only_fd, 0);
+    ASSERT_NE(mapping, MAP_FAILED);
+
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+    const ChipId mmio_chip = *cluster->get_target_mmio_device_ids().begin();
+    SysmemManager* sysmem_manager = cluster->get_chip(mmio_chip)->get_sysmem_manager();
+    auto sysmem_buffer = sysmem_manager->map_sysmem_buffer(mapping, mapping_size, true, DeviceBufferAccess::ReadOnly);
+
+    ASSERT_NE(sysmem_buffer, nullptr);
+    EXPECT_EQ(sysmem_buffer->get_buffer_va(), mapping);
+    EXPECT_EQ(sysmem_buffer->get_buffer_size(), mapping_size);
+    EXPECT_EQ(sysmem_buffer->get_device_access(), DeviceBufferAccess::ReadOnly);
+    EXPECT_TRUE(sysmem_buffer->get_noc_addr().has_value());
+
+    sysmem_buffer.reset();
+    EXPECT_EQ(munmap(mapping, mapping_size), 0);
+    EXPECT_EQ(close(read_only_fd), 0);
 }
 
 TEST(ApiSysmemManager, AutoNumChannels) {

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -292,14 +292,10 @@ TEST(ApiSysmemManager, ReadOnlySharedFileMapping) {
     }
     const ChipId mmio_chip = *cluster->get_target_mmio_device_ids().begin();
 
-    // Probe the capability on the device the mapping will actually be made through. PCIDevice::enumerate_devices()
-    // and the cluster's MMIO chip ordering are independent, so checking enumerate_devices()[0] can clear a device
-    // that is not the one map_sysmem_buffer ends up on, and the mapping then throws instead of skipping.
-    PCIDevice* pci_device = cluster->get_chip(mmio_chip)->get_tt_device()->get_pci_device();
-    if (pci_device == nullptr) {
-        GTEST_SKIP() << "MMIO chip has no PCI device.";
-    }
-    if (!pci_device->is_read_only_page_pinning_supported()) {
+    // Probe the capability on the manager the mapping will actually be made through, so a device other than the one
+    // map_sysmem_buffer ends up on cannot clear the gate and turn a skip into a throw.
+    SysmemManager* sysmem_manager = cluster->get_chip(mmio_chip)->get_sysmem_manager();
+    if (!sysmem_manager->is_read_only_page_pinning_supported()) {
         GTEST_SKIP() << "Device-read-only page pinning requires an active IOMMU and KMD "
                      << KMD_READ_ONLY_PAGE_PINNING.str() << " or newer.";
     }
@@ -345,13 +341,12 @@ TEST(ApiSysmemManager, ReadOnlySharedFileMapping) {
     void* mapping = mmap(nullptr, mapping_size, PROT_READ, MAP_SHARED, read_only_fd, 0);
     ASSERT_NE(mapping, MAP_FAILED);
 
-    SysmemManager* sysmem_manager = cluster->get_chip(mmio_chip)->get_sysmem_manager();
-    auto sysmem_buffer = sysmem_manager->map_sysmem_buffer(mapping, mapping_size, true, DeviceBufferAccess::ReadOnly);
+    auto sysmem_buffer = sysmem_manager->map_sysmem_buffer(mapping, mapping_size, true, DeviceBufferAccess::READ_ONLY);
 
     ASSERT_NE(sysmem_buffer, nullptr);
     EXPECT_EQ(sysmem_buffer->get_buffer_va(), mapping);
     EXPECT_EQ(sysmem_buffer->get_buffer_size(), mapping_size);
-    EXPECT_EQ(sysmem_buffer->get_device_access(), DeviceBufferAccess::ReadOnly);
+    EXPECT_EQ(sysmem_buffer->get_device_access(), DeviceBufferAccess::READ_ONLY);
     EXPECT_TRUE(sysmem_buffer->get_noc_addr().has_value());
 
     // Device reads the read-only mapping and writes it into Tensix L1 -- the direction read-only pinning exists to

--- a/tests/api/test_sysmem_manager.cpp
+++ b/tests/api/test_sysmem_manager.cpp
@@ -9,11 +9,14 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
+#include <filesystem>
 #include <memory>
 #include <optional>
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 #include <unordered_set>
 #include <vector>
 
@@ -283,39 +286,65 @@ TEST(ApiSysmemManager, SysmemBufferNocAddress) {
 }
 
 TEST(ApiSysmemManager, ReadOnlySharedFileMapping) {
-    std::vector<int> pci_device_ids = PCIDevice::enumerate_devices();
-    if (pci_device_ids.empty()) {
-        GTEST_SKIP() << "No Tenstorrent PCI devices found.";
+    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
+    if (cluster->get_target_mmio_device_ids().empty()) {
+        GTEST_SKIP() << "No Tenstorrent MMIO devices found.";
     }
+    const ChipId mmio_chip = *cluster->get_target_mmio_device_ids().begin();
 
-    PCIDevice pci_device(pci_device_ids[0]);
-    if (!pci_device.is_iommu_enabled()) {
-        GTEST_SKIP() << "Device-read-only page pinning requires an active IOMMU.";
+    // Probe the capability on the device the mapping will actually be made through. PCIDevice::enumerate_devices()
+    // and the cluster's MMIO chip ordering are independent, so checking enumerate_devices()[0] can clear a device
+    // that is not the one map_sysmem_buffer ends up on, and the mapping then throws instead of skipping.
+    PCIDevice* pci_device = cluster->get_chip(mmio_chip)->get_tt_device()->get_pci_device();
+    if (pci_device == nullptr) {
+        GTEST_SKIP() << "MMIO chip has no PCI device.";
     }
-    if (PCIDevice::read_kmd_version() < KMD_READ_ONLY_PAGE_PINNING) {
-        GTEST_SKIP() << "Device-read-only page pinning requires KMD " << KMD_READ_ONLY_PAGE_PINNING.str()
-                     << " or newer.";
+    if (!pci_device->is_read_only_page_pinning_supported()) {
+        GTEST_SKIP() << "Device-read-only page pinning requires an active IOMMU and KMD "
+                     << KMD_READ_ONLY_PAGE_PINNING.str() << " or newer.";
     }
-    if (!pci_device.is_mapping_buffer_to_noc_supported()) {
+    if (!PCIDevice::is_mapping_buffer_to_noc_supported()) {
         GTEST_SKIP() << "KMD does not support mapping host buffers to NOC.";
     }
 
     const size_t mapping_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
-    char file_name[] = "./tt_umd_read_only_pin_XXXXXX";
-    int writable_fd = mkstemp(file_name);
+    const std::string file_template = (std::filesystem::temp_directory_path() / "tt_umd_read_only_pin_XXXXXX").string();
+    std::vector<char> file_name(file_template.begin(), file_template.end());
+    file_name.push_back('\0');
+    int writable_fd = mkstemp(file_name.data());
     ASSERT_NE(writable_fd, -1);
+
+    // Remove the file on every exit path, including an ASSERT failure before the explicit unlink below.
+    struct FileRemover {
+        std::string path;
+
+        ~FileRemover() {
+            std::error_code ec;
+            std::filesystem::remove(path, ec);
+        }
+    } file_remover{std::string(file_name.data())};
+
     ASSERT_EQ(ftruncate(writable_fd, mapping_size), 0);
+
+    // Seed the file with a position-dependent pattern while it is still writable, so the transfer below proves the
+    // device actually reads the pinned pages rather than just that the accessors echo their arguments back.
+    void* writable_mapping = mmap(nullptr, mapping_size, PROT_READ | PROT_WRITE, MAP_SHARED, writable_fd, 0);
+    ASSERT_NE(writable_mapping, MAP_FAILED);
+    std::vector<uint8_t> expected(mapping_size);
+    for (size_t i = 0; i < mapping_size; ++i) {
+        expected[i] = static_cast<uint8_t>((i * 31 + 7) % 256);
+    }
+    std::memcpy(writable_mapping, expected.data(), mapping_size);
+    ASSERT_EQ(munmap(writable_mapping, mapping_size), 0);
     ASSERT_EQ(close(writable_fd), 0);
 
-    int read_only_fd = open(file_name, O_RDONLY | O_CLOEXEC);
+    int read_only_fd = open(file_name.data(), O_RDONLY | O_CLOEXEC);
     ASSERT_NE(read_only_fd, -1);
-    ASSERT_EQ(unlink(file_name), 0);
+    ASSERT_EQ(unlink(file_name.data()), 0);
 
     void* mapping = mmap(nullptr, mapping_size, PROT_READ, MAP_SHARED, read_only_fd, 0);
     ASSERT_NE(mapping, MAP_FAILED);
 
-    std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
-    const ChipId mmio_chip = *cluster->get_target_mmio_device_ids().begin();
     SysmemManager* sysmem_manager = cluster->get_chip(mmio_chip)->get_sysmem_manager();
     auto sysmem_buffer = sysmem_manager->map_sysmem_buffer(mapping, mapping_size, true, DeviceBufferAccess::ReadOnly);
 
@@ -324,6 +353,22 @@ TEST(ApiSysmemManager, ReadOnlySharedFileMapping) {
     EXPECT_EQ(sysmem_buffer->get_buffer_size(), mapping_size);
     EXPECT_EQ(sysmem_buffer->get_device_access(), DeviceBufferAccess::ReadOnly);
     EXPECT_TRUE(sysmem_buffer->get_noc_addr().has_value());
+
+    // Device reads the read-only mapping and writes it into Tensix L1 -- the direction read-only pinning exists to
+    // serve. Reading it back independently confirms the mapping is genuinely usable, not merely accepted.
+    const CoreCoord tensix_core = cluster->get_soc_descriptor(mmio_chip).get_cores(CoreType::TENSIX)[0];
+    std::vector<uint8_t> zeros(mapping_size, 0);
+    cluster->write_to_device(zeros.data(), mapping_size, mmio_chip, tensix_core, 0);
+    sysmem_buffer->dma_write_to_device(0, mapping_size, tensix_core.to_pair(), 0);
+
+    // Read back over MMIO rather than DMA: D2H DMA is unsupported on Blackhole, and the direction under test here
+    // is the device-side read of the pinned mapping, not how the host retrieves the result.
+    std::vector<uint8_t> readback(mapping_size, 0);
+    cluster->read_from_device(readback.data(), mmio_chip, tensix_core, 0, mapping_size);
+    EXPECT_EQ(readback, expected);
+
+    // The opposite direction writes host memory, so it must be refused on a device-read-only mapping.
+    EXPECT_THROW(sysmem_buffer->dma_read_from_device(0, mapping_size, tensix_core.to_pair(), 0), std::exception);
 
     sysmem_buffer.reset();
     EXPECT_EQ(munmap(mapping, mapping_size), 0);

--- a/tt-kmd-lib/api/tt-kmd-lib/tt_kmd_lib.h
+++ b/tt-kmd-lib/api/tt-kmd-lib/tt_kmd_lib.h
@@ -352,6 +352,14 @@ enum tt_dma_map_flags {
      * range, e.g. for hugepages. It has no effect when an IOMMU is active.
      */
     TT_DMA_FLAG_CONTIGUOUS = 1 << 2,
+
+    /**
+     * @brief Restricts the mapping to device reads.
+     *
+     * Requires KMD 2.9.0 or newer and an active IOMMU. Device writes to this
+     * mapping fault. This flag may be combined with either NOC mapping flag.
+     */
+    TT_DMA_FLAG_READ_ONLY = 1 << 3,
 };
 
 /**

--- a/tt-kmd-lib/src/ioctl.h
+++ b/tt-kmd-lib/src/ioctl.h
@@ -172,6 +172,7 @@ struct tenstorrent_reset_device {
 #define TENSTORRENT_PIN_PAGES_CONTIGUOUS 1	// app attests that the pages are physically contiguous
 #define TENSTORRENT_PIN_PAGES_NOC_DMA 2		// app wants to use the pages for NOC DMA
 #define TENSTORRENT_PIN_PAGES_NOC_TOP_DOWN 4	// NOC DMA will be allocated top-down (default is bottom-up)
+#define TENSTORRENT_PIN_PAGES_READ_ONLY 8	// device will only read; requires IOMMU translation
 
 struct tenstorrent_pin_pages_in {
 	__u32 output_size_bytes;

--- a/tt-kmd-lib/src/tt_kmd_lib.c
+++ b/tt-kmd-lib/src/tt_kmd_lib.c
@@ -430,6 +430,9 @@ int tt_pin_pages(tt_device_t* dev, void* addr, size_t len, int flags, uint64_t* 
     } else if (flags & TT_DMA_FLAG_NOC_TOP_DOWN) {
         pin_pages.in.flags |= TENSTORRENT_PIN_PAGES_NOC_TOP_DOWN;
     }
+    if (flags & TT_DMA_FLAG_READ_ONLY) {
+        pin_pages.in.flags |= TENSTORRENT_PIN_PAGES_READ_ONLY;
+    }
 
     if (ioctl(dev->fd, TENSTORRENT_IOCTL_PIN_PAGES, &pin_pages) != 0) {
         return -errno;


### PR DESCRIPTION
### Issue
Closes #2680

### Description
Adds support for pinning host pages so that the device may read them but not write them.

KMD 2.9.0 introduced a read-only pinning mode: the IOMMU mapping permits device reads and faults device writes, which additionally allows device-readable mappings of read-only and shared file-backed memory. Without it, a host buffer that is only ever a DMA *source* still has to be pinned read/write, so memory the process cannot write — an `mmap(PROT_READ)` of a weights file, for example — cannot be pinned at all and has to be copied first.

This exposes that mode through `DeviceBufferAccess` and threads it down to the pin ioctl.

### List of the changes
- New `DeviceBufferAccess` enum (`ReadWrite` / `ReadOnly`) in `device/api/umd/device/types/host_memory.hpp`.
- `PCIDevice::map_for_dma()` and `PCIDevice::map_buffer_to_noc()` take a `DeviceBufferAccess` (defaulting to `ReadWrite`) and set `TT_DMA_FLAG_READ_ONLY` when read-only is requested.
- New `PCIDevice::is_read_only_page_pinning_supported()`, true only when an IOMMU is active and the KMD is at least 2.9.0. Requesting a read-only mapping without support throws rather than silently widening.
- New `KMD_READ_ONLY_PAGE_PINNING = 2.9.0` in `kmd_versions.hpp`.
- New `TT_DMA_FLAG_READ_ONLY` in the tt-kmd-lib flag enum, translated to `TENSTORRENT_PIN_PAGES_READ_ONLY` in `tt_dma_map()`.
- `SysmemBuffer` records its access mode and exposes `get_device_access()`. `dma_read_from_device()` now throws on a read-only mapping, since that direction writes host memory.
- `SysmemManager::map_sysmem_buffer()` (silicon and simulation) plumbs the access mode through.

### Testing
New `ApiSysmemManager.ReadOnlySharedFileMapping` in `tests/api/test_sysmem_manager.cpp`, gated on the capability of the device the mapping is actually made through. It seeds a file with a position-dependent pattern, maps it `PROT_READ`, pins it read-only, has the device DMA it into Tensix L1, and reads that back to compare — so it fails if the KMD accepts the flag but maps the pages wrongly, which an accessor-only test could not detect. It also asserts `dma_read_from_device` throws on a read-only mapping, since that direction writes host memory. Readback goes over MMIO rather than DMA because D2H DMA is unsupported on Blackhole, which would otherwise make the test skip there.

`api_tests --gtest_filter='*SysmemManager*'` on `yyzo-bh-07`: 24 passed, 2 skipped (the pre-existing DMA siblings, which skip on Blackhole).

Verified on `yyzo-bh-07` (Blackhole p150, KMD 2.9.0, IOMMU `DMA-FQ`) through the consumer side in tt-metal — the tt-metal branch below builds against this commit and its four pinned-memory suites pass, including a 36 MiB H2D upload from a `PROT_READ` file mapping, which is the case that cannot work without this change. Note that the CI runner fleet is still on KMD 2.8.0, so the read-only paths skip there; on that path the tt-metal side widens to read/write and keeps working.

Paired with tenstorrent/tt-metal#52893, which consumes this and is related to tenstorrent/tt-metal#46132. This PR needs to land first — that one bumps its umd submodule to this branch.

### API Changes
This PR has API changes.

- `PCIDevice::map_for_dma()` and `PCIDevice::map_buffer_to_noc()` gain a trailing `DeviceBufferAccess access = DeviceBufferAccess::ReadWrite` parameter. Existing callers are source compatible.
- `SysmemManager::map_sysmem_buffer()` gains the same trailing defaulted parameter.
- New public `DeviceBufferAccess` type, `SysmemBuffer::get_device_access()`, and `PCIDevice::is_read_only_page_pinning_supported()`.
