### PR TITLE
Back chip specific PCIe locks with KMD resource locks

### DIFF
--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -49,6 +49,10 @@ std::string to_string(MutexType mutex_type);
 // Locks are only ever added to the registry, never removed, and that is what makes the returned
 // std::unique_lock<MutexInterface> safe to hold for as long as the caller likes: the mutex it refers to stays where it
 // is for the lifetime of the process. Anything that removed locks again would leave every outstanding one dangling.
+//
+// Chip specific locks on a PCIe device are backed by a KMD resource lock, so that processes which share the device but
+// not /dev/shm still serialize against each other. Everything else - system wide locks and locks on a JTAG device - is
+// backed by RobustMutex, since a KMD resource lock exists only per local PCIe device.
 class LockManager {
 public:
     LockManager() = delete;
@@ -88,9 +92,16 @@ public:
         MutexType mutex_type, int device_id, IODeviceType device_type);
 
 private:
-    static void initialize_mutex_internal(const std::string& mutex_name);
-    static std::unique_lock<MutexInterface> acquire_mutex_internal(const std::string& mutex_name);
-    static std::optional<std::pair<pid_t, pid_t>> probe_mutex_internal(const std::string& mutex_name);
+    // Locks backed by a shared memory RobustMutex, addressed by their name.
+    static void initialize_robust_mutex(const std::string& mutex_name);
+    static std::unique_lock<MutexInterface> acquire_robust_mutex(const std::string& mutex_name);
+    static std::optional<std::pair<pid_t, pid_t>> probe_robust_mutex(const std::string& mutex_name);
+
+    // Locks backed by a KMD resource lock on the device owning the lock table. They take the shared memory lock as
+    // well, for as long as clients on an older UMD exist which know only about that one.
+    static void initialize_kmd_mutex(MutexType mutex_type, int pci_device_num);
+    static std::unique_lock<MutexInterface> acquire_kmd_mutex(MutexType mutex_type, int pci_device_num);
+    static std::optional<std::pair<pid_t, pid_t>> probe_kmd_mutex(MutexType mutex_type, int pci_device_num);
 };
 
 }  // namespace tt::umd

--- a/device/utils/README.md
+++ b/device/utils/README.md
@@ -50,6 +50,12 @@ convention for ERISC cores; use higher indices for general coordination.
 - Coordination **without** a shared filesystem (e.g. across containers that only share the device) →
   `KmdMutex`, accepting the per-device scope.
 
+`LockManager` makes this choice for UMD's own locks. A chip specific lock on a PCIe device takes both:
+the KMD lock is the one that works across containers, and the shared memory lock is kept for as long
+as clients on an older UMD exist, since those take only that one and would otherwise not serialize
+against a process on this one. System wide locks and locks on a JTAG device use `RobustMutex` alone,
+since a KMD resource lock exists only per local PCIe device.
+
 ## Benchmark
 
 Relative performance can be measured with the locks microbenchmark

--- a/device/utils/lock_manager.cpp
+++ b/device/utils/lock_manager.cpp
@@ -11,6 +11,7 @@
 #include <unordered_map>
 
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/kmd_mutex.hpp"
 #include "umd/device/utils/robust_mutex.hpp"
 
 namespace tt::umd {
@@ -33,6 +34,72 @@ std::string get_mutex_name(MutexType mutex_type, int device_id, IODeviceType dev
            DeviceTypeToString.at(device_type);
 }
 
+// KMD resource lock index used for each chip specific mutex type. Indices 0..15 are reserved for ERISC cores (see
+// KmdLockIndex), so UMD's own locks start above that range. Processes serialize against each other only if they agree
+// on the index, so these values must never be renumbered.
+const std::unordered_map<MutexType, uint8_t> MUTEX_TYPE_TO_KMD_LOCK_INDEX = {
+    {MutexType::ARC_MSG, 16},
+    {MutexType::REMOTE_ARC_MSG, 17},
+    {MutexType::NON_MMIO, 18},
+    {MutexType::MEM_BARRIER, 19},
+    {MutexType::CHIP_IN_USE, 20},
+    {MutexType::PCIE_DMA, 21},
+};
+
+uint8_t get_kmd_lock_index(MutexType mutex_type) {
+    auto it = MUTEX_TYPE_TO_KMD_LOCK_INDEX.find(mutex_type);
+    UMD_ASSERT(
+        it != MUTEX_TYPE_TO_KMD_LOCK_INDEX.end(),
+        error::RuntimeError,
+        "Mutex " + MUTEX_TYPE_TO_STRING.at(mutex_type) + " has no KMD resource lock index assigned to it");
+    return it->second;
+}
+
+// Holds two mutexes as one. This exists only for the move from shared memory locks to KMD resource locks: a process
+// running an older UMD takes the shared memory lock alone and knows nothing about the KMD one, so during the
+// transition both have to be taken or the two processes would not serialize. Once every client takes KMD locks, the
+// shared memory half can go and the KMD mutex can be used on its own.
+// The two are always taken in the same order, which is what keeps processes taking both from deadlocking against each
+// other.
+class CompositeMutex : public MutexInterface {
+public:
+    CompositeMutex(std::unique_ptr<MutexInterface> first, std::unique_ptr<MutexInterface> second) :
+        first_(std::move(first)), second_(std::move(second)) {}
+
+    void initialize() override {
+        first_->initialize();
+        second_->initialize();
+    }
+
+    void lock() override {
+        first_->lock();
+        second_->lock();
+    }
+
+    void unlock() override {
+        second_->unlock();
+        first_->unlock();
+    }
+
+    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout) override {
+        std::optional<std::pair<pid_t, pid_t>> owner = first_->probe_lock(timeout);
+        if (owner.has_value()) {
+            return owner;
+        }
+        // Probing acquired the first one. If the second turns out to be taken, give the first one back, so that a
+        // failed probe leaves nothing held.
+        owner = second_->probe_lock(timeout);
+        if (owner.has_value()) {
+            first_->unlock();
+        }
+        return owner;
+    }
+
+private:
+    std::unique_ptr<MutexInterface> first_;
+    std::unique_ptr<MutexInterface> second_;
+};
+
 // Every mutex UMD has initialized, keyed by name. Names are made from the mutex type name, combined with the device
 // number for chip specific ones.
 struct MutexRegistry {
@@ -47,6 +114,38 @@ MutexRegistry& get_registry() {
     // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     static MutexRegistry* registry = new MutexRegistry();
     return *registry;
+}
+
+void add_mutex(const std::string& mutex_name, std::unique_ptr<MutexInterface> mutex) {
+    MutexRegistry& registry = get_registry();
+
+    {
+        std::lock_guard<std::mutex> guard(registry.guard);
+        if (registry.mutexes.find(mutex_name) != registry.mutexes.end()) {
+            // Whoever needed this lock first has already set it up. Initializing is not owning, so this is the expected
+            // outcome whenever more than one object works with the same device.
+            return;
+        }
+    }
+
+    // Setting a mutex up talks to the OS - a shared memory one takes a blocking flock, a KMD one opens the device - so
+    // it happens outside the registry guard. Holding the guard across it would stall every other thread that only
+    // wanted to look a lock up, and looking one up is on the IO paths.
+    mutex->initialize();
+
+    std::lock_guard<std::mutex> guard(registry.guard);
+    // Another thread may have set the same lock up in the meantime, in which case theirs is the one in the registry and
+    // ours is dropped here. Setting the same one up twice is harmless: both backends make that safe.
+    registry.mutexes.try_emplace(mutex_name, std::move(mutex));
+}
+
+// Probing has to acquire a free mutex to find out it was free, so release it again to keep probing a query.
+std::optional<std::pair<pid_t, pid_t>> probe_and_release(MutexInterface& mutex) {
+    std::optional<std::pair<pid_t, pid_t>> owner = mutex.probe_lock(std::chrono::seconds(0));
+    if (!owner.has_value()) {
+        mutex.unlock();
+    }
+    return owner;
 }
 
 // Looking a mutex up hands out a reference into the registry, which stays valid because entries are only ever added.
@@ -67,70 +166,70 @@ MutexInterface& get_initialized_mutex(const std::string& mutex_name) {
 std::string to_string(MutexType mutex_type) { return MUTEX_TYPE_TO_STRING.at(mutex_type); }
 
 void LockManager::initialize_mutex(MutexType mutex_type) {
-    initialize_mutex_internal(MUTEX_TYPE_TO_STRING.at(mutex_type));
+    initialize_robust_mutex(MUTEX_TYPE_TO_STRING.at(mutex_type));
 }
 
 void LockManager::initialize_mutex(MutexType mutex_type, int device_id, IODeviceType device_type) {
-    std::string mutex_name = get_mutex_name(mutex_type, device_id, device_type);
-    initialize_mutex_internal(mutex_name);
+    if (device_type == IODeviceType::PCIe) {
+        initialize_kmd_mutex(mutex_type, device_id);
+    } else {
+        initialize_robust_mutex(get_mutex_name(mutex_type, device_id, device_type));
+    }
 }
 
 std::unique_lock<MutexInterface> LockManager::acquire_mutex(MutexType mutex_type) {
-    return acquire_mutex_internal(MUTEX_TYPE_TO_STRING.at(mutex_type));
+    return acquire_robust_mutex(MUTEX_TYPE_TO_STRING.at(mutex_type));
 }
 
 std::unique_lock<MutexInterface> LockManager::acquire_mutex(
     MutexType mutex_type, int device_id, IODeviceType device_type) {
-    std::string mutex_name = get_mutex_name(mutex_type, device_id, device_type);
-    return acquire_mutex_internal(mutex_name);
+    if (device_type == IODeviceType::PCIe) {
+        return acquire_kmd_mutex(mutex_type, device_id);
+    }
+    return acquire_robust_mutex(get_mutex_name(mutex_type, device_id, device_type));
 }
 
 std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex(MutexType mutex_type) {
-    return probe_mutex_internal(MUTEX_TYPE_TO_STRING.at(mutex_type));
+    return probe_robust_mutex(MUTEX_TYPE_TO_STRING.at(mutex_type));
 }
 
 std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex(
     MutexType mutex_type, int device_id, IODeviceType device_type) {
-    std::string mutex_name = get_mutex_name(mutex_type, device_id, device_type);
-    return probe_mutex_internal(mutex_name);
-}
-
-void LockManager::initialize_mutex_internal(const std::string& mutex_name) {
-    MutexRegistry& registry = get_registry();
-
-    {
-        std::lock_guard<std::mutex> guard(registry.guard);
-        if (registry.mutexes.find(mutex_name) != registry.mutexes.end()) {
-            // Whoever needed this lock first has already set it up. Initializing is not owning, so this is the expected
-            // outcome whenever more than one object works with the same device.
-            return;
-        }
+    if (device_type == IODeviceType::PCIe) {
+        return probe_kmd_mutex(mutex_type, device_id);
     }
-
-    // Setting a mutex up talks to the OS, and for a shared memory one that includes a blocking flock, so it happens
-    // outside the registry guard. Holding the guard across it would stall every other thread that only wanted to look
-    // a lock up, and looking one up is on the IO paths.
-    std::unique_ptr<MutexInterface> mutex = std::make_unique<RobustMutex>(mutex_name);
-    mutex->initialize();
-
-    std::lock_guard<std::mutex> guard(registry.guard);
-    // Another thread may have set the same lock up in the meantime, in which case theirs is the one in the registry and
-    // ours is dropped here. Setting the same one up twice is harmless: the backend serializes that internally.
-    registry.mutexes.try_emplace(mutex_name, std::move(mutex));
+    return probe_robust_mutex(get_mutex_name(mutex_type, device_id, device_type));
 }
 
-std::unique_lock<MutexInterface> LockManager::acquire_mutex_internal(const std::string& mutex_name) {
+void LockManager::initialize_robust_mutex(const std::string& mutex_name) {
+    add_mutex(mutex_name, std::make_unique<RobustMutex>(mutex_name));
+}
+
+std::unique_lock<MutexInterface> LockManager::acquire_robust_mutex(const std::string& mutex_name) {
     return std::unique_lock(get_initialized_mutex(mutex_name));
 }
 
-std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex_internal(const std::string& mutex_name) {
-    MutexInterface& mutex = get_initialized_mutex(mutex_name);
-    std::optional<std::pair<pid_t, pid_t>> owner = mutex.probe_lock(std::chrono::seconds(0));
-    if (!owner.has_value()) {
-        // The mutex was free, which means probing it took it. Release it so that probing stays a query.
-        mutex.unlock();
-    }
-    return owner;
+std::optional<std::pair<pid_t, pid_t>> LockManager::probe_robust_mutex(const std::string& mutex_name) {
+    return probe_and_release(get_initialized_mutex(mutex_name));
+}
+
+void LockManager::initialize_kmd_mutex(MutexType mutex_type, int pci_device_num) {
+    // Registered under the name its shared memory half keeps, so that a process on an older UMD, which takes only that
+    // half, contends on the very same lock.
+    std::string mutex_name = get_mutex_name(mutex_type, pci_device_num, IODeviceType::PCIe);
+    add_mutex(
+        mutex_name,
+        std::make_unique<CompositeMutex>(
+            std::make_unique<RobustMutex>(mutex_name),
+            std::make_unique<KmdMutex>(pci_device_num, get_kmd_lock_index(mutex_type))));
+}
+
+std::unique_lock<MutexInterface> LockManager::acquire_kmd_mutex(MutexType mutex_type, int pci_device_num) {
+    return std::unique_lock(get_initialized_mutex(get_mutex_name(mutex_type, pci_device_num, IODeviceType::PCIe)));
+}
+
+std::optional<std::pair<pid_t, pid_t>> LockManager::probe_kmd_mutex(MutexType mutex_type, int pci_device_num) {
+    return probe_and_release(get_initialized_mutex(get_mutex_name(mutex_type, pci_device_num, IODeviceType::PCIe)));
 }
 
 }  // namespace tt::umd

--- a/device/utils/lock_manager.cpp
+++ b/device/utils/lock_manager.cpp
@@ -34,8 +34,8 @@ std::string get_mutex_name(MutexType mutex_type, int device_id, IODeviceType dev
            DeviceTypeToString.at(device_type);
 }
 
-// KMD resource lock index used for each chip specific mutex type. Indices 0..15 are reserved for ERISC cores (see
-// KmdLockIndex), so UMD's own locks start above that range. Processes serialize against each other only if they agree
+// KMD resource lock index used for each chip specific mutex type. KMD suggests indices 0..15 for ERISC cores (see
+// tt_kmd_lib.h), so UMD's own locks start above that range. Processes serialize against each other only if they agree
 // on the index, so these values must never be renumbered.
 const std::unordered_map<MutexType, uint8_t> MUTEX_TYPE_TO_KMD_LOCK_INDEX = {
     {MutexType::ARC_MSG, 16},
@@ -71,13 +71,27 @@ public:
         second_->initialize();
     }
 
+    // The first one is given back whenever taking the second does not work out, whether it reports the lock as taken
+    // or throws. Otherwise it would stay held for the lifetime of the process: the caller never receives a
+    // std::unique_lock when the constructor's lock() throws, so nothing is left to release it, and the shared memory
+    // half only recovers itself when its holder dies.
     void lock() override {
         first_->lock();
-        second_->lock();
+        try {
+            second_->lock();
+        } catch (...) {
+            first_->unlock();
+            throw;
+        }
     }
 
     void unlock() override {
-        second_->unlock();
+        try {
+            second_->unlock();
+        } catch (...) {
+            first_->unlock();
+            throw;
+        }
         first_->unlock();
     }
 
@@ -86,9 +100,14 @@ public:
         if (owner.has_value()) {
             return owner;
         }
-        // Probing acquired the first one. If the second turns out to be taken, give the first one back, so that a
-        // failed probe leaves nothing held.
-        owner = second_->probe_lock(timeout);
+
+        // Probing acquired the first one.
+        try {
+            owner = second_->probe_lock(timeout);
+        } catch (...) {
+            first_->unlock();
+            throw;
+        }
         if (owner.has_value()) {
             first_->unlock();
         }

--- a/tests/misc/CMakeLists.txt
+++ b/tests/misc/CMakeLists.txt
@@ -3,6 +3,7 @@ set(UMD_MISC_TESTS_SRCS
     test_errors.cpp
     test_robust_mutex.cpp
     test_kmd_mutex.cpp
+    test_lock_manager.cpp
     test_op_timeout_guard.cpp
 )
 

--- a/tests/misc/test_lock_manager.cpp
+++ b/tests/misc/test_lock_manager.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/utils/kmd_mutex.hpp"
+#include "umd/device/utils/lock_manager.hpp"
+#include "umd/device/utils/robust_mutex.hpp"
+
+using namespace tt::umd;
+
+namespace {
+
+// The lock name and the KMD lock index are what different processes agree on, so they are spelled out here rather than
+// read back from LockManager: a change to either breaks serialization against processes built from another UMD
+// version, and this test is what should notice.
+constexpr uint8_t MEM_BARRIER_KMD_LOCK_INDEX = 19;
+
+std::string mem_barrier_lock_name(int device_num) { return "MEM_BARRIER_" + std::to_string(device_num) + "_PCIe"; }
+
+}  // namespace
+
+// A chip specific lock on a PCIe device has to be held in both places at once: in KMD, so that processes sharing only
+// the device serialize, and in shared memory, so that processes on an older UMD - which know only about that one -
+// still serialize too.
+TEST(TestLockManager, ChipSpecificPcieLockIsHeldInBothBackends) {
+    std::vector<int> devices = PCIDevice::enumerate_devices();
+    if (devices.empty()) {
+        GTEST_SKIP() << "No /dev/tenstorrent device present";
+    }
+    const int device_num = devices.front();
+
+    KmdMutex kmd_lock(device_num, MEM_BARRIER_KMD_LOCK_INDEX);
+    kmd_lock.initialize();
+    RobustMutex shm_lock(mem_barrier_lock_name(device_num));
+    shm_lock.initialize();
+
+    LockManager::initialize_mutex(MutexType::MEM_BARRIER, device_num, IODeviceType::PCIe);
+
+    {
+        auto lock = LockManager::acquire_mutex(MutexType::MEM_BARRIER, device_num, IODeviceType::PCIe);
+
+        EXPECT_TRUE(kmd_lock.is_locked_by_anyone()) << "KMD resource lock should be held";
+        EXPECT_TRUE(shm_lock.probe_lock(std::chrono::seconds(0)).has_value()) << "Shared memory lock should be held";
+    }
+
+    EXPECT_FALSE(kmd_lock.is_locked_by_anyone()) << "KMD resource lock should have been released";
+    EXPECT_FALSE(shm_lock.probe_lock(std::chrono::seconds(0)).has_value())
+        << "Shared memory lock should have been released";
+    shm_lock.unlock();
+}

--- a/tools/lock_virus.cpp
+++ b/tools/lock_virus.cpp
@@ -41,11 +41,16 @@ constexpr std::string_view DEVICE_TYPE_JTAG = "jtag";
 // ── reporting ─────────────────────────────────────────────────────────────────
 
 static void report_state(const std::string& mutex_name, const std::optional<std::pair<pid_t, pid_t>>& owner) {
-    if (owner.has_value()) {
-        log_info(tt::LogUMD, "    [{:<16}]  LOCKED  PID={} TID={}", mutex_name, owner->first, owner->second);
-    } else {
+    if (!owner.has_value()) {
         log_info(tt::LogUMD, "    [{:<16}]  FREE", mutex_name);
+        return;
     }
+    // A backend that cannot say who holds the lock reports {0, 0}, which is not a pid anyone has.
+    if (owner->first == 0 && owner->second == 0) {
+        log_info(tt::LogUMD, "    [{:<16}]  LOCKED  by an unknown holder", mutex_name);
+        return;
+    }
+    log_info(tt::LogUMD, "    [{:<16}]  LOCKED  PID={} TID={}", mutex_name, owner->first, owner->second);
 }
 
 static void report_device_locks(int device_id, IODeviceType device_type) {


### PR DESCRIPTION
### Issue
#2745

### Description
Perf analysis: https://tenstorrent.atlassian.net/wiki/spaces/UMD/pages/2564948067/Locks+perf+analysis

Shared memory locks require every participant to see the same /dev/shm, which does not hold across
containers. Chip specific locks on a PCIe device now also take a KMD resource lock, which lives in
the driver and needs nothing shared beyond the device itself.

They take both for now. A process running an older UMD knows only about the shared memory lock, so
dropping it would leave old and new processes not serializing at all. The shared memory half goes
away once every client is on KMD locks. Locks with no KMD equivalent, meaning system wide ones and
locks on a JTAG device, are unchanged.

### List of the changes
- Split LockManager's internals into a RobustMutex backed and a KMD backed set
- Add the mutex type to KMD lock index mapping, above the range KMD reserves for ERISC cores
- Add CompositeMutex, holding both backends in a fixed order, for the duration of the transition
- Add a test asserting a chip specific PCIe lock is held in both backends

### Testing
umd_misc_tests. The new test needs a card and is skipped without one.

### API Changes
This PR has no API changes.

Follow up, blocked until #3232 is deployed everywhere: #3233 Stop taking the shared memory half of chip specific PCIe locks

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/locks_11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
