### PR TITLE
Align ArchitectureImplementation naming with the Base API specification

### DIFF
--- a/device/api/umd/device/arch/architecture_implementation.hpp
+++ b/device/api/umd/device/arch/architecture_implementation.hpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <iterator>
 #include <memory>
-#include <optional>
 #include <utility>
 #include <vector>
 
@@ -43,16 +42,10 @@ public:
     virtual uint32_t get_soft_reset_staggered_start() const = 0;
     // Replace with std::span once we enable C++20.
     virtual const std::vector<uint32_t>& get_harvesting_noc_locations() const = 0;
-    virtual const std::vector<uint32_t>& get_t6_x_locations() const = 0;
-    virtual const std::vector<uint32_t>& get_t6_y_locations() const = 0;
 
     virtual DeviceL1AddressParams get_l1_address_params() const = 0;
 
     static std::unique_ptr<ArchitectureImplementation> create(tt::ARCH architecture);
-
-    // Map a PCI bus id to a UBB tray id (1..4). Returns std::nullopt for archs without UBB
-    // boards or when the bus id does not correspond to a known tray.
-    virtual std::optional<uint8_t> get_ubb_tray_id(uint16_t bus_id) const { return std::nullopt; }
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/arch/architecture_implementation.hpp
+++ b/device/api/umd/device/arch/architecture_implementation.hpp
@@ -29,17 +29,20 @@ public:
     virtual ~ArchitectureImplementation() = default;
 
     virtual tt::ARCH get_architecture() const = 0;
-    virtual uint32_t get_arc_message_arc_go_busy() const = 0;
-    virtual uint32_t get_arc_message_arc_go_long_idle() const = 0;
-    virtual uint32_t get_arc_reset_unit_refclk_low_offset() const = 0;
-    virtual uint32_t get_arc_reset_unit_refclk_high_offset() const = 0;
+    virtual uint32_t get_firmware_message_go_busy() const = 0;
+    virtual uint32_t get_firmware_message_go_idle() const = 0;
+    virtual uint64_t get_reset_unit_refclk_low_offset() const = 0;
+    virtual uint64_t get_reset_unit_refclk_high_offset() const = 0;
     virtual uint32_t get_dram_banks_number() const = 0;
-    virtual uint32_t get_aiclk_busy_val() const = 0;
+    // AICLK frequency the chip parks at when idle, in MHz.
+    virtual uint32_t get_min_clock_freq() const = 0;
     virtual uint32_t get_num_eth_channels() const = 0;
-    virtual uint32_t get_tensix_soft_reset_addr() const = 0;
+    virtual uint64_t get_tensix_soft_reset_addr() const = 0;
     virtual uint32_t get_soft_reset_reg_value(RiscType risc_type) const = 0;
     virtual RiscType get_soft_reset_risc_type(uint32_t soft_reset_reg_value) const = 0;
     virtual uint32_t get_soft_reset_staggered_start() const = 0;
+    // Maps the harvesting indexes firmware reports onto NOC coordinates along the harvesting axis,
+    // rows for Wormhole and columns for Blackhole.
     // Replace with std::span once we enable C++20.
     virtual const std::vector<uint32_t>& get_harvesting_noc_locations() const = 0;
 

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -335,25 +335,25 @@ class BlackholeImplementation : public ArchitectureImplementation {
 public:
     tt::ARCH get_architecture() const override { return tt::ARCH::BLACKHOLE; }
 
-    uint32_t get_arc_message_arc_go_busy() const override {
+    uint32_t get_firmware_message_go_busy() const override {
         return static_cast<uint32_t>(blackhole::arc_message_type::ARC_GO_BUSY);
     }
 
-    uint32_t get_arc_message_arc_go_long_idle() const override {
+    uint32_t get_firmware_message_go_idle() const override {
         return static_cast<uint32_t>(blackhole::arc_message_type::ARC_GO_LONG_IDLE);
     }
 
-    uint32_t get_arc_reset_unit_refclk_low_offset() const override { return blackhole::ARC_RESET_REFCLK_LOW_OFFSET; }
+    uint64_t get_reset_unit_refclk_low_offset() const override { return blackhole::ARC_RESET_REFCLK_LOW_OFFSET; }
 
-    uint32_t get_arc_reset_unit_refclk_high_offset() const override { return blackhole::ARC_RESET_REFCLK_HIGH_OFFSET; }
+    uint64_t get_reset_unit_refclk_high_offset() const override { return blackhole::ARC_RESET_REFCLK_HIGH_OFFSET; }
 
     uint32_t get_dram_banks_number() const override { return blackhole::NUM_DRAM_BANKS; }
 
-    uint32_t get_aiclk_busy_val() const override { return blackhole::AICLK_BUSY_VAL; }
+    uint32_t get_min_clock_freq() const override { return blackhole::AICLK_IDLE_VAL; }
 
     uint32_t get_num_eth_channels() const override { return blackhole::NUM_ETH_CHANNELS; }
 
-    uint32_t get_tensix_soft_reset_addr() const override { return blackhole::TENSIX_SOFT_RESET_ADDR; }
+    uint64_t get_tensix_soft_reset_addr() const override { return blackhole::TENSIX_SOFT_RESET_ADDR; }
 
     uint32_t get_soft_reset_reg_value(RiscType risc_type) const override;
 

--- a/device/api/umd/device/arch/blackhole_implementation.hpp
+++ b/device/api/umd/device/arch/blackhole_implementation.hpp
@@ -365,10 +365,6 @@ public:
         return blackhole::HARVESTING_NOC_LOCATIONS;
     }
 
-    const std::vector<uint32_t>& get_t6_x_locations() const override { return blackhole::T6_X_LOCATIONS; }
-
-    const std::vector<uint32_t>& get_t6_y_locations() const override { return blackhole::T6_Y_LOCATIONS; }
-
     DeviceL1AddressParams get_l1_address_params() const override;
 };
 

--- a/device/api/umd/device/arch/grendel_implementation.hpp
+++ b/device/api/umd/device/arch/grendel_implementation.hpp
@@ -326,25 +326,25 @@ class GrendelImplementation : public ArchitectureImplementation {
 public:
     tt::ARCH get_architecture() const override { return tt::ARCH::QUASAR; }
 
-    uint32_t get_arc_message_arc_go_busy() const override {
+    uint32_t get_firmware_message_go_busy() const override {
         return static_cast<uint32_t>(grendel::arc_message_type::ARC_GO_BUSY);
     }
 
-    uint32_t get_arc_message_arc_go_long_idle() const override {
+    uint32_t get_firmware_message_go_idle() const override {
         return static_cast<uint32_t>(grendel::arc_message_type::ARC_GO_LONG_IDLE);
     }
 
-    uint32_t get_arc_reset_unit_refclk_low_offset() const override { return grendel::ARC_RESET_REFCLK_LOW_OFFSET; }
+    uint64_t get_reset_unit_refclk_low_offset() const override { return grendel::ARC_RESET_REFCLK_LOW_OFFSET; }
 
-    uint32_t get_arc_reset_unit_refclk_high_offset() const override { return grendel::ARC_RESET_REFCLK_HIGH_OFFSET; }
+    uint64_t get_reset_unit_refclk_high_offset() const override { return grendel::ARC_RESET_REFCLK_HIGH_OFFSET; }
 
     uint32_t get_dram_banks_number() const override { return grendel::NUM_DRAM_BANKS; }
 
-    uint32_t get_aiclk_busy_val() const override { return grendel::AICLK_BUSY_VAL; }
+    uint32_t get_min_clock_freq() const override { return grendel::AICLK_IDLE_VAL; }
 
     uint32_t get_num_eth_channels() const override { return grendel::NUM_ETH_CHANNELS; }
 
-    uint32_t get_tensix_soft_reset_addr() const override { return grendel::TENSIX_SOFT_RESET_ADDR; }
+    uint64_t get_tensix_soft_reset_addr() const override { return grendel::TENSIX_SOFT_RESET_ADDR; }
 
     uint32_t get_soft_reset_reg_value(RiscType risc_type) const override;
 

--- a/device/api/umd/device/arch/grendel_implementation.hpp
+++ b/device/api/umd/device/arch/grendel_implementation.hpp
@@ -358,10 +358,6 @@ public:
         return grendel::HARVESTING_NOC_LOCATIONS;
     }
 
-    const std::vector<uint32_t>& get_t6_x_locations() const override { return grendel::T6_X_LOCATIONS; }
-
-    const std::vector<uint32_t>& get_t6_y_locations() const override { return grendel::T6_Y_LOCATIONS; }
-
     DeviceL1AddressParams get_l1_address_params() const override;
 };
 

--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -422,20 +422,7 @@ public:
         return wormhole::HARVESTING_NOC_LOCATIONS;
     }
 
-    const std::vector<uint32_t>& get_t6_x_locations() const override { return wormhole::T6_X_LOCATIONS; }
-
-    const std::vector<uint32_t>& get_t6_y_locations() const override { return wormhole::T6_Y_LOCATIONS; }
-
     DeviceL1AddressParams get_l1_address_params() const override;
-
-    std::optional<uint8_t> get_ubb_tray_id(uint16_t bus_id) const override {
-        const uint16_t bus_high = static_cast<uint16_t>(bus_id & 0xF0);
-        auto it = std::find(wormhole::UBB_TRAY_BUS_IDS.begin(), wormhole::UBB_TRAY_BUS_IDS.end(), bus_high);
-        if (it == wormhole::UBB_TRAY_BUS_IDS.end()) {
-            return std::nullopt;
-        }
-        return static_cast<uint8_t>(std::distance(wormhole::UBB_TRAY_BUS_IDS.begin(), it) + 1);
-    }
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/arch/wormhole_implementation.hpp
+++ b/device/api/umd/device/arch/wormhole_implementation.hpp
@@ -392,25 +392,25 @@ class WormholeImplementation : public ArchitectureImplementation {
 public:
     tt::ARCH get_architecture() const override { return tt::ARCH::WORMHOLE_B0; }
 
-    uint32_t get_arc_message_arc_go_busy() const override {
+    uint32_t get_firmware_message_go_busy() const override {
         return static_cast<uint32_t>(wormhole::arc_message_type::ARC_GO_BUSY);
     }
 
-    uint32_t get_arc_message_arc_go_long_idle() const override {
+    uint32_t get_firmware_message_go_idle() const override {
         return static_cast<uint32_t>(wormhole::arc_message_type::ARC_GO_LONG_IDLE);
     }
 
-    uint32_t get_arc_reset_unit_refclk_low_offset() const override { return wormhole::ARC_RESET_REFCLK_LOW_OFFSET; }
+    uint64_t get_reset_unit_refclk_low_offset() const override { return wormhole::ARC_RESET_REFCLK_LOW_OFFSET; }
 
-    uint32_t get_arc_reset_unit_refclk_high_offset() const override { return wormhole::ARC_RESET_REFCLK_HIGH_OFFSET; }
+    uint64_t get_reset_unit_refclk_high_offset() const override { return wormhole::ARC_RESET_REFCLK_HIGH_OFFSET; }
 
     uint32_t get_dram_banks_number() const override { return wormhole::NUM_DRAM_BANKS; }
 
-    uint32_t get_aiclk_busy_val() const override { return wormhole::AICLK_BUSY_VAL; }
+    uint32_t get_min_clock_freq() const override { return wormhole::AICLK_IDLE_VAL; }
 
     uint32_t get_num_eth_channels() const override { return wormhole::NUM_ETH_CHANNELS; }
 
-    uint32_t get_tensix_soft_reset_addr() const override { return wormhole::TENSIX_SOFT_RESET_ADDR; }
+    uint64_t get_tensix_soft_reset_addr() const override { return wormhole::TENSIX_SOFT_RESET_ADDR; }
 
     uint32_t get_soft_reset_reg_value(RiscType risc_type) const override;
 

--- a/device/cluster_descriptor.cpp
+++ b/device/cluster_descriptor.cpp
@@ -8,6 +8,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -29,6 +30,8 @@
 #include "common/utils.hpp"
 #include "disjoint_set.hpp"
 #include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/blackhole_implementation.hpp"
+#include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/coordinates/coordinate_manager.hpp"
 #include "umd/device/utils/error.hpp"
 #include "umd/device/utils/semver.hpp"
@@ -1372,16 +1375,29 @@ uint16_t ClusterDescriptor::get_bus_id(ChipId chip_id) const {
     return it->second;
 }
 
+namespace {
+
+// High nibble of the PCI bus id identifies which UBB tray a chip sits on.
+std::optional<uint8_t> ubb_tray_id(const std::array<uint16_t, 4> &tray_bus_ids, const uint16_t bus_id) {
+    const uint16_t bus_high = static_cast<uint16_t>(bus_id & 0xF0);
+    const auto it = std::find(tray_bus_ids.begin(), tray_bus_ids.end(), bus_high);
+    if (it == tray_bus_ids.end()) {
+        return std::nullopt;
+    }
+    return static_cast<uint8_t>(std::distance(tray_bus_ids.begin(), it) + 1);
+}
+
+}  // namespace
+
 std::optional<uint8_t> ClusterDescriptor::get_tray_id(ChipId chip_id) const {
-    const BoardType board = get_board_type(chip_id);
-    if (board != BoardType::UBB_WORMHOLE && board != BoardType::UBB_BLACKHOLE) {
-        return std::nullopt;
+    switch (get_board_type(chip_id)) {
+        case BoardType::UBB_WORMHOLE:
+            return ubb_tray_id(wormhole::UBB_TRAY_BUS_IDS, get_bus_id(chip_id));
+        case BoardType::UBB_BLACKHOLE:
+            return ubb_tray_id(blackhole::UBB_TRAY_BUS_IDS, get_bus_id(chip_id));
+        default:
+            return std::nullopt;
     }
-    auto arch_impl = ArchitectureImplementation::create(get_arch(chip_id));
-    if (!arch_impl) {
-        return std::nullopt;
-    }
-    return arch_impl->get_ubb_tray_id(get_bus_id(chip_id));
 }
 
 const std::unordered_map<ChipId, uint16_t> &ClusterDescriptor::get_chip_to_bus_id() const { return chip_to_bus_id; }

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -235,7 +235,7 @@ uint32_t BlackholeTTDevice::get_clock() {
     UMD_THROW(error::RuntimeError, "AICLK telemetry not available for Blackhole device.");
 }
 
-uint32_t BlackholeTTDevice::get_min_clock_freq() { return blackhole::AICLK_IDLE_VAL; }
+uint32_t BlackholeTTDevice::get_min_clock_freq() { return get_architecture_implementation()->get_min_clock_freq(); }
 
 void BlackholeTTDevice::set_clock_state(TTDevice::PowerState state, NocId /*noc_id*/) {
     ZoneScoped;

--- a/device/tt_device/ethernet_broadcast.cpp
+++ b/device/tt_device/ethernet_broadcast.cpp
@@ -16,7 +16,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "umd/device/arch/architecture_implementation.hpp"
 #include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/types/arch.hpp"
@@ -25,23 +24,20 @@
 
 namespace tt::umd {
 
-static bool tensix_or_eth_in_broadcast(
-    const std::set<uint32_t>& cols_to_exclude, const ArchitectureImplementation* arch_impl) {
+static bool tensix_or_eth_in_broadcast(const std::set<uint32_t>& cols_to_exclude) {
     bool found_tensix_or_eth = false;
-    for (const auto& col : arch_impl->get_t6_x_locations()) {
+    for (const auto& col : wormhole::T6_X_LOCATIONS) {
         found_tensix_or_eth |= (cols_to_exclude.find(col) == cols_to_exclude.end());
     }
     return found_tensix_or_eth;
 }
 
 static bool valid_tensix_broadcast_grid(
-    const std::set<uint32_t>& rows_to_exclude,
-    const std::set<uint32_t>& cols_to_exclude,
-    const ArchitectureImplementation* arch_impl) {
+    const std::set<uint32_t>& rows_to_exclude, const std::set<uint32_t>& cols_to_exclude) {
     bool t6_bcast_rows_complete = true;
     bool t6_bcast_rows_empty = true;
 
-    for (const auto& row : arch_impl->get_t6_y_locations()) {
+    for (const auto& row : wormhole::T6_Y_LOCATIONS) {
         t6_bcast_rows_complete &= (rows_to_exclude.find(row) == rows_to_exclude.end());
         t6_bcast_rows_empty &= (rows_to_exclude.find(row) != rows_to_exclude.end());
     }
@@ -290,11 +286,10 @@ void EthernetBroadcast::broadcast_write_to_cluster(
     adjust_coordinates_for_ethernet_broadcast(
         rows_to_exclude, columns_to_exclude, use_translated_coords, rows_to_exclude_virtual, cols_to_exclude_virtual);
 
-    auto arch_impl = ArchitectureImplementation::create(tt::ARCH::WORMHOLE_B0);
     if (cols_to_exclude_virtual.find(0) == cols_to_exclude_virtual.end() or
         cols_to_exclude_virtual.find(5) == cols_to_exclude_virtual.end()) {
         UMD_ASSERT(
-            !tensix_or_eth_in_broadcast(cols_to_exclude_virtual, arch_impl.get()),
+            !tensix_or_eth_in_broadcast(cols_to_exclude_virtual),
             error::RuntimeError,
             "Cannot broadcast to tensix/ethernet and DRAM simultaneously on Wormhole.");
         if (cols_to_exclude_virtual.find(0) == cols_to_exclude_virtual.end()) {
@@ -328,8 +323,7 @@ void EthernetBroadcast::broadcast_write_to_cluster(
         }
     } else {
         UMD_ASSERT(
-            use_translated_coords or
-                valid_tensix_broadcast_grid(rows_to_exclude_virtual, cols_to_exclude_virtual, arch_impl.get()),
+            use_translated_coords || valid_tensix_broadcast_grid(rows_to_exclude_virtual, cols_to_exclude_virtual),
             error::RuntimeError,
             "Must broadcast to all tensix rows when using noc0 coordinates.");
         ethernet_broadcast_write(

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -606,11 +606,11 @@ uint64_t TTDevice::get_refclk_counter() {
     uint32_t high1_addr = 0;
     uint32_t high2_addr = 0;
     uint32_t low_addr = 0;
-    read_from_arc_apb(&high1_addr, architecture_impl_->get_arc_reset_unit_refclk_high_offset(), sizeof(high1_addr));
-    read_from_arc_apb(&low_addr, architecture_impl_->get_arc_reset_unit_refclk_low_offset(), sizeof(low_addr));
-    read_from_arc_apb(&high1_addr, architecture_impl_->get_arc_reset_unit_refclk_high_offset(), sizeof(high1_addr));
+    read_from_arc_apb(&high1_addr, architecture_impl_->get_reset_unit_refclk_high_offset(), sizeof(high1_addr));
+    read_from_arc_apb(&low_addr, architecture_impl_->get_reset_unit_refclk_low_offset(), sizeof(low_addr));
+    read_from_arc_apb(&high1_addr, architecture_impl_->get_reset_unit_refclk_high_offset(), sizeof(high1_addr));
     if (high2_addr > high1_addr) {
-        read_from_arc_apb(&low_addr, architecture_impl_->get_arc_reset_unit_refclk_low_offset(), sizeof(low_addr));
+        read_from_arc_apb(&low_addr, architecture_impl_->get_reset_unit_refclk_low_offset(), sizeof(low_addr));
     }
     return (static_cast<uint64_t>(high2_addr) << 32) | low_addr;
 }

--- a/device/tt_device/tt_sim_tt_device.cpp
+++ b/device/tt_device/tt_sim_tt_device.cpp
@@ -294,7 +294,7 @@ bool TTSimTTDevice::special_dram_read(void* mem_ptr, tt_xy_pair core, uint64_t a
 void TTSimTTDevice::assert_risc_reset(CoreCoord core, const RiscType selected_riscs) {
     std::lock_guard<std::recursive_mutex> lock(device_lock);
     log_debug(tt::LogEmulationDriver, "Sending 'assert_risc_reset' signal for risc_type {}", selected_riscs);
-    uint32_t soft_reset_addr = architecture_impl_->get_tensix_soft_reset_addr();
+    uint64_t soft_reset_addr = architecture_impl_->get_tensix_soft_reset_addr();
     uint32_t soft_reset_update = architecture_impl_->get_soft_reset_reg_value(selected_riscs);
     if (libttsim_pci_device_id == 0xFEED) {  // QSR
         uint64_t reset_value;
@@ -313,7 +313,7 @@ void TTSimTTDevice::assert_risc_reset(CoreCoord core, const RiscType selected_ri
 void TTSimTTDevice::deassert_risc_reset(CoreCoord core, const RiscType selected_riscs, bool staggered_start) {
     std::lock_guard<std::recursive_mutex> lock(device_lock);
     log_debug(tt::LogEmulationDriver, "Sending 'deassert_risc_reset' signal for risc_type {}", selected_riscs);
-    uint32_t soft_reset_addr = architecture_impl_->get_tensix_soft_reset_addr();
+    uint64_t soft_reset_addr = architecture_impl_->get_tensix_soft_reset_addr();
     uint32_t soft_reset_update = architecture_impl_->get_soft_reset_reg_value(selected_riscs);
 
     if (libttsim_pci_device_id == 0xFEED) {  // QSR

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -108,17 +108,17 @@ uint32_t WormholeTTDevice::get_clock() {
     return arc_msg_return_values[0];
 }
 
-uint32_t WormholeTTDevice::get_min_clock_freq() { return wormhole::AICLK_IDLE_VAL; }
+uint32_t WormholeTTDevice::get_min_clock_freq() { return get_architecture_implementation()->get_min_clock_freq(); }
 
 uint32_t WormholeTTDevice::get_power_state_arc_msg(TTDevice::PowerState state) {
     uint32_t msg = wormhole::ARC_MSG_COMMON_PREFIX;
     switch (state) {
         case TTDevice::PowerState::BUSY: {
-            msg |= get_architecture_implementation()->get_arc_message_arc_go_busy();
+            msg |= get_architecture_implementation()->get_firmware_message_go_busy();
             break;
         }
         case TTDevice::PowerState::IDLE: {
-            msg |= get_architecture_implementation()->get_arc_message_arc_go_long_idle();
+            msg |= get_architecture_implementation()->get_firmware_message_go_idle();
             break;
         }
         default:

--- a/tests/api/test_firmware_info_provider.cpp
+++ b/tests/api/test_firmware_info_provider.cpp
@@ -17,7 +17,9 @@
 #include <utility>
 #include <vector>
 
-#include "umd/device/arch/architecture_implementation.hpp"
+#include "umd/device/arch/blackhole_implementation.hpp"
+#include "umd/device/arch/grendel_implementation.hpp"
+#include "umd/device/arch/wormhole_implementation.hpp"
 #include "umd/device/firmware/firmware_info_provider.hpp"
 #include "umd/device/firmware/firmware_utils.hpp"
 #include "umd/device/pcie/pci_device.hpp"
@@ -185,6 +187,20 @@ TEST_F(TestFirmwareInfoProvider, Temperature) {
     }
 }
 
+// AICLK the chip claims when busy, which is what firmware should report as the maximum.
+static uint32_t expected_max_clock_freq(const tt::ARCH arch) {
+    switch (arch) {
+        case tt::ARCH::WORMHOLE_B0:
+            return wormhole::AICLK_BUSY_VAL;
+        case tt::ARCH::BLACKHOLE:
+            return blackhole::AICLK_BUSY_VAL;
+        case tt::ARCH::QUASAR:
+            return grendel::AICLK_BUSY_VAL;
+        default:
+            throw std::runtime_error("No busy AICLK known for the tested architecture.");
+    }
+}
+
 TEST_F(TestFirmwareInfoProvider, ClockFrequencies) {
     for (const auto& tt_device : get_tt_devices()) {
         FirmwareInfoProvider* fw_info = tt_device->get_firmware_info_provider();
@@ -192,10 +208,9 @@ TEST_F(TestFirmwareInfoProvider, ClockFrequencies) {
 
         tt::ARCH arch = tt_device->get_arch();
         FirmwareBundleVersion fw_version = fw_info->get_firmware_version();
-        auto arch_impl = tt_device->get_architecture_implementation();
 
         std::string range = fw_range_label(fw_version);
-        uint32_t aiclk_busy_val = arch_impl->get_aiclk_busy_val();
+        uint32_t aiclk_busy_val = expected_max_clock_freq(arch);
 
         std::optional<uint32_t> aiclk = fw_info->get_aiclk();
         std::optional<uint32_t> axiclk = fw_info->get_axiclk();

--- a/tests/wormhole/test_arc_messages_wh.cpp
+++ b/tests/wormhole/test_arc_messages_wh.cpp
@@ -66,7 +66,7 @@ TEST(WormholeArcMessages, WormholeArcMessagesAICLK) {
     for (uint32_t chip_id : target_chips) {
         [[maybe_unused]] uint32_t response = arc_messengers.at(chip_id)->send_message(
             wormhole::ARC_MSG_COMMON_PREFIX |
-                tt_devices.at(chip_id)->get_architecture_implementation()->get_arc_message_arc_go_busy(),
+                tt_devices.at(chip_id)->get_architecture_implementation()->get_firmware_message_go_busy(),
             {0, 0});
     }
 
@@ -80,7 +80,7 @@ TEST(WormholeArcMessages, WormholeArcMessagesAICLK) {
 
         [[maybe_unused]] uint32_t response = arc_messengers.at(chip_id)->send_message(
             wormhole::ARC_MSG_COMMON_PREFIX |
-                tt_devices.at(chip_id)->get_architecture_implementation()->get_arc_message_arc_go_long_idle(),
+                tt_devices.at(chip_id)->get_architecture_implementation()->get_firmware_message_go_idle(),
             {0, 0});
     }
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2873

### Description
Stacked on #3227.

Last of the series. With the misplaced methods gone, this renames and retypes what is left to
match the Base API specification, so the interface reads as the specification describes it.

The idle AICLK frequency the specification asks for already existed as `TTDevice::get_min_clock_freq`
with per architecture overrides reading `AICLK_IDLE_VAL`. It moves onto the interface and the
concrete devices delegate, so the value has one definition. The busy frequency does not stay, it had a single
consumer in `test_firmware_info_provider` which now resolves `AICLK_BUSY_VAL` for its own
architecture, so the interface carries only what the specification lists.

### List of the changes
- Rename the two power state messages to `get_firmware_message_go_busy` and `_go_idle`, and drop
  the `arc_` prefix from the reset unit refclk offsets.
- Widen the refclk offsets and the Tensix soft reset address to `uint64_t`.
- Add `get_min_clock_freq` and remove `get_aiclk_busy_val`.
- Document what `get_harvesting_noc_locations` returns.

### Testing
Code builds. ARC message, clock and soft reset paths are covered in CI.

### API Changes
This PR has API changes, renamed and retyped methods on `ArchitectureImplementation`.

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/arch_impl_12

