### PR TITLE
[Base API] Link gmock into the test targets

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ target_link_libraries(
         umd::tt-umd
         gtest_main
         gtest
+        gmock
         pthread
         spdlog::spdlog_header_only
         fmt::fmt-header-only

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -24,6 +24,9 @@ if(TT_UMD_BUILD_TESTS)
         SYSTEM YES
         OPTIONS
             "INSTALL_GTEST OFF"
+            # googletest builds gmock by default, but pin it so an upstream default change cannot
+            # silently drop the target that test_common links.
+            "BUILD_GMOCK ON"
     )
     if(GTest_ADDED)
         target_compile_options(gtest PRIVATE -Wno-implicit-int-float-conversion)


### PR DESCRIPTION
## Issue

Tests could not use mocks: nothing in the repo linked gmock, so components taking interfaces had to be tested against real hardware or hand-written fakes.

## Description

No new dependency is needed. googletest already ships googlemock and builds it by default, so the `gmock` target exists and simply was not linked.

## List of the changes

- `test_common` links `gmock` alongside `gtest`/`gtest_main`.
- `BUILD_GMOCK ON` pinned in the googletest CPM options, so an upstream default change cannot silently drop the target.

## Testing

Built the `gmock` target with `TT_UMD_BUILD_TESTS=ON` and confirmed `libgmock.a` is produced. First mock-based tests are in the next PR.

## API Changes

None. Test-only build change.

Stacked on #3204.