### PR TITLE
[Bug fix] Route TTSim TLB window reads and writes through arch-aware addressing so Quasar targets cores by coordinate

### DIFF
--- a/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
@@ -49,6 +49,14 @@ private:
      */
     uint64_t get_physical_address(uint64_t offset) const;
 
+    /**
+     * Single entry points for all reads and writes, so the choice between
+     * addressing the simulator by physical address and addressing it by core
+     * coordinate is made in exactly one place.
+     */
+    void translate_and_write(uint64_t offset, const void* data, size_t size);
+    void translate_and_read(uint64_t offset, void* data, size_t size);
+
     TTSimCommunicator* sim_communicator_;
 };
 

--- a/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
+++ b/device/api/umd/device/pcie/tt_sim_tlb_window.hpp
@@ -49,14 +49,6 @@ private:
      */
     uint64_t get_physical_address(uint64_t offset) const;
 
-    /**
-     * Single entry points for all reads and writes, so the choice between
-     * addressing the simulator by physical address and addressing it by core
-     * coordinate is made in exactly one place.
-     */
-    void translate_and_write(uint64_t offset, const void* data, size_t size);
-    void translate_and_read(uint64_t offset, void* data, size_t size);
-
     TTSimCommunicator* sim_communicator_;
 };
 

--- a/device/pcie/tt_sim_tlb_window.cpp
+++ b/device/pcie/tt_sim_tlb_window.cpp
@@ -57,9 +57,7 @@ void TTSimTlbWindow::translate_and_read(uint64_t offset, void* data, size_t size
         static_cast<uint32_t>(size));
 }
 
-void TTSimTlbWindow::write16(uint64_t offset, uint16_t value) {
-    translate_and_write(offset, &value, sizeof(value));
-}
+void TTSimTlbWindow::write16(uint64_t offset, uint16_t value) { translate_and_write(offset, &value, sizeof(value)); }
 
 uint16_t TTSimTlbWindow::read16(uint64_t offset) {
     uint16_t value = 0;
@@ -67,9 +65,7 @@ uint16_t TTSimTlbWindow::read16(uint64_t offset) {
     return value;
 }
 
-void TTSimTlbWindow::write32(uint64_t offset, uint32_t value) {
-    translate_and_write(offset, &value, sizeof(value));
-}
+void TTSimTlbWindow::write32(uint64_t offset, uint32_t value) { translate_and_write(offset, &value, sizeof(value)); }
 
 uint32_t TTSimTlbWindow::read32(uint64_t offset) {
     uint32_t value = 0;
@@ -81,9 +77,7 @@ void TTSimTlbWindow::write_register(uint64_t offset, const void* data, size_t si
     translate_and_write(offset, data, size);
 }
 
-void TTSimTlbWindow::read_register(uint64_t offset, void* data, size_t size) {
-    translate_and_read(offset, data, size);
-}
+void TTSimTlbWindow::read_register(uint64_t offset, void* data, size_t size) { translate_and_read(offset, data, size); }
 
 void TTSimTlbWindow::write_block(uint64_t offset, const void* data, size_t size) {
     translate_and_write(offset, data, size);

--- a/device/pcie/tt_sim_tlb_window.cpp
+++ b/device/pcie/tt_sim_tlb_window.cpp
@@ -37,9 +37,7 @@ uint32_t TTSimTlbWindow::read32(uint64_t offset) {
     return value;
 }
 
-void TTSimTlbWindow::write_register(uint64_t offset, const void* data, size_t size) {
-    write_block(offset, data, size);
-}
+void TTSimTlbWindow::write_register(uint64_t offset, const void* data, size_t size) { write_block(offset, data, size); }
 
 void TTSimTlbWindow::read_register(uint64_t offset, void* data, size_t size) { read_block(offset, data, size); }
 

--- a/device/pcie/tt_sim_tlb_window.cpp
+++ b/device/pcie/tt_sim_tlb_window.cpp
@@ -12,6 +12,7 @@
 #include "umd/device/pcie/tt_sim_tlb_handle.hpp"
 #include "umd/device/simulation/tt_sim_communicator.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/types/arch.hpp"
 #include "umd/device/types/tlb.hpp"
 
 namespace tt::umd {
@@ -20,49 +21,75 @@ TTSimTlbWindow::TTSimTlbWindow(
     std::unique_ptr<TlbHandle> handle, TTSimCommunicator* communicator, const tlb_data config) :
     TlbWindow(std::move(handle), config), sim_communicator_(communicator) {}
 
+void TTSimTlbWindow::translate_and_write(uint64_t offset, const void* data, size_t size) {
+    validate(offset, size);
+    // Quasar's TLB handle programs no TLB registers and is left without a base address, so a
+    // physical address derived from it carries no identity for the core this window was created
+    // for. Name the core explicitly. Wormhole and Blackhole keep the physical-address path.
+    if (tlb_handle->get_arch() != tt::ARCH::QUASAR) {
+        sim_communicator_->pci_mem_write_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
+        return;
+    }
+    // configure() stored local_offset in units of the TLB size, so scale it back to a device address.
+    const tlb_data& config = tlb_handle->get_config();
+    const uint64_t device_addr = config.local_offset * tlb_handle->get_size() + get_total_offset(offset);
+    sim_communicator_->tile_write_bytes(
+        static_cast<uint32_t>(config.x_end),
+        static_cast<uint32_t>(config.y_end),
+        device_addr,
+        data,
+        static_cast<uint32_t>(size));
+}
+
+void TTSimTlbWindow::translate_and_read(uint64_t offset, void* data, size_t size) {
+    validate(offset, size);
+    if (tlb_handle->get_arch() != tt::ARCH::QUASAR) {
+        sim_communicator_->pci_mem_read_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
+        return;
+    }
+    const tlb_data& config = tlb_handle->get_config();
+    const uint64_t device_addr = config.local_offset * tlb_handle->get_size() + get_total_offset(offset);
+    sim_communicator_->tile_read_bytes(
+        static_cast<uint32_t>(config.x_end),
+        static_cast<uint32_t>(config.y_end),
+        device_addr,
+        data,
+        static_cast<uint32_t>(size));
+}
+
 void TTSimTlbWindow::write16(uint64_t offset, uint16_t value) {
-    validate(offset, sizeof(uint16_t));
-    sim_communicator_->pci_mem_write_bytes(get_physical_address(offset), &value, sizeof(uint16_t));
+    translate_and_write(offset, &value, sizeof(value));
 }
 
 uint16_t TTSimTlbWindow::read16(uint64_t offset) {
-    validate(offset, sizeof(uint16_t));
     uint16_t value = 0;
-    sim_communicator_->pci_mem_read_bytes(get_physical_address(offset), &value, sizeof(uint16_t));
+    translate_and_read(offset, &value, sizeof(value));
     return value;
 }
 
 void TTSimTlbWindow::write32(uint64_t offset, uint32_t value) {
-    validate(offset, sizeof(uint32_t));
-    sim_communicator_->pci_mem_write_bytes(get_physical_address(offset), &value, sizeof(uint32_t));
+    translate_and_write(offset, &value, sizeof(value));
 }
 
 uint32_t TTSimTlbWindow::read32(uint64_t offset) {
-    validate(offset, sizeof(uint32_t));
     uint32_t value = 0;
-    sim_communicator_->pci_mem_read_bytes(get_physical_address(offset), &value, sizeof(uint32_t));
+    translate_and_read(offset, &value, sizeof(value));
     return value;
 }
 
 void TTSimTlbWindow::write_register(uint64_t offset, const void* data, size_t size) {
-    validate(offset, size);
-    sim_communicator_->pci_mem_write_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
+    translate_and_write(offset, data, size);
 }
 
 void TTSimTlbWindow::read_register(uint64_t offset, void* data, size_t size) {
-    validate(offset, size);
-    sim_communicator_->pci_mem_read_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
+    translate_and_read(offset, data, size);
 }
 
 void TTSimTlbWindow::write_block(uint64_t offset, const void* data, size_t size) {
-    validate(offset, size);
-    sim_communicator_->pci_mem_write_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
+    translate_and_write(offset, data, size);
 }
 
-void TTSimTlbWindow::read_block(uint64_t offset, void* data, size_t size) {
-    validate(offset, size);
-    sim_communicator_->pci_mem_read_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
-}
+void TTSimTlbWindow::read_block(uint64_t offset, void* data, size_t size) { translate_and_read(offset, data, size); }
 
 uint64_t TTSimTlbWindow::get_physical_address(uint64_t offset) const {
     // Get the base address from the TLB handle and add the offset

--- a/device/pcie/tt_sim_tlb_window.cpp
+++ b/device/pcie/tt_sim_tlb_window.cpp
@@ -21,11 +21,36 @@ TTSimTlbWindow::TTSimTlbWindow(
     std::unique_ptr<TlbHandle> handle, TTSimCommunicator* communicator, const tlb_data config) :
     TlbWindow(std::move(handle), config), sim_communicator_(communicator) {}
 
-void TTSimTlbWindow::translate_and_write(uint64_t offset, const void* data, size_t size) {
+void TTSimTlbWindow::write16(uint64_t offset, uint16_t value) { write_block(offset, &value, sizeof(value)); }
+
+uint16_t TTSimTlbWindow::read16(uint64_t offset) {
+    uint16_t value = 0;
+    read_block(offset, &value, sizeof(value));
+    return value;
+}
+
+void TTSimTlbWindow::write32(uint64_t offset, uint32_t value) { write_block(offset, &value, sizeof(value)); }
+
+uint32_t TTSimTlbWindow::read32(uint64_t offset) {
+    uint32_t value = 0;
+    read_block(offset, &value, sizeof(value));
+    return value;
+}
+
+void TTSimTlbWindow::write_register(uint64_t offset, const void* data, size_t size) {
+    write_block(offset, data, size);
+}
+
+void TTSimTlbWindow::read_register(uint64_t offset, void* data, size_t size) { read_block(offset, data, size); }
+
+void TTSimTlbWindow::write_block(uint64_t offset, const void* data, size_t size) {
     validate(offset, size);
     // Quasar's TLB handle programs no TLB registers and is left without a base address, so a
     // physical address derived from it carries no identity for the core this window was created
     // for. Name the core explicitly. Wormhole and Blackhole keep the physical-address path.
+    //
+    // This is an arch check rather than a capability check because the simulator does not model
+    // Quasar TLBs at all. If it ever does, this needs to become a capability check.
     if (tlb_handle->get_arch() != tt::ARCH::QUASAR) {
         sim_communicator_->pci_mem_write_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
         return;
@@ -41,7 +66,7 @@ void TTSimTlbWindow::translate_and_write(uint64_t offset, const void* data, size
         static_cast<uint32_t>(size));
 }
 
-void TTSimTlbWindow::translate_and_read(uint64_t offset, void* data, size_t size) {
+void TTSimTlbWindow::read_block(uint64_t offset, void* data, size_t size) {
     validate(offset, size);
     if (tlb_handle->get_arch() != tt::ARCH::QUASAR) {
         sim_communicator_->pci_mem_read_bytes(get_physical_address(offset), data, static_cast<uint32_t>(size));
@@ -56,34 +81,6 @@ void TTSimTlbWindow::translate_and_read(uint64_t offset, void* data, size_t size
         data,
         static_cast<uint32_t>(size));
 }
-
-void TTSimTlbWindow::write16(uint64_t offset, uint16_t value) { translate_and_write(offset, &value, sizeof(value)); }
-
-uint16_t TTSimTlbWindow::read16(uint64_t offset) {
-    uint16_t value = 0;
-    translate_and_read(offset, &value, sizeof(value));
-    return value;
-}
-
-void TTSimTlbWindow::write32(uint64_t offset, uint32_t value) { translate_and_write(offset, &value, sizeof(value)); }
-
-uint32_t TTSimTlbWindow::read32(uint64_t offset) {
-    uint32_t value = 0;
-    translate_and_read(offset, &value, sizeof(value));
-    return value;
-}
-
-void TTSimTlbWindow::write_register(uint64_t offset, const void* data, size_t size) {
-    translate_and_write(offset, data, size);
-}
-
-void TTSimTlbWindow::read_register(uint64_t offset, void* data, size_t size) { translate_and_read(offset, data, size); }
-
-void TTSimTlbWindow::write_block(uint64_t offset, const void* data, size_t size) {
-    translate_and_write(offset, data, size);
-}
-
-void TTSimTlbWindow::read_block(uint64_t offset, void* data, size_t size) { translate_and_read(offset, data, size); }
 
 uint64_t TTSimTlbWindow::get_physical_address(uint64_t offset) const {
     // Get the base address from the TLB handle and add the offset


### PR DESCRIPTION
### Description
On Quasar, the simulated TLB handle has no base address — it does not program TLB registers the way Wormhole and Blackhole do — so computing a physical address from it and sending that to the simulator does not reliably identify the intended destination core.

This change adds a per-architecture decision inside the memory-access path that chooses whether to address the simulator by physical address (Wormhole, Blackhole) or by explicit core coordinate plus device address (Quasar). All read and write entry points on the TLB window now route through the two block-transfer methods that make this decision, rather than each computing a physical address independently, so the addressing rules live in one place going forward.

### List of the changes
- The per-architecture choice between physical-address addressing and core-coordinate addressing is now made inside the existing `write_block` and `read_block` methods.
- The remaining read and write entry points (16-bit, 32-bit, and register transfers) now delegate to `write_block`/`read_block` instead of each computing a physical address directly.
- For Quasar, addressing now uses the core's row and column coordinates (`x_end`, `y_end`) together with a device address derived from the TLB configuration, sent via `tile_write_bytes`/`tile_read_bytes`.
- Behavior for Wormhole and Blackhole is unchanged; both continue on the existing physical-address path (`pci_mem_write_bytes`/`pci_mem_read_bytes`).
- The Quasar path is selected by an architecture check rather than a capability check, because the simulator does not currently model Quasar TLBs at all; this should become a capability check if that ever changes.

### Testing
Quasar fast dispatch tests in `tt-metal` that utilize the full Quasar 8x4 grid on craq-sim were manually run with this change.

### API Changes
None