### PR TITLE
Move legacy ETH firmware params to wormhole namespace

### DIFF
--- a/device/api/umd/device/arch/architecture_implementation.hpp
+++ b/device/api/umd/device/arch/architecture_implementation.hpp
@@ -75,9 +75,6 @@ public:
     virtual uint32_t get_static_tlb_cfg_addr() const = 0;
 
     virtual DeviceL1AddressParams get_l1_address_params() const = 0;
-    virtual DriverHostAddressParams get_host_address_params() const = 0;
-    virtual DriverEthInterfaceParams get_eth_interface_params() const = 0;
-    virtual DriverNocParams get_noc_params() const = 0;
 
     static std::unique_ptr<ArchitectureImplementation> create(tt::ARCH architecture);
 

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -433,9 +433,6 @@ public:
     uint32_t get_static_tlb_cfg_addr() const override { return blackhole::STATIC_TLB_CFG_ADDR; }
 
     DeviceL1AddressParams get_l1_address_params() const override;
-    DriverHostAddressParams get_host_address_params() const override;
-    DriverEthInterfaceParams get_eth_interface_params() const override;
-    DriverNocParams get_noc_params() const override;
 
     uint64_t get_noc_node_id_offset() const override { return blackhole::NOC_NODE_ID_OFFSET; }
 

--- a/device/api/umd/device/arch/grendel_implementation.hpp
+++ b/device/api/umd/device/arch/grendel_implementation.hpp
@@ -424,9 +424,6 @@ public:
     uint32_t get_static_tlb_cfg_addr() const override { return grendel::STATIC_TLB_CFG_ADDR; }
 
     DeviceL1AddressParams get_l1_address_params() const override;
-    DriverHostAddressParams get_host_address_params() const override;
-    DriverEthInterfaceParams get_eth_interface_params() const override;
-    DriverNocParams get_noc_params() const override;
 
     uint64_t get_noc_node_id_offset() const override { return grendel::NOC_NODE_ID_OFFSET; }
 

--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -15,6 +15,7 @@
 
 #include "architecture_implementation.hpp"
 #include "umd/device/types/arch.hpp"
+#include "umd/device/types/cluster_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/tlb.hpp"
 #include "umd/device/types/xy_pair.hpp"
@@ -376,6 +377,12 @@ inline constexpr uint32_t ARC_SPI_CHUNK_SIZE = SPI_PAGE_ERASE_SIZE;
 // High nibble of the PCI bus id (bus_id & 0xF0) for trays 1..4 on UBB Wormhole boards.
 inline constexpr std::array<uint16_t, 4> UBB_TRAY_BUS_IDS = {0xC0, 0x80, 0x00, 0x40};
 
+// Parameters of the legacy ETH routing firmware protocol and of the NOC address layout, used when
+// talking to remote chips over that firmware.
+DriverHostAddressParams get_host_address_params();
+DriverEthInterfaceParams get_eth_interface_params();
+DriverNocParams get_noc_params();
+
 }  // namespace wormhole
 
 class WormholeImplementation : public ArchitectureImplementation {
@@ -483,9 +490,6 @@ public:
     uint32_t get_static_tlb_cfg_addr() const override { return wormhole::STATIC_TLB_CFG_ADDR; }
 
     DeviceL1AddressParams get_l1_address_params() const override;
-    DriverHostAddressParams get_host_address_params() const override;
-    DriverEthInterfaceParams get_eth_interface_params() const override;
-    DriverNocParams get_noc_params() const override;
 
     uint64_t get_noc_node_id_offset() const override { return wormhole::NOC_NODE_ID_OFFSET; }
 

--- a/device/api/umd/device/tt_device/remote_communication_legacy_firmware.hpp
+++ b/device/api/umd/device/tt_device/remote_communication_legacy_firmware.hpp
@@ -12,6 +12,7 @@
 
 #include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
+#include "umd/device/types/cluster_types.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/timeouts.hpp"
 
@@ -48,6 +49,10 @@ public:
 private:
     EthCoord target_chip;
     bool large_transfer_warning_printed_ = false;
+
+    const DriverHostAddressParams host_address_params_;
+    const DriverEthInterfaceParams eth_interface_params_;
+    const DriverNocParams noc_params_;
 };
 
 }  // namespace tt::umd

--- a/device/arch/blackhole_implementation.cpp
+++ b/device/arch/blackhole_implementation.cpp
@@ -9,7 +9,6 @@
 #include <cstdint>
 #include <tuple>
 
-#include "umd/device/firmware/erisc_firmware.hpp"
 #include "umd/device/types/blackhole_eth.hpp"
 #include "umd/device/types/blackhole_l1.hpp"
 #include "umd/device/types/cluster_types.hpp"
@@ -17,11 +16,6 @@
 #include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
-
-namespace blackhole {
-constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h, common for WH && BH
-constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6;  // source: noc_parameters.h, common for WH && BH
-}  // namespace blackhole
 
 tlb_configuration BlackholeImplementation::get_tlb_configuration(uint32_t tlb_index) const {
     // If TLB index is in range for 4GB tlbs (8 TLBs after 202 TLBs for 2MB).
@@ -52,41 +46,6 @@ DeviceL1AddressParams BlackholeImplementation::get_l1_address_params() const {
     // L1 barrier base and erisc barrier base should be explicitly set by the client.
     // Setting some default values here, but it should be ultimately overridden by the client.
     return {blackhole::L1_BARRIER_BASE, blackhole::ERISC_BARRIER_BASE, blackhole::ETH_FW_VERSION_ADDR};
-}
-
-DriverHostAddressParams BlackholeImplementation::get_host_address_params() const {
-    return {
-        erisc_firmware::eth_routing::ETH_ROUTING_BLOCK_SIZE, erisc_firmware::eth_routing::ETH_ROUTING_BUFFERS_START};
-}
-
-DriverEthInterfaceParams BlackholeImplementation::get_eth_interface_params() const {
-    using namespace erisc_firmware::eth_routing;
-    return {
-        ETH_RACK_COORD_WIDTH,
-        CMD_BUF_SIZE_MASK,
-        MAX_BLOCK_SIZE,
-        REQUEST_CMD_QUEUE_BASE,
-        RESPONSE_CMD_QUEUE_BASE,
-        CMD_COUNTERS_SIZE_BYTES,
-        REMOTE_UPDATE_PTR_SIZE_BYTES,
-        CMD_DATA_BLOCK,
-        CMD_WR_REQ,
-        CMD_WR_ACK,
-        CMD_RD_REQ,
-        CMD_RD_DATA,
-        CMD_BUF_SIZE,
-        CMD_DATA_BLOCK_DRAM,
-        ETH_ROUTING_DATA_BUFFER_ADDR,
-        REQUEST_ROUTING_CMD_QUEUE_BASE,
-        RESPONSE_ROUTING_CMD_QUEUE_BASE,
-        CMD_BUF_PTR_MASK,
-        CMD_ORDERED,
-        CMD_BROADCAST,
-    };
-}
-
-DriverNocParams BlackholeImplementation::get_noc_params() const {
-    return {blackhole::NOC_ADDR_LOCAL_BITS, blackhole::NOC_ADDR_NODE_ID_BITS};
 }
 
 uint64_t BlackholeImplementation::get_noc_reg_base(

--- a/device/arch/grendel_implementation.cpp
+++ b/device/arch/grendel_implementation.cpp
@@ -9,7 +9,6 @@
 #include <cstdint>
 #include <tuple>
 
-#include "umd/device/firmware/erisc_firmware.hpp"
 #include "umd/device/types/blackhole_eth.hpp"
 #include "umd/device/types/blackhole_l1.hpp"
 #include "umd/device/types/cluster_types.hpp"
@@ -17,11 +16,6 @@
 #include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
-
-namespace grendel {
-constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h, common for WH && BH
-constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6;  // source: noc_parameters.h, common for WH && BH
-}  // namespace grendel
 
 tlb_configuration GrendelImplementation::get_tlb_configuration(uint32_t tlb_index) const {
     // If TLB index is in range for 4GB tlbs (8 TLBs after 202 TLBs for 2MB).
@@ -52,41 +46,6 @@ DeviceL1AddressParams GrendelImplementation::get_l1_address_params() const {
     // L1 barrier base and erisc barrier base should be explicitly set by the client.
     // Setting some default values here, but it should be ultimately overridden by the client.
     return {blackhole::L1_BARRIER_BASE, blackhole::ERISC_BARRIER_BASE, blackhole::ETH_FW_VERSION_ADDR};
-}
-
-DriverHostAddressParams GrendelImplementation::get_host_address_params() const {
-    return {
-        erisc_firmware::eth_routing::ETH_ROUTING_BLOCK_SIZE, erisc_firmware::eth_routing::ETH_ROUTING_BUFFERS_START};
-}
-
-DriverEthInterfaceParams GrendelImplementation::get_eth_interface_params() const {
-    using namespace erisc_firmware::eth_routing;
-    return {
-        ETH_RACK_COORD_WIDTH,
-        CMD_BUF_SIZE_MASK,
-        MAX_BLOCK_SIZE,
-        REQUEST_CMD_QUEUE_BASE,
-        RESPONSE_CMD_QUEUE_BASE,
-        CMD_COUNTERS_SIZE_BYTES,
-        REMOTE_UPDATE_PTR_SIZE_BYTES,
-        CMD_DATA_BLOCK,
-        CMD_WR_REQ,
-        CMD_WR_ACK,
-        CMD_RD_REQ,
-        CMD_RD_DATA,
-        CMD_BUF_SIZE,
-        CMD_DATA_BLOCK_DRAM,
-        ETH_ROUTING_DATA_BUFFER_ADDR,
-        REQUEST_ROUTING_CMD_QUEUE_BASE,
-        RESPONSE_ROUTING_CMD_QUEUE_BASE,
-        CMD_BUF_PTR_MASK,
-        CMD_ORDERED,
-        CMD_BROADCAST,
-    };
-}
-
-DriverNocParams GrendelImplementation::get_noc_params() const {
-    return {grendel::NOC_ADDR_LOCAL_BITS, grendel::NOC_ADDR_NODE_ID_BITS};
 }
 
 uint64_t GrendelImplementation::get_noc_reg_base(

--- a/device/arch/wormhole_implementation.cpp
+++ b/device/arch/wormhole_implementation.cpp
@@ -65,12 +65,12 @@ DeviceL1AddressParams WormholeImplementation::get_l1_address_params() const {
     return {wormhole::L1_BARRIER_BASE, wormhole::ERISC_BARRIER_BASE, wormhole::ETH_FW_VERSION_ADDR};
 }
 
-DriverHostAddressParams WormholeImplementation::get_host_address_params() const {
+DriverHostAddressParams wormhole::get_host_address_params() {
     return {
         erisc_firmware::eth_routing::ETH_ROUTING_BLOCK_SIZE, erisc_firmware::eth_routing::ETH_ROUTING_BUFFERS_START};
 }
 
-DriverEthInterfaceParams WormholeImplementation::get_eth_interface_params() const {
+DriverEthInterfaceParams wormhole::get_eth_interface_params() {
     using namespace erisc_firmware::eth_routing;
     return {
         ETH_RACK_COORD_WIDTH,
@@ -96,9 +96,7 @@ DriverEthInterfaceParams WormholeImplementation::get_eth_interface_params() cons
     };
 }
 
-DriverNocParams WormholeImplementation::get_noc_params() const {
-    return {wormhole::NOC_ADDR_LOCAL_BITS, wormhole::NOC_ADDR_NODE_ID_BITS};
-}
+DriverNocParams wormhole::get_noc_params() { return {wormhole::NOC_ADDR_LOCAL_BITS, wormhole::NOC_ADDR_NODE_ID_BITS}; }
 
 // TODO: integrate noc_port for DRAM core type inside the function.
 uint64_t WormholeImplementation::get_noc_reg_base(

--- a/device/tt_device/remote_communication_legacy_firmware.cpp
+++ b/device/tt_device/remote_communication_legacy_firmware.cpp
@@ -13,7 +13,7 @@
 #include <vector>
 
 #include "noc_access.hpp"
-#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
 #include "umd/device/driver_atomics.hpp"
 #include "umd/device/topology/topology_utils.hpp"
@@ -48,7 +48,17 @@ struct routing_cmd_t {
 
 RemoteCommunicationLegacyFirmware::RemoteCommunicationLegacyFirmware(
     TTDevice* local_tt_device, EthCoord target_chip, SysmemManager* sysmem_manager) :
-    RemoteCommunication(local_tt_device, sysmem_manager), target_chip(target_chip) {}
+    RemoteCommunication(local_tt_device, sysmem_manager),
+    target_chip(target_chip),
+    // The ETH routing firmware this class talks to only ever ran on Wormhole.
+    host_address_params_(wormhole::get_host_address_params()),
+    eth_interface_params_(wormhole::get_eth_interface_params()),
+    noc_params_(wormhole::get_noc_params()) {
+    UMD_ASSERT(
+        local_tt_device->get_arch() == tt::ARCH::WORMHOLE_B0,
+        error::RuntimeError,
+        "Legacy ETH routing firmware remote communication is supported on Wormhole only.");
+}
 
 std::optional<EthCoord> RemoteCommunicationLegacyFirmware::get_target_eth_coord() { return target_chip; }
 
@@ -114,14 +124,10 @@ void RemoteCommunicationLegacyFirmware::read_non_mmio(
     using data_word_t = uint32_t;
     constexpr int DATA_WORD_SIZE = sizeof(data_word_t);
 
-    auto host_address_params = local_tt_device_->get_architecture_implementation()->get_host_address_params();
-    auto eth_interface_params = local_tt_device_->get_architecture_implementation()->get_eth_interface_params();
-    auto noc_params = local_tt_device_->get_architecture_implementation()->get_noc_params();
-
     std::vector<std::uint32_t> erisc_command;
     std::vector<std::uint32_t> erisc_q_rptr;
     std::vector<std::uint32_t> erisc_q_ptrs =
-        std::vector<uint32_t>(eth_interface_params.remote_update_ptr_size_bytes * 2 / DATA_WORD_SIZE);
+        std::vector<uint32_t>(eth_interface_params_.remote_update_ptr_size_bytes * 2 / DATA_WORD_SIZE);
     std::vector<std::uint32_t> erisc_resp_q_wptr = std::vector<uint32_t>(1);
     std::vector<std::uint32_t> erisc_resp_q_rptr = std::vector<uint32_t>(1);
 
@@ -137,24 +143,24 @@ void RemoteCommunicationLegacyFirmware::read_non_mmio(
     local_tt_device_->read_from_device(
         erisc_q_ptrs.data(),
         remote_transfer_ethernet_core,
-        eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
-        eth_interface_params.remote_update_ptr_size_bytes * 2,
+        eth_interface_params_.request_cmd_queue_base + eth_interface_params_.cmd_counters_size_bytes,
+        eth_interface_params_.remote_update_ptr_size_bytes * 2,
         get_selected_noc_id());
     local_tt_device_->read_from_device(
         erisc_resp_q_wptr.data(),
         remote_transfer_ethernet_core,
-        eth_interface_params.response_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
+        eth_interface_params_.response_cmd_queue_base + eth_interface_params_.cmd_counters_size_bytes,
         DATA_WORD_SIZE,
         get_selected_noc_id());
     local_tt_device_->read_from_device(
         erisc_resp_q_rptr.data(),
         remote_transfer_ethernet_core,
-        eth_interface_params.response_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes +
-            eth_interface_params.remote_update_ptr_size_bytes,
+        eth_interface_params_.response_cmd_queue_base + eth_interface_params_.cmd_counters_size_bytes +
+            eth_interface_params_.remote_update_ptr_size_bytes,
         DATA_WORD_SIZE,
         get_selected_noc_id());
 
-    bool full = is_non_mmio_cmd_q_full(eth_interface_params, erisc_q_ptrs[0], erisc_q_ptrs[4]);
+    bool full = is_non_mmio_cmd_q_full(eth_interface_params_, erisc_q_ptrs[0], erisc_q_ptrs[4]);
     erisc_q_rptr.resize(1);
     erisc_q_rptr[0] = erisc_q_ptrs[4];
 
@@ -168,7 +174,7 @@ void RemoteCommunicationLegacyFirmware::read_non_mmio(
 
     // When sysmem_manager is not available, we chunk the transfer using smaller blocks.
     uint32_t max_block_size =
-        use_host_dram ? host_address_params.eth_routing_block_size : eth_interface_params.max_block_size;
+        use_host_dram ? host_address_params_.eth_routing_block_size : eth_interface_params_.max_block_size;
 
     uint32_t offset = 0;
     uint32_t block_size;
@@ -180,16 +186,16 @@ void RemoteCommunicationLegacyFirmware::read_non_mmio(
             local_tt_device_->read_from_device(
                 erisc_q_rptr.data(),
                 remote_transfer_ethernet_core,
-                eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes +
-                    eth_interface_params.remote_update_ptr_size_bytes,
+                eth_interface_params_.request_cmd_queue_base + eth_interface_params_.cmd_counters_size_bytes +
+                    eth_interface_params_.remote_update_ptr_size_bytes,
                 DATA_WORD_SIZE,
                 get_selected_noc_id());
-            full = is_non_mmio_cmd_q_full(eth_interface_params, erisc_q_ptrs[0], erisc_q_rptr[0]);
+            full = is_non_mmio_cmd_q_full(eth_interface_params_, erisc_q_ptrs[0], erisc_q_rptr[0]);
 
             utils::check_timeout(start, timeout_ms, "Timeout waiting for Ethernet core service remote IO request.");
         }
 
-        uint32_t req_wr_ptr = erisc_q_ptrs[0] & eth_interface_params.cmd_buf_size_mask;
+        uint32_t req_wr_ptr = erisc_q_ptrs[0] & eth_interface_params_.cmd_buf_size_mask;
         if ((core_src + offset) & 0x1F) {  // address not 32-byte aligned
             block_size = DATA_WORD_SIZE;   // 4 byte aligned block
         } else {
@@ -199,28 +205,28 @@ void RemoteCommunicationLegacyFirmware::read_non_mmio(
             block_size = (block_size + alignment_mask) & ~alignment_mask;
         }
         uint32_t req_flags = block_size > DATA_WORD_SIZE
-                                 ? (eth_interface_params.cmd_data_block | eth_interface_params.cmd_rd_req)
-                                 : eth_interface_params.cmd_rd_req;
+                                 ? (eth_interface_params_.cmd_data_block | eth_interface_params_.cmd_rd_req)
+                                 : eth_interface_params_.cmd_rd_req;
         uint32_t resp_flags = block_size > DATA_WORD_SIZE
-                                  ? (eth_interface_params.cmd_data_block | eth_interface_params.cmd_rd_data)
-                                  : eth_interface_params.cmd_rd_data;
-        uint32_t resp_rd_ptr = erisc_resp_q_rptr[0] & eth_interface_params.cmd_buf_size_mask;
-        uint32_t host_dram_block_addr = host_address_params.eth_routing_buffers_start + resp_rd_ptr * max_block_size;
+                                  ? (eth_interface_params_.cmd_data_block | eth_interface_params_.cmd_rd_data)
+                                  : eth_interface_params_.cmd_rd_data;
+        uint32_t resp_rd_ptr = erisc_resp_q_rptr[0] & eth_interface_params_.cmd_buf_size_mask;
+        uint32_t host_dram_block_addr = host_address_params_.eth_routing_buffers_start + resp_rd_ptr * max_block_size;
         uint16_t host_dram_channel = 0;  // This needs to be 0, since WH can only map ETH buffers to chan 0.
 
         if (use_host_dram && block_size > DATA_WORD_SIZE) {
-            req_flags |= eth_interface_params.cmd_data_block_dram;
-            resp_flags |= eth_interface_params.cmd_data_block_dram;
+            req_flags |= eth_interface_params_.cmd_data_block_dram;
+            resp_flags |= eth_interface_params_.cmd_data_block_dram;
         }
 
         // Send the read request.
         UMD_ASSERT(
-            (req_flags == eth_interface_params.cmd_rd_req) || (((core_src + offset) & 0x1F) == 0),
+            (req_flags == eth_interface_params_.cmd_rd_req) || (((core_src + offset) & 0x1F) == 0),
             error::RuntimeError,
             "Block mode offset must be 32-byte aligned.");  // Block mode offset must be 32-byte aligned.
         new_cmd->sys_addr =
-            get_sys_addr(noc_params, target_chip.x, target_chip.y, target_core.x, target_core.y, core_src + offset);
-        new_cmd->rack = get_sys_rack(eth_interface_params, target_chip.rack, target_chip.shelf);
+            get_sys_addr(noc_params_, target_chip.x, target_chip.y, target_core.x, target_core.y, core_src + offset);
+        new_cmd->rack = get_sys_rack(eth_interface_params_, target_chip.rack, target_chip.shelf);
         new_cmd->data = block_size;
         new_cmd->flags = req_flags;
         new_cmd->flags |= (is_selected_noc1() ? 1 : 0) << REMOTE_CMD_NOC_BIT;
@@ -230,19 +236,19 @@ void RemoteCommunicationLegacyFirmware::read_non_mmio(
         local_tt_device_->write_to_device(
             erisc_command.data(),
             remote_transfer_ethernet_core,
-            eth_interface_params.request_routing_cmd_queue_base + (sizeof(routing_cmd_t) * req_wr_ptr),
+            eth_interface_params_.request_routing_cmd_queue_base + (sizeof(routing_cmd_t) * req_wr_ptr),
             erisc_command.size() * DATA_WORD_SIZE,
             get_selected_noc_id());
         tt_driver_atomics::sfence();
 
-        erisc_q_ptrs[0] = (erisc_q_ptrs[0] + 1) & eth_interface_params.cmd_buf_ptr_mask;
+        erisc_q_ptrs[0] = (erisc_q_ptrs[0] + 1) & eth_interface_params_.cmd_buf_ptr_mask;
         std::vector<std::uint32_t> erisc_q_wptr;
         erisc_q_wptr.resize(1);
         erisc_q_wptr[0] = erisc_q_ptrs[0];
         local_tt_device_->write_to_device(
             erisc_q_wptr.data(),
             remote_transfer_ethernet_core,
-            eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
+            eth_interface_params_.request_cmd_queue_base + eth_interface_params_.cmd_counters_size_bytes,
             erisc_q_wptr.size() * DATA_WORD_SIZE,
             get_selected_noc_id());
         tt_driver_atomics::sfence();
@@ -251,14 +257,14 @@ void RemoteCommunicationLegacyFirmware::read_non_mmio(
         // As long as current command push does not fill up the queue completely, we do not want
         // to poll rd pointer in every iteration.
 
-        if (is_non_mmio_cmd_q_full(eth_interface_params, (erisc_q_ptrs[0]), erisc_q_rptr[0])) {
+        if (is_non_mmio_cmd_q_full(eth_interface_params_, (erisc_q_ptrs[0]), erisc_q_rptr[0])) {
             local_tt_device_->read_from_device(
                 erisc_q_ptrs.data(),
                 remote_transfer_ethernet_core,
-                eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
-                eth_interface_params.remote_update_ptr_size_bytes * 2,
+                eth_interface_params_.request_cmd_queue_base + eth_interface_params_.cmd_counters_size_bytes,
+                eth_interface_params_.remote_update_ptr_size_bytes * 2,
                 get_selected_noc_id());
-            full = is_non_mmio_cmd_q_full(eth_interface_params, erisc_q_ptrs[0], erisc_q_ptrs[4]);
+            full = is_non_mmio_cmd_q_full(eth_interface_params_, erisc_q_ptrs[0], erisc_q_ptrs[4]);
             erisc_q_rptr[0] = erisc_q_ptrs[4];
         }
 
@@ -276,7 +282,7 @@ void RemoteCommunicationLegacyFirmware::read_non_mmio(
             local_tt_device_->read_from_device(
                 erisc_resp_q_wptr.data(),
                 remote_transfer_ethernet_core,
-                eth_interface_params.response_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
+                eth_interface_params_.response_cmd_queue_base + eth_interface_params_.cmd_counters_size_bytes,
                 DATA_WORD_SIZE,
                 get_selected_noc_id());
 
@@ -291,7 +297,7 @@ void RemoteCommunicationLegacyFirmware::read_non_mmio(
             local_tt_device_->read_from_device(
                 erisc_resp_flags.data(),
                 remote_transfer_ethernet_core,
-                eth_interface_params.response_routing_cmd_queue_base + flags_offset,
+                eth_interface_params_.response_routing_cmd_queue_base + flags_offset,
                 DATA_WORD_SIZE,
                 get_selected_noc_id());
 
@@ -306,7 +312,7 @@ void RemoteCommunicationLegacyFirmware::read_non_mmio(
                 local_tt_device_->read_from_device(
                     erisc_resp_data.data(),
                     remote_transfer_ethernet_core,
-                    eth_interface_params.response_routing_cmd_queue_base + data_offset,
+                    eth_interface_params_.response_routing_cmd_queue_base + data_offset,
                     DATA_WORD_SIZE,
                     get_selected_noc_id());
                 if (size_in_bytes - offset < 4) {
@@ -324,7 +330,7 @@ void RemoteCommunicationLegacyFirmware::read_non_mmio(
                         host_dram_channel, data_block.data(), host_dram_block_addr, block_size);
                 } else {
                     uint32_t buf_address =
-                        eth_interface_params.eth_routing_data_buffer_addr + resp_rd_ptr * max_block_size;
+                        eth_interface_params_.eth_routing_data_buffer_addr + resp_rd_ptr * max_block_size;
                     size_buffer_to_capacity(data_block, block_size);
                     local_tt_device_->read_from_device(
                         data_block.data(),
@@ -347,12 +353,12 @@ void RemoteCommunicationLegacyFirmware::read_non_mmio(
         }
 
         // Finally increment the rdptr for the response command q.
-        erisc_resp_q_rptr[0] = (erisc_resp_q_rptr[0] + 1) & eth_interface_params.cmd_buf_ptr_mask;
+        erisc_resp_q_rptr[0] = (erisc_resp_q_rptr[0] + 1) & eth_interface_params_.cmd_buf_ptr_mask;
         local_tt_device_->write_to_device(
             erisc_resp_q_rptr.data(),
             remote_transfer_ethernet_core,
-            eth_interface_params.response_cmd_queue_base + sizeof(remote_update_ptr_t) +
-                eth_interface_params.cmd_counters_size_bytes,
+            eth_interface_params_.response_cmd_queue_base + sizeof(remote_update_ptr_t) +
+                eth_interface_params_.cmd_counters_size_bytes,
             erisc_resp_q_rptr.size() * DATA_WORD_SIZE,
             get_selected_noc_id());
         tt_driver_atomics::sfence();
@@ -383,14 +389,10 @@ void RemoteCommunicationLegacyFirmware::write_to_non_mmio(
     constexpr int DATA_WORD_SIZE = sizeof(data_word_t);
     constexpr int BROADCAST_HEADER_SIZE = sizeof(data_word_t) * 8;  // Broadcast header is 8 words
 
-    auto host_address_params = local_tt_device_->get_architecture_implementation()->get_host_address_params();
-    auto eth_interface_params = local_tt_device_->get_architecture_implementation()->get_eth_interface_params();
-    auto noc_params = local_tt_device_->get_architecture_implementation()->get_noc_params();
-
     std::vector<std::uint32_t> erisc_command;
     std::vector<std::uint32_t> erisc_q_rptr = std::vector<uint32_t>(1);
     std::vector<std::uint32_t> erisc_q_ptrs =
-        std::vector<uint32_t>(eth_interface_params.remote_update_ptr_size_bytes * 2 / sizeof(uint32_t));
+        std::vector<uint32_t>(eth_interface_params_.remote_update_ptr_size_bytes * 2 / sizeof(uint32_t));
 
     std::vector<std::uint32_t> data_block;
 
@@ -411,7 +413,7 @@ void RemoteCommunicationLegacyFirmware::write_to_non_mmio(
     UMD_ASSERT(
         !broadcast || system_mem_available, error::RuntimeError, "Broadcasts not available without system memory.");
     uint32_t max_block_size =
-        use_host_dram ? host_address_params.eth_routing_block_size : eth_interface_params.max_block_size;
+        use_host_dram ? host_address_params_.eth_routing_block_size : eth_interface_params_.max_block_size;
 
     tt_xy_pair remote_transfer_ethernet_core = get_remote_transfer_ethernet_core();
 
@@ -420,13 +422,13 @@ void RemoteCommunicationLegacyFirmware::write_to_non_mmio(
     local_tt_device_->read_from_device(
         erisc_q_ptrs.data(),
         remote_transfer_ethernet_core,
-        eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
-        eth_interface_params.remote_update_ptr_size_bytes * 2,
+        eth_interface_params_.request_cmd_queue_base + eth_interface_params_.cmd_counters_size_bytes,
+        eth_interface_params_.remote_update_ptr_size_bytes * 2,
         get_selected_noc_id());
     uint32_t offset = 0;
     uint32_t block_size;
 
-    bool full = is_non_mmio_cmd_q_full(eth_interface_params, erisc_q_ptrs[0], erisc_q_ptrs[4]);
+    bool full = is_non_mmio_cmd_q_full(eth_interface_params_, erisc_q_ptrs[0], erisc_q_ptrs[4]);
     erisc_q_rptr.resize(1);
     erisc_q_rptr[0] = erisc_q_ptrs[4];
 
@@ -437,11 +439,11 @@ void RemoteCommunicationLegacyFirmware::write_to_non_mmio(
             local_tt_device_->read_from_device(
                 erisc_q_rptr.data(),
                 remote_transfer_ethernet_core,
-                eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes +
-                    eth_interface_params.remote_update_ptr_size_bytes,
+                eth_interface_params_.request_cmd_queue_base + eth_interface_params_.cmd_counters_size_bytes +
+                    eth_interface_params_.remote_update_ptr_size_bytes,
                 DATA_WORD_SIZE,
                 get_selected_noc_id());
-            full = is_non_mmio_cmd_q_full(eth_interface_params, erisc_q_ptrs[0], erisc_q_rptr[0]);
+            full = is_non_mmio_cmd_q_full(eth_interface_params_, erisc_q_ptrs[0], erisc_q_rptr[0]);
 
             utils::check_timeout(start, timeout_ms, "Timeout waiting for Ethernet core service remote IO request.");
         }
@@ -452,7 +454,7 @@ void RemoteCommunicationLegacyFirmware::write_to_non_mmio(
         //  to poll rd pointer in every iteration.
         // full = is_non_mmio_cmd_q_full((erisc_q_ptrs[0] + 1) & CMD_BUF_PTR_MASK, erisc_q_rptr[0]);
 
-        uint32_t req_wr_ptr = erisc_q_ptrs[0] & eth_interface_params.cmd_buf_size_mask;
+        uint32_t req_wr_ptr = erisc_q_ptrs[0] & eth_interface_params_.cmd_buf_size_mask;
         if ((core_dest + offset) & 0x1F) {  // address not 32-byte aligned
             block_size = DATA_WORD_SIZE;    // 4 byte aligned
         } else {
@@ -469,23 +471,23 @@ void RemoteCommunicationLegacyFirmware::write_to_non_mmio(
             std::min(block_size, size_in_bytes - offset);  // Host side data size that needs to be copied
         // Use block mode for broadcast.
         uint32_t req_flags = (broadcast || (block_size > DATA_WORD_SIZE))
-                                 ? (eth_interface_params.cmd_data_block | eth_interface_params.cmd_wr_req | timestamp)
-                                 : eth_interface_params.cmd_wr_req;
+                                 ? (eth_interface_params_.cmd_data_block | eth_interface_params_.cmd_wr_req | timestamp)
+                                 : eth_interface_params_.cmd_wr_req;
         timestamp = 0;
 
         if (broadcast) {
-            req_flags |= eth_interface_params.cmd_broadcast;
+            req_flags |= eth_interface_params_.cmd_broadcast;
         }
 
         uint32_t host_dram_block_addr =
-            host_address_params.eth_routing_buffers_start +
-            (active_eth_core_idx * eth_interface_params.cmd_buf_size + req_wr_ptr) * max_block_size;
+            host_address_params_.eth_routing_buffers_start +
+            (active_eth_core_idx * eth_interface_params_.cmd_buf_size + req_wr_ptr) * max_block_size;
         uint16_t host_dram_channel = 0;  // This needs to be 0, since WH can only map ETH buffers to chan 0.
 
-        if (req_flags & eth_interface_params.cmd_data_block) {
+        if (req_flags & eth_interface_params_.cmd_data_block) {
             // Copy data to sysmem or device DRAM for Block mode.
             if (use_host_dram) {
-                req_flags |= eth_interface_params.cmd_data_block_dram;
+                req_flags |= eth_interface_params_.cmd_data_block_dram;
                 size_buffer_to_capacity(data_block, block_size);
                 memcpy(data_block.data(), static_cast<const uint8_t*>(src) + offset, transfer_size);
                 if (broadcast) {
@@ -504,7 +506,7 @@ void RemoteCommunicationLegacyFirmware::write_to_non_mmio(
                     data_block.size() * DATA_WORD_SIZE);
 
             } else {
-                uint32_t buf_address = eth_interface_params.eth_routing_data_buffer_addr + req_wr_ptr * max_block_size;
+                uint32_t buf_address = eth_interface_params_.eth_routing_data_buffer_addr + req_wr_ptr * max_block_size;
                 size_buffer_to_capacity(data_block, block_size);
                 memcpy(data_block.data(), static_cast<const uint8_t*>(src) + offset, transfer_size);
                 local_tt_device_->write_to_device(
@@ -519,7 +521,7 @@ void RemoteCommunicationLegacyFirmware::write_to_non_mmio(
 
         // Send the read request.
         UMD_ASSERT(
-            broadcast || (req_flags == eth_interface_params.cmd_wr_req) || (((core_dest + offset) % 32) == 0),
+            broadcast || (req_flags == eth_interface_params_.cmd_wr_req) || (((core_dest + offset) % 32) == 0),
             error::RuntimeError,
             "Block mode address must be 32-byte aligned.");  // Block mode address must be 32-byte aligned.
 
@@ -528,11 +530,11 @@ void RemoteCommunicationLegacyFirmware::write_to_non_mmio(
             new_cmd->sys_addr = core_dest + offset;
         } else {
             new_cmd->sys_addr = get_sys_addr(
-                noc_params, target_chip.x, target_chip.y, target_core.x, target_core.y, core_dest + offset);
-            new_cmd->rack = get_sys_rack(eth_interface_params, target_chip.rack, target_chip.shelf);
+                noc_params_, target_chip.x, target_chip.y, target_core.x, target_core.y, core_dest + offset);
+            new_cmd->rack = get_sys_rack(eth_interface_params_, target_chip.rack, target_chip.shelf);
         }
 
-        if (req_flags & eth_interface_params.cmd_data_block) {
+        if (req_flags & eth_interface_params_.cmd_data_block) {
             // Block mode.
             new_cmd->data = block_size + BROADCAST_HEADER_SIZE * broadcast;
         } else {
@@ -553,19 +555,19 @@ void RemoteCommunicationLegacyFirmware::write_to_non_mmio(
         local_tt_device_->write_to_device(
             erisc_command.data(),
             remote_transfer_ethernet_core,
-            eth_interface_params.request_routing_cmd_queue_base + (sizeof(routing_cmd_t) * req_wr_ptr),
+            eth_interface_params_.request_routing_cmd_queue_base + (sizeof(routing_cmd_t) * req_wr_ptr),
             erisc_command.size() * DATA_WORD_SIZE,
             get_selected_noc_id());
         tt_driver_atomics::sfence();
 
-        erisc_q_ptrs[0] = (erisc_q_ptrs[0] + 1) & eth_interface_params.cmd_buf_ptr_mask;
+        erisc_q_ptrs[0] = (erisc_q_ptrs[0] + 1) & eth_interface_params_.cmd_buf_ptr_mask;
         std::vector<std::uint32_t> erisc_q_wptr;
         erisc_q_wptr.resize(1);
         erisc_q_wptr[0] = erisc_q_ptrs[0];
         local_tt_device_->write_to_device(
             erisc_q_wptr.data(),
             remote_transfer_ethernet_core,
-            eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
+            eth_interface_params_.request_cmd_queue_base + eth_interface_params_.cmd_counters_size_bytes,
             erisc_q_wptr.size() * DATA_WORD_SIZE,
             get_selected_noc_id());
         tt_driver_atomics::sfence();
@@ -578,16 +580,16 @@ void RemoteCommunicationLegacyFirmware::write_to_non_mmio(
         // to poll rd pointer in every iteration.
 
         if (is_non_mmio_cmd_q_full(
-                eth_interface_params, (erisc_q_ptrs[0]) & eth_interface_params.cmd_buf_ptr_mask, erisc_q_rptr[0])) {
+                eth_interface_params_, (erisc_q_ptrs[0]) & eth_interface_params_.cmd_buf_ptr_mask, erisc_q_rptr[0])) {
             update_active_eth_core_idx();
             remote_transfer_ethernet_core = get_remote_transfer_ethernet_core();
             local_tt_device_->read_from_device(
                 erisc_q_ptrs.data(),
                 remote_transfer_ethernet_core,
-                eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
-                eth_interface_params.remote_update_ptr_size_bytes * 2,
+                eth_interface_params_.request_cmd_queue_base + eth_interface_params_.cmd_counters_size_bytes,
+                eth_interface_params_.remote_update_ptr_size_bytes * 2,
                 get_selected_noc_id());
-            full = is_non_mmio_cmd_q_full(eth_interface_params, erisc_q_ptrs[0], erisc_q_ptrs[4]);
+            full = is_non_mmio_cmd_q_full(eth_interface_params_, erisc_q_ptrs[0], erisc_q_ptrs[4]);
             erisc_q_rptr[0] = erisc_q_ptrs[4];
         }
     }
@@ -601,11 +603,9 @@ void RemoteCommunicationLegacyFirmware::wait_for_non_mmio_flush(const std::chron
             "Non-MMIO flush not supported in Blackhole");
 
         if (local_tt_device_->get_arch() == tt::ARCH::WORMHOLE_B0) {
-            auto eth_interface_params = local_tt_device_->get_architecture_implementation()->get_eth_interface_params();
-
             std::vector<std::uint32_t> erisc_txn_counters = std::vector<uint32_t>(2);
             std::vector<std::uint32_t> erisc_q_ptrs =
-                std::vector<uint32_t>(eth_interface_params.remote_update_ptr_size_bytes * 2 / sizeof(uint32_t));
+                std::vector<uint32_t>(eth_interface_params_.remote_update_ptr_size_bytes * 2 / sizeof(uint32_t));
 
             // wait for all queues to be empty.
             for (tt_xy_pair& core : remote_transfer_eth_cores_) {
@@ -615,8 +615,8 @@ void RemoteCommunicationLegacyFirmware::wait_for_non_mmio_flush(const std::chron
                     local_tt_device_->read_from_device(
                         erisc_q_ptrs.data(),
                         core,
-                        eth_interface_params.request_cmd_queue_base + eth_interface_params.cmd_counters_size_bytes,
-                        eth_interface_params.remote_update_ptr_size_bytes * 2,
+                        eth_interface_params_.request_cmd_queue_base + eth_interface_params_.cmd_counters_size_bytes,
+                        eth_interface_params_.remote_update_ptr_size_bytes * 2,
                         get_selected_noc_id());
 
                     utils::check_timeout(
@@ -631,7 +631,7 @@ void RemoteCommunicationLegacyFirmware::wait_for_non_mmio_flush(const std::chron
                     local_tt_device_->read_from_device(
                         erisc_txn_counters.data(),
                         core,
-                        eth_interface_params.request_cmd_queue_base,
+                        eth_interface_params_.request_cmd_queue_base,
                         8,
                         get_selected_noc_id());
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2873

### Description
Stacked on #3192.

`get_host_address_params`, `get_eth_interface_params` and `get_noc_params` describe the
legacy ETH routing firmware protocol, which only ever ran on Wormhole. Their single
consumer is `RemoteCommunicationLegacyFirmware`. Blackhole and Grendel carried copies of
these which nothing ever called, so they are deleted rather than moved.

The params are now read once in the constructor instead of on every remote read/write -
before this each `read_non_mmio`/`write_to_non_mmio` call rebuilt all three structs.

### List of the changes
- Remove `get_host_address_params`, `get_eth_interface_params` and `get_noc_params` from
  `ArchitectureImplementation`.
- Declare and define them in the `wormhole` namespace instead, bodies unchanged.
- Delete the Blackhole and Grendel copies, together with their now unused
  `NOC_ADDR_LOCAL_BITS` / `NOC_ADDR_NODE_ID_BITS` constants and `erisc_firmware.hpp` include.
- `RemoteCommunicationLegacyFirmware` keeps the three param structs as const members,
  initialized in the constructor.
- Assert in the `RemoteCommunicationLegacyFirmware` constructor that the local device is
  Wormhole, since that is the only architecture this path is valid for.

### Testing
Code builds. Existing CI over WH remote guards unintentional function changes.

### API Changes
This PR has API changes, three methods removed from `ArchitectureImplementation` and moved
to the `wormhole` namespace. Doesn't break anyone externally.


### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/arch_impl_11
