### PR TITLE
Drop ArchitectureImplementation from the PCIe and simulation TLB paths

### DIFF
--- a/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
@@ -15,8 +15,6 @@
 
 namespace tt::umd {
 
-class ArchitectureImplementation;
-
 /**
  * In-process allocator for simulation TLB indices.
  *
@@ -26,7 +24,7 @@ class ArchitectureImplementation;
  */
 class SimulationTlbAllocator {
 public:
-    SimulationTlbAllocator(uint64_t bar0_base, const ArchitectureImplementation* arch_impl, uint64_t bar4_base = 0);
+    SimulationTlbAllocator(uint64_t bar0_base, tt::ARCH arch, uint64_t bar4_base = 0);
 
     /**
      * Allocate the smallest TLB whose size class is >= the requested size. If no
@@ -66,8 +64,6 @@ public:
      */
     uint64_t get_tlb_reg_address_from_index(int tlb_index);
 
-    const ArchitectureImplementation* get_architecture_impl() const;
-
     tt::ARCH get_architecture() const;
 
 private:
@@ -91,7 +87,6 @@ private:
 
     uint64_t bar0_base_ = 0;
     uint64_t bar4_base_ = 0;
-    const ArchitectureImplementation* arch_impl_ = nullptr;
     tt::ARCH architecture_;
     size_t tlb_reg_size_bytes_ = 8;  // Default to Wormhole size.
 

--- a/device/api/umd/device/pcie/pci_device.hpp
+++ b/device/api/umd/device/pcie/pci_device.hpp
@@ -18,7 +18,6 @@
 #include <utility>
 #include <vector>
 
-#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/pcie/silicon_tlb_handle.hpp"
 #include "umd/device/pcie/tlb_handle.hpp"
 #include "umd/device/types/arch.hpp"
@@ -29,7 +28,6 @@
 struct tt_device_t;
 
 namespace tt::umd {
-class ArchitectureImplementation;
 
 struct PciDeviceInfo {
     uint16_t vendor_id;
@@ -129,7 +127,6 @@ class PCIDevice {
     const tt::ARCH arch;             // e.g. Wormhole, Blackhole
     const SemVer kmd_version;        // KMD version
     const bool iommu_enabled;        // Whether the system is protected from this device by an IOMMU
-    std::unique_ptr<ArchitectureImplementation> arch_impl_;  // Architecture-specific implementation
     DmaBuffer dma_buffer{};
 
 public:
@@ -206,11 +203,6 @@ public:
      * @return what architecture this device is (e.g. Wormhole, Blackhole, etc.)
      */
     tt::ARCH get_arch() const { return arch; }
-
-    /**
-     * @return the architecture-specific implementation for this device
-     */
-    ArchitectureImplementation *get_architecture_implementation() const { return arch_impl_.get(); }
 
     /**
      * @return whether the system is protected from this device by an IOMMU

--- a/device/chip_helpers/simulation_tlb_allocator.cpp
+++ b/device/chip_helpers/simulation_tlb_allocator.cpp
@@ -9,17 +9,13 @@
 #include <tt-logger/tt-logger.hpp>
 
 #include "tracy.hpp"
-#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/architecture_tlbs.hpp"
-#include "umd/device/arch/blackhole_implementation.hpp"
-#include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
 
-SimulationTlbAllocator::SimulationTlbAllocator(
-    uint64_t bar0_base, const ArchitectureImplementation* arch_impl, uint64_t bar4_base) :
-    bar0_base_(bar0_base), bar4_base_(bar4_base), arch_impl_(arch_impl) {
+SimulationTlbAllocator::SimulationTlbAllocator(uint64_t bar0_base, tt::ARCH arch, uint64_t bar4_base) :
+    bar0_base_(bar0_base), bar4_base_(bar4_base), architecture_(arch) {
     initialize_architecture_config();
 }
 
@@ -107,8 +103,6 @@ uint64_t SimulationTlbAllocator::get_tlb_reg_address_from_index(int tlb_index) {
     return bar0_base_ + TLB_CONFIG_REG_BASE_OFFSET + tlb_index * tlb_reg_size_bytes_;
 }
 
-const ArchitectureImplementation* SimulationTlbAllocator::get_architecture_impl() const { return arch_impl_; }
-
 tt::ARCH SimulationTlbAllocator::get_architecture() const { return architecture_; }
 
 SimulationTlbAllocator::TlbSizeClass* SimulationTlbAllocator::find_size_class_for_index(int tlb_index) {
@@ -127,8 +121,6 @@ SimulationTlbAllocator::TlbSizeClass* SimulationTlbAllocator::find_size_class_fo
 }
 
 void SimulationTlbAllocator::initialize_architecture_config() {
-    architecture_ = arch_impl_->get_architecture();
-
     if (architecture_ == tt::ARCH::WORMHOLE_B0) {
         tlb_reg_size_bytes_ = 8;  // wormhole::TLB_CFG_REG_SIZE_BYTES.
 

--- a/device/pcie/pci_device.cpp
+++ b/device/pcie/pci_device.cpp
@@ -33,7 +33,6 @@
 #include "tracy.hpp"
 #include "tt-kmd-lib/pci_ids.h"
 #include "tt-kmd-lib/tt_kmd_lib.h"
-#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/pcie/silicon_tlb_handle.hpp"
 #include "umd/device/types/arch.hpp"
@@ -395,8 +394,7 @@ PCIDevice::PCIDevice(int pci_device_number) :
     revision(read_sysfs<int>(info, "revision")),
     arch(info.get_arch()),
     kmd_version(PCIDevice::read_kmd_version()),
-    iommu_enabled(detect_iommu(info)),
-    arch_impl_(ArchitectureImplementation::create(arch)) {
+    iommu_enabled(detect_iommu(info)) {
     if (kmd_version < KMD_MINIMUM_VERSION) {
         UMD_THROW(
             error::RuntimeError,

--- a/device/pcie/rtl_sim_tlb_handle.cpp
+++ b/device/pcie/rtl_sim_tlb_handle.cpp
@@ -9,7 +9,6 @@
 #include <memory>
 #include <tt-logger/tt-logger.hpp>
 
-#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 #include "umd/device/types/arch.hpp"
 #include "umd/device/types/tlb.hpp"
@@ -26,7 +25,7 @@ RtlSimTlbHandle::RtlSimTlbHandle(
     // QUASAR bypasses the simulation TLB allocator (see the Quasar branch in
     // RtlSimulationTTDevice's constructor); skip the allocator query for it so
     // get_tlb_address_from_index doesn't throw on the empty pool.
-    if (allocator_ && allocator_->get_architecture_impl()->get_architecture() != tt::ARCH::QUASAR) {
+    if (allocator_ && allocator_->get_architecture() != tt::ARCH::QUASAR) {
         // This is a fake, non-dereferenceable pointer used only for address arithmetic.
         // For RTL sim, bar0_base is 0, so this will be a near-null address.
         tlb_base_ = reinterpret_cast<uint8_t*>(allocator_->get_tlb_address_from_index(tlb_id_));

--- a/device/pcie/tt_sim_tlb_handle.cpp
+++ b/device/pcie/tt_sim_tlb_handle.cpp
@@ -11,7 +11,6 @@
 #include <tt-logger/tt-logger.hpp>
 #include <utility>
 
-#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/blackhole_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
@@ -37,7 +36,7 @@ TTSimTlbHandle::TTSimTlbHandle(
     // handles all I/O), so the allocator has no pools and the get_*_from_index
     // calls would throw. Skip them for QUASAR; tlb_base_ / tlb_reg_addr_ stay at
     // their defaults (nullptr / 0), which the QUASAR path never dereferences.
-    if (allocator_ && allocator_->get_architecture_impl()->get_architecture() != tt::ARCH::QUASAR) {
+    if (allocator_ && allocator_->get_architecture() != tt::ARCH::QUASAR) {
         tlb_base_ = reinterpret_cast<uint8_t*>(allocator_->get_tlb_address_from_index(tlb_id_));
         tlb_reg_addr_ = allocator_->get_tlb_reg_address_from_index(tlb_id_);
     }

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -250,7 +250,7 @@ void SimulationTTDevice::client_read(CoreCoord core, uint64_t addr, void* mem_pt
 }
 
 void SimulationTTDevice::init_tlb_allocator(uint64_t bar0_base) {
-    tlb_allocator_ = std::make_shared<SimulationTlbAllocator>(bar0_base, architecture_impl_.get());
+    tlb_allocator_ = std::make_shared<SimulationTlbAllocator>(bar0_base, arch);
 }
 
 void SimulationTTDevice::setup_cached_tlb_window() {

--- a/tests/baremetal/test_simulation_tlb_allocator.cpp
+++ b/tests/baremetal/test_simulation_tlb_allocator.cpp
@@ -8,7 +8,6 @@
 #include <memory>
 #include <unordered_set>
 
-#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/chip_helpers/simulation_tlb_allocator.hpp"
 #include "umd/device/types/arch.hpp"
 
@@ -23,8 +22,7 @@ constexpr uint64_t TEST_BAR0_BASE = 0x10000000ULL;
 }  // namespace
 
 TEST(SimulationTlbAllocator, WormholeBasicAllocateAndDeallocate) {
-    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
 
     int idx = allocator.allocate_tlb_index(0x100000);
     ASSERT_NE(idx, -1);
@@ -41,8 +39,7 @@ TEST(SimulationTlbAllocator, WormholeBasicAllocateAndDeallocate) {
 }
 
 TEST(SimulationTlbAllocator, WormholeAllocateEachSizeClass) {
-    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
 
     int idx_1mb = allocator.allocate_tlb_index(0x100000);
     ASSERT_NE(idx_1mb, -1);
@@ -58,8 +55,7 @@ TEST(SimulationTlbAllocator, WormholeAllocateEachSizeClass) {
 }
 
 TEST(SimulationTlbAllocator, WormholeAllocateZeroPicksSmallest) {
-    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
 
     int idx = allocator.allocate_tlb_index(0);
     ASSERT_NE(idx, -1);
@@ -68,8 +64,7 @@ TEST(SimulationTlbAllocator, WormholeAllocateZeroPicksSmallest) {
 }
 
 TEST(SimulationTlbAllocator, WormholeAllocateZeroFallsBackWhenSmallestClassExhausted) {
-    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
 
     // Drain the 1MB pool entirely (Wormhole has 156 1MB TLBs).
     for (size_t i = 0; i < 156; ++i) {
@@ -83,8 +78,7 @@ TEST(SimulationTlbAllocator, WormholeAllocateZeroFallsBackWhenSmallestClassExhau
 }
 
 TEST(SimulationTlbAllocator, WormholeIndicesAreUniqueWithinSizeClass) {
-    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
 
     std::unordered_set<int> seen_indices;
     seen_indices.reserve(156);
@@ -97,8 +91,7 @@ TEST(SimulationTlbAllocator, WormholeIndicesAreUniqueWithinSizeClass) {
 }
 
 TEST(SimulationTlbAllocator, WormholeFallsBackToLargerSizeClassWhenExhausted) {
-    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
 
     // Drain the 1MB pool entirely (Wormhole has 156 1MB TLBs).
     for (size_t i = 0; i < 156; ++i) {
@@ -112,8 +105,7 @@ TEST(SimulationTlbAllocator, WormholeFallsBackToLargerSizeClassWhenExhausted) {
 }
 
 TEST(SimulationTlbAllocator, WormholeReturnsNegativeOneWhenAllPoolsExhausted) {
-    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
 
     // Exhaust every size class. allocate_tlb_index(0) picks any available TLB.
     while (allocator.allocate_tlb_index(0) != -1) {
@@ -125,8 +117,7 @@ TEST(SimulationTlbAllocator, WormholeReturnsNegativeOneWhenAllPoolsExhausted) {
 }
 
 TEST(SimulationTlbAllocator, WormholeAddressFromIndex) {
-    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
 
     // Wormhole layout from BAR0 base 0x10000000:
     //   indices   0..155: 156 x 1MB  (0x10000000 .. 0x19BFFFFF)
@@ -139,8 +130,7 @@ TEST(SimulationTlbAllocator, WormholeAddressFromIndex) {
 }
 
 TEST(SimulationTlbAllocator, WormholeRegAddressFromIndex) {
-    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
 
     // TLB config registers start at BAR0+0x1FC00000 with 8-byte stride on Wormhole.
     EXPECT_EQ(allocator.get_tlb_reg_address_from_index(0), 0x2FC00000ULL);
@@ -148,8 +138,7 @@ TEST(SimulationTlbAllocator, WormholeRegAddressFromIndex) {
 }
 
 TEST(SimulationTlbAllocator, BlackholeBasicAllocate) {
-    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::BLACKHOLE);
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::BLACKHOLE);
 
     int idx = allocator.allocate_tlb_index(0x200000);
     ASSERT_NE(idx, -1);
@@ -159,8 +148,7 @@ TEST(SimulationTlbAllocator, BlackholeBasicAllocate) {
 }
 
 TEST(SimulationTlbAllocator, BlackholeAddressFromIndex) {
-    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::BLACKHOLE);
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::BLACKHOLE);
 
     // Blackhole layout from BAR0 base 0x10000000:
     //   indices 0..201: 202 x 2MB (0x10000000 .. 0x291FFFFF)
@@ -169,8 +157,7 @@ TEST(SimulationTlbAllocator, BlackholeAddressFromIndex) {
 }
 
 TEST(SimulationTlbAllocator, BlackholeRegAddressFromIndex) {
-    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::BLACKHOLE);
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::BLACKHOLE);
 
     // TLB config registers start at BAR0+0x1FC00000 with 12-byte stride on Blackhole.
     EXPECT_EQ(allocator.get_tlb_reg_address_from_index(0), 0x2FC00000ULL);
@@ -178,8 +165,7 @@ TEST(SimulationTlbAllocator, BlackholeRegAddressFromIndex) {
 }
 
 TEST(SimulationTlbAllocator, GettersThrowOnInvalidIndex) {
-    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
-    SimulationTlbAllocator allocator(TEST_BAR0_BASE, arch_impl.get());
+    SimulationTlbAllocator allocator(TEST_BAR0_BASE, tt::ARCH::WORMHOLE_B0);
 
     // Negative indices are rejected.
     EXPECT_THROW(allocator.get_tlb_size_from_index(-1), std::exception);


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2873

### Description
Stacked on #3223.

Leftover from #3223. `PCIDevice` and `SimulationTlbAllocator` held an
`ArchitectureImplementation` only to reach the TLB layout, which now comes from
`ArchitectureTlbs`, so the dependency is unused. The allocator still needs the architecture
itself, so it takes that directly instead.

With this, nothing under the PCIe, TLB or chip helper paths depends on the interface.

### List of the changes
- Remove `arch_impl_` and `get_architecture_implementation` from `PCIDevice`.
- `SimulationTlbAllocator` takes `tt::ARCH` instead of the architecture implementation, and loses
  `get_architecture_impl`. The simulation TLB handles read the architecture from the allocator,
  which already exposed it.
- Simplify the allocator test accordingly.

### Testing
Code builds. TLB allocation and simulation device IO tests cover these paths in CI.

### API Changes
This PR has API changes, `PCIDevice::get_architecture_implementation` is removed and the
`SimulationTlbAllocator` constructor takes an architecture.

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/arch_impl_12
