### PR TITLE
Rename architecture_implementation to ArchitectureImplementation

### DIFF
--- a/device/api/umd/device/arch/architecture_implementation.hpp
+++ b/device/api/umd/device/arch/architecture_implementation.hpp
@@ -28,9 +28,9 @@ namespace tt::umd {
 
 static const uint32_t HANG_READ_VALUE = 0xFFFFFFFFu;
 
-class architecture_implementation {
+class ArchitectureImplementation {
 public:
-    virtual ~architecture_implementation() = default;
+    virtual ~ArchitectureImplementation() = default;
 
     virtual tt::ARCH get_architecture() const = 0;
     virtual uint32_t get_arc_message_arc_get_harvesting() const = 0;
@@ -79,7 +79,7 @@ public:
     virtual DriverEthInterfaceParams get_eth_interface_params() const = 0;
     virtual DriverNocParams get_noc_params() const = 0;
 
-    static std::unique_ptr<architecture_implementation> create(tt::ARCH architecture);
+    static std::unique_ptr<ArchitectureImplementation> create(tt::ARCH architecture);
 
     virtual uint64_t get_noc_node_id_offset() const = 0;
     virtual uint64_t get_noc_node_translated_id_offset() const = 0;

--- a/device/api/umd/device/arch/architecture_implementation.hpp
+++ b/device/api/umd/device/arch/architecture_implementation.hpp
@@ -9,7 +9,6 @@
 #include <iterator>
 #include <memory>
 #include <optional>
-#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -40,45 +39,27 @@ public:
     virtual uint32_t get_arc_message_deassert_riscv_reset() const = 0;
     virtual uint32_t get_arc_message_get_aiclk() const = 0;
     virtual uint32_t get_arc_message_setup_iatu_for_peer_to_peer() const = 0;
-    virtual uint32_t get_arc_message_test() const = 0;
     virtual uint32_t get_arc_csm_bar0_mailbox_offset() const = 0;
     virtual uint32_t get_arc_axi_apb_peripheral_offset() const = 0;
-    virtual uint32_t get_arc_reset_arc_misc_cntl_offset() const = 0;
     virtual uint32_t get_arc_reset_scratch_offset() const = 0;
     virtual uint32_t get_arc_reset_scratch_2_offset() const = 0;
     virtual uint32_t get_arc_reset_unit_refclk_low_offset() const = 0;
     virtual uint32_t get_arc_reset_unit_refclk_high_offset() const = 0;
-    virtual uint32_t get_dram_channel_0_peer2peer_region_start() const = 0;
-    virtual uint32_t get_dram_channel_0_x() const = 0;
-    virtual uint32_t get_dram_channel_0_y() const = 0;
     virtual uint32_t get_dram_banks_number() const = 0;
     virtual uint32_t get_aiclk_busy_val() const = 0;
-    virtual uint32_t get_broadcast_tlb_index() const = 0;
-    virtual uint32_t get_dynamic_tlb_2m_base() const = 0;
-    virtual uint32_t get_dynamic_tlb_2m_size() const = 0;
-    virtual uint32_t get_dynamic_tlb_16m_base() const = 0;
-    virtual uint32_t get_dynamic_tlb_16m_size() const = 0;
-    virtual uint32_t get_dynamic_tlb_16m_cfg_addr() const = 0;
-    virtual uint32_t get_mem_large_read_tlb() const = 0;
-    virtual uint32_t get_mem_large_write_tlb() const = 0;
     virtual uint32_t get_num_eth_channels() const = 0;
     virtual uint32_t get_read_checking_offset() const = 0;
-    virtual uint32_t get_reg_tlb() const = 0;
-    virtual uint32_t get_tlb_base_index_16m() const = 0;
     virtual uint32_t get_tensix_soft_reset_addr() const = 0;
     virtual uint32_t get_debug_reg_addr() const = 0;
     virtual uint32_t get_soft_reset_reg_value(RiscType risc_type) const = 0;
     virtual RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const = 0;
     virtual uint32_t get_soft_reset_staggered_start() const = 0;
-    virtual uint32_t get_grid_size_x() const = 0;
-    virtual uint32_t get_grid_size_y() const = 0;
     virtual uint64_t get_arc_apb_noc_base_address() const = 0;
     virtual uint64_t get_arc_csm_noc_base_address() const = 0;
     // Replace with std::span once we enable C++20.
     virtual const std::vector<uint32_t>& get_harvesting_noc_locations() const = 0;
     virtual const std::vector<uint32_t>& get_t6_x_locations() const = 0;
     virtual const std::vector<uint32_t>& get_t6_y_locations() const = 0;
-    virtual const std::vector<std::vector<tt_xy_pair>>& get_dram_cores_noc0() const = 0;
 
     // TLB related. Move other functions here as well.
     virtual std::pair<uint32_t, uint32_t> get_tlb_1m_base_and_count() const = 0;
@@ -89,7 +70,6 @@ public:
     // Get available TLB sizes for this architecture.
     virtual const std::vector<size_t>& get_tlb_sizes() const = 0;
 
-    virtual std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const = 0;
     virtual tlb_configuration get_tlb_configuration(uint32_t tlb_index) const = 0;
     virtual uint64_t get_tlb_cfg_reg_size_bytes() const = 0;
     virtual uint32_t get_static_tlb_cfg_addr() const = 0;

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -359,15 +359,11 @@ public:
         return static_cast<uint32_t>(blackhole::arc_message_type::SETUP_IATU_FOR_PEER_TO_PEER);
     }
 
-    uint32_t get_arc_message_test() const override { return static_cast<uint32_t>(blackhole::arc_message_type::TEST); }
-
     uint32_t get_arc_csm_bar0_mailbox_offset() const override {
         UMD_THROW(error::RuntimeError, "Not implemented for Blackhole architecture.");
     }
 
     uint32_t get_arc_axi_apb_peripheral_offset() const override { return blackhole::ARC_APB_BAR0_XBAR_OFFSET_START; }
-
-    uint32_t get_arc_reset_arc_misc_cntl_offset() const override { return blackhole::ARC_RESET_ARC_MISC_CNTL_OFFSET; }
 
     uint32_t get_arc_reset_scratch_offset() const override { return blackhole::ARC_RESET_SCRATCH_OFFSET; }
 
@@ -377,50 +373,14 @@ public:
 
     uint32_t get_arc_reset_unit_refclk_high_offset() const override { return blackhole::ARC_RESET_REFCLK_HIGH_OFFSET; }
 
-    uint32_t get_dram_channel_0_peer2peer_region_start() const override {
-        return blackhole::DRAM_CHANNEL_0_PEER2PEER_REGION_START;
-    }
-
-    uint32_t get_dram_channel_0_x() const override { return blackhole::DRAM_CHANNEL_0_X; }
-
-    uint32_t get_dram_channel_0_y() const override { return blackhole::DRAM_CHANNEL_0_Y; }
-
     uint32_t get_dram_banks_number() const override { return blackhole::NUM_DRAM_BANKS; }
 
     uint32_t get_aiclk_busy_val() const override { return blackhole::AICLK_BUSY_VAL; }
-
-    uint32_t get_broadcast_tlb_index() const override { return blackhole::BROADCAST_TLB_INDEX; }
-
-    uint32_t get_dynamic_tlb_2m_base() const override { return blackhole::DYNAMIC_TLB_2M_BASE; }
-
-    uint32_t get_dynamic_tlb_2m_size() const override { return blackhole::DYNAMIC_TLB_2M_SIZE; }
-
-    uint32_t get_dynamic_tlb_16m_base() const override {
-        UMD_THROW(error::RuntimeError, "No 16MB TLB size in Blackhole architecture.");
-    }
-
-    uint32_t get_dynamic_tlb_16m_size() const override {
-        UMD_THROW(error::RuntimeError, "No 16MB TLB size in Blackhole architecture.");
-    }
-
-    uint32_t get_dynamic_tlb_16m_cfg_addr() const override {
-        UMD_THROW(error::RuntimeError, "No 16MB TLB size in Blackhole architecture.");
-    }
-
-    uint32_t get_mem_large_read_tlb() const override { return blackhole::MEM_LARGE_READ_TLB; }
-
-    uint32_t get_mem_large_write_tlb() const override { return blackhole::MEM_LARGE_WRITE_TLB; }
 
     uint32_t get_num_eth_channels() const override { return blackhole::NUM_ETH_CHANNELS; }
 
     uint32_t get_read_checking_offset() const override {
         return blackhole::NIU_CFG_NOC0_BAR_PCIE_ADDR + blackhole::NOC_NODE_ID_OFFSET;
-    }
-
-    uint32_t get_reg_tlb() const override { return blackhole::REG_TLB; }
-
-    uint32_t get_tlb_base_index_16m() const override {
-        UMD_THROW(error::RuntimeError, "No 16MB TLB size in Blackhole architecture.");
     }
 
     uint32_t get_tensix_soft_reset_addr() const override { return blackhole::TENSIX_SOFT_RESET_ADDR; }
@@ -432,10 +392,6 @@ public:
     RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const override;
 
     uint32_t get_soft_reset_staggered_start() const override { return blackhole::SOFT_RESET_STAGGERED_START; }
-
-    uint32_t get_grid_size_x() const override { return blackhole::GRID_SIZE_X; }
-
-    uint32_t get_grid_size_y() const override { return blackhole::GRID_SIZE_Y; }
 
     uint64_t get_arc_apb_noc_base_address() const override { return blackhole::ARC_NOC_XBAR_ADDRESS_START; }
 
@@ -450,10 +406,6 @@ public:
     const std::vector<uint32_t>& get_t6_x_locations() const override { return blackhole::T6_X_LOCATIONS; }
 
     const std::vector<uint32_t>& get_t6_y_locations() const override { return blackhole::T6_Y_LOCATIONS; }
-
-    const std::vector<std::vector<tt_xy_pair>>& get_dram_cores_noc0() const override {
-        return blackhole::DRAM_CORES_NOC0;
-    };
 
     std::pair<uint32_t, uint32_t> get_tlb_1m_base_and_count() const override { return {0, 0}; }
 
@@ -474,7 +426,6 @@ public:
         return tlb_sizes;
     }
 
-    std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const override;
     tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
 
     uint64_t get_tlb_cfg_reg_size_bytes() const override { return 12; }

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -331,7 +331,7 @@ inline constexpr std::array<uint16_t, 4> UBB_TRAY_BUS_IDS = {0x00, 0x40, 0xC0, 0
 
 }  // namespace blackhole
 
-class blackhole_implementation : public architecture_implementation {
+class BlackholeImplementation : public ArchitectureImplementation {
 public:
     tt::ARCH get_architecture() const override { return tt::ARCH::BLACKHOLE; }
 

--- a/device/api/umd/device/arch/grendel_implementation.hpp
+++ b/device/api/umd/device/arch/grendel_implementation.hpp
@@ -350,15 +350,11 @@ public:
         return static_cast<uint32_t>(grendel::arc_message_type::SETUP_IATU_FOR_PEER_TO_PEER);
     }
 
-    uint32_t get_arc_message_test() const override { return static_cast<uint32_t>(grendel::arc_message_type::TEST); }
-
     uint32_t get_arc_csm_bar0_mailbox_offset() const override {
         UMD_THROW(error::RuntimeError, "Not implemented for Grendel architecture.");
     }
 
     uint32_t get_arc_axi_apb_peripheral_offset() const override { return grendel::ARC_APB_BAR0_XBAR_OFFSET_START; }
-
-    uint32_t get_arc_reset_arc_misc_cntl_offset() const override { return grendel::ARC_RESET_ARC_MISC_CNTL_OFFSET; }
 
     uint32_t get_arc_reset_scratch_offset() const override { return grendel::ARC_RESET_SCRATCH_OFFSET; }
 
@@ -368,49 +364,13 @@ public:
 
     uint32_t get_arc_reset_unit_refclk_high_offset() const override { return grendel::ARC_RESET_REFCLK_HIGH_OFFSET; }
 
-    uint32_t get_dram_channel_0_peer2peer_region_start() const override {
-        return grendel::DRAM_CHANNEL_0_PEER2PEER_REGION_START;
-    }
-
-    uint32_t get_dram_channel_0_x() const override { return grendel::DRAM_CHANNEL_0_X; }
-
-    uint32_t get_dram_channel_0_y() const override { return grendel::DRAM_CHANNEL_0_Y; }
-
     uint32_t get_dram_banks_number() const override { return grendel::NUM_DRAM_BANKS; }
 
     uint32_t get_aiclk_busy_val() const override { return grendel::AICLK_BUSY_VAL; }
 
-    uint32_t get_broadcast_tlb_index() const override { return grendel::BROADCAST_TLB_INDEX; }
-
-    uint32_t get_dynamic_tlb_2m_base() const override { return grendel::DYNAMIC_TLB_2M_BASE; }
-
-    uint32_t get_dynamic_tlb_2m_size() const override { return grendel::DYNAMIC_TLB_2M_SIZE; }
-
-    uint32_t get_dynamic_tlb_16m_base() const override {
-        UMD_THROW(error::RuntimeError, "No 16MB TLB size in Grendel architecture.");
-    }
-
-    uint32_t get_dynamic_tlb_16m_size() const override {
-        UMD_THROW(error::RuntimeError, "No 16MB TLB size in Grendel architecture.");
-    }
-
-    uint32_t get_dynamic_tlb_16m_cfg_addr() const override {
-        UMD_THROW(error::RuntimeError, "No 16MB TLB size in Grendel architecture.");
-    }
-
-    uint32_t get_mem_large_read_tlb() const override { return grendel::MEM_LARGE_READ_TLB; }
-
-    uint32_t get_mem_large_write_tlb() const override { return grendel::MEM_LARGE_WRITE_TLB; }
-
     uint32_t get_num_eth_channels() const override { return grendel::NUM_ETH_CHANNELS; }
 
     uint32_t get_read_checking_offset() const override { return grendel::BH_NOC_NODE_ID_OFFSET; }
-
-    uint32_t get_reg_tlb() const override { return grendel::REG_TLB; }
-
-    uint32_t get_tlb_base_index_16m() const override {
-        UMD_THROW(error::RuntimeError, "No 16MB TLB size in Grendel architecture.");
-    }
 
     uint32_t get_tensix_soft_reset_addr() const override { return grendel::TENSIX_SOFT_RESET_ADDR; }
 
@@ -423,10 +383,6 @@ public:
     uint32_t get_soft_reset_staggered_start() const override {
         return 0;
     }  // grendel does not support staggered start ??
-
-    uint32_t get_grid_size_x() const override { return grendel::GRID_SIZE_X; }
-
-    uint32_t get_grid_size_y() const override { return grendel::GRID_SIZE_Y; }
 
     uint64_t get_arc_apb_noc_base_address() const override { return grendel::ARC_NOC_XBAR_ADDRESS_START; }
 
@@ -441,10 +397,6 @@ public:
     const std::vector<uint32_t>& get_t6_x_locations() const override { return grendel::T6_X_LOCATIONS; }
 
     const std::vector<uint32_t>& get_t6_y_locations() const override { return grendel::T6_Y_LOCATIONS; }
-
-    const std::vector<std::vector<tt_xy_pair>>& get_dram_cores_noc0() const override {
-        return grendel::DRAM_CORES_NOC0;
-    };
 
     std::pair<uint32_t, uint32_t> get_tlb_1m_base_and_count() const override { return {0, 0}; }
 
@@ -465,7 +417,6 @@ public:
         return tlb_sizes;
     }
 
-    std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const override;
     tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
 
     uint64_t get_tlb_cfg_reg_size_bytes() const override { return 12; }

--- a/device/api/umd/device/arch/grendel_implementation.hpp
+++ b/device/api/umd/device/arch/grendel_implementation.hpp
@@ -322,7 +322,7 @@ tt_xy_pair get_arc_core(const bool noc_translation_enabled, const bool use_noc1)
 
 }  // namespace grendel
 
-class grendel_implementation : public architecture_implementation {
+class GrendelImplementation : public ArchitectureImplementation {
 public:
     tt::ARCH get_architecture() const override { return tt::ARCH::QUASAR; }
 

--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -406,15 +406,11 @@ public:
         return static_cast<uint32_t>(wormhole::arc_message_type::SETUP_IATU_FOR_PEER_TO_PEER);
     }
 
-    uint32_t get_arc_message_test() const override { return static_cast<uint32_t>(wormhole::arc_message_type::TEST); }
-
     uint32_t get_arc_csm_bar0_mailbox_offset() const override {
         return wormhole::ARC_CSM_BAR0_XBAR_OFFSET_START + wormhole::ARC_CSM_MAILBOX_OFFSET;
     }
 
     uint32_t get_arc_axi_apb_peripheral_offset() const override { return wormhole::ARC_APB_BAR0_XBAR_OFFSET_START; }
-
-    uint32_t get_arc_reset_arc_misc_cntl_offset() const override { return wormhole::ARC_RESET_ARC_MISC_CNTL_OFFSET; }
 
     uint32_t get_arc_reset_scratch_offset() const override { return wormhole::ARC_RESET_SCRATCH_OFFSET; }
 
@@ -424,43 +420,15 @@ public:
 
     uint32_t get_arc_reset_unit_refclk_high_offset() const override { return wormhole::ARC_RESET_REFCLK_HIGH_OFFSET; }
 
-    uint32_t get_dram_channel_0_peer2peer_region_start() const override {
-        return wormhole::DRAM_CHANNEL_0_PEER2PEER_REGION_START;
-    }
-
-    uint32_t get_dram_channel_0_x() const override { return wormhole::DRAM_CHANNEL_0_X; }
-
-    uint32_t get_dram_channel_0_y() const override { return wormhole::DRAM_CHANNEL_0_Y; }
-
     uint32_t get_dram_banks_number() const override { return wormhole::NUM_DRAM_BANKS; }
 
     uint32_t get_aiclk_busy_val() const override { return wormhole::AICLK_BUSY_VAL; }
-
-    uint32_t get_broadcast_tlb_index() const override { return wormhole::BROADCAST_TLB_INDEX; }
-
-    uint32_t get_dynamic_tlb_2m_base() const override { return wormhole::DYNAMIC_TLB_2M_BASE; }
-
-    uint32_t get_dynamic_tlb_2m_size() const override { return wormhole::DYNAMIC_TLB_2M_SIZE; }
-
-    uint32_t get_dynamic_tlb_16m_base() const override { return wormhole::DYNAMIC_TLB_16M_BASE; }
-
-    uint32_t get_dynamic_tlb_16m_size() const override { return wormhole::DYNAMIC_TLB_16M_SIZE; }
-
-    uint32_t get_dynamic_tlb_16m_cfg_addr() const override { return wormhole::DYNAMIC_TLB_16M_CFG_ADDR; }
-
-    uint32_t get_mem_large_read_tlb() const override { return wormhole::MEM_LARGE_READ_TLB; }
-
-    uint32_t get_mem_large_write_tlb() const override { return wormhole::MEM_LARGE_WRITE_TLB; }
 
     uint32_t get_num_eth_channels() const override { return wormhole::NUM_ETH_CHANNELS; }
 
     uint32_t get_read_checking_offset() const override {
         return wormhole::NIU_CFG_NOC0_BAR_ARC_ADDR + wormhole::NOC_NODE_ID_OFFSET;
     }
-
-    uint32_t get_reg_tlb() const override { return wormhole::REG_TLB; }
-
-    uint32_t get_tlb_base_index_16m() const override { return wormhole::TLB_BASE_INDEX_16M; }
 
     uint32_t get_tensix_soft_reset_addr() const override { return wormhole::TENSIX_SOFT_RESET_ADDR; }
 
@@ -471,10 +439,6 @@ public:
     RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const override;
 
     uint32_t get_soft_reset_staggered_start() const override { return wormhole::SOFT_RESET_STAGGERED_START; }
-
-    uint32_t get_grid_size_x() const override { return wormhole::GRID_SIZE_X; }
-
-    uint32_t get_grid_size_y() const override { return wormhole::GRID_SIZE_Y; }
 
     uint64_t get_arc_apb_noc_base_address() const override {
         return wormhole::ARC_NOC_ADDRESS_START + wormhole::ARC_APB_NOC_XBAR_OFFSET_START;
@@ -491,10 +455,6 @@ public:
     const std::vector<uint32_t>& get_t6_x_locations() const override { return wormhole::T6_X_LOCATIONS; }
 
     const std::vector<uint32_t>& get_t6_y_locations() const override { return wormhole::T6_Y_LOCATIONS; }
-
-    const std::vector<std::vector<tt_xy_pair>>& get_dram_cores_noc0() const override {
-        return wormhole::DRAM_CORES_NOC0;
-    };
 
     std::pair<uint32_t, uint32_t> get_tlb_1m_base_and_count() const override {
         return {wormhole::TLB_BASE_1M, wormhole::TLB_COUNT_1M};
@@ -516,7 +476,6 @@ public:
         return tlb_sizes;
     }
 
-    std::tuple<xy_pair, xy_pair> multicast_workaround(xy_pair start, xy_pair end) const override;
     tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
 
     uint64_t get_tlb_cfg_reg_size_bytes() const override { return 8; }

--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -378,7 +378,7 @@ inline constexpr std::array<uint16_t, 4> UBB_TRAY_BUS_IDS = {0xC0, 0x80, 0x00, 0
 
 }  // namespace wormhole
 
-class wormhole_implementation : public architecture_implementation {
+class WormholeImplementation : public ArchitectureImplementation {
 public:
     tt::ARCH get_architecture() const override { return tt::ARCH::WORMHOLE_B0; }
 

--- a/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
@@ -15,7 +15,7 @@
 
 namespace tt::umd {
 
-class architecture_implementation;
+class ArchitectureImplementation;
 
 /**
  * In-process allocator for simulation TLB indices.
@@ -26,7 +26,7 @@ class architecture_implementation;
  */
 class SimulationTlbAllocator {
 public:
-    SimulationTlbAllocator(uint64_t bar0_base, const architecture_implementation* arch_impl, uint64_t bar4_base = 0);
+    SimulationTlbAllocator(uint64_t bar0_base, const ArchitectureImplementation* arch_impl, uint64_t bar4_base = 0);
 
     /**
      * Allocate the smallest TLB whose size class is >= the requested size. If no
@@ -66,7 +66,7 @@ public:
      */
     uint64_t get_tlb_reg_address_from_index(int tlb_index);
 
-    const architecture_implementation* get_architecture_impl() const;
+    const ArchitectureImplementation* get_architecture_impl() const;
 
     tt::ARCH get_architecture() const;
 
@@ -91,7 +91,7 @@ private:
 
     uint64_t bar0_base_ = 0;
     uint64_t bar4_base_ = 0;
-    const architecture_implementation* arch_impl_ = nullptr;
+    const ArchitectureImplementation* arch_impl_ = nullptr;
     tt::ARCH architecture_;
     size_t tlb_reg_size_bytes_ = 8;  // Default to Wormhole size.
 

--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -29,7 +29,7 @@
 struct tt_device_t;
 
 namespace tt::umd {
-class architecture_implementation;
+class ArchitectureImplementation;
 
 struct PciDeviceInfo {
     uint16_t vendor_id;
@@ -129,7 +129,7 @@ class PCIDevice {
     const tt::ARCH arch;             // e.g. Wormhole, Blackhole
     const SemVer kmd_version;        // KMD version
     const bool iommu_enabled;        // Whether the system is protected from this device by an IOMMU
-    std::unique_ptr<architecture_implementation> arch_impl_;  // Architecture-specific implementation
+    std::unique_ptr<ArchitectureImplementation> arch_impl_;  // Architecture-specific implementation
     DmaBuffer dma_buffer{};
 
 public:
@@ -210,7 +210,7 @@ public:
     /**
      * @return the architecture-specific implementation for this device
      */
-    architecture_implementation *get_architecture_implementation() const { return arch_impl_.get(); }
+    ArchitectureImplementation *get_architecture_implementation() const { return arch_impl_.get(); }
 
     /**
      * @return whether the system is protected from this device by an IOMMU

--- a/device/api/umd/device/tt_device/hang_detection/blackhole_hang_detector.hpp
+++ b/device/api/umd/device/tt_device/hang_detection/blackhole_hang_detector.hpp
@@ -12,7 +12,7 @@
 
 namespace tt::umd {
 class DeviceProtocol;
-class architecture_implementation;
+class ArchitectureImplementation;
 enum class NocId : uint8_t;
 
 // Blackhole variant: reads BAR and NOC node ID from the PCIe tile.
@@ -21,7 +21,7 @@ enum class NocId : uint8_t;
 class BlackholeHangDetector : public HangDetectorImplementation {
 public:
     BlackholeHangDetector(
-        DeviceProtocol* protocol, architecture_implementation* arch_impl, bool noc_translation_enabled);
+        DeviceProtocol* protocol, ArchitectureImplementation* arch_impl, bool noc_translation_enabled);
 
 private:
     uint32_t read_hang_check_reg_via_bar() override;

--- a/device/api/umd/device/tt_device/hang_detection/hang_detector_implementation.hpp
+++ b/device/api/umd/device/tt_device/hang_detection/hang_detector_implementation.hpp
@@ -44,13 +44,13 @@ public:
     void set_noc_reg_reader(NocRegReader reader);
 
 protected:
-    HangDetectorImplementation(DeviceProtocol* protocol, architecture_implementation* arch_impl);
+    HangDetectorImplementation(DeviceProtocol* protocol, ArchitectureImplementation* arch_impl);
 
     DeviceProtocol* get_protocol() const { return protocol_; }
 
     PcieInterface* get_pcie_interface() const { return pcie_interface_; }
 
-    architecture_implementation* get_arch_impl() const { return arch_impl_; }
+    ArchitectureImplementation* get_arch_impl() const { return arch_impl_; }
 
     // Reads a 32-bit NOC register through the configured NocRegReader. Arch-specific variants compute the
     // (core, addr) for their hang-check register and route the actual read through here.
@@ -64,7 +64,7 @@ private:
     DeviceProtocol* protocol_;
     PcieInterface* pcie_interface_;
     bool is_mmio_protocol_;
-    architecture_implementation* arch_impl_;
+    ArchitectureImplementation* arch_impl_;
     NocRegReader noc_reg_reader_;
 };
 

--- a/device/api/umd/device/tt_device/hang_detection/wormhole_hang_detector.hpp
+++ b/device/api/umd/device/tt_device/hang_detection/wormhole_hang_detector.hpp
@@ -12,13 +12,13 @@
 
 namespace tt::umd {
 class DeviceProtocol;
-class architecture_implementation;
+class ArchitectureImplementation;
 enum class NocId : uint8_t;
 
 // Wormhole variant: reads BAR and NOC node ID from the ARC tile.
 class WormholeHangDetector : public HangDetectorImplementation {
 public:
-    WormholeHangDetector(DeviceProtocol* protocol, architecture_implementation* arch_impl);
+    WormholeHangDetector(DeviceProtocol* protocol, ArchitectureImplementation* arch_impl);
 
 private:
     uint32_t read_hang_check_reg_via_bar() override;

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -108,7 +108,7 @@ public:
 
     virtual ~TTDevice() = default;
 
-    architecture_implementation *get_architecture_implementation();
+    ArchitectureImplementation *get_architecture_implementation();
     PCIDevice *get_pci_device();
     RemoteCommunication *get_remote_communication();
 
@@ -523,24 +523,24 @@ public:
 protected:
     IODeviceType communication_device_type_ = IODeviceType::UNDEFINED;
     int communication_device_id_ = -1;
-    std::unique_ptr<architecture_implementation> architecture_impl_;
+    std::unique_ptr<ArchitectureImplementation> architecture_impl_;
     tt::ARCH arch = tt::ARCH::Invalid;
     LockManager lock_manager;
 
     TTDevice() = default;
     TTDevice(
         std::unique_ptr<PCIDevice> pci_device,
-        std::unique_ptr<architecture_implementation> architecture_impl,
+        std::unique_ptr<ArchitectureImplementation> architecture_impl,
         const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
         bool use_safe_api);
     TTDevice(
         std::unique_ptr<JtagDevice> jtag_device,
         uint8_t jlink_id,
-        std::unique_ptr<architecture_implementation> architecture_impl,
+        std::unique_ptr<ArchitectureImplementation> architecture_impl,
         const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
     TTDevice(
         std::unique_ptr<RemoteCommunication> remote_communication,
-        std::unique_ptr<architecture_implementation> architecture_impl,
+        std::unique_ptr<ArchitectureImplementation> architecture_impl,
         const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
 
     virtual void retrain_dram_core(const uint32_t dram_channel) = 0;

--- a/device/arch/architecture_implementation.cpp
+++ b/device/arch/architecture_implementation.cpp
@@ -12,14 +12,14 @@
 
 namespace tt::umd {
 
-std::unique_ptr<architecture_implementation> architecture_implementation::create(tt::ARCH architecture) {
+std::unique_ptr<ArchitectureImplementation> ArchitectureImplementation::create(tt::ARCH architecture) {
     switch (architecture) {
         case tt::ARCH::QUASAR:
-            return std::make_unique<grendel_implementation>();
+            return std::make_unique<GrendelImplementation>();
         case tt::ARCH::BLACKHOLE:
-            return std::make_unique<blackhole_implementation>();
+            return std::make_unique<BlackholeImplementation>();
         case tt::ARCH::WORMHOLE_B0:
-            return std::make_unique<wormhole_implementation>();
+            return std::make_unique<WormholeImplementation>();
         default:
             return nullptr;
     }

--- a/device/arch/blackhole_implementation.cpp
+++ b/device/arch/blackhole_implementation.cpp
@@ -23,17 +23,6 @@ constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h,
 constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6;  // source: noc_parameters.h, common for WH && BH
 }  // namespace blackhole
 
-std::tuple<xy_pair, xy_pair> blackhole_implementation::multicast_workaround(xy_pair start, xy_pair end) const {
-    // TODO: This is copied from wormhole_implementation. It should be implemented properly.
-
-    // When multicasting there is a rare case where including the multicasting node in the box can result in a backup
-    // and the multicasted data not reaching all endpoints specified. As a workaround we exclude the pci endpoint from
-    // the multicast. This doesn't cause any problems with making some tensix cores inaccessible because column 0 (which
-    // we are excluding) doesn't have tensix.
-    start.x = start.x == 0 ? 1 : start.x;
-    return std::make_tuple(start, end);
-}
-
 tlb_configuration blackhole_implementation::get_tlb_configuration(uint32_t tlb_index) const {
     // If TLB index is in range for 4GB tlbs (8 TLBs after 202 TLBs for 2MB).
     if (tlb_index >= blackhole::TLB_COUNT_2M && tlb_index < blackhole::TLB_COUNT_2M + blackhole::TLB_COUNT_4G) {

--- a/device/arch/blackhole_implementation.cpp
+++ b/device/arch/blackhole_implementation.cpp
@@ -23,7 +23,7 @@ constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h,
 constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6;  // source: noc_parameters.h, common for WH && BH
 }  // namespace blackhole
 
-tlb_configuration blackhole_implementation::get_tlb_configuration(uint32_t tlb_index) const {
+tlb_configuration BlackholeImplementation::get_tlb_configuration(uint32_t tlb_index) const {
     // If TLB index is in range for 4GB tlbs (8 TLBs after 202 TLBs for 2MB).
     if (tlb_index >= blackhole::TLB_COUNT_2M && tlb_index < blackhole::TLB_COUNT_2M + blackhole::TLB_COUNT_4G) {
         return tlb_configuration{
@@ -48,18 +48,18 @@ tlb_configuration blackhole_implementation::get_tlb_configuration(uint32_t tlb_i
     };
 }
 
-DeviceL1AddressParams blackhole_implementation::get_l1_address_params() const {
+DeviceL1AddressParams BlackholeImplementation::get_l1_address_params() const {
     // L1 barrier base and erisc barrier base should be explicitly set by the client.
     // Setting some default values here, but it should be ultimately overridden by the client.
     return {blackhole::L1_BARRIER_BASE, blackhole::ERISC_BARRIER_BASE, blackhole::ETH_FW_VERSION_ADDR};
 }
 
-DriverHostAddressParams blackhole_implementation::get_host_address_params() const {
+DriverHostAddressParams BlackholeImplementation::get_host_address_params() const {
     return {
         erisc_firmware::eth_routing::ETH_ROUTING_BLOCK_SIZE, erisc_firmware::eth_routing::ETH_ROUTING_BUFFERS_START};
 }
 
-DriverEthInterfaceParams blackhole_implementation::get_eth_interface_params() const {
+DriverEthInterfaceParams BlackholeImplementation::get_eth_interface_params() const {
     using namespace erisc_firmware::eth_routing;
     return {
         ETH_RACK_COORD_WIDTH,
@@ -85,11 +85,11 @@ DriverEthInterfaceParams blackhole_implementation::get_eth_interface_params() co
     };
 }
 
-DriverNocParams blackhole_implementation::get_noc_params() const {
+DriverNocParams BlackholeImplementation::get_noc_params() const {
     return {blackhole::NOC_ADDR_LOCAL_BITS, blackhole::NOC_ADDR_NODE_ID_BITS};
 }
 
-uint64_t blackhole_implementation::get_noc_reg_base(
+uint64_t BlackholeImplementation::get_noc_reg_base(
     const CoreType core_type, const uint32_t noc, const uint32_t noc_port) const {
     if (noc == 0) {
         for (const auto& noc_pair : blackhole::NOC0_CONTROL_REG_ADDR_BASE_MAP) {
@@ -110,7 +110,7 @@ uint64_t blackhole_implementation::get_noc_reg_base(
     UMD_THROW(error::RuntimeError, fmt::format("Invalid NOC: {} for getting NOC register addr base.", noc));
 }
 
-uint32_t blackhole_implementation::get_soft_reset_reg_value(RiscType risc_type) const {
+uint32_t BlackholeImplementation::get_soft_reset_reg_value(RiscType risc_type) const {
     if ((risc_type & RiscType::ALL_NEO) != RiscType::NONE) {
         // Throw if any of the NEO cores are selected.
         UMD_THROW(error::RuntimeError, "NEO risc cores should not be used on Blackhole architecture.");
@@ -147,7 +147,7 @@ uint32_t blackhole_implementation::get_soft_reset_reg_value(RiscType risc_type) 
     return soft_reset_reg_value;
 }
 
-RiscType blackhole_implementation::get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const {
+RiscType BlackholeImplementation::get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const {
     RiscType risc_type = RiscType::NONE;
     if (soft_reset_reg_value & blackhole::SOFT_RESET_BRISC) {
         risc_type |= RiscType::BRISC;

--- a/device/arch/grendel_implementation.cpp
+++ b/device/arch/grendel_implementation.cpp
@@ -23,7 +23,7 @@ constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h,
 constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6;  // source: noc_parameters.h, common for WH && BH
 }  // namespace grendel
 
-tlb_configuration grendel_implementation::get_tlb_configuration(uint32_t tlb_index) const {
+tlb_configuration GrendelImplementation::get_tlb_configuration(uint32_t tlb_index) const {
     // If TLB index is in range for 4GB tlbs (8 TLBs after 202 TLBs for 2MB).
     if (tlb_index >= grendel::TLB_COUNT_2M && tlb_index < grendel::TLB_COUNT_2M + grendel::TLB_COUNT_4G) {
         return tlb_configuration{
@@ -48,18 +48,18 @@ tlb_configuration grendel_implementation::get_tlb_configuration(uint32_t tlb_ind
     };
 }
 
-DeviceL1AddressParams grendel_implementation::get_l1_address_params() const {
+DeviceL1AddressParams GrendelImplementation::get_l1_address_params() const {
     // L1 barrier base and erisc barrier base should be explicitly set by the client.
     // Setting some default values here, but it should be ultimately overridden by the client.
     return {blackhole::L1_BARRIER_BASE, blackhole::ERISC_BARRIER_BASE, blackhole::ETH_FW_VERSION_ADDR};
 }
 
-DriverHostAddressParams grendel_implementation::get_host_address_params() const {
+DriverHostAddressParams GrendelImplementation::get_host_address_params() const {
     return {
         erisc_firmware::eth_routing::ETH_ROUTING_BLOCK_SIZE, erisc_firmware::eth_routing::ETH_ROUTING_BUFFERS_START};
 }
 
-DriverEthInterfaceParams grendel_implementation::get_eth_interface_params() const {
+DriverEthInterfaceParams GrendelImplementation::get_eth_interface_params() const {
     using namespace erisc_firmware::eth_routing;
     return {
         ETH_RACK_COORD_WIDTH,
@@ -85,11 +85,11 @@ DriverEthInterfaceParams grendel_implementation::get_eth_interface_params() cons
     };
 }
 
-DriverNocParams grendel_implementation::get_noc_params() const {
+DriverNocParams GrendelImplementation::get_noc_params() const {
     return {grendel::NOC_ADDR_LOCAL_BITS, grendel::NOC_ADDR_NODE_ID_BITS};
 }
 
-uint64_t grendel_implementation::get_noc_reg_base(
+uint64_t GrendelImplementation::get_noc_reg_base(
     const CoreType core_type, const uint32_t noc, const uint32_t noc_port) const {
     if (noc == 0) {
         for (const auto& noc_pair : grendel::NOC0_CONTROL_REG_ADDR_BASE_MAP) {
@@ -110,7 +110,7 @@ uint64_t grendel_implementation::get_noc_reg_base(
     UMD_THROW(error::RuntimeError, fmt::format("Invalid NOC: {} for getting NOC register addr base.", noc));
 }
 
-uint32_t grendel_implementation::get_soft_reset_reg_value(RiscType risc_type) const {
+uint32_t GrendelImplementation::get_soft_reset_reg_value(RiscType risc_type) const {
     if ((risc_type & RiscType::ALL_TENSIX) != RiscType::NONE) {
         // Throw if any of the NEO cores are selected.
         UMD_THROW(error::RuntimeError, "TENSIX risc cores should not be used on Grendel architecture.");
@@ -168,7 +168,7 @@ uint32_t grendel_implementation::get_soft_reset_reg_value(RiscType risc_type) co
     return soft_reset_reg_value;
 }
 
-RiscType grendel_implementation::get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const {
+RiscType GrendelImplementation::get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const {
     RiscType risc_type = RiscType::NONE;
     if (soft_reset_reg_value & grendel::SOFT_RESET_DM0) {
         risc_type |= RiscType::DM0;

--- a/device/arch/grendel_implementation.cpp
+++ b/device/arch/grendel_implementation.cpp
@@ -23,17 +23,6 @@ constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h,
 constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6;  // source: noc_parameters.h, common for WH && BH
 }  // namespace grendel
 
-std::tuple<xy_pair, xy_pair> grendel_implementation::multicast_workaround(xy_pair start, xy_pair end) const {
-    // TODO: This is copied from wormhole_implementation. It should be implemented properly.
-
-    // When multicasting there is a rare case where including the multicasting node in the box can result in a backup
-    // and the multicasted data not reaching all endpoints specified. As a workaround we exclude the pci endpoint from
-    // the multicast. This doesn't cause any problems with making some tensix cores inaccessible because column 0 (which
-    // we are excluding) doesn't have tensix.
-    start.x = start.x == 0 ? 1 : start.x;
-    return std::make_tuple(start, end);
-}
-
 tlb_configuration grendel_implementation::get_tlb_configuration(uint32_t tlb_index) const {
     // If TLB index is in range for 4GB tlbs (8 TLBs after 202 TLBs for 2MB).
     if (tlb_index >= grendel::TLB_COUNT_2M && tlb_index < grendel::TLB_COUNT_2M + grendel::TLB_COUNT_4G) {

--- a/device/arch/wormhole_implementation.cpp
+++ b/device/arch/wormhole_implementation.cpp
@@ -25,7 +25,7 @@ constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h,
 constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6;  // source: noc_parameters.h, common for WH && BH
 }  // namespace wormhole
 
-tlb_configuration wormhole_implementation::get_tlb_configuration(uint32_t tlb_index) const {
+tlb_configuration WormholeImplementation::get_tlb_configuration(uint32_t tlb_index) const {
     if (tlb_index >= wormhole::TLB_BASE_INDEX_16M) {
         return tlb_configuration{
             .size = wormhole::DYNAMIC_TLB_16M_SIZE,
@@ -59,18 +59,18 @@ tlb_configuration wormhole_implementation::get_tlb_configuration(uint32_t tlb_in
     }
 }
 
-DeviceL1AddressParams wormhole_implementation::get_l1_address_params() const {
+DeviceL1AddressParams WormholeImplementation::get_l1_address_params() const {
     // L1 barrier base and erisc barrier base should be explicitly set by the client.
     // Setting some default values here, but it should be ultimately overridden by the client.
     return {wormhole::L1_BARRIER_BASE, wormhole::ERISC_BARRIER_BASE, wormhole::ETH_FW_VERSION_ADDR};
 }
 
-DriverHostAddressParams wormhole_implementation::get_host_address_params() const {
+DriverHostAddressParams WormholeImplementation::get_host_address_params() const {
     return {
         erisc_firmware::eth_routing::ETH_ROUTING_BLOCK_SIZE, erisc_firmware::eth_routing::ETH_ROUTING_BUFFERS_START};
 }
 
-DriverEthInterfaceParams wormhole_implementation::get_eth_interface_params() const {
+DriverEthInterfaceParams WormholeImplementation::get_eth_interface_params() const {
     using namespace erisc_firmware::eth_routing;
     return {
         ETH_RACK_COORD_WIDTH,
@@ -96,12 +96,12 @@ DriverEthInterfaceParams wormhole_implementation::get_eth_interface_params() con
     };
 }
 
-DriverNocParams wormhole_implementation::get_noc_params() const {
+DriverNocParams WormholeImplementation::get_noc_params() const {
     return {wormhole::NOC_ADDR_LOCAL_BITS, wormhole::NOC_ADDR_NODE_ID_BITS};
 }
 
 // TODO: integrate noc_port for DRAM core type inside the function.
-uint64_t wormhole_implementation::get_noc_reg_base(
+uint64_t WormholeImplementation::get_noc_reg_base(
     const CoreType core_type, const uint32_t noc, const uint32_t noc_port) const {
     if (noc == 0) {
         for (const auto& noc_pair : wormhole::NOC0_CONTROL_REG_ADDR_BASE_MAP) {
@@ -129,7 +129,7 @@ uint64_t wormhole_implementation::get_noc_reg_base(
     UMD_THROW(error::RuntimeError, fmt::format("Invalid NOC: {} for getting NOC register addr base.", noc));
 }
 
-uint32_t wormhole_implementation::get_soft_reset_reg_value(RiscType risc_type) const {
+uint32_t WormholeImplementation::get_soft_reset_reg_value(RiscType risc_type) const {
     if ((risc_type & RiscType::ALL_NEO) != RiscType::NONE) {
         // Throw if any of the NEO cores are selected.
         UMD_THROW(error::RuntimeError, "NEO risc cores should not be used on Wormhole architecture.");
@@ -166,7 +166,7 @@ uint32_t wormhole_implementation::get_soft_reset_reg_value(RiscType risc_type) c
     return soft_reset_reg_value;
 }
 
-RiscType wormhole_implementation::get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const {
+RiscType WormholeImplementation::get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const {
     RiscType risc_type = RiscType::NONE;
     if (soft_reset_reg_value & wormhole::SOFT_RESET_BRISC) {
         risc_type |= RiscType::BRISC;

--- a/device/arch/wormhole_implementation.cpp
+++ b/device/arch/wormhole_implementation.cpp
@@ -25,15 +25,6 @@ constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h,
 constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6;  // source: noc_parameters.h, common for WH && BH
 }  // namespace wormhole
 
-std::tuple<xy_pair, xy_pair> wormhole_implementation::multicast_workaround(xy_pair start, xy_pair end) const {
-    // When multicasting there is a rare case where including the multicasting node in the box can result in a backup
-    // and the multicasted data not reaching all endpoints specified. As a workaround we exclude the pci endpoint from
-    // the multicast. This doesn't cause any problems with making some tensix cores inaccessible because column 0 (which
-    // we are excluding) doesn't have tensix.
-    start.x = start.x == 0 ? 1 : start.x;
-    return std::make_tuple(start, end);
-}
-
 tlb_configuration wormhole_implementation::get_tlb_configuration(uint32_t tlb_index) const {
     if (tlb_index >= wormhole::TLB_BASE_INDEX_16M) {
         return tlb_configuration{

--- a/device/chip/chip.cpp
+++ b/device/chip/chip.cpp
@@ -33,10 +33,10 @@ Chip::Chip(const ChipInfo chip_info, tt::ARCH arch) : chip_info_(chip_info) { se
 
 // TODO: This will be moved to LocalChip.
 void Chip::set_default_params(ARCH arch) {
-    auto architecture_implementation = architecture_implementation::create(arch);
+    auto arch_impl = ArchitectureImplementation::create(arch);
 
     // Default initialize l1_address_params based on detected arch.
-    l1_address_params = architecture_implementation->get_l1_address_params();
+    l1_address_params = arch_impl->get_l1_address_params();
 
     // Default initialize dram_address_params.
     dram_address_params = {0u};

--- a/device/chip_helpers/simulation_tlb_allocator.cpp
+++ b/device/chip_helpers/simulation_tlb_allocator.cpp
@@ -17,7 +17,7 @@
 namespace tt::umd {
 
 SimulationTlbAllocator::SimulationTlbAllocator(
-    uint64_t bar0_base, const architecture_implementation* arch_impl, uint64_t bar4_base) :
+    uint64_t bar0_base, const ArchitectureImplementation* arch_impl, uint64_t bar4_base) :
     bar0_base_(bar0_base), bar4_base_(bar4_base), arch_impl_(arch_impl) {
     initialize_architecture_config();
 }
@@ -106,7 +106,7 @@ uint64_t SimulationTlbAllocator::get_tlb_reg_address_from_index(int tlb_index) {
     return bar0_base_ + TLB_CONFIG_REG_BASE_OFFSET + tlb_index * tlb_reg_size_bytes_;
 }
 
-const architecture_implementation* SimulationTlbAllocator::get_architecture_impl() const { return arch_impl_; }
+const ArchitectureImplementation* SimulationTlbAllocator::get_architecture_impl() const { return arch_impl_; }
 
 tt::ARCH SimulationTlbAllocator::get_architecture() const { return architecture_; }
 

--- a/device/cluster.cpp
+++ b/device/cluster.cpp
@@ -762,7 +762,7 @@ void Cluster::assert_risc_reset() {
     }
 
     uint32_t reset_reg_value =
-        architecture_implementation::create(arch_name)->get_soft_reset_reg_value(RiscType::ALL_TENSIX);
+        ArchitectureImplementation::create(arch_name)->get_soft_reset_reg_value(RiscType::ALL_TENSIX);
     broadcast_tensix_risc_reset_to_cluster(reset_reg_value);
 }
 
@@ -782,7 +782,7 @@ void Cluster::deassert_risc_reset() {
         return;
     }
 
-    auto arch_impl = architecture_implementation::create(arch_name);
+    auto arch_impl = ArchitectureImplementation::create(arch_name);
     uint32_t reset_reg_value = arch_impl->get_soft_reset_reg_value(RiscType::ALL_TENSIX & ~RiscType::BRISC) |
                                arch_impl->get_soft_reset_staggered_start();
     broadcast_tensix_risc_reset_to_cluster(reset_reg_value);

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -616,7 +616,7 @@ void ClusterDescriptor::load_ethernet_connections_from_connectivity_descriptor(Y
                 ? 0
                 : CoordinateManager::get_num_harvested(harvesting_masks_map.at(chip).eth_harvesting_mask);
         int num_channels =
-            architecture_implementation::create(chip_arch.at(chip))->get_num_eth_channels() - num_harvested_channels;
+            ArchitectureImplementation::create(chip_arch.at(chip))->get_num_eth_channels() - num_harvested_channels;
         for (int i = 0; i < num_channels; i++) {
             idle_eth_channels[chip].insert(i);
         }
@@ -1377,7 +1377,7 @@ std::optional<uint8_t> ClusterDescriptor::get_tray_id(ChipId chip_id) const {
     if (board != BoardType::UBB_WORMHOLE && board != BoardType::UBB_BLACKHOLE) {
         return std::nullopt;
     }
-    auto arch_impl = architecture_implementation::create(get_arch(chip_id));
+    auto arch_impl = ArchitectureImplementation::create(get_arch(chip_id));
     if (!arch_impl) {
         return std::nullopt;
     }

--- a/device/coordinates/coordinate_manager.cpp
+++ b/device/coordinates/coordinate_manager.cpp
@@ -408,7 +408,7 @@ HarvestingMasks CoordinateManager::get_harvesting_masks() const { return harvest
 
 uint32_t CoordinateManager::shuffle_tensix_harvesting_mask(tt::ARCH arch, uint32_t tensix_harvesting_physical_layout) {
     std::vector<uint32_t> harvesting_locations =
-        architecture_implementation::create(arch)->get_harvesting_noc_locations();
+        ArchitectureImplementation::create(arch)->get_harvesting_noc_locations();
 
     std::vector<uint32_t> sorted_harvesting_locations = harvesting_locations;
     std::sort(sorted_harvesting_locations.begin(), sorted_harvesting_locations.end());
@@ -432,7 +432,7 @@ uint32_t CoordinateManager::shuffle_tensix_harvesting_mask(tt::ARCH arch, uint32
 uint32_t CoordinateManager::shuffle_tensix_harvesting_mask_to_noc0_coords(
     tt::ARCH arch, uint32_t tensix_harvesting_logical_layout) {
     std::vector<uint32_t> sorted_harvesting_locations =
-        architecture_implementation::create(arch)->get_harvesting_noc_locations();
+        ArchitectureImplementation::create(arch)->get_harvesting_noc_locations();
 
     std::sort(sorted_harvesting_locations.begin(), sorted_harvesting_locations.end());
     size_t new_harvesting_mask = 0;

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -394,7 +394,7 @@ PCIDevice::PCIDevice(int pci_device_number) :
     arch(info.get_arch()),
     kmd_version(PCIDevice::read_kmd_version()),
     iommu_enabled(detect_iommu(info)),
-    arch_impl_(architecture_implementation::create(arch)) {
+    arch_impl_(ArchitectureImplementation::create(arch)) {
     if (kmd_version < KMD_MINIMUM_VERSION) {
         UMD_THROW(
             error::RuntimeError,

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -44,7 +44,7 @@ BlackholeTTDevice::BlackholeTTDevice(
     std::unique_ptr<PCIDevice> pci_device,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
     bool use_safe_api) :
-    TTDevice(std::move(pci_device), std::make_unique<blackhole_implementation>(), soc_arch_descriptor, use_safe_api) {
+    TTDevice(std::move(pci_device), std::make_unique<BlackholeImplementation>(), soc_arch_descriptor, use_safe_api) {
     BlackholeTTDevice::set_arc_coordinate();
     set_hang_detector(std::make_unique<BlackholeHangDetector>(
         get_device_protocol(), get_architecture_implementation(), BlackholeTTDevice::get_noc_translation_enabled()));
@@ -54,7 +54,7 @@ BlackholeTTDevice::BlackholeTTDevice(
     std::unique_ptr<JtagDevice> jtag_device,
     uint8_t jlink_id,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
-    TTDevice(std::move(jtag_device), jlink_id, std::make_unique<blackhole_implementation>(), soc_arch_descriptor) {
+    TTDevice(std::move(jtag_device), jlink_id, std::make_unique<BlackholeImplementation>(), soc_arch_descriptor) {
     BlackholeTTDevice::set_arc_coordinate();
     set_hang_detector(std::make_unique<BlackholeHangDetector>(
         get_device_protocol(), get_architecture_implementation(), BlackholeTTDevice::get_noc_translation_enabled()));

--- a/device/tt_device/ethernet_broadcast.cpp
+++ b/device/tt_device/ethernet_broadcast.cpp
@@ -26,7 +26,7 @@
 namespace tt::umd {
 
 static bool tensix_or_eth_in_broadcast(
-    const std::set<uint32_t>& cols_to_exclude, const architecture_implementation* arch_impl) {
+    const std::set<uint32_t>& cols_to_exclude, const ArchitectureImplementation* arch_impl) {
     bool found_tensix_or_eth = false;
     for (const auto& col : arch_impl->get_t6_x_locations()) {
         found_tensix_or_eth |= (cols_to_exclude.find(col) == cols_to_exclude.end());
@@ -37,7 +37,7 @@ static bool tensix_or_eth_in_broadcast(
 static bool valid_tensix_broadcast_grid(
     const std::set<uint32_t>& rows_to_exclude,
     const std::set<uint32_t>& cols_to_exclude,
-    const architecture_implementation* arch_impl) {
+    const ArchitectureImplementation* arch_impl) {
     bool t6_bcast_rows_complete = true;
     bool t6_bcast_rows_empty = true;
 
@@ -290,7 +290,7 @@ void EthernetBroadcast::broadcast_write_to_cluster(
     adjust_coordinates_for_ethernet_broadcast(
         rows_to_exclude, columns_to_exclude, use_translated_coords, rows_to_exclude_virtual, cols_to_exclude_virtual);
 
-    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
     if (cols_to_exclude_virtual.find(0) == cols_to_exclude_virtual.end() or
         cols_to_exclude_virtual.find(5) == cols_to_exclude_virtual.end()) {
         UMD_ASSERT(

--- a/device/tt_device/hang_detection/blackhole_hang_detector.cpp
+++ b/device/tt_device/hang_detection/blackhole_hang_detector.cpp
@@ -17,7 +17,7 @@
 namespace tt::umd {
 
 BlackholeHangDetector::BlackholeHangDetector(
-    DeviceProtocol* protocol, architecture_implementation* arch_impl, bool noc_translation_enabled) :
+    DeviceProtocol* protocol, ArchitectureImplementation* arch_impl, bool noc_translation_enabled) :
     HangDetectorImplementation(protocol, arch_impl), noc_translation_enabled_(noc_translation_enabled) {}
 
 uint32_t BlackholeHangDetector::read_hang_check_reg_via_bar() {

--- a/device/tt_device/hang_detection/hang_detector_implementation.cpp
+++ b/device/tt_device/hang_detection/hang_detector_implementation.cpp
@@ -13,7 +13,7 @@
 
 namespace tt::umd {
 HangDetectorImplementation::HangDetectorImplementation(
-    DeviceProtocol* protocol, architecture_implementation* arch_impl) :
+    DeviceProtocol* protocol, ArchitectureImplementation* arch_impl) :
     protocol_(protocol),
     pcie_interface_(dynamic_cast<PcieInterface*>(protocol)),
     is_mmio_protocol_(!dynamic_cast<RemoteInterface*>(protocol)),

--- a/device/tt_device/hang_detection/wormhole_hang_detector.cpp
+++ b/device/tt_device/hang_detection/wormhole_hang_detector.cpp
@@ -16,7 +16,7 @@
 
 namespace tt::umd {
 
-WormholeHangDetector::WormholeHangDetector(DeviceProtocol* protocol, architecture_implementation* arch_impl) :
+WormholeHangDetector::WormholeHangDetector(DeviceProtocol* protocol, ArchitectureImplementation* arch_impl) :
     HangDetectorImplementation(protocol, arch_impl) {}
 
 uint32_t WormholeHangDetector::read_hang_check_reg_via_bar() {

--- a/device/tt_device/rtl_simulation_tt_device.cpp
+++ b/device/tt_device/rtl_simulation_tt_device.cpp
@@ -95,7 +95,7 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
     communicator_(std::make_unique<RtlSimCommunicator>(simulator_directory)) {
     log_info(tt::LogEmulationDriver, "Instantiating RTL simulation TTDevice");
     set_soc_descriptor(soc_descriptor);
-    architecture_impl_ = architecture_implementation::create(get_soc_descriptor().arch);
+    architecture_impl_ = ArchitectureImplementation::create(get_soc_descriptor().arch);
     arch = get_soc_descriptor().arch;
 
     // Host/local mode: the lifecycle drives the in-process RTL backend (the communicator).
@@ -109,7 +109,7 @@ RtlSimulationTTDevice::RtlSimulationTTDevice(
     SimulationTTDevice(std::move(client)) {
     set_soc_descriptor(soc_descriptor);
     arch = soc_descriptor.arch;
-    architecture_impl_ = architecture_implementation::create(soc_descriptor.arch);
+    architecture_impl_ = ArchitectureImplementation::create(soc_descriptor.arch);
 
     // Client mode: the lifecycle drives the remote host over the socket. read/write are not wired
     // here -- the SimulationClient has no device I/O yet -- so those throw until the API grows.

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -66,7 +66,7 @@ constexpr double AICLK_TOLERANCE_PERCENT = 5.0;
 
 TTDevice::TTDevice(
     std::unique_ptr<PCIDevice> pci_device,
-    std::unique_ptr<architecture_implementation> architecture_impl,
+    std::unique_ptr<ArchitectureImplementation> architecture_impl,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
     bool use_safe_api) :
     communication_device_type_(IODeviceType::PCIe),
@@ -90,7 +90,7 @@ TTDevice::TTDevice(
 TTDevice::TTDevice(
     std::unique_ptr<JtagDevice> jtag_device,
     uint8_t jlink_id,
-    std::unique_ptr<architecture_implementation> architecture_impl,
+    std::unique_ptr<ArchitectureImplementation> architecture_impl,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     communication_device_type_(IODeviceType::JTAG),
     communication_device_id_(jlink_id),
@@ -105,7 +105,7 @@ TTDevice::TTDevice(
 
 TTDevice::TTDevice(
     std::unique_ptr<RemoteCommunication> remote_communication,
-    std::unique_ptr<architecture_implementation> architecture_impl,
+    std::unique_ptr<ArchitectureImplementation> architecture_impl,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     communication_device_type_(remote_communication->get_local_device()->get_communication_device_type()),
     communication_device_id_(remote_communication->get_local_device()->get_communication_device_id()),
@@ -248,7 +248,7 @@ std::unique_ptr<TTDevice> TTDevice::create_simulation_remote(
 }
 #endif  // TT_UMD_BUILD_SIMULATION
 
-architecture_implementation *TTDevice::get_architecture_implementation() { return architecture_impl_.get(); }
+ArchitectureImplementation *TTDevice::get_architecture_implementation() { return architecture_impl_.get(); }
 
 // The nullptr check for capabilities in the APIs get_pci_device and get_remote_communication
 // exists for backward compatibility — these APIs are expected to return nullptr when a capability is unavailable.

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -115,7 +115,7 @@ TTSimTTDevice::TTSimTTDevice(
     // init_tt_device() (no PCI probe), so without this arch stays tt::ARCH::Invalid and downstream
     // consumers (e.g. tt-exalens constructing a SocDescriptor from the device) see the wrong arch.
     arch = soc_descriptor.arch;
-    architecture_impl_ = architecture_implementation::create(soc_descriptor.arch);
+    architecture_impl_ = ArchitectureImplementation::create(soc_descriptor.arch);
     // Host/local mode: the lifecycle drives the in-process .so backend (the communicator).
     setup_ = [this] { initialize_backend(); };
     teardown_ = [this] { communicator_->shutdown(); };
@@ -189,7 +189,7 @@ TTSimTTDevice::TTSimTTDevice(
     SimulationTTDevice(std::move(client)), chip_id_(chip_id) {
     set_soc_descriptor(soc_descriptor);
     arch = soc_descriptor.arch;
-    architecture_impl_ = architecture_implementation::create(soc_descriptor.arch);
+    architecture_impl_ = ArchitectureImplementation::create(soc_descriptor.arch);
 
     // Client mode: the lifecycle drives the remote host over the socket. read/write are not wired
     // here -- the SimulationClient has no device I/O yet -- so those throw until the API grows.

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -44,7 +44,7 @@ WormholeTTDevice::WormholeTTDevice(
     std::unique_ptr<PCIDevice> pci_device,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
     bool use_safe_api) :
-    TTDevice(std::move(pci_device), std::make_unique<wormhole_implementation>(), soc_arch_descriptor, use_safe_api) {
+    TTDevice(std::move(pci_device), std::make_unique<WormholeImplementation>(), soc_arch_descriptor, use_safe_api) {
     WormholeTTDevice::set_arc_coordinate();
     set_hang_detector(std::make_unique<WormholeHangDetector>(get_device_protocol(), get_architecture_implementation()));
 }
@@ -53,7 +53,7 @@ WormholeTTDevice::WormholeTTDevice(
     std::unique_ptr<JtagDevice> jtag_device,
     uint8_t jlink_id,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
-    TTDevice(std::move(jtag_device), jlink_id, std::make_unique<wormhole_implementation>(), soc_arch_descriptor) {
+    TTDevice(std::move(jtag_device), jlink_id, std::make_unique<WormholeImplementation>(), soc_arch_descriptor) {
     WormholeTTDevice::set_arc_coordinate();
     set_hang_detector(std::make_unique<WormholeHangDetector>(get_device_protocol(), get_architecture_implementation()));
 }
@@ -61,7 +61,7 @@ WormholeTTDevice::WormholeTTDevice(
 WormholeTTDevice::WormholeTTDevice(
     std::unique_ptr<RemoteCommunication> remote_communication,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
-    TTDevice(std::move(remote_communication), std::make_unique<wormhole_implementation>(), soc_arch_descriptor) {
+    TTDevice(std::move(remote_communication), std::make_unique<WormholeImplementation>(), soc_arch_descriptor) {
     WormholeTTDevice::set_arc_coordinate();
     is_remote_tt_device = true;
     set_hang_detector(std::make_unique<WormholeHangDetector>(

--- a/tests/api/test_cluster_descriptor.cpp
+++ b/tests/api/test_cluster_descriptor.cpp
@@ -125,7 +125,7 @@ TEST(TestClusterDescriptor, EthernetConnectivity) {
     for (auto chip : cluster_desc->get_all_chips()) {
         // Wormhole has 16 and Blackhole has 14 ethernet channels.
         for (int eth_chan = 0;
-             eth_chan < architecture_implementation::create(cluster_desc->get_arch(chip))->get_num_eth_channels();
+             eth_chan < ArchitectureImplementation::create(cluster_desc->get_arch(chip))->get_num_eth_channels();
              eth_chan++) {
             bool has_active_link = cluster_desc->ethernet_core_has_active_ethernet_link(chip, eth_chan);
             std::cout << "Chip " << chip << " channel " << eth_chan << " has active link: " << has_active_link

--- a/tests/baremetal/test_simulation_tlb_allocator.cpp
+++ b/tests/baremetal/test_simulation_tlb_allocator.cpp
@@ -23,7 +23,7 @@ constexpr uint64_t TEST_BAR0_BASE = 0x10000000ULL;
 }  // namespace
 
 TEST(SimulationTlbAllocator, WormholeBasicAllocateAndDeallocate) {
-    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
     int idx = allocator.allocate_tlb_index(0x100000);
@@ -41,7 +41,7 @@ TEST(SimulationTlbAllocator, WormholeBasicAllocateAndDeallocate) {
 }
 
 TEST(SimulationTlbAllocator, WormholeAllocateEachSizeClass) {
-    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
     int idx_1mb = allocator.allocate_tlb_index(0x100000);
@@ -58,7 +58,7 @@ TEST(SimulationTlbAllocator, WormholeAllocateEachSizeClass) {
 }
 
 TEST(SimulationTlbAllocator, WormholeAllocateZeroPicksSmallest) {
-    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
     int idx = allocator.allocate_tlb_index(0);
@@ -68,7 +68,7 @@ TEST(SimulationTlbAllocator, WormholeAllocateZeroPicksSmallest) {
 }
 
 TEST(SimulationTlbAllocator, WormholeAllocateZeroFallsBackWhenSmallestClassExhausted) {
-    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
     // Drain the 1MB pool entirely (Wormhole has 156 1MB TLBs).
@@ -83,7 +83,7 @@ TEST(SimulationTlbAllocator, WormholeAllocateZeroFallsBackWhenSmallestClassExhau
 }
 
 TEST(SimulationTlbAllocator, WormholeIndicesAreUniqueWithinSizeClass) {
-    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
     std::unordered_set<int> seen_indices;
@@ -97,7 +97,7 @@ TEST(SimulationTlbAllocator, WormholeIndicesAreUniqueWithinSizeClass) {
 }
 
 TEST(SimulationTlbAllocator, WormholeFallsBackToLargerSizeClassWhenExhausted) {
-    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
     // Drain the 1MB pool entirely (Wormhole has 156 1MB TLBs).
@@ -112,7 +112,7 @@ TEST(SimulationTlbAllocator, WormholeFallsBackToLargerSizeClassWhenExhausted) {
 }
 
 TEST(SimulationTlbAllocator, WormholeReturnsNegativeOneWhenAllPoolsExhausted) {
-    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
     // Exhaust every size class. allocate_tlb_index(0) picks any available TLB.
@@ -125,7 +125,7 @@ TEST(SimulationTlbAllocator, WormholeReturnsNegativeOneWhenAllPoolsExhausted) {
 }
 
 TEST(SimulationTlbAllocator, WormholeAddressFromIndex) {
-    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
     // Wormhole layout from BAR0 base 0x10000000:
@@ -139,7 +139,7 @@ TEST(SimulationTlbAllocator, WormholeAddressFromIndex) {
 }
 
 TEST(SimulationTlbAllocator, WormholeRegAddressFromIndex) {
-    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
     // TLB config registers start at BAR0+0x1FC00000 with 8-byte stride on Wormhole.
@@ -148,7 +148,7 @@ TEST(SimulationTlbAllocator, WormholeRegAddressFromIndex) {
 }
 
 TEST(SimulationTlbAllocator, BlackholeBasicAllocate) {
-    auto arch_impl = architecture_implementation::create(tt::ARCH::BLACKHOLE);
+    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::BLACKHOLE);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
     int idx = allocator.allocate_tlb_index(0x200000);
@@ -159,7 +159,7 @@ TEST(SimulationTlbAllocator, BlackholeBasicAllocate) {
 }
 
 TEST(SimulationTlbAllocator, BlackholeAddressFromIndex) {
-    auto arch_impl = architecture_implementation::create(tt::ARCH::BLACKHOLE);
+    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::BLACKHOLE);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
     // Blackhole layout from BAR0 base 0x10000000:
@@ -169,7 +169,7 @@ TEST(SimulationTlbAllocator, BlackholeAddressFromIndex) {
 }
 
 TEST(SimulationTlbAllocator, BlackholeRegAddressFromIndex) {
-    auto arch_impl = architecture_implementation::create(tt::ARCH::BLACKHOLE);
+    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::BLACKHOLE);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
     // TLB config registers start at BAR0+0x1FC00000 with 12-byte stride on Blackhole.
@@ -178,7 +178,7 @@ TEST(SimulationTlbAllocator, BlackholeRegAddressFromIndex) {
 }
 
 TEST(SimulationTlbAllocator, GettersThrowOnInvalidIndex) {
-    auto arch_impl = architecture_implementation::create(tt::ARCH::WORMHOLE_B0);
+    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
     SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
 
     // Negative indices are rejected.

--- a/tools/tlb_virus.cpp
+++ b/tools/tlb_virus.cpp
@@ -26,7 +26,7 @@
 using namespace tt::umd;
 
 // Helper function to get TLB count for a given size from architecture.
-uint32_t get_tlb_count_for_size(architecture_implementation* arch_impl, size_t tlb_size) {
+uint32_t get_tlb_count_for_size(ArchitectureImplementation* arch_impl, size_t tlb_size) {
     static constexpr size_t one_mb = 1 << 20;
     static constexpr size_t one_gb = 1 << 30;
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2873

### Description
Stacked on #3191.

Pure rename to match the naming used by the Base API specification and the rest of
the codebase. Doing it in its own PR keeps the mechanical churn out of the following
PRs in the series, which move methods between components.

File names are left in snake_case, same as for example `soc_arch_descriptor.hpp` /
`SocArchDescriptor`.

### List of the changes
- Rename `architecture_implementation` to `ArchitectureImplementation`, and the three
  implementations to `WormholeImplementation`, `BlackholeImplementation` and
  `GrendelImplementation`.
- `Chip::set_default_params` had a local variable named exactly like the class, renamed
  it to `arch_impl`.

### Testing
Code builds.

### API Changes
This PR has API changes, due to said rename. No client repo uses these classes externally.
