### PR TITLE
Resolve TLB window configuration generically

### DIFF
--- a/device/api/umd/device/arch/architecture_tlbs.hpp
+++ b/device/api/umd/device/arch/architecture_tlbs.hpp
@@ -18,20 +18,22 @@ struct TlbSizeClass {
     size_t size;
     uint32_t count;
     uint32_t base_index;
+    // Byte offset of the class's window region within its BAR.
+    uint64_t bar_offset;
     // Blackhole and Grendel map their largest windows through BAR4, everything else is in BAR0.
     bool in_bar4;
+    // Bit layout of the window configuration register.
+    tlb_offsets register_layout;
 };
-
-// Resolves a TLB window index to its configuration.
-using TlbConfigurationResolver = tlb_configuration (*)(uint32_t tlb_index);
 
 // The TLB window layout of one architecture. Architecture specific code reads its own constants
 // directly; this exists for callers which are not tied to one architecture.
 struct ArchitectureTlbs {
-    // Size classes the architecture provides, smallest size first.
+    // Window groups the architecture provides, smallest size first.
     std::vector<TlbSizeClass> size_classes;
 
-    // Preferred window size, the size class with the most windows.
+    // Size UMD keeps its cached windows at. Matches the size the architecture has the most windows
+    // of, but deliberately a constant so it can be set independently per architecture.
     size_t cached_window_size;
 
     // Whether static_vc should be used for window configuration.
@@ -40,7 +42,8 @@ struct ArchitectureTlbs {
     uint32_t static_cfg_addr;
     uint64_t cfg_reg_size_bytes;
 
-    TlbConfigurationResolver get_configuration;
+    // Configuration of the window at the given index.
+    tlb_configuration get_configuration(uint32_t tlb_index) const;
 };
 
 const ArchitectureTlbs& get_architecture_tlbs(const tt::ARCH arch);

--- a/device/arch/architecture_tlbs.cpp
+++ b/device/arch/architecture_tlbs.cpp
@@ -19,129 +19,106 @@ constexpr size_t ONE_MB = 1 << 20;
 constexpr size_t ONE_GB = 1024 * ONE_MB;
 }  // namespace
 
-namespace wormhole {
-
-static tlb_configuration tlb_configuration_for(const uint32_t tlb_index) {
-    if (tlb_index >= TLB_BASE_INDEX_16M) {
+tlb_configuration ArchitectureTlbs::get_configuration(const uint32_t tlb_index) const {
+    for (const TlbSizeClass& size_class : size_classes) {
+        if (tlb_index < size_class.base_index || tlb_index >= size_class.base_index + size_class.count) {
+            continue;
+        }
+        const uint64_t index_offset = tlb_index - size_class.base_index;
         return tlb_configuration{
-            .size = DYNAMIC_TLB_16M_SIZE,
-            .base = DYNAMIC_TLB_16M_BASE,
-            .cfg_addr = DYNAMIC_TLB_16M_CFG_ADDR,
-            .index_offset = tlb_index - TLB_BASE_INDEX_16M,
-            .tlb_offset = DYNAMIC_TLB_16M_BASE + (tlb_index - TLB_BASE_INDEX_16M) * DYNAMIC_TLB_16M_SIZE,
-            .offset = TLB_16M_OFFSET,
-        };
-    } else if (tlb_index >= TLB_BASE_INDEX_2M) {
-        return tlb_configuration{
-            .size = DYNAMIC_TLB_2M_SIZE,
-            .base = DYNAMIC_TLB_2M_BASE,
-            .cfg_addr = DYNAMIC_TLB_2M_CFG_ADDR,
-            .index_offset = tlb_index - TLB_BASE_INDEX_2M,
-            .tlb_offset = DYNAMIC_TLB_2M_BASE + (tlb_index - TLB_BASE_INDEX_2M) * DYNAMIC_TLB_2M_SIZE,
-            .offset = TLB_2M_OFFSET,
-        };
-    } else {
-        return tlb_configuration{
-            .size = DYNAMIC_TLB_1M_SIZE,
-            .base = DYNAMIC_TLB_1M_BASE,
-            .cfg_addr = DYNAMIC_TLB_1M_CFG_ADDR,
-            .index_offset = tlb_index - TLB_BASE_INDEX_1M,
-            .tlb_offset = DYNAMIC_TLB_1M_BASE + (tlb_index - TLB_BASE_INDEX_1M) * DYNAMIC_TLB_1M_SIZE,
-            .offset = TLB_1M_OFFSET,
-        };
-    }
-}
-
-}  // namespace wormhole
-
-namespace blackhole {
-
-static tlb_configuration tlb_configuration_for(const uint32_t tlb_index) {
-    // If TLB index is in range for 4GB tlbs (8 TLBs after 202 TLBs for 2MB).
-    if (tlb_index >= TLB_COUNT_2M && tlb_index < TLB_COUNT_2M + TLB_COUNT_4G) {
-        return tlb_configuration{
-            .size = DYNAMIC_TLB_4G_SIZE,
-            .base = DYNAMIC_TLB_4G_BASE,
-            .cfg_addr = DYNAMIC_TLB_4G_CFG_ADDR,
-            .index_offset = tlb_index - TLB_BASE_INDEX_4G,
-            .tlb_offset = DYNAMIC_TLB_4G_BASE + (tlb_index - TLB_BASE_INDEX_4G) * DYNAMIC_TLB_4G_SIZE,
-            .offset = TLB_4G_OFFSET,
+            .size = size_class.size,
+            .base = size_class.bar_offset,
+            // Address of the size class's first configuration register.
+            .cfg_addr = static_cfg_addr + size_class.base_index * cfg_reg_size_bytes,
+            .index_offset = index_offset,
+            .tlb_offset = size_class.bar_offset + index_offset * size_class.size,
+            .offset = size_class.register_layout,
         };
     }
 
-    return tlb_configuration{
-        .size = DYNAMIC_TLB_2M_SIZE,
-        .base = DYNAMIC_TLB_2M_BASE,
-        .cfg_addr = DYNAMIC_TLB_2M_CFG_ADDR,
-        .index_offset = tlb_index - TLB_BASE_INDEX_2M,
-        .tlb_offset = DYNAMIC_TLB_2M_BASE + (tlb_index - TLB_BASE_INDEX_2M) * DYNAMIC_TLB_2M_SIZE,
-        .offset = TLB_2M_OFFSET,
-    };
+    UMD_THROW(error::RuntimeError, fmt::format("No TLB window with index {}.", tlb_index));
 }
-
-}  // namespace blackhole
-
-namespace grendel {
-
-static tlb_configuration tlb_configuration_for(const uint32_t tlb_index) {
-    // If TLB index is in range for 4GB tlbs (8 TLBs after 202 TLBs for 2MB).
-    if (tlb_index >= TLB_COUNT_2M && tlb_index < TLB_COUNT_2M + TLB_COUNT_4G) {
-        return tlb_configuration{
-            .size = DYNAMIC_TLB_4G_SIZE,
-            .base = DYNAMIC_TLB_4G_BASE,
-            .cfg_addr = DYNAMIC_TLB_4G_CFG_ADDR,
-            .index_offset = tlb_index - TLB_BASE_INDEX_4G,
-            .tlb_offset = DYNAMIC_TLB_4G_BASE + (tlb_index - TLB_BASE_INDEX_4G) * DYNAMIC_TLB_4G_SIZE,
-            .offset = TLB_4G_OFFSET,
-        };
-    }
-
-    return tlb_configuration{
-        .size = DYNAMIC_TLB_2M_SIZE,
-        .base = DYNAMIC_TLB_2M_BASE,
-        .cfg_addr = DYNAMIC_TLB_2M_CFG_ADDR,
-        .index_offset = tlb_index - TLB_BASE_INDEX_2M,
-        .tlb_offset = DYNAMIC_TLB_2M_BASE + (tlb_index - TLB_BASE_INDEX_2M) * DYNAMIC_TLB_2M_SIZE,
-        .offset = TLB_2M_OFFSET,
-    };
-}
-
-}  // namespace grendel
 
 const ArchitectureTlbs& get_architecture_tlbs(const tt::ARCH arch) {
     static const ArchitectureTlbs wormhole_tlbs = {
         .size_classes =
-            {{ONE_MB, wormhole::TLB_COUNT_1M, wormhole::TLB_BASE_INDEX_1M, false},
-             {2 * ONE_MB, wormhole::TLB_COUNT_2M, wormhole::TLB_BASE_INDEX_2M, false},
-             {16 * ONE_MB, wormhole::TLB_COUNT_16M, wormhole::TLB_BASE_INDEX_16M, false}},
+            {{
+                 .size = ONE_MB,
+                 .count = wormhole::TLB_COUNT_1M,
+                 .base_index = wormhole::TLB_BASE_INDEX_1M,
+                 .bar_offset = wormhole::DYNAMIC_TLB_1M_BASE,
+                 .in_bar4 = false,
+                 .register_layout = wormhole::TLB_1M_OFFSET,
+             },
+             {
+                 .size = 2 * ONE_MB,
+                 .count = wormhole::TLB_COUNT_2M,
+                 .base_index = wormhole::TLB_BASE_INDEX_2M,
+                 .bar_offset = wormhole::DYNAMIC_TLB_2M_BASE,
+                 .in_bar4 = false,
+                 .register_layout = wormhole::TLB_2M_OFFSET,
+             },
+             {
+                 .size = 16 * ONE_MB,
+                 .count = wormhole::TLB_COUNT_16M,
+                 .base_index = wormhole::TLB_BASE_INDEX_16M,
+                 .bar_offset = wormhole::DYNAMIC_TLB_16M_BASE,
+                 .in_bar4 = false,
+                 .register_layout = wormhole::TLB_16M_OFFSET,
+             }},
         .cached_window_size = wormhole::STATIC_TLB_SIZE,
         .use_static_vc = true,
         .static_cfg_addr = wormhole::STATIC_TLB_CFG_ADDR,
-        .cfg_reg_size_bytes = 8,
-        .get_configuration = &wormhole::tlb_configuration_for,
+        .cfg_reg_size_bytes = wormhole::TLB_CFG_REG_SIZE_BYTES,
     };
 
     static const ArchitectureTlbs blackhole_tlbs = {
         .size_classes =
-            {{2 * ONE_MB, blackhole::TLB_COUNT_2M, blackhole::TLB_BASE_INDEX_2M, false},
-             {4 * ONE_GB, blackhole::TLB_COUNT_4G, blackhole::TLB_BASE_INDEX_4G, true}},
+            {{
+                 .size = 2 * ONE_MB,
+                 .count = blackhole::TLB_COUNT_2M,
+                 .base_index = blackhole::TLB_BASE_INDEX_2M,
+                 .bar_offset = blackhole::DYNAMIC_TLB_2M_BASE,
+                 .in_bar4 = false,
+                 .register_layout = blackhole::TLB_2M_OFFSET,
+             },
+             {
+                 .size = 4 * ONE_GB,
+                 .count = blackhole::TLB_COUNT_4G,
+                 .base_index = blackhole::TLB_BASE_INDEX_4G,
+                 .bar_offset = blackhole::DYNAMIC_TLB_4G_BASE,
+                 .in_bar4 = true,
+                 .register_layout = blackhole::TLB_4G_OFFSET,
+             }},
         .cached_window_size = blackhole::STATIC_TLB_SIZE,
         // False due to a known HW issue.
         .use_static_vc = false,
         .static_cfg_addr = blackhole::STATIC_TLB_CFG_ADDR,
-        .cfg_reg_size_bytes = 12,
-        .get_configuration = &blackhole::tlb_configuration_for,
+        .cfg_reg_size_bytes = blackhole::TLB_CFG_REG_SIZE_BYTES,
     };
 
     static const ArchitectureTlbs grendel_tlbs = {
         .size_classes =
-            {{2 * ONE_MB, grendel::TLB_COUNT_2M, grendel::TLB_BASE_INDEX_2M, false},
-             {4 * ONE_GB, grendel::TLB_COUNT_4G, grendel::TLB_BASE_INDEX_4G, true}},
+            {{
+                 .size = 2 * ONE_MB,
+                 .count = grendel::TLB_COUNT_2M,
+                 .base_index = grendel::TLB_BASE_INDEX_2M,
+                 .bar_offset = grendel::DYNAMIC_TLB_2M_BASE,
+                 .in_bar4 = false,
+                 .register_layout = grendel::TLB_2M_OFFSET,
+             },
+             {
+                 .size = 4 * ONE_GB,
+                 .count = grendel::TLB_COUNT_4G,
+                 .base_index = grendel::TLB_BASE_INDEX_4G,
+                 .bar_offset = grendel::DYNAMIC_TLB_4G_BASE,
+                 .in_bar4 = true,
+                 .register_layout = grendel::TLB_4G_OFFSET,
+             }},
         .cached_window_size = grendel::STATIC_TLB_SIZE,
         .use_static_vc = true,
         .static_cfg_addr = grendel::STATIC_TLB_CFG_ADDR,
-        .cfg_reg_size_bytes = 12,
-        .get_configuration = &grendel::tlb_configuration_for,
+        .cfg_reg_size_bytes = grendel::TLB_CFG_REG_SIZE_BYTES,
     };
 
     switch (arch) {

--- a/device/chip_helpers/simulation_tlb_allocator.cpp
+++ b/device/chip_helpers/simulation_tlb_allocator.cpp
@@ -123,11 +123,7 @@ SimulationTlbAllocator::TlbPool* SimulationTlbAllocator::find_pool_for_index(int
 }
 
 void SimulationTlbAllocator::initialize_architecture_config() {
-    if (architecture_ == tt::ARCH::WORMHOLE_B0) {
-        tlb_reg_size_bytes_ = 8;  // wormhole::TLB_CFG_REG_SIZE_BYTES.
-    } else if (architecture_ == tt::ARCH::BLACKHOLE) {
-        tlb_reg_size_bytes_ = 12;  // blackhole::TLB_CFG_REG_SIZE_BYTES.
-    } else {
+    if (architecture_ != tt::ARCH::WORMHOLE_B0 && architecture_ != tt::ARCH::BLACKHOLE) {
         // Intentional: architectures like QUASAR construct a SimulationTlbAllocator
         // but the sim TTDevice's constructor bypasses it entirely (builds the
         // cached TLB window with a fixed index, never calling allocate_tlb_index).
@@ -142,7 +138,10 @@ void SimulationTlbAllocator::initialize_architecture_config() {
         return;
     }
 
-    for (const TlbSizeClass& size_class : get_architecture_tlbs(architecture_).size_classes) {
+    const ArchitectureTlbs& tlbs = get_architecture_tlbs(architecture_);
+    tlb_reg_size_bytes_ = tlbs.cfg_reg_size_bytes;
+
+    for (const TlbSizeClass& size_class : tlbs.size_classes) {
         TlbPool pool;
         pool.layout = size_class;
         pool.allocated.resize(size_class.count, false);

--- a/tests/baremetal/CMakeLists.txt
+++ b/tests/baremetal/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(BAREMETAL_TESTS_SRCS
+    test_architecture_tlbs.cpp
     test_cluster_descriptor_offline.cpp
     test_core_coord_translation_wh.cpp
     test_core_coord_translation_bh.cpp

--- a/tests/baremetal/test_architecture_tlbs.cpp
+++ b/tests/baremetal/test_architecture_tlbs.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <exception>
+#include <string>
+
+#include "umd/device/arch/architecture_tlbs.hpp"
+#include "umd/device/arch/blackhole_implementation.hpp"
+#include "umd/device/arch/wormhole_implementation.hpp"
+#include "umd/device/types/arch.hpp"
+
+using namespace tt::umd;
+
+class ArchitectureTlbsTest : public ::testing::TestWithParam<tt::ARCH> {};
+
+INSTANTIATE_TEST_SUITE_P(
+    Architectures,
+    ArchitectureTlbsTest,
+    testing::Values(tt::ARCH::WORMHOLE_B0, tt::ARCH::BLACKHOLE, tt::ARCH::QUASAR),
+    [](const testing::TestParamInfo<tt::ARCH>& info) { return tt::arch_to_str(info.param); });
+
+// Expectations come from the size classes themselves rather than from architecture constants, so
+// this covers which size class an index resolves to without restating the tables.
+TEST_P(ArchitectureTlbsTest, ResolvesEveryWindowToTheClassOwningIt) {
+    const ArchitectureTlbs& tlbs = get_architecture_tlbs(GetParam());
+
+    for (const TlbSizeClass& size_class : tlbs.size_classes) {
+        for (const uint32_t index_offset : {uint32_t{0}, size_class.count - 1}) {
+            const tlb_configuration config = tlbs.get_configuration(size_class.base_index + index_offset);
+
+            EXPECT_EQ(config.size, size_class.size) << "window " << index_offset;
+            EXPECT_EQ(config.base, size_class.bar_offset) << "window " << index_offset;
+            EXPECT_EQ(config.index_offset, index_offset);
+            // The bit layout differs per window size, so this catches a class wired to another's.
+            EXPECT_EQ(config.offset.local_offset, size_class.register_layout.local_offset);
+        }
+    }
+}
+
+TEST_P(ArchitectureTlbsTest, ThrowsForIndexWithoutWindow) {
+    const ArchitectureTlbs& tlbs = get_architecture_tlbs(GetParam());
+    const TlbSizeClass& last = tlbs.size_classes.back();
+
+    EXPECT_THROW(tlbs.get_configuration(last.base_index + last.count), std::exception);
+}
+
+// The configuration register address is derived rather than stored, so hold that derivation against
+// each architecture's own definition of it.
+TEST(ArchitectureTlbs, ConfigRegisterAddressMatchesArchitectureDefinition) {
+    const ArchitectureTlbs& wormhole_tlbs = get_architecture_tlbs(tt::ARCH::WORMHOLE_B0);
+    EXPECT_EQ(wormhole_tlbs.get_configuration(wormhole::TLB_BASE_INDEX_1M).cfg_addr, wormhole::DYNAMIC_TLB_1M_CFG_ADDR);
+    EXPECT_EQ(wormhole_tlbs.get_configuration(wormhole::TLB_BASE_INDEX_2M).cfg_addr, wormhole::DYNAMIC_TLB_2M_CFG_ADDR);
+    EXPECT_EQ(
+        wormhole_tlbs.get_configuration(wormhole::TLB_BASE_INDEX_16M).cfg_addr, wormhole::DYNAMIC_TLB_16M_CFG_ADDR);
+
+    const ArchitectureTlbs& blackhole_tlbs = get_architecture_tlbs(tt::ARCH::BLACKHOLE);
+    EXPECT_EQ(
+        blackhole_tlbs.get_configuration(blackhole::TLB_BASE_INDEX_2M).cfg_addr, blackhole::DYNAMIC_TLB_2M_CFG_ADDR);
+    EXPECT_EQ(
+        blackhole_tlbs.get_configuration(blackhole::TLB_BASE_INDEX_4G).cfg_addr, blackhole::DYNAMIC_TLB_4G_CFG_ADDR);
+}


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2873

### Description
Stacked on #3228. Follow up to the review on #3223.

Resolving a window index to its configuration is the same operation on every architecture: find the
group whose index range contains the index, then offset within it. The three per architecture
functions become one, which also removes the function pointer the struct carried.

An index no longer owned by any group now throws. Before, Blackhole and Grendel fell through to a
2MB configuration for anything past the 4GB range and Wormhole's cascade had no upper bound.

### List of the changes
- Add the BAR byte offset and the configuration register layout to `TlbWindowGroup`.
- Replace the three `tlb_configuration_for` functions and the resolver function pointer with
  `ArchitectureTlbs::get_configuration`, which throws for an index without a window.
- Derive `cfg_addr` instead of storing it, every architecture defines it from the static config
  address and the group base index.
- The simulation TLB allocator takes its configuration register size from the architecture.
- Add baremetal tests for which group an index resolves to, the throwing case, and the derivation.

### Testing
Code builds. New `ArchitectureTlbs` tests and the existing simulation TLB allocator tests pass.

### API Changes
This PR has API changes, `ArchitectureTlbs` resolves configurations itself and derives `cfg_addr`.

### Full stack diff
https://github.com/tenstorrent/tt-umd/compare/main...brosko/arch_impl_12
