### PR TITLE
[base API] Move SocArchDescriptor into TTDeviceModel

### DIFF
--- a/device/api/umd/device/tt_device/blackhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/blackhole_tt_device.hpp
@@ -55,8 +55,7 @@ public:
     EthTrainingStatus read_eth_core_training_status(CoreCoord eth_core) override;
 
 protected:
-    BlackholeTTDevice(
-        std::unique_ptr<TTDeviceModel> model, const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
+    explicit BlackholeTTDevice(std::unique_ptr<TTDeviceModel> model);
 
     virtual bool is_arc_available_over_axi();
 

--- a/device/api/umd/device/tt_device/tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_device.hpp
@@ -530,13 +530,9 @@ protected:
     LockManager lock_manager;
 
     // Every TTDevice is built around a model, which supplies its identity, the protocol it talks to
-    // hardware over and -- as components are decoupled from TTDevice -- the components it runs on.
-    // The transport no longer reaches TTDevice at all; the model owns it.
+    // hardware over, its SoC architecture descriptor and -- as components are decoupled from
+    // TTDevice -- the components it runs on.
     TTDevice(std::unique_ptr<TTDeviceModel> model, std::unique_ptr<ArchitectureImplementation> architecture_impl);
-    TTDevice(
-        std::unique_ptr<TTDeviceModel> model,
-        std::unique_ptr<ArchitectureImplementation> architecture_impl,
-        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
 
     virtual void retrain_dram_core(const uint32_t dram_channel) = 0;
 
@@ -575,14 +571,11 @@ protected:
 private:
     void log_aiclk_timeout_warning(uint32_t target_aiclk, std::chrono::milliseconds timeout_ms);
 
-    void assign_soc_arch_descriptor(const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
-
     xy_pair resolve_coordinate(CoreCoord core, NocId noc_id) const;
 
     DmaInterface *get_dma_interface();
 
     std::unique_ptr<TTDeviceModel> model_;
-    std::shared_ptr<SocArchDescriptor> soc_arch_descriptor_ = nullptr;
     std::optional<SocDescriptor> soc_descriptor_ = std::nullopt;
     std::unique_ptr<ArcMessenger> arc_messenger_ = nullptr;
     std::unique_ptr<FirmwareTelemetryReader> telemetry = nullptr;

--- a/device/api/umd/device/tt_device/wormhole_tt_device.hpp
+++ b/device/api/umd/device/tt_device/wormhole_tt_device.hpp
@@ -54,8 +54,7 @@ public:
     ~WormholeTTDevice() override = default;
 
 protected:
-    WormholeTTDevice(
-        std::unique_ptr<TTDeviceModel> model, const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
+    explicit WormholeTTDevice(std::unique_ptr<TTDeviceModel> model);
 
     void retrain_dram_core(const uint32_t dram_channel) override;
 

--- a/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/blackhole_tt_device_model.hpp
@@ -11,6 +11,7 @@
 namespace tt::umd {
 
 class JtagDevice;
+class SocArchDescriptor;
 class RemoteCommunication;
 
 // Model for a Blackhole device, over any transport that reaches one. Each constructor builds the
@@ -18,14 +19,22 @@ class RemoteCommunication;
 // protocol provides -- the rest stay null.
 class BlackholeTTDeviceModel : public TTDeviceModel {
 public:
-    BlackholeTTDeviceModel(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api);
-    BlackholeTTDeviceModel(std::unique_ptr<JtagDevice> jtag_device, uint8_t jlink_id);
+    BlackholeTTDeviceModel(
+        std::unique_ptr<PCIDevice> pci_device,
+        bool use_safe_api,
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
+    BlackholeTTDeviceModel(
+        std::unique_ptr<JtagDevice> jtag_device,
+        uint8_t jlink_id,
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
 
     tt::ARCH get_arch() const override;
 
     int get_communication_device_id() const override;
 
     DeviceProtocol *get_device_protocol() override;
+
+    SocArchDescriptor *get_soc_arch_descriptor() override;
 
     PcieInterface *get_pcie_interface() override;
 
@@ -35,10 +44,13 @@ public:
 
     RemoteInterface *get_remote_interface() override;
 
+    std::shared_ptr<SocArchDescriptor> get_shared_soc_arch_descriptor() override;
+
     PCIDevice *get_pci_device() override;
 
 private:
     int communication_device_id_;
+    std::shared_ptr<SocArchDescriptor> soc_arch_descriptor_;
 
     std::unique_ptr<DeviceProtocol> protocol_;
     PcieInterface *pcie_interface_ = nullptr;

--- a/device/api/umd/device/tt_device_model/simulation_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/simulation_tt_device_model.hpp
@@ -23,6 +23,10 @@ public:
 
     DeviceProtocol *get_device_protocol() override;
 
+    SocArchDescriptor *get_soc_arch_descriptor() override;
+
+    std::shared_ptr<SocArchDescriptor> get_shared_soc_arch_descriptor() override;
+
 private:
     tt::ARCH arch_;
 };

--- a/device/api/umd/device/tt_device_model/tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/tt_device_model.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "umd/device/tt_device/protocol/device_protocol.hpp"
 #include "umd/device/types/arch.hpp"
 
@@ -16,6 +18,7 @@ class JtagInterface;
 class PCIDevice;
 class PcieInterface;
 class RemoteInterface;
+class SocArchDescriptor;
 
 /**
  * Composition root for a single device's hardware-facing components.
@@ -51,6 +54,9 @@ public:
     // Required components.
     virtual DeviceProtocol *get_device_protocol() = 0;
 
+    // The model resolves this from what the caller supplied, or from its architecture's constants.
+    virtual SocArchDescriptor *get_soc_arch_descriptor() = 0;
+
     // Optional components.
     virtual HangDetector *get_hang_detector() { return nullptr; }
 
@@ -64,6 +70,11 @@ public:
     virtual JtagInterface *get_jtag_interface() { return nullptr; }
 
     virtual RemoteInterface *get_remote_interface() { return nullptr; }
+
+    // TODO: temporary - SocDescriptor shares ownership of the architecture descriptor, so TTDevice
+    // needs the shared_ptr rather than the raw pointer the Base API exposes above. Delete once
+    // SocDescriptor's ownership model is revisited.
+    virtual std::shared_ptr<SocArchDescriptor> get_shared_soc_arch_descriptor() = 0;
 
     // TODO: temporary - delete along with TTDevice::get_pci_device() once callers go through
     // PcieInterface only.

--- a/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
+++ b/device/api/umd/device/tt_device_model/wormhole_tt_device_model.hpp
@@ -11,6 +11,7 @@
 namespace tt::umd {
 
 class JtagDevice;
+class SocArchDescriptor;
 class RemoteCommunication;
 
 // Model for a Wormhole device, over any transport that reaches one. Each constructor builds the
@@ -18,15 +19,25 @@ class RemoteCommunication;
 // protocol provides -- the rest stay null.
 class WormholeTTDeviceModel : public TTDeviceModel {
 public:
-    WormholeTTDeviceModel(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api);
-    WormholeTTDeviceModel(std::unique_ptr<JtagDevice> jtag_device, uint8_t jlink_id);
-    explicit WormholeTTDeviceModel(std::unique_ptr<RemoteCommunication> remote_communication);
+    WormholeTTDeviceModel(
+        std::unique_ptr<PCIDevice> pci_device,
+        bool use_safe_api,
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
+    WormholeTTDeviceModel(
+        std::unique_ptr<JtagDevice> jtag_device,
+        uint8_t jlink_id,
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
+    WormholeTTDeviceModel(
+        std::unique_ptr<RemoteCommunication> remote_communication,
+        const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor);
 
     tt::ARCH get_arch() const override;
 
     int get_communication_device_id() const override;
 
     DeviceProtocol *get_device_protocol() override;
+
+    SocArchDescriptor *get_soc_arch_descriptor() override;
 
     PcieInterface *get_pcie_interface() override;
 
@@ -36,10 +47,13 @@ public:
 
     RemoteInterface *get_remote_interface() override;
 
+    std::shared_ptr<SocArchDescriptor> get_shared_soc_arch_descriptor() override;
+
     PCIDevice *get_pci_device() override;
 
 private:
     int communication_device_id_;
+    std::shared_ptr<SocArchDescriptor> soc_arch_descriptor_;
 
     std::unique_ptr<DeviceProtocol> protocol_;
     PcieInterface *pcie_interface_ = nullptr;

--- a/device/tt_device/blackhole_tt_device.cpp
+++ b/device/tt_device/blackhole_tt_device.cpp
@@ -41,9 +41,8 @@
 
 namespace tt::umd {
 
-BlackholeTTDevice::BlackholeTTDevice(
-    std::unique_ptr<TTDeviceModel> model, const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
-    TTDevice(std::move(model), std::make_unique<BlackholeImplementation>(), soc_arch_descriptor) {
+BlackholeTTDevice::BlackholeTTDevice(std::unique_ptr<TTDeviceModel> model) :
+    TTDevice(std::move(model), std::make_unique<BlackholeImplementation>()) {
     BlackholeTTDevice::set_arc_coordinate();
     set_hang_detector(std::make_unique<BlackholeHangDetector>(
         get_device_protocol(), BlackholeTTDevice::get_noc_translation_enabled()));

--- a/device/tt_device/tt_device.cpp
+++ b/device/tt_device/tt_device.cpp
@@ -69,35 +69,12 @@ constexpr double AICLK_TOLERANCE_PERCENT = 5.0;
 
 TTDevice::TTDevice(
     std::unique_ptr<TTDeviceModel> model, std::unique_ptr<ArchitectureImplementation> architecture_impl) :
-    architecture_impl_(std::move(architecture_impl)), model_(std::move(model)) {}
-
-TTDevice::TTDevice(
-    std::unique_ptr<TTDeviceModel> model,
-    std::unique_ptr<ArchitectureImplementation> architecture_impl,
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     architecture_impl_(std::move(architecture_impl)), model_(std::move(model)) {
-    assign_soc_arch_descriptor(soc_arch_descriptor);
-
     if (model_->get_pcie_interface() != nullptr) {
         // Initialize PCIe DMA mutex through LockManager for cross-process synchronization.
         lock_manager.initialize_mutex(
             MutexType::PCIE_DMA, get_communication_device_id(), get_communication_device_type());
     }
-}
-
-void TTDevice::assign_soc_arch_descriptor(const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
-    if (soc_arch_descriptor == nullptr) {
-        soc_arch_descriptor_ = std::make_shared<SocArchDescriptor>(architecture_impl_->get_architecture());
-        return;
-    }
-    UMD_ASSERT(
-        soc_arch_descriptor->get_arch() == get_arch(),
-        error::RuntimeError,
-        fmt::format(
-            "SocArchDescriptor architecture {} does not match device architecture {}.",
-            arch_to_str(soc_arch_descriptor->get_arch()),
-            arch_to_str(get_arch())));
-    soc_arch_descriptor_ = soc_arch_descriptor;
 }
 
 void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
@@ -121,7 +98,7 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
         get_arc_core(NocId::NOC0),
         get_arc_core(NocId::NOC1),
         get_firmware_telemetry_reader());
-    construct_soc_descriptor(soc_arch_descriptor_);
+    construct_soc_descriptor(model_->get_shared_soc_arch_descriptor());
 }
 
 /* static */ std::unique_ptr<TTDevice> TTDevice::create(
@@ -140,13 +117,12 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
         arch = jtag_device->get_jtag_arch(device_number);
         switch (arch) {
             case ARCH::WORMHOLE_B0:
-                return std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(
-                    std::make_unique<WormholeTTDeviceModel>(std::move(jtag_device), device_number),
-                    soc_arch_descriptor));
+                return std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(std::make_unique<WormholeTTDeviceModel>(
+                    std::move(jtag_device), device_number, soc_arch_descriptor)));
             case ARCH::BLACKHOLE:
-                return std::unique_ptr<BlackholeTTDevice>(new BlackholeTTDevice(
-                    std::make_unique<BlackholeTTDeviceModel>(std::move(jtag_device), device_number),
-                    soc_arch_descriptor));
+                return std::unique_ptr<BlackholeTTDevice>(
+                    new BlackholeTTDevice(std::make_unique<BlackholeTTDeviceModel>(
+                        std::move(jtag_device), device_number, soc_arch_descriptor)));
             default:
                 UMD_THROW(
                     error::RuntimeError,
@@ -160,10 +136,10 @@ void TTDevice::init_tt_device(const std::chrono::milliseconds timeout_ms) {
     switch (arch) {
         case ARCH::WORMHOLE_B0:
             return std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(
-                std::make_unique<WormholeTTDeviceModel>(std::move(pci_device), use_safe_api), soc_arch_descriptor));
+                std::make_unique<WormholeTTDeviceModel>(std::move(pci_device), use_safe_api, soc_arch_descriptor)));
         case ARCH::BLACKHOLE:
             return std::unique_ptr<BlackholeTTDevice>(new BlackholeTTDevice(
-                std::make_unique<BlackholeTTDeviceModel>(std::move(pci_device), use_safe_api), soc_arch_descriptor));
+                std::make_unique<BlackholeTTDeviceModel>(std::move(pci_device), use_safe_api, soc_arch_descriptor)));
         default:
             UMD_THROW(
                 error::RuntimeError,
@@ -180,7 +156,7 @@ std::unique_ptr<TTDevice> TTDevice::create(
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0:
             return std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(
-                std::make_unique<WormholeTTDeviceModel>(std::move(remote_communication)), soc_arch_descriptor));
+                std::make_unique<WormholeTTDeviceModel>(std::move(remote_communication), soc_arch_descriptor)));
         default:
             UMD_THROW(
                 error::RuntimeError,
@@ -203,9 +179,9 @@ std::unique_ptr<TTDevice> TTDevice::create_simulation_remote(
             arch_to_str(arch)));
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: {
-            auto device = std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(
-                std::make_unique<WormholeTTDeviceModel>(std::move(remote_communication)),
-                /*soc_arch_descriptor=*/nullptr));
+            auto device =
+                std::unique_ptr<WormholeTTDevice>(new WormholeTTDevice(std::make_unique<WormholeTTDeviceModel>(
+                    std::move(remote_communication), /*soc_arch_descriptor=*/nullptr)));
             // This device is never run through init_tt_device() (no ARC to probe), so construct_soc_descriptor()
             // never overwrites the descriptor set here; set_soc_descriptor keeps the assign-exactly-once invariant.
             device->set_soc_descriptor(soc_descriptor);

--- a/device/tt_device/wormhole_tt_device.cpp
+++ b/device/tt_device/wormhole_tt_device.cpp
@@ -40,9 +40,8 @@
 
 namespace tt::umd {
 
-WormholeTTDevice::WormholeTTDevice(
-    std::unique_ptr<TTDeviceModel> model, const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
-    TTDevice(std::move(model), std::make_unique<WormholeImplementation>(), soc_arch_descriptor) {
+WormholeTTDevice::WormholeTTDevice(std::unique_ptr<TTDeviceModel> model) :
+    TTDevice(std::move(model), std::make_unique<WormholeImplementation>()) {
     WormholeTTDevice::set_arc_coordinate();
     // A remote device has no protocol of its own to probe; its liveness is that of the local device
     // it is reached through.

--- a/device/tt_device_model/blackhole_tt_device_model.cpp
+++ b/device/tt_device_model/blackhole_tt_device_model.cpp
@@ -4,48 +4,23 @@
 
 #include "umd/device/tt_device_model/blackhole_tt_device_model.hpp"
 
-#include <fmt/format.h>
-
 #include <utility>
 
+#include "tt_device_model/soc_arch_descriptor_resolver.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
-#include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_protocol.hpp"
-#include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
-
-namespace {
-
-// A caller may supply the descriptor; otherwise it comes from the architecture's constants.
-// Named per architecture on purpose: a unity build folds the model sources into one translation
-// unit, where a shared name in this anonymous namespace would collide with the other model's copy.
-std::shared_ptr<SocArchDescriptor> resolve_blackhole_soc_arch_descriptor(
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
-    if (soc_arch_descriptor == nullptr) {
-        return std::make_shared<SocArchDescriptor>(tt::ARCH::BLACKHOLE);
-    }
-    UMD_ASSERT(
-        soc_arch_descriptor->get_arch() == tt::ARCH::BLACKHOLE,
-        error::RuntimeError,
-        fmt::format(
-            "SocArchDescriptor architecture {} does not match device architecture {}.",
-            arch_to_str(soc_arch_descriptor->get_arch()),
-            arch_to_str(tt::ARCH::BLACKHOLE)));
-    return soc_arch_descriptor;
-}
-
-}  // namespace
 
 BlackholeTTDeviceModel::BlackholeTTDeviceModel(
     std::unique_ptr<PCIDevice> pci_device,
     bool use_safe_api,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     communication_device_id_(pci_device->get_device_num()),
-    soc_arch_descriptor_(resolve_blackhole_soc_arch_descriptor(soc_arch_descriptor)),
+    soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::BLACKHOLE>(soc_arch_descriptor)),
     pci_device_(pci_device.get()) {
     auto pcie_protocol = std::make_unique<PcieProtocol>(std::move(pci_device), use_safe_api);
     pcie_interface_ = pcie_protocol.get();
@@ -61,7 +36,7 @@ BlackholeTTDeviceModel::BlackholeTTDeviceModel(
     uint8_t jlink_id,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     communication_device_id_(jlink_id),
-    soc_arch_descriptor_(resolve_blackhole_soc_arch_descriptor(soc_arch_descriptor)) {
+    soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::BLACKHOLE>(soc_arch_descriptor)) {
     auto jtag_protocol = std::make_unique<JtagProtocol>(std::move(jtag_device), jlink_id);
     jtag_interface_ = jtag_protocol.get();
     protocol_ = std::move(jtag_protocol);

--- a/device/tt_device_model/blackhole_tt_device_model.cpp
+++ b/device/tt_device_model/blackhole_tt_device_model.cpp
@@ -4,18 +4,49 @@
 
 #include "umd/device/tt_device_model/blackhole_tt_device_model.hpp"
 
+#include <fmt/format.h>
+
 #include <utility>
 
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
+#include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_protocol.hpp"
+#include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
 
-BlackholeTTDeviceModel::BlackholeTTDeviceModel(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api) :
-    communication_device_id_(pci_device->get_device_num()), pci_device_(pci_device.get()) {
+namespace {
+
+// A caller may supply the descriptor; otherwise it comes from the architecture's constants.
+// Named per architecture on purpose: a unity build folds the model sources into one translation
+// unit, where a shared name in this anonymous namespace would collide with the other model's copy.
+std::shared_ptr<SocArchDescriptor> resolve_blackhole_soc_arch_descriptor(
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
+    if (soc_arch_descriptor == nullptr) {
+        return std::make_shared<SocArchDescriptor>(tt::ARCH::BLACKHOLE);
+    }
+    UMD_ASSERT(
+        soc_arch_descriptor->get_arch() == tt::ARCH::BLACKHOLE,
+        error::RuntimeError,
+        fmt::format(
+            "SocArchDescriptor architecture {} does not match device architecture {}.",
+            arch_to_str(soc_arch_descriptor->get_arch()),
+            arch_to_str(tt::ARCH::BLACKHOLE)));
+    return soc_arch_descriptor;
+}
+
+}  // namespace
+
+BlackholeTTDeviceModel::BlackholeTTDeviceModel(
+    std::unique_ptr<PCIDevice> pci_device,
+    bool use_safe_api,
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
+    communication_device_id_(pci_device->get_device_num()),
+    soc_arch_descriptor_(resolve_blackhole_soc_arch_descriptor(soc_arch_descriptor)),
+    pci_device_(pci_device.get()) {
     auto pcie_protocol = std::make_unique<PcieProtocol>(std::move(pci_device), use_safe_api);
     pcie_interface_ = pcie_protocol.get();
     dma_interface_ = pcie_protocol.get();
@@ -25,8 +56,12 @@ BlackholeTTDeviceModel::BlackholeTTDeviceModel(std::unique_ptr<PCIDevice> pci_de
     }
 }
 
-BlackholeTTDeviceModel::BlackholeTTDeviceModel(std::unique_ptr<JtagDevice> jtag_device, uint8_t jlink_id) :
-    communication_device_id_(jlink_id) {
+BlackholeTTDeviceModel::BlackholeTTDeviceModel(
+    std::unique_ptr<JtagDevice> jtag_device,
+    uint8_t jlink_id,
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
+    communication_device_id_(jlink_id),
+    soc_arch_descriptor_(resolve_blackhole_soc_arch_descriptor(soc_arch_descriptor)) {
     auto jtag_protocol = std::make_unique<JtagProtocol>(std::move(jtag_device), jlink_id);
     jtag_interface_ = jtag_protocol.get();
     protocol_ = std::move(jtag_protocol);
@@ -37,6 +72,12 @@ tt::ARCH BlackholeTTDeviceModel::get_arch() const { return tt::ARCH::BLACKHOLE; 
 int BlackholeTTDeviceModel::get_communication_device_id() const { return communication_device_id_; }
 
 DeviceProtocol *BlackholeTTDeviceModel::get_device_protocol() { return protocol_.get(); }
+
+SocArchDescriptor *BlackholeTTDeviceModel::get_soc_arch_descriptor() { return soc_arch_descriptor_.get(); }
+
+std::shared_ptr<SocArchDescriptor> BlackholeTTDeviceModel::get_shared_soc_arch_descriptor() {
+    return soc_arch_descriptor_;
+}
 
 PcieInterface *BlackholeTTDeviceModel::get_pcie_interface() { return pcie_interface_; }
 

--- a/device/tt_device_model/simulation_tt_device_model.cpp
+++ b/device/tt_device_model/simulation_tt_device_model.cpp
@@ -18,4 +18,10 @@ int SimulationTTDeviceModel::get_communication_device_id() const { return -1; }
 // simulation TTDevice overrides the read/write paths instead of routing them through one.
 DeviceProtocol *SimulationTTDeviceModel::get_device_protocol() { return nullptr; }
 
+// A simulation backend supplies a full SocDescriptor of its own rather than an architecture
+// descriptor for TTDevice to build one from.
+SocArchDescriptor *SimulationTTDeviceModel::get_soc_arch_descriptor() { return nullptr; }
+
+std::shared_ptr<SocArchDescriptor> SimulationTTDeviceModel::get_shared_soc_arch_descriptor() { return nullptr; }
+
 }  // namespace tt::umd

--- a/device/tt_device_model/soc_arch_descriptor_resolver.hpp
+++ b/device/tt_device_model/soc_arch_descriptor_resolver.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <fmt/format.h>
+
+#include <memory>
+
+#include "umd/device/soc_arch_descriptor.hpp"
+#include "umd/device/types/arch.hpp"
+#include "umd/device/utils/error.hpp"
+
+namespace tt::umd {
+
+// A caller may supply the descriptor; otherwise it comes from the architecture's constants. The
+// architecture is a template parameter so each model states its own, and a supplied descriptor is
+// checked against it.
+template <tt::ARCH arch>
+std::shared_ptr<SocArchDescriptor> resolve_soc_arch_descriptor(
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
+    if (soc_arch_descriptor == nullptr) {
+        return std::make_shared<SocArchDescriptor>(arch);
+    }
+    UMD_ASSERT(
+        soc_arch_descriptor->get_arch() == arch,
+        error::RuntimeError,
+        fmt::format(
+            "SocArchDescriptor architecture {} does not match device architecture {}.",
+            arch_to_str(soc_arch_descriptor->get_arch()),
+            arch_to_str(arch)));
+    return soc_arch_descriptor;
+}
+
+}  // namespace tt::umd

--- a/device/tt_device_model/wormhole_tt_device_model.cpp
+++ b/device/tt_device_model/wormhole_tt_device_model.cpp
@@ -4,21 +4,52 @@
 
 #include "umd/device/tt_device_model/wormhole_tt_device_model.hpp"
 
+#include <fmt/format.h>
+
 #include <utility>
 
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
+#include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_protocol.hpp"
 #include "umd/device/tt_device/protocol/remote_protocol.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
+#include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
 
-WormholeTTDeviceModel::WormholeTTDeviceModel(std::unique_ptr<PCIDevice> pci_device, bool use_safe_api) :
-    communication_device_id_(pci_device->get_device_num()), pci_device_(pci_device.get()) {
+namespace {
+
+// A caller may supply the descriptor; otherwise it comes from the architecture's constants.
+// Named per architecture on purpose: a unity build folds the model sources into one translation
+// unit, where a shared name in this anonymous namespace would collide with the other model's copy.
+std::shared_ptr<SocArchDescriptor> resolve_wormhole_soc_arch_descriptor(
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
+    if (soc_arch_descriptor == nullptr) {
+        return std::make_shared<SocArchDescriptor>(tt::ARCH::WORMHOLE_B0);
+    }
+    UMD_ASSERT(
+        soc_arch_descriptor->get_arch() == tt::ARCH::WORMHOLE_B0,
+        error::RuntimeError,
+        fmt::format(
+            "SocArchDescriptor architecture {} does not match device architecture {}.",
+            arch_to_str(soc_arch_descriptor->get_arch()),
+            arch_to_str(tt::ARCH::WORMHOLE_B0)));
+    return soc_arch_descriptor;
+}
+
+}  // namespace
+
+WormholeTTDeviceModel::WormholeTTDeviceModel(
+    std::unique_ptr<PCIDevice> pci_device,
+    bool use_safe_api,
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
+    communication_device_id_(pci_device->get_device_num()),
+    soc_arch_descriptor_(resolve_wormhole_soc_arch_descriptor(soc_arch_descriptor)),
+    pci_device_(pci_device.get()) {
     auto pcie_protocol = std::make_unique<PcieProtocol>(std::move(pci_device), use_safe_api);
     pcie_interface_ = pcie_protocol.get();
     dma_interface_ = pcie_protocol.get();
@@ -28,16 +59,23 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(std::unique_ptr<PCIDevice> pci_devi
     }
 }
 
-WormholeTTDeviceModel::WormholeTTDeviceModel(std::unique_ptr<JtagDevice> jtag_device, uint8_t jlink_id) :
-    communication_device_id_(jlink_id) {
+WormholeTTDeviceModel::WormholeTTDeviceModel(
+    std::unique_ptr<JtagDevice> jtag_device,
+    uint8_t jlink_id,
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
+    communication_device_id_(jlink_id),
+    soc_arch_descriptor_(resolve_wormhole_soc_arch_descriptor(soc_arch_descriptor)) {
     auto jtag_protocol = std::make_unique<JtagProtocol>(std::move(jtag_device), jlink_id);
     jtag_interface_ = jtag_protocol.get();
     protocol_ = std::move(jtag_protocol);
 }
 
 // A remote device is reached through a local one, so it takes the local device's identity.
-WormholeTTDeviceModel::WormholeTTDeviceModel(std::unique_ptr<RemoteCommunication> remote_communication) :
-    communication_device_id_(remote_communication->get_local_device()->get_communication_device_id()) {
+WormholeTTDeviceModel::WormholeTTDeviceModel(
+    std::unique_ptr<RemoteCommunication> remote_communication,
+    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
+    communication_device_id_(remote_communication->get_local_device()->get_communication_device_id()),
+    soc_arch_descriptor_(resolve_wormhole_soc_arch_descriptor(soc_arch_descriptor)) {
     auto remote_protocol = std::make_unique<RemoteProtocol>(std::move(remote_communication));
     remote_interface_ = remote_protocol.get();
     protocol_ = std::move(remote_protocol);
@@ -48,6 +86,12 @@ tt::ARCH WormholeTTDeviceModel::get_arch() const { return tt::ARCH::WORMHOLE_B0;
 int WormholeTTDeviceModel::get_communication_device_id() const { return communication_device_id_; }
 
 DeviceProtocol *WormholeTTDeviceModel::get_device_protocol() { return protocol_.get(); }
+
+SocArchDescriptor *WormholeTTDeviceModel::get_soc_arch_descriptor() { return soc_arch_descriptor_.get(); }
+
+std::shared_ptr<SocArchDescriptor> WormholeTTDeviceModel::get_shared_soc_arch_descriptor() {
+    return soc_arch_descriptor_;
+}
 
 PcieInterface *WormholeTTDeviceModel::get_pcie_interface() { return pcie_interface_; }
 

--- a/device/tt_device_model/wormhole_tt_device_model.cpp
+++ b/device/tt_device_model/wormhole_tt_device_model.cpp
@@ -4,51 +4,26 @@
 
 #include "umd/device/tt_device_model/wormhole_tt_device_model.hpp"
 
-#include <fmt/format.h>
-
 #include <utility>
 
+#include "tt_device_model/soc_arch_descriptor_resolver.hpp"
 #include "umd/device/jtag/jtag_device.hpp"
 #include "umd/device/pcie/pci_device.hpp"
 #include "umd/device/pcie/silicon_tlb_window.hpp"
-#include "umd/device/soc_arch_descriptor.hpp"
 #include "umd/device/tt_device/protocol/jtag_protocol.hpp"
 #include "umd/device/tt_device/protocol/pcie_protocol.hpp"
 #include "umd/device/tt_device/protocol/remote_protocol.hpp"
 #include "umd/device/tt_device/remote_communication.hpp"
 #include "umd/device/tt_device/tt_device.hpp"
-#include "umd/device/utils/error.hpp"
 
 namespace tt::umd {
-
-namespace {
-
-// A caller may supply the descriptor; otherwise it comes from the architecture's constants.
-// Named per architecture on purpose: a unity build folds the model sources into one translation
-// unit, where a shared name in this anonymous namespace would collide with the other model's copy.
-std::shared_ptr<SocArchDescriptor> resolve_wormhole_soc_arch_descriptor(
-    const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) {
-    if (soc_arch_descriptor == nullptr) {
-        return std::make_shared<SocArchDescriptor>(tt::ARCH::WORMHOLE_B0);
-    }
-    UMD_ASSERT(
-        soc_arch_descriptor->get_arch() == tt::ARCH::WORMHOLE_B0,
-        error::RuntimeError,
-        fmt::format(
-            "SocArchDescriptor architecture {} does not match device architecture {}.",
-            arch_to_str(soc_arch_descriptor->get_arch()),
-            arch_to_str(tt::ARCH::WORMHOLE_B0)));
-    return soc_arch_descriptor;
-}
-
-}  // namespace
 
 WormholeTTDeviceModel::WormholeTTDeviceModel(
     std::unique_ptr<PCIDevice> pci_device,
     bool use_safe_api,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     communication_device_id_(pci_device->get_device_num()),
-    soc_arch_descriptor_(resolve_wormhole_soc_arch_descriptor(soc_arch_descriptor)),
+    soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::WORMHOLE_B0>(soc_arch_descriptor)),
     pci_device_(pci_device.get()) {
     auto pcie_protocol = std::make_unique<PcieProtocol>(std::move(pci_device), use_safe_api);
     pcie_interface_ = pcie_protocol.get();
@@ -64,7 +39,7 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(
     uint8_t jlink_id,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     communication_device_id_(jlink_id),
-    soc_arch_descriptor_(resolve_wormhole_soc_arch_descriptor(soc_arch_descriptor)) {
+    soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::WORMHOLE_B0>(soc_arch_descriptor)) {
     auto jtag_protocol = std::make_unique<JtagProtocol>(std::move(jtag_device), jlink_id);
     jtag_interface_ = jtag_protocol.get();
     protocol_ = std::move(jtag_protocol);
@@ -75,7 +50,7 @@ WormholeTTDeviceModel::WormholeTTDeviceModel(
     std::unique_ptr<RemoteCommunication> remote_communication,
     const std::shared_ptr<SocArchDescriptor> &soc_arch_descriptor) :
     communication_device_id_(remote_communication->get_local_device()->get_communication_device_id()),
-    soc_arch_descriptor_(resolve_wormhole_soc_arch_descriptor(soc_arch_descriptor)) {
+    soc_arch_descriptor_(resolve_soc_arch_descriptor<tt::ARCH::WORMHOLE_B0>(soc_arch_descriptor)) {
     auto remote_protocol = std::make_unique<RemoteProtocol>(std::move(remote_communication));
     remote_interface_ = remote_protocol.get();
     protocol_ = std::move(remote_protocol);


### PR DESCRIPTION
### Issue
#2864

### Description
The model resolves its own SoC architecture descriptor: it validates a supplied
one against the architecture it reports, or builds that architecture's default
when none is given. `TTDevice` reads it from the model when it constructs its
`SocDescriptor`, and no longer takes or stores one.

This leaves `TTDevice` with a single constructor -- the descriptor was the last
thing separating the silicon path from the transport-less one -- and the
architecture devices with a single constructor each, taking nothing but a model.

### List of the changes
- `TTDeviceModel` resolves and owns the SoC architecture descriptor; its
architecture check moves here from `TTDevice::assign_soc_arch_descriptor()`.
- Drop `TTDevice::assign_soc_arch_descriptor()` and `soc_arch_descriptor_`;
`init_tt_device()` builds the `SocDescriptor` from the model's descriptor.
- Collapse `TTDevice` to one constructor, and `WormholeTTDevice` /
`BlackholeTTDevice` to one each taking only a model.
- `TTDevice::create` passes the caller's descriptor to the model.

### Testing
CI

### API Changes
This PR has API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/tt_device_model_hang_detector
