### PR TITLE
[base API] Move DeviceProtocol into TTDeviceModel

### DIFF
--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -56,15 +56,7 @@ public:
 
 protected:
     BlackholeTTDevice(
-        std::unique_ptr<TTDeviceModel> model,
-        std::unique_ptr<PCIDevice> pci_device,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
-        bool use_safe_api);
-    BlackholeTTDevice(
-        std::unique_ptr<TTDeviceModel> model,
-        std::unique_ptr<JtagDevice> jtag_device,
-        uint8_t jlink_id,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
+        std::unique_ptr<TTDeviceModel> model, const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
 
     virtual bool is_arc_available_over_axi();
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -529,24 +529,12 @@ protected:
     std::unique_ptr<ArchitectureImplementation> architecture_impl_;
     LockManager lock_manager;
 
-    // This overload is for backends with no host transport; the others additionally take the
-    // transport pieces TTDevice still owns itself.
+    // Every TTDevice is built around a model, which supplies its identity, the protocol it talks to
+    // hardware over and -- as components are decoupled from TTDevice -- the components it runs on.
+    // The transport no longer reaches TTDevice at all; the model owns it.
     TTDevice(std::unique_ptr<TTDeviceModel> model, std::unique_ptr<ArchitectureImplementation> architecture_impl);
     TTDevice(
         std::unique_ptr<TTDeviceModel> model,
-        std::unique_ptr<PCIDevice> pci_device,
-        std::unique_ptr<ArchitectureImplementation> architecture_impl,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
-        bool use_safe_api);
-    TTDevice(
-        std::unique_ptr<TTDeviceModel> model,
-        std::unique_ptr<JtagDevice> jtag_device,
-        uint8_t jlink_id,
-        std::unique_ptr<ArchitectureImplementation> architecture_impl,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
-    TTDevice(
-        std::unique_ptr<TTDeviceModel> model,
-        std::unique_ptr<RemoteCommunication> remote_communication,
         std::unique_ptr<ArchitectureImplementation> architecture_impl,
         const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
 
@@ -599,13 +587,7 @@ private:
     std::unique_ptr<ArcMessenger> arc_messenger_ = nullptr;
     std::unique_ptr<FirmwareTelemetryReader> telemetry = nullptr;
     std::unique_ptr<FirmwareInfoProvider> firmware_info_provider = nullptr;
-    std::unique_ptr<DeviceProtocol> device_protocol_;
     std::unique_ptr<HangDetector> hang_detector_;
-    PcieInterface *pcie_capabilities_ = nullptr;
-    DmaInterface *dma_capabilities_ = nullptr;
-    PcieProtocol *pcie_protocol_ = nullptr;
-    JtagInterface *jtag_capabilities_ = nullptr;
-    RemoteInterface *remote_capabilities_ = nullptr;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -55,19 +55,7 @@ public:
 
 protected:
     WormholeTTDevice(
-        std::unique_ptr<TTDeviceModel> model,
-        std::unique_ptr<PCIDevice> pci_device,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
-        bool use_safe_api);
-    WormholeTTDevice(
-        std::unique_ptr<TTDeviceModel> model,
-        std::unique_ptr<JtagDevice> jtag_device,
-        uint8_t jlink_id,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
-    WormholeTTDevice(
-        std::unique_ptr<TTDeviceModel> model,
-        std::unique_ptr<RemoteCommunication> remote_communication,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
+        std::unique_ptr<TTDeviceModel> model, const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
 
     void retrain_dram_core(const uint32_t dram_channel) override;
 

--- a/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
@@ -4,21 +4,49 @@
 
 #pragma once
 
+#include <memory>
+
 #include "umd/device/tt_device_model/tt_device_model.hpp"
 
 namespace tt::umd {
 
-// Model for a Blackhole device, over any transport that reaches one.
+class JtagDevice;
+class RemoteCommunication;
+
+// Model for a Blackhole device, over any transport that reaches one. Each constructor builds the
+// protocol for its transport and, knowing the concrete protocol type, records the interfaces that
+// protocol provides -- the rest stay null.
 class BlackholeTTDeviceModel : public TTDeviceModel {
 public:
-    explicit BlackholeTTDeviceModel(int communication_device_id);
+    BlackholeTTDeviceModel(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api);
+    BlackholeTTDeviceModel(std::unique_ptr<JtagDevice> jtag_device, uint8_t jlink_id);
 
     tt::ARCH get_arch() const override;
 
     int get_communication_device_id() const override;
 
+    DeviceProtocol *get_device_protocol() override;
+
+    PcieInterface *get_pcie_interface() override;
+
+    DmaInterface *get_dma_interface() override;
+
+    JtagInterface *get_jtag_interface() override;
+
+    RemoteInterface *get_remote_interface() override;
+
+    PCIDevice *get_pci_device() override;
+
 private:
     int communication_device_id_;
+
+    std::unique_ptr<DeviceProtocol> protocol_;
+    PcieInterface *pcie_interface_ = nullptr;
+    DmaInterface *dma_interface_ = nullptr;
+    JtagInterface *jtag_interface_ = nullptr;
+    RemoteInterface *remote_interface_ = nullptr;
+    // Owned by the PCIe protocol; retained only to serve get_pci_device().
+    PCIDevice *pci_device_ = nullptr;
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device_model/simulation_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/simulation_tt_device_model.hpp
@@ -21,6 +21,8 @@ public:
 
     int get_communication_device_id() const override;
 
+    DeviceProtocol *get_device_protocol() override;
+
 private:
     tt::ARCH arch_;
 };

--- a/device/api/umd/device/tt_device_model/tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/tt_device_model.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/types/arch.hpp"
 
 namespace tt::umd {
@@ -12,6 +13,7 @@ class DmaInterface;
 class FirmwareTelemetryReader;
 class HangDetector;
 class JtagInterface;
+class PCIDevice;
 class PcieInterface;
 class RemoteInterface;
 
@@ -22,15 +24,15 @@ class RemoteInterface;
  * device-specific choices are made here rather than spread across TTDevice subclasses.
  *
  * Models are specialized by architecture, and by backend for simulation. The transport is
- * deliberately not a subclass axis, so one architecture model serves every transport that
- * architecture supports.
+ * deliberately not a subclass axis: it selects a constructor instead, so one architecture model
+ * serves every transport that architecture supports.
  *
  * This is a pure interface: it holds no state and provides no constructor, so each concrete model
  * declares whatever it needs to answer with. Required components are pure virtual; optional ones
  * return nullptr, and a concrete model overrides only those it actually provides.
  *
- * TODO: temporary note - components are declared here as they are decoupled from TTDevice, so no
- * required component appears yet. Remove this note once the migration is done.
+ * TODO: temporary note - components are declared here as they are decoupled from TTDevice, so only
+ * some of the required ones appear so far. Remove this note once the migration is done.
  */
 class TTDeviceModel {
 public:
@@ -46,6 +48,9 @@ public:
     // once DeviceProtocol moves here.
     virtual int get_communication_device_id() const = 0;
 
+    // Required components.
+    virtual DeviceProtocol *get_device_protocol() = 0;
+
     // Optional components.
     virtual HangDetector *get_hang_detector() { return nullptr; }
 
@@ -59,6 +64,10 @@ public:
     virtual JtagInterface *get_jtag_interface() { return nullptr; }
 
     virtual RemoteInterface *get_remote_interface() { return nullptr; }
+
+    // TODO: temporary - delete along with TTDevice::get_pci_device() once callers go through
+    // PcieInterface only.
+    virtual PCIDevice *get_pci_device() { return nullptr; }
 };
 
 }  // namespace tt::umd

--- a/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
@@ -4,21 +4,50 @@
 
 #pragma once
 
+#include <memory>
+
 #include "umd/device/tt_device_model/tt_device_model.hpp"
 
 namespace tt::umd {
 
-// Model for a Wormhole device, over any transport that reaches one.
+class JtagDevice;
+class RemoteCommunication;
+
+// Model for a Wormhole device, over any transport that reaches one. Each constructor builds the
+// protocol for its transport and, knowing the concrete protocol type, records the interfaces that
+// protocol provides -- the rest stay null.
 class WormholeTTDeviceModel : public TTDeviceModel {
 public:
-    explicit WormholeTTDeviceModel(int communication_device_id);
+    WormholeTTDeviceModel(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api);
+    WormholeTTDeviceModel(std::unique_ptr<JtagDevice> jtag_device, uint8_t jlink_id);
+    explicit WormholeTTDeviceModel(std::unique_ptr<RemoteCommunication> remote_communication);
 
     tt::ARCH get_arch() const override;
 
     int get_communication_device_id() const override;
 
+    DeviceProtocol *get_device_protocol() override;
+
+    PcieInterface *get_pcie_interface() override;
+
+    DmaInterface *get_dma_interface() override;
+
+    JtagInterface *get_jtag_interface() override;
+
+    RemoteInterface *get_remote_interface() override;
+
+    PCIDevice *get_pci_device() override;
+
 private:
     int communication_device_id_;
+
+    std::unique_ptr<DeviceProtocol> protocol_;
+    PcieInterface *pcie_interface_ = nullptr;
+    DmaInterface *dma_interface_ = nullptr;
+    JtagInterface *jtag_interface_ = nullptr;
+    RemoteInterface *remote_interface_ = nullptr;
+    // Owned by the PCIe protocol; retained only to serve get_pci_device().
+    PCIDevice *pci_device_ = nullptr;
 };
 
 }  // namespace tt::umd

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -42,32 +42,8 @@
 namespace tt::umd {
 
 BlackholeTTDevice::BlackholeTTDevice(
-    std::unique_ptr<TTDeviceModel> model,
-    std::unique_ptr<PCIDevice> pci_device,
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
-    bool use_safe_api) :
-    TTDevice(
-        std::move(model),
-        std::move(pci_device),
-        std::make_unique<BlackholeImplementation>(),
-        soc_arch_descriptor,
-        use_safe_api) {
-    BlackholeTTDevice::set_arc_coordinate();
-    set_hang_detector(std::make_unique<BlackholeHangDetector>(
-        get_device_protocol(), BlackholeTTDevice::get_noc_translation_enabled()));
-}
-
-BlackholeTTDevice::BlackholeTTDevice(
-    std::unique_ptr<TTDeviceModel> model,
-    std::unique_ptr<JtagDevice> jtag_device,
-    uint8_t jlink_id,
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
-    TTDevice(
-        std::move(model),
-        std::move(jtag_device),
-        jlink_id,
-        std::make_unique<BlackholeImplementation>(),
-        soc_arch_descriptor) {
+    std::unique_ptr<TTDeviceModel> model, const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
+    TTDevice(std::move(model), std::make_unique<BlackholeImplementation>(), soc_arch_descriptor) {
     BlackholeTTDevice::set_arc_coordinate();
     set_hang_detector(std::make_unique<BlackholeHangDetector>(
         get_device_protocol(), BlackholeTTDevice::get_noc_translation_enabled()));

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -73,50 +73,16 @@ TTDevice::TTDevice(
 
 TTDevice::TTDevice(
     std::unique_ptr<TTDeviceModel> model,
-    std::unique_ptr<PCIDevice> pci_device,
     std::unique_ptr<ArchitectureImplementation> architecture_impl,
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
-    bool use_safe_api) :
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     architecture_impl_(std::move(architecture_impl)), model_(std::move(model)) {
     assign_soc_arch_descriptor(soc_arch_descriptor);
 
-    auto pcie_protocol = std::make_unique<PcieProtocol>(std::move(pci_device), use_safe_api);
-    pcie_capabilities_ = pcie_protocol.get();
-    dma_capabilities_ = pcie_protocol.get();
-    pcie_protocol_ = pcie_protocol.get();
-    device_protocol_ = std::move(pcie_protocol);
-    // Initialize PCIe DMA mutex through LockManager for cross-process synchronization.
-    lock_manager.initialize_mutex(MutexType::PCIE_DMA, get_communication_device_id(), get_communication_device_type());
-    if (use_safe_api) {
-        set_sigbus_safe_handler(true);
+    if (model_->get_pcie_interface() != nullptr) {
+        // Initialize PCIe DMA mutex through LockManager for cross-process synchronization.
+        lock_manager.initialize_mutex(
+            MutexType::PCIE_DMA, get_communication_device_id(), get_communication_device_type());
     }
-}
-
-TTDevice::TTDevice(
-    std::unique_ptr<TTDeviceModel> model,
-    std::unique_ptr<JtagDevice> jtag_device,
-    uint8_t jlink_id,
-    std::unique_ptr<ArchitectureImplementation> architecture_impl,
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
-    architecture_impl_(std::move(architecture_impl)), model_(std::move(model)) {
-    assign_soc_arch_descriptor(soc_arch_descriptor);
-
-    auto jtag_protocol = std::make_unique<JtagProtocol>(std::move(jtag_device), jlink_id);
-    jtag_capabilities_ = jtag_protocol.get();
-    device_protocol_ = std::move(jtag_protocol);
-}
-
-TTDevice::TTDevice(
-    std::unique_ptr<TTDeviceModel> model,
-    std::unique_ptr<RemoteCommunication> remote_communication,
-    std::unique_ptr<ArchitectureImplementation> architecture_impl,
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
-    architecture_impl_(std::move(architecture_impl)), model_(std::move(model)) {
-    assign_soc_arch_descriptor(soc_arch_descriptor);
-
-    auto remote_protocol = std::make_unique<RemoteProtocol>(std::move(remote_communication));
-    remote_capabilities_ = remote_protocol.get();
-    device_protocol_ = std::move(remote_protocol);
 }
 
 void TTDevice::assign_soc_arch_descriptor(const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
@@ -136,7 +102,7 @@ void TTDevice::assign_soc_arch_descriptor(const std::shared_ptr<SocArchDescripto
 
 void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     ZoneScopedC(tracy::Color::DarkGreen);
-    if (pcie_capabilities_ != nullptr) {
+    if (model_->get_pcie_interface() != nullptr) {
         is_pcie_hung();
     }
     bool noc_hang_check_result =
@@ -175,15 +141,11 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
         switch (arch) {
             case ARCH::WORMHOLE_B0:
                 return std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(
-                    std::make_unique<WormholeTTDeviceModel>(device_number),
-                    std::move(jtag_device),
-                    device_number,
+                    std::make_unique<WormholeTTDeviceModel>(std::move(jtag_device), device_number),
                     soc_arch_descriptor));
             case ARCH::BLACKHOLE:
                 return std::unique_ptr<BlackholeTTDevice>(new BlackholeTTDevice(
-                    std::make_unique<BlackholeTTDeviceModel>(device_number),
-                    std::move(jtag_device),
-                    device_number,
+                    std::make_unique<BlackholeTTDeviceModel>(std::move(jtag_device), device_number),
                     soc_arch_descriptor));
             default:
                 UMD_THROW(
@@ -194,22 +156,14 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
 
     auto pci_device = std::make_unique<PCIDevice>(device_number);
     arch = pci_device->get_arch();
-    // Read before the pci_device is moved from: argument evaluation order is unspecified.
-    const int pci_device_num = pci_device->get_device_num();
 
     switch (arch) {
         case ARCH::WORMHOLE_B0:
             return std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(
-                std::make_unique<WormholeTTDeviceModel>(pci_device_num),
-                std::move(pci_device),
-                soc_arch_descriptor,
-                use_safe_api));
+                std::make_unique<WormholeTTDeviceModel>(std::move(pci_device), use_safe_api), soc_arch_descriptor));
         case ARCH::BLACKHOLE:
             return std::unique_ptr<BlackholeTTDevice>(new BlackholeTTDevice(
-                std::make_unique<BlackholeTTDeviceModel>(pci_device_num),
-                std::move(pci_device),
-                soc_arch_descriptor,
-                use_safe_api));
+                std::make_unique<BlackholeTTDeviceModel>(std::move(pci_device), use_safe_api), soc_arch_descriptor));
         default:
             UMD_THROW(
                 error::RuntimeError,
@@ -224,12 +178,9 @@ std::unique_ptr<TTDevice> TTDevice::create(
     UMD_ASSERT(remote_communication != nullptr, error::RuntimeError, "RemoteCommunication pointer cannot be null.");
     tt::ARCH arch = remote_communication->get_local_device()->get_arch();
     switch (arch) {
-        case tt::ARCH::WORMHOLE_B0: {
-            auto model = std::make_unique<WormholeTTDeviceModel>(
-                remote_communication->get_local_device()->get_communication_device_id());
-            return std::unique_ptr<WormholeTTDevice>(
-                new WormholeTTDevice(std::move(model), std::move(remote_communication), soc_arch_descriptor));
-        }
+        case tt::ARCH::WORMHOLE_B0:
+            return std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(
+                std::make_unique<WormholeTTDeviceModel>(std::move(remote_communication)), soc_arch_descriptor));
         default:
             UMD_THROW(
                 error::RuntimeError,
@@ -252,10 +203,9 @@ std::unique_ptr<TTDevice> TTDevice::create_simulation_remote(
             arch_to_str(arch)));
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: {
-            auto model = std::make_unique<WormholeTTDeviceModel>(
-                remote_communication->get_local_device()->get_communication_device_id());
             auto device = std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(
-                std::move(model), std::move(remote_communication), /*soc_arch_descriptor=*/nullptr));
+                std::make_unique<WormholeTTDeviceModel>(std::move(remote_communication)),
+                /*soc_arch_descriptor=*/nullptr));
             // This device is never run through init_tt_device() (no ARC to probe), so construct_soc_descriptor()
             // never overwrites the descriptor set here; set_soc_descriptor keeps the assign-exactly-once invariant.
             device->set_soc_descriptor(soc_descriptor);
@@ -276,22 +226,15 @@ ArchitectureImplementation *TTDevice::get_architecture_implementation() { return
 // Throwing an exception would break existing behavior and require significant changes across client code.
 // This approach is intended as a temporary measure until the API is updated to use tl::expected or std::optional,
 // providing callers with an explicit way to check validity rather than relying on nullptr semantics.
-PCIDevice *TTDevice::get_pci_device() {
-    if (!pcie_capabilities_) {
-        return nullptr;
-    }
-    return pcie_protocol_->get_pci_device();
-}
+PCIDevice *TTDevice::get_pci_device() { return model_->get_pci_device(); }
 
 RemoteCommunication *TTDevice::get_remote_communication() {
-    if (!remote_capabilities_) {
-        return nullptr;
-    }
-    return get_remote_interface()->get_remote_communication();
+    RemoteInterface *remote_interface = model_->get_remote_interface();
+    return remote_interface == nullptr ? nullptr : remote_interface->get_remote_communication();
 }
 
 void TTDevice::set_power_state(TTDevice::PowerState state, NocId /*noc_id*/) {
-    if (is_remote() || !pcie_capabilities_) {
+    if (is_remote() || model_->get_pcie_interface() == nullptr) {
         return;
     }
     get_pci_device()->set_power_state(state == TTDevice::PowerState::BUSY);
@@ -373,34 +316,38 @@ void TTDevice::log_aiclk_timeout_warning(uint32_t target_aiclk, std::chrono::mil
     }
 }
 
-DeviceProtocol *TTDevice::get_device_protocol() { return device_protocol_.get(); }
+DeviceProtocol *TTDevice::get_device_protocol() { return model_->get_device_protocol(); }
 
 PcieInterface *TTDevice::get_pcie_interface() {
-    if (!pcie_capabilities_) {
+    PcieInterface *pcie_interface = model_->get_pcie_interface();
+    if (!pcie_interface) {
         UMD_THROW(error::RuntimeError, "PCIe interface is not available for this device.");
     }
-    return pcie_capabilities_;
+    return pcie_interface;
 }
 
 DmaInterface *TTDevice::get_dma_interface() {
-    if (!dma_capabilities_) {
+    DmaInterface *dma_interface = model_->get_dma_interface();
+    if (!dma_interface) {
         UMD_THROW(error::RuntimeError, "DMA interface is not available for this device.");
     }
-    return dma_capabilities_;
+    return dma_interface;
 }
 
 JtagInterface *TTDevice::get_jtag_interface() {
-    if (!jtag_capabilities_) {
+    JtagInterface *jtag_interface = model_->get_jtag_interface();
+    if (!jtag_interface) {
         UMD_THROW(error::RuntimeError, "JTAG interface is not available for this device.");
     }
-    return jtag_capabilities_;
+    return jtag_interface;
 }
 
 RemoteInterface *TTDevice::get_remote_interface() {
-    if (!remote_capabilities_) {
+    RemoteInterface *remote_interface = model_->get_remote_interface();
+    if (!remote_interface) {
         UMD_THROW(error::RuntimeError, "Remote interface is not available for this device.");
     }
-    return remote_capabilities_;
+    return remote_interface;
 }
 
 tt::ARCH TTDevice::get_arch() const { return model_->get_arch(); }
@@ -447,20 +394,20 @@ void TTDevice::set_hang_detector(std::unique_ptr<HangDetector> hang_detector) {
     hang_detector_ = std::move(hang_detector);
 
     // The per-op timed MMIO path is PCIe-specific, so the hang-check wiring only applies to PCIe devices.
-    if (pcie_capabilities_ == nullptr) {
+    if (model_->get_pcie_interface() == nullptr) {
         return;
     }
 
     // A null detector disables hang detection: clear any previously wired callback and stop before
     // dereferencing it below.
     if (hang_detector_ == nullptr) {
-        pcie_capabilities_->set_io_timeout_callback({});
+        get_pcie_interface()->set_io_timeout_callback({});
         return;
     }
 
     // Route a single-op memcpy overrun to a NOC liveness check on the in-flight op's NOC: a hung NOC
     // aborts the transfer with DeviceTimeoutError; a healthy NOC lets it continue.
-    pcie_capabilities_->set_io_timeout_callback(
+    get_pcie_interface()->set_io_timeout_callback(
         [this](NocId noc) -> bool { return is_noc_hung(noc, HangAction::RETURN); });
 
     // The liveness check runs from inside a timed-out memcpy that holds io_lock_, so it must read through a
@@ -510,22 +457,22 @@ std::unique_ptr<TlbWindow> TTDevice::get_io_window(tlb_data config, TlbMapping m
 
 void TTDevice::read_from_device(void *mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id) {
     ZoneScopedC(tracy::Color::Orange);
-    device_protocol_->read_data(mem_ptr, resolve_coordinate(core, noc_id), addr, size, noc_id);
+    get_device_protocol()->read_data(mem_ptr, resolve_coordinate(core, noc_id), addr, size, noc_id);
 }
 
 void TTDevice::write_to_device(const void *mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id) {
     ZoneScopedC(tracy::Color::Orange);
-    device_protocol_->write_data(mem_ptr, resolve_coordinate(core, noc_id), addr, size, noc_id);
+    get_device_protocol()->write_data(mem_ptr, resolve_coordinate(core, noc_id), addr, size, noc_id);
 }
 
 void TTDevice::read_from_device_reg(void *mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id) {
     ZoneScopedC(tracy::Color::Orange);
-    device_protocol_->read_ctrl(mem_ptr, resolve_coordinate(core, noc_id), addr, size, noc_id);
+    get_device_protocol()->read_ctrl(mem_ptr, resolve_coordinate(core, noc_id), addr, size, noc_id);
 }
 
 void TTDevice::write_to_device_reg(const void *mem_ptr, CoreCoord core, uint64_t addr, size_t size, NocId noc_id) {
     ZoneScopedC(tracy::Color::Orange);
-    device_protocol_->write_ctrl(mem_ptr, resolve_coordinate(core, noc_id), addr, size, noc_id);
+    get_device_protocol()->write_ctrl(mem_ptr, resolve_coordinate(core, noc_id), addr, size, noc_id);
 }
 
 void TTDevice::configure_iatu_region(size_t region, uint64_t target, size_t region_size) {
@@ -613,13 +560,13 @@ FirmwareInfoProvider *TTDevice::get_firmware_info_provider() const {
 FirmwareBundleVersion TTDevice::get_firmware_version() { return get_firmware_info_provider()->get_firmware_version(); }
 
 void TTDevice::wait_for_non_mmio_flush() {
-    if (!remote_capabilities_) {
+    if (model_->get_remote_interface() == nullptr) {
         return;
     }
     get_remote_interface()->get_remote_communication()->wait_for_non_mmio_flush();
 }
 
-bool TTDevice::is_remote() { return remote_capabilities_ != nullptr; }
+bool TTDevice::is_remote() { return model_->get_remote_interface() != nullptr; }
 
 int TTDevice::get_communication_device_id() const { return model_->get_communication_device_id(); }
 
@@ -627,14 +574,15 @@ int TTDevice::get_communication_device_id() const { return model_->get_communica
 // interfaces is present, and a remote device reports the transport of the local device it is
 // reached through.
 IODeviceType TTDevice::get_communication_device_type() const {
-    if (pcie_capabilities_ != nullptr) {
+    if (model_->get_pcie_interface() != nullptr) {
         return IODeviceType::PCIe;
     }
-    if (jtag_capabilities_ != nullptr) {
+    if (model_->get_jtag_interface() != nullptr) {
         return IODeviceType::JTAG;
     }
-    if (remote_capabilities_ != nullptr) {
-        return remote_capabilities_->get_remote_communication()->get_local_device()->get_communication_device_type();
+    RemoteInterface *remote_interface = model_->get_remote_interface();
+    if (remote_interface != nullptr) {
+        return remote_interface->get_remote_communication()->get_local_device()->get_communication_device_type();
     }
     return IODeviceType::UNDEFINED;
 }
@@ -677,8 +625,8 @@ ChipInfo TTDevice::get_chip_info() {
 uint32_t TTDevice::get_max_clock_freq() { return get_firmware_info_provider()->get_max_clock_freq().value_or(0); }
 
 void TTDevice::advance_device_execution() {
-    if (remote_capabilities_ != nullptr) {
-        remote_capabilities_->get_remote_communication()->get_local_device()->advance_device_execution();
+    if (model_->get_remote_interface() != nullptr) {
+        get_remote_interface()->get_remote_communication()->get_local_device()->advance_device_execution();
     }
 }
 
@@ -726,7 +674,7 @@ void TTDevice::noc_multicast_write(
     xy_pair translated_start = resolve_coordinate(core_start, noc_id);
     xy_pair translated_end = resolve_coordinate(core_end, noc_id);
     bool multicast_success =
-        device_protocol_->write_to_core_range(src, translated_start, translated_end, addr, size, noc_id);
+        get_device_protocol()->write_to_core_range(src, translated_start, translated_end, addr, size, noc_id);
 
     log_trace(
         LogUMD,

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -41,47 +41,16 @@
 namespace tt::umd {
 
 WormholeTTDevice::WormholeTTDevice(
-    std::unique_ptr<TTDeviceModel> model,
-    std::unique_ptr<PCIDevice> pci_device,
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor,
-    bool use_safe_api) :
-    TTDevice(
-        std::move(model),
-        std::move(pci_device),
-        std::make_unique<WormholeImplementation>(),
-        soc_arch_descriptor,
-        use_safe_api) {
+    std::unique_ptr<TTDeviceModel> model, const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
+    TTDevice(std::move(model), std::make_unique<WormholeImplementation>(), soc_arch_descriptor) {
     WormholeTTDevice::set_arc_coordinate();
-    set_hang_detector(std::make_unique<WormholeHangDetector>(get_device_protocol()));
-}
-
-WormholeTTDevice::WormholeTTDevice(
-    std::unique_ptr<TTDeviceModel> model,
-    std::unique_ptr<JtagDevice> jtag_device,
-    uint8_t jlink_id,
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
-    TTDevice(
-        std::move(model),
-        std::move(jtag_device),
-        jlink_id,
-        std::make_unique<WormholeImplementation>(),
-        soc_arch_descriptor) {
-    WormholeTTDevice::set_arc_coordinate();
-    set_hang_detector(std::make_unique<WormholeHangDetector>(get_device_protocol()));
-}
-
-WormholeTTDevice::WormholeTTDevice(
-    std::unique_ptr<TTDeviceModel> model,
-    std::unique_ptr<RemoteCommunication> remote_communication,
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
-    TTDevice(
-        std::move(model),
-        std::move(remote_communication),
-        std::make_unique<WormholeImplementation>(),
-        soc_arch_descriptor) {
-    WormholeTTDevice::set_arc_coordinate();
-    set_hang_detector(std::make_unique<WormholeHangDetector>(
-        TTDevice::get_remote_interface()->get_remote_communication()->get_local_device()->get_device_protocol()));
+    // A remote device has no protocol of its own to probe; its liveness is that of the local device
+    // it is reached through.
+    DeviceProtocol *hang_check_protocol =
+        is_remote()
+            ? TTDevice::get_remote_interface()->get_remote_communication()->get_local_device()->get_device_protocol()
+            : get_device_protocol();
+    set_hang_detector(std::make_unique<WormholeHangDetector>(hang_check_protocol));
 }
 
 bool WormholeTTDevice::get_noc_translation_enabled() {

--- a/device/tt_device_model/blackhole_tt_device_model.cpp
+++ b/device/tt_device_model/blackhole_tt_device_model.cpp
@@ -4,13 +4,48 @@
 
 #include "umd/device/tt_device_model/blackhole_tt_device_model.hpp"
 
+#include <utility>
+
+#include "umd/device/jtag/jtag_device.hpp"
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/pcie/silicon_tlb_window.hpp"
+#include "umd/device/tt_device/protocol/jtag_protocol.hpp"
+#include "umd/device/tt_device/protocol/pcie_protocol.hpp"
+
 namespace tt::umd {
 
-BlackholeTTDeviceModel::BlackholeTTDeviceModel(int communication_device_id) :
-    communication_device_id_(communication_device_id) {}
+BlackholeTTDeviceModel::BlackholeTTDeviceModel(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api) :
+    communication_device_id_(pci_device->get_device_num()), pci_device_(pci_device.get()) {
+    auto pcie_protocol = std::make_unique<PcieProtocol>(std::move(pci_device), use_safe_api);
+    pcie_interface_ = pcie_protocol.get();
+    dma_interface_ = pcie_protocol.get();
+    protocol_ = std::move(pcie_protocol);
+    if (use_safe_api) {
+        SiliconTlbWindow::set_sigbus_safe_handler(true);
+    }
+}
+
+BlackholeTTDeviceModel::BlackholeTTDeviceModel(std::unique_ptr<JtagDevice> jtag_device, uint8_t jlink_id) :
+    communication_device_id_(jlink_id) {
+    auto jtag_protocol = std::make_unique<JtagProtocol>(std::move(jtag_device), jlink_id);
+    jtag_interface_ = jtag_protocol.get();
+    protocol_ = std::move(jtag_protocol);
+}
 
 tt::ARCH BlackholeTTDeviceModel::get_arch() const { return tt::ARCH::BLACKHOLE; }
 
 int BlackholeTTDeviceModel::get_communication_device_id() const { return communication_device_id_; }
+
+DeviceProtocol *BlackholeTTDeviceModel::get_device_protocol() { return protocol_.get(); }
+
+PcieInterface *BlackholeTTDeviceModel::get_pcie_interface() { return pcie_interface_; }
+
+DmaInterface *BlackholeTTDeviceModel::get_dma_interface() { return dma_interface_; }
+
+JtagInterface *BlackholeTTDeviceModel::get_jtag_interface() { return jtag_interface_; }
+
+RemoteInterface *BlackholeTTDeviceModel::get_remote_interface() { return remote_interface_; }
+
+PCIDevice *BlackholeTTDeviceModel::get_pci_device() { return pci_device_; }
 
 }  // namespace tt::umd

--- a/device/tt_device_model/simulation_tt_device_model.cpp
+++ b/device/tt_device_model/simulation_tt_device_model.cpp
@@ -14,4 +14,8 @@ tt::ARCH SimulationTTDeviceModel::get_arch() const { return arch_; }
 // device at all.
 int SimulationTTDeviceModel::get_communication_device_id() const { return -1; }
 
+// A simulation backend reaches its device directly rather than over a transport protocol; the
+// simulation TTDevice overrides the read/write paths instead of routing them through one.
+DeviceProtocol *SimulationTTDeviceModel::get_device_protocol() { return nullptr; }
+
 }  // namespace tt::umd

--- a/device/tt_device_model/wormhole_tt_device_model.cpp
+++ b/device/tt_device_model/wormhole_tt_device_model.cpp
@@ -4,13 +4,59 @@
 
 #include "umd/device/tt_device_model/wormhole_tt_device_model.hpp"
 
+#include <utility>
+
+#include "umd/device/jtag/jtag_device.hpp"
+#include "umd/device/pcie/pci_device.hpp"
+#include "umd/device/pcie/silicon_tlb_window.hpp"
+#include "umd/device/tt_device/protocol/jtag_protocol.hpp"
+#include "umd/device/tt_device/protocol/pcie_protocol.hpp"
+#include "umd/device/tt_device/protocol/remote_protocol.hpp"
+#include "umd/device/tt_device/remote_communication.hpp"
+#include "umd/device/tt_device/tt_device.hpp"
+
 namespace tt::umd {
 
-WormholeTTDeviceModel::WormholeTTDeviceModel(int communication_device_id) :
-    communication_device_id_(communication_device_id) {}
+WormholeTTDeviceModel::WormholeTTDeviceModel(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api) :
+    communication_device_id_(pci_device->get_device_num()), pci_device_(pci_device.get()) {
+    auto pcie_protocol = std::make_unique<PcieProtocol>(std::move(pci_device), use_safe_api);
+    pcie_interface_ = pcie_protocol.get();
+    dma_interface_ = pcie_protocol.get();
+    protocol_ = std::move(pcie_protocol);
+    if (use_safe_api) {
+        SiliconTlbWindow::set_sigbus_safe_handler(true);
+    }
+}
+
+WormholeTTDeviceModel::WormholeTTDeviceModel(std::unique_ptr<JtagDevice> jtag_device, uint8_t jlink_id) :
+    communication_device_id_(jlink_id) {
+    auto jtag_protocol = std::make_unique<JtagProtocol>(std::move(jtag_device), jlink_id);
+    jtag_interface_ = jtag_protocol.get();
+    protocol_ = std::move(jtag_protocol);
+}
+
+// A remote device is reached through a local one, so it takes the local device's identity.
+WormholeTTDeviceModel::WormholeTTDeviceModel(std::unique_ptr<RemoteCommunication> remote_communication) :
+    communication_device_id_(remote_communication->get_local_device()->get_communication_device_id()) {
+    auto remote_protocol = std::make_unique<RemoteProtocol>(std::move(remote_communication));
+    remote_interface_ = remote_protocol.get();
+    protocol_ = std::move(remote_protocol);
+}
 
 tt::ARCH WormholeTTDeviceModel::get_arch() const { return tt::ARCH::WORMHOLE_B0; }
 
 int WormholeTTDeviceModel::get_communication_device_id() const { return communication_device_id_; }
+
+DeviceProtocol *WormholeTTDeviceModel::get_device_protocol() { return protocol_.get(); }
+
+PcieInterface *WormholeTTDeviceModel::get_pcie_interface() { return pcie_interface_; }
+
+DmaInterface *WormholeTTDeviceModel::get_dma_interface() { return dma_interface_; }
+
+JtagInterface *WormholeTTDeviceModel::get_jtag_interface() { return jtag_interface_; }
+
+RemoteInterface *WormholeTTDeviceModel::get_remote_interface() { return remote_interface_; }
+
+PCIDevice *WormholeTTDeviceModel::get_pci_device() { return pci_device_; }
 
 }  // namespace tt::umd


### PR DESCRIPTION
### Issue
#2864

### Description
The model now builds its own `DeviceProtocol` from the transport object it is
handed, so the transport no longer reaches `TTDevice` at all. Each constructor
knows the concrete protocol type it built, so the interfaces that protocol
provides (PCIe, DMA, JTAG, remote) are recorded by plain assignment -- no
runtime type checks anywhere.

Transport selects a model constructor rather than a model subclass, so one
architecture model still serves PCIe, JTAG and remote alike. With the protocol
out of `TTDevice`, its three silicon constructors collapse into one and six
members go away. The model returns nullptr for an interface a transport does not
provide, while `TTDevice`'s getters keep throwing, so its public behaviour is
unchanged.

### List of the changes
- `TTDeviceModel` gains one constructor per transport, each building its protocol
and recording the interfaces it provides; the architecture models forward to them.
- `TTDevice` drops `device_protocol_` and the five cached capability pointers, and
serves the protocol and interface getters from the model.
- Collapse the three silicon `TTDevice` constructors, and the `WormholeTTDevice` /
`BlackholeTTDevice` constructors, into one each.
- `TTDevice::create` and the remote factories build the model from the transport.

### Testing
CI

### API Changes
This PR has API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/tt_device_model_hang_detector
