### PR TITLE
Skip unnecessary trailing configure in dma transfers

### DIFF
--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -346,6 +346,10 @@ bool PcieProtocol::dma_transfer(void* buffer, size_t size, uint64_t addr, tlb_da
         addr += transfer_size;
         buf += transfer_size;
 
+        if (size == 0) {
+            break;
+        }
+
         config.local_offset = addr;
         tlb_window->configure(config);
         axi_address = axi_address_base + (addr - (addr & ~(tlb_handle_size - 1)));
@@ -386,6 +390,10 @@ bool PcieProtocol::dma_transfer_zero_copy(
         size -= transfer_size;
         addr += transfer_size;
         iova += transfer_size;
+
+        if (size == 0) {
+            break;
+        }
 
         config.local_offset = addr;
         tlb_window->configure(config);


### PR DESCRIPTION
### Issue
Followup from #3095

### Description
Skip the redundant TLB reconfigure that ran after the last chunk of a DMA transfer, since nothing reads through the window again before the next call reconfigures it anyway. Added on top of ajovanovic/dma_mixed_reads_fix, since each configure now takes longer due to the readback added there, making this redundant call more costly than before.

### List of the changes
- `dma_transfer` and `dma_transfer_zero_copy`: break out of the chunk loop once `size == 0`, before the trailing `configure()`/`axi_address` recompute

### Testing
Measured on n150 WH: removes one PCIe round-trip per DMA call. Small-transfer overhead from the readback fix drops from +88% to roughly half on a 4 B write (4.56 us -> 3.35 us).

### API Changes
This PR has no API changes.
