### PR TITLE
[base API] FirmwareTelemetryReader header + stateless NOC

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -185,6 +185,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/arch/architecture_implementation.hpp
                 api/umd/device/arc/arc_messenger.hpp
                 api/umd/device/arc/arc_telemetry_reader.hpp
+                api/umd/device/arc/firmware_telemetry_reader.hpp
                 api/umd/device/arc/blackhole_arc_message_queue.hpp
                 api/umd/device/arc/blackhole_arc_messenger.hpp
                 api/umd/device/arc/smbus_arc_telemetry_reader.hpp

--- a/device/api/umd/device/arc/arc_telemetry_reader.hpp
+++ b/device/api/umd/device/arc/arc_telemetry_reader.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <unordered_set>
 
+#include "firmware_telemetry_reader.hpp"
 #include "umd/device/types/telemetry.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/timeouts.hpp"
@@ -17,13 +18,11 @@
 namespace tt::umd {
 class TTDevice;
 
-class ArcTelemetryReader {
+class ArcTelemetryReader : public FirmwareTelemetryReader {
 public:
-    virtual ~ArcTelemetryReader() = default;
+    uint32_t read_entry(const uint8_t telemetry_tag, [[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) override;
 
-    virtual uint32_t read_entry(const uint8_t telemetry_tag);
-
-    virtual bool is_entry_available(const uint8_t telemetry_tag);
+    bool is_entry_available(const uint8_t telemetry_tag, [[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) override;
 
     // Constructs the reader and waits for the ARC telemetry table to be fully populated.
     static std::unique_ptr<ArcTelemetryReader> create_arc_telemetry_reader(

--- a/device/api/umd/device/arc/firmware_telemetry_reader.hpp
+++ b/device/api/umd/device/arc/firmware_telemetry_reader.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "umd/device/types/noc_id.hpp"
+
+namespace tt::umd {
+/**
+ * @brief Raw telemetry reader interface.
+ */
+class FirmwareTelemetryReader {
+public:
+    virtual ~FirmwareTelemetryReader() = default;
+
+    /**
+     * @brief Reads a telemetry entry by tag.
+     * @param tag Telemetry tag identifying the entry to read.
+     * @return uint32_t The telemetry value.
+     */
+    virtual uint32_t read_entry(uint8_t tag, [[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) = 0;
+
+    /**
+     * @brief Checks whether a telemetry entry is available.
+     * @param tag Telemetry tag identifying the entry to check.
+     * @param noc_id NOC to route through.
+     * @return true if the entry exists in the firmware telemetry table.
+     */
+    virtual bool is_entry_available(uint8_t tag, [[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) = 0;
+};
+}  // namespace tt::umd

--- a/device/api/umd/device/arc/smbus_arc_telemetry_reader.hpp
+++ b/device/api/umd/device/arc/smbus_arc_telemetry_reader.hpp
@@ -20,9 +20,9 @@ class SmBusArcTelemetryReader : public ArcTelemetryReader {
 public:
     SmBusArcTelemetryReader(TTDevice* tt_device);
 
-    uint32_t read_entry(const uint8_t telemetry_tag) override;
+    uint32_t read_entry(const uint8_t telemetry_tag, [[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) override;
 
-    bool is_entry_available(const uint8_t telemetry_tag) override;
+    bool is_entry_available(const uint8_t telemetry_tag, [[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) override;
 
 protected:
     // Polls LegacyTelemetryTag::FW_BUNDLE_VERSION (the last entry written to the SMBus

--- a/device/arc/arc_telemetry_reader.cpp
+++ b/device/arc/arc_telemetry_reader.cpp
@@ -53,7 +53,6 @@ std::unique_ptr<ArcTelemetryReader> ArcTelemetryReader::create_arc_telemetry_rea
         default:
             UMD_THROW(error::RuntimeError, "Unsupported architecture for creating ArcTelemetryReader.");
     }
-    reader->wait_for_telemetry_initialized(timeout_ms);
     return reader;
 }
 
@@ -93,7 +92,7 @@ void ArcTelemetryReader::initialize_telemetry() {
 }
 
 uint32_t ArcTelemetryReader::read_entry(const uint8_t telemetry_tag, NocId noc_id) {
-    if (!is_entry_available(telemetry_tag)) {
+    if (!is_entry_available(telemetry_tag, noc_id)) {
         UMD_THROW(
             error::RuntimeError,
             fmt::format(

--- a/device/arc/arc_telemetry_reader.cpp
+++ b/device/arc/arc_telemetry_reader.cpp
@@ -92,7 +92,7 @@ void ArcTelemetryReader::initialize_telemetry() {
     }
 }
 
-uint32_t ArcTelemetryReader::read_entry(const uint8_t telemetry_tag) {
+uint32_t ArcTelemetryReader::read_entry(const uint8_t telemetry_tag, NocId noc_id) {
     if (!is_entry_available(telemetry_tag)) {
         UMD_THROW(
             error::RuntimeError,
@@ -119,7 +119,7 @@ uint32_t ArcTelemetryReader::read_entry(const uint8_t telemetry_tag) {
     return telemetry_values[telemetry_tag];
 }
 
-bool ArcTelemetryReader::is_entry_available(const uint8_t telemetry_tag) {
+bool ArcTelemetryReader::is_entry_available(const uint8_t telemetry_tag, NocId noc_id) {
     return telemetry_values.find(telemetry_tag) != telemetry_values.end();
 }
 

--- a/device/arc/smbus_arc_telemetry_reader.cpp
+++ b/device/arc/smbus_arc_telemetry_reader.cpp
@@ -43,7 +43,7 @@ void SmBusArcTelemetryReader::get_telemetry_address() {
 }
 
 uint32_t SmBusArcTelemetryReader::read_entry(const uint8_t telemetry_tag, NocId noc_id) {
-    if (!is_entry_available(telemetry_tag)) {
+    if (!is_entry_available(telemetry_tag, noc_id)) {
         UMD_THROW(
             error::RuntimeError,
             fmt::format(

--- a/device/arc/smbus_arc_telemetry_reader.cpp
+++ b/device/arc/smbus_arc_telemetry_reader.cpp
@@ -15,6 +15,7 @@
 #include "tt-logger/tt-logger.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/wormhole_telemetry.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error.hpp"
@@ -41,7 +42,7 @@ void SmBusArcTelemetryReader::get_telemetry_address() {
     telemetry_base_noc_addr = arc_msg_return_values[0] + noc_telemetry_offset;
 }
 
-uint32_t SmBusArcTelemetryReader::read_entry(const uint8_t telemetry_tag) {
+uint32_t SmBusArcTelemetryReader::read_entry(const uint8_t telemetry_tag, NocId noc_id) {
     if (!is_entry_available(telemetry_tag)) {
         UMD_THROW(
             error::RuntimeError,
@@ -62,7 +63,7 @@ uint32_t SmBusArcTelemetryReader::read_entry(const uint8_t telemetry_tag) {
     return telemetry_value;
 }
 
-bool SmBusArcTelemetryReader::is_entry_available(const uint8_t telemetry_tag) {
+bool SmBusArcTelemetryReader::is_entry_available(const uint8_t telemetry_tag, NocId noc_id) {
     return telemetry_tag >= 0 && telemetry_tag < wormhole::LegacyTelemetryTag::NUMBER_OF_TAGS;
 }
 

--- a/nanobind/py_api_telemetry.cpp
+++ b/nanobind/py_api_telemetry.cpp
@@ -15,6 +15,7 @@
 #include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/firmware/firmware_utils.hpp"
 #include "umd/device/types/gddr_telemetry.hpp"
+#include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/telemetry.hpp"
 #include "umd/device/types/wormhole_telemetry.hpp"
 
@@ -189,17 +190,33 @@ void bind_telemetry(nb::module_& m) {
         });
 
     nb::class_<ArcTelemetryReader>(m, "ArcTelemetryReader")
-        .def("read_entry", &ArcTelemetryReader::read_entry, nb::arg("telemetry_tag"), release_gil())
-        .def("is_entry_available", &ArcTelemetryReader::is_entry_available, nb::arg("telemetry_tag"), release_gil());
+        .def(
+            "read_entry",
+            &ArcTelemetryReader::read_entry,
+            nb::arg("telemetry_tag"),
+            nb::arg("noc_id") = NocId::DEFAULT_NOC,
+            release_gil())
+        .def(
+            "is_entry_available",
+            &ArcTelemetryReader::is_entry_available,
+            nb::arg("telemetry_tag"),
+            nb::arg("noc_id") = NocId::DEFAULT_NOC,
+            release_gil());
 
     // SmBusArcTelemetryReader binding - for direct instantiation when SMBUS telemetry is needed.
     nb::class_<SmBusArcTelemetryReader, ArcTelemetryReader>(m, "SmBusArcTelemetryReader")
         .def(nb::init<TTDevice*>(), nb::arg("tt_device"), release_gil())
-        .def("read_entry", &SmBusArcTelemetryReader::read_entry, nb::arg("telemetry_tag"), release_gil())
+        .def(
+            "read_entry",
+            &SmBusArcTelemetryReader::read_entry,
+            nb::arg("telemetry_tag"),
+            nb::arg("noc_id") = NocId::DEFAULT_NOC,
+            release_gil())
         .def(
             "is_entry_available",
             &SmBusArcTelemetryReader::is_entry_available,
             nb::arg("telemetry_tag"),
+            nb::arg("noc_id") = NocId::DEFAULT_NOC,
             release_gil());
 
     nb::enum_<tt::DramTrainingStatus>(m, "DramTrainingStatus")


### PR DESCRIPTION
### Issue
#2878 

### Description
Initial work on porting ArcTelemetryReader to the base API spec. Added the interface header file, stateless NOC arguments (no implementation) and implemented the FirmwareTelemetryReader interface in ArcTelemetryReader.

### List of the changes
- Add `firmware_telemetry_reader.hpp` base API interface file.
- Implement the interface in ArcTelemetryReader.
- Add interface only stateless NOC arguments.

### Testing
CI

### API Changes
This PR has API changes.
