### PR TITLE
Introduce IoWindow interface

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -220,6 +220,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/pcie/tt_sim_tlb_handle.hpp
                 api/umd/device/pcie/rtl_sim_tlb_window.hpp
                 api/umd/device/pcie/rtl_sim_tlb_handle.hpp
+                api/umd/device/io_window/io_window.hpp
                 api/umd/device/warm_reset.hpp
                 api/umd/device/warm_reset_with_recovery.hpp
                 api/umd/device/utils/semver.hpp
@@ -294,6 +295,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                 api/umd/device/types/host_memory.hpp
                 api/umd/device/types/telemetry.hpp
                 api/umd/device/types/tlb.hpp
+                api/umd/device/types/io_window_config.hpp
                 api/umd/device/types/wormhole_dram.hpp
                 api/umd/device/types/wormhole_eth.hpp
                 api/umd/device/types/wormhole_l1.hpp

--- a/device/api/umd/device/io_window/io_window.hpp
+++ b/device/api/umd/device/io_window/io_window.hpp
@@ -1,0 +1,126 @@
+/*
+ * SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "umd/device/types/io_window_config.hpp"
+
+namespace tt::umd {
+
+/**
+ * @brief Host memory-mapped window into device address space.
+ *
+ * Maps a fixed-size region of host virtual address space to device address space.
+ * Through this window, the host can read and write device memory directly.
+ *
+ * The window has a fixed size determined at construction, but can be reconfigured at
+ * runtime to point to different device addresses.
+ *
+ * Ordering guarantees for all operations are determined by the concrete implementation, which
+ * accounts for both host-side factors (e.g., memory caching strategy) and device-side factors
+ * (e.g., hardware ordering rules). The APIs below indicate which use cases they are more suited
+ * for, but provide minimal guarantees at the interface level.
+ */
+class IoWindow {
+public:
+    virtual ~IoWindow() = default;
+
+    /**
+     * @brief Writes a block of data through the window. More suited for bulk data transactions.
+     * @param offset Byte offset from the window base.
+     * @param data Pointer to the source data.
+     * @param size Number of bytes to write.
+     */
+    virtual void write_block(uint64_t offset, const void* data, size_t size) = 0;
+
+    /**
+     * @brief Reads a block of data through the window. More suited for bulk data transactions.
+     * @param offset Byte offset from the window base.
+     * @param data Pointer to the destination buffer.
+     * @param size Number of bytes to read.
+     */
+    virtual void read_block(uint64_t offset, void* data, size_t size) = 0;
+
+    /**
+     * @brief Writes a 16-bit value through the window. Suitable for both data and register transactions.
+     * @param offset Byte offset from the window base.
+     * @param value The 16-bit value to write.
+     */
+    virtual void write16(uint64_t offset, uint16_t value) = 0;
+
+    /**
+     * @brief Reads a 16-bit value through the window. Suitable for both data and register transactions.
+     * @param offset Byte offset from the window base.
+     * @return uint16_t The value read.
+     */
+    virtual uint16_t read16(uint64_t offset) = 0;
+
+    /**
+     * @brief Writes a 32-bit value through the window. Suitable for both data and register transactions.
+     * @param offset Byte offset from the window base.
+     * @param value The 32-bit value to write.
+     */
+    virtual void write32(uint64_t offset, uint32_t value) = 0;
+
+    /**
+     * @brief Reads a 32-bit value through the window. Suitable for both data and register transactions.
+     * @param offset Byte offset from the window base.
+     * @return uint32_t The value read.
+     */
+    virtual uint32_t read32(uint64_t offset) = 0;
+
+    /**
+     * @brief Writes 4-byte aligned data through the window. More suited for register transactions.
+     * @param offset Byte offset from the window base. Must be 4-byte aligned.
+     * @param data Pointer to the source data.
+     * @param size Number of bytes to write. Must be a multiple of 4.
+     */
+    virtual void write_aligned(uint64_t offset, const void* data, size_t size) = 0;
+
+    /**
+     * @brief Reads 4-byte aligned data through the window. More suited for register transactions.
+     * @param offset Byte offset from the window base. Must be 4-byte aligned.
+     * @param data Pointer to the destination buffer.
+     * @param size Number of bytes to read. Must be a multiple of 4.
+     */
+    virtual void read_aligned(uint64_t offset, void* data, size_t size) = 0;
+
+    /**
+     * @brief Reconfigures the window to map to a different region of device address space.
+     *
+     * Updates the underlying hardware mapping so that subsequent read/write operations
+     * target the new device address.
+     *
+     * @param config Device-side target describing the core, address, and optional NOC.
+     */
+    virtual void configure(const TargetIoWindowConfig& config) = 0;
+
+    /**
+     * @brief Returns the current device-side target configuration of this window.
+     * @return TargetIoWindowConfig The core, address, and optional NOC of the current mapping.
+     */
+    virtual TargetIoWindowConfig get_target_config() const = 0;
+
+    /**
+     * @brief Returns the actual size of this I/O window in bytes.
+     *
+     * The size is determined by the concrete implementation during construction
+     * and may differ from what was requested in HostIoWindowConfig.
+     *
+     * @return size_t Window size as allocated by the implementation.
+     */
+    virtual size_t get_size() const = 0;
+
+    /**
+     * @brief Returns the host memory caching strategy of this window.
+     * @return HostMemoryCaching The caching type (WC or UC), fixed at construction.
+     */
+    virtual HostMemoryCaching get_memory_caching_type() const = 0;
+};
+
+}  // namespace tt::umd

--- a/device/api/umd/device/types/io_window_config.hpp
+++ b/device/api/umd/device/types/io_window_config.hpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <type_traits>
+
+#include "umd/device/types/noc_id.hpp"
+#include "umd/device/types/xy_pair.hpp"
+
+namespace tt::umd {
+
+/**
+ * @brief Host memory caching strategy for an IoWindow.
+ */
+enum class HostMemoryCaching {
+    WC,  ///< Write-Combining — bypasses cache, batches small writes into bus bursts. Higher throughput, relaxed
+         ///< ordering.
+    UC,  ///< Uncacheable — bypasses cache, every access hits hardware immediately. Strict ordering.
+};
+
+/**
+ * @brief Type-safe transaction attributes for an IoWindow target.
+ */
+enum class WindowFlags : uint32_t {
+    None = 0,
+    Atomic = 1 << 0,  ///< Issue transaction as atomic on the target interconnect.
+    Snoop = 1 << 1,   ///< Mark transaction as snoopable for cache coherency.
+};
+
+constexpr WindowFlags operator|(WindowFlags lhs, WindowFlags rhs) noexcept {
+    return static_cast<WindowFlags>(
+        static_cast<std::underlying_type_t<WindowFlags>>(lhs) | static_cast<std::underlying_type_t<WindowFlags>>(rhs));
+}
+
+constexpr WindowFlags operator&(WindowFlags lhs, WindowFlags rhs) noexcept {
+    return static_cast<WindowFlags>(
+        static_cast<std::underlying_type_t<WindowFlags>>(lhs) & static_cast<std::underlying_type_t<WindowFlags>>(rhs));
+}
+
+constexpr WindowFlags operator~(WindowFlags val) noexcept {
+    return static_cast<WindowFlags>(~static_cast<std::underlying_type_t<WindowFlags>>(val));
+}
+
+constexpr WindowFlags& operator|=(WindowFlags& lhs, WindowFlags rhs) noexcept {
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+constexpr WindowFlags& operator&=(WindowFlags& lhs, WindowFlags rhs) noexcept {
+    lhs = lhs & rhs;
+    return lhs;
+}
+
+/**
+ * @brief Device-side target for an IoWindow: core, address, optional NOC, and transaction flags.
+ */
+struct TargetIoWindowConfig {
+    tt_xy_pair core_start;  ///< Target core, or upper-left corner of a multicast grid.
+    std::optional<tt_xy_pair> core_end =
+        std::nullopt;                         ///< Lower-right corner of a multicast grid, or nullopt for unicast.
+    uint64_t addr;                            ///< Destination address on the target core(s).
+    std::optional<NocId> noc = std::nullopt;  ///< Optional routing selection.
+    WindowFlags flags = WindowFlags::None;    ///< Transaction attributes.
+};
+
+/**
+ * @brief Host-side properties for an IoWindow.
+ *
+ * Controls the host memory caching strategy and requested window size.
+ * A size of 0 is valid and delegates the window size selection to the concrete implementation.
+ */
+struct HostIoWindowConfig {
+    HostMemoryCaching mapping = HostMemoryCaching::WC;
+    size_t size = 0;
+};
+
+}  // namespace tt::umd


### PR DESCRIPTION
### Issue
#2875 

### Description
Adds the IoWindow interface and its supporting config types as defined by the Base API Specification. This is the first of a stacked series migrating TlbHandle/TlbWindow to the new interface; no wiring or consumer changes are included here.

### List of the changes
 - Add IoWindow interface in device/api/umd/device/io_window/io_window.hpp
 - Add HostMemoryCaching, WindowFlags, TargetIoWindowConfig, HostIoWindowConfig in device/api/umd/device/types/io_window_config.hpp
 - Register new headers in device/CMakeLists.txt

### Testing
Local build.

### API Changes
New public interface IoWindow and new public config types added. Nothing existing is removed or modified. TlbHandle and TlbWindow are untouched and will be merged into IoWindow in a follow-up PR.
