### PR TITLE
[Base API] Expose power state control through PcieInterface

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -258,6 +258,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/firmware/firmware_telemetry_mapping.hpp
                 api/umd/device/firmware/firmware_utils.hpp
                 api/umd/device/types/noc_id.hpp
+                api/umd/device/types/power_state.hpp
                 api/umd/device/types/risc_type.hpp
                 api/umd/device/simulation/simulation_chip.hpp
                 api/umd/device/simulation/simulation_connector.hpp

--- a/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_interface.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 
 #include "umd/device/types/noc_id.hpp"
+#include "umd/device/types/power_state.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
@@ -42,6 +43,15 @@ public:
      * @return int NUMA node ID, or -1 if the system is non-NUMA.
      */
     virtual int get_numa_node() const = 0;
+
+    /**
+     * @brief Requests a hardware power domain state change through the kernel driver.
+     *
+     * A no-op on architectures or KMD versions without power state management.
+     *
+     * @param state The requested power state.
+     */
+    virtual void set_power_state(PowerState state) = 0;
 
     /**
      * @brief Exports (core, addr) as a dma-buf fd for peer-to-peer PCIe DMA, backed by a dedicated

--- a/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
+++ b/device/api/umd/device/tt_device/protocol/pcie_protocol.hpp
@@ -53,6 +53,7 @@ public:
     int get_mmio_id() override;
 
     // PcieInterface.
+    void set_power_state(PowerState state) override;
     void bar_write32(uint32_t addr, uint32_t data) override;
     uint32_t bar_read32(uint32_t addr) override;
     int get_numa_node() const override;

--- a/device/api/umd/device/types/power_state.hpp
+++ b/device/api/umd/device/types/power_state.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace tt::umd {
+
+/**
+ * @brief Requested hardware power domain state for a device.
+ */
+enum class PowerState : uint8_t {
+    HIGH,  ///< Claims all power domains.
+    LOW,   ///< Releases power domains, allowing the device to enter lower power states.
+};
+
+}  // namespace tt::umd

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -140,7 +140,7 @@ bool PcieProtocol::write_to_core_range(
     return true;
 }
 
-int PcieProtocol::get_mmio_id() { return pci_device_->get_pci_device_id(); }
+int PcieProtocol::get_mmio_id() { return pci_device_->get_device_num(); }
 
 void PcieProtocol::noc_multicast_write(
     const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) {

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -25,6 +25,7 @@
 #include "umd/device/tt_device/protocol/pcie_dma/blackhole_dma_transfer.hpp"
 #include "umd/device/tt_device/protocol/pcie_dma/wormhole_dma_transfer.hpp"
 #include "umd/device/types/arch.hpp"
+#include "umd/device/types/power_state.hpp"
 #include "umd/device/types/tlb.hpp"
 #include "utils.hpp"
 
@@ -141,6 +142,11 @@ bool PcieProtocol::write_to_core_range(
 }
 
 int PcieProtocol::get_mmio_id() { return pci_device_->get_device_num(); }
+
+// PCIDevice takes a bool, so the requested state is narrowed here rather than in the interface.
+void PcieProtocol::set_power_state(PowerState state) {
+    pci_device_->set_power_state(/*busy=*/state == PowerState::HIGH);
+}
 
 void PcieProtocol::noc_multicast_write(
     const void* src, size_t size, tt_xy_pair core_start, tt_xy_pair core_end, uint64_t addr, NocId noc_id) {


### PR DESCRIPTION
## Issue

Requesting a hardware power domain change required reaching for `TTDevice` or `PCIDevice` directly: `TTDevice::set_power_state` calls `get_pci_device()->set_power_state(...)`, and `PcieInterface` had no power entry point at all.

## Description

Adds the operation to `PcieInterface` so any component holding that interface can request it. `PcieProtocol` is the adapter, so it narrows the requested state to the `bool` that `PCIDevice::set_power_state` takes.

`PowerState` is introduced in `types/power_state.hpp` rather than in either layer, so the protocol layer and its callers can both name it without depending on each other.

Arch and KMD version gating stays inside `PCIDevice::set_power_state` (it returns early for non-Blackhole and for KMD below `KMD_POWER_STATE`), so neither the interface nor its callers repeat it.

## List of the changes

- New `umd/device/types/power_state.hpp` defining `PowerState { HIGH, LOW }`.
- `PcieInterface::set_power_state(PowerState)` added, implemented in `PcieProtocol`.
- Header added to the installed `api` FILE_SET.

## Testing

No behavior change to verify: `PcieProtocol` is the only implementer of `PcieInterface`, there are no test mocks of it, and nothing calls the new method in this PR.

## API Changes

- `PcieInterface` gains a pure virtual `set_power_state(PowerState)`. Out-of-tree implementers of `PcieInterface` would need to implement it; there are none in this repo.
- New public header `umd/device/types/power_state.hpp`.

Stacked on #3200.