### PR TITLE
Stop taking the shared memory half of chip specific PCIe locks

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -241,6 +241,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/warm_reset.hpp
                 api/umd/device/warm_reset_with_recovery.hpp
                 api/umd/device/utils/semver.hpp
+                api/umd/device/utils/mutex_interface.hpp
                 api/umd/device/utils/robust_mutex.hpp
                 api/umd/device/utils/kmd_mutex.hpp
                 api/umd/device/cluster_descriptor.hpp

--- a/device/api/umd/device/arc/arc_messenger.hpp
+++ b/device/api/umd/device/arc/arc_messenger.hpp
@@ -67,7 +67,6 @@ protected:
     ArcMessenger(TTDevice* tt_device);
 
     TTDevice* tt_device;
-    LockManager lock_manager;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/arc/arc_messenger.hpp
+++ b/device/api/umd/device/arc/arc_messenger.hpp
@@ -56,7 +56,7 @@ public:
         const std::vector<uint32_t>& args = {},
         const std::chrono::milliseconds timeout_ms = timeout::ARC_MESSAGE_TIMEOUT);
 
-    virtual ~ArcMessenger();
+    virtual ~ArcMessenger() = default;
 
 protected:
     /**

--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -83,7 +83,6 @@ private:
 
     std::unique_ptr<TLBManager> tlb_manager_;
     std::unique_ptr<SysmemManager> sysmem_manager_;
-    LockManager lock_manager_;
 
     // unique_lock is RAII, so if this member holds an object, the mutex is locked, if it is empty, the
     // mutex is unlocked.

--- a/device/api/umd/device/chip/local_chip.hpp
+++ b/device/api/umd/device/chip/local_chip.hpp
@@ -22,7 +22,7 @@
 #include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/core_coordinates.hpp"
 #include "umd/device/utils/lock_manager.hpp"
-#include "umd/device/utils/robust_mutex.hpp"
+#include "umd/device/utils/mutex_interface.hpp"
 
 namespace tt::umd {
 class SocDescriptor;
@@ -85,9 +85,9 @@ private:
     std::unique_ptr<SysmemManager> sysmem_manager_;
     LockManager lock_manager_;
 
-    // unique_lock is RAII, so if this member holds an object, the RobustMutex is locked, if it is empty, the
-    // RobustMutex is unlocked.
-    std::optional<std::unique_lock<RobustMutex>> chip_started_lock_;
+    // unique_lock is RAII, so if this member holds an object, the mutex is locked, if it is empty, the
+    // mutex is unlocked.
+    std::optional<std::unique_lock<MutexInterface>> chip_started_lock_;
 
     void initialize_tlb_manager();
     void initialize_default_chip_mutexes();

--- a/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/blackhole_device_firmware.hpp
@@ -17,7 +17,6 @@
 #include "umd/device/types/communication_protocol.hpp"
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/xy_pair.hpp"
-#include "umd/device/utils/lock_manager.hpp"
 #include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
@@ -103,10 +102,6 @@ private:
     tt_xy_pair arc_core_noc1_;
 
     BlackholeArcApb arc_apb_;
-
-    // Serializes ARC messages against other processes driving the same device, exactly as
-    // ArcMessenger does for the path this replaces.
-    LockManager lock_manager_;
 
     // Created by init_firmware(), not by the constructor: building it reads the queue descriptor
     // from the device, which the ARC firmware only publishes once it is up. Declared after arc_apb_

--- a/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
+++ b/device/api/umd/device/tt_device/firmware/wormhole_device_firmware.hpp
@@ -16,7 +16,6 @@
 #include "umd/device/types/eth_training_status.hpp"
 #include "umd/device/types/noc_id.hpp"
 #include "umd/device/types/xy_pair.hpp"
-#include "umd/device/utils/lock_manager.hpp"
 #include "umd/device/utils/timeouts.hpp"
 
 namespace tt::umd {
@@ -110,10 +109,6 @@ private:
 
     WormholeArcWindow arc_apb_;
     WormholeArcWindow arc_csm_;
-
-    // Serializes ARC messages against other processes driving the same device, exactly as
-    // ArcMessenger does for the path this replaces.
-    LockManager lock_manager_;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/remote_communication.hpp
+++ b/device/api/umd/device/tt_device/remote_communication.hpp
@@ -82,7 +82,6 @@ protected:
 
     TTDevice* local_tt_device_;
 
-    LockManager lock_manager_;
     SysmemManager* sysmem_manager_;
 };
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -550,7 +550,6 @@ public:
     const SocDescriptor &get_soc_descriptor() const;
 
 protected:
-
     // Every TTDevice is built around a model, which supplies its identity and the components it
     // runs on: the protocol it talks to hardware over, its architecture implementation and its SoC
     // architecture descriptor.

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -550,7 +550,6 @@ public:
     const SocDescriptor &get_soc_descriptor() const;
 
 protected:
-    LockManager lock_manager;
 
     // Every TTDevice is built around a model, which supplies its identity and the components it
     // runs on: the protocol it talks to hardware over, its architecture implementation and its SoC

--- a/device/api/umd/device/utils/kmd_mutex.hpp
+++ b/device/api/umd/device/utils/kmd_mutex.hpp
@@ -86,7 +86,7 @@ public:
     // Returns std::nullopt if the lock was acquired (the caller now holds it). On contention returns a
     // {pid, tid} pair, but KMD does not expose the owner, so it is always {0, 0} here - the pair's
     // presence signals "held by someone else", nothing more.
-    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout = std::chrono::seconds(0)) override;
+    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout) override;
 
     // Releases the lock. It is also released automatically when this object (and thus its handle) is
     // destroyed, or when the owning process exits.

--- a/device/api/umd/device/utils/kmd_mutex.hpp
+++ b/device/api/umd/device/utils/kmd_mutex.hpp
@@ -12,6 +12,8 @@
 #include <string>
 #include <utility>
 
+#include "umd/device/utils/mutex_interface.hpp"
+
 // tt-kmd-lib device handle. Forward declared so this public header does not require tt-kmd-lib's
 // include path, which UMD links privately.
 struct tt_device_t;
@@ -53,7 +55,7 @@ namespace tt::umd {
 //
 // It meets the C++ Lockable requirement (lock()/try_lock()/unlock()), so it can be used with RAII
 // helpers like std::lock_guard and std::unique_lock.
-class KmdMutex {
+class KmdMutex : public MutexInterface {
 public:
     // @param pci_device_num  N in /dev/tenstorrent/N (a UMD logical device id / PCIDevice number).
     // @param lock_index      KMD resource lock index in [0, TT_RESOURCE_LOCK_COUNT). See
@@ -64,7 +66,7 @@ public:
     // Opens the dedicated device handle used to hold the lock. Must be called before
     // lock()/try_lock(). Kept separate from the constructor so that failures during setup are still
     // cleaned up by the destructor. Calling it again once the handle is open does nothing.
-    void initialize();
+    void initialize() override;
 
     // Move-only so it can live in STL containers. Copying would alias the owned handle.
     KmdMutex(KmdMutex&& other) noexcept;
@@ -74,7 +76,7 @@ public:
 
     // Blocks until the lock is acquired. If a reset is detected while waiting (the handle becomes
     // unusable), the handle is transparently reopened and the wait is retried.
-    void lock();
+    void lock() override;
 
     // Attempts to acquire without blocking. Returns true if acquired, false if held by another
     // handle.
@@ -84,11 +86,11 @@ public:
     // Returns std::nullopt if the lock was acquired (the caller now holds it). On contention returns a
     // {pid, tid} pair, but KMD does not expose the owner, so it is always {0, 0} here - the pair's
     // presence signals "held by someone else", nothing more.
-    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout = std::chrono::seconds(0));
+    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout = std::chrono::seconds(0)) override;
 
     // Releases the lock. It is also released automatically when this object (and thus its handle) is
     // destroyed, or when the owning process exits.
-    void unlock();
+    void unlock() override;
 
     // Best-effort query of whether the lock is currently held by any handle (including this one).
     // This is inherently racy and intended for debugging/diagnostics only.

--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -97,8 +97,7 @@ private:
     static std::unique_lock<MutexInterface> acquire_robust_mutex(const std::string& mutex_name);
     static std::optional<std::pair<pid_t, pid_t>> probe_robust_mutex(const std::string& mutex_name);
 
-    // Locks backed by a KMD resource lock on the device owning the lock table. They take the shared memory lock as
-    // well, for as long as clients on an older UMD exist which know only about that one.
+    // Locks backed by a KMD resource lock on the device owning the lock table.
     static void initialize_kmd_mutex(MutexType mutex_type, int pci_device_num);
     static std::unique_lock<MutexInterface> acquire_kmd_mutex(MutexType mutex_type, int pci_device_num);
     static std::optional<std::pair<pid_t, pid_t>> probe_kmd_mutex(MutexType mutex_type, int pci_device_num);

--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -4,7 +4,10 @@
 
 #pragma once
 
+#include <sys/types.h>
+
 #include <mutex>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -31,6 +34,9 @@ enum class MutexType {
     // Used for guarding PCIe DMA operations against concurrent access from multiple processes.
     PCIE_DMA,
 };
+
+// Name of a mutex type, for logging and diagnostics.
+std::string to_string(MutexType mutex_type);
 
 // Note that the returned std::unique_lock<RobustMutex> should never outlive the LockManager which holds underlying
 // RobustMutexes. Also note that clear_mutex doesn't need to be explicitly called, since the mutexes will all get
@@ -84,10 +90,18 @@ public:
     std::unique_lock<RobustMutex> acquire_mutex(
         const std::string& mutex_prefix, int device_id, IODeviceType device_type = IODeviceType::PCIe);
 
+    // Reports whether a mutex is currently held, without holding it afterwards. Returns std::nullopt if the mutex was
+    // free, otherwise the owning {pid, tid}. Since a free mutex has to be acquired to find that out, and is released
+    // again right after, the answer is best effort and may be stale as soon as it is returned.
+    std::optional<std::pair<pid_t, pid_t>> probe_mutex(MutexType mutex_type);
+    std::optional<std::pair<pid_t, pid_t>> probe_mutex(
+        MutexType mutex_type, int device_id, IODeviceType device_type = IODeviceType::PCIe);
+
 private:
     void initialize_mutex_internal(const std::string& mutex_name);
     void clear_mutex_internal(const std::string& mutex_name);
     std::unique_lock<RobustMutex> acquire_mutex_internal(const std::string& mutex_name);
+    std::optional<std::pair<pid_t, pid_t>> probe_mutex_internal(const std::string& mutex_name);
 
     // Maps from mutex name to an initialized mutex.
     // Mutex names are made from mutex type name or directly mutex name combined with device number.

--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -40,10 +40,9 @@ enum class MutexType {
 std::string to_string(MutexType mutex_type);
 
 // Note that the returned std::unique_lock<MutexInterface> should never outlive the LockManager which holds
-// underlying mutexes. Also note that clear_mutex doesn't need to be explicitly called, since the mutexes will all get
-// cleared automatically when the LockManager goes out of scope. We could implement these lock such that initialization
-// is not needed, and they are initialized every time they're locked, but since that communicates with the OS filesystem
-// it might be slower do to it each time. This way, locking/unlocking should be faster.
+// underlying mutexes, which are cleared when the LockManager goes out of scope. We could implement these lock such that
+// initialization is not needed, and they are initialized every time they're locked, but since that communicates with
+// the OS filesystem it might be slower do to it each time. This way, locking/unlocking should be faster.
 class LockManager {
 public:
     // Mutex types that are initialized per chip (combined with device_id + device_type).
@@ -64,12 +63,10 @@ public:
 
     // This set of functions is used to manage mutexes which are system wide and not chip specific.
     void initialize_mutex(MutexType mutex_type);
-    void clear_mutex(MutexType mutex_type);
     std::unique_lock<MutexInterface> acquire_mutex(MutexType mutex_type);
 
     // This set of functions is used to manage mutexes which are chip specific.
     void initialize_mutex(MutexType mutex_type, int device_id, IODeviceType device_type);
-    void clear_mutex(MutexType mutex_type, int device_id, IODeviceType device_type);
     std::unique_lock<MutexInterface> acquire_mutex(MutexType mutex_type, int device_id, IODeviceType device_type);
 
     // Reports whether a mutex is currently held, without holding it afterwards. Returns the owning {pid, tid} if it is
@@ -82,7 +79,6 @@ public:
 
 private:
     void initialize_mutex_internal(const std::string& mutex_name);
-    void clear_mutex_internal(const std::string& mutex_name);
     std::unique_lock<MutexInterface> acquire_mutex_internal(const std::string& mutex_name);
     std::optional<std::pair<pid_t, pid_t>> probe_mutex_internal(const std::string& mutex_name);
 

--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -46,6 +46,9 @@ std::string to_string(MutexType mutex_type);
 // We could implement these locks such that initialization is not needed, and they are initialized every time they're
 // locked, but since that communicates with the OS it might be slower to do it each time. This way, locking/unlocking
 // should be faster.
+// Locks are only ever added to the registry, never removed, and that is what makes the returned
+// std::unique_lock<MutexInterface> safe to hold for as long as the caller likes: the mutex it refers to stays where it
+// is for the lifetime of the process. Anything that removed locks again would leave every outstanding one dangling.
 class LockManager {
 public:
     LockManager() = delete;

--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -87,7 +87,8 @@ private:
     std::optional<std::pair<pid_t, pid_t>> probe_mutex_internal(const std::string& mutex_name);
 
     // Maps from mutex name to an initialized mutex.
-    // Mutex names are made from the mutex type name, combined with device number for chip specific ones.
+    // Mutex names are made from the mutex type name, combined with the device number and device type for chip
+    // specific ones.
     // Note that once LockManager is out of scope, all the mutexes will be cleared up automatically.
     std::unordered_map<std::string, std::unique_ptr<MutexInterface>> mutexes;
 };

--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -46,17 +46,6 @@ std::string to_string(MutexType mutex_type);
 // it might be slower do to it each time. This way, locking/unlocking should be faster.
 class LockManager {
 public:
-    // Maps MutexType enum values to their string names used in shared-memory lock names.
-    inline static const std::unordered_map<MutexType, std::string> MUTEX_TYPE_TO_STRING = {
-        {MutexType::ARC_MSG, "ARC_MSG"},
-        {MutexType::REMOTE_ARC_MSG, "REMOTE_ARC_MSG"},
-        {MutexType::NON_MMIO, "NON_MMIO"},
-        {MutexType::MEM_BARRIER, "MEM_BARRIER"},
-        {MutexType::CREATE_ETH_MAP, "CREATE_ETH_MAP"},
-        {MutexType::CHIP_IN_USE, "CHIP_IN_USE"},
-        {MutexType::PCIE_DMA, "PCIE_DMA"},
-    };
-
     // Mutex types that are initialized per chip (combined with device_id + device_type).
     inline static const std::vector<MutexType> CHIP_SPECIFIC_MUTEX_TYPES = {
         MutexType::ARC_MSG,
@@ -79,17 +68,9 @@ public:
     std::unique_lock<MutexInterface> acquire_mutex(MutexType mutex_type);
 
     // This set of functions is used to manage mutexes which are chip specific.
-    void initialize_mutex(MutexType mutex_type, int device_id, IODeviceType device_type = IODeviceType::PCIe);
-    void clear_mutex(MutexType mutex_type, int device_id, IODeviceType device_type = IODeviceType::PCIe);
-    std::unique_lock<MutexInterface> acquire_mutex(
-        MutexType mutex_type, int device_id, IODeviceType device_type = IODeviceType::PCIe);
-
-    // This set of functions is used to manage mutexes which are chip specific. This variant accepts custom mutex name.
-    void initialize_mutex(
-        const std::string& mutex_prefix, int device_id, IODeviceType device_type = IODeviceType::PCIe);
-    void clear_mutex(const std::string& mutex_prefix, int device_id, IODeviceType device_type = IODeviceType::PCIe);
-    std::unique_lock<MutexInterface> acquire_mutex(
-        const std::string& mutex_prefix, int device_id, IODeviceType device_type = IODeviceType::PCIe);
+    void initialize_mutex(MutexType mutex_type, int device_id, IODeviceType device_type);
+    void clear_mutex(MutexType mutex_type, int device_id, IODeviceType device_type);
+    std::unique_lock<MutexInterface> acquire_mutex(MutexType mutex_type, int device_id, IODeviceType device_type);
 
     // Reports whether a mutex is currently held, without holding it afterwards. Returns the owning {pid, tid} if it is
     // held, and std::nullopt if it is not - which covers both a mutex nobody had taken and one whose owner died holding
@@ -97,8 +78,7 @@ public:
     // free mutex has to be acquired to find that out, and is released again right after, the answer is best effort and
     // may be stale as soon as it is returned.
     std::optional<std::pair<pid_t, pid_t>> probe_mutex(MutexType mutex_type);
-    std::optional<std::pair<pid_t, pid_t>> probe_mutex(
-        MutexType mutex_type, int device_id, IODeviceType device_type = IODeviceType::PCIe);
+    std::optional<std::pair<pid_t, pid_t>> probe_mutex(MutexType mutex_type, int device_id, IODeviceType device_type);
 
 private:
     void initialize_mutex_internal(const std::string& mutex_name);
@@ -107,7 +87,7 @@ private:
     std::optional<std::pair<pid_t, pid_t>> probe_mutex_internal(const std::string& mutex_name);
 
     // Maps from mutex name to an initialized mutex.
-    // Mutex names are made from mutex type name or directly mutex name combined with device number.
+    // Mutex names are made from the mutex type name, combined with device number for chip specific ones.
     // Note that once LockManager is out of scope, all the mutexes will be cleared up automatically.
     std::unordered_map<std::string, std::unique_ptr<MutexInterface>> mutexes;
 };

--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -6,6 +6,7 @@
 
 #include <sys/types.h>
 
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -14,7 +15,7 @@
 #include <vector>
 
 #include "umd/device/types/communication_protocol.hpp"
-#include "umd/device/utils/robust_mutex.hpp"
+#include "umd/device/utils/mutex_interface.hpp"
 
 namespace tt::umd {
 
@@ -38,8 +39,8 @@ enum class MutexType {
 // Name of a mutex type, for logging and diagnostics.
 std::string to_string(MutexType mutex_type);
 
-// Note that the returned std::unique_lock<RobustMutex> should never outlive the LockManager which holds underlying
-// RobustMutexes. Also note that clear_mutex doesn't need to be explicitly called, since the mutexes will all get
+// Note that the returned std::unique_lock<MutexInterface> should never outlive the LockManager which holds
+// underlying mutexes. Also note that clear_mutex doesn't need to be explicitly called, since the mutexes will all get
 // cleared automatically when the LockManager goes out of scope. We could implement these lock such that initialization
 // is not needed, and they are initialized every time they're locked, but since that communicates with the OS filesystem
 // it might be slower do to it each time. This way, locking/unlocking should be faster.
@@ -75,19 +76,19 @@ public:
     // This set of functions is used to manage mutexes which are system wide and not chip specific.
     void initialize_mutex(MutexType mutex_type);
     void clear_mutex(MutexType mutex_type);
-    std::unique_lock<RobustMutex> acquire_mutex(MutexType mutex_type);
+    std::unique_lock<MutexInterface> acquire_mutex(MutexType mutex_type);
 
     // This set of functions is used to manage mutexes which are chip specific.
     void initialize_mutex(MutexType mutex_type, int device_id, IODeviceType device_type = IODeviceType::PCIe);
     void clear_mutex(MutexType mutex_type, int device_id, IODeviceType device_type = IODeviceType::PCIe);
-    std::unique_lock<RobustMutex> acquire_mutex(
+    std::unique_lock<MutexInterface> acquire_mutex(
         MutexType mutex_type, int device_id, IODeviceType device_type = IODeviceType::PCIe);
 
     // This set of functions is used to manage mutexes which are chip specific. This variant accepts custom mutex name.
     void initialize_mutex(
         const std::string& mutex_prefix, int device_id, IODeviceType device_type = IODeviceType::PCIe);
     void clear_mutex(const std::string& mutex_prefix, int device_id, IODeviceType device_type = IODeviceType::PCIe);
-    std::unique_lock<RobustMutex> acquire_mutex(
+    std::unique_lock<MutexInterface> acquire_mutex(
         const std::string& mutex_prefix, int device_id, IODeviceType device_type = IODeviceType::PCIe);
 
     // Reports whether a mutex is currently held, without holding it afterwards. Returns the owning {pid, tid} if it is
@@ -102,13 +103,13 @@ public:
 private:
     void initialize_mutex_internal(const std::string& mutex_name);
     void clear_mutex_internal(const std::string& mutex_name);
-    std::unique_lock<RobustMutex> acquire_mutex_internal(const std::string& mutex_name);
+    std::unique_lock<MutexInterface> acquire_mutex_internal(const std::string& mutex_name);
     std::optional<std::pair<pid_t, pid_t>> probe_mutex_internal(const std::string& mutex_name);
 
     // Maps from mutex name to an initialized mutex.
     // Mutex names are made from mutex type name or directly mutex name combined with device number.
     // Note that once LockManager is out of scope, all the mutexes will be cleared up automatically.
-    std::unordered_map<std::string, RobustMutex> mutexes;
+    std::unordered_map<std::string, std::unique_ptr<MutexInterface>> mutexes;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -90,9 +90,11 @@ public:
     std::unique_lock<RobustMutex> acquire_mutex(
         const std::string& mutex_prefix, int device_id, IODeviceType device_type = IODeviceType::PCIe);
 
-    // Reports whether a mutex is currently held, without holding it afterwards. Returns std::nullopt if the mutex was
-    // free, otherwise the owning {pid, tid}. Since a free mutex has to be acquired to find that out, and is released
-    // again right after, the answer is best effort and may be stale as soon as it is returned.
+    // Reports whether a mutex is currently held, without holding it afterwards. Returns the owning {pid, tid} if it is
+    // held, and std::nullopt if it is not - which covers both a mutex nobody had taken and one whose owner died holding
+    // it, since probing a shared memory mutex recovers it from a dead owner rather than reporting it as held. Since a
+    // free mutex has to be acquired to find that out, and is released again right after, the answer is best effort and
+    // may be stale as soon as it is returned.
     std::optional<std::pair<pid_t, pid_t>> probe_mutex(MutexType mutex_type);
     std::optional<std::pair<pid_t, pid_t>> probe_mutex(
         MutexType mutex_type, int device_id, IODeviceType device_type = IODeviceType::PCIe);

--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -40,9 +40,9 @@ enum class MutexType {
 std::string to_string(MutexType mutex_type);
 
 // Note that the returned std::unique_lock<MutexInterface> should never outlive the LockManager which holds
-// underlying mutexes, which are cleared when the LockManager goes out of scope. We could implement these lock such that
-// initialization is not needed, and they are initialized every time they're locked, but since that communicates with
-// the OS filesystem it might be slower do to it each time. This way, locking/unlocking should be faster.
+// underlying mutexes, which are cleared when the LockManager goes out of scope. We could implement these locks such
+// that initialization is not needed, and they are initialized every time they're locked, but since that communicates
+// with the OS filesystem it might be slower to do it each time. This way, locking/unlocking should be faster.
 class LockManager {
 public:
     // Mutex types that are initialized per chip (combined with device_id + device_type).

--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -6,11 +6,9 @@
 
 #include <sys/types.h>
 
-#include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -39,12 +37,19 @@ enum class MutexType {
 // Name of a mutex type, for logging and diagnostics.
 std::string to_string(MutexType mutex_type);
 
-// Note that the returned std::unique_lock<MutexInterface> should never outlive the LockManager which holds
-// underlying mutexes, which are cleared when the LockManager goes out of scope. We could implement these locks such
-// that initialization is not needed, and they are initialized every time they're locked, but since that communicates
-// with the OS filesystem it might be slower to do it each time. This way, locking/unlocking should be faster.
+// The locks handed out here are process wide, and the underlying ones system wide, so LockManager holds them in a
+// single registry for the whole process rather than one per owner. A lock is initialized once, by whoever needs it
+// first, and lives until the process exits.
+// Besides being the honest model, this bounds how many locks a process can have open at a time. An initialized mutex
+// may hold a file descriptor for as long as it lives, so a registry per owner meant the same lock was opened once per
+// chip, per device and per cluster, and a process working with many chips could run itself out of descriptors.
+// We could implement these locks such that initialization is not needed, and they are initialized every time they're
+// locked, but since that communicates with the OS it might be slower to do it each time. This way, locking/unlocking
+// should be faster.
 class LockManager {
 public:
+    LockManager() = delete;
+
     // Mutex types that are initialized per chip (combined with device_id + device_type).
     inline static const std::vector<MutexType> CHIP_SPECIFIC_MUTEX_TYPES = {
         MutexType::ARC_MSG,
@@ -62,31 +67,27 @@ public:
     };
 
     // This set of functions is used to manage mutexes which are system wide and not chip specific.
-    void initialize_mutex(MutexType mutex_type);
-    std::unique_lock<MutexInterface> acquire_mutex(MutexType mutex_type);
+    static void initialize_mutex(MutexType mutex_type);
+    static std::unique_lock<MutexInterface> acquire_mutex(MutexType mutex_type);
 
     // This set of functions is used to manage mutexes which are chip specific.
-    void initialize_mutex(MutexType mutex_type, int device_id, IODeviceType device_type);
-    std::unique_lock<MutexInterface> acquire_mutex(MutexType mutex_type, int device_id, IODeviceType device_type);
+    static void initialize_mutex(MutexType mutex_type, int device_id, IODeviceType device_type);
+    static std::unique_lock<MutexInterface> acquire_mutex(
+        MutexType mutex_type, int device_id, IODeviceType device_type);
 
     // Reports whether a mutex is currently held, without holding it afterwards. Returns the owning {pid, tid} if it is
     // held, and std::nullopt if it is not - which covers both a mutex nobody had taken and one whose owner died holding
     // it, since probing a shared memory mutex recovers it from a dead owner rather than reporting it as held. Since a
     // free mutex has to be acquired to find that out, and is released again right after, the answer is best effort and
     // may be stale as soon as it is returned.
-    std::optional<std::pair<pid_t, pid_t>> probe_mutex(MutexType mutex_type);
-    std::optional<std::pair<pid_t, pid_t>> probe_mutex(MutexType mutex_type, int device_id, IODeviceType device_type);
+    static std::optional<std::pair<pid_t, pid_t>> probe_mutex(MutexType mutex_type);
+    static std::optional<std::pair<pid_t, pid_t>> probe_mutex(
+        MutexType mutex_type, int device_id, IODeviceType device_type);
 
 private:
-    void initialize_mutex_internal(const std::string& mutex_name);
-    std::unique_lock<MutexInterface> acquire_mutex_internal(const std::string& mutex_name);
-    std::optional<std::pair<pid_t, pid_t>> probe_mutex_internal(const std::string& mutex_name);
-
-    // Maps from mutex name to an initialized mutex.
-    // Mutex names are made from the mutex type name, combined with the device number and device type for chip
-    // specific ones.
-    // Note that once LockManager is out of scope, all the mutexes will be cleared up automatically.
-    std::unordered_map<std::string, std::unique_ptr<MutexInterface>> mutexes;
+    static void initialize_mutex_internal(const std::string& mutex_name);
+    static std::unique_lock<MutexInterface> acquire_mutex_internal(const std::string& mutex_name);
+    static std::optional<std::pair<pid_t, pid_t>> probe_mutex_internal(const std::string& mutex_name);
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/utils/lock_manager.hpp
+++ b/device/api/umd/device/utils/lock_manager.hpp
@@ -49,6 +49,10 @@ std::string to_string(MutexType mutex_type);
 // Locks are only ever added to the registry, never removed, and that is what makes the returned
 // std::unique_lock<MutexInterface> safe to hold for as long as the caller likes: the mutex it refers to stays where it
 // is for the lifetime of the process. Anything that removed locks again would leave every outstanding one dangling.
+//
+// Chip specific locks on a PCIe device are backed by a KMD resource lock, so that processes which share the device but
+// not /dev/shm still serialize against each other. Everything else - system wide locks and locks on a JTAG device - is
+// backed by RobustMutex, since a KMD resource lock exists only per local PCIe device.
 class LockManager {
 public:
     LockManager() = delete;
@@ -88,9 +92,16 @@ public:
         MutexType mutex_type, int device_id, IODeviceType device_type);
 
 private:
-    static void initialize_mutex_internal(const std::string& mutex_name);
-    static std::unique_lock<MutexInterface> acquire_mutex_internal(const std::string& mutex_name);
-    static std::optional<std::pair<pid_t, pid_t>> probe_mutex_internal(const std::string& mutex_name);
+    // Locks backed by a shared memory RobustMutex, addressed by their name.
+    static void initialize_robust_mutex(const std::string& mutex_name);
+    static std::unique_lock<MutexInterface> acquire_robust_mutex(const std::string& mutex_name);
+    static std::optional<std::pair<pid_t, pid_t>> probe_robust_mutex(const std::string& mutex_name);
+
+    // Locks backed by a KMD resource lock on the device owning the lock table. They take the shared memory lock as
+    // well, for as long as clients on an older UMD exist which know only about that one.
+    static void initialize_kmd_mutex(MutexType mutex_type, int pci_device_num);
+    static std::unique_lock<MutexInterface> acquire_kmd_mutex(MutexType mutex_type, int pci_device_num);
+    static std::optional<std::pair<pid_t, pid_t>> probe_kmd_mutex(MutexType mutex_type, int pci_device_num);
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/utils/mutex_interface.hpp
+++ b/device/api/umd/device/utils/mutex_interface.hpp
@@ -17,9 +17,24 @@ namespace tt::umd {
 // backends compare.
 // Implementations meet the C++ BasicLockable requirement, so they work with std::lock_guard and
 // std::unique_lock.
+//
+// What an implementation owes its callers, and what it does not:
+//   - The mutex is not recursive. A thread already holding it must not take it again.
+//   - Misuse is not required to be diagnosed. Taking the lock again from the thread that holds it,
+//     unlocking from a thread that does not hold it, or unlocking twice, may throw, may be ignored, or
+//     may block forever. Which of those happens is not part of this interface, so callers must not
+//     depend on any of them. Taking the lock through std::lock_guard or std::unique_lock avoids all
+//     three.
 class MutexInterface {
 public:
+    MutexInterface() = default;
     virtual ~MutexInterface() = default;
+
+    // Copying through a MutexInterface& would slice, and an implementation holding an OS resource
+    // cannot be copied meaningfully anyway. Deleting these in the implementations does not cover an
+    // assignment made through the interface, which is what callers hold.
+    MutexInterface(const MutexInterface&) = delete;
+    MutexInterface& operator=(const MutexInterface&) = delete;
 
     // Sets up the underlying OS resource. Must be called before any locking operation.
     virtual void initialize() = 0;

--- a/device/api/umd/device/utils/mutex_interface.hpp
+++ b/device/api/umd/device/utils/mutex_interface.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <sys/types.h>  // pid_t
+
+#include <chrono>
+#include <optional>
+#include <utility>
+
+namespace tt::umd {
+
+// Common interface of UMD's cross-process locking backends, so that a lock can be guarded by whichever
+// backend suits it without its users having to know which one. See device/utils/README.md for how the
+// backends compare.
+// Implementations meet the C++ BasicLockable requirement, so they work with std::lock_guard and
+// std::unique_lock.
+class MutexInterface {
+public:
+    virtual ~MutexInterface() = default;
+
+    // Sets up the underlying OS resource. Must be called before any locking operation.
+    virtual void initialize() = 0;
+
+    virtual void lock() = 0;
+
+    virtual void unlock() = 0;
+
+    // Tries to acquire the lock, waiting up to timeout. Returns std::nullopt if the lock was acquired,
+    // otherwise the owning {pid, tid} if the backend can identify the owner, {0, 0} if it cannot.
+    virtual std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout) = 0;
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/utils/robust_mutex.hpp
+++ b/device/api/umd/device/utils/robust_mutex.hpp
@@ -16,6 +16,8 @@
 #include <string_view>
 #include <utility>
 
+#include "umd/device/utils/mutex_interface.hpp"
+
 namespace tt::umd {
 
 // RobustMutex is a class that provides a robust locking mechanism using POSIX shared memory mutexes.
@@ -25,7 +27,7 @@ namespace tt::umd {
 // Note that the implementation relies on the client not deleting underlying /dev/shm files.
 // Also, if the pthread implementation changes, we can enter some weird states if one process is holding the old mutex,
 // and the new one tries to initialize it with the new pthread.
-class RobustMutex {
+class RobustMutex : public MutexInterface {
 public:
     // Prefix used for shared memory files backing each mutex.
     static constexpr std::string_view SHM_FILE_PREFIX = "TT_UMD_LOCK.";
@@ -37,7 +39,7 @@ public:
     // The initialization can fail and throw an exception. In case of failure we still want to clean up the resources.
     // For easier handling of such case, the destructor cleans up the resources if they were taken. Having this code out
     // of constructor will guarantee that the destructor is called in case of exception.
-    void initialize();
+    void initialize() override;
 
     // Move constructor and assignment are defined so that this class can be used with c++ stl containers, like
     // unordered_map.
@@ -50,10 +52,10 @@ public:
 
     // Locks the mutex, blocking indefinitely.  Uses a 1-second timed attempt first so that a
     // warning can be emitted when the lock is contended before blocking without a timeout.
-    void lock();
+    void lock() override;
 
     // Unlocks the mutex.
-    void unlock();
+    void unlock() override;
 
     // Attempts to acquire the lock and returns immediately if timeout is zero (default), or waits
     // up to `timeout` seconds before giving up.
@@ -63,7 +65,7 @@ public:
     // Note: the returned PID/TID pair is a snapshot that may already be stale, since there is a race condition inherent
     // in trying to inspect a lock without acquiring it. So consider the information best-effort and for debugging
     // purposes only.
-    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout = std::chrono::seconds(0));
+    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout = std::chrono::seconds(0)) override;
 
 private:
     // A wrapper which holds the flag for whether the mutex has been initialized or not,

--- a/device/api/umd/device/utils/robust_mutex.hpp
+++ b/device/api/umd/device/utils/robust_mutex.hpp
@@ -65,7 +65,7 @@ public:
     // Note: the returned PID/TID pair is a snapshot that may already be stale, since there is a race condition inherent
     // in trying to inspect a lock without acquiring it. So consider the information best-effort and for debugging
     // purposes only.
-    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout = std::chrono::seconds(0)) override;
+    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout) override;
 
 private:
     // A wrapper which holds the flag for whether the mutex has been initialized or not,

--- a/device/arc/arc_messenger.cpp
+++ b/device/arc/arc_messenger.cpp
@@ -50,17 +50,4 @@ uint32_t ArcMessenger::send_message(
     return send_message(msg_code, return_values, args, timeout_ms);
 }
 
-// The mutex clearing below is commented out to avoid a segfault, and is going away shortly in a
-// separate PR. On a remote device get_communication_device_type() reaches through to the local device
-// it is routed through, which teardown does not keep alive: a caller that drops TopologyDiscovery's
-// device map destroys the two in unspecified order. LockManager documents that clear_mutex need not
-// be called explicitly anyway.
-//     lock_manager.clear_mutex(
-//         MutexType::ARC_MSG, tt_device->get_communication_device_id(), tt_device->get_communication_device_type());
-//     lock_manager.clear_mutex(
-//         MutexType::REMOTE_ARC_MSG,
-//         tt_device->get_communication_device_id(),
-//         tt_device->get_communication_device_type());
-ArcMessenger::~ArcMessenger() = default;
-
 }  // namespace tt::umd

--- a/device/arc/arc_messenger.cpp
+++ b/device/arc/arc_messenger.cpp
@@ -34,14 +34,14 @@ std::unique_ptr<ArcMessenger> ArcMessenger::create_arc_messenger(TTDevice* tt_de
 }
 
 ArcMessenger::ArcMessenger(TTDevice* tt_device) : tt_device(tt_device) {
-    lock_manager.initialize_mutex(
+    LockManager::initialize_mutex(
         MutexType::ARC_MSG, tt_device->get_communication_device_id(), tt_device->get_communication_device_type());
-    lock_manager.initialize_mutex(
+    LockManager::initialize_mutex(
         MutexType::REMOTE_ARC_MSG,
         tt_device->get_communication_device_id(),
         tt_device->get_communication_device_type());
     // TODO: Remove this once we have proper mutex usage.
-    lock_manager.initialize_mutex(MutexType::ARC_MSG);
+    LockManager::initialize_mutex(MutexType::ARC_MSG);
 }
 
 uint32_t ArcMessenger::send_message(

--- a/device/arc/blackhole_arc_messenger.cpp
+++ b/device/arc/blackhole_arc_messenger.cpp
@@ -42,7 +42,7 @@ uint32_t BlackholeArcMessenger::send_message(
     std::vector<uint32_t>& return_values,
     const std::vector<uint32_t>& args,
     const std::chrono::milliseconds timeout_ms) {
-    auto lock = lock_manager.acquire_mutex(
+    auto lock = LockManager::acquire_mutex(
         MutexType::ARC_MSG, tt_device->get_communication_device_id(), tt_device->get_communication_device_type());
     uint32_t exit_code = blackhole_arc_msg_queue->send_message(
         (ArcMessageType)msg_code, return_values, args, timeout_ms, get_selected_noc_id());

--- a/device/arc/blackhole_arc_messenger.cpp
+++ b/device/arc/blackhole_arc_messenger.cpp
@@ -42,7 +42,8 @@ uint32_t BlackholeArcMessenger::send_message(
     std::vector<uint32_t>& return_values,
     const std::vector<uint32_t>& args,
     const std::chrono::milliseconds timeout_ms) {
-    auto lock = lock_manager.acquire_mutex(MutexType::ARC_MSG, tt_device->get_pci_device()->get_device_num());
+    auto lock = lock_manager.acquire_mutex(
+        MutexType::ARC_MSG, tt_device->get_pci_device()->get_device_num(), IODeviceType::PCIe);
     uint32_t exit_code = blackhole_arc_msg_queue->send_message(
         (ArcMessageType)msg_code, return_values, args, timeout_ms, get_selected_noc_id());
     log_debug(

--- a/device/arc/blackhole_arc_messenger.cpp
+++ b/device/arc/blackhole_arc_messenger.cpp
@@ -43,7 +43,7 @@ uint32_t BlackholeArcMessenger::send_message(
     const std::vector<uint32_t>& args,
     const std::chrono::milliseconds timeout_ms) {
     auto lock = lock_manager.acquire_mutex(
-        MutexType::ARC_MSG, tt_device->get_pci_device()->get_device_num(), IODeviceType::PCIe);
+        MutexType::ARC_MSG, tt_device->get_communication_device_id(), tt_device->get_communication_device_type());
     uint32_t exit_code = blackhole_arc_msg_queue->send_message(
         (ArcMessageType)msg_code, return_values, args, timeout_ms, get_selected_noc_id());
     log_debug(

--- a/device/arc/wormhole_arc_messenger.cpp
+++ b/device/arc/wormhole_arc_messenger.cpp
@@ -70,18 +70,18 @@ uint32_t WormholeArcMessenger::send_message(
     // Caveat: two different local chips talking to the same remote chip are not serialized against each other (e.g.
     // parallel topology discovery reaching one remote chip through different local chips). This is accepted for now;
     // proper serialization requires a unique remote chip id rather than keying on the local communication device.
-    auto lock = tt_device->is_remote() ? lock_manager.acquire_mutex(
+    auto lock = tt_device->is_remote() ? LockManager::acquire_mutex(
                                              MutexType::REMOTE_ARC_MSG,
                                              tt_device->get_communication_device_id(),
                                              tt_device->get_communication_device_type())
-                                       : lock_manager.acquire_mutex(
+                                       : LockManager::acquire_mutex(
                                              MutexType::ARC_MSG,
                                              tt_device->get_communication_device_id(),
                                              tt_device->get_communication_device_type());
     // TODO: This lock is deprecated, and will be removed once all clients update the code and start locking using the
     // locks above. This prevents a potential intermediary bug where two clients running on different UMD versions are
     // not synchronizing on the same lock.
-    auto lock_global = lock_manager.acquire_mutex(MutexType::ARC_MSG);
+    auto lock_global = LockManager::acquire_mutex(MutexType::ARC_MSG);
 
     uint32_t fw_arg = arg0 | (arg1 << 16);
     int exit_code = 0;

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -99,14 +99,14 @@ void LocalChip::initialize_default_chip_mutexes() {
     // Initialize non-MMIO mutexes for WH devices regardless of number of chips, since these may be used for
     // ethernet broadcast
     if (tt_device_->get_arch() == tt::ARCH::WORMHOLE_B0) {
-        lock_manager_.initialize_mutex(MutexType::REMOTE_ARC_MSG, pci_device_id);
+        lock_manager_.initialize_mutex(MutexType::REMOTE_ARC_MSG, pci_device_id, IODeviceType::PCIe);
     }
 
     // Initialize interprocess mutexes to make host -> device memory barriers atomic.
-    lock_manager_.initialize_mutex(MutexType::MEM_BARRIER, pci_device_id);
+    lock_manager_.initialize_mutex(MutexType::MEM_BARRIER, pci_device_id, IODeviceType::PCIe);
 
     // Initialize mutex guarding initialized chips.
-    lock_manager_.initialize_mutex(MutexType::CHIP_IN_USE, pci_device_id);
+    lock_manager_.initialize_mutex(MutexType::CHIP_IN_USE, pci_device_id, IODeviceType::PCIe);
 }
 
 void LocalChip::initialize_membars(uint32_t dram_subchannel) {
@@ -145,8 +145,8 @@ void LocalChip::start_device(uint32_t dram_membar_subchannel) {
 
     // TODO: acquire mutex should live in Chip class. Currently we don't have unique id for all chips.
     // The lock here should suffice since we have to open Local chip to have Remote chips initialized.
-    chip_started_lock_.emplace(
-        lock_manager_.acquire_mutex(MutexType::CHIP_IN_USE, tt_device_->get_pci_device()->get_device_num()));
+    chip_started_lock_.emplace(lock_manager_.acquire_mutex(
+        MutexType::CHIP_IN_USE, tt_device_->get_pci_device()->get_device_num(), IODeviceType::PCIe));
 
     sysmem_manager_->pin_or_map_sysmem_to_device();
     initialize_membars(dram_membar_subchannel);
@@ -434,7 +434,8 @@ void LocalChip::set_membar_flag(
 
 void LocalChip::insert_host_to_device_barrier(const std::vector<CoreCoord>& cores, const uint32_t barrier_addr) {
     // Ensure that this memory barrier is atomic across processes/threads.
-    auto lock = lock_manager_.acquire_mutex(MutexType::MEM_BARRIER, tt_device_->get_pci_device()->get_device_num());
+    auto lock = lock_manager_.acquire_mutex(
+        MutexType::MEM_BARRIER, tt_device_->get_pci_device()->get_device_num(), IODeviceType::PCIe);
     set_membar_flag(cores, MemBarFlag::SET, barrier_addr);
     set_membar_flag(cores, MemBarFlag::RESET, barrier_addr);
 }

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -100,14 +100,14 @@ void LocalChip::initialize_default_chip_mutexes() {
     // Initialize non-MMIO mutexes for WH devices regardless of number of chips, since these may be used for
     // ethernet broadcast
     if (tt_device_->get_arch() == tt::ARCH::WORMHOLE_B0) {
-        lock_manager_.initialize_mutex(MutexType::REMOTE_ARC_MSG, device_id, device_type);
+        LockManager::initialize_mutex(MutexType::REMOTE_ARC_MSG, device_id, device_type);
     }
 
     // Initialize interprocess mutexes to make host -> device memory barriers atomic.
-    lock_manager_.initialize_mutex(MutexType::MEM_BARRIER, device_id, device_type);
+    LockManager::initialize_mutex(MutexType::MEM_BARRIER, device_id, device_type);
 
     // Initialize mutex guarding initialized chips.
-    lock_manager_.initialize_mutex(MutexType::CHIP_IN_USE, device_id, device_type);
+    LockManager::initialize_mutex(MutexType::CHIP_IN_USE, device_id, device_type);
 }
 
 void LocalChip::initialize_membars(uint32_t dram_subchannel) {
@@ -146,7 +146,7 @@ void LocalChip::start_device(uint32_t dram_membar_subchannel) {
 
     // TODO: acquire mutex should live in Chip class. Currently we don't have unique id for all chips.
     // The lock here should suffice since we have to open Local chip to have Remote chips initialized.
-    chip_started_lock_.emplace(lock_manager_.acquire_mutex(
+    chip_started_lock_.emplace(LockManager::acquire_mutex(
         MutexType::CHIP_IN_USE,
         tt_device_->get_communication_device_id(),
         tt_device_->get_communication_device_type()));
@@ -437,7 +437,7 @@ void LocalChip::set_membar_flag(
 
 void LocalChip::insert_host_to_device_barrier(const std::vector<CoreCoord>& cores, const uint32_t barrier_addr) {
     // Ensure that this memory barrier is atomic across processes/threads.
-    auto lock = lock_manager_.acquire_mutex(
+    auto lock = LockManager::acquire_mutex(
         MutexType::MEM_BARRIER, tt_device_->get_communication_device_id(), tt_device_->get_communication_device_type());
     set_membar_flag(cores, MemBarFlag::SET, barrier_addr);
     set_membar_flag(cores, MemBarFlag::RESET, barrier_addr);

--- a/device/chip/local_chip.cpp
+++ b/device/chip/local_chip.cpp
@@ -94,19 +94,20 @@ void LocalChip::initialize_default_chip_mutexes() {
     // time here (during device init) since it's unsafe to modify shared state during multithreaded runtime.
     // cleanup_mutexes_in_shm is tied to clean_system_resources from the constructor. The main process is
     // responsible for initializing the driver with this field set to cleanup after an aborted process.
-    int pci_device_id = tt_device_->get_pci_device()->get_device_num();
+    int device_id = tt_device_->get_communication_device_id();
+    IODeviceType device_type = tt_device_->get_communication_device_type();
 
     // Initialize non-MMIO mutexes for WH devices regardless of number of chips, since these may be used for
     // ethernet broadcast
     if (tt_device_->get_arch() == tt::ARCH::WORMHOLE_B0) {
-        lock_manager_.initialize_mutex(MutexType::REMOTE_ARC_MSG, pci_device_id, IODeviceType::PCIe);
+        lock_manager_.initialize_mutex(MutexType::REMOTE_ARC_MSG, device_id, device_type);
     }
 
     // Initialize interprocess mutexes to make host -> device memory barriers atomic.
-    lock_manager_.initialize_mutex(MutexType::MEM_BARRIER, pci_device_id, IODeviceType::PCIe);
+    lock_manager_.initialize_mutex(MutexType::MEM_BARRIER, device_id, device_type);
 
     // Initialize mutex guarding initialized chips.
-    lock_manager_.initialize_mutex(MutexType::CHIP_IN_USE, pci_device_id, IODeviceType::PCIe);
+    lock_manager_.initialize_mutex(MutexType::CHIP_IN_USE, device_id, device_type);
 }
 
 void LocalChip::initialize_membars(uint32_t dram_subchannel) {
@@ -146,7 +147,9 @@ void LocalChip::start_device(uint32_t dram_membar_subchannel) {
     // TODO: acquire mutex should live in Chip class. Currently we don't have unique id for all chips.
     // The lock here should suffice since we have to open Local chip to have Remote chips initialized.
     chip_started_lock_.emplace(lock_manager_.acquire_mutex(
-        MutexType::CHIP_IN_USE, tt_device_->get_pci_device()->get_device_num(), IODeviceType::PCIe));
+        MutexType::CHIP_IN_USE,
+        tt_device_->get_communication_device_id(),
+        tt_device_->get_communication_device_type()));
 
     sysmem_manager_->pin_or_map_sysmem_to_device();
     initialize_membars(dram_membar_subchannel);
@@ -435,7 +438,7 @@ void LocalChip::set_membar_flag(
 void LocalChip::insert_host_to_device_barrier(const std::vector<CoreCoord>& cores, const uint32_t barrier_addr) {
     // Ensure that this memory barrier is atomic across processes/threads.
     auto lock = lock_manager_.acquire_mutex(
-        MutexType::MEM_BARRIER, tt_device_->get_pci_device()->get_device_num(), IODeviceType::PCIe);
+        MutexType::MEM_BARRIER, tt_device_->get_communication_device_id(), tt_device_->get_communication_device_type());
     set_membar_flag(cores, MemBarFlag::SET, barrier_addr);
     set_membar_flag(cores, MemBarFlag::RESET, barrier_addr);
 }

--- a/device/tt_device/firmware/blackhole_device_firmware.cpp
+++ b/device/tt_device/firmware/blackhole_device_firmware.cpp
@@ -22,8 +22,8 @@
 #include "umd/device/types/blackhole_arc.hpp"
 #include "umd/device/types/blackhole_eth.hpp"
 #include "umd/device/types/telemetry.hpp"
-#include "umd/device/utils/lock_manager.hpp"
 #include "umd/device/utils/common.hpp"
+#include "umd/device/utils/lock_manager.hpp"
 #include "utils.hpp"
 
 namespace tt::umd {

--- a/device/tt_device/firmware/blackhole_device_firmware.cpp
+++ b/device/tt_device/firmware/blackhole_device_firmware.cpp
@@ -22,6 +22,7 @@
 #include "umd/device/types/blackhole_arc.hpp"
 #include "umd/device/types/blackhole_eth.hpp"
 #include "umd/device/types/telemetry.hpp"
+#include "umd/device/utils/lock_manager.hpp"
 #include "umd/device/utils/common.hpp"
 #include "utils.hpp"
 
@@ -59,7 +60,7 @@ BlackholeDeviceFirmware::BlackholeDeviceFirmware(
 
     // acquire_mutex() throws unless the mutex was initialized first, so claim it up front the way
     // ArcMessenger's constructor does.
-    lock_manager_.initialize_mutex(MutexType::ARC_MSG, device_id_, get_io_device_type());
+    LockManager::initialize_mutex(MutexType::ARC_MSG, device_id_, get_io_device_type());
 
     // Resolve both ARC coordinates once. The NOC translation state they depend on is fixed for the
     // device's lifetime and is read over BAR/JTAG, so this does not need the firmware to be up.
@@ -123,7 +124,7 @@ void BlackholeDeviceFirmware::init_firmware(std::chrono::milliseconds timeout_ms
 DeviceCommandResult BlackholeDeviceFirmware::send_device_command(
     uint32_t msg_code, const std::vector<uint32_t>& args, std::chrono::milliseconds timeout, NocId noc_id) {
     // Serializes against other processes messaging the same device's ARC.
-    auto lock = lock_manager_.acquire_mutex(MutexType::ARC_MSG, device_id_, get_io_device_type());
+    auto lock = LockManager::acquire_mutex(MutexType::ARC_MSG, device_id_, get_io_device_type());
 
     if (arc_msg_queue_ == nullptr) {
         UMD_THROW(error::RuntimeError, "ARC message queue is unavailable because init_firmware() has not been run.");

--- a/device/tt_device/firmware/wormhole_device_firmware.cpp
+++ b/device/tt_device/firmware/wormhole_device_firmware.cpp
@@ -20,6 +20,7 @@
 #include "umd/device/tt_device/protocol/remote_interface.hpp"
 #include "umd/device/tt_device/tt_device_error.hpp"
 #include "umd/device/types/wormhole_eth.hpp"
+#include "umd/device/utils/lock_manager.hpp"
 #include "umd/device/utils/common.hpp"
 #include "utils.hpp"
 
@@ -51,7 +52,7 @@ WormholeDeviceFirmware::WormholeDeviceFirmware(
     // several topology discovery instances can reach the same remote chip through different local
     // chips, so a per-device lock would let concurrent messages interleave on that chip. This mirrors
     // WormholeArcMessenger::send_message and the TODO recorded there.
-    lock_manager_.initialize_mutex(MutexType::ARC_MSG);
+    LockManager::initialize_mutex(MutexType::ARC_MSG);
 
     // The ARC core is at a fixed NOC0 coordinate on Wormhole, so both coordinates are known without
     // reading anything from the device.
@@ -217,7 +218,7 @@ DeviceCommandResult WormholeDeviceFirmware::send_device_command(
 
     // Serializes against other processes messaging any device's ARC; see the constructor for why the
     // lock is system-wide on Wormhole.
-    auto lock = lock_manager_.acquire_mutex(MutexType::ARC_MSG);
+    auto lock = LockManager::acquire_mutex(MutexType::ARC_MSG);
 
     uint32_t fw_arg = arg0 | (arg1 << 16);
     write_to_arc_apb(&fw_arg, wormhole::ARC_RESET_SCRATCH_RES0_OFFSET, sizeof(uint32_t), noc_id);

--- a/device/tt_device/firmware/wormhole_device_firmware.cpp
+++ b/device/tt_device/firmware/wormhole_device_firmware.cpp
@@ -20,8 +20,8 @@
 #include "umd/device/tt_device/protocol/remote_interface.hpp"
 #include "umd/device/tt_device/tt_device_error.hpp"
 #include "umd/device/types/wormhole_eth.hpp"
-#include "umd/device/utils/lock_manager.hpp"
 #include "umd/device/utils/common.hpp"
+#include "umd/device/utils/lock_manager.hpp"
 #include "utils.hpp"
 
 namespace tt::umd {

--- a/device/tt_device/remote_communication.cpp
+++ b/device/tt_device/remote_communication.cpp
@@ -20,7 +20,10 @@ namespace tt::umd {
 
 RemoteCommunication::RemoteCommunication(TTDevice* local_tt_device, SysmemManager* sysmem_manager) :
     local_tt_device_(local_tt_device), sysmem_manager_(sysmem_manager) {
-    lock_manager_.initialize_mutex(MutexType::NON_MMIO, local_tt_device->get_communication_device_id());
+    lock_manager_.initialize_mutex(
+        MutexType::NON_MMIO,
+        local_tt_device->get_communication_device_id(),
+        local_tt_device->get_communication_device_type());
 }
 
 std::unique_ptr<RemoteCommunication> RemoteCommunication::create_remote_communication(

--- a/device/tt_device/remote_communication.cpp
+++ b/device/tt_device/remote_communication.cpp
@@ -20,7 +20,7 @@ namespace tt::umd {
 
 RemoteCommunication::RemoteCommunication(TTDevice* local_tt_device, SysmemManager* sysmem_manager) :
     local_tt_device_(local_tt_device), sysmem_manager_(sysmem_manager) {
-    lock_manager_.initialize_mutex(
+    LockManager::initialize_mutex(
         MutexType::NON_MMIO,
         local_tt_device->get_communication_device_id(),
         local_tt_device->get_communication_device_type());

--- a/device/tt_device/remote_communication_legacy_firmware.cpp
+++ b/device/tt_device/remote_communication_legacy_firmware.cpp
@@ -119,7 +119,7 @@ void RemoteCommunicationLegacyFirmware::read_non_mmio(
     uint64_t core_src,
     uint32_t size_in_bytes,
     const std::chrono::milliseconds timeout_ms) {
-    auto lock = lock_manager_.acquire_mutex(
+    auto lock = LockManager::acquire_mutex(
         MutexType::NON_MMIO,
         local_tt_device_->get_communication_device_id(),
         local_tt_device_->get_communication_device_type());
@@ -385,7 +385,7 @@ void RemoteCommunicationLegacyFirmware::write_to_non_mmio(
     bool broadcast,
     std::vector<int> broadcast_header,
     const std::chrono::milliseconds timeout_ms) {
-    auto lock = lock_manager_.acquire_mutex(
+    auto lock = LockManager::acquire_mutex(
         MutexType::NON_MMIO,
         local_tt_device_->get_communication_device_id(),
         local_tt_device_->get_communication_device_type());

--- a/device/tt_device/remote_communication_legacy_firmware.cpp
+++ b/device/tt_device/remote_communication_legacy_firmware.cpp
@@ -119,7 +119,10 @@ void RemoteCommunicationLegacyFirmware::read_non_mmio(
     uint64_t core_src,
     uint32_t size_in_bytes,
     const std::chrono::milliseconds timeout_ms) {
-    auto lock = lock_manager_.acquire_mutex(MutexType::NON_MMIO, local_tt_device_->get_communication_device_id());
+    auto lock = lock_manager_.acquire_mutex(
+        MutexType::NON_MMIO,
+        local_tt_device_->get_communication_device_id(),
+        local_tt_device_->get_communication_device_type());
 
     using data_word_t = uint32_t;
     constexpr int DATA_WORD_SIZE = sizeof(data_word_t);
@@ -382,7 +385,10 @@ void RemoteCommunicationLegacyFirmware::write_to_non_mmio(
     bool broadcast,
     std::vector<int> broadcast_header,
     const std::chrono::milliseconds timeout_ms) {
-    auto lock = lock_manager_.acquire_mutex(MutexType::NON_MMIO, local_tt_device_->get_communication_device_id());
+    auto lock = lock_manager_.acquire_mutex(
+        MutexType::NON_MMIO,
+        local_tt_device_->get_communication_device_id(),
+        local_tt_device_->get_communication_device_type());
     flush_non_mmio_ = true;
 
     using data_word_t = uint32_t;

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -71,7 +71,7 @@ constexpr double AICLK_TOLERANCE_PERCENT = 5.0;
 TTDevice::TTDevice(std::unique_ptr<TTDeviceModel> model) : model_(std::move(model)) {
     if (model_->get_pcie_interface() != nullptr) {
         // Initialize PCIe DMA mutex through LockManager for cross-process synchronization.
-        lock_manager.initialize_mutex(
+        LockManager::initialize_mutex(
             MutexType::PCIE_DMA, get_communication_device_id(), get_communication_device_type());
     }
     wire_hang_detector();
@@ -730,7 +730,7 @@ void TTDevice::dma_write(const void *src, uint64_t dst_addr, size_t size, CoreCo
         UMD_THROW(error::RuntimeError, "DMA write not supported for remote device.");
     }
     auto pcie_dma_lock =
-        lock_manager.acquire_mutex(MutexType::PCIE_DMA, get_communication_device_id(), get_communication_device_type());
+        LockManager::acquire_mutex(MutexType::PCIE_DMA, get_communication_device_id(), get_communication_device_type());
 
     // Returns true if DMA transfer succeeded, false if DMA is not available.
     bool dma_success = get_dma_interface()->dma_write(src, dst_addr, size, resolve_coordinate(core, noc_id), noc_id);
@@ -749,7 +749,7 @@ void TTDevice::dma_read(void *dst, uint64_t src_addr, size_t size, CoreCoord cor
         UMD_THROW(error::RuntimeError, "DMA read from device not supported for remote device.");
     }
     auto pcie_dma_lock =
-        lock_manager.acquire_mutex(MutexType::PCIE_DMA, get_communication_device_id(), get_communication_device_type());
+        LockManager::acquire_mutex(MutexType::PCIE_DMA, get_communication_device_id(), get_communication_device_type());
 
     // Returns true if DMA transfer succeeded, false if DMA is not available.
     bool dma_success = get_dma_interface()->dma_read(dst, src_addr, size, resolve_coordinate(core, noc_id), noc_id);
@@ -769,7 +769,7 @@ void TTDevice::dma_write_to_core_range(
         UMD_THROW(error::RuntimeError, "DMA write to core range not supported for remote device.");
     }
     auto pcie_dma_lock =
-        lock_manager.acquire_mutex(MutexType::PCIE_DMA, get_communication_device_id(), get_communication_device_type());
+        LockManager::acquire_mutex(MutexType::PCIE_DMA, get_communication_device_id(), get_communication_device_type());
 
     // Returns true if DMA transfer succeeded, false if DMA is not available.
     bool dma_success = get_dma_interface()->dma_multicast_write(
@@ -790,7 +790,7 @@ void TTDevice::dma_read_zero_copy(uint64_t dst_iova, uint64_t src_addr, size_t s
         UMD_THROW(error::RuntimeError, "DMA zero-copy read not supported for remote device.");
     }
     auto pcie_dma_lock =
-        lock_manager.acquire_mutex(MutexType::PCIE_DMA, get_communication_device_id(), get_communication_device_type());
+        LockManager::acquire_mutex(MutexType::PCIE_DMA, get_communication_device_id(), get_communication_device_type());
 
     bool dma_success =
         get_dma_interface()->dma_read_zero_copy(dst_iova, src_addr, size, resolve_coordinate(core, noc_id), noc_id);
@@ -805,7 +805,7 @@ void TTDevice::dma_write_zero_copy(uint64_t src_iova, uint64_t dst_addr, size_t 
         UMD_THROW(error::RuntimeError, "DMA zero-copy write not supported for remote device.");
     }
     auto pcie_dma_lock =
-        lock_manager.acquire_mutex(MutexType::PCIE_DMA, get_communication_device_id(), get_communication_device_type());
+        LockManager::acquire_mutex(MutexType::PCIE_DMA, get_communication_device_id(), get_communication_device_type());
 
     bool dma_success =
         get_dma_interface()->dma_write_zero_copy(src_iova, dst_addr, size, resolve_coordinate(core, noc_id), noc_id);

--- a/device/utils/README.md
+++ b/device/utils/README.md
@@ -50,11 +50,9 @@ convention for ERISC cores; use higher indices for general coordination.
 - Coordination **without** a shared filesystem (e.g. across containers that only share the device) →
   `KmdMutex`, accepting the per-device scope.
 
-`LockManager` makes this choice for UMD's own locks. A chip specific lock on a PCIe device takes both:
-the KMD lock is the one that works across containers, and the shared memory lock is kept for as long
-as clients on an older UMD exist, since those take only that one and would otherwise not serialize
-against a process on this one. System wide locks and locks on a JTAG device use `RobustMutex` alone,
-since a KMD resource lock exists only per local PCIe device.
+`LockManager` makes this choice for UMD's own locks: a chip specific lock on a PCIe device uses
+`KmdMutex`, so that processes sharing only the device still serialize. System wide locks and locks on
+a JTAG device use `RobustMutex`, since a KMD resource lock exists only per local PCIe device.
 
 ## Benchmark
 

--- a/device/utils/README.md
+++ b/device/utils/README.md
@@ -50,6 +50,12 @@ convention for ERISC cores; use higher indices for general coordination.
 - Coordination **without** a shared filesystem (e.g. across containers that only share the device) →
   `KmdMutex`, accepting the per-device scope.
 
+`LockManager` makes this choice for UMD's own locks. A chip specific lock on a PCIe device takes both:
+the KMD lock is the one that works across containers, and the shared memory lock is kept for as long
+as clients on an older UMD exist, since those take only that one and would otherwise not serialize
+against a process on this one. System wide locks and locks on a JTAG device use `RobustMutex` alone,
+since a KMD resource lock exists only per local PCIe device.
+
 ## Benchmark
 
 Relative performance can be measured with the locks microbenchmark

--- a/device/utils/README.md
+++ b/device/utils/README.md
@@ -1,9 +1,9 @@
 # UMD locking backends
 
 UMD provides two cross-process lock implementations. They expose the same small interface
-(`initialize()`, `lock()`, `try_lock()`, `unlock()`, `probe_lock()`) and meet the C++ `Lockable`
-requirement, so they work with `std::lock_guard` / `std::unique_lock` and can be swapped for one
-another. They differ in *how* processes find each other and in the performance/robustness trade-off.
+(`initialize()`, `lock()`, `unlock()`, `probe_lock()`, gathered in `MutexInterface`) and meet the C++
+`BasicLockable` requirement, so they work with `std::lock_guard` / `std::unique_lock` and can be
+swapped for one another. `KmdMutex` additionally offers `try_lock()`. They differ in *how* processes find each other and in the performance/robustness trade-off.
 
 | Backend | Mechanism | Coordination requires | Lock/unlock cost | Crash-robust | Scope |
 |---|---|---|---|---|---|

--- a/device/utils/lock_manager.cpp
+++ b/device/utils/lock_manager.cpp
@@ -55,70 +55,6 @@ uint8_t get_kmd_lock_index(MutexType mutex_type) {
     return it->second;
 }
 
-// Holds two mutexes as one. This exists only for the move from shared memory locks to KMD resource locks: a process
-// running an older UMD takes the shared memory lock alone and knows nothing about the KMD one, so during the
-// transition both have to be taken or the two processes would not serialize. Once every client takes KMD locks, the
-// shared memory half can go and the KMD mutex can be used on its own.
-// The two are always taken in the same order, which is what keeps processes taking both from deadlocking against each
-// other.
-class CompositeMutex : public MutexInterface {
-public:
-    CompositeMutex(std::unique_ptr<MutexInterface> first, std::unique_ptr<MutexInterface> second) :
-        first_(std::move(first)), second_(std::move(second)) {}
-
-    void initialize() override {
-        first_->initialize();
-        second_->initialize();
-    }
-
-    // The first one is given back whenever taking the second does not work out, whether it reports the lock as taken
-    // or throws. Otherwise it would stay held for the lifetime of the process: the caller never receives a
-    // std::unique_lock when the constructor's lock() throws, so nothing is left to release it, and the shared memory
-    // half only recovers itself when its holder dies.
-    void lock() override {
-        first_->lock();
-        try {
-            second_->lock();
-        } catch (...) {
-            first_->unlock();
-            throw;
-        }
-    }
-
-    void unlock() override {
-        try {
-            second_->unlock();
-        } catch (...) {
-            first_->unlock();
-            throw;
-        }
-        first_->unlock();
-    }
-
-    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout) override {
-        std::optional<std::pair<pid_t, pid_t>> owner = first_->probe_lock(timeout);
-        if (owner.has_value()) {
-            return owner;
-        }
-
-        // Probing acquired the first one.
-        try {
-            owner = second_->probe_lock(timeout);
-        } catch (...) {
-            first_->unlock();
-            throw;
-        }
-        if (owner.has_value()) {
-            first_->unlock();
-        }
-        return owner;
-    }
-
-private:
-    std::unique_ptr<MutexInterface> first_;
-    std::unique_ptr<MutexInterface> second_;
-};
-
 // Every mutex UMD has initialized, keyed by name. Names are made from the mutex type name, combined with the device
 // number for chip specific ones.
 struct MutexRegistry {
@@ -233,14 +169,9 @@ std::optional<std::pair<pid_t, pid_t>> LockManager::probe_robust_mutex(const std
 }
 
 void LockManager::initialize_kmd_mutex(MutexType mutex_type, int pci_device_num) {
-    // Registered under the name its shared memory half keeps, so that a process on an older UMD, which takes only that
-    // half, contends on the very same lock.
-    std::string mutex_name = get_mutex_name(mutex_type, pci_device_num, IODeviceType::PCIe);
     add_mutex(
-        mutex_name,
-        std::make_unique<CompositeMutex>(
-            std::make_unique<RobustMutex>(mutex_name),
-            std::make_unique<KmdMutex>(pci_device_num, get_kmd_lock_index(mutex_type))));
+        get_mutex_name(mutex_type, pci_device_num, IODeviceType::PCIe),
+        std::make_unique<KmdMutex>(pci_device_num, get_kmd_lock_index(mutex_type)));
 }
 
 std::unique_lock<MutexInterface> LockManager::acquire_kmd_mutex(MutexType mutex_type, int pci_device_num) {

--- a/device/utils/lock_manager.cpp
+++ b/device/utils/lock_manager.cpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/robust_mutex.hpp"
 
 namespace tt::umd {
 
@@ -33,11 +34,11 @@ void LockManager::clear_mutex(MutexType mutex_type, int device_id, IODeviceType 
     clear_mutex_internal(mutex_name);
 }
 
-std::unique_lock<RobustMutex> LockManager::acquire_mutex(MutexType mutex_type) {
+std::unique_lock<MutexInterface> LockManager::acquire_mutex(MutexType mutex_type) {
     return acquire_mutex_internal(MUTEX_TYPE_TO_STRING.at(mutex_type));
 }
 
-std::unique_lock<RobustMutex> LockManager::acquire_mutex(
+std::unique_lock<MutexInterface> LockManager::acquire_mutex(
     MutexType mutex_type, int device_id, IODeviceType device_type) {
     std::string mutex_name = MUTEX_TYPE_TO_STRING.at(mutex_type) + "_" + std::to_string(device_id) + "_" +
                              DeviceTypeToString.at(device_type);
@@ -54,7 +55,7 @@ void LockManager::clear_mutex(const std::string& mutex_prefix, int device_id, IO
     clear_mutex_internal(mutex_name);
 }
 
-std::unique_lock<RobustMutex> LockManager::acquire_mutex(
+std::unique_lock<MutexInterface> LockManager::acquire_mutex(
     const std::string& mutex_prefix, int device_id, IODeviceType device_type) {
     std::string mutex_name = mutex_prefix + "_" + std::to_string(device_id) + "_" + DeviceTypeToString.at(device_type);
     return acquire_mutex_internal(mutex_name);
@@ -77,8 +78,9 @@ void LockManager::initialize_mutex_internal(const std::string& mutex_name) {
         return;
     }
 
-    mutexes.emplace(mutex_name, RobustMutex(mutex_name));
-    mutexes.at(mutex_name).initialize();
+    std::unique_ptr<MutexInterface> mutex = std::make_unique<RobustMutex>(mutex_name);
+    mutex->initialize();
+    mutexes.emplace(mutex_name, std::move(mutex));
 }
 
 void LockManager::clear_mutex_internal(const std::string& mutex_name) {
@@ -90,18 +92,18 @@ void LockManager::clear_mutex_internal(const std::string& mutex_name) {
     mutexes.erase(mutex_name);
 }
 
-std::unique_lock<RobustMutex> LockManager::acquire_mutex_internal(const std::string& mutex_name) {
+std::unique_lock<MutexInterface> LockManager::acquire_mutex_internal(const std::string& mutex_name) {
     if (mutexes.find(mutex_name) == mutexes.end()) {
         UMD_THROW(error::RuntimeError, "Mutex not initialized: " + mutex_name);
     }
-    return std::unique_lock(mutexes.at(mutex_name));
+    return std::unique_lock(*mutexes.at(mutex_name));
 }
 
 std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex_internal(const std::string& mutex_name) {
     if (mutexes.find(mutex_name) == mutexes.end()) {
         UMD_THROW(error::RuntimeError, "Mutex not initialized: " + mutex_name);
     }
-    RobustMutex& mutex = mutexes.at(mutex_name);
+    MutexInterface& mutex = *mutexes.at(mutex_name);
     std::optional<std::pair<pid_t, pid_t>> owner = mutex.probe_lock(std::chrono::seconds(0));
     if (!owner.has_value()) {
         // The mutex was free, which means probing it took it. Release it so that probing stays a query.

--- a/device/utils/lock_manager.cpp
+++ b/device/utils/lock_manager.cpp
@@ -97,17 +97,26 @@ std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex(
 
 void LockManager::initialize_mutex_internal(const std::string& mutex_name) {
     MutexRegistry& registry = get_registry();
-    std::lock_guard<std::mutex> guard(registry.guard);
 
-    if (registry.mutexes.find(mutex_name) != registry.mutexes.end()) {
-        // Whoever needed this lock first has already set it up. Initializing is not owning, so this is the expected
-        // outcome whenever more than one object works with the same device.
-        return;
+    {
+        std::lock_guard<std::mutex> guard(registry.guard);
+        if (registry.mutexes.find(mutex_name) != registry.mutexes.end()) {
+            // Whoever needed this lock first has already set it up. Initializing is not owning, so this is the expected
+            // outcome whenever more than one object works with the same device.
+            return;
+        }
     }
 
+    // Setting a mutex up talks to the OS, and for a shared memory one that includes a blocking flock, so it happens
+    // outside the registry guard. Holding the guard across it would stall every other thread that only wanted to look
+    // a lock up, and looking one up is on the IO paths.
     std::unique_ptr<MutexInterface> mutex = std::make_unique<RobustMutex>(mutex_name);
     mutex->initialize();
-    registry.mutexes.emplace(mutex_name, std::move(mutex));
+
+    std::lock_guard<std::mutex> guard(registry.guard);
+    // Another thread may have set the same lock up in the meantime, in which case theirs is the one in the registry and
+    // ours is dropped here. Setting the same one up twice is harmless: the backend serializes that internally.
+    registry.mutexes.try_emplace(mutex_name, std::move(mutex));
 }
 
 std::unique_lock<MutexInterface> LockManager::acquire_mutex_internal(const std::string& mutex_name) {

--- a/device/utils/lock_manager.cpp
+++ b/device/utils/lock_manager.cpp
@@ -14,23 +14,41 @@
 
 namespace tt::umd {
 
-std::string to_string(MutexType mutex_type) { return LockManager::MUTEX_TYPE_TO_STRING.at(mutex_type); }
+namespace {
+
+// Names of the shared memory files backing each mutex.
+const std::unordered_map<MutexType, std::string> MUTEX_TYPE_TO_STRING = {
+    {MutexType::ARC_MSG, "ARC_MSG"},
+    {MutexType::REMOTE_ARC_MSG, "REMOTE_ARC_MSG"},
+    {MutexType::NON_MMIO, "NON_MMIO"},
+    {MutexType::MEM_BARRIER, "MEM_BARRIER"},
+    {MutexType::CREATE_ETH_MAP, "CREATE_ETH_MAP"},
+    {MutexType::CHIP_IN_USE, "CHIP_IN_USE"},
+    {MutexType::PCIE_DMA, "PCIE_DMA"},
+};
+
+std::string get_mutex_name(MutexType mutex_type, int device_id, IODeviceType device_type) {
+    return MUTEX_TYPE_TO_STRING.at(mutex_type) + "_" + std::to_string(device_id) + "_" +
+           DeviceTypeToString.at(device_type);
+}
+
+}  // namespace
+
+std::string to_string(MutexType mutex_type) { return MUTEX_TYPE_TO_STRING.at(mutex_type); }
 
 void LockManager::initialize_mutex(MutexType mutex_type) {
     initialize_mutex_internal(MUTEX_TYPE_TO_STRING.at(mutex_type));
 }
 
 void LockManager::initialize_mutex(MutexType mutex_type, int device_id, IODeviceType device_type) {
-    std::string mutex_name = MUTEX_TYPE_TO_STRING.at(mutex_type) + "_" + std::to_string(device_id) + "_" +
-                             DeviceTypeToString.at(device_type);
+    std::string mutex_name = get_mutex_name(mutex_type, device_id, device_type);
     initialize_mutex_internal(mutex_name);
 }
 
 void LockManager::clear_mutex(MutexType mutex_type) { clear_mutex_internal(MUTEX_TYPE_TO_STRING.at(mutex_type)); }
 
 void LockManager::clear_mutex(MutexType mutex_type, int device_id, IODeviceType device_type) {
-    std::string mutex_name = MUTEX_TYPE_TO_STRING.at(mutex_type) + "_" + std::to_string(device_id) + "_" +
-                             DeviceTypeToString.at(device_type);
+    std::string mutex_name = get_mutex_name(mutex_type, device_id, device_type);
     clear_mutex_internal(mutex_name);
 }
 
@@ -40,24 +58,7 @@ std::unique_lock<MutexInterface> LockManager::acquire_mutex(MutexType mutex_type
 
 std::unique_lock<MutexInterface> LockManager::acquire_mutex(
     MutexType mutex_type, int device_id, IODeviceType device_type) {
-    std::string mutex_name = MUTEX_TYPE_TO_STRING.at(mutex_type) + "_" + std::to_string(device_id) + "_" +
-                             DeviceTypeToString.at(device_type);
-    return acquire_mutex_internal(mutex_name);
-}
-
-void LockManager::initialize_mutex(const std::string& mutex_prefix, int device_id, IODeviceType device_type) {
-    std::string mutex_name = mutex_prefix + "_" + std::to_string(device_id) + "_" + DeviceTypeToString.at(device_type);
-    initialize_mutex_internal(mutex_name);
-}
-
-void LockManager::clear_mutex(const std::string& mutex_prefix, int device_id, IODeviceType device_type) {
-    std::string mutex_name = mutex_prefix + "_" + std::to_string(device_id) + "_" + DeviceTypeToString.at(device_type);
-    clear_mutex_internal(mutex_name);
-}
-
-std::unique_lock<MutexInterface> LockManager::acquire_mutex(
-    const std::string& mutex_prefix, int device_id, IODeviceType device_type) {
-    std::string mutex_name = mutex_prefix + "_" + std::to_string(device_id) + "_" + DeviceTypeToString.at(device_type);
+    std::string mutex_name = get_mutex_name(mutex_type, device_id, device_type);
     return acquire_mutex_internal(mutex_name);
 }
 
@@ -67,8 +68,7 @@ std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex(MutexType mutex_
 
 std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex(
     MutexType mutex_type, int device_id, IODeviceType device_type) {
-    std::string mutex_name = MUTEX_TYPE_TO_STRING.at(mutex_type) + "_" + std::to_string(device_id) + "_" +
-                             DeviceTypeToString.at(device_type);
+    std::string mutex_name = get_mutex_name(mutex_type, device_id, device_type);
     return probe_mutex_internal(mutex_name);
 }
 

--- a/device/utils/lock_manager.cpp
+++ b/device/utils/lock_manager.cpp
@@ -13,6 +13,8 @@
 
 namespace tt::umd {
 
+std::string to_string(MutexType mutex_type) { return LockManager::MUTEX_TYPE_TO_STRING.at(mutex_type); }
+
 void LockManager::initialize_mutex(MutexType mutex_type) {
     initialize_mutex_internal(MUTEX_TYPE_TO_STRING.at(mutex_type));
 }
@@ -58,6 +60,17 @@ std::unique_lock<RobustMutex> LockManager::acquire_mutex(
     return acquire_mutex_internal(mutex_name);
 }
 
+std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex(MutexType mutex_type) {
+    return probe_mutex_internal(MUTEX_TYPE_TO_STRING.at(mutex_type));
+}
+
+std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex(
+    MutexType mutex_type, int device_id, IODeviceType device_type) {
+    std::string mutex_name = MUTEX_TYPE_TO_STRING.at(mutex_type) + "_" + std::to_string(device_id) + "_" +
+                             DeviceTypeToString.at(device_type);
+    return probe_mutex_internal(mutex_name);
+}
+
 void LockManager::initialize_mutex_internal(const std::string& mutex_name) {
     if (mutexes.find(mutex_name) != mutexes.end()) {
         log_warning(LogUMD, "Mutex already initialized: {}", mutex_name);
@@ -82,6 +95,19 @@ std::unique_lock<RobustMutex> LockManager::acquire_mutex_internal(const std::str
         UMD_THROW(error::RuntimeError, "Mutex not initialized: " + mutex_name);
     }
     return std::unique_lock(mutexes.at(mutex_name));
+}
+
+std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex_internal(const std::string& mutex_name) {
+    if (mutexes.find(mutex_name) == mutexes.end()) {
+        UMD_THROW(error::RuntimeError, "Mutex not initialized: " + mutex_name);
+    }
+    RobustMutex& mutex = mutexes.at(mutex_name);
+    std::optional<std::pair<pid_t, pid_t>> owner = mutex.probe_lock(std::chrono::seconds(0));
+    if (!owner.has_value()) {
+        // The mutex was free, which means probing it took it. Release it so that probing stays a query.
+        mutex.unlock();
+    }
+    return owner;
 }
 
 }  // namespace tt::umd

--- a/device/utils/lock_manager.cpp
+++ b/device/utils/lock_manager.cpp
@@ -11,6 +11,7 @@
 #include <unordered_map>
 
 #include "umd/device/utils/error.hpp"
+#include "umd/device/utils/kmd_mutex.hpp"
 #include "umd/device/utils/robust_mutex.hpp"
 
 namespace tt::umd {
@@ -33,6 +34,72 @@ std::string get_mutex_name(MutexType mutex_type, int device_id, IODeviceType dev
            DeviceTypeToString.at(device_type);
 }
 
+// KMD resource lock index used for each chip specific mutex type. Indices 0..15 are reserved for ERISC cores (see
+// KmdLockIndex), so UMD's own locks start above that range. Processes serialize against each other only if they agree
+// on the index, so these values must never be renumbered.
+const std::unordered_map<MutexType, uint8_t> MUTEX_TYPE_TO_KMD_LOCK_INDEX = {
+    {MutexType::ARC_MSG, 16},
+    {MutexType::REMOTE_ARC_MSG, 17},
+    {MutexType::NON_MMIO, 18},
+    {MutexType::MEM_BARRIER, 19},
+    {MutexType::CHIP_IN_USE, 20},
+    {MutexType::PCIE_DMA, 21},
+};
+
+uint8_t get_kmd_lock_index(MutexType mutex_type) {
+    auto it = MUTEX_TYPE_TO_KMD_LOCK_INDEX.find(mutex_type);
+    UMD_ASSERT(
+        it != MUTEX_TYPE_TO_KMD_LOCK_INDEX.end(),
+        error::RuntimeError,
+        "Mutex " + MUTEX_TYPE_TO_STRING.at(mutex_type) + " has no KMD resource lock index assigned to it");
+    return it->second;
+}
+
+// Holds two mutexes as one. This exists only for the move from shared memory locks to KMD resource locks: a process
+// running an older UMD takes the shared memory lock alone and knows nothing about the KMD one, so during the
+// transition both have to be taken or the two processes would not serialize. Once every client takes KMD locks, the
+// shared memory half can go and the KMD mutex can be used on its own.
+// The two are always taken in the same order, which is what keeps processes taking both from deadlocking against each
+// other.
+class CompositeMutex : public MutexInterface {
+public:
+    CompositeMutex(std::unique_ptr<MutexInterface> first, std::unique_ptr<MutexInterface> second) :
+        first_(std::move(first)), second_(std::move(second)) {}
+
+    void initialize() override {
+        first_->initialize();
+        second_->initialize();
+    }
+
+    void lock() override {
+        first_->lock();
+        second_->lock();
+    }
+
+    void unlock() override {
+        second_->unlock();
+        first_->unlock();
+    }
+
+    std::optional<std::pair<pid_t, pid_t>> probe_lock(std::chrono::seconds timeout) override {
+        std::optional<std::pair<pid_t, pid_t>> owner = first_->probe_lock(timeout);
+        if (owner.has_value()) {
+            return owner;
+        }
+        // Probing acquired the first one. If the second turns out to be taken, give the first one back, so that a
+        // failed probe leaves nothing held.
+        owner = second_->probe_lock(timeout);
+        if (owner.has_value()) {
+            first_->unlock();
+        }
+        return owner;
+    }
+
+private:
+    std::unique_ptr<MutexInterface> first_;
+    std::unique_ptr<MutexInterface> second_;
+};
+
 // Every mutex UMD has initialized, keyed by name. Names are made from the mutex type name, combined with the device
 // number for chip specific ones.
 struct MutexRegistry {
@@ -47,6 +114,38 @@ MutexRegistry& get_registry() {
     // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     static MutexRegistry* registry = new MutexRegistry();
     return *registry;
+}
+
+void add_mutex(const std::string& mutex_name, std::unique_ptr<MutexInterface> mutex) {
+    MutexRegistry& registry = get_registry();
+
+    {
+        std::lock_guard<std::mutex> guard(registry.guard);
+        if (registry.mutexes.find(mutex_name) != registry.mutexes.end()) {
+            // Whoever needed this lock first has already set it up. Initializing is not owning, so this is the expected
+            // outcome whenever more than one object works with the same device.
+            return;
+        }
+    }
+
+    // Setting a mutex up talks to the OS - a shared memory one takes a blocking flock, a KMD one opens the device - so
+    // it happens outside the registry guard. Holding the guard across it would stall every other thread that only
+    // wanted to look a lock up, and looking one up is on the IO paths.
+    mutex->initialize();
+
+    std::lock_guard<std::mutex> guard(registry.guard);
+    // Another thread may have set the same lock up in the meantime, in which case theirs is the one in the registry and
+    // ours is dropped here. Setting the same one up twice is harmless: both backends make that safe.
+    registry.mutexes.try_emplace(mutex_name, std::move(mutex));
+}
+
+// Probing has to acquire a free mutex to find out it was free, so release it again to keep probing a query.
+std::optional<std::pair<pid_t, pid_t>> probe_and_release(MutexInterface& mutex) {
+    std::optional<std::pair<pid_t, pid_t>> owner = mutex.probe_lock(std::chrono::seconds(0));
+    if (!owner.has_value()) {
+        mutex.unlock();
+    }
+    return owner;
 }
 
 // Looking a mutex up hands out a reference into the registry, which stays valid because entries are only ever added.
@@ -67,70 +166,70 @@ MutexInterface& get_initialized_mutex(const std::string& mutex_name) {
 std::string to_string(MutexType mutex_type) { return MUTEX_TYPE_TO_STRING.at(mutex_type); }
 
 void LockManager::initialize_mutex(MutexType mutex_type) {
-    initialize_mutex_internal(MUTEX_TYPE_TO_STRING.at(mutex_type));
+    initialize_robust_mutex(MUTEX_TYPE_TO_STRING.at(mutex_type));
 }
 
 void LockManager::initialize_mutex(MutexType mutex_type, int device_id, IODeviceType device_type) {
-    std::string mutex_name = get_mutex_name(mutex_type, device_id, device_type);
-    initialize_mutex_internal(mutex_name);
+    if (device_type == IODeviceType::PCIe) {
+        initialize_kmd_mutex(mutex_type, device_id);
+    } else {
+        initialize_robust_mutex(get_mutex_name(mutex_type, device_id, device_type));
+    }
 }
 
 std::unique_lock<MutexInterface> LockManager::acquire_mutex(MutexType mutex_type) {
-    return acquire_mutex_internal(MUTEX_TYPE_TO_STRING.at(mutex_type));
+    return acquire_robust_mutex(MUTEX_TYPE_TO_STRING.at(mutex_type));
 }
 
 std::unique_lock<MutexInterface> LockManager::acquire_mutex(
     MutexType mutex_type, int device_id, IODeviceType device_type) {
-    std::string mutex_name = get_mutex_name(mutex_type, device_id, device_type);
-    return acquire_mutex_internal(mutex_name);
+    if (device_type == IODeviceType::PCIe) {
+        return acquire_kmd_mutex(mutex_type, device_id);
+    }
+    return acquire_robust_mutex(get_mutex_name(mutex_type, device_id, device_type));
 }
 
 std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex(MutexType mutex_type) {
-    return probe_mutex_internal(MUTEX_TYPE_TO_STRING.at(mutex_type));
+    return probe_robust_mutex(MUTEX_TYPE_TO_STRING.at(mutex_type));
 }
 
 std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex(
     MutexType mutex_type, int device_id, IODeviceType device_type) {
-    std::string mutex_name = get_mutex_name(mutex_type, device_id, device_type);
-    return probe_mutex_internal(mutex_name);
-}
-
-void LockManager::initialize_mutex_internal(const std::string& mutex_name) {
-    MutexRegistry& registry = get_registry();
-
-    {
-        std::lock_guard<std::mutex> guard(registry.guard);
-        if (registry.mutexes.find(mutex_name) != registry.mutexes.end()) {
-            // Whoever needed this lock first has already set it up. Initializing is not owning, so this is the expected
-            // outcome whenever more than one object works with the same device.
-            return;
-        }
+    if (device_type == IODeviceType::PCIe) {
+        return probe_kmd_mutex(mutex_type, device_id);
     }
-
-    // Setting a mutex up talks to the OS, and for a shared memory one that includes a blocking flock, so it happens
-    // outside the registry guard. Holding the guard across it would stall every other thread that only wanted to look
-    // a lock up, and looking one up is on the IO paths.
-    std::unique_ptr<MutexInterface> mutex = std::make_unique<RobustMutex>(mutex_name);
-    mutex->initialize();
-
-    std::lock_guard<std::mutex> guard(registry.guard);
-    // Another thread may have set the same lock up in the meantime, in which case theirs is the one in the registry and
-    // ours is dropped here. Setting the same one up twice is harmless: the backend serializes that internally.
-    registry.mutexes.try_emplace(mutex_name, std::move(mutex));
+    return probe_robust_mutex(get_mutex_name(mutex_type, device_id, device_type));
 }
 
-std::unique_lock<MutexInterface> LockManager::acquire_mutex_internal(const std::string& mutex_name) {
+void LockManager::initialize_robust_mutex(const std::string& mutex_name) {
+    add_mutex(mutex_name, std::make_unique<RobustMutex>(mutex_name));
+}
+
+std::unique_lock<MutexInterface> LockManager::acquire_robust_mutex(const std::string& mutex_name) {
     return std::unique_lock(get_initialized_mutex(mutex_name));
 }
 
-std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex_internal(const std::string& mutex_name) {
-    MutexInterface& mutex = get_initialized_mutex(mutex_name);
-    std::optional<std::pair<pid_t, pid_t>> owner = mutex.probe_lock(std::chrono::seconds(0));
-    if (!owner.has_value()) {
-        // The mutex was free, which means probing it took it. Release it so that probing stays a query.
-        mutex.unlock();
-    }
-    return owner;
+std::optional<std::pair<pid_t, pid_t>> LockManager::probe_robust_mutex(const std::string& mutex_name) {
+    return probe_and_release(get_initialized_mutex(mutex_name));
+}
+
+void LockManager::initialize_kmd_mutex(MutexType mutex_type, int pci_device_num) {
+    // Registered under the name its shared memory half keeps, so that a process on an older UMD, which takes only that
+    // half, contends on the very same lock.
+    std::string mutex_name = get_mutex_name(mutex_type, pci_device_num, IODeviceType::PCIe);
+    add_mutex(
+        mutex_name,
+        std::make_unique<CompositeMutex>(
+            std::make_unique<RobustMutex>(mutex_name),
+            std::make_unique<KmdMutex>(pci_device_num, get_kmd_lock_index(mutex_type))));
+}
+
+std::unique_lock<MutexInterface> LockManager::acquire_kmd_mutex(MutexType mutex_type, int pci_device_num) {
+    return std::unique_lock(get_initialized_mutex(get_mutex_name(mutex_type, pci_device_num, IODeviceType::PCIe)));
+}
+
+std::optional<std::pair<pid_t, pid_t>> LockManager::probe_kmd_mutex(MutexType mutex_type, int pci_device_num) {
+    return probe_and_release(get_initialized_mutex(get_mutex_name(mutex_type, pci_device_num, IODeviceType::PCIe)));
 }
 
 }  // namespace tt::umd

--- a/device/utils/lock_manager.cpp
+++ b/device/utils/lock_manager.cpp
@@ -45,13 +45,6 @@ void LockManager::initialize_mutex(MutexType mutex_type, int device_id, IODevice
     initialize_mutex_internal(mutex_name);
 }
 
-void LockManager::clear_mutex(MutexType mutex_type) { clear_mutex_internal(MUTEX_TYPE_TO_STRING.at(mutex_type)); }
-
-void LockManager::clear_mutex(MutexType mutex_type, int device_id, IODeviceType device_type) {
-    std::string mutex_name = get_mutex_name(mutex_type, device_id, device_type);
-    clear_mutex_internal(mutex_name);
-}
-
 std::unique_lock<MutexInterface> LockManager::acquire_mutex(MutexType mutex_type) {
     return acquire_mutex_internal(MUTEX_TYPE_TO_STRING.at(mutex_type));
 }
@@ -81,15 +74,6 @@ void LockManager::initialize_mutex_internal(const std::string& mutex_name) {
     std::unique_ptr<MutexInterface> mutex = std::make_unique<RobustMutex>(mutex_name);
     mutex->initialize();
     mutexes.emplace(mutex_name, std::move(mutex));
-}
-
-void LockManager::clear_mutex_internal(const std::string& mutex_name) {
-    if (mutexes.find(mutex_name) == mutexes.end()) {
-        log_warning(LogUMD, "Mutex not initialized or already cleared: {}", mutex_name);
-        return;
-    }
-    // The destructor will automatically close the underlying mutex.
-    mutexes.erase(mutex_name);
 }
 
 std::unique_lock<MutexInterface> LockManager::acquire_mutex_internal(const std::string& mutex_name) {

--- a/device/utils/lock_manager.cpp
+++ b/device/utils/lock_manager.cpp
@@ -34,8 +34,8 @@ std::string get_mutex_name(MutexType mutex_type, int device_id, IODeviceType dev
            DeviceTypeToString.at(device_type);
 }
 
-// KMD resource lock index used for each chip specific mutex type. Indices 0..15 are reserved for ERISC cores (see
-// KmdLockIndex), so UMD's own locks start above that range. Processes serialize against each other only if they agree
+// KMD resource lock index used for each chip specific mutex type. KMD suggests indices 0..15 for ERISC cores (see
+// tt_kmd_lib.h), so UMD's own locks start above that range. Processes serialize against each other only if they agree
 // on the index, so these values must never be renumbered.
 const std::unordered_map<MutexType, uint8_t> MUTEX_TYPE_TO_KMD_LOCK_INDEX = {
     {MutexType::ARC_MSG, 16},
@@ -71,13 +71,27 @@ public:
         second_->initialize();
     }
 
+    // The first one is given back whenever taking the second does not work out, whether it reports the lock as taken
+    // or throws. Otherwise it would stay held for the lifetime of the process: the caller never receives a
+    // std::unique_lock when the constructor's lock() throws, so nothing is left to release it, and the shared memory
+    // half only recovers itself when its holder dies.
     void lock() override {
         first_->lock();
-        second_->lock();
+        try {
+            second_->lock();
+        } catch (...) {
+            first_->unlock();
+            throw;
+        }
     }
 
     void unlock() override {
-        second_->unlock();
+        try {
+            second_->unlock();
+        } catch (...) {
+            first_->unlock();
+            throw;
+        }
         first_->unlock();
     }
 
@@ -86,9 +100,14 @@ public:
         if (owner.has_value()) {
             return owner;
         }
-        // Probing acquired the first one. If the second turns out to be taken, give the first one back, so that a
-        // failed probe leaves nothing held.
-        owner = second_->probe_lock(timeout);
+
+        // Probing acquired the first one.
+        try {
+            owner = second_->probe_lock(timeout);
+        } catch (...) {
+            first_->unlock();
+            throw;
+        }
         if (owner.has_value()) {
             first_->unlock();
         }

--- a/device/utils/lock_manager.cpp
+++ b/device/utils/lock_manager.cpp
@@ -4,6 +4,7 @@
 
 #include "umd/device/utils/lock_manager.hpp"
 
+#include <memory>
 #include <mutex>
 #include <string>
 #include <tt-logger/tt-logger.hpp>
@@ -30,6 +31,35 @@ const std::unordered_map<MutexType, std::string> MUTEX_TYPE_TO_STRING = {
 std::string get_mutex_name(MutexType mutex_type, int device_id, IODeviceType device_type) {
     return MUTEX_TYPE_TO_STRING.at(mutex_type) + "_" + std::to_string(device_id) + "_" +
            DeviceTypeToString.at(device_type);
+}
+
+// Every mutex UMD has initialized, keyed by name. Names are made from the mutex type name, combined with the device
+// number for chip specific ones.
+struct MutexRegistry {
+    std::mutex guard;
+    std::unordered_map<std::string, std::unique_ptr<MutexInterface>> mutexes;
+};
+
+// Deliberately never destroyed: a mutex outliving the registry is far less trouble than one being torn down while
+// another thread still holds it, or after the logger it reports through is gone. The OS reclaims the mappings and
+// file descriptors at exit anyway.
+MutexRegistry& get_registry() {
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+    static MutexRegistry* registry = new MutexRegistry();
+    return *registry;
+}
+
+// Looking a mutex up hands out a reference into the registry, which stays valid because entries are only ever added.
+// The registry guard is held for the lookup only, never while taking the mutex itself.
+MutexInterface& get_initialized_mutex(const std::string& mutex_name) {
+    MutexRegistry& registry = get_registry();
+    std::lock_guard<std::mutex> guard(registry.guard);
+
+    auto it = registry.mutexes.find(mutex_name);
+    if (it == registry.mutexes.end()) {
+        UMD_THROW(error::RuntimeError, "Mutex not initialized: " + mutex_name);
+    }
+    return *it->second;
 }
 
 }  // namespace
@@ -66,28 +96,26 @@ std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex(
 }
 
 void LockManager::initialize_mutex_internal(const std::string& mutex_name) {
-    if (mutexes.find(mutex_name) != mutexes.end()) {
-        log_warning(LogUMD, "Mutex already initialized: {}", mutex_name);
+    MutexRegistry& registry = get_registry();
+    std::lock_guard<std::mutex> guard(registry.guard);
+
+    if (registry.mutexes.find(mutex_name) != registry.mutexes.end()) {
+        // Whoever needed this lock first has already set it up. Initializing is not owning, so this is the expected
+        // outcome whenever more than one object works with the same device.
         return;
     }
 
     std::unique_ptr<MutexInterface> mutex = std::make_unique<RobustMutex>(mutex_name);
     mutex->initialize();
-    mutexes.emplace(mutex_name, std::move(mutex));
+    registry.mutexes.emplace(mutex_name, std::move(mutex));
 }
 
 std::unique_lock<MutexInterface> LockManager::acquire_mutex_internal(const std::string& mutex_name) {
-    if (mutexes.find(mutex_name) == mutexes.end()) {
-        UMD_THROW(error::RuntimeError, "Mutex not initialized: " + mutex_name);
-    }
-    return std::unique_lock(*mutexes.at(mutex_name));
+    return std::unique_lock(get_initialized_mutex(mutex_name));
 }
 
 std::optional<std::pair<pid_t, pid_t>> LockManager::probe_mutex_internal(const std::string& mutex_name) {
-    if (mutexes.find(mutex_name) == mutexes.end()) {
-        UMD_THROW(error::RuntimeError, "Mutex not initialized: " + mutex_name);
-    }
-    MutexInterface& mutex = *mutexes.at(mutex_name);
+    MutexInterface& mutex = get_initialized_mutex(mutex_name);
     std::optional<std::pair<pid_t, pid_t>> owner = mutex.probe_lock(std::chrono::seconds(0));
     if (!owner.has_value()) {
         // The mutex was free, which means probing it took it. Release it so that probing stays a query.

--- a/tests/microbenchmark/host_benchmark/test_locks.cpp
+++ b/tests/microbenchmark/host_benchmark/test_locks.cpp
@@ -182,7 +182,7 @@ TEST(MicrobenchmarkLocks, ProbeContended) {
         auto prober = make_robust();
         holder.lock();
         bench.name("RobustMutex").run([&] {
-            auto owner = prober.probe_lock();
+            auto owner = prober.probe_lock(std::chrono::seconds(0));
             ankerl::nanobench::doNotOptimizeAway(owner);
         });
         holder.unlock();
@@ -192,7 +192,7 @@ TEST(MicrobenchmarkLocks, ProbeContended) {
         auto prober = make_kmd(*device_num);
         holder.lock();
         bench.name("KmdMutex").run([&] {
-            auto owner = prober.probe_lock();
+            auto owner = prober.probe_lock(std::chrono::seconds(0));
             ankerl::nanobench::doNotOptimizeAway(owner);
         });
         holder.unlock();

--- a/tests/misc/CMakeLists.txt
+++ b/tests/misc/CMakeLists.txt
@@ -3,6 +3,7 @@ set(UMD_MISC_TESTS_SRCS
     test_errors.cpp
     test_robust_mutex.cpp
     test_kmd_mutex.cpp
+    test_lock_manager.cpp
     test_op_timeout_guard.cpp
 )
 

--- a/tests/misc/test_lock_manager.cpp
+++ b/tests/misc/test_lock_manager.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/utils/kmd_mutex.hpp"
+#include "umd/device/utils/lock_manager.hpp"
+#include "umd/device/utils/robust_mutex.hpp"
+
+using namespace tt::umd;
+
+namespace {
+
+// The lock name and the KMD lock index are what different processes agree on, so they are spelled out here rather than
+// read back from LockManager: a change to either breaks serialization against processes built from another UMD
+// version, and this test is what should notice.
+constexpr uint8_t MEM_BARRIER_KMD_LOCK_INDEX = 19;
+
+std::string mem_barrier_lock_name(int device_num) { return "MEM_BARRIER_" + std::to_string(device_num) + "_PCIe"; }
+
+}  // namespace
+
+// A chip specific lock on a PCIe device has to be held in both places at once: in KMD, so that processes sharing only
+// the device serialize, and in shared memory, so that processes on an older UMD - which know only about that one -
+// still serialize too.
+TEST(TestLockManager, ChipSpecificPcieLockIsHeldInBothBackends) {
+    std::vector<int> devices = PCIDevice::enumerate_devices();
+    if (devices.empty()) {
+        GTEST_SKIP() << "No /dev/tenstorrent device present";
+    }
+    const int device_num = devices.front();
+
+    KmdMutex kmd_lock(device_num, MEM_BARRIER_KMD_LOCK_INDEX);
+    kmd_lock.initialize();
+    RobustMutex shm_lock(mem_barrier_lock_name(device_num));
+    shm_lock.initialize();
+
+    LockManager::initialize_mutex(MutexType::MEM_BARRIER, device_num, IODeviceType::PCIe);
+
+    {
+        auto lock = LockManager::acquire_mutex(MutexType::MEM_BARRIER, device_num, IODeviceType::PCIe);
+
+        EXPECT_TRUE(kmd_lock.is_locked_by_anyone()) << "KMD resource lock should be held";
+        EXPECT_TRUE(shm_lock.probe_lock(std::chrono::seconds(0)).has_value()) << "Shared memory lock should be held";
+    }
+
+    EXPECT_FALSE(kmd_lock.is_locked_by_anyone()) << "KMD resource lock should have been released";
+    EXPECT_FALSE(shm_lock.probe_lock(std::chrono::seconds(0)).has_value())
+        << "Shared memory lock should have been released";
+    shm_lock.unlock();
+}

--- a/tests/misc/test_lock_manager.cpp
+++ b/tests/misc/test_lock_manager.cpp
@@ -27,10 +27,9 @@ std::string mem_barrier_lock_name(int device_num) { return "MEM_BARRIER_" + std:
 
 }  // namespace
 
-// A chip specific lock on a PCIe device has to be held in both places at once: in KMD, so that processes sharing only
-// the device serialize, and in shared memory, so that processes on an older UMD - which know only about that one -
-// still serialize too.
-TEST(TestLockManager, ChipSpecificPcieLockIsHeldInBothBackends) {
+// A chip specific lock on a PCIe device is held in KMD, and only there. Nothing takes the shared memory lock of the
+// same name any more, which is what makes it safe to remove.
+TEST(TestLockManager, ChipSpecificPcieLockIsHeldInKmd) {
     std::vector<int> devices = PCIDevice::enumerate_devices();
     if (devices.empty()) {
         GTEST_SKIP() << "No /dev/tenstorrent device present";
@@ -48,11 +47,10 @@ TEST(TestLockManager, ChipSpecificPcieLockIsHeldInBothBackends) {
         auto lock = LockManager::acquire_mutex(MutexType::MEM_BARRIER, device_num, IODeviceType::PCIe);
 
         EXPECT_TRUE(kmd_lock.is_locked_by_anyone()) << "KMD resource lock should be held";
-        EXPECT_TRUE(shm_lock.probe_lock(std::chrono::seconds(0)).has_value()) << "Shared memory lock should be held";
+        EXPECT_FALSE(shm_lock.probe_lock(std::chrono::seconds(0)).has_value())
+            << "Shared memory lock should no longer be taken";
+        shm_lock.unlock();
     }
 
     EXPECT_FALSE(kmd_lock.is_locked_by_anyone()) << "KMD resource lock should have been released";
-    EXPECT_FALSE(shm_lock.probe_lock(std::chrono::seconds(0)).has_value())
-        << "Shared memory lock should have been released";
-    shm_lock.unlock();
 }

--- a/tests/misc/test_robust_mutex.cpp
+++ b/tests/misc/test_robust_mutex.cpp
@@ -32,7 +32,7 @@ using namespace std::chrono_literals;
 // LOCKED long after the read had failed. The natural suspicion was "tt-telemetry swallows UMD's
 // exception, so the lock is never released". These tests pin down what actually happens:
 //   1. LockReleasedWhenHolderThrows  -> an exception thrown while the lock is held DOES release it,
-//      because LockManager hands out a std::unique_lock<RobustMutex> whose destructor runs during
+//      because LockManager hands out a std::unique_lock whose destructor runs during
 //      stack unwinding. So swallowing the exception upstream is NOT what leaks the lock.
 //   2. LockStaysHeldWhenHolderNeverReturns -> if a code path holds the lock and neither returns nor
 //      throws (e.g. an unbounded poll loop with no check_timeout), the lock is held forever and every
@@ -55,16 +55,17 @@ void unlink_backing_file(std::string_view mutex_name) {
 
 }  // namespace
 
-// An exception thrown while a std::unique_lock<RobustMutex> is in scope releases the lock during
-// stack unwinding (the unique_lock destructor calls unlock()). This is exactly the type LockManager
-// returns, so the production read/write paths get this behavior for free. A subsequent acquirer must
-// therefore succeed immediately.
+// An exception thrown while a std::unique_lock over the mutex is in scope releases the lock during
+// stack unwinding (the unique_lock destructor calls unlock()). LockManager hands out a
+// std::unique_lock<MutexInterface> over the same mutex, so the production read/write paths get this
+// behavior for free. A subsequent acquirer must therefore succeed immediately.
 TEST(RobustMutex, LockReleasedWhenHolderThrows) {
     RobustMutex mutex(kExceptionMutexName);
     mutex.initialize();
 
     try {
-        // Same RAII wrapper LockManager::acquire_mutex() returns to callers like read_non_mmio().
+        // The RAII wrapper LockManager::acquire_mutex() returns to callers like read_non_mmio(), over
+        // the concrete type, since this test is about RobustMutex rather than about which backend.
         std::unique_lock<RobustMutex> lock(mutex);
 
         // Simulate read_non_mmio() hitting utils::check_timeout() and throwing while holding the lock.

--- a/tools/lock_virus.cpp
+++ b/tools/lock_virus.cpp
@@ -48,10 +48,10 @@ static void report_state(const std::string& mutex_name, const std::optional<std:
     }
 }
 
-static void report_device_locks(LockManager& lock_manager, int device_id, IODeviceType device_type) {
+static void report_device_locks(int device_id, IODeviceType device_type) {
     for (MutexType mutex_type : LockManager::CHIP_SPECIFIC_MUTEX_TYPES) {
-        lock_manager.initialize_mutex(mutex_type, device_id, device_type);
-        report_state(to_string(mutex_type), lock_manager.probe_mutex(mutex_type, device_id, device_type));
+        LockManager::initialize_mutex(mutex_type, device_id, device_type);
+        report_state(to_string(mutex_type), LockManager::probe_mutex(mutex_type, device_id, device_type));
     }
 }
 
@@ -105,15 +105,14 @@ static void spin_forever() {
 }
 
 static void hold_lock(MutexType mutex_type, std::optional<int> device_id, IODeviceType device_type) {
-    LockManager lock_manager;
     if (device_id.has_value()) {
-        lock_manager.initialize_mutex(mutex_type, *device_id, device_type);
-        auto lock = lock_manager.acquire_mutex(mutex_type, *device_id, device_type);
+        LockManager::initialize_mutex(mutex_type, *device_id, device_type);
+        auto lock = LockManager::acquire_mutex(mutex_type, *device_id, device_type);
         log_info(tt::LogUMD, "Holding lock — press Ctrl-C to release.");
         spin_forever();
     } else {
-        lock_manager.initialize_mutex(mutex_type);
-        auto lock = lock_manager.acquire_mutex(mutex_type);
+        LockManager::initialize_mutex(mutex_type);
+        auto lock = LockManager::acquire_mutex(mutex_type);
         log_info(tt::LogUMD, "Holding lock — press Ctrl-C to release.");
         spin_forever();
     }
@@ -190,12 +189,10 @@ int main(int argc, char* argv[]) {
             hold_lock(*mutex_type, device_id, device_type);
         }
 
-        LockManager lock_manager;
-
         log_info(tt::LogUMD, "=== System wide locks ===");
         for (MutexType mutex_type : LockManager::SYSTEM_WIDE_MUTEX_TYPES) {
-            lock_manager.initialize_mutex(mutex_type);
-            report_state(to_string(mutex_type), lock_manager.probe_mutex(mutex_type));
+            LockManager::initialize_mutex(mutex_type);
+            report_state(to_string(mutex_type), LockManager::probe_mutex(mutex_type));
         }
 
         std::vector<int> pcie_device_ids = PCIDevice::enumerate_devices();
@@ -203,7 +200,7 @@ int main(int argc, char* argv[]) {
         log_info(tt::LogUMD, "=== PCIe devices found ({}) ===", pcie_device_ids.size());
         for (int device_id : pcie_device_ids) {
             log_info(tt::LogUMD, "  device {}", device_id);
-            report_device_locks(lock_manager, device_id, IODeviceType::PCIe);
+            report_device_locks(device_id, IODeviceType::PCIe);
         }
 
         std::vector<int> jtag_device_ids = enumerate_jtag_devices();
@@ -211,7 +208,7 @@ int main(int argc, char* argv[]) {
         log_info(tt::LogUMD, "=== JTAG devices found ({}) ===", jtag_device_ids.size());
         for (int device_id : jtag_device_ids) {
             log_info(tt::LogUMD, "  device {}", device_id);
-            report_device_locks(lock_manager, device_id, IODeviceType::JTAG);
+            report_device_locks(device_id, IODeviceType::JTAG);
         }
     } catch (const std::exception& e) {
         log_error(tt::LogUMD, "Error: {}", e.what());

--- a/tools/lock_virus.cpp
+++ b/tools/lock_virus.cpp
@@ -2,87 +2,96 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// lock_virus: inspect all UMD shared-memory locks present in /dev/shm, report
-// their state (free / held, owner PID/TID), and cross-check against the locks
-// expected for every enumerated PCIe device.
+// lock_virus: report the state (free / held, owner PID/TID) of every lock UMD can take - each mutex
+// type, for every PCIe and JTAG device found. Locks are probed through LockManager, so what gets
+// reported is the lock UMD would actually take, whichever mutex happens to back it.
 
-#include <dirent.h>
-
-#include <algorithm>
-#include <cerrno>
-#include <cstdlib>
-#include <cstring>
 #include <cxxopts.hpp>
 #include <iostream>
-#include <set>
+#include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 #include <tt-logger/tt-logger.hpp>
+#include <utility>
 #include <vector>
 
+#include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/utils/lock_manager.hpp"
-#include "umd/device/utils/robust_mutex.hpp"
 
 using namespace tt::umd;
 
-// ── lock-name helpers ─────────────────────────────────────────────────────────
-
-static std::vector<std::string> chip_specific_mutex_names(int device_id, const std::string& device_type = "PCIe") {
-    std::vector<std::string> names;
-    names.reserve(LockManager::CHIP_SPECIFIC_MUTEX_TYPES.size());
-    for (MutexType type : LockManager::CHIP_SPECIFIC_MUTEX_TYPES) {
-        std::string name = LockManager::MUTEX_TYPE_TO_STRING.at(type);
-        name.append("_").append(std::to_string(device_id)).append("_").append(device_type);
-        names.push_back(std::move(name));
-    }
-    return names;
-}
-
-// ── /dev/shm scan ─────────────────────────────────────────────────────────────
-
-static std::vector<std::string> scan_umd_locks() {
-    static constexpr std::string_view prefix = RobustMutex::SHM_FILE_PREFIX;
-
-    std::vector<std::string> found;
-    DIR* dir = opendir("/dev/shm");
-    if (!dir) {
-        log_warning(tt::LogUMD, "Could not open /dev/shm: {}", std::to_string(errno));
-        return found;
-    }
-
-    struct dirent* entry;
-    while ((entry = readdir(dir)) != nullptr) {
-        std::string name(entry->d_name);
-        if (name.rfind(std::string(prefix), 0) == 0) {
-            found.push_back(name);
-        }
-    }
-    closedir(dir);
-    std::sort(found.begin(), found.end());
-    return found;
-}
-
 // ── reporting ─────────────────────────────────────────────────────────────────
 
-static void report_lock(const std::string& shm_name) {
-    // shm_name includes the TT_UMD_LOCK. prefix; RobustMutex wants the bare name.
-    const std::string mutex_name = shm_name.substr(RobustMutex::SHM_FILE_PREFIX.size());
-    RobustMutex m(mutex_name);
-    try {
-        m.initialize();
-    } catch (const std::exception& e) {
-        log_info(tt::LogUMD, "  [{:<55}]  ERROR initializing: {}", shm_name, e.what());
-        return;
-    }
-
-    if (auto owner = m.probe_lock(std::chrono::seconds(0))) {
-        // Optional has a value: lock is held by another thread/process.
-        log_info(tt::LogUMD, "  [{:<55}]  LOCKED  PID={} TID={}", shm_name, owner->first, owner->second);
+static void report_state(const std::string& mutex_name, const std::optional<std::pair<pid_t, pid_t>>& owner) {
+    if (owner.has_value()) {
+        log_info(tt::LogUMD, "    [{:<16}]  LOCKED  PID={} TID={}", mutex_name, owner->first, owner->second);
     } else {
-        // nullopt: we acquired the lock — it was free.
-        m.unlock();
-        log_info(tt::LogUMD, "  [{:<55}]  FREE", shm_name);
+        log_info(tt::LogUMD, "    [{:<16}]  FREE", mutex_name);
+    }
+}
+
+static void report_device_locks(LockManager& lock_manager, int device_id, IODeviceType device_type) {
+    for (MutexType mutex_type : LockManager::CHIP_SPECIFIC_MUTEX_TYPES) {
+        lock_manager.initialize_mutex(mutex_type, device_id, device_type);
+        report_state(to_string(mutex_type), lock_manager.probe_mutex(mutex_type, device_id, device_type));
+    }
+}
+
+// ── device enumeration ────────────────────────────────────────────────────────
+
+// Returns the JTAG device indices, or an empty list if JTAG is not usable on this host. The J-Link
+// library it needs is loaded at runtime and is absent on most systems.
+static std::vector<int> enumerate_jtag_devices() {
+    try {
+        std::unique_ptr<JtagDevice> jtag_device = JtagDevice::create();
+        std::vector<int> device_ids;
+        device_ids.reserve(jtag_device->get_device_cnt());
+        for (uint32_t index = 0; index < jtag_device->get_device_cnt(); index++) {
+            device_ids.push_back(static_cast<int>(index));
+        }
+        return device_ids;
+    } catch (const std::exception& e) {
+        log_debug(tt::LogUMD, "JTAG devices could not be enumerated: {}", e.what());
+        return {};
+    }
+}
+
+// ── testing mode ──────────────────────────────────────────────────────────────
+
+static std::optional<MutexType> find_mutex_type(const std::string& mutex_name) {
+    for (MutexType mutex_type : LockManager::SYSTEM_WIDE_MUTEX_TYPES) {
+        if (to_string(mutex_type) == mutex_name) {
+            return mutex_type;
+        }
+    }
+    for (MutexType mutex_type : LockManager::CHIP_SPECIFIC_MUTEX_TYPES) {
+        if (to_string(mutex_type) == mutex_name) {
+            return mutex_type;
+        }
+    }
+    return std::nullopt;
+}
+
+static void spin_forever() {
+    while (true) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+}
+
+static void hold_lock(MutexType mutex_type, std::optional<int> device_id, IODeviceType device_type) {
+    LockManager lock_manager;
+    if (device_id.has_value()) {
+        lock_manager.initialize_mutex(mutex_type, *device_id, device_type);
+        auto lock = lock_manager.acquire_mutex(mutex_type, *device_id, device_type);
+        log_info(tt::LogUMD, "Holding lock — press Ctrl-C to release.");
+        spin_forever();
+    } else {
+        lock_manager.initialize_mutex(mutex_type);
+        auto lock = lock_manager.acquire_mutex(mutex_type);
+        log_info(tt::LogUMD, "Holding lock — press Ctrl-C to release.");
+        spin_forever();
     }
 }
 
@@ -91,17 +100,21 @@ static void report_lock(const std::string& shm_name) {
 int main(int argc, char* argv[]) {
     cxxopts::Options options(
         "lock_virus",
-        "Inspect all UMD shared-memory locks in /dev/shm and report their state.\n"
-        "Also enumerates PCIe devices and reports expected locks that are missing.\n"
+        "Report the state of every lock UMD can take, for all PCIe and JTAG devices found.\n"
         "\n"
-        "Testing mode: --hold-lock <name> acquires the named mutex and spins forever,\n"
-        "allowing lock_virus (run separately) to observe the lock as held.");
+        "Testing mode: --hold-lock <MUTEX_TYPE> acquires that lock and spins forever, allowing\n"
+        "lock_virus (run separately) to observe it as held. Without --device the system wide\n"
+        "lock of that type is taken, with it the lock of the given device.");
 
     // clang-format off
     options.add_options()
-        ("h,help",      "Print usage")
-        ("hold-lock",   "Acquire the named mutex and hold it indefinitely (for testing)",
-                        cxxopts::value<std::string>());
+        ("h,help",        "Print usage")
+        ("hold-lock",     "Acquire the lock of the given mutex type and hold it indefinitely (for testing)",
+                          cxxopts::value<std::string>())
+        ("device",        "Device to take the lock of, when holding a chip specific lock",
+                          cxxopts::value<int>())
+        ("device-type",   "Device type to take the lock of: pcie or jtag",
+                          cxxopts::value<std::string>()->default_value("pcie"));
     // clang-format on
 
     auto result = options.parse(argc, argv);
@@ -110,85 +123,52 @@ int main(int argc, char* argv[]) {
         return 0;
     }
 
-    // ── Testing mode: hold a single lock and spin ─────────────────────────
-    if (result.count("hold-lock")) {
-        const std::string mutex_name = result["hold-lock"].as<std::string>();
-        RobustMutex m(mutex_name);
-        m.initialize();
-        if (auto owner = m.probe_lock()) {
-            log_error(
-                tt::LogUMD, "Lock '{}' is already held by PID={} TID={}", mutex_name, owner->first, owner->second);
+    try {
+        const std::string device_type_name = result["device-type"].as<std::string>();
+        if (device_type_name != "pcie" && device_type_name != "jtag") {
+            log_error(tt::LogUMD, "Unknown device type '{}', expected pcie or jtag.", device_type_name);
             return 1;
         }
-        log_info(tt::LogUMD, "Holding lock '{}' — press Ctrl-C to release.", mutex_name);
-        while (true) {
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-        }
-    }
+        const IODeviceType device_type = device_type_name == "jtag" ? IODeviceType::JTAG : IODeviceType::PCIe;
 
-    try {
-        // ── 1. Scan /dev/shm for existing UMD locks ───────────────────────
-        std::vector<std::string> found_locks = scan_umd_locks();
-
-        log_info(tt::LogUMD, "=== UMD locks found in /dev/shm ({}) ===", found_locks.size());
-        if (found_locks.empty()) {
-            log_info(tt::LogUMD, "  (none)");
-        } else {
-            for (const auto& name : found_locks) {
-                report_lock(name);
+        // ── Testing mode: hold a single lock and spin ─────────────────────
+        if (result.count("hold-lock")) {
+            const std::string mutex_name = result["hold-lock"].as<std::string>();
+            std::optional<MutexType> mutex_type = find_mutex_type(mutex_name);
+            if (!mutex_type.has_value()) {
+                log_error(tt::LogUMD, "Unknown mutex type '{}'.", mutex_name);
+                return 1;
             }
+            std::optional<int> device_id;
+            if (result.count("device")) {
+                device_id = result["device"].as<int>();
+            }
+            hold_lock(*mutex_type, device_id, device_type);
         }
 
-        // ── 2. Enumerate PCIe devices and compute expected lock names ─────
-        std::vector<int> device_ids = PCIDevice::enumerate_devices();
+        LockManager lock_manager;
 
+        log_info(tt::LogUMD, "=== System wide locks ===");
+        for (MutexType mutex_type : LockManager::SYSTEM_WIDE_MUTEX_TYPES) {
+            lock_manager.initialize_mutex(mutex_type);
+            report_state(to_string(mutex_type), lock_manager.probe_mutex(mutex_type));
+        }
+
+        std::vector<int> pcie_device_ids = PCIDevice::enumerate_devices();
         log_info(tt::LogUMD, "");
-        log_info(tt::LogUMD, "=== PCIe devices found ({}) ===", device_ids.size());
-        if (device_ids.empty()) {
-            log_info(tt::LogUMD, "  (none)");
-        } else {
-            for (int id : device_ids) {
-                log_info(tt::LogUMD, "  device {}", id);
-            }
+        log_info(tt::LogUMD, "=== PCIe devices found ({}) ===", pcie_device_ids.size());
+        for (int device_id : pcie_device_ids) {
+            log_info(tt::LogUMD, "  device {}", device_id);
+            report_device_locks(lock_manager, device_id, IODeviceType::PCIe);
         }
 
-        // Build the full set of expected lock names.
-        std::set<std::string> found_set(found_locks.begin(), found_locks.end());
-        std::vector<std::string> expected_names;
-        expected_names.reserve(
-            LockManager::SYSTEM_WIDE_MUTEX_TYPES.size() +
-            device_ids.size() * LockManager::CHIP_SPECIFIC_MUTEX_TYPES.size());
-
-        static const std::string prefix(RobustMutex::SHM_FILE_PREFIX);
-        for (MutexType type : LockManager::SYSTEM_WIDE_MUTEX_TYPES) {
-            expected_names.push_back(prefix + LockManager::MUTEX_TYPE_TO_STRING.at(type));
-        }
-        for (int id : device_ids) {
-            for (const auto& name : chip_specific_mutex_names(id)) {
-                expected_names.push_back(prefix + name);
-            }
-        }
-
-        // ── 3. Report expected locks that are missing from /dev/shm ──────
-        std::vector<std::string> missing;
-        missing.reserve(expected_names.size());
-        for (const auto& name : expected_names) {
-            if (found_set.find(name) == found_set.end()) {
-                missing.push_back(name);
-            }
-        }
-        missing.shrink_to_fit();
-
+        std::vector<int> jtag_device_ids = enumerate_jtag_devices();
         log_info(tt::LogUMD, "");
-        log_info(tt::LogUMD, "=== Expected locks missing from /dev/shm ({}) ===", missing.size());
-        if (missing.empty()) {
-            log_info(tt::LogUMD, "  (none)");
-        } else {
-            for (const auto& name : missing) {
-                log_info(tt::LogUMD, "  [MISSING]  {}", name);
-            }
+        log_info(tt::LogUMD, "=== JTAG devices found ({}) ===", jtag_device_ids.size());
+        for (int device_id : jtag_device_ids) {
+            log_info(tt::LogUMD, "  device {}", device_id);
+            report_device_locks(lock_manager, device_id, IODeviceType::JTAG);
         }
-
     } catch (const std::exception& e) {
         log_error(tt::LogUMD, "Error: {}", e.what());
         return 1;

--- a/tools/lock_virus.cpp
+++ b/tools/lock_virus.cpp
@@ -41,11 +41,16 @@ constexpr std::string_view DEVICE_TYPE_JTAG = "jtag";
 // ── reporting ─────────────────────────────────────────────────────────────────
 
 static void report_state(const std::string& mutex_name, const std::optional<std::pair<pid_t, pid_t>>& owner) {
-    if (owner.has_value()) {
-        log_info(tt::LogUMD, "    [{:<16}]  LOCKED  PID={} TID={}", mutex_name, owner->first, owner->second);
-    } else {
+    if (!owner.has_value()) {
         log_info(tt::LogUMD, "    [{:<16}]  FREE", mutex_name);
+        return;
     }
+    // A backend that cannot say who holds the lock reports {0, 0}, which is not a pid anyone has.
+    if (owner->first == 0 && owner->second == 0) {
+        log_info(tt::LogUMD, "    [{:<16}]  LOCKED  by an unknown holder", mutex_name);
+        return;
+    }
+    log_info(tt::LogUMD, "    [{:<16}]  LOCKED  PID={} TID={}", mutex_name, owner->first, owner->second);
 }
 
 static void report_device_locks(int device_id, IODeviceType device_type) {

--- a/tools/lock_virus.cpp
+++ b/tools/lock_virus.cpp
@@ -5,7 +5,16 @@
 // lock_virus: report the state (free / held, owner PID/TID) of every lock UMD can take - each mutex
 // type, for every PCIe and JTAG device found. Locks are probed through LockManager, so what gets
 // reported is the lock UMD would actually take, whichever mutex happens to back it.
+//
+// What this is for: finding out who is holding a lock when something is stuck, in particular when the
+// holder is a process nobody knows about any more. That is also why it probes every lock rather than
+// only the ones that already exist - a lock that was never taken is worth reporting as free.
+//
+// Note that probing a lock initializes it, and initializing a shared memory backed lock creates its
+// /dev/shm file. So a run leaves the backing files of every lock it reported behind. They are empty
+// locks, harmless to UMD, but it does mean "which lock files exist" says nothing after the first run.
 
+#include <chrono>
 #include <cxxopts.hpp>
 #include <iostream>
 #include <memory>
@@ -21,6 +30,13 @@
 #include "umd/device/utils/lock_manager.hpp"
 
 using namespace tt::umd;
+
+namespace {
+
+constexpr std::string_view DEVICE_TYPE_PCIE = "pcie";
+constexpr std::string_view DEVICE_TYPE_JTAG = "jtag";
+
+}  // namespace
 
 // ── reporting ─────────────────────────────────────────────────────────────────
 
@@ -46,9 +62,10 @@ static void report_device_locks(LockManager& lock_manager, int device_id, IODevi
 static std::vector<int> enumerate_jtag_devices() {
     try {
         std::unique_ptr<JtagDevice> jtag_device = JtagDevice::create();
+        const uint32_t device_count = jtag_device->get_device_cnt();
         std::vector<int> device_ids;
-        device_ids.reserve(jtag_device->get_device_cnt());
-        for (uint32_t index = 0; index < jtag_device->get_device_cnt(); index++) {
+        device_ids.reserve(device_count);
+        for (uint32_t index = 0; index < device_count; index++) {
             device_ids.push_back(static_cast<int>(index));
         }
         return device_ids;
@@ -60,18 +77,25 @@ static std::vector<int> enumerate_jtag_devices() {
 
 // ── testing mode ──────────────────────────────────────────────────────────────
 
-static std::optional<MutexType> find_mutex_type(const std::string& mutex_name) {
-    for (MutexType mutex_type : LockManager::SYSTEM_WIDE_MUTEX_TYPES) {
-        if (to_string(mutex_type) == mutex_name) {
-            return mutex_type;
-        }
-    }
-    for (MutexType mutex_type : LockManager::CHIP_SPECIFIC_MUTEX_TYPES) {
+static std::optional<MutexType> find_mutex_type(
+    const std::vector<MutexType>& mutex_types, const std::string& mutex_name) {
+    for (MutexType mutex_type : mutex_types) {
         if (to_string(mutex_type) == mutex_name) {
             return mutex_type;
         }
     }
     return std::nullopt;
+}
+
+static std::string join_mutex_type_names(const std::vector<MutexType>& mutex_types) {
+    std::string names;
+    for (MutexType mutex_type : mutex_types) {
+        if (!names.empty()) {
+            names += ", ";
+        }
+        names += to_string(mutex_type);
+    }
+    return names;
 }
 
 static void spin_forever() {
@@ -101,10 +125,14 @@ int main(int argc, char* argv[]) {
     cxxopts::Options options(
         "lock_virus",
         "Report the state of every lock UMD can take, for all PCIe and JTAG devices found.\n"
+        "Meant for finding out who holds a lock when something is stuck.\n"
+        "\n"
+        "Probing a lock initializes it, so a run creates the /dev/shm file of every shared memory\n"
+        "backed lock it reports and leaves it behind. The files are harmless.\n"
         "\n"
         "Testing mode: --hold-lock <MUTEX_TYPE> acquires that lock and spins forever, allowing\n"
-        "lock_virus (run separately) to observe it as held. Without --device the system wide\n"
-        "lock of that type is taken, with it the lock of the given device.");
+        "lock_virus (run separately) to observe it as held. Without --device a system wide lock\n"
+        "is taken, with it the chip specific lock of the given device.");
 
     // clang-format off
     options.add_options()
@@ -113,7 +141,7 @@ int main(int argc, char* argv[]) {
                           cxxopts::value<std::string>())
         ("device",        "Device to take the lock of, when holding a chip specific lock",
                           cxxopts::value<int>())
-        ("device-type",   "Device type to take the lock of: pcie or jtag",
+        ("device-type",   "Device type to take the lock of, lowercase: pcie or jtag",
                           cxxopts::value<std::string>()->default_value("pcie"));
     // clang-format on
 
@@ -125,23 +153,39 @@ int main(int argc, char* argv[]) {
 
     try {
         const std::string device_type_name = result["device-type"].as<std::string>();
-        if (device_type_name != "pcie" && device_type_name != "jtag") {
-            log_error(tt::LogUMD, "Unknown device type '{}', expected pcie or jtag.", device_type_name);
+        if (device_type_name != DEVICE_TYPE_PCIE && device_type_name != DEVICE_TYPE_JTAG) {
+            log_error(
+                tt::LogUMD,
+                "Unknown device type '{}', expected {} or {}.",
+                device_type_name,
+                DEVICE_TYPE_PCIE,
+                DEVICE_TYPE_JTAG);
             return 1;
         }
-        const IODeviceType device_type = device_type_name == "jtag" ? IODeviceType::JTAG : IODeviceType::PCIe;
+        const IODeviceType device_type = device_type_name == DEVICE_TYPE_JTAG ? IODeviceType::JTAG : IODeviceType::PCIe;
 
         // ── Testing mode: hold a single lock and spin ─────────────────────
         if (result.count("hold-lock")) {
             const std::string mutex_name = result["hold-lock"].as<std::string>();
-            std::optional<MutexType> mutex_type = find_mutex_type(mutex_name);
-            if (!mutex_type.has_value()) {
-                log_error(tt::LogUMD, "Unknown mutex type '{}'.", mutex_name);
-                return 1;
-            }
             std::optional<int> device_id;
             if (result.count("device")) {
                 device_id = result["device"].as<int>();
+            }
+
+            // A mutex type is either system wide or chip specific, and --device is what picks between
+            // the two. Holding the wrong one would take a lock UMD never takes, and which this tool
+            // would never report either, so the type has to exist in the form being asked for.
+            const std::vector<MutexType>& holdable_types =
+                device_id.has_value() ? LockManager::CHIP_SPECIFIC_MUTEX_TYPES : LockManager::SYSTEM_WIDE_MUTEX_TYPES;
+            std::optional<MutexType> mutex_type = find_mutex_type(holdable_types, mutex_name);
+            if (!mutex_type.has_value()) {
+                log_error(
+                    tt::LogUMD,
+                    "'{}' is not a {} mutex type. Expected one of: {}",
+                    mutex_name,
+                    device_id.has_value() ? "chip specific" : "system wide",
+                    join_mutex_type_names(holdable_types));
+                return 1;
             }
             hold_lock(*mutex_type, device_id, device_type);
         }


### PR DESCRIPTION
### Issue
#2745

### Description
**DO NOT MERGE** until #3232 is rolled out to every client. This PR is the second half of that one
and only becomes safe once nothing takes the shared memory lock alone any more.

#3232 has chip specific PCIe locks take both a KMD resource lock and the shared memory lock of the
same name, so that a process on a UMD version predating KMD locks still serializes against one that
has them. Once every client is on a UMD that takes the KMD lock, that half is dead weight: it costs
a /dev/shm file and a second lock operation per acquisition, and it is the only reason UMD still
needs a shared /dev/shm for these locks at all.

Merging this before every client is updated leaves an old process taking a lock nothing else takes,
which means it serializes against nothing.

### List of the changes
- Drop CompositeMutex, chip specific PCIe locks now use KmdMutex directly
- The test asserts the shared memory lock is no longer taken

### Testing
umd_misc_tests. The test needs a card and is skipped without one.

### API Changes
This PR has no API changes.

Part of stack #3261, but deliberately not in it: this one waits until #3232 is deployed everywhere.

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/locks_11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
