### PR TITLE
Bump fmt to 12.2.0

### DIFF
--- a/device/common/utils.hpp
+++ b/device/common/utils.hpp
@@ -138,7 +138,8 @@ inline std::unordered_set<int> get_visible_devices(const std::unordered_set<int>
 
 template <typename... Args>
 inline std::string convert_to_space_separated_string(Args&&... args) {
-    return fmt::format("{}", fmt::join({fmt::to_string(std::forward<Args>(args))...}, " "));
+    std::vector<std::string> parts{fmt::to_string(std::forward<Args>(args))...};
+    return fmt::format("{}", fmt::join(parts, " "));
 }
 
 template <typename T>

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -119,7 +119,7 @@ endif()
 # fmt : https://github.com/fmtlib/fmt
 ###################################################################################################################
 
-CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 11.1.4 SYSTEM YES FIND_PACKAGE_ARGUMENTS GLOBAL)
+CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 12.2.0 SYSTEM YES FIND_PACKAGE_ARGUMENTS GLOBAL)
 
 ###################################################################################################################
 # nanobench (for uBenchmarking)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -119,7 +119,7 @@ endif()
 # fmt : https://github.com/fmtlib/fmt
 ###################################################################################################################
 
-CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 12.2.0 SYSTEM YES FIND_PACKAGE_ARGUMENTS GLOBAL)
+CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 12.2.0 SYSTEM YES FIND_PACKAGE_ARGUMENTS GLOBAL OPTIONS "FMT_INSTALL ON")
 
 ###################################################################################################################
 # nanobench (for uBenchmarking)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -119,7 +119,15 @@ endif()
 # fmt : https://github.com/fmtlib/fmt
 ###################################################################################################################
 
-CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 12.2.0 SYSTEM YES FIND_PACKAGE_ARGUMENTS GLOBAL OPTIONS "FMT_INSTALL ON")
+CPMAddPackage(
+    NAME fmt
+    GITHUB_REPOSITORY fmtlib/fmt
+    GIT_TAG 12.2.0
+    SYSTEM YES
+    FIND_PACKAGE_ARGUMENTS GLOBAL
+    OPTIONS
+        "FMT_INSTALL ON"
+)
 
 ###################################################################################################################
 # nanobench (for uBenchmarking)


### PR DESCRIPTION
## What
Bumps the `fmt` (fmtlib/fmt) CPM pin in `third_party/CMakeLists.txt` from `11.1.4` to `12.2.0`.

## Context
This is 1 of 3 coordinated PRs aligning the `fmt` version to 12.2.0 across tt-umd, tt-logger, and tt-metal:
- tt-umd: this PR
- tt-logger: https://github.com/tenstorrent/tt-logger/pull/31
- tt-metal: https://github.com/tenstorrent/tt-metal/pull/53724 (also temporarily points its tt-umd submodule at this PR's head commit for CI validation; that pointer must be moved back to a `main` commit once this merges)

## Notes
- fmt 11 -> 12 is a **major version bump** per fmtlib's semver and may include breaking API changes — see the 12.0.0 changelog at https://github.com/fmtlib/fmt/releases. CI is the intended validation for this change.
- fmt release tags have no `v` prefix, so `12.2.0` is the correct tag form (consistent with the previous `11.1.4` pin).
