### PR TITLE
Support only KMD versions >= 2.0.0

### DIFF
--- a/device/api/umd/device/utils/kmd_versions.hpp
+++ b/device/api/umd/device/utils/kmd_versions.hpp
@@ -14,12 +14,6 @@ namespace tt::umd {
 inline constexpr SemVer KMD_MINIMUM_VERSION = SemVer(2, 0, 0);
 
 /**
- * KMD version 1.29.0 introduced IOMMU support. UMD requires at least this version to run with IOMMU enabled.
- * With newer versions of KMD, UMD will still work when IOMMU is disabled on the system.
- */
-inline constexpr SemVer KMD_IOMMU = SemVer(1, 29, 0);
-
-/**
  * KMD version 2.0.0 introduced support for mapping buffers to NOC by using IOCTL. Before 2.0.0, UMD used to access
  * iATU configuration registers directly to perform such mappings. KMD exposed this functionality via IOCTL which brings
  * the ability to map buffers from multiple processes safely. While it's still possible to use direct register access
@@ -32,13 +26,6 @@ inline constexpr SemVer KMD_MAP_TO_NOC = SemVer(2, 0, 0);
  * IOCTL UMD can now reset different architectures without needing to have architecture specific reset IOCTLs.
  */
 inline constexpr SemVer KMD_ARCH_AGNOSTIC_RESET = SemVer{2, 4, 1};
-
-/**
- * KMD version 1.34.0 introduced support for configuring and using PCIe TLBs for buffer mappings. This feature enables
- * calls into KMD to reserve TLB by size, in order to enable multiple user processes to use the device safely at the
- * same time.
- */
-inline constexpr SemVer KMD_TLBS = SemVer(1, 34, 0);
 
 /**
  * KMD version 2.6.0 introduced the TENSTORRENT_IOCTL_SET_POWER_STATE IOCTL for explicit per-client power domain

--- a/device/api/umd/device/utils/kmd_versions.hpp
+++ b/device/api/umd/device/utils/kmd_versions.hpp
@@ -9,8 +9,13 @@
 namespace tt::umd {
 
 /**
+ * The minimum KMD version that can be used to interact with Tenstorrent devices in UMD.
+ */
+inline constexpr SemVer KMD_MINIMUM_VERSION = SemVer(2, 0, 0);
+
+/**
  * KMD version 1.29.0 introduced IOMMU support. UMD requires at least this version to run with IOMMU enabled.
- * With never versions of KMD, UMD will still work when IOMMU is disabled on the system.
+ * With newer versions of KMD, UMD will still work when IOMMU is disabled on the system.
  */
 inline constexpr SemVer KMD_IOMMU = SemVer(1, 29, 0);
 

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -393,21 +393,10 @@ PCIDevice::PCIDevice(int pci_device_number) :
     kmd_version(PCIDevice::read_kmd_version()),
     iommu_enabled(detect_iommu(info)),
     arch_impl_(architecture_implementation::create(arch)) {
-    if (iommu_enabled && kmd_version < KMD_IOMMU) {
+    if (kmd_version < KMD_MINIMUM_VERSION) {
         UMD_THROW(
             error::RuntimeError,
-            fmt::format("Running with IOMMU support requires KMD version {} or newer.", KMD_IOMMU.to_string()));
-    }
-    if (kmd_version < KMD_TLBS) {
-        UMD_THROW(
-            error::RuntimeError, fmt::format("Running UMD requires KMD version {} or newer.", KMD_TLBS.to_string()));
-    }
-
-    if (iommu_enabled && kmd_version < KMD_MAP_TO_NOC) {
-        log_warning(
-            LogUMD,
-            "Running with IOMMU support prior to KMD version {} is of limited support.",
-            KMD_MAP_TO_NOC.to_string());
+            fmt::format("Running UMD requires KMD version {} or newer.", KMD_MINIMUM_VERSION.to_string()));
     }
 
     int extra_flags = 0;


### PR DESCRIPTION
### Issue
/

### Description
Increase the minimum supported KMD version to 2.0.0 (from June 2025). UMD will not be able to open devices with KMD older than 2.0.0. The previous minimum supported version was 1.34 (from May 2025).

### List of the changes
- Increase the minimum supported KMD version to 2.0.0 
- Remove older KMD version constants.

### Testing
CI

### API Changes
This PR has no API changes.
