### PR TITLE
Move TLB layout to ArchitectureTlbs

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -63,6 +63,7 @@ target_sources(
     PRIVATE
         arch/architecture_implementation.cpp
         arch/architecture_registers.cpp
+        arch/architecture_tlbs.cpp
         chip/chip.cpp
         chip/local_chip.cpp
         chip/mock_chip.cpp
@@ -185,6 +186,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
             FILES
                 api/umd/device/arch/architecture_implementation.hpp
                 api/umd/device/arch/architecture_registers.hpp
+                api/umd/device/arch/architecture_tlbs.hpp
                 api/umd/device/arc/arc_messenger.hpp
                 api/umd/device/arc/arc_telemetry_reader.hpp
                 api/umd/device/arc/firmware_telemetry_reader.hpp

--- a/device/api/umd/device/arch/architecture_implementation.hpp
+++ b/device/api/umd/device/arch/architecture_implementation.hpp
@@ -16,7 +16,6 @@
 #include "umd/device/types/cluster_types.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/types/risc_type.hpp"
-#include "umd/device/types/tlb.hpp"
 #include "umd/device/types/xy_pair.hpp"
 #include "umd/device/utils/semver.hpp"
 
@@ -47,28 +46,9 @@ public:
     virtual const std::vector<uint32_t>& get_t6_x_locations() const = 0;
     virtual const std::vector<uint32_t>& get_t6_y_locations() const = 0;
 
-    // TLB related. Move other functions here as well.
-    virtual std::pair<uint32_t, uint32_t> get_tlb_1m_base_and_count() const = 0;
-    virtual std::pair<uint32_t, uint32_t> get_tlb_2m_base_and_count() const = 0;
-    virtual std::pair<uint32_t, uint32_t> get_tlb_16m_base_and_count() const = 0;
-    virtual std::pair<uint32_t, uint32_t> get_tlb_4g_base_and_count() const = 0;
-
-    // Get available TLB sizes for this architecture.
-    virtual const std::vector<size_t>& get_tlb_sizes() const = 0;
-
-    virtual tlb_configuration get_tlb_configuration(uint32_t tlb_index) const = 0;
-    virtual uint64_t get_tlb_cfg_reg_size_bytes() const = 0;
-    virtual uint32_t get_static_tlb_cfg_addr() const = 0;
-
     virtual DeviceL1AddressParams get_l1_address_params() const = 0;
 
     static std::unique_ptr<ArchitectureImplementation> create(tt::ARCH architecture);
-
-    // Get preferred tlb size, which is the tlb group with the largest count available.
-    virtual size_t get_cached_tlb_size() const = 0;
-
-    // Whether static_vc should be used for tlb configuration.
-    virtual bool get_static_vc() const = 0;
 
     // Map a PCI bus id to a UBB tray id (1..4). Returns std::nullopt for archs without UBB
     // boards or when the bus id does not correspond to a known tray.

--- a/device/api/umd/device/arch/architecture_tlbs.hpp
+++ b/device/api/umd/device/arch/architecture_tlbs.hpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "umd/device/types/arch.hpp"
+#include "umd/device/types/tlb.hpp"
+
+namespace tt::umd {
+
+// Resolves a TLB window index to its configuration.
+using TlbConfigurationResolver = tlb_configuration (*)(uint32_t tlb_index);
+
+// The TLB window layout of one architecture. Architecture specific code reads its own constants
+// directly; this exists for callers which are not tied to one architecture.
+struct ArchitectureTlbs {
+    // Base index and window count per window size. A zero count means the architecture has no
+    // windows of that size.
+    std::pair<uint32_t, uint32_t> base_and_count_1m;
+    std::pair<uint32_t, uint32_t> base_and_count_2m;
+    std::pair<uint32_t, uint32_t> base_and_count_16m;
+    std::pair<uint32_t, uint32_t> base_and_count_4g;
+
+    // Window sizes the architecture provides, smallest first.
+    std::vector<size_t> sizes;
+
+    // Preferred window size, the group with the largest count available.
+    size_t cached_window_size;
+
+    // Whether static_vc should be used for window configuration.
+    bool use_static_vc;
+
+    uint32_t static_cfg_addr;
+    uint64_t cfg_reg_size_bytes;
+
+    TlbConfigurationResolver get_configuration;
+};
+
+const ArchitectureTlbs& get_architecture_tlbs(const tt::ARCH arch);
+
+}  // namespace tt::umd

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -369,45 +369,7 @@ public:
 
     const std::vector<uint32_t>& get_t6_y_locations() const override { return blackhole::T6_Y_LOCATIONS; }
 
-    std::pair<uint32_t, uint32_t> get_tlb_1m_base_and_count() const override { return {0, 0}; }
-
-    std::pair<uint32_t, uint32_t> get_tlb_2m_base_and_count() const override {
-        return {blackhole::TLB_BASE_2M, blackhole::TLB_COUNT_2M};
-    }
-
-    std::pair<uint32_t, uint32_t> get_tlb_16m_base_and_count() const override { return {0, 0}; }
-
-    std::pair<uint32_t, uint32_t> get_tlb_4g_base_and_count() const override {
-        return {blackhole::TLB_BASE_4G, blackhole::TLB_COUNT_4G};
-    }
-
-    const std::vector<size_t>& get_tlb_sizes() const override {
-        static constexpr uint32_t one_mb = 1 << 20;
-        static constexpr size_t one_gb = 1024ULL * one_mb;
-        static const std::vector<size_t> tlb_sizes = {2 * one_mb, 4ULL * one_gb};
-        return tlb_sizes;
-    }
-
-    tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
-
-    uint64_t get_tlb_cfg_reg_size_bytes() const override { return 12; }
-
-    uint32_t get_static_tlb_cfg_addr() const override { return blackhole::STATIC_TLB_CFG_ADDR; }
-
     DeviceL1AddressParams get_l1_address_params() const override;
-
-    size_t get_cached_tlb_size() const override { return blackhole::STATIC_TLB_SIZE; }
-
-    bool get_static_vc() const override { return false; }  // False due to a known HW issue.
-
-    std::optional<uint8_t> get_ubb_tray_id(uint16_t bus_id) const override {
-        const uint16_t bus_high = static_cast<uint16_t>(bus_id & 0xF0);
-        auto it = std::find(blackhole::UBB_TRAY_BUS_IDS.begin(), blackhole::UBB_TRAY_BUS_IDS.end(), bus_high);
-        if (it == blackhole::UBB_TRAY_BUS_IDS.end()) {
-            return std::nullopt;
-        }
-        return static_cast<uint8_t>(std::distance(blackhole::UBB_TRAY_BUS_IDS.begin(), it) + 1);
-    }
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/arch/grendel_implementation.hpp
+++ b/device/api/umd/device/arch/grendel_implementation.hpp
@@ -362,36 +362,7 @@ public:
 
     const std::vector<uint32_t>& get_t6_y_locations() const override { return grendel::T6_Y_LOCATIONS; }
 
-    std::pair<uint32_t, uint32_t> get_tlb_1m_base_and_count() const override { return {0, 0}; }
-
-    std::pair<uint32_t, uint32_t> get_tlb_2m_base_and_count() const override {
-        return {grendel::TLB_BASE_2M, grendel::TLB_COUNT_2M};
-    }
-
-    std::pair<uint32_t, uint32_t> get_tlb_16m_base_and_count() const override { return {0, 0}; }
-
-    std::pair<uint32_t, uint32_t> get_tlb_4g_base_and_count() const override {
-        return {grendel::TLB_BASE_4G, grendel::TLB_COUNT_4G};
-    }
-
-    const std::vector<size_t>& get_tlb_sizes() const override {
-        static constexpr uint32_t one_mb = 1 << 20;
-        static constexpr size_t one_gb = 1024ULL * one_mb;
-        static const std::vector<size_t> tlb_sizes = {2 * one_mb, 4ULL * one_gb};
-        return tlb_sizes;
-    }
-
-    tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
-
-    uint64_t get_tlb_cfg_reg_size_bytes() const override { return 12; }
-
-    uint32_t get_static_tlb_cfg_addr() const override { return grendel::STATIC_TLB_CFG_ADDR; }
-
     DeviceL1AddressParams get_l1_address_params() const override;
-
-    size_t get_cached_tlb_size() const override { return grendel::STATIC_TLB_SIZE; }
-
-    bool get_static_vc() const override { return true; }
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -426,37 +426,7 @@ public:
 
     const std::vector<uint32_t>& get_t6_y_locations() const override { return wormhole::T6_Y_LOCATIONS; }
 
-    std::pair<uint32_t, uint32_t> get_tlb_1m_base_and_count() const override {
-        return {wormhole::TLB_BASE_1M, wormhole::TLB_COUNT_1M};
-    }
-
-    std::pair<uint32_t, uint32_t> get_tlb_2m_base_and_count() const override {
-        return {wormhole::TLB_BASE_2M, wormhole::TLB_COUNT_2M};
-    }
-
-    std::pair<uint32_t, uint32_t> get_tlb_16m_base_and_count() const override {
-        return {wormhole::TLB_BASE_16M, wormhole::TLB_COUNT_16M};
-    }
-
-    std::pair<uint32_t, uint32_t> get_tlb_4g_base_and_count() const override { return {0, 0}; }
-
-    const std::vector<size_t>& get_tlb_sizes() const override {
-        static constexpr uint32_t one_mb = 1 << 20;
-        static const std::vector<size_t> tlb_sizes = {1 * one_mb, 2 * one_mb, 16 * one_mb};
-        return tlb_sizes;
-    }
-
-    tlb_configuration get_tlb_configuration(uint32_t tlb_index) const override;
-
-    uint64_t get_tlb_cfg_reg_size_bytes() const override { return 8; }
-
-    uint32_t get_static_tlb_cfg_addr() const override { return wormhole::STATIC_TLB_CFG_ADDR; }
-
     DeviceL1AddressParams get_l1_address_params() const override;
-
-    size_t get_cached_tlb_size() const override { return wormhole::STATIC_TLB_SIZE; }
-
-    bool get_static_vc() const override { return true; }
 
     std::optional<uint8_t> get_ubb_tray_id(uint16_t bus_id) const override {
         const uint16_t bus_high = static_cast<uint16_t>(bus_id & 0xF0);

--- a/device/arch/architecture_tlbs.cpp
+++ b/device/arch/architecture_tlbs.cpp
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "umd/device/arch/architecture_tlbs.hpp"
+
+#include <fmt/format.h>
+
+#include "umd/device/arch/blackhole_implementation.hpp"
+#include "umd/device/arch/grendel_implementation.hpp"
+#include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/utils/error.hpp"
+
+namespace tt::umd {
+
+namespace {
+constexpr size_t ONE_MB = 1 << 20;
+constexpr size_t ONE_GB = 1024 * ONE_MB;
+}  // namespace
+
+namespace wormhole {
+
+static tlb_configuration tlb_configuration_for(const uint32_t tlb_index) {
+    if (tlb_index >= TLB_BASE_INDEX_16M) {
+        return tlb_configuration{
+            .size = DYNAMIC_TLB_16M_SIZE,
+            .base = DYNAMIC_TLB_16M_BASE,
+            .cfg_addr = DYNAMIC_TLB_16M_CFG_ADDR,
+            .index_offset = tlb_index - TLB_BASE_INDEX_16M,
+            .tlb_offset = DYNAMIC_TLB_16M_BASE + (tlb_index - TLB_BASE_INDEX_16M) * DYNAMIC_TLB_16M_SIZE,
+            .offset = TLB_16M_OFFSET,
+        };
+    } else if (tlb_index >= TLB_BASE_INDEX_2M) {
+        return tlb_configuration{
+            .size = DYNAMIC_TLB_2M_SIZE,
+            .base = DYNAMIC_TLB_2M_BASE,
+            .cfg_addr = DYNAMIC_TLB_2M_CFG_ADDR,
+            .index_offset = tlb_index - TLB_BASE_INDEX_2M,
+            .tlb_offset = DYNAMIC_TLB_2M_BASE + (tlb_index - TLB_BASE_INDEX_2M) * DYNAMIC_TLB_2M_SIZE,
+            .offset = TLB_2M_OFFSET,
+        };
+    } else {
+        return tlb_configuration{
+            .size = DYNAMIC_TLB_1M_SIZE,
+            .base = DYNAMIC_TLB_1M_BASE,
+            .cfg_addr = DYNAMIC_TLB_1M_CFG_ADDR,
+            .index_offset = tlb_index - TLB_BASE_INDEX_1M,
+            .tlb_offset = DYNAMIC_TLB_1M_BASE + (tlb_index - TLB_BASE_INDEX_1M) * DYNAMIC_TLB_1M_SIZE,
+            .offset = TLB_1M_OFFSET,
+        };
+    }
+}
+
+}  // namespace wormhole
+
+namespace blackhole {
+
+static tlb_configuration tlb_configuration_for(const uint32_t tlb_index) {
+    // If TLB index is in range for 4GB tlbs (8 TLBs after 202 TLBs for 2MB).
+    if (tlb_index >= TLB_COUNT_2M && tlb_index < TLB_COUNT_2M + TLB_COUNT_4G) {
+        return tlb_configuration{
+            .size = DYNAMIC_TLB_4G_SIZE,
+            .base = DYNAMIC_TLB_4G_BASE,
+            .cfg_addr = DYNAMIC_TLB_4G_CFG_ADDR,
+            .index_offset = tlb_index - TLB_BASE_INDEX_4G,
+            .tlb_offset = DYNAMIC_TLB_4G_BASE + (tlb_index - TLB_BASE_INDEX_4G) * DYNAMIC_TLB_4G_SIZE,
+            .offset = TLB_4G_OFFSET,
+        };
+    }
+
+    return tlb_configuration{
+        .size = DYNAMIC_TLB_2M_SIZE,
+        .base = DYNAMIC_TLB_2M_BASE,
+        .cfg_addr = DYNAMIC_TLB_2M_CFG_ADDR,
+        .index_offset = tlb_index - TLB_BASE_INDEX_2M,
+        .tlb_offset = DYNAMIC_TLB_2M_BASE + (tlb_index - TLB_BASE_INDEX_2M) * DYNAMIC_TLB_2M_SIZE,
+        .offset = TLB_2M_OFFSET,
+    };
+}
+
+}  // namespace blackhole
+
+namespace grendel {
+
+static tlb_configuration tlb_configuration_for(const uint32_t tlb_index) {
+    // If TLB index is in range for 4GB tlbs (8 TLBs after 202 TLBs for 2MB).
+    if (tlb_index >= TLB_COUNT_2M && tlb_index < TLB_COUNT_2M + TLB_COUNT_4G) {
+        return tlb_configuration{
+            .size = DYNAMIC_TLB_4G_SIZE,
+            .base = DYNAMIC_TLB_4G_BASE,
+            .cfg_addr = DYNAMIC_TLB_4G_CFG_ADDR,
+            .index_offset = tlb_index - TLB_BASE_INDEX_4G,
+            .tlb_offset = DYNAMIC_TLB_4G_BASE + (tlb_index - TLB_BASE_INDEX_4G) * DYNAMIC_TLB_4G_SIZE,
+            .offset = TLB_4G_OFFSET,
+        };
+    }
+
+    return tlb_configuration{
+        .size = DYNAMIC_TLB_2M_SIZE,
+        .base = DYNAMIC_TLB_2M_BASE,
+        .cfg_addr = DYNAMIC_TLB_2M_CFG_ADDR,
+        .index_offset = tlb_index - TLB_BASE_INDEX_2M,
+        .tlb_offset = DYNAMIC_TLB_2M_BASE + (tlb_index - TLB_BASE_INDEX_2M) * DYNAMIC_TLB_2M_SIZE,
+        .offset = TLB_2M_OFFSET,
+    };
+}
+
+}  // namespace grendel
+
+const ArchitectureTlbs& get_architecture_tlbs(const tt::ARCH arch) {
+    static const ArchitectureTlbs wormhole_tlbs = {
+        .base_and_count_1m = {wormhole::TLB_BASE_1M, wormhole::TLB_COUNT_1M},
+        .base_and_count_2m = {wormhole::TLB_BASE_2M, wormhole::TLB_COUNT_2M},
+        .base_and_count_16m = {wormhole::TLB_BASE_16M, wormhole::TLB_COUNT_16M},
+        .base_and_count_4g = {0, 0},
+        .sizes = {ONE_MB, 2 * ONE_MB, 16 * ONE_MB},
+        .cached_window_size = wormhole::STATIC_TLB_SIZE,
+        .use_static_vc = true,
+        .static_cfg_addr = wormhole::STATIC_TLB_CFG_ADDR,
+        .cfg_reg_size_bytes = 8,
+        .get_configuration = &wormhole::tlb_configuration_for,
+    };
+
+    static const ArchitectureTlbs blackhole_tlbs = {
+        .base_and_count_1m = {0, 0},
+        .base_and_count_2m = {blackhole::TLB_BASE_2M, blackhole::TLB_COUNT_2M},
+        .base_and_count_16m = {0, 0},
+        .base_and_count_4g = {blackhole::TLB_BASE_4G, blackhole::TLB_COUNT_4G},
+        .sizes = {2 * ONE_MB, 4 * ONE_GB},
+        .cached_window_size = blackhole::STATIC_TLB_SIZE,
+        // False due to a known HW issue.
+        .use_static_vc = false,
+        .static_cfg_addr = blackhole::STATIC_TLB_CFG_ADDR,
+        .cfg_reg_size_bytes = 12,
+        .get_configuration = &blackhole::tlb_configuration_for,
+    };
+
+    static const ArchitectureTlbs grendel_tlbs = {
+        .base_and_count_1m = {0, 0},
+        .base_and_count_2m = {grendel::TLB_BASE_2M, grendel::TLB_COUNT_2M},
+        .base_and_count_16m = {0, 0},
+        .base_and_count_4g = {grendel::TLB_BASE_4G, grendel::TLB_COUNT_4G},
+        .sizes = {2 * ONE_MB, 4 * ONE_GB},
+        .cached_window_size = grendel::STATIC_TLB_SIZE,
+        .use_static_vc = true,
+        .static_cfg_addr = grendel::STATIC_TLB_CFG_ADDR,
+        .cfg_reg_size_bytes = 12,
+        .get_configuration = &grendel::tlb_configuration_for,
+    };
+
+    switch (arch) {
+        case tt::ARCH::WORMHOLE_B0:
+            return wormhole_tlbs;
+        case tt::ARCH::BLACKHOLE:
+            return blackhole_tlbs;
+        case tt::ARCH::QUASAR:
+            return grendel_tlbs;
+        default:
+            UMD_THROW(
+                error::RuntimeError, fmt::format("No TLB layout defined for {} architecture.", arch_to_str(arch)));
+    }
+}
+
+}  // namespace tt::umd

--- a/device/arch/blackhole_implementation.cpp
+++ b/device/arch/blackhole_implementation.cpp
@@ -17,31 +17,6 @@
 
 namespace tt::umd {
 
-tlb_configuration BlackholeImplementation::get_tlb_configuration(uint32_t tlb_index) const {
-    // If TLB index is in range for 4GB tlbs (8 TLBs after 202 TLBs for 2MB).
-    if (tlb_index >= blackhole::TLB_COUNT_2M && tlb_index < blackhole::TLB_COUNT_2M + blackhole::TLB_COUNT_4G) {
-        return tlb_configuration{
-            .size = blackhole::DYNAMIC_TLB_4G_SIZE,
-            .base = blackhole::DYNAMIC_TLB_4G_BASE,
-            .cfg_addr = blackhole::DYNAMIC_TLB_4G_CFG_ADDR,
-            .index_offset = tlb_index - blackhole::TLB_BASE_INDEX_4G,
-            .tlb_offset = blackhole::DYNAMIC_TLB_4G_BASE +
-                          (tlb_index - blackhole::TLB_BASE_INDEX_4G) * blackhole::DYNAMIC_TLB_4G_SIZE,
-            .offset = blackhole::TLB_4G_OFFSET,
-        };
-    }
-
-    return tlb_configuration{
-        .size = blackhole::DYNAMIC_TLB_2M_SIZE,
-        .base = blackhole::DYNAMIC_TLB_2M_BASE,
-        .cfg_addr = blackhole::DYNAMIC_TLB_2M_CFG_ADDR,
-        .index_offset = tlb_index - blackhole::TLB_BASE_INDEX_2M,
-        .tlb_offset = blackhole::DYNAMIC_TLB_2M_BASE +
-                      (tlb_index - blackhole::TLB_BASE_INDEX_2M) * blackhole::DYNAMIC_TLB_2M_SIZE,
-        .offset = blackhole::TLB_2M_OFFSET,
-    };
-}
-
 DeviceL1AddressParams BlackholeImplementation::get_l1_address_params() const {
     // L1 barrier base and erisc barrier base should be explicitly set by the client.
     // Setting some default values here, but it should be ultimately overridden by the client.

--- a/device/arch/grendel_implementation.cpp
+++ b/device/arch/grendel_implementation.cpp
@@ -17,31 +17,6 @@
 
 namespace tt::umd {
 
-tlb_configuration GrendelImplementation::get_tlb_configuration(uint32_t tlb_index) const {
-    // If TLB index is in range for 4GB tlbs (8 TLBs after 202 TLBs for 2MB).
-    if (tlb_index >= grendel::TLB_COUNT_2M && tlb_index < grendel::TLB_COUNT_2M + grendel::TLB_COUNT_4G) {
-        return tlb_configuration{
-            .size = grendel::DYNAMIC_TLB_4G_SIZE,
-            .base = grendel::DYNAMIC_TLB_4G_BASE,
-            .cfg_addr = grendel::DYNAMIC_TLB_4G_CFG_ADDR,
-            .index_offset = tlb_index - grendel::TLB_BASE_INDEX_4G,
-            .tlb_offset =
-                grendel::DYNAMIC_TLB_4G_BASE + (tlb_index - grendel::TLB_BASE_INDEX_4G) * grendel::DYNAMIC_TLB_4G_SIZE,
-            .offset = grendel::TLB_4G_OFFSET,
-        };
-    }
-
-    return tlb_configuration{
-        .size = grendel::DYNAMIC_TLB_2M_SIZE,
-        .base = grendel::DYNAMIC_TLB_2M_BASE,
-        .cfg_addr = grendel::DYNAMIC_TLB_2M_CFG_ADDR,
-        .index_offset = tlb_index - grendel::TLB_BASE_INDEX_2M,
-        .tlb_offset =
-            grendel::DYNAMIC_TLB_2M_BASE + (tlb_index - grendel::TLB_BASE_INDEX_2M) * grendel::DYNAMIC_TLB_2M_SIZE,
-        .offset = grendel::TLB_2M_OFFSET,
-    };
-}
-
 DeviceL1AddressParams GrendelImplementation::get_l1_address_params() const {
     // L1 barrier base and erisc barrier base should be explicitly set by the client.
     // Setting some default values here, but it should be ultimately overridden by the client.

--- a/device/arch/wormhole_implementation.cpp
+++ b/device/arch/wormhole_implementation.cpp
@@ -25,40 +25,6 @@ constexpr std::uint32_t NOC_ADDR_LOCAL_BITS = 36;   // source: noc_parameters.h,
 constexpr std::uint32_t NOC_ADDR_NODE_ID_BITS = 6;  // source: noc_parameters.h, common for WH && BH
 }  // namespace wormhole
 
-tlb_configuration WormholeImplementation::get_tlb_configuration(uint32_t tlb_index) const {
-    if (tlb_index >= wormhole::TLB_BASE_INDEX_16M) {
-        return tlb_configuration{
-            .size = wormhole::DYNAMIC_TLB_16M_SIZE,
-            .base = wormhole::DYNAMIC_TLB_16M_BASE,
-            .cfg_addr = wormhole::DYNAMIC_TLB_16M_CFG_ADDR,
-            .index_offset = tlb_index - wormhole::TLB_BASE_INDEX_16M,
-            .tlb_offset = wormhole::DYNAMIC_TLB_16M_BASE +
-                          (tlb_index - wormhole::TLB_BASE_INDEX_16M) * wormhole::DYNAMIC_TLB_16M_SIZE,
-            .offset = wormhole::TLB_16M_OFFSET,
-        };
-    } else if (tlb_index >= wormhole::TLB_BASE_INDEX_2M) {
-        return tlb_configuration{
-            .size = wormhole::DYNAMIC_TLB_2M_SIZE,
-            .base = wormhole::DYNAMIC_TLB_2M_BASE,
-            .cfg_addr = wormhole::DYNAMIC_TLB_2M_CFG_ADDR,
-            .index_offset = tlb_index - wormhole::TLB_BASE_INDEX_2M,
-            .tlb_offset = wormhole::DYNAMIC_TLB_2M_BASE +
-                          (tlb_index - wormhole::TLB_BASE_INDEX_2M) * wormhole::DYNAMIC_TLB_2M_SIZE,
-            .offset = wormhole::TLB_2M_OFFSET,
-        };
-    } else {
-        return tlb_configuration{
-            .size = wormhole::DYNAMIC_TLB_1M_SIZE,
-            .base = wormhole::DYNAMIC_TLB_1M_BASE,
-            .cfg_addr = wormhole::DYNAMIC_TLB_1M_CFG_ADDR,
-            .index_offset = tlb_index - wormhole::TLB_BASE_INDEX_1M,
-            .tlb_offset = wormhole::DYNAMIC_TLB_1M_BASE +
-                          (tlb_index - wormhole::TLB_BASE_INDEX_1M) * wormhole::DYNAMIC_TLB_1M_SIZE,
-            .offset = wormhole::TLB_1M_OFFSET,
-        };
-    }
-}
-
 DeviceL1AddressParams WormholeImplementation::get_l1_address_params() const {
     // L1 barrier base and erisc barrier base should be explicitly set by the client.
     // Setting some default values here, but it should be ultimately overridden by the client.

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -21,6 +21,7 @@
 #include "noc_access.hpp"
 #include "tracy.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/chip_helpers/silicon_sysmem_manager.hpp"
 #include "umd/device/chip_helpers/sysmem_manager.hpp"
@@ -327,7 +328,7 @@ void LocalChip::write_to_device_reg(CoreCoord core, const void* src, uint64_t re
     config.y_end = translated_core.y;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = tlb_data::Strict;
-    config.static_vc = get_tt_device()->get_architecture_implementation()->get_static_vc();
+    config.static_vc = get_architecture_tlbs(get_tt_device()->get_arch()).use_static_vc;
     TlbWindow* tlb_window = get_cached_uc_tlb_window();
     tlb_window->configure(config);
 
@@ -358,7 +359,7 @@ void LocalChip::read_from_device_reg(CoreCoord core, void* dest, uint64_t reg_sr
     config.y_end = translated_core.y;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = tlb_data::Strict;
-    config.static_vc = get_tt_device()->get_architecture_implementation()->get_static_vc();
+    config.static_vc = get_architecture_tlbs(get_tt_device()->get_arch()).use_static_vc;
     TlbWindow* tlb_window = get_cached_uc_tlb_window();
     tlb_window->configure(config);
 
@@ -514,7 +515,7 @@ int LocalChip::get_numa_node() { return tt_device_->get_pci_device()->get_numa_n
 TlbWindow* LocalChip::get_cached_wc_tlb_window() {
     if (cached_wc_tlb_window == nullptr) {
         cached_wc_tlb_window = std::make_unique<SiliconTlbWindow>(get_tt_device()->get_pci_device()->allocate_tlb(
-            get_tt_device()->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::WC));
+            get_architecture_tlbs(get_tt_device()->get_arch()).cached_window_size, TlbMapping::WC));
         cached_wc_tlb_window->set_io_timeout_hang_check(make_io_timeout_hang_check());
         return cached_wc_tlb_window.get();
     }
@@ -525,7 +526,7 @@ TlbWindow* LocalChip::get_cached_wc_tlb_window() {
 TlbWindow* LocalChip::get_cached_uc_tlb_window() {
     if (cached_uc_tlb_window == nullptr) {
         cached_uc_tlb_window = std::make_unique<SiliconTlbWindow>(get_tt_device()->get_pci_device()->allocate_tlb(
-            get_tt_device()->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::UC));
+            get_architecture_tlbs(get_tt_device()->get_arch()).cached_window_size, TlbMapping::UC));
         cached_uc_tlb_window->set_io_timeout_hang_check(make_io_timeout_hang_check());
         return cached_uc_tlb_window.get();
     }

--- a/device/chip_helpers/simulation_tlb_allocator.cpp
+++ b/device/chip_helpers/simulation_tlb_allocator.cpp
@@ -10,6 +10,7 @@
 
 #include "tracy.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/utils/error.hpp"
@@ -131,7 +132,7 @@ void SimulationTlbAllocator::initialize_architecture_config() {
     if (architecture_ == tt::ARCH::WORMHOLE_B0) {
         tlb_reg_size_bytes_ = 8;  // wormhole::TLB_CFG_REG_SIZE_BYTES.
 
-        const auto& tlb_sizes = arch_impl_->get_tlb_sizes();
+        const auto& tlb_sizes = get_architecture_tlbs(architecture_).sizes;
         size_classes_[ONE_MB].size = tlb_sizes[0];  // 1MB.
         size_classes_[ONE_MB].count = 156;
         size_classes_[TWO_MB].size = tlb_sizes[1];  // 2MB.
@@ -143,7 +144,7 @@ void SimulationTlbAllocator::initialize_architecture_config() {
     } else if (architecture_ == tt::ARCH::BLACKHOLE) {
         tlb_reg_size_bytes_ = 12;  // blackhole::TLB_CFG_REG_SIZE_BYTES.
 
-        const auto& tlb_sizes = arch_impl_->get_tlb_sizes();
+        const auto& tlb_sizes = get_architecture_tlbs(architecture_).sizes;
         size_classes_[TWO_MB].size = tlb_sizes[0];  // 2MB.
         size_classes_[TWO_MB].count = 202;
         size_classes_[FOUR_GB].size = tlb_sizes[1];  // 4GB.

--- a/device/chip_helpers/tlb_manager.cpp
+++ b/device/chip_helpers/tlb_manager.cpp
@@ -17,6 +17,7 @@
 #include "noc_access.hpp"
 #include "tracy.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
 #include "umd/device/pcie/tlb_handle.hpp"
@@ -42,7 +43,7 @@ void TLBManager::configure_tlb(tt_xy_pair core, size_t tlb_size, uint64_t addres
     config.y_end = core.y;
     config.noc_sel = is_selected_noc1() ? 1 : 0;
     config.ordering = ordering;
-    config.static_vc = get_tt_device()->get_architecture_implementation()->get_static_vc();
+    config.static_vc = get_architecture_tlbs(get_tt_device()->get_arch()).use_static_vc;
     std::unique_ptr<TlbWindow> tlb_window = allocate_tlb_window(config, TlbMapping::WC, tlb_size);
 
     log_debug(
@@ -91,7 +92,7 @@ tlb_configuration TLBManager::get_tlb_configuration(tt_xy_pair core) {
     UMD_ASSERT(is_tlb_mapped(core), error::RuntimeError, fmt::format("TLB not mapped for core: {}", core.str()));
 
     int tlb_index = map_core_to_tlb_.at(core);
-    return tt_device_->get_architecture_implementation()->get_tlb_configuration(tlb_index);
+    return get_architecture_tlbs(tt_device_->get_arch()).get_configuration(tlb_index);
 }
 
 std::unique_ptr<TlbWindow> TLBManager::allocate_tlb_window(

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -34,6 +34,7 @@
 #include "tt-kmd-lib/pci_ids.h"
 #include "tt-kmd-lib/tt_kmd_lib.h"
 #include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/pcie/silicon_tlb_handle.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/utils/error.hpp"
@@ -490,7 +491,7 @@ PCIDevice::PCIDevice(int pci_device_number) :
         PROT_READ | PROT_WRITE,
         MAP_SHARED,
         pci_device_file_desc,
-        bar0_uc_mapping.base + arch_impl_->get_static_tlb_cfg_addr());
+        bar0_uc_mapping.base + get_architecture_tlbs(arch).static_cfg_addr);
 
     if (tlb_config_space == MAP_FAILED) {
         UMD_THROW(
@@ -826,13 +827,13 @@ std::unique_ptr<TlbHandle> PCIDevice::allocate_tlb(
 
 void PCIDevice::configure_tlb(const uint32_t tlb_index, const tlb_data &tlb_config, const bool verify) {
     // Get the TLB configuration for this index.
-    auto tlb_configuration = arch_impl_->get_tlb_configuration(tlb_index);
+    auto tlb_configuration = get_architecture_tlbs(arch).get_configuration(tlb_index);
 
     // Apply the architecture-specific bit field offsets to pack the TLB data.
     auto [lower_64, upper_64] = tlb_config.apply_offset(tlb_configuration.offset);
 
     // Calculate the register address for this TLB index using architecture-specific register size.
-    const uint64_t tlb_cfg_reg_size_bytes = arch_impl_->get_tlb_cfg_reg_size_bytes();
+    const uint64_t tlb_cfg_reg_size_bytes = get_architecture_tlbs(arch).cfg_reg_size_bytes;
     uint64_t tlb_register_addr = tlb_index * tlb_cfg_reg_size_bytes;
 
     // Write to the appropriate location in BAR0.

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
 #include "umd/device/pcie/tlb_window.hpp"
@@ -76,7 +77,7 @@ void PcieProtocol::set_io_timeout_callback(const std::function<bool(NocId)>& han
 TlbWindow* PcieProtocol::get_cached_wc_tlb_window() {
     if (cached_wc_tlb_window_ == nullptr) {
         cached_wc_tlb_window_ = std::make_unique<SiliconTlbWindow>(pci_device_->allocate_tlb(
-            pci_device_->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::WC));
+            get_architecture_tlbs(pci_device_->get_arch()).cached_window_size, TlbMapping::WC));
         cached_wc_tlb_window_->set_io_timeout_hang_check(hang_check_);
     }
     return cached_wc_tlb_window_.get();
@@ -85,7 +86,7 @@ TlbWindow* PcieProtocol::get_cached_wc_tlb_window() {
 TlbWindow* PcieProtocol::get_cached_uc_tlb_window() {
     if (cached_uc_tlb_window_ == nullptr) {
         cached_uc_tlb_window_ = std::make_unique<SiliconTlbWindow>(pci_device_->allocate_tlb(
-            pci_device_->get_architecture_implementation()->get_cached_tlb_size(), TlbMapping::UC));
+            get_architecture_tlbs(pci_device_->get_arch()).cached_window_size, TlbMapping::UC));
         cached_uc_tlb_window_->set_io_timeout_hang_check(hang_check_);
     }
     return cached_uc_tlb_window_.get();
@@ -223,7 +224,7 @@ int PcieProtocol::export_dmabuf(tt_xy_pair core, uint64_t addr, size_t size, uin
         error::RuntimeError,
         fmt::format("Size {} must be a multiple of the host page size ({} bytes) to be exported.", size, page_size));
 
-    const std::vector<size_t>& size_classes = pci_device_->get_architecture_implementation()->get_tlb_sizes();
+    const std::vector<size_t>& size_classes = get_architecture_tlbs(pci_device_->get_arch()).sizes;
     size_t window_size = 0;
     for (const size_t candidate : size_classes) {
         if (size <= candidate - (addr % candidate)) {
@@ -249,7 +250,7 @@ int PcieProtocol::export_dmabuf(tt_xy_pair core, uint64_t addr, size_t size, uin
     config.y_end = core.y;
     config.noc_sel = static_cast<uint64_t>(noc_id);
     config.ordering = ordering;
-    config.static_vc = pci_device_->get_architecture_implementation()->get_static_vc();
+    config.static_vc = get_architecture_tlbs(pci_device_->get_arch()).use_static_vc;
 
     log_debug(
         LogUMD,
@@ -321,7 +322,7 @@ tlb_data PcieProtocol::create_dma_tlb_config(
     config.y_end = core_end.y;
     config.noc_sel = static_cast<uint64_t>(noc_id);
     config.ordering = tlb_data::Relaxed;
-    config.static_vc = pci_device_->get_architecture_implementation()->get_static_vc();
+    config.static_vc = get_architecture_tlbs(pci_device_->get_arch()).use_static_vc;
     if (core_start) {
         config.x_start = core_start->x;
         config.y_start = core_start->y;
@@ -343,8 +344,8 @@ bool PcieProtocol::dma_transfer(void* buffer, size_t size, uint64_t addr, tlb_da
     size_t dmabuf_size = dma_buffer.size;
     TlbWindow* tlb_window = get_cached_dma_tlb_window(config);
 
-    auto axi_address_base = pci_device_->get_architecture_implementation()
-                                ->get_tlb_configuration(tlb_window->handle_ref().get_tlb_id())
+    auto axi_address_base = get_architecture_tlbs(pci_device_->get_arch())
+                                .get_configuration(tlb_window->handle_ref().get_tlb_id())
                                 .tlb_offset;
 
     const size_t tlb_handle_size = tlb_window->handle_ref().get_size();
@@ -386,8 +387,8 @@ bool PcieProtocol::dma_transfer_zero_copy(
 
     TlbWindow* tlb_window = get_cached_dma_tlb_window(config);
 
-    auto axi_address_base = pci_device_->get_architecture_implementation()
-                                ->get_tlb_configuration(tlb_window->handle_ref().get_tlb_id())
+    auto axi_address_base = get_architecture_tlbs(pci_device_->get_arch())
+                                .get_configuration(tlb_window->handle_ref().get_tlb_id())
                                 .tlb_offset;
 
     const size_t tlb_handle_size = tlb_window->handle_ref().get_size();

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -22,6 +22,7 @@
 #include "umd/device/arc/arc_messenger.hpp"
 #include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/arc/firmware_telemetry_reader.hpp"
+#include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/driver_atomics.hpp"
 #include "umd/device/firmware/firmware_info_provider_implementation.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
@@ -471,7 +472,7 @@ std::unique_ptr<TlbWindow> TTDevice::get_io_window(tlb_data config, TlbMapping m
     }
 
     // Caller didn't specify a size — try arch-supported sizes in preference order.
-    const std::vector<size_t> &possible_sizes = get_architecture_implementation()->get_tlb_sizes();
+    const std::vector<size_t> &possible_sizes = get_architecture_tlbs(arch).sizes;
     for (const auto &s : possible_sizes) {
         try {
             return std::make_unique<SiliconTlbWindow>(pci->allocate_tlb(s, mapping), config);

--- a/tools/tlb_virus.cpp
+++ b/tools/tlb_virus.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "common.hpp"
+#include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/chip_helpers/tlb_manager.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
@@ -26,18 +27,18 @@
 using namespace tt::umd;
 
 // Helper function to get TLB count for a given size from architecture.
-uint32_t get_tlb_count_for_size(ArchitectureImplementation* arch_impl, size_t tlb_size) {
+uint32_t get_tlb_count_for_size(const ArchitectureTlbs& tlbs, size_t tlb_size) {
     static constexpr size_t one_mb = 1 << 20;
     static constexpr size_t one_gb = 1 << 30;
 
     if (tlb_size == 1 * one_mb) {
-        return arch_impl->get_tlb_1m_base_and_count().second;
+        return tlbs.base_and_count_1m.second;
     } else if (tlb_size == 2 * one_mb) {
-        return arch_impl->get_tlb_2m_base_and_count().second;
+        return tlbs.base_and_count_2m.second;
     } else if (tlb_size == 16 * one_mb) {
-        return arch_impl->get_tlb_16m_base_and_count().second;
+        return tlbs.base_and_count_16m.second;
     } else if (tlb_size == 4ULL * one_gb) {
-        return arch_impl->get_tlb_4g_base_and_count().second;
+        return tlbs.base_and_count_4g.second;
     }
     return 0;
 }
@@ -64,9 +65,8 @@ int main(int argc, char* argv[]) {
             tt_device->init_tt_device();
             tt::ARCH arch = tt_device->get_arch();
             auto pci_device = tt_device->get_pci_device();
-            auto arch_impl = tt_device->get_architecture_implementation();
-
-            const std::vector<size_t>& tlb_sizes = arch_impl->get_tlb_sizes();
+            const ArchitectureTlbs& tlbs = get_architecture_tlbs(arch);
+            const std::vector<size_t>& tlb_sizes = tlbs.sizes;
 
             log_info(
                 tt::LogUMD,
@@ -76,7 +76,7 @@ int main(int argc, char* argv[]) {
 
             // Fetch and log TLB counts per size for this architecture.
             for (size_t tlb_size : tlb_sizes) {
-                uint32_t total_count = get_tlb_count_for_size(arch_impl, tlb_size);
+                uint32_t total_count = get_tlb_count_for_size(tlbs, tlb_size);
                 // Initialize tracking for this device and size.
                 tlb_allocation_summary[pci_device_id][tlb_size] = {0, total_count};
             }


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2873

### Description
Stacked on #3222.

The TLB window layout is not part of the Base API specification, so it moves out of
`ArchitectureImplementation` into `ArchitectureTlbs`, filled per architecture in one file, same
shape as `ArchitectureRegisters`. Resolving a window index to its configuration is per
architecture logic, so that one entry is a lookup and its implementation stays private to that
file.

`PCIDevice` and `SimulationTlbAllocator` are left holding an `ArchitectureImplementation` they no
longer read anything from. Dropping it is a small follow up PR.

### List of the changes
- Add `ArchitectureTlbs` with the base and count per window size, the available sizes, the cached
  window size, the static VC flag, the config register address and size, and the window
  configuration lookup.
- Remove the ten TLB getters from `ArchitectureImplementation` and its implementations, and move
  the window configuration resolution out of the arch implementations.
- Update the TLB call sites in PCIDevice, the PCIe protocol, TLB manager, local chip, TTDevice,
  the simulation TLB allocator and the tlb_virus tool.

### Testing
Code builds. TLB allocation and device IO tests cover these paths in CI.

### API Changes
This PR has API changes, ten methods removed from `ArchitectureImplementation` and a new
`ArchitectureTlbs`.

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/arch_impl_12
