### PR TITLE
Introduce MutexInterface

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -234,6 +234,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/warm_reset.hpp
                 api/umd/device/warm_reset_with_recovery.hpp
                 api/umd/device/utils/semver.hpp
+                api/umd/device/utils/mutex_interface.hpp
                 api/umd/device/utils/robust_mutex.hpp
                 api/umd/device/utils/kmd_mutex.hpp
                 api/umd/device/cluster_descriptor.hpp

--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -22,7 +22,7 @@
 #include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/utils/lock_manager.hpp"
-#include "umd/device/utils/robust_mutex.hpp"
+#include "umd/device/utils/mutex_interface.hpp"
 
 namespace tt::umd {
 class SocDescriptor;
@@ -85,9 +85,9 @@ private:
     std::unique_ptr<SysmemManager> sysmem_manager_;
     LockManager lock_manager_;
 
-    // unique_lock is RAII, so if this member holds an object, the RobustMutex is locked, if it is empty, the
-    // RobustMutex is unlocked.
-    std::optional<std::unique_lock<RobustMutex>> chip_started_lock_;
+    // unique_lock is RAII, so if this member holds an object, the mutex is locked, if it is empty, the
+    // mutex is unlocked.
+    std::optional<std::unique_lock<MutexInterface>> chip_started_lock_;
 
     void initialize_tlb_manager();
     void initialize_default_chip_mutexes();

--- a/device/api/umd/device/utils/kmd_mutex.hpp
+++ b/device/api/umd/device/utils/kmd_mutex.hpp
@@ -86,7 +86,7 @@ public:
     // Returns std::nullopt if the lock was acquired (the caller now holds it). On contention returns a
     // {pid, tid} pair, but KMD does not expose the owner, so it is always {0, 0} here - the pair's
     // presence signals "held by someone else", nothing more.
-    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout = std::chrono::seconds(0)) override;
+    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout) override;
 
     // Releases the lock. It is also released automatically when this object (and thus its handle) is
     // destroyed, or when the owning process exits.

--- a/device/api/umd/device/utils/kmd_mutex.hpp
+++ b/device/api/umd/device/utils/kmd_mutex.hpp
@@ -12,6 +12,8 @@
 #include <string>
 #include <utility>
 
+#include "umd/device/utils/mutex_interface.hpp"
+
 // tt-kmd-lib device handle. Forward declared so this public header does not require tt-kmd-lib's
 // include path, which UMD links privately.
 struct tt_device_t;
@@ -53,7 +55,7 @@ namespace tt::umd {
 //
 // It meets the C++ Lockable requirement (lock()/try_lock()/unlock()), so it can be used with RAII
 // helpers like std::lock_guard and std::unique_lock.
-class KmdMutex {
+class KmdMutex : public MutexInterface {
 public:
     // @param pci_device_num  N in /dev/tenstorrent/N (a UMD logical device id / PCIDevice number).
     // @param lock_index      KMD resource lock index in [0, TT_RESOURCE_LOCK_COUNT). See
@@ -64,7 +66,7 @@ public:
     // Opens the dedicated device handle used to hold the lock. Must be called before
     // lock()/try_lock(). Kept separate from the constructor so that failures during setup are still
     // cleaned up by the destructor. Calling it again once the handle is open does nothing.
-    void initialize();
+    void initialize() override;
 
     // Move-only so it can live in STL containers. Copying would alias the owned handle.
     KmdMutex(KmdMutex&& other) noexcept;
@@ -74,7 +76,7 @@ public:
 
     // Blocks until the lock is acquired. If a reset is detected while waiting (the handle becomes
     // unusable), the handle is transparently reopened and the wait is retried.
-    void lock();
+    void lock() override;
 
     // Attempts to acquire without blocking. Returns true if acquired, false if held by another
     // handle.
@@ -84,11 +86,11 @@ public:
     // Returns std::nullopt if the lock was acquired (the caller now holds it). On contention returns a
     // {pid, tid} pair, but KMD does not expose the owner, so it is always {0, 0} here - the pair's
     // presence signals "held by someone else", nothing more.
-    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout = std::chrono::seconds(0));
+    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout = std::chrono::seconds(0)) override;
 
     // Releases the lock. It is also released automatically when this object (and thus its handle) is
     // destroyed, or when the owning process exits.
-    void unlock();
+    void unlock() override;
 
     // Best-effort query of whether the lock is currently held by any handle (including this one).
     // This is inherently racy and intended for debugging/diagnostics only.

--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -6,6 +6,7 @@
 
 #include <sys/types.h>
 
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -14,7 +15,7 @@
 #include <vector>
 
 #include "umd/device/types/communication_protocol.hpp"
-#include "umd/device/utils/robust_mutex.hpp"
+#include "umd/device/utils/mutex_interface.hpp"
 
 namespace tt::umd {
 
@@ -38,8 +39,8 @@ enum class MutexType {
 // Name of a mutex type, for logging and diagnostics.
 std::string to_string(MutexType mutex_type);
 
-// Note that the returned std::unique_lock<RobustMutex> should never outlive the LockManager which holds underlying
-// RobustMutexes. Also note that clear_mutex doesn't need to be explicitly called, since the mutexes will all get
+// Note that the returned std::unique_lock<MutexInterface> should never outlive the LockManager which holds
+// underlying mutexes. Also note that clear_mutex doesn't need to be explicitly called, since the mutexes will all get
 // cleared automatically when the LockManager goes out of scope. We could implement these lock such that initialization
 // is not needed, and they are initialized every time they're locked, but since that communicates with the OS filesystem
 // it might be slower do to it each time. This way, locking/unlocking should be faster.
@@ -75,19 +76,19 @@ public:
     // This set of functions is used to manage mutexes which are system wide and not chip specific.
     void initialize_mutex(MutexType mutex_type);
     void clear_mutex(MutexType mutex_type);
-    std::unique_lock<RobustMutex> acquire_mutex(MutexType mutex_type);
+    std::unique_lock<MutexInterface> acquire_mutex(MutexType mutex_type);
 
     // This set of functions is used to manage mutexes which are chip specific.
     void initialize_mutex(MutexType mutex_type, int device_id, IODeviceType device_type = IODeviceType::PCIe);
     void clear_mutex(MutexType mutex_type, int device_id, IODeviceType device_type = IODeviceType::PCIe);
-    std::unique_lock<RobustMutex> acquire_mutex(
+    std::unique_lock<MutexInterface> acquire_mutex(
         MutexType mutex_type, int device_id, IODeviceType device_type = IODeviceType::PCIe);
 
     // This set of functions is used to manage mutexes which are chip specific. This variant accepts custom mutex name.
     void initialize_mutex(
         const std::string& mutex_prefix, int device_id, IODeviceType device_type = IODeviceType::PCIe);
     void clear_mutex(const std::string& mutex_prefix, int device_id, IODeviceType device_type = IODeviceType::PCIe);
-    std::unique_lock<RobustMutex> acquire_mutex(
+    std::unique_lock<MutexInterface> acquire_mutex(
         const std::string& mutex_prefix, int device_id, IODeviceType device_type = IODeviceType::PCIe);
 
     // Reports whether a mutex is currently held, without holding it afterwards. Returns the owning {pid, tid} if it is
@@ -102,13 +103,13 @@ public:
 private:
     void initialize_mutex_internal(const std::string& mutex_name);
     void clear_mutex_internal(const std::string& mutex_name);
-    std::unique_lock<RobustMutex> acquire_mutex_internal(const std::string& mutex_name);
+    std::unique_lock<MutexInterface> acquire_mutex_internal(const std::string& mutex_name);
     std::optional<std::pair<pid_t, pid_t>> probe_mutex_internal(const std::string& mutex_name);
 
     // Maps from mutex name to an initialized mutex.
     // Mutex names are made from mutex type name or directly mutex name combined with device number.
     // Note that once LockManager is out of scope, all the mutexes will be cleared up automatically.
-    std::unordered_map<std::string, RobustMutex> mutexes;
+    std::unordered_map<std::string, std::unique_ptr<MutexInterface>> mutexes;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/utils/mutex_interface.hpp
+++ b/device/api/umd/device/utils/mutex_interface.hpp
@@ -17,9 +17,24 @@ namespace tt::umd {
 // backends compare.
 // Implementations meet the C++ BasicLockable requirement, so they work with std::lock_guard and
 // std::unique_lock.
+//
+// What an implementation owes its callers, and what it does not:
+//   - The mutex is not recursive. A thread already holding it must not take it again.
+//   - Misuse is not required to be diagnosed. Taking the lock again from the thread that holds it,
+//     unlocking from a thread that does not hold it, or unlocking twice, may throw, may be ignored, or
+//     may block forever. Which of those happens is not part of this interface, so callers must not
+//     depend on any of them. Taking the lock through std::lock_guard or std::unique_lock avoids all
+//     three.
 class MutexInterface {
 public:
+    MutexInterface() = default;
     virtual ~MutexInterface() = default;
+
+    // Copying through a MutexInterface& would slice, and an implementation holding an OS resource
+    // cannot be copied meaningfully anyway. Deleting these in the implementations does not cover an
+    // assignment made through the interface, which is what callers hold.
+    MutexInterface(const MutexInterface&) = delete;
+    MutexInterface& operator=(const MutexInterface&) = delete;
 
     // Sets up the underlying OS resource. Must be called before any locking operation.
     virtual void initialize() = 0;

--- a/device/api/umd/device/utils/mutex_interface.hpp
+++ b/device/api/umd/device/utils/mutex_interface.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <sys/types.h>  // pid_t
+
+#include <chrono>
+#include <optional>
+#include <utility>
+
+namespace tt::umd {
+
+// Common interface of UMD's cross-process locking backends, so that a lock can be guarded by whichever
+// backend suits it without its users having to know which one. See device/utils/README.md for how the
+// backends compare.
+// Implementations meet the C++ BasicLockable requirement, so they work with std::lock_guard and
+// std::unique_lock.
+class MutexInterface {
+public:
+    virtual ~MutexInterface() = default;
+
+    // Sets up the underlying OS resource. Must be called before any locking operation.
+    virtual void initialize() = 0;
+
+    virtual void lock() = 0;
+
+    virtual void unlock() = 0;
+
+    // Tries to acquire the lock, waiting up to timeout. Returns std::nullopt if the lock was acquired,
+    // otherwise the owning {pid, tid} if the backend can identify the owner, {0, 0} if it cannot.
+    virtual std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout) = 0;
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/utils/robust_mutex.hpp
+++ b/device/api/umd/device/utils/robust_mutex.hpp
@@ -16,6 +16,8 @@
 #include <string_view>
 #include <utility>
 
+#include "umd/device/utils/mutex_interface.hpp"
+
 namespace tt::umd {
 
 // RobustMutex is a class that provides a robust locking mechanism using POSIX shared memory mutexes.
@@ -25,7 +27,7 @@ namespace tt::umd {
 // Note that the implementation relies on the client not deleting underlying /dev/shm files.
 // Also, if the pthread implementation changes, we can enter some weird states if one process is holding the old mutex,
 // and the new one tries to initialize it with the new pthread.
-class RobustMutex {
+class RobustMutex : public MutexInterface {
 public:
     // Prefix used for shared memory files backing each mutex.
     static constexpr std::string_view SHM_FILE_PREFIX = "TT_UMD_LOCK.";
@@ -37,7 +39,7 @@ public:
     // The initialization can fail and throw an exception. In case of failure we still want to clean up the resources.
     // For easier handling of such case, the destructor cleans up the resources if they were taken. Having this code out
     // of constructor will guarantee that the destructor is called in case of exception.
-    void initialize();
+    void initialize() override;
 
     // Move constructor and assignment are defined so that this class can be used with c++ stl containers, like
     // unordered_map.
@@ -50,10 +52,10 @@ public:
 
     // Locks the mutex, blocking indefinitely.  Uses a 1-second timed attempt first so that a
     // warning can be emitted when the lock is contended before blocking without a timeout.
-    void lock();
+    void lock() override;
 
     // Unlocks the mutex.
-    void unlock();
+    void unlock() override;
 
     // Attempts to acquire the lock and returns immediately if timeout is zero (default), or waits
     // up to `timeout` seconds before giving up.
@@ -63,7 +65,7 @@ public:
     // Note: the returned PID/TID pair is a snapshot that may already be stale, since there is a race condition inherent
     // in trying to inspect a lock without acquiring it. So consider the information best-effort and for debugging
     // purposes only.
-    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout = std::chrono::seconds(0));
+    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout = std::chrono::seconds(0)) override;
 
 private:
     // A wrapper which holds the flag for whether the mutex has been initialized or not,

--- a/device/api/umd/device/utils/robust_mutex.hpp
+++ b/device/api/umd/device/utils/robust_mutex.hpp
@@ -65,7 +65,7 @@ public:
     // Note: the returned PID/TID pair is a snapshot that may already be stale, since there is a race condition inherent
     // in trying to inspect a lock without acquiring it. So consider the information best-effort and for debugging
     // purposes only.
-    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout = std::chrono::seconds(0)) override;
+    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout) override;
 
 private:
     // A wrapper which holds the flag for whether the mutex has been initialized or not,

--- a/device/utils/README.md
+++ b/device/utils/README.md
@@ -1,9 +1,9 @@
 # UMD locking backends
 
 UMD provides two cross-process lock implementations. They expose the same small interface
-(`initialize()`, `lock()`, `try_lock()`, `unlock()`, `probe_lock()`) and meet the C++ `Lockable`
-requirement, so they work with `std::lock_guard` / `std::unique_lock` and can be swapped for one
-another. They differ in *how* processes find each other and in the performance/robustness trade-off.
+(`initialize()`, `lock()`, `unlock()`, `probe_lock()`, gathered in `MutexInterface`) and meet the C++
+`BasicLockable` requirement, so they work with `std::lock_guard` / `std::unique_lock` and can be
+swapped for one another. `KmdMutex` additionally offers `try_lock()`. They differ in *how* processes find each other and in the performance/robustness trade-off.
 
 | Backend | Mechanism | Coordination requires | Lock/unlock cost | Crash-robust | Scope |
 |---|---|---|---|---|---|

--- a/device/utils/lock_manager.cpp
+++ b/device/utils/lock_manager.cpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/robust_mutex.hpp"
 
 namespace tt::umd {
 
@@ -33,11 +34,11 @@ void LockManager::clear_mutex(MutexType mutex_type, int device_id, IODeviceType 
     clear_mutex_internal(mutex_name);
 }
 
-std::unique_lock<RobustMutex> LockManager::acquire_mutex(MutexType mutex_type) {
+std::unique_lock<MutexInterface> LockManager::acquire_mutex(MutexType mutex_type) {
     return acquire_mutex_internal(MUTEX_TYPE_TO_STRING.at(mutex_type));
 }
 
-std::unique_lock<RobustMutex> LockManager::acquire_mutex(
+std::unique_lock<MutexInterface> LockManager::acquire_mutex(
     MutexType mutex_type, int device_id, IODeviceType device_type) {
     std::string mutex_name = MUTEX_TYPE_TO_STRING.at(mutex_type) + "_" + std::to_string(device_id) + "_" +
                              DeviceTypeToString.at(device_type);
@@ -54,7 +55,7 @@ void LockManager::clear_mutex(const std::string& mutex_prefix, int device_id, IO
     clear_mutex_internal(mutex_name);
 }
 
-std::unique_lock<RobustMutex> LockManager::acquire_mutex(
+std::unique_lock<MutexInterface> LockManager::acquire_mutex(
     const std::string& mutex_prefix, int device_id, IODeviceType device_type) {
     std::string mutex_name = mutex_prefix + "_" + std::to_string(device_id) + "_" + DeviceTypeToString.at(device_type);
     return acquire_mutex_internal(mutex_name);
@@ -77,8 +78,9 @@ void LockManager::initialize_mutex_internal(const std::string& mutex_name) {
         return;
     }
 
-    mutexes.emplace(mutex_name, RobustMutex(mutex_name));
-    mutexes.at(mutex_name).initialize();
+    std::unique_ptr<MutexInterface> mutex = std::make_unique<RobustMutex>(mutex_name);
+    mutex->initialize();
+    mutexes.emplace(mutex_name, std::move(mutex));
 }
 
 void LockManager::clear_mutex_internal(const std::string& mutex_name) {
@@ -90,18 +92,18 @@ void LockManager::clear_mutex_internal(const std::string& mutex_name) {
     mutexes.erase(mutex_name);
 }
 
-std::unique_lock<RobustMutex> LockManager::acquire_mutex_internal(const std::string& mutex_name) {
+std::unique_lock<MutexInterface> LockManager::acquire_mutex_internal(const std::string& mutex_name) {
     if (mutexes.find(mutex_name) == mutexes.end()) {
         UMD_THROW(error::RuntimeError, "Mutex not initialized: " + mutex_name);
     }
-    return std::unique_lock(mutexes.at(mutex_name));
+    return std::unique_lock(*mutexes.at(mutex_name));
 }
 
 std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex_internal(const std::string& mutex_name) {
     if (mutexes.find(mutex_name) == mutexes.end()) {
         UMD_THROW(error::RuntimeError, "Mutex not initialized: " + mutex_name);
     }
-    RobustMutex& mutex = mutexes.at(mutex_name);
+    MutexInterface& mutex = *mutexes.at(mutex_name);
     std::optional<std::pair<pid_t, pid_t>> owner = mutex.probe_lock(std::chrono::seconds(0));
     if (!owner.has_value()) {
         // The mutex was free, which means probing it took it. Release it so that probing stays a query.

--- a/tests/microbenchmark/host_benchmark/test_locks.cpp
+++ b/tests/microbenchmark/host_benchmark/test_locks.cpp
@@ -182,7 +182,7 @@ TEST(MicrobenchmarkLocks, ProbeContended) {
         auto prober = make_robust();
         holder.lock();
         bench.name("RobustMutex").run([&] {
-            auto owner = prober.probe_lock();
+            auto owner = prober.probe_lock(std::chrono::seconds(0));
             ankerl::nanobench::doNotOptimizeAway(owner);
         });
         holder.unlock();
@@ -192,7 +192,7 @@ TEST(MicrobenchmarkLocks, ProbeContended) {
         auto prober = make_kmd(*device_num);
         holder.lock();
         bench.name("KmdMutex").run([&] {
-            auto owner = prober.probe_lock();
+            auto owner = prober.probe_lock(std::chrono::seconds(0));
             ankerl::nanobench::doNotOptimizeAway(owner);
         });
         holder.unlock();

--- a/tests/misc/test_robust_mutex.cpp
+++ b/tests/misc/test_robust_mutex.cpp
@@ -32,7 +32,7 @@ using namespace std::chrono_literals;
 // LOCKED long after the read had failed. The natural suspicion was "tt-telemetry swallows UMD's
 // exception, so the lock is never released". These tests pin down what actually happens:
 //   1. LockReleasedWhenHolderThrows  -> an exception thrown while the lock is held DOES release it,
-//      because LockManager hands out a std::unique_lock<RobustMutex> whose destructor runs during
+//      because LockManager hands out a std::unique_lock whose destructor runs during
 //      stack unwinding. So swallowing the exception upstream is NOT what leaks the lock.
 //   2. LockStaysHeldWhenHolderNeverReturns -> if a code path holds the lock and neither returns nor
 //      throws (e.g. an unbounded poll loop with no check_timeout), the lock is held forever and every
@@ -55,16 +55,17 @@ void unlink_backing_file(std::string_view mutex_name) {
 
 }  // namespace
 
-// An exception thrown while a std::unique_lock<RobustMutex> is in scope releases the lock during
-// stack unwinding (the unique_lock destructor calls unlock()). This is exactly the type LockManager
-// returns, so the production read/write paths get this behavior for free. A subsequent acquirer must
-// therefore succeed immediately.
+// An exception thrown while a std::unique_lock over the mutex is in scope releases the lock during
+// stack unwinding (the unique_lock destructor calls unlock()). LockManager hands out a
+// std::unique_lock<MutexInterface> over the same mutex, so the production read/write paths get this
+// behavior for free. A subsequent acquirer must therefore succeed immediately.
 TEST(RobustMutex, LockReleasedWhenHolderThrows) {
     RobustMutex mutex(kExceptionMutexName);
     mutex.initialize();
 
     try {
-        // Same RAII wrapper LockManager::acquire_mutex() returns to callers like read_non_mmio().
+        // The RAII wrapper LockManager::acquire_mutex() returns to callers like read_non_mmio(), over
+        // the concrete type, since this test is about RobustMutex rather than about which backend.
         std::unique_lock<RobustMutex> lock(mutex);
 
         // Simulate read_non_mmio() hitting utils::check_timeout() and throwing while holding the lock.


### PR DESCRIPTION
### Issue
#2745

### Description
RobustMutex and KmdMutex already expose the same operations, but nothing states that, so whoever
holds a lock has to know which of the two backs it. MutexInterface states it, and both implement it.

LockManager keeps and hands out its mutexes through the interface, so which backend guards a lock
stops being visible to its callers. It still only ever creates RobustMutex; choosing between the
two comes later in the stack.

### List of the changes
- Add MutexInterface with initialize / lock / unlock / probe_lock
- RobustMutex and KmdMutex implement it
- LockManager holds std::unique_ptr<MutexInterface> and hands out std::unique_lock<MutexInterface>

### Testing
No behavior change, the one backend in use is the same one as before. umd_misc_tests, plus a
lock_virus run, which goes through LockManager and so through the interface.

### API Changes
This PR has API changes, adds MutexInterface and acquire_mutex now returns
std::unique_lock<MutexInterface>.

Follow up, blocked until #3232 is deployed everywhere: #3233 Stop taking the shared memory half of chip specific PCIe locks

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/locks_11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
