### PR TITLE
KMDMutex init

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -124,6 +124,7 @@ target_sources(
         types/xy_pair.cpp
         utils/lock_manager.cpp
         utils/robust_mutex.cpp
+        utils/kmd_mutex.cpp
         topology/topology_discovery.cpp
         topology/topology_discovery_blackhole.cpp
         topology/topology_discovery_wormhole.cpp
@@ -224,6 +225,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/warm_reset_with_recovery.hpp
                 api/umd/device/utils/semver.hpp
                 api/umd/device/utils/robust_mutex.hpp
+                api/umd/device/utils/kmd_mutex.hpp
                 api/umd/device/cluster_descriptor.hpp
                 api/umd/device/types/core_coordinates.hpp
                 api/umd/device/tt_device/blackhole_tt_device.hpp

--- a/device/api/umd/device/utils/kmd_mutex.hpp
+++ b/device/api/umd/device/utils/kmd_mutex.hpp
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <sys/types.h>  // pid_t
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace tt::umd {
+
+// Conventional KMD resource-lock indices. These mirror the TENSTORRENT_LOCK_INDEX_* defines in KMD's
+// ioctl.h: indices 0..15 are reserved by convention for ERISC cores. They are copied here (the KMD
+// header lives in a separate repo and cannot be included/linked from UMD); keep this in sync with
+// KMD. Callers coordinating their own resources should use indices outside this reserved range.
+enum class KmdLockIndex : uint8_t {
+    ETH00 = 0,
+    ETH01 = 1,
+    ETH02 = 2,
+    ETH03 = 3,
+    ETH04 = 4,
+    ETH05 = 5,
+    ETH06 = 6,
+    ETH07 = 7,
+    ETH08 = 8,
+    ETH09 = 9,
+    ETH10 = 10,
+    ETH11 = 11,
+    ETH12 = 12,
+    ETH13 = 13,
+    ETH14 = 14,
+    ETH15 = 15,
+};
+
+// KmdMutex is a cross-process lock backed by the Tenstorrent kernel-mode driver (KMD) resource locks
+// (TENSTORRENT_IOCTL_LOCK_CTL). See device/utils/README.md for how the available locking backends
+// compare.
+//
+// Properties:
+//   - The lock is tied to the device itself, not to a host filesystem. Any process that can open
+//     /dev/tenstorrent/<N> contends over the same lock, even across different containers or mount
+//     namespaces, with no /dev/shm (or other filesystem) sharing required. This makes it the right
+//     primitive for serializing whole workloads against one device.
+//   - Every operation is an ioctl (a syscall); there is no userspace fast path. A contended lock()
+//     polls the non-blocking acquire with a short backoff (the ioctl set has no efficient blocking
+//     wait), so waiting for a held lock costs more than a single syscall.
+//   - The lock is held by the open file descriptor, and KMD releases all of an fd's locks when the
+//     fd is closed. Since the kernel closes every fd of a process when it dies, a crashed holder
+//     cannot leak the lock - it is reclaimed automatically.
+//   - Scope is limited to a single local device: there is no global lock that spans devices.
+//
+// Each KMD device exposes TENSTORRENT_RESOURCE_LOCK_COUNT (64) independent lock indices (see
+// KmdLockIndex for the reserved ones).
+//
+// This class owns its own dedicated chardev fd, separate from any fd used to run a workload. That
+// is deliberate: a device reset invalidates every fd that was open across it (further ioctls return
+// ENODEV), but the lock itself survives the reset and stays held until its fd is closed. Keeping the
+// lock on a dedicated fd lets a caller hold the lock, reset the device, then open fresh fds to run a
+// workload. lock() transparently reopens its fd and retries if it observes that a reset happened
+// while it was waiting.
+//
+// It meets the C++ Lockable requirement (lock()/try_lock()/unlock()), so it can be used with RAII
+// helpers like std::lock_guard and std::unique_lock.
+class KmdMutex {
+public:
+    // @param pci_device_num  N in /dev/tenstorrent/N (a UMD logical device id / PCIDevice number).
+    // @param lock_index      KMD resource lock index in [0, 64). Avoid 0..15 (reserved, see
+    //                        KmdLockIndex).
+    KmdMutex(int pci_device_num, uint8_t lock_index);
+    ~KmdMutex() noexcept;
+
+    // Opens the dedicated chardev fd used to hold the lock, after verifying the installed KMD supports
+    // resource locks (throws otherwise). Must be called before lock()/try_lock(). Kept separate from
+    // the constructor so that failures during setup are still cleaned up by the destructor.
+    void initialize();
+
+    // Move-only so it can live in STL containers. Copying would alias the owned fd.
+    KmdMutex(KmdMutex&& other) noexcept;
+    KmdMutex& operator=(KmdMutex&& other) noexcept;
+    KmdMutex(const KmdMutex&) = delete;
+    KmdMutex& operator=(const KmdMutex&) = delete;
+
+    // Blocks until the lock is acquired. If a reset is detected while waiting (the fd becomes
+    // unusable), the fd is transparently reopened and the wait is retried.
+    void lock();
+
+    // Attempts to acquire without blocking. Returns true if acquired, false if held by another fd.
+    bool try_lock();
+
+    // Tries to acquire the lock (immediately if timeout is zero, otherwise polling until timeout).
+    // Returns std::nullopt if the lock was acquired (the caller now holds it). On contention returns a
+    // {pid, tid} pair, but KMD does not expose the owner, so it is always {0, 0} here - the pair's
+    // presence signals "held by someone else", nothing more.
+    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout = std::chrono::seconds(0));
+
+    // Releases the lock. It is also released automatically when this object (and thus its fd) is
+    // destroyed, or when the owning process exits.
+    void unlock();
+
+    // Best-effort query of whether the lock is currently held by any fd (including this one). This
+    // is inherently racy and intended for debugging/diagnostics only.
+    bool is_locked_by_anyone();
+
+private:
+    void open_device_fd();
+    void close_fd() noexcept;
+
+    int pci_device_num_;
+    uint8_t lock_index_;
+    int fd_ = -1;
+    std::string device_path_;
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/utils/kmd_mutex.hpp
+++ b/device/api/umd/device/utils/kmd_mutex.hpp
@@ -12,6 +12,10 @@
 #include <string>
 #include <utility>
 
+// tt-kmd-lib device handle. Forward declared so this public header does not require tt-kmd-lib's
+// include path, which UMD links privately.
+struct tt_device_t;
+
 namespace tt::umd {
 
 // Conventional KMD resource-lock indices. These mirror the TENSTORRENT_LOCK_INDEX_* defines in KMD's
@@ -37,9 +41,9 @@ enum class KmdLockIndex : uint8_t {
     ETH15 = 15,
 };
 
-// KmdMutex is a cross-process lock backed by the Tenstorrent kernel-mode driver (KMD) resource locks
-// (TENSTORRENT_IOCTL_LOCK_CTL). See device/utils/README.md for how the available locking backends
-// compare.
+// KmdMutex is a cross-process lock backed by the Tenstorrent kernel-mode driver (KMD) resource locks,
+// which it drives through tt-kmd-lib's tt_lock_* API. See device/utils/README.md for how the
+// available locking backends compare.
 //
 // Properties:
 //   - The lock is tied to the device itself, not to a host filesystem. Any process that can open
@@ -54,15 +58,15 @@ enum class KmdLockIndex : uint8_t {
 //     cannot leak the lock - it is reclaimed automatically.
 //   - Scope is limited to a single local device: there is no global lock that spans devices.
 //
-// Each KMD device exposes TENSTORRENT_RESOURCE_LOCK_COUNT (64) independent lock indices (see
-// KmdLockIndex for the reserved ones).
+// Each KMD device exposes TT_RESOURCE_LOCK_COUNT (64) independent lock indices (see KmdLockIndex for
+// the reserved ones).
 //
-// This class owns its own dedicated chardev fd, separate from any fd used to run a workload. That
-// is deliberate: a device reset invalidates every fd that was open across it (further ioctls return
-// ENODEV), but the lock itself survives the reset and stays held until its fd is closed. Keeping the
-// lock on a dedicated fd lets a caller hold the lock, reset the device, then open fresh fds to run a
-// workload. lock() transparently reopens its fd and retries if it observes that a reset happened
-// while it was waiting.
+// This class owns its own dedicated device handle (chardev fd), separate from any fd used to run a
+// workload. That is deliberate: a device reset invalidates every fd that was open across it (further
+// ioctls return ENODEV), but the lock itself survives the reset and stays held until its fd is
+// closed. Keeping the lock on a dedicated handle lets a caller hold the lock, reset the device, then
+// open fresh fds to run a workload. lock() transparently reopens its handle and retries if it
+// observes that a reset happened while it was waiting.
 //
 // It meets the C++ Lockable requirement (lock()/try_lock()/unlock()), so it can be used with RAII
 // helpers like std::lock_guard and std::unique_lock.
@@ -74,22 +78,23 @@ public:
     KmdMutex(int pci_device_num, uint8_t lock_index);
     ~KmdMutex() noexcept;
 
-    // Opens the dedicated chardev fd used to hold the lock, after verifying the installed KMD supports
-    // resource locks (throws otherwise). Must be called before lock()/try_lock(). Kept separate from
-    // the constructor so that failures during setup are still cleaned up by the destructor.
+    // Opens the dedicated device handle used to hold the lock. Must be called before
+    // lock()/try_lock(). Kept separate from the constructor so that failures during setup are still
+    // cleaned up by the destructor.
     void initialize();
 
-    // Move-only so it can live in STL containers. Copying would alias the owned fd.
+    // Move-only so it can live in STL containers. Copying would alias the owned handle.
     KmdMutex(KmdMutex&& other) noexcept;
     KmdMutex& operator=(KmdMutex&& other) noexcept;
     KmdMutex(const KmdMutex&) = delete;
     KmdMutex& operator=(const KmdMutex&) = delete;
 
-    // Blocks until the lock is acquired. If a reset is detected while waiting (the fd becomes
-    // unusable), the fd is transparently reopened and the wait is retried.
+    // Blocks until the lock is acquired. If a reset is detected while waiting (the handle becomes
+    // unusable), the handle is transparently reopened and the wait is retried.
     void lock();
 
-    // Attempts to acquire without blocking. Returns true if acquired, false if held by another fd.
+    // Attempts to acquire without blocking. Returns true if acquired, false if held by another
+    // handle.
     bool try_lock();
 
     // Tries to acquire the lock (immediately if timeout is zero, otherwise polling until timeout).
@@ -98,21 +103,21 @@ public:
     // presence signals "held by someone else", nothing more.
     std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout = std::chrono::seconds(0));
 
-    // Releases the lock. It is also released automatically when this object (and thus its fd) is
+    // Releases the lock. It is also released automatically when this object (and thus its handle) is
     // destroyed, or when the owning process exits.
     void unlock();
 
-    // Best-effort query of whether the lock is currently held by any fd (including this one). This
-    // is inherently racy and intended for debugging/diagnostics only.
+    // Best-effort query of whether the lock is currently held by any handle (including this one).
+    // This is inherently racy and intended for debugging/diagnostics only.
     bool is_locked_by_anyone();
 
 private:
-    void open_device_fd();
-    void close_fd() noexcept;
+    void open_device();
+    void close_device() noexcept;
 
     int pci_device_num_;
     uint8_t lock_index_;
-    int fd_ = -1;
+    tt_device_t* device_ = nullptr;
     std::string device_path_;
 };
 

--- a/device/api/umd/device/utils/kmd_mutex.hpp
+++ b/device/api/umd/device/utils/kmd_mutex.hpp
@@ -18,29 +18,6 @@ struct tt_device_t;
 
 namespace tt::umd {
 
-// Conventional KMD resource-lock indices. These mirror the TENSTORRENT_LOCK_INDEX_* defines in KMD's
-// ioctl.h: indices 0..15 are reserved by convention for ERISC cores. They are copied here (the KMD
-// header lives in a separate repo and cannot be included/linked from UMD); keep this in sync with
-// KMD. Callers coordinating their own resources should use indices outside this reserved range.
-enum class KmdLockIndex : uint8_t {
-    ETH00 = 0,
-    ETH01 = 1,
-    ETH02 = 2,
-    ETH03 = 3,
-    ETH04 = 4,
-    ETH05 = 5,
-    ETH06 = 6,
-    ETH07 = 7,
-    ETH08 = 8,
-    ETH09 = 9,
-    ETH10 = 10,
-    ETH11 = 11,
-    ETH12 = 12,
-    ETH13 = 13,
-    ETH14 = 14,
-    ETH15 = 15,
-};
-
 // KmdMutex is a cross-process lock backed by the Tenstorrent kernel-mode driver (KMD) resource locks,
 // which it drives through tt-kmd-lib's tt_lock_* API. See device/utils/README.md for how the
 // available locking backends compare.
@@ -51,15 +28,21 @@ enum class KmdLockIndex : uint8_t {
 //     namespaces, with no /dev/shm (or other filesystem) sharing required. This makes it the right
 //     primitive for serializing whole workloads against one device.
 //   - Every operation is an ioctl (a syscall); there is no userspace fast path. A contended lock()
-//     polls the non-blocking acquire with a short backoff (the ioctl set has no efficient blocking
+//     polls the non-blocking acquire once a millisecond (the ioctl set has no efficient blocking
 //     wait), so waiting for a held lock costs more than a single syscall.
 //   - The lock is held by the open file descriptor, and KMD releases all of an fd's locks when the
 //     fd is closed. Since the kernel closes every fd of a process when it dies, a crashed holder
 //     cannot leak the lock - it is reclaimed automatically.
 //   - Scope is limited to a single local device: there is no global lock that spans devices.
-//
-// Each KMD device exposes TT_RESOURCE_LOCK_COUNT (64) independent lock indices (see KmdLockIndex for
-// the reserved ones).
+//   - Threads of one process contend for the lock like separate processes do, even when they share
+//     one KmdMutex, because KMD arbitrates on a device wide bit rather than on the file descriptor:
+//     an acquire fails if the lock is held, including by the handle asking for it. So a single
+//     instance can be shared by every thread that needs the lock.
+//   - Releasing is not owner checked. KMD tracks which handle holds a lock, not which thread, so a
+//     thread can release a lock another thread of the same process took. Taking the lock through
+//     std::lock_guard or std::unique_lock keeps that from happening.
+//   - Nothing here is annotated for TSAN, unlike RobustMutex, so data that is guarded only by a
+//     KmdMutex is reported as racing under a TSAN build.
 //
 // This class owns its own dedicated device handle (chardev fd), separate from any fd used to run a
 // workload. That is deliberate: a device reset invalidates every fd that was open across it (further
@@ -73,14 +56,14 @@ enum class KmdLockIndex : uint8_t {
 class KmdMutex {
 public:
     // @param pci_device_num  N in /dev/tenstorrent/N (a UMD logical device id / PCIDevice number).
-    // @param lock_index      KMD resource lock index in [0, 64). Avoid 0..15 (reserved, see
-    //                        KmdLockIndex).
+    // @param lock_index      KMD resource lock index in [0, TT_RESOURCE_LOCK_COUNT). See
+    //                        tt_kmd_lib.h for which indices KMD suggests for which purpose.
     KmdMutex(int pci_device_num, uint8_t lock_index);
     ~KmdMutex() noexcept;
 
     // Opens the dedicated device handle used to hold the lock. Must be called before
     // lock()/try_lock(). Kept separate from the constructor so that failures during setup are still
-    // cleaned up by the destructor.
+    // cleaned up by the destructor. Calling it again once the handle is open does nothing.
     void initialize();
 
     // Move-only so it can live in STL containers. Copying would alias the owned handle.
@@ -114,6 +97,10 @@ public:
 private:
     void open_device();
     void close_device() noexcept;
+
+    // Closes and reopens the handle after a reset made it unusable. Closing is what releases any lock
+    // KMD still has recorded against the old handle. Returns whether the handle is usable again.
+    bool reopen_device() noexcept;
 
     int pci_device_num_;
     uint8_t lock_index_;

--- a/device/api/umd/device/utils/kmd_versions.hpp
+++ b/device/api/umd/device/utils/kmd_versions.hpp
@@ -53,11 +53,4 @@ inline constexpr SemVer KMD_TLB_DMABUF_EXPORT = SemVer(2, 10, 0, 1);
  * introduced in that release.
  */
 inline constexpr SemVer MIN_KERNEL_TLB_DMABUF_EXPORT = SemVer(5, 8, 0);
-
-/**
- * KMD version 1.26.0 introduced the TENSTORRENT_IOCTL_LOCK_CTL IOCTL, a generic per-device resource
- * locking primitive (acquire/release/test of one of TENSTORRENT_RESOURCE_LOCK_COUNT named locks).
- * KmdMutex requires at least this version.
- */
-inline constexpr SemVer KMD_RESOURCE_LOCKS = SemVer(1, 26, 0);
 }  // namespace tt::umd

--- a/device/api/umd/device/utils/kmd_versions.hpp
+++ b/device/api/umd/device/utils/kmd_versions.hpp
@@ -53,4 +53,11 @@ inline constexpr SemVer KMD_TLB_DMABUF_EXPORT = SemVer(2, 10, 0, 1);
  * introduced in that release.
  */
 inline constexpr SemVer MIN_KERNEL_TLB_DMABUF_EXPORT = SemVer(5, 8, 0);
+
+/**
+ * KMD version 1.26.0 introduced the TENSTORRENT_IOCTL_LOCK_CTL IOCTL, a generic per-device resource
+ * locking primitive (acquire/release/test of one of TENSTORRENT_RESOURCE_LOCK_COUNT named locks).
+ * KmdMutex requires at least this version.
+ */
+inline constexpr SemVer KMD_RESOURCE_LOCKS = SemVer(1, 26, 0);
 }  // namespace tt::umd

--- a/device/utils/README.md
+++ b/device/utils/README.md
@@ -1,0 +1,64 @@
+# UMD locking backends
+
+UMD provides two cross-process lock implementations. They expose the same small interface
+(`initialize()`, `lock()`, `try_lock()`, `unlock()`, `probe_lock()`) and meet the C++ `Lockable`
+requirement, so they work with `std::lock_guard` / `std::unique_lock` and can be swapped for one
+another. They differ in *how* processes find each other and in the performance/robustness trade-off.
+
+| Backend | Mechanism | Coordination requires | Lock/unlock cost | Crash-robust | Scope |
+|---|---|---|---|---|---|
+| `RobustMutex` | pthread robust mutex in a `/dev/shm` file | shared `/dev/shm` | fastest — userspace fast path, no syscall when uncontended | yes (`EOWNERDEAD` recovery) | any name |
+| `KmdMutex` | KMD resource lock via `ioctl` | shared access to `/dev/tenstorrent/<N>` | slower — an `ioctl` on every lock and unlock | yes (released on fd close / process death) | a single silicon device |
+
+## RobustMutex
+
+A robust pthread mutex living in a shared-memory (`/dev/shm`) file. Because the mutex is in shared
+memory, the uncontended `lock()`/`unlock()` path is pure userspace (a futex that never enters the
+kernel), which makes it the **faster** of the two. It is robust: if the owning process dies, the
+next acquirer recovers the mutex (`EOWNERDEAD` → `pthread_mutex_consistent`).
+
+Cost: it requires every participant to see the **same `/dev/shm`**. Processes in separate containers
+must share `/dev/shm` explicitly. It also carries the most implementation complexity (shared-memory
+layout, pthread-version assumptions, dead-owner recovery).
+
+## KmdMutex
+
+A lock backed by the kernel-mode driver's resource locks (`TENSTORRENT_IOCTL_LOCK_CTL`). It is
+**slower** than `RobustMutex` because every operation is a (custom) `ioctl` syscall, with no userspace
+fast path. The ioctl set used exposes only a non-blocking acquire, so a contended `lock()` polls with a
+short backoff rather than waiting efficiently in the kernel (this also avoids KMD's blocking-acquire
+path, which has had a deadlock against device reset).
+
+Its distinguishing property: it needs **no filesystem sharing beyond the device itself**. The lock
+lives in the driver, keyed by the device and a lock index, so any process that can open
+`/dev/tenstorrent/<N>` contends over the same lock — across containers and mount namespaces, with no
+`/dev/shm` to share. The lock is released automatically on fd close / process death.
+
+Limitation: the lock is **tied to a single silicon device**. There is no global lock spanning
+devices, and a remote chip reachable through more than one local gateway cannot be serialized by a
+single KMD lock (each gateway has its own independent lock table). Indices `0..15` are reserved by
+convention for ERISC cores; use higher indices for general coordination.
+
+## Choosing
+
+- Hot, fine-grained locks taken in inner loops, where a shared `/dev/shm` exists → `RobustMutex` (the
+  userspace fast path matters).
+- Coordination **without** a shared filesystem (e.g. across containers that only share the device) →
+  `KmdMutex`, accepting the per-device scope.
+
+## Benchmark
+
+Relative performance can be measured with the locks microbenchmark
+(`tests/microbenchmark/host_benchmark/test_locks.cpp`):
+
+It is built as its own executable (`umd_locks_benchmark`), separate from the regular
+`umd_microbenchmark`, since it is a one-off comparison rather than a routine benchmark:
+
+```bash
+cmake -B build -G Ninja -DTT_UMD_BUILD_TESTS=ON
+ninja umd_locks_benchmark -C build
+./build/test/umd/microbenchmark/umd_locks_benchmark
+```
+
+It reports initialize, single-thread lock/unlock, contended `probe_lock`, and multi-threaded
+contended throughput per backend. `KmdMutex` cases are skipped when no device is present.

--- a/device/utils/README.md
+++ b/device/utils/README.md
@@ -23,7 +23,8 @@ layout, pthread-version assumptions, dead-owner recovery).
 
 ## KmdMutex
 
-A lock backed by the kernel-mode driver's resource locks (`TENSTORRENT_IOCTL_LOCK_CTL`). It is
+A lock backed by the kernel-mode driver's resource locks, driven through tt-kmd-lib's `tt_lock_*`
+API (`TENSTORRENT_IOCTL_LOCK_CTL` under the hood). It is
 **slower** than `RobustMutex` because every operation is a (custom) `ioctl` syscall, with no userspace
 fast path. The ioctl set used exposes only a non-blocking acquire, so a contended `lock()` polls with a
 short backoff rather than waiting efficiently in the kernel (this also avoids KMD's blocking-acquire

--- a/device/utils/README.md
+++ b/device/utils/README.md
@@ -26,14 +26,17 @@ layout, pthread-version assumptions, dead-owner recovery).
 A lock backed by the kernel-mode driver's resource locks, driven through tt-kmd-lib's `tt_lock_*`
 API (`TENSTORRENT_IOCTL_LOCK_CTL` under the hood). It is
 **slower** than `RobustMutex` because every operation is a (custom) `ioctl` syscall, with no userspace
-fast path. The ioctl set used exposes only a non-blocking acquire, so a contended `lock()` polls with a
-short backoff rather than waiting efficiently in the kernel (this also avoids KMD's blocking-acquire
+fast path. The ioctl set used exposes only a non-blocking acquire, so a contended `lock()` polls once a
+millisecond rather than waiting efficiently in the kernel (this also avoids KMD's blocking-acquire
 path, which has had a deadlock against device reset).
 
 Its distinguishing property: it needs **no filesystem sharing beyond the device itself**. The lock
 lives in the driver, keyed by the device and a lock index, so any process that can open
 `/dev/tenstorrent/<N>` contends over the same lock — across containers and mount namespaces, with no
 `/dev/shm` to share. The lock is released automatically on fd close / process death.
+
+Unlike `RobustMutex`, it carries no TSAN annotations, so data guarded only by a `KmdMutex` is
+reported as racing under a TSAN build.
 
 Limitation: the lock is **tied to a single silicon device**. There is no global lock spanning
 devices, and a remote chip reachable through more than one local gateway cannot be serialized by a

--- a/device/utils/kmd_mutex.cpp
+++ b/device/utils/kmd_mutex.cpp
@@ -1,0 +1,215 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/utils/kmd_mutex.hpp"
+
+#include <fcntl.h>  // ::open, O_RDWR, O_CLOEXEC, O_APPEND
+#include <fmt/format.h>
+#include <sys/ioctl.h>  // ioctl
+#include <unistd.h>     // ::close
+
+#include <cerrno>
+#include <chrono>
+#include <thread>
+#include <tt-logger/tt-logger.hpp>
+
+#include "pcie/ioctl.h"  // TENSTORRENT_IOCTL_LOCK_CTL and friends
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/utils/error.hpp"
+#include "umd/device/utils/kmd_versions.hpp"
+
+namespace tt::umd {
+
+KmdMutex::KmdMutex(int pci_device_num, uint8_t lock_index) :
+    pci_device_num_(pci_device_num),
+    lock_index_(lock_index),
+    device_path_(fmt::format("/dev/tenstorrent/{}", pci_device_num)) {
+    UMD_ASSERT(
+        lock_index_ < TENSTORRENT_RESOURCE_LOCK_COUNT,
+        error::RuntimeError,
+        fmt::format("KMD resource lock index {} out of range [0, {})", lock_index_, TENSTORRENT_RESOURCE_LOCK_COUNT));
+}
+
+KmdMutex::~KmdMutex() noexcept { close_fd(); }
+
+KmdMutex::KmdMutex(KmdMutex&& other) noexcept :
+    pci_device_num_(other.pci_device_num_),
+    lock_index_(other.lock_index_),
+    fd_(other.fd_),
+    device_path_(std::move(other.device_path_)) {
+    // Invalidate the other object so its destructor doesn't close our fd.
+    other.fd_ = -1;
+}
+
+KmdMutex& KmdMutex::operator=(KmdMutex&& other) noexcept {
+    if (this != &other) {
+        close_fd();  // clean up existing resources
+
+        pci_device_num_ = other.pci_device_num_;
+        lock_index_ = other.lock_index_;
+        fd_ = other.fd_;
+        device_path_ = std::move(other.device_path_);
+
+        other.fd_ = -1;
+    }
+    return *this;
+}
+
+void KmdMutex::open_device_fd() {
+    // O_APPEND tells KMD (>= 2.6) not to request high power on open; a lock-only fd should not change
+    // the device's power state. The flag is harmless on older KMD versions. O_CLOEXEC avoids leaking
+    // the lock fd into child processes, which would keep the lock held longer than intended.
+    fd_ = ::open(device_path_.c_str(), O_RDWR | O_CLOEXEC | O_APPEND);
+    UMD_ASSERT(
+        fd_ != -1,
+        error::RuntimeError,
+        fmt::format("open() failed for KMD lock device {} errno: {}", device_path_, std::to_string(errno)));
+}
+
+void KmdMutex::initialize() {
+    // Resource locks require a KMD new enough to implement the LOCK_CTL ioctl; on older KMD the
+    // ioctl would simply fail at use time. Fail early and clearly instead.
+    SemVer kmd_version = PCIDevice::read_kmd_version();
+    UMD_ASSERT(
+        kmd_version >= KMD_RESOURCE_LOCKS,
+        error::RuntimeError,
+        fmt::format(
+            "KmdMutex requires KMD version {} or newer for resource locks, but the installed KMD is {}.",
+            KMD_RESOURCE_LOCKS.to_string(),
+            kmd_version.to_string()));
+
+    open_device_fd();
+}
+
+void KmdMutex::close_fd() noexcept {
+    if (fd_ != -1) {
+        // Closing the fd releases any lock held on it (enforced by KMD), so this is also our unlock
+        // path on destruction.
+        if (::close(fd_) != 0) {
+            // Destructor path: log instead of throwing.
+            log_warning(
+                tt::LogUMD, "close() failed for KMD lock device {} errno: {}", device_path_, std::to_string(errno));
+        }
+        fd_ = -1;
+    }
+}
+
+bool KmdMutex::try_lock() {
+    UMD_ASSERT(fd_ != -1, error::RuntimeError, "KmdMutex::try_lock() called before initialize()");
+
+    tenstorrent_lock_ctl lock_ctl{};
+    lock_ctl.in.output_size_bytes = sizeof(lock_ctl.out);
+    lock_ctl.in.flags = TENSTORRENT_LOCK_CTL_ACQUIRE;
+    lock_ctl.in.index = lock_index_;
+
+    if (ioctl(fd_, TENSTORRENT_IOCTL_LOCK_CTL, &lock_ctl) != 0) {
+        // A reset across our fd makes it unusable; reopen and retry once on a fresh fd.
+        if (errno == ENODEV) {
+            close_fd();
+            open_device_fd();
+            if (ioctl(fd_, TENSTORRENT_IOCTL_LOCK_CTL, &lock_ctl) == 0) {
+                return lock_ctl.out.value == 1;
+            }
+        }
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format(
+                "LOCK_CTL ACQUIRE failed for lock {} on {} errno: {}",
+                lock_index_,
+                device_path_,
+                std::to_string(errno)));
+    }
+
+    // out.value: 1 = acquired, 0 = held by another fd.
+    return lock_ctl.out.value == 1;
+}
+
+void KmdMutex::lock() {
+    UMD_ASSERT(fd_ != -1, error::RuntimeError, "KmdMutex::lock() called before initialize()");
+
+    // The LOCK_CTL ioctl set used here exposes only non-blocking acquire, so a blocking lock is
+    // implemented by polling the non-blocking acquire with a short backoff. This also deliberately
+    // avoids KMD's blocking-acquire path, which has had a deadlock against the reset ioctl. try_lock()
+    // already handles a reset (ENODEV) by reopening the fd.
+    while (!try_lock()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+}
+
+std::optional<std::pair<pid_t, pid_t>> KmdMutex::probe_lock(std::chrono::seconds timeout) {
+    // KMD only offers non-blocking acquire and blocking acquire (no native timed acquire), so a
+    // bounded wait is implemented by polling the non-blocking acquire. On success we hold the lock and
+    // return nullopt.
+    if (try_lock()) {
+        return std::nullopt;
+    }
+    if (timeout.count() == 0) {
+        // Owner is unknown - KMD does not expose which fd/process holds the lock.
+        return std::make_pair(static_cast<pid_t>(0), static_cast<pid_t>(0));
+    }
+
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        if (try_lock()) {
+            return std::nullopt;
+        }
+    }
+    return std::make_pair(static_cast<pid_t>(0), static_cast<pid_t>(0));
+}
+
+void KmdMutex::unlock() {
+    UMD_ASSERT(fd_ != -1, error::RuntimeError, "KmdMutex::unlock() called before initialize()");
+
+    tenstorrent_lock_ctl lock_ctl{};
+    lock_ctl.in.output_size_bytes = sizeof(lock_ctl.out);
+    lock_ctl.in.flags = TENSTORRENT_LOCK_CTL_RELEASE;
+    lock_ctl.in.index = lock_index_;
+
+    if (ioctl(fd_, TENSTORRENT_IOCTL_LOCK_CTL, &lock_ctl) != 0) {
+        // If the fd died due to a reset, the lock is still held in KMD until the fd is closed; the
+        // destructor's close() will release it, so this is not fatal.
+        if (errno == ENODEV) {
+            log_warning(
+                tt::LogUMD,
+                "LOCK_CTL RELEASE for lock {} on {} hit ENODEV (device reset); lock will be released on close",
+                lock_index_,
+                device_path_);
+            return;
+        }
+        UMD_THROW(
+            error::RuntimeError,
+            fmt::format(
+                "LOCK_CTL RELEASE failed for lock {} on {} errno: {}",
+                lock_index_,
+                device_path_,
+                std::to_string(errno)));
+    }
+
+    // out.value == 0 means we did not actually hold the lock. Benign (e.g. double unlock), but worth a
+    // debug trace.
+    if (lock_ctl.out.value == 0) {
+        log_debug(tt::LogUMD, "LOCK_CTL RELEASE for lock {} on {}: lock was not held by us", lock_index_, device_path_);
+    }
+}
+
+bool KmdMutex::is_locked_by_anyone() {
+    UMD_ASSERT(fd_ != -1, error::RuntimeError, "KmdMutex::is_locked_by_anyone() called before initialize()");
+
+    tenstorrent_lock_ctl lock_ctl{};
+    lock_ctl.in.output_size_bytes = sizeof(lock_ctl.out);
+    lock_ctl.in.flags = TENSTORRENT_LOCK_CTL_TEST;
+    lock_ctl.in.index = lock_index_;
+
+    UMD_ASSERT(
+        ioctl(fd_, TENSTORRENT_IOCTL_LOCK_CTL, &lock_ctl) == 0,
+        error::RuntimeError,
+        fmt::format(
+            "LOCK_CTL TEST failed for lock {} on {} errno: {}", lock_index_, device_path_, std::to_string(errno)));
+
+    // out.value: bit 0 = held by us, bit 1 = held by any fd.
+    return (lock_ctl.out.value & 0b10) != 0;
+}
+
+}  // namespace tt::umd

--- a/device/utils/kmd_mutex.cpp
+++ b/device/utils/kmd_mutex.cpp
@@ -4,20 +4,16 @@
 
 #include "umd/device/utils/kmd_mutex.hpp"
 
-#include <fcntl.h>  // ::open, O_RDWR, O_CLOEXEC, O_APPEND
+#include <fcntl.h>  // O_APPEND
 #include <fmt/format.h>
-#include <sys/ioctl.h>  // ioctl
-#include <unistd.h>     // ::close
 
 #include <cerrno>
 #include <chrono>
 #include <thread>
 #include <tt-logger/tt-logger.hpp>
 
-#include "pcie/ioctl.h"  // TENSTORRENT_IOCTL_LOCK_CTL and friends
-#include "umd/device/pcie/pci_device.hpp"
+#include "tt-kmd-lib/tt_kmd_lib.h"
 #include "umd/device/utils/error.hpp"
-#include "umd/device/utils/kmd_versions.hpp"
 
 namespace tt::umd {
 
@@ -26,112 +22,89 @@ KmdMutex::KmdMutex(int pci_device_num, uint8_t lock_index) :
     lock_index_(lock_index),
     device_path_(fmt::format("/dev/tenstorrent/{}", pci_device_num)) {
     UMD_ASSERT(
-        lock_index_ < TENSTORRENT_RESOURCE_LOCK_COUNT,
+        lock_index_ < TT_RESOURCE_LOCK_COUNT,
         error::RuntimeError,
-        fmt::format("KMD resource lock index {} out of range [0, {})", lock_index_, TENSTORRENT_RESOURCE_LOCK_COUNT));
+        fmt::format("KMD resource lock index {} out of range [0, {})", lock_index_, TT_RESOURCE_LOCK_COUNT));
 }
 
-KmdMutex::~KmdMutex() noexcept { close_fd(); }
+KmdMutex::~KmdMutex() noexcept { close_device(); }
 
 KmdMutex::KmdMutex(KmdMutex&& other) noexcept :
     pci_device_num_(other.pci_device_num_),
     lock_index_(other.lock_index_),
-    fd_(other.fd_),
+    device_(other.device_),
     device_path_(std::move(other.device_path_)) {
-    // Invalidate the other object so its destructor doesn't close our fd.
-    other.fd_ = -1;
+    // Invalidate the other object so its destructor doesn't close our handle.
+    other.device_ = nullptr;
 }
 
 KmdMutex& KmdMutex::operator=(KmdMutex&& other) noexcept {
     if (this != &other) {
-        close_fd();  // clean up existing resources
+        close_device();  // clean up existing resources
 
         pci_device_num_ = other.pci_device_num_;
         lock_index_ = other.lock_index_;
-        fd_ = other.fd_;
+        device_ = other.device_;
         device_path_ = std::move(other.device_path_);
 
-        other.fd_ = -1;
+        other.device_ = nullptr;
     }
     return *this;
 }
 
-void KmdMutex::open_device_fd() {
-    // O_APPEND tells KMD (>= 2.6) not to request high power on open; a lock-only fd should not change
-    // the device's power state. The flag is harmless on older KMD versions. O_CLOEXEC avoids leaking
-    // the lock fd into child processes, which would keep the lock held longer than intended.
-    fd_ = ::open(device_path_.c_str(), O_RDWR | O_CLOEXEC | O_APPEND);
+void KmdMutex::open_device() {
+    // O_APPEND tells KMD (>= 2.6) not to request high power on open; a lock-only handle should not
+    // change the device's power state. The flag is harmless on older KMD versions.
+    int result = tt_device_open(device_path_.c_str(), &device_, O_APPEND);
     UMD_ASSERT(
-        fd_ != -1,
+        result == 0,
         error::RuntimeError,
-        fmt::format("open() failed for KMD lock device {} errno: {}", device_path_, std::to_string(errno)));
+        fmt::format("tt_device_open() failed for KMD lock device {} errno: {}", device_path_, -result));
 }
 
-void KmdMutex::initialize() {
-    // Resource locks require a KMD new enough to implement the LOCK_CTL ioctl; on older KMD the
-    // ioctl would simply fail at use time. Fail early and clearly instead.
-    SemVer kmd_version = PCIDevice::read_kmd_version();
-    UMD_ASSERT(
-        kmd_version >= KMD_RESOURCE_LOCKS,
-        error::RuntimeError,
-        fmt::format(
-            "KmdMutex requires KMD version {} or newer for resource locks, but the installed KMD is {}.",
-            KMD_RESOURCE_LOCKS.to_string(),
-            kmd_version.to_string()));
+void KmdMutex::initialize() { open_device(); }
 
-    open_device_fd();
-}
-
-void KmdMutex::close_fd() noexcept {
-    if (fd_ != -1) {
-        // Closing the fd releases any lock held on it (enforced by KMD), so this is also our unlock
-        // path on destruction.
-        if (::close(fd_) != 0) {
+void KmdMutex::close_device() noexcept {
+    if (device_ != nullptr) {
+        // Closing the handle releases any lock held on it (enforced by KMD), so this is also our
+        // unlock path on destruction.
+        int result = tt_device_close(device_);
+        if (result != 0) {
             // Destructor path: log instead of throwing.
-            log_warning(
-                tt::LogUMD, "close() failed for KMD lock device {} errno: {}", device_path_, std::to_string(errno));
+            log_warning(tt::LogUMD, "tt_device_close() failed for KMD lock device {} errno: {}", device_path_, -result);
         }
-        fd_ = -1;
+        device_ = nullptr;
     }
 }
 
 bool KmdMutex::try_lock() {
-    UMD_ASSERT(fd_ != -1, error::RuntimeError, "KmdMutex::try_lock() called before initialize()");
+    UMD_ASSERT(device_ != nullptr, error::RuntimeError, "KmdMutex::try_lock() called before initialize()");
 
-    tenstorrent_lock_ctl lock_ctl{};
-    lock_ctl.in.output_size_bytes = sizeof(lock_ctl.out);
-    lock_ctl.in.flags = TENSTORRENT_LOCK_CTL_ACQUIRE;
-    lock_ctl.in.index = lock_index_;
+    int acquired = 0;
+    int result = tt_lock_acquire(device_, lock_index_, &acquired);
 
-    if (ioctl(fd_, TENSTORRENT_IOCTL_LOCK_CTL, &lock_ctl) != 0) {
-        // A reset across our fd makes it unusable; reopen and retry once on a fresh fd.
-        if (errno == ENODEV) {
-            close_fd();
-            open_device_fd();
-            if (ioctl(fd_, TENSTORRENT_IOCTL_LOCK_CTL, &lock_ctl) == 0) {
-                return lock_ctl.out.value == 1;
-            }
-        }
-        UMD_THROW(
-            error::RuntimeError,
-            fmt::format(
-                "LOCK_CTL ACQUIRE failed for lock {} on {} errno: {}",
-                lock_index_,
-                device_path_,
-                std::to_string(errno)));
+    // A reset across our handle makes it unusable; reopen and retry once on a fresh handle.
+    if (result == -ENODEV) {
+        close_device();
+        open_device();
+        result = tt_lock_acquire(device_, lock_index_, &acquired);
     }
 
-    // out.value: 1 = acquired, 0 = held by another fd.
-    return lock_ctl.out.value == 1;
+    UMD_ASSERT(
+        result == 0,
+        error::RuntimeError,
+        fmt::format("tt_lock_acquire() failed for lock {} on {} errno: {}", lock_index_, device_path_, -result));
+
+    return acquired == 1;
 }
 
 void KmdMutex::lock() {
-    UMD_ASSERT(fd_ != -1, error::RuntimeError, "KmdMutex::lock() called before initialize()");
+    UMD_ASSERT(device_ != nullptr, error::RuntimeError, "KmdMutex::lock() called before initialize()");
 
-    // The LOCK_CTL ioctl set used here exposes only non-blocking acquire, so a blocking lock is
-    // implemented by polling the non-blocking acquire with a short backoff. This also deliberately
-    // avoids KMD's blocking-acquire path, which has had a deadlock against the reset ioctl. try_lock()
-    // already handles a reset (ENODEV) by reopening the fd.
+    // KMD exposes only non-blocking acquire, so a blocking lock is implemented by polling it with a
+    // short backoff. This also deliberately avoids KMD's blocking-acquire path, which has had a
+    // deadlock against the reset ioctl. try_lock() already handles a reset (ENODEV) by reopening the
+    // handle.
     while (!try_lock()) {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
@@ -145,7 +118,7 @@ std::optional<std::pair<pid_t, pid_t>> KmdMutex::probe_lock(std::chrono::seconds
         return std::nullopt;
     }
     if (timeout.count() == 0) {
-        // Owner is unknown - KMD does not expose which fd/process holds the lock.
+        // Owner is unknown - KMD does not expose which handle/process holds the lock.
         return std::make_pair(static_cast<pid_t>(0), static_cast<pid_t>(0));
     }
 
@@ -160,56 +133,45 @@ std::optional<std::pair<pid_t, pid_t>> KmdMutex::probe_lock(std::chrono::seconds
 }
 
 void KmdMutex::unlock() {
-    UMD_ASSERT(fd_ != -1, error::RuntimeError, "KmdMutex::unlock() called before initialize()");
+    UMD_ASSERT(device_ != nullptr, error::RuntimeError, "KmdMutex::unlock() called before initialize()");
 
-    tenstorrent_lock_ctl lock_ctl{};
-    lock_ctl.in.output_size_bytes = sizeof(lock_ctl.out);
-    lock_ctl.in.flags = TENSTORRENT_LOCK_CTL_RELEASE;
-    lock_ctl.in.index = lock_index_;
+    int was_held = 0;
+    int result = tt_lock_release(device_, lock_index_, &was_held);
 
-    if (ioctl(fd_, TENSTORRENT_IOCTL_LOCK_CTL, &lock_ctl) != 0) {
-        // If the fd died due to a reset, the lock is still held in KMD until the fd is closed; the
-        // destructor's close() will release it, so this is not fatal.
-        if (errno == ENODEV) {
-            log_warning(
-                tt::LogUMD,
-                "LOCK_CTL RELEASE for lock {} on {} hit ENODEV (device reset); lock will be released on close",
-                lock_index_,
-                device_path_);
-            return;
-        }
-        UMD_THROW(
-            error::RuntimeError,
-            fmt::format(
-                "LOCK_CTL RELEASE failed for lock {} on {} errno: {}",
-                lock_index_,
-                device_path_,
-                std::to_string(errno)));
+    // If the handle died due to a reset, the lock is still held in KMD until the handle is closed;
+    // the destructor's close will release it, so this is not fatal.
+    if (result == -ENODEV) {
+        log_warning(
+            tt::LogUMD,
+            "tt_lock_release() for lock {} on {} hit ENODEV (device reset); lock will be released on close",
+            lock_index_,
+            device_path_);
+        return;
     }
 
-    // out.value == 0 means we did not actually hold the lock. Benign (e.g. double unlock), but worth a
-    // debug trace.
-    if (lock_ctl.out.value == 0) {
-        log_debug(tt::LogUMD, "LOCK_CTL RELEASE for lock {} on {}: lock was not held by us", lock_index_, device_path_);
+    UMD_ASSERT(
+        result == 0,
+        error::RuntimeError,
+        fmt::format("tt_lock_release() failed for lock {} on {} errno: {}", lock_index_, device_path_, -result));
+
+    // Not having held the lock is benign (e.g. double unlock), but worth a debug trace.
+    if (!was_held) {
+        log_debug(
+            tt::LogUMD, "tt_lock_release() for lock {} on {}: lock was not held by us", lock_index_, device_path_);
     }
 }
 
 bool KmdMutex::is_locked_by_anyone() {
-    UMD_ASSERT(fd_ != -1, error::RuntimeError, "KmdMutex::is_locked_by_anyone() called before initialize()");
+    UMD_ASSERT(device_ != nullptr, error::RuntimeError, "KmdMutex::is_locked_by_anyone() called before initialize()");
 
-    tenstorrent_lock_ctl lock_ctl{};
-    lock_ctl.in.output_size_bytes = sizeof(lock_ctl.out);
-    lock_ctl.in.flags = TENSTORRENT_LOCK_CTL_TEST;
-    lock_ctl.in.index = lock_index_;
-
+    uint32_t state = 0;
+    int result = tt_lock_test(device_, lock_index_, &state);
     UMD_ASSERT(
-        ioctl(fd_, TENSTORRENT_IOCTL_LOCK_CTL, &lock_ctl) == 0,
+        result == 0,
         error::RuntimeError,
-        fmt::format(
-            "LOCK_CTL TEST failed for lock {} on {} errno: {}", lock_index_, device_path_, std::to_string(errno)));
+        fmt::format("tt_lock_test() failed for lock {} on {} errno: {}", lock_index_, device_path_, -result));
 
-    // out.value: bit 0 = held by us, bit 1 = held by any fd.
-    return (lock_ctl.out.value & 0b10) != 0;
+    return (state & TT_LOCK_STATE_HELD_BY_ANY) != 0;
 }
 
 }  // namespace tt::umd

--- a/device/utils/kmd_mutex.cpp
+++ b/device/utils/kmd_mutex.cpp
@@ -17,6 +17,9 @@
 
 namespace tt::umd {
 
+// How long a contended lock() waits before reporting, once, that it is waiting.
+constexpr auto WAIT_WARNING_DELAY = std::chrono::seconds(1);
+
 KmdMutex::KmdMutex(int pci_device_num, uint8_t lock_index) :
     pci_device_num_(pci_device_num),
     lock_index_(lock_index),
@@ -62,7 +65,25 @@ void KmdMutex::open_device() {
         fmt::format("tt_device_open() failed for KMD lock device {} errno: {}", device_path_, -result));
 }
 
-void KmdMutex::initialize() { open_device(); }
+void KmdMutex::initialize() {
+    if (device_ != nullptr) {
+        // Already open. Opening again would overwrite the handle and leak the old one, along with any
+        // lock KMD has recorded against it.
+        return;
+    }
+    open_device();
+}
+
+bool KmdMutex::reopen_device() noexcept {
+    close_device();
+    try {
+        open_device();
+    } catch (const std::exception& e) {
+        log_warning(tt::LogUMD, "Reopening KMD lock device {} failed: {}", device_path_, e.what());
+        return false;
+    }
+    return true;
+}
 
 void KmdMutex::close_device() noexcept {
     if (device_ != nullptr) {
@@ -101,11 +122,24 @@ bool KmdMutex::try_lock() {
 void KmdMutex::lock() {
     UMD_ASSERT(device_ != nullptr, error::RuntimeError, "KmdMutex::lock() called before initialize()");
 
-    // KMD exposes only non-blocking acquire, so a blocking lock is implemented by polling it with a
-    // short backoff. This also deliberately avoids KMD's blocking-acquire path, which has had a
+    // KMD exposes only non-blocking acquire, so a blocking lock is implemented by polling it once a
+    // millisecond. This also deliberately avoids KMD's blocking-acquire path, which has had a
     // deadlock against the reset ioctl. try_lock() already handles a reset (ENODEV) by reopening the
     // handle.
+    // A lock that is taking a while is reported once, the way RobustMutex reports it, so that a lock
+    // nobody releases shows up in the log instead of looking like a hang. KMD does not say which
+    // handle holds the lock, so there is no owner to name.
+    const auto warn_at = std::chrono::steady_clock::now() + WAIT_WARNING_DELAY;
+    bool warned = false;
     while (!try_lock()) {
+        if (!warned && std::chrono::steady_clock::now() >= warn_at) {
+            log_warning(
+                tt::LogUMD,
+                "Waiting for KMD lock {} on {}, which is currently held by another handle",
+                lock_index_,
+                device_path_);
+            warned = true;
+        }
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 }
@@ -138,14 +172,17 @@ void KmdMutex::unlock() {
     int was_held = 0;
     int result = tt_lock_release(device_, lock_index_, &was_held);
 
-    // If the handle died due to a reset, the lock is still held in KMD until the handle is closed;
-    // the destructor's close will release it, so this is not fatal.
+    // A reset made the handle unusable, and the release did not go through. KMD still has the lock
+    // recorded against the old handle and only closing it gives the lock back, so close here rather
+    // than leaving it held for as long as this object lives - which, since locks are kept for the
+    // lifetime of the process, would be until the process exits.
     if (result == -ENODEV) {
         log_warning(
             tt::LogUMD,
-            "tt_lock_release() for lock {} on {} hit ENODEV (device reset); lock will be released on close",
+            "tt_lock_release() for lock {} on {} hit ENODEV (device reset); reopening the handle to release it",
             lock_index_,
             device_path_);
+        reopen_device();
         return;
     }
 

--- a/tests/microbenchmark/CMakeLists.txt
+++ b/tests/microbenchmark/CMakeLists.txt
@@ -25,3 +25,7 @@ set_target_properties(
         RUNTIME_OUTPUT_DIRECTORY
             ${CMAKE_BINARY_DIR}/test/umd/microbenchmark
 )
+
+# Host-side one-off benchmarks (e.g. locking backends) live in their own subdirectory with a
+# dedicated CMakeLists, separate from the regular device microbenchmarks above.
+add_subdirectory(host_benchmark)

--- a/tests/microbenchmark/host_benchmark/CMakeLists.txt
+++ b/tests/microbenchmark/host_benchmark/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Host-side perf comparisons (no device required for most cases). Kept as its own executable,
+# separate from umd_microbenchmark, because these are one-off comparisons rather than routine
+# benchmarks.
+add_executable(umd_locks_benchmark test_locks.cpp)
+target_link_libraries(
+    umd_locks_benchmark
+    PRIVATE
+        test_common
+        nanobench
+)
+target_include_directories(
+    umd_locks_benchmark
+    PRIVATE
+        ${nanobench_SOURCE_DIR}/src/include
+        # Parent microbenchmark dir, so "common/microbenchmark_utils.hpp" resolves.
+        ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+set_target_properties(
+    umd_locks_benchmark
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${CMAKE_BINARY_DIR}/test/umd/microbenchmark
+)

--- a/tests/microbenchmark/host_benchmark/test_locks.cpp
+++ b/tests/microbenchmark/host_benchmark/test_locks.cpp
@@ -1,0 +1,280 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Microbenchmarks comparing the available UMD locking backends:
+//   - RobustMutex     : pthread robust mutex in a /dev/shm file (userspace fast path).
+//   - KmdMutex        : KMD resource lock via ioctl (syscall per op, tied to a silicon device).
+//
+// FlockMutex (flock(2) over a /dev/shm file) was a third backend; its implementation has been
+// removed, but its benchmark wiring is kept commented out below so it can be re-enabled easily.
+//
+// What is measured, per mechanism:
+//   - Initialize        : construct + initialize() + destroy.
+//   - LockUnlock         : uncontended lock() + unlock() on one thread.
+//   - ProbeContended     : probe_lock() cost when the lock is already held (returns "busy").
+//   - LockUnlockThreads  : aggregate lock()/unlock() throughput under N contending threads.
+//
+// KmdMutex benchmarks are skipped when no /dev/tenstorrent device is present. They use a high
+// resource-lock index that does not collide with ERISC (0..15) or the device-exclusive convention.
+
+#include <gtest/gtest.h>
+#include <nanobench.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+#include "common/microbenchmark_utils.hpp"
+#include "umd/device/pcie/pci_device.hpp"
+// #include "umd/device/utils/flock_mutex.hpp"  // FlockMutex removed; see note at top of file.
+#include "umd/device/utils/kmd_mutex.hpp"
+#include "umd/device/utils/robust_mutex.hpp"
+
+using namespace tt::umd;
+
+namespace {
+
+// Names/index used only by these benchmarks, kept distinct from real UMD locks.
+constexpr std::string_view BENCH_ROBUST_NAME = "MICROBENCH_ROBUST";
+// constexpr std::string_view BENCH_FLOCK_NAME = "MICROBENCH_FLOCK";  // FlockMutex removed.
+constexpr uint8_t BENCH_KMD_LOCK_INDEX = 32;
+
+// Thread counts exercised by the contended throughput benchmark.
+const std::vector<int> THREAD_COUNTS = {1, 2, 4, 8};
+// Each (mechanism, thread-count) combination runs for this long; bounding by time rather than by a
+// fixed iteration count keeps total runtime predictable even for slow, polling-based backends.
+constexpr std::chrono::milliseconds CONTENDED_BUDGET{200};
+
+// Returns a /dev/tenstorrent device number to benchmark KMD locks against, or nullopt if none exist.
+std::optional<int> first_device() {
+    std::vector<int> devices = PCIDevice::enumerate_devices();
+    if (devices.empty()) {
+        return std::nullopt;
+    }
+    return devices.front();
+}
+
+// Construct + initialize a fresh mutex of the requested kind. Each factory returns an initialized,
+// ready-to-lock instance; the mutex types are move-only and movable, so returning by value is cheap.
+RobustMutex make_robust() {
+    RobustMutex m(BENCH_ROBUST_NAME);
+    m.initialize();
+    return m;
+}
+
+// FlockMutex removed; factory kept commented out so the benchmark can be re-enabled easily.
+// FlockMutex make_flock() {
+//     FlockMutex m(BENCH_FLOCK_NAME);
+//     m.initialize();
+//     return m;
+// }
+
+KmdMutex make_kmd(int device_num) {
+    KmdMutex m(device_num, BENCH_KMD_LOCK_INDEX);
+    m.initialize();
+    return m;
+}
+
+// Measures aggregate lock()/unlock() throughput: num_threads threads, each with its own instance
+// contending over the same underlying lock, each looping lock/unlock until the time budget expires.
+// Returns nanoseconds per lock+unlock pair (wall-clock / total ops summed across threads).
+template <typename MakeFn>
+double bench_contended_threads(MakeFn make, int num_threads, std::chrono::milliseconds budget) {
+    std::atomic<int> ready{0};
+    std::atomic<bool> go{false};
+    std::atomic<bool> stop{false};
+    std::atomic<int64_t> total_ops{0};
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+
+    for (int t = 0; t < num_threads; ++t) {
+        threads.emplace_back([&]() {
+            auto m = make();  // each thread owns its own instance / fd
+            ready.fetch_add(1, std::memory_order_release);
+            while (!go.load(std::memory_order_acquire)) {
+            }
+            // Check the stop flag only once per batch so the atomic load does not show up in the
+            // per-op measurement. Overshooting the time budget by up to one batch is harmless: the
+            // returned ns/op is elapsed_time / ops, so both numerator and denominator include the
+            // overshoot and the ratio stays accurate.
+            constexpr int64_t STOP_CHECK_BATCH = 1000;
+            int64_t ops = 0;
+            while (!stop.load(std::memory_order_relaxed)) {
+                for (int64_t i = 0; i < STOP_CHECK_BATCH; ++i) {
+                    m.lock();
+                    m.unlock();
+                }
+                ops += STOP_CHECK_BATCH;
+            }
+            total_ops.fetch_add(ops, std::memory_order_relaxed);
+        });
+    }
+
+    // Start timing only once every thread has constructed its instance and is spinning on `go`.
+    while (ready.load(std::memory_order_acquire) < num_threads) {
+    }
+    auto start = std::chrono::steady_clock::now();
+    go.store(true, std::memory_order_release);
+    std::this_thread::sleep_for(budget);
+    stop.store(true, std::memory_order_release);
+    for (auto& thread : threads) {
+        thread.join();
+    }
+    auto end = std::chrono::steady_clock::now();
+
+    int64_t ops = total_ops.load(std::memory_order_relaxed);
+    if (ops == 0) {
+        return 0.0;
+    }
+    double total_ns = static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count());
+    return total_ns / static_cast<double>(ops);
+}
+
+}  // namespace
+
+// construct + initialize() + destroy.
+TEST(MicrobenchmarkLocks, Initialize) {
+    std::optional<int> device_num = first_device();
+
+    auto bench = ankerl::nanobench::Bench().title("LockInitialize").unit("init");
+    bench.name("RobustMutex").run([&] {
+        auto m = make_robust();
+        ankerl::nanobench::doNotOptimizeAway(&m);
+    });
+    // FlockMutex removed; kept commented out so the benchmark can be re-enabled easily.
+    // bench.name("FlockMutex").run([&] { auto m = make_flock(); ankerl::nanobench::doNotOptimizeAway(&m); });
+    if (device_num.has_value()) {
+        bench.name("KmdMutex").run([&] {
+            auto m = make_kmd(*device_num);
+            ankerl::nanobench::doNotOptimizeAway(&m);
+        });
+    }
+    tt::umd::test::utils::export_results(bench);
+    std::cout << std::endl;
+}
+
+// Uncontended lock() + unlock() on a single thread.
+TEST(MicrobenchmarkLocks, LockUnlock) {
+    std::optional<int> device_num = first_device();
+
+    auto bench = ankerl::nanobench::Bench().title("LockUnlock").unit("lock+unlock");
+
+    auto robust = make_robust();
+    bench.name("RobustMutex").run([&] {
+        robust.lock();
+        robust.unlock();
+    });
+
+    // FlockMutex removed; kept commented out so the benchmark can be re-enabled easily.
+    // auto flock = make_flock();
+    // bench.name("FlockMutex").run([&] {
+    //     flock.lock();
+    //     flock.unlock();
+    // });
+
+    if (device_num.has_value()) {
+        auto kmd = make_kmd(*device_num);
+        bench.name("KmdMutex").run([&] {
+            kmd.lock();
+            kmd.unlock();
+        });
+    }
+    tt::umd::test::utils::export_results(bench);
+    std::cout << std::endl;
+}
+
+// probe_lock() cost when the lock is already held by another instance (returns "busy", no acquire).
+TEST(MicrobenchmarkLocks, ProbeContended) {
+    std::optional<int> device_num = first_device();
+
+    auto bench = ankerl::nanobench::Bench().title("LockProbeContended").unit("probe");
+
+    {
+        auto holder = make_robust();
+        auto prober = make_robust();
+        holder.lock();
+        bench.name("RobustMutex").run([&] {
+            auto owner = prober.probe_lock();
+            ankerl::nanobench::doNotOptimizeAway(owner);
+        });
+        holder.unlock();
+    }
+    // FlockMutex removed; kept commented out so the benchmark can be re-enabled easily.
+    // {
+    //     auto holder = make_flock();
+    //     auto prober = make_flock();
+    //     holder.lock();
+    //     bench.name("FlockMutex").run([&] {
+    //         auto owner = prober.probe_lock();
+    //         ankerl::nanobench::doNotOptimizeAway(owner);
+    //     });
+    //     holder.unlock();
+    // }
+    if (device_num.has_value()) {
+        auto holder = make_kmd(*device_num);
+        auto prober = make_kmd(*device_num);
+        holder.lock();
+        bench.name("KmdMutex").run([&] {
+            auto owner = prober.probe_lock();
+            ankerl::nanobench::doNotOptimizeAway(owner);
+        });
+        holder.unlock();
+    }
+    tt::umd::test::utils::export_results(bench);
+    std::cout << std::endl;
+}
+
+// Column widths for the LockUnlockThreads table.
+constexpr int BACKEND_COL_W = 15;
+constexpr int THREAD_COL_W = 13;
+
+// Runs the contended benchmark for `backend` across every thread count and prints one table row
+// (ns/op per thread count). Templated so it accepts both plain factory functions and lambdas.
+template <typename MakeFn>
+void print_backend_row(const std::string& backend, MakeFn make) {
+    std::cout << "| " << std::left << std::setw(BACKEND_COL_W) << backend;
+    for (int num_threads : THREAD_COUNTS) {
+        double ns = bench_contended_threads(make, num_threads, CONTENDED_BUDGET);
+        std::cout << " | " << std::right << std::setw(THREAD_COL_W) << std::fixed << std::setprecision(2) << ns;
+    }
+    std::cout << " |" << std::endl;
+}
+
+// Aggregate lock()/unlock() throughput under contention from multiple threads. One row per lock
+// backend, one column per thread count, reporting ns per lock+unlock pair (lower is better).
+TEST(MicrobenchmarkLocks, LockUnlockThreads) {
+    std::optional<int> device_num = first_device();
+
+    std::cout << std::endl << "LockUnlockThreads - contended lock+unlock, ns/op (lower is better):" << std::endl;
+
+    // Header row built from THREAD_COUNTS so it tracks whatever thread counts are configured.
+    std::cout << "| " << std::left << std::setw(BACKEND_COL_W) << "backend";
+    for (int num_threads : THREAD_COUNTS) {
+        std::cout << " | " << std::right << std::setw(THREAD_COL_W) << (std::to_string(num_threads) + " threads");
+    }
+    std::cout << " |" << std::endl;
+
+    // Markdown alignment separator (left-aligned name column, right-aligned numeric columns).
+    std::cout << "|:" << std::string(BACKEND_COL_W, '-');
+    for (size_t i = 0; i < THREAD_COUNTS.size(); ++i) {
+        std::cout << "|" << std::string(THREAD_COL_W + 1, '-') << ":";
+    }
+    std::cout << "|" << std::endl;
+
+    print_backend_row("RobustMutex", make_robust);
+    // FlockMutex removed; kept commented out so the benchmark can be re-enabled easily.
+    // print_backend_row("FlockMutex", make_flock);
+    if (device_num.has_value()) {
+        print_backend_row("KmdMutex", [&] { return make_kmd(*device_num); });
+    }
+    std::cout << std::endl;
+}

--- a/tests/microbenchmark/host_benchmark/test_locks.cpp
+++ b/tests/microbenchmark/host_benchmark/test_locks.cpp
@@ -6,9 +6,6 @@
 //   - RobustMutex     : pthread robust mutex in a /dev/shm file (userspace fast path).
 //   - KmdMutex        : KMD resource lock via ioctl (syscall per op, tied to a silicon device).
 //
-// FlockMutex (flock(2) over a /dev/shm file) was a third backend; its implementation has been
-// removed, but its benchmark wiring is kept commented out below so it can be re-enabled easily.
-//
 // What is measured, per mechanism:
 //   - Initialize        : construct + initialize() + destroy.
 //   - LockUnlock         : uncontended lock() + unlock() on one thread.
@@ -16,7 +13,7 @@
 //   - LockUnlockThreads  : aggregate lock()/unlock() throughput under N contending threads.
 //
 // KmdMutex benchmarks are skipped when no /dev/tenstorrent device is present. They use a high
-// resource-lock index that does not collide with ERISC (0..15) or the device-exclusive convention.
+// resource-lock index, so they do not collide with the locks UMD itself takes.
 
 #include <gtest/gtest.h>
 #include <nanobench.h>
@@ -35,7 +32,6 @@
 
 #include "common/microbenchmark_utils.hpp"
 #include "umd/device/pcie/pci_device.hpp"
-// #include "umd/device/utils/flock_mutex.hpp"  // FlockMutex removed; see note at top of file.
 #include "umd/device/utils/kmd_mutex.hpp"
 #include "umd/device/utils/robust_mutex.hpp"
 
@@ -45,7 +41,6 @@ namespace {
 
 // Names/index used only by these benchmarks, kept distinct from real UMD locks.
 constexpr std::string_view BENCH_ROBUST_NAME = "MICROBENCH_ROBUST";
-// constexpr std::string_view BENCH_FLOCK_NAME = "MICROBENCH_FLOCK";  // FlockMutex removed.
 constexpr uint8_t BENCH_KMD_LOCK_INDEX = 32;
 
 // Thread counts exercised by the contended throughput benchmark.
@@ -70,13 +65,6 @@ RobustMutex make_robust() {
     m.initialize();
     return m;
 }
-
-// FlockMutex removed; factory kept commented out so the benchmark can be re-enabled easily.
-// FlockMutex make_flock() {
-//     FlockMutex m(BENCH_FLOCK_NAME);
-//     m.initialize();
-//     return m;
-// }
 
 KmdMutex make_kmd(int device_num) {
     KmdMutex m(device_num, BENCH_KMD_LOCK_INDEX);
@@ -150,8 +138,6 @@ TEST(MicrobenchmarkLocks, Initialize) {
         auto m = make_robust();
         ankerl::nanobench::doNotOptimizeAway(&m);
     });
-    // FlockMutex removed; kept commented out so the benchmark can be re-enabled easily.
-    // bench.name("FlockMutex").run([&] { auto m = make_flock(); ankerl::nanobench::doNotOptimizeAway(&m); });
     if (device_num.has_value()) {
         bench.name("KmdMutex").run([&] {
             auto m = make_kmd(*device_num);
@@ -173,13 +159,6 @@ TEST(MicrobenchmarkLocks, LockUnlock) {
         robust.lock();
         robust.unlock();
     });
-
-    // FlockMutex removed; kept commented out so the benchmark can be re-enabled easily.
-    // auto flock = make_flock();
-    // bench.name("FlockMutex").run([&] {
-    //     flock.lock();
-    //     flock.unlock();
-    // });
 
     if (device_num.has_value()) {
         auto kmd = make_kmd(*device_num);
@@ -208,17 +187,6 @@ TEST(MicrobenchmarkLocks, ProbeContended) {
         });
         holder.unlock();
     }
-    // FlockMutex removed; kept commented out so the benchmark can be re-enabled easily.
-    // {
-    //     auto holder = make_flock();
-    //     auto prober = make_flock();
-    //     holder.lock();
-    //     bench.name("FlockMutex").run([&] {
-    //         auto owner = prober.probe_lock();
-    //         ankerl::nanobench::doNotOptimizeAway(owner);
-    //     });
-    //     holder.unlock();
-    // }
     if (device_num.has_value()) {
         auto holder = make_kmd(*device_num);
         auto prober = make_kmd(*device_num);
@@ -271,8 +239,6 @@ TEST(MicrobenchmarkLocks, LockUnlockThreads) {
     std::cout << "|" << std::endl;
 
     print_backend_row("RobustMutex", make_robust);
-    // FlockMutex removed; kept commented out so the benchmark can be re-enabled easily.
-    // print_backend_row("FlockMutex", make_flock);
     if (device_num.has_value()) {
         print_backend_row("KmdMutex", [&] { return make_kmd(*device_num); });
     }

--- a/tests/misc/CMakeLists.txt
+++ b/tests/misc/CMakeLists.txt
@@ -2,6 +2,7 @@ set(UMD_MISC_TESTS_SRCS
     test_semver.cpp
     test_errors.cpp
     test_robust_mutex.cpp
+    test_kmd_mutex.cpp
     test_op_timeout_guard.cpp
 )
 

--- a/tests/misc/test_kmd_mutex.cpp
+++ b/tests/misc/test_kmd_mutex.cpp
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <vector>
+
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/utils/kmd_mutex.hpp"
+
+using namespace tt::umd;
+
+// A KMD resource lock is held by the file descriptor that took it, which makes it fair to ask whether
+// threads of one process exclude each other at all. They do, and these tests pin that down, because
+// UMD hands one mutex object to every thread that needs a given lock. What arbitrates is a device wide
+// bit, not the handle: an acquire fails while the lock is held, no matter who asks.
+
+namespace {
+
+// Test-only index, kept away from the ones UMD takes on a real device.
+constexpr uint8_t TEST_KMD_LOCK_INDEX = 33;
+
+std::optional<int> first_device() {
+    std::vector<int> devices = PCIDevice::enumerate_devices();
+    if (devices.empty()) {
+        return std::nullopt;
+    }
+    return devices.front();
+}
+
+}  // namespace
+
+// Taking the lock twice from the same handle must fail the second time. This is what makes threads of
+// one process exclude each other, since they share the handle.
+TEST(TestKmdMutex, SameHandleCannotAcquireTwice) {
+    std::optional<int> device_num = first_device();
+    if (!device_num.has_value()) {
+        GTEST_SKIP() << "No /dev/tenstorrent device present";
+    }
+
+    KmdMutex mutex(*device_num, TEST_KMD_LOCK_INDEX);
+    mutex.initialize();
+
+    ASSERT_TRUE(mutex.try_lock());
+    EXPECT_FALSE(mutex.try_lock()) << "The handle holding the lock acquired it a second time";
+    mutex.unlock();
+}
+
+// A second handle over the same lock is what two processes look like to KMD.
+TEST(TestKmdMutex, SecondHandleCannotAcquireWhileHeld) {
+    std::optional<int> device_num = first_device();
+    if (!device_num.has_value()) {
+        GTEST_SKIP() << "No /dev/tenstorrent device present";
+    }
+
+    KmdMutex holder(*device_num, TEST_KMD_LOCK_INDEX);
+    holder.initialize();
+    KmdMutex contender(*device_num, TEST_KMD_LOCK_INDEX);
+    contender.initialize();
+
+    {
+        std::lock_guard<KmdMutex> lock(holder);
+        EXPECT_FALSE(contender.try_lock()) << "A second handle acquired a lock that was already held";
+        EXPECT_TRUE(contender.is_locked_by_anyone());
+    }
+
+    EXPECT_TRUE(contender.try_lock()) << "Lock was not released";
+    contender.unlock();
+}
+
+// Same again, with the second handle opened and used from another thread, since that is how UMD meets
+// this lock: threads that never share a mutex object still have to serialize.
+TEST(TestKmdMutex, HandleInAnotherThreadCannotAcquireWhileHeld) {
+    std::optional<int> device_num = first_device();
+    if (!device_num.has_value()) {
+        GTEST_SKIP() << "No /dev/tenstorrent device present";
+    }
+
+    KmdMutex holder(*device_num, TEST_KMD_LOCK_INDEX);
+    holder.initialize();
+
+    // Opening the handle in the thread as well, so nothing about it is shared with the holder.
+    auto try_acquire_in_thread = [&]() {
+        bool acquired = false;
+        std::thread thread([&]() {
+            KmdMutex contender(*device_num, TEST_KMD_LOCK_INDEX);
+            contender.initialize();
+            acquired = contender.try_lock();
+            if (acquired) {
+                contender.unlock();
+            }
+        });
+        thread.join();
+        return acquired;
+    };
+
+    {
+        std::lock_guard<KmdMutex> lock(holder);
+        EXPECT_FALSE(try_acquire_in_thread()) << "Another thread acquired a lock this one was holding";
+    }
+
+    EXPECT_TRUE(try_acquire_in_thread()) << "Lock was not released";
+}

--- a/tt-kmd-lib/api/tt-kmd-lib/tt_kmd_lib.h
+++ b/tt-kmd-lib/api/tt-kmd-lib/tt_kmd_lib.h
@@ -620,6 +620,64 @@ int tt_device_set_power_state(tt_device_t* dev, uint16_t power_flags);
  */
 int tt_device_reset(tt_device_t* dev, uint32_t reset_flags);
 
+/**
+ * @brief Number of independent resource locks a device exposes.
+ *
+ * Valid lock indices are [0, TT_RESOURCE_LOCK_COUNT). Indices 0..15 are reserved
+ * by convention for ERISC cores; use higher indices for other coordination.
+ */
+#define TT_RESOURCE_LOCK_COUNT 64
+
+/**
+ * @brief State bits reported by `tt_lock_test()`.
+ */
+enum tt_lock_state {
+    TT_LOCK_STATE_HELD_BY_SELF = (1U << 0), /**< Held by this device handle */
+    TT_LOCK_STATE_HELD_BY_ANY = (1U << 1),  /**< Held by some handle, possibly this one */
+};
+
+/**
+ * @brief Attempts to acquire a device resource lock without blocking.
+ *
+ * A resource lock is a cross-process lock that lives in the driver, keyed by device and index. Any
+ * process that can open the device's chardev contends over the same lock, with no shared host
+ * filesystem required. The lock is owned by the device handle that acquired it, and the driver
+ * releases every lock a handle holds when it is closed, so a crashed holder cannot leak it.
+ *
+ * The driver offers no timed acquire; build a bounded or blocking wait by polling this call.
+ *
+ * @param dev Device handle
+ * @param index Lock index in [0, TT_RESOURCE_LOCK_COUNT)
+ * @param out_acquired 1 if `dev` now holds the lock, 0 if another handle holds it
+ * @return 0 on success, negative error code on failure. -ENODEV if a device reset invalidated the
+ *         handle, in which case the caller must reopen the device to retry.
+ */
+int tt_lock_acquire(tt_device_t* dev, uint8_t index, int* out_acquired);
+
+/**
+ * @brief Releases a device resource lock.
+ *
+ * @param dev Device handle
+ * @param index Lock index in [0, TT_RESOURCE_LOCK_COUNT)
+ * @param out_was_held 1 if `dev` held the lock, 0 if it did not (e.g. a double release). May be NULL.
+ * @return 0 on success, negative error code on failure. On -ENODEV the lock remains held until the
+ *         device handle is closed.
+ */
+int tt_lock_release(tt_device_t* dev, uint8_t index, int* out_was_held);
+
+/**
+ * @brief Queries whether a device resource lock is held.
+ *
+ * Inherently racy - another handle may acquire or release the lock before the result is used - so
+ * this is intended for diagnostics.
+ *
+ * @param dev Device handle
+ * @param index Lock index in [0, TT_RESOURCE_LOCK_COUNT)
+ * @param out_state Bitmask of `enum tt_lock_state`
+ * @return 0 on success, negative error code on failure
+ */
+int tt_lock_test(tt_device_t* dev, uint8_t index, uint32_t* out_state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tt-kmd-lib/src/tt_kmd_lib.c
+++ b/tt-kmd-lib/src/tt_kmd_lib.c
@@ -741,3 +741,71 @@ int tt_device_reset(tt_device_t* dev, uint32_t reset_flags) {
 
     return tt_device_close(dev);
 }
+
+/* All three lock operations issue the same ioctl, differing only in the flag they pass and in how
+ * they interpret out.value. */
+static int lock_ctl(tt_device_t* dev, uint8_t index, uint32_t flags, uint8_t* out_value) {
+    if (dev == NULL || index >= TT_RESOURCE_LOCK_COUNT) {
+        return -EINVAL;
+    }
+
+    struct tenstorrent_lock_ctl ctl = {0};
+    ctl.in.output_size_bytes = sizeof(ctl.out);
+    ctl.in.flags = flags;
+    ctl.in.index = index;
+
+    if (ioctl(dev->fd, TENSTORRENT_IOCTL_LOCK_CTL, &ctl) != 0) {
+        return -errno;
+    }
+
+    *out_value = ctl.out.value;
+
+    return 0;
+}
+
+int tt_lock_acquire(tt_device_t* dev, uint8_t index, int* out_acquired) {
+    if (out_acquired == NULL) {
+        return -EINVAL;
+    }
+
+    uint8_t value = 0;
+    int result = lock_ctl(dev, index, TENSTORRENT_LOCK_CTL_ACQUIRE, &value);
+    if (result != 0) {
+        return result;
+    }
+
+    *out_acquired = (value == 1);
+
+    return 0;
+}
+
+int tt_lock_release(tt_device_t* dev, uint8_t index, int* out_was_held) {
+    uint8_t value = 0;
+    int result = lock_ctl(dev, index, TENSTORRENT_LOCK_CTL_RELEASE, &value);
+    if (result != 0) {
+        return result;
+    }
+
+    if (out_was_held != NULL) {
+        *out_was_held = (value == 1);
+    }
+
+    return 0;
+}
+
+int tt_lock_test(tt_device_t* dev, uint8_t index, uint32_t* out_state) {
+    if (out_state == NULL) {
+        return -EINVAL;
+    }
+
+    uint8_t value = 0;
+    int result = lock_ctl(dev, index, TENSTORRENT_LOCK_CTL_TEST, &value);
+    if (result != 0) {
+        return result;
+    }
+
+    /* The driver's value bits are laid out exactly as enum tt_lock_state. */
+    *out_state = value;
+
+    return 0;
+}


### PR DESCRIPTION
### Issue
#2745 

### Description
Perf analysis can be found here: https://tenstorrent.atlassian.net/wiki/spaces/UMD/pages/2564948067/Locks+perf+analysis
We are diverging away from requiring /dev/shm as it doesn't scale well on all environments, so we want to stop using RobustMutex on the main path.

This PR introduces KMDMutex class, and adds relevant tests which output some perf of locks

### List of the changes
- Introduce KMDMutex
- Add missing entry points to tt_kmd_lib
- Add test for different lock types. Note this includes FLock based mutex which I tested but don't want to commit the implementation to our codebase.

### Testing
This PR includes perf tests. For functional test, CI test in this tip of the stack: https://github.com/tenstorrent/tt-umd/pull/3233

### API Changes
This PR has API changes, introduces KMDMutex
