### PR TITLE
Move register addresses to ArchitectureRegisters

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -62,6 +62,7 @@ target_sources(
     tt-umd
     PRIVATE
         arch/architecture_implementation.cpp
+        arch/architecture_registers.cpp
         chip/chip.cpp
         chip/local_chip.cpp
         chip/mock_chip.cpp
@@ -183,6 +184,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
             BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/api
             FILES
                 api/umd/device/arch/architecture_implementation.hpp
+                api/umd/device/arch/architecture_registers.hpp
                 api/umd/device/arc/arc_messenger.hpp
                 api/umd/device/arc/arc_telemetry_reader.hpp
                 api/umd/device/arc/firmware_telemetry_reader.hpp

--- a/device/api/umd/device/arch/architecture_implementation.hpp
+++ b/device/api/umd/device/arch/architecture_implementation.hpp
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "umd/device/arch/architecture_registers.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -25,8 +26,6 @@ enum class CoreType;
 }  // namespace tt
 
 namespace tt::umd {
-
-static const uint32_t HANG_READ_VALUE = 0xFFFFFFFFu;
 
 class ArchitectureImplementation {
 public:
@@ -48,9 +47,7 @@ public:
     virtual uint32_t get_dram_banks_number() const = 0;
     virtual uint32_t get_aiclk_busy_val() const = 0;
     virtual uint32_t get_num_eth_channels() const = 0;
-    virtual uint32_t get_read_checking_offset() const = 0;
     virtual uint32_t get_tensix_soft_reset_addr() const = 0;
-    virtual uint32_t get_debug_reg_addr() const = 0;
     virtual uint32_t get_soft_reset_reg_value(RiscType risc_type) const = 0;
     virtual RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const = 0;
     virtual uint32_t get_soft_reset_staggered_start() const = 0;
@@ -77,11 +74,6 @@ public:
     virtual DeviceL1AddressParams get_l1_address_params() const = 0;
 
     static std::unique_ptr<ArchitectureImplementation> create(tt::ARCH architecture);
-
-    virtual uint64_t get_noc_node_id_offset() const = 0;
-    virtual uint64_t get_noc_node_translated_id_offset() const = 0;
-    virtual uint64_t get_noc_reg_base(
-        const CoreType core_type, const uint32_t noc, const uint32_t noc_port = 0) const = 0;
 
     // Get preferred tlb size, which is the tlb group with the largest count available.
     virtual size_t get_cached_tlb_size() const = 0;

--- a/device/api/umd/device/arch/architecture_registers.hpp
+++ b/device/api/umd/device/arch/architecture_registers.hpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+
+namespace tt::umd {
+
+// A read returning all ones is how a hung bus or NOC shows up on every architecture.
+inline constexpr uint32_t HANG_READ_VALUE = 0xFFFFFFFFu;
+
+// Resolves the address of a NOC register within the control register block of a core type.
+using NocRegAddrResolver = uint64_t (*)(CoreType core_type, uint32_t noc, uint32_t noc_port);
+
+// Addresses of device registers which mean the same thing on every architecture but sit at
+// different addresses. Architecture specific code reads its own constants directly; this exists for
+// callers which are not tied to one architecture.
+struct ArchitectureRegisters {
+    // BAR0 offset of the NOC0 node id register. Reachable before the NOC is up, which is what makes
+    // it usable as the bus hang check.
+    uint32_t noc_node_id_bar_offset;
+
+    // Tensix RISCV debug bus control register.
+    uint32_t riscv_debug_bus_cntl_reg;
+
+    // The NOC node id registers sit in a per core type control register block, so their address is a
+    // lookup rather than a fixed offset.
+    NocRegAddrResolver get_noc_node_id_reg_addr;
+    NocRegAddrResolver get_noc_translated_id_reg_addr;
+};
+
+ArchitectureRegisters get_architecture_registers(const tt::ARCH arch);
+
+}  // namespace tt::umd

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -379,13 +379,7 @@ public:
 
     uint32_t get_num_eth_channels() const override { return blackhole::NUM_ETH_CHANNELS; }
 
-    uint32_t get_read_checking_offset() const override {
-        return blackhole::NIU_CFG_NOC0_BAR_PCIE_ADDR + blackhole::NOC_NODE_ID_OFFSET;
-    }
-
     uint32_t get_tensix_soft_reset_addr() const override { return blackhole::TENSIX_SOFT_RESET_ADDR; }
-
-    uint32_t get_debug_reg_addr() const override { return blackhole::RISCV_DEBUG_REG_DBG_BUS_CNTL_REG; }
 
     uint32_t get_soft_reset_reg_value(RiscType risc_type) const override;
 
@@ -433,12 +427,6 @@ public:
     uint32_t get_static_tlb_cfg_addr() const override { return blackhole::STATIC_TLB_CFG_ADDR; }
 
     DeviceL1AddressParams get_l1_address_params() const override;
-
-    uint64_t get_noc_node_id_offset() const override { return blackhole::NOC_NODE_ID_OFFSET; }
-
-    uint64_t get_noc_node_translated_id_offset() const override { return blackhole::NOC_ID_TRANSLATED_OFFSET; }
-
-    uint64_t get_noc_reg_base(const CoreType core_type, const uint32_t noc, const uint32_t noc_port = 0) const override;
 
     size_t get_cached_tlb_size() const override { return blackhole::STATIC_TLB_SIZE; }
 

--- a/device/api/umd/device/arch/grendel_implementation.hpp
+++ b/device/api/umd/device/arch/grendel_implementation.hpp
@@ -370,11 +370,7 @@ public:
 
     uint32_t get_num_eth_channels() const override { return grendel::NUM_ETH_CHANNELS; }
 
-    uint32_t get_read_checking_offset() const override { return grendel::BH_NOC_NODE_ID_OFFSET; }
-
     uint32_t get_tensix_soft_reset_addr() const override { return grendel::TENSIX_SOFT_RESET_ADDR; }
-
-    uint32_t get_debug_reg_addr() const override { return grendel::RISCV_DEBUG_REG_DBG_BUS_CNTL_REG; }
 
     uint32_t get_soft_reset_reg_value(RiscType risc_type) const override;
 
@@ -424,12 +420,6 @@ public:
     uint32_t get_static_tlb_cfg_addr() const override { return grendel::STATIC_TLB_CFG_ADDR; }
 
     DeviceL1AddressParams get_l1_address_params() const override;
-
-    uint64_t get_noc_node_id_offset() const override { return grendel::NOC_NODE_ID_OFFSET; }
-
-    uint64_t get_noc_node_translated_id_offset() const override { return grendel::BH_NOC_ID_TRANSLATED_OFFSET; }
-
-    uint64_t get_noc_reg_base(const CoreType core_type, const uint32_t noc, const uint32_t noc_port = 0) const override;
 
     size_t get_cached_tlb_size() const override { return grendel::STATIC_TLB_SIZE; }
 

--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -433,13 +433,7 @@ public:
 
     uint32_t get_num_eth_channels() const override { return wormhole::NUM_ETH_CHANNELS; }
 
-    uint32_t get_read_checking_offset() const override {
-        return wormhole::NIU_CFG_NOC0_BAR_ARC_ADDR + wormhole::NOC_NODE_ID_OFFSET;
-    }
-
     uint32_t get_tensix_soft_reset_addr() const override { return wormhole::TENSIX_SOFT_RESET_ADDR; }
-
-    uint32_t get_debug_reg_addr() const override { return wormhole::RISCV_DEBUG_REG_DBG_BUS_CNTL_REG; }
 
     uint32_t get_soft_reset_reg_value(RiscType risc_type) const override;
 
@@ -490,12 +484,6 @@ public:
     uint32_t get_static_tlb_cfg_addr() const override { return wormhole::STATIC_TLB_CFG_ADDR; }
 
     DeviceL1AddressParams get_l1_address_params() const override;
-
-    uint64_t get_noc_node_id_offset() const override { return wormhole::NOC_NODE_ID_OFFSET; }
-
-    uint64_t get_noc_node_translated_id_offset() const override { return wormhole::NOC_ID_TRANSLATED_OFFSET; }
-
-    uint64_t get_noc_reg_base(const CoreType core_type, const uint32_t noc, const uint32_t noc_port = 0) const override;
 
     size_t get_cached_tlb_size() const override { return wormhole::STATIC_TLB_SIZE; }
 

--- a/device/api/umd/device/tt_device/hang_detection/blackhole_hang_detector.hpp
+++ b/device/api/umd/device/tt_device/hang_detection/blackhole_hang_detector.hpp
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 
+#include "umd/device/arch/architecture_registers.hpp"
 #include "umd/device/tt_device/hang_detection/hang_detector_implementation.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
@@ -30,6 +31,7 @@ private:
     tt_xy_pair get_hang_check_core(NocId noc) const;
 
     bool noc_translation_enabled_;
+    const ArchitectureRegisters registers_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/hang_detection/wormhole_hang_detector.hpp
+++ b/device/api/umd/device/tt_device/hang_detection/wormhole_hang_detector.hpp
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 
+#include "umd/device/arch/architecture_registers.hpp"
 #include "umd/device/tt_device/hang_detection/hang_detector_implementation.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
@@ -25,6 +26,8 @@ private:
     uint32_t read_hang_check_reg_via_noc(NocId noc) override;
 
     static tt_xy_pair get_hang_check_core(NocId noc);
+
+    const ArchitectureRegisters registers_;
 };
 
 }  // namespace tt::umd

--- a/device/arch/architecture_registers.cpp
+++ b/device/arch/architecture_registers.cpp
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/arch/architecture_registers.hpp"
+
+#include <fmt/format.h>
+
+#include "umd/device/arch/blackhole_implementation.hpp"
+#include "umd/device/arch/grendel_implementation.hpp"
+#include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/core_coordinates.hpp"
+#include "umd/device/utils/error.hpp"
+
+namespace tt::umd {
+
+namespace wormhole {
+
+static uint64_t noc_reg_base(const CoreType core_type, const uint32_t noc, const uint32_t noc_port) {
+    if (noc == 0) {
+        for (const auto& noc_pair : NOC0_CONTROL_REG_ADDR_BASE_MAP) {
+            if (core_type == CoreType::DRAM) {
+                return DRAM_NOC0_CONTROL_REG_ADDR_BASE_MAP[noc_port];
+            }
+            if (noc_pair.first == core_type) {
+                return noc_pair.second;
+            }
+        }
+        UMD_THROW(error::RuntimeError, "Invalid core type for getting NOC register addr base.");
+    } else if (noc == 1) {
+        for (const auto& noc_pair : NOC1_CONTROL_REG_ADDR_BASE_MAP) {
+            if (noc_pair.first == core_type) {
+                if (core_type == CoreType::DRAM) {
+                    return DRAM_NOC1_CONTROL_REG_ADDR_BASE_MAP[noc_port];
+                }
+                return noc_pair.second;
+            }
+        }
+        UMD_THROW(error::RuntimeError, "Invalid core type for getting NOC register addr base.");
+    }
+
+    UMD_THROW(error::RuntimeError, fmt::format("Invalid NOC: {} for getting NOC register addr base.", noc));
+}
+
+static uint64_t noc_node_id_reg_addr(const CoreType core_type, const uint32_t noc, const uint32_t noc_port) {
+    return noc_reg_base(core_type, noc, noc_port) + NOC_NODE_ID_OFFSET;
+}
+
+static uint64_t noc_translated_id_reg_addr(const CoreType core_type, const uint32_t noc, const uint32_t noc_port) {
+    return noc_reg_base(core_type, noc, noc_port) + NOC_ID_TRANSLATED_OFFSET;
+}
+
+}  // namespace wormhole
+
+namespace blackhole {
+
+static uint64_t noc_reg_base(const CoreType core_type, const uint32_t noc, const uint32_t noc_port) {
+    if (noc == 0) {
+        for (const auto& noc_pair : NOC0_CONTROL_REG_ADDR_BASE_MAP) {
+            if (noc_pair.first == core_type) {
+                return noc_pair.second;
+            }
+        }
+        UMD_THROW(error::RuntimeError, "Invalid core type for getting NOC register addr base.");
+    } else if (noc == 1) {
+        for (const auto& noc_pair : NOC1_CONTROL_REG_ADDR_BASE_MAP) {
+            if (noc_pair.first == core_type) {
+                return noc_pair.second;
+            }
+        }
+        UMD_THROW(error::RuntimeError, "Invalid core type for getting NOC register addr base.");
+    }
+
+    UMD_THROW(error::RuntimeError, fmt::format("Invalid NOC: {} for getting NOC register addr base.", noc));
+}
+
+static uint64_t noc_node_id_reg_addr(const CoreType core_type, const uint32_t noc, const uint32_t noc_port) {
+    return noc_reg_base(core_type, noc, noc_port) + NOC_NODE_ID_OFFSET;
+}
+
+static uint64_t noc_translated_id_reg_addr(const CoreType core_type, const uint32_t noc, const uint32_t noc_port) {
+    return noc_reg_base(core_type, noc, noc_port) + NOC_ID_TRANSLATED_OFFSET;
+}
+
+}  // namespace blackhole
+
+namespace grendel {
+
+static uint64_t noc_reg_base(const CoreType core_type, const uint32_t noc, const uint32_t noc_port) {
+    if (noc == 0) {
+        for (const auto& noc_pair : NOC0_CONTROL_REG_ADDR_BASE_MAP) {
+            if (noc_pair.first == core_type) {
+                return noc_pair.second;
+            }
+        }
+        UMD_THROW(error::RuntimeError, "Invalid core type for getting NOC register addr base.");
+    } else if (noc == 1) {
+        for (const auto& noc_pair : NOC1_CONTROL_REG_ADDR_BASE_MAP) {
+            if (noc_pair.first == core_type) {
+                return noc_pair.second;
+            }
+        }
+        UMD_THROW(error::RuntimeError, "Invalid core type for getting NOC register addr base.");
+    }
+
+    UMD_THROW(error::RuntimeError, fmt::format("Invalid NOC: {} for getting NOC register addr base.", noc));
+}
+
+static uint64_t noc_node_id_reg_addr(const CoreType core_type, const uint32_t noc, const uint32_t noc_port) {
+    return noc_reg_base(core_type, noc, noc_port) + NOC_NODE_ID_OFFSET;
+}
+
+static uint64_t noc_translated_id_reg_addr(const CoreType core_type, const uint32_t noc, const uint32_t noc_port) {
+    return noc_reg_base(core_type, noc, noc_port) + BH_NOC_ID_TRANSLATED_OFFSET;
+}
+
+}  // namespace grendel
+
+ArchitectureRegisters get_architecture_registers(const tt::ARCH arch) {
+    switch (arch) {
+        case tt::ARCH::WORMHOLE_B0:
+            return {
+                .noc_node_id_bar_offset = wormhole::NIU_CFG_NOC0_BAR_ARC_ADDR + wormhole::NOC_NODE_ID_OFFSET,
+                .riscv_debug_bus_cntl_reg = wormhole::RISCV_DEBUG_REG_DBG_BUS_CNTL_REG,
+                .get_noc_node_id_reg_addr = &wormhole::noc_node_id_reg_addr,
+                .get_noc_translated_id_reg_addr = &wormhole::noc_translated_id_reg_addr,
+            };
+        case tt::ARCH::BLACKHOLE:
+            return {
+                .noc_node_id_bar_offset = blackhole::NIU_CFG_NOC0_BAR_PCIE_ADDR + blackhole::NOC_NODE_ID_OFFSET,
+                .riscv_debug_bus_cntl_reg = blackhole::RISCV_DEBUG_REG_DBG_BUS_CNTL_REG,
+                .get_noc_node_id_reg_addr = &blackhole::noc_node_id_reg_addr,
+                .get_noc_translated_id_reg_addr = &blackhole::noc_translated_id_reg_addr,
+            };
+        case tt::ARCH::QUASAR:
+            return {
+                .noc_node_id_bar_offset = grendel::BH_NOC_NODE_ID_OFFSET,
+                .riscv_debug_bus_cntl_reg = grendel::RISCV_DEBUG_REG_DBG_BUS_CNTL_REG,
+                .get_noc_node_id_reg_addr = &grendel::noc_node_id_reg_addr,
+                .get_noc_translated_id_reg_addr = &grendel::noc_translated_id_reg_addr,
+            };
+        default:
+            UMD_THROW(error::RuntimeError, fmt::format("No registers defined for {} architecture.", arch_to_str(arch)));
+    }
+}
+
+}  // namespace tt::umd

--- a/device/arch/blackhole_implementation.cpp
+++ b/device/arch/blackhole_implementation.cpp
@@ -48,27 +48,6 @@ DeviceL1AddressParams BlackholeImplementation::get_l1_address_params() const {
     return {blackhole::L1_BARRIER_BASE, blackhole::ERISC_BARRIER_BASE, blackhole::ETH_FW_VERSION_ADDR};
 }
 
-uint64_t BlackholeImplementation::get_noc_reg_base(
-    const CoreType core_type, const uint32_t noc, const uint32_t noc_port) const {
-    if (noc == 0) {
-        for (const auto& noc_pair : blackhole::NOC0_CONTROL_REG_ADDR_BASE_MAP) {
-            if (noc_pair.first == core_type) {
-                return noc_pair.second;
-            }
-        }
-        UMD_THROW(error::RuntimeError, "Invalid core type for getting NOC register addr base.");
-    } else if (noc == 1) {
-        for (const auto& noc_pair : blackhole::NOC1_CONTROL_REG_ADDR_BASE_MAP) {
-            if (noc_pair.first == core_type) {
-                return noc_pair.second;
-            }
-        }
-        UMD_THROW(error::RuntimeError, "Invalid core type for getting NOC register addr base.");
-    }
-
-    UMD_THROW(error::RuntimeError, fmt::format("Invalid NOC: {} for getting NOC register addr base.", noc));
-}
-
 uint32_t BlackholeImplementation::get_soft_reset_reg_value(RiscType risc_type) const {
     if ((risc_type & RiscType::ALL_NEO) != RiscType::NONE) {
         // Throw if any of the NEO cores are selected.

--- a/device/arch/grendel_implementation.cpp
+++ b/device/arch/grendel_implementation.cpp
@@ -48,27 +48,6 @@ DeviceL1AddressParams GrendelImplementation::get_l1_address_params() const {
     return {blackhole::L1_BARRIER_BASE, blackhole::ERISC_BARRIER_BASE, blackhole::ETH_FW_VERSION_ADDR};
 }
 
-uint64_t GrendelImplementation::get_noc_reg_base(
-    const CoreType core_type, const uint32_t noc, const uint32_t noc_port) const {
-    if (noc == 0) {
-        for (const auto& noc_pair : grendel::NOC0_CONTROL_REG_ADDR_BASE_MAP) {
-            if (noc_pair.first == core_type) {
-                return noc_pair.second;
-            }
-        }
-        UMD_THROW(error::RuntimeError, "Invalid core type for getting NOC register addr base.");
-    } else if (noc == 1) {
-        for (const auto& noc_pair : grendel::NOC1_CONTROL_REG_ADDR_BASE_MAP) {
-            if (noc_pair.first == core_type) {
-                return noc_pair.second;
-            }
-        }
-        UMD_THROW(error::RuntimeError, "Invalid core type for getting NOC register addr base.");
-    }
-
-    UMD_THROW(error::RuntimeError, fmt::format("Invalid NOC: {} for getting NOC register addr base.", noc));
-}
-
 uint32_t GrendelImplementation::get_soft_reset_reg_value(RiscType risc_type) const {
     if ((risc_type & RiscType::ALL_TENSIX) != RiscType::NONE) {
         // Throw if any of the NEO cores are selected.

--- a/device/arch/wormhole_implementation.cpp
+++ b/device/arch/wormhole_implementation.cpp
@@ -99,34 +99,6 @@ DriverEthInterfaceParams wormhole::get_eth_interface_params() {
 DriverNocParams wormhole::get_noc_params() { return {wormhole::NOC_ADDR_LOCAL_BITS, wormhole::NOC_ADDR_NODE_ID_BITS}; }
 
 // TODO: integrate noc_port for DRAM core type inside the function.
-uint64_t WormholeImplementation::get_noc_reg_base(
-    const CoreType core_type, const uint32_t noc, const uint32_t noc_port) const {
-    if (noc == 0) {
-        for (const auto& noc_pair : wormhole::NOC0_CONTROL_REG_ADDR_BASE_MAP) {
-            if (core_type == CoreType::DRAM) {
-                return wormhole::DRAM_NOC0_CONTROL_REG_ADDR_BASE_MAP[noc_port];
-            }
-            if (noc_pair.first == core_type) {
-                return noc_pair.second;
-            }
-        }
-        UMD_THROW(error::RuntimeError, "Invalid core type for getting NOC register addr base.");
-    } else if (noc == 1) {
-        for (const auto& noc_pair : wormhole::NOC1_CONTROL_REG_ADDR_BASE_MAP) {
-            if (noc_pair.first == core_type) {
-                if (core_type == CoreType::DRAM) {
-                    return wormhole::DRAM_NOC1_CONTROL_REG_ADDR_BASE_MAP[noc_port];
-                    ;
-                }
-                return noc_pair.second;
-            }
-        }
-        UMD_THROW(error::RuntimeError, "Invalid core type for getting NOC register addr base.");
-    }
-
-    UMD_THROW(error::RuntimeError, fmt::format("Invalid NOC: {} for getting NOC register addr base.", noc));
-}
-
 uint32_t WormholeImplementation::get_soft_reset_reg_value(RiscType risc_type) const {
     if ((risc_type & RiscType::ALL_NEO) != RiscType::NONE) {
         // Throw if any of the NEO cores are selected.

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -20,6 +20,7 @@
 #include "umd/device/arc/arc_messenger.hpp"
 #include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/architecture_registers.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/coordinates/coordinate_manager.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
@@ -334,7 +335,7 @@ EthTrainingStatus BlackholeTTDevice::read_eth_core_training_status(CoreCoord eth
 
 int BlackholeTTDevice::get_pcie_x_coordinate() {
     // Extract the x-coordinate from the register using the lower 6 bits.
-    return bar_read32(get_architecture_implementation()->get_read_checking_offset()) & 0x3F;
+    return bar_read32(get_architecture_registers(tt::ARCH::BLACKHOLE).noc_node_id_bar_offset) & 0x3F;
 }
 
 // ARC tile accessibility over AXI via PCIe depends on the PCIe tile's x-coordinate:

--- a/device/tt_device/hang_detection/blackhole_hang_detector.cpp
+++ b/device/tt_device/hang_detection/blackhole_hang_detector.cpp
@@ -8,7 +8,7 @@
 
 #include <vector>
 
-#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/architecture_registers.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -18,16 +18,17 @@ namespace tt::umd {
 
 BlackholeHangDetector::BlackholeHangDetector(
     DeviceProtocol* protocol, ArchitectureImplementation* arch_impl, bool noc_translation_enabled) :
-    HangDetectorImplementation(protocol, arch_impl), noc_translation_enabled_(noc_translation_enabled) {}
+    HangDetectorImplementation(protocol, arch_impl),
+    noc_translation_enabled_(noc_translation_enabled),
+    registers_(get_architecture_registers(tt::ARCH::BLACKHOLE)) {}
 
 uint32_t BlackholeHangDetector::read_hang_check_reg_via_bar() {
-    return get_pcie_interface()->bar_read32(get_arch_impl()->get_read_checking_offset());
+    return get_pcie_interface()->bar_read32(registers_.noc_node_id_bar_offset);
 }
 
 uint32_t BlackholeHangDetector::read_hang_check_reg_via_noc(NocId noc) {
     tt_xy_pair core = get_hang_check_core(noc);
-    uint64_t addr = get_arch_impl()->get_noc_reg_base(CoreType::PCIE, static_cast<uint32_t>(noc)) +
-                    get_arch_impl()->get_noc_node_id_offset();
+    uint64_t addr = registers_.get_noc_node_id_reg_addr(CoreType::PCIE, static_cast<uint32_t>(noc), 0);
     return read_noc_reg(core, addr, noc);
 }
 

--- a/device/tt_device/hang_detection/wormhole_hang_detector.cpp
+++ b/device/tt_device/hang_detection/wormhole_hang_detector.cpp
@@ -8,7 +8,7 @@
 
 #include <vector>
 
-#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/architecture_registers.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/tt_device/protocol/pcie_interface.hpp"
 #include "umd/device/types/core_coordinates.hpp"
@@ -17,16 +17,15 @@
 namespace tt::umd {
 
 WormholeHangDetector::WormholeHangDetector(DeviceProtocol* protocol, ArchitectureImplementation* arch_impl) :
-    HangDetectorImplementation(protocol, arch_impl) {}
+    HangDetectorImplementation(protocol, arch_impl), registers_(get_architecture_registers(tt::ARCH::WORMHOLE_B0)) {}
 
 uint32_t WormholeHangDetector::read_hang_check_reg_via_bar() {
-    return get_pcie_interface()->bar_read32(get_arch_impl()->get_read_checking_offset());
+    return get_pcie_interface()->bar_read32(registers_.noc_node_id_bar_offset);
 }
 
 uint32_t WormholeHangDetector::read_hang_check_reg_via_noc(NocId noc) {
     tt_xy_pair core = get_hang_check_core(noc);
-    uint64_t addr = get_arch_impl()->get_noc_reg_base(CoreType::ARC, static_cast<uint32_t>(noc)) +
-                    get_arch_impl()->get_noc_node_id_offset();
+    uint64_t addr = registers_.get_noc_node_id_reg_addr(CoreType::ARC, static_cast<uint32_t>(noc), 0);
     return read_noc_reg(core, addr, noc);
 }
 

--- a/tests/api/test_noc.cpp
+++ b/tests/api/test_noc.cpp
@@ -22,7 +22,7 @@
 #include <vector>
 
 #include "tests/test_utils/device_test_utils.hpp"
-#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/architecture_registers.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
@@ -150,10 +150,8 @@ public:
         // NOTE: The noc_port parameter is not used for Blackhole. Unlike Wormhole where DRAM banks
         // have multiple NOC ports with different register base addresses, Blackhole uses a single
         // register base address per core type.
-        const uint64_t noc_node_id_reg_addr =
-            cluster_->get_tt_device(0)->get_architecture_implementation()->get_noc_reg_base(
-                core.core_type, noc_index, noc_port) +
-            cluster_->get_tt_device(0)->get_architecture_implementation()->get_noc_node_id_offset();
+        const uint64_t noc_node_id_reg_addr = get_architecture_registers(cluster_->get_tt_device(0)->get_arch())
+                                                  .get_noc_node_id_reg_addr(core.core_type, noc_index, noc_port);
         uint32_t noc_node_id_val;
         cluster_->read_from_device_reg(&noc_node_id_val, chip, core, noc_node_id_reg_addr, sizeof(noc_node_id_val));
         uint32_t x = noc_node_id_val & 0x3F;
@@ -176,9 +174,8 @@ public:
     tt_xy_pair read_noc_translated_id_reg(ChipId chip, tt_xy_pair core, uint8_t noc_index) {
         auto noc_port = get_noc_port(core, noc_index);
         const uint64_t noc_translated_id_reg_addr =
-            cluster_->get_tt_device(chip)->get_architecture_implementation()->get_noc_reg_base(
-                CoreType::DRAM, noc_index, noc_port) +
-            cluster_->get_tt_device(chip)->get_architecture_implementation()->get_noc_node_translated_id_offset();
+            get_architecture_registers(cluster_->get_tt_device(chip)->get_arch())
+                .get_noc_translated_id_reg_addr(CoreType::DRAM, noc_index, noc_port);
 
         uint32_t noc_translated_id_val;
         cluster_->get_tt_device(chip)->read_from_device_reg(
@@ -194,9 +191,8 @@ public:
     tt_xy_pair read_noc_translated_id_reg(ChipId chip, CoreCoord core, uint8_t noc_index) {
         auto noc_port = get_noc_port(core);
         const uint64_t noc_translated_id_reg_addr =
-            cluster_->get_tt_device(chip)->get_architecture_implementation()->get_noc_reg_base(
-                core.core_type, noc_index, noc_port) +
-            cluster_->get_tt_device(chip)->get_architecture_implementation()->get_noc_node_translated_id_offset();
+            get_architecture_registers(cluster_->get_tt_device(chip)->get_arch())
+                .get_noc_translated_id_reg_addr(core.core_type, noc_index, noc_port);
 
         uint32_t noc_translated_id_val;
         cluster_->read_from_device_reg(
@@ -685,12 +681,10 @@ TEST_F(TestNoc, BlackholeRouterOnlyNoc1TranslatedCoords) {
         get_cluster()->get_soc_descriptor(chip).get_cores(CoreType::ROUTER_ONLY, CoordSystem::NOC1);
 
     auto* device = get_cluster()->get_tt_device(chip);
-    auto* arch_impl = device->get_architecture_implementation();
+    const ArchitectureRegisters registers = get_architecture_registers(device->get_arch());
 
-    const uint64_t noc_node_id_reg_addr =
-        arch_impl->get_noc_reg_base(CoreType::ROUTER_ONLY, 1, 0) + arch_impl->get_noc_node_id_offset();
-    const uint64_t noc_translated_id_reg_addr =
-        arch_impl->get_noc_reg_base(CoreType::ROUTER_ONLY, 1, 0) + arch_impl->get_noc_node_translated_id_offset();
+    const uint64_t noc_node_id_reg_addr = registers.get_noc_node_id_reg_addr(CoreType::ROUTER_ONLY, 1, 0);
+    const uint64_t noc_translated_id_reg_addr = registers.get_noc_translated_id_reg_addr(CoreType::ROUTER_ONLY, 1, 0);
 
     ASSERT_EQ(noc1_to_translated_router_only.size(), noc1_cores.size());
 

--- a/tests/api/test_tt_device.cpp
+++ b/tests/api/test_tt_device.cpp
@@ -17,7 +17,7 @@
 
 #include "tests/test_utils/device_test_utils.hpp"
 #include "tests/test_utils/test_api_common.hpp"
-#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/architecture_registers.hpp"
 #include "umd/device/chip/chip.hpp"
 #include "umd/device/cluster.hpp"
 #include "umd/device/cluster_descriptor.hpp"
@@ -73,7 +73,7 @@ TEST(ApiTTDeviceTest, TTDeviceRegIO) {
         std::unique_ptr<TTDevice> tt_device = TTDevice::create(pci_device_id);
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
-        uint64_t address = tt_device->get_architecture_implementation()->get_debug_reg_addr();
+        uint64_t address = get_architecture_registers(tt_device->get_arch()).riscv_debug_bus_cntl_reg;
 
         const SocDescriptor& soc_desc = tt_device->get_soc_descriptor();
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2873

### Description
Stacked on #3194.

Individual register addresses are not part of the Base API specification, so they move out of
`ArchitectureImplementation` into `ArchitectureRegisters`. Architecture specific code keeps
reading its own constants directly, this exists for callers which are not tied to one
architecture and previously had to go through the interface for it.

`architecture_registers.cpp` fills one struct per architecture in a single place, so adding an
architecture means editing one file. The NOC node id registers sit in a per core type control
register block, so those two entries are lookups rather than fixed offsets, and the register base
resolution stays private to that file.

`HANG_READ_VALUE` moves there too, it is the same kind of hardware fact and it has users beyond
hang detection.

### List of the changes
- Add `ArchitectureRegisters` with the NOC0 node id BAR offset, the Tensix RISCV debug register
  and the two NOC node id register lookups, filled per architecture.
- Remove the five NOC and debug register getters from the interface and its implementations, and
  move the NOC register base resolution out of the arch implementations.
- Move `HANG_READ_VALUE` out of the interface header into `architecture_registers.hpp`.
- The hang detectors, the Blackhole PCIe coordinate read and the NOC and TTDevice tests read
  through the new struct.

### Testing
Code builds. NOC register tests and hang detection tests cover these paths in CI.

### API Changes
This PR has API changes, five methods removed from `ArchitectureImplementation`, new
`ArchitectureRegisters` and `HANG_READ_VALUE` moved header.

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/arch_impl_12
