### PR TITLE
[base API] Derive is_remote() from the remote interface

### DIFF
--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -572,8 +572,6 @@ protected:
 
     void set_hang_detector(std::unique_ptr<HangDetector> hang_detector);
 
-    bool is_remote_tt_device = false;
-
     xy_pair arc_core_noc0;
     xy_pair arc_core_noc1;
 

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -291,7 +291,7 @@ RemoteCommunication *TTDevice::get_remote_communication() {
 }
 
 void TTDevice::set_power_state(TTDevice::PowerState state, NocId /*noc_id*/) {
-    if (is_remote_tt_device || !pcie_capabilities_) {
+    if (is_remote() || !pcie_capabilities_) {
         return;
     }
     get_pci_device()->set_power_state(state == TTDevice::PowerState::BUSY);
@@ -619,7 +619,7 @@ void TTDevice::wait_for_non_mmio_flush() {
     get_remote_interface()->get_remote_communication()->wait_for_non_mmio_flush();
 }
 
-bool TTDevice::is_remote() { return is_remote_tt_device; }
+bool TTDevice::is_remote() { return remote_capabilities_ != nullptr; }
 
 int TTDevice::get_communication_device_id() const { return model_->get_communication_device_id(); }
 
@@ -731,13 +731,13 @@ void TTDevice::noc_multicast_write(
     log_trace(
         LogUMD,
         "Multicast on {} chip write to cores {} - {} {}",
-        is_remote_tt_device ? "remote" : "local",
+        is_remote() ? "remote" : "local",
         translated_start.str(),
         translated_end.str(),
         multicast_success ? "succeeded" : "failed, running unicast fallback.");
 
     // We need to flush the writes in case of remote communication.
-    if (multicast_success && is_remote_tt_device) {
+    if (multicast_success && is_remote()) {
         get_remote_communication()->wait_for_non_mmio_flush();
     }
 
@@ -746,7 +746,7 @@ void TTDevice::noc_multicast_write(
     }
 
     multicast_write_via_unicast(src, size, core_start, core_end, addr, noc_id);
-    if (is_remote_tt_device) {
+    if (is_remote()) {
         get_remote_communication()->wait_for_non_mmio_flush();
     }
 }
@@ -781,7 +781,7 @@ void TTDevice::multicast_write_via_unicast(
 }
 
 int TTDevice::export_dmabuf(CoreCoord core, uint64_t addr, size_t size, uint64_t ordering, NocId noc_id) {
-    if (is_remote_tt_device) {
+    if (is_remote()) {
         UMD_THROW(error::RuntimeError, "Exporting a dma-buf is not supported for remote device.");
     }
     return get_pcie_interface()->export_dmabuf(resolve_coordinate(core, noc_id), addr, size, ordering, noc_id);
@@ -789,7 +789,7 @@ int TTDevice::export_dmabuf(CoreCoord core, uint64_t addr, size_t size, uint64_t
 
 void TTDevice::dma_write_to_device(const void *src, size_t size, CoreCoord core, uint64_t addr, NocId noc_id) {
     ZoneScopedC(tracy::Color::MediumPurple);
-    if (is_remote_tt_device) {
+    if (is_remote()) {
         UMD_THROW(error::RuntimeError, "DMA write to device not supported for remote device.");
     }
     auto pcie_dma_lock =
@@ -808,7 +808,7 @@ void TTDevice::dma_write_to_device(const void *src, size_t size, CoreCoord core,
 
 void TTDevice::dma_read_from_device(void *dst, size_t size, CoreCoord core, uint64_t addr, NocId noc_id) {
     ZoneScopedC(tracy::Color::MediumPurple);
-    if (is_remote_tt_device) {
+    if (is_remote()) {
         UMD_THROW(error::RuntimeError, "DMA read from device not supported for remote device.");
     }
     auto pcie_dma_lock =
@@ -828,7 +828,7 @@ void TTDevice::dma_read_from_device(void *dst, size_t size, CoreCoord core, uint
 void TTDevice::dma_multicast_write(
     void *src, size_t size, CoreCoord core_start, CoreCoord core_end, uint64_t addr, NocId noc_id) {
     ZoneScopedC(tracy::Color::MediumPurple);
-    if (is_remote_tt_device) {
+    if (is_remote()) {
         UMD_THROW(error::RuntimeError, "DMA multicast write not supported for remote device.");
     }
     auto pcie_dma_lock =
@@ -849,7 +849,7 @@ void TTDevice::dma_multicast_write(
 
 void TTDevice::dma_read_zero_copy(uint64_t dst_iova, uint64_t src_addr, size_t size, CoreCoord core, NocId noc_id) {
     ZoneScopedC(tracy::Color::MediumPurple);
-    if (is_remote_tt_device) {
+    if (is_remote()) {
         UMD_THROW(error::RuntimeError, "DMA zero-copy read not supported for remote device.");
     }
     auto pcie_dma_lock =
@@ -864,7 +864,7 @@ void TTDevice::dma_read_zero_copy(uint64_t dst_iova, uint64_t src_addr, size_t s
 
 void TTDevice::dma_write_zero_copy(uint64_t src_iova, uint64_t dst_addr, size_t size, CoreCoord core, NocId noc_id) {
     ZoneScopedC(tracy::Color::MediumPurple);
-    if (is_remote_tt_device) {
+    if (is_remote()) {
         UMD_THROW(error::RuntimeError, "DMA zero-copy write not supported for remote device.");
     }
     auto pcie_dma_lock =

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -80,7 +80,6 @@ WormholeTTDevice::WormholeTTDevice(
         std::make_unique<WormholeImplementation>(),
         soc_arch_descriptor) {
     WormholeTTDevice::set_arc_coordinate();
-    is_remote_tt_device = true;
     set_hang_detector(std::make_unique<WormholeHangDetector>(
         TTDevice::get_remote_interface()->get_remote_communication()->get_local_device()->get_device_protocol()));
 }
@@ -195,7 +194,7 @@ void WormholeTTDevice::read_from_arc_apb(void *mem_ptr, uint64_t arc_addr_offset
     if (arc_addr_offset > wormhole::ARC_APB_ADDRESS_RANGE) {
         UMD_THROW(error::RuntimeError, "Address is out of ARC APB address range.");
     }
-    if (is_remote_tt_device) {
+    if (is_remote()) {
         read_from_device_reg(mem_ptr, get_arc_core(), registers_.arc_apb_noc_base_address + arc_addr_offset, size);
         return;
     }
@@ -216,7 +215,7 @@ void WormholeTTDevice::write_to_arc_apb(const void *mem_ptr, uint64_t arc_addr_o
     if (arc_addr_offset > wormhole::ARC_APB_ADDRESS_RANGE) {
         UMD_THROW(error::RuntimeError, "Address is out of ARC APB address range.");
     }
-    if (is_remote_tt_device) {
+    if (is_remote()) {
         write_to_device_reg(mem_ptr, get_arc_core(), registers_.arc_apb_noc_base_address + arc_addr_offset, size);
         return;
     }
@@ -236,7 +235,7 @@ void WormholeTTDevice::read_from_arc_csm(void *mem_ptr, uint64_t arc_addr_offset
     if (arc_addr_offset > wormhole::ARC_CSM_ADDRESS_RANGE) {
         UMD_THROW(error::RuntimeError, "Address is out of ARC CSM address range.");
     }
-    if (is_remote_tt_device) {
+    if (is_remote()) {
         read_from_device(mem_ptr, get_arc_core(), wormhole::ARC_CSM_NOC_BASE_ADDRESS + arc_addr_offset, size);
         return;
     }
@@ -257,7 +256,7 @@ void WormholeTTDevice::write_to_arc_csm(const void *mem_ptr, uint64_t arc_addr_o
     if (arc_addr_offset > wormhole::ARC_CSM_ADDRESS_RANGE) {
         UMD_THROW(error::RuntimeError, "Address is out of ARC CSM address range.");
     }
-    if (is_remote_tt_device) {
+    if (is_remote()) {
         write_to_device(mem_ptr, get_arc_core(), wormhole::ARC_CSM_NOC_BASE_ADDRESS + arc_addr_offset, size);
         return;
     }


### PR DESCRIPTION
### Issue
#2864

### Description
TTDevice tracked remoteness twice: `is_remote_tt_device`, set by
`WormholeTTDevice`'s remote constructor, and `remote_capabilities_`, set by
`TTDevice`'s. Both are set on exactly the same path -- remote creation only ever
goes through that constructor pair, since `create()` and
`create_simulation_remote()` both throw for non-Wormhole -- so the flag carries
no information the remote interface does not already have.

Split out of the TTDeviceModel stack ahead of the DeviceProtocol move, which
collapses the TTDevice constructors and would otherwise leave the flag with
nowhere to be set.

### List of the changes
- Drop `is_remote_tt_device`; `is_remote()` now returns whether the remote
interface is present.
- Update its call sites in `TTDevice` and `WormholeTTDevice` to use `is_remote()`.

### Testing
CI

### API Changes
This PR has API changes: the protected `is_remote_tt_device` member is removed from
`TTDevice`. The public `is_remote()` is unchanged in both signature and semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/tt_device_model_hang_detector

