### PR TITLE
Fix DMA reads returning another core's data via unflushed TLB config

### DIFF
--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -284,8 +284,11 @@ public:
      *
      * @param tlb_size Size of the TLB caller wants to allocate.
      * @param mapping_type Type of TLB mapping to allocate (UC or WC).
+     * @param verify_config Whether the handle should confirm each configure() reached the device
+     *                      before returning; see TlbHandle's protected verify_config constructor.
      */
-    std::unique_ptr<TlbHandle> allocate_tlb(const size_t tlb_size, const TlbMapping tlb_mapping = TlbMapping::UC);
+    std::unique_ptr<TlbHandle> allocate_tlb(
+        const size_t tlb_size, const TlbMapping tlb_mapping = TlbMapping::UC, const bool verify_config = false);
 
     /**
      * Configure TLB register in user space by writing directly to BAR0.
@@ -295,7 +298,8 @@ public:
      * @param verify Read the register back and wait until it holds the written configuration before
      *               returning. MMIO writes are posted, so without this the mapping is not
      *               guaranteed live on return. Only needed when the next user of the window is not
-     *               the host itself -- see TlbHandle::set_verify_config. Costs a PCIe round trip.
+     *               the host itself -- see TlbHandle's protected verify_config constructor. Costs a
+     *               PCIe round trip.
      */
     void configure_tlb(const uint32_t tlb_index, const tlb_data &tlb_config, const bool verify = false);
 

--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -292,8 +292,12 @@ public:
      *
      * @param tlb_index The TLB index/ID to configure
      * @param tlb_config The TLB configuration data
+     * @param verify Read the register back and wait until it holds the written configuration before
+     *               returning. MMIO writes are posted, so without this the mapping is not
+     *               guaranteed live on return. Only needed when the next user of the window is not
+     *               the host itself -- see TlbHandle::set_verify_config. Costs a PCIe round trip.
      */
-    void configure_tlb(const uint32_t tlb_index, const tlb_data &tlb_config);
+    void configure_tlb(const uint32_t tlb_index, const tlb_data &tlb_config, const bool verify = false);
 
     /**
      * Read command byte.

--- a/device/api/umd/device/pcie/silicon_tlb_handle.hpp
+++ b/device/api/umd/device/pcie/silicon_tlb_handle.hpp
@@ -34,6 +34,12 @@ public:
      */
     SiliconTlbHandle(PCIDevice& pci_device, size_t size, const TlbMapping tlb_mapping = TlbMapping::UC);
 
+    /**
+     * Constructor for SiliconTlbHandle that additionally fixes verify_config_ for the handle's
+     * lifetime. See TlbHandle's protected verify_config constructor for when to pass true.
+     */
+    SiliconTlbHandle(PCIDevice& pci_device, size_t size, const TlbMapping tlb_mapping, const bool verify_config);
+
     ~SiliconTlbHandle() noexcept override;
 
     void configure(const tlb_data& new_config) override;

--- a/device/api/umd/device/pcie/tlb_handle.hpp
+++ b/device/api/umd/device/pcie/tlb_handle.hpp
@@ -52,6 +52,18 @@ public:
      */
     int get_tlb_id() const { return tlb_id_; }
 
+    /**
+     * Require every subsequent configure() to confirm the new configuration has reached the device
+     * before returning, at the cost of a PCIe round trip per reconfigure.
+     *
+     * Off by default, which is correct whenever the host itself is the next user of the window: the
+     * host's access to the window travels behind the config write, into the same block, so it
+     * cannot be translated by the old configuration. Turn it on for a window whose next user is
+     * on-chip -- notably the PCIe DMA engine, which is a separate requester started by a doorbell to
+     * a different register block, and so is not ordered behind the config write at all.
+     */
+    void set_verify_config(const bool verify) { verify_config_ = verify; }
+
     virtual tt::ARCH get_arch() const = 0;
 
 protected:
@@ -65,6 +77,7 @@ protected:
     size_t tlb_size_ = 0;
     tlb_data tlb_config_{};
     TlbMapping tlb_mapping_ = TlbMapping::UC;
+    bool verify_config_ = false;
 
 private:
     /**

--- a/device/api/umd/device/pcie/tlb_handle.hpp
+++ b/device/api/umd/device/pcie/tlb_handle.hpp
@@ -52,18 +52,6 @@ public:
      */
     int get_tlb_id() const { return tlb_id_; }
 
-    /**
-     * Require every subsequent configure() to confirm the new configuration has reached the device
-     * before returning, at the cost of a PCIe round trip per reconfigure.
-     *
-     * Off by default, which is correct whenever the host itself is the next user of the window: the
-     * host's access to the window travels behind the config write, into the same block, so it
-     * cannot be translated by the old configuration. Turn it on for a window whose next user is
-     * on-chip -- notably the PCIe DMA engine, which is a separate requester started by a doorbell to
-     * a different register block, and so is not ordered behind the config write at all.
-     */
-    void set_verify_config(const bool verify) { verify_config_ = verify; }
-
     virtual tt::ARCH get_arch() const = 0;
 
 protected:
@@ -72,12 +60,31 @@ protected:
      */
     TlbHandle() = default;
 
+    /**
+     * Protected constructor letting derived classes fix verify_config_ for the lifetime of the handle.
+     *
+     * @param verify_config Require every subsequent configure() to confirm the new configuration has
+     *                       reached the device before returning, at the cost of a PCIe round trip per
+     *                       reconfigure. False is correct whenever the host itself is the next user of
+     *                       the window: the host's access to the window travels behind the config
+     *                       write, into the same block, so it cannot be translated by the old
+     *                       configuration. Pass true for a window whose next user is on-chip --
+     *                       notably the PCIe DMA engine, which is a separate requester started by a
+     *                       doorbell to a different register block, and so is not ordered behind the
+     *                       config write at all.
+     */
+    explicit TlbHandle(const bool verify_config) : verify_config_(verify_config) {}
+
+    /**
+     * Whether configure() must confirm the new configuration reached the device before returning.
+     */
+    bool get_verify_config() const { return verify_config_; }
+
     int tlb_id_ = 0;
     uint8_t* tlb_base_ = nullptr;
     size_t tlb_size_ = 0;
     tlb_data tlb_config_{};
     TlbMapping tlb_mapping_ = TlbMapping::UC;
-    bool verify_config_ = false;
 
 private:
     /**
@@ -85,6 +92,8 @@ private:
      * Implemented by derived classes.
      */
     virtual void free_tlb() noexcept = 0;
+
+    bool verify_config_ = false;
 };
 
 }  // namespace tt::umd

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -37,6 +37,7 @@
 #include "umd/device/types/arch.hpp"
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/kmd_versions.hpp"
+#include "umd/device/utils/timeouts.hpp"
 #include "utils.hpp"
 
 namespace tt::umd {
@@ -810,7 +811,7 @@ std::unique_ptr<TlbHandle> PCIDevice::allocate_tlb(const size_t tlb_size, const 
     }
 }
 
-void PCIDevice::configure_tlb(const uint32_t tlb_index, const tlb_data &tlb_config) {
+void PCIDevice::configure_tlb(const uint32_t tlb_index, const tlb_data &tlb_config, const bool verify) {
     // Get the TLB configuration for this index.
     auto tlb_configuration = arch_impl_->get_tlb_configuration(tlb_index);
 
@@ -832,12 +833,37 @@ void PCIDevice::configure_tlb(const uint32_t tlb_index, const tlb_data &tlb_conf
 
     // Write the TLB register values
     // Wormhole uses 64-bit registers (8 bytes), Blackhole uses 96-bit registers (12 bytes).
-    tlb_reg_ptr[0] = static_cast<uint32_t>(lower_64);
-    tlb_reg_ptr[1] = static_cast<uint32_t>(lower_64 >> 32);
+    const uint32_t config_words[] = {
+        static_cast<uint32_t>(lower_64), static_cast<uint32_t>(lower_64 >> 32), static_cast<uint32_t>(upper_64)};
+    const size_t num_config_words = arch == tt::ARCH::BLACKHOLE ? 3 : 2;
+    for (size_t i = 0; i < num_config_words; i++) {
+        tlb_reg_ptr[i] = config_words[i];
+    }
 
-    if (arch == tt::ARCH::BLACKHOLE) {
-        // Blackhole needs the upper 32 bits as well (96-bit total).
-        tlb_reg_ptr[2] = static_cast<uint32_t>(upper_64);
+    // MMIO writes are posted, so read the low 64 bits back to prove the mapping is live before
+    // anything uses it. Costs a PCIe round trip, hence opt-in.
+    if (verify) {
+        static constexpr auto TLB_CONFIG_BUSY_POLL_WINDOW =
+            std::chrono::duration_cast<std::chrono::microseconds>(timeout::MMIO_OP_TIMEOUT);
+        static constexpr auto TLB_CONFIG_POLL_INTERVAL = std::chrono::microseconds(1);
+
+        const bool config_landed = utils::poll_until(
+            [&]() { return tlb_reg_ptr[0] == config_words[0] && tlb_reg_ptr[1] == config_words[1]; },
+            timeout::MMIO_OP_TIMEOUT,
+            TLB_CONFIG_BUSY_POLL_WINDOW,
+            TLB_CONFIG_POLL_INTERVAL);
+
+        UMD_ASSERT(
+            config_landed,
+            error::RuntimeError,
+            fmt::format(
+                "TLB index {} did not read back the configuration written to it (wrote {:#x} {:#x}, read {:#x} {:#x}). "
+                "The window is either not responding or is being written by another owner.",
+                tlb_index,
+                config_words[0],
+                config_words[1],
+                tlb_reg_ptr[0],
+                tlb_reg_ptr[1]));
     }
 
     log_trace(

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -10,6 +10,7 @@
 #include <sys/utsname.h>  // for uname
 #include <unistd.h>       // for ::close
 
+#include <array>
 #include <cerrno>
 #include <cstdint>
 #include <cstdlib>
@@ -786,10 +787,11 @@ SemVer PCIDevice::read_kernel_version() {
     return SemVer(uts.release);
 }
 
-std::unique_ptr<TlbHandle> PCIDevice::allocate_tlb(const size_t tlb_size, const TlbMapping tlb_mapping) {
+std::unique_ptr<TlbHandle> PCIDevice::allocate_tlb(
+    const size_t tlb_size, const TlbMapping tlb_mapping, const bool verify_config) {
     ZoneScopedC(tracy::Color::Cyan);
     try {
-        return std::make_unique<SiliconTlbHandle>(*this, tlb_size, tlb_mapping);
+        return std::make_unique<SiliconTlbHandle>(*this, tlb_size, tlb_mapping, verify_config);
     } catch (const std::exception &e) {
         if (read_kmd_version() < SemVer(2, 6, 0)) {
             UMD_THROW(
@@ -833,9 +835,9 @@ void PCIDevice::configure_tlb(const uint32_t tlb_index, const tlb_data &tlb_conf
 
     // Write the TLB register values
     // Wormhole uses 64-bit registers (8 bytes), Blackhole uses 96-bit registers (12 bytes).
-    const uint32_t config_words[] = {
+    const std::array<uint32_t, 3> config_words = {
         static_cast<uint32_t>(lower_64), static_cast<uint32_t>(lower_64 >> 32), static_cast<uint32_t>(upper_64)};
-    const size_t num_config_words = arch == tt::ARCH::BLACKHOLE ? 3 : 2;
+    const size_t num_config_words = (arch == tt::ARCH::BLACKHOLE) ? 3 : 2;
     for (size_t i = 0; i < num_config_words; i++) {
         tlb_reg_ptr[i] = config_words[i];
     }
@@ -848,7 +850,7 @@ void PCIDevice::configure_tlb(const uint32_t tlb_index, const tlb_data &tlb_conf
         static constexpr auto TLB_CONFIG_POLL_INTERVAL = std::chrono::microseconds(1);
 
         const bool config_landed = utils::poll_until(
-            [&]() { return tlb_reg_ptr[0] == config_words[0] && tlb_reg_ptr[1] == config_words[1]; },
+            [&]() { return (tlb_reg_ptr[0] == config_words[0]) && (tlb_reg_ptr[1] == config_words[1]); },
             timeout::MMIO_OP_TIMEOUT,
             TLB_CONFIG_BUSY_POLL_WINDOW,
             TLB_CONFIG_POLL_INTERVAL);

--- a/device/pcie/silicon_tlb_handle.cpp
+++ b/device/pcie/silicon_tlb_handle.cpp
@@ -18,7 +18,11 @@
 namespace tt::umd {
 
 SiliconTlbHandle::SiliconTlbHandle(PCIDevice& pci_device, size_t size, const TlbMapping tlb_mapping) :
-    pci_device_(pci_device) {
+    SiliconTlbHandle(pci_device, size, tlb_mapping, false) {}
+
+SiliconTlbHandle::SiliconTlbHandle(
+    PCIDevice& pci_device, size_t size, const TlbMapping tlb_mapping, const bool verify_config) :
+    TlbHandle(verify_config), pci_device_(pci_device) {
     tlb_size_ = size;
     tlb_mapping_ = tlb_mapping;
 
@@ -49,7 +53,7 @@ void SiliconTlbHandle::configure(const tlb_data& new_config) {
     // before passing to configure_tlb.
     tlb_data cfg_data = new_config;
     cfg_data.local_offset = cfg_data.local_offset / get_size();
-    pci_device_.configure_tlb(tlb_id_, cfg_data, verify_config_);
+    pci_device_.configure_tlb(tlb_id_, cfg_data, get_verify_config());
 
     tlb_config_ = new_config;
 }

--- a/device/pcie/silicon_tlb_handle.cpp
+++ b/device/pcie/silicon_tlb_handle.cpp
@@ -49,7 +49,7 @@ void SiliconTlbHandle::configure(const tlb_data& new_config) {
     // before passing to configure_tlb.
     tlb_data cfg_data = new_config;
     cfg_data.local_offset = cfg_data.local_offset / get_size();
-    pci_device_.configure_tlb(tlb_id_, cfg_data);
+    pci_device_.configure_tlb(tlb_id_, cfg_data, verify_config_);
 
     tlb_config_ = new_config;
 }

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -397,10 +397,10 @@ bool PcieProtocol::dma_transfer_zero_copy(
 
 TlbWindow* PcieProtocol::get_cached_dma_tlb_window(tlb_data config) {
     if (cached_dma_tlb_window_ == nullptr) {
-        auto handle = pci_device_->allocate_tlb(get_dma_tlb_size(pci_device_->get_arch()), TlbMapping::WC);
         // The DMA engine, not the host, reads through this window, so it is not ordered behind our
-        // config write. Set before constructing the window: the constructor configures.
-        handle->set_verify_config(true);
+        // config write - pass verify_config so every configure() confirms it landed first.
+        auto handle = pci_device_->allocate_tlb(
+            get_dma_tlb_size(pci_device_->get_arch()), TlbMapping::WC, /*verify_config=*/true);
         cached_dma_tlb_window_ = std::make_unique<SiliconTlbWindow>(std::move(handle), config);
         return cached_dma_tlb_window_.get();
     }

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -397,8 +397,11 @@ bool PcieProtocol::dma_transfer_zero_copy(
 
 TlbWindow* PcieProtocol::get_cached_dma_tlb_window(tlb_data config) {
     if (cached_dma_tlb_window_ == nullptr) {
-        cached_dma_tlb_window_ = std::make_unique<SiliconTlbWindow>(
-            pci_device_->allocate_tlb(get_dma_tlb_size(pci_device_->get_arch()), TlbMapping::WC), config);
+        auto handle = pci_device_->allocate_tlb(get_dma_tlb_size(pci_device_->get_arch()), TlbMapping::WC);
+        // The DMA engine, not the host, reads through this window, so it is not ordered behind our
+        // config write. Set before constructing the window: the constructor configures.
+        handle->set_verify_config(true);
+        cached_dma_tlb_window_ = std::make_unique<SiliconTlbWindow>(std::move(handle), config);
         return cached_dma_tlb_window_.get();
     }
 


### PR DESCRIPTION
### Issue
#3095

### Description
PCIe DMA transfers could be routed through the DMA TLB window's previous configuration and
return another core's data. MMIO writes are posted, so the window config write is not
guaranteed to have landed when the doorbell starts the DMA engine, which is a separate
requester reached through a different register block and so is not ordered behind it.

### List of the changes
 - PCIDevice::configure_tlb takes an optional verify flag that polls the config register until
it reads back the written low 64 bits, throwing on timeout.
 - TlbHandle::set_verify_config marks a window as needing that verification, passed through by
SiliconTlbHandle on every configure. Off by default, so MMIO paths pay nothing.
 - PcieProtocol enables it on the PCIe DMA window only, set before the window is constructed so
the first configure is covered too.


### Testing
CI, local overhead measurement via existing benchmarks

### API Changes
This PR has API changes.
