### PR TITLE
Remove unused methods from architecture_implementation

### DIFF
--- a/device/api/umd/device/arch/architecture_implementation.hpp
+++ b/device/api/umd/device/arch/architecture_implementation.hpp
@@ -9,7 +9,6 @@
 #include <iterator>
 #include <memory>
 #include <optional>
-#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -40,45 +39,27 @@ public:
     virtual uint32_t get_arc_message_deassert_riscv_reset() const = 0;
     virtual uint32_t get_arc_message_get_aiclk() const = 0;
     virtual uint32_t get_arc_message_setup_iatu_for_peer_to_peer() const = 0;
-    virtual uint32_t get_arc_message_test() const = 0;
     virtual uint32_t get_arc_csm_bar0_mailbox_offset() const = 0;
     virtual uint32_t get_arc_axi_apb_peripheral_offset() const = 0;
-    virtual uint32_t get_arc_reset_arc_misc_cntl_offset() const = 0;
     virtual uint32_t get_arc_reset_scratch_offset() const = 0;
     virtual uint32_t get_arc_reset_scratch_2_offset() const = 0;
     virtual uint32_t get_arc_reset_unit_refclk_low_offset() const = 0;
     virtual uint32_t get_arc_reset_unit_refclk_high_offset() const = 0;
-    virtual uint32_t get_dram_channel_0_peer2peer_region_start() const = 0;
-    virtual uint32_t get_dram_channel_0_x() const = 0;
-    virtual uint32_t get_dram_channel_0_y() const = 0;
     virtual uint32_t get_dram_banks_number() const = 0;
     virtual uint32_t get_aiclk_busy_val() const = 0;
-    virtual uint32_t get_broadcast_tlb_index() const = 0;
-    virtual uint32_t get_dynamic_tlb_2m_base() const = 0;
-    virtual uint32_t get_dynamic_tlb_2m_size() const = 0;
-    virtual uint32_t get_dynamic_tlb_16m_base() const = 0;
-    virtual uint32_t get_dynamic_tlb_16m_size() const = 0;
-    virtual uint32_t get_dynamic_tlb_16m_cfg_addr() const = 0;
-    virtual uint32_t get_mem_large_read_tlb() const = 0;
-    virtual uint32_t get_mem_large_write_tlb() const = 0;
     virtual uint32_t get_num_eth_channels() const = 0;
     virtual uint32_t get_read_checking_offset() const = 0;
-    virtual uint32_t get_reg_tlb() const = 0;
-    virtual uint32_t get_tlb_base_index_16m() const = 0;
     virtual uint32_t get_tensix_soft_reset_addr() const = 0;
     virtual uint32_t get_debug_reg_addr() const = 0;
     virtual uint32_t get_soft_reset_reg_value(RiscType risc_type) const = 0;
     virtual RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const = 0;
     virtual uint32_t get_soft_reset_staggered_start() const = 0;
-    virtual uint32_t get_grid_size_x() const = 0;
-    virtual uint32_t get_grid_size_y() const = 0;
     virtual uint64_t get_arc_apb_noc_base_address() const = 0;
     virtual uint64_t get_arc_csm_noc_base_address() const = 0;
     // Replace with std::span once we enable C++20.
     virtual const std::vector<uint32_t>& get_harvesting_noc_locations() const = 0;
     virtual const std::vector<uint32_t>& get_t6_x_locations() const = 0;
     virtual const std::vector<uint32_t>& get_t6_y_locations() const = 0;
-    virtual const std::vector<std::vector<tt_xy_pair>>& get_dram_cores_noc0() const = 0;
 
     // TLB related. Move other functions here as well.
     virtual std::pair<uint32_t, uint32_t> get_tlb_1m_base_and_count() const = 0;
@@ -89,7 +70,6 @@ public:
     // Get available TLB sizes for this architecture.
     virtual const std::vector<size_t>& get_tlb_sizes() const = 0;
 
-    virtual std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const = 0;
     virtual tlb_configuration get_tlb_configuration(uint32_t tlb_index) const = 0;
     virtual uint64_t get_tlb_cfg_reg_size_bytes() const = 0;
     virtual uint32_t get_static_tlb_cfg_addr() const = 0;

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -359,15 +359,11 @@ public:
         return static_cast<uint32_t>(blackhole::arc_message_type::SETUP_IATU_FOR_PEER_TO_PEER);
     }
 
-    uint32_t get_arc_message_test() const override { return static_cast<uint32_t>(blackhole::arc_message_type::TEST); }
-
     uint32_t get_arc_csm_bar0_mailbox_offset() const override {
         UMD_THROW(error::RuntimeError, "Not implemented for Blackhole architecture.");
     }
 
     uint32_t get_arc_axi_apb_peripheral_offset() const override { return blackhole::ARC_APB_BAR0_XBAR_OFFSET_START; }
-
-    uint32_t get_arc_reset_arc_misc_cntl_offset() const override { return blackhole::ARC_RESET_ARC_MISC_CNTL_OFFSET; }
 
     uint32_t get_arc_reset_scratch_offset() const override { return blackhole::ARC_RESET_SCRATCH_OFFSET; }
 
@@ -377,50 +373,14 @@ public:
 
     uint32_t get_arc_reset_unit_refclk_high_offset() const override { return blackhole::ARC_RESET_REFCLK_HIGH_OFFSET; }
 
-    uint32_t get_dram_channel_0_peer2peer_region_start() const override {
-        return blackhole::DRAM_CHANNEL_0_PEER2PEER_REGION_START;
-    }
-
-    uint32_t get_dram_channel_0_x() const override { return blackhole::DRAM_CHANNEL_0_X; }
-
-    uint32_t get_dram_channel_0_y() const override { return blackhole::DRAM_CHANNEL_0_Y; }
-
     uint32_t get_dram_banks_number() const override { return blackhole::NUM_DRAM_BANKS; }
 
     uint32_t get_aiclk_busy_val() const override { return blackhole::AICLK_BUSY_VAL; }
-
-    uint32_t get_broadcast_tlb_index() const override { return blackhole::BROADCAST_TLB_INDEX; }
-
-    uint32_t get_dynamic_tlb_2m_base() const override { return blackhole::DYNAMIC_TLB_2M_BASE; }
-
-    uint32_t get_dynamic_tlb_2m_size() const override { return blackhole::DYNAMIC_TLB_2M_SIZE; }
-
-    uint32_t get_dynamic_tlb_16m_base() const override {
-        UMD_THROW(error::RuntimeError, "No 16MB TLB size in Blackhole architecture.");
-    }
-
-    uint32_t get_dynamic_tlb_16m_size() const override {
-        UMD_THROW(error::RuntimeError, "No 16MB TLB size in Blackhole architecture.");
-    }
-
-    uint32_t get_dynamic_tlb_16m_cfg_addr() const override {
-        UMD_THROW(error::RuntimeError, "No 16MB TLB size in Blackhole architecture.");
-    }
-
-    uint32_t get_mem_large_read_tlb() const override { return blackhole::MEM_LARGE_READ_TLB; }
-
-    uint32_t get_mem_large_write_tlb() const override { return blackhole::MEM_LARGE_WRITE_TLB; }
 
     uint32_t get_num_eth_channels() const override { return blackhole::NUM_ETH_CHANNELS; }
 
     uint32_t get_read_checking_offset() const override {
         return blackhole::NIU_CFG_NOC0_BAR_PCIE_ADDR + blackhole::NOC_NODE_ID_OFFSET;
-    }
-
-    uint32_t get_reg_tlb() const override { return blackhole::REG_TLB; }
-
-    uint32_t get_tlb_base_index_16m() const override {
-        UMD_THROW(error::RuntimeError, "No 16MB TLB size in Blackhole architecture.");
     }
 
     uint32_t get_tensix_soft_reset_addr() const override { return blackhole::TENSIX_SOFT_RESET_ADDR; }
@@ -432,10 +392,6 @@ public:
     RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const override;
 
     uint32_t get_soft_reset_staggered_start() const override { return blackhole::SOFT_RESET_STAGGERED_START; }
-
-    uint32_t get_grid_size_x() const override { return blackhole::GRID_SIZE_X; }
-
-    uint32_t get_grid_size_y() const override { return blackhole::GRID_SIZE_Y; }
 
     uint64_t get_arc_apb_noc_base_address() const override { return blackhole::ARC_NOC_XBAR_ADDRESS_START; }
 
@@ -450,10 +406,6 @@ public:
     const std::vector<uint32_t>& get_t6_x_locations() const override { return blackhole::T6_X_LOCATIONS; }
 
     const std::vector<uint32_t>& get_t6_y_locations() const override { return blackhole::T6_Y_LOCATIONS; }
-
-    const std::vector<std::vector<tt_xy_pair>>& get_dram_cores_noc0() const override {
-        return blackhole::DRAM_CORES_NOC0;
-    };
 
     std::pair<uint32_t, uint32_t> get_tlb_1m_base_and_count() const override { return {0, 0}; }
 
@@ -474,7 +426,6 @@ public:
         return tlb_sizes;
     }
 
-    std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const override;
     tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
 
     uint64_t get_tlb_cfg_reg_size_bytes() const override { return 12; }

--- a/device/api/umd/device/arch/grendel_implementation.hpp
+++ b/device/api/umd/device/arch/grendel_implementation.hpp
@@ -350,15 +350,11 @@ public:
         return static_cast<uint32_t>(grendel::arc_message_type::SETUP_IATU_FOR_PEER_TO_PEER);
     }
 
-    uint32_t get_arc_message_test() const override { return static_cast<uint32_t>(grendel::arc_message_type::TEST); }
-
     uint32_t get_arc_csm_bar0_mailbox_offset() const override {
         UMD_THROW(error::RuntimeError, "Not implemented for Grendel architecture.");
     }
 
     uint32_t get_arc_axi_apb_peripheral_offset() const override { return grendel::ARC_APB_BAR0_XBAR_OFFSET_START; }
-
-    uint32_t get_arc_reset_arc_misc_cntl_offset() const override { return grendel::ARC_RESET_ARC_MISC_CNTL_OFFSET; }
 
     uint32_t get_arc_reset_scratch_offset() const override { return grendel::ARC_RESET_SCRATCH_OFFSET; }
 
@@ -368,49 +364,13 @@ public:
 
     uint32_t get_arc_reset_unit_refclk_high_offset() const override { return grendel::ARC_RESET_REFCLK_HIGH_OFFSET; }
 
-    uint32_t get_dram_channel_0_peer2peer_region_start() const override {
-        return grendel::DRAM_CHANNEL_0_PEER2PEER_REGION_START;
-    }
-
-    uint32_t get_dram_channel_0_x() const override { return grendel::DRAM_CHANNEL_0_X; }
-
-    uint32_t get_dram_channel_0_y() const override { return grendel::DRAM_CHANNEL_0_Y; }
-
     uint32_t get_dram_banks_number() const override { return grendel::NUM_DRAM_BANKS; }
 
     uint32_t get_aiclk_busy_val() const override { return grendel::AICLK_BUSY_VAL; }
 
-    uint32_t get_broadcast_tlb_index() const override { return grendel::BROADCAST_TLB_INDEX; }
-
-    uint32_t get_dynamic_tlb_2m_base() const override { return grendel::DYNAMIC_TLB_2M_BASE; }
-
-    uint32_t get_dynamic_tlb_2m_size() const override { return grendel::DYNAMIC_TLB_2M_SIZE; }
-
-    uint32_t get_dynamic_tlb_16m_base() const override {
-        UMD_THROW(error::RuntimeError, "No 16MB TLB size in Grendel architecture.");
-    }
-
-    uint32_t get_dynamic_tlb_16m_size() const override {
-        UMD_THROW(error::RuntimeError, "No 16MB TLB size in Grendel architecture.");
-    }
-
-    uint32_t get_dynamic_tlb_16m_cfg_addr() const override {
-        UMD_THROW(error::RuntimeError, "No 16MB TLB size in Grendel architecture.");
-    }
-
-    uint32_t get_mem_large_read_tlb() const override { return grendel::MEM_LARGE_READ_TLB; }
-
-    uint32_t get_mem_large_write_tlb() const override { return grendel::MEM_LARGE_WRITE_TLB; }
-
     uint32_t get_num_eth_channels() const override { return grendel::NUM_ETH_CHANNELS; }
 
     uint32_t get_read_checking_offset() const override { return grendel::BH_NOC_NODE_ID_OFFSET; }
-
-    uint32_t get_reg_tlb() const override { return grendel::REG_TLB; }
-
-    uint32_t get_tlb_base_index_16m() const override {
-        UMD_THROW(error::RuntimeError, "No 16MB TLB size in Grendel architecture.");
-    }
 
     uint32_t get_tensix_soft_reset_addr() const override { return grendel::TENSIX_SOFT_RESET_ADDR; }
 
@@ -423,10 +383,6 @@ public:
     uint32_t get_soft_reset_staggered_start() const override {
         return 0;
     }  // grendel does not support staggered start ??
-
-    uint32_t get_grid_size_x() const override { return grendel::GRID_SIZE_X; }
-
-    uint32_t get_grid_size_y() const override { return grendel::GRID_SIZE_Y; }
 
     uint64_t get_arc_apb_noc_base_address() const override { return grendel::ARC_NOC_XBAR_ADDRESS_START; }
 
@@ -441,10 +397,6 @@ public:
     const std::vector<uint32_t>& get_t6_x_locations() const override { return grendel::T6_X_LOCATIONS; }
 
     const std::vector<uint32_t>& get_t6_y_locations() const override { return grendel::T6_Y_LOCATIONS; }
-
-    const std::vector<std::vector<tt_xy_pair>>& get_dram_cores_noc0() const override {
-        return grendel::DRAM_CORES_NOC0;
-    };
 
     std::pair<uint32_t, uint32_t> get_tlb_1m_base_and_count() const override { return {0, 0}; }
 
@@ -465,7 +417,6 @@ public:
         return tlb_sizes;
     }
 
-    std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const override;
     tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
 
     uint64_t get_tlb_cfg_reg_size_bytes() const override { return 12; }

--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -406,15 +406,11 @@ public:
         return static_cast<uint32_t>(wormhole::arc_message_type::SETUP_IATU_FOR_PEER_TO_PEER);
     }
 
-    uint32_t get_arc_message_test() const override { return static_cast<uint32_t>(wormhole::arc_message_type::TEST); }
-
     uint32_t get_arc_csm_bar0_mailbox_offset() const override {
         return wormhole::ARC_CSM_BAR0_XBAR_OFFSET_START + wormhole::ARC_CSM_MAILBOX_OFFSET;
     }
 
     uint32_t get_arc_axi_apb_peripheral_offset() const override { return wormhole::ARC_APB_BAR0_XBAR_OFFSET_START; }
-
-    uint32_t get_arc_reset_arc_misc_cntl_offset() const override { return wormhole::ARC_RESET_ARC_MISC_CNTL_OFFSET; }
 
     uint32_t get_arc_reset_scratch_offset() const override { return wormhole::ARC_RESET_SCRATCH_OFFSET; }
 
@@ -424,43 +420,15 @@ public:
 
     uint32_t get_arc_reset_unit_refclk_high_offset() const override { return wormhole::ARC_RESET_REFCLK_HIGH_OFFSET; }
 
-    uint32_t get_dram_channel_0_peer2peer_region_start() const override {
-        return wormhole::DRAM_CHANNEL_0_PEER2PEER_REGION_START;
-    }
-
-    uint32_t get_dram_channel_0_x() const override { return wormhole::DRAM_CHANNEL_0_X; }
-
-    uint32_t get_dram_channel_0_y() const override { return wormhole::DRAM_CHANNEL_0_Y; }
-
     uint32_t get_dram_banks_number() const override { return wormhole::NUM_DRAM_BANKS; }
 
     uint32_t get_aiclk_busy_val() const override { return wormhole::AICLK_BUSY_VAL; }
-
-    uint32_t get_broadcast_tlb_index() const override { return wormhole::BROADCAST_TLB_INDEX; }
-
-    uint32_t get_dynamic_tlb_2m_base() const override { return wormhole::DYNAMIC_TLB_2M_BASE; }
-
-    uint32_t get_dynamic_tlb_2m_size() const override { return wormhole::DYNAMIC_TLB_2M_SIZE; }
-
-    uint32_t get_dynamic_tlb_16m_base() const override { return wormhole::DYNAMIC_TLB_16M_BASE; }
-
-    uint32_t get_dynamic_tlb_16m_size() const override { return wormhole::DYNAMIC_TLB_16M_SIZE; }
-
-    uint32_t get_dynamic_tlb_16m_cfg_addr() const override { return wormhole::DYNAMIC_TLB_16M_CFG_ADDR; }
-
-    uint32_t get_mem_large_read_tlb() const override { return wormhole::MEM_LARGE_READ_TLB; }
-
-    uint32_t get_mem_large_write_tlb() const override { return wormhole::MEM_LARGE_WRITE_TLB; }
 
     uint32_t get_num_eth_channels() const override { return wormhole::NUM_ETH_CHANNELS; }
 
     uint32_t get_read_checking_offset() const override {
         return wormhole::NIU_CFG_NOC0_BAR_ARC_ADDR + wormhole::NOC_NODE_ID_OFFSET;
     }
-
-    uint32_t get_reg_tlb() const override { return wormhole::REG_TLB; }
-
-    uint32_t get_tlb_base_index_16m() const override { return wormhole::TLB_BASE_INDEX_16M; }
 
     uint32_t get_tensix_soft_reset_addr() const override { return wormhole::TENSIX_SOFT_RESET_ADDR; }
 
@@ -471,10 +439,6 @@ public:
     RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const override;
 
     uint32_t get_soft_reset_staggered_start() const override { return wormhole::SOFT_RESET_STAGGERED_START; }
-
-    uint32_t get_grid_size_x() const override { return wormhole::GRID_SIZE_X; }
-
-    uint32_t get_grid_size_y() const override { return wormhole::GRID_SIZE_Y; }
 
     uint64_t get_arc_apb_noc_base_address() const override {
         return wormhole::ARC_NOC_ADDRESS_START + wormhole::ARC_APB_NOC_XBAR_OFFSET_START;
@@ -491,10 +455,6 @@ public:
     const std::vector<uint32_t>& get_t6_x_locations() const override { return wormhole::T6_X_LOCATIONS; }
 
     const std::vector<uint32_t>& get_t6_y_locations() const override { return wormhole::T6_Y_LOCATIONS; }
-
-    const std::vector<std::vector<tt_xy_pair>>& get_dram_cores_noc0() const override {
-        return wormhole::DRAM_CORES_NOC0;
-    };
 
     std::pair<uint32_t, uint32_t> get_tlb_1m_base_and_count() const override {
         return {wormhole::TLB_BASE_1M, wormhole::TLB_COUNT_1M};
@@ -516,7 +476,6 @@ public:
         return tlb_sizes;
     }
 
-    std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const override;
     tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
 
     uint64_t get_tlb_cfg_reg_size_bytes() const override { return 8; }

--- a/device/arch/blackhole_implementation.cpp
+++ b/device/arch/blackhole_implementation.cpp
@@ -23,17 +23,6 @@ constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h,
 constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6;  // source: noc_parameters.h, common for WH && BH
 }  // namespace blackhole
 
-std::tuple<xy_pair, xy_pair> blackhole_implementation::multicast_workaround(xy_pair start, xy_pair end) const {
-    // TODO: This is copied from wormhole_implementation. It should be implemented properly.
-
-    // When multicasting there is a rare case where including the multicasting node in the box can result in a backup
-    // and the multicasted data not reaching all endpoints specified. As a workaround we exclude the pci endpoint from
-    // the multicast. This doesn't cause any problems with making some tensix cores inaccessible because column 0 (which
-    // we are excluding) doesn't have tensix.
-    start.x = start.x == 0 ? 1 : start.x;
-    return std::make_tuple(start, end);
-}
-
 tlb_configuration blackhole_implementation::get_tlb_configuration(uint32_t tlb_index) const {
     // If TLB index is in range for 4GB tlbs (8 TLBs after 202 TLBs for 2MB).
     if (tlb_index >= blackhole::TLB_COUNT_2M && tlb_index < blackhole::TLB_COUNT_2M + blackhole::TLB_COUNT_4G) {

--- a/device/arch/grendel_implementation.cpp
+++ b/device/arch/grendel_implementation.cpp
@@ -23,17 +23,6 @@ constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h,
 constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6;  // source: noc_parameters.h, common for WH && BH
 }  // namespace grendel
 
-std::tuple<xy_pair, xy_pair> grendel_implementation::multicast_workaround(xy_pair start, xy_pair end) const {
-    // TODO: This is copied from wormhole_implementation. It should be implemented properly.
-
-    // When multicasting there is a rare case where including the multicasting node in the box can result in a backup
-    // and the multicasted data not reaching all endpoints specified. As a workaround we exclude the pci endpoint from
-    // the multicast. This doesn't cause any problems with making some tensix cores inaccessible because column 0 (which
-    // we are excluding) doesn't have tensix.
-    start.x = start.x == 0 ? 1 : start.x;
-    return std::make_tuple(start, end);
-}
-
 tlb_configuration grendel_implementation::get_tlb_configuration(uint32_t tlb_index) const {
     // If TLB index is in range for 4GB tlbs (8 TLBs after 202 TLBs for 2MB).
     if (tlb_index >= grendel::TLB_COUNT_2M && tlb_index < grendel::TLB_COUNT_2M + grendel::TLB_COUNT_4G) {

--- a/device/arch/wormhole_implementation.cpp
+++ b/device/arch/wormhole_implementation.cpp
@@ -25,15 +25,6 @@ constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h,
 constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6;  // source: noc_parameters.h, common for WH && BH
 }  // namespace wormhole
 
-std::tuple<xy_pair, xy_pair> wormhole_implementation::multicast_workaround(xy_pair start, xy_pair end) const {
-    // When multicasting there is a rare case where including the multicasting node in the box can result in a backup
-    // and the multicasted data not reaching all endpoints specified. As a workaround we exclude the pci endpoint from
-    // the multicast. This doesn't cause any problems with making some tensix cores inaccessible because column 0 (which
-    // we are excluding) doesn't have tensix.
-    start.x = start.x == 0 ? 1 : start.x;
-    return std::make_tuple(start, end);
-}
-
 tlb_configuration wormhole_implementation::get_tlb_configuration(uint32_t tlb_index) const {
     if (tlb_index >= wormhole::TLB_BASE_INDEX_16M) {
         return tlb_configuration{


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2873

### Description
First PR in a series trimming `architecture_implementation` down to the Base API
specification. This one only drops virtuals which have no caller anywhere in the
repo (device, tests, tools, examples, nanobind), so there are no call site changes
and no behavior change. Doing it first keeps the following PRs in the series small.

Verified there are no consumers outside UMD either: tt-metal, tt-debuda, tt-topology
and tt-telemetry never touch this class.

### List of the changes
- Remove 19 unused virtuals from `architecture_implementation` and its wormhole,
  blackhole and grendel implementations:
  - ARC: `get_arc_message_test`, `get_arc_reset_arc_misc_cntl_offset`
  - DRAM: `get_dram_channel_0_peer2peer_region_start`, `get_dram_channel_0_x`,
    `get_dram_channel_0_y`, `get_dram_cores_noc0`
  - TLB: `get_broadcast_tlb_index`, `get_dynamic_tlb_2m_base`, `get_dynamic_tlb_2m_size`,
    `get_dynamic_tlb_16m_base`, `get_dynamic_tlb_16m_size`, `get_dynamic_tlb_16m_cfg_addr`,
    `get_mem_large_read_tlb`, `get_mem_large_write_tlb`, `get_reg_tlb`,
    `get_tlb_base_index_16m`
  - Grid: `get_grid_size_x`, `get_grid_size_y`
  - `multicast_workaround`
- Drop the now unused `<tuple>` include.

The arch constants these returned are left in place. Some of them are now unused
(`GRID_SIZE_X`/`GRID_SIZE_Y`, which also duplicate `GRID_SIZE`, `DRAM_CHANNEL_0_X`/`_Y`,
`REG_TLB`, `MEM_LARGE_*_TLB`, `BROADCAST_TLB_INDEX`) - can be cleaned up separately.

### Testing
CI.

### API Changes
This PR has API changes. Methods are removed from a public header, but none of them
have a user in UMD or in any client repo.

