### PR TITLE
Move ARC register offsets to ArchitectureRegisters

### DIFF
--- a/device/api/umd/device/arch/architecture_implementation.hpp
+++ b/device/api/umd/device/arch/architecture_implementation.hpp
@@ -32,16 +32,8 @@ public:
     virtual ~ArchitectureImplementation() = default;
 
     virtual tt::ARCH get_architecture() const = 0;
-    virtual uint32_t get_arc_message_arc_get_harvesting() const = 0;
     virtual uint32_t get_arc_message_arc_go_busy() const = 0;
     virtual uint32_t get_arc_message_arc_go_long_idle() const = 0;
-    virtual uint32_t get_arc_message_deassert_riscv_reset() const = 0;
-    virtual uint32_t get_arc_message_get_aiclk() const = 0;
-    virtual uint32_t get_arc_message_setup_iatu_for_peer_to_peer() const = 0;
-    virtual uint32_t get_arc_csm_bar0_mailbox_offset() const = 0;
-    virtual uint32_t get_arc_axi_apb_peripheral_offset() const = 0;
-    virtual uint32_t get_arc_reset_scratch_offset() const = 0;
-    virtual uint32_t get_arc_reset_scratch_2_offset() const = 0;
     virtual uint32_t get_arc_reset_unit_refclk_low_offset() const = 0;
     virtual uint32_t get_arc_reset_unit_refclk_high_offset() const = 0;
     virtual uint32_t get_dram_banks_number() const = 0;
@@ -51,8 +43,6 @@ public:
     virtual uint32_t get_soft_reset_reg_value(RiscType risc_type) const = 0;
     virtual RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const = 0;
     virtual uint32_t get_soft_reset_staggered_start() const = 0;
-    virtual uint64_t get_arc_apb_noc_base_address() const = 0;
-    virtual uint64_t get_arc_csm_noc_base_address() const = 0;
     // Replace with std::span once we enable C++20.
     virtual const std::vector<uint32_t>& get_harvesting_noc_locations() const = 0;
     virtual const std::vector<uint32_t>& get_t6_x_locations() const = 0;

--- a/device/api/umd/device/arch/architecture_registers.hpp
+++ b/device/api/umd/device/arch/architecture_registers.hpp
@@ -21,6 +21,13 @@ using NocRegAddrResolver = uint64_t (*)(CoreType core_type, uint32_t noc, uint32
 // different addresses. Architecture specific code reads its own constants directly; this exists for
 // callers which are not tied to one architecture.
 struct ArchitectureRegisters {
+    uint32_t arc_apb_bar0_offset;
+    uint32_t arc_csm_bar0_mailbox_offset;
+    // ARC reset unit scratch registers, relative to the APB window.
+    uint32_t arc_reset_scratch_offset;
+    uint32_t arc_reset_scratch_2_offset;
+    uint64_t arc_apb_noc_base_address;
+
     // BAR0 offset of the NOC0 node id register. Reachable before the NOC is up, which is what makes
     // it usable as the bus hang check.
     uint32_t noc_node_id_bar_offset;

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -335,10 +335,6 @@ class BlackholeImplementation : public ArchitectureImplementation {
 public:
     tt::ARCH get_architecture() const override { return tt::ARCH::BLACKHOLE; }
 
-    uint32_t get_arc_message_arc_get_harvesting() const override {
-        return static_cast<uint32_t>(blackhole::arc_message_type::ARC_GET_HARVESTING);
-    }
-
     uint32_t get_arc_message_arc_go_busy() const override {
         return static_cast<uint32_t>(blackhole::arc_message_type::ARC_GO_BUSY);
     }
@@ -346,28 +342,6 @@ public:
     uint32_t get_arc_message_arc_go_long_idle() const override {
         return static_cast<uint32_t>(blackhole::arc_message_type::ARC_GO_LONG_IDLE);
     }
-
-    uint32_t get_arc_message_deassert_riscv_reset() const override {
-        return static_cast<uint32_t>(blackhole::arc_message_type::DEASSERT_RISCV_RESET);
-    }
-
-    uint32_t get_arc_message_get_aiclk() const override {
-        return static_cast<uint32_t>(blackhole::arc_message_type::GET_AICLK);
-    }
-
-    uint32_t get_arc_message_setup_iatu_for_peer_to_peer() const override {
-        return static_cast<uint32_t>(blackhole::arc_message_type::SETUP_IATU_FOR_PEER_TO_PEER);
-    }
-
-    uint32_t get_arc_csm_bar0_mailbox_offset() const override {
-        UMD_THROW(error::RuntimeError, "Not implemented for Blackhole architecture.");
-    }
-
-    uint32_t get_arc_axi_apb_peripheral_offset() const override { return blackhole::ARC_APB_BAR0_XBAR_OFFSET_START; }
-
-    uint32_t get_arc_reset_scratch_offset() const override { return blackhole::ARC_RESET_SCRATCH_OFFSET; }
-
-    uint32_t get_arc_reset_scratch_2_offset() const override { return blackhole::ARC_RESET_SCRATCH_2_OFFSET; }
 
     uint32_t get_arc_reset_unit_refclk_low_offset() const override { return blackhole::ARC_RESET_REFCLK_LOW_OFFSET; }
 
@@ -386,12 +360,6 @@ public:
     RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const override;
 
     uint32_t get_soft_reset_staggered_start() const override { return blackhole::SOFT_RESET_STAGGERED_START; }
-
-    uint64_t get_arc_apb_noc_base_address() const override { return blackhole::ARC_NOC_XBAR_ADDRESS_START; }
-
-    uint64_t get_arc_csm_noc_base_address() const override {
-        UMD_THROW(error::RuntimeError, "CSM fetch base address not implemented for Blackhole architecture.");
-    }
 
     const std::vector<uint32_t>& get_harvesting_noc_locations() const override {
         return blackhole::HARVESTING_NOC_LOCATIONS;

--- a/device/api/umd/device/arch/grendel_implementation.hpp
+++ b/device/api/umd/device/arch/grendel_implementation.hpp
@@ -326,10 +326,6 @@ class GrendelImplementation : public ArchitectureImplementation {
 public:
     tt::ARCH get_architecture() const override { return tt::ARCH::QUASAR; }
 
-    uint32_t get_arc_message_arc_get_harvesting() const override {
-        return static_cast<uint32_t>(grendel::arc_message_type::ARC_GET_HARVESTING);
-    }
-
     uint32_t get_arc_message_arc_go_busy() const override {
         return static_cast<uint32_t>(grendel::arc_message_type::ARC_GO_BUSY);
     }
@@ -337,28 +333,6 @@ public:
     uint32_t get_arc_message_arc_go_long_idle() const override {
         return static_cast<uint32_t>(grendel::arc_message_type::ARC_GO_LONG_IDLE);
     }
-
-    uint32_t get_arc_message_deassert_riscv_reset() const override {
-        return static_cast<uint32_t>(grendel::arc_message_type::DEASSERT_RISCV_RESET);
-    }
-
-    uint32_t get_arc_message_get_aiclk() const override {
-        return static_cast<uint32_t>(grendel::arc_message_type::GET_AICLK);
-    }
-
-    uint32_t get_arc_message_setup_iatu_for_peer_to_peer() const override {
-        return static_cast<uint32_t>(grendel::arc_message_type::SETUP_IATU_FOR_PEER_TO_PEER);
-    }
-
-    uint32_t get_arc_csm_bar0_mailbox_offset() const override {
-        UMD_THROW(error::RuntimeError, "Not implemented for Grendel architecture.");
-    }
-
-    uint32_t get_arc_axi_apb_peripheral_offset() const override { return grendel::ARC_APB_BAR0_XBAR_OFFSET_START; }
-
-    uint32_t get_arc_reset_scratch_offset() const override { return grendel::ARC_RESET_SCRATCH_OFFSET; }
-
-    uint32_t get_arc_reset_scratch_2_offset() const override { return grendel::ARC_RESET_SCRATCH_2_OFFSET; }
 
     uint32_t get_arc_reset_unit_refclk_low_offset() const override { return grendel::ARC_RESET_REFCLK_LOW_OFFSET; }
 
@@ -379,12 +353,6 @@ public:
     uint32_t get_soft_reset_staggered_start() const override {
         return 0;
     }  // grendel does not support staggered start ??
-
-    uint64_t get_arc_apb_noc_base_address() const override { return grendel::ARC_NOC_XBAR_ADDRESS_START; }
-
-    uint64_t get_arc_csm_noc_base_address() const override {
-        UMD_THROW(error::RuntimeError, "CSM fetch base address not implemented for Grendel architecture.");
-    }
 
     const std::vector<uint32_t>& get_harvesting_noc_locations() const override {
         return grendel::HARVESTING_NOC_LOCATIONS;

--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -255,6 +255,7 @@ inline constexpr uint32_t ARC_CSM_NOC_XBAR_OFFSET_END = 0x1007FFFF;
 inline constexpr uint32_t ARC_CSM_ADDRESS_RANGE = ARC_CSM_NOC_XBAR_OFFSET_END - ARC_CSM_NOC_XBAR_OFFSET_START;
 
 inline constexpr uint32_t ARC_CSM_MAILBOX_OFFSET = 0x783C4;
+inline constexpr uint32_t ARC_CSM_BAR0_MAILBOX_OFFSET = ARC_CSM_BAR0_XBAR_OFFSET_START + ARC_CSM_MAILBOX_OFFSET;
 inline constexpr uint32_t ARC_CSM_MAILBOX_SIZE_OFFSET = 0x784C4;
 inline constexpr uint32_t ARC_CSM_ARC_PCIE_DMA_REQUEST = 0x784D4;
 
@@ -305,6 +306,8 @@ inline constexpr uint32_t ARC_RESET_REFCLK_HIGH_OFFSET = ARC_RESET_UNIT_OFFSET +
 inline constexpr uint32_t ARC_RESET_ARC_MISC_CNTL_OFFSET = ARC_RESET_UNIT_OFFSET + 0x0100;
 
 inline constexpr uint64_t ARC_NOC_ADDRESS_START = 0x800000000;
+inline constexpr uint64_t ARC_APB_NOC_BASE_ADDRESS = ARC_NOC_ADDRESS_START + ARC_APB_NOC_XBAR_OFFSET_START;
+inline constexpr uint64_t ARC_CSM_NOC_BASE_ADDRESS = ARC_NOC_ADDRESS_START + ARC_CSM_NOC_XBAR_OFFSET_START;
 
 inline constexpr uint64_t ARC_RESET_SCRATCH_ADDR = 0x880030060;
 inline constexpr uint64_t ARC_RESET_MISC_CNTL_ADDR = 0x880030100;
@@ -389,10 +392,6 @@ class WormholeImplementation : public ArchitectureImplementation {
 public:
     tt::ARCH get_architecture() const override { return tt::ARCH::WORMHOLE_B0; }
 
-    uint32_t get_arc_message_arc_get_harvesting() const override {
-        return static_cast<uint32_t>(wormhole::arc_message_type::ARC_GET_HARVESTING);
-    }
-
     uint32_t get_arc_message_arc_go_busy() const override {
         return static_cast<uint32_t>(wormhole::arc_message_type::ARC_GO_BUSY);
     }
@@ -400,28 +399,6 @@ public:
     uint32_t get_arc_message_arc_go_long_idle() const override {
         return static_cast<uint32_t>(wormhole::arc_message_type::ARC_GO_LONG_IDLE);
     }
-
-    uint32_t get_arc_message_deassert_riscv_reset() const override {
-        return static_cast<uint32_t>(wormhole::arc_message_type::DEASSERT_RISCV_RESET);
-    }
-
-    uint32_t get_arc_message_get_aiclk() const override {
-        return static_cast<uint32_t>(wormhole::arc_message_type::GET_AICLK);
-    }
-
-    uint32_t get_arc_message_setup_iatu_for_peer_to_peer() const override {
-        return static_cast<uint32_t>(wormhole::arc_message_type::SETUP_IATU_FOR_PEER_TO_PEER);
-    }
-
-    uint32_t get_arc_csm_bar0_mailbox_offset() const override {
-        return wormhole::ARC_CSM_BAR0_XBAR_OFFSET_START + wormhole::ARC_CSM_MAILBOX_OFFSET;
-    }
-
-    uint32_t get_arc_axi_apb_peripheral_offset() const override { return wormhole::ARC_APB_BAR0_XBAR_OFFSET_START; }
-
-    uint32_t get_arc_reset_scratch_offset() const override { return wormhole::ARC_RESET_SCRATCH_OFFSET; }
-
-    uint32_t get_arc_reset_scratch_2_offset() const override { return wormhole::ARC_RESET_SCRATCH_2_OFFSET; }
 
     uint32_t get_arc_reset_unit_refclk_low_offset() const override { return wormhole::ARC_RESET_REFCLK_LOW_OFFSET; }
 
@@ -440,14 +417,6 @@ public:
     RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const override;
 
     uint32_t get_soft_reset_staggered_start() const override { return wormhole::SOFT_RESET_STAGGERED_START; }
-
-    uint64_t get_arc_apb_noc_base_address() const override {
-        return wormhole::ARC_NOC_ADDRESS_START + wormhole::ARC_APB_NOC_XBAR_OFFSET_START;
-    }
-
-    uint64_t get_arc_csm_noc_base_address() const override {
-        return wormhole::ARC_NOC_ADDRESS_START + wormhole::ARC_CSM_NOC_XBAR_OFFSET_START;
-    }
 
     const std::vector<uint32_t>& get_harvesting_noc_locations() const override {
         return wormhole::HARVESTING_NOC_LOCATIONS;

--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -12,6 +12,7 @@
 #include <set>
 
 #include "umd/device/arc/blackhole_arc_telemetry_reader.hpp"
+#include "umd/device/arch/architecture_registers.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/blackhole_eth.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -72,7 +73,11 @@ protected:
 
     void set_arc_coordinate() override;
 
+    void probe_arc() override;
+
 private:
+    const ArchitectureRegisters registers_ = get_architecture_registers(tt::ARCH::BLACKHOLE);
+
     int get_pcie_x_coordinate();
 
     friend std::unique_ptr<TTDevice> TTDevice::create(

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -576,9 +576,11 @@ protected:
 
     virtual void set_arc_coordinate() {}
 
-private:
-    void probe_arc();
+    // TODO: temporary. The register to probe is architecture specific, so only the concrete devices
+    // can implement it. Goes away once DeviceFirmware::init_firmware owns ARC startup.
+    virtual void probe_arc() {}
 
+private:
     void log_aiclk_timeout_warning(uint32_t target_aiclk, std::chrono::milliseconds timeout_ms);
 
     void assign_soc_arch_descriptor(const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <mutex>
 
+#include "umd/device/arch/architecture_registers.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -69,7 +70,11 @@ protected:
 
     void set_arc_coordinate() override;
 
+    void probe_arc() override;
+
 private:
+    const ArchitectureRegisters registers_ = get_architecture_registers(tt::ARCH::WORMHOLE_B0);
+
     // Builds the ARC message (with the common prefix) that requests the given clock state.
     uint32_t get_power_state_arc_msg(PowerState state);
 

--- a/device/arch/architecture_registers.cpp
+++ b/device/arch/architecture_registers.cpp
@@ -121,6 +121,11 @@ ArchitectureRegisters get_architecture_registers(const tt::ARCH arch) {
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0:
             return {
+                .arc_apb_bar0_offset = wormhole::ARC_APB_BAR0_XBAR_OFFSET_START,
+                .arc_csm_bar0_mailbox_offset = wormhole::ARC_CSM_BAR0_MAILBOX_OFFSET,
+                .arc_reset_scratch_offset = wormhole::ARC_RESET_SCRATCH_OFFSET,
+                .arc_reset_scratch_2_offset = wormhole::ARC_RESET_SCRATCH_2_OFFSET,
+                .arc_apb_noc_base_address = wormhole::ARC_APB_NOC_BASE_ADDRESS,
                 .noc_node_id_bar_offset = wormhole::NIU_CFG_NOC0_BAR_ARC_ADDR + wormhole::NOC_NODE_ID_OFFSET,
                 .riscv_debug_bus_cntl_reg = wormhole::RISCV_DEBUG_REG_DBG_BUS_CNTL_REG,
                 .get_noc_node_id_reg_addr = &wormhole::noc_node_id_reg_addr,
@@ -128,6 +133,11 @@ ArchitectureRegisters get_architecture_registers(const tt::ARCH arch) {
             };
         case tt::ARCH::BLACKHOLE:
             return {
+                .arc_apb_bar0_offset = blackhole::ARC_APB_BAR0_XBAR_OFFSET_START,
+                .arc_csm_bar0_mailbox_offset = blackhole::ARC_CSM_MAILBOX_OFFSET,
+                .arc_reset_scratch_offset = blackhole::ARC_RESET_SCRATCH_OFFSET,
+                .arc_reset_scratch_2_offset = blackhole::ARC_RESET_SCRATCH_2_OFFSET,
+                .arc_apb_noc_base_address = blackhole::ARC_NOC_XBAR_ADDRESS_START,
                 .noc_node_id_bar_offset = blackhole::NIU_CFG_NOC0_BAR_PCIE_ADDR + blackhole::NOC_NODE_ID_OFFSET,
                 .riscv_debug_bus_cntl_reg = blackhole::RISCV_DEBUG_REG_DBG_BUS_CNTL_REG,
                 .get_noc_node_id_reg_addr = &blackhole::noc_node_id_reg_addr,
@@ -135,6 +145,11 @@ ArchitectureRegisters get_architecture_registers(const tt::ARCH arch) {
             };
         case tt::ARCH::QUASAR:
             return {
+                .arc_apb_bar0_offset = grendel::ARC_APB_BAR0_XBAR_OFFSET_START,
+                .arc_csm_bar0_mailbox_offset = grendel::ARC_CSM_MAILBOX_OFFSET,
+                .arc_reset_scratch_offset = grendel::ARC_RESET_SCRATCH_OFFSET,
+                .arc_reset_scratch_2_offset = grendel::ARC_RESET_SCRATCH_2_OFFSET,
+                .arc_apb_noc_base_address = grendel::ARC_NOC_XBAR_ADDRESS_START,
                 .noc_node_id_bar_offset = grendel::BH_NOC_NODE_ID_OFFSET,
                 .riscv_debug_bus_cntl_reg = grendel::RISCV_DEBUG_REG_DBG_BUS_CNTL_REG,
                 .get_noc_node_id_reg_addr = &grendel::noc_node_id_reg_addr,

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -501,8 +501,7 @@ void LocalChip::deassert_risc_resets() {
     ZoneScopedC(tracy::Color::DarkGreen);
     if (get_soc_descriptor().arch != tt::ARCH::BLACKHOLE) {
         arc_msg(
-            wormhole::ARC_MSG_COMMON_PREFIX |
-                tt_device_->get_architecture_implementation()->get_arc_message_deassert_riscv_reset(),
+            wormhole::ARC_MSG_COMMON_PREFIX | static_cast<uint32_t>(wormhole::arc_message_type::DEASSERT_RISCV_RESET),
             true,
             {0, 0});
     }

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -190,6 +190,11 @@ ChipInfo BlackholeTTDevice::get_chip_info() {
     return chip_info;
 }
 
+void BlackholeTTDevice::probe_arc() {
+    uint32_t dummy;
+    read_from_arc_apb(&dummy, registers_.arc_reset_scratch_offset, sizeof(dummy));  // SCRATCH_0
+}
+
 void BlackholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeout_ms) {
     uint32_t arc_boot_status = 0;
     uint32_t arc_postcode = 0;
@@ -200,7 +205,7 @@ void BlackholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds time
     const bool arc_core_started = utils::poll_until(
         [this, &arc_boot_status, &arc_postcode]() {
             read_from_arc_apb(&arc_boot_status, blackhole::SCRATCH_RAM_2, sizeof arc_boot_status);
-            read_from_arc_apb(&arc_postcode, architecture_impl_->get_arc_reset_scratch_offset(), sizeof arc_postcode);
+            read_from_arc_apb(&arc_postcode, registers_.arc_reset_scratch_offset, sizeof arc_postcode);
             return (arc_boot_status & 0x7) == 0x5;
         },
         timeout_ms,
@@ -260,17 +265,16 @@ void BlackholeTTDevice::read_from_arc_apb(void *mem_ptr, uint64_t arc_addr_offse
         get_device_protocol()->read_ctrl(
             mem_ptr,
             blackhole::ARC_CORES_NOC0[0],
-            blackhole::ARC_NOC_XBAR_ADDRESS_START + arc_addr_offset,
+            registers_.arc_apb_noc_base_address + arc_addr_offset,
             sizeof(uint32_t),
             NocId::DEFAULT_NOC);
         return;
     }
     if (!is_arc_available_over_axi()) {
-        read_from_device_reg(
-            mem_ptr, get_arc_core(), architecture_impl_->get_arc_apb_noc_base_address() + arc_addr_offset, size);
+        read_from_device_reg(mem_ptr, get_arc_core(), registers_.arc_apb_noc_base_address + arc_addr_offset, size);
         return;
     }
-    auto result = bar_read32(blackhole::ARC_APB_BAR0_XBAR_OFFSET_START + arc_addr_offset);
+    auto result = bar_read32(registers_.arc_apb_bar0_offset + arc_addr_offset);
     *(reinterpret_cast<uint32_t *>(mem_ptr)) = result;
 };
 
@@ -282,18 +286,16 @@ void BlackholeTTDevice::write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_
         get_device_protocol()->write_ctrl(
             mem_ptr,
             blackhole::ARC_CORES_NOC0[0],
-            blackhole::ARC_NOC_XBAR_ADDRESS_START + arc_addr_offset,
+            registers_.arc_apb_noc_base_address + arc_addr_offset,
             sizeof(uint32_t),
             NocId::DEFAULT_NOC);
         return;
     }
     if (!is_arc_available_over_axi()) {
-        write_to_device_reg(
-            mem_ptr, get_arc_core(), architecture_impl_->get_arc_apb_noc_base_address() + arc_addr_offset, size);
+        write_to_device_reg(mem_ptr, get_arc_core(), registers_.arc_apb_noc_base_address + arc_addr_offset, size);
         return;
     }
-    bar_write32(
-        blackhole::ARC_APB_BAR0_XBAR_OFFSET_START + arc_addr_offset, *(reinterpret_cast<const uint32_t *>(mem_ptr)));
+    bar_write32(registers_.arc_apb_bar0_offset + arc_addr_offset, *(reinterpret_cast<const uint32_t *>(mem_ptr)));
 }
 
 void BlackholeTTDevice::write_to_arc_csm(const void *mem_ptr, uint64_t arc_addr_offset, size_t size) {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -118,11 +118,6 @@ TTDevice::TTDevice(
     device_protocol_ = std::move(remote_protocol);
 }
 
-void TTDevice::probe_arc() {
-    uint32_t dummy;
-    read_from_arc_apb(&dummy, architecture_impl_->get_arc_reset_scratch_offset(), sizeof(dummy));  // SCRATCH_0
-}
-
 void TTDevice::assign_soc_arch_descriptor(const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
     if (soc_arch_descriptor == nullptr) {
         soc_arch_descriptor_ = std::make_shared<SocArchDescriptor>(architecture_impl_->get_architecture());

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -82,7 +82,7 @@ ChipInfo WormholeTTDevice::get_chip_info() {
 
     std::vector<uint32_t> arc_msg_return_values = {0};
     uint32_t ret_code = get_arc_messenger()->send_message(
-        wormhole::ARC_MSG_COMMON_PREFIX | get_architecture_implementation()->get_arc_message_arc_get_harvesting(),
+        wormhole::ARC_MSG_COMMON_PREFIX | static_cast<uint32_t>(wormhole::arc_message_type::ARC_GET_HARVESTING),
         arc_msg_return_values,
         {0, 0});
 
@@ -100,7 +100,7 @@ uint32_t WormholeTTDevice::get_clock() {
     // There is one return value from AICLK ARC message.
     std::vector<uint32_t> arc_msg_return_values = {0};
     auto exit_code = get_arc_messenger()->send_message(
-        wormhole::ARC_MSG_COMMON_PREFIX | get_architecture_implementation()->get_arc_message_get_aiclk(),
+        wormhole::ARC_MSG_COMMON_PREFIX | static_cast<uint32_t>(wormhole::arc_message_type::GET_AICLK),
         arc_msg_return_values,
         {0xFFFF, 0xFFFF});
     if (exit_code != 0) {
@@ -154,12 +154,14 @@ void WormholeTTDevice::configure_iatu_region(size_t region, uint64_t target, siz
         UMD_THROW(error::RuntimeError, "configure_iatu_region is redundant for JTAG communication type.");
     }
 
-    bar_write32(architecture_impl_->get_arc_csm_bar0_mailbox_offset() + 0 * 4, region_id_to_use);
-    bar_write32(architecture_impl_->get_arc_csm_bar0_mailbox_offset() + 1 * 4, dest_bar_lo);
-    bar_write32(architecture_impl_->get_arc_csm_bar0_mailbox_offset() + 2 * 4, dest_bar_hi);
-    bar_write32(architecture_impl_->get_arc_csm_bar0_mailbox_offset() + 3 * 4, region_size);
+    bar_write32(registers_.arc_csm_bar0_mailbox_offset + 0 * 4, region_id_to_use);
+    bar_write32(registers_.arc_csm_bar0_mailbox_offset + 1 * 4, dest_bar_lo);
+    bar_write32(registers_.arc_csm_bar0_mailbox_offset + 2 * 4, dest_bar_hi);
+    bar_write32(registers_.arc_csm_bar0_mailbox_offset + 3 * 4, region_size);
     get_arc_messenger()->send_message(
-        wormhole::ARC_MSG_COMMON_PREFIX | architecture_impl_->get_arc_message_setup_iatu_for_peer_to_peer(), {0, 0});
+        wormhole::ARC_MSG_COMMON_PREFIX |
+            static_cast<uint32_t>(wormhole::arc_message_type::SETUP_IATU_FOR_PEER_TO_PEER),
+        {0, 0});
 
     // Print what just happened.
     uint32_t peer_region_start = region_id_to_use * region_size;
@@ -178,20 +180,19 @@ void WormholeTTDevice::read_from_arc_apb(void *mem_ptr, uint64_t arc_addr_offset
         UMD_THROW(error::RuntimeError, "Address is out of ARC APB address range.");
     }
     if (is_remote_tt_device) {
-        read_from_device_reg(
-            mem_ptr, get_arc_core(), architecture_impl_->get_arc_apb_noc_base_address() + arc_addr_offset, size);
+        read_from_device_reg(mem_ptr, get_arc_core(), registers_.arc_apb_noc_base_address + arc_addr_offset, size);
         return;
     }
     if (communication_device_type_ == IODeviceType::JTAG) {
         get_device_protocol()->read_ctrl(
             mem_ptr,
             wormhole::ARC_CORES_NOC0[0],
-            architecture_impl_->get_arc_apb_noc_base_address() + arc_addr_offset,
+            registers_.arc_apb_noc_base_address + arc_addr_offset,
             sizeof(uint32_t),
             NocId::DEFAULT_NOC);
         return;
     }
-    auto result = bar_read32(wormhole::ARC_APB_BAR0_XBAR_OFFSET_START + arc_addr_offset);
+    auto result = bar_read32(registers_.arc_apb_bar0_offset + arc_addr_offset);
     *(reinterpret_cast<uint32_t *>(mem_ptr)) = result;
 }
 
@@ -200,21 +201,19 @@ void WormholeTTDevice::write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_o
         UMD_THROW(error::RuntimeError, "Address is out of ARC APB address range.");
     }
     if (is_remote_tt_device) {
-        write_to_device_reg(
-            mem_ptr, get_arc_core(), architecture_impl_->get_arc_apb_noc_base_address() + arc_addr_offset, size);
+        write_to_device_reg(mem_ptr, get_arc_core(), registers_.arc_apb_noc_base_address + arc_addr_offset, size);
         return;
     }
     if (communication_device_type_ == IODeviceType::JTAG) {
         get_device_protocol()->write_ctrl(
             mem_ptr,
             wormhole::ARC_CORES_NOC0[0],
-            architecture_impl_->get_arc_apb_noc_base_address() + arc_addr_offset,
+            registers_.arc_apb_noc_base_address + arc_addr_offset,
             sizeof(uint32_t),
             NocId::DEFAULT_NOC);
         return;
     }
-    bar_write32(
-        wormhole::ARC_APB_BAR0_XBAR_OFFSET_START + arc_addr_offset, *(reinterpret_cast<const uint32_t *>(mem_ptr)));
+    bar_write32(registers_.arc_apb_bar0_offset + arc_addr_offset, *(reinterpret_cast<const uint32_t *>(mem_ptr)));
 }
 
 void WormholeTTDevice::read_from_arc_csm(void *mem_ptr, uint64_t arc_addr_offset, size_t size) {
@@ -222,15 +221,14 @@ void WormholeTTDevice::read_from_arc_csm(void *mem_ptr, uint64_t arc_addr_offset
         UMD_THROW(error::RuntimeError, "Address is out of ARC CSM address range.");
     }
     if (is_remote_tt_device) {
-        read_from_device(
-            mem_ptr, get_arc_core(), architecture_impl_->get_arc_csm_noc_base_address() + arc_addr_offset, size);
+        read_from_device(mem_ptr, get_arc_core(), wormhole::ARC_CSM_NOC_BASE_ADDRESS + arc_addr_offset, size);
         return;
     }
     if (communication_device_type_ == IODeviceType::JTAG) {
         get_device_protocol()->read_ctrl(
             mem_ptr,
             wormhole::ARC_CORES_NOC0[0],
-            architecture_impl_->get_arc_csm_noc_base_address() + arc_addr_offset,
+            wormhole::ARC_CSM_NOC_BASE_ADDRESS + arc_addr_offset,
             sizeof(uint32_t),
             NocId::DEFAULT_NOC);
         return;
@@ -244,15 +242,14 @@ void WormholeTTDevice::write_to_arc_csm(const void *mem_ptr, uint64_t arc_addr_o
         UMD_THROW(error::RuntimeError, "Address is out of ARC CSM address range.");
     }
     if (is_remote_tt_device) {
-        write_to_device(
-            mem_ptr, get_arc_core(), architecture_impl_->get_arc_csm_noc_base_address() + arc_addr_offset, size);
+        write_to_device(mem_ptr, get_arc_core(), wormhole::ARC_CSM_NOC_BASE_ADDRESS + arc_addr_offset, size);
         return;
     }
     if (communication_device_type_ == IODeviceType::JTAG) {
         get_device_protocol()->write_ctrl(
             mem_ptr,
             wormhole::ARC_CORES_NOC0[0],
-            architecture_impl_->get_arc_csm_noc_base_address() + arc_addr_offset,
+            wormhole::ARC_CSM_NOC_BASE_ADDRESS + arc_addr_offset,
             sizeof(uint32_t),
             NocId::DEFAULT_NOC);
         return;
@@ -321,6 +318,11 @@ EthTrainingStatus WormholeTTDevice::read_eth_core_training_status(CoreCoord eth_
     return static_cast<EthTrainingStatus>(training_status);
 }
 
+void WormholeTTDevice::probe_arc() {
+    uint32_t dummy;
+    read_from_arc_apb(&dummy, registers_.arc_reset_scratch_offset, sizeof(dummy));  // SCRATCH_0
+}
+
 void WormholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeout_ms) {
     // Status codes.
     constexpr uint32_t STATUS_NO_ACCESS = 0xFFFFFFFF;
@@ -359,9 +361,7 @@ void WormholeTTDevice::wait_arc_core_start(const std::chrono::milliseconds timeo
                 sizeof(bar_read_arc_reset_scratch_status));
 
             read_from_arc_apb(
-                &bar_read_arc_post_code,
-                architecture_impl_->get_arc_reset_scratch_offset(),
-                sizeof(bar_read_arc_post_code));
+                &bar_read_arc_post_code, registers_.arc_reset_scratch_offset, sizeof(bar_read_arc_post_code));
 
             uint32_t bar_read_arc_csm_pcie_dma_request = 0;
             read_from_arc_csm(

--- a/examples/tt_device_example/tt_device_example.cpp
+++ b/examples/tt_device_example/tt_device_example.cpp
@@ -38,8 +38,8 @@ int main(int argc, char* argv[]) {
         std::cout << "PCI Device: " << device->get_pci_device()->get_device_num() << std::endl;
 
         std::cout << "Testing BAR read/write (without init)..." << std::endl;
-        uint32_t test_addr = device->get_architecture_implementation()->get_arc_axi_apb_peripheral_offset() +
-                             device->get_architecture_implementation()->get_arc_reset_scratch_offset();
+        // ARC reset unit SCRATCH_0 over BAR0, at the same address on all supported architectures.
+        constexpr uint32_t test_addr = 0x1FF30060;
         uint32_t original_value = device->bar_read32(test_addr);
         std::cout << "Original value at 0x" << std::hex << test_addr << ": 0x" << original_value << std::dec
                   << std::endl;

--- a/tests/api/test_warm_reset.cpp
+++ b/tests/api/test_warm_reset.cpp
@@ -34,7 +34,7 @@
 #include "tests/test_utils/multi_process_event.hpp"
 #include "tests/test_utils/pipe_communication.hpp"
 #include "tests/test_utils/test_api_common.hpp"
-#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/architecture_registers.hpp"
 #include "umd/device/chip/chip.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
@@ -286,6 +286,12 @@ TEST(WarmResetTest, DISABLED_SafeApiMultiProcess) {
     }
 }
 
+// BAR0 address of the ARC scratch register these tests use to prove a reset happened.
+static uint32_t arc_scratch_2_bar_address(TTDevice* tt_device) {
+    const ArchitectureRegisters registers = get_architecture_registers(tt_device->get_arch());
+    return registers.arc_apb_bar0_offset + registers.arc_reset_scratch_2_offset;
+}
+
 TEST(WarmResetTest, GalaxyWarmResetScratch) {
     std::unique_ptr<Cluster> cluster = test_utils::make_default_test_cluster();
     static constexpr uint32_t DEFAULT_VALUE_IN_SCRATCH_REGISTER = 0;
@@ -307,10 +313,7 @@ TEST(WarmResetTest, GalaxyWarmResetScratch) {
 
     for (auto& chip_id : cluster->get_target_mmio_device_ids()) {
         auto tt_device = cluster->get_chip(chip_id)->get_tt_device();
-        tt_device->bar_write32(
-            tt_device->get_architecture_implementation()->get_arc_axi_apb_peripheral_offset() +
-                tt_device->get_architecture_implementation()->get_arc_reset_scratch_2_offset(),
-            write_test_data);
+        tt_device->bar_write32(arc_scratch_2_bar_address(tt_device), write_test_data);
     }
 
     WarmResetWithRecovery::ubb_warm_reset();
@@ -322,9 +325,7 @@ TEST(WarmResetTest, GalaxyWarmResetScratch) {
     for (auto& chip_id : cluster->get_target_mmio_device_ids()) {
         auto tt_device = cluster->get_chip(chip_id)->get_tt_device();
 
-        auto read_test_data = tt_device->bar_read32(
-            tt_device->get_architecture_implementation()->get_arc_axi_apb_peripheral_offset() +
-            tt_device->get_architecture_implementation()->get_arc_reset_scratch_2_offset());
+        auto read_test_data = tt_device->bar_read32(arc_scratch_2_bar_address(tt_device));
 
         EXPECT_NE(write_test_data, read_test_data);
         EXPECT_EQ(DEFAULT_VALUE_IN_SCRATCH_REGISTER, read_test_data);
@@ -418,10 +419,7 @@ TEST_P(ClusterWarmResetScratchMethodTest, ClusterWarmResetScratch) {
     auto chip_id = *cluster->get_target_mmio_device_ids().begin();
     auto tt_device = cluster->get_chip(chip_id)->get_tt_device();
 
-    tt_device->bar_write32(
-        tt_device->get_architecture_implementation()->get_arc_axi_apb_peripheral_offset() +
-            tt_device->get_architecture_implementation()->get_arc_reset_scratch_2_offset(),
-        write_test_data);
+    tt_device->bar_write32(arc_scratch_2_bar_address(tt_device), write_test_data);
 
     switch (GetParam()) {
         case WarmResetMethod::PCI_DEVICE_IDS:
@@ -454,9 +452,7 @@ TEST_P(ClusterWarmResetScratchMethodTest, ClusterWarmResetScratch) {
     chip_id = *cluster->get_target_device_ids().begin();
     tt_device = cluster->get_chip(chip_id)->get_tt_device();
 
-    auto read_test_data = tt_device->bar_read32(
-        tt_device->get_architecture_implementation()->get_arc_axi_apb_peripheral_offset() +
-        tt_device->get_architecture_implementation()->get_arc_reset_scratch_2_offset());
+    auto read_test_data = tt_device->bar_read32(arc_scratch_2_bar_address(tt_device));
 
     EXPECT_NE(write_test_data, read_test_data);
 }

--- a/tests/wormhole/test_arc_messages_wh.cpp
+++ b/tests/wormhole/test_arc_messages_wh.cpp
@@ -38,8 +38,7 @@ TEST(WormholeArcMessages, WormholeArcMessagesHarvesting) {
 
         std::vector<uint32_t> arc_msg_return_values = {0};
         arc_messenger->send_message(
-            wormhole::ARC_MSG_COMMON_PREFIX |
-                tt_device->get_architecture_implementation()->get_arc_message_arc_get_harvesting(),
+            wormhole::ARC_MSG_COMMON_PREFIX | static_cast<uint32_t>(wormhole::arc_message_type::ARC_GET_HARVESTING),
             arc_msg_return_values,
             {0, 0});
 
@@ -111,7 +110,7 @@ TEST(WormholeArcMessages, MultipleThreadsArcMessages) {
                 std::vector<uint32_t> arc_msg_return_values = {0};
                 arc_messenger->send_message(
                     wormhole::ARC_MSG_COMMON_PREFIX |
-                        tt_device->get_architecture_implementation()->get_arc_message_arc_get_harvesting(),
+                        static_cast<uint32_t>(wormhole::arc_message_type::ARC_GET_HARVESTING),
                     arc_msg_return_values,
                     {0, 0});
 
@@ -128,7 +127,7 @@ TEST(WormholeArcMessages, MultipleThreadsArcMessages) {
                 std::vector<uint32_t> arc_msg_return_values = {0};
                 arc_messenger->send_message(
                     wormhole::ARC_MSG_COMMON_PREFIX |
-                        tt_device->get_architecture_implementation()->get_arc_message_arc_get_harvesting(),
+                        static_cast<uint32_t>(wormhole::arc_message_type::ARC_GET_HARVESTING),
                     arc_msg_return_values,
                     {0, 0});
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2873

### Description
Stacked on #3218.

The ARC register offsets and message ids are not part of the Base API specification. The
offsets join the other register addresses in `ArchitectureRegisters`, so there is still one
struct per architecture filled in one place. Message ids need nothing new, the per architecture
`arc_message_type` enums already exist and are already used around these call sites.

`probe_arc` was the only thing in the base `TTDevice` which needed these, so it becomes a hook
the concrete devices implement.

### List of the changes
- Add the APB BAR0 offset, CSM mailbox BAR0 offset, the two reset unit scratch offsets and the
  APB NOC base address to `ArchitectureRegisters`.
- Move `probe_arc` from `TTDevice` into the concrete devices, which hold their register map.
- Remove the ten ARC offset and message getters from `ArchitectureImplementation` and update all
  call sites. The concrete devices already read some of these from their own constants, so those
  lines go through the struct too.
- The tt_device example only needed some BAR readable address, so it no longer derives one.

### Testing
Code builds. Existing CI covers ARC init and warm reset paths on both architectures.

### API Changes
This PR has API changes, ten methods removed from `ArchitectureImplementation` and ARC entries
added to `ArchitectureRegisters`.

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/arch_impl_12
