### PR TITLE
Remove Tensix location and UBB tray getters from ArchitectureImplementation

### DIFF
--- a/device/api/umd/device/arch/architecture_implementation.hpp
+++ b/device/api/umd/device/arch/architecture_implementation.hpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <iterator>
 #include <memory>
-#include <optional>
 #include <utility>
 #include <vector>
 
@@ -43,16 +42,10 @@ public:
     virtual uint32_t get_soft_reset_staggered_start() const = 0;
     // Replace with std::span once we enable C++20.
     virtual const std::vector<uint32_t>& get_harvesting_noc_locations() const = 0;
-    virtual const std::vector<uint32_t>& get_t6_x_locations() const = 0;
-    virtual const std::vector<uint32_t>& get_t6_y_locations() const = 0;
 
     virtual DeviceL1AddressParams get_l1_address_params() const = 0;
 
     static std::unique_ptr<ArchitectureImplementation> create(tt::ARCH architecture);
-
-    // Map a PCI bus id to a UBB tray id (1..4). Returns std::nullopt for archs without UBB
-    // boards or when the bus id does not correspond to a known tray.
-    virtual std::optional<uint8_t> get_ubb_tray_id(uint16_t bus_id) const { return std::nullopt; }
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -365,10 +365,6 @@ public:
         return blackhole::HARVESTING_NOC_LOCATIONS;
     }
 
-    const std::vector<uint32_t>& get_t6_x_locations() const override { return blackhole::T6_X_LOCATIONS; }
-
-    const std::vector<uint32_t>& get_t6_y_locations() const override { return blackhole::T6_Y_LOCATIONS; }
-
     DeviceL1AddressParams get_l1_address_params() const override;
 };
 

--- a/device/api/umd/device/arch/grendel_implementation.hpp
+++ b/device/api/umd/device/arch/grendel_implementation.hpp
@@ -358,10 +358,6 @@ public:
         return grendel::HARVESTING_NOC_LOCATIONS;
     }
 
-    const std::vector<uint32_t>& get_t6_x_locations() const override { return grendel::T6_X_LOCATIONS; }
-
-    const std::vector<uint32_t>& get_t6_y_locations() const override { return grendel::T6_Y_LOCATIONS; }
-
     DeviceL1AddressParams get_l1_address_params() const override;
 };
 

--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -422,20 +422,7 @@ public:
         return wormhole::HARVESTING_NOC_LOCATIONS;
     }
 
-    const std::vector<uint32_t>& get_t6_x_locations() const override { return wormhole::T6_X_LOCATIONS; }
-
-    const std::vector<uint32_t>& get_t6_y_locations() const override { return wormhole::T6_Y_LOCATIONS; }
-
     DeviceL1AddressParams get_l1_address_params() const override;
-
-    std::optional<uint8_t> get_ubb_tray_id(uint16_t bus_id) const override {
-        const uint16_t bus_high = static_cast<uint16_t>(bus_id & 0xF0);
-        auto it = std::find(wormhole::UBB_TRAY_BUS_IDS.begin(), wormhole::UBB_TRAY_BUS_IDS.end(), bus_high);
-        if (it == wormhole::UBB_TRAY_BUS_IDS.end()) {
-            return std::nullopt;
-        }
-        return static_cast<uint8_t>(std::distance(wormhole::UBB_TRAY_BUS_IDS.begin(), it) + 1);
-    }
 };
 
 }  // namespace tt::umd

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -8,6 +8,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -29,6 +30,8 @@
 #include "common/utils.hpp"
 #include "disjoint_set.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/blackhole_implementation.hpp"
+#include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/coordinates/coordinate_manager.hpp"
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/semver.hpp"
@@ -1372,16 +1375,29 @@ uint16_t ClusterDescriptor::get_bus_id(ChipId chip_id) const {
     return it->second;
 }
 
+namespace {
+
+// High nibble of the PCI bus id identifies which UBB tray a chip sits on.
+std::optional<uint8_t> ubb_tray_id(const std::array<uint16_t, 4> &tray_bus_ids, const uint16_t bus_id) {
+    const uint16_t bus_high = static_cast<uint16_t>(bus_id & 0xF0);
+    const auto it = std::find(tray_bus_ids.begin(), tray_bus_ids.end(), bus_high);
+    if (it == tray_bus_ids.end()) {
+        return std::nullopt;
+    }
+    return static_cast<uint8_t>(std::distance(tray_bus_ids.begin(), it) + 1);
+}
+
+}  // namespace
+
 std::optional<uint8_t> ClusterDescriptor::get_tray_id(ChipId chip_id) const {
-    const BoardType board = get_board_type(chip_id);
-    if (board != BoardType::UBB_WORMHOLE && board != BoardType::UBB_BLACKHOLE) {
-        return std::nullopt;
+    switch (get_board_type(chip_id)) {
+        case BoardType::UBB_WORMHOLE:
+            return ubb_tray_id(wormhole::UBB_TRAY_BUS_IDS, get_bus_id(chip_id));
+        case BoardType::UBB_BLACKHOLE:
+            return ubb_tray_id(blackhole::UBB_TRAY_BUS_IDS, get_bus_id(chip_id));
+        default:
+            return std::nullopt;
     }
-    auto arch_impl = ArchitectureImplementation::create(get_arch(chip_id));
-    if (!arch_impl) {
-        return std::nullopt;
-    }
-    return arch_impl->get_ubb_tray_id(get_bus_id(chip_id));
 }
 
 const std::unordered_map<ChipId, uint16_t> &ClusterDescriptor::get_chip_to_bus_id() const { return chip_to_bus_id; }

--- a/device/tt_device/ethernet_broadcast.cpp
+++ b/device/tt_device/ethernet_broadcast.cpp
@@ -16,7 +16,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/types/arch.hpp"
@@ -25,23 +24,20 @@
 
 namespace tt::umd {
 
-static bool tensix_or_eth_in_broadcast(
-    const std::set<uint32_t>& cols_to_exclude, const ArchitectureImplementation* arch_impl) {
+static bool tensix_or_eth_in_broadcast(const std::set<uint32_t>& cols_to_exclude) {
     bool found_tensix_or_eth = false;
-    for (const auto& col : arch_impl->get_t6_x_locations()) {
+    for (const auto& col : wormhole::T6_X_LOCATIONS) {
         found_tensix_or_eth |= (cols_to_exclude.find(col) == cols_to_exclude.end());
     }
     return found_tensix_or_eth;
 }
 
 static bool valid_tensix_broadcast_grid(
-    const std::set<uint32_t>& rows_to_exclude,
-    const std::set<uint32_t>& cols_to_exclude,
-    const ArchitectureImplementation* arch_impl) {
+    const std::set<uint32_t>& rows_to_exclude, const std::set<uint32_t>& cols_to_exclude) {
     bool t6_bcast_rows_complete = true;
     bool t6_bcast_rows_empty = true;
 
-    for (const auto& row : arch_impl->get_t6_y_locations()) {
+    for (const auto& row : wormhole::T6_Y_LOCATIONS) {
         t6_bcast_rows_complete &= (rows_to_exclude.find(row) == rows_to_exclude.end());
         t6_bcast_rows_empty &= (rows_to_exclude.find(row) != rows_to_exclude.end());
     }
@@ -290,11 +286,10 @@ void EthernetBroadcast::broadcast_write_to_cluster(
     adjust_coordinates_for_ethernet_broadcast(
         rows_to_exclude, columns_to_exclude, use_translated_coords, rows_to_exclude_virtual, cols_to_exclude_virtual);
 
-    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
     if (cols_to_exclude_virtual.find(0) == cols_to_exclude_virtual.end() or
         cols_to_exclude_virtual.find(5) == cols_to_exclude_virtual.end()) {
         UMD_ASSERT(
-            !tensix_or_eth_in_broadcast(cols_to_exclude_virtual, arch_impl.get()),
+            !tensix_or_eth_in_broadcast(cols_to_exclude_virtual),
             error::RuntimeError,
             "Cannot broadcast to tensix/ethernet and DRAM simultaneously on Wormhole.");
         if (cols_to_exclude_virtual.find(0) == cols_to_exclude_virtual.end()) {
@@ -328,8 +323,7 @@ void EthernetBroadcast::broadcast_write_to_cluster(
         }
     } else {
         UMD_ASSERT(
-            use_translated_coords or
-                valid_tensix_broadcast_grid(rows_to_exclude_virtual, cols_to_exclude_virtual, arch_impl.get()),
+            use_translated_coords || valid_tensix_broadcast_grid(rows_to_exclude_virtual, cols_to_exclude_virtual),
             error::RuntimeError,
             "Must broadcast to all tensix rows when using noc0 coordinates.");
         ethernet_broadcast_write(


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2873

### Description
Stacked on #3226.

Neither of these is in the Base API specification, and neither needs a new home.

`get_t6_x_locations` and `get_t6_y_locations` had one caller, the legacy ETH broadcast path, which
was already constructing a Wormhole implementation explicitly to reach them. It reads the Wormhole
constants directly now.

`get_ubb_tray_id` mapped a PCI bus id to a UBB tray. `ClusterDescriptor::get_tray_id` already
knows the board type before asking, so it picks the tray table from the board rather than
constructing an architecture implementation to dispatch on the architecture. The tables stay per
architecture, the lookup over them is written once.

### List of the changes
- Remove `get_t6_x_locations`, `get_t6_y_locations` and `get_ubb_tray_id` from the interface and
  its implementations.
- The ETH broadcast helpers read the Wormhole Tensix locations directly.
- `ClusterDescriptor::get_tray_id` selects the tray table by board type.

### Testing
Code builds. Cluster descriptor and Wormhole broadcast paths are covered in CI.

### API Changes
This PR has API changes, three methods removed from `ArchitectureImplementation`.

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/arch_impl_12
