### PR TITLE
Refactor get_firmware_version_util() and make SemVer constructor explicit

### DIFF
--- a/device/api/umd/device/firmware/firmware_utils.hpp
+++ b/device/api/umd/device/firmware/firmware_utils.hpp
@@ -25,8 +25,6 @@ FirmwareBundleVersion get_minimum_compatible_firmware_version(tt::ARCH arch);
 
 FirmwareBundleVersion get_latest_supported_firmware_version(tt::ARCH arch);
 
-FirmwareBundleVersion get_firmware_version_util(TTDevice* tt_device);
-
 SemVer get_tt_flash_version_from_telemetry(const uint32_t telemetry_data);
 
 SemVer get_cm_fw_version_from_telemetry(const uint32_t telemetry_data, tt::ARCH arch);

--- a/device/api/umd/device/utils/semver.hpp
+++ b/device/api/umd/device/utils/semver.hpp
@@ -26,7 +26,7 @@ public:
 
     constexpr SemVer() : major(0), minor(0), patch(0), pre_release(0) {}
 
-    constexpr SemVer(uint64_t major, uint64_t minor = 0, uint64_t patch = 0, uint64_t pre_release = 0) :
+    constexpr explicit SemVer(uint64_t major, uint64_t minor = 0, uint64_t patch = 0, uint64_t pre_release = 0) :
         major(major), minor(minor), patch(patch), pre_release(pre_release) {}
 
     /*

--- a/device/arc/arc_telemetry_reader.cpp
+++ b/device/arc/arc_telemetry_reader.cpp
@@ -38,8 +38,8 @@ std::unique_ptr<ArcTelemetryReader> ArcTelemetryReader::create_arc_telemetry_rea
     switch (tt_device->get_arch()) {
         case tt::ARCH::WORMHOLE_B0: {
             reader = std::make_unique<SmBusArcTelemetryReader>(tt_device);
-            FirmwareBundleVersion fw_bundle_version =
-                reader->read_entry(wormhole::LegacyTelemetryTag::FW_BUNDLE_VERSION);
+            FirmwareBundleVersion fw_bundle_version = FirmwareBundleVersion::from_firmware_bundle_tag(
+                reader->read_entry(wormhole::LegacyTelemetryTag::FW_BUNDLE_VERSION));
 
             if (fw_bundle_version < FW_NEW_TELEMETRY) {
                 return reader;

--- a/device/arc/arc_telemetry_reader.cpp
+++ b/device/arc/arc_telemetry_reader.cpp
@@ -16,10 +16,12 @@
 #include "umd/device/arc/blackhole_arc_telemetry_reader.hpp"
 #include "umd/device/arc/smbus_arc_telemetry_reader.hpp"
 #include "umd/device/arc/wormhole_arc_telemetry_reader.hpp"
+#include "umd/device/firmware/firmware_telemetry_mapping.hpp"
 #include "umd/device/firmware/firmware_utils.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/noc_id.hpp"
+#include "umd/device/types/wormhole_telemetry.hpp"
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/semver.hpp"
 #include "utils.hpp"
@@ -35,15 +37,15 @@ std::unique_ptr<ArcTelemetryReader> ArcTelemetryReader::create_arc_telemetry_rea
     std::unique_ptr<ArcTelemetryReader> reader;
     switch (tt_device->get_arch()) {
         case tt::ARCH::WORMHOLE_B0: {
-            FirmwareBundleVersion fw_bundle_version = get_firmware_version_util(tt_device);
+            reader = std::make_unique<SmBusArcTelemetryReader>(tt_device);
+            FirmwareBundleVersion fw_bundle_version =
+                reader->read_entry(wormhole::LegacyTelemetryTag::FW_BUNDLE_VERSION);
 
-            if (fw_bundle_version >= FW_NEW_TELEMETRY) {
-                log_debug(tt::LogUMD, "Creating new-style telemetry reader.");
-                reader = std::make_unique<WormholeArcTelemetryReader>(tt_device);
-            } else {
-                log_debug(tt::LogUMD, "Creating old-style telemetry reader.");
-                reader = std::make_unique<SmBusArcTelemetryReader>(tt_device);
+            if (fw_bundle_version < FW_NEW_TELEMETRY) {
+                return reader;
             }
+
+            reader = std::make_unique<WormholeArcTelemetryReader>(tt_device);
             break;
         }
         case tt::ARCH::BLACKHOLE:

--- a/device/firmware/firmware_info_provider_implementation.cpp
+++ b/device/firmware/firmware_info_provider_implementation.cpp
@@ -39,9 +39,11 @@ FirmwareInfoProviderImplementation::FirmwareInfoProviderImplementation(TTDevice*
     }
     firmware_version = FirmwareBundleVersion(0, 0, 0);
     if (tt_device->get_arch() == ARCH::WORMHOLE_B0 && dynamic_cast<SmBusArcTelemetryReader*>(telemetry) != nullptr) {
-        firmware_version = telemetry->read_entry(wormhole::LegacyTelemetryTag::FW_BUNDLE_VERSION);
+        firmware_version = FirmwareBundleVersion::from_firmware_bundle_tag(
+            telemetry->read_entry(wormhole::LegacyTelemetryTag::FW_BUNDLE_VERSION));
     } else if (telemetry->is_entry_available(TelemetryTag::FLASH_BUNDLE_VERSION)) {
-        firmware_version = telemetry->read_entry(TelemetryTag::FLASH_BUNDLE_VERSION);
+        firmware_version =
+            FirmwareBundleVersion::from_firmware_bundle_tag(telemetry->read_entry(TelemetryTag::FLASH_BUNDLE_VERSION));
     }
 
     firmware_feature_map = create_firmware_feature_map(tt_device, firmware_version);

--- a/device/firmware/firmware_info_provider_implementation.cpp
+++ b/device/firmware/firmware_info_provider_implementation.cpp
@@ -26,16 +26,22 @@
 #include "umd/device/types/gddr_telemetry.hpp"
 #include "umd/device/types/telemetry.hpp"
 #include "umd/device/types/wormhole_dram.hpp"
+#include "umd/device/types/wormhole_telemetry.hpp"
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/semver.hpp"
 
 namespace tt::umd {
 
-FirmwareInfoProviderImplementation::FirmwareInfoProviderImplementation(TTDevice* tt_device) :
-    tt_device(tt_device), firmware_version(get_firmware_version_util(tt_device)) {
+FirmwareInfoProviderImplementation::FirmwareInfoProviderImplementation(TTDevice* tt_device) : tt_device(tt_device) {
     FirmwareTelemetryReader* telemetry = tt_device->get_firmware_telemetry_reader();
     if (telemetry == nullptr) {
         UMD_THROW(error::RuntimeError, "No telemetry reader present in tt_device.");
+    }
+    firmware_version = FirmwareBundleVersion(0, 0, 0);
+    if (tt_device->get_arch() == ARCH::WORMHOLE_B0 && dynamic_cast<SmBusArcTelemetryReader*>(telemetry) != nullptr) {
+        firmware_version = telemetry->read_entry(wormhole::LegacyTelemetryTag::FW_BUNDLE_VERSION);
+    } else if (telemetry->is_entry_available(TelemetryTag::FLASH_BUNDLE_VERSION)) {
+        firmware_version = telemetry->read_entry(TelemetryTag::FLASH_BUNDLE_VERSION);
     }
 
     firmware_feature_map = create_firmware_feature_map(tt_device, firmware_version);

--- a/device/firmware/firmware_utils.cpp
+++ b/device/firmware/firmware_utils.cpp
@@ -49,19 +49,6 @@ FirmwareBundleVersion get_minimum_compatible_firmware_version(tt::ARCH arch) {
     }
 }
 
-FirmwareBundleVersion get_firmware_version_util(TTDevice* tt_device) {
-    if (tt_device->get_arch() == tt::ARCH::WORMHOLE_B0) {
-        SmBusArcTelemetryReader smbus_reader(tt_device);
-        return FirmwareBundleVersion::from_firmware_bundle_tag(
-            smbus_reader.read_entry(wormhole::LegacyTelemetryTag::FW_BUNDLE_VERSION));
-    }
-    FirmwareTelemetryReader* telemetry = tt_device->get_firmware_telemetry_reader();
-    return telemetry->is_entry_available(TelemetryTag::FLASH_BUNDLE_VERSION)
-               ? FirmwareBundleVersion::from_firmware_bundle_tag(
-                     telemetry->read_entry(TelemetryTag::FLASH_BUNDLE_VERSION))
-               : FirmwareBundleVersion(0, 0, 0);
-}
-
 SemVer get_tt_flash_version_from_telemetry(const uint32_t telemetry_data) {
     return SemVer((telemetry_data >> 16) & 0xFF, (telemetry_data >> 8) & 0xFF, telemetry_data & 0xFF);
 }

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -38,6 +38,7 @@
 #include "umd/device/types/arch.hpp"
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/kmd_versions.hpp"
+#include "umd/device/utils/semver.hpp"
 #include "umd/device/utils/timeouts.hpp"
 #include "utils.hpp"
 
@@ -774,7 +775,7 @@ SemVer PCIDevice::read_kmd_version() {
 
     if (!file.is_open()) {
         log_warning(LogUMD, "Failed to open file: {}", path);
-        return {0, 0, 0};
+        return SemVer{0, 0, 0};
     }
 
     std::string version_str;
@@ -788,7 +789,7 @@ SemVer PCIDevice::read_kernel_version() {
 
     if (uname(&uts) != 0) {
         log_warning(LogUMD, "uname() failed: {}", strerror(errno));
-        return {0, 0, 0};
+        return SemVer{0, 0, 0};
     }
 
     // uts.release looks like "5.15.0-91-generic"; SemVer's parser reads leading digits of each


### PR DESCRIPTION
### Issue
Related to #2876 #2878 

### Description
Remove get_firmware_version_util(). This method won't be able to take a TTDevice in its arguments when constructing FirmwareTelemetryReader and FirmwareInfoProvider. The function is used when constructing FirmwareTelemetryReader, but constructs FirmwareTelemetryReader in itself and then deletes it.
Also, make SemVer constructor explicit.
### Testing
CI

### API Changes
This PR has API changes.
