### PR TITLE
Add fix for TSan personality syscall

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -50,8 +50,11 @@ jobs:
       - ${{ inputs.card }}
     container:
       image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}:${{ inputs.image-tag }}
-      # Set dummy var for baremetal, as options has to have some value
-      options: ${{ inputs.arch != 'baremetal' && '--device /dev/tenstorrent' || '-e DUMMY_VAR=' }}
+      # seccomp=unconfined is required by TSan builds: the runtime re-execs itself with ASLR
+      # disabled via personality(ADDR_NO_RANDOMIZE), which Docker's default seccomp profile denies.
+      options: >-
+        --security-opt seccomp=unconfined
+        ${{ inputs.arch != 'baremetal' && '--device /dev/tenstorrent' || '' }}
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -52,8 +52,10 @@ jobs:
       image: ghcr.io/${{ github.repository }}/tt-umd-ci-${{ inputs.ubuntu-docker-version }}:${{ inputs.image-tag }}
       # seccomp=unconfined is required by TSan builds: the runtime re-execs itself with ASLR
       # disabled via personality(ADDR_NO_RANDOMIZE), which Docker's default seccomp profile denies.
+      # Set dummy var for baremetal, as options has to have some value.
       options: >-
-        ${{ inputs.build-type == 'TSan' && '--security-opt seccomp=unconfined ' || '' }}${{ inputs.arch != 'baremetal' && '--device /dev/tenstorrent' || '-e DUMMY_VAR=' }}
+        ${{ inputs.build-type == 'TSan' && '--security-opt seccomp=unconfined' || '' }}
+        ${{ inputs.arch != 'baremetal' && '--device /dev/tenstorrent' || '-e DUMMY_VAR=' }}
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -53,8 +53,7 @@ jobs:
       # seccomp=unconfined is required by TSan builds: the runtime re-execs itself with ASLR
       # disabled via personality(ADDR_NO_RANDOMIZE), which Docker's default seccomp profile denies.
       options: >-
-        --security-opt seccomp=unconfined
-        ${{ inputs.arch != 'baremetal' && '--device /dev/tenstorrent' || '' }}
+        ${{ inputs.build-type == 'TSan' && '--security-opt seccomp=unconfined ' || '' }}${{ inputs.arch != 'baremetal' && '--device /dev/tenstorrent' || '-e DUMMY_VAR=' }}
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G


### PR DESCRIPTION
### Issue
#3162 

### Description
This pull request updates the Docker container options in the GitHub Actions workflow to improve compatibility with ThreadSanitizer (TSan) builds and clarify device handling. The most important changes are:

### List of the changes
**Container Security and Compatibility:**

* Updated the `options` field for the container to include `--security-opt seccomp=unconfined`, which is required for TSan builds. This allows the runtime to disable ASLR using `personality(ADDR_NO_RANDOMIZE)`, a behavior denied by Docker's default seccomp profile.

**Device Handling:**

* Refined the device mapping logic: for non-`baremetal` architectures, the workflow now adds `--device /dev/tenstorrent`; for `baremetal`, no extra option is added (previously a dummy environment variable was set).


### Testing
CI

### API Changes
/
