### PR TITLE
Simulation: UPPER_SNAKE the simulation enum class values

### DIFF
--- a/device/api/umd/device/simulation/simulation_server_protocol.hpp
+++ b/device/api/umd/device/simulation/simulation_server_protocol.hpp
@@ -23,7 +23,8 @@ namespace tt::umd {
 // structs and free functions. Stream framing (length-prefixing messages on the socket) is a
 // transport concern and lives with the socket send/recv helpers, not here.
 
-// Direction of a device-memory access; mirrors wire::SimulationServerCommand in the schema.
+// What a client asks the host to do: a device-memory access (READ/WRITE), an identity or topology
+// query, or a graceful shutdown. Mirrors wire::SimulationServerCommand in the schema.
 enum class SimulationServerCommand : int8_t {
     READ = 0,
     WRITE = 1,

--- a/device/api/umd/device/simulation/simulation_server_protocol.hpp
+++ b/device/api/umd/device/simulation/simulation_server_protocol.hpp
@@ -25,25 +25,25 @@ namespace tt::umd {
 
 // Direction of a device-memory access; mirrors wire::SimulationServerCommand in the schema.
 enum class SimulationServerCommand : int8_t {
-    Read = 0,
-    Write = 1,
-    GetDeviceInfo = 2,
-    GetClusterDescriptor = 3,
+    READ = 0,
+    WRITE = 1,
+    GET_DEVICE_INFO = 2,
+    GET_CLUSTER_DESCRIPTOR = 3,
     // Asks the host to shut down gracefully; the host acks with a SimulationServerResponse then tears
     // down (closing every client connection). A host that didn't opt in acks as a no-op.
-    Shutdown = 4,
+    SHUTDOWN = 4,
 };
 
 // Which simulator the host runs; mirrors wire::SimulationBackendType. Served as part of the device
 // identity so a client can build the matching device class without a local simulator build.
 enum class SimulationBackendType : int8_t {
-    TTSim = 0,
-    Rtl = 1,
+    TTSIM = 0,
+    RTL = 1,
 };
 
 // A device-memory access request addressed by (core x/y, address, size).
 struct SimulationServerRequest {
-    SimulationServerCommand command = SimulationServerCommand::Read;
+    SimulationServerCommand command = SimulationServerCommand::READ;
     uint32_t x = 0;
     uint32_t y = 0;
     uint64_t address = 0;
@@ -68,7 +68,7 @@ struct SimulationServerDeviceInfo {
     // tt::ARCH value of the served device.
     int32_t arch = 0;
     // Which simulator the host runs, so the client instantiates the matching device class.
-    SimulationBackendType backend_type = SimulationBackendType::TTSim;
+    SimulationBackendType backend_type = SimulationBackendType::TTSIM;
     // Full text of the host's SoC descriptor YAML file, so the client can build a matching one.
     std::string soc_descriptor_yaml;
     // Whether the host applies NOC translation.

--- a/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
+++ b/device/api/umd/device/tt_device/rtl_simulation_tt_device.hpp
@@ -62,7 +62,7 @@ public:
     RtlSimCommunicator* get_communicator() { return communicator_.get(); }
 
 protected:
-    SimulationBackendType backend_type() const override { return SimulationBackendType::Rtl; }
+    SimulationBackendType backend_type() const override { return SimulationBackendType::RTL; }
 
     std::unique_ptr<TlbWindow> create_tlb_window(
         int tlb_index, size_t size, TlbMapping mapping, tlb_data config) override;

--- a/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
+++ b/device/api/umd/device/tt_device/tt_sim_tt_device.hpp
@@ -94,7 +94,7 @@ public:
     uint64_t bar4_base = 0;
 
 protected:
-    SimulationBackendType backend_type() const override { return SimulationBackendType::TTSim; }
+    SimulationBackendType backend_type() const override { return SimulationBackendType::TTSIM; }
 
     std::unique_ptr<TlbWindow> create_tlb_window(
         int tlb_index, size_t size, TlbMapping mapping, tlb_data config) override;

--- a/device/simulation/simulation_connector.cpp
+++ b/device/simulation/simulation_connector.cpp
@@ -84,9 +84,9 @@ std::unique_ptr<TTDevice> make_host_device(
 std::unique_ptr<TTDevice> make_client_device(
     ChipId chip_id, std::unique_ptr<SimulationClient> client, const SimulationServerDeviceInfo& info) {
     switch (info.backend_type) {
-        case SimulationBackendType::TTSim:
+        case SimulationBackendType::TTSIM:
             return TTSimTTDevice::create_client(chip_id, std::move(client), info);
-        case SimulationBackendType::Rtl:
+        case SimulationBackendType::RTL:
             return RtlSimulationTTDevice::create_client(chip_id, std::move(client), info);
     }
     // A value outside the enum means a corrupt/incompatible reply from the host; fail loudly rather

--- a/device/simulation/simulation_device_identity.cpp
+++ b/device/simulation/simulation_device_identity.cpp
@@ -117,7 +117,7 @@ SocDescriptor build_soc_descriptor(const SimulationServerDeviceInfo& device_info
 SimulationServerDeviceInfo fetch_device_info_from_host(SimulationClient& client) {
     client.attach();  // idempotent; safe if already attached
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::GetDeviceInfo;
+    request.command = SimulationServerCommand::GET_DEVICE_INFO;
     const SimulationServerDeviceInfo info = decode_device_info(client.transact(encode(request)));
     UMD_ASSERT(
         info.status == 0,
@@ -156,7 +156,7 @@ SimulationServerClusterDescriptor describe_cluster(const std::filesystem::path& 
 std::string fetch_cluster_descriptor_yaml(SimulationClient& client) {
     client.attach();  // idempotent; safe if already attached
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::GetClusterDescriptor;
+    request.command = SimulationServerCommand::GET_CLUSTER_DESCRIPTOR;
     const SimulationServerClusterDescriptor cluster_descriptor =
         decode_cluster_descriptor(client.transact(encode(request)));
     UMD_ASSERT(

--- a/device/tt_device/simulation_tt_device.cpp
+++ b/device/tt_device/simulation_tt_device.cpp
@@ -63,7 +63,7 @@ std::vector<uint8_t> SimulationTTDevice::handle_request(
 
     // GetDeviceInfo returns a different wire message (SimulationServerDeviceInfo) than the
     // read/write skeleton below (SimulationServerResponse), so it is handled up front.
-    if (request.command == SimulationServerCommand::GetDeviceInfo) {
+    if (request.command == SimulationServerCommand::GET_DEVICE_INFO) {
         try {
             return encode(describe_device(get_soc_descriptor(), backend_type()));
         } catch (const std::exception& e) {
@@ -76,7 +76,7 @@ std::vector<uint8_t> SimulationTTDevice::handle_request(
 
     // GetClusterDescriptor also returns its own wire message; serve the build's cluster-descriptor
     // YAML (empty when the build ships none) so a client can rebuild the full topology.
-    if (request.command == SimulationServerCommand::GetClusterDescriptor) {
+    if (request.command == SimulationServerCommand::GET_CLUSTER_DESCRIPTOR) {
         try {
             return encode(describe_cluster(simulator_directory_));
         } catch (const std::exception& e) {
@@ -92,7 +92,7 @@ std::vector<uint8_t> SimulationTTDevice::handle_request(
     // ack. The handler was fixed before serving started, so it is read here without locking; it must
     // only signal -- it must not tear down from this serving thread. The ack is sent before any
     // teardown, and this serving thread hits EOF and is joined during that teardown.
-    if (request.command == SimulationServerCommand::Shutdown) {
+    if (request.command == SimulationServerCommand::SHUTDOWN) {
         if (shutdown_handler) {
             shutdown_handler();
         }
@@ -107,11 +107,11 @@ std::vector<uint8_t> SimulationTTDevice::handle_request(
     SimulationServerResponse response;
     try {
         switch (request.command) {
-            case SimulationServerCommand::Read:
+            case SimulationServerCommand::READ:
                 response.data.resize(request.size);
                 read_from_device(response.data.data(), core, request.address, request.size);
                 break;
-            case SimulationServerCommand::Write:
+            case SimulationServerCommand::WRITE:
                 UMD_ASSERT(
                     request.data.size() >= request.size,
                     error::RuntimeError,
@@ -203,7 +203,7 @@ void SimulationTTDevice::client_write(CoreCoord core, uint64_t addr, const void*
     const xy_pair translated_core =
         get_soc_descriptor().translate_chip_coord_to_translated(core, get_selected_noc_id());
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::Write;
+    request.command = SimulationServerCommand::WRITE;
     request.x = static_cast<uint32_t>(translated_core.x);
     request.y = static_cast<uint32_t>(translated_core.y);
     request.address = addr;
@@ -229,7 +229,7 @@ void SimulationTTDevice::client_read(CoreCoord core, uint64_t addr, void* mem_pt
     const xy_pair translated_core =
         get_soc_descriptor().translate_chip_coord_to_translated(core, get_selected_noc_id());
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::Read;
+    request.command = SimulationServerCommand::READ;
     request.x = static_cast<uint32_t>(translated_core.x);
     request.y = static_cast<uint32_t>(translated_core.y);
     request.address = addr;

--- a/tests/api/test_simulation_connector.cpp
+++ b/tests/api/test_simulation_connector.cpp
@@ -94,7 +94,7 @@ TEST(SimulationConnector, HostServesClientMemoryOverSocket) {
     // Host writes directly; the client reads the same location over the socket.
     host->write_to_device(pattern.data(), tensix, addr, pattern.size());
     SimulationServerRequest read_req;
-    read_req.command = SimulationServerCommand::Read;
+    read_req.command = SimulationServerCommand::READ;
     read_req.x = static_cast<uint32_t>(noc.x);
     read_req.y = static_cast<uint32_t>(noc.y);
     read_req.address = addr;
@@ -107,7 +107,7 @@ TEST(SimulationConnector, HostServesClientMemoryOverSocket) {
     const std::vector<uint8_t> pattern2 = {0x55, 0x66, 0x77, 0x88};
     constexpr uint64_t addr2 = 0x2000;
     SimulationServerRequest write_req;
-    write_req.command = SimulationServerCommand::Write;
+    write_req.command = SimulationServerCommand::WRITE;
     write_req.x = static_cast<uint32_t>(noc.x);
     write_req.y = static_cast<uint32_t>(noc.y);
     write_req.address = addr2;
@@ -145,13 +145,13 @@ TEST(SimulationConnector, HostServesDeviceInfoOverSocket) {
     SimulationClient client(socket);
     client.attach();
     SimulationServerRequest info_request;
-    info_request.command = SimulationServerCommand::GetDeviceInfo;
+    info_request.command = SimulationServerCommand::GET_DEVICE_INFO;
     const SimulationServerDeviceInfo info = decode_device_info(client.transact(encode(info_request)));
 
     EXPECT_EQ(info.status, 0);
     EXPECT_EQ(info.arch, static_cast<int32_t>(soc.arch));
     const bool is_ttsim = std::filesystem::path(simulator_path).extension() == ".so";
-    EXPECT_EQ(info.backend_type, is_ttsim ? SimulationBackendType::TTSim : SimulationBackendType::Rtl);
+    EXPECT_EQ(info.backend_type, is_ttsim ? SimulationBackendType::TTSIM : SimulationBackendType::RTL);
     EXPECT_FALSE(info.soc_descriptor_yaml.empty());
     EXPECT_EQ(info.noc_translation_enabled, soc.noc_translation_enabled);
     EXPECT_EQ(info.tensix_harvesting_mask, soc.harvesting_masks.tensix_harvesting_mask);

--- a/tests/api/test_simulation_device_identity.cpp
+++ b/tests/api/test_simulation_device_identity.cpp
@@ -33,9 +33,9 @@ TEST(SimulationDeviceIdentity, DescribeThenRebuildMatches) {
     SocDescriptor original(
         std::make_shared<SocArchDescriptor>(test_utils::GetSocDescAbsPath("blackhole_140_arch.yaml")), chip_info);
 
-    const SimulationServerDeviceInfo info = describe_device(original, SimulationBackendType::TTSim);
+    const SimulationServerDeviceInfo info = describe_device(original, SimulationBackendType::TTSIM);
     EXPECT_EQ(info.status, 0);
-    EXPECT_EQ(info.backend_type, SimulationBackendType::TTSim);
+    EXPECT_EQ(info.backend_type, SimulationBackendType::TTSIM);
     EXPECT_FALSE(info.soc_descriptor_yaml.empty());
     EXPECT_EQ(info.tensix_harvesting_mask, 0x1u);
 

--- a/tests/api/test_simulation_server_protocol.cpp
+++ b/tests/api/test_simulation_server_protocol.cpp
@@ -15,7 +15,7 @@ using namespace tt::umd;
 // A read request carries the access geometry and no payload; encode -> decode reproduces it.
 TEST(SimulationServerProtocol, ReadRequestRoundTrip) {
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::Read;
+    request.command = SimulationServerCommand::READ;
     request.x = 3;
     request.y = 5;
     request.address = 0x1000'2000'3000'4000ULL;
@@ -23,7 +23,7 @@ TEST(SimulationServerProtocol, ReadRequestRoundTrip) {
 
     const SimulationServerRequest decoded = decode_request(encode(request));
 
-    EXPECT_EQ(decoded.command, SimulationServerCommand::Read);
+    EXPECT_EQ(decoded.command, SimulationServerCommand::READ);
     EXPECT_EQ(decoded.x, request.x);
     EXPECT_EQ(decoded.y, request.y);
     EXPECT_EQ(decoded.address, request.address);
@@ -34,7 +34,7 @@ TEST(SimulationServerProtocol, ReadRequestRoundTrip) {
 // A write request carries its payload; encode -> decode reproduces geometry and bytes.
 TEST(SimulationServerProtocol, WriteRequestRoundTrip) {
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::Write;
+    request.command = SimulationServerCommand::WRITE;
     request.x = 1;
     request.y = 2;
     request.address = 0xDEAD'BEEFULL;
@@ -43,7 +43,7 @@ TEST(SimulationServerProtocol, WriteRequestRoundTrip) {
 
     const SimulationServerRequest decoded = decode_request(encode(request));
 
-    EXPECT_EQ(decoded.command, SimulationServerCommand::Write);
+    EXPECT_EQ(decoded.command, SimulationServerCommand::WRITE);
     EXPECT_EQ(decoded.x, request.x);
     EXPECT_EQ(decoded.y, request.y);
     EXPECT_EQ(decoded.address, request.address);
@@ -85,7 +85,7 @@ TEST(SimulationServerProtocol, DecodeEmptyBufferThrows) {
 // verification instead of reading out of bounds.
 TEST(SimulationServerProtocol, DecodeTruncatedBufferThrows) {
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::Read;
+    request.command = SimulationServerCommand::READ;
     request.size = 64;
     std::vector<uint8_t> encoded = encode(request);
     ASSERT_GT(encoded.size(), 4u);
@@ -99,7 +99,7 @@ TEST(SimulationServerProtocol, DeviceInfoSerializationRoundTrip) {
     SimulationServerDeviceInfo info;
     info.status = 0;
     info.arch = 2;  // arbitrary tt::ARCH value
-    info.backend_type = SimulationBackendType::Rtl;
+    info.backend_type = SimulationBackendType::RTL;
     info.soc_descriptor_yaml = "arch: wormhole_b0\ngrid: [10, 12]\n";
     info.noc_translation_enabled = false;
     info.tensix_harvesting_mask = 0x5;
@@ -125,9 +125,9 @@ TEST(SimulationServerProtocol, DeviceInfoSerializationRoundTrip) {
 // The GetDeviceInfo command survives a request round-trip.
 TEST(SimulationServerProtocol, GetDeviceInfoRequestRoundTrip) {
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::GetDeviceInfo;
+    request.command = SimulationServerCommand::GET_DEVICE_INFO;
     const SimulationServerRequest decoded = decode_request(encode(request));
-    EXPECT_EQ(decoded.command, SimulationServerCommand::GetDeviceInfo);
+    EXPECT_EQ(decoded.command, SimulationServerCommand::GET_DEVICE_INFO);
 }
 
 // The cluster-descriptor message round-trips its status and YAML text.
@@ -153,15 +153,15 @@ TEST(SimulationServerProtocol, ClusterDescriptorEmptyYamlRoundTrip) {
 // The GetClusterDescriptor command survives a request round-trip.
 TEST(SimulationServerProtocol, GetClusterDescriptorRequestRoundTrip) {
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::GetClusterDescriptor;
+    request.command = SimulationServerCommand::GET_CLUSTER_DESCRIPTOR;
     const SimulationServerRequest decoded = decode_request(encode(request));
-    EXPECT_EQ(decoded.command, SimulationServerCommand::GetClusterDescriptor);
+    EXPECT_EQ(decoded.command, SimulationServerCommand::GET_CLUSTER_DESCRIPTOR);
 }
 
 // The Shutdown command survives a request round-trip (its reply is a plain SimulationServerResponse).
 TEST(SimulationServerProtocol, ShutdownRequestRoundTrip) {
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::Shutdown;
+    request.command = SimulationServerCommand::SHUTDOWN;
     const SimulationServerRequest decoded = decode_request(encode(request));
-    EXPECT_EQ(decoded.command, SimulationServerCommand::Shutdown);
+    EXPECT_EQ(decoded.command, SimulationServerCommand::SHUTDOWN);
 }

--- a/tools/sim_server.cpp
+++ b/tools/sim_server.cpp
@@ -56,7 +56,7 @@ std::string probe_socket(const std::filesystem::path& socket_path) {
         return fmt::format(
             "{}/{}",
             tt::arch_to_str(static_cast<tt::ARCH>(info.arch)),
-            info.backend_type == SimulationBackendType::TTSim ? "ttsim" : "rtl");
+            info.backend_type == SimulationBackendType::TTSIM ? "ttsim" : "rtl");
     } catch (const std::exception&) {
         return "";  // socket file present, but no live host answering
     }
@@ -141,7 +141,7 @@ int cmd_kill(int server_index) {
     SimulationClient client(it->sockets.begin()->second);
     client.attach();
     SimulationServerRequest request;
-    request.command = SimulationServerCommand::Shutdown;
+    request.command = SimulationServerCommand::SHUTDOWN;
     const SimulationServerResponse response = decode_response(client.transact(encode(request)));
     if (response.status != 0) {
         log_error(tt::LogUMD, "Server {} did not acknowledge shutdown (status {}).", server_index, response.status);


### PR DESCRIPTION
### Issue
Part of #2677 (simulation server). @nbuncicTT has repeatedly asked, across the simulation epic, for the enum classes to use `UPPER_SNAKE_CASE`.

Replaces #3082, which GitHub auto-closed when its stacked base branch was deleted on merge. Same change, rebased onto `main`.

### Description
Renames the C++ enum-class values to `UPPER_SNAKE_CASE`:
- `SimulationServerCommand`: `Read`/`Write`/`GetDeviceInfo`/`GetClusterDescriptor`/`Shutdown` -> `READ`/`WRITE`/`GET_DEVICE_INFO`/`GET_CLUSTER_DESCRIPTOR`/`SHUTDOWN`.
- `SimulationBackendType`: `TTSim`/`Rtl` -> `TTSIM`/`RTL`.

This is a **value-name-only** rename: the enum types, their underlying integer values, and the wire format are unchanged. The `.fbs` wire schema was already `UPPER_SNAKE`, so the C++ now matches it. `protocol.cpp` casts between the C++ and wire enums by value (no value-name references), so the wire (de)serialization is untouched.

### List of the changes
- `simulation_server_protocol.hpp` - the two enum definitions.
- All qualified usages across `device/`, `tools/`, `tests/`.
- Corrects the `SimulationServerCommand` doc comment, which still described the enum as it stood in #2967 (`Read`/`Write` only) before #3019 and #3053 added the other three values.

### Testing
CI

### API Changes
Enum-class value names only (`tt::umd::SimulationServerCommand`, `tt::umd::SimulationBackendType`). Simulation-internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)