### PR TITLE
Describe TLB windows as size classes instead of one field per size

### DIFF
--- a/device/api/umd/device/arch/architecture_tlbs.hpp
+++ b/device/api/umd/device/arch/architecture_tlbs.hpp
@@ -6,7 +6,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <utility>
 #include <vector>
 
 #include "umd/device/types/arch.hpp"
@@ -14,23 +13,25 @@
 
 namespace tt::umd {
 
+// A set of TLB windows which all share one size, contiguous in the window index space.
+struct TlbSizeClass {
+    size_t size;
+    uint32_t count;
+    uint32_t base_index;
+    // Blackhole and Grendel map their largest windows through BAR4, everything else is in BAR0.
+    bool in_bar4;
+};
+
 // Resolves a TLB window index to its configuration.
 using TlbConfigurationResolver = tlb_configuration (*)(uint32_t tlb_index);
 
 // The TLB window layout of one architecture. Architecture specific code reads its own constants
 // directly; this exists for callers which are not tied to one architecture.
 struct ArchitectureTlbs {
-    // Base index and window count per window size. A zero count means the architecture has no
-    // windows of that size.
-    std::pair<uint32_t, uint32_t> base_and_count_1m;
-    std::pair<uint32_t, uint32_t> base_and_count_2m;
-    std::pair<uint32_t, uint32_t> base_and_count_16m;
-    std::pair<uint32_t, uint32_t> base_and_count_4g;
+    // Size classes the architecture provides, smallest size first.
+    std::vector<TlbSizeClass> size_classes;
 
-    // Window sizes the architecture provides, smallest first.
-    std::vector<size_t> sizes;
-
-    // Preferred window size, the group with the largest count available.
+    // Preferred window size, the size class with the most windows.
     size_t cached_window_size;
 
     // Whether static_vc should be used for window configuration.

--- a/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
+++ b/device/api/umd/device/chip_helpers/simulation_tlb_allocator.hpp
@@ -4,13 +4,13 @@
 
 #pragma once
 
-#include <array>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
 #include <vector>
 
+#include "umd/device/arch/architecture_tlbs.hpp"
 #include "umd/device/types/arch.hpp"
 
 namespace tt::umd {
@@ -67,23 +67,17 @@ public:
     tt::ARCH get_architecture() const;
 
 private:
-    // A pool of TLB indices that all share a single size.
-    struct TlbSizeClass {
-        size_t size = 0;         // Bytes per TLB; 0 means unused on the current arch.
-        size_t count = 0;        // Number of TLBs in the pool.
-        size_t start_index = 0;  // First global TLB index belonging to this pool.
+    // A size class and which of its windows are currently allocated.
+    struct TlbPool {
+        TlbSizeClass layout;
         std::vector<bool> allocated;
     };
-
-    // Indices into size_classes_; ordered smallest -> largest so allocate-with-escalation
-    // and address-layout iteration both Just Work.
-    enum SizeClass : size_t { ONE_MB = 0, TWO_MB = 1, SIXTEEN_MB = 2, FOUR_GB = 3, NUM_SIZE_CLASSES = 4 };
 
     void initialize_architecture_config();
 
     // Returns the pool that owns `tlb_index`, or nullptr if no pool covers it
     // (including for negative indices).
-    TlbSizeClass* find_size_class_for_index(int tlb_index);
+    TlbPool* find_pool_for_index(int tlb_index);
 
     uint64_t bar0_base_ = 0;
     uint64_t bar4_base_ = 0;
@@ -91,7 +85,9 @@ private:
     size_t tlb_reg_size_bytes_ = 8;  // Default to Wormhole size.
 
     std::mutex allocation_mutex_;
-    std::array<TlbSizeClass, NUM_SIZE_CLASSES> size_classes_;
+    // Ordered smallest window size first, so allocate-with-escalation and the BAR0 address
+    // layout both follow the iteration order.
+    std::vector<TlbPool> pools_;
 
     // Counter for the Quasar bypass branch of allocate_tlb_index(); see its docstring.
     std::atomic<int> next_bypass_tlb_id_{0};

--- a/device/arch/architecture_tlbs.cpp
+++ b/device/arch/architecture_tlbs.cpp
@@ -110,11 +110,10 @@ static tlb_configuration tlb_configuration_for(const uint32_t tlb_index) {
 
 const ArchitectureTlbs& get_architecture_tlbs(const tt::ARCH arch) {
     static const ArchitectureTlbs wormhole_tlbs = {
-        .base_and_count_1m = {wormhole::TLB_BASE_1M, wormhole::TLB_COUNT_1M},
-        .base_and_count_2m = {wormhole::TLB_BASE_2M, wormhole::TLB_COUNT_2M},
-        .base_and_count_16m = {wormhole::TLB_BASE_16M, wormhole::TLB_COUNT_16M},
-        .base_and_count_4g = {0, 0},
-        .sizes = {ONE_MB, 2 * ONE_MB, 16 * ONE_MB},
+        .size_classes =
+            {{ONE_MB, wormhole::TLB_COUNT_1M, wormhole::TLB_BASE_INDEX_1M, false},
+             {2 * ONE_MB, wormhole::TLB_COUNT_2M, wormhole::TLB_BASE_INDEX_2M, false},
+             {16 * ONE_MB, wormhole::TLB_COUNT_16M, wormhole::TLB_BASE_INDEX_16M, false}},
         .cached_window_size = wormhole::STATIC_TLB_SIZE,
         .use_static_vc = true,
         .static_cfg_addr = wormhole::STATIC_TLB_CFG_ADDR,
@@ -123,11 +122,9 @@ const ArchitectureTlbs& get_architecture_tlbs(const tt::ARCH arch) {
     };
 
     static const ArchitectureTlbs blackhole_tlbs = {
-        .base_and_count_1m = {0, 0},
-        .base_and_count_2m = {blackhole::TLB_BASE_2M, blackhole::TLB_COUNT_2M},
-        .base_and_count_16m = {0, 0},
-        .base_and_count_4g = {blackhole::TLB_BASE_4G, blackhole::TLB_COUNT_4G},
-        .sizes = {2 * ONE_MB, 4 * ONE_GB},
+        .size_classes =
+            {{2 * ONE_MB, blackhole::TLB_COUNT_2M, blackhole::TLB_BASE_INDEX_2M, false},
+             {4 * ONE_GB, blackhole::TLB_COUNT_4G, blackhole::TLB_BASE_INDEX_4G, true}},
         .cached_window_size = blackhole::STATIC_TLB_SIZE,
         // False due to a known HW issue.
         .use_static_vc = false,
@@ -137,11 +134,9 @@ const ArchitectureTlbs& get_architecture_tlbs(const tt::ARCH arch) {
     };
 
     static const ArchitectureTlbs grendel_tlbs = {
-        .base_and_count_1m = {0, 0},
-        .base_and_count_2m = {grendel::TLB_BASE_2M, grendel::TLB_COUNT_2M},
-        .base_and_count_16m = {0, 0},
-        .base_and_count_4g = {grendel::TLB_BASE_4G, grendel::TLB_COUNT_4G},
-        .sizes = {2 * ONE_MB, 4 * ONE_GB},
+        .size_classes =
+            {{2 * ONE_MB, grendel::TLB_COUNT_2M, grendel::TLB_BASE_INDEX_2M, false},
+             {4 * ONE_GB, grendel::TLB_COUNT_4G, grendel::TLB_BASE_INDEX_4G, true}},
         .cached_window_size = grendel::STATIC_TLB_SIZE,
         .use_static_vc = true,
         .static_cfg_addr = grendel::STATIC_TLB_CFG_ADDR,

--- a/device/chip_helpers/simulation_tlb_allocator.cpp
+++ b/device/chip_helpers/simulation_tlb_allocator.cpp
@@ -31,20 +31,20 @@ int SimulationTlbAllocator::allocate_tlb_index(size_t size) {
 
     std::lock_guard<std::mutex> lock(allocation_mutex_);
 
-    // Walk size classes smallest-first; pick the first free slot in the first
-    // class that can satisfy the request. Escalate to a larger class when the
-    // current one is full (a larger TLB still satisfies the request).
+    // Walk pools smallest-first; pick the first free slot in the first pool that can
+    // satisfy the request. Escalate to a larger pool when the current one is full (a
+    // larger TLB still satisfies the request).
     //
-    // size == 0 is handled by the same loop: `0 > sc.size` is always false for
-    // size_t, so every non-empty class is considered, smallest first.
-    for (auto& sc : size_classes_) {
-        if (sc.size == 0 || size > sc.size) {
+    // size == 0 is handled by the same loop: `0 > pool.layout.size` is always false for
+    // size_t, so every pool is considered, smallest first.
+    for (TlbPool& pool : pools_) {
+        if (size > pool.layout.size) {
             continue;
         }
-        for (size_t i = 0; i < sc.count; ++i) {
-            if (!sc.allocated[i]) {
-                sc.allocated[i] = true;
-                return static_cast<int>(sc.start_index + i);
+        for (size_t i = 0; i < pool.layout.count; ++i) {
+            if (!pool.allocated[i]) {
+                pool.allocated[i] = true;
+                return static_cast<int>(pool.layout.base_index + i);
             }
         }
     }
@@ -55,47 +55,49 @@ int SimulationTlbAllocator::allocate_tlb_index(size_t size) {
 void SimulationTlbAllocator::deallocate_tlb_index(int tlb_index) {
     ZoneScopedC(tracy::Color::Cyan);
     std::lock_guard<std::mutex> lock(allocation_mutex_);
-    if (auto* sc = find_size_class_for_index(tlb_index)) {
-        sc->allocated[static_cast<size_t>(tlb_index) - sc->start_index] = false;
+    if (TlbPool* pool = find_pool_for_index(tlb_index)) {
+        pool->allocated[static_cast<size_t>(tlb_index) - pool->layout.base_index] = false;
     }
 }
 
 size_t SimulationTlbAllocator::get_tlb_size_from_index(int tlb_index) {
-    auto* sc = find_size_class_for_index(tlb_index);
-    if (!sc) {
+    TlbPool* pool = find_pool_for_index(tlb_index);
+    if (!pool) {
         UMD_THROW(error::RuntimeError, fmt::format("Invalid simulation TLB index {}.", tlb_index));
     }
-    return sc->size;
+    return pool->layout.size;
 }
 
 uint64_t SimulationTlbAllocator::get_tlb_address_from_index(int tlb_index) {
-    auto* sc = find_size_class_for_index(tlb_index);
-    if (!sc) {
+    TlbPool* pool = find_pool_for_index(tlb_index);
+    if (!pool) {
         UMD_THROW(error::RuntimeError, fmt::format("Invalid simulation TLB index {}.", tlb_index));
     }
 
-    // BH 4GB TLBs live in BAR4, not BAR0. Each 4GB slot occupies its own region in
-    // BAR4, in TLB-index order starting from the FOUR_GB pool's start_index.
-    if (architecture_ == tt::ARCH::BLACKHOLE && sc == &size_classes_[FOUR_GB]) {
-        uint64_t slot = static_cast<uint64_t>(tlb_index) - sc->start_index;
-        return bar4_base_ + slot * sc->size;
+    const uint64_t slot = static_cast<uint64_t>(tlb_index) - pool->layout.base_index;
+
+    // Each BAR4 resident window occupies its own region, in TLB-index order.
+    if (pool->layout.in_bar4) {
+        return bar4_base_ + slot * pool->layout.size;
     }
 
-    // Size classes are laid out contiguously in BAR0; sum the sizes of all classes
-    // ordered before this one to get the offset where this class's region begins.
+    // Pools are laid out contiguously in BAR0; sum the sizes of all pools ordered before
+    // this one to get the offset where this pool's region begins.
     uint64_t region_offset = 0;
-    for (const auto& earlier : size_classes_) {
-        if (&earlier == sc) {
+    for (const TlbPool& earlier : pools_) {
+        if (&earlier == pool) {
             break;
         }
-        region_offset += earlier.count * earlier.size;
+        if (!earlier.layout.in_bar4) {
+            region_offset += earlier.layout.count * earlier.layout.size;
+        }
     }
 
-    return bar0_base_ + region_offset + (static_cast<uint64_t>(tlb_index) - sc->start_index) * sc->size;
+    return bar0_base_ + region_offset + slot * pool->layout.size;
 }
 
 uint64_t SimulationTlbAllocator::get_tlb_reg_address_from_index(int tlb_index) {
-    if (!find_size_class_for_index(tlb_index)) {
+    if (!find_pool_for_index(tlb_index)) {
         UMD_THROW(error::RuntimeError, fmt::format("Invalid simulation TLB index {}.", tlb_index));
     }
     // TLB configuration registers start at this offset from BAR0 base.
@@ -105,16 +107,16 @@ uint64_t SimulationTlbAllocator::get_tlb_reg_address_from_index(int tlb_index) {
 
 tt::ARCH SimulationTlbAllocator::get_architecture() const { return architecture_; }
 
-SimulationTlbAllocator::TlbSizeClass* SimulationTlbAllocator::find_size_class_for_index(int tlb_index) {
+SimulationTlbAllocator::TlbPool* SimulationTlbAllocator::find_pool_for_index(int tlb_index) {
     // Returning nullptr for negative indices avoids signed/unsigned comparison
     // pitfalls below (where size_t promotion would turn -1 into SIZE_MAX).
     if (tlb_index < 0) {
         return nullptr;
     }
     auto idx = static_cast<size_t>(tlb_index);
-    for (auto& sc : size_classes_) {
-        if (sc.count > 0 && idx >= sc.start_index && idx < sc.start_index + sc.count) {
-            return &sc;
+    for (TlbPool& pool : pools_) {
+        if (idx >= pool.layout.base_index && idx < pool.layout.base_index + pool.layout.count) {
+            return &pool;
         }
     }
     return nullptr;
@@ -123,26 +125,8 @@ SimulationTlbAllocator::TlbSizeClass* SimulationTlbAllocator::find_size_class_fo
 void SimulationTlbAllocator::initialize_architecture_config() {
     if (architecture_ == tt::ARCH::WORMHOLE_B0) {
         tlb_reg_size_bytes_ = 8;  // wormhole::TLB_CFG_REG_SIZE_BYTES.
-
-        const auto& tlb_sizes = get_architecture_tlbs(architecture_).sizes;
-        size_classes_[ONE_MB].size = tlb_sizes[0];  // 1MB.
-        size_classes_[ONE_MB].count = 156;
-        size_classes_[TWO_MB].size = tlb_sizes[1];  // 2MB.
-        size_classes_[TWO_MB].count = 10;
-        size_classes_[SIXTEEN_MB].size = tlb_sizes[2];  // 16MB.
-        size_classes_[SIXTEEN_MB].count = 20;
-        // FOUR_GB stays at default (count=0).
-
     } else if (architecture_ == tt::ARCH::BLACKHOLE) {
         tlb_reg_size_bytes_ = 12;  // blackhole::TLB_CFG_REG_SIZE_BYTES.
-
-        const auto& tlb_sizes = get_architecture_tlbs(architecture_).sizes;
-        size_classes_[TWO_MB].size = tlb_sizes[0];  // 2MB.
-        size_classes_[TWO_MB].count = 202;
-        size_classes_[FOUR_GB].size = tlb_sizes[1];  // 4GB.
-        size_classes_[FOUR_GB].count = 8;
-        // ONE_MB and SIXTEEN_MB stay at default (count=0).
-
     } else {
         // Intentional: architectures like QUASAR construct a SimulationTlbAllocator
         // but the sim TTDevice's constructor bypasses it entirely (builds the
@@ -158,15 +142,11 @@ void SimulationTlbAllocator::initialize_architecture_config() {
         return;
     }
 
-    // Lay out size classes contiguously in BAR0: each non-empty class starts where
-    // the previous one ends.
-    size_t next_start = 0;
-    for (auto& sc : size_classes_) {
-        sc.start_index = next_start;
-        if (sc.count > 0) {
-            sc.allocated.resize(sc.count, false);
-            next_start += sc.count;
-        }
+    for (const TlbSizeClass& size_class : get_architecture_tlbs(architecture_).size_classes) {
+        TlbPool pool;
+        pool.layout = size_class;
+        pool.allocated.resize(size_class.count, false);
+        pools_.push_back(std::move(pool));
     }
 }
 

--- a/device/tt_device/protocol/pcie_protocol.cpp
+++ b/device/tt_device/protocol/pcie_protocol.cpp
@@ -224,11 +224,11 @@ int PcieProtocol::export_dmabuf(tt_xy_pair core, uint64_t addr, size_t size, uin
         error::RuntimeError,
         fmt::format("Size {} must be a multiple of the host page size ({} bytes) to be exported.", size, page_size));
 
-    const std::vector<size_t>& size_classes = get_architecture_tlbs(pci_device_->get_arch()).sizes;
+    const std::vector<TlbSizeClass>& size_classes = get_architecture_tlbs(pci_device_->get_arch()).size_classes;
     size_t window_size = 0;
-    for (const size_t candidate : size_classes) {
-        if (size <= candidate - (addr % candidate)) {
-            window_size = candidate;
+    for (const TlbSizeClass& size_class : size_classes) {
+        if (size <= size_class.size - (addr % size_class.size)) {
+            window_size = size_class.size;
             break;
         }
     }
@@ -240,7 +240,7 @@ int PcieProtocol::export_dmabuf(tt_xy_pair core, uint64_t addr, size_t size, uin
             "size-aligned. Use a smaller size or a more aligned address.",
             size,
             addr,
-            size_classes.back()));
+            size_classes.back().size));
 
     const uint64_t window_offset = addr % window_size;
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -472,12 +472,11 @@ std::unique_ptr<TlbWindow> TTDevice::get_io_window(tlb_data config, TlbMapping m
     }
 
     // Caller didn't specify a size — try arch-supported sizes in preference order.
-    const std::vector<size_t> &possible_sizes = get_architecture_tlbs(arch).sizes;
-    for (const auto &s : possible_sizes) {
+    for (const TlbSizeClass &size_class : get_architecture_tlbs(arch).size_classes) {
         try {
-            return std::make_unique<SiliconTlbWindow>(pci->allocate_tlb(s, mapping), config);
+            return std::make_unique<SiliconTlbWindow>(pci->allocate_tlb(size_class.size, mapping), config);
         } catch (const std::exception &e) {
-            log_debug(LogUMD, "Failed to allocate TLB window of size {}: {}", s, e.what());
+            log_debug(LogUMD, "Failed to allocate TLB window of size {}: {}", size_class.size, e.what());
         }
     }
 

--- a/tools/tlb_virus.cpp
+++ b/tools/tlb_virus.cpp
@@ -26,23 +26,6 @@
 
 using namespace tt::umd;
 
-// Helper function to get TLB count for a given size from architecture.
-uint32_t get_tlb_count_for_size(const ArchitectureTlbs& tlbs, size_t tlb_size) {
-    static constexpr size_t one_mb = 1 << 20;
-    static constexpr size_t one_gb = 1 << 30;
-
-    if (tlb_size == 1 * one_mb) {
-        return tlbs.base_and_count_1m.second;
-    } else if (tlb_size == 2 * one_mb) {
-        return tlbs.base_and_count_2m.second;
-    } else if (tlb_size == 16 * one_mb) {
-        return tlbs.base_and_count_16m.second;
-    } else if (tlb_size == 4ULL * one_gb) {
-        return tlbs.base_and_count_4g.second;
-    }
-    return 0;
-}
-
 int main(int argc, char* argv[]) {
     cxxopts::Options options("tlb_virus", "Allocate TLBs in an infinite loop until failure for all sizes.");
 
@@ -65,8 +48,7 @@ int main(int argc, char* argv[]) {
             tt_device->init_tt_device();
             tt::ARCH arch = tt_device->get_arch();
             auto pci_device = tt_device->get_pci_device();
-            const ArchitectureTlbs& tlbs = get_architecture_tlbs(arch);
-            const std::vector<size_t>& tlb_sizes = tlbs.sizes;
+            const std::vector<TlbSizeClass>& tlb_size_classes = get_architecture_tlbs(arch).size_classes;
 
             log_info(
                 tt::LogUMD,
@@ -74,14 +56,13 @@ int main(int argc, char* argv[]) {
                 pci_device_id,
                 tt::arch_to_str(arch));
 
-            // Fetch and log TLB counts per size for this architecture.
-            for (size_t tlb_size : tlb_sizes) {
-                uint32_t total_count = get_tlb_count_for_size(tlbs, tlb_size);
-                // Initialize tracking for this device and size.
-                tlb_allocation_summary[pci_device_id][tlb_size] = {0, total_count};
+            // Initialize tracking for this device, per window size.
+            for (const TlbSizeClass& size_class : tlb_size_classes) {
+                tlb_allocation_summary[pci_device_id][size_class.size] = {0, size_class.count};
             }
 
-            for (size_t tlb_size : tlb_sizes) {
+            for (const TlbSizeClass& size_class : tlb_size_classes) {
+                const size_t tlb_size = size_class.size;
                 int total_allocated = 0;
                 log_info(tt::LogUMD, "Testing TLB size: {} bytes", tlb_size);
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2873

### Description
Stacked on #3224.

`ArchitectureTlbs` had a base and count field per window size plus a separate list of sizes, so
architectures filled `{0, 0}` for sizes they do not have and callers matched size literals to find
a count. One list of size classes replaces all of it. The class also carries the base window
index and the BAR4 mapping, both of which the architecture already defines.

`SimulationTlbAllocator` kept a near copy of the same structure, so its pools are built from the
classes now instead of a fixed array indexed by a size class enum.

### List of the changes
- Replace the four base and count fields and the size list with a list of `TlbSizeClass`.
- Drop the unused base offset, which was a BAR offset rather than the window index it claimed.
- `SimulationTlbAllocator` keeps one pool per class, so its size class enum, its duplicated window
  counts and its index layout pass are gone.

### Testing
Code builds. Simulation TLB allocator unit tests pass, including the address from index cases.

### API Changes
This PR has API changes, `ArchitectureTlbs` describes size classes instead of a field per size.

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/arch_impl_12

