### PR TITLE
Drop ArchitectureImplementation from the hang detectors

### DIFF
--- a/device/api/umd/device/arch/architecture_implementation.hpp
+++ b/device/api/umd/device/arch/architecture_implementation.hpp
@@ -12,7 +12,6 @@
 #include <utility>
 #include <vector>
 
-#include "umd/device/arch/architecture_registers.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/cluster_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"

--- a/device/api/umd/device/tt_device/hang_detection/blackhole_hang_detector.hpp
+++ b/device/api/umd/device/tt_device/hang_detection/blackhole_hang_detector.hpp
@@ -13,7 +13,6 @@
 
 namespace tt::umd {
 class DeviceProtocol;
-class ArchitectureImplementation;
 enum class NocId : uint8_t;
 
 // Blackhole variant: reads BAR and NOC node ID from the PCIe tile.
@@ -21,8 +20,7 @@ enum class NocId : uint8_t;
 // because the PCIe tile y-coordinate differs (0 vs 11).
 class BlackholeHangDetector : public HangDetectorImplementation {
 public:
-    BlackholeHangDetector(
-        DeviceProtocol* protocol, ArchitectureImplementation* arch_impl, bool noc_translation_enabled);
+    BlackholeHangDetector(DeviceProtocol* protocol, bool noc_translation_enabled);
 
 private:
     uint32_t read_hang_check_reg_via_bar() override;

--- a/device/api/umd/device/tt_device/hang_detection/hang_detector.hpp
+++ b/device/api/umd/device/tt_device/hang_detection/hang_detector.hpp
@@ -8,7 +8,7 @@
 #include <cstdint>
 #include <optional>
 
-#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/architecture_registers.hpp"
 #include "umd/device/types/noc_id.hpp"
 
 namespace tt::umd {

--- a/device/api/umd/device/tt_device/hang_detection/hang_detector_implementation.hpp
+++ b/device/api/umd/device/tt_device/hang_detection/hang_detector_implementation.hpp
@@ -44,13 +44,11 @@ public:
     void set_noc_reg_reader(NocRegReader reader);
 
 protected:
-    HangDetectorImplementation(DeviceProtocol* protocol, ArchitectureImplementation* arch_impl);
+    HangDetectorImplementation(DeviceProtocol* protocol);
 
     DeviceProtocol* get_protocol() const { return protocol_; }
 
     PcieInterface* get_pcie_interface() const { return pcie_interface_; }
-
-    ArchitectureImplementation* get_arch_impl() const { return arch_impl_; }
 
     // Reads a 32-bit NOC register through the configured NocRegReader. Arch-specific variants compute the
     // (core, addr) for their hang-check register and route the actual read through here.
@@ -64,7 +62,6 @@ private:
     DeviceProtocol* protocol_;
     PcieInterface* pcie_interface_;
     bool is_mmio_protocol_;
-    ArchitectureImplementation* arch_impl_;
     NocRegReader noc_reg_reader_;
 };
 

--- a/device/api/umd/device/tt_device/hang_detection/wormhole_hang_detector.hpp
+++ b/device/api/umd/device/tt_device/hang_detection/wormhole_hang_detector.hpp
@@ -13,13 +13,12 @@
 
 namespace tt::umd {
 class DeviceProtocol;
-class ArchitectureImplementation;
 enum class NocId : uint8_t;
 
 // Wormhole variant: reads BAR and NOC node ID from the ARC tile.
 class WormholeHangDetector : public HangDetectorImplementation {
 public:
-    WormholeHangDetector(DeviceProtocol* protocol, ArchitectureImplementation* arch_impl);
+    WormholeHangDetector(DeviceProtocol* protocol);
 
 private:
     uint32_t read_hang_check_reg_via_bar() override;

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -20,6 +20,7 @@
 #include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/arc/firmware_telemetry_reader.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/architecture_registers.hpp"
 #include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/pcie/pci_device.hpp"

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -48,7 +48,7 @@ BlackholeTTDevice::BlackholeTTDevice(
     TTDevice(std::move(pci_device), std::make_unique<BlackholeImplementation>(), soc_arch_descriptor, use_safe_api) {
     BlackholeTTDevice::set_arc_coordinate();
     set_hang_detector(std::make_unique<BlackholeHangDetector>(
-        get_device_protocol(), get_architecture_implementation(), BlackholeTTDevice::get_noc_translation_enabled()));
+        get_device_protocol(), BlackholeTTDevice::get_noc_translation_enabled()));
 }
 
 BlackholeTTDevice::BlackholeTTDevice(
@@ -58,7 +58,7 @@ BlackholeTTDevice::BlackholeTTDevice(
     TTDevice(std::move(jtag_device), jlink_id, std::make_unique<BlackholeImplementation>(), soc_arch_descriptor) {
     BlackholeTTDevice::set_arc_coordinate();
     set_hang_detector(std::make_unique<BlackholeHangDetector>(
-        get_device_protocol(), get_architecture_implementation(), BlackholeTTDevice::get_noc_translation_enabled()));
+        get_device_protocol(), BlackholeTTDevice::get_noc_translation_enabled()));
 }
 
 BlackholeTTDevice::~BlackholeTTDevice() {

--- a/device/tt_device/hang_detection/blackhole_hang_detector.cpp
+++ b/device/tt_device/hang_detection/blackhole_hang_detector.cpp
@@ -16,9 +16,8 @@
 
 namespace tt::umd {
 
-BlackholeHangDetector::BlackholeHangDetector(
-    DeviceProtocol* protocol, ArchitectureImplementation* arch_impl, bool noc_translation_enabled) :
-    HangDetectorImplementation(protocol, arch_impl),
+BlackholeHangDetector::BlackholeHangDetector(DeviceProtocol* protocol, bool noc_translation_enabled) :
+    HangDetectorImplementation(protocol),
     noc_translation_enabled_(noc_translation_enabled),
     registers_(get_architecture_registers(tt::ARCH::BLACKHOLE)) {}
 

--- a/device/tt_device/hang_detection/hang_detector_implementation.cpp
+++ b/device/tt_device/hang_detection/hang_detector_implementation.cpp
@@ -12,12 +12,10 @@
 #include "umd/device/types/noc_id.hpp"
 
 namespace tt::umd {
-HangDetectorImplementation::HangDetectorImplementation(
-    DeviceProtocol* protocol, ArchitectureImplementation* arch_impl) :
+HangDetectorImplementation::HangDetectorImplementation(DeviceProtocol* protocol) :
     protocol_(protocol),
     pcie_interface_(dynamic_cast<PcieInterface*>(protocol)),
     is_mmio_protocol_(!dynamic_cast<RemoteInterface*>(protocol)),
-    arch_impl_(arch_impl),
     // Default reader: plain protocol register read. A higher layer may override it via set_noc_reg_reader().
     noc_reg_reader_([this](tt_xy_pair core, uint64_t addr, NocId noc) -> uint32_t {
         uint32_t value = 0;

--- a/device/tt_device/hang_detection/wormhole_hang_detector.cpp
+++ b/device/tt_device/hang_detection/wormhole_hang_detector.cpp
@@ -16,8 +16,8 @@
 
 namespace tt::umd {
 
-WormholeHangDetector::WormholeHangDetector(DeviceProtocol* protocol, ArchitectureImplementation* arch_impl) :
-    HangDetectorImplementation(protocol, arch_impl), registers_(get_architecture_registers(tt::ARCH::WORMHOLE_B0)) {}
+WormholeHangDetector::WormholeHangDetector(DeviceProtocol* protocol) :
+    HangDetectorImplementation(protocol), registers_(get_architecture_registers(tt::ARCH::WORMHOLE_B0)) {}
 
 uint32_t WormholeHangDetector::read_hang_check_reg_via_bar() {
     return get_pcie_interface()->bar_read32(registers_.noc_node_id_bar_offset);

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -46,7 +46,7 @@ WormholeTTDevice::WormholeTTDevice(
     bool use_safe_api) :
     TTDevice(std::move(pci_device), std::make_unique<WormholeImplementation>(), soc_arch_descriptor, use_safe_api) {
     WormholeTTDevice::set_arc_coordinate();
-    set_hang_detector(std::make_unique<WormholeHangDetector>(get_device_protocol(), get_architecture_implementation()));
+    set_hang_detector(std::make_unique<WormholeHangDetector>(get_device_protocol()));
 }
 
 WormholeTTDevice::WormholeTTDevice(
@@ -55,7 +55,7 @@ WormholeTTDevice::WormholeTTDevice(
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     TTDevice(std::move(jtag_device), jlink_id, std::make_unique<WormholeImplementation>(), soc_arch_descriptor) {
     WormholeTTDevice::set_arc_coordinate();
-    set_hang_detector(std::make_unique<WormholeHangDetector>(get_device_protocol(), get_architecture_implementation()));
+    set_hang_detector(std::make_unique<WormholeHangDetector>(get_device_protocol()));
 }
 
 WormholeTTDevice::WormholeTTDevice(
@@ -65,8 +65,7 @@ WormholeTTDevice::WormholeTTDevice(
     WormholeTTDevice::set_arc_coordinate();
     is_remote_tt_device = true;
     set_hang_detector(std::make_unique<WormholeHangDetector>(
-        TTDevice::get_remote_interface()->get_remote_communication()->get_local_device()->get_device_protocol(),
-        get_architecture_implementation()));
+        TTDevice::get_remote_interface()->get_remote_communication()->get_local_device()->get_device_protocol()));
 }
 
 bool WormholeTTDevice::get_noc_translation_enabled() {


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2873

### Description
Stacked on #3196.

Leftover from #3218. The hang detectors only ever held an `ArchitectureImplementation` to look up
the hang check register locations, and those now come from `ArchitectureRegisters`, so the
dependency is unused and drops out of their constructors.

`hang_detector.hpp` was including the interface header only for `HANG_READ_VALUE`, so it now
includes `architecture_registers.hpp` instead. That in turn lets the interface header stop
pulling in `architecture_registers.hpp`, which #3218 needed only to keep resolving that constant.

### List of the changes
- Remove the `ArchitectureImplementation` parameter, member and accessor from
  `HangDetectorImplementation` and both arch variants, and update the construction sites.
- Point `hang_detector.hpp` at `architecture_registers.hpp` and drop that include from
  `architecture_implementation.hpp`.

### Testing
Code builds. Hang detection tests cover these paths in CI.

### API Changes
This PR has API changes, the hang detector constructors take one argument less.

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/arch_impl_12
