### PR TITLE
Probe locks in lock_virus through LockManager

### DIFF
--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -4,7 +4,10 @@
 
 #pragma once
 
+#include <sys/types.h>
+
 #include <mutex>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -31,6 +34,9 @@ enum class MutexType {
     // Used for guarding PCIe DMA operations against concurrent access from multiple processes.
     PCIE_DMA,
 };
+
+// Name of a mutex type, for logging and diagnostics.
+std::string to_string(MutexType mutex_type);
 
 // Note that the returned std::unique_lock<RobustMutex> should never outlive the LockManager which holds underlying
 // RobustMutexes. Also note that clear_mutex doesn't need to be explicitly called, since the mutexes will all get
@@ -84,10 +90,18 @@ public:
     std::unique_lock<RobustMutex> acquire_mutex(
         const std::string& mutex_prefix, int device_id, IODeviceType device_type = IODeviceType::PCIe);
 
+    // Reports whether a mutex is currently held, without holding it afterwards. Returns std::nullopt if the mutex was
+    // free, otherwise the owning {pid, tid}. Since a free mutex has to be acquired to find that out, and is released
+    // again right after, the answer is best effort and may be stale as soon as it is returned.
+    std::optional<std::pair<pid_t, pid_t>> probe_mutex(MutexType mutex_type);
+    std::optional<std::pair<pid_t, pid_t>> probe_mutex(
+        MutexType mutex_type, int device_id, IODeviceType device_type = IODeviceType::PCIe);
+
 private:
     void initialize_mutex_internal(const std::string& mutex_name);
     void clear_mutex_internal(const std::string& mutex_name);
     std::unique_lock<RobustMutex> acquire_mutex_internal(const std::string& mutex_name);
+    std::optional<std::pair<pid_t, pid_t>> probe_mutex_internal(const std::string& mutex_name);
 
     // Maps from mutex name to an initialized mutex.
     // Mutex names are made from mutex type name or directly mutex name combined with device number.

--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -90,9 +90,11 @@ public:
     std::unique_lock<RobustMutex> acquire_mutex(
         const std::string& mutex_prefix, int device_id, IODeviceType device_type = IODeviceType::PCIe);
 
-    // Reports whether a mutex is currently held, without holding it afterwards. Returns std::nullopt if the mutex was
-    // free, otherwise the owning {pid, tid}. Since a free mutex has to be acquired to find that out, and is released
-    // again right after, the answer is best effort and may be stale as soon as it is returned.
+    // Reports whether a mutex is currently held, without holding it afterwards. Returns the owning {pid, tid} if it is
+    // held, and std::nullopt if it is not - which covers both a mutex nobody had taken and one whose owner died holding
+    // it, since probing a shared memory mutex recovers it from a dead owner rather than reporting it as held. Since a
+    // free mutex has to be acquired to find that out, and is released again right after, the answer is best effort and
+    // may be stale as soon as it is returned.
     std::optional<std::pair<pid_t, pid_t>> probe_mutex(MutexType mutex_type);
     std::optional<std::pair<pid_t, pid_t>> probe_mutex(
         MutexType mutex_type, int device_id, IODeviceType device_type = IODeviceType::PCIe);

--- a/device/utils/lock_manager.cpp
+++ b/device/utils/lock_manager.cpp
@@ -13,6 +13,8 @@
 
 namespace tt::umd {
 
+std::string to_string(MutexType mutex_type) { return LockManager::MUTEX_TYPE_TO_STRING.at(mutex_type); }
+
 void LockManager::initialize_mutex(MutexType mutex_type) {
     initialize_mutex_internal(MUTEX_TYPE_TO_STRING.at(mutex_type));
 }
@@ -58,6 +60,17 @@ std::unique_lock<RobustMutex> LockManager::acquire_mutex(
     return acquire_mutex_internal(mutex_name);
 }
 
+std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex(MutexType mutex_type) {
+    return probe_mutex_internal(MUTEX_TYPE_TO_STRING.at(mutex_type));
+}
+
+std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex(
+    MutexType mutex_type, int device_id, IODeviceType device_type) {
+    std::string mutex_name = MUTEX_TYPE_TO_STRING.at(mutex_type) + "_" + std::to_string(device_id) + "_" +
+                             DeviceTypeToString.at(device_type);
+    return probe_mutex_internal(mutex_name);
+}
+
 void LockManager::initialize_mutex_internal(const std::string& mutex_name) {
     if (mutexes.find(mutex_name) != mutexes.end()) {
         log_warning(LogUMD, "Mutex already initialized: {}", mutex_name);
@@ -82,6 +95,19 @@ std::unique_lock<RobustMutex> LockManager::acquire_mutex_internal(const std::str
         UMD_THROW(error::RuntimeError, "Mutex not initialized: " + mutex_name);
     }
     return std::unique_lock(mutexes.at(mutex_name));
+}
+
+std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex_internal(const std::string& mutex_name) {
+    if (mutexes.find(mutex_name) == mutexes.end()) {
+        UMD_THROW(error::RuntimeError, "Mutex not initialized: " + mutex_name);
+    }
+    RobustMutex& mutex = mutexes.at(mutex_name);
+    std::optional<std::pair<pid_t, pid_t>> owner = mutex.probe_lock(std::chrono::seconds(0));
+    if (!owner.has_value()) {
+        // The mutex was free, which means probing it took it. Release it so that probing stays a query.
+        mutex.unlock();
+    }
+    return owner;
 }
 
 }  // namespace tt::umd

--- a/tools/lock_virus.cpp
+++ b/tools/lock_virus.cpp
@@ -2,87 +2,96 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// lock_virus: inspect all UMD shared-memory locks present in /dev/shm, report
-// their state (free / held, owner PID/TID), and cross-check against the locks
-// expected for every enumerated PCIe device.
+// lock_virus: report the state (free / held, owner PID/TID) of every lock UMD can take - each mutex
+// type, for every PCIe and JTAG device found. Locks are probed through LockManager, so what gets
+// reported is the lock UMD would actually take, whichever mutex happens to back it.
 
-#include <dirent.h>
-
-#include <algorithm>
-#include <cerrno>
-#include <cstdlib>
-#include <cstring>
 #include <cxxopts.hpp>
 #include <iostream>
-#include <set>
+#include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 #include <tt-logger/tt-logger.hpp>
+#include <utility>
 #include <vector>
 
+#include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/utils/lock_manager.hpp"
-#include "umd/device/utils/robust_mutex.hpp"
 
 using namespace tt::umd;
 
-// ── lock-name helpers ─────────────────────────────────────────────────────────
-
-static std::vector<std::string> chip_specific_mutex_names(int device_id, const std::string& device_type = "PCIe") {
-    std::vector<std::string> names;
-    names.reserve(LockManager::CHIP_SPECIFIC_MUTEX_TYPES.size());
-    for (MutexType type : LockManager::CHIP_SPECIFIC_MUTEX_TYPES) {
-        std::string name = LockManager::MUTEX_TYPE_TO_STRING.at(type);
-        name.append("_").append(std::to_string(device_id)).append("_").append(device_type);
-        names.push_back(std::move(name));
-    }
-    return names;
-}
-
-// ── /dev/shm scan ─────────────────────────────────────────────────────────────
-
-static std::vector<std::string> scan_umd_locks() {
-    static constexpr std::string_view prefix = RobustMutex::SHM_FILE_PREFIX;
-
-    std::vector<std::string> found;
-    DIR* dir = opendir("/dev/shm");
-    if (!dir) {
-        log_warning(tt::LogUMD, "Could not open /dev/shm: {}", std::to_string(errno));
-        return found;
-    }
-
-    struct dirent* entry;
-    while ((entry = readdir(dir)) != nullptr) {
-        std::string name(entry->d_name);
-        if (name.rfind(std::string(prefix), 0) == 0) {
-            found.push_back(name);
-        }
-    }
-    closedir(dir);
-    std::sort(found.begin(), found.end());
-    return found;
-}
-
 // ── reporting ─────────────────────────────────────────────────────────────────
 
-static void report_lock(const std::string& shm_name) {
-    // shm_name includes the TT_UMD_LOCK. prefix; RobustMutex wants the bare name.
-    const std::string mutex_name = shm_name.substr(RobustMutex::SHM_FILE_PREFIX.size());
-    RobustMutex m(mutex_name);
-    try {
-        m.initialize();
-    } catch (const std::exception& e) {
-        log_info(tt::LogUMD, "  [{:<55}]  ERROR initializing: {}", shm_name, e.what());
-        return;
-    }
-
-    if (auto owner = m.probe_lock(std::chrono::seconds(0))) {
-        // Optional has a value: lock is held by another thread/process.
-        log_info(tt::LogUMD, "  [{:<55}]  LOCKED  PID={} TID={}", shm_name, owner->first, owner->second);
+static void report_state(const std::string& mutex_name, const std::optional<std::pair<pid_t, pid_t>>& owner) {
+    if (owner.has_value()) {
+        log_info(tt::LogUMD, "    [{:<16}]  LOCKED  PID={} TID={}", mutex_name, owner->first, owner->second);
     } else {
-        // nullopt: we acquired the lock — it was free.
-        m.unlock();
-        log_info(tt::LogUMD, "  [{:<55}]  FREE", shm_name);
+        log_info(tt::LogUMD, "    [{:<16}]  FREE", mutex_name);
+    }
+}
+
+static void report_device_locks(LockManager& lock_manager, int device_id, IODeviceType device_type) {
+    for (MutexType mutex_type : LockManager::CHIP_SPECIFIC_MUTEX_TYPES) {
+        lock_manager.initialize_mutex(mutex_type, device_id, device_type);
+        report_state(to_string(mutex_type), lock_manager.probe_mutex(mutex_type, device_id, device_type));
+    }
+}
+
+// ── device enumeration ────────────────────────────────────────────────────────
+
+// Returns the JTAG device indices, or an empty list if JTAG is not usable on this host. The J-Link
+// library it needs is loaded at runtime and is absent on most systems.
+static std::vector<int> enumerate_jtag_devices() {
+    try {
+        std::unique_ptr<JtagDevice> jtag_device = JtagDevice::create();
+        std::vector<int> device_ids;
+        device_ids.reserve(jtag_device->get_device_cnt());
+        for (uint32_t index = 0; index < jtag_device->get_device_cnt(); index++) {
+            device_ids.push_back(static_cast<int>(index));
+        }
+        return device_ids;
+    } catch (const std::exception& e) {
+        log_debug(tt::LogUMD, "JTAG devices could not be enumerated: {}", e.what());
+        return {};
+    }
+}
+
+// ── testing mode ──────────────────────────────────────────────────────────────
+
+static std::optional<MutexType> find_mutex_type(const std::string& mutex_name) {
+    for (MutexType mutex_type : LockManager::SYSTEM_WIDE_MUTEX_TYPES) {
+        if (to_string(mutex_type) == mutex_name) {
+            return mutex_type;
+        }
+    }
+    for (MutexType mutex_type : LockManager::CHIP_SPECIFIC_MUTEX_TYPES) {
+        if (to_string(mutex_type) == mutex_name) {
+            return mutex_type;
+        }
+    }
+    return std::nullopt;
+}
+
+static void spin_forever() {
+    while (true) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+}
+
+static void hold_lock(MutexType mutex_type, std::optional<int> device_id, IODeviceType device_type) {
+    LockManager lock_manager;
+    if (device_id.has_value()) {
+        lock_manager.initialize_mutex(mutex_type, *device_id, device_type);
+        auto lock = lock_manager.acquire_mutex(mutex_type, *device_id, device_type);
+        log_info(tt::LogUMD, "Holding lock — press Ctrl-C to release.");
+        spin_forever();
+    } else {
+        lock_manager.initialize_mutex(mutex_type);
+        auto lock = lock_manager.acquire_mutex(mutex_type);
+        log_info(tt::LogUMD, "Holding lock — press Ctrl-C to release.");
+        spin_forever();
     }
 }
 
@@ -91,17 +100,21 @@ static void report_lock(const std::string& shm_name) {
 int main(int argc, char* argv[]) {
     cxxopts::Options options(
         "lock_virus",
-        "Inspect all UMD shared-memory locks in /dev/shm and report their state.\n"
-        "Also enumerates PCIe devices and reports expected locks that are missing.\n"
+        "Report the state of every lock UMD can take, for all PCIe and JTAG devices found.\n"
         "\n"
-        "Testing mode: --hold-lock <name> acquires the named mutex and spins forever,\n"
-        "allowing lock_virus (run separately) to observe the lock as held.");
+        "Testing mode: --hold-lock <MUTEX_TYPE> acquires that lock and spins forever, allowing\n"
+        "lock_virus (run separately) to observe it as held. Without --device the system wide\n"
+        "lock of that type is taken, with it the lock of the given device.");
 
     // clang-format off
     options.add_options()
-        ("h,help",      "Print usage")
-        ("hold-lock",   "Acquire the named mutex and hold it indefinitely (for testing)",
-                        cxxopts::value<std::string>());
+        ("h,help",        "Print usage")
+        ("hold-lock",     "Acquire the lock of the given mutex type and hold it indefinitely (for testing)",
+                          cxxopts::value<std::string>())
+        ("device",        "Device to take the lock of, when holding a chip specific lock",
+                          cxxopts::value<int>())
+        ("device-type",   "Device type to take the lock of: pcie or jtag",
+                          cxxopts::value<std::string>()->default_value("pcie"));
     // clang-format on
 
     auto result = options.parse(argc, argv);
@@ -110,85 +123,52 @@ int main(int argc, char* argv[]) {
         return 0;
     }
 
-    // ── Testing mode: hold a single lock and spin ─────────────────────────
-    if (result.count("hold-lock")) {
-        const std::string mutex_name = result["hold-lock"].as<std::string>();
-        RobustMutex m(mutex_name);
-        m.initialize();
-        if (auto owner = m.probe_lock()) {
-            log_error(
-                tt::LogUMD, "Lock '{}' is already held by PID={} TID={}", mutex_name, owner->first, owner->second);
+    try {
+        const std::string device_type_name = result["device-type"].as<std::string>();
+        if (device_type_name != "pcie" && device_type_name != "jtag") {
+            log_error(tt::LogUMD, "Unknown device type '{}', expected pcie or jtag.", device_type_name);
             return 1;
         }
-        log_info(tt::LogUMD, "Holding lock '{}' — press Ctrl-C to release.", mutex_name);
-        while (true) {
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-        }
-    }
+        const IODeviceType device_type = device_type_name == "jtag" ? IODeviceType::JTAG : IODeviceType::PCIe;
 
-    try {
-        // ── 1. Scan /dev/shm for existing UMD locks ───────────────────────
-        std::vector<std::string> found_locks = scan_umd_locks();
-
-        log_info(tt::LogUMD, "=== UMD locks found in /dev/shm ({}) ===", found_locks.size());
-        if (found_locks.empty()) {
-            log_info(tt::LogUMD, "  (none)");
-        } else {
-            for (const auto& name : found_locks) {
-                report_lock(name);
+        // ── Testing mode: hold a single lock and spin ─────────────────────
+        if (result.count("hold-lock")) {
+            const std::string mutex_name = result["hold-lock"].as<std::string>();
+            std::optional<MutexType> mutex_type = find_mutex_type(mutex_name);
+            if (!mutex_type.has_value()) {
+                log_error(tt::LogUMD, "Unknown mutex type '{}'.", mutex_name);
+                return 1;
             }
+            std::optional<int> device_id;
+            if (result.count("device")) {
+                device_id = result["device"].as<int>();
+            }
+            hold_lock(*mutex_type, device_id, device_type);
         }
 
-        // ── 2. Enumerate PCIe devices and compute expected lock names ─────
-        std::vector<int> device_ids = PCIDevice::enumerate_devices();
+        LockManager lock_manager;
 
+        log_info(tt::LogUMD, "=== System wide locks ===");
+        for (MutexType mutex_type : LockManager::SYSTEM_WIDE_MUTEX_TYPES) {
+            lock_manager.initialize_mutex(mutex_type);
+            report_state(to_string(mutex_type), lock_manager.probe_mutex(mutex_type));
+        }
+
+        std::vector<int> pcie_device_ids = PCIDevice::enumerate_devices();
         log_info(tt::LogUMD, "");
-        log_info(tt::LogUMD, "=== PCIe devices found ({}) ===", device_ids.size());
-        if (device_ids.empty()) {
-            log_info(tt::LogUMD, "  (none)");
-        } else {
-            for (int id : device_ids) {
-                log_info(tt::LogUMD, "  device {}", id);
-            }
+        log_info(tt::LogUMD, "=== PCIe devices found ({}) ===", pcie_device_ids.size());
+        for (int device_id : pcie_device_ids) {
+            log_info(tt::LogUMD, "  device {}", device_id);
+            report_device_locks(lock_manager, device_id, IODeviceType::PCIe);
         }
 
-        // Build the full set of expected lock names.
-        std::set<std::string> found_set(found_locks.begin(), found_locks.end());
-        std::vector<std::string> expected_names;
-        expected_names.reserve(
-            LockManager::SYSTEM_WIDE_MUTEX_TYPES.size() +
-            device_ids.size() * LockManager::CHIP_SPECIFIC_MUTEX_TYPES.size());
-
-        static const std::string prefix(RobustMutex::SHM_FILE_PREFIX);
-        for (MutexType type : LockManager::SYSTEM_WIDE_MUTEX_TYPES) {
-            expected_names.push_back(prefix + LockManager::MUTEX_TYPE_TO_STRING.at(type));
-        }
-        for (int id : device_ids) {
-            for (const auto& name : chip_specific_mutex_names(id)) {
-                expected_names.push_back(prefix + name);
-            }
-        }
-
-        // ── 3. Report expected locks that are missing from /dev/shm ──────
-        std::vector<std::string> missing;
-        missing.reserve(expected_names.size());
-        for (const auto& name : expected_names) {
-            if (found_set.find(name) == found_set.end()) {
-                missing.push_back(name);
-            }
-        }
-        missing.shrink_to_fit();
-
+        std::vector<int> jtag_device_ids = enumerate_jtag_devices();
         log_info(tt::LogUMD, "");
-        log_info(tt::LogUMD, "=== Expected locks missing from /dev/shm ({}) ===", missing.size());
-        if (missing.empty()) {
-            log_info(tt::LogUMD, "  (none)");
-        } else {
-            for (const auto& name : missing) {
-                log_info(tt::LogUMD, "  [MISSING]  {}", name);
-            }
+        log_info(tt::LogUMD, "=== JTAG devices found ({}) ===", jtag_device_ids.size());
+        for (int device_id : jtag_device_ids) {
+            log_info(tt::LogUMD, "  device {}", device_id);
+            report_device_locks(lock_manager, device_id, IODeviceType::JTAG);
         }
-
     } catch (const std::exception& e) {
         log_error(tt::LogUMD, "Error: {}", e.what());
         return 1;

--- a/tools/lock_virus.cpp
+++ b/tools/lock_virus.cpp
@@ -5,7 +5,16 @@
 // lock_virus: report the state (free / held, owner PID/TID) of every lock UMD can take - each mutex
 // type, for every PCIe and JTAG device found. Locks are probed through LockManager, so what gets
 // reported is the lock UMD would actually take, whichever mutex happens to back it.
+//
+// What this is for: finding out who is holding a lock when something is stuck, in particular when the
+// holder is a process nobody knows about any more. That is also why it probes every lock rather than
+// only the ones that already exist - a lock that was never taken is worth reporting as free.
+//
+// Note that probing a lock initializes it, and initializing a shared memory backed lock creates its
+// /dev/shm file. So a run leaves the backing files of every lock it reported behind. They are empty
+// locks, harmless to UMD, but it does mean "which lock files exist" says nothing after the first run.
 
+#include <chrono>
 #include <cxxopts.hpp>
 #include <iostream>
 #include <memory>
@@ -21,6 +30,13 @@
 #include "umd/device/utils/lock_manager.hpp"
 
 using namespace tt::umd;
+
+namespace {
+
+constexpr std::string_view DEVICE_TYPE_PCIE = "pcie";
+constexpr std::string_view DEVICE_TYPE_JTAG = "jtag";
+
+}  // namespace
 
 // ── reporting ─────────────────────────────────────────────────────────────────
 
@@ -46,9 +62,10 @@ static void report_device_locks(LockManager& lock_manager, int device_id, IODevi
 static std::vector<int> enumerate_jtag_devices() {
     try {
         std::unique_ptr<JtagDevice> jtag_device = JtagDevice::create();
+        const uint32_t device_count = jtag_device->get_device_cnt();
         std::vector<int> device_ids;
-        device_ids.reserve(jtag_device->get_device_cnt());
-        for (uint32_t index = 0; index < jtag_device->get_device_cnt(); index++) {
+        device_ids.reserve(device_count);
+        for (uint32_t index = 0; index < device_count; index++) {
             device_ids.push_back(static_cast<int>(index));
         }
         return device_ids;
@@ -60,18 +77,25 @@ static std::vector<int> enumerate_jtag_devices() {
 
 // ── testing mode ──────────────────────────────────────────────────────────────
 
-static std::optional<MutexType> find_mutex_type(const std::string& mutex_name) {
-    for (MutexType mutex_type : LockManager::SYSTEM_WIDE_MUTEX_TYPES) {
-        if (to_string(mutex_type) == mutex_name) {
-            return mutex_type;
-        }
-    }
-    for (MutexType mutex_type : LockManager::CHIP_SPECIFIC_MUTEX_TYPES) {
+static std::optional<MutexType> find_mutex_type(
+    const std::vector<MutexType>& mutex_types, const std::string& mutex_name) {
+    for (MutexType mutex_type : mutex_types) {
         if (to_string(mutex_type) == mutex_name) {
             return mutex_type;
         }
     }
     return std::nullopt;
+}
+
+static std::string join_mutex_type_names(const std::vector<MutexType>& mutex_types) {
+    std::string names;
+    for (MutexType mutex_type : mutex_types) {
+        if (!names.empty()) {
+            names += ", ";
+        }
+        names += to_string(mutex_type);
+    }
+    return names;
 }
 
 static void spin_forever() {
@@ -101,10 +125,14 @@ int main(int argc, char* argv[]) {
     cxxopts::Options options(
         "lock_virus",
         "Report the state of every lock UMD can take, for all PCIe and JTAG devices found.\n"
+        "Meant for finding out who holds a lock when something is stuck.\n"
+        "\n"
+        "Probing a lock initializes it, so a run creates the /dev/shm file of every shared memory\n"
+        "backed lock it reports and leaves it behind. The files are harmless.\n"
         "\n"
         "Testing mode: --hold-lock <MUTEX_TYPE> acquires that lock and spins forever, allowing\n"
-        "lock_virus (run separately) to observe it as held. Without --device the system wide\n"
-        "lock of that type is taken, with it the lock of the given device.");
+        "lock_virus (run separately) to observe it as held. Without --device a system wide lock\n"
+        "is taken, with it the chip specific lock of the given device.");
 
     // clang-format off
     options.add_options()
@@ -113,7 +141,7 @@ int main(int argc, char* argv[]) {
                           cxxopts::value<std::string>())
         ("device",        "Device to take the lock of, when holding a chip specific lock",
                           cxxopts::value<int>())
-        ("device-type",   "Device type to take the lock of: pcie or jtag",
+        ("device-type",   "Device type to take the lock of, lowercase: pcie or jtag",
                           cxxopts::value<std::string>()->default_value("pcie"));
     // clang-format on
 
@@ -125,23 +153,39 @@ int main(int argc, char* argv[]) {
 
     try {
         const std::string device_type_name = result["device-type"].as<std::string>();
-        if (device_type_name != "pcie" && device_type_name != "jtag") {
-            log_error(tt::LogUMD, "Unknown device type '{}', expected pcie or jtag.", device_type_name);
+        if (device_type_name != DEVICE_TYPE_PCIE && device_type_name != DEVICE_TYPE_JTAG) {
+            log_error(
+                tt::LogUMD,
+                "Unknown device type '{}', expected {} or {}.",
+                device_type_name,
+                DEVICE_TYPE_PCIE,
+                DEVICE_TYPE_JTAG);
             return 1;
         }
-        const IODeviceType device_type = device_type_name == "jtag" ? IODeviceType::JTAG : IODeviceType::PCIe;
+        const IODeviceType device_type = device_type_name == DEVICE_TYPE_JTAG ? IODeviceType::JTAG : IODeviceType::PCIe;
 
         // ── Testing mode: hold a single lock and spin ─────────────────────
         if (result.count("hold-lock")) {
             const std::string mutex_name = result["hold-lock"].as<std::string>();
-            std::optional<MutexType> mutex_type = find_mutex_type(mutex_name);
-            if (!mutex_type.has_value()) {
-                log_error(tt::LogUMD, "Unknown mutex type '{}'.", mutex_name);
-                return 1;
-            }
             std::optional<int> device_id;
             if (result.count("device")) {
                 device_id = result["device"].as<int>();
+            }
+
+            // A mutex type is either system wide or chip specific, and --device is what picks between
+            // the two. Holding the wrong one would take a lock UMD never takes, and which this tool
+            // would never report either, so the type has to exist in the form being asked for.
+            const std::vector<MutexType>& holdable_types =
+                device_id.has_value() ? LockManager::CHIP_SPECIFIC_MUTEX_TYPES : LockManager::SYSTEM_WIDE_MUTEX_TYPES;
+            std::optional<MutexType> mutex_type = find_mutex_type(holdable_types, mutex_name);
+            if (!mutex_type.has_value()) {
+                log_error(
+                    tt::LogUMD,
+                    "'{}' is not a {} mutex type. Expected one of: {}",
+                    mutex_name,
+                    device_id.has_value() ? "chip specific" : "system wide",
+                    join_mutex_type_names(holdable_types));
+                return 1;
             }
             hold_lock(*mutex_type, device_id, device_type);
         }


### PR DESCRIPTION
### Issue
#2745

### Description
lock_virus built the names of the locks it expected from LockManager's internal name map, and
probed them by opening the backing RobustMutex itself. That tied the tool to how locks happen to
be implemented, right before that implementation changes.

It now walks every mutex type LockManager exposes, for every PCIe and JTAG device found, and
probes each one through LockManager. Whatever ends up backing a lock, the tool reports the lock
UMD would actually take.

Output before, on a host with no card. What it lists is whatever is left in /dev/shm, here mostly
locks left behind by unit tests, and it has no idea whether UMD would ever take them:

```
=== UMD locks found in /dev/shm (5) ===
  [TT_UMD_LOCK.ARC_MSG                                    ]  FREE
  [TT_UMD_LOCK.CREATE_ETH_MAP                             ]  FREE
  [TT_UMD_LOCK.UMD_TEST_MUTEX_INTERFACE                   ]  FREE
  [TT_UMD_LOCK.UMD_TEST_ROBUST_MUTEX_EXCEPTION            ]  FREE
  [TT_UMD_LOCK.UMD_TEST_ROBUST_MUTEX_HANG                 ]  FREE

=== PCIe devices found (0) ===
  (none)

=== Expected locks missing from /dev/shm (0) ===
  (none)
```

Output after, on the same host. Each lock UMD can take is listed under the device it belongs to,
one block per device found:

```
=== System wide locks ===
    [ARC_MSG         ]  FREE
    [CREATE_ETH_MAP  ]  FREE

=== PCIe devices found (0) ===

=== JTAG devices found (0) ===
```

### List of the changes
- Add LockManager::probe_mutex, which reports a lock's owner without leaving it held
- Add to_string(MutexType)
- Rewrite lock_virus to enumerate mutex types and devices instead of scanning /dev/shm
- --hold-lock takes a mutex type, with --device / --device-type, instead of a lock name

### Testing
Ran lock_virus on a host with no card, and against a second instance holding ARC_MSG via
--hold-lock, which it reports as LOCKED with the holder's PID/TID.

### API Changes
This PR has API changes, adds LockManager::probe_mutex and to_string(MutexType).

Follow up, blocked until #3232 is deployed everywhere: #3233 Stop taking the shared memory half of chip specific PCIe locks

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/locks_11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
