### PR TITLE
[Base API] Fix PcieProtocol::get_mmio_id to return the device number

### DIFF
--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -140,7 +140,7 @@ bool PcieProtocol::write_to_core_range(
     return true;
 }
 
-int PcieProtocol::get_mmio_id() { return pci_device_->get_pci_device_id(); }
+int PcieProtocol::get_mmio_id() { return pci_device_->get_device_num(); }
 
 void PcieProtocol::noc_multicast_write(
     const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) {


### PR DESCRIPTION
## Issue

`PcieProtocol::get_mmio_id()` returned the PCI *device ID* (`info.device_id`), the silicon model number that is identical on every card of the same type.

## Description

`DeviceProtocol::get_mmio_id()` is documented as "identifying both the device and its protocol instance", and the other two implementations agree on that meaning: `JtagProtocol` returns its `jlink_id` and `RemoteProtocol` returns the local device's `get_communication_device_id()`. Only the PCIe one was different.

Keying anything per-device on it (an ARC mutex name, for instance) would have collapsed every Blackhole card in a host onto one identity.

## List of the changes

- `PcieProtocol::get_mmio_id()` now returns `pci_device_->get_device_num()`, the `/dev/tenstorrent/N` index.

## Testing

No behavior change to verify: `get_mmio_id` has no callers outside the protocol classes, in UMD or in tt-metal's `llrt`.

## API Changes

None. The declaration is unchanged; only the value it returns is corrected.