### PR TITLE
[base API] Adapt ethernet firmware info methods

### DIFF
--- a/device/api/umd/device/firmware/firmware_info_provider.hpp
+++ b/device/api/umd/device/firmware/firmware_info_provider.hpp
@@ -167,10 +167,26 @@ public:
     /*
      * Get per-link ethernet heartbeat status.
      * Available on Wormhole (all versions) and Blackhole (firmware 19.9+); returns std::nullopt otherwise.
+     * @returns Per-core heartbeat status (true = active), or std::nullopt if unavailable.
+     */
+    [[deprecated("Use get_eth_heartbeat_status_per_core()")]] virtual std::optional<std::vector<bool>>
+    get_eth_heartbeat_status() const;
+
+    /*
+     * Get per-link ethernet retrain status.
+     * Only available on Wormhole with firmware prior to 19.9; returns std::nullopt otherwise.
+     * @returns Per-core retrain status (true = retrained), or std::nullopt if unavailable.
+     */
+    [[deprecated("Use get_eth_retrain_status_per_core()")]] virtual std::optional<std::vector<bool>>
+    get_eth_retrain_status() const;
+
+    /*
+     * Get per-link ethernet heartbeat status.
+     * Available on Wormhole (all versions) and Blackhole (firmware 19.9+); returns std::nullopt otherwise.
      * Each entry pairs an ETH core's NOC0 coordinate with its status (16 entries on WH, 14 on BH).
      * @returns Per-core heartbeat status (true = active), or std::nullopt if unavailable.
      */
-    virtual std::optional<std::vector<std::pair<CoreCoord, bool>>> get_eth_heartbeat_status() const;
+    virtual std::optional<std::vector<std::pair<CoreCoord, bool>>> get_eth_heartbeat_status_per_core() const;
 
     /*
      * Get per-link ethernet retrain status.
@@ -178,7 +194,7 @@ public:
      * Each entry pairs an ETH core's NOC0 coordinate with its status.
      * @returns Per-core retrain status (true = retrained), or std::nullopt if unavailable.
      */
-    virtual std::optional<std::vector<std::pair<CoreCoord, bool>>> get_eth_retrain_status() const;
+    virtual std::optional<std::vector<std::pair<CoreCoord, bool>>> get_eth_retrain_status_per_core() const;
 
     /*
      * Get per-link ethernet link status.
@@ -186,7 +202,7 @@ public:
      * Each entry pairs an ETH core's NOC0 coordinate with its status.
      * @returns Per-core link status (true = up), or std::nullopt if unavailable.
      */
-    virtual std::optional<std::vector<std::pair<CoreCoord, bool>>> get_eth_link_status() const;
+    virtual std::optional<std::vector<std::pair<CoreCoord, bool>>> get_eth_link_status_per_core() const;
 
     virtual std::vector<DramTrainingStatus> get_dram_training_status(uint32_t num_dram_channels) const;
 

--- a/device/firmware/firmware_info_provider.cpp
+++ b/device/firmware/firmware_info_provider.cpp
@@ -722,7 +722,20 @@ std::vector<std::pair<CoreCoord, bool>> FirmwareInfoProvider::parse_eth_status_b
     return statuses;
 }
 
-std::optional<std::vector<std::pair<CoreCoord, bool>>> FirmwareInfoProvider::get_eth_heartbeat_status() const {
+std::optional<std::vector<bool>> FirmwareInfoProvider::get_eth_heartbeat_status() const {
+    auto statuses = get_eth_heartbeat_status_per_core();
+    if (!statuses.has_value()) {
+        return std::nullopt;
+    }
+    std::vector<bool> heartbeat_status;
+    heartbeat_status.reserve(statuses->size());
+    for (const auto& [core, status] : statuses.value()) {
+        heartbeat_status.push_back(status);
+    }
+    return heartbeat_status;
+}
+
+std::optional<std::vector<std::pair<CoreCoord, bool>>> FirmwareInfoProvider::get_eth_heartbeat_status_per_core() const {
     auto data = read_scalar<uint16_t>(FirmwareFeature::ETH_HEARTBEAT_STATUS);
     if (!data.has_value()) {
         return std::nullopt;
@@ -730,7 +743,7 @@ std::optional<std::vector<std::pair<CoreCoord, bool>>> FirmwareInfoProvider::get
     return parse_eth_status_bitmask(data.value());
 }
 
-std::optional<std::vector<std::pair<CoreCoord, bool>>> FirmwareInfoProvider::get_eth_link_status() const {
+std::optional<std::vector<std::pair<CoreCoord, bool>>> FirmwareInfoProvider::get_eth_link_status_per_core() const {
     auto data = read_scalar<uint16_t>(FirmwareFeature::ETH_LINK_STATUS);
     if (!data.has_value()) {
         return std::nullopt;
@@ -738,7 +751,20 @@ std::optional<std::vector<std::pair<CoreCoord, bool>>> FirmwareInfoProvider::get
     return parse_eth_status_bitmask(data.value());
 }
 
-std::optional<std::vector<std::pair<CoreCoord, bool>>> FirmwareInfoProvider::get_eth_retrain_status() const {
+std::optional<std::vector<bool>> FirmwareInfoProvider::get_eth_retrain_status() const {
+    auto statuses = get_eth_retrain_status_per_core();
+    if (!statuses.has_value()) {
+        return std::nullopt;
+    }
+    std::vector<bool> retrain_status;
+    retrain_status.reserve(statuses->size());
+    for (const auto& [core, status] : statuses.value()) {
+        retrain_status.push_back(status);
+    }
+    return retrain_status;
+}
+
+std::optional<std::vector<std::pair<CoreCoord, bool>>> FirmwareInfoProvider::get_eth_retrain_status_per_core() const {
     auto data = read_scalar<uint16_t>(FirmwareFeature::ETH_RETRAIN_STATUS);
     if (!data.has_value()) {
         return std::nullopt;

--- a/nanobind/py_api_telemetry.cpp
+++ b/nanobind/py_api_telemetry.cpp
@@ -240,9 +240,12 @@ void bind_telemetry(nb::module_& m) {
         .def("get_board_power_limit", &FirmwareInfoProvider::get_board_power_limit, release_gil())
         .def("get_thm_limit_throttle", &FirmwareInfoProvider::get_thm_limit_throttle, release_gil())
         .def("get_therm_trip_count", &FirmwareInfoProvider::get_therm_trip_count, release_gil())
-        .def("get_eth_heartbeat_status", &FirmwareInfoProvider::get_eth_heartbeat_status, release_gil())
-        .def("get_eth_retrain_status", &FirmwareInfoProvider::get_eth_retrain_status, release_gil())
-        .def("get_eth_link_status", &FirmwareInfoProvider::get_eth_link_status, release_gil())
+        .def(
+            "get_eth_heartbeat_status_per_core",
+            &FirmwareInfoProvider::get_eth_heartbeat_status_per_core,
+            release_gil())
+        .def("get_eth_retrain_status_per_core", &FirmwareInfoProvider::get_eth_retrain_status_per_core, release_gil())
+        .def("get_eth_link_status_per_core", &FirmwareInfoProvider::get_eth_link_status_per_core, release_gil())
         .def_static(
             "create_firmware_info_provider",
             &FirmwareInfoProvider::create_firmware_info_provider,

--- a/tests/api/test_firmware_info_provider.cpp
+++ b/tests/api/test_firmware_info_provider.cpp
@@ -696,7 +696,7 @@ TEST_F(TestFirmwareInfoProvider, EthHeartbeatStatus) {
 
         tt::ARCH arch = tt_device->get_arch();
         auto fw_version = fw_info->get_firmware_version();
-        auto heartbeats = fw_info->get_eth_heartbeat_status();
+        auto heartbeats = fw_info->get_eth_heartbeat_status_per_core();
 
         // Available on Wormhole (all versions) and Blackhole >= 19.9.
         if (arch == tt::ARCH::BLACKHOLE && fw_version < FirmwareBundleVersion(19, 9, 0)) {
@@ -724,7 +724,7 @@ TEST_F(TestFirmwareInfoProvider, EthRetrainStatus) {
 
         tt::ARCH arch = tt_device->get_arch();
         auto fw_version = fw_info->get_firmware_version();
-        auto retrains = fw_info->get_eth_retrain_status();
+        auto retrains = fw_info->get_eth_retrain_status_per_core();
 
         // Only available on Wormhole prior to 19.9.
         if (arch == tt::ARCH::BLACKHOLE || fw_version >= FirmwareBundleVersion(19, 9, 0)) {
@@ -750,7 +750,7 @@ TEST_F(TestFirmwareInfoProvider, EthLinkStatus) {
 
         tt::ARCH arch = tt_device->get_arch();
         auto fw_version = fw_info->get_firmware_version();
-        auto links = fw_info->get_eth_link_status();
+        auto links = fw_info->get_eth_link_status_per_core();
 
         // Available on firmware >= 19.9 for both Wormhole and Blackhole.
         if (fw_version < FirmwareBundleVersion(19, 9, 0)) {
@@ -786,7 +786,7 @@ TEST_F(TestFirmwareInfoProvider, DISABLED_PrintEthStatus) {
             soc_desc.get_num_harvested_eth_channels(),
             soc_desc.get_num_eth_channels());
 
-        auto heartbeats = fw_info->get_eth_heartbeat_status();
+        auto heartbeats = fw_info->get_eth_heartbeat_status_per_core();
         if (heartbeats.has_value()) {
             log_info(tt::LogUMD, "--- Heartbeat (all channels) ---");
             for (const auto& [coord, status] : heartbeats.value()) {
@@ -803,7 +803,7 @@ TEST_F(TestFirmwareInfoProvider, DISABLED_PrintEthStatus) {
             log_info(tt::LogUMD, "Heartbeat: unavailable");
         }
 
-        auto links = fw_info->get_eth_link_status();
+        auto links = fw_info->get_eth_link_status_per_core();
         if (links.has_value()) {
             log_info(tt::LogUMD, "--- Link status (all channels) ---");
             for (const auto& [coord, status] : links.value()) {


### PR DESCRIPTION
### Issue
#2876

### Description
The base API for FirmwareInfoProvider formalizes the old versions of `get_eth_heartbeat_status()` and `get_eth_retrain_status()` returning `std::optional<std::vector<bool>>`. These are deprecated and the existing methods returning are suffixed with `_per_core()` to avoid name clashing. 

### List of the changes
- Rename existing `get_eth_heartbeat_status()` and `get_eth_retrain_status()` to `get_eth_heartbeat_status_per_core()` and `get_eth_retrain_status_per_core()` respectively.
- Introduce and deprecate `get_eth_heartbeat_status()` and `get_eth_retrain_status()` returning `std::optional<std::vector<bool>>` as per base API specification.
- Rename `get_eth_link_status()` to `get_eth_link_status_per_core()`
- Update tests.

### Testing
CI

### API Changes
This PR has API changes.
