### PR TITLE
Add 4-chip Blackhole qb-ge case to VerifyStandardTopology

### DIFF
--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -246,7 +246,7 @@ TEST(TestClusterDescriptor, VerifyStandardTopology) {
             break;
         }
 
-        // This covers Quietbox 2/Quietbox GE (2 P300 cards = 4 chips)
+        // This covers Quietbox 2/Quietbox GE (2 P300 cards = 4 chips).
         case 4: {
             switch (cluster_desc->get_arch()) {
                 case tt::ARCH::BLACKHOLE: {

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -246,6 +246,30 @@ TEST(TestClusterDescriptor, VerifyStandardTopology) {
             break;
         }
 
+        // This covers Quietbox 2/Quietbox GE (2 P300 cards = 4 chips)
+        case 4: {
+            switch (cluster_desc->get_arch()) {
+                case tt::ARCH::BLACKHOLE: {
+                    auto chips_with_mmio = cluster_desc->get_chips_with_mmio();
+                    EXPECT_EQ(chips_with_mmio.size(), 4);
+
+                    auto eth_connections = cluster_desc->get_ethernet_connections();
+                    EXPECT_EQ(count_connections(eth_connections), 16);
+
+                    for (auto chip : all_chips) {
+                        BoardType board_type = cluster_desc->get_board_type(chip);
+                        EXPECT_TRUE(board_type == BoardType::P300)
+                            << "Unexpected board type for chip " << chip << ": " << static_cast<int>(board_type);
+                    }
+                    break;
+                }
+                default: {
+                    throw std::runtime_error("Unexpected architecture for 4 chip cluster descriptor.");
+                }
+            }
+            break;
+        }
+
         // This covers Wormhole T3K (Loudbox and Quietbox), as well as Blackhole loudbox.
         case 8: {
             switch (cluster_desc->get_arch()) {

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -264,7 +264,7 @@ TEST(TestClusterDescriptor, VerifyStandardTopology) {
                     break;
                 }
                 default: {
-                    throw std::runtime_error("Unexpected architecture for 4 chip cluster descriptor.");
+                    throw std::runtime_error("Unexpected architecture for 4-chip cluster descriptor.");
                 }
             }
             break;


### PR DESCRIPTION
### Issue
Fixes #3174 

### Description
`TestClusterDescriptor.VerifyStandardTopology` had no case for 4-chip systems, so it threw
`"Unexpected number of chips in the cluster descriptor: 4"` on Blackhole QuietBox
(2x P300 boards = 4 chips). This adds a `case 4` covering that topology.

### List of the changes
- Added `case 4` to the chip-count switch in `tests/api/test_cluster_descriptor.cpp`,
  following the arch-switch structure of `case 8`:
  - `BLACKHOLE`: expects 4 MMIO-capable chips, 16 ethernet connection entries,
      and board type P300 for all chips.
  - Any other architecture throws, since no standard 4-chip configuration exists for it.

### Testing
Validated on a Blackhole QuietBox (2x P300, FW bundle 19.12.0, KMD 2.7.0):
- `TestClusterDescriptor.VerifyStandardTopology` now passes (was the only failing api test
  on this system before the change).
- Full `api_tests` suite: 369 ran, 293 passed, 0 failed, 76 skipped.
 
### API Changes
This PR has no API changes.
