### PR TITLE
[Base API] Remove TTDevice dependency from FirmwareTelemetryReader

### DIFF
--- a/device/api/umd/device/arc/arc_telemetry_reader.hpp
+++ b/device/api/umd/device/arc/arc_telemetry_reader.hpp
@@ -12,6 +12,7 @@
 
 #include "firmware_telemetry_reader.hpp"
 #include "umd/device/types/arch.hpp"
+#include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/telemetry.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/timeouts.hpp"
@@ -68,12 +69,7 @@ protected:
     std::map<uint32_t, uint32_t> telemetry_values;
     std::map<uint32_t, uint32_t> telemetry_offset;
 
-    // During initialization of telemetry, if the NOC0 is hung then we need to read the telemetry values from NOC1.
-    // Both sets of ARC core coordinates are kept, get_arc_core() picks the one for the selected NOC.
-    tt_xy_pair arc_core_noc0;
-    tt_xy_pair arc_core_noc1;
-
-    tt_xy_pair get_arc_core() const;
+    tt_xy_pair get_arc_core(NocId noc_id) const;
 
     DeviceProtocol* device_protocol;
 
@@ -96,6 +92,11 @@ private:
         TelemetryTag::ENABLED_GDDR,
         TelemetryTag::ENABLED_L2CPU,
         TelemetryTag::PCIE_USAGE};
+
+    // During initialization of telemetry, if the NOC0 is hung then we need to read the telemetry values from NOC1.
+    // Both sets of ARC core coordinates are kept, get_arc_core() picks the one for the selected NOC.
+    tt_xy_pair arc_core_noc0;
+    tt_xy_pair arc_core_noc1;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/arc/arc_telemetry_reader.hpp
+++ b/device/api/umd/device/arc/arc_telemetry_reader.hpp
@@ -11,12 +11,13 @@
 #include <unordered_set>
 
 #include "firmware_telemetry_reader.hpp"
+#include "umd/device/types/arch.hpp"
 #include "umd/device/types/telemetry.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
-class TTDevice;
+class DeviceProtocol;
 
 class ArcTelemetryReader : public FirmwareTelemetryReader {
 public:
@@ -26,10 +27,14 @@ public:
 
     // Constructs the reader and waits for the ARC telemetry table to be fully populated.
     static std::unique_ptr<ArcTelemetryReader> create_arc_telemetry_reader(
-        TTDevice* tt_device, std::chrono::milliseconds timeout_ms = timeout::TELEMETRY_INIT_TIMEOUT);
+        DeviceProtocol* device_protocol,
+        const tt::ARCH arch,
+        const tt_xy_pair arc_core_noc0,
+        const tt_xy_pair arc_core_noc1,
+        std::chrono::milliseconds timeout_ms = timeout::TELEMETRY_INIT_TIMEOUT);
 
 protected:
-    ArcTelemetryReader(TTDevice* tt_device);
+    ArcTelemetryReader(DeviceProtocol* device_protocol, const tt_xy_pair arc_core_noc0, const tt_xy_pair arc_core_noc1);
 
     // Wait until ARC firmware has published the telemetry table. ARC writes the table pointer
     // register only after the whole table has been populated, so a non-zero pointer register
@@ -65,9 +70,13 @@ protected:
     std::map<uint32_t, uint32_t> telemetry_offset;
 
     // During initialization of telemetry, if the NOC0 is hung then we need to read the telemetry values from NOC1.
-    tt_xy_pair arc_core;
+    // Both sets of ARC core coordinates are kept, get_arc_core() picks the one for the selected NOC.
+    tt_xy_pair arc_core_noc0;
+    tt_xy_pair arc_core_noc1;
 
-    TTDevice* tt_device;
+    tt_xy_pair get_arc_core() const;
+
+    DeviceProtocol* device_protocol;
 
 private:
     const std::unordered_set<uint16_t> static_entries{

--- a/device/api/umd/device/arc/arc_telemetry_reader.hpp
+++ b/device/api/umd/device/arc/arc_telemetry_reader.hpp
@@ -30,8 +30,7 @@ public:
         DeviceProtocol* device_protocol,
         const tt::ARCH arch,
         const tt_xy_pair arc_core_noc0,
-        const tt_xy_pair arc_core_noc1,
-        std::chrono::milliseconds timeout_ms = timeout::TELEMETRY_INIT_TIMEOUT);
+        const tt_xy_pair arc_core_noc1);
 
 protected:
     ArcTelemetryReader(DeviceProtocol* device_protocol, const tt_xy_pair arc_core_noc0, const tt_xy_pair arc_core_noc1);

--- a/device/api/umd/device/arc/blackhole_arc_telemetry_reader.hpp
+++ b/device/api/umd/device/arc/blackhole_arc_telemetry_reader.hpp
@@ -8,11 +8,12 @@
 #include "umd/device/arch/blackhole_implementation.hpp"
 
 namespace tt::umd {
-class TTDevice;
+class DeviceProtocol;
 
 class BlackholeArcTelemetryReader : public ArcTelemetryReader {
 public:
-    BlackholeArcTelemetryReader(TTDevice* tt_device);
+    BlackholeArcTelemetryReader(
+        DeviceProtocol* device_protocol, const tt_xy_pair arc_core_noc0, const tt_xy_pair arc_core_noc1);
 
 protected:
     void get_telemetry_address() override;

--- a/device/api/umd/device/arc/smbus_arc_telemetry_reader.hpp
+++ b/device/api/umd/device/arc/smbus_arc_telemetry_reader.hpp
@@ -35,7 +35,7 @@ protected:
     void get_telemetry_address() override;
 
 private:
-    uint64_t telemetry_base_noc_addr;
+    static constexpr uint64_t SMBUS_TELEMETRY_NOC_ADDR = 0x820078d60;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/arc/smbus_arc_telemetry_reader.hpp
+++ b/device/api/umd/device/arc/smbus_arc_telemetry_reader.hpp
@@ -9,16 +9,16 @@
 #include <unordered_set>
 
 #include "umd/device/arc/arc_telemetry_reader.hpp"
-#include "umd/device/tt_device/tt_device.hpp"
 #include "umd/device/types/telemetry.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
-class TTDevice;
+class DeviceProtocol;
 
 class SmBusArcTelemetryReader : public ArcTelemetryReader {
 public:
-    SmBusArcTelemetryReader(TTDevice* tt_device);
+    SmBusArcTelemetryReader(
+        DeviceProtocol* device_protocol, const tt_xy_pair arc_core_noc0, const tt_xy_pair arc_core_noc1);
 
     uint32_t read_entry(const uint8_t telemetry_tag, [[maybe_unused]] NocId noc_id = NocId::DEFAULT_NOC) override;
 

--- a/device/api/umd/device/arc/wormhole_arc_telemetry_reader.hpp
+++ b/device/api/umd/device/arc/wormhole_arc_telemetry_reader.hpp
@@ -9,11 +9,12 @@
 #include "umd/device/arch/wormhole_implementation.hpp"
 
 namespace tt::umd {
-class TTDevice;
+class DeviceProtocol;
 
 class WormholeArcTelemetryReader : public ArcTelemetryReader {
 public:
-    WormholeArcTelemetryReader(TTDevice* tt_device);
+    WormholeArcTelemetryReader(
+        DeviceProtocol* device_protocol, const tt_xy_pair arc_core_noc0, const tt_xy_pair arc_core_noc1);
 
 protected:
     void get_telemetry_address() override;

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -387,6 +387,8 @@ public:
 
     tt_xy_pair get_arc_core() const;
 
+    tt_xy_pair get_arc_core(const NocId noc_id) const;
+
     FirmwareInfoProvider *get_firmware_info_provider() const;
 
     /**

--- a/device/arc/arc_telemetry_reader.cpp
+++ b/device/arc/arc_telemetry_reader.cpp
@@ -31,9 +31,11 @@ static constexpr FirmwareBundleVersion FW_NEW_TELEMETRY = FirmwareBundleVersion(
 
 ArcTelemetryReader::ArcTelemetryReader(
     DeviceProtocol* device_protocol, const tt_xy_pair arc_core_noc0, const tt_xy_pair arc_core_noc1) :
-    arc_core_noc0(arc_core_noc0), arc_core_noc1(arc_core_noc1), device_protocol(device_protocol) {}
+    device_protocol(device_protocol), arc_core_noc0(arc_core_noc0), arc_core_noc1(arc_core_noc1) {}
 
-tt_xy_pair ArcTelemetryReader::get_arc_core() const { return is_selected_noc1() ? arc_core_noc1 : arc_core_noc0; }
+tt_xy_pair ArcTelemetryReader::get_arc_core(NocId noc_id) const {
+    return noc_id == NocId::NOC1 ? arc_core_noc1 : arc_core_noc0;
+}
 
 std::unique_ptr<ArcTelemetryReader> ArcTelemetryReader::create_arc_telemetry_reader(
     DeviceProtocol* device_protocol,
@@ -65,7 +67,11 @@ std::unique_ptr<ArcTelemetryReader> ArcTelemetryReader::create_arc_telemetry_rea
 
 void ArcTelemetryReader::initialize_telemetry() {
     device_protocol->read_data(
-        &entry_count, get_arc_core(), telemetry_table_addr + sizeof(uint32_t), sizeof(uint32_t), get_selected_noc_id());
+        &entry_count,
+        get_arc_core(get_selected_noc_id()),
+        telemetry_table_addr + sizeof(uint32_t),
+        sizeof(uint32_t),
+        get_selected_noc_id());
 
     // We offset the tag_table_address by 2 * sizeof(uint32_t) to skip the first two uint32_t values,
     // which are version and entry count. For representaiton look at telemetry.h
@@ -73,7 +79,7 @@ void ArcTelemetryReader::initialize_telemetry() {
     std::vector<TelemetryTagEntry> telemetry_tag_entries(entry_count);
     device_protocol->read_data(
         telemetry_tag_entries.data(),
-        get_arc_core(),
+        get_arc_core(get_selected_noc_id()),
         tag_table_address,
         entry_count * sizeof(TelemetryTagEntry),
         get_selected_noc_id());
@@ -81,7 +87,7 @@ void ArcTelemetryReader::initialize_telemetry() {
     std::vector<uint32_t> telemetry_data(entry_count);
     device_protocol->read_data(
         telemetry_data.data(),
-        get_arc_core(),
+        get_arc_core(get_selected_noc_id()),
         telemetry_values_addr,
         entry_count * sizeof(uint32_t),
         get_selected_noc_id());
@@ -92,7 +98,11 @@ void ArcTelemetryReader::initialize_telemetry() {
         // 4 * i is to get to the i-th entry in the tag table where each entry is 4 bytes big.
         // Looking at layout in arc_telemetry_reader.h for reference.
         device_protocol->read_data(
-            &tag_offset, get_arc_core(), telemetry_table_addr + 8 + 4 * i, sizeof(uint32_t), get_selected_noc_id());
+            &tag_offset,
+            get_arc_core(get_selected_noc_id()),
+            telemetry_table_addr + 8 + 4 * i,
+            sizeof(uint32_t),
+            get_selected_noc_id());
 
         const uint16_t tag_val = tag_offset & 0xFFFF;
         const uint16_t offset_val = tag_offset >> 16;
@@ -120,7 +130,7 @@ uint32_t ArcTelemetryReader::read_entry(const uint8_t telemetry_tag, NocId noc_i
     uint32_t telemetry_val;
     device_protocol->read_data(
         &telemetry_val,
-        get_arc_core(),
+        get_arc_core(noc_id),
         telemetry_values_addr + offset * sizeof(uint32_t),
         sizeof(uint32_t),
         get_selected_noc_id());

--- a/device/arc/arc_telemetry_reader.cpp
+++ b/device/arc/arc_telemetry_reader.cpp
@@ -39,8 +39,7 @@ std::unique_ptr<ArcTelemetryReader> ArcTelemetryReader::create_arc_telemetry_rea
     DeviceProtocol* device_protocol,
     const tt::ARCH arch,
     const tt_xy_pair arc_core_noc0,
-    const tt_xy_pair arc_core_noc1,
-    std::chrono::milliseconds timeout_ms) {
+    const tt_xy_pair arc_core_noc1) {
     std::unique_ptr<ArcTelemetryReader> reader;
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: {

--- a/device/arc/arc_telemetry_reader.cpp
+++ b/device/arc/arc_telemetry_reader.cpp
@@ -56,7 +56,6 @@ std::unique_ptr<ArcTelemetryReader> ArcTelemetryReader::create_arc_telemetry_rea
             break;
         }
         case tt::ARCH::BLACKHOLE:
-            log_debug(tt::LogUMD, "Creating new-style telemetry reader.");
             reader = std::make_unique<BlackholeArcTelemetryReader>(device_protocol, arc_core_noc0, arc_core_noc1);
             break;
         default:

--- a/device/arc/arc_telemetry_reader.cpp
+++ b/device/arc/arc_telemetry_reader.cpp
@@ -133,7 +133,7 @@ uint32_t ArcTelemetryReader::read_entry(const uint8_t telemetry_tag, NocId noc_i
         get_arc_core(noc_id),
         telemetry_values_addr + offset * sizeof(uint32_t),
         sizeof(uint32_t),
-        get_selected_noc_id());
+        noc_id);
 
     telemetry_values[telemetry_tag] = telemetry_val;
     return telemetry_values[telemetry_tag];

--- a/device/arc/arc_telemetry_reader.cpp
+++ b/device/arc/arc_telemetry_reader.cpp
@@ -130,10 +130,10 @@ uint32_t ArcTelemetryReader::read_entry(const uint8_t telemetry_tag, NocId noc_i
     uint32_t telemetry_val;
     device_protocol->read_data(
         &telemetry_val,
-        get_arc_core(noc_id),
+        get_arc_core(get_selected_noc_id()),
         telemetry_values_addr + offset * sizeof(uint32_t),
         sizeof(uint32_t),
-        noc_id);
+        get_selected_noc_id());
 
     telemetry_values[telemetry_tag] = telemetry_val;
     return telemetry_values[telemetry_tag];

--- a/device/arc/arc_telemetry_reader.cpp
+++ b/device/arc/arc_telemetry_reader.cpp
@@ -12,14 +12,15 @@
 #include <thread>
 #include <vector>
 
+#include "noc_access.hpp"
 #include "tt-logger/tt-logger.hpp"
 #include "umd/device/arc/blackhole_arc_telemetry_reader.hpp"
 #include "umd/device/arc/smbus_arc_telemetry_reader.hpp"
 #include "umd/device/arc/wormhole_arc_telemetry_reader.hpp"
-#include "umd/device/firmware/firmware_utils.hpp"
-#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/noc_id.hpp"
+#include "umd/device/types/wormhole_telemetry.hpp"
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/semver.hpp"
 #include "utils.hpp"
@@ -28,27 +29,39 @@ namespace tt::umd {
 
 static constexpr FirmwareBundleVersion FW_NEW_TELEMETRY = FirmwareBundleVersion(18, 4, 0);
 
-ArcTelemetryReader::ArcTelemetryReader(TTDevice* tt_device) : tt_device(tt_device) {}
+ArcTelemetryReader::ArcTelemetryReader(
+    DeviceProtocol* device_protocol, const tt_xy_pair arc_core_noc0, const tt_xy_pair arc_core_noc1) :
+    arc_core_noc0(arc_core_noc0), arc_core_noc1(arc_core_noc1), device_protocol(device_protocol) {}
+
+tt_xy_pair ArcTelemetryReader::get_arc_core() const { return is_selected_noc1() ? arc_core_noc1 : arc_core_noc0; }
 
 std::unique_ptr<ArcTelemetryReader> ArcTelemetryReader::create_arc_telemetry_reader(
-    TTDevice* tt_device, std::chrono::milliseconds timeout_ms) {
+    DeviceProtocol* device_protocol,
+    const tt::ARCH arch,
+    const tt_xy_pair arc_core_noc0,
+    const tt_xy_pair arc_core_noc1,
+    std::chrono::milliseconds timeout_ms) {
     std::unique_ptr<ArcTelemetryReader> reader;
-    switch (tt_device->get_arch()) {
+    switch (arch) {
         case tt::ARCH::WORMHOLE_B0: {
-            FirmwareBundleVersion fw_bundle_version = get_firmware_version_util(tt_device);
+            // The SMBus telemetry table is the only one guaranteed to exist on all Wormhole firmware versions, so
+            // the bundle version deciding which reader to create has to be read through it.
+            SmBusArcTelemetryReader smbus_reader(device_protocol, arc_core_noc0, arc_core_noc1);
+            const FirmwareBundleVersion fw_bundle_version = FirmwareBundleVersion::from_firmware_bundle_tag(
+                smbus_reader.read_entry(wormhole::LegacyTelemetryTag::FW_BUNDLE_VERSION));
 
             if (fw_bundle_version >= FW_NEW_TELEMETRY) {
                 log_debug(tt::LogUMD, "Creating new-style telemetry reader.");
-                reader = std::make_unique<WormholeArcTelemetryReader>(tt_device);
+                reader = std::make_unique<WormholeArcTelemetryReader>(device_protocol, arc_core_noc0, arc_core_noc1);
             } else {
                 log_debug(tt::LogUMD, "Creating old-style telemetry reader.");
-                reader = std::make_unique<SmBusArcTelemetryReader>(tt_device);
+                reader = std::make_unique<SmBusArcTelemetryReader>(device_protocol, arc_core_noc0, arc_core_noc1);
             }
             break;
         }
         case tt::ARCH::BLACKHOLE:
             log_debug(tt::LogUMD, "Creating new-style telemetry reader.");
-            reader = std::make_unique<BlackholeArcTelemetryReader>(tt_device);
+            reader = std::make_unique<BlackholeArcTelemetryReader>(device_protocol, arc_core_noc0, arc_core_noc1);
             break;
         default:
             UMD_THROW(error::RuntimeError, "Unsupported architecture for creating ArcTelemetryReader.");
@@ -57,31 +70,35 @@ std::unique_ptr<ArcTelemetryReader> ArcTelemetryReader::create_arc_telemetry_rea
 }
 
 void ArcTelemetryReader::initialize_telemetry() {
-    tt_device->read_from_device(
-        &entry_count, arc_core, telemetry_table_addr + sizeof(uint32_t), sizeof(uint32_t), get_selected_noc_id());
+    device_protocol->read_data(
+        &entry_count, get_arc_core(), telemetry_table_addr + sizeof(uint32_t), sizeof(uint32_t), get_selected_noc_id());
 
     // We offset the tag_table_address by 2 * sizeof(uint32_t) to skip the first two uint32_t values,
     // which are version and entry count. For representaiton look at telemetry.h
     uint64_t tag_table_address = telemetry_table_addr + 2 * sizeof(uint32_t);
     std::vector<TelemetryTagEntry> telemetry_tag_entries(entry_count);
-    tt_device->read_from_device(
+    device_protocol->read_data(
         telemetry_tag_entries.data(),
-        arc_core,
+        get_arc_core(),
         tag_table_address,
         entry_count * sizeof(TelemetryTagEntry),
         get_selected_noc_id());
 
     std::vector<uint32_t> telemetry_data(entry_count);
-    tt_device->read_from_device(
-        telemetry_data.data(), arc_core, telemetry_values_addr, entry_count * sizeof(uint32_t), get_selected_noc_id());
+    device_protocol->read_data(
+        telemetry_data.data(),
+        get_arc_core(),
+        telemetry_values_addr,
+        entry_count * sizeof(uint32_t),
+        get_selected_noc_id());
 
     for (uint32_t i = 0; i < entry_count; ++i) {
         uint32_t tag_offset;
         // + 8 is to skip first 2 numbers representing version and entry count.
         // 4 * i is to get to the i-th entry in the tag table where each entry is 4 bytes big.
         // Looking at layout in arc_telemetry_reader.h for reference.
-        tt_device->read_from_device(
-            &tag_offset, arc_core, telemetry_table_addr + 8 + 4 * i, sizeof(uint32_t), get_selected_noc_id());
+        device_protocol->read_data(
+            &tag_offset, get_arc_core(), telemetry_table_addr + 8 + 4 * i, sizeof(uint32_t), get_selected_noc_id());
 
         const uint16_t tag_val = tag_offset & 0xFFFF;
         const uint16_t offset_val = tag_offset >> 16;
@@ -107,9 +124,9 @@ uint32_t ArcTelemetryReader::read_entry(const uint8_t telemetry_tag, NocId noc_i
 
     const uint32_t offset = telemetry_offset.at(telemetry_tag);
     uint32_t telemetry_val;
-    tt_device->read_from_device(
+    device_protocol->read_data(
         &telemetry_val,
-        arc_core,
+        get_arc_core(),
         telemetry_values_addr + offset * sizeof(uint32_t),
         sizeof(uint32_t),
         get_selected_noc_id());

--- a/device/arc/blackhole_arc_telemetry_reader.cpp
+++ b/device/arc/blackhole_arc_telemetry_reader.cpp
@@ -8,22 +8,34 @@
 
 #include "noc_access.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
-#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/protocol/device_protocol.hpp"
 
 namespace tt::umd {
 
-BlackholeArcTelemetryReader::BlackholeArcTelemetryReader(TTDevice* tt_device) : ArcTelemetryReader(tt_device) {
-    arc_core = blackhole::get_arc_core(tt_device->get_noc_translation_enabled(), is_selected_noc1());
+BlackholeArcTelemetryReader::BlackholeArcTelemetryReader(
+    DeviceProtocol* device_protocol, const tt_xy_pair arc_core_noc0, const tt_xy_pair arc_core_noc1) :
+    ArcTelemetryReader(device_protocol, arc_core_noc0, arc_core_noc1) {
     wait_for_telemetry_initialized();
 }
 
 void BlackholeArcTelemetryReader::get_telemetry_address() {
+    // The ARC APB scratch RAM registers are reached over the NOC through the ARC XBAR window.
     uint32_t telemetry_table_addr_u32;
-    tt_device->read_from_arc_apb(&telemetry_table_addr_u32, blackhole::SCRATCH_RAM_13, sizeof(uint32_t));
+    device_protocol->read_ctrl(
+        &telemetry_table_addr_u32,
+        get_arc_core(),
+        blackhole::ARC_NOC_XBAR_ADDRESS_START + blackhole::SCRATCH_RAM_13,
+        sizeof(uint32_t),
+        get_selected_noc_id());
     telemetry_table_addr_reg = telemetry_table_addr_u32;
     telemetry_table_addr = telemetry_table_addr_u32;
     uint32_t telemetry_values_addr_u32;
-    tt_device->read_from_arc_apb(&telemetry_values_addr_u32, blackhole::SCRATCH_RAM_12, sizeof(uint32_t));
+    device_protocol->read_ctrl(
+        &telemetry_values_addr_u32,
+        get_arc_core(),
+        blackhole::ARC_NOC_XBAR_ADDRESS_START + blackhole::SCRATCH_RAM_12,
+        sizeof(uint32_t),
+        get_selected_noc_id());
     telemetry_values_addr = telemetry_values_addr_u32;
 }
 

--- a/device/arc/blackhole_arc_telemetry_reader.cpp
+++ b/device/arc/blackhole_arc_telemetry_reader.cpp
@@ -23,7 +23,7 @@ void BlackholeArcTelemetryReader::get_telemetry_address() {
     uint32_t telemetry_table_addr_u32;
     device_protocol->read_ctrl(
         &telemetry_table_addr_u32,
-        get_arc_core(),
+        get_arc_core(get_selected_noc_id()),
         blackhole::ARC_NOC_XBAR_ADDRESS_START + blackhole::SCRATCH_RAM_13,
         sizeof(uint32_t),
         get_selected_noc_id());
@@ -32,7 +32,7 @@ void BlackholeArcTelemetryReader::get_telemetry_address() {
     uint32_t telemetry_values_addr_u32;
     device_protocol->read_ctrl(
         &telemetry_values_addr_u32,
-        get_arc_core(),
+        get_arc_core(get_selected_noc_id()),
         blackhole::ARC_NOC_XBAR_ADDRESS_START + blackhole::SCRATCH_RAM_12,
         sizeof(uint32_t),
         get_selected_noc_id());

--- a/device/arc/smbus_arc_telemetry_reader.cpp
+++ b/device/arc/smbus_arc_telemetry_reader.cpp
@@ -44,7 +44,7 @@ uint32_t SmBusArcTelemetryReader::read_entry(const uint8_t telemetry_tag, NocId 
     uint32_t telemetry_value;
     device_protocol->read_data(
         &telemetry_value,
-        get_arc_core(),
+        get_arc_core(noc_id),
         SMBUS_TELEMETRY_NOC_ADDR + telemetry_tag * sizeof(uint32_t),
         sizeof(uint32_t),
         get_selected_noc_id());

--- a/device/arc/smbus_arc_telemetry_reader.cpp
+++ b/device/arc/smbus_arc_telemetry_reader.cpp
@@ -31,16 +31,7 @@ SmBusArcTelemetryReader::SmBusArcTelemetryReader(TTDevice* tt_device) : ArcTelem
     SmBusArcTelemetryReader::wait_for_telemetry_initialized();
 }
 
-void SmBusArcTelemetryReader::get_telemetry_address() {
-    std::vector<uint32_t> arc_msg_return_values = {0};
-    tt_device->get_arc_messenger()->send_message(
-        wormhole::ARC_MSG_COMMON_PREFIX | (uint32_t)wormhole::arc_message_type::GET_SMBUS_TELEMETRY_ADDR,
-        arc_msg_return_values,
-        {0, 0});
-
-    static constexpr uint64_t noc_telemetry_offset = 0x810000000;
-    telemetry_base_noc_addr = arc_msg_return_values[0] + noc_telemetry_offset;
-}
+void SmBusArcTelemetryReader::get_telemetry_address() {}
 
 uint32_t SmBusArcTelemetryReader::read_entry(const uint8_t telemetry_tag, NocId noc_id) {
     if (!is_entry_available(telemetry_tag, noc_id)) {
@@ -56,7 +47,7 @@ uint32_t SmBusArcTelemetryReader::read_entry(const uint8_t telemetry_tag, NocId 
     tt_device->read_from_device(
         &telemetry_value,
         arc_core,
-        telemetry_base_noc_addr + telemetry_tag * sizeof(uint32_t),
+        SMBUS_TELEMETRY_NOC_ADDR + telemetry_tag * sizeof(uint32_t),
         sizeof(uint32_t),
         get_selected_noc_id());
 

--- a/device/arc/smbus_arc_telemetry_reader.cpp
+++ b/device/arc/smbus_arc_telemetry_reader.cpp
@@ -14,7 +14,7 @@
 #include "noc_access.hpp"
 #include "tt-logger/tt-logger.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
-#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/wormhole_telemetry.hpp"
 #include "umd/device/types/xy_pair.hpp"
@@ -22,11 +22,9 @@
 
 namespace tt::umd {
 
-SmBusArcTelemetryReader::SmBusArcTelemetryReader(TTDevice* tt_device) : ArcTelemetryReader(tt_device) {
-    arc_core = !is_selected_noc1() ? wormhole::ARC_CORES_NOC0[0]
-                                   : tt_xy_pair(
-                                         wormhole::NOC0_X_TO_NOC1_X[wormhole::ARC_CORES_NOC0[0].x],
-                                         wormhole::NOC0_Y_TO_NOC1_Y[wormhole::ARC_CORES_NOC0[0].y]);
+SmBusArcTelemetryReader::SmBusArcTelemetryReader(
+    DeviceProtocol* device_protocol, const tt_xy_pair arc_core_noc0, const tt_xy_pair arc_core_noc1) :
+    ArcTelemetryReader(device_protocol, arc_core_noc0, arc_core_noc1) {
     SmBusArcTelemetryReader::get_telemetry_address();
     SmBusArcTelemetryReader::wait_for_telemetry_initialized();
 }
@@ -44,9 +42,9 @@ uint32_t SmBusArcTelemetryReader::read_entry(const uint8_t telemetry_tag, NocId 
     }
 
     uint32_t telemetry_value;
-    tt_device->read_from_device(
+    device_protocol->read_data(
         &telemetry_value,
-        arc_core,
+        get_arc_core(),
         SMBUS_TELEMETRY_NOC_ADDR + telemetry_tag * sizeof(uint32_t),
         sizeof(uint32_t),
         get_selected_noc_id());

--- a/device/arc/smbus_arc_telemetry_reader.cpp
+++ b/device/arc/smbus_arc_telemetry_reader.cpp
@@ -12,13 +12,13 @@
 #include <vector>
 
 #include "noc_access.hpp"
-#include "tt-logger/tt-logger.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/wormhole_telemetry.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/error.hpp"
+#include "utils.hpp"
 
 namespace tt::umd {
 
@@ -44,10 +44,10 @@ uint32_t SmBusArcTelemetryReader::read_entry(const uint8_t telemetry_tag, NocId 
     uint32_t telemetry_value;
     device_protocol->read_data(
         &telemetry_value,
-        get_arc_core(noc_id),
+        get_arc_core(get_selected_noc_id()),
         SMBUS_TELEMETRY_NOC_ADDR + telemetry_tag * sizeof(uint32_t),
         sizeof(uint32_t),
-        noc_id);
+        get_selected_noc_id());
 
     return telemetry_value;
 }
@@ -57,16 +57,19 @@ bool SmBusArcTelemetryReader::is_entry_available(const uint8_t telemetry_tag, No
 }
 
 void SmBusArcTelemetryReader::wait_for_telemetry_initialized(std::chrono::milliseconds timeout_ms) {
-    auto start = std::chrono::steady_clock::now();
+    constexpr auto busy_poll_window = std::chrono::microseconds(10);
     constexpr auto poll_interval = std::chrono::milliseconds(10);
 
-    while (SmBusArcTelemetryReader::read_entry(wormhole::LegacyTelemetryTag::FW_BUNDLE_VERSION) == 0) {
-        if (std::chrono::steady_clock::now() - start > timeout_ms) {
-            log_warning(
-                tt::LogUMD, "Timeout waiting for SMBus telemetry initialization (FW_BUNDLE_VERSION not populated).");
-            return;
-        }
-        std::this_thread::sleep_for(poll_interval);
+    const bool initialized = utils::poll_until(
+        [this]() { return SmBusArcTelemetryReader::read_entry(wormhole::LegacyTelemetryTag::FW_BUNDLE_VERSION) != 0; },
+        timeout_ms,
+        busy_poll_window,
+        poll_interval);
+
+    if (!initialized) {
+        UMD_THROW(
+            error::RuntimeError,
+            "Timeout waiting for SMBus telemetry initialization (FW_BUNDLE_VERSION not populated).");
     }
 }
 

--- a/device/arc/smbus_arc_telemetry_reader.cpp
+++ b/device/arc/smbus_arc_telemetry_reader.cpp
@@ -47,7 +47,7 @@ uint32_t SmBusArcTelemetryReader::read_entry(const uint8_t telemetry_tag, NocId 
         get_arc_core(noc_id),
         SMBUS_TELEMETRY_NOC_ADDR + telemetry_tag * sizeof(uint32_t),
         sizeof(uint32_t),
-        get_selected_noc_id());
+        noc_id);
 
     return telemetry_value;
 }

--- a/device/arc/wormhole_arc_telemetry_reader.cpp
+++ b/device/arc/wormhole_arc_telemetry_reader.cpp
@@ -9,24 +9,22 @@
 
 #include "noc_access.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
-#include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/types/xy_pair.hpp"
 
 namespace tt::umd {
 
-WormholeArcTelemetryReader::WormholeArcTelemetryReader(TTDevice* tt_device) : ArcTelemetryReader(tt_device) {
-    arc_core = !is_selected_noc1() ? wormhole::ARC_CORES_NOC0[0]
-                                   : tt_xy_pair(
-                                         wormhole::NOC0_X_TO_NOC1_X[wormhole::ARC_CORES_NOC0[0].x],
-                                         wormhole::NOC0_Y_TO_NOC1_Y[wormhole::ARC_CORES_NOC0[0].y]);
+WormholeArcTelemetryReader::WormholeArcTelemetryReader(
+    DeviceProtocol* device_protocol, const tt_xy_pair arc_core_noc0, const tt_xy_pair arc_core_noc1) :
+    ArcTelemetryReader(device_protocol, arc_core_noc0, arc_core_noc1) {
     wait_for_telemetry_initialized();
 }
 
 void WormholeArcTelemetryReader::get_telemetry_address() {
     uint32_t telemetry_table_arc_addr;
-    tt_device->read_from_device(
+    device_protocol->read_data(
         &telemetry_table_arc_addr,
-        arc_core,
+        get_arc_core(),
         wormhole::ARC_NOC_RESET_UNIT_BASE_ADDR + wormhole::NOC_NODEID_X_0,
         sizeof(uint32_t),
         get_selected_noc_id());
@@ -35,9 +33,9 @@ void WormholeArcTelemetryReader::get_telemetry_address() {
     telemetry_table_addr = telemetry_table_arc_addr + wormhole::ARC_NOC_ADDRESS_START;
 
     uint32_t telemetry_values_arc_addr;
-    tt_device->read_from_device(
+    device_protocol->read_data(
         &telemetry_values_arc_addr,
-        arc_core,
+        get_arc_core(),
         wormhole::ARC_NOC_RESET_UNIT_BASE_ADDR + wormhole::NOC_NODEID_Y_0,
         sizeof(uint32_t),
         get_selected_noc_id());

--- a/device/arc/wormhole_arc_telemetry_reader.cpp
+++ b/device/arc/wormhole_arc_telemetry_reader.cpp
@@ -24,7 +24,7 @@ void WormholeArcTelemetryReader::get_telemetry_address() {
     uint32_t telemetry_table_arc_addr;
     device_protocol->read_data(
         &telemetry_table_arc_addr,
-        get_arc_core(),
+        get_arc_core(get_selected_noc_id()),
         wormhole::ARC_NOC_RESET_UNIT_BASE_ADDR + wormhole::NOC_NODEID_X_0,
         sizeof(uint32_t),
         get_selected_noc_id());
@@ -35,7 +35,7 @@ void WormholeArcTelemetryReader::get_telemetry_address() {
     uint32_t telemetry_values_arc_addr;
     device_protocol->read_data(
         &telemetry_values_arc_addr,
-        get_arc_core(),
+        get_arc_core(get_selected_noc_id()),
         wormhole::ARC_NOC_RESET_UNIT_BASE_ADDR + wormhole::NOC_NODEID_Y_0,
         sizeof(uint32_t),
         get_selected_noc_id());

--- a/device/firmware/firmware_info_provider_implementation.cpp
+++ b/device/firmware/firmware_info_provider_implementation.cpp
@@ -251,7 +251,10 @@ uint32_t FirmwareInfoProviderImplementation::read_raw_telemetry(const FeatureKey
                 auto* tel = tt_device->get_firmware_telemetry_reader();
                 return (tel && tel->is_entry_available(arg)) ? tel->read_entry(arg) : 0;
             } else if constexpr (std::is_same_v<T, SmBusTag>) {
-                const auto sm_bus_telemetry = std::make_unique<SmBusArcTelemetryReader>(tt_device);
+                const auto sm_bus_telemetry = std::make_unique<SmBusArcTelemetryReader>(
+                    tt_device->get_device_protocol(),
+                    tt_device->get_arc_core(NocId::NOC0),
+                    tt_device->get_arc_core(NocId::NOC1));
                 return sm_bus_telemetry->read_entry(arg.tag);
             } else if constexpr (std::is_same_v<T, FixedValue>) {
                 return arg.value;
@@ -281,7 +284,10 @@ bool FirmwareInfoProviderImplementation::is_feature_available(FirmwareFeature fe
                 auto* tel = tt_device->get_firmware_telemetry_reader();
                 return tel && tel->is_entry_available(arg);
             } else if constexpr (std::is_same_v<T, SmBusTag>) {
-                const auto sm_bus_telemetry = std::make_unique<SmBusArcTelemetryReader>(tt_device);
+                const auto sm_bus_telemetry = std::make_unique<SmBusArcTelemetryReader>(
+                    tt_device->get_device_protocol(),
+                    tt_device->get_arc_core(NocId::NOC0),
+                    tt_device->get_arc_core(NocId::NOC1));
                 return sm_bus_telemetry->is_entry_available(arg.tag);
             } else if constexpr (std::is_same_v<T, FixedValue>) {
                 return true;

--- a/device/firmware/firmware_utils.cpp
+++ b/device/firmware/firmware_utils.cpp
@@ -51,7 +51,10 @@ FirmwareBundleVersion get_minimum_compatible_firmware_version(tt::ARCH arch) {
 
 FirmwareBundleVersion get_firmware_version_util(TTDevice* tt_device) {
     if (tt_device->get_arch() == tt::ARCH::WORMHOLE_B0) {
-        SmBusArcTelemetryReader smbus_reader(tt_device);
+        SmBusArcTelemetryReader smbus_reader(
+            tt_device->get_device_protocol(),
+            tt_device->get_arc_core(NocId::NOC0),
+            tt_device->get_arc_core(NocId::NOC1));
         return FirmwareBundleVersion::from_firmware_bundle_tag(
             smbus_reader.read_entry(wormhole::LegacyTelemetryTag::FW_BUNDLE_VERSION));
     }

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -151,7 +151,8 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     probe_arc();
     wait_arc_core_start(timeout_ms);
     arc_messenger_ = ArcMessenger::create_arc_messenger(this);
-    telemetry = ArcTelemetryReader::create_arc_telemetry_reader(this, timeout_ms);
+    telemetry = ArcTelemetryReader::create_arc_telemetry_reader(
+        get_device_protocol(), get_arch(), arc_core_noc0, arc_core_noc1, timeout_ms);
     firmware_info_provider = FirmwareInfoProviderImplementation::create_firmware_info_provider(this);
     construct_soc_descriptor(soc_arch_descriptor_);
 }
@@ -677,6 +678,10 @@ void TTDevice::deassert_risc_reset(CoreCoord core, const RiscType selected_riscs
 }
 
 tt_xy_pair TTDevice::get_arc_core() const { return is_selected_noc1() ? arc_core_noc1 : arc_core_noc0; }
+
+tt_xy_pair TTDevice::get_arc_core(const NocId noc_id) const {
+    return noc_id == NocId::NOC1 ? arc_core_noc1 : arc_core_noc0;
+}
 
 void TTDevice::noc_multicast_write(
     const void *src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr, NocId noc_id) {

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -152,7 +152,7 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     wait_arc_core_start(timeout_ms);
     arc_messenger_ = ArcMessenger::create_arc_messenger(this);
     telemetry = ArcTelemetryReader::create_arc_telemetry_reader(
-        get_device_protocol(), get_arch(), arc_core_noc0, arc_core_noc1, timeout_ms);
+        get_device_protocol(), get_arch(), arc_core_noc0, arc_core_noc1);
     firmware_info_provider = FirmwareInfoProviderImplementation::create_firmware_info_provider(this);
     construct_soc_descriptor(soc_arch_descriptor_);
 }

--- a/nanobind/py_api_telemetry.cpp
+++ b/nanobind/py_api_telemetry.cpp
@@ -221,7 +221,16 @@ void bind_telemetry(nb::module_& m) {
 
     // SmBusArcTelemetryReader binding - for direct instantiation when SMBUS telemetry is needed.
     nb::class_<SmBusArcTelemetryReader, ArcTelemetryReader>(m, "SmBusArcTelemetryReader")
-        .def(nb::init<TTDevice*>(), nb::arg("tt_device"), release_gil())
+        .def(
+            "__init__",
+            [](SmBusArcTelemetryReader* self, TTDevice* tt_device) {
+                new (self) SmBusArcTelemetryReader(
+                    tt_device->get_device_protocol(),
+                    tt_device->get_arc_core(NocId::NOC0),
+                    tt_device->get_arc_core(NocId::NOC1));
+            },
+            nb::arg("tt_device"),
+            release_gil())
         .def(
             "read_entry",
             &SmBusArcTelemetryReader::read_entry,

--- a/tests/wormhole/test_arc_telemetry_wh.cpp
+++ b/tests/wormhole/test_arc_telemetry_wh.cpp
@@ -19,7 +19,11 @@ TEST(WormholeTelemetry, BasicWormholeTelemetry) {
         tt_device->init_tt_device();
 
         std::unique_ptr<ArcTelemetryReader> blackhole_arc_telemetry_reader =
-            ArcTelemetryReader::create_arc_telemetry_reader(tt_device.get());
+            ArcTelemetryReader::create_arc_telemetry_reader(
+                tt_device->get_device_protocol(),
+                tt_device->get_arch(),
+                tt_device->get_arc_core(NocId::NOC0),
+                tt_device->get_arc_core(NocId::NOC1));
 
         uint32_t board_id_high =
             blackhole_arc_telemetry_reader->read_entry(wormhole::LegacyTelemetryTag::BOARD_ID_HIGH);
@@ -40,8 +44,11 @@ TEST(WormholeTelemetry, WormholeTelemetryEntryAvailable) {
         tt_device->set_power_state(TTDevice::PowerState::BUSY);
         tt_device->init_tt_device();
 
-        std::unique_ptr<ArcTelemetryReader> telemetry =
-            ArcTelemetryReader::create_arc_telemetry_reader(tt_device.get());
+        std::unique_ptr<ArcTelemetryReader> telemetry = ArcTelemetryReader::create_arc_telemetry_reader(
+            tt_device->get_device_protocol(),
+            tt_device->get_arch(),
+            tt_device->get_arc_core(NocId::NOC0),
+            tt_device->get_arc_core(NocId::NOC1));
 
         for (uint32_t telem_tag = 0; telem_tag < wormhole::LegacyTelemetryTag::NUMBER_OF_TAGS; telem_tag++) {
             EXPECT_TRUE(telemetry->is_entry_available(telem_tag));
@@ -62,8 +69,10 @@ TEST(TestTelemetry, CompareTwoTelemetryValues) {
         tt_device->init_tt_device();
         FirmwareTelemetryReader* arc_telemetry_reader = tt_device->get_firmware_telemetry_reader();
 
-        std::unique_ptr<SmBusArcTelemetryReader> smbus_telemetry_reader =
-            std::make_unique<SmBusArcTelemetryReader>(tt_device.get());
+        std::unique_ptr<SmBusArcTelemetryReader> smbus_telemetry_reader = std::make_unique<SmBusArcTelemetryReader>(
+            tt_device->get_device_protocol(),
+            tt_device->get_arc_core(NocId::NOC0),
+            tt_device->get_arc_core(NocId::NOC1));
 
         EXPECT_EQ(
             arc_telemetry_reader->read_entry(TelemetryTag::DM_BL_FW_VERSION),

--- a/tools/telemetry.cpp
+++ b/tools/telemetry.cpp
@@ -20,11 +20,9 @@
 #include <string>
 #include <thread>
 #include <tt-logger/tt-logger.hpp>
-#include <utility>
-#include <vector>
 
 #include "common.hpp"
-#include "umd/device/arc/arc_telemetry_reader.hpp"
+#include "umd/device/arc/firmware_telemetry_reader.hpp"
 #include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/topology/topology_discovery.hpp"
 #include "umd/device/types/cluster_descriptor_types.hpp"
@@ -99,35 +97,19 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    std::vector<std::pair<tt::ChipId, std::unique_ptr<ArcTelemetryReader>>> telemetry_readers;
-    std::vector<std::unique_ptr<TTDevice>> tt_devices;
-    for (auto& [chip_id, tt_device] : tt_devices_map) {
-        std::unique_ptr<ArcTelemetryReader> arc_telemetry_reader = ArcTelemetryReader::create_arc_telemetry_reader(
-            tt_device->get_device_protocol(),
-            tt_device->get_arch(),
-            tt_device->get_arc_core(NocId::NOC0),
-            tt_device->get_arc_core(NocId::NOC1));
-        tt_devices.push_back(std::move(tt_device));
-        telemetry_readers.push_back(std::make_pair(chip_id, std::move(arc_telemetry_reader)));
-    }
-
     for (int iteration = 0; max_count == 0 || iteration < max_count; iteration++) {
         auto start_time = std::chrono::steady_clock::now();
-        for (int i = 0; i < (int)telemetry_readers.size(); i++) {
-            tt::ChipId chip_id = telemetry_readers.at(i).first;
-            auto& telemetry_reader = telemetry_readers.at(i).second;
-            auto firmware_info_provider = tt_devices.at(i)->get_firmware_info_provider();
-
+        for (auto& [chip_id, tt_device] : tt_devices_map) {
             std::string telemetry_message;
             if (telemetry_tag == -1) {
-                auto arch = tt_devices.at(i)->get_arch();
+                auto arch = tt_device->get_arch();
                 if (arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE) {
-                    telemetry_message = run_default_telemetry(chip_id, firmware_info_provider);
+                    telemetry_message = run_default_telemetry(chip_id, tt_device->get_firmware_info_provider());
                 } else {
                     UMD_THROW(error::RuntimeError, "Unsupported device architecture.");
                 }
             } else {
-                uint32_t telemetry_value = telemetry_reader->read_entry(telemetry_tag);
+                uint32_t telemetry_value = tt_device->get_firmware_telemetry_reader()->read_entry(telemetry_tag);
                 telemetry_message = fmt::format("Chip ID {} - Telemetry value: 0x{:x}", chip_id, telemetry_value);
             }
             if (output_file.is_open()) {

--- a/tools/telemetry.cpp
+++ b/tools/telemetry.cpp
@@ -102,8 +102,11 @@ int main(int argc, char* argv[]) {
     std::vector<std::pair<tt::ChipId, std::unique_ptr<ArcTelemetryReader>>> telemetry_readers;
     std::vector<std::unique_ptr<TTDevice>> tt_devices;
     for (auto& [chip_id, tt_device] : tt_devices_map) {
-        std::unique_ptr<ArcTelemetryReader> arc_telemetry_reader =
-            ArcTelemetryReader::create_arc_telemetry_reader(tt_device.get());
+        std::unique_ptr<ArcTelemetryReader> arc_telemetry_reader = ArcTelemetryReader::create_arc_telemetry_reader(
+            tt_device->get_device_protocol(),
+            tt_device->get_arch(),
+            tt_device->get_arc_core(NocId::NOC0),
+            tt_device->get_arc_core(NocId::NOC1));
         tt_devices.push_back(std::move(tt_device));
         telemetry_readers.push_back(std::make_pair(chip_id, std::move(arc_telemetry_reader)));
     }


### PR DESCRIPTION
### Issue
Closes #2878

### Description
Remove TTDevice dependency from FirmwareTelemetryReader.

### List of the changes
- Remove TTDevice from all telemetry reader ctors and builder method.
- Update calls to ctor and builder methods.
- Update telemetry tool.
- Replace warning with error on SMBus telemetry init timeout.

### Testing
CI

### API Changes
This PR has API changes.
